### PR TITLE
refactor(platform-review): Wave 4 — unify parallel implementations (PS-4, MR-3, DR-8, SC-11)

### DIFF
--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Any
 
 from hal0.config.loader import load_hardware_info
-from hal0.config.schema import DEVICE_DEFAULT_PROFILES
 from hal0.errors import Hal0Error
 from hal0.model_fit import evaluate_model_fit
 from hal0.profiles import ProfileCatalog, ResolvedProfile
@@ -745,20 +744,14 @@ def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:
 
     Mirrors CapabilityOrchestrator's conservative inference so picker and
     apply use the same model/profile/slot compatibility rules until the
-    selection schema carries an explicit profile.
+    selection schema carries an explicit profile. Both surfaces share the
+    single :func:`hal0.capabilities.profile_fit.profile_name_for_fit` rule.
     """
-    profile_name: str | None = None
-    if capability == "tts":
-        # Engine switch within the tts slot — GPU resolves Qwen3, CPU Kokoro.
-        # Must precede the generic gpu→llama branch (a TTS slot never runs the
-        # rocm/vulkan llama profile). See ``tts_profile_for_device``.
-        profile_name = tts_profile_for_device(device)
-    elif device == "npu":
-        profile_name = DEVICE_DEFAULT_PROFILES.get("npu")
-    elif device in {"gpu-rocm", "gpu-vulkan"}:
-        profile_name = DEVICE_DEFAULT_PROFILES.get(device)
-    elif capability == "image":
-        profile_name = "comfyui"
+    # Local import: profile_fit imports tts_profile_for_device from this
+    # module, so a top-level import here would be circular.
+    from hal0.capabilities.profile_fit import profile_name_for_fit
+
+    profile_name = profile_name_for_fit(capability, device)
     if not profile_name:
         return None
     try:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -45,9 +45,9 @@ from hal0.capabilities.config import (
     load_capabilities_config,
     save_capabilities_config,
 )
+from hal0.capabilities.profile_fit import profile_name_for_fit
 from hal0.config import paths
 from hal0.config.loader import load_slot_config, write_toml_atomic
-from hal0.config.schema import DEVICE_DEFAULT_PROFILES
 from hal0.dispatcher._npu_common import is_container_npu_cfg
 from hal0.errors import BadRequest, Hal0Error, NotFound
 from hal0.model_fit import evaluate_model_fit
@@ -632,23 +632,11 @@ class CapabilityOrchestrator:
         The capability selection schema does not yet carry an explicit
         profile. Keep inference conservative: use profiles where the
         existing device/capability already identifies a runtime family, and
-        avoid treating generic CPU as kokoro except for TTS.
+        avoid treating generic CPU as kokoro except for TTS. The rule is
+        shared with the picker via
+        :func:`hal0.capabilities.profile_fit.profile_name_for_fit`.
         """
-        profile_name: str | None = None
-        if capability == "tts":
-            # TTS is engine-selected within the single ``tts`` slot: GPU →
-            # Qwen3-TTS (``tts-qwen3`` → Qwen3TTSProvider), CPU → Kokoro
-            # (``tts``). This must precede the generic gpu→llama branch below,
-            # which would otherwise hand a TTS slot the rocm/vulkan llama
-            # profile (wrong runtime family — the slot would never start the
-            # TTS image).
-            profile_name = tts_profile_for_device(device)
-        elif device == "npu":
-            profile_name = DEVICE_DEFAULT_PROFILES.get("npu")
-        elif device in {"gpu-rocm", "gpu-vulkan"}:
-            profile_name = DEVICE_DEFAULT_PROFILES.get(device)
-        elif capability == "image":
-            profile_name = "comfyui"
+        profile_name = profile_name_for_fit(capability, device)
         if not profile_name:
             return None
         try:

--- a/src/hal0/capabilities/profile_fit.py
+++ b/src/hal0/capabilities/profile_fit.py
@@ -1,0 +1,42 @@
+"""Shared picker/apply profile-fit inference (device → runtime profile name).
+
+Single source for the ``(capability, device) → profile name`` rule that the
+capability *picker* (``catalog._profile_for_fit``) and the *apply-time*
+reconciler (``CapabilityOrchestrator._profile_for_fit``) both need so a
+selection resolves to the SAME runtime profile in both surfaces.
+
+This is the conservative, *plain-base* mapping: it uses the canonical
+device-class-representative table (:data:`hal0.config.schema.DEVICE_DEFAULT_PROFILES`)
+and deliberately never prefers the MTP ``rocm-dnse`` image — a picker/reconcile
+must not silently force a slot onto MTP. The install-flavoured, MTP-preferring
+counterpart is :func:`hal0.install.profile_derive.derive_profile`.
+"""
+
+from __future__ import annotations
+
+from hal0.capabilities.catalog import tts_profile_for_device
+from hal0.config.schema import DEVICE_DEFAULT_PROFILES
+
+
+def profile_name_for_fit(capability: str, device: str) -> str | None:
+    """Infer the runtime profile name implied by a picker/apply selection.
+
+    Keeps inference conservative: use profiles where the device/capability
+    already identifies a runtime family, and avoid treating generic CPU as
+    kokoro except for TTS. Returns ``None`` when nothing can be inferred (the
+    selection schema does not yet carry an explicit profile).
+
+    Order matters — the ``tts`` branch must precede the generic ``gpu`` branch
+    so a TTS slot never receives the rocm/vulkan llama profile (wrong runtime
+    family — the slot would never start the TTS image).
+    """
+    if capability == "tts":
+        # Engine switch within the tts slot — GPU resolves Qwen3, CPU Kokoro.
+        return tts_profile_for_device(device)
+    if device == "npu":
+        return DEVICE_DEFAULT_PROFILES.get("npu")
+    if device in {"gpu-rocm", "gpu-vulkan"}:
+        return DEVICE_DEFAULT_PROFILES.get(device)
+    if capability == "image":
+        return "comfyui"
+    return None

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -12,7 +12,7 @@ The (device, profile) pairs this produces are backend-coherent per #807:
 
 from __future__ import annotations
 
-from hal0.config.schema import HardwareInfo
+from hal0.config.schema import DEVICE_DEFAULT_PROFILES, HardwareInfo
 
 #: NPU-trio capabilities (NPU chat agent + npu stt/embed passengers). Kept as a
 #: symbol because the trio code is left **dormant** (out of scope to remove,
@@ -89,18 +89,29 @@ def derive_device(capability: str, hw: HardwareInfo, *, npu_opt_in: bool) -> str
 
 
 def derive_profile(capability: str, device: str) -> str:
-    """Return a ``SEED_PROFILES`` name for a (capability, device) pair."""
-    if device == "npu":
-        return "flm"
-    if device == "gpu-rocm":
+    """Return a ``SEED_PROFILES`` name for a (capability, device) pair.
+
+    Reads the canonical device-class base profile from the single-source
+    :data:`~hal0.config.schema.DEVICE_DEFAULT_PROFILES` table (gpu-rocm→rocm,
+    gpu-vulkan→vulkan, cpu→cpu-llm, npu→flm) and layers the install path's
+    TWO genuine specialisations on top:
+
+    * ``gpu-rocm`` + dense chat/coder → the MTP ``rocm-dnse`` image. This MTP
+      preference is what makes this the *install*-flavoured resolver — the
+      picker/reconcile fit path (:func:`hal0.capabilities.profile_fit.profile_name_for_fit`)
+      and the drawer device-flip (``_base_profile_for_backend``) deliberately
+      stay on plain ``rocm`` so nothing silently forces a slot onto MTP.
+    * ``cpu`` + ``tts`` → the kokoro ``tts`` profile.
+
+    An unknown device falls back to ``cpu-llm`` (the CPU-coherent llama-server
+    profile) — returning a GPU profile there caused #807 to reject the slot on
+    GPU-less boxes (device=cpu + profile=vulkan incoherent, #834).
+    """
+    if device == "gpu-rocm" and capability in ("chat", "coder"):
         # Dense chat/coder benefit from MTP; embed + others take plain rocm.
-        return "rocm-dnse" if capability in ("chat", "coder") else "rocm"
-    if device == "gpu-vulkan":
-        return "vulkan"
-    if device == "cpu":
-        # ``tts`` stays on the kokoro/CPU profile; everything else (chat,
-        # coder, embed, utility, …) goes to the CPU-coherent llama-server
-        # profile.  Returning "vulkan" here caused #807 to reject the slot
-        # on GPU-less boxes (device=cpu + profile=vulkan incoherent, #834).
-        return "tts" if capability == "tts" else "cpu-llm"
-    return "cpu-llm"
+        return "rocm-dnse"
+    if device == "cpu" and capability == "tts":
+        # ``tts`` stays on the kokoro/CPU profile; everything else on CPU takes
+        # the CPU-coherent llama-server profile from the base table below.
+        return "tts"
+    return DEVICE_DEFAULT_PROFILES.get(device, "cpu-llm")

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -76,6 +76,74 @@ def classify(model_id: str = "", capabilities: Any = None) -> str:
     return "chat"
 
 
+# ── filename → capability token (MR-3) ───────────────────────────────────────
+#
+# ONE token table feeding both filename heuristics that used to drift:
+# ``registry/discover._guess_capability`` (auto-scan) and
+# ``registry/detect._filename_capability`` (single-file detect). Before this
+# the same "guess capability from a filename" logic lived in three places with
+# three different token sets, so a reranker gguf auto-scanned as ``chat`` in
+# discover while ``classify`` already knew it was ``rerank``.
+#
+# This returns a CAPABILITY token — not a coarse modality bucket like
+# :func:`classify` — or ``None`` when nothing matches. Each caller applies its
+# own default so their output vocabularies stay intact (discover defaults to
+# ``chat``; detect narrows to embed/asr/tts).
+#
+# Ordering is load-bearing: ``rerank`` is tested BEFORE ``embed`` so a
+# "bge-reranker" filename (which also contains the embed token "bge")
+# classifies as ``rerank`` rather than ``embed``.
+
+_RERANK_NAME_TOKENS: tuple[str, ...] = ("rerank",)
+_EMBED_NAME_TOKENS: tuple[str, ...] = ("embed", "bge", "e5", "nomic", "gte-", "jina-embed")
+_VISION_NAME_TOKENS: tuple[str, ...] = ("vl", "vision", "vit")
+_ASR_NAME_TOKENS: tuple[str, ...] = ("whisper", "moonshine", "-asr", "_asr", "asr", "stt")
+_TTS_NAME_TOKENS: tuple[str, ...] = ("tts", "kokoro", "vibevoice", "voice")
+# Clearly-diffusion media families (#940 hardening): classifying these as
+# video/image instead of defaulting to ``chat`` keeps a 25GB video-diffusion
+# gguf out of the chat fallback pool ``SlotManager._fallback_local_model``
+# draws from. Conservative: only well-known families, matched as substrings.
+_VIDEO_NAME_TOKENS: tuple[str, ...] = (
+    "ltx",
+    "wan",
+    "hunyuan-video",
+    "hunyuanvideo",
+    "cogvideo",
+    "svd",
+)
+_IMAGE_NAME_TOKENS: tuple[str, ...] = ("sdxl", "flux", "stable-diffusion", "stable_diffusion")
+
+
+def capability_from_filename(name: str) -> str | None:
+    """Best-effort capability token inferred from a model filename.
+
+    Returns one of ``rerank | embed | vision | asr | tts | video | image``,
+    or ``None`` when no token matches. Matching is a case-insensitive
+    substring test against a single shared token table; ``rerank`` is checked
+    before ``embed`` so cross-encoder rerankers (whose names carry an embed
+    token such as "bge") don't misclassify as embedders.
+
+    Callers apply their own default for the ``None`` case so their existing
+    output vocabularies are preserved (see the module note above).
+    """
+    lower = name.lower()
+    if any(tok in lower for tok in _RERANK_NAME_TOKENS):
+        return "rerank"
+    if any(tok in lower for tok in _EMBED_NAME_TOKENS):
+        return "embed"
+    if any(tok in lower for tok in _VISION_NAME_TOKENS):
+        return "vision"
+    if any(tok in lower for tok in _ASR_NAME_TOKENS):
+        return "asr"
+    if any(tok in lower for tok in _TTS_NAME_TOKENS):
+        return "tts"
+    if any(tok in lower for tok in _VIDEO_NAME_TOKENS):
+        return "video"
+    if any(tok in lower for tok in _IMAGE_NAME_TOKENS):
+        return "image"
+    return None
+
+
 # ── device → recipe/backend mapping ──────────────────────────────────────────
 #
 # Plan §4.1 + ADR-0008 §6 locked the four-way mapping; the result feeds
@@ -216,6 +284,7 @@ def labels_of(cfg: dict[str, Any]) -> set[str]:
 
 __all__ = [
     "canonical_device",
+    "capability_from_filename",
     "classify",
     "device_to_backend",
     "device_to_legacy_backend",

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -87,18 +87,31 @@ def classify(model_id: str = "", capabilities: Any = None) -> str:
 #
 # This returns a CAPABILITY token — not a coarse modality bucket like
 # :func:`classify` — or ``None`` when nothing matches. Each caller applies its
-# own default so their output vocabularies stay intact (discover defaults to
-# ``chat``; detect narrows to embed/asr/tts).
+# own default for the ``None`` case (discover defaults to ``chat``; detect
+# narrows to embed/asr/tts). Note: unifying on this shared table intentionally
+# BROADENS discover's embed vocabulary — bge/gte-/e5-/jina-embed filenames that
+# discover previously mislabeled as ``chat`` now correctly resolve to ``embed``
+# (the MR-3 fix, of a piece with the reranker fix). See the token-table comment.
 #
 # Ordering is load-bearing: ``rerank`` is tested BEFORE ``embed`` so a
 # "bge-reranker" filename (which also contains the embed token "bge")
 # classifies as ``rerank`` rather than ``embed``.
 
 _RERANK_NAME_TOKENS: tuple[str, ...] = ("rerank",)
-_EMBED_NAME_TOKENS: tuple[str, ...] = ("embed", "bge", "e5", "nomic", "gte-", "jina-embed")
+# Embedder families. bge/gte-/jina-embed/nomic/e5- are INTENTIONALLY included
+# here as part of the MR-3 unification: discover previously only knew
+# ("embed","nomic") and mislabeled bge/gte/e5 embedders as ``chat`` (keeping
+# them out of the correct embed slot). Tokens are anchored to avoid loose
+# 2-char false positives — ``e5-`` (not bare "e5", which would match any chat
+# filename containing "e5") and ``gte-`` (not bare "gte"). ``rerank`` is tested
+# first (below) so "bge-reranker" resolves to rerank, not embed.
+_EMBED_NAME_TOKENS: tuple[str, ...] = ("embed", "bge", "e5-", "nomic", "gte-", "jina-embed")
 _VISION_NAME_TOKENS: tuple[str, ...] = ("vl", "vision", "vit")
 _ASR_NAME_TOKENS: tuple[str, ...] = ("whisper", "moonshine", "-asr", "_asr", "asr", "stt")
-_TTS_NAME_TOKENS: tuple[str, ...] = ("tts", "kokoro", "vibevoice", "voice")
+# ``vibevoice`` is explicit; bare "voice" is deliberately excluded (too loose —
+# would catch a chat model named "...voice..."). xtts-voice still resolves via
+# the bare "tts" token.
+_TTS_NAME_TOKENS: tuple[str, ...] = ("tts", "kokoro", "vibevoice")
 # Clearly-diffusion media families (#940 hardening): classifying these as
 # video/image instead of defaulting to ``chat`` keeps a 25GB video-diffusion
 # gguf out of the chat fallback pool ``SlotManager._fallback_local_model``

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -33,6 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from hal0.model_meta import capability_from_filename
 from hal0.registry.gguf_header import read_gguf_header
 
 log = logging.getLogger(__name__)
@@ -42,10 +43,6 @@ Confidence = Literal["high", "medium", "low"]
 # Backends llama-server can target for any GGUF file. The slot config
 # picks one based on hardware probe; detection just lists what's *compatible*.
 _GGUF_BACKENDS: list[str] = ["vulkan", "rocm", "cuda", "cpu"]
-
-_EMBED_TOKENS = ("embed", "bge", "e5", "nomic", "gte-", "jina-embed")
-_ASR_TOKENS = ("whisper", "moonshine", "-asr", "_asr")
-_TTS_TOKENS = ("kokoro", "vibevoice", "-tts", "_tts")
 
 
 def _hf_repo_name_from_path(path: Path) -> str | None:
@@ -99,15 +96,19 @@ class DetectionResult:
 
 
 def _filename_capability(name: str) -> str | None:
-    """Best-effort capability inferred from filename tokens. ``None`` if no hit."""
-    lower = name.lower()
-    if any(tok in lower for tok in _EMBED_TOKENS):
-        return "embed"
-    if any(tok in lower for tok in _ASR_TOKENS):
-        return "asr"
-    if any(tok in lower for tok in _TTS_TOKENS):
-        return "tts"
-    return None
+    """Best-effort capability inferred from filename tokens. ``None`` if no hit.
+
+    Delegates to the single shared token table
+    (:func:`hal0.model_meta.capability_from_filename`, MR-3) but preserves
+    detect's narrower contract: the downstream branching in
+    :func:`_heuristic_only` and the GGUF embed fallback in :func:`detect`
+    only understand ``embed``/``asr``/``tts``, so any other token the shared
+    helper recognises (rerank/vision/video/image) is collapsed back to
+    ``None`` here. Extending detect to emit ``rerank`` is a separate,
+    pooling-semantics follow-up.
+    """
+    cap = capability_from_filename(name)
+    return cap if cap in ("embed", "asr", "tts") else None
 
 
 def _heuristic_only(path: Path) -> DetectionResult:

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hal0.config.schema import ModelsConfig
+from hal0.model_meta import capability_from_filename
 from hal0.registry.curated import CURATED_MODELS, CuratedModel
 from hal0.registry.model import Model
 from hal0.registry.store import ModelAlreadyExists, ModelRegistry
@@ -111,36 +112,17 @@ def _normalise_id(stem: str) -> str:
     return collapsed or "model"
 
 
-# Filename tokens that mark an image/video diffusion artifact. Classifying
-# these as ``image``/``video`` (instead of defaulting to ``chat``) keeps them
-# out of the chat candidate pool that ``SlotManager._fallback_local_model``
-# draws from — the live ltx-2 incident, where a 25GB video diffusion gguf was
-# default-guessed ``chat`` and selected as the chat slot's fallback. The
-# fallback's own diffusion guard is the must-have backstop; this is defence in
-# depth at the source. Conservative: only well-known families, matched as
-# substrings of the lower-cased filename.
-_VIDEO_NAME_TOKENS = ("ltx", "wan", "hunyuan-video", "hunyuanvideo", "cogvideo", "svd")
-_IMAGE_NAME_TOKENS = ("sdxl", "flux", "stable-diffusion", "stable_diffusion")
-
-
 def _guess_capability(filename: str) -> str:
-    """Best-effort capability inference from the filename."""
-    lower = filename.lower()
-    if any(tok in lower for tok in ("embed", "nomic")):
-        return "embed"
-    if any(tok in lower for tok in ("vl", "vision", "vit")):
-        return "vision"
-    if any(tok in lower for tok in ("tts", "voice", "kokoro", "vibevoice")):
-        return "tts"
-    if any(tok in lower for tok in ("whisper", "moonshine", "asr", "stt")):
-        return "asr"
-    # Clearly-diffusion media: classify as image/video rather than the chat
-    # default so they never pollute the chat fallback pool (#940 hardening).
-    if any(tok in lower for tok in _VIDEO_NAME_TOKENS):
-        return "video"
-    if any(tok in lower for tok in _IMAGE_NAME_TOKENS):
-        return "image"
-    return "chat"
+    """Best-effort capability inference from the filename.
+
+    Delegates to the single shared token table in
+    :func:`hal0.model_meta.capability_from_filename` (MR-3) so the auto-scan,
+    single-file detect, and ``classify`` heuristics can no longer drift.
+    Reranker filenames now yield ``rerank`` instead of the old ``chat``
+    default. ``chat`` remains the default for unrecognised filenames — the
+    #940 backstop contract ``SlotManager._fallback_local_model`` relies on.
+    """
+    return capability_from_filename(filename) or "chat"
 
 
 def _match_curated(filename: str) -> CuratedModel | None:

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -77,6 +77,56 @@ def write_slot_toml(path: Path | str, data: dict[str, Any]) -> None:
     write_toml_atomic(Path(path), data)
 
 
+# ── the shared slot-projection merge primitive (SC-11) ───────────────────────
+
+
+def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Project ``updates`` onto a slot-config ``base`` dict, copy-safe.
+
+    THE one shared "base dict + updates dict → merged dict" mechanic that
+    both the store (:meth:`SlotConfigStore._reconciled_slot`) and
+    :meth:`hal0.slots.manager.SlotManager.update_config` used to hand-roll
+    (SC-11). It does exactly three things and no field-specific reconciliation
+    (the store's selection→updates mapping and the manager's device/profile
+    coherence stay with their respective callers):
+
+      - shallow-copies ``base`` so the caller's dict is never mutated,
+      - runs a ONE-level-deep merge: for a key present as a dict on both
+        sides the sub-tables are merged key-by-key (``{**existing, **value}``,
+        so sibling ``[model]`` keys like ``default``/``context_size``
+        survive); every other key (scalars, lists, dict-vs-scalar) replaces
+        wholesale — value wins,
+      - folds the legacy ``[model].ctx_size`` alias into the canonical
+        ``context_size`` (#585): a fresh ``ctx_size`` wins over any stale
+        ``context_size``, then the alias is dropped so exactly one key
+        survives on disk.
+
+    Copy-safety is load-bearing: the store diffs ``before`` against ``after``
+    and rolls back to ``before`` on a failed commit, so the returned dict must
+    never share the ``[model]`` sub-dict with ``base``. Both the merge path
+    (which builds a fresh ``{**existing, **value}``) and the fold path (which
+    copies the sub-dict before ``pop``) honour that.
+    """
+    after = dict(base)
+    for key, value in updates.items():
+        existing = after.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            after[key] = {**existing, **value}
+        else:
+            after[key] = value
+
+    # #585: fold the legacy [model].ctx_size alias into the canonical
+    # context_size. Copy the sub-dict before mutating so ``base`` (the store's
+    # ``before`` snapshot) is never touched even when ``updates`` carried no
+    # [model] and ``after["model"]`` is still ``base``'s object.
+    model = after.get("model")
+    if isinstance(model, dict) and "ctx_size" in model:
+        model = dict(model)
+        model["context_size"] = model.pop("ctx_size")
+        after["model"] = model
+    return after
+
+
 # ── ChangeSet ────────────────────────────────────────────────────────────────
 
 
@@ -260,12 +310,18 @@ class SlotConfigStore:
           - the backend/device/provider/model/profile fields are reconciled
             ONLY when the selection is enabled (a pure disable never rewrites
             the model/device siblings),
-          - one-level deep merge for the nested ``[model]`` table so
-            sibling keys (``context_size`` etc.) survive,
           - both ``device`` (v0.2 canonical) and ``backend`` (one-release
-            legacy alias) written, translated via :mod:`hal0.model_meta`,
-          - the ``ctx_size`` → ``context_size`` alias folded (#585) so
-            the two keys can't diverge on disk.
+            legacy alias) written, translated via :mod:`hal0.model_meta`.
+
+        Once the store-specific ``updates`` dict is built, the actual
+        projection — the one-level-deep ``[model]`` merge (so sibling keys
+        like ``context_size`` survive) and the ``ctx_size`` → ``context_size``
+        fold (#585) — is delegated to the shared, copy-safe
+        :func:`merge_slot_config` (SC-11), the same primitive
+        :meth:`SlotManager.update_config` uses. Copy-safety matters here: the
+        returned ``after`` must not mutate ``raw_before`` (the ChangeSet's
+        ``before`` snapshot) or a disable-only reconcile could break the
+        commit diff / rollback.
 
         voice.tts engine switch (follow-up to #972): the two TTS engines
         (Kokoro CPU / Qwen3-TTS GPU) live in the SAME ``tts`` slot, selected
@@ -307,22 +363,10 @@ class SlotConfigStore:
             if tts_profile is not None:
                 updates["profile"] = tts_profile
 
-        after = dict(raw_before)
-        for key, value in updates.items():
-            existing = after.get(key)
-            if isinstance(existing, dict) and isinstance(value, dict):
-                after[key] = {**existing, **value}
-            else:
-                after[key] = value
-
-        # #585 parity with SlotManager.update_config: fold the legacy
-        # [model].ctx_size alias into the canonical context_size key.
-        model = after.get("model")
-        if isinstance(model, dict) and "ctx_size" in model:
-            model = dict(model)
-            model["context_size"] = model.pop("ctx_size")
-            after["model"] = model
-        return after
+        # The one-level [model] merge + #585 ctx_size fold is the shared,
+        # copy-safe primitive (SC-11) — ``raw_before`` (the ChangeSet's
+        # ``before`` snapshot) is never mutated.
+        return merge_slot_config(raw_before, updates)
 
     @staticmethod
     def _tts_profile_for(slot_selection: SlotSelection) -> str | None:
@@ -367,5 +411,6 @@ __all__ = [
     "FileState",
     "SlotConfigStore",
     "SlotSelection",
+    "merge_slot_config",
     "write_slot_toml",
 ]

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -176,22 +176,23 @@ def serialize_slot(slot: Any, model_cache: dict[str, Any] | None = None) -> dict
 
 # ── loaded-model derivation ──────────────────────────────────────────────────
 
-#: Dispatchable ready-set (#696) — mirrors SlotManager.is_ready_for_dispatch.
-_READY_STATES = frozenset({"ready", "serving", "idle"})
-
 
 def loaded_model_names_from_slots(slots: list[Any]) -> set[str]:
     """Model ids currently served by dispatchable slots.
 
     Derives the loaded set from Slot snapshots: a model counts as
     loaded when its slot is in the dispatchable ready-set (READY /
-    SERVING / IDLE, per #696). Junk entries are skipped.
+    SERVING / IDLE, per #696 / DR-8). Junk entries are skipped.
     """
+    # Lazy import: top-level ``from hal0.slots...`` would cycle (hal0.slots
+    # __init__ pulls in the heavy manager, which imports this module). Mirror
+    # the pattern used in ``serialize_slot`` above. ``is_dispatchable_state``
+    # owns the shared str/StrEnum normalisation, so pass the raw snapshot state.
+    from hal0.slots.state import is_dispatchable_state
+
     names: set[str] = set()
     for slot in slots:
-        raw_state = getattr(slot, "state", "")
-        state = str(getattr(raw_state, "value", raw_state) or "").lower()
-        if state not in _READY_STATES:
+        if not is_dispatchable_state(getattr(slot, "state", "")):
             continue
         model_id = getattr(slot, "model_id", None)
         if isinstance(model_id, str) and model_id:

--- a/src/hal0/slots/arbiter.py
+++ b/src/hal0/slots/arbiter.py
@@ -60,7 +60,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from hal0.config import paths
 from hal0.errors import Hal0Error, NotFound
-from hal0.slots.state import SlotState
+from hal0.slots.state import DISPATCHABLE_STATES, SlotState
 
 if TYPE_CHECKING:  # pragma: no cover — import cycle guard (manager owns us)
     from hal0.slots.manager import SlotManager
@@ -86,9 +86,8 @@ _IMG_READY_TIMEOUT_S = 120.0
 _READY_POLL_S = 0.5
 
 #: Slot states that can take a dispatch / mean "the img container is up".
-_DISPATCHABLE: frozenset[SlotState] = frozenset(
-    {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
-)
+#: Aliases the canonical set (DR-8) — do not re-declare the literal here.
+_DISPATCHABLE: frozenset[SlotState] = DISPATCHABLE_STATES
 #: Terminal states that abort the readiness poll immediately.
 _TERMINAL: frozenset[SlotState] = frozenset({SlotState.ERROR, SlotState.OFFLINE})
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3209,6 +3209,13 @@ def _base_profile_for_backend(catalog: Any, backend: str) -> str:
 
     Prefers the seed profile named after the backend (``rocm`` / ``vulkan``);
     falls back to any non-MTP then any profile that declares ``backend``.
+
+    This is the deliberate *non-MTP* counterpart of
+    :func:`hal0.install.profile_derive.derive_profile`'s ``rocm-dnse``
+    preference: it answers backend→base-profile from the live catalog so a
+    drawer device-flip re-derives a plain base image (``rocm``/``vulkan``) and
+    never silently switches a slot onto the MTP ``rocm-dnse`` image. Do NOT
+    fold it into the device→profile helper (finding PS-4).
     """
     named = catalog.profile.get(backend)
     if named is not None and getattr(named, "backend", None) == backend:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -39,7 +39,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hal0.config import paths
-from hal0.slot_config import write_slot_toml
+from hal0.slot_config import merge_slot_config, write_slot_toml
 from hal0.slots.state import (
     DISPATCHABLE_STATES,
     IllegalSlotTransition,
@@ -1823,27 +1823,24 @@ class SlotManager:
         self._ensure_known(slot_name)
         cfg = await self._load_slot_config(slot_name)
         cfg_dict = _cfg_to_dict(cfg)
-        # One-level deep merge for nested TOML tables ([model], [server]).
+        # One-level deep merge for nested TOML tables ([model], [server]) plus
+        # the #585 ctx_size→context_size fold, via the shared, copy-safe
+        # ``merge_slot_config`` primitive (SC-11) — the SAME projection the
+        # SlotConfigStore uses, so the two can't silently diverge.
+        #
         # A bare shallow ``dict.update`` replaced a sub-table wholesale, so a
         # partial ``PATCH /defaults`` body like ``{"model": {"ctx_size": N}}``
         # silently dropped sibling keys — most damagingly ``[model].default``
         # (the model name), which left the slot unable to resolve a model and
         # turned the dashboard Start button into a silent no-op after a
-        # restart. Merge sub-table dicts key-by-key so partial updates only
-        # touch the fields they carry; scalars and lists still replace
-        # wholesale (predictable, and no caller relies on list-merge).
-        for key, value in updates.items():
-            existing = cfg_dict.get(key)
-            if isinstance(existing, dict) and isinstance(value, dict):
-                merged = dict(existing)
-                merged.update(value)
-                cfg_dict[key] = merged
-            else:
-                cfg_dict[key] = value
-
-        # #585: the dashboard writes [model].ctx_size; canonicalize to
-        # context_size so the two keys can't diverge on disk.
-        _normalize_ctx_key(cfg_dict)
+        # restart. The helper merges sub-table dicts key-by-key so partial
+        # updates only touch the fields they carry; scalars and lists still
+        # replace wholesale (predictable, and no caller relies on list-merge).
+        # It also folds the dashboard's legacy ``[model].ctx_size`` alias into
+        # the canonical ``context_size`` (#585) so the two keys can't diverge
+        # on disk. ``merge_slot_config`` returns a fresh dict, so rebind
+        # ``cfg_dict`` before the downstream reconcile/guard calls below.
+        cfg_dict = merge_slot_config(cfg_dict, updates)
 
         # Keep device↔profile backend coherent: a profile switch re-derives
         # device (the drawer path that previously left a vulkan device under a

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING, Any
 from hal0.config import paths
 from hal0.slot_config import write_slot_toml
 from hal0.slots.state import (
+    DISPATCHABLE_STATES,
     IllegalSlotTransition,
     NpuExclusivityViolation,
     SlotConfigError,
@@ -120,9 +121,10 @@ _SLOT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
 # inactive underneath us the watcher flips state and emits an SSE
 # frame within ~1s.
 _FAIL_WATCH_INTERVAL_S: float = 2.0
-_FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = frozenset(
-    {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
-)
+#: The "live" states the fail-watcher polls are exactly the dispatchable
+#: ready-set (container up and usable) — alias the one canonical set (DR-8)
+#: rather than re-declaring the literal.
+_FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = DISPATCHABLE_STATES
 # #783/B4: an active unit is not necessarily healthy. The watcher also probes
 # the model server's /health; a crashed-but-active server (active unit, failing
 # /health) is demoted to ERROR — but only after this many CONSECUTIVE failures,
@@ -515,11 +517,10 @@ class SlotManager:
     # ── public readiness interface (issue #696) ─────────────────────────────
 
     #: States in which a slot is safe to dispatch inference requests to.
-    #: Single source of truth per #696 — never duplicate inline.
+    #: Single source of truth per #696 / DR-8 — aliases the one canonical set
+    #: in ``hal0.slots.state`` so this class never re-declares the literal.
     #: Sync read so call sites in the hot dispatch path pay zero await overhead.
-    _DISPATCHABLE_STATES: frozenset[SlotState] = frozenset(
-        {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
-    )
+    _DISPATCHABLE_STATES: frozenset[SlotState] = DISPATCHABLE_STATES
 
     def state(self, name: str) -> SlotState:
         """Return the current :class:`SlotState` for *name*.

--- a/src/hal0/slots/metrics.py
+++ b/src/hal0/slots/metrics.py
@@ -22,8 +22,12 @@ from __future__ import annotations
 
 from typing import Any
 
-#: Dispatchable ready-set (#696) — mirrors SlotManager.is_ready_for_dispatch.
-_READY_STATES = frozenset({"ready", "serving", "idle"})
+from hal0.slots.state import DISPATCHABLE_STATES
+
+#: Dispatchable ready-set (#696 / DR-8) — the one canonical set from
+#: hal0.slots.state. SlotState is a StrEnum, so membership works for the
+#: lowercase wire strings this renderer compares against (``"ready" in set``).
+_READY_STATES = DISPATCHABLE_STATES
 
 
 def _escape_label(value: str) -> str:

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -119,6 +119,30 @@ def is_transition_legal(from_state: SlotState, to_state: SlotState) -> bool:
     return to_state in LEGAL_TRANSITIONS.get(from_state, frozenset())
 
 
+# ── dispatchable ready-set (single source of truth, #696 / DR-8) ─────────────
+
+#: States in which a slot is safe to dispatch inference requests to.
+#: This is the ONE canonical definition (finding DR-8): SlotManager, the GPU
+#: arbiter, stack apply, the Prometheus metrics renderer, and the slot_view
+#: aggregator all reference this set instead of re-declaring their own copy.
+#: Because SlotState is a StrEnum, membership works for BOTH enum members and
+#: their lowercase wire strings — ``"ready" in DISPATCHABLE_STATES`` is True —
+#: so the string-based snapshot callers (metrics / slot_view) share it too.
+DISPATCHABLE_STATES: frozenset[SlotState] = frozenset(
+    {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
+)
+
+
+def is_dispatchable_state(state: SlotState | str) -> bool:
+    """Return True when *state* is in the dispatchable ready-set.
+
+    Accepts a :class:`SlotState` or a raw wire string and applies the same
+    str/StrEnum normalisation the snapshot callers use, so a ``SlotState``
+    member, its ``.value``, or a plain lowercase string all classify alike.
+    """
+    return str(getattr(state, "value", state) or "").lower() in DISPATCHABLE_STATES
+
+
 #: Providers that serve a baked-in model and don't require an explicit model_id.
 #: Must stay in sync with ui/src/composables/useSlotStats.js SELF_MANAGED_PROVIDERS.
 SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "qwen3tts", "moonshine", "vibevoice"})
@@ -323,6 +347,7 @@ def read_state(path: Path | str) -> SlotStateRecord | None:
 
 
 __all__ = [
+    "DISPATCHABLE_STATES",
     "LEGAL_TRANSITIONS",
     "SELF_MANAGED_PROVIDERS",
     "IllegalSlotTransition",
@@ -335,6 +360,7 @@ __all__ = [
     "SlotSpawnFailed",
     "SlotState",
     "SlotStateRecord",
+    "is_dispatchable_state",
     "is_transition_legal",
     "provider_requires_model",
     "read_state",

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -23,7 +23,7 @@ from hal0.config import paths
 from hal0.config.schema import StackConfig, StackSlotEntry
 from hal0.model_meta import canonical_device, device_to_legacy_backend
 from hal0.slot_config import ChangeSet, FileState, SlotConfigStore
-from hal0.slots.state import SlotState
+from hal0.slots.state import DISPATCHABLE_STATES, SlotState
 from hal0.stacks.state import (
     StackStateRecord,
     read_stack_state,
@@ -62,7 +62,8 @@ class StackChangePlan:
 
 
 # Slot states by convergence intent.
-_DISPATCHABLE = frozenset({SlotState.READY, SlotState.SERVING, SlotState.IDLE})
+# _DISPATCHABLE aliases the canonical ready-set (DR-8) — single source of truth.
+_DISPATCHABLE = DISPATCHABLE_STATES
 _TRANSITIONAL = frozenset(
     {SlotState.PULLING, SlotState.STARTING, SlotState.WARMING, SlotState.UNLOADING}
 )

--- a/tests/config/test_profile_derivation_parity.py
+++ b/tests/config/test_profile_derivation_parity.py
@@ -1,0 +1,165 @@
+"""Parity/regression lock for the device→profile derivations (finding PS-4).
+
+The platform review found three parallel ``(capability, device) → profile``
+derivations that drifted apart across #834's churn:
+
+  1. :func:`hal0.install.profile_derive.derive_profile` — the install-flavoured,
+     MTP-preferring resolver (gpu-rocm + dense chat/coder → ``rocm-dnse``).
+  2. :data:`hal0.config.schema.DEVICE_DEFAULT_PROFILES` — the canonical, plain
+     device-class-representative base table (never MTP).
+  3. The verbatim-twin ``_profile_for_fit`` blocks in ``capabilities/catalog.py``
+     and ``capabilities/orchestrator.py`` (now both routed through the shared
+     :func:`hal0.capabilities.profile_fit.profile_name_for_fit`).
+
+The consolidation in PS-4 is a literal-dedup + shared-helper refactor with ZERO
+behaviour change. These tests pin the CURRENT matrix so a future unification
+cannot silently drift — critically they lock in the deliberate split between the
+MTP-preferring install path and the non-MTP picker/reconcile path (the naive
+three-way merge the finding proposed would break this).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.capabilities.catalog import _profile_for_fit as catalog_profile_for_fit
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+from hal0.capabilities.profile_fit import profile_name_for_fit
+from hal0.config.schema import DEVICE_DEFAULT_PROFILES
+from hal0.install.profile_derive import derive_profile
+
+# The exact CURRENT (capability, device) → derive_profile matrix. Any change
+# here is a behaviour change and must be a deliberate, reviewed edit.
+_CAPABILITIES = ("chat", "coder", "embed", "utility", "tts", "agent", "image")
+_DEVICES = ("gpu-rocm", "gpu-vulkan", "cpu", "npu")
+
+# derive_profile (install path): MTP-preferring on ROCm for dense chat/coder.
+_DERIVE_MATRIX: dict[tuple[str, str], str] = {
+    # gpu-rocm — dense chat/coder get MTP rocm-dnse; everything else plain rocm.
+    ("chat", "gpu-rocm"): "rocm-dnse",
+    ("coder", "gpu-rocm"): "rocm-dnse",
+    ("embed", "gpu-rocm"): "rocm",
+    ("utility", "gpu-rocm"): "rocm",
+    ("tts", "gpu-rocm"): "rocm",
+    ("agent", "gpu-rocm"): "rocm",
+    ("image", "gpu-rocm"): "rocm",
+    # gpu-vulkan — always the vulkan profile.
+    ("chat", "gpu-vulkan"): "vulkan",
+    ("coder", "gpu-vulkan"): "vulkan",
+    ("embed", "gpu-vulkan"): "vulkan",
+    ("utility", "gpu-vulkan"): "vulkan",
+    ("tts", "gpu-vulkan"): "vulkan",
+    ("agent", "gpu-vulkan"): "vulkan",
+    ("image", "gpu-vulkan"): "vulkan",
+    # cpu — tts stays on kokoro; everything else on the CPU llama profile
+    # (the Wave-1 cpu → "cpu-llm" fix for #807/#834).
+    ("chat", "cpu"): "cpu-llm",
+    ("coder", "cpu"): "cpu-llm",
+    ("embed", "cpu"): "cpu-llm",
+    ("utility", "cpu"): "cpu-llm",
+    ("tts", "cpu"): "tts",
+    ("agent", "cpu"): "cpu-llm",
+    ("image", "cpu"): "cpu-llm",
+    # npu — always flm.
+    ("chat", "npu"): "flm",
+    ("coder", "npu"): "flm",
+    ("embed", "npu"): "flm",
+    ("utility", "npu"): "flm",
+    ("tts", "npu"): "flm",
+    ("agent", "npu"): "flm",
+    ("image", "npu"): "flm",
+}
+
+
+@pytest.mark.parametrize(("capability", "device"), _DERIVE_MATRIX.keys())
+def test_derive_profile_matrix_is_pinned(capability: str, device: str) -> None:
+    """derive_profile locks the exact current output for every cap x device."""
+    assert derive_profile(capability, device) == _DERIVE_MATRIX[(capability, device)]
+
+
+def test_derive_profile_rocm_prefers_mtp_for_dense_chat_coder() -> None:
+    # The one genuine install-path specialisation on ROCm.
+    assert derive_profile("chat", "gpu-rocm") == "rocm-dnse"
+    assert derive_profile("coder", "gpu-rocm") == "rocm-dnse"
+    assert derive_profile("embed", "gpu-rocm") == "rocm"
+
+
+def test_derive_profile_cpu_tts_vs_non_tts() -> None:
+    # The one genuine install-path specialisation on CPU (Wave-1 cpu-llm fix).
+    assert derive_profile("tts", "cpu") == "tts"
+    assert derive_profile("chat", "cpu") == "cpu-llm"
+
+
+def test_device_default_profiles_table_is_pinned() -> None:
+    """Guards the Wave-1 cpu → "cpu-llm" fix and the canonical base table."""
+    assert DEVICE_DEFAULT_PROFILES == {
+        "gpu-rocm": "rocm",
+        "gpu-vulkan": "vulkan",
+        "cpu": "cpu-llm",
+        "npu": "flm",
+    }
+
+
+@pytest.mark.parametrize("capability", _CAPABILITIES)
+@pytest.mark.parametrize("device", _DEVICES)
+def test_profile_for_fit_twin_parity(capability: str, device: str, tmp_hal0_home: str) -> None:
+    """catalog._profile_for_fit and orchestrator._profile_for_fit resolve to
+    the SAME profile name for every cap x device.
+
+    Proves the two blocks are currently identical AND prevents the extracted
+    shared helper from regressing only one copy. ``self`` is unused by the
+    orchestrator method, so it is invoked unbound with ``None``.
+    """
+    cat = catalog_profile_for_fit(capability, device)
+    orch = CapabilityOrchestrator._profile_for_fit(None, capability, device)
+    cat_name = cat.name if cat is not None else None
+    orch_name = orch.name if orch is not None else None
+    assert cat_name == orch_name
+
+
+@pytest.mark.parametrize("capability", _CAPABILITIES)
+@pytest.mark.parametrize("device", _DEVICES)
+def test_profile_for_fit_matches_shared_helper(
+    capability: str, device: str, tmp_hal0_home: str
+) -> None:
+    """The resolved catalog profile name equals the shared helper's name."""
+    cat = catalog_profile_for_fit(capability, device)
+    expected = profile_name_for_fit(capability, device)
+    cat_name = cat.name if cat is not None else None
+    assert cat_name == expected
+
+
+def test_fit_helper_is_non_mtp_on_rocm() -> None:
+    """The picker/apply fit path NEVER prefers the MTP rocm-dnse image —
+    that is the install path's job only. This is the guard the naive
+    three-way merge would break.
+    """
+    assert profile_name_for_fit("chat", "gpu-rocm") == "rocm"
+    assert profile_name_for_fit("coder", "gpu-rocm") == "rocm"
+    assert profile_name_for_fit("embed", "gpu-rocm") == "rocm"
+    assert profile_name_for_fit("chat", "gpu-vulkan") == "vulkan"
+
+
+def test_base_profile_for_backend_is_non_mtp(tmp_hal0_home: str) -> None:
+    """_base_profile_for_backend answers the backend→non-MTP-base question so a
+    drawer device-flip never silently switches a slot onto the MTP image.
+    """
+    from hal0.config.loader import load_profiles_config
+    from hal0.slots.manager import _base_profile_for_backend
+
+    catalog = load_profiles_config()
+    assert _base_profile_for_backend(catalog, "rocm") == "rocm"
+    assert _base_profile_for_backend(catalog, "vulkan") == "vulkan"
+
+
+def test_reconcile_device_flip_stays_non_mtp(tmp_hal0_home: str) -> None:
+    """Flipping a chat slot gpu-rocm → gpu-vulkan yields "vulkan", never the
+    MTP "rocm-dnse" — locks in the deliberate non-MTP reconcile semantics.
+    """
+    from hal0.slots.manager import _reconcile_device_profile
+
+    # Slot was on the rocm-dnse (MTP) profile; operator flips the device only.
+    cfg_dict: dict[str, object] = {"device": "gpu-vulkan", "profile": "rocm-dnse"}
+    _reconcile_device_profile(cfg_dict, changed={"device"})
+    assert cfg_dict["profile"] == "vulkan"
+    assert cfg_dict["profile"] != "rocm-dnse"

--- a/tests/model_meta/test_model_meta.py
+++ b/tests/model_meta/test_model_meta.py
@@ -71,6 +71,12 @@ from hal0.model_meta import (
         # No token → None (caller applies its own default; never "chat" here).
         ("qwen2.5-7b.gguf", None),
         ("llama-3.1-8b-instruct.gguf", None),
+        # Anchored tokens: a bare "e5" / "voice" substring in a chat filename
+        # must NOT flip it to embed/tts (guards the loose-token false positive
+        # the MR-3 review flagged). Real embedders use "e5-"; xtts still tts.
+        ("tinyllama-1.1b-e5.gguf", None),
+        ("my-voice-chat.gguf", None),
+        ("xtts-voice-v2.gguf", "tts"),
     ],
 )
 def test_capability_from_filename(name: str, expected: str | None) -> None:

--- a/tests/model_meta/test_model_meta.py
+++ b/tests/model_meta/test_model_meta.py
@@ -24,12 +24,58 @@ import pytest
 
 from hal0.model_meta import (
     canonical_device,
+    capability_from_filename,
     classify,
     device_to_backend,
     device_to_legacy_backend,
     is_resolvable,
     labels_of,
 )
+
+# ── capability_from_filename ─────────────────────────────────────────────────
+#
+# (filename, expected capability token or None). MR-3: the ONE token table
+# that feeds registry/discover + registry/detect filename heuristics. Pins the
+# vocabulary so a future edit can't silently drop a token — and locks the
+# rerank-before-embed precedence that fixes the reranker→chat auto-scan bug.
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # rerank is tested before embed, so a bge-reranker → rerank not embed.
+        ("bge-reranker-v2-m3.gguf", "rerank"),
+        ("jina-reranker-v2-base.gguf", "rerank"),
+        # embed family (the union of every prior site's embed tokens).
+        ("nomic-embed-text.gguf", "embed"),
+        ("bge-base-en-v1.5.gguf", "embed"),
+        ("e5-mistral-7b.safetensors", "embed"),
+        ("gte-large.gguf", "embed"),
+        ("jina-embeddings-v3.gguf", "embed"),
+        # vision.
+        ("qwen2-vl-7b-instruct.gguf", "vision"),
+        ("some-vision-model.gguf", "vision"),
+        # asr.
+        ("whisper-large-v3.gguf", "asr"),
+        ("moonshine-base.onnx", "asr"),
+        ("parakeet-asr.gguf", "asr"),
+        # tts.
+        ("kokoro-82m.pth", "tts"),
+        ("vibevoice-1.5b.safetensors", "tts"),
+        ("some-tts-model.gguf", "tts"),
+        # diffusion media (#940 hardening).
+        ("ltx-2-19b-dev-fp8.gguf", "video"),
+        ("wan2.1-t2v-14b.gguf", "video"),
+        ("flux1-dev.gguf", "image"),
+        ("sdxl-base-1.0.safetensors", "image"),
+        # No token → None (caller applies its own default; never "chat" here).
+        ("qwen2.5-7b.gguf", None),
+        ("llama-3.1-8b-instruct.gguf", None),
+    ],
+)
+def test_capability_from_filename(name: str, expected: str | None) -> None:
+    assert capability_from_filename(name) == expected
+
 
 # ── classify ─────────────────────────────────────────────────────────────────
 #

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -125,6 +125,42 @@ class TestFilenameHeuristic:
         assert r.confidence == "low"
 
 
+class TestMr3ConsolidationPreservesDetectContract:
+    """MR-3: routing detect's filename heuristic through the shared token
+    table must not change detect's embed/asr/tts-only output vocabulary."""
+
+    def test_chat_gguf_still_chat(self, tmp_path: Path) -> None:
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("llama")),
+            ("llama.context_length", _GGUF_TYPE_UINT32, struct.pack("<I", 8192)),
+        ]
+        p = _write_fixture(tmp_path, "llama-3.1-8b.gguf", _build_gguf(3, kvs))
+        assert detect(p).suggested_capabilities == ["chat"]
+
+    def test_embed_gguf_still_embed(self, tmp_path: Path) -> None:
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+            ("bert.context_length", _GGUF_TYPE_UINT32, struct.pack("<I", 512)),
+            ("bert.pooling_type", _GGUF_TYPE_UINT32, struct.pack("<I", 2)),
+        ]
+        p = _write_fixture(tmp_path, "bge-small.gguf", _build_gguf(3, kvs))
+        assert detect(p).suggested_capabilities == ["embed"]
+
+    def test_reranker_is_not_emitted_by_detect(self, tmp_path: Path) -> None:
+        """detect deliberately does NOT emit 'rerank' yet — a reranker gguf
+        with no pooling_type is not forced to embed by the shared table (the
+        'rerank' token is collapsed to None in detect's narrower contract)."""
+        p = tmp_path / "bge-reranker-v2-m3.onnx"
+        p.write_bytes(b"")
+        # Non-gguf, rerank token → collapsed to None → unknown, empty caps.
+        assert detect(p).suggested_capabilities == []
+
+    def test_classify_multicap_rerank_preserved(self) -> None:
+        from hal0.model_meta import classify
+
+        assert classify("", capabilities=["chat", "rerank"]) == "rerank"
+
+
 class TestMissingFile:
     def test_missing_path_returns_filename_heuristic(self, tmp_path: Path) -> None:
         # Detect on a path that doesn't exist; gguf extension → heuristic

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -112,6 +112,49 @@ def test_capability_guess_classifies_diffusion_media() -> None:
     assert _guess_capability("qwen3-4b-instruct-q4_k_m.gguf") == "chat"
 
 
+def test_capability_guess_classifies_rerankers() -> None:
+    """MR-3: a reranker filename must classify as 'rerank', not the old 'chat'
+    default. rerank is checked before embed so a "bge-reranker" name (which
+    also carries the embed token "bge") doesn't fall through to embed."""
+    from hal0.registry.discover import _guess_capability
+
+    # The bug: these auto-scanned as 'chat' before the shared-table fix.
+    assert _guess_capability("bge-reranker-v2-m3-Q8_0.gguf") == "rerank"
+    assert _guess_capability("bge-reranker-base-f16.gguf") == "rerank"
+    # bge non-reranker stays embed (rerank precedence didn't swallow it).
+    assert _guess_capability("bge-base-en-v1.5.gguf") == "embed"
+    # No vocabulary regression for the other families.
+    assert _guess_capability("ltx-2-19b-dev-fp8.gguf") == "video"
+    assert _guess_capability("nomic-embed-text-v1.gguf") == "embed"
+    assert _guess_capability("whisper-large-v3.gguf") == "asr"
+    assert _guess_capability("llama-3.1-8b-instruct.gguf") == "chat"
+
+
+def test_scan_and_register_reranker_capability(tmp_path: Path, registry: ModelRegistry) -> None:
+    """End-to-end: a NON-curated reranker gguf under a scan root registers with
+    capabilities == ['rerank'] (it registered as ['chat'] before MR-3), while
+    an EXACT curated reranker filename still registers 'rerank' via the curated
+    override branch."""
+    root = tmp_path / "models"
+    root.mkdir()
+    # Non-curated reranker (Q8_0 is not a curated hf_file) → capability_guess.
+    non_curated = root / "bge-reranker-v2-m3-Q8_0.gguf"
+    non_curated.write_bytes(b"r" * 64)
+    # Exact curated reranker filename → curated-override branch.
+    curated = root / "bge-reranker-v2-m3-Q4_K_M.gguf"
+    curated.write_bytes(b"c" * 64)
+
+    cfg = ModelsConfig(roots=[str(root)])
+    scan_and_register(registry, cfg)
+    models = {Path(m.path).name: m for m in registry.list()}
+
+    assert models["bge-reranker-v2-m3-Q8_0.gguf"].capabilities == ["rerank"]
+    # The curated entry masks discover and still yields 'rerank'.
+    curated_model = models["bge-reranker-v2-m3-Q4_K_M.gguf"]
+    assert curated_model.capabilities == ["rerank"]
+    assert curated_model.id == "bge-reranker-v2-m3-q4_k_m"
+
+
 def test_curated_match_by_filename(model_root: Path) -> None:
     """A discovered file whose name matches a curated entry's hf_file
     must surface that curated entry on the candidate."""

--- a/tests/slot_config/test_merge_slot_config.py
+++ b/tests/slot_config/test_merge_slot_config.py
@@ -1,0 +1,209 @@
+"""SC-11: the one shared slot-projection merge primitive.
+
+Both the store (:meth:`SlotConfigStore._reconciled_slot`) and
+:meth:`SlotManager.update_config` used to hand-roll the same "base dict +
+updates dict → merged dict with the ``ctx_size`` alias folded" mechanic.
+They now share :func:`hal0.slot_config.merge_slot_config`. These tests pin
+the load-bearing nuances of that primitive:
+
+  - the one-level-deep, value-wins merge (sibling ``[model]`` keys survive),
+  - the ``ctx_size`` → ``context_size`` fold (fresh alias wins, alias
+    dropped),
+  - COPY-SAFETY: the base dict is never mutated, so it is safe for the
+    store's commit diff / rollback (``before`` vs ``after``).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from hal0.capabilities.config import CapabilitySelection
+from hal0.slot_config import (
+    SlotConfigStore,
+    SlotSelection,
+    merge_slot_config,
+)
+
+# ── merge_slot_config unit behaviour ─────────────────────────────────────────
+
+
+def test_merge_one_level_deep_keeps_model_siblings() -> None:
+    """A partial ``{"model": {...}}`` update merges into the nested table,
+    not clobber it — ``[model].default`` survives a ctx-only write."""
+    base = {"model": {"default": "m", "context_size": 4096}, "enabled": True}
+    after = merge_slot_config(base, {"model": {"context_size": 8192}})
+    assert after["model"] == {"default": "m", "context_size": 8192}
+
+
+def test_merge_scalars_and_lists_replace_wholesale() -> None:
+    base = {"workers": 1, "labels": ["a"]}
+    after = merge_slot_config(base, {"workers": 4, "labels": ["b"]})
+    assert after["workers"] == 4
+    assert after["labels"] == ["b"]
+
+
+def test_merge_folds_ctx_size_alias() -> None:
+    """Fresh ``ctx_size`` wins over a stale ``context_size`` seed, then the
+    alias is dropped so exactly one key survives (#585)."""
+    base = {"model": {"default": "m", "context_size": 4096}}
+    after = merge_slot_config(base, {"model": {"ctx_size": 32768}})
+    assert after["model"] == {"default": "m", "context_size": 32768}
+    assert "ctx_size" not in after["model"]
+
+
+def test_merge_folds_ctx_size_keeps_default_sibling() -> None:
+    """manager.py dropped-sibling scenario: ``{"model": {"ctx_size": N}}``
+    must keep ``[model].default``."""
+    base = {"model": {"default": "keep-me"}}
+    after = merge_slot_config(base, {"model": {"ctx_size": 2048}})
+    assert after["model"]["default"] == "keep-me"
+    assert after["model"]["context_size"] == 2048
+
+
+def test_merge_is_copy_safe_when_updates_carry_no_model() -> None:
+    """The load-bearing nuance: a pure non-model update (e.g. a disable) that
+    still triggers the ctx_size fold on the inherited base ``[model]`` must
+    NOT mutate the caller's base dict. Proves the fold copies before pop."""
+    base = {"model": {"default": "m", "ctx_size": 4096}, "enabled": True}
+    after = merge_slot_config(base, {"enabled": False})
+    # The returned copy folded the alias …
+    assert after["model"]["context_size"] == 4096
+    assert "ctx_size" not in after["model"]
+    assert after["enabled"] is False
+    # … while the caller's base is untouched (still the legacy alias).
+    assert base["model"] == {"default": "m", "ctx_size": 4096}
+    assert base["enabled"] is True
+
+
+def test_merge_does_not_alias_base_model_on_merge_path() -> None:
+    """Even when updates DO carry a model sub-table, the base's model dict
+    must not be mutated (fresh merged dict, not in-place)."""
+    base = {"model": {"default": "m", "context_size": 4096}}
+    after = merge_slot_config(base, {"model": {"context_size": 8192}})
+    after["model"]["default"] = "mutated"
+    assert base["model"]["default"] == "m"
+
+
+# ── store integration: copy-safety survives commit ───────────────────────────
+
+
+def _etc(home: str) -> Path:
+    return Path(home) / "etc" / "hal0"
+
+
+def _write_caps_disabled_embed(home: str) -> Path:
+    path = _etc(home) / "capabilities.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "schema_version = 2",
+                "[selections.embed.embed]",
+                'device = "gpu-vulkan"',
+                'provider = "llama-server"',
+                'model = "old-model"',
+                "enabled = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_embed_slot(home: str, extra_model_lines: list[str]) -> Path:
+    slots_dir = _etc(home) / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    slot_path = slots_dir / "embed.toml"
+    slot_path.write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'backend = "vulkan"',
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                'default = "old-model"',
+                *extra_model_lines,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return slot_path
+
+
+def test_store_copy_safe_disable_still_writes(tmp_hal0_home: str) -> None:
+    """A pure disable carries NO ``[model]`` update, yet the slot's inherited
+    ``[model]`` still gets its ctx_size folded — via the shared copy-safe
+    helper. The ChangeSet must see ``before != after`` (so commit writes) and
+    the folded ``context_size`` must land on disk. A naive extraction that
+    reused the in-place ``_normalize_ctx_key`` would fold ``before`` too and
+    could break the diff — this pins that it does not."""
+    slot_path = _write_embed_slot(tmp_hal0_home, ["ctx_size = 4096"])
+    _write_caps_disabled_embed(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    sel = SlotSelection(
+        slot="embed",
+        child="embed",
+        slot_name="embed",
+        selection=CapabilitySelection(
+            device="gpu-vulkan",
+            provider="llama-server",
+            model="old-model",
+            enabled=False,
+        ),
+    )
+    cs = store.apply(sel)
+    slot_change = next(fs for fs in cs.after if fs.path == slot_path)
+    before_change = next(fs for fs in cs.before if fs.path == slot_path)
+    assert slot_change.data is not None
+    # Disable flips enabled=false and folds the inherited ctx_size alias.
+    assert slot_change.data["enabled"] is False
+    assert slot_change.data["model"]["context_size"] == 4096
+    assert "ctx_size" not in slot_change.data["model"]
+    # The before snapshot must remain the un-folded legacy shape (proof the
+    # shared helper did not mutate the base), so before != after → commit writes.
+    assert before_change.data is not None
+    assert before_change.data["model"].get("ctx_size") == 4096
+    assert before_change.data != slot_change.data
+    assert cs.changed
+
+    store.commit(cs)
+    with open(slot_path, "rb") as f:
+        on_disk = tomllib.load(f)
+    assert on_disk["enabled"] is False
+    assert on_disk["model"]["context_size"] == 4096
+    assert "ctx_size" not in on_disk["model"]
+
+
+def test_store_disable_does_not_rewrite_backend_device_model(tmp_hal0_home: str) -> None:
+    """SC-1 parity: a disable selection produces ``enabled=False`` and does
+    NOT rewrite backend/device/model siblings (the store only reconciles those
+    when the selection is enabled)."""
+    slot_path = _write_embed_slot(tmp_hal0_home, [])
+    _write_caps_disabled_embed(tmp_hal0_home)
+
+    store = SlotConfigStore()
+    sel = SlotSelection(
+        slot="embed",
+        child="embed",
+        slot_name="embed",
+        selection=CapabilitySelection(
+            device="gpu-rocm",  # a DIFFERENT device than on disk
+            provider="some-other",
+            model="new-model",
+            enabled=False,
+        ),
+    )
+    cs = store.apply(sel)
+    slot_change = next(fs for fs in cs.after if fs.path == slot_path)
+    assert slot_change.data is not None
+    assert slot_change.data["enabled"] is False
+    # A disable must NOT rewrite the siblings from the (ignored) selection.
+    assert slot_change.data["backend"] == "vulkan"
+    assert slot_change.data["provider"] == "llama-server"
+    assert slot_change.data["model"]["default"] == "old-model"

--- a/tests/slots/test_dispatchable_ready_set_single_source.py
+++ b/tests/slots/test_dispatchable_ready_set_single_source.py
@@ -1,0 +1,128 @@
+"""Drift guard: the dispatchable ready-set has a single source of truth (DR-8).
+
+Finding DR-8 unified four copies of the ``{READY, SERVING, IDLE}`` ready-set
+onto ``hal0.slots.state.DISPATCHABLE_STATES``. These tests fail the moment any
+copy diverges — by identity for the enum-set consumers, by value for the
+string-set consumers, and by exhaustive membership so a newly-added
+non-dispatchable SlotState is auto-caught.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hal0.slots.state import (
+    DISPATCHABLE_STATES,
+    SlotState,
+    is_dispatchable_state,
+)
+
+# The three states that dispatch, expressed independently of the constant under
+# test so a mistaken edit to the constant does not silently pass.
+_EXPECTED_ENUM = {SlotState.READY, SlotState.SERVING, SlotState.IDLE}
+_EXPECTED_STR = {"ready", "serving", "idle"}
+
+
+# 1. Identity/equality — enum-set consumers alias the canonical frozenset.
+def test_manager_aliases_canonical_set() -> None:
+    from hal0.slots.manager import SlotManager
+
+    assert SlotManager._DISPATCHABLE_STATES is DISPATCHABLE_STATES
+
+
+def test_arbiter_aliases_canonical_set() -> None:
+    import hal0.slots.arbiter as arbiter
+
+    assert arbiter._DISPATCHABLE is DISPATCHABLE_STATES
+
+
+def test_stacks_apply_aliases_canonical_set() -> None:
+    import hal0.stacks.apply as apply
+
+    assert apply._DISPATCHABLE is DISPATCHABLE_STATES
+
+
+# 2. String-set alignment — the value-based consumers agree with the constant.
+def test_canonical_set_values() -> None:
+    assert {s.value for s in DISPATCHABLE_STATES} == _EXPECTED_STR
+    assert DISPATCHABLE_STATES == _EXPECTED_ENUM
+
+
+def test_slot_view_uses_shared_membership() -> None:
+    """slot_view derives loaded models via the shared dispatchable set.
+
+    Dispatchable states contribute their model; non-dispatchable ones don't.
+    """
+    from hal0.slot_view import loaded_model_names_from_slots
+
+    dispatchable = [SimpleNamespace(state=s, model_id=f"m-{s.value}") for s in _EXPECTED_ENUM]
+    non_dispatchable = [
+        SimpleNamespace(state=SlotState.OFFLINE, model_id="m-offline"),
+        SimpleNamespace(state=SlotState.WARMING, model_id="m-warming"),
+    ]
+    got = loaded_model_names_from_slots(dispatchable + non_dispatchable)
+    assert got == {f"m-{s.value}" for s in _EXPECTED_ENUM}
+
+
+def test_metrics_ready_set_matches() -> None:
+    import hal0.slots.metrics as metrics
+
+    assert set(metrics._READY_STATES) == _EXPECTED_STR
+
+
+# 3. Exhaustive membership guard — every SlotState classified consistently.
+@pytest.mark.parametrize("state", list(SlotState), ids=lambda s: s.value)
+def test_membership_exhaustive(state: SlotState) -> None:
+    expected = state in _EXPECTED_ENUM
+    assert (state in DISPATCHABLE_STATES) is expected
+    assert is_dispatchable_state(state) is expected
+    # StrEnum membership also works for the lowercase wire string.
+    assert (state.value in DISPATCHABLE_STATES) is expected
+    assert is_dispatchable_state(state.value) is expected
+
+
+# 4. Behaviour preservation for the orthogonal nuances (#792, #791).
+def test_slot_view_serving_empty_cache_downgrades_to_idle() -> None:
+    """#792/#31: a model-requiring serving slot with empty cache surfaces idle."""
+    from hal0.slot_view import serialize_slot
+    from hal0.slots.manager import Slot
+
+    slot = Slot(
+        "chat",
+        state=SlotState.SERVING,
+        port=8081,
+        model_id="m",
+        metadata={"provider": "llamacpp"},
+    )
+    view = serialize_slot(slot, model_cache={"chat": []})
+    assert view["status"] == "idle"
+
+
+def test_metrics_health_ok_false_forces_down() -> None:
+    """#791: a serving slot with health_ok False reports up=0."""
+    from hal0.slots.metrics import render_slot_metrics
+
+    slot = SimpleNamespace(name="chat", state=SlotState.SERVING, metadata={"health_ok": False})
+    body = render_slot_metrics([slot])
+    assert 'hal0_slot_up{slot="chat"} 0' in body
+
+
+# 5. Cross-file grep lint — no other module hardcodes the literal ready-set.
+def test_no_duplicate_literals_outside_state_module() -> None:
+    src_root = Path(__file__).resolve().parents[2] / "src" / "hal0"
+    needles = (
+        "{SlotState.READY, SlotState.SERVING, SlotState.IDLE}",
+        '{"ready", "serving", "idle"}',
+    )
+    offenders: list[str] = []
+    for path in src_root.rglob("*.py"):
+        if path.name == "state.py" and path.parent.name == "slots":
+            continue
+        text = path.read_text(encoding="utf-8")
+        for needle in needles:
+            if needle in text:
+                offenders.append(f"{path}: {needle}")
+    assert not offenders, f"duplicate ready-set literals: {offenders}"

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -927,3 +927,69 @@ async def test_update_config_ctx_size_alias_wins_over_stale_context_size(
     assert "context_size = 32768" in cfg_text
     assert "4096" not in cfg_text
     assert "ctx_size = " not in cfg_text
+
+
+@pytest.mark.parametrize(
+    ("seed_model_lines", "updates", "expected_model"),
+    [
+        # Partial ctx-only update keeps the seeded [model].default sibling.
+        (
+            ['default = "seed-model"'],
+            {"model": {"ctx_size": 2048}},
+            {"default": "seed-model", "context_size": 2048},
+        ),
+        # A fresh ctx_size wins over a stale context_size seed, alias dropped.
+        (
+            ['default = "seed-model"', "context_size = 4096"],
+            {"model": {"ctx_size": 32768}},
+            {"default": "seed-model", "context_size": 32768},
+        ),
+        # A model default swap merges, leaving the seeded context_size intact.
+        (
+            ['default = "seed-model"', "context_size = 8192"],
+            {"model": {"default": "new-model"}},
+            {"default": "new-model", "context_size": 8192},
+        ),
+    ],
+)
+async def test_update_config_model_merge_matches_shared_helper(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    seed_model_lines: list[str],
+    updates: dict[str, object],
+    expected_model: dict[str, object],
+) -> None:
+    """SC-11: ``update_config`` and the shared ``merge_slot_config`` primitive
+    must project the same (base, updates) pair onto the same ``[model]`` — the
+    manager routes through the helper, so the on-disk table equals what the
+    helper computes (sibling keys survive, ctx_size folds)."""
+    import tomllib
+
+    from hal0.slot_config import merge_slot_config
+    from hal0.slots.state import SlotState as _S
+
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                "port = 8081",
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                *seed_model_lines,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    # The shared helper's projection of the same base + updates.
+    base = tomllib.loads((slot_root / "chat.toml").read_text(encoding="utf-8"))
+    helper_after = merge_slot_config(base, updates)
+    assert helper_after["model"] == expected_model
+
+    sm = SlotManager()
+    await sm._transition("chat", _S.OFFLINE, force=True)
+    await sm.update_config("chat", updates)
+    on_disk = tomllib.loads((slot_root / "chat.toml").read_text(encoding="utf-8"))
+    assert on_disk["model"] == expected_model
+    assert on_disk["model"] == helper_after["model"]


### PR DESCRIPTION
## Wave 4 of the platform-review remediation program

Theme T3 — retire the parallel re-implementations that were silently drifting. Each finding adversarially verified, consolidated behavior-preservingly (with characterization/parity tests), gated by tree-wide ruff + a behavior-preservation review.

| ID | Consolidation |
|----|---------------|
| **MR-3** | discover + detect now delegate to one `capability_from_filename()` token table (extended `model_meta`) — **fixes** the reranker (`bge-reranker-v2-m3`) misclassifying as `chat` and being unroutable, while leaving embed/chat classification unchanged. |
| **PS-4** | One `profile_name_for_fit()` shared by the picker + apply reconciler (they were byte-identical); `derive_profile` single-sources its base table from `DEVICE_DEFAULT_PROFILES`. Every current output preserved exactly (incl. Wave 1 `cpu→cpu-llm`); removes the drift behind the #834 churn. |
| **DR-8** | `arbiter._DISPATCHABLE`, `slot_view._READY_STATES`, and manager's fail-watch set all consume one `DISPATCHABLE_STATES`/`is_ready_for_dispatch`; slot_view's serving-with-empty-cache nuance folded in explicitly, not dropped. |
| **SC-11** | One shared `merge_slot_config()` used by both `slot_config._reconciled_slot` and `manager.update_config` (nested `[model]` merge + `ctx_size→context_size` fold). Preserves Wave 1 SC-1 enabled-on-disable. |

### Verification
- All four **confirmed** (PS-4 partial→confirmed); MR-3 is the only behavior change (the intended reranker fix), the rest are pure dedup with parity/characterization tests.
- New tests incl. `tests/config/test_profile_derivation_parity.py` (90 parametrized cases), `tests/slots/test_dispatchable_ready_set_single_source.py`, `tests/slot_config/test_merge_slot_config.py`, and MR-3 discover/detect coverage.
- Local: capabilities+install+slots+slot_config+model_meta+registry+slot_view+stacks+config **1256 passed**; dispatcher **164 passed**; tree-wide ruff clean.

### Integration notes
3 of 4 findings touched `manager.py`; SC-11's hunk was hand-merged (DR-8 shifted the import region). Behavior-preservation review gate pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)