### PR TITLE
Wire inert config keys + hindsight-era memory schema (settings completeness P1+P2)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -814,6 +814,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         upstream_registry=upstreams,
         model_registry=model_registry,
         prefetch_timeout_s=hal0_cfg.dispatcher.prefetch_timeout_s,
+        prefetch_parallel_cap=hal0_cfg.dispatcher.prefetch_parallel_cap,
         cached_models=lambda name: model_cache.get(name, []),
         fetch_models=_fetch_and_cache,
         slot_manager=slot_manager,

--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -108,9 +108,9 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     # [telemetry]
     "telemetry.enabled": {"apply_class": "immediate", "services": []},
     "telemetry.channel": {"apply_class": "immediate", "services": []},
-    # [dispatcher] — prefetch_timeout_s is threaded into the Dispatcher at
-    # create_app time, so a change lands on the next hal0-api restart.
-    # prefetch_parallel_cap is reserved (not yet consumed by the fanout).
+    # [dispatcher] — both knobs are threaded into the Dispatcher at
+    # create_app time (timeout bounds the fanout, parallel_cap bounds its
+    # concurrency), so a change lands on the next hal0-api restart.
     "dispatcher.prefetch_timeout_s": {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
@@ -119,10 +119,11 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
     },
-    # [slots]
-    "slots.max_slots": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
-    "slots.port_range_start": {"apply_class": "manual-restart", "services": []},
-    "slots.port_range_end": {"apply_class": "manual-restart", "services": []},
+    # [slots] — max_slots (creation gate) and the port pool are read from
+    # the LIVE config on every POST /api/slots, so they apply immediately.
+    "slots.max_slots": {"apply_class": "immediate", "services": []},
+    "slots.port_range_start": {"apply_class": "immediate", "services": []},
+    "slots.port_range_end": {"apply_class": "immediate", "services": []},
     "slots.idle_timeout_s": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "slots.evict_pressure_mb": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     # [models]
@@ -135,24 +136,16 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     # engine is consumed once at create_app when the memory provider is
     # constructed (api/__init__.py) — a change only lands on restart.
     "memory.engine": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
-    # [memory.embedding] — the rerank timeouts are threaded into
-    # Hal0Reranker at startup (memory/__init__.py), so they're
-    # service-restart, not immediate. The remaining rerank knobs are
-    # reserved (cognee-era; not consumed by the hindsight provider).
-    "memory.embedding.model": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
-    "memory.embedding.rerank_enabled": {
+    # [memory.embedding] — hindsight-era reranker knobs, all threaded into
+    # Hal0Reranker at startup (memory/__init__.py), hence service-restart.
+    # The cognee-era keys (model, rerank_enabled, rerank_url,
+    # rerank_over_fetch_factor, rerank_max_candidates) were deleted from
+    # the schema alongside the cognee wrapper.
+    "memory.embedding.rerank_gateway_url": {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
     },
-    "memory.embedding.rerank_url": {
-        "apply_class": "service-restart",
-        "services": [SERVICE_HAL0_API],
-    },
-    "memory.embedding.rerank_over_fetch_factor": {
-        "apply_class": "service-restart",
-        "services": [SERVICE_HAL0_API],
-    },
-    "memory.embedding.rerank_max_candidates": {
+    "memory.embedding.rerank_model": {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
     },
@@ -164,11 +157,13 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
         "apply_class": "service-restart",
         "services": [SERVICE_HAL0_API],
     },
-    # [memory.graph] — ADR-0023: extraction_slot propagates to hindsight-api via a
-    # systemd drop-in + restart (handled in the /api/memory/graph PUT handler, which
-    # is the sole writer; the apply pipeline only needs to know the key is valid).
+    # [memory.graph] — ADR-0023: extraction_slot + llm_timeout_s propagate to
+    # hindsight-api via a systemd drop-in + restart (handled in the
+    # /api/memory/graph PUT handler, which is the sole writer; the apply
+    # pipeline only needs to know the keys are valid).
     "memory.graph.enabled": {"apply_class": "immediate", "services": []},
     "memory.graph.extraction_slot": {"apply_class": "immediate", "services": []},
+    "memory.graph.llm_timeout_s": {"apply_class": "immediate", "services": []},
     # [activity] — the AuditStore is constructed once at create_app
     # (api/__init__.py); retention/max_rows/enabled land on restart.
     "activity.enabled": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -228,6 +228,9 @@ async def graph_status(request: Request) -> dict[str, Any]:
     available = await _enabled_llm_slots(request)
     status["available_slots"] = available
     status["slot_resolves"] = status.get("extraction_slot") in available
+    # llm_timeout_s lives in hal0.toml (not on the provider) — echo it so the
+    # dashboard's graph panel can edit it without a second config fetch.
+    status["llm_timeout_s"] = load_hal0_config().memory.graph.llm_timeout_s
     await _augment_build_counters(request, status)
     return status
 
@@ -341,14 +344,18 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
     except ValueError as exc:
         raise MemoryGraphConfigInvalid(str(exc)) from exc
 
-    # Propagate the extraction slot to hindsight-api (drop-in + restart) so the
-    # engine's native extraction LLM follows the choice. Best-effort: a restart
-    # failure is surfaced in the response but does not roll back the config.
+    # Propagate the extraction slot + LLM timeout to hindsight-api (drop-in +
+    # restart) so the engine's native extraction LLM follows the choice.
+    # Best-effort: a restart failure is surfaced in the response but does not
+    # roll back the config.
+    timeout_changed = new_cfg.llm_timeout_s != cfg.memory.graph.llm_timeout_s
     propagation: dict[str, Any] | None = None
-    if slot_changed:
+    if slot_changed or timeout_changed:
         from hal0.memory.extraction_env import apply_extraction_slot
 
-        propagation = apply_extraction_slot(new_cfg.extraction_slot)
+        propagation = apply_extraction_slot(
+            new_cfg.extraction_slot, timeout_s=new_cfg.llm_timeout_s
+        )
 
     cfg.memory.graph = new_cfg
     try:

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -232,8 +232,9 @@ def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:
 
     Walks ``/etc/hal0/slots/*.toml`` collecting both top-level ``port``
     and nested ``[server] port`` values. Returns the lowest port in
-    ``[start, end]`` not already claimed. The 8081-8099 range matches
-    PLAN.md §2 ports table.
+    ``[start, end]`` not already claimed. The default range matches
+    PLAN.md §2; callers thread ``[slots].port_range_start/end`` from the
+    live config so the pool is operator-tunable.
     """
     import tomllib
 
@@ -265,7 +266,12 @@ def _next_free_slot_port(start: int = 8081, end: int = 8099) -> int:
     )
 
 
-def _normalize_create_body(body: dict[str, Any]) -> dict[str, Any]:
+def _normalize_create_body(
+    body: dict[str, Any],
+    *,
+    port_start: int = 8081,
+    port_end: int = 8099,
+) -> dict[str, Any]:
     """Normalize a POST /api/slots body to the canonical nested shape.
 
     Two compat hops (#275 bugs 1 + 2):
@@ -277,16 +283,17 @@ def _normalize_create_body(body: dict[str, Any]) -> dict[str, Any]:
        top-level string. The result was ``model_default`` MISSING from
        /api/slots responses for any slot created via POST.
     2. Missing or zero ``port`` → auto-assign via
-       :func:`_next_free_slot_port`. Without this, new slots persist
-       ``port=0`` and the dashboard card shows ``port=0`` instead of a
-       useable port.
+       :func:`_next_free_slot_port` over the configured
+       ``[slots].port_range_start/end`` pool. Without this, new slots
+       persist ``port=0`` and the dashboard card shows ``port=0``
+       instead of a useable port.
     """
     out = dict(body)
     model_val = out.get("model")
     if isinstance(model_val, str):
         out["model"] = {"default": model_val}
     if "port" not in out or not isinstance(out.get("port"), int) or out.get("port") in (0, None):
-        out["port"] = _next_free_slot_port()
+        out["port"] = _next_free_slot_port(port_start, port_end)
     return out
 
 
@@ -324,7 +331,26 @@ async def create_slot(request: Request) -> dict[str, object]:
             code="slot.name_required",
         )
 
-    body = _normalize_create_body(body)
+    # [slots] policy is read from the live config on every create, so a PUT
+    # /api/settings change applies to the next creation without a restart.
+    slots_cfg = getattr(getattr(request.app.state, "hal0_config", None), "slots", None)
+    max_slots = int(getattr(slots_cfg, "max_slots", 0) or 0)
+    if max_slots:
+        existing = await sm.list()
+        if len(existing) >= max_slots:
+            raise BadRequest(
+                f"slot budget reached: [slots].max_slots={max_slots} and "
+                f"{len(existing)} slots already exist (seeded slots count "
+                "toward the budget — raise max_slots or delete a slot)",
+                code="slot.capacity_exhausted",
+                details={"max_slots": max_slots, "existing_slots": len(existing)},
+            )
+
+    body = _normalize_create_body(
+        body,
+        port_start=int(getattr(slots_cfg, "port_range_start", 8081) or 8081),
+        port_end=int(getattr(slots_cfg, "port_range_end", 8099) or 8099),
+    )
     async with record_action(
         request,
         category="slot",
@@ -767,18 +793,27 @@ async def slot_metrics(request: Request) -> dict[str, Any]:
 
 @router.get("/capacity")
 async def slot_capacity(request: Request) -> dict[str, object]:
-    """Per-slot resident memory for the dashboard memory map.
+    """Per-slot resident memory + slot-count budget for the dashboard.
 
     Returns ``{"per_slot": {slot_name: {vram_mb, ram_mb, mem_mb, state,
-    model_id}}}`` for slots in a resident state. Mirrors the ``per_slot``
-    block also stamped onto ``GET /api/stats/hardware``.
+    model_id}}, "slot_budget": {"used_slots", "max_slots"}}``. ``per_slot``
+    mirrors the block also stamped onto ``GET /api/stats/hardware``;
+    ``slot_budget`` reflects the ``[slots].max_slots`` creation gate
+    (max_slots 0 = unlimited).
     """
     from hal0.slots.capacity import build_per_slot
 
     sm = _get_slot_manager(request)
     slots = await sm.list()
     registry = getattr(request.app.state, "model_registry", None)
-    return {"per_slot": await build_per_slot(slots, registry=registry)}
+    slots_cfg = getattr(getattr(request.app.state, "hal0_config", None), "slots", None)
+    return {
+        "per_slot": await build_per_slot(slots, registry=registry),
+        "slot_budget": {
+            "used_slots": len(slots),
+            "max_slots": int(getattr(slots_cfg, "max_slots", 0) or 0),
+        },
+    }
 
 
 # ── per-slot ───────────────────────────────────────────────────────────────

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -91,8 +91,18 @@ _VALID_PROVIDERS = frozenset({"llama-server", "flm", "moonshine", "kokoro", "qwe
 # Slot port range.  8080 is the hal0 API; slots get 8081-8099; 8188 =
 # ComfyUI's stock port for the img slot — kept well-known so operator
 # bookmarks/tooling keep working.
+#
+# Two distinct bounds on purpose:
+#   * _SLOT_PORT_MIN/_SLOT_PORT_MAX bound what a single slot's ``port``
+#     field may be — wide enough to admit the img slot's 8188.
+#   * _SLOT_PORT_POOL_END is the default END of the AUTO-ALLOCATION pool
+#     ([slots].port_range_end) — deliberately below 8188 so freshly
+#     created slots can never squat on ComfyUI's port. Operators may
+#     widen the pool in hal0.toml; the allocator still skips ports
+#     claimed by existing slot TOMLs.
 _SLOT_PORT_MIN = 8081
 _SLOT_PORT_MAX = 8200
+_SLOT_PORT_POOL_END = 8099
 
 # Schema version for migrations.  Bumped when a backwards-incompatible
 # config-shape change lands.  See PLAN.md §5 Tier 3.
@@ -1531,19 +1541,30 @@ class SlotsConfig(BaseModel):
     max_slots: int = Field(
         default=0,
         ge=0,
-        description="Maximum concurrent slots.  0 means unlimited.",
+        description=(
+            "Maximum number of slots that may exist (creation gate; 0 = "
+            "unlimited). Counts every slot TOML including the seeded ones "
+            "(utility, rerank, tts, img, npu, …), so values below the "
+            "current slot count block new-slot creation. Applies to the "
+            "next slot creation — no restart needed."
+        ),
     )
     port_range_start: int = Field(
         default=_SLOT_PORT_MIN,
         ge=1024,
         le=65535,
-        description="First port in the slot pool.",
+        description="First port in the auto-allocation pool for new slots.",
     )
     port_range_end: int = Field(
-        default=_SLOT_PORT_MAX,
+        default=_SLOT_PORT_POOL_END,
         ge=1024,
         le=65535,
-        description="Last port in the slot pool (inclusive).",
+        description=(
+            "Last port in the auto-allocation pool (inclusive). The default "
+            "stops below 8188 so new slots never claim ComfyUI's port; the "
+            "allocator also skips any port already used by an existing slot "
+            "TOML. Applies to the next slot creation — no restart needed."
+        ),
     )
     idle_timeout_s: int = Field(
         default=300,
@@ -1650,8 +1671,19 @@ class MemoryGraphConfig(BaseModel):
             "The local llm slot Hindsight uses for graph extraction / "
             "consolidation / reflect. Propagated to hindsight-api as "
             "HINDSIGHT_API_LLM_MODEL=hal0/<slot> via a systemd drop-in. Validated "
-            "against the live enabled-llm-slot set by the API at set-time. This is "
-            "the sole memory-graph knob."
+            "against the live enabled-llm-slot set by the API at set-time."
+        ),
+    )
+    llm_timeout_s: int = Field(
+        default=300,
+        ge=30,
+        le=3600,
+        description=(
+            "Timeout (seconds) for the Hindsight daemon's LLM calls — "
+            "extraction, consolidation, and reflect. Covers cold slot starts "
+            "and long reflects. Propagated to hindsight-api as "
+            "HINDSIGHT_API_LLM_TIMEOUT via the same systemd drop-in as the "
+            "extraction slot; the daemon restarts to pick it up."
         ),
     )
 
@@ -1934,85 +1966,44 @@ class AgentConfig(BaseModel):
 
 
 class MemoryEmbeddingConfig(BaseModel):
-    """[memory.embedding] section of hal0.toml (issue #116 G3 + G4).
+    """[memory.embedding] section of hal0.toml — Hindsight-era rerank knobs.
 
-    Pins the embedding model Cognee uses for memory vector retrieval and
-    (optionally) wires a second-pass rerank slot in front of
-    :meth:`hal0.memory.cognee_wrapper.CogneeWrapper.search`.
+    ADR-0023 made Hindsight the platform memory engine. Hindsight embeds
+    server-side with its own bundled model, so hal0 no longer pins an
+    embedding model here; what remains configurable is the second-pass
+    reranker hal0 runs over cross-bank recall results
+    (:class:`hal0.memory.hindsight_provider.Hal0Reranker`):
 
-    Defaults are zero-config preserving:
+      - ``rerank_gateway_url`` — the OpenAI-surface gateway the reranker
+        POSTs ``/v1/rerankings`` to (hal0-api's dispatcher, which routes
+        to the rerank slot).
+      - ``rerank_model`` — the rerank model id sent in the request body.
+      - ``rerank_connect_timeout_s`` / ``rerank_read_timeout_s`` — the
+        HTTP budgets; failures fall through to fused vector ordering,
+        never blocking recall.
 
-      - ``model`` keeps Cognee's stock pick (``BAAI/bge-small-en-v1.5``,
-        384-dim) so an upgrade does NOT silently re-embed an existing
-        LanceDB index (dimension mismatch corrupts the store).
-      - ``rerank_enabled`` is OFF by default; when flipped on, the
-        wrapper calls ``rerank_url`` after vector retrieval and reorders
-        candidates by relevance score. Failures fall through to the
-        original vector ordering — never block memory_search.
-      - ``rerank_url`` points at hal0's built-in rerank container slot
-        (port 8083, seeded by ``installer/etc-hal0/slots/rerank.toml``).
-        The old value 8086 was the retired embed-rerank combined slot;
-        ``hal0.toml`` overrides take precedence over this default.
-
-    G3 (pin embedding model) deliberately ships the *existing* default
-    so users who do not flip the toggle see no behavioral change. Future
-    work (audit doc §G3) may bump the default to ``bge-large-en-v1.5``
-    once a migration story for the LanceDB index exists.
+    The cognee-era fields (``model``, ``rerank_enabled``, ``rerank_url``,
+    ``rerank_over_fetch_factor``, ``rerank_max_candidates``) were removed
+    with the cognee wrapper; ``extra = "ignore"`` silently drops them
+    from an older hal0.toml on load (gone on next save), mirroring how
+    ADR-0023 retired ``[memory.graph]``'s ``route``/``upstream``.
     """
 
-    model_config = {"populate_by_name": True, "extra": "allow"}
+    model_config = {"populate_by_name": True, "extra": "ignore"}
 
-    model: str = Field(
-        default="BAAI/bge-small-en-v1.5",
+    rerank_gateway_url: str = Field(
+        default="http://127.0.0.1:8080",
         description=(
-            "Embedding model the Cognee wrapper pins (issue #116 G3). "
-            "Defaults to the existing Cognee stock value so the install "
-            "default is byte-identical to v0.3.0 behavior — bumping this "
-            "without a re-embed migration corrupts the LanceDB index."
+            "Base URL of the OpenAI-compatible gateway the memory reranker "
+            "calls (``POST {url}/v1/rerankings``). Defaults to hal0-api "
+            "itself, whose dispatcher routes to the rerank slot."
         ),
     )
-    rerank_enabled: bool = Field(
-        default=False,
+    rerank_model: str = Field(
+        default="builtin.jina-reranker-v1-tiny-en-q8",
         description=(
-            "When True, memory_search posts the vector top-N candidates "
-            "to ``rerank_url`` and reorders by ``relevance_score`` before "
-            "returning the top-K (issue #116 G4). When False (default), "
-            "vector ordering is returned unchanged."
-        ),
-    )
-    rerank_url: str = Field(
-        default="http://127.0.0.1:8083",
-        description=(
-            "Base URL of the llama.cpp rerank endpoint. The wrapper "
-            "POSTs to ``{rerank_url}/rerank`` with "
-            "``{model, query, documents}`` per llama.cpp's reranking "
-            "protocol. Defaults to hal0's bundled rerank container slot "
-            "(port 8083). hal0.toml overrides win."
-        ),
-    )
-    rerank_over_fetch_factor: int = Field(
-        default=5,
-        ge=1,
-        le=20,
-        description=(
-            "Multiplier on ``limit`` used to determine the vector-search "
-            "candidate count fed into the rerank pass. With the default of "
-            "5, a ``limit=10`` search rerank-scores up to 50 candidates "
-            "before clipping back to the top 10. Bumping this trades "
-            "rerank latency for recall; dropping it toward 1 makes the "
-            "rerank pass increasingly pointless."
-        ),
-    )
-    rerank_max_candidates: int = Field(
-        default=500,
-        ge=10,
-        le=2000,
-        description=(
-            "Absolute cap on candidates per rerank call, applied AFTER "
-            "``rerank_over_fetch_factor`` so memory + latency stay bounded "
-            "regardless of the requested ``limit``. The pre-PR hard-coded "
-            "100 silently collapsed the over-fetch ratio at ``limit >= 20`` "
-            "and made rerank a no-op at ``limit >= 100``."
+            "Rerank model id sent to the gateway. Must resolve to a model "
+            "the rerank slot serves (see /v1/models on the gateway)."
         ),
     )
     rerank_connect_timeout_s: float = Field(
@@ -2040,18 +2031,11 @@ class MemoryEmbeddingConfig(BaseModel):
         ),
     )
 
-    @field_validator("model")
+    @field_validator("rerank_gateway_url", "rerank_model")
     @classmethod
-    def model_nonempty(cls, v: str) -> str:
+    def rerank_fields_nonempty(cls, v: str, info: Any) -> str:
         if not v or not v.strip():
-            raise ValueError("memory.embedding.model must not be empty")
-        return v
-
-    @field_validator("rerank_url")
-    @classmethod
-    def rerank_url_nonempty(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("memory.embedding.rerank_url must not be empty")
+            raise ValueError(f"memory.embedding.{info.field_name} must not be empty")
         return v
 
 

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -417,6 +417,8 @@ class Dispatcher:
         model_registry:     Source of truth for model→upstream bindings.
         prefetch_timeout_s: Cold-cache prefetch fanout timeout
                             (PLAN.md §5 Tier 2 — was hardcoded 4s, now 8s).
+        prefetch_parallel_cap: Max concurrent cold-prefetch legs
+                            ([dispatcher].prefetch_parallel_cap, default 4).
         cached_models:      Returns the cached /v1/models for an upstream.
         is_online:          Health probe predicate.
         fetch_models:       Async /v1/models fetcher.
@@ -429,6 +431,7 @@ class Dispatcher:
         model_registry: ModelRegistry | None = None,
         *,
         prefetch_timeout_s: float = 8.0,  # TIER2 — configurable (was hardcoded 4s)
+        prefetch_parallel_cap: int = 4,  # max concurrent cold-prefetch legs
         cached_models: CachedModelsFn | None = None,
         is_online: IsOnlineFn | None = None,
         fetch_models: FetchModelsFn | None = None,
@@ -440,6 +443,8 @@ class Dispatcher:
         self._models = model_registry
         # TIER2 — prefetch timeout is configurable.  Default 8s (haloai had 4s).
         self.prefetch_timeout_s: float = prefetch_timeout_s
+        # Cap on concurrent cold-prefetch legs ([dispatcher].prefetch_parallel_cap).
+        self._prefetch_parallel_cap: int = max(1, int(prefetch_parallel_cap))
         self._cached_models: CachedModelsFn = cached_models or _default_cached_models
         self._is_online: IsOnlineFn = is_online or _default_is_online
         self._fetch_models: FetchModelsFn = fetch_models or _default_fetch_models
@@ -1274,13 +1279,18 @@ class Dispatcher:
 
         All concurrent prefetches for the same upstream share one HTTP call
         (Tier 3).  The total fanout is bounded by ``prefetch_timeout_s``
-        (Tier 2, configurable; was hardcoded 4s in haloai).
+        (Tier 2, configurable; was hardcoded 4s in haloai) and its
+        concurrency by ``prefetch_parallel_cap`` — a leg waiting on the
+        semaphore still counts against the timeout, so a small cap over
+        many cold remotes trades tail legs for bounded connection churn.
         """
+        sem = asyncio.Semaphore(self._prefetch_parallel_cap)
 
         async def _one(u: Upstream) -> None:
             key = f"prefetch:{u.name}"
             try:
-                await self._single_flight.do(key, self._fetch_models, u)
+                async with sem:
+                    await self._single_flight.do(key, self._fetch_models, u)
             except Exception as exc:  # TIER1 — log, don't crash the fanout
                 # Errors in cold prefetch are *expected* (remotes go offline).
                 # We swallow at this granularity ONLY because the call sites

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -91,7 +91,8 @@ def provider_from_config(cfg: Any) -> MemoryProvider:
     from hal0.memory.hindsight_provider import Hal0Reranker
 
     reranker = Hal0Reranker(
-        base_url=str(getattr(embed, "rerank_gateway_url", None) or "http://127.0.0.1:8080"),
+        base_url=str(embed.rerank_gateway_url),
+        model=str(embed.rerank_model),
         connect_timeout_s=float(embed.rerank_connect_timeout_s),
         read_timeout_s=float(embed.rerank_read_timeout_s),
     )

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -35,28 +35,38 @@ DROP_IN_DIR = Path("/etc/systemd/system/hindsight-api.service.d")
 DROP_IN_PATH = DROP_IN_DIR / "extraction-model.conf"
 SERVICE = "hindsight-api"
 
+#: Default daemon LLM timeout (seconds) — mirrors MemoryGraphConfig.llm_timeout_s.
+DEFAULT_LLM_TIMEOUT_S = 300
+
 _DROP_IN_TEMPLATE = (
-    "# Managed by hal0 (ADR-0023 — memory.graph.extraction_slot).\n"
-    "# Overrides HINDSIGHT_API_LLM_MODEL in the base hindsight-api.service unit.\n"
-    "# Do not edit by hand; set via `hal0 memory graph enable --slot <name>` or the\n"
-    "# Memory dashboard, which rewrites this file and restarts the service.\n"
+    "# Managed by hal0 (ADR-0023 — memory.graph.extraction_slot / llm_timeout_s).\n"
+    "# Overrides HINDSIGHT_API_LLM_MODEL and HINDSIGHT_API_LLM_TIMEOUT in the base\n"
+    "# hindsight-api.service unit. Do not edit by hand; set via `hal0 memory graph\n"
+    "# enable --slot <name>` or the dashboard, which rewrites this file and\n"
+    "# restarts the service.\n"
     "[Service]\n"
     "Environment=HINDSIGHT_API_LLM_MODEL=hal0/{slot}\n"
+    "Environment=HINDSIGHT_API_LLM_TIMEOUT={timeout_s}\n"
 )
 
 
-def render_drop_in(slot: str) -> str:
-    """Return the drop-in file contents pinning extraction to ``hal0/<slot>``."""
-    return _DROP_IN_TEMPLATE.format(slot=slot)
+def render_drop_in(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> str:
+    """Return the drop-in contents pinning extraction to ``hal0/<slot>`` + timeout."""
+    return _DROP_IN_TEMPLATE.format(slot=slot, timeout_s=int(timeout_s))
 
 
-def apply_extraction_slot(slot: str, *, restart: bool = True) -> dict[str, Any]:
+def apply_extraction_slot(
+    slot: str,
+    *,
+    timeout_s: int = DEFAULT_LLM_TIMEOUT_S,
+    restart: bool = True,
+) -> dict[str, Any]:
     """Write the drop-in for ``slot`` and (best-effort) restart hindsight-api.
 
     Returns a status dict::
 
-        {"slot", "model", "drop_in", "written", "daemon_reloaded",
-         "restarted", "error"}
+        {"slot", "model", "timeout_s", "drop_in", "written",
+         "daemon_reloaded", "restarted", "error"}
 
     ``error`` is ``None`` on full success. The write is atomic (temp + rename) so a
     crash mid-write never leaves a half-written override that would wedge the unit.
@@ -65,6 +75,7 @@ def apply_extraction_slot(slot: str, *, restart: bool = True) -> dict[str, Any]:
     result: dict[str, Any] = {
         "slot": slot,
         "model": model,
+        "timeout_s": int(timeout_s),
         "drop_in": str(DROP_IN_PATH),
         "written": False,
         "daemon_reloaded": False,
@@ -75,7 +86,7 @@ def apply_extraction_slot(slot: str, *, restart: bool = True) -> dict[str, Any]:
     try:
         DROP_IN_DIR.mkdir(parents=True, exist_ok=True)
         tmp = DROP_IN_PATH.with_suffix(".conf.tmp")
-        tmp.write_text(render_drop_in(slot), encoding="utf-8")
+        tmp.write_text(render_drop_in(slot, timeout_s), encoding="utf-8")
         tmp.replace(DROP_IN_PATH)
         result["written"] = True
     except OSError as exc:

--- a/tests/api/test_settings_apply.py
+++ b/tests/api/test_settings_apply.py
@@ -62,14 +62,15 @@ def test_registry_declares_three_apply_classes() -> None:
         # [telemetry]
         ("telemetry.enabled", "immediate", []),
         ("telemetry.channel", "immediate", []),
-        # [dispatcher] — prefetch_timeout_s is threaded into the Dispatcher
-        # at create_app time; a change lands on the next hal0-api restart.
+        # [dispatcher] — both knobs are threaded into the Dispatcher at
+        # create_app time; a change lands on the next hal0-api restart.
         ("dispatcher.prefetch_timeout_s", "service-restart", [SERVICE_HAL0_API]),
         ("dispatcher.prefetch_parallel_cap", "service-restart", [SERVICE_HAL0_API]),
-        # [slots]
-        ("slots.max_slots", "service-restart", [SERVICE_HAL0_API]),
-        ("slots.port_range_start", "manual-restart", []),
-        ("slots.port_range_end", "manual-restart", []),
+        # [slots] — max_slots + the port pool are read from the live config
+        # on every POST /api/slots, so they apply immediately.
+        ("slots.max_slots", "immediate", []),
+        ("slots.port_range_start", "immediate", []),
+        ("slots.port_range_end", "immediate", []),
         ("slots.idle_timeout_s", "service-restart", [SERVICE_HAL0_API]),
         ("slots.evict_pressure_mb", "service-restart", [SERVICE_HAL0_API]),
         # [models]
@@ -81,17 +82,16 @@ def test_registry_declares_three_apply_classes() -> None:
         # [memory] — engine is consumed once when the provider is built at
         # create_app; the rerank timeouts feed Hal0Reranker at startup.
         ("memory.engine", "service-restart", [SERVICE_HAL0_API]),
-        # [memory.embedding]
-        ("memory.embedding.model", "service-restart", [SERVICE_HAL0_API]),
-        ("memory.embedding.rerank_enabled", "service-restart", [SERVICE_HAL0_API]),
-        ("memory.embedding.rerank_url", "service-restart", [SERVICE_HAL0_API]),
-        ("memory.embedding.rerank_over_fetch_factor", "service-restart", [SERVICE_HAL0_API]),
-        ("memory.embedding.rerank_max_candidates", "service-restart", [SERVICE_HAL0_API]),
+        # [memory.embedding] — hindsight-era reranker knobs (the cognee-era
+        # keys were deleted from the schema with the cognee wrapper).
+        ("memory.embedding.rerank_gateway_url", "service-restart", [SERVICE_HAL0_API]),
+        ("memory.embedding.rerank_model", "service-restart", [SERVICE_HAL0_API]),
         ("memory.embedding.rerank_connect_timeout_s", "service-restart", [SERVICE_HAL0_API]),
         ("memory.embedding.rerank_read_timeout_s", "service-restart", [SERVICE_HAL0_API]),
         # [memory.graph] — ADR-0023: route/upstream replaced by extraction_slot
         ("memory.graph.enabled", "immediate", []),
         ("memory.graph.extraction_slot", "immediate", []),
+        ("memory.graph.llm_timeout_s", "immediate", []),
         # [activity] — AuditStore is constructed once at create_app.
         ("activity.enabled", "service-restart", [SERVICE_HAL0_API]),
         ("activity.retention_days", "service-restart", [SERVICE_HAL0_API]),
@@ -174,16 +174,16 @@ def test_apply_plan_partitions_immediate_service_and_manual() -> None:
         [
             "telemetry.enabled",  # immediate
             "models.store",  # service-restart[slots]
-            "slots.max_slots",  # service-restart[hal0-api]
-            "slots.port_range_start",  # manual-restart
+            "slots.idle_timeout_s",  # service-restart[hal0-api]
+            "meta.schema_version",  # manual-restart
         ]
     )
     assert plan["immediate"] == ["telemetry.enabled"]
     assert plan["service_restart"] == {
         SERVICE_SLOTS: ["models.store"],
-        SERVICE_HAL0_API: ["slots.max_slots"],
+        SERVICE_HAL0_API: ["slots.idle_timeout_s"],
     }
-    assert plan["manual_restart"] == ["slots.port_range_start"]
+    assert plan["manual_restart"] == ["meta.schema_version"]
     assert plan["unknown"] == []
 
 
@@ -291,8 +291,10 @@ def test_get_apply_plan_returns_full_registry(isolated_client: TestClient) -> No
     assert registry["telemetry.enabled"]["apply_class"] == "immediate"
     assert registry["models.store"]["apply_class"] == "service-restart"
     assert registry["models.store"]["services"] == [SERVICE_SLOTS]
-    assert registry["slots.max_slots"]["services"] == [SERVICE_HAL0_API]
-    assert registry["slots.port_range_start"]["apply_class"] == "manual-restart"
+    assert registry["slots.idle_timeout_s"]["services"] == [SERVICE_HAL0_API]
+    # max_slots + the port pool are read live on every POST /api/slots.
+    assert registry["slots.max_slots"]["apply_class"] == "immediate"
+    assert registry["meta.schema_version"]["apply_class"] == "manual-restart"
 
     # Every entry has the right TypedDict shape.
     for key, entry in registry.items():

--- a/tests/api/test_slots_policy.py
+++ b/tests/api/test_slots_policy.py
@@ -1,0 +1,123 @@
+"""[slots] policy wiring — max_slots creation gate + configurable port pool.
+
+Both keys are read from the LIVE ``app.state.hal0_config`` on every
+POST /api/slots (apply-class ``immediate``): the max_slots gate rejects
+creation once the on-disk slot count reaches the budget (seeded slots
+count), and the port auto-allocator draws from
+``[slots].port_range_start/end`` instead of the old hardcoded 8081-8099.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes.slots import _next_free_slot_port, _normalize_create_body
+
+
+def _seed_slot(home: str, name: str, port: int) -> None:
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.toml").write_text(
+        "\n".join(
+            [
+                f'name = "{name}"',
+                f"port = {port}",
+                'device = "gpu-vulkan"',
+                "enabled = true",
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    # Instantiate after tmp_hal0_home is in place (same rationale as
+    # test_slots_routes.isolated_app).
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+# ── port pool ────────────────────────────────────────────────────────────────
+
+
+def test_next_free_port_honours_configured_range(tmp_hal0_home: str) -> None:
+    _seed_slot(tmp_hal0_home, "a", 8150)
+    assert _next_free_slot_port(8150, 8155) == 8151
+
+
+def test_normalize_create_body_allocates_from_configured_pool(tmp_hal0_home: str) -> None:
+    out = _normalize_create_body({"name": "x", "model": "m"}, port_start=8190, port_end=8195)
+    assert out["port"] == 8190
+    assert out["model"] == {"default": "m"}
+
+
+def test_normalize_create_body_keeps_explicit_port(tmp_hal0_home: str) -> None:
+    out = _normalize_create_body({"name": "x", "port": 8188}, port_start=8081, port_end=8099)
+    assert out["port"] == 8188
+
+
+# ── max_slots creation gate ──────────────────────────────────────────────────
+
+
+def test_create_slot_rejects_when_max_slots_reached(
+    tmp_hal0_home: str,
+    isolated_app: FastAPI,
+    isolated_client: TestClient,
+) -> None:
+    _seed_slot(tmp_hal0_home, "existing", 8081)
+    # Live-config read: mutate app.state (what PUT /api/settings updates)
+    # rather than the on-disk TOML — the gate must see it without restart.
+    isolated_app.state.hal0_config.slots.max_slots = 1
+    r = isolated_client.post(
+        "/api/slots",
+        json={"name": "second", "model": "qwen3-4b-q4_k_m", "device": "gpu-vulkan"},
+    )
+    assert r.status_code == 400, r.text
+    err = r.json()["error"]
+    assert err["code"] == "slot.capacity_exhausted"
+    assert err["details"]["max_slots"] == 1
+    assert err["details"]["existing_slots"] == 1
+
+
+def test_create_slot_allows_when_under_budget(
+    tmp_hal0_home: str,
+    isolated_app: FastAPI,
+    isolated_client: TestClient,
+) -> None:
+    _seed_slot(tmp_hal0_home, "existing", 8081)
+    isolated_app.state.hal0_config.slots.max_slots = 5
+    r = isolated_client.post(
+        "/api/slots",
+        json={"name": "second", "model": "qwen3-4b-q4_k_m", "device": "gpu-vulkan"},
+    )
+    assert r.status_code == 201, r.text
+    # Auto-allocated from the default pool, skipping the seeded 8081.
+    assert r.json()["port"] == 8082
+
+
+def test_capacity_endpoint_reports_slot_budget(
+    tmp_hal0_home: str,
+    isolated_app: FastAPI,
+    isolated_client: TestClient,
+) -> None:
+    _seed_slot(tmp_hal0_home, "existing", 8081)
+    isolated_app.state.hal0_config.slots.max_slots = 4
+    r = isolated_client.get("/api/slots/capacity")
+    assert r.status_code == 200, r.text
+    budget = r.json()["slot_budget"]
+    assert budget == {"used_slots": 1, "max_slots": 4}

--- a/tests/config/test_memory_graph_schema.py
+++ b/tests/config/test_memory_graph_schema.py
@@ -41,7 +41,7 @@ class TestMemoryGraphDefaults:
     def test_legacy_route_upstream_keys_are_no_longer_emitted(self) -> None:
         """The dumped block carries only the ADR-0023 fields."""
         dumped = MemoryGraphConfig().model_dump()
-        assert set(dumped) == {"enabled", "extraction_slot"}
+        assert set(dumped) == {"enabled", "extraction_slot", "llm_timeout_s"}
 
 
 class TestExtractionSlotGrammar:

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -1,4 +1,4 @@
-"""Tests for Phase C5 — rerank + utility seed TOMLs and rerank_url default."""
+"""Tests for Phase C5 — rerank + utility seed TOMLs and reranker defaults."""
 
 import tomllib
 from pathlib import Path
@@ -31,5 +31,27 @@ def test_seed_utility_toml_validates() -> None:
     assert slot.model.context_size == 65536
 
 
-def test_rerank_url_default_is_rerank_slot() -> None:
-    assert MemoryEmbeddingConfig().rerank_url == "http://127.0.0.1:8083"
+def test_rerank_defaults_are_hindsight_era() -> None:
+    cfg = MemoryEmbeddingConfig()
+    # Gateway = hal0-api's own OpenAI surface; the dispatcher routes
+    # /v1/rerankings to the rerank slot.
+    assert cfg.rerank_gateway_url == "http://127.0.0.1:8080"
+    assert cfg.rerank_model == "builtin.jina-reranker-v1-tiny-en-q8"
+
+
+def test_cognee_era_embedding_keys_are_dropped_silently() -> None:
+    # extra="ignore": a stale hal0.toml carrying the removed cognee-era keys
+    # must load cleanly and shed them (gone on next save) instead of failing
+    # validation — same migration path ADR-0023 used for [memory.graph].
+    cfg = MemoryEmbeddingConfig.model_validate(
+        {
+            "model": "BAAI/bge-small-en-v1.5",
+            "rerank_enabled": True,
+            "rerank_url": "http://127.0.0.1:8083",
+            "rerank_over_fetch_factor": 5,
+            "rerank_max_candidates": 500,
+        }
+    )
+    dumped = cfg.model_dump()
+    for dead in ("model", "rerank_enabled", "rerank_url", "rerank_over_fetch_factor"):
+        assert dead not in dumped

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -269,6 +269,47 @@ async def test_prefetch_respects_configurable_timeout() -> None:
     assert exc.value.code == "dispatch.no_route"
 
 
+@pytest.mark.asyncio
+async def test_prefetch_respects_parallel_cap() -> None:
+    """[dispatcher].prefetch_parallel_cap bounds cold-prefetch concurrency.
+
+    Five cold remotes with a cap of 2: the recording fetcher must never
+    observe more than 2 legs in flight at once, while all legs still run
+    (the semaphore serialises, not drops).
+    """
+    remotes = [make_remote(f"r{i}", f"https://r{i}.example.com/v1") for i in range(5)]
+    upstreams = FakeUpstreamRegistry(remotes)
+    models = FakeModelRegistry(routes={})
+
+    in_flight = 0
+    max_in_flight = 0
+    legs_run = 0
+
+    async def recording_fetch(_u: Upstream) -> list[str]:
+        nonlocal in_flight, max_in_flight, legs_run
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        legs_run += 1
+        await asyncio.sleep(0.01)
+        in_flight -= 1
+        return []
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda _name: [],
+        fetch_models=recording_fetch,
+        prefetch_timeout_s=5.0,
+        prefetch_parallel_cap=2,
+    )
+
+    with pytest.raises(NoRouteFound):
+        await dispatcher.dispatch(make_request(), body={"model": "nowhere"})
+
+    assert legs_run == 5, "every cold remote must still be prefetched"
+    assert max_in_flight <= 2, f"cap of 2 exceeded: saw {max_in_flight} concurrent legs"
+
+
 # ── 4. legacy fallback path ──────────────────────────────────────────────────
 
 

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -87,3 +87,24 @@ def test_apply_no_restart_skips_systemctl(monkeypatch, tmp_path: Path):
     assert result["restarted"] is False
     assert result["error"] is None
     assert drop_in.exists()
+
+
+def test_render_drop_in_includes_llm_timeout():
+    # Default mirrors MemoryGraphConfig.llm_timeout_s (300s); explicit values
+    # ride the same drop-in so one file owns both hindsight LLM env overrides.
+    assert "HINDSIGHT_API_LLM_TIMEOUT=300" in render_drop_in("utility")
+    assert "HINDSIGHT_API_LLM_TIMEOUT=600" in render_drop_in("utility", timeout_s=600)
+
+
+def test_apply_threads_timeout_into_drop_in_and_status(monkeypatch, tmp_path: Path):
+    import hal0.memory.extraction_env as ee
+
+    drop_in = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+    monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
+    monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
+
+    result = apply_extraction_slot("agent", timeout_s=900, restart=False)
+    assert result["timeout_s"] == 900
+    text = drop_in.read_text()
+    assert "HINDSIGHT_API_LLM_MODEL=hal0/agent" in text
+    assert "HINDSIGHT_API_LLM_TIMEOUT=900" in text

--- a/tests/memory/test_pgvector_degrade_safety.py
+++ b/tests/memory/test_pgvector_degrade_safety.py
@@ -27,12 +27,8 @@ def _cfg(engine="hindsight"):
         memory=SimpleNamespace(
             engine=engine,
             embedding=SimpleNamespace(
-                model="BAAI/bge-small-en-v1.5",
-                rerank_enabled=False,
-                rerank_url="http://127.0.0.1:8086",
                 rerank_gateway_url="http://127.0.0.1:8080",
-                rerank_over_fetch_factor=5,
-                rerank_max_candidates=500,
+                rerank_model="builtin.jina-reranker-v1-tiny-en-q8",
                 rerank_connect_timeout_s=1.0,
                 rerank_read_timeout_s=8.0,
             ),

--- a/tests/memory/test_provider_factory.py
+++ b/tests/memory/test_provider_factory.py
@@ -13,12 +13,8 @@ def _cfg(engine="hindsight"):
         memory=SimpleNamespace(
             engine=engine,
             embedding=SimpleNamespace(
-                model="BAAI/bge-small-en-v1.5",
-                rerank_enabled=False,
-                rerank_url="http://127.0.0.1:8086",
                 rerank_gateway_url="http://127.0.0.1:8080",
-                rerank_over_fetch_factor=5,
-                rerank_max_candidates=500,
+                rerank_model="builtin.jina-reranker-v1-tiny-en-q8",
                 rerank_connect_timeout_s=1.0,
                 rerank_read_timeout_s=8.0,
             ),
@@ -66,12 +62,8 @@ def test_factory_default_engine_is_hindsight_after_cutover():
     cfg = SimpleNamespace(
         memory=SimpleNamespace(
             embedding=SimpleNamespace(
-                model="m",
-                rerank_enabled=False,
-                rerank_url="http://127.0.0.1:8086",
                 rerank_gateway_url="http://127.0.0.1:8080",
-                rerank_over_fetch_factor=5,
-                rerank_max_candidates=500,
+                rerank_model="builtin.jina-reranker-v1-tiny-en-q8",
                 rerank_connect_timeout_s=1.0,
                 rerank_read_timeout_s=8.0,
             ),

--- a/ui/src/api/hooks/useMemory.ts
+++ b/ui/src/api/hooks/useMemory.ts
@@ -88,6 +88,9 @@ export interface MemoryGraphStatus {
   slot_resolves: boolean
   // Enabled llm slot names the operator may pick.
   available_slots: string[]
+  // Hindsight daemon LLM timeout ([memory.graph].llm_timeout_s) — echoed by
+  // the status route so the settings panel can edit it in one round trip.
+  llm_timeout_s?: number
   in_flight: number
   builds_ok: number
   errors: number
@@ -98,6 +101,7 @@ export interface MemoryGraphStatus {
 export interface MemoryGraphUpdate {
   enabled?: boolean
   extraction_slot?: string
+  llm_timeout_s?: number
 }
 
 // ADR-0023 §3: when the extraction slot changes, the PUT response carries a

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -1304,21 +1304,23 @@ function GeneralSection() {
 //
 // memory.engine is a plain string in the schema (validator-enforced), so
 // its options are pinned here to the backend's accepted set.
-// Keys deliberately NOT exposed even though they're in the schema, because
-// the backend doesn't consume them yet (verified against src/hal0):
-// slots.max_slots, slots.port_range_start/end (allocation is hardcoded
-// 8081-8099), dispatcher.prefetch_parallel_cap, memory.embedding.model,
-// and the cognee-era rerank knobs (rerank_enabled/url/over_fetch/
-// max_candidates). Add them back once the backend wires them.
+// Every key here is verified consumed by the backend: max_slots gates
+// POST /api/slots, the port pool feeds the auto-allocator (both read from
+// the live config — no restart), the dispatcher knobs bound the cold
+// prefetch fanout, and the memory rerank knobs configure Hal0Reranker.
+// (The cognee-era embedding keys were deleted from the schema.)
 const ADV_GROUPS = [
   { title: "Slots runtime", sub: "hal0.toml [slots]", keys: [
+    "slots.max_slots", "slots.port_range_start", "slots.port_range_end",
     "slots.idle_timeout_s", "slots.evict_pressure_mb",
   ]},
   { title: "Dispatcher", sub: "hal0.toml [dispatcher]", keys: [
-    "dispatcher.prefetch_timeout_s",
+    "dispatcher.prefetch_timeout_s", "dispatcher.prefetch_parallel_cap",
   ]},
-  { title: "Memory", sub: "hal0.toml [memory] · engine + rerank timeouts; graph extraction below", keys: [
+  { title: "Memory", sub: "hal0.toml [memory] · engine + reranker; graph extraction below", keys: [
     "memory.engine",
+    "memory.embedding.rerank_gateway_url",
+    "memory.embedding.rerank_model",
     "memory.embedding.rerank_connect_timeout_s",
     "memory.embedding.rerank_read_timeout_s",
   ]},
@@ -1621,13 +1623,21 @@ function MemoryGraphPanel() {
 
   const [enabled, setEnabled] = useStateSet(false);
   const [slot, setSlot] = useStateSet("");
+  const [timeoutS, setTimeoutS] = useStateSet("300");
   useEffectSet(() => {
     if (!st) return;
     setEnabled(!!st.enabled);
     setSlot(st.extraction_slot || "");
-  }, [st?.enabled, st?.extraction_slot]);
+    if (st.llm_timeout_s != null) setTimeoutS(String(st.llm_timeout_s));
+  }, [st?.enabled, st?.extraction_slot, st?.llm_timeout_s]);
 
-  const dirty = !!st && (enabled !== !!st.enabled || slot !== (st.extraction_slot || ""));
+  const timeoutNum = parseInt(timeoutS, 10);
+  const timeoutValid = /^\d+$/.test(timeoutS.trim()) && timeoutNum >= 30 && timeoutNum <= 3600;
+  const dirty = !!st && (
+    enabled !== !!st.enabled
+    || slot !== (st.extraction_slot || "")
+    || (st.llm_timeout_s != null && timeoutS !== String(st.llm_timeout_s))
+  );
   const slots = st?.available_slots || [];
   // Keep the currently-configured slot pickable even when it no longer
   // resolves, so the operator can see (and move off) a stale value.
@@ -1637,6 +1647,7 @@ function MemoryGraphPanel() {
     try {
       const body = { enabled };
       if (slot) body.extraction_slot = slot;
+      if (timeoutValid) body.llm_timeout_s = timeoutNum;
       const resp = await updateGraph.mutateAsync(body);
       const perr = resp?.propagation?.error;
       window.__hal0Toast && window.__hal0Toast(
@@ -1695,6 +1706,19 @@ function MemoryGraphPanel() {
           )
         }
       />
+      <SRow
+        k="LLM timeout"
+        sub="Seconds the Hindsight daemon waits on extraction / consolidation / reflect calls (30–3600) · covers cold slot starts"
+        v={
+          <input
+            type="number" min={30} max={3600} value={timeoutS} disabled={!st}
+            onChange={e => setTimeoutS(e.target.value)}
+            placeholder="300"
+            className="mono"
+            style={{..._advInputStyle, width: 100, borderColor: timeoutValid || !timeoutS ? "var(--line)" : "var(--err)"}}
+          />
+        }
+      />
       {st && (
         <SRow
           k="Extraction health"
@@ -1710,9 +1734,13 @@ function MemoryGraphPanel() {
       )}
       <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
         {dirty && (
-          <button className="btn ghost sm" onClick={() => { setEnabled(!!st?.enabled); setSlot(st?.extraction_slot || ""); }}>Reset</button>
+          <button className="btn ghost sm" onClick={() => {
+            setEnabled(!!st?.enabled);
+            setSlot(st?.extraction_slot || "");
+            setTimeoutS(st?.llm_timeout_s != null ? String(st.llm_timeout_s) : "300");
+          }}>Reset</button>
         )}
-        <button className="btn sm" disabled={!dirty || updateGraph.isPending} onClick={doSave}>
+        <button className="btn sm" disabled={!dirty || !timeoutValid || updateGraph.isPending} onClick={doSave}>
           {updateGraph.isPending ? "Saving…" : "Save graph settings"}
         </button>
       </div>


### PR DESCRIPTION
## What

Phases 1–2 of the settings-completeness plan: every `hal0.toml` key that was persisted but never read is now **actually consumed** (or deleted where consuming it would be dangerous), and `[memory.embedding]` is rebuilt for the hindsight era. Follow-up to #1031.

### Phase 1 — wire the inert keys

- **`slots.max_slots`** — creation gate in `POST /api/slots`, read from the **live** config on every create (apply-class `immediate`, no restart). Seeded slots count toward the budget and the 400 (`slot.capacity_exhausted`) says so with counts. `GET /api/slots/capacity` gains `slot_budget: {used_slots, max_slots}`.
- **`slots.port_range_start/end`** — the port auto-allocator now draws from the configured pool instead of hardcoded 8081–8099 (`immediate`). Schema default end drops 8200 → new `_SLOT_PORT_POOL_END = 8099` so auto-created slots can never squat on ComfyUI's 8188; per-slot `port` validation stays 8081–8200 so the seeded img slot still validates.
- **`dispatcher.prefetch_parallel_cap`** — `asyncio.Semaphore` around the cold-prefetch fanout legs, threaded at `create_app` beside `prefetch_timeout_s`.
- **`memory.embedding.model`** — deleted rather than wired: hindsight embeds server-side with its own bundled model, and swapping embedders changes vector dimensionality, corrupting existing banks with no in-tree migration.

### Phase 2 — hindsight-era `[memory.embedding]`

- Deleted the cognee-era keys (`model`, `rerank_enabled`, `rerank_url`, `rerank_over_fetch_factor`, `rerank_max_candidates`). `extra="ignore"` silently drops them from an older `hal0.toml` on load — same migration path ADR-0023 used for `[memory.graph]`'s `route`/`upstream`.
- Promoted **`rerank_gateway_url`** from a hidden `getattr` fallback to a real schema field; added **`rerank_model`** (previously hardcoded in `Hal0Reranker`). Both threaded into the reranker at startup.
- New **`memory.graph.llm_timeout_s`** (30–3600s, default 300) — propagated to hindsight-api as `HINDSIGHT_API_LLM_TIMEOUT` via the same systemd drop-in as the extraction slot; `PUT /api/memory/graph` accepts it, the status route echoes it, and the drop-in now carries both env lines.

### Registry + UI

- Apply-plan registry corrected: `max_slots`/port pool → `immediate`, dead keys removed, new keys registered.
- Settings → Advanced now exposes all wired keys (max_slots, port pool, parallel cap, rerank gateway/model); the memory graph panel gains the LLM-timeout field with 30–3600 validation.

## Verification

- `uv run pytest tests/api tests/memory tests/dispatcher tests/config tests/slots` — 2069 passed; the only failure is the pre-existing `test_set_store_rejects_non_writable_path` (fails on clean main).
- New coverage: `tests/api/test_slots_policy.py` (gate, pool allocation, budget endpoint), prefetch parallel-cap concurrency test, drop-in timeout tests, cognee-key silent-drop migration test.
- `ruff check` / `ruff format --check` clean; UI `npm run build` + `typecheck` clean; dash unit tests 3/3.

## Out of scope (per the approved plan)

Phase 3 (Voice: fix the dead `default_voice` field, voices proxy endpoint, speed/format defaults), Phase 4 (Settings → NPU section), Phase 5 (ComfyUI arbiter re-read hook + workflow listing) land as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR)_