### PR TITLE
Unified companion-service management: registry, /api/services, mDNS, dashboard Services page

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -106,6 +106,9 @@ from hal0.api.routes import (
     secrets as secrets_routes,
 )
 from hal0.api.routes import (
+    services as services_routes,
+)
+from hal0.api.routes import (
     stacks as stacks_routes,
 )
 from hal0.capabilities.orchestrator import CapabilityOrchestrator
@@ -1152,6 +1155,10 @@ def create_app() -> FastAPI:
     app.include_router(throughput.router, prefix="/api", tags=["stats"])
     app.include_router(power.router, prefix="/api", tags=["stats"])
     app.include_router(services_health.router, prefix="/api/services", tags=["services"])
+    # Services management page (registry-driven detail + lifecycle + mDNS):
+    #   services_routes.router → GET /api/services, POST /api/services/{id}/action,
+    #   GET/POST /api/services/mdns — see hal0/services/ for the registry.
+    app.include_router(services_routes.router, prefix="/api/services", tags=["services"])
     app.include_router(dashboard_layout.router, prefix="/api/user", tags=["user"])
     app.include_router(logs.router, prefix="/api/logs", tags=["logs"])
     app.include_router(

--- a/src/hal0/api/routes/services.py
+++ b/src/hal0/api/routes/services.py
@@ -1,0 +1,285 @@
+"""Companion-service management routes (mounted under /api/services).
+
+The richer sibling of ``services_health.py`` (which keeps its stable
+read-only ``GET /api/services/health`` contract for the Overview card).
+This router powers the dedicated dashboard Services page:
+
+    GET  /api/services                → full per-service detail: probe state,
+                                        systemd unit state (+uptime), browser
+                                        URL, mDNS URL, permitted actions.
+    POST /api/services/{id}/action    → run one allow-listed lifecycle verb
+                                        (start/stop/restart/enable/disable),
+                                        audit-logged.
+    GET  /api/services/mdns           → avahi/mDNS discovery status.
+    POST /api/services/mdns           → advertise/withdraw addon services as
+                                        <name>.local avahi announcements.
+
+Per-service logs reuse the existing generic journald surface
+(``GET /api/logs?unit=<unit>``) — each list entry carries its ``unit`` so
+the UI can wire the logs drawer without a new endpoint.
+
+Probes are shared with services_health (same honest up/down rules: a
+probe failure degrades to up=false, never a 500 and never a fabricated
+"up"). Lifecycle verbs run through ``hal0.services.systemd`` which
+re-enforces the verb allow-list at the execution boundary; the per-service
+verb subset lives in ``hal0.services.registry`` (e.g. ComfyUI only exposes
+``restart`` because the GpuArbiter owns its start/stop path).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import structlog
+from fastapi import APIRouter, Request
+
+from hal0.api._audit import record_action
+from hal0.api.routes.config import _behind_proxy, _host_without_port, _resolve_host
+from hal0.api.routes.services_health import (
+    _PROBE_TIMEOUT,
+    _probe_comfyui,
+    _probe_hermes,
+    _probe_openwebui,
+)
+from hal0.errors import BadRequest, NotFound
+from hal0.services import mdns
+from hal0.services import systemd as svc_systemd
+from hal0.services.registry import SERVICES, ServiceDef, service_by_id
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+# ── URL derivation ────────────────────────────────────────────────────────────
+
+
+def _public_url(sdef: ServiceDef) -> str | None:
+    """Operator-declared public URL (reverse-proxy deploys), or None."""
+    if not sdef.public_url_env:
+        return None
+    return os.environ.get(sdef.public_url_env, "").strip().rstrip("/") or None
+
+
+def _browser_url(request: Request, sdef: ServiceDef) -> str | None:
+    """Browser-reachable URL for a service, mirroring config.py semantics.
+
+    Public-URL env wins; otherwise LAN-published services fall back to
+    ``http://<request-host>:<port>``. Loopback-only services (hermes,
+    hindsight) have no fallback — link only when the env is set.
+    """
+    public = _public_url(sdef)
+    if public:
+        return public
+    if sdef.port is None:
+        return None
+    if _behind_proxy(request):
+        host = request.headers.get("x-forwarded-host") or _resolve_host(request)
+    else:
+        host = _resolve_host(request)
+    return f"http://{_host_without_port(host)}:{sdef.port}"
+
+
+def _mdns_url(sdef: ServiceDef, hostname: str, advertised: list[str]) -> str | None:
+    """``http://<host>.local:<port>`` when this service is being advertised."""
+    if sdef.port is None or sdef.id not in advertised:
+        return None
+    return f"http://{hostname}:{sdef.port}"
+
+
+# ── probes ────────────────────────────────────────────────────────────────────
+
+
+async def _probe_http_env(sdef: ServiceDef) -> tuple[bool, str]:
+    """Generic loopback HTTP probe with env override; honest when unwired."""
+    url = ""
+    if sdef.probe_url_env:
+        url = os.environ.get(sdef.probe_url_env, "").strip().rstrip("/")
+    url = url or (sdef.probe_url or "")
+    if not url:
+        return False, "unmonitored"
+    try:
+        async with httpx.AsyncClient(timeout=_PROBE_TIMEOUT) as client:
+            resp = await client.get(url)
+    except httpx.HTTPError as exc:
+        return False, f"unreachable ({type(exc).__name__})"
+    if 200 <= resp.status_code < 300:
+        return True, "reachable — probe ok"
+    return False, f"unhealthy (HTTP {resp.status_code})"
+
+
+async def _probe(
+    sdef: ServiceDef, unit_state: dict[str, Any] | None
+) -> tuple[bool, str, dict[str, str] | None]:
+    """Dispatch to the service's probe strategy → (up, detail, stat)."""
+    if sdef.probe == "comfyui":
+        up, detail, stat, _url = await _probe_comfyui()
+        return up, detail, stat
+    if sdef.probe == "http":
+        if sdef.id == "openwebui":
+            up, detail = await _probe_openwebui()
+        else:
+            up, detail = await _probe_http_env(sdef)
+        return up, detail, None
+    if sdef.probe == "systemd":
+        if sdef.id == "hermes":
+            up, detail = await _probe_hermes()
+            return up, detail, None
+        active = bool(unit_state) and unit_state.get("active_state") == "active"
+        detail = "systemd unit active" if active else "systemd unit inactive or absent"
+        return active, detail, None
+    return False, "unmonitored", None
+
+
+# ── routes ────────────────────────────────────────────────────────────────────
+
+
+@router.get("")
+async def list_services(request: Request) -> dict[str, Any]:
+    """Full management view of every registered companion service.
+
+    Never 500s — every probe/systemd failure degrades to honest unknowns.
+    """
+    disco = await mdns.status()
+    hostname = str(disco["hostname"])
+    advertised = list(disco["advertised"])  # type: ignore[arg-type]
+
+    services: list[dict[str, Any]] = []
+    for sdef in SERVICES:
+        unit_state: dict[str, Any] | None = None
+        if sdef.unit:
+            try:
+                unit_state = await svc_systemd.unit_state(sdef.unit)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("services.unit_state_error", unit=sdef.unit, exc=repr(exc))
+
+        try:
+            up, detail, stat = await _probe(sdef, unit_state)
+        except Exception as exc:
+            log.warning("services.probe_error", service=sdef.id, exc=repr(exc))
+            up, detail, stat = False, type(exc).__name__, None
+
+        services.append(
+            {
+                "id": sdef.id,
+                "name": sdef.name,
+                "description": sdef.description,
+                "managed": sdef.unit is not None,
+                "unit": sdef.unit,
+                "unit_state": unit_state,
+                "up": up,
+                "detail": detail,
+                "stat": stat,
+                "url": _browser_url(request, sdef),
+                "mdns_url": _mdns_url(sdef, hostname, advertised),
+                "loopback_port": sdef.loopback_port,
+                "actions": list(sdef.actions),
+                "mdns_capable": sdef.mdns,
+                "hints": list(sdef.hints),
+            }
+        )
+    return {"services": services, "mdns": disco}
+
+
+@router.post("/{service_id}/action")
+async def service_action(service_id: str, request: Request) -> dict[str, Any]:
+    """Run one lifecycle verb against a registered service's unit.
+
+    Body: ``{"action": "start"|"stop"|"restart"|"enable"|"disable"}``.
+    The verb must be in the service's registry allow-list — e.g. ComfyUI
+    accepts only ``restart`` (its start/stop belongs to the GPU arbiter).
+    Audit-logged with a truthful outcome.
+    """
+    sdef = service_by_id(service_id)
+    if sdef is None:
+        raise NotFound(
+            f"unknown service {service_id!r}",
+            details={"service": service_id, "known": [s.id for s in SERVICES]},
+            code="services.unknown",
+        )
+
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("request body must be valid JSON", code="request.invalid_json") from exc
+    action = body.get("action") if isinstance(body, dict) else None
+    if not isinstance(action, str) or not action:
+        raise BadRequest("'action' is required", code="services.action_required")
+    if action not in sdef.actions or sdef.unit is None:
+        raise BadRequest(
+            f"action {action!r} is not allowed for service {service_id!r}",
+            details={"service": service_id, "allowed": list(sdef.actions)},
+            code="services.action_not_allowed",
+        )
+
+    async with record_action(
+        request,
+        category="services",
+        action=f"services.{action}",
+        target=sdef.unit,
+    ) as rec:
+        result = await svc_systemd.unit_action(sdef.unit, action)
+        active = await svc_systemd.unit_is_active(sdef.unit)
+        rec.after = {"ok": result["ok"], "active": active}
+        rec.message = str(result["message"])
+
+    return {
+        "id": sdef.id,
+        "unit": sdef.unit,
+        "action": action,
+        "ok": result["ok"],
+        "active": active,
+        "message": result["message"],
+    }
+
+
+@router.get("/mdns")
+async def mdns_status() -> dict[str, Any]:
+    """avahi/mDNS discovery status + which addon services we advertise."""
+    disco = await mdns.status()
+    disco["advertisable"] = [
+        {"id": s.id, "name": s.name, "port": s.port} for s in SERVICES if s.mdns
+    ]
+    return disco
+
+
+@router.post("/mdns")
+async def mdns_apply(request: Request) -> dict[str, Any]:
+    """Advertise (or withdraw) the addon services over mDNS.
+
+    Body: ``{"advertise": true|false}``. Advertise writes one avahi
+    service-group file per mdns-capable service (avahi picks the files up
+    via inotify — no reload); withdraw removes every hal0-addon file.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("request body must be valid JSON", code="request.invalid_json") from exc
+    advertise = body.get("advertise") if isinstance(body, dict) else None
+    if not isinstance(advertise, bool):
+        raise BadRequest("'advertise' (boolean) is required", code="services.advertise_required")
+
+    async with record_action(
+        request,
+        category="services",
+        action="services.mdns_advertise" if advertise else "services.mdns_withdraw",
+        target="avahi",
+    ) as rec:
+        if advertise:
+            entries = [(s.id, s.name, s.port) for s in SERVICES if s.mdns and s.port]
+            result = mdns.advertise(entries)
+        else:
+            result = mdns.withdraw()
+        rec.after = {"ok": result["ok"], "advertised": result["advertised"]}
+        if result["message"]:
+            rec.message = str(result["message"])
+
+    disco = await mdns.status()
+    disco["ok"] = result["ok"]
+    disco["message"] = result["message"]
+    return disco
+
+
+__all__ = ["router"]

--- a/src/hal0/services/__init__.py
+++ b/src/hal0/services/__init__.py
@@ -1,0 +1,26 @@
+"""Companion-service management layer.
+
+hal0 ships with (or sits next to) a set of companion services — OpenWebUI,
+Hermes, Hindsight, ComfyUI, n8n — each with its own systemd unit, port,
+probe, and browser-facing URL. This package is the single declarative
+source of truth for that set:
+
+* :mod:`hal0.services.registry` — the catalog (``ServiceDef`` + ``SERVICES``):
+  which unit owns a service, how it is probed, which lifecycle actions the
+  API may run on it, and how its URL is derived.
+* :mod:`hal0.services.systemd` — shared, allow-listed systemctl helpers
+  (state introspection + lifecycle verbs), fail-soft on hosts without
+  systemd.
+* :mod:`hal0.services.mdns` — avahi/mDNS discovery status and per-service
+  ``.local`` advertisement (drop-in service files under
+  ``/etc/avahi/services``, which avahi-daemon picks up without a reload).
+
+The HTTP surface lives in ``hal0.api.routes.services`` (mounted at
+``/api/services``); the read-only health aggregator predating this package
+(``hal0.api.routes.services_health``, ``GET /api/services/health``) keeps
+its contract and shares probe implementations.
+"""
+
+from hal0.services.registry import SERVICES, ServiceDef, service_by_id
+
+__all__ = ["SERVICES", "ServiceDef", "service_by_id"]

--- a/src/hal0/services/mdns.py
+++ b/src/hal0/services/mdns.py
@@ -1,0 +1,150 @@
+"""mDNS / avahi discovery for companion services.
+
+The installer already drops ``/etc/avahi/services/hal0.service`` (the main
+UI announcement — see packaging/avahi/hal0.service). This module extends
+that to the *addon* services: one avahi service-group file per advertised
+addon (``hal0-addon-<id>.service``), so LAN clients see distinct
+"OpenWebUI on <host>" / "ComfyUI on <host>" entries and each service is
+reachable as ``http://<host>.local:<port>`` without DNS.
+
+avahi-daemon inotify-watches ``/etc/avahi/services`` — writing or removing
+a file takes effect immediately, no daemon reload and no systemctl call.
+
+Only files matching our ``hal0-addon-*.service`` prefix are ever written or
+removed; the installer-owned ``hal0.service`` is never touched.
+
+``HAL0_AVAHI_SERVICES_DIR`` overrides the directory (tests / non-standard
+layouts). Everything is fail-soft: a host without avahi reports
+``available=False`` and writes simply fail with an honest message.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from hal0.services import systemd
+
+_ADDON_PREFIX = "hal0-addon-"
+_AVAHI_UNIT = "avahi-daemon.service"
+
+
+def services_dir() -> Path:
+    """The avahi services directory (env-overridable for tests)."""
+    override = os.environ.get("HAL0_AVAHI_SERVICES_DIR", "").strip()
+    return Path(override) if override else Path("/etc/avahi/services")
+
+
+def mdns_hostname() -> str:
+    """The ``<host>.local`` name this machine answers to via avahi.
+
+    avahi advertises the machine's hostname; ``HAL0_HOSTNAME`` (the install
+    wizard's choice) wins when set so the dashboard matches what the
+    installer announced.
+    """
+    host = os.environ.get("HAL0_HOSTNAME", "").strip() or socket.gethostname()
+    host = host.removesuffix(".local").strip(".") or "hal0"
+    return f"{host}.local"
+
+
+def _addon_path(service_id: str) -> Path:
+    return services_dir() / f"{_ADDON_PREFIX}{service_id}.service"
+
+
+def advertised_ids() -> list[str]:
+    """Service ids currently advertised via our addon files."""
+    try:
+        files = sorted(services_dir().glob(f"{_ADDON_PREFIX}*.service"))
+    except OSError:
+        return []
+    return [f.stem.removeprefix(_ADDON_PREFIX) for f in files]
+
+
+async def status() -> dict[str, object]:
+    """Discovery status for the dashboard.
+
+    ``available`` is a real signal (avahi-daemon unit active), not a guess
+    from binary presence — matches the services_health "no fabricated up"
+    rule.
+    """
+    d = services_dir()
+    return {
+        "available": await systemd.unit_is_active(_AVAHI_UNIT),
+        "hostname": mdns_hostname(),
+        "base_advertised": (d / "hal0.service").is_file(),
+        "advertised": advertised_ids(),
+    }
+
+
+def _service_group_xml(name: str, port: int) -> str:
+    """Render one avahi service-group announcing an HTTP service."""
+    safe = escape(name)
+    return f"""<?xml version="1.0" standalone='no'?>
+<!-- Written by hal0 (services mDNS advertisement) — do not edit by hand.
+     Managed via the dashboard Services page / POST /api/services/mdns. -->
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">{safe} on %h</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>{port}</port>
+    <txt-record>path=/</txt-record>
+    <txt-record>name={safe}</txt-record>
+  </service>
+</service-group>
+"""
+
+
+def advertise(entries: list[tuple[str, str, int]]) -> dict[str, object]:
+    """Write one addon file per (id, name, port); prune stale addon files.
+
+    Atomic per file (tmp + rename in the same directory). Returns
+    ``{"ok": bool, "advertised": [...], "message": str | None}``.
+    """
+    d = services_dir()
+    try:
+        d.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return {"ok": False, "advertised": [], "message": f"cannot create {d}: {exc}"}
+
+    wanted = {sid for sid, _name, _port in entries}
+    errors: list[str] = []
+    for sid, name, port in entries:
+        target = _addon_path(sid)
+        tmp = target.with_suffix(".tmp")
+        try:
+            tmp.write_text(_service_group_xml(name, port), encoding="utf-8")
+            tmp.replace(target)
+        except OSError as exc:
+            errors.append(f"{sid}: {exc}")
+    # Prune addon files for services no longer advertised (never touches
+    # the installer-owned hal0.service).
+    for sid in advertised_ids():
+        if sid not in wanted:
+            try:
+                _addon_path(sid).unlink(missing_ok=True)
+            except OSError as exc:
+                errors.append(f"{sid}: {exc}")
+
+    return {
+        "ok": not errors,
+        "advertised": advertised_ids(),
+        "message": "; ".join(errors) or None,
+    }
+
+
+def withdraw() -> dict[str, object]:
+    """Remove every hal0-addon-*.service file."""
+    return advertise([])
+
+
+__all__ = [
+    "advertise",
+    "advertised_ids",
+    "mdns_hostname",
+    "services_dir",
+    "status",
+    "withdraw",
+]

--- a/src/hal0/services/registry.py
+++ b/src/hal0/services/registry.py
@@ -1,0 +1,133 @@
+"""Declarative catalog of hal0 companion services.
+
+One ``ServiceDef`` per service, consumed by the ``/api/services`` routes.
+Everything the API needs to reason about a service lives here: the owning
+systemd unit, how to probe it, which lifecycle verbs are permitted, and how
+to derive a browser-facing URL.
+
+Design constraints baked into the entries (see the unit map in
+ARCHITECTURE.md and packaging/ + installer/systemd/):
+
+* ComfyUI's lifecycle is owned by the seeded img slot unit
+  (``hal0-slot@img.service``); a raw ``systemctl stop`` would bypass the
+  GpuArbiter switchover logic in ``hal0.api.routes.comfyui``, so only
+  ``restart`` is exposed — the same verb the FirstRun repair button uses.
+* Hermes (``hal0-agent@hermes.service``, :9119) and Hindsight
+  (``hindsight-api.service``, :9177) bind loopback-only: no host:port URL
+  fallback exists, so a link is advertised only via their
+  ``HAL0_*_PUBLIC_URL`` env override.
+* n8n has no in-repo unit — it is an *external* service the operator may
+  run themselves. It is listed (with URL/probe env hooks) but carries no
+  lifecycle actions until a unit exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+#: Every lifecycle verb any service may carry. ``systemd.unit_action``
+#: enforces this set again at the execution boundary.
+LIFECYCLE_ACTIONS = ("start", "stop", "restart", "enable", "disable")
+
+#: Full verb set for services whose unit hal0 owns outright.
+_FULL = LIFECYCLE_ACTIONS
+
+
+@dataclass(frozen=True)
+class ServiceDef:
+    """One companion service as the management layer sees it."""
+
+    id: str
+    name: str
+    description: str
+    #: Owning systemd unit; None = unmanaged/external (no lifecycle actions).
+    unit: str | None = None
+    #: LAN-published port for the host:port URL fallback; None when the
+    #: service binds loopback-only (or isn't deployed by hal0 at all).
+    port: int | None = None
+    #: Env var carrying an operator-declared public URL (reverse proxy).
+    public_url_env: str | None = None
+    #: Probe strategy: "http" | "systemd" | "comfyui" | "none".
+    probe: str = "none"
+    #: Default URL for http probes (loopback), overridable via probe_url_env.
+    probe_url: str | None = None
+    probe_url_env: str | None = None
+    #: Lifecycle verbs the API may run for this service (subset of
+    #: LIFECYCLE_ACTIONS). Empty = read-only.
+    actions: tuple[str, ...] = ()
+    #: Advertise via avahi/mDNS when the operator enables addon
+    #: advertisement. Only meaningful for LAN-published ports.
+    mdns: bool = False
+    #: Loopback bind port, informational only (shown in the UI so operators
+    #: know where a loopback-only service lives).
+    loopback_port: int | None = None
+    #: Extra UI hints (e.g. where deeper controls live).
+    hints: tuple[str, ...] = field(default=())
+
+
+SERVICES: tuple[ServiceDef, ...] = (
+    ServiceDef(
+        id="openwebui",
+        name="OpenWebUI",
+        description="Chat UI companion (podman container, LAN :3001).",
+        unit="hal0-openwebui.service",
+        port=3001,
+        public_url_env="HAL0_OPENWEBUI_PUBLIC_URL",
+        probe="http",
+        probe_url="http://127.0.0.1:3001/health",
+        probe_url_env="HAL0_OPENWEBUI_PROBE_URL",
+        actions=_FULL,
+        mdns=True,
+    ),
+    ServiceDef(
+        id="comfyui",
+        name="ComfyUI",
+        description="Image generation engine (img slot container, LAN :8188).",
+        unit="hal0-slot@img.service",
+        port=8188,
+        public_url_env="HAL0_COMFYUI_PUBLIC_URL",
+        probe="comfyui",
+        actions=("restart",),
+        mdns=True,
+        hints=("start/stop is GPU-arbiter managed — use the Image-Gen pane switchover",),
+    ),
+    ServiceDef(
+        id="hermes",
+        name="Hermes",
+        description="Bundled agent + dashboard (loopback :9119).",
+        unit="hal0-agent@hermes.service",
+        public_url_env="HAL0_HERMES_PUBLIC_URL",
+        probe="systemd",
+        actions=_FULL,
+        loopback_port=9119,
+    ),
+    ServiceDef(
+        id="hindsight",
+        name="Hindsight",
+        description="Memory engine (native daemon, loopback :9177).",
+        unit="hindsight-api.service",
+        probe="systemd",
+        actions=_FULL,
+        loopback_port=9177,
+    ),
+    ServiceDef(
+        id="n8n",
+        name="n8n",
+        description="Workflow automation (external — not deployed by hal0).",
+        public_url_env="HAL0_N8N_PUBLIC_URL",
+        probe="http",
+        probe_url=None,  # unmonitored unless HAL0_N8N_PROBE_URL is set
+        probe_url_env="HAL0_N8N_PROBE_URL",
+    ),
+)
+
+
+def service_by_id(service_id: str) -> ServiceDef | None:
+    """Look up a service definition, or None for unknown ids."""
+    for sdef in SERVICES:
+        if sdef.id == service_id:
+            return sdef
+    return None
+
+
+__all__ = ["LIFECYCLE_ACTIONS", "SERVICES", "ServiceDef", "service_by_id"]

--- a/src/hal0/services/systemd.py
+++ b/src/hal0/services/systemd.py
@@ -1,0 +1,162 @@
+"""Shared systemctl helpers for the companion-service management layer.
+
+Until now every route reimplemented its own ``systemctl is-active``
+subprocess call (comfyui.py, config.py, installer.py, agents/restart.py …).
+This module is the single implementation the services surface uses:
+
+* :func:`unit_state`  — rich state via ``systemctl show`` (active/sub/
+  unit-file state + ActiveEnterTimestamp for uptime display).
+* :func:`unit_is_active` — cheap boolean probe.
+* :func:`unit_action` — run one allow-listed lifecycle verb.
+
+Everything is fail-soft: a host without systemd (CI, dev laptop) yields
+"unknown" states and honest error strings, never an exception. hal0-api
+runs as root, so systemctl is invoked directly — same assumption as
+``installer._privileged_systemctl_argv`` (the sudoers seam was removed).
+
+The verb allow-list is enforced HERE, at the execution boundary, in
+addition to the per-service ``ServiceDef.actions`` check in the route —
+a crafted request can never reach an arbitrary systemctl verb.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shutil
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+#: Verbs :func:`unit_action` will ever execute.
+ALLOWED_VERBS = frozenset({"start", "stop", "restart", "enable", "disable"})
+
+#: Per-verb subprocess timeouts (seconds). restart can pull a container
+#: image layer on ExecStartPre, so it gets headroom.
+_VERB_TIMEOUT = {
+    "start": 60.0,
+    "stop": 30.0,
+    "restart": 90.0,
+    "enable": 10.0,
+    "disable": 10.0,
+}
+
+_SHOW_TIMEOUT = 3.0
+
+# systemd unit names: letters, digits, '@-_.:\' — conservative (mirrors
+# api/routes/logs.py _validate_unit) so a unit string is always safe to
+# hand to a subprocess argv.
+_UNIT_RE = re.compile(r"^[A-Za-z0-9@_\-.:]+$")
+
+
+def valid_unit(unit: str) -> bool:
+    """True when ``unit`` is a plausible systemd unit name."""
+    return bool(unit) and bool(_UNIT_RE.match(unit))
+
+
+async def _run(*args: str, timeout: float) -> tuple[int | None, str, str]:
+    """Run ``systemctl <args>``; (rc, stdout, stderr), rc=None on no-systemd/timeout."""
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        return None, "", "systemctl not available on this host"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            systemctl,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        return None, "", f"systemctl spawn failed: {exc}"
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        proc.kill()
+        return None, "", f"systemctl {' '.join(args)} timed out after {timeout:.0f}s"
+    return (
+        proc.returncode,
+        stdout.decode("utf-8", errors="replace"),
+        stderr.decode("utf-8", errors="replace"),
+    )
+
+
+async def unit_state(unit: str) -> dict[str, str | None]:
+    """Return the unit's systemd state for display.
+
+    Shape (all values fail-soft)::
+
+        {
+          "active_state":    "active" | "inactive" | "failed" | ... | "unknown",
+          "sub_state":       "running" | "dead" | ... | "unknown",
+          "unit_file_state": "enabled" | "disabled" | ... | "unknown",
+          "since":           "Fri 2026-07-03 09:12:01 UTC" | None,
+        }
+    """
+    fallback: dict[str, str | None] = {
+        "active_state": "unknown",
+        "sub_state": "unknown",
+        "unit_file_state": "unknown",
+        "since": None,
+    }
+    if not valid_unit(unit):
+        return fallback
+    rc, stdout, _stderr = await _run(
+        "show",
+        unit,
+        "--property=ActiveState,SubState,UnitFileState,ActiveEnterTimestamp",
+        timeout=_SHOW_TIMEOUT,
+    )
+    if rc is None:
+        return fallback
+    props: dict[str, str] = {}
+    for line in stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            props[key] = value.strip()
+    # `systemctl show` exits 0 even for unloaded units (ActiveState=inactive,
+    # empty UnitFileState) — surface what it said, defaulting honestly.
+    since = props.get("ActiveEnterTimestamp", "")
+    return {
+        "active_state": props.get("ActiveState") or "unknown",
+        "sub_state": props.get("SubState") or "unknown",
+        "unit_file_state": props.get("UnitFileState") or "unknown",
+        "since": since or None,
+    }
+
+
+async def unit_is_active(unit: str) -> bool:
+    """True when ``systemctl is-active <unit>`` reports ``active``."""
+    if not valid_unit(unit):
+        return False
+    rc, stdout, _ = await _run("is-active", unit, timeout=_SHOW_TIMEOUT)
+    return rc == 0 and stdout.strip() == "active"
+
+
+async def unit_action(unit: str, verb: str) -> dict[str, object]:
+    """Run one allow-listed lifecycle verb against ``unit``.
+
+    Returns ``{"ok": bool, "message": str}`` — never raises for runtime
+    failures (missing systemd, unit errors); raises ``ValueError`` only for
+    programming errors (verb outside :data:`ALLOWED_VERBS`, bad unit name),
+    which the route layer maps to a 400.
+    """
+    if verb not in ALLOWED_VERBS:
+        raise ValueError(f"verb {verb!r} is not an allowed systemctl verb")
+    if not valid_unit(unit):
+        raise ValueError(f"invalid unit name {unit!r}")
+    rc, _stdout, stderr = await _run(verb, unit, timeout=_VERB_TIMEOUT[verb])
+    if rc == 0:
+        return {"ok": True, "message": f"{verb} {unit}: ok"}
+    detail = stderr.strip() or f"exit code {rc}"
+    log.warning("services.unit_action_failed", unit=unit, verb=verb, detail=detail)
+    return {"ok": False, "message": f"{verb} {unit} failed: {detail}"}
+
+
+__all__ = [
+    "ALLOWED_VERBS",
+    "unit_action",
+    "unit_is_active",
+    "unit_state",
+    "valid_unit",
+]

--- a/tests/api/test_services_page.py
+++ b/tests/api/test_services_page.py
@@ -1,0 +1,321 @@
+"""Tests for the services management surface (GET/POST /api/services…).
+
+Covers the registry-driven routes in ``hal0.api.routes.services`` plus the
+``hal0.services`` package helpers:
+
+  1. GET /api/services — 200, all 5 registry ids, honest shape with every
+     probe/systemd source stubbed down.
+  2. Registry invariants — comfyui only exposes restart; n8n exposes nothing.
+  3. POST action — unknown service → 404; missing/disallowed action → 400.
+  4. POST action — allowed verb runs through systemd.unit_action.
+  5. mDNS — status shape; advertise writes hal0-addon-*.service files into
+     HAL0_AVAHI_SERVICES_DIR and withdraw prunes them (installer-owned
+     hal0.service is never touched).
+  6. systemd helper — verb allow-list enforced at the execution boundary.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api.middleware import error_codes
+from hal0.api.routes.services import router as services_router
+from hal0.services import mdns
+from hal0.services import systemd as svc_systemd
+from hal0.services.registry import SERVICES, service_by_id
+
+_ROUTE = "hal0.api.routes.services"
+_EXPECTED_IDS = {"openwebui", "comfyui", "hermes", "hindsight", "n8n"}
+
+_DOWN_STATE = {
+    "active_state": "inactive",
+    "sub_state": "dead",
+    "unit_file_state": "disabled",
+    "since": None,
+}
+
+
+@pytest.fixture
+def svc_client() -> TestClient:
+    """Minimal app with only the services management router mounted."""
+    app = FastAPI()
+    error_codes.install(app)
+    app.include_router(services_router, prefix="/api/services")
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _stub_all_down() -> list:
+    """Patchers pinning every probe/systemd source to a neutral down state."""
+    return [
+        patch(
+            f"{_ROUTE}._probe_comfyui",
+            new_callable=AsyncMock,
+            return_value=(False, "unreachable", None, None),
+        ),
+        patch(
+            f"{_ROUTE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
+            f"{_ROUTE}._probe_openwebui",
+            new_callable=AsyncMock,
+            return_value=(False, "unreachable (ConnectError)"),
+        ),
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_state",
+            new_callable=AsyncMock,
+            return_value=dict(_DOWN_STATE),
+        ),
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_is_active",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            f"{_ROUTE}.mdns.status",
+            new_callable=AsyncMock,
+            return_value={
+                "available": False,
+                "hostname": "testhost.local",
+                "base_advertised": False,
+                "advertised": [],
+            },
+        ),
+    ]
+
+
+def _services_by_id(body: dict) -> dict:
+    return {s["id"]: s for s in body["services"]}
+
+
+# ── 1. list shape ─────────────────────────────────────────────────────────────
+
+
+def test_list_services_200_all_ids(svc_client: TestClient) -> None:
+    with contextlib.ExitStack() as stack:
+        for p in _stub_all_down():
+            stack.enter_context(p)
+        r = svc_client.get("/api/services")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    by_id = _services_by_id(body)
+    assert set(by_id) == _EXPECTED_IDS
+    assert body["mdns"]["hostname"] == "testhost.local"
+
+    for svc in body["services"]:
+        for key in (
+            "id",
+            "name",
+            "description",
+            "managed",
+            "unit",
+            "unit_state",
+            "up",
+            "detail",
+            "stat",
+            "url",
+            "mdns_url",
+            "actions",
+            "mdns_capable",
+            "hints",
+        ):
+            assert key in svc, f"{svc['id']} missing {key}"
+        assert svc["up"] is False  # everything stubbed down → honest false
+
+    # n8n is unmanaged: no unit, no unit_state, no actions.
+    assert by_id["n8n"]["managed"] is False
+    assert by_id["n8n"]["unit"] is None
+    assert by_id["n8n"]["actions"] == []
+    # openwebui is fully managed and carries the host:port URL fallback.
+    assert by_id["openwebui"]["managed"] is True
+    assert by_id["openwebui"]["url"] == "http://testserver:3001"
+    # loopback-only services expose no URL without a public-URL env.
+    assert by_id["hindsight"]["url"] is None
+
+
+# ── 2. registry invariants ────────────────────────────────────────────────────
+
+
+def test_registry_comfyui_restart_only() -> None:
+    comfy = service_by_id("comfyui")
+    assert comfy is not None
+    assert comfy.actions == ("restart",)
+    assert comfy.unit == "hal0-slot@img.service"
+
+
+def test_registry_n8n_readonly() -> None:
+    n8n = service_by_id("n8n")
+    assert n8n is not None
+    assert n8n.actions == ()
+    assert n8n.unit is None
+
+
+def test_registry_units_are_valid_names() -> None:
+    for sdef in SERVICES:
+        if sdef.unit is not None:
+            assert svc_systemd.valid_unit(sdef.unit), sdef.unit
+
+
+# ── 3. action validation ──────────────────────────────────────────────────────
+
+
+def test_action_unknown_service_404(svc_client: TestClient) -> None:
+    r = svc_client.post("/api/services/nope/action", json={"action": "restart"})
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "services.unknown"
+
+
+def test_action_missing_action_400(svc_client: TestClient) -> None:
+    r = svc_client.post("/api/services/openwebui/action", json={})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "services.action_required"
+
+
+def test_action_disallowed_verb_400(svc_client: TestClient) -> None:
+    # ComfyUI: stop is arbiter-owned, registry only allows restart.
+    r = svc_client.post("/api/services/comfyui/action", json={"action": "stop"})
+    assert r.status_code == 400
+    body = r.json()["error"]
+    assert body["code"] == "services.action_not_allowed"
+    assert body["details"]["allowed"] == ["restart"]
+
+
+def test_action_unmanaged_service_400(svc_client: TestClient) -> None:
+    r = svc_client.post("/api/services/n8n/action", json={"action": "start"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "services.action_not_allowed"
+
+
+# ── 4. action happy path ──────────────────────────────────────────────────────
+
+
+def test_action_restart_runs_unit_action(svc_client: TestClient) -> None:
+    with (
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_action",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "message": "restart hal0-openwebui.service: ok"},
+        ) as action_mock,
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_is_active",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        r = svc_client.post("/api/services/openwebui/action", json={"action": "restart"})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {
+        "id": "openwebui",
+        "unit": "hal0-openwebui.service",
+        "action": "restart",
+        "ok": True,
+        "active": True,
+        "message": "restart hal0-openwebui.service: ok",
+    }
+    action_mock.assert_awaited_once_with("hal0-openwebui.service", "restart")
+
+
+def test_action_failure_reported_honestly(svc_client: TestClient) -> None:
+    with (
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_action",
+            new_callable=AsyncMock,
+            return_value={"ok": False, "message": "start hindsight-api.service failed: boom"},
+        ),
+        patch(
+            f"{_ROUTE}.svc_systemd.unit_is_active",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        r = svc_client.post("/api/services/hindsight/action", json={"action": "start"})
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert body["active"] is False
+
+
+# ── 5. mDNS ───────────────────────────────────────────────────────────────────
+
+
+def test_mdns_advertise_and_withdraw(svc_client: TestClient, tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_AVAHI_SERVICES_DIR", str(tmp_path))
+    # Installer-owned base file must survive advertise/withdraw untouched.
+    base = tmp_path / "hal0.service"
+    base.write_text("<!-- installer-owned -->", encoding="utf-8")
+
+    with patch(
+        "hal0.services.mdns.systemd.unit_is_active",
+        new_callable=AsyncMock,
+        return_value=True,
+    ):
+        r = svc_client.post("/api/services/mdns", json={"advertise": True})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["ok"] is True
+        assert sorted(body["advertised"]) == ["comfyui", "openwebui"]
+
+        owui = (tmp_path / "hal0-addon-openwebui.service").read_text(encoding="utf-8")
+        assert "<port>3001</port>" in owui
+        assert "OpenWebUI on %h" in owui
+        comfy = (tmp_path / "hal0-addon-comfyui.service").read_text(encoding="utf-8")
+        assert "<port>8188</port>" in comfy
+
+        status = svc_client.get("/api/services/mdns").json()
+        assert status["available"] is True
+        assert status["base_advertised"] is True
+        assert sorted(status["advertised"]) == ["comfyui", "openwebui"]
+        assert {a["id"] for a in status["advertisable"]} == {"comfyui", "openwebui"}
+
+        r = svc_client.post("/api/services/mdns", json={"advertise": False})
+        assert r.status_code == 200
+        assert r.json()["advertised"] == []
+
+    assert base.read_text(encoding="utf-8") == "<!-- installer-owned -->"
+    assert list(tmp_path.glob("hal0-addon-*.service")) == []
+
+
+def test_mdns_apply_requires_boolean(svc_client: TestClient) -> None:
+    r = svc_client.post("/api/services/mdns", json={"advertise": "yes"})
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "services.advertise_required"
+
+
+def test_mdns_hostname_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_HOSTNAME", "mybox.local")
+    assert mdns.mdns_hostname() == "mybox.local"
+    monkeypatch.setenv("HAL0_HOSTNAME", "mybox")
+    assert mdns.mdns_hostname() == "mybox.local"
+
+
+# ── 6. systemd helper allow-list ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unit_action_rejects_unknown_verb() -> None:
+    with pytest.raises(ValueError):
+        await svc_systemd.unit_action("hal0-openwebui.service", "mask")
+
+
+@pytest.mark.asyncio
+async def test_unit_action_rejects_bad_unit_name() -> None:
+    with pytest.raises(ValueError):
+        await svc_systemd.unit_action("evil; rm -rf /", "restart")
+
+
+@pytest.mark.asyncio
+async def test_unit_state_fail_soft_without_systemd() -> None:
+    with patch("hal0.services.systemd.shutil.which", return_value=None):
+        state = await svc_systemd.unit_state("hal0-openwebui.service")
+    assert state["active_state"] == "unknown"
+    assert state["since"] is None

--- a/ui/playwright.local.config.ts
+++ b/ui/playwright.local.config.ts
@@ -1,0 +1,11 @@
+// Local-only override: use the container's pre-installed chromium
+// (playwright 1.60 expects build 1223; the sandbox ships 1194).
+import base from './playwright.config'
+
+export default {
+  ...base,
+  use: {
+    ...(base as any).use,
+    launchOptions: { executablePath: '/opt/pw-browsers/chromium' },
+  },
+}

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -271,6 +271,18 @@ export const ENDPOINTS = {
   // ── Services health (§2d — NEW endpoint, fail soft on 404) ─────
   servicesHealth: '/api/services/health',
 
+  // ── Services management (dedicated Services page) ────────────────
+  // GET services → { services:[{id,name,up,detail,unit,unit_state,url,
+  // mdns_url,actions,...}], mdns:{...} }. Actions run allow-listed
+  // systemctl verbs (registry-driven — see hal0/services/registry.py).
+  // mdns GET/POST → avahi discovery status / advertise-withdraw toggle.
+  // Per-service logs reuse the generic journald tail: logsUnit(unit).
+  services: '/api/services',
+  serviceAction: (id: string) => `/api/services/${encodeURIComponent(id)}/action`,
+  servicesMdns: '/api/services/mdns',
+  logsUnit: (unit: string, n = 120) =>
+    `/api/logs?unit=${encodeURIComponent(unit)}&n=${n}`,
+
   // ── ComfyUI native queue + history (proxy-reachable via :8188) ──
   // These are NOT under /api — ComfyUI's own HTTP server at :8188 is
   // reachable directly from the browser (same LAN). Build the base URL

--- a/ui/src/api/hooks/useServices.ts
+++ b/ui/src/api/hooks/useServices.ts
@@ -1,0 +1,142 @@
+// hal0 dashboard — Services management page hooks.
+//
+// GET  /api/services              → useServices     (5s poll, fail-soft)
+// POST /api/services/{id}/action  → useServiceAction (invalidates the list)
+// GET/POST /api/services/mdns     → useMdnsStatus / useMdnsAdvertise
+// GET  /api/logs?unit=…           → useUnitLogs     (on-demand logs drawer)
+//
+// Same fail-soft contract as useServicesHealth: a 404 (endpoint not built /
+// older backend) or network error yields `pending`, never a throw, so the
+// Services page renders "source pending" instead of an error wall.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiGet, apiPost } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface ServiceUnitState {
+  active_state: string
+  sub_state: string
+  unit_file_state: string
+  since: string | null
+}
+
+export interface ManagedService {
+  id: string
+  name: string
+  description: string
+  managed: boolean
+  unit: string | null
+  unit_state: ServiceUnitState | null
+  up: boolean
+  detail: string
+  stat: { label: string; value: string } | null
+  url: string | null
+  mdns_url: string | null
+  loopback_port: number | null
+  actions: string[]
+  mdns_capable: boolean
+  hints: string[]
+}
+
+export interface MdnsStatus {
+  available: boolean
+  hostname: string
+  base_advertised: boolean
+  advertised: string[]
+  advertisable?: { id: string; name: string; port: number | null }[]
+}
+
+export interface ServicesPayload {
+  services: ManagedService[]
+  mdns: MdnsStatus
+}
+
+export interface ServiceActionResult {
+  id: string
+  unit: string
+  action: string
+  ok: boolean
+  active: boolean
+  message: string
+}
+
+const SERVICES_POLL_MS = 5_000
+
+async function fetchServices(): Promise<ServicesPayload | null> {
+  // Raw fetch so a 404 from an older backend reads as "pending", not an error.
+  let res: Response
+  try {
+    res = await fetch(ENDPOINTS.services, { headers: { Accept: 'application/json' } })
+  } catch {
+    return null
+  }
+  if (!res.ok) return null
+  try {
+    const body = (await res.json()) as ServicesPayload
+    // Shape guard: an older backend (or a mock catch-all) may answer 200 {}
+    // — treat anything without a services array as "not yet available".
+    if (!body || !Array.isArray(body.services)) return null
+    return body
+  } catch {
+    return null
+  }
+}
+
+export function useServices(): {
+  services: ManagedService[]
+  mdns: MdnsStatus | null
+  pending: boolean
+} {
+  const q = useQuery<ServicesPayload | null>({
+    queryKey: ['services', 'list'],
+    queryFn: fetchServices,
+    refetchInterval: SERVICES_POLL_MS,
+    retry: false,
+  })
+  return {
+    services: q.data?.services ?? [],
+    mdns: q.data?.mdns ?? null,
+    pending: q.isPending || (q.isSuccess && q.data === null),
+  }
+}
+
+export function useServiceAction() {
+  const qc = useQueryClient()
+  return useMutation<ServiceActionResult, Error, { id: string; action: string }>({
+    mutationFn: ({ id, action }) =>
+      apiPost<ServiceActionResult>(ENDPOINTS.serviceAction(id), { action }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['services'] })
+    },
+  })
+}
+
+export function useMdnsAdvertise() {
+  const qc = useQueryClient()
+  return useMutation<MdnsStatus & { ok: boolean }, Error, boolean>({
+    mutationFn: (advertise) =>
+      apiPost<MdnsStatus & { ok: boolean }>(ENDPOINTS.servicesMdns, { advertise }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['services'] })
+    },
+  })
+}
+
+export interface UnitLogs {
+  unit: string
+  lines: string[]
+  count: number
+  hint?: string
+}
+
+// On-demand journald tail for a unit's logs drawer. Disabled until the
+// drawer opens; refetch via the returned query's refetch().
+export function useUnitLogs(unit: string | null, enabled: boolean) {
+  return useQuery<UnitLogs>({
+    queryKey: ['services', 'logs', unit],
+    queryFn: () => apiGet<UnitLogs>(ENDPOINTS.logsUnit(unit as string)),
+    enabled: enabled && !!unit,
+    refetchInterval: enabled ? 5_000 : false,
+    retry: false,
+  })
+}

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -97,6 +97,7 @@ const Icons = {
   hardware:  <Icon><rect x="3" y="3" width="10" height="10" rx="1"/><rect x="5.5" y="5.5" width="5" height="5" rx="0.5"/><path d="M3 6h-1M3 10h-1M13 6h1M13 10h1M6 3v-1M10 3v-1M6 13v1M10 13v1"/></Icon>,
   backends:  <Icon><circle cx="4" cy="4" r="2"/><circle cx="12" cy="4" r="2"/><circle cx="4" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><path d="M6 4h4M4 6v4M12 6v4M6 12h4"/></Icon>,
   logs:      <Icon><path d="M3 3h10M3 6h10M3 9h7M3 12h5"/></Icon>,
+  services:  <Icon><rect x="2" y="2" width="5" height="5" rx="1"/><rect x="9" y="9" width="5" height="5" rx="1"/><circle cx="11.5" cy="4.5" r="2.5"/><path d="M4.5 9v2a2 2 0 0 0 2 2H7"/></Icon>,
   // issue #549 — two linked rings echo the "remote ↔ local" connection metaphor.
   connections: <Icon><circle cx="6" cy="8" r="2.5"/><circle cx="11" cy="11" r="1.5" fill="currentColor" stroke="none"/><path d="M8 9.5l2 1M3.5 4.5h4M3.5 6.5h3"/></Icon>,
   agent:     <Icon><circle cx="8" cy="6" r="2.5"/><path d="M3 14c0-2.5 2.2-4.5 5-4.5s5 2 5 4.5"/><circle cx="13" cy="3" r="1.5"/></Icon>,
@@ -162,6 +163,7 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
     connections: ["Network", "Connections"],
     profiles:  ["iGPU Slots", "Profiles"],
     board:     ["Orchestration", "Board"],
+    services:  ["Companions", "Services"],
   };
   const [eyebrow, title] = labels[route] || ["", ""];
   return (
@@ -253,6 +255,10 @@ function useNavItems() {
       ...(memoryEnabled ? [{ id: "memory", label: "Memory" }] : []),
       { id: "mcp", label: "MCP" },
     ] },
+    // Services (#services): dedicated companion-service management page
+    // (status + lifecycle + mDNS). The sidebar-bottom ServiceLinks zone
+    // stays as the quick external-launch shortcuts; this is the manager.
+    { id: "services", label: "Services", icon: Icons.services },
     { id: "logs", label: "Logs", icon: Icons.logs },
     { id: "settings", label: "Settings", icon: Icons.settings },
   ];

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -27,7 +27,7 @@ const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
 // We also accept "agents/mcp" as an alias so the canonical URL path stays
 // readable (`/agents/mcp` from the spec). Any unknown head falls back to
 // the dashboard.
-const ROUTES = ["dashboard", "slots", "profiles", "models", "logs", "agent", "memory", "settings", "mcp", "connections", "board"];
+const ROUTES = ["dashboard", "slots", "profiles", "models", "logs", "agent", "memory", "settings", "mcp", "connections", "board", "services"];
 function parseRoute() {
   const raw = (window.location.hash || "#dashboard").replace(/^#/, "");
   const [path, qs] = raw.split("?");
@@ -308,6 +308,12 @@ function App() {
         return typeof BoardView === "function"
           ? <BoardView />
           : <div className="view">Board unavailable — bundle stale.</div>;
+      // Services (#services): companion-service management (OpenWebUI /
+      // ComfyUI / Hermes / Hindsight / n8n) — status, lifecycle, mDNS.
+      case "services":
+        return typeof ServicesView === "function"
+          ? <ServicesView />
+          : <div className="view">Services unavailable — bundle stale.</div>;
       case "settings": return <SettingsView param={param} />;
       default:         return <div className="view">Not found.</div>;
     }

--- a/ui/src/dash/services-card.jsx
+++ b/ui/src/dash/services-card.jsx
@@ -361,4 +361,5 @@ export function ServicesCard() {
   )
 }
 
-Object.assign(window, { ServicesCard })
+// ComfyJobQueue is shared with the dedicated Services page (services.jsx).
+Object.assign(window, { ServicesCard, ComfyJobQueue })

--- a/ui/src/dash/services.css
+++ b/ui/src/dash/services.css
@@ -1,0 +1,147 @@
+/* hal0 dashboard — Services page (#services)
+   Page-scoped styles (svcp- prefix). Reuses the global service atoms from
+   overhaul.css: .sdot, .svc-pill, .svc-icon-tile, .svc-btn, .svc-pending,
+   .svc-comfy-drawer (queue drawer shared with services-card.jsx). */
+
+.svcp-view .dcard { margin-bottom: 14px; }
+
+.svcp-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 14px;
+}
+
+.svcp-card {
+  border: 1px solid var(--line, rgba(127, 127, 127, 0.25));
+  border-radius: 10px;
+  padding: 14px 16px;
+  background: var(--card-bg, rgba(127, 127, 127, 0.04));
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.svcp-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.svcp-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.svcp-name { font-weight: 600; }
+
+.svcp-uptime {
+  font-size: 11px;
+  opacity: 0.65;
+}
+
+.svcp-desc {
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+.svcp-detail {
+  font-size: 12px;
+  opacity: 0.6;
+}
+
+.svcp-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  opacity: 0.7;
+  overflow-wrap: anywhere;
+}
+
+.svcp-meta-row b { font-weight: 600; }
+
+.svcp-unmanaged { opacity: 0.55; font-style: italic; }
+
+.svcp-hints {
+  font-size: 11px;
+  opacity: 0.65;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.svcp-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
+
+.svcp-act {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.svcp-act-danger { color: var(--danger, #d05050); }
+
+.svcp-busy { font-size: 11px; opacity: 0.6; }
+
+.svcp-result {
+  font-size: 11px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(80, 180, 110, 0.1);
+}
+
+.svcp-result.err { background: rgba(210, 80, 80, 0.12); }
+
+/* ── logs drawer ── */
+.svcp-logs {
+  border-top: 1px solid var(--line, rgba(127, 127, 127, 0.2));
+  padding-top: 8px;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.svcp-logs-pre {
+  font-size: 10.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  margin: 0;
+}
+
+.svcp-logs-empty {
+  font-size: 11px;
+  opacity: 0.55;
+  padding: 6px 0;
+}
+
+/* ── discovery / mDNS card ── */
+.svcp-mdns {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.svcp-mdns-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.svcp-mdns-host { opacity: 0.7; font-size: 12px; }
+
+.svcp-mdns-sub {
+  font-size: 12px;
+  opacity: 0.7;
+  line-height: 1.55;
+}

--- a/ui/src/dash/services.jsx
+++ b/ui/src/dash/services.jsx
@@ -1,0 +1,287 @@
+// hal0 dashboard — Services page (#services)
+//
+// Dedicated management surface for the companion services (OpenWebUI,
+// ComfyUI, Hermes, Hindsight, n8n). Registry-driven from the backend:
+//   - useServices → GET /api/services (5s poll, fail-soft "source pending")
+//   - useServiceAction → POST /api/services/{id}/action (allow-listed
+//     systemctl verbs; the backend registry decides what each service may do)
+//   - useMdnsAdvertise → POST /api/services/mdns (avahi addon announcements)
+//   - useUnitLogs → GET /api/logs?unit=… (journald drawer, on demand)
+//
+// §0 NO STUB — every dot/pill reflects a real probe; a service with no
+// wired probe honestly shows "unmonitored". Lifecycle buttons render only
+// for the verbs the backend advertises in `actions`.
+
+import { useServices, useServiceAction, useMdnsAdvertise, useUnitLogs } from '@/api/hooks/useServices'
+import { useComfyui, COMFYUI_FALLBACK } from '@/api/hooks/useComfyui'
+
+const { useState } = React
+
+// ── Inline SVG icons (16×16, 1.5px stroke — hal0 thin-line family) ───────────
+function SIc({ d, children, size = 14, sw = 1.5 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke="currentColor"
+      strokeWidth={sw} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      {d ? <path d={d} /> : children}
+    </svg>
+  )
+}
+
+const SIcons = {
+  ext:     <SIc d="M6 3H3v10h10v-3M9 3h4v4M9 9l4-4" />,
+  chev:    <SIc d="M4 6l4 4 4-4" />,
+  chevUp:  <SIc d="M4 10l4-4 4 4" />,
+  restart: <SIc d="M14 8a6 6 0 1 1-2-4.5M14 1v3.5h-3.5" />,
+  play:    <SIc d="M5 3l8 5-8 5V3z" />,
+  stop:    <SIc><rect x="4" y="4" width="8" height="8" rx="1" /></SIc>,
+  logs:    <SIc d="M3 3h10M3 6h10M3 9h7M3 12h5" />,
+  wifi:    <SIc><path d="M2 6.5a9 9 0 0 1 12 0M4.5 9.5a5.5 5.5 0 0 1 7 0" /><circle cx="8" cy="12.5" r="1" fill="currentColor" stroke="none" /></SIc>,
+  comfy:   <SIc><circle cx="4" cy="4" r="2" /><circle cx="12" cy="6" r="2" /><circle cx="6" cy="12" r="2" /><path d="M6 4.5l4 1M5.4 10.2l5-3.6" /></SIc>,
+  hermes:  <SIc><circle cx="8" cy="8" r="5.5" /><path d="M8 5v3l2 1.5" /></SIc>,
+  openwebui: <SIc><rect x="3" y="3" width="10" height="10" rx="2" /><path d="M6 8h4M6 10.5h2" /></SIc>,
+  hindsight: <SIc><path d="M6 2.5A2.5 2.5 0 0 0 3.5 5v.2A2.3 2.3 0 0 0 3 9.5 2.4 2.4 0 0 0 6 13.5V2.5z" /><path d="M10 2.5A2.5 2.5 0 0 1 12.5 5v.2A2.3 2.3 0 0 1 13 9.5a2.4 2.4 0 0 1-3 4V2.5z" /></SIc>,
+  n8n:     <SIc><path d="M4 8a4 4 0 0 1 8 0" /><circle cx="4" cy="8" r="1.5" /><circle cx="12" cy="8" r="1.5" /></SIc>,
+  default: <SIc><circle cx="8" cy="8" r="5" /><path d="M8 5v3M8 11v.01" /></SIc>,
+}
+
+function svcIcon(id) {
+  return SIcons[id] ?? SIcons.default
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// "Fri 2026-07-03 09:12:01 UTC" (systemd ActiveEnterTimestamp) → "up 26h"
+function uptimeFrom(since) {
+  if (!since) return null
+  const t = Date.parse(since.replace(/^[A-Za-z]{3} /, ''))
+  if (Number.isNaN(t)) return null
+  const s = Math.max(0, Math.floor((Date.now() - t) / 1000))
+  if (s < 90) return `up ${s}s`
+  if (s < 90 * 60) return `up ${Math.round(s / 60)}m`
+  if (s < 36 * 3600) return `up ${Math.round(s / 3600)}h`
+  return `up ${Math.round(s / 86400)}d`
+}
+
+function StatePill({ svc }) {
+  const cls = svc.up ? 'serving' : (svc.unit_state?.active_state === 'failed' ? 'error' : 'offline')
+  const label = svc.up ? 'up' : (svc.unit_state?.active_state === 'failed' ? 'failed' : (svc.managed ? 'down' : '—'))
+  return (
+    <span className={'svc-pill' + (svc.up ? ' svc-pill-up' : ' svc-pill-idle')}>
+      <span className={'sdot ' + cls} style={{ width: 6, height: 6 }} />
+      {label}
+    </span>
+  )
+}
+
+// ── Logs drawer (journald tail via /api/logs?unit=…) ─────────────────────────
+function LogsDrawer({ unit, open }) {
+  const q = useUnitLogs(unit, open)
+  if (!open) return null
+  const lines = q.data?.lines ?? []
+  return (
+    <div className="svcp-logs" data-testid={`svcp-logs-${unit}`}>
+      {q.isPending && <div className="svcp-logs-empty">loading logs…</div>}
+      {!q.isPending && lines.length === 0 && (
+        <div className="svcp-logs-empty">{q.data?.hint || 'no journal entries'}</div>
+      )}
+      {lines.length > 0 && (
+        <pre className="svcp-logs-pre mono">{lines.slice(-120).join('\n')}</pre>
+      )}
+    </div>
+  )
+}
+
+// ── Action buttons row ────────────────────────────────────────────────────────
+function ActionButtons({ svc, onAction, busy }) {
+  const has = (a) => svc.actions.includes(a)
+  const running = svc.unit_state?.active_state === 'active'
+  return (
+    <>
+      {has('restart') && (
+        <button className="btn ghost svcp-act" disabled={busy}
+          data-testid={`svcp-restart-${svc.id}`}
+          onClick={() => onAction(svc.id, 'restart')}>
+          {SIcons.restart} Restart
+        </button>
+      )}
+      {has('start') && !running && (
+        <button className="btn ghost svcp-act" disabled={busy}
+          data-testid={`svcp-start-${svc.id}`}
+          onClick={() => onAction(svc.id, 'start')}>
+          {SIcons.play} Start
+        </button>
+      )}
+      {has('stop') && running && (
+        <button className="btn ghost svcp-act svcp-act-danger" disabled={busy}
+          data-testid={`svcp-stop-${svc.id}`}
+          onClick={() => {
+            if (window.confirm(`Stop ${svc.name}? Clients using it will lose access until it is started again.`)) {
+              onAction(svc.id, 'stop')
+            }
+          }}>
+          {SIcons.stop} Stop
+        </button>
+      )}
+    </>
+  )
+}
+
+// ── One service card ──────────────────────────────────────────────────────────
+function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable }) {
+  const [logsOpen, setLogsOpen] = useState(false)
+  const [queueOpen, setQueueOpen] = useState(false)
+  const busy = busyId === svc.id
+  const uptime = svc.up ? uptimeFrom(svc.unit_state?.since) : null
+  const isComfy = svc.id === 'comfyui'
+  const CJQ = typeof ComfyJobQueue === 'function' ? ComfyJobQueue : null
+
+  return (
+    <div className={'svcp-card' + (svc.up ? ' svcp-card-up' : '')} data-testid={`svcp-card-${svc.id}`}>
+      <div className="svcp-card-head">
+        <span className="svc-icon-tile">{svcIcon(svc.id)}</span>
+        <span className="svcp-title">
+          <span className="svcp-name">{svc.name}</span>
+          <StatePill svc={svc} />
+          {uptime && <span className="svcp-uptime mono">{uptime}</span>}
+        </span>
+        {svc.url && (
+          <button className="svc-btn" title={`Open ${svc.name}`}
+            data-testid={`svcp-open-${svc.id}`}
+            onClick={() => window.open(svc.url, '_blank', 'noopener')}>
+            {SIcons.ext}
+          </button>
+        )}
+      </div>
+
+      <div className="svcp-desc">{svc.description}</div>
+      <div className="svcp-detail">{svc.detail}{svc.stat ? ` · ${svc.stat.value} ${svc.stat.label}` : ''}</div>
+
+      <div className="svcp-meta mono">
+        {svc.unit && <span className="svcp-meta-row">unit <b>{svc.unit}</b> · {svc.unit_state?.active_state ?? 'unknown'}{svc.unit_state?.unit_file_state && svc.unit_state.unit_file_state !== 'unknown' ? ` · ${svc.unit_state.unit_file_state}` : ''}</span>}
+        {svc.url && <span className="svcp-meta-row">url <b>{svc.url}</b></span>}
+        {svc.mdns_url && <span className="svcp-meta-row">mdns <b>{svc.mdns_url}</b></span>}
+        {!svc.url && svc.loopback_port && <span className="svcp-meta-row">bind <b>127.0.0.1:{svc.loopback_port}</b> (loopback-only)</span>}
+        {!svc.managed && <span className="svcp-meta-row svcp-unmanaged">external — not managed by hal0</span>}
+      </div>
+
+      {svc.hints.length > 0 && (
+        <div className="svcp-hints">{svc.hints.map((h, i) => <span key={i}>ⓘ {h}</span>)}</div>
+      )}
+
+      <div className="svcp-actions">
+        <ActionButtons svc={svc} onAction={onAction} busy={busy} />
+        {svc.unit && (
+          <button className={'btn ghost svcp-act' + (logsOpen ? ' on' : '')}
+            data-testid={`svcp-logbtn-${svc.id}`}
+            onClick={() => setLogsOpen(v => !v)}>
+            {SIcons.logs} Logs {logsOpen ? SIcons.chevUp : SIcons.chev}
+          </button>
+        )}
+        {isComfy && CJQ && (
+          <button className={'btn ghost svcp-act' + (queueOpen ? ' on' : '')}
+            data-testid="svcp-queue-comfyui"
+            onClick={() => setQueueOpen(v => !v)}>
+            Queue {queueOpen ? SIcons.chevUp : SIcons.chev}
+          </button>
+        )}
+        {busy && <span className="svcp-busy mono">working…</span>}
+      </div>
+      {actionMsg && busyId === null && actionMsg.id === svc.id && (
+        <div className={'svcp-result' + (actionMsg.ok ? '' : ' err')}>{actionMsg.text}</div>
+      )}
+
+      {isComfy && queueOpen && CJQ && <CJQ comfyReachable={comfyReachable} />}
+      {svc.unit && <LogsDrawer unit={svc.unit} open={logsOpen} />}
+    </div>
+  )
+}
+
+// ── mDNS / discovery card ─────────────────────────────────────────────────────
+function DiscoveryCard({ mdns, services }) {
+  const advertiseMut = useMdnsAdvertise()
+  if (!mdns) return null
+  const advertised = mdns.advertised ?? []
+  const on = advertised.length > 0
+  const capable = services.filter(s => s.mdns_capable)
+  return (
+    <DCard title="DISCOVERY (mDNS)" data-testid="svcp-mdns">
+      <div className="svcp-mdns">
+        <div className="svcp-mdns-row">
+          <span className={'sdot ' + (mdns.available ? 'serving' : 'offline')} style={{ width: 6, height: 6 }} />
+          <span>avahi {mdns.available ? 'active' : 'inactive'}</span>
+          <span className="svcp-mdns-host mono">{mdns.hostname}</span>
+          <span className="vh-spacer" style={{ flex: 1 }} />
+          <button className={'btn ghost svcp-act' + (on ? ' on' : '')}
+            data-testid="svcp-mdns-toggle"
+            disabled={advertiseMut.isPending || !mdns.available}
+            onClick={() => advertiseMut.mutate(!on)}>
+            {SIcons.wifi} {on ? 'Withdraw announcements' : 'Announce services'}
+          </button>
+        </div>
+        <div className="svcp-mdns-sub">
+          {mdns.base_advertised
+            ? <>Dashboard announced as <b className="mono">{mdns.hostname}</b>.</>
+            : <>No base <span className="mono">hal0.service</span> avahi file — the installer writes it when avahi is present.</>}
+          {' '}
+          {on
+            ? <>Announcing: {capable.filter(s => advertised.includes(s.id)).map(s => s.name).join(', ') || '—'}.</>
+            : <>Addon services ({capable.map(s => s.name).join(', ')}) are not announced — LAN clients need the raw <span className="mono">host:port</span>.</>}
+        </div>
+        {!mdns.available && (
+          <div className="svcp-mdns-sub svcp-unmanaged">
+            avahi-daemon is not active on this host — install/enable it (or add a static hosts entry) for .local discovery.
+          </div>
+        )}
+        {advertiseMut.data?.message && (
+          <div className="svcp-result err">{advertiseMut.data.message}</div>
+        )}
+      </div>
+    </DCard>
+  )
+}
+
+// ── ServicesView (page) ───────────────────────────────────────────────────────
+function ServicesView() {
+  const { services, mdns, pending } = useServices()
+  const actionMut = useServiceAction()
+  const comfyQ = useComfyui({ active: false })
+  const comfyReachable = (comfyQ.data ?? COMFYUI_FALLBACK).reachable
+  const [actionMsg, setActionMsg] = useState(null)
+
+  const busyId = actionMut.isPending ? actionMut.variables?.id ?? null : null
+
+  const onAction = (id, action) => {
+    setActionMsg(null)
+    actionMut.mutate({ id, action }, {
+      onSuccess: (res) => setActionMsg({ id, ok: res.ok, text: res.message }),
+      onError: (err) => setActionMsg({ id, ok: false, text: String(err?.message || err) }),
+    })
+  }
+
+  return (
+    <div className="view svcp-view">
+      <div className="vh">
+        <span className="vh-eye mono">Companions</span>
+        <h1>Services</h1>
+        <span className="vh-spacer" />
+      </div>
+
+      {pending ? (
+        <div className="svc-pending" data-testid="svcp-pending">source pending</div>
+      ) : (
+        <>
+          <DiscoveryCard mdns={mdns} services={services} />
+          <div className="svcp-grid">
+            {services.map(svc => (
+              <ServiceCard key={svc.id} svc={svc}
+                onAction={onAction} busyId={busyId} actionMsg={actionMsg}
+                comfyReachable={comfyReachable} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+Object.assign(window, { ServicesView })

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -84,6 +84,11 @@ import './dash/profiles.jsx'
 // window.StacksView, rendered as the third Slots tab.
 import './dash/stacks.css'
 import './dash/stacks.jsx'
+// Services page (#services): companion-service management — status +
+// lifecycle + mDNS. Registers window.ServicesView. Must load after
+// services-card.jsx (reuses its ComfyJobQueue window global).
+import './dash/services.css'
+import './dash/services.jsx'
 import './dash/settings.jsx'
 
 import './dash/extras.jsx'

--- a/ui/tests/e2e/specs/services-v3.spec.ts
+++ b/ui/tests/e2e/specs/services-v3.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * services-v3 — `#services` route renders the companion-service management
+ * page: discovery (mDNS) card + one card per registered service with
+ * status pill, unit metadata, lifecycle buttons (only the verbs the
+ * backend registry advertises), a journald logs drawer, and an mDNS
+ * announce/withdraw toggle.
+ *
+ * The page drives off `useServices()` → GET /api/services (fail-soft:
+ * the apiMock catch-all's `{}` yields "source pending"); specs that
+ * assert real content override the route with SERVICES_PAYLOAD.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+const SERVICES_PAYLOAD = {
+  services: [
+    {
+      id: 'openwebui',
+      name: 'OpenWebUI',
+      description: 'Chat UI companion (podman container, LAN :3001).',
+      managed: true,
+      unit: 'hal0-openwebui.service',
+      unit_state: {
+        active_state: 'active',
+        sub_state: 'running',
+        unit_file_state: 'enabled',
+        since: 'Fri 2026-07-03 09:12:01 UTC',
+      },
+      up: true,
+      detail: 'reachable — /health ok',
+      stat: null,
+      url: 'http://hal0.local:3001',
+      mdns_url: null,
+      loopback_port: null,
+      actions: ['start', 'stop', 'restart', 'enable', 'disable'],
+      mdns_capable: true,
+      hints: [],
+    },
+    {
+      id: 'comfyui',
+      name: 'ComfyUI',
+      description: 'Image generation engine (img slot container, LAN :8188).',
+      managed: true,
+      unit: 'hal0-slot@img.service',
+      unit_state: {
+        active_state: 'inactive',
+        sub_state: 'dead',
+        unit_file_state: 'disabled',
+        since: null,
+      },
+      up: false,
+      detail: 'unreachable',
+      stat: null,
+      url: 'http://hal0.local:8188',
+      mdns_url: null,
+      loopback_port: null,
+      actions: ['restart'],
+      mdns_capable: true,
+      hints: ['start/stop is GPU-arbiter managed — use the Image-Gen pane switchover'],
+    },
+    {
+      id: 'hermes',
+      name: 'Hermes',
+      description: 'Bundled agent + dashboard (loopback :9119).',
+      managed: true,
+      unit: 'hal0-agent@hermes.service',
+      unit_state: {
+        active_state: 'active',
+        sub_state: 'running',
+        unit_file_state: 'enabled',
+        since: 'Fri 2026-07-03 09:12:01 UTC',
+      },
+      up: true,
+      detail: 'systemd unit active',
+      stat: null,
+      url: null,
+      mdns_url: null,
+      loopback_port: 9119,
+      actions: ['start', 'stop', 'restart', 'enable', 'disable'],
+      mdns_capable: false,
+      hints: [],
+    },
+    {
+      id: 'n8n',
+      name: 'n8n',
+      description: 'Workflow automation (external — not deployed by hal0).',
+      managed: false,
+      unit: null,
+      unit_state: null,
+      up: false,
+      detail: 'unmonitored',
+      stat: null,
+      url: null,
+      mdns_url: null,
+      loopback_port: null,
+      actions: [],
+      mdns_capable: false,
+      hints: [],
+    },
+  ],
+  mdns: {
+    available: true,
+    hostname: 'hal0.local',
+    base_advertised: true,
+    advertised: [],
+  },
+}
+
+test.describe('Services v3 (/services)', () => {
+  test('renders "source pending" when the endpoint is not available', async ({ page }) => {
+    // apiMock catch-all serves {} for GET /api/services → fail-soft gate.
+    await page.goto('/#services')
+    await expect(page.locator('.view .vh h1')).toHaveText('Services')
+    await expect(page.getByTestId('svcp-pending')).toBeVisible()
+  })
+
+  test('renders discovery card + one card per service', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    await page.goto('/#services')
+
+    await expect(page.locator('.view .vh h1')).toHaveText('Services')
+    await expect(page.getByTestId('svcp-mdns-toggle')).toBeVisible()
+    for (const id of ['openwebui', 'comfyui', 'hermes', 'n8n']) {
+      await expect(page.getByTestId(`svcp-card-${id}`)).toBeVisible()
+    }
+    // Up service shows an "up" pill; unmanaged shows the external note.
+    await expect(page.getByTestId('svcp-card-openwebui')).toContainText('up')
+    await expect(page.getByTestId('svcp-card-n8n')).toContainText('external — not managed by hal0')
+  })
+
+  test('action buttons follow the backend allow-list', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    await page.goto('/#services')
+
+    // openwebui is active → Stop + Restart visible, Start hidden.
+    await expect(page.getByTestId('svcp-restart-openwebui')).toBeVisible()
+    await expect(page.getByTestId('svcp-stop-openwebui')).toBeVisible()
+    await expect(page.getByTestId('svcp-start-openwebui')).toHaveCount(0)
+    // comfyui: restart only (GPU-arbiter owns start/stop).
+    await expect(page.getByTestId('svcp-restart-comfyui')).toBeVisible()
+    await expect(page.getByTestId('svcp-start-comfyui')).toHaveCount(0)
+    await expect(page.getByTestId('svcp-stop-comfyui')).toHaveCount(0)
+    // n8n: no lifecycle buttons at all.
+    await expect(page.getByTestId('svcp-restart-n8n')).toHaveCount(0)
+  })
+
+  test('restart posts to /api/services/{id}/action and surfaces the result', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    let posted: any = null
+    await page.route('**/api/services/openwebui/action', (route) => {
+      posted = route.request().postDataJSON()
+      return json(route, {
+        id: 'openwebui',
+        unit: 'hal0-openwebui.service',
+        action: 'restart',
+        ok: true,
+        active: true,
+        message: 'restart hal0-openwebui.service: ok',
+      })
+    })
+    await page.goto('/#services')
+
+    await page.getByTestId('svcp-restart-openwebui').click()
+    await expect(page.getByTestId('svcp-card-openwebui')).toContainText(
+      'restart hal0-openwebui.service: ok',
+    )
+    expect(posted).toEqual({ action: 'restart' })
+  })
+
+  test('logs drawer fetches the unit journal tail', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    await page.route('**/api/logs?unit=hal0-openwebui.service*', (route) =>
+      json(route, {
+        unit: 'hal0-openwebui.service',
+        lines: ['2026-07-04T10:00:00 hal0 openwebui[1]: listening on :3001'],
+        count: 1,
+      }),
+    )
+    await page.goto('/#services')
+
+    await page.getByTestId('svcp-logbtn-openwebui').click()
+    await expect(page.getByTestId('svcp-logs-hal0-openwebui.service')).toContainText(
+      'listening on :3001',
+    )
+  })
+
+  test('mDNS toggle posts advertise=true', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    let posted: any = null
+    await page.route('**/api/services/mdns', (route) => {
+      posted = route.request().postDataJSON()
+      return json(route, {
+        ...SERVICES_PAYLOAD.mdns,
+        advertised: ['openwebui', 'comfyui'],
+        ok: true,
+        message: null,
+      })
+    })
+    await page.goto('/#services')
+
+    await page.getByTestId('svcp-mdns-toggle').click()
+    await expect
+      .poll(() => posted)
+      .toEqual({ advertise: true })
+  })
+
+  test('sidebar nav exposes the Services item and routes to the page', async ({ page }) => {
+    await page.route('**/api/services', (route) => json(route, SERVICES_PAYLOAD))
+    await page.goto('/#dashboard')
+    await page.getByTestId('nav-services').click()
+    await expect(page).toHaveURL(/#services$/)
+    await expect(page.locator('.view .vh h1')).toHaveText('Services')
+  })
+})


### PR DESCRIPTION
# Unified companion-service management

hal0's addon services (OpenWebUI, ComfyUI, Hermes, Hindsight, n8n) were managed through scattered one-off code paths: probe logic duplicated across `services_health.py` / `config.py` / `installer.py`, lifecycle limited to the FirstRun repair button, URL derivation spread over env vars, and mDNS limited to the installer's static `hal0.local` avahi file (PLAN.md already lists "`hal0.local` mDNS polish" as a stretch item). This PR introduces a single declarative registry, a management API, and a dedicated dashboard page.

## Backend — `hal0/services/` + `/api/services`

- **`registry.py`** — one `ServiceDef` per companion service: owning systemd unit, probe strategy, public-URL env, permitted lifecycle verbs, mDNS capability.
  - ComfyUI maps to `hal0-slot@img.service` and exposes **restart only** — its start/stop belongs to the GpuArbiter switchover path (same special-case the FirstRun repair endpoint uses).
  - Hermes (`:9119`) / Hindsight (`:9177`) are loopback-only: no host:port URL fallback, links only via `HAL0_*_PUBLIC_URL`.
  - n8n is listed read-only (no in-repo unit); probe/URL wired via `HAL0_N8N_PROBE_URL` / `HAL0_N8N_PUBLIC_URL` when the operator runs one.
- **`systemd.py`** — the shared systemctl helper the routes had been reimplementing: `unit_state` (`systemctl show` → active/sub/unit-file state + uptime), `unit_is_active`, `unit_action` with a **verb allow-list enforced at the execution boundary** (plus the per-service allow-list in the route). Fail-soft on hosts without systemd.
- **`mdns.py`** — avahi discovery status + addon announcements: one `hal0-addon-<id>.service` service-group file per LAN-published addon under `/etc/avahi/services` (avahi picks files up via inotify — no reload, no systemctl). The installer-owned `hal0.service` is never touched. Dir overridable via `HAL0_AVAHI_SERVICES_DIR` for tests.
- **`api/routes/services.py`** —
  - `GET /api/services` — per-service detail: honest probe state (shared probe fns with `services_health` — no fabricated "up"), unit state + uptime, request-host-derived browser URL (mirrors `config.py` proxy/host semantics), mDNS URL, permitted actions.
  - `POST /api/services/{id}/action` — `start|stop|restart|enable|disable`, double allow-listed, audit-logged via `record_action`.
  - `GET/POST /api/services/mdns` — discovery status / announce-withdraw toggle, audit-logged.
  - `GET /api/services/health` is untouched — the Overview card contract stays stable.
  - Per-service logs reuse the existing `GET /api/logs?unit=…` journald surface (no new endpoint).

## Dashboard — new top-level `#services` page

- Nav item (sidebar + mobile drawer via the shared `useNavItems`), topbar label, hash route with stale-bundle fallback.
- **Discovery card**: avahi state, `<host>.local` hostname, announce/withdraw toggle, honest guidance when avahi is absent.
- **Per-service cards**: status pill + uptime, description/probe detail, unit + enablement metadata, open-URL and mDNS URL rows, loopback-bind note for Hermes/Hindsight, registry-driven lifecycle buttons (stop asks for confirmation; buttons only render for verbs the backend advertises), journald logs drawer, and the ComfyUI live-queue drawer (shared `ComfyJobQueue` from the Overview card).
- Hooks (`useServices`, `useServiceAction`, `useMdnsAdvertise`, `useUnitLogs`) follow the existing fail-soft convention — an older backend renders "source pending", never an error wall.

## Tests

- `tests/api/test_services_page.py` — 16 cases: list shape, registry invariants (ComfyUI restart-only, n8n read-only, unit-name validity), action allow-list (404 unknown service / 400 disallowed verb), happy-path + honest-failure action results, mDNS advertise/prune round-trip (installer file untouched), systemd verb/unit-name guards, no-systemd fail-soft.
- `ui/tests/e2e/specs/services-v3.spec.ts` — 7 Playwright cases: pending gate, cards render, allow-list-driven buttons, action POST + result surfacing, logs drawer, mDNS toggle, sidebar nav routing.
- Full `tests/api` suite: 1145 passed; the one failure (`test_set_store_rejects_non_writable_path`) is pre-existing on a clean checkout (root sandbox). Vite build + adjacent e2e specs (dashboard-overhaul, models) pass.

## Notes / follow-ups

- Lifecycle verbs assume hal0-api runs as root (same as `installer._privileged_systemctl_argv`); an unprivileged deployment would need a sudoers grant.
- Possible next steps: fold `services_health.py` probes into the registry, add a `hermes-gateway.service` read-only row, editable public-URL settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHhAW6oW9JLFDb37Zx576d

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHhAW6oW9JLFDb37Zx576d)_