### PR TITLE
gateway: serve POST /v1/rerank (alias of /v1/rerankings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ tree is gitignored, #638) and referenced by number throughout the code.
   window.
 
 ### Fixed
+- **Gateway now serves `POST /v1/rerank`.** The dispatcher's capability path
+  map already resolved `/rerank` to the rerank slot, but the gateway only
+  registered `/v1/rerankings` — so clients using llama-server's / Jina-style
+  `/v1/rerank` got 405 and had to hit the slot port directly (field finding).
+  `/v1/rerank` is now an alias of `/v1/rerankings` through the same dispatch
+  path.
 - **Crash-only `mtp = true` overrides are defused automatically.** A forced
   MTP override pointing at a model with no MTP heads crashes llama-server at
   load once the slot's unit re-renders under the v0.8.5b1 MTP separation

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -996,6 +996,15 @@ async def rerankings(request: Request, dispatcher: DispatcherDep) -> Response:
     return await _dispatch_and_forward(request, dispatcher)
 
 
+@router.post("/rerank")
+async def rerank(request: Request, dispatcher: DispatcherDep) -> Response:
+    """Alias of ``/rerankings`` under the path llama-server (and Jina/Cohere-
+    style clients) actually use. The capability path map already resolved
+    ``/rerank`` to the rerank slot, but no gateway route existed — clients got
+    405 and had to hit the slot port directly (field finding, CT105)."""
+    return await _dispatch_and_forward(request, dispatcher)
+
+
 @router.post("/audio/transcriptions")
 async def audio_transcriptions(request: Request, dispatcher: DispatcherDep) -> Response:
     # Multipart upload — extract the model field to route, then forward the

--- a/tests/api/test_v1_proxy.py
+++ b/tests/api/test_v1_proxy.py
@@ -113,3 +113,17 @@ def test_v1_rerankings_no_route_returns_typed_404(client: TestClient) -> None:
     )
     assert r.status_code == 404
     assert r.json()["error"]["code"] == "dispatch.no_route"
+
+
+def test_v1_rerank_alias_is_routed_not_405(client: TestClient) -> None:
+    """/v1/rerank (llama-server's / Jina-style clients' path) must reach the
+    dispatcher like /v1/rerankings — it previously had NO gateway route, so
+    clients got 405 and had to hit the slot port directly (CT105 finding)."""
+    r = client.post(
+        "/v1/rerank",
+        json={"model": "model-nobody-serves", "query": "q", "documents": ["d"]},
+    )
+    # A typed dispatch 404 proves the route exists and resolves through the
+    # dispatcher; the pre-fix failure mode was a bare 405 Method Not Allowed.
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "dispatch.no_route"


### PR DESCRIPTION
Closes the CT105 field finding: the dispatcher's capability path map already resolved `/rerank` to the rerank slot, but the gateway only registered `/v1/rerankings` — clients using llama-server's / Jina-style `/v1/rerank` got **405** and had to hit the slot port (:8083) directly.

`/v1/rerank` is now an alias of `/v1/rerankings` through the same `_dispatch_and_forward` path. New test pins a typed `dispatch.no_route` 404 for the alias (proving route + dispatcher resolution), where the pre-fix failure was a bare 405. Changelog entry under `[Unreleased]`.

Targeted for the v0.8.5b2 hotfix cut together with the already-merged #1049 (MTP crash defuse + unit re-render).

196 green across api+dispatcher suites; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw)_