### PR TITLE
fix(platform-review): Wave 6 — cross-process safety & housekeeping (MR-5/SC-10/MR-8/MR-9/MR-13/DR-12/MR-7)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -892,6 +892,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         sweep_orphaned_partials()
     except Exception as exc:  # housekeeping must never block startup
         log.warning("model.partial_sweep_startup_failed", error=str(exc))
+    # Reap stale terminal pull-job snapshots left by deleted / failed /
+    # cancelled pulls or older builds (#MR-8). Best-effort — a broken sweep
+    # must never block startup.
+    try:
+        from hal0.registry.pull import sweep_pull_jobs
+
+        reaped = sweep_pull_jobs()
+        if reaped:
+            log.info("model.pull_jobs_swept", count=reaped)
+    except Exception as exc:
+        log.warning("model.pull_jobs_sweep_failed", error=str(exc))
     # Container image-pull job registry — keyed by slot name, value is a
     # dict with keys: state (pulling|completed|failed), layer, total_layers,
     # error, and a threading.Event for SSE fan-out.

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -883,6 +883,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # and status routes snapshot ``as_dict()`` rather than hold the
     # dataclass across event-loop ticks.
     app.state.model_pull_jobs = {}
+    # Reap orphaned *.part staging files left by a SIGKILL/OOM mid-pull
+    # (MR-9). Age-gated so an in-flight pull from another worker is never
+    # touched; housekeeping must never block startup.
+    try:
+        from hal0.registry.pull import sweep_orphaned_partials
+
+        sweep_orphaned_partials()
+    except Exception as exc:  # housekeeping must never block startup
+        log.warning("model.partial_sweep_startup_failed", error=str(exc))
     # Container image-pull job registry — keyed by slot name, value is a
     # dict with keys: state (pulling|completed|failed), layer, total_layers,
     # error, and a threading.Event for SSE fan-out.

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1049,6 +1049,11 @@ async def delete_model(
             _clear_slot_default(Path(entry["path"]), entry["config"])
 
         removed = registry.remove(model_id)
+        # Best-effort GC of the durable pull-job snapshot (#MR-8). A failed
+        # unlink must never break the delete or the model.deleted emit; the
+        # startup sweep reaps anything we miss here.
+        with contextlib.suppress(OSError):
+            _pull_job_file(model_id).unlink(missing_ok=True)
         rec.after = {
             "id": model_id,
             "deleted": bool(removed),

--- a/src/hal0/capabilities/config.py
+++ b/src/hal0/capabilities/config.py
@@ -277,34 +277,45 @@ def auto_migrate_capabilities_file(path: Path | None = None) -> bool:
     """
     import os
 
+    from hal0.config.locking import file_lock
+
     target = Path(path) if path is not None else capabilities_toml_path()
-    if not target.exists():
-        return False
 
-    with open(target, "rb") as f:
-        raw = tomllib.load(f)
+    # SC-10: the read → rename-backup → replace → write is one read-modify-write
+    # that must not race a concurrent capabilities.toml writer (this runs at
+    # hal0-api boot AND from the CLI ``migrate*`` commands). Hold the same
+    # advisory lock every other writer uses; the check is re-done inside the
+    # lock so a peer that migrated while we blocked short-circuits. The lock is
+    # re-entrant, so calling this from an already-locked ``initialize_if_missing``
+    # does not self-deadlock.
+    with file_lock(target):
+        if not target.exists():
+            return False
 
-    current_version = read_schema_version(raw)
-    if current_version >= CAPABILITIES_SCHEMA_VERSION_CURRENT:
-        return False
+        with open(target, "rb") as f:
+            raw = tomllib.load(f)
 
-    backup = capabilities_v1_backup_path(target)
-    # Atomic-rename live → .v1.bak. If a stale backup exists (a prior
-    # migration that crashed mid-write), refuse to clobber it — the
-    # operator will see the live file untouched on next boot.
-    if backup.exists():
-        log.warning(
-            "capabilities.migrate.backup_exists",
-            extra={"path": str(backup)},
-        )
-    else:
-        os.replace(target, backup)
+        current_version = read_schema_version(raw)
+        if current_version >= CAPABILITIES_SCHEMA_VERSION_CURRENT:
+            return False
 
-    migrated = migrate_capabilities_v1_to_v2(raw)
-    # Validate before write — a malformed migration output should never
-    # land on disk. ``model_validate`` raises with the offending path.
-    CapabilityConfig.model_validate(migrated)
-    write_toml_atomic(target, migrated)
+        backup = capabilities_v1_backup_path(target)
+        # Atomic-rename live → .v1.bak. If a stale backup exists (a prior
+        # migration that crashed mid-write), refuse to clobber it — the
+        # operator will see the live file untouched on next boot.
+        if backup.exists():
+            log.warning(
+                "capabilities.migrate.backup_exists",
+                extra={"path": str(backup)},
+            )
+        else:
+            os.replace(target, backup)
+
+        migrated = migrate_capabilities_v1_to_v2(raw)
+        # Validate before write — a malformed migration output should never
+        # land on disk. ``model_validate`` raises with the offending path.
+        CapabilityConfig.model_validate(migrated)
+        write_toml_atomic(target, migrated)
 
     log.info(
         "migrated capabilities.toml from schema_version=%d to %d",

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -48,6 +48,7 @@ from hal0.capabilities.config import (
 from hal0.capabilities.profile_fit import profile_name_for_fit
 from hal0.config import paths
 from hal0.config.loader import load_slot_config, write_toml_atomic
+from hal0.config.locking import file_lock
 from hal0.dispatcher._npu_common import is_container_npu_cfg
 from hal0.errors import BadRequest, Hal0Error, NotFound
 from hal0.model_fit import evaluate_model_fit
@@ -206,41 +207,48 @@ class CapabilityOrchestrator:
         """
         from hal0.capabilities.config import auto_migrate_capabilities_file
 
-        if self._config_path.exists():
-            # Migrate v1 → v2 in place if needed. Idempotent on v2 files.
-            try:
-                auto_migrate_capabilities_file(self._config_path)
-            except Exception as exc:
-                # Don't let a migration crash block API startup — the
-                # orchestrator already swallows initialise failures one
-                # level up.
-                log.warning(
-                    "capabilities.migrate.skipped",
-                    extra={"path": str(self._config_path), "error": str(exc)},
-                )
-            return
+        # SC-10: the exists-check + seed write (and the nested auto-migrate)
+        # are one read-modify-write that must not race a concurrent CLI/API
+        # writer. Hold the same capabilities.toml advisory lock every other
+        # writer uses; re-check existence INSIDE the lock so a writer that
+        # seeded the file while we blocked isn't overwritten. The lock is
+        # re-entrant, so the nested (also-locked) auto-migrate is safe.
+        with file_lock(self._config_path):
+            if self._config_path.exists():
+                # Migrate v1 → v2 in place if needed. Idempotent on v2 files.
+                try:
+                    auto_migrate_capabilities_file(self._config_path)
+                except Exception as exc:
+                    # Don't let a migration crash block API startup — the
+                    # orchestrator already swallows initialise failures one
+                    # level up.
+                    log.warning(
+                        "capabilities.migrate.skipped",
+                        extra={"path": str(self._config_path), "error": str(exc)},
+                    )
+                return
 
-        cfg = CapabilityConfig()
-        for (slot, child), slot_name in _CHILD_TO_SLOT.items():
-            cfg.selections.setdefault(slot, {})
-            selection = CapabilitySelection()
-            try:
-                slot_cfg = load_slot_config(slot_name)
-            except Exception:
-                # Slot TOML missing or invalid — leave the selection blank.
+            cfg = CapabilityConfig()
+            for (slot, child), slot_name in _CHILD_TO_SLOT.items():
+                cfg.selections.setdefault(slot, {})
+                selection = CapabilitySelection()
+                try:
+                    slot_cfg = load_slot_config(slot_name)
+                except Exception:
+                    # Slot TOML missing or invalid — leave the selection blank.
+                    cfg.selections[slot][child] = selection
+                    continue
+                # Lift the fields we care about. v0.2: write ``device``
+                # (not the deprecated ``backend``). SlotConfig auto-promotes
+                # legacy ``backend`` on load, so ``slot_cfg.device`` is the
+                # right v0.2 surface here.
+                selection.device = canonical_device(slot_cfg.device)
+                selection.provider = slot_cfg.provider
+                selection.model = slot_cfg.model.default or ""
+                selection.enabled = bool(slot_cfg.enabled) and bool(selection.model)
                 cfg.selections[slot][child] = selection
-                continue
-            # Lift the fields we care about. v0.2: write ``device``
-            # (not the deprecated ``backend``). SlotConfig auto-promotes
-            # legacy ``backend`` on load, so ``slot_cfg.device`` is the
-            # right v0.2 surface here.
-            selection.device = canonical_device(slot_cfg.device)
-            selection.provider = slot_cfg.provider
-            selection.model = slot_cfg.model.default or ""
-            selection.enabled = bool(slot_cfg.enabled) and bool(selection.model)
-            cfg.selections[slot][child] = selection
 
-        self._save(cfg)
+            self._save(cfg)
 
     # ── shape helpers ────────────────────────────────────────────────────────
     #
@@ -426,11 +434,14 @@ class CapabilityOrchestrator:
         #   - the reconciliation itself (enabled selections projected onto
         #     an existing slot TOML, model_meta-translated device/backend)
         #     lives in the store where it is independently tested.
-        change_set = self._store.apply(
-            SlotSelection(slot=slot, child=child, slot_name=slot_name, selection=merged)
-        )
+        # SC-10: apply_and_commit holds the capabilities.toml advisory lock
+        # across the authoritative before-read AND the write, so a concurrent
+        # CLI/API writer cannot interleave its RMW and drop this change (the
+        # committed ChangeSet is computed under the lock).
         try:
-            self._store.commit(change_set)
+            self._store.apply_and_commit(
+                SlotSelection(slot=slot, child=child, slot_name=slot_name, selection=merged)
+            )
         except Exception as exc:
             raise CapabilityApplyFailed(
                 f"failed to persist capability change: {exc}",

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -38,6 +38,7 @@ from hal0.capabilities.config import (
     save_capabilities_config,
 )
 from hal0.capabilities.orchestrator import _CHILD_TO_CAPABILITY
+from hal0.config.locking import file_lock
 from hal0.registry.store import ModelRegistry
 
 app = typer.Typer(
@@ -104,94 +105,102 @@ def migrate(
 
     Idempotent — running it twice is a no-op once everything is legal.
     """
-    cfg = load_capabilities_config()
-    registry = ModelRegistry()
+    # SC-10: the load → diff → save is one read-modify-write. Hold the same
+    # capabilities.toml advisory lock the running API uses so a ``migrate``
+    # invoked while hal0-api is applying a selection cannot read a stale copy
+    # and clobber the API's concurrent write (or vice-versa). The lock spans
+    # the whole span — locking only the ``save`` would leave the stale read
+    # unguarded. Dry-run holds it too (cheap) so the preview reflects a
+    # consistent snapshot.
+    with file_lock(capabilities_toml_path()):
+        cfg = load_capabilities_config()
+        registry = ModelRegistry()
 
-    changes: list[dict[str, str]] = []
-    for slot, children in cfg.selections.items():
-        for child, sel in children.items():
-            capability = _CHILD_TO_CAPABILITY.get((slot, child))
-            if capability is None:
-                continue
-            verdict, legal = _classify_pair(capability, sel.model, sel.backend, registry)
-            if verdict in {"empty", "ok"}:
-                continue
-            if verdict == "illegal_backend":
-                new_backend = legal[0] if legal else ""
-                # Re-resolve provider against the matching row so the
-                # slot rewrite uses the right runtime tag.
-                rows = models_for_capability(capability, registry=registry)
-                row = next((r for r in rows if r["id"] == sel.model), None)
-                new_provider = ""
-                if row is not None:
-                    backend_meta = next(
-                        (b for b in row.get("backends", []) if b["id"] == new_backend),
-                        None,
+        changes: list[dict[str, str]] = []
+        for slot, children in cfg.selections.items():
+            for child, sel in children.items():
+                capability = _CHILD_TO_CAPABILITY.get((slot, child))
+                if capability is None:
+                    continue
+                verdict, legal = _classify_pair(capability, sel.model, sel.backend, registry)
+                if verdict in {"empty", "ok"}:
+                    continue
+                if verdict == "illegal_backend":
+                    new_backend = legal[0] if legal else ""
+                    # Re-resolve provider against the matching row so the
+                    # slot rewrite uses the right runtime tag.
+                    rows = models_for_capability(capability, registry=registry)
+                    row = next((r for r in rows if r["id"] == sel.model), None)
+                    new_provider = ""
+                    if row is not None:
+                        backend_meta = next(
+                            (b for b in row.get("backends", []) if b["id"] == new_backend),
+                            None,
+                        )
+                        if backend_meta is not None:
+                            new_provider = backend_meta.get("provider", "") or ""
+                    changes.append(
+                        {
+                            "slot": slot,
+                            "child": child,
+                            "model": sel.model,
+                            "before": f"{sel.backend or '—'} / {sel.provider or '—'}",
+                            "after": f"{new_backend or '—'} / {new_provider or '—'}",
+                            "reason": "backend cannot serve model",
+                        }
                     )
-                    if backend_meta is not None:
-                        new_provider = backend_meta.get("provider", "") or ""
-                changes.append(
-                    {
-                        "slot": slot,
-                        "child": child,
-                        "model": sel.model,
-                        "before": f"{sel.backend or '—'} / {sel.provider or '—'}",
-                        "after": f"{new_backend or '—'} / {new_provider or '—'}",
-                        "reason": "backend cannot serve model",
-                    }
-                )
-                if not dry_run:
-                    children[child] = CapabilitySelection(
-                        backend=new_backend,
-                        provider=new_provider,
-                        model=sel.model,
-                        enabled=sel.enabled,
+                    if not dry_run:
+                        children[child] = CapabilitySelection(
+                            backend=new_backend,
+                            provider=new_provider,
+                            model=sel.model,
+                            enabled=sel.enabled,
+                        )
+                elif verdict == "unknown_model":
+                    changes.append(
+                        {
+                            "slot": slot,
+                            "child": child,
+                            "model": sel.model,
+                            "before": f"{sel.backend or '—'} / {sel.provider or '—'}",
+                            "after": "(cleared)",
+                            "reason": "model not in catalog",
+                        }
                     )
-            elif verdict == "unknown_model":
-                changes.append(
-                    {
-                        "slot": slot,
-                        "child": child,
-                        "model": sel.model,
-                        "before": f"{sel.backend or '—'} / {sel.provider or '—'}",
-                        "after": "(cleared)",
-                        "reason": "model not in catalog",
-                    }
-                )
-                if not dry_run:
-                    children[child] = CapabilitySelection(
-                        backend=sel.backend,
-                        provider=sel.provider,
-                        model="",
-                        enabled=False,
-                    )
+                    if not dry_run:
+                        children[child] = CapabilitySelection(
+                            backend=sel.backend,
+                            provider=sel.provider,
+                            model="",
+                            enabled=False,
+                        )
 
-    if not changes:
+        if not changes:
+            console.print(
+                f"[green]nothing to migrate[/green] — every selection in "
+                f"{capabilities_toml_path()} is legal against the current catalog."
+            )
+            raise typer.Exit(0)
+
+        table = Table(title="capabilities migrate")
+        table.add_column("slot", style="bold")
+        table.add_column("child")
+        table.add_column("model")
+        table.add_column("before")
+        table.add_column("after")
+        table.add_column("reason")
+        for c in changes:
+            table.add_row(c["slot"], c["child"], c["model"], c["before"], c["after"], c["reason"])
+        console.print(table)
+
+        if dry_run:
+            console.print(
+                f"\n[yellow]--dry-run[/yellow] — {len(changes)} selection(s) "
+                f"would be rewritten in {capabilities_toml_path()}."
+            )
+            raise typer.Exit(0)
+
+        save_capabilities_config(cfg)
         console.print(
-            f"[green]nothing to migrate[/green] — every selection in "
-            f"{capabilities_toml_path()} is legal against the current catalog."
+            f"\n[green]migrated[/green] {len(changes)} selection(s) in {capabilities_toml_path()}."
         )
-        raise typer.Exit(0)
-
-    table = Table(title="capabilities migrate")
-    table.add_column("slot", style="bold")
-    table.add_column("child")
-    table.add_column("model")
-    table.add_column("before")
-    table.add_column("after")
-    table.add_column("reason")
-    for c in changes:
-        table.add_row(c["slot"], c["child"], c["model"], c["before"], c["after"], c["reason"])
-    console.print(table)
-
-    if dry_run:
-        console.print(
-            f"\n[yellow]--dry-run[/yellow] — {len(changes)} selection(s) "
-            f"would be rewritten in {capabilities_toml_path()}."
-        )
-        raise typer.Exit(0)
-
-    save_capabilities_config(cfg)
-    console.print(
-        f"\n[green]migrated[/green] {len(changes)} selection(s) in {capabilities_toml_path()}."
-    )

--- a/src/hal0/cli/registry_commands.py
+++ b/src/hal0/cli/registry_commands.py
@@ -46,6 +46,8 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from hal0.registry.store import registry_write_lock
+
 console = Console()
 
 app = typer.Typer(
@@ -138,33 +140,39 @@ def _atomic_copy(source: Path, dest: Path) -> None:
     mid-copy never leaves a partial ``registry.toml`` at the canonical
     path — which would brick every registry consumer until the
     operator manually rolls back.
+
+    MR-5: takes the same cross-process sidecar flock as the store's
+    mutators, so ``hal0 registry import`` cannot interleave its
+    ``os.replace`` with an in-flight API write and silently clobber a
+    just-added row.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_str = tempfile.mkstemp(
-        prefix=f".{dest.name}.",
-        suffix=".tmp",
-        dir=dest.parent,
-    )
-    tmp_path = Path(tmp_str)
-    try:
+    with registry_write_lock(dest.parent):
+        fd, tmp_str = tempfile.mkstemp(
+            prefix=f".{dest.name}.",
+            suffix=".tmp",
+            dir=dest.parent,
+        )
+        tmp_path = Path(tmp_str)
         try:
-            with (
-                open(source, "rb") as src,
-                os.fdopen(fd, "wb") as dst,
-            ):
-                shutil.copyfileobj(src, dst)
-                dst.flush()
-                os.fsync(dst.fileno())
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.close(fd)
-            raise
-        os.replace(tmp_path, dest)
-        tmp_path = None  # type: ignore[assignment]
-    finally:
-        if tmp_path is not None:
-            with contextlib.suppress(OSError):
-                tmp_path.unlink(missing_ok=True)
+            try:
+                with (
+                    open(source, "rb") as src,
+                    os.fdopen(fd, "wb") as dst,
+                ):
+                    shutil.copyfileobj(src, dst)
+                    dst.flush()
+                    os.fsync(dst.fileno())
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    os.close(fd)
+                raise
+            os.replace(tmp_path, dest)
+            tmp_path = None  # type: ignore[assignment]
+        finally:
+            if tmp_path is not None:
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
 
 
 @app.command("import")

--- a/src/hal0/config/locking.py
+++ b/src/hal0/config/locking.py
@@ -1,0 +1,111 @@
+"""Cross-process advisory file locking for config read-modify-write (SC-10).
+
+Several config files — most notably ``/etc/hal0/capabilities.toml`` and its
+paired ``slots/*.toml`` — are read-modify-write surfaces touched by more than
+one cooperating hal0 process (the API and the ``hal0`` CLI). Two concurrent
+writers otherwise interleave ``read -> modify -> write`` and clobber each
+other's change (the classic lost update).
+
+:func:`file_lock` generalises the ``hal0.mcp.installed._registry_lock`` pattern
+into one shared helper: it holds an exclusive advisory ``fcntl.flock`` on a
+sibling ``<target>.lock`` for the duration of the ``with`` body. Every writer
+of a given file must lock the SAME path — ``flock`` is advisory and per-inode,
+so serialization only holds when all cooperating writers point at one lock
+file.
+
+Two properties the callers rely on:
+
+  - **Cross-process exclusion.** ``flock(LOCK_EX)`` blocks a second process
+    until the first releases. Advisory locks are honoured only by processes
+    that also call :func:`file_lock`, which is exactly the API + CLI surface
+    the finding names.
+  - **Same-thread re-entrancy.** ``flock`` on a fresh descriptor is NOT
+    recursive: two open descriptions of the same inode contend even within one
+    process, so a naive nested acquire would self-deadlock. A locked outer
+    writer (``initialize_if_missing``) legitimately calls a locked inner writer
+    (``auto_migrate_capabilities_file``); to keep that safe we track a
+    per-thread recursion depth and only take/release the OS lock on the
+    outermost acquire. Different threads still serialize — each takes its own
+    descriptor and the second ``flock`` blocks.
+
+Graceful degradation: on a platform without ``fcntl`` (e.g. Windows) the lock
+becomes a best-effort no-op so the config paths still function, matching the
+advisory nature of the primitive.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX platforms
+    fcntl = None  # type: ignore[assignment]
+
+# Per-thread recursion depth keyed by lock-file path. Only the outermost
+# acquire in a thread touches the OS lock; nested acquires are cheap no-ops.
+_reentry = threading.local()
+
+
+def _depths() -> dict[str, int]:
+    depths: dict[str, int] | None = getattr(_reentry, "depths", None)
+    if depths is None:
+        depths = {}
+        _reentry.depths = depths
+    return depths
+
+
+def lock_path_for(target: Path | str) -> Path:
+    """Return the sibling ``.lock`` path :func:`file_lock` locks for ``target``."""
+    return Path(f"{os.fspath(target)}.lock")
+
+
+@contextlib.contextmanager
+def file_lock(target: Path | str) -> Iterator[None]:
+    """Hold an exclusive advisory lock serializing an RMW on ``target``.
+
+    Locks the sibling ``<target>.lock`` (created on demand). Re-entrant within
+    the same thread; serializing across threads and processes. See the module
+    docstring for the full contract.
+    """
+    lock_path = lock_path_for(target)
+    key = str(lock_path)
+    depths = _depths()
+
+    if depths.get(key, 0) > 0:
+        # Re-entrant acquire in this thread — the OS lock is already held.
+        depths[key] += 1
+        try:
+            yield
+        finally:
+            depths[key] -= 1
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if fcntl is None:  # pragma: no cover - non-POSIX platforms
+        # No advisory locking available: degrade to a no-op guard so the
+        # config paths still work (single-process installs are unaffected).
+        depths[key] = 1
+        try:
+            yield
+        finally:
+            depths.pop(key, None)
+        return
+
+    with open(lock_path, "w") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        depths[key] = 1
+        try:
+            yield
+        finally:
+            depths.pop(key, None)
+            with contextlib.suppress(OSError):
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+__all__ = ["file_lock", "lock_path_for"]

--- a/src/hal0/dispatcher/_capability_resolve.py
+++ b/src/hal0/dispatcher/_capability_resolve.py
@@ -1,0 +1,243 @@
+"""Capability/path routing heuristics — dispatcher resolution Step 4.
+
+Extracted from :mod:`hal0.dispatcher.router` (finding DR-12) so the router
+module no longer mixes the last-resort path/name heuristics with the core
+registry/passthrough resolution logic.
+
+This is a **leaf** module: it depends only on :mod:`hal0.errors`,
+:mod:`hal0.slots.manager` (``SLOT_ALIASES``) and
+:mod:`hal0.upstreams.registry` — never on ``router`` — so ``router`` can
+``from hal0.dispatcher._capability_resolve import resolve_by_capability``
+back without creating an import cycle.  ``router`` re-exports
+:func:`resolve_by_capability` and :class:`LegacyResolutionFailed` verbatim
+(and keeps them in ``__all__``), so every existing call site and importer
+keeps working unchanged.  Routing behaviour is preserved verbatim — this is
+a lift-and-shift, not a logic change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hal0.errors import Hal0Error
+from hal0.slots.manager import SLOT_ALIASES
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+# Path default used only for routing — never written back into the body.
+# Mirrors haloai lib/dispatcher.py:_DEFAULT_MODEL.
+# ADR-0023: the default/fallback LLM anchor is the `agent` slot (was `chat`).
+# Kept here (a leaf module) and imported by ``router`` so the two resolution
+# steps that reference it share a single source without an import cycle.
+_DEFAULT_MODEL = "agent"
+
+
+# ── Capability/path routing constants ─────────────────────────────────────────
+#
+# Path + model-name heuristics that route a request to a slot when the registry
+# and warm caches have nothing to say (the last-resort dispatch step).  Absorbed
+# from the retired ``dispatcher.proxy`` module (ported from haloai
+# ``lib/proxy.py``); operator muscle memory ("slot named coding-1m" addressing)
+# and the four capability endpoints (embed/rerank/tts/image — whose model names
+# the registry doesn't bind) depend on these heuristics.
+
+# Path fragments that pin a request to the embed slot regardless of model.
+# Mirrors haloai lib/proxy.py:51-58 (embeddings only; rerank split to its own
+# dedicated slot in Phase C — see _RERANK_PATHS below).
+_EMBED_PATHS = ("/embeddings",)
+
+# Path fragments that pin a request to the dedicated rerank slot (vulkan
+# llama-server with --reranking, port 8083, added Phase C task C5).
+# Both /rerankings (hal0's public OpenAI-compat route) and /rerank (llama-
+# server's native endpoint shape) route here; the dispatcher applies
+# _UPSTREAM_PATH_REWRITES to translate /v1/rerankings → /v1/rerank on the
+# outgoing upstream request (llama-server serves POST /rerank natively, not
+# /rerankings).
+_RERANK_PATHS = ("/rerankings", "/rerank")
+
+# Path fragments that pin a request to the TTS slot (kokoro container).
+# Model-id matching is unreliable — the kokoro container advertises "kokoro"
+# while clients send "kokoro-v1", "tts", etc. — so we route by path instead.
+# Only /audio/speech (synthesis); /audio/transcriptions is STT, not TTS.
+_TTS_PATHS = ("/audio/speech",)
+
+# Path fragments that pin a request to the image-gen slot (ComfyUI). The
+# OpenAI shape is `/v1/images/generations` — when that hits this step we don't
+# want it routed to the chat slot.
+_IMAGE_PATHS = ("/images/generations", "/images/edits", "/images/variations")
+
+# Substrings in the model name that pin to known slot roles.  Order matters:
+# the ":" (FLM tag-style id) check runs before the bare-name substring checks
+# so that "qwen3.5:embed" still routes to the NPU rather than to embed.
+_EMBED_NAME_HINTS = ("embed", "rerank")
+
+# Model id prefixes that pin to the image-gen slot. Curated catalogue uses
+# these prefixes (sdxl-turbo, sd-1.5-..., flux-*). Anything matching
+# these in the bare-model lookup goes to the `img` slot before slot-name
+# resolution kicks in.
+_IMAGE_NAME_PREFIXES = ("sdxl", "sd-1.5", "sd15", "flux")
+
+
+# ── Typed error ───────────────────────────────────────────────────────────────
+
+
+class LegacyResolutionFailed(Hal0Error):
+    """Raised when the capability/path heuristics find no slot to serve a request.
+
+    Carries a ``dispatch.legacy_unresolved`` code so the structured error
+    envelope distinguishes "nothing in registry AND nothing in capability
+    routing" from "registry binding pointed at an unknown upstream."  The
+    code string is part of the error contract (clients/dashboard key on it),
+    so it is preserved verbatim from the retired ``dispatcher.proxy`` module.
+
+    ``dispatch()`` wraps this into a client-facing ``NoRouteFound``
+    (404) — callers never see ``dispatch.legacy_unresolved`` directly, only
+    via ``details.legacy_error``.
+    """
+
+    code = "dispatch.legacy_unresolved"
+    status = 404
+
+
+def resolve_by_capability(  # TIER1
+    path: str,
+    body: dict[str, Any] | None,
+    upstreams: UpstreamRegistry,
+) -> Upstream:
+    """Resolve a request to a slot Upstream using path+name heuristics.
+
+    The last-resort dispatch step (Step 4): used when the registry and warm
+    caches have nothing to say.  Absorbed verbatim from the retired
+    ``dispatcher.proxy.resolve_slot`` (haloai ``lib/proxy.py``); returns a
+    typed :class:`Upstream` (or raises a typed error) instead of the old
+    ``(slot_name, port)`` tuple.
+
+    Resolution rules (in order):
+      1. ``/embeddings`` in path → ``embed`` slot.
+      2. ``/rerankings`` or ``/rerank`` in path → ``rerank`` slot (Phase C;
+         outgoing path is rewritten to ``/v1/rerank`` by the dispatcher —
+         llama-server's native reranking endpoint is ``POST /rerank``, not
+         ``/rerankings``).
+      3. ``/audio/speech`` in path → ``tts`` slot (kokoro; model-id unreliable).
+      4. ``/images/...`` in path → ``img`` slot (ComfyUI).
+
+    Path-pinned candidates (rules 1-4, plus the rule-6 model-prefix pin)
+    accept either a local ``kind="slot"`` upstream or a container-backed
+    ``kind="remote"`` upstream whose ``slot_name`` matches the candidate
+    (container slots register as remotes via
+    ``SlotManager._register_container_upstream``, #656).  All other rules
+    require ``kind="slot"``.
+      5. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
+      6. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
+      7. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
+      8. Model id exactly matches a registered slot upstream name (other
+         than the default ``agent`` anchor) → that slot.  Back-compat alias
+         (``agent-hermes`` → ``agent``) is resolved first.
+      9. Fallback → ``agent`` slot (ADR-0023 default anchor).
+
+    Args:
+        path:       The original request path (e.g. "/v1/chat/completions").
+        body:       Parsed JSON body dict (may be None for GETs).
+        upstreams:  Registry to resolve slot names against.
+
+    Returns:
+        An :class:`Upstream` representing the slot to forward to.
+
+    Raises:
+        LegacyResolutionFailed: If the heuristics select a slot name but no
+            matching slot Upstream is registered.  Carries a
+            ``dispatch.legacy_unresolved`` code via the typed Hal0Error envelope.
+    """
+    candidate: str | None = None
+    # Path-pinned candidates ("route purely by path") may also resolve to a
+    # container-backed kind="remote" upstream for that slot — container slots
+    # register via SlotManager._register_container_upstream as kind="remote"
+    # with slot_name set (#656), and a registered container remote for a
+    # path-pinned slot is exactly the right target.  Model-name rules keep
+    # the strict kind=="slot" gate.
+    path_pinned = False
+
+    # Rule 1 — path-based pin (embeddings → embed slot).
+    if any(frag in path for frag in _EMBED_PATHS):
+        candidate = "embed"
+        path_pinned = True
+    # Rule 2 — rerank path pin (/rerankings or /rerank → rerank slot, Phase C).
+    # The public route is /v1/rerankings; the upstream rewrite
+    # (/v1/rerankings → /v1/rerank) is applied by the dispatcher before
+    # forwarding (llama-server's native endpoint is POST /rerank).
+    elif any(frag in path for frag in _RERANK_PATHS):
+        candidate = "rerank"
+        path_pinned = True
+    # Rule 3 — TTS path pin (/audio/speech → tts slot).
+    # Model-id matching is unreliable for kokoro (server advertises "kokoro",
+    # clients send "kokoro-v1"/"tts"/etc.) so we route purely by path.
+    elif any(frag in path for frag in _TTS_PATHS):
+        candidate = "tts"
+        path_pinned = True
+    # Rule 4 — image-generation path pins to the img slot.  img is a
+    # container slot post-Phase-D (ComfyUI via podman, registers as a
+    # kind="remote" upstream) — same container-remote acceptance as the
+    # embed/tts/rerank path pins.
+    elif any(frag in path for frag in _IMAGE_PATHS):
+        candidate = "img"
+        path_pinned = True
+    elif body:
+        model = body.get("model", "")
+        if isinstance(model, str) and model:
+            m = model.lower()
+            # Rule 5 — FLM tag format "name:tag" routes to NPU.
+            if ":" in model:
+                candidate = "npu"
+            # Rule 6 — image-gen model id prefix pin (sdxl-/sd-1.5-/flux-).
+            # path_pinned here means "deterministically pinned": the curated
+            # sdxl-/sd-1.5-/flux- prefixes are exact catalogue prefixes, the
+            # same trust level as a path pin — so the container-backed img
+            # remote must qualify here too (Phase D).
+            elif any(m.startswith(prefix) for prefix in _IMAGE_NAME_PREFIXES):
+                candidate = "img"
+                path_pinned = True
+            # Rule 7 — name-substring pin (embed/rerank → embed slot).
+            elif any(hint in m for hint in _EMBED_NAME_HINTS):
+                candidate = "embed"
+            else:
+                # Rule 8 — explicit slot-name addressing.
+                # Resolve back-compat aliases (agent-hermes→agent) before the
+                # upstream lookup so old callers still land correctly.
+                m_resolved = SLOT_ALIASES.get(m, m)
+                slot_match = upstreams.get(m_resolved)
+                # ADR-0023: the anchor (`agent`) is reached via the rule-9 default,
+                # not explicit name matching here — guard against double-routing.
+                if (
+                    slot_match is not None
+                    and slot_match.kind == "slot"
+                    and m_resolved != _DEFAULT_MODEL
+                ):
+                    candidate = m_resolved
+
+    # Rule 9 — fallback default slot (ADR-0023: the `agent` anchor).
+    if candidate is None:
+        candidate = _DEFAULT_MODEL
+
+    upstream = upstreams.get(candidate)
+    # Acceptance: a local slot upstream always qualifies.  For PATH-pinned
+    # candidates only, a container-backed remote (kind="remote" with
+    # slot_name == candidate — how Step 0 preemption identifies container
+    # slots) qualifies too: kokoro's tts container registers as a remote, so
+    # the old kind=="slot"-only gate sent /audio/speech to NoRouteFound and
+    # a dead legacy tts slot.  Genuine external remotes (slot_name=None)
+    # are still rejected.
+    acceptable = upstream is not None and (
+        upstream.kind == "slot"
+        or (path_pinned and upstream.kind == "remote" and upstream.slot_name == candidate)
+    )
+    if upstream is None or not acceptable:
+        raise LegacyResolutionFailed(
+            f"capability routing selected slot {candidate!r} but no matching slot upstream is registered",
+            details={"slot": candidate, "path": path},
+        )
+    return upstream
+
+
+__all__ = [
+    "LegacyResolutionFailed",
+    "resolve_by_capability",
+]

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -46,9 +46,13 @@ import httpx
 import structlog
 from fastapi.responses import Response, StreamingResponse
 
+from hal0.dispatcher._capability_resolve import (
+    _DEFAULT_MODEL,
+    LegacyResolutionFailed,
+    resolve_by_capability,
+)
 from hal0.dispatcher.single_flight import SingleFlightGroup
 from hal0.errors import Hal0Error
-from hal0.slots.manager import SLOT_ALIASES
 from hal0.slots.state import SlotState
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
@@ -91,8 +95,9 @@ log = structlog.get_logger("hal0-dispatch")
 #      readiness gate (``_check_slot_ready_for_dispatch``) and the SERVING wrap
 #      must be skipped for it — otherwise a populated model cache would route a
 #      chat request to the composite and immediately 503 with
-#      ``slot 'hal0' is offline`` (the gate calls ``_current_state('hal0')``
-#      which finds no slot and returns OFFLINE).
+#      ``slot 'hal0' is offline`` (the gate calls
+#      ``SlotManager.is_ready_for_dispatch('hal0')``/``state('hal0')`` which
+#      find no slot and return OFFLINE).
 #   2. Its registered ``url`` is hal0-api's OWN ``/v1`` surface
 #      (``127.0.0.1:8080/v1``). That value is deliberate so the ``/v1/models``
 #      aggregator can short-circuit it instead of recursing over HTTP. But it
@@ -146,9 +151,9 @@ _DEAD_PORT_TRANSPORT_ERRORS = (
 )
 
 # Path defaults used only for routing — never written back into the body.
-# Mirrors haloai lib/dispatcher.py:_DEFAULT_MODEL etc.
-# ADR-0023: the default/fallback LLM anchor is the `agent` slot (was `chat`).
-_DEFAULT_MODEL = "agent"
+# Mirrors haloai lib/dispatcher.py:_DEFAULT_MODEL etc.  ``_DEFAULT_MODEL`` (the
+# ADR-0023 `agent` anchor) now lives in ``dispatcher._capability_resolve`` and
+# is imported above so the router and the capability step share one source.
 _EMBED_DEFAULT = "embed"
 # Phase C: /rerank paths now route to a dedicated rerank slot (vulkan llama-
 # server with --reranking, port 8083). Previously this pointed at "embed".
@@ -184,50 +189,13 @@ _UPSTREAM_PATH_REWRITES: dict[str, str] = {
 }
 
 
-# ── Capability/path routing constants ─────────────────────────────────────────
-#
-# Path + model-name heuristics that route a request to a slot when the registry
-# and warm caches have nothing to say (the last-resort dispatch step).  Absorbed
-# from the retired ``dispatcher.proxy`` module (ported from haloai
-# ``lib/proxy.py``); operator muscle memory ("slot named coding-1m" addressing)
-# and the four capability endpoints (embed/rerank/tts/image — whose model names
-# the registry doesn't bind) depend on these heuristics.
-
-# Path fragments that pin a request to the embed slot regardless of model.
-# Mirrors haloai lib/proxy.py:51-58 (embeddings only; rerank split to its own
-# dedicated slot in Phase C — see _RERANK_PATHS below).
-_EMBED_PATHS = ("/embeddings",)
-
-# Path fragments that pin a request to the dedicated rerank slot (vulkan
-# llama-server with --reranking, port 8083, added Phase C task C5).
-# Both /rerankings (hal0's public OpenAI-compat route) and /rerank (llama-
-# server's native endpoint shape) route here; the dispatcher applies
-# _UPSTREAM_PATH_REWRITES to translate /v1/rerankings → /v1/rerank on the
-# outgoing upstream request (llama-server serves POST /rerank natively, not
-# /rerankings).
-_RERANK_PATHS = ("/rerankings", "/rerank")
-
-# Path fragments that pin a request to the TTS slot (kokoro container).
-# Model-id matching is unreliable — the kokoro container advertises "kokoro"
-# while clients send "kokoro-v1", "tts", etc. — so we route by path instead.
-# Only /audio/speech (synthesis); /audio/transcriptions is STT, not TTS.
-_TTS_PATHS = ("/audio/speech",)
-
-# Path fragments that pin a request to the image-gen slot (ComfyUI). The
-# OpenAI shape is `/v1/images/generations` — when that hits this step we don't
-# want it routed to the chat slot.
-_IMAGE_PATHS = ("/images/generations", "/images/edits", "/images/variations")
-
-# Substrings in the model name that pin to known slot roles.  Order matters:
-# the ":" (FLM tag-style id) check runs before the bare-name substring checks
-# so that "qwen3.5:embed" still routes to the NPU rather than to embed.
-_EMBED_NAME_HINTS = ("embed", "rerank")
-
-# Model id prefixes that pin to the image-gen slot. Curated catalogue uses
-# these prefixes (sdxl-turbo, sd-1.5-..., flux-*). Anything matching
-# these in the bare-model lookup goes to the `img` slot before slot-name
-# resolution kicks in.
-_IMAGE_NAME_PREFIXES = ("sdxl", "sd-1.5", "sd15", "flux")
+# NOTE: the capability/path routing constants (``_EMBED_PATHS``,
+# ``_RERANK_PATHS``, ``_TTS_PATHS``, ``_IMAGE_PATHS``, ``_EMBED_NAME_HINTS``,
+# ``_IMAGE_NAME_PREFIXES``) and the ``resolve_by_capability`` step (Step 4) they
+# feed now live in ``hal0.dispatcher._capability_resolve`` (finding DR-12).
+# ``resolve_by_capability`` and ``LegacyResolutionFailed`` are imported above and
+# re-exported here (see ``__all__``) so existing call sites and importers are
+# unaffected.
 
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
@@ -320,22 +288,9 @@ class SlotLoadFailed(DispatchError):
     status = 502
 
 
-class LegacyResolutionFailed(Hal0Error):
-    """Raised when the capability/path heuristics find no slot to serve a request.
-
-    Carries a ``dispatch.legacy_unresolved`` code so the structured error
-    envelope distinguishes "nothing in registry AND nothing in capability
-    routing" from "registry binding pointed at an unknown upstream."  The
-    code string is part of the error contract (clients/dashboard key on it),
-    so it is preserved verbatim from the retired ``dispatcher.proxy`` module.
-
-    ``dispatch()`` wraps this into a client-facing :class:`NoRouteFound`
-    (404) — callers never see ``dispatch.legacy_unresolved`` directly, only
-    via ``details.legacy_error``.
-    """
-
-    code = "dispatch.legacy_unresolved"
-    status = 404
+# NOTE: ``LegacyResolutionFailed`` (raised by the capability/path Step 4) now
+# lives in ``hal0.dispatcher._capability_resolve`` and is imported + re-exported
+# above (finding DR-12).
 
 
 # ── UpstreamCall ──────────────────────────────────────────────────────────────
@@ -1457,145 +1412,6 @@ def _join_url(upstream_url: str, request_path: str) -> str:
 def _filter_response_headers(headers: httpx.Headers) -> dict[str, str]:
     """Drop hop-by-hop and length headers so Starlette can recompute them."""
     return {k: v for k, v in headers.items() if k.lower() not in _HOP_BY_HOP_RESPONSE_HEADERS}
-
-
-def resolve_by_capability(  # TIER1
-    path: str,
-    body: dict[str, Any] | None,
-    upstreams: UpstreamRegistry,
-) -> Upstream:
-    """Resolve a request to a slot Upstream using path+name heuristics.
-
-    The last-resort dispatch step (Step 4): used when the registry and warm
-    caches have nothing to say.  Absorbed verbatim from the retired
-    ``dispatcher.proxy.resolve_slot`` (haloai ``lib/proxy.py``); returns a
-    typed :class:`Upstream` (or raises a typed error) instead of the old
-    ``(slot_name, port)`` tuple.
-
-    Resolution rules (in order):
-      1. ``/embeddings`` in path → ``embed`` slot.
-      2. ``/rerankings`` or ``/rerank`` in path → ``rerank`` slot (Phase C;
-         outgoing path is rewritten to ``/v1/rerank`` by the dispatcher —
-         llama-server's native reranking endpoint is ``POST /rerank``, not
-         ``/rerankings``).
-      3. ``/audio/speech`` in path → ``tts`` slot (kokoro; model-id unreliable).
-      4. ``/images/...`` in path → ``img`` slot (ComfyUI).
-
-    Path-pinned candidates (rules 1-4, plus the rule-6 model-prefix pin)
-    accept either a local ``kind="slot"`` upstream or a container-backed
-    ``kind="remote"`` upstream whose ``slot_name`` matches the candidate
-    (container slots register as remotes via
-    ``SlotManager._register_container_upstream``, #656).  All other rules
-    require ``kind="slot"``.
-      5. Model id contains ``:`` (FLM tag-style) → ``npu`` slot.
-      6. Model id starts with ``sdxl``/``sd-1.5``/``sd15``/``flux`` → ``img`` slot.
-      7. Model id contains ``embed`` or ``rerank`` substring → ``embed`` slot.
-      8. Model id exactly matches a registered slot upstream name (other
-         than the default ``agent`` anchor) → that slot.  Back-compat alias
-         (``agent-hermes`` → ``agent``) is resolved first.
-      9. Fallback → ``agent`` slot (ADR-0023 default anchor).
-
-    Args:
-        path:       The original request path (e.g. "/v1/chat/completions").
-        body:       Parsed JSON body dict (may be None for GETs).
-        upstreams:  Registry to resolve slot names against.
-
-    Returns:
-        An :class:`Upstream` representing the slot to forward to.
-
-    Raises:
-        LegacyResolutionFailed: If the heuristics select a slot name but no
-            matching slot Upstream is registered.  Carries a
-            ``dispatch.legacy_unresolved`` code via the typed Hal0Error envelope.
-    """
-    candidate: str | None = None
-    # Path-pinned candidates ("route purely by path") may also resolve to a
-    # container-backed kind="remote" upstream for that slot — container slots
-    # register via SlotManager._register_container_upstream as kind="remote"
-    # with slot_name set (#656), and a registered container remote for a
-    # path-pinned slot is exactly the right target.  Model-name rules keep
-    # the strict kind=="slot" gate.
-    path_pinned = False
-
-    # Rule 1 — path-based pin (embeddings → embed slot).
-    if any(frag in path for frag in _EMBED_PATHS):
-        candidate = "embed"
-        path_pinned = True
-    # Rule 2 — rerank path pin (/rerankings or /rerank → rerank slot, Phase C).
-    # The public route is /v1/rerankings; the upstream rewrite
-    # (/v1/rerankings → /v1/rerank) is applied by the dispatcher before
-    # forwarding (llama-server's native endpoint is POST /rerank).
-    elif any(frag in path for frag in _RERANK_PATHS):
-        candidate = "rerank"
-        path_pinned = True
-    # Rule 3 — TTS path pin (/audio/speech → tts slot).
-    # Model-id matching is unreliable for kokoro (server advertises "kokoro",
-    # clients send "kokoro-v1"/"tts"/etc.) so we route purely by path.
-    elif any(frag in path for frag in _TTS_PATHS):
-        candidate = "tts"
-        path_pinned = True
-    # Rule 4 — image-generation path pins to the img slot.  img is a
-    # container slot post-Phase-D (ComfyUI via podman, registers as a
-    # kind="remote" upstream) — same container-remote acceptance as the
-    # embed/tts/rerank path pins.
-    elif any(frag in path for frag in _IMAGE_PATHS):
-        candidate = "img"
-        path_pinned = True
-    elif body:
-        model = body.get("model", "")
-        if isinstance(model, str) and model:
-            m = model.lower()
-            # Rule 5 — FLM tag format "name:tag" routes to NPU.
-            if ":" in model:
-                candidate = "npu"
-            # Rule 6 — image-gen model id prefix pin (sdxl-/sd-1.5-/flux-).
-            # path_pinned here means "deterministically pinned": the curated
-            # sdxl-/sd-1.5-/flux- prefixes are exact catalogue prefixes, the
-            # same trust level as a path pin — so the container-backed img
-            # remote must qualify here too (Phase D).
-            elif any(m.startswith(prefix) for prefix in _IMAGE_NAME_PREFIXES):
-                candidate = "img"
-                path_pinned = True
-            # Rule 7 — name-substring pin (embed/rerank → embed slot).
-            elif any(hint in m for hint in _EMBED_NAME_HINTS):
-                candidate = "embed"
-            else:
-                # Rule 8 — explicit slot-name addressing.
-                # Resolve back-compat aliases (agent-hermes→agent) before the
-                # upstream lookup so old callers still land correctly.
-                m_resolved = SLOT_ALIASES.get(m, m)
-                slot_match = upstreams.get(m_resolved)
-                # ADR-0023: the anchor (`agent`) is reached via the rule-9 default,
-                # not explicit name matching here — guard against double-routing.
-                if (
-                    slot_match is not None
-                    and slot_match.kind == "slot"
-                    and m_resolved != _DEFAULT_MODEL
-                ):
-                    candidate = m_resolved
-
-    # Rule 9 — fallback default slot (ADR-0023: the `agent` anchor).
-    if candidate is None:
-        candidate = _DEFAULT_MODEL
-
-    upstream = upstreams.get(candidate)
-    # Acceptance: a local slot upstream always qualifies.  For PATH-pinned
-    # candidates only, a container-backed remote (kind="remote" with
-    # slot_name == candidate — how Step 0 preemption identifies container
-    # slots) qualifies too: kokoro's tts container registers as a remote, so
-    # the old kind=="slot"-only gate sent /audio/speech to NoRouteFound and
-    # a dead legacy tts slot.  Genuine external remotes (slot_name=None)
-    # are still rejected.
-    acceptable = upstream is not None and (
-        upstream.kind == "slot"
-        or (path_pinned and upstream.kind == "remote" and upstream.slot_name == candidate)
-    )
-    if upstream is None or not acceptable:
-        raise LegacyResolutionFailed(
-            f"capability routing selected slot {candidate!r} but no matching slot upstream is registered",
-            details={"slot": candidate, "path": path},
-        )
-    return upstream
 
 
 __all__ = [

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -38,7 +38,7 @@ import httpx
 from hal0.config import paths
 from hal0.errors import Hal0Error
 from hal0.registry.model import Model
-from hal0.registry.store import ModelNotFound, ModelRegistry
+from hal0.registry.store import ModelNotFound, ModelRegistry, _fsync_dir
 
 log = logging.getLogger(__name__)
 
@@ -366,6 +366,7 @@ def persist_pull_job(job: PullJob) -> None:
                 f.flush()
                 os.fsync(f.fileno())
             os.replace(tmp_path, path)
+            _fsync_dir(path.parent)
             tmp_path = None
         finally:
             if tmp_path is not None:

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -375,6 +375,44 @@ def persist_pull_job(job: PullJob) -> None:
         log.warning("model.pull_job_persist_failed model_id=%s error=%s", job.model_id, exc)
 
 
+def sweep_pull_jobs(max_age_days: int = 14) -> int:
+    """Garbage-collect stale terminal pull-job snapshots (#MR-8).
+
+    Reap on-disk snapshots whose ``state`` is terminal (``completed`` /
+    ``failed`` / ``cancelled``) and whose file mtime is older than
+    ``max_age_days``. Non-terminal snapshots (``queued`` / ``running``) are
+    preserved regardless of age so an in-flight or restart-surviving pull is
+    never dropped. Called best-effort from the API lifespan on startup.
+
+    Every step is fail-soft: a single unreadable / malformed / undeletable
+    file is skipped so one bad snapshot never aborts the whole sweep. A
+    missing jobs directory is a no-op. Returns the number of files removed.
+    """
+    jobs_dir = _pull_jobs_dir()
+    if not jobs_dir.is_dir():
+        return 0
+
+    terminal = {"completed", "failed", "cancelled"}
+    cutoff = max_age_days * 86400
+    now = time.time()
+    removed = 0
+    for path in jobs_dir.glob("*.json"):
+        try:
+            if now - path.stat().st_mtime <= cutoff:
+                continue
+            with path.open(encoding="utf-8") as f:
+                state = json.load(f).get("state")
+            if state not in terminal:
+                continue
+            path.unlink(missing_ok=True)
+            removed += 1
+        except (OSError, ValueError):
+            # ValueError covers json.JSONDecodeError; OSError covers stat /
+            # read / unlink failures. Skip this file, keep sweeping.
+            continue
+    return removed
+
+
 async def run_pull(
     job: PullJob,
     *,
@@ -920,4 +958,5 @@ __all__ = [
     "run_flm_pull",
     "run_pull",
     "sweep_orphaned_partials",
+    "sweep_pull_jobs",
 ]

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -268,6 +268,38 @@ def _tmp_dir() -> Path:
     return _pull_root() / ".tmp"
 
 
+_PARTIAL_MAX_AGE_S: float = 24 * 3600  # reap .part files idle > 24h
+
+
+def sweep_orphaned_partials(max_age_s: float = _PARTIAL_MAX_AGE_S) -> int:
+    """Delete stale ``*.part`` staging files left by SIGKILL/OOM mid-pull.
+
+    Best-effort, fail-soft. Only removes ``*.part`` files whose mtime is
+    older than ``max_age_s`` so a concurrently-downloading partial (whose
+    mtime advances as it grows) is never reaped. Returns count removed.
+    """
+    tmp_dir = _tmp_dir()
+    removed = 0
+    try:
+        entries = list(tmp_dir.glob("*.part"))
+    except OSError:
+        return 0
+    now = time.time()
+    for p in entries:
+        try:
+            if not p.is_file():
+                continue
+            if (now - p.stat().st_mtime) < max_age_s:
+                continue
+            p.unlink(missing_ok=True)
+            removed += 1
+        except OSError as exc:
+            log.warning("model.partial_sweep_failed path=%s error=%s", p, exc)
+    if removed:
+        log.info("model.partial_sweep removed=%d dir=%s", removed, tmp_dir)
+    return removed
+
+
 def hf_download_url(repo: str, filename: str, revision: str = "main") -> str:
     """Build the canonical HuggingFace download URL.
 
@@ -887,4 +919,5 @@ __all__ = [
     "pull_job_file",
     "run_flm_pull",
     "run_pull",
+    "sweep_orphaned_partials",
 ]

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -274,14 +274,18 @@ _PARTIAL_MAX_AGE_S: float = 24 * 3600  # reap .part files idle > 24h
 def sweep_orphaned_partials(max_age_s: float = _PARTIAL_MAX_AGE_S) -> int:
     """Delete stale ``*.part`` staging files left by SIGKILL/OOM mid-pull.
 
-    Best-effort, fail-soft. Only removes ``*.part`` files whose mtime is
-    older than ``max_age_s`` so a concurrently-downloading partial (whose
-    mtime advances as it grows) is never reaped. Returns count removed.
+    Best-effort, fail-soft. Only removes ``*.part`` files (and their
+    ``*.part.json`` resume sidecars) whose mtime is older than ``max_age_s``
+    so a concurrently-downloading partial (whose mtime advances as it grows)
+    is never reaped. Sidecars are swept too so a reaped-but-not-resumed
+    partial doesn't leave its sidecar lingering. Returns count removed.
     """
     tmp_dir = _tmp_dir()
     removed = 0
     try:
-        entries = list(tmp_dir.glob("*.part"))
+        # Both the partial and its resume sidecar (MR-7); once a .part is stale
+        # enough to reap, its resume coordinates are worthless too.
+        entries = list(tmp_dir.glob("*.part")) + list(tmp_dir.glob("*.part.json"))
     except OSError:
         return 0
     now = time.time()
@@ -566,7 +570,12 @@ async def run_pull(
     tmp_dir.mkdir(parents=True, exist_ok=True)
     # Deterministic staging name (MR-7) so a prior interrupted pull can be
     # found and resumed. The JSON sidecar next to it records the resume
-    # coordinates (url, etag, bytes-on-disk, total).
+    # coordinates (url, etag, bytes-on-disk, total). TRADEOFF: unlike the old
+    # random-tag name, this is not isolated across two concurrent pulls of the
+    # SAME model_id. In-process pulls are deduped by model_pull_jobs
+    # (routes/models.pull_model), so the only unguarded case is two SEPARATE
+    # processes pulling the identical id at once (rare — not an expected flow);
+    # resumability is worth that edge.
     sanitised = _sanitise_id(job.model_id)
     part = tmp_dir / f"{sanitised}.part"
     sidecar = tmp_dir / f"{sanitised}.part.json"

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -414,6 +414,117 @@ def sweep_pull_jobs(max_age_days: int = 14) -> int:
     return removed
 
 
+# ── resume / partial-download support (MR-7) ──────────────────────────────────
+#
+# A prior interrupted pull leaves a deterministic ``<id>.part`` in the staging
+# dir plus a ``<id>.part.json`` sidecar recording the resume coordinates. The
+# next ``run_pull`` re-reads the sidecar, re-hashes the on-disk prefix (stdlib
+# hashlib can't serialise/restore its state, so re-reading the local prefix is
+# the correctness-preserving way to keep the final SHA-256 exact), and issues a
+# ``Range`` request to fetch only the tail. Hash correctness is non-negotiable:
+# any doubt about the prefix (size mismatch, changed object, server ignoring the
+# Range) triggers a clean full restart, never a silent double-count.
+
+_CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+)", re.IGNORECASE)
+
+
+def _read_resume_sidecar(part: Path, sidecar: Path, url: str) -> dict[str, Any] | None:
+    """Return the resume metadata iff an on-disk partial is trustworthy.
+
+    Guards every assumption the resume relies on: both files present, valid
+    JSON, a positive recorded byte count, the same source url, and the recorded
+    byte count matching the actual ``.part`` size on disk. Any mismatch returns
+    ``None`` so the caller discards the stale partial and starts fresh.
+    """
+    if not (part.exists() and sidecar.exists()):
+        return None
+    try:
+        meta = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    have = meta.get("bytes")
+    if not isinstance(have, int) or have <= 0:
+        return None
+    if meta.get("url") != url:
+        return None
+    try:
+        if part.stat().st_size != have:
+            return None
+    except OSError:
+        return None
+    return meta
+
+
+def _discard_partial(part: Path, sidecar: Path) -> None:
+    """Remove the staging ``.part`` and its sidecar, ignoring absence/errors."""
+    with contextlib.suppress(OSError):
+        part.unlink(missing_ok=True)
+    with contextlib.suppress(OSError):
+        sidecar.unlink(missing_ok=True)
+
+
+def _write_resume_sidecar(
+    part: Path,
+    sidecar: Path,
+    *,
+    url: str,
+    etag: str | None,
+    total: int,
+) -> None:
+    """Persist resume coordinates next to a preserved ``.part`` (best-effort).
+
+    Records the *actual* on-disk byte count (not the in-memory counter) so the
+    next :func:`_read_resume_sidecar` probe — which compares against
+    ``part.stat().st_size`` — accepts it. A zero-length or missing partial is
+    not worth resuming, so it (and any stale sidecar) is discarded instead.
+    """
+    try:
+        have = part.stat().st_size
+    except OSError:
+        _discard_partial(part, sidecar)
+        return
+    if have <= 0:
+        _discard_partial(part, sidecar)
+        return
+    payload = {"url": url, "etag": etag, "bytes": have, "total": total}
+    with contextlib.suppress(OSError):
+        sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _parse_content_range_total(header: str | None, resume_from: int) -> int | None:
+    """Parse ``Content-Range: bytes <start>-<last>/<total>`` → total.
+
+    Returns ``None`` when the header is missing/unparseable or when the range
+    start disagrees with ``resume_from`` (a server sending from a different
+    offset than we requested would corrupt the hash — the caller must restart).
+    """
+    if not header:
+        return None
+    m = _CONTENT_RANGE_RE.match(header.strip())
+    if not m:
+        return None
+    start = int(m.group(1))
+    total = int(m.group(3))
+    if start != resume_from:
+        return None
+    return total
+
+
+def _rehash_prefix(part: Path, hasher: Any) -> int:
+    """Feed the on-disk prefix into ``hasher``; return the byte count read."""
+    total = 0
+    with open(part, "rb") as f:
+        while True:
+            block = f.read(_CHUNK_BYTES)
+            if not block:
+                break
+            hasher.update(block)
+            total += len(block)
+    return total
+
+
 async def run_pull(
     job: PullJob,
     *,
@@ -453,8 +564,12 @@ async def run_pull(
 
     tmp_dir = _tmp_dir()
     tmp_dir.mkdir(parents=True, exist_ok=True)
-    rand_tag = secrets.token_hex(4)
-    tmp_path = tmp_dir / f"{_sanitise_id(job.model_id)}.{rand_tag}.part"
+    # Deterministic staging name (MR-7) so a prior interrupted pull can be
+    # found and resumed. The JSON sidecar next to it records the resume
+    # coordinates (url, etag, bytes-on-disk, total).
+    sanitised = _sanitise_id(job.model_id)
+    part = tmp_dir / f"{sanitised}.part"
+    sidecar = tmp_dir / f"{sanitised}.part.json"
 
     hasher = hashlib.sha256()
     last_emit = time.monotonic()
@@ -465,86 +580,159 @@ async def run_pull(
             follow_redirects=True,
         )
 
+    # ── Resume probe (MR-7) ───────────────────────────────────────────────
+    # Only reuse an on-disk partial the sidecar vouches for; anything else is
+    # discarded so a stale/mismatched prefix can never corrupt the final hash.
+    resume_from = 0
+    resume_meta = _read_resume_sidecar(part, sidecar, url)
+    if resume_meta is not None:
+        resume_from = int(resume_meta["bytes"])
+        headers["Range"] = f"bytes={resume_from}-"
+        etag = resume_meta.get("etag")
+        if etag:
+            # If-Range forces a full 200 body when the object has changed,
+            # so we never stitch a fresh tail onto a stale prefix.
+            headers["If-Range"] = etag
+    else:
+        _discard_partial(part, sidecar)
+
+    installed = False
+    captured_etag: str | None = None
     try:
-        async with client.stream("GET", url, headers=headers) as resp:
-            if resp.status_code == 401 or resp.status_code == 403:
-                raise PullError(
-                    f"hugging face returned {resp.status_code} for {hf_repo}/{hf_file}"
-                    " (gated repo? set HF_TOKEN)",
-                    details={
-                        "status": resp.status_code,
-                        "repo": hf_repo,
-                        "file": hf_file,
-                    },
-                )
-            if resp.status_code == 404:
-                raise PullError(
-                    f"hugging face has no file {hf_file!r} in {hf_repo!r} at main",
-                    details={"repo": hf_repo, "file": hf_file},
-                )
-            if resp.status_code >= 400:
-                raise PullError(
-                    f"hugging face returned HTTP {resp.status_code} for {url}",
-                    details={"status": resp.status_code, "url": url},
-                )
+        # Retry loop exists solely so a 416 (bad/complete range) can fall back
+        # to a clean full download in the same invocation. The happy path runs
+        # the body exactly once and breaks.
+        while True:
+            async with client.stream("GET", url, headers=headers) as resp:
+                if resp.status_code == 416 and resume_from > 0:
+                    # Range not satisfiable (already complete or bad range) —
+                    # discard the prefix and restart from zero.
+                    resume_from = 0
+                    headers.pop("Range", None)
+                    headers.pop("If-Range", None)
+                    _discard_partial(part, sidecar)
+                    hasher = hashlib.sha256()
+                    continue
 
-            content_length = resp.headers.get("content-length")
-            if content_length:
-                try:
-                    job.bytes_total = int(content_length)
-                except ValueError:
-                    job.bytes_total = 0
-            job._signal()
+                if resp.status_code == 401 or resp.status_code == 403:
+                    raise PullError(
+                        f"hugging face returned {resp.status_code} for {hf_repo}/{hf_file}"
+                        " (gated repo? set HF_TOKEN)",
+                        details={
+                            "status": resp.status_code,
+                            "repo": hf_repo,
+                            "file": hf_file,
+                        },
+                    )
+                if resp.status_code == 404:
+                    raise PullError(
+                        f"hugging face has no file {hf_file!r} in {hf_repo!r} at main",
+                        details={"repo": hf_repo, "file": hf_file},
+                    )
+                if resp.status_code >= 400:
+                    raise PullError(
+                        f"hugging face returned HTTP {resp.status_code} for {url}",
+                        details={"status": resp.status_code, "url": url},
+                    )
 
-            # Disk-space preflight (MR-4): bail before opening the .part file
-            # (and streaming multi-GB) if the staging FS clearly can't hold the
-            # advertised size. Measured against tmp_dir — that's where bytes
-            # land before the os.replace() into the final path. A probe failure
-            # must not itself fail the pull: if we can't measure, fall through
-            # to the existing stream-until-ENOSPC behavior (no regression).
-            # PullInsufficientDisk is not an OSError, so the raise inside the
-            # suppress still propagates to the except Hal0Error handler below.
-            if job.bytes_total > 0:
-                with contextlib.suppress(OSError):
-                    free = shutil.disk_usage(tmp_dir).free
-                    if free < job.bytes_total:
-                        raise PullInsufficientDisk(
-                            f"insufficient disk for {job.model_id}: need "
-                            f"{job.bytes_total} bytes, {free} free at {tmp_dir}",
+                captured_etag = resp.headers.get("etag")
+
+                if resp.status_code == 206 and resume_from > 0:
+                    # Server honoured the Range — continue the existing prefix.
+                    total = _parse_content_range_total(
+                        resp.headers.get("content-range"), resume_from
+                    )
+                    if total is None:
+                        # Offset the server sent disagrees with what we asked
+                        # for — refuse to stitch (would corrupt the hash).
+                        raise PullError(
+                            f"resume range mismatch for {job.model_id}: "
+                            f"unexpected Content-Range {resp.headers.get('content-range')!r}",
                             details={
-                                "required_bytes": job.bytes_total,
-                                "free_bytes": free,
-                                "path": str(tmp_dir),
+                                "resume_from": resume_from,
+                                "content_range": resp.headers.get("content-range"),
                             },
                         )
+                    job.bytes_total = total
+                    # Re-hash the on-disk prefix so the final SHA-256 is exact
+                    # (stdlib hashlib can't restore a checkpoint).
+                    hashed = _rehash_prefix(part, hasher)
+                    if hashed != resume_from:
+                        raise PullError(
+                            f"resume prefix changed for {job.model_id}: expected "
+                            f"{resume_from} bytes, re-read {hashed}",
+                            details={"expected": resume_from, "hashed": hashed},
+                        )
+                    job.bytes_downloaded = resume_from
+                    mode = "ab"
+                else:
+                    # 200 (fresh, or the server/CDN ignored our Range) — start
+                    # over from a clean hasher so we never double-count a prefix.
+                    if resume_from > 0:
+                        hasher = hashlib.sha256()
+                        resume_from = 0
+                    content_length = resp.headers.get("content-length")
+                    if content_length:
+                        try:
+                            job.bytes_total = int(content_length)
+                        except ValueError:
+                            job.bytes_total = 0
+                    job.bytes_downloaded = 0
+                    mode = "wb"
+                job._signal()
 
-            with open(tmp_path, "wb") as f:
-                async for chunk in resp.aiter_bytes(chunk_size=_CHUNK_BYTES):
-                    if job.cancel_requested:
-                        # Caller asked for cancellation — drop the partial
-                        # and exit cleanly.
-                        f.close()
-                        with contextlib.suppress(OSError):
-                            tmp_path.unlink(missing_ok=True)
-                        job.state = "cancelled"
-                        job.finished_at = time.time()
-                        job._signal()
-                        return
-                    if not chunk:
-                        continue
-                    f.write(chunk)
-                    hasher.update(chunk)
-                    job.bytes_downloaded += len(chunk)
-                    now = time.monotonic()
-                    if (now - last_emit) >= _SSE_MIN_INTERVAL_S:
-                        last_emit = now
-                        job._signal()
+                # Disk-space preflight (MR-4): bail before streaming multi-GB
+                # if the staging FS clearly can't hold what's still to fetch.
+                # Measured against tmp_dir — that's where bytes land before the
+                # os.replace() into the final path. A probe failure must not
+                # itself fail the pull: if we can't measure, fall through to the
+                # existing stream-until-ENOSPC behavior (no regression). On a
+                # resume we only need room for the remaining (total-have) bytes.
+                # PullInsufficientDisk is not an OSError, so the raise inside the
+                # suppress still propagates to the except Hal0Error handler below.
+                if job.bytes_total > 0:
+                    with contextlib.suppress(OSError):
+                        free = shutil.disk_usage(tmp_dir).free
+                        needed = job.bytes_total - resume_from
+                        if free < needed:
+                            raise PullInsufficientDisk(
+                                f"insufficient disk for {job.model_id}: need "
+                                f"{needed} bytes, {free} free at {tmp_dir}",
+                                details={
+                                    "required_bytes": needed,
+                                    "free_bytes": free,
+                                    "path": str(tmp_dir),
+                                },
+                            )
+
+                with open(part, mode) as f:
+                    async for chunk in resp.aiter_bytes(chunk_size=_CHUNK_BYTES):
+                        if job.cancel_requested:
+                            # Explicit user cancel — drop the partial + sidecar
+                            # and exit cleanly.
+                            f.close()
+                            _discard_partial(part, sidecar)
+                            job.state = "cancelled"
+                            job.finished_at = time.time()
+                            job._signal()
+                            return
+                        if not chunk:
+                            continue
+                        f.write(chunk)
+                        hasher.update(chunk)
+                        job.bytes_downloaded += len(chunk)
+                        now = time.monotonic()
+                        if (now - last_emit) >= _SSE_MIN_INTERVAL_S:
+                            last_emit = now
+                            job._signal()
+            break
 
         # Download complete — atomic install.
         final = _final_path_for_entry(job.model_id, hf_file, comfyui_subdir, capability)
         final.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(tmp_path, final)
-        tmp_path = final  # so the cleanup `finally` doesn't unlink the installed file
+        os.replace(part, final)
+        installed = True  # so the cleanup handlers don't touch the installed file
+        _discard_partial(part, sidecar)  # part is renamed away; drop the sidecar
         size_bytes = final.stat().st_size
         digest = hasher.hexdigest()
 
@@ -582,18 +770,19 @@ async def run_pull(
         job.finished_at = time.time()
         job._signal()
     except asyncio.CancelledError:
-        # Task itself was cancelled by the event loop — treat as cancellation.
-        with contextlib.suppress(OSError):
-            if tmp_path and tmp_path.exists() and tmp_path.suffix == ".part":
-                tmp_path.unlink()
+        # Task itself was cancelled by the event loop — treat as an explicit
+        # cancel: discard the partial + sidecar (MR-7).
+        if not installed:
+            _discard_partial(part, sidecar)
         job.state = "cancelled"
         job.finished_at = time.time()
         job._signal()
         raise
     except Hal0Error as exc:
-        with contextlib.suppress(OSError):
-            if tmp_path and tmp_path.exists() and tmp_path.suffix == ".part":
-                tmp_path.unlink()
+        # Permanent failures (4xx PullError, insufficient disk) are not
+        # resumable — discard the partial + sidecar (MR-7).
+        if not installed:
+            _discard_partial(part, sidecar)
         job.state = "failed"
         job.error = exc.message
         job.error_code = exc.code
@@ -601,9 +790,17 @@ async def run_pull(
         job._signal()
         log.warning("model.pull_failed", extra={"model_id": job.model_id, "error": exc.message})
     except Exception as exc:
-        with contextlib.suppress(OSError):
-            if tmp_path and tmp_path.exists() and tmp_path.suffix == ".part":
-                tmp_path.unlink()
+        # A transient transport error (connection drop / read timeout) must
+        # PRESERVE the .part and record a resume sidecar so the NEXT run_pull
+        # continues where this one left off (MR-7). Truly unexpected errors
+        # poison state, so those still discard.
+        if not installed:
+            if isinstance(exc, httpx.HTTPError):
+                _write_resume_sidecar(
+                    part, sidecar, url=url, etag=captured_etag, total=job.bytes_total
+                )
+            else:
+                _discard_partial(part, sidecar)
         job.state = "failed"
         job.error = f"{type(exc).__name__}: {exc}"
         job.error_code = "model.pull_failed"

--- a/src/hal0/registry/store.py
+++ b/src/hal0/registry/store.py
@@ -31,7 +31,7 @@ import os
 import tempfile
 import threading
 import tomllib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -41,7 +41,17 @@ from hal0.config import paths
 from hal0.errors import Hal0Error
 from hal0.registry.model import Model
 
+try:  # POSIX advisory file locking. Absent on Windows; repo targets Linux.
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX fallback
+    fcntl = None  # type: ignore[assignment]
+
 log = logging.getLogger(__name__)
+
+# MR-5: sidecar lockfile guarding cross-process registry writes. It has a
+# STABLE inode — unlike registry.toml, which _atomic_write swaps via
+# os.replace, so a flock on the .toml would guard a now-unlinked inode.
+_PROCESS_LOCK_FILENAME = "registry.toml.lock"
 
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
@@ -66,6 +76,44 @@ class ModelAlreadyExists(RegistryError):
 
     code = "model.already_exists"
     status = 409
+
+
+# ── cross-process write lock (MR-5) ───────────────────────────────────────────
+
+
+@contextlib.contextmanager
+def registry_write_lock(registry_dir: str | Path) -> Iterator[None]:
+    """Hold an exclusive POSIX advisory lock on the registry sidecar lockfile.
+
+    Serializes registry read-modify-write critical sections ACROSS processes
+    (each open file description gets its own ``fcntl.flock`` slot, so this is
+    mutually exclusive between separate processes and separate open fds).
+    Composes with the in-process ``threading.RLock``: the RLock serializes
+    threads inside one instance, this flock serializes across processes.
+
+    The lock is taken on a dedicated sidecar (``registry.toml.lock``) with a
+    stable inode, NOT on ``registry.toml`` itself — the atomic-write path
+    swaps ``registry.toml``'s inode via ``os.replace``, so a lock on the old
+    inode would not guard the freshly-written file.
+
+    Gracefully degrades to a no-op when ``fcntl`` is unavailable (non-POSIX);
+    the repo targets Linux, so the real path is always POSIX.
+    """
+    lock_dir = Path(registry_dir)
+    if fcntl is None:  # pragma: no cover - non-POSIX fallback
+        yield
+        return
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / _PROCESS_LOCK_FILENAME
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 # ── ModelRegistry ─────────────────────────────────────────────────────────────
@@ -257,6 +305,15 @@ class ModelRegistry:
         """Clear the mtime tag so the next read re-parses."""
         self._cache_mtime = -1.0
 
+    def _process_lock(self) -> contextlib.AbstractContextManager[None]:
+        """Cross-process exclusive lock guarding this registry's writes (MR-5).
+
+        Thin wrapper over :func:`registry_write_lock` bound to this instance's
+        ``registry_dir``. Held for the duration of a mutator's read-modify-write
+        so a second process cannot interleave its ``os.replace`` and drop rows.
+        """
+        return registry_write_lock(self.registry_dir)
+
     # ── public reads ─────────────────────────────────────────────────────
 
     def list(self) -> list[Model]:
@@ -308,7 +365,10 @@ class ModelRegistry:
         Raises:
             ModelAlreadyExists: If the model id is already present.
         """
-        with self._lock:
+        with self._lock, self._process_lock():
+            # Re-read UNDER the flock so we observe any writer that committed
+            # just before we acquired it (MR-5).
+            self._invalidate()
             models = dict(self._ensure_fresh())
             if model.id in models:
                 raise ModelAlreadyExists(
@@ -326,7 +386,8 @@ class ModelRegistry:
         Returns:
             ``True`` if the model was present and removed, ``False`` if absent.
         """
-        with self._lock:
+        with self._lock, self._process_lock():
+            self._invalidate()
             models = dict(self._ensure_fresh())
             if model_id not in models:
                 return False
@@ -353,7 +414,8 @@ class ModelRegistry:
                 "updates must be a dict",
                 details={"got": type(updates).__name__},
             )
-        with self._lock:
+        with self._lock, self._process_lock():
+            self._invalidate()
             models = dict(self._ensure_fresh())
             if model_id not in models:
                 raise ModelNotFound(
@@ -454,4 +516,5 @@ __all__ = [
     "ModelRegistry",
     "RegistryError",
     "model_to_toml_dict",
+    "registry_write_lock",
 ]

--- a/src/hal0/registry/store.py
+++ b/src/hal0/registry/store.py
@@ -116,6 +116,26 @@ def registry_write_lock(registry_dir: str | Path) -> Iterator[None]:
         os.close(fd)
 
 
+# ── Durability helper (MR-13) ─────────────────────────────────────────────────
+
+
+def _fsync_dir(dir_path: Path) -> None:
+    """Best-effort fsync of a directory so a just-renamed entry is durable.
+
+    An atomic ``os.replace`` only guarantees the rename is visible to later
+    ``open`` calls; the directory entry itself is not on stable storage until
+    the parent directory is fsynced. This is best-effort — any OSError (e.g. a
+    platform without ``O_DIRECTORY``) is suppressed so it can never break the
+    write it is meant to harden.
+    """
+    with contextlib.suppress(OSError):
+        dfd = os.open(dir_path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(dfd)
+        finally:
+            os.close(dfd)
+
+
 # ── ModelRegistry ─────────────────────────────────────────────────────────────
 
 
@@ -295,6 +315,7 @@ class ModelRegistry:
                     os.close(fd)
                 raise
             os.replace(tmp_path, target)
+            _fsync_dir(target.parent)
             tmp_path = None
         finally:
             if tmp_path is not None:

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -40,12 +40,14 @@ from __future__ import annotations
 import contextlib
 import logging
 import tomllib
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hal0.config import paths
 from hal0.config.loader import write_toml_atomic
+from hal0.config.locking import file_lock
 from hal0.model_meta import canonical_device, device_to_legacy_backend
 
 if TYPE_CHECKING:
@@ -247,6 +249,39 @@ class SlotConfigStore:
                 FileState(path=slot_path, data=slot_after),
             ),
         )
+
+    # ── cross-process serialized RMW (SC-10) ─────────────────────────────────
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Hold the capabilities.toml cross-process lock for the body.
+
+        Every capabilities.toml writer (this store, the orchestrator seed,
+        the CLI migrate, the schema auto-migration) serializes on the SAME
+        advisory lock — the sibling ``<capabilities.toml>.lock`` — so a
+        concurrent read-modify-write from the API and the CLI cannot
+        interleave and drop each other's change (SC-10). The lock is
+        re-entrant within a thread, so a caller already inside ``transaction``
+        may nest a locked leaf writer without self-deadlocking.
+        """
+        with file_lock(self._caps_path()):
+            yield
+
+    def apply_and_commit(self, selection: SlotSelection) -> ChangeSet:
+        """Atomically read, reconcile and write ``selection`` under the lock.
+
+        The authoritative ``before`` snapshot (``apply``) and the ``after``
+        write (``commit``) happen inside one held lock so the whole
+        read-modify-write is a single critical section. Locking ``commit``
+        alone would NOT fix the lost update — the stale ``before`` would
+        already have been read outside the lock. Callers that need an earlier
+        ChangeSet for a dry-run/telemetry display should recompute the
+        committed one here, under the lock.
+        """
+        with self.transaction():
+            cs = self.apply(selection)
+            self.commit(cs)
+            return cs
 
     # ── commit / revert ──────────────────────────────────────────────────────
 

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -242,8 +242,14 @@ class StackApplyEngine:
         tmpfile+fsync+rename; a mid-set failure restores every already-written
         file to its ``before`` snapshot and re-raises — disk is never left
         half-reconciled. A no-op ChangeSet (nothing changed) writes nothing.
+
+        SC-10: the commit runs under the store's shared advisory lock so a
+        stack apply and a concurrent capability apply (which reconcile the same
+        ``slots/*.toml`` surface) serialize rather than interleaving their
+        writes.
         """
-        self._store.commit(plan.change_set)
+        with self._store.transaction():
+            self._store.commit(plan.change_set)
 
     # ── drift / active pointer ───────────────────────────────────────────────
 

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -437,6 +437,48 @@ def test_delete_unknown_model_returns_404(
     assert r.json()["error"]["code"] == "model.not_found"
 
 
+def test_delete_reaps_pull_job_snapshot(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """Deleting a model garbage-collects its durable pull-job snapshot (#MR-8)."""
+    from hal0.registry.pull import pull_job_file
+
+    fpath = crud_models_root / "reaped.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post("/api/models", json={"id": "reaped", "path": str(fpath)})
+    assert r.status_code == 201, r.text
+
+    snap = pull_job_file("reaped")
+    snap.parent.mkdir(parents=True, exist_ok=True)
+    snap.write_text('{"model_id": "reaped", "state": "completed"}', encoding="utf-8")
+    assert snap.exists()
+
+    r = crud_client.delete("/api/models/reaped")
+    assert r.status_code == 200, r.text
+    assert r.json()["deleted"] is True
+    assert not snap.exists()
+
+
+def test_delete_succeeds_when_snapshot_absent(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """The snapshot-GC is fail-soft: an already-absent file never breaks delete."""
+    from hal0.registry.pull import pull_job_file
+
+    fpath = crud_models_root / "no-snap.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post("/api/models", json={"id": "no-snap", "path": str(fpath)})
+    assert r.status_code == 201, r.text
+
+    assert not pull_job_file("no-snap").exists()
+
+    r = crud_client.delete("/api/models/no-snap")
+    assert r.status_code == 200, r.text
+    assert r.json()["deleted"] is True
+
+
 # ── EventBus subscriber verification ───────────────────────────────────────
 
 

--- a/tests/config/test_locking.py
+++ b/tests/config/test_locking.py
@@ -1,0 +1,77 @@
+"""Unit tests for the shared advisory ``file_lock`` helper (SC-10).
+
+Mirrors the intent of the existing ``hal0.mcp.installed._registry_lock``:
+an exclusive cross-process advisory lock on a sibling ``<target>.lock`` that
+serializes a read-modify-write. The lock is also re-entrant within a single
+process/thread so a locked outer writer (e.g. ``initialize_if_missing``) can
+call a locked inner writer (``auto_migrate_capabilities_file``) without a
+self-deadlock.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from pathlib import Path
+from typing import Any
+
+from hal0.config.locking import file_lock
+
+
+def _hold_then_release(target: str, barrier: Any, hold_s: float, events: Any) -> None:
+    """Acquire the lock, record acquire/release timestamps around a hold."""
+    barrier.wait()
+    with file_lock(target):
+        events.put(("holder_acquire", time.monotonic()))
+        time.sleep(hold_s)
+        events.put(("holder_release", time.monotonic()))
+
+
+def _contender(target: str, barrier: Any, head_start_s: float, events: Any) -> None:
+    """Wait for the holder to grab the lock first, then block on acquire."""
+    barrier.wait()
+    time.sleep(head_start_s)  # let the holder win the lock first
+    with file_lock(target):
+        events.put(("contender_acquire", time.monotonic()))
+
+
+def test_second_process_blocks_until_first_releases(tmp_path: Path) -> None:
+    target = tmp_path / "thing.toml"
+
+    ctx = multiprocessing.get_context("fork")
+    barrier = ctx.Barrier(2)
+    events: Any = ctx.Queue()
+
+    holder = ctx.Process(target=_hold_then_release, args=(str(target), barrier, 0.5, events))
+    contender = ctx.Process(target=_contender, args=(str(target), barrier, 0.1, events))
+    holder.start()
+    contender.start()
+    holder.join(timeout=15)
+    contender.join(timeout=15)
+    assert holder.exitcode == 0 and contender.exitcode == 0
+
+    timeline: dict[str, float] = {}
+    while not events.empty():
+        name, ts = events.get()
+        timeline[name] = ts
+
+    assert set(timeline) == {"holder_acquire", "holder_release", "contender_acquire"}
+    # The contender must not enter the critical section until the holder left.
+    assert timeline["contender_acquire"] >= timeline["holder_release"], (
+        "contender acquired the lock before the holder released it"
+    )
+
+
+def test_creates_sibling_lock_file(tmp_path: Path) -> None:
+    target = tmp_path / "sub" / "cfg.toml"
+    with file_lock(target):
+        pass
+    assert (tmp_path / "sub" / "cfg.toml.lock").exists()
+
+
+def test_reentrant_within_same_process(tmp_path: Path) -> None:
+    """A nested acquire on the same path in the same thread must not deadlock."""
+    target = tmp_path / "cfg.toml"
+    with file_lock(target), file_lock(target):
+        entered = True
+    assert entered

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -639,3 +639,21 @@ async def test_composite_bound_model_without_live_slot_is_no_route() -> None:
             make_request(),
             body={"model": "gemma3-4b-FLM", "messages": []},
         )
+
+
+# ── DR-12: capability heuristics extraction — public surface preservation ─────
+
+
+def test_resolve_by_capability_reexported_from_router() -> None:
+    """DR-12: resolve_by_capability lives in _capability_resolve but stays
+    re-exported from router (same object, in __all__) so every existing
+    call site and importer keeps working unchanged after the extraction."""
+    import hal0.dispatcher.router as r
+    from hal0.dispatcher import _capability_resolve as cr
+
+    assert r.resolve_by_capability is cr.resolve_by_capability
+    assert "resolve_by_capability" in r.__all__
+    # LegacyResolutionFailed is raised by the extracted function and imported
+    # by external callers from router — the identity must be preserved too.
+    assert r.LegacyResolutionFailed is cr.LegacyResolutionFailed
+    assert "LegacyResolutionFailed" in r.__all__

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -18,6 +18,7 @@ import httpx
 import pytest
 
 from hal0.registry.pull import (
+    _CHUNK_BYTES,
     _pull_root,
     _sanitise_id,
     _tmp_dir,
@@ -357,6 +358,9 @@ async def test_run_pull_cancellation_removes_partial(
     final_dir = Path(tmp_hal0_home) / "var-lib" / "hal0" / "models" / "cancel-me"
     if final_dir.exists():
         assert not any(final_dir.iterdir())
+    # The cancel path also discards the staging .part + sidecar (MR-7).
+    assert not _part_paths("cancel-me")[0].exists()
+    assert not _part_paths("cancel-me")[1].exists()
 
 
 # ── sweep_orphaned_partials: startup reaper (MR-9) ───────────────────────────
@@ -396,3 +400,250 @@ def test_sweep_orphaned_partials_missing_tmp_dir_is_noop(tmp_hal0_home: str) -> 
     """No .tmp directory present → returns 0 and never raises (fail-soft)."""
     assert not _tmp_dir().exists()
     assert sweep_orphaned_partials() == 0
+
+
+# ── MR-7: resume / partial-download support ──────────────────────────────────
+
+
+def _part_paths(model_id: str) -> tuple[Path, Path]:
+    """Return the deterministic ``.part`` and ``.part.json`` sidecar paths."""
+    tmp = _tmp_dir()
+    stem = _sanitise_id(model_id)
+    return tmp / f"{stem}.part", tmp / f"{stem}.part.json"
+
+
+def _seed_partial(
+    model_id: str,
+    url: str,
+    have: int,
+    total: int,
+    prefix: bytes,
+    *,
+    etag: str | None = None,
+) -> tuple[Path, Path]:
+    """Pre-create a valid-looking partial + sidecar as a prior interrupted pull."""
+    tmp = _tmp_dir()
+    tmp.mkdir(parents=True, exist_ok=True)
+    part, sidecar = _part_paths(model_id)
+    part.write_bytes(prefix)
+    sidecar.write_text(
+        json.dumps({"url": url, "etag": etag, "bytes": have, "total": total}),
+        encoding="utf-8",
+    )
+    return part, sidecar
+
+
+def _fail_midstream(body: bytes, first_n: int, exc: Exception) -> httpx.MockTransport:
+    """Transport that streams ``body[:first_n]`` then raises ``exc`` mid-body."""
+
+    async def handler(req: httpx.Request) -> httpx.Response:
+        async def agen():  # type: ignore[no-untyped-def]
+            yield body[:first_n]
+            raise exc
+
+        return httpx.Response(200, headers={"Content-Length": str(len(body))}, content=agen())
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_run_pull_resumes_from_partial_with_range(tmp_hal0_home: str) -> None:
+    """Primary MR-7 guard: an interrupted pull resumes via a Range request on
+    the NEXT run_pull and produces a byte-identical SHA-256."""
+    total = _CHUNK_BYTES * 3
+    body = _payload(total)
+    digest = hashlib.sha256(body).hexdigest()
+    registry = ModelRegistry()
+
+    # ── Pass 1: stream the first chunk, then drop the connection mid-body. ──
+    job1 = make_job("resume-me")
+    client1 = httpx.AsyncClient(
+        transport=_fail_midstream(body, _CHUNK_BYTES, httpx.ReadError("dropped"))
+    )
+    try:
+        await run_pull(
+            job1,
+            hf_repo="Org/Resume-GGUF",
+            hf_file="resume.gguf",
+            registry=registry,
+            client=client1,
+        )
+    finally:
+        await client1.aclose()
+
+    assert job1.state == "failed"
+    part, sidecar = _part_paths("resume-me")
+    assert part.exists(), "transient error must PRESERVE the .part for resume"
+    assert sidecar.exists(), "transient error must write a resume sidecar"
+    assert part.stat().st_size == _CHUNK_BYTES
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["bytes"] == _CHUNK_BYTES
+
+    # ── Pass 2: fresh job, same model_id → resumes with a Range header. ──
+    job2 = make_job("resume-me")
+    seen: dict[str, str] = {}
+
+    async def resume_handler(req: httpx.Request) -> httpx.Response:
+        seen["range"] = req.headers.get("range", "")
+        remainder = body[_CHUNK_BYTES:]
+        return httpx.Response(
+            206,
+            headers={
+                "Content-Length": str(len(remainder)),
+                "Content-Range": f"bytes {_CHUNK_BYTES}-{total - 1}/{total}",
+            },
+            content=remainder,
+        )
+
+    client2 = httpx.AsyncClient(transport=httpx.MockTransport(resume_handler))
+    try:
+        await run_pull(
+            job2,
+            hf_repo="Org/Resume-GGUF",
+            hf_file="resume.gguf",
+            registry=registry,
+            client=client2,
+        )
+    finally:
+        await client2.aclose()
+
+    assert seen["range"] == f"bytes={_CHUNK_BYTES}-"
+    assert job2.state == "completed", f"got {job2.state}: {job2.error}"
+    final = Path(job2.path)  # type: ignore[arg-type]
+    assert final.read_bytes() == body
+    assert job2.sha256 == digest, "resume must produce a byte-identical hash"
+    assert job2.bytes_downloaded == total
+    # Staging cleaned up on success.
+    assert not part.exists()
+    assert not sidecar.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_pull_restarts_when_server_ignores_range(tmp_hal0_home: str) -> None:
+    """A CDN that ignores Range (returns 200 + full body) must reset the hasher
+    and re-download cleanly — no double-counted prefix, correct SHA-256."""
+    total = _CHUNK_BYTES * 2
+    body = _payload(total)
+    digest = hashlib.sha256(body).hexdigest()
+    url = hf_download_url("Org/Ignore-GGUF", "ignore.gguf")
+    _seed_partial("ignore-me", url, _CHUNK_BYTES, total, body[:_CHUNK_BYTES])
+
+    job = make_job("ignore-me")
+    registry = ModelRegistry()
+
+    async def ignore_range_handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"Content-Length": str(total)}, content=body)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(ignore_range_handler))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Org/Ignore-GGUF",
+            hf_file="ignore.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert job.sha256 == digest
+    assert job.bytes_downloaded == total
+    assert Path(job.path).read_bytes() == body  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_run_pull_restarts_when_object_changed(tmp_hal0_home: str) -> None:
+    """A changed object (If-Range miss → 200 full body) discards the stale
+    prefix and re-pulls with the correct SHA-256."""
+    total = _CHUNK_BYTES * 2
+    body = _payload(total)
+    digest = hashlib.sha256(body).hexdigest()
+    url = hf_download_url("Org/Changed-GGUF", "changed.gguf")
+    _seed_partial("changed-me", url, _CHUNK_BYTES, total, body[:_CHUNK_BYTES], etag='"old-etag"')
+
+    job = make_job("changed-me")
+    registry = ModelRegistry()
+    seen: dict[str, str] = {}
+
+    async def changed_handler(req: httpx.Request) -> httpx.Response:
+        seen["if_range"] = req.headers.get("if-range", "")
+        return httpx.Response(
+            200,
+            headers={"Content-Length": str(total), "ETag": '"new-etag"'},
+            content=body,
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(changed_handler))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Org/Changed-GGUF",
+            hf_file="changed.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert seen["if_range"] == '"old-etag"', "resume must send If-Range with the etag"
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert job.sha256 == digest
+    assert Path(job.path).read_bytes() == body  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_run_pull_transient_error_preserves_partial(tmp_hal0_home: str) -> None:
+    """A mid-stream transport error must PRESERVE the .part + sidecar so the
+    next run_pull can resume (regression guard for the failure-cleanup change)."""
+    total = _CHUNK_BYTES * 3
+    body = _payload(total)
+    job = make_job("keepme")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(
+        transport=_fail_midstream(body, _CHUNK_BYTES, httpx.TransportError("boom"))
+    )
+    try:
+        await run_pull(
+            job,
+            hf_repo="Org/Keep-GGUF",
+            hf_file="keep.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "failed"
+    part, sidecar = _part_paths("keepme")
+    assert part.exists(), "transient error must preserve the .part"
+    assert sidecar.exists()
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["bytes"] == _CHUNK_BYTES
+
+
+@pytest.mark.asyncio
+async def test_run_pull_permanent_error_removes_partial(tmp_hal0_home: str) -> None:
+    """A permanent 4xx (404) must DISCARD any leftover .part + sidecar — a
+    permanent failure is not resumable."""
+    url = hf_download_url("Org/Perm-GGUF", "perm.gguf")
+    total = _CHUNK_BYTES * 2
+    body = _payload(total)
+    part, sidecar = _seed_partial("permfail", url, _CHUNK_BYTES, total, body[:_CHUNK_BYTES])
+    assert part.exists()
+
+    job = make_job("permfail")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_status_handler(404))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Org/Perm-GGUF",
+            hf_file="perm.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "failed"
+    assert not part.exists(), "permanent 4xx must discard the partial"
+    assert not sidecar.exists()

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -17,11 +18,14 @@ import httpx
 import pytest
 
 from hal0.registry.pull import (
+    _pull_root,
     _sanitise_id,
+    _tmp_dir,
     hf_download_url,
     make_job,
     pull_job_file,
     run_pull,
+    sweep_orphaned_partials,
 )
 from hal0.registry.store import ModelRegistry
 
@@ -353,3 +357,42 @@ async def test_run_pull_cancellation_removes_partial(
     final_dir = Path(tmp_hal0_home) / "var-lib" / "hal0" / "models" / "cancel-me"
     if final_dir.exists():
         assert not any(final_dir.iterdir())
+
+
+# ── sweep_orphaned_partials: startup reaper (MR-9) ───────────────────────────
+
+
+def test_sweep_orphaned_partials_reaps_old_but_keeps_fresh_and_final(
+    tmp_hal0_home: str,
+) -> None:
+    """Aged *.part files are reaped; fresh partials and installed files survive."""
+    tmp = _tmp_dir()
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    # Stale partial left by a SIGKILL/OOM mid-pull — backdate its mtime 48h.
+    old = tmp / "modelA.aaaa.part"
+    old.write_bytes(b"partial")
+    t = time.time() - 48 * 3600
+    os.utime(old, (t, t))
+
+    # An actively-growing partial from a concurrent pull — mtime is now.
+    fresh = tmp / "modelB.bbbb.part"
+    fresh.write_bytes(b"partial")
+
+    # A completed install, NOT under .tmp — must never be touched.
+    installed = _pull_root() / "modelC" / "model.gguf"
+    installed.parent.mkdir(parents=True, exist_ok=True)
+    installed.write_bytes(b"GGUF")
+
+    removed = sweep_orphaned_partials()
+
+    assert removed == 1
+    assert not old.exists()
+    assert fresh.exists()
+    assert installed.exists()
+
+
+def test_sweep_orphaned_partials_missing_tmp_dir_is_noop(tmp_hal0_home: str) -> None:
+    """No .tmp directory present → returns 0 and never raises (fail-soft)."""
+    assert not _tmp_dir().exists()
+    assert sweep_orphaned_partials() == 0

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -402,6 +402,31 @@ def test_sweep_orphaned_partials_missing_tmp_dir_is_noop(tmp_hal0_home: str) -> 
     assert sweep_orphaned_partials() == 0
 
 
+def test_sweep_orphaned_partials_reaps_stale_resume_sidecars(tmp_hal0_home: str) -> None:
+    """A stale .part.json resume sidecar is reaped too, not left to linger."""
+    tmp = _tmp_dir()
+    tmp.mkdir(parents=True, exist_ok=True)
+    old = time.time() - 48 * 3600
+
+    stale_part = tmp / "modelA.part"
+    stale_part.write_bytes(b"partial")
+    stale_sidecar = tmp / "modelA.part.json"
+    stale_sidecar.write_text('{"bytes": 7}', encoding="utf-8")
+    for p in (stale_part, stale_sidecar):
+        os.utime(p, (old, old))
+
+    # A fresh sidecar from an in-flight pull must survive.
+    fresh_sidecar = tmp / "modelB.part.json"
+    fresh_sidecar.write_text('{"bytes": 3}', encoding="utf-8")
+
+    removed = sweep_orphaned_partials()
+
+    assert removed == 2  # stale .part + its stale sidecar
+    assert not stale_part.exists()
+    assert not stale_sidecar.exists()
+    assert fresh_sidecar.exists()
+
+
 # ── MR-7: resume / partial-download support ──────────────────────────────────
 
 

--- a/tests/registry/test_pull_store.py
+++ b/tests/registry/test_pull_store.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import os
+import time
 from pathlib import Path
 
 from hal0.config import paths
@@ -51,3 +54,44 @@ def test_effective_store_prefers_explicit_store() -> None:
         store="/new/store",
     )
     assert models.effective_store() == "/new/store"
+
+
+# ── sweep_pull_jobs — GC of stale terminal snapshots (#MR-8) ────────────────
+
+
+def _write_snapshot(model_id: str, state: str, age_days: float) -> Path:
+    """Drop a snapshot for ``model_id`` in ``state`` with an aged mtime."""
+    from hal0.registry.pull import _pull_jobs_dir
+
+    jobs_dir = _pull_jobs_dir()
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    path = jobs_dir / f"{model_id}.json"
+    path.write_text(json.dumps({"model_id": model_id, "state": state}), encoding="utf-8")
+    if age_days:
+        when = time.time() - age_days * 86400
+        os.utime(path, (when, when))
+    return path
+
+
+def test_sweep_pull_jobs_reaps_only_old_terminal(tmp_hal0_home: str) -> None:
+    """Old terminal snapshot is reaped; fresh terminal + old running survive."""
+    from hal0.registry.pull import sweep_pull_jobs
+
+    old_terminal = _write_snapshot("old-done", "completed", age_days=30)
+    fresh_terminal = _write_snapshot("fresh-done", "completed", age_days=0)
+    old_running = _write_snapshot("old-running", "running", age_days=30)
+
+    removed = sweep_pull_jobs(max_age_days=14)
+
+    assert removed == 1
+    assert not old_terminal.exists()
+    assert fresh_terminal.exists()
+    assert old_running.exists()  # non-terminal preserved regardless of age
+
+
+def test_sweep_pull_jobs_missing_dir_returns_zero(tmp_hal0_home: str) -> None:
+    """A missing jobs directory is a no-op, not an error."""
+    from hal0.registry.pull import _pull_jobs_dir, sweep_pull_jobs
+
+    assert not _pull_jobs_dir().exists()
+    assert sweep_pull_jobs() == 0

--- a/tests/registry/test_pull_store.py
+++ b/tests/registry/test_pull_store.py
@@ -7,6 +7,8 @@ import os
 import time
 from pathlib import Path
 
+import pytest
+
 from hal0.config import paths
 from hal0.config.loader import save_hal0_config
 from hal0.config.schema import Hal0Config, ModelsConfig
@@ -95,3 +97,52 @@ def test_sweep_pull_jobs_missing_dir_returns_zero(tmp_hal0_home: str) -> None:
 
     assert not _pull_jobs_dir().exists()
     assert sweep_pull_jobs() == 0
+
+
+# ── MR-13: persist_pull_job fsyncs the parent directory ──────────────────────
+
+
+def test_persist_pull_job_fsyncs_parent_dir(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """persist_pull_job fsyncs the snapshot's parent dir after os.replace."""
+    import hal0.registry.pull as pull_mod
+    from hal0.registry.pull import make_job, persist_pull_job, pull_job_file
+
+    calls: list[Path] = []
+    real = pull_mod._fsync_dir
+
+    def _spy(dir_path: Path) -> None:
+        calls.append(dir_path)
+        real(dir_path)
+
+    monkeypatch.setattr(pull_mod, "_fsync_dir", _spy)
+
+    job = make_job("qwen3-4b")
+    persist_pull_job(job)
+
+    snapshot = pull_job_file(job.model_id)
+    assert snapshot.exists()
+    assert calls == [snapshot.parent]
+
+
+def test_persist_pull_job_survives_dir_fsync_failure(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed directory fsync stays fail-soft — the snapshot still lands."""
+    import hal0.registry.pull as pull_mod
+    from hal0.registry.pull import make_job, persist_pull_job, pull_job_file
+
+    real_open = pull_mod.os.open
+
+    def _flaky_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if flags & getattr(pull_mod.os, "O_DIRECTORY", 0):
+            raise OSError("no O_DIRECTORY here")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(pull_mod.os, "open", _flaky_open)
+
+    job = make_job("qwen3-4b")
+    persist_pull_job(job)  # must not raise
+
+    assert pull_job_file(job.model_id).exists()

--- a/tests/registry/test_store.py
+++ b/tests/registry/test_store.py
@@ -349,3 +349,47 @@ class TestPreexistingCorruption:
 
         reg = ModelRegistry(registry_dir=rdir)
         assert reg.list() == []
+
+
+# ── MR-13: atomic writes fsync the parent directory ──────────────────────────
+
+
+class TestParentDirFsync:
+    def test_add_fsyncs_registry_dir(
+        self, reg: ModelRegistry, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """add() fsyncs the parent dir after os.replace so the rename is durable."""
+        import hal0.registry.store as store_mod
+
+        calls: list[Path] = []
+        real = store_mod._fsync_dir
+
+        def _spy(dir_path: Path) -> None:
+            calls.append(dir_path)
+            real(dir_path)
+
+        monkeypatch.setattr(store_mod, "_fsync_dir", _spy)
+
+        reg.add(_model("a"))
+
+        assert calls == [reg.registry_file.parent]
+
+    def test_add_survives_dir_fsync_failure(
+        self, reg: ModelRegistry, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed directory fsync is best-effort — the write still lands."""
+        import hal0.registry.store as store_mod
+
+        real_open = store_mod.os.open
+
+        def _flaky_open(path, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if flags & getattr(store_mod.os, "O_DIRECTORY", 0):
+                raise OSError("no O_DIRECTORY here")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(store_mod.os, "open", _flaky_open)
+
+        reg.add(_model("a", name="Alpha"))
+
+        assert reg.registry_file.exists()
+        assert reg.get("a").name == "Alpha"

--- a/tests/registry/test_store_concurrency.py
+++ b/tests/registry/test_store_concurrency.py
@@ -1,0 +1,233 @@
+"""Cross-process write serialization for ModelRegistry (MR-5 regression).
+
+These tests reproduce the "lost update" defect: two writers each do a
+read-modify-write of ``registry.toml`` (read current models → add a row →
+atomic ``os.replace``). The per-instance ``threading.RLock`` only serializes
+threads *inside one ModelRegistry instance*; it does nothing across separate
+instances or separate processes. Without a shared file lock, the second
+writer's ``os.replace`` clobbers the first writer's freshly-committed row.
+
+The fix adds a POSIX advisory ``fcntl.flock`` on a stable sidecar lockfile
+(``registry.toml.lock``) around each mutator's critical section, so the two
+read-modify-write sections cannot interleave.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import threading
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from hal0.registry.model import Model
+from hal0.registry.store import ModelRegistry
+
+
+def _model(model_id: str, path: str = "/models/x.gguf") -> Model:
+    return Model(id=model_id, path=path)
+
+
+def _read_ids_from_disk(registry_dir: Path) -> set[str]:
+    """Re-read registry.toml straight off disk (no cache) and return ids."""
+    toml_path = registry_dir / "registry.toml"
+    with open(toml_path, "rb") as f:
+        data = tomllib.load(f)
+    return set(data.get("models", {}).keys())
+
+
+def _slow_atomic_write_wrapper(reg: ModelRegistry, delay: float) -> None:
+    """Patch reg._atomic_write to sleep AFTER read, before os.replace.
+
+    Widening the read→write window guarantees the two critical sections
+    interleave, making the lost-update deterministic when unserialized.
+    """
+    import time
+
+    original = reg._atomic_write
+
+    def slow(models: dict[str, Model]) -> None:
+        time.sleep(delay)
+        original(models)
+
+    reg._atomic_write = slow  # type: ignore[method-assign]
+
+
+# ── two-instance (models two processes within one pytest process) ────────────
+
+
+def test_two_instances_no_lost_update(tmp_path: Path) -> None:
+    """Two ModelRegistry instances on the same dir must not drop rows.
+
+    Each instance opens its own fd, so ``fcntl.flock(LOCK_EX)`` is mutually
+    exclusive per open file description — this models two processes even
+    within a single pytest process.
+
+    Pre-fix: fails — RLock is per-instance so nothing serializes the two
+    read-modify-write sections; the later ``os.replace`` drops the other row.
+    Post-fix: passes — the sidecar flock serializes the critical sections and
+    each re-reads the committed base under the lock.
+    """
+    registry_dir = tmp_path / "registry"
+    reg_a = ModelRegistry(registry_dir=registry_dir)
+    reg_b = ModelRegistry(registry_dir=registry_dir)
+
+    # Seed a base row so both writers must preserve it.
+    reg_a.add(_model("base"))
+
+    # Widen the read→write window on BOTH instances so the interleave is
+    # deterministic without the fix.
+    _slow_atomic_write_wrapper(reg_a, 0.05)
+    _slow_atomic_write_wrapper(reg_b, 0.05)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def add_on(reg: ModelRegistry, mid: str) -> None:
+        try:
+            barrier.wait()
+            reg.add(_model(mid))
+        except BaseException as exc:
+            errors.append(exc)
+
+    t_a = threading.Thread(target=add_on, args=(reg_a, "a"))
+    t_b = threading.Thread(target=add_on, args=(reg_b, "b"))
+    t_a.start()
+    t_b.start()
+    t_a.join()
+    t_b.join()
+
+    assert not errors, f"writer raised: {errors!r}"
+
+    ids = _read_ids_from_disk(registry_dir)
+    assert ids == {"base", "a", "b"}, f"lost update: on-disk ids = {ids!r}"
+
+
+# ── true cross-process via multiprocessing ───────────────────────────────────
+
+
+def _child_add(hal0_home: str, model_id: str, barrier: Any, delay: float) -> None:
+    """Child process: construct a ModelRegistry on HAL0_HOME and add a row."""
+    import time
+
+    os.environ["HAL0_HOME"] = hal0_home
+    # Re-import inside the child so paths resolve against this env.
+    from hal0.registry.model import Model as _Model
+    from hal0.registry.store import ModelRegistry as _Registry
+
+    reg = _Registry()
+
+    original = reg._atomic_write
+
+    def slow(models: dict) -> None:
+        time.sleep(delay)
+        original(models)
+
+    reg._atomic_write = slow  # type: ignore[method-assign]
+
+    barrier.wait()
+    reg.add(_Model(id=model_id, path="/models/x.gguf"))
+
+
+def test_multiprocessing_no_lost_update(tmp_path: Path) -> None:
+    """Two child processes adding distinct rows: both must survive.
+
+    This proves true cross-process safety — separate interpreters, separate
+    fds, coordinated only by the on-disk sidecar flock.
+    """
+    hal0_home = tmp_path / "home"
+    hal0_home.mkdir(parents=True, exist_ok=True)
+
+    # Seed a base row using a parent-side registry rooted at the same HAL0_HOME.
+    os.environ["HAL0_HOME"] = str(hal0_home)
+    from hal0.config import paths
+
+    seed = ModelRegistry()
+    seed.add(_model("base"))
+    registry_dir = paths.registry_dir()
+
+    ctx = mp.get_context("spawn")
+    barrier = ctx.Barrier(2)
+    procs = [
+        ctx.Process(target=_child_add, args=(str(hal0_home), "a", barrier, 0.05)),
+        ctx.Process(target=_child_add, args=(str(hal0_home), "b", barrier, 0.05)),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0, f"child exited with {p.exitcode}"
+
+    ids = _read_ids_from_disk(registry_dir)
+    assert ids == {"base", "a", "b"}, f"lost update: on-disk ids = {ids!r}"
+
+
+# ── CLI import (`_atomic_copy`) must not clobber a concurrent store add ───────
+
+
+def test_registry_import_does_not_drop_concurrent_add(tmp_path: Path) -> None:
+    """`registry import --force` (_atomic_copy) serializes with a store add.
+
+    Timeline (both threads released by one barrier):
+
+    * ``add`` enters ``ModelRegistry.add`` immediately, acquires the lock,
+      reads ``{base}``, then its patched ``_atomic_write`` sleeps 0.1s before
+      ``os.replace`` — a wide read→write window.
+    * ``import`` sleeps 0.02s (so ``add`` is mid-critical-section), then runs
+      ``_atomic_copy`` of a backup containing only ``imported``.
+
+    Pre-fix: nothing serializes them. At t≈0.02 the import ``os.replace``-s the
+    file to ``{imported}``; at t≈0.1 the add's ``os.replace`` — built from its
+    stale ``{base}`` read — lands last and silently clobbers the import,
+    resurrecting ``base`` and producing ``{base, a}``. The import "succeeded"
+    but its result vanished.
+
+    Post-fix: ``add`` holds the sidecar flock for its whole critical section,
+    so ``_atomic_copy`` blocks until t≈0.1, then replaces the file cleanly —
+    on-disk state is exactly ``{imported}``, the import's complete result.
+    """
+    import time
+
+    from hal0.cli import registry_commands
+
+    registry_dir = tmp_path / "registry"
+    reg = ModelRegistry(registry_dir=registry_dir)
+    reg.add(_model("base"))
+    dest = reg.registry_file
+
+    # A backup file containing only "imported" (no "base", no "a").
+    backup = tmp_path / "backup.toml"
+    backup.write_text('[models.imported]\npath = "/models/imported.gguf"\n')
+
+    _slow_atomic_write_wrapper(reg, 0.1)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def do_add() -> None:
+        try:
+            barrier.wait()
+            reg.add(_model("a"))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def do_import() -> None:
+        try:
+            barrier.wait()
+            time.sleep(0.02)  # let the add enter its critical section first
+            registry_commands._atomic_copy(backup, dest)
+        except BaseException as exc:
+            errors.append(exc)
+
+    t_add = threading.Thread(target=do_add)
+    t_import = threading.Thread(target=do_import)
+    t_add.start()
+    t_import.start()
+    t_add.join()
+    t_import.join()
+
+    assert not errors, f"worker raised: {errors!r}"
+
+    ids = _read_ids_from_disk(registry_dir)
+    assert ids == {"imported"}, f"import clobbered by stale store write: {ids!r}"

--- a/tests/registry/test_store_concurrency.py
+++ b/tests/registry/test_store_concurrency.py
@@ -21,6 +21,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from hal0.registry.model import Model
 from hal0.registry.store import ModelRegistry
 
@@ -130,7 +132,7 @@ def _child_add(hal0_home: str, model_id: str, barrier: Any, delay: float) -> Non
     reg.add(_Model(id=model_id, path="/models/x.gguf"))
 
 
-def test_multiprocessing_no_lost_update(tmp_path: Path) -> None:
+def test_multiprocessing_no_lost_update(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Two child processes adding distinct rows: both must survive.
 
     This proves true cross-process safety — separate interpreters, separate
@@ -140,7 +142,9 @@ def test_multiprocessing_no_lost_update(tmp_path: Path) -> None:
     hal0_home.mkdir(parents=True, exist_ok=True)
 
     # Seed a base row using a parent-side registry rooted at the same HAL0_HOME.
-    os.environ["HAL0_HOME"] = str(hal0_home)
+    # monkeypatch.setenv auto-restores HAL0_HOME on teardown so this never
+    # leaks into later tests (test_models_config default-path assertions).
+    monkeypatch.setenv("HAL0_HOME", str(hal0_home))
     from hal0.config import paths
 
     seed = ModelRegistry()

--- a/tests/slot_config/test_store_locking.py
+++ b/tests/slot_config/test_store_locking.py
@@ -1,0 +1,172 @@
+"""Cross-process lost-update regression for SlotConfigStore (SC-10).
+
+capabilities.toml is a read-modify-write file touched by both hal0-api and
+the CLI. Without a cross-process lock two concurrent selection writes
+interleave read -> modify -> write and clobber each other's change (the
+classic lost update). :meth:`SlotConfigStore.apply_and_commit` closes that
+gap by holding one advisory ``flock`` on the capabilities.toml sibling
+``.lock`` for the whole read+compute+write span.
+
+These tests use REAL OS processes (``multiprocessing`` with the ``fork``
+context) because advisory ``flock`` is honoured per open-file-description
+across processes — threads in one interpreter would not exercise the
+cross-process semantics the finding is about.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.config import (
+    CapabilitySelection,
+    capabilities_toml_path,
+    load_capabilities_config,
+)
+from hal0.slot_config import SlotConfigStore, SlotSelection
+
+
+def _seed_caps(caps_path: Path) -> None:
+    """Seed a v2 capabilities.toml carrying two children (embed + stt)."""
+    caps_path.parent.mkdir(parents=True, exist_ok=True)
+    caps_path.write_text(
+        "\n".join(
+            [
+                "schema_version = 2",
+                "[selections.embed.embed]",
+                'device = "cpu"',
+                'provider = "llama-server"',
+                'model = "embed-old"',
+                "enabled = false",
+                "[selections.voice.stt]",
+                'device = "cpu"',
+                'provider = "moonshine"',
+                'model = "stt-old"',
+                "enabled = false",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _worker(
+    slot: str,
+    child: str,
+    slot_name: str,
+    model: str,
+    barrier: Any,
+    commit_delay: float,
+) -> None:
+    """Run one ``apply_and_commit`` for a single child in its own process.
+
+    ``commit_delay`` inserts a pause between the store's authoritative read
+    (``apply``) and its write (``commit``) by wrapping the store's own
+    ``commit`` — the seam that, absent a lock, lets the other worker's full
+    RMW land in the gap and get clobbered. With the lock the delay is spent
+    holding the lock, so the other worker blocks and re-reads.
+    """
+    store = SlotConfigStore()
+    if commit_delay:
+        real_commit = store.commit
+
+        def _slow_commit(cs: Any) -> None:
+            time.sleep(commit_delay)
+            real_commit(cs)
+
+        store.commit = _slow_commit  # type: ignore[method-assign]
+
+    selection = SlotSelection(
+        slot=slot,
+        child=child,
+        slot_name=slot_name,
+        selection=CapabilitySelection(
+            device="cpu", provider="llama-server", model=model, enabled=True
+        ),
+    )
+    barrier.wait()
+    store.apply_and_commit(selection)
+
+
+def test_concurrent_apply_and_commit_keeps_both_updates(tmp_hal0_home: str) -> None:
+    """Two processes updating DIFFERENT children must both survive.
+
+    Worker A (embed) sleeps between its read and write; worker B (stt) does
+    a fast RMW. Without the lock A's stale write clobbers B's stt change.
+    The advisory lock forces the loser to re-read, so both land.
+    """
+    caps_path = capabilities_toml_path()
+    _seed_caps(caps_path)
+
+    ctx = multiprocessing.get_context("fork")
+    barrier = ctx.Barrier(2)
+
+    worker_a = ctx.Process(
+        target=_worker,
+        args=("embed", "embed", "embed", "embed-NEW", barrier, 0.5),
+    )
+    worker_b = ctx.Process(
+        target=_worker,
+        args=("voice", "stt", "stt", "stt-NEW", barrier, 0.0),
+    )
+    worker_a.start()
+    worker_b.start()
+    worker_a.join(timeout=15)
+    worker_b.join(timeout=15)
+    assert worker_a.exitcode == 0, "worker A crashed"
+    assert worker_b.exitcode == 0, "worker B crashed"
+
+    cfg = load_capabilities_config(caps_path)
+    embed = cfg.selections["embed"]["embed"]
+    stt = cfg.selections["voice"]["stt"]
+    assert embed.model == "embed-NEW", "embed update lost"
+    assert stt.model == "stt-NEW", "stt update lost (lost-update regression)"
+
+
+def _cli_migrate_worker(barrier: Any, commit_delay: float) -> None:
+    """Emulate the CLI migrate save path (load -> mutate -> save) under lock."""
+    from hal0.capabilities.config import save_capabilities_config
+    from hal0.config.locking import file_lock
+
+    barrier.wait()
+    with file_lock(capabilities_toml_path()):
+        cfg = load_capabilities_config()
+        cfg.selections.setdefault("embed", {})["embed"] = CapabilitySelection(
+            device="cpu", provider="llama-server", model="embed-CLI", enabled=True
+        )
+        if commit_delay:
+            time.sleep(commit_delay)
+        save_capabilities_config(cfg)
+
+
+def test_cli_migrate_vs_store_apply_no_lost_update(tmp_hal0_home: str) -> None:
+    """CLI-vs-API interleave: the migrate save path and store apply_and_commit
+    both hold the same lock, so neither drops the other's change."""
+    caps_path = capabilities_toml_path()
+    _seed_caps(caps_path)
+
+    ctx = multiprocessing.get_context("fork")
+    barrier = ctx.Barrier(2)
+
+    cli = ctx.Process(target=_cli_migrate_worker, args=(barrier, 0.5))
+    api = ctx.Process(
+        target=_worker,
+        args=("voice", "stt", "stt", "stt-NEW", barrier, 0.0),
+    )
+    cli.start()
+    api.start()
+    cli.join(timeout=15)
+    api.join(timeout=15)
+    assert cli.exitcode == 0 and api.exitcode == 0
+
+    cfg = load_capabilities_config(caps_path)
+    assert cfg.selections["embed"]["embed"].model == "embed-CLI", "CLI change lost"
+    assert cfg.selections["voice"]["stt"].model == "stt-NEW", "API change lost"
+
+
+if __name__ == "__main__":  # pragma: no cover - manual repro helper
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.7.3b2"
+version = "0.8.2b4"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## Wave 6 (final) of the platform-review remediation program

The report's last sequencing step — cross-process safety and housekeeping. Each finding verified, fixed TDD-style, gated by tree-wide ruff + a review pass.

| ID | Fix |
|----|-----|
| **MR-5** | Advisory `fcntl.flock` on a stable sidecar lockfile around registry `add/update/remove` + CLI `registry import`, closing the cross-process lost-update window. RLock retained; no-op fallback without fcntl. |
| **SC-10** | Shared `config/locking.py` advisory lock around capabilities/slot-config writes so a CLI migrate racing an API apply can't drop an update. |
| **MR-8** | `delete_model` unlinks the model's pull-job snapshot; a startup `sweep_pull_jobs()` reaps stale terminal snapshots. |
| **MR-9** | Startup `sweep_orphaned_partials()` reclaims `.part` files left by an OOM/SIGKILL mid-pull. |
| **MR-13** | `_atomic_write` (registry) and `persist_pull_job` (pull) fsync the parent dir after `os.replace` via a shared `_fsync_dir`. |
| **DR-12** | Extracted `resolve_by_capability` heuristics into `dispatcher/_capability_resolve.py`; fixed the stale `router.py` gate docstring. Behavior-preserving. |
| **MR-7** | Interrupted pulls resume via HTTP `Range` (+ `If-Range`/etag) instead of re-pulling from 0; re-hashes the on-disk prefix so the final SHA-256 stays exact — any doubt triggers a clean full restart. |

### Verification
- All 7 **confirmed**; red→green regression tests per finding.
- Local: registry+capabilities+slot_config+config+dispatcher+stacks **918 passed**; tree-wide ruff clean.
- Fixed a test-isolation bug found during integration: the MR-5 concurrency test leaked `HAL0_HOME` into later tests (would have failed CI ordering) — now uses `monkeypatch.setenv`.

Heavy integration wave: `registry/pull.py` was touched by 4 findings and `store.py` by 2; conflicts hand-merged (both startup sweeps kept, both durability helpers kept, MR-7 resume block + MR-8 GC coexist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)