### PR TITLE
feat(profiles): ship rocmfpx-rocm / rocmfpx-moe seed profiles for the ROCmFPX runner

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -881,6 +881,35 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "intent": "MoE + MTP · q8 KV",
         "quant": "FP4",
     },
+    "rocmfpx-rocm": {
+        # hal0 ROCmFPX runner (llama.cpp fork, ghcr.io/hal0ai/hal0-rocmfpx —
+        # HIP+Vulkan, Strix Halo gfx1151). ROCm0/HIP lane for the custom ROCmFP4
+        # dense weight format (NOT stock Q4 / MXFP4 / NVFP4). mtp=True is gated by
+        # model_is_mtp_eligible, so it only activates for MTP heads. Per-model KV
+        # and spec-draft tuning come from the model's defaults.extra_args (e.g.
+        # the 27B Coder card pins -ctk q4_0 / draft-type q4_0).
+        "image": "ghcr.io/hal0ai/hal0-rocmfpx:server",
+        "flags": "-ngl 999 -fa on -dev ROCm0 -b 512 -ub 512 --parallel 1 --threads 16 --threads-batch 32 --no-mmap --jinja --metrics --no-webui --ctx-checkpoints 0 --checkpoint-every-n-tokens -1",
+        "mtp": True,
+        "device_class": "gpu",
+        "backend": "rocm",
+        "intent": "ROCmFPX · ROCmFP4 dense · ROCm0 + MTP",
+        "quant": "ROCmFP4",
+    },
+    "rocmfpx-moe": {
+        # hal0 ROCmFPX runner — Vulkan0 lane for the ROCmFPX MoEQuality weight
+        # format (35B-A3B). Vulkan0 gives the best decode t/s for the MoE (ROCm0
+        # wins prefill if a slot overrides -dev). -sm none (single GPU) and
+        # --no-context-shift per the validated Tool-Eval card. The external chat
+        # template (Froggeric Qwen fixed) is set per-slot via [server].extra_args.
+        "image": "ghcr.io/hal0ai/hal0-rocmfpx:server",
+        "flags": "-ngl 999 -fa on -dev Vulkan0 -sm none -b 2048 -ub 512 --parallel 1 --threads 16 --threads-batch 32 --no-context-shift --jinja --metrics --no-webui",
+        "mtp": True,
+        "device_class": "gpu",
+        "backend": "vulkan",
+        "intent": "ROCmFPX · MoEQuality 35B-A3B · Vulkan0 + MTP",
+        "quant": "ROCmFPX",
+    },
     "vulkan": {
         # Strix Halo matrix 2026-07-04 (RADV): -ub sweep monotonic — 256 is the
         # sweet spot (pp2048 274.7 vs 260.7 @512 = +5.4%; 1024 is WORSE at 244.7),

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,13 +42,14 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (12: the rocm/rocm-dnse/rocm-moe trio,
-        vulkan, the experimental NVIDIA cuda profile, the dedicated embed and
-        rerank GPU lanes, flm NPU, the tts/tts-qwen3 pair, the cpu-llm CPU
-        profile #834, and Phase D comfyui)."""
+        """One entry per seed profile (14: the rocm/rocm-dnse/rocm-moe trio,
+        the rocmfpx-rocm/rocmfpx-moe ROCmFPX-runner pair, vulkan, the
+        experimental NVIDIA cuda profile, the dedicated embed and rerank GPU
+        lanes, flm NPU, the tts/tts-qwen3 pair, the cpu-llm CPU profile #834,
+        and Phase D comfyui)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 12
+        assert len(data) == 14
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm container profile to the seeds."""


### PR DESCRIPTION
## What
Adds two built-in `SEED_PROFILES` so the **hal0 ROCmFPX runner** ships to every install instead of living only as operator config on one box:

| Seed | Backend / device | For |
|---|---|---|
| `rocmfpx-rocm` | ROCm0 (HIP) | custom **ROCmFP4** dense weight format (not stock Q4/MXFP4/NVFP4) |
| `rocmfpx-moe` | Vulkan0 | **ROCmFPX MoEQuality** format (35B-A3B) — best decode t/s for the MoE |

Both point at the now-public `ghcr.io/hal0ai/hal0-rocmfpx:server` (llama.cpp fork, HIP+Vulkan, Strix Halo gfx1151), `mtp=True` (gated by `model_is_mtp_eligible`, so it only activates for MTP heads — safe for non-MTP models bound to the profile).

## Why
The ROCmFP4/ROCmFPX lanes were validated end-to-end (build → image → slots → smoke → bench) but only existed as `/etc/hal0/profiles.toml` operator config. Making them seed profiles means a fresh install gets the lanes as first-class, self-healing (virtual-seed) profiles.

## Design
The seeds are generic **runner + device + batch** templates. Per-model KV type, spec-draft/MTP tuning, and the external Froggeric chat template stay on the bound model/slot (`defaults.extra_args` / `[server].extra_args`), matching how the other GPU seeds work.

## Notes
- Runner image is **public** and linked to `Hal0ai/Hal0_ROCmFPX` via `org.opencontainers.image.source`.
- Bench parity confirmed on Strix Halo: new runner ≥ old ROCm/Vulkan images; MTP ~2.1× decode; 35B MoE runs on both Vulkan0 (best decode) and ROCm0 (best prefill).
- Companion PR #1068 adds the ROCmFPX **quant detector** (independent change).

## Tests
Seed-count assertion 12→14 + docstring; `tests/api/test_profiles_route.py` **20 passed**. All seeds validate as `ProfileConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)