### PR TITLE
fix(platform-review): Wave 2 — install-path reliability (MR-1, MR-2, DR-2, DR-3)

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -93,8 +93,15 @@ def _persist_pull_job(job: PullJob) -> None:
         log.warning("model.pull_job_persist_failed model_id=%s error=%s", job.model_id, exc)
 
 
-def _load_persisted_pull_job(model_id: str) -> dict[str, Any] | None:
-    """Read a persisted pull-job snapshot from disk, or None if absent/unreadable."""
+def _load_persisted_pull_job(
+    model_id: str, registry: Any | None = None
+) -> dict[str, Any] | None:
+    """Read a persisted pull-job snapshot from disk, or None if absent/unreadable.
+
+    ``registry`` (when supplied) is forwarded to the reconcile step so a stale
+    non-terminal snapshot can be cross-checked against ground truth — an
+    install that actually landed is reported ``completed``, not ``failed``.
+    """
     path = _pull_job_file(model_id)
     try:
         raw = path.read_text(encoding="utf-8")
@@ -106,20 +113,50 @@ def _load_persisted_pull_job(model_id: str) -> dict[str, Any] | None:
         return None
     if not isinstance(loaded, dict):
         return None
-    return _reconcile_persisted_pull_job(loaded)
+    return _reconcile_persisted_pull_job(loaded, registry)
 
 
-def _reconcile_persisted_pull_job(persisted: dict[str, Any]) -> dict[str, Any]:
+def _reconcile_persisted_pull_job(
+    persisted: dict[str, Any], registry: Any | None = None
+) -> dict[str, Any]:
     """Repair a persisted snapshot that was left in a non-terminal state.
 
     A snapshot only reaches disk-fallback when its job is absent from the
     in-memory dict — which after a restart means the worker that owned it is
     gone. A ``queued``/``running`` snapshot can therefore never make further
-    progress, so we surface it as ``failed`` (rather than a state the client
-    would poll forever) with an explanatory error. Terminal snapshots
-    (completed/failed/cancelled) are returned unchanged.
+    progress.
+
+    Before declaring it failed, cross-check ground truth (#MR-2): the terminal
+    on-disk write is fail-soft, so a pull that actually completed can be left
+    with a stale ``running`` snapshot. When ``registry`` knows the id and its
+    model file exists on disk, the install landed — surface ``completed``
+    (backfilling ``path``/``size_bytes`` from the registry) rather than a
+    spurious ``failed``. Only a snapshot with no matching installed file falls
+    through to the failed-rewrite. Terminal snapshots (completed/failed/
+    cancelled) are returned unchanged.
     """
     if persisted.get("state") in ("queued", "running"):
+        model_id = persisted.get("model_id")
+        if registry is not None and model_id:
+            try:
+                if registry.has(model_id):
+                    model = registry.get(model_id)
+                    p = getattr(model, "path", None)
+                    if p and Path(p).exists():
+                        persisted = dict(persisted)
+                        persisted["state"] = "completed"
+                        persisted.setdefault("path", str(p))
+                        size = getattr(model, "size_bytes", None)
+                        if size:
+                            persisted.setdefault("size_bytes", size)
+                        sha = getattr(model, "sha256", None)
+                        if sha:
+                            persisted.setdefault("sha256", sha)
+                        return persisted
+            except Exception:
+                # A registry hiccup must never raise inside a status poll —
+                # degrade to the failed-rewrite below.
+                pass
         persisted = dict(persisted)
         persisted["state"] = "failed"
         persisted.setdefault("error", "pull interrupted by hal0-api restart; re-run the pull")
@@ -1548,7 +1585,7 @@ async def pull_status(model_id: str, request: Request) -> dict[str, object]:
     jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
     job = jobs.get(model_id)
     if job is None:
-        persisted = _load_persisted_pull_job(model_id)
+        persisted = _load_persisted_pull_job(model_id, request.app.state.model_registry)
         if persisted is not None:
             return persisted
         raise PullJobNotFound(
@@ -1574,7 +1611,7 @@ async def pull_stream(model_id: str, request: Request) -> StreamingResponse:
     jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
     job = jobs.get(model_id)
     if job is None:
-        persisted = _load_persisted_pull_job(model_id)
+        persisted = _load_persisted_pull_job(model_id, request.app.state.model_registry)
         if persisted is not None:
             # Serve one terminal frame from the persisted snapshot so the
             # client's SSE consumer sees the final state and can close.

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -13,7 +13,6 @@ import contextlib
 import json
 import logging
 import os
-import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -24,7 +23,6 @@ from fastapi.responses import StreamingResponse
 
 from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, NotFound
-from hal0.config import paths as _config_paths
 from hal0.config.loader import load_hal0_config
 from hal0.errors import Hal0Error
 from hal0.model_meta import classify
@@ -40,6 +38,8 @@ from hal0.registry.pull import (
     run_flm_pull,
     run_pull,
 )
+from hal0.registry.pull import persist_pull_job as _persist_pull_job
+from hal0.registry.pull import pull_job_file as _pull_job_file
 
 # See slots.py for the writer-gate rationale.
 
@@ -48,49 +48,13 @@ router = APIRouter()
 log = logging.getLogger(__name__)
 
 
-# ── durable pull-job store (#626) ─────────────────────────────────────────────
+# ── durable pull-job store (#626 / #MR-1) ─────────────────────────────────────
 #
-# Model-pull jobs live only on app.state.model_pull_jobs, so a hal0-api
-# restart mid-pull 404s the status poll. Mirror each job snapshot to
-# /var/lib/hal0/model-pull-jobs/<model_id>.json (atomic write) and fall back
-# to disk on status lookup — mirroring the updater.py pattern (#509).
-
-
-def _pull_jobs_dir() -> Path:
-    """Return /var/lib/hal0/model-pull-jobs (HAL0_HOME-aware via paths)."""
-    return _config_paths.var_lib() / "model-pull-jobs"
-
-
-def _pull_job_file(model_id: str) -> Path:
-    from hal0.registry.pull import _sanitise_id
-
-    return _pull_jobs_dir() / f"{_sanitise_id(model_id)}.json"
-
-
-def _persist_pull_job(job: PullJob) -> None:
-    """Atomically write a pull-job snapshot to disk (best-effort, fail-soft).
-
-    A failure to persist must never break the pull flow — the in-memory
-    registry remains authoritative for the running process.
-    """
-    path = _pull_job_file(job.model_id)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
-        tmp_path = Path(tmp_str)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(job.as_dict(), f)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, path)
-            tmp_path = None  # type: ignore[assignment]
-        finally:
-            if tmp_path is not None:
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-    except OSError as exc:
-        log.warning("model.pull_job_persist_failed model_id=%s error=%s", job.model_id, exc)
+# The snapshot writer now lives in registry.pull (imported above as
+# ``_persist_pull_job``/``_pull_job_file``) so ``run_pull`` persists terminal
+# state for EVERY caller — the dashboard route AND the installer/bundle-tier
+# pulls that call run_pull directly. The disk-fallback read path below still
+# consumes those snapshots.
 
 
 def _load_persisted_pull_job(

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -57,9 +57,7 @@ log = logging.getLogger(__name__)
 # consumes those snapshots.
 
 
-def _load_persisted_pull_job(
-    model_id: str, registry: Any | None = None
-) -> dict[str, Any] | None:
+def _load_persisted_pull_job(model_id: str, registry: Any | None = None) -> dict[str, Any] | None:
     """Read a persisted pull-job snapshot from disk, or None if absent/unreadable.
 
     ``registry`` (when supplied) is forwarded to the reconcile step so a stale

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -807,28 +807,49 @@ class Dispatcher:
             # LLM model back onto the GPU while the arbiter holds it for
             # the img slot.
             self._guard_gpu_image_mode(call)
-        if call.slot_name and self._slot_manager is not None:
-            # B1 (ADR-0022): backend-aware lazy-load. On a cold miss we
-            # kick SlotManager.load(slot_name) FIRST so the slot's declared
-            # device/profile drives the load, then gate on readiness.
-            await self._ensure_slot_loaded_backend_aware(call)
-            # Swap-window gate: refuse to forward if the slot is loading.
-            # Without this, requests hit a dead port (502) or a still-
-            # loading llama-server (raw 503 with no Retry-After).
-            self._check_slot_ready_for_dispatch(call)
-            return await self._forward_with_serving(call)
-        if call.container_slot_name and self._slot_manager is not None:
-            # Container-slot readiness gate (#656): container slots register
-            # as kind="remote" upstreams so slot_name is empty above and the
-            # slot-kind gate never fires.  We probe the container directly
-            # (systemctl is-active + /health) before forwarding so the client
-            # gets a structured slot.loading 503 with Retry-After instead of
-            # a raw 502 ConnectError when the container is down or starting.
-            await self._check_container_slot_ready(call)
-            # Mirror the slot_name branch: wrap the forward in the serving
-            # context so the slot transitions READY → SERVING → READY and
-            # last_used_at is bumped around every request (#746).
-            return await self._forward_with_serving(call)
+            # DR-2: take a dispatch ticket SYNCHRONOUSLY here — right after the
+            # guard, BEFORE the first await below — so the arbiter's drain sees
+            # any request that has passed the image-mode guard even in the
+            # window before ``serving()`` increments its own counter. Because
+            # both guard_dispatch and enter_dispatch are sync, no other task
+            # (incl. ensure_img, which persists IMG mode before draining) can
+            # interleave between the guard read and the ticket take. The ticket
+            # is released on EVERY exit path via the try/finally. getattr keeps
+            # light test stand-ins that don't model the ticket surface working
+            # (mirrors the arbiter getattr opt-out above); the real SlotManager
+            # always exposes enter_dispatch/exit_dispatch.
+            effective_slot = call.slot_name or call.container_slot_name
+            enter_dispatch = getattr(self._slot_manager, "enter_dispatch", None)
+            exit_dispatch = getattr(self._slot_manager, "exit_dispatch", None)
+            if enter_dispatch is not None:
+                enter_dispatch(effective_slot)
+            try:
+                if call.slot_name:
+                    # B1 (ADR-0022): backend-aware lazy-load. On a cold miss we
+                    # kick SlotManager.load(slot_name) FIRST so the slot's
+                    # declared device/profile drives the load, then gate on
+                    # readiness.
+                    await self._ensure_slot_loaded_backend_aware(call)
+                    # Swap-window gate: refuse to forward if the slot is
+                    # loading. Without this, requests hit a dead port (502) or a
+                    # still-loading llama-server (raw 503 with no Retry-After).
+                    self._check_slot_ready_for_dispatch(call)
+                    return await self._forward_with_serving(call)
+                # Container-slot readiness gate (#656): container slots register
+                # as kind="remote" upstreams so slot_name is empty above and the
+                # slot-kind gate never fires.  We probe the container directly
+                # (systemctl is-active + /health) before forwarding so the
+                # client gets a structured slot.loading 503 with Retry-After
+                # instead of a raw 502 ConnectError when the container is down
+                # or starting.
+                await self._check_container_slot_ready(call)
+                # Mirror the slot_name branch: wrap the forward in the serving
+                # context so the slot transitions READY → SERVING → READY and
+                # last_used_at is bumped around every request (#746).
+                return await self._forward_with_serving(call)
+            finally:
+                if exit_dispatch is not None:
+                    exit_dispatch(effective_slot)
         return await self._forward_plain(call)
 
     def _guard_gpu_image_mode(self, call: UpstreamCall) -> None:

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -21,10 +21,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import hashlib
+import json
 import logging
 import os
 import re
 import secrets
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -288,6 +290,51 @@ def get_job(jobs: dict[str, PullJob], model_id: str) -> PullJob | None:
     return jobs.get(model_id)
 
 
+# ── durable pull-job store (#626 / #MR-1) ─────────────────────────────────────
+#
+# The snapshot lives here (not in routes/models) so ``run_pull`` itself writes
+# the terminal state on EVERY path — the dashboard route AND the installer /
+# bundle-tier pulls, which call ``run_pull`` directly and previously bypassed the
+# routes/models wrappers, 404ing every status poll after an install-time restart.
+
+
+def _pull_jobs_dir() -> Path:
+    """Return ``<var_lib>/model-pull-jobs`` (HAL0_HOME-aware via config paths)."""
+    return paths.var_lib() / "model-pull-jobs"
+
+
+def pull_job_file(model_id: str) -> Path:
+    """Path of the durable snapshot for ``model_id``'s pull job."""
+    return _pull_jobs_dir() / f"{_sanitise_id(model_id)}.json"
+
+
+def persist_pull_job(job: PullJob) -> None:
+    """Atomically mirror a pull-job snapshot to disk (best-effort, fail-soft).
+
+    A failure to persist must never break the pull flow — the in-memory job
+    stays authoritative for the running process. Called from ``run_pull`` so a
+    restart-surviving status poll resolves for any caller (#MR-1).
+    """
+    path = pull_job_file(job.model_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        tmp_path: Path | None = Path(tmp_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(job.as_dict(), f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+            tmp_path = None
+        finally:
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+    except OSError as exc:
+        log.warning("model.pull_job_persist_failed model_id=%s error=%s", job.model_id, exc)
+
+
 async def run_pull(
     job: PullJob,
     *,
@@ -463,6 +510,12 @@ async def run_pull(
         job._signal()
         log.exception("model.pull_unexpected_error", extra={"model_id": job.model_id})
     finally:
+        # Persist FIRST — a durable snapshot of the terminal (completed/failed/
+        # cancelled) state so a restart-surviving status poll resolves for ANY
+        # caller, including installer/bundle-tier pulls that call run_pull
+        # directly (#MR-1). Ordered before the client close so a theoretical
+        # aclose() raise can't skip the persist.
+        persist_pull_job(job)
         if owns_client:
             await client.aclose()
 
@@ -799,6 +852,8 @@ __all__ = [
     "get_job",
     "hf_download_url",
     "make_job",
+    "persist_pull_job",
+    "pull_job_file",
     "run_flm_pull",
     "run_pull",
 ]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -334,6 +334,13 @@ class SlotManager:
         # when N concurrent requests arrive in the same tick.
         self._serving_count: dict[str, int] = {}
         self._serving_lock: asyncio.Lock = asyncio.Lock()
+        # DR-2 — per-slot committed-dispatch tickets.  ``Dispatcher.forward``
+        # takes a ticket synchronously right after the image-mode guard and
+        # BEFORE its first await, closing the window where a request has
+        # passed the guard but not yet entered ``serving()``.  ``in_flight_count``
+        # sums tickets + serving so the GpuArbiter drain never unloads a slot
+        # out from under a request that is already committed to dispatch.
+        self._dispatch_tickets: dict[str, int] = {}
         # IDLE — background sweeper task that demotes READY→IDLE after
         # ``idle_after_s`` seconds of inactivity.  Started explicitly via
         # ``start_idle_monitor()`` (the API lifespan owns the lifecycle so
@@ -2303,8 +2310,39 @@ class SlotManager:
                 )
 
     def in_flight_count(self, slot_name: str) -> int:
-        """Return the number of currently-active ``serving()`` contexts."""
-        return self._serving_count.get(slot_name, 0)
+        """Return the number of in-flight requests for ``slot_name``.
+
+        Sums active ``serving()`` contexts AND committed dispatch tickets
+        (DR-2): a request that has passed ``Dispatcher.forward``'s image-mode
+        guard but has not yet entered ``serving()`` still holds a ticket, so
+        the GpuArbiter drain sees it and never unloads the slot out from under
+        an in-flight request.  Temporary overlap while both counters hold the
+        same request is harmless — both reach 0 only when the request ends.
+        """
+        return self._serving_count.get(slot_name, 0) + self._dispatch_tickets.get(slot_name, 0)
+
+    def enter_dispatch(self, slot_name: str) -> None:
+        """Synchronously commit a dispatch ticket for ``slot_name`` (DR-2).
+
+        Called by ``Dispatcher.forward`` immediately after the image-mode
+        guard and BEFORE the first await.  Being sync (no lock, no await) is
+        the whole point: nothing — not even ``GpuArbiter.ensure_img`` — can
+        interleave between the guard read and the ticket take, so any request
+        that passed the guard registers before the drain's next poll.
+        """
+        self._dispatch_tickets[slot_name] = self._dispatch_tickets.get(slot_name, 0) + 1
+
+    def exit_dispatch(self, slot_name: str) -> None:
+        """Release the dispatch ticket taken by :meth:`enter_dispatch` (DR-2).
+
+        Balanced on EVERY exit path of ``Dispatcher.forward``'s slot branches
+        (success, typed raises, ``UpstreamUnavailable``, cancellation).
+        """
+        remaining = self._dispatch_tickets.get(slot_name, 1) - 1
+        if remaining > 0:
+            self._dispatch_tickets[slot_name] = remaining
+        else:
+            self._dispatch_tickets.pop(slot_name, None)
 
     # ── GpuArbiter (Phase D, spec §7) ────────────────────────────────────────
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2783,9 +2783,11 @@ class SlotManager:
         Polls GET /health on the slot's container port until 200.
 
         Returns:
-            SlotState.READY when the container is serving (or the
-            health wait timed out — the fail watcher picks up ongoing
-            unhealthiness).
+            SlotState.READY when the container is serving. On a health-wait
+            timeout, resolves to SlotState.WARMING (non-dispatchable) rather
+            than a lying READY: WARMING keeps the slot retryable so the fail
+            watcher / next-request reload governs recovery, instead of live
+            traffic being forwarded to a wedged server on a false READY.
         """
         cfg = await self._maybe_load_config(slot_name)
         if not cfg:
@@ -2803,8 +2805,13 @@ class SlotManager:
                 "slot.container_await_ready_timeout",
                 extra={"slot": slot_name, "port": slot_port, "error": str(exc)},
             )
-            # Let the fail watcher detect ongoing unhealthiness.
-            return SlotState.READY
+            # DR-3: the inference server never answered /health, so do NOT
+            # advertise a dispatchable READY. WARMING is not in
+            # _DISPATCHABLE_STATES, so _check_slot_ready_for_dispatch raises
+            # the retryable SlotLoading (503 + Retry-After) and the next
+            # request re-drives load() — the fail watcher / reload governs
+            # recovery instead of live traffic hitting a wedged server.
+            return SlotState.WARMING
 
     # ── adoption / drift reconcile (ISSUE #30) ───────────────────────────────
 

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -341,3 +341,76 @@ def test_pull_status_reconciles_stale_inflight_to_failed_after_restart(
     body = s.json()
     assert body["state"] == "failed"
     assert body["error_code"] == "pull.interrupted"
+
+
+def test_pull_status_reports_completed_when_registry_has_installed_model_despite_stale_snapshot(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    tmp_hal0_home: str,
+    tmp_path: Path,
+) -> None:
+    """MR-2: a pull that actually landed must not be reported ``failed``.
+
+    The terminal on-disk write can fail-soft (swallowed OSError), leaving a
+    stale ``running`` snapshot even though the model file is present. On a
+    restart the disk fallback + reconcile must cross-check the registry: when
+    the id is installed and its file exists on disk, surface ``completed`` —
+    not ``failed``/``pull.interrupted``.
+    """
+    from hal0.registry.model import Model
+
+    model_file = tmp_path / "curated-x.gguf"
+    model_file.write_bytes(b"gguf-bytes")
+    app_isolated.state.model_registry.add(
+        Model(
+            id="curated.x",
+            name="curated.x",
+            path=str(model_file),
+            size_bytes=model_file.stat().st_size,
+        )
+    )
+
+    job_dir = Path(tmp_hal0_home) / "var-lib" / "hal0" / "model-pull-jobs"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    (job_dir / "curated.x.json").write_text(
+        json.dumps(
+            {"id": "j1", "model_id": "curated.x", "state": "running", "bytes_downloaded": 512}
+        ),
+        encoding="utf-8",
+    )
+    # Fresh in-memory dict → forces the disk fallback + reconcile path.
+    app_isolated.state.model_pull_jobs = {}
+
+    s = client_isolated.get("/api/models/curated.x/pull/status")
+    assert s.status_code == 200, s.text
+    body = s.json()
+    assert body["state"] == "completed"
+    assert body.get("error_code") != "pull.interrupted"
+    assert body.get("path") == str(model_file)
+
+
+def test_pull_status_reports_failed_when_model_not_installed(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    tmp_hal0_home: str,
+) -> None:
+    """MR-2 negative twin: a genuinely-interrupted pull still fails.
+
+    Same stale ``running`` snapshot, but the registry does NOT have the id
+    (nothing landed) → the reconcile must fall through to the failed-rewrite,
+    proving the ground-truth guard doesn't mask real interruptions."""
+    job_dir = Path(tmp_hal0_home) / "var-lib" / "hal0" / "model-pull-jobs"
+    job_dir.mkdir(parents=True, exist_ok=True)
+    (job_dir / "curated.x.json").write_text(
+        json.dumps(
+            {"id": "j1", "model_id": "curated.x", "state": "running", "bytes_downloaded": 512}
+        ),
+        encoding="utf-8",
+    )
+    app_isolated.state.model_pull_jobs = {}
+
+    s = client_isolated.get("/api/models/curated.x/pull/status")
+    assert s.status_code == 200, s.text
+    body = s.json()
+    assert body["state"] == "failed"
+    assert body["error_code"] == "pull.interrupted"

--- a/tests/dispatcher/test_arbiter_dispatch.py
+++ b/tests/dispatcher/test_arbiter_dispatch.py
@@ -27,6 +27,7 @@ test_serving_integration.py; app-level tests mirror tests/api/test_v1_images.py.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from pathlib import Path
@@ -60,6 +61,7 @@ class _ArbiterSlotManager:
         self._state = state
         self.events: list[tuple[str, str]] = []
         self._counts: dict[str, int] = {}
+        self._tickets: dict[str, int] = {}
         self.load_calls: list[tuple[str, Any]] = []
         self.unload_calls: list[str] = []
         self.cfgs: list[dict[str, Any]] = []
@@ -90,7 +92,19 @@ class _ArbiterSlotManager:
         return _Ctx()
 
     def in_flight_count(self, slot_name: str) -> int:
-        return self._counts.get(slot_name, 0)
+        # Mirrors the real SlotManager (DR-2): serving contexts + committed
+        # dispatch tickets, so the arbiter drain sees requests past the guard.
+        return self._counts.get(slot_name, 0) + self._tickets.get(slot_name, 0)
+
+    def enter_dispatch(self, slot_name: str) -> None:
+        self._tickets[slot_name] = self._tickets.get(slot_name, 0) + 1
+
+    def exit_dispatch(self, slot_name: str) -> None:
+        remaining = self._tickets.get(slot_name, 1) - 1
+        if remaining > 0:
+            self._tickets[slot_name] = remaining
+        else:
+            self._tickets.pop(slot_name, None)
 
     def state(self, _slot_name: str) -> SlotState:
         return self._state
@@ -576,3 +590,92 @@ def test_force_killed_inflight_gets_clean_5xx(
     body = r.json()
     assert body["error"]["code"] == "gpu.image_mode"
     assert int(r.headers["Retry-After"]) >= 15
+
+
+# ── DR-2: drain must wait for a request already past the image-mode guard ────
+
+
+def _dr2_cfgs() -> list[dict[str, Any]]:
+    """An llm-group slot (``primary``) plus an img-group slot for group derivation."""
+    return [
+        {
+            "name": "primary",
+            "device": "gpu-rocm",
+            "runtime": "container",
+            "provider": "llama-server",
+            "type": "llm",
+        },
+        {
+            "name": "img",
+            "device": "gpu-rocm",
+            "runtime": "container",
+            "provider": "comfyui",
+            "type": "image",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_request_past_guard_before_serving(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DR-2: a request parked between the guard and serving() blocks the drain.
+
+    Regression for the racy GpuArbiter drain: ``in_flight_count`` used to count
+    only active ``serving()`` contexts, so a request that had passed
+    ``_guard_gpu_image_mode`` but not yet entered ``serving()`` was invisible —
+    ``ensure_img`` unloaded the llm slot out from under it. With the synchronous
+    dispatch ticket taken in ``Dispatcher.forward`` (before the first await),
+    ``in_flight_count`` reflects the committed request and the drain blocks
+    until it finishes.
+
+    Pre-fix this FAILS: the ticket is never taken, ``in_flight_count`` stays 0,
+    the drain immediately unloads ``primary`` while the request is still parked.
+    """
+    monkeypatch.setattr("hal0.slots.arbiter._DRAIN_POLL_S", 0.01)
+
+    sm = _ArbiterSlotManager(tmp_path)  # LLM mode (no state file), slot READY
+    sm.cfgs = _dr2_cfgs()
+
+    gate = asyncio.Event()
+    entered = asyncio.Event()
+
+    async def _blocked_ensure_loaded(_call: UpstreamCall) -> None:
+        # Park the forward AFTER the guard + dispatch ticket (router.py) and
+        # BEFORE serving() increments its own counter — exactly the DR-2 window.
+        entered.set()
+        await gate.wait()
+
+    dispatcher = _make_dispatcher(
+        httpx.MockTransport(lambda req: httpx.Response(200, json={"ok": True})), sm
+    )
+    monkeypatch.setattr(dispatcher, "_ensure_slot_loaded_backend_aware", _blocked_ensure_loaded)
+
+    try:
+        req_task = asyncio.create_task(dispatcher.forward(_slot_call("primary")))
+        await asyncio.wait_for(entered.wait(), timeout=2.0)
+
+        # The request is parked in the window: serving() has NOT entered, yet
+        # the committed dispatch ticket makes it visible to the drain.
+        assert not req_task.done()
+        assert sm.events == [], "serving() must not have entered yet"
+        assert sm.in_flight_count("primary") == 1, "committed dispatch ticket must be visible"
+
+        # Flip to image mode concurrently; its drain must block on the ticket.
+        img_task = asyncio.create_task(sm.arbiter.ensure_img())
+        await asyncio.sleep(0.1)
+        assert not img_task.done(), "drain must wait for the in-flight request"
+        assert sm.unload_calls == [], "slot must not be unloaded under an in-flight request"
+
+        # Release the request: it finishes 200 on the still-loaded slot; ONLY
+        # then does the drain observe in_flight_count==0 and unload the slot.
+        gate.set()
+        resp = await asyncio.wait_for(req_task, timeout=2.0)
+        assert resp.status_code == 200
+        assert sm.in_flight_count("primary") == 0, "ticket + serving balanced on exit"
+
+        await asyncio.wait_for(img_task, timeout=2.0)
+        assert sm.unload_calls == ["primary"], "unload only after the request finished"
+        assert sm.arbiter.mode == GpuMode.IMG
+    finally:
+        await dispatcher.aclose()

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -8,13 +8,12 @@ redirect handling, and partial downloads / cancellation.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from pathlib import Path
 
 import httpx
 import pytest
-
-import json
 
 from hal0.registry.pull import (
     _sanitise_id,

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -14,10 +14,13 @@ from pathlib import Path
 import httpx
 import pytest
 
+import json
+
 from hal0.registry.pull import (
     _sanitise_id,
     hf_download_url,
     make_job,
+    pull_job_file,
     run_pull,
 )
 from hal0.registry.store import ModelRegistry
@@ -110,6 +113,66 @@ async def test_run_pull_happy_path_writes_file_and_registers(
     assert entry.size_bytes == len(body)
     assert entry.hf_repo == "Qwen/Qwen3-4B-Instruct-GGUF"
     assert entry.metadata.get("sha256") == digest
+
+
+# ── MR-1: run_pull persists a durable snapshot for ALL callers ────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pull_persists_terminal_snapshot_for_direct_callers(
+    tmp_hal0_home: str,
+) -> None:
+    """MR-1: installer/bundle-tier pulls call ``run_pull`` directly (bypassing
+    the routes/models wrappers). ``run_pull`` must itself write the durable
+    pull-job snapshot so a status poll after an install-time api restart
+    resolves instead of 404ing."""
+    body = _payload(2048)
+    job = make_job("hal0-max")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-Max-GGUF",
+            hf_file="hal0-max.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed"
+    # The snapshot the /pull/status disk-fallback reads must exist and be terminal.
+    snapshot = pull_job_file("hal0-max")
+    assert snapshot.exists(), "run_pull must persist a durable snapshot itself (MR-1)"
+    persisted = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert persisted["state"] == "completed"
+    assert persisted["model_id"] == "hal0-max"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_persists_failed_snapshot_on_error(tmp_hal0_home: str) -> None:
+    """MR-1: a failed direct pull is also persisted terminally, so a restart
+    doesn't leave the poller with no snapshot at all."""
+    job = make_job("ghost")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_status_handler(404))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/ghost-GGUF",
+            hf_file="ghost.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "failed"
+    snapshot = pull_job_file("ghost")
+    assert snapshot.exists()
+    persisted = json.loads(snapshot.read_text(encoding="utf-8"))
+    assert persisted["state"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/tests/slots/test_gpu_arbiter.py
+++ b/tests/slots/test_gpu_arbiter.py
@@ -103,6 +103,9 @@ class FakeManager:
         self.configs = configs if configs is not None else _base_configs()
         self.ready: set[str] = set(ready or {"chat", "agent", "npu", "tts"})
         self.in_flight: dict[str, Any] = dict(in_flight or {})
+        # DR-2 — committed dispatch tickets, summed into in_flight_count so the
+        # drain sees requests that passed the guard but aren't yet serving().
+        self.tickets: dict[str, int] = {}
         self.calls: list[tuple[Any, ...]] = []
         self.poll_log: list[tuple[str, int]] = []
         self.on_unload = None  # optional hook(name) fired before recording
@@ -134,8 +137,19 @@ class FakeManager:
             count = int(val.pop(0)) if len(val) > 1 else int(val[0])
         else:
             count = int(val)
+        count += self.tickets.get(name, 0)
         self.poll_log.append((name, count))
         return count
+
+    def enter_dispatch(self, name: str) -> None:
+        self.tickets[name] = self.tickets.get(name, 0) + 1
+
+    def exit_dispatch(self, name: str) -> None:
+        remaining = self.tickets.get(name, 1) - 1
+        if remaining > 0:
+            self.tickets[name] = remaining
+        else:
+            self.tickets.pop(name, None)
 
     async def load(self, name: str, model_id: str | None = None) -> None:
         if name in self.fail_loads:
@@ -269,6 +283,32 @@ async def test_ensure_img_drains_then_stops_then_starts(
     final = _read_state(state_path)
     assert final["mode"] == "img"
     assert isinstance(final["last_img_activity"], float)
+
+
+async def test_ensure_img_drain_blocks_on_committed_dispatch_ticket(
+    fake_mgr: FakeManager, state_path: Path
+) -> None:
+    """DR-2: a committed dispatch ticket keeps the drain alive until released.
+
+    ``serving()`` reports 0 (the request passed the guard but hasn't entered
+    the serving context yet), yet ``in_flight_count`` must still be >= 1 so the
+    drain does not prematurely reach 0 and unload the slot under the request.
+    """
+    fake_mgr.in_flight = {"chat": 0}  # serving() count is 0…
+    fake_mgr.enter_dispatch("chat")  # …but a request is committed past the guard
+    assert fake_mgr.in_flight_count("chat") == 1
+
+    arb = GpuArbiter(fake_mgr, state_path=state_path)
+    task = asyncio.create_task(arb.ensure_img())
+    await asyncio.sleep(0.05)
+    assert not task.done(), "drain must block while a dispatch ticket is held"
+    assert ("unload", "chat") not in fake_mgr.calls
+
+    fake_mgr.exit_dispatch("chat")  # request finished → drain can proceed
+    assert fake_mgr.in_flight_count("chat") == 0
+    await asyncio.wait_for(task, timeout=2.0)
+    assert ("unload", "chat") in fake_mgr.calls
+    assert arb.mode is GpuMode.IMG
 
 
 async def test_ensure_img_noop_when_already_img(fake_mgr: FakeManager, state_path: Path) -> None:

--- a/tests/slots/test_manager_npu_container.py
+++ b/tests/slots/test_manager_npu_container.py
@@ -218,9 +218,7 @@ async def test_await_ready_health_timeout_stays_non_dispatchable(
 
     fake_provider = _make_container_provider_mock()
     # Simulate the container port never becoming healthy within the window.
-    fake_provider.wait_ready = AsyncMock(
-        side_effect=TimeoutError("port did not become healthy")
-    )
+    fake_provider.wait_ready = AsyncMock(side_effect=TimeoutError("port did not become healthy"))
 
     with (
         patch("hal0.providers.container.container_provider", return_value=fake_provider),
@@ -236,6 +234,4 @@ async def test_await_ready_health_timeout_stays_non_dispatchable(
         assert mgr.state("npu") == SlotState.WARMING, (
             "health-probe timeout must resolve to WARMING, not a lying READY"
         )
-        assert mgr.is_ready_for_dispatch("npu") is False, (
-            "a WARMING slot must not be dispatchable"
-        )
+        assert mgr.is_ready_for_dispatch("npu") is False, "a WARMING slot must not be dispatchable"

--- a/tests/slots/test_manager_npu_container.py
+++ b/tests/slots/test_manager_npu_container.py
@@ -194,3 +194,48 @@ async def test_registry_style_model_id_does_not_take_flm_path(
     assert model_info_arg["_model_key"] == "qwopus3.6-27b-v2"
     # flm_tag is also always stamped (from the base info dict).
     assert model_info_arg["flm_tag"] == "qwopus3.6-27b-v2"
+
+
+# ── DR-3: health-probe timeout must NOT advertise a lying READY ──────────────
+
+
+@pytest.mark.anyio
+async def test_await_ready_health_timeout_stays_non_dispatchable(
+    slot_root: Path,
+    tmp_hal0_home: str,
+) -> None:
+    """A /health wait timeout resolves to WARMING (non-dispatchable), not READY.
+
+    DR-3: when ``container_provider().wait_ready`` times out, the container's
+    inference server never answered /health, so the slot must NOT be advertised
+    as dispatchable. Resolving to WARMING keeps it retryable (the fail watcher /
+    next-request reload governs recovery) instead of forwarding live traffic to
+    a wedged server on a false READY.
+    """
+    from hal0.slots.manager import SlotState
+
+    _write_npu_container_slot(slot_root, "npu")
+
+    fake_provider = _make_container_provider_mock()
+    # Simulate the container port never becoming healthy within the window.
+    fake_provider.wait_ready = AsyncMock(
+        side_effect=TimeoutError("port did not become healthy")
+    )
+
+    with (
+        patch("hal0.providers.container.container_provider", return_value=fake_provider),
+        patch(
+            "hal0.providers.flm.flm_served_models",
+            return_value=[{"tag": "gemma3:4b", "installed": True}],
+        ),
+        patch("hal0.agents.hermes_refresh.spawn_context_refresh", lambda *a, **k: None),
+    ):
+        mgr = SlotManager()
+        await mgr.load("npu", "gemma3:4b")
+
+        assert mgr.state("npu") == SlotState.WARMING, (
+            "health-probe timeout must resolve to WARMING, not a lying READY"
+        )
+        assert mgr.is_ready_for_dispatch("npu") is False, (
+            "a WARMING slot must not be dispatchable"
+        )


### PR DESCRIPTION
## Wave 2 of the platform-review remediation program

Install-path reliability findings from `handoffs/platform-review-2026-07-03.md`. Each finding adversarially re-verified against current source, then fixed TDD-style (failing regression test → minimal fix → green), and the whole diff passed a correctness+security review gate.

| ID | Fix |
|----|-----|
| **MR-1** | Lift the durable pull-job snapshot writer into `registry/pull.py` and persist terminal state inside `run_pull`'s `finally`, so installer/bundle-tier pulls (which call `run_pull` directly, bypassing the `routes/models` wrappers) survive an install-time api restart instead of 404'ing every `/pull/status`. `routes/models` imports the lifted helpers (single owner, dedup). |
| **MR-2** | `_reconcile_persisted_pull_job` cross-checks ground truth: a stale `queued`/`running` snapshot whose model is actually installed (registry + file present) reconciles to `completed`, not a spurious `failed` that makes the user re-pull. |
| **DR-2** | Take a per-slot dispatch ticket at the image-mode guard (before any `await`) so the `GpuArbiter` drain sees requests committed past the guard but not yet at `_serving_enter` — closing the race that unloaded an llm slot under an in-flight request (502). |
| **DR-3** | `_await_ready` returns `WARMING` (not `READY`) on a health-probe timeout, so the FSM-only dispatch gate no longer forwards to a wedged server; the request gets a retryable 503 and the slot re-drives its load. |

### Verification
- Adversarial verify: MR-2/DR-3 **confirmed**, DR-2 **partial→confirmed** (scope tightened).
- New red→green regression tests in `tests/registry/test_pull.py`, `tests/api/test_pull_routes.py`, `tests/dispatcher/test_arbiter_dispatch.py`, `tests/slots/`.
- Local: registry+slots+dispatcher **606 passed**; `tests/api` **1110 passed** (the 3 failures are pre-existing env-specific — root user / proxy config — and reproduce on unmodified `main`).
- Review gate: clean, no merge-blocking issues; applied one belt-and-suspenders ordering fix (persist before client-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)