### PR TITLE
refactor(platform-review): Wave 5 — UI drawer rework (UI-1/3/12/14/19)

### DIFF
--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -7,34 +7,101 @@ import { useComfyui } from '@/api/hooks/useComfyui'
 
 const { useState: useStateP, useEffect: useEffectP, useRef: useRefP, createContext: createContextP, useContext: useContextP } = React;
 
-// ─── Portal-less Modal ────────────────────────────────────────────────────
-// Click backdrop or Esc to close. Focus restored on close. Width auto-sized.
-function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dismissable = true }) {
-  const overlayRef = useRefP(null);
+// ─── Shared leaf utilities (single source of truth for the dash editors) ───
+// Slug/name rule — mirrors the API regex ^[a-z0-9][a-z0-9_-]{0,31}$. Consumed
+// by the Profiles/Stacks drawers + import dialogs (was duplicated per-file).
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+// Toast shim — dash modules fire user-facing toasts through the global
+// installed by chrome.jsx. Safe no-op when it isn't present (SSR/tests).
+function toast(msg, kind = "info") {
+  if (typeof window !== "undefined" && window.__hal0Toast) window.__hal0Toast(msg, kind);
+}
+
+// ─── useFocusTrap — shared focus management for modal surfaces ──────────────
+// On open: remembers the previously-focused element and, unless something
+// inside the container already holds focus (e.g. an autoFocus input), moves
+// focus to the container (which must carry tabIndex=-1). While open: Tab /
+// Shift+Tab cycle within the container's focusables. On close/unmount: focus
+// returns to the previously-focused element. Used by Modal, Drawer, FormDrawer
+// so the role="dialog" aria-modal="true" contract is actually honoured.
+const FOCUSABLE_SEL =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+function useFocusTrap(ref, open) {
   useEffectP(() => {
     if (!open) return;
-    const onKey = (e) => { if (e.key === "Escape" && dismissable) onClose(); };
+    const node = ref.current;
+    if (!node) return;
+    const prev = document.activeElement;
+    // Initial focus: honour an existing autoFocus inside the container;
+    // otherwise focus the container itself so the surface is announced
+    // without stealing focus from a specific control.
+    if (!node.contains(document.activeElement)) {
+      try { node.focus(); } catch { /* jsdom / detached node */ }
+    }
+    const onKey = (e) => {
+      if (e.key !== "Tab") return;
+      const items = Array.from(node.querySelectorAll(FOCUSABLE_SEL))
+        .filter(el => el.offsetParent !== null || el === document.activeElement);
+      if (items.length === 0) { e.preventDefault(); node.focus(); return; }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !node.contains(active)) { e.preventDefault(); last.focus(); }
+      } else if (active === last || !node.contains(active)) {
+        e.preventDefault(); first.focus();
+      }
+    };
+    node.addEventListener("keydown", onKey);
+    return () => {
+      node.removeEventListener("keydown", onKey);
+      // Return focus only if it's still inside the closing surface — avoid
+      // yanking focus if the user has already clicked elsewhere.
+      if (prev && typeof prev.focus === "function" && node.contains(document.activeElement)) {
+        try { prev.focus(); } catch { /* element gone */ }
+      }
+    };
+  }, [open, ref]);
+}
+
+// ─── Portal-less Modal ────────────────────────────────────────────────────
+// Click backdrop or Esc to close. Captures + restores focus on close and traps
+// Tab within the shell. Width auto-sized. Pass `dirty` (+ optional
+// `confirmDiscard`) to guard the dismiss paths against unsaved changes.
+function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dismissable = true, dirty = false, confirmDiscard = "Discard unsaved changes?" }) {
+  const overlayRef = useRefP(null);
+  const shellRef = useRefP(null);
+  const requestClose = () => {
+    if (dirty && !window.confirm(confirmDiscard)) return;
+    onClose();
+  };
+  useEffectP(() => {
+    if (!open) return;
+    const onKey = (e) => { if (e.key === "Escape" && dismissable) requestClose(); };
     document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, dismissable, onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, dismissable, onClose, dirty]);
+  useFocusTrap(shellRef, open);
   if (!open) return null;
   return (
     <div
       className="modal-backdrop"
       ref={overlayRef}
-      onMouseDown={(e) => { if (dismissable && e.target === overlayRef.current) onClose(); }}
+      onMouseDown={(e) => { if (dismissable && e.target === overlayRef.current) requestClose(); }}
     >
-      <div className="modal-shell" style={{ maxWidth: width }} onMouseDown={(e) => e.stopPropagation()}>
+      <div className="modal-shell" ref={shellRef} tabIndex={-1} role="dialog" aria-modal="true" style={{ maxWidth: width }} onMouseDown={(e) => e.stopPropagation()}>
         {(title || eyebrow) && (
           <div className="modal-h">
             {eyebrow && <div className="modal-h-eye mono">{eyebrow}</div>}
             {title && <h2 className="mono">{title}</h2>}
             {dismissable && (
-              <button className="modal-close" onClick={onClose} aria-label="Close">{Icons.close}</button>
+              <button className="modal-close" onClick={requestClose} aria-label="Close">{Icons.close}</button>
             )}
           </div>
         )}
@@ -46,20 +113,33 @@ function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dis
 }
 
 // ─── Right-side Drawer ────────────────────────────────────────────────────
-function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, headRight }) {
+// Captures + restores focus and traps Tab within the drawer (honours
+// role="dialog" aria-modal). Pass `dirty` (+ optional `confirmDiscard`) to
+// guard Esc/backdrop/close against unsaved changes; `dismissable={false}`
+// disables backdrop dismissal.
+function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, headRight, dirty = false, dismissable = true, confirmDiscard = "Discard unsaved changes?" }) {
+  const shellRef = useRefP(null);
+  const requestClose = () => {
+    if (dirty && !window.confirm(confirmDiscard)) return;
+    onClose();
+  };
   useEffectP(() => {
     if (!open) return;
-    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    const onKey = (e) => { if (e.key === "Escape") requestClose(); };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, onClose, dirty]);
+  useFocusTrap(shellRef, open);
   return (
     <>
       <div
         className={"drawer-backdrop" + (open ? " open" : "")}
-        onClick={onClose}
+        onClick={() => { if (dismissable) requestClose(); }}
       />
       <aside
+        ref={shellRef}
+        tabIndex={-1}
         className={"drawer" + (open ? " open" : "")}
         style={{ width }}
         role="dialog"
@@ -70,7 +150,7 @@ function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, he
           {eyebrow && <div className="modal-h-eye mono">{eyebrow}</div>}
           {title && <h2 className="mono">{title}</h2>}
           {headRight && <div className="drawer-h-right">{headRight}</div>}
-          <button className="modal-close" onClick={onClose} aria-label="Close">{Icons.close}</button>
+          <button className="modal-close" onClick={requestClose} aria-label="Close">{Icons.close}</button>
         </div>
         <div className="drawer-body">{children}</div>
         {foot && <div className="drawer-foot mono">{foot}</div>}
@@ -526,4 +606,256 @@ function Menu({ anchor = "right", items, onClose, style }) {
   );
 }
 
-Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FirstRunBanner, FieldGroup, PillToggle });
+// ─── FormRow — labelled config row (shared by Profiles + Stacks drawers) ───
+// The superset variant: supports error / warn / ok / counter affordances.
+// Renders a real <label htmlFor> wired to a single input/select/textarea child
+// (id auto-generated) so the visible label is a genuine control label; non-
+// control children (segmented buttons, switches) are passed through untouched.
+function FormRow({ label, sub, req, children, error, warn, ok, counter }) {
+  const autoId = React.useId();
+  const genId = "fr-" + autoId;
+  let control = children;
+  let htmlFor;
+  if (
+    React.isValidElement(children) &&
+    (children.type === "input" || children.type === "select" || children.type === "textarea")
+  ) {
+    const childId = children.props.id || genId;
+    control = React.cloneElement(children, { id: childId });
+    htmlFor = childId;
+  }
+  return (
+    <div className={"pf-row" + (error ? " has-err" : "")}>
+      <label className="pf-row-lbl" htmlFor={htmlFor}>
+        <span>{label}{req && <span className="pf-req" title="required">*</span>}</span>
+        {sub && <span className="pf-row-sub mono">{sub}</span>}
+      </label>
+      <div className="pf-row-ctl">
+        <div className={"pf-field" + (ok ? " ok" : "") + (error ? " err" : "")}>
+          {control}
+          {ok && <span className="pf-field-ok" aria-hidden="true">{Icons.check}</span>}
+        </div>
+        {(error || warn || counter) && (
+          <div className="pf-row-foot">
+            {error
+              ? <span className="pf-msg err mono hint err">{Icons.alert}{error}</span>
+              : warn
+              ? <span className="pf-msg warn mono">{Icons.alert}{warn}</span>
+              : <span />}
+            {counter && <span className={"pf-counter mono" + (counter.warn ? " warn" : "")}>{counter.text}</span>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── useForm — shared form-state hook for the dash editors ──────────────────
+// Owns: values (single object), touched map, submitted/submitting/closing
+// flags, a set(k,v) that also marks touched, touch(k), reset(), derived
+// errors/warns (validation rules stay in the CALLER — passed in verbatim), a
+// submitted/touched `show(field)` gate, a `blocking` flag, and an `isDirty`
+// snapshot diff (the field that unlocks the unsaved-changes guard). Re-derives
+// the initial snapshot whenever `resetKey` changes — replicating the editors'
+// existing [mode, source] / [open, defaults] reset effects.
+function useForm({ initial, deriveInitial, resetKey, validate, warn }) {
+  const compute = () => (typeof deriveInitial === "function" ? deriveInitial() : initial);
+  const initialRef = useRefP(null);
+  const [values, setValues] = useStateP(() => {
+    const v = compute();
+    initialRef.current = v;
+    return v;
+  });
+  const [touched, setTouched] = useStateP({});
+  const [submitted, setSubmitted] = useStateP(false);
+  const [submitting, setSubmitting] = useStateP(false);
+  const [closing, setClosing] = useStateP(false);
+
+  useEffectP(() => {
+    const v = compute();
+    initialRef.current = v;
+    setValues(v);
+    setTouched({});
+    setSubmitted(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey]);
+
+  const set = (k, v) => { setValues(f => ({ ...f, [k]: v })); setTouched(t => ({ ...t, [k]: true })); };
+  const touch = (k) => setTouched(t => ({ ...t, [k]: true }));
+  const reset = () => { setValues(initialRef.current); setTouched({}); setSubmitted(false); };
+
+  const errors = validate ? (validate(values) || {}) : {};
+  const warns = warn ? (warn(values) || {}) : {};
+  const blocking = Object.keys(errors).length > 0;
+  const show = (f) => submitted || !!touched[f];
+  const isDirty = JSON.stringify(values) !== JSON.stringify(initialRef.current);
+
+  return {
+    values, setValues, set, touch, touched,
+    submitted, setSubmitted, submitting, setSubmitting,
+    closing, setClosing,
+    errors, warns, blocking, show, reset, isDirty,
+    initial: initialRef.current,
+  };
+}
+
+// ─── FormDrawer — the shared pf-drawer form shell (Profiles + Stacks) ───────
+// Owns the pf-scrim / pf-drawer / pf-form-panel chrome, the closing + 200ms
+// animation on dismiss, eyebrow/title head, the aria-busy panel, focus trap +
+// return-focus, and the unsaved-changes guard on the scrim + X. The per-view
+// body (children) and foot (render-prop receiving `requestClose` so a Cancel
+// button routes through the same guard) stay with the caller, keeping each
+// editor's submit + validation exactly as they were.
+function FormDrawer({ eyebrow, title, ariaLabel, panelClassName = "", submitting = false, dirty = false, confirmDiscard = "Discard unsaved changes?", onClose, children, foot }) {
+  const [closing, setClosing] = useStateP(false);
+  const shellRef = useRefP(null);
+  const requestClose = () => {
+    if (submitting) return;
+    if (dirty && !window.confirm(confirmDiscard)) return;
+    setClosing(true);
+    setTimeout(onClose, 200);
+  };
+  useFocusTrap(shellRef, true);
+  return (
+    <div className={"pf-scrim" + (closing ? " out" : "")} onMouseDown={requestClose}>
+      <div
+        ref={shellRef}
+        tabIndex={-1}
+        className={("pf-drawer pf-form-panel " + panelClassName).trim() + (closing ? " out" : "")}
+        onMouseDown={e => e.stopPropagation()}
+        role="dialog"
+        aria-label={ariaLabel || title}
+        aria-busy={submitting}
+      >
+        <div className="pf-drawer-head">
+          <div>
+            <div className="pf-drawer-eye mono">{eyebrow}</div>
+            <div className="pf-drawer-title pf-form-title mono">{title}</div>
+          </div>
+          <button className="pf-x" onClick={requestClose} aria-label="Close" disabled={submitting}>{Icons.close}</button>
+        </div>
+        {children}
+        <div className="pf-drawer-foot">
+          {typeof foot === "function" ? foot({ requestClose }) : foot}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── ImportDialog — shared stk-dialog import shell (file → dry-run → commit) ─
+// Wraps the .stk-scrim / .stk-dialog / .stk-dlg-* chrome + the file picker,
+// dry-run report, "Save as" name/slug input, and commit button. Per-view
+// specifics are injected: `deriveName(file, report)` seeds the name field,
+// `renderPreview(report)` draws the resolutions/model rows (Stacks) or nothing
+// (Profiles), and `onFileError` supplies the "not a valid envelope" copy. The
+// caller owns the actual mutations via `dryRun` / `commit` callbacks so the
+// hook stays in the per-view wrapper.
+function ImportDialog({
+  title = "Import",
+  ariaLabel,
+  fileAccept = ".json,application/json",
+  fileHint = "Choose a file",
+  fileTestid,
+  nameTestid,
+  confirmTestid,
+  namePlaceholder = "name",
+  existing = [],
+  invalidCopy = "Not a valid envelope",
+  deriveName,
+  renderPreview,
+  dryRun,
+  commit,
+  onClose,
+  onImported,
+}) {
+  const [envelope, setEnvelope] = useStateP(null);
+  const [report, setReport] = useStateP(null);
+  const [name, setName] = useStateP("");
+  const [busy, setBusy] = useStateP(false);
+  const [err, setErr] = useStateP("");
+
+  async function onFile(file) {
+    setErr("");
+    try {
+      const text = await file.text();
+      const env = JSON.parse(text);
+      setEnvelope(env);
+      const r = await dryRun(env);
+      setReport(r);
+      setName(deriveName ? deriveName(file, r) : (r?.name || ""));
+    } catch (e) {
+      setErr(e?.message || invalidCopy);
+      setEnvelope(null);
+      setReport(null);
+    }
+  }
+
+  const taken = existing.includes(name);
+  const nameValid = NAME_RE.test(name) && !taken;
+  const canCommit = !!report && nameValid && !busy;
+
+  async function onCommit() {
+    if (!canCommit) return;
+    setBusy(true);
+    try {
+      await commit({ envelope, name });
+      onImported();
+    } catch (e) {
+      // The caller's commit() may rethrow with a friendly inline message for
+      // collisions; otherwise fall back to a generic toast.
+      if (e?.inline) setErr(e.inline);
+      else toast(e?.message || "Import failed", "err");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="stk-scrim" onMouseDown={() => { if (!busy) onClose(); }}>
+      <div className="stk-dialog" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label={ariaLabel || title} aria-busy={busy}>
+        <div className="stk-dlg-h">
+          <span className="stk-dlg-eye">{title}</span>
+          <button className="stk-dlg-x" onClick={onClose} aria-label="Close" disabled={busy}>{Icons.close}</button>
+        </div>
+        <div className="stk-dlg-b">
+          {!report ? (
+            <label className="stk-drop">
+              <input type="file" accept={fileAccept} style={{ display: "none" }}
+                onChange={e => e.target.files?.[0] && onFile(e.target.files[0])} data-testid={fileTestid} />
+              <span className="stk-drop-glyph">{Icons.attach}</span>
+              <span className="mono">{fileHint}</span>
+              {err && <span className="stk-dlg-warn">{Icons.alert}{err}</span>}
+            </label>
+          ) : (
+            <>
+              {renderPreview && renderPreview(report)}
+              <div className="stk-slot-list">
+                <div className="stk-slot-row">
+                  <span className="sname">Save as</span>
+                  <input className={"pf-input mono" + (name && !NAME_RE.test(name) ? " err" : "")} value={name}
+                    onChange={e => { setName(e.target.value); setErr(""); }} maxLength={32} placeholder={namePlaceholder}
+                    style={{ flex: 1, background: "transparent", border: "none", color: "var(--fg)", fontFamily: "var(--jbm)" }}
+                    data-testid={nameTestid} />
+                </div>
+              </div>
+              {name && !NAME_RE.test(name) && <div className="stk-dlg-warn">{Icons.alert}lowercase · digits · - · _ · ≤32</div>}
+              {taken && NAME_RE.test(name) && <div className="stk-dlg-warn">{Icons.alert}“{name}” already exists</div>}
+              {err && <div className="stk-dlg-warn">{Icons.alert}{err}</div>}
+            </>
+          )}
+        </div>
+        <div className="stk-dlg-f">
+          <button className="btn ghost sm" onClick={onClose} disabled={busy}>Cancel</button>
+          {report && (
+            <button className="btn sm" onClick={onCommit} disabled={!canCommit} data-testid={confirmTestid}>
+              {busy ? "Importing…" : "Import"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FirstRunBanner, FieldGroup, PillToggle, NAME_RE, toast, useFocusTrap, FormRow, useForm, FormDrawer, ImportDialog });

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -35,8 +35,7 @@ const BACKEND_META = {
   cpu:    { label: 'CPU',       color: 'var(--dev-cpu)',    device_class: 'cpu', backendField: null },
 };
 
-// Mirrors the API name regex ^[a-z0-9][a-z0-9_-]{0,31}$.
-const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+// `NAME_RE` (name regex) and `toast` are shared globals from primitives.jsx.
 
 const BLANK = { name: '', intent: '', image: '', backend: 'rocm', quant: '', flags: '', mtp: false };
 
@@ -58,10 +57,6 @@ function intentOf(p) {
   if (p.intent) return p.intent;
   const base = p.image ? p.image.split(':').pop() : prettyProfile(p.name);
   return p.mtp ? `${base} · MTP` : base;
-}
-
-function toast(msg, kind = 'info') {
-  if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind);
 }
 
 // ── slot binding pill ─────────────────────────────────────────────────────────
@@ -169,33 +164,8 @@ function Section({ title, count, hint, children }) {
 }
 
 // ── Form drawer (create / edit / clone) ─────────────────────────────────────────
-
-function FormRow({ label, sub, req, children, error, warn, ok, counter }) {
-  return (
-    <div className={'pf-row' + (error ? ' has-err' : '')}>
-      <div className="pf-row-lbl">
-        <span>{label}{req && <span className="pf-req" title="required">*</span>}</span>
-        {sub && <span className="pf-row-sub mono">{sub}</span>}
-      </div>
-      <div className="pf-row-ctl">
-        <div className={'pf-field' + (ok ? ' ok' : '') + (error ? ' err' : '')}>
-          {children}
-          {ok && <span className="pf-field-ok" aria-hidden="true">{Icons.check}</span>}
-        </div>
-        {(error || warn || counter) && (
-          <div className="pf-row-foot">
-            {error
-              ? <span className="pf-msg err mono hint err">{Icons.alert}{error}</span>
-              : warn
-              ? <span className="pf-msg warn mono">{Icons.alert}{warn}</span>
-              : <span />}
-            {counter && <span className={'pf-counter mono' + (counter.warn ? ' warn' : '')}>{counter.text}</span>}
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
+// FormRow is a shared primitive (primitives.jsx) — the superset variant this
+// view seeded (error/warn/ok/counter + real <label htmlFor>).
 
 function validateForm(form, existing) {
   const errs = {};
@@ -215,9 +185,14 @@ function warnForm(form) {
   return warns;
 }
 
-function Drawer({ mode, source, existing = [], onClose, onSaved }) {
+// The editor drawer. Consumes the shared FormDrawer shell + useForm hook +
+// shared FormRow. Named ProfileDrawer (not Drawer) to avoid shadowing the
+// primitives.jsx Drawer global. validateForm/warnForm are passed into useForm
+// verbatim so the validation rules stay in this view.
+function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
   const isEdit = mode === 'edit';
-  const initial = (() => {
+
+  const deriveInitial = () => {
     if (mode === 'create') return { ...BLANK };
     const base = {
       name: source.name,
@@ -233,41 +208,38 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
       return { ...base, name: (source.name + suffix).slice(0, 32), cloned_from: source.name };
     }
     return base;
-  })();
-
-  const [form, setForm] = useState(initial);
-  const [touched, setTouched] = useState({});
-  const [submitted, setSubmitted] = useState(false);
-  const [closing, setClosing] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
+  };
 
   const create = useProfileCreate();
   const update = useProfileUpdate();
 
-  useEffect(() => { setForm(initial); setTouched({}); setSubmitted(false); /* eslint-disable-next-line */ }, [mode, source]);
-
-  const meta = bk(form.backend);
-
   const taken = existing.filter(n => !(isEdit && n === source.name));
-  const errs = validateForm(form, taken);
-  const warns = warnForm(form);
-  const blocking = Object.keys(errs).length > 0;
-  const show = (f) => submitted || touched[f];
+  const f = useForm({
+    deriveInitial,
+    resetKey: `${mode}:${source?.name ?? ''}`,
+    validate: (v) => validateForm(v, taken),
+    warn: (v) => warnForm(v),
+  });
+  const form = f.values;
+  const errs = f.errors;
+  const warns = f.warns;
+  const blocking = f.blocking;
+  const show = f.show;
+  const set = f.set;
+  const touch = f.touch;
+  const meta = bk(form.backend);
   const nameValid = !errs.name && (form.name || '').trim().length > 0;
-
-  const set = (k, v) => { setForm(f => ({ ...f, [k]: v })); setTouched(t => ({ ...t, [k]: true })); };
-  const touch = (k) => setTouched(t => ({ ...t, [k]: true }));
-  const close = () => { if (submitting) return; setClosing(true); setTimeout(onClose, 200); };
+  const nameLen = (form.name || '').length;
 
   async function submit(e) {
     e.preventDefault();
-    setSubmitted(true);
+    f.setSubmitted(true);
     if (blocking) {
       const first = document.querySelector('.pf-field.err input');
       if (first) first.focus();
       return;
     }
-    setSubmitting(true);
+    f.setSubmitting(true);
     const choice = bk(form.backend);
     const body = {
       name: form.name.trim(),
@@ -293,7 +265,7 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
     } catch (err) {
       const code = err?.code || '';
       if (code === 'profiles.exists') {
-        setTouched(t => ({ ...t, name: true }));
+        touch('name');
         toast(`A profile named ${body.name} already exists`, 'err');
       } else if (code === 'profiles.seed_immutable') {
         toast('Seed profiles cannot be modified', 'err');
@@ -301,7 +273,7 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
         toast(err?.message || 'Save failed', 'err');
       }
     } finally {
-      setSubmitting(false);
+      f.setSubmitting(false);
     }
   }
 
@@ -309,98 +281,88 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
     : mode === 'clone' ? (source.seed ? `Edit a copy · ${source.name}` : `Clone · ${source.name}`)
     : 'New profile';
   const eyebrow = mode === 'create' ? 'CREATE' : mode === 'clone' ? (source.seed ? 'EDIT A COPY' : 'CLONE') : 'EDIT';
-  const nameLen = (form.name || '').length;
 
   return (
-    <div className={'pf-scrim' + (closing ? ' out' : '')} onMouseDown={close}>
-      <div
-        className={'pf-drawer pf-form-panel' + (closing ? ' out' : '')}
-        onMouseDown={e => e.stopPropagation()}
-        role="dialog"
-        aria-label={title}
-        aria-busy={submitting}
-      >
-        <div className="pf-drawer-head">
-          <div>
-            <div className="pf-drawer-eye mono">{eyebrow}</div>
-            <div className="pf-drawer-title pf-form-title mono">{title}</div>
-          </div>
-          <button className="pf-x" onClick={close} aria-label="Close" disabled={submitting}>{Icons.close}</button>
-        </div>
-
-        <form className="pf-drawer-body" onSubmit={submit} noValidate>
-          <FormRow label="Name" req sub="lowercase · - _ · ≤32"
-            error={show('name') ? errs.name : null}
-            ok={!isEdit && nameValid}
-            counter={!isEdit ? { text: nameLen + '/32', warn: nameLen >= 28 } : null}>
-            <input className={'pf-input mono' + (show('name') && errs.name ? ' err' : '')} value={form.name}
-              onChange={e => set('name', e.target.value)} onBlur={() => touch('name')}
-              placeholder="my-profile" maxLength={32} disabled={isEdit}
-              aria-invalid={!!(show('name') && errs.name)} data-testid="pf-input-name" />
-          </FormRow>
-
-          <FormRow label="Intent" sub="what it's for">
-            <input className="pf-input" value={form.intent} onChange={e => set('intent', e.target.value)}
-              placeholder="MoE agents · long-ctx" data-testid="pf-input-intent" />
-          </FormRow>
-
-          <FormRow label="Image" req sub="container image URI"
-            error={show('image') ? errs.image : null}
-            warn={!errs.image ? warns.image : null}
-            ok={!!(form.image || '').trim() && !errs.image && !warns.image}>
-            <input className={'pf-input mono' + (show('image') && errs.image ? ' err' : '')} value={form.image}
-              onChange={e => set('image', e.target.value)} onBlur={() => touch('image')}
-              placeholder="ghcr.io/hal0ai/…:tag" aria-invalid={!!(show('image') && errs.image)}
-              data-testid="pf-input-image" />
-          </FormRow>
-
-          <FormRow label="Backend" sub="runtime path">
-            <div className="pf-seg" data-testid="pf-seg-backend">
-              {Object.keys(BACKEND_META).map(k => (
-                <button type="button" key={k} className={'pf-seg-btn' + (form.backend === k ? ' on' : '')}
-                  style={{ '--bk': BACKEND_META[k].color }} onClick={() => set('backend', k)}>
-                  <span className="pf-chip-dot" />{BACKEND_META[k].label}
-                </button>
-              ))}
-            </div>
-          </FormRow>
-
-          <FormRow label="Quant" sub="weight format">
-            <input className="pf-input mono" value={form.quant || ''} onChange={e => set('quant', e.target.value)}
-              placeholder="FP4 · Q4_K_M …" data-testid="pf-input-quant" />
-          </FormRow>
-
-          <FormRow label="Flags" sub="appended to the run command">
-            <textarea className="pf-input mono pf-textarea" value={form.flags || ''}
-              onChange={e => set('flags', e.target.value)} rows={3} placeholder="--flash-attn on -ngl 999"
-              data-testid="pf-input-flags" />
-          </FormRow>
-
-          <FormRow label="MTP" sub="Multi-Token Prediction speculative decode">
-            <button type="button" className={'pf-switch' + (form.mtp ? ' on' : '')} onClick={() => set('mtp', !form.mtp)}
-              role="switch" aria-checked={form.mtp} data-testid="pf-check-mtp">
-              <span className="pf-switch-knob" />
-              <span className="pf-switch-lbl mono">{form.mtp ? 'enabled' : 'disabled'}</span>
-            </button>
-          </FormRow>
-        </form>
-
-        <div className="pf-drawer-foot">
+    <FormDrawer
+      eyebrow={eyebrow}
+      title={title}
+      submitting={f.submitting}
+      dirty={f.isDirty}
+      onClose={onClose}
+      foot={({ requestClose }) => (
+        <>
           <div className="pf-drawer-preview mono" style={{ '--bk': meta.color }}>
             <span className="pf-chip-dot" />{meta.label}{form.mtp ? ' · MTP' : ''}
           </div>
           <span className="pf-grow" />
-          {submitted && blocking && (
+          {f.submitted && blocking && (
             <span className="pf-foot-err mono">{Icons.alert}Fix {Object.keys(errs).length} field{Object.keys(errs).length > 1 ? 's' : ''}</span>
           )}
-          <button className="pf-btn" onClick={close} type="button" disabled={submitting}>Cancel</button>
-          <button className={'pf-btn primary' + (submitted && blocking ? ' is-blocked' : '')}
-            onClick={submit} disabled={submitting} data-testid="pf-btn-submit">
-            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create profile'}
+          <button className="pf-btn" onClick={requestClose} type="button" disabled={f.submitting}>Cancel</button>
+          <button className={'pf-btn primary' + (f.submitted && blocking ? ' is-blocked' : '')}
+            onClick={submit} disabled={f.submitting} data-testid="pf-btn-submit">
+            {f.submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create profile'}
           </button>
-        </div>
-      </div>
-    </div>
+        </>
+      )}
+    >
+      <form className="pf-drawer-body" onSubmit={submit} noValidate>
+        <FormRow label="Name" req sub="lowercase · - _ · ≤32"
+          error={show('name') ? errs.name : null}
+          ok={!isEdit && nameValid}
+          counter={!isEdit ? { text: nameLen + '/32', warn: nameLen >= 28 } : null}>
+          <input className={'pf-input mono' + (show('name') && errs.name ? ' err' : '')} value={form.name}
+            onChange={e => set('name', e.target.value)} onBlur={() => touch('name')}
+            placeholder="my-profile" maxLength={32} disabled={isEdit}
+            aria-invalid={!!(show('name') && errs.name)} data-testid="pf-input-name" />
+        </FormRow>
+
+        <FormRow label="Intent" sub="what it's for">
+          <input className="pf-input" value={form.intent} onChange={e => set('intent', e.target.value)}
+            placeholder="MoE agents · long-ctx" data-testid="pf-input-intent" />
+        </FormRow>
+
+        <FormRow label="Image" req sub="container image URI"
+          error={show('image') ? errs.image : null}
+          warn={!errs.image ? warns.image : null}
+          ok={!!(form.image || '').trim() && !errs.image && !warns.image}>
+          <input className={'pf-input mono' + (show('image') && errs.image ? ' err' : '')} value={form.image}
+            onChange={e => set('image', e.target.value)} onBlur={() => touch('image')}
+            placeholder="ghcr.io/hal0ai/…:tag" aria-invalid={!!(show('image') && errs.image)}
+            data-testid="pf-input-image" />
+        </FormRow>
+
+        <FormRow label="Backend" sub="runtime path">
+          <div className="pf-seg" data-testid="pf-seg-backend">
+            {Object.keys(BACKEND_META).map(k => (
+              <button type="button" key={k} className={'pf-seg-btn' + (form.backend === k ? ' on' : '')}
+                style={{ '--bk': BACKEND_META[k].color }} onClick={() => set('backend', k)}>
+                <span className="pf-chip-dot" />{BACKEND_META[k].label}
+              </button>
+            ))}
+          </div>
+        </FormRow>
+
+        <FormRow label="Quant" sub="weight format">
+          <input className="pf-input mono" value={form.quant || ''} onChange={e => set('quant', e.target.value)}
+            placeholder="FP4 · Q4_K_M …" data-testid="pf-input-quant" />
+        </FormRow>
+
+        <FormRow label="Flags" sub="appended to the run command">
+          <textarea className="pf-input mono pf-textarea" value={form.flags || ''}
+            onChange={e => set('flags', e.target.value)} rows={3} placeholder="--flash-attn on -ngl 999"
+            data-testid="pf-input-flags" />
+        </FormRow>
+
+        <FormRow label="MTP" sub="Multi-Token Prediction speculative decode">
+          <button type="button" className={'pf-switch' + (form.mtp ? ' on' : '')} onClick={() => set('mtp', !form.mtp)}
+            role="switch" aria-checked={form.mtp} data-testid="pf-check-mtp">
+            <span className="pf-switch-knob" />
+            <span className="pf-switch-lbl mono">{form.mtp ? 'enabled' : 'disabled'}</span>
+          </button>
+        </FormRow>
+      </form>
+    </FormDrawer>
   );
 }
 
@@ -467,98 +429,50 @@ function DeleteConfirm({ p, onCancel, onConfirmed }) {
 // profile references no models, so the preview is just identity + integrity +
 // collision — no model resolve/pull affordance.
 
+// Thin wrapper over the shared <ImportDialog>: owns the useProfileImport hook
+// and the profile-specific preview (identity + integrity + collision — no
+// model resolve/pull). The dialog shell + name input + commit live in
+// primitives.jsx.
 function ImportModal({ existing, onClose, onImported }) {
   const imp = useProfileImport();
-  const [envelope, setEnvelope] = useState(null);
-  const [report, setReport] = useState(null);
-  const [name, setName] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState('');
-
-  async function onFile(file) {
-    setErr('');
-    try {
-      const text = await file.text();
-      const env = JSON.parse(text);
-      setEnvelope(env);
-      const r = await imp.mutateAsync({ envelope: env, dry_run: true });
-      setReport(r);
-      setName(r.name || '');
-    } catch (e) {
-      setErr(e?.message || 'Not a valid .hal0profile.json envelope');
-      setEnvelope(null); setReport(null);
-    }
-  }
-
-  const taken = existing.includes(name);
-  const nameValid = NAME_RE.test(name);
-  const canCommit = !!report && nameValid && !busy;
-
-  async function commit() {
-    if (!report || !name.trim()) return;
-    setBusy(true);
-    try {
-      await imp.mutateAsync({ envelope, name, dry_run: false });
-      toast(`Imported ${name}`, 'ok');
-      onImported();
-    } catch (e) {
-      if (e?.code === 'profiles.exists' || e?.status === 409) {
-        setErr(`“${name}” already exists — pick another name`);
-      } else {
-        toast(e?.message || 'Import failed', 'err');
-      }
-    } finally { setBusy(false); }
-  }
-
-  return (
-    <div className="stk-scrim" onMouseDown={() => { if (!busy) onClose(); }}>
-      <div className="stk-dialog" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Import profile" aria-busy={busy}>
-        <div className="stk-dlg-h">
-          <span className="stk-dlg-eye">Import profile</span>
-          <button className="stk-dlg-x" onClick={onClose} aria-label="Close" disabled={busy}>{Icons.close}</button>
-        </div>
-        <div className="stk-dlg-b">
-          {!report ? (
-            <label className="stk-drop">
-              <input type="file" accept=".hal0profile.json,.json,application/json" style={{ display: 'none' }}
-                onChange={e => e.target.files?.[0] && onFile(e.target.files[0])} data-testid="pf-import-file" />
-              <span className="stk-drop-glyph">{Icons.attach}</span>
-              <span className="mono">Choose a .hal0profile.json file</span>
-              {err && <span className="stk-dlg-warn">{Icons.alert}{err}</span>}
-            </label>
-          ) : (
-            <>
-              <div className="stk-dlg-hint">
-                {report.name || 'profile'} · schema v{report.schema_version} · checksum {report.checksum_ok ? '✓ ok' : '✗ mismatch'}
-              </div>
-              {report.collides && (
-                <div className="stk-dlg-warn">{Icons.alert}A profile named “{report.name}” already exists — choose a different name to import.</div>
-              )}
-              <div className="stk-slot-list">
-                <div className="stk-slot-row">
-                  <span className="sname">Save as</span>
-                  <input className={'pf-input mono' + (name && !nameValid ? ' err' : '')} value={name}
-                    onChange={e => { setName(e.target.value); setErr(''); }} maxLength={32} placeholder="my-profile"
-                    style={{ flex: 1, background: 'transparent', border: 'none', color: 'var(--fg)', fontFamily: 'var(--jbm)' }}
-                    data-testid="pf-import-name" />
-                </div>
-              </div>
-              {name && !nameValid && <div className="stk-dlg-warn">{Icons.alert}lowercase · digits · - · _ · ≤32</div>}
-              {taken && nameValid && <div className="stk-dlg-warn">{Icons.alert}“{name}” already exists</div>}
-              {err && <div className="stk-dlg-warn">{Icons.alert}{err}</div>}
-            </>
-          )}
-        </div>
-        <div className="stk-dlg-f">
-          <button className="btn ghost sm" onClick={onClose} disabled={busy}>Cancel</button>
-          {report && (
-            <button className="btn sm" onClick={commit} disabled={!canCommit} data-testid="pf-import-confirm">
-              {busy ? 'Importing…' : 'Import'}
-            </button>
-          )}
-        </div>
+  const renderPreview = (report) => (
+    <>
+      <div className="stk-dlg-hint">
+        {report.name || 'profile'} · schema v{report.schema_version} · checksum {report.checksum_ok ? '✓ ok' : '✗ mismatch'}
       </div>
-    </div>
+      {report.collides && (
+        <div className="stk-dlg-warn">{Icons.alert}A profile named “{report.name}” already exists — choose a different name to import.</div>
+      )}
+    </>
+  );
+  return (
+    <ImportDialog
+      title="Import profile"
+      ariaLabel="Import profile"
+      fileAccept=".hal0profile.json,.json,application/json"
+      fileHint="Choose a .hal0profile.json file"
+      fileTestid="pf-import-file"
+      nameTestid="pf-import-name"
+      confirmTestid="pf-import-confirm"
+      namePlaceholder="my-profile"
+      invalidCopy="Not a valid .hal0profile.json envelope"
+      existing={existing}
+      renderPreview={renderPreview}
+      dryRun={(env) => imp.mutateAsync({ envelope: env, dry_run: true })}
+      commit={async ({ envelope, name }) => {
+        try {
+          await imp.mutateAsync({ envelope, name, dry_run: false });
+          toast(`Imported ${name}`, 'ok');
+        } catch (e) {
+          if (e?.code === 'profiles.exists' || e?.status === 409) {
+            throw { inline: `“${name}” already exists — pick another name` };
+          }
+          throw e;
+        }
+      }}
+      onClose={onClose}
+      onImported={onImported}
+    />
   );
 }
 
@@ -707,7 +621,7 @@ function ProfilesView() {
       )}
 
       {drawer && (
-        <Drawer
+        <ProfileDrawer
           mode={drawer.mode}
           source={drawer.source}
           existing={profiles.map(p => p.name)}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -88,13 +88,40 @@ function normalizeApiModel(m) {
   };
 }
 
+// One shared compatible-models filter for all three slot surfaces (create
+// modal, edit drawer, swap popover). Takes the raw /api/models list, normalizes
+// it, and filters to the requested `type`, hiding ROCmFP4-quantized models
+// whenever the target backend isn't rocm (those weights only run on the rocm
+// fork binary). Previously the create modal filtered on type ALONE and could
+// offer rocmfp4 models that the backend then rejects — this closes that gap.
+function compatibleModels(models, { type, backend }) {
+  return (models ?? []).map(normalizeApiModel).filter(m =>
+    m.type === type &&
+    !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && backend !== "rocm")
+  );
+}
+
 // ─── Create-slot modal ──────────────────────────────────────────
 function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
-  const [name, setName] = useStateSM(defaults.name || "");
-  const [type, setType] = useStateSM(defaults.type || "llm");
-  const [profile, setProfile] = useStateSM(defaults.profile || "");
-  const [model, setModel] = useStateSM(defaults.model || "");
-  const [makeDefault, setMakeDefault] = useStateSM(false);
+  // Shared form-state hook (useForm): values + touched/submitted + isDirty (the
+  // unsaved-changes guard) + a reset that re-derives from `defaults` when the
+  // modal (re)opens. Field setters are thin wrappers so the JSX stays intact.
+  const f = useForm({
+    deriveInitial: () => ({
+      name: defaults.name || "",
+      type: defaults.type || "llm",
+      profile: defaults.profile || "",
+      model: "",
+      makeDefault: false,
+    }),
+    resetKey: `${open ? "o" : "c"}:${JSON.stringify(defaults)}`,
+  });
+  const { name, type, profile, model, makeDefault } = f.values;
+  const setName = (val) => f.set("name", val);
+  const setType = (val) => f.set("type", val);
+  const setProfile = (val) => f.set("profile", val);
+  const setModel = (val) => f.set("model", val);
+  const setMakeDefault = (val) => f.set("makeDefault", val);
   const [submitErr, setSubmitErr] = useStateSM(null);
 
   const createMut = useSlotCreate();
@@ -102,16 +129,7 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const modelsQuery = useModels();
   const profilesQuery = useProfiles();
 
-  useEffectSM(() => {
-    if (open) {
-      setName(defaults.name || "");
-      setType(defaults.type || "llm");
-      setProfile(defaults.profile || "");
-      setModel("");
-      setMakeDefault(false);
-      setSubmitErr(null);
-    }
-  }, [open, defaults]);
+  useEffectSM(() => { if (open) setSubmitErr(null); }, [open]);
 
   // validation — slot collision uses the live slot list passed in from
   // the SlotsView (useSlots data), not HAL0_DATA.
@@ -120,16 +138,13 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const nameInvalid = name && !/^[a-z][a-z0-9-]{0,30}$/.test(name);
   const nameError = nameCollision ? "name already in use" : nameInvalid ? "lowercase + dashes only" : null;
 
-  // Live catalogue from /api/models (normalized to the legacy HAL0_DATA
-  // shape so the existing filter + render code keeps working). Sending a
-  // mock id like `qwen3.6-27b-mtp` here would tunnel into POST
-  // /api/slots/{name}/swap and the slot orchestrator would reject it
-  // against the real registry (slot.not_found).
-  const allModels = (modelsQuery.data ?? []).map(normalizeApiModel);
   const allProfiles = profilesQuery.data ?? [];
-  // Any model of the right type works — the profile's image determines
-  // the backend, not a device selector.
-  const compatible = allModels.filter(m => m.type === type);
+  // Compatible models: filter by type AND the selected profile's backend so
+  // rocmfp4 models are hidden on non-rocm profiles (was type-only — the gap
+  // UI-3 closes). Before a profile is picked, backend is undefined → rocmfp4
+  // models stay hidden, the safe default.
+  const selBackend = allProfiles.find(p => p.name === profile)?.backend;
+  const compatible = compatibleModels(modelsQuery.data, { type, backend: selBackend });
 
   const canSave = !!name && !nameError && !createMut.isPending && !!profile;
 
@@ -175,6 +190,7 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
       eyebrow="Slots · new"
       title="Create slot"
       width={640}
+      dirty={f.isDirty}
       foot={
         <>
           <span>
@@ -183,7 +199,7 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
               : "capabilities.toml will be written on save."}
           </span>
           <span style={{display: "inline-flex", gap: 8}}>
-            <button className="btn ghost sm" onClick={onClose}>Cancel</button>
+            <button className="btn ghost sm" onClick={() => { if (f.isDirty && !window.confirm("Discard unsaved changes?")) return; onClose(); }}>Cancel</button>
             <button
               className="btn sm"
               onClick={onCreateClick}
@@ -569,10 +585,25 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const extraArgsDirty = extraArgs !== extraArgsBaseline;
   const extraArgsErr = validateExtraArgs(extraArgs);
 
+  // UI-1: unsaved-changes guard. Aggregate ONLY the Save-batched fields
+  // (extra_args, ctx, profile, chat_template override). The instant-apply
+  // toggles (thinking / MTP / enable) fire their own PUT/POST outside Save and
+  // are intentionally excluded — a flipped toggle is already persisted.
+  const dirty =
+    extraArgsDirty ||
+    String(ctx) !== String(slot.metrics?.ctx || 16384) ||
+    (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
+    (overrideOpen && chatTemplate !== (slot.chat_template || ""));
+  const requestClose = () => {
+    if (dirty && !window.confirm("Discard unsaved changes?")) return;
+    onClose();
+  };
+
   return (
     <Drawer
       open={open}
       onClose={onClose}
+      dirty={dirty}
       eyebrow={`Slots · /slots/${slot.name}`}
       title={`Edit ${slot.name}`}
       width={560}
@@ -601,7 +632,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
           >{Icons.unload} {deleting ? "Deleting…" : "Delete slot"}</button>
           <span style={{display: "inline-flex", gap: 8, alignItems: "center"}}>
             {submitErr && <span style={{color: "var(--err)", fontSize: 11}}>{submitErr}</span>}
-            <button className="btn ghost sm" onClick={onClose}>Cancel</button>
+            <button className="btn ghost sm" onClick={requestClose}>Cancel</button>
             <button
               className="btn sm"
               disabled={saving || deleting}
@@ -724,14 +755,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         // the operator switches profiles — before Save is clicked.
         const selProfileMeta = (profilesQuery.data ?? []).find(p => p.name === selectedProfile);
         const selBackend = selProfileMeta?.backend ?? slot.backend;
-        const compatible = (modelsQuery.data ?? [])
-          .map(normalizeApiModel)
-          .filter(m =>
-            m.type === slot.type &&
-            // ROCmFP4-quantized models only run on the rocm fork binary — hide
-            // them when the selected profile isn't on the rocm backend.
-            !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && selBackend !== "rocm")
-          );
+        const compatible = compatibleModels(modelsQuery.data, { type: slot.type, backend: selBackend });
         const cur = slot.model_id || slot.model || "";
         const has = compatible.some(m => m.id === cur);
         // A background swap is in flight — the select stays usable, but show a
@@ -1168,14 +1192,9 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
 
   const isContainer = slot.runtime === "container";
   const ramFreeGb = hwQuery.data?.ram?.free ?? 0;
-  const compatible = (modelsQuery.data ?? [])
-    .map(normalizeApiModel)
-    .filter(m =>
-      m.type === slot.type &&
-      // ROCmFP4-quantized models only run on the custom rocm fork binary —
-      // don't offer them when swapping a non-rocm slot.
-      !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && slot.backend !== "rocm")
-    );
+  // ROCmFP4-quantized models only run on the custom rocm fork binary — don't
+  // offer them when swapping a non-rocm slot (shared compatibleModels filter).
+  const compatible = compatibleModels(modelsQuery.data, { type: slot.type, backend: slot.backend });
 
   // N2: container swap = cold systemctl restart (not a hot in-place swap).
   // Intercept onPick for container slots: show a confirm toast and fire

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -38,18 +38,13 @@ const DEVICE_META = {
 };
 const DEVICES = Object.keys(DEVICE_META);
 
-// Mirrors the API slug regex ^[a-z0-9][a-z0-9_-]{0,31}$.
-const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+// `NAME_RE` (slug regex) and `toast` are shared globals from primitives.jsx.
 
 const BLANK_SLOT = { slot: '', model: '', device: 'gpu-rocm', profile: '', mtp: false, capabilities: [] };
 const BLANK = { name: '', description: '', icon: '', tags: '', slots: [{ ...BLANK_SLOT }] };
 
 const DOT_STATES = new Set(['serving', 'ready', 'warming', 'idle', 'offline']);
 function dotCls(state) { return DOT_STATES.has(state) ? state : 'offline'; }
-
-function toast(msg, kind = 'info') {
-  if (typeof window !== 'undefined' && window.__hal0Toast) window.__hal0Toast(msg, kind);
-}
 
 // ── status dot ────────────────────────────────────────────────────────────────
 
@@ -287,104 +282,59 @@ function LibCard({ vm, idx, isCustom, onLoad, onPull, onExport, onClone, onEdit,
 
 // ── Import modal (file → dry-run resolve → commit) ──────────────────────────
 
+// Thin wrapper over the shared <ImportDialog>: owns the useStackImport hook and
+// the stacks-specific preview (model resolutions + unresolvable warning) and
+// filename→slug derivation. The dialog shell + name input + commit button live
+// in primitives.jsx.
 function ImportModal({ existing, onClose, onImported }) {
   const imp = useStackImport();
-  const [envelope, setEnvelope] = useState(null);
-  const [report, setReport] = useState(null);
-  const [slug, setSlug] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState('');
-
-  async function onFile(file) {
-    setErr('');
-    try {
-      const text = await file.text();
-      const env = JSON.parse(text);
-      setEnvelope(env);
-      const r = await imp.mutateAsync({ envelope: env, dry_run: true });
-      setReport(r);
-      const base = (file.name || '').replace(/\.hal0stack\.json$|\.json$/i, '')
-        .toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32);
-      setSlug(base || 'imported-stack');
-    } catch (e) {
-      setErr(e?.message || 'Not a valid .hal0stack.json envelope');
-      setEnvelope(null); setReport(null);
-    }
-  }
-
-  const slugTaken = existing.includes(slug);
-  const slugValid = NAME_RE.test(slug) && !slugTaken;
-
-  async function commit() {
-    if (!slugValid) return;
-    setBusy(true);
-    try {
-      await imp.mutateAsync({ envelope, slug });
-      toast(`Imported as ${slug}`, 'ok');
-      onImported();
-    } catch (e) {
-      toast(e?.message || 'Import failed', 'err');
-    } finally { setBusy(false); }
-  }
-
-  return (
-    <div className="stk-scrim" onMouseDown={() => { if (!busy) onClose(); }}>
-      <div className="stk-dialog" onMouseDown={e => e.stopPropagation()} role="dialog" aria-label="Import stack">
-        <div className="stk-dlg-h">
-          <span className="stk-dlg-eye">Import stack</span>
-          <button className="stk-dlg-x" onClick={onClose} aria-label="Close" disabled={busy}>{Icons.close}</button>
-        </div>
-        <div className="stk-dlg-b">
-          {!report ? (
-            <label className="stk-drop">
-              <input type="file" accept=".json,application/json" style={{ display: 'none' }}
-                onChange={e => e.target.files?.[0] && onFile(e.target.files[0])} data-testid="st-import-file" />
-              <span className="stk-drop-glyph">{Icons.attach}</span>
-              <span className="mono">Choose a .hal0stack.json file</span>
-              {err && <span className="stk-dlg-warn">{Icons.alert}{err}</span>}
-            </label>
-          ) : (
-            <>
-              <div className="stk-dlg-hint">
-                {report.name || 'stack'} · schema v{report.schema_version} · checksum {report.checksum_ok ? 'ok' : '⚠ mismatch'}
-              </div>
-              <div className="stk-slot-list">
-                {(report.resolutions || []).map(r => (
-                  <div key={r.model_id} className={'stk-slot-row' + (r.status === 'unresolvable' ? ' miss' : '')}>
-                    <span className="smodel">{r.model_id}</span>
-                    <span className="smiss" style={{ color: r.status === 'present' ? 'var(--ok)' : r.status === 'pullable' ? 'var(--info)' : 'var(--err)' }}>{r.status}</span>
-                  </div>
-                ))}
-                {(!report.resolutions || report.resolutions.length === 0) && (
-                  <div className="stk-dlg-hint" style={{ color: 'var(--fg-5)' }}>no model references</div>
-                )}
-              </div>
-              {report.unresolvable?.length > 0 && (
-                <div className="stk-dlg-warn">{Icons.alert}{report.unresolvable.length} model(s) unresolvable — those slots import disabled.</div>
-              )}
-              <div className="stk-slot-list">
-                <div className="stk-slot-row">
-                  <span className="sname">Save as</span>
-                  <input className={'pf-input mono' + (slug && !slugValid ? ' err' : '')} value={slug}
-                    onChange={e => setSlug(e.target.value)} maxLength={32} placeholder="my-stack"
-                    style={{ flex: 1, background: 'transparent', border: 'none', color: 'var(--fg)', fontFamily: 'var(--jbm)' }}
-                    data-testid="st-import-slug" />
-                </div>
-              </div>
-              {slugTaken && <div className="stk-dlg-warn">{Icons.alert}“{slug}” already exists</div>}
-            </>
-          )}
-        </div>
-        <div className="stk-dlg-f">
-          <button className="btn ghost sm" onClick={onClose} disabled={busy}>Cancel</button>
-          {report && (
-            <button className="btn sm" onClick={commit} disabled={!slugValid || busy} data-testid="st-import-confirm">
-              {busy ? 'Importing…' : 'Import'}
-            </button>
-          )}
-        </div>
+  const deriveSlug = (file) => {
+    const base = (file.name || '').replace(/\.hal0stack\.json$|\.json$/i, '')
+      .toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 32);
+    return base || 'imported-stack';
+  };
+  const renderPreview = (report) => (
+    <>
+      <div className="stk-dlg-hint">
+        {report.name || 'stack'} · schema v{report.schema_version} · checksum {report.checksum_ok ? 'ok' : '⚠ mismatch'}
       </div>
-    </div>
+      <div className="stk-slot-list">
+        {(report.resolutions || []).map(r => (
+          <div key={r.model_id} className={'stk-slot-row' + (r.status === 'unresolvable' ? ' miss' : '')}>
+            <span className="smodel">{r.model_id}</span>
+            <span className="smiss" style={{ color: r.status === 'present' ? 'var(--ok)' : r.status === 'pullable' ? 'var(--info)' : 'var(--err)' }}>{r.status}</span>
+          </div>
+        ))}
+        {(!report.resolutions || report.resolutions.length === 0) && (
+          <div className="stk-dlg-hint" style={{ color: 'var(--fg-5)' }}>no model references</div>
+        )}
+      </div>
+      {report.unresolvable?.length > 0 && (
+        <div className="stk-dlg-warn">{Icons.alert}{report.unresolvable.length} model(s) unresolvable — those slots import disabled.</div>
+      )}
+    </>
+  );
+  return (
+    <ImportDialog
+      title="Import stack"
+      ariaLabel="Import stack"
+      fileHint="Choose a .hal0stack.json file"
+      fileTestid="st-import-file"
+      nameTestid="st-import-slug"
+      confirmTestid="st-import-confirm"
+      namePlaceholder="my-stack"
+      invalidCopy="Not a valid .hal0stack.json envelope"
+      existing={existing}
+      deriveName={deriveSlug}
+      renderPreview={renderPreview}
+      dryRun={(env) => imp.mutateAsync({ envelope: env, dry_run: true })}
+      commit={async ({ envelope, name }) => {
+        await imp.mutateAsync({ envelope, slug: name });
+        toast(`Imported as ${name}`, 'ok');
+      }}
+      onClose={onClose}
+      onImported={onImported}
+    />
   );
 }
 
@@ -407,55 +357,59 @@ function fromStack(s) {
   };
 }
 
-function Drawer({ mode, source, existing = [], onClose, onSaved }) {
+// The editor drawer. Consumes the shared FormDrawer shell + useForm hook +
+// shared FormRow from primitives.jsx. Named StackDrawer (not Drawer) to avoid
+// shadowing the primitives.jsx Drawer global. Validation rules (slug/slot) and
+// the submit body are preserved verbatim.
+function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
   const isEdit = mode === 'edit';
   const models = useModels().data || [];
   const profiles = useProfiles().data || [];
   const liveSlots = (useSlots().data || []).filter(s => (s.kind ?? 'local') === 'local');
 
-  const initial = (() => {
-    if (mode === 'create') return source ? fromStack(source) : { ...BLANK, slots: [{ ...BLANK_SLOT }] };
+  const create = useStackCreate();
+  const update = useStackUpdate();
+
+  const deriveInitial = () => {
+    if (mode === 'create') {
+      const base = source ? fromStack(source) : { ...BLANK, slots: [{ ...BLANK_SLOT }] };
+      return { ...base, _slug: '' };
+    }
     const base = fromStack(source);
     if (mode === 'clone') {
       const suffix = source.seed ? '-custom' : '-copy';
       return { ...base, _slug: (source.slug + suffix).slice(0, 32) };
     }
     return { ...base, _slug: source.slug };
-  })();
+  };
 
-  const [form, setForm] = useState(initial);
-  const [slug, setSlug] = useState(initial._slug || '');
-  const [submitting, setSubmitting] = useState(false);
-  const [closing, setClosing] = useState(false);
+  const f = useForm({ deriveInitial, resetKey: `${mode}:${source?.slug ?? ''}` });
+  const v = f.values;
+  const slug = v._slug || '';
 
-  const create = useStackCreate();
-  const update = useStackUpdate();
-
-  useEffect(() => { setForm(initial); setSlug(initial._slug || ''); /* eslint-disable-next-line */ }, [mode, source]);
+  const setSlug = (val) => f.set('_slug', val);
+  const setSlot = (i, k, val) => f.setValues(ff => ({ ...ff, slots: ff.slots.map((s, j) => j === i ? { ...s, [k]: val } : s) }));
+  const addSlot = () => f.setValues(ff => ({ ...ff, slots: [...ff.slots, { ...BLANK_SLOT }] }));
+  const rmSlot = (i) => f.setValues(ff => ({ ...ff, slots: ff.slots.filter((_, j) => j !== i) }));
 
   const taken = existing.filter(n => !(isEdit && n === source?.slug));
   const slugErr = !slug.trim() ? 'Slug is required'
     : !NAME_RE.test(slug) ? 'lowercase · digits · - · _ · ≤32'
     : taken.includes(slug) ? `“${slug}” already exists` : '';
-  const slotErr = !form.slots.length ? 'add at least one slot'
-    : form.slots.some(s => !s.slot.trim()) ? 'every slot needs a name' : '';
+  const slotErr = !v.slots.length ? 'add at least one slot'
+    : v.slots.some(s => !s.slot.trim()) ? 'every slot needs a name' : '';
   const blocking = (!isEdit && !!slugErr) || !!slotErr;
-
-  const setSlot = (i, k, v) => setForm(f => ({ ...f, slots: f.slots.map((s, j) => j === i ? { ...s, [k]: v } : s) }));
-  const addSlot = () => setForm(f => ({ ...f, slots: [...f.slots, { ...BLANK_SLOT }] }));
-  const rmSlot = (i) => setForm(f => ({ ...f, slots: f.slots.filter((_, j) => j !== i) }));
-  const close = () => { if (submitting) return; setClosing(true); setTimeout(onClose, 200); };
 
   async function submit(e) {
     e.preventDefault();
     if (blocking) { toast('Fix the highlighted fields', 'warn'); return; }
-    setSubmitting(true);
+    f.setSubmitting(true);
     const body = {
-      name: form.name.trim(),
-      description: form.description.trim(),
-      icon: form.icon.trim(),
-      tags: form.tags.split(',').map(t => t.trim()).filter(Boolean),
-      slots: form.slots.map(s => ({
+      name: v.name.trim(),
+      description: v.description.trim(),
+      icon: v.icon.trim(),
+      tags: v.tags.split(',').map(t => t.trim()).filter(Boolean),
+      slots: v.slots.map(s => ({
         slot: s.slot.trim(),
         model: s.model || null,
         device: s.device || null,
@@ -478,7 +432,7 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
       if (code === 'stacks.exists') toast(`A stack named ${slug} already exists`, 'err');
       else if (code === 'stacks.seed_immutable') toast('Seed stacks cannot be modified', 'err');
       else toast(err?.message || 'Save failed', 'err');
-    } finally { setSubmitting(false); }
+    } finally { f.setSubmitting(false); }
   }
 
   const title = isEdit ? `Edit · ${source.slug}`
@@ -487,100 +441,82 @@ function Drawer({ mode, source, existing = [], onClose, onSaved }) {
   const eyebrow = isEdit ? 'EDIT' : mode === 'clone' ? (source?.seed ? 'EDIT A COPY' : 'CLONE') : 'CREATE';
 
   return (
-    <div className={'pf-scrim' + (closing ? ' out' : '')} onMouseDown={close}>
-      <div className={'pf-drawer pf-form-panel st-drawer' + (closing ? ' out' : '')}
-        onMouseDown={e => e.stopPropagation()} role="dialog" aria-label={title} aria-busy={submitting}>
-        <div className="pf-drawer-head">
-          <div>
-            <div className="pf-drawer-eye mono">{eyebrow}</div>
-            <div className="pf-drawer-title pf-form-title mono">{title}</div>
-          </div>
-          <button className="pf-x" onClick={close} aria-label="Close" disabled={submitting}>{Icons.close}</button>
-        </div>
-
-        <form className="pf-drawer-body" onSubmit={submit} noValidate>
-          <FormRow label="Slug" req sub="lowercase · - _ · ≤32" error={!isEdit ? slugErr : null}>
-            <input className={'pf-input mono' + (!isEdit && slugErr ? ' err' : '')} value={slug}
-              onChange={e => setSlug(e.target.value)} placeholder="my-stack" maxLength={32}
-              disabled={isEdit} data-testid="st-input-slug" />
-          </FormRow>
-          <FormRow label="Name" sub="display label">
-            <input className="pf-input" value={form.name}
-              onChange={e => setForm(f => ({ ...f, name: e.target.value }))} placeholder="Coding" data-testid="st-input-name" />
-          </FormRow>
-          <FormRow label="Description" sub="what it's for">
-            <textarea className="pf-input pf-textarea" rows={2} value={form.description}
-              onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
-              placeholder="Fast coder + agentic muscle + repo retrieval" />
-          </FormRow>
-          <FormRow label="Tags" sub="comma-separated">
-            <input className="pf-input mono" value={form.tags}
-              onChange={e => setForm(f => ({ ...f, tags: e.target.value }))} placeholder="coding, fast" />
-          </FormRow>
-
-          <div className="st-slots-edit">
-            <div className="pf-row-lbl" style={{ marginBottom: 6 }}>
-              <span>Slots{slotErr && <span className="pf-msg err mono hint err" style={{ marginLeft: 8 }}>{Icons.alert}{slotErr}</span>}</span>
-            </div>
-            <datalist id="st-existing-slots">
-              {liveSlots.map(s => <option key={s.name} value={s.name} />)}
-            </datalist>
-            {form.slots.map((s, i) => {
-              const isNew = !!s.slot && !liveSlots.some(ls => ls.name === s.slot);
-              return (
-                <div className="st-slot-edit" key={i}>
-                  <input className="pf-input mono st-slot-name" value={s.slot} list="st-existing-slots"
-                    onChange={e => setSlot(i, 'slot', e.target.value)} placeholder="pick or name…" maxLength={32}
-                    title={isNew ? 'New slot — created on apply' : 'Existing slot'} data-testid={`st-slot-name-${i}`} />
-                  {isNew && <span className="st-slot-new mono" title="Created on apply">new</span>}
-                  <select className="pf-input mono st-slot-model" value={s.model}
-                    onChange={e => setSlot(i, 'model', e.target.value)} data-testid={`st-slot-model-${i}`}>
-                    <option value="">— model —</option>
-                    {models.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
-                  </select>
-                  <select className="pf-input mono st-slot-dev" value={s.device} onChange={e => setSlot(i, 'device', e.target.value)}>
-                    {DEVICES.map(d => <option key={d} value={d}>{DEVICE_META[d].label}</option>)}
-                  </select>
-                  <select className="pf-input mono st-slot-prof" value={s.profile} onChange={e => setSlot(i, 'profile', e.target.value)}>
-                    <option value="">— profile —</option>
-                    {profiles.map(p => <option key={p.name} value={p.name}>{p.name}</option>)}
-                  </select>
-                  <button type="button" className={'pf-switch sm' + (s.mtp ? ' on' : '')}
-                    onClick={() => setSlot(i, 'mtp', !s.mtp)} role="switch" aria-checked={s.mtp} title="MTP speculative decode">
-                    <span className="pf-switch-knob" /><span className="mono">MTP</span>
-                  </button>
-                  <button type="button" className="pf-btn danger" onClick={() => rmSlot(i)} title="Remove slot" data-testid={`st-slot-rm-${i}`}>{Icons.trash}</button>
-                </div>
-              );
-            })}
-            <button type="button" className="pf-btn" onClick={addSlot} data-testid="st-slot-add">{Icons.plus} Add slot</button>
-          </div>
-        </form>
-
-        <div className="pf-drawer-foot">
+    <FormDrawer
+      eyebrow={eyebrow}
+      title={title}
+      panelClassName="st-drawer"
+      submitting={f.submitting}
+      dirty={f.isDirty}
+      onClose={onClose}
+      foot={({ requestClose }) => (
+        <>
           <span className="pf-grow" />
-          <button className="pf-btn" onClick={close} type="button" disabled={submitting}>Cancel</button>
-          <button className="pf-btn primary" onClick={submit} disabled={submitting} data-testid="st-btn-submit">
-            {submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create stack'}
+          <button className="pf-btn" onClick={requestClose} type="button" disabled={f.submitting}>Cancel</button>
+          <button className="pf-btn primary" onClick={submit} disabled={f.submitting} data-testid="st-btn-submit">
+            {f.submitting ? 'Saving…' : isEdit ? 'Save changes' : 'Create stack'}
           </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+        </>
+      )}
+    >
+      <form className="pf-drawer-body" onSubmit={submit} noValidate>
+        <FormRow label="Slug" req sub="lowercase · - _ · ≤32" error={!isEdit ? slugErr : null}>
+          <input className={'pf-input mono' + (!isEdit && slugErr ? ' err' : '')} value={slug}
+            onChange={e => setSlug(e.target.value)} placeholder="my-stack" maxLength={32}
+            disabled={isEdit} data-testid="st-input-slug" />
+        </FormRow>
+        <FormRow label="Name" sub="display label">
+          <input className="pf-input" value={v.name}
+            onChange={e => f.set('name', e.target.value)} placeholder="Coding" data-testid="st-input-name" />
+        </FormRow>
+        <FormRow label="Description" sub="what it's for">
+          <textarea className="pf-input pf-textarea" rows={2} value={v.description}
+            onChange={e => f.set('description', e.target.value)}
+            placeholder="Fast coder + agentic muscle + repo retrieval" />
+        </FormRow>
+        <FormRow label="Tags" sub="comma-separated">
+          <input className="pf-input mono" value={v.tags}
+            onChange={e => f.set('tags', e.target.value)} placeholder="coding, fast" />
+        </FormRow>
 
-function FormRow({ label, sub, req, children, error }) {
-  return (
-    <div className={'pf-row' + (error ? ' has-err' : '')}>
-      <div className="pf-row-lbl">
-        <span>{label}{req && <span className="pf-req" title="required">*</span>}</span>
-        {sub && <span className="pf-row-sub mono">{sub}</span>}
-      </div>
-      <div className="pf-row-ctl">
-        <div className={'pf-field' + (error ? ' err' : '')}>{children}</div>
-        {error && <div className="pf-row-foot"><span className="pf-msg err mono hint err">{Icons.alert}{error}</span></div>}
-      </div>
-    </div>
+        <div className="st-slots-edit">
+          <div className="pf-row-lbl" style={{ marginBottom: 6 }}>
+            <span>Slots{slotErr && <span className="pf-msg err mono hint err" style={{ marginLeft: 8 }}>{Icons.alert}{slotErr}</span>}</span>
+          </div>
+          <datalist id="st-existing-slots">
+            {liveSlots.map(s => <option key={s.name} value={s.name} />)}
+          </datalist>
+          {v.slots.map((s, i) => {
+            const isNew = !!s.slot && !liveSlots.some(ls => ls.name === s.slot);
+            return (
+              <div className="st-slot-edit" key={i}>
+                <input className="pf-input mono st-slot-name" value={s.slot} list="st-existing-slots"
+                  onChange={e => setSlot(i, 'slot', e.target.value)} placeholder="pick or name…" maxLength={32}
+                  title={isNew ? 'New slot — created on apply' : 'Existing slot'} data-testid={`st-slot-name-${i}`} />
+                {isNew && <span className="st-slot-new mono" title="Created on apply">new</span>}
+                <select className="pf-input mono st-slot-model" value={s.model}
+                  onChange={e => setSlot(i, 'model', e.target.value)} data-testid={`st-slot-model-${i}`}>
+                  <option value="">— model —</option>
+                  {models.map(m => <option key={m.id} value={m.id}>{m.id}</option>)}
+                </select>
+                <select className="pf-input mono st-slot-dev" value={s.device} onChange={e => setSlot(i, 'device', e.target.value)}>
+                  {DEVICES.map(d => <option key={d} value={d}>{DEVICE_META[d].label}</option>)}
+                </select>
+                <select className="pf-input mono st-slot-prof" value={s.profile} onChange={e => setSlot(i, 'profile', e.target.value)}>
+                  <option value="">— profile —</option>
+                  {profiles.map(p => <option key={p.name} value={p.name}>{p.name}</option>)}
+                </select>
+                <button type="button" className={'pf-switch sm' + (s.mtp ? ' on' : '')}
+                  onClick={() => setSlot(i, 'mtp', !s.mtp)} role="switch" aria-checked={s.mtp} title="MTP speculative decode">
+                  <span className="pf-switch-knob" /><span className="mono">MTP</span>
+                </button>
+                <button type="button" className="pf-btn danger" onClick={() => rmSlot(i)} title="Remove slot" data-testid={`st-slot-rm-${i}`}>{Icons.trash}</button>
+              </div>
+            );
+          })}
+          <button type="button" className="pf-btn" onClick={addSlot} data-testid="st-slot-add">{Icons.plus} Add slot</button>
+        </div>
+      </form>
+    </FormDrawer>
   );
 }
 
@@ -779,7 +715,7 @@ function StacksView() {
         </div>
       )}
 
-      {drawer && <Drawer mode={drawer.mode} source={drawer.source} existing={existing}
+      {drawer && <StackDrawer mode={drawer.mode} source={drawer.source} existing={existing}
         onClose={() => setDrawer(null)} onSaved={() => setDrawer(null)} />}
       {confirm && <DeleteConfirm vm={confirm} onCancel={() => setConfirm(null)} onConfirmed={() => setConfirm(null)} />}
       {loadTgt && <LoadDialog vm={loadTgt} busy={loadBusy} onLoad={confirmLoad} onPull={openPull} onClose={() => setLoadTgt(null)} />}


### PR DESCRIPTION
## Wave 5 of the platform-review remediation program

Consolidates the dash editing-drawer form infrastructure and closes the UX/a11y gaps. One coherent refactor (the findings are tightly coupled on the same 4 files).

| ID | Change |
|----|--------|
| **UI-12** | One shared `FormDrawer` + `FormRow` + `ImportDialog` + `toast` + `NAME_RE` promoted into `primitives.jsx`; per-view local copies in `stacks.jsx`/`profiles.jsx` deleted; local `Drawer` name-shadow removed (editors renamed `ProfileDrawer`/`StackDrawer`). |
| **UI-19** | One `useForm({initial, validate})` hook adopted by `ProfileDrawer`/`StackDrawer`/`CreateSlotModal` (each keeps its own validation rules verbatim). |
| **UI-1** | Unsaved-changes dirty guard on `Modal`/`Drawer`: Esc/backdrop/close confirm when dirty; backdrop-dismiss disabled while dirty. |
| **UI-3** | One `compatibleModels(models, {type, backend})` filter used by all three slot-modal sites; the create modal now applies the backend/rocmfp4 check (previously type-only → could offer an incompatible id). |
| **UI-14** | Focus trap + return-focus on `Modal`/`Drawer`; real `<label htmlFor>`/`id` wiring in the shared `FormRow`. |

### Verification
- All confirmed (UI-12 partial → the "shadowing" half was conceptual; handled by rename).
- `tsc` clean **but note** `checkJs:false` means `.jsx` isn't type-checked — real gates are **`npm run build` (vite, passes locally, 217 modules)** + the **`γ-suite` Playwright e2e** which drives these drawers, plus a behavior-preservation code review.
- Scope held to de-dup + safety: no field reordering, no change to Save payloads. `EditSlotDrawer`'s instant-apply controls (thinking/MTP/enable) stay outside the batch form.

Deferred to a follow-up (not in this PR): UI-2 (instant-vs-batched badges), UI-4 (lead-with-fields reorder), and the low-severity UI items (UI-5/6/9/10/16/20/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)