### PR TITLE
feat(slots): configurable slot publish host ([slots].publish_host)

### DIFF
--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -126,6 +126,10 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     "slots.port_range_end": {"apply_class": "immediate", "services": []},
     "slots.idle_timeout_s": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "slots.evict_pressure_mb": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
+    # publish_host is baked into each slot's rendered ExecStart --publish; the
+    # unit re-renders from config on load, so the affected slot units must be
+    # restarted to observe the new bind address.
+    "slots.publish_host": {"apply_class": "service-restart", "services": [SERVICE_SLOTS]},
     # [models]
     "models.roots": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "models.auto_scan_on_start": {"apply_class": "immediate", "services": []},

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1768,6 +1768,42 @@ class SlotsConfig(BaseModel):
             "back above the floor. 0 disables pressure eviction."
         ),
     )
+    publish_host: str = Field(
+        default="127.0.0.1",
+        description=(
+            "Host address slot containers publish their port on "
+            "(``--publish=<host>:<port>:<port>``). Default ``127.0.0.1`` keeps "
+            "slot ports loopback-only, reachable solely through hal0-api/Traefik "
+            "— the safe default. Set to ``0.0.0.0`` to bind every slot on all "
+            "interfaces so raw slot ports are reachable directly over the LAN "
+            "(e.g. ``http://<host>.local:<port>``); this EXPOSES inference "
+            "endpoints on your network, bypassing the API/reverse-proxy front "
+            "door. A specific interface IP (e.g. ``10.0.1.142``) binds just that "
+            "address. Applies on the next slot (re)start. Host-networked slots "
+            "(``network_mode=host``) ignore this — port publishing is a no-op there."
+        ),
+    )
+
+    @field_validator("publish_host")
+    @classmethod
+    def _publish_host_sane(cls, v: str) -> str:
+        """Reject shapes that would break the rendered ``--publish`` token.
+
+        The value lands verbatim in ``--publish=<host>:<port>:<port>`` on the
+        systemd ExecStart line, so a stray space, colon, or newline would
+        corrupt the argv. We don't resolve/validate reachability — an operator
+        may legitimately bind an address that isn't up yet — only that the
+        token is well-formed.
+        """
+        host = str(v).strip()
+        if not host:
+            raise ValueError("[slots].publish_host must not be empty (use 127.0.0.1 for loopback)")
+        if any(c.isspace() for c in host) or ":" in host or "/" in host:
+            raise ValueError(
+                f"[slots].publish_host {host!r} is not a bare IPv4/hostname "
+                "(no spaces, ':', or '/'; IPv6 literals are not supported here)"
+            )
+        return host
 
     @model_validator(mode="after")
     def port_range_sane(self) -> SlotsConfig:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -14,7 +14,12 @@ Container lifecycle → systemd template unit ``hal0-slot@<name>.service``:
 
 The slot's port is loopback-published (``-p 127.0.0.1:<port>:<port>``) so
 the dispatcher can proxy it via a ``kind="remote"`` upstream entry without
-exposing it on the LAN.
+exposing it on the LAN.  The publish host is configurable via
+``[slots].publish_host`` (``SlotsConfig.publish_host``) — an operator can set
+it to ``0.0.0.0`` to reach raw slot ports directly over the LAN
+(``http://<host>.local:<port>``); the loopback default is retained for every
+install that doesn't opt in.  ``load_sync`` reads the live value and passes it
+to :func:`_render_unit_from_plan`; the scalar shims keep the loopback default.
 
 Mount design (IDENTICAL path, design doc §2 gotcha):
   /mnt/ai-models → /mnt/ai-models:ro
@@ -192,6 +197,24 @@ def _container_runtime() -> str:
     )
 
 
+def _slot_publish_host() -> str:
+    """Live ``[slots].publish_host`` — the address slot ports publish on.
+
+    Fail-soft to the loopback default: a malformed/unreadable hal0.toml must
+    never widen the bind (fail-open to 0.0.0.0) nor block a slot from
+    starting. Read fresh each render so a Settings change lands on the next
+    slot (re)start without an api process bounce.
+    """
+    try:
+        from hal0.config.loader import load_hal0_config
+
+        host = (load_hal0_config().slots.publish_host or "").strip()
+        return host or "127.0.0.1"
+    except Exception:
+        log.warning("container.publish_host_load_failed", exc_info=True)
+        return "127.0.0.1"
+
+
 # Health-check tuning: poll GET /health on the slot port.
 _HEALTH_POLL_INTERVAL_S = 2.0
 _HEALTH_TIMEOUT_S = 180.0
@@ -256,6 +279,7 @@ def _render_unit_from_plan(
     plan: RuntimeLaunchPlan,
     *,
     runtime_bin: str | None = None,
+    publish_host: str = "127.0.0.1",
 ) -> str:
     """Render a complete self-contained systemd unit from a launch plan.
 
@@ -274,6 +298,11 @@ def _render_unit_from_plan(
         runtime_bin: Override the container runtime binary.  Defaults to
                      :func:`_container_runtime`.  Pass explicitly in tests to
                      avoid requiring podman/docker in the test environment.
+        publish_host: Host address the slot port is published on
+                     (``--publish=<host>:<port>:<port>``).  Defaults to
+                     ``127.0.0.1`` (loopback-only); ``load_sync`` overrides it
+                     with the live ``[slots].publish_host`` so an operator can
+                     opt into ``0.0.0.0`` (LAN-exposed) or a specific address.
     """
     runtime = runtime_bin or _container_runtime()
     container_name = f"hal0-slot-{slot_name}"
@@ -315,11 +344,13 @@ def _render_unit_from_plan(
         argv.append(f"--volume={Mount.coerce(mount).render()}")
     for k, v in plan.env.items():
         argv.append(f"--env={k}={v}")
-    # Loopback publish derived from plan.port (declarative — plans no longer
-    # hand-roll "-p ..." in extra_args).  Skipped under host networking where
+    # Publish derived from plan.port (declarative — plans no longer
+    # hand-roll "-p ..." in extra_args).  ``publish_host`` defaults to
+    # loopback (127.0.0.1); an operator can widen it to 0.0.0.0 / a specific
+    # address via [slots].publish_host.  Skipped under host networking where
     # port publishing is meaningless.
     if plan.port and plan.network_mode != "host":
-        argv.append(f"--publish=127.0.0.1:{plan.port}:{plan.port}")
+        argv.append(f"--publish={publish_host}:{plan.port}:{plan.port}")
     # Healthcheck override (#684): the toolbox image bakes a HEALTHCHECK that
     # probes a hardcoded port, but a slot runs its server on its own port — so
     # the image check fails forever and `podman ps` shows a permanent
@@ -1020,6 +1051,7 @@ class ContainerProvider(Provider):
             slot_name,
             plan,
             runtime_bin=_container_runtime(),
+            publish_host=_slot_publish_host(),
         )
         self._write_and_start_unit(slot_name, unit_text)
 

--- a/tests/api/test_settings_apply.py
+++ b/tests/api/test_settings_apply.py
@@ -73,6 +73,9 @@ def test_registry_declares_three_apply_classes() -> None:
         ("slots.port_range_end", "immediate", []),
         ("slots.idle_timeout_s", "service-restart", [SERVICE_HAL0_API]),
         ("slots.evict_pressure_mb", "service-restart", [SERVICE_HAL0_API]),
+        # publish_host is baked into each slot's rendered --publish; the slot
+        # units must be restarted to re-render with the new bind address.
+        ("slots.publish_host", "service-restart", [SERVICE_SLOTS]),
         # [models]
         ("models.roots", "service-restart", [SERVICE_HAL0_API]),
         ("models.auto_scan_on_start", "immediate", []),

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -509,6 +509,21 @@ class TestContainerSpec:
         unit = _render_unit_from_plan("test-slot", spec, runtime_bin=_TEST_RUNTIME)
         assert "--publish=127.0.0.1:8095:8095" in unit
 
+    def test_publish_host_default_is_loopback(self) -> None:
+        """Absent a publish_host override the renderer keeps the safe default."""
+        spec = self._build_spec()
+        unit = _render_unit_from_plan("test-slot", spec, runtime_bin=_TEST_RUNTIME)
+        assert "--publish=127.0.0.1:8095:8095" in unit
+
+    def test_publish_host_override_widens_bind(self) -> None:
+        """[slots].publish_host=0.0.0.0 → the slot publishes on all interfaces."""
+        spec = self._build_spec()
+        unit = _render_unit_from_plan(
+            "test-slot", spec, runtime_bin=_TEST_RUNTIME, publish_host="0.0.0.0"
+        )
+        assert "--publish=0.0.0.0:8095:8095" in unit
+        assert "--publish=127.0.0.1:8095:8095" not in unit
+
     def test_network_mode_empty(self) -> None:
         """network_mode must be empty (not 'host') so loopback publish is used."""
         spec = self._build_spec()

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -1534,7 +1534,7 @@ function GeneralSection() {
 const ADV_GROUPS = [
   { title: "Slots runtime", sub: "hal0.toml [slots]", keys: [
     "slots.max_slots", "slots.port_range_start", "slots.port_range_end",
-    "slots.idle_timeout_s", "slots.evict_pressure_mb",
+    "slots.idle_timeout_s", "slots.evict_pressure_mb", "slots.publish_host",
   ]},
   { title: "Dispatcher", sub: "hal0.toml [dispatcher]", keys: [
     "dispatcher.prefetch_timeout_s", "dispatcher.prefetch_parallel_cap",
@@ -1557,6 +1557,10 @@ const ADV_OPTIONS = {
 };
 // Overrides replace the schema description where it's stale or missing.
 const ADV_DESC_OVERRIDE = {
+  "slots.publish_host":
+    "Host address slot ports publish on. 127.0.0.1 = loopback-only (default, safe): slots are reachable only via hal0-api/Traefik. " +
+    "0.0.0.0 exposes every slot's raw port directly on your LAN (e.g. http://<host>.local:<port>), bypassing the reverse-proxy front door — " +
+    "only widen this on a trusted network. A specific interface IP binds just that address. Applies on the next slot restart.",
   "memory.engine":
     "Active memory engine, applied on the next hal0-api restart. hindsight is the durable default. " +
     "pgvector is an in-memory, NON-DURABLE fallback — existing memories are not migrated and won't be visible while selected.",


### PR DESCRIPTION
## What

Slot containers were hardcoded to publish on `127.0.0.1` (loopback-only), so raw slot ports were reachable only via hal0-api/Traefik and never at `http://<host>.local:<port>` directly. This adds a first-class, UI-settable **`[slots].publish_host`** (default `"127.0.0.1"`, unchanged behavior) that an operator can widen to `0.0.0.0` (LAN-exposed) or a specific interface IP.

## Why

On a LAN (e.g. accessing an appliance at `http://<host>.local:<port>`), loopback-only publishing means slot ports aren't reachable without a reverse proxy. This makes the bind address an explicit, opt-in setting instead of a hardcoded default — while keeping every existing install loopback-safe.

## Changes

- **schema** — `SlotsConfig.publish_host` with a validator rejecting tokens that would corrupt the rendered `--publish` (empty / whitespace / `:` / `/`).
- **container** — thread `publish_host` through the single renderer (`_render_unit_from_plan`), sourced at `load_sync` from live config via a fail-soft `_slot_publish_host()` that falls back to loopback (never fails open to `0.0.0.0`, never blocks a slot start). Read per-render, so a change lands on the next slot restart.
- **settings-apply** — register `slots.publish_host` as `service-restart[slots]` (the value is baked into ExecStart; live slots must restart to re-bind).
- **ui** — schema-driven Settings row under *Slots runtime* + a loud description override flagging the LAN-exposure implication.
- **tests** — renderer default + override cases; apply-plan registry row.

## Security note

Default stays `127.0.0.1` — no install changes behavior unless the operator explicitly sets `0.0.0.0`/an IP, which exposes raw slot ports on the network (bypassing the API/reverse-proxy front door). The UI copy calls this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)