### PR TITLE
updater: split apply() into prepare()+commit() for signed release-notes review

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -257,6 +257,75 @@ async def _run_apply_job(
         _persist_job(job)
 
 
+async def _run_prepare_job(
+    jobs: dict[str, dict[str, Any]],
+    job_id: str,
+    channel: str,
+    version: str | None,
+) -> None:
+    """Background task that STAGES an update via ``Updater.prepare()``.
+
+    Downloads + cosign-verifies + extracts the release without touching the
+    running system, then attaches the (verified) release notes + resolved
+    version to the job and transitions it to the terminal ``prepared`` state.
+    Does NOT restart hal0-api — nothing is active yet. The caller reviews the
+    notes and then POSTs ``/commit`` to activate.
+    """
+    job = jobs[job_id]
+    job["state"] = "running"
+    job["updated_at"] = time.time()
+    _persist_job(job)
+    try:
+        updater = Updater(channel=channel)
+        result = await updater.prepare(version)
+    except Exception as exc:
+        job["state"] = "failed"
+        job["error"] = str(exc)
+        job["error_code"] = type(exc).__name__
+    else:
+        job["resolved_version"] = result.get("version")
+        job["notes"] = result.get("notes")
+        job["cosign_skipped"] = result.get("cosign_skipped")
+        job["state"] = "prepared"
+    finally:
+        job["updated_at"] = time.time()
+        _persist_job(job)
+
+
+async def _run_commit_job(
+    jobs: dict[str, dict[str, Any]],
+    job_id: str,
+    channel: str,
+    version: str,
+) -> None:
+    """Background task that ACTIVATES a prepared version via ``Updater.commit()``.
+
+    Runs the migrations + symlink swap + venv re-pip, then try-restarts
+    ``hal0-api.service`` fail-soft (same policy as ``_run_apply_job``). Requires
+    that ``/prepare`` staged ``version`` first; ``commit()`` raises otherwise and
+    the job goes to ``failed``.
+    """
+    job = jobs[job_id]
+    job["state"] = "running"
+    job["updated_at"] = time.time()
+    _persist_job(job)
+    try:
+        updater = Updater(channel=channel)
+        await updater.commit(version)
+    except Exception as exc:
+        job["state"] = "failed"
+        job["error"] = str(exc)
+        job["error_code"] = type(exc).__name__
+    else:
+        restarted, restart_error = await asyncio.to_thread(_try_restart_hal0_api)
+        job["restarted"] = restarted
+        job["restart_error"] = restart_error
+        job["state"] = "applied"
+    finally:
+        job["updated_at"] = time.time()
+        _persist_job(job)
+
+
 # ── /state ─────────────────────────────────────────────────────────────────
 
 
@@ -527,6 +596,98 @@ async def apply_update(request: Request) -> dict[str, Any]:
     task = asyncio.create_task(_run_apply_job(jobs, job_id, channel, version))
     bg_tasks.add(task)
     task.add_done_callback(bg_tasks.discard)
+    return dict(jobs[job_id])
+
+
+def _spawn_update_task(request: Request, coro: Any) -> None:
+    """Track a fire-and-forget update background task on app.state (RUF006)."""
+    bg_tasks = getattr(request.app.state, "_update_bg_tasks", None)
+    if bg_tasks is None:
+        bg_tasks = set()
+        request.app.state._update_bg_tasks = bg_tasks
+    task = asyncio.create_task(coro)
+    bg_tasks.add(task)
+    task.add_done_callback(bg_tasks.discard)
+
+
+def _body_version(body: Any) -> str | None:
+    """Extract a normalised ``version`` from a request body (strip a leading v)."""
+    if isinstance(body, dict):
+        v = body.get("version")
+        if isinstance(v, str) and v.strip():
+            return v.strip().lstrip("v") or None
+    return None
+
+
+@router.post("/prepare", status_code=202)
+async def prepare_update(request: Request) -> dict[str, Any]:
+    """Stage an update (download + cosign-verify + extract) WITHOUT activating it.
+
+    Returns a queued-job snapshot (202). Poll ``/api/updates/status/{job_id}``
+    until state ``prepared`` — the job then carries ``resolved_version`` and
+    ``notes`` (release notes read from the *verified* tree) — then POST
+    ``/api/updates/commit`` with that version to activate. Nothing about the
+    running system changes until commit, so an abandoned prepare is harmless.
+
+    Body (optional): ``{"version": "0.1.0"}`` — pin a version; omit for latest.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    version = _body_version(body)
+    channel = _current_channel(request)
+    jobs = _update_jobs(request)
+    job_id = uuid.uuid4().hex[:12]
+    jobs[job_id] = {
+        "id": job_id,
+        "state": "queued",
+        "phase": "prepare",
+        "channel": channel,
+        "version": version,
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "error": None,
+    }
+    _persist_job(jobs[job_id])
+    _spawn_update_task(request, _run_prepare_job(jobs, job_id, channel, version))
+    return dict(jobs[job_id])
+
+
+@router.post("/commit", status_code=202)
+async def commit_update(request: Request) -> dict[str, Any]:
+    """Activate a previously ``/prepare``d version.
+
+    Body (required): ``{"version": "0.1.0"}`` — the ``resolved_version`` returned
+    by the prepare job. Returns a queued-job snapshot (202); poll
+    ``/status/{job_id}`` until ``applied`` | ``failed``. The daemon try-restarts
+    hal0-api fail-soft after a successful commit.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    version = _body_version(body)
+    if not version:
+        raise BadRequest(
+            "commit requires a 'version' — the resolved_version from /prepare",
+            details={"hint": "POST /api/updates/prepare first, then commit its resolved_version"},
+        )
+    channel = _current_channel(request)
+    jobs = _update_jobs(request)
+    job_id = uuid.uuid4().hex[:12]
+    jobs[job_id] = {
+        "id": job_id,
+        "state": "queued",
+        "phase": "commit",
+        "channel": channel,
+        "version": version,
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "error": None,
+    }
+    _persist_job(jobs[job_id])
+    _spawn_update_task(request, _run_commit_job(jobs, job_id, channel, version))
     return dict(jobs[job_id])
 
 

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -299,13 +299,12 @@ def update(
     # headless/piped invocations (cron, scripts) proceed as before so unattended
     # updates never block. Nothing is active yet — declining just leaves the
     # staged tree, which is harmless.
-    if not yes and _interactive():
-        if not typer.confirm(f"Apply hal0 {resolved}?", default=True):
-            console.print(
-                "[dim]staged but not applied — re-run `hal0 update` to apply, "
-                "or `hal0 update --yes`.[/dim]"
-            )
-            return
+    if not yes and _interactive() and not typer.confirm(f"Apply hal0 {resolved}?", default=True):
+        console.print(
+            "[dim]staged but not applied — re-run `hal0 update` to apply, "
+            "or `hal0 update --yes`.[/dim]"
+        )
+        return
 
     try:
         cjob = api_post("/api/updates/commit", json={"version": resolved})

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -16,6 +16,7 @@ Surface:
 
 from __future__ import annotations
 
+import sys
 import time
 import tomllib
 from enum import StrEnum
@@ -23,6 +24,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
@@ -131,8 +133,13 @@ def _print_check(body: dict) -> None:
         console.print(table)
 
 
-def _poll_job(job_id: str, *, timeout_s: float = 600.0) -> dict:
-    """Poll /api/updates/status/<id> until it leaves the queued/running states."""
+def _poll_job(
+    job_id: str,
+    *,
+    terminal: tuple[str, ...] = ("applied", "failed"),
+    timeout_s: float = 600.0,
+) -> dict:
+    """Poll /api/updates/status/<id> until it reaches a terminal state."""
     deadline = time.monotonic() + timeout_s
     last_state: str | None = None
     while time.monotonic() < deadline:
@@ -145,11 +152,48 @@ def _poll_job(job_id: str, *, timeout_s: float = 600.0) -> dict:
         if state != last_state:
             console.print(f"[dim]· job {job_id} → {state}[/dim]")
             last_state = state
-        if state in ("applied", "failed"):
+        if state in terminal:
             return job
         time.sleep(0.5)
     die(f"update job {job_id} timed out after {timeout_s:.0f}s")
     return {}
+
+
+def _interactive() -> bool:
+    """True on an interactive TTY — the gate for the pre-commit confirm prompt.
+
+    Factored out so headless/piped runs (cron, scripts, ``|`` pipelines) skip the
+    prompt, and so tests can force either path deterministically.
+    """
+    return sys.stdout.isatty()
+
+
+def _render_notes(notes: dict | None) -> None:
+    """Render the release notes from a prepared update job.
+
+    ``breaking`` / ``migrations`` get a loud panel; ``highlights`` a bullet
+    list; the full markdown (if any) is rendered below. All fields optional —
+    a release without notes renders nothing.
+    """
+    if not isinstance(notes, dict):
+        return
+    highlights = notes.get("highlights") or []
+    breaking = notes.get("breaking") or []
+    migrations = notes.get("migrations") or []
+    markdown = (notes.get("markdown") or "").strip()
+
+    if breaking or migrations:
+        lines = [f"[red]⚠ {b}[/red]" for b in breaking]
+        lines += [f"[yellow]↻ {m}[/yellow]" for m in migrations]
+        console.print(
+            Panel("\n".join(lines), title="Breaking / migrations", border_style="yellow")
+        )
+    if highlights:
+        console.print("[bold]Highlights[/bold]")
+        for h in highlights:
+            console.print(f"  • {h}")
+    if markdown:
+        console.print(Markdown(markdown))
 
 
 def update(
@@ -172,6 +216,12 @@ def update(
         None,
         "--target",
         help="Pin a specific version (e.g. v0.1.1). Overrides the latest manifest version.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt after reviewing release notes.",
     ),
 ) -> None:
     """Check for, apply, or roll back a hal0 update.
@@ -222,9 +272,12 @@ def update(
         console.print("[dim]nothing to apply.[/dim]")
         return
 
+    # ── Stage → review notes → confirm → activate (prepare/commit split) ────────
+    # prepare downloads + cosign-verifies + extracts WITHOUT touching the running
+    # system, so we can show verified release notes and confirm before activating.
     try:
         job = api_post(
-            "/api/updates/apply", json={"version": target_version} if target_version else {}
+            "/api/updates/prepare", json={"version": target_version} if target_version else {}
         )
     except CliApiError as exc:
         die(str(exc))
@@ -233,9 +286,39 @@ def update(
     if not job_id:
         die("server returned no job id")
         return
-    console.print(f"[cyan]apply job:[/cyan] {job_id}")
+    console.print(f"[cyan]staging update:[/cyan] {job_id}")
+    prepared = _poll_job(job_id, terminal=("prepared", "failed"))
+    if prepared.get("state") != "prepared":
+        die(f"prepare failed: {prepared.get('error') or 'unknown error'}")
+        return
 
-    final = _poll_job(job_id)
+    resolved = prepared.get("resolved_version") or target_version
+    _render_notes(prepared.get("notes"))
+
+    # Confirm before activating. Prompt only on an interactive TTY without --yes;
+    # headless/piped invocations (cron, scripts) proceed as before so unattended
+    # updates never block. Nothing is active yet — declining just leaves the
+    # staged tree, which is harmless.
+    if not yes and _interactive():
+        if not typer.confirm(f"Apply hal0 {resolved}?", default=True):
+            console.print(
+                "[dim]staged but not applied — re-run `hal0 update` to apply, "
+                "or `hal0 update --yes`.[/dim]"
+            )
+            return
+
+    try:
+        cjob = api_post("/api/updates/commit", json={"version": resolved})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    cjob_id = cjob.get("id")
+    if not cjob_id:
+        die("server returned no commit job id")
+        return
+    console.print(f"[cyan]applying:[/cyan] {cjob_id}")
+
+    final = _poll_job(cjob_id, terminal=("applied", "failed"))
     state = final.get("state")
     if state == "applied":
         console.print(Panel("[green]update applied.[/green]", border_style="green"))

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -185,9 +185,7 @@ def _render_notes(notes: dict | None) -> None:
     if breaking or migrations:
         lines = [f"[red]⚠ {b}[/red]" for b in breaking]
         lines += [f"[yellow]↻ {m}[/yellow]" for m in migrations]
-        console.print(
-            Panel("\n".join(lines), title="Breaking / migrations", border_style="yellow")
-        )
+        console.print(Panel("\n".join(lines), title="Breaking / migrations", border_style="yellow"))
     if highlights:
         console.print("[bold]Highlights[/bold]")
         for h in highlights:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -862,6 +862,69 @@ def _cache_dir(version: str) -> Path:
     return paths.var_lib() / "cache" / version
 
 
+def _manifest_cache_path(version: str) -> Path:
+    """Where :meth:`Updater.prepare` stashes the verified manifest for commit()."""
+    return _cache_dir(version) / "manifest.json"
+
+
+def _load_cached_manifest(version: str) -> dict[str, Any]:
+    """Read the manifest cached by :meth:`Updater.prepare`.
+
+    ``commit()`` needs ``min_data_version`` without re-fetching (a re-fetch could
+    resolve a *newer* release than the one that was prepared+verified). Raises
+    ``UpdateError`` if the cache is missing — i.e. commit was called without a
+    prior prepare for this version.
+    """
+    path = _manifest_cache_path(version)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise UpdateError(
+            f"no staged manifest for {version} — call prepare() before commit()",
+            details={"version": version, "path": str(path), "error": str(exc)},
+        ) from exc
+
+
+#: Cap release-notes markdown so a hostile/oversized tree can't blow up the job
+#: record or the CLI render. Notes are informational, not a transport.
+_MAX_NOTES_BYTES = 64 * 1024
+
+
+def _read_release_notes(install_dir: Path) -> dict[str, Any]:
+    """Read release notes shipped INSIDE the (cosign-verified) release tree.
+
+    ``RELEASE_NOTES.md`` (markdown) and an optional ``release.json``
+    (``{highlights, breaking, migrations}``) at the tree root. Both are optional
+    — older releases without them yield empty notes (graceful). Because they live
+    in the extracted tarball, they are covered by the sha256 + cosign
+    verification, unlike a manifest ``notes_url`` fetched over plain TLS — so what
+    the operator reviews before commit is exactly what was signed.
+    """
+    markdown = ""
+    md_path = install_dir / "RELEASE_NOTES.md"
+    if md_path.is_file():
+        with contextlib.suppress(OSError):
+            markdown = md_path.read_text(encoding="utf-8", errors="replace")[:_MAX_NOTES_BYTES]
+
+    highlights: list[str] = []
+    breaking: list[str] = []
+    migrations: list[str] = []
+    json_path = install_dir / "release.json"
+    if json_path.is_file():
+        with contextlib.suppress(OSError, ValueError):
+            data = json.loads(json_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                highlights = [str(x) for x in (data.get("highlights") or [])][:50]
+                breaking = [str(x) for x in (data.get("breaking") or [])][:50]
+                migrations = [str(x) for x in (data.get("migrations") or [])][:50]
+    return {
+        "markdown": markdown,
+        "highlights": highlights,
+        "breaking": breaking,
+        "migrations": migrations,
+    }
+
+
 # ── Seed-profile merge helpers ─────────────────────────────────────────────────
 
 
@@ -1218,10 +1281,10 @@ class Updater:
 
     # ── apply ──────────────────────────────────────────────────────────────────
 
-    async def apply(self, version: str | None = None) -> dict[str, Any]:
-        """Download, verify, install, and activate ``version`` (or latest).
+    async def prepare(self, version: str | None = None) -> dict[str, Any]:
+        """Download, verify, and STAGE ``version`` (or latest) — without activating.
 
-        Implements the full §9 update sequence:
+        Runs §9 steps **1–6** only:
 
           1. Fetch + schema-validate the release manifest.
           2. Confirm the target version (caller-pinned or manifest.version).
@@ -1229,17 +1292,15 @@ class Updater:
           4. SHA-256 verify against the manifest digest.
           5. Cosign verify-blob against the GH Actions OIDC identity.
           6. Extract to ``/usr/lib/hal0-<version>/`` (refuse non-empty).
-          7. Run forward config migrations if ``min_data_version`` advanced.
-          8. Atomic-swap the ``/usr/lib/hal0/current`` symlink.
-          9. Record the prior target in ``/var/lib/hal0/hal0.previous``.
 
-        Slot units are NOT restarted; the ``hal0-api.service`` restart is
-        the route layer's responsibility (``routes/updater._run_apply_job``
-        try-restarts it fail-soft after a successful apply).
+        Nothing about the running system changes: the ``current`` symlink, the
+        venv, and ``/etc/hal0`` are untouched, so an abandoned prepare is
+        discarded by deleting the staged tree. The verified manifest is cached
+        (``<cache>/manifest.json``) so :meth:`commit` reads ``min_data_version``
+        without a re-fetch, and release notes are read from the *verified* tree
+        so what the operator reviews before commit is exactly what was signed.
 
-        Returns a breadcrumb dict the route layer can attach to the job
-        record (``version``, ``previous``, ``installed_at``,
-        ``cosign_skipped``).
+        Returns ``{version, install_dir, cache_dir, cosign_skipped, notes}``.
 
         Raises:
             UpdateError + subclasses on any step failure. Partial-state
@@ -1258,7 +1319,7 @@ class Updater:
             )
 
         # Step 1: fetch + validate manifest.
-        log.info("updater.apply_start", job_id=self.job_id, channel=self.channel, pinned=version)
+        log.info("updater.prepare_start", job_id=self.job_id, channel=self.channel, pinned=version)
         try:
             raw = await fetch_release_manifest(self.channel)
         except (OSError, ValueError) as exc:
@@ -1335,6 +1396,58 @@ class Updater:
         # after a half-failed apply isn't permanently wedged.
         install_dir = _versioned_install_dir(target_version)
         await asyncio.to_thread(_extract_tarball, tarball_path, install_dir, job_id=self.job_id)
+
+        # Cache the verified manifest so commit() reads min_data_version without a
+        # re-fetch (which could resolve a *newer* release than the one just
+        # verified), then read release notes from the *verified* tree — so what an
+        # operator reviews before commit is exactly what cosign signed.
+        _write_atomic_text(_manifest_cache_path(target_version), json.dumps(raw))
+        notes = _read_release_notes(install_dir)
+        log.info("updater.prepare_ok", job_id=self.job_id, version=target_version)
+        return {
+            "version": target_version,
+            "install_dir": str(install_dir),
+            "cache_dir": str(cache),
+            "cosign_skipped": _cosign_skip(),
+            "notes": notes,
+        }
+
+    async def commit(self, version: str) -> dict[str, Any]:
+        """Activate a previously :meth:`prepare`d ``version`` (§9 steps 7–9+).
+
+        Runs forward config migrations, prunes materialised seed profiles, clears
+        stale mtp overrides, atomic-swaps the ``current`` symlink, re-pips the
+        tree into the running venv, and re-renders slot units. Requires that
+        :meth:`prepare` already staged this version (its ``install_dir`` and
+        cached manifest must exist) — otherwise raises ``UpdateError``.
+
+        Slot units are NOT restarted and ``hal0-api`` is not bounced here; the
+        route layer (``routes/updater._run_commit_job``) try-restarts hal0-api
+        fail-soft after a successful commit. Returns the same breadcrumb dict
+        shape as the old single-step apply.
+        """
+        if _is_editable_install():
+            raise UpdateError(
+                "update is not supported on an editable (dev) install — "
+                "run 'git pull && pip install -e .' to update",
+                details={"hint": "editable install detected via hal0.__file__ outside sys.prefix"},
+            )
+        target_version = (version or "").strip()
+        if not target_version:
+            raise UpdateManifestInvalid(
+                "commit requires an explicit prepared version",
+                details={"channel": self.channel},
+            )
+        install_dir = _versioned_install_dir(target_version)
+        cache = _cache_dir(target_version)
+        if not install_dir.exists():
+            raise UpdateError(
+                f"nothing staged for {target_version} — call prepare() before commit()",
+                details={"version": target_version, "install_dir": str(install_dir)},
+            )
+        # Manifest cached by prepare(); needed for min_data_version below.
+        manifest = _parse_manifest(_load_cached_manifest(target_version))
+        log.info("updater.commit_start", job_id=self.job_id, version=target_version)
 
         # Step 7: config migrations.
         migration_info: tuple[int, int]
@@ -1477,6 +1590,17 @@ class Updater:
             "cosign_skipped": _cosign_skip(),
             "installed_at": time.time(),
         }
+
+    async def apply(self, version: str | None = None) -> dict[str, Any]:
+        """Prepare + commit in one call — the back-compat single-step update.
+
+        Equivalent to the pre-split ``apply()``: stages the release
+        (:meth:`prepare`) and immediately activates it (:meth:`commit`). Callers
+        that want to show release notes / gate on confirmation between the two
+        phases call :meth:`prepare` then :meth:`commit` directly instead.
+        """
+        prepared = await self.prepare(version)
+        return await self.commit(str(prepared["version"]))
 
     # ── rollback ───────────────────────────────────────────────────────────────
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1284,7 +1284,7 @@ class Updater:
     async def prepare(self, version: str | None = None) -> dict[str, Any]:
         """Download, verify, and STAGE ``version`` (or latest) — without activating.
 
-        Runs §9 steps **1–6** only:
+        Runs §9 steps **1-6** only:
 
           1. Fetch + schema-validate the release manifest.
           2. Confirm the target version (caller-pinned or manifest.version).
@@ -1413,7 +1413,7 @@ class Updater:
         }
 
     async def commit(self, version: str) -> dict[str, Any]:
-        """Activate a previously :meth:`prepare`d ``version`` (§9 steps 7–9+).
+        """Activate a previously :meth:`prepare`d ``version`` (§9 steps 7-9+).
 
         Runs forward config migrations, prunes materialised seed profiles, clears
         stale mtp overrides, atomic-swaps the ``current`` symlink, re-pips the

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -501,3 +501,78 @@ def test_apply_target_strips_leading_v(
         time.sleep(0.05)
 
     assert seen == ["0.1.1"], seen
+
+
+# ── prepare / commit split ─────────────────────────────────────────────────────
+
+
+def test_prepare_route_returns_queued_prepare_job(isolated_client: TestClient) -> None:
+    """POST /api/updates/prepare returns a queued job tagged phase=prepare."""
+    r = isolated_client.post("/api/updates/prepare", json={})
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert "id" in body and isinstance(body["id"], str)
+    assert body["phase"] == "prepare"
+    assert body["state"] == "queued"
+    assert body["channel"] == "stable"
+
+
+def test_prepare_job_reaches_prepared_with_notes(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After the bg prepare job runs, status shows prepared + resolved_version + notes.
+
+    ``Updater.prepare`` is stubbed as an async success (same style as the
+    apply-route tests stub ``Updater.apply``) so the test exercises the route
+    layer's bg-job handling, not the real download/verify path.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_prepare(self: object, version: str | None = None) -> dict:
+        return {
+            "version": "0.0.1",
+            "install_dir": "/tmp/hal0-0.0.1",
+            "cache_dir": "/tmp/cache/0.0.1",
+            "cosign_skipped": True,
+            "notes": {
+                "markdown": "# 0.0.1\n- did xyz",
+                "highlights": ["h"],
+                "breaking": [],
+                "migrations": [],
+            },
+        }
+
+    monkeypatch.setattr(u_mod.Updater, "prepare", fake_prepare)
+
+    r = isolated_client.post("/api/updates/prepare", json={})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("prepared", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") == "prepared", final
+    assert final.get("resolved_version") == "0.0.1"
+    assert final.get("notes")
+
+
+def test_commit_route_requires_version(isolated_client: TestClient) -> None:
+    """POST /api/updates/commit with no version rejects with a typed 400."""
+    r = isolated_client.post("/api/updates/commit", json={})
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert "error" in body
+
+
+def test_commit_route_accepts_version(isolated_client: TestClient) -> None:
+    """POST /api/updates/commit with a version queues a phase=commit job (202)."""
+    r = isolated_client.post("/api/updates/commit", json={"version": "0.0.1"})
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["phase"] == "commit"
+    assert body["state"] == "queued"
+    assert body["version"] == "0.0.1"

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -60,7 +60,9 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
         captured["put_json"] = json
         return {"channel": json.get("channel") if isinstance(json, dict) else None}
 
-    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+    def fake_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
         # prepare poll → 'prepared' + resolved version + notes; commit poll → 'applied'.
         if "prepared" in terminal:
             return {
@@ -112,7 +114,9 @@ def test_prepare_then_commit_flow(stub_api: dict, monkeypatch: pytest.MonkeyPatc
     assert stub_api["commit_json"] == {"version": "0.1.1"}
 
 
-def test_yes_flag_present_and_skips_confirm(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_yes_flag_present_and_skips_confirm(
+    stub_api: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """``--yes`` is a real flag and drives straight to commit without prompting."""
     assert "yes" in inspect.signature(uc.update).parameters
     monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
@@ -120,7 +124,9 @@ def test_yes_flag_present_and_skips_confirm(stub_api: dict, monkeypatch: pytest.
     # were reached it would flip the flag, so a clean commit proves it skipped.
     monkeypatch.setattr(uc, "_interactive", lambda: True)
     called = {"confirm": False}
-    monkeypatch.setattr(uc.typer, "confirm", lambda *a, **k: called.__setitem__("confirm", True) or True)
+    monkeypatch.setattr(
+        uc.typer, "confirm", lambda *a, **k: called.__setitem__("confirm", True) or True
+    )
     result = runner.invoke(app, ["update", "--target", "0.1.1", "--yes"])
     assert result.exit_code == 0, result.output
     assert called["confirm"] is False

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -27,13 +27,18 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     Returns a captured-calls dict so assertions can inspect what the CLI
     sent to /api/updates/apply.
     """
-    captured: dict = {"apply_json": None, "get_paths": [], "put_json": None}
+    captured: dict = {
+        "prepare_json": None,
+        "commit_json": None,
+        "get_paths": [],
+        "put_json": None,
+    }
 
     monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
 
     def fake_get(path: str, **kwargs: object) -> dict:
         captured["get_paths"].append(path)
-        # /api/updates/check - advertise an available update so apply runs.
+        # /api/updates/check - advertise an available update so the flow runs.
         return {
             "current": "0.0.0",
             "latest": "9.9.9",
@@ -43,16 +48,27 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
         }
 
     def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
-        if path == "/api/updates/apply":
-            captured["apply_json"] = json
-            return {"id": "job123", "state": "queued"}
+        if path == "/api/updates/prepare":
+            captured["prepare_json"] = json
+            return {"id": "prep123", "state": "queued"}
+        if path == "/api/updates/commit":
+            captured["commit_json"] = json
+            return {"id": "commit123", "state": "queued"}
         return {}
 
     def fake_put(path: str, *, json: object = None, **kwargs: object) -> dict:
         captured["put_json"] = json
         return {"channel": json.get("channel") if isinstance(json, dict) else None}
 
-    def fake_poll(job_id: str, **kwargs: object) -> dict:
+    def fake_poll(job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object) -> dict:
+        # prepare poll → 'prepared' + resolved version + notes; commit poll → 'applied'.
+        if "prepared" in terminal:
+            return {
+                "id": job_id,
+                "state": "prepared",
+                "resolved_version": "0.1.1",
+                "notes": {"markdown": "", "highlights": [], "breaking": [], "migrations": []},
+            }
         return {"id": job_id, "state": "applied"}
 
     monkeypatch.setattr(uc, "api_get", fake_get)
@@ -71,11 +87,11 @@ def test_restart_slots_flag_removed() -> None:
 
 
 def test_target_strips_leading_v(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
-    """``--target v0.1.1`` is normalized to ``0.1.1`` before hitting the API."""
+    """``--target v0.1.1`` is normalized to ``0.1.1`` before hitting /prepare."""
     monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
     result = runner.invoke(app, ["update", "--target", "v0.1.1"])
     assert result.exit_code == 0, result.output
-    assert stub_api["apply_json"] == {"version": "0.1.1"}
+    assert stub_api["prepare_json"] == {"version": "0.1.1"}
 
 
 def test_target_without_v_is_unchanged(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -83,7 +99,65 @@ def test_target_without_v_is_unchanged(stub_api: dict, monkeypatch: pytest.Monke
     monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
     result = runner.invoke(app, ["update", "--target", "0.1.1"])
     assert result.exit_code == 0, result.output
-    assert stub_api["apply_json"] == {"version": "0.1.1"}
+    assert stub_api["prepare_json"] == {"version": "0.1.1"}
+
+
+def test_prepare_then_commit_flow(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI stages via /prepare, then activates via /commit with the resolved version."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+    assert result.exit_code == 0, result.output
+    # prepare got the (normalized) target; commit got the resolved_version from the poll.
+    assert stub_api["prepare_json"] == {"version": "0.1.1"}
+    assert stub_api["commit_json"] == {"version": "0.1.1"}
+
+
+def test_yes_flag_present_and_skips_confirm(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--yes`` is a real flag and drives straight to commit without prompting."""
+    assert "yes" in inspect.signature(uc.update).parameters
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    # Force an interactive TTY so only --yes can suppress the prompt; if confirm
+    # were reached it would flip the flag, so a clean commit proves it skipped.
+    monkeypatch.setattr(uc, "_interactive", lambda: True)
+    called = {"confirm": False}
+    monkeypatch.setattr(uc.typer, "confirm", lambda *a, **k: called.__setitem__("confirm", True) or True)
+    result = runner.invoke(app, ["update", "--target", "0.1.1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert called["confirm"] is False
+    assert stub_api["commit_json"] == {"version": "0.1.1"}
+
+
+def test_tty_decline_stages_without_commit(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a TTY without --yes, declining the prompt stages but never commits."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr(uc, "_interactive", lambda: True)
+    monkeypatch.setattr(uc.typer, "confirm", lambda *a, **k: False)
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["prepare_json"] == {"version": "0.1.1"}
+    assert stub_api["commit_json"] is None  # declined → no commit
+
+
+def test_render_notes_shows_breaking_and_migrations(capsys: pytest.CaptureFixture[str]) -> None:
+    """_render_notes surfaces breaking/migration callouts and highlights."""
+    uc._render_notes(
+        {
+            "markdown": "# 0.1.1\nbody",
+            "highlights": ["new profiles"],
+            "breaking": ["removed rocm-moe"],
+            "migrations": ["slots fall back to rocm"],
+        }
+    )
+    out = capsys.readouterr().out
+    assert "removed rocm-moe" in out
+    assert "slots fall back to rocm" in out
+    assert "new profiles" in out
+
+
+def test_render_notes_none_is_noop(capsys: pytest.CaptureFixture[str]) -> None:
+    """No notes → nothing rendered (older releases without a notes payload)."""
+    uc._render_notes(None)
+    assert capsys.readouterr().out == ""
 
 
 def test_editable_drift_warns_when_source_ahead(

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -42,6 +42,7 @@ from hal0.updater.updater import (
     _is_pre_release,
     _parse_manifest,
     _previous_record,
+    _read_release_notes,
     _version_tuple,
     _versioned_install_dir,
 )
@@ -532,6 +533,121 @@ def test_apply_repip_failure_rolls_back_symlink(
 
     # Rolled back: current still points at the prior (0.0.1) tree.
     assert Path(os.readlink(_current_symlink())).name == "hal0-0.0.1"
+
+
+# ── prepare / commit split ─────────────────────────────────────────────────────
+
+
+def test_prepare_stages_without_swap(
+    synthetic_release: dict[str, Any], cosign_skip: None
+) -> None:
+    """prepare() downloads + verifies + extracts but activates nothing.
+
+    The staged tree lands under /usr/lib/hal0-<version>/ yet the `current`
+    symlink is untouched — an abandoned prepare is discarded by deleting the
+    staged dir.
+    """
+    res = asyncio.run(Updater().prepare())
+    assert res["version"] == "0.0.1"
+    assert "notes" in res
+
+    # The versioned tree is staged …
+    install = _versioned_install_dir("0.0.1")
+    assert install.exists()
+    assert (install / "VERSION").read_text().strip() == "0.0.1"
+
+    # … but nothing was activated: the `current` symlink does not resolve to it.
+    link = _current_symlink()
+    assert not link.is_symlink() or (
+        Path(os.readlink(link)).resolve() != install.resolve()
+    )
+
+
+def test_commit_without_prepare_raises(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """commit() with nothing staged for the version raises UpdateError.
+
+    A fresh HAL0_HOME means no prepare() has run, so `_versioned_install_dir`
+    and the cached manifest are both absent.
+    """
+    # Pretend prod (non-editable) so we reach the staged-manifest guard rather
+    # than the editable-install refusal.
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    with pytest.raises(UpdateError):
+        asyncio.run(Updater().commit("0.0.1"))
+
+
+def test_prepare_then_commit_swaps(
+    synthetic_release: dict[str, Any], cosign_skip: None
+) -> None:
+    """prepare() then commit() reaches the same end state as apply()."""
+    asyncio.run(Updater().prepare())
+    # Not yet activated after prepare.
+    assert not _current_symlink().is_symlink()
+
+    res = asyncio.run(Updater().commit("0.0.1"))
+    assert res["version"] == "0.0.1"
+
+    link = _current_symlink()
+    assert link.is_symlink()
+    install = _versioned_install_dir("0.0.1")
+    assert Path(os.readlink(link)).resolve() == install.resolve()
+
+
+def test_prepare_reads_release_notes(
+    tmp_hal0_home: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cosign_skip: None,
+) -> None:
+    """prepare() reads RELEASE_NOTES.md + release.json from the verified tree.
+
+    Both files ship at the tarball ROOT (so they're covered by the sha256 +
+    cosign verification) and surface on the returned ``notes`` dict.
+    """
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    version = "0.0.1"
+    contents = {
+        "site-packages/hal0/__init__.py": f'__version__ = "{version}"\n',
+        "VERSION": version,
+        "RELEASE_NOTES.md": "# 0.0.1\n- did xyz\n",
+        "release.json": json.dumps(
+            {"highlights": ["h"], "breaking": ["b"], "migrations": ["m"]}
+        ),
+    }
+    tarball = _build_release_tarball(tmp=artifacts, version=version, contents=contents)
+    sig = artifacts / f"hal0-{version}.tar.gz.sig"
+    sig.write_bytes(b"sig\n")
+    cert = artifacts / f"hal0-{version}.tar.gz.crt"
+    cert.write_bytes(b"cert\n")
+    manifest_path = artifacts / "latest.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        sig=sig,
+        cert=cert,
+        version=version,
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+
+    res = asyncio.run(Updater().prepare())
+    notes = res["notes"]
+    assert "did xyz" in notes["markdown"]
+    assert notes["highlights"] == ["h"]
+    assert notes["breaking"] == ["b"]
+    assert notes["migrations"] == ["m"]
+
+
+def test_read_release_notes_missing_is_empty(tmp_path: Path) -> None:
+    """A tree with no notes files yields all-empty lists + empty markdown."""
+    notes = _read_release_notes(tmp_path)
+    assert notes["markdown"] == ""
+    assert notes["highlights"] == []
+    assert notes["breaking"] == []
+    assert notes["migrations"] == []
 
 
 # ── apply error paths ──────────────────────────────────────────────────────────

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -538,9 +538,7 @@ def test_apply_repip_failure_rolls_back_symlink(
 # ── prepare / commit split ─────────────────────────────────────────────────────
 
 
-def test_prepare_stages_without_swap(
-    synthetic_release: dict[str, Any], cosign_skip: None
-) -> None:
+def test_prepare_stages_without_swap(synthetic_release: dict[str, Any], cosign_skip: None) -> None:
     """prepare() downloads + verifies + extracts but activates nothing.
 
     The staged tree lands under /usr/lib/hal0-<version>/ yet the `current`
@@ -558,14 +556,10 @@ def test_prepare_stages_without_swap(
 
     # … but nothing was activated: the `current` symlink does not resolve to it.
     link = _current_symlink()
-    assert not link.is_symlink() or (
-        Path(os.readlink(link)).resolve() != install.resolve()
-    )
+    assert not link.is_symlink() or (Path(os.readlink(link)).resolve() != install.resolve())
 
 
-def test_commit_without_prepare_raises(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_commit_without_prepare_raises(tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """commit() with nothing staged for the version raises UpdateError.
 
     A fresh HAL0_HOME means no prepare() has run, so `_versioned_install_dir`
@@ -578,9 +572,7 @@ def test_commit_without_prepare_raises(
         asyncio.run(Updater().commit("0.0.1"))
 
 
-def test_prepare_then_commit_swaps(
-    synthetic_release: dict[str, Any], cosign_skip: None
-) -> None:
+def test_prepare_then_commit_swaps(synthetic_release: dict[str, Any], cosign_skip: None) -> None:
     """prepare() then commit() reaches the same end state as apply()."""
     asyncio.run(Updater().prepare())
     # Not yet activated after prepare.
@@ -613,9 +605,7 @@ def test_prepare_reads_release_notes(
         "site-packages/hal0/__init__.py": f'__version__ = "{version}"\n',
         "VERSION": version,
         "RELEASE_NOTES.md": "# 0.0.1\n- did xyz\n",
-        "release.json": json.dumps(
-            {"highlights": ["h"], "breaking": ["b"], "migrations": ["m"]}
-        ),
+        "release.json": json.dumps({"highlights": ["h"], "breaking": ["b"], "migrations": ["m"]}),
     }
     tarball = _build_release_tarball(tmp=artifacts, version=version, contents=contents)
     sig = artifacts / f"hal0-{version}.tar.gz.sig"


### PR DESCRIPTION
Stage-then-activate so `hal0 update` can show cosign-verified release notes and confirm before touching the running system.

- **updater.py**: `apply()` split into `prepare()` (steps 1–6: download → verify → extract to staged dir; reads `RELEASE_NOTES.md`/`release.json` from the *signed* tree) and `commit()` (steps 7–9+: migrations → symlink swap → venv re-pip → unit re-render). `apply()` = prepare+commit (back-compat). Manifest cached between phases so commit can't drift to a newer release than the one verified.
- **API**: `POST /prepare` (→ `prepared` state with notes + resolved_version), `POST /commit` (requires version → `applied`). `/apply` unchanged.
- **CLI**: stage → render notes (breaking/migrations panel + highlights + markdown) → confirm only on a TTY without `--yes` (headless/cron proceeds unchanged) → commit. Adds `--yes/-y`.

Notes live inside the cosign-verified tarball (not a plain-TLS `notes_url`), so what an operator reviews is exactly what was signed. 101 tests pass across updater + routes + CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)