### PR TITLE
fix(memory): audit destructive ops + console shape guard (#1024, #1026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+### Added
+- **Memory: audit trail for destructive ops (#1024).** Every destructive
+  `/api/memory/*` op — bank delete, and memories/config/document/directive/
+  operation/mental-model deletes, plus the namespace `POST /api/memory/delete`
+  — now records a durable audit row (actor + target + truthful outcome) via the
+  shared `record_action` facility, so a memory wipe is attributable after the
+  fact. Complements the bank-DELETE `?confirm=` guard shipped in #1028.
+- **Memory: response-shape guard on the cognition consoles (#1026).** The
+  recall/reflect/directives passthroughs now validate the load-bearing envelope
+  key (`results`/`text`/`items`); upstream Hindsight shape drift surfaces as a
+  loud `memory.engine_shape` 502 instead of a silently-blank console panel. The
+  two colliding `recall` contracts (namespace `{items}` vs bank `{results}`) are
+  now documented at both call sites.
+
+### Changed
+- **Memory Overview UI.** The graph-extraction gate now sits beside a shrunk
+  "memories retained" spark in the top row; card headings share one unified
+  "eyebrow" style; dropped the stray `ADR-0023` label from the extraction title.
+
 ## [v0.8.3b1] — 2026-07-04
 
 A large **reliability and UI-completeness** release. The headline is a

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -25,6 +25,7 @@ from typing import Any
 from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
+from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import MemoryGraphConfig
@@ -508,6 +509,11 @@ async def memory_recall(request: Request) -> dict[str, Any]:
 
     Falls back to ``search`` semantics on engines without a richer recall
     (the ABC default), so this route is safe regardless of active engine.
+
+    Contract note (#1026): this is the NAMESPACE recall — ACL-scoped,
+    cross-bank fan-out, envelope ``{items}``. It is distinct from the bank
+    console recall ``POST /api/memory/banks/{bank}/recall`` (single-bank
+    Hindsight passthrough, envelope ``{results}``). Same verb, different scope.
     """
     body = await _read_json_body(request)
     query = body.get("query")
@@ -627,11 +633,19 @@ async def memory_delete(request: Request) -> dict[str, int]:
         except MemoryNamespaceError as exc:
             raise MemoryNamespaceInvalid(str(exc)) from exc
     wrapper = _wrapper(request)
-    return await wrapper.delete(
-        ids=ids,
-        client_id=agent_id if agent_id != "anonymous" else None,
-        dataset=dataset,
-    )
+    # #1024 hardening: id-scoped delete is destructive — record it (actor +
+    # ids + outcome) so bulk removals are attributable after the fact.
+    async with record_action(
+        request,
+        category="memory",
+        action="memory.items.delete",
+        target=",".join(str(i) for i in ids)[:200],
+    ):
+        return await wrapper.delete(
+            ids=ids,
+            client_id=agent_id if agent_id != "anonymous" else None,
+            dataset=dataset,
+        )
 
 
 async def _read_json_body(request: Request) -> dict[str, Any]:

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -29,11 +29,13 @@ import asyncio
 import json
 import logging
 import re
+from collections.abc import Callable
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, Request
 
+from hal0.api._audit import record_action
 from hal0.api.routes import _memory_subgraph as _sg
 from hal0.api.routes.memory import MemoryUnavailable
 from hal0.errors import BadRequest, Hal0Error, NotFound, UnprocessableEntity
@@ -69,6 +71,21 @@ class MemoryEngineError(Hal0Error):
     """Hindsight answered with an error; status mirrors upstream (4xx) or 502."""
 
     code = "memory.engine_error"
+    status = 502
+
+
+class MemoryEngineShape(Hal0Error):
+    """Hindsight answered 2xx but with an envelope the dashboard can't consume.
+
+    The recall/reflect/directives consoles are verbatim passthroughs whose UI
+    hooks assume a specific response shape (``{results}`` / ``{text}`` /
+    ``{items}``). If Hindsight drifts that shape (version bump, breaking change)
+    the console would break *silently* with a blank panel. This guard turns that
+    silent break into a loud, attributable 502 so the drift is diagnosable
+    (issue #1026).
+    """
+
+    code = "memory.engine_shape"
     status = 502
 
 
@@ -274,7 +291,13 @@ async def delete_bank(request: Request, bank_id: str) -> Any:
             details={"bank_id": bank_id},
         )
     log.warning("memory_admin: deleting bank %r (confirmed)", bank_id)
-    return await _forward(client, "DELETE", f"/v1/default/banks/{bank_id}")
+    # #1024 hardening: every confirmed destructive op lands in the audit store
+    # (actor + timestamp + outcome) so a bank wipe is attributable after the
+    # fact. Bank deletion is the highest-blast-radius op on this surface.
+    async with record_action(
+        request, category="memory", action="memory.bank.delete", target=bank_id
+    ):
+        return await _forward(client, "DELETE", f"/v1/default/banks/{bank_id}")
 
 
 # ── allowlisted passthrough table ──────────────────────────────────────────────
@@ -343,6 +366,13 @@ _FORWARDS: tuple[tuple[str, str, str], ...] = (
     ),
     ("GET", "/banks/{bank_id}/tags", "/v1/default/banks/{bank_id}/tags"),
     # cognition consoles
+    #
+    # NB two distinct ``recall`` contracts exist under /api/memory (issue #1026):
+    #   * POST /api/memory/recall            (hal0.api.routes.memory) — NAMESPACE
+    #     recall: ACL-scoped, cross-bank fan-out, returns ``{items: MemoryItem[]}``.
+    #   * POST /api/memory/banks/{bank}/recall (this table)          — BANK recall:
+    #     a single-bank verbatim Hindsight passthrough, returns ``{results: [...]}``.
+    # Same verb, different scope + envelope — do not conflate them.
     ("POST", "/banks/{bank_id}/recall", "/v1/default/banks/{bank_id}/memories/recall"),
     ("POST", "/banks/{bank_id}/reflect", "/v1/default/banks/{bank_id}/reflect"),
     # mental models
@@ -417,14 +447,71 @@ _FORWARDS: tuple[tuple[str, str, str], ...] = (
 _BODY_METHODS = {"POST", "PUT", "PATCH"}
 
 
+# ── #1026: response-shape guards for the cognition consoles ─────────────────────
+#
+# The recall/reflect/directives passthroughs feed UI hooks that assume a fixed
+# envelope. We validate the *presence + type* of the load-bearing key (not the
+# full schema) so upstream drift surfaces as a loud, attributable 502
+# (``memory.engine_shape``) instead of a silently-blank console panel.
+
+
+def _require(payload: Any, key: str, kind: type, upstream: str) -> None:
+    if not isinstance(payload, dict) or not isinstance(payload.get(key), kind):
+        raise MemoryEngineShape(
+            f"memory engine response missing expected {key!r} ({kind.__name__})",
+            details={
+                "upstream": upstream,
+                "expected_key": key,
+                "expected_type": kind.__name__,
+                "got_keys": sorted(payload.keys()) if isinstance(payload, dict) else None,
+            },
+        )
+
+
+#: (method, upstream template) → validator run against the 2xx response body.
+_SHAPE_GUARDS: dict[tuple[str, str], Callable[[Any], None]] = {
+    ("POST", "/v1/default/banks/{bank_id}/memories/recall"): lambda p: _require(
+        p, "results", list, "recall"
+    ),
+    ("POST", "/v1/default/banks/{bank_id}/reflect"): lambda p: _require(p, "text", str, "reflect"),
+    ("GET", "/v1/default/banks/{bank_id}/directives"): lambda p: _require(
+        p, "items", list, "directives"
+    ),
+}
+
+
+#: #1024: DELETE forwards audited via record_action. Template → audit action.
+_DELETE_ACTIONS: dict[str, str] = {
+    "/v1/default/banks/{bank_id}/config": "memory.bank_config.delete",
+    "/v1/default/banks/{bank_id}/memories": "memory.memories.delete",
+    "/v1/default/banks/{bank_id}/documents/{document_id}": "memory.document.delete",
+    "/v1/default/banks/{bank_id}/directives/{directive_id}": "memory.directive.delete",
+    "/v1/default/banks/{bank_id}/operations/{operation_id}": "memory.operation.delete",
+    "/v1/default/banks/{bank_id}/mental-models/{model_id}": "memory.mental_model.delete",
+}
+
+
 def _make_handler(method: str, template: str):
+    guard = _SHAPE_GUARDS.get((method, template))
+    audit_action = _DELETE_ACTIONS.get(template) if method == "DELETE" else None
+
     async def handler(request: Request) -> Any:
         client = _client(request)
         segments = _validate_segments(dict(request.path_params))
         upstream = template.format(**segments) if segments else template
         body = await _read_body(request) if method in _BODY_METHODS else None
         params = dict(request.query_params) or None
-        return await _forward(client, method, upstream, params=params, json_body=body)
+        if audit_action is not None:
+            # #1024: audit destructive ops with a truthful outcome — the block
+            # records outcome=error if the forward raises, outcome=ok otherwise.
+            async with record_action(
+                request, category="memory", action=audit_action, target=upstream
+            ):
+                return await _forward(client, method, upstream, params=params, json_body=body)
+        result = await _forward(client, method, upstream, params=params, json_body=body)
+        if guard is not None:
+            guard(result)
+        return result
 
     return handler
 

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -19,6 +19,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from hal0.activity import AuditStore
 from hal0.api.middleware import error_codes
 from hal0.api.routes import memory_admin
 from hal0.memory.hindsight_client import HindsightRestClient
@@ -167,6 +168,9 @@ def test_memories_list_maps_paths_and_params(client: TestClient, recorder: _Reco
 
 
 def test_recall_post_passes_body_through(client: TestClient, recorder: _Recorder) -> None:
+    recorder.respond(
+        "POST", "/v1/default/banks/shared/memories/recall", 200, {"results": [{"text": "x"}]}
+    )
     body = {"query": "what changed", "budget": "high", "include": {"entities": {}}}
     r = client.post("/api/memory/banks/shared/recall", json=body)
     assert r.status_code == 200
@@ -176,9 +180,41 @@ def test_recall_post_passes_body_through(client: TestClient, recorder: _Recorder
 
 
 def test_reflect_post_forwards(client: TestClient, recorder: _Recorder) -> None:
+    recorder.respond("POST", "/v1/default/banks/shared/reflect", 200, {"text": "you are hal0"})
     r = client.post("/api/memory/banks/shared/reflect", json={"query": "who am i"})
     assert r.status_code == 200
     assert recorder.requests[-1]["path"] == "/v1/default/banks/shared/reflect"
+
+
+# ── #1026: response-shape guards on the cognition consoles ──────────────────────
+
+
+def test_recall_shape_drift_maps_to_502(client: TestClient, recorder: _Recorder) -> None:
+    # Upstream drops the ``results`` key → loud 502 instead of a blank console.
+    recorder.respond("POST", "/v1/default/banks/shared/memories/recall", 200, {"answers": []})
+    r = client.post("/api/memory/banks/shared/recall", json={"query": "x"})
+    assert r.status_code == 502
+    payload = r.json()["error"]
+    assert payload["code"] == "memory.engine_shape"
+    assert payload["details"]["expected_key"] == "results"
+
+
+def test_reflect_shape_drift_maps_to_502(client: TestClient, recorder: _Recorder) -> None:
+    recorder.respond("POST", "/v1/default/banks/shared/reflect", 200, {"summary": "nope"})
+    r = client.post("/api/memory/banks/shared/reflect", json={"query": "x"})
+    assert r.status_code == 502
+    assert r.json()["error"]["code"] == "memory.engine_shape"
+
+
+def test_directives_get_shape_guard(client: TestClient, recorder: _Recorder) -> None:
+    recorder.respond("GET", "/v1/default/banks/shared/directives", 200, {"items": [], "total": 0})
+    r = client.get("/api/memory/banks/shared/directives")
+    assert r.status_code == 200
+
+    recorder.respond("GET", "/v1/default/banks/shared/directives", 200, {"directives": []})
+    r = client.get("/api/memory/banks/shared/directives")
+    assert r.status_code == 502
+    assert r.json()["error"]["code"] == "memory.engine_shape"
 
 
 def test_bank_create_put_and_delete_forward(client: TestClient, recorder: _Recorder) -> None:
@@ -231,6 +267,48 @@ def test_document_delete_and_reprocess_forward(client: TestClient, recorder: _Re
     r = client.post("/api/memory/banks/shared/documents/doc-1/reprocess")
     assert r.status_code == 200
     assert recorder.requests[-1]["path"] == "/v1/default/banks/shared/documents/doc-1/reprocess"
+
+
+# ── #1024: destructive ops are audited ─────────────────────────────────────────
+
+
+def _build_app_with_audit(provider: Any, audit: AuditStore) -> FastAPI:
+    app = _build_app(provider)
+    app.state.audit = audit
+    return app
+
+
+def test_destructive_ops_land_audit_rows(recorder: _Recorder, tmp_path: Any) -> None:
+    audit = AuditStore(tmp_path / "audit.db")
+    audit.init_schema()
+    transport = httpx.MockTransport(recorder.handler)
+    http = httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177")
+    rest = HindsightRestClient(http_client=http, api_key="hal0-local-noauth")
+    app = _build_app_with_audit(_HindsightStubProvider(rest), audit)
+
+    with TestClient(app) as c:
+        # Rejected (unconfirmed) bank delete → NOT a destructive op → no row.
+        assert c.delete("/api/memory/banks/scratch").status_code == 400
+        assert audit.query(action="memory.bank.delete") == []
+
+        # Confirmed bank delete → audited, actor derived from X-hal0-Agent.
+        r = c.delete(
+            "/api/memory/banks/scratch?confirm=scratch", headers={"X-hal0-Agent": "hermes"}
+        )
+        assert r.status_code == 200
+        # A generic table DELETE (document) → audited via _make_handler.
+        assert c.delete("/api/memory/banks/scratch/documents/doc-1").status_code == 200
+
+    bank_rows = audit.query(action="memory.bank.delete")
+    assert bank_rows, "expected a memory.bank.delete audit row"
+    assert bank_rows[0]["outcome"] == "ok"
+    assert bank_rows[0]["actor"] == "mcp:hermes"
+    assert bank_rows[0]["target"] == "scratch"
+
+    doc_rows = audit.query(action="memory.document.delete")
+    assert doc_rows, "expected a memory.document.delete audit row"
+    assert doc_rows[0]["actor"] == "dashboard"
+    assert doc_rows[0]["target"] == "/v1/default/banks/scratch/documents/doc-1"
 
 
 # ── upstream error mapping ─────────────────────────────────────────────────────

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -191,6 +191,53 @@ def test_put_bad_slot_name_returns_400(client: TestClient, stub_wrapper: StubWra
     assert r.json()["error"]["code"] == "config.memory_graph_invalid"
 
 
+class _HindsightyWrapper(StubWrapper):
+    """Wrapper that also exposes a hindsight_client, so graph/status can
+    aggregate real per-bank extraction counters (#1025)."""
+
+    def __init__(self, stats_by_bank: dict[str, Any]) -> None:
+        super().__init__()
+        self._stats = stats_by_bank
+        parent = self
+
+        class _Client:
+            async def request_json(self, method: str, path: str) -> Any:
+                if path == "/v1/default/banks":
+                    return {"banks": [{"bank_id": b} for b in parent._stats]}
+                for bank, stats in parent._stats.items():
+                    if path == f"/v1/default/banks/{bank}/stats":
+                        return stats
+                raise AssertionError(f"unexpected path {path}")
+
+        self.hindsight_client = _Client()
+
+
+def test_graph_status_aggregates_real_counters_from_hindsight(hal0_home: Path) -> None:
+    # #1025: graph/status must reflect ACTUAL extraction activity read back from
+    # Hindsight per-bank /stats, not the provider's 0/None placeholders.
+    wrapper = _HindsightyWrapper(
+        {
+            "shared": {
+                "operations_by_status": {"completed": 3, "processing": 1, "failed": 0},
+                "pending_operations": 2,
+                "failed_operations": 1,
+                "last_consolidated_at": "2026-07-04T01:00:00Z",
+            },
+            "private__hermes": {
+                "operations_by_status": {"completed": 5},
+                "last_consolidated_at": "2026-07-04T02:00:00Z",
+            },
+        }
+    )
+    app = _build_app(wrapper, "utility")
+    with TestClient(app) as c:
+        body = c.get("/api/memory/graph/status").json()
+    assert body["builds_ok"] == 8  # 3 + 5 completed
+    assert body["in_flight"] == 3  # 2 pending + 1 processing
+    assert body["errors"] == 1  # failed_operations on shared
+    assert body["last_built_at"] == "2026-07-04T02:00:00Z"  # newest across banks
+
+
 def test_status_unavailable_when_no_wrapper(
     hal0_home: Path,
 ) -> None:

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -306,6 +306,28 @@ def test_delete_passes_ids_unchanged(client: TestClient, stub_wrapper: StubWrapp
     assert r.json() == {"deleted": 2}
 
 
+def test_delete_is_audited(stub_wrapper: StubWrapper, tmp_path: Any) -> None:
+    """#1024: id-scoped delete lands a durable audit row (actor + ids)."""
+    from hal0.activity import AuditStore
+
+    audit = AuditStore(tmp_path / "audit.db")
+    audit.init_schema()
+    app = _build_app(stub_wrapper)
+    app.state.audit = audit
+    with TestClient(app) as c:
+        r = c.post(
+            "/api/memory/delete",
+            json={"ids": ["a", "b"]},
+            headers={"X-hal0-Agent": "hermes-agent"},
+        )
+        assert r.status_code == 200, r.text
+    rows = audit.query(action="memory.items.delete")
+    assert rows, "expected a memory.items.delete audit row"
+    assert rows[0]["outcome"] == "ok"
+    assert rows[0]["actor"] == "mcp:hermes-agent"
+    assert rows[0]["target"] == "a,b"
+
+
 # ── PR #366 review hardening (closes #317 + #367) ──────────────────────────
 #
 # Six new contract pins surfaced by the request-changes review. The

--- a/ui/src/dash/agents/memory-tab.jsx
+++ b/ui/src/dash/agents/memory-tab.jsx
@@ -154,11 +154,10 @@ function MemoryGraphPanel() {
 
   return (
     <div className="card" style={{padding: 18, marginBottom: 14}}>
-      <div style={{display: "flex", alignItems: "center", gap: 12, marginBottom: 10}}>
-        <span className="mono" style={{fontSize: 10, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "0.1em"}}>Graph extraction · ADR-0023</span>
-        <span style={{marginLeft: "auto"}}>
-          {enabled ? <span className="chip ok">ON · {extractionSlot}</span> : <span className="chip">OFF</span>}
-        </span>
+      <div className="mo-card-h">
+        <span className="mo-eyebrow">Graph extraction</span>
+        <span className="grow" />
+        {enabled ? <span className="chip ok">ON · {extractionSlot}</span> : <span className="chip">OFF</span>}
       </div>
 
       {!enabled && !showSlotPicker && (

--- a/ui/src/dash/memory-overhaul.css
+++ b/ui/src/dash/memory-overhaul.css
@@ -165,7 +165,23 @@
 .mg-nbr-label { font-size: 11.5px; color: var(--fg-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ─── Overview ───────────────────────────────────────────────────── */
-.mo-top { display: grid; grid-template-columns: 360px 1fr; gap: 16px; margin-bottom: 22px; align-items: start; }
+/* Three cards across the top: engine identity · (shrunk) memories-retained
+   spark · graph-extraction gate. The spark column is deliberately narrow so
+   the graph panel gets the room it needs beside it. */
+.mo-top { display: grid; grid-template-columns: 300px minmax(0, 0.8fr) minmax(0, 1.25fr); gap: 16px; margin-bottom: 22px; align-items: start; }
+.mo-graphcol { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+/* Panel is reused from the #agent tab where it carries a bottom margin; drop it
+   here so the three top cards bottom-align cleanly (!important beats the inline
+   style the shared component sets). */
+.mo-graphcol > .card { margin-bottom: 0 !important; }
+
+/* Unified card heading — an uppercase mono "eyebrow" label with right-aligned
+   controls, shared by the memories-retained + graph-extraction cards so the
+   Overview reads as one system instead of three bespoke headers. */
+.mo-card-h { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.mo-card-h .grow { flex: 1; }
+.mo-eyebrow { font-family: var(--jbm); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--accent); white-space: nowrap; }
+
 .mo-engine { padding: 16px; }
 .mo-engine-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
 .mo-engine-name { display: inline-flex; align-items: center; gap: 8px; font-size: 15px; color: var(--fg); }
@@ -270,7 +286,16 @@
 .ag-ptr-h { font-size: 15px; color: var(--fg); margin-bottom: 6px; }
 .ag-ptr-body p { font-size: 12.5px; color: var(--fg-3); line-height: 1.55; margin: 0 0 14px; max-width: 560px; }
 
-@media (max-width: 900px) {
+@media (max-width: 1200px) {
+  /* Two columns: engine + spark on the first row, graph panel spanning below. */
+  .mo-top {
+    grid-template-columns: 300px 1fr;
+  }
+  .mo-graphcol {
+    grid-column: 1 / -1;
+  }
+}
+@media (max-width: 720px) {
   .mo-top {
     grid-template-columns: 1fr;
   }

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -119,8 +119,9 @@ function MemTimeseries({ bank, period, setPeriod }) {
 
   return (
     <div className="card mo-ts" data-testid="mem-timeseries">
-      <div className="mo-ts-head">
-        <span className="mono">memories retained · {bank || '—'}</span>
+      <div className="mo-ts-head mo-card-h">
+        <span className="mo-eyebrow">memories retained · {bank || '—'}</span>
+        <span className="grow" />
         <div className="mo-ts-periods">
           {['1d', '7d', '30d', '90d'].map(p => (
             <button
@@ -577,6 +578,11 @@ function MemoryView({ param } = {}) {
         <MemToolsPanel />
       ) : (
       <div className="mo">
+      {/* Top row: engine identity · (shrunk) memories-retained spark ·
+          the graph-extraction gate/slot panel beside it. MemoryGraphPanel is
+          the canonical window global from agents/memory-tab.jsx so the
+          enabled/slot/builds_ok/errors/last_built_at controls live here on the
+          Overview, not just the #agent tab. */}
       <div className="mo-top">
         <MemEngineCard
           engine={engineQuery.data}
@@ -585,23 +591,16 @@ function MemoryView({ param } = {}) {
           onOpenGraph={() => { window.location.hash = '#memory/graph'; }}
         />
         <MemTimeseries bank={chartBank} period={period} setPeriod={setPeriod} />
+        <div className="mo-graphcol">
+          {graphInFlight > 0 && (
+            <span className="mem-act-badge working" data-testid="mem-graph-inflight" title="graph extraction running">
+              <span className="mem-spin" aria-hidden="true" />
+              extracting… ({graphInFlight} in flight)
+            </span>
+          )}
+          {typeof MemoryGraphPanel === 'function' ? <MemoryGraphPanel /> : null}
+        </div>
       </div>
-
-      {/* ADR-0023 graph-extraction gate + slot picker — reuses the canonical
-          MemoryGraphPanel (window global from agents/memory-tab.jsx) so the
-          enabled/slot/slot_resolves/builds_ok/errors/last_built_at/last_error
-          controls live here on the Memory Overview, not just the #agent tab. */}
-      <div className="sec">
-        <h2>Graph extraction</h2>
-        <div className="rule" />
-        {graphInFlight > 0 && (
-          <span className="mem-act-badge working" data-testid="mem-graph-inflight" title="graph extraction running">
-            <span className="mem-spin" aria-hidden="true" />
-            extracting… ({graphInFlight} in flight)
-          </span>
-        )}
-      </div>
-      {typeof MemoryGraphPanel === 'function' ? <MemoryGraphPanel /> : null}
 
       {/* .sec is a flex title-row (h2 + flex:1 rule); content must be a SIBLING,
           not a child, or it gets pinned into the heading row and shrink-wraps. */}


### PR DESCRIPTION
Follow-ups to the 2026-07-04 memory-loss incident (#1024–1027). Picks up the three tractable issues; the acute bank-DELETE guard already shipped in #1028.

## #1024 — audit trail for destructive memory ops
The op that caused the data loss had **no audit record**. Every destructive `/api/memory/*` op now records a durable row (actor + target + truthful outcome) via the existing `record_action` facility:
- bank delete (guarded handler)
- generic table DELETEs: memories, bank config, document, directive, operation, mental-model
- namespace `POST /api/memory/delete`

**Deliberately deferred (still open on #1024), because both are design decisions rather than mechanical fixes:**
- *Write-auth on mutating routes* — reintroducing auth contradicts the ADR-0012 decision to run the surface open on `0.0.0.0:8080`; localhost-only would break the LAN dashboard's own mutations. Needs an explicit call.
- *Soft-delete / tombstone for banks* — requires upstream Hindsight support (rename + TTL purge) that doesn't exist yet.

## #1026 — response-shape guard + recall disambiguation
- Per-route guard on the recall/reflect/directives passthroughs validates the load-bearing envelope key (`results` / `text` / `items`). Upstream drift → loud `memory.engine_shape` 502 instead of a silently-blank console panel.
- Documented and disambiguated the two colliding `recall` contracts: namespace `POST /api/memory/recall` (`{items}`, ACL-scoped fan-out) vs bank `POST /api/memory/banks/{bank}/recall` (`{results}`, single-bank passthrough).

## #1025 — already resolved by #1028 (closing separately)
`_augment_build_counters` (shipped in #1028) already aggregates real `builds_ok`/`errors`/`in_flight`/`last_built_at` from Hindsight per-bank `/stats`. Added a regression test pinning that aggregation.

## UI (Memory Overview)
- Graph-extraction gate now sits **beside** a shrunk "memories retained" spark in the top row (3-up, responsive down to 1-col).
- Unified card heading styles via a shared `.mo-eyebrow` / `.mo-card-h` treatment.
- Removed the stray `ADR-0023` label from the extraction title.

## Verification
- `pytest tests/api/test_memory_{admin,rest,graph}_route*.py` → **63 passed**
- `ruff check` + `ruff format --check` clean
- `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)