### PR TITLE
feat(ui): telemetry-header handoff on the slots page (combined metrics card + NPU occupancy update)

### DIFF
--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -4,12 +4,11 @@
 // (comfyui-pane.jsx). Where ComfyUI models ONE containerized generation
 // engine, this pane is a summary engine-shell over the iGPU/CPU slot stack,
 // implementing the P2 *card* direction from the design handoff
-// (design_handoff_inference_slots/P2-inference-pane.html):
-//   · collapsed = compact hero — iGPU GTT memory map + combined-throughput
-//     tile + the active (serving/ready) slots as compact cards
-//   · expanded  = the same hero pinned on top, then ALL pane slots as full
-//     cards (model picker · tok/s · ttft · ctx · per-slot controls) and a
-//     right-aligned status line
+// (design_handoff_inference_slots/P2-inference-pane.html): ALL pane slots
+// as full cards (model picker · tok/s · ttft · ctx · per-slot controls)
+// and a right-aligned status line. The page-level memory + throughput hero
+// now lives in the TelemetryHeader card (telemetry-header.jsx), mounted by
+// SlotsView above the tabs.
 //
 // NPU/FLM slots are cordoned off to the NPU · FLM stack pane below — they
 // live on the NPU budget, not the GTT carve-out, so they appear in neither
@@ -21,9 +20,7 @@
 //   - useModels()          → the per-slot model picker (full cards)
 //   - useMemoryMapModel()  → per-slot resident memory (real mem_mb) + GTT pool
 //   - useSlot{Restart,Unload,Load,Swap} → real lifecycle mutations
-// Throughput history is a client ring buffer (the ThroughputCard pattern) —
-// the backend exposes no rolling-60s series. Absent metrics render an
-// em-dash; the pane never fabricates a number.
+// Absent metrics render an em-dash; the pane never fabricates a number.
 //
 // Per the design voice: lowercase mono labels, no emoji in the chrome,
 // em-dash for any metric the backend hasn't reported.
@@ -38,7 +35,6 @@ import {
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
-import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
@@ -46,7 +42,7 @@ import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 // and npu-pane.jsx).
 import { devKind } from '@/lib/deviceMeta'
 
-const { useState: useStateI, useRef: useRefI, useEffect: useEffectI } = React
+const { useState: useStateI } = React
 
 // ── icons (16×16, thin-line family — ported from the design's infer-core) ──
 const II = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -155,230 +151,6 @@ function SubLabel({ icon, note, children }) {
           <span className="note">{note}</span>
         </>
       )}
-    </div>
-  )
-}
-
-// ── memory — the iGPU GTT carve-out track (P2's MemDual, iGPU-only) ────────
-// Reuses useMemoryMapModel()'s real per-slot resident memory (mem_mb) and
-// colours. The frame is the GTT pool ceiling (~80 GB carve-out on the
-// appliance); NPU/FLM models are NOT in this bar — they live on the NPU
-// budget. A single honest "system" segment accounts for GTT in use beyond
-// the named model weights (KV cache + runtime + buffers) — no fabricated
-// KV/OS split. Each segment carries a native title (name · GB).
-function MemGtt({ mm, full }) {
-  const pool = mm.pool || {}
-  const self = mm.self || {}
-  const capGb = pool.totalGb || 0
-  const frame = capGb || 1
-  const gpuSegs = (self.slots || [])
-    .filter((s) => (s.device === 'rocm' || s.device === 'vulkan') && s.bytesGb > 0)
-    .sort((a, b) => b.bytesGb - a.bytesGb)
-  const gpuModelGb = gpuSegs.reduce((a, s) => a + s.bytesGb, 0)
-  const gttUsedGb = self.gttUsedGb || 0
-  const systemGb = Math.max(0, round1(gttUsedGb - gpuModelGb))
-  const usedGb = round1(Math.max(gttUsedGb, gpuModelGb))
-  const segs = [
-    ...gpuSegs.map((s) => ({ key: s.name, label: s.name, gb: s.bytesGb, color: s.color })),
-    ...(systemGb > 0
-      ? [{ key: '__sys', label: 'system · KV + runtime', gb: systemGb, color: 'var(--fg-5)' }]
-      : []),
-  ]
-  const freeGb = Math.max(0, round1(frame - usedGb))
-  const pct = (gb) => (gb / frame) * 100
-
-  return (
-    <div className="mem">
-      <SubLabel icon="mem" note={capGb ? `${Math.round(capGb)} GB carve-out` : '—'}>
-        memory · iGPU GTT
-      </SubLabel>
-      <div className="mtrack">
-        <div className="mt-h">
-          <span className="lbl">
-            <span className="dchip vulkan">
-              <span className="d" />
-              iGPU
-            </span>{' '}
-            GTT carve-out
-          </span>
-          <span className="val">
-            <b>{usedGb.toFixed(1)}</b> / {Math.round(capGb)} GB
-          </span>
-        </div>
-        <div className="membar tall" data-testid="infer-membar">
-          {segs.map((s) => (
-            <i
-              key={s.key}
-              className="seg-gap"
-              style={{ width: pct(s.gb) + '%', background: s.color }}
-              title={`${s.label} · ${s.gb} GB`}
-            />
-          ))}
-          <i className="free" style={{ width: Math.max(0, 100 - pct(usedGb)) + '%' }} />
-        </div>
-      </div>
-      {/* Legend is always visible — the memory bar is meaningless without it,
-          even in the collapsed pane (was previously gated on `full`). */}
-      {(
-        <div className="mem-legend">
-          {segs.map((s) => (
-            <div className="ln" key={s.key}>
-              <span className="sw" style={{ background: s.color }} />
-              <span className="nm">{s.label}</span>
-              <span className="gb">
-                <b>{s.gb}</b> GB
-              </span>
-            </div>
-          ))}
-          <div className="ln">
-            <span className="sw free" />
-            <span className="nm">free</span>
-            <span className="gb">
-              <b>{freeGb.toFixed(1)}</b> GB
-            </span>
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── throughput tile (P2's TpTile) ──────────────────────────────────────────
-function SparkBars({ data = [], hotN = 4 }) {
-  const max = Math.max(...data, 1)
-  if (!data.length) return <div className="spark2" />
-  return (
-    <div className="spark2">
-      {data.map((v, i) => (
-        <i
-          key={i}
-          className={i >= data.length - hotN ? 'hot' : ''}
-          style={{ height: (v / max) * 100 + '%' }}
-        />
-      ))}
-    </div>
-  )
-}
-
-function TpTile({ value, ticks, peak, servingN, prefillMs }) {
-  return (
-    <div className="tp-tile" data-testid="infer-tp">
-      <div className="blk-h" style={{ margin: 0 }}>
-        <span className="ic">
-          <Ic name="activity" size={13} />
-        </span>{' '}
-        combined throughput
-      </div>
-      <div className="tp-row">
-        <div className="tp tp-mid">
-          <div className="tp-num">
-            {value == null ? '—' : value}
-            <span className="u">tok/s</span>
-          </div>
-        </div>
-        <div className="tp-aside">
-          <span>{peak == null ? 'peak —' : `peak ${peak}`}</span>
-          <span className="pk">{servingN} serving</span>
-        </div>
-      </div>
-      <SparkBars data={ticks} />
-      <div className="tp-prefill" data-testid="infer-prefill">
-        <span className="pf-lbl">prefill</span>
-        <span className="pf-val">
-          {prefillMs == null ? '—' : prefillMs}
-          {prefillMs != null && <span className="u">ms ttft</span>}
-        </span>
-      </div>
-    </div>
-  )
-}
-
-// ── iGPU usage gauge (270° radial) ──────────────────────────────────────
-// Same SVG semicircle as the NPU (purple) and ComfyUI (blue) panes; here it
-// carries the iGPU device hue (--dev-rocm) and reads live GPU usage off
-// /api/stats/hardware. `pct` null → renders an em-dash (never a fake 0).
-function Gauge({ pct, label, sub, size = 132 }) {
-  const sw = Math.round(size * 0.065)
-  const r = size / 2 - sw - 4
-  const cx = size / 2
-  const cy = size / 2
-  const C = 2 * Math.PI * r
-  const arc = C * 0.75 // 270° sweep
-  const p = Math.max(0, Math.min(1, (pct || 0) / 100))
-  const fill = p * arc
-  return (
-    <div className="gauge" style={{ width: size, height: size }}>
-      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
-        <circle
-          className="gtrack"
-          cx={cx}
-          cy={cy}
-          r={r}
-          strokeWidth={sw}
-          strokeDasharray={`${arc} ${C}`}
-          strokeLinecap="round"
-          transform={`rotate(135 ${cx} ${cy})`}
-        />
-        <circle
-          className="gfill"
-          cx={cx}
-          cy={cy}
-          r={r}
-          strokeWidth={sw}
-          strokeDasharray={`${fill} ${C}`}
-          transform={`rotate(135 ${cx} ${cy})`}
-        />
-      </svg>
-      <div className="gc">
-        <div className="pct">
-          {pct == null ? '—' : Math.round(pct)}
-          {pct != null && <span className="s">%</span>}
-        </div>
-        <div className="lbl">{label}</div>
-        {sub ? <div className="sub">{sub}</div> : null}
-      </div>
-    </div>
-  )
-}
-
-// iGPU usage tile for the hero band — gauge of GPU compute %, captioned with
-// the live shader clock (MHz) and edge temperature (°C). Forced-high perf
-// pinning (gpu-compute.service) makes the % unreliable; we tag it "pinned"
-// so the reading is captioned, not silently trusted (mirrors the backend
-// util_is_forced_high contract).
-function GpuGauge() {
-  const hw = useStatsHardware()
-  const d = hw.data || {}
-  const util = typeof d.gpu_util === 'number' ? d.gpu_util : null
-  const pct = util == null ? null : util * 100
-  const mhz = typeof d.gpu_clock_mhz === 'number' && d.gpu_clock_mhz > 0 ? d.gpu_clock_mhz : null
-  const temp = typeof d.gpu_temp_c === 'number' ? d.gpu_temp_c : null
-  const forced = !!d.util_is_forced_high
-  return (
-    <div className="gpu-gauge-tile" data-testid="infer-gpu-gauge">
-      <div className="blk-h" style={{ margin: 0 }}>
-        <span className="ic">
-          <Ic name="mem" size={13} />
-        </span>{' '}
-        igpu usage{forced ? ' · pinned' : ''}
-      </div>
-      <Gauge pct={pct} label="igpu" />
-      <div className="gpu-readout">
-        <div className="st">
-          <div className="sv">
-            {mhz == null ? '—' : mhz}
-            {mhz != null && <span className="u">MHz</span>}
-          </div>
-          <div className="sl">clock</div>
-        </div>
-        <div className="st">
-          <div className="sv">
-            {temp == null ? '—' : Math.round(temp)}
-            {temp != null && <span className="u">°C</span>}
-          </div>
-          <div className="sl">temp</div>
-        </div>
-      </div>
     </div>
   )
 }
@@ -741,64 +513,9 @@ function MiniCards({ rows, busyName, handlers }) {
   )
 }
 
-// Page-level hero band — the iGPU GTT memory map + combined-throughput tile,
-// lifted out of the Inference engine shell so it sits at the very top of the
-// Slots page (above the Inference ⇄ Image Gen tabs) and stays visible across
-// tabs. Self-contained: owns its own slots/memory queries + throughput ring
-// buffer, so SlotsView can drop it in without threading any state down. Wrapped
-// in `.infer-pane .proto` so it inherits the pane's accent vars + box-sizing
-// and reuses the existing .hero-band / .mem / .tp styling verbatim.
-export function InferenceHeroBand() {
-  const slotsQuery = useSlots()
-  const mm = useMemoryMapModel()
-
-  const allSlots = slotsQuery.data || []
-  const nonImg = allSlots.filter((s) => String(s?.type) !== 'image')
-  const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
-  const rows = slots.map((s) => ({ s, ind: slotIndicatorFromPhase(s) }))
-  const servingN = rows.filter((r) => r.ind.cls === 'serving').length
-
-  // Combined throughput — summed tok/s across this pane's serving slots, with a
-  // client ring buffer for the spark (the backend exposes no rolling series).
-  const toksVals = slots
-    .map((s) => s?.metrics?.toks)
-    .filter((t) => typeof t === 'number' && t > 0)
-  const value = toksVals.length ? Math.round(toksVals.reduce((a, b) => a + b, 0)) : null
-  const historyRef = useRefI([])
-  const lastRef = useRefI(null)
-  const [, force] = useStateI(0)
-  useEffectI(() => {
-    if (value == null) return
-    if (lastRef.current === value) return
-    lastRef.current = value
-    historyRef.current = [...historyRef.current, value].slice(-21)
-    force((n) => n + 1)
-  }, [value])
-  const ticks = historyRef.current
-  const peak = ticks.length ? Math.max(...ticks) : null
-
-  // Combined prefill — avg TTFT (ms) across this pane's serving slots. The
-  // backend deliberately doesn't scrape a prompt-eval rate, so TTFT is the
-  // available prefill signal (slot.metrics.ttft). null → em-dash, never 0.
-  const ttftVals = slots
-    .map((s) => s?.metrics?.ttft)
-    .filter((t) => typeof t === 'number' && t > 0)
-  const prefillMs = ttftVals.length
-    ? Math.round(ttftVals.reduce((a, b) => a + b, 0) / ttftVals.length)
-    : null
-
-  return (
-    <div className="infer-pane infer-hero-top" data-testid="infer-hero-band">
-      <div className="proto">
-        <div className="hero-band">
-          <MemGtt mm={mm} full />
-          <GpuGauge />
-          <TpTile value={value} ticks={ticks} peak={peak} servingN={servingN} prefillMs={prefillMs} />
-        </div>
-      </div>
-    </div>
-  )
-}
+// The page-level hero band (iGPU GTT memory map + combined-throughput tile)
+// was replaced by the TelemetryHeader card (telemetry-header.jsx) at the top
+// of SlotsView — its MemGtt / GpuGauge / TpTile tiles went with it.
 
 export function InferencePane() {
   const slotsQuery = useSlots()
@@ -928,7 +645,7 @@ export function InferencePane() {
 
           {/* All slots as full cards — always visible (freed from the old
               collapse/expand accordion). The memory + throughput hero now lives
-              in the page-level InferenceHeroBand above the tabs. */}
+              in the page-level TelemetryHeader card above the tabs. */}
           <div className="engine-b" data-testid="infer-slots">
             <div>
               <SubLabel
@@ -988,4 +705,4 @@ export function InferencePane() {
   )
 }
 
-Object.assign(window, { InferencePane, InferenceHeroBand })
+Object.assign(window, { InferencePane })

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -384,7 +384,7 @@ export function NpuOccupancyCard({ slots }) {
   }
 
   const dutySub = colsAvailable
-    ? `${colsUsed}/${colsTotal} columns claimed`
+    ? `${colsUsed}/${colsTotal} columns`
     : 'column probe unavailable'
 
   // slots-live count = slots the occupancy probe reports as actually

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -64,9 +64,9 @@ const isNpuSlot = (s) => s.device_class === 'npu' || devKind(s.device) === 'npu'
 // usually shows just the first. The hue fills the slot's claimed columns in the
 // grid AND its mini column strip; glow/line drive the active-tile halo.
 const HUES = [
-  { hue: 'var(--npu-s0)', glow: 'var(--npu-s0-glow)', line: 'var(--npu-s0-line)', dim: 'var(--npu-s0-dim)' },
-  { hue: 'var(--npu-s1)', glow: 'var(--npu-s1-glow)', line: 'var(--npu-s1-line)', dim: 'var(--npu-s1-dim)' },
-  { hue: 'var(--npu-s2)', glow: 'var(--npu-s2-glow)', line: 'var(--npu-s2-line)', dim: 'var(--npu-s2-dim)' },
+  { hue: 'var(--npu-s0)', glow: 'var(--npu-s0-glow)', line: 'var(--npu-s0-line)', dim: 'var(--npu-s0-dim)', fg: 'var(--npu-s0-fg)' },
+  { hue: 'var(--npu-s1)', glow: 'var(--npu-s1-glow)', line: 'var(--npu-s1-line)', dim: 'var(--npu-s1-dim)', fg: 'var(--npu-s1-fg)' },
+  { hue: 'var(--npu-s2)', glow: 'var(--npu-s2-glow)', line: 'var(--npu-s2-line)', dim: 'var(--npu-s2-dim)', fg: 'var(--npu-s2-fg)' },
 ]
 
 // honour reduced-motion → frozen snapshot (no breathing, no glow pulse)
@@ -277,7 +277,7 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0 }) {
   const gb = occ && typeof occ.gb === 'number' ? round1(occ.gb) : typeof m.mem === 'number' ? round1(m.mem) : null
   const model = String(slot.model_id || slot.model || occ?.model || '').replace(/-FLM$/, '')
   return (
-    <div className={'cslot' + (serving ? '' : ' dim')} style={{ '--slot-hue': hue.hue }}>
+    <div className={'cslot' + (serving ? '' : ' dim')} style={{ '--slot-hue': hue.hue, '--slot-fg': hue.fg }}>
       <div className="cslot-top">
         <span className={'ldot ' + (serving ? 'serving' : ind.cls === 'error' ? 'offline' : 'ready')} />
         <span className="nm">{slot.name}</span>
@@ -387,6 +387,10 @@ export function NpuOccupancyCard({ slots }) {
     ? `${colsUsed}/${colsTotal} columns claimed`
     : 'column probe unavailable'
 
+  // slots-live count = slots the occupancy probe reports as actually
+  // holding columns (a slot with an empty cols[] is resident but not live).
+  const liveCount = occSlots.filter((s) => (s.cols || []).length > 0).length
+
   return (
     <div className="npu-card">
       <div className="wcard">
@@ -402,7 +406,12 @@ export function NpuOccupancyCard({ slots }) {
           <span className="grow" />
           <span className="meta">
             <b>{colsUsed * NPU_ROWS}</b>/{tiles} tiles claimed · <b>{NPU_ROWS}×{NPU_COLS}</b> AIE-ML
-            {occ.single_tenant !== false && <span className="st"> · single-tenant</span>}
+            {/* telemetry-header handoff: the meta leads with how many slots
+                actually hold columns; single-tenant only shows when nothing
+                is live (once slots claim columns the free card carries it) */}
+            {liveCount > 0
+              ? <span className="st"> · {liveCount} slot{liveCount !== 1 ? 's' : ''} live</span>
+              : occ.single_tenant !== false && <span className="st"> · single-tenant</span>}
           </span>
         </div>
         <div className="wcard-b">
@@ -442,16 +451,22 @@ export function NpuOccupancyCard({ slots }) {
                   act={act}
                 />
               ))}
-              {colsUsed < colsTotal && (
-                <div className="cslot free">
-                  <div className="cslot-top">
-                    <span className="sw free" />
-                    <span className="nm">free</span>
-                    <span className="grow" />
-                    <span className="md">{colsTotal - colsUsed} columns · idle</span>
-                  </div>
+              {/* third owner hue stays reserved — the dashed free card
+                  renders even at 0 free columns ("array full") so the
+                  single-tenant ceiling stays visible (handoff screen 2) */}
+              <div className="cslot free">
+                <div className="cslot-top">
+                  <span className="sw free" />
+                  <span className="nm">free</span>
+                  <span className="grow" />
+                  <span className="md">
+                    {colsTotal - colsUsed} columns ·{' '}
+                    {colsUsed >= colsTotal && occ.single_tenant !== false
+                      ? 'single-tenant array full'
+                      : 'idle'}
+                  </span>
                 </div>
-              )}
+              </div>
             </div>
           </div>
         </div>

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -2,15 +2,41 @@
  *
  * The NPU is an AMD XDNA 2 (Ryzen AI) inference engine: a 4×8 = 32 AIE-ML
  * tile array, partitioned by columns, running FLM slots. This sheet owns the
- * PURPLE device accent (--dev-npu) — the NPU's stable hue — and rations amber
- * (--accent) to the single live throughput number, as the rest of the product
- * rations amber to "live / primary".
+ * PURPLE device accent (--dev-npu) — the NPU's stable hue. Throughput
+ * readouts on this card are tinted --dev-npu (telemetry-header handoff);
+ * amber stays reserved for the product-wide "live / primary" accents.
  *
  * Everything is scoped under .npu-card so the generic class names (.combo,
  * .aie-tile, .gauge…) can't collide with other panes. Slot-control buttons
  * (.sctrl / .slot-ctrls) are intentionally NOT redefined here — they reuse the
  * shared definitions in engine-panes.css, whose selector includes .npu-card
  * so the buttons match the inference/comfyui slot cards exactly. */
+
+/* per-slot owner accents — assigned by slot index (npu-pane HUES). These
+   fill the slot's claimed columns (grid + mini strip + partition bars) and
+   are SHARED with the dashboard telemetry header's NPU cell, so they live
+   on :root rather than .npu-card. The glow/line halos are deliberately
+   *lightened* tints of each base so the colours (esp. the dark indigo s0)
+   read as a halo against the dark grid; the -fg tints are the same
+   lightened hues at full alpha, used for owner-tinted text (per-slot
+   tok/s, partition labels, owner tags). */
+:root {
+  --npu-s0: #4a4466; /* slot 0 — deep indigo */
+  --npu-s0-dim: rgba(74, 68, 102, 0.2);
+  --npu-s0-glow: rgba(138, 130, 184, 0.62); /* lightened indigo halo */
+  --npu-s0-line: rgba(138, 130, 184, 0.5);
+  --npu-s0-fg: #8a82b8; /* solid lightened indigo — text tint */
+  --npu-s1: #6eadbc; /* slot 1 — teal */
+  --npu-s1-dim: rgba(110, 173, 188, 0.2);
+  --npu-s1-glow: rgba(140, 205, 220, 0.62);
+  --npu-s1-line: rgba(140, 205, 220, 0.5);
+  --npu-s1-fg: #8ccddc;
+  --npu-s2: #9fcbad; /* slot 2 — sage */
+  --npu-s2-dim: rgba(159, 203, 173, 0.2);
+  --npu-s2-glow: rgba(183, 224, 196, 0.62);
+  --npu-s2-line: rgba(183, 224, 196, 0.5);
+  --npu-s2-fg: #9fcbad;
+}
 
 .npu-card {
   --npu: var(--dev-npu); /* #c896ff — NPU device hue, the card accent */
@@ -25,23 +51,6 @@
   --npu-b-dim: rgba(104, 112, 149, 0.18);
   --npu-b-glow: rgba(104, 112, 149, 0.5);
   --npu-b-line: rgba(104, 112, 149, 0.45);
-
-  /* per-slot owner accents — assigned by slot index in npu-pane HUES. These
-     fill the slot's claimed columns (grid + mini strip). The glow/line halos
-     are deliberately *lightened* tints of each base so the colours (esp. the
-     dark indigo s0) read as a halo against the dark grid. */
-  --npu-s0: #4a4466; /* slot 0 — deep indigo */
-  --npu-s0-dim: rgba(74, 68, 102, 0.2);
-  --npu-s0-glow: rgba(138, 130, 184, 0.62); /* lightened indigo halo */
-  --npu-s0-line: rgba(138, 130, 184, 0.5);
-  --npu-s1: #6eadbc; /* slot 1 — teal */
-  --npu-s1-dim: rgba(110, 173, 188, 0.2);
-  --npu-s1-glow: rgba(140, 205, 220, 0.62);
-  --npu-s1-line: rgba(140, 205, 220, 0.5);
-  --npu-s2: #9fcbad; /* slot 2 — sage */
-  --npu-s2-dim: rgba(159, 203, 173, 0.2);
-  --npu-s2-glow: rgba(183, 224, 196, 0.62);
-  --npu-s2-line: rgba(183, 224, 196, 0.5);
 }
 .npu-card * {
   box-sizing: border-box;
@@ -257,8 +266,10 @@
   margin-left: 3px;
   letter-spacing: 0;
 }
+/* throughput readout — tinted with the NPU device hue, not amber
+   (telemetry-header handoff: amber stays the product-wide live accent) */
 .npu-card .aie-stat .sv.acc {
-  color: var(--accent);
+  color: var(--npu);
 }
 .npu-card .aie-stat .sl {
   font-family: var(--jbm);
@@ -532,9 +543,13 @@
   flex-shrink: 0;
 }
 .npu-card .cslot-mx .tps {
-  font-size: 14.5px;
+  /* enlarged + tinted with the slot's own owner hue fg tint (--slot-fg is
+     set per-card in npu-pane ComboSlot; --npu-b is the pre-handoff
+     fallback for a card that carries no owner hue) */
+  font-size: 17px;
   font-weight: 500;
-  color: var(--npu-b);
+  font-feature-settings: 'tnum' 1;
+  color: var(--slot-fg, var(--npu-b));
 }
 .npu-card .cslot-mx .tps .u {
   font-size: 9px;

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -1428,3 +1428,421 @@
   color: var(--fg-5);
   line-height: 1.4;
 }
+
+/* ─── telemetry header (design_handoff_telemetry_header) ─────────────────── */
+/* Full-width combined live-metrics card (telemetry-header.jsx), mounted at
+   the top of the Slots page: four auto-fit cells over the memory rack
+   ruler. The 1px gap on a line-soft background draws the hairline dividers
+   and lets cells wrap 4→2→1 at narrow widths — cells never clip. One house
+   easing everywhere (--ease = cubic-bezier(.22,1,.36,1)); pulse only on
+   live dots; npuTilePulse keyframes come from npu.css. */
+
+.th-card {
+  border: 1px solid var(--line);
+  border-radius: var(--rad-lg, 10px);
+  background: var(--bg-1);
+  overflow: hidden;
+}
+.th-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1px;
+  background: var(--line-soft);
+}
+.th-cell {
+  padding: 14px 18px 12px;
+  background: var(--bg-1);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.th-cell.th-cell-tps { gap: 8px; }
+
+/* eyebrow — 6px device dot + uppercase JBM label + lowercase sublabel */
+.th-eyebrow {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  font-family: var(--jbm);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-4);
+  min-width: 0;
+}
+/* the label never wraps — only the sublabel gives way (ellipsis) */
+.th-eyebrow > span { white-space: nowrap; }
+.th-eyebrow .d {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+/* liveness is the pulsing dot — no "active" pill anywhere in the strip */
+.th-eyebrow .d.live {
+  box-shadow: 0 0 8px currentColor;
+  animation: pulse 1.2s var(--ease) infinite;
+}
+.th-eyebrow .sub {
+  text-transform: lowercase;
+  letter-spacing: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.th-eyebrow .right {
+  margin-left: auto;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* cell 1 — throughput hero + 20-bucket spark strip */
+.th-hero-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: 0;
+}
+.th-hero {
+  font-family: var(--jbm);
+  font-size: 34px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--accent);
+  font-feature-settings: 'zero' 1, 'tnum' 1;
+}
+.th-hero.dim { color: var(--fg-4); }
+.th-spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 30px;
+  flex: 1;
+  min-width: 0;
+}
+.th-spark i {
+  display: block;
+  flex: 1;
+  min-height: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+  transition: height 0.5s var(--ease);
+}
+.th-spark i.pad { opacity: 0.15; }
+.th-sub {
+  font-family: var(--jbm);
+  font-size: 10.5px;
+  color: var(--fg-4);
+}
+.th-sub .g { color: var(--fg-2); }
+.th-sub .n { color: var(--dev-npu); }
+.th-sub .s { color: var(--fg-3); }
+
+/* shared cell body row: gauge | digit grid */
+.th-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 0;
+}
+
+/* semicircle gauge — center values are HTML overlays, not SVG <text> */
+.th-gauge {
+  position: relative;
+  width: 118px;
+  height: 68px;
+  flex: none;
+}
+.th-gauge svg { display: block; }
+.th-gauge path {
+  fill: none;
+  stroke-width: 7;
+  stroke-linecap: round;
+}
+.th-gauge .track { stroke: var(--bg-3); }
+.th-gauge .fill { transition: stroke-dasharray 0.6s var(--ease); }
+.th-gauge-c {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  pointer-events: none;
+}
+.th-gauge-v {
+  font-family: var(--jbm);
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.1;
+  color: var(--fg);
+  font-feature-settings: 'tnum' 1;
+}
+.th-gauge-v.sm {
+  font-size: 16px;
+  line-height: 1.2;
+}
+.th-gauge-cap {
+  font-family: var(--jbm);
+  font-size: 8px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-5);
+  white-space: nowrap;
+}
+
+/* metric digits — 3-col (GPU) / 2-col (CPU) grids */
+.th-digits {
+  display: grid;
+  gap: 14px;
+  flex: 1;
+  min-width: 0;
+}
+.th-digits.c3 { grid-template-columns: repeat(3, 1fr); }
+.th-digits.c2 { grid-template-columns: repeat(2, 1fr); }
+.th-digit .v {
+  font-family: var(--jbm);
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.1;
+  color: var(--fg);
+  font-feature-settings: 'tnum' 1;
+}
+.th-digit .v.warn { color: var(--warn); }
+.th-digit .v.sec { color: var(--fg-2); }
+.th-digit .cap {
+  font-family: var(--jbm);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-5);
+  margin-top: 5px;
+}
+/* aligns the temp caption with util's caption after its micro-bar */
+.th-digit .cap.push { margin-top: 19px; }
+.th-microbar {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--bg-3);
+  margin-top: 7px;
+  overflow: hidden;
+}
+.th-microbar i {
+  display: block;
+  height: 100%;
+  background: var(--dev-cpu);
+  transition: width 0.5s var(--ease);
+}
+
+/* cell 4 — compact AIE occupancy grid + partition bars + owner tags */
+.th-npu {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+}
+.th-aie {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: none;
+}
+.th-aie-grid {
+  display: grid;
+  gap: 3px;
+  grid-auto-flow: column; /* filled column-by-column, like the array */
+}
+.th-aie-grid i {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: var(--bg-3);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+/* claimed tiles breathe via npu.css npuTilePulse (opacity .5→.95), each
+   with a randomized 2.2–4.8s duration + negative delay so they desync */
+.th-aie-grid i.on {
+  opacity: 0.82;
+  --lo: 0.5;
+  --hi: 0.95;
+  animation: npuTilePulse var(--dur, 3s) ease-in-out var(--delay, 0s) infinite;
+}
+.th-aie-parts {
+  display: flex;
+  gap: 3px;
+}
+.th-aie-part {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.th-aie-part .br {
+  height: 3px;
+  border-radius: 2px;
+}
+.th-aie-part .pl {
+  font-family: var(--jbm);
+  font-size: 9px;
+  line-height: 1;
+  white-space: nowrap;
+}
+.th-aie-part .pl .pc { color: var(--fg-5); }
+.th-npu-right {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+  min-width: 0;
+}
+.th-npu-nums {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+}
+.th-npu-num {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+}
+.th-npu-num .v {
+  font-family: var(--jbm);
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.1;
+  color: var(--fg);
+  font-feature-settings: 'tnum' 1;
+}
+.th-npu-num .v.npu { color: var(--dev-npu); }
+.th-npu-num .u {
+  font-family: var(--jbm);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-5);
+}
+.th-tags {
+  display: flex;
+  gap: 5px;
+}
+.th-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 36px;
+  min-height: 18px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-family: var(--jbm);
+  font-size: 10px;
+}
+.th-tag .sw {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+}
+/* unused owner hue — dashed placeholder, blank */
+.th-tag.off {
+  border: 1px dashed var(--line-strong);
+  background: transparent;
+}
+.th-npu-cap {
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  color: var(--fg-5);
+}
+
+/* memory rack ruler — full-width second row; absorbs the memory-map band */
+.th-ruler {
+  padding: 14px 18px 16px;
+  border-top: 1px solid var(--line-soft);
+}
+.th-ruler-h {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-3);
+  margin-bottom: 8px;
+}
+.th-ruler-h b {
+  color: var(--fg);
+  font-weight: 500;
+  font-feature-settings: 'tnum' 1;
+}
+.th-ruler-h b.ok { color: var(--ok); }
+.th-ruler-h .lim { color: var(--fg-5); }
+.th-ruler-wrap { position: relative; }
+.th-ruler-bar {
+  display: flex;
+  height: 28px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--bg-3);
+  border: 1px solid var(--line-soft);
+}
+/* segments are border-box and only take padding when wide enough for a
+   label — tiny segments (embed, npu) stay true to the GB scale */
+.th-ruler-seg {
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: width 0.5s var(--ease);
+}
+.th-ruler-seg.pad { padding: 0 8px; }
+.th-ruler-seg .nm {
+  font-family: var(--jbm);
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(0, 0, 0, 0.75);
+}
+.th-ruler-seg .gb {
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  color: rgba(0, 0, 0, 0.55);
+  margin-left: 6px;
+}
+.th-ruler-free {
+  height: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-5);
+}
+/* used marker — 2px amber line at used/cap %, 3px above/below the bar */
+.th-ruler-marker {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: var(--accent);
+  transition: left 0.5s var(--ease);
+}
+.th-ruler-ticks {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--jbm);
+  font-size: 9.5px;
+  color: var(--fg-5);
+  margin-top: 5px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .th-eyebrow .d.live,
+  .th-aie-grid i.on {
+    animation: none !important;
+  }
+}

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -23,12 +23,12 @@ import { ComfyuiPane } from './comfyui-pane.jsx'
 import { NpuOccupancyCard } from './npu-pane.jsx'
 import {
   InferencePane,
-  InferenceHeroBand,
   SlotScard,
   ModelPicker,
   SlotControls,
   slotCtrlPhase,
 } from './inference-pane.jsx'
+import { TelemetryHeader } from './telemetry-header.jsx'
 import { slotIndicatorFromPhase, slotButtonPhase, isSlotLive } from './slot-status.js'
 import { prettyProfile } from './profile-names.js'
 
@@ -882,10 +882,12 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         <button className="btn" onClick={() => setCreateOpen(true)}>{Icons.plus} New slot</button>
       </div>
 
-      {/* Memory map + combined-throughput band — lifted out of the Inference
-          engine shell to the top of the page, above the tabs, so iGPU GTT usage
-          and live throughput stay visible regardless of which tab is active. */}
-      <InferenceHeroBand />
+      {/* Telemetry header — the combined live-metrics card (throughput / GPU /
+          CPU·memory / NPU cells + memory rack ruler) at the top of the page,
+          above the tabs, so system load stays visible regardless of which tab
+          is active. Replaces the old InferenceHeroBand (memory map +
+          combined-throughput band). */}
+      <TelemetryHeader />
 
       {/* Inference ⇄ Image Gen tabs. Tab 1 holds every non-image slot; tab 2 is
           the ComfyUI generation engine pane (one container, not per-model

--- a/ui/src/dash/telemetry-header.jsx
+++ b/ui/src/dash/telemetry-header.jsx
@@ -1,0 +1,456 @@
+// hal0 dashboard — telemetry header (design_handoff_telemetry_header).
+//
+// Full-width combined live-metrics card: four auto-fit cells (Throughput
+// hero + spark · GPU semicircle gauge + digits · CPU/Memory gauge + digits
+// · NPU AIE occupancy) above a full-width memory "rack ruler". Mounted at
+// the top of the Slots page (SlotsView), where it replaces the old
+// InferenceHeroBand (iGPU GTT memory map + combined-throughput tile).
+//
+// Data comes ONLY from the existing hooks; the honesty rules from
+// metric-cards.jsx carry over — absent metric → em-dash (never 0%), 404
+// endpoint → "source pending", a measured 0.0 tok/s always renders with
+// the explicit serving count, and a forced-high GPU util reading is
+// captioned "pinned" (util_is_forced_high contract), never silently
+// trusted. Column allocation in the NPU cell comes from
+// useNpuOccupancy().slots[].cols — never hardcoded.
+//
+// Styles: overhaul.css (th-*). Owner hues: the :root --npu-s0/s1/s2 token
+// sets from npu.css (shared with the slots-page NpuOccupancyCard).
+
+import { useSlots } from '@/api/hooks/useSlots'
+import { useHardware } from '@/api/hooks/useHardware'
+import { useStatsHardware } from '@/api/hooks/useStatsHardware'
+import { useStatsPower } from '@/api/hooks/useStatsPower'
+import { useThroughputHistory } from '@/api/hooks/useThroughputHistory'
+import { useNpuOccupancy } from '@/api/hooks/useNpuOccupancy'
+import { useMemoryMapModel } from './memory-map'
+import { devKind } from '@/lib/deviceMeta'
+
+const round1 = (n) => Math.round((n || 0) * 10) / 10
+const fmt1 = (n) => (typeof n === 'number' ? n.toFixed(1) : '—')
+const isNpuDev = (s) => s.device_class === 'npu' || devKind(s.device) === 'npu'
+// Measured tok/s sum over a slot subset — only real positive readings count.
+const sumToks = (list) =>
+  list
+    .map((s) => s?.metrics?.toks)
+    .filter((t) => typeof t === 'number' && t > 0)
+    .reduce((a, b) => a + b, 0)
+// Deterministic per-tile hash → [0,1), stable across renders (mirrors the
+// npu-pane pattern — the desync is decorative, never claimed as per-tile load).
+const hash01 = (n) => {
+  const x = Math.sin(n) * 43758.5453
+  return x - Math.floor(x)
+}
+
+// Owner hues shared with the slots-page NPU card — tokens live on :root in
+// npu.css (npu-pane HUES mirrors this table).
+const TH_HUES = [
+  { hue: 'var(--npu-s0)', line: 'var(--npu-s0-line)', glow: 'var(--npu-s0-glow)', dim: 'var(--npu-s0-dim)', fg: 'var(--npu-s0-fg)' },
+  { hue: 'var(--npu-s1)', line: 'var(--npu-s1-line)', glow: 'var(--npu-s1-glow)', dim: 'var(--npu-s1-dim)', fg: 'var(--npu-s1-fg)' },
+  { hue: 'var(--npu-s2)', line: 'var(--npu-s2-line)', glow: 'var(--npu-s2-glow)', dim: 'var(--npu-s2-dim)', fg: 'var(--npu-s2-fg)' },
+]
+
+// Semicircle gauge — SVG arc, but the center value is an HTML overlay
+// (absolutely positioned flex column, bottom-aligned), NOT SVG <text>.
+function SemiGauge({ pct, stroke, value, valueSmall, caption }) {
+  const dash = pct == null ? 0 : Math.max(0, Math.min(100, pct))
+  return (
+    <div className="th-gauge">
+      <svg width="118" height="68" viewBox="0 0 100 57">
+        <path className="track" d="M8 52 A42 42 0 0 1 92 52" pathLength="100" />
+        <path
+          className="fill"
+          d="M8 52 A42 42 0 0 1 92 52"
+          pathLength="100"
+          style={{ stroke, strokeDasharray: `${dash} 100` }}
+        />
+      </svg>
+      <div className="th-gauge-c">
+        <span className={'th-gauge-v' + (valueSmall ? ' sm' : '')}>{value}</span>
+        <span className="th-gauge-cap">{caption}</span>
+      </div>
+    </div>
+  )
+}
+
+// Eyebrow row every cell leads with: 6px device dot + uppercase label +
+// lowercase sublabel. `live` adds the glow + pulse (NPU only — the pulsing
+// dot carries liveness; there is no "active" pill).
+function ThEyebrow({ dot, live, label, sub, right }) {
+  return (
+    <div className="th-eyebrow">
+      {dot && <span className={'d' + (live ? ' live' : '')} style={{ background: dot, color: dot }} />}
+      <span>{label}</span>
+      {sub && <span className="sub">{sub}</span>}
+      {right && <span className="right">{right}</span>}
+    </div>
+  )
+}
+
+// Cell 1 · THROUGHPUT — hero number + 20-bucket spark strip. Same gating
+// as ThroughputCard2: history pending/empty → "source pending" body, no
+// fabricated bars ever. The gpu/npu split in the sub-row is the measured
+// per-slot tok/s from the live slot poll.
+function ThCellThroughput({ slots }) {
+  const { data, isPending } = useThroughputHistory()
+  const samples = data?.samples ?? []
+  const latest = samples.length > 0 ? samples[samples.length - 1] : null
+  const hasReading = latest != null && typeof latest.total_tps === 'number'
+  const heroTps = hasReading ? latest.total_tps : null
+  const serving = hasReading ? (latest.serving_slots ?? 0) : null
+
+  const bars = samples.slice(-20)
+  const maxTps = bars.length > 0 ? Math.max(...bars.map((s) => s.total_tps), 1) : 1
+
+  const npuTps = sumToks((slots || []).filter(isNpuDev))
+  const gpuTps = sumToks((slots || []).filter((s) => !isNpuDev(s)))
+
+  return (
+    <div className="th-cell th-cell-tps">
+      <ThEyebrow label="Throughput" right="tok/s" />
+      {isPending ? (
+        <div className="mc-pending">
+          <span className="mc-pending-label">source pending</span>
+          <span className="mc-pending-sub">waiting for throughput history</span>
+        </div>
+      ) : (
+        <>
+          <div className="th-hero-row">
+            <span className={'th-hero' + (heroTps != null ? '' : ' dim')}>{fmt1(heroTps)}</span>
+            <div className="th-spark">
+              {/* pad on the LEFT so the newest sample stays on the right edge */}
+              {bars.length < 20 &&
+                Array.from({ length: 20 - bars.length }).map((_, i) => (
+                  <i key={`pad-${i}`} className="pad" style={{ height: '2%' }} />
+                ))}
+              {bars.map((s, i) => (
+                <i
+                  key={s.ts}
+                  style={{
+                    height: `${Math.max((s.total_tps / maxTps) * 100, 4)}%`,
+                    opacity: i >= bars.length - 4 ? 1 : 0.35 + (i / bars.length) * 0.45,
+                  }}
+                  title={`${fmt1(s.total_tps)} tok/s`}
+                />
+              ))}
+            </div>
+          </div>
+          {/* Sub-row ALWAYS renders with a real reading so a measured 0.0
+              is disambiguated by the explicit serving count (#221). */}
+          {hasReading && (
+            <div className="th-sub">
+              gpu <span className="g">{fmt1(gpuTps)}</span> · npu <span className="n">{fmt1(npuTps)}</span> ·{' '}
+              <span className="s">{serving} slot{serving !== 1 ? 's' : ''} serving</span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// Cell 2 · GPU — semicircle util gauge + sclk / temp / watts digits.
+// Forced-high perf pinning (gpu-compute.service) makes the util % unreliable;
+// the gauge caption carries "pinned" so the reading is never silently trusted
+// (util_is_forced_high, same contract the old GpuGauge tile honoured).
+function ThCellGpu() {
+  const hw = useHardware()
+  const stats = useStatsHardware()
+  const power = useStatsPower()
+  const s = stats.data
+  const H = hw.data
+
+  const util = typeof s?.gpu_util === 'number' ? s.gpu_util : null
+  const pinned = !!s?.util_is_forced_high
+  const mhz = s?.gpu_clock_mhz ?? null
+  const temp = s?.gpu_temp_c ?? null
+  const watts = power.data?.gpu_power_w ?? null
+  const sub = H?.gpu ? H.gpu + (H.vulkanCapable ? ' · vulkan' : '') : '—'
+
+  return (
+    <div className="th-cell">
+      <ThEyebrow dot="var(--dev-vulkan)" label="GPU" sub={sub} />
+      <div className="th-row">
+        <SemiGauge
+          pct={util != null ? util * 100 : null}
+          stroke="var(--dev-vulkan)"
+          value={util != null ? Math.round(util * 100) + '%' : '—'}
+          caption={pinned ? 'util · pinned' : 'util'}
+        />
+        <div className="th-digits c3">
+          <div className="th-digit">
+            <div className="v">{mhz != null ? Math.round(mhz) : '—'}</div>
+            <div className="cap">MHz sclk</div>
+          </div>
+          <div className="th-digit">
+            <div className={'v' + (temp != null && temp >= 75 ? ' warn' : '')}>
+              {temp != null ? Math.round(temp) + '°' : '—'}
+            </div>
+            <div className="cap">temp C</div>
+          </div>
+          <div className="th-digit">
+            <div className="v sec">{watts != null ? Math.round(watts) : '—'}</div>
+            <div className="cap">watts</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Cell 3 · CPU · MEMORY — sys-ram gauge + cpu util (micro-bar) / temp digits.
+function ThCellCpuMem() {
+  const hw = useHardware()
+  const stats = useStatsHardware()
+  const power = useStatsPower()
+  const s = stats.data
+
+  const usedGb = s?.ram_used_mb != null ? s.ram_used_mb / 1024 : null
+  const totalGb = s?.ram_total_mb != null ? s.ram_total_mb / 1024 : hw.data?.ram?.total || null
+  const ramPct = usedGb != null && totalGb ? (usedGb / totalGb) * 100 : null
+  const cpuUtil = typeof s?.cpu_util === 'number' ? s.cpu_util : null
+  const cpuTemp = power.data?.cpu_temp_c ?? null
+
+  return (
+    <div className="th-cell">
+      <ThEyebrow dot="var(--dev-cpu)" label="CPU · Memory" sub={hw.data?.cpu || '—'} />
+      <div className="th-row">
+        <SemiGauge
+          pct={ramPct}
+          stroke="var(--dev-cpu)"
+          valueSmall
+          value={usedGb != null ? fmt1(round1(usedGb)) + ' GB' : '—'}
+          caption={totalGb ? `sys ram / ${Math.round(totalGb)} GB` : 'sys ram'}
+        />
+        <div className="th-digits c2">
+          <div className="th-digit">
+            <div className="v">{cpuUtil != null ? Math.round(cpuUtil * 100) + '%' : '—'}</div>
+            <div className="th-microbar">
+              <i style={{ width: `${cpuUtil != null ? Math.round(cpuUtil * 100) : 0}%` }} />
+            </div>
+            <div className="cap">util</div>
+          </div>
+          <div className="th-digit">
+            <div className="v sec">{cpuTemp != null ? Math.round(cpuTemp) + '°' : '—'}</div>
+            <div className="cap push">temp C</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Cell 4 · NPU — compact 4×8 AIE occupancy grid + partition bars + owner
+// tags. Column allocation comes from useNpuOccupancy().slots[].cols — the
+// grid, bars, tags and caption all derive from that one per-column owner
+// array (mirrors the owners[] pattern in npu-pane.jsx). Never hardcoded.
+function ThCellNpu({ slots }) {
+  const occQ = useNpuOccupancy()
+  const stats = useStatsHardware()
+  const hw = useHardware()
+  const occ = occQ.data || {}
+  const rows = occ.rows || 4
+  const cols = occ.cols || 8
+  const occSlots = occ.slots || []
+  const tiles = occ.tiles || rows * cols
+
+  const owners = Array(cols).fill(null)
+  occSlots.forEach((sl, idx) => {
+    const hue = TH_HUES[idx % TH_HUES.length]
+    const o = { name: sl.name, idx, ...hue }
+    ;(sl.cols || []).forEach((c) => {
+      if (c >= 0 && c < cols) owners[c] = o
+    })
+  })
+  const liveCount = occSlots.filter((sl) => (sl.cols || []).length > 0).length
+  const claimedTiles = owners.filter(Boolean).length * rows
+
+  // partition runs — consecutive columns with the same owner (by identity)
+  const parts = []
+  for (let i = 0; i < cols; ) {
+    const o = owners[i]
+    let span = 1
+    while (i + span < cols && owners[i + span] === o) span++
+    parts.push({ start: i, span, owner: o })
+    i += span
+  }
+  // bar spans exactly its claimed columns: cols*12 + (cols-1)*3
+  const partW = (span) => span * 12 + (span - 1) * 3
+
+  const npuUtil = typeof stats.data?.npu_util === 'number' ? stats.data.npu_util : null
+  const npuTps = sumToks((slots || []).filter(isNpuDev))
+  const npuName = hw.data?.npu?.present ? hw.data.npu.name || 'XDNA' : null
+  const sub = npuName ? `${npuName}${occSlots.length > 0 ? ' · flm' : ''}` : '—'
+
+  const tileEls = []
+  for (let i = 0; i < rows * cols; i++) {
+    const o = owners[Math.floor(i / rows)] // column-major fill
+    if (o) {
+      const dur = 2.2 + hash01(i * 12.9898) * 2.6
+      tileEls.push(
+        <i
+          key={i}
+          className="on"
+          style={{
+            background: o.hue,
+            boxShadow: `inset 0 0 0 1px ${o.line}, 0 0 6px -1px ${o.glow}`,
+            '--dur': dur.toFixed(2) + 's',
+            '--delay': (-hash01(i * 39.346) * dur).toFixed(2) + 's',
+          }}
+        />
+      )
+    } else {
+      tileEls.push(<i key={i} />)
+    }
+  }
+
+  return (
+    <div className="th-cell">
+      <ThEyebrow dot="var(--dev-npu)" live={liveCount > 0} label="NPU" sub={sub} />
+      <div className="th-npu">
+        <div className="th-aie">
+          <div
+            className="th-aie-grid"
+            style={{ gridTemplateColumns: `repeat(${cols}, 12px)`, gridTemplateRows: `repeat(${rows}, 12px)` }}
+          >
+            {tileEls}
+          </div>
+          <div className="th-aie-parts">
+            {parts.map((p) => (
+              <div key={p.start} className="th-aie-part" style={{ width: partW(p.span) + 'px' }}>
+                <span
+                  className="br"
+                  style={{
+                    background: p.owner ? p.owner.hue : 'var(--bg-4)',
+                    boxShadow: p.owner ? `0 0 6px -1px ${p.owner.glow}` : 'none',
+                  }}
+                />
+                <span
+                  className="pl"
+                  style={{ color: p.owner ? (p.owner.idx === 0 ? 'var(--fg-3)' : p.owner.fg) : 'var(--fg-5)' }}
+                >
+                  {p.owner ? p.owner.name : 'free'} <span className="pc">· {p.span}c</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="th-npu-right">
+          <div className="th-npu-nums">
+            <div className="th-npu-num">
+              <span className="v npu">{npuUtil != null ? Math.round(npuUtil * 100) + '%' : '—'}</span>
+              <span className="u">util</span>
+            </div>
+            <div className="th-npu-num">
+              <span className="v">{npuTps > 0 ? fmt1(npuTps) : '—'}</span>
+              <span className="u">tok/s</span>
+            </div>
+          </div>
+          <div className="th-tags">
+            {TH_HUES.map((hue, idx) => {
+              const o = occSlots[idx]
+              return o ? (
+                <span
+                  key={idx}
+                  className="th-tag"
+                  style={{ border: `1px solid ${hue.line}`, background: hue.dim, color: hue.fg }}
+                >
+                  <span className="sw" style={{ background: hue.hue, boxShadow: `inset 0 0 0 1px ${hue.line}` }} />
+                  {o.name}
+                </span>
+              ) : (
+                <span key={idx} className="th-tag off" />
+              )
+            })}
+          </div>
+          <span className="th-npu-cap">
+            {claimedTiles}/{tiles} tiles claimed · {rows}×{cols} AIE-ML · {liveCount} slot
+            {liveCount !== 1 ? 's' : ''} live
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Memory rack ruler — full-width second row; replaces and absorbs the old
+// memory-map band. All attribution comes from useMemoryMapModel() verbatim
+// (pool cap, per-slot bytesGb + Okabe–Ito colors, headroom + limitedBy);
+// the legend list is replaced by in-segment labels. Segments are
+// border-box and drop their padding when too narrow for a label so widths
+// stay true to the GB scale.
+function ThRuler() {
+  const model = useMemoryMapModel()
+  const { pool, self, headroom } = model
+  const total = pool.totalGb || 0
+  const used = self.modelUsedGb
+  const free = Math.max(0, round1(total - used))
+  const segs = self.slots.filter((s) => s.bytesGb > 0)
+  const pct = (gb) => (total > 0 ? (gb / total) * 100 : 0)
+  const ticks = total > 0 ? [0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(total * f)) : null
+
+  return (
+    <div className="th-ruler">
+      <div className="th-ruler-h">
+        <span>memory · {pool.label}</span>
+        <span>
+          model <b>{fmt1(used)} GB</b> · free <b>{fmt1(free)} GB</b> · headroom{' '}
+          <b className="ok">{fmt1(headroom.availableGb)} GB</b>{' '}
+          <span className="lim">— limited by {headroom.limitedBy}</span>
+        </span>
+      </div>
+      <div className="th-ruler-wrap">
+        <div className="th-ruler-bar">
+          {segs.map((s) => {
+            const w = pct(s.bytesGb)
+            const labeled = w >= 4.5 // wide enough to carry a label + padding
+            return (
+              <div
+                key={s.name}
+                className={'th-ruler-seg' + (labeled ? ' pad' : '')}
+                style={{ width: w + '%', background: s.color }}
+                title={`${s.name} · ${fmt1(s.bytesGb)} GB`}
+              >
+                {labeled && <span className="nm">{s.name}</span>}
+                {w >= 9 && <span className="gb">{fmt1(s.bytesGb)} GB</span>}
+              </div>
+            )
+          })}
+          <div className="th-ruler-free">free</div>
+        </div>
+        <div className="th-ruler-marker" style={{ left: `${Math.min(100, pct(used))}%` }} />
+      </div>
+      {ticks && (
+        <div className="th-ruler-ticks">
+          {ticks.map((t, i) => (
+            <span key={i}>
+              {t}
+              {i === ticks.length - 1 ? ' GB' : ''}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function TelemetryHeader({ slots: slotsProp }) {
+  // Self-contained by default (react-query dedupes the poll); a caller that
+  // already holds the slot list can pass it to skip the extra subscription.
+  const slotsQuery = useSlots()
+  const slots = slotsProp || slotsQuery.data || []
+  return (
+    <div className="th-card" data-testid="telemetry-header">
+      <div className="th-strip">
+        <ThCellThroughput slots={slots} />
+        <ThCellGpu />
+        <ThCellCpuMem />
+        <ThCellNpu slots={slots} />
+      </div>
+      <ThRuler />
+    </div>
+  )
+}
+
+// Window export keeps parity with the other dash modules' debug exports.
+Object.assign(window, { TelemetryHeader })

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -3,8 +3,8 @@
  * P2 card direction (design_handoff_inference_slots).
  *
  * Behaviour under test:
- *   - the page-level hero band (InferenceHeroBand, above the tabs) renders the
- *     iGPU GTT memory map + combined-throughput tile from HAL0_DATA
+ *   - the page-level telemetry header (TelemetryHeader, above the tabs)
+ *     renders the combined metrics card: throughput cell + memory rack ruler
  *   - the engine pane renders the epill + ALL slots as full cards, always
  *     visible (the old collapse/expand accordion + qcaret were removed)
  *   - the serving card's status pill shows live tok/s (no fabricated numbers)
@@ -19,25 +19,27 @@
  * The slot LIST comes from in-bundle HAL0_DATA (VITE_MOCK_HAL0=1); mutations
  * go through fetch, so per-route stubs capture the write path.
  *
- * NOTE: the page now carries TWO `.infer-pane` roots — the hero band
- * (`.infer-hero-top`, above the tabs) and the engine pane below it. The engine
- * locators scope to `.infer-pane:not(.infer-hero-top)` to target the pane; the
- * hero band is reached via its `infer-hero-band` testid.
+ * NOTE: the old hero band (`.infer-hero-top`) was replaced by the telemetry
+ * header card (telemetry-header.jsx), reached via its `telemetry-header`
+ * testid. The engine locators keep the `:not(.infer-hero-top)` scope so they
+ * stay valid either way.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
 
 const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').first()
 const engine = (page: Page) => pane(page).locator('.engine').first()
 const body = (page: Page) => pane(page).locator('.engine-b').first()
-const hero = (page: Page) => page.getByTestId('infer-hero-band')
+const hero = (page: Page) => page.getByTestId('telemetry-header')
 
 test.describe('Inference engine pane (/slots · Inference tab)', () => {
-  test('hero band renders memory + throughput; engine renders epill + full slot cards', async ({ page }) => {
+  test('telemetry header renders throughput cell + memory ruler; engine renders epill + full slot cards', async ({ page }) => {
     await page.goto('/#slots')
-    // page-level hero band (above the tabs): iGPU GTT memory map + throughput.
+    // page-level telemetry header (above the tabs): throughput cell + memory
+    // rack ruler. Forced-mock has no throughput-history endpoint, so the cell
+    // shows its honest "source pending" gate — the cell itself must render.
     await expect(hero(page)).toBeVisible()
-    await expect(hero(page).locator('.mem .blk-h')).toContainText('memory · iGPU GTT')
-    await expect(hero(page).locator('.tp-tile')).toBeVisible()
+    await expect(hero(page).locator('.th-ruler-h')).toContainText('memory ·')
+    await expect(hero(page).locator('.th-cell-tps')).toBeVisible()
     // engine pane: state pill summarises serving/loaded counts (primary serving).
     await expect(pane(page)).toBeVisible()
     await expect(page.getByTestId('infer-epill')).toContainText('serving')
@@ -76,10 +78,10 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
 
   test('engine renders full slot cards with the metric meta row (no accordion)', async ({ page }) => {
     await page.goto('/#slots')
-    // full-card grid is always present; the throughput tile now lives in the
-    // page hero band, not the engine body.
+    // full-card grid is always present; throughput now lives in the page
+    // telemetry header's cell, not the engine body.
     await expect(body(page).locator('.scards.full')).toHaveCount(1)
-    await expect(hero(page).locator('.tp-tile')).toHaveCount(1)
+    await expect(hero(page).locator('.th-cell-tps')).toHaveCount(1)
     await expect(body(page).locator('.tp-tile')).toHaveCount(0)
     // the full card's meta row reports real metrics for the serving primary
     // slot (toks 45 · ttft 220 in the seed; no fabricated numbers).


### PR DESCRIPTION
## Summary

Implements `project_files/design_handoff_telemetry_header/` with both surfaces landing on the **Slots page** — the `#dashboard` page has a full redesign underway and stays untouched.

### Commit 1 — slots-page NPU occupancy update (`npu-pane.jsx` / `npu.css`)

- Throughput readout under the duty gauge tinted `--dev-npu` instead of amber; amber stays the product-wide "live / primary" accent.
- Per-slot tok/s enlarged to 17px/500, tinted with the slot's own owner hue text tint (`--npu-s0/s1/s2-fg` via `--slot-fg`; `--npu-b` fallback).
- Header meta gains `· N slots live` (tinted `--dev-npu`) — the count of occupancy slots actually holding columns; `single-tenant` only renders when nothing is live.
- The dashed free card (third reserved owner hue) always renders — `0 columns · single-tenant array full` when the array is fully claimed.
- `--npu-s0/s1/s2` token sets hoisted to `:root` (+ solid `-fg` text-tint aliases of the existing lightened halo hues — no new colors) so the telemetry header shares the owner-column language.

### Commit 2 — telemetry header card at the top of the Slots page (new `telemetry-header.jsx`)

The combined live-metrics card replaces the old `InferenceHeroBand` (memory map + combined-throughput band) above the Inference ⇄ Image Gen tabs:

- **Four auto-fit cells**: Throughput hero + 20-bucket spark (gated exactly like `ThroughputCard2` — pending → "source pending", never fabricated bars; gpu/npu sub-split from measured per-slot tok/s) · GPU semicircle gauge + sclk/temp/watts digits (temp warns ≥75 °C; util captioned **pinned** under `util_is_forced_high`) · CPU·Memory sys-ram gauge + cpu util micro-bar/temp · NPU compact 4×8 AIE occupancy grid + partition bars + owner tags, all derived from `useNpuOccupancy().slots[].cols`.
- **Memory rack ruler**: full-width bar reusing `useMemoryMapModel()` verbatim (pool cap, per-slot `bytesGb` + Okabe–Ito `--mem-slot-*` colors, headroom + `limitedBy`); border-box segments drop padding below the label threshold so widths stay true to the GB scale; amber used-marker; real tick labels from the pool cap.
- Cells wrap 4→2→1 (`repeat(auto-fit, minmax(320px,1fr))`, 1px-gap hairlines) and never clip; gauge centers are HTML overlays, not SVG `<text>`; one house easing (`cubic-bezier(0.22,1,0.36,1)`); pulse only on live dots; `prefers-reduced-motion` honoured.
- Dead code removed with the band: `InferenceHeroBand`, `MemGtt`, `GpuGauge`, `TpTile`, `SparkBars`, `Gauge` (inference-pane local) — `SubLabel` stays (used by the engine pane).
- `inference-pane-v3.spec.ts` retargeted from the hero band to the header.

## Verification

- `npm run typecheck` + `npm run build` clean.
- `inference-pane-v3.spec.ts`: 10 passed / 1 skipped / 3 failed — the same 3 tests fail identically on the base commit (pre-existing, unrelated to this diff).
- Rendered against the live local API at 1600px (all 4 cells one row) and 800px (2×2 wrap, no clipping): honest pending/em-dash states, ruler segments at true scale (agent 17.4 GB labeled + GB, npu label-only below the 9% threshold), used-marker at model total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)