### PR TITLE
feat(dashboard): surface live telemetry widgets (Power/Thermal, Per-Slot Throughput, MHz/temp)

### DIFF
--- a/ui/src/api/hooks/useDashLayout.ts
+++ b/ui/src/api/hooks/useDashLayout.ts
@@ -58,9 +58,9 @@ export const CARD_REGISTRY: CardDef[] = [
   { id: 'services',    name: 'Services',           icon: 'route',     span: 6,  min: 4,  locked: false, defaultOn: true  },
   { id: 'utilization', name: 'Utilization',        icon: 'gauge',     span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'attention',   name: 'Needs Attention',    icon: 'shield',    span: 4,  min: 3,  locked: false, defaultOn: true  },
-  { id: 'slottrack',   name: 'Per-Slot Throughput',icon: 'flow',      span: 4,  min: 3,  locked: false, defaultOn: false },
+  { id: 'slottrack',   name: 'Per-Slot Throughput',icon: 'flow',      span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'approvals',   name: 'Agent Approvals',    icon: 'shield',    span: 4,  min: 3,  locked: false, defaultOn: false },
-  { id: 'power',       name: 'Power & Thermal',    icon: 'thermo',    span: 4,  min: 3,  locked: false, defaultOn: false },
+  { id: 'power',       name: 'Power & Thermal',    icon: 'thermo',    span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'scheduler',   name: 'Scheduler',          icon: 'clock',     span: 4,  min: 3,  locked: false, defaultOn: false },
 ]
 

--- a/ui/src/dash/dash-grid.jsx
+++ b/ui/src/dash/dash-grid.jsx
@@ -46,9 +46,9 @@ const CARD_REGISTRY = [
   { id: 'services',    name: 'Services',            icon: 'route',  span: 6,  min: 4,  locked: false, defaultOn: true  },
   { id: 'utilization', name: 'Utilization',         icon: 'gauge',  span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'attention',   name: 'Needs Attention',     icon: 'shield', span: 4,  min: 3,  locked: false, defaultOn: true  },
-  { id: 'slottrack',   name: 'Per-Slot Throughput', icon: 'flow',   span: 4,  min: 3,  locked: false, defaultOn: false },
+  { id: 'slottrack',   name: 'Per-Slot Throughput', icon: 'flow',   span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'approvals',   name: 'Agent Approvals',     icon: 'shield', span: 4,  min: 3,  locked: false, defaultOn: false },
-  { id: 'power',       name: 'Power & Thermal',     icon: 'thermo', span: 4,  min: 3,  locked: false, defaultOn: false },
+  { id: 'power',       name: 'Power & Thermal',     icon: 'thermo', span: 4,  min: 3,  locked: false, defaultOn: true  },
   { id: 'scheduler',   name: 'Scheduler',           icon: 'clock',  span: 4,  min: 3,  locked: false, defaultOn: false },
 ];
 const CARD_MAP = Object.fromEntries(CARD_REGISTRY.map(c => [c.id, c]));

--- a/ui/src/dash/metric-cards.jsx
+++ b/ui/src/dash/metric-cards.jsx
@@ -153,6 +153,16 @@ function UtilizationCard() {
   // iGPU: gpu_util (float 0-1). Present in existing endpoint.
   const gpuUtil = stats?.gpu_util ?? null
 
+  // Live iGPU clock + temp — same payload, mirrors the Inference GPU gauge
+  // caption (inference-pane.jsx). Rendered as a small caption, each piece
+  // guarded so a missing value is simply omitted (never a fake 0).
+  const gpuMhz  = stats?.gpu_clock_mhz ?? null
+  const gpuTemp = stats?.gpu_temp_c ?? null
+  const gpuCaption = [
+    gpuMhz  != null ? `${Math.round(gpuMhz)} MHz` : null,
+    gpuTemp != null ? `${Math.round(gpuTemp)}°C` : null,
+  ].filter(Boolean).join(' · ')
+
   // CPU: cpu_util — NEW field (§2b), optional until backend ships.
   // Plain JS property access — absent key returns undefined, ?? null gates it.
   const cpuUtil = stats?.cpu_util ?? null
@@ -174,6 +184,11 @@ function UtilizationCard() {
           color="var(--dev-vulkan)"
           note={gpuUtil == null ? 'pending driver' : null}
         />
+
+        {/* iGPU clock + temp caption — live from the same hardware payload */}
+        {gpuCaption && (
+          <div className="uc-gpu-caption mono">{gpuCaption}</div>
+        )}
 
         {/* CPU row */}
         <UtilCard_Row

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -964,6 +964,15 @@
   letter-spacing: 0.04em;
 }
 
+/* iGPU clock + temp caption — mirrors the Inference GPU gauge readout */
+.uc-gpu-caption {
+  font-family: var(--jbm);
+  font-size: 9px;
+  color: var(--fg-4);
+  letter-spacing: 0.04em;
+  margin: -4px 0 2px 16px;
+}
+
 /* NPU pill: active / idle */
 .uc-npu-status {
   display: flex;


### PR DESCRIPTION
## Wave 8A — live telemetry on the main dashboard

The customizable dashboard board already shipped the telemetry cards as **opt-in**; this makes the throughput / usage / live-clock signals visible by default.

- **Power & Thermal** card (live GPU **MHz** + temp + power, from `/api/stats/power`) → `defaultOn: true`.
- **Per-Slot Throughput** card (per-slot tok/s, from `/api/throughput`) → `defaultOn: true`.
- **Utilization** card (already default-on) now shows a guarded **live clock/temp caption** ("1234 MHz · 61°C") reusing `gpu_clock_mhz`/`gpu_temp_c` already in its `useStatsHardware` payload.

Both `CARD_REGISTRY` copies (`dash-grid.jsx` + `useDashLayout.ts`) updated identically. No new data hooks or client ring buffers; existing card behavior unchanged.

### Verification
- `npm run build` (vite) clean; **13 dashboard e2e specs pass** locally (dashboard-overhaul, dashboard-v3, footer-throughput, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)