### PR TITLE
fix(board): Hermes-contract repairs, honest UI state, platform-assistant chat

### DIFF
--- a/handoffs/board-hermes-kanban-analysis-2026-07-04.md
+++ b/handoffs/board-hermes-kanban-analysis-2026-07-04.md
@@ -1,0 +1,201 @@
+# Operator Board ↔ Hermes kanban plugin — analysis & recommended hal0-side fixes
+
+> Scope: the hal0 Operator Board surface (`src/hal0/board/`, `src/hal0/api/routes/board*.py`,
+> `ui/src/dash/board/`, `ui/src/api/hooks/useBoard.ts`) versus the connection to the external
+> hermes-agent dashboard's kanban plugin (`{HERMES_DASHBOARD_BASE_URL}/api/plugins/kanban/*`).
+> All recommendations are hal0-side only — Hermes is upstream (`NousResearch/hermes-agent`,
+> pip-installed, loopback-only :9119) and cannot be patched from here.
+
+## 1. Architecture summary (what works well)
+
+The proxy design is sound and consistently executed:
+
+- **Single boundary.** The browser only ever talks to hal0-api `:8080` under `/api/board/*`;
+  `HermesKanbanClient` (`src/hal0/board/__init__.py`) is the one place auth, base-url, and
+  error mapping live. Reads are a table-driven allowlist passthrough; every mutation is an
+  explicit handler wrapped in `record_action` (`board.py`), so the audit trail is complete.
+- **Token model.** Hermes rotates an ephemeral per-process bearer on every restart; hal0
+  harvests `window.__HERMES_SESSION_TOKEN__` from the dashboard HTML, caches it, and
+  re-harvests once on 401 (REST, `__init__.py:231-236`) / on failed WS upgrade
+  (`board_ws.py:132-146`). Browser credentials are stripped inbound. The shared
+  `app.state.hermes_kanban` client means a refresh on either surface benefits both — the fix
+  for the earlier "board loads but never updates live" regression.
+- **Wire-shape tolerance.** `useBoard.ts` normalises the four board shapes Hermes may emit
+  (`{columns:[…]}`, `{lanes}`, `{tasks}`, bare array), the `/tasks/{id}` envelope
+  (`{task, comments, events, attachments, links, runs}`), epoch-second timestamps, and the
+  `{name, on_disk, counts}` actor shape (`boardActors.js`) that previously black-screened the
+  dashboard (React #31).
+
+The gaps below are almost all on the **hal0 UI layer** — the FE diverges from its own frozen
+contract (`ui/CONTRACTS.md` §"Operator Board") and from what the backend proxy actually
+forwards.
+
+## 2. Bugs (correctness — ordered by impact)
+
+### 2.1 `DELETE /links` from the drawer never removes a dependency  — HIGH
+- Backend + upstream contract: `parent_id`/`child_id` ride as **query params**
+  (`board.py:218-229`; asserted in `tests/board/test_board_routes.py:227-238` — `fwd["body"] == ""`).
+- UI: `useRemoveLink` (`useBoard.ts:697-714`) sends them as a **JSON body**
+  (`api(…, {method:'DELETE', body: linkBody})`), query string carries only `?board=`.
+- Result: the proxy forwards `DELETE /api/plugins/kanban/links` with no ids → upstream 4xx
+  (surfaced as `board.upstream_error`) or no-op. The drawer's dep-chip "×"
+  (`task-drawer.jsx:87-91`) toasts "dep removed" regardless.
+- **Fix:** build the query string in `useRemoveLink`:
+  `${ENDPOINTS.boardLinks}?parent_id=…&child_id=…[&board=…]`, drop the body.
+
+### 2.2 Events WS never reconnects after a clean close → live updates die silently — HIGH
+- `board_ws.py` closes the browser socket with **1011** when the upstream connect fails
+  (`:143-146`) and closes normally when the pumps end (Hermes restart drops the upstream,
+  `:169-174`), explicitly expecting "the client's reconnect logic" to engage.
+- But `useBoardEventsStream` only schedules a reconnect in **`ws.onerror`**
+  (`useBoard.ts:972-984`); `onclose` just sets `connected=false` (`:986-988`). A server-sent
+  close frame (1011 or normal) fires only `close` in browsers — so after any Hermes restart
+  the board stops updating live until a full page reload, precisely the regression class the
+  backend WS fix was shipped for.
+- **Fix:** move the backoff/reconnect scheduling into `onclose` (guarded by the effect's
+  `cancelled` flag so unmount/`follow=false` doesn't loop), keep `onerror` as a
+  `ws.close()` trigger. Optionally track the last received `cursor` and pass it as `since`
+  on reconnect so the gap is replayed (the frame already carries it:
+  `{"events":[…], "cursor": N}`, `board_ws.py:1-8`).
+
+### 2.3 "Show archived" shows an empty lane — MEDIUM
+- The archived lane is revealed by `showArchived` (`board-view.jsx:288-291`) but the data
+  query is always `useBoardView({})` (`board-view.jsx:177`) — `include_archived=true` is
+  never sent, even though the hook supports it (`useBoard.ts:443`). Unless Hermes returns
+  archived tasks by default (it hides them, which is why the param exists), the lane is
+  permanently empty.
+- **Fix:** `useBoardView({ includeArchived: showArchived })` (the option is already in the
+  query key, so toggling refetches correctly).
+
+### 2.4 Selected board is not threaded into queries, mutations, or the WS — MEDIUM
+- `board-view.jsx` keeps `board` state and calls `switchBoard.mutate(slug)` (server-side
+  "current board"), but then calls `useBoardView({})`, `useUpdateTask()`,
+  `useCreateTask()`, `useBoardEventsStream()` etc. with **no board argument** — every hook
+  supports one. The frozen contract says "`?board=<slug>` threads through every
+  task/board-scoped call".
+- Consequences: two dashboards (or the MCP/agent surface) racing on the server-side current
+  board mutate each other's view; the WS subscribes to all boards' events; the local
+  `setBoard(slug)` happens before the switch mutation settles with no rollback on error.
+- **Fix:** pass `board` through `useBoardView({board})`, the mutation hooks
+  (`useUpdateTask(board)` …), `useBoardAssignees(board)`, and
+  `useBoardEventsStream({board})`. Keep the `/switch` POST for Hermes-side default-board
+  semantics, but stop depending on it for correctness.
+
+### 2.5 Orchestration `mode` is a phantom field — MEDIUM
+- The contract's PUT knobs are `orchestrator_profile, default_assignee, auto_decompose,
+  auto_promote_children` (`CONTRACTS.md:214`, `useBoard.ts:139-145`). There is no `mode`.
+- Yet the pill renders `orchData.mode ?? "auto"` (`board-view.jsx:461-467`) — always "auto",
+  since GET `/orchestration` never returns `mode` — and `OrchPopover.handleSave` PUTs
+  `mode` upstream (`orchestration-popover.jsx:55-63`), which Hermes will ignore or reject.
+  The popover header's "dispatching/paused" state is therefore cosmetic fiction, violating
+  the board's own "NO STUB DATA" hard rule.
+- **Fix:** drop `mode` from the PUT payload and the pill, or derive a real signal (e.g.
+  from `/config`/`/diagnostics`) and render "source pending" until one exists.
+
+### 2.6 Dropping a card anywhere outside a lane hard-DELETEs the task — MEDIUM (UX/data-loss)
+- `board-view.jsx:598-621`: any drop on the board background calls `delTasks([dragId])` →
+  `DELETE /api/board/tasks/{id}` upstream. One missed lane target = task (and its comments,
+  runs, links — Hermes owns the row) destroyed with no confirmation and no undo.
+- **Fix:** make drop-outside archive instead of delete, or require the existing
+  `delArmed` veil to be a distinct explicit drop target with a confirm step. At minimum
+  offer an undo toast (re-`POST /tasks` is lossy, so prefer archive).
+
+### 2.7 Small UI truth bugs — LOW
+- **Refresh is a no-op:** `doRefresh` only toasts "board refreshed" (`board-view.jsx:341-343`).
+  Wire it to `queryClient.invalidateQueries({queryKey: boardKey(board)})` (expose via the
+  bridge) or `boardViewQ.refetch()`.
+- **Attention "Show" clears filters instead of filtering:** it resets tenant/profile/search
+  and toasts "filtered to attention" (`board-view.jsx:495`) — it does not filter to
+  blocked/review. Add an attention filter state the lane filter respects.
+- **`window.LANE` is never defined** — `stName` (`task-drawer.jsx:16-19`) always falls back
+  to the raw status id, and the contract's "`running` → 'in-progress'" display label is
+  implemented nowhere (`BOARD_LANES` says "Running"). Publish the lane map from
+  board-view (`window.LANE = Object.fromEntries(BOARD_LANES.map(l => [l.id, l]))`) and fix
+  the label.
+- **Chat tool frames render as "operator":** `roleLabel` in `agent-chat.jsx:76-77` maps
+  everything non-assistant to "operator", so the `role:'tool'` frames from `useBoardChat`
+  show as operator messages. Add a `tool` branch (and consider rendering `tool_result`
+  frames, which are currently invisible — only used for invalidation).
+- **`depCount` badge char-indexing:** `task.depCount[0] !== task.depCount[2]`
+  (`kcard.jsx:47`) breaks for counts ≥10 ("10/12"). Split on "/" and compare parts.
+- **`create_task` warning dropped:** contract says surface the "no dispatcher running"
+  `warning` as a toast/banner; `board-view.jsx:683-688` toasts a generic success. Inspect
+  the mutation result for `warning` and toast it.
+- **Unknown statuses vanish:** `normaliseBoardResponse` drops tasks whose status isn't in
+  the 9-value enum from every lane (`useBoard.ts:408-414`) while keeping them in `tasks` —
+  invisible on the board, still counted in "N tasks". Bucket unknowns into `triage` (or an
+  "unknown" catch-all) so upstream enum drift degrades visibly.
+
+## 3. Functional gaps vs the Hermes connection
+
+### 3.1 Board chat can mutate but cannot see the board — HIGH (functionality)
+`board_chat.py` gives the LLM ten **write** tools mapping 1:1 onto the audited mutations,
+but:
+- **No read tools** (`get_board`, `get_task`, `list_assignees`) and **no system prompt** —
+  the model receives only the raw user/assistant turns (`_chat_stream`, `board_chat.py:357-374`).
+  "What's blocked?" or "move the auth task to review" (the UI's own suggestion chips,
+  `agent-chat.jsx:13-18`) cannot be answered/executed unless the user pastes task ids.
+- **Recommended:** (a) prepend a system message describing the surface + lane semantics;
+  (b) add read tools backed by the same allowlisted GET paths (`/board`, `/tasks/{id}`,
+  `/assignees`) — they need no audit rows, matching the REST split; or cheaper, inject a
+  compact board snapshot (ids/titles/status/assignee) into the system message per turn.
+- **No token streaming:** the loop posts `stream: False` and emits each round's full text as
+  one `token` frame — the UI's streaming renderer is real but receives one blob per round.
+  Streaming the final round would materially improve perceived latency; the SSE contract
+  already supports it.
+- The FE also omits `X-hal0-Agent` on `/chat` (`useBoard.ts:1075-1083`); audit actor falls
+  back to "dashboard", which is acceptable but a `chat` marker would make
+  `board.chat.turn` rows self-describing without relying on `message="chat:<tool>"`.
+
+### 3.2 Bulk actions bypass the bulk endpoint — MEDIUM
+`moveTo`/`delTasks` fan out N single-task mutations (`board-view.jsx:307-319`) even though
+`POST /tasks/bulk` exists, is audited as one row (`board.py:147-157`), and `useBulkTasks`
+is already exported on the bridge. N PATCHes = N audit rows, N upstream round-trips, N
+invalidations, and partial-failure states the UI doesn't report. Use `useBulkTasks` for the
+bulkbar (and drag-multi-select later); keep single-card ops on PATCH.
+
+### 3.3 WS invalidation storm — LOW/MEDIUM
+Every WS frame invalidates the board query (`useBoard.ts:961-970`). Hermes polls
+`task_events` at 300ms and pushes batches; a busy run can trigger several refetches per
+second, each a full `GET /board` proxied to Hermes. Debounce invalidation (e.g. trailing
+250–500ms), or eventually apply `events` payloads to the cache directly. Also type
+`BoardEvent` to the real frame (`{events:[…], cursor}`) — the current `{kind, task_id}`
+interface describes an element, not the frame, and `lastEvent` is misleading to consumers.
+
+### 3.4 Unused Hermes surface — LOW
+`/stats`, `/diagnostics`, `/workers/active`, `/runs/{id}`, `/tasks/bulk`, `/reclaim`,
+`/profiles/{name}` PATCH are proxied, audited, hook-wrapped and bridge-published — and no
+board component calls them. Either surface them (stats strip in the board top bar;
+workers-active badge on `running`; reclaim button on stuck `running` cards — reclaim is
+exactly the recovery path for a claim-TTL expiry) or note them as future in CONTRACTS to
+keep the FROZEN table honest.
+
+## 4. Design / UI polish
+
+- **Reduced motion:** `board.css` animations (`board-pulse` on `.kdot.live`, typing dots,
+  `data-accent="dot"` pulse) have no `prefers-reduced-motion: reduce` guard; the
+  dashboard-wide rule only covers `.dot.*`. The board's own acceptance gate requires the
+  loops to die under reduced motion. Add one `@media` block in `board.css`.
+- **Stub replies still shipped:** `agent-chat.jsx:46-53` contains canned fake responses
+  (used only when the hook bridge is absent, but "NO STUB DATA" is a hard rule and the
+  fallback can mask a broken bridge in prod). Replace the stub path with a gated
+  "chat backend unavailable" notice.
+- **Conditional hook calls:** `board-view.jsx`/`task-drawer.jsx` call hooks behind
+  `window.__hal0Use* ?` guards. Because the bridge loads before mount this works, but if a
+  bridge global ever appears/disappears between renders React will throw (hook-order).
+  Worth a comment-level invariant at minimum; longer-term, the window-globals prototype
+  files should migrate to real imports.
+- **Optimistic move only:** `useUpdateTask` patches the cache optimistically for `status`
+  changes only; reassign/priority edits wait for the round-trip. Fine, but drag-and-drop
+  between lanes plus the 300ms event echo can cause a brief snap-back when the refetch
+  lands before Hermes commits; the debounce in §3.3 also mitigates this.
+
+## 5. Suggested execution order
+
+1. §2.1 remove-link query params (one-line hook fix + unit test).
+2. §2.2 WS reconnect-on-close (+ cursor resume) — restores the "live board" guarantee.
+3. §2.3/§2.4 thread `includeArchived` + `board` through the hooks.
+4. §2.6 drag-delete → archive/confirm.
+5. §3.1 board-chat read tools + system prompt.
+6. §2.5, §2.7 batch of small truth fixes.
+7. §3.2 bulkbar → `/tasks/bulk`; §3.3 invalidation debounce; §4 polish.

--- a/handoffs/board-hermes-kanban-analysis-2026-07-04.md
+++ b/handoffs/board-hermes-kanban-analysis-2026-07-04.md
@@ -1,5 +1,16 @@
 # Operator Board ↔ Hermes kanban plugin — analysis & recommended hal0-side fixes
 
+> **Implementation status (2026-07-04, this branch):** everything in §2 and §3
+> is FIXED here except §3.1's token streaming (the loop still posts
+> `stream: false`; frames arrive per round). §2.6 resolved as drop-outside →
+> ARCHIVE. §3.1 landed as read tools + system prompt, then grew into the
+> platform-assistant scope (slots/models/agents/orchestration tools — see
+> `board_chat.py` docstring). §3.4 remains open for stats/diagnostics/
+> workers-active/reclaim surfaces. §4's reduced-motion + stub-reply items are
+> fixed; the window-globals hook-guard pattern is unchanged (noted risk only).
+> Bonus: the dashboard's fonts.googleapis.com dependency was replaced with the
+> already-shipped @fontsource packages (offline-correct, deterministic e2e).
+
 > Scope: the hal0 Operator Board surface (`src/hal0/board/`, `src/hal0/api/routes/board*.py`,
 > `ui/src/dash/board/`, `ui/src/api/hooks/useBoard.ts`) versus the connection to the external
 > hermes-agent dashboard's kanban plugin (`{HERMES_DASHBOARD_BASE_URL}/api/plugins/kanban/*`).

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -181,8 +181,7 @@ def _tool_schemas() -> list[dict[str, Any]]:
         ),
         _fn(
             "slot_unload",
-            "Unload a slot's model from memory. DISRUPTIVE — only on explicit "
-            "operator request.",
+            "Unload a slot's model from memory. DISRUPTIVE — only on explicit operator request.",
             {"name": {"type": "string"}},
             ["name"],
         ),
@@ -357,9 +356,7 @@ def _compact_board(result: Any) -> Any:
     else:
         return result
     return {
-        "tasks": [
-            {k: t[k] for k in _COMPACT_TASK_FIELDS if t.get(k) is not None} for t in rows
-        ]
+        "tasks": [{k: t[k] for k in _COMPACT_TASK_FIELDS if t.get(k) is not None} for t in rows]
     }
 
 
@@ -381,9 +378,7 @@ _PLATFORM_READS = {
 _SLOT_MUTATIONS = {"slot_load": "load", "slot_unload": "unload", "slot_restart": "restart"}
 
 
-def _resolve_platform_tool(
-    name: str, args: dict[str, Any]
-) -> tuple[str | None, str, bool]:
+def _resolve_platform_tool(name: str, args: dict[str, Any]) -> tuple[str | None, str, bool]:
     """Map a platform tool → (method, hal0-api path, mutating)."""
     if name in _PLATFORM_READS:
         return "GET", _PLATFORM_READS[name], False
@@ -664,9 +659,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     messages: list[dict[str, Any]] = list(payload.get("messages") or [])
     # Seed the system prompt unless the client sent its own — the model needs
     # the lane vocabulary and the read-before-write rule to act on the board.
-    if not messages or not (
-        isinstance(messages[0], dict) and messages[0].get("role") == "system"
-    ):
+    if not messages or not (isinstance(messages[0], dict) and messages[0].get("role") == "system"):
         messages.insert(0, {"role": "system", "content": _SYSTEM_PROMPT})
 
     body: dict[str, Any] = {

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -1,18 +1,24 @@
-"""Operator Board chat orchestrator — ``POST /api/board/chat`` (SSE).
+"""Platform assistant chat orchestrator — ``POST /api/board/chat`` (SSE).
 
-SPEC §2.D: a hal0-NATIVE conversational surface that can manage the board.
-hal0-api runs a client-side OpenAI tool-calling loop whose LLM is the hal0
-``primary`` chat slot (reached via hal0-api's own ``/v1/chat/completions``
-surface, mirroring :class:`hal0.omni_router.OmniRouter`). The toolset maps 1:1
-onto the AUDITED ``/api/board/*`` mutations:
+SPEC §2.D grown into the platform surface: a hal0-NATIVE conversational agent
+that administers the whole instance, not just the board. hal0-api runs a
+client-side OpenAI tool-calling loop whose LLM is the hal0 ``agent`` slot
+(reached via hal0-api's own ``/v1/chat/completions`` surface, mirroring
+:class:`hal0.omni_router.OmniRouter`). Three tool families:
 
-    move/assign · create · comment · dep add/remove · block · specify ·
-    decompose · nudge
+* **Board reads** (unaudited, via :class:`HermesKanbanClient` — mirrors the
+  REST proxy's allowlisted GET rows): get_board · get_task · get_assignees ·
+  get_orchestration.
+* **Board mutations** (each an AUDITED ``board.chat.turn`` row through the
+  same client the REST handlers use): move/assign · create · comment ·
+  dep add/remove · block · specify · decompose · nudge · orchestration update.
+* **Platform tools** (hal0-api's OWN surface, self-HTTP against
+  ``app.state.self_api_base_url``): slots list/get/load/unload/restart,
+  models, hardware stats, installed agents. Reads unaudited; slot mutations
+  write ``platform.chat.turn`` rows.
 
-Every tool the LLM calls is dispatched through the SAME audited mutation path
-the REST handlers use (the :class:`HermesKanbanClient` + a ``board.chat.turn``
-audit row per call), so a chat-driven mutation surfaces on the board LIVE via
-the kanban events WS — chat is NOT the board transport.
+A chat-driven board mutation surfaces on the board LIVE via the kanban events
+WS — chat is NOT the board transport.
 
 Transport contract (kept stable so the LLM backend can later swap to the
 Hermes agent via chat_proxy WITHOUT any UI change):
@@ -57,6 +63,39 @@ _MAX_ROUNDS = 8
 # (Named PRIMARY_SLOT_MODEL for back-compat; resolves via the resolver chains.)
 PRIMARY_SLOT_MODEL = "hal0/agent"
 
+# Injected as the leading system message when the client doesn't send one.
+# Without it the LLM had ten write tools, no read tools, and no idea what the
+# lanes mean — it could mutate the board but never see it, so "what's
+# blocked?" or "move the auth task to review" was unanswerable.
+_SYSTEM_PROMPT = """\
+You are the hal0 platform assistant: a terse operations agent that
+administers this hal0 instance via tools — the Operator Board (kanban),
+inference slots, models, agent profiles, and orchestration settings.
+
+Surfaces:
+- Board: lanes (the `status` values) are triage (new, awaiting spec), todo
+  (specified and queued), scheduled (time-triggered), ready (claimed for
+  dispatch), running (worker active), blocked (waiting on input; carries
+  block_reason), review (needs operator sign-off), done, archived.
+- Slots: list_slots / get_slot report each inference slot's state (serving,
+  ready, warming, idle, offline, error), model and throughput;
+  slot_load / slot_unload / slot_restart change them.
+- Catalogue: list_models (model library), list_agents (installed platform
+  agents), hardware_stats (RAM/VRAM/GTT, GPU util, NPU status).
+- Settings: get_orchestration / update_orchestration (board dispatcher knobs:
+  orchestrator_profile, default_assignee, auto_decompose,
+  auto_promote_children).
+
+Rules:
+- You cannot see state unless you look. Call the matching read tool first and
+  resolve exact task ids / slot names before mutating. Never guess ids.
+- Board mutations are audited and land on the live board immediately.
+- Slot load/unload/restart are DISRUPTIVE (they can evict models and drop
+  in-flight requests): do them only when the operator explicitly asks, and
+  state what you did.
+- Prefer a clarifying question over a destructive guess. Keep replies short.
+"""
+
 #: LLM backend signature: an OpenAI chat-completion request body in, the
 #: parsed response dict out.
 LlmFn = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
@@ -81,8 +120,97 @@ def _fn(name: str, desc: str, props: dict[str, Any], required: list[str]) -> dic
 
 
 def _tool_schemas() -> list[dict[str, Any]]:
-    """OpenAI ``tools`` array advertised to the LLM."""
+    """OpenAI ``tools`` array advertised to the LLM (reads first, then writes)."""
     return [
+        _fn(
+            "get_board",
+            "Read the whole board: every task's id/title/status/assignee/"
+            "priority. Call this FIRST to resolve task ids before mutating.",
+            {},
+            [],
+        ),
+        _fn(
+            "get_task",
+            "Read one task in full: body, comments, events, runs, links.",
+            {"task_id": {"type": "string"}},
+            ["task_id"],
+        ),
+        _fn(
+            "get_assignees",
+            "List the assignable actors (agent profiles) on this board.",
+            {},
+            [],
+        ),
+        _fn(
+            "get_orchestration",
+            "Read the board dispatcher settings (orchestrator_profile, "
+            "default_assignee, auto_decompose, auto_promote_children).",
+            {},
+            [],
+        ),
+        _fn(
+            "update_orchestration",
+            "Update the board dispatcher settings. Only pass the knobs to change.",
+            {
+                "orchestrator_profile": {"type": "string"},
+                "default_assignee": {"type": "string"},
+                "auto_decompose": {"type": "boolean"},
+                "auto_promote_children": {"type": "boolean"},
+            },
+            [],
+        ),
+        _fn(
+            "list_slots",
+            "List the inference slots: name, state (serving/ready/warming/idle/"
+            "offline/error), model, backend, throughput.",
+            {},
+            [],
+        ),
+        _fn(
+            "get_slot",
+            "Read one inference slot in detail.",
+            {"name": {"type": "string"}},
+            ["name"],
+        ),
+        _fn(
+            "slot_load",
+            "Load a slot's model into memory. DISRUPTIVE: may evict other "
+            "tenants — only on explicit operator request.",
+            {"name": {"type": "string"}},
+            ["name"],
+        ),
+        _fn(
+            "slot_unload",
+            "Unload a slot's model from memory. DISRUPTIVE — only on explicit "
+            "operator request.",
+            {"name": {"type": "string"}},
+            ["name"],
+        ),
+        _fn(
+            "slot_restart",
+            "Restart a slot's backend process. DISRUPTIVE: drops in-flight "
+            "requests — only on explicit operator request.",
+            {"name": {"type": "string"}},
+            ["name"],
+        ),
+        _fn(
+            "list_models",
+            "List the model library (installed + known models).",
+            {},
+            [],
+        ),
+        _fn(
+            "hardware_stats",
+            "Read hardware utilisation: RAM/VRAM/GTT, GPU util, NPU status.",
+            {},
+            [],
+        ),
+        _fn(
+            "list_agents",
+            "List the installed platform agents (e.g. hermes, pi-coder).",
+            {},
+            [],
+        ),
         _fn(
             "move_task",
             "Move a task to a different lane / status (drag-drop equivalent).",
@@ -168,6 +296,153 @@ def _tool_schemas() -> list[dict[str, Any]]:
     ]
 
 
+# ── read tools (allowlisted GETs — mirror the UNAUDITED REST read rows) ─────
+
+
+def _resolve_read_tool(name: str, args: dict[str, Any]) -> tuple[str | None, str]:
+    """Map a read tool → (method, upstream sub-path); (None, "") if not a read.
+
+    These hit the same allowlisted GET paths the table-driven REST proxy
+    forwards, and like those reads they write NO audit rows.
+    """
+    if name == "get_board":
+        return "GET", "/board"
+    if name == "get_task":
+        return "GET", f"/tasks/{args.get('task_id', '')}"
+    if name == "get_assignees":
+        return "GET", "/assignees"
+    if name == "get_orchestration":
+        return "GET", "/orchestration"
+    return None, ""
+
+
+# Fields kept when compacting a board row for the tool result. Full rows carry
+# bodies/summaries per task; a big board would blow the loop's context budget.
+_COMPACT_TASK_FIELDS = (
+    "id",
+    "title",
+    "status",
+    "assignee",
+    "profile",
+    "priority",
+    "block_reason",
+    "tenant",
+)
+
+
+def _compact_board(result: Any) -> Any:
+    """Trim a GET /board payload to compact task rows.
+
+    Accepts the same four wire shapes the dashboard normaliser handles —
+    ``{columns:[{tasks}]}`` (what Hermes emits), ``{lanes:{status:[...]}}``,
+    ``{tasks:[...]}``, or a bare list — and returns ``{"tasks": [...]}``.
+    Anything unrecognised passes through untouched.
+    """
+    rows: list[dict[str, Any]] = []
+    if isinstance(result, dict):
+        if isinstance(result.get("columns"), list):
+            for col in result["columns"]:
+                if isinstance(col, dict) and isinstance(col.get("tasks"), list):
+                    rows.extend(t for t in col["tasks"] if isinstance(t, dict))
+        elif isinstance(result.get("lanes"), dict):
+            for tasks in result["lanes"].values():
+                if isinstance(tasks, list):
+                    rows.extend(t for t in tasks if isinstance(t, dict))
+        elif isinstance(result.get("tasks"), list):
+            rows = [t for t in result["tasks"] if isinstance(t, dict)]
+        else:
+            return result
+    elif isinstance(result, list):
+        rows = [t for t in result if isinstance(t, dict)]
+    else:
+        return result
+    return {
+        "tasks": [
+            {k: t[k] for k in _COMPACT_TASK_FIELDS if t.get(k) is not None} for t in rows
+        ]
+    }
+
+
+# ── platform tools (hal0-api's OWN surface, via self-HTTP) ──────────────────
+#
+# These do not touch Hermes: they call hal0-api's existing slot/model/agent
+# routes on the same instance (``app.state.self_api_base_url``), re-entering
+# the normal dispatch chain. Tests inject ``app.state.platform_http`` (an
+# httpx.AsyncClient over a MockTransport); production builds one per call.
+
+_PLATFORM_READS = {
+    "list_slots": "/api/slots",
+    "list_models": "/api/models",
+    "hardware_stats": "/api/stats/hardware",
+    "list_agents": "/api/agents",
+}
+
+# Disruptive slot verbs — each is audited as a ``platform.chat.turn`` row.
+_SLOT_MUTATIONS = {"slot_load": "load", "slot_unload": "unload", "slot_restart": "restart"}
+
+
+def _resolve_platform_tool(
+    name: str, args: dict[str, Any]
+) -> tuple[str | None, str, bool]:
+    """Map a platform tool → (method, hal0-api path, mutating)."""
+    if name in _PLATFORM_READS:
+        return "GET", _PLATFORM_READS[name], False
+    if name == "get_slot":
+        return "GET", f"/api/slots/{args.get('name', '')}", False
+    if name in _SLOT_MUTATIONS:
+        return "POST", f"/api/slots/{args.get('name', '')}/{_SLOT_MUTATIONS[name]}", True
+    return None, "", False
+
+
+async def _platform_request(http: httpx.AsyncClient, method: str, path: str) -> Any:
+    """One self-HTTP call, mapped to a tool-result the loop can step against."""
+    try:
+        resp = await http.request(method, path)
+    except httpx.HTTPError as exc:
+        return {"error": f"platform API unreachable: {exc}"}
+    if resp.status_code >= 400:
+        return {"error": f"platform API HTTP {resp.status_code}: {resp.text[:300]}"}
+    if not resp.content:
+        return {}
+    try:
+        return resp.json()
+    except ValueError:
+        return {"raw": resp.text[:500]}
+
+
+async def _dispatch_platform_tool(
+    request: Request,
+    name: str,
+    args: dict[str, Any],
+    *,
+    method: str,
+    path: str,
+    mutating: bool,
+) -> Any:
+    """Run one platform tool; slot mutations write a ``platform.chat.turn`` row."""
+    http = getattr(request.app.state, "platform_http", None)
+    owns = http is None
+    if owns:
+        base = getattr(request.app.state, "self_api_base_url", "http://127.0.0.1:8080")
+        http = httpx.AsyncClient(base_url=base.rstrip("/"), timeout=60.0)
+    try:
+        if not mutating:
+            return await _platform_request(http, method, path)
+        async with record_action(
+            request,
+            category="platform",
+            action="platform.chat.turn",
+            target=args.get("name"),
+            message=f"chat:{name}",
+        ) as rec:
+            result = await _platform_request(http, method, path)
+            rec.after = result if isinstance(result, dict) else {"result": result}
+            return result
+    finally:
+        if owns:
+            await http.aclose()
+
+
 # ── tool dispatch → audited board mutation ──────────────────────────────────
 
 
@@ -218,6 +493,10 @@ def _resolve_tool(
         if args.get("max") is not None:
             params["max"] = args["max"]
         return "POST", "/dispatch", params, {}, None
+    if name == "update_orchestration":
+        # PUT /orchestration — partial update, only the knobs passed.
+        body = {k: v for k, v in args.items() if v is not None}
+        return "PUT", "/orchestration", {}, body, None
     return None, "", {}, None, None
 
 
@@ -229,12 +508,30 @@ async def _dispatch_tool(
     *,
     board: str | None,
 ) -> Any:
-    """Run one board tool through the audited mutation path.
+    """Run one board tool: reads pass straight through, mutations are audited.
 
     Returns the upstream JSON result (or an ``{"error": ...}`` envelope the
-    loop can keep stepping against). Each call writes a ``board.chat.turn``
-    audit row with ``rec.after`` = result.
+    loop can keep stepping against). Each MUTATION writes a ``board.chat.turn``
+    audit row with ``rec.after`` = result; reads write none — matching the
+    REST proxy's audited-mutations / unaudited-reads split.
     """
+    read_method, read_path = _resolve_read_tool(name, args)
+    if read_method is not None:
+        params = {"board": board} if board else None
+        result = await client.request_json(
+            read_method,
+            read_path,
+            params=params,
+            agent_id=request.headers.get("X-hal0-Agent"),
+        )
+        return _compact_board(result) if name == "get_board" else result
+
+    p_method, p_path, p_mutating = _resolve_platform_tool(name, args)
+    if p_method is not None:
+        return await _dispatch_platform_tool(
+            request, name, args, method=p_method, path=p_path, mutating=p_mutating
+        )
+
     method, path, tool_params, body, target = _resolve_tool(name, args)
     if method is None:
         return {"error": f"unknown tool: {name}"}
@@ -365,6 +662,12 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     llm = _resolve_llm(request)
     board = payload.get("board")
     messages: list[dict[str, Any]] = list(payload.get("messages") or [])
+    # Seed the system prompt unless the client sent its own — the model needs
+    # the lane vocabulary and the read-before-write rule to act on the board.
+    if not messages or not (
+        isinstance(messages[0], dict) and messages[0].get("role") == "system"
+    ):
+        messages.insert(0, {"role": "system", "content": _SYSTEM_PROMPT})
 
     body: dict[str, Any] = {
         "model": payload.get("model") or PRIMARY_SLOT_MODEL,
@@ -446,7 +749,11 @@ async def run_board_chat(request: Request) -> StreamingResponse:
 __all__ = [
     "PRIMARY_SLOT_MODEL",
     "_chat_stream",
+    "_compact_board",
+    "_dispatch_platform_tool",
     "_dispatch_tool",
+    "_resolve_platform_tool",
+    "_resolve_read_tool",
     "_resolve_tool",
     "_tool_schemas",
     "run_board_chat",

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -21,7 +21,15 @@ from fastapi.testclient import TestClient
 from hal0.activity import AuditStore
 from hal0.api.middleware import error_codes
 from hal0.api.routes import board
-from hal0.api.routes.board_chat import _extract_tool_calls, _resolve_tool, _tool_schemas
+from hal0.api.routes.board_chat import (
+    _SYSTEM_PROMPT,
+    _compact_board,
+    _extract_tool_calls,
+    _resolve_platform_tool,
+    _resolve_read_tool,
+    _resolve_tool,
+    _tool_schemas,
+)
 from hal0.board import KANBAN_BASE_PATH, HermesKanbanClient
 
 P = KANBAN_BASE_PATH
@@ -55,6 +63,26 @@ class _Recorder:
     def recorded(self, method: str, path: str) -> list[dict[str, Any]]:
         full = f"{P}{path}"
         return [r for r in self.requests if r["method"] == method and r["path"] == full]
+
+
+class _PlatformRecorder:
+    """Like _Recorder but for hal0-api's OWN routes (no kanban prefix)."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.responses: dict[tuple[str, str], httpx.Response] = {}
+
+    def respond(self, method: str, path: str, body: Any, status: int = 200) -> None:
+        self.responses[(method, path)] = httpx.Response(status, json=body)
+
+    async def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append({"method": request.method, "path": request.url.path})
+        return self.responses.get(
+            (request.method, request.url.path), httpx.Response(200, json={"ok": True})
+        )
+
+    def recorded(self, method: str, path: str) -> list[dict[str, Any]]:
+        return [r for r in self.requests if r["method"] == method and r["path"] == path]
 
 
 class _StubLLM:
@@ -117,7 +145,14 @@ def _final_response(text: str) -> dict[str, Any]:
     return {"choices": [{"message": {"role": "assistant", "content": text}}]}
 
 
-def _make_app(recorder: _Recorder, stub: Any, tmp_path, *, no_client: bool = False) -> tuple:
+def _make_app(
+    recorder: _Recorder,
+    stub: Any,
+    tmp_path,
+    *,
+    no_client: bool = False,
+    platform: _PlatformRecorder | None = None,
+) -> tuple:
     app = FastAPI()
     error_codes.install(app)
     app.include_router(board.router, prefix="/api/board")
@@ -128,6 +163,11 @@ def _make_app(recorder: _Recorder, stub: Any, tmp_path, *, no_client: bool = Fal
         http = httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9119")
         app.state.hermes_kanban = HermesKanbanClient(
             http_client=http, session_token_resolver=lambda: "TOK"
+        )
+    if platform is not None:
+        app.state.platform_http = httpx.AsyncClient(
+            transport=httpx.MockTransport(platform.handler),
+            base_url="http://127.0.0.1:8080",
         )
     store = AuditStore(tmp_path / "audit.db")
     store.init_schema()
@@ -380,6 +420,181 @@ def test_multi_tool_one_response(tmp_path) -> None:
     assert len(rows) == 2
 
 
+# ── read tools (unaudited, board-scoped) ────────────────────────────────────
+
+
+def test_read_tool_get_board_forwards_and_is_not_audited(tmp_path) -> None:
+    rec = _Recorder()
+    rec.respond(
+        "GET",
+        "/board",
+        {
+            "columns": [
+                {
+                    "name": "todo",
+                    "tasks": [
+                        {
+                            "id": "t1",
+                            "title": "fix",
+                            "status": "todo",
+                            "assignee": "bob",
+                            "body": "a very long body that must be trimmed",
+                        }
+                    ],
+                }
+            ]
+        },
+    )
+    stub = _StubLLM([_tool_call_response("get_board", {}, "c_gb"), _final_response("ok")])
+    app, client = _make_app(rec, stub, tmp_path)
+    resp = client.post(
+        "/api/board/chat",
+        json={"board": "alpha", "messages": [{"role": "user", "content": "what's up"}]},
+    )
+    assert resp.status_code == 200
+    hits = rec.recorded("GET", "/board")
+    assert len(hits) == 1
+    assert hits[0]["params"]["board"] == "alpha"  # board scope threads through
+    # tool_result carries the COMPACTED rows (no body field)
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert result["result"] == {
+        "tasks": [{"id": "t1", "title": "fix", "status": "todo", "assignee": "bob"}]
+    }
+    # reads write NO audit rows — matches the REST proxy's split
+    assert app.state.audit.query(action="board.chat.turn") == []
+
+
+def test_read_tool_get_task_forwards(tmp_path) -> None:
+    rec = _Recorder()
+    rec.respond("GET", "/tasks/t9", {"task": {"id": "t9"}, "comments": []})
+    stub = _StubLLM(
+        [_tool_call_response("get_task", {"task_id": "t9"}, "c_gt"), _final_response("ok")]
+    )
+    app, client = _make_app(rec, stub, tmp_path)
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert len(rec.recorded("GET", "/tasks/t9")) == 1
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert result["result"]["task"]["id"] == "t9"  # detail is NOT compacted
+    assert app.state.audit.query(action="board.chat.turn") == []
+
+
+def test_read_tool_get_assignees_forwards(tmp_path) -> None:
+    rec = _Recorder()
+    rec.respond("GET", "/assignees", [{"name": "scout", "on_disk": True}])
+    stub = _StubLLM([_tool_call_response("get_assignees", {}, "c_ga"), _final_response("ok")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert len(rec.recorded("GET", "/assignees")) == 1
+
+
+# ── platform tools (slots/models/agents/stats via self-HTTP) ────────────────
+
+
+def test_platform_list_slots_forwards_and_is_not_audited(tmp_path) -> None:
+    rec = _Recorder()
+    plat = _PlatformRecorder()
+    plat.respond("GET", "/api/slots", [{"name": "agent", "state": "serving"}])
+    stub = _StubLLM([_tool_call_response("list_slots", {}, "c_ls"), _final_response("ok")])
+    app, client = _make_app(rec, stub, tmp_path, platform=plat)
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert len(plat.recorded("GET", "/api/slots")) == 1
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert result["result"] == [{"name": "agent", "state": "serving"}]
+    assert app.state.audit.query(action="platform.chat.turn") == []
+
+
+def test_platform_slot_restart_forwards_and_audits(tmp_path) -> None:
+    rec = _Recorder()
+    plat = _PlatformRecorder()
+    plat.respond("POST", "/api/slots/img/restart", {"ok": True})
+    stub = _StubLLM(
+        [_tool_call_response("slot_restart", {"name": "img"}, "c_sr"), _final_response("ok")]
+    )
+    app, client = _make_app(rec, stub, tmp_path, platform=plat)
+    client.post(
+        "/api/board/chat",
+        json={"messages": [{"role": "user", "content": "restart img"}]},
+        headers={"X-hal0-Agent": "op"},
+    )
+    assert len(plat.recorded("POST", "/api/slots/img/restart")) == 1
+    rows = app.state.audit.query(action="platform.chat.turn")
+    assert len(rows) == 1
+    assert rows[0]["target"] == "img"
+    # No Hermes traffic for a platform tool.
+    assert rec.requests == []
+
+
+def test_platform_error_becomes_tool_result(tmp_path) -> None:
+    rec = _Recorder()
+    plat = _PlatformRecorder()
+    plat.respond("GET", "/api/slots", {"error": "nope"}, status=500)
+    stub = _StubLLM([_tool_call_response("list_slots", {}, "c_e"), _final_response("ok")])
+    _app, client = _make_app(rec, stub, tmp_path, platform=plat)
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert "HTTP 500" in result["result"]["error"]
+    # The loop keeps stepping — the turn still terminates cleanly.
+    assert events[-1]["type"] == "done"
+
+
+def test_orchestration_tools_route_via_kanban_client(tmp_path) -> None:
+    rec = _Recorder()
+    rec.respond("GET", "/orchestration", {"orchestrator_profile": "admin"})
+    rec.respond("PUT", "/orchestration", {"ok": True})
+    stub = _StubLLM(
+        [
+            _tool_call_response("get_orchestration", {}, "c_go"),
+            _tool_call_response("update_orchestration", {"auto_decompose": True}, "c_uo"),
+            _final_response("ok"),
+        ]
+    )
+    app, client = _make_app(rec, stub, tmp_path)
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert len(rec.recorded("GET", "/orchestration")) == 1
+    puts = rec.recorded("PUT", "/orchestration")
+    assert len(puts) == 1
+    assert json.loads(puts[0]["body"]) == {"auto_decompose": True}
+    # read unaudited, update audited as a board mutation
+    rows = app.state.audit.query(action="board.chat.turn")
+    assert len(rows) == 1
+
+
+# ── system prompt injection ─────────────────────────────────────────────────
+
+
+def test_system_prompt_injected_when_absent(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "hello"}]})
+    sent = stub.calls[0]["messages"]
+    assert sent[0]["role"] == "system"
+    assert sent[0]["content"] == _SYSTEM_PROMPT
+    assert sent[1] == {"role": "user", "content": "hello"}
+
+
+def test_system_prompt_not_duplicated_when_client_sends_one(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    client.post(
+        "/api/board/chat",
+        json={
+            "messages": [
+                {"role": "system", "content": "custom"},
+                {"role": "user", "content": "hello"},
+            ]
+        },
+    )
+    sent = stub.calls[0]["messages"]
+    assert sent[0] == {"role": "system", "content": "custom"}
+    assert sum(1 for m in sent if m.get("role") == "system") == 1
+
+
 # ── loop termination + errors ───────────────────────────────────────────────
 
 
@@ -460,9 +675,67 @@ def test_resolve_tool_unknown() -> None:
     assert method is None
 
 
+def test_resolve_read_tool_paths() -> None:
+    assert _resolve_read_tool("get_board", {}) == ("GET", "/board")
+    assert _resolve_read_tool("get_task", {"task_id": "t1"}) == ("GET", "/tasks/t1")
+    assert _resolve_read_tool("get_assignees", {}) == ("GET", "/assignees")
+    assert _resolve_read_tool("get_orchestration", {}) == ("GET", "/orchestration")
+    assert _resolve_read_tool("move_task", {}) == (None, "")
+
+
+def test_resolve_platform_tool_paths() -> None:
+    assert _resolve_platform_tool("list_slots", {}) == ("GET", "/api/slots", False)
+    assert _resolve_platform_tool("get_slot", {"name": "img"}) == (
+        "GET",
+        "/api/slots/img",
+        False,
+    )
+    assert _resolve_platform_tool("slot_load", {"name": "img"}) == (
+        "POST",
+        "/api/slots/img/load",
+        True,
+    )
+    assert _resolve_platform_tool("slot_unload", {"name": "img"}) == (
+        "POST",
+        "/api/slots/img/unload",
+        True,
+    )
+    assert _resolve_platform_tool("slot_restart", {"name": "img"}) == (
+        "POST",
+        "/api/slots/img/restart",
+        True,
+    )
+    assert _resolve_platform_tool("list_models", {}) == ("GET", "/api/models", False)
+    assert _resolve_platform_tool("hardware_stats", {}) == (
+        "GET",
+        "/api/stats/hardware",
+        False,
+    )
+    assert _resolve_platform_tool("list_agents", {}) == ("GET", "/api/agents", False)
+    assert _resolve_platform_tool("move_task", {}) == (None, "", False)
+
+
+def test_compact_board_shapes() -> None:
+    row = {"id": "t1", "title": "x", "status": "todo", "body": "long", "priority": 2}
+    compacted = {"id": "t1", "title": "x", "status": "todo", "priority": 2}
+    assert _compact_board({"columns": [{"tasks": [row]}]}) == {"tasks": [compacted]}
+    assert _compact_board({"lanes": {"todo": [row]}}) == {"tasks": [compacted]}
+    assert _compact_board({"tasks": [row]}) == {"tasks": [compacted]}
+    assert _compact_board([row]) == {"tasks": [compacted]}
+    # unrecognised shapes pass through untouched
+    assert _compact_board({"weird": True}) == {"weird": True}
+    assert _compact_board("raw") == "raw"
+
+
 def test_tool_schemas_complete() -> None:
     names = {s["function"]["name"] for s in _tool_schemas()}
     assert names == {
+        # board reads (unaudited — the model's eyes on the board)
+        "get_board",
+        "get_task",
+        "get_assignees",
+        "get_orchestration",
+        # audited board mutations
         "move_task",
         "assign_task",
         "create_task",
@@ -473,6 +746,16 @@ def test_tool_schemas_complete() -> None:
         "specify_task",
         "decompose_task",
         "nudge_dispatcher",
+        "update_orchestration",
+        # platform surface (slots/models/agents/stats via self-HTTP)
+        "list_slots",
+        "get_slot",
+        "slot_load",
+        "slot_unload",
+        "slot_restart",
+        "list_models",
+        "hardware_stats",
+        "list_agents",
     }
 
 

--- a/ui/CONTRACTS.md
+++ b/ui/CONTRACTS.md
@@ -213,7 +213,7 @@ Move a task = `PATCH /api/board/tasks/{id} {status}`. `done` completes; `blocked
 | `/config` | GET | — (read-only knobs: tick-interval/failure-limit/claim-TTL/max-in-flight) |
 | `/orchestration` | GET / PUT | — / board.orchestration.update (4 knobs: orchestrator_profile, default_assignee, auto_decompose, auto_promote_children) |
 | `/events` | WS ?token=&since=&board=&tenant= | — |
-| `/chat` | POST(SSE) | board.chat.turn (per tool call) |
+| `/chat` | POST(SSE) | board.chat.turn per board mutation · platform.chat.turn per slot mutation (reads unaudited) |
 
 ## Wire shapes (board task — the canonical card/drawer shape)
 A `Task` from `/board` lanes + `/tasks/{id}`:
@@ -230,8 +230,14 @@ so view components consume one stable camelCase shape. `/board` returns lanes ke
 flat task list the hook buckets by `status`). Empty board ⇒ all 8 lanes render with "— no tasks —".
 
 ## Gaps surfaced honestly in the UI (do not fake)
-- Orchestration popover: only the 4 PUT knobs are editable. tick-interval / failure-limit /
-  claim-TTL / max-in-flight are read from `/config` and rendered **read-only with a note**.
+- Orchestration popover: only the 4 PUT knobs are editable (no auto/manual "mode" — the
+  server has no such field). tick-interval / failure-limit / claim-TTL / max-in-flight are
+  read from `/config` and rendered **read-only with a note**.
+- The `/chat` agent is the PLATFORM assistant: board tools (reads + audited mutations,
+  incl. get/update_orchestration) plus hal0-api self-HTTP tools (slots list/get/
+  load/unload/restart, models, hardware stats, installed agents). Same SSE frame contract.
+- Drag-and-drop outside any lane ARCHIVES the card (`board-drop-archive` /
+  `board-archive-veil`); nothing on the board hard-deletes without an explicit action.
 - "Nudge dispatcher" = one-shot `POST /dispatch?max=N`. No continuous start/stop.
 - Worker log is pull-only (`/tasks/{id}/log?tail=`); poll on drawer open, no live stream.
 - `create_task` may return a `warning` (no dispatcher running) — show it as a toast/banner.

--- a/ui/index.html
+++ b/ui/index.html
@@ -18,12 +18,9 @@
       content="hal0 v0.5.0-alpha.1 dashboard — container-runtime slots, NPU trio, OmniRouter, agent approvals. Operator surface for a local AI appliance."
     />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Fonts are self-hosted via @fontsource imports in src/main.tsx — no
+         external font CDN: the dashboard must render identically on an
+         offline LAN box. -->
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -410,6 +410,10 @@ function normaliseBoardResponse(
       lanes[task.status].push(task)
     } else if (task.status === 'archived' && includeArchived) {
       lanes['archived'].push(task)
+    } else if (task.status !== 'archived') {
+      // Unknown status (upstream enum drift): surface the card in triage
+      // rather than letting it vanish while still counting toward "N tasks".
+      lanes['triage'].push(task)
     }
   }
 
@@ -697,16 +701,20 @@ export function useAddLink(board?: string) {
 export function useRemoveLink(board?: string) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (linkBody: LinkBody) =>
-      api<unknown>(
-        board
-          ? `${ENDPOINTS.boardLinks}?board=${encodeURIComponent(board)}`
-          : ENDPOINTS.boardLinks,
-        {
-          method: 'DELETE',
-          body: linkBody as unknown as Record<string, unknown>,
-        },
-      ),
+    // DELETE /links takes parent_id/child_id as QUERY params — the backend
+    // forwards the query string verbatim and sends NO body on this route
+    // (board.py remove_link), so ids in a JSON body are silently dropped
+    // upstream and the dependency is never removed.
+    mutationFn: (linkBody: LinkBody) => {
+      const params = new URLSearchParams({
+        parent_id: linkBody.parent_id,
+        child_id: linkBody.child_id,
+      })
+      if (board) params.set('board', board)
+      return api<unknown>(`${ENDPOINTS.boardLinks}?${params}`, {
+        method: 'DELETE',
+      })
+    },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: boardKey(board) })
     },
@@ -881,10 +889,15 @@ export function useNudgeDispatch() {
 
 // ── WS events stream ─────────────────────────────────────────────────
 
+/**
+ * One frame from the events WS. The upstream kanban WS polls task_events and
+ * pushes BATCH frames — `{"events": [...], "cursor": N}` — not single events.
+ * `cursor` is the resume point: threaded back as `?since=` on reconnect so
+ * the gap between a drop and the reconnect is replayed, not lost.
+ */
 export interface BoardEvent {
-  kind?: string
-  task_id?: string
-  at?: string
+  events?: unknown[]
+  cursor?: number
   [k: string]: unknown
 }
 
@@ -917,6 +930,9 @@ export function boardEventsWsUrl(opts: {
 }
 
 const WS_MAX_BACKOFF_MS = 16_000
+// Hermes polls task_events every 300ms and pushes a frame per batch; without
+// a debounce a busy run triggers a full GET /board refetch per frame.
+const WS_INVALIDATE_DEBOUNCE_MS = 300
 
 export function useBoardEventsStream(
   opts: UseBoardEventsStreamOptions = {},
@@ -926,6 +942,8 @@ export function useBoardEventsStream(
   const [lastEvent, setLastEvent] = useState<BoardEvent | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const errorCountRef = useRef(0)
+  // Last frame cursor — used as `since` on reconnect to replay the gap.
+  const cursorRef = useRef<number | null>(null)
   const qc = useQueryClient()
 
   useEffect(() => {
@@ -940,11 +958,37 @@ export function useBoardEventsStream(
 
     let cancelled = false
     let backoffTimer: ReturnType<typeof setTimeout> | null = null
+    let invalidateTimer: ReturnType<typeof setTimeout> | null = null
+
+    const scheduleInvalidate = () => {
+      if (invalidateTimer) return // trailing-edge: one refetch per window
+      invalidateTimer = setTimeout(() => {
+        invalidateTimer = null
+        qc.invalidateQueries({ queryKey: boardKey(board) })
+      }, WS_INVALIDATE_DEBOUNCE_MS)
+    }
+
+    const scheduleReconnect = () => {
+      if (cancelled || backoffTimer) return
+      errorCountRef.current += 1
+      const delay = Math.min(
+        1000 * 2 ** Math.min(errorCountRef.current - 1, 4),
+        WS_MAX_BACKOFF_MS,
+      )
+      backoffTimer = setTimeout(() => {
+        backoffTimer = null
+        connect()
+      }, delay)
+    }
 
     const connect = () => {
       if (cancelled) return
       try {
-        const url = boardEventsWsUrl({ board, tenant, since })
+        const url = boardEventsWsUrl({
+          board,
+          tenant,
+          since: cursorRef.current ?? since,
+        })
         wsRef.current = new WebSocket(url)
       } catch {
         setConnected(false)
@@ -961,30 +1005,28 @@ export function useBoardEventsStream(
       ws.onmessage = (evt) => {
         try {
           const data = JSON.parse(String(evt.data)) as BoardEvent
+          if (typeof data.cursor === 'number') cursorRef.current = data.cursor
           setLastEvent(data)
-          // Invalidate board query so cards refresh live
-          qc.invalidateQueries({ queryKey: boardKey(board) })
+          scheduleInvalidate()
         } catch {
           // ignore malformed
         }
       }
 
+      // Reconnect is driven from `close` ONLY. The proxy ends the browser WS
+      // with a close frame (1011 on upstream connect failure, normal close
+      // when the upstream drops, e.g. a Hermes restart) — that fires just
+      // `close` in browsers, never `error`. And every transport `error` is
+      // always followed by `close`, so scheduling from both would double-book
+      // the backoff timer.
       ws.onerror = () => {
         setConnected(false)
-        errorCountRef.current += 1
-        if (wsRef.current) {
-          wsRef.current.close()
-          wsRef.current = null
-        }
-        const delay = Math.min(
-          1000 * 2 ** Math.min(errorCountRef.current - 1, 4),
-          WS_MAX_BACKOFF_MS,
-        )
-        backoffTimer = setTimeout(connect, delay)
       }
 
       ws.onclose = () => {
         setConnected(false)
+        if (wsRef.current === ws) wsRef.current = null
+        scheduleReconnect()
       }
     }
 
@@ -993,7 +1035,9 @@ export function useBoardEventsStream(
     return () => {
       cancelled = true
       if (backoffTimer) clearTimeout(backoffTimer)
+      if (invalidateTimer) clearTimeout(invalidateTimer)
       if (wsRef.current) {
+        // `cancelled` is set, so the close event this fires won't reconnect.
         wsRef.current.close()
         wsRef.current = null
       }

--- a/ui/src/dash/board/agent-chat.jsx
+++ b/ui/src/dash/board/agent-chat.jsx
@@ -10,11 +10,12 @@ function Icon(props) {
   return BI ? <BI {...props} /> : null;
 }
 
+// Grounded in real tools: board reads/mutations + slot/model/hardware reads.
 const AGENT_SUGGEST = window.AGENT_SUGGEST || [
   "what's blocked?",
+  "which slots are serving?",
   "triage everything",
-  "assign all ready tasks",
-  "free memory for img",
+  "how's the hardware doing?",
 ];
 
 // ─── Agent chat slide-out (the orchestrator) ──────────────────────────
@@ -26,55 +27,30 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
     ? chat
     : (window.__hal0UseBoardChat ? window.__hal0UseBoardChat() : null);
 
-  // live path
-  const messages = chatHook ? chatHook.messages : (window.AGENT_SEED || []);
-  const streaming = chatHook ? chatHook.streaming : false;
+  // NO STUB DATA (CONTRACTS.md hard rule): when the hook bridge isn't loaded
+  // the composer is disabled and the thread shows an unavailable notice —
+  // canned fake replies here used to mask a broken bridge as a working agent.
+  const displayMsgs = chatHook ? chatHook.messages : [];
+  const isTyping    = chatHook ? chatHook.streaming : false;
 
-  // local draft (send delegates to hook or stub)
   const [draft, setDraft] = useState("");
-
-  // stub state only used when hook absent
-  const [stubMsgs, setStubMsgs] = useState(window.AGENT_SEED || []);
-  const [stubTyping, setStubTyping] = useState(false);
-
   const threadRef = useRef(null);
 
   useEffect(() => {
     if (threadRef.current) threadRef.current.scrollTop = threadRef.current.scrollHeight;
-  }, [messages, stubMsgs, streaming, stubTyping]);
-
-  const stubReply = (q) => {
-    const lc = q.toLowerCase();
-    if (lc.includes("block")) return { body: "One task is blocked: the img slot can't claim GTT to load sdxl-turbo. It needs ~6.5 GB of unified-memory headroom. Everything else is healthy.", refs: [] };
-    if (lc.includes("triage")) return { body: "Triage tasks are being processed. I'll decompose anything over complexity threshold 3.", refs: [] };
-    if (lc.includes("assign") || lc.includes("ready")) return { body: "Ready tasks will be dispatched. Confirm and I'll claim them.", refs: [] };
-    if (lc.includes("memory") || lc.includes("free") || lc.includes("img")) return { body: "To free GTT for img I'd nuclear-evict the previous GPU tenant. Want me to queue the evict and retry the slot?", refs: [] };
-    return { body: "Tracked. I'll keep the board in sync and surface anything that needs your call.", refs: [] };
-  };
+  }, [displayMsgs, isTyping]);
 
   const send = (text) => {
     const t = (text || draft).trim();
-    if (!t) return;
+    if (!t || !chatHook) return;
     setDraft("");
-    if (chatHook) {
-      chatHook.send(t);
-      return;
-    }
-    // stub fallback
-    setStubMsgs(m => [...m, { role: "user", at: "just now", body: t, refs: [] }]);
-    setStubTyping(true);
-    setTimeout(() => {
-      const r = stubReply(t);
-      setStubTyping(false);
-      setStubMsgs(m => [...m, { role: "assistant", at: "just now", body: r.body, refs: r.refs }]);
-    }, 900);
+    chatHook.send(t);
   };
 
-  const displayMsgs = chatHook ? messages : stubMsgs;
-  const isTyping    = chatHook ? streaming : stubTyping;
-
-  const roleLabel = (role) => role === "assistant" ? "agent" : "operator";
-  const roleCls   = (role) => role === "assistant" ? "agent" : "operator";
+  // `tool` frames are the orchestrator's audited board mutations — label them
+  // as tool activity, not as operator messages.
+  const roleLabel = (role) => role === "assistant" ? "agent" : role === "tool" ? "tool" : "operator";
+  const roleCls   = (role) => role === "assistant" ? "agent" : role === "tool" ? "tool" : "operator";
 
   return (
     <React.Fragment>
@@ -82,20 +58,24 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
       <aside
         className="b-drawer chat"
         role="dialog"
-        aria-label="agent orchestrator"
+        aria-label="platform assistant"
         data-testid="board-chat"
       >
         <div className="b-drawer-h">
           <span className="dh-title">
             <span className="kdot live" style={{ "--st": "var(--ok)" }} />
-            agent · orchestrator
+            agent · platform assistant
           </span>
           <span className="spacer" />
           <span className="dh-x" onClick={onClose}><Icon name="close" /></span>
         </div>
 
         <div className="chat-thread" ref={threadRef}>
-          <div className="chat-intro">talks to the gateway dispatcher · acts on this board</div>
+          <div className="chat-intro">
+            {chatHook
+              ? "administers this hal0 instance · board · slots · models · settings"
+              : "chat backend unavailable — hook bridge not loaded"}
+          </div>
 
           {displayMsgs.map((m, i) => (
             <div
@@ -150,7 +130,8 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
         <div className="b-dr-composer">
           <textarea
             value={draft}
-            placeholder="Ask the orchestrator…  (Enter to send)"
+            disabled={!chatHook}
+            placeholder={chatHook ? "Ask the orchestrator…  (Enter to send)" : "chat unavailable"}
             data-testid="board-chat-input"
             onChange={e => setDraft(e.target.value)}
             onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); } }}
@@ -158,6 +139,7 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
           <button
             className="btn"
             data-testid="board-chat-send"
+            disabled={!chatHook}
             onClick={() => send()}
           >
             <Icon name="send" size={13} />Send

--- a/ui/src/dash/board/board-view.jsx
+++ b/ui/src/dash/board/board-view.jsx
@@ -24,6 +24,8 @@
 //   window.__hal0UseUpdateTask
 //   window.__hal0UseBulkTasks
 //   window.__hal0UseDeleteTask
+//   (board scope: the selected board slug threads through every hook —
+//   query, mutations, events WS — per the frozen ?board= contract)
 //   window.__hal0UseReassignTask
 //   window.__hal0UseNudgeDispatch
 //   window.__hal0UseSwitchBoard
@@ -90,7 +92,9 @@ const BOARD_LANES = [
   { id: "todo",      name: "To-do",     desc: "Specified + queued" },
   { id: "scheduled", name: "Scheduled", desc: "Time-triggered tasks" },
   { id: "ready",     name: "Ready",     desc: "Claimed, agent dispatching" },
-  { id: "running",   name: "Running",   desc: "Worker active" },
+  // Contract (CONTRACTS.md §Status/lane model): UI label for `running` is
+  // "In-progress" — the status VALUE stays `running` on the wire.
+  { id: "running",   name: "In-progress", desc: "Worker active" },
   { id: "blocked",   name: "Blocked",   desc: "Waiting for resource or input" },
   { id: "review",    name: "Review",    desc: "Needs operator sign-off" },
   { id: "done",      name: "Done",      desc: "Completed" },
@@ -99,6 +103,10 @@ const BOARD_LANES = [
   // via the bulk "archive" action and the task-drawer archive button.
   { id: "archived",  name: "Archived",  desc: "Archived tasks" },
 ];
+
+// Published for the drawer's stName() (task-drawer.jsx reads window.LANE to
+// render lane display names — without this it falls back to raw status ids).
+window.LANE = Object.fromEntries(BOARD_LANES.map(l => [l.id, l]));
 
 // ─── Lightweight dropdown (filter selects) ────────────────────────────────────
 function BoardSelect({ label, value, options, onChange, width }) {
@@ -162,6 +170,7 @@ function BoardView() {
   const useBoardOrchestration = window.__hal0UseBoardOrchestration;
   const useBoardConfig      = window.__hal0UseBoardConfig;
   const useUpdateTask       = window.__hal0UseUpdateTask;
+  const useBulkTasks        = window.__hal0UseBulkTasks;
   const useDeleteTask       = window.__hal0UseDeleteTask;
   const useReassignTask     = window.__hal0UseReassignTask;
   const useNudgeDispatch    = window.__hal0UseNudgeDispatch;
@@ -170,25 +179,36 @@ function BoardView() {
   const useCreateTask       = window.__hal0UseCreateTask;
   const useBoardEventsStream = window.__hal0UseBoardEventsStream;
 
-  // ── keep WS stream alive ──
-  useBoardEventsStream && useBoardEventsStream();
+  // ── board scope (declared before the queries that thread it) ──
+  // null = the server's current board (omit ?board=, per contract). Set only
+  // on an explicit switch so a fresh mount follows whatever Hermes considers
+  // current instead of assuming a "default" slug exists.
+  const [board, setBoard]           = useState(null);
+  const [showArchived, setShowArchived] = useState(false);
+  const boardArg = board || undefined;
+
+  // ── keep WS stream alive (scoped to the selected board) ──
+  useBoardEventsStream && useBoardEventsStream({ board: boardArg });
 
   // ── data queries ──
-  const boardViewQ    = useBoardView ? useBoardView({}) : { data: null };
+  const boardViewQ    = useBoardView
+    ? useBoardView({ board: boardArg, includeArchived: showArchived })
+    : { data: null };
   const boardsQ       = useBoards    ? useBoards()       : { data: null };
   const profilesQ     = useBoardProfiles ? useBoardProfiles() : { data: null };
-  const assigneesQ    = useBoardAssignees ? useBoardAssignees() : { data: null };
+  const assigneesQ    = useBoardAssignees ? useBoardAssignees(boardArg) : { data: null };
   const orchQ         = useBoardOrchestration ? useBoardOrchestration() : { data: null };
   const configQ       = useBoardConfig ? useBoardConfig() : { data: null };
 
-  // ── mutations ──
-  const updateTask  = useUpdateTask  ? useUpdateTask()  : null;
-  const deleteTask  = useDeleteTask  ? useDeleteTask()  : null;
-  const reassignTask = useReassignTask ? useReassignTask() : null;
+  // ── mutations (board-scoped so ?board= + cache invalidation line up) ──
+  const updateTask  = useUpdateTask  ? useUpdateTask(boardArg)  : null;
+  const bulkTasks   = useBulkTasks   ? useBulkTasks(boardArg)   : null;
+  const deleteTask  = useDeleteTask  ? useDeleteTask(boardArg)  : null;
+  const reassignTask = useReassignTask ? useReassignTask(boardArg) : null;
   const nudge       = useNudgeDispatch ? useNudgeDispatch() : null;
   const switchBoard = useSwitchBoard ? useSwitchBoard()  : null;
   const createBoard = useCreateBoard ? useCreateBoard()  : null;
-  const createTask  = useCreateTask  ? useCreateTask()   : null;
+  const createTask  = useCreateTask  ? useCreateTask(boardArg)   : null;
   // The agent-chat slide-out (and its persistent conversation hook) now lives
   // in App (main.jsx) so it can be triggered from anywhere in the dash, not
   // just this page. The board's chat button toggles that global slide-out via
@@ -196,17 +216,17 @@ function BoardView() {
   // state. byId is published below so the global chat can resolve task refs.
 
   // ── local state ──
-  const [board, setBoard]           = useState("default");
   const [boardMenu, setBoardMenu]   = useState(false);
   const [newBoard, setNewBoard]     = useState(false);
 
   const [orchOpen, setOrchOpen]     = useState(false);
-  const [orch, setOrch]             = useState({ mode: "auto", tickInterval: 30, failureLimit: 3, maxInflight: 4, claimTtl: 120 });
+  // Popover fallback seed only — live values come from GET /orchestration.
+  const [orch, setOrch]             = useState({});
 
   const [search, setSearch]         = useState("");
   const [tenant, setTenant]         = useState("all");
   const [profile, setProfile]       = useState("all");
-  const [showArchived, setShowArchived] = useState(false);
+  const [attnOnly, setAttnOnly]     = useState(false);
   const [byProfile, setByProfile]   = useState(true);
 
   const [sel, setSel]               = useState(() => new Set());
@@ -222,7 +242,7 @@ function BoardView() {
 
   const [dragId, setDragId]         = useState(null);
   const [dragOver, setDragOver]     = useState(null);
-  const [delArmed, setDelArmed]     = useState(false);
+  const [archArmed, setArchArmed]   = useState(false);
 
   // ── reassign local state (for bulk reassign select) ──
   const [reassignTarget, setReassignTarget] = useState("");
@@ -282,6 +302,7 @@ function BoardView() {
     )) return false;
     if (tenant !== "all" && t.tenant !== tenant) return false;
     if (profile !== "all" && t.assignee !== profile) return false;
+    if (attnOnly && t.status !== "blocked" && t.status !== "review") return false;
     return true;
   };
 
@@ -294,7 +315,7 @@ function BoardView() {
 
   const visibleIds = useMemo(() =>
     tasks.filter(t => (t.status !== "archived" || showArchived) && matches(t)).map(t => t.id),
-    [tasks, search, tenant, profile, showArchived]
+    [tasks, search, tenant, profile, attnOnly, showArchived]
   );
 
   const attnTasks = tasks.filter(t => t.status === "blocked" || t.status === "review");
@@ -304,9 +325,13 @@ function BoardView() {
   const clearSel  = () => setSel(new Set());
   const selectAllVisible = () => setSel(new Set(visibleIds));
 
-  // ── mutations: bulk move via N updateTask PATCHes ──
+  // ── mutations: multi-card moves ride the audited POST /tasks/bulk (one
+  // round-trip, one audit row); single-card moves stay on PATCH so the
+  // optimistic drag update applies. ──
   const moveTo = (ids, status) => {
-    if (updateTask) {
+    if (ids.length > 1 && bulkTasks) {
+      bulkTasks.mutate({ ids, update: { status } });
+    } else if (updateTask) {
       ids.forEach(id => updateTask.mutate({ id, body: { status } }));
     }
   };
@@ -339,6 +364,7 @@ function BoardView() {
   };
 
   const doRefresh = () => {
+    if (boardViewQ && boardViewQ.refetch) boardViewQ.refetch();
     toast("board refreshed");
   };
 
@@ -351,7 +377,7 @@ function BoardView() {
       e.dataTransfer.effectAllowed = "move";
       try { e.dataTransfer.setData("text/plain", task.id); } catch (_) {}
     },
-    onDragEnd: () => { setDragId(null); setDragOver(null); setDelArmed(false); },
+    onDragEnd: () => { setDragId(null); setDragOver(null); setArchArmed(false); },
     onDrop: (laneId) => {
       if (dragId) {
         moveTo([dragId], laneId);
@@ -362,8 +388,8 @@ function BoardView() {
     },
   };
 
-  const clearFilters = () => { setSearch(""); setTenant("all"); setProfile("all"); setShowArchived(false); };
-  const anyFilter = search || tenant !== "all" || profile !== "all" || showArchived;
+  const clearFilters = () => { setSearch(""); setTenant("all"); setProfile("all"); setAttnOnly(false); setShowArchived(false); };
+  const anyFilter = search || tenant !== "all" || profile !== "all" || attnOnly || showArchived;
 
   // ── window component lookups ──
   const TaskDrawer     = window.TaskDrawer;
@@ -457,13 +483,16 @@ function BoardView() {
             {/* orchestration row */}
             <div className="orch-row">
               <div className="board-select" style={{ position: "relative" }}>
+                {/* The pill shows the REAL orchestrator profile from GET
+                    /orchestration. (An earlier version rendered a `mode`
+                    field the server never returns — a fabricated value.) */}
                 <div
-                  className={"orch-pill" + ((orchData.mode === "manual") ? " manual" : "")}
+                  className="orch-pill"
                   onClick={() => setOrchOpen(o => !o)}
                 >
                   <span className="od" />
                   <span className="k">Orchestration</span>
-                  <span className="v">{orchData.mode ?? "auto"}</span>
+                  <span className="v">{orchData.orchestrator_profile || "unset"}</span>
                 </div>
                 {orchOpen && (
                   <React.Fragment>
@@ -492,7 +521,7 @@ function BoardView() {
                 <span className="spacer" />
                 <button
                   className="ab"
-                  onClick={() => { setTenant("all"); setProfile("all"); setSearch(""); toast("filtered to attention"); }}
+                  onClick={() => { setTenant("all"); setProfile("all"); setSearch(""); setAttnOnly(true); toast("filtered to attention"); }}
                 >Show</button>
                 <span className="axc" onClick={() => setAttn(false)}>
                   <BoardIcon name="close" size={14} />
@@ -595,29 +624,31 @@ function BoardView() {
             )}
           </div>
 
-          {/* lanes — dropping a card ANYWHERE outside a column deletes it.
+          {/* lanes — dropping a card ANYWHERE outside a column ARCHIVES it
+              (recoverable via "Show archived"; a missed lane target must
+              never hard-delete the row — Hermes owns comments/runs/links).
               While a drag is over the board background (not a lane) the
-              danger veil below arms; releasing there removes the card. */}
+              archive veil below arms; releasing there archives the card. */}
           <div
             className="lanes-scroll"
-            data-testid="board-drop-delete"
+            data-testid="board-drop-archive"
             onDragOver={(e) => {
               if (!dragId) return;
               const overLane = e.target.closest && e.target.closest(".lane");
               e.preventDefault();
-              setDelArmed(!overLane);
+              setArchArmed(!overLane);
             }}
             onDrop={(e) => {
               if (!dragId) return;
               const overLane = e.target.closest && e.target.closest(".lane");
               if (!overLane) {
                 e.preventDefault();
-                delTasks([dragId]);
-                toast(dragId + " deleted");
+                moveTo([dragId], "archived");
+                toast(dragId + " archived");
               }
               setDragId(null);
               setDragOver(null);
-              setDelArmed(false);
+              setArchArmed(false);
             }}
           >
             <div className="lanes">
@@ -641,13 +672,13 @@ function BoardView() {
           </div>
         </div>
 
-        {/* danger veil — pointer-events:none so the drop still lands on the
+        {/* archive veil — pointer-events:none so the drop still lands on the
             lanes-scroll background underneath; purely a visual cue. */}
-        {dragId && delArmed && (
-          <div className="danger-veil" data-testid="board-danger-veil" aria-hidden="true">
-            <div className="danger-badge">
-              <BoardIcon name="trash" size={34} />
-              <span>Release to delete</span>
+        {dragId && archArmed && (
+          <div className="archive-veil" data-testid="board-archive-veil" aria-hidden="true">
+            <div className="archive-badge">
+              <BoardIcon name="archive" size={34} />
+              <span>Release to archive</span>
             </div>
           </div>
         )}
@@ -659,6 +690,7 @@ function BoardView() {
           key={opened.id}
           task={opened}
           byId={byId}
+          board={boardArg}
           onClose={() => setOpenTask(null)}
           onOpenTask={(id) => setOpenTask(id)}
           onToast={toast}
@@ -683,7 +715,15 @@ function BoardView() {
               if (createTask) {
                 createTask.mutate(
                   { ...fields, status: laneId },
-                  { onSuccess: () => toast('task "' + fields.title + '" created in ' + laneId) }
+                  {
+                    onSuccess: (res) => {
+                      toast('task "' + fields.title + '" created in ' + laneId);
+                      // Hermes flags creation with no dispatcher running via a
+                      // `warning` on the result — surface it, don't swallow it.
+                      const warn = res && (res.warning || (res.task && res.task.warning));
+                      if (warn) toast(String(warn), "warn");
+                    },
+                  }
                 );
               }
             }}

--- a/ui/src/dash/board/board.css
+++ b/ui/src/dash/board/board.css
@@ -226,11 +226,12 @@
 .board[data-meta="off"] .kc-id { display: none; }
 .board[data-meta="off"] .kc-when { display: none; }
 
-/* drag-to-delete danger veil — shown while a card is dragged over the board
+/* drag-to-archive veil — shown while a card is dragged over the board
    background (outside any column). pointer-events:none so the drop still
-   reaches the lanes-scroll handler underneath. */
-.board .danger-veil { position: fixed; inset: 0; z-index: 110; pointer-events: none; display: flex; align-items: center; justify-content: center; background: radial-gradient(ellipse at center, rgba(0,0,0,0) 32%, var(--err-soft) 100%); animation: board-fade-in var(--dur) var(--ease); }
-.board .danger-badge { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 22px 30px; border: 1px solid var(--err-line); border-radius: var(--rad-lg); background: var(--err-soft); color: var(--err); font-family: var(--jbm); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; box-shadow: var(--shadow-menu); }
+   reaches the lanes-scroll handler underneath. Amber accent, not destructive
+   red: the drop archives (recoverable via "Show archived"), it never deletes. */
+.board .archive-veil { position: fixed; inset: 0; z-index: 110; pointer-events: none; display: flex; align-items: center; justify-content: center; background: radial-gradient(ellipse at center, rgba(0,0,0,0) 32%, var(--accent-soft) 100%); animation: board-fade-in var(--dur) var(--ease); }
+.board .archive-badge { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 22px 30px; border: 1px solid var(--accent-line); border-radius: var(--rad-lg); background: var(--accent-soft); color: var(--accent); font-family: var(--jbm); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; box-shadow: var(--shadow-menu); }
 
 /* ─── Drawer scrim (position:fixed — intentionally unscoped) ─────────── */
 .b-drawer-scrim { position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 90; animation: board-fade-in var(--dur) var(--ease); }
@@ -338,6 +339,10 @@
 .b-drawer .msg-ref { display: inline-flex; align-items: center; gap: 6px; font-family: var(--jbm); font-size: 10.5px; color: var(--fg-2); border: 1px solid var(--line-strong); border-radius: var(--rad-sm); padding: 2px 7px; cursor: pointer; background: var(--bg-1); }
 .b-drawer .msg-ref:hover { border-color: var(--accent-line); color: var(--accent); }
 .b-drawer .msg-ref .kdot { width: 5px; height: 5px; }
+/* tool frames — the orchestrator's audited board mutations: compact + mono */
+.b-drawer .msg.tool { align-self: flex-start; max-width: 100%; }
+.b-drawer .msg.tool .msg-meta .who { color: var(--info); }
+.b-drawer .msg.tool .msg-b { background: var(--bg-1); border-style: dashed; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); word-break: break-word; }
 .b-drawer .chat-suggest { display: flex; flex-wrap: wrap; gap: 7px; padding: 0 14px 10px; flex-shrink: 0; }
 .b-drawer .sugg { font-family: var(--jbm); font-size: 11px; color: var(--fg-3); border: 1px solid var(--line); border-radius: var(--rad-pill); padding: 5px 11px; cursor: pointer; background: var(--bg); }
 .b-drawer .sugg:hover { border-color: var(--accent-line); color: var(--accent); }
@@ -437,5 +442,17 @@
 
   .board .lanes-scroll {
     padding: 4px 16px 0;
+  }
+}
+
+/* ─── A11y: reduced motion ───────────────────────────────────────────── */
+/* Kill the pulse/typing loops for reduced-motion users (acceptance gate in
+   CONTRACTS.md). Colour + glow stay so the state signal survives without
+   motion; the dashboard-wide guard only covers .dot.*, not the board's kdot. */
+@media (prefers-reduced-motion: reduce) {
+  .board .kdot.live,
+  .board[data-accent="dot"] .st-running .kc-dot,
+  .b-drawer .typing i {
+    animation: none;
   }
 }

--- a/ui/src/dash/board/kcard.jsx
+++ b/ui/src/dash/board/kcard.jsx
@@ -13,6 +13,10 @@ const { useState, useCallback } = React;
 function BoardCard({ task, selected, onToggle, onOpen, isOpen, onDragStart, onDragEnd }) {
   const BoardIcon = window.BoardIcon;
 
+  // depCount is "done/total" (e.g. "2/3", "10/12") — split on the slash;
+  // char-indexing broke for counts of 10+.
+  const dep = task.depCount ? String(task.depCount).split("/") : null;
+
   return (
     <div
       className={
@@ -43,8 +47,8 @@ function BoardCard({ task, selected, onToggle, onOpen, isOpen, onDragStart, onDr
               {BoardIcon && <BoardIcon name="flag" size={12} />}
             </span>
           )}
-          {task.depCount && (
-            <span className={"kc-dep" + (task.depCount[0] !== task.depCount[2] ? " warn" : "")}>
+          {dep && (
+            <span className={"kc-dep" + (dep[0] !== dep[1] ? " warn" : "")}>
               {BoardIcon && <BoardIcon name="dep" size={11} />}
               {task.depCount}
             </span>

--- a/ui/src/dash/board/orchestration-popover.jsx
+++ b/ui/src/dash/board/orchestration-popover.jsx
@@ -35,9 +35,12 @@
     const useUpdateOrch = window.__hal0UseUpdateOrchestration;
     const updateOrch = useUpdateOrch ? useUpdateOrch() : null;
 
-    // Local editable state seeded from live orchData (fallback to prop orch)
+    // Local editable state seeded from live orchData (fallback to prop orch).
+    // NOTE: there is no `mode` knob — GET/PUT /orchestration carry exactly 4
+    // fields (orchestrator_profile, default_assignee, auto_decompose,
+    // auto_promote_children). The old auto/manual segment rendered and PUT a
+    // field the server neither returns nor accepts.
     const src = orchData || orch || {};
-    const [mode, setMode] = useState(src.mode || "auto");
     const [profile, setProfile] = useState(src.orchestrator_profile || "");
     const [assignee, setAssignee] = useState(src.default_assignee || "");
     const [autoDecompose, setAutoDecompose] = useState(
@@ -53,7 +56,6 @@
 
     const handleSave = () => {
       const patch = {
-        mode,
         orchestrator_profile: profile,
         default_assignee: assignee,
         auto_decompose: autoDecompose,
@@ -82,12 +84,12 @@
         onClick={(e) => e.stopPropagation()}
         data-testid="board-orch-popover"
       >
-        {/* header */}
+        {/* header — shows the live orchestrator profile (a real value) */}
         <div className="orch-pop-h">
           <span className="t">Orchestration</span>
           <span className="st">
             <span className="dot" />
-            {mode === "auto" ? "dispatching" : "paused"}
+            {profile || "unset"}
           </span>
           {onClose && (
             <span className="x" onClick={onClose} style={{ marginLeft: "auto", cursor: "pointer" }}>
@@ -97,24 +99,6 @@
         </div>
 
         <div className="orch-pop-b">
-          {/* mode seg — editable */}
-          <div className="orch-mode">
-            <div
-              className={"orch-seg" + (mode === "auto" ? " on" : "")}
-              onClick={() => setMode("auto")}
-              data-testid="board-orch-mode-auto"
-            >
-              auto
-            </div>
-            <div
-              className={"orch-seg" + (mode === "manual" ? " on" : "")}
-              onClick={() => setMode("manual")}
-              data-testid="board-orch-mode-manual"
-            >
-              manual
-            </div>
-          </div>
-
           {/* orchestrator_profile — editable dropdown */}
           <div className="orch-set">
             <div>

--- a/ui/src/dash/board/task-drawer.jsx
+++ b/ui/src/dash/board/task-drawer.jsx
@@ -21,7 +21,7 @@ const stName = (s) => {
 const liveDot = (s) => "kdot" + (s === "running" ? " live" : " glow");
 
 // ─── Task detail drawer ────────────────────────────────────────────────
-function TaskDrawer({ task, byId, onClose, onOpenTask }) {
+function TaskDrawer({ task, byId, onClose, onOpenTask, board }) {
   const toast = (msg) => { if (window.__hal0Toast) window.__hal0Toast(msg); };
 
   // prefer live hook; fall back to prop. useBoardTask returns a TanStack
@@ -33,13 +33,14 @@ function TaskDrawer({ task, byId, onClose, onOpenTask }) {
   const [parentSelect, setParentSelect] = useState("");
   const [childSelect, setChildSelect] = useState("");
 
-  // mutations (guarded)
-  const updateTask = window.__hal0UseUpdateTask ? window.__hal0UseUpdateTask() : null;
-  const addComment = window.__hal0UseAddComment ? window.__hal0UseAddComment() : null;
-  const addLink    = window.__hal0UseAddLink    ? window.__hal0UseAddLink()    : null;
-  const removeLink = window.__hal0UseRemoveLink ? window.__hal0UseRemoveLink() : null;
-  const specifyTask   = window.__hal0UseSpecifyTask   ? window.__hal0UseSpecifyTask()   : null;
-  const decomposeTask = window.__hal0UseDecomposeTask ? window.__hal0UseDecomposeTask() : null;
+  // mutations (guarded; board threads through so ?board= + the cache
+  // invalidation key match the view the operator is looking at)
+  const updateTask = window.__hal0UseUpdateTask ? window.__hal0UseUpdateTask(board) : null;
+  const addComment = window.__hal0UseAddComment ? window.__hal0UseAddComment(board) : null;
+  const addLink    = window.__hal0UseAddLink    ? window.__hal0UseAddLink(board)    : null;
+  const removeLink = window.__hal0UseRemoveLink ? window.__hal0UseRemoveLink(board) : null;
+  const specifyTask   = window.__hal0UseSpecifyTask   ? window.__hal0UseSpecifyTask(board)   : null;
+  const decomposeTask = window.__hal0UseDecomposeTask ? window.__hal0UseDecomposeTask(board) : null;
 
   // worker log (pull-only)
   const logHook = window.__hal0UseBoardTaskLog ? window.__hal0UseBoardTaskLog(t.id) : null;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -24,6 +24,17 @@
 //    in this file would execute AFTER the dash imports.
 import './globals-install'
 
+// Self-hosted fonts (package.json shipped these but nothing imported them,
+// so the dashboard silently depended on the fonts.googleapis.com <link> in
+// index.html — a per-load external fetch on what is a local-first LAN
+// appliance, and offline it stalls then falls back). The CSS font stacks
+// already list "Geist Variable" / "JetBrains Mono" (dashboard.css --geist /
+// --jbm), so bundling the files makes them deterministic.
+import '@fontsource-variable/geist'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource/jetbrains-mono/600.css'
+
 // 2) Side-effect imports — order matches the original script tags in
 //    `hal0 v2 dashboard.html`. Each module installs its components on
 //    `window` via `Object.assign(window, …)`.

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -134,8 +134,8 @@ export async function installDefaultMocks(page: Page, state: MockState) {
     json(route, BOARD_PROFILES),
   )
 
-  // GET /api/board/assignees?board=
-  await page.route('**/api/board/assignees', (route) =>
+  // GET /api/board/assignees?board=  (regex: the ?board= query must match)
+  await page.route(/\/api\/board\/assignees(\?|$)/, (route) =>
     json(route, BOARD_ASSIGNEES),
   )
 
@@ -165,13 +165,15 @@ export async function installDefaultMocks(page: Page, state: MockState) {
     json(route, { dispatched: 1 }),
   )
 
-  // POST /api/board/tasks/bulk (must be before /tasks/:id patterns)
-  await page.route('**/api/board/tasks/bulk', (route) =>
+  // POST /api/board/tasks/bulk?board= (must be before /tasks/:id patterns;
+  // regex so the optional ?board= query matches)
+  await page.route(/\/api\/board\/tasks\/bulk(\?|$)/, (route) =>
     json(route, { updated: 0 }),
   )
 
-  // POST /api/board/links  +  DELETE /api/board/links (body-DELETE)
-  await page.route('**/api/board/links', (route) => {
+  // POST /api/board/links  +  DELETE /api/board/links?parent_id=&child_id=
+  // (regex: DELETE carries its ids as QUERY params per the backend contract)
+  await page.route(/\/api\/board\/links(\?|$)/, (route) => {
     const method = route.request().method()
     if (method === 'POST')   return json(route, { ok: true }, 201)
     if (method === 'DELETE') return json(route, { ok: true })
@@ -213,8 +215,9 @@ export async function installDefaultMocks(page: Page, state: MockState) {
     return json(route, {})
   })
 
-  // POST /api/board/tasks (create)
-  await page.route('**/api/board/tasks', (route) => {
+  // POST /api/board/tasks (create; regex so an optional ?board= matches —
+  // trailing (\?|$) keeps /tasks/:id out of this route)
+  await page.route(/\/api\/board\/tasks(\?|$)/, (route) => {
     if (route.request().method() === 'POST') {
       const body = route.request().postDataJSON?.() ?? {}
       const newTask = {
@@ -244,8 +247,9 @@ export async function installDefaultMocks(page: Page, state: MockState) {
     json(route, { ok: true }),
   )
 
-  // GET /api/board/board (main board view — lanes format)
-  await page.route('**/api/board/board', (route) => {
+  // GET /api/board/board?board=&include_archived= (main board view — lanes
+  // format; regex so the query params the hook now threads actually match)
+  await page.route(/\/api\/board\/board(\?|$)/, (route) => {
     const url = route.request().url()
     const includeArchived = url.includes('include_archived=true')
     return json(route, makeBoardLanesResponse(includeArchived))

--- a/ui/tests/e2e/specs/board-bulk-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-bulk-v3.spec.ts
@@ -6,9 +6,10 @@
  *   - reassign → POST /tasks/<id>/reassign body {assignee}
  *   - select-all / clear selection
  *
- * For PATCH-based status moves the test asserts N individual PATCH calls
- * (one per selected task id) with the correct {status} body — this matches
- * the moveTo() implementation in board-view.jsx.
+ * Multi-select status moves ride ONE audited POST /tasks/bulk with
+ * {ids, update:{status}} — this matches the moveTo() implementation in
+ * board-view.jsx (single-card moves stay on per-task PATCH for the
+ * optimistic drag path; delete has no bulk upstream and stays per-id).
  *
  * Card selection is via .kc-check (the checkbox element inside each card).
  */
@@ -17,6 +18,21 @@ import { test, expect, json } from '../fixtures/apiMock'
 import { BOARD_TASKS } from '../fixtures/mock-data'
 
 const FIVE_S = 5_500
+
+// Route + capture POST /api/board/tasks/bulk bodies. Registered by each test
+// BEFORE navigation so it wins over apiMock's stub for the same path.
+async function captureBulk(page: any): Promise<any[]> {
+  const bodies: any[] = []
+  await page.route(/\/api\/board\/tasks\/bulk/, async (route: any) => {
+    if (route.request().method() === 'POST') {
+      bodies.push(route.request().postDataJSON())
+      await json(route, { updated: bodies[bodies.length - 1]?.ids?.length ?? 0 })
+    } else {
+      await route.fallback()
+    }
+  })
+  return bodies
+}
 
 async function gotoBoardAndWait(page: any) {
   await page.goto('/#board')
@@ -46,18 +62,9 @@ test.describe('BoardView — bulk actions', () => {
     await expect(bulkbar).toContainText('2 selected')
   })
 
-  test('bulk → todo: fires PATCH {status:"todo"} per selected id', async ({ page }) => {
+  test('bulk → todo: fires ONE POST /tasks/bulk {ids, update:{status:"todo"}}', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'ready').slice(0, 2)
-    const patchBodies: any[] = []
-
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'PATCH') {
-        patchBodies.push(route.request().postDataJSON())
-        await json(route, { ok: true })
-      } else {
-        await route.fallback()
-      }
-    })
+    const bulkBodies = await captureBulk(page)
 
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
@@ -65,57 +72,42 @@ test.describe('BoardView — bulk actions', () => {
     await page.locator('[data-testid="board-action-todo"]').click()
     await page.waitForTimeout(300)
 
-    expect(patchBodies.length).toBeGreaterThanOrEqual(2)
-    expect(patchBodies.every(b => b.status === 'todo')).toBe(true)
+    expect(bulkBodies.length).toBe(1)
+    expect(bulkBodies[0].update).toMatchObject({ status: 'todo' })
+    expect(bulkBodies[0].ids.sort()).toEqual(targets.map(t => t.id).sort())
   })
 
-  test('bulk → ready: fires PATCH {status:"ready"} per selected id', async ({ page }) => {
+  test('bulk → ready: fires POST /tasks/bulk {update:{status:"ready"}}', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'todo').slice(0, 2)
-    const patchBodies: any[] = []
-
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'PATCH') {
-        patchBodies.push(route.request().postDataJSON())
-        await json(route, { ok: true })
-      } else {
-        await route.fallback()
-      }
-    })
+    const bulkBodies = await captureBulk(page)
 
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
     await page.locator('[data-testid="board-action-ready"]').click()
     await page.waitForTimeout(300)
 
-    expect(patchBodies.some(b => b.status === 'ready')).toBe(true)
+    expect(bulkBodies.some(b => b.update?.status === 'ready')).toBe(true)
   })
 
-  test('bulk → block: fires PATCH {status:"blocked"} per selected id', async ({ page }) => {
+  test('bulk → block: fires POST /tasks/bulk {update:{status:"blocked"}}', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'todo').slice(0, 2)
-    const patchBodies: any[] = []
-
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'PATCH') {
-        patchBodies.push(route.request().postDataJSON())
-        await json(route, { ok: true })
-      } else {
-        await route.fallback()
-      }
-    })
+    const bulkBodies = await captureBulk(page)
 
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
     await page.locator('[data-testid="board-action-block"]').click()
     await page.waitForTimeout(300)
 
-    expect(patchBodies.some(b => b.status === 'blocked')).toBe(true)
+    expect(bulkBodies.some(b => b.update?.status === 'blocked')).toBe(true)
   })
 
-  test('bulk → unblock: fires PATCH {status:"todo"} (unblock = move to todo)', async ({ page }) => {
+  test('bulk → unblock (single selection): stays on per-task PATCH', async ({ page }) => {
+    // One selected card = single-task path (optimistic PATCH), not bulk.
     const targets = BOARD_TASKS.filter(t => t.status === 'blocked').slice(0, 1)
     const patchBodies: any[] = []
+    const bulkBodies = await captureBulk(page)
 
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
+    await page.route(/\/api\/board\/tasks\/(?!bulk)[^/]+$/, async (route) => {
       if (route.request().method() === 'PATCH') {
         patchBodies.push(route.request().postDataJSON())
         await json(route, { ok: true })
@@ -130,48 +122,31 @@ test.describe('BoardView — bulk actions', () => {
     await page.waitForTimeout(300)
 
     expect(patchBodies.some(b => b.status === 'todo')).toBe(true)
+    expect(bulkBodies.length).toBe(0)
   })
 
-  test('bulk → complete: fires PATCH {status:"done"}', async ({ page }) => {
+  test('bulk → complete: fires POST /tasks/bulk {update:{status:"done"}}', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'ready').slice(0, 2)
-    const patchBodies: any[] = []
-
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'PATCH') {
-        patchBodies.push(route.request().postDataJSON())
-        await json(route, { ok: true })
-      } else {
-        await route.fallback()
-      }
-    })
+    const bulkBodies = await captureBulk(page)
 
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
     await page.locator('[data-testid="board-action-complete"]').click()
     await page.waitForTimeout(300)
 
-    expect(patchBodies.some(b => b.status === 'done')).toBe(true)
+    expect(bulkBodies.some(b => b.update?.status === 'done')).toBe(true)
   })
 
-  test('bulk → archive: fires PATCH {status:"archived"}', async ({ page }) => {
+  test('bulk → archive: fires POST /tasks/bulk {update:{status:"archived"}}', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'done').slice(0, 2)
-    const patchBodies: any[] = []
-
-    await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'PATCH') {
-        patchBodies.push(route.request().postDataJSON())
-        await json(route, { ok: true })
-      } else {
-        await route.fallback()
-      }
-    })
+    const bulkBodies = await captureBulk(page)
 
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
     await page.locator('[data-testid="board-action-archive"]').click()
     await page.waitForTimeout(300)
 
-    expect(patchBodies.some(b => b.status === 'archived')).toBe(true)
+    expect(bulkBodies.some(b => b.update?.status === 'archived')).toBe(true)
   })
 
   test('bulk → delete: fires DELETE per selected id', async ({ page }) => {

--- a/ui/tests/e2e/specs/board-chat-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-chat-v3.spec.ts
@@ -116,13 +116,14 @@ test.describe('BoardView — agent chat', () => {
     await expect(page.locator('[data-testid="board-chat-msg"]').nth(1)).toContainText('Persisted reply')
   })
 
-  // ── Send via stub (no hook) ────────────────────────────────────────────
-  // When __hal0UseBoardChat is absent the stub path is used (typing reply + setTimeout).
-  // The spec uses the mock SSE route which makes the hook present.
+  // ── No hook → honest unavailable state (NO STUB DATA hard rule) ────────
+  // When __hal0UseBoardChat is absent the composer is DISABLED and the thread
+  // shows an unavailable notice. The old canned-reply stub path masked a
+  // broken hook bridge as a working agent.
 
-  test('stub path: suggestion chip sends message and stub reply appears', async ({ page }) => {
-    // Block the chat hook so stub path fires (delete alone won't work —
-    // board-hook-bridge.ts sets it after all init scripts; use defineProperty to prevent that)
+  test('missing hook: composer disabled + unavailable notice, no fake replies', async ({ page }) => {
+    // Block the chat hook (delete alone won't work — board-hook-bridge.ts
+    // sets it after all init scripts; use defineProperty to prevent that)
     await page.addInitScript(() => {
       Object.defineProperty(window, '__hal0UseBoardChat', {
         get: () => undefined,
@@ -134,13 +135,13 @@ test.describe('BoardView — agent chat', () => {
     await gotoBoardAndWait(page)
     await openChat(page)
 
-    // Click first suggestion chip
+    await expect(page.locator('[data-testid="board-chat"] .chat-intro')).toContainText('unavailable')
+    await expect(page.locator('[data-testid="board-chat-input"]')).toBeDisabled()
+    await expect(page.locator('[data-testid="board-chat-send"]')).toBeDisabled()
+    // Clicking a suggestion chip must NOT fabricate a reply.
     await page.locator('[data-testid="board-chat-suggest-0"]').click()
-    // User message should appear
-    const msgs = page.locator('[data-testid="board-chat-msg"]')
-    await expect(msgs.first()).toBeVisible({ timeout: FIVE_S })
-    // After ~1s the stub reply appears
-    await expect(msgs).toHaveCount(2, { timeout: 3000 })
+    await page.waitForTimeout(1200)
+    await expect(page.locator('[data-testid="board-chat-msg"]')).toHaveCount(0)
   })
 
   // ── SSE streaming path ────────────────────────────────────────────────
@@ -240,30 +241,37 @@ test.describe('BoardView — agent chat', () => {
     await expect(msgs.nth(1)).toContainText('Moving task')
   })
 
+  // Ref-chip rendering is driven through a CONTROLLED hook (the stub-reply
+  // path is gone): pin __hal0UseBoardChat to a fake returning messages with
+  // refs, exercising the real render path in AgentChat.
+
+  // NOTE: addInitScript serialises the function — it must not close over
+  // spec-scope variables; everything rides in the single argument.
+  const pinChatHookWithRefs = ({ id, body }: { id: string; body: string }) => {
+    const fakeHook = () => ({
+      messages: [{ role: 'assistant', at: 'just now', body, refs: [id] }],
+      send: () => {},
+      streaming: false,
+    })
+    Object.defineProperty(window, '__hal0UseBoardChat', {
+      get: () => fakeHook,
+      set: () => {},
+      configurable: false,
+    })
+  }
+
   test('chat ref chip (board-chat-ref-<id>) renders when refs present', async ({ page }) => {
     const refTask = BOARD_TASKS.find(t => t.status === 'blocked')!
 
-    // Block hook so stub path fires with refs
-    await page.addInitScript((id: string) => {
-      ;(window as any).AGENT_SEED = [
-        {
-          role: 'assistant',
-          at: 'just now',
-          body: 'Blocked task needs attention.',
-          refs: [id],
-        },
-      ]
-      Object.defineProperty(window, '__hal0UseBoardChat', {
-        get: () => undefined,
-        set: () => {},
-        configurable: false,
-      })
-    }, refTask.id)
+    await page.addInitScript(pinChatHookWithRefs, {
+      id: refTask.id,
+      body: 'Blocked task needs attention.',
+    })
 
     await gotoBoardAndWait(page)
     await openChat(page)
 
-    // Ref chip for the blocked task should be visible in the seeded message
+    // Ref chip for the blocked task should be visible in the hook's message
     const refChip = page.locator(`[data-testid="board-chat-ref-${refTask.id}"]`)
     await expect(refChip).toBeVisible({ timeout: FIVE_S })
   })
@@ -271,21 +279,7 @@ test.describe('BoardView — agent chat', () => {
   test('clicking ref chip opens task drawer', async ({ page }) => {
     const refTask = BOARD_TASKS.find(t => t.status === 'blocked')!
 
-    await page.addInitScript((id: string) => {
-      ;(window as any).AGENT_SEED = [
-        {
-          role: 'assistant',
-          at: 'just now',
-          body: 'Check this.',
-          refs: [id],
-        },
-      ]
-      Object.defineProperty(window, '__hal0UseBoardChat', {
-        get: () => undefined,
-        set: () => {},
-        configurable: false,
-      })
-    }, refTask.id)
+    await page.addInitScript(pinChatHookWithRefs, { id: refTask.id, body: 'Check this.' })
 
     await gotoBoardAndWait(page)
     await openChat(page)

--- a/ui/tests/e2e/specs/board-dragdrop-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-dragdrop-v3.spec.ts
@@ -3,7 +3,8 @@
  *
  * Covers:
  *   - Drag card between lanes → assert PATCH /api/board/tasks/<id> body {status}
- *   - Drop card to delete zone → assert DELETE /api/board/tasks/<id>
+ *   - Drop card outside any lane → assert PATCH {status:"archived"} (a missed
+ *     drop must never hard-delete the row — archiving is recoverable)
  *
  * HTML5 DnD note: Playwright dragTo() fires dragstart+dragover+drop too fast
  * for React's synthetic event to commit dragId state. We use the split approach:
@@ -132,13 +133,20 @@ test.describe('BoardView — drag-and-drop', () => {
     expect(patchBody).toMatchObject({ status: 'done' })
   })
 
-  test('drop card on delete zone → DELETE /api/board/tasks/<id>', async ({ page }) => {
+  test('drop card outside any lane → PATCH {status:"archived"}, never DELETE', async ({ page }) => {
     const anyTask = BOARD_TASKS.find(t => t.status === 'ready')!
-    let deleteUrl = ''
+    let patchUrl = ''
+    let patchBody: any = null
+    let deleted = false
 
     await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route) => {
-      if (route.request().method() === 'DELETE') {
-        deleteUrl = route.request().url()
+      const method = route.request().method()
+      if (method === 'PATCH') {
+        patchUrl = route.request().url()
+        patchBody = route.request().postDataJSON()
+        await json(route, { ok: true })
+      } else if (method === 'DELETE') {
+        deleted = true
         await json(route, { ok: true })
       } else {
         await route.fallback()
@@ -150,10 +158,12 @@ test.describe('BoardView — drag-and-drop', () => {
     const cardTestId = `board-task-${anyTask.id}`
     await expect(page.locator(`[data-testid="${cardTestId}"]`)).toBeVisible()
 
-    await doDrag(page, cardTestId, 'board-drop-delete')
+    await doDrag(page, cardTestId, 'board-drop-archive')
 
     await page.waitForTimeout(300)
-    expect(deleteUrl).toContain(anyTask.id)
+    expect(patchUrl).toContain(anyTask.id)
+    expect(patchBody).toMatchObject({ status: 'archived' })
+    expect(deleted).toBe(false)
   })
 
   test('drag blocked task to triage lane → PATCH body {status: "triage"}', async ({ page }) => {
@@ -180,14 +190,14 @@ test.describe('BoardView — drag-and-drop', () => {
     expect(patchBody).toMatchObject({ status: 'triage' })
   })
 
-  test('dragging a card over the board background arms the danger veil', async ({ page }) => {
+  test('dragging a card over the board background arms the archive veil', async ({ page }) => {
     const anyTask = BOARD_TASKS.find(t => t.status === 'ready')!
     await gotoBoardAndWait(page)
     const cardTestId = `board-task-${anyTask.id}`
     await expect(page.locator(`[data-testid="${cardTestId}"]`)).toBeVisible()
 
     // Veil is hidden until a drag is in progress over the background.
-    await expect(page.locator('[data-testid="board-danger-veil"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="board-archive-veil"]')).toHaveCount(0)
 
     // dragstart on the card, then dragover the lanes-scroll background.
     await page.evaluate((src: string) => {
@@ -199,13 +209,13 @@ test.describe('BoardView — drag-and-drop', () => {
     }, cardTestId)
     await page.waitForTimeout(120)
     await page.evaluate(() => {
-      const el = document.querySelector('[data-testid="board-drop-delete"]') as HTMLElement
+      const el = document.querySelector('[data-testid="board-drop-archive"]') as HTMLElement
       const dt = (window as any).__e2eDt || new DataTransfer()
       el.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }))
     })
 
-    await expect(page.locator('[data-testid="board-danger-veil"]')).toBeVisible({ timeout: FIVE_S })
-    await expect(page.locator('[data-testid="board-danger-veil"]')).toContainText('Release to delete')
+    await expect(page.locator('[data-testid="board-archive-veil"]')).toBeVisible({ timeout: FIVE_S })
+    await expect(page.locator('[data-testid="board-archive-veil"]')).toContainText('Release to archive')
   })
 
 })

--- a/ui/tests/e2e/specs/board-drawer-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-drawer-v3.spec.ts
@@ -292,14 +292,16 @@ test.describe('TaskDrawer — per-status contract', () => {
     await expect(childChip).toBeVisible()
   })
 
-  test('dep remove chip fires DELETE on /api/board/links', async ({ page }) => {
+  test('dep remove chip fires DELETE /api/board/links?parent_id=&child_id=', async ({ page }) => {
     const task = BOARD_TASKS.find(t => t.deps.children.length > 0)!
     const childId = task.deps.children[0]
-    let deleteBody: any = null
+    let deleteUrl: URL | null = null
 
-    await page.route('**/api/board/links', async (route) => {
+    // The ids ride as QUERY params (the backend forwards the query string
+    // verbatim and sends no body on DELETE) — a JSON body would be dropped.
+    await page.route(/\/api\/board\/links(\?|$)/, async (route) => {
       if (route.request().method() === 'DELETE') {
-        deleteBody = route.request().postDataJSON()
+        deleteUrl = new URL(route.request().url())
         await json(route, { ok: true })
       } else {
         await route.fallback()
@@ -313,7 +315,9 @@ test.describe('TaskDrawer — per-status contract', () => {
     await expect(removeBtn).toBeVisible()
     await removeBtn.click()
     await page.waitForTimeout(200)
-    expect(deleteBody).toBeTruthy()
+    expect(deleteUrl).toBeTruthy()
+    expect(deleteUrl!.searchParams.get('parent_id')).toBe(task.id)
+    expect(deleteUrl!.searchParams.get('child_id')).toBe(childId)
   })
 
   test('add parent dep fires POST /api/board/links', async ({ page }) => {

--- a/ui/tests/e2e/specs/board-render-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-render-v3.spec.ts
@@ -197,9 +197,9 @@ test.describe('BoardView — render', () => {
 
   // ── Drop-to-delete zone ───────────────────────────────────────────────
 
-  test('drop-to-delete zone is visible', async ({ page }) => {
+  test('drop-to-archive zone is visible', async ({ page }) => {
     await gotoBoardAndWait(page)
-    await expect(page.locator('[data-testid="board-drop-delete"]')).toBeVisible()
+    await expect(page.locator('[data-testid="board-drop-archive"]')).toBeVisible()
   })
 
 })

--- a/ui/tests/e2e/specs/board-selector-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-selector-v3.spec.ts
@@ -265,8 +265,10 @@ test.describe('BoardView — selector, new board, orchestration, tweaks', () => 
     await page.locator('.orch-pill').click()
     await expect(page.locator('[data-testid="board-orch-popover"]')).toBeVisible()
 
-    await expect(page.locator('[data-testid="board-orch-mode-auto"]')).toBeVisible()
-    await expect(page.locator('[data-testid="board-orch-mode-manual"]')).toBeVisible()
+    // Exactly the 4 contract knobs — no auto/manual "mode" segment (that was
+    // a phantom field the server never returned nor accepted).
+    await expect(page.locator('[data-testid="board-orch-mode-auto"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="board-orch-mode-manual"]')).toHaveCount(0)
     await expect(page.locator('[data-testid="board-orch-profile"]')).toBeVisible()
     await expect(page.locator('[data-testid="board-orch-assignee"]')).toBeVisible()
     await expect(page.locator('[data-testid="board-orch-autodecompose"]')).toBeVisible()
@@ -298,20 +300,6 @@ test.describe('BoardView — selector, new board, orchestration, tweaks', () => 
     await expect(page.locator('[data-testid="board-orch-ro-ttl"]')).toHaveText('600s')
   })
 
-  test('toggle orch mode to manual then auto', async ({ page }) => {
-    await gotoBoardAndWait(page)
-    await page.locator('.orch-pill').click()
-    await expect(page.locator('[data-testid="board-orch-popover"]')).toBeVisible()
-
-    // Click manual
-    await page.locator('[data-testid="board-orch-mode-manual"]').click()
-    await expect(page.locator('[data-testid="board-orch-mode-manual"]')).toHaveClass(/on/)
-
-    // Click auto
-    await page.locator('[data-testid="board-orch-mode-auto"]').click()
-    await expect(page.locator('[data-testid="board-orch-mode-auto"]')).toHaveClass(/on/)
-  })
-
   test('orch save fires PUT /api/board/orchestration', async ({ page }) => {
     let putBody: any = null
     await page.route('**/api/board/orchestration', async (route) => {
@@ -327,22 +315,21 @@ test.describe('BoardView — selector, new board, orchestration, tweaks', () => 
     await page.locator('.orch-pill').click()
     await expect(page.locator('[data-testid="board-orch-popover"]')).toBeVisible()
 
-    // Toggle mode to manual
-    await page.locator('[data-testid="board-orch-mode-manual"]').click()
     // Save
     await page.locator('[data-testid="board-action-orch-save"]').click()
     await page.waitForTimeout(300)
 
-    // PUT body carries the toggled mode plus the 4 editable knobs, seeded from the
-    // live /api/board/orchestration response (BOARD_ORCH_DEFAULT, unwrapped via .data).
+    // PUT body carries exactly the 4 contract knobs, seeded from the live
+    // /api/board/orchestration response (BOARD_ORCH_DEFAULT, unwrapped via
+    // .data). No `mode` — the server neither returns nor accepts one.
     expect(putBody).toBeTruthy()
     expect(putBody).toMatchObject({
-      mode: 'manual',
       orchestrator_profile: 'admin-agent',
       default_assignee: 'admin-agent',
       auto_decompose: true,
       auto_promote_children: true,
     })
+    expect(putBody.mode).toBeUndefined()
   })
 
   test('orch popover closes on Escape', async ({ page }) => {


### PR DESCRIPTION
## Summary

Started as an audit of the hal0 Operator Board vs the hermes-agent kanban plugin connection (`handoffs/board-hermes-kanban-analysis-2026-07-04.md`, included) — now also **implements the fixes**, plus the requested expansion of the board chat into a platform-wide admin assistant.

## Contract-break fixes (hal0 side)

- **Dependency removal was broken**: `useRemoveLink` sent `parent_id`/`child_id` as a JSON body; the proxy forwards no body on `DELETE /links` (query-params only, per its own tests). Now sent as query params.
- **Live updates died after any Hermes restart**: the proxy ends the browser WS with a clean close frame (1011 / pump-end), which fires only `onclose` — and the client only reconnected from `onerror`. Reconnect now drives from `onclose` with backoff, resumes from the last frame `cursor` via `?since=`, and debounces the board refetch (Hermes pushes batches on a 300ms poll).
- **`?board=` / `include_archived` threading**: the selected board and archived toggle now ride through queries, mutations, the events WS, and the task drawer, per the frozen contract ("Show archived" previously showed an empty lane).
- **Phantom orchestration `mode`** removed from the pill, popover, and PUT payload — the server never returned nor accepted it; the pill now shows the real `orchestrator_profile`.
- **Drag-outside-a-lane now archives** (recoverable) instead of hard-deleting the row Hermes owns; amber veil + updated specs.
- Truth fixes: Refresh actually refetches; attention "Show" filters to blocked/review; `create_task` warnings surface as toasts; `window.LANE` published (drawer lane names, `running` → "In-progress"); unknown statuses bucket into triage instead of vanishing; depCount badge fixed for 10+ deps; multi-select moves use one audited `POST /tasks/bulk`.

## Chat → platform assistant

`POST /api/board/chat` now runs a platform admin agent, not just a board mutator:
- **Board reads** (unaudited, matching the REST proxy split): `get_board` (compacted rows), `get_task`, `get_assignees`, `get_orchestration` — the model can finally *see* what it manages; a system prompt supplies the lane vocabulary and a read-before-write rule.
- **Platform tools** over hal0-api's own surface: `list_slots` / `get_slot`, disruptive `slot_load|unload|restart` (audited as `platform.chat.turn`), `list_models`, `hardware_stats`, `list_agents`, and `update_orchestration` (audited board mutation).
- UI: "agent · platform assistant" copy, grounded suggestion chips, tool frames rendered as tool activity, canned stub replies removed (NO STUB DATA rule) — a missing hook bridge now shows an honest disabled state.

## Polish

- Fonts self-hosted via the already-shipped `@fontsource` packages; the `fonts.googleapis.com` `<link>` meant every page load on an offline LAN box stalled on an external fetch (and flaked e2e).
- `prefers-reduced-motion` guard for the board pulse loops (CONTRACTS acceptance gate).

## Verification

- Backend: `tests/board/` **101 passed** (8 new read-tool/system-prompt tests + 5 platform-tool tests). `tests/api/` 1123 passed; the 1 failure (`test_set_store_rejects_non_writable_path`) is pre-existing on the base commit (sandbox runs as root).
- UI: `tsc --noEmit` clean, `vite build` clean, board e2e suite **97 passed** (specs updated where they pinned the old broken behaviors; board-render went from minutes to seconds once the external font fetch was removed).
- `ruff check` clean on changed Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GaQ4kJeK3c7aPukgozbWE