### PR TITLE
release: v0.9.0 — first public beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,42 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ## [Unreleased]
 
+## [v0.9.0] — 2026-07-04
+
+**The first public-beta cut.** hal0 graduates from the b-tagged 0.8.x
+line: the dashboard gets its redesigned fixed-band layout and a live
+telemetry header, seed profiles carry flags from a measured Strix Halo
+bench matrix (plus a new per-model-family override layer), MCP servers
+are manageable from the CLI, and the Memory view becomes a per-bank
+workspace. **Safe upgrade from v0.8.5b2** — no on-disk migrations in
+this cut. Profile flag changes (re-tune, `FAMILY_DEFAULTS`) land on each
+slot's next restart; thanks to the v0.8.5b2 auto unit re-render, any
+restart path picks them up.
+
 ### Added
 
+- **Dashboard redesign — fixed-band layout with swap-in-place widgets
+  (#1061).** The free-form drag/resize grid is replaced by a fixed
+  vertical band stack: hero strip (steady-on + quick actions), 5-cell
+  health strip, a full-width **Unified Memory hero** (slot allocations
+  drawn inside the pool bar, striped system block, Proxmox-host block
+  when configured), Throughput / Utilization / Requests band, locked
+  dense slot rows, and an Activity / Services / Needs-Attention band
+  with inline actions. Customization is swap-in-place per cell (layout
+  v3 via the existing `PUT /api/user/dashboard-layout`, fail-soft to
+  defaults on old payloads). Ships a new **Requests & Latency** widget
+  against a new `/api/stats/requests` endpoint (gates to "source
+  pending" until the dispatcher rollup ships).
+- **Telemetry header on the Slots page (#1059, #1062, #1064).** One
+  combined live-metrics card replaces the old hero band: throughput
+  hero + 20-bucket spark, GPU semicircle gauge (sclk/temp/watts), CPU +
+  memory gauge, and the NPU 4×8 occupancy grid with per-slot owner
+  hues — above a full-width memory rack ruler in the #1061 memory-hero
+  style (in-bar allocations, live tok/s on serving segments, click-through
+  to the slot). Honest-data rules throughout: missing metric → em-dash,
+  measured zero renders as 0.0 with the serving count, GPU util captioned
+  "pinned" when forced high. Container queries keep the 4→3→2→1 column
+  wrap gap-free.
 - **`hal0 mcp` CLI surface** (#504) — `hal0 mcp {list,status,install,uninstall,restart,catalog}`
   backed by the existing `/api/mcp/*` routes. Rich tables with `--json` flag for
   machine output. The `restart` subcommand surfaces the 501 supervisor-stub
@@ -30,9 +64,34 @@ tree is gitignored, #638) and referenced by number throughout the code.
   measured -28.5% pp on RADV / -10% tg on rocm, plus SWA+cache-reuse bugs
   #21468/#21749). This fixes the live gemma-on-`rocm-dnse` regression and makes
   adopting Vulkan q8 KV safe as a follow-up.
+- **Configurable slot publish host — `[slots].publish_host` (#1058).**
+  Slot containers published on 127.0.0.1 only; raw slot ports were
+  reachable solely through hal0-api/Traefik. A first-class, UI-settable
+  config key (default `127.0.0.1`, unchanged behavior) lets an operator
+  widen to `0.0.0.0` or a specific interface IP. Fail-soft: an
+  unresolvable value falls back to loopback, never opens the box. Baked
+  into ExecStart, so live slots re-bind on their next restart; the
+  Settings row carries a loud LAN-exposure warning.
 
 ### Changed
 
+- **Memory Overview is a per-bank workspace (#1057).** Selecting a bank
+  drives one combined primary card — retained-memories spark, graph
+  extraction panel, embedded Tools (recall · reflect · documents ·
+  mental models · directives), async operations, danger zone. The
+  standalone `#memory/tools` route is retired; documents paginate and
+  show composed titles instead of raw UUIDs; mental models and
+  directives gain create forms.
+- **The MTP control is always visible on llm slots (#1054).** Hiding the
+  row for ineligible models made the tri-state undiscoverable. The slot
+  drawer now always renders it, with a reason line for Auto·off ("model
+  has no MTP heads" / "profile doesn't enable MTP") and a
+  launch-will-fail warning when forcing On for a model without
+  advertised heads. Stack editor rows follow the same contract.
+- **Activity sidebar rework (#1063).** Taller pane, stacked
+  timestamp/actor meta reclaiming horizontal space, and the free-text
+  search replaced by a slot filter dropdown (exact target match,
+  server-side pre-narrowed).
 - **Seed profiles: bench-driven flag re-tune (Strix Halo matrix, 2026-07-04).**
   `rocm-moe` micro-batch `-ub 2048` → `-ub 1024` (+30% prompt-processing on
   Qwen3.6-35B-A3B-MTP: 1165 vs 895 t/s pp2048, consistent across all `-b`;
@@ -50,6 +109,29 @@ tree is gitignored, #638) and referenced by number throughout the code.
   no longer intrinsically gemma-safe — it relies on `FAMILY_DEFAULTS["gemma"]`
   pinning gemma slots back to f16 KV. (The upstream "~10x pp cliff" did NOT
   reproduce on this fork.)
+
+### Fixed
+
+- **OpenRouter OAuth callback route is gated behind
+  `HAL0_OPENROUTER_OAUTH_ENABLED` (#775).** The callback endpoint no
+  longer registers unless the flow is explicitly enabled, closing an
+  unauthenticated surface on installs that never use OpenRouter OAuth.
+- **Capability slot mini-cards regained Logs/Edit buttons (#1055).** The
+  utility-tier (embedding/reranking/tts/transcription) cards rendered
+  compact controls with no way to edit or tail a capability slot created
+  via the UI.
+- **Hermes memory identity defaults to `hermes` (#1056).** The upstream
+  plugin base defaulted to `hermes-agent` on env-less code paths,
+  spawning a stray duplicate `private:hermes-agent` bank alongside the
+  correct `private:hermes`. Reads/writes now consistently target
+  `private:hermes`.
+- **Telemetry throughput no longer flaps to "source pending" on an idle
+  box (#1062).** An empty 100-second history window is a measurement
+  (0.0 with the live serving count), and the spark keeps the last 20
+  measured buckets on screen; "source pending" is reserved for a
+  genuinely missing source.
+- Removed a dead duplicate `SELF_MANAGED_PROVIDERS` constant from
+  `kokoro.py` (#982).
 
 ## [v0.8.5b2] — 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ tree is gitignored, #638) and referenced by number throughout the code.
 
 ### Added
 
+- **`hal0 mcp` CLI surface** (#504) — `hal0 mcp {list,status,install,uninstall,restart,catalog}`
+  backed by the existing `/api/mcp/*` routes. Rich tables with `--json` flag for
+  machine output. The `restart` subcommand surfaces the 501 supervisor-stub
+  gracefully until ADR-0015 lands.
 - **`FAMILY_DEFAULTS` — per-model-family launcher-flag overrides.** A new
   resolution layer between a profile's generic flags and a slot's own
   `[model].defaults`, keyed on model family (matched from the id/filename).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ curl -fsSL https://hal0.dev/install.sh | bash
 <td width="33%"><a href="https://hal0.dev/docs/guides/generate-images/"><img src="https://hal0.dev/screenshots/image-gen-comfyui.png" alt="Image generation" width="100%"></a><br><sub><b>Image generation</b> — ComfyUI queue and GPU gauges.</sub></td>
 <td width="33%"><a href="https://hal0.dev/docs/guides/enable-memory/"><img src="https://hal0.dev/screenshots/memory-graph.png" alt="Memory graph" width="100%"></a><br><sub><b>Memory</b> — Hindsight facts and graph extraction.</sub></td>
 </tr>
+<tr>
+<td width="33%"><a href="https://hal0.dev/docs/concepts/architecture/"><img src="https://hal0.dev/screenshots/services-page.png" alt="Services page" width="100%"></a><br><sub><b>Services</b> — Open WebUI, ComfyUI, Hermes, Hindsight, n8n with mDNS.</sub></td>
+<td width="33%"><a href="https://hal0.dev/docs/concepts/slots/"><img src="https://hal0.dev/screenshots/stacks-tab.png" alt="Stacks" width="100%"></a><br><sub><b>Stacks</b> — declarative slot + profile + model bundles, applied atomically.</sub></td>
+<td width="33%"><a href="https://hal0.dev/docs/guides/manage-slots/"><img src="https://hal0.dev/screenshots/slots-inference.png" alt="Slots + telemetry" width="100%"></a><br><sub><b>Slots + telemetry</b> — live throughput, GPU/CPU/NPU, unified-memory rack.</sub></td>
+</tr>
 </table>
 
 <sub>More in the <a href="https://hal0.dev/docs/">docs</a>.</sub>

--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ curl -fsSL https://hal0.dev/install.sh | bash
 
 <div align="center">
 
-<a href="https://hal0.dev/docs/"><img src="https://hal0.dev/screenshots/dashboard-overview.png" alt="hal0 dashboard — unified-memory hero, health strip, live slot rows" width="820"></a>
-
-<em>The dashboard — unified-memory hero, at-a-glance health, and live slot rows.</em>
+<table>
+<tr>
+<td width="50%"><a href="https://hal0.dev/docs/"><img src="https://hal0.dev/screenshots/dashboard-overview.png" alt="hal0 dashboard" width="100%"></a><br><sub><b>Dashboard</b> — unified-memory hero, at-a-glance health, and live slot rows.</sub></td>
+<td width="50%"><a href="https://hal0.dev/docs/guides/manage-slots/"><img src="https://hal0.dev/screenshots/slots-inference.png" alt="Slots" width="100%"></a><br><sub><b>Slots</b> — the inference engine: per-slot models, devices, and live telemetry.</sub></td>
+</tr>
+</table>
 
 <table>
 <tr>
@@ -69,7 +72,7 @@ curl -fsSL https://hal0.dev/install.sh | bash
 <tr>
 <td width="33%"><a href="https://hal0.dev/docs/concepts/architecture/"><img src="https://hal0.dev/screenshots/services-page.png" alt="Services page" width="100%"></a><br><sub><b>Services</b> — Open WebUI, ComfyUI, Hermes, Hindsight, n8n with mDNS.</sub></td>
 <td width="33%"><a href="https://hal0.dev/docs/concepts/slots/"><img src="https://hal0.dev/screenshots/stacks-tab.png" alt="Stacks" width="100%"></a><br><sub><b>Stacks</b> — declarative slot + profile + model bundles, applied atomically.</sub></td>
-<td width="33%"><a href="https://hal0.dev/docs/guides/manage-slots/"><img src="https://hal0.dev/screenshots/slots-inference.png" alt="Slots + telemetry" width="100%"></a><br><sub><b>Slots + telemetry</b> — live throughput, GPU/CPU/NPU, unified-memory rack.</sub></td>
+<td width="33%"><a href="https://hal0.dev/docs/guides/configure/"><img src="https://hal0.dev/screenshots/settings-page.png" alt="Settings" width="100%"></a><br><sub><b>Settings</b> — full <code>hal0.toml</code> parity with an Advanced section.</sub></td>
 </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -28,21 +28,28 @@ shared inference daemon; no extra process to babysit.
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
 
-> **Status:** **v0.8.4b1** — container-runtime era, declarative
-> config. Each slot (`agent`, `utility`, `embed`, `rerank`, `stt`, `tts`,
-> `img`, `vision`, NPU trio) runs as a dedicated podman container
-> (`hal0-slot@<name>.service`).
-> Slot definitions live in `/etc/hal0/slots/<name>.toml`; backend profiles
-> in `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
+> **Status:** **v0.9.0 — first public beta.** Container-runtime era,
+> declarative config. Each slot (`agent`, `utility`, `embed`, `rerank`,
+> `stt`, `tts`, `img`, `vision`, NPU trio) runs as a dedicated podman
+> container (`hal0-slot@<name>.service`). Slot definitions live in
+> `/etc/hal0/slots/<name>.toml`; backend profiles in
+> `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
 > single source of truth for every HuggingFace coordinate and SHA-256
 > digest. The launch command for every slot is resolved from a single
 > source (deduped, with per-flag provenance), **Stacks** apply
 > declarative model/slot layouts atomically, and profiles share the same
-> portable export/import envelope. Models can carry a preferred runtime
-> profile, interrupted pulls resume, and voice runs end-to-end (NPU STT +
-> Kokoro or GPU Qwen3-TTS). The one-liner
-> seeds the recommended Main slot non-interactively; run `hal0 setup`
-> anytime to configure models, extensions, and NPU interactively. See
+> portable export/import envelope. hal0 is **Strix Halo native, not
+> Strix-Halo-only**: experimental CUDA + multi-GPU pinning ride alongside
+> the ROCm/Vulkan defaults. Companion services (Open WebUI, ComfyUI,
+> Hermes, Hindsight, n8n) are managed from one **Services** dashboard
+> page with mDNS discovery; the dashboard itself has a redesigned
+> fixed-band layout with a live telemetry header. Seed profiles are
+> virtual (code-defined, self-healing on upgrade) with dedicated
+> embed/rerank lanes and a model×profile×slot MTP decision; models carry
+> a preferred runtime profile, interrupted pulls resume, and voice runs
+> end-to-end (NPU STT + Kokoro or GPU Qwen3-TTS). The one-liner seeds the
+> recommended Main slot non-interactively; run `hal0 setup` anytime to
+> configure models, extensions, and NPU interactively. See
 > [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
 
 ## Why hal0

--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ curl -fsSL https://hal0.dev/install.sh | bash
 > configure models, extensions, and NPU interactively. See
 > [`PLAN.md`](./PLAN.md) §1 for what ships now and the path to v1.0.
 
+## Screenshots
+
+<div align="center">
+
+<a href="https://hal0.dev/docs/"><img src="https://hal0.dev/screenshots/dashboard-overview.png" alt="hal0 dashboard — unified-memory hero, health strip, live slot rows" width="820"></a>
+
+<em>The dashboard — unified-memory hero, at-a-glance health, and live slot rows.</em>
+
+<table>
+<tr>
+<td width="33%"><a href="https://hal0.dev/docs/guides/pull-and-register-models/"><img src="https://hal0.dev/screenshots/models-registry.png" alt="Model registry" width="100%"></a><br><sub><b>Model registry</b> — catalogue with quant chips and pull status.</sub></td>
+<td width="33%"><a href="https://hal0.dev/docs/guides/generate-images/"><img src="https://hal0.dev/screenshots/image-gen-comfyui.png" alt="Image generation" width="100%"></a><br><sub><b>Image generation</b> — ComfyUI queue and GPU gauges.</sub></td>
+<td width="33%"><a href="https://hal0.dev/docs/guides/enable-memory/"><img src="https://hal0.dev/screenshots/memory-graph.png" alt="Memory graph" width="100%"></a><br><sub><b>Memory</b> — Hindsight facts and graph extraction.</sub></td>
+</tr>
+</table>
+
+<sub>More in the <a href="https://hal0.dev/docs/">docs</a>.</sub>
+
+</div>
+
 ## Why hal0
 
 **Strix Halo native, but not Strix-Halo-only.** The probe is UMA-aware

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Open-source home AI inference platform
 
-[hal0.dev](https://hal0.dev) · [Install](https://hal0.dev/docs/install/) · [Docs](https://hal0.dev/docs/) · [Roadmap](https://hal0.dev/roadmap) · [Discord](https://discord.gg/7M4y6dcUyq)
+[hal0.dev](https://hal0.dev) · [Install](https://hal0.dev/docs/install/) · [Docs](https://hal0.dev/docs/) · [Roadmap](https://hal0.dev/#roadmap) · [Discord](https://discord.gg/7M4y6dcUyq)
 
 </div>
 
@@ -361,10 +361,23 @@ VM installs leave the panel off and the dashboard stays quiet.
 ## Roadmap
 
 No dates — items are direction. The closer to the left, the closer to
-running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap).
+running on your box. Full version at [hal0.dev/#roadmap](https://hal0.dev/#roadmap).
 
-### Shipped (v0.3 / container runtime)
+### Shipped (v0.9 / public beta)
 
+- **Dashboard redesign + live telemetry header** — fixed-band layout
+  with a unified-memory hero, and a combined throughput / GPU / CPU /
+  NPU-occupancy metrics card that reads only from live probes
+- **Companion services, one surface** — Open WebUI, ComfyUI, Hermes,
+  Hindsight, and n8n managed from a dashboard **Services** page with
+  mDNS discovery and allow-listed lifecycle actions
+- **GPU generalization** — experimental CUDA + per-slot `gpu_index`
+  pinning for multi-GPU hosts, alongside the ROCm/Vulkan defaults
+- **Virtual seed profiles** — code-defined and self-healing on upgrade,
+  with dedicated embed/rerank lanes and a model×profile×slot MTP
+  decision (tri-state Auto/On/Off)
+- **`hal0 mcp` CLI + two-way MCP** — manage MCP servers from the CLI;
+  hal0 hosts admin + memory servers and reaches external ones
 - **Per-slot podman containers** — every inference workload runs in
   its own `hal0-slot@<name>.service` container; `ContainerProvider` +
   `profiles.toml` replace the old single-daemon model
@@ -395,14 +408,12 @@ running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap
 
 ### Soon
 
-- **Advanced memory** — MCP client side of hal0 (agents reach
-  external MCP servers), federated memory across local + remote
-  sources
+- **Federated memory** — recall across local + remote sources behind
+  one memory surface (the MCP-client side shipped in v0.9)
 - **Benchmarks & presets UI** — in-dashboard tok/s + latency runs,
   plus curated loadout presets you can flash onto a fresh install
 - **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of
   the install script; pacman and apt as first-class install paths
-- `hal0.local` mDNS auto-discovery polish
 - Light mode toggle
 
 ### Exploring (v1.x +)
@@ -414,8 +425,6 @@ running on your box. Full version at [hal0.dev/roadmap](https://hal0.dev/roadmap
   warm base model without unloading the underlying weights
 - **Per-model rate limits & budgets** — cost-style accounting for
   local inference — cap a chatty agent without taking the whole box down
-- **Voice mode end-to-end** — agent loop stitched into a hands-free
-  streaming conversation
 - **ChatOps adapters** — Slack and Matrix bridges as extensions —
   talk to hal0 from the rooms you already live in
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -214,6 +214,33 @@ There is no `rotate-token` subcommand. The daemon has no built-in auth
 sets from `$HAL0_AGENT_ID`.
 </Aside>
 
+## `hal0 mcp` — MCP servers
+
+A thin HTTP client over the daemon's `/api/mcp/*` routes — every command
+hits `127.0.0.1:8080`. Manage the bundled MCP servers (`hal0-admin`,
+`hal0-memory`) and any user-installed ones.
+
+| Command | Purpose | Key options |
+|---|---|---|
+| `mcp list` | List all MCP servers (bundled + installed) with state. | `--json` |
+| `mcp status <id>` | Show detail for one MCP server. | `--json` |
+| `mcp install <url-spec>` | Install a user MCP server from a URL / spec (`oci://…`, `npm:…`, etc.). | `--json` |
+| `mcp uninstall <id>` | Uninstall a user-installed server. Bundled servers reject with `409`. | `--force`/`-f` |
+| `mcp restart <id>` | Restart an MCP server (bundled or installed). | — |
+
+### `hal0 mcp catalog`
+
+| Command | Purpose | Key options |
+|---|---|---|
+| `mcp catalog list` | List installable MCP servers from the catalog. | `--json` |
+| `mcp catalog refresh` | Refresh the installable-MCP catalog (re-fetches from upstream). | — |
+
+<Aside type="note">
+`mcp restart` currently surfaces the `501` supervisor-stub gracefully — live
+MCP process restart lands with ADR-0015. Until then, `restart` reports the
+stub instead of bouncing the server.
+</Aside>
+
 ## `hal0 migrate` — config/state migrations
 
 The `migrate` sub-app houses one-shot upgrade helpers for moving older on-disk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.8.5b2"
+version = "0.9.0"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1392,15 +1392,17 @@ def create_app() -> FastAPI:
         tags=["mcp"],
     )
 
-    # OpenRouter OAuth callback scaffold (ADR-0020, Phase 0). The route
-    # is registered so V1 (the OpenRouter-as-Hermes-upstream PR) inherits
-    # the loopback guard from day 1; the handler currently returns 501
-    # with a pointer to ADR-0020. Router declares absolute paths so no
-    # prefix is needed here.
-    app.include_router(
-        openrouter_auth_router,
-        tags=["openrouter", "auth"],
-    )
+    # OpenRouter OAuth callback scaffold (ADR-0020, Phase 0).  The route
+    # is gated behind HAL0_OPENROUTER_OAUTH_ENABLED so the 501 placeholder
+    # does not appear in the API surface while the linked-account PKCE flow
+    # is unimplemented (#775).  Set the env var to "1" or "true" to mount
+    # the callback route so V1 (the OpenRouter-as-Hermes-upstream PR) can
+    # inherit the loopback guard from day 1.
+    if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
+        app.include_router(
+            openrouter_auth_router,
+            tags=["openrouter", "auth"],
+        )
 
     # Hermes dashboard plugin host (v0.3 PR-7). hal0-api proxies the
     # upstream manifest list + the per-plugin static-asset surface so

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -32,6 +32,7 @@ from hal0.cli.agent_commands import app as agent_app
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
+from hal0.cli.mcp_commands import app as mcp_app
 from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
@@ -66,6 +67,9 @@ app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(agent_app, name="agent")
 app.add_typer(migrate_app, name="migrate")
 app.add_typer(registry_app, name="registry")
+# Issue #504 — ``hal0 mcp {list,status,install,uninstall,restart,catalog}``
+# CLI over /api/mcp/*. Mounted after registry before setup.
+app.add_typer(mcp_app, name="mcp")
 app.add_typer(setup_app, name="setup", help="First-run setup")
 
 

--- a/src/hal0/cli/mcp_commands.py
+++ b/src/hal0/cli/mcp_commands.py
@@ -26,7 +26,6 @@ from typing import Any
 import typer
 from rich.console import Console
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.table import Table
 
 from hal0.cli._shared import (
@@ -36,7 +35,6 @@ from hal0.cli._shared import (
     api_delete,
     api_get,
     api_post,
-    api_patch,
     die,
 )
 
@@ -73,9 +71,7 @@ def _state_style(state: str) -> str:
 
 @app.command("list")
 def list_cmd(
-    json_out: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of the table."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the table."),
 ) -> None:
     """List all MCP servers (bundled + installed)."""
     url = _api_base()
@@ -123,9 +119,7 @@ def list_cmd(
 @app.command("status")
 def status_cmd(
     server_id: str = typer.Argument(..., help="MCP server id (e.g. 'hal0-admin')."),
-    json_out: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of the panel."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the panel."),
 ) -> None:
     """Show detail for one MCP server."""
     url = _api_base()
@@ -210,9 +204,7 @@ def status_cmd(
 @app.command("install")
 def install_cmd(
     url_spec: str = typer.Argument(..., help="MCP server URL or spec (oci://…, npm:…, etc.)."),
-    json_out: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of the panel."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the panel."),
 ) -> None:
     """Install a user MCP server from a URL / spec."""
     api_url = _api_base()
@@ -247,9 +239,7 @@ def install_cmd(
 @app.command("uninstall")
 def uninstall_cmd(
     server_id: str = typer.Argument(..., help="MCP server id to remove."),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Skip confirmation prompt."
-    ),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompt."),
 ) -> None:
     """Uninstall a user-installed MCP server. Bundled servers reject 409."""
     if not force:
@@ -301,9 +291,7 @@ def restart_cmd(
 
 @catalog_app.command("list")
 def catalog_list_cmd(
-    json_out: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of the table."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the table."),
 ) -> None:
     """List installable MCP servers from the catalog."""
     url = _api_base()
@@ -352,9 +340,7 @@ def catalog_list_cmd(
 
 @catalog_app.command("refresh")
 def catalog_refresh_cmd(
-    json_out: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of the table."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Emit raw JSON instead of the table."),
 ) -> None:
     """Refresh the installable-MCP catalog (re-fetches from upstream).
 

--- a/src/hal0/cli/mcp_commands.py
+++ b/src/hal0/cli/mcp_commands.py
@@ -1,0 +1,387 @@
+"""hal0 mcp subcommands — thin HTTP client to /api/mcp/*.
+
+Issue #504: ``hal0 mcp {list,status,install,uninstall,restart,catalog list}``
+backing the existing API routes in :mod:`hal0.api.routes.mcp`.  ADR-0015 +
+the Hermes ``MCP-CLIENTS.md.j2`` template already promise this surface.
+
+Endpoints hit
+-------------
+
+    hal0 mcp list              → GET  /api/mcp/servers
+    hal0 mcp status <id>       → GET  /api/mcp/servers (filter by id)
+    hal0 mcp install <url>     → POST /api/mcp/install
+    hal0 mcp uninstall <id>    → DELETE /api/mcp/{id}
+    hal0 mcp restart <id>      → POST /api/mcp/{id}/restart
+    hal0 mcp catalog list      → GET  /api/mcp/catalog
+    hal0 mcp catalog refresh   → GET  /api/mcp/catalog (force-refresh stub)
+
+PLAN.md §13 ("CLI is a thin client") — every command hits 127.0.0.1:8080.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+
+from hal0.cli._shared import (
+    CliApiError,
+    _api_base,
+    _api_unreachable,
+    api_delete,
+    api_get,
+    api_post,
+    api_patch,
+    die,
+)
+
+app = typer.Typer(help="Manage MCP servers.")
+console = Console()
+
+# Sub-app for ``hal0 mcp catalog``
+catalog_app = typer.Typer(help="Browse the installable-MCP catalog.")
+app.add_typer(catalog_app, name="catalog")
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _find_server(servers: list[dict[str, Any]], server_id: str) -> dict[str, Any] | None:
+    """Case-insensitive server-id lookup in the servers list."""
+    for s in servers:
+        if s.get("id", "").lower() == server_id.lower():
+            return s
+    return None
+
+
+def _state_style(state: str) -> str:
+    """Rich colour for a server state."""
+    if state == "running":
+        return "[green]running[/green]"
+    if state == "stopped":
+        return "[dim]stopped[/dim]"
+    return f"[yellow]{state}[/yellow]"
+
+
+# ── `hal0 mcp list` ──────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def list_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of the table."
+    ),
+) -> None:
+    """List all MCP servers (bundled + installed)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_get("/api/mcp/servers")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+
+    servers: list[dict[str, Any]] = result.get("servers", [])
+    if not servers:
+        console.print("[dim]No MCP servers found.[/dim]")
+        return
+
+    table = Table(title="MCP Servers")
+    table.add_column("ID", style="bold")
+    table.add_column("Name")
+    table.add_column("State")
+    table.add_column("Tools", justify="right")
+    table.add_column("Provider")
+    table.add_column("Bundled", justify="center")
+
+    for s in servers:
+        table.add_row(
+            s.get("id", "—"),
+            s.get("name", "—"),
+            _state_style(s.get("state", "unknown")),
+            str(s.get("tools", "—")),
+            s.get("provider", "—"),
+            "✓" if s.get("bundled") else "",
+        )
+
+    console.print(table)
+
+
+# ── `hal0 mcp status` ────────────────────────────────────────────────────────
+
+
+@app.command("status")
+def status_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id (e.g. 'hal0-admin')."),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of the panel."
+    ),
+) -> None:
+    """Show detail for one MCP server."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_get("/api/mcp/servers")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    servers: list[dict[str, Any]] = result.get("servers", [])
+    server = _find_server(servers, server_id)
+    if server is None:
+        die(f"no MCP server matching '{server_id}'")
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(server, indent=2, sort_keys=True))
+        return
+
+    # Basic fields
+    lines: list[str] = [
+        f"[bold]{server.get('name', server_id)}[/bold]",
+        f"  id:       {server.get('id', '—')}",
+        f"  state:    {_state_style(server.get('state', 'unknown'))}",
+        f"  tools:    {server.get('tools', '—')}",
+        f"  prompts:  {server.get('prompts', '—')}",
+        f"  provider: {server.get('provider', '—')}",
+        f"  bundled:  {server.get('bundled')}",
+    ]
+    if server.get("description"):
+        lines.append(f"  desc:     {server['description']}")
+    if server.get("pid"):
+        lines.append(f"  pid:      {server['pid']}")
+    if server.get("version"):
+        lines.append(f"  version:  {server['version']}")
+    if server.get("connect_url"):
+        lines.append(f"  connect:  [dim]{server['connect_url']}[/dim]")
+    if server.get("transport"):
+        lines.append(f"  transport:{server['transport']}")
+
+    # Activity
+    activity = server.get("activity", {})
+    rpm = activity.get("rpm", 0)
+    lines.append(f"  activity: {rpm} rpm")
+
+    # Connected clients
+    connected = server.get("connected") or []
+    if connected:
+        lines.append(f"  clients:  {', '.join(connected)}")
+
+    # Env overrides (installed servers)
+    env_block = server.get("env")
+    if env_block:
+        lines.append("  env:")
+        for k, v in sorted(env_block.items()):
+            masked = v if not v else "***"
+            lines.append(f"    {k} = {masked}")
+
+    console.print(Panel("\n".join(lines), title="mcp · status", border_style="dim"))
+
+    # Tool details
+    tool_details = server.get("tool_details") or []
+    if tool_details:
+        tool_table = Table(title="Tools")
+        tool_table.add_column("Name", style="bold")
+        tool_table.add_column("Description")
+        tool_table.add_column("Gated", justify="center")
+        for td in tool_details:
+            tool_table.add_row(
+                td.get("name", "—"),
+                (td.get("description") or "")[:80],
+                "✓" if td.get("gated") else "",
+            )
+        console.print(tool_table)
+
+
+# ── `hal0 mcp install` ───────────────────────────────────────────────────────
+
+
+@app.command("install")
+def install_cmd(
+    url_spec: str = typer.Argument(..., help="MCP server URL or spec (oci://…, npm:…, etc.)."),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of the panel."
+    ),
+) -> None:
+    """Install a user MCP server from a URL / spec."""
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    try:
+        result = api_post("/api/mcp/install", json={"url": url_spec})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+
+    installed = result.get("installed", {})
+    sid = installed.get("id", "?")
+    console.print(
+        Panel(
+            f"[bold green]✓ installed[/bold green] [bold]{sid}[/bold]\n"
+            f"  name:  {installed.get('name', '—')}\n"
+            f"  tools: {installed.get('tools', '—')}\n"
+            f"  spec:  [dim]{installed.get('spec', '—')}[/dim]",
+            border_style="green",
+        )
+    )
+
+
+# ── `hal0 mcp uninstall` ─────────────────────────────────────────────────────
+
+
+@app.command("uninstall")
+def uninstall_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id to remove."),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation prompt."
+    ),
+) -> None:
+    """Uninstall a user-installed MCP server. Bundled servers reject 409."""
+    if not force:
+        typer.confirm(
+            f"Uninstall MCP server '{server_id}'? This only affects user-installed servers.",
+            abort=True,
+        )
+
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    try:
+        result = api_delete(f"/api/mcp/{server_id}")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    console.print(
+        Panel(
+            f"[bold]Uninstalled[/bold] {result.get('uninstalled', server_id)}",
+            border_style="yellow",
+        )
+    )
+
+
+# ── `hal0 mcp restart` ───────────────────────────────────────────────────────
+
+
+@app.command("restart")
+def restart_cmd(
+    server_id: str = typer.Argument(..., help="MCP server id to restart."),
+) -> None:
+    """Restart an MCP server (bundled or installed)."""
+    api_url = _api_base()
+    if _api_unreachable(api_url):
+        raise typer.Exit(1)
+    try:
+        result = api_post(f"/api/mcp/{server_id}/restart")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    # Expecting a 501 for now (supervisor not implemented), but handle gracefully
+    console.print(f"[bold yellow]restart {server_id}:[/bold yellow] {result}")
+
+
+# ── `hal0 mcp catalog list` ──────────────────────────────────────────────────
+
+
+@catalog_app.command("list")
+def catalog_list_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of the table."
+    ),
+) -> None:
+    """List installable MCP servers from the catalog."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_get("/api/mcp/catalog")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+
+    items = result.get("items", [])
+    categories = result.get("categories", [])
+
+    table = Table(title="MCP Catalog")
+    table.add_column("ID", style="bold")
+    table.add_column("Name")
+    table.add_column("Author")
+    table.add_column("Tools", justify="right")
+    table.add_column("Stars", justify="right")
+    table.add_column("Category")
+    table.add_column("Verified", justify="center")
+
+    for item in items:
+        table.add_row(
+            item.get("id", "—"),
+            item.get("name", "—"),
+            item.get("author", "—"),
+            str(item.get("tools", "—")),
+            str(item.get("stars", "—")),
+            item.get("category", "—"),
+            "✓" if item.get("verified") else "",
+        )
+
+    console.print(table)
+    if categories:
+        console.print(f"[dim]categories:[/dim] {', '.join(categories)}")
+
+
+# ── `hal0 mcp catalog refresh` ───────────────────────────────────────────────
+
+
+@catalog_app.command("refresh")
+def catalog_refresh_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of the table."
+    ),
+) -> None:
+    """Refresh the installable-MCP catalog (re-fetches from upstream).
+
+    Currently a stub — re-fetches the static catalog.  The backend will
+    grow a live registry probe per ADR-0013; when that lands this command
+    will force a re-index instead of returning the same static payload.
+    """
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_get("/api/mcp/catalog")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+
+    items = result.get("items", [])
+    console.print(
+        Panel(
+            f"[bold green]Catalog refreshed[/bold green]  [dim]{len(items)} entries.[/dim]",
+            border_style="green",
+        )
+    )
+
+
+__all__ = ["app", "catalog_app"]

--- a/src/hal0/providers/kokoro.py
+++ b/src/hal0/providers/kokoro.py
@@ -55,9 +55,6 @@ _DEFAULT_PROFILE = "tts"
 # (profiles.toml); a non-default [models].store moves the mount but not that
 # flag yet — tracked as a follow-up.
 
-# Providers whose model weights are pre-staged by the operator (not hal0 registry).
-SELF_MANAGED_PROVIDERS: frozenset[str] = frozenset({"kokoro", "comfyui"})
-
 # Health/infer timeouts.
 _HEALTH_TIMEOUT = httpx.Timeout(5.0)
 _INFER_TIMEOUT = httpx.Timeout(connect=5.0, read=60.0, write=5.0, pool=5.0)

--- a/tests/api/test_openrouter_auth_loopback.py
+++ b/tests/api/test_openrouter_auth_loopback.py
@@ -209,6 +209,7 @@ def test_require_loopback_helper_handles_missing_client() -> None:
         require_loopback(req)
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
 
+
 # ── Gating behaviour (HAL0_OPENROUTER_OAUTH_ENABLED) ──────────────────
 # The route is only mounted when the env var is set to "1" or "true".
 # When unset (default) the callback URL is not registered — it does
@@ -219,6 +220,7 @@ def test_require_loopback_helper_handles_missing_client() -> None:
 def gated_app() -> FastAPI:
     """FastAPI app that behaves like create_app() gating decision."""
     import os
+
     app = FastAPI()
     if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
         app.include_router(openrouter_router)
@@ -238,6 +240,7 @@ def test_callback_mounted_when_env_is_one(
     """With HAL0_OPENROUTER_OAUTH_ENABLED=1, the route mounts (501)."""
     monkeypatch.setenv("HAL0_OPENROUTER_OAUTH_ENABLED", "1")
     import os
+
     app = FastAPI()
     if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
         app.include_router(openrouter_router)
@@ -256,6 +259,7 @@ def test_callback_mounted_when_env_is_true(
     """Case-insensitive — "true" also mounts."""
     monkeypatch.setenv("HAL0_OPENROUTER_OAUTH_ENABLED", "true")
     import os
+
     app = FastAPI()
     if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
         app.include_router(openrouter_router)
@@ -271,6 +275,7 @@ def test_callback_mounted_when_env_is_true(
 def test_callback_not_mounted_for_unknown_env_value() -> None:
     """Garbage values like yes do NOT mount — fail-closed."""
     import os
+
     app = FastAPI()
     # os.environ.get defaults to yes → NOT in (1,true) → no router
     if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "yes").lower() in ("1", "true"):

--- a/tests/api/test_openrouter_auth_loopback.py
+++ b/tests/api/test_openrouter_auth_loopback.py
@@ -208,3 +208,73 @@ def test_require_loopback_helper_handles_missing_client() -> None:
     with pytest.raises(HTTPException) as exc:
         require_loopback(req)
     assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+# ── Gating behaviour (HAL0_OPENROUTER_OAUTH_ENABLED) ──────────────────
+# The route is only mounted when the env var is set to "1" or "true".
+# When unset (default) the callback URL is not registered — it does
+# NOT appear in the API surface (#775).
+
+
+@pytest.fixture()
+def gated_app() -> FastAPI:
+    """FastAPI app that behaves like create_app() gating decision."""
+    import os
+    app = FastAPI()
+    if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
+        app.include_router(openrouter_router)
+    return app
+
+
+def test_callback_not_mounted_when_env_unset(gated_app: FastAPI) -> None:
+    """Without HAL0_OPENROUTER_OAUTH_ENABLED, the route is absent (404)."""
+    with TestClient(gated_app) as client:
+        r = client.get("/api/openrouter/auth/callback")
+    assert r.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_callback_mounted_when_env_is_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With HAL0_OPENROUTER_OAUTH_ENABLED=1, the route mounts (501)."""
+    monkeypatch.setenv("HAL0_OPENROUTER_OAUTH_ENABLED", "1")
+    import os
+    app = FastAPI()
+    if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
+        app.include_router(openrouter_router)
+    with TestClient(app) as client:
+        client.app.dependency_overrides[require_loopback] = lambda: None
+        try:
+            r = client.get("/api/openrouter/auth/callback")
+        finally:
+            client.app.dependency_overrides.pop(require_loopback, None)
+    assert r.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+def test_callback_mounted_when_env_is_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Case-insensitive — "true" also mounts."""
+    monkeypatch.setenv("HAL0_OPENROUTER_OAUTH_ENABLED", "true")
+    import os
+    app = FastAPI()
+    if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "").lower() in ("1", "true"):
+        app.include_router(openrouter_router)
+    with TestClient(app) as client:
+        client.app.dependency_overrides[require_loopback] = lambda: None
+        try:
+            r = client.get("/api/openrouter/auth/callback")
+        finally:
+            client.app.dependency_overrides.pop(require_loopback, None)
+    assert r.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+
+def test_callback_not_mounted_for_unknown_env_value() -> None:
+    """Garbage values like yes do NOT mount — fail-closed."""
+    import os
+    app = FastAPI()
+    # os.environ.get defaults to yes → NOT in (1,true) → no router
+    if os.environ.get("HAL0_OPENROUTER_OAUTH_ENABLED", "yes").lower() in ("1", "true"):
+        app.include_router(openrouter_router)
+    with TestClient(app) as client:
+        r = client.get("/api/openrouter/auth/callback")
+    assert r.status_code == status.HTTP_404_NOT_FOUND

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.8.5b2"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
Cuts **v0.9.0**, hal0's first public-beta-worthy release, off the 0.8.x b-tag line.

_(Supersedes #1065 — same branch, renamed `claude/charming-heyrovsky-fb0fa0` → `release/v0.9.0` for self-documenting history; the rename closed the old PR.)_

## What's in it
- **CHANGELOG `[v0.9.0]`** — accumulated `Unreleased` entries plus ~10 PRs that landed without changelog coverage (dashboard redesign #1061, telemetry header #1059/#1062/#1064, per-bank Memory #1057, `publish_host` #1058, MTP control visibility #1054, activity sidebar #1063, `hal0 mcp` CLI #504, OpenRouter OAuth gating #775, capability mini-card buttons #1055, hermes identity #1056, kokoro cleanup #982).
- **Version bump** — `pyproject.toml` + `uv.lock` → `0.9.0`.
- **README** — v0.9.0 status block + a screenshot gallery (referenced from hal0.dev so it auto-refreshes).
- **CI fixes bundled with the branch's local-ahead features** — ruff check/format on `mcp_commands.py`, and `docs/reference/cli.mdx` now documents `hal0 mcp` (unblocks `test_cli_docs_parity`).

## Note for reviewers
Three features ride only on this branch (not previously on `main`): `hal0 mcp` CLI #504, OpenRouter gating #775, kokoro #982. They're part of this release.

## Before tagging (post-merge)
1. Run tier-γ `make release-test` on Strix Halo hardware → `tests/release-gate-report.json`.
2. `git tag -a v0.9.0 && git push origin v0.9.0` → triggers the signed `release.yml` publish.

The `hal0 mcp` `cli.mdx` edit also needs to land in the hal0-web Starlight source, or the next docs-sync reverts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)