### PR TITLE
docs: re-baseline README to v0.8.4b1 + mirror refreshed hal0.dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,19 @@ shared inference daemon; no extra process to babysit.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.8.2b3** — container-runtime era, declarative
-> config. Each slot (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, NPU
-> trio) runs as a dedicated podman container (`hal0-slot@<name>.service`).
+> **Status:** **v0.8.4b1** — container-runtime era, declarative
+> config. Each slot (`agent`, `utility`, `embed`, `rerank`, `stt`, `tts`,
+> `img`, `vision`, NPU trio) runs as a dedicated podman container
+> (`hal0-slot@<name>.service`).
 > Slot definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles
 > in `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
 > single source of truth for every HuggingFace coordinate and SHA-256
-> digest. The launch command for every slot is now resolved from a single
-> source (deduped, with per-flag provenance), and **Stacks** apply
-> declarative model/slot layouts atomically. `hal0-api` can run
-> unprivileged — install with `HAL0_USER=hal0` to drop it off root (slot
-> containers stay rootful; default `root` is unchanged). The one-liner
+> digest. The launch command for every slot is resolved from a single
+> source (deduped, with per-flag provenance), **Stacks** apply
+> declarative model/slot layouts atomically, and profiles share the same
+> portable export/import envelope. Models can carry a preferred runtime
+> profile, interrupted pulls resume, and voice runs end-to-end (NPU STT +
+> Kokoro or GPU Qwen3-TTS). The one-liner
 > seeds the recommended Main slot non-interactively; run `hal0 setup`
 > anytime to configure models, extensions, and NPU interactively. See
 > [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
@@ -101,9 +103,9 @@ be evicted out from under a streaming request.
 - **Slots** — each named target in `capabilities.toml` carries a
   `type` (`llm | embedding | reranking | transcription | tts | image`),
   a `device` (`gpu-rocm | gpu-vulkan | cpu | npu | img`), a `model`,
-  plus `enabled` and optional `default`. Six seeded slots (`chat`,
-  `embed`, `rerank`, `stt`, `tts`, `img`) plus three NPU slots
-  (`npu`, `stt-npu`, `embed-npu`) when FastFlowLM is installed.
+  plus `enabled` and optional `default`. Eight seeded slots (`agent`,
+  `utility`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`) plus NPU
+  slots (`npu`, `stt-npu`, `embed-npu`) when FastFlowLM is installed.
   User-added slots via `hal0 slot create NAME --type TYPE --model MODEL`.
   Slots refer to a **profile** in `/etc/hal0/profiles.toml` that pins
   the container image + flag bundle for that backend.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ installed, a single FLM process inside the `hal0-toolbox-flm` container
 hosts chat + transcription + embedding concurrently on the one AMDXDNA
 hardware context — ~2 GB NPU memory, gemma3:1b at 40 tok/s +
 Whisper-V3-Turbo + Embedding-Gemma all coresident. hal0 exposes this
-as three slots (`agent`, `stt-npu`, `embed-npu`); the `npu.toml`
+as three slots (`npu`, `stt-npu`, `embed-npu`); the `npu.toml`
 `[npu]` table toggles ASR and embed. The host-side FLM `.deb` is
 installed for device-sanity probes only — inference runs in the
 container. See ADR-0009 (FLM trio NPU packing) for why.
@@ -132,13 +132,21 @@ be evicted out from under a streaming request.
   hardware-aware configuration, live logs, system health, and a
   built-in chat page (with popout window + reasoning toggle).
   SSE-backed status + log tail. Journal panel streams per-slot
-  container logs via journald. Dark by default.
+  container logs via journald. Dark by default. Live telemetry —
+  Power & Thermal (GPU clock/temp/power) and Per-Slot Throughput —
+  is on by default, and the logs/events surface is unified across
+  channels with real source/slot attribution.
   The slots page splits into Inference | Image Gen tabs: the Image-Gen
   tab operates the ComfyUI container (live GTT/RAM gauges, queue
   depth, model inventory) with a gated inference ⇄ generation iGPU
   switchover behind a blast-radius confirm.
 - **Extensions** — selectable Apps (Open WebUI) and Agents (Hermes,
   Pi) that `hal0 setup` auto-wires into the platform.
+- **Companion-service management** — `/api/services` is the declarative
+  source of truth for OpenWebUI, Hermes, Hindsight, ComfyUI, and n8n:
+  audit-logged systemd lifecycle actions (start/stop/restart/enable/
+  disable), mDNS `.local` advertisement, and a dedicated dashboard
+  Services page.
 - **Stacks** — declarative, runtime-switchable model/slot layouts as a
   replacement for install-time bundle tiers. A `StackConfig` is planned
   into a change set, applied atomically (with rollback) and converged
@@ -183,7 +191,8 @@ reachable by any MCP-speaking client — Claude Code, future RAG
 services, external scripts. The bundled agent is single-pick at install:
 `pi-coder` (CLI shape, installed from `Hal0ai/pi-mono` fork via
 `@earendil-works/pi-coding-agent` on npm) or `Hermes-Agent` (service
-shape, installed via the hal0-owned `hal0-hermes` wrapper; connects to
+shape, installed via the hal0-owned `hermes` wrapper — `hal0-hermes` is
+kept as a back-compat symlink; connects to
 `hal0-api` via `HAL0_INFERENCE_BASE=http://127.0.0.1:8080`). Select
 one during `hal0 setup` (Extensions step) or any time via `hal0 agent
 install <name>`; swap atomically with `--switch`. Capital-D destructive MCP calls
@@ -202,11 +211,11 @@ pins the container image and flag bundle for each backend.
 
 | Capability               | Profile / image                  | Device              | Notes                                                        |
 |--------------------------|----------------------------------|---------------------|--------------------------------------------------------------|
-| chat + embed + rerank    | `rocm` / `rocm-mtp` / `vulkan` | ROCm / Vulkan / CPU | ROCm FP4 fork baked into the image; MTP via `--spec-type draft-mtp` |
+| chat + embed + rerank    | `rocm` / `rocm-dnse` / `rocm-moe` / `vulkan` / `cuda` (experimental) | ROCm / Vulkan / CUDA / CPU | ROCm FP4 fork baked into the image; MTP via `--spec-type draft-mtp` on the `rocm-dnse`/`rocm-moe` profiles |
 | chat + STT + embed (NPU) | `flm` (`hal0-toolbox-flm`)  | AMD XDNA (opt-in)   | FLM trio: one container, `[npu] asr/embed` toggles, ~2 GB NPU mem |
 | transcription            | whisper.cpp in toolbox image     | Vulkan / CPU        | `stt` slot                                                   |
-| TTS                      | `tts` (`hal0-toolbox-kokoro`) | CPU             | `[CPU]` chip + tooltip in dashboard                          |
-| image                    | `comfyui` (`hal0-toolbox-comfyui`) | ROCm              | Exclusive GPU via arbiter; SD Turbo / Flux-2-Klein-9B        |
+| TTS                      | `tts` (`hal0-toolbox-kokoro`) / `tts-qwen3` (`hal0-toolbox-qwen3tts`) | CPU / ROCm | `voice.tts` switches Kokoro (CPU) ⇄ Qwen3-TTS (GPU) without reconfiguring the slot |
+| image                    | `comfyui` (`docker.io/kyuz0/amd-strix-halo-comfyui`) | ROCm | Exclusive GPU via arbiter; SD Turbo / Flux-2-Klein-9B        |
 
 The NPU path is opt-in: the installer places a FastFlowLM `.deb` on
 the host for device-sanity probes (`flm validate`); inference runs
@@ -221,16 +230,16 @@ TOML fields, profiles, GPU arbiter, and day-2 commands — see
 ## Hardware
 
 Linux + systemd is the only hard requirement
-([`installer/install.sh:86`](./installer/install.sh)). macOS and Windows
+([`installer/install.sh:246`](./installer/install.sh)). macOS and Windows
 are not in scope for v1.
 
 | Tier            | Hardware                                                                  | Status |
 |-----------------|---------------------------------------------------------------------------|--------|
 | **First-class** | AMD Ryzen AI Max+ 395 ("Strix Halo") with iGPU + XDNA NPU + 128 GB unified | Reference deployment. All published perf numbers come from this box. |
 | **First-class** | AMD Ryzen AI Max 385 / 390 with 64 GB unified                              | Same path; small + mid tiers fit, 70B Q4 with shorter context. |
-| **Supported**   | NVIDIA RTX 30/40/50 (10–32 GB)                                            | CUDA-backed llama-server in the `vulkan` container profile. Same slot lifecycle, dedicated VRAM instead of UMA. |
+| **Experimental** | NVIDIA RTX 30/40/50 (10–32 GB)                                           | Dedicated `cuda` seed profile — upstream `ghcr.io/ggml-org/llama.cpp:server-cuda` via CDI (`nvidia-container-toolkit`), with multi-GPU `gpu_index` pinning on the `gpu-cuda` device. Auto-falls back to the `vulkan` profile when CDI isn't present. `/api/backends` doesn't yet auto-advertise `gpu-cuda`. |
 | **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | ROCm or Vulkan container profiles; same `hal0-slot@<name>` lifecycle. |
-| **Fallback**    | CPU-only x86_64                                                            | `vulkan` profile, CPU path. Usable for tiny models / smoke tests, not the headline experience. |
+| **Fallback**    | CPU-only x86_64                                                            | `cpu-llm` profile — the Vulkan toolbox image run CPU-only (no GPU passed to the container). Usable for tiny models / smoke tests, not the headline experience. |
 
 ## Project layout
 
@@ -241,7 +250,6 @@ hal0/
 │   ├── slots/        # slot manager, state machine, GpuArbiter
 │   └── omni_router/  # client-side tool-calling loop + tool definitions
 ├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard (v3)
-├── ui-vue.bak/       # v0.2.1 Vue 3 dashboard preserved verbatim for reference
 ├── installer/        # install.sh (writes /etc/hal0/, systemd units, hal0-api.service)
 │   ├── etc-hal0/     # seed slot TOMLs + profiles.toml
 │   └── systemd/      # hal0-agent@ template units
@@ -275,8 +283,10 @@ server URL (usually `http://127.0.0.1:5173`).
 
 Run `hal0 doctor` any time to re-check pre-flight (systemd / python /
 disk / ports / NPU probe). `hal0 model pull <ref>` streams models from
-Hugging Face into `registry.toml` under the `user.*` namespace, and
-`hal0 uninstall [--keep-data]` tears down a running install (thin
+Hugging Face into `registry.toml` under the `user.*` namespace — a
+disk-space preflight fails fast before a multi-GB pull, and an
+interrupted pull resumes via HTTP `Range` instead of restarting from
+zero — and `hal0 uninstall [--keep-data]` tears down a running install (thin
 wrapper over `installer/uninstall.sh`).
 
 Useful day-2 commands:
@@ -291,7 +301,7 @@ journalctl -fu hal0-api
 journalctl -fu 'hal0-slot@*'
 
 # restart a wedged slot container
-systemctl restart hal0-slot@chat
+systemctl restart hal0-slot@agent
 ```
 
 ### Auth posture
@@ -358,11 +368,9 @@ running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap
 
 ### Soon
 
-- **GPU-accelerated TTS** — kokoro-vulkan or successor; closes the
-  `[CPU]` chip on the voice slot card
-- **Advanced memory** — Hindsight graph extraction enabled, MCP
-  client side of hal0 (agents reach external MCP servers), federated
-  memory across local + remote sources
+- **Advanced memory** — MCP client side of hal0 (agents reach
+  external MCP servers), federated memory across local + remote
+  sources
 - **Benchmarks & presets UI** — in-dashboard tok/s + latency runs,
   plus curated loadout presets you can flash onto a fresh install
 - **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -61,13 +61,9 @@ state changes to the dashboard footer. These are shared across all requests —
 the API is a thin layer over them.
 
 <Aside type="note">
-hal0 ships built-in auth via `--auth=basic` (Caddy + basic_auth + bearer tokens + automatic HTTPS). Without the flag (or your own reverse proxy), the API binds
-`0.0.0.0:8080` open on the LAN. What it *does* provide:
-HMAC session cookies for the dashboard and agent chat, MCP host and origin
-allowlists, per-agent bearer tokens, and an approval queue for privileged
-agent actions. For TLS and per-request access control, put a reverse proxy
-(Traefik / Caddy / nginx) in front of it. See
-[Security](/docs/concepts/security) for the full threat model.
+hal0 ships with **no built-in authentication or TLS**. The API is open on the
+local network by design. See [Security](/docs/concepts/security) for the
+reverse-proxy pattern you put in front of it.
 </Aside>
 
 ## Slots: where models actually run

--- a/docs/concepts/capabilities-and-profiles.mdx
+++ b/docs/concepts/capabilities-and-profiles.mdx
@@ -59,9 +59,10 @@ hal0 ships seed profiles so a fresh install is immediately usable:
 | Profile | Targets | Purpose |
 |---|---|---|
 | `rocm` | GPU (ROCm) | MoE / agent models, FP4, no MTP (larger q8 KV) — the `gpu-rocm` default |
-| `rocm-dnse` | GPU (ROCm) | Dense models with MTP speculative decoding (q4 KV) |
-| `rocm-moe` | GPU (ROCm) | MoE models with MTP speculative decoding (q4 KV) |
+| `rocm-dnse` | GPU (ROCm) | Dense models with MTP speculative decoding (q8 KV) |
+| `rocm-moe` | GPU (ROCm) | MoE models with MTP speculative decoding (q8 KV) |
 | `vulkan` | GPU (Vulkan) | Standard Vulkan path and fallback |
+| `cuda` | GPU (CUDA) | NVIDIA GPUs via upstream llama.cpp CUDA — **experimental**, the `gpu-cuda` default |
 | `flm` | NPU | FLM inference on the NPU |
 | `tts` | CPU | Text-to-speech (Kokoro) |
 | `comfyui` | image | Image generation (ComfyUI) |
@@ -72,14 +73,29 @@ clone it under a new name and edit the copy. Each profile is also classified
 into a runtime family (llama-server, FLM, Kokoro, or ComfyUI) that determines
 which slot types it can serve.
 
+Profiles are also **portable**: any profile can be exported to a
+self-contained, checksummed `.hal0profile.json` envelope and imported on
+another host — the same sharing model stacks use. See [Devices, providers &
+profiles](/docs/reference/providers-profiles-devices#portable-profiles-exportimport)
+for the routes and MCP tools.
+
+A registry model can also carry a **preferred profile** (`defaults.profile`)
+that a slot adopts automatically on creation and on every model swap, gated on
+device/type compatibility — see [Devices, providers &
+profiles](/docs/reference/providers-profiles-devices#model-preferred-profile)
+for the exact rule.
+
 ![The Profiles tab in the hal0 dashboard showing seed profile cards for rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, and comfyui with bench metrics and device class chips](/screenshots/profiles-tab.png)
 
 *The Profiles tab — seed profile cards with bench metrics, device class chips, and the clone affordance for creating custom profiles.*
 
 <Aside type="tip">
-When `mtp` is enabled on a profile, hal0 appends a tuned speculative-decoding
-flag bundle to the profile's flags at launch. A slot can override the profile's
-MTP setting for itself.
+When `mtp` is enabled on a profile, hal0 merges a tuned speculative-decoding
+flag bundle into the profile's flags at launch — as defaults only. Any
+`--spec-draft-*` flag the profile pins explicitly wins over the bundle; the
+bundle just fills in what the profile left unset (fixed in v0.8.2b2 — the
+bundle used to be appended verbatim and could clobber a profile's own tuning).
+A slot can override the profile's MTP setting for itself.
 </Aside>
 
 ## Device and backend: where a slot runs
@@ -90,12 +106,17 @@ typo fails fast. The valid devices are:
 
 - `gpu-rocm` — the AMD iGPU via ROCm.
 - `gpu-vulkan` — a GPU via Vulkan (the broad-compatibility path).
+- `gpu-cuda` — an NVIDIA GPU via CUDA (**experimental**).
 - `cpu` — CPU-only execution.
 - `npu` — the AMD XDNA NPU via FastFlowLM.
 
 <Aside type="caution">
-NVIDIA/CUDA is **not** a valid device. An NVIDIA GPU is detected and shown, but
-hal0 runs it through Vulkan, never CUDA. There is no `cuda` device.
+NVIDIA/CUDA support is **experimental**. `gpu-cuda` runs an NVIDIA GPU through
+the upstream `llama.cpp` CUDA image via CDI passthrough (requires
+`nvidia-container-toolkit`); it isn't part of the bench-tuned AMD Strix Halo
+profile family and isn't yet auto-advertised by the dashboard's
+backend-availability probe. Without `nvidia-container-toolkit`, an NVIDIA GPU
+still only surfaces through the generic Vulkan path.
 </Aside>
 
 `device` replaced an older overloaded `backend` field that mixed hardware and
@@ -111,7 +132,8 @@ migration:
 |---|---|
 | `gpu-rocm` | `rocm` |
 | `gpu-vulkan` | `vulkan` |
-| `cpu` | `tts` |
+| `gpu-cuda` | `cuda` |
+| `cpu` | `cpu-llm` |
 | `npu` | `flm` |
 
 Because a slot carries both a `device` and a `profile`, the two must stay

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -1,6 +1,6 @@
 ---
 title: Memory
-description: hal0's optional memory subsystem — a Hindsight-backed brain that operators and agents share. It's opt-in via HAL0_MEMORY_ENABLED and degrades cleanly to a no-op when off.
+description: hal0's memory subsystem — a Hindsight-backed brain that operators and agents share. Gated by HAL0_MEMORY_ENABLED (on by default on a fresh install) and degrades cleanly to a no-op when off.
 sidebar:
   order: 50
 ---
@@ -9,8 +9,10 @@ import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 hal0 can give your platform a persistent **memory** — a store of facts that both
 the operator surfaces and the bundled agent can write to and recall from. It's a
-deliberate, opt-in subsystem: powerful when you want it, and completely absent
-when you don't.
+deliberate, gated subsystem behind a single flag: powerful when it's on, and
+completely absent when it's off. A fresh install turns it on for you; it stays
+a conscious, revertible choice rather than something that silently accumulates
+data on an existing box.
 
 ## What memory is
 
@@ -23,11 +25,15 @@ dashboard shows.
 ![Memory interface showing stored facts and recall](/screenshots/memory-view.png)
 *Memory view in the hal0 dashboard*
 
-The default engine is **Hindsight** — a memory service that powers the shared
-operator and agent "brain." When configured, hal0 builds a Hindsight client and
-wraps it with a reranker so recall surfaces the most relevant facts. If the
-Hindsight service is unavailable at boot, hal0 degrades gracefully to a local
-provider rather than failing — the subsystem stays usable.
+The engine is **Hindsight** — a memory service that powers the shared operator
+and agent "brain." (Cognee, the prior engine, was fully removed in
+v0.8.0-beta.3; `hal0 memory migrate` remains for boxes still carrying a
+Cognee-era store.) When configured, hal0 builds a Hindsight client and wraps
+it with a reranker so recall surfaces the most relevant facts. If the
+Hindsight daemon is unavailable at boot, hal0 degrades to an in-memory
+PgVector fallback rather than failing — the subsystem stays usable, but that
+fallback is volatile (writes don't survive a restart) and exists to keep the
+tools answering, not as a durable substitute.
 
 ![Memory graph visualization showing relationships between facts](/screenshots/memory-graph.png)
 *Fact relationships in the knowledge graph*
@@ -38,11 +44,11 @@ provider is selected from config, so the surfaces (REST + MCP) stay the same
 regardless of which engine backs them.
 </Aside>
 
-## Memory is opt-in
+## Memory is gated by one flag
 
-This is the most important thing to know: **memory is disabled by default.** hal0
-only constructs a memory provider when `HAL0_MEMORY_ENABLED=1` is set in the
-environment. When it isn't:
+This is the most important thing to know: hal0 only constructs a memory
+provider when `HAL0_MEMORY_ENABLED=1` is set in the environment. When it
+isn't:
 
 - No memory provider is built.
 - Every downstream caller degrades to a no-op or a clean error — the
@@ -50,14 +56,20 @@ environment. When it isn't:
   and the per-agent memory stats all handle the absent provider gracefully.
 - The dashboard hides the Memory navigation.
 
-Flipping the flag is the *entire* toggle — no code change, and the behaviour is
-identical on fresh and upgraded installs (an upgrade never rewrites your
-environment file to turn it on). This default-off posture exists so memory is a
-conscious choice, not something that quietly accumulates data you didn't ask for.
+Flipping the flag is the *entire* toggle — no code change required either way.
+The one-line installer writes `HAL0_MEMORY_ENABLED=1` into `/etc/hal0/api.env`
+and stands up the local Hindsight daemon for you, so **a fresh install has
+memory on out of the box**; the underlying default (a box with no `api.env`
+entry at all — a manual/source setup, or one that predates the flip) is off.
+An upgrade never rewrites an existing `api.env`, so a box that was installed
+before memory shipped on by default, or that had the flag removed by hand,
+stays off until you set it yourself. Either way it's a conscious, revertible
+choice, not something that quietly starts accumulating data you didn't ask
+for.
 
 <Aside type="caution">
-Turn memory on only when you want hal0 to retain facts across sessions. Until you
-set `HAL0_MEMORY_ENABLED=1`, the memory surfaces are inert.
+The flag is the whole toggle. Until `HAL0_MEMORY_ENABLED=1` is set (by the
+installer or by hand) and the API is restarted, the memory surfaces are inert.
 </Aside>
 
 ## What memory powers
@@ -65,23 +77,38 @@ set `HAL0_MEMORY_ENABLED=1`, the memory surfaces are inert.
 When enabled, memory becomes the shared brain that ties the platform together:
 
 <CardGrid>
-  <Card title="The agent's recall" icon="comment">
-    The bundled agent reads and writes memory through MCP, so it can remember
-    context across conversations — scoped to a per-agent namespace.
+  <Card title="Hermes's durable memory, by default" icon="comment">
+    Since v0.8.1-beta.1, provisioning a fresh Hermes wires it straight to this
+    subsystem (`memory.provider=hal0-memory`) with no manual config: a
+    `private:hermes` bank for its own facts and a `shared` bank every agent on
+    the host can read, both backed by Hindsight via the hal0-api REST front
+    door. Reads union both banks; recalled context is injected automatically
+    every turn, and the agent can also call `hal0_memory_search` /
+    `hal0_memory_recall` / `hal0_memory_add` directly (`shared=true` writes
+    the shared bank).
   </Card>
   <Card title="Operator memory" icon="document">
-    The dashboard Memory view and the `/api/memory/*` routes let you add, search,
-    and prune facts directly.
+    The dashboard Memory view and the `/api/memory/*` routes let you add,
+    search, browse the graph, and prune facts directly — across banks,
+    documents, mental models, and directives.
   </Card>
   <Card title="Namespaced writes" icon="setting">
     Callers identify themselves (via the `X-hal0-Agent` header), so private
     writes land in the right per-agent namespace rather than a shared pool.
+  </Card>
+  <Card title="Destructive ops are audited" icon="approve-check">
+    Bank deletes and every memories / config / document / directive /
+    operation / mental-model delete record a durable audit row — actor,
+    target, and outcome — so a wipe is attributable after the fact. Deleting
+    an entire bank additionally requires the caller to echo the bank id back
+    via `?confirm=<bank_id>`.
   </Card>
 </CardGrid>
 
 ## Where to go next
 
 <CardGrid>
+  <LinkCard title="Enable memory" href="/docs/guides/enable-memory" description="Flip the flag, control graph extraction, migrate a legacy store." />
   <LinkCard title="Agents" href="/docs/concepts/agents" description="The agent that uses memory as its brain." />
   <LinkCard title="Security" href="/docs/concepts/security" description="Identity, namespaces, and the MCP allowlist." />
   <LinkCard title="Architecture" href="/docs/concepts/architecture" description="Where the memory surfaces sit in the API." />

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -1,60 +1,50 @@
 ---
 title: Security posture
-description: hal0 ships Caddy + basic_auth + bearer tokens + automatic HTTPS behind one flag. Learn the built-in and bring-your-own-proxy auth paths, the MCP host and origin allowlists, and the gated-agent model.
+description: hal0 ships no built-in auth or TLS — open on your LAN by design. Learn the threat model, the reverse-proxy pattern, and the MCP host and origin allowlists.
 sidebar:
   order: 70
 ---
 
 import { Aside, Card, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
 
-hal0 ships real authentication and TLS behind a single flag: `--auth=basic`.
-Pass it at install time and you get Caddy running at the edge with browser
-basic_auth, bearer tokens for the OpenAI-compatible API, and automatic HTTPS —
-internal CA for `.local` addresses, Let's Encrypt for real domains. Zero
-certbot.
-
-<Aside type="tip">
-**`--auth=basic`** is the quickest way to a public-facing hal0. It brings up
-Caddy with basic_auth at the edge, bearer tokens for the API, and automatic
-HTTPS — internal CA for `.local`, Let's Encrypt for real domains. The rest of
-this page covers what ships built in and how to bring your own proxy if you
-prefer.
-</Aside>
-
-## Two auth paths
-
-hal0 intentionally offers two paths so you pick the one that fits your
-deployment:
-
-- **Built-in Caddy (`--auth=basic`)** — hal0 provisions and manages a Caddy
-  reverse proxy in front of the API. You get basic_auth for browser sessions
-  (dashboard, OpenWebUI), bearer tokens for programmatic `/v1/*` access, and
-  automatic HTTPS. This is the recommended path when hal0 needs to be
-  reachable beyond a single trusted LAN. See
-  [Authentication & HTTPS](/docs/operate/auth) for the full reference.
-
-- **Bring your own proxy** — hal0 binds `0.0.0.0:8080` with no auth gate of
-  its own. You front it with Traefik, nginx, or any reverse proxy you already
-  operate, and that proxy owns TLS termination and authentication. This is
-  the original posture from the early betas and still the right choice when
-  hal0 lives inside infrastructure you already manage.
+hal0 makes one security decision explicit and central: it does **not** ship
+built-in authentication or TLS. The API binds `0.0.0.0:8080` and every endpoint
+is open to anything that can reach that port. This is a deliberate design choice
+(ADR-0012), and the rest of your security posture is built on top of it rather
+than inside it.
 
 <Aside type="caution">
-Without `--auth=basic` (or your own reverse proxy), hal0-api binds
-`0.0.0.0:8080` and every endpoint is open to anything that can reach that
-port. Do not expose an unprotected hal0 to the public internet. Keep it on a
-trusted network or put a proxy in front of it.
+Do not expose hal0-api directly to the public internet. It has no auth gate —
+anyone who can reach the port can load models, run inference, drive agents, and
+read activity. Keep it on a trusted network, and put a reverse proxy in front of
+it for anything beyond a single trusted LAN.
 </Aside>
 
-## The reverse-proxy pattern (bring your own)
+## Why no built-in auth?
 
-When you already run a reverse proxy in your infrastructure, hal0 stays a
-pure inference and control plane behind it:
+Earlier designs bundled an auth layer and a TLS-terminating proxy. That was
+removed (ADR-0012) because it duplicated, badly, what every operator already
+runs better elsewhere: a real reverse proxy. Bundling auth meant maintaining
+credential storage, token rotation, and TLS certificate plumbing inside the
+inference server — surface area that is someone else's core competency.
+
+Instead, hal0 assumes one of two postures:
+
+- **Single trusted LAN** — hal0 is reachable only from machines you trust, and
+  the open API is acceptable.
+- **Reverse proxy in front** — you terminate TLS and enforce authentication at a
+  proxy you control, and only the proxy talks to hal0.
+
+## The reverse-proxy pattern
+
+To add TLS and authentication, place a reverse proxy of your choice — Traefik
+and nginx are common choices — between your clients and hal0-api. The proxy
+owns:
 
 <Steps>
 
 1. **TLS termination** — present a certificate for your chosen hostname and
-   terminate HTTPS at your proxy.
+   terminate HTTPS at the proxy.
 
 2. **Authentication** — enforce whatever you need (basic auth, OAuth/OIDC, mTLS,
    an allowlist) before a request is forwarded.
@@ -71,13 +61,12 @@ control lives.
 
 <Aside type="note">
 The proxy is **your** infrastructure, not a hal0 feature. hal0 has no opinion
-about which one you use and ships nothing to configure it — unless you use
-`--auth=basic`, in which case hal0 provisions and manages Caddy for you.
+about which one you use and ships nothing to configure it.
 </Aside>
 
 ## MCP host and origin allowlists
 
-The one place hal0 always enforces a network gate is the MCP mount. The admin and
+The one place hal0 does enforce a network gate is the MCP mount. The admin and
 memory MCP servers are mounted as sub-applications under `/mcp/admin` and
 `/mcp/memory`, and the MCP transport applies DNS-rebinding protection.
 
@@ -99,10 +88,24 @@ to reach `/mcp/*` from another machine or through your proxy:
   each host you add, so the dashboard and a reverse-proxy vhost work without a
   second knob.
 
-When Caddy auth is active (`--auth=basic`), the MCP mounts sit behind the same
-Caddy instance — they inherit its TLS and basic_auth gating. The host/origin
-allowlist is still relevant for the MCP transport layer but the outer gate is
-already handled.
+This is a host/origin gate, not authentication — it stops a browser on another
+site from rebinding DNS to reach your loopback MCP server. Real access control
+still belongs at your reverse proxy.
+
+## Agent chat: origin allowlist + session cookie
+
+The agent-chat WebSocket routes carry a second, narrower gate on top of the
+MCP allowlist above: every WS upgrade is checked against an **origin
+allowlist** (`HAL0_ALLOWED_ORIGINS`, comma-separated; the default covers
+`http://hal0.local`, `http://localhost:5173`, and `http://127.0.0.1:8080`),
+and an **HMAC-SHA256 session cookie** (`hal0_session`, `HttpOnly`,
+`SameSite=Lax`) is minted on first `GET /agents/` and verified on every
+WebSocket upgrade after that. The signing secret lives at
+`/var/lib/hal0/agents/secret.bin` (mode `0600`), generated on first use and
+never leaves the hal0 service user. This closes off drive-by sites
+WebSocket-ing into the chat proxy from a browser that already has a session
+open elsewhere — it is not a general-purpose auth system, and caller identity
+still flows on `X-hal0-Agent` underneath it.
 
 ## Agent identity and gated actions
 
@@ -118,13 +121,12 @@ approval queue fit together.
 ## Practical checklist
 
 <CardGrid>
-  <Card title="Use --auth=basic for public exposure" icon="approve-check">
-    One flag at install time: Caddy + basic_auth + bearer tokens + automatic
-    HTTPS. See Authentication & HTTPS.
+  <Card title="Keep it off the internet" icon="warning">
+    Never bind the open API where untrusted clients can reach it. Front it with
+    a proxy or keep it LAN-only.
   </Card>
-  <Card title="Or bring your own proxy" icon="setting">
-    Front hal0 with Traefik / nginx / any reverse proxy you already trust;
-    let only the proxy reach hal0.
+  <Card title="Terminate TLS at a proxy" icon="approve-check">
+    Add HTTPS and auth at Traefik / nginx; let only the proxy reach hal0.
   </Card>
   <Card title="Scope the MCP allowlist" icon="setting">
     Widen `HAL0_MCP_ALLOWED_HOSTS` only to the hosts that must reach `/mcp/*`;
@@ -139,7 +141,7 @@ approval queue fit together.
 ## Where to go next
 
 <CardGrid>
-  <LinkCard title="Authentication & HTTPS" href="/docs/operate/auth" description="Caddy, basic_auth, bearer tokens, automatic HTTPS — one flag." />
+  <LinkCard title="Securing hal0" href="/docs/operate/auth" description="The reverse-proxy-at-edge pattern, worked example, and what hal0 provides on its own." />
   <LinkCard title="Architecture" href="/docs/concepts/architecture" description="How the open API, slots, and dispatcher fit together." />
   <LinkCard title="Agents" href="/docs/concepts/agents" description="Personas, tool gating, and the approval queue." />
   <LinkCard title="Memory" href="/docs/concepts/memory" description="The opt-in memory subsystem." />

--- a/docs/concepts/slots.mdx
+++ b/docs/concepts/slots.mdx
@@ -109,7 +109,10 @@ instead of silently failing. The image container itself stays resident — what'
 exclusive is the GPU **memory**, not the container — so switching modes is fast.
 After the image slot has had no jobs for its configured idle window
 (`idle_restore_minutes`, 60 by default; `0` means manual-only), the arbiter
-frees the diffusion models and restores the LLM slots it had stopped.
+frees the diffusion models and restores the LLM slots it had stopped. If the
+image slot still has an in-flight generation job when the idle window elapses,
+the restore defers rather than unloading it mid-render — a long video render
+simply pushes the LLM restore back until it finishes.
 
 <Aside type="caution">
 The single NPU LLM anchor is exclusive too, but for a different reason: the AMD
@@ -122,22 +125,33 @@ enabling a second `device=npu` chat slot is rejected.
 Every install starts with a set of **seeded slots** so the common capabilities
 have a home before you create anything:
 
-`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`, and `agent`.
+`utility`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`, and `agent`.
 
 When the NPU runtime (FLM) is present, two more shadow slots are seeded:
-`stt-npu` and `embed-npu`. Seeded slots are reserved — you can't create a
-conflicting name or delete them.
+`stt-npu` and `embed-npu` (riding the NPU chat anchor's own `npu` slot).
+Seeded slots are reserved — you can't create a conflicting name or delete them.
+
+The two canonical LLM roles are **`agent`** (the capable default — the
+dispatch fallback anchor every routing chain ends in) and **`utility`** (the
+cheap helper, seeded on every install so tasks like memory extraction always
+have a cheap local model to target). `chat` and `primary` are retired as
+slot/role names — the `chat` *capability* itself is unaffected, since any
+`type: llm` slot can serve it.
 
 Each slot carries a **type** (`llm`, `embedding`, `reranking`, `transcription`,
 `tts`, or `image`) and a **device** preference (`gpu-rocm`, `gpu-vulkan`, `cpu`,
-or `npu`). hal0 also keeps a couple of back-compat **aliases** so older callers
-keep working: `primary` resolves to `chat`, and `agent-hermes` resolves to
-`agent`. Aliases are never written to disk and never appear in slot listings —
-they're a transparent translation at dispatch time.
+or `npu`). hal0 keeps one back-compat **alias** so older callers keep working:
+`agent-hermes` resolves to `agent`. Aliases are never written to disk and
+never appear in slot listings — they're a transparent translation at dispatch
+time.
 
-Addressing a slot by its name (e.g. `model: "chat"`) is the stable way to pin a
-co-resident model: the name doesn't change when you swap the underlying model
-file.
+Addressing a slot by its name (e.g. `model: "agent"`) is the stable way to pin
+a co-resident model: the name doesn't change when you swap the underlying
+model file. hal0 also advertises three virtual model names that resolve to
+whichever slot is actually loaded — `hal0/agent`, `hal0/utility`, and
+`hal0/npu` — and generalizes the pattern to any enabled `type: llm` slot: a
+custom slot named `research` is addressable as `hal0/research` even though
+it isn't one of the three advertised names.
 
 ## Where to go next
 

--- a/docs/getting-started/first-chat.mdx
+++ b/docs/getting-started/first-chat.mdx
@@ -91,10 +91,9 @@ The chat-slot aliases accepted as the `model` id are the slot names
 works too.
 </Aside>
 
-No `Authorization` header is required by default — hal0 treats the local
-network as trusted. Pass `--auth=basic` at install for Caddy + bearer tokens
-+ HTTPS; or front it with your own reverse proxy if exposed.
-You can point any OpenAI SDK at the same base URL:
+No `Authorization` header is required — hal0 ships with no built-in auth
+and treats the local network as trusted (front it with a reverse proxy if
+it is exposed). You can point any OpenAI SDK at the same base URL:
 
 ```python
 from openai import OpenAI

--- a/docs/getting-started/first-model.mdx
+++ b/docs/getting-started/first-model.mdx
@@ -54,10 +54,12 @@ flow is **list → pull → assign**.
    slot):
 
    ```sh
-   hal0 model assign qwen3-4b --slot chat
+   hal0 model assign qwen3-4b --slot agent
    ```
 
-   This writes `model.default` into the slot's configuration. Start the
+   This writes `model.default` into the slot's configuration. `agent` is the
+   always-seeded default/anchor slot (see [Slots](/docs/concepts/slots)); swap
+   in `utility` or any other slot name you've created instead. Start the
    slot afterward (see [Manage slots](/docs/guides/manage-slots/)).
 
 </Steps>

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -69,10 +69,9 @@ FastFlowLM is installed) runs in a dedicated podman container. See the
   />
 </CardGrid>
 
-<Aside type="note" title="Auth & HTTPS">
-hal0 ships Caddy + basic_auth + bearer tokens + automatic HTTPS behind
-one flag: `--auth=basic`. Pass it at install time for a public-facing
-setup. Without it (the default), hal0 runs open on the LAN — front it
-with your own reverse proxy if it's reachable from untrusted networks.
-See [Security](/docs/concepts/security) for the full picture.
+<Aside type="caution" title="No built-in auth or TLS">
+`hal0-api` binds `0.0.0.0:8080` and treats every request as authenticated
+by network reachability — the right posture for a trusted LAN appliance.
+If hal0 is reachable from anywhere you do not control, front it with a
+reverse proxy that owns auth and TLS.
 </Aside>

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -15,14 +15,6 @@ it, and hands off to the real installer.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-<Aside type="tip" title="Public-facing? Add --auth=basic">
-One extra flag: `curl -fsSL https://hal0.dev/install.sh | bash -s -- --auth=basic`.
-It provisions Caddy with basic_auth, bearer tokens for the API, and automatic
-HTTPS — internal CA for `.local`, Let's Encrypt for real domains. Safe to
-expose beyond a single trusted LAN. See
-[Authentication & HTTPS](/docs/operate/auth).
-</Aside>
-
 <Aside type="note">
 The installer needs root to write to `/etc`, `/usr/lib`, and the systemd
 unit directory. When piped through `bash` without `sudo`, it re-execs

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -47,12 +47,21 @@ over an always-on context pane (detected RAM, GPU, NPU) on the right. It walks:
 3. **Main model** — the chat model for the `chat` slot, anchored to a
    hardware-fit tier (see below).
 
-4. **Agent model** — the model backing the bundled agent slot.
+4. **Agent model** — the model backing the `coder` slot used by agent/coding
+   extensions (Hermes' coding tools, Pi).
 
 5. **NPU** — when an AMD XDNA NPU + FastFlowLM are present, enable the NPU trio
    (chat + STT + embed passengers on one `flm serve`).
 
 </Steps>
+
+<Aside type="note">
+The Main and Agent model steps provision dedicated `chat` and `coder` slots
+(distinct from the always-seeded `agent`/`utility` anchor roles — see
+[Slots](/docs/concepts/slots)). hal0's live-resolve virtuals still route
+correctly on a freshly-set-up box: `hal0/agent` falls back to a `chat`-named
+slot until you rename it or assign a model to `agent` directly.
+</Aside>
 
 Setup then applies your selection — in-process when run at install time, or via
 the running API (`POST /api/install/apply-selections`) when the daemon is up —
@@ -61,15 +70,27 @@ writes the first-run sentinel on completion.
 
 ## Hardware-anchored tiers
 
-The main-model step is anchored to four tiers; the highest that fits your
-detected memory is recommended, and tiers that exceed your pool are flagged.
+The main-model step is anchored to five bundle tiers; the highest that fits
+your detected memory is recommended, and tiers that exceed your pool are
+flagged.
 
 | Tier | Fits |
 |---|---|
-| **hal0-Lite** | smaller hosts — a tiny chat model only |
-| **hal0-Default** | mid-range — chat + embed/rerank + voice |
-| **hal0-Pro** | larger unified memory — adds a coder model + image generation |
-| **hal0-Max** | high-memory Strix Halo — adds the NPU trio |
+| **hal0-Lite** | 16 GB+ — a small chat model only |
+| **hal0-Default** | 32 GB+ — chat + embed + voice (STT/TTS) |
+| **hal0-Pro** | 64 GB+ — adds a coder model, rerank, and image generation |
+| **hal0-Max** | 100 GB+ Strix Halo — larger chat/coder models, same voice/embed/rerank/image set as Pro |
+| **LMX-Omni-52B-Halo** | 100 GB+ — AMD-curated, vendor-blessed Strix Halo bundle |
+
+The NPU trio (step 5) is offered independently of tier whenever AMD XDNA +
+FastFlowLM hardware is detected, regardless of which tier you pick.
+
+<Aside type="tip" title="GPU-less hosts">
+On a box with no detected GPU, the `cpu` device now defaults to the `cpu-llm`
+profile — a real chat-capable llama-server profile — instead of one bound to
+the Kokoro TTS engine, so a GPU-less install still gets a working primary
+chat slot.
+</Aside>
 
 ## Flags
 

--- a/docs/guides/choose-models.mdx
+++ b/docs/guides/choose-models.mdx
@@ -81,6 +81,13 @@ research-only, SD 1.5 is RAIL-M. Read the license before using output
 commercially.
 </Aside>
 
+The dashboard's Models view keeps these off the dispatcher-facing
+**Models** tab entirely — they live on their own **Image / ComfyUI** tab,
+grouped by the ComfyUI models-tree subdirectory each one actually lands in
+(`checkpoints`, `loras`, `vae`, `upscale_models`, …). See
+[Generate images](/docs/guides/generate-images) for how that surface
+works.
+
 ## How model fit is evaluated
 
 Before a model is assigned to a slot, hal0 computes a **fit verdict** —
@@ -111,6 +118,20 @@ assignment. This is why the device you pick for a slot has to be
 consistent with its profile — see
 [Manage slots](/docs/guides/manage-slots) for the `--hardware` flag that
 sets it.
+
+<Aside type="tip">
+Fit-checking runs at *assignment* time. If a slot's already-configured
+default later stops resolving locally — its file was removed, or a seed
+pinned an id that was never actually pulled under that exact name —
+`hal0 slot load` doesn't crash-loop on the missing path. `load()` falls
+back to the best locally-registered model that matches the slot's
+capability, preferring whichever candidate shares the most leading
+name tokens with the configured id (then the largest one on disk), and
+always excluding diffusion/image/video artifacts so a text slot can
+never load one by accident. The substitution is logged
+(`slot.model_default_fallback`) so you can go fix the slot's configured
+default.
+</Aside>
 
 ## Off-catalogue models
 

--- a/docs/guides/configure.mdx
+++ b/docs/guides/configure.mdx
@@ -85,6 +85,30 @@ down, the command exits non-zero — start hal0-api first.
 ![Settings page showing live reload status](/screenshots/settings-page.png)
 *Settings page with live daemon status and reload controls.*
 
+The dashboard's **Settings → Storage** section also has its own **Reload
+from disk** button next to the `hal0.toml` path, which hits this same
+`POST /api/settings/reload` — use it after an out-of-band edit with `hal0
+config edit`.
+
+## The dashboard Settings page
+
+Beyond the files and CLI above, the dashboard's Settings view covers most of
+the same ground with a few operator conveniences:
+
+- **Anonymous telemetry** — an opt-in toggle for `[telemetry] enabled`
+  (off by default; see [Configuration schema reference](/docs/reference/config-schema)).
+- **Image-gen defaults** — `default_size`, `default_steps`, and
+  `idle_restore_minutes` for the `img`/ComfyUI slot's `[image]` table.
+- **Secrets** — provider API key presets (Hugging Face, OpenAI, Anthropic,
+  Google, Groq) plus a paired **AWS Bedrock** preset
+  (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), or a custom key name.
+- **Advanced** — schema-driven controls for every `[slots]`, `[dispatcher]`,
+  `[memory]`, and `[activity]` key that previously required `hal0 config
+  edit` (including `slots.evict_pressure_mb`, the pressure-eviction floor),
+  plus a dedicated **memory graph** panel for `[memory.graph]`
+  (`extraction_slot`, `llm_timeout_s`) and a **Restart hal0-api** button for
+  settings marked "restart required".
+
 ## Migrate the schema forward
 
 When you update hal0 across a schema bump, bring `hal0.toml` to the latest

--- a/docs/guides/connect-external-providers.mdx
+++ b/docs/guides/connect-external-providers.mdx
@@ -96,7 +96,7 @@ environment so the change takes effect immediately, and **never echoes
 the secret back** — the response carries `"value": "***REDACTED***"`.
 
 <Aside type="caution">
-Without `--auth=basic`, the hal0 API binds open
+There is no built-in authentication on the hal0 API (ADR-0012) — it binds
 to the LAN. `api.env` is a LAN-writable file; treat the host as you would
 any secret-bearing service and reverse-proxy it if it needs to be exposed.
 </Aside>

--- a/docs/guides/connect-mcp.mdx
+++ b/docs/guides/connect-mcp.mdx
@@ -16,12 +16,11 @@ servers, mounted on the API as Streamable-HTTP sub-apps:
   hardware probes. Its `memory_*` tools route in-process to the memory
   server.
 
-<Aside type="note">
-hal0 ships built-in auth via `--auth=basic` (Caddy + basic_auth + bearer
-tokens + automatic HTTPS). Without it, hal0 runs open on the LAN — run it
-on a trusted network or behind your own reverse proxy. Do not expose
-`/mcp/*` unprotected to the internet. See
-[Security](/docs/concepts/security).
+<Aside type="caution">
+hal0 has **no built-in network auth** (ADR-0012). The MCP mounts are
+reachable to anything that can reach the API. Run hal0 on a trusted LAN
+or behind your own reverse proxy — do not expose `/mcp/*` to the
+internet.
 </Aside>
 
 ## Connect
@@ -35,7 +34,8 @@ http://localhost:8080/mcp/memory
 
 ### Identify with X-hal0-Agent
 
-Caller identity flows on the **`X-hal0-Agent`** request header. The value must match
+Caller identity flows on the **`X-hal0-Agent`** request header (Bearer
+auth was removed in ADR-0012). The value must match
 `^[a-zA-Z0-9_-]{1,64}$`. It stamps the audit trail and powers the
 `private:<agent>` memory namespace.
 

--- a/docs/guides/enable-memory.mdx
+++ b/docs/guides/enable-memory.mdx
@@ -1,23 +1,36 @@
 ---
 title: Enable memory
-description: hal0's memory subsystem is opt-in. Enable it with HAL0_MEMORY_ENABLED=1, then control graph extraction with hal0 memory graph and migrate any legacy store.
+description: hal0's memory subsystem is gated by HAL0_MEMORY_ENABLED (on by default on a fresh install). Control graph extraction with hal0 memory graph --slot, and migrate any legacy store.
 sidebar:
   order: 50
 ---
 
 import { Steps, Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components';
 
-hal0's memory subsystem is **off by default**. When enabled it gives
-agents a persistent recall store (Hindsight by default) plus an optional
-knowledge-graph extraction layer. Enabling it is a single environment
-flag — no code change, no reinstall.
+hal0's memory subsystem is gated by a single environment flag,
+`HAL0_MEMORY_ENABLED`. When it's on, hal0 gives agents a persistent recall
+store — **Hindsight** — plus an optional knowledge-graph extraction layer.
+Flipping the flag is a single environment change — no code change, no
+reinstall.
 
 <Aside type="note">
-Memory ships disabled so behaviour is identical on fresh and upgraded
-installs. Every downstream caller — the admin MCP tools, the
-`/api/memory/*` routes, the agent memory provider — degrades to a no-op or
-`503` when memory is off, so flipping the flag is the whole toggle.
+A fresh install turns this on for you: the one-line installer writes
+`HAL0_MEMORY_ENABLED=1` into `/etc/hal0/api.env` and stands up the local
+Hindsight daemon automatically (skip it at install time with
+`HAL0_SKIP_HINDSIGHT=1`). The steps below are for the cases the installer
+doesn't cover: a box that predates the default flip, a manual/source
+install, or re-enabling memory after you turned it off. In every case, every
+downstream caller — the admin MCP tools, the `/api/memory/*` routes, the
+agent memory provider — degrades to a no-op or `503` when memory is off, so
+flipping the flag is the whole toggle either way.
 </Aside>
+
+Hermes ships with its own durable-memory wiring already pointed at this
+subsystem (`memory.provider=hal0-memory`, two banks — `private:hermes` and
+`shared`) — see [What memory powers](/docs/concepts/memory#what-memory-powers)
+for how that fits together. Hermes's memory calls still need
+`HAL0_MEMORY_ENABLED=1` on the hal0-api side to actually work; without it they
+degrade the same as every other caller.
 
 ## Turn it on
 
@@ -45,15 +58,31 @@ installs. Every downstream caller — the admin MCP tools, the
 </Steps>
 
 When the flag is set, hal0 builds the memory provider from your config.
-The default engine is **Hindsight**; if the Hindsight service is
-unreachable at startup, hal0 logs a warning and degrades to a local
-pgvector-backed provider rather than failing startup.
+The engine is **Hindsight**; if the Hindsight daemon is unreachable at
+startup, hal0 logs a warning and degrades to an in-memory PgVector fallback
+rather than failing startup.
+
+<Aside type="caution">
+The PgVector fallback is **volatile** — every write is lost on restart. It
+exists so the tools and dashboard keep answering (empty results instead of a
+crash) while Hindsight is down, not as a durable substitute. Check
+`GET /api/memory/engine` — `"engine": "hindsight"` and `"reachable": true`
+means you're on the real store; `"engine": null` means you're on the
+volatile fallback.
+</Aside>
 
 ## The graph-extraction gate
 
 Storing recall items is one thing; running an LLM over them to extract a
-knowledge graph is heavier and separately gated. Control it with the
-`hal0 memory graph` sub-app (a thin client over `/api/memory/graph`).
+knowledge graph is heavier and separately gated, and it's **off by default**
+even on a fresh install. Control it with the `hal0 memory graph` sub-app (a
+thin client over `/api/memory/graph`).
+
+Hindsight builds its graph natively from whatever local llm slot you point it
+at — there's no external-upstream routing anymore. That slot is
+`[memory.graph].extraction_slot` in `hal0.toml` (default `"utility"`);
+changing it repoints Hindsight's extraction LLM and restarts `hindsight-api`
+to apply it.
 
 ![Memory view showing live graph extraction status and counters](/screenshots/memory-view.png)
 *Live memory and graph-extraction dashboard in hal0.*
@@ -66,26 +95,28 @@ hal0 memory graph status
 hal0 memory graph status --json
 ```
 
-Shows whether extraction is on, the dispatch route, the configured
-upstream, and counters (builds OK, errors, in-flight, last build / error).
+Shows whether extraction is on, the configured extraction slot (and whether
+it currently resolves to a live enabled llm slot), the available slots you
+could pick instead, and counters (builds OK, errors, in-flight, last build /
+error).
 
 </TabItem>
 <TabItem label="Enable">
 
 ```sh
-# extract via a configured external upstream
-hal0 memory graph enable --route upstream \
-  --provider openrouter --model anthropic/claude-3.5-sonnet
+# turn extraction on, keeping the current extraction slot
+hal0 memory graph enable
 
-# or route to a local slot
-hal0 memory graph enable --route primary
-hal0 memory graph enable --route agent
+# turn extraction on and repoint it at a specific local slot
+hal0 memory graph enable --slot utility
+hal0 memory graph enable --slot agent
 ```
 
-`--route` is one of `upstream`, `primary`, or `agent`. When
-`--route=upstream`, both `--provider` and `--model` are required (the
-server enforces this too, so scripts hitting the API directly get the same
-validation).
+`--slot` names a local `type=llm` slot; it must already be enabled — the
+server validates the choice against the live enabled-slot set and rejects an
+unknown or non-llm slot before it ever reaches `hal0.toml`. On success it
+restarts `hindsight-api` so its extraction LLM actually follows the change.
+Omit `--slot` to flip `enabled` without touching the current slot.
 
 </TabItem>
 <TabItem label="Disable">
@@ -94,7 +125,8 @@ validation).
 hal0 memory graph disable
 ```
 
-Turns extraction off and cancels any in-flight build.
+Turns extraction off and cancels any in-flight build. Vector recall is
+unaffected either way — this gate only controls the graph layer.
 
 </TabItem>
 </Tabs>
@@ -116,9 +148,21 @@ Migration is **dry-run only** today — it reports the plan without writing.
 Passing `--no-dry-run` exits with a "not yet implemented" error.
 </Aside>
 
+## Destructive ops are audited
+
+Every destructive call under `/api/memory/*` — bank delete, and the
+memories / config / document / directive / operation / mental-model delete
+routes, plus the namespace `POST /api/memory/delete` used for id-scoped
+deletes — records a durable audit row (actor, target, and a truthful
+outcome) so a memory wipe is attributable after the fact. Deleting a whole
+bank additionally requires
+an explicit confirmation that echoes the bank id back, via `?confirm=<bank_id>`
+(or `{"confirm": "<bank_id>"}` in the body) — a plain `DELETE` with no
+confirmation is rejected with `memory.confirm_required`.
+
 ## Related
 
 - [Run agents](/docs/guides/run-agents) — agents are the main consumer of
   the memory store.
-- [Connect external providers](/docs/guides/connect-external-providers) —
-  set up the upstream you route graph extraction through.
+- [MCP tools](/docs/reference/mcp-tools) — the `memory_*` tool tiers and
+  the `/mcp/memory` server this guide's flag gates.

--- a/docs/guides/generate-images.mdx
+++ b/docs/guides/generate-images.mdx
@@ -109,6 +109,29 @@ return **503** (`comfyui.arbiter_unavailable`). See
 [Manage slots](/docs/guides/manage-slots) for how to add and enable the
 `img` slot.
 
+## Image models in the Models view
+
+The dashboard's Models view keeps image-gen models off the
+dispatcher-facing catalog entirely — a segmented toggle switches between
+**Models** (chat/embed/rerank/stt/tts, the models the dispatcher can
+route a request to) and **Image / ComfyUI**. There's no `image` filter
+chip on the Models tab any more; image lives on its own tab instead.
+
+The Image / ComfyUI tab only ever lists **installed** checkpoints — same
+rule as FLM/NPU models, an un-pulled image model is never advertised
+there — grouped by the ComfyUI models-tree subdirectory each one actually
+landed in (`checkpoints`, `loras`, `vae`, `upscale_models`, …), derived
+straight from the on-disk path under `.../comfyui/models/<subdir>/`.
+
+A model registers as ComfyUI (`owned_by: "comfyui"`, `comfyui` tagged
+into `backends`) no matter which path added it — a curated pull, "add by
+path", or a directory scan all tag it consistently. `GET /api/models`
+also self-heals any row an older hal0 build mis-tagged (for example
+`capabilities: ["chat"]` with empty `backends`) by re-deriving its
+ComfyUI category from the path on every list call — the fix isn't
+persisted back to the registry, it just re-applies on read, so no
+migration is needed.
+
 ## Generate an image
 
 The OpenAI-compatible endpoint translates your request into a ComfyUI

--- a/docs/guides/logs-and-activity.mdx
+++ b/docs/guides/logs-and-activity.mdx
@@ -33,10 +33,10 @@ journalctl -u hal0-api.service -f
 </TabItem>
 </Tabs>
 
-For example, to follow the chat slot or the image-gen slot:
+For example, to follow the agent slot or the image-gen slot:
 
 ```sh
-journalctl -u hal0-slot@chat.service -f
+journalctl -u hal0-slot@agent.service -f
 journalctl -u hal0-slot@img.service -f
 ```
 
@@ -52,7 +52,7 @@ curl 'http://localhost:8080/api/logs?unit=hal0-api&n=200'
 
 | Query param | Default | Notes |
 |-------------|---------|-------|
-| `unit`      | —       | Required. The systemd unit, e.g. `hal0-api` or `hal0-slot@chat`. Validated against a conservative character set. |
+| `unit`      | —       | Required. The systemd unit, e.g. `hal0-api` or `hal0-slot@agent`. Validated against a conservative character set. |
 | `n`         | `200`   | Trailing lines, 1–5000. |
 | `since`     | —       | A `journalctl --since` value (ISO timestamp or `'5min ago'`). |
 | `level`     | —       | Filter to this priority **and higher severity**: `warning` returns warning and all higher-severity levels (error, critical, alert, emergency). |
@@ -66,7 +66,7 @@ On a host without `journalctl` (e.g. CI), the endpoint returns an empty
 Stream a live tail as Server-Sent Events:
 
 ```sh
-curl -N 'http://localhost:8080/api/logs/stream?unit=hal0-slot@chat&level=warning'
+curl -N 'http://localhost:8080/api/logs/stream?unit=hal0-slot@agent&level=warning'
 ```
 
 Each non-empty journal line arrives as a `data:` frame carrying the line
@@ -80,6 +80,32 @@ ENCRYPTION_KEY | SALT` is replaced with `{"value": "***REDACTED***",
 "set": <bool>}` — the UI learns whether a secret is configured without
 ever seeing it.
 </Aside>
+
+## The dashboard Logs page (unified logs/events)
+
+The dashboard's Logs page reads from two different backends behind one
+**channel** selector — `events` / `slot` / `merged`:
+
+- **`events`** — the structured `GET /api/journal` feed (hal0's internal
+  EventBus: slot state transitions, config changes, and the like). Every
+  entry now carries its real `source` (`slot:<name>`, `system`,
+  `model:<id>`, …) instead of everything collapsing to the literal
+  `"hal0"`, plus a parsed `slot` field so per-slot filtering doesn't
+  require re-parsing `source` client-side. `GET /api/journal` (and its
+  `/api/journal/stream` SSE counterpart) accepts `?source=` (exact match,
+  or pass `source=slot` to match every `slot:*` source) and `?slot=` for
+  the same filtering server-side.
+- **`slot`** — the raw per-slot journald tail, i.e. `GET
+  /api/slots/{name}/logs` and `/api/slots/{name}/logs/stream` (the same
+  data `hal0 slot logs` reads — see
+  [Manage slots](/docs/guides/manage-slots)), picked from a slot dropdown.
+  This channel now backfills on open instead of only showing output from
+  the moment you opened it, so the one-shot model-loading lines a slot
+  emits at container start are visible again. A `quiet` filter (on by
+  default; both endpoints accept `quiet=false`) drops `update_slots: all
+  slots are idle` heartbeat spam that would otherwise push real log lines
+  out of view.
+- **`merged`** — both channels together.
 
 ## The durable Activity and Audit log
 

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -39,7 +39,7 @@ hal0 slot list --json
 ## Inspect one slot
 
 ```sh
-hal0 slot show chat
+hal0 slot show agent
 ```
 
 Prints the full status **and** the on-disk TOML config as JSON. Use
@@ -49,7 +49,10 @@ Prints the full status **and** the on-disk TOML config as JSON. Use
 *The slot detail panel combines live status with the persisted TOML config in a single view.*
 
 <Aside type="note">
-The legacy name `primary` is still accepted as an alias for `chat`.
+`primary` and `chat` are retired slot/role names (ADR-0023) — neither is
+accepted as an alias anymore. The canonical LLM roles are `agent` (the
+capable default/fallback anchor) and `utility` (the cheap helper seeded for
+memory extraction); a custom slot is reachable only by its own name.
 </Aside>
 
 ## Create a slot
@@ -168,8 +171,33 @@ The dashboard's slot edit drawer can also set per-slot `[server] extra_args`
 (raw launch flags) — there's no CLI flag for this; it writes via
 `PUT /api/slots/{name}/config`. After changing args that the container baked
 in, the drawer surfaces a **Regenerate** action to rebuild the unit. The
-drawer's context-size field defaults to 16k in the UI; the CLI `--ctx-size`
-default remains `4096`.
+drawer's context-size field seeds from the slot's *persisted*
+`[model].context_size` (not the live runtime metric, which reads `0` on a
+slot that isn't currently serving) and is only written back on Save if you
+actually changed it — so saving an unrelated field (profile, extra_args) no
+longer clobbers the stored context window on a cold reload or model swap.
+The CLI `--ctx-size` default remains `4096`.
+</Aside>
+
+## Dashboard edit drawers
+
+The dashboard's slot and model-recipe edit drawers expose fields the `hal0
+slot` / `hal0 model` CLIs don't have flags for:
+
+- **Per-slot vision toggle** — defaults on when the bound model ships an
+  `mmproj` sidecar (instant-apply; drops or reloads the ~0.9 GB vision
+  projector and cold-restarts the container).
+- **NPU modality toggles** — on `device = npu` slots, `asr` and `embed`
+  toggles write the slot's `[npu]` table (instant-apply, cold-restart).
+- **Model recipe editor** — `capabilities`, `backends`, the `mmproj` path,
+  and the `hf_repo`/`hf_filename` re-pull coordinates are all editable from
+  the Models view, not just the registry API.
+
+<Aside type="note">
+`rope_freq_base` is not editable from either drawer — it's deprecated and
+inert (the launch path never emits it, on both the per-model default and the
+slot `[model]` table). Override RoPE base via `[server] extra_args` instead,
+e.g. `--rope-freq-base 10000`.
 </Aside>
 
 ## Delete a slot
@@ -182,9 +210,44 @@ Stops the unit and removes the config. You'll be asked to confirm; pass
 `--force` / `-f` to skip the prompt.
 
 <Aside type="note">
-Built-in slots (`chat`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`, `agent`) are reserved
-and cannot be deleted — the API rejects the request.
+Seeded slots (`utility`, `embed`, `rerank`, `stt`, `tts`, `img`, `vision`,
+`agent`) are reserved and cannot be deleted — the API rejects the request.
+To stop one of these from serving, disable its capability in
+`capabilities.toml` (or `hal0 slot edit <name>` its `enabled` flag) instead
+of trying to remove it.
 </Aside>
+
+## Idle eviction and memory pressure
+
+Two independent timers can idle-evict a slot, freeing the host RAM
+llama-server statically allocated at `ctx_size` (unloading is the only way
+to reclaim it):
+
+- **Per-slot idle TTL** — `idle_timeout_s` (default `300`s, `0` disables).
+  A slot idle past this is unloaded.
+- **Host memory pressure** — `[slots].evict_pressure_mb` (default `8192`
+  MiB, `0` disables). When host `MemAvailable` drops below this floor,
+  idle LRU-eligible slots are evicted oldest-first until free RAM recovers.
+
+An idle-evicted slot isn't gone: the dispatcher reloads it transparently on
+its next request (wake-on-request), including `embed` / `rerank` / `tts`
+slots — these previously 404'd until a manual `hal0 slot load` after an
+idle eviction. The one exception is a slot **disabled** via a capability
+toggle: hal0 writes `enabled = false` to the slot's TOML, and a disabled
+slot is excluded from wake-on-request, so it stays off until you re-enable
+the capability — a disable now genuinely sticks instead of being silently
+woken by the next matching request.
+
+See [Configuration schema reference](/docs/reference/config-schema) for
+`idle_timeout_s` and `evict_pressure_mb`.
+
+## Dashboard telemetry
+
+On the main dashboard, the **Power & Thermal** card (GPU clock MHz,
+temperature, power draw) and the **Per-Slot Throughput** card are on by
+default, and the **Utilization** card's iGPU row carries a live clock/temp
+caption alongside its usage bar. All three render a "pending driver" note
+instead of a fake reading when a metric isn't available on your host.
 
 ## Stream logs
 

--- a/docs/guides/pull-and-register-models.mdx
+++ b/docs/guides/pull-and-register-models.mdx
@@ -39,11 +39,51 @@ upserts the registry entry with the size and integrity digest. Because
 the temp staging dir lives on the same filesystem as the final path, the
 install is a true atomic rename even for multi-GB files.
 
+Before it streams a multi-GB file, hal0 runs a disk-space preflight
+against the staging filesystem — measured against what's still left to
+fetch, so a resumed pull only needs room for the remainder. If there
+isn't enough free space it fails fast with a structured
+`model.insufficient_disk` (`507`) error instead of streaming until the
+disk fills up.
+
+When HuggingFace's LFS metadata advertises an expected SHA-256 for the
+file, hal0 compares it against the hash it computed on completion; a
+mismatch fails the pull with `pull.checksum_mismatch` (`502`). The
+completed `.part` is kept on disk for diagnosis, but its resume sidecar
+is dropped so a retry starts a clean download rather than "resuming"
+corrupt bytes. Files HF exposes with no advertised hash keep the older
+record-only behaviour.
+
 <Aside type="note">
 Gated or private repos return `401`/`403`. Set `HF_TOKEN` (or
 `HUGGING_FACE_HUB_TOKEN`) in the API environment and the pull adds the
 `Authorization: Bearer …` header automatically.
 </Aside>
+
+### Resuming an interrupted pull
+
+If a pull is interrupted — network drop, `hal0-api` restart, an OOM kill
+— it leaves a deterministic `.part` file in the staging dir plus a small
+resume sidecar recording where it left off. The next pull for that model
+id picks the partial back up with an HTTP `Range` request instead of
+starting over from zero:
+
+- The sidecar's ETag is sent as `If-Range`, so if the upstream object
+  changed in the meantime the server hands back a full `200` body and
+  hal0 restarts the download clean rather than splicing mismatched bytes.
+- The on-disk prefix is re-hashed before the resume continues, so the
+  final SHA-256 still comes out byte-for-byte exact.
+- A `.part` (and its sidecar) left untouched for more than 24 hours is
+  swept on the next daemon start.
+
+### Vision models: the mmproj sidecar
+
+A vision-capable pick pulls its multimodal projector (`mmproj`) as a
+second file in the same job, right after the main GGUF — no separate
+directory scan needed to find it afterwards. The job's per-file manifest
+carries both entries, but the top-level `bytes_downloaded` / `bytes_total`
+on the status/SSE payload stay the aggregate across every file, so
+existing status/progress consumers don't need to change.
 
 ### Progress, status, and cancel
 
@@ -71,7 +111,9 @@ curl -X POST http://localhost:8080/api/models/qwen3-4b/pull/cancel
 <TabItem label="Status fields">
 
 The status payload carries `state`, `bytes_downloaded`, `bytes_total`,
-`sha256`, `path`, and (on failure) `error` / `error_code`. Cancellation
+`sha256`, `path`, and (on failure) `error` / `error_code`. A multi-file
+pull (mmproj sidecar) additionally carries `files`, a per-file manifest
+with each entry's own `bytes_done` / `bytes_total` / `sha256`. Cancellation
 sets a flag the background task observes on the next chunk boundary; the
 partial download is unlinked and the job transitions to `cancelled`.
 
@@ -142,6 +184,22 @@ hal0 model list --json
 
 Aggregates the local registry with everything advertised by configured
 upstreams. Local files win on id collision and are flagged `installed`.
+Every row also carries an explicit `origin` — `local` (bytes actually on
+this host) or `upstream` (only advertised by a remote provider's
+`/v1/models`, never pulled) — so the dashboard's Models list can badge
+upstream-only rows **Upstream · remote** instead of guessing from
+`installed`/`upstream` alone. A tag a composite upstream advertises
+before its weights are genuinely on disk (an FLM slot-default tag, for
+example) is dropped from the catalogue rather than shown as a
+pullable-but-fake row; the dedicated FLM probe re-adds it once it's
+actually installed.
+
+The dashboard's Models catalogue can also be sorted (name / size / params
+/ added-date, independently within each section — installed, catalogue,
+your pulls, upstream) and filtered by tag chips drawn from the curated
+tag vocabulary. Every registered GGUF also carries a `quant` field (e.g.
+`Q4_K_XL`) extracted from the GGUF header at registration time, surfaced
+as a filterable chip alongside the tags.
 
 </TabItem>
 <TabItem label="Show">
@@ -178,9 +236,32 @@ This sets the slot's default model but does **not** load it — follow with
 `hal0 slot load chat` (see
 [Manage slots](/docs/guides/manage-slots)).
 
+## Preferred profile
+
+A registry model can also declare a **preferred profile** — the runtime
+profile it wants loaded alongside it — under `defaults.profile`:
+
+```sh
+curl -X PUT http://localhost:8080/api/models/qwen3.6-27b \
+  -H 'content-type: application/json' \
+  -d '{"defaults": {"profile": "rocm-moe"}}'
+```
+
+A slot adopts this preference automatically: when it's created bound to
+the model with no explicit profile of its own, and again on **every**
+subsequent model swap. The preference is honoured only when it's
+compatible with the slot's existing device and type — an incompatible
+preference is ignored and the slot keeps its current/device-default
+profile; hal0 never flips a slot's hardware to satisfy a model's
+preference. The dashboard's model editor surfaces this as a
+**preferred profile** selector in the model's Recipe pane (filtered to
+profiles that fit the model's backends/device/type), with
+`None (use slot default)` when there's no preference set.
+
 ## The registry on disk
 
 Registry entries are metadata records — id, display name, path, size,
-SHA-256, capabilities, and the Hugging Face coordinates a pull came from.
-The registry is the source of truth the dispatcher resolves model ids
-against; the actual weights live in your configured model store.
+SHA-256, capabilities, launcher defaults (including an optional preferred
+profile), and the Hugging Face coordinates a pull came from. The registry
+is the source of truth the dispatcher resolves model ids against; the
+actual weights live in your configured model store.

--- a/docs/guides/update-and-rollback.mdx
+++ b/docs/guides/update-and-rollback.mdx
@@ -24,6 +24,17 @@ running version. It shows `current → latest (channel)` plus whether an
 update is available, and (when present) the release date, notes URL,
 digest, and signer identity.
 
+<Aside type="note">
+Version comparison uses [PEP 440](https://peps.python.org/pep-0440/)
+(`packaging.version.Version`) in both the updater and the API route, so a
+pip-normalized installed beta (`0.8.0b3`) and a tag-form manifest version
+(`0.8.1-beta.1`) compare correctly. A digit-tuple parser used to misread the
+installed beta number as a patch component, so every box on a `0.8.0bN`
+beta saw the newer release as "not newer" and `hal0 update` reported
+nothing to apply — fixed in v0.8.1-beta.2. Non-PEP-440 nightly tags still
+fall back to the digit-tuple comparator for their timestamp ordering.
+</Aside>
+
 ## Apply an update
 
 ```sh
@@ -85,6 +96,16 @@ The manifest is fetched from `https://releases.hal0.dev/<channel>.json`
 <Aside type="caution">
 Signature verification is mandatory on the `stable` channel — there is no
 skip hatch. Don't disable it.
+</Aside>
+
+<Aside type="note">
+This mandatory check is for the ongoing `hal0 update` path above. The
+**initial one-line installer** is more lenient (v0.8.4b1): it no longer
+hard-requires the `cosign` binary to be present — a missing `cosign` logs a
+warning and the install proceeds without publisher-signature verification
+(the tarball's checksum is still checked). Set
+`HAL0_INSTALL_REQUIRE_COSIGN=1` before running the installer to restore the
+old hard-require behavior.
 </Aside>
 
 ## Roll back

--- a/docs/guides/voice-stt-tts.mdx
+++ b/docs/guides/voice-stt-tts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Speech to text and text to speech
-description: "Enable hal0's voice capability: transcription via whisper-v3:turbo on the XDNA NPU (FLM), synthesis via Kokoro, then call /v1/audio/transcriptions and /v1/audio/speech."
+description: "Enable hal0's voice capability: transcription via whisper-v3:turbo on the XDNA NPU (FLM), synthesis via Kokoro (CPU) or Qwen3-TTS (GPU), then call /v1/audio/transcriptions and /v1/audio/speech."
 sidebar:
   order: 80
 ---
@@ -12,8 +12,11 @@ hal0 exposes two voice directions through OpenAI-compatible endpoints:
 - **Speech-to-text** (`POST /v1/audio/transcriptions`) — `whisper-v3:turbo` served by
   FastFlowLM (FLM) on the XDNA NPU, co-loaded with the chat model in one FLM process
   (the "NPU trio": chat + STT + embed).
-- **Text-to-speech** (`POST /v1/audio/speech`) — Kokoro-82M ONNX container on CPU,
-  54 voices, MP3 by default (default voice: `af_heart`).
+- **Text-to-speech** (`POST /v1/audio/speech`) — served from the single canonical
+  `tts` slot, which can run **either** engine: Kokoro-82M ONNX on CPU, or
+  Qwen3-TTS CustomVoice on the GPU (ROCm, native gfx1151). The `voice.tts`
+  capability picker is an engine switch — choosing a device swaps which
+  provider the `tts` slot runs, with no separate slot to configure.
 
 Both are children of the **`voice`** capability: `voice.stt` maps to the
 `stt` slot and `voice.tts` maps to the `tts` slot.
@@ -43,14 +46,41 @@ curl -X POST http://localhost:8080/api/capabilities/voice/tts \
 ```
 
 </TabItem>
+<TabItem label="Text-to-speech (GPU, Qwen3-TTS)">
+
+```sh
+curl -X POST http://localhost:8080/api/capabilities/voice/tts \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true, "backend": "gpu-rocm", "provider": "qwen3tts"}'
+```
+
+</TabItem>
 </Tabs>
 
 The response is `{ "ok": true, "selection": { ...current selection... } }`.
 
 <Aside type="note">
 STT runs on the XDNA NPU via the FLM container — not on CPU. There is no CPU
-whisper.cpp backend in hal0. Kokoro TTS runs on CPU (ONNX). Neither uses ROCm.
+whisper.cpp backend in hal0. TTS runs from the single `tts` slot on either
+engine: Kokoro (CPU, ONNX) or Qwen3-TTS (GPU, ROCm) — picking a device in the
+`voice.tts` picker swaps the engine in place, it does not add a second slot.
 </Aside>
+
+### The `voice.tts` engine switch
+
+`voice.tts` isn't a model picker in the usual sense — it's a switch between
+two engines that both serve the same `tts` slot and the same
+`POST /v1/audio/speech` contract:
+
+| Device | Provider | Slot profile | Runs on |
+| --- | --- | --- | --- |
+| `cpu` | `kokoro` | `tts` | CPU (ONNX) |
+| `gpu-rocm` | `qwen3tts` | `tts-qwen3` | Strix Halo iGPU (ROCm, native gfx1151) |
+
+Selecting a device rewrites which profile/provider the `tts` slot loads —
+the slot itself doesn't move. Qwen3-TTS weights are operator-staged (not
+pulled through the hal0 registry) and the slot mounts a writable cache
+directory for the MIOpen kernel DB and HuggingFace codec/tokenizer cache.
 
 ### How the NPU STT path works
 
@@ -78,8 +108,9 @@ The `model` form field is **required**; omitting it returns **400**
 
 ## Synthesize speech (text to speech)
 
-Send a JSON body with `model`, `input`, and `voice`. The response is the
-audio stream:
+Send a JSON body with `model` and `input`. `voice`, `speed`, and
+`response_format` are optional — see [request defaults](#tts-request-defaults-and-live-voice-list)
+below for what happens when you omit them:
 
 ```sh
 curl -X POST http://localhost:8080/v1/audio/speech \
@@ -96,10 +127,45 @@ As with transcription, `model` is required — a missing or empty `model`
 returns **400** (`request.missing_model`).
 
 <Aside type="note">
-Kokoro weights are operator-staged on the configured model store. The Kokoro
-toolbox is a containerized server managed by hal0 as a podman slot — no manual
-container management needed. It implements `POST /v1/audio/speech`,
-`GET /v1/models`, and `GET /health`.
+Kokoro weights are operator-staged on the configured model store; Qwen3-TTS
+weights are likewise operator-staged (not pulled through the hal0 registry).
+Both engines run as containerized servers managed by hal0 as the `tts` slot —
+no manual container management needed — and both implement
+`POST /v1/audio/speech`, `GET /v1/models`, and `GET /health`.
+</Aside>
+
+### TTS request defaults and live voice list
+
+The `tts` slot can carry persisted request defaults that `/v1/audio/speech`
+seeds into a request whenever the body omits the matching field — an
+explicit value in the request always wins:
+
+- `default_voice` — voice id injected when the request omits `voice`. When
+  unset, the request falls through to the serving engine's own default
+  (Kokoro's own default is `af_bella`).
+- `default_speed` — playback speed (`0.25`–`4.0`) injected when the request
+  omits `speed`. When unset, the engine default (`1.0`) applies.
+- `default_response_format` — one of `mp3` / `wav` / `opus` / `flac` / `pcm`,
+  injected when the request omits `response_format`. When unset, the engine
+  default (`mp3`) applies.
+
+These are set from the dashboard's Settings → Voice panel (which PUTs the
+`tts` slot config) and take effect immediately — no container restart. Slot
+selection for the seed prefers the `tts` slot bound to the requested model,
+then the per-type default `tts` slot, then the seeded `tts` slot name.
+
+The dashboard's voice picker also reads a **live voice list** from
+`GET /api/slots/tts/voices`, which proxies the serving engine's own
+`GET /v1/audio/voices` (both Kokoro and Qwen3-TTS expose it). If the `tts`
+slot is cold or unreachable, the route fails soft with
+`{ "voices": [], "source": "offline" }` and the picker falls back to a
+built-in Kokoro seed list; a previously-saved voice that's missing from the
+live list stays selectable.
+
+<Aside type="note">
+Open WebUI's Call mode is separately prewired (via its own env config, not
+the `tts` slot defaults above) to request `kokoro-v1` with voice `af_heart`.
+That's independent of what `default_voice` on the `tts` slot resolves to.
 </Aside>
 
 ## See also

--- a/docs/operate/auth.mdx
+++ b/docs/operate/auth.mdx
@@ -1,180 +1,184 @@
 ---
-title: Authentication & HTTPS
-description: hal0 ships Caddy + basic_auth + bearer tokens + automatic HTTPS behind one flag. Reference for --auth=basic, token management, and bringing your own proxy.
+title: Securing hal0
+description: hal0 ships no built-in authentication, user accounts, or TLS. Reference for the threat model, the reverse-proxy-at-edge pattern, and what hal0 does provide (MCP allowlists, agent-chat origin check + session cookie, agent identity).
 sidebar:
   order: 85
 ---
 
 import { Aside, Steps, Tabs, TabItem, Code } from '@astrojs/starlight/components';
 
-hal0 ships a complete auth stack behind one flag: `--auth=basic`. Pass it at
-install time and hal0 provisions and manages a Caddy reverse proxy in front of
-the API, giving you:
+hal0 has no built-in authentication CLI, no user/password store, and no
+bundled reverse proxy. `hal0-api` binds `0.0.0.0:8080` and every endpoint is
+reachable by anything that can reach that port. This was a deliberate cut
+(ADR-0012, "remove-auth-and-caddy") — earlier betas bundled a password store
+and a Caddy TLS-terminating proxy, and both were removed because they
+duplicated, badly, what a real reverse proxy already does better. There is no
+`--auth=basic` install flag and no `hal0 auth` subcommand.
 
-- **Browser basic_auth** for the dashboard and OpenWebUI.
-- **Bearer tokens** for the OpenAI-compatible `/v1/*` API (SDKs, CLI, MCP
-  clients).
-- **Automatic HTTPS** — internal CA for `.local` and mDNS addresses, Let's
-  Encrypt for real domains. Zero certbot.
-
-<Aside type="tip">
-This is the fastest way to make hal0 safe to expose beyond a single trusted
-machine. One flag, no manual proxy config, no cert plumbing.
+<Aside type="caution">
+Do not expose hal0-api directly to the public internet. Anyone who can reach
+the port can load models, run inference, drive agents, and read activity.
+Keep it on a trusted network, or put your own reverse proxy in front of it.
 </Aside>
 
-## Quick start
+## Threat model, in short
 
-The flag goes on the install command:
+hal0 assumes one of two deployment postures:
 
-```sh
-curl -fsSL https://hal0.dev/install.sh | bash -s -- --auth=basic
+- **Single trusted LAN** — hal0 is reachable only from machines you trust
+  (e.g. your home network), and an open API is an acceptable risk.
+- **Reverse proxy at the edge** — you put a proxy you control (Caddy,
+  Traefik, nginx, a cloud load balancer, a tunnel) in front of hal0, and that
+  proxy — not hal0 — owns TLS termination and authentication.
+
+There is no third, hal0-managed option. If you want a login prompt, HTTPS, or
+per-request access control, that's a proxy you stand up and run yourself.
+
+## Reverse proxy at the edge (your proxy, not hal0's)
+
+Run hal0 bound to `127.0.0.1` (or a private interface) and put a proxy in
+front of it that terminates TLS and enforces auth before forwarding to hal0.
+None of the following is installed, managed, or aware of hal0 — these are
+plain examples of proxies *you* configure and operate.
+
+<Tabs>
+<TabItem label="Caddy">
+
+```txt
+hal0.example.com {
+    basic_auth {
+        alice $2a$14$...   # bcrypt hash from `caddy hash-password`
+    }
+    reverse_proxy 127.0.0.1:8080
+}
 ```
 
-Or on a re-install or setup re-run:
+Caddy obtains and renews the certificate automatically via ACME as long as
+port 80/443 are reachable for the challenge. Generate the bcrypt hash once
+with `caddy hash-password` — Caddy never sees the plaintext password again.
 
-```sh
-hal0 setup --auth=basic
+</TabItem>
+<TabItem label="Traefik">
+
+```yaml
+http:
+  routers:
+    hal0:
+      rule: "Host(`hal0.example.com`)"
+      service: hal0
+      tls:
+        certResolver: letsencrypt
+      middlewares:
+        - hal0-auth
+  middlewares:
+    hal0-auth:
+      basicAuth:
+        users:
+          - "alice:$apr1$...htpasswd-hash..."
+  services:
+    hal0:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:8080"
 ```
 
-hal0 provisions Caddy, generates a default admin user, provisions a bearer
-token for API access, and brings up automatic HTTPS. The dashboard and
-OpenWebUI prompt for the basic_auth credentials; API clients present the
-bearer token in the `Authorization` header.
+</TabItem>
+<TabItem label="nginx">
 
-## Built-in Caddy (`--auth=basic`) vs. bring your own proxy
+```nginx
+server {
+    listen 443 ssl;
+    server_name hal0.example.com;
 
-| | `--auth=basic` | Bring your own proxy |
-|---|---|---|
-| **Who manages the proxy** | hal0 provisions and manages Caddy | You run Traefik / nginx / etc. |
-| **Browser auth** | Caddy basic_auth (default admin user + any you add) | Whatever your proxy supports |
-| **API auth** | hal0-managed bearer tokens | Your proxy's auth + hal0's agent headers |
-| **TLS** | Automatic: internal CA for `.local`, Let's Encrypt for real domains | Your certs, your renewal |
-| **Best for** | Public-facing homelab, quick setup, "it just works" | Existing infra, custom auth stacks, corp networks |
+    ssl_certificate     /etc/letsencrypt/live/hal0.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hal0.example.com/privkey.pem;
 
-## Bearer token management
+    auth_basic           "hal0";
+    auth_basic_user_file /etc/nginx/hal0.htpasswd;
 
-When `--auth=basic` is active, hal0 manages bearer tokens for programmatic
-access to the `/v1/*` endpoints.
-
-### Provision a token
-
-```sh
-hal0 auth token create --name "my-sdk-client" --scopes chat,embeddings
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
 ```
 
-The command prints the token once. Store it — it is not recoverable.
+Generate `/etc/nginx/hal0.htpasswd` with `htpasswd -c` and obtain the
+certificate however you already manage certs (certbot, an ACME client, or a
+cert issued by internal infrastructure).
 
-### List and revoke
+</TabItem>
+</Tabs>
 
-```sh
-hal0 auth token list
-hal0 auth token revoke <token-id>
-```
+<Steps>
 
-### Use a token
+1. **TLS termination** — present a certificate for your chosen hostname and
+   terminate HTTPS at the proxy.
 
-Set it as your `OPENAI_API_KEY` (or the equivalent for your SDK):
+2. **Authentication** — enforce whatever you need (basic auth as shown above,
+   OAuth/OIDC, mTLS, an IP allowlist) before a request is forwarded.
 
-```sh
-export OPENAI_API_KEY="hal0-..."
-curl -H "Authorization: Bearer hal0-..." https://hal0.local:8080/v1/models
-```
+3. **Forwarding** — proxy the authenticated request to hal0-api on
+   `127.0.0.1:8080` (or its LAN address), and bind hal0 itself so only the
+   proxy can reach it.
 
-Tokens carry scopes (a subset of `chat`, `embeddings`, `rerank`, `audio`,
-`images`, `admin`) so you can issue narrow credentials for different clients.
-
-### Token vs. agent identity
-
-Bearer tokens protect the `/v1/*` API surface. Agent identity (for MCP tools
-and the memory system) still flows on the `X-hal0-Agent` header and is
-orthogonal to bearer tokens. When Caddy auth is active, both layers apply:
-Caddy gates the connection, and hal0 resolves agent identity from the header
-inside the gated session.
-
-## Automatic HTTPS
-
-Caddy obtains certificates automatically based on the hostname:
-
-| Hostname pattern | Certificate source |
-|---|---|
-| `*.local` (mDNS) | Caddy's internal CA — trusted on the install host automatically |
-| Real domain (e.g. `hal0.example.com`) | Let's Encrypt (ACME) — requires port 80/443 reachability for the challenge |
-| IP address | Internal CA (self-signed) — browsers show a warning unless you install the CA |
+</Steps>
 
 <Aside type="note">
-The internal CA cert is installed into the system trust store on the hal0
-host at provision time. Other machines on your LAN need the CA certificate
-imported manually (or access hal0 by IP and accept the warning, or use a
-real domain with Let's Encrypt).
+The proxy is **your** infrastructure. hal0 ships nothing to configure it,
+generate certificates for it, or manage its user list — the examples above
+are just common patterns, not hal0 features.
 </Aside>
 
-## Managing users
+## What hal0 does provide on its own
 
-Caddy basic_auth users are managed through hal0 (not by editing Caddy configs
-directly):
+hal0 doesn't manage user accounts or TLS, but it isn't a bare-open socket
+either. A few narrower gates exist inside hal0 itself:
 
-```sh
-hal0 auth user add --name "alice"     # prompts for password
-hal0 auth user list
-hal0 auth user remove --name "alice"
-hal0 auth user password --name "alice" # change password
-```
+- **MCP host and origin allowlist** — the admin (`/mcp/admin`) and memory
+  (`/mcp/memory`) MCP mounts default to a localhost-only DNS-rebinding
+  allowlist (`127.0.0.1`, `localhost`, `[::1]`); a non-localhost `Host`
+  header gets a bare `421 Invalid Host header`. Widen it with
+  `HAL0_MCP_ALLOWED_HOSTS` (and, if needed, `HAL0_MCP_ALLOWED_ORIGINS`) to
+  reach `/mcp/*` from another machine or through your proxy. This is a
+  host/origin gate against DNS rebinding, not authentication — see
+  [Security](/docs/concepts/security#mcp-host-and-origin-allowlists).
+- **Agent-chat origin allowlist + session cookie** — the agent-chat
+  WebSocket routes check the browser `Origin` against `HAL0_ALLOWED_ORIGINS`
+  (default covers `http://hal0.local`, `http://localhost:5173`, and
+  `http://127.0.0.1:8080`) on every upgrade, and require an HMAC-SHA256
+  session cookie (`hal0_session`, `HttpOnly`, `SameSite=Lax`, ~8h TTL) that
+  is minted on first `GET /agents/` and verified on the WS upgrade. The
+  signing secret is generated on first use at
+  `/var/lib/hal0/agents/secret.bin` (mode `0600`) and never leaves the hal0
+  service user. This stops a drive-by site from WebSocket-ing into the chat
+  proxy using a browser session that's already open to hal0 — it is not a
+  login system.
+- **`X-hal0-Agent` identity header** — every agent/MCP caller identifies
+  itself with the `X-hal0-Agent` header (validated to a bounded
+  `[a-zA-Z0-9_-]{1,64}` id), which stamps the audit log and resolves the
+  `private:<agent>` memory namespace consistently whether the call arrived
+  over REST or MCP. There is no Bearer/API-key surface — this header is an
+  identity claim, not a secret, so it only means something once you've
+  already gated access at the network layer (LAN-only or your proxy).
+- **Gated agent actions** — privileged or destructive agent/MCP actions
+  don't execute immediately; they enqueue onto an approval queue that a
+  human clears from the dashboard, the CLI, or the approvals API. See
+  [Agents](/docs/concepts/agents) for how personas, tool gating, and the
+  approval queue fit together.
 
-The first admin user is created during `hal0 setup --auth=basic`. Add more
-for teammates or roommates who need dashboard access.
-
-## Public-route allowlist
-
-Some endpoints (landing page, health check) can be exposed without auth even
-when Caddy is active:
-
-```sh
-hal0 auth public-route add /health
-hal0 auth public-route add /api/status
-hal0 auth public-route list
-hal0 auth public-route remove /health
-```
-
-This is useful for monitoring (your uptime checker hits `/health` without
-credentials) without opening the whole API.
-
-## mDNS and `.local` addresses
-
-hal0 advertises itself on mDNS when `--auth=basic` is active, so other
-machines on the LAN can reach it at `hal0.local`:
-
-```sh
-# On another machine:
-curl -H "Authorization: Bearer hal0-..." https://hal0.local:8080/v1/models
-```
-
-The `.local` hostname gets an internal-CA certificate. Import the CA cert
-from the hal0 host to avoid browser warnings:
-
-```sh
-# On the hal0 host, print the CA cert:
-hal0 auth ca-cert
-# Copy it to the client machine and install into the system trust store.
-```
-
-## Rollback / disable
-
-To disable built-in auth and return to LAN-open mode:
-
-```sh
-hal0 auth disable
-```
-
-Caddy is stopped and removed from the service supervision tree. The API
-returns to binding `0.0.0.0:8080` with no auth gate. Any tokens you created
-are revoked. This is reversible — re-run `halo setup --auth=basic` to
-re-provision.
+None of the above is a substitute for authentication at the edge — they
+narrow specific browser/DNS-rebinding attack surfaces and give you an audit
+trail, but they don't gate who can reach `/api/*` or `/v1/*` in the first
+place. That's still the reverse proxy's job.
 
 ## See also
 
-- [Security](/docs/concepts/security) — the full security posture, including
-  the bring-your-own-proxy path and MCP host/origin allowlists.
-- [Install](/docs/getting-started/install) — the `--auth=basic` flag in the
-  installer.
-- [Connect an MCP client](/docs/guides/connect-mcp) — MCP mounts behind
-  Caddy auth.
+- [Security](/docs/concepts/security) — the full security posture and threat
+  model this page is a reference companion to.
+- [Connect an MCP client](/docs/guides/connect-mcp) — configuring
+  `HAL0_MCP_ALLOWED_HOSTS`/`HAL0_MCP_ALLOWED_ORIGINS` and the
+  `X-hal0-Agent` header in practice.
+- [Environment variables](/docs/reference/env-vars) — the full env-var
+  reference, including `HAL0_ALLOWED_ORIGINS` and the MCP allowlist knobs.

--- a/docs/operate/services.mdx
+++ b/docs/operate/services.mdx
@@ -1,0 +1,115 @@
+---
+title: Companion services
+description: The unified companion-service registry, the dashboard Services page, mDNS discovery, and the /api/services management surface for OpenWebUI, ComfyUI, Hermes, Hindsight, and n8n.
+sidebar:
+  order: 86
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+hal0 sits next to a handful of companion services — a chat UI, an image-gen
+engine, a bundled agent, a memory engine — each with its own systemd unit,
+port, and health story. The **companion-service management** layer gives
+these one declarative registry, one API surface, and one dashboard page,
+instead of the ad-hoc `systemctl` calls and per-feature status cards each
+service used to grow independently.
+
+## The registry
+
+Every companion service is one entry in a declarative catalog
+(`hal0.services.registry`). Each entry carries: the owning systemd unit (or
+`None` for an unmanaged/external service), the LAN port for a `host:port` URL
+fallback, an env var for an operator-declared public URL, a probe strategy,
+the lifecycle verbs the API is allowed to run, and whether the service is
+advertised over mDNS.
+
+The current catalog:
+
+| Service | Unit | Port | Actions | Notes |
+|---|---|---|---|---|
+| **OpenWebUI** | `hal0-openwebui.service` | `:3001` (LAN) | start/stop/restart/enable/disable | Podman container; HTTP-probed at `/health`. |
+| **ComfyUI** | `hal0-slot@img.service` | `:8188` (LAN) | restart only | Start/stop is GPU-arbiter managed — the img slot unit owns the switchover logic, so only `restart` is exposed (the same verb the FirstRun repair button uses). |
+| **Hermes** | `hal0-agent@hermes.service` | `:9119` (loopback only) | start/stop/restart/enable/disable | Bundled agent + dashboard. No LAN URL fallback — a link is shown only when `HAL0_HERMES_PUBLIC_URL` is set. |
+| **Hindsight** | `hindsight-api.service` | `:9177` (loopback only) | start/stop/restart/enable/disable | Native memory-engine daemon. Same no-fallback-URL rule as Hermes. |
+| **n8n** | *(none — external)* | — | read-only | Workflow automation the operator runs themselves; hal0 does not deploy it. Listed with URL/probe env hooks but carries no lifecycle actions until a unit exists. |
+
+<Aside type="note">
+This table mirrors `SERVICES` in `hal0.services.registry` at the time this
+page was written. Treat the registry itself as the source of truth — new
+companion services get added there first.
+</Aside>
+
+Every lifecycle verb (`start`, `stop`, `restart`, `enable`, `disable`) is
+enforced twice: once against the per-service allow-list in the registry, and
+again at the execution boundary in `hal0.services.systemd` — a crafted
+request can never reach an arbitrary `systemctl` verb, and a service like
+ComfyUI can never be stopped or started through this surface even if the
+route is called directly.
+
+## Dashboard: Services page
+
+The dashboard has a top-level **Services** nav item (hash route `#services`)
+showing:
+
+- A **discovery (mDNS) card** with an announce/withdraw toggle for addon
+  advertisement.
+- One card per registered service: status pill, systemd uptime, unit
+  metadata, an "open" button for the browser-facing URL, registry-driven
+  lifecycle buttons (a `stop` action asks for confirmation first), a journald
+  logs drawer (reusing `GET /api/logs?unit=`), and — for ComfyUI — the shared
+  live-queue drawer.
+
+Every probe is fail-soft: a probe or systemd failure degrades to an honest
+"unknown"/`down` state, never a fabricated "up" and never a 500. Older
+backends without this surface show "source pending" rather than breaking the
+page.
+
+## mDNS discovery
+
+hal0's installer already advertises the main dashboard as `hal0.service`
+under `/etc/avahi/services`. The companion-service layer extends that with
+one **addon** announcement per advertised service:
+`hal0-addon-<id>.service`, so LAN clients see distinct entries like
+"OpenWebUI on \<host\>" / "ComfyUI on \<host\>" and can reach each one at
+`http://<host>.local:<port>` without DNS.
+
+Key properties:
+
+- Only services with `mdns=True` in the registry **and** a LAN port are
+  advertisable — that's OpenWebUI and ComfyUI today. Loopback-only services
+  (Hermes, Hindsight) and the external n8n entry are never advertised.
+- Advertising writes an avahi service-group XML file per service;
+  withdrawing removes every `hal0-addon-*` file. avahi-daemon inotify-watches
+  the directory, so changes take effect immediately — no daemon reload, no
+  `systemctl` call.
+- The installer-owned `hal0.service` file is never touched by this layer.
+- `available` in the discovery status reflects whether `avahi-daemon.service`
+  is actually active — not a guess from binary presence.
+- `HAL0_HOSTNAME` (set by the install wizard) wins over the raw system
+  hostname when deriving the `.local` name shown to operators.
+
+## The `/api/services` surface
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/services` | Full per-service detail: probe state, systemd unit state + uptime, browser URL, mDNS URL, and the permitted `actions` list. Never 500s — every probe/systemd failure degrades to an honest unknown. |
+| `POST /api/services/{id}/action` | Run one lifecycle verb (`start`/`stop`/`restart`/`enable`/`disable`) against a service's unit. Body: `{"action": "..."}`. Rejected with `400 services.action_not_allowed` if the verb isn't in that service's allow-list, or `404 services.unknown` for an unrecognized id. Audit-logged via the shared action-recording facility. |
+| `GET /api/services/mdns` | avahi/mDNS discovery status (`available`, `hostname`, `advertised`) plus the list of `advertisable` services. |
+| `POST /api/services/mdns` | Advertise (`{"advertise": true}`) or withdraw (`{"advertise": false}`) the addon mDNS announcements. Audit-logged. |
+
+This is the richer sibling of the pre-existing `GET /api/services/health`
+aggregator, which keeps its own stable read-only contract for the dashboard
+Overview card — the two share probe implementations under the hood, so
+health numbers stay consistent between the Overview card and the dedicated
+Services page.
+
+Per-service logs reuse the existing generic journald surface
+(`GET /api/logs?unit=<unit>`) — each entry in `GET /api/services` carries its
+`unit` name so the UI can wire a logs drawer without a dedicated endpoint.
+
+## See also
+
+- [REST API index](/docs/reference/api/rest-api) — the full `/api/*` router
+  index, including `/api/services` and `/api/services/health`.
+- [Authentication & HTTPS](/docs/operate/auth) — mDNS/`.local` addressing for
+  the main dashboard, which this page's addon advertisements build on.

--- a/docs/reference/api/openai-compat.mdx
+++ b/docs/reference/api/openai-compat.mdx
@@ -21,8 +21,8 @@ binary for audio speech) and non-streaming responses are both handled by the
 forwarder.
 
 <Aside type="caution">
-Without `--auth=basic`, the server binds open on the
-local network. Pass `--auth=basic` at install for Caddy + bearer tokens + HTTPS, or put hal0 behind your own reverse proxy.
+There is no built-in authentication (ADR-0012). The server binds open on the
+local network; put it behind your own reverse proxy if you need auth or TLS.
 `GET /v1/models` and `/v1/models/{id}` are deliberately auth-free so SDKs can
 probe the catalog before sending any `Authorization` header.
 </Aside>

--- a/docs/reference/api/rest-api.mdx
+++ b/docs/reference/api/rest-api.mdx
@@ -14,7 +14,7 @@ references.
 
 <Aside type="note">
 All endpoints are open on the local network — auth and TLS were removed in
-your reverse proxy's job. The OpenAPI spec is served live at
+ADR-0012 and are your reverse proxy's job. The OpenAPI spec is served live at
 `/api/openapi.json` (interactive docs at `/api/docs`).
 </Aside>
 
@@ -23,20 +23,21 @@ your reverse proxy's job. The OpenAPI spec is served live at
 | Prefix                  | Purpose                                                              |
 |-------------------------|---------------------------------------------------------------------|
 | `/api/install`          | First-run wizard endpoints.                                          |
-| `/api/slots`            | Slot lifecycle — list, create, delete, restart, model swap.         |
+| `/api/slots`            | Slot lifecycle — list, create, delete, restart, model swap, resolved-argv provenance. |
 | `/api/comfyui`          | ComfyUI generation-engine status + the gated image-gen switchover.  |
 | `/api/models`           | Model registry — list, pull, delete, inspect.                       |
 | `/api/hf`               | Hugging Face Hub discovery (search proxy).                          |
 | `/api/hardware`, `/api/stats/hardware` | Hardware probe + live hardware stats.                |
 | `/api/stats/throughput` | Bucketed throughput history.                                        |
 | `/api/power`            | Power / GPU stats.                                                  |
+| `/api/services`         | Companion-service registry — full detail, lifecycle actions, mDNS discovery/advertisement. See [Services](/docs/operate/services). |
 | `/api/services/health`  | Health of dependent services.                                       |
 | `/api/user/dashboard-layout` | Persisted dashboard layout (file-backed).                      |
 | `/api/logs`             | journald tail for hal0 units.                                       |
 | `/api/settings`         | Read/write `hal0.toml` top-level settings.                          |
 | `/api/secrets`          | Operator secrets store (write-only, persisted to `api.env`).        |
 | `/api/settings/proxmox` | Proxmox integration config.                                        |
-| `/api/memory`           | Memory provider gate/status + Hindsight engine admin (banks, graph, recall). Opt-in. |
+| `/api/memory`           | Memory provider gate/status + Hindsight engine admin (banks, graph, recall). Opt-in. Destructive ops are audit-logged; bank delete requires confirmation. |
 | `/api/providers`        | External LLM provider config.                                       |
 | `/api/updates`          | Update check, apply, rollback (channels + cosign).                  |
 | `/api/capabilities`     | Capability overlay — embed/voice/img children mapped onto slots.    |
@@ -45,7 +46,8 @@ your reverse proxy's job. The OpenAPI spec is served live at
 | `/api/board`            | Hermes agent board — chat proxy, WebSocket session, and board-level events. |
 | `/api/status`           | Server status (public).                                              |
 | `/api/config`           | Dashboard URLs discovery (`/api/config/urls`) + models list (public). |
-| `/api/profiles`         | Profile catalog (seeds + custom).                                   |
+| `/api/meta`             | Canonical device/backend/capability taxonomy (`/api/meta/enums`), cached. |
+| `/api/profiles`         | Profile catalog (seeds + custom) — CRUD plus portable export/import. |
 | `/api/chat-templates`   | Chat-template catalog — bundled + operator-added.                   |
 | `/api/events`           | Dashboard footer event stream (SSE).                               |
 | `/api/activity`         | Durable activity / audit surface (config changes + transitions).    |
@@ -54,6 +56,59 @@ your reverse proxy's job. The OpenAPI spec is served live at
 | `/api/agents`           | Bundled-agent lifecycle, personas, budget, restart, memory stats, chat proxy. |
 | `/api/agent/approvals`  | Approval inbox for gated agent/MCP actions.                         |
 | `/api/mcp`              | MCP introspection — hosted servers, clients, catalog, tool-event tail. |
+
+## Recently added endpoints
+
+A few router groups above got new routes worth calling out individually.
+
+### `/api/services`
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/services` | Full per-service detail — probe state, systemd unit state + uptime, browser URL, mDNS URL, permitted `actions`. Never 500s. |
+| `POST /api/services/{id}/action` | Run one allow-listed lifecycle verb (`start`/`stop`/`restart`/`enable`/`disable`) against a service's unit. Audit-logged. `400 services.action_not_allowed` / `404 services.unknown`. |
+| `GET /api/services/mdns` | avahi/mDNS discovery status + advertisable services. |
+| `POST /api/services/mdns` | Advertise (`{"advertise": true}`) or withdraw (`{"advertise": false}`) addon mDNS announcements. Audit-logged. |
+
+See [Services](/docs/operate/services) for the operator-facing guide (registry, dashboard page, mDNS behavior).
+
+### `/api/meta`
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/meta/enums` | The canonical device/backend/capability taxonomy in one document — devices, legacy/selectable backends, device classes, slot types, runtime families, model capabilities + aliases, model backends, curated model tags, and the backend↔device translation maps. Weak version-keyed `ETag` + `If-None-Match` → `304`; `Cache-Control: public, max-age=3600`. |
+
+### `/api/profiles` — portable export/import
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/profiles/{name}` | Resolve a single profile. `404 profiles.not_found`. |
+| `POST /api/profiles/{name}/export` | Serialize a profile into a portable `.hal0profile.json` envelope (template only — no secrets, no host paths), stamped with a content checksum and `exported_at`. |
+| `POST /api/profiles/import` | Import a profile envelope. Body: `{"envelope": {...}, "name": "...", "dry_run": bool}`. `dry_run` validates the envelope + checksum and reports name collision without writing; a commit creates the profile under `name` and returns the resolved item. `400 profiles.bad_envelope`, `400 profiles.import_no_name`, `409 profiles.exists` on a name collision. |
+
+### `/api/memory` — hardening
+
+- Every destructive `/api/memory/*` operation — bank delete, and the
+  memories/config/document/directive/operation/mental-model deletes, plus the
+  namespace `POST /api/memory/delete` — records a durable audit row (actor +
+  target + truthful outcome) via the shared action-recording facility, so a
+  memory wipe is attributable after the fact.
+- `DELETE /api/memory/banks/{bank_id}` requires confirmation that echoes the
+  bank id — `?confirm=<bank_id>` and/or JSON body `{"confirm": "<bank_id>"}` —
+  otherwise `400 memory.confirm_required`.
+- The namespace `POST /api/memory/delete` deletes by id (`{ids: [...], dataset?}`)
+  and is itself audited as a destructive op.
+- The cognition-console passthroughs (`POST /api/memory/banks/{bank_id}/recall`,
+  `POST .../reflect`, `GET .../directives`) validate the load-bearing envelope
+  key (`results` / `text` / `items` respectively). Upstream Hindsight shape
+  drift on a `2xx` response now surfaces as a loud `502 memory.engine_shape`
+  instead of a silently-blank console panel.
+
+### `/api/slots` — resolved argv provenance
+
+| Method & path | Purpose |
+|---|---|
+| `GET /api/slots/{name}/resolved` | The deduped, resolved llama-server argv plus per-flag provenance — which segment (`base` / `profile` / `model_defaults` / `chat_template` / `mmproj` / `slot_overrides` / `extra_args`) set each surviving flag's final value, and how many duplicate flags were collapsed (`removed`). Non-llama slots (no profile) return `{"argv": null, "provenance": [], "removed": 0}` rather than an error. |
 
 ## Mounted MCP servers
 
@@ -71,3 +126,4 @@ See [MCP tools](/docs/reference/mcp-tools) for the per-tool catalog and gating.
 - [Streaming (SSE)](/docs/reference/api/streaming) — the `/v1` streaming wire format.
 - [MCP tools](/docs/reference/mcp-tools) — what each MCP tool forwards to here.
 - [Environment variables](/docs/reference/env-vars) — `HAL0_PORT` and the rest.
+- [Services](/docs/operate/services) — the operator guide to the companion-service registry, dashboard page, and mDNS discovery behind `/api/services`.

--- a/docs/reference/api/streaming.mdx
+++ b/docs/reference/api/streaming.mdx
@@ -84,8 +84,8 @@ for chunk in stream:
         print(delta.content, end="", flush=True)
 ```
 
-The SDK consumes the `[DONE]` sentinel for you. Without `--auth=basic`,
-any `api_key` value is accepted on the local network.
+The SDK consumes the `[DONE]` sentinel for you. hal0 ships with no built-in
+auth, so any `api_key` value is accepted on the local network.
 
 </TabItem>
 </Tabs>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -209,8 +209,8 @@ left the catalog are cleared. Idempotent.
 | `agent personas activate <id>` | Switch the active persona and nudge Hermes to hot-reload. | `--reload-url` |
 
 <Aside type="note">
-There is no `rotate-token` subcommand. Without `--auth=basic`,
-agent identity flows through the `X-hal0-Agent` header the wrapper
+There is no `rotate-token` subcommand. The daemon has no built-in auth
+(ADR-0012); agent identity flows through the `X-hal0-Agent` header the wrapper
 sets from `$HAL0_AGENT_ID`.
 </Aside>
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -64,9 +64,10 @@ defaults (an empty file is valid).
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `max_slots` | int (≥0) | `0` | Max concurrent slots; `0` = unlimited. |
-| `port_range_start` | int | `8081` | First port in the slot pool. |
-| `port_range_end` | int | `8200` | Last port (inclusive); must be ≥ start. |
+| `port_range_start` | int | `8081` | First port in the auto-allocation pool for new slots. |
+| `port_range_end` | int | `8099` | Last port in the auto-allocation pool (inclusive); must be ≥ start. The pool stops below `8188` so a new slot never claims ComfyUI's port — this only bounds auto-*allocation*, not an individual slot's `port` field, which validates up to `8200` (see `[slot].port` below). |
 | `idle_timeout_s` | int (≥0) | `300` | Default idle-eviction TTL; `0` disables. Per-slot value overrides. |
+| `evict_pressure_mb` | int (≥0) | `8192` | Host free-RAM floor (MiB) for pressure-driven LRU eviction. When host `MemAvailable` drops below this, idle LRU-eligible slots are evicted in least-recently-used order until free RAM recovers; `0` disables pressure eviction. |
 
 ### `[dispatcher]`
 
@@ -103,6 +104,7 @@ fast disk / network mount to align pulls and slot bind-mounts on one path.
 |---|---|---|---|
 | `enabled` | bool | `false` | Off by default. On the Hindsight engine this is a reporting gate — Hindsight builds its graph natively; vector recall works either way. |
 | `extraction_slot` | str | `"utility"` | The local `type=llm` slot Hindsight uses for graph extraction. Propagated to `hindsight-api` as `HINDSIGHT_API_LLM_MODEL=hal0/<slot>` via a systemd drop-in. Validated against the live enabled-llm-slot set at set-time. Slot-name grammar (lowercase alnum/`-`/`_`, ≤32, leading alphanumeric). |
+| `llm_timeout_s` | int (30–3600) | `300` | Timeout for the Hindsight daemon's LLM calls — extraction, consolidation, and reflect. Covers cold slot starts and long reflects. Propagated to `hindsight-api` as `HINDSIGHT_API_LLM_TIMEOUT` via the same systemd drop-in as `extraction_slot`; the daemon restarts to pick it up. |
 
 <Aside type="note">
 ADR-0023 replaced the legacy `route` / `upstream` keys (the Cognee-era extraction
@@ -147,7 +149,7 @@ container provider.
 | `default` | str | `""` | Default model id from the registry. |
 | `context_size` | int (≥128) | `null (derived)` | When unset, hal0 derives the context window from the model's native size (capped) or a safe floor; never silently falls back to 4096. |
 | `n_gpu_layers` | int | `-1` | Layers offloaded to GPU; `-1` = all. |
-| `rope_freq_base` | float (≥0) | `0.0` | RoPE base override; `0.0` = model default. |
+| `rope_freq_base` | float (≥0) | `0.0` | Deprecated (accepted, ignored) — parsed and round-tripped but never emitted by the container launch path. Set `--rope-freq-base <n>` via `[server].extra_args` instead. |
 
 ### `[server]` section
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -30,8 +30,9 @@ config by env-var name. Never commit a populated `api.env`.
 | `HAL0_ACTIVITY_RETENTION_DAYS` | Override the activity/audit store retention window.          | from `hal0.toml` |
 
 <Aside type="note">
-hal0 ships built-in auth via `--auth=basic` (Caddy + basic_auth + bearer tokens + automatic HTTPS). Without it (or your own reverse proxy), the API is open on the
-local network. To add auth, pass `--auth=basic` at install time; to add TLS and access control, put hal0 behind your own reverse proxy.
+hal0 ships with **no built-in auth or TLS** (ADR-0012). The API is open on the
+local network; put it behind your own reverse proxy for TLS and access control.
+There is no bearer-token or basic-auth flag to enable.
 </Aside>
 
 ## Paths
@@ -61,7 +62,7 @@ podman is not installed.
 
 | Variable                  | What it does                                                       | Default |
 |---------------------------|-------------------------------------------------------------------|---------|
-| `HAL0_MEMORY_ENABLED`     | Enable the memory subsystem (Hindsight / Cognee-backed, `/mcp/memory`, `/api/memory/*`). Memory is **opt-in**. | `0` (disabled) |
+| `HAL0_MEMORY_ENABLED`     | Enable the memory subsystem (Hindsight-backed, `/mcp/memory`, `/api/memory/*`). Memory is **opt-in**. | `0` (disabled) |
 | `HAL0_MCP_ALLOWED_HOSTS`  | Allowlist of `Host` headers accepted by the mounted MCP servers.  | unset   |
 | `HAL0_MCP_ALLOWED_ORIGINS`| Allowlist of origins for MCP transport requests.                  | unset   |
 

--- a/docs/reference/hardware-matrix.mdx
+++ b/docs/reference/hardware-matrix.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hardware matrix
-description: hal0 hardware reference — AMD GPU (ROCm/Vulkan), AMD XDNA NPU (FastFlowLM), CPU fallback, backend availability order, and why NVIDIA/CUDA is unsupported.
+description: hal0 hardware reference — AMD GPU (ROCm/Vulkan), NVIDIA GPU (CUDA, experimental), AMD XDNA NPU (FastFlowLM), CPU fallback, multi-GPU pinning, and the backend availability order.
 sidebar:
   order: 50
 ---
@@ -8,17 +8,19 @@ sidebar:
 import { Aside } from '@astrojs/starlight/components';
 
 hal0 targets AMD APU/GPU plus the AMD XDNA NPU, with a CPU fallback that is
-always available. This page lists what runs on each accelerator and the order
+always available. NVIDIA GPUs are also supported via an experimental CUDA
+path (see below). This page lists what runs on each accelerator and the order
 hal0 prefers them in.
 
 ## Hardware targets
 
-| Target              | Backend / runtime         | What runs there                                    |
-|---------------------|---------------------------|----------------------------------------------------|
-| AMD GPU (ROCm)      | llama.cpp ROCm            | chat / embed / rerank LLM inference (highest tps)  |
-| AMD GPU (Vulkan)    | llama.cpp Vulkan          | chat / embed / rerank LLM inference (broad-compat) |
-| AMD XDNA NPU        | FastFlowLM (FLM)          | chat + speech-to-text + embeddings (one process)   |
-| CPU                 | llama.cpp / ONNX          | fallback LLM inference; Kokoro TTS                 |
+| Target              | Backend / runtime               | What runs there                                    |
+|---------------------|-----------------------------------|----------------------------------------------------|
+| AMD GPU (ROCm)      | llama.cpp ROCm                    | chat / embed / rerank LLM inference (highest tps)  |
+| AMD GPU (Vulkan)    | llama.cpp Vulkan                  | chat / embed / rerank LLM inference (broad-compat) |
+| NVIDIA GPU (CUDA)   | llama.cpp CUDA — **experimental** | chat / embed / rerank LLM inference                |
+| AMD XDNA NPU        | FastFlowLM (FLM)                  | chat + speech-to-text + embeddings (one process)   |
+| CPU                 | llama.cpp / ONNX                  | fallback LLM inference; Kokoro TTS                 |
 
 The reference platform is AMD Strix Halo: an 8060S-class iGPU, an XDNA NPU, and
 a unified-memory pool the GPU shares with the host via GTT. hal0's profile flags
@@ -51,15 +53,37 @@ order:
 The NPU is **multiplex**: a single `flm serve` process answers chat, STT, and
 embeddings at once, so one NPU slot can back three capabilities.
 
+<Aside type="note">
+`gpu-cuda` is **not** part of this auto-advertised list — `/api/backends`
+(the dashboard's backend-availability footer) doesn't probe for CUDA yet, so
+an NVIDIA GPU still only shows up here as `gpu-vulkan`. `gpu-cuda` is chosen
+by the installer's hardware recommender on NVIDIA hosts where
+`nvidia-container-toolkit` (CDI) is detected, or set explicitly with
+`device = "gpu-cuda"` in a slot TOML.
+</Aside>
+
 ![The hal0 Slots view showing iGPU and FLM (NPU) slots in the Inference Engine, above the shared GTT memory carve-out](/screenshots/npu-occupancy.png)
 *The Inference Engine slot inventory — here `4 iGPU · 3 FLM` — with the shared iGPU GTT carve-out above it.*
 
-<Aside type="caution" title="NVIDIA / CUDA is not supported">
-hal0's device enum is `{gpu-rocm, gpu-vulkan, cpu, npu}` — there is no CUDA
-device. An NVIDIA GPU will only ever surface through the generic Vulkan path
-(`gpu-vulkan`); there is no ROCm/CUDA compute backend for it. hal0 is built and
-tested on Linux x86_64.
+<Aside type="caution" title="NVIDIA / CUDA is experimental">
+hal0's device enum is `{gpu-rocm, gpu-vulkan, gpu-cuda, cpu, npu}` — `gpu-cuda`
+runs NVIDIA GPUs through the upstream `ghcr.io/ggml-org/llama.cpp:server-cuda`
+image via CDI GPU passthrough (`nvidia-container-toolkit` required). It's
+experimental: unbenched, not part of the AMD Strix Halo toolbox family, and
+not yet part of the `/api/backends` auto-probe above. Without
+`nvidia-container-toolkit`, an NVIDIA GPU still only surfaces through the
+generic Vulkan path (`gpu-vulkan`); there is no ROCm path for NVIDIA hardware.
+hal0 is built and tested on Linux x86_64.
 </Aside>
+
+## Multi-GPU hosts
+
+hal0's hardware probe enumerates every detected GPU additively (index + PCI
+bus id), for both AMD and NVIDIA hosts. A slot can pin itself to one GPU via
+the `gpu_index` field — see [Devices, providers &
+profiles](/docs/reference/providers-profiles-devices#multi-gpu-hosts) for the
+per-backend visibility-env mapping. Leaving `gpu_index` unset exposes all GPUs
+to the slot, unchanged from prior single-GPU behaviour.
 
 ## NPU host requirements
 

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -17,7 +17,7 @@ autonomous-write, or approval-gated. Gated tools enqueue for owner approval
 before they run; autonomous tools execute immediately.
 
 <Aside type="note">
-hal0 ships built-in auth via `--auth=basic` (Caddy + basic_auth + bearer tokens). Without it, the API is open — there are no bearer tokens. When Hermes
+hal0 has no built-in auth (ADR-0012) — there are no bearer tokens. When Hermes
 or another bundled agent calls the MCP server, it identifies itself with the
 `X-hal0-Agent` header (set from `$HAL0_AGENT_ID` by the agent wrapper). The
 server stamps that identity on every audit row and carries it onto the internal
@@ -27,7 +27,7 @@ secret. Each tool call is written to the audit log.
 
 ## Memory MCP (`/mcp/memory`)
 
-Hindsight (Cognee-backed) long-term memory. The memory subsystem is **opt-in** — these tools
+Hindsight-backed long-term memory. The memory subsystem is **opt-in** — these tools
 only function when the server is started with `HAL0_MEMORY_ENABLED=1`; otherwise
 calls degrade to a no-op / unavailable surface.
 

--- a/docs/reference/providers-profiles-devices.mdx
+++ b/docs/reference/providers-profiles-devices.mdx
@@ -15,7 +15,9 @@ authoritative reference for the valid values of each and how they connect.
 <Aside type="caution" title="device, not backend">
 The legacy `backend` field is deprecated and accepted for one migration release
 only. Author every slot with `device`. A slot TOML that sets `backend` without
-`device` logs a deprecation warning and auto-fills `device`.
+`device` logs a deprecation warning and auto-fills `device`. (The legacy enum
+also accepts `cuda` now, so a `gpu-cuda` device round-trips through the same
+one-release write-back as every other device.)
 </Aside>
 
 ## Devices
@@ -23,17 +25,40 @@ only. Author every slot with `device`. A slot TOML that sets `backend` without
 `device` carries hardware intent only. It is validated at config-load time —
 a typo raises a `ValidationError` with the field path.
 
-| `device`     | Hardware                       | Default provider |
-|--------------|--------------------------------|------------------|
-| `gpu-rocm`   | AMD GPU via ROCm               | `llama-server`   |
-| `gpu-vulkan` | Any GPU via Vulkan             | `llama-server`   |
-| `cpu`        | CPU-only fallback              | `llama-server`   |
-| `npu`        | AMD XDNA NPU via FastFlowLM    | `flm`            |
+| `device`     | Hardware                              | Default provider |
+|--------------|----------------------------------------|------------------|
+| `gpu-rocm`   | AMD GPU via ROCm                      | `llama-server`   |
+| `gpu-vulkan` | Any GPU via Vulkan                    | `llama-server`   |
+| `gpu-cuda`   | NVIDIA GPU via CUDA — **experimental** | `llama-server`   |
+| `cpu`        | CPU-only fallback                     | `llama-server`   |
+| `npu`        | AMD XDNA NPU via FastFlowLM            | `flm`            |
 
 `gpu-rocm` is the package-level default `device` constant, but the hardware
 recommender actively steers Strix Halo (unified memory) installs to `gpu-vulkan`
-for broader compatibility. The recommender may also select `cpu` or `npu` on
+for broader compatibility. On an NVIDIA host the recommender picks `gpu-cuda`
+when `nvidia-container-toolkit` (CDI) is present, and falls back to
+`gpu-vulkan` otherwise. The recommender may also select `cpu` or `npu` on
 hosts without ROCm support.
+
+<Aside type="note">
+This page, the dashboard, and the API all draw from one canonical device/
+backend taxonomy, served live at `GET /api/meta/enums` (devices, legacy
+backends, selectable backends, device classes, capabilities, and the
+device→default-profile map). If this page and a running host ever disagree,
+`/api/meta/enums` is the source of truth.
+</Aside>
+
+### Multi-GPU hosts
+
+hal0's hardware probe enumerates every detected GPU (index + PCI bus id),
+additively for both AMD and NVIDIA parts. A slot can pin to one GPU via the
+`gpu_index` field, which emits the backend-appropriate visibility mechanism:
+`HIP_VISIBLE_DEVICES` + `ROCR_VISIBLE_DEVICES` for `gpu-rocm`,
+`GGML_VK_VISIBLE_DEVICES` for `gpu-vulkan`, or a CDI `nvidia.com/gpu=<n>`
+device plus `CUDA_VISIBLE_DEVICES=0` inside the container for `gpu-cuda`. An
+explicit `[server].env` entry always wins over the derived visibility var.
+Leaving `gpu_index` unset (the default) exposes all GPUs — unchanged
+behaviour.
 
 ## Providers
 
@@ -43,7 +68,7 @@ backwards compatibility.
 
 | `provider`     | Runtime                                  | Typical slot types                     |
 |----------------|------------------------------------------|----------------------------------------|
-| `llama-server` | llama.cpp server (ROCm / Vulkan / CPU)   | chat, embed, rerank                     |
+| `llama-server` | llama.cpp server (ROCm / Vulkan / CUDA / CPU) | chat, embed, rerank                     |
 | `flm`          | FastFlowLM on the NPU                     | chat / stt / embed (one process, trio) |
 | `kokoro`       | Kokoro-82M text-to-speech (ONNX)          | tts                                    |
 | `comfyui`      | ComfyUI image generation                  | image                                  |
@@ -59,9 +84,10 @@ model, context size, and port.
 | Profile     | `device_class` | Image                                                                | MTP   | Intent                |
 |-------------|----------------|----------------------------------------------------------------------|-------|-----------------------|
 | `rocm`      | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`  | off   | MoE agents · q8 KV    |
-| `rocm-dnse` | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`  | on    | Dense + MTP · q4 KV   |
-| `rocm-moe`  | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`  | on    | MoE + MTP · q4 KV     |
+| `rocm-dnse` | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`  | on    | Dense + MTP · q8 KV   |
+| `rocm-moe`  | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server`  | on    | MoE + MTP · q8 KV     |
 | `vulkan`    | gpu            | `ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server`         | off   | Vulkan std · fallback |
+| `cuda`      | gpu            | `ghcr.io/ggml-org/llama.cpp:server-cuda`                             | off   | CUDA · NVIDIA (upstream, experimental) |
 | `flm`       | npu            | `ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43`                             | off   | FLM NPU inference     |
 | `tts`       | cpu            | `ghcr.io/hal0ai/hal0-toolbox-kokoro:v1`                              | off   | TTS · Kokoro          |
 | `comfyui`   | img            | `docker.io/kyuz0/amd-strix-halo-comfyui@sha256:0066678ae9043f69…`   | off   | Image generation      |
@@ -70,11 +96,21 @@ model, context size, and port.
 *Profiles tab in the hal0 dashboard — seed profile cards display device class, quantisation, and bench throughput (tokens/sec or RTF).*
 
 <Aside type="note">
-GPU profiles also carry a `backend` field (`rocm` or `vulkan`) — that field, not
-the slug, is the authoritative ROCm-vs-Vulkan choice. Non-GPU profiles
-(`flm`, `tts`, `comfyui`) omit it and let `device_class` drive display.
-Canonical image refs are pinned per release in `manifest.json` and may differ
-from these seed defaults.
+GPU profiles also carry a `backend` field (`rocm`, `vulkan`, or `cuda`) — that
+field, not the slug, is the authoritative ROCm-vs-Vulkan-vs-CUDA choice.
+Non-GPU profiles (`flm`, `tts`, `comfyui`) omit it and let `device_class` drive
+display. Canonical image refs are pinned per release in `manifest.json` and may
+differ from these seed defaults.
+</Aside>
+
+<Aside type="caution" title="`cuda` is experimental">
+The `cuda` profile runs the upstream `ghcr.io/ggml-org/llama.cpp:server-cuda`
+image — not one of the AMD Strix Halo toolboxes — and needs
+`nvidia-container-toolkit` (CDI) on the host for GPU passthrough. It has no
+`PROFILE_BENCH` entry (unbenched) and isn't part of the Strix Halo–tuned
+profile family; it exists so NVIDIA hosts have a working `gpu-cuda` path. See
+[Hardware matrix](/docs/reference/hardware-matrix) for the current support
+level.
 </Aside>
 
 <Aside type="caution" title="The old `rocm-mtp` slug">
@@ -88,8 +124,13 @@ repointed to one of the current profiles.
 ### MTP flag bundle
 
 When a profile's effective MTP setting is on (profile `mtp = true`, or a slot's
-`mtp = true` override), the multi-token-prediction draft-speculation flag bundle
-is appended after the profile flags at resolve time. A slot's `mtp` field
+`mtp = true` override), `resolve_profile_flags` merges the multi-token-prediction
+draft-speculation flag bundle (`MTP_FLAG_BUNDLE`) into the profile's flags — as
+**defaults only**. A profile's own explicit `--spec-draft-*` flags win; the
+bundle just fills in whatever the profile left unset. Before v0.8.2b2 (#963)
+the bundle was appended verbatim and silently clobbered a profile's pinned
+spec-draft flags (e.g. a profile asking for `--spec-draft-type-k f16` still
+launched with the bundle's `q8_0`) — that's fixed now. A slot's `mtp` field
 (`true` / `false` / unset-to-inherit) overrides the profile default.
 
 ## Device-to-default-profile map
@@ -101,8 +142,51 @@ a starting profile per device class:
 |--------------|-----------------|
 | `gpu-rocm`   | `rocm`          |
 | `gpu-vulkan` | `vulkan`        |
-| `cpu`        | `tts`           |
+| `gpu-cuda`   | `cuda`          |
+| `cpu`        | `cpu-llm`       |
 | `npu`        | `flm`           |
+
+<Aside type="note">
+`cpu`'s default profile is `cpu-llm`, not `tts` — an earlier map pointed `cpu`
+at `tts`, which left a `profile=""` slot unloadable ("profile '' not found").
+`cpu-llm` runs the Vulkan toolbox image in CPU-only mode (no GPU devices passed
+to the container).
+</Aside>
+
+### Model preferred profile
+
+A registry model can also carry a preferred profile via `defaults.profile`. A
+slot adopts it on **create** (when the slot has no explicit profile) and on
+**every model swap** — but only when the profile fits the slot: it must exist
+in the catalog, support the slot's `type`, and match the slot's
+`device_class`/`backend`. An incompatible preference is skipped (logged as
+`slot.preferred_profile_skipped`) and the slot keeps its current or
+device-default profile; hal0 never flips a slot's device to satisfy a model's
+preference.
+
+## Portable profiles: export/import
+
+A profile can be exported to a self-contained, checksummed
+`.hal0profile.json` envelope and imported on another host — the same sharing
+model stacks use (no secrets, no host paths, an independent `schema_version`).
+
+- `GET /api/profiles/{name}` — resolve a single profile.
+- `POST /api/profiles/{name}/export` — build the envelope:
+  `{kind: "hal0.profile", schema_version, hal0_version, exported_at, name,
+  checksum, profile}`. `checksum` is a sha256 over the canonical profile body
+  only (key-order independent), so re-exporting an unchanged profile yields the
+  same checksum every time.
+- `POST /api/profiles/import` — dry-run then commit. `{"envelope": {...},
+  "name": "...", "dry_run": true}` validates the envelope + checksum and
+  reports whether `name` collides with an existing profile, without creating
+  anything. A commit (`dry_run` false, `name` set) creates the profile and
+  returns `409 profiles.exists` on a name collision.
+
+MCP mirrors the same surface: `profile_list` / `profile_status` /
+`profile_export` are read-shaped (autonomous, no confirmation gate);
+`profile_import` / `profile_delete` are gated. The dashboard's Profiles tab
+has an **Export** button on every profile card and an **Import** dialog
+(file → dry-run → commit) in the tab header.
 
 ## Toolbox images
 

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -28,6 +28,15 @@ snapshots.
 | `UNLOADING` | `unloading` | Graceful shutdown in progress; waiting for the container to exit. |
 | `ERROR` | `error` | Slot has failed. Details in `state.json` and journald. |
 
+<Aside type="note">
+A health-probe timeout during `warming` resolves to `WARMING`, never a false
+`READY` — a slot is only ever advertised dispatchable once it has actually
+answered a health probe. The fail-watcher still polls the underlying systemd
+unit while a slot sits in `WARMING`, so a container that dies mid-load is
+caught even though `/health` alone can't distinguish "still loading" from
+"hung."
+</Aside>
+
 ### The two faces of `idle`
 
 `idle` is reached two ways; both render identically on the wire but the state
@@ -70,6 +79,38 @@ Some providers serve a baked-in model and need no explicit `model_id` to reach
 `ready`: `kokoro` and `vibevoice`. Other providers require a loaded model before
 they can serve.
 </Aside>
+
+## Idle eviction and wake-on-request
+
+Beyond the idle-timeout demotion to `IDLE`, a slot can be **unloaded**
+(`ready`/`idle → unloading → offline`) two ways:
+
+- **Hard TTL.** A slot idle past its resolved `idle_timeout_s` (per-slot TOML
+  override, else a 300-second default) is unloaded outright, freeing host RAM.
+  An explicit `idle_timeout_s = 0` pins a slot against this.
+- **Host-memory-pressure LRU eviction.** When host `MemAvailable` drops below a
+  configured floor, hal0 evicts idle, `lru = true`-flagged slots oldest-`last_used`-first
+  until free RAM recovers (or no eligible slots remain). A slot actively
+  serving a request is never evicted, and `agent`, `utility`, and `npu` are
+  never evicted by pressure regardless of their `lru` flag — they're the
+  anchors the dispatch fallback chains depend on.
+
+Either kind of eviction leaves the slot in `OFFLINE`, not `ERROR` — it's a
+resource-management transition, not a failure. A request that lands on an
+idle-evicted slot triggers a lazy reload rather than a 404: the dispatcher
+kicks off `SlotManager.load()` for the target slot and returns a structured
+`slot.loading` 503 with `Retry-After`, so the client's retry lands once the
+slot is back up.
+
+## Fallback on load
+
+If a slot's configured `model.default` isn't locally servable — deleted,
+never pulled, or pulled-away — `load()` doesn't just fail. It searches the
+local registry for the best match by the slot's capability (chat, embed,
+rerank, asr, tts) and loads that instead, preferring name-similarity to the
+configured id. Diffusion / image / video artifacts are always excluded from
+this fallback search for a non-image slot, so a text slot can never silently
+come up serving an image-gen model it can't actually run.
 
 ## Persistence — `state.json`
 


### PR DESCRIPTION
## What

Documentation sync for the v0.8.x line (through v0.8.4b1), paired with Hal0ai/hal0-web#32 on the same branch name.

- **README re-baselined and accuracy-passed** against v0.8.4b1 source: status block v0.8.2b3 → v0.8.4b1; retired `chat` slot → canonical `agent`/`utility` roles (ADR-0023) + `vision`; dropped the removed `HAL0_USER=hal0` unprivileged mode; real backend profiles (`rocm`/`rocm-dnse`/`rocm-moe`/`vulkan`/`cuda`), GPU Qwen3-TTS, real ComfyUI image pin, experimental-CUDA hardware row, `cpu-llm` fallback, NPU trio slot names, shipped roadmap items removed, plus companion services / default-on telemetry / resumable pulls mentions.
- **`docs/` mirror refreshed** — byte-identical to the hal0-web docs source on the matching branch (normally maintained by hal0-web's `mirror-docs.yml` on master merges; mirrored here so both PRs review consistently). Includes a new `operate/services` page and the corrected `operate/auth` page.

## Why the auth pages changed direction

The previous docs pass (3e056de) documented a built-in `--auth=basic` / managed-Caddy / `hal0 auth` CLI stack that **does not exist in the codebase** — Caddy and the auth surface were removed in v0.3 (ADR-0012) and never reintroduced (`installer/README.md:106`, `src/hal0/cli/agent_commands.py:845`). The refreshed docs restore the real model: reverse-proxy-at-edge, MCP host/origin allowlists, agent-chat origin allowlist + HMAC session cookies, `X-hal0-Agent` identity, approval queue. If built-in auth is planned for v0.9, those docs should ship with the feature, not before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsqZewS75G2Grf9AjUQmun