### PR TITLE
fix(memory): functional Memory tab + guard bank DELETE (incident #1024 fixes)

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -18,6 +18,7 @@ veneer that:
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any
 
@@ -27,6 +28,7 @@ from pydantic import ValidationError
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import MemoryGraphConfig
+from hal0.memory.hindsight_provider import bank_to_namespace
 from hal0.memory.namespace import (
     DEFAULT_DATASET,
     MemoryNamespaceError,
@@ -35,6 +37,8 @@ from hal0.memory.namespace import (
 )
 
 router = APIRouter()
+
+log = logging.getLogger(__name__)
 
 
 # ── ADR-0012 identity + ADR-0005 §3 namespace helpers ─────────────────────
@@ -485,6 +489,7 @@ async def memory_recall(request: Request) -> dict[str, Any]:
 async def memory_list(
     request: Request,
     dataset: str | None = None,
+    bank: str | None = None,
     cursor: str | None = None,
     limit: int = 50,
 ) -> dict[str, Any]:
@@ -494,7 +499,24 @@ async def memory_list(
     explicit ``?dataset=`` resolves to the caller's own private bucket
     so the ``hal0 agent memory list`` CLI subcommand can enumerate
     per-agent items without the operator passing the namespace by hand.
+
+    ``?bank=`` is a convenience alias for the dashboard's Hindsight bank
+    browser: a bank id (``private__hermes``) is translated to the matching
+    dataset namespace (``private:hermes``) when no explicit ``?dataset=`` is
+    given. If both are supplied and conflict, the explicit ``dataset`` wins.
     """
+    if bank is not None:
+        bank_dataset = bank_to_namespace(bank)
+        if dataset is None:
+            dataset = bank_dataset
+        elif dataset != bank_dataset:
+            log.info(
+                "memory_list: ?dataset=%r overrides conflicting ?bank=%r (->%r)",
+                dataset,
+                bank,
+                bank_dataset,
+            )
+
     agent_id = _agent_id(request)
     private = _is_private(request)
     try:

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -227,7 +227,61 @@ async def graph_status(request: Request) -> dict[str, Any]:
     available = await _enabled_llm_slots(request)
     status["available_slots"] = available
     status["slot_resolves"] = status.get("extraction_slot") in available
+    await _augment_build_counters(request, status)
     return status
+
+
+async def _augment_build_counters(request: Request, status: dict[str, Any]) -> None:
+    """Replace the provider's placeholder ``0``/``None`` build counters with
+    real extraction/consolidation activity aggregated from Hindsight's
+    per-bank ``/stats`` (``operations_by_status``, ``pending_operations``,
+    ``failed_operations``, ``last_consolidated_at``).
+
+    Extraction runs inside the Hindsight daemon, so hal0 keeps no in-process
+    counter — we read it back. Best-effort: on any error the provider's
+    placeholder values are left intact, so the endpoint never fails.
+    """
+    provider = getattr(request.app.state, "memory_provider", None)
+    client = getattr(provider, "hindsight_client", None) if provider is not None else None
+    if client is None:
+        return
+
+    async def _get(path: str) -> Any | None:
+        try:
+            return await client.request_json("GET", path)
+        except Exception:
+            return None
+
+    banks_resp = await _get("/v1/default/banks")
+    banks = banks_resp.get("banks") if isinstance(banks_resp, dict) else banks_resp
+    if not isinstance(banks, list):
+        return
+
+    in_flight = builds_ok = errors = 0
+    last_built: str | None = None
+    saw_stats = False
+    for entry in banks:
+        bank_id = entry.get("bank_id") if isinstance(entry, dict) else entry
+        if not bank_id:
+            continue
+        st = await _get(f"/v1/default/banks/{bank_id}/stats")
+        if not isinstance(st, dict):
+            continue
+        saw_stats = True
+        by_status = st.get("operations_by_status") or {}
+        in_flight += int(st.get("pending_operations") or 0)
+        in_flight += int(by_status.get("processing") or 0) + int(by_status.get("claimed") or 0)
+        builds_ok += int(by_status.get("completed") or 0)
+        errors += int(st.get("failed_operations") or by_status.get("failed") or 0)
+        built = st.get("last_consolidated_at")
+        if built and (last_built is None or built > last_built):
+            last_built = built
+
+    if saw_stats:
+        status["in_flight"] = in_flight
+        status["builds_ok"] = builds_ok
+        status["errors"] = errors
+        status["last_built_at"] = last_built
 
 
 # ── PUT /api/memory/graph ──────────────────────────────────────────────────

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
 from typing import Any
 
@@ -38,6 +39,8 @@ from hal0.api.routes.memory import MemoryUnavailable
 from hal0.errors import BadRequest, Hal0Error, NotFound, UnprocessableEntity
 
 router = APIRouter()
+
+log = logging.getLogger(__name__)
 
 #: Bank ids come from namespace_to_bank() (``private__<agent>``) or operator
 #: input — kebab/snake alphanumerics only, no dots (blocks path tricks).
@@ -247,6 +250,33 @@ async def bank_subgraph(request: Request, bank_id: str) -> dict[str, Any]:
     return out
 
 
+# ── DELETE /banks/{bank_id} — guarded (NOT a passthrough) ──────────────────────
+#
+# Bank deletion is irreversible upstream (drops every memory/document/entity in
+# the bank), so it is special-cased OUT of the _FORWARDS table and gated behind
+# an explicit confirmation that must echo the target bank id — via ?confirm=
+# and/or a JSON body ``{"confirm": ...}``. Registered before the _FORWARDS loop
+# so the guarded route owns the verb; only forwards once confirmation matches.
+
+
+@router.delete("/banks/{bank_id}")
+async def delete_bank(request: Request, bank_id: str) -> Any:
+    client = _client(request)
+    _validate_segments({"bank_id": bank_id})
+    body = await _read_body(request)
+    confirm = request.query_params.get("confirm")
+    if confirm is None and isinstance(body, dict):
+        confirm = body.get("confirm")
+    if confirm != bank_id:
+        raise BadRequest(
+            f"confirm={bank_id} required to delete bank {bank_id}",
+            code="memory.confirm_required",
+            details={"bank_id": bank_id},
+        )
+    log.warning("memory_admin: deleting bank %r (confirmed)", bank_id)
+    return await _forward(client, "DELETE", f"/v1/default/banks/{bank_id}")
+
+
 # ── allowlisted passthrough table ──────────────────────────────────────────────
 #
 # (hal0 method, hal0 path under /api/memory, upstream path template).
@@ -259,7 +289,8 @@ _FORWARDS: tuple[tuple[str, str, str], ...] = (
     ("GET", "/banks", "/v1/default/banks"),
     ("PUT", "/banks/{bank_id}", "/v1/default/banks/{bank_id}"),
     ("PATCH", "/banks/{bank_id}", "/v1/default/banks/{bank_id}"),
-    ("DELETE", "/banks/{bank_id}", "/v1/default/banks/{bank_id}"),
+    # DELETE /banks/{bank_id} is NOT here — it is special-cased into the guarded
+    # ``delete_bank`` handler above (irreversible; requires ?confirm=<bank_id>).
     ("GET", "/banks/{bank_id}/stats", "/v1/default/banks/{bank_id}/stats"),
     (
         "GET",

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -34,6 +34,14 @@ def namespace_to_bank(namespace: str) -> str:
     return namespace.replace(":", "__")
 
 
+def bank_to_namespace(bank: str) -> str:
+    """Inverse of :func:`namespace_to_bank` — map a Hindsight bank id back to
+    its hal0 namespace (``private__hermes`` -> ``private:hermes``; ``shared``
+    stays ``shared``). Only the prefix delimiter is rewritten, so agent ids
+    that contain single underscores survive untouched."""
+    return bank.replace("__", ":", 1)
+
+
 class Hal0Reranker:
     """Async reranker over hal0-api's OpenAI surface (Cohere-style ``/v1/rerankings``).
 

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -187,9 +187,23 @@ def test_bank_create_put_and_delete_forward(client: TestClient, recorder: _Recor
     assert recorder.requests[-1]["method"] == "PUT"
     assert recorder.requests[-1]["path"] == "/v1/default/banks/scratch"
 
+    # Bank deletion is guarded: without a matching ?confirm= it is rejected
+    # (400) and NOT forwarded upstream.
+    before = len(recorder.requests)
     r = client.delete("/api/memory/banks/scratch")
+    assert r.status_code == 400
+    assert len(recorder.requests) == before
+
+    # Mismatched confirmation is likewise rejected.
+    r = client.delete("/api/memory/banks/scratch?confirm=other")
+    assert r.status_code == 400
+    assert len(recorder.requests) == before
+
+    # Matching confirmation forwards the DELETE.
+    r = client.delete("/api/memory/banks/scratch?confirm=scratch")
     assert r.status_code == 200
     assert recorder.requests[-1]["method"] == "DELETE"
+    assert recorder.requests[-1]["path"] == "/v1/default/banks/scratch"
 
 
 def test_operation_retry_and_consolidate_forward(client: TestClient, recorder: _Recorder) -> None:

--- a/ui/src/api/hooks/useHindsight.ts
+++ b/ui/src/api/hooks/useHindsight.ts
@@ -143,15 +143,59 @@ export function useBankDelete() {
 
 // ── operations ───────────────────────────────────────────────────────────────
 
-export function useBankOperations(bank: string | null, opts?: { status?: string }) {
+const IN_FLIGHT_STATUSES = new Set(['pending', 'processing'])
+
+/** Rolled-up per-bank operation counts for the live activity indicators. */
+export interface BankActivity {
+  pending: number
+  processing: number
+  completed: number
+  failed: number
+  cancelled: number
+  /** pending + processing — "work in flight" drives the spinner/pulse. */
+  inFlight: number
+  /** operation_type of each failed op, for the failed-ops affordance. */
+  failedTypes: string[]
+  total: number
+}
+
+/** Fold a bank's operations list into the counts the activity badges render. */
+export function summarizeBankOperations(ops?: BankOperations | null): BankActivity {
+  const counts = { pending: 0, processing: 0, completed: 0, failed: 0, cancelled: 0 }
+  const failedTypes: string[] = []
+  const items = ops?.items ?? []
+  for (const op of items) {
+    if (op.status in counts) counts[op.status as keyof typeof counts] += 1
+    if (op.status === 'failed') failedTypes.push(op.operation_type)
+  }
+  return {
+    ...counts,
+    inFlight: counts.pending + counts.processing,
+    failedTypes,
+    total: items.length,
+  }
+}
+
+// Shared query — the bank list card AND the bank detail panel read the same
+// key so there is one poll per bank, not one per consumer (no stampede).
+// Polling is adaptive: fast (3s) while work is in flight so ingest/extraction
+// visibly progresses, then it backs off (20s) once the bank is quiescent.
+export function useBankOperations(
+  bank: string | null,
+  opts?: { status?: string; enabled?: boolean },
+) {
   const qs = opts?.status ? `?status=${encodeURIComponent(opts.status)}` : ''
   return useQuery<BankOperations>({
     queryKey: ['memory', 'banks', bank, 'operations', opts?.status ?? 'all'],
     queryFn: () =>
       apiGet<BankOperations>(`${ENDPOINTS.memoryBankOperations(bank as string)}${qs}`),
-    enabled: !!bank,
-    staleTime: 5_000,
-    refetchInterval: 15_000,
+    enabled: !!bank && opts?.enabled !== false,
+    staleTime: 3_000,
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? []
+      const inFlight = items.some((o) => IN_FLIGHT_STATUSES.has(o.status))
+      return inFlight ? 3_000 : 20_000
+    },
   })
 }
 

--- a/ui/src/api/hooks/useHindsight.ts
+++ b/ui/src/api/hooks/useHindsight.ts
@@ -130,7 +130,11 @@ export function useBankUpsert() {
 export function useBankDelete() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (bank: string) => apiDelete(ENDPOINTS.memoryBank(bank)),
+    // The backend guards bank deletion behind ?confirm=<bank_id> (the delete
+    // is irreversible). The UI already gates this behind a two-step confirm
+    // dialog, so echo the bank id to satisfy the guard.
+    mutationFn: (bank: string) =>
+      apiDelete(`${ENDPOINTS.memoryBank(bank)}?confirm=${encodeURIComponent(bank)}`),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ['memory'] })
     },
@@ -179,6 +183,9 @@ export function useConsolidate() {
     mutationFn: (bank: string) => apiPost(ENDPOINTS.memoryBankConsolidate(bank), {}),
     onSuccess: (_data, bank) => {
       void qc.invalidateQueries({ queryKey: ['memory', 'banks', bank] })
+      // The queued consolidation shows up in the Operations list — refetch it
+      // explicitly so the new op appears without waiting for the poll tick.
+      void qc.invalidateQueries({ queryKey: ['memory', 'banks', bank, 'operations'] })
     },
   })
 }

--- a/ui/src/api/hooks/useMemory.ts
+++ b/ui/src/api/hooks/useMemory.ts
@@ -125,7 +125,9 @@ export function useMemoryGraphStatus() {
   return useQuery<MemoryGraphStatus>({
     queryKey: ['memory', 'graph', 'status'],
     queryFn: () => apiGet<MemoryGraphStatus>(ENDPOINTS.memoryGraphStatus),
-    refetchInterval: POLL_MS,
+    // Poll faster while extraction is in flight so the "extracting…" badge
+    // tracks live progress; back off to the idle cadence otherwise.
+    refetchInterval: (query) => ((query.state.data?.in_flight ?? 0) > 0 ? 3_000 : POLL_MS),
   })
 }
 

--- a/ui/src/dash/memory-hook-bridge.ts
+++ b/ui/src/dash/memory-hook-bridge.ts
@@ -41,9 +41,16 @@ import {
   useOperationCancel,
   useOperationRetry,
 } from '@/api/hooks/useHindsight'
+// ADR-0023 graph-extraction gate hooks — the Memory Overview drives its
+// graph on/off line + slot picker from these (same source as the #agent
+// Memory tab; bridged here too so #memory doesn't depend on that tab's
+// bridge load order).
+import { useMemoryGraphStatus, useUpdateMemoryGraph } from '@/api/hooks/useMemory'
 
 Object.assign(window as unknown as Record<string, unknown>, {
   __hal0UseMemoryEngine: useMemoryEngine,
+  __hal0UseMemoryGraphStatus: useMemoryGraphStatus,
+  __hal0UseUpdateMemoryGraph: useUpdateMemoryGraph,
   __hal0UseMemoryBanks: useMemoryBanks,
   __hal0UseBankStats: useBankStats,
   __hal0UseBankTimeseries: useBankTimeseries,

--- a/ui/src/dash/memory-hook-bridge.ts
+++ b/ui/src/dash/memory-hook-bridge.ts
@@ -40,6 +40,7 @@ import {
   useMemoryEngine,
   useOperationCancel,
   useOperationRetry,
+  summarizeBankOperations,
 } from '@/api/hooks/useHindsight'
 // ADR-0023 graph-extraction gate hooks — the Memory Overview drives its
 // graph on/off line + slot picker from these (same source as the #agent
@@ -57,6 +58,7 @@ Object.assign(window as unknown as Record<string, unknown>, {
   __hal0UseBankUpsert: useBankUpsert,
   __hal0UseBankDelete: useBankDelete,
   __hal0UseBankOperations: useBankOperations,
+  __hal0MemSummarizeOps: summarizeBankOperations,
   __hal0UseOperationRetry: useOperationRetry,
   __hal0UseOperationCancel: useOperationCancel,
   __hal0UseConsolidate: useConsolidate,

--- a/ui/src/dash/memory-overhaul.css
+++ b/ui/src/dash/memory-overhaul.css
@@ -201,6 +201,36 @@
 .mo-bank-meta { font-size: 10.5px; color: var(--fg-4); display: flex; gap: 5px; align-items: center; flex-wrap: wrap; }
 .mo-bank-meta .num { color: var(--fg-2); }
 
+/* ─── Live activity (ingest / extraction / consolidation) ────────── */
+/* Compact, wrapping row of status chips shown on bank cards + detail, plus
+   the graph-extraction "extracting…" badge. Spinner appears only while work
+   is in flight so the operator can SEE progress + WHERE it is happening. */
+.mem-activity { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 5px; position: relative; }
+.mem-detail-activity { margin: 4px 0 14px; }
+.mem-act-quiet { font-size: 10.5px; color: var(--fg-5); }
+
+.mem-act-badge { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; padding: 2px 8px; border-radius: var(--rad-pill, 999px); border: 1px solid var(--accent-line, var(--line)); color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.mem-act-badge.working { color: var(--accent); }
+
+.mem-act-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; padding: 2px 7px; border-radius: var(--rad-xs); border: 1px solid var(--line); color: var(--fg-3); background: transparent; line-height: 1.5; }
+.mem-act-chip.proc { color: var(--accent); border-color: var(--accent-line, var(--line)); }
+.mem-act-chip.pend { color: var(--warn); border-color: var(--warn-line); }
+.mem-act-chip.done { color: var(--ok); border-color: var(--ok-line); }
+.mem-act-chip.failed { color: var(--err); border-color: var(--err-line); cursor: pointer; font-family: var(--jbm); }
+.mem-act-chip.failed:hover, .mem-act-chip.failed.open { background: color-mix(in srgb, var(--err) 12%, transparent); }
+
+/* Failed-ops popover — lightweight list of failed operation types. */
+.mem-failed-pop { position: absolute; top: calc(100% + 6px); left: 0; z-index: 20; min-width: 160px; max-width: 280px; display: flex; flex-direction: column; gap: 3px; padding: 8px 10px; border: 1px solid var(--err-line); border-radius: var(--rad); background: var(--bg-1); box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35); }
+.mem-failed-h { font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--fg-4); margin-bottom: 2px; }
+.mem-failed-row { font-size: 11px; color: var(--err); }
+
+/* Spinner — self-contained (no cross-file keyframe dependency). */
+.mem-spin { width: 11px; height: 11px; border: 1.5px solid var(--line-strong); border-top-color: var(--accent); border-radius: 50%; animation: mem-spin 0.7s linear infinite; flex-shrink: 0; }
+@keyframes mem-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .mem-spin { animation: none; }
+}
+
 /* ─── Tools ──────────────────────────────────────────────────────── */
 .mt-bankbar { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; font-size: 11px; }
 .mt-bankbar .input { padding: 6px 9px; }

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -181,14 +181,80 @@ function MemTimeseries({ bank, period, setPeriod }) {
   );
 }
 
+// ── Live per-bank activity (ingest / extraction / consolidation) ──────────────
+//
+// Polls GET /api/memory/banks/{bank}/operations via the shared, adaptive
+// useBankOperations query (fast while work is in flight, backing off when
+// idle) so the operator can SEE what's happening and WHERE. Renders a spinner
+// "N working" badge while pending+processing > 0, plus pending/processing/
+// completed/failed counts. Failed count is a button that reveals the failed
+// operation types (affordance for "extraction failed, roughly why").
+function MemBankActivity({ bank, active = true, compact = false }) {
+  const useBankOperations = window.__hal0UseBankOperations;
+  const summarize = window.__hal0MemSummarizeOps;
+  const q = useBankOperations ? useBankOperations(bank, { enabled: active }) : { data: null };
+  const [showFailed, setShowFailed] = useStateMem(false);
+  const a = summarize
+    ? summarize(q.data)
+    : { pending: 0, processing: 0, completed: 0, failed: 0, inFlight: 0, failedTypes: [], total: 0 };
+
+  if (!q.data) return null;
+  if (a.total === 0) {
+    return compact ? null : <span className="mem-act-quiet mono">no activity yet</span>;
+  }
+
+  function toggleFailed(ev) {
+    ev.preventDefault();
+    ev.stopPropagation();
+    setShowFailed(v => !v);
+  }
+
+  return (
+    <span className="mem-activity mono" data-testid={`mem-activity-${bank}`}>
+      {a.inFlight > 0 && (
+        <span className="mem-act-badge working" title={`${a.inFlight} operation(s) in flight`}>
+          <span className="mem-spin" aria-hidden="true" />
+          {a.inFlight} working
+        </span>
+      )}
+      {a.processing > 0 && <span className="mem-act-chip proc" title="processing">{a.processing} proc</span>}
+      {a.pending > 0 && <span className="mem-act-chip pend" title="queued / pending">{a.pending} pending</span>}
+      {!compact && a.completed > 0 && (
+        <span className="mem-act-chip done" title="completed">{a.completed} done</span>
+      )}
+      {a.failed > 0 && (
+        <button
+          type="button"
+          className={'mem-act-chip failed' + (showFailed ? ' open' : '')}
+          onClick={toggleFailed}
+          title="failed operations — click to see which"
+          data-testid={`mem-failed-${bank}`}
+        >
+          {a.failed} failed
+        </button>
+      )}
+      {showFailed && a.failed > 0 && (
+        <span
+          className="mem-failed-pop mono"
+          data-testid={`mem-failed-pop-${bank}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="mem-failed-h">failed operations</span>
+          {a.failedTypes.map((t, i) => (
+            <span key={i} className="mem-failed-row">{t}</span>
+          ))}
+        </span>
+      )}
+    </span>
+  );
+}
+
 // ── Bank card ─────────────────────────────────────────────────────────────────
 
 function MemBankCard({ bank, selected, onSelect }) {
   const useBankStats = window.__hal0UseBankStats;
   const stats = (useBankStats ? useBankStats(bank.bank_id) : { data: null }).data;
   const byType = stats?.nodes_by_fact_type || {};
-  const pending = stats?.pending_operations || 0;
-  const failed = stats?.failed_operations || 0;
   function onKey(ev) {
     if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); onSelect(bank); }
   }
@@ -204,12 +270,7 @@ function MemBankCard({ bank, selected, onSelect }) {
       <div className="mo-bank-head">
         <span className="mono mo-bank-id">{bank.bank_id}</span>
         <div className="mem-bank-badges">
-          {pending > 0 && (
-            <span className="mo-badge warn mono" title="pending operations">{pending} pending</span>
-          )}
-          {failed > 0 && (
-            <span className="mo-badge warn mono" style={{ color: 'var(--err)', borderColor: 'var(--err-line)' }} title="failed operations">{failed} failed</span>
-          )}
+          <MemBankActivity bank={bank.bank_id} compact />
         </div>
       </div>
       {bank.mission && <div className="mo-bank-mission">{bank.mission}</div>}
@@ -341,6 +402,11 @@ function MemBankDetail({ bank, onClose, onDeleted }) {
           <button className="btn ghost sm pf-form-close" onClick={onClose} aria-label="Close">×</button>
         </div>
       </div>
+      {/* Live activity for this bank — spinner while ingest/extraction/
+          consolidation is in flight, with failed-ops affordance. */}
+      <div className="mem-detail-activity">
+        <MemBankActivity bank={bank.bank_id} />
+      </div>
       {/* .sec is a flex title-row — keep only the heading in it; content
           (ops list, danger controls) must be siblings or they shrink-wrap. */}
       <div className="sec">
@@ -453,6 +519,7 @@ function MemoryView({ param } = {}) {
   const banksQuery = useMemoryBanks ? useMemoryBanks() : { data: null, isLoading: false };
   const graphQuery = useMemoryGraphStatus ? useMemoryGraphStatus() : { data: null };
   const graphEnabled = !!graphQuery.data?.enabled;
+  const graphInFlight = graphQuery.data?.in_flight || 0;
 
   const banks = banksQuery.data?.banks || [];
   const [selectedId, setSelectedId] = useStateMem(() => {
@@ -527,6 +594,12 @@ function MemoryView({ param } = {}) {
       <div className="sec">
         <h2>Graph extraction</h2>
         <div className="rule" />
+        {graphInFlight > 0 && (
+          <span className="mem-act-badge working" data-testid="mem-graph-inflight" title="graph extraction running">
+            <span className="mem-spin" aria-hidden="true" />
+            extracting… ({graphInFlight} in flight)
+          </span>
+        )}
       </div>
       {typeof MemoryGraphPanel === 'function' ? <MemoryGraphPanel /> : null}
 

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -40,7 +40,7 @@ function fmtWhen(iso) {
 
 // ── Engine card ───────────────────────────────────────────────────────────────
 
-function MemEngineCard({ engine, isLoading, onOpenGraph }) {
+function MemEngineCard({ engine, isLoading, graphEnabled, onOpenGraph }) {
   if (isLoading) {
     return (
       <div className="card mo-engine" data-testid="mem-engine-card">
@@ -56,7 +56,10 @@ function MemEngineCard({ engine, isLoading, onOpenGraph }) {
   const reachable = !!e.reachable;
   const features = e.features || {};
   const featureNames = Object.keys(features);
-  const graphOn = !!features.graph;
+  // Graph-extraction on/off comes from /api/memory/graph/status (the real
+  // state), NOT the Hindsight capability flags in /engine — those have no
+  // `graph` key, so keying off them always read "off".
+  const graphOn = !!graphEnabled;
   return (
     <div className="card mo-engine" data-testid="mem-engine-card">
       <div className="mo-engine-head">
@@ -299,10 +302,20 @@ function MemBankDetail({ bank, onClose, onDeleted }) {
 
   async function doConsolidate() {
     try {
+      // Any 2xx is success — Hindsight may 202 with an empty body (res === null)
+      // or return the queued op under operation_id / id / operation.
       const res = await consolidate.mutateAsync(bank.bank_id);
-      memToast(`Consolidation queued (${res?.operation_id || 'ok'})`, 'ok');
+      const opId = res?.operation_id ?? res?.id ?? res?.operation;
+      memToast(`Consolidation queued (${opId || 'ok'})`, 'ok');
     } catch (err) {
-      memToast(err?.message || 'Consolidate failed', 'err');
+      // "already in progress" (409) / "nothing to consolidate" aren't failures
+      // — the queue is simply busy or empty; report them informationally.
+      const msg = err?.message || '';
+      if (err?.status === 409 || /in progress|nothing to consolidate/i.test(msg)) {
+        memToast(msg || 'Consolidation already in progress', 'info');
+      } else {
+        memToast(msg || 'Consolidate failed', 'err');
+      }
     }
   }
 
@@ -435,8 +448,11 @@ function MemoryView({ param } = {}) {
   const section = param === 'graph' ? 'graph' : param === 'tools' ? 'tools' : 'overview';
   const useMemoryEngine = window.__hal0UseMemoryEngine;
   const useMemoryBanks = window.__hal0UseMemoryBanks;
+  const useMemoryGraphStatus = window.__hal0UseMemoryGraphStatus;
   const engineQuery = useMemoryEngine ? useMemoryEngine() : { data: null, isLoading: false };
   const banksQuery = useMemoryBanks ? useMemoryBanks() : { data: null, isLoading: false };
+  const graphQuery = useMemoryGraphStatus ? useMemoryGraphStatus() : { data: null };
+  const graphEnabled = !!graphQuery.data?.enabled;
 
   const banks = banksQuery.data?.banks || [];
   const [selectedId, setSelectedId] = useStateMem(() => {
@@ -498,10 +514,21 @@ function MemoryView({ param } = {}) {
         <MemEngineCard
           engine={engineQuery.data}
           isLoading={engineQuery.isLoading}
+          graphEnabled={graphEnabled}
           onOpenGraph={() => { window.location.hash = '#memory/graph'; }}
         />
         <MemTimeseries bank={chartBank} period={period} setPeriod={setPeriod} />
       </div>
+
+      {/* ADR-0023 graph-extraction gate + slot picker — reuses the canonical
+          MemoryGraphPanel (window global from agents/memory-tab.jsx) so the
+          enabled/slot/slot_resolves/builds_ok/errors/last_built_at/last_error
+          controls live here on the Memory Overview, not just the #agent tab. */}
+      <div className="sec">
+        <h2>Graph extraction</h2>
+        <div className="rule" />
+      </div>
+      {typeof MemoryGraphPanel === 'function' ? <MemoryGraphPanel /> : null}
 
       {/* .sec is a flex title-row (h2 + flex:1 rule); content must be a SIBLING,
           not a child, or it gets pinned into the heading row and shrink-wraps. */}

--- a/ui/tests/e2e/specs/memory-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-view-v3.spec.ts
@@ -8,7 +8,7 @@
  *   - Nav: "Memory" item present when memory_enabled, routes to #memory
  *   - Engine card: version + reachable chip + bank count from /api/memory/engine
  *   - Engine card: unreachable state renders a degraded (not crashed) card
- *   - Bank cards: fact-type counts, pending/failed op badges from per-bank stats
+ *   - Bank cards: fact-type counts, live activity (working/pending/failed) from /operations
  *   - Timeseries: stacked spark bars render from stats/timeseries buckets
  *   - Operations panel: failed op row exposes Retry → POST .../operations/{id}/retry
  *   - Create bank: form PUTs /api/memory/banks/{name}
@@ -173,22 +173,31 @@ test.describe('Memory view — Hindsight surface', () => {
     await expect(card.locator('.chip')).toContainText(/reachable/i)
   })
 
-  test('bank cards show fact-type counts and op badges', async ({ page }) => {
+  test('bank cards show fact-type counts and live activity', async ({ page }) => {
     await gotoMemory(page)
-    // baked banks: primary (default) has fact-type breakdowns; ingest carries
-    // the failed-operation badge.
+    // baked banks: primary (default) has fact-type breakdowns + a pending op;
+    // ingest carries in-flight + failed operations.
     const primary = page.locator('[data-testid="mem-bank-primary"]')
     await expect(primary).toBeVisible()
     await expect(primary).toContainText('world')
     await expect(primary).toContainText('experience')
     await expect(primary).toContainText('observation')
-    // primary has a pending op → warn badge.
-    await expect(primary.locator('.mo-badge.warn', { hasText: 'pending' })).toBeVisible()
+    // primary has a pending op in flight → live spinner "working" badge + a
+    // pending activity chip (driven by /operations, not stats).
+    await expect(primary.locator('.mem-act-badge.working')).toBeVisible()
+    await expect(primary.locator('.mem-act-chip.pend')).toContainText('pending')
 
-    // ingest bank exposes a failed-ops badge from its stats (1 failed).
+    // ingest bank carries a failed op → a red failed affordance that reveals
+    // the failed operation type(s) on click.
     const ingest = page.locator('[data-testid="mem-bank-ingest"]')
     await expect(ingest).toBeVisible()
-    await expect(ingest.locator('.mo-badge.warn', { hasText: 'failed' })).toContainText('1')
+    const failed = ingest.locator('[data-testid="mem-failed-ingest"]')
+    await expect(failed).toContainText('1')
+    await expect(failed).toContainText('failed')
+    await failed.click()
+    await expect(ingest.locator('[data-testid="mem-failed-pop-ingest"]')).toContainText(
+      'consolidation',
+    )
   })
 
   test('timeseries renders stacked spark bars per bucket', async ({ page }) => {


### PR DESCRIPTION
Makes the dashboard Memory tab functional and closes the unguarded-delete hole that caused a real data-loss incident on CT105 (2026-07-04). Fixes hotpatched live; this PR makes them durable through releases.

## Backend
- **Guard `DELETE /api/memory/banks/{bank_id}`** — now requires `?confirm=<bank_id>` (or body `{"confirm":...}`) matching the target; mismatch/absent → 400, no upstream forward. Was a bare unauthenticated cascade delete (one curl wiped a bank). Closes the vector behind #1024 (see that issue for the remaining auth hardening).
- **`GET /api/memory/list?bank=` alias** — `bank` is now honored (mapped to dataset via new `bank_to_namespace`); previously silently dropped → returned default-dataset rows regardless of `bank`.

## UI
- **Graph-extraction "off" bug** — Overview now reads `/api/memory/graph/status.enabled` instead of the absent `features.graph` from `/api/memory/engine`.
- **Slot-selection control on the Overview** — lifted from `MemoryGraphPanel`: enabled toggle, `extraction_slot` `<select>` from `available_slots`, `slot_resolves` chip, builds_ok/errors/in_flight/last_built_at/last_error (note: builds_ok/last_built_at are still hard-coded upstream — see #1025).
- **Consolidate robustness** — treats 202/empty-body as success, parses `operation_id ?? id ?? operation`, maps "already in progress"/nothing-to-do to info toast, invalidates the operations query.
- **Live activity indicators** — per-bank pending/processing/completed/failed with a pulsing "N working" badge, a graph "extracting… (N in flight)" badge, and a clickable "N failed" affordance listing failed op types. Efficient shared polling (fast while in-flight, backs off idle; reduced-motion safe).

## Tests
Backend memory tests updated for the guarded delete contract (unconfirmed/mismatched → 400; matching confirm → forwards). e2e memory-view spec updated for the new activity markup. ruff + typecheck clean.

Related: #1024 (delete auth/soft-delete), #1025 (graph counters), #1026 (passthrough shape adapters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)