### PR TITLE
ui: always show the MTP control on llm slots (reason line + force-on warning)

### DIFF
--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -626,7 +626,13 @@ function PillToggle({ on, disabled, label, stateText, onToggle }) {
 //   value: null (auto) | true (on) | false (off)
 //   autoActive: whether the derived decision is currently ON (model eligible AND
 //               profile opts in) — only shown as context while value is Auto.
-function MtpControl({ value, autoActive, disabled, onChange }) {
+//   inactiveReason: optional precise reason Auto is inactive ("model has no MTP
+//               heads", "profile doesn't enable MTP", …) so the hint explains
+//               itself instead of a generic requirement blurb.
+//   forceOnRisky: when true and value===true, warn that the force will fail at
+//               launch (model doesn't advertise MTP heads — the escape hatch is
+//               for models the eligibility heuristics miss, not headless ones).
+function MtpControl({ value, autoActive, disabled, onChange, inactiveReason, forceOnRisky }) {
   const isAuto = value == null;
   const OPTS = [
     { key: "auto", v: null, label: "Auto" },
@@ -634,7 +640,9 @@ function MtpControl({ value, autoActive, disabled, onChange }) {
     { key: "off", v: false, label: "Off" },
   ];
   const eff = isAuto
-    ? (autoActive ? "Auto · MTP active" : "Auto · inactive — needs an MTP model on an MTP profile")
+    ? (autoActive
+        ? "Auto · MTP active"
+        : `Auto · off — ${inactiveReason || "needs an MTP model on an MTP profile"}`)
     : (value ? "Forced on" : "Forced off");
   return (
     <div className="mtp-ctl">
@@ -658,6 +666,11 @@ function MtpControl({ value, autoActive, disabled, onChange }) {
         })}
       </div>
       <span className={"mtp-eff mono" + (isAuto && !autoActive ? " muted" : "")}>{eff}</span>
+      {value === true && forceOnRisky && (
+        <span className="mtp-eff mono" style={{ color: "var(--warn)" }} data-testid="mtp-force-warn">
+          ⚠ model doesn't advertise MTP heads — launch fails unless it truly has them
+        </span>
+      )}
     </div>
   );
 }

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -1040,23 +1040,29 @@ function EditSlotDrawer({ open, slot, onClose }) {
           shows whether Auto is currently effective. Instant-apply via PUT
           /config + non-blocking restart. */}
       {(() => {
+        // ALWAYS visible on LLM slots (operator feedback): hiding the row when
+        // the model is ineligible left the state undiscoverable — you couldn't
+        // see WHY MTP was off, couldn't find Auto, and the force-on escape
+        // hatch (for models the eligibility heuristics miss) had no UI. The
+        // tri-state + reason line explains itself; only non-LLM slot types
+        // (embed/rerank/tts/…) skip the row, where MTP is meaningless.
+        if ((slot.type || "llm") !== "llm") return null;
         const cur = slot.model_id || slot.model || "";
         const m = (modelsQuery.data ?? []).map(normalizeApiModel).find(x => x.id === cur);
         // Same eligibility rule as the server (`model_is_mtp_eligible`): the
-        // `mtp` tag OR a delimited MTP name marker — so an untagged local pull
-        // named "…-MTP-….gguf" (which the server WILL auto-speculate on an MTP
-        // profile) still surfaces the control here.
+        // `mtp` tag OR a delimited MTP name marker.
         const modelEligible = isMtpEligibleModel(m);
-        // Show for an eligible model, or when MTP is force-ON on a now-ineligible
-        // model so it stays adjustable. A force-OFF on an ineligible model needs
-        // no control (it's already off and would be off under Auto too).
-        const forcedOn = slot.mtp === true;
-        if (!modelEligible && !forcedOn) return null;
         // Auto is effective only when the model is eligible AND the slot's
         // profile opts into MTP — mirror the server's _effective_mtp rule so
         // the hint never disagrees with what actually launches.
         const prof = (profilesQuery.data ?? []).find(p => p.name === (selectedProfile || slot.profile));
-        const autoActive = modelEligible && !!prof?.mtp;
+        const profileOptsIn = !!prof?.mtp;
+        const autoActive = modelEligible && profileOptsIn;
+        const inactiveReason = !modelEligible && !profileOptsIn
+          ? "model has no MTP heads and profile doesn't enable MTP"
+          : !modelEligible
+            ? "model has no MTP heads"
+            : "profile doesn't enable MTP";
         return (
           <div className="form-row">
             <div className="form-lbl">
@@ -1067,6 +1073,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
               <MtpControl
                 value={mtp}
                 autoActive={autoActive}
+                inactiveReason={inactiveReason}
+                forceOnRisky={!modelEligible}
                 disabled={saving}
                 onChange={async (next) => {
                   // Optimistic — set local state before the PUT, revert on error.

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -545,14 +545,15 @@ function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
             }
             // MTP is DERIVED (model-eligibility × profile opt-in) and defaults
             // to Auto — no stale boolean per row. Surface the tri-state control
-            // when the picked model is MTP-eligible, or when a force-ON was
-            // persisted (so it stays adjustable). The row's own model+profile
-            // pick drive whether Auto is actually effective.
+            // whenever EITHER side is MTP-relevant (eligible model OR an
+            // MTP-opting profile) or an explicit override is persisted — the
+            // drawer's always-show rationale, bounded so rows where MTP is
+            // meaningless stay compact.
             const rowModel = models.find(m => m.id === s.model);
             // Same eligibility rule as the server: `mtp` tag OR MTP name marker.
             const modelEligible = isMtpEligibleModel(rowModel);
             const profileOptsIn = !!profiles.find(p => p.name === s.profile)?.mtp;
-            const showMtp = modelEligible || s.mtp === true;
+            const showMtp = modelEligible || profileOptsIn || s.mtp != null;
             return (
               <div className="st-slot-card" key={i}>
                 <div className="st-slot-head">
@@ -618,6 +619,10 @@ function StackDrawer({ mode, source, existing = [], onClose, onSaved }) {
                       <MtpControl
                         value={s.mtp ?? null}
                         autoActive={modelEligible && profileOptsIn}
+                        inactiveReason={!modelEligible && !profileOptsIn
+                          ? 'model has no MTP heads and profile doesn\'t enable MTP'
+                          : !modelEligible ? 'model has no MTP heads' : 'profile doesn\'t enable MTP'}
+                        forceOnRisky={!modelEligible}
                         onChange={(next) => setSlot(i, 'mtp', next)}
                       />
                     </div>

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -316,8 +316,10 @@ test.describe('C7 — drawer-editable profile + create-modal device derivation',
     // undiscoverable (can't see WHY it's off; the force-on escape hatch had no
     // UI). The row is now ALWAYS shown on llm slots — for an ineligible model
     // it explains Auto is off and warns before a force-on that would fail at
-    // launch. Fixture model carries neither the tag nor a name marker.
-    const slot = { ...MTP_SLOT, model_id: 'qwen-plain', model: 'qwen-plain' }
+    // launch. Fixture model carries neither the tag nor a name marker, and the
+    // slot has NO override (mtp: null = Auto) — MTP_SLOT's mtp:false would
+    // legitimately select "Off" instead of Auto.
+    const slot = { ...MTP_SLOT, model_id: 'qwen-plain', model: 'qwen-plain', mtp: null }
     await seedSlotsAndModels(page, [slot], [{ id: 'qwen-plain', name: 'qwen-plain', capabilities: ['chat'], tags: ['rocmfp4'] }])
     await page.route('**/api/slots/chat/config', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -311,18 +311,29 @@ test.describe('C7 — drawer-editable profile + create-modal device derivation',
     expect(puts[1].mtp).toBeNull()
   })
 
-  test('C7j — MTP control hidden when the model is not MTP-capable', async ({ page }) => {
-    // Eligibility = registry `mtp` tag OR a delimited MTP name marker (server
-    // parity via isMtpEligibleModel) — so this fixture model must carry
-    // NEITHER. The old fixture reused the id "qwen-mtp", which the name-marker
-    // rule now correctly treats as eligible (the server would auto-speculate
-    // it too), so it needs a marker-free id here.
+  test('C7j — MTP control visible for a non-MTP model, with reason + force-on warning', async ({ page }) => {
+    // Operator feedback: hiding the row for ineligible models made the state
+    // undiscoverable (can't see WHY it's off; the force-on escape hatch had no
+    // UI). The row is now ALWAYS shown on llm slots — for an ineligible model
+    // it explains Auto is off and warns before a force-on that would fail at
+    // launch. Fixture model carries neither the tag nor a name marker.
     const slot = { ...MTP_SLOT, model_id: 'qwen-plain', model: 'qwen-plain' }
     await seedSlotsAndModels(page, [slot], [{ id: 'qwen-plain', name: 'qwen-plain', capabilities: ['chat'], tags: ['rocmfp4'] }])
+    await page.route('**/api/slots/chat/config', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/chat/restart', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
     await page.goto('/#slots/chat')
-    await expect(page.locator('.drawer')).toBeVisible()
-    // Expect no .form-row whose label span reads exactly "MTP"
-    await expect(page.locator('.drawer .form-row').filter({ has: page.locator('.form-lbl span', { hasText: /^MTP$/ }) })).toHaveCount(0)
+    const row = page.locator('.drawer .form-row').filter({ has: page.locator('.form-lbl span', { hasText: /^MTP$/ }) })
+    await expect(row).toBeVisible()
+    // Auto is selected and the reason line names the model.
+    await expect(row.getByTestId('mtp-seg-auto')).toHaveAttribute('aria-checked', 'true')
+    await expect(row.locator('.mtp-eff').first()).toContainText('model has no MTP heads')
+    // Forcing On surfaces the crash warning (escape hatch stays usable).
+    await row.getByTestId('mtp-seg-on').click()
+    await expect(row.getByTestId('mtp-force-warn')).toBeVisible()
   })
 
   // ─── Chat-template override (Task 5) ────────────────────────────────────────


### PR DESCRIPTION
Operator feedback from the live box (v0.8.5b2): slots with an ineligible model hid the MTP row entirely (e.g. `agent` with MTP forced off), making the state undiscoverable — no way to see *why* MTP is off, no way to find Auto, and no UI for the force-on escape hatch. Hiding was an inheritance from the old binary pill; the tri-state explains itself and should be visible.

- **Slot drawer:** MTP row renders on every `llm`-type slot. `MtpControl` gains `inactiveReason` ("model has no MTP heads" / "profile doesn't enable MTP" / both) so `Auto · off` names its cause, and `forceOnRisky` — forcing On for a model without advertised heads shows a launch-will-fail warning instead of silently arming a crash.
- **Stack editor:** rows show the control when either side is MTP-relevant (eligible model OR MTP-opting profile) or an override is persisted — same reason/warning props; irrelevant rows stay compact.
- **e2e `C7j` inverted** to the new contract: visible for a non-MTP model, Auto selected, reason line present, force-on warning appears. `C7i` (On→`mtp:true`, Auto→`mtp:null`) unchanged and passing.

`vite build` + `tsc` clean; both MTP e2e specs green locally against the pinned chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw)_