### PR TITLE
feat(ui): edit-drawer completeness — all backend values editable (slot/model/profile) + UI-2/20

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -308,6 +308,14 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         # the truth source the dashboard uses to dirty-track changes,
         # so an absent on-disk field surfaces as null/None, not the
         # schema default.
+        # #901: per-slot vision toggle (tri-valued: true/false/absent → null).
+        # Surfaced so the edit-drawer Vision pill seeds from disk. The
+        # SlotConfig default is ON (True) — the mmproj sidecar loads unless
+        # explicitly disabled — so the UI treats null as "on" and only writes
+        # back when the operator turns the ~0.9 GB projector off. Mirrors the
+        # idle_timeout_s lift below (absent surfaces as None, not the schema
+        # default, so the dashboard can dirty-track real on-disk state).
+        entry["vision"] = cfg.get("vision")
         entry["idle_timeout_s"] = cfg.get("idle_timeout_s")
         entry["workers"] = cfg.get("workers")
         server_cfg = cfg.get("server")

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -302,6 +302,7 @@ class TestConfigEnrichment:
             enable_thinking=True,
             idle_timeout_s=900,
             workers=2,
+            vision=False,
             server={"extra_args": "--flash-attn on"},
             npu={"asr": True, "embed": False},
         )
@@ -321,6 +322,8 @@ class TestConfigEnrichment:
         assert e["chat_template"] == "chatml"
         assert e["n_gpu_layers"] == 24
         assert e["rope_freq_base"] == 10000.0
+        # #901: vision toggle lifted (default-on; explicit false persisted).
+        assert e["vision"] is False
         assert e["idle_timeout_s"] == 900
         assert e["workers"] == 2
         assert e["llamacpp_args"] == "--flash-attn on"
@@ -350,6 +353,8 @@ class TestConfigEnrichment:
         assert e["chat_template"] is None
         assert e["n_gpu_layers"] == -1
         assert e["rope_freq_base"] is None
+        # #901: vision surfaces as None when absent (UI treats null as on).
+        assert e["vision"] is None
         assert e["idle_timeout_s"] is None
         assert e["workers"] is None
         assert e["llamacpp_args"] is None

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -252,6 +252,20 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   );
 }
 
+// Model.capabilities vocabulary (registry/model.py) — drives dispatch/omni
+// eligibility. Historically only settable at register time.
+const MODEL_CAPABILITIES = ["chat", "embed", "rerank", "vision", "asr", "tts"];
+// Model.backends vocabulary — drives slot-compat filtering in the slot form.
+const MODEL_BACKENDS = ["rocm", "vulkan", "cpu", "cuda", "flm", "moonshine", "kokoro"];
+
+// Order-insensitive set equality for the array fields (capabilities/backends),
+// so a defaults-only save doesn't spuriously report those as changed.
+function sameStringSet(a, b) {
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.length === sb.length && sa.join(" ") === sb.join(" ");
+}
+
 // ─── Recipe editor (per-model defaults) ────────────────────────
 function RecipeEditorModal({ open, onClose, model }) {
   const update = useModelUpdate();
@@ -261,6 +275,7 @@ function RecipeEditorModal({ open, onClose, model }) {
   const init = model?.defaults || {};
   const [ctx, setCtx] = useStateMM("");
   const [ngl, setNgl] = useStateMM("");
+  const [rope, setRope] = useStateMM("");
   const [extra, setExtra] = useStateMM("");
   const [chatTemplate, setChatTemplate] = useStateMM("auto");
   // Identity + types. `name` is the editable display name; `types` is the
@@ -269,40 +284,70 @@ function RecipeEditorModal({ open, onClose, model }) {
   const [name, setName] = useStateMM("");
   const [types, setTypes] = useStateMM([]);
   const [otherTags, setOtherTags] = useStateMM([]);
+  // Routing-critical top-level fields (registry/model.py): capabilities gate
+  // dispatch/omni eligibility, backends gate slot-compat filtering, mmproj is
+  // the vision projector sidecar path, and hf_repo/hf_filename are the re-pull
+  // coords (POST /pull 422s without them).
+  const [caps, setCaps] = useStateMM([]);
+  const [backends, setBackends] = useStateMM([]);
+  const [mmproj, setMmproj] = useStateMM("");
+  const [hfRepo, setHfRepo] = useStateMM("");
+  const [hfFilename, setHfFilename] = useStateMM("");
 
   useEffectMM(() => {
     if (open && model) {
       setCtx(init.context_size != null ? String(init.context_size) : "");
       setNgl(init.n_gpu_layers != null ? String(init.n_gpu_layers) : "");
+      setRope(init.rope_freq_base != null ? String(init.rope_freq_base) : "");
       setExtra(init.extra_args || "");
       setChatTemplate(init.chat_template ?? "auto");
       setName(model.name || "");
       const split = splitModelTags(model.tags);
       setTypes(split.selected);
       setOtherTags(split.other);
+      setCaps(Array.isArray(model.capabilities) ? model.capabilities : []);
+      setBackends(Array.isArray(model.backends) ? model.backends : []);
+      setMmproj(model.mmproj || "");
+      setHfRepo(model.hf_repo || "");
+      setHfFilename(model.hf_filename || "");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, model?.id]);
 
   const toggleType = (tag) =>
     setTypes(prev => prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]);
+  const toggleCap = (cap) =>
+    setCaps(prev => prev.includes(cap) ? prev.filter(c => c !== cap) : [...prev, cap]);
+  const toggleBackend = (b) =>
+    setBackends(prev => prev.includes(b) ? prev.filter(x => x !== b) : [...prev, b]);
 
   if (!model) return null;
 
   const onSave = async () => {
-    const defaults = {};
+    // Preserve any ModelDefaults field the editor doesn't surface. The
+    // registry PUT flat-merges `defaults` WHOLESALE, so we must start from the
+    // stored defaults and only override the keys we render inputs for —
+    // otherwise siblings (e.g. a hand-set rope_freq_base) are silently cleared.
+    // Emptying a shown input clears just that one key (delete), keeping the
+    // "empty = launcher default" affordance intact.
+    const defaults = { ...init };
     if (ctx.trim()) {
       const n = parseInt(ctx, 10);
-      if (Number.isFinite(n)) defaults.context_size = n;
-    }
+      if (Number.isFinite(n)) defaults.context_size = n; else delete defaults.context_size;
+    } else delete defaults.context_size;
     if (ngl.trim()) {
       const n = parseInt(ngl, 10);
-      if (Number.isFinite(n)) defaults.n_gpu_layers = n;
-    }
-    if (extra.trim()) defaults.extra_args = extra;
+      if (Number.isFinite(n)) defaults.n_gpu_layers = n; else delete defaults.n_gpu_layers;
+    } else delete defaults.n_gpu_layers;
+    if (rope.trim()) {
+      const n = parseFloat(rope);
+      if (Number.isFinite(n)) defaults.rope_freq_base = n; else delete defaults.rope_freq_base;
+    } else delete defaults.rope_freq_base;
+    if (extra.trim()) defaults.extra_args = extra; else delete defaults.extra_args;
     // Only persist a real template choice — 'auto' means GGUF-embedded, which
     // is the absence of an override, so don't pollute defaults with it.
     if (chatTemplate && chatTemplate !== "auto") defaults.chat_template = chatTemplate;
+    else delete defaults.chat_template;
     const body = { defaults };
     // Display name: only persist a real, changed value — never blank it out.
     const trimmedName = name.trim();
@@ -316,6 +361,20 @@ function RecipeEditorModal({ open, onClose, model }) {
       nextTags.length === prevTags.length &&
       [...nextTags].sort().join(" ") === [...prevTags].sort().join(" ");
     if (!sameTags) body.tags = nextTags;
+    // Capabilities + backends: routing-critical top-level sets. Emit only when
+    // the set actually changed (order-insensitive).
+    const prevCaps = Array.isArray(model.capabilities) ? model.capabilities : [];
+    if (!sameStringSet(caps, prevCaps)) body.capabilities = caps;
+    const prevBackends = Array.isArray(model.backends) ? model.backends : [];
+    if (!sameStringSet(backends, prevBackends)) body.backends = backends;
+    // Vision projector sidecar path; "" clears it (null on the wire).
+    const trimmedMmproj = mmproj.trim();
+    if (trimmedMmproj !== (model.mmproj || "")) body.mmproj = trimmedMmproj || null;
+    // Re-pull source coords — without these a subsequent Pull 422s.
+    const trimmedRepo = hfRepo.trim();
+    if (trimmedRepo !== (model.hf_repo || "")) body.hf_repo = trimmedRepo;
+    const trimmedFile = hfFilename.trim();
+    if (trimmedFile !== (model.hf_filename || "")) body.hf_filename = trimmedFile;
     try {
       await update.mutateAsync({ id: model.id, body });
       window.__hal0Toast && window.__hal0Toast(`Updated ${model.longName || model.id}`, "ok");
@@ -387,11 +446,68 @@ function RecipeEditorModal({ open, onClose, model }) {
       </div>
       <div className="form-row">
         <div className="form-lbl">
+          <span>capabilities</span>
+          <span className="sub">dispatch / omni eligibility · chat · embed · rerank · vision · asr · tts</span>
+        </div>
+        <div className="form-ctl" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {MODEL_CAPABILITIES.map(cap => {
+            const on = caps.includes(cap);
+            return (
+              <button
+                key={cap}
+                type="button"
+                role="switch"
+                aria-checked={on}
+                data-testid={`cap-toggle-${cap}`}
+                className={"mdl-chip" + (on ? " on" : "")}
+                onClick={() => toggleCap(cap)}
+              >
+                {cap}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>backends</span>
+          <span className="sub">runners this model can bind · drives slot-compat filtering</span>
+        </div>
+        <div className="form-ctl" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {MODEL_BACKENDS.map(b => {
+            const on = backends.includes(b);
+            return (
+              <button
+                key={b}
+                type="button"
+                role="switch"
+                aria-checked={on}
+                data-testid={`backend-toggle-${b}`}
+                className={"mdl-chip" + (on ? " on" : "")}
+                onClick={() => toggleBackend(b)}
+              >
+                {b}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
           <span>context_size</span>
           <span className="sub">tokens · empty = launcher default</span>
         </div>
         <div className="form-ctl">
           <input className="input mono" inputMode="numeric" placeholder="e.g. 8192" value={ctx} onChange={e => setCtx(e.target.value)} />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>rope_freq_base</span>
+          <span className="sub">float · empty = launcher / GGUF default</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" inputMode="decimal" placeholder="e.g. 10000" value={rope} onChange={e => setRope(e.target.value)} />
         </div>
       </div>
       <div className="form-row">
@@ -428,6 +544,42 @@ function RecipeEditorModal({ open, onClose, model }) {
               <option key={t.id} value={t.id}>{t.label}</option>
             ))}
           </select>
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>mmproj</span>
+          <span className="sub">vision projector sidecar path · required when a vision capability is set</span>
+        </div>
+        <div className="form-ctl">
+          <input
+            className="input mono"
+            placeholder="/var/lib/hal0/models/…/mmproj-Q8.gguf"
+            value={mmproj}
+            onChange={e => setMmproj(e.target.value)}
+          />
+          {caps.includes("vision") && !mmproj.trim() && (
+            <div className="err" style={{marginTop: 6}}>vision capability requires an mmproj sidecar path</div>
+          )}
+        </div>
+      </div>
+      <div className="form-section">Source · re-pull coords</div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>hf_repo</span>
+          <span className="sub">HuggingFace repo · needed to re-pull</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" placeholder="unsloth/Qwen3-8B-GGUF" value={hfRepo} onChange={e => setHfRepo(e.target.value)} />
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>hf_filename</span>
+          <span className="sub">variant filename within the repo</span>
+        </div>
+        <div className="form-ctl">
+          <input className="input mono" placeholder="qwen3-8b-q4_k_m.gguf" value={hfFilename} onChange={e => setHfFilename(e.target.value)} />
         </div>
       </div>
       {update.isError && (

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -29,10 +29,16 @@ import { prettyProfile } from './profile-names'
 // value persisted to ProfileConfig.backend (null for non-GPU paths, where
 // device_class carries the hardware intent — see #751).
 const BACKEND_META = {
-  rocm:   { label: 'ROCm',      color: 'var(--dev-rocm)',   device_class: 'gpu', backendField: 'rocm' },
-  vulkan: { label: 'Vulkan',    color: 'var(--dev-vulkan)', device_class: 'gpu', backendField: 'vulkan' },
-  npu:    { label: 'FLM · NPU', color: 'var(--dev-npu)',    device_class: 'npu', backendField: null },
-  cpu:    { label: 'CPU',       color: 'var(--dev-cpu)',    device_class: 'cpu', backendField: null },
+  rocm:   { label: 'ROCm',          color: 'var(--dev-rocm)',   device_class: 'gpu', backendField: 'rocm' },
+  vulkan: { label: 'Vulkan',        color: 'var(--dev-vulkan)', device_class: 'gpu', backendField: 'vulkan' },
+  npu:    { label: 'FLM · NPU',     color: 'var(--dev-npu)',    device_class: 'npu', backendField: null },
+  cpu:    { label: 'CPU',           color: 'var(--dev-cpu)',    device_class: 'cpu', backendField: null },
+  // ComfyUI image-gen path: no llama.cpp backend, device_class carries the
+  // 'img' intent. Present so an existing device_class='img' profile survives an
+  // edit (backendOf → 'img' → device_class:'img') instead of being silently
+  // rewritten to 'gpu'/'cpu'. Backend PUT /api/profiles accepts device_class ∈
+  // {gpu,cpu,npu,img}.
+  img:    { label: 'ComfyUI · IMG', color: 'var(--dev-img)',    device_class: 'img', backendField: null },
 };
 
 // `NAME_RE` (name regex) and `toast` are shared globals from primitives.jsx.
@@ -45,6 +51,7 @@ function bk(name) { return BACKEND_META[name] || BACKEND_META.cpu; }
 // set, otherwise mapped from device_class so npu/cpu/img still get a hue.
 function backendOf(p) {
   if (p.backend && BACKEND_META[p.backend]) return p.backend;
+  if (p.device_class === 'img') return 'img';
   if (p.device_class === 'npu') return 'npu';
   if (p.device_class === 'cpu') return 'cpu';
   if ((p.image || '').toLowerCase().includes('vulkan')) return 'vulkan';

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -349,40 +349,6 @@ function validateExtraArgs(s) {
   return null;
 }
 
-// UI-2: apply-semantics marker. Mirrors the Settings ApplyBadge 'live' vs
-// restart language so operators can tell, at a glance, which drawer controls
-// take effect the instant they're touched (their own PUT/POST — enable, model
-// swap, reasoning, MTP, vision, NPU) from those that only persist when the
-// Save button is pressed (ctx, profile, chat_template, extra_args,
-// idle_timeout). `mode` is "live" | "save".
-function ApplyChip({ mode }) {
-  const live = mode === "live";
-  return (
-    <span
-      className="chip"
-      title={
-        live
-          ? "Applies immediately when toggled — no Save needed"
-          : "Staged — persisted when you press Save"
-      }
-      style={{
-        fontFamily: "var(--jbm)",
-        fontSize: 9,
-        padding: "1px 6px",
-        marginLeft: 6,
-        verticalAlign: "middle",
-        whiteSpace: "nowrap",
-        letterSpacing: "0.04em",
-        color: live ? "var(--ok)" : "var(--fg-4)",
-        borderColor: live ? "var(--ok)" : "var(--line-soft)",
-        background: live ? "rgba(46,204,113,0.08)" : "var(--bg)",
-      }}
-    >
-      {live ? "applies now" : "on Save"}
-    </span>
-  );
-}
-
 function EditSlotDrawer({ open, slot, onClose }) {
   // Hooks must execute every render — early `return null` would skip
   // them; render the drawer shell with a sentinel slot instead.
@@ -448,12 +414,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const [vision, setVision] = useStateSM(slot?.vision !== false);
   const [visionPending, setVisionPending] = useStateSM(false);
   const [visionErr, setVisionErr] = useStateSM(null);
-  // Task 2 (idle_timeout_s): Save-batched numeric field (ge=0; 0 disables
-  // eviction). Seeded from the slot list payload — empty string when unset so
-  // an untouched field never writes a fabricated default.
-  const [idleTimeout, setIdleTimeout] = useStateSM(
-    slot?.idle_timeout_s != null ? String(slot.idle_timeout_s) : ""
-  );
   // Task 3 (NPU modality toggles): asr/embed instant-apply + cold restart for
   // device=npu slots. Seeded from slot.npu ({asr,embed}); optimistic with
   // revert-on-error.
@@ -484,13 +444,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
       // Task 5: re-seed chat_template override from the slot prop.
       setChatTemplate(slot.chat_template || "");
       setOverrideOpen(!!(slot.chat_template));
-      // Wave 8: re-seed the instant-apply toggles + idle_timeout field from
-      // the (possibly-updated) slot prop.
+      // Wave 8: re-seed the instant-apply toggles from the (possibly-updated)
+      // slot prop.
       setMtp(slot.mtp === true);
       setVision(slot.vision !== false);
       setVisionPending(false);
       setVisionErr(null);
-      setIdleTimeout(slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "");
       setNpuAsr(slot.npu?.asr === true);
       setNpuEmbed(slot.npu?.embed === true);
       setNpuPending(false);
@@ -508,15 +467,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
     const errs = {};
     if (!Number.isFinite(ctxNum) || !Number.isInteger(ctxNum) || ctxNum < 128) {
       errs.ctx = "Must be an integer ≥ 128";
-    }
-    // Task 2 (idle_timeout_s): validate only when the field carries a value —
-    // an empty field means "leave the on-disk value alone". Backend contract
-    // is ge=0 (0 disables idle eviction).
-    if (idleTimeout !== "") {
-      const idleNum = Number(idleTimeout);
-      if (!Number.isFinite(idleNum) || !Number.isInteger(idleNum) || idleNum < 0) {
-        errs.idleTimeout = "Must be an integer ≥ 0 (0 disables eviction)";
-      }
     }
     // Task 5: GPU-class slots have an editable profile select; mirror the
     // create-slot modal's guard and block Save when it's been cleared. NPU/CPU
@@ -545,11 +495,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
     // Task 5: include chat_template only when the user has set/changed an override.
     // Dirty-track against slot.chat_template (mirrors profileChanged pattern).
     const chatTemplateChanged = overrideOpen && chatTemplate !== (slot.chat_template || "");
-    // Task 2 (idle_timeout_s): dirty-track against the on-disk value. An empty
-    // field is "no change" (can't clear the override from this UI — 0 is the
-    // explicit disable-eviction value, not empty).
-    const idleBaseline = slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "";
-    const idleTimeoutChanged = idleTimeout !== "" && idleTimeout !== idleBaseline;
     // Per-slot extra_args override — ship only when changed, nested under
     // [server] so the backend one-level merge preserves sibling server keys.
     const extraArgsChanged = extraArgs !== extraArgsBaseline;
@@ -568,11 +513,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
       }
       if (chatTemplateChanged) {
         slotBody.chat_template = chatTemplate;
-      }
-      // Task 2: idle_timeout_s is a top-level SlotConfig field — PUT /config
-      // shallow-merges it. Only sent when changed (ge=0, 0 disables eviction).
-      if (idleTimeoutChanged) {
-        slotBody.idle_timeout_s = Number(idleTimeout);
       }
       if (extraArgsChanged) {
         slotBody.server = { extra_args: extraArgs };
@@ -698,9 +638,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
     extraArgsDirty ||
     String(ctx) !== String(slot.metrics?.ctx || 16384) ||
     (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
-    (overrideOpen && chatTemplate !== (slot.chat_template || "")) ||
-    // Task 2: idle_timeout_s is Save-batched — a pending edit is unsaved.
-    (idleTimeout !== "" && idleTimeout !== (slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : ""));
+    (overrideOpen && chatTemplate !== (slot.chat_template || ""));
   const requestClose = () => {
     if (dirty && !window.confirm("Discard unsaved changes?")) return;
     onClose();
@@ -802,7 +740,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Profile{isGpuProfile && <ApplyChip mode="save" />}</span>
+              <span>Profile</span>
               {isGpuProfile
                 ? <span className="sub warn">⟳ restart required on change</span>
                 : <span className="sub">image + bench-tuned flags for this slot — runtime-pinned</span>
@@ -872,7 +810,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Model<ApplyChip mode="live" /></span>
+              <span>Model</span>
               <span className="sub">
                 {isContainer ? "swap restarts the container to load" : "applies immediately"}
               </span>
@@ -923,7 +861,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
       <div className="form-row">
         <div className="form-lbl">
-          <span>ctx_size<ApplyChip mode="save" /></span>
+          <span>ctx_size</span>
           <span className="warn">⟳ restarts the container (~model-load seconds)</span>
         </div>
         <div className="form-ctl">
@@ -950,7 +888,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Template<ApplyChip mode="save" /></span>
+              <span>Template</span>
               <span className="sub warn">⟳ restart required on change</span>
             </div>
             <div className="form-ctl">
@@ -1012,7 +950,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
       {slot.type === "llm" && (
         <div className="form-row">
           <div className="form-lbl">
-            <span>Reasoning<ApplyChip mode="live" /></span>
+            <span>Reasoning</span>
             <span className="sub">Stream reasoning before the answer. Off = faster, direct replies. Applies to the next message.</span>
           </div>
           <div className="form-ctl">
@@ -1060,7 +998,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>MTP<ApplyChip mode="live" /></span>
+              <span>MTP</span>
               <span className="sub">Multi-token speculative decoding — dense models only (MoE runs slower). Restarts the container.</span>
             </div>
             <div className="form-ctl">
@@ -1104,7 +1042,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Vision<ApplyChip mode="live" /></span>
+              <span>Vision</span>
               <span className="sub">Load the multimodal projector so the slot accepts images. Off frees ~0.9 GB (text-only). Restarts the container.</span>
             </div>
             <div className="form-ctl">
@@ -1167,7 +1105,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
           <>
             <div className="form-row">
               <div className="form-lbl">
-                <span>NPU · ASR<ApplyChip mode="live" /></span>
+                <span>NPU · ASR</span>
                 <span className="sub">Serve speech-to-text on the coresident NPU process. Restarts the container.</span>
               </div>
               <div className="form-ctl">
@@ -1182,7 +1120,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
             </div>
             <div className="form-row">
               <div className="form-lbl">
-                <span>NPU · Embed<ApplyChip mode="live" /></span>
+                <span>NPU · Embed</span>
                 <span className="sub">Serve embeddings on the coresident NPU process. Restarts the container.</span>
               </div>
               <div className="form-ctl">
@@ -1206,27 +1144,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
           disclosure primitive exists in primitives.jsx). */}
       <details className="adv-disclosure">
       <summary className="form-section" style={{cursor: "pointer", listStyle: "revert"}}>Advanced</summary>
-
-      {/* Task 2: idle_timeout_s — editable, Save-batched (PUT /config). Seconds
-          of inactivity before the slot is evicted; 0 disables eviction. Blank
-          leaves the on-disk value untouched. */}
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>idle_timeout_s<ApplyChip mode="save" /></span>
-          <span className="sub">evict after N idle seconds · 0 disables · blank = leave as-is</span>
-        </div>
-        <div className="form-ctl">
-          <input
-            className={"input mono" + (fieldErrs.idleTimeout ? " input-err" : "")}
-            value={idleTimeout}
-            inputMode="numeric"
-            onChange={e => { setIdleTimeout(e.target.value); setFieldErrs(p => ({...p, idleTimeout: undefined})); }}
-            placeholder={slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "unset (uses default)"}
-            data-testid="idle-timeout-input"
-          />
-          {fieldErrs.idleTimeout && <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.idleTimeout}</div>}
-        </div>
-      </div>
 
       {/* C5: GPU offload tuning — read-only, defined by the profile. */}
       <div className="form-row">
@@ -1256,7 +1173,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
           operators can test one-off flags without minting a new profile. */}
       <div className="form-row">
         <div className="form-lbl">
-          <span>extra_args<ApplyChip mode="save" /></span>
+          <span>extra_args</span>
           <span className="sub">per-slot override · wins over profile flags</span>
         </div>
         <div className="form-ctl">

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -349,6 +349,40 @@ function validateExtraArgs(s) {
   return null;
 }
 
+// UI-2: apply-semantics marker. Mirrors the Settings ApplyBadge 'live' vs
+// restart language so operators can tell, at a glance, which drawer controls
+// take effect the instant they're touched (their own PUT/POST — enable, model
+// swap, reasoning, MTP, vision, NPU) from those that only persist when the
+// Save button is pressed (ctx, profile, chat_template, extra_args,
+// idle_timeout). `mode` is "live" | "save".
+function ApplyChip({ mode }) {
+  const live = mode === "live";
+  return (
+    <span
+      className="chip"
+      title={
+        live
+          ? "Applies immediately when toggled — no Save needed"
+          : "Staged — persisted when you press Save"
+      }
+      style={{
+        fontFamily: "var(--jbm)",
+        fontSize: 9,
+        padding: "1px 6px",
+        marginLeft: 6,
+        verticalAlign: "middle",
+        whiteSpace: "nowrap",
+        letterSpacing: "0.04em",
+        color: live ? "var(--ok)" : "var(--fg-4)",
+        borderColor: live ? "var(--ok)" : "var(--line-soft)",
+        background: live ? "rgba(46,204,113,0.08)" : "var(--bg)",
+      }}
+    >
+      {live ? "applies now" : "on Save"}
+    </span>
+  );
+}
+
 function EditSlotDrawer({ open, slot, onClose }) {
   // Hooks must execute every render — early `return null` would skip
   // them; render the drawer shell with a sentinel slot instead.
@@ -404,6 +438,29 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // overrideOpen tracks whether the user has clicked [Override] to reveal the select.
   const [chatTemplate, setChatTemplate] = useStateSM(slot?.chat_template || "");
   const [overrideOpen, setOverrideOpen] = useStateSM(!!(slot?.chat_template));
+  // UI-20: MTP local state — mirrors the reasoning toggle's optimistic
+  // set-before-mutate / revert-on-error pattern. Seeds from slot.mtp (default
+  // off; only `true` counts as on, matching the previous `slot.mtp === true`).
+  const [mtp, setMtp] = useStateSM(slot?.mtp === true);
+  // #901: per-slot vision toggle (instant-apply + cold restart). Default-ON:
+  // the mmproj sidecar loads unless explicitly disabled, so null/undefined →
+  // on. Optimistic local state with revert-on-error (mirrors reasoning).
+  const [vision, setVision] = useStateSM(slot?.vision !== false);
+  const [visionPending, setVisionPending] = useStateSM(false);
+  const [visionErr, setVisionErr] = useStateSM(null);
+  // Task 2 (idle_timeout_s): Save-batched numeric field (ge=0; 0 disables
+  // eviction). Seeded from the slot list payload — empty string when unset so
+  // an untouched field never writes a fabricated default.
+  const [idleTimeout, setIdleTimeout] = useStateSM(
+    slot?.idle_timeout_s != null ? String(slot.idle_timeout_s) : ""
+  );
+  // Task 3 (NPU modality toggles): asr/embed instant-apply + cold restart for
+  // device=npu slots. Seeded from slot.npu ({asr,embed}); optimistic with
+  // revert-on-error.
+  const [npuAsr, setNpuAsr] = useStateSM(slot?.npu?.asr === true);
+  const [npuEmbed, setNpuEmbed] = useStateSM(slot?.npu?.embed === true);
+  const [npuPending, setNpuPending] = useStateSM(false);
+  const [npuErr, setNpuErr] = useStateSM(null);
 
   // Resolved command provenance — only fetched while the drawer is open.
   // Falls back gracefully when null (non-llama slots) or on error.
@@ -427,6 +484,17 @@ function EditSlotDrawer({ open, slot, onClose }) {
       // Task 5: re-seed chat_template override from the slot prop.
       setChatTemplate(slot.chat_template || "");
       setOverrideOpen(!!(slot.chat_template));
+      // Wave 8: re-seed the instant-apply toggles + idle_timeout field from
+      // the (possibly-updated) slot prop.
+      setMtp(slot.mtp === true);
+      setVision(slot.vision !== false);
+      setVisionPending(false);
+      setVisionErr(null);
+      setIdleTimeout(slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "");
+      setNpuAsr(slot.npu?.asr === true);
+      setNpuEmbed(slot.npu?.embed === true);
+      setNpuPending(false);
+      setNpuErr(null);
     }
   }, [slot?.name]);
 
@@ -440,6 +508,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
     const errs = {};
     if (!Number.isFinite(ctxNum) || !Number.isInteger(ctxNum) || ctxNum < 128) {
       errs.ctx = "Must be an integer ≥ 128";
+    }
+    // Task 2 (idle_timeout_s): validate only when the field carries a value —
+    // an empty field means "leave the on-disk value alone". Backend contract
+    // is ge=0 (0 disables idle eviction).
+    if (idleTimeout !== "") {
+      const idleNum = Number(idleTimeout);
+      if (!Number.isFinite(idleNum) || !Number.isInteger(idleNum) || idleNum < 0) {
+        errs.idleTimeout = "Must be an integer ≥ 0 (0 disables eviction)";
+      }
     }
     // Task 5: GPU-class slots have an editable profile select; mirror the
     // create-slot modal's guard and block Save when it's been cleared. NPU/CPU
@@ -468,6 +545,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
     // Task 5: include chat_template only when the user has set/changed an override.
     // Dirty-track against slot.chat_template (mirrors profileChanged pattern).
     const chatTemplateChanged = overrideOpen && chatTemplate !== (slot.chat_template || "");
+    // Task 2 (idle_timeout_s): dirty-track against the on-disk value. An empty
+    // field is "no change" (can't clear the override from this UI — 0 is the
+    // explicit disable-eviction value, not empty).
+    const idleBaseline = slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "";
+    const idleTimeoutChanged = idleTimeout !== "" && idleTimeout !== idleBaseline;
     // Per-slot extra_args override — ship only when changed, nested under
     // [server] so the backend one-level merge preserves sibling server keys.
     const extraArgsChanged = extraArgs !== extraArgsBaseline;
@@ -486,6 +568,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
       }
       if (chatTemplateChanged) {
         slotBody.chat_template = chatTemplate;
+      }
+      // Task 2: idle_timeout_s is a top-level SlotConfig field — PUT /config
+      // shallow-merges it. Only sent when changed (ge=0, 0 disables eviction).
+      if (idleTimeoutChanged) {
+        slotBody.idle_timeout_s = Number(idleTimeout);
       }
       if (extraArgsChanged) {
         slotBody.server = { extra_args: extraArgs };
@@ -611,7 +698,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
     extraArgsDirty ||
     String(ctx) !== String(slot.metrics?.ctx || 16384) ||
     (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
-    (overrideOpen && chatTemplate !== (slot.chat_template || ""));
+    (overrideOpen && chatTemplate !== (slot.chat_template || "")) ||
+    // Task 2: idle_timeout_s is Save-batched — a pending edit is unsaved.
+    (idleTimeout !== "" && idleTimeout !== (slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : ""));
   const requestClose = () => {
     if (dirty && !window.confirm("Discard unsaved changes?")) return;
     onClose();
@@ -713,7 +802,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Profile</span>
+              <span>Profile{isGpuProfile && <ApplyChip mode="save" />}</span>
               {isGpuProfile
                 ? <span className="sub warn">⟳ restart required on change</span>
                 : <span className="sub">image + bench-tuned flags for this slot — runtime-pinned</span>
@@ -783,7 +872,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Model</span>
+              <span>Model<ApplyChip mode="live" /></span>
               <span className="sub">
                 {isContainer ? "swap restarts the container to load" : "applies immediately"}
               </span>
@@ -834,7 +923,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
       <div className="form-row">
         <div className="form-lbl">
-          <span>ctx_size</span>
+          <span>ctx_size<ApplyChip mode="save" /></span>
           <span className="warn">⟳ restarts the container (~model-load seconds)</span>
         </div>
         <div className="form-ctl">
@@ -861,7 +950,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>Template</span>
+              <span>Template<ApplyChip mode="save" /></span>
               <span className="sub warn">⟳ restart required on change</span>
             </div>
             <div className="form-ctl">
@@ -923,7 +1012,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
       {slot.type === "llm" && (
         <div className="form-row">
           <div className="form-lbl">
-            <span>Reasoning</span>
+            <span>Reasoning<ApplyChip mode="live" /></span>
             <span className="sub">Stream reasoning before the answer. Off = faster, direct replies. Applies to the next message.</span>
           </div>
           <div className="form-ctl">
@@ -968,20 +1057,22 @@ function EditSlotDrawer({ open, slot, onClose }) {
         // defensive fallback for any path that bypasses the normalizer.
         const isRocm = slot.backend === "rocm" || String(slot.device || "").startsWith("gpu-rocm");
         if (!mtpCapable || !isRocm) return null;
-        const mtpOn = slot.mtp === true;
         return (
           <div className="form-row">
             <div className="form-lbl">
-              <span>MTP</span>
+              <span>MTP<ApplyChip mode="live" /></span>
               <span className="sub">Multi-token speculative decoding — dense models only (MoE runs slower). Restarts the container.</span>
             </div>
             <div className="form-ctl">
               <PillToggle
-                on={mtpOn}
+                on={mtp}
                 disabled={saving}
                 label="MTP"
-                stateText={mtpOn ? "On" : "Off"}
+                stateText={mtp ? "On" : "Off"}
                 onToggle={async (next) => {
+                  // UI-20: optimistic — flip local state before the PUT, revert
+                  // on error (mirrors the reasoning toggle above).
+                  setMtp(next);
                   setSubmitErr(null);
                   try {
                     await editMut.mutateAsync({ name: slot.name, body: { mtp: next } });
@@ -990,12 +1081,122 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     });
                     window.__hal0Toast && window.__hal0Toast(`${slot.name} MTP ${next ? "on" : "off"} — restarting in the background`, "info");
                   } catch (err) {
+                    setMtp(!next);
                     setSubmitErr(err?.message || "MTP toggle failed");
                   }
                 }}
               />
             </div>
           </div>
+        );
+      })()}
+      {/* #901: Vision pill — gated to slots whose bound model carries an mmproj
+          sidecar (the registry Model.mmproj presence flag). Toggling drops or
+          adds the ~0.9 GB projector; instant-apply via PUT /config {vision}
+          plus a non-blocking cold restart (mirrors MTP). Default-ON, so a
+          null/absent on-disk value renders as on. */}
+      {(() => {
+        const cur = slot.model_id || slot.model || "";
+        const m = (modelsQuery.data ?? []).map(normalizeApiModel).find(x => x.id === cur);
+        // mmproj is a presence flag on the registry row (path or marker string);
+        // any truthy value means the model ships a vision projector sidecar.
+        if (!m || !m.mmproj) return null;
+        return (
+          <div className="form-row">
+            <div className="form-lbl">
+              <span>Vision<ApplyChip mode="live" /></span>
+              <span className="sub">Load the multimodal projector so the slot accepts images. Off frees ~0.9 GB (text-only). Restarts the container.</span>
+            </div>
+            <div className="form-ctl">
+              <PillToggle
+                on={vision}
+                disabled={visionPending || saving}
+                label="Vision"
+                stateText={vision ? "On" : "Off"}
+                onToggle={async (next) => {
+                  // Optimistic set-before-mutate + revert-on-error (mirrors MTP).
+                  setVision(next);
+                  setVisionPending(true);
+                  setVisionErr(null);
+                  setSubmitErr(null);
+                  try {
+                    await editMut.mutateAsync({ name: slot.name, body: { vision: next } });
+                    restartMut.mutate(slot.name, {
+                      onError: (err) => window.__hal0Toast && window.__hal0Toast(`Vision restart failed — ${err?.message || "see logs"}`, "err"),
+                    });
+                    window.__hal0Toast && window.__hal0Toast(`${slot.name} vision ${next ? "on" : "off"} — restarting in the background`, "info");
+                  } catch (err) {
+                    setVision(!next);
+                    setVisionErr(err?.message || "vision toggle failed");
+                  } finally {
+                    setVisionPending(false);
+                  }
+                }}
+              />
+              {visionErr && <div className="hint" style={{ color: "var(--err)" }}>{visionErr}</div>}
+            </div>
+          </div>
+        );
+      })()}
+      {/* Task 3: NPU modality toggles (asr/embed) — device=npu slots only.
+          Seeded from slot.npu; each toggle sends the full {asr,embed} object via
+          PUT /config {npu:{...}} (the backend one-level merge replaces the [npu]
+          table wholesale) + a non-blocking cold restart. Optimistic with
+          revert-on-error. */}
+      {slot.device === "npu" && (() => {
+        const applyNpu = async (nextAsr, nextEmbed, prevAsr, prevEmbed, which) => {
+          setNpuPending(true);
+          setNpuErr(null);
+          setSubmitErr(null);
+          try {
+            await editMut.mutateAsync({ name: slot.name, body: { npu: { asr: nextAsr, embed: nextEmbed } } });
+            restartMut.mutate(slot.name, {
+              onError: (err) => window.__hal0Toast && window.__hal0Toast(`NPU restart failed — ${err?.message || "see logs"}`, "err"),
+            });
+            window.__hal0Toast && window.__hal0Toast(`${slot.name} NPU ${which} updated — restarting in the background`, "info");
+          } catch (err) {
+            // Revert both to their pre-toggle values.
+            setNpuAsr(prevAsr);
+            setNpuEmbed(prevEmbed);
+            setNpuErr(err?.message || "NPU toggle failed");
+          } finally {
+            setNpuPending(false);
+          }
+        };
+        return (
+          <>
+            <div className="form-row">
+              <div className="form-lbl">
+                <span>NPU · ASR<ApplyChip mode="live" /></span>
+                <span className="sub">Serve speech-to-text on the coresident NPU process. Restarts the container.</span>
+              </div>
+              <div className="form-ctl">
+                <PillToggle
+                  on={npuAsr}
+                  disabled={npuPending || saving}
+                  label="NPU ASR"
+                  stateText={npuAsr ? "On" : "Off"}
+                  onToggle={(next) => { setNpuAsr(next); applyNpu(next, npuEmbed, npuAsr, npuEmbed, "ASR"); }}
+                />
+              </div>
+            </div>
+            <div className="form-row">
+              <div className="form-lbl">
+                <span>NPU · Embed<ApplyChip mode="live" /></span>
+                <span className="sub">Serve embeddings on the coresident NPU process. Restarts the container.</span>
+              </div>
+              <div className="form-ctl">
+                <PillToggle
+                  on={npuEmbed}
+                  disabled={npuPending || saving}
+                  label="NPU Embed"
+                  stateText={npuEmbed ? "On" : "Off"}
+                  onToggle={(next) => { setNpuEmbed(next); applyNpu(npuAsr, next, npuAsr, npuEmbed, "Embed"); }}
+                />
+              </div>
+            </div>
+            {npuErr && <div className="hint" style={{ color: "var(--err)" }}>{npuErr}</div>}
+          </>
         );
       })()}
       </FieldGroup>
@@ -1005,6 +1206,27 @@ function EditSlotDrawer({ open, slot, onClose }) {
           disclosure primitive exists in primitives.jsx). */}
       <details className="adv-disclosure">
       <summary className="form-section" style={{cursor: "pointer", listStyle: "revert"}}>Advanced</summary>
+
+      {/* Task 2: idle_timeout_s — editable, Save-batched (PUT /config). Seconds
+          of inactivity before the slot is evicted; 0 disables eviction. Blank
+          leaves the on-disk value untouched. */}
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>idle_timeout_s<ApplyChip mode="save" /></span>
+          <span className="sub">evict after N idle seconds · 0 disables · blank = leave as-is</span>
+        </div>
+        <div className="form-ctl">
+          <input
+            className={"input mono" + (fieldErrs.idleTimeout ? " input-err" : "")}
+            value={idleTimeout}
+            inputMode="numeric"
+            onChange={e => { setIdleTimeout(e.target.value); setFieldErrs(p => ({...p, idleTimeout: undefined})); }}
+            placeholder={slot.idle_timeout_s != null ? String(slot.idle_timeout_s) : "unset (uses default)"}
+            data-testid="idle-timeout-input"
+          />
+          {fieldErrs.idleTimeout && <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.idleTimeout}</div>}
+        </div>
+      </div>
 
       {/* C5: GPU offload tuning — read-only, defined by the profile. */}
       <div className="form-row">
@@ -1034,7 +1256,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
           operators can test one-off flags without minting a new profile. */}
       <div className="form-row">
         <div className="form-lbl">
-          <span>extra_args</span>
+          <span>extra_args<ApplyChip mode="save" /></span>
           <span className="sub">per-slot override · wins over profile flags</span>
         </div>
         <div className="form-ctl">


### PR DESCRIPTION
## Wave 8B — every backend-supported value made editable in the edit drawers

Audit found several typed fields the backend already accepts on its PUT endpoints but that no drawer let you edit. Plus a real data-loss bug and two polish items.

### Slot drawer (`slot-modals.jsx` + `slot_view` enrichment)
- **vision** toggle (drops `--mmproj`/~0.9 GB when off) — gated to models with an mmproj sidecar; needed a `slot_view` enrichment lift (+ test).
- **idle_timeout_s** (Advanced; `ge=0`, 0 disables eviction).
- **NPU asr/embed** modality toggles for FLM NPU slots.
- **UI-2** apply-semantics markers (live vs on-Save) on each field.
- **UI-20** MTP toggle now optimistic-with-revert (parity with Reasoning).

### Model editor (`model-modals.jsx`)
- **Bug fix:** `onSave` rebuilt `defaults` **wholesale**, silently clearing unshown `ModelDefaults` on every save — now sends the complete merged defaults.
- New editable fields: **capabilities**, **backends**, **rope_freq_base**, **mmproj**, **hf_repo/hf_filename** — each only sent when actually changed (editing tags won't wipe capabilities/backends).

### Profile drawer (`profiles.jsx`)
- Fixed the **`device_class='img'`** dead/corrupting control so ComfyUI image profiles round-trip (were silently rewritten on edit).

### Verification
- vite build clean; `tests/slot_view` **53 passed**; drawer e2e (slots/models/profiles/inference) **34 passed**; tree-wide ruff clean.
- Data-correctness review: **clean** — verified no save path wipes a backend field and all new fields round-trip (complete-object sends, change-gated, NaN-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)