### PR TITLE
release: v0.8.5b2 — hotfix cut (MTP defuse, unit re-render, /v1/rerank)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+## [v0.8.5b2] — 2026-07-04
+
+Hotfix over v0.8.5b1, closing the three findings from the first live
+update+verification pass on Strix Halo hardware (CT105): stale `mtp = true`
+overrides crashing slots on re-render, slot units not re-rendering on update,
+and the gateway missing `POST /v1/rerank`. **Safe upgrade from v0.8.5b1** —
+the one migration (crash-only MTP override defuse) touches exactly the slot
+configs that could not have loaded anyway, with a loud per-slot log.
+
 ### Added
 - **Slot units re-render automatically on update.** A slot's systemd unit
   bakes the launch argv at load time, so updating hal0 changed the code that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.5b1"
+version = "0.8.5b2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.8.5b1"
+version = "0.8.5b2"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
Release prep for the v0.8.5b2 hotfix: converts `[Unreleased]` into the release section (the three CT105 field-finding fixes — #1049 crash-only `mtp=true` defuse migration + swap guard, #1049 slot-unit re-render on update, #1052 gateway `/v1/rerank` alias), bumps `pyproject.toml` to `0.8.5b2` (release-check gate 7), and re-locks `uv.lock`.

On merge: tag `v0.8.5b2` via `release.yml` `workflow_dispatch` → signed tarball + manifest → stable channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw)_