### PR TITLE
ComfyUI: hot-reload idle_restore + workflow listing (settings completeness P5)

### DIFF
--- a/src/hal0/api/routes/comfyui.py
+++ b/src/hal0/api/routes/comfyui.py
@@ -679,6 +679,54 @@ def _workflow_not_found_response() -> JSONResponse:
     )
 
 
+def _list_workflow_names() -> list[dict[str, Any]]:
+    """Enumerate launchable ``<name>.json`` workflows across both search dirs.
+
+    Scans the primary workflows dir and the ``user/default/workflows``
+    fallback (both bind-mounted into the container, so operator-dropped
+    files show up here). Names are deduped with primary winning; each entry
+    carries the resolved ``source`` dir so the UI can hint where a file
+    lives. Fail-soft: an unreadable/missing dir contributes nothing rather
+    than raising, so the list endpoint never 500s on a fresh install.
+    """
+    seen: dict[str, dict[str, Any]] = {}
+    for source, directory in (
+        ("primary", _comfyui_workflows_dir()),
+        ("user", os.path.join(_comfyui_data_dir(), "user", "default", "workflows")),
+    ):
+        try:
+            entries = sorted(os.listdir(directory))
+        except OSError:
+            continue
+        for fn in entries:
+            if not fn.endswith(".json"):
+                continue
+            name = fn[: -len(".json")]
+            if not _WORKFLOW_NAME_RE.fullmatch(name) or ".." in name:
+                continue
+            # Primary wins — don't let the fallback shadow it.
+            seen.setdefault(name, {"name": name, "source": source})
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# GET /workflows — list launchable workflows from the bind-mounted dirs
+# ---------------------------------------------------------------------------
+
+
+@router.get("/workflows")
+async def comfyui_workflows() -> dict[str, Any]:
+    """List launchable workflow templates discoverable on disk.
+
+    Returns ``{"workflows": [{"name", "source"}, ...]}`` — the names the
+    UI can hand to ``POST /workflows/{name}/launch``. Operators drop
+    ``<name>.json`` files into the bind-mounted workflows dir and they
+    appear here without a rebuild. Empty list on a fresh install (no dir
+    yet) rather than an error.
+    """
+    return {"workflows": _list_workflow_names()}
+
+
 # ---------------------------------------------------------------------------
 # POST /render/cancel — clear queue + interrupt current render
 # ---------------------------------------------------------------------------

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2048,6 +2048,32 @@ class SlotManager:
                 write_state_atomic(self._state_file(slot_name), refreshed)
                 self._states[slot_name] = refreshed
 
+        # #599 follow-up: ``[image].idle_restore_minutes`` is read into the
+        # GpuArbiter once at lazy construction, so a config write alone left
+        # the live idle-restore window stale until the next api restart — the
+        # Settings control silently under-delivered. Push the new value into
+        # the already-constructed arbiter (if any) so the idle loop's next
+        # tick honours it immediately. Fail-soft: the arbiter reads
+        # ``idle_restore_minutes`` fresh each tick, so a bad value can't wedge
+        # it, and an absent arbiter picks the value up at construction anyway.
+        if self._arbiter is not None and "image" in updates:
+            from hal0.slots.arbiter import gpu_exclusive_group
+
+            if gpu_exclusive_group(cfg_dict) == "img":
+                image = cfg_dict.get("image") or cfg_dict.get("image_gen") or {}
+                val = image.get("idle_restore_minutes") if isinstance(image, dict) else None
+                if isinstance(val, int) and not isinstance(val, bool) and val >= 0:
+                    if val != self._arbiter.idle_restore_minutes:
+                        log.info(
+                            "gpu_arbiter.idle_restore_minutes_hot_reload",
+                            extra={
+                                "slot": slot_name,
+                                "old": self._arbiter.idle_restore_minutes,
+                                "new": val,
+                            },
+                        )
+                    self._arbiter.idle_restore_minutes = val
+
         return await self.status(slot_name)
 
     async def reconcile_unconfigured_slots(self) -> None:

--- a/tests/api/test_comfyui_phase4.py
+++ b/tests/api/test_comfyui_phase4.py
@@ -378,6 +378,65 @@ class TestWorkflowLaunch:
         assert r.json()["prompt_id"] == "xyz"
 
 
+class TestWorkflowList:
+    def test_lists_json_files_from_primary_dir(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        wf_dir = tmp_path / "comfyui" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "alpha.json").write_text("{}")
+        (wf_dir / "beta.json").write_text("{}")
+        (wf_dir / "notes.txt").write_text("ignore me")  # non-json skipped
+        monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(wf_dir))
+
+        r = client.get("/api/comfyui/workflows")
+        assert r.status_code == 200
+        names = {w["name"]: w["source"] for w in r.json()["workflows"]}
+        assert names == {"alpha": "primary", "beta": "primary"}
+
+    def test_primary_wins_over_user_fallback(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        primary = tmp_path / "comfyui" / "workflows"
+        primary.mkdir(parents=True)
+        (primary / "shared.json").write_text("{}")
+        fallback = tmp_path / "comfyui" / "user" / "default" / "workflows"
+        fallback.mkdir(parents=True)
+        (fallback / "shared.json").write_text("{}")
+        (fallback / "extra.json").write_text("{}")
+        monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(primary))
+        monkeypatch.setenv("COMFYUI_DATA_DIR", str(tmp_path / "comfyui"))
+
+        r = client.get("/api/comfyui/workflows")
+        assert r.status_code == 200
+        by_name = {w["name"]: w["source"] for w in r.json()["workflows"]}
+        assert by_name["shared"] == "primary"  # primary shadows the fallback copy
+        assert by_name["extra"] == "user"
+
+    def test_missing_dir_returns_empty_list_not_error(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(tmp_path / "does-not-exist"))
+        monkeypatch.setenv("COMFYUI_DATA_DIR", str(tmp_path / "also-gone"))
+        r = client.get("/api/comfyui/workflows")
+        assert r.status_code == 200
+        assert r.json() == {"workflows": []}
+
+    def test_traversal_names_are_filtered(
+        self, client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        wf_dir = tmp_path / "comfyui" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "good.json").write_text("{}")
+        # A file whose stem carries a path-ish char must not surface.
+        (wf_dir / "a b.json").write_text("{}")  # space fails the name regex
+        monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(wf_dir))
+
+        r = client.get("/api/comfyui/workflows")
+        names = {w["name"] for w in r.json()["workflows"]}
+        assert names == {"good"}
+
+
 # ---------------------------------------------------------------------------
 # GET /api/comfyui/preview
 # ---------------------------------------------------------------------------

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -993,3 +993,74 @@ async def test_update_config_model_merge_matches_shared_helper(
     on_disk = tomllib.loads((slot_root / "chat.toml").read_text(encoding="utf-8"))
     assert on_disk["model"] == expected_model
     assert on_disk["model"] == helper_after["model"]
+
+
+# ── #599 follow-up: [image].idle_restore_minutes hot-reload into the arbiter ──
+
+
+def _write_img_slot(root: Path, *, idle_restore_minutes: int, port: int = 8188) -> None:
+    """Write an img-group (ComfyUI) slot TOML carrying [image].idle_restore_minutes."""
+    (root / "img.toml").write_text(
+        "\n".join(
+            [
+                'name = "img"',
+                f"port = {port}",
+                'type = "image"',
+                'provider = "comfyui"',
+                'device = "gpu-rocm"',
+                'runtime = "container"',
+                'profile = "comfyui"',
+                "enabled = true",
+                "[model]",
+                'default = "sdxl-turbo"',
+                "[image]",
+                f"idle_restore_minutes = {idle_restore_minutes}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+async def test_update_config_hot_reloads_arbiter_idle_restore(slot_root: Path) -> None:
+    """Editing [image].idle_restore_minutes pushes the new value into the
+    already-constructed GpuArbiter without an api restart (the value used to
+    be read only once at lazy construction)."""
+    _write_img_slot(slot_root, idle_restore_minutes=60)
+    sm = SlotManager()
+    # Touch the property so the arbiter is lazily constructed and caches 60.
+    assert sm.arbiter.idle_restore_minutes == 60
+
+    from hal0.slots.state import SlotState as _S
+
+    await sm._transition("img", _S.OFFLINE, force=True)
+    await sm.update_config("img", {"image": {"idle_restore_minutes": 15}})
+
+    # Live arbiter reflects the new window immediately.
+    assert sm.arbiter.idle_restore_minutes == 15
+
+
+async def test_update_config_hot_reload_accepts_zero_manual_only(slot_root: Path) -> None:
+    """0 is valid (#599 manual-only restore) and must propagate, not fall back."""
+    _write_img_slot(slot_root, idle_restore_minutes=60)
+    sm = SlotManager()
+    assert sm.arbiter.idle_restore_minutes == 60
+
+    from hal0.slots.state import SlotState as _S
+
+    await sm._transition("img", _S.OFFLINE, force=True)
+    await sm.update_config("img", {"image": {"idle_restore_minutes": 0}})
+    assert sm.arbiter.idle_restore_minutes == 0
+
+
+async def test_update_config_non_image_edit_leaves_arbiter_untouched(slot_root: Path) -> None:
+    """A write that doesn't touch [image] must not perturb the arbiter window."""
+    _write_img_slot(slot_root, idle_restore_minutes=45)
+    sm = SlotManager()
+    assert sm.arbiter.idle_restore_minutes == 45
+
+    from hal0.slots.state import SlotState as _S
+
+    await sm._transition("img", _S.OFFLINE, force=True)
+    await sm.update_config("img", {"model": {"default": "sd-1.5"}})
+    assert sm.arbiter.idle_restore_minutes == 45

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -20,6 +20,9 @@ export const ENDPOINTS = {
   comfyuiRenderCancel: '/api/comfyui/render/cancel',
   comfyuiRestart: '/api/comfyui/restart',
   comfyuiLogs: '/api/comfyui/logs',
+  // List launchable workflow .json files discovered on disk (operator-dropped
+  // files in the bind-mounted workflows dir show up here without a rebuild).
+  comfyuiWorkflows: '/api/comfyui/workflows',
   comfyuiWorkflowLaunch: (name: string) => `/api/comfyui/workflows/${encodeURIComponent(name)}/launch`,
   // Latest output image proxy
   comfyuiPreview: '/api/comfyui/preview',

--- a/ui/src/api/hooks/useComfyui.ts
+++ b/ui/src/api/hooks/useComfyui.ts
@@ -164,6 +164,30 @@ export function useComfyuiLogs(tail = 60) {
   })
 }
 
+// List launchable workflows discovered on disk. Fail-soft: 404 / network
+// error (comfyui not installed, no dir yet) yields an empty list so the
+// curated strip renders unchanged. Polled lazily — the file set changes
+// rarely, so a long staleTime keeps this cheap.
+export interface ComfyuiWorkflow {
+  name: string
+  source: 'primary' | 'user'
+}
+
+export function useComfyuiWorkflows() {
+  return useQuery({
+    queryKey: ['comfyui', 'workflows'],
+    queryFn: async (): Promise<ComfyuiWorkflow[]> => {
+      try {
+        const res = await apiGet<{ workflows?: ComfyuiWorkflow[] }>(ENDPOINTS.comfyuiWorkflows)
+        return Array.isArray(res?.workflows) ? res.workflows : []
+      } catch {
+        return []
+      }
+    },
+    staleTime: 60_000,
+  })
+}
+
 // Quick-launch a named workflow (202).
 export function useComfyuiWorkflowLaunch() {
   return useMutation({

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -18,6 +18,7 @@ import {
   useComfyui,
   useComfyuiRenderCancel,
   useComfyuiRestart,
+  useComfyuiWorkflows,
   transformComfyuiStatus,
   COMFYUI_FALLBACK,
 } from '@/api/hooks/useComfyui'
@@ -268,10 +269,24 @@ function workflowHref(comfyBaseUrl, wf) {
   return wf ? `${comfyBaseUrl}/?workflow=${encodeURIComponent(wf)}` : comfyBaseUrl
 }
 
-// `max` caps the strip so it stays ~2 rows — a curated, varied set sorted by
-// type rather than an unbounded wall of tags.
-function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl, max = 6 }) {
+// `max` caps the curated strip so it stays ~2 rows — a curated, varied set
+// sorted by type rather than an unbounded wall of tags. Operator-added
+// workflows discovered on disk (GET /api/comfyui/workflows) are appended as
+// plain chips so files dropped into the bind-mounted workflows dir are
+// visible without a rebuild; they were previously invisible (hardcoded list).
+function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl, max = 6, maxCustom = 8 }) {
   const shown = sortFlowsByType(flows).slice(0, max)
+  const workflowsQuery = useComfyuiWorkflows()
+
+  // Curated entries already reference a ``<file>.json``; don't list an
+  // operator file twice if it matches one of those. Compare on the bare name.
+  const curatedFiles = new Set(
+    flows.map(f => (f.wf ? f.wf.replace(/\.json$/i, '') : null)).filter(Boolean),
+  )
+  const custom = (workflowsQuery.data || [])
+    .filter(w => w.name && !curatedFiles.has(w.name))
+    .slice(0, maxCustom)
+
   return (
     <div>
       <BlkH icon="bolt" acc note="opens in ComfyUI ↗">workflows</BlkH>
@@ -293,6 +308,25 @@ function WorkflowsBlock({ flows = FLOWS_DEFAULT, comfyBaseUrl, max = 6 }) {
               <span className="arr">→</span>
               <span>{f.b}</span>
               {f.tag && <span className="tag">{f.tag}</span>}
+            </a>
+          )
+        })}
+        {custom.map((w) => {
+          const href = workflowHref(comfyBaseUrl, `${w.name}.json`)
+          return (
+            <a
+              className="flow"
+              key={`custom:${w.name}`}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-disabled={href ? undefined : 'true'}
+              data-workflow={w.name}
+              title={`${w.name}.json (${w.source})`}
+            >
+              <span className="ic"><Ci name="bolt" size={14} /></span>
+              <span>{w.name}</span>
+              <span className="tag">custom</span>
             </a>
           )
         })}


### PR DESCRIPTION
## What

Phase 5 — the final phase of the settings-completeness plan. Two ComfyUI fixes.

### Arbiter `idle_restore_minutes` hot-reload
The `GpuArbiter` read `[image].idle_restore_minutes` once at lazy construction, so editing it through the existing Image-gen settings control (`PUT /api/slots/{img}/config`) wrote the TOML but left the **live** idle-restore window stale until the next hal0-api restart — the control silently under-delivered. `SlotManager.update_config` now pushes the new value into the already-constructed arbiter whenever a write touches `[image]` on the img-group slot.

- Fail-soft: the idle loop reads the attribute fresh each tick, so a bad value can't wedge it; an absent arbiter still picks the value up at construction.
- `0` (manual-only restore, #599 semantics) propagates correctly rather than falling back to 60.

### Workflow listing
- New **`GET /api/comfyui/workflows`** enumerates launchable `<name>.json` files across the primary and `user/default/workflows` bind-mounted dirs (primary wins on dedupe; traversal / invalid names filtered; missing dir → empty list, never 500). Operator-dropped workflow files already worked via `POST /workflows/{name}/launch` but were invisible in the UI's hardcoded 6-flow strip.
- The ComfyUI pane's `WorkflowsBlock` now appends discovered custom workflows (`useComfyuiWorkflows`, fail-soft) as chips after the curated set, so files dropped on disk show up without a rebuild.

## Verification
- `uv run pytest tests/slots/test_manager.py tests/slots/test_gpu_arbiter.py tests/api/test_comfyui_phase4.py tests/api/test_comfyui_proxy.py tests/providers/test_comfyui_workflows.py` — 171 passed.
- New coverage: arbiter hot-reload (change / zero-manual-only / non-image-write-leaves-untouched) in `test_manager.py`; workflow-list (listing, primary-wins-on-dedupe, missing-dir-empty, name filtering) in `test_comfyui_phase4.py`.
- `ruff check` / `ruff format --check` clean; UI `npm run build` + `typecheck` clean; dash unit tests 3/3.

## Plan complete
This closes the settings-completeness plan: P1+P2 (#1036 inert keys + hindsight memory schema), P3 (#1038 Voice), P4 (#1040 NPU), P5 (this). Every previously-inert `hal0.toml` key is now consumed or deleted, and the Voice / NPU / ComfyUI surfaces are honest end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbetLmpWk4hk9RXYMj1SGR)_