### PR TITLE
Wire TTS request defaults + live voice list (settings completeness P3)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -948,6 +948,41 @@ async def get_slot_config(name: str, request: Request) -> dict[str, object]:
     return cfg
 
 
+@router.get("/{name}/voices")
+async def get_slot_voices(name: str, request: Request) -> dict[str, object]:
+    """Proxy the slot's ``GET /v1/audio/voices`` (TTS engines expose it).
+
+    Kokoro and qwen3tts containers serve the list of loaded voices; the
+    dashboard's Voice settings populate the default-voice picker from it
+    instead of hardcoding the pack. Fail-soft: a cold/unreachable slot (or
+    an engine without the route) returns ``{"voices": [], "source":
+    "offline"}`` rather than an error — the UI falls back to a seed list.
+    Unknown slot names still 404 via ``SlotManager.get_config``.
+    """
+    import httpx
+
+    sm = _get_slot_manager(request)
+    cfg = await sm.get_config(name)
+    port = cfg.get("port")
+    if not isinstance(port, int) or port <= 0:
+        return {"name": name, "voices": [], "source": "offline"}
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=1.0)) as client:
+            resp = await client.get(f"http://127.0.0.1:{port}/v1/audio/voices")
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception:
+        return {"name": name, "voices": [], "source": "offline"}
+    voices = payload.get("voices") if isinstance(payload, dict) else None
+    if not isinstance(voices, list):
+        voices = []
+    return {
+        "name": name,
+        "voices": [str(v) for v in voices if isinstance(v, str | int)],
+        "source": "live",
+    }
+
+
 @router.get("/{name}/resolved")
 async def get_slot_resolved(name: str, request: Request) -> dict[str, object]:
     """Return the resolved llama-server argv with per-flag provenance.

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -1037,7 +1037,60 @@ async def audio_speech(request: Request, dispatcher: DispatcherDep) -> Response:
             details={"field": "model", "path": "/v1/audio/speech"},
             code="request.missing_model",
         )
+    # Seed the serving tts slot's persisted request defaults (default_voice /
+    # default_speed / default_response_format — Settings → Voice) into the
+    # body BEFORE dispatch, mirroring how /v1/images/generations seeds the
+    # img slot's [image] defaults. Explicit request params always win.
+    _seed_tts_defaults(await _tts_slot_config(request, model), body)
     return await _dispatch_and_forward(request, dispatcher, body=body)
+
+
+async def _tts_slot_config(request: Request, model: str) -> dict[str, Any]:
+    """Config of the tts slot that will serve ``model``, or ``{}``.
+
+    Selection mirrors dispatch closely enough for default-seeding: prefer
+    the tts slot bound to the requested model, then the per-type default
+    tts slot, then the seeded ``tts`` name, then a sole tts slot.
+    """
+    manager = getattr(request.app.state, "slot_manager", None)
+    if manager is None:
+        return {}
+    try:
+        cfgs = await manager.iter_configs()
+    except Exception:  # pragma: no cover — defensive; seeding is optional
+        return {}
+
+    def _model_id(cfg: dict[str, Any]) -> str:
+        model_section = cfg.get("model") or {}
+        mid = (
+            cfg.get("model_default")
+            or cfg.get("model_id")
+            or (model_section.get("default") if isinstance(model_section, dict) else None)
+            or ""
+        )
+        return mid if isinstance(mid, str) else ""
+
+    tts = [c for c in cfgs if (c.get("type") or "").lower() == "tts"]
+    return (
+        next((c for c in tts if _model_id(c) == model), None)
+        or next((c for c in tts if c.get("default")), None)
+        or next((c for c in tts if (c.get("name") or "") == "tts"), None)
+        or (tts[0] if len(tts) == 1 else None)
+        or {}
+    )
+
+
+def _seed_tts_defaults(tts_cfg: dict[str, Any], body: dict[str, Any]) -> None:
+    """Fill omitted /v1/audio/speech params from the slot's persisted defaults."""
+    voice = tts_cfg.get("default_voice")
+    if not body.get("voice") and isinstance(voice, str) and voice:
+        body["voice"] = voice
+    speed = tts_cfg.get("default_speed")
+    if body.get("speed") is None and isinstance(speed, int | float) and not isinstance(speed, bool):
+        body["speed"] = float(speed)
+    fmt = tts_cfg.get("default_response_format")
+    if not body.get("response_format") and isinstance(fmt, str) and fmt:
+        body["response_format"] = fmt
 
 
 # ── /v1/images/generations (ComfyUI provider, hal0-managed translation) ────

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -392,6 +392,39 @@ class SlotConfig(BaseModel):
         ),
     )
 
+    # ── TTS request defaults (Settings → Voice) ─────────────────────────
+    # Read by /v1/audio/speech at request time: when the body omits the
+    # matching param, the serving tts slot's persisted default is injected
+    # before dispatch — so changes apply immediately, no container bounce.
+    # default_voice previously round-tripped via extra="allow" only (the
+    # dashboard wrote it, nothing read it); declaring the trio makes the
+    # values validated and schema-visible.
+    default_voice: str | None = Field(
+        default=None,
+        description=(
+            "TTS slots only — voice id injected into /v1/audio/speech when "
+            "the request omits `voice`. None → engine default (Kokoro: "
+            "af_bella)."
+        ),
+    )
+    default_speed: float | None = Field(
+        default=None,
+        ge=0.25,
+        le=4.0,
+        description=(
+            "TTS slots only — playback speed injected when the request omits "
+            "`speed`. Engines clamp to their supported range (Kokoro: "
+            "0.5-2.0). None → engine default (1.0)."
+        ),
+    )
+    default_response_format: Literal["mp3", "wav", "opus", "flac", "pcm"] | None = Field(
+        default=None,
+        description=(
+            "TTS slots only — audio container injected when the request "
+            "omits `response_format`. None → engine default (mp3)."
+        ),
+    )
+
     # [model] section (nested)
     model: ModelConfig = Field(default_factory=ModelConfig)
 

--- a/tests/api/test_tts_request_defaults.py
+++ b/tests/api/test_tts_request_defaults.py
@@ -1,0 +1,146 @@
+"""TTS request-default injection + voices proxy (Settings → Voice, Phase 3).
+
+``/v1/audio/speech`` seeds ``voice`` / ``speed`` / ``response_format`` from
+the serving tts slot's persisted ``default_*`` fields when the request body
+omits them — explicit request params always win. ``GET
+/api/slots/{name}/voices`` proxies the engine's ``/v1/audio/voices`` and
+fails soft to ``{"voices": [], "source": "offline"}`` on a cold slot.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes.v1 import _seed_tts_defaults, _tts_slot_config
+
+# ── _seed_tts_defaults ───────────────────────────────────────────────────────
+
+
+def test_seed_fills_omitted_params() -> None:
+    body: dict = {"model": "kokoro-v1", "input": "hi"}
+    cfg = {"default_voice": "bf_emma", "default_speed": 1.25, "default_response_format": "wav"}
+    _seed_tts_defaults(cfg, body)
+    assert body["voice"] == "bf_emma"
+    assert body["speed"] == 1.25
+    assert body["response_format"] == "wav"
+
+
+def test_seed_never_overrides_explicit_params() -> None:
+    body: dict = {"voice": "am_adam", "speed": 2.0, "response_format": "pcm"}
+    cfg = {"default_voice": "bf_emma", "default_speed": 1.25, "default_response_format": "wav"}
+    _seed_tts_defaults(cfg, body)
+    assert body["voice"] == "am_adam"
+    assert body["speed"] == 2.0
+    assert body["response_format"] == "pcm"
+
+
+def test_seed_skips_unset_defaults() -> None:
+    body: dict = {"model": "kokoro-v1"}
+    _seed_tts_defaults({"default_voice": None, "default_speed": None}, body)
+    assert "voice" not in body
+    assert "speed" not in body
+    assert "response_format" not in body
+
+
+def test_seed_ignores_bool_speed() -> None:
+    # bool is an int subclass — a corrupted TOML must not inject speed=True.
+    body: dict = {}
+    _seed_tts_defaults({"default_speed": True}, body)
+    assert "speed" not in body
+
+
+# ── _tts_slot_config selection ───────────────────────────────────────────────
+
+
+def _request_with_cfgs(cfgs: list[dict]) -> SimpleNamespace:
+    async def iter_configs() -> list[dict]:
+        return cfgs
+
+    manager = SimpleNamespace(iter_configs=iter_configs)
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(slot_manager=manager)))
+
+
+@pytest.mark.asyncio
+async def test_tts_slot_prefers_model_match() -> None:
+    cfgs = [
+        {"name": "tts", "type": "tts", "model": {"default": "kokoro-v1"}, "default_voice": "a"},
+        {
+            "name": "qwen3tts",
+            "type": "tts",
+            "model": {"default": "qwen3-tts"},
+            "default_voice": "b",
+        },
+    ]
+    cfg = await _tts_slot_config(_request_with_cfgs(cfgs), "qwen3-tts")
+    assert cfg["default_voice"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_tts_slot_falls_back_to_default_then_name() -> None:
+    cfgs = [
+        {"name": "other", "type": "tts", "default": True, "default_voice": "flagged"},
+        {"name": "tts", "type": "tts", "default_voice": "named"},
+    ]
+    cfg = await _tts_slot_config(_request_with_cfgs(cfgs), "unknown-model")
+    assert cfg["default_voice"] == "flagged"
+
+
+@pytest.mark.asyncio
+async def test_tts_slot_empty_when_no_tts_slots() -> None:
+    cfgs = [{"name": "chat", "type": "llm"}]
+    assert await _tts_slot_config(_request_with_cfgs(cfgs), "kokoro-v1") == {}
+
+
+# ── GET /api/slots/{name}/voices ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+def _seed_tts_slot(home: str, port: int = 8084) -> None:
+    root = Path(home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "tts.toml").write_text(
+        "\n".join(
+            [
+                'name = "tts"',
+                f"port = {port}",
+                'type = "tts"',
+                'provider = "kokoro"',
+                "enabled = true",
+                "[model]",
+                'default = "kokoro-v1"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_voices_offline_slot_fails_soft(tmp_hal0_home: str, isolated_client: TestClient) -> None:
+    # Nothing listens on the seeded port in tests — the proxy must degrade
+    # to an empty list, not surface a 502.
+    _seed_tts_slot(tmp_hal0_home)
+    r = isolated_client.get("/api/slots/tts/voices")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"name": "tts", "voices": [], "source": "offline"}
+
+
+def test_voices_unknown_slot_404(tmp_hal0_home: str, isolated_client: TestClient) -> None:
+    r = isolated_client.get("/api/slots/nope/voices")
+    assert r.status_code == 404, r.text

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -27,6 +27,9 @@ export const ENDPOINTS = {
   slotMetrics: '/api/slots/metrics',
   slot: (name: string) => `/api/slots/${encodeURIComponent(name)}`,
   slotConfig: (name: string) => `/api/slots/${encodeURIComponent(name)}/config`,
+  // TTS voice-list proxy — forwards to the slot container's /v1/audio/voices;
+  // {voices: [], source: "offline"} when the slot is cold.
+  slotVoices: (name: string) => `/api/slots/${encodeURIComponent(name)}/voices`,
   slotDefaults: (name: string) => `/api/slots/${encodeURIComponent(name)}/defaults`,
   slotBackend: (name: string) => `/api/slots/${encodeURIComponent(name)}/backend`,
   slotRestart: (name: string) => `/api/slots/${encodeURIComponent(name)}/restart`,

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -518,6 +518,25 @@ export function useSlotDelete() {
  * values (e.g. default_voice, default_steps) that live in the slot TOML
  * but are not surfaced by the capabilities/selections payload.
  */
+// Voice list for a TTS slot, proxied from the container. `source` is
+// "live" when the engine answered, "offline" when cold/unreachable — the
+// consumer falls back to its seed list in that case.
+export interface SlotVoices {
+  name: string
+  voices: string[]
+  source: 'live' | 'offline'
+}
+
+export function useSlotVoices(name: string | null | undefined) {
+  return useQuery<SlotVoices>({
+    queryKey: ['slot-voices', name],
+    queryFn: () => apiGet<SlotVoices>(ENDPOINTS.slotVoices(name as string)),
+    enabled: !!name,
+    staleTime: 60_000,
+    retry: false,
+  })
+}
+
 export function useSlotConfig(name: string | null | undefined) {
   return useQuery<Record<string, unknown>>({
     queryKey: ['slot-config', name],

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -19,7 +19,7 @@ import { useSecrets, useSecretSet, useSecretDelete } from '@/api/hooks/useSecret
 import { SECRET_PRESETS } from './extra-modals.jsx'
 import { useUpdateState, useUpdateCheck, useUpdateApply, useUpdateJob, useSetUpdateChannel, useUpdateRollback } from '@/api/hooks/useUpdates'
 import { useCapabilities, useCapabilityApply } from '@/api/hooks/useCapabilities'
-import { useSlots, useSlotEdit, useSlotConfig } from '@/api/hooks/useSlots'
+import { useSlots, useSlotEdit, useSlotConfig, useSlotVoices } from '@/api/hooks/useSlots'
 import {
   useSettings,
   useSettingsUpdate,
@@ -771,19 +771,21 @@ const KOKORO_VOICES = [
 //
 // STT: pick model from capabilities.catalogs.voice.stt — persisted via
 //   POST /api/capabilities/voice/stt {model, provider, enabled}.
-// TTS: pick model + default_voice — model/enabled via capabilities POST,
-//   default_voice via PUT /api/slots/tts/config {default_voice}.
+// TTS: model/enabled via capabilities POST; request defaults
+//   (default_voice / default_speed / default_response_format) via
+//   PUT /api/slots/tts/config. /v1/audio/speech injects them at request
+//   time when the body omits the param, so saves apply immediately.
+//   The voice picker prefers the live list from GET /api/slots/tts/voices
+//   (engine /v1/audio/voices proxy) and falls back to the Kokoro seed pack.
 //
-// Reflects current effective values from capabilities.selections.voice.{stt,tts}
-// and from /api/slots/tts/config (for default_voice).
-//
-// Deferred (no per-slot-config path today):
-//   - STT language hints, silence thresholds (per-request params, not slot config).
-//   - TTS speed/sample-rate (per-request in /v1/audio/speech body, not persisted).
+// Not offered on purpose: STT language hints (moonshine is English-only —
+// the request param is ignored), STT silence thresholds (no such endpoint
+// param exists), TTS sample rate (fixed 24 kHz container constant).
 function VoiceSection() {
   const capsQuery = useCapabilities();
   const applyCapability = useCapabilityApply();
   const ttsSlotCfgQuery = useSlotConfig("tts");
+  const ttsVoicesQuery = useSlotVoices("tts");
   const editSlot = useSlotEdit();
 
   const caps = capsQuery.data;
@@ -801,6 +803,8 @@ function VoiceSection() {
   const [ttsModel, setTtsModel] = useStateSet("");
   const [ttsEnabled, setTtsEnabled] = useStateSet(false);
   const [ttsVoice, setTtsVoice] = useStateSet("");
+  const [ttsSpeed, setTtsSpeed] = useStateSet("");
+  const [ttsFormat, setTtsFormat] = useStateSet("");
 
   // Populate from live data
   useEffectSet(() => {
@@ -816,10 +820,18 @@ function VoiceSection() {
   useEffectSet(() => {
     const v = ttsCfg.default_voice;
     if (v != null) setTtsVoice(String(v));
-  }, [ttsCfg.default_voice]);
+    if (ttsCfg.default_speed != null) setTtsSpeed(String(ttsCfg.default_speed));
+    if (ttsCfg.default_response_format != null) setTtsFormat(String(ttsCfg.default_response_format));
+  }, [ttsCfg.default_voice, ttsCfg.default_speed, ttsCfg.default_response_format]);
 
+  const origVoice = ttsCfg.default_voice ? String(ttsCfg.default_voice) : "";
+  const origSpeed = ttsCfg.default_speed != null ? String(ttsCfg.default_speed) : "";
+  const origFormat = ttsCfg.default_response_format ? String(ttsCfg.default_response_format) : "";
+  const speedNum = parseFloat(ttsSpeed);
+  const speedValid = ttsSpeed.trim() === "" || (!isNaN(speedNum) && speedNum >= 0.25 && speedNum <= 4);
   const sttDirty = sttModel !== (sttSelection.model || "") || sttEnabled !== !!sttSelection.enabled;
-  const ttsDirty = ttsModel !== (ttsSelection.model || "") || ttsEnabled !== !!ttsSelection.enabled || ttsVoice !== (ttsCfg.default_voice ? String(ttsCfg.default_voice) : "");
+  const ttsDirty = ttsModel !== (ttsSelection.model || "") || ttsEnabled !== !!ttsSelection.enabled
+    || ttsVoice !== origVoice || ttsSpeed !== origSpeed || ttsFormat !== origFormat;
 
   const sttCatalogItems = voiceCatalogs.stt?.items || voiceCatalogs.stt?.models || [];
   const ttsCatalogItems = voiceCatalogs.tts?.items || voiceCatalogs.tts?.models || [];
@@ -837,13 +849,17 @@ function VoiceSection() {
     try {
       // Persist model + enabled via capability apply
       await applyCapability.mutateAsync({ slot: "voice", child: "tts", body: { model: ttsModel, enabled: ttsEnabled } });
-      // Persist default_voice via slot config if changed
-      const origVoice = ttsCfg.default_voice ? String(ttsCfg.default_voice) : "";
-      if (ttsVoice !== origVoice) {
-        // ttsVoice === "" intentionally clears default_voice back to the server default
-        await editSlot.mutateAsync({ name: "tts", body: { default_voice: ttsVoice } });
+      // Persist request defaults via slot config — only the changed fields.
+      // Empty string intentionally clears a default back to the engine's own
+      // (null on the wire; /v1/audio/speech skips null/empty on injection).
+      const patch = {};
+      if (ttsVoice !== origVoice) patch.default_voice = ttsVoice || null;
+      if (ttsSpeed !== origSpeed) patch.default_speed = ttsSpeed.trim() === "" ? null : speedNum;
+      if (ttsFormat !== origFormat) patch.default_response_format = ttsFormat || null;
+      if (Object.keys(patch).length > 0) {
+        await editSlot.mutateAsync({ name: "tts", body: patch });
       }
-      window.__hal0Toast && window.__hal0Toast("TTS settings saved", "ok");
+      window.__hal0Toast && window.__hal0Toast("TTS settings saved — applies to the next /v1/audio/speech request", "ok");
     } catch (e) {
       window.__hal0Toast && window.__hal0Toast(`TTS save failed — ${e?.message || "see logs"}`, "err");
     }
@@ -886,6 +902,7 @@ function VoiceSection() {
               className="mono" style={{background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px", fontSize: 11, width: 260}} />
           )
         } sub={sttCatalogItems.length === 0 ? "no installed STT models — install one in the Models view" : undefined} />
+        <SRow k="Language" sub="moonshine is English-only; the /v1/audio/transcriptions language param is accepted but ignored" mono v={<span style={{color: "var(--fg-4)"}}>English</span>} />
         <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
           {sttDirty && (
             <button className="btn ghost sm" onClick={() => { setSttModel(sttSelection.model || ""); setSttEnabled(!!sttSelection.enabled); }}>Reset</button>
@@ -917,38 +934,69 @@ function VoiceSection() {
               className="mono" style={{background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px", fontSize: 11, width: 260}} />
           )
         } sub={ttsCatalogItems.length === 0 ? "no installed TTS models — install one in the Models view" : undefined} />
-        {/* The bundled voice list is Kokoro-specific. Kokoro is also the
-            bundled default TTS engine, so an unset model gets the list too;
-            only an explicitly-selected non-Kokoro model switches to a
-            free-form model-specific voice id. */}
-        <SRow k="Default voice" sub={
-          (!ttsModel || ttsModel.toLowerCase().includes("kokoro"))
-            ? "applied when /v1/audio/speech omits the voice param · bundled voices (Kokoro v1)"
-            : "applied when /v1/audio/speech omits the voice param · model-specific voice id"
-        } v={
-          (!ttsModel || ttsModel.toLowerCase().includes("kokoro")) ? (
-            <select value={ttsVoice} onChange={e => setTtsVoice(e.target.value)}
-              style={{fontFamily: "var(--jbm)", fontSize: 11, background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px"}}>
-              <option value="">— use server default (af_bella) —</option>
-              {KOKORO_VOICES.map(v => (
-                <option key={v.id} value={v.id}>{v.label}</option>
-              ))}
-            </select>
-          ) : (
-            <input value={ttsVoice} onChange={e => setTtsVoice(e.target.value)}
-              placeholder="empty = server default"
-              className="mono" style={{background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px", fontSize: 11, width: 220}} />
-          )
+        {/* Voice options come from the live slot when it answers
+            (GET /api/slots/tts/voices proxies the engine's /v1/audio/voices);
+            the hardcoded Kokoro pack is only the cold-slot fallback for the
+            bundled default engine. An explicitly non-Kokoro model with no
+            live list gets a free-form voice id input. */}
+        {(() => {
+          const liveVoices = ttsVoicesQuery.data?.source === "live" ? (ttsVoicesQuery.data.voices || []) : [];
+          const kokoroish = !ttsModel || ttsModel.toLowerCase().includes("kokoro");
+          const options = liveVoices.length > 0
+            ? liveVoices.map(v => {
+                const seed = KOKORO_VOICES.find(k => k.id === v);
+                return { id: v, label: seed ? seed.label : v };
+              })
+            : (kokoroish ? KOKORO_VOICES : null);
+          const srcNote = liveVoices.length > 0
+            ? "voices reported live by the tts slot"
+            : (kokoroish ? "bundled voices (Kokoro v1) · slot offline — list is the seed pack" : "model-specific voice id");
+          return (
+            <SRow k="Default voice" sub={`applied when /v1/audio/speech omits the voice param · ${srcNote}`} v={
+              options ? (
+                <select value={ttsVoice} onChange={e => setTtsVoice(e.target.value)}
+                  style={{fontFamily: "var(--jbm)", fontSize: 11, background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px"}}>
+                  <option value="">— use engine default (af_bella) —</option>
+                  {/* keep a saved voice selectable even if the live list lost it */}
+                  {ttsVoice && !options.some(o => o.id === ttsVoice) && (
+                    <option value={ttsVoice}>{ttsVoice} (saved)</option>
+                  )}
+                  {options.map(v => (
+                    <option key={v.id} value={v.id}>{v.label}</option>
+                  ))}
+                </select>
+              ) : (
+                <input value={ttsVoice} onChange={e => setTtsVoice(e.target.value)}
+                  placeholder="empty = engine default"
+                  className="mono" style={{background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px", fontSize: 11, width: 220}} />
+              )
+            } />
+          );
+        })()}
+        <SRow k="Default speed" sub="applied when the request omits speed · Kokoro clamps to 0.5–2.0 · empty = engine default (1.0)" v={
+          <input type="number" min={0.25} max={4} step={0.05} value={ttsSpeed}
+            onChange={e => setTtsSpeed(e.target.value)} placeholder="1.0"
+            className="mono" style={{background: "var(--bg-2)", color: "var(--fg)", border: `1px solid ${speedValid ? "var(--line)" : "var(--err)"}`, borderRadius: 4, padding: "3px 6px", fontSize: 11, width: 100}} />
         } />
+        <SRow k="Default format" sub="applied when the request omits response_format · empty = engine default (mp3)" v={
+          <select value={ttsFormat} onChange={e => setTtsFormat(e.target.value)}
+            style={{fontFamily: "var(--jbm)", fontSize: 11, background: "var(--bg-2)", color: "var(--fg)", border: "1px solid var(--line)", borderRadius: 4, padding: "3px 6px"}}>
+            <option value="">— engine default (mp3) —</option>
+            {["mp3", "wav", "opus", "flac", "pcm"].map(f => <option key={f} value={f}>{f}</option>)}
+          </select>
+        } />
+        <SRow k="Sample rate" sub="fixed by the Kokoro engine — not configurable" mono v={<span style={{color: "var(--fg-4)"}}>24 kHz</span>} />
         <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
           {ttsDirty && (
             <button className="btn ghost sm" onClick={() => {
               setTtsModel(ttsSelection.model || "");
               setTtsEnabled(!!ttsSelection.enabled);
-              setTtsVoice(ttsCfg.default_voice ? String(ttsCfg.default_voice) : "");
+              setTtsVoice(origVoice);
+              setTtsSpeed(origSpeed);
+              setTtsFormat(origFormat);
             }}>Reset</button>
           )}
-          <button className="btn sm" disabled={!ttsDirty || loading || applyCapability.isPending || editSlot.isPending} onClick={doSaveTts}>Save TTS</button>
+          <button className="btn sm" disabled={!ttsDirty || !speedValid || loading || applyCapability.isPending || editSlot.isPending} onClick={doSaveTts}>Save TTS</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Phase 3 of the settings-completeness plan (follow-up to #1036): the Voice settings stop being decorative.

### The headline fix
Settings → Voice's **"Default voice" was a dead control** — it persisted `default_voice` into the tts slot TOML, but neither the Kokoro/qwen3tts providers nor the dispatcher ever read it. Now `/v1/audio/speech` injects the serving tts slot's persisted defaults (`voice`, `speed`, `response_format`) into the request body when the caller omits them — explicit request params always win. Same pattern `/v1/images/generations` already uses for `[image]` defaults, so saves apply **immediately** with no container bounce.

### Backend
- `SlotConfig` declares the trio as validated fields: `default_voice`, `default_speed` (0.25–4.0), `default_response_format` (`mp3|wav|opus|flac|pcm`) — `default_voice` previously round-tripped only via `extra="allow"`.
- Slot selection for seeding: model-matched tts slot → per-type default tts slot → seeded `tts` name → sole tts slot.
- New **`GET /api/slots/{name}/voices`** proxying the engine's `/v1/audio/voices` (both bundled TTS engines expose it), fail-soft `{"voices": [], "source": "offline"}` on cold slots, 404 on unknown slots.

### Dashboard
- Voice picker prefers the **live list** from the proxy; the hardcoded Kokoro pack is now only the cold-slot fallback, and a saved voice missing from the live list stays selectable.
- New **Default speed** and **Default format** controls (same slot-config PUT), read-only sample-rate row (fixed 24 kHz container constant), and an honest STT "English-only" note (moonshine accepts but ignores the `language` param — verified, so no fake control was built).

## Verification
- `uv run pytest tests/api tests/slots tests/omni_router` — 1611 passed; only failure is the pre-existing `test_set_store_rejects_non_writable_path` (fails on clean main).
- New `tests/api/test_tts_request_defaults.py`: seeding semantics (fill / never-override / unset skip / bool-guard), slot-selection order, voices-proxy fail-soft + 404.
- `ruff check`/`format` clean; UI build + typecheck + dash unit tests clean.

## Next (per plan)
Phase 4 (Settings → NPU section) and Phase 5 (ComfyUI arbiter re-read + workflow listing) follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR)_