### PR TITLE
slots/updater: MTP crash defuse + slot-unit re-render on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+### Added
+- **Slot units re-render automatically on update.** A slot's systemd unit
+  bakes the launch argv at load time, so updating hal0 changed the code that
+  WOULD render but not the file that DID — `systemctl restart`, crash
+  restarts, and reboots kept running pre-update flags until an operator did a
+  hal0-level slot restart (field finding). The updater (post venv-reinstall,
+  via a fresh interpreter so the NEW code renders) and `install.sh` now
+  rewrite every existing unit through current code plus one `daemon-reload` —
+  running services are never bounced; fresh argv applies on each slot's next
+  start from any path. Per-slot failures log and skip. The dashboard drift
+  indicator still covers the "process running old argv until next restart"
+  window.
+
 ### Fixed
 - **Crash-only `mtp = true` overrides are defused automatically.** A forced
   MTP override pointing at a model with no MTP heads crashes llama-server at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+### Fixed
+- **Crash-only `mtp = true` overrides are defused automatically.** A forced
+  MTP override pointing at a model with no MTP heads crashes llama-server at
+  load once the slot's unit re-renders under the v0.8.5b1 MTP separation
+  (field-confirmed: pre-separation `mtp = true` debris on a headless MoE
+  model). Two mechanisms now clear exactly that combination: an updater
+  migration over the slot TOMLs (`updater.mtp_force_on_cleared` log; force-off,
+  eligible force-on, and unresolvable models untouched) and a swap-path guard
+  (swapping onto an ineligible model drops a forced `true` → AUTO, so the
+  staleness can't regenerate). The false-negative escape hatch — forcing MTP
+  on for an untagged-but-capable model — is preserved.
+
 ## [v0.8.5b1] — 2026-07-04
 
 Everything landed on `main` since the v0.8.4b1 cut. The headlines: hal0
@@ -36,6 +48,17 @@ builds.
 > dashboard's resolved-command drift indicator shows which slots are
 > stale. Automatic unit re-rendering on update (without bouncing serving)
 > is planned as the follow-up.
+>
+> **Upgrade note — stale `mtp = true` slot overrides crash on re-render.**
+> An explicit `mtp = true` in a slot TOML is honored literally (it is the
+> escape hatch for MTP-capable models the eligibility heuristics miss). If
+> a stale override — typically left behind by the old binary MTP pill or a
+> pre-#1045 stack apply, surviving a later model swap — points at a model
+> with NO MTP layers, llama-server exits at load ("context type MTP
+> requested but model doesn't contain MTP layers") once the unit
+> re-renders. Fix: set the slot's MTP to Auto (`{"mtp": null}`) or Off in
+> the drawer and restart. An updater migration that clears provably-stale
+> force-ons (with a loud log) ships in the follow-up.
 
 ### Added
 - **GPU generalization — experimental CUDA + multi-GPU.** A dedicated

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1114,6 +1114,24 @@ else
     info "profiles.toml absent — seeds served in-memory on first request"
 fi
 
+# ── stale mtp=true slot-override migration ────────────────────────────────────
+# A slot forcing MTP on for a model with no MTP heads crashes llama-server at
+# load once the unit re-renders under post-separation code (the old baked units
+# masked the contradiction). Clear exactly those overrides (→ AUTO), loudly;
+# eligible or unresolvable models are left untouched.
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    info "dev mode — skipping stale-MTP slot migration (no system writes)"
+else
+    "${VENV_DIR}/bin/python" - <<'PYEOF'
+from hal0.updater.updater import clear_stale_mtp_overrides
+n = clear_stale_mtp_overrides()
+if n:
+    print(f"  cleared {n} crash-only mtp=true slot override(s) — see log for slots")
+else:
+    print("  no stale mtp=true slot overrides found")
+PYEOF
+fi
+
 # ── ComfyUI model share ───────────────────────────────────────────────────────
 # The docker comfy-up/down/logs/postinstall.sh scripts have been retired; the
 # podman img slot (hal0-slot@img.service) is the sole lifecycle owner of :8188

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1132,6 +1132,25 @@ else:
 PYEOF
 fi
 
+# ── slot-unit re-render ───────────────────────────────────────────────────────
+# Slot units bake the launch argv at load time; without this, systemctl
+# restarts and reboots keep running PRE-update flags until an operator does a
+# hal0-level slot restart. Rewrite existing units through the just-installed
+# code + one daemon-reload — running services are NOT bounced; new argv
+# applies on each slot's next start.
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    info "dev mode — skipping slot-unit re-render (no system writes)"
+else
+    "${VENV_DIR}/bin/python" - <<'PYEOF'
+from hal0.updater.updater import rerender_slot_units
+n = rerender_slot_units()
+if n:
+    print(f"  re-rendered {n} slot unit(s) through the new code (services not restarted)")
+else:
+    print("  all slot units already match the new code")
+PYEOF
+fi
+
 # ── ComfyUI model share ───────────────────────────────────────────────────────
 # The docker comfy-up/down/logs/postinstall.sh scripts have been retired; the
 # podman img slot (hal0-slot@img.service) is the sole lifecycle owner of :8188

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1023,6 +1023,42 @@ class ContainerProvider(Provider):
         )
         self._write_and_start_unit(slot_name, unit_text)
 
+    def rerender_unit_sync(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> bool:
+        """Re-render an EXISTING unit file through current code — without
+        touching the running service.
+
+        The unit bakes the launch argv at load time, so after a hal0 update the
+        on-disk ExecStart still carries pre-update flags: a bare ``systemctl
+        restart`` (or a reboot!) re-runs stale config. This rewrites the unit
+        via the same plan path as :meth:`load_sync` but deliberately does NOT
+        enable/restart — serving is never bounced by an update; the new argv
+        applies on the next start from any path. Callers batch one
+        ``daemon_reload`` after a sweep.
+
+        Returns True when the unit file changed. No-ops (False) when the slot
+        has no unit on disk (never rendered → nothing stale) or the fresh
+        render is byte-identical.
+        """
+        slot_name: str = str(slot_cfg.get("name", ""))
+        unit_path = self._unit_path(slot_name)
+        if not unit_path.exists():
+            return False
+        provider = _spec_provider_for(slot_cfg) or self
+        plan = provider.container_spec(slot_cfg, model_info)
+        unit_text = _render_unit_from_plan(slot_name, plan, runtime_bin=_container_runtime())
+        if unit_path.read_text() == unit_text:
+            return False
+        unit_path.write_text(unit_text)
+        log.info(
+            "container.unit_rerendered",
+            extra={"slot": slot_name, "unit_path": str(unit_path)},
+        )
+        return True
+
+    def daemon_reload(self) -> None:
+        """``systemctl daemon-reload`` — public for the unit-rerender sweep."""
+        self._run("systemctl", "daemon-reload")
+
     def expected_argv(
         self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
     ) -> list[str] | None:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1253,6 +1253,19 @@ class SlotManager:
                 "slot.preferred_profile_swap_failed",
                 extra={"slot": slot_name, "model_id": new_model_id, "error": str(exc)},
             )
+        # MTP defuse: a forced mtp=true pointing at a model with no MTP heads
+        # makes llama-server exit at load ("model doesn't contain MTP layers"),
+        # so a swap onto an ineligible model clears exactly that override
+        # (→ AUTO). Force-off and force-on-for-eligible survive swaps; an
+        # unresolvable model is left alone (can't judge). Soft-fails like the
+        # preferred-profile hook — a write failure must not block the swap.
+        try:
+            await self._defuse_stale_mtp_on_swap(slot_name, new_model_id)
+        except Exception as exc:
+            log.warning(
+                "slot.mtp_defuse_swap_failed",
+                extra={"slot": slot_name, "model_id": new_model_id, "error": str(exc)},
+            )
         await self.unload(slot_name)
         slot = await self.load(slot_name, model_id=new_model_id)
         # Refresh Hermes's live-context files so a model swap is visible to
@@ -2263,6 +2276,52 @@ class SlotManager:
         log.info(
             "slot.preferred_profile_applied",
             extra={"slot": slot_name, "model_id": model_id, "profile": preferred},
+        )
+        return True
+
+    async def _defuse_stale_mtp_on_swap(self, slot_name: str, model_id: str) -> bool:
+        """Clear a forced ``mtp = true`` when swapping onto a non-MTP model.
+
+        MTP is a model property, and a force-on pointing at a model with no MTP
+        heads makes llama-server exit at load ("context type MTP requested but
+        model doesn't contain MTP layers") — the override would down the slot
+        the moment the swapped container starts. Clears the override to AUTO
+        for exactly that combination; a force-off, a force-on for an eligible
+        model, and an unresolvable model (can't judge) all pass through
+        untouched. Returns True when the override was cleared.
+        """
+        from hal0.model_meta import model_is_mtp_eligible
+
+        with slot_write_lock():
+            cfg = await self._load_slot_config(slot_name)
+            cfg_dict = _cfg_to_dict(cfg)
+            if cfg_dict.get("mtp") is not True:
+                return False
+            try:
+                from hal0.registry.store import ModelRegistry
+
+                model = ModelRegistry().get(model_id)
+                info = model.model_dump() if hasattr(model, "model_dump") else dict(model)
+            except Exception:
+                return False  # unresolvable — leave the escape hatch alone
+            info.setdefault("_model_key", model_id)
+            if model_is_mtp_eligible(info):
+                return False
+            cfg_dict = dict(cfg_dict)
+            cfg_dict.pop("mtp", None)  # absent = AUTO (TOML has no null)
+            write_slot_toml(self._config_file(slot_name), cfg_dict)
+            self._invalidate_cfg_cache(slot_name)
+        log.warning(
+            "slot.mtp_force_on_cleared_on_swap",
+            extra={
+                "slot": slot_name,
+                "model_id": model_id,
+                "note": (
+                    "forced MTP would crash llama-server for this model (no MTP "
+                    "heads); override cleared to AUTO. Tag the model 'mtp' or "
+                    "re-force in the drawer if it really ships MTP layers."
+                ),
+            },
         )
         return True
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -977,6 +977,98 @@ def ensure_seed_profiles(*, job_id: str | None = None) -> int:
     return len(stale)
 
 
+def clear_stale_mtp_overrides(*, job_id: str | None = None, registry: Any = None) -> int:
+    """Clear crash-only ``mtp = true`` slot overrides (upgrade migration).
+
+    An explicit slot ``mtp = true`` is honored literally at launch — it is the
+    escape hatch for MTP-capable models the eligibility heuristics miss. But a
+    force-on pointing at a model with NO MTP layers makes llama-server exit at
+    load ("context type MTP requested but model doesn't contain MTP layers").
+    Such overrides are typically debris from the pre-separation binary MTP
+    pill or an old stack apply, left behind by a later model swap and masked
+    for months by stale baked units.
+
+    For every slot with ``mtp = true`` whose bound model is registry-resolvable
+    and NOT MTP-eligible, drop the override (→ AUTO) and log loudly. Slots are
+    left untouched when the model can't be resolved (can't judge, stay
+    conservative), when the override is ``false``/absent (harmless), or when
+    the model is eligible (deliberate force-on — the escape hatch stands).
+
+    Args:
+        job_id: Optional breadcrumb for structured-log tracing.
+        registry: Model-registry override for tests (anything with
+            ``get(model_id)`` returning an object with ``model_dump()``).
+            ``None`` uses the real :class:`~hal0.registry.store.ModelRegistry`.
+
+    Returns:
+        Number of slot overrides cleared.
+    """
+    import tomllib
+
+    from hal0.config.loader import write_toml_atomic
+    from hal0.config.paths import slots_config_dir
+    from hal0.model_meta import model_is_mtp_eligible
+
+    if registry is None:
+        from hal0.registry.store import ModelRegistry
+
+        registry = ModelRegistry()
+
+    # Raw-TOML surgery, deliberately schema-free: slot TOMLs exist in two
+    # shapes on real boxes (flat manager-written keys vs the nested ``[slot]``
+    # table of the installer seeds), and a migration must not depend on the
+    # current SlotConfig validating either. Only the ``mtp`` key is touched,
+    # and a file is rewritten only when it actually changes.
+    cleared = 0
+    slots_dir = slots_config_dir()
+    for toml_path in sorted(slots_dir.glob("*.toml")) if slots_dir.is_dir() else []:
+        slot_name = toml_path.stem
+        try:
+            raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            log.warning("updater.mtp_migration_slot_unreadable", slot=slot_name, error=str(exc))
+            continue
+        # ``mtp`` lives top-level (flat shape) or under [slot] (nested shape).
+        holder = raw
+        if not isinstance(holder.get("mtp"), bool) and isinstance(raw.get("slot"), dict):
+            holder = raw["slot"]
+        if holder.get("mtp") is not True:
+            continue
+        model_table = raw.get("model")
+        model_id = model_table.get("default", "") if isinstance(model_table, dict) else ""
+        if not model_id:
+            continue
+        try:
+            model = registry.get(model_id)
+            info = model.model_dump() if hasattr(model, "model_dump") else dict(model)
+        except Exception:
+            # Unresolvable model — can't judge eligibility; leave the override.
+            continue
+        info.setdefault("_model_key", model_id)
+        if model_is_mtp_eligible(info):
+            continue
+        del holder["mtp"]  # absent = AUTO (TOML has no null)
+        try:
+            write_toml_atomic(toml_path, raw)
+        except Exception as exc:
+            log.warning("updater.mtp_migration_write_failed", slot=slot_name, error=str(exc))
+            continue
+        cleared += 1
+        log.warning(
+            "updater.mtp_force_on_cleared",
+            job_id=job_id,
+            slot=slot_name,
+            model=model_id,
+            note=(
+                "slot forced MTP on but the model has no MTP heads (would crash "
+                "llama-server at load); override cleared to AUTO. If the model "
+                "really ships MTP layers, tag it 'mtp' in the registry or re-force "
+                "MTP in the slot drawer."
+            ),
+        )
+    return cleared
+
+
 # ── Updater class ──────────────────────────────────────────────────────────────
 
 
@@ -1218,6 +1310,21 @@ class Updater:
             )
             # Non-fatal: a lingering materialised seed is harmless (the overlay
             # overwrites it on load); don't abort the update.
+
+        # Step 7c: clear crash-only mtp=true slot overrides (a force-on pointing
+        # at a model with no MTP heads makes llama-server exit at load once the
+        # unit re-renders under post-separation code). Loud per-slot log; the
+        # eligible / unresolvable cases are left untouched.
+        try:
+            await asyncio.to_thread(clear_stale_mtp_overrides, job_id=self.job_id)
+        except Exception as exc:
+            log.warning(
+                "updater.mtp_migration_failed",
+                job_id=self.job_id,
+                error=str(exc),
+            )
+            # Non-fatal: the affected slot simply fails to load until the
+            # operator flips MTP to Auto/Off in the drawer.
 
         # Step 8 + 9: atomic symlink swap + record previous.
         link = _current_symlink()

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1069,6 +1069,64 @@ def clear_stale_mtp_overrides(*, job_id: str | None = None, registry: Any = None
     return cleared
 
 
+def rerender_slot_units(*, job_id: str | None = None) -> int:
+    """Re-render every existing container slot unit through current code.
+
+    A slot's systemd unit bakes the launch argv at load time. Updating hal0
+    changes the code that WOULD render but not the file that DID — so
+    ``systemctl restart``, crash-restarts, and reboots keep running pre-update
+    flags until an operator remembers a hal0-level reload (field finding,
+    CT105). This sweep rewrites each on-disk unit via the same plan path a
+    load uses and batches one ``daemon-reload`` — it never enables, starts, or
+    restarts anything, so serving is not bounced; the fresh argv applies on
+    the next start from ANY path. The dashboard's drift indicator covers the
+    remaining "process still running old argv" window.
+
+    Per-slot failures (unresolvable model/profile, malformed TOML) log and
+    skip — a bad slot must never wedge an update.
+
+    Returns the number of unit files rewritten.
+    """
+    import tomllib
+
+    from hal0.config.paths import slots_config_dir
+    from hal0.providers.container import ContainerProvider, _best_effort_model_info
+
+    provider = ContainerProvider()
+    rewritten = 0
+    slots_dir = slots_config_dir()
+    for toml_path in sorted(slots_dir.glob("*.toml")) if slots_dir.is_dir() else []:
+        slot_name = toml_path.stem
+        try:
+            raw = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            # Slot TOMLs exist flat (manager-written) or with a [slot] table
+            # (installer seeds); hoist the nested shape to the flat one the
+            # provider consumes. [model]/[server] tables pass through as-is.
+            cfg: dict[str, Any] = {**raw, **(raw.get("slot") or {})}
+            cfg.pop("slot", None)
+            cfg.setdefault("name", slot_name)
+            # Same registry-backed, never-raising resolver the preview path
+            # uses — a registry miss degrades to a minimal path dict.
+            model_info = _best_effort_model_info(cfg, None)
+            if provider.rerender_unit_sync(cfg, model_info):
+                rewritten += 1
+                log.info("updater.unit_rerendered", job_id=job_id, slot=slot_name)
+        except Exception as exc:
+            log.warning(
+                "updater.unit_rerender_skipped",
+                job_id=job_id,
+                slot=slot_name,
+                error=str(exc),
+            )
+    if rewritten:
+        try:
+            provider.daemon_reload()
+        except Exception as exc:
+            log.warning("updater.unit_rerender_daemon_reload_failed", job_id=job_id, error=str(exc))
+        log.info("updater.unit_rerender_complete", job_id=job_id, rewritten=rewritten)
+    return rewritten
+
+
 # ── Updater class ──────────────────────────────────────────────────────────────
 
 
@@ -1357,6 +1415,48 @@ class Updater:
                     with contextlib.suppress(OSError):
                         _atomic_symlink_swap(prior, link)
                 raise
+
+        # Step 8c: re-render existing slot units through the NEW code so any
+        # subsequent start (systemctl restart, crash-restart, reboot) uses
+        # current argv — never bounces serving (write + daemon-reload only).
+        # Must run AFTER the 8b venv reinstall and in a FRESH interpreter:
+        # this (still-old) process would render pre-update argv, defeating the
+        # point; a subprocess of the re-pipped venv executes the new module.
+        if not _is_editable_install():
+            try:
+                proc = await asyncio.to_thread(
+                    subprocess.run,
+                    [
+                        sys.executable,
+                        "-c",
+                        "from hal0.updater.updater import rerender_slot_units; "
+                        "print(rerender_slot_units())",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+                if proc.returncode == 0:
+                    log.info(
+                        "updater.unit_rerender_done",
+                        job_id=self.job_id,
+                        rewritten=(proc.stdout or "").strip(),
+                    )
+                else:
+                    log.warning(
+                        "updater.unit_rerender_failed",
+                        job_id=self.job_id,
+                        rc=proc.returncode,
+                        stderr=(proc.stderr or "")[-500:],
+                    )
+            except Exception as exc:
+                log.warning(
+                    "updater.unit_rerender_failed",
+                    job_id=self.job_id,
+                    error=str(exc),
+                )
+                # Non-fatal: stale units keep old flags until a hal0-level slot
+                # restart; the dashboard drift indicator surfaces them.
 
         if prior is not None:
             _write_atomic_text(_previous_record(), str(prior))

--- a/tests/slots/test_mtp_defuse.py
+++ b/tests/slots/test_mtp_defuse.py
@@ -1,0 +1,123 @@
+"""MTP force-on defuse — swap path + updater migration.
+
+A slot's explicit ``mtp = true`` is the escape hatch for MTP-capable models
+the eligibility heuristics miss — but pointed at a model with NO MTP heads it
+makes llama-server exit at load ("context type MTP requested but model doesn't
+contain MTP layers"). Two mechanisms clear exactly that crash-only combination
+(and nothing else):
+
+  - :meth:`SlotManager._defuse_stale_mtp_on_swap` — on model swap, so the
+    staleness can't regenerate (the override is model-scoped debris once the
+    model changes).
+  - :func:`hal0.updater.updater.clear_stale_mtp_overrides` — upgrade
+    migration for overrides already on disk (pre-separation binary-pill /
+    stack-apply leftovers masked for months by stale baked units).
+"""
+
+from __future__ import annotations
+
+import tomllib
+
+from hal0.config.paths import slots_config_dir
+from hal0.registry.model import Model
+from hal0.registry.store import ModelRegistry
+from hal0.slots.manager import SlotManager
+from hal0.updater.updater import clear_stale_mtp_overrides
+
+
+def _register(model_id: str, *, tags: list[str] | None = None) -> None:
+    ModelRegistry().add(
+        Model(id=model_id, path=f"/tmp/{model_id}.gguf", capabilities=["chat"], tags=tags or [])
+    )
+
+
+def _slot_cfg(name: str, model: str, *, mtp: bool | None) -> dict:
+    cfg: dict = {
+        "name": name,
+        "port": 8093,
+        "type": "llm",
+        "device": "gpu-vulkan",
+        "profile": "vulkan",
+        "provider": "llama-server",
+        "enabled": True,
+        "group": "custom",
+        "model": {"default": model},
+    }
+    if mtp is not None:
+        cfg["mtp"] = mtp
+    return cfg
+
+
+def _on_disk_mtp(name: str):
+    raw = tomllib.loads((slots_config_dir() / f"{name}.toml").read_text(encoding="utf-8"))
+    slot = raw.get("slot", raw)
+    return slot.get("mtp", raw.get("mtp"))
+
+
+# ── swap-path defuse ──────────────────────────────────────────────────────────
+
+
+async def test_swap_defuse_clears_force_on_for_ineligible_model(tmp_hal0_home: str) -> None:
+    _register("plain-chat")
+    sm = SlotManager()
+    await sm.create("s", _slot_cfg("s", "old-model", mtp=True))
+    assert await sm._defuse_stale_mtp_on_swap("s", "plain-chat") is True
+    assert _on_disk_mtp("s") is None  # absent = AUTO
+
+
+async def test_swap_defuse_keeps_force_on_for_eligible_model(tmp_hal0_home: str) -> None:
+    _register("tagged-model", tags=["mtp"])
+    sm = SlotManager()
+    await sm.create("s", _slot_cfg("s", "old-model", mtp=True))
+    assert await sm._defuse_stale_mtp_on_swap("s", "tagged-model") is False
+    assert _on_disk_mtp("s") is True
+
+
+async def test_swap_defuse_keeps_force_off_and_auto(tmp_hal0_home: str) -> None:
+    _register("plain-chat")
+    sm = SlotManager()
+    await sm.create("off", _slot_cfg("off", "old-model", mtp=False))
+    await sm.create("auto", _slot_cfg("auto", "old-model", mtp=None))
+    assert await sm._defuse_stale_mtp_on_swap("off", "plain-chat") is False
+    assert await sm._defuse_stale_mtp_on_swap("auto", "plain-chat") is False
+    assert _on_disk_mtp("off") is False
+    assert _on_disk_mtp("auto") is None
+
+
+async def test_swap_defuse_leaves_unresolvable_model_alone(tmp_hal0_home: str) -> None:
+    # Escape hatch preserved: if the registry can't judge the model, don't touch.
+    sm = SlotManager()
+    await sm.create("s", _slot_cfg("s", "old-model", mtp=True))
+    assert await sm._defuse_stale_mtp_on_swap("s", "not-in-registry") is False
+    assert _on_disk_mtp("s") is True
+
+
+# ── updater migration ─────────────────────────────────────────────────────────
+
+
+async def test_migration_clears_only_crash_combo(tmp_hal0_home: str) -> None:
+    _register("plain-chat")
+    _register("tagged-model", tags=["mtp"])
+    sm = SlotManager()
+    # crash combo: force-on + ineligible model → cleared
+    await sm.create("crash", _slot_cfg("crash", "plain-chat", mtp=True))
+    # deliberate force-on for an eligible model → kept
+    await sm.create("keep", _slot_cfg("keep", "tagged-model", mtp=True))
+    # force-off → harmless, kept
+    await sm.create("off", _slot_cfg("off", "plain-chat", mtp=False))
+    # unresolvable model → can't judge, kept
+    await sm.create("unknown", _slot_cfg("unknown", "ghost-model", mtp=True))
+
+    assert clear_stale_mtp_overrides() == 1
+    assert _on_disk_mtp("crash") is None
+    assert _on_disk_mtp("keep") is True
+    assert _on_disk_mtp("off") is False
+    assert _on_disk_mtp("unknown") is True
+
+
+async def test_migration_is_idempotent(tmp_hal0_home: str) -> None:
+    _register("plain-chat")
+    sm = SlotManager()
+    await sm.create("s", _slot_cfg("s", "plain-chat", mtp=True))
+    assert clear_stale_mtp_overrides() == 1
+    assert clear_stale_mtp_overrides() == 0

--- a/tests/updater/test_unit_rerender.py
+++ b/tests/updater/test_unit_rerender.py
@@ -1,0 +1,145 @@
+"""rerender_slot_units — the update-time slot-unit re-render sweep.
+
+Slot units bake the launch argv at load time, so a hal0 update changes the
+code that WOULD render but not the file that DID (field finding, CT105:
+`systemctl restart` after an update re-ran the stale ExecStart). The sweep
+rewrites existing units through current code + one daemon-reload and never
+starts/enables/restarts anything.
+
+Contract under test:
+  - a stale on-disk unit is rewritten to the fresh render,
+  - an up-to-date unit is left untouched (no gratuitous write),
+  - a slot with NO unit file is skipped (never rendered → nothing stale),
+  - exactly one daemon-reload per sweep, and none when nothing changed,
+  - a per-slot failure (unresolvable profile) skips that slot, not the sweep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import ProfileConfig
+from hal0.providers import container as container_mod
+from hal0.slots.manager import SlotManager
+from hal0.updater import updater as updater_mod
+from hal0.updater.updater import rerender_slot_units
+
+_PROFILE = ProfileConfig(
+    image="ghcr.io/test/toolbox:v2",
+    flags="-fa on -b 1024",
+    mtp=False,
+    device_class="gpu",
+    backend="vulkan",
+)
+
+
+@pytest.fixture
+def rerender_env(tmp_hal0_home: str, tmp_path, monkeypatch):
+    """Sandbox the systemd dir, container runtime, profile lookup, and
+    systemctl calls; return the fake unit dir + recorded systemctl argv."""
+    unit_dir = tmp_path / "systemd"
+    unit_dir.mkdir()
+    monkeypatch.setattr(container_mod, "_SYSTEMD_SYSTEM_DIR", unit_dir)
+    monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "/usr/bin/podman")
+    monkeypatch.setattr(container_mod, "_resolve_profile", lambda name: _PROFILE)
+
+    calls: list[tuple[str, ...]] = []
+
+    def _fake_run(self, *args, check=True, **kwargs):
+        calls.append(args)
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(container_mod.ContainerProvider, "_run", _fake_run)
+    return unit_dir, calls
+
+
+def _unit_path(unit_dir, name: str):
+    return unit_dir / f"hal0-slot@{name}.service"
+
+
+async def _mk_slot(name: str, port: int) -> None:
+    await SlotManager().create(
+        name,
+        {
+            "name": name,
+            "port": port,
+            "type": "llm",
+            "device": "gpu-vulkan",
+            "profile": "vulkan",
+            "provider": "llama-server",
+            "runtime": "container",
+            "enabled": True,
+            "group": "custom",
+            "model": {"default": "some-model"},
+        },
+    )
+
+
+async def test_stale_unit_rewritten_and_one_daemon_reload(rerender_env) -> None:
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    _unit_path(unit_dir, "a").write_text("# stale pre-update unit\n")
+
+    assert rerender_slot_units() == 1
+
+    text = _unit_path(unit_dir, "a").read_text()
+    assert "some-model" in text and "-fa on" in text, "fresh render expected"
+    assert calls.count(("systemctl", "daemon-reload")) == 1
+    # Never bounce serving: no enable/start/restart in the sweep.
+    assert not [c for c in calls if c[0] == "systemctl" and c[1] in ("enable", "start", "restart")]
+
+
+async def test_up_to_date_unit_untouched(rerender_env) -> None:
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    _unit_path(unit_dir, "a").write_text("stale")
+    assert rerender_slot_units() == 1
+    before = _unit_path(unit_dir, "a").read_text()
+    calls.clear()
+
+    # Second sweep: byte-identical render → no write, no daemon-reload.
+    assert rerender_slot_units() == 0
+    assert _unit_path(unit_dir, "a").read_text() == before
+    assert ("systemctl", "daemon-reload") not in calls
+
+
+async def test_slot_without_unit_file_skipped(rerender_env) -> None:
+    unit_dir, calls = rerender_env
+    await _mk_slot("never-loaded", 8096)
+
+    assert rerender_slot_units() == 0
+    assert not _unit_path(unit_dir, "never-loaded").exists()
+    assert ("systemctl", "daemon-reload") not in calls
+
+
+async def test_per_slot_failure_does_not_wedge_sweep(rerender_env, monkeypatch) -> None:
+    unit_dir, _calls = rerender_env
+    await _mk_slot("bad", 8097)
+    await _mk_slot("good", 8098)
+    _unit_path(unit_dir, "bad").write_text("stale")
+    _unit_path(unit_dir, "good").write_text("stale")
+
+    # Break only the 'bad' slot's plan build; 'good' renders normally.
+    real_spec = container_mod.ContainerProvider.container_spec
+
+    def _spec(self, cfg, mi):
+        if cfg.get("name") == "bad":
+            raise RuntimeError("boom")
+        return real_spec(self, cfg, mi)
+
+    monkeypatch.setattr(container_mod.ContainerProvider, "container_spec", _spec)
+
+    assert rerender_slot_units() == 1  # good rewritten, bad skipped
+    assert _unit_path(unit_dir, "bad").read_text() == "stale"
+    assert "some-model" in _unit_path(unit_dir, "good").read_text()
+
+
+async def test_updater_module_reexports(rerender_env) -> None:
+    # install.sh + Step 8c import it from the updater module.
+    assert callable(updater_mod.rerender_slot_units)


### PR DESCRIPTION
Follow-up to v0.8.5b1 closing both CT105 field findings: the stale `mtp=true` crash and the stale-baked-unit problem.

## 1. Crash-only `mtp = true` overrides are defused (two mechanisms)

Field-confirmed crash: pre-separation `mtp = true` debris on a headless MoE model → llama-server exits at load ("context type MTP requested but model doesn't contain MTP layers"); `utility` was crash-looping, re-rendering `agent` reproduced it.

- **`updater.clear_stale_mtp_overrides()`** (Updater step 7c + `install.sh`): raw-TOML surgery over slot files (schema-free — handles flat manager-written and `[slot]`-nested shapes; rewrites only on change). Force-on + registry-resolvable **ineligible** model → override dropped (AUTO), loud `updater.mtp_force_on_cleared` log. Force-off, eligible force-on, and unresolvable models untouched — the false-negative escape hatch stands.
- **`SlotManager._defuse_stale_mtp_on_swap()`**: swapping onto an ineligible model clears a forced `true` before reload, so the staleness can't regenerate. Soft-fails; never blocks the swap.

## 2. Slot units re-render on update (no service bounce)

Updating hal0 changed the code that WOULD render but not the unit that DID — `systemctl restart`, crash-restarts, and **reboots** kept running pre-update flags until a hal0-level slot restart.

- **`ContainerProvider.rerender_unit_sync()`**: rewrite an existing unit via the same plan path as `load_sync` — write-if-changed, never enable/start/restart.
- **`updater.rerender_slot_units()`**: sweep all slots, one batched `daemon-reload`, per-slot fail-soft.
- Wired as **updater step 8c** — after the venv reinstall and via a **fresh interpreter subprocess** (the still-running old updater process would render pre-update argv, defeating the point). Editable installs skip; `install.sh` runs the sweep directly from the new checkout.

Serving is never bounced by an update; fresh argv applies on each slot's next start from any path. The dashboard drift indicator covers the remaining process-still-old window.

## Testing
- `tests/slots/test_mtp_defuse.py` (6): crash combo cleared / eligible kept / off+auto kept / unresolvable kept / idempotent.
- `tests/updater/test_unit_rerender.py` (5): stale rewritten + exactly one daemon-reload + zero start/enable/restart; up-to-date untouched; unit-less skipped; per-slot failure isolation.
- 1212 green across affected suites locally; ruff check + format clean; `bash -n install.sh` clean.

## Next (separate PR)
- Gateway `/v1/rerank` proxy route (currently 405; slot-direct works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw