### PR TITLE
Finish catalog sort/tag/quant controls + chat-template pick at pull (WS-13/WS-6)

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1247,6 +1247,7 @@ def _seed_registry_from_body(
     hf_repo: str,
     hf_file: str,
     labels: list[str] | None,
+    chat_template: str | None = None,
 ) -> None:
     """Upsert a registry row for ``model_id`` from body-supplied HF coords.
 
@@ -1262,23 +1263,30 @@ def _seed_registry_from_body(
     intentional (rather than silently re-pulling the old variant).
     """
     from hal0.config import paths
-    from hal0.registry.model import Model
+    from hal0.registry.model import Model, ModelDefaults
     from hal0.registry.store import ModelAlreadyExists
 
     registry = request.app.state.model_registry
     provisional_path = str(paths.models_dir() / model_id / hf_file)
     caps = [str(c).strip() for c in (labels or []) if str(c).strip()] or ["chat"]
+    # A pinned chat template is a launcher default that only matters at load
+    # time (long after the pull finishes), so seed it now while the row is
+    # created — the modal closes on pull start and can't sequence a later PUT.
+    # The "auto" sentinel means "use the GGUF-embedded template" → no override.
+    ct = (chat_template or "").strip()
+    defaults = ModelDefaults(chat_template=ct) if ct and ct != "auto" else None
     try:
         existing = registry.get(model_id)
     except Exception:
         existing = None
     if existing is not None:
-        # Refresh HF coords so a retry with a different variant lands.
+        # Refresh HF coords so a retry with a different variant lands, and
+        # carry a freshly-picked chat template onto the existing row.
+        patch: dict[str, Any] = {"hf_repo": hf_repo, "hf_filename": hf_file}
+        if defaults is not None:
+            patch["defaults"] = defaults.model_dump(exclude_none=True)
         with contextlib.suppress(Exception):
-            registry.update(
-                model_id,
-                {"hf_repo": hf_repo, "hf_filename": hf_file},
-            )
+            registry.update(model_id, patch)
         return
     entry = Model(
         id=model_id,
@@ -1290,6 +1298,7 @@ def _seed_registry_from_body(
         hf_filename=hf_file,
         tags=["user-added"],
         metadata={"source": "add-by-hf"},
+        defaults=defaults,
     )
     # Race with another caller — the existing row already has coords.
     with contextlib.suppress(ModelAlreadyExists):
@@ -1566,7 +1575,10 @@ async def pull_model(
         labels = body.get("labels") if isinstance(body, dict) else None
         if not isinstance(labels, list):
             labels = None
-        _seed_registry_from_body(request, model_id, hf_repo, hf_file, labels)
+        chat_template = body.get("chat_template") if isinstance(body, dict) else None
+        if not isinstance(chat_template, str):
+            chat_template = None
+        _seed_registry_from_body(request, model_id, hf_repo, hf_file, labels, chat_template)
     job = make_job(model_id)
     jobs[model_id] = job
     # Persist the queued snapshot before returning so a status poll resolves

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -134,6 +134,86 @@ def test_pull_body_hf_coords_used_when_id_not_registered(
     assert fake_run_pull[0]["hf_repo"] == "unsloth/Qwen3.6-27B-A3B-MTP-GGUF"
 
 
+def test_pull_body_chat_template_seeds_defaults(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+) -> None:
+    """WS-6 — a chat_template in the pull body is pinned onto the freshly
+    seeded registry row's defaults at pull start (the modal closes on start
+    and can't sequence a later PUT). It only matters at load time, so the
+    default persists whether or not the pull ultimately succeeds.
+    """
+    new_id = "user.WithTemplate"
+    r = client_isolated.post(
+        f"/api/models/{new_id}/pull",
+        json={
+            "hf_repo": "unsloth/Some-GGUF",
+            "hf_filename": "Some-Q4_K_M.gguf",
+            "labels": ["chat"],
+            "chat_template": "chatml",
+        },
+    )
+    assert r.status_code == 202, r.text
+    entry = app_isolated.state.model_registry.get(new_id)
+    assert entry.defaults is not None
+    assert entry.defaults.chat_template == "chatml"
+
+
+def test_pull_body_chat_template_auto_seeds_no_default(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+) -> None:
+    """The "auto" sentinel means "use the GGUF-embedded template" — it must
+    NOT persist as an override (so the launcher keeps its auto behavior)."""
+    new_id = "user.AutoTemplate"
+    r = client_isolated.post(
+        f"/api/models/{new_id}/pull",
+        json={
+            "hf_repo": "unsloth/Some-GGUF",
+            "hf_filename": "Some-Q4_K_M.gguf",
+            "chat_template": "auto",
+        },
+    )
+    assert r.status_code == 202, r.text
+    entry = app_isolated.state.model_registry.get(new_id)
+    assert entry.defaults is None or entry.defaults.chat_template is None
+
+
+def test_pull_body_chat_template_patches_existing_row(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+) -> None:
+    """A re-pull that supplies a chat_template carries the pin onto an
+    already-registered row alongside the refreshed HF coordinates."""
+    from hal0.registry.model import Model
+
+    app_isolated.state.model_registry.add(
+        Model(
+            id="user.RepullTemplate",
+            name="user.RepullTemplate",
+            path="/tmp/stub.gguf",
+            hf_repo="stub/old-repo",
+            hf_filename="old.gguf",
+        )
+    )
+    r = client_isolated.post(
+        "/api/models/user.RepullTemplate/pull",
+        json={
+            "hf_repo": "stub/new-repo",
+            "hf_filename": "new.gguf",
+            "chat_template": "llama3",
+        },
+    )
+    assert r.status_code == 202, r.text
+    entry = app_isolated.state.model_registry.get("user.RepullTemplate")
+    assert entry.hf_filename == "new.gguf"
+    assert entry.defaults is not None
+    assert entry.defaults.chat_template == "llama3"
+
+
 def test_pull_body_hf_coords_override_registry_entry(
     client_isolated: TestClient,
     app_isolated: FastAPI,

--- a/ui/src/dash/__tests__/model-sort.test.mjs
+++ b/ui/src/dash/__tests__/model-sort.test.mjs
@@ -1,0 +1,138 @@
+// Dependency-free tests for the Models catalog sort / tag-filter helpers
+// (WS-13) used by the toolbar.
+//
+// Run: node ui/src/dash/__tests__/model-sort.test.mjs
+//
+// These pin the behaviours the UI relies on: unknown sort keys sink to the
+// end (so a "sort by params" doesn't shove registry rows above real values),
+// the sort is stable, tag filtering is AND-narrowing, tag chips are the
+// curated vocab ∩ present tags, and the "added" label stays humane.
+
+import {
+  MODEL_SORT_FIELDS,
+  parseParamCount,
+  modelSizeBytes,
+  modelSortKey,
+  sortModels,
+  tagChipsFor,
+  modelMatchesTags,
+  fmtAdded,
+} from "../model-sort.js";
+
+let failures = 0;
+const fail = (msg) => {
+  failures += 1;
+  console.error("  ✗ " + msg);
+};
+const eq = (a, b, msg) => {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    fail(`${msg} — expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+  }
+};
+const ok = (cond, msg) => {
+  if (!cond) fail(msg);
+};
+
+// ── param parsing ───────────────────────────────────────────────────
+eq(parseParamCount("27B"), 27e9, "27B → 27e9");
+eq(parseParamCount("350M"), 350e6, "350M → 350e6");
+eq(parseParamCount("1.5B"), 1.5e9, "1.5B → 1.5e9");
+eq(parseParamCount("74K"), 74e3, "74K → 74e3");
+eq(parseParamCount("8"), 8e9, "bare number defaults to billions");
+eq(parseParamCount("nonsense"), null, "unparseable → null");
+eq(parseParamCount(undefined), null, "undefined → null");
+
+// ── size resolution ─────────────────────────────────────────────────
+eq(modelSizeBytes({ size_bytes: 1234 }), 1234, "size_bytes wins");
+eq(modelSizeBytes({ size: "1 GB" }), 1024 ** 3, "legacy size string parsed");
+eq(modelSizeBytes({}), null, "no size → null");
+
+// ── sort: unknown keys sink, stable ─────────────────────────────────
+{
+  const rows = [
+    { id: "b", name: "b", params: "7B" },
+    { id: "a", name: "a", params: undefined }, // unknown params
+    { id: "c", name: "c", params: "27B" },
+  ];
+  eq(
+    sortModels(rows, "params", "desc").map((m) => m.id),
+    ["c", "b", "a"],
+    "params desc: real values ordered, unknown sinks last",
+  );
+  eq(
+    sortModels(rows, "params", "asc").map((m) => m.id),
+    ["b", "c", "a"],
+    "params asc: unknown STILL sinks last (not floated by direction)",
+  );
+  eq(
+    sortModels(rows, "name", "asc").map((m) => m.id),
+    ["a", "b", "c"],
+    "name asc alphabetical",
+  );
+}
+{
+  // stability: equal keys keep input order
+  const rows = [
+    { id: "x", name: "same" },
+    { id: "y", name: "same" },
+    { id: "z", name: "same" },
+  ];
+  eq(
+    sortModels(rows, "name", "asc").map((m) => m.id),
+    ["x", "y", "z"],
+    "equal keys preserve input order (stable)",
+  );
+}
+{
+  // input is not mutated
+  const rows = [{ id: "b", name: "b" }, { id: "a", name: "a" }];
+  sortModels(rows, "name", "asc");
+  eq(rows.map((m) => m.id), ["b", "a"], "sortModels does not mutate input");
+}
+
+// ── modelSortKey ────────────────────────────────────────────────────
+eq(modelSortKey({ name: "Foo" }, "name"), "foo", "name key lowercased");
+eq(modelSortKey({ created: 100 }, "added"), 100, "added key = created ts");
+eq(modelSortKey({ created: 0 }, "added"), null, "created 0 → null (unknown)");
+
+// ── tag filtering (AND) ─────────────────────────────────────────────
+ok(modelMatchesTags({ tags: ["coder", "mtp"] }, []), "no selection matches all");
+ok(modelMatchesTags({ tags: ["coder", "mtp"] }, ["coder"]), "single tag match");
+ok(modelMatchesTags({ tags: ["coder", "mtp"] }, ["coder", "mtp"]), "AND match");
+ok(!modelMatchesTags({ tags: ["coder"] }, ["coder", "mtp"]), "AND miss narrows");
+ok(!modelMatchesTags({}, ["coder"]), "no tags → no match when selecting");
+
+// ── tag chips = curated ∩ present, in curated order ─────────────────
+{
+  const rows = [{ tags: ["coder", "user-added"] }, { tags: ["mtp"] }];
+  eq(
+    tagChipsFor(rows, ["mtp", "coder", "vision"]),
+    ["mtp", "coder"],
+    "chips are curated∩present in curated order (vision dropped, no rows)",
+  );
+  eq(tagChipsFor([], ["mtp"]), [], "no rows → no chips");
+  eq(tagChipsFor(rows, []), [], "no curated vocab → no chips");
+}
+
+// ── added label ─────────────────────────────────────────────────────
+{
+  const now = 1_700_000_000; // fixed clock (seconds)
+  eq(fmtAdded(now, now), "today", "same instant → today");
+  eq(fmtAdded(now - 3 * 86400, now), "3d ago", "3 days → 3d ago");
+  eq(fmtAdded(0, now), "—", "0 → unknown dash");
+  eq(fmtAdded(undefined, now), "—", "undefined → unknown dash");
+  eq(fmtAdded(now + 86400, now), "—", "future → dash (no negative ages)");
+}
+
+// ── the sort field vocabulary is what the toolbar expects ───────────
+eq(
+  MODEL_SORT_FIELDS.map((f) => f.id),
+  ["name", "size", "params", "added"],
+  "sort field ids match the toolbar dropdown",
+);
+
+if (failures) {
+  console.error(`\n${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("✓ model-sort: all assertions passed");

--- a/ui/src/dash/model-modals.jsx
+++ b/ui/src/dash/model-modals.jsx
@@ -32,9 +32,15 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
   const [name, setName] = useStateMM("");
   const [labels, setLabels] = useStateMM({ chat: true });
   const [mmproj, setMmproj] = useStateMM("");
+  // Optional chat-template pin, applied at pull time (WS-6). "auto" = use the
+  // GGUF-embedded template — the common case, so it's the default.
+  const [chatTemplate, setChatTemplate] = useStateMM("auto");
 
   const inspect = useModelInspect();
   const pullJob = usePullJob();
+  // Chat-template catalogue — gated on `open` like the Recipe editor so the
+  // request only fires while the modal is visible.
+  const templates = useChatTemplates(open);
   // One canonical capability vocabulary for every add/edit surface —
   // meta.model_capabilities (this modal used to carry its own ad-hoc list
   // with legacy spellings: embeddings/reranking/transcription).
@@ -47,6 +53,7 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
       setName("");
       setLabels({ chat: true });
       setMmproj("");
+      setChatTemplate("auto");
       inspect.reset();
       pullJob.reset();
     }
@@ -99,6 +106,7 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
         hf_filename: variant,
         mmproj_filename: mmproj || undefined,
         labels: labelList,
+        chat_template: chatTemplate && chatTemplate !== "auto" ? chatTemplate : undefined,
       });
       window.__hal0Toast && window.__hal0Toast(
         `Pulling ${name} · ${sel?.size ?? ""}`, "info",
@@ -239,6 +247,25 @@ function AddByHfModal({ open, onClose, initialRepo = "" }) {
               </div>
             </div>
           )}
+
+          <div className="form-row">
+            <div className="form-lbl">
+              <span>chat template</span>
+              <span className="sub">auto = use template embedded in the GGUF · applied on pull</span>
+            </div>
+            <div className="form-ctl">
+              <select
+                className="input mono chat-template-select"
+                value={chatTemplate}
+                onChange={e => setChatTemplate(e.target.value)}
+              >
+                <option value="auto">Auto (GGUF embedded)</option>
+                {(Array.isArray(templates.data) ? templates.data : []).filter(t => t.id !== "auto").map(t => (
+                  <option key={t.id} value={t.id}>{t.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
 
           {inspect.data?.metadata?.license && (
             <div className="form-section">License · <span className="mono" style={{color: "var(--fg)"}}>{inspect.data.metadata.license}</span></div>

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -92,6 +92,8 @@ function ModelsView() {
       const bes = Array.isArray(m.backends) ? m.backends : [];
       if (!bes.includes(filters.device) && m.device !== filters.device) return false;
     }
+    // Tag chips narrow with AND semantics (empty selection matches all).
+    if (!modelMatchesTags(m, tagSel)) return false;
     if (q.trim()) {
       const needle = q.trim().toLowerCase();
       const hay = `${m.longName || ""} ${m.name || ""} ${m.id || ""} ${m.repo || ""}`.toLowerCase();
@@ -99,6 +101,13 @@ function ModelsView() {
     }
     return true;
   };
+  // Sort applied WITHIN each section (the section structure never reorders).
+  const bySort = rows => sortModels(rows, sortField, sortDir);
+  // Tag chips worth rendering: curated vocab ∩ tags actually present on rows.
+  const tagChips = useMemoM(
+    () => tagChipsFor(modelList, enums.curated_model_tags),
+    [modelList, enums],
+  );
   // A model belongs to the ComfyUI/image surface when the backend flags it
   // (owned_by/backends "comfyui", or a comfyui_category derived from its path)
   // or it classifies as image. Path-derived flags self-heal rows an older pull
@@ -200,8 +209,38 @@ function ModelsView() {
                     <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
                   ))}
                 </div>
-                {(filters.type || filters.device || q.trim()) && (
-                  <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); }}>clear ✕</button>
+                {tagChips.length > 0 && (
+                  <div className="mdl-toolbar-grp">
+                    <span className="lbl">tag</span>
+                    {tagChips.map(t => (
+                      <button
+                        key={t}
+                        className={"mdl-chip" + (tagSel.includes(t) ? " on" : "")}
+                        data-testid={`mdl-tag-${t}`}
+                        onClick={() => setTagSel(s => s.includes(t) ? s.filter(x => x !== t) : [...s, t])}
+                      >{t}</button>
+                    ))}
+                  </div>
+                )}
+                <div className="mdl-toolbar-grp">
+                  <span className="lbl">sort</span>
+                  <select
+                    className="input mono mdl-sort"
+                    data-testid="mdl-sort-field"
+                    value={sortField}
+                    onChange={e => setSortField(e.target.value)}
+                  >
+                    {MODEL_SORT_FIELDS.map(f => <option key={f.id} value={f.id}>{f.label}</option>)}
+                  </select>
+                  <button
+                    className="mdl-chip mdl-sort-dir"
+                    data-testid="mdl-sort-dir"
+                    title={sortDir === "asc" ? "ascending" : "descending"}
+                    onClick={() => setSortDir(d => d === "asc" ? "desc" : "asc")}
+                  >{sortDir === "asc" ? "↑" : "↓"}</button>
+                </div>
+                {(filters.type || filters.device || q.trim() || tagSel.length > 0) && (
+                  <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); setTagSel([]); }}>clear ✕</button>
                 )}
               </>
             )}
@@ -224,22 +263,22 @@ function ModelsView() {
           {tab === "models" ? (
             <>
               {installed.length > 0 && <div className="mdl-section-label">Installed · {installed.length}</div>}
-              {installed.map(m => (
+              {bySort(installed).map(m => (
                 <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
               ))}
 
               {blessed.length > 0 && <div className="mdl-section-label">Available · blessed · {blessed.length}</div>}
-              {blessed.map(m => (
+              {bySort(blessed).map(m => (
                 <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
               ))}
 
               {userNs.length > 0 && <div className="mdl-section-label">user.* · {userNs.length}</div>}
-              {userNs.map(m => (
+              {bySort(userNs).map(m => (
                 <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
               ))}
 
               {upstreamAdv.length > 0 && <div className="mdl-section-label">Upstream · remote · {upstreamAdv.length}</div>}
-              {upstreamAdv.map(m => (
+              {bySort(upstreamAdv).map(m => (
                 <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
               ))}
 
@@ -382,6 +421,7 @@ function ModelRow({ model, selected, onSelect }) {
       </span>
       <span className="mdl-row-tags">
         {model.type && <span className="chip">{model.type}</span>}
+        {model.quant && <span className="chip quant" data-testid="mdl-row-quant">{model.quant}</span>}
         {backends.map(b => (
           <span key={b} className={"chip dev-" + b}>{b}</span>
         ))}
@@ -475,10 +515,12 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       <div className="mdl-detail-meta">
         <div><div className="k">params</div><div className="v">{model.params || "—"}</div></div>
         <div><div className="k">size</div><div className="v">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "—")}</div></div>
+        <div><div className="k">quant</div><div className="v" data-testid="mdl-detail-quant">{model.quant || "—"}</div></div>
         <div><div className="k">type</div><div className="v">{model.type || (model.capabilities?.[0]) || "—"}</div></div>
         <div><div className="k">device</div><div className="v">{model.device || (model.backends?.[0]) || "—"}</div></div>
         <div><div className="k">runtime</div><div className="v">{model.runtime || "—"}</div></div>
         <div><div className="k">namespace</div><div className="v">{model.ns || "—"}</div></div>
+        <div><div className="k">added</div><div className="v">{fmtAdded(model.created)}</div></div>
         <div><div className="k">origin</div><div className="v">{isUpstreamModel(model) ? `upstream · ${model.upstream}` : "local"}</div></div>
       </div>
       <div className="mdl-detail-labels">

--- a/ui/tests/e2e/specs/models-catalog-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-catalog-controls-v3.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * models-catalog-controls-v3 — the WS-13 catalog toolbar (sort dropdown +
+ * direction toggle, curated tag-filter chips, quant chip on rows + detail
+ * cell, "added" detail cell) and the WS-6 chat-template pick in the
+ * Add-by-HF modal.
+ *
+ * Forced-mock note: VITE_MOCK_HAL0 short-circuits page.route for
+ * /api/models, so the catalog fixture rows are injected by intercepting the
+ * `window.HAL0_DATA = …` assignment (data.jsx) via addInitScript — the mock
+ * layer reads HAL0_DATA.models lazily on every fetch. The Add-by-HF flow
+ * mocks POST /api/models/inspect directly (it isn't part of HAL0_DATA).
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+// Three installed local rows with distinct sort keys, quants, tags, and
+// added-timestamps so every control has something to bite on.
+const ROWS = [
+  {
+    id: 'local.alpha-7b',
+    name: 'alpha-7b',
+    longName: 'Alpha 7B',
+    installed: true,
+    ns: 'pulled',
+    capabilities: ['chat', 'tool-calling'],
+    backends: ['rocm'],
+    size_bytes: 4_500_000_000,
+    params: '7B',
+    quant: 'Q4_K_M',
+    tags: ['coder'],
+    created: 1_700_000_000,
+  },
+  {
+    id: 'local.zeta-27b',
+    name: 'zeta-27b',
+    longName: 'Zeta 27B',
+    installed: true,
+    ns: 'pulled',
+    capabilities: ['chat'],
+    backends: ['rocm'],
+    size_bytes: 16_000_000_000,
+    params: '27B',
+    quant: 'Q8_0',
+    tags: ['moe'],
+    created: 1_600_000_000,
+  },
+  {
+    id: 'local.mid-13b',
+    name: 'mid-13b',
+    longName: 'Mid 13B',
+    installed: true,
+    ns: 'pulled',
+    capabilities: ['chat'],
+    backends: ['vulkan'],
+    size_bytes: 9_000_000_000,
+    params: '13B',
+    quant: 'Q5_K_M',
+    tags: ['coder', 'moe'],
+    created: 1_650_000_000,
+  },
+]
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((rows) => {
+    let stored: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get: () => stored,
+      set: (v) => {
+        if (v && Array.isArray(v.models)) v.models = [...rows, ...v.models]
+        stored = v
+      },
+    })
+  }, ROWS)
+})
+
+// Names of the installed section's rows, top to bottom.
+async function installedOrder(page: any): Promise<string[]> {
+  const names = await page.locator('.mdl-row .nm').allInnerTexts()
+  // Keep only our fixtures (the mock catalog may add its own rows).
+  return names
+    .map((t: string) => t.split('\n')[0].trim())
+    .filter((n: string) => ['Alpha 7B', 'Zeta 27B', 'Mid 13B'].includes(n))
+}
+
+test.describe('Models v3 — catalog controls (/models)', () => {
+  test('sort by size asc/desc reorders within the section', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toBeVisible()
+
+    await page.getByTestId('mdl-sort-field').selectOption('size')
+    // default dir is asc → smallest first
+    expect(await installedOrder(page)).toEqual(['Alpha 7B', 'Mid 13B', 'Zeta 27B'])
+
+    await page.getByTestId('mdl-sort-dir').click() // → desc
+    expect(await installedOrder(page)).toEqual(['Zeta 27B', 'Mid 13B', 'Alpha 7B'])
+  })
+
+  test('sort by params orders by parsed count, not string', async ({ page }) => {
+    await page.goto('/#models')
+    await page.getByTestId('mdl-sort-field').selectOption('params')
+    // asc: 7B < 13B < 27B (numeric, not lexicographic where "13B" < "7B")
+    expect(await installedOrder(page)).toEqual(['Alpha 7B', 'Mid 13B', 'Zeta 27B'])
+  })
+
+  test('tag chips narrow the catalog with AND semantics', async ({ page }) => {
+    await page.goto('/#models')
+    // coder → alpha + mid; moe → zeta + mid; coder AND moe → mid only.
+    await page.getByTestId('mdl-tag-coder').click()
+    await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toBeVisible()
+    await expect(page.locator('.mdl-row', { hasText: 'Mid 13B' })).toBeVisible()
+    await expect(page.locator('.mdl-row', { hasText: 'Zeta 27B' })).toHaveCount(0)
+
+    await page.getByTestId('mdl-tag-moe').click()
+    await expect(page.locator('.mdl-row', { hasText: 'Mid 13B' })).toBeVisible()
+    await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toHaveCount(0)
+    await expect(page.locator('.mdl-row', { hasText: 'Zeta 27B' })).toHaveCount(0)
+  })
+
+  test('quant chip renders on rows and in the detail meta grid', async ({ page }) => {
+    await page.goto('/#models')
+    const row = page.locator('.mdl-row', { hasText: 'Alpha 7B' })
+    await expect(row.getByTestId('mdl-row-quant')).toHaveText('Q4_K_M')
+
+    await row.click()
+    await expect(page.getByTestId('mdl-detail-quant')).toHaveText('Q4_K_M')
+    // "added" cell renders a humane label (not a raw timestamp).
+    await expect(
+      page.locator('.mdl-detail-meta > div', { hasText: 'added' }).locator('.v'),
+    ).not.toHaveText('—')
+  })
+
+  test('Add-by-HF modal offers a chat-template pick', async ({ page }) => {
+    await page.route('**/api/chat-templates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 'chatml', label: 'ChatML', valid: true, error: null },
+          { id: 'llama3', label: 'Llama 3', valid: true, error: null },
+        ]),
+      }),
+    )
+    await page.route('**/api/models/inspect', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          repo: 'unsloth/Qwen3-8B-GGUF',
+          cached: false,
+          variants: [{ id: 'qwen3-8b-q4_k_m.gguf', size_bytes: 4_900_000_000, size: '4.56 GB' }],
+          tags: ['gguf'],
+          metadata: {},
+        }),
+      }),
+    )
+    await page.goto('/#models')
+    await page.locator('.view .vh button:has-text("Add by HF coords")').click()
+    await page.locator('input[placeholder*="unsloth/Qwen3-8B-GGUF"]').fill('unsloth/Qwen3-8B-GGUF')
+    await page.locator('button:has-text("Inspect")').click()
+
+    const select = page.locator('.chat-template-select')
+    await expect(select).toBeVisible()
+    // "auto" is the default; the catalogue options come from the mock.
+    await expect(select).toHaveValue('auto')
+    await expect(select.locator('option', { hasText: 'ChatML' })).toHaveCount(1)
+    await select.selectOption('chatml')
+    await expect(select).toHaveValue('chatml')
+  })
+})


### PR DESCRIPTION
# WS-13 catalog controls + WS-6 chat-template pick

Follow-up to the merged #1039. Two items from the pipeline plan (`handoffs/model-pipeline-fix-plan-2026-07-04.md`) that #1039 landed only partially:

## WS-13 — catalog controls (the wiring was missing)
#1039 shipped the pure `model-sort.js` helpers and the toolbar `sortField`/`sortDir`/`tagSel` state, but they were never referenced in the render. This wires them in:
- **Sort** dropdown (name / size / params / added) + a direction toggle, applied *within* each section (the installed/blessed/user/upstream structure never reorders). Params sort parses `27B`/`350M` so it orders numerically, not lexically; rows with unknown keys sink to the end regardless of direction.
- **Tag filter** chips sourced from `meta.curated_model_tags` ∩ tags actually present on rows, AND-narrowing.
- **Quant** chip on each row + a `quant` cell and an `added` cell in the detail meta grid (`quant`/`created` already flow through the serializer and normalizer from #1039).

## WS-6 — chat-template pick at pull time
- Add-by-HF modal gains an optional chat-template select (mirrors the Recipe editor's). The pick rides the pull body as `chat_template`; the backend `_seed_registry_from_body` pins it onto the registry row's `defaults.chat_template` **at pull start** (new-row create and existing-row re-pull both). The modal closes on pull start, so a post-unmount PUT would be fragile — and the default only matters at load time, long after the pull finishes, so seeding it early is correct. The `auto` sentinel writes no override.

## Test plan
- `node ui/src/dash/__tests__/model-sort.test.mjs` — dependency-free helper coverage (numeric params, unknown-key sink, stable sort, AND tag filter, curated∩present chips, humane "added" label).
- `models-catalog-controls-v3.spec.ts` — 5 Playwright cases (size asc/desc reorder, params numeric sort, AND tag narrowing, quant chip on row + detail, Add-by-HF template pick). Neighboring `models-v3`/`models-upstream-v3`/`model-recipe-template-v3` specs still green (15 passed).
- `tests/api/test_pull_routes.py` — 3 new cases (template seeds new-row defaults, `auto` seeds none, template patches an existing row); pull/models suites 66 passed.
- `npx tsc --noEmit`, `npm run build`, `ruff check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016cUG4Khk9JZ9KMivsZE3PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016cUG4Khk9JZ9KMivsZE3PQ)_