### PR TITLE
Slot/profile pipeline overhaul: single argv assembler, taxonomy cleanup, backend completeness

### DIFF
--- a/handoffs/model-pipeline-fix-plan-2026-07-04.md
+++ b/handoffs/model-pipeline-fix-plan-2026-07-04.md
@@ -1,0 +1,374 @@
+# Plan: model/slot/profile pipeline + models UI — fixes & polish
+
+**Status:** EXECUTION PLAN — researched against the tree at `4f1d41b` (v0.8.4b1).
+**Scope:** merges two analyses: (a) the model storage/listing/tagging/pull +
+upstream-identification review, and (b) the model/slot/profile pipeline & UI
+audit (dead launch path, preview drift, taxonomy sprawl, per-backend gaps,
+flag-storage correctness, UI findings, runtime robustness).
+**Coordination:** implementation is happening on `claude/new-session-09hvwe`.
+The upstream-vs-local UI identification is ALREADY SHIPPED on
+`claude/model-storage-ui-bguvd1` (draft PR #1035) — rebase over it before
+touching `models.jsx`, `slot-modals.jsx`, `inference-pane.jsx`, or
+`lib/normalizeApiModel.ts`, all of which it modifies.
+
+Each workstream below is sized to one PR. "Fix" sections are prescriptive:
+they name the mechanism that already exists in-tree to build on, not just the
+symptom.
+
+---
+
+## Tier 0 — shipped / in flight
+
+### WS-0 · Upstream-vs-local identification (DONE, PR #1035)
+Upstream-advertised rows (`installed=false` + `upstream=<name>`) now get their
+own "Upstream · remote" catalog section, an `upstream` chip, an `origin` cell
+in the detail pane, a served-remotely note instead of Pull/View-on-HF, and are
+excluded from all slot model pickers via `isUpstreamModel()` in
+`ui/src/lib/normalizeApiModel.ts`. e2e: `models-upstream-v3.spec.ts`.
+
+**Follow-ups folded into later workstreams:** explicit `origin` field on the
+API row (→ WS-7), a Connections-view panel consuming the orphaned
+`useEndpoints()` hook (→ WS-19).
+
+---
+
+## Tier 1 — quick wins (small diffs, immediate user value)
+
+### WS-1 · Fix divergent model normalizer hiding models from slot pickers (BUG)
+- **Problem:** `slot-modals.jsx:59-67` derives `type: 'llm'` only from
+  `chat|coding` capabilities; the canonical `lib/normalizeApiModel.ts:41-49`
+  also maps `tool-calling|vision`. A tool-calling-only or vision-only chat
+  model is `type:''` in `compatibleModels()` and invisible in every slot
+  picker while rendering normally in the Models pane.
+- **Fix:** delete the local `normalizeApiModel` copy in `slot-modals.jsx` and
+  import the TS one (the file already uses ESM imports — see its
+  `@/api/hooks/*` imports — so `import { normalizeApiModel } from
+  '@/lib/normalizeApiModel'` is mechanical). While there, dedupe
+  `deriveDevice` and the redundant `fmtBytes` copies against the same module.
+  Note `useModels()` already normalizes rows, so the double-normalize in
+  `compatibleModels` can drop to a plain pass-through once callers are audited
+  (create modal + edit drawer + swap popover all consume `useModels`).
+- **Test:** unit-level: a row with `capabilities:['tool-calling']` classifies
+  `llm`. e2e: extend `models-upstream-v3.spec.ts`'s create-slot-picker test
+  pattern — inject a tool-calling-only row via the `HAL0_DATA` init-script
+  hook and assert it appears as an option.
+- **Conflict note:** PR #1035 adds `isUpstreamModel` to `compatibleModels` —
+  rebase first.
+
+### WS-2 · Make the resolved-command preview the launch truth
+- **Problem:** `_resolve_slot_argv` (`providers/container.py:1008-1058`)
+  re-assembles argv separately from `_llama_launch_plan` (`container.py:338`)
+  and omits the slot `mtp` override, `--chat-template-file`, `--mmproj`, and
+  the `--ctx-size` fallback from `_resolve_context_size`. Preview uses
+  `resolve_argv`, launch uses `normalize_argv`; drift detection
+  (`manager.py:1313`) uses `container_spec`, so preview and drift already
+  disagree. The provenance drawer (`slot-modals.jsx:1218-1348`) presents the
+  preview as auditable truth.
+- **Fix:** `slots/argv.py` already exports
+  `resolve_argv(segments: list[tuple[str, list[str]]])` — a labelled-segment
+  resolver. Extract the segment assembly out of `_llama_launch_plan` into a
+  shared `_llama_argv_segments(...) -> list[tuple[str, list[str]]]` (labels:
+  `base`, `profile`, `chat-template`, `mmproj`, `extra_args`), have
+  `_llama_launch_plan` flatten+`normalize_argv` it, and have
+  `resolved_argv_detail_for_slot` feed the *same* segments (with the same mtp
+  override and resolved context size) to `resolve_argv` for provenance. One
+  assembler; preview, launch, and drift all derive from it.
+- **Also:** route drift comparison through `argv.FLAG_ALIASES`
+  canonicalization (`manager.py:135` + `:3236`) so `--batch-size` vs `-b`
+  stops reporting false drift.
+- **Test:** golden test asserting `flatten(segments) == launch argv` for a
+  slot with mtp+chat-template+mmproj+extra_args; regression test for `-b` vs
+  `--batch-size` drift.
+
+### WS-3 · Wire the real FLM health probe into the container path
+- **Problem:** `FLMProvider.health` (`providers/flm.py:332`) does a real
+  inference probe (written because `/v1/models`-only was a known bug), but
+  container-managed NPU slots always use the weak generic
+  `ContainerProvider.health` (`container.py:637-665`).
+- **Fix:** in `ContainerProvider.health`, delegate to
+  `_spec_provider_for(slot_cfg)`'s health when the spec provider defines one
+  (the FLM/Kokoro/Qwen3-TTS/ComfyUI dispatch mechanism already exists at
+  `container.py:408`); fall back to the generic HTTP check otherwise.
+- **Bundle the small FLM hygiene items** while in the file: unify the two
+  hardcoded install roots (`flm.py:57` vs `:196`), delete the unread
+  `_FLM_PROBE_OK` global, add a TTL to the catalog cache, add the missing `T`
+  unit to `parse_flm_progress` (`flm.py:712`).
+
+### WS-4 · One port-range constant
+- **Problem:** `_next_free_slot_port` scans 8081–8099
+  (`api/routes/slots.py:230`), the schema allows ≤8200 (`schema.py:95`),
+  `stats.py` documents a third range.
+- **Fix:** define `SLOT_PORT_RANGE = range(8081, 8200)` in one module
+  (`hal0/config/schema.py` or `hal0/slots/__init__`), import everywhere,
+  assert schema bounds from it.
+
+### WS-5 · Backend-switch surface: finish or kill (recommend: kill for now)
+- **Problem:** `useSlotBackend` (`useSlots.ts:485`) has no caller; the
+  `backend_mismatch` chip (`slots.jsx:311-319`) tells the user to switch with
+  no affordance; server-side `_backend_build_present` is a stub always
+  returning True (documented 409 unreachable) and `actual_backend` is
+  hardcoded `None` (`slots.py:962-972,1080,1125`).
+- **Fix (recommended):** since backend identity is now expressed via profiles
+  (the switch endpoint predates that), remove the endpoint's vestigial
+  response fields + the dead hook, and make the chip's remediation "open the
+  profile picker" (which is the real switch mechanism). Finishing the legacy
+  endpoint would re-add a second way to express what profiles already own.
+- **Also:** drop the four duplicate NPU endpoint aliases in
+  `ui/src/api/endpoints.ts:64-77` (their TODOs already say so).
+
+### WS-6 · Chat-template pick at pull time
+- **Problem:** MMPROJ is selectable in the Add-by-HF modal but chat template
+  is only settable post-hoc in the Recipe editor
+  (`model-modals.jsx:539-556`).
+- **Fix:** UI-only is enough: reuse the Recipe editor's `useChatTemplates`
+  select in `AddByHfModal`, and on pull completion issue the same
+  `PUT /api/models/{id}` (`useModelUpdate`) with
+  `defaults.chat_template` — `usePullJob` already exposes the completion
+  event to sequence it. (Backend alternative — accepting `defaults` in
+  `POST /{id}/pull` — is cleaner long-term but touches
+  `_resolve_pull_source_with_body`; do it only if already in there for WS-11.)
+
+---
+
+## Tier 2 — medium (one PR each)
+
+### WS-7 · Canonical device/backend taxonomy + `/api/meta/enums`
+- **Problem:** ≥5 backend vocabularies (`schema.py:45,52`, profile
+  `runtime_family`/`device_class`, `model_meta.device_to_backend`), three
+  duplicated backend↔device maps (`schema.BACKEND_TO_DEVICE:67`,
+  `api/routes/slots.py:952`, `model_meta:238`), `DEVICE_DEFAULT_PROFILES`
+  duplicated with different CPU behavior (`stacks.py:149`), three
+  unknown-value policies, and five more hand-copied spellings in the UI
+  (`models.jsx:165`, `model-modals.jsx:260` incl. a dead `cuda` toggle,
+  `profiles.jsx:31`, `stacks.jsx:33`, `devKind` ×3).
+- **Fix:** `hal0/model_meta/` already exports `canonical_device`,
+  `device_to_backend`, `device_to_legacy_backend`, `classify` — finish the
+  consolidation there: move `BACKEND_TO_DEVICE` + `DEVICE_DEFAULT_PROFILES`
+  in, pick ONE unknown policy (recommend: passthrough + logged warning, since
+  silent `cpu` coercion masks typos), and delete the route/stacks copies.
+  Then add `GET /api/meta/enums` returning `{devices, backends, slot_types,
+  capabilities, device_classes, curated_model_tags}` and a `useMetaEnums()`
+  hook; replace the UI literals (incl. the three capability vocabularies in
+  `model-modals.jsx:202/258/965` — `embed` vs `embeddings` etc.). Drop the
+  `cuda` toggle or render it disabled-with-tooltip ("Phase 2,
+  `recommend.py:124`").
+- **Sequencing:** land before WS-16 (structured flag editor) and before any
+  further UI vocab work; other UI PRs should stop adding literals now.
+
+### WS-8 · Decide the fate of inert model/slot launch knobs (recommend: wire in)
+- **Problem:** `model.defaults.extra_args` / `n_gpu_layers` /
+  `rope_freq_base` and slot `[model].n_gpu_layers`/`rope_freq_base` are
+  persisted, editable in the UI, and never read by the live launch — only the
+  dead `LlamaServerProvider.merge_flags` consumed them. The `ModelDefaults`
+  docstring (`registry/model.py:22`) still promises the merge.
+- **Fix (recommended: option a — honor the contract):** in the WS-2 segment
+  assembler add a `model-defaults` segment between `profile` and
+  `extra_args`: `defaults.extra_args` verbatim, `n_gpu_layers → -ngl`,
+  `rope_freq_base → --rope-freq-base`. Last-wins dedup via `normalize_argv`
+  keeps slot `extra_args` authoritative. The UI already renders these as
+  launcher defaults, so no UI change. If option (b — deprecate) is chosen
+  instead: reject at `PUT /api/models/{id}` with a clear error, hide the
+  fields in the Recipe editor, migration-strip on registry load.
+- **Depends on:** WS-2 (segments).
+
+### WS-9 · Boundary validation on slot config writes
+- **Problem:** `PUT /config` and `PATCH /defaults` pass raw dicts to
+  `update_config`; `SlotConfig`/`ModelConfig`/`ServerConfig` are
+  `extra="allow"`, so `extra_arg`/`contextsize` typos persist silently.
+  `ctx_size → context_size` is folded in three places
+  (`slot_config/__init__.py:120`, `manager.py:1859`, `:3266`).
+- **Fix:** one `normalize_slot_patch()` at the route boundary: fold known
+  aliases (`ctx_size`), validate the patch against the pydantic models with
+  `extra="forbid"` **for the patch only** (storage models stay
+  `extra="allow"` for forward-compat), 400 with the unknown key named.
+  Collapse the three `ctx_size` folds into it.
+
+### WS-10 · Stacks write through the guarded path
+- **Problem:** `stacks/apply.py:184-226` merges slot TOML itself — skipping
+  the `ctx_size` fold, `_reconcile_device_profile`, NPU-exclusivity and
+  default-uniqueness guards — and writes a different field set (incl. legacy
+  `backend`) than the other two writers. Locking is asymmetric
+  (`SlotConfigStore.transaction` locks only `capabilities.toml`); `create()`
+  has a check-then-write TOCTOU (`manager.py:1773-1780`).
+- **Fix:** route stack slot mutations through `SlotManager.update_config` /
+  `create` (or extract the guard set into a shared function both call). Take
+  the slot-TOML write lock in `update_config`/`create`/
+  `_persist_model_default` (the flock sidecar mechanism already exists in
+  `registry/store.py:85` — mirror it). Close the TOCTOU under the same lock.
+- **Also:** stacks UX identity fixes from the audit if small enough, else
+  split: `buildVM`'s `profile: sl.profile || sl.device` conflation
+  (`stacks.jsx:68`), profile selects unfiltered by device class (`:517`), no
+  `img` device option, three independent MTP toggles with gating only at
+  slot level.
+
+### WS-11 · Multi-file pulls: fetch MMPROJ with the model
+- **Problem:** `run_pull` (`registry/pull.py:532`) streams exactly one file.
+  The Add-by-HF modal *requires* an mmproj pick for vision models and passes
+  `mmproj_filename`, but curated/detail-pane pulls fetch only the main GGUF;
+  the mmproj association then depends on a later directory scan
+  (`discover.py:166-255`). Curated multi-file pulls are an acknowledged TODO
+  (`curated.py:20-62`).
+- **Fix:** generalize `PullJob` to a file list (`files: [{hf_filename,
+  dest, bytes_total, bytes_done, sha256}]`), aggregate progress across files
+  (SSE shape keeps top-level `bytes_downloaded/bytes_total` so the UI needs
+  no change), download mmproj after the model into the same directory, and
+  set `model.mmproj` in `_register_pulled` directly instead of waiting for a
+  scan. Resume sidecars are already per-file (`<id>.part.json`) — key them by
+  filename. Extend `POST /{id}/pull` source resolution to carry
+  `mmproj_filename` through `_resolve_pull_source_with_body`
+  (`models.py:1253`).
+- **Test:** pull a two-file fixture over the mocked HF endpoint; assert both
+  files land, registry row has `mmproj` set, progress is monotonic across the
+  file boundary; cancel mid-second-file resumes correctly.
+
+### WS-12 · Verify pull integrity against an expected hash
+- **Problem:** SHA-256 is computed while streaming and *recorded*
+  (`pull.py:583,832`) but never compared to anything.
+- **Fix:** `POST /api/models/inspect` already talks to the HF API — extend it
+  (or the pull-source resolution) to capture the LFS object sha256 that HF
+  exposes per file (`x-linked-etag` on the resolve redirect / `lfs.oid` in
+  the repo tree API). Store as `expected_sha256` on the job; on stream
+  completion compare and fail the job with a `pull.checksum_mismatch` error
+  code (new entry in the `model.*`/`pull.*` error namespace), leaving the
+  `.part` for diagnosis. When HF provides no hash (non-LFS files), keep
+  today's record-only behavior.
+
+### WS-13 · Models catalog: sorting, quant, date, tag filters
+- **Problem:** no sort control anywhere (registry is id-sorted, UI only
+  groups); quant is not a structured field (`gguf_header.py` doesn't read
+  it; `meta.json.quant` is always `None`); `created` is emitted but never
+  rendered; tags are edit-only, never a browse dimension.
+- **Fix (client-heavy, backend-light):**
+  - UI sort dropdown in the `.mdl-toolbar` (name / size / params / date,
+    asc-desc), applied within each existing section — all fields are already
+    on the rows.
+  - Backend: extract quant at registration in `detect.py` — regex the
+    filename (`(?i)(i?q\d[_a-z0-9]*|f16|bf16|f32)`) and/or read
+    `general.file_type` in `gguf_header.py` — store as `Model.quant`,
+    surface in `_model_to_dict`, render as a chip + filter.
+  - Render `created` as an "added" column/detail cell.
+  - Tag filter chips in the toolbar sourced from the curated tag vocab
+    (via WS-7's `/api/meta/enums`), matching `Model.tags`.
+  - Add `origin: "local"|"upstream"` to `_model_to_dict`/upstream rows
+    (`models.py:213-293`) so clients stop inferring from
+    `installed`+`upstream` (WS-0 follow-up; keep the old fields).
+
+### WS-14 · Runtime robustness batch
+One PR of small verified fixes in `slots/manager.py` + friends:
+- Seed `_last_used` on adopt/reconcile (`manager.py:2708,2791,3017`) so
+  idle-TTL/pressure eviction sees adopted slots.
+- Add WARMING to `_FAIL_WATCH_LIVE_STATES` (or a warmup-deadline watcher) so
+  a slot stuck after `_await_ready` timeout isn't a monitoring blind spot.
+- mtime-keyed cache in `iter_configs` to stop `resolve_for_request`
+  re-reading every slot TOML twice per routed request
+  (`manager.py:1488,1518,1527`).
+- Registry outage → explicit `model.registry_unavailable` error instead of
+  silently assuming "model cached" (`manager.py:2437,2289`).
+- Align capacity-math default ctx (`capacity.py:106`, 64k) with the
+  launcher's fallbacks (`container.py:469-470`, 8k/32k) — one shared
+  constant.
+- Fold `flag_merge.py` into `argv.py` (full aliasing, fixes `-b 8192`
+  mis-tokenization; only live consumer is the MTP bundle merge) and delete it.
+
+---
+
+## Tier 3 — structural (design sign-off first)
+
+### WS-15 · Retire the dead launch path
+Delete `LlamaServerProvider` launch machinery (`providers/llama_server.py:104`
+— backend→binary selection, `HAL0_BACKEND`, `_HAL0_TOOLBOX_IMAGES` which now
+diverges from `SEED_PROFILES`, device filtering, `-ngl` emission,
+`merge_flags`) and `base.render_systemd_override` (`base.py:292-400`,
+type-incompatible with `Mount`). **Precondition:** WS-8 has landed (so the
+only still-referenced behavior, the model-defaults merge, lives in the live
+path) and WS-19's device-existence filter has been ported out of it. Keep
+whatever test fixtures still assert argv shapes by pointing them at the
+segment assembler from WS-2.
+
+### WS-16 · Structured flag editing in the profile UI
+The most-tuned knobs (`-ngl`, rope, batch, flash-attn, cache-type) are
+read-only "defined by profile" in the slot drawer
+(`slot-modals.jsx:1164-1183`) while the profile editor is one opaque textarea
+(`profiles.jsx:358`). Add a structured overlay on the profile form: parse the
+flag string through the `argv.py` alias table into known fields + "other
+flags" remainder, edit fields, serialize back. Expose the alias table via
+WS-7's meta endpoint (or a `flag_schema` key on it) so the UI doesn't
+hand-copy flag names. Storage model unchanged (still one flag string).
+
+### WS-17 · Per-slot env + GPU pinning
+- `[server].env` table on the slot schema → `RuntimeLaunchPlan.env`
+  (`container.py:394-405` currently builds with no env) → rendered into the
+  unit. Unlocks `HSA_OVERRIDE_GFX_VERSION` etc. without forking images.
+- Per-slot `gpu_index` mapped to the right visibility env per runtime family
+  (`HIP_VISIBLE_DEVICES` / `GGML_VK_VISIBLE_DEVICES`) — cheap future-proofing
+  for dGPU/multi-GPU hosts; no behavior change when unset.
+
+### WS-18 · Device-class gating of GPU passthrough
+`container_spec` unconditionally injects GPU device nodes/groups
+(`container.py:605-606`) — a `cpu-llm` slot gets `--device=/dev/kfd` if
+present, and `_gpu.py:56-57` falls back to legacy dir strings on non-GPU
+hosts. Gate on the profile's `device_class` (`cpu` → no GPU plumbing) and
+filter device paths by `Path.exists()` (port the filter from the dead
+provider before WS-15 deletes it). Also parameterize the Strix-Halo constants
+behind the hardware probe (accel/render node names `flm.py:307`, AIE column
+cap `npu_columns.py:151`, fallback GIDs `_gpu.py:73-79`, model paths inside
+seed-profile flag strings `schema.py:778,787`) when a second hardware target
+becomes concrete — not before.
+
+### WS-19 · UI polish batch
+Bundle of small verified items (one PR, mostly mechanical):
+- Connections view: render remote upstreams via the orphaned `useEndpoints()`
+  (`useSlots.ts:370-377`) — endpoint name, kind, health, advertised-model
+  count; links the WS-0 upstream story end-to-end.
+- `useProfiles` gets a `refetchInterval` (`useProfiles.ts:73`).
+- Mock allowlist: add `/api/profiles` + `/api/stacks` so forced-mock mode
+  doesn't break the create-slot flow.
+- Replace native `window.confirm` (swap/dirty-close) with the
+  `ConfirmDialog` primitive.
+- Pull progressbar `aria-valuenow` wired to actual pct.
+- Remove the injectable demo "sha256 mismatch" banner from the production
+  render path (`slots.jsx:811-814`).
+- `list`/`spec` slot-card variants: drop never-populated `rpm/xrt/avg`
+  metrics; either wire lifecycle handlers or render their buttons disabled
+  (`slots.jsx:766-770`).
+- `enable_thinking` toggle gets a "applies per-request — no restart" hint
+  (asymmetric with `mtp`, which restarts).
+- Unify the two model-store-root defaults (`/mnt/ai-models` bind-mount vs
+  `models_dir()` pull default via `effective_store()`,
+  `config/paths.py:140-143` vs `pull.py:160`) — pick one, document it in the
+  install docs.
+
+---
+
+## Suggested sequencing
+
+```
+Tier 1 (parallel-safe): WS-1 ─ WS-3 ─ WS-4 ─ WS-5 ─ WS-6
+                         WS-2 ──► WS-8 ──► WS-15
+Tier 2: WS-7 ──► WS-13 (enums), WS-16 (flag schema)
+        WS-9 ──► WS-10 (shared boundary normalizer)
+        WS-11 ─ WS-12 (both touch pull.py — same author or sequential)
+        WS-14 (independent)
+Tier 3: WS-15, WS-17, WS-18 (WS-18's existence filter ported before WS-15
+        deletes its source), WS-19 (independent)
+```
+
+Rebase note for the implementing session: PR #1035
+(`claude/model-storage-ui-bguvd1`) touches `models.jsx`, `slot-modals.jsx`
+(`compatibleModels`), `inference-pane.jsx` (`ModelPicker`), and
+`normalizeApiModel.ts` — WS-1, WS-7, WS-13, WS-19 all overlap those files.
+
+## Test strategy
+
+- **Backend:** every WS that touches argv/launch gets a golden-argv test
+  against the WS-2 segment assembler; pull changes run against the existing
+  mocked-HF fixtures (`tests/` has `test_models_routes.py` patterns to
+  extend); taxonomy consolidation gets a one-shot exhaustive-mapping test
+  (every legacy backend ↔ device ↔ profile default round-trips).
+- **UI:** dependency-free `.mjs` unit tests for pure helpers (pattern:
+  `ui/src/dash/__tests__/model-types.test.mjs`); Playwright specs for
+  user-visible changes using the forced-mock `HAL0_DATA` init-script
+  injection pattern established in `models-upstream-v3.spec.ts`. In this
+  environment, bridge the browser revision via the
+  `/opt/pw-browsers/chromium_headless_shell-*` symlink trick (see PR #1035
+  session) before running specs.

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -97,6 +97,9 @@ from hal0.api.routes import (
     memory_admin as memory_admin_routes,
 )
 from hal0.api.routes import (
+    meta as meta_routes,
+)
+from hal0.api.routes import (
     profiles as profiles_routes,
 )
 from hal0.api.routes import (
@@ -1239,6 +1242,10 @@ def create_app() -> FastAPI:
     # public (e.g. /api/status, /api/config/urls). Auth was removed in
     # ADR-0012; all endpoints on this server are open on the local network.
     app.include_router(health.router, prefix="/api", tags=["health"])
+    # Static backend vocabulary (GET /api/meta/enums) — the canonical
+    # device/backend/capability enums from hal0.model_meta, read once by the
+    # dashboard at startup. Code-level constants only; no auth (ADR-0012).
+    app.include_router(meta_routes.router, prefix="/api/meta", tags=["meta"])
     app.include_router(config_routes.router, prefix="/api/config", tags=["config"])
 
     # Profile catalog — read-only, no auth (ADR-0012). Returns every profile

--- a/src/hal0/api/routes/meta.py
+++ b/src/hal0/api/routes/meta.py
@@ -1,0 +1,87 @@
+"""Static backend vocabulary surface.
+
+Mounted under /api/meta:
+
+    GET /api/meta/enums — every identity vocabulary the backend speaks, in
+    one JSON document, sourced verbatim from the canonical taxonomy in
+    :mod:`hal0.model_meta` (see its module docstring for the vocabulary
+    table + unknown-value policy).
+
+The UI reads this once at startup instead of hard-coding its own copies of
+the device/backend/capability enums, so a taxonomy change lands in exactly
+one place. The payload is pure code-level constants — it only changes with
+a hal0 release — so it is served with a version-keyed ``ETag`` and a
+``Cache-Control`` allowing revalidated caching. No auth (ADR-0012: the
+read-only /api surface is open), no app state touched.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from fastapi import APIRouter, Request, Response
+
+from hal0 import __version__
+from hal0.model_meta import (
+    BACKEND_TO_DEVICE,
+    CANONICAL_DEVICES,
+    CAPABILITY_ALIASES,
+    DEVICE_CLASSES,
+    DEVICE_TO_DEFAULT_PROFILE,
+    LEGACY_BACKENDS,
+    MODEL_BACKENDS,
+    MODEL_CAPABILITIES,
+    RUNTIME_FAMILIES,
+    SELECTABLE_BACKENDS,
+    SLOT_TYPES,
+)
+
+router = APIRouter()
+
+# The payload only changes with a code release, so the running version is a
+# sufficient cache validator. Weak ETag: byte-identity is irrelevant here.
+_ENUMS_ETAG = f'W/"hal0-enums-{__version__}"'
+
+
+@router.get("/enums")
+async def get_enums(request: Request, response: Response) -> Any:
+    """Canonical backend vocabularies (devices, backends, capabilities, …).
+
+    Response contract (the dashboard codes against these exact field
+    names):
+
+    - ``devices``: ordered device cards — ``{id, label, device_class,
+      default_profile, legacy_backend, recommended, description}``.
+      ``gpu-rocm`` carries ``recommended: true`` (CONTEXT.md: best
+      throughput on Strix Halo; ``gpu-vulkan`` is the slower fallback).
+    - ``backends``: DEPRECATED v0.1 ``SlotConfig.backend`` tokens.
+    - ``selectable_backends``: what POST /api/slots/{name}/backend accepts.
+    - ``device_classes`` / ``slot_types`` / ``runtime_families``: the
+      profile + dispatcher vocabularies.
+    - ``model_capabilities`` + ``capability_aliases``: canonical registry
+      capability spellings and the tolerated synonyms.
+    - ``model_backends``: valid registry ``model.backends`` values.
+    - ``backend_to_device`` / ``device_default_profiles``: the two
+      canonical translation maps.
+
+    Static data — served with a version-keyed ETag so clients can cache
+    across the session and revalidate for free (304).
+    """
+    cache_headers = {"ETag": _ENUMS_ETAG, "Cache-Control": "public, max-age=3600"}
+    if request.headers.get("if-none-match") == _ENUMS_ETAG:
+        return Response(status_code=304, headers=cache_headers)
+    response.headers.update(cache_headers)
+    return {
+        "devices": [asdict(d) for d in CANONICAL_DEVICES],
+        "backends": list(LEGACY_BACKENDS),
+        "selectable_backends": list(SELECTABLE_BACKENDS),
+        "device_classes": list(DEVICE_CLASSES),
+        "slot_types": list(SLOT_TYPES),
+        "model_capabilities": list(MODEL_CAPABILITIES),
+        "capability_aliases": dict(CAPABILITY_ALIASES),
+        "model_backends": list(MODEL_BACKENDS),
+        "runtime_families": list(RUNTIME_FAMILIES),
+        "backend_to_device": dict(BACKEND_TO_DEVICE),
+        "device_default_profiles": dict(DEVICE_TO_DEFAULT_PROFILE),
+    }

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -32,7 +32,7 @@ from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 
 from hal0.api._audit import record_action
-from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
+from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.model_meta import device_to_backend, is_resolvable
 from hal0.slot_view import (
     SlotViewAggregator,
@@ -42,7 +42,7 @@ from hal0.slot_view import (
     serialize_slot,
     synthesize_upstream_entries,
 )
-from hal0.slots.manager import Slot, SlotManager
+from hal0.slots.manager import Slot, SlotManager, _cfg_effective_backend
 
 # Auth was removed in ADR-0012. All routes are open on the local network.
 
@@ -227,17 +227,46 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
     return [view.to_dict() for view in await aggregator.snapshot()]
 
 
-def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:
-    """Return the next free port in the slots range (#275 bug 2).
+def _slot_port_range() -> tuple[int, int]:
+    """Resolve the slot port pool: hal0.toml ``[slots]`` or the schema range.
+
+    ``SlotsConfig.port_range_start/end`` default to the schema constants
+    (``_SLOT_PORT_MIN``/``_SLOT_PORT_MAX`` = 8081..8200 — the same bounds the
+    ``SlotConfig.port`` validator enforces), so with no hal0.toml override
+    the full schema range is allocatable. An operator ``[slots]``
+    ``port_range_start/end`` in hal0.toml narrows/moves the pool. Falls back
+    to the schema constants when hal0.toml is unreadable.
+    """
+    from hal0.config.schema import _SLOT_PORT_MAX, _SLOT_PORT_MIN
+
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        slots_cfg = load_hal0_config().slots
+        return int(slots_cfg.port_range_start), int(slots_cfg.port_range_end)
+    except Exception:
+        return _SLOT_PORT_MIN, _SLOT_PORT_MAX
+
+
+def _next_free_slot_port(start: int | None = None, end: int | None = None) -> int:
+    """Return the next free port in the configured slot range (#275 bug 2).
 
     Walks ``/etc/hal0/slots/*.toml`` collecting both top-level ``port``
     and nested ``[server] port`` values. Returns the lowest port in
-    ``[start, end]`` not already claimed. The 8081-8099 range matches
-    PLAN.md §2 ports table.
+    ``[start, end]`` not already claimed. The bounds default to the
+    configured pool (hal0.toml ``[slots] port_range_start/end``, itself
+    defaulting to the schema's 8081..8200) — previously this helper was
+    pinned to a stale 8081-8099 literal that contradicted the schema and
+    the ``SlotsConfig`` default, capping installs at 19 slots.
     """
     import tomllib
 
     from hal0.config.paths import slots_config_dir
+
+    if start is None or end is None:
+        cfg_start, cfg_end = _slot_port_range()
+        start = cfg_start if start is None else start
+        end = cfg_end if end is None else end
 
     used: set[int] = set()
     slots_dir = slots_config_dir()
@@ -263,6 +292,32 @@ def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:
         f"no free port in {start}-{end} (all slots occupied)",
         code="slot.no_free_port",
     )
+
+
+def _reject_unknown_config_keys(payload: dict[str, Any]) -> None:
+    """400 when a slot-config write body carries keys the schema doesn't know.
+
+    ``SlotConfig``/``ModelConfig``/``ServerConfig`` are ``extra="allow"`` so a
+    typo'd key (``ctx_sizee``, ``enabeld``) used to persist to TOML silently
+    and the intended setting never took effect. The boundary now validates
+    against :func:`hal0.slot_config.unknown_slot_config_keys` (field sets
+    derived dynamically from the pydantic models, tolerating the documented
+    legacy aliases like ``[model].ctx_size`` and the string ``image``
+    override) and rejects unknown keys with the paths listed.
+    """
+    from hal0.slot_config import unknown_slot_config_keys
+
+    unknown = unknown_slot_config_keys(payload)
+    if unknown:
+        raise BadRequest(
+            "unknown slot config key(s): " + ", ".join(unknown),
+            details={
+                "unknown_keys": unknown,
+                "hint": "check spelling against the SlotConfig schema "
+                "(known sub-tables: [model], [server], [npu], [image])",
+            },
+            code="validation.unknown_keys",
+        )
 
 
 def _normalize_create_body(body: dict[str, Any]) -> dict[str, Any]:
@@ -325,6 +380,7 @@ async def create_slot(request: Request) -> dict[str, object]:
         )
 
     body = _normalize_create_body(body)
+    _reject_unknown_config_keys(body)
     async with record_action(
         request,
         category="slot",
@@ -891,6 +947,7 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
         ) from exc
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
+    _reject_unknown_config_keys(body)
     before = await _safe_config(sm, name)
     async with record_action(
         request, category="slot", action="slot.edit_config", target=name, before=before
@@ -920,10 +977,13 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
 
 @router.patch("/{name}/defaults")
 async def update_slot_defaults(name: str, request: Request) -> dict[str, object]:
-    """Update slot defaults (ctx_size, temperature, etc.).
+    """Update slot defaults (ctx_size / context_size, n_gpu_layers, …).
 
     Convenience wrapper over update_config — body keys merge into the
-    slot's [model] sub-table rather than the top level.
+    slot's [model] sub-table rather than the top level. Keys are validated
+    against the ModelConfig schema (plus the documented ``ctx_size``
+    alias); unknown keys 400 with ``validation.unknown_keys``. Provider-
+    specific params belong under ``extra`` (passed through verbatim).
     """
     sm = _get_slot_manager(request)
     try:
@@ -936,6 +996,9 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
         ) from exc
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
+    # Defaults merge into [model] — validate the wrapped shape so unknown
+    # keys surface as their real destination path (``model.<key>``).
+    _reject_unknown_config_keys({"model": body})
     before = await _safe_config(sm, name)
     async with record_action(
         request, category="slot", action="slot.edit_defaults", target=name, before=before
@@ -945,31 +1008,23 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
     return _slot_to_dict(snap, request)
 
 
-# Map a normalized runtime-backend token to the SlotConfig ``device`` enum
-# the TOML persists. ``auto`` clears the device so the load path falls back
-# to its default. flm/npu are not selectable through this control (they
-# require a profile switch, not a device flip).
-_BACKEND_TO_DEVICE: dict[str, str | None] = {
-    "rocm": "gpu-rocm",
-    "vulkan": "gpu-vulkan",
-    "cpu": "cpu",
-    "auto": None,
-}
+def _selectable_backend_devices() -> dict[str, str | None]:
+    """Selectable backend token → SlotConfig ``device`` enum for the TOML.
 
-# Container images supply the backend builds; a missing image surfaces as
-# ``image_status="missing"`` on the slot card and pulls on demand, so no
-# on-disk build-presence validation is needed here.
-_BACKEND_BUILD_BIN: dict[str, str] = {}
-
-
-def _backend_build_present(backend: str) -> bool:
-    """Backend builds ship inside container images — always present.
-
-    Kept as a seam (module-level, monkeypatchable) for tests and for any
-    future host-side build requirement.
+    Derived from the single schema map (``config.schema.BACKEND_TO_DEVICE``)
+    rather than a duplicated literal, so the two can't drift; only the
+    ``auto`` → ``None`` entry (clear the device so the load path falls back
+    to its default) is endpoint-local. flm/npu are not selectable through
+    this control (they require a recipe/profile switch, not a device flip).
     """
-    del backend
-    return True
+    from hal0.config.schema import BACKEND_TO_DEVICE
+
+    return {
+        "rocm": BACKEND_TO_DEVICE["rocm"],
+        "vulkan": BACKEND_TO_DEVICE["vulkan"],
+        "cpu": BACKEND_TO_DEVICE["cpu"],
+        "auto": None,
+    }
 
 
 def _normalize_backend_token(raw: str) -> str:
@@ -999,18 +1054,24 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
     ``update_config`` (which auto-refreshes the mirrored ``extra.backend``);
     if the slot is currently loaded it is restarted so the model reloads
     under the new backend. Idempotent — when the requested backend already
-    equals the declared device (and, when loaded, the actual backend) it is
-    a no-op with ``reloaded: false``.
+    equals the declared device (and, when loaded, the effective backend) it
+    is a no-op with ``reloaded: false``.
 
-    Validation:
-      - ``rocm``/``vulkan`` → 409 ``backend.build_missing`` when the build's
-        ``llama-server`` binary is absent.
-      - ``cpu`` and ``auto`` are always valid.
-      - ``flm``/``npu`` → 400 ``backend.not_selectable``.
+    Validation: ``rocm``/``vulkan``/``cpu``/``auto`` are valid (backend
+    builds ship inside the container images — a missing image surfaces as
+    ``image_status="missing"`` on the slot card and pulls on demand, so
+    there is no host-side build-presence check); ``flm``/``npu`` → 400
+    ``backend.not_selectable``.
 
-    Response 200: the standard ``_slot_to_dict`` payload plus
-    ``requested_backend`` / ``declared_backend`` / ``actual_backend`` /
-    ``reloaded``.
+    Response 200: the standard ``_slot_to_dict`` payload plus the ADR-0022
+    declared/effective snapshot — ``requested_backend`` /
+    ``declared_backend`` / ``effective_backend`` / ``device`` / ``profile``
+    / ``reloaded``. ``actual_backend`` is kept for wire back-compat
+    (ui useSlots.ts) and carries the same EFFECTIVE backend token, derived
+    from the post-write config (device → backend via the single
+    ``_cfg_effective_backend`` mapping); per-process introspection was
+    retired with the legacy runtime (#663 — the running image is the
+    backend-of-record, surfaced as ``actual_image``).
     """
     sm = _get_slot_manager(request)
     try:
@@ -1043,22 +1104,14 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
             "(NPU/FLM requires a recipe change, not a backend flip)",
             code="backend.not_selectable",
         )
-    if backend not in _BACKEND_TO_DEVICE:
+    backend_to_device = _selectable_backend_devices()
+    if backend not in backend_to_device:
         raise BadRequest(
             f"backend {backend!r} is not recognised; choose from rocm|vulkan|cpu|auto",
             code="backend.not_selectable",
         )
 
-    # Build-presence validation for the GPU backends.
-    if not _backend_build_present(backend):
-        bin_path = _BACKEND_BUILD_BIN.get(backend)
-        raise Conflict(
-            f"backend {backend!r} build is not installed ({bin_path} missing)",
-            details={"backend": backend, "expected_binary": bin_path},
-            code="backend.build_missing",
-        )
-
-    target_device = _BACKEND_TO_DEVICE[backend]
+    target_device = backend_to_device[backend]
 
     # Determine current declared device + whether the slot is loaded, so we
     # can short-circuit an idempotent no-op and decide whether to restart.
@@ -1068,6 +1121,11 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
     # the idempotency comparison).
     _recipe, _llamacpp = device_to_backend(current_device)
     current_declared = _llamacpp or (_recipe if _recipe == "flm" else None)
+    # EFFECTIVE backend for the current config: device-derived (with the
+    # legacy ``backend``-field fallback) via the single shared mapping —
+    # what the container will actually run under. This fills the ADR-0022
+    # declared/actual contract honestly instead of a hardcoded None.
+    current_effective = _cfg_effective_backend(cfg) if isinstance(cfg, dict) else None
 
     # Is the slot currently loaded? Container truth is the slot's
     # lifecycle state; per-process backend introspection retired with the
@@ -1077,21 +1135,25 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
         is_loaded = bool(sm.is_ready_for_dispatch(name))
     except Exception:
         is_loaded = False
-    actual_backend = None
 
     # Idempotency: the requested backend already equals the declared device,
-    # AND (when loaded) the actual backend already matches → no-op.
+    # AND (when loaded) the effective backend already matches → no-op.
+    # ``auto`` has no requested token to compare, so declared-match decides.
     requested_declared = device_to_backend(target_device)[1] if target_device else None
     already_declared = current_device == (target_device or "")
-    already_actual = (
-        (not is_loaded) or (actual_backend is None) or (actual_backend == requested_declared)
+    already_effective = (
+        (not is_loaded) or (requested_declared is None) or (current_effective == requested_declared)
     )
-    if already_declared and already_actual:
+    if already_declared and already_effective:
         snap = await sm.status(name)
         out = _slot_to_dict(snap, request)
         out["requested_backend"] = backend
         out["declared_backend"] = current_declared
-        out["actual_backend"] = actual_backend if actual_backend else None
+        out["effective_backend"] = current_effective
+        # Back-compat alias — carries the effective value now (see docstring).
+        out["actual_backend"] = current_effective
+        out["device"] = current_device or None
+        out["profile"] = cfg.get("profile") if isinstance(cfg, dict) else None
         out["reloaded"] = False
         return out
 
@@ -1117,15 +1179,21 @@ async def set_slot_backend(name: str, request: Request) -> dict[str, object]:
 
     snap = await sm.status(name)
     out = _slot_to_dict(snap, request)
-    # Recompute declared/actual from the post-change state.
+    # Recompute the declared/effective snapshot from the post-change config
+    # so the response reports {declared_backend, effective_backend, device,
+    # profile} coherently for what will actually run.
     new_cfg = await sm.get_config(name)
     new_device = (new_cfg.get("device") if isinstance(new_cfg, dict) else None) or ""
     _nrecipe, _nllamacpp = device_to_backend(new_device)
     new_declared = _nllamacpp or (_nrecipe if _nrecipe == "flm" else None)
-    new_actual = None
+    new_effective = _cfg_effective_backend(new_cfg) if isinstance(new_cfg, dict) else None
     out["requested_backend"] = backend
     out["declared_backend"] = new_declared
-    out["actual_backend"] = new_actual if new_actual else None
+    out["effective_backend"] = new_effective
+    # Back-compat alias — carries the effective value now (see docstring).
+    out["actual_backend"] = new_effective
+    out["device"] = new_device or None
+    out["profile"] = new_cfg.get("profile") if isinstance(new_cfg, dict) else None
     out["reloaded"] = reloaded
     return out
 

--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -37,6 +37,7 @@ from hal0.api._audit import record_action
 from hal0.config import paths
 from hal0.config.schema import StackConfig
 from hal0.errors import BadRequest
+from hal0.model_meta import DEVICE_TO_DEFAULT_PROFILE
 from hal0.profiles import ProfileCatalog
 from hal0.stacks import ResolvedStack, StacksCatalog
 from hal0.stacks.apply import StackApplyEngine
@@ -145,13 +146,11 @@ def _registry(request: Request) -> Any:
 # A stack may name a slot that doesn't exist yet (e.g. a "quick" coder slot in a
 # cloned/imported stack). Apply must create it before the converge load, the way
 # the spec's seed copy expects. Without a profile a fresh slot fails to load
-# ("profile '' not found"), so default a coherent profile from the device.
-_PROFILE_BY_DEVICE = {
-    "gpu-rocm": "rocm",
-    "gpu-vulkan": "vulkan",
-    "npu": "flm",
-    "cpu": "",
-}
+# ("profile '' not found"), so default a coherent profile from the device via
+# the canonical map (hal0.model_meta.DEVICE_TO_DEFAULT_PROFILE) — this replaced
+# a local copy whose ``cpu`` entry was ``""``, which left a cpu-device stack
+# slot born broken with exactly that "profile '' not found" error; the
+# canonical ``cpu → "cpu-llm"`` seed profile is the deliberate unification.
 
 
 def _slot_toml_exists(slot: str) -> bool:
@@ -181,7 +180,7 @@ async def _create_missing_slots(
         if not entry.model or _slot_toml_exists(entry.slot):
             continue
         device = entry.device or "gpu-vulkan"
-        profile = entry.profile or _PROFILE_BY_DEVICE.get(device, "")
+        profile = entry.profile or DEVICE_TO_DEFAULT_PROFILE.get(device, "")
         body: dict[str, Any] = {
             "name": entry.slot,
             "type": "llm",

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -845,34 +845,31 @@ class CapabilityOrchestrator:
             ) from exc
 
     def _next_free_slot_port(self) -> int:
-        """Pick a free port in the slot range.
+        """Pick a free port in the configured slot range.
 
-        Scans every existing slot TOML for its ``port``, returns the
-        first gap inside ``8081-8099``. The SlotConfig validator pins
-        ports into that range; collisions here would surface as a
-        validation error from ``SlotManager.create``.
+        Delegates to the shared allocator
+        (:func:`hal0.api.routes.slots._next_free_slot_port`), which walks
+        every slot TOML (top-level ``port`` AND nested ``[server] port``)
+        over the configured pool — hal0.toml ``[slots]``
+        ``port_range_start/end``, defaulting to the schema's
+        ``_SLOT_PORT_MIN``/``_SLOT_PORT_MAX`` (8081-8200). This replaced a
+        stale local copy pinned to an 8081-8099 literal that contradicted
+        the schema range and capped installs at 19 slots. Exhaustion is
+        re-raised as apply_failed rather than silently colliding — the
+        user sees the envelope and knows to clean up.
         """
-        used: set[int] = set()
-        cfg_dir = paths.slots_config_dir()
-        if cfg_dir.exists():
-            for p in cfg_dir.glob("*.toml"):
-                try:
-                    slot_cfg = load_slot_config(p.stem)
-                    used.add(slot_cfg.port)
-                except Exception:
-                    # Malformed TOMLs don't reserve ports — they'll be
-                    # surfaced via the slot routes the next time the
-                    # operator looks.
-                    continue
-        for port in range(8081, 8100):
-            if port not in used:
-                return port
-        # Pool is full — surface as apply_failed rather than silently
-        # collide. The user will see the envelope and know to clean up.
-        raise CapabilityApplyFailed(
-            "no free slot port available in 8081-8099",
-            details={"used": sorted(used)},
-        )
+        # Lazy import: the API route module imports widely; keep the
+        # orchestrator importable without dragging the route graph in at
+        # module-import time.
+        from hal0.api.routes.slots import _next_free_slot_port as shared_next_free_slot_port
+
+        try:
+            return shared_next_free_slot_port()
+        except BadRequest as exc:
+            raise CapabilityApplyFailed(
+                str(exc),
+                details=dict(getattr(exc, "details", None) or {}),
+            ) from exc
 
 
 __all__ = [

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -275,9 +275,7 @@ class ServerConfig(BaseModel):
 
     @field_validator("env")
     @classmethod
-    def _env_keys_and_values_sane(
-        cls, v: dict[str, str] | None
-    ) -> dict[str, str] | None:
+    def _env_keys_and_values_sane(cls, v: dict[str, str] | None) -> dict[str, str] | None:
         """Reject non-env-var-name keys and multi-line values.
 
         A stray newline in a value would break the rendered ``--env=K=V``

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -30,10 +30,29 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 
 from hal0.config import paths
+from hal0.model_meta import (
+    BACKEND_TO_DEVICE,
+    DEFAULT_DEVICE,
+    DEVICE_TO_DEFAULT_PROFILE,
+    map_backend_to_device,
+)
+from hal0.model_meta import (
+    LEGACY_BACKENDS as _LEGACY_BACKENDS,
+)
+from hal0.model_meta import (
+    VALID_DEVICES as _VALID_DEVICES,
+)
 
 log = logging.getLogger(__name__)
 
 # ── Shared constants ───────────────────────────────────────────────────────────
+#
+# The identity vocabularies (device enum, legacy backend enum, the
+# backend→device map, per-device default profiles) live in ONE place —
+# ``hal0.model_meta`` (see its module docstring for the full vocabulary
+# table + unknown-value policy). This module re-exports them so every
+# existing ``from hal0.config.schema import …`` call site keeps working.
+# model_meta imports nothing from schema, so the dependency is one-way.
 
 # TIER1: surface-area for the backend whitelist. Typos like
 # `backend = "vukan"` must raise at load time with the field path.
@@ -43,43 +62,14 @@ log = logging.getLogger(__name__)
 # one release so legacy slot TOMLs round-trip cleanly; a warning is logged
 # whenever ``backend`` is read without an accompanying ``device``. See
 # ADR-0006 §7 (v0.2 migration plan, decision 15).
-_VALID_BACKENDS = frozenset({"vulkan", "rocm", "flm", "moonshine", "kokoro", "cpu"})
+_VALID_BACKENDS = frozenset(_LEGACY_BACKENDS)
 
 # v0.2 hardware-preference enum. ``device`` replaces the overloaded
 # ``backend`` field — it carries hardware intent only, not provider choice.
 # ``hal0.model_meta.device_to_backend`` maps these to the recipe:backend
-# pair that feeds container profile/argv derivation.
+# pair that feeds container profile/argv derivation. The Literal must match
+# ``hal0.model_meta.VALID_DEVICES`` (asserted by tests/model_meta).
 DeviceLiteral = Literal["gpu-rocm", "gpu-vulkan", "cpu", "npu"]
-_VALID_DEVICES = frozenset({"gpu-rocm", "gpu-vulkan", "cpu", "npu"})
-
-# Default ``device`` for fresh installs. Strix Halo (hal0's reference
-# target) gets best throughput on ROCm; the recommender may downgrade
-# this in hardware-aware seeds.
-DEFAULT_DEVICE: str = "gpu-rocm"
-
-# Mapping from the legacy ``backend`` enum to the v0.2 ``device`` enum.
-# Used by:
-#   - ``SlotConfig`` model-validator (auto-promote on load).
-#   - ``hal0/config/migrations/capabilities_v2.py`` (file migration).
-#   - the capabilities on-load auto-migration.
-# Keep these aligned with ADR-0006 §7. The values for moonshine/kokoro map
-# to ``cpu`` because those toolboxes were always CPU runtimes — the legacy
-# enum overloaded the term ``backend`` with provider identity.
-BACKEND_TO_DEVICE: dict[str, str] = {
-    "vulkan": "gpu-vulkan",
-    "rocm": "gpu-rocm",
-    "flm": "npu",
-    "moonshine": "cpu",
-    "kokoro": "cpu",
-    "cpu": "cpu",
-    # The capabilities catalog has historically stored values in the new
-    # namespace already (e.g. ``gpu-rocm``); accept them idempotently so
-    # both SlotConfig.backend and CapabilitySelection.backend can flow
-    # through the same map without surprise.
-    "gpu-rocm": "gpu-rocm",
-    "gpu-vulkan": "gpu-vulkan",
-    "npu": "npu",
-}
 
 # Valid provider names. ContainerProvider drives every slot lifecycle;
 # the pre-container names remain accepted so legacy slot TOMLs round-trip
@@ -115,27 +105,9 @@ CAPABILITIES_SCHEMA_VERSION_LEGACY = 1
 CAPABILITIES_SCHEMA_VERSION_CURRENT = 2
 
 
-def map_backend_to_device(backend: str | None) -> str:
-    """Map a legacy ``backend`` value to the v0.2 ``device`` enum.
-
-    Unknown values (e.g. an operator hand-edited a slot TOML with a
-    bespoke backend tag) fall back to ``cpu`` so the runtime has a safe
-    default rather than crashing at load. A warning is logged so the
-    operator notices on the next ``hal0-api`` boot.
-
-    Empty / None input is treated as "no opinion" and returns the
-    package-level default ``DEFAULT_DEVICE``.
-    """
-    if not backend:
-        return DEFAULT_DEVICE
-    mapped = BACKEND_TO_DEVICE.get(backend)
-    if mapped is not None:
-        return mapped
-    log.warning(
-        "config.device_mapping_unknown_backend",
-        extra={"backend": backend, "fallback": "cpu"},
-    )
-    return "cpu"
+# NOTE: ``map_backend_to_device`` now lives in ``hal0.model_meta`` (imported
+# above and re-exported via ``__all__``) so the legacy→device translation and
+# its unknown-value policy are defined exactly once.
 
 
 # ── ModelConfig + SlotConfig ───────────────────────────────────────────────────
@@ -877,13 +849,10 @@ PROFILE_BENCH: dict[str, dict[str, float]] = {
 #: Preselect map for the create-modal device picker and legacy-slot
 #: migration defaults.  Keys are ``DeviceLiteral`` values (gpu-rocm,
 #: gpu-vulkan, cpu, npu); values are seed profile names that best represent
-#: each device class.
-DEVICE_DEFAULT_PROFILES: dict[str, str] = {
-    "gpu-rocm": "rocm",
-    "gpu-vulkan": "vulkan",
-    "cpu": "cpu-llm",
-    "npu": "flm",
-}
+#: each device class.  Alias of the canonical
+#: :data:`hal0.model_meta.DEVICE_TO_DEFAULT_PROFILE` (kept under the old
+#: name so existing imports don't break).
+DEVICE_DEFAULT_PROFILES: dict[str, str] = DEVICE_TO_DEFAULT_PROFILE
 
 
 class ProfileConfig(BaseModel):

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -23,6 +23,7 @@ See PLAN.md §3, §5 Tier 1 ("pydantic-validated TOML schema at load time").
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Any, Literal
 
@@ -93,6 +94,9 @@ _VALID_PROVIDERS = frozenset({"llama-server", "flm", "moonshine", "kokoro", "qwe
 # bookmarks/tooling keep working.
 _SLOT_PORT_MIN = 8081
 _SLOT_PORT_MAX = 8200
+
+#: A valid POSIX environment-variable name — used to validate [server].env keys.
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # Schema version for migrations.  Bumped when a backwards-incompatible
 # config-shape change lands.  See PLAN.md §5 Tier 3.
@@ -167,7 +171,12 @@ class ModelConfig(BaseModel):
     rope_freq_base: float = Field(
         default=0.0,
         ge=0.0,
-        description="RoPE frequency base override.  0.0 means use model default.",
+        description=(
+            "DEPRECATED (accepted, ignored): the launch path no longer emits "
+            "--rope-freq-base from this field. To override RoPE base, pass "
+            "``--rope-freq-base <n>`` via [server].extra_args instead. Retained "
+            "so existing TOMLs round-trip; 0.0 means use the model default."
+        ),
     )
     extra: dict[str, Any] = Field(
         default_factory=dict,
@@ -253,6 +262,42 @@ class ServerConfig(BaseModel):
             "(append-list flags like --lora / --draft-model / --override-kv are kept)."
         ),
     )
+    env: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Environment variables injected into the slot container via "
+            "docker/podman ``--env`` (e.g. HSA_OVERRIDE_GFX_VERSION). Lets an "
+            "operator tune the runtime without forking the toolbox image. Keys "
+            "must be valid env-var names ([A-Za-z_][A-Za-z0-9_]*); values must "
+            "not contain newlines."
+        ),
+    )
+
+    @field_validator("env")
+    @classmethod
+    def _env_keys_and_values_sane(
+        cls, v: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        """Reject non-env-var-name keys and multi-line values.
+
+        A stray newline in a value would break the rendered ``--env=K=V``
+        ExecStart line (systemd is line-oriented); an invalid key name would
+        be silently ignored or mangled by the container runtime.
+        """
+        if v is None:
+            return v
+        cleaned: dict[str, str] = {}
+        for key, value in v.items():
+            if not _ENV_VAR_NAME_RE.match(str(key)):
+                raise ValueError(
+                    f"[server].env key {key!r} is not a valid environment variable name "
+                    "(must match [A-Za-z_][A-Za-z0-9_]*)"
+                )
+            sval = str(value)
+            if "\n" in sval or "\r" in sval:
+                raise ValueError(f"[server].env value for {key!r} must not contain newlines")
+            cleaned[str(key)] = sval
+        return cleaned
 
 
 class SlotConfig(BaseModel):
@@ -1268,8 +1313,10 @@ def resolve_profile_flags(profile: ProfileConfig, mtp_override: bool | None = No
         # asking for ``--spec-draft-type-k f16`` still launched with q8_0.
         #
         # Local import: ``hal0.config`` is imported before ``hal0.slots``, so a
-        # module-level import would create a cycle.
-        from hal0.slots.flag_merge import merge_flags
+        # module-level import would create a cycle. ``merge_flags`` now lives in
+        # hal0.slots.argv (folded from the retired flag_merge module) so it
+        # shares argv's tokenizer + short/long alias table.
+        from hal0.slots.argv import merge_flags
 
         return merge_flags(MTP_FLAG_BUNDLE, base)
     return base

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -10,21 +10,20 @@ Picks intentionally use models from :mod:`hal0.registry.curated` so the
 slot validates against the registry as soon as the model is downloaded.
 We do NOT invent model names.
 
-Device choice respects ``hal0.config.schema._VALID_DEVICES`` —
-``gpu-rocm``, ``gpu-vulkan``, ``cpu``, ``npu`` (ADR-0006 §7). The
-output also emits the legacy ``backend`` field for one release so a
-downgrade to v0.1.x reads the recommendation file cleanly.
+Device choice respects the canonical device enum
+(``hal0.model_meta.VALID_DEVICES`` — ``gpu-rocm``, ``gpu-vulkan``,
+``cpu``, ``npu``, ADR-0006 §7). The output also emits the legacy
+``backend`` field for one release so a downgrade to v0.1.x reads the
+recommendation file cleanly. Both translations (backend→device, device→
+default profile) come from the canonical maps in :mod:`hal0.model_meta`.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from hal0.config.schema import (
-    DEVICE_DEFAULT_PROFILES,
-    HardwareInfo,
-    map_backend_to_device,
-)
+from hal0.config.schema import HardwareInfo
+from hal0.model_meta import DEVICE_TO_DEFAULT_PROFILE, map_backend_to_device
 from hal0.registry.curated import get_curated
 
 # Curated chat models suitable for the primary slot, ordered from
@@ -200,7 +199,7 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
     # "profile '' not found in catalog", so the primary slot is born broken
     # on every fresh install. Map the device to its default profile using
     # the same table the create-modal + legacy-slot migration use.
-    profile = DEVICE_DEFAULT_PROFILES.get(device)
+    profile = DEVICE_TO_DEFAULT_PROFILE.get(device)
 
     return {
         "name": "chat",

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -7,17 +7,273 @@ five sites (``routes/models.py``, ``routes/slots.py``,
 copy. They all import from here now.
 
 The module is **stateless** — no classes, no construction, just
-importable functions. ``classify`` and ``device_to_backend`` are pure;
-``is_resolvable`` takes the registry explicitly as an argument so the
-module stays importable everywhere without threading a handle through.
+importable functions and constants. ``classify`` and
+``device_to_backend`` are pure; ``is_resolvable`` takes the registry
+explicitly as an argument so the module stays importable everywhere
+without threading a handle through.
+
+Canonical vocabulary table (issue #695 follow-up — every identity
+vocabulary the backend speaks, defined ONCE here; ``config.schema``
+re-exports for compatibility, it no longer defines its own copies):
+
+========================  ====================================================
+Vocabulary                Purpose / members
+========================  ====================================================
+device                    v0.2 hardware-preference enum stored in slot TOMLs
+                          and the capabilities catalog:
+                          ``gpu-rocm | gpu-vulkan | cpu | npu``
+                          (:data:`CANONICAL_DEVICES` carries per-device
+                          metadata; :data:`VALID_DEVICES` is the id set).
+legacy backend            DEPRECATED v0.1 ``SlotConfig.backend`` enum, kept
+                          one release for TOML round-trip:
+                          ``rocm | vulkan | cpu | flm | moonshine | kokoro``
+                          (:data:`LEGACY_BACKENDS`). It overloaded hardware
+                          intent with provider identity — ``moonshine`` /
+                          ``kokoro`` were CPU runtimes, hence they map to
+                          ``cpu`` in :data:`BACKEND_TO_DEVICE`.
+selectable backend        The runtime-switch tokens POST /api/slots/{name}/
+                          backend accepts: ``rocm | vulkan | cpu | auto``
+                          (:data:`SELECTABLE_BACKENDS`). flm/npu are excluded
+                          — switching to NPU is a recipe change, not a
+                          backend flip.
+device_class              Coarse profile bucket driving container device
+                          passthrough + card display:
+                          ``gpu | cpu | npu | img`` (:data:`DEVICE_CLASSES`).
+runtime family            Which server process a profile launches:
+                          ``llama-server | flm | kokoro | qwen3tts | comfyui``
+                          (:data:`RUNTIME_FAMILIES`; mirrors
+                          ``hal0.profiles.RuntimeFamily``).
+slot type                 Dispatcher slot vocabulary:
+                          ``llm | embedding | reranking | transcription |
+                          tts | image`` (:data:`SLOT_TYPES`; the source for
+                          ``slots.manager._VALID_SLOT_TYPES`` and mirrored by
+                          ``hal0.profiles.SlotType``).
+model capability          Canonical registry ``model.capabilities`` spellings:
+                          ``chat | vision | embed | rerank | asr | tts |
+                          image | video`` (:data:`MODEL_CAPABILITIES`, with
+                          the tolerated synonyms in
+                          :data:`CAPABILITY_ALIASES`).
+model backend             Valid ``model.backends`` values in the registry:
+                          GGUF seeds vulkan/rocm/cuda/cpu (registry/detect
+                          already lists cuda as *compatible* — slot configs
+                          can't select it yet), plus the dedicated providers
+                          flm/moonshine/kokoro/comfyui
+                          (:data:`MODEL_BACKENDS`).
+========================  ====================================================
+
+Unknown-value policy — ONE documented rule per translation direction
+(previously three sites disagreed silently):
+
+* legacy backend → device (:func:`map_backend_to_device`, and
+  :func:`canonical_device` which routes through it): unknown → **warn +
+  ``"cpu"``**. Safety default — the runtime must load *somewhere*, and CPU
+  always exists; crashing at config load over a typo would brick the API.
+* device → runtime pair (:func:`device_to_backend`): unknown → **warn +
+  ``(None, None)``** ("no opinion"). Callers already handle ``None`` by
+  applying their own defaults, so inventing a backend tag here would
+  override deliberate downstream fallbacks.
+* device → legacy write-back (:func:`device_to_legacy_backend`): unknown →
+  **warn + passthrough unchanged**. Load-bearing for forward/backward
+  compat: this function feeds the deprecated ``SlotConfig.backend`` field,
+  and passing a hand-edited token through unchanged keeps the TOML legible
+  on downgrade (the orchestrator always preserved such tokens — see the
+  #695 shape audits). Do NOT unify this onto ``None``/``cpu`` semantics.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 log = logging.getLogger(__name__)
+
+
+# ── canonical device taxonomy ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceMeta:
+    """Everything the backend (and /api/meta/enums) knows about one device."""
+
+    id: str
+    label: str
+    device_class: str
+    default_profile: str
+    legacy_backend: str
+    recommended: bool
+    description: str
+
+
+#: The four canonical devices (ADR-0006 §7), with per-device metadata.
+#: Ordering is presentation order for pickers: recommended first, then the
+#: fallback, then the non-GPU devices. Per CONTEXT.md (spike data):
+#: ``gpu-rocm`` is the recommended default on Strix Halo; ``gpu-vulkan`` is
+#: the slower fallback.
+CANONICAL_DEVICES: tuple[DeviceMeta, ...] = (
+    DeviceMeta(
+        id="gpu-rocm",
+        label="GPU (ROCm)",
+        device_class="gpu",
+        default_profile="rocm",
+        legacy_backend="rocm",
+        recommended=True,
+        description="Best throughput on Strix Halo — the recommended default.",
+    ),
+    DeviceMeta(
+        id="gpu-vulkan",
+        label="GPU (Vulkan)",
+        device_class="gpu",
+        default_profile="vulkan",
+        legacy_backend="vulkan",
+        recommended=False,
+        description="Runs anywhere Mesa Vulkan does; slower than ROCm on Strix Halo — fallback.",
+    ),
+    DeviceMeta(
+        id="cpu",
+        label="CPU",
+        device_class="cpu",
+        default_profile="cpu-llm",
+        legacy_backend="cpu",
+        recommended=False,
+        description="CPU-only inference — always available, slow but correct.",
+    ),
+    DeviceMeta(
+        id="npu",
+        label="NPU (FLM)",
+        device_class="npu",
+        default_profile="flm",
+        legacy_backend="flm",
+        recommended=False,
+        description="AMD XDNA NPU via FastFlowLM — chat/embed/ASR trio on one process.",
+    ),
+)
+
+#: Canonical device id set — the single source ``config.schema._VALID_DEVICES``
+#: now aliases.
+VALID_DEVICES: frozenset[str] = frozenset(d.id for d in CANONICAL_DEVICES)
+
+#: Default ``device`` for fresh installs (see the gpu-rocm entry above).
+DEFAULT_DEVICE: str = "gpu-rocm"
+
+#: DEPRECATED v0.1 ``SlotConfig.backend`` enum (whitelist source for
+#: ``config.schema._VALID_BACKENDS``). Tuple so JSON surfaces are ordered.
+LEGACY_BACKENDS: tuple[str, ...] = ("rocm", "vulkan", "cpu", "flm", "moonshine", "kokoro")
+
+#: Tokens POST /api/slots/{name}/backend accepts (``auto`` clears the device
+#: so the load path falls back to its default). flm/npu are deliberately not
+#: selectable — NPU needs a recipe/profile switch, not a backend flip.
+SELECTABLE_BACKENDS: tuple[str, ...] = ("rocm", "vulkan", "cpu", "auto")
+
+#: Coarse profile device buckets (``ProfileConfig.device_class``).
+DEVICE_CLASSES: tuple[str, ...] = ("gpu", "cpu", "npu", "img")
+
+#: Profile runtime families. MUST stay in sync with the
+#: ``hal0.profiles.RuntimeFamily`` Literal (a Literal can't be built from a
+#: runtime tuple; tests/model_meta assert the two match).
+RUNTIME_FAMILIES: tuple[str, ...] = ("llama-server", "flm", "kokoro", "qwen3tts", "comfyui")
+
+#: Legacy ``backend`` token → canonical ``device``. Used by the SlotConfig
+#: model-validator (auto-promote on load), the capabilities v1→v2 migration,
+#: and the capabilities on-load auto-migration. Keep aligned with ADR-0006 §7.
+#: moonshine/kokoro map to ``cpu`` because those toolboxes were always CPU
+#: runtimes — the legacy enum overloaded ``backend`` with provider identity.
+#: Canonical device ids are included idempotently so both SlotConfig.backend
+#: and CapabilitySelection.backend can flow through the same map.
+BACKEND_TO_DEVICE: dict[str, str] = {
+    **{d.legacy_backend: d.id for d in CANONICAL_DEVICES},
+    "moonshine": "cpu",
+    "kokoro": "cpu",
+    **{d.id: d.id for d in CANONICAL_DEVICES},
+}
+
+#: Device → seed profile that best represents it (create-modal preselect,
+#: legacy-slot migration defaults, stack apply's fresh-slot creation, and the
+#: installer's primary-slot recommendation). ``cpu`` maps to ``cpu-llm`` —
+#: a fresh slot with ``profile=""`` fails to load ("profile '' not found"),
+#: so an empty default is never correct here.
+DEVICE_TO_DEFAULT_PROFILE: dict[str, str] = {d.id: d.default_profile for d in CANONICAL_DEVICES}
+
+
+def map_backend_to_device(backend: str | None) -> str:
+    """Map a legacy ``backend`` value to the v0.2 ``device`` enum.
+
+    Unknown values (e.g. an operator hand-edited a slot TOML with a
+    bespoke backend tag) fall back to ``cpu`` so the runtime has a safe
+    default rather than crashing at load (module unknown-value policy,
+    direction 1). A warning is logged so the operator notices on the
+    next ``hal0-api`` boot.
+
+    Empty / None input is treated as "no opinion" and returns the
+    package-level default ``DEFAULT_DEVICE``.
+
+    Historically ``hal0.config.schema.map_backend_to_device`` — schema
+    still re-exports it; the log event name is kept for grep continuity.
+    """
+    if not backend:
+        return DEFAULT_DEVICE
+    mapped = BACKEND_TO_DEVICE.get(backend)
+    if mapped is not None:
+        return mapped
+    log.warning(
+        "config.device_mapping_unknown_backend",
+        extra={"backend": backend, "fallback": "cpu"},
+    )
+    return "cpu"
+
+
+# ── canonical model vocabulary ───────────────────────────────────────────────
+
+#: Dispatcher slot ``type`` vocabulary (plan §4.1). Single source for
+#: ``slots.manager._VALID_SLOT_TYPES``; mirrored by ``hal0.profiles.SlotType``
+#: (Literal — kept in sync by tests/model_meta).
+SLOT_TYPES: tuple[str, ...] = ("llm", "embedding", "reranking", "transcription", "tts", "image")
+
+#: Canonical ``model.capabilities`` spellings the registry stores:
+#: registry/model.py documents chat/embed/rerank/vision/asr/tts;
+#: registry/detect.py additionally emits ``image`` (ComfyUI tree) and the
+#: shared filename table (:func:`capability_from_filename`) can yield
+#: ``video`` via registry/discover (#940 diffusion hardening).
+MODEL_CAPABILITIES: tuple[str, ...] = (
+    "chat",
+    "vision",
+    "embed",
+    "rerank",
+    "asr",
+    "tts",
+    "image",
+    "video",
+)
+
+#: Tolerated capability synonyms → canonical spelling. Matches what the code
+#: actually accepts today: ``classify``'s ``_CAPABILITY_TO_TYPE`` folds
+#: stt→asr-bucket and img→image; the layout migration
+#: (cli/migrate_commands._CAPABILITY_TO_LEAF_CAP) additionally tolerates the
+#: slot-type-flavoured embedding/embeddings/reranking/transcription spellings.
+CAPABILITY_ALIASES: dict[str, str] = {
+    "embedding": "embed",
+    "embeddings": "embed",
+    "reranking": "rerank",
+    "transcription": "asr",
+    "stt": "asr",
+    "img": "image",
+}
+
+#: Valid ``model.backends`` values in the registry. The GGUF compatibility
+#: seed is registry/detect._GGUF_BACKENDS (vulkan/rocm/cuda/cpu — ``cuda`` is
+#: already listed there as *compatible*, though no slot config can select it
+#: until Wave 3 lands CUDA support); the rest are the dedicated providers
+#: detect assigns by filename/tree (moonshine, kokoro, comfyui) plus flm.
+MODEL_BACKENDS: tuple[str, ...] = (
+    "vulkan",
+    "rocm",
+    "cuda",
+    "cpu",
+    "flm",
+    "moonshine",
+    "kokoro",
+    "comfyui",
+)
 
 
 # ── classification ───────────────────────────────────────────────────────────
@@ -216,31 +472,26 @@ def canonical_device(value: str) -> str:
     is a near-identity. It still tolerates a legacy ``backend``-style
     input (``vulkan|rocm|flm|moonshine|kokoro``) for forward
     compatibility with hand-edited slot TOMLs by routing through
-    :func:`hal0.config.schema.map_backend_to_device`.
+    :func:`map_backend_to_device` (so a genuinely unknown token warns and
+    falls back to ``"cpu"`` — unknown-value policy, direction 1).
 
     Empty input means "no opinion" and returns ``""``.
     """
-    from hal0.config.schema import _VALID_DEVICES, map_backend_to_device
-
     if not value:
         return ""
-    if value in _VALID_DEVICES:
+    if value in VALID_DEVICES:
         return value
     return map_backend_to_device(value)
 
 
 # NOTE(#695): this is deliberately NOT expressed through
-# ``device_to_backend`` — the two sites disagreed on unknown input.
+# ``device_to_backend`` — the two directions differ on unknown input by
+# design (see the module docstring's unknown-value policy).
 # ``device_to_backend`` maps unknown devices to ``(None, None)`` ("no
-# opinion"), while the orchestrator's ``_slot_backend_for_catalog_id``
-# passed unknown tokens through UNCHANGED so hand-edited values stay
-# legible on downgrade. Both behaviours are preserved as-is.
-_DEVICE_TO_LEGACY_BACKEND: dict[str, str] = {
-    "gpu-vulkan": "vulkan",
-    "gpu-rocm": "rocm",
-    "npu": "flm",
-    "cpu": "cpu",
-}
+# opinion"), while this write-back path passes unknown tokens through
+# UNCHANGED so hand-edited values stay legible on downgrade. Derived from
+# :data:`CANONICAL_DEVICES` so it can never drift from the device table.
+_DEVICE_TO_LEGACY_BACKEND: dict[str, str] = {d.id: d.legacy_backend for d in CANONICAL_DEVICES}
 
 
 def device_to_legacy_backend(device: str) -> str:
@@ -249,9 +500,17 @@ def device_to_legacy_backend(device: str) -> str:
 
     Still used by code paths that write the deprecated SlotConfig.backend
     field (kept until the ``backend`` field is excised for downgrade
-    legibility). Unknown values pass through unchanged.
+    legibility). Unknown values warn and pass through unchanged
+    (unknown-value policy, direction 3 — load-bearing, see module
+    docstring).
     """
-    return _DEVICE_TO_LEGACY_BACKEND.get(device, device)
+    if not device or device in _DEVICE_TO_LEGACY_BACKEND:
+        return _DEVICE_TO_LEGACY_BACKEND.get(device, device)
+    log.warning(
+        "model_meta.unknown_device_passthrough",
+        extra={"device": device},
+    )
+    return device
 
 
 # ── resolvability ────────────────────────────────────────────────────────────
@@ -296,6 +555,20 @@ def labels_of(cfg: dict[str, Any]) -> set[str]:
 
 
 __all__ = [
+    "BACKEND_TO_DEVICE",
+    "CANONICAL_DEVICES",
+    "CAPABILITY_ALIASES",
+    "DEFAULT_DEVICE",
+    "DEVICE_CLASSES",
+    "DEVICE_TO_DEFAULT_PROFILE",
+    "LEGACY_BACKENDS",
+    "MODEL_BACKENDS",
+    "MODEL_CAPABILITIES",
+    "RUNTIME_FAMILIES",
+    "SELECTABLE_BACKENDS",
+    "SLOT_TYPES",
+    "VALID_DEVICES",
+    "DeviceMeta",
     "canonical_device",
     "capability_from_filename",
     "classify",
@@ -303,4 +576,5 @@ __all__ = [
     "device_to_legacy_backend",
     "is_resolvable",
     "labels_of",
+    "map_backend_to_device",
 ]

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -53,7 +53,7 @@ from hal0.config.schema import resolve_chat_template, resolve_profile_flags
 from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import resolve_gpu_device_paths, resolve_gpu_group_ids
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
-from hal0.slots.argv import ResolvedArgv, normalize_argv, resolve_argv
+from hal0.slots.argv import ResolvedArgv, resolve_argv
 
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
@@ -335,6 +335,86 @@ def _render_unit_from_spec(
     return _render_unit_from_plan(slot_name, spec, runtime_bin=runtime_bin)
 
 
+def _llama_argv_segments(
+    *,
+    port: int,
+    model_path: str,
+    model_alias: str | None = None,
+    context_size: int | None = None,
+    profile_flags: str = "",
+    model_defaults: dict[str, Any] | None = None,
+    chat_template_path: str | None = None,
+    mmproj: str | None = None,
+    slot_n_gpu_layers: int | None = None,
+    extra_args: str | None = None,
+) -> list[tuple[str, list[str]]]:
+    """Build the ordered, labelled llama-server argv segments (SINGLE SOURCE).
+
+    Both the launch path (:func:`_llama_launch_plan` → :func:`normalize_argv`)
+    and the preview path (:func:`_resolve_slot_argv` → :func:`resolve_argv`
+    provenance) consume THESE segments, so what an operator previews via
+    ``GET /api/slots`` / ``.../resolved`` is exactly what launches.
+
+    Precedence (lowest → highest; ``resolve_argv``/``normalize_argv`` keeps the
+    LAST occurrence of each canonical flag)::
+
+        base < profile < model_defaults < chat_template < mmproj
+             < slot_overrides < extra_args
+
+    Rationale: profile flags are generic bench-tuning; per-model registry
+    ``defaults`` should override the profile; the chat-template / mmproj the
+    slot+model resolve to come next; a slot-level ``[model].n_gpu_layers`` beats
+    the model default; and a hand-authored ``[server].extra_args`` always wins.
+    """
+    base: list[str] = ["--host", "0.0.0.0", "--port", str(port)]
+    if model_path:
+        base += ["--model", model_path]
+    # Advertise the hal0 registry model id (else llama-server reports the raw
+    # GGUF basename, which the dispatcher can't match to hal0/* virtual names).
+    if model_alias:
+        base += ["--alias", str(model_alias)]
+    # Slot context window (always resolved by _resolve_context_size — never let
+    # a slot silently inherit llama-server's 4096 default).
+    if context_size is not None:
+        base += ["--ctx-size", str(context_size)]
+
+    profile_tokens = shlex.split(profile_flags) if profile_flags and profile_flags.strip() else []
+
+    # Model-registry defaults: shlex-split extra_args + `-ngl <n>` from
+    # defaults.n_gpu_layers. rope_freq_base is intentionally NOT emitted
+    # (reachable via extra_args only — see ModelDefaults deprecation note).
+    md_tokens: list[str] = []
+    if model_defaults:
+        md_extra = model_defaults.get("extra_args")
+        if md_extra and str(md_extra).strip():
+            md_tokens += shlex.split(str(md_extra))
+        md_ngl = model_defaults.get("n_gpu_layers")
+        if md_ngl is not None:
+            md_tokens += ["-ngl", str(int(md_ngl))]
+
+    chat_tokens = ["--chat-template-file", chat_template_path] if chat_template_path else []
+    mmproj_tokens = ["--mmproj", mmproj] if mmproj else []
+
+    # Slot-level [model].n_gpu_layers (schema default -1 = unset). Emitted just
+    # before extra_args so it beats the model default but a manual -ngl in
+    # extra_args still wins.
+    slot_override_tokens: list[str] = []
+    if slot_n_gpu_layers is not None and int(slot_n_gpu_layers) >= 0:
+        slot_override_tokens += ["-ngl", str(int(slot_n_gpu_layers))]
+
+    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
+
+    return [
+        ("base", base),
+        ("profile", profile_tokens),
+        ("model_defaults", md_tokens),
+        ("chat_template", chat_tokens),
+        ("mmproj", mmproj_tokens),
+        ("slot_overrides", slot_override_tokens),
+        ("extra_args", extra_tokens),
+    ]
+
+
 def _llama_launch_plan(
     *,
     image: str,
@@ -348,43 +428,37 @@ def _llama_launch_plan(
     model_alias: str | None = None,
     chat_template_path: str | None = None,
     mmproj: str | None = None,
+    model_defaults: dict[str, Any] | None = None,
+    slot_n_gpu_layers: int | None = None,
+    env: dict[str, str] | None = None,
 ) -> RuntimeLaunchPlan:
     """Build the GPU/llama-server :class:`RuntimeLaunchPlan`.
 
     Single source of the llama-server launch shape — used by both
     :meth:`ContainerProvider.container_spec` (the load path) and the
-    :func:`_render_unit` scalar shim.  llama-server takes space-separated
-    args (``--host HOST``), so they go in ``command`` after the image.
+    :func:`_render_unit` scalar shim.  The in-container argv is assembled from
+    :func:`_llama_argv_segments` and collapsed by :func:`normalize_argv`
+    (last-wins, effective-value-preserving) so cross-segment duplicates become
+    one auditable source of truth.  llama-server takes space-separated args
+    (``--host HOST``), so they go in ``command`` after the image.
     """
-    flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
-    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
-
-    command: list[str] = ["--host", "0.0.0.0", "--port", str(port), "--model", model_path]
-    # Advertise the hal0 registry model id (else llama-server reports the raw
-    # GGUF basename, which the dispatcher can't match to hal0/* virtual names).
-    if model_alias:
-        command += ["--alias", model_alias]
-    # Slot context window (else llama-server defaults to 4096).
-    if context_size is not None:
-        command += ["--ctx-size", str(context_size)]
-    # Bench-tuned profile flags, then chat-template (resolved from slot/model),
-    # then [server].extra_args (slot wins — a manual --chat-template-file in
-    # extra_args can override the resolved one since it follows).
-    command += flag_tokens
-    if chat_template_path:
-        command += ["--chat-template-file", chat_template_path]
-    # Vision projector: --mmproj loads the multimodal projector so the model
-    # can accept images. Mirrors the native llama_server.py provider. Placed
-    # before extra_tokens so a manual --mmproj in [server].extra_args can win.
-    if mmproj:
-        command += ["--mmproj", mmproj]
-    command += extra_tokens
-
-    # Collapse cross-segment duplicates (profile flags vs [server].extra_args vs
-    # toggle-derived flags) to one source of truth: last-wins dedup, which is
-    # effective-value-preserving because llama-server already used the last
-    # occurrence. See hal0.slots.argv.normalize_argv.
-    command = normalize_argv(command).argv
+    segments = _llama_argv_segments(
+        port=port,
+        model_path=model_path,
+        model_alias=model_alias,
+        context_size=context_size,
+        profile_flags=flags_str,
+        model_defaults=model_defaults,
+        chat_template_path=chat_template_path,
+        mmproj=mmproj,
+        slot_n_gpu_layers=slot_n_gpu_layers,
+        extra_args=extra_args,
+    )
+    # resolve_argv over the labelled segments is argv-equivalent to
+    # normalize_argv over the flat concatenation (pinned by tests/slots/
+    # test_argv.py::test_resolve_argv_equivalent_argv_to_normalize), so launch
+    # and preview render byte-identical commands.
+    command = resolve_argv(segments).argv
 
     # Effective model-store root (honours [models].store / HAL0_MODEL_STORE,
     # default /mnt/ai-models). Mounted identical-path, read-only, with an
@@ -394,6 +468,9 @@ def _llama_launch_plan(
     return RuntimeLaunchPlan(
         image=image,
         command=command,
+        # [server].env → docker run --env (e.g. HSA_OVERRIDE_GFX_VERSION) so
+        # operators can tune the runtime without forking the image.
+        env=dict(env) if env else {},
         mounts=[Mount(model_store, model_store, read_only=True, selinux="z")],
         devices=list(devices),
         group_add=list(group_ids),
@@ -507,6 +584,72 @@ def _resolve_context_size(explicit: int | None, model_info: dict[str, Any]) -> i
     return _CTX_SAFE_FALLBACK
 
 
+def _resolve_llama_scalars(
+    slot_cfg: dict[str, Any],
+    model_info: dict[str, Any],
+    profile: Any,
+) -> dict[str, Any]:
+    """Resolve every llama-server launch scalar for a slot+model+profile.
+
+    SINGLE SOURCE for both the launch path (:meth:`ContainerProvider.container_spec`)
+    and the preview path (:func:`_resolve_slot_argv`): profile flags (MTP-expanded
+    via the slot ``mtp`` override), the always-resolved context size, the
+    registry model alias, the resolved chat-template file path, the vision-gated
+    mmproj sidecar, the per-model registry ``defaults`` bundle, the slot-level
+    ``[model].n_gpu_layers`` override, and the ``[server]`` env / extra_args.
+    Returning one dict means the two paths can never drift.
+    """
+    image, flags_str = _profile_image_and_flags(profile, slot_cfg.get("mtp"))
+
+    model_table = slot_cfg.get("model") or {}
+    if not isinstance(model_table, dict):
+        model_table = {}
+    context_size = _resolve_context_size(model_table.get("context_size"), model_info)
+
+    server_table = slot_cfg.get("server") or {}
+    if not isinstance(server_table, dict):
+        server_table = {}
+    extra_args = server_table.get("extra_args")
+    server_env = server_table.get("env")
+    if not isinstance(server_env, dict):
+        server_env = None
+
+    # Registry model id → llama-server --alias so the container advertises the
+    # hal0 id (not the raw GGUF basename) for dispatcher matching.
+    model_alias = model_info.get("_model_key") or model_table.get("default") or None
+
+    # Resolve chat template: slot override > model defaults.chat_template > None.
+    # None/'auto' = GGUF-embedded template (no --chat-template-file flag).
+    tmpl_id = resolve_chat_template(slot_cfg, model_info)
+    chat_template_path = (
+        str(Path(model_store_root()) / "chat-templates" / f"{tmpl_id}.jinja") if tmpl_id else None
+    )
+
+    # Vision projector sidecar, gated by the per-slot ``vision`` toggle (#901).
+    mmproj = model_info.get("mmproj")
+    if not slot_cfg.get("vision", True):
+        mmproj = None
+
+    defaults = model_info.get("defaults")
+    model_defaults = defaults if isinstance(defaults, dict) else None
+
+    slot_n_gpu_layers = model_table.get("n_gpu_layers")
+
+    return {
+        "image": str(image),
+        "flags_str": str(flags_str),
+        "context_size": context_size,
+        "extra_args": extra_args,
+        "server_env": server_env,
+        "model_alias": model_alias,
+        "chat_template_path": chat_template_path,
+        "mmproj": str(mmproj) if mmproj else None,
+        "model_defaults": model_defaults,
+        "slot_n_gpu_layers": slot_n_gpu_layers,
+        "device_class": str(getattr(profile, "device_class", "gpu") or "gpu"),
+    }
+
+
 class ContainerProvider(Provider):
     """Podman-container-per-slot inference backend.
 
@@ -551,64 +694,48 @@ class ContainerProvider(Provider):
 
         This is the load path for GPU slots: :meth:`load_sync` resolves the
         provider, calls ``container_spec``, and hands the plan to the single
-        renderer.  The plan is complete — registry alias, slot ``context_size``,
-        ``[server].extra_args``, the read-only model-store mount, and the
-        health-check override are all included, so what loads matches what the
-        plan describes (no GPU-special argv assembly elsewhere).
+        renderer.  The plan is complete — registry alias, model-registry
+        ``defaults``, slot ``context_size``, chat-template, mmproj,
+        ``[server].env``/``extra_args``, the read-only model-store mount, and
+        the health-check override are all included, so what loads matches what
+        the plan describes (no GPU-special argv assembly elsewhere).
+
+        GPU device nodes + group GIDs are included ONLY for gpu/img profiles
+        and are existence-filtered — a cpu (or npu) ``device_class`` profile
+        gets no ``/dev/kfd`` / ``/dev/dri`` passthrough or ``--group-add``.
         """
         profile_name = slot_cfg.get("profile") or ""
-        image, flags_str = _profile_image_and_flags(
-            _resolve_profile(profile_name), slot_cfg.get("mtp")
-        )
+        profile = _resolve_profile(profile_name)
+        scalars = _resolve_llama_scalars(slot_cfg, model_info, profile)
 
         model_path = _resolve_model_path(model_info)
         port = int(slot_cfg.get("port", 0))
 
-        model_table = slot_cfg.get("model") or {}
-        context_size = _resolve_context_size(
-            model_table.get("context_size") if isinstance(model_table, dict) else None,
-            model_info,
-        )
-        server_table = slot_cfg.get("server") or {}
-        extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
-        # Registry model id → llama-server --alias so the container advertises
-        # the hal0 id (not the raw GGUF basename) for dispatcher matching.
-        model_alias = model_info.get("_model_key") or (
-            model_table.get("default") if isinstance(model_table, dict) else None
-        )
-
-        # Resolve chat template: slot override > model defaults.chat_template > None.
-        # None/'auto' = use GGUF-embedded template (no --chat-template-file flag).
-        # Templates live at <model_store_root>/chat-templates/<id>.jinja and are
-        # mounted identical-path into the container, so the host path == container path.
-        tmpl_id = resolve_chat_template(slot_cfg, model_info)
-        chat_template_path = (
-            str(Path(model_store_root()) / "chat-templates" / f"{tmpl_id}.jinja")
-            if tmpl_id
-            else None
-        )
-
-        # Vision projector sidecar associated with the model in the registry
-        # (#899). Bind-mounted at its identical host path, so the container sees
-        # the same path. None for text-only models — no flag emitted. Gated by
-        # the per-slot ``vision`` toggle (#901, default-on): vision=false boots
-        # the slot text-only even when a sidecar exists.
-        mmproj = model_info.get("mmproj")
-        if not slot_cfg.get("vision", True):
-            mmproj = None
+        # GPU plumbing gate (#674/CPU-profile fix): only gpu/img profiles get
+        # device nodes + group GIDs, and only device paths that actually exist
+        # on this host are passed (podman errors on a non-existent --device).
+        if scalars["device_class"] in ("gpu", "img"):
+            devices = [p for p in resolve_gpu_device_paths() if os.path.exists(p)]
+            group_ids = [str(g) for g in resolve_gpu_group_ids()]
+        else:
+            devices = []
+            group_ids = []
 
         return _llama_launch_plan(
-            image=image,
+            image=scalars["image"],
             port=port,
             model_path=model_path,
-            flags_str=flags_str,
-            devices=list(resolve_gpu_device_paths()),
-            group_ids=[str(g) for g in resolve_gpu_group_ids()],
-            context_size=context_size,
-            extra_args=extra_args,
-            model_alias=model_alias,
-            chat_template_path=chat_template_path,
-            mmproj=str(mmproj) if mmproj else None,
+            flags_str=scalars["flags_str"],
+            devices=devices,
+            group_ids=group_ids,
+            context_size=scalars["context_size"],
+            extra_args=scalars["extra_args"],
+            model_alias=scalars["model_alias"],
+            chat_template_path=scalars["chat_template_path"],
+            mmproj=scalars["mmproj"],
+            model_defaults=scalars["model_defaults"],
+            slot_n_gpu_layers=scalars["slot_n_gpu_layers"],
+            env=scalars["server_env"],
         )
 
     # ── ContainerProvider-specific control plane ──────────────────────────────
@@ -623,7 +750,9 @@ class ContainerProvider(Provider):
         """Run a subprocess synchronously (load/unload are blocking ops anyway)."""
         return subprocess.run(list(args), capture_output=True, text=True, check=check)
 
-    async def health(self, port: int) -> dict[str, Any]:
+    async def health(
+        self, port: int, slot_cfg: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Probe GET /health on the container port.
 
         For llama-server slots /health returns 200 when ready.
@@ -632,6 +761,18 @@ class ContainerProvider(Provider):
         body is JSON and carries a ``model_loaded`` key, ok is gated on
         ``model_loaded is True``. Bodies without the key (llama-server) keep
         the plain-200 behavior.
+
+        FLM Tier-1 delegation: when ``slot_cfg`` is supplied and the slot
+        resolves to :class:`~hal0.providers.flm.FLMProvider` (via
+        :func:`_spec_provider_for`), delegate to that provider's health probe —
+        a real ``/v1/chat/completions`` round-trip (non-empty /v1/models is a
+        known-insufficient check for a wedged NPU). The probe distinguishes
+        "up but still loading" (ok=False, status ``models_endpoint_empty`` /
+        ``sentinel_completion_*``) from "dead" (transport error), preserving
+        FLMProvider.health's semantics for the manager's strike-based
+        fail-watcher. Callers without slot context (the legacy port-only path)
+        keep the weak /v1/models fallback below.
+
         FLM containers have no /health endpoint — they return 404 there.
         When /health returns a non-connection error (e.g. 404), fall back to
         GET /v1/models; 200 there means the server is up and healthy.
@@ -639,6 +780,16 @@ class ContainerProvider(Provider):
 
         Returns {"ok": bool, "status": str}.
         """
+        if slot_cfg is not None:
+            try:
+                provider = _spec_provider_for(slot_cfg)
+            except Exception:
+                provider = None
+            from hal0.providers.flm import FLMProvider
+
+            if isinstance(provider, FLMProvider):
+                return await provider.health(port)
+
         health_url = f"http://127.0.0.1:{port}/health"
         models_url = f"http://127.0.0.1:{port}/v1/models"
         try:
@@ -1005,6 +1156,43 @@ def resolved_command_for_slot(
     return [image, *result.argv]
 
 
+def _best_effort_model_info(
+    slot_cfg: dict[str, Any],
+    model_path: str | None = None,
+) -> dict[str, Any]:
+    """Best-effort model-registry entry for the preview path.
+
+    The preview builders (:func:`resolved_command_for_slot` /
+    :func:`resolved_argv_detail_for_slot`) run without a live model download and
+    are called with only the slot cfg. To render the SAME argv the launch path
+    would (model registry ``defaults``, mmproj sidecar, native context window,
+    chat-template), look the model up in the registry — but never raise: a miss
+    or an un-wired registry degrades to a minimal ``{_model_key, path}`` dict,
+    exactly the best-effort contract the launch path's ``_resolve_model_path``
+    already tolerates.
+    """
+    model_table = slot_cfg.get("model") or {}
+    model_id = (
+        model_table.get("default", "") if isinstance(model_table, dict) else str(model_table)
+    ) or ""
+    info: dict[str, Any] = {}
+    if model_id:
+        info["_model_key"] = model_id
+        try:
+            from hal0.registry.store import ModelRegistry
+
+            model = ModelRegistry().get(model_id)
+            dump = model.model_dump() if hasattr(model, "model_dump") else dict(model)
+            info.update(dump)
+        except Exception:
+            # Registry miss / un-wired / stub — minimal info is fine for preview.
+            pass
+    effective = model_path or info.get("path") or model_id
+    if effective:
+        info["path"] = str(effective)
+    return info
+
+
 def _resolve_slot_argv(
     slot_cfg: dict[str, Any],
     model_path: str | None = None,
@@ -1013,49 +1201,39 @@ def _resolve_slot_argv(
 
     Returns ``(image, ResolvedArgv)`` — the deduped flag portion (image
     excluded) plus per-flag provenance — or ``None`` when the slot has no
-    profile / the profile lookup fails. Segments are ordered lowest-precedence
-    first (base < profile < extra_args) so ``resolve_argv``'s last-wins matches
-    the launch path: a flag in ``[server].extra_args`` overrides the profile.
+    profile / the profile lookup fails. Consumes the SAME
+    :func:`_llama_argv_segments` builder and :func:`_resolve_llama_scalars`
+    resolver the launch path uses, so the previewed argv (including the mtp
+    override, model-registry defaults, chat-template file, mmproj, slot ngl
+    override, and the always-resolved ctx-size) is byte-identical to what
+    :meth:`ContainerProvider.container_spec` would launch.
     """
     profile_name = str(slot_cfg.get("profile") or "")
     if not profile_name:
         return None
     try:
-        image, flags_str = _profile_image_and_flags(_resolve_profile(profile_name))
+        profile = _resolve_profile(profile_name)
+        model_info = _best_effort_model_info(slot_cfg, model_path)
+        scalars = _resolve_llama_scalars(slot_cfg, model_info, profile)
     except Exception:
         return None
 
-    flag_tokens = shlex.split(flags_str) if flags_str.strip() else []
-
     # port: may be at top-level or nested under [slot]
     port = int(slot_cfg.get("port") or slot_cfg.get("slot", {}).get("port") or 0)
-    # model lives under [model] default (nested TOML table), not as a top-level string
-    model_table = slot_cfg.get("model") or {}
-    default_model = (
-        model_table.get("default", "") if isinstance(model_table, dict) else str(model_table)
-    )
-    effective_model = model_path or str(default_model or "")
-    context_size = model_table.get("context_size") if isinstance(model_table, dict) else None
-    server_table = slot_cfg.get("server") or {}
-    extra_args = server_table.get("extra_args") if isinstance(server_table, dict) else None
-    extra_tokens = shlex.split(extra_args) if extra_args and extra_args.strip() else []
 
-    base: list[str] = ["--host", "0.0.0.0", "--port", str(port)]
-    if effective_model:
-        base += ["--model", effective_model]
-    if default_model:
-        base += ["--alias", str(default_model)]
-    if context_size is not None:
-        base += ["--ctx-size", str(context_size)]
-
-    result = resolve_argv(
-        [
-            ("base", base),
-            ("profile", flag_tokens),
-            ("extra_args", extra_tokens),
-        ]
+    segments = _llama_argv_segments(
+        port=port,
+        model_path=str(model_info.get("path") or ""),
+        model_alias=scalars["model_alias"],
+        context_size=scalars["context_size"],
+        profile_flags=scalars["flags_str"],
+        model_defaults=scalars["model_defaults"],
+        chat_template_path=scalars["chat_template_path"],
+        mmproj=scalars["mmproj"],
+        slot_n_gpu_layers=scalars["slot_n_gpu_layers"],
+        extra_args=scalars["extra_args"],
     )
-    return image, result
+    return str(scalars["image"]), resolve_argv(segments)
 
 
 def resolved_argv_detail_for_slot(
@@ -1066,9 +1244,10 @@ def resolved_argv_detail_for_slot(
 
     Returns ``{"argv", "provenance", "removed"}`` where ``provenance`` lists each
     surviving flag with the segment that set its final value (``base`` /
-    ``profile`` / ``extra_args``) — so an operator can see exactly which source
-    won each flag and how many duplicates were collapsed. ``None`` for a slot
-    with no profile.
+    ``profile`` / ``model_defaults`` / ``chat_template`` / ``mmproj`` /
+    ``slot_overrides`` / ``extra_args``) — so an operator can see exactly which
+    source won each flag and how many duplicates were collapsed. The UI renders
+    these labels generically. ``None`` for a slot with no profile.
     """
     resolved = _resolve_slot_argv(slot_cfg, model_path)
     if resolved is None:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -750,9 +750,7 @@ class ContainerProvider(Provider):
         """Run a subprocess synchronously (load/unload are blocking ops anyway)."""
         return subprocess.run(list(args), capture_output=True, text=True, check=check)
 
-    async def health(
-        self, port: int, slot_cfg: dict[str, Any] | None = None
-    ) -> dict[str, Any]:
+    async def health(self, port: int, slot_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
         """Probe GET /health on the container port.
 
         For llama-server slots /health returns 200 when ready.

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -51,11 +51,16 @@ _DEFAULT_FLM_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
 # at the binary. ENTRYPOINT runs the in-image flm via tini, so the
 # container_spec only supplies the subcommand + args.
 #
-# _DEFAULT_FLM_ROOT below is retained ONLY for the non-container fallback
-# path used by start_cmd() (native systemd runs, tests, debug shells).
-# Container runs no longer reference it.
-_IMAGE_FLM_ROOT = "/opt/fastflowlm"
-_DEFAULT_FLM_ROOT = "/opt/hal0/flm-ubuntu"
+# Two distinct FLM install roots — kept clearly named so they never get
+# confused again:
+#   * _CONTAINER_FLM_ROOT — where the toolbox IMAGE bundles FLM (binary, libs,
+#     xclbins, share assets). Used only to build the container's env
+#     (FLM_CONFIG_PATH / LD_LIBRARY_PATH) in container_spec().
+#   * _NATIVE_FLM_ROOT — where a HOST/native FLM tree lives for the non-
+#     container fallback path used by start_cmd() (native systemd runs, tests,
+#     debug shells). Container runs never reference it.
+_CONTAINER_FLM_ROOT = "/opt/fastflowlm"
+_NATIVE_FLM_ROOT = "/opt/hal0/flm-ubuntu"
 # FLM's per-user model cache. Bind-mounted writable so `flm pull` downloads
 # survive container restarts. (Still used by the serving container_spec below.)
 _DEFAULT_FLM_MODELS_DIR = "/var/lib/hal0/.config/flm/models"
@@ -193,7 +198,7 @@ class FLMProvider(Provider):
         Used by tests and the fallback systemd-without-Docker path. The
         primary deployment path is ``container_spec``.
         """
-        binary = os.environ.get("HAL0_FLM_BINARY", f"{_DEFAULT_FLM_ROOT}/bin/flm")
+        binary = os.environ.get("HAL0_FLM_BINARY", f"{_NATIVE_FLM_ROOT}/bin/flm")
         argv = [
             binary,
             "serve",
@@ -292,7 +297,7 @@ class FLMProvider(Provider):
             env={
                 # Image-internal paths (the Dockerfile installs FLM at
                 # /opt/fastflowlm and XRT at /opt/xilinx/xrt).
-                "FLM_CONFIG_PATH": f"{_IMAGE_FLM_ROOT}/share/flm/model_list.json",
+                "FLM_CONFIG_PATH": f"{_CONTAINER_FLM_ROOT}/share/flm/model_list.json",
                 # Docker `--env LD_LIBRARY_PATH=...` REPLACES the image ENV
                 # set by the Dockerfile rather than augmenting it, so we
                 # must spell out every path here even though the image's
@@ -300,7 +305,7 @@ class FLMProvider(Provider):
                 # (XRT runtime) and the FLM libs (libllama_npu.so &c, dlopen'd
                 # when models load) both need to be findable; missing either
                 # crashes /usr/local/bin/flm at startup before main().
-                "LD_LIBRARY_PATH": f"{_IMAGE_FLM_ROOT}/lib:/opt/xilinx/xrt/lib:/usr/lib/x86_64-linux-gnu",
+                "LD_LIBRARY_PATH": f"{_CONTAINER_FLM_ROOT}/lib:/opt/xilinx/xrt/lib:/usr/lib/x86_64-linux-gnu",
             },
             mounts=mounts,
             # /dev/accel/accel0: XDNA2 NPU. /dev/dri/renderD128: iGPU companion.
@@ -424,15 +429,16 @@ class FLMProvider(Provider):
 # hal0.capabilities.catalog, which calls flm_served_models() to learn
 # which model tags the NPU advertises.
 #
-# Design call (2026-05-20): cache the probe result until process restart.
-# Toolbox image upgrades require an hal0-api restart anyway, and the
-# catalog refresh path is rare enough that a TTL would add complexity
-# without buying us much. Tests + a future manual-refresh CLI can call
-# reset_flm_catalog_cache() to invalidate.
-
+# Design call: cache the probe result with a short TTL. A `flm pull` (or a
+# toolbox/host FLM upgrade) changes what's installed WITHOUT restarting
+# hal0-api, so a restart-only cache would show a stale catalog for the rest of
+# the process lifetime. A 5-minute TTL bounds that staleness cheaply; tests and
+# the force-refresh CLI/UI hook call reset_flm_catalog_cache() to invalidate
+# immediately.
+_FLM_CATALOG_TTL_S = 300.0
 
 _FLM_CATALOG_CACHE: list[dict[str, Any]] | None = None
-_FLM_PROBE_OK: bool = False
+_FLM_CATALOG_CACHED_AT: float = 0.0
 
 
 def _classify_flm_model(entry: dict[str, Any]) -> list[str]:
@@ -562,19 +568,22 @@ def flm_served_models() -> list[dict[str, Any]]:
             "family":       "embed-gemma",       # details.family — useful for grouping
         }
 
-    Cached at module scope on first successful probe; subsequent calls
-    are O(1). On probe failure the result is an empty list (also
-    cached) so the catalog still renders — call
-    :func:`reset_flm_catalog_cache` to force a re-probe.
+    Cached at module scope with a 5-minute TTL (:data:`_FLM_CATALOG_TTL_S`);
+    subsequent calls inside the window are O(1). On probe failure the result is
+    an empty list (also cached, same TTL) so the catalog still renders — call
+    :func:`reset_flm_catalog_cache` to force an immediate re-probe.
     """
-    global _FLM_CATALOG_CACHE, _FLM_PROBE_OK
-    if _FLM_CATALOG_CACHE is not None:
+    import time
+
+    global _FLM_CATALOG_CACHE, _FLM_CATALOG_CACHED_AT
+    now = time.monotonic()
+    if _FLM_CATALOG_CACHE is not None and (now - _FLM_CATALOG_CACHED_AT) < _FLM_CATALOG_TTL_S:
         return _FLM_CATALOG_CACHE
 
     raw = _probe_flm_catalog()
     if raw is None:
         _FLM_CATALOG_CACHE = []
-        _FLM_PROBE_OK = False
+        _FLM_CATALOG_CACHED_AT = now
         return _FLM_CATALOG_CACHE
 
     out: list[dict[str, Any]] = []
@@ -597,19 +606,20 @@ def flm_served_models() -> list[dict[str, Any]]:
         )
 
     _FLM_CATALOG_CACHE = out
-    _FLM_PROBE_OK = True
+    _FLM_CATALOG_CACHED_AT = now
     return _FLM_CATALOG_CACHE
 
 
 def reset_flm_catalog_cache() -> None:
-    """Drop the cached FLM catalog so the next call re-probes.
+    """Drop the cached FLM catalog so the next call re-probes immediately.
 
-    Exposed for tests and for a future "refresh catalog" CLI/UI hook.
-    Production code relies on process restart to invalidate.
+    Exposed for tests and for the "refresh catalog" CLI/UI hook. The 5-minute
+    TTL bounds staleness on its own; this forces an out-of-band refresh (e.g.
+    right after a ``flm pull``).
     """
-    global _FLM_CATALOG_CACHE, _FLM_PROBE_OK
+    global _FLM_CATALOG_CACHE, _FLM_CATALOG_CACHED_AT
     _FLM_CATALOG_CACHE = None
-    _FLM_PROBE_OK = False
+    _FLM_CATALOG_CACHED_AT = 0.0
 
 
 def is_flm_tag(model_id: str) -> bool:
@@ -691,7 +701,7 @@ def flm_pull_command(tag: str) -> tuple[list[str], str]:
 
 
 _FLM_PROGRESS_RE = re.compile(
-    r"Downloading:\s*([0-9.]+)%\s*\(([0-9.]+)\s*([KMG]?)B\s*/\s*([0-9.]+)\s*([KMG]?)B\)"
+    r"Downloading:\s*([0-9.]+)%\s*\(([0-9.]+)\s*([KMGT]?)B\s*/\s*([0-9.]+)\s*([KMGT]?)B\)"
 )
 
 
@@ -709,7 +719,7 @@ def parse_flm_progress(line: str) -> tuple[int, int] | None:
     if not m:
         return None
     _pct, cur, cur_unit, tot, tot_unit = m.groups()
-    units = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3}
+    units = {"": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
     try:
         bytes_downloaded = int(float(cur) * units[cur_unit])
         bytes_total = int(float(tot) * units[tot_unit])

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -75,8 +75,66 @@ def write_slot_toml(path: Path | str, data: dict[str, Any]) -> None:
     writer inventory stays greppable (issue #697). Raises ``OSError`` on
     filesystem failure and ``TypeError`` on non-TOML-encodable values,
     same as the underlying writer.
+
+    Cross-process serialization is the CALLER's job: wrap the whole
+    read-modify-write (not just this write) in :func:`slot_write_lock`.
     """
     write_toml_atomic(Path(path), data)
+
+
+@contextlib.contextmanager
+def slot_write_lock(slots_dir: Path | str | None = None) -> Iterator[None]:
+    """Hold the coarse cross-process lock for ALL slots/*.toml writes.
+
+    Historically :meth:`SlotConfigStore.transaction` guarded only
+    ``capabilities.toml``, so slot-TOML read-modify-writes from the API
+    (``SlotManager.update_config`` / ``create`` / ``_persist_model_default``),
+    the CLI, and the stacks apply engine could interleave and drop each
+    other's change. Every slot-TOML RMW now opts into this ONE advisory
+    lock — a single lock file (``<slots_dir>.lock``, i.e. the sibling of
+    the slots config dir) covering every slot file. Deliberately coarse:
+    slot writes are rare, tiny, and a per-file lock would buy nothing but
+    ordering headaches.
+
+    Same re-entrancy contract as :func:`hal0.config.locking.file_lock`
+    (per-thread re-entrant; serializing across threads and processes).
+    IMPORTANT: do not ``await`` anything that can actually suspend while
+    holding it — a second coroutine on the same thread would observe the
+    thread-local re-entrancy depth and walk straight in.
+
+    ``slots_dir`` overrides the default ``paths.slots_config_dir()`` for
+    stores constructed against a custom directory (tests).
+    """
+    base = Path(slots_dir) if slots_dir is not None else paths.slots_config_dir()
+    with file_lock(base):
+        yield
+
+
+def fold_ctx_size_alias(cfg_dict: dict[str, Any]) -> None:
+    """Fold the legacy ``[model].ctx_size`` alias into the canonical
+    ``context_size`` (#585) — THE single normalization point.
+
+    The dashboard slot-edit panel writes ``ctx_size``; the load path reads
+    ``context_size``. Persisting both lets them silently diverge. A fresh
+    ``ctx_size`` (the operator's latest write) wins over any stale
+    ``context_size``, then the alias is dropped so exactly one key survives
+    on disk. No-op when ``ctx_size`` is absent.
+
+    Copy-safe on the nested table: the ``[model]`` sub-dict is copied
+    before mutation and rebound onto ``cfg_dict``, so callers that share
+    the sub-dict with a "before" snapshot (the store's ChangeSet) are
+    never corrupted. ``cfg_dict`` itself is mutated in place.
+
+    Used by :func:`merge_slot_config` (which covers
+    ``SlotManager.update_config`` and the store) and by
+    ``SlotManager.create`` — previously three separate copies of this fold
+    existed and could drift.
+    """
+    model = cfg_dict.get("model")
+    if isinstance(model, dict) and "ctx_size" in model:
+        model = dict(model)
+        model["context_size"] = model.pop("ctx_size")
+        cfg_dict["model"] = model
 
 
 # ── the shared slot-projection merge primitive (SC-11) ───────────────────────
@@ -118,15 +176,122 @@ def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str
             after[key] = value
 
     # #585: fold the legacy [model].ctx_size alias into the canonical
-    # context_size. Copy the sub-dict before mutating so ``base`` (the store's
+    # context_size via the ONE shared fold (:func:`fold_ctx_size_alias`).
+    # The fold copies the sub-dict before mutating so ``base`` (the store's
     # ``before`` snapshot) is never touched even when ``updates`` carried no
     # [model] and ``after["model"]`` is still ``base``'s object.
-    model = after.get("model")
-    if isinstance(model, dict) and "ctx_size" in model:
-        model = dict(model)
-        model["context_size"] = model.pop("ctx_size")
-        after["model"] = model
+    fold_ctx_size_alias(after)
     return after
+
+
+# ── boundary validation for slot-config writes ───────────────────────────────
+
+#: Top-level keys that are NOT declared on ``SlotConfig`` (they round-trip
+#: through its ``extra="allow"``) but are documented, actively-read parts of
+#: the slot-TOML surface. The unknown-key validator tolerates exactly these;
+#: anything else at the top level is treated as a typo.
+#:
+#:   - ``type``           — slot kind (llm/embedding/…), read all over manager/routing.
+#:   - ``default``        — SC-4 per-type default flag, read by default_slot_for.
+#:   - ``lru``            — pressure-eviction eligibility (#903).
+#:   - ``default_voice`` / ``default_language`` — TTS engine extras written by
+#:     the dashboard voice settings (PUT /api/slots/tts/config).
+#:   - ``slot``           — the nested on-disk [slot] table shape (hoisted on load).
+TOLERATED_SLOT_CONFIG_KEYS: frozenset[str] = frozenset(
+    {"type", "default", "lru", "default_voice", "default_language", "slot"}
+)
+
+#: Extra keys tolerated inside specific sub-tables, keyed by sub-table name.
+#: ``[model].ctx_size`` is the documented legacy alias of ``context_size``
+#: (#585) — accepted on write, folded by :func:`fold_ctx_size_alias`.
+_TOLERATED_SUBTABLE_KEYS: dict[str, frozenset[str]] = {
+    "model": frozenset({"ctx_size"}),
+}
+
+
+def _known_field_names(model_cls: Any) -> set[str]:
+    """Field names + aliases a pydantic model accepts — derived dynamically.
+
+    Reading ``model_fields`` (not a hardcoded list) means a field another
+    change adds to the schema (e.g. ``ServerConfig.env``) passes validation
+    automatically, with no second list to keep in sync.
+    """
+    names: set[str] = set()
+    for name, field in model_cls.model_fields.items():
+        names.add(name)
+        alias = getattr(field, "alias", None)
+        if alias:
+            names.add(alias)
+    return names
+
+
+def unknown_slot_config_keys(payload: dict[str, Any]) -> list[str]:
+    """Dotted paths of payload keys the slot-config schema does not know.
+
+    ``SlotConfig`` and its sub-models are ``extra="allow"`` so a typo'd key
+    (``ctx_sizee``, ``enabeld``) round-trips to disk silently and the
+    intended setting never takes effect. This walks ``payload`` (a partial
+    slot-config write body: PUT /config, PATCH /defaults wrapped under
+    ``model``, POST create) against the pydantic field sets of
+    ``SlotConfig`` / ``ModelConfig`` / ``ServerConfig`` / ``NpuConfig`` /
+    ``ImageGenConfig`` and returns the paths of unknown keys, sorted.
+
+    Tolerated beyond the declared fields:
+      - documented legacy aliases: ``[model].ctx_size``, top-level
+        ``backend`` / ``provider`` / ``runtime`` (declared deprecated
+        fields), a *string* ``image`` (per-slot container-image override),
+      - the actively-read extras in :data:`TOLERATED_SLOT_CONFIG_KEYS`,
+      - ``extra`` tables at any level (verbatim provider passthrough by
+        contract — never validated).
+
+    Known fields are derived from ``model_fields`` dynamically, so schema
+    additions (e.g. ``[server].env``) pass without touching this module.
+    """
+    from hal0.config.schema import (
+        ImageGenConfig,
+        ModelConfig,
+        NpuConfig,
+        ServerConfig,
+        SlotConfig,
+    )
+
+    sub_models: dict[str, Any] = {
+        "model": ModelConfig,
+        "server": ServerConfig,
+        "npu": NpuConfig,
+        "image": ImageGenConfig,
+        "image_gen": ImageGenConfig,
+    }
+    top_known = _known_field_names(SlotConfig) | TOLERATED_SLOT_CONFIG_KEYS
+    unknown: list[str] = []
+
+    def _check_subtable(prefix: str, table: dict[str, Any], model_cls: Any, name: str) -> None:
+        known = _known_field_names(model_cls) | _TOLERATED_SUBTABLE_KEYS.get(name, frozenset())
+        for key in table:
+            if key not in known:
+                unknown.append(f"{prefix}{key}")
+
+    def _check_top(prefix: str, mapping: dict[str, Any]) -> None:
+        for key, value in mapping.items():
+            if key not in top_known:
+                unknown.append(f"{prefix}{key}")
+                continue
+            if key == "extra":
+                continue  # verbatim passthrough by contract
+            if key == "slot" and isinstance(value, dict):
+                # Nested on-disk [slot] table — same vocabulary as top level.
+                for sub_key in value:
+                    if sub_key not in top_known or sub_key == "slot":
+                        unknown.append(f"{prefix}slot.{sub_key}")
+                continue
+            model_cls = sub_models.get(key)
+            if model_cls is not None and isinstance(value, dict):
+                _check_subtable(f"{prefix}{key}.", value, model_cls, key)
+            # A non-dict ``image`` is the legacy string container-image
+            # override — tolerated as-is (parked under extra on load).
+
+    _check_top("", payload)
+    return sorted(set(unknown))
 
 
 # ── ChangeSet ────────────────────────────────────────────────────────────────
@@ -263,8 +428,16 @@ class SlotConfigStore:
         interleave and drop each other's change (SC-10). The lock is
         re-entrant within a thread, so a caller already inside ``transaction``
         may nest a locked leaf writer without self-deadlocking.
+
+        The store's commit also writes ``slots/*.toml``, so the body
+        additionally holds the coarse slot-TOML write lock
+        (:func:`slot_write_lock`) — a stack apply / capability apply and a
+        concurrent ``SlotManager.update_config`` (which takes only the slot
+        lock) serialize instead of interleaving their slot-file writes.
+        Lock order is always capabilities → slots; no slot-lock holder ever
+        acquires the capabilities lock, so the ordering cannot invert.
         """
-        with file_lock(self._caps_path()):
+        with file_lock(self._caps_path()), slot_write_lock(self._slots_dir):
             yield
 
     def apply_and_commit(self, selection: SlotSelection) -> ChangeSet:
@@ -442,10 +615,14 @@ def _write_state(fs: FileState) -> None:
 
 
 __all__ = [
+    "TOLERATED_SLOT_CONFIG_KEYS",
     "ChangeSet",
     "FileState",
     "SlotConfigStore",
     "SlotSelection",
+    "fold_ctx_size_alias",
     "merge_slot_config",
+    "slot_write_lock",
+    "unknown_slot_config_keys",
     "write_slot_toml",
 ]

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -34,7 +34,11 @@ without restructuring how they build the list.
 
 from __future__ import annotations
 
+import logging
+import shlex
 from dataclasses import dataclass
+
+log = logging.getLogger(__name__)
 
 # Short→long canonicalisation. Used ONLY to compute the dedup key; the emitted
 # token keeps its original spelling. Seeded from the flags hal0 profiles +
@@ -235,12 +239,65 @@ def resolve_argv(segments: list[tuple[str, list[str]]]) -> ResolvedArgv:
     return ResolvedArgv(argv=out, provenance=provenance, removed=removed)
 
 
+# ── merge_flags: string ⊕ string, last-wins per-flag ─────────────────────────
+#
+# Folded in from the retired ``hal0.slots.flag_merge`` module so it shares this
+# module's tokenizer + short/long alias table (``-b`` now dedups against
+# ``--batch-size``, which the old ``--``-only tokenizer could not do). Combines
+#
+#     model_defaults (registry Model.defaults.extra_args)
+#     slot_extra     (SlotConfig.server.extra_args)
+#
+# into one argv-ready string: the slot string wins on any colliding flag, and
+# APPEND_FLAGS (--lora / --draft-model / --override-kv) are kept additively.
+
+
+def merge_flags(model_defaults: str | None, slot_extra: str | None) -> str:
+    """Combine model-default and slot-override CLI flag strings (last-wins).
+
+    Args:
+        model_defaults: ``Model.defaults.extra_args`` from the registry, or
+            ``None`` if the model has no defaults.
+        slot_extra: ``SlotConfig.server.extra_args``, or ``None``.
+
+    Returns:
+        A single trimmed string with the slot's flags winning any collision
+        with a model default (short/long aliases collapse against each other;
+        APPEND_FLAGS are kept). Empty inputs collapse to ``""``.
+
+        On malformed input (unbalanced quotes that ``shlex.split`` rejects)
+        this falls back to a whitespace concat with a structured warning, so
+        the launcher still gets *something* runnable instead of crashing.
+    """
+    left = model_defaults if (model_defaults and model_defaults.strip()) else ""
+    right = slot_extra if (slot_extra and slot_extra.strip()) else ""
+    if not left and not right:
+        return ""
+
+    try:
+        left_tokens = shlex.split(left) if left else []
+        right_tokens = shlex.split(right) if right else []
+    except ValueError as exc:
+        log.warning(
+            "flag_merge: unbalanced quotes; falling back to dumb concat",
+            extra={"event": "flag_merge.malformed_input", "reason": str(exc)},
+        )
+        return " ".join(p.strip() for p in (left, right) if p.strip())
+
+    # model defaults first, slot override last → resolve keeps the slot's value
+    # on any collision (last-wins). Re-quote each surviving token so a value
+    # with embedded spaces survives the launcher's re-``shlex.split``.
+    merged = normalize_argv(left_tokens + right_tokens).argv
+    return " ".join(shlex.quote(tok) for tok in merged)
+
+
 __all__ = [
     "APPEND_FLAGS",
     "FLAG_ALIASES",
     "FlagProvenance",
     "NormalizedArgv",
     "ResolvedArgv",
+    "merge_flags",
     "normalize_argv",
     "resolve_argv",
 ]

--- a/src/hal0/slots/flag_merge.py
+++ b/src/hal0/slots/flag_merge.py
@@ -1,187 +1,21 @@
-"""Merge a model's default CLI flags with a slot's extra-args override.
+"""DEPRECATED shim — ``merge_flags`` now lives in :mod:`hal0.slots.argv`.
 
-Used by the llama-server launcher arg-build path (and any future
-backend that takes a freeform CLI passthrough) to combine
+The merge logic was folded into ``hal0.slots.argv`` so it reuses argv's shared
+tokenizer + short/long alias table (``-b`` ⟷ ``--batch-size`` now dedup against
+each other, which this module's ``--``-only tokenizer could not do). The
+APPEND-list flag set is likewise unified there (``hal0.slots.argv.APPEND_FLAGS``).
 
-    model.defaults.extra_args   — registry-level defaults
-    slot.server.extra_args      — per-slot override
-
-into a single argv-ready string with collision rules:
-
-  * The slot string wins on any ``--flag (value?)`` pair it contains —
-    matching flag/value tuples are stripped from the model defaults.
-  * A small set of *append-list* flags (``--lora``, ``--draft-model``,
-    ``--override-kv``) skip dedup: llama-server accepts repeated
-    occurrences, and silently dropping one of them would surprise the
-    operator.
-  * Whitespace-only / None inputs are no-ops.
-  * Malformed input (e.g. unbalanced quotes that ``shlex.split`` rejects)
-    falls back to a dumb concat with a structured warning log — the
-    launcher still gets *something* runnable instead of a hard crash.
-
-See docs/internal/models-slots-impl-plan.md §A3.
+This module re-exports the canonical implementations for existing importers
+(``hal0.providers.llama_server`` — a provider retired in a later wave). New code
+should import from ``hal0.slots.argv`` directly.
 """
 
 from __future__ import annotations
 
-import logging
-import shlex
-from collections.abc import Iterable
+from hal0.slots.argv import APPEND_FLAGS as _APPEND_LIST_FLAGS
+from hal0.slots.argv import merge_flags
 
-log = logging.getLogger(__name__)
-
-# Flags whose semantics are "may be repeated".  llama-server treats each
-# occurrence additively, so deduping by flag-name would silently drop
-# the user's intent.
-_APPEND_LIST_FLAGS: frozenset[str] = frozenset(
-    {
-        "--lora",
-        "--draft-model",
-        "--override-kv",
-    }
-)
-
-
-def _tokenise(raw: str) -> list[str]:
-    """Whitespace-tokenise with shell-quote awareness.
-
-    Raises ``ValueError`` on unbalanced quotes; callers handle the
-    malformed-input path.
-    """
-    return shlex.split(raw, posix=True)
-
-
-def _split_flag_pairs(tokens: list[str]) -> list[tuple[str, list[str]]]:
-    """Group a flat token list into ``(flag, [value?])`` tuples.
-
-    A token starting with ``--`` opens a new flag; the next token is
-    its value iff it does not itself start with ``--``.  Tokens that
-    appear before any ``--`` (or look like bare positional values) are
-    grouped under an empty-string "flag" so the caller can decide what
-    to do with them (currently: preserve, no dedup).
-    """
-    pairs: list[tuple[str, list[str]]] = []
-    i = 0
-    n = len(tokens)
-    while i < n:
-        tok = tokens[i]
-        if tok.startswith("--"):
-            value: list[str] = []
-            # Lookahead for a single value that isn't itself a flag.
-            if i + 1 < n and not tokens[i + 1].startswith("--"):
-                value.append(tokens[i + 1])
-                i += 2
-            else:
-                i += 1
-            pairs.append((tok, value))
-        else:
-            # Stray positional — keep it under an empty flag-name so
-            # dedup leaves it alone.
-            pairs.append(("", [tok]))
-            i += 1
-    return pairs
-
-
-def _flatten_pairs(pairs: Iterable[tuple[str, list[str]]]) -> list[str]:
-    """Inverse of ``_split_flag_pairs``."""
-    out: list[str] = []
-    for flag, values in pairs:
-        if flag:
-            out.append(flag)
-        out.extend(values)
-    return out
-
-
-def _dumb_concat(model_defaults: str | None, slot_extra: str | None) -> str:
-    """Whitespace-glue fallback used on tokenisation failure."""
-    parts = [s for s in (model_defaults, slot_extra) if s and s.strip()]
-    return " ".join(p.strip() for p in parts)
-
-
-def merge_flags(model_defaults: str | None, slot_extra: str | None) -> str:
-    """Combine model-default and slot-override CLI flag strings.
-
-    Args:
-        model_defaults: ``Model.defaults.extra_args`` from the registry,
-            or ``None`` if the model has no defaults.
-        slot_extra: ``SlotConfig.server.extra_args``, or ``None`` if
-            the slot hasn't overridden anything.
-
-    Returns:
-        A single trimmed string with the slot's flags appended *after*
-        any non-conflicting model defaults.  Empty inputs collapse to
-        ``""``.
-    """
-    if not (model_defaults and model_defaults.strip()) and not (slot_extra and slot_extra.strip()):
-        return ""
-
-    if not (slot_extra and slot_extra.strip()):
-        # Slot has nothing to say — return model defaults as-is (trimmed).
-        # We still validate parseability so a malformed model string
-        # gets caught here too rather than later at exec time.
-        assert model_defaults is not None  # for type-checker
-        try:
-            _tokenise(model_defaults)
-        except ValueError as exc:
-            log.warning(
-                "flag_merge: malformed model_defaults; falling back to dumb concat",
-                extra={
-                    "event": "flag_merge.malformed_input",
-                    "side": "model_defaults",
-                    "reason": str(exc),
-                },
-            )
-            return _dumb_concat(model_defaults, slot_extra)
-        return model_defaults.strip()
-
-    if not (model_defaults and model_defaults.strip()):
-        assert slot_extra is not None
-        try:
-            _tokenise(slot_extra)
-        except ValueError as exc:
-            log.warning(
-                "flag_merge: malformed slot_extra; falling back to dumb concat",
-                extra={
-                    "event": "flag_merge.malformed_input",
-                    "side": "slot_extra",
-                    "reason": str(exc),
-                },
-            )
-            return _dumb_concat(model_defaults, slot_extra)
-        return slot_extra.strip()
-
-    # Both sides non-empty: do the real merge.
-    try:
-        model_tokens = _tokenise(model_defaults)
-        slot_tokens = _tokenise(slot_extra)
-    except ValueError as exc:
-        log.warning(
-            "flag_merge: unbalanced quotes; falling back to dumb concat",
-            extra={
-                "event": "flag_merge.malformed_input",
-                "reason": str(exc),
-            },
-        )
-        return _dumb_concat(model_defaults, slot_extra)
-
-    model_pairs = _split_flag_pairs(model_tokens)
-    slot_pairs = _split_flag_pairs(slot_tokens)
-
-    # Build the dedup set: every flag the slot uses *except* append-list
-    # flags.  Empty-string "flags" (stray positionals) are never deduped.
-    slot_flag_names = {flag for flag, _ in slot_pairs if flag and flag not in _APPEND_LIST_FLAGS}
-
-    cleaned_model_pairs = [
-        (flag, values) for flag, values in model_pairs if flag not in slot_flag_names
-    ]
-
-    cleaned_model_tokens = _flatten_pairs(cleaned_model_pairs)
-    cleaned_model_str = " ".join(cleaned_model_tokens).strip()
-    slot_str = " ".join(_flatten_pairs(slot_pairs)).strip()
-
-    if cleaned_model_str and slot_str:
-        return f"{cleaned_model_str} {slot_str}"
-    return cleaned_model_str or slot_str
-
-
-__all__ = ["merge_flags"]
+# ``_APPEND_LIST_FLAGS`` is re-exported (aliased to the unified
+# ``hal0.slots.argv.APPEND_FLAGS``) for any legacy importer that still reaches
+# for it from this module; there is now a single append-flag definition.
+__all__ = ["_APPEND_LIST_FLAGS", "merge_flags"]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hal0.config import paths
+from hal0.model_meta import SLOT_TYPES
 from hal0.slot_config import (
     fold_ctx_size_alias,
     merge_slot_config,
@@ -109,10 +110,10 @@ SLOT_ALIASES: dict[str, str] = {
     "agent-hermes": "agent",
 }
 
-#: Slot ``type`` vocabulary (plan §4.1).
-_VALID_SLOT_TYPES: frozenset[str] = frozenset(
-    {"llm", "embedding", "reranking", "transcription", "tts", "image"}
-)
+#: Slot ``type`` vocabulary (plan §4.1) — sourced from the canonical
+#: taxonomy (:data:`hal0.model_meta.SLOT_TYPES`) so validation, profiles,
+#: and /api/meta/enums can never drift.
+_VALID_SLOT_TYPES: frozenset[str] = frozenset(SLOT_TYPES)
 
 #: Slot-name policy: kebab-case, max 32 chars, leading alphanumeric.
 _SLOT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -39,7 +39,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hal0.config import paths
-from hal0.slot_config import merge_slot_config, write_slot_toml
+from hal0.slot_config import (
+    fold_ctx_size_alias,
+    merge_slot_config,
+    slot_write_lock,
+    write_slot_toml,
+)
 from hal0.slots.state import (
     DISPATCHABLE_STATES,
     IllegalSlotTransition,
@@ -121,17 +126,29 @@ _SLOT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
 # inactive underneath us the watcher flips state and emits an SSE
 # frame within ~1s.
 _FAIL_WATCH_INTERVAL_S: float = 2.0
-#: The "live" states the fail-watcher polls are exactly the dispatchable
-#: ready-set (container up and usable) — alias the one canonical set (DR-8)
-#: rather than re-declaring the literal.
-_FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = DISPATCHABLE_STATES
+#: The "live" states the fail-watcher polls: the dispatchable ready-set
+#: (container up and usable, aliased from the one canonical set — DR-8) PLUS
+#: WARMING. WARMING is watched because a health-wait timeout leaves the slot
+#: parked there indefinitely (see ``_await_ready``); without a watcher a unit
+#: that later dies is never noticed. WARMING gets softer treatment inside the
+#: loop: only the systemd is-active check can strike it (never /health), so a
+#: slot legitimately still loading a large model is never killed.
+_FAIL_WATCH_LIVE_STATES: frozenset[SlotState] = DISPATCHABLE_STATES | {SlotState.WARMING}
 # #783/B4: an active unit is not necessarily healthy. The watcher also probes
 # the model server's /health; a crashed-but-active server (active unit, failing
 # /health) is demoted to ERROR — but only after this many CONSECUTIVE failures,
 # so a single transient blip doesn't trigger a disruptive model reload.
 _HEALTH_FAIL_STRIKES: int = 2
-# Must match the exact flag spellings emitted by ContainerProvider's llama
-# launch renderer; drift checks compare argv text, not llama-server aliases.
+# WARMING-only: consecutive is-active failures before a warming slot is
+# declared dead. Higher than _HEALTH_FAIL_STRIKES because a freshly-spawned
+# unit can legitimately read "activating"/inactive to the probe for a beat or
+# two while podman brings the container up — a warming slot must only be
+# flipped when the unit is *stably* down, never while a big model loads.
+_WARMING_INACTIVE_STRIKES: int = 3
+# Config-drift comparison keys. Spelling no longer needs to match the launch
+# renderer exactly: both sides of the comparison are canonicalized through
+# slots.argv.FLAG_ALIASES (so ``--batch-size`` in a running argv matches a
+# rendered ``-b`` instead of reporting false drift).
 _CONFIG_DRIFT_KEYS: tuple[str, ...] = ("--ctx-size", "--model", "--alias", "-b", "-ub")
 
 # Idle-monitor defaults. A READY slot whose last activity is older than
@@ -730,8 +747,8 @@ class SlotManager:
     def _update_fail_watcher(self, name: str, new_state: SlotState) -> None:
         """Spawn or cancel the per-slot fail-watcher to match ``new_state``.
 
-        Live states (READY/SERVING/IDLE) → ensure a watcher task is running.
-        Any other state → cancel the watcher if present.
+        Live states (READY/SERVING/IDLE/WARMING) → ensure a watcher task is
+        running. Any other state → cancel the watcher if present.
 
         Self-cancellation is a no-op: when the watcher itself fires the
         transition to ERROR, we let it return naturally rather than calling
@@ -770,12 +787,17 @@ class SlotManager:
     async def _fail_watch_loop(self, slot_name: str) -> None:
         """Poll the container unit's is-active and flip state when it dies.
 
-        Runs as a background task while the slot is in READY/SERVING/IDLE.
+        Runs as a background task while the slot is in READY/SERVING/IDLE —
+        or WARMING (the post-health-timeout blind spot): a warming slot is
+        judged ONLY on the unit's is-active (``_WARMING_INACTIVE_STRIKES``
+        consecutive failures), never on /health, so a dead unit is caught
+        while a slot legitimately still loading a large model is left alone.
         Detection latency = up to one poll interval (~2s). Exits cleanly
         once the slot leaves the live-state set, by self-cancel via the
         ERROR transition, or via outer ``task.cancel()``.
         """
         health_failures = 0
+        warming_inactive = 0
         try:
             while True:
                 await asyncio.sleep(_FAIL_WATCH_INTERVAL_S)
@@ -796,6 +818,15 @@ class SlotManager:
                     )
                     continue
                 if active:
+                    warming_inactive = 0
+                    if current is SlotState.WARMING:
+                        # Warming slots are still loading — /health failing is
+                        # the EXPECTED condition, not a crash signal. Only the
+                        # unit's liveness may strike a warming slot, so skip
+                        # the health probe entirely (a big-model load can hold
+                        # /health down for minutes without being wedged).
+                        health_failures = 0
+                        continue
                     # #783/B4: active is necessary but not sufficient. Probe
                     # the model server's /health — a crashed/wedged server is
                     # active to systemd while /health fails, so an is-active-
@@ -834,6 +865,29 @@ class SlotManager:
                 # have moved us legitimately during the probe.
                 current = self._current_state(slot_name)
                 if current not in _FAIL_WATCH_LIVE_STATES:
+                    return
+                if current is SlotState.WARMING:
+                    # A warming slot tolerates a few inactive reads (a
+                    # freshly-spawned unit can look inactive to the probe
+                    # for a beat) but a *stably* dead unit is a real load
+                    # failure — flip to ERROR so the red dot cues the
+                    # operator instead of the slot lying in WARMING forever.
+                    warming_inactive += 1
+                    if warming_inactive < _WARMING_INACTIVE_STRIKES:
+                        continue
+                    try:
+                        await self._transition(
+                            slot_name,
+                            SlotState.ERROR,
+                            message="container unit died while warming",
+                            extra={"health_ok": False},
+                            force=True,
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            "slot.fail_watch_transition_failed",
+                            extra={"slot": slot_name, "error": str(exc)},
+                        )
                     return
                 # A stopped unit (GPU arbiter handoff, systemd stop,
                 # OOM-kill with Restart= pending) is a clean not-loaded
@@ -904,7 +958,13 @@ class SlotManager:
         from hal0.providers.container import container_provider
 
         try:
-            health = await container_provider().health(port)
+            # Pass the slot config so FLM slots get the Tier-1 real-inference
+            # probe (health() delegates to FLMProvider.health when the cfg
+            # resolves to FLM) instead of the weak /v1/models fallback. The
+            # probe distinguishes "up but still loading" (ok=False) from
+            # "dead"; WARMING slots are never health-struck by the
+            # fail-watcher (is-active only), so a loading FLM model is safe.
+            health = await container_provider().health(port, cfg)
         except Exception as exc:
             # Inconclusive — a transport error is not proof the model server
             # is dead. Don't demote; the next poll re-probes.
@@ -944,10 +1004,13 @@ class SlotManager:
         if not active:
             return False, "inactive"
 
-        # 2) /health probe (only meaningful when the unit is active)
+        # 2) /health probe (only meaningful when the unit is active). The
+        # slot config is passed so FLM slots use the Tier-1 real-inference
+        # probe (see ContainerProvider.health) — a still-loading FLM reports
+        # ok=False here, which maps to the retryable "starting" reason.
         port = _cfg_port(cfg)
         if port:
-            health = await container_provider().health(port)
+            health = await container_provider().health(port, cfg)
             if not health.get("ok"):
                 return False, "starting"
 
@@ -1728,8 +1791,10 @@ class SlotManager:
         slots/*.toml write path (issue #697).
         """
         cfg_dict = _cfg_to_dict(slot_cfg)
-        # #585: canonicalize a ctx_size alias from the create modal too.
-        _normalize_ctx_key(cfg_dict)
+        # #585: canonicalize a ctx_size alias from the create modal too —
+        # same single fold (:func:`hal0.slot_config.fold_ctx_size_alias`)
+        # the merge/update path uses.
+        fold_ctx_size_alias(cfg_dict)
         # Persist a concrete context window when the operator left it unset, so
         # the TOML, the dashboard, and the running container all agree. The
         # provider's load-path derive is the belt-and-suspenders fallback; this
@@ -1761,46 +1826,55 @@ class SlotManager:
         # suspenders). Fast fast path when this write isn't a new default.
         await self._check_default_uniqueness(slot_name, cfg_dict)
         cfg_path = self._config_file(slot_name)
-        # SC-5: refuse to clobber an existing slot's config. Without this,
-        # a duplicate create() overwrote the on-disk TOML and force-reset
-        # state.json to OFFLINE, orphaning any running container. Most
-        # internal reconcile callers pre-check cfg_path.exists() before
-        # create() (orchestrator, backends, stacks._create_missing_slots),
-        # so they never reach this guard; install/orchestrate does NOT
-        # pre-check but wraps create() in a best-effort except, so a
-        # duplicate degrades to a per-slot error rather than a crash.
-        # add_slot and POST /api/slots surface the conflict to the caller.
-        if cfg_path.exists():
-            raise SlotConfigError(
-                f"slot {slot_name!r} already exists; use update to modify it",
-                details={"slot": slot_name, "config": str(cfg_path)},
-            )
-        cfg_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            write_slot_toml(cfg_path, cfg_dict)
-        except OSError as exc:
-            raise SlotConfigError(
-                f"failed to write slot config {cfg_path}: {exc}",
-                details={"slot": slot_name},
-            ) from exc
+        # TOCTOU fix: the exists-check + write below used to run unlocked, so
+        # two concurrent create() calls (all callers are async — api routes,
+        # orchestrator, stacks _create_missing_slots) could both pass the
+        # check and the loser clobbered the winner's TOML. Serialize
+        # in-process on the per-slot asyncio lock and cross-process on the
+        # coarse slot-TOML file lock so the SC-5 guard is race-free.
+        async with self._lock(slot_name):
+            with slot_write_lock():
+                # SC-5: refuse to clobber an existing slot's config. Without
+                # this, a duplicate create() overwrote the on-disk TOML and
+                # force-reset state.json to OFFLINE, orphaning any running
+                # container. Most internal reconcile callers pre-check
+                # cfg_path.exists() before create() (orchestrator, backends,
+                # stacks._create_missing_slots), so they never reach this
+                # guard; install/orchestrate does NOT pre-check but wraps
+                # create() in a best-effort except, so a duplicate degrades
+                # to a per-slot error rather than a crash. add_slot and
+                # POST /api/slots surface the conflict to the caller.
+                if cfg_path.exists():
+                    raise SlotConfigError(
+                        f"slot {slot_name!r} already exists; use update to modify it",
+                        details={"slot": slot_name, "config": str(cfg_path)},
+                    )
+                cfg_path.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    write_slot_toml(cfg_path, cfg_dict)
+                except OSError as exc:
+                    raise SlotConfigError(
+                        f"failed to write slot config {cfg_path}: {exc}",
+                        details={"slot": slot_name},
+                    ) from exc
 
-        # Initialise state.
-        await self._transition(
-            slot_name,
-            SlotState.OFFLINE,
-            port=_cfg_port(cfg_dict),
-            model_id=_model_default(cfg_dict) or None,
-            extra={
-                # W3: seed the device-derived effective backend, not a
-                # hardcoded "vulkan" default — the slot's ``device`` is what
-                # will actually run. ``status()`` re-derives from the TOML on
-                # every read, so this is only a fallback, but keeping it
-                # honest avoids a transient lie before the first status call.
-                "backend": _cfg_effective_backend(cfg_dict) or "vulkan",
-                "provider": cfg_dict.get("provider", "llama-server"),
-            },
-            force=True,
-        )
+            # Initialise state.
+            await self._transition(
+                slot_name,
+                SlotState.OFFLINE,
+                port=_cfg_port(cfg_dict),
+                model_id=_model_default(cfg_dict) or None,
+                extra={
+                    # W3: seed the device-derived effective backend, not a
+                    # hardcoded "vulkan" default — the slot's ``device`` is what
+                    # will actually run. ``status()`` re-derives from the TOML on
+                    # every read, so this is only a fallback, but keeping it
+                    # honest avoids a transient lie before the first status call.
+                    "backend": _cfg_effective_backend(cfg_dict) or "vulkan",
+                    "provider": cfg_dict.get("provider", "llama-server"),
+                },
+                force=True,
+            )
         return await self.status(slot_name)
 
     async def delete(self, slot_name: str) -> None:
@@ -1841,55 +1915,55 @@ class SlotManager:
         """
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
-        cfg = await self._load_slot_config(slot_name)
-        cfg_dict = _cfg_to_dict(cfg)
-        # One-level deep merge for nested TOML tables ([model], [server]) plus
-        # the #585 ctx_size→context_size fold, via the shared, copy-safe
-        # ``merge_slot_config`` primitive (SC-11) — the SAME projection the
-        # SlotConfigStore uses, so the two can't silently diverge.
-        #
-        # A bare shallow ``dict.update`` replaced a sub-table wholesale, so a
-        # partial ``PATCH /defaults`` body like ``{"model": {"ctx_size": N}}``
-        # silently dropped sibling keys — most damagingly ``[model].default``
-        # (the model name), which left the slot unable to resolve a model and
-        # turned the dashboard Start button into a silent no-op after a
-        # restart. The helper merges sub-table dicts key-by-key so partial
-        # updates only touch the fields they carry; scalars and lists still
-        # replace wholesale (predictable, and no caller relies on list-merge).
-        # It also folds the dashboard's legacy ``[model].ctx_size`` alias into
-        # the canonical ``context_size`` (#585) so the two keys can't diverge
-        # on disk. ``merge_slot_config`` returns a fresh dict, so rebind
-        # ``cfg_dict`` before the downstream reconcile/guard calls below.
-        cfg_dict = merge_slot_config(cfg_dict, updates)
-
-        # Keep device↔profile backend coherent: a profile switch re-derives
-        # device (the drawer path that previously left a vulkan device under a
-        # rocm-dnse profile), a cross-backend device flip re-points the profile
-        # (the POST /backend path, which writes device only), and an explicit
-        # conflicting pair raises. Only the field(s) the caller changed drive
-        # reconciliation.
-        _reconcile_device_profile(cfg_dict, set(updates.keys()))
-
-        # PR-11: re-run the NPU exclusivity guard whenever the merged
-        # config could land a second device=npu, type=llm anchor (plan
-        # §5.3). Cheap when no NPU LLM is involved — the helper short-
-        # circuits on the merged cfg's own device/type.
-        await self._check_npu_exclusivity(slot_name, cfg_dict)
-
-        # SC-4: a PATCH that flips default=true (even when ``type`` lives
-        # only on the pre-existing config) is checked against the merged
-        # cfg_dict — the authoritative post-merge state, same as the NPU
-        # guard. The peer walk excludes slot_name, so re-persisting the
-        # sole default never self-conflicts.
-        await self._check_default_uniqueness(slot_name, cfg_dict)
-
         cfg_path = self._config_file(slot_name)
-        try:
-            write_slot_toml(cfg_path, cfg_dict)
-        except OSError as exc:
-            raise SlotConfigError(
-                f"failed to rewrite {cfg_path}: {exc}",
-            ) from exc
+        # The whole read→merge→guard→write below is one cross-process
+        # critical section (slot_write_lock): a concurrent CLI / stacks /
+        # capabilities writer can no longer interleave its own RMW and drop
+        # this update. Everything awaited inside is sync at heart (plain
+        # file IO) so the event loop never actually suspends while the
+        # advisory lock is held — do not introduce real awaits here.
+        with slot_write_lock():
+            cfg = await self._load_slot_config(slot_name)
+            cfg_dict = _cfg_to_dict(cfg)
+            # One-level deep merge for nested TOML tables ([model], [server])
+            # plus the #585 ctx_size→context_size fold and device↔profile
+            # backend coherence, via the shared ``reconcile_slot_updates``
+            # pipeline — the SAME projection the SlotConfigStore and the
+            # stacks apply engine use, so the writers can't silently diverge.
+            #
+            # A bare shallow ``dict.update`` replaced a sub-table wholesale,
+            # so a partial ``PATCH /defaults`` body like ``{"model":
+            # {"ctx_size": N}}`` silently dropped sibling keys — most
+            # damagingly ``[model].default`` (the model name). The merge
+            # touches only the fields the update carries; scalars and lists
+            # still replace wholesale. Device/profile coherence: a profile
+            # switch re-derives device (the drawer path that previously left
+            # a vulkan device under a rocm-dnse profile), a cross-backend
+            # device flip re-points the profile (the POST /backend path,
+            # which writes device only), and an explicit conflicting pair
+            # raises. Only the field(s) the caller changed drive
+            # reconciliation. Returns a fresh dict — rebind ``cfg_dict``.
+            cfg_dict = reconcile_slot_updates(cfg_dict, updates)
+
+            # PR-11: re-run the NPU exclusivity guard whenever the merged
+            # config could land a second device=npu, type=llm anchor (plan
+            # §5.3). Cheap when no NPU LLM is involved — the helper short-
+            # circuits on the merged cfg's own device/type.
+            await self._check_npu_exclusivity(slot_name, cfg_dict)
+
+            # SC-4: a PATCH that flips default=true (even when ``type`` lives
+            # only on the pre-existing config) is checked against the merged
+            # cfg_dict — the authoritative post-merge state, same as the NPU
+            # guard. The peer walk excludes slot_name, so re-persisting the
+            # sole default never self-conflicts.
+            await self._check_default_uniqueness(slot_name, cfg_dict)
+
+            try:
+                write_slot_toml(cfg_path, cfg_dict)
+            except OSError as exc:
+                raise SlotConfigError(
+                    f"failed to rewrite {cfg_path}: {exc}",
+                ) from exc
 
         # Issue #359: invalidate stale top-level metadata in state.json
         # whenever the operator's update changes a field that's also
@@ -2015,20 +2089,23 @@ class SlotManager:
         slots/*.toml write path (issue #697). Failures bubble up so the
         caller can log + soft-fail without affecting the live load state.
         """
-        cfg = await self._load_slot_config(slot_name)
-        cfg_dict = _cfg_to_dict(cfg)
-        existing_model = cfg_dict.get("model")
-        base_model = existing_model if isinstance(existing_model, dict) else {}
-        cfg_dict = {**cfg_dict, "model": {**base_model, "default": model_id}}
+        # Cross-process RMW guard: read + rewrite under the shared slot-TOML
+        # lock so a concurrent update_config / stacks apply can't be dropped.
+        with slot_write_lock():
+            cfg = await self._load_slot_config(slot_name)
+            cfg_dict = _cfg_to_dict(cfg)
+            existing_model = cfg_dict.get("model")
+            base_model = existing_model if isinstance(existing_model, dict) else {}
+            cfg_dict = {**cfg_dict, "model": {**base_model, "default": model_id}}
 
-        cfg_path = self._config_file(slot_name)
-        try:
-            write_slot_toml(cfg_path, cfg_dict)
-        except OSError as exc:
-            raise SlotConfigError(
-                f"failed to persist model.default to {cfg_path}: {exc}",
-                details={"slot": slot_name, "model_id": model_id},
-            ) from exc
+            cfg_path = self._config_file(slot_name)
+            try:
+                write_slot_toml(cfg_path, cfg_dict)
+            except OSError as exc:
+                raise SlotConfigError(
+                    f"failed to persist model.default to {cfg_path}: {exc}",
+                    details={"slot": slot_name, "model_id": model_id},
+                ) from exc
 
     # ── model preferred profile (Q1: profile loads with the model) ────────────
 
@@ -2097,24 +2174,27 @@ class SlotManager:
         preferred = await self._preferred_profile_for(model_id)
         if not preferred:
             return False
-        cfg = await self._load_slot_config(slot_name)
-        cfg_dict = _cfg_to_dict(cfg)
-        if cfg_dict.get("profile") == preferred:
-            return False
-        if not self._profile_fits_slot(preferred, cfg_dict):
-            log.info(
-                "slot.preferred_profile_skipped",
-                extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
-            )
-            return False
-        cfg_dict = {**cfg_dict, "profile": preferred}
-        try:
-            write_slot_toml(self._config_file(slot_name), cfg_dict)
-        except OSError as exc:
-            raise SlotConfigError(
-                f"failed to persist preferred profile to slot {slot_name}: {exc}",
-                details={"slot": slot_name, "profile": preferred},
-            ) from exc
+        # Read + rewrite under the shared cross-process slot-TOML lock so a
+        # concurrent config writer isn't silently dropped.
+        with slot_write_lock():
+            cfg = await self._load_slot_config(slot_name)
+            cfg_dict = _cfg_to_dict(cfg)
+            if cfg_dict.get("profile") == preferred:
+                return False
+            if not self._profile_fits_slot(preferred, cfg_dict):
+                log.info(
+                    "slot.preferred_profile_skipped",
+                    extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
+                )
+                return False
+            cfg_dict = {**cfg_dict, "profile": preferred}
+            try:
+                write_slot_toml(self._config_file(slot_name), cfg_dict)
+            except OSError as exc:
+                raise SlotConfigError(
+                    f"failed to persist preferred profile to slot {slot_name}: {exc}",
+                    details={"slot": slot_name, "profile": preferred},
+                ) from exc
         log.info(
             "slot.preferred_profile_applied",
             extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
@@ -2146,46 +2226,13 @@ class SlotManager:
         whether any pre-existing NPU LLM is already enabled. Reading
         the writer's own slot from disk is skipped — the in-memory
         ``cfg_dict`` IS the authoritative new state.
+
+        Thin async wrapper (kept for the public method surface and test
+        monkeypatchability) over the module-level sync
+        :func:`check_npu_exclusivity`, which the stacks apply engine
+        shares so its writes obey the same guard.
         """
-        device = cfg_dict.get("device")
-        type_ = cfg_dict.get("type")
-        if device != "npu" or type_ != "llm":
-            return
-        # The merged write is for an NPU LLM slot. If it isn't being
-        # enabled, no collision is possible — at most one OTHER slot
-        # could still be enabled, and that's the legal state we want.
-        if cfg_dict.get("enabled") is False:
-            return
-        # Walk peers. Use _all_configured_slot_names() so we see slots
-        # whose TOML exists but whose in-memory state hasn't been hit
-        # yet (e.g. installer-seeded slots before first poll).
-        peer_names = [n for n in self._all_configured_slot_names() if n != slot_name]
-        offenders: list[str] = []
-        for name in peer_names:
-            try:
-                peer = await self._load_slot_config(name)
-            except SlotConfigError:
-                # Malformed TOML doesn't block the user's legitimate
-                # write — surface the malformed-slot warning via the
-                # usual path instead of conflating it here.
-                continue
-            except SlotNotFound:
-                continue
-            if peer.get("device") != "npu" or peer.get("type") != "llm":
-                continue
-            if peer.get("enabled") is False:
-                continue
-            offenders.append(name)
-        if offenders:
-            raise NpuExclusivityViolation(
-                "only one NPU LLM slot may be enabled at a time "
-                f"(slot {slot_name!r} would conflict with {offenders[0]!r})",
-                details={
-                    "slot": slot_name,
-                    "conflicting_slots": sorted(offenders),
-                    "hint": "disable the existing NPU LLM slot before enabling another",
-                },
-            )
+        check_npu_exclusivity(slot_name, cfg_dict)
 
     async def _check_default_uniqueness(
         self,
@@ -2215,42 +2262,13 @@ class SlotManager:
         the same type that is already ``default=true``. Reading the
         writer's own slot is skipped — the in-memory ``cfg_dict`` IS the
         authoritative new state.
+
+        Thin async wrapper (kept for the public method surface and test
+        monkeypatchability) over the module-level sync
+        :func:`check_default_uniqueness`, which the stacks apply engine
+        shares so its writes obey the same guard.
         """
-        if cfg_dict.get("default") is not True:
-            return
-        type_ = cfg_dict.get("type")
-        if not type_:
-            return
-        # Walk peers. Use _all_configured_slot_names() so we see slots
-        # whose TOML exists but whose in-memory state hasn't been hit
-        # yet (e.g. installer-seeded slots before first poll).
-        peer_names = [n for n in self._all_configured_slot_names() if n != slot_name]
-        offenders: list[str] = []
-        for name in peer_names:
-            try:
-                peer = await self._load_slot_config(name)
-            except SlotConfigError:
-                # Malformed TOML doesn't block the user's legitimate
-                # write — surface the malformed-slot warning via the
-                # usual path instead of conflating it here.
-                continue
-            except SlotNotFound:
-                continue
-            if peer.get("type") != type_:
-                continue
-            if peer.get("default") is True:
-                offenders.append(name)
-        if offenders:
-            raise SlotConfigError(
-                f"slot type {type_!r} already has a default=true slot "
-                f"(slot {slot_name!r} would conflict with {offenders[0]!r})",
-                details={
-                    "slot": slot_name,
-                    "type": type_,
-                    "conflicting_slots": sorted(offenders),
-                    "hint": "clear the existing default before setting another",
-                },
-            )
+        check_default_uniqueness(slot_name, cfg_dict)
 
     # ── idle / wake-on-request ───────────────────────────────────────────────
 
@@ -2688,6 +2706,28 @@ class SlotManager:
             return None
         return float(self._evict_after_s) if self._evict_after_s > 0 else None
 
+    def _sweep_candidates(self) -> dict[str, float]:
+        """Slot → last-activity timestamp map for the idle/pressure sweeps.
+
+        ``_last_used`` only tracks slots that served a request (or were
+        adopted) during THIS process's lifetime. Dispatchable slots missing
+        from it — e.g. adopted before the bump-on-adoption fix, or hydrated
+        from a state.json that outlived an api restart — used to be
+        invisible to both sweeps and could squat on RAM forever. For those,
+        fall back to the state record's ``updated_at`` (the last observed
+        transition) as the activity timestamp; the sweeps' own state and
+        serving-count guards still apply on top.
+        """
+        candidates = dict(self._last_used)
+        for name, rec in list(self._states.items()):
+            if name in candidates:
+                continue
+            if rec.state not in (SlotState.READY, SlotState.IDLE):
+                continue
+            if rec.updated_at:
+                candidates[name] = float(rec.updated_at)
+        return candidates
+
     async def _sweep_idle_once(self) -> None:
         """One idle-sweep pass over every tracked slot.
 
@@ -2705,7 +2745,7 @@ class SlotManager:
         so eviction is safe.
         """
         now = time.time()
-        for slot_name, ts in list(self._last_used.items()):
+        for slot_name, ts in self._sweep_candidates().items():
             idle_for = now - ts
             if self._serving_count.get(slot_name, 0) > 0:
                 continue
@@ -2784,11 +2824,12 @@ class SlotManager:
         if free_mb >= self._evict_pressure_mb:
             return
 
-        # Build the LRU-ordered candidate list.  Only slots with a
-        # last_used timestamp are candidates (unloaded/offline slots are
-        # never in _last_used) so this is naturally bounded.
+        # Build the LRU-ordered candidate list. ``_sweep_candidates`` unions
+        # _last_used with dispatchable slots known only via state.json
+        # (adopted / restart-surviving), timestamped by their last observed
+        # transition, so pressure eviction can also reclaim those.
         candidates: list[tuple[float, str]] = []
-        for slot_name, ts in list(self._last_used.items()):
+        for slot_name, ts in self._sweep_candidates().items():
             if self._serving_count.get(slot_name, 0) > 0:
                 continue
             canonical = self._resolve_alias(slot_name)
@@ -2884,13 +2925,21 @@ class SlotManager:
                     f"(no config at {path} and no in-memory state)",
                     details={"slot": slot_name, "path": str(path)},
                 )
-            return {
+            # W3: no hardcoded "vulkan" fallback — carry whatever backend the
+            # state record actually recorded (itself device-derived at
+            # create/adopt time). When absent, omit the key so downstream
+            # consumers (``_cfg_effective_backend``) honestly report
+            # "unknown" / derive from ``device`` instead of a stale lie.
+            fallback: dict[str, Any] = {
                 "name": slot_name,
                 "port": rec.port,
-                "backend": rec.extra.get("backend", "vulkan"),
                 "provider": rec.extra.get("provider", "llama-server"),
                 "model": {"default": rec.model_id or ""},
             }
+            rec_backend = rec.extra.get("backend")
+            if rec_backend:
+                fallback["backend"] = rec_backend
+            return fallback
         try:
             with open(path, "rb") as f:
                 data = tomllib.load(f)
@@ -3043,7 +3092,11 @@ class SlotManager:
         healthy = await self._probe_health(slot_name)
         resolved = SlotState.READY if healthy else SlotState.WARMING
         extras: dict[str, Any] = {
-            "backend": cfg.get("backend", "vulkan"),
+            # W3: mirror the device-derived EFFECTIVE backend, not a
+            # hardcoded "vulkan" fallback — the slot's ``device`` (or its
+            # legacy ``backend`` field, folded by _cfg_effective_backend)
+            # is what is actually running.
+            "backend": _cfg_effective_backend(cfg) or cfg.get("backend"),
             "provider": cfg.get("provider", "llama-server"),
             "adopted": True,
             # Record the probe result so /api/health + hal0_slot_up can fold
@@ -3063,6 +3116,13 @@ class SlotManager:
             extra=extras,
             force=True,
         )
+        # Start the idle clock: adopted slots were invisible to the idle-TTL
+        # and pressure sweeps because nothing ever bumped ``_last_used`` for
+        # them (both sweeps key off it), so a container that outlived an api
+        # restart could squat on RAM forever. Adoption counts as activity —
+        # the TTL runs from now, and the sweeps' state.json fallback covers
+        # any dispatchable slot that still slips through in-memory tracking.
+        self.bump_last_used(slot_name)
         log.info(
             "slot.adopted",
             extra={
@@ -3234,26 +3294,35 @@ def _model_default(cfg: SlotConfig | dict[str, Any]) -> str:
 
 
 def _argv_values(argv: list[str], keys: tuple[str, ...]) -> dict[str, str | None]:
-    """Return the last value for each flag key in argv.
+    """Return the last value for each flag key in argv, alias-aware.
+
+    Both the requested ``keys`` and the argv tokens are canonicalized
+    through :data:`hal0.slots.argv.FLAG_ALIASES` before comparison, so a
+    running ``--batch-size 512`` matches a rendered ``-b 512`` (and vice
+    versa) instead of reporting false config drift. The result stays keyed
+    by the caller's original ``keys`` spelling (the drift payload contract).
 
     Last value wins because slot ``[server].extra_args`` intentionally follows
     profile flags and can override them.
     """
-    wanted = set(keys)
+    from hal0.slots.argv import FLAG_ALIASES
+
+    canon_to_key = {FLAG_ALIASES.get(k, k): k for k in keys}
     out: dict[str, str | None] = {}
     i = 0
     while i < len(argv):
         token = argv[i]
-        if token in wanted:
-            out[token] = argv[i + 1] if i + 1 < len(argv) else None
-            i += 2
+        flag, eq, inline = token.partition("=")
+        key = canon_to_key.get(FLAG_ALIASES.get(flag, flag))
+        if key is None:
+            i += 1
             continue
-        for key in keys:
-            prefix = f"{key}="
-            if token.startswith(prefix):
-                out[key] = token[len(prefix) :]
-                break
-        i += 1
+        if eq:
+            out[key] = inline
+            i += 1
+        else:
+            out[key] = argv[i + 1] if i + 1 < len(argv) else None
+            i += 2
     return out
 
 
@@ -3261,21 +3330,6 @@ def _config_drift_values_equal(key: str, running: str | None, rendered: str | No
     if key == "--model" and running is not None and rendered is not None:
         return os.path.realpath(running) == os.path.realpath(rendered)
     return running == rendered
-
-
-def _normalize_ctx_key(cfg_dict: dict[str, Any]) -> None:
-    """Fold the legacy ``[model].ctx_size`` alias into the canonical
-    ``context_size`` (SlotConfig's field), in place (#585).
-
-    The dashboard slot-edit panel writes ``ctx_size``; the load path
-    reads ``context_size``. Persisting both lets them silently diverge.
-    A fresh ``ctx_size`` (the operator's latest UI write) wins over any
-    stale ``context_size`` seed, then the alias is dropped so exactly one
-    key survives on disk. No-op when ``ctx_size`` is absent.
-    """
-    model = cfg_dict.get("model")
-    if isinstance(model, dict) and "ctx_size" in model:
-        model["context_size"] = model.pop("ctx_size")
 
 
 def _cfg_effective_backend(cfg: SlotConfig | dict[str, Any]) -> str | None:
@@ -3405,10 +3459,167 @@ def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> No
     # edit.
 
 
+# ── shared slot-config write pipeline (guards for every writer) ──────────────
+#
+# SlotManager.update_config, SlotManager.create, and the stacks apply engine
+# all project "partial updates onto an existing slot config". Historically
+# only update_config/create ran the full guard pipeline; the stacks engine
+# hand-rolled its own merge and could persist a vulkan-device+rocm-profile
+# incoherence or a second NPU anchor. These module-level, synchronous
+# functions are the ONE pipeline every writer calls.
+
+
+def _read_slot_toml_dict(path: Path) -> dict[str, Any] | None:
+    """Best-effort raw read of one ``slots/*.toml`` (with the [slot] hoist).
+
+    Returns ``None`` on a missing or malformed file — guard peer-walks skip
+    those rather than blocking the caller's legitimate write (the malformed
+    slot surfaces its own error on its own paths).
+    """
+    import tomllib
+
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    slot_tbl = data.pop("slot", None)
+    if isinstance(slot_tbl, dict):
+        for k, v in slot_tbl.items():
+            data[k] = v
+    return data
+
+
+def _iter_peer_configs(
+    slot_name: str, slots_dir: Path | None = None
+) -> list[tuple[str, dict[str, Any]]]:
+    """(name, cfg) for every readable configured slot other than ``slot_name``."""
+    base = Path(slots_dir) if slots_dir is not None else paths.slots_config_dir()
+    if not base.is_dir():
+        return []
+    peers: list[tuple[str, dict[str, Any]]] = []
+    for path in sorted(base.glob("*.toml")):
+        if path.stem == slot_name:
+            continue
+        peer = _read_slot_toml_dict(path)
+        if peer is not None:
+            peers.append((path.stem, peer))
+    return peers
+
+
+def check_npu_exclusivity(
+    slot_name: str,
+    cfg_dict: dict[str, Any],
+    *,
+    slots_dir: Path | None = None,
+) -> None:
+    """Reject a write that would land a second enabled NPU LLM anchor.
+
+    Sync core of :meth:`SlotManager._check_npu_exclusivity` (see its
+    docstring for the full contract), shared with the stacks apply engine.
+    ``slots_dir`` overrides the default config dir for engines constructed
+    against a custom directory (tests).
+    """
+    if cfg_dict.get("device") != "npu" or cfg_dict.get("type") != "llm":
+        return
+    if cfg_dict.get("enabled") is False:
+        return
+    offenders = [
+        name
+        for name, peer in _iter_peer_configs(slot_name, slots_dir)
+        if peer.get("device") == "npu"
+        and peer.get("type") == "llm"
+        and peer.get("enabled") is not False
+    ]
+    if offenders:
+        raise NpuExclusivityViolation(
+            "only one NPU LLM slot may be enabled at a time "
+            f"(slot {slot_name!r} would conflict with {offenders[0]!r})",
+            details={
+                "slot": slot_name,
+                "conflicting_slots": sorted(offenders),
+                "hint": "disable the existing NPU LLM slot before enabling another",
+            },
+        )
+
+
+def check_default_uniqueness(
+    slot_name: str,
+    cfg_dict: dict[str, Any],
+    *,
+    slots_dir: Path | None = None,
+) -> None:
+    """Reject a write that would land a second ``default=true`` per type.
+
+    Sync core of :meth:`SlotManager._check_default_uniqueness` (see its
+    docstring for the full contract), shared with the stacks apply engine.
+    """
+    if cfg_dict.get("default") is not True:
+        return
+    type_ = cfg_dict.get("type")
+    if not type_:
+        return
+    offenders = [
+        name
+        for name, peer in _iter_peer_configs(slot_name, slots_dir)
+        if peer.get("type") == type_ and peer.get("default") is True
+    ]
+    if offenders:
+        raise SlotConfigError(
+            f"slot type {type_!r} already has a default=true slot "
+            f"(slot {slot_name!r} would conflict with {offenders[0]!r})",
+            details={
+                "slot": slot_name,
+                "type": type_,
+                "conflicting_slots": sorted(offenders),
+                "hint": "clear the existing default before setting another",
+            },
+        )
+
+
+def reconcile_slot_updates(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Normalize + merge ``updates`` onto ``base`` and keep device/profile coherent.
+
+    The write-side projection shared by ``SlotManager.update_config`` and the
+    stacks apply engine: the copy-safe one-level merge + #585 ctx_size fold
+    (:func:`hal0.slot_config.merge_slot_config`) followed by
+    :func:`_reconcile_device_profile` driven by exactly the keys the caller
+    changed. Returns a fresh dict; ``base`` is never mutated.
+    """
+    merged = merge_slot_config(base, updates)
+    _reconcile_device_profile(merged, set(updates.keys()))
+    return merged
+
+
+def reconcile_and_guard_slot_config(
+    slot_name: str,
+    base: dict[str, Any],
+    updates: dict[str, Any],
+    *,
+    slots_dir: Path | None = None,
+) -> dict[str, Any]:
+    """The full guarded write pipeline: normalize + merge + reconcile + guards.
+
+    Raises :class:`SlotConfigError` / :class:`NpuExclusivityViolation` when the
+    projected config is incoherent (conflicting device+profile backends) or
+    violates a cross-slot invariant (second enabled NPU anchor, second
+    default=true of a type). Used by the stacks apply engine so a stack can no
+    longer persist what ``update_config`` would have refused.
+    """
+    merged = reconcile_slot_updates(base, updates)
+    check_npu_exclusivity(slot_name, merged, slots_dir=slots_dir)
+    check_default_uniqueness(slot_name, merged, slots_dir=slots_dir)
+    return merged
+
+
 __all__ = [
     "NPU_SEEDED_SLOTS",
     "SEEDED_SLOTS",
     "SLOT_ALIASES",
     "Slot",
     "SlotManager",
+    "check_default_uniqueness",
+    "check_npu_exclusivity",
+    "reconcile_and_guard_slot_config",
+    "reconcile_slot_updates",
 ]

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +23,13 @@ from hal0.config import paths
 from hal0.config.schema import StackConfig, StackSlotEntry
 from hal0.model_meta import canonical_device, device_to_legacy_backend
 from hal0.slot_config import ChangeSet, FileState, SlotConfigStore
-from hal0.slots.state import DISPATCHABLE_STATES, SlotState
+from hal0.slots.manager import reconcile_and_guard_slot_config
+from hal0.slots.state import (
+    DISPATCHABLE_STATES,
+    NpuExclusivityViolation,
+    SlotConfigError,
+    SlotState,
+)
 from hal0.stacks.state import (
     StackStateRecord,
     read_stack_state,
@@ -53,12 +59,18 @@ class StackChangePlan:
 
     ``change_set`` is consumed by :meth:`StackApplyEngine.apply_config` (commit)
     and by the drift hasher; ``summary`` is human-readable diff lines for the
-    dry-run preview.
+    dry-run preview. ``errors`` carries per-slot guard violations
+    (``(slot, message)``) from the shared write pipeline — an entry that
+    would persist an incoherent device/profile pair (or break the NPU /
+    default-uniqueness invariants) is kept at ``after == before`` and
+    reported here instead of aborting the whole plan; the rejection also
+    appears as a ``summary`` line so dry-run and apply responses surface it.
     """
 
     stack_slug: str
     change_set: ChangeSet
     summary: list[str]
+    errors: list[tuple[str, str]] = field(default_factory=list)
 
 
 # Slot states by convergence intent.
@@ -135,17 +147,29 @@ class StackApplyEngine:
         Only entries that carry a primary ``model`` and whose slot TOML already
         exists are reconciled (slot creation is SlotManager's job, out of 2a
         scope). For every other entry ``after == before``.
+
+        Guard violations from the shared write pipeline (incoherent
+        device+profile pair, NPU exclusivity, default uniqueness) never abort
+        the plan: the offending entry keeps ``after == before`` and the
+        violation is recorded per-slot in ``plan.errors`` (mirrored into
+        ``summary``), matching the engine's report-don't-raise philosophy.
         """
         befores: list[FileState] = []
         afters: list[FileState] = []
         summary: list[str] = []
+        errors: list[tuple[str, str]] = []
 
         for entry in stack.slots:
             if not entry.model:
                 continue
             path = self._slot_path(entry.slot)
             before = _read_toml_or_none(path)
-            after = self._reconciled_stack_slot(before, entry)
+            try:
+                after = self._reconciled_stack_slot(before, entry)
+            except (SlotConfigError, NpuExclusivityViolation) as exc:
+                errors.append((entry.slot, str(exc)))
+                summary.append(f"{entry.slot}: rejected — {exc}")
+                after = before
             befores.append(FileState(path=path, data=before))
             afters.append(FileState(path=path, data=after))
             if before != after:
@@ -155,6 +179,7 @@ class StackApplyEngine:
             stack_slug=slug,
             change_set=ChangeSet(before=tuple(befores), after=tuple(afters)),
             summary=summary,
+            errors=errors,
         )
 
     def validate(
@@ -186,44 +211,52 @@ class StackApplyEngine:
     ) -> dict[str, Any] | None:
         """Project a stack slot entry onto the existing slot TOML dict.
 
-        Deep-merges the nested ``[model]``/``[server]`` tables so sibling keys
-        (``context_size`` etc.) survive. Writes both the v0.2 ``device`` and the
-        one-release-legacy ``backend`` alias via :mod:`hal0.model_meta`. Returns
-        ``before`` unchanged when the slot file is absent (creation is out of
-        2a scope).
+        Builds the update set (both the v0.2 ``device`` and the
+        one-release-legacy ``backend`` alias via :mod:`hal0.model_meta` —
+        the SAME dual write ``SlotConfigStore._reconciled_slot`` performs)
+        and then routes it through the shared guarded pipeline
+        :func:`hal0.slots.manager.reconcile_and_guard_slot_config`: the
+        copy-safe one-level ``[model]``/``[server]`` merge, the #585
+        ``ctx_size``→``context_size`` fold, device↔profile backend
+        coherence, and the NPU-exclusivity / default-uniqueness guards.
+        A stack can therefore no longer persist what ``update_config``
+        would refuse (e.g. a vulkan device under a rocm profile) — guard
+        violations raise and :meth:`plan` records them per-slot. Returns
+        ``before`` unchanged when the slot file is absent (creation is out
+        of 2a scope).
         """
         if before is None:
             return None
-        after = dict(before)
+        updates: dict[str, Any] = {}
 
         if entry.model:
-            model = dict(after.get("model") or {})
-            model["default"] = entry.model
-            after["model"] = model
+            updates["model"] = {"default": entry.model}
         if entry.device:
             device = canonical_device(entry.device)
             if device:
-                after["device"] = device
+                updates["device"] = device
+                # Deprecated field, kept for one release — see ADR-0006 §7.
                 legacy = device_to_legacy_backend(device)
                 if legacy:
-                    after["backend"] = legacy
+                    updates["backend"] = legacy
         if entry.provider:
-            after["provider"] = entry.provider
+            updates["provider"] = entry.provider
         if entry.profile is not None:
-            after["profile"] = entry.profile
+            updates["profile"] = entry.profile
         if entry.role is not None:
-            after["role"] = entry.role
+            updates["role"] = entry.role
         # ``vision`` is a plain bool (no inherit) → declaratively written.
-        after["vision"] = entry.vision
+        updates["vision"] = entry.vision
         if entry.mtp is not None:
-            after["mtp"] = entry.mtp
+            updates["mtp"] = entry.mtp
         if entry.enable_thinking is not None:
-            after["enable_thinking"] = entry.enable_thinking
+            updates["enable_thinking"] = entry.enable_thinking
         if entry.server_extra_args is not None:
-            server = dict(after.get("server") or {})
-            server["extra_args"] = entry.server_extra_args
-            after["server"] = server
-        return after
+            updates["server"] = {"extra_args": entry.server_extra_args}
+
+        return reconcile_and_guard_slot_config(
+            entry.slot, before, updates, slots_dir=self._slots_dir
+        )
 
     @staticmethod
     def _summarize(slot: str, before: dict[str, Any] | None, after: dict[str, Any] | None) -> str:

--- a/tests/api/test_meta_enums.py
+++ b/tests/api/test_meta_enums.py
@@ -1,0 +1,119 @@
+"""Contract tests for GET /api/meta/enums (canonical vocabulary surface).
+
+The dashboard codes against these EXACT field names — the payload is the
+wire form of the canonical taxonomy in :mod:`hal0.model_meta`, so every
+key, the device-card shape, and the recommended flag are pinned here.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from hal0 import model_meta
+
+_EXPECTED_KEYS = {
+    "devices",
+    "backends",
+    "selectable_backends",
+    "device_classes",
+    "slot_types",
+    "model_capabilities",
+    "capability_aliases",
+    "model_backends",
+    "runtime_families",
+    "backend_to_device",
+    "device_default_profiles",
+}
+
+_DEVICE_FIELDS = {
+    "id",
+    "label",
+    "device_class",
+    "default_profile",
+    "legacy_backend",
+    "recommended",
+    "description",
+}
+
+
+def _get_enums(client: TestClient) -> dict:
+    r = client.get("/api/meta/enums")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_contract_shape(client: TestClient) -> None:
+    body = _get_enums(client)
+    assert set(body.keys()) == _EXPECTED_KEYS
+    # List-valued vocabularies.
+    for key in (
+        "backends",
+        "selectable_backends",
+        "device_classes",
+        "slot_types",
+        "model_capabilities",
+        "model_backends",
+        "runtime_families",
+    ):
+        assert isinstance(body[key], list) and body[key], key
+        assert all(isinstance(x, str) for x in body[key]), key
+    # Map-valued vocabularies.
+    for key in ("capability_aliases", "backend_to_device", "device_default_profiles"):
+        assert isinstance(body[key], dict) and body[key], key
+
+
+def test_devices_complete_and_shaped(client: TestClient) -> None:
+    devices = _get_enums(client)["devices"]
+    assert [d["id"] for d in devices] == ["gpu-rocm", "gpu-vulkan", "cpu", "npu"]
+    for d in devices:
+        assert set(d.keys()) == _DEVICE_FIELDS, d
+        assert isinstance(d["recommended"], bool)
+        assert d["label"] and d["description"]
+        assert d["device_class"] in model_meta.DEVICE_CLASSES
+        assert d["legacy_backend"] in model_meta.LEGACY_BACKENDS
+        # Every device names a real seed default profile — a fresh slot
+        # with profile="" fails to load, so "" is never valid here.
+        assert d["default_profile"], d["id"]
+
+
+def test_gpu_rocm_is_the_only_recommended_device(client: TestClient) -> None:
+    # CONTEXT.md: gpu-rocm is the recommended default on Strix Halo;
+    # gpu-vulkan is the slower fallback.
+    devices = _get_enums(client)["devices"]
+    recommended = [d["id"] for d in devices if d["recommended"]]
+    assert recommended == ["gpu-rocm"]
+
+
+def test_payload_matches_canonical_taxonomy(client: TestClient) -> None:
+    body = _get_enums(client)
+    assert body["backends"] == list(model_meta.LEGACY_BACKENDS)
+    assert body["selectable_backends"] == ["rocm", "vulkan", "cpu", "auto"]
+    assert body["device_classes"] == list(model_meta.DEVICE_CLASSES)
+    assert body["slot_types"] == list(model_meta.SLOT_TYPES)
+    assert body["model_capabilities"] == list(model_meta.MODEL_CAPABILITIES)
+    assert body["capability_aliases"] == model_meta.CAPABILITY_ALIASES
+    assert body["model_backends"] == list(model_meta.MODEL_BACKENDS)
+    assert body["runtime_families"] == list(model_meta.RUNTIME_FAMILIES)
+    assert body["backend_to_device"] == model_meta.BACKEND_TO_DEVICE
+    assert body["device_default_profiles"] == model_meta.DEVICE_TO_DEFAULT_PROFILE
+    # The cpu default profile is the deliberate "cpu-llm" unification
+    # (the stacks route used to carry a divergent "" entry).
+    assert body["device_default_profiles"]["cpu"] == "cpu-llm"
+
+
+def test_capability_aliases_point_at_canonical_spellings(client: TestClient) -> None:
+    body = _get_enums(client)
+    caps = set(body["model_capabilities"])
+    for alias, canonical in body["capability_aliases"].items():
+        assert canonical in caps, (alias, canonical)
+        assert alias not in caps, alias  # an alias is never also canonical
+
+
+def test_cache_headers_and_304_revalidation(client: TestClient) -> None:
+    r = client.get("/api/meta/enums")
+    assert r.status_code == 200
+    etag = r.headers.get("etag")
+    assert etag
+    assert "max-age" in r.headers.get("cache-control", "")
+    r2 = client.get("/api/meta/enums", headers={"If-None-Match": etag})
+    assert r2.status_code == 304

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -61,7 +61,9 @@ def container_stub(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     def is_active(self: ContainerProvider, slot_name: str) -> bool:
         return slot_name in state["active"]
 
-    async def health(self: ContainerProvider, port: int) -> dict[str, Any]:
+    async def health(
+        self: ContainerProvider, port: int, slot_cfg: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         return {"ok": True, "status": 200}
 
     async def wait_ready(self: ContainerProvider, port: int) -> None:

--- a/tests/api/test_slot_backend_control.py
+++ b/tests/api/test_slot_backend_control.py
@@ -8,23 +8,25 @@ is currently loaded so the container re-renders under the new backend.
 Phase E (#687) semantics under test:
   - "loaded" is the SlotManager's own truth (``is_ready_for_dispatch``) —
     no external daemon is consulted.
-  - ``actual_backend`` is always ``None``: per-process backend
-    introspection retired with the legacy runtime (#663 — the running
+  - ``effective_backend`` (and its wire back-compat alias
+    ``actual_backend``) is the EFFECTIVE backend derived from the slot's
+    config (device → backend via ``_cfg_effective_backend``); per-process
+    introspection was retired with the legacy runtime (#663 — the running
     image is the backend-of-record, surfaced as ``actual_image``).
-  - Backend builds ship inside the container images, so
-    ``_BACKEND_BUILD_BIN`` is empty and ``_backend_build_present`` always
-    returns True; it is kept as a monkeypatchable seam, and the 409
-    ``backend.build_missing`` path is exercised through that seam.
+  - Backend builds ship inside the container images, so there is NO
+    host-side build-presence check (the old always-True stub and its dead
+    409 ``backend.build_missing`` branch were removed).
 
 Validation:
-  - cpu / auto → always valid.
+  - rocm / vulkan / cpu / auto → always valid.
   - flm/npu → 400 ``backend.not_selectable``.
 
 Idempotent: same backend already declared → no-op, ``reloaded: false``.
 
 Response 200 carries the standard ``_slot_to_dict`` payload PLUS
-``requested_backend`` / ``declared_backend`` / ``actual_backend`` /
-``reloaded``.
+``requested_backend`` / ``declared_backend`` / ``effective_backend`` /
+``actual_backend`` (back-compat alias of effective) / ``device`` /
+``profile`` / ``reloaded``.
 """
 
 from __future__ import annotations
@@ -34,8 +36,6 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-
-import hal0.api.routes.slots as slots_mod
 
 
 @pytest.fixture
@@ -100,11 +100,13 @@ def test_switch_to_rocm_writes_device_and_restarts_when_loaded(
     body = r.json()
     # device persisted to TOML.
     assert _read_device(slot_toml) == "gpu-rocm"
-    # response contract.
+    # response contract: coherent declared/effective/device snapshot.
     assert body["requested_backend"] == "rocm"
     assert body["declared_backend"] == "rocm"
-    # Phase E: per-process backend introspection retired — always None.
-    assert body["actual_backend"] is None
+    assert body["effective_backend"] == "rocm"
+    # Back-compat alias carries the effective value (was hardcoded None).
+    assert body["actual_backend"] == "rocm"
+    assert body["device"] == "gpu-rocm"
     assert body["reloaded"] is True
     # standard slot payload still present.
     assert body["name"] == "chat"
@@ -143,35 +145,22 @@ def test_accepts_device_alias_and_normalizes_gpu_form(
 # ── build presence: container images always carry the build ─────────────────
 
 
-def test_build_presence_defaults_to_true_no_409(
+def test_gpu_backend_switch_never_gated_on_host_builds(
     slot_toml: Path,
     client: TestClient,
 ) -> None:
     """Backend builds ship inside container images — no host-side check.
 
-    ``_BACKEND_BUILD_BIN`` is empty and ``_backend_build_present`` always
-    returns True, so an unpatched rocm switch succeeds.
+    The always-True ``_backend_build_present`` stub and its unreachable 409
+    ``backend.build_missing`` branch were removed; an unpatched rocm switch
+    must simply succeed.
     """
-    assert slots_mod._BACKEND_BUILD_BIN == {}
-    assert slots_mod._backend_build_present("rocm") is True
-    assert slots_mod._backend_build_present("vulkan") is True
+    import hal0.api.routes.slots as slots_mod
+
+    assert not hasattr(slots_mod, "_backend_build_present"), "dead stub must stay removed"
     r = client.post("/api/slots/chat/backend", json={"backend": "rocm"})
     assert r.status_code == 200, r.text
     assert _read_device(slot_toml) == "gpu-rocm"
-
-
-def test_rocm_build_missing_returns_409_via_seam(
-    slot_toml: Path,
-    client: TestClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The monkeypatchable seam still gates the switch (future host builds)."""
-    monkeypatch.setattr(slots_mod, "_backend_build_present", lambda b: b != "rocm")
-    r = client.post("/api/slots/chat/backend", json={"backend": "rocm"})
-    assert r.status_code == 409, r.text
-    assert r.json()["error"]["code"] == "backend.build_missing"
-    # device must NOT have changed.
-    assert _read_device(slot_toml) == "gpu-vulkan"
 
 
 # ── 400 not_selectable for flm/npu ───────────────────────────────────────────
@@ -221,15 +210,17 @@ def test_idempotent_same_backend_no_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Requesting the already-declared backend is a no-op, even when loaded
-    (actual_backend is always None post-#663, so the declared device is
-    the only idempotency input)."""
+    (the effective backend is config-derived, so declared==effective when
+    the device already matches)."""
     restarts = _patch_loaded(client, monkeypatch, loaded=True)
     r = client.post("/api/slots/chat/backend", json={"backend": "vulkan"})
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["reloaded"] is False
     assert body["declared_backend"] == "vulkan"
-    assert body["actual_backend"] is None
+    assert body["effective_backend"] == "vulkan"
+    assert body["actual_backend"] == "vulkan"
+    assert body["device"] == "gpu-vulkan"
     # No restart cycle.
     assert not restarts, "idempotent no-op must not restart"
     # device unchanged.

--- a/tests/api/test_slot_config_validation.py
+++ b/tests/api/test_slot_config_validation.py
@@ -1,0 +1,190 @@
+"""Boundary validation on slot-config writes (PUT config / PATCH defaults /
+POST create) + configured port-range allocation.
+
+``SlotConfig``/``ModelConfig``/``ServerConfig`` are ``extra="allow"``, so a
+typo'd key used to persist silently and the intended setting never took
+effect. The routes now reject unknown keys with 400
+``validation.unknown_keys`` listing the offending paths, while all
+documented legacy aliases (``[model].ctx_size``, string ``image``, …) and
+actively-read extras (``type``, ``default``, ``lru``, ``default_voice``)
+keep working. Known fields are derived from the pydantic models
+dynamically, so schema additions (e.g. ``[server].env``) pass automatically.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api.routes.slots import _next_free_slot_port
+
+
+@pytest.fixture
+def slot_toml(tmp_hal0_home: str) -> Path:
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "chat.toml"
+    path.write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                'type = "llm"',
+                'device = "gpu-vulkan"',
+                "enabled = true",
+                "port = 8081",
+                "[model]",
+                'default = "qwen3-4b"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _read(path: Path) -> dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+# ── PUT /config ──────────────────────────────────────────────────────────────
+
+
+def test_put_config_unknown_top_level_key_400(slot_toml: Path, client: TestClient) -> None:
+    r = client.put("/api/slots/chat/config", json={"enabeld": False})
+    assert r.status_code == 400, r.text
+    body = r.json()["error"]
+    assert body["code"] == "validation.unknown_keys"
+    assert body["details"]["unknown_keys"] == ["enabeld"]
+    # Nothing persisted.
+    assert "enabeld" not in _read(slot_toml)
+
+
+def test_put_config_unknown_model_key_400_with_path(slot_toml: Path, client: TestClient) -> None:
+    r = client.put("/api/slots/chat/config", json={"model": {"ctx_sizee": 8192}})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["details"]["unknown_keys"] == ["model.ctx_sizee"]
+
+
+def test_put_config_valid_keys_and_dynamic_server_fields_pass(
+    slot_toml: Path, client: TestClient
+) -> None:
+    """[server].env (schema-derived, not hardcoded) + extra_args pass."""
+    r = client.put(
+        "/api/slots/chat/config",
+        json={"server": {"extra_args": "-b 2048", "env": {"HSA_XNACK": "1"}}},
+    )
+    assert r.status_code == 200, r.text
+    on_disk = _read(slot_toml)
+    assert on_disk["server"]["extra_args"] == "-b 2048"
+    assert on_disk["server"]["env"] == {"HSA_XNACK": "1"}
+
+
+def test_put_config_tolerated_extras_pass(slot_toml: Path, client: TestClient) -> None:
+    """default_voice (voice settings) and string image override keep working."""
+    r = client.put("/api/slots/chat/config", json={"default_voice": "Ryan"})
+    assert r.status_code == 200, r.text
+    r = client.put("/api/slots/chat/config", json={"image": "ghcr.io/hal0ai/toolbox:vulkan"})
+    assert r.status_code == 200, r.text
+    on_disk = _read(slot_toml)
+    assert on_disk["default_voice"] == "Ryan"
+    assert on_disk["image"] == "ghcr.io/hal0ai/toolbox:vulkan"
+
+
+# ── PATCH /defaults ──────────────────────────────────────────────────────────
+
+
+def test_patch_defaults_ctx_size_alias_still_accepted(slot_toml: Path, client: TestClient) -> None:
+    r = client.patch("/api/slots/chat/defaults", json={"ctx_size": 32768})
+    assert r.status_code == 200, r.text
+    model = _read(slot_toml)["model"]
+    # Folded to the canonical key; exactly one survives on disk (#585).
+    assert model["context_size"] == 32768
+    assert "ctx_size" not in model
+    assert model["default"] == "qwen3-4b", "sibling [model] keys must survive"
+
+
+def test_patch_defaults_unknown_key_400(slot_toml: Path, client: TestClient) -> None:
+    r = client.patch("/api/slots/chat/defaults", json={"contxt_size": 32768})
+    assert r.status_code == 400, r.text
+    body = r.json()["error"]
+    assert body["code"] == "validation.unknown_keys"
+    assert body["details"]["unknown_keys"] == ["model.contxt_size"]
+
+
+# ── POST create ──────────────────────────────────────────────────────────────
+
+
+def test_create_unknown_key_400_writes_nothing(tmp_hal0_home: str, client: TestClient) -> None:
+    r = client.post(
+        "/api/slots",
+        json={"name": "extra", "type": "llm", "modle": "qwen3-4b"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["details"]["unknown_keys"] == ["modle"]
+    assert not (Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "extra.toml").exists()
+
+
+def test_create_flat_body_valid_keys_201(slot_toml: Path, client: TestClient) -> None:
+    r = client.post(
+        "/api/slots",
+        json={
+            "name": "extra",
+            "type": "llm",
+            "runtime": "container",
+            "device": "gpu-vulkan",
+            "model": "qwen3-4b",
+            "default": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+    # Auto-assigned port skips chat's 8081.
+    assert r.json()["port"] == 8082
+
+
+# ── port-range allocation ────────────────────────────────────────────────────
+
+
+def test_next_free_slot_port_spans_full_schema_range(tmp_hal0_home: str) -> None:
+    """Ports beyond the stale 8099 cap are allocatable (schema max 8200)."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    for port in range(8081, 8100):  # occupy the legacy 8081-8099 window
+        (root / f"s{port}.toml").write_text(f'name = "s{port}"\nport = {port}\n', encoding="utf-8")
+    # Pre-fix this raised slot.no_free_port; now the pool extends to 8200.
+    assert _next_free_slot_port() == 8100
+
+
+def test_next_free_slot_port_honors_hal0_toml_range(tmp_hal0_home: str) -> None:
+    etc = Path(tmp_hal0_home) / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "hal0.toml").write_text(
+        "[slots]\nport_range_start = 8150\nport_range_end = 8152\n",
+        encoding="utf-8",
+    )
+    (etc / "slots").mkdir(exist_ok=True)
+    (etc / "slots" / "a.toml").write_text('name = "a"\nport = 8150\n', encoding="utf-8")
+    assert _next_free_slot_port() == 8151
+
+
+def test_next_free_slot_port_exhausted_configured_range_raises(
+    tmp_hal0_home: str,
+) -> None:
+    from hal0.api.middleware.error_codes import BadRequest
+
+    etc = Path(tmp_hal0_home) / "etc" / "hal0"
+    (etc / "slots").mkdir(parents=True, exist_ok=True)
+    (etc / "hal0.toml").write_text(
+        "[slots]\nport_range_start = 8150\nport_range_end = 8151\n",
+        encoding="utf-8",
+    )
+    for port in (8150, 8151):
+        (etc / "slots" / f"s{port}.toml").write_text(
+            f'name = "s{port}"\nport = {port}\n', encoding="utf-8"
+        )
+    with pytest.raises(BadRequest) as exc_info:
+        _next_free_slot_port()
+    assert exc_info.value.code == "slot.no_free_port"

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -290,6 +290,26 @@ class TestSlotConfigRoundTrip:
         # No stray empty [server] table.
         assert "server" not in data
 
+    # ── [server].env ─────────────────────────────────────────────────────
+
+    def test_server_env_loads_and_round_trips(self, tmp_hal0_home: str) -> None:
+        """`[server].env` populates the typed field and round-trips to disk."""
+        paths.slots_config_dir().mkdir(parents=True, exist_ok=True)
+        (paths.slots_config_dir() / "primary.toml").write_text(
+            "[slot]\n"
+            'name = "primary"\n'
+            "port = 8081\n"
+            "[server.env]\n"
+            'HSA_OVERRIDE_GFX_VERSION = "11.0.0"\n'
+        )
+        cfg = load_slot_config("primary")
+        assert cfg.server.env == {"HSA_OVERRIDE_GFX_VERSION": "11.0.0"}
+
+        save_slot_config(cfg)
+        with open(paths.slots_config_dir() / "primary.toml", "rb") as f:
+            data = tomllib.load(f)
+        assert data["server"]["env"]["HSA_OVERRIDE_GFX_VERSION"] == "11.0.0"
+
 
 # ── providers.toml round-trip ────────────────────────────────────────────────
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -50,6 +50,7 @@ class TestServerConfigEnv:
         with pytest.raises(ValidationError):
             ServerConfig(env={"OK": "line1\nline2"})
 
+
 # ── SlotConfig ────────────────────────────────────────────────────────────────
 
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -23,12 +23,32 @@ from hal0.config.schema import (
     ModelConfig,
     ProviderEntry,
     ProvidersConfig,
+    ServerConfig,
     SlotConfig,
     SlotsConfig,
     TelemetryConfig,
     UpstreamEntry,
     UpstreamsConfig,
 )
+
+
+class TestServerConfigEnv:
+    def test_valid_env_accepted(self) -> None:
+        sc = ServerConfig(env={"HSA_OVERRIDE_GFX_VERSION": "11.0.0", "FOO_BAR": "x"})
+        assert sc.env == {"HSA_OVERRIDE_GFX_VERSION": "11.0.0", "FOO_BAR": "x"}
+
+    def test_env_default_none(self) -> None:
+        assert ServerConfig().env is None
+
+    def test_invalid_env_key_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ServerConfig(env={"1BAD": "x"})
+        with pytest.raises(ValidationError):
+            ServerConfig(env={"has-dash": "x"})
+
+    def test_newline_in_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ServerConfig(env={"OK": "line1\nline2"})
 
 # ── SlotConfig ────────────────────────────────────────────────────────────────
 

--- a/tests/config/test_schema_migration.py
+++ b/tests/config/test_schema_migration.py
@@ -98,7 +98,9 @@ class TestMapBackendToDevice:
 
     def test_unknown_value_maps_to_cpu_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         # Edge case: operator hand-edited backend to a typo.
-        with caplog.at_level("WARNING", logger="hal0.config.schema"):
+        # The implementation moved to hal0.model_meta (schema re-exports it);
+        # the log event name is unchanged for grep continuity.
+        with caplog.at_level("WARNING", logger="hal0.model_meta"):
             result = map_backend_to_device("rcom")
         assert result == "cpu"
         assert any("device_mapping_unknown_backend" in r.message for r in caplog.records)

--- a/tests/model_meta/test_model_meta.py
+++ b/tests/model_meta/test_model_meta.py
@@ -309,3 +309,114 @@ def test_device_to_legacy_backend(device: str, expected: str) -> None:
 )
 def test_labels_of(cfg: dict[str, Any], expected: set[str]) -> None:
     assert labels_of(cfg) == expected
+
+
+# ── canonical taxonomy (Wave 2: model_meta as the single vocabulary home) ────
+#
+# The taxonomy constants feed /api/meta/enums and the schema re-exports;
+# these tests pin the cross-module sync points and the unified
+# unknown-value policy documented in the model_meta module docstring.
+
+
+def test_schema_reexports_alias_the_canonical_taxonomy() -> None:
+    """config.schema's public names are thin re-exports of model_meta."""
+    from hal0 import model_meta
+    from hal0.config import schema
+
+    assert schema.BACKEND_TO_DEVICE is model_meta.BACKEND_TO_DEVICE
+    assert schema.DEFAULT_DEVICE == model_meta.DEFAULT_DEVICE
+    assert schema.DEVICE_DEFAULT_PROFILES is model_meta.DEVICE_TO_DEFAULT_PROFILE
+    assert schema.map_backend_to_device is model_meta.map_backend_to_device
+    assert schema._VALID_DEVICES == model_meta.VALID_DEVICES
+    assert frozenset(model_meta.LEGACY_BACKENDS) == schema._VALID_BACKENDS
+
+
+def test_device_literal_matches_valid_devices() -> None:
+    from typing import get_args
+
+    from hal0.config.schema import DeviceLiteral
+    from hal0.model_meta import VALID_DEVICES
+
+    assert set(get_args(DeviceLiteral)) == set(VALID_DEVICES)
+
+
+def test_profiles_literals_match_model_meta() -> None:
+    """hal0.profiles' Literals mirror the canonical tuples (a Literal can't
+    be built from a runtime tuple, so sync is enforced here)."""
+    from typing import get_args
+
+    from hal0.model_meta import RUNTIME_FAMILIES, SLOT_TYPES
+    from hal0.profiles import RuntimeFamily, SlotType
+
+    assert set(get_args(RuntimeFamily)) == set(RUNTIME_FAMILIES)
+    assert set(get_args(SlotType)) == set(SLOT_TYPES)
+
+
+def test_slot_manager_valid_slot_types_match() -> None:
+    from hal0.model_meta import SLOT_TYPES
+    from hal0.slots.manager import _VALID_SLOT_TYPES
+
+    assert frozenset(SLOT_TYPES) == _VALID_SLOT_TYPES
+
+
+def test_device_metadata_is_internally_consistent() -> None:
+    from hal0.config.schema import SEED_PROFILES
+    from hal0.model_meta import (
+        BACKEND_TO_DEVICE,
+        CANONICAL_DEVICES,
+        DEVICE_CLASSES,
+        DEVICE_TO_DEFAULT_PROFILE,
+        LEGACY_BACKENDS,
+        VALID_DEVICES,
+    )
+
+    assert {d.id for d in CANONICAL_DEVICES} == VALID_DEVICES
+    for d in CANONICAL_DEVICES:
+        assert d.device_class in DEVICE_CLASSES
+        assert d.legacy_backend in LEGACY_BACKENDS
+        # Every default profile must be a real seed profile — "" would
+        # leave a fresh slot born broken ("profile '' not found").
+        assert d.default_profile in SEED_PROFILES, d.id
+        assert BACKEND_TO_DEVICE[d.legacy_backend] == d.id
+        assert BACKEND_TO_DEVICE[d.id] == d.id  # idempotent
+        assert DEVICE_TO_DEFAULT_PROFILE[d.id] == d.default_profile
+    recommended = [d.id for d in CANONICAL_DEVICES if d.recommended]
+    assert recommended == ["gpu-rocm"]  # CONTEXT.md: ROCm default, Vulkan fallback
+
+
+# ── unified unknown-value policy ─────────────────────────────────────────────
+
+
+def test_unknown_legacy_backend_warns_and_defaults_cpu(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Direction 1: unknown legacy backend → warn + safe 'cpu' default."""
+    from hal0.model_meta import map_backend_to_device
+
+    with caplog.at_level("WARNING", logger="hal0.model_meta"):
+        assert map_backend_to_device("vukan") == "cpu"
+    assert any("device_mapping_unknown_backend" in r.message for r in caplog.records)
+
+
+def test_unknown_device_warns_and_returns_no_opinion(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Direction 2: unknown device → warn + (None, None) (callers default)."""
+    with caplog.at_level("WARNING", logger="hal0.model_meta"):
+        assert device_to_backend("quantum-annealer") == (None, None)
+    assert any("unknown_device" in r.message for r in caplog.records)
+
+
+def test_unknown_device_legacy_writeback_warns_and_passes_through(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Direction 3: unknown device on the legacy write-back path → warn +
+    UNCHANGED passthrough (load-bearing for downgrade legibility)."""
+    with caplog.at_level("WARNING", logger="hal0.model_meta"):
+        assert device_to_legacy_backend("weird-token") == "weird-token"
+    assert any("unknown_device_passthrough" in r.message for r in caplog.records)
+    # Empty input stays silent — "no opinion" is not an unknown value.
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="hal0.model_meta"):
+        assert device_to_legacy_backend("") == ""
+    assert not caplog.records

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -482,9 +482,14 @@ class TestContainerSpec:
         assert store_mount.read_only is True
 
     def test_devices_present(self) -> None:
-        with patch(
-            "hal0.providers.container.resolve_gpu_device_paths",
-            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        with (
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            # GPU device nodes are existence-filtered at the container_spec call
+            # site; force present so the CI host (no /dev/kfd) still keeps them.
+            patch("hal0.providers.container.os.path.exists", return_value=True),
         ):
             spec = self._build_spec()
         assert spec.devices == ["/dev/kfd", "/dev/dri/renderD128"]

--- a/tests/providers/test_container_assembler.py
+++ b/tests/providers/test_container_assembler.py
@@ -1,0 +1,236 @@
+"""Single-assembler tests: launch/preview parity, model-default precedence,
+GPU gating for cpu profiles, and [server].env rendering.
+
+These pin the refactor that makes the launch path
+(``ContainerProvider.container_spec`` → ``_llama_launch_plan``) and the preview
+path (``resolved_command_for_slot`` / ``_resolve_slot_argv``) share ONE labelled
+segment builder (``_llama_argv_segments``), so an operator's previewed command
+is byte-identical to what launches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from hal0.config.schema import ProfileConfig
+from hal0.providers.container import (
+    ContainerProvider,
+    _llama_launch_plan,
+    _render_unit_from_plan,
+    resolved_command_for_slot,
+)
+
+_TEST_RUNTIME = "/usr/bin/docker"
+
+
+def _gpu_profile(**overrides: Any) -> ProfileConfig:
+    base: dict[str, Any] = dict(
+        image="ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        flags="-fa on -ctk q8_0 -b 512 --parallel 1 --threads 8",
+        mtp=False,
+        device_class="gpu",
+        backend="rocm",
+    )
+    base.update(overrides)
+    return ProfileConfig(**base)
+
+
+# ── 1. preview == launch parity (mtp + chat_template + mmproj + extra_args) ────
+
+
+def test_preview_equals_launch_full_slot() -> None:
+    """resolved_command_for_slot renders the exact argv container_spec launches
+    for a slot exercising the mtp override, model-registry defaults, a
+    chat-template, an mmproj sidecar, a slot ngl override, and extra_args."""
+    cfg = {
+        "name": "agent",
+        "port": 8101,
+        "profile": "rocm",
+        "device": "gpu-rocm",
+        "mtp": True,
+        "chat_template": "chatml",
+        "vision": True,
+        "model": {"default": "my-model", "context_size": 40000, "n_gpu_layers": 88},
+        "server": {"extra_args": "-b 8192 --jinja"},
+    }
+    model_info = {
+        "_model_key": "my-model",
+        "path": "/mnt/ai-models/my-model.gguf",
+        "mmproj": "/mnt/ai-models/my-model/mmproj-f16.gguf",
+        "defaults": {"extra_args": "--rope-scaling linear", "n_gpu_layers": 40},
+        "metadata": {"context_length": 262144},
+    }
+
+    profile = _gpu_profile(mtp=False)  # slot mtp=True must force the bundle on
+
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=profile),
+        patch(
+            "hal0.providers.container._best_effort_model_info",
+            return_value=model_info,
+        ),
+    ):
+        preview = resolved_command_for_slot(cfg)
+        launch_plan = ContainerProvider().container_spec(cfg, model_info)
+
+    assert preview is not None
+    # preview = [image, *argv]; launch command excludes the image.
+    assert preview[0] == profile.image
+    assert preview[1:] == launch_plan.command
+
+
+# ── 2. model-default / ngl precedence ─────────────────────────────────────────
+
+
+def _ngl(command: list[str]) -> str | None:
+    return command[command.index("-ngl") + 1] if "-ngl" in command else None
+
+
+def test_ngl_precedence_extra_args_wins() -> None:
+    plan = _llama_launch_plan(
+        image="i:1",
+        port=8095,
+        model_path="/m.gguf",
+        flags_str="-ngl 10",
+        devices=[],
+        group_ids=[],
+        model_defaults={"n_gpu_layers": 20},
+        slot_n_gpu_layers=30,
+        extra_args="-ngl 40",
+    )
+    assert _ngl(plan.command) == "40"
+    assert plan.command.count("-ngl") == 1
+
+
+def test_ngl_precedence_slot_beats_model_default() -> None:
+    plan = _llama_launch_plan(
+        image="i:1",
+        port=8095,
+        model_path="/m.gguf",
+        flags_str="-ngl 10",
+        devices=[],
+        group_ids=[],
+        model_defaults={"n_gpu_layers": 20},
+        slot_n_gpu_layers=30,
+    )
+    assert _ngl(plan.command) == "30"
+
+
+def test_ngl_precedence_model_default_beats_profile() -> None:
+    plan = _llama_launch_plan(
+        image="i:1",
+        port=8095,
+        model_path="/m.gguf",
+        flags_str="-ngl 10",
+        devices=[],
+        group_ids=[],
+        model_defaults={"n_gpu_layers": 20},
+        slot_n_gpu_layers=-1,  # unset sentinel → no slot override
+    )
+    assert _ngl(plan.command) == "20"
+
+
+def test_model_default_extra_args_emitted_and_overridable() -> None:
+    plan = _llama_launch_plan(
+        image="i:1",
+        port=8095,
+        model_path="/m.gguf",
+        flags_str="",
+        devices=[],
+        group_ids=[],
+        model_defaults={"extra_args": "--rope-scaling linear --foo 1"},
+        extra_args="--foo 2",  # slot extra_args overrides a model default
+    )
+    assert "--rope-scaling" in plan.command
+    assert plan.command[plan.command.index("--rope-scaling") + 1] == "linear"
+    assert plan.command.count("--foo") == 1
+    assert plan.command[plan.command.index("--foo") + 1] == "2"
+
+
+# ── 3. cpu profile gets no GPU devices / GIDs ─────────────────────────────────
+
+
+def test_cpu_profile_gets_no_gpu_plumbing() -> None:
+    cfg = {
+        "name": "cpu-slot",
+        "port": 8095,
+        "profile": "cpu-llm",
+        "device": "cpu",
+        "model": {"default": "m"},
+    }
+    cpu_profile = _gpu_profile(device_class="cpu", backend=None)
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=cpu_profile),
+        patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ),
+        patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
+        patch("hal0.providers.container.os.path.exists", return_value=True),
+    ):
+        spec = ContainerProvider().container_spec(
+            cfg, {"_model_key": "m", "path": "/mnt/ai-models/m.gguf"}
+        )
+    assert spec.devices == []
+    assert spec.group_add == []
+
+
+def test_gpu_profile_existence_filters_devices() -> None:
+    cfg = {
+        "name": "gpu-slot",
+        "port": 8095,
+        "profile": "rocm",
+        "device": "gpu-rocm",
+        "model": {"default": "m"},
+    }
+
+    def _exists(path: str) -> bool:
+        return path == "/dev/dri/renderD128"  # /dev/kfd absent on this host
+
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=_gpu_profile()),
+        patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ),
+        patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993]),
+        patch("hal0.providers.container.os.path.exists", side_effect=_exists),
+    ):
+        spec = ContainerProvider().container_spec(
+            cfg, {"_model_key": "m", "path": "/mnt/ai-models/m.gguf"}
+        )
+    assert spec.devices == ["/dev/dri/renderD128"]  # non-existent /dev/kfd dropped
+    assert spec.group_add == ["993"]
+
+
+# ── 4. [server].env renders into the unit ─────────────────────────────────────
+
+
+def test_server_env_threads_into_plan_and_unit() -> None:
+    cfg = {
+        "name": "gpu-slot",
+        "port": 8095,
+        "profile": "rocm",
+        "device": "gpu-rocm",
+        "model": {"default": "m"},
+        "server": {"env": {"HSA_OVERRIDE_GFX_VERSION": "11.0.0"}},
+    }
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=_gpu_profile()),
+        patch("hal0.providers.container.resolve_gpu_device_paths", return_value=[]),
+        patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[]),
+    ):
+        spec = ContainerProvider().container_spec(
+            cfg, {"_model_key": "m", "path": "/mnt/ai-models/m.gguf"}
+        )
+    assert spec.env == {"HSA_OVERRIDE_GFX_VERSION": "11.0.0"}
+    unit = _render_unit_from_plan("gpu-slot", spec, runtime_bin=_TEST_RUNTIME)
+    assert "--env=HSA_OVERRIDE_GFX_VERSION=11.0.0" in unit
+
+
+def test_env_empty_when_no_server_env() -> None:
+    plan = _llama_launch_plan(
+        image="i:1", port=8095, model_path="/m.gguf", flags_str="", devices=[], group_ids=[]
+    )
+    assert plan.env == {}

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -236,6 +236,9 @@ class TestLoadSyncNpuBranch:
                 "hal0.providers.container.resolve_gpu_device_paths",
                 return_value=["/dev/kfd", "/dev/dri/renderD128"],
             ),
+            # GPU device nodes are existence-filtered at the container_spec call
+            # site; force present so the CI host (no /dev/kfd) still renders them.
+            patch("hal0.providers.container.os.path.exists", return_value=True),
             patch.object(provider, "_run", side_effect=fake_run),
             patch.object(provider, "_unit_path", return_value=unit_file),
         ):
@@ -329,6 +332,56 @@ async def test_health_200_on_health_still_healthy() -> None:
 
     assert result["ok"] is True
     assert result["status"] == "healthy"
+
+
+@pytest.mark.anyio
+async def test_health_delegates_to_flm_tier1_when_slot_is_npu() -> None:
+    """When ContainerProvider.health is given an FLM slot_cfg, it delegates to
+    FLMProvider.health (the Tier-1 /v1/chat/completions probe) instead of the
+    weak /v1/models fallback."""
+    from hal0.providers.flm import FLMProvider
+
+    sentinel = {"ok": True, "status": "ready", "model": "qwen3:0.6b"}
+
+    async def fake_flm_health(self: Any, port: int) -> dict[str, Any]:
+        assert port == 8088
+        return sentinel
+
+    provider = ContainerProvider()
+    with (
+        patch.object(FLMProvider, "health", fake_flm_health),
+        # /health must NOT be probed on the delegation path.
+        patch(
+            "hal0.providers.container.httpx.AsyncClient",
+            side_effect=AssertionError("must not open an httpx client when delegating to FLM"),
+        ),
+    ):
+        result = await provider.health(8088, slot_cfg={"device": "npu"})
+
+    assert result is sentinel
+
+
+@pytest.mark.anyio
+async def test_health_no_delegation_without_slot_cfg() -> None:
+    """The legacy port-only call keeps the /health + /v1/models fallback path
+    (no FLM delegation, so existing manager call sites are unaffected)."""
+    provider = ContainerProvider()
+
+    health_resp = MagicMock()
+    health_resp.status_code = 200
+
+    async def fake_get(url: str, **kwargs: Any) -> MagicMock:
+        return health_resp
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = fake_get
+
+    with patch("hal0.providers.container.httpx.AsyncClient", return_value=mock_client):
+        result = await provider.health(8095)
+
+    assert result["ok"] is True
 
 
 @pytest.mark.anyio

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -198,6 +198,9 @@ def test_gpu_slot_unaffected_still_takes_llama_path(tmp_path: Any) -> None:
             "hal0.providers.container.resolve_gpu_group_ids",
             return_value=[],
         ),
+        # GPU device nodes are existence-filtered at the container_spec call
+        # site; force them "present" so the CI host (no /dev/kfd) still renders.
+        patch("hal0.providers.container.os.path.exists", return_value=True),
         patch.object(provider, "_run", side_effect=fake_run),
         patch.object(provider, "_unit_path", return_value=unit_file),
     ):

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -492,3 +492,27 @@ def test_flm_id_to_tag_empty_catalog_returns_none() -> None:
 
     with patch("hal0.providers.flm.flm_served_models", list):
         assert flm.flm_id_to_tag("gemma4-it-e2b-FLM") is None
+
+
+# ─── parse_flm_progress units (incl. terabyte) ───────────────────────────────
+
+
+def test_parse_flm_progress_megabytes() -> None:
+    import hal0.providers.flm as flm
+
+    got = flm.parse_flm_progress("[FLM]  Downloading: 38.8% (253.0MB / 652.1MB)")
+    assert got == (int(253.0 * 1024**2), int(652.1 * 1024**2))
+
+
+def test_parse_flm_progress_terabytes() -> None:
+    """The unit map now includes 'T' so a multi-TB shard doesn't KeyError→None."""
+    import hal0.providers.flm as flm
+
+    got = flm.parse_flm_progress("[FLM]  Downloading: 10.0% (0.5TB / 5.0TB)")
+    assert got == (int(0.5 * 1024**4), int(5.0 * 1024**4))
+
+
+def test_parse_flm_progress_non_matching_line_is_none() -> None:
+    import hal0.providers.flm as flm
+
+    assert flm.parse_flm_progress("[FLM] verifying checksum") is None

--- a/tests/slot_config/test_validation_and_lock.py
+++ b/tests/slot_config/test_validation_and_lock.py
@@ -1,0 +1,120 @@
+"""Unit tests for the slot-config write helpers added in the guarded-writes
+wave: ``unknown_slot_config_keys`` (boundary validation),
+``fold_ctx_size_alias`` (the ONE #585 fold), and ``slot_write_lock``
+(coarse cross-process lock for all slots/*.toml writes).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.config.locking import lock_path_for
+from hal0.slot_config import (
+    fold_ctx_size_alias,
+    slot_write_lock,
+    unknown_slot_config_keys,
+)
+
+# ── unknown_slot_config_keys ─────────────────────────────────────────────────
+
+
+class TestUnknownKeys:
+    def test_clean_payload_passes(self) -> None:
+        payload = {
+            "name": "chat",
+            "port": 8081,
+            "type": "llm",
+            "device": "gpu-vulkan",
+            "backend": "vulkan",  # deprecated but declared field
+            "provider": "llama-server",
+            "runtime": "container",
+            "enabled": True,
+            "default": True,
+            "lru": True,
+            "profile": "vulkan",
+            "model": {"default": "m", "context_size": 8192, "extra": {"anything": 1}},
+            "server": {"extra_args": "-b 2048"},
+            "npu": {"asr": True, "embed": False},
+            "image": {"default_steps": 20},
+        }
+        assert unknown_slot_config_keys(payload) == []
+
+    def test_typo_top_level_flagged(self) -> None:
+        assert unknown_slot_config_keys({"enabeld": True}) == ["enabeld"]
+
+    def test_typo_in_subtables_flagged_with_paths(self) -> None:
+        payload = {
+            "model": {"ctx_sizee": 1},
+            "server": {"extra_argz": ""},
+            "npu": {"asrr": True},
+        }
+        assert unknown_slot_config_keys(payload) == [
+            "model.ctx_sizee",
+            "npu.asrr",
+            "server.extra_argz",
+        ]
+
+    def test_legacy_ctx_size_alias_tolerated(self) -> None:
+        assert unknown_slot_config_keys({"model": {"ctx_size": 8192}}) == []
+
+    def test_string_image_override_tolerated(self) -> None:
+        assert unknown_slot_config_keys({"image": "ghcr.io/x/y:z"}) == []
+
+    def test_extra_tables_pass_verbatim(self) -> None:
+        assert unknown_slot_config_keys({"extra": {"whatever": {"nested": 1}}}) == []
+
+    def test_nested_slot_table_checked_against_top_vocabulary(self) -> None:
+        assert unknown_slot_config_keys({"slot": {"port": 8081, "prot": 1}}) == ["slot.prot"]
+
+    def test_fields_derived_dynamically_from_schema(self) -> None:
+        """Every declared ServerConfig field passes without a hardcoded list —
+        this is what keeps schema additions like [server].env in sync."""
+        from hal0.config.schema import ServerConfig
+
+        payload = {"server": dict.fromkeys(ServerConfig.model_fields, None)}
+        assert unknown_slot_config_keys(payload) == []
+
+
+# ── fold_ctx_size_alias ──────────────────────────────────────────────────────
+
+
+class TestFoldCtxSizeAlias:
+    def test_folds_and_drops_alias(self) -> None:
+        cfg = {"model": {"ctx_size": 4096, "context_size": 2048, "default": "m"}}
+        fold_ctx_size_alias(cfg)
+        assert cfg["model"] == {"context_size": 4096, "default": "m"}
+
+    def test_noop_without_alias(self) -> None:
+        cfg = {"model": {"context_size": 2048}}
+        fold_ctx_size_alias(cfg)
+        assert cfg == {"model": {"context_size": 2048}}
+
+    def test_copy_safe_on_shared_model_subdict(self) -> None:
+        """The 'before' snapshot sharing the [model] object is never mutated."""
+        shared = {"ctx_size": 4096}
+        before = {"model": shared}
+        cfg = {"model": shared}
+        fold_ctx_size_alias(cfg)
+        assert before["model"] == {"ctx_size": 4096}, "shared sub-dict must not mutate"
+        assert cfg["model"] == {"context_size": 4096}
+
+
+# ── slot_write_lock ──────────────────────────────────────────────────────────
+
+
+class TestSlotWriteLock:
+    def test_creates_one_coarse_lock_for_the_slots_dir(self, tmp_path: Path) -> None:
+        slots_dir = tmp_path / "slots"
+        with slot_write_lock(slots_dir):
+            assert lock_path_for(slots_dir).exists()
+
+    def test_reentrant_within_thread(self, tmp_path: Path) -> None:
+        slots_dir = tmp_path / "slots"
+        with slot_write_lock(slots_dir), slot_write_lock(slots_dir):
+            pass  # nested acquire must not self-deadlock
+
+    def test_defaults_to_configured_slots_dir(self, tmp_hal0_home: str) -> None:
+        from hal0.config import paths
+
+        with slot_write_lock():
+            assert lock_path_for(paths.slots_config_dir()).exists()

--- a/tests/slots/conftest.py
+++ b/tests/slots/conftest.py
@@ -76,7 +76,10 @@ class FakeContainerProvider:
     async def wait_ready(self, port: int, timeout_s: float | None = None) -> None:
         return None
 
-    async def health(self, port: int) -> dict[str, Any]:
+    async def health(self, port: int, slot_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        # Mirrors ContainerProvider.health's (port, slot_cfg) signature —
+        # the manager passes the slot config so FLM slots get the Tier-1
+        # real-inference probe in production.
         return {"ok": self.healthy}
 
     # — slot_view container_enrichment extras —

--- a/tests/slots/test_adopted_slot_eviction.py
+++ b/tests/slots/test_adopted_slot_eviction.py
@@ -1,0 +1,129 @@
+"""Adopted / restart-surviving slots participate in idle + pressure eviction.
+
+Two halves of the fix:
+
+  1. ``_maybe_adopt_running_slot`` bumps ``last_used`` so an adopted slot's
+     idle clock starts at adoption instead of never.
+  2. ``_sweep_candidates`` falls back to the state record's ``updated_at``
+     for dispatchable slots missing from ``_last_used`` entirely, so both
+     ``_sweep_idle_once`` and ``_pressure_evict_once`` can see them.
+
+Pre-fix, a container that outlived an api restart was invisible to both
+sweeps (they iterated only ``_last_used``) and squatted on RAM forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def test_adoption_bumps_last_used(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """Adopting a running slot starts its idle clock."""
+    sm = SlotManager()
+    container_stub.active.add("chat")
+    assert "chat" not in sm._last_used
+
+    snap = await sm.status("chat")  # no state.json + active unit → adoption
+    assert snap.state == SlotState.READY
+    assert snap.metadata.get("adopted") is True
+    assert "chat" in sm._last_used
+
+
+async def test_adoption_records_effective_backend_not_hardcoded_vulkan(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The adopted extras carry the device/backend-derived token."""
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                "port = 8081",
+                'device = "gpu-rocm"',
+                'provider = "llama-server"',
+                "enabled = true",
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sm = SlotManager()
+    container_stub.active.add("chat")
+    snap = await sm.status("chat")
+    assert snap.metadata.get("adopted") is True
+    assert snap.backend == "rocm"
+
+
+async def test_sweep_candidates_falls_back_to_state_updated_at(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A READY slot absent from _last_used surfaces via state.json updated_at."""
+    sm = SlotManager()
+    container_stub.active.add("chat")
+    await sm._transition("chat", SlotState.READY, force=True)
+    sm._last_used.pop("chat", None)
+
+    candidates = sm._sweep_candidates()
+    assert "chat" in candidates
+    assert candidates["chat"] == sm._states["chat"].updated_at
+
+
+async def test_idle_sweep_evicts_slot_missing_from_last_used(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """The TTL sweep unloads a dispatchable slot it previously couldn't see."""
+    sm = SlotManager(evict_after_s=0.05)
+    container_stub.active.add("chat")
+    await sm._transition("chat", SlotState.READY, force=True)
+    sm._last_used.pop("chat", None)
+
+    await asyncio.sleep(0.1)  # exceed the tiny TTL
+    await sm._sweep_idle_once()
+
+    assert sm._current_state("chat") == SlotState.OFFLINE
+    assert container_stub.unload_calls, "eviction must dispatch a real unload"
+
+
+async def test_pressure_sweep_sees_slot_missing_from_last_used(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch,
+) -> None:
+    """Pressure eviction reclaims an lru slot known only via state.json."""
+    (slot_root / "chat.toml").write_text(
+        "\n".join(
+            [
+                'name = "chat"',
+                "port = 8081",
+                'provider = "llama-server"',
+                "enabled = true",
+                "lru = true",
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    sm = SlotManager(evict_pressure_mb=1024)
+    container_stub.active.add("chat")
+    await sm._transition("chat", SlotState.READY, force=True)
+    sm._last_used.pop("chat", None)
+    # Host reads as under pressure on every probe.
+    monkeypatch.setattr(sm, "_probe_host_free_mb", lambda: 128.0)
+
+    await sm._pressure_evict_once()
+
+    assert sm._current_state("chat") == SlotState.OFFLINE

--- a/tests/slots/test_config_drift_aliases.py
+++ b/tests/slots/test_config_drift_aliases.py
@@ -1,0 +1,91 @@
+"""Config-drift comparison is flag-alias aware.
+
+``_argv_values`` used to compare raw argv tokens, so a running container
+started with ``--batch-size 2048`` read as drifted against a rendered
+``-b 2048`` (and vice versa) even though llama-server treats the two
+spellings identically. Both sides are now canonicalized through
+``hal0.slots.argv.FLAG_ALIASES`` before comparison.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.slots.manager import _CONFIG_DRIFT_KEYS, SlotManager, _argv_values
+from tests.slots.conftest import FakeContainerProvider
+
+
+def test_argv_values_matches_long_spelling_for_short_key() -> None:
+    """``-b``/``-ub`` keys pick up ``--batch-size``/``--ubatch-size`` tokens."""
+    argv = ["--batch-size", "2048", "--ubatch-size", "512", "--ctx-size", "8192"]
+    out = _argv_values(argv, _CONFIG_DRIFT_KEYS)
+    assert out["-b"] == "2048"
+    assert out["-ub"] == "512"
+    assert out["--ctx-size"] == "8192"
+
+
+def test_argv_values_matches_short_spelling_for_long_key() -> None:
+    """A ``--ctx-size`` key matches the ``-c`` short alias (and inline =)."""
+    assert _argv_values(["-c", "4096"], ("--ctx-size",)) == {"--ctx-size": "4096"}
+    assert _argv_values(["--ctx-size=4096"], ("--ctx-size",)) == {"--ctx-size": "4096"}
+    assert _argv_values(["--batch-size=64"], ("-b",)) == {"-b": "64"}
+
+
+def test_argv_values_last_value_wins_across_spellings() -> None:
+    """extra_args overriding the profile with the other spelling still wins."""
+    argv = ["-b", "512", "--batch-size", "2048"]
+    assert _argv_values(argv, ("-b",)) == {"-b": "2048"}
+
+
+async def test_no_false_drift_between_alias_spellings(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """Running ``--batch-size`` vs rendered ``-b`` must NOT report drift."""
+    container_stub.expected_argv_by_slot["chat"] = [
+        "--model",
+        "/mnt/ai-models/qwen.gguf",
+        "--alias",
+        "qwen3-4b-q4_k_m",
+        "--ctx-size",
+        "131072",
+        "-b",
+        "2048",
+        "-ub",
+        "512",
+    ]
+    container_stub.running_argv_by_slot["chat"] = [
+        "--model",
+        "/mnt/ai-models/qwen.gguf",
+        "--alias",
+        "qwen3-4b-q4_k_m",
+        "-c",
+        "131072",
+        "--batch-size",
+        "2048",
+        "--ubatch-size",
+        "512",
+    ]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    assert snap.metadata.get("config_drift") == {"drifted": False, "diffs": []}
+
+
+async def test_real_drift_still_detected_across_spellings(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A real value difference is still flagged even with mixed spellings."""
+    container_stub.expected_argv_by_slot["chat"] = ["-b", "2048"]
+    container_stub.running_argv_by_slot["chat"] = ["--batch-size", "512"]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    drift = snap.metadata.get("config_drift")
+    assert drift is not None and drift["drifted"] is True
+    assert {"key": "-b", "running": "512", "rendered": "2048"} in drift["diffs"]

--- a/tests/slots/test_fail_watcher_warming.py
+++ b/tests/slots/test_fail_watcher_warming.py
@@ -1,0 +1,104 @@
+"""WARMING is fail-watched — but only on unit liveness, never /health.
+
+A health-wait timeout parks the slot in WARMING (``_await_ready``), which
+was previously outside ``_FAIL_WATCH_LIVE_STATES`` — no watcher ran, so a
+unit that later died left the slot lying in WARMING forever. WARMING is now
+watched with softer semantics: /health failures never strike (a big model
+legitimately loads for minutes), only ``_WARMING_INACTIVE_STRIKES``
+consecutive is-active failures flip the slot to ERROR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.slots import manager as mgr_mod
+from hal0.slots.manager import _FAIL_WATCH_LIVE_STATES, SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+@pytest.fixture
+def fast_fail_watch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mgr_mod, "_FAIL_WATCH_INTERVAL_S", 0.1)
+
+
+def test_warming_is_in_the_watched_set() -> None:
+    assert SlotState.WARMING in _FAIL_WATCH_LIVE_STATES
+
+
+async def _load_into_warming(sm: SlotManager, container_stub: FakeContainerProvider) -> None:
+    """Drive load() through a health-wait timeout so the slot parks WARMING."""
+
+    async def _wait_ready_timeout(port: int, timeout_s: float | None = None) -> None:
+        raise TimeoutError("health wait timed out")
+
+    container_stub.wait_ready = _wait_ready_timeout  # type: ignore[method-assign]
+    await sm.load("chat")
+    assert sm._current_state("chat") == SlotState.WARMING
+
+
+async def test_warming_slot_gets_a_watcher_and_survives_failing_health(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """Active unit + failing /health must NOT strike a WARMING slot."""
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+    assert "chat" in sm._fail_watchers, "WARMING must spawn a fail-watcher"
+
+    # Model server still loading: /health says not-ok while the unit is up.
+    container_stub.healthy = False
+    await asyncio.sleep(0.6)  # several poll intervals — plenty of strikes
+
+    assert sm._current_state("chat") == SlotState.WARMING, (
+        "a slow-loading model must never be demoted on /health while WARMING"
+    )
+
+
+async def test_warming_slot_flips_error_when_unit_dies(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """A stably-dead unit under a WARMING slot is caught (was the blind spot)."""
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+
+    container_stub.active.discard("chat")
+
+    deadline = asyncio.get_event_loop().time() + 5.0
+    observed: Any = None
+    while asyncio.get_event_loop().time() < deadline:
+        observed = sm._current_state("chat")
+        if observed == SlotState.ERROR:
+            break
+        await asyncio.sleep(0.05)
+    assert observed == SlotState.ERROR, (
+        f"dead unit under WARMING never surfaced; final state={observed}"
+    )
+    rec = sm._states["chat"]
+    assert "warming" in (rec.message or "").lower()
+
+
+async def test_warming_slot_tolerates_a_transient_inactive_blip(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """One or two inactive reads (unit still activating) must not strike out."""
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+
+    # Blip: inactive for ~one poll, then back.
+    container_stub.active.discard("chat")
+    await asyncio.sleep(0.15)
+    container_stub.active.add("chat")
+    await asyncio.sleep(0.5)
+
+    assert sm._current_state("chat") == SlotState.WARMING

--- a/tests/slots/test_flag_merge.py
+++ b/tests/slots/test_flag_merge.py
@@ -102,7 +102,7 @@ def test_unbalanced_quote_falls_back_to_dumb_concat(
 ) -> None:
     bad_model = '--threads 4 --prompt "oops'
     slot = "--threads 8"
-    caplog.set_level(logging.WARNING, logger="hal0.slots.flag_merge")
+    caplog.set_level(logging.WARNING, logger="hal0.slots.argv")
     out = merge_flags(bad_model, slot)
     # Dumb concat preserves both sides verbatim (trimmed).
     assert bad_model.strip() in out
@@ -120,7 +120,7 @@ def test_unbalanced_quote_on_one_side_only(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Malformed input on only the model side still warns + returns concat."""
-    caplog.set_level(logging.WARNING, logger="hal0.slots.flag_merge")
+    caplog.set_level(logging.WARNING, logger="hal0.slots.argv")
     out = merge_flags('--prompt "oops', None)
     # Falls back to the trimmed model defaults via the dumb-concat path.
     assert "--prompt" in out
@@ -158,3 +158,36 @@ def test_slot_can_remove_value_by_overriding_with_bare_flag() -> None:
     """Slot's bare --threads (no value) wins; model's value pair disappears."""
     out = merge_flags("--threads 4", "--threads")
     assert out.split() == ["--threads"]
+
+
+# ─── Short-flag handling (folded into hal0.slots.argv) ────────────────────────
+# The retired flag_merge tokenizer only understood ``--long`` flags — a
+# ``-b 8192`` slot override was mis-parsed as a stray positional and could not
+# dedup against the model's ``-b``. The argv-backed merge fixes this.
+
+
+def test_short_flag_dedups_last_wins() -> None:
+    """A short flag on both sides collapses to one, slot value last-wins."""
+    assert merge_flags("-b 512", "-b 8192") == "-b 8192"
+
+
+def test_short_flag_dedups_against_long_alias() -> None:
+    """``-b`` and ``--batch-size`` share a canonical key, so the slot's -b
+    overrides the model's --batch-size (impossible with the old --only lexer)."""
+    assert merge_flags("--batch-size 512", "-b 8192") == "-b 8192"
+
+
+def test_short_flag_negative_value_is_not_a_flag() -> None:
+    """``-ngl -1`` keeps -1 as the value (not mis-read as a flag)."""
+    assert merge_flags("", "-ngl -1") == "-ngl -1"
+
+
+def test_mixed_short_and_long_flags_merge() -> None:
+    out = merge_flags("-b 512 --threads 8", "-b 8192 -t 16")
+    tokens = out.split()
+    # -b collapsed to one, slot's 8192 wins
+    assert tokens.count("-b") == 1
+    assert tokens[tokens.index("-b") + 1] == "8192"
+    # --threads (model, long) vs -t (slot, short) share a key → -t wins
+    assert "--threads" not in tokens
+    assert tokens[tokens.index("-t") + 1] == "16"

--- a/tests/slots/test_health_probe_cfg.py
+++ b/tests/slots/test_health_probe_cfg.py
@@ -1,0 +1,52 @@
+"""The manager's health probes pass the slot config to the provider.
+
+``ContainerProvider.health(port, slot_cfg=None)`` delegates to the FLM
+Tier-1 real-inference probe when ``slot_cfg`` resolves to an FLM slot; the
+delegation only activates if the manager's two probe call sites actually
+supply the config. These tests pin that contract at the manager boundary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hal0.slots.manager import SlotManager
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def test_probe_health_passes_slot_cfg(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _health(port: int, slot_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        seen["port"] = port
+        seen["cfg"] = slot_cfg
+        return {"ok": True}
+
+    container_stub.health = _health  # type: ignore[method-assign]
+    sm = SlotManager()
+    assert await sm._probe_health("chat") is True
+    assert seen["port"] == 8081
+    assert isinstance(seen["cfg"], dict) and seen["cfg"]["name"] == "chat"
+
+
+async def test_container_readiness_check_passes_slot_cfg(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def _health(port: int, slot_cfg: dict[str, Any] | None = None) -> dict[str, Any]:
+        seen["cfg"] = slot_cfg
+        return {"ok": False}
+
+    container_stub.health = _health  # type: ignore[method-assign]
+    container_stub.active.add("chat")
+    sm = SlotManager()
+    ready, reason = await sm.container_readiness_check("chat")
+    # ok=False maps to the retryable "starting" (a still-loading FLM model).
+    assert (ready, reason) == (False, "starting")
+    assert isinstance(seen["cfg"], dict) and seen["cfg"]["name"] == "chat"

--- a/tests/stacks/test_apply_plan.py
+++ b/tests/stacks/test_apply_plan.py
@@ -119,3 +119,119 @@ class TestReconciliation:
         plan = StackApplyEngine().plan("s", stack)
         after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
         assert after["vision"] is False
+
+
+class TestGuardedReconcile:
+    """The stack write path shares SlotManager's guard pipeline.
+
+    Pre-fix ``_reconciled_stack_slot`` hand-rolled its merge, skipping the
+    ctx_size fold, device↔profile coherence, and the NPU/default guards —
+    a stack could persist a vulkan-device+rocm-profile pair that
+    ``update_config`` would refuse.
+    """
+
+    def _write_slot(self, home: str, name: str, lines: list[str]) -> Path:
+        path = _slots_dir(home) / f"{name}.toml"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def test_conflicting_device_profile_is_flagged_not_applied(self, tmp_hal0_home: str) -> None:
+        slot_path = _write_agent_slot(tmp_hal0_home)
+        stack = StackConfig(
+            name="Bad",
+            slots=[
+                StackSlotEntry(
+                    slot="agent",
+                    model="m",
+                    device="gpu-vulkan",
+                    profile="rocm-dnse",  # rocm profile under a vulkan device
+                )
+            ],
+        )
+        plan = StackApplyEngine().plan("bad", stack)
+        # Per-slot error recorded; whole plan not aborted.
+        assert plan.errors and plan.errors[0][0] == "agent"
+        assert "conflict" in plan.errors[0][1]
+        assert any("rejected" in line for line in plan.summary)
+        # The offending slot's after == before (nothing to commit).
+        after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
+        assert after == _read(slot_path)
+        assert plan.change_set.changed is False
+
+    def test_device_flip_repoints_stale_profile(self, tmp_hal0_home: str) -> None:
+        """A stack that moves device across backends heals the profile too."""
+        slot_path = self._write_slot(
+            tmp_hal0_home,
+            "agent",
+            [
+                'name = "agent"',
+                "port = 8087",
+                'device = "gpu-vulkan"',
+                'profile = "vulkan"',
+                "[model]",
+                'default = "old"',
+            ],
+        )
+        stack = StackConfig(
+            name="S",
+            slots=[StackSlotEntry(slot="agent", model="m", device="gpu-rocm")],
+        )
+        plan = StackApplyEngine().plan("s", stack)
+        assert plan.errors == []
+        after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
+        assert after["device"] == "gpu-rocm"
+        assert after["backend"] == "rocm"
+        # Pre-fix: profile stayed "vulkan" → rocm device under a vulkan image.
+        assert after["profile"] == "rocm"
+
+    def test_ctx_size_alias_folded_by_stack_write(self, tmp_hal0_home: str) -> None:
+        slot_path = self._write_slot(
+            tmp_hal0_home,
+            "agent",
+            [
+                'name = "agent"',
+                "port = 8087",
+                "[model]",
+                'default = "old"',
+                "ctx_size = 4096",
+            ],
+        )
+        stack = StackConfig(name="S", slots=[StackSlotEntry(slot="agent", model="m")])
+        plan = StackApplyEngine().plan("s", stack)
+        after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
+        assert after["model"]["context_size"] == 4096
+        assert "ctx_size" not in after["model"]
+
+    def test_second_npu_anchor_is_flagged(self, tmp_hal0_home: str) -> None:
+        self._write_slot(
+            tmp_hal0_home,
+            "npu",
+            [
+                'name = "npu"',
+                "port = 8090",
+                'device = "npu"',
+                'type = "llm"',
+                "enabled = true",
+                "[model]",
+                'default = "qwen3.5:4b"',
+            ],
+        )
+        slot_path = self._write_slot(
+            tmp_hal0_home,
+            "npu2",
+            [
+                'name = "npu2"',
+                "port = 8091",
+                'device = "npu"',
+                'type = "llm"',
+                "enabled = true",
+                "[model]",
+                'default = "old"',
+            ],
+        )
+        stack = StackConfig(name="S", slots=[StackSlotEntry(slot="npu2", model="gemma4-it:e2b")])
+        plan = StackApplyEngine().plan("s", stack)
+        assert plan.errors and plan.errors[0][0] == "npu2"
+        assert "NPU" in plan.errors[0][1]
+        after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
+        assert after == _read(slot_path)

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -277,6 +277,13 @@ export const ENDPOINTS = {
   // Fail-soft: 404 treated as "no layout saved" by useDashLayout hook.
   dashboardLayout: '/api/user/dashboard-layout',
 
+  // ── Meta enums (static per-release taxonomy) ─────────────────────
+  // GET /api/meta/enums → devices / backends / device_classes / slot_types /
+  // model_capabilities (+ aliases) / model_backends / runtime_families +
+  // backend_to_device / device_default_profiles maps. Consumed by useMeta;
+  // useMetaEnums() falls back to META_ENUMS_FALLBACK when absent.
+  metaEnums: '/api/meta/enums',
+
   // ── Chat templates (per-model default template catalogue) ────────
   // GET /api/chat-templates → [{id, label}] list of known template ids
   // that can be pinned as model.defaults.chat_template. The "auto"

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -62,19 +62,13 @@ export const ENDPOINTS = {
   hfSearch: '/api/hf/search',
 
   // ── Backends ─────────────────────────────────────────────────────
+  // There is NO generic install route — the only install-like operations
+  // the server exposes are the NPU load/unload pair below
+  // (src/hal0/api/routes/backends.py).
   backends: '/api/backends',
   backend: (id: string) => `/api/backends/${encodeURIComponent(id)}`,
-  // NOTE: backendInstall has no generic backend route. The only install-
-  // like operation available is NPU: POST /api/backends/npu/load (and
-  // /api/backends/npu/unload). The UI flow-modals.jsx BackendInstallModal
-  // should route the NPU case to backendNpuLoad; remove this constant once
-  // ui-sweep-a's BackendInstallModal migration is complete.
-  backendInstall: (id: string) => `/api/backends/${encodeURIComponent(id)}/install`,
   backendNpuLoad: '/api/backends/npu/load',
   backendNpuUnload: '/api/backends/npu/unload',
-  // Alias spelling used in ui-sweep-a hook files (PR #741 TODOs).
-  backendsNpuLoad: '/api/backends/npu/load',
-  backendsNpuUnload: '/api/backends/npu/unload',
 
   // ── Capabilities ─────────────────────────────────────────────────
   capabilities: '/api/capabilities',

--- a/ui/src/api/hooks/useBackends.ts
+++ b/ui/src/api/hooks/useBackends.ts
@@ -49,13 +49,9 @@ export function useBackendSnapshot(id: string | null | undefined) {
   })
 }
 
-export function useBackendInstall() {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (id: string) => apiPost(ENDPOINTS.backendInstall(id)),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['backends'] }),
-  })
-}
+// NOTE: there is no useBackendInstall — the backend exposes no generic
+// install route (see src/hal0/api/routes/backends.py). The NPU load/unload
+// hooks below are the only install-adjacent operations.
 
 export function useBackendUninstall() {
   const qc = useQueryClient()
@@ -67,12 +63,11 @@ export function useBackendUninstall() {
 
 // ── NPU load / unload (POST /api/backends/npu/{load,unload}) ──────────────
 // The only install-adjacent backend operations the server exposes today.
-// TODO endpoints.ts (ui-sweep-b owns) — inline paths for now.
 
 export function useNpuLoad() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => apiPost<unknown>('/api/backends/npu/load'),
+    mutationFn: () => apiPost<unknown>(ENDPOINTS.backendNpuLoad),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['backends'] }),
   })
 }
@@ -80,7 +75,7 @@ export function useNpuLoad() {
 export function useNpuUnload() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: () => apiPost<unknown>('/api/backends/npu/unload'),
+    mutationFn: () => apiPost<unknown>(ENDPOINTS.backendNpuUnload),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['backends'] }),
   })
 }

--- a/ui/src/api/hooks/useMeta.ts
+++ b/ui/src/api/hooks/useMeta.ts
@@ -1,0 +1,45 @@
+// hal0 v3 dashboard — meta-enums hook.
+//
+// GET /api/meta/enums — the backend's authoritative taxonomy: devices (with
+// device_class / default_profile / legacy_backend / recommended flags),
+// selectable backends, slot types, model capabilities (+ aliases), model
+// backends, runtime families and the backend→device / device→default-profile
+// maps. Static per release, so the query caches forever (staleTime Infinity).
+//
+// Consumers should reach for `useMetaEnums()` — it always returns a fully
+// populated MetaEnums: the live payload when the endpoint exists, merged
+// per-key over META_ENUMS_FALLBACK (src/lib/deviceMeta.ts) so an older
+// backend, a partial payload, or mock mode never leaves a picker empty.
+
+import { useMemo } from 'react'
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { apiGet } from '../client'
+import { ENDPOINTS } from '../endpoints'
+import {
+  META_ENUMS_FALLBACK,
+  resolveMetaEnums,
+  type MetaDevice,
+  type MetaEnums,
+} from '../../lib/deviceMeta'
+
+export { META_ENUMS_FALLBACK, resolveMetaEnums }
+export type { MetaDevice, MetaEnums }
+
+export function useMeta(): UseQueryResult<Partial<MetaEnums>> {
+  return useQuery({
+    queryKey: ['meta', 'enums'],
+    queryFn: () => apiGet<Partial<MetaEnums>>(ENDPOINTS.metaEnums),
+    // Enums are static per release — never refetch, never gc.
+    staleTime: Infinity,
+    gcTime: Infinity,
+    // A missing endpoint (older backend) should settle to the fallback fast,
+    // not retry-storm.
+    retry: false,
+  })
+}
+
+/** Resolved enums — never undefined; the static fallback fills any gap. */
+export function useMetaEnums(): MetaEnums {
+  const q = useMeta()
+  return useMemo(() => resolveMetaEnums(q.data), [q.data])
+}

--- a/ui/src/api/hooks/useProfiles.ts
+++ b/ui/src/api/hooks/useProfiles.ts
@@ -74,7 +74,10 @@ export function useProfiles() {
   return useQuery({
     queryKey: ['profiles'],
     queryFn: () => apiGet<Profile[]>(ENDPOINTS.profiles),
-    staleTime: 60_000,
+    staleTime: 25_000,
+    // Profiles can be edited externally (CLI, another browser, hal0 setup);
+    // a 30s background refetch converges the page without a manual reload.
+    refetchInterval: 30_000,
   })
 }
 

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -33,15 +33,12 @@ export interface SlotMetrics {
   ctx?: number
   kv?: number | null
   mem?: number
-  rpm?: number
   lat?: number | null
   dim?: number
-  xrt?: number
   precision?: string
   maxDocs?: number
   secs?: number
   voice?: string
-  avg?: number
   res?: string
 }
 
@@ -175,15 +172,12 @@ const DEFAULT_METRICS: SlotMetrics = {
   ctx: 0,
   kv: null,
   mem: 0,
-  rpm: 0,
   lat: null,
   dim: 0,
-  xrt: 0,
   precision: '',
   maxDocs: 0,
   secs: 0,
   voice: '',
-  avg: 0,
   res: '',
 }
 
@@ -479,14 +473,33 @@ export function useSlotDefaults() {
 }
 
 /**
+ * Response of POST /api/slots/{name}/backend. The backend is being
+ * extended to carry the post-switch snapshot (declared/effective backend,
+ * device, profile) — every field is OPTIONAL so the UI tolerates both the
+ * old bare response and the enriched one. `effective_backend` and
+ * `actual_backend` are alternative spellings during the transition.
+ */
+export interface SlotBackendSwitchResponse {
+  name?: string
+  declared_backend?: string | null
+  effective_backend?: string | null
+  actual_backend?: string | null
+  device?: string | null
+  profile?: string | null
+  [k: string]: unknown
+}
+
+/**
  * POST /api/slots/{name}/backend — switch the slot's backend
- * (e.g. vulkan → rocm). Body shape: `{ backend: string }`.
+ * (e.g. vulkan → rocm). Body shape: `{ backend: string }`. Triggers a
+ * container restart server-side; the caller should confirm with the
+ * operator first (see the backend-mismatch chip in slots.jsx).
  */
 export function useSlotBackend() {
   const invalidate = useSlotsInvalidator()
   return useMutation({
     mutationFn: ({ name, backend }: { name: string; backend: string }) =>
-      slotPost(ENDPOINTS.slotBackend(name), { backend }),
+      slotPost<SlotBackendSwitchResponse>(ENDPOINTS.slotBackend(name), { backend }),
     onSuccess: invalidate,
   })
 }
@@ -516,8 +529,23 @@ export function useSlotConfig(name: string | null | undefined) {
 
 // ─── useSlotResolved ──────────────────────────────────────────────────────────
 
-/** Source segment that supplied the surviving value for a flag. */
-export type ProvenanceSource = 'base' | 'profile' | 'extra_args'
+/**
+ * Source segment that supplied the surviving value for a flag.
+ * Known values: base | profile | extra_args, plus the newer assembler
+ * segments (model_defaults | chat_template | mmproj | slot_overrides).
+ * Kept open (`string`) — the badge renderer in slot-modals.jsx falls back
+ * to a generic style for labels it doesn't recognise, so a new backend
+ * segment never breaks the drawer.
+ */
+export type ProvenanceSource =
+  | 'base'
+  | 'profile'
+  | 'extra_args'
+  | 'model_defaults'
+  | 'chat_template'
+  | 'mmproj'
+  | 'slot_overrides'
+  | (string & {})
 
 /** Per-flag provenance entry returned by GET /api/slots/{name}/resolved. */
 export interface FlagProvenance {

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -16,6 +16,8 @@
 // Ambient typing lives in `src/types/globals.d.ts` — no local
 // `declare global` here (it would conflict on `HAL0_DATA` modifiers).
 
+import { META_ENUMS_FALLBACK } from '../lib/deviceMeta'
+
 const FORCED = !!(import.meta.env && (import.meta.env as any).VITE_MOCK_HAL0 === '1')
 
 export function isMockForced() {
@@ -118,6 +120,185 @@ function buildNpuOccupancy() {
       gb: typeof s.gb === 'number' ? s.gb : 2.4,
     })),
   }
+}
+
+// ── Meta enums — static per-release taxonomy ──────────────────────
+// Mirrors GET /api/meta/enums exactly; the payload IS the typed fallback
+// (src/lib/deviceMeta.ts) so mock mode and fallback mode can't drift.
+function buildMetaEnums() {
+  return META_ENUMS_FALLBACK
+}
+
+// ── Profiles — mirrors GET /api/profiles (list of ProfileConfig rows) ──
+// Seed shapes match profiles.jsx expectations (name/image/flags/mtp/
+// resolved_flags/device_class/backend/seed/intent/quant/tps|rtf/used_by),
+// grounded in config/schema.py SEED_PROFILES + PROFILE_BENCH, plus one
+// custom profile so the "Custom profiles" section renders in mock mode.
+function buildProfiles() {
+  return [
+    {
+      name: 'rocm',
+      image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server',
+      flags: '-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap',
+      mtp: false,
+      resolved_flags: '-fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap',
+      device_class: 'gpu',
+      backend: 'rocm',
+      seed: true,
+      cloned_from: null,
+      intent: 'MoE agents',
+      quant: 'FP4',
+      tps: 52.8,
+      rtf: null,
+      used_by: ['primary', 'embed', 'rerank'],
+    },
+    {
+      name: 'vulkan',
+      image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server',
+      flags: '-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap',
+      mtp: false,
+      resolved_flags: '-fa on -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap',
+      device_class: 'gpu',
+      backend: 'vulkan',
+      seed: true,
+      cloned_from: null,
+      intent: 'Vulkan std · fallback',
+      quant: 'Q4_K_M',
+      tps: 41.0,
+      rtf: null,
+      used_by: ['legacy'],
+    },
+    {
+      name: 'flm',
+      image: 'ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43',
+      flags: '',
+      mtp: false,
+      resolved_flags: '',
+      device_class: 'npu',
+      backend: null,
+      seed: true,
+      cloned_from: null,
+      intent: 'FLM NPU inference',
+      quant: 'W4ABF16',
+      tps: 38.6,
+      rtf: null,
+      used_by: ['agent', 'stt-npu', 'embed-npu'],
+    },
+    {
+      name: 'tts',
+      image: 'ghcr.io/hal0ai/hal0-toolbox-kokoro:v1',
+      flags: '--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx',
+      mtp: false,
+      resolved_flags: '--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx',
+      device_class: 'cpu',
+      backend: null,
+      seed: true,
+      cloned_from: null,
+      intent: 'TTS · Kokoro',
+      quant: '',
+      tps: null,
+      rtf: 0.18,
+      used_by: ['tts'],
+    },
+    {
+      name: 'cpu-llm',
+      image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server',
+      flags: '--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap',
+      mtp: false,
+      resolved_flags: '--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap',
+      device_class: 'cpu',
+      backend: null,
+      seed: true,
+      cloned_from: null,
+      intent: 'CPU-only LLM · llama-server',
+      quant: 'Q4_K_M',
+      tps: null,
+      rtf: null,
+      used_by: [],
+    },
+    {
+      name: 'comfyui',
+      image: 'docker.io/kyuz0/amd-strix-halo-comfyui:latest',
+      flags: '--disable-mmap --bf16-vae --cache-none',
+      mtp: false,
+      resolved_flags: '--disable-mmap --bf16-vae --cache-none',
+      device_class: 'img',
+      backend: null,
+      seed: true,
+      cloned_from: null,
+      intent: 'Image generation',
+      quant: '',
+      tps: null,
+      rtf: null,
+      used_by: ['img'],
+    },
+    {
+      name: 'rocm-fast',
+      image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server',
+      flags: '-fa on -b 8192 -ub 2048 --threads 16 --no-mmap',
+      mtp: true,
+      resolved_flags: '-fa on -b 8192 -ub 2048 --threads 16 --no-mmap',
+      device_class: 'gpu',
+      backend: 'rocm',
+      seed: false,
+      cloned_from: 'rocm',
+      intent: 'Dense + MTP · benched on this box',
+      quant: 'FP4',
+      tps: null,
+      rtf: null,
+      used_by: [],
+    },
+  ]
+}
+
+// ── Stacks — mirrors GET /api/stacks ({stacks, active, drift}) ─────
+// Slot entries reference HAL0_DATA model ids where possible so the
+// available/missing affordances exercise both paths in mock mode.
+function buildStacksList() {
+  return {
+    active: null,
+    drift: 'none',
+    stacks: [
+      {
+        slug: 'coding',
+        name: 'Coding',
+        description: 'Fast coder + repo retrieval',
+        author: 'hal0',
+        icon: '',
+        tags: ['coding', 'fast'],
+        seed: true,
+        slots: [
+          { slot: 'primary', model: 'qwen3-coder-30b', device: 'gpu-rocm', profile: 'rocm', mtp: false, capabilities: [] },
+          { slot: 'embed', model: 'nomic-v1.5', device: 'gpu-rocm', profile: 'rocm', mtp: false, capabilities: [] },
+        ],
+      },
+      {
+        slug: 'daily-driver',
+        name: 'Daily driver',
+        description: 'General chat + voice + image',
+        author: 'hal0',
+        icon: '',
+        tags: ['general'],
+        seed: false,
+        slots: [
+          { slot: 'primary', model: 'qwen3.6-27b-mtp', device: 'gpu-rocm', profile: 'rocm', mtp: true, capabilities: [] },
+          { slot: 'tts', model: 'kokoro-v1', device: 'cpu', profile: 'tts', mtp: false, capabilities: [] },
+          { slot: 'img', model: 'sd-turbo', device: 'img', profile: 'comfyui', mtp: false, capabilities: [] },
+          { slot: 'scribe', model: 'whisper-large-v3-missing', device: 'npu', profile: 'flm', mtp: false, capabilities: [] },
+        ],
+      },
+    ],
+  }
+}
+
+// ── Chat templates — mirrors GET /api/chat-templates ([{id,label,valid}]) ──
+function buildChatTemplates() {
+  return [
+    { id: 'chatml', label: 'ChatML', valid: true, error: null },
+    { id: 'llama3', label: 'Llama 3', valid: true, error: null },
+    { id: 'mistral', label: 'Mistral / [INST]', valid: true, error: null },
+    { id: 'gemma', label: 'Gemma', valid: true, error: null },
+  ]
 }
 
 function buildJournal() {
@@ -839,7 +1020,16 @@ function buildMemoryGraphStatus() {
 // ─── Allowlist (first match wins) ─────────────────────────────────
 type Builder = (url: string, match: RegExpMatchArray) => unknown
 
-export const MOCK_ALLOWLIST: ReadonlyArray<{ re: RegExp; build: Builder }> = Object.freeze([
+// `networkFirst` rows try the real network even in FORCED mock mode and only
+// substitute the baked payload when the GET fails (network error / 404 / a
+// dev-proxy 5xx). This keeps Playwright `page.route` overrides authoritative
+// for these endpoints (the e2e suite runs with VITE_MOCK_HAL0=1 and drives
+// /api/profiles, /api/stacks, /api/chat-templates via route fulfils), while
+// unrouted dev/preview builds still get a plausible payload. networkFirst
+// substitution is GET-only — mutations (POST/PUT/DELETE) always pass through.
+type AllowRow = { re: RegExp; build: Builder; networkFirst?: boolean }
+
+export const MOCK_ALLOWLIST: ReadonlyArray<AllowRow> = Object.freeze([
   { re: /^\/api\/status$/, build: buildStatus },
   { re: /^\/api\/slots$/, build: buildSlots },
   { re: /^\/api\/slots\/[^/]+$/, build: () => null }, // 404-style — Slot detail not in mock
@@ -853,6 +1043,10 @@ export const MOCK_ALLOWLIST: ReadonlyArray<{ re: RegExp; build: Builder }> = Obj
   { re: /^\/api\/auth\/token$/, build: buildAuthToken },
   { re: /^\/api\/auth\/allowed-origins$/, build: buildAllowedOrigins },
   { re: /^\/api\/secrets$/, build: buildSecrets },
+  { re: /^\/api\/meta\/enums$/, build: buildMetaEnums, networkFirst: true },
+  { re: /^\/api\/profiles$/, build: buildProfiles, networkFirst: true },
+  { re: /^\/api\/stacks$/, build: buildStacksList, networkFirst: true },
+  { re: /^\/api\/chat-templates$/, build: buildChatTemplates, networkFirst: true },
   // ── Memory (Hindsight) — engine + bank-scoped surface ────────────
   // Forced-mock + 404-fallback story for the Memory graph overhaul. The
   // bank id is captured as group 1. ORDER MATTERS: the more-specific
@@ -949,11 +1143,19 @@ export async function mockFetch(
   const path = parsePath(url)
   if (!path) return fetch(url as any, options)
 
+  const method = String(
+    options?.method ??
+      (typeof Request !== 'undefined' && url instanceof Request ? url.method : 'GET'),
+  ).toUpperCase()
+
   const hit = matchAllowlist(path)
   // builders receive the query-bearing path (subgraph/recall read params)
   const builderUrl = pathWithSearch(url) ?? path
+  // networkFirst substitution only ever applies to reads — a POST/PUT/DELETE
+  // to e.g. /api/profiles must reach the network (or a page.route) untouched.
+  const substitutable = !!hit && (!hit.row.networkFirst || method === 'GET')
 
-  if (FORCED && hit) {
+  if (FORCED && hit && substitutable && !hit.row.networkFirst) {
     return jsonResponse(hit.row.build(builderUrl, hit.match))
   }
 
@@ -961,14 +1163,23 @@ export async function mockFetch(
   try {
     res = await fetch(url as any, options)
   } catch (e) {
-    if (hit) {
+    if (hit && substitutable) {
       // network-level failure on a mocked path — fall back
       return jsonResponse(hit.row.build(builderUrl, hit.match))
     }
     throw e
   }
-  if (res.status === 404 && hit) {
-    return jsonResponse(hit.row.build(builderUrl, hit.match))
+  if (hit && substitutable) {
+    if (res.status === 404) {
+      return jsonResponse(hit.row.build(builderUrl, hit.match))
+    }
+    // Forced mock + networkFirst: an unrouted GET lands on the vite proxy
+    // (ECONNREFUSED → 5xx). Serve the baked payload for any failed read so
+    // dev/preview never renders an error shell, while a page.route-fulfilled
+    // 2xx stays authoritative.
+    if (FORCED && hit.row.networkFirst && !res.ok) {
+      return jsonResponse(hit.row.build(builderUrl, hit.match))
+    }
   }
   return res
 }

--- a/ui/src/dash/data.jsx
+++ b/ui/src/dash/data.jsx
@@ -141,7 +141,7 @@ const HAL0_DATA = {
       isDefault: true,
       port: 8095,
       pid: 28498,
-      metrics: { rpm: 124, lat: 18, dim: 768, mem: 0.35 },
+      metrics: { lat: 18, dim: 768, mem: 0.35 },
       spark: [4, 5, 5, 6, 5, 7, 8, 6, 7, 8, 9, 7, 8, 9, 8, 7],
     },
     {
@@ -162,7 +162,7 @@ const HAL0_DATA = {
       isDefault: true,
       port: 8096,
       pid: 28502,
-      metrics: { rpm: 22, lat: 32, maxDocs: 200, mem: 0.4 },
+      metrics: { lat: 32, maxDocs: 200, mem: 0.4 },
       spark: [1, 0, 2, 1, 1, 0, 1, 2, 1, 0, 1, 1, 2, 1, 0, 1],
     },
     {
@@ -183,7 +183,7 @@ const HAL0_DATA = {
       coresident: true,
       port: 8093,
       pid: 28482,
-      metrics: { rpm: 8, xrt: 0.18, precision: "Q4_K_M", mem: 0.4 },
+      metrics: { precision: "Q4_K_M", mem: 0.4 },
     },
     {
       name: "embed-npu",
@@ -202,7 +202,7 @@ const HAL0_DATA = {
       coresident: true,
       port: 8093,
       pid: 28482,
-      metrics: { rpm: 0, lat: null, dim: 768, mem: 0.35 },
+      metrics: { lat: null, dim: 768, mem: 0.35 },
     },
     {
       name: "tts",
@@ -224,7 +224,7 @@ const HAL0_DATA = {
       cpuOnly: true,
       port: 8097,
       pid: 28510,
-      metrics: { rpm: 4, secs: 47, voice: "af_heart", mem: 0.4 },
+      metrics: { secs: 47, voice: "af_heart", mem: 0.4 },
     },
     {
       name: "img",
@@ -244,7 +244,7 @@ const HAL0_DATA = {
       container_health: true,
       port: 8098,
       pid: 28518,
-      metrics: { rpm: 2, avg: 4.1, res: "512×512", mem: 1.2 },
+      metrics: { res: "512×512", mem: 1.2 },
     },
   ],
 

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -36,6 +36,7 @@ import {
   useSlotSwap,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
+import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
@@ -427,7 +428,11 @@ export function ModelPicker({ s, models, disabled, onSwap }) {
         {s.model || '—'}
       </div>
     )
-  const opts = (Array.isArray(models) ? models : []).filter((m) => m.type === 'llm')
+  // Upstream-advertised rows can't be bound to a slot (no local file) —
+  // same exclusion as slot-modals' compatibleModels().
+  const opts = (Array.isArray(models) ? models : []).filter(
+    (m) => m.type === 'llm' && !isUpstreamModel(m),
+  )
   const cur = s.model_id || s.model || ''
   const has = opts.some((m) => m.id === cur)
   return (

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -34,11 +34,16 @@ import {
   useSlotUnload,
   useSlotLoad,
   useSlotSwap,
+  useSlotBackend,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
+// devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
+// the copy this file used to carry (and the verbatim clones in slot-list.jsx
+// and npu-pane.jsx).
+import { devKind } from '@/lib/deviceMeta'
 
 const { useState: useStateI, useRef: useRefI, useEffect: useEffectI } = React
 
@@ -97,16 +102,6 @@ const Ic = ({ name, size = 16 }) =>
 const round1 = (n) => Math.round((n || 0) * 10) / 10
 const toast = (msg, kind = 'info') =>
   typeof window !== 'undefined' && window.__hal0Toast && window.__hal0Toast(msg, kind)
-
-// Normalize a slot.device string to the chip's device-kind token.
-function devKind(device) {
-  const d = String(device || '').toLowerCase()
-  if (d === 'npu') return 'npu'
-  if (d === 'cpu') return 'cpu'
-  if (d.includes('vulkan')) return 'vulkan'
-  if (d.includes('rocm') || d.startsWith('gpu')) return 'rocm'
-  return 'cpu'
-}
 
 // Utility (support) slot types — the non-conversational tier that renders as
 // the compact mini-card row below the headline chat/agent cards. Placement is
@@ -418,6 +413,85 @@ function DevCell({ s, onProfile }) {
   )
 }
 
+// Backend-mismatch remediation (ADR-0022) — mirrors slots.jsx SlotCard: when
+// the slot reports backend_mismatch + actual_backend, render an amber chip
+// surfacing the ACTUAL runtime backend plus a "Switch to <declared>" action.
+// Confirming POSTs /api/slots/{name}/backend (useSlotBackend) — a container
+// restart — via the shared ConfirmDialog (primitives.jsx window global).
+function BackendMismatch({ s }) {
+  const backendMut = useSlotBackend()
+  const [open, setOpen] = useStateI(false)
+  if (!s.backend_mismatch || !s.actual_backend) return null
+  const declared = s.declared_backend || s.backend || s.device
+  const onConfirm = () => {
+    setOpen(false)
+    backendMut.mutate(
+      { name: s.name, backend: declared },
+      {
+        onSuccess: (resp) => {
+          const effective = resp?.effective_backend || resp?.actual_backend || declared
+          toast(`${s.name} backend → ${effective}`, 'ok')
+        },
+        onError: (err) =>
+          toast(`${s.name}: backend switch failed — ${err?.message || 'see logs'}`, 'warn'),
+      },
+    )
+    toast(`Switching ${s.name} to ${declared} — restarting…`, 'info')
+  }
+  return (
+    <>
+      <button
+        type="button"
+        className="tag-chip"
+        style={{
+          color: 'var(--warn)',
+          borderColor: 'var(--warn-line)',
+          background: 'var(--warn-soft)',
+          cursor: 'pointer',
+        }}
+        title={`Declared ${declared} but running ${s.actual_backend} — click to switch back to ${declared} (restarts the container)`}
+        disabled={backendMut.isPending}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(true)
+        }}
+        data-testid={`infer-backend-mismatch-${s.name}`}
+      >
+        {s.actual_backend} ≠ declared
+      </button>
+      <button
+        type="button"
+        className="rbtn"
+        style={{ fontSize: 10, padding: '1px 6px' }}
+        disabled={backendMut.isPending}
+        onClick={(e) => {
+          e.stopPropagation()
+          setOpen(true)
+        }}
+        data-testid={`infer-backend-switch-${s.name}`}
+      >
+        {backendMut.isPending ? 'Switching…' : `Switch to ${declared}`}
+      </button>
+      <ConfirmDialog
+        open={open}
+        onCancel={() => setOpen(false)}
+        onConfirm={onConfirm}
+        title={`Switch ${s.name} to ${declared}?`}
+        message={
+          <span>
+            <span className="mono" style={{ color: 'var(--fg)' }}>{s.name}</span> is running
+            on <span className="mono">{s.actual_backend}</span> but is declared
+            as <span className="mono">{declared}</span>. Switching restarts the
+            container to reload on the declared backend (~model-load seconds); the slot
+            is unavailable while it reloads.
+          </span>
+        }
+        confirmLabel="Switch backend"
+      />
+    </>
+  )
+}
+
 // full cards get a real model picker (a styled <select> wired to useModels);
 // non-LLM slots keep their static model line.
 export function ModelPicker({ s, models, disabled, onSwap }) {
@@ -557,6 +631,7 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) 
         )}
         <div className={'scard-foot' + (full ? '' : ' bare')}>
           <DevCell s={s} onProfile={onEdit} />
+          <BackendMismatch s={s} />
           {full && memGb != null && <span className="tag-chip">{memGb} GB</span>}
           <span className="grow" />
           {controls}

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -15,6 +15,8 @@ import { useSlots } from '@/api/hooks/useSlots'
 import { useSettings } from '@/api/hooks/useSettings'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
 import { useProfiles } from '@/api/hooks/useProfiles'
+import { useMetaEnums } from '@/api/hooks/useMeta'
+import { canonicalCapabilities, modelDeviceClasses, profileDeviceClass } from '@/lib/deviceMeta'
 import { MODEL_TYPE_TAGS, splitModelTags, mergeModelTags } from '@/dash/model-types.js'
 
 const { useState: useStateMM, useEffect: useEffectMM, useMemo: useMemoMM } = React;
@@ -33,6 +35,10 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
 
   const inspect = useModelInspect();
   const pullJob = usePullJob();
+  // One canonical capability vocabulary for every add/edit surface —
+  // meta.model_capabilities (this modal used to carry its own ad-hoc list
+  // with legacy spellings: embeddings/reranking/transcription).
+  const enums = useMetaEnums();
 
   useEffectMM(() => {
     if (open) {
@@ -199,7 +205,7 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
               <span className="sub">drives OmniRouter eligibility</span>
             </div>
             <div className="form-ctl" style={{display: "flex", flexWrap: "wrap", gap: 8}}>
-              {["chat", "tool-calling", "vision", "embeddings", "reranking", "transcription", "tts", "image", "edit"].map(l => (
+              {enums.model_capabilities.map(l => (
                 <label key={l} className="checkbox-row">
                   <input
                     type="checkbox"
@@ -253,11 +259,10 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   );
 }
 
-// Model.capabilities vocabulary (registry/model.py) — drives dispatch/omni
-// eligibility. Historically only settable at register time.
-const MODEL_CAPABILITIES = ["chat", "embed", "rerank", "vision", "asr", "tts"];
-// Model.backends vocabulary — drives slot-compat filtering in the slot form.
-const MODEL_BACKENDS = ["rocm", "vulkan", "cpu", "cuda", "flm", "moonshine", "kokoro"];
+// Model capability + backend vocabularies now come from GET /api/meta/enums
+// (useMetaEnums → meta.model_capabilities / meta.model_backends, with the
+// typed static fallback) — the hardcoded MODEL_CAPABILITIES / MODEL_BACKENDS
+// constants that used to live here are gone.
 
 // Order-insensitive set equality for the array fields (capabilities/backends),
 // so a defaults-only save doesn't spuriously report those as changed.
@@ -274,10 +279,10 @@ function RecipeEditorModal({ open, onClose, model }) {
   // so an ungated fetch would fire on the models list and detach row controls.
   const templates = useChatTemplates(open);
   const profilesQuery = useProfiles();
+  const enums = useMetaEnums();
   const init = model?.defaults || {};
   const [ctx, setCtx] = useStateMM("");
   const [ngl, setNgl] = useStateMM("");
-  const [rope, setRope] = useStateMM("");
   const [extra, setExtra] = useStateMM("");
   const [chatTemplate, setChatTemplate] = useStateMM("auto");
   // Preferred runtime profile that loads with this model (ModelDefaults.profile).
@@ -302,7 +307,6 @@ function RecipeEditorModal({ open, onClose, model }) {
     if (open && model) {
       setCtx(init.context_size != null ? String(init.context_size) : "");
       setNgl(init.n_gpu_layers != null ? String(init.n_gpu_layers) : "");
-      setRope(init.rope_freq_base != null ? String(init.rope_freq_base) : "");
       setExtra(init.extra_args || "");
       setChatTemplate(init.chat_template ?? "auto");
       setProfile(init.profile || "");
@@ -310,7 +314,9 @@ function RecipeEditorModal({ open, onClose, model }) {
       const split = splitModelTags(model.tags);
       setTypes(split.selected);
       setOtherTags(split.other);
-      setCaps(Array.isArray(model.capabilities) ? model.capabilities : []);
+      // Normalize legacy capability spellings (embeddings/reranking/…)
+      // through meta.capability_aliases so the toggles light up correctly.
+      setCaps(canonicalCapabilities(model.capabilities, enums));
       setBackends(Array.isArray(model.backends) ? model.backends : []);
       setMmproj(model.mmproj || "");
       setHfRepo(model.hf_repo || "");
@@ -332,9 +338,10 @@ function RecipeEditorModal({ open, onClose, model }) {
     // Preserve any ModelDefaults field the editor doesn't surface. The
     // registry PUT flat-merges `defaults` WHOLESALE, so we must start from the
     // stored defaults and only override the keys we render inputs for —
-    // otherwise siblings (e.g. a hand-set rope_freq_base) are silently cleared.
-    // Emptying a shown input clears just that one key (delete), keeping the
-    // "empty = launcher default" affordance intact.
+    // otherwise siblings (e.g. a legacy hand-set rope_freq_base, which no
+    // longer has an input here — deprecated backend-side, use extra_args)
+    // are silently cleared. Emptying a shown input clears just that one key
+    // (delete), keeping the "empty = launcher default" affordance intact.
     const defaults = { ...init };
     if (ctx.trim()) {
       const n = parseInt(ctx, 10);
@@ -344,10 +351,6 @@ function RecipeEditorModal({ open, onClose, model }) {
       const n = parseInt(ngl, 10);
       if (Number.isFinite(n)) defaults.n_gpu_layers = n; else delete defaults.n_gpu_layers;
     } else delete defaults.n_gpu_layers;
-    if (rope.trim()) {
-      const n = parseFloat(rope);
-      if (Number.isFinite(n)) defaults.rope_freq_base = n; else delete defaults.rope_freq_base;
-    } else delete defaults.rope_freq_base;
     if (extra.trim()) defaults.extra_args = extra; else delete defaults.extra_args;
     // Only persist a real template choice — 'auto' means GGUF-embedded, which
     // is the absence of an override, so don't pollute defaults with it.
@@ -370,8 +373,9 @@ function RecipeEditorModal({ open, onClose, model }) {
       [...nextTags].sort().join(" ") === [...prevTags].sort().join(" ");
     if (!sameTags) body.tags = nextTags;
     // Capabilities + backends: routing-critical top-level sets. Emit only when
-    // the set actually changed (order-insensitive).
-    const prevCaps = Array.isArray(model.capabilities) ? model.capabilities : [];
+    // the set actually changed (order-insensitive, compared through the
+    // canonical alias map so a legacy "embeddings" row isn't spuriously dirty).
+    const prevCaps = canonicalCapabilities(model.capabilities, enums);
     if (!sameStringSet(caps, prevCaps)) body.capabilities = caps;
     const prevBackends = Array.isArray(model.backends) ? model.backends : [];
     if (!sameStringSet(backends, prevBackends)) body.backends = backends;
@@ -455,10 +459,10 @@ function RecipeEditorModal({ open, onClose, model }) {
       <div className="form-row">
         <div className="form-lbl">
           <span>capabilities</span>
-          <span className="sub">dispatch / omni eligibility · chat · embed · rerank · vision · asr · tts</span>
+          <span className="sub">dispatch / omni eligibility · canonical vocab from /api/meta/enums</span>
         </div>
         <div className="form-ctl" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-          {MODEL_CAPABILITIES.map(cap => {
+          {enums.model_capabilities.map(cap => {
             const on = caps.includes(cap);
             return (
               <button
@@ -482,7 +486,7 @@ function RecipeEditorModal({ open, onClose, model }) {
           <span className="sub">runners this model can bind · drives slot-compat filtering</span>
         </div>
         <div className="form-ctl" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-          {MODEL_BACKENDS.map(b => {
+          {enums.model_backends.map(b => {
             const on = backends.includes(b);
             return (
               <button
@@ -507,15 +511,6 @@ function RecipeEditorModal({ open, onClose, model }) {
         </div>
         <div className="form-ctl">
           <input className="input mono" inputMode="numeric" placeholder="e.g. 8192" value={ctx} onChange={e => setCtx(e.target.value)} />
-        </div>
-      </div>
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>rope_freq_base</span>
-          <span className="sub">float · empty = launcher / GGUF default</span>
-        </div>
-        <div className="form-ctl">
-          <input className="input mono" inputMode="decimal" placeholder="e.g. 10000" value={rope} onChange={e => setRope(e.target.value)} />
         </div>
       </div>
       <div className="form-row">
@@ -567,18 +562,23 @@ function RecipeEditorModal({ open, onClose, model }) {
           >
             <option value="">None (use slot default)</option>
             {(() => {
-              // Filter to profiles that fit this model: same slot type, and same
-              // device class where the model's device is known (rocm/vulkan→gpu).
-              const dc =
-                model.device === "rocm" || model.device === "vulkan" ? "gpu"
-                : model.device === "npu" ? "npu"
-                : model.device === "cpu" ? "cpu"
-                : null;
+              // Filter to profiles that fit this model, keyed on the profile's
+              // device_class/backend vs the model's backends set (the old code
+              // compared the brittle derived `model.device` string). A model
+              // with unknown backends matches every class; a profile with no
+              // class signal is likewise never filtered out.
               const all = Array.isArray(profilesQuery.data) ? profilesQuery.data : [];
-              const fit = all.filter(p =>
-                (!dc || !p.device_class || p.device_class === dc) &&
-                (!model.type || !Array.isArray(p.supported_slot_types) || p.supported_slot_types.includes(model.type))
-              );
+              const mClasses = modelDeviceClasses(model.backends, model.device, enums);
+              const mBackends = Array.isArray(model.backends) ? model.backends : [];
+              const fit = all.filter(p => {
+                const pc = profileDeviceClass(p);
+                const classOk = !pc || mClasses.size === 0 || mClasses.has(pc);
+                // GPU profiles pin a concrete runtime (rocm|vulkan) — require
+                // the model to actually list that backend when it lists any.
+                const backendOk = !p.backend || mBackends.length === 0 || mBackends.includes(p.backend);
+                const typeOk = !model.type || !Array.isArray(p.supported_slot_types) || p.supported_slot_types.includes(model.type);
+                return classOk && backendOk && typeOk;
+              });
               // Always include the current selection even if it doesn't pass the
               // filter, so an existing preference never silently disappears.
               const names = new Set(fit.map(p => p.name));
@@ -863,6 +863,9 @@ function AddByPathModal({ open, onClose }) {
   const [labelSel, setLabelSel] = useStateMM({ chat: true });
   const add = useAddModelFromPath();
   const settings = useSettings();
+  // Canonical capability vocabulary — same meta-driven list as the HF modal
+  // and the recipe editor (this surface used to hand-roll a third variant).
+  const enums = useMetaEnums();
 
   useEffectMM(() => {
     if (open) {
@@ -962,7 +965,7 @@ function AddByPathModal({ open, onClose }) {
           <span className="sub">empty → auto-detect from header / filename</span>
         </div>
         <div className="form-ctl" style={{display: "flex", flexWrap: "wrap", gap: 8}}>
-          {["chat", "tool-calling", "vision", "embed", "rerank", "asr", "tts"].map(l => (
+          {enums.model_capabilities.map(l => (
             <label key={l} className="checkbox-row">
               <input
                 type="checkbox"

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -9,6 +9,7 @@
 
 import { useModels, usePullJob, useHfSearch, fmtBytes } from '@/api/hooks/useModels'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
+import { useMetaEnums } from '@/api/hooks/useMeta'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
@@ -42,6 +43,25 @@ function ModelsView() {
 
   const modelsQuery = useModels();
   const modelList = modelsQuery.data ?? [];
+  const enums = useMetaEnums();
+
+  // Toolbar chip vocabularies — meta-driven (GET /api/meta/enums, with the
+  // static fallback when the endpoint is absent). Type chips are the slot
+  // types minus `image` (image models live on the Image/ComfyUI tab); device
+  // chips are the legacy backend tokens the model normalizer emits (rocm /
+  // vulkan from the GPU devices' legacy_backend, plus npu/cpu device ids).
+  const typeChips = useMemoM(
+    () => enums.slot_types.filter(t => t !== "image"),
+    [enums],
+  );
+  const deviceChips = useMemoM(
+    () => [...new Set(
+      enums.devices
+        .filter(d => d.device_class !== "img")
+        .map(d => d.legacy_backend || d.id),
+    )],
+    [enums],
+  );
 
   // Auto-pick the first installed model on first render so the detail
   // pane never opens empty.
@@ -156,13 +176,13 @@ function ModelsView() {
                   <span className="lbl">type</span>
                   {/* image models moved to the Image/ComfyUI tab — no "image"
                       chip here (it used to match nothing). */}
-                  {["llm", "embedding", "reranking", "transcription", "tts"].map(t => (
+                  {typeChips.map(t => (
                     <button key={t} className={"mdl-chip" + (filters.type === t ? " on" : "")} onClick={() => toggle("type", t)}>{t}</button>
                   ))}
                 </div>
                 <div className="mdl-toolbar-grp">
                   <span className="lbl">device</span>
-                  {["rocm", "vulkan", "cpu", "npu"].map(d => (
+                  {deviceChips.map(d => (
                     <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
                   ))}
                 </div>

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -9,6 +9,7 @@
 
 import { useModels, usePullJob, useHfSearch, fmtBytes } from '@/api/hooks/useModels'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
+import { isUpstreamModel } from '@/lib/normalizeApiModel'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
@@ -81,9 +82,14 @@ function ModelsView() {
     m.type === "image";
 
   // Dispatcher-routable models — the ComfyUI ones are pulled out to their tab.
+  // Upstream-advertised rows (aggregated from a provider's /v1/models, never
+  // on this host's disk) get their own section instead of masquerading as
+  // local not-yet-pulled entries in user.*.
   const installed = modelList.filter(m => m.installed && !isComfy(m) && fil(m));
   const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && fil(m));
-  const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && !isComfy(m) && fil(m));
+  const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && !isUpstreamModel(m) && !isComfy(m) && fil(m));
+  const upstreamAdv = modelList.filter(m => isUpstreamModel(m) && !isComfy(m) && fil(m));
+  const upstreamTotal = modelList.filter(m => isUpstreamModel(m)).length;
 
   // ComfyUI/image surface — INSTALLED only (we never advertise un-pulled image
   // models, same rule as FLM). Text search applies; the type/device chips do
@@ -174,8 +180,8 @@ function ModelsView() {
           </div>
           <div className="mdl-list-h">
             <span>{tab === "models" ? "Catalog" : "Image / ComfyUI"}</span>
-            <span className="ct">· {tab === "models" ? (installed.length + blessed.length + userNs.length) : comfyModels.length} shown</span>
-            <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {comfyTotal} image</span>
+            <span className="ct">· {tab === "models" ? (installed.length + blessed.length + userNs.length + upstreamAdv.length) : comfyModels.length} shown</span>
+            <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {upstreamTotal} upstream · {comfyTotal} image</span>
           </div>
 
           {modelsQuery.isPending && (
@@ -204,7 +210,12 @@ function ModelsView() {
                 <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
               ))}
 
-              {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length) === 0 && (
+              {upstreamAdv.length > 0 && <div className="mdl-section-label">Upstream · remote · {upstreamAdv.length}</div>}
+              {upstreamAdv.map(m => (
+                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              ))}
+
+              {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length + upstreamAdv.length) === 0 && (
                 <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
                   No models match — {(q.trim() || filters.type || filters.device) ? "adjust the search or filters." : "the catalog is empty."}
                 </div>
@@ -351,7 +362,9 @@ function ModelRow({ model, selected, onSelect }) {
       <span className="tg">
         {model.installed
           ? <span className="chip ok">installed</span>
-          : <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>}
+          : isUpstreamModel(model)
+            ? <span className="chip info" title={`Advertised by the "${model.upstream}" upstream — not stored on this host`}>upstream</span>
+            : <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>}
       </span>
     </div>
   );
@@ -424,7 +437,9 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
           <span style={{marginLeft: "auto"}}>
             {model.installed
               ? <span className="chip ok">installed</span>
-              : <span className="chip amber">available</span>}
+              : isUpstreamModel(model)
+                ? <span className="chip info">upstream · {model.upstream}</span>
+                : <span className="chip amber">available</span>}
           </span>
         </div>
         <div className="repo">{model.repo || model.hf_repo || model.id}</div>
@@ -436,6 +451,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
         <div><div className="k">device</div><div className="v">{model.device || (model.backends?.[0]) || "—"}</div></div>
         <div><div className="k">runtime</div><div className="v">{model.runtime || "—"}</div></div>
         <div><div className="k">namespace</div><div className="v">{model.ns || "—"}</div></div>
+        <div><div className="k">origin</div><div className="v">{isUpstreamModel(model) ? `upstream · ${model.upstream}` : "local"}</div></div>
       </div>
       <div className="mdl-detail-labels">
         {(model.labels || model.capabilities || []).map(l => <span key={l} className="chip">{l}</span>)}
@@ -506,6 +522,12 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
             <button className="btn ghost sm" onClick={onEdit}>{Icons.edit} Edit options</button>
             <button className="btn danger sm" onClick={onDelete}>{Icons.unload} Delete</button>
           </>
+        ) : isUpstreamModel(model) ? (
+          // Upstream-advertised row: nothing to pull — the dispatcher proxies
+          // requests to the remote provider. Manage it on the Connections view.
+          <div className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
+            Served remotely by the <span className="chip info">{model.upstream}</span> upstream — not stored on this host.
+          </div>
         ) : (
           <>
             <button className="btn" onClick={onPull} disabled={pull.inFlight}>

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -20,6 +20,10 @@ import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useSlotRestart, useSlotUnload, useSlotLoad } from '@/api/hooks/useSlots'
 import { SlotControls, slotCtrlPhase } from './inference-pane.jsx'
 import { slotIndicatorFromPhase } from './slot-status.js'
+// devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
+// the local copy (which also mis-classified backend tokens like "flm" —
+// the shared helper folds them through backend_to_device → npu).
+import { devKind } from '@/lib/deviceMeta'
 
 // ─── icons (16×16, hal0 thin-line family — ported from the design) ─────────
 const NI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -53,13 +57,6 @@ const toast = (msg, kind = 'info') =>
   typeof window !== 'undefined' && window.__hal0Toast && window.__hal0Toast(msg, kind)
 
 const round1 = (n) => Math.round((n || 0) * 10) / 10
-const devKind = (device) => {
-  const d = String(device || '').toLowerCase()
-  if (d === 'npu') return 'npu'
-  if (d.includes('vulkan')) return 'vulkan'
-  if (d.includes('rocm') || d.startsWith('gpu')) return 'rocm'
-  return d || 'cpu'
-}
 const isNpuSlot = (s) => s.device_class === 'npu' || devKind(s.device) === 'npu'
 
 // owner hues — assigned by slot index so each resident FLM reads as its own

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -65,15 +65,38 @@ function useFocusTrap(ref, open) {
   }, [open, ref]);
 }
 
+// ─── DiscardGuardDialog — shared unsaved-changes confirm ────────────────────
+// Dialog-based replacement for the window.confirm the Modal/Drawer/FormDrawer
+// `dirty` prop used to fire (same ConfirmDialog idiom the slot drawer adopted
+// in slot-modals.jsx). `message` is the caller's `confirmDiscard` copy, kept
+// as the dialog body so the existing prop API stays backward compatible.
+function DiscardGuardDialog({ open, message, onCancel, onDiscard }) {
+  return (
+    <ConfirmDialog
+      open={open}
+      onCancel={onCancel}
+      onConfirm={onDiscard}
+      title="Unsaved changes"
+      message={message || "Discard unsaved changes?"}
+      confirmLabel="Discard"
+      cancelLabel="Keep editing"
+    />
+  );
+}
+
 // ─── Portal-less Modal ────────────────────────────────────────────────────
 // Click backdrop or Esc to close. Captures + restores focus on close and traps
 // Tab within the shell. Width auto-sized. Pass `dirty` (+ optional
-// `confirmDiscard`) to guard the dismiss paths against unsaved changes.
+// `confirmDiscard`) to guard the dismiss paths against unsaved changes —
+// the guard confirms through the shared DiscardGuardDialog (state-driven),
+// not window.confirm.
 function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dismissable = true, dirty = false, confirmDiscard = "Discard unsaved changes?" }) {
   const overlayRef = useRefP(null);
   const shellRef = useRefP(null);
+  const [discardOpen, setDiscardOpen] = useStateP(false);
+  useEffectP(() => { if (!open) setDiscardOpen(false); }, [open]);
   const requestClose = () => {
-    if (dirty && !window.confirm(confirmDiscard)) return;
+    if (dirty) { setDiscardOpen(true); return; }
     onClose();
   };
   useEffectP(() => {
@@ -90,6 +113,7 @@ function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dis
   useFocusTrap(shellRef, open);
   if (!open) return null;
   return (
+    <>
     <div
       className="modal-backdrop"
       ref={overlayRef}
@@ -109,6 +133,15 @@ function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dis
         {foot && <div className="modal-foot mono">{foot}</div>}
       </div>
     </div>
+    {dirty && (
+      <DiscardGuardDialog
+        open={discardOpen}
+        message={confirmDiscard}
+        onCancel={() => setDiscardOpen(false)}
+        onDiscard={() => { setDiscardOpen(false); onClose(); }}
+      />
+    )}
+    </>
   );
 }
 
@@ -119,8 +152,10 @@ function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dis
 // disables backdrop dismissal.
 function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, headRight, dirty = false, dismissable = true, confirmDiscard = "Discard unsaved changes?" }) {
   const shellRef = useRefP(null);
+  const [discardOpen, setDiscardOpen] = useStateP(false);
+  useEffectP(() => { if (!open) setDiscardOpen(false); }, [open]);
   const requestClose = () => {
-    if (dirty && !window.confirm(confirmDiscard)) return;
+    if (dirty) { setDiscardOpen(true); return; }
     onClose();
   };
   useEffectP(() => {
@@ -137,6 +172,14 @@ function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, he
         className={"drawer-backdrop" + (open ? " open" : "")}
         onClick={() => { if (dismissable) requestClose(); }}
       />
+      {dirty && (
+        <DiscardGuardDialog
+          open={discardOpen}
+          message={confirmDiscard}
+          onCancel={() => setDiscardOpen(false)}
+          onDiscard={() => { setDiscardOpen(false); onClose(); }}
+        />
+      )}
       <aside
         ref={shellRef}
         tabIndex={-1}
@@ -708,15 +751,20 @@ function useForm({ initial, deriveInitial, resetKey, validate, warn }) {
 // editor's submit + validation exactly as they were.
 function FormDrawer({ eyebrow, title, ariaLabel, panelClassName = "", submitting = false, dirty = false, confirmDiscard = "Discard unsaved changes?", onClose, children, foot }) {
   const [closing, setClosing] = useStateP(false);
+  const [discardOpen, setDiscardOpen] = useStateP(false);
   const shellRef = useRefP(null);
-  const requestClose = () => {
-    if (submitting) return;
-    if (dirty && !window.confirm(confirmDiscard)) return;
+  const beginClose = () => {
     setClosing(true);
     setTimeout(onClose, 200);
   };
+  const requestClose = () => {
+    if (submitting) return;
+    if (dirty) { setDiscardOpen(true); return; }
+    beginClose();
+  };
   useFocusTrap(shellRef, true);
   return (
+    <>
     <div className={"pf-scrim" + (closing ? " out" : "")} onMouseDown={requestClose}>
       <div
         ref={shellRef}
@@ -740,6 +788,16 @@ function FormDrawer({ eyebrow, title, ariaLabel, panelClassName = "", submitting
         </div>
       </div>
     </div>
+    {/* Rendered after the scrim — equal z-index overlays stack by DOM order. */}
+    {dirty && (
+      <DiscardGuardDialog
+        open={discardOpen}
+        message={confirmDiscard}
+        onCancel={() => setDiscardOpen(false)}
+        onDiscard={() => { setDiscardOpen(false); beginClose(); }}
+      />
+    )}
+    </>
   );
 }
 

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -13,7 +13,7 @@
 // Seeds are immutable: Edit becomes "Edit a copy" (forks <seed>-custom with
 // cloned_from set); Delete is disabled. Custom profiles get Clone/Edit/Delete.
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import {
   useProfiles,
   useProfileCreate,
@@ -22,35 +22,54 @@ import {
   useProfileExport,
   useProfileImport,
 } from '@/api/hooks/useProfiles'
+import { useMetaEnums } from '@/api/hooks/useMeta'
 import { prettyProfile } from './profile-names'
 
-// Backend runtime hue. Keys are the display backends shown on the card +
-// drawer; colors reference shared dashboard tokens. `backendField` is the
-// value persisted to ProfileConfig.backend (null for non-GPU paths, where
-// device_class carries the hardware intent — see #751).
-const BACKEND_META = {
-  rocm:   { label: 'ROCm',          color: 'var(--dev-rocm)',   device_class: 'gpu', backendField: 'rocm' },
-  vulkan: { label: 'Vulkan',        color: 'var(--dev-vulkan)', device_class: 'gpu', backendField: 'vulkan' },
-  npu:    { label: 'FLM · NPU',     color: 'var(--dev-npu)',    device_class: 'npu', backendField: null },
-  cpu:    { label: 'CPU',           color: 'var(--dev-cpu)',    device_class: 'cpu', backendField: null },
-  // ComfyUI image-gen path: no llama.cpp backend, device_class carries the
-  // 'img' intent. Present so an existing device_class='img' profile survives an
-  // edit (backendOf → 'img' → device_class:'img') instead of being silently
-  // rewritten to 'gpu'/'cpu'. Backend PUT /api/profiles accepts device_class ∈
-  // {gpu,cpu,npu,img}.
-  img:    { label: 'ComfyUI · IMG', color: 'var(--dev-img)',    device_class: 'img', backendField: null },
-};
+// Backend runtime hue map — built from meta.devices (GET /api/meta/enums via
+// useMetaEnums, static fallback when absent) instead of the old hardcoded
+// table. Keys stay the display backends shown on the card + drawer (rocm /
+// vulkan / npu / cpu / img); colors reference shared dashboard tokens.
+// `backendField` is the value persisted to ProfileConfig.backend (the GPU
+// devices' legacy_backend; null for non-GPU paths, where device_class carries
+// the hardware intent — see #751). PUT /api/profiles accepts device_class ∈
+// {gpu,cpu,npu,img}, so the img/ComfyUI entry keeps an existing
+// device_class='img' profile from being silently rewritten on edit.
+function buildBackendMeta(enums) {
+  const out = {};
+  for (const d of enums.devices) {
+    const key = d.legacy_backend
+      || (d.device_class && d.device_class !== 'gpu' ? d.device_class : String(d.id).replace(/^gpu-/, ''));
+    if (!key || out[key]) continue;
+    out[key] = {
+      label: d.label || key,
+      color: `var(--dev-${key})`,
+      device_class: d.device_class,
+      backendField: d.legacy_backend || null,
+      recommended: !!d.recommended,
+      description: d.description || '',
+    };
+  }
+  // Defensive floor — bk() falls back to `cpu`, so the key must exist even
+  // against a degenerate enums payload.
+  if (!out.cpu) out.cpu = { label: 'CPU', color: 'var(--dev-cpu)', device_class: 'cpu', backendField: null, recommended: false, description: '' };
+  return out;
+}
+
+function useBackendMeta() {
+  const enums = useMetaEnums();
+  return useMemo(() => buildBackendMeta(enums), [enums]);
+}
 
 // `NAME_RE` (name regex) and `toast` are shared globals from primitives.jsx.
 
 const BLANK = { name: '', intent: '', image: '', backend: 'rocm', quant: '', flags: '', mtp: false };
 
-function bk(name) { return BACKEND_META[name] || BACKEND_META.cpu; }
+function bk(name, meta) { return meta[name] || meta.cpu; }
 
 // Display backend for a profile: the explicit GPU backend (rocm|vulkan) when
 // set, otherwise mapped from device_class so npu/cpu/img still get a hue.
-function backendOf(p) {
-  if (p.backend && BACKEND_META[p.backend]) return p.backend;
+function backendOf(p, meta) {
+  if (p.backend && meta[p.backend]) return p.backend;
   if (p.device_class === 'img') return 'img';
   if (p.device_class === 'npu') return 'npu';
   if (p.device_class === 'cpu') return 'cpu';
@@ -93,7 +112,8 @@ function PfRow({ label, value, hue }) {
 // Profile card — adopts the Stacks library-card shell (.stk-lib-*) so the
 // Profiles and Stacks grids read as one family. Same data + actions as before.
 function ProfileCard({ p, index, onEdit, onClone, onDelete, onExport }) {
-  const meta = bk(backendOf(p));
+  const BACKEND_META = useBackendMeta();
+  const meta = bk(backendOf(p, BACKEND_META), BACKEND_META);
   const isSeed = !!p.seed;
   const usedBy = p.used_by || [];
   const inUse = usedBy.length;
@@ -198,6 +218,7 @@ function warnForm(form) {
 // verbatim so the validation rules stay in this view.
 function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
   const isEdit = mode === 'edit';
+  const BACKEND_META = useBackendMeta();
 
   const deriveInitial = () => {
     if (mode === 'create') return { ...BLANK };
@@ -205,7 +226,7 @@ function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
       name: source.name,
       intent: source.intent || '',
       image: source.image || '',
-      backend: backendOf(source),
+      backend: backendOf(source, BACKEND_META),
       quant: source.quant || '',
       flags: source.flags || '',
       mtp: !!source.mtp,
@@ -234,7 +255,7 @@ function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
   const show = f.show;
   const set = f.set;
   const touch = f.touch;
-  const meta = bk(form.backend);
+  const meta = bk(form.backend, BACKEND_META);
   const nameValid = !errs.name && (form.name || '').trim().length > 0;
   const nameLen = (form.name || '').length;
 
@@ -247,7 +268,7 @@ function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
       return;
     }
     f.setSubmitting(true);
-    const choice = bk(form.backend);
+    const choice = bk(form.backend, BACKEND_META);
     const body = {
       name: form.name.trim(),
       image: form.image.trim(),
@@ -340,13 +361,28 @@ function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
         </FormRow>
 
         <FormRow label="Backend" sub="runtime path">
-          <div className="pf-seg" data-testid="pf-seg-backend">
-            {Object.keys(BACKEND_META).map(k => (
-              <button type="button" key={k} className={'pf-seg-btn' + (form.backend === k ? ' on' : '')}
-                style={{ '--bk': BACKEND_META[k].color }} onClick={() => set('backend', k)}>
-                <span className="pf-chip-dot" />{BACKEND_META[k].label}
-              </button>
-            ))}
+          <div>
+            <div className="pf-seg" data-testid="pf-seg-backend">
+              {Object.keys(BACKEND_META).map(k => (
+                <button type="button" key={k} className={'pf-seg-btn' + (form.backend === k ? ' on' : '')}
+                  style={{ '--bk': BACKEND_META[k].color }} onClick={() => set('backend', k)}
+                  title={BACKEND_META[k].description || BACKEND_META[k].label}>
+                  <span className="pf-chip-dot" />{BACKEND_META[k].label}
+                  {BACKEND_META[k].recommended && <span title="Recommended" aria-label="recommended"> ★</span>}
+                </button>
+              ))}
+            </div>
+            {/* Meta-driven guidance for the picked runtime path — the enums
+                endpoint flags gpu-rocm as recommended and labels vulkan as the
+                fallback; surface that at the moment of choice. */}
+            {(meta.recommended || meta.description) && (
+              <div className="mono" data-testid="pf-backend-hint" style={{
+                marginTop: 6, fontSize: 10.5, lineHeight: 1.5,
+                color: meta.recommended ? 'var(--ok)' : 'var(--fg-4)',
+              }}>
+                {meta.recommended ? '★ recommended · ' : ''}{meta.description}
+              </div>
+            )}
           </div>
         </FormRow>
 
@@ -538,6 +574,7 @@ function ProfilesView() {
   const query = useProfiles();
   const profiles = query.data ?? [];
   const exportMut = useProfileExport();
+  const BACKEND_META = useBackendMeta();
 
   const [drawer, setDrawer] = useState(null);   // {mode, source}
   const [confirm, setConfirm] = useState(null);

--- a/ui/src/dash/slot-list.jsx
+++ b/ui/src/dash/slot-list.jsx
@@ -18,19 +18,11 @@
 import { useSlots } from '@/api/hooks/useSlots'
 import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { slotIndicatorFromPhase } from './slot-status.js'
+// devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
+// the copy this file used to carry alongside npu-pane and inference-pane.
+import { devKind } from '@/lib/deviceMeta'
 
 const { useState: useStateL, useCallback: useCallbackL } = React
-
-// ── devKind — copied verbatim from inference-pane.jsx (window-global fn there;
-//    safest to carry a local copy than depend on load order).
-function devKind(device) {
-  const d = String(device || '').toLowerCase()
-  if (d === 'npu') return 'npu'
-  if (d === 'cpu') return 'cpu'
-  if (d.includes('vulkan')) return 'vulkan'
-  if (d.includes('rocm') || d.startsWith('gpu')) return 'rocm'
-  return 'cpu'
-}
 
 // ── metric helpers ────────────────────────────────────────────────────────────
 

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -21,6 +21,7 @@ import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
 import { useSlotLogsStream } from '@/api/hooks/useLogs'
 import { ENDPOINTS } from '@/api/endpoints'
+import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { stateChipClassForSlot, slotButtonPhase } from './slot-status.js'
 
 const { useState: useStateSM, useEffect: useEffectSM } = React;
@@ -96,8 +97,12 @@ function normalizeApiModel(m) {
 // fork binary). Previously the create modal filtered on type ALONE and could
 // offer rocmfp4 models that the backend then rejects — this closes that gap.
 function compatibleModels(models, { type, backend }) {
+  // Upstream-advertised rows are excluded outright: a slot binds a local
+  // file path, and these rows have none (they'd render as "will pull" and
+  // then 422 — there is no HF source to pull them from).
   return (models ?? []).map(normalizeApiModel).filter(m =>
     m.type === type &&
+    !isUpstreamModel(m) &&
     !(Array.isArray(m.tags) && m.tags.includes("rocmfp4") && backend !== "rocm")
   );
 }

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -19,6 +19,7 @@ import { useHardware } from '@/api/hooks/useHardware'
 import { useModels } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
+import { useMetaEnums } from '@/api/hooks/useMeta'
 import { useSlotLogsStream } from '@/api/hooks/useLogs'
 import { ENDPOINTS } from '@/api/endpoints'
 import { normalizeApiModel } from '@/lib/normalizeApiModel'
@@ -99,6 +100,9 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const hwQuery = useHardware();
   const modelsQuery = useModels();
   const profilesQuery = useProfiles();
+  // Slot type vocabulary — meta-driven (GET /api/meta/enums, static fallback
+  // when absent) instead of the old hardcoded <option> list.
+  const enums = useMetaEnums();
 
   useEffectSM(() => { if (open) { setSubmitErr(null); setDiscardOpen(false); } }, [open]);
 
@@ -210,12 +214,9 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
         </div>
         <div className="form-ctl">
           <select className="input mono" value={type} onChange={e => setType(e.target.value)}>
-            <option value="llm">llm</option>
-            <option value="embedding">embedding</option>
-            <option value="reranking">reranking</option>
-            <option value="transcription">transcription</option>
-            <option value="tts">tts</option>
-            <option value="image">image</option>
+            {/* keep an out-of-vocab persisted type selectable */}
+            {type && !enums.slot_types.includes(type) && <option value={type}>{type}</option>}
+            {enums.slot_types.map(t => <option key={t} value={t}>{t}</option>)}
           </select>
         </div>
       </div>
@@ -662,9 +663,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // instant-apply toggles (thinking / MTP / enable) fire their own PUT/POST
   // outside Save and are intentionally excluded — a flipped toggle is
   // already persisted.
+  // ctx dirty test matches the SAVE path's numeric comparison (ctxChanged in
+  // onSaveClick: Number(ctx) !== Number(ctxBaseline)) — the old string compare
+  // flagged "8192 " / "08192" as dirty even though Save would send nothing.
+  // Trim + parse before comparing; an unparseable edit still counts dirty
+  // (NaN !== N) so garbage input keeps the guard armed.
+  const ctxDirty = Number(String(ctx).trim()) !== Number(ctxBaseline);
   const dirty =
     extraArgsDirty ||
-    String(ctx) !== String(ctxBaseline) ||
+    ctxDirty ||
     nglDirty ||
     (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
     (overrideOpen && chatTemplate !== (slot.chat_template || ""));
@@ -694,8 +701,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
   return (
     <>
     {/* The Drawer's Esc/backdrop/✕ paths call onClose — routed through
-        requestClose so the dirty guard runs through the shared ConfirmDialog
-        (NOT the primitive's `dirty` prop, which uses window.confirm). */}
+        requestClose so the dirty guard runs through this drawer's own
+        ConfirmDialog copy below. (The primitive's `dirty` prop is now also
+        dialog-based — DiscardGuardDialog in primitives.jsx — but this drawer
+        keeps its slot-specific discard copy.) */}
     <Drawer
       open={open}
       onClose={requestClose}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -21,6 +21,7 @@ import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
 import { useSlotLogsStream } from '@/api/hooks/useLogs'
 import { ENDPOINTS } from '@/api/endpoints'
+import { normalizeApiModel } from '@/lib/normalizeApiModel'
 import { stateChipClassForSlot, slotButtonPhase } from './slot-status.js'
 
 const { useState: useStateSM, useEffect: useEffectSM } = React;
@@ -39,55 +40,16 @@ function stateChipClass(stateOrSlot) {
   return stateChipClassForSlot(stateOrSlot);
 }
 
-// Map /api/models registry rows → the shape this file's swap popover and
-// create-slot modal grew up around (HAL0_DATA seed). Done in JSX rather
-// than at the API layer so the response stays identical to what the
-// Models view (models.jsx) already consumes. NEVER ship HAL0_DATA model
-// ids to the backend — they're fictional (`qwen3.6-27b-mtp` etc.) and
-// the slot orchestrator correctly rejects them against the real registry.
-function normalizeApiModel(m) {
-  // Accept both shapes: the registry/API shape (capabilities + backends +
-  // size_bytes + name + hf_repo) and the legacy HAL0_DATA seed shape
-  // (labels + device + size + longName + repo + type). Local dev without
-  // a backend falls back via src/api/mock.ts to HAL0_DATA.models, and the
-  // γ-suite hits that fallback when fetch fails before page.route catches
-  // (race + connection-refused on the Vite proxy target). Tolerating both
-  // shapes keeps the popover non-empty in every mock path.
-  const sourceCaps = Array.isArray(m.capabilities)
-    ? m.capabilities
-    : Array.isArray(m.labels) ? m.labels : [];
-  const derivedType =
-    sourceCaps.includes('chat') || sourceCaps.includes('coding') ? 'llm'
-    : sourceCaps.includes('rerank') || sourceCaps.includes('reranking') ? 'reranking'
-    : sourceCaps.includes('embed') || sourceCaps.includes('embeddings') ? 'embedding'
-    : sourceCaps.includes('transcription') || sourceCaps.includes('asr') ? 'transcription'
-    : sourceCaps.includes('tts') ? 'tts'
-    : sourceCaps.includes('image') ? 'image'
-    : '';
-  const type = typeof m.type === 'string' && m.type ? m.type : derivedType;
-  const backends = Array.isArray(m.backends) ? m.backends : [];
-  const derivedDevice =
-    backends.includes('rocm') ? 'rocm'
-    : backends.includes('vulkan') ? 'vulkan'
-    : backends.includes('cpu') ? 'cpu'
-    : backends[0] || '';
-  const device = typeof m.device === 'string' && m.device ? m.device : derivedDevice;
-  const b = m.size_bytes || 0;
-  const derivedSize = !b
-    ? '—'
-    : b < 1024 ** 2 ? `${(b / 1024).toFixed(1)} KB`
-    : b < 1024 ** 3 ? `${(b / 1024 ** 2).toFixed(1)} MB`
-    : `${(b / 1024 ** 3).toFixed(2)} GB`;
-  const size = typeof m.size === 'string' && m.size ? m.size : derivedSize;
-  return {
-    ...m,
-    type,
-    device,
-    longName: m.longName || m.name || m.id,
-    size,
-    repo: m.repo || m.hf_repo || m.path || '',
-  };
-}
+// Model rows come from /api/models and are normalized by the SHARED
+// lib/normalizeApiModel (imported above), which tolerates both the
+// registry/API shape (capabilities + backends + size_bytes + name +
+// hf_repo) and the legacy HAL0_DATA seed shape (labels + device + size +
+// longName + repo + type — mock.ts fallback / γ-suite race). This file
+// used to carry its own divergent copy whose deriveType missed
+// tool-calling/vision → 'llm', hiding those models from every slot's
+// model picker. NEVER ship HAL0_DATA model ids to the backend — they're
+// fictional (`qwen3.6-27b-mtp` etc.) and the slot orchestrator correctly
+// rejects them against the real registry.
 
 // One shared compatible-models filter for all three slot surfaces (create
 // modal, edit drawer, swap popover). Takes the raw /api/models list, normalizes
@@ -128,13 +90,22 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const setModel = (val) => f.set("model", val);
   const setMakeDefault = (val) => f.set("makeDefault", val);
   const [submitErr, setSubmitErr] = useStateSM(null);
+  // UI: dirty-close confirms through the shared ConfirmDialog (state-driven)
+  // instead of window.confirm. Every dismiss path (Cancel, ✕, Esc, backdrop)
+  // funnels through requestClose below.
+  const [discardOpen, setDiscardOpen] = useStateSM(false);
 
   const createMut = useSlotCreate();
   const hwQuery = useHardware();
   const modelsQuery = useModels();
   const profilesQuery = useProfiles();
 
-  useEffectSM(() => { if (open) setSubmitErr(null); }, [open]);
+  useEffectSM(() => { if (open) { setSubmitErr(null); setDiscardOpen(false); } }, [open]);
+
+  const requestClose = () => {
+    if (f.isDirty) { setDiscardOpen(true); return; }
+    onClose();
+  };
 
   // validation — slot collision uses the live slot list passed in from
   // the SlotsView (useSlots data), not HAL0_DATA.
@@ -189,13 +160,13 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   }
 
   return (
+    <>
     <Modal
       open={open}
-      onClose={onClose}
+      onClose={requestClose}
       eyebrow="Slots · new"
       title="Create slot"
       width={640}
-      dirty={f.isDirty}
       foot={
         <>
           <span>
@@ -204,7 +175,7 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
               : "capabilities.toml will be written on save."}
           </span>
           <span style={{display: "inline-flex", gap: 8}}>
-            <button className="btn ghost sm" onClick={() => { if (f.isDirty && !window.confirm("Discard unsaved changes?")) return; onClose(); }}>Cancel</button>
+            <button className="btn ghost sm" onClick={requestClose}>Cancel</button>
             <button
               className="btn sm"
               onClick={onCreateClick}
@@ -329,6 +300,15 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
       </div>
 
     </Modal>
+    <ConfirmDialog
+      open={discardOpen}
+      onCancel={() => setDiscardOpen(false)}
+      onConfirm={() => { setDiscardOpen(false); onClose(); }}
+      title="Discard unsaved changes?"
+      message="The new slot has not been created — closing now discards what you entered."
+      confirmLabel="Discard"
+    />
+    </>
   );
 }
 
@@ -363,9 +343,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const chatTemplatesQuery = useChatTemplates(open);
 
   // Seed from the slot list payload when available (PR #587 — same fix
-  // class as #584). llamacpp_args / n_gpu_layers / rope_freq_base are
-  // surfaced on the list payload and rendered read-only (the profile
-  // owns them for container slots).
+  // class as #584). llamacpp_args (profile base flags) is read-only;
+  // n_gpu_layers is an editable per-slot override (PATCH /defaults →
+  // [model].n_gpu_layers).
   const initialExtraArgs = slot?.llamacpp_args != null ? slot.llamacpp_args : "";
 
   // Seed from the PERSISTED context window (slot.ctx_max, from
@@ -375,18 +355,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // metric, then the backend's safe 8192 floor.
   const [ctx, setCtx] = useStateSM(slot?.ctx_max ?? (slot?.metrics?.ctx || 8192));
   // C4/C5: thinking is instant-apply (its own PUT); n_gpu_layers rides the Save
-  // button through PATCH /defaults. Both seed from the slot list payload.
+  // button through PATCH /defaults ([model].n_gpu_layers; -1/empty = unset →
+  // sends null). Both seed from the slot list payload.
   const [thinking, setThinking] = useStateSM(slot?.enable_thinking === true);
   const [thinkingPending, setThinkingPending] = useStateSM(false);
   const [nGpuLayers, setNGpuLayers] = useStateSM(
     slot?.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1"
   );
-  // Issue #548: rope_freq_base — seeded from list payload (null → "0" default).
-  const [ropeFreqBase, setRopeFreqBase] = useStateSM(
-    slot?.rope_freq_base != null ? String(slot.rope_freq_base) : "0"
-  );
   const [extraArgs, setExtraArgs] = useStateSM(initialExtraArgs);
   const [submitErr, setSubmitErr] = useStateSM(null);
+  // Dirty-close confirms through the shared ConfirmDialog (state-driven),
+  // replacing the raw window.confirm. Every dismiss path (Cancel, ✕, Esc,
+  // backdrop) funnels through requestClose below.
+  const [discardOpen, setDiscardOpen] = useStateSM(false);
+  // UI-5 (state-driven): swapping the model on a LIVE container slot
+  // cold-restarts it — stash the picked {id, label} here and confirm through
+  // ConfirmDialog before firing the swap. null = no confirm pending.
+  const [pendingSwap, setPendingSwap] = useStateSM(null);
   // Enable/disable is instant-apply via its own PUT (mirrors the slot card's
   // pill toggle, which the redesigned cards dropped). `enableBusy` gates the
   // header toggle against a double-trigger while the mutation is in flight.
@@ -438,11 +423,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
       setThinking(slot.enable_thinking === true);
       setThinkingPending(false);
       setNGpuLayers(slot.n_gpu_layers != null ? String(slot.n_gpu_layers) : "-1");
-      setRopeFreqBase(slot.rope_freq_base != null ? String(slot.rope_freq_base) : "0");
       // #587: re-seed from the slot prop so the drawer tracks the real
       // on-disk values.
       setExtraArgs(slot.llamacpp_args != null ? slot.llamacpp_args : "");
       setSubmitErr(null);
+      setDiscardOpen(false);
+      setPendingSwap(null);
       setThinkingErr(null);
       setFieldErrs({});
       // C7: re-seed profile from the (possibly-updated) slot prop.
@@ -473,6 +459,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
     const errs = {};
     if (!Number.isFinite(ctxNum) || !Number.isInteger(ctxNum) || ctxNum < 128) {
       errs.ctx = "Must be an integer ≥ 128";
+    }
+    // n_gpu_layers: -1 or empty = "use model default / profile" (persisted as
+    // null → backend unsets [model].n_gpu_layers); otherwise an integer ≥ 0.
+    const nglRaw = String(nGpuLayers).trim();
+    const nglNum = nglRaw === "" ? null : Number(nglRaw);
+    if (nglRaw !== "" && (!Number.isFinite(nglNum) || !Number.isInteger(nglNum) || nglNum < -1)) {
+      errs.ngl = "Must be an integer ≥ -1 (or empty)";
     }
     // Task 5: GPU-class slots have an editable profile select; mirror the
     // create-slot modal's guard and block Save when it's been cleared. NPU/CPU
@@ -509,12 +502,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
     // on a not-currently-serving slot clobbered the persisted context window
     // with the seeded fallback. Gate on the persisted baseline (ctxBaseline).
     const ctxChanged = ctxNum !== Number(ctxBaseline);
+    // n_gpu_layers rides the same PATCH /defaults path as ctx_size
+    // ([model].n_gpu_layers). -1 and empty both mean "unset" (→ null on the
+    // wire); only ship when the NORMALIZED value differs from the persisted
+    // baseline so a no-op Save stays quiet (#587 dirty-tracking contract).
+    const nglValue = nglRaw === "" || nglNum === -1 ? null : nglNum;
+    const nglChanged = nglValue !== nglBaselineValue;
     try {
-      // Two-step: defaults (ctx_size lives under [model]) + slot config
-      // for the top-level keys (default, profile). n_gpu_layers /
-      // rope_freq_base / llamacpp_args are owned by the profile — never
-      // include them in a save. These are fast on-disk writes, so we await
-      // them and keep the drawer open to surface any write error.
+      // Two-step: defaults (ctx_size / n_gpu_layers live under [model]) +
+      // slot config for the top-level keys (profile, chat_template, server).
+      // llamacpp_args base flags are owned by the profile — never included in
+      // a save (extra_args is the per-slot override). These are fast on-disk
+      // writes, so we await them and keep the drawer open to surface any
+      // write error.
       const slotBody = {};
       if (profileChanged) {
         slotBody.profile = selectedProfile;
@@ -525,10 +525,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
       if (extraArgsChanged) {
         slotBody.server = { extra_args: extraArgs };
       }
-      if (ctxChanged) {
+      const defaultsBody = {};
+      if (ctxChanged) defaultsBody.ctx_size = ctxNum;
+      if (nglChanged) defaultsBody.n_gpu_layers = nglValue;
+      if (Object.keys(defaultsBody).length > 0) {
         await defaultsMut.mutateAsync({
           name: slot.name,
-          body: { ctx_size: ctxNum },
+          body: defaultsBody,
         });
       }
       await editMut.mutateAsync({
@@ -644,27 +647,58 @@ function EditSlotDrawer({ open, slot, onClose }) {
   // the 8192 floor only when nothing is persisted, so an untouched field on a
   // cold slot is never counted dirty (and never written — see ctxChanged).
   const ctxBaseline = slot.ctx_max ?? (slot.metrics?.ctx || 8192);
+  // n_gpu_layers baseline, NORMALIZED: -1 and absent both mean "unset" (use
+  // model default / profile), so they compare equal — an untouched "-1" seed
+  // never counts dirty and never rides the PATCH.
+  const nglBaselineValue =
+    slot.n_gpu_layers == null || slot.n_gpu_layers === -1 ? null : slot.n_gpu_layers;
+  const nglRawNow = String(nGpuLayers).trim();
+  const nglValueNow =
+    nglRawNow === "" || Number(nglRawNow) === -1 ? null : Number(nglRawNow);
+  const nglDirty = nglValueNow !== nglBaselineValue;
 
   // UI-1: unsaved-changes guard. Aggregate ONLY the Save-batched fields
-  // (extra_args, ctx, profile, chat_template override). The instant-apply
-  // toggles (thinking / MTP / enable) fire their own PUT/POST outside Save and
-  // are intentionally excluded — a flipped toggle is already persisted.
+  // (extra_args, ctx, n_gpu_layers, profile, chat_template override). The
+  // instant-apply toggles (thinking / MTP / enable) fire their own PUT/POST
+  // outside Save and are intentionally excluded — a flipped toggle is
+  // already persisted.
   const dirty =
     extraArgsDirty ||
     String(ctx) !== String(ctxBaseline) ||
+    nglDirty ||
     (!!selectedProfile && selectedProfile !== (slot.profile || "")) ||
     (overrideOpen && chatTemplate !== (slot.chat_template || ""));
   const requestClose = () => {
-    if (dirty && !window.confirm("Discard unsaved changes?")) return;
+    if (dirty) { setDiscardOpen(true); return; }
     onClose();
+  };
+
+  // Fire the model swap (POST /slots/{name}/swap). Non-blocking: a swap
+  // cold-restarts container slots to load the model (slow) — fire it and let
+  // the slots poll reflect the transitional phase; never freeze the drawer on
+  // the load. Called directly for non-live swaps, or from the ConfirmDialog
+  // once the operator confirms a live-container cold restart.
+  const fireSwap = (id, label) => {
+    setSubmitErr(null);
+    swapMut.mutate({ name: slot.name, model_id: id }, {
+      onError: (err) => setSubmitErr(err?.message || "model swap failed"),
+    });
+    window.__hal0Toast && window.__hal0Toast(
+      slot.runtime === "container"
+        ? `Restarting ${slot.name} to load ${label} — loading in the background`
+        : `${slot.name} → ${label}`,
+      "info",
+    );
   };
 
   return (
     <>
+    {/* The Drawer's Esc/backdrop/✕ paths call onClose — routed through
+        requestClose so the dirty guard runs through the shared ConfirmDialog
+        (NOT the primitive's `dirty` prop, which uses window.confirm). */}
     <Drawer
       open={open}
-      onClose={onClose}
-      dirty={dirty}
+      onClose={requestClose}
       eyebrow={`Slots · /slots/${slot.name}`}
       title={`Edit ${slot.name}`}
       width={560}
@@ -839,27 +873,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
                 onChange={(e) => {
                   const id = e.target.value;
                   if (!id || id === cur) return;
-                  // UI-5: swapping the model on a LIVE container slot cold-restarts
-                  // it (~model-load seconds). Confirm before firing — bailing here
-                  // re-renders the select back to `cur` (value={cur}), so no manual
-                  // revert is needed. Mirrors the delete/dirty-close confirm gates.
-                  const live = slotButtonPhase(slot) === "running";
-                  if (isContainer && live && !window.confirm(`Swap model on running slot "${slot.name}"? This cold-restarts the container (~model-load seconds).`)) return;
-                  setSubmitErr(null);
                   const picked = compatible.find(m => m.id === id);
                   const label = picked?.longName || id;
-                  // Non-blocking: a swap cold-restarts container slots to load
-                  // the model (slow). Fire it and let the slots poll reflect the
-                  // transitional phase — never freeze the drawer on the load.
-                  swapMut.mutate({ name: slot.name, model_id: id }, {
-                    onError: (err) => setSubmitErr(err?.message || "model swap failed"),
-                  });
-                  window.__hal0Toast && window.__hal0Toast(
-                    isContainer
-                      ? `Restarting ${slot.name} to load ${label} — loading in the background`
-                      : `${slot.name} → ${label}`,
-                    "info",
-                  );
+                  // UI-5: swapping the model on a LIVE container slot cold-restarts
+                  // it (~model-load seconds). Confirm through the shared
+                  // ConfirmDialog before firing — stashing the pick re-renders the
+                  // select back to `cur` (value={cur}), so cancel needs no manual
+                  // revert. Mirrors the delete/dirty-close confirm gates.
+                  const live = slotButtonPhase(slot) === "running";
+                  if (isContainer && live) { setPendingSwap({ id, label }); return; }
+                  fireSwap(id, label);
                 }}
               >
                 {cur && !has && <option value={cur}>{slot.modelLong || slot.model || cur}</option>}
@@ -1160,25 +1183,27 @@ function EditSlotDrawer({ open, slot, onClose }) {
       <details className="adv-disclosure">
       <summary className="form-section" style={{cursor: "pointer", listStyle: "revert"}}>Advanced</summary>
 
-      {/* C5: GPU offload tuning — read-only, defined by the profile. */}
+      {/* GPU offload tuning — per-slot override persisted via
+          PATCH /defaults ([model].n_gpu_layers). -1/empty = unset, i.e. the
+          model default / profile value applies. Rides the Save button with
+          the same dirty-tracking as ctx_size.
+          (rope_freq_base was removed — deprecated; advanced users set it via
+          extra_args below.) */}
       <div className="form-row">
         <div className="form-lbl">
           <span>n_gpu_layers</span>
-          <span className="sub">defined by profile {slot.profile}</span>
+          <span className="sub">-1 / empty = use model default / profile</span>
         </div>
         <div className="form-ctl">
-          <input className="input mono" value={nGpuLayers} readOnly />
-        </div>
-      </div>
-
-      {/* Issue #548: rope_freq_base — read-only, defined by the profile. */}
-      <div className="form-row">
-        <div className="form-lbl">
-          <span>rope_freq_base</span>
-          <span className="sub">defined by profile {slot.profile}</span>
-        </div>
-        <div className="form-ctl">
-          <input className="input mono" value={ropeFreqBase} readOnly />
+          <input
+            className={"input mono" + (fieldErrs.ngl ? " input-err" : "")}
+            value={nGpuLayers}
+            onChange={e => { setNGpuLayers(e.target.value); setFieldErrs(p => ({...p, ngl: undefined})); }}
+            placeholder="-1"
+            inputMode="numeric"
+            data-testid="n-gpu-layers-input"
+          />
+          {fieldErrs.ngl && <div className="hint" style={{color: "var(--err)"}}>{fieldErrs.ngl}</div>}
         </div>
       </div>
 
@@ -1274,14 +1299,28 @@ function EditSlotDrawer({ open, slot, onClose }) {
         if (!resolvedData || !Array.isArray(resolvedData.provenance) || resolvedData.provenance.length === 0) {
           return null;
         }
-        // Source → display label + CSS variable colour
+        // Source → display label + CSS variable colour. The backend command
+        // assembler emits MORE segment labels than the original three (new:
+        // model_defaults, chat_template, mmproj, slot_overrides) and may grow
+        // others — metaFor() falls back to a generic neutral badge carrying
+        // the raw label text, so an unknown source renders instead of being
+        // mislabelled "base" or breaking the drawer.
         const SOURCE_META = {
           base:       { label: "base",       color: "var(--fg-4)" },
           profile:    { label: "profile",    color: "var(--info)" },
           extra_args: { label: "extra_args", color: "var(--accent)" },
         };
+        const metaFor = (source) =>
+          SOURCE_META[source] || { label: String(source || "unknown"), color: "var(--fg-3)" };
+        // Legend: the known trio plus any additional sources actually present
+        // in this slot's provenance (deduped, generic-styled).
+        const legendSources = [
+          ...Object.keys(SOURCE_META),
+          ...[...new Set(resolvedData.provenance.map((e) => e.source))]
+            .filter((s) => !SOURCE_META[s]),
+        ];
         const badgeStyle = (source) => {
-          const meta = SOURCE_META[source] || SOURCE_META.base;
+          const meta = metaFor(source);
           return {
             display: "inline-block",
             padding: "1px 5px",
@@ -1304,8 +1343,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
               paddingBottom: 6, flexWrap: "wrap",
             }}>
               <span style={{fontSize: 10, color: "var(--fg-5)", fontFamily: "var(--jbm)"}}>source:</span>
-              {Object.entries(SOURCE_META).map(([src, meta]) => (
-                <span key={src} style={badgeStyle(src)}>{meta.label}</span>
+              {legendSources.map((src) => (
+                <span key={src} style={badgeStyle(src)}>{metaFor(src).label}</span>
               ))}
             </div>
             {/* Per-flag provenance rows */}
@@ -1326,7 +1365,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     )}
                   </span>
                   <span style={badgeStyle(entry.source)}>
-                    {SOURCE_META[entry.source]?.label ?? entry.source}
+                    {metaFor(entry.source).label}
                   </span>
                 </div>
               ))}
@@ -1364,6 +1403,36 @@ function EditSlotDrawer({ open, slot, onClose }) {
       destructive
       typeToConfirm={slot.name}
     />
+    <ConfirmDialog
+      open={discardOpen}
+      onCancel={() => setDiscardOpen(false)}
+      onConfirm={() => { setDiscardOpen(false); onClose(); }}
+      title="Discard unsaved changes?"
+      message={
+        <span>
+          <span className="mono" style={{color: "var(--fg)"}}>{slot.name}</span> has
+          unsaved edits — closing the drawer discards them.
+        </span>
+      }
+      confirmLabel="Discard"
+    />
+    <ConfirmDialog
+      open={!!pendingSwap}
+      onCancel={() => setPendingSwap(null)}
+      onConfirm={() => {
+        const p = pendingSwap;
+        setPendingSwap(null);
+        if (p) fireSwap(p.id, p.label);
+      }}
+      title={`Swap model on running slot ${slot.name}?`}
+      message={
+        <span>
+          Loading <span className="mono" style={{color: "var(--fg)"}}>{pendingSwap?.label || ""}</span> cold-restarts
+          the container (~model-load seconds). The slot is unavailable while it reloads.
+        </span>
+      }
+      confirmLabel="Swap model"
+    />
     </>
   );
 }
@@ -1384,6 +1453,10 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
   // useQuery's own caching means useModels() costs ~nothing when closed.
   const modelsQuery = useModels();
   const hwQuery = useHardware();
+  // UI-5 (state-driven): a live-container pick is stashed here and confirmed
+  // through the shared ConfirmDialog before committing. Must be declared
+  // before the early return (rules-of-hooks).
+  const [pendingPick, setPendingPick] = useStateSM(null);
   if (!open) return null;
 
   const isContainer = slot.runtime === "container";
@@ -1393,25 +1466,27 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
   const compatible = compatibleModels(modelsQuery.data, { type: slot.type, backend: slot.backend });
 
   // N2: container swap = cold systemctl restart (not a hot in-place swap).
-  // Intercept onPick for container slots: show a confirm toast and fire
-  // the same onPick (which drives restart), so the parent card drives to
-  // "starting" state immediately. The parent's onSwapPick calls useSlotSwap
-  // which triggers a restart for container slots server-side.
-  const handlePick = (m) => {
+  // Intercept onPick for container slots: toast the restart and fire the same
+  // onPick (which drives restart), so the parent card drives to "starting"
+  // state immediately. The parent's onSwapPick calls useSlotSwap which
+  // triggers a restart for container slots server-side.
+  const commitPick = (m) => {
     if (isContainer) {
-      const name = slot.name;
-      const label = m.longName || m.id;
-      // UI-5: confirm before cold-restarting a LIVE container slot. Bail out
-      // (leaving the popover open) when the operator declines.
-      const live = slotButtonPhase(slot) === "running";
-      if (live && !window.confirm(`Swap model on running slot "${name}"? This cold-restarts the container (~model-load seconds).`)) return;
       window.__hal0Toast && window.__hal0Toast(
-        `Restarting ${name} to load ${label} — ~model-load seconds`,
+        `Restarting ${slot.name} to load ${m.longName || m.id} — ~model-load seconds`,
         "info"
       );
     }
     onPick(m);
     onClose();
+  };
+  const handlePick = (m) => {
+    // UI-5: confirm before cold-restarting a LIVE container slot. Cancelling
+    // the dialog leaves the popover open, same as declining the old
+    // window.confirm.
+    const live = slotButtonPhase(slot) === "running";
+    if (isContainer && live) { setPendingPick(m); return; }
+    commitPick(m);
   };
 
   return (
@@ -1461,6 +1536,23 @@ function InlineSwapPopover({ slot, open, onClose, onPick }) {
            onClick={() => { onClose(); window.location.hash = "#models"; }}>
         + Browse all models →
       </div>
+      <ConfirmDialog
+        open={!!pendingPick}
+        onCancel={() => setPendingPick(null)}
+        onConfirm={() => {
+          const m = pendingPick;
+          setPendingPick(null);
+          if (m) commitPick(m);
+        }}
+        title={`Swap model on running slot ${slot.name}?`}
+        message={
+          <span>
+            Loading <span className="mono" style={{color: "var(--fg)"}}>{pendingPick?.longName || pendingPick?.id || ""}</span> cold-restarts
+            the container (~model-load seconds). The slot is unavailable while it reloads.
+          </span>
+        }
+        confirmLabel="Swap model"
+      />
     </div>
   );
 }
@@ -1590,9 +1682,11 @@ function ImagePullBar({ pull }) {
         {label}
       </div>
       <div style={{height: 3, background: "var(--bg-2)", borderRadius: 2, overflow: "hidden"}}>
+        {/* Correct ARIA pattern: omit aria-valuenow entirely while the
+            layer count is unknown (indeterminate progressbar). */}
         <div
           role="progressbar"
-          aria-valuenow={pct ?? 0}
+          {...(pct !== null ? { "aria-valuenow": pct } : {})}
           aria-valuemin={0}
           aria-valuemax={100}
           style={{

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -13,6 +13,7 @@ import {
   useSlotLoad,
   useSlotSwap,
   useSlotEdit,
+  useSlotBackend,
   useSlotImagePull,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
@@ -110,9 +111,12 @@ function SlotImagePullBar({ slot }) {
         {label}
       </div>
       <div style={{height: 3, background: "var(--bg-2)", borderRadius: 2, overflow: "hidden"}}>
+        {/* The backend only reports image_status === "pulling" (no layer
+            progress on the slot payload), so this bar is INDETERMINATE:
+            per the ARIA progressbar pattern, aria-valuenow is omitted
+            entirely rather than pinned to a fabricated 0. */}
         <div
           role="progressbar"
-          aria-valuenow={0}
           aria-valuemin={0}
           aria-valuemax={100}
           aria-label={label}
@@ -145,6 +149,29 @@ function SlotCard({
   busy,
 }) {
   const { type, device, model, state, isDefault, coresident, metrics } = slot;
+  // ADR-0022: backend-mismatch remediation. The amber "≠ declared" chip now
+  // has a real affordance — a "Switch to <declared>" button that confirms
+  // (container restart) then POSTs /api/slots/{name}/backend with the
+  // declared backend. Fire-and-forget (mutate): the hook invalidates
+  // ['slots'] and the 5s poll reflects the restart.
+  const backendMut = useSlotBackend();
+  const [switchOpen, setSwitchOpen] = useStateS(false);
+  const declaredBackend = slot.declared_backend || slot.backend || device;
+  const onSwitchBackendConfirm = () => {
+    setSwitchOpen(false);
+    backendMut.mutate({ name: slot.name, backend: declaredBackend }, {
+      onSuccess: (resp) => {
+        const effective = resp?.effective_backend || resp?.actual_backend || declaredBackend;
+        window.__hal0Toast && window.__hal0Toast(
+          `${slot.name} backend → ${effective}`, "ok");
+      },
+      onError: (err) =>
+        window.__hal0Toast && window.__hal0Toast(
+          `${slot.name}: backend switch failed — ${err?.message || "see logs"}`, "warn"),
+    });
+    window.__hal0Toast && window.__hal0Toast(
+      `Switching ${slot.name} to ${declaredBackend} — restarting…`, "info");
+  };
   // Spec 1 / C3: a slot is enabled unless explicitly off. Disabled slots fade,
   // hide lifecycle buttons, and sort to the end of the grid (SlotsView).
   const enabled = slot.enabled !== false;
@@ -208,6 +235,7 @@ function SlotCard({
   })();
 
   return (
+    <>
     <div className={"slot" + statusClass + (swapOpen ? " swap-open" : "") + (enabled ? "" : " slot--disabled") + (liveWhileDisabled ? " slot--live" : "")}>
       <div className="slot-h">
         <IndicatorDot slot={slot} />
@@ -307,15 +335,31 @@ function SlotCard({
         {/* Backend mismatch (ADR-0022): amber chip surfaces the ACTUAL runtime
             backend when it differs from the declared one. Container slots are
             the only real slots, so this now renders alongside the image-tag
-            chip (previously trapped in the dead non-container branch). */}
+            chip (previously trapped in the dead non-container branch).
+            Clicking the chip or the paired button opens the switch-backend
+            confirm (container restart) — the chip is no longer advice-only. */}
         {slot.backend_mismatch && slot.actual_backend && (
-          <span
-            className={"chip dev-" + String(slot.actual_backend)}
-            style={{borderColor: "var(--warn-line)", background: "var(--warn-soft)"}}
-            title={`Declared ${slot.declared_backend || slot.backend || device} but running ${slot.actual_backend} — switch backend to reload`}
-          >
-            {slot.actual_backend} <span style={{color: "var(--warn)", marginLeft: 4}}>≠ declared</span>
-          </span>
+          <>
+            <button
+              type="button"
+              className={"chip dev-" + String(slot.actual_backend)}
+              style={{borderColor: "var(--warn-line)", background: "var(--warn-soft)", cursor: "pointer"}}
+              title={`Declared ${declaredBackend} but running ${slot.actual_backend} — click to switch back to ${declaredBackend} (restarts the container)`}
+              disabled={backendMut.isPending}
+              onClick={() => setSwitchOpen(true)}
+            >
+              {slot.actual_backend} <span style={{color: "var(--warn)", marginLeft: 4}}>≠ declared</span>
+            </button>
+            <button
+              type="button"
+              className="btn ghost sm"
+              style={{fontSize: 10, padding: "1px 6px"}}
+              disabled={backendMut.isPending}
+              onClick={() => setSwitchOpen(true)}
+            >
+              {backendMut.isPending ? "Switching…" : `Switch to ${declaredBackend}`}
+            </button>
+          </>
         )}
         {(() => {
           // Colour aligned to the slotIndicatorFromPhase() vocabulary
@@ -377,6 +421,23 @@ function SlotCard({
       </div>
       {errorMsg && <div style={{marginTop: 4}}><ErrorSlotCardBanner slot={slot} message={errorMsg} /></div>}
     </div>
+    <ConfirmDialog
+      open={switchOpen}
+      onCancel={() => setSwitchOpen(false)}
+      onConfirm={onSwitchBackendConfirm}
+      title={`Switch ${slot.name} to ${declaredBackend}?`}
+      message={
+        <span>
+          <span className="mono" style={{color: "var(--fg)"}}>{slot.name}</span> is running
+          on <span className="mono">{slot.actual_backend}</span> but is declared
+          as <span className="mono">{declaredBackend}</span>. Switching restarts the
+          container to reload on the declared backend (~model-load seconds); the slot
+          is unavailable while it reloads.
+        </span>
+      }
+      confirmLabel="Switch backend"
+    />
+    </>
   );
 }
 
@@ -397,11 +458,11 @@ function SlotListRow({ slot, onEdit }) {
     });
     window.__hal0Toast && window.__hal0Toast(`Restarting ${slot.name}…`, "info");
   };
-  const tps = type === "llm" ? `${metrics.toks || 0} t/s` :
-              type === "embedding" ? `${metrics.rpm} r/m` :
-              type === "transcription" ? `${metrics.xrt} xrt` :
-              type === "image" ? `${metrics.avg}s avg` :
-              `${metrics.rpm || 0} r/m`;
+  // Only tok/s is backed by a real slot-payload field. The legacy rpm/xrt/avg
+  // metrics were never populated by the backend (same reasoning as the card
+  // variant's dead-chip cleanup, W6) — non-llm rows show an em-dash instead
+  // of a fabricated 0.
+  const tps = type === "llm" ? `${metrics.toks || 0} t/s` : "—";
   return (
     <div className="slot-list-row" onClick={goEdit}>
       <IndicatorDot slot={slot} />
@@ -763,11 +824,9 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
     );
   }
 
-  const renderSlot = (s) => slotVariant === "list"
-    ? <SlotListRow key={s.name} slot={s} />
-    : slotVariant === "spec"
-      ? <SlotCard key={s.name} slot={s} />
-      : <SlotCard key={s.name} slot={s} />;
+  // (The old `renderSlot` helper was dead code — renderGroup below is the
+  // only card/list dispatcher, and its "spec"/"list" branches rendered
+  // handler-less, inert cards. Removed.)
 
   // C6: stable-sort enabled slots before disabled ones, preserving the
   // existing order within each bucket. Array.prototype.sort is stable, so a
@@ -807,13 +866,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
           <div className="rule" />
         </div>
         <div className={"slots-grid" + (slotVariant === "spec" ? " spec" : "") + (opts.quarter ? " quarter" : "")}>
-          {items.map(s => {
-            // Demo: show error banner on a single slot if a banner-state would fire
-            const errMsg = (window.__hal0Banners && window.__hal0Banners.get && window.__hal0Banners.get()["model-missing"] && s.name === "primary")
-              ? "sha256 mismatch on shard 2 — verify the model on /models then retry"
-              : null;
-            return slotWithState(s, errMsg);
-          })}
+          {items.map(s => slotWithState(s))}
         </div>
       </section>
     );

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -12,7 +12,7 @@
 // real model pull job; Export downloads the portable envelope; Import / New /
 // Snapshot reuse the existing flows. Styles: .stk-* in stacks.css.
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import {
   useStacks,
   useStackCreate,
@@ -26,36 +26,69 @@ import {
 import { useModels } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useSlots } from '@/api/hooks/useSlots'
+import { useMetaEnums } from '@/api/hooks/useMeta'
+import { deviceClassForToken, profileDeviceClass } from '@/lib/deviceMeta'
 import { api } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
+import { slotIndicatorFromPhase } from './slot-status.js'
 
-// Device hue, for the editor selectors.
-const DEVICE_META = {
-  'gpu-rocm':   { label: 'ROCm',   color: 'var(--dev-rocm)' },
-  'gpu-vulkan': { label: 'Vulkan', color: 'var(--dev-vulkan)' },
-  npu:          { label: 'NPU',    color: 'var(--dev-npu)' },
-  cpu:          { label: 'CPU',    color: 'var(--dev-cpu)' },
-};
-const DEVICES = Object.keys(DEVICE_META);
+// Device hue + label map for the editor selectors — built from meta.devices
+// (GET /api/meta/enums via useMetaEnums, static fallback when the endpoint is
+// absent). Includes the img/ComfyUI device, previously missing here, so image
+// slots can be expressed in stacks. Hue token: the GPU devices' legacy backend
+// (rocm/vulkan), else the device_class (npu/cpu/img) — matches the shared
+// --dev-* palette.
+function buildDeviceMeta(enums) {
+  const out = {};
+  for (const d of enums.devices) {
+    const hue = d.legacy_backend || d.device_class || 'cpu';
+    out[d.id] = {
+      label: d.label || d.id,
+      color: `var(--dev-${hue})`,
+      device_class: d.device_class,
+      recommended: !!d.recommended,
+      description: d.description || '',
+      default_profile: d.default_profile || null,
+    };
+  }
+  return out;
+}
 
 // `NAME_RE` (slug regex) and `toast` are shared globals from primitives.jsx.
 
 const BLANK_SLOT = { slot: '', model: '', device: 'gpu-rocm', profile: '', mtp: false, capabilities: [] };
 const BLANK = { name: '', description: '', icon: '', tags: '', slots: [{ ...BLANK_SLOT }] };
 
-const DOT_STATES = new Set(['serving', 'ready', 'warming', 'idle', 'offline']);
-function dotCls(state) { return DOT_STATES.has(state) ? state : 'offline'; }
+// Live-slot → dot class, derived from the SHARED slot-status classifier
+// (slot-status.js) instead of the old local DOT_STATES re-derivation, so the
+// hero dots agree with every other slot surface (recency + health gates
+// included). `stale` renders as the `ready` dot, same mapping the Inference
+// pane uses; a missing live slot is offline.
+function liveDotCls(liveSlot) {
+  if (!liveSlot) return 'offline';
+  const cls = slotIndicatorFromPhase(liveSlot).cls;
+  if (cls === 'stale') return 'ready';
+  return cls; // serving | warming | error | offline
+}
 
 // ── status dot ────────────────────────────────────────────────────────────────
 
 function D({ state, sz = 6 }) {
-  return <span className={'dot ' + dotCls(state)} style={{ width: sz, height: sz, flexShrink: 0 }} />;
+  return <span className={'dot ' + (state || 'offline')} style={{ width: sz, height: sz, flexShrink: 0 }} />;
 }
 
 // ── view-model: project a stack into the Focus shape ──────────────────────────
-// slots: [{ name, model, profile, state, available }]. `state` is the live slot
-// status for the active stack, "offline" otherwise. `available` is false only
-// when a referenced model isn't in the local registry (→ pull affordance).
+// slots: [{ name, model, profile, device, state, available }]. `profile` and
+// `device` are kept as SEPARATE fields (the old VM conflated them into one
+// `profile: sl.profile || sl.device` string); displays that want a single
+// line join them via profileLine(). `state` is the live slot status for the
+// active stack (shared slot-status classifier), "offline" otherwise.
+// `available` is false only when a referenced model isn't in the local
+// registry (→ pull affordance).
+
+function profileLine(s) {
+  return [s.profile, s.device].filter(Boolean).join(' · ');
+}
 
 function buildVM(stack, modelSet, liveByName, activeSlug) {
   const active = stack.slug === activeSlug;
@@ -65,8 +98,9 @@ function buildVM(stack, modelSet, liveByName, activeSlug) {
       slots.push({
         name: sl.slot,
         model: sl.model,
-        profile: sl.profile || sl.device || '',
-        state: active ? dotCls(liveByName[sl.slot]?.status) : 'offline',
+        profile: sl.profile || '',
+        device: sl.device || '',
+        state: active ? liveDotCls(liveByName[sl.slot]) : 'offline',
         available: modelSet.has(sl.model),
       });
     }
@@ -75,7 +109,8 @@ function buildVM(stack, modelSet, liveByName, activeSlug) {
       slots.push({
         name: row.child,
         model: row.model,
-        profile: row.device || '',
+        profile: '',
+        device: row.device || '',
         state: 'offline',
         available: modelSet.has(row.model),
       });
@@ -213,7 +248,7 @@ function HeroPanel({ vm, isCustom, onPull, onExport, onReapply, onEdit }) {
               <span className="stk-hs-name">{s.name}</span>
               <span className={'stk-hs-state ' + s.state}>{s.available ? s.state : 'no model'}</span>
             </div>
-            <div className="stk-hs-profile">{s.profile}</div>
+            <div className="stk-hs-profile">{profileLine(s)}</div>
             <div className="stk-hs-model">{s.model}</div>
           </div>
         ))}
@@ -366,6 +401,9 @@ function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
   const models = useModels().data || [];
   const profiles = useProfiles().data || [];
   const liveSlots = (useSlots().data || []).filter(s => (s.kind ?? 'local') === 'local');
+  const enums = useMetaEnums();
+  const deviceMeta = useMemo(() => buildDeviceMeta(enums), [enums]);
+  const deviceIds = Object.keys(deviceMeta);
 
   const create = useStackCreate();
   const update = useStackUpdate();
@@ -487,6 +525,29 @@ function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
           </datalist>
           {v.slots.map((s, i) => {
             const isNew = !!s.slot && !liveSlots.some(ls => ls.name === s.slot);
+            const dm = deviceMeta[s.device];
+            // Profile compatibility for this row's device: match the
+            // profile's device_class (explicit, or gpu inferred from its
+            // rocm/vulkan backend — same rule as profiles.jsx backendOf)
+            // against the picked device's class. Unknown class on either
+            // side never filters. Incompatible profiles stay listed as a
+            // disabled escape hatch (and the current pick is never trapped).
+            const rowClass = dm?.device_class ?? deviceClassForToken(s.device, enums);
+            const compatProfiles = [];
+            const incompatProfiles = [];
+            for (const p of profiles) {
+              const pc = profileDeviceClass(p);
+              (!pc || !rowClass || pc === rowClass ? compatProfiles : incompatProfiles).push(p);
+            }
+            // MTP gate — same rule as the slot drawer (slot-modals.jsx):
+            // the picked model must carry the "mtp" tag AND the row must run
+            // the rocm backend. A pre-existing mtp=true row stays visible so
+            // it can be turned off.
+            const rowModel = models.find(m => m.id === s.model);
+            const mtpCapable = Array.isArray(rowModel?.tags) && rowModel.tags.includes('mtp');
+            const rowIsRocm = (enums.devices.find(d => d.id === s.device)?.legacy_backend === 'rocm')
+              || String(s.device || '').includes('rocm');
+            const showMtp = (mtpCapable && rowIsRocm) || !!s.mtp;
             return (
               <div className="st-slot-card" key={i}>
                 <div className="st-slot-head">
@@ -508,24 +569,57 @@ function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
                   </label>
                   <label className="st-fld">
                     <span className="st-fld-lbl">Device</span>
-                    <select className="pf-input mono" value={s.device} onChange={e => setSlot(i, 'device', e.target.value)}>
-                      {DEVICES.map(d => <option key={d} value={d}>{DEVICE_META[d].label}</option>)}
+                    <select className="pf-input mono" value={s.device}
+                      title={dm?.description || undefined}
+                      onChange={e => setSlot(i, 'device', e.target.value)} data-testid={`st-slot-device-${i}`}>
+                      {/* keep an out-of-vocab persisted device selectable */}
+                      {s.device && !deviceIds.includes(s.device) && (
+                        <option value={s.device}>{s.device}</option>
+                      )}
+                      {deviceIds.map(d => (
+                        <option key={d} value={d} title={deviceMeta[d].description}>
+                          {deviceMeta[d].label}{deviceMeta[d].recommended ? ' ★' : ''}
+                        </option>
+                      ))}
                     </select>
+                    {dm && (dm.recommended || dm.description) && (
+                      <span className="mono" style={{ fontSize: 9.5, lineHeight: 1.4, marginTop: 2, color: dm.recommended ? 'var(--ok)' : 'var(--fg-5)' }}>
+                        {dm.recommended ? '★ recommended' : dm.description}
+                      </span>
+                    )}
                   </label>
                   <label className="st-fld">
                     <span className="st-fld-lbl">Profile</span>
-                    <select className="pf-input mono" value={s.profile} onChange={e => setSlot(i, 'profile', e.target.value)}>
+                    <select className="pf-input mono" value={s.profile} onChange={e => setSlot(i, 'profile', e.target.value)} data-testid={`st-slot-profile-${i}`}>
                       <option value="">— profile —</option>
-                      {profiles.map(p => <option key={p.name} value={p.name}>{p.name}</option>)}
+                      {compatProfiles.map(p => <option key={p.name} value={p.name}>{p.name}</option>)}
+                      {incompatProfiles.length > 0 && (
+                        <optgroup label={`— other device class${rowClass ? ` (not ${rowClass})` : ''} —`}>
+                          {incompatProfiles.map(p => (
+                            /* escape hatch: incompatible profiles are listed but
+                               disabled; the row's CURRENT pick stays enabled so a
+                               pre-existing binding is never trapped. */
+                            <option key={p.name} value={p.name} disabled={p.name !== s.profile}>
+                              {p.name}{profileDeviceClass(p) ? ` · ${profileDeviceClass(p)}` : ''}
+                            </option>
+                          ))}
+                        </optgroup>
+                      )}
                     </select>
                   </label>
-                  <div className="st-fld st-fld-mtp">
-                    <span className="st-fld-lbl">Speculative decode</span>
-                    <button type="button" className={'pf-switch sm' + (s.mtp ? ' on' : '')}
-                      onClick={() => setSlot(i, 'mtp', !s.mtp)} role="switch" aria-checked={s.mtp} title="MTP speculative decode">
-                      <span className="pf-switch-knob" /><span className="mono">MTP</span>
-                    </button>
-                  </div>
+                  {showMtp && (
+                    <div className="st-fld st-fld-mtp">
+                      <span className="st-fld-lbl">Speculative decode</span>
+                      <button type="button" className={'pf-switch sm' + (s.mtp ? ' on' : '')}
+                        onClick={() => setSlot(i, 'mtp', !s.mtp)} role="switch" aria-checked={s.mtp}
+                        title={mtpCapable && rowIsRocm
+                          ? 'MTP speculative decode'
+                          : 'MTP persisted on this row — model tag/backend no longer qualify (mtp tag + rocm required)'}
+                        data-testid={`st-slot-mtp-${i}`}>
+                        <span className="pf-switch-knob" /><span className="mono">MTP</span>
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
             );

--- a/ui/src/lib/deviceMeta.ts
+++ b/ui/src/lib/deviceMeta.ts
@@ -1,0 +1,300 @@
+// Shared device / backend taxonomy helpers (meta-enums aware).
+//
+// Single source of truth for the device→class→backend vocabulary the dash
+// panes used to hardcode (devKind was copied verbatim into slot-list.jsx,
+// npu-pane.jsx and inference-pane.jsx; profiles/stacks each carried their own
+// BACKEND_META / DEVICE_META tables). All helpers accept an optional
+// `MetaEnums` (from GET /api/meta/enums via useMeta) and fall back to
+// `META_ENUMS_FALLBACK` — a typed snapshot of today's known values — so every
+// consumer keeps working against an older backend or in mock mode.
+//
+// This module is import-cycle-safe by design: it must NOT import from
+// src/api/* (mock.ts and the hooks both import from here).
+
+export interface MetaDevice {
+  /** Device enum id — SlotConfig.device vocabulary: gpu-rocm | gpu-vulkan | cpu | npu | img. */
+  id: string
+  /** Human label ("ROCm", "FLM · NPU"). */
+  label: string
+  /** Silicon class: gpu | cpu | npu | img. */
+  device_class: string
+  /** Seed profile preselected for this device (DEVICE_DEFAULT_PROFILES). */
+  default_profile: string | null
+  /** ProfileConfig.backend value for GPU devices (rocm|vulkan); null off-GPU. */
+  legacy_backend: string | null
+  /** True for the device the project recommends (gpu-rocm on Strix Halo). */
+  recommended: boolean
+  /** One-line operator guidance ("Vulkan fallback — …"). */
+  description: string
+}
+
+export interface MetaEnums {
+  devices: MetaDevice[]
+  backends: string[]
+  selectable_backends: string[]
+  device_classes: string[]
+  slot_types: string[]
+  model_capabilities: string[]
+  capability_aliases: Record<string, string>
+  model_backends: string[]
+  runtime_families: string[]
+  backend_to_device: Record<string, string>
+  device_default_profiles: Record<string, string>
+}
+
+/**
+ * Static fallback — today's known values, kept in step with the backend:
+ *   config/schema.py    DeviceLiteral, BACKEND_TO_DEVICE, DEVICE_DEFAULT_PROFILES,
+ *                       SEED_PROFILES (device_class/backend/img)
+ *   slots/manager.py    _VALID_SLOT_TYPES
+ *   registry/model.py   capabilities + backends vocab
+ * Enums are static per release, so this snapshot only drifts across upgrades —
+ * and then only until the live /api/meta/enums response takes over.
+ */
+export const META_ENUMS_FALLBACK: MetaEnums = Object.freeze({
+  devices: [
+    {
+      id: 'gpu-rocm',
+      label: 'ROCm',
+      device_class: 'gpu',
+      default_profile: 'rocm',
+      legacy_backend: 'rocm',
+      recommended: true,
+      description: 'AMD ROCm — best throughput on Strix Halo (recommended)',
+    },
+    {
+      id: 'gpu-vulkan',
+      label: 'Vulkan',
+      device_class: 'gpu',
+      default_profile: 'vulkan',
+      legacy_backend: 'vulkan',
+      recommended: false,
+      description: 'Vulkan fallback — broad compatibility, lower throughput than ROCm',
+    },
+    {
+      id: 'npu',
+      label: 'FLM · NPU',
+      device_class: 'npu',
+      default_profile: 'flm',
+      legacy_backend: null,
+      recommended: false,
+      description: 'FLM on the XDNA NPU — coresident chat / ASR / embed stack',
+    },
+    {
+      id: 'cpu',
+      label: 'CPU',
+      device_class: 'cpu',
+      default_profile: 'cpu-llm',
+      legacy_backend: null,
+      recommended: false,
+      description: 'CPU-only llama-server — no GPU required',
+    },
+    {
+      id: 'img',
+      label: 'ComfyUI · IMG',
+      device_class: 'img',
+      default_profile: 'comfyui',
+      legacy_backend: null,
+      recommended: false,
+      description: 'ComfyUI image generation (GPU held via the arbiter)',
+    },
+  ],
+  backends: ['rocm', 'vulkan', 'cpu', 'flm', 'moonshine', 'kokoro'],
+  selectable_backends: ['rocm', 'vulkan', 'cpu', 'auto'],
+  device_classes: ['gpu', 'cpu', 'npu', 'img'],
+  slot_types: ['llm', 'embedding', 'reranking', 'transcription', 'tts', 'image'],
+  // Canonical model-capability vocabulary (registry vocab + the routing tags
+  // the add-model surfaces expose). Aliases below normalize legacy spellings.
+  model_capabilities: [
+    'chat',
+    'tool-calling',
+    'vision',
+    'embed',
+    'rerank',
+    'asr',
+    'tts',
+    'image',
+    'edit',
+  ],
+  capability_aliases: {
+    embeddings: 'embed',
+    embedding: 'embed',
+    reranking: 'rerank',
+    transcription: 'asr',
+    stt: 'asr',
+  },
+  model_backends: ['rocm', 'vulkan', 'cpu', 'cuda', 'flm', 'moonshine', 'kokoro'],
+  runtime_families: ['llamacpp', 'flm', 'whispercpp', 'sdcpp', 'kokoro', 'comfyui'],
+  backend_to_device: {
+    rocm: 'gpu-rocm',
+    vulkan: 'gpu-vulkan',
+    cpu: 'cpu',
+    flm: 'npu',
+    moonshine: 'cpu',
+    kokoro: 'cpu',
+  },
+  device_default_profiles: {
+    'gpu-rocm': 'rocm',
+    'gpu-vulkan': 'vulkan',
+    cpu: 'cpu-llm',
+    npu: 'flm',
+    img: 'comfyui',
+  },
+})
+
+const _isFilledArray = (v: unknown): v is unknown[] => Array.isArray(v) && v.length > 0
+const _isFilledRecord = (v: unknown): v is Record<string, string> =>
+  !!v && typeof v === 'object' && !Array.isArray(v) && Object.keys(v as object).length > 0
+
+/**
+ * Merge a (possibly partial / empty / older-backend) /api/meta/enums payload
+ * over the static fallback. Any missing or empty field falls back per-key, so
+ * `resolveMetaEnums({})` === the fallback and a partial payload never leaves a
+ * consumer with an empty vocabulary.
+ */
+export function resolveMetaEnums(data?: Partial<MetaEnums> | null): MetaEnums {
+  if (!data || typeof data !== 'object') return META_ENUMS_FALLBACK
+  const f = META_ENUMS_FALLBACK
+  return {
+    devices: _isFilledArray(data.devices) ? (data.devices as MetaDevice[]) : f.devices,
+    backends: _isFilledArray(data.backends) ? (data.backends as string[]) : f.backends,
+    selectable_backends: _isFilledArray(data.selectable_backends)
+      ? (data.selectable_backends as string[])
+      : f.selectable_backends,
+    device_classes: _isFilledArray(data.device_classes)
+      ? (data.device_classes as string[])
+      : f.device_classes,
+    slot_types: _isFilledArray(data.slot_types) ? (data.slot_types as string[]) : f.slot_types,
+    model_capabilities: _isFilledArray(data.model_capabilities)
+      ? (data.model_capabilities as string[])
+      : f.model_capabilities,
+    capability_aliases: _isFilledRecord(data.capability_aliases)
+      ? data.capability_aliases
+      : f.capability_aliases,
+    model_backends: _isFilledArray(data.model_backends)
+      ? (data.model_backends as string[])
+      : f.model_backends,
+    runtime_families: _isFilledArray(data.runtime_families)
+      ? (data.runtime_families as string[])
+      : f.runtime_families,
+    backend_to_device: _isFilledRecord(data.backend_to_device)
+      ? data.backend_to_device
+      : f.backend_to_device,
+    device_default_profiles: _isFilledRecord(data.device_default_profiles)
+      ? data.device_default_profiles
+      : f.device_default_profiles,
+  }
+}
+
+/** Chip/palette token vocabulary (drives .dev-* / .sl-dev-* / .dchip classes). */
+export type DevKind = 'rocm' | 'vulkan' | 'cpu' | 'npu'
+
+/**
+ * Normalize a slot `device` (or backend token) to the chip device-kind token.
+ * Replaces the three per-pane copies (slot-list / npu-pane / inference-pane).
+ * Meta-aware: unknown tokens are folded through `backend_to_device` (e.g. an
+ * "flm" backend string classifies as npu) before defaulting to cpu.
+ */
+export function devKind(device?: string | null, meta: MetaEnums = META_ENUMS_FALLBACK): DevKind {
+  const d = String(device || '').toLowerCase()
+  if (!d) return 'cpu'
+  if (d === 'npu') return 'npu'
+  if (d === 'cpu') return 'cpu'
+  if (d.includes('vulkan')) return 'vulkan'
+  if (d.includes('rocm') || d.startsWith('gpu')) return 'rocm'
+  const mapped = meta.backend_to_device[d]
+  if (mapped && mapped !== d) return devKind(mapped, meta)
+  return 'cpu'
+}
+
+/** Map a capability alias (embeddings/reranking/transcription/…) to its canonical id. */
+export function canonicalCapability(cap: string, meta: MetaEnums = META_ENUMS_FALLBACK): string {
+  const c = String(cap || '').trim()
+  return meta.capability_aliases[c] ?? c
+}
+
+/** Canonicalize + de-dupe a capability list (order of first occurrence wins). */
+export function canonicalCapabilities(
+  caps: unknown,
+  meta: MetaEnums = META_ENUMS_FALLBACK,
+): string[] {
+  const list = Array.isArray(caps) ? caps : []
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const c of list) {
+    const canon = canonicalCapability(String(c), meta)
+    if (canon && !seen.has(canon)) {
+      seen.add(canon)
+      out.push(canon)
+    }
+  }
+  return out
+}
+
+/** Look up a device enum row by id ("gpu-rocm"). */
+export function deviceById(
+  id?: string | null,
+  meta: MetaEnums = META_ENUMS_FALLBACK,
+): MetaDevice | undefined {
+  const key = String(id || '').toLowerCase()
+  return meta.devices.find((d) => d.id === key)
+}
+
+/**
+ * Resolve any device/backend token (device id, backend name, legacy device
+ * string, or a bare device-class) to its device_class — gpu | cpu | npu | img.
+ * Returns null for an empty token.
+ */
+export function deviceClassForToken(
+  token?: string | null,
+  meta: MetaEnums = META_ENUMS_FALLBACK,
+): string | null {
+  const t = String(token || '').toLowerCase()
+  if (!t) return null
+  if (meta.device_classes.includes(t) && !deviceById(t, meta)) return t
+  const devId = meta.backend_to_device[t] ?? t
+  const dev = deviceById(devId, meta)
+  if (dev) return dev.device_class
+  if (meta.device_classes.includes(t)) return t
+  const kind = devKind(t, meta)
+  return kind === 'rocm' || kind === 'vulkan' ? 'gpu' : kind
+}
+
+/**
+ * Device classes a model can run on, derived from its `backends` list (with a
+ * legacy `device` string as fallback input). Empty set = unknown → callers
+ * should treat as compatible-with-everything.
+ */
+export function modelDeviceClasses(
+  backends: unknown,
+  legacyDevice?: string | null,
+  meta: MetaEnums = META_ENUMS_FALLBACK,
+): Set<string> {
+  const tokens =
+    Array.isArray(backends) && backends.length > 0
+      ? (backends as string[])
+      : legacyDevice
+        ? [legacyDevice]
+        : []
+  const out = new Set<string>()
+  for (const t of tokens) {
+    const cls = deviceClassForToken(t, meta)
+    if (cls) out.add(cls)
+  }
+  return out
+}
+
+/**
+ * A profile's device class: the explicit `device_class` when the API emits it,
+ * else inferred from the GPU `backend` field (#751), else null (= unknown —
+ * treat as compatible).
+ */
+export function profileDeviceClass(p?: {
+  device_class?: string | null
+  backend?: string | null
+} | null): string | null {
+  if (!p) return null
+  if (p.device_class) return String(p.device_class)
+  if (p.backend === 'rocm' || p.backend === 'vulkan') return 'gpu'
+  return null
+}

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -27,6 +27,19 @@ export interface ApiModelRaw {
   hf_repo?: string
   path?: string
   type?: string | null
+  // ── Legacy HAL0_DATA mock shape (data.jsx fixtures / mock.ts 404
+  // fallback). Real /api/models rows never carry these; the normalizer
+  // tolerates them so mock mode keeps working through the same code path.
+  /** Legacy alias of `capabilities`. */
+  labels?: string[]
+  /** Legacy pre-derived device token (rocm|vulkan|cpu|npu|…). */
+  device?: string
+  /** Legacy pre-derived display name. */
+  longName?: string
+  /** Legacy pre-formatted human size ("18.8 GB"). */
+  size?: string
+  /** Legacy pre-derived repo coordinate. */
+  repo?: string
   [k: string]: unknown
 }
 
@@ -40,7 +53,7 @@ export interface NormalizedModel extends ApiModelRaw {
 
 function deriveType(caps: string[]): SlotType {
   if (caps.includes('chat') || caps.includes('coding') || caps.includes('tool-calling') || caps.includes('vision')) return 'llm'
-  if (caps.includes('rerank')) return 'reranking'
+  if (caps.includes('rerank') || caps.includes('reranking')) return 'reranking'
   if (caps.includes('embed') || caps.includes('embeddings')) return 'embedding'
   if (caps.includes('transcription') || caps.includes('asr')) return 'transcription'
   if (caps.includes('tts')) return 'tts'
@@ -48,14 +61,14 @@ function deriveType(caps: string[]): SlotType {
   return ''
 }
 
-function deriveDevice(backends: string[]): string {
+export function deriveDevice(backends: string[]): string {
   if (backends.includes('rocm')) return 'rocm'
   if (backends.includes('vulkan')) return 'vulkan'
   if (backends.includes('cpu')) return 'cpu'
   return backends[0] || ''
 }
 
-function formatSize(b: number): string {
+export function formatSize(b: number): string {
   if (!b) return '—'
   if (b < 1024 ** 2) return `${(b / 1024).toFixed(1)} KB`
   if (b < 1024 ** 3) return `${(b / 1024 ** 2).toFixed(1)} MB`
@@ -81,15 +94,24 @@ function deriveRepo(m: ApiModelRaw): string {
   return ''
 }
 
+// Accepts BOTH shapes: the registry/API shape (capabilities + backends +
+// size_bytes + name + hf_repo) and the legacy HAL0_DATA seed shape
+// (labels + device + size + longName + repo + type). Local dev without a
+// backend falls back via src/api/mock.ts to HAL0_DATA.models, and the
+// γ-suite hits that fallback when fetch fails before page.route catches.
+// Explicit legacy fields win; API fields are derived otherwise. Also
+// idempotent — normalizing an already-normalized row is a no-op.
 export function normalizeApiModel(m: ApiModelRaw): NormalizedModel {
-  const caps = Array.isArray(m.capabilities) ? m.capabilities : []
+  const caps = Array.isArray(m.capabilities)
+    ? m.capabilities
+    : Array.isArray(m.labels) ? m.labels : []
   const backends = Array.isArray(m.backends) ? m.backends : []
   return {
     ...m,
-    type: deriveType(caps),
-    device: deriveDevice(backends),
-    longName: m.name || m.id,
-    size: formatSize(m.size_bytes || 0),
-    repo: deriveRepo(m),
+    type: typeof m.type === 'string' && m.type ? (m.type as SlotType) : deriveType(caps),
+    device: typeof m.device === 'string' && m.device ? m.device : deriveDevice(backends),
+    longName: (typeof m.longName === 'string' && m.longName) || m.name || m.id,
+    size: typeof m.size === 'string' && m.size ? m.size : formatSize(m.size_bytes || 0),
+    repo: (typeof m.repo === 'string' && m.repo) || deriveRepo(m),
   }
 }

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -62,13 +62,23 @@ function formatSize(b: number): string {
   return `${(b / 1024 ** 3).toFixed(2)} GB`
 }
 
+// A row `/api/models` aggregated from an upstream provider's `/v1/models`
+// rather than the local registry: advertised-only, never on this host's
+// disk, routed by the dispatcher to `m.upstream`. FLM/NPU rows also carry
+// `upstream` ("npu") but are installed host-side, so the `installed` check
+// keeps them local.
+export function isUpstreamModel(m: ApiModelRaw): boolean {
+  return !m.installed && typeof m.upstream === 'string' && m.upstream !== ''
+}
+
 // Coordinate shown under a model's name. We standardize on the HuggingFace
 // `<org>/<repo>` style and NEVER surface a raw `/mnt/ai-models/…/x.gguf`
 // filesystem path (which leaked through the old `hf_repo || path` fallback):
 //   1. an explicit `hf_repo` wins;
 //   2. else reconstruct coords from a HF cache path
 //      (`…/models--<org>--<repo>/snapshots/<sha>/…` → `<org>/<repo>`);
-//   3. else it's a genuinely local model → a clean `local/<id>` coordinate.
+//   3. else an upstream-advertised row → name the provider, never `local/…`;
+//   4. else it's a genuinely local model → a clean `local/<id>` coordinate.
 function deriveRepo(m: ApiModelRaw): string {
   if (typeof m.hf_repo === 'string' && m.hf_repo) return m.hf_repo
   const path = typeof m.path === 'string' ? m.path : ''
@@ -77,6 +87,7 @@ function deriveRepo(m: ApiModelRaw): string {
     const parts = cacheMatch[1].split('--')
     if (parts.length >= 2) return `${parts[0]}/${parts.slice(1).join('--')}`
   }
+  if (isUpstreamModel(m)) return `via ${m.upstream}`
   if (m.id) return `local/${m.id}`
   return ''
 }

--- a/ui/tests/e2e/specs/models-upstream-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-upstream-v3.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * models-upstream-v3 — upstream-advertised rows (aggregated by
+ * GET /api/models from a provider's /v1/models: installed=false +
+ * upstream=<name>) must be clearly identified as remote, not local:
+ *
+ *   - their own "Upstream · remote" catalog section (not user.*),
+ *   - an "upstream · <name>" chip instead of the ns chip,
+ *   - an origin cell in the detail meta grid,
+ *   - no Pull affordance (there is no HF source — pulls would 422),
+ *   - excluded from the create-slot model picker (a slot binds a
+ *     local file path these rows don't have).
+ *
+ * Forced-mock note: VITE_MOCK_HAL0 short-circuits page.route for
+ * /api/models, so the upstream fixture row is injected by intercepting
+ * the `window.HAL0_DATA = …` assignment (data.jsx) via addInitScript —
+ * the mock layer reads HAL0_DATA.models lazily on every fetch.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const UPSTREAM_ROW = {
+  id: 'meta-llama/llama-3.3-70b-instruct',
+  name: 'meta-llama/llama-3.3-70b-instruct',
+  object: 'model',
+  created: 1751600000,
+  installed: false,
+  owned_by: 'openrouter',
+  upstream: 'openrouter',
+  ns: 'pulled',
+  capabilities: ['chat'],
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((row) => {
+    let stored: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get: () => stored,
+      set: (v) => {
+        if (v && Array.isArray(v.models)) v.models = [...v.models, row]
+        stored = v
+      },
+    })
+  }, UPSTREAM_ROW)
+})
+
+test.describe('Models v3 — upstream-advertised rows (/models)', () => {
+  test('upstream rows get their own section + upstream chip, never user.*', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(
+      page.locator('.mdl-section-label', { hasText: 'Upstream · remote' }),
+    ).toBeVisible()
+
+    const row = page.locator('.mdl-row', { hasText: 'llama-3.3-70b-instruct' })
+    await expect(row).toBeVisible()
+    await expect(row.locator('.chip.info')).toHaveText('upstream')
+
+    // The catalog header counts the upstream bucket explicitly.
+    await expect(page.locator('.mdl-list-h .right')).toContainText('1 upstream')
+  })
+
+  test('detail pane shows origin=upstream and no Pull affordance', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.mdl-row', { hasText: 'llama-3.3-70b-instruct' }).click()
+
+    const detail = page.locator('.mdl-detail')
+    await expect(detail.locator('.mdl-detail-h .chip.info')).toHaveText('upstream · openrouter')
+    // Meta grid origin cell names the provider.
+    await expect(
+      detail.locator('.mdl-detail-meta > div', { hasText: 'origin' }).locator('.v'),
+    ).toHaveText('upstream · openrouter')
+    // No Pull / View-on-HF — the actions area explains the remote origin.
+    await expect(detail.locator('button', { hasText: 'Pull' })).toHaveCount(0)
+    await expect(detail.locator('button', { hasText: 'View on HF' })).toHaveCount(0)
+    await expect(detail.locator('.mdl-detail-actions')).toContainText('not stored on this host')
+  })
+
+  test('local not-installed rows keep the ns chip + Pull button (control)', async ({ page }) => {
+    await page.goto('/#models')
+    // HAL0_DATA seeds qwen3.5-9b as installed=false ns=blessed — a local
+    // pullable row must be untouched by the upstream split.
+    const row = page.locator('.mdl-row', { hasText: 'Qwen3.5-9B' })
+    await expect(row).toBeVisible()
+    await expect(row.locator('.chip.info')).toHaveCount(0)
+    await row.click()
+    await expect(
+      page.locator('.mdl-detail .mdl-detail-meta > div', { hasText: 'origin' }).locator('.v'),
+    ).toHaveText('local')
+    await expect(page.locator('.mdl-detail button', { hasText: 'Pull' })).toBeVisible()
+  })
+
+  test('create-slot model picker excludes upstream-advertised rows', async ({ page }) => {
+    await page.goto('/#slots')
+    await page.locator('.view .vh button:has-text("New slot")').click()
+    const modal = page.locator('.modal, [role="dialog"]').last()
+    await expect(modal).toBeVisible()
+    // Control: a local not-installed llm row is offered ("will pull")…
+    await expect(modal.locator('option', { hasText: 'Qwen3.5-9B' })).toHaveCount(1)
+    // …but the upstream-advertised llm row is not.
+    await expect(modal.locator('option', { hasText: 'llama-3.3-70b-instruct' })).toHaveCount(0)
+  })
+})

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -5,8 +5,10 @@
  *   C3. enabled toggle on the slot CARD → PUT /config { enabled } + fade.
  *   C4. enable_thinking toggle in the edit DRAWER (llm slots only) →
  *       PUT /config { enable_thinking } instantly.
- *   C5. n_gpu_layers in the drawer Advanced section is READ-ONLY —
- *       profile-owned; Save ships ctx_size via PATCH /defaults instead.
+ *   C5. n_gpu_layers in the drawer Advanced section is an EDITABLE per-slot
+ *       override persisted via PATCH /defaults ([model].n_gpu_layers);
+ *       -1/empty = unset (null on the wire) and an untouched field never
+ *       rides the PATCH. ctx_size shares the same PATCH.
  *   C6. enabled slots sort before disabled ones in the grid.
  *
  * The dashboard renders the slot LIST from in-bundle HAL0_DATA
@@ -87,7 +89,7 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(page.locator('.drawer .form-row', { hasText: 'Reasoning' })).toHaveCount(0)
   })
 
-  test('C5 — n_gpu_layers is read-only, owned by the profile', async ({ page }) => {
+  test('C5 — n_gpu_layers is editable with the unset helper text', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
 
     await page.goto('/#slots/primary')
@@ -95,8 +97,51 @@ test.describe('Slot edit controls (/slots)', () => {
     await page.locator('.drawer details.adv-disclosure summary').click()
     const row = page.locator('.drawer .form-row', { hasText: 'n_gpu_layers' })
     await expect(row).toBeVisible()
-    await expect(row.locator('.form-lbl .sub')).toContainText('defined by profile')
-    await expect(row.locator('input')).toHaveAttribute('readonly', '')
+    await expect(row.locator('.form-lbl .sub')).toContainText('-1 / empty = use model default / profile')
+    const input = page.getByTestId('n-gpu-layers-input')
+    await expect(input).not.toHaveAttribute('readonly', '')
+    await expect(input).toHaveValue('-1')
+  })
+
+  test('C5 — editing n_gpu_layers Save PATCHes /defaults { n_gpu_layers }', async ({ page }) => {
+    const patches: any[] = []
+    await page.route('**/api/slots/primary/defaults', async (route) => {
+      patches.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/config', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await seedSlots(page, [PRIMARY, EMBED])
+
+    await page.goto('/#slots/primary')
+    await page.locator('.drawer details.adv-disclosure summary').click()
+    await page.getByTestId('n-gpu-layers-input').fill('24')
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => patches.length).toBeGreaterThan(0)
+    expect(patches[0].n_gpu_layers).toBe(24)
+    // Untouched ctx_size must not ride along (dirty-tracking contract).
+    expect(patches[0]).not.toHaveProperty('ctx_size')
+  })
+
+  test('C5 — clearing n_gpu_layers back to -1/empty PATCHes null (unset)', async ({ page }) => {
+    const patches: any[] = []
+    await page.route('**/api/slots/primary/defaults', async (route) => {
+      patches.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/primary/config', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    // Baseline has an explicit override (24) — clearing the field unsets it.
+    await seedSlots(page, [{ ...PRIMARY, n_gpu_layers: 24 }, EMBED])
+
+    await page.goto('/#slots/primary')
+    await page.locator('.drawer details.adv-disclosure summary').click()
+    await page.getByTestId('n-gpu-layers-input').fill('')
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => patches.length).toBeGreaterThan(0)
+    expect(patches[0]).toHaveProperty('n_gpu_layers', null)
   })
 
   test('C5 — editing ctx_size Save PATCHes /defaults { ctx_size }', async ({ page }) => {
@@ -118,7 +163,7 @@ test.describe('Slot edit controls (/slots)', () => {
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => patches.length).toBeGreaterThan(0)
     expect(patches[0].ctx_size).toBe(16384)
-    // Profile-owned knobs never ride the defaults PATCH.
+    // Untouched n_gpu_layers (seeded -1 = unset) never rides the PATCH.
     expect(patches[0]).not.toHaveProperty('n_gpu_layers')
   })
 


### PR DESCRIPTION
## Summary

Multi-wave cleanup/deepening of the model/slot/profile running pipeline and dashboard UI, following a full audit of flag storage/precedence, backend handling (ROCm/Vulkan/CPU/NPU-FLM), and the UI surfaces that edit them.

**Wave 1 (this push, in progress):**
- **Single argv assembler** — launch and the operator-facing "resolved command" preview now share one labelled-segment builder; the preview previously omitted the MTP override, `--chat-template-file`, `--mmproj`, and resolved `--ctx-size`.
- **Model defaults wired in** — registry `defaults.extra_args` and `defaults.n_gpu_layers` now actually apply to container launches (they were persisted + shown in the UI but never read). Precedence: profile &lt; model defaults &lt; slot `[model].n_gpu_layers` &lt; `[server].extra_args`. `rope_freq_base` deprecated (parsed, never emitted).
- **`[server].env`** — per-slot environment variables rendered into the podman unit.
- **FLM/NPU health** — container health can delegate to the Tier-1 real-inference FLM probe instead of the weak `/v1/models` check.
- **GPU plumbing gated** — CPU-profile slots no longer receive `/dev/kfd`/`/dev/dri` passthrough; device paths existence-filtered.
- **Flag-merge unification** — `flag_merge` folded into `slots/argv.py` (short↔long alias dedup now works); FLM cleanups (TB progress unit, catalog TTL, dead globals).

**Coming in subsequent pushes on this branch:** slots API hardening (boundary validation, backend-switch completion, port-range unification), manager guard fixes (TOCTOU, drift canonicalization, eviction blind spots), stacks writing through the guarded path, UI quick wins (model-picker normalizer bug, backend-switch action, dead code), canonical device/backend taxonomy + `/api/meta/enums`, and GPU generalization (CUDA/NVIDIA, multi-GPU pinning, parameterized Strix-Halo constants).

## Test plan
- `uv run pytest tests/` — backend suites green per wave (2 pre-existing `test_moonshine_server.py` ffmpeg-env failures unrelated).
- `cd ui && npx tsc --noEmit && npm run build` per UI wave.
- New tests: preview==launch argv parity, model-default/ngl precedence, CPU-profile GPU gating, `[server].env` unit rendering, FLM health delegation, short-flag merge dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cUG4Khk9JZ9KMivsZE3PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016cUG4Khk9JZ9KMivsZE3PQ)_