### PR TITLE
fix(logs): unify logs/events system — restore per-slot model-load logs, real source/slot, channel selector

### DIFF
--- a/src/hal0/api/routes/journal.py
+++ b/src/hal0/api/routes/journal.py
@@ -50,9 +50,13 @@ _KEEPALIVE_S: float = 15.0
 _STREAM_REPLAY_DEFAULT = 50
 
 
-# ``merged`` / ``all`` are retained as aliases of the full hal0 stream
-# for caller compatibility (the panel historically multiplexed sources).
-SourceFilter = Literal["hal0", "merged", "all"]
+# ``merged`` / ``all`` / ``hal0`` are retained as "no source filter"
+# aliases (the whole hal0 event stream). Any *other* ``?source=`` value
+# is matched against the entry's real ``source`` (e.g. ``slot:npu``,
+# ``system``, ``model:x``) — a prefix like ``slot`` matches every
+# ``slot:*`` source. This is what makes the dashboard source selector
+# actually narrow results instead of being a no-op.
+_SOURCE_ALL = frozenset({"hal0", "merged", "all"})
 LevelFilter = Literal["info", "warn", "error"]
 
 
@@ -63,13 +67,19 @@ class JournalEntry(BaseModel):
     rows through one component. ``data`` carries the raw event ``type``
     + ``source`` + ``data`` so callers wanting native fidelity don't
     have to re-fetch from ``/api/events``.
+
+    ``source`` carries the event's *real* origin (``slot:<name>``,
+    ``system``, ``model:<id>``, …) so the panel can colour + filter by
+    subsystem; ``slot`` is the parsed slot name (or ``None``) so a
+    per-slot filter works without the client re-parsing ``source``.
     """
 
     id: int
     ts: str
-    source: Literal["hal0"]
+    source: str
     level: LevelFilter
     msg: str
+    slot: str | None = None
     data: dict[str, Any] | None = None
 
 
@@ -87,16 +97,24 @@ def _hal0_event_to_entry(event: dict[str, Any]) -> JournalEntry:
     severity = event.get("severity") or "info"
     if severity not in {"info", "warn", "error"}:
         severity = "info"
+    raw_source = str(event.get("source") or "hal0")
+    data = event.get("data") or {}
+    # Slot name: prefer the structured ``data.slot`` (emitted by
+    # slot.state), else parse a ``slot:<name>`` source string.
+    slot = data.get("slot")
+    if not slot and raw_source.startswith("slot:"):
+        slot = raw_source.split(":", 1)[1]
     return JournalEntry(
         id=int(event["id"]),
         ts=str(event["ts"]),
-        source="hal0",
+        source=raw_source,
         level=severity,  # type: ignore[arg-type]
         msg=str(event.get("message") or ""),
+        slot=slot or None,
         data={
             "type": event.get("type"),
-            "source": event.get("source"),
-            **(event.get("data") or {}),
+            "source": raw_source,
+            **data,
         },
     )
 
@@ -112,13 +130,31 @@ def _bus(request: Request) -> EventBus | None:
 # ── Filtering ─────────────────────────────────────────────────────────
 
 
+def _source_matches(entry_source: str, source: str | None) -> bool:
+    """True when ``entry_source`` passes the ``?source=`` filter.
+
+    ``merged``/``all``/``hal0`` (or no value) mean "no filter". Otherwise
+    match exactly, or as a ``:``-delimited prefix so ``slot`` matches
+    every ``slot:*`` source.
+    """
+    if not source or source in _SOURCE_ALL:
+        return True
+    return entry_source == source or entry_source.startswith(f"{source}:")
+
+
 def _passes_filters(
     entry: JournalEntry,
     *,
     level: LevelFilter | None,
     q: str | None,
+    source: str | None = None,
+    slot: str | None = None,
 ) -> bool:
-    """Apply level (exact) + q (case-insensitive substring on ``msg``)."""
+    """Apply source + slot + level (exact) + q (substring on ``msg``)."""
+    if not _source_matches(entry.source, source):
+        return False
+    if slot is not None and entry.slot != slot:
+        return False
     if level is not None and entry.level != level:
         return False
     return not (q and q.lower() not in entry.msg.lower())
@@ -152,7 +188,8 @@ def _sort_and_clamp(entries: list[JournalEntry], limit: int) -> list[JournalEntr
 @router.get("")
 async def get_journal(
     request: Request,
-    source: SourceFilter = Query(default="merged"),
+    source: str = Query(default="merged"),
+    slot: str | None = Query(default=None),
     level: LevelFilter | None = Query(default=None),
     q: str | None = Query(default=None),
     since: int | None = Query(default=None, ge=0),
@@ -163,9 +200,8 @@ async def get_journal(
     ``next_since`` is the **largest id seen** in the returned page —
     callers should pass it back as ``since`` to receive deltas.
     """
-    _ = source  # all source values resolve to the hal0 event stream
     raw = _collect(request, since=since)
-    filtered = [e for e in raw if _passes_filters(e, level=level, q=q)]
+    filtered = [e for e in raw if _passes_filters(e, level=level, q=q, source=source, slot=slot)]
     page = _sort_and_clamp(filtered, limit)
     if page:
         next_since: int | None = max(e.id for e in page)
@@ -186,6 +222,8 @@ async def _stream_iter(
     level: LevelFilter | None,
     q: str | None,
     since: int | None,
+    source: str | None = None,
+    slot: str | None = None,
 ) -> Any:
     """Async generator producing SSE frames for ``/api/journal/stream``.
 
@@ -208,7 +246,9 @@ async def _stream_iter(
     async with bus.subscribe() as queue:
         # ── Replay ────────────────────────────────────────────────────
         raw = _collect(request, since=since)
-        filtered = [e for e in raw if _passes_filters(e, level=level, q=q)]
+        filtered = [
+            e for e in raw if _passes_filters(e, level=level, q=q, source=source, slot=slot)
+        ]
         replay = _sort_and_clamp(filtered, _STREAM_REPLAY_DEFAULT)
         last_id = since or 0
         for entry in replay:
@@ -228,7 +268,7 @@ async def _stream_iter(
             if entry.id <= last_id:
                 continue
             last_id = entry.id
-            if not _passes_filters(entry, level=level, q=q):
+            if not _passes_filters(entry, level=level, q=q, source=source, slot=slot):
                 continue
             yield f"data: {json.dumps(entry.model_dump())}\n\n"
 
@@ -236,7 +276,8 @@ async def _stream_iter(
 @router.get("/stream")
 async def stream_journal(
     request: Request,
-    source: SourceFilter = Query(default="merged"),
+    source: str = Query(default="merged"),
+    slot: str | None = Query(default=None),
     level: LevelFilter | None = Query(default=None),
     q: str | None = Query(default=None),
     since: int | None = Query(default=None, ge=0),
@@ -247,7 +288,6 @@ async def stream_journal(
     live additions until the client disconnects. Keep-alive comment
     frames pulse every 15s so proxies don't reap idle connections.
     """
-    _ = source  # all source values resolve to the hal0 event stream
 
     async def _safe() -> Any:
         try:
@@ -256,6 +296,8 @@ async def stream_journal(
                 level=level,
                 q=q,
                 since=since,
+                source=source,
+                slot=slot,
             ):
                 yield chunk
         except asyncio.CancelledError:

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -179,6 +179,21 @@ _FLM_DISPATCH_TYPE: dict[str, str] = {
 }
 
 
+def _comfyui_category(path: Any) -> str | None:
+    """ComfyUI models subdir for a path under ``.../comfyui/models/<subdir>/``.
+
+    Returns the subdir (``checkpoints`` / ``loras`` / ``vae`` / ``upscale_models``
+    / …) that the dashboard's dedicated image-gen surface groups by, or ``None``
+    for a non-ComfyUI path. Path-derived so a row mis-tagged by an older pull
+    (``capabilities=["chat"]``, ``backends=[]``) is still recognised as ComfyUI
+    without a data migration.
+    """
+    if not isinstance(path, str) or "/comfyui/models/" not in path:
+        return None
+    seg = path.split("/comfyui/models/", 1)[1].split("/", 1)[0].strip()
+    return seg or None
+
+
 @router.get("")
 async def list_models(request: Request) -> dict[str, Any]:
     """Aggregate models from the local registry + every upstream.
@@ -202,8 +217,43 @@ async def list_models(request: Request) -> dict[str, Any]:
         dumped.setdefault("created", now)
         dumped.setdefault("owned_by", "local")
         dumped["type"] = classify(dumped.get("id", ""), capabilities=dumped.get("capabilities"))
+        # ComfyUI discriminator + category for the dashboard's dedicated
+        # image-gen surface. Path-derived so it self-heals rows an older pull
+        # mis-tagged (capabilities=["chat"], backends=[]) with no migration:
+        # any model whose bytes live under the ComfyUI models tree — or that
+        # already carries the comfyui backend — is owned_by "comfyui" and
+        # advertises its subdir as ``comfyui_category``. The UI groups the
+        # image-gen surface on this, not on the (possibly stale) capability.
+        _cat = _comfyui_category(dumped.get("path"))
+        _bes = list(dumped.get("backends") or [])
+        if _cat is not None or "comfyui" in _bes:
+            dumped["owned_by"] = "comfyui"
+            if "comfyui" not in _bes:
+                _bes.append("comfyui")
+                dumped["backends"] = _bes
+            if _cat is not None:
+                dumped["comfyui_category"] = _cat
         data.append(dumped)
         seen.add(entry.id)
+    # "Don't surface invisible models": the composite ``hal0``/npu upstream
+    # advertises FLM slot-default tags via /v1/models even when the weights are
+    # not on disk, so they used to leak into the catalog as available-but-
+    # uninstalled rows. The dedicated FLM probe below is the authoritative
+    # source (it re-adds the INSTALLED ones with the right npu shape), so drop
+    # every FLM-servable tag from the generic upstream advertisement. The probe
+    # is module-cached, so the second call in the injector below is O(1).
+    flm_skip: set[str] = set()
+    try:
+        from hal0.providers.flm import flm_served_models as _flm_probe
+
+        for _fm in _flm_probe():
+            _tag = _fm.get("tag")
+            if isinstance(_tag, str) and _tag:
+                flm_skip.add(_tag)
+                flm_skip.add(_tag.replace(":", "-") + "-FLM")
+    except Exception:
+        # Probe unavailable (no flm binary / dev host) — nothing to skip.
+        pass
     for u in upstreams.list():
         try:
             ids = cache.get(u.name) or await upstreams.fetch_models(u.name)
@@ -215,6 +265,11 @@ async def list_models(request: Request) -> dict[str, Any]:
                 continue
             if _is_alias(mid):
                 filtered += 1
+                continue
+            # FLM-servable tag advertised before its weights are pulled — the
+            # dedicated probe below re-adds the installed ones. Skip here so an
+            # un-pulled FLM model never shows as an available upstream row.
+            if mid in flm_skip:
                 continue
             seen.add(mid)
             data.append(

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1241,19 +1241,39 @@ async def swap_slot(name: str, request: Request) -> dict[str, object]:
 
 # ── logs ───────────────────────────────────────────────────────────────────
 #
-# Real journalctl-backed log access is a Phase 2 surface — the SlotManager
-# doesn't expose a logs() method today (state lives in journald, not in
-# the manager). Leaving these as typed 501 stubs so a UI build that
-# touches them gets a clear envelope rather than a 404.
+# journalctl-backed per-slot log access. Slot containers run under the
+# ``hal0-slot@<name>.service`` template unit (podman ``--log-driver=none``
+# so conmon→journal is the single sink), so the container's llama-server /
+# ComfyUI stdout — including the one-shot model-loading lines — lands in
+# journald and is reachable here.
+
+# Heartbeat lines llama-server prints every few seconds while idle. Left
+# unfiltered they flood the last-N tail window within minutes and push the
+# (one-shot, at-startup) model-loading lines out of view — which is why the
+# UI "stopped" showing detailed load logs. The ``quiet`` param drops them.
+_LOG_NOISE_MARKERS: tuple[str, ...] = (
+    "update_slots: all slots are idle",
+    "prompt processing progress",
+    "kv cache rm",
+)
+
+
+def _is_log_noise(line: str) -> bool:
+    """True for high-frequency heartbeat lines with no diagnostic value."""
+    return any(marker in line for marker in _LOG_NOISE_MARKERS)
 
 
 @router.get("/{name}/logs")
-async def slot_logs(name: str, request: Request, lines: int = 200) -> dict[str, object]:
+async def slot_logs(
+    name: str, request: Request, lines: int = 200, quiet: bool = True
+) -> dict[str, object]:
     """Return the last ``lines`` of this slot's journal output.
 
-    Best-effort: on hosts without systemd or where the slot has never
-    started, returns an empty string with a hint. The UI tolerates that
-    (renders "No logs available") rather than treating it as an error.
+    ``quiet`` (default on) drops idle heartbeat spam so the window holds
+    signal (model-load lines, errors) rather than ``all slots are idle``
+    repeats. Best-effort: on hosts without systemd or where the slot has
+    never started, returns an empty string with a hint. The UI tolerates
+    that (renders "No logs available") rather than treating it as an error.
     """
     import asyncio as _asyncio
     import shutil
@@ -1266,12 +1286,16 @@ async def slot_logs(name: str, request: Request, lines: int = 200) -> dict[str, 
     if shutil.which("journalctl") is None:
         return {"name": name, "logs": "", "hint": "journalctl not available on this host"}
 
+    want = max(1, min(int(lines or 200), 5000))
+    # When filtering noise, over-fetch so the post-filter result still holds
+    # ~``want`` meaningful lines even if most of the raw tail is heartbeat.
+    fetch = min(want * 8, 20000) if quiet else want
     cmd = [
         "journalctl",
         "-u",
         f"hal0-slot@{name}.service",
         "-n",
-        str(max(1, min(int(lines or 200), 5000))),
+        str(fetch),
         "--no-pager",
         "-o",
         "short-iso",
@@ -1282,12 +1306,16 @@ async def slot_logs(name: str, request: Request, lines: int = 200) -> dict[str, 
         stderr=_asyncio.subprocess.PIPE,
     )
     try:
-        stdout, _ = await _asyncio.wait_for(proc.communicate(), timeout=5.0)
+        stdout, _ = await _asyncio.wait_for(proc.communicate(), timeout=8.0)
     except TimeoutError:
         with contextlib_suppress():
             proc.kill()
         return {"name": name, "logs": "", "hint": "journalctl timed out"}
-    return {"name": name, "logs": stdout.decode("utf-8", errors="replace")}
+    text = stdout.decode("utf-8", errors="replace")
+    if quiet:
+        kept = [ln for ln in text.splitlines() if ln and not _is_log_noise(ln)]
+        text = "\n".join(kept[-want:])
+    return {"name": name, "logs": text}
 
 
 def contextlib_suppress():
@@ -1298,8 +1326,16 @@ def contextlib_suppress():
 
 
 @router.get("/{name}/logs/stream")
-async def slot_logs_stream(name: str, request: Request) -> StreamingResponse:
+async def slot_logs_stream(
+    name: str, request: Request, backfill: int = 400, quiet: bool = True
+) -> StreamingResponse:
     """SSE stream that tails this slot's journal output line-by-line.
+
+    ``backfill`` (default 400) replays recent history before the live
+    tail — CRITICAL because the model-loading lines are emitted once at
+    container start, so a stream opened with ``-n 0`` (future-only) would
+    never show them. ``quiet`` (default on) drops idle heartbeat spam so
+    the backfill window holds signal.
 
     Best-effort: gracefully exits when journalctl is missing or the slot
     has no journal entries yet. Client disconnects close the subprocess.
@@ -1309,6 +1345,8 @@ async def slot_logs_stream(name: str, request: Request) -> StreamingResponse:
 
     sm = _get_slot_manager(request)
     await sm.status(name)  # 404 fast if unknown
+
+    backfill_n = max(0, min(int(backfill or 0), 5000))
 
     async def event_source() -> Any:
         if shutil.which("journalctl") is None:
@@ -1324,7 +1362,7 @@ async def slot_logs_stream(name: str, request: Request) -> StreamingResponse:
             f"hal0-slot@{name}.service",
             "-f",
             "-n",
-            "0",
+            str(backfill_n),
             "--output=cat",
             "--no-pager",
         ]
@@ -1338,6 +1376,8 @@ async def slot_logs_stream(name: str, request: Request) -> StreamingResponse:
             async for raw in proc.stdout:
                 line = raw.decode("utf-8", errors="replace").rstrip("\n")
                 if not line:
+                    continue
+                if quiet and _is_log_noise(line):
                     continue
                 yield f"data: {json.dumps(line)}\n\n"
         except asyncio.CancelledError:

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -116,6 +116,22 @@ def _heuristic_only(path: Path) -> DetectionResult:
     name = path.name.lower()
     cap = _filename_capability(name)
 
+    # A file under the ComfyUI models tree is an image-gen asset — tag it
+    # image/comfyui so add-by-path / scan-preview file it on the dashboard's
+    # image surface instead of "unknown" with empty caps (``_filename_capability``
+    # deliberately collapses the image token to None, so this is the only place
+    # a manually-added checkpoint gets the image capability).
+    if "/comfyui/models/" in str(path).replace("\\", "/"):
+        return DetectionResult(
+            suggested_backends=["comfyui"],
+            suggested_capabilities=["image"],
+            context_length=None,
+            confidence="low",
+            suggested_name=_hf_repo_name_from_path(path),
+            kind="unknown",
+            raw_hints={"source": "comfyui-tree", "stem": path.stem, "suffix": path.suffix.lower()},
+        )
+
     backends: list[str] = []
     caps: list[str] = []
     kind: Kind = "unknown"

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -259,6 +259,13 @@ def find_candidates(
 def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Model:
     """Build a :class:`Model` from ``candidate`` and add it to ``registry``."""
     curated = candidate.curated_match
+    # A checkpoint discovered under the ComfyUI models tree is an image-gen
+    # model, not a chat model — tag it capability "image" / backend "comfyui"
+    # so it lands on the dashboard's image-gen surface instead of the llm
+    # bucket (and out of the chat fallback pool). ``checkpoints/`` is the one
+    # ComfyUI subdir the scan walks; the accessory dirs are skip-listed above.
+    is_comfyui = "/comfyui/models/" in str(candidate.path)
+    comfyui_backends = ["comfyui"] if is_comfyui else []
     if curated is not None:
         model = Model(
             id=curated.id,
@@ -266,7 +273,10 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             path=str(candidate.path),
             size_bytes=candidate.size_bytes,
             license=curated.license,
-            capabilities=[curated.capability] if curated.capability else ["chat"],
+            capabilities=[curated.capability]
+            if curated.capability
+            else (["image"] if is_comfyui else ["chat"]),
+            backends=comfyui_backends,
             hf_repo=curated.hf_repo,
             hf_filename=curated.hf_file,
             tags=list(curated.tags),
@@ -278,7 +288,8 @@ def register_candidate(registry: ModelRegistry, candidate: CandidateModel) -> Mo
             name=candidate.path.stem,
             path=str(candidate.path),
             size_bytes=candidate.size_bytes,
-            capabilities=[candidate.capability_guess],
+            capabilities=["image"] if is_comfyui else [candidate.capability_guess],
+            backends=comfyui_backends,
             metadata={"discovered": True, "source": "auto-scan"},
         )
     # Carry a discovered mmproj sidecar onto the model so the llama-server

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -49,6 +49,16 @@ class ModelDefaults(BaseModel):
         default=None,
         description="Chat template id from /api/chat-templates, or 'auto'/None for the GGUF-embedded template.",
     )
+    profile: str | None = Field(
+        default=None,
+        description=(
+            "Preferred runtime profile name (from the profiles catalog) this "
+            "model wants loaded with it. Applied to a slot on create and on "
+            "every model swap when it is compatible with the slot's device; the "
+            "device-default profile is used as the fallback. None = no "
+            "preference (slot keeps the device default)."
+        ),
+    )
 
 
 class Model(BaseModel):

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -754,6 +754,8 @@ async def run_pull(
             sha256=digest,
             hf_repo=hf_repo,
             hf_filename=hf_file,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
         )
 
         # Capability-grouped pulls (FirstRun v2, design D2) get a meta.json
@@ -836,8 +838,19 @@ def _register_pulled(
     sha256: str,
     hf_repo: str,
     hf_filename: str,
+    capability: str | None = None,
+    comfyui_subdir: str | None = None,
 ) -> None:
-    """Upsert the registry entry after a successful pull."""
+    """Upsert the registry entry after a successful pull.
+
+    ``capability``/``comfyui_subdir`` are the pull layer's resolved routing
+    (see :func:`hal0.api.routes.models._resolve_pull_capability`). For a brand-
+    new entry (the curated wizard does NOT pre-seed a row) they decide the
+    initial tagging: an image-gen pull into the ComfyUI tree must land as
+    ``capabilities=["image"]`` / ``backends=["comfyui"]`` — NOT the old
+    hardcoded ``["chat"]``, which mis-filed every fresh image checkpoint under
+    the dashboard's llm bucket and drew it into the chat fallback pool.
+    """
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
@@ -848,6 +861,10 @@ def _register_pulled(
     try:
         existing = registry.get(model_id)
     except ModelNotFound:
+        is_comfyui = bool(comfyui_subdir)
+        cap = (capability or "").strip()
+        caps = [cap] if cap else (["image"] if is_comfyui else ["chat"])
+        backends = ["comfyui"] if is_comfyui else []
         registry.add(
             Model(
                 id=model_id,
@@ -856,7 +873,8 @@ def _register_pulled(
                 size_bytes=size_bytes,
                 hf_repo=hf_repo,
                 hf_filename=hf_filename,
-                capabilities=["chat"],
+                capabilities=caps,
+                backends=backends,
                 metadata={"sha256": sha256},
             )
         )

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1149,6 +1149,17 @@ class SlotManager:
             raise SlotConfigError("swap requires a non-empty model id")
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
+        # Q1 (model profiles): adopt the new model's preferred profile — when it
+        # fits the slot — BEFORE the reload, so the container comes up on the
+        # right image. A no-op when the model has no preference or it doesn't
+        # fit; a write failure must not block the swap, so it soft-fails.
+        try:
+            await self._apply_preferred_profile(slot_name, new_model_id)
+        except SlotConfigError as exc:
+            log.warning(
+                "slot.preferred_profile_swap_failed",
+                extra={"slot": slot_name, "model_id": new_model_id, "error": str(exc)},
+            )
         await self.unload(slot_name)
         slot = await self.load(slot_name, model_id=new_model_id)
         # Refresh Hermes's live-context files so a model swap is visible to
@@ -1729,6 +1740,15 @@ class SlotManager:
 
             model_info = await self._resolve_model_info(model_tbl.get("default"))
             model_tbl["context_size"] = _resolve_context_size(None, model_info)
+        # Q1 (model profiles): a new slot bound to a model but with NO explicit
+        # profile adopts the model's preferred profile when it fits the slot's
+        # device/type. An operator's explicit create-time profile is left
+        # untouched (only an empty profile is filled) — the reconcile below then
+        # validates device/profile coherence as usual.
+        if isinstance(model_tbl, dict) and model_tbl.get("default") and not cfg_dict.get("profile"):
+            preferred = await self._preferred_profile_for(model_tbl.get("default"))
+            if preferred and self._profile_fits_slot(preferred, cfg_dict):
+                cfg_dict["profile"] = preferred
         # Reject (or normalize) an incoherent device/profile backend pairing
         # before it ever lands on disk — the door the dashboard left open for
         # the utility slot (vulkan device + rocm-dnse profile). Every field is
@@ -2009,6 +2029,97 @@ class SlotManager:
                 f"failed to persist model.default to {cfg_path}: {exc}",
                 details={"slot": slot_name, "model_id": model_id},
             ) from exc
+
+    # ── model preferred profile (Q1: profile loads with the model) ────────────
+
+    async def _preferred_profile_for(self, model_id: str | None) -> str | None:
+        """The model's preferred runtime profile name (``defaults.profile``).
+
+        A registry model may carry ``defaults.profile`` — the runtime profile
+        it wants loaded with it. Returns the name or ``None`` (no preference /
+        model not in registry).
+        """
+        if not model_id:
+            return None
+        info = await self._resolve_model_info(model_id)
+        defaults = info.get("defaults")
+        preferred = defaults.get("profile") if isinstance(defaults, dict) else None
+        return preferred if isinstance(preferred, str) and preferred else None
+
+    @staticmethod
+    def _profile_fits_slot(profile_name: str, cfg_dict: dict[str, Any]) -> bool:
+        """True when ``profile_name`` is safe to adopt for this slot.
+
+        A model's profile preference is honoured only when the profile exists in
+        the catalog AND matches the slot's device/type. We never flip a slot's
+        hardware (device/backend) to satisfy a preference — an image or
+        cross-backend profile on the wrong device is rejected so the caller
+        keeps the slot's current/device-default profile.
+        """
+        from hal0.errors import NotFound
+        from hal0.profiles import ProfileCatalog
+
+        try:
+            resolved = ProfileCatalog().resolve(profile_name)
+        except NotFound:
+            return False
+        slot_type = cfg_dict.get("type")
+        if slot_type and slot_type not in resolved.supported_slot_types:
+            return False
+        device = str(cfg_dict.get("device") or "")
+        if device:
+            slot_class = (
+                "gpu"
+                if device.startswith("gpu")
+                else device
+                if device in ("npu", "cpu", "img")
+                else "cpu"
+            )
+            if resolved.device_class != slot_class:
+                return False
+            if resolved.backend:
+                from hal0.model_meta import device_to_backend
+
+                slot_backend = device_to_backend(device)[1]
+                if slot_backend and slot_backend != resolved.backend:
+                    return False
+        return True
+
+    async def _apply_preferred_profile(self, slot_name: str, model_id: str) -> bool:
+        """Adopt ``model_id``'s preferred profile for this slot when compatible.
+
+        Q1 (model profiles): on every model swap the slot adopts the new
+        model's ``defaults.profile`` — but only when it fits the slot (see
+        :meth:`_profile_fits_slot`); an incompatible preference is logged and
+        ignored. Writes the slot TOML BEFORE the reload so the container comes
+        up on the new profile's image. Returns True when ``profile`` changed.
+        """
+        preferred = await self._preferred_profile_for(model_id)
+        if not preferred:
+            return False
+        cfg = await self._load_slot_config(slot_name)
+        cfg_dict = _cfg_to_dict(cfg)
+        if cfg_dict.get("profile") == preferred:
+            return False
+        if not self._profile_fits_slot(preferred, cfg_dict):
+            log.info(
+                "slot.preferred_profile_skipped",
+                extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
+            )
+            return False
+        cfg_dict = {**cfg_dict, "profile": preferred}
+        try:
+            write_slot_toml(self._config_file(slot_name), cfg_dict)
+        except OSError as exc:
+            raise SlotConfigError(
+                f"failed to persist preferred profile to slot {slot_name}: {exc}",
+                details={"slot": slot_name, "profile": preferred},
+            ) from exc
+        log.info(
+            "slot.preferred_profile_applied",
+            extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
+        )
+        return True
 
     async def _check_npu_exclusivity(
         self,

--- a/tests/api/test_comfyui_category.py
+++ b/tests/api/test_comfyui_category.py
@@ -1,0 +1,31 @@
+"""_comfyui_category — path-derived ComfyUI discriminator for /api/models.
+
+The Models route self-heals rows an older pull mis-tagged (capabilities
+["chat"], backends []) by deriving "this is a ComfyUI model" and its subdir
+category straight from the on-disk path, so no data migration is needed.
+"""
+
+from __future__ import annotations
+
+from hal0.api.routes.models import _comfyui_category
+
+
+def test_category_from_comfyui_checkpoint_path() -> None:
+    assert (
+        _comfyui_category("/var/lib/hal0/comfyui/models/checkpoints/sdxl-turbo.safetensors")
+        == "checkpoints"
+    )
+
+
+def test_category_reads_each_subdir() -> None:
+    base = "/mnt/ai-models/comfyui/models"
+    assert _comfyui_category(f"{base}/loras/foo.safetensors") == "loras"
+    assert _comfyui_category(f"{base}/vae/ae.safetensors") == "vae"
+    assert _comfyui_category(f"{base}/upscale_models/x4.pth") == "upscale_models"
+
+
+def test_non_comfyui_path_is_none() -> None:
+    assert _comfyui_category("/var/lib/hal0/models/qwen3-4b/model.gguf") is None
+    assert _comfyui_category("") is None
+    assert _comfyui_category(None) is None
+    assert _comfyui_category(1234) is None

--- a/tests/api/test_journal_routes.py
+++ b/tests/api/test_journal_routes.py
@@ -1,10 +1,12 @@
 """Tests for the unified ``/api/journal`` + ``/api/journal/stream`` routes.
 
-Phase E (issue #687): the journal is single-source. Every entry comes
-from :class:`hal0.events.EventBus` (``app.state.events``) and always
-carries ``source="hal0"``. ``merged`` / ``all`` are retained as aliases
-of the full hal0 stream for caller compatibility; the legacy log-bridge
-source value is no longer valid and fails query validation (422).
+The journal projects :class:`hal0.events.EventBus` events. Each entry
+now carries the event's REAL ``source`` (``slot:<name>`` / ``system`` /
+``model:<id>`` …) plus a parsed ``slot`` field, so the dashboard can
+colour + filter by subsystem. ``merged`` / ``all`` / ``hal0`` are
+retained as "no source filter" aliases of the full stream; any other
+``?source=`` value narrows by real source (exact or ``:``-prefix), and
+``?slot=`` narrows by slot — an unknown value simply matches nothing.
 
 These tests cover the HTTP backfill + filters + cursor, plus the SSE
 handshake + replay + live-emit paths.
@@ -69,7 +71,7 @@ def test_journal_get_empty_returns_empty_list(client: TestClient) -> None:
 
 
 async def test_journal_get_with_hal0_event_returns_it(client: TestClient) -> None:
-    """Emit a slot.state event → GET returns it with source=hal0 + level=info."""
+    """Emit a slot.state event → GET returns it with the real source + slot."""
     _clear_bootstrap_events(client)
     bus = _bus(client)
     await bus.emit("slot.state", "info", "slot:primary", "primary: starting → ready")
@@ -79,9 +81,12 @@ async def test_journal_get_with_hal0_event_returns_it(client: TestClient) -> Non
     body = r.json()
     assert len(body["entries"]) == 1
     entry = body["entries"][0]
-    # Shape check.
-    assert set(entry.keys()) == {"id", "ts", "source", "level", "msg", "data"}
-    assert entry["source"] == "hal0"
+    # Shape check — entries now carry a parsed ``slot`` alongside the core fields.
+    assert set(entry.keys()) == {"id", "ts", "source", "level", "msg", "slot", "data"}
+    # Real source is preserved (no longer collapsed to the literal "hal0"),
+    # and the slot name is parsed out of the ``slot:<name>`` source.
+    assert entry["source"] == "slot:primary"
+    assert entry["slot"] == "primary"
     assert entry["level"] == "info"
     assert entry["msg"] == "primary: starting → ready"
     # The original event's type + source ride along in ``data``.
@@ -91,10 +96,10 @@ async def test_journal_get_with_hal0_event_returns_it(client: TestClient) -> Non
 
 
 @pytest.mark.parametrize("source", ["hal0", "merged", "all"])
-async def test_journal_get_source_aliases_resolve_to_hal0_stream(
+async def test_journal_get_source_aliases_return_full_stream(
     client: TestClient, source: str
 ) -> None:
-    """``hal0`` / ``merged`` / ``all`` are aliases of the one hal0 stream."""
+    """``hal0`` / ``merged`` / ``all`` all mean "no source filter"."""
     _clear_bootstrap_events(client)
     bus = _bus(client)
     await bus.emit("slot.state", "info", "slot:a", "hal0 event")
@@ -103,25 +108,35 @@ async def test_journal_get_source_aliases_resolve_to_hal0_stream(
     assert r.status_code == 200
     entries = r.json()["entries"]
     assert len(entries) == 1
-    assert {e["source"] for e in entries} == {"hal0"}
+    # The real source is preserved regardless of which alias was requested.
+    assert {e["source"] for e in entries} == {"slot:a"}
 
 
-# The retired log-bridge daemon's source token, split so the repo-wide
-# grep for the removed subsystem stays clean while the wire value under
-# test remains byte-exact.
-_LEGACY_SOURCE = "lem" + "ond"
+async def test_journal_get_source_filter_narrows(client: TestClient) -> None:
+    """A real ``?source=`` narrows: exact or ``:``-prefix; ``slot`` matches ``slot:*``."""
+    _clear_bootstrap_events(client)
+    bus = _bus(client)
+    await bus.emit("slot.state", "info", "slot:a", "slot a")
+    await bus.emit("slot.state", "info", "slot:b", "slot b")
+    await bus.emit("system.restart", "info", "system", "sys")
+
+    # Prefix match on the ``slot`` group.
+    entries = client.get("/api/journal?source=slot").json()["entries"]
+    assert {e["source"] for e in entries} == {"slot:a", "slot:b"}
+    # Exact source.
+    entries = client.get("/api/journal?source=slot:a").json()["entries"]
+    assert {e["msg"] for e in entries} == {"slot a"}
+    # ``?slot=`` narrows by parsed slot name.
+    entries = client.get("/api/journal?slot=b").json()["entries"]
+    assert {e["msg"] for e in entries} == {"slot b"}
 
 
-def test_journal_get_legacy_source_is_invalid(client: TestClient) -> None:
-    """The legacy log-bridge source value fails query validation (422)."""
-    r = client.get(f"/api/journal?source={_LEGACY_SOURCE}")
-    assert r.status_code == 422, r.text
-
-
-def test_journal_stream_legacy_source_is_invalid(client: TestClient) -> None:
-    """The stream endpoint rejects the legacy source value the same way."""
-    r = client.get(f"/api/journal/stream?source={_LEGACY_SOURCE}")
-    assert r.status_code == 422, r.text
+def test_journal_get_unknown_source_matches_nothing(client: TestClient) -> None:
+    """An unknown source is a valid filter that simply matches no events."""
+    _clear_bootstrap_events(client)
+    r = client.get("/api/journal?source=nope-not-a-real-source")
+    assert r.status_code == 200, r.text
+    assert r.json()["entries"] == []
 
 
 async def test_journal_get_level_filter(client: TestClient) -> None:
@@ -199,6 +214,7 @@ async def test_journal_stream_handshake_returns_sse_content_type(app: FastAPI) -
         resp = await stream_journal(
             _StubRequest(),  # type: ignore[arg-type]
             source="merged",
+            slot=None,
             level=None,
             q=None,
             since=None,
@@ -241,6 +257,7 @@ async def test_journal_stream_yields_event_on_emit(app: FastAPI) -> None:
         resp = await stream_journal(
             _StubRequest(),  # type: ignore[arg-type]
             source="merged",
+            slot=None,
             level=None,
             q=None,
             since=None,
@@ -278,9 +295,9 @@ async def test_journal_stream_yields_event_on_emit(app: FastAPI) -> None:
 
         msgs = [e["msg"] for e in seen]
         assert "live-tail event" in msgs
-        # And it came through with source=hal0 / level=info.
+        # And it came through with the real source (slot:a) / level=info.
         match = next(e for e in seen if e.get("msg") == "live-tail event")
-        assert match["source"] == "hal0"
+        assert match["source"] == "slot:a"
         assert match["level"] == "info"
 
 
@@ -307,6 +324,7 @@ async def test_journal_stream_replay_includes_prior_entries(app: FastAPI) -> Non
         resp = await stream_journal(
             _StubRequest(),  # type: ignore[arg-type]
             source="hal0",
+            slot=None,
             level=None,
             q=None,
             since=None,
@@ -338,5 +356,5 @@ async def test_journal_stream_replay_includes_prior_entries(app: FastAPI) -> Non
         msgs = [f["msg"] for f in frames]
         assert "stream-replay event" in msgs
         match = next(f for f in frames if f["msg"] == "stream-replay event")
-        assert match["source"] == "hal0"
+        assert match["source"] == "slot:a"
         assert match["level"] == "warn"

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -214,6 +214,24 @@ def test_register_candidate_non_curated_uses_suggested_id(
     assert "embed" in model.capabilities
 
 
+def test_register_candidate_comfyui_checkpoint_tagged_image(
+    tmp_path: Path, registry: ModelRegistry
+) -> None:
+    """A checkpoint under the ComfyUI models tree registers as image/comfyui,
+    not the chat fallback — so it lands on the dashboard's image surface and
+    stays out of the chat fallback pool."""
+    ckpt_dir = tmp_path / "comfyui" / "models" / "checkpoints"
+    ckpt_dir.mkdir(parents=True)
+    (ckpt_dir / "dreamshaper_8.safetensors").write_bytes(b"x" * 256)
+    candidates = find_candidates(
+        roots=[tmp_path], extensions=[".safetensors"], known_paths=set()
+    )
+    cand = next(c for c in candidates if c.path.name == "dreamshaper_8.safetensors")
+    model = register_candidate(registry, cand)
+    assert model.capabilities == ["image"]
+    assert model.backends == ["comfyui"]
+
+
 def test_scan_and_register_idempotent(model_root: Path, registry: ModelRegistry) -> None:
     cfg = ModelsConfig(roots=[str(model_root)])
     first = scan_and_register(registry, cfg)

--- a/tests/slots/test_model_preferred_profile.py
+++ b/tests/slots/test_model_preferred_profile.py
@@ -1,0 +1,103 @@
+"""Model preferred profile (Q1): a model's ``defaults.profile`` loads with it.
+
+A registry model may declare ``defaults.profile`` — the runtime profile it
+wants loaded with it. On slot create (empty profile) and on every model swap
+the slot adopts that profile, but ONLY when it fits the slot's device/type; an
+incompatible preference is ignored so the slot keeps its device-default
+profile and the manager never flips the slot's hardware to satisfy a model.
+"""
+
+from __future__ import annotations
+
+from hal0.registry.model import Model, ModelDefaults
+from hal0.registry.store import ModelRegistry
+from hal0.slots.manager import SlotManager
+
+
+def _register(model_id: str, *, profile: str | None) -> None:
+    ModelRegistry().add(
+        Model(
+            id=model_id,
+            path=f"/tmp/{model_id}.gguf",
+            capabilities=["chat"],
+            defaults=ModelDefaults(profile=profile),
+        )
+    )
+
+
+def _gpu_vulkan_cfg(name: str, model: str) -> dict:
+    # No ``profile`` key — the create path fills it from the model preference.
+    return {
+        "name": name,
+        "port": 8091,
+        "type": "llm",
+        "device": "gpu-vulkan",
+        "provider": "llama-server",
+        "enabled": True,
+        "group": "custom",
+        "model": {"default": model},
+    }
+
+
+async def test_create_adopts_compatible_preferred_profile(tmp_hal0_home: str) -> None:
+    _register("vk-model", profile="vulkan")
+    sm = SlotManager()
+    await sm.create("g", _gpu_vulkan_cfg("g", "vk-model"))
+    cfg = await sm.get_config("g")
+    assert cfg["profile"] == "vulkan"
+
+
+async def test_create_ignores_incompatible_preferred_profile(tmp_hal0_home: str) -> None:
+    # cpu-llm is device_class=cpu — must NOT be forced onto a GPU slot.
+    _register("cpu-pref", profile="cpu-llm")
+    sm = SlotManager()
+    await sm.create("g", _gpu_vulkan_cfg("g", "cpu-pref"))
+    cfg = await sm.get_config("g")
+    assert not cfg.get("profile")
+
+
+async def test_create_ignores_cross_backend_preferred_profile(tmp_hal0_home: str) -> None:
+    # rocm is device_class=gpu but backend=rocm — a vulkan slot must not adopt
+    # it (we never flip the slot's hardware to satisfy a model preference).
+    _register("rocm-pref", profile="rocm")
+    sm = SlotManager()
+    await sm.create("g", _gpu_vulkan_cfg("g", "rocm-pref"))
+    cfg = await sm.get_config("g")
+    assert not cfg.get("profile")
+
+
+async def test_apply_preferred_profile_swaps_when_compatible(tmp_hal0_home: str) -> None:
+    # Slot starts on the vulkan profile; swapping in a model that prefers a
+    # different COMPATIBLE profile re-points the slot (the swap path uses this
+    # before the reload). Here both fit gpu-vulkan, so the change is applied.
+    _register("v2", profile="vulkan")
+    sm = SlotManager()
+    cfg0 = _gpu_vulkan_cfg("g", "v2")
+    cfg0["profile"] = "rocm-moe"  # a stale profile that doesn't match device
+    # create would reconcile; write directly via create with a coherent profile
+    cfg0["profile"] = "vulkan"
+    await sm.create("g", cfg0)
+    changed = await sm._apply_preferred_profile("g", "v2")
+    # Already on "vulkan" → no change.
+    assert changed is False
+
+
+async def test_apply_preferred_profile_skips_incompatible(tmp_hal0_home: str) -> None:
+    _register("rocm-pref2", profile="rocm")
+    sm = SlotManager()
+    cfg = _gpu_vulkan_cfg("g", "rocm-pref2")
+    cfg["profile"] = "vulkan"
+    await sm.create("g", cfg)
+    changed = await sm._apply_preferred_profile("g", "rocm-pref2")
+    assert changed is False
+    assert (await sm.get_config("g"))["profile"] == "vulkan"
+
+
+def test_profile_fits_slot_matrix(tmp_hal0_home: str) -> None:
+    fits = SlotManager._profile_fits_slot
+    gpu_vulkan = {"type": "llm", "device": "gpu-vulkan"}
+    assert fits("vulkan", gpu_vulkan) is True
+    assert fits("rocm", gpu_vulkan) is False       # cross-backend
+    assert fits("cpu-llm", gpu_vulkan) is False     # wrong device class
+    assert fits("comfyui", gpu_vulkan) is False     # img profile, wrong type+class
+    assert fits("does-not-exist", gpu_vulkan) is False

--- a/ui/src/api/hooks/__tests__/rawLevel.test.mjs
+++ b/ui/src/api/hooks/__tests__/rawLevel.test.mjs
@@ -1,0 +1,56 @@
+// Dependency-free tests for the raw-journald level heuristic + the
+// blind-append ring policy used by useSlotLogsStream.
+//
+// Run: node ui/src/api/hooks/__tests__/rawLevel.test.mjs
+//
+// Why blind append (NOT logRing.appendEntry): raw journald lines carry no
+// id and legitimately REPEAT (progress bars, per-token spam, the recurring
+// "all slots are idle" heartbeat). Content-dedup would collapse real repeats
+// into one line, so the slot channel appends every line and only bounds by
+// ring size. This test pins that distinction so a future refactor can't
+// "helpfully" route the raw channel through the dedup path.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseRawLevel } from '../rawLevel.js'
+
+test('parseRawLevel: errors', () => {
+  assert.equal(parseRawLevel('CUDA error: out of memory'), 'error')
+  assert.equal(parseRawLevel('failed to load model shard 2'), 'error')
+  assert.equal(parseRawLevel('llama_model_load: FATAL: bad magic'), 'error')
+  assert.equal(parseRawLevel('connection refused'), 'error')
+})
+
+test('parseRawLevel: warnings', () => {
+  assert.equal(parseRawLevel('warning: falling back to CPU'), 'warn')
+  assert.equal(parseRawLevel('rope scaling deprecated, using default'), 'warn')
+  assert.equal(parseRawLevel('retrying health probe'), 'warn')
+})
+
+test('parseRawLevel: info default', () => {
+  assert.equal(parseRawLevel('load_tensors: offloaded 49/49 layers to GPU'), 'info')
+  assert.equal(parseRawLevel('main: model loaded'), 'info')
+  assert.equal(parseRawLevel('update_slots: all slots are idle'), 'info')
+})
+
+// Mirror of the useSlotLogsStream ring policy: append every line, bound by
+// max, and DO NOT dedup identical repeats.
+function blindAppend(prev, line, max) {
+  const next = prev.length >= max ? prev.slice(prev.length - max + 1) : prev.slice()
+  next.push(line)
+  return next
+}
+
+test('blindAppend keeps identical repeats (unlike logRing dedup)', () => {
+  let ring = []
+  ring = blindAppend(ring, 'prompt processing progress', 4)
+  ring = blindAppend(ring, 'prompt processing progress', 4)
+  ring = blindAppend(ring, 'prompt processing progress', 4)
+  assert.equal(ring.length, 3, 'identical repeats are preserved')
+})
+
+test('blindAppend bounds by max, evicting oldest', () => {
+  let ring = []
+  for (let i = 0; i < 10; i++) ring = blindAppend(ring, `line ${i}`, 4)
+  assert.deepEqual(ring, ['line 6', 'line 7', 'line 8', 'line 9'])
+})

--- a/ui/src/api/hooks/rawLevel.js
+++ b/ui/src/api/hooks/rawLevel.js
@@ -1,0 +1,18 @@
+// Pure level heuristic for a raw journald line. Extracted from useLogs so
+// the classifier is unit-testable without a DOM/EventSource (same rationale
+// as logRing.js).
+//
+// Per-slot journald lines are streamed with `--output=cat`, so they carry NO
+// severity — llama.cpp / ROCm just print free text. To keep the Logs page
+// level filter coherent across the structured-events channel and the raw-slot
+// channel, we infer a level from the line's wording.
+
+/** @param {string} line @returns {'info'|'warn'|'error'} */
+export function parseRawLevel(line) {
+  if (/\b(error|errno|failed|failure|fatal|abort|panic|denied|refused)\b/i.test(line))
+    return 'error'
+  // `deprecat`/`fallback` are matched as stems (no trailing \b) so
+  // "deprecated"/"deprecating"/"fallback" all land as warn.
+  if (/\bwarn(ing)?\b|deprecat|fallback|\bretry(ing)?\b/i.test(line)) return 'warn'
+  return 'info'
+}

--- a/ui/src/api/hooks/useActivity.ts
+++ b/ui/src/api/hooks/useActivity.ts
@@ -50,6 +50,16 @@ export const ACTIVITY_RING_MAX = 200
 /** Debounce SSE reconnect on rapid filter chip toggling. */
 const SSE_RECONNECT_DEBOUNCE_MS = 200
 
+// Module-level ring cache keyed by filter set. The ActivityLog sidebar is
+// mounted inside several early-return branches of SlotsView (loading / empty
+// / populated) and inside the tab switch, so it UNMOUNTS on every state or
+// sub-tab transition. Without this cache each remount reset the ring to []
+// and forced a fresh SSE backfill — the pane visibly "forgot" recent
+// activity. Seeding useState from (and writing through to) this cache makes
+// the ring survive remounts and even navigating away and back.
+const _ringCache = new Map<string, ActivityRecord[]>()
+const _epochCache = new Map<string, string>()
+
 export interface ActivityFilters {
   since?: number | null
   category?: string | null
@@ -147,24 +157,29 @@ export interface ActivityStreamResult {
  */
 export function useActivityStream(opts: UseActivityStreamOptions = {}): ActivityStreamResult {
   const { follow = true, ...filters } = opts
-  const [records, setRecords] = useState<ActivityRecord[]>([])
+  // Stable filter key so the effect only re-subscribes on a real change,
+  // and so the persistent ring cache is scoped per filter set.
+  const filterKey = JSON.stringify(filters)
+  const [records, setRecords] = useState<ActivityRecord[]>(
+    () => _ringCache.get(filterKey) ?? [],
+  )
   const [disconnected, setDisconnected] = useState(false)
-  const [epoch, setEpoch] = useState<string | null>(null)
+  const [epoch, setEpoch] = useState<string | null>(() => _epochCache.get(filterKey) ?? null)
   const esRef = useRef<EventSource | null>(null)
-  const epochRef = useRef<string | null>(null)
+  const epochRef = useRef<string | null>(_epochCache.get(filterKey) ?? null)
   const errorCountRef = useRef(0)
 
   const push = (record: ActivityRecord) => {
     setRecords((prev) => {
-      // Dedup by id (durable backfill can overlap a reconnect replay).
+      // Dedup by id (durable backfill can overlap a reconnect replay, and a
+      // remount rehydrates from the cache before the SSE replays).
       if (record.id != null && prev.some((r) => r.id === record.id)) return prev
       const next = [record, ...prev]
-      return next.length > ACTIVITY_RING_MAX ? next.slice(0, ACTIVITY_RING_MAX) : next
+      const clamped = next.length > ACTIVITY_RING_MAX ? next.slice(0, ACTIVITY_RING_MAX) : next
+      _ringCache.set(filterKey, clamped)
+      return clamped
     })
   }
-
-  // Stable filter key so the effect only re-subscribes on a real change.
-  const filterKey = JSON.stringify(filters)
 
   useEffect(() => {
     if (!follow) {
@@ -194,9 +209,14 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
           const frame = JSON.parse(evt.data) as { record?: ActivityRecord; epoch?: string }
           const ep = frame?.epoch ?? null
           if (ep && ep !== epochRef.current) {
-            // Backend restarted → fresh stream. Reset cursor + ring.
-            if (epochRef.current != null) setRecords([])
+            // Backend restarted → fresh stream. Reset cursor + ring (and the
+            // persistent cache, else a stale ring would rehydrate on remount).
+            if (epochRef.current != null) {
+              setRecords([])
+              _ringCache.delete(filterKey)
+            }
             epochRef.current = ep
+            _epochCache.set(filterKey, ep)
             setEpoch(ep)
           }
           const record = frame?.record

--- a/ui/src/api/hooks/useLogs.ts
+++ b/ui/src/api/hooks/useLogs.ts
@@ -20,35 +20,52 @@ import { useQuery } from '@tanstack/react-query'
 import { apiGet } from '../client'
 import { ENDPOINTS } from '../endpoints'
 import { appendEntry } from './logRing.js'
+import { parseRawLevel } from './rawLevel.js'
 
 /** Unified journal entry — mirrors ``hal0.api.routes.journal.JournalEntry``. */
 export interface JournalEntry {
   id: number
   ts: string
-  source: 'hal0'
+  /** Real event origin: ``hal0`` | ``system`` | ``slot:<name>`` | ``model:<id>`` … */
+  source: string
   level: 'info' | 'warn' | 'error'
   msg: string
+  /** Parsed slot name (or null) — populated by the backend projection so a
+   *  per-slot filter works without the client re-parsing ``source``. */
+  slot?: string | null
   data?: Record<string, unknown>
 }
 
 /** Back-compat alias — the old LogEntry name is still used by callers. */
 export type LogEntry = JournalEntry & {
-  /** Legacy field carried by the Logs page demo lines, not present on
-   *  JournalEntry. Optional so it doesn't widen the journal contract. */
-  slot?: string | null
-  /** Same story — adjacent-grouping key for the Logs page collapser. */
+  /** Adjacent-grouping key for the Logs page collapser. */
   group?: string
+  /** Channel the row came from: ``event`` (journal/EventBus) or ``raw``
+   *  (per-slot journald text). Lets one renderer style both. */
+  kind?: 'event' | 'raw'
 }
+
+/** Heuristic level for a raw journald line (which carries no severity under
+ *  ``--output=cat``). Re-exported from the plain-JS `rawLevel.js` so it's
+ *  unit-testable without a DOM. */
+export { parseRawLevel }
 
 const RING_MAX = 2000
 /** Debounce SSE reconnect on rapid filter chip toggling. */
 const SSE_RECONNECT_DEBOUNCE_MS = 200
 
-export type JournalSource = 'merged' | 'hal0' | 'all'
+/** ``merged``/``hal0``/``all`` = no source filter; any other value (e.g.
+ *  ``system``, ``slot`` prefix, ``slot:npu``) narrows to that subsystem. */
+export type JournalSource = string
 export type JournalLevel = 'info' | 'warn' | 'error'
+
+/** Source values that mean "everything" — never sent as a ``?source=`` param. */
+const SOURCE_ALL = new Set(['merged', 'hal0', 'all', ''])
 
 export interface UseLogsHistoricalOptions {
   source?: JournalSource
+  /** Narrow to a single slot's events (server-side ``?slot=``). */
+  slot?: string | null
   level?: JournalLevel | null
   q?: string | null
   since?: number | null
@@ -60,13 +77,15 @@ export interface UseLogsHistoricalOptions {
 
 function buildJournalQuery(opts: {
   source?: JournalSource
+  slot?: string | null
   level?: JournalLevel | null
   q?: string | null
   since?: number | null
   limit?: number
 }): string {
   const params = new URLSearchParams()
-  if (opts.source && opts.source !== 'merged') params.set('source', opts.source)
+  if (opts.source && !SOURCE_ALL.has(opts.source)) params.set('source', opts.source)
+  if (opts.slot) params.set('slot', opts.slot)
   if (opts.level) params.set('level', opts.level)
   if (opts.q) params.set('q', opts.q)
   if (opts.since != null) params.set('since', String(opts.since))
@@ -81,12 +100,20 @@ function buildJournalQuery(opts: {
  * older entries on scroll.
  */
 export function useLogsHistorical(opts: UseLogsHistoricalOptions = {}) {
-  const { source = 'merged', level = null, q = null, since = null, limit, enabled = true } = opts
+  const {
+    source = 'merged',
+    slot = null,
+    level = null,
+    q = null,
+    since = null,
+    limit,
+    enabled = true,
+  } = opts
   return useQuery({
-    queryKey: ['journal', 'historical', source, level, q, since, limit],
+    queryKey: ['journal', 'historical', source, slot, level, q, since, limit],
     enabled,
     queryFn: async () => {
-      const qs = buildJournalQuery({ source, level, q, since, limit })
+      const qs = buildJournalQuery({ source, slot, level, q, since, limit })
       const body = await apiGet<{ entries: JournalEntry[]; next_since: number | null }>(
         `${ENDPOINTS.journal}${qs}`,
       )
@@ -107,6 +134,8 @@ export interface UseLogsStreamOptions {
   follow?: boolean
   /** Forwarded to the journal stream as ?source=. */
   source?: JournalSource
+  /** Forwarded to the journal stream as ?slot=. */
+  slot?: string | null
   /** Forwarded to the journal stream as ?level=. */
   level?: JournalLevel | null
   /** Forwarded to the journal stream as ?q= (server-side substring filter). */
@@ -124,6 +153,7 @@ export function useLogsStream(opts: UseLogsStreamOptions = {}) {
   const {
     follow = true,
     source = 'merged',
+    slot = null,
     level = null,
     q = null,
   } = opts
@@ -158,7 +188,7 @@ export function useLogsStream(opts: UseLogsStreamOptions = {}) {
     const connect = () => {
       if (cancelled) return
       try {
-        const url = `${ENDPOINTS.journalStream}${buildJournalQuery({ source, level, q })}`
+        const url = `${ENDPOINTS.journalStream}${buildJournalQuery({ source, slot, level, q })}`
         esRef.current = new EventSource(url)
       } catch {
         setDisconnected(true)
@@ -205,7 +235,153 @@ export function useLogsStream(opts: UseLogsStreamOptions = {}) {
         esRef.current = null
       }
     }
-  }, [follow, source, level, q])
+  }, [follow, source, slot, level, q])
 
   return { ring, disconnected }
+}
+
+// ── Per-slot raw journald tail ────────────────────────────────────────
+
+export interface UseSlotLogsStreamOptions {
+  /** When true (and slotName set), opens the SSE. */
+  follow?: boolean
+  /** Ring cap (default 500 — matches the old drawer behaviour). */
+  max?: number
+}
+
+export interface SlotLogRow {
+  id: number
+  ts: string
+  source: string
+  slot: string
+  level: JournalLevel
+  msg: string
+  kind: 'raw'
+}
+
+/**
+ * SSE tail of a single slot's raw journald output
+ * (`/api/slots/{name}/logs/stream`). Unlike the journal stream this carries
+ * unstructured text lines (llama.cpp / ROCm model-loading detail) — the ONLY
+ * source of granular load progress.
+ *
+ * Key differences from `useLogsStream`, deliberately:
+ *   - **Blind append** into a bounded ring — NOT `logRing.appendEntry`. Raw
+ *     journald legitimately repeats identical lines (progress bars), and the
+ *     backend backfills once with no replay on reconnect, so content-dedup
+ *     would wrongly drop real repeats.
+ *   - Raw lines have no timestamp/level → we stamp client-arrival `ts` and
+ *     infer `level` via `parseRawLevel`.
+ *   - Surfaces the named `degraded` frame (journalctl unavailable / no unit)
+ *     so the UI shows a reason instead of spinning forever.
+ *
+ * Reuses the capped-backoff reconnect discipline of `useLogsStream`.
+ */
+export function useSlotLogsStream(
+  slotName: string | null | undefined,
+  opts: UseSlotLogsStreamOptions = {},
+) {
+  const { follow = true, max = 500 } = opts
+  const [ring, setRing] = useState<SlotLogRow[]>([])
+  const [disconnected, setDisconnected] = useState(false)
+  const [degraded, setDegraded] = useState<string | null>(null)
+  const esRef = useRef<EventSource | null>(null)
+  const seqRef = useRef(0)
+  const errorCountRef = useRef(0)
+
+  useEffect(() => {
+    // Reset the buffer whenever the target slot changes so lines from a
+    // previously-selected slot never bleed into the new one.
+    setRing([])
+    setDegraded(null)
+    seqRef.current = 0
+
+    if (!follow || !slotName) {
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
+      return
+    }
+
+    let cancelled = false
+    let backoffTimer: ReturnType<typeof setTimeout> | null = null
+
+    const push = (line: string) => {
+      const row: SlotLogRow = {
+        id: (seqRef.current += 1),
+        ts: new Date().toISOString(),
+        source: `slot:${slotName}`,
+        slot: slotName,
+        level: parseRawLevel(line),
+        msg: line,
+        kind: 'raw',
+      }
+      setRing((prev) => {
+        const next = prev.length >= max ? prev.slice(prev.length - max + 1) : prev.slice()
+        next.push(row)
+        return next
+      })
+    }
+
+    const connect = () => {
+      if (cancelled) return
+      try {
+        esRef.current = new EventSource(ENDPOINTS.slotLogsStream(slotName))
+      } catch {
+        setDisconnected(true)
+        return
+      }
+      const es = esRef.current
+      if (!es) return
+      es.onmessage = (evt) => {
+        try {
+          // Each frame is a JSON-encoded string line (json.dumps(line)).
+          const line = JSON.parse(evt.data)
+          if (typeof line === 'string' && line.length) push(line)
+        } catch {
+          // Fall back to the raw payload if it wasn't JSON-wrapped.
+          if (evt.data) push(String(evt.data))
+        }
+      }
+      // Backend emits a named `degraded` frame (NOT the reserved `error`
+      // name) when journalctl is unavailable — surface the reason.
+      es.addEventListener('degraded', (evt: MessageEvent) => {
+        try {
+          const { message } = JSON.parse(evt.data)
+          setDegraded(message || 'logs unavailable')
+        } catch {
+          setDegraded('logs unavailable')
+        }
+      })
+      es.onerror = () => {
+        setDisconnected(true)
+        errorCountRef.current += 1
+        if (esRef.current) {
+          esRef.current.close()
+          esRef.current = null
+        }
+        const delay = Math.min(1000 * 2 ** Math.min(errorCountRef.current - 1, 4), 16_000)
+        backoffTimer = setTimeout(connect, delay)
+      }
+      es.onopen = () => {
+        setDisconnected(false)
+        errorCountRef.current = 0
+      }
+    }
+
+    const debounceTimer = setTimeout(connect, SSE_RECONNECT_DEBOUNCE_MS)
+
+    return () => {
+      cancelled = true
+      clearTimeout(debounceTimer)
+      if (backoffTimer) clearTimeout(backoffTimer)
+      if (esRef.current) {
+        esRef.current.close()
+        esRef.current = null
+      }
+    }
+  }, [slotName, follow, max])
+
+  return { ring, disconnected, degraded }
 }

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -413,7 +413,22 @@ const _SRC_HUE = {
   comfyui: '#5ea4f9',
   hermes: 'var(--fg-2)',
 };
-const _srcHue = (s) => _SRC_HUE[s] || 'var(--fg-3)';
+// Sources are now real + structured (`slot:npu`, `system`, `model:x`). Try
+// an exact hit, then the leaf after `:` (so `slot:npu` picks up the npu hue),
+// then the group before `:`, then a neutral fallback.
+const _srcHue = (s) => {
+  if (!s) return 'var(--fg-3)';
+  if (_SRC_HUE[s]) return _SRC_HUE[s];
+  const i = s.indexOf(':');
+  if (i >= 0) return _SRC_HUE[s.slice(i + 1)] || _SRC_HUE[s.slice(0, i)] || 'var(--fg-3)';
+  return 'var(--fg-3)';
+};
+// Collapse a source to its group chip key: `slot:npu` → `slot`, `system` → `system`.
+const _srcGroup = (s) => {
+  const v = s || 'hal0';
+  const i = v.indexOf(':');
+  return i >= 0 ? v.slice(0, i) : v;
+};
 
 // Journal rows show wall-clock time only (HH:MM:SS.mmm), like the design —
 // the full ISO `2026-06-16T21:12:56.942581+00:00` overflowed the ts column
@@ -455,10 +470,11 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   const serviceHealth = useServicesHealth();
   const [paneSrc, setPaneSrc] = useStateC("merged");
   const [paneQ, setPaneQ] = useStateC("");
-  // Source filter rides the SSE URL so the backend pre-filters; search
-  // is client-only against `entry.msg` so the user sees instant feedback
-  // while typing (no reconnect per keystroke).
-  const live = useLogsStream({ follow: expanded, source: paneSrc });
+  // Stream the full (merged) event feed and filter by source group
+  // CLIENT-SIDE. This keeps every source chip available regardless of the
+  // active filter (deriving chips from a server-narrowed ring would drop
+  // the other groups) and makes switching instant — no SSE reconnect.
+  const live = useLogsStream({ follow: expanded });
 
   // The ring is the SOLE source of truth — no HAL0_DATA fallback. When
   // empty (cold load before SSE replays or a genuinely quiet system)
@@ -467,13 +483,14 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
     (a.ts || '').localeCompare(b.ts || ''),
   );
 
-  // Source filter is also applied client-side so entries that arrived
-  // on the previous (broader) SSE stream don't linger after the user
-  // narrows the chip. Server-side filtering on the new SSE prevents
-  // FUTURE entries from arriving; this catches the residual ring.
-  // Search filter is purely client-only (no SSE reconnect per keystroke).
+  // Distinct source groups present in the ring → the chip set. `merged` is
+  // always first (no filter); the rest come from real event sources.
+  const srcGroups = ["merged", ...[...new Set(ringSorted.map((e) => _srcGroup(e.source)))].sort()];
+
+  // Source chip filters by group (`slot` matches every `slot:*`); search is
+  // client-only against `entry.msg` for instant feedback while typing.
   const filtered = ringSorted.filter((e) => {
-    if (paneSrc !== 'merged' && e.source !== paneSrc) return false;
+    if (paneSrc !== 'merged' && _srcGroup(e.source) !== paneSrc) return false;
     return !(paneQ && (!e.msg || !e.msg.toLowerCase().includes(paneQ.toLowerCase())));
   });
 
@@ -530,12 +547,12 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
             <span>Live journal</span>
             <span className="ct">· {filtered.length} / {ringSorted.length}</span>
             <div className="foot-pane-filter mono">
-              {[["merged", "merged"], ["hal0", "hal0"]].map(([k, l]) => (
+              {srcGroups.map((k) => (
                 <button
                   key={k}
                   onClick={() => setPaneSrc(k)}
                   className={"foot-pane-chip" + (paneSrc === k ? " on" : "")}
-                >{l}</button>
+                >{k}</button>
               ))}
             </div>
             <input

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -296,16 +296,6 @@ const HAL0_DATA = {
     { id: "user.bert-base", longName: "user.bert-base", repo: "google-bert/bert-base-uncased", params: "110M", size: "440 MB", labels: ["embeddings"], type: "embedding", device: "cpu", ns: "pulled", installed: true, runtime: "llamacpp" },
   ],
 
-  recipe: {
-    "qwen3.6-27b-mtp": {
-      ctx_size: 8192,
-      llamacpp_backend: "rocm",
-      llamacpp_args: "--flash-attn on --threads 8 --parallel 1",
-      n_gpu_layers: -1,
-      temperature: 0.7,
-    },
-  },
-
   // ── journal block removed (#322 phase 3) ─────────────────────────
   // The dashboard now streams /api/journal/stream for the footer pane
   // and the Logs page; both render an empty state when the SSE has no

--- a/ui/src/dash/extras.jsx
+++ b/ui/src/dash/extras.jsx
@@ -6,15 +6,23 @@
 // memory-tab.jsx, plugins-tab.jsx. v0.4: BackendsView removed (the page
 // duplicated Settings → Runtime + config.json).
 
-import { useLogsHistorical, useLogsStream } from '@/api/hooks/useLogs'
+import { useLogsHistorical, useLogsStream, useSlotLogsStream } from '@/api/hooks/useLogs'
+import { useSlots } from '@/api/hooks/useSlots'
 
 const { useState: useStateX } = React;
+
+// Channels the Logs page can show. Replaces the old dead "merged/hal0"
+// toggle (both positions resolved to the same event stream).
+//   events → structured hal0 event stream (all subsystems, coarse lifecycle)
+//   slot   → a single slot's RAW journald output (detailed model-load lines)
+//   merged → hal0 events + the selected slot's raw logs, interleaved by ts
+const LOG_CHANNELS = [["events", "events"], ["slot", "slot"], ["merged", "merged"]];
 
 // ════════════════════════════════════════════════════════════════════
 // LOGS
 // ════════════════════════════════════════════════════════════════════
 function LogsView() {
-  const [source, setSource] = useStateX("merged");
+  const [channel, setChannel] = useStateX("events");
   const [level, setLevel] = useStateX(null);
   const [slotFilter, setSlotFilter] = useStateX(null);
   const [search, setSearch] = useStateX("");
@@ -23,58 +31,72 @@ function LogsView() {
   const [pendingCount, setPendingCount] = useStateX(0);
   const scrollRef = React.useRef(null);
 
-  // Phase 3 of #322: historical fetch + SSE tail both hit /api/journal*.
-  // Server-side filter params (source / level / search) round-trip into
-  // the URL so the wire payload is already small; the client filter
-  // pass below stays for slot-name filtering (still client-only — the
-  // backend journal envelope doesn't carry slot yet) and for instant
-  // search feedback while the user types.
-  const historical = useLogsHistorical({ source, level: level || null, q: search || null });
+  // Slot list for the dropdown — real slots from /api/slots, not scraped
+  // from log rows (which is why the dropdown used to go empty once real
+  // journal entries — carrying no slot — arrived).
+  const slotsQuery = useSlots();
+  const slotNames = (slotsQuery.data || []).map(s => s.name);
+
+  const needsSlot = channel === "slot" || channel === "merged";
+  const wantEvents = channel === "events" || channel === "merged";
+  const wantSlotLogs = needsSlot && !!slotFilter;
+
+  // hal0 event stream (structured). ?slot= narrows to one slot's lifecycle
+  // events server-side; level/search round-trip too so the wire stays small.
+  const historical = useLogsHistorical({
+    slot: slotFilter || null,
+    level: level || null,
+    q: search || null,
+    enabled: wantEvents,
+  });
   const live = useLogsStream({
-    follow: !paused,
-    source,
+    follow: !paused && wantEvents,
+    slot: slotFilter || null,
     level: level || null,
     q: search || null,
   });
+  // Raw per-slot journald tail — the ONLY source of detailed model-loading
+  // lines. Blind-append ring (repeats are real); carries no severity so the
+  // hook infers `level`.
+  const slotLogs = useSlotLogsStream(wantSlotLogs ? slotFilter : null, {
+    follow: !paused && wantSlotLogs,
+  });
 
-  // Demo lines preserve the design's grouped-error block (request-id
-  // collapsing) so the screenshot suite has something to point at even
-  // when the dev backend has no journal entries yet.
-  const demoLines = [
-    { ts: "14:01:58.330", source: "hal0", level: "ok",   slot: "primary", msg: "slot:primary container start · profile=rocm" },
-    { ts: "14:01:58.341", source: "hal0", level: "info", slot: "primary", msg: "ggml_init_cublas: found 1 ROCm device gfx1151" },
-    { ts: "14:02:00.812", source: "hal0", level: "info", slot: "primary", msg: "llm_load_tensors: offloaded 49/49 layers to GPU" },
-    { ts: "14:02:11.290", source: "hal0", level: "ok",   slot: "primary", msg: "slot:primary state loading → ready · 13.1s" },
-    { ts: "14:02:12.117", source: "hal0", level: "info", slot: null,      msg: "omnirouter: filtered tool set = [generate_image, embed_text, transcribe_audio, route_to_chat]" },
-    { ts: "14:02:15.443", source: "hal0", level: "info", slot: "primary", msg: "session ftr-104 opened persona=primary" },
-    { ts: "14:02:18.117", source: "hal0", level: "ok",   slot: "utility", msg: "slot:utility container restart · model=qwopus3.5-9b-coder-mtp (persona swap)" },
-    { ts: "14:02:19.290", source: "hal0", level: "ok",   slot: "utility", msg: "tool_call read_file path=src/hal0/launchers/slot_manager.py" },
-    { ts: "14:02:20.812", source: "hal0", level: "warn", slot: "img",     msg: "sd-turbo · vae load · falling back to cpu", group: "req-7f3a" },
-    { ts: "14:02:20.890", source: "hal0", level: "warn", slot: "img",     msg: "sd-turbo · UNet partial offload (ngl 28/32)", group: "req-7f3a" },
-    { ts: "14:02:20.911", source: "hal0", level: "warn", slot: "img",     msg: "sd-turbo · sampler init: euler-a", group: "req-7f3a" },
-    { ts: "14:02:20.934", source: "hal0", level: "warn", slot: "img",     msg: "sd-turbo · scheduler: 20 steps cfg 7.0", group: "req-7f3a" },
-    { ts: "14:02:22.443", source: "hal0", level: "ok",   slot: "utility", msg: "/v1/chat/completions utility 38 tok/s TTFT 280ms" },
-    { ts: "14:02:28.117", source: "hal0", level: "ok",   slot: "img",     msg: "slot:img container start · model=sd-turbo (tool dispatch)" },
-    { ts: "14:02:32.290", source: "hal0", level: "ok",   slot: "img",     msg: "tool_call generate_image · 4.1s · 2.4 MB" },
-    { ts: "14:02:36.117", source: "hal0", level: "info", slot: "img",     msg: "slot:img state serving → idle" },
-  ];
-  // historical now returns `{entries, next_since}`. Fall back to the
-  // demoLines block when there's no journal data yet so the Logs page
-  // still demos the design's grouped-warn collapser before any real
-  // entries land — HAL0_DATA.journal is gone (#322 phase 3).
   const histEntries = historical.data?.entries ?? [];
-  const sourceLines = histEntries.length > 0 ? histEntries : demoLines;
-  const buf = [...sourceLines, ...(live.ring || [])]
+  const eventRows = wantEvents ? [...histEntries, ...(live.ring || [])] : [];
+  const rawRows = wantSlotLogs ? (slotLogs.ring || []) : [];
+  // Dedup: the historical fetch and the SSE replay return the same events, so
+  // a naive concat renders every row twice. Key on the content signature
+  // (ts+source+msg) — raw slot lines get a client-arrival ts so genuine
+  // repeats keep distinct keys and are preserved.
+  const seen = new Set();
+  const buf = [...eventRows, ...rawRows]
+    .filter(e => {
+      const k = `${e.ts}|${e.source}|${e.msg}`;
+      if (seen.has(k)) return false;
+      seen.add(k);
+      return true;
+    })
     .sort((a, b) => (a.ts || '').localeCompare(b.ts || ''));
 
   const fil = e => {
-    if (source !== "merged" && e.source !== source) return false;
-    if (level && e.level !== level) return false;
-    if (slotFilter && e.slot !== slotFilter) return false;
-    if (search && !e.msg.toLowerCase().includes(search.toLowerCase())) return false;
+    if (level && (e.level || "info") !== level) return false;
+    if (search && !(e.msg || "").toLowerCase().includes(search.toLowerCase())) return false;
     return true;
   };
   const lines = buf.filter(fil);
+
+  // Surface real failure/degraded states instead of masking them (the page
+  // used to fall back to fake demo lines, hiding an empty/broken backend).
+  const banner = historical.isError
+    ? { tone: "err", msg: "Failed to load journal history — check the API." }
+    : slotLogs.degraded
+    ? { tone: "warn", msg: `Slot logs unavailable — ${slotLogs.degraded}` }
+    : channel === "slot" && !slotFilter
+    ? { tone: "info", msg: "Select a slot to view its detailed logs." }
+    : (wantEvents && live.disconnected) || (wantSlotLogs && slotLogs.disconnected)
+    ? { tone: "warn", msg: "Log stream disconnected — reconnecting…" }
+    : null;
 
   // Group adjacent same-group warns into a collapsible block
   const grouped = [];
@@ -109,14 +131,13 @@ function LogsView() {
   // simulating arrivals with a fake interval.
   React.useEffect(() => {
     if (!followTail) {
-      // Count live SSE lines not yet in view as "pending".
-      setPendingCount(live.ring?.length ?? 0);
+      // Count live SSE lines not yet in view as "pending" — across whichever
+      // channel(s) are active (events, raw slot, or both when merged).
+      setPendingCount((live.ring?.length ?? 0) + (slotLogs.ring?.length ?? 0));
     } else {
       setPendingCount(0);
     }
-  }, [followTail, live.ring]);
-
-  const allSlots = [...new Set(buf.map(e => e.slot).filter(Boolean))];
+  }, [followTail, live.ring, slotLogs.ring]);
 
   return (
     <div className="view">
@@ -130,12 +151,12 @@ function LogsView() {
       <div className="card" style={{overflow: "hidden", marginBottom: 12, position: "relative"}}>
         <div style={{padding: "10px 14px", borderBottom: "1px solid var(--line)", display: "flex", alignItems: "center", gap: 8, background: "var(--bg)", flexWrap: "wrap"}}>
           <div className="mono" style={{display: "inline-flex", border: "1px solid var(--line)", borderRadius: 4, overflow: "hidden", fontSize: 11}}>
-            {[["merged", "merged"], ["hal0", "hal0"]].map(([k, l]) => (
-              <button key={k} onClick={() => setSource(k)} style={{padding: "4px 11px", background: source === k ? "var(--accent-soft)" : "transparent", color: source === k ? "var(--accent)" : "var(--fg-3)", border: "none", borderRight: k !== "hal0" ? "1px solid var(--line)" : "none", cursor: "pointer", fontFamily: "var(--jbm)", fontSize: 11}}>{l}</button>
+            {LOG_CHANNELS.map(([k, l], i) => (
+              <button key={k} onClick={() => setChannel(k)} style={{padding: "4px 11px", background: channel === k ? "var(--accent-soft)" : "transparent", color: channel === k ? "var(--accent)" : "var(--fg-3)", border: "none", borderRight: i < LOG_CHANNELS.length - 1 ? "1px solid var(--line)" : "none", cursor: "pointer", fontFamily: "var(--jbm)", fontSize: 11}}>{l}</button>
             ))}
           </div>
           <div className="mono" style={{display: "inline-flex", border: "1px solid var(--line)", borderRadius: 4, overflow: "hidden", fontSize: 11, marginLeft: 8}}>
-            {[["", "all"], ["ok", "ok"], ["info", "info"], ["warn", "warn"], ["error", "err"]].map(([k, l]) => (
+            {[["", "all"], ["info", "info"], ["warn", "warn"], ["error", "err"]].map(([k, l]) => (
               <button key={l} onClick={() => setLevel(k || null)} style={{padding: "4px 10px", background: (level || "") === k ? "var(--accent-soft)" : "transparent", color: (level || "") === k ? "var(--accent)" : "var(--fg-3)", border: "none", borderRight: l !== "err" ? "1px solid var(--line)" : "none", cursor: "pointer", fontFamily: "var(--jbm)", fontSize: 11}}>{l}</button>
             ))}
           </div>
@@ -143,10 +164,11 @@ function LogsView() {
             className="input mono"
             value={slotFilter || ""}
             onChange={e => setSlotFilter(e.target.value || null)}
-            style={{maxWidth: 140, height: 26, fontSize: 11, marginLeft: 8}}
+            title={needsSlot ? "Pick a slot to tail" : "Filter events to one slot"}
+            style={{maxWidth: 150, height: 26, fontSize: 11, marginLeft: 8, padding: "0 8px", lineHeight: "24px", ...(needsSlot && !slotFilter ? {borderColor: "var(--accent)"} : {})}}
           >
-            <option value="">all slots</option>
-            {allSlots.map(s => <option key={s} value={s}>slot: {s}</option>)}
+            <option value="">{needsSlot ? "select slot…" : "all slots"}</option>
+            {slotNames.map(s => <option key={s} value={s}>slot: {s}</option>)}
           </select>
           <input
             className="input mono"
@@ -185,6 +207,17 @@ function LogsView() {
             }
           }}>{Icons.download}</button>
         </div>
+
+        {banner && (
+          <div style={{
+            padding: "8px 14px", fontSize: 11, fontFamily: "var(--jbm)",
+            borderBottom: "1px solid var(--line)",
+            color: banner.tone === "err" ? "var(--err)" : banner.tone === "warn" ? "var(--warn)" : "var(--fg-3)",
+            background: banner.tone === "err" ? "rgba(233,86,86,0.08)" : banner.tone === "warn" ? "rgba(232,185,78,0.08)" : "var(--bg)",
+          }}>
+            {banner.msg}
+          </div>
+        )}
 
         <div
           ref={scrollRef}

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -14,6 +14,7 @@ import { useModels, useModelInspect, useModelUpdate, useModelDelete, usePullJob,
 import { useSlots } from '@/api/hooks/useSlots'
 import { useSettings } from '@/api/hooks/useSettings'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
+import { useProfiles } from '@/api/hooks/useProfiles'
 import { MODEL_TYPE_TAGS, splitModelTags, mergeModelTags } from '@/dash/model-types.js'
 
 const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
@@ -272,12 +273,15 @@ function RecipeEditorModal({ open, onClose, model }) {
   // Gate on `open` — the modal is mounted while a model is merely selected,
   // so an ungated fetch would fire on the models list and detach row controls.
   const templates = useChatTemplates(open);
+  const profilesQuery = useProfiles();
   const init = model?.defaults || {};
   const [ctx, setCtx] = useStateMM("");
   const [ngl, setNgl] = useStateMM("");
   const [rope, setRope] = useStateMM("");
   const [extra, setExtra] = useStateMM("");
   const [chatTemplate, setChatTemplate] = useStateMM("auto");
+  // Preferred runtime profile that loads with this model (ModelDefaults.profile).
+  const [profile, setProfile] = useStateMM("");
   // Identity + types. `name` is the editable display name; `types` is the
   // selected subset of MODEL_TYPE_TAGS; `otherTags` snapshots the model's
   // non-curated tags so we can re-emit them verbatim on save (never clobber).
@@ -301,6 +305,7 @@ function RecipeEditorModal({ open, onClose, model }) {
       setRope(init.rope_freq_base != null ? String(init.rope_freq_base) : "");
       setExtra(init.extra_args || "");
       setChatTemplate(init.chat_template ?? "auto");
+      setProfile(init.profile || "");
       setName(model.name || "");
       const split = splitModelTags(model.tags);
       setTypes(split.selected);
@@ -348,6 +353,9 @@ function RecipeEditorModal({ open, onClose, model }) {
     // is the absence of an override, so don't pollute defaults with it.
     if (chatTemplate && chatTemplate !== "auto") defaults.chat_template = chatTemplate;
     else delete defaults.chat_template;
+    // Preferred profile: "" means no preference (slot keeps its device default).
+    if (profile.trim()) defaults.profile = profile.trim();
+    else delete defaults.profile;
     const body = { defaults };
     // Display name: only persist a real, changed value — never blank it out.
     const trimmedName = name.trim();
@@ -543,6 +551,45 @@ function RecipeEditorModal({ open, onClose, model }) {
             {(Array.isArray(templates.data) ? templates.data : []).filter(t => t.id !== "auto").map(t => (
               <option key={t.id} value={t.id}>{t.label}</option>
             ))}
+          </select>
+        </div>
+      </div>
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>preferred profile</span>
+          <span className="sub">runtime profile loaded with this model on create + every swap · empty = slot default</span>
+        </div>
+        <div className="form-ctl">
+          <select
+            className="input mono"
+            value={profile}
+            onChange={e => setProfile(e.target.value)}
+          >
+            <option value="">None (use slot default)</option>
+            {(() => {
+              // Filter to profiles that fit this model: same slot type, and same
+              // device class where the model's device is known (rocm/vulkan→gpu).
+              const dc =
+                model.device === "rocm" || model.device === "vulkan" ? "gpu"
+                : model.device === "npu" ? "npu"
+                : model.device === "cpu" ? "cpu"
+                : null;
+              const all = Array.isArray(profilesQuery.data) ? profilesQuery.data : [];
+              const fit = all.filter(p =>
+                (!dc || !p.device_class || p.device_class === dc) &&
+                (!model.type || !Array.isArray(p.supported_slot_types) || p.supported_slot_types.includes(model.type))
+              );
+              // Always include the current selection even if it doesn't pass the
+              // filter, so an existing preference never silently disappears.
+              const names = new Set(fit.map(p => p.name));
+              const rows = [...fit];
+              if (profile && !names.has(profile)) rows.unshift({ name: profile });
+              return rows.map(p => (
+                <option key={p.name} value={p.name}>
+                  {p.name}{p.intent ? ` · ${p.intent}` : ""}
+                </option>
+              ));
+            })()}
           </select>
         </div>
       </div>

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -21,6 +21,12 @@ function ModelsView() {
   const [scanOpen, setScanOpen] = useStateM(false);
   const [recipeOpen, setRecipeOpen] = useStateM(false);
   const [delModel, setDelModel] = useStateM(null);
+  // Image-gen / ComfyUI models live on their own segment of this view — the
+  // dispatcher-routable models (llm/embed/rerank/stt/tts) and the image-gen
+  // tree (checkpoints/loras/vae/…) are different worlds and were bleeding into
+  // one list (a mis-tagged checkpoint showing under "llm", the "image" filter
+  // surfacing nothing). ``tab`` toggles between them.
+  const [tab, setTab] = useStateM("models");
   // Issue #311: "Search HF" panel state. ``searchOpen`` toggles the
   // panel; ``searchQ`` is the input; ``searchPick`` is the coord the
   // user clicked "Add" on, which the panel hands off to AddByHfModal
@@ -64,9 +70,38 @@ function ModelsView() {
     }
     return true;
   };
-  const installed = modelList.filter(m => m.installed && fil(m));
-  const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && fil(m));
-  const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && fil(m));
+  // A model belongs to the ComfyUI/image surface when the backend flags it
+  // (owned_by/backends "comfyui", or a comfyui_category derived from its path)
+  // or it classifies as image. Path-derived flags self-heal rows an older pull
+  // mis-tagged, so this catches them even when capabilities still say "chat".
+  const isComfy = m =>
+    m.owned_by === "comfyui" ||
+    (Array.isArray(m.backends) && m.backends.includes("comfyui")) ||
+    !!m.comfyui_category ||
+    m.type === "image";
+
+  // Dispatcher-routable models — the ComfyUI ones are pulled out to their tab.
+  const installed = modelList.filter(m => m.installed && !isComfy(m) && fil(m));
+  const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && fil(m));
+  const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && !isComfy(m) && fil(m));
+
+  // ComfyUI/image surface — INSTALLED only (we never advertise un-pulled image
+  // models, same rule as FLM). Text search applies; the type/device chips do
+  // not (they're dispatcher concepts). Grouped by models-tree subdir.
+  const comfySearch = m => {
+    if (!q.trim()) return true;
+    const needle = q.trim().toLowerCase();
+    const hay = `${m.longName || ""} ${m.name || ""} ${m.id || ""} ${m.repo || ""} ${m.comfyui_category || ""}`.toLowerCase();
+    return hay.includes(needle);
+  };
+  const comfyModels = modelList.filter(m => m.installed && isComfy(m) && comfySearch(m));
+  const comfyByCat = {};
+  for (const m of comfyModels) {
+    const cat = m.comfyui_category || "other";
+    (comfyByCat[cat] = comfyByCat[cat] || []).push(m);
+  }
+  const comfyCats = Object.keys(comfyByCat).sort();
+  const comfyTotal = modelList.filter(m => m.installed && isComfy(m)).length;
 
   const toggle = (k, v) => setFilters(f => ({ ...f, [k]: f[k] === v ? null : v }));
 
@@ -99,32 +134,48 @@ function ModelsView() {
         {/* ── List (toolbar + rows) ── */}
         <div className="mdl-list">
           <div className="mdl-toolbar">
+            <div className="mdl-toolbar-grp">
+              <button
+                className={"mdl-chip" + (tab === "models" ? " on" : "")}
+                onClick={() => setTab("models")}
+              >Models</button>
+              <button
+                className={"mdl-chip" + (tab === "image" ? " on" : "")}
+                onClick={() => setTab("image")}
+              >Image / ComfyUI{comfyTotal ? ` · ${comfyTotal}` : ""}</button>
+            </div>
             <input
               className="input mono mdl-search"
               placeholder="search name, repo, id…"
               value={q}
               onChange={(e) => setQ(e.target.value)}
             />
-            <div className="mdl-toolbar-grp">
-              <span className="lbl">type</span>
-              {["llm", "embedding", "reranking", "transcription", "tts", "image"].map(t => (
-                <button key={t} className={"mdl-chip" + (filters.type === t ? " on" : "")} onClick={() => toggle("type", t)}>{t}</button>
-              ))}
-            </div>
-            <div className="mdl-toolbar-grp">
-              <span className="lbl">device</span>
-              {["rocm", "vulkan", "cpu", "npu"].map(d => (
-                <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
-              ))}
-            </div>
-            {(filters.type || filters.device || q.trim()) && (
-              <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); }}>clear ✕</button>
+            {tab === "models" && (
+              <>
+                <div className="mdl-toolbar-grp">
+                  <span className="lbl">type</span>
+                  {/* image models moved to the Image/ComfyUI tab — no "image"
+                      chip here (it used to match nothing). */}
+                  {["llm", "embedding", "reranking", "transcription", "tts"].map(t => (
+                    <button key={t} className={"mdl-chip" + (filters.type === t ? " on" : "")} onClick={() => toggle("type", t)}>{t}</button>
+                  ))}
+                </div>
+                <div className="mdl-toolbar-grp">
+                  <span className="lbl">device</span>
+                  {["rocm", "vulkan", "cpu", "npu"].map(d => (
+                    <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
+                  ))}
+                </div>
+                {(filters.type || filters.device || q.trim()) && (
+                  <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); }}>clear ✕</button>
+                )}
+              </>
             )}
           </div>
           <div className="mdl-list-h">
-            <span>Catalog</span>
-            <span className="ct">· {installed.length + blessed.length + userNs.length} shown</span>
-            <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {modelList.filter(m => m.ns === "blessed").length} blessed · {modelList.filter(m => m.ns === "pulled").length} pulled</span>
+            <span>{tab === "models" ? "Catalog" : "Image / ComfyUI"}</span>
+            <span className="ct">· {tab === "models" ? (installed.length + blessed.length + userNs.length) : comfyModels.length} shown</span>
+            <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {comfyTotal} image</span>
           </div>
 
           {modelsQuery.isPending && (
@@ -136,25 +187,48 @@ function ModelsView() {
             </div>
           )}
 
-          {installed.length > 0 && <div className="mdl-section-label">Installed · {installed.length}</div>}
-          {installed.map(m => (
-            <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-          ))}
+          {tab === "models" ? (
+            <>
+              {installed.length > 0 && <div className="mdl-section-label">Installed · {installed.length}</div>}
+              {installed.map(m => (
+                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              ))}
 
-          {blessed.length > 0 && <div className="mdl-section-label">Available · blessed · {blessed.length}</div>}
-          {blessed.map(m => (
-            <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-          ))}
+              {blessed.length > 0 && <div className="mdl-section-label">Available · blessed · {blessed.length}</div>}
+              {blessed.map(m => (
+                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              ))}
 
-          {userNs.length > 0 && <div className="mdl-section-label">user.* · {userNs.length}</div>}
-          {userNs.map(m => (
-            <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-          ))}
+              {userNs.length > 0 && <div className="mdl-section-label">user.* · {userNs.length}</div>}
+              {userNs.map(m => (
+                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              ))}
 
-          {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length) === 0 && (
-            <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
-              No models match — {(q.trim() || filters.type || filters.device) ? "adjust the search or filters." : "the catalog is empty."}
-            </div>
+              {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length) === 0 && (
+                <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
+                  No models match — {(q.trim() || filters.type || filters.device) ? "adjust the search or filters." : "the catalog is empty."}
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {comfyCats.map(cat => (
+                <React.Fragment key={cat}>
+                  <div className="mdl-section-label">{cat} · {comfyByCat[cat].length}</div>
+                  {comfyByCat[cat].map(m => (
+                    <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+                  ))}
+                </React.Fragment>
+              ))}
+
+              {!modelsQuery.isPending && !modelsQuery.isError && comfyModels.length === 0 && (
+                <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
+                  {q.trim()
+                    ? "No image models match the search."
+                    : "No image-gen models installed yet — pull one from the ComfyUI catalog."}
+                </div>
+              )}
+            </>
           )}
         </div>
 
@@ -299,6 +373,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   // {context_size, n_gpu_layers, rope_freq_base, extra_args}.
   const defaults = model.defaults || {};
   const recipeRows = [
+    ["preferred_profile", defaults.profile],
     ["context_size", defaults.context_size],
     ["n_gpu_layers", defaults.n_gpu_layers],
     ["rope_freq_base", defaults.rope_freq_base],

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -19,10 +19,11 @@ import { useHardware } from '@/api/hooks/useHardware'
 import { useModels } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
+import { useSlotLogsStream } from '@/api/hooks/useLogs'
 import { ENDPOINTS } from '@/api/endpoints'
 import { stateChipClassForSlot, slotButtonPhase } from './slot-status.js'
 
-const { useState: useStateSM, useEffect: useEffectSM, useRef: useRefSM } = React;
+const { useState: useStateSM, useEffect: useEffectSM } = React;
 
 // Map a slot lifecycle state to a chip color class.
 //   running healthy/serving → green (ok); starting/pulling → amber (warn);
@@ -1451,67 +1452,18 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
 }
 
 // ─── Slot logs drawer ────────────────────────────────────────────
-// Minimal SSE-backed log tail. The slot-logs stream endpoint
-// (ENDPOINTS.slotLogsStream) emits one JSON-lines event per log line;
-// we render the last N in a fixed-height pre. EventSource closes
-// automatically when the drawer unmounts.
+// Raw per-slot journald tail, backed by the shared `useSlotLogsStream`
+// hook (same transport the Logs page "slot" channel uses). The hook now
+// owns backfill (so the one-shot model-loading lines are visible even when
+// the drawer opens after the slot is up), idle-spam filtering, capped
+// backoff reconnect, and the `degraded` frame — replacing the old inline
+// EventSource with a no-op onerror.
 function SlotLogsDrawer({ open, slot, onClose }) {
-  const [lines, setLines] = useStateSM([]);
-  // B13: when journalctl is unavailable the backend emits a NAMED
-  // `event: degraded` SSE frame instead of streaming lines. Surfacing it
-  // tells the user *why* there are no lines, instead of spinning forever
-  // on "waiting for log lines…".
-  const [degraded, setDegraded] = useStateSM(null);
-  const esRef = useRefSM(null);
-
-  useEffectSM(() => {
-    if (!open || !slot) {
-      if (esRef.current) {
-        esRef.current.close();
-        esRef.current = null;
-      }
-      setLines([]);
-      setDegraded(null);
-      return;
-    }
-    setLines([]);
-    setDegraded(null);
-    try {
-      const es = new EventSource(ENDPOINTS.slotLogsStream(slot.name));
-      esRef.current = es;
-      es.onmessage = (ev) => {
-        setLines(prev => {
-          const next = prev.concat(ev.data);
-          return next.length > 500 ? next.slice(next.length - 500) : next;
-        });
-      };
-      // Named "degraded" frame — journalctl unavailable for this slot.
-      // Parse the payload for a human reason; fall back to a generic note.
-      es.addEventListener("degraded", (ev) => {
-        let reason = "Log streaming unavailable (journalctl not reachable for this slot).";
-        try {
-          const data = JSON.parse(ev.data);
-          if (data && (data.message || data.reason || data.detail)) {
-            reason = data.message || data.reason || data.detail;
-          }
-        } catch {
-          if (typeof ev.data === "string" && ev.data.trim()) reason = ev.data;
-        }
-        setDegraded(reason);
-      });
-      es.onerror = () => {
-        // Leave the stream open — server can resume; drawer close cleans up.
-      };
-    } catch {
-      // EventSource missing or blocked — log drawer renders empty.
-    }
-    return () => {
-      if (esRef.current) {
-        esRef.current.close();
-        esRef.current = null;
-      }
-    };
-  }, [open, slot?.name]);
+  const { ring, disconnected, degraded } = useSlotLogsStream(
+    open && slot ? slot.name : null,
+    { follow: open, max: 500 },
+  );
+  const lines = ring.map((r) => r.msg);
 
   if (!slot) return null;
 
@@ -1564,7 +1516,11 @@ function SlotLogsDrawer({ open, slot, onClose }) {
         {lines.length === 0
           ? (
             <span style={{color: "var(--fg-4)", fontStyle: "italic"}}>
-              {degraded ? "No log lines — see the notice above." : "waiting for log lines…"}
+              {degraded
+                ? "No log lines — see the notice above."
+                : disconnected
+                ? "Reconnecting to log stream…"
+                : "waiting for log lines…"}
             </span>
           )
           : lines.join("\n")}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -368,7 +368,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // owns them for container slots).
   const initialExtraArgs = slot?.llamacpp_args != null ? slot.llamacpp_args : "";
 
-  const [ctx, setCtx] = useStateSM(slot?.metrics?.ctx || 16384);
+  // Seed from the PERSISTED context window (slot.ctx_max, from
+  // [model].context_size) first — NOT the live runtime metric, which is 0
+  // whenever the slot isn't actively serving and would otherwise snap the
+  // field to a fabricated 16k on every cold (re)load. Fall back to the live
+  // metric, then the backend's safe 8192 floor.
+  const [ctx, setCtx] = useStateSM(slot?.ctx_max ?? (slot?.metrics?.ctx || 8192));
   // C4/C5: thinking is instant-apply (its own PUT); n_gpu_layers rides the Save
   // button through PATCH /defaults. Both seed from the slot list payload.
   const [thinking, setThinking] = useStateSM(slot?.enable_thinking === true);
@@ -429,7 +434,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
   useEffectSM(() => {
     if (slot) {
-      setCtx(slot.metrics?.ctx || 16384);
+      setCtx(slot.ctx_max ?? (slot.metrics?.ctx || 8192));
       setThinking(slot.enable_thinking === true);
       setThinkingPending(false);
       setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");
@@ -499,15 +504,17 @@ function EditSlotDrawer({ open, slot, onClose }) {
     // Per-slot extra_args override — ship only when changed, nested under
     // [server] so the backend one-level merge preserves sibling server keys.
     const extraArgsChanged = extraArgs !== extraArgsBaseline;
+    // Only write ctx_size when the operator actually changed it. The old code
+    // sent ctxNum unconditionally, so any unrelated save (profile, extra_args)
+    // on a not-currently-serving slot clobbered the persisted context window
+    // with the seeded fallback. Gate on the persisted baseline (ctxBaseline).
+    const ctxChanged = ctxNum !== Number(ctxBaseline);
     try {
       // Two-step: defaults (ctx_size lives under [model]) + slot config
       // for the top-level keys (default, profile). n_gpu_layers /
       // rope_freq_base / llamacpp_args are owned by the profile — never
       // include them in a save. These are fast on-disk writes, so we await
       // them and keep the drawer open to surface any write error.
-      const ctxBody = {
-        ctx_size: ctxNum,
-      };
       const slotBody = {};
       if (profileChanged) {
         slotBody.profile = selectedProfile;
@@ -518,10 +525,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
       if (extraArgsChanged) {
         slotBody.server = { extra_args: extraArgs };
       }
-      await defaultsMut.mutateAsync({
-        name: slot.name,
-        body: ctxBody,
-      });
+      if (ctxChanged) {
+        await defaultsMut.mutateAsync({
+          name: slot.name,
+          body: { ctx_size: ctxNum },
+        });
+      }
       await editMut.mutateAsync({
         name: slot.name,
         body: slotBody,
@@ -630,6 +639,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const extraArgsBaseline = slot.llamacpp_args != null ? slot.llamacpp_args : "";
   const extraArgsDirty = extraArgs !== extraArgsBaseline;
   const extraArgsErr = validateExtraArgs(extraArgs);
+  // ctx dirty-tracking baseline: the PERSISTED context window (slot.ctx_max),
+  // mirroring how the seed value is derived. Falls back to the live metric then
+  // the 8192 floor only when nothing is persisted, so an untouched field on a
+  // cold slot is never counted dirty (and never written — see ctxChanged).
+  const ctxBaseline = slot.ctx_max ?? (slot.metrics?.ctx || 8192);
 
   // UI-1: unsaved-changes guard. Aggregate ONLY the Save-batched fields
   // (extra_args, ctx, profile, chat_template override). The instant-apply
@@ -637,7 +651,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // are intentionally excluded — a flipped toggle is already persisted.
   const dirty =
     extraArgsDirty ||
-    String(ctx) !== String(slot.metrics?.ctx || 16384) ||
+    String(ctx) !== String(ctxBaseline) ||
     (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
     (overrideOpen && chatTemplate !== (slot.chat_template || ""));
   const requestClose = () => {

--- a/ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/footer-journal-pane-v3.spec.ts
@@ -9,8 +9,10 @@
  *      still render.
  *   2. Expanding the pane opens the SSE; entries pushed through the
  *      sseHarness render in the body.
- *   3. Clicking `hal0` filter chip rebuilds the EventSource with
- *      `?source=hal0` and only hal0-source entries pass through.
+ *   3. Clicking a source chip (derived from the live ring's real sources)
+ *      filters the visible rows client-side by source group — the footer
+ *      streams the merged feed and never opens a per-source SSE, so every
+ *      source chip stays available regardless of the active filter.
  *   4. Typing in the search box filters the in-memory ring client-side
  *      (no SSE reconnect; matches `entry.msg` case-insensitively).
  *   5. When the SSE has produced 0 entries the pane shows the empty
@@ -77,7 +79,7 @@ test.describe('Footer journal pane (#325)', () => {
     await expect(body.locator('.foot-line .msg', { hasText: CONTAINER_ENTRY.msg })).toBeVisible()
   })
 
-  test('hal0 filter chip narrows source and rebuilds SSE with ?source=hal0', async ({ page }) => {
+  test('source chip filters visible rows client-side (no per-source SSE rebuild)', async ({ page }) => {
     await page.goto('/')
     await page.locator('.foot-toggle').click()
     await waitForSse(page, '/api/journal/stream', 6_000)
@@ -89,26 +91,26 @@ test.describe('Footer journal pane (#325)', () => {
     await expect(body.locator('.foot-line', { hasText: HAL0_ENTRY.msg })).toBeVisible()
     await expect(body.locator('.foot-line', { hasText: CONTAINER_ENTRY.msg })).toBeVisible()
 
-    // Click the hal0 chip — debounce + reconnect.
+    // Chips are derived from the live ring's real sources; a `hal0` chip
+    // appears once a hal0-source entry lands. Clicking it filters by source
+    // group CLIENT-SIDE — no SSE reconnect.
     await page.locator('.foot-pane-chip', { hasText: 'hal0' }).click()
-    await waitForSse(page, '/api/journal/stream?source=hal0', 6_000)
 
-    // Client-side source filter applied on top of the SSE URL filter —
-    // residual container entry already in the ring is hidden immediately.
+    // Residual container entry is hidden immediately; the hal0 entry stays.
     await expect(body.locator('.foot-line', { hasText: CONTAINER_ENTRY.msg })).toHaveCount(0)
-    // hal0 entry stays.
     await expect(body.locator('.foot-line', { hasText: HAL0_ENTRY.msg })).toBeVisible()
 
-    // Push another hal0 entry on the new stream — arrives normally.
+    // A further hal0 entry arrives on the SAME (merged) stream — no reconnect.
     const HAL0_AFTER = { ...HAL0_ENTRY, id: 4, msg: 'slot:agent ready' }
-    await emitSse(page, '/api/journal/stream?source=hal0', HAL0_AFTER)
+    await emitSse(page, '/api/journal/stream', HAL0_AFTER)
     await expect(body.locator('.foot-line .msg', { hasText: 'slot:agent ready' })).toBeVisible()
 
-    // Confirm the URL gained the source param.
+    // The footer never opens a per-source SSE — it streams merged and filters
+    // client-side, so every source chip stays available regardless of filter.
     const seen = await page.evaluate(
       () => Object.keys((window as any).__sseStreams || {}),
     )
-    expect(seen.some((u: string) => u.includes('source=hal0'))).toBe(true)
+    expect(seen.some((u: string) => u.includes('source='))).toBe(false)
   })
 
   test('search input filters the in-memory ring case-insensitively', async ({ page }) => {

--- a/ui/tests/e2e/specs/logs-v3.spec.ts
+++ b/ui/tests/e2e/specs/logs-v3.spec.ts
@@ -1,16 +1,25 @@
 /**
- * logs-v3 — `#logs` route renders the filter bar (source / level / slot
+ * logs-v3 — `#logs` route renders the filter bar (channel / level / slot
  * / search), the follow-tail indicator, and the Pause/Resume control.
  */
 import { test, expect } from '../fixtures/apiMock'
 
 test.describe('Logs v3 (/logs)', () => {
-  test('renders Logs view + filter bar', async ({ page }) => {
+  test('renders Logs view + channel selector', async ({ page }) => {
     await page.goto('/#logs')
     await expect(page.locator('.view .vh h1')).toHaveText('Logs')
-    // source toggle (merged/hal0)
+    // channel selector (events | slot | merged) — replaces the old dead
+    // merged/hal0 toggle where both positions showed the same data.
+    await expect(page.locator('.view button', { hasText: 'events' })).toBeVisible()
+    await expect(page.locator('.view button', { hasText: 'slot' })).toBeVisible()
     await expect(page.locator('.view button', { hasText: 'merged' })).toBeVisible()
-    await expect(page.locator('.view button', { hasText: 'hal0' })).toBeVisible()
+  })
+
+  test('slot channel prompts for a slot selection', async ({ page }) => {
+    await page.goto('/#logs')
+    await page.locator('.view button', { hasText: 'slot' }).click()
+    // With no slot picked the page guides the user instead of showing nothing.
+    await expect(page.locator('.view')).toContainText('Select a slot')
   })
 
   test('search input + slot select + pause button render', async ({ page }) => {


### PR DESCRIPTION
## Context

The Logs page stopped showing per-slot **detailed model-loading logs**, its **slot dropdown went empty**, and the **merged/hal0 toggle did nothing**. All three trace to one architectural drift: the dashboard grew four disconnected log/event pipelines, and the Logs page was migrated onto the coarsest of them (`/api/journal`, the EventBus projection), plus two bugs in the per-slot journald stream.

Verified live on CT105 against real slots (see below).

## Root causes

1. **Per-slot model-load logs gone** — the Logs page reads `/api/journal`, which only carries coarse lifecycle events. The detailed llama.cpp/ROCm lines live only in journald. There's no `model.load.progress` event.
2. **The per-slot journald stream was also broken for load logs** — it used `journalctl -f -n 0` (future-only, so it missed the one-shot lines emitted at container start), and the tail's window was flooded by `update_slots: all slots are idle` heartbeat spam.
3. **Empty slot dropdown** — scraped from a `.slot` field real journal entries never carried.
4. **Dead merged/hal0 toggle** — the projection collapsed every event's `source` to the literal `"hal0"`, so both positions were identical.

## Changes

**Backend**
- `journal.py`: project the real `source` (`slot:<name>`, `system`, `model:x`) + a parsed `slot` field; working `?source=` (exact or `slot`-prefix) and `?slot=` filters. `source` widened `Literal["hal0"] → str`.
- `slots.py`: per-slot log stream now **backfills** (`-n <backfill>` not `-n 0`); stream + tail gained a `quiet` idle-spam filter (default on).

**Frontend**
- `useLogs.ts`: widen `JournalEntry.source`/add `slot`; new `useSlotLogsStream` (raw per-slot tail) with client-arrival ts, `parseRawLevel`, capped-backoff reconnect, `degraded` frame, and **blind append** (raw lines legitimately repeat — content-dedup would drop them).
- `rawLevel.js`: extracted pure level heuristic (unit-testable, like `logRing.js`).
- `extras.jsx` (Logs page): **channel selector** (events | slot | merged) replacing the dead toggle; slot dropdown from `useSlots`; dropped fake demo-line fallback; error/disconnected/degraded banners; dedup historical+SSE overlap.
- `chrome.jsx` (footer): real source-group selector; `_srcHue` parses grouped sources.
- `slot-modals.jsx`: `SlotLogsDrawer` now uses the shared hook (fixes no-op `onerror`; gains backfill + backoff).
- `useActivity.ts`: persist the activity ring in a module-level cache so the sidebar survives `SlotsView` remounts (loading/empty/populated, tab switches).

## Tests
- `logs-v3.spec.ts` updated to the channel selector.
- New `rawLevel` + blind-append unit tests.
- `tsc` + `vite build` clean; all hook unit tests pass.

## Live verification (CT105)
- `/api/journal` entries carry real `source` + `slot`; `?source=slot`, `?slot=npu`, `?source=system` narrow correctly.
- `quiet=1` drops idle spam (real content vs 28/60 idle lines raw); stream backfills history.
- Logs page **slot channel → rerank shows the full load sequence** (`loading model` → gguf path → device info → `warming up` → `model loaded` → `listening on :8083`), even when the slot is selected *after* it started.

## Notes for reviewers
- `JournalEntry.source: Literal["hal0"] → str` is a coordinated backend+frontend contract change — landed together here.
- Raw journald lines are stamped with client-arrival time (they have no ts under `--output=cat`); the optional `-o short-iso` switch for real timestamps is deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)