### PR TITLE
fix(ui): add Logs/Edit buttons to capability slot mini-cards

### DIFF
--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -713,10 +713,11 @@ function MiniCard({ s, ind, busy, handlers }) {
         <SlotControls
           phase={ph}
           busy={busy}
-          compact
           onStart={() => handlers.onStart(s)}
           onStop={() => handlers.onStop(s)}
           onRestart={() => handlers.onRestart(s)}
+          onLogs={() => handlers.onLogs(s)}
+          onEdit={() => handlers.onEdit(s)}
         />
       </div>
     </div>


### PR DESCRIPTION
## Problem
The small utility-tier slot cards (embedding / reranking / tts / transcription) in the inference pane had **no way to edit or view logs** once created via the UI. Their `MiniCard` rendered `SlotControls` with the `compact` flag — which gates off the Logs/Edit buttons — and never forwarded the `onLogs`/`onEdit` handlers.

## Fix
In `ui/src/dash/inference-pane.jsx`, drop `compact` on `MiniCard`'s `SlotControls` and wire the two handlers that already flow into the component via the shared `handlers` object:

- **Edit** → sets `#slots/<name>`, opening `EditSlotDrawer`
- **Logs** → dispatches `hal0:slot-logs`, opening `SlotLogsDrawer`

No new prop threading needed — `handlers` (incl. `onEdit`/`onLogs`) already reaches `MiniCard`. The four 22px buttons fit the 218px min-width card; the model name already truncates via `flex:1; min-width:0`.

## Testing
No test asserts these buttons are absent; the inference-pane e2e spec only checks util slots route to the support footer (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)