### PR TITLE
fix(platform-review): Wave 7 — UI honesty/safety (T6) + PS-5 part 2

### DIFF
--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -256,7 +256,7 @@ def list_stacks() -> dict[str, Any]:
         {
           "stacks": [ {slug, name, ..., seed, active, drift}, ... ],
           "active": "coding" | null,
-          "drift":  "clean" | "modified" | "none"
+          "drift":  "clean" | "degraded" | "modified" | "none"
         }
 
     ``drift`` is meaningful for the active stack; the matching item also carries
@@ -394,10 +394,15 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
 
         plan = engine.plan(slug, cfg)
         engine.apply_config(plan)
-        engine.record_active(plan, applied_at=time.time())
+        # converge BEFORE recording active so the pointer carries the Phase-B
+        # outcome (PS-5 part 2). A slot-create or per-slot lifecycle failure
+        # means disk is honest but runtime never fully came up → converge_ok
+        # False so drift_status reports ``degraded`` rather than ``clean``.
         converged: dict[str, Any] = {}
+        converge_ok = not create_errors
         if slot_manager is not None and orchestrator is not None:
             report = await engine.converge(cfg)
+            converge_ok = converge_ok and not report.errors
             converged = {
                 "loaded": report.loaded,
                 "swapped": report.swapped,
@@ -406,6 +411,7 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
                 "capabilities_applied": report.capabilities_applied,
                 "errors": [{"target": t, "error": e} for t, e in report.errors] + create_errors,
             }
+        engine.record_active(plan, applied_at=time.time(), converge_ok=converge_ok)
         rec.after = {
             "slug": slug,
             "changed": sum(1 for r in _diff_rows(plan) if r["changed"]),

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -266,17 +266,25 @@ class StackApplyEngine:
             out[entry.slot] = _read_toml_or_none(self._slot_path(entry.slot))
         return out
 
-    def record_active(self, plan: StackChangePlan, *, applied_at: float) -> None:
+    def record_active(
+        self, plan: StackChangePlan, *, applied_at: float, converge_ok: bool = True
+    ) -> None:
         """Record ``plan``'s stack as active, fingerprinting what it wrote.
 
         Call AFTER ``apply_config`` succeeds. The hash is taken over the
         after-state projection, which equals live disk immediately post-commit
         (so ``drift_status`` reports ``clean`` until something hand-edits a slot).
+
+        ``converge_ok`` carries the Phase-B outcome (PS-5 part 2): pass ``False``
+        when converge recorded per-slot lifecycle errors, so ``drift_status``
+        reports ``degraded`` instead of ``clean`` even though disk still matches
+        the fingerprint. Defaults to ``True`` (no converge attempted / clean).
         """
         record = StackStateRecord(
             active_slug=plan.stack_slug,
             content_hash=stack_content_hash(self._projection_from_plan(plan)),
             applied_at=applied_at,
+            converge_ok=converge_ok,
         )
         write_stack_state_atomic(paths.stacks_state_path(), record)
 
@@ -284,8 +292,11 @@ class StackApplyEngine:
         """Report the active stack and whether live config has drifted from it.
 
         ``none`` — no stack applied. ``clean`` — live slot config matches the
-        applied fingerprint. ``modified`` — a slot was hand-edited since apply.
-        ``catalog`` is a ``StacksCatalog`` (duck-typed: needs ``.resolve(slug)``).
+        applied fingerprint AND converge brought runtime up cleanly. ``degraded``
+        — disk matches but converge recorded per-slot lifecycle errors (PS-5
+        part 2): the config is honest but the runtime never fully came up.
+        ``modified`` — a slot was hand-edited since apply.  ``catalog`` is a
+        ``StacksCatalog`` (duck-typed: needs ``.resolve(slug)``).
         """
         record = read_stack_state(paths.stacks_state_path())
         if record is None:
@@ -296,7 +307,12 @@ class StackApplyEngine:
             # Active stack was deleted out from under the pointer.
             return {"active": record.active_slug, "status": "modified"}
         live = self._projection_live(StackConfig(slots=list(resolved.slots)))
-        status = "clean" if stack_content_hash(live) == record.content_hash else "modified"
+        if stack_content_hash(live) != record.content_hash:
+            status = "modified"
+        elif not record.converge_ok:
+            status = "degraded"
+        else:
+            status = "clean"
         return {"active": record.active_slug, "status": status}
 
     # ── converge (Phase B — runtime lifecycle) ───────────────────────────────

--- a/src/hal0/stacks/state.py
+++ b/src/hal0/stacks/state.py
@@ -20,17 +20,27 @@ from typing import Any
 
 @dataclass(frozen=True)
 class StackStateRecord:
-    """Which stack is applied, and the hash of what it wrote."""
+    """Which stack is applied, the hash of what it wrote, and whether converge
+    brought runtime up cleanly.
+
+    ``converge_ok`` is ``False`` when the apply committed config to disk (Phase A)
+    but one or more per-slot lifecycle steps failed during converge (Phase B), so
+    live disk still matches the fingerprint yet the runtime never fully came up.
+    Drift detection reads it to tell ``clean`` from ``degraded`` (PS-5 part 2).
+    Older records lacking the field default to ``True`` (assume a clean converge).
+    """
 
     active_slug: str
     content_hash: str
     applied_at: float
+    converge_ok: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "active_slug": self.active_slug,
             "content_hash": self.content_hash,
             "applied_at": self.applied_at,
+            "converge_ok": self.converge_ok,
         }
 
     @classmethod
@@ -39,6 +49,7 @@ class StackStateRecord:
             active_slug=str(data.get("active_slug", "")),
             content_hash=str(data.get("content_hash", "")),
             applied_at=float(data.get("applied_at", 0.0)),
+            converge_ok=bool(data.get("converge_ok", True)),
         )
 
 

--- a/tests/stacks/test_drift.py
+++ b/tests/stacks/test_drift.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from hal0.config import paths
 from hal0.config.schema import StackConfig, StackSlotEntry
+from hal0.slots.state import SlotState
 from hal0.stacks import StacksCatalog
 from hal0.stacks.apply import StackApplyEngine
 from hal0.stacks.state import (
@@ -18,6 +19,7 @@ from hal0.stacks.state import (
     stack_content_hash,
     write_stack_state_atomic,
 )
+from tests.stacks.conftest import FakeSnap, RecordingOrchestrator, RecordingSlotManager
 
 
 def _slots_dir(home: str) -> Path:
@@ -101,3 +103,50 @@ class TestDriftStatus:
         # Hand-edit the slot after applying → drift.
         slot_path.write_text(slot_path.read_text() + '\nrole = "primary"\n', encoding="utf-8")
         assert engine.drift_status(catalog)["status"] == "modified"
+
+
+class TestConvergeDegraded:
+    """PS-5 part 2 — a converge whose per-slot loads failed must not read clean.
+
+    The slot TOMLs are committed cleanly (Phase A), so the drift hash still
+    matches live disk; without the converge_ok flag drift_status would wrongly
+    report ``clean`` even though the runtime never came up. It must report
+    ``degraded`` instead.
+    """
+
+    async def test_load_error_reports_degraded_not_clean(self, tmp_hal0_home: str) -> None:
+        _write_slot(tmp_hal0_home, "agent", "old")
+        catalog = StacksCatalog(path=Path(tmp_hal0_home) / "etc" / "hal0" / "stacks.toml")
+        catalog.create("saber", _saber())
+
+        class Boom(RecordingSlotManager):
+            async def load(self, slot_name, model_id=None):
+                raise RuntimeError("spawn failed")
+
+        sm = Boom([FakeSnap("agent", SlotState.OFFLINE, None)])
+        engine = StackApplyEngine(slot_manager=sm, orchestrator=RecordingOrchestrator())
+
+        plan = engine.plan("saber", _saber())
+        engine.apply_config(plan)
+        report = await engine.converge(_saber())
+        assert report.errors, "converge should have recorded a per-slot load error"
+        engine.record_active(plan, applied_at=1.0, converge_ok=not report.errors)
+
+        status = engine.drift_status(catalog)
+        assert status == {"active": "saber", "status": "degraded"}
+
+    async def test_clean_converge_still_reports_clean(self, tmp_hal0_home: str) -> None:
+        _write_slot(tmp_hal0_home, "agent", "old")
+        catalog = StacksCatalog(path=Path(tmp_hal0_home) / "etc" / "hal0" / "stacks.toml")
+        catalog.create("saber", _saber())
+
+        sm = RecordingSlotManager([FakeSnap("agent", SlotState.OFFLINE, None)])
+        engine = StackApplyEngine(slot_manager=sm, orchestrator=RecordingOrchestrator())
+
+        plan = engine.plan("saber", _saber())
+        engine.apply_config(plan)
+        report = await engine.converge(_saber())
+        assert not report.errors
+        engine.record_active(plan, applied_at=1.0, converge_ok=not report.errors)
+
+        assert engine.drift_status(catalog) == {"active": "saber", "status": "clean"}

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -447,7 +447,7 @@ function DeleteModelDialog({ open, onClose, model }) {
   const slotsQuery = useSlots();
   if (!model) return null;
   const slots = slotsQuery.data ?? [];
-  const slotsUsing = slots.filter(s => (s.model_id || s.model?.default) === model.id);
+  const slotsUsing = slots.filter(s => s.model_id === model.id || s.model === model.id);
   const hasUsers = slotsUsing.length > 0;
 
   const onConfirm = async () => {
@@ -496,7 +496,7 @@ function UsedByPanel({ model }) {
   const slotsQuery = useSlots();
   if (!model) return null;
   const slots = slotsQuery.data ?? [];
-  const using = slots.filter(s => (s.model_id || s.model?.default) === model.id);
+  const using = slots.filter(s => s.model_id === model.id || s.model === model.id);
   return (
     <div className="mdl-detail-recipe">
       <div className="lbl">Used by</div>
@@ -579,7 +579,9 @@ function DownloadRow({ modelId, onRemove }) {
       setCancelling(false);
     }
   };
-  const onPause = doCancel;  // engine has no pause; degrade to cancel.
+  // UI-9: no "Pause" button — the pull engine has no pause (job.cancel() sets
+  // the terminal `cancelled` state and destroys the download). Only an honest
+  // Cancel is offered; a re-pull resumes from the .part file backend-side.
   const onCancel = doCancel;
   const onRetry = () => { job.start(modelId); };
 
@@ -625,10 +627,7 @@ function DownloadRow({ modelId, onRemove }) {
       )}
       <div style={{display: "flex", gap: 4, marginTop: 6}}>
         {state === "running" && (
-          <>
-            <button className="btn ghost sm" onClick={onPause} disabled={cancelling}>Pause</button>
-            <button className="btn ghost sm" onClick={onCancel} disabled={cancelling}>{cancelling ? "Cancelling…" : "Cancel"}</button>
-          </>
+          <button className="btn ghost sm" onClick={onCancel} disabled={cancelling}>{cancelling ? "Cancelling…" : "Cancel"}</button>
         )}
         {state === "queued" && (
           <button className="btn ghost sm" onClick={onCancel} disabled={cancelling}>{cancelling ? "Cancelling…" : "Cancel"}</button>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -20,7 +20,7 @@ import { useModels } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
 import { ENDPOINTS } from '@/api/endpoints'
-import { stateChipClassForSlot } from './slot-status.js'
+import { stateChipClassForSlot, slotButtonPhase } from './slot-status.js'
 
 const { useState: useStateSM, useEffect: useEffectSM, useRef: useRefSM } = React;
 
@@ -118,7 +118,11 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   });
   const { name, type, profile, model, makeDefault } = f.values;
   const setName = (val) => f.set("name", val);
-  const setType = (val) => f.set("type", val);
+  // UI-21: changing Type must clear the selected model — a model compatible
+  // with the old type is almost always incompatible with the new one, and the
+  // stale id would otherwise ride into the create body. Use setValues so both
+  // fields flip in one update (mark type touched to match f.set semantics).
+  const setType = (val) => { f.setValues(v => ({ ...v, type: val, model: "" })); f.touch("type"); };
   const setProfile = (val) => f.set("profile", val);
   const setModel = (val) => f.set("model", val);
   const setMakeDefault = (val) => f.set("makeDefault", val);
@@ -280,9 +284,18 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
               </option>
             ))}
           </select>
-          {model && compatible.find(m => m.id === model) && (
-            <div className="ok">✓ fits in available memory ({hwQuery.data?.ram?.free ?? "?"} GB free)</div>
-          )}
+          {model && (() => {
+            // UI-6: real size-vs-RAM check, reusing the same parseSizeGB test
+            // the InlineSwapPopover uses (data.jsx global). The old branch
+            // rendered an unconditional "fits" claim regardless of model size.
+            const selM = compatible.find(m => m.id === model);
+            if (!selM) return null;
+            const ramFreeGb = hwQuery.data?.ram?.free ?? 0;
+            const fits = ramFreeGb > parseSizeGB(selM.size);
+            return fits
+              ? <div className="ok">✓ fits in available memory ({ramFreeGb} GB free)</div>
+              : <div className="hint" style={{color: "var(--warn)"}}>⚠ may not fit — {selM.size} model vs {ramFreeGb} GB free</div>;
+          })()}
         </div>
       </div>
 
@@ -372,6 +385,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // pill toggle, which the redesigned cards dropped). `enableBusy` gates the
   // header toggle against a double-trigger while the mutation is in flight.
   const [enableBusy, setEnableBusy] = useStateSM(false);
+  // UI-16: destructive delete confirms through the shared ConfirmDialog
+  // (type-to-confirm the slot name), mirroring DeleteModelDialog — replaces
+  // the raw window.confirm that used to gate onDeleteClick.
+  const [delOpen, setDelOpen] = useStateSM(false);
   // Inline error for the instant-apply thinking toggle (task 3): surface the
   // failure next to the control instead of only reverting state silently.
   const [thinkingErr, setThinkingErr] = useStateSM(null);
@@ -536,14 +553,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
     );
   }
 
-  async function onDeleteClick() {
-    if (!window.confirm(`Delete slot "${slot.name}"?`)) return;
+  async function onDeleteConfirm() {
     setSubmitErr(null);
     try {
       await deleteMut.mutateAsync(slot.name);
       window.__hal0Toast && window.__hal0Toast(`Slot "${slot.name}" deleted`, "ok");
+      setDelOpen(false);
       onClose();
     } catch (err) {
+      setDelOpen(false);
       setSubmitErr(err?.message || "delete failed");
     }
   }
@@ -600,6 +618,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
   };
 
   return (
+    <>
     <Drawer
       open={open}
       onClose={onClose}
@@ -628,7 +647,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
           <button
             className="btn danger sm"
             disabled={deleting}
-            onClick={onDeleteClick}
+            onClick={() => setDelOpen(true)}
           >{Icons.unload} {deleting ? "Deleting…" : "Delete slot"}</button>
           <span style={{display: "inline-flex", gap: 8, alignItems: "center"}}>
             {submitErr && <span style={{color: "var(--err)", fontSize: 11}}>{submitErr}</span>}
@@ -778,6 +797,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
                 onChange={(e) => {
                   const id = e.target.value;
                   if (!id || id === cur) return;
+                  // UI-5: swapping the model on a LIVE container slot cold-restarts
+                  // it (~model-load seconds). Confirm before firing — bailing here
+                  // re-renders the select back to `cur` (value={cur}), so no manual
+                  // revert is needed. Mirrors the delete/dirty-close confirm gates.
+                  const live = slotButtonPhase(slot) === "running";
+                  if (isContainer && live && !window.confirm(`Swap model on running slot "${slot.name}"? This cold-restarts the container (~model-load seconds).`)) return;
                   setSubmitErr(null);
                   const picked = compatible.find(m => m.id === id);
                   const label = picked?.longName || id;
@@ -1169,6 +1194,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
       </div>
       </details>
     </Drawer>
+    <ConfirmDialog
+      open={delOpen}
+      onCancel={() => setDelOpen(false)}
+      onConfirm={onDeleteConfirm}
+      title={`Delete slot ${slot.name}?`}
+      message={
+        <span>
+          This removes the slot <span className="mono" style={{color: "var(--fg)"}}>{slot.name}</span> and
+          its <span className="mono">capabilities.toml</span> config. The container is stopped and the
+          slot is gone from the host.
+        </span>
+      }
+      confirmLabel={deleting ? "Deleting…" : "Delete slot"}
+      destructive
+      typeToConfirm={slot.name}
+    />
+    </>
   );
 }
 
@@ -1205,6 +1247,10 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
     if (isContainer) {
       const name = slot.name;
       const label = m.longName || m.id;
+      // UI-5: confirm before cold-restarting a LIVE container slot. Bail out
+      // (leaving the popover open) when the operator declines.
+      const live = slotButtonPhase(slot) === "running";
+      if (live && !window.confirm(`Swap model on running slot "${name}"? This cold-restarts the container (~model-load seconds).`)) return;
       window.__hal0Toast && window.__hal0Toast(
         `Restarting ${name} to load ${label} — ~model-load seconds`,
         "info"

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -125,8 +125,13 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     )
 
     await page.goto('/#slots/primary')
-    page.on('dialog', (d) => d.accept())
+    // UI-16: slot delete now confirms through the styled ConfirmDialog
+    // (type-to-confirm the slot name), replacing the raw window.confirm.
     await page.locator('.drawer button.btn.danger:has-text("Delete")').click()
+    await page.locator('input.input.mono').last().fill('primary')
+    // The ConfirmDialog overlay renders last, so its confirm button is the
+    // last "Delete slot" match (the drawer's own danger button is the first).
+    await page.locator('button:has-text("Delete slot")').last().click()
     await expect.poll(() => deletes.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Wave 7 — the deferred T6 cut ("destructive & disruptive actions lack friction and honesty") + PS-5 part 2

All 7 findings adversarially verified against current (post-Wave-1..6) source, then fixed reusing Wave-5/6 primitives.

| ID | Fix |
|----|-----|
| **UI-9** | Removed the "Pause" button that silently **cancelled** (destroyed) a download — only honest Cancel remains. |
| **UI-6** | Real size-vs-free-RAM check (reuses `parseSizeGB`) instead of the fake "✓ fits in available memory" that showed whenever a model was merely selected. |
| **UI-5** | Confirm before a model-swap **cold-restarts a running** container (was instant on `<select>` change with only a toast). |
| **UI-16** | Styled `ConfirmDialog` (type-to-confirm) for slot delete, matching model/profile/stack deletes — was a raw `window.confirm`. |
| **UI-10** | Fixed the dead `s.model?.default` branch so the delete-cascade "used by" warning stops under-reporting (matches `s.model_id === id || s.model === id`). |
| **UI-21** | Reset the selected model when slot **type** changes, so a stale now-incompatible id isn't sent in the create body. |
| **PS-5 pt2** | Stack converge failures now report **degraded**, not clean: a `converge_ok` flag threads through `record_active`/`StackStateRecord` so `drift_status` stops lying when the config committed but slots failed to load. |

### Verification
- All 7 **confirmed**; PS-5-p2 red→green regression tests (`TestConvergeDegraded`).
- Local: stacks + stacks-routes **102 passed**; `tsc` + **vite build clean** (the real `.jsx` gate); tree-wide ruff clean.
- UI cluster reuses existing primitives (ConfirmDialog, `parseSizeGB`, `slotButtonPhase`, `useForm.setValues`) — no new dialogs/sizing invented.

Closes the T6 through-line and the PS-5 deferral. Remaining backlog after this: the low-severity UI polish (UI-2/4/20) and unsequenced SC/MR/DR/PS items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)