### PR TITLE
fix(ui): telemetry header — ruler fills the blank cell in the 3-column band

### DIFF
--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -1442,12 +1442,36 @@
   border-radius: var(--rad-lg, 10px);
   background: var(--bg-1);
   overflow: hidden;
+  container-type: inline-size;
 }
+/* Base = auto-fit (also the fallback for pre-container-query browsers);
+   the ruler is a strip item spanning the full row. Container queries
+   below pin explicit column counts so the 3-column band can pull the
+   ruler UP into the blank space beside the wrapped NPU cell instead of
+   leaving a dead cell; at 4 / 2 / 1 columns it returns to full width. */
 .th-strip {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1px;
   background: var(--line-soft);
+}
+@supports (container-type: inline-size) {
+  /* ≥1283cqw: four cells one row, ruler full-width row 2 */
+  .th-strip { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  /* 3-col band: cells 1-3 on row 1, NPU wraps to row 2 col 1 — the ruler
+     rises beside it (cols 2-3) so no blank cell remains */
+  @container (max-width: 1282px) {
+    .th-strip { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .th-strip .th-ruler { grid-column: 2 / -1; }
+  }
+  /* 2-col band: clean 2×2 with the ruler back to full width */
+  @container (max-width: 961px) {
+    .th-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .th-strip .th-ruler { grid-column: 1 / -1; }
+  }
+  @container (max-width: 640px) {
+    .th-strip { grid-template-columns: minmax(0, 1fr); }
+  }
 }
 .th-cell {
   padding: 14px 18px 12px;
@@ -1757,9 +1781,13 @@
 }
 
 /* memory rack ruler — full-width second row; absorbs the memory-map band */
+/* Strip item: bg-1 over the line-soft strip background — the 1px grid gap
+   draws the hairline that the old border-top used to. */
 .th-ruler {
   padding: 14px 18px 16px;
-  border-top: 1px solid var(--line-soft);
+  background: var(--bg-1);
+  grid-column: 1 / -1;
+  min-width: 0;
 }
 .th-ruler-h {
   display: flex;

--- a/ui/src/dash/telemetry-header.jsx
+++ b/ui/src/dash/telemetry-header.jsx
@@ -560,8 +560,11 @@ export function TelemetryHeader({ slots: slotsProp }) {
         <ThCellGpu />
         <ThCellCpuMem />
         <ThCellNpu slots={slots} />
+        {/* The ruler is a strip item (grid-column set in overhaul.css) so the
+            3-column band can pull it up into the blank space beside the
+            wrapped NPU cell; at 4/2/1 columns it spans the full width. */}
+        <ThRuler slots={slots} />
       </div>
-      <ThRuler slots={slots} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up to #1062. At in-between viewport widths the auto-fit strip wrapped 3+1: the NPU cell landed alone on row 2 with a dead blank cell beside it, and the memory ruler sat below as a third band.

The ruler is now a grid item of the strip, and container queries on `.th-card` pin explicit column counts per band:

- **4 columns** (≥1283cqw): four cells in one row, ruler full-width on row 2
- **3 columns**: NPU wraps to row 2 col 1 and the **ruler rises into the blank space beside it** (`grid-column: 2 / -1`)
- **2 columns** (≤961cqw): clean 2×2 with the ruler back to full width
- **1 column** below 640cqw

`repeat(auto-fit, minmax(320px,1fr))` remains the base rule as the fallback for pre-container-query browsers. As a strip item the ruler carries `--bg-1` and the 1px grid gap draws the hairline the old `border-top` provided; segment label gating adapts automatically since it's driven by the measured bar width.

## Verification

- `npm run typecheck` + `npm run build` clean.
- Live API at 1513px (the reported viewport): row 2 = NPU cell + ruler side by side, no blank cell; ticks/labels adapt to the narrower bar.
- 1096px: 2×2 cells + full-width ruler (the layout that already worked stays identical); 1920px unchanged (4 + full-width ruler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)