### PR TITLE
release: v0.8.5b1 — version bump + changelog cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ v0.8.4b1** — the one on-disk migration (virtual-seed prune) backs up
 names; note the MTP auto behaviour below if you run untagged local MTP
 builds.
 
+> **Upgrade note — re-render slot units after updating.** A container
+> slot's systemd unit bakes the launch argv at load time, so after an
+> update the running slots (and their unit files) still carry the
+> PRE-update flags. A bare `systemctl restart hal0-slot@<name>` re-runs
+> the stale ExecStart — restart slots **through hal0** (dashboard restart,
+> or unload→load) so the unit re-renders through the new code. The
+> dashboard's resolved-command drift indicator shows which slots are
+> stale. Automatic unit re-rendering on update (without bouncing serving)
+> is planned as the follow-up.
+
 ### Added
 - **GPU generalization — experimental CUDA + multi-GPU.** A dedicated
   `cuda` seed profile (upstream `llama.cpp:server-cuda` image, preferred

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,12 @@ builds.
   `mtp.auto_off_model_ineligible` when this bites.
 
 ### Fixed
+- **MTP auto-off breadcrumb is launch-gated.** The
+  `mtp.auto_off_model_ineligible` hint lives inside the shared launch/preview
+  scalar resolver, so it fired on every dashboard `GET /api/slots` poll
+  (~0.4/s per client, forever) for any AUTO slot pairing an MTP profile with a
+  non-MTP model. It now logs only on a real container launch; preview/status
+  renders stay silent, and launch/preview argv parity is unchanged.
 - **Upstream-advertised models are clearly identified as remote (#1035)**,
   not local, across the dashboard model surfaces.
 - **Operator Board (#1032).** Hermes-contract repairs, honest UI state,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,19 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+## [v0.8.5b1] — 2026-07-04
+
 Everything landed on `main` since the v0.8.4b1 cut. The headlines: hal0
 generalizes beyond the Strix Halo iGPU (experimental CUDA + multi-GPU
 pinning), companion services get one management surface (registry +
 `/api/services` + mDNS + dashboard page), the settings-completeness plan
 finishes (phases 3–5 + an Advanced section with full `hal0.toml` parity),
 and seed profiles go virtual with dedicated embed/rerank lanes and a
-proper model×profile×slot MTP decision (#1045).
+proper model×profile×slot MTP decision (#1045). **Safe upgrade from
+v0.8.4b1** — the one on-disk migration (virtual-seed prune) backs up
+`profiles.toml` first and rescues divergent operator content to `-custom`
+names; note the MTP auto behaviour below if you run untagged local MTP
+builds.
 
 ### Added
 - **GPU generalization — experimental CUDA + multi-GPU.** A dedicated
@@ -53,6 +59,14 @@ proper model×profile×slot MTP decision (#1045).
   (install path and picker/apply fit path both updated); Vulkan/CPU boxes
   keep falling back to the `vulkan` / `cpu-llm` profile until
   backend-specific variants ship.
+- **Profile bench matrix tooling (#1045).** `installer/bench/profile-matrix.sh`
+  scripts the seed-profile re-tune matrix as `hal0-benchctl` seam sweeps, and
+  `installer/bench/server_ab.py` measures the server-level levers llama-bench
+  can't see — MTP draft depth (with acceptance %), `--cache-reuse` on a
+  shared-prefix trace, poll, and embed/rerank endpoint sanity — via hal0-api
+  as the unprivileged user, always restoring the slot's original config.
+  Supersedes the ad-hoc `/root/bench_mtp.py`; an on-box runbook ships at
+  `handoffs/bench-profile-matrix-local-session-2026-07-04.md`.
 - **Catalog UX finish (#1042).** Sort / tag-filter / quant chip wiring in
   the Models view, and a chat-template pick at pull time.
 - **Canonical device/backend taxonomy.** One enum source at `GET
@@ -69,8 +83,12 @@ proper model×profile×slot MTP decision (#1045).
   copy, `save_profiles_config` strips seeds before writing, and the updater's
   `ensure_seed_profiles()` prunes any materialised seeds left by an older
   install (self-heal on upgrade). Seed profiles remain immutable — clone to
-  customise. Operator (non-seed) profiles are untouched. **Safe upgrade** — no
-  operator data is lost (seeds were never operator-editable through the API).
+  customise. Operator (non-seed) profiles are untouched. **Data-safe
+  migration**: the pre-prune file is backed up once
+  (`profiles.toml.pre-virtual-seeds.bak`) and any seed-named entry whose
+  content differs from the code seed (a hand-edited seed table, or an operator
+  profile whose name only became a seed in this release, e.g. `embed`) is
+  rescued to `<name>-custom` instead of deleted, with a loud log.
 - **MTP is now a model × profile × slot decision (#1045).** Model
   eligibility (`mtp` registry tag or name marker) × profile opt-in
   (`profile.mtp` now means "enable for eligible models", not "append the
@@ -80,7 +98,14 @@ proper model×profile×slot MTP decision (#1045).
   draft device tracks the profile backend (ROCm/Vulkan/CUDA) instead of
   hardcoded ROCm. The slot drawer swaps the binary MTP pill for the
   tri-state control with a live "Auto · active/inactive" hint; stack
-  editor rows default to Auto.
+  editor rows default to Auto, and an Auto row now clears a forced
+  override on apply (the config write layer treats an explicit `null` as
+  delete-key — TOML has no null — which is also what makes "back to
+  Auto" work from the dashboard instead of 500ing). **Behaviour note:**
+  an MTP-capable model that carries neither the registry `mtp` tag nor an
+  MTP name marker stops speculating under Auto after this upgrade — tag
+  the model or force the slot On; the launch log says
+  `mtp.auto_off_model_ineligible` when this bites.
 
 ### Fixed
 - **Upstream-advertised models are clearly identified as remote (#1035)**,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.4b1"
+version = "0.8.5b1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -109,7 +109,13 @@ def _profile_image_and_flags(profile: Any, mtp_override: bool | None = None) -> 
     return str(profile.image), str(flags)
 
 
-def _effective_mtp(slot_mtp: bool | None, profile: Any, model_info: Mapping[str, Any]) -> bool:
+def _effective_mtp(
+    slot_mtp: bool | None,
+    profile: Any,
+    model_info: Mapping[str, Any],
+    *,
+    log_ineligible: bool = False,
+) -> bool:
     """Resolve whether MTP speculative decoding is on for this slot launch.
 
     The three concerns are separated (design: MTP is a model property, not a
@@ -125,12 +131,19 @@ def _effective_mtp(slot_mtp: bool | None, profile: Any, model_info: Mapping[str,
     This is what stops a non-MTP model on an MTP profile (e.g. a plain chat
     GGUF pinned to ``rocm-moe``) from launching with dead ``--spec-draft-*``
     flags, without any per-slot wiring for the common case.
+
+    ``log_ineligible`` gates the auto-off breadcrumb to the LAUNCH path only.
+    This function sits inside the shared launch/preview scalar resolver
+    (:func:`_resolve_llama_scalars`), and the preview path is hit by every
+    dashboard ``GET /api/slots`` poll — logging unconditionally here turned a
+    once-per-launch hint into a ~0.4/s stream per polling client for every
+    AUTO slot pairing an MTP profile with a non-MTP model.
     """
     if slot_mtp is not None:
         return bool(slot_mtp)
     profile_opts_in = bool(getattr(profile, "mtp", False))
     eligible = model_is_mtp_eligible(model_info)
-    if profile_opts_in and not eligible:
+    if log_ineligible and profile_opts_in and not eligible:
         # Visible breadcrumb for the silent-auto-off case: an MTP-capable model
         # that carries neither the registry tag nor a name marker stops
         # speculating under auto. The fix is tagging the model (or slot
@@ -632,6 +645,8 @@ def _resolve_llama_scalars(
     slot_cfg: dict[str, Any],
     model_info: dict[str, Any],
     profile: Any,
+    *,
+    for_launch: bool = False,
 ) -> dict[str, Any]:
     """Resolve every llama-server launch scalar for a slot+model+profile.
 
@@ -642,9 +657,14 @@ def _resolve_llama_scalars(
     mmproj sidecar, the per-model registry ``defaults`` bundle, the slot-level
     ``[model].n_gpu_layers`` override, and the ``[server]`` env / extra_args.
     Returning one dict means the two paths can never drift.
+
+    ``for_launch`` marks the real launch call (vs a status/preview render) —
+    it only gates side-effects like the MTP auto-off breadcrumb; the RESOLVED
+    VALUES are identical on both paths, preserving launch/preview parity.
     """
     image, flags_str = _profile_image_and_flags(
-        profile, _effective_mtp(slot_cfg.get("mtp"), profile, model_info)
+        profile,
+        _effective_mtp(slot_cfg.get("mtp"), profile, model_info, log_ineligible=for_launch),
     )
 
     model_table = slot_cfg.get("model") or {}
@@ -776,7 +796,9 @@ class ContainerProvider(Provider):
         """
         profile_name = slot_cfg.get("profile") or ""
         profile = _resolve_profile(profile_name)
-        scalars = _resolve_llama_scalars(slot_cfg, model_info, profile)
+        # for_launch: this is the real container-spec build — side-effect logs
+        # (MTP auto-off breadcrumb) fire here, never on preview/status renders.
+        scalars = _resolve_llama_scalars(slot_cfg, model_info, profile, for_launch=True)
 
         model_path = _resolve_model_path(model_info)
         port = int(slot_cfg.get("port", 0))

--- a/tests/config/test_mtp_override.py
+++ b/tests/config/test_mtp_override.py
@@ -134,3 +134,19 @@ def test_slot_override_true_forces_on_even_for_plain_model():
 
 def test_slot_override_false_forces_off_even_for_eligible():
     assert _effective_mtp(False, _profile(True), _mtp_model()) is False
+
+
+def test_auto_off_breadcrumb_only_on_launch_path(caplog):
+    """The auto-off log is launch-gated: _effective_mtp sits inside the SHARED
+    launch/preview resolver, and the preview path runs on every dashboard
+    GET /api/slots poll — an ungated log turned a once-per-launch hint into a
+    ~0.4/s stream per polling client (measured 43 logs : 43 status GETs)."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="hal0.providers.container"):
+        # Preview/status path (default): silent.
+        assert _effective_mtp(None, _profile(True), _plain_model()) is False
+        assert not [r for r in caplog.records if "auto_off" in r.getMessage()]
+        # Launch path: exactly one breadcrumb.
+        assert _effective_mtp(None, _profile(True), _plain_model(), log_ineligible=True) is False
+        assert len([r for r in caplog.records if "auto_off" in r.getMessage()]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.8.4b1"
+version = "0.8.5b1"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
Release prep for **v0.8.5b1** (beta cut so on-box updaters can pull the virtual-seeds / embed-rerank / MTP-separation work).

- `pyproject.toml` → `0.8.5b1` (the only version pin; satisfies release-check gate 7).
- `CHANGELOG.md`: converts `[Unreleased]` (catalogued in #1047) into `## [v0.8.5b1] — 2026-07-04` with upgrade notes, and applies #1047's own caveat — the #1045 bullets now reflect what actually landed: bench-matrix tooling (`profile-matrix.sh` + `server_ab.py` + on-box runbook), the data-safe prune migration (one-time backup + `-custom` rescue), the `null`-clears-override config-write semantics, and the MTP auto behaviour note for untagged local MTP builds.

**After merge:** tag `v0.8.5b1` on the merge commit + `workflow_dispatch` on `release.yml` → tarball, cosign signature, `hal0.releases.v1` manifest → GitHub Release → `releases.hal0.dev/stable.json` (~60s CF TTL).

Pre-tag gates runnable in this environment are green: full pytest (this session), UI build + `tsc`, ruff check/format, all 7 toolbox digests pinned. Not run here (box-bound): tier-γ `make release-test` report; toolbox digests unchanged since this morning's v0.8.4b1 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw)_