### PR TITLE
bench(rocmfpx): exploratory bench results + tooling fixes

### DIFF
--- a/handoffs/rocmfpx-bench-handoff-next-2026-07-05.md
+++ b/handoffs/rocmfpx-bench-handoff-next-2026-07-05.md
@@ -1,0 +1,193 @@
+# ROCmFPX bench — RESULTS + next-session handoff (2026-07-05)
+
+Strix Halo box (gfx1151, 128 GB unified, ~256 GB/s LPDDR5X). Runtime **podman**.
+This closes out the exploratory ROCmFPX profile bench (the `rocmfpx-bench-handoff-2026-07-05.md`
+gate is fully passed: #1068 and #1069 are merged and live), reports results against
+the runbook's pre-registered hypotheses, and hands the next session a **model-selection**
+research task that the bench proved is the dominant performance lever.
+
+Companion docs: `rocmfpx-runner-bench-runbook-2026-07-05.md` (the spec: matrix,
+findings 0.1–0.7, §2 gates, §3 pre-registered deltas), `rocmfpx-bench-results-2026-07-05.md`
+(earlier appendix — this doc supersedes it).
+
+---
+
+## 0. TL;DR
+
+- The bench **could not run as the runbook specified** — three runner-level
+  blockers (per-request MTP override ignored, a cumulative GPU-memory leak, and a
+  stale/wrong-image Tier-A seam) invalidate most of the pre-registered sweep. Those
+  blockers are themselves the highest-value findings.
+- What was delivered instead: the full prereq stack validated live, both FPX
+  profiles set to their **HF-model-card-exact** flags, trustworthy production
+  decode numbers for both FPX models, a draft-KV experiment, a new `saber-fpx`
+  profile, and a **quantitative explanation of the "140 t/s" gap** (it's the quant,
+  not the args).
+- **The seeds already match the vendor cards; there is almost no flag lever left.**
+  The real lever is **model/quant selection per slot** — hence the next-session task.
+
+---
+
+## 1. RESULTS vs the runbook's §3 pre-registered deltas (§2 gate applied)
+
+Production numbers are greedy (temp 0), seeded/card MTP config, `hal0-rocmfpx:7aa484a`
+runner. "Real task" = a genuine LRU-cache code-gen via chat template; "deterministic"
+= the repeated-passage bench prompt (inflates MTP acceptance → decode ceiling).
+
+| Model (slot) | Lane | Decode t/s | Prefill t/s | MTP accept |
+|---|---|---|---|---|
+| 27B dense ROCmFP4 (`code-fpx`) | ROCm0 | **~29** real / ~38.5 synthetic | ~330 | 57% / 85–92% |
+| 35B-A3B MoEQuality (`moe-fpx`/saber) | Vulkan0 | **~76** real / ~95–98 deterministic | ~820 @3.8k-depth | 74% real / ~88–100% det. |
+
+Per-hypothesis verdicts:
+
+- **0.1 Batch shape** — NOT independently re-derived (Tier-A seam blocked, see §2).
+  The merged seed already ships `-b 512 -ub 512` (27B) / `-b 2048 -ub 512` (35B),
+  which **matches the HF card verbatim**. Verdict: **keep** (card-canonical), unproven-on-box.
+- **0.2 KV quant** — 27B main KV `q4_0` and 35B main KV `q8_0` already baked (card).
+  **Draft-KV experiment (relaunch-based, the only valid way — see 0.6):** q8_0 draft
+  helped the 27B (**+6%**, 29→30.8 t/s, accept 57→61%) but **hurt** the 35B (**−4%**,
+  76→73 t/s, accept 74→69%). Per user, reverted to card (27B q4_0, 35B f16). Verdict:
+  **draft-KV is model-specific**; ship the card values; q8 is a live option for the dense 27B only.
+- **0.3 MTP params** — n-max/p-min per card (27B n4/p0.0, 35B n3/p0.25). NOT swept
+  this session (per-request override is dead, see 0.6; relaunch sweep descoped).
+- **0.4 MTP × continuous batching** — NOT measured. The seed ships `--parallel 1`;
+  concurrency needs a relaunch with `--parallel N -np N`, and the memory leak (§2)
+  makes a long np-sweep unsafe without per-cell relaunch. **Open.**
+- **0.5 Vulkan vs HIP lane crossover** — NOT cross-measured (each model stayed on its
+  card lane). Data points: 27B ROCm0 decode ~29–38 t/s / prefill ~330; 35B Vulkan0
+  decode ~76–98 / prefill ~820. Cross-lane runs are **open**.
+- **0.6 Restart-free MTP sweep** — **REJECTED / INVALID.** The 7aa484a runner
+  **ignores per-request `speculative.{n_max,n_min,p_min}`** (draft_n identical for
+  n_max=1 vs 4). MTP params must be swept by **relaunch**.
+- **0.7 HIP env** — **ACCEPTED.** `HSA_OVERRIDE_GFX_VERSION=11.5.1` +
+  `GGML_HIP_ENABLE_UNIFIED_MEMORY=1` added to `code-fpx` `[server].env`; confirmed
+  reaching podman `--env` on the live container. Ship it.
+
+**Concrete seed-flag diffs (net):** the seeds/cards need **no flag changes** beyond
+(a) HIP env on the ROCm lane (done) and (b) an optional bounded `context_size` for
+bench grinds. Everything else already matches the vendor cards. The only *behavioral*
+levers left are **draft-KV q8 for the dense 27B** (+6%, optional) and **model/quant
+selection** (§5 — the real win).
+
+---
+
+## 2. Blockers / findings that reshaped the plan (all reproduced)
+
+1. **Per-request MTP override ignored** (finding 0.6 above) — kills the restart-free sweep.
+2. **Cumulative GPU memory leak → OOM** (`amdgpu BO_VA -12`/ENOMEM) after ~15–18 MTP
+   requests per warm server; smaller ctx only delays it. Relaunch every ≤4 cells.
+   (Source of the stray `oom` file.) NOTE: the card's `-c 262144` (27B) / `-c 65536`
+   (35B) **load fine** — the OOM is the leak under sustained load, not the allocation.
+3. **Tier-A llama-bench seam is stale + wrong image.** `sudo hal0-benchctl` runs
+   `/usr/lib/hal0/bench/` (Jul 4, no fpx cells, old `server_ab.py`) whose `config.sh`
+   hardcodes STOCK toolbox images, not the ROCmFPX fork. FPX Tier-A can't run until the
+   installed harness is refreshed + `config.sh` BACKENDS repointed to `localhost/hal0-rocmfpx:7aa484a`.
+4. **`server_ab.py --mode mtp` mismeasures early-EOS models** — raw `/completion` makes
+   the 35B (strict template) stop at 1 token; use the chat endpoint or `ignore_eos`.
+5. **MTP acceptance is non-deterministic run-to-run even on byte-identical input** —
+   ~1 in 5 runs the draft acceptance collapses (~100% → ~55–60%), dropping decode
+   ~35% (95 → 64 t/s). Decode t/s tracks acceptance ~linearly. Worth a root-cause pass
+   (KV/scheduler state carryover on the warm server).
+
+---
+
+## 3. The "140 t/s" question (answered — important for §5)
+
+A friend gets ~140 t/s on the SABER model with the *same args*; this box gets ~95
+(deterministic ceiling). **It is the quant, not the config** (our resolved command
+matches their paste exactly):
+
+- Friend: `...NSC-ACE-SABER-MTP-F16-to-ROCmFP4-STRIX_LEAN.gguf` (~4 bpw, ~19 GB).
+- Ours:   `...Ace-Saber-MTP-ROCmFPX-MoEQuality-7.07BPW.gguf` (7.07 bpw, 29.3 GB).
+
+Decode on this APU is **memory-bandwidth-bound** (~256 GB/s). A3B ≈ 3B active params/token:
+FP4 → ~1.5 GB/token → ~170 t/s ceiling; 7.07 BPW → ~2.6 GB/token → ~98 t/s ceiling.
+Both parties sit at the ceiling for their quant. Size ratio 29.3/19 = **1.54×** predicts
+95 × 1.54 = **146 t/s** — brackets the friend's 140. The FP4 STRIX_LEAN saber is **not on
+the box** (only a 125-byte HF download stub: `...STRIX_LEAN.gguf.metadata`). Friend also
+built a decode-tuned Vulkan branch (`wt-submit-fpx-vulkan-fp3-speed`), a secondary few-%.
+
+**Takeaway that drives §5:** on Strix Halo, **quant choice ≈ decode speed**. Model/quant
+selection per slot is a bigger lever than any flag.
+
+---
+
+## 4. On-box state (what changed — all documented, reversible)
+
+- **Live/serving:** `moe-fpx` is loaded on the new `saber-fpx` profile serving
+  `CHADROCK-35B-Ace-Saber-MTP-ROCmFPX-MoEQuality-7.07BPW.gguf` (ctx 32768). `code-fpx`
+  is offline with card flags applied. The `hal0` gateway + remote `minimax` were never
+  stopped (GPU was already idle — no assistant disruption).
+- **Profiles:** new custom `[profile.saber-fpx]` in `/etc/hal0/profiles.toml` (throughput
+  config, image pinned `localhost/hal0-rocmfpx:7aa484a`, `--no-mmproj` text-only,
+  f16 KV, n4/p0.0, sampler baked). Seed `rocmfpx-rocm`/`rocmfpx-moe` images overridden
+  to `:7aa484a` in the **venv** `SEED_PROFILES` (ephemeral — lost on release; seeds are
+  virtual so `profiles.toml` edits to them are no-ops).
+- **Registry:** `moe-fpx`/`code-fpx` model `defaults.extra_args` carry card flags;
+  `moe-fpx` slot `[server].extra_args` forces `--spec-draft-p-min 0.0` (wins over model 0.25).
+- **Contexts:** slot `context_size` set to card values (27B 262144, 35B 32768 for the saber bench).
+- **venv src:** synced to origin/main (#1068 detector + #1069 seeds live in the running
+  `hal0-api`; it imports from venv site-packages, NOT an editable checkout).
+- **Backups:** `/etc/hal0/fpx-bench-backup-20260705/`, `/var/lib/hal0/venv-fpx-backup-20260705/`,
+  `/var/lib/hal0/registry/registry.toml.bak-draftkv8-20260705`.
+- **Bench display fix:** `installer/bench/generate_results_json.py` now ingests
+  `server-ab/*.json` into a Tier B/C SUMMARY section (was Tier-A-only). Staged on branch
+  `bench/rocmfpx-explore-2026-07-05`, not committed.
+
+---
+
+## 5. NEXT SESSION — research & pick optimized models for slot/stack layouts
+
+This is the highest-value follow-up. The bench proved flags are mostly maxed and the
+runner is the constraint; the open lever is **which model + which quant runs in which
+slot**, and **which slots co-reside in a stack**. Spend real time here — treat it as
+research, not a mechanical config edit.
+
+**Ground truth to reason from:**
+- Decode t/s ≈ `mem_bandwidth / (active_params × bytes_per_weight)`; Strix Halo ≈
+  256 GB/s. So on an A3B MoE: FP4 ≈ ~140–170 t/s, 7BPW ≈ ~95 t/s, Q8 ≈ ~50 t/s.
+  Dense models pay full param count every token (27B dense ROCmFP4 ≈ ~29 t/s).
+- Prefill is compute-bound and lane-sensitive (Vulkan0 strong: ~820 t/s @ 3.8k; ROCm ~330).
+- Total unified budget 128 GB; GTT is the real constraint for co-residency (each 35B
+  MoEQuality ≈ 33 GB resident; FP4 ≈ ~20 GB). Stacks that co-load multiple GPU slots
+  must fit the sum + KV.
+- Quant is a **quality↔speed** trade: FP4 STRIX_LEAN = fast/leaner; MoEQuality 7.07 =
+  accurate/heavy. Match to the slot's job.
+
+**Deliverables for the next session:**
+1. **Inventory** every model/quant available (and pullable) per role — `hal0 model list`,
+   the registry, `/mnt/ai-models`, and the HF repos (`jcbtc/*`, `GestaltLabs/*`,
+   `Qwen-AgentWorld`, `fastcontext`, etc.). Record size, bpw, active params, lane,
+   MTP/vision, and the vendor card's recommended args for each.
+2. **Per-slot recommendation** — for each functional slot (assistant/chat, coder,
+   agent/tool-calling, nano/fast-context, explore, embed/rerank, vision), pick the
+   model+quant that best fits its latency/quality/memory profile, with the predicted
+   decode t/s and the reasoning. E.g.: interactive assistant → favor FP4 STRIX_LEAN for
+   speed; quality-critical coding/agent → MoEQuality; nano → smallest fast draft.
+3. **Stack layouts** — propose 2–3 concrete `stacks.toml` layouts (which slots co-reside)
+   that fit the 128 GB / GTT budget and the GPU arbiter's single-GPU reality, e.g. a
+   "coding" stack, an "agent fan-in" stack, a "voice+vision" stack. Note eviction/
+   co-residency (the ~31 GB GTT floor caveat) and which lane each slot takes.
+4. **The FP4-vs-MoEQuality decision for SABER** — decide whether to pull the ~19 GB FP4
+   STRIX_LEAN saber (HF `jcbtc/chadrock-35b-ace-saber-rocmfp4-mtp`, only a stub on-box
+   now) for the ~140 t/s throughput lane, keep MoEQuality for quality, or run BOTH as
+   selectable models on the `moe-fpx`/saber slot. Bench both head-to-head on the
+   deterministic prompt if pulled.
+5. Optionally evaluate building the `fp3-speed` Vulkan runner for the last few %.
+
+**Method note:** use the deep-research / model-card reading approach, not guesswork —
+each `jcbtc/*` card documents the intended quant/lane/args. Cross-check against the
+bandwidth math above so every recommendation has a predicted t/s, not a vibe.
+
+---
+
+## 6. To resume the bench itself (if flags get revisited)
+
+- Slot is warm-restart-sensitive to the leak → run ≤4 cells then `hal0 slot load <slot>`.
+- MTP param sweeps: **relaunch per value** (edit model `defaults.extra_args` or slot
+  `[server].extra_args`, restart `hal0-api`, reload slot) — per-request JSON is ignored.
+- Always `--runner-image hal0-rocmfpx:7aa484a`; bench via `server_ab.py` from the
+  worktree (the installed seam harness is stale). Use `ignore_eos` + a real/deterministic
+  prompt; report decode + acceptance together (decode tracks acceptance).
+- Restore: leave FPX slots offline; backups listed in §4.

--- a/handoffs/rocmfpx-bench-results-2026-07-05.md
+++ b/handoffs/rocmfpx-bench-results-2026-07-05.md
@@ -1,0 +1,91 @@
+# ROCmFPX exploratory bench — RESULTS (2026-07-05)
+
+Ran on the Strix Halo box (gfx1151, 128 GB unified) after #1068/#1069 merged.
+Runner: `localhost/hal0-rocmfpx:7aa484a` (a066ead70b2d) on both FPX slots.
+Scope (per user): **FPX / FP4 / MTP models only** — `code-fpx` (27B ROCmFP4
+dense, ROCm0) and `moe-fpx` (35B-A3B ROCmFPX MoEQuality, Vulkan0).
+
+## Headline numbers (greedy temp=0, seeded MTP config, real code-gen chat task)
+
+| Model (slot) | Lane | Decode t/s | MTP accept | Prefill @depth2k |
+|---|---|---:|---:|---:|
+| 27B dense (`code-fpx`) | ROCm0 | **~29** (real task) / ~38.5 (synthetic prompt) | 57% / 85–92% | ~330 |
+| 35B-A3B MoE (`moe-fpx`) | Vulkan0 | **~76** | 74% | ~1040 |
+
+**The A3B MoE on Vulkan decodes ~2.6× faster and prefills ~3× faster than the
+dense 27B on ROCm** (3B active params vs 27B dense). For the two most-used FPX
+models, `moe-fpx` is by far the stronger performer.
+
+Decode is prompt-sensitive: the 27B's synthetic depth-2k prompt gave 85–92%
+acceptance (→38.5 t/s); a genuine LRU-cache task gave 57% (→29 t/s). Report the
+real-task numbers as production-representative.
+
+## Blockers / findings that reshape the plan (all real, all reproduced)
+
+1. **Per-request MTP override is IGNORED by the 7aa484a runner.** `speculative.
+   {n_max,n_min,p_min}` in the `/completion` JSON does nothing: `draft_n=116,
+   accepted=98` identical for n_max=1 vs n_max=4. This **invalidates runbook
+   finding 0.6** (restart-free MTP sweep) — every `--mode mtp` cell measured the
+   same launch-time config. MTP params must be swept by RELAUNCH (`--mode ab`
+   variant flags or model `defaults.extra_args` edits), not per-request JSON.
+
+2. **Cumulative GPU memory leak → OOM (`amdgpu BO_VA -12` / ENOMEM).** The
+   runner leaks across MTP requests: crashed at cell 5 (168k ctx) / cell 7 (40k
+   ctx), i.e. ~15–18 requests per server session regardless of ctx size (smaller
+   ctx only delays it). Mitigation: **relaunch the slot every ≤4 cells.** This is
+   why prior sessions left a stray `oom` file.
+
+3. **168k/65k seed context OOMs on load-under-pressure.** Bounded both FPX slots
+   to `context_size = 40960` (`/etc/hal0/slots/{code-fpx,moe-fpx}.toml`). **128k
+   depth is memory-infeasible** for 27B+MTP here; depth >~24k fails HTTP 400
+   against the 40k bound.
+
+4. **Tier-A llama-bench FPX cells are un-runnable via the seam.** `sudo
+   hal0-benchctl` runs a STALE installed harness (`/usr/lib/hal0/bench/`, Jul 4 —
+   no fpx cells, old `server_ab.py`) whose `config.sh` hardcodes STOCK toolbox
+   images (`amd-strix-halo-toolboxes:*`), not the ROCmFPX fork. FPX weights need
+   the 7aa484a runner. → Tier A deferred; Tier B/C `server_ab.py` (real runner,
+   `--runner-image`) is the only valid path. To enable Tier A: refresh the
+   installed harness + point `config.sh` BACKENDS at `localhost/hal0-rocmfpx:7aa484a`.
+
+5. **`server_ab.py --mode mtp` mismeasures early-EOS models.** Raw `/completion`
+   prompts make the 35B (strict Froggeric template) stop after 1 token
+   (`predicted_n=1`). Needs `ignore_eos` or the chat endpoint. Tool gap to fix.
+
+## Seed-flag verdicts (§2 gate applied)
+
+- **27B `-b 512 -ub 512`, `-ctk/-ctv q4_0`**: already baked in the merged seed
+  (verified in resolved command). NOT re-derived via Tier A (seam blocked), but
+  the seed matches the fork's own optimization doc — **keep**.
+- **35B `-b 2048 -ub 512`, main KV q8/q8, draft-KV f16, n-max 3 p-min 0.25,
+  `--no-spec-draft-backend-sampling`**: baked in seed; runs at ~76 t/s / 74%
+  accept — **keep** (no evidence to change; draft-KV q4 hypothesis untested
+  because per-request/ab sweep needs relaunch and was descoped this session).
+- **HIP env** (`HSA_OVERRIDE_GFX_VERSION=11.5.1`,
+  `GGML_HIP_ENABLE_UNIFIED_MEMORY=1`): **added** to `code-fpx` `[server].env`
+  (confirmed reaching podman `--env`). ROCm lane was previously env-less. SHIP
+  this to the seed/slot.
+- **context_size**: seed 168k/65k → **40960** (OOM fix). Recommend the seed
+  ship a bounded default for the FPX MTP slots on gfx1151.
+- **image**: bench used `localhost/hal0-rocmfpx:7aa484a`; seed ships `:server`
+  (identical intent, local-only tag). No seed change — repoint per-box.
+
+## On-box changes left in place (documented, reversible)
+
+- `/etc/hal0/slots/code-fpx.toml`: `[server.env]` HIP vars; `context_size 40960`.
+- `/etc/hal0/slots/moe-fpx.toml`: `context_size 40960`.
+- venv `SEED_PROFILES` rocmfpx-rocm/moe image → `localhost/hal0-rocmfpx:7aa484a`
+  (marked `BENCH-OVERRIDE`; ephemeral — lost on next release). Backups:
+  `/etc/hal0/fpx-bench-backup-20260705/`, `/var/lib/hal0/venv-fpx-backup-20260705/`.
+- venv src synced to origin/main (#1068 detector + #1069 seeds now live).
+- Both FPX slots left **offline** (pre-bench run state). Live `hal0` gateway +
+  remote `minimax` never stopped (GPU was already idle).
+
+## Display improvement (the other ask)
+
+`installer/bench/generate_results_json.py` now ingests `server-ab/*.json` and
+renders a **Tier B/C section** (decode t/s · draft accept % · concurrency
+aggregate/per-stream/TTFT) in SUMMARY.md — previously it only showed Tier-A
+llama-bench and could not display ANY of this bench's output. Also: short model
+names + a `quant` column (ROCMFP4·MTP etc.). Staged on branch
+`bench/rocmfpx-explore-2026-07-05`.

--- a/handoffs/rocmfpx-runner-bench-runbook-2026-07-05.md
+++ b/handoffs/rocmfpx-runner-bench-runbook-2026-07-05.md
@@ -91,13 +91,17 @@ Each is a hypothesis to CONFIRM on our box, with the source that motivates it.
   slot may want the ROCm lane at high `-np`**. → Cell **LANE** (every model on
   BOTH lanes) and the LANE×NP crossover is the headline result.
 
-### 0.6 Restart-free MTP sweeps via per-request JSON
-- **Finding:** the fork accepts per-request `speculative.{n_max,n_min,p_min}`
-  in the `/completion` JSON (helper `scripts/rocmfpx-draft-profile.py`). MTP
-  param sweeps need **no server restart** — only KV-quant / batch-shape /
-  lane changes require a relaunch. This collapses Cell MTP from ~12 restarts
-  to a single warm server. `server_ab.py --mode batch` should pass these
-  through (small enhancement, see §4).
+### 0.6 Restart-free MTP sweeps via per-request JSON — DISPROVEN on this build
+- **Original hypothesis:** the fork's docs reference per-request
+  `speculative.{n_max,n_min,p_min}` (helper `scripts/rocmfpx-draft-profile.py`),
+  which would let Cell MTP run against one warm server (no restart per cell).
+- **BENCH RESULT (2026-07-05):** the ROCmFPX runner at **7aa484a silently
+  IGNORES** the per-request override — swept cells returned identical numbers.
+  So MTP param sweeps DO need a relaunch per value, same as KV/batch/lane.
+  `--mode mtp` relaunches by default; the per-request path is retained behind
+  `--per-request` only for a future build that honors it. Practical impact:
+  MTP sweeps are relaunch-bound (≤4 cells/session per the resume note, §6 of
+  the results handoff).
 
 ### 0.7 Env + build facts to pin before trusting any number
 - **HIP lane requires:** `HSA_OVERRIDE_GFX_VERSION=11.5.1`,
@@ -120,11 +124,14 @@ Two models × the axes below. Models: **27B** = `code-fpx`
 (CHADROCK3.6-35B-A3B ROCmFPX MoEQuality 7.08 BPW). Both ship mmproj (vision)
 and an MTP head. Froggeric template on the 35B; `--jinja` embedded on the 27B.
 
-**Depth axis (applies to every decode cell):** ctx-fill **2k / 32k / 128k**.
-Rationale: the model card's own sweep shows decode 21→12.5→7 t/s and PP
-316→201→142 across 4k→65k→130k with acceptance FLAT (~40%). Tuning at 2k and
-shipping for agents that run at 32k+ is how we mis-tune. Every "best" is
-reported per depth.
+**Depth axis (applies to every decode cell):** ctx-fill **2k / ~24k** (NOT
+128k). Rationale: the model card's own sweep shows decode 21→12.5→7 t/s and PP
+316→201→142 across 4k→65k→130k with acceptance FLAT (~40%), so depth matters —
+but the 2026-07-05 bench found **128k is memory-infeasible** for 27B+MTP on
+this box (cumulative-leak OOM, blocker #2 in the results appendix) and the FPX
+slots are bounded to `context_size = 40960`; a depth request >~24k returns HTTP
+400 against that bound. Sweep 2k and ~24k; treat deeper depths as blocked until
+the runner's per-request memory leak is fixed upstream.
 
 **Sampler axis (every MTP cell):** run **greedy** (temp 0, upper-bound
 acceptance) AND **production sampler** (27B: `temp 0.6 top-p 0.95 top-k 20`
@@ -225,11 +232,17 @@ today's seeds; the runbook either confirms → we ship, or rejects → we keep.
 Items 1–3 are DONE on `claude/llamacpp-strix-halo-flags-cyzyo8` (the box just
 runs; it does not build). Item 4 is box-side config.
 
-1. **DONE — `server_ab.py --mode mtp`** — restart-free per-request MTP sweep:
-   `--spec-nmax`/`--spec-pmin` (comma-lists) + `--spec-nmin` sent as
-   `speculative.*` in the `/completion` JSON (0.6). Depth axis via `--depth`
-   (2k/32k/128k); sampler axis via `--temp`/`--top-p`/`--top-k` (greedy vs
-   production). Reports decode t/s + draft acceptance per (n_max, p_min) cell.
+1. **DONE — `server_ab.py --mode mtp`** — MTP draft-param sweep:
+   `--spec-nmax`/`--spec-pmin` (comma-lists) + `--spec-nmin`. **CORRECTION
+   (post-bench):** finding 0.6's restart-free per-request override is DEAD on
+   this runner — the ROCmFPX build at 7aa484a **silently ignores** the
+   per-request `speculative.*` JSON, so every cell would read the launch-time
+   config. `--mode mtp` therefore **relaunches per value** (writes
+   `--spec-draft-*` into `[server].extra_args` + restart, like `--mode ab`);
+   `--per-request` opts back into the ignored path for a future build that
+   honors it. Depth axis via `--depth` (2k/32k/128k); sampler axis via
+   `--temp`/`--top-p`/`--top-k` (greedy vs production). Reports decode t/s +
+   draft acceptance per (n_max, p_min) cell.
 2. **DONE — `profile-matrix.sh` FPX cells** — `fpx-batch` (A-BATCH),
    `fpx-kv27`/`fpx-kv35` (A-KVQ three-way q4/q8/f16), `fpx-lane` (A-LANE), plus
    `FPX_DENSE`/`FPX_MOE` model vars and refreshed Tier B guidance (mtp mode,

--- a/installer/bench/generate_results_json.py
+++ b/installer/bench/generate_results_json.py
@@ -13,11 +13,12 @@ benchmark history so the datasets can later merge.
 
 Results dir resolution: argv[1] > $HAL0_BENCH_RESULTS > /var/lib/hal0/benchmarks
 """
+
 import json
 import os
 import sys
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 if len(sys.argv) > 1:
     RESULT_DIR = sys.argv[1]
@@ -100,9 +101,7 @@ def collect():
         if not fname.endswith(".json") or fname.endswith(".meta.json"):
             continue
         path = os.path.join(RUNS_DIR, fname)
-        mtime_iso = datetime.fromtimestamp(
-            os.path.getmtime(path), tz=timezone.utc
-        ).isoformat()
+        mtime_iso = datetime.fromtimestamp(os.path.getmtime(path), tz=UTC).isoformat()
         try:
             with open(path) as fh:
                 rows = json.load(fh)
@@ -167,12 +166,14 @@ def write_summary(records):
     lines.append("# Strix Halo Benchmark Summary")
     lines.append("")
     lines.append(
-        f"Generated {datetime.now(tz=timezone.utc).isoformat()} · "
+        f"Generated {datetime.now(tz=UTC).isoformat()} · "
         f"{len(records)} measurements · backends: {', '.join(backends) or 'none'}"
     )
     lines.append("")
-    lines.append("Throughput in tokens/sec (avg±stddev). "
-                 "**pp** = prompt processing, **tg** = token generation.")
+    lines.append(
+        "Throughput in tokens/sec (avg±stddev). "
+        "**pp** = prompt processing, **tg** = token generation."
+    )
     lines.append("")
 
     lines.append("## Tier A — llama-bench (single-stream kernel shape)")
@@ -235,8 +236,9 @@ def _fnum(x):
 def _cell_metrics(val):
     """Pull the display metrics out of one label's result block, whatever the
     mode. `median` (ab/batch/mtp) or `second_call` (reuse) or the block itself."""
-    empty = {k: None for k in
-             ("prefill", "decode", "accept", "aggregate", "per_stream", "ttft_p95")}
+    empty = {
+        k: None for k in ("prefill", "decode", "accept", "aggregate", "per_stream", "ttft_p95")
+    }
     if not isinstance(val, dict):
         return empty
     m = val.get("median") or val.get("second_call") or val
@@ -312,7 +314,7 @@ def main():
 
     index_path = os.path.join(RESULT_DIR, "index.json")
     out = {
-        "generated": datetime.now(tz=timezone.utc).isoformat(),
+        "generated": datetime.now(tz=UTC).isoformat(),
         "count": len(records),
         "records": records,
         "server_ab": server_ab,
@@ -326,8 +328,7 @@ def main():
         fh.write("\n")
         fh.write(write_server_ab_section(server_ab))
 
-    print(f"Wrote {index_path} ({len(records)} measurements, "
-          f"{len(server_ab)} server-ab files)")
+    print(f"Wrote {index_path} ({len(records)} measurements, {len(server_ab)} server-ab files)")
     print(f"Wrote {summary_path}")
 
 

--- a/installer/bench/generate_results_json.py
+++ b/installer/bench/generate_results_json.py
@@ -125,15 +125,43 @@ def fmt_ts(rec):
     return f"{m['avg_ts']:.1f}±{sd:.1f}"
 
 
+def short_model(name):
+    """Display name: drop the dir prefix and the .gguf suffix so the table
+    reads as a model, not a filesystem path."""
+    if not name:
+        return "?"
+    base = name.rsplit("/", 1)[-1]
+    if base.lower().endswith(".gguf"):
+        base = base[: -len(".gguf")]
+    return base
+
+
+# Quant families we care about for the FPX/FP4/MTP bench (finding 0.2/0.3).
+_QUANT_TAGS = ("ROCMFPX", "ROCMFP8", "ROCMFP6", "ROCMFP4", "ROCMFP3")
+
+
+def quant_tag(rec):
+    """Short quant/speculation label from model.type + name, e.g. `ROCMFP4·MTP`.
+    Empty for models outside the FPX/FP4/MTP family so the focused view can
+    filter on it."""
+    hay = f"{rec['model'].get('type') or ''} {rec['model'].get('name') or ''}".upper()
+    parts = [t for t in _QUANT_TAGS if t in hay]
+    fam = parts[0] if parts else ""
+    if "MTP" in hay:
+        fam = f"{fam}·MTP" if fam else "MTP"
+    return fam
+
+
 def write_summary(records):
     """Markdown table: rows = model x context x tag, columns = backend (pp / tg t/s)."""
     backends = sorted({r["backend"] for r in records if r.get("backend")})
     grid = defaultdict(lambda: defaultdict(dict))
     for r in records:
-        mname = r["model"]["name"] or "?"
+        mname = short_model(r["model"]["name"])
+        quant = quant_tag(r)
         ctx = r.get("context", "default")
         tag = r.get("tag") or ""
-        grid[(mname, ctx, tag)][r.get("backend")][r["test"]] = fmt_ts(r)
+        grid[(mname, quant, ctx, tag)][r.get("backend")][r["test"]] = fmt_ts(r)
 
     lines = []
     lines.append("# Strix Halo Benchmark Summary")
@@ -147,16 +175,18 @@ def write_summary(records):
                  "**pp** = prompt processing, **tg** = token generation.")
     lines.append("")
 
-    header = ["model", "context", "tag"]
+    lines.append("## Tier A — llama-bench (single-stream kernel shape)")
+    lines.append("")
+    header = ["model", "quant", "context", "tag"]
     for b in backends:
         header += [f"{b} pp", f"{b} tg"]
     lines.append("| " + " | ".join(header) + " |")
     lines.append("|" + "|".join(["---"] * len(header)) + "|")
 
     for key in sorted(grid):
-        mname, ctx, tag = key
+        mname, quant, ctx, tag = key
         cells = grid[key]
-        row = [mname, ctx, tag or "-"]
+        row = [mname, quant or "-", ctx, tag or "-"]
         for b in backends:
             row.append(cells.get(b, {}).get("pp", "-"))
             row.append(cells.get(b, {}).get("tg", "-"))
@@ -166,8 +196,118 @@ def write_summary(records):
     return "\n".join(lines) + "\n"
 
 
+def collect_server_ab():
+    """Ingest server_ab.py output (Tier B/C: MTP draft sweeps, concurrency,
+    cache-reuse). These carry the metrics Tier A can't — decode t/s under
+    speculation, draft-acceptance %, and aggregate/per-stream/TTFT under
+    -np>1 — which is the whole point of the FPX/FP4/MTP bench. Each file is
+    `{mode, slot, provenance, results:{label:{...median...}}}`."""
+    sa_dir = os.path.join(RESULT_DIR, "server-ab")
+    docs = []
+    if not os.path.isdir(sa_dir):
+        return docs
+    for fname in sorted(os.listdir(sa_dir)):
+        if not fname.endswith(".json"):
+            continue
+        try:
+            with open(os.path.join(sa_dir, fname)) as fh:
+                doc = json.load(fh)
+        except (OSError, ValueError) as exc:
+            print(f"  [warn] skipping unreadable {fname}: {exc}", file=sys.stderr)
+            continue
+        # Current server_ab.py wraps results in a dict; skip legacy bare-list files.
+        if not isinstance(doc, dict) or "results" not in doc:
+            print(f"  [warn] {fname}: legacy/unknown shape, skipped", file=sys.stderr)
+            continue
+        # This section covers the decode/draft/concurrency modes (the FPX/FP4/MTP
+        # story). embed/rerank have a flat, non-label results shape — skip them.
+        if doc.get("mode") not in ("ab", "batch", "mtp", "reuse"):
+            continue
+        doc["_file"] = fname
+        docs.append(doc)
+    return docs
+
+
+def _fnum(x):
+    return "-" if x is None else (f"{x:.1f}" if isinstance(x, float) else str(x))
+
+
+def _cell_metrics(val):
+    """Pull the display metrics out of one label's result block, whatever the
+    mode. `median` (ab/batch/mtp) or `second_call` (reuse) or the block itself."""
+    empty = {k: None for k in
+             ("prefill", "decode", "accept", "aggregate", "per_stream", "ttft_p95")}
+    if not isinstance(val, dict):
+        return empty
+    m = val.get("median") or val.get("second_call") or val
+    if not isinstance(m, dict):
+        return empty
+    return {
+        "prefill": m.get("prompt_per_second"),
+        "decode": m.get("predicted_per_second"),
+        "accept": m.get("draft_acceptance_pct"),
+        "aggregate": m.get("aggregate_tps"),
+        "per_stream": m.get("per_stream_tps"),
+        "ttft_p95": m.get("ttft_p95_s"),
+    }
+
+
+def write_server_ab_section(docs):
+    lines = ["## Tier B/C — server (MTP · draft · concurrency)", ""]
+    if not docs:
+        lines.append("_No server-ab results yet._")
+        lines.append("")
+        return "\n".join(lines) + "\n"
+    lines.append(
+        "Live-server measurements: decode t/s under speculation, draft "
+        "acceptance, and concurrency aggregate/per-stream/TTFT. Governing "
+        "metric per §2 is **net decode t/s at the production sampler**."
+    )
+    lines.append("")
+    for doc in docs:
+        prov = doc.get("provenance") or {}
+        img = prov.get("runner_image") or "?"
+        depth = prov.get("depth_tokens")
+        temp = (prov.get("sampler") or {}).get("temperature")
+        meta = [f"mode={doc.get('mode')}"]
+        if depth is not None:
+            meta.append(f"depth~{depth}")
+        if temp is not None:
+            meta.append(f"temp {temp}")
+        meta.append(f"img={img}")
+        if prov.get("note"):
+            meta.append(f"note={prov['note']}")
+        lines.append(f"### {doc.get('slot', '?')} · " + " · ".join(meta))
+        lines.append("")
+        results = doc.get("results") or {}
+        is_batch = doc.get("mode") == "batch" or any(
+            _cell_metrics(v).get("aggregate") is not None for v in results.values()
+        )
+        if is_batch:
+            lines.append("| cell | aggregate t/s | per-stream t/s | TTFT p95 s |")
+            lines.append("|---|---|---|---|")
+            for label, val in results.items():
+                c = _cell_metrics(val)
+                lines.append(
+                    f"| {label} | {_fnum(c['aggregate'])} | "
+                    f"{_fnum(c['per_stream'])} | {_fnum(c['ttft_p95'])} |"
+                )
+        else:
+            lines.append("| cell | decode t/s | prefill t/s | draft accept % |")
+            lines.append("|---|---|---|---|")
+            for label, val in results.items():
+                c = _cell_metrics(val)
+                lines.append(
+                    f"| {label} | {_fnum(c['decode'])} | "
+                    f"{_fnum(c['prefill'])} | {_fnum(c['accept'])} |"
+                )
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
 def main():
     records = collect()
+    server_ab = collect_server_ab()
     os.makedirs(RESULT_DIR, exist_ok=True)
 
     index_path = os.path.join(RESULT_DIR, "index.json")
@@ -175,6 +315,7 @@ def main():
         "generated": datetime.now(tz=timezone.utc).isoformat(),
         "count": len(records),
         "records": records,
+        "server_ab": server_ab,
     }
     with open(index_path, "w") as fh:
         json.dump(out, fh, indent=2)
@@ -182,8 +323,11 @@ def main():
     summary_path = os.path.join(RESULT_DIR, "SUMMARY.md")
     with open(summary_path, "w") as fh:
         fh.write(write_summary(records))
+        fh.write("\n")
+        fh.write(write_server_ab_section(server_ab))
 
-    print(f"Wrote {index_path} ({len(records)} measurements)")
+    print(f"Wrote {index_path} ({len(records)} measurements, "
+          f"{len(server_ab)} server-ab files)")
     print(f"Wrote {summary_path}")
 
 

--- a/installer/bench/profile-matrix.sh
+++ b/installer/bench/profile-matrix.sh
@@ -148,9 +148,12 @@ embed/rerank endpoints. Use server_ab.py (same dir) against live slots:
   # MTP draft grid (ROCmFPX): restart-free per-request n_max x p_min sweep at
   # depth, greedy AND production sampler. The seeded bundle hardcodes n-max 4 /
   # p-min 0.0; the fork says these are model+depth-specific (runbook B-MTP).
-  ./server_ab.py --mode mtp --slot code-fpx --depth 2000  --spec-nmax 1,2,3,4 --spec-pmin 0.0,0.25,0.5,0.75
-  ./server_ab.py --mode mtp --slot code-fpx --depth 32768 --spec-nmax 1,2,3,4 --spec-pmin 0.0,0.25
-  ./server_ab.py --mode mtp --slot code-fpx --depth 2000  --temp 0.6 --top-p 0.95 --top-k 20  # production sampler
+  # mtp mode relaunches per (n_max,p_min) — 7aa484a ignores per-request override.
+  # Depth <=24k: the FPX slots are ctx-bounded to 40960 (OOM fix); 128k infeasible.
+  # Relaunch every <=4 cells (runner leaks GPU mem across MTP requests -> OOM).
+  ./server_ab.py --mode mtp --slot code-fpx --depth 2000  --spec-nmax 2,4 --spec-pmin 0.0,0.5
+  ./server_ab.py --mode mtp --slot code-fpx --depth 24000 --spec-nmax 2,4 --spec-pmin 0.0
+  ./server_ab.py --mode mtp --slot code-fpx --depth 2000  --temp 0.6 --top-p 0.95 --top-k 20 --spec-nmax 4 --spec-pmin 0.0  # production sampler
 
   # Draft-KV quant needs a relaunch (per-request can't change it) — use ab.
   # Fork: 27B wants q4 draft KV, 35B wants q4 draft + q8 main.

--- a/installer/bench/server_ab.py
+++ b/installer/bench/server_ab.py
@@ -32,12 +32,12 @@ Modes
           --concurrency simultaneous /completion streams, and report aggregate
           t/s, per-stream median, and p95 TTFT. The Tier C measurement behind
           the concurrency-batching plan. Restores the original `parallel`.
-  mtp     Restart-free MTP draft-param sweep. The ROCmFPX fork accepts
-          per-request `speculative.{n_max,n_min,p_min}`, so the --spec-nmax x
-          --spec-pmin grid runs against ONE warm server (no restart per cell).
-          Depth via --depth (2k/32k/128k); greedy vs production sampler via
-          --temp/--top-p/--top-k. Reports decode t/s + draft acceptance per
-          cell (runbook B-MTP). Slot must already be running with MTP on.
+  mtp     MTP draft-param sweep over --spec-nmax x --spec-pmin at --depth
+          (2k/32k/128k) and a chosen sampler (--temp/--top-p/--top-k: greedy vs
+          production). Relaunches per cell so the draft params take effect —
+          the ROCmFPX runner at 7aa484a IGNORES the per-request speculative.*
+          override (--per-request opts into it anyway, for a future build that
+          honors it). Reports decode t/s + draft acceptance per cell (B-MTP).
 
 Results: JSON to --out (default /var/lib/hal0/benchmarks/server-ab/<stamp>.json).
 
@@ -157,16 +157,24 @@ def _completion(
     *,
     sampler: dict | None = None,
     speculative: dict | None = None,
+    ignore_eos: bool = True,
 ) -> dict:
     """One /completion call; returns llama-server's timings dict (+ our wall).
 
     ``sampler`` defaults to greedy (temp 0) for reproducibility; pass
     ``_sampler_body(args)`` for a production sampler. ``speculative`` carries a
-    per-request MTP override (``_spec_override(...)['speculative']``)."""
+    per-request MTP override (``_spec_override(...)['speculative']``).
+
+    ``ignore_eos`` defaults True: a decode-throughput measurement needs the full
+    ``n_predict`` tokens, but a strict chat template (e.g. the 35B's Froggeric)
+    emits EOS after ~1 token on a raw /completion prompt, collapsing
+    ``predicted_n`` to 1 and making the t/s meaningless. Off only for the reuse
+    trace, where the natural stop is fine."""
     body: dict[str, Any] = {
         "prompt": prompt,
         "n_predict": n_predict,
         "cache_prompt": cache_prompt,
+        "ignore_eos": ignore_eos,
     }
     body.update(sampler or {"temperature": 0})
     if speculative:
@@ -253,10 +261,18 @@ def mode_reuse(args: argparse.Namespace) -> dict:
             # measurement — with reuse the shared prefix is KV-shifted, without
             # it the whole prompt reprocesses.
             _completion(
-                port, REUSE_PREFIX + "Summarize the first paragraph.", 32, cache_prompt=True
+                port,
+                REUSE_PREFIX + "Summarize the first paragraph.",
+                32,
+                cache_prompt=True,
+                ignore_eos=False,
             )
             second = _completion(
-                port, REUSE_PREFIX + "List three key claims.", 32, cache_prompt=True
+                port,
+                REUSE_PREFIX + "List three key claims.",
+                32,
+                cache_prompt=True,
+                ignore_eos=False,
             )
             print(f"  second-call timings: {second}", flush=True)
             results[label] = {"extra_args": merged, "second_call": second}
@@ -402,47 +418,81 @@ def _csv_floats(raw: str) -> list[float]:
 
 
 def mode_mtp(args: argparse.Namespace) -> dict:
-    """Restart-free MTP draft-param sweep. The ROCmFPX fork accepts
-    `speculative.{n_max,n_min,p_min}` per /completion request, so the whole
-    n-max x p-min grid runs against ONE warm server — no PUT/restart per cell
-    (runbook cell B-MTP, finding 0.6). Draft-KV quant is NOT swept here (that
-    needs a relaunch — do it with --mode ab). Reports decode t/s + draft
-    acceptance per (n_max, p_min) so the per-model/per-depth winner is picked
-    on NET decode, not acceptance alone (greedy acceptance is a ceiling)."""
+    """MTP draft-param sweep over the --spec-nmax x --spec-pmin grid at a given
+    --depth and sampler, reporting decode t/s + draft acceptance per cell so the
+    winner is picked on NET decode (greedy acceptance is a ceiling, not a ship
+    metric). Draft-KV quant is NOT swept here (use --mode ab).
+
+    Default is RELAUNCH-PER-VALUE: each cell writes `--spec-draft-n-max/-n-min/
+    -p-min` into [server].extra_args and restarts (like mode_ab). The
+    per-request `speculative.*` JSON override was tried first (it would let the
+    whole grid run against one warm server) but the ROCmFPX runner at 7aa484a
+    SILENTLY IGNORES it — every cell then reads the launch-time config and the
+    sweep is meaningless. --per-request opts back into that path for a future
+    runner build that honors it (with a loud caveat)."""
     slot = _get_slot(args.api, args.slot)
     port = int(slot["port"])
+    original = slot.get("llamacpp_args") or None
     prompt = _build_prompt(args.depth)
     sampler = _sampler_body(args)
     n_maxes = _csv_ints(args.spec_nmax)
     p_mins = _csv_floats(args.spec_pmin)
     n_min = int(args.spec_nmin)
 
-    _wait_ready(port)  # no config change — server must already be MTP-on
+    if args.per_request:
+        print(
+            "[mtp] WARNING: --per-request sends speculative.* in the /completion "
+            "JSON; the ROCmFPX runner at 7aa484a IGNORES it (all cells read "
+            "identical). Only use on a runner build known to honor it.",
+            flush=True,
+        )
+
     results: dict[str, Any] = {}
-    for n_max in n_maxes:
-        for p_min in p_mins:
-            spec = _spec_override(n_max, p_min, n_min)["speculative"]
-            label = f"nmax{n_max}_pmin{p_min}"
-            print(f"[mtp] {label} (depth~{args.depth}, temp {sampler['temperature']})", flush=True)
-            runs = []
-            for i in range(args.n):
-                t = _completion(
-                    port,
-                    prompt,
-                    args.max_tokens,
-                    cache_prompt=False,
-                    sampler=sampler,
-                    speculative=spec,
+    try:
+        for n_max in n_maxes:
+            for p_min in p_mins:
+                label = f"nmax{n_max}_pmin{p_min}"
+                if args.per_request:
+                    spec = _spec_override(n_max, p_min, n_min)["speculative"]
+                    _wait_ready(port)
+                else:
+                    # Relaunch so the draft params actually take effect.
+                    flags = (
+                        f"--spec-draft-n-max {n_max} --spec-draft-n-min {n_min} "
+                        f"--spec-draft-p-min {p_min}"
+                    )
+                    merged = f"{original} {flags}".strip() if original else flags
+                    _apply_extra_args(args.api, args.slot, merged)
+                    _wait_ready(port)
+                    spec = None
+                print(
+                    f"[mtp] {label} (depth~{args.depth}, temp {sampler['temperature']}, "
+                    f"{'per-request' if args.per_request else 'relaunch'})",
+                    flush=True,
                 )
-                print(f"  run {i + 1}/{args.n}: {t}", flush=True)
-                runs.append(t)
-            results[label] = {
-                "n_max": n_max,
-                "p_min": p_min,
-                "n_min": n_min,
-                "runs": runs,
-                "median": _summarize_runs(runs),
-            }
+                runs = []
+                for i in range(args.n):
+                    t = _completion(
+                        port,
+                        prompt,
+                        args.max_tokens,
+                        cache_prompt=False,
+                        sampler=sampler,
+                        speculative=spec,
+                    )
+                    print(f"  run {i + 1}/{args.n}: {t}", flush=True)
+                    runs.append(t)
+                results[label] = {
+                    "n_max": n_max,
+                    "p_min": p_min,
+                    "n_min": n_min,
+                    "runs": runs,
+                    "median": _summarize_runs(runs),
+                }
+    finally:
+        if not args.per_request:
+            print(f"[mtp] restoring original extra_args = {original!r}", flush=True)
+            _apply_extra_args(args.api, args.slot, original)
     return results
 
 
@@ -511,7 +561,8 @@ def main() -> None:
     ap.add_argument(
         "--top-k", dest="top_k", type=int, default=None, help="mtp mode: top-k (optional)"
     )
-    # MTP draft-param grid (per-request; restart-free).
+    # MTP draft-param grid. Relaunch-per-value by default (7aa484a ignores the
+    # per-request override — see --per-request).
     ap.add_argument(
         "--spec-nmax", default="1,2,3,4", help="mtp mode: comma list of speculative n_max"
     )
@@ -520,6 +571,12 @@ def main() -> None:
     )
     ap.add_argument(
         "--spec-nmin", type=int, default=0, help="mtp mode: speculative n_min (default 0)"
+    )
+    ap.add_argument(
+        "--per-request",
+        action="store_true",
+        help="mtp mode: send speculative.* per request instead of relaunching "
+        "(IGNORED by the ROCmFPX runner at 7aa484a — only for a build that honors it)",
     )
     # Provenance (plan risk 6) — the local-only runner image is not reproducible
     # without capturing what built it.


### PR DESCRIPTION
Lands the on-box ROCmFPX exploratory bench results and fixes the two `server_ab.py` bugs the bench exposed. Combines the box session's branch (`bench/rocmfpx-explore-2026-07-05`) with the tooling corrections so the blockers and their fixes land together.

## Bench results (docs)
- `handoffs/rocmfpx-bench-results-2026-07-05.md` — results appendix. Headline: the **35B-A3B MoE on Vulkan decodes ~2.6× faster and prefills ~3× faster than the dense 27B on ROCm** (3B active vs 27B dense; decode is bandwidth-bound). Production numbers: 27B ~29 t/s / 57% accept (real task); 35B ~76 t/s / 74% accept. Seeds already match the vendor cards — the only real levers are HIP env (now shipped) and an optional 27B draft-KV tweak.
- `handoffs/rocmfpx-bench-handoff-next-2026-07-05.md` — next-session handoff (model-selection research grounded in the decode ≈ bandwidth ÷ (active_params × bytes/weight) ground-truth).
- The matrix did NOT fully complete — runner blockers (below) prevented most sweeps. Documented honestly rather than papered over; the findings + card-canonical config + the quant/bandwidth insight are the deliverables.

## Tooling fixes (`server_ab.py`) — address blockers the results doc raises
- **Blocker #1 — per-request `speculative.*` ignored at 7aa484a.** `--mode mtp` now **relaunches per (n_max, p_min)** via `[server].extra_args` (restores after), instead of the silently-ignored per-request JSON. `--per-request` retained as an opt-in for a future runner build that honors it.
- **Blocker #5 — early-EOS mismeasurement.** `_completion` now sends `ignore_eos=True` for throughput cells (the 35B's strict Froggeric template otherwise stops after ~1 token → meaningless decode t/s); off for the reuse trace.

## SUMMARY display
- `generate_results_json.py` now ingests `server-ab/*.json` and renders a Tier B/C section (decode t/s · draft accept % · concurrency aggregate/per-stream/TTFT) — previously it showed only Tier-A llama-bench and could display none of this bench's output. Adds short model names + a `quant` column. (Plus a ruff UP017 `datetime.UTC` fixup for CI.)

## Runbook corrections
- Finding 0.6 (restart-free MTP sweep) marked **DISPROVEN** on this build; depth axis **128k → ≤24k** (128k is OOM-infeasible for 27B+MTP here; slots ctx-bounded to 40960); Tier B guidance notes relaunch-every-≤4-cells (runner leaks GPU memory across MTP requests).

## Not in this PR (box-side, not version-controlled)
The live-slot config (venv `SEED_PROFILES` image override, `/etc/hal0/slots/*.toml` HIP env + `context_size 40960`, the `saber-fpx` profile) stays on the box with the backups noted in the results handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ky49xV79kYjmiYMp4uzHMw)_