### PR TITLE
profiles: simplify seed stack — remove rocm-moe/rocm-dnse, rename rocmfpx-moe→vkfpx-moe

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -845,40 +845,18 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: let ``device_class`` drive display.
 SEED_PROFILES: dict[str, dict[str, object]] = {
     "rocm": {
-        # -ngl 999 explicit (GTT/unified free-mem autodetect is unreliable) and
-        # --jinja for correct chat templating — house-standard on all GPU LLM
-        # profiles (consolidation handoff §3).
+        # Basic general-purpose ROCm GPU LLM profile (Strix Halo toolbox image).
+        # Intentionally minimal: -ngl 999 (offload all), -fa on (flash attn),
+        # --jinja (chat templating). Per-model KV/batch/MTP tuning lives in the
+        # model's defaults.extra_args. mtp stays False — the ROCmFPX profiles
+        # (rocmfpx-rocm / vkfpx-moe) are the MTP lanes now; the legacy MTP
+        # rocm-dnse / rocm-moe profiles were removed 2026-07-05.
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-ngl 999 -fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 512 --parallel 1 --threads 8 --no-mmap --jinja",
+        "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
         "backend": "rocm",
-        "intent": "MoE agents",
-        "quant": "FP4",
-    },
-    "rocm-dnse": {
-        # Strix Halo matrix 2026-07-04: dense -b/-ub inconclusive (keep 8192/2048);
-        # --threads-batch 32 and --poll 100/--poll-batch 1 measured within noise at
-        # full offload → dropped (simpler flags win ties). +-ngl 999/--jinja.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-ngl 999 -fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 2048 --parallel 1 --threads 16 --no-mmap --jinja",
-        "mtp": True,
-        "device_class": "gpu",
-        "backend": "rocm",
-        "intent": "Dense + MTP · q8 KV",
-        "quant": "FP4",
-    },
-    "rocm-moe": {
-        # Strix Halo matrix 2026-07-04 (Qwen3.6-35B-A3B-MTP): -ub 1024 beats the
-        # old -ub 2048 by +30% pp2048 (1165 vs 895 t/s), consistent across every
-        # -b; tg flat ~47. --threads-batch 32 and --poll 100/--poll-batch 1 within
-        # noise → dropped. +-ngl 999.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
-        "flags": "-ngl 999 -fa on -ctk q8_0 -ctv q8_0 -b 8192 -ub 1024 --parallel 1 --threads 16 --no-mmap --jinja",
-        "mtp": True,
-        "device_class": "gpu",
-        "backend": "rocm",
-        "intent": "MoE + MTP · q8 KV",
+        "intent": "ROCm · basic GPU LLM",
         "quant": "FP4",
     },
     "rocmfpx-rocm": {
@@ -896,7 +874,9 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "intent": "ROCmFPX · ROCmFP4 dense · ROCm0 + MTP",
         "quant": "ROCmFP4",
     },
-    "rocmfpx-moe": {
+    # Renamed rocmfpx-moe -> vkfpx-moe (2026-07-05) so the name indicates the
+    # Vulkan lane (this MoEQuality profile runs on Vulkan0, not the ROCm/HIP lane).
+    "vkfpx-moe": {
         # hal0 ROCmFPX runner — Vulkan0 lane for the ROCmFPX MoEQuality weight
         # format (35B-A3B). Vulkan0 gives the best decode t/s for the MoE (ROCm0
         # wins prefill if a slot overrides -dev). -sm none (single GPU) and
@@ -907,24 +887,20 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": True,
         "device_class": "gpu",
         "backend": "vulkan",
-        "intent": "ROCmFPX · MoEQuality 35B-A3B · Vulkan0 + MTP",
+        "intent": "VKFPX · ROCmFPX MoEQuality 35B-A3B · Vulkan0 + MTP",
         "quant": "ROCmFPX",
     },
     "vulkan": {
-        # Strix Halo matrix 2026-07-04 (RADV): -ub sweep monotonic — 256 is the
-        # sweet spot (pp2048 274.7 vs 260.7 @512 = +5.4%; 1024 is WORSE at 244.7),
-        # so -ub 512→256. +-ngl 999/--jinja. Symmetric q8 KV measured +45% pp at
-        # 32k depth on qwen (168 vs 116) and halves KV memory — now ADOPTED. It is
-        # the mirror image on gemma (gemma-4-12B @32k: q8 costs -28.5% pp RADV), so
-        # this profile is NO LONGER intrinsically gemma-safe — it relies on
-        # FAMILY_DEFAULTS["gemma"] pinning gemma slots back to f16 KV. Do NOT drop
-        # the gemma family guard without reverting this to f16.
+        # Basic general-purpose Vulkan (RADV) GPU LLM profile. Intentionally
+        # minimal: -ngl 999, -fa on, --jinja. No KV quant (defaults to f16, which
+        # is gemma-safe) — per-model KV/batch tuning lives in the model's
+        # defaults.extra_args.
         "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
-        "flags": "-ngl 999 -fa on -ctk q8_0 -ctv q8_0 -b 512 -ub 256 --parallel 1 --threads 8 --no-mmap --jinja",
+        "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
         "backend": "vulkan",
-        "intent": "Vulkan std · fallback",
+        "intent": "Vulkan · basic GPU LLM (RADV)",
         "quant": "Q4_K_M",
     },
     "cuda": {
@@ -939,7 +915,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": False,
         "device_class": "gpu",
         "backend": "cuda",
-        "intent": "CUDA · NVIDIA (upstream llama.cpp, experimental)",
+        "intent": "CUDA · basic GPU LLM (NVIDIA, experimental)",
         "quant": "Q4_K_M",
     },
     "embed": {
@@ -981,7 +957,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "",
         "mtp": False,
         "device_class": "npu",
-        "intent": "FLM NPU inference",
+        "intent": "FLM · NPU inference",
         "quant": "W4ABF16",
     },
     "tts": {
@@ -989,7 +965,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx",
         "mtp": False,
         "device_class": "cpu",
-        "intent": "TTS · Kokoro",
+        "intent": "TTS · Kokoro (CPU)",
         "quant": "",
     },
     "tts-qwen3": {
@@ -1001,7 +977,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "mtp": False,
         "device_class": "gpu",
         "backend": "rocm",
-        "intent": "TTS · Qwen3 (multilingual GPU)",
+        "intent": "TTS · Qwen3 (GPU, multilingual)",
         "quant": "BF16",
     },
     "cpu-llm": {
@@ -1014,7 +990,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --no-mmap --jinja",
         "mtp": False,
         "device_class": "cpu",
-        "intent": "CPU-only LLM · llama-server",
+        "intent": "CPU · basic LLM (llama-server)",
         "quant": "Q4_K_M",
     },
     "comfyui": {
@@ -1022,7 +998,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "flags": "--disable-mmap --bf16-vae --cache-none",
         "mtp": False,
         "device_class": "img",
-        "intent": "Image generation",
+        "intent": "ComfyUI · image generation",
         "quant": "",
     },
 }
@@ -1037,8 +1013,6 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
 #: these decode-based hero numbers still hold.
 PROFILE_BENCH: dict[str, dict[str, float]] = {
     "rocm": {"tps": 52.8},
-    "rocm-moe": {"tps": 90.0},
-    "rocm-dnse": {"tps": 30.4},
     "vulkan": {"tps": 41.0},
     "flm": {"tps": 38.6},
     "tts": {"rtf": 0.18},
@@ -1422,7 +1396,7 @@ SEED_STACKS: dict[str, StackConfig] = {
                 slot="agent",
                 model="qwen3-6-35b-a3b-nsc-ace-saber-mtp-f16-to-rocmfp4-strix-lean",
                 device="gpu-rocm",
-                profile="rocm-moe",
+                profile="rocm",
                 mtp=True,
                 capabilities=_embed_rerank_rows(),
             ),

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -108,8 +108,10 @@ def derive_profile(capability: str, device: str) -> str:
     GPU-less boxes (device=cpu + profile=vulkan incoherent, #834).
     """
     if device == "gpu-rocm" and capability in ("chat", "coder"):
-        # Dense chat/coder benefit from MTP; embed/rerank take their own lanes.
-        return "rocm-dnse"
+        # Plain ROCm GPU LLM. (The legacy MTP rocm-dnse profile was removed
+        # 2026-07-05; MTP dense now lives on the ROCmFPX profiles, which slots
+        # opt into explicitly — derivation never silently forces MTP.)
+        return "rocm"
     if device == "gpu-rocm" and capability == "embed":
         # Embeddings get the dedicated GPU embed profile (llama-server
         # --embedding, -ub 8192) rather than the chat-tuned plain `rocm` — the

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -86,6 +86,36 @@ def _resolve_profile(name: str) -> Any:
     return ProfileCatalog().resolve(name)
 
 
+def _resolve_profile_or_base(profile_name: str, slot_cfg: dict[str, Any]) -> Any:
+    """Resolve a slot's profile, falling back to the backend's basic seed
+    profile (``rocm`` / ``vulkan``) when the pinned profile no longer exists.
+
+    A seed cleanup (or a renamed seed) can leave an existing slot pinned to a
+    profile name that is gone from the catalog — e.g. the retired
+    ``rocm-dnse`` / ``rocm-moe``. Rather than hard-fail the launch, fall back to
+    the simple profile named after the slot's backend so the slot stays
+    launchable across an update. MTP-tuning is lost in the fallback (the base
+    profiles are non-MTP); operators re-pin an explicit profile if they want it.
+    """
+    from hal0.errors import NotFound
+
+    try:
+        return _resolve_profile(profile_name)
+    except NotFound:
+        from hal0.config.loader import load_profiles_config
+
+        backend = str(slot_cfg.get("backend") or "")
+        catalog = load_profiles_config().profile
+        base = backend if backend in catalog else "rocm"
+        log.warning(
+            "profile %r not found; falling back to base profile %r",
+            profile_name,
+            base,
+            extra={"event": "profile.fallback", "missing": profile_name, "base": base},
+        )
+        return _resolve_profile(base)
+
+
 def _profile_image_and_flags(profile: Any, mtp_override: bool | None = None) -> tuple[str, str]:
     """Extract ``(image, resolved_flags)`` from a profile object.
 
@@ -900,7 +930,7 @@ class ContainerProvider(Provider):
           nodes + permissions itself).
         """
         profile_name = slot_cfg.get("profile") or ""
-        profile = _resolve_profile(profile_name)
+        profile = _resolve_profile_or_base(profile_name, slot_cfg)
         # for_launch: this is the real container-spec build — side-effect logs
         # (MTP auto-off breadcrumb) fire here, never on preview/status renders.
         scalars = _resolve_llama_scalars(slot_cfg, model_info, profile, for_launch=True)
@@ -1456,7 +1486,7 @@ def _resolve_slot_argv(
     if not profile_name:
         return None
     try:
-        profile = _resolve_profile(profile_name)
+        profile = _resolve_profile_or_base(profile_name, slot_cfg)
         model_info = _best_effort_model_info(slot_cfg, model_path)
         scalars = _resolve_llama_scalars(slot_cfg, model_info, profile)
     except Exception:

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -46,13 +46,13 @@ def test_build_slot_cfg_sets_device_profile_model():
         slot="chat",
         model_id="qwen3.6-27b",
         device="gpu-rocm",
-        profile="rocm-dnse",
+        profile="rocm",
         port=8081,
         context_size=32768,
     )
     assert cfg["name"] == "chat"
     assert cfg["device"] == "gpu-rocm"
-    assert cfg["profile"] == "rocm-dnse"
+    assert cfg["profile"] == "rocm"
     assert cfg["enabled"] is True
     assert cfg["model"]["default"] == "qwen3.6-27b"
     assert cfg["model"]["context_size"] == 32768
@@ -107,7 +107,7 @@ def test_apply_seeds_jobs_and_creates_slots(isolated_app_client, tmp_hal0_home, 
     # The default tier's primary is a curated chat model → a job + slot exist.
     assert "qwen3.5-9b" in body["model_ids"]
     chat = next(s for s in body["slots"] if s["slot"] == "chat")
-    assert chat["profile"] in ("rocm-dnse", "vulkan")
+    assert chat["profile"] in ("rocm", "vulkan")
     assert chat["created"] is True
     # Slot TOML written OFFLINE (not started).
     toml = Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "chat.toml"
@@ -142,7 +142,7 @@ def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monk
             "storage_dir": tmp_hal0_home,
             "npu_opt_in": False,
             # Override chat: a different curated model + the vulkan profile/device
-            # (coherent pair) instead of the auto-derived rocm-dnse.
+            # (coherent pair) instead of the auto-derived rocm.
             "overrides": {
                 "chat": {"model_id": "qwen3.6-27b", "profile": "vulkan", "device": "gpu-vulkan"}
             },

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -42,14 +42,14 @@ class TestListProfiles:
         assert isinstance(data, list)
 
     def test_returns_seed_profiles(self, client: TestClient) -> None:
-        """One entry per seed profile (14: the rocm/rocm-dnse/rocm-moe trio,
-        the rocmfpx-rocm/rocmfpx-moe ROCmFPX-runner pair, vulkan, the
-        experimental NVIDIA cuda profile, the dedicated embed and rerank GPU
-        lanes, flm NPU, the tts/tts-qwen3 pair, the cpu-llm CPU profile #834,
-        and Phase D comfyui)."""
+        """One entry per seed profile (12: the basic rocm profile, the
+        rocmfpx-rocm/vkfpx-moe ROCmFPX-runner pair, vulkan, the experimental
+        NVIDIA cuda profile, the dedicated embed and rerank GPU lanes, flm NPU,
+        the tts/tts-qwen3 pair, the cpu-llm CPU profile #834, and Phase D
+        comfyui)."""
         data = client.get("/api/profiles").json()
         assert len(data) == len(SEED_PROFILES)
-        assert len(data) == 14
+        assert len(data) == 12
 
     def test_flm_npu_seed_present(self, client: TestClient) -> None:
         """Phase A added the flm container profile to the seeds."""
@@ -101,7 +101,7 @@ class TestListProfiles:
         data = client.get("/api/profiles").json()
         by_name = {item["name"]: item for item in data}
         assert by_name["rocm"]["backend"] == "rocm"
-        assert by_name["rocm-dnse"]["backend"] == "rocm"
+        assert by_name["rocmfpx-rocm"]["backend"] == "rocm"
         assert by_name["vulkan"]["backend"] == "vulkan"
         assert by_name["flm"]["backend"] is None
         assert by_name["tts"]["backend"] is None
@@ -114,7 +114,7 @@ class TestListProfiles:
 
     def test_dense_mtp_rocmfp4_mtp_true(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-dnse")
+        dense = next(item for item in data if item["name"] == "rocmfpx-rocm")
         assert dense["mtp"] is True
 
     def test_vulkan_std_image_contains_vulkan(self, client: TestClient) -> None:
@@ -124,12 +124,12 @@ class TestListProfiles:
 
     def test_mtp_true_resolved_flags_contains_spec_type(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-dnse")
+        dense = next(item for item in data if item["name"] == "rocmfpx-rocm")
         assert "--spec-type draft-mtp" in dense["resolved_flags"]
 
     def test_mtp_true_resolved_flags_contains_bundle(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()
-        dense = next(item for item in data if item["name"] == "rocm-dnse")
+        dense = next(item for item in data if item["name"] == "rocmfpx-rocm")
         assert MTP_FLAG_BUNDLE in dense["resolved_flags"]
 
     def test_mtp_false_resolved_flags_no_spec_type(self, client: TestClient) -> None:
@@ -176,7 +176,7 @@ class TestEnrichedFields:
         data = client.get("/api/profiles").json()
         by_name = {p["name"]: p for p in data}
         rocm = by_name["rocm"]
-        assert rocm["intent"] == "MoE agents"
+        assert rocm["intent"] == "ROCm · basic GPU LLM"
         assert rocm["quant"] == "FP4"
         assert rocm["tps"] == 52.8
         assert rocm["rtf"] is None

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1629,7 +1629,7 @@ def test_config_profile_change_drives_device_via_route(
 ) -> None:
     """PUT /config with a new profile re-derives device (drawer path).
 
-    Re-points a vulkan slot at the rocm-dnse profile; the device must follow
+    Re-points a vulkan slot at the rocm profile; the device must follow
     to gpu-rocm so the slot no longer reports vulkan under a ROCm profile.
     """
     _seed_slot_toml(
@@ -1648,11 +1648,11 @@ def test_config_profile_change_drives_device_via_route(
         ],
     )
 
-    r = isolated_client.put("/api/slots/utility/config", json={"profile": "rocm-dnse"})
+    r = isolated_client.put("/api/slots/utility/config", json={"profile": "rocm"})
     assert r.status_code == 200, r.text
 
     cfg = isolated_client.get("/api/slots/utility/config").json()
-    assert cfg["profile"] == "rocm-dnse"
+    assert cfg["profile"] == "rocm"
     assert cfg["device"] == "gpu-rocm"
 
 
@@ -1663,8 +1663,8 @@ def test_backend_flip_reconciles_profile_via_route(
 ) -> None:
     """POST /backend (writes device only) re-points an incompatible profile.
 
-    Flipping a rocm-dnse slot to the vulkan backend must drop the rocm-only
-    profile rather than persist a vulkan device under rocm-dnse.
+    Flipping a rocm slot to the vulkan backend must drop the rocm-only
+    profile rather than persist a vulkan device under rocm.
     """
     _seed_slot_toml(
         tmp_hal0_home,
@@ -1675,7 +1675,7 @@ def test_backend_flip_reconciles_profile_via_route(
             'device = "gpu-rocm"',
             'provider = "llama-server"',
             'runtime = "container"',
-            'profile = "rocm-dnse"',
+            'profile = "rocm"',
             "enabled = true",
             "[model]",
             'default = "m"',

--- a/tests/cli/test_setup_ui.py
+++ b/tests/cli/test_setup_ui.py
@@ -48,7 +48,7 @@ def test_suggestion_table_stars_recommended():
             0.0,
             32768,
             "gpu-rocm",
-            "rocm-dnse",
+            "rocm",
             "chat",
             False,
             recommended=True,

--- a/tests/config/test_profile_derivation_parity.py
+++ b/tests/config/test_profile_derivation_parity.py
@@ -3,8 +3,9 @@
 The platform review found three parallel ``(capability, device) → profile``
 derivations that drifted apart across #834's churn:
 
-  1. :func:`hal0.install.profile_derive.derive_profile` — the install-flavoured,
-     MTP-preferring resolver (gpu-rocm + dense chat/coder → ``rocm-dnse``).
+  1. :func:`hal0.install.profile_derive.derive_profile` — the install-flavoured
+     resolver (gpu-rocm + dense chat/coder → plain ``rocm``; the legacy MTP
+     ``rocm-dnse`` preference was removed 2026-07-05).
   2. :data:`hal0.config.schema.DEVICE_DEFAULT_PROFILES` — the canonical, plain
      device-class-representative base table (never MTP).
   3. The verbatim-twin ``_profile_for_fit`` blocks in ``capabilities/catalog.py``
@@ -13,9 +14,10 @@ derivations that drifted apart across #834's churn:
 
 The consolidation in PS-4 is a literal-dedup + shared-helper refactor with ZERO
 behaviour change. These tests pin the CURRENT matrix so a future unification
-cannot silently drift — critically they lock in the deliberate split between the
-MTP-preferring install path and the non-MTP picker/reconcile path (the naive
-three-way merge the finding proposed would break this).
+cannot silently drift. Since the MTP ``rocm-dnse`` seed was removed
+(2026-07-05), all three paths now resolve dense chat/coder on ROCm to the plain
+non-MTP ``rocm`` base — MTP dense lives on the opt-in ``rocmfpx-rocm`` profile,
+which nothing forces silently.
 """
 
 from __future__ import annotations
@@ -33,12 +35,13 @@ from hal0.install.profile_derive import derive_profile
 _CAPABILITIES = ("chat", "coder", "embed", "rerank", "utility", "tts", "agent", "image")
 _DEVICES = ("gpu-rocm", "gpu-vulkan", "cpu", "npu")
 
-# derive_profile (install path): MTP-preferring on ROCm for dense chat/coder.
+# derive_profile (install path): plain rocm base on ROCm (the legacy MTP
+# rocm-dnse preference was removed 2026-07-05).
 _DERIVE_MATRIX: dict[tuple[str, str], str] = {
-    # gpu-rocm — dense chat/coder get MTP rocm-dnse; embed/rerank take their
-    # dedicated GPU lanes; everything else plain rocm.
-    ("chat", "gpu-rocm"): "rocm-dnse",
-    ("coder", "gpu-rocm"): "rocm-dnse",
+    # gpu-rocm — dense chat/coder get the plain rocm base; embed/rerank take
+    # their dedicated GPU lanes; everything else plain rocm.
+    ("chat", "gpu-rocm"): "rocm",
+    ("coder", "gpu-rocm"): "rocm",
     ("embed", "gpu-rocm"): "embed",
     ("rerank", "gpu-rocm"): "rerank",
     ("utility", "gpu-rocm"): "rocm",
@@ -83,11 +86,11 @@ def test_derive_profile_matrix_is_pinned(capability: str, device: str) -> None:
     assert derive_profile(capability, device) == _DERIVE_MATRIX[(capability, device)]
 
 
-def test_derive_profile_rocm_prefers_mtp_for_dense_chat_coder() -> None:
-    # The install-path specialisations on ROCm: MTP for dense chat/coder, and
-    # the dedicated embed/rerank lanes for those capabilities.
-    assert derive_profile("chat", "gpu-rocm") == "rocm-dnse"
-    assert derive_profile("coder", "gpu-rocm") == "rocm-dnse"
+def test_derive_profile_rocm_dense_chat_coder_and_lanes() -> None:
+    # dense chat/coder derive to the plain rocm base (no MTP preference since
+    # rocm-dnse was removed 2026-07-05); embed/rerank take their dedicated lanes.
+    assert derive_profile("chat", "gpu-rocm") == "rocm"
+    assert derive_profile("coder", "gpu-rocm") == "rocm"
     assert derive_profile("embed", "gpu-rocm") == "embed"
     assert derive_profile("rerank", "gpu-rocm") == "rerank"
 
@@ -139,14 +142,14 @@ def test_profile_for_fit_matches_shared_helper(
 
 
 def test_fit_helper_is_non_mtp_on_rocm() -> None:
-    """The picker/apply fit path NEVER prefers the MTP rocm-dnse image —
-    that is the install path's job only. This is the guard the naive
-    three-way merge would break.
+    """The picker/apply fit path NEVER forces an MTP image on ROCm — dense
+    chat/coder resolve to the plain non-MTP ``rocm`` base (MTP lives only on
+    the opt-in rocmfpx-rocm profile).
     """
     assert profile_name_for_fit("chat", "gpu-rocm") == "rocm"
     assert profile_name_for_fit("coder", "gpu-rocm") == "rocm"
     # embed/rerank resolve to their dedicated lanes — still non-MTP, so the
-    # "never force rocm-dnse" guarantee holds.
+    # "never force MTP" guarantee holds.
     assert profile_name_for_fit("embed", "gpu-rocm") == "embed"
     assert profile_name_for_fit("rerank", "gpu-rocm") == "rerank"
     assert profile_name_for_fit("chat", "gpu-vulkan") == "vulkan"
@@ -165,13 +168,13 @@ def test_base_profile_for_backend_is_non_mtp(tmp_hal0_home: str) -> None:
 
 
 def test_reconcile_device_flip_stays_non_mtp(tmp_hal0_home: str) -> None:
-    """Flipping a chat slot gpu-rocm → gpu-vulkan yields "vulkan", never the
-    MTP "rocm-dnse" — locks in the deliberate non-MTP reconcile semantics.
+    """Flipping a chat slot gpu-rocm → gpu-vulkan yields "vulkan", never a
+    ROCm MTP profile — locks in the deliberate non-MTP reconcile semantics.
     """
     from hal0.slots.manager import _reconcile_device_profile
 
-    # Slot was on the rocm-dnse (MTP) profile; operator flips the device only.
-    cfg_dict: dict[str, object] = {"device": "gpu-vulkan", "profile": "rocm-dnse"}
+    # Slot was on the rocmfpx-rocm (MTP) profile; operator flips the device only.
+    cfg_dict: dict[str, object] = {"device": "gpu-vulkan", "profile": "rocmfpx-rocm"}
     _reconcile_device_profile(cfg_dict, changed={"device"})
     assert cfg_dict["profile"] == "vulkan"
-    assert cfg_dict["profile"] != "rocm-dnse"
+    assert cfg_dict["profile"] != "rocmfpx-rocm"

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -182,13 +182,14 @@ class TestLoadProfilesConfig:
 
     def test_seed_count(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        # rocm, rocm-dnse, rocm-moe, vulkan, flm, tts, tts-qwen3, comfyui, cpu-llm
+        # rocm, rocmfpx-rocm, vkfpx-moe, vulkan, cuda, embed, rerank, flm, tts,
+        # tts-qwen3, cpu-llm, comfyui
         assert len(cfg.profile) == len(SEED_PROFILES)
 
     def test_seed_profiles_have_correct_names(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
         assert "rocm" in cfg.profile
-        assert "rocm-dnse" in cfg.profile
+        assert "rocmfpx-rocm" in cfg.profile
         assert "vulkan" in cfg.profile
 
     def test_seed_rocm_mtp_false(self, tmp_path: Path) -> None:
@@ -197,7 +198,7 @@ class TestLoadProfilesConfig:
 
     def test_seed_rocm_mtp_mtp_true(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert cfg.profile["rocm-dnse"].mtp is True
+        assert cfg.profile["rocmfpx-rocm"].mtp is True
 
     def test_seed_vulkan_correct_image(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
@@ -206,7 +207,7 @@ class TestLoadProfilesConfig:
     def test_seed_gpu_profiles_have_backend(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
         assert cfg.profile["rocm"].backend == "rocm"
-        assert cfg.profile["rocm-dnse"].backend == "rocm"
+        assert cfg.profile["rocmfpx-rocm"].backend == "rocm"
         assert cfg.profile["vulkan"].backend == "vulkan"
         assert cfg.profile["flm"].backend is None
         assert cfg.profile["tts"].backend is None
@@ -387,7 +388,7 @@ def test_profile_device_class_defaults_gpu() -> None:
 def test_seed_device_classes() -> None:
     assert SEED_PROFILES["vulkan"]["device_class"] == "gpu"
     assert SEED_PROFILES["rocm"]["device_class"] == "gpu"
-    assert SEED_PROFILES["rocm-dnse"]["device_class"] == "gpu"
+    assert SEED_PROFILES["rocmfpx-rocm"]["device_class"] == "gpu"
     assert SEED_PROFILES["flm"]["device_class"] == "npu"
     assert SEED_PROFILES["tts"]["device_class"] == "cpu"
     assert SEED_PROFILES["comfyui"]["device_class"] == "img"
@@ -395,7 +396,7 @@ def test_seed_device_classes() -> None:
 
 def test_seed_backends() -> None:
     assert SEED_PROFILES["rocm"]["backend"] == "rocm"
-    assert SEED_PROFILES["rocm-dnse"]["backend"] == "rocm"
+    assert SEED_PROFILES["rocmfpx-rocm"]["backend"] == "rocm"
     assert SEED_PROFILES["vulkan"]["backend"] == "vulkan"
     # non-GPU profiles carry no backend (device_class drives display)
     assert SEED_PROFILES["flm"].get("backend") is None

--- a/tests/install/test_orchestrate.py
+++ b/tests/install/test_orchestrate.py
@@ -73,7 +73,7 @@ async def test_apply_setup_creates_chat_slot_and_plans_pull():
         write_sentinel=False,
     )
     assert sm.created["chat"]["device"] == "gpu-rocm"
-    assert sm.created["chat"]["profile"] == "rocm-dnse"
+    assert sm.created["chat"]["profile"] == "rocm"
     out = res.slots[0]
     assert out.created is True and out.skipped is None
     assert "qwen3-4b" in res.model_ids

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -31,10 +31,12 @@ def _hw(*, platform="bare-metal-amd-gpu", compute=True, vulkan=True, npu=False):
     )
 
 
-def test_chat_on_rocm_box_picks_rocm_mtp():
+def test_chat_on_rocm_box_picks_rocm():
+    # derive no longer prefers the MTP image on ROCm — chat/coder derive to the
+    # plain `rocm` profile; MTP dense now lives on rocmfpx-rocm (opt-in only).
     hw = _hw(compute=True)
     assert derive_device("chat", hw, npu_opt_in=False) == "gpu-rocm"
-    assert derive_profile("chat", "gpu-rocm") == "rocm-dnse"
+    assert derive_profile("chat", "gpu-rocm") == "rocm"
 
 
 def test_chat_on_vulkan_only_box_picks_vulkan():

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -32,7 +32,7 @@ def test_resolve_qwen3tts_seed_is_gpu_tts_family(tmp_hal0_home: str) -> None:
 def test_resolve_exposes_backend(tmp_hal0_home: str) -> None:
     catalog = ProfileCatalog()
     assert catalog.resolve("rocm").backend == "rocm"
-    assert catalog.resolve("rocm-dnse").backend == "rocm"
+    assert catalog.resolve("rocmfpx-rocm").backend == "rocm"
     assert catalog.resolve("vulkan").backend == "vulkan"
     # non-GPU seeds carry no backend
     assert catalog.resolve("flm").backend is None
@@ -123,7 +123,7 @@ def test_cloned_from_defaults_to_none_and_survives_update(tmp_hal0_home: str) ->
 def test_seed_bench_metrics_exposed(tmp_hal0_home: str) -> None:
     by_name = {p.name: p for p in ProfileCatalog().list()}
     assert by_name["rocm"].tps == 52.8
-    assert by_name["rocm-dnse"].tps == 30.4
+    assert by_name["vulkan"].tps == 41.0
     # TTS is synth — reported as a real-time factor, not tok/s.
     assert by_name["tts"].tps is None
     assert by_name["tts"].rtf == 0.18
@@ -131,7 +131,7 @@ def test_seed_bench_metrics_exposed(tmp_hal0_home: str) -> None:
 
 def test_seed_intent_and_quant_exposed(tmp_hal0_home: str) -> None:
     by_name = {p.name: p for p in ProfileCatalog().list()}
-    assert by_name["rocm"].intent == "MoE agents"
+    assert by_name["rocm"].intent == "ROCm · basic GPU LLM"
     assert by_name["rocm"].quant == "FP4"
     assert by_name["vulkan"].quant == "Q4_K_M"
 

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -891,22 +891,22 @@ class TestFamilyDefaults:
         assert argv is not None
         assert argv[argv.index("-ctk") + 1] == "q4_0"  # slot override wins over family
 
-    def test_vulkan_seed_ships_q8_but_gemma_is_guarded(self) -> None:
-        """The vulkan seed adopts q8 KV (qwen +45% pp win) and RELIES on the
-        gemma family guard for safety — qwen-on-vulkan gets q8, gemma gets f16."""
+    def test_vulkan_seed_is_basic_no_forced_kv_quant(self) -> None:
+        """The vulkan seed ships minimal flags with NO forced KV quant.
+
+        The 2026-07-05 seed cleanup reduced the plain ``vulkan`` seed to basic
+        flags, so f16 (the llama-server default) applies universally — it is
+        gemma-safe without relying on a family guard against a q8 vulkan seed,
+        and per-model KV tuning now lives in the model's ``defaults.extra_args``.
+        A slot on the basic vulkan seed therefore never gets a forced q8 KV.
+        """
         vseed = SEED_PROFILES["vulkan"]
-        assert "-ctk q8_0 -ctv q8_0" in vseed["flags"], "vulkan seed must ship q8 KV"
+        assert "-ctk" not in vseed["flags"] and "q8_0" not in vseed["flags"]
+        assert "-ngl 999" in vseed["flags"] and "-fa on" in vseed["flags"]
+
         profile = ProfileConfig(image=vseed["image"], flags=vseed["flags"], mtp=False)
-
-        def _resolve(model_default: str, path: str) -> list[str]:
-            cfg = {"profile": "vulkan", "port": 8096, "model": {"default": model_default}}
-            with patch("hal0.providers.container._resolve_profile", return_value=profile):
-                argv = resolved_command_for_slot(cfg, model_path=path)
-            assert argv is not None
-            return argv
-
-        qwen = _resolve("qwen3-27b", "/mnt/ai-models/qwen3-27b.gguf")
-        assert qwen[qwen.index("-ctk") + 1] == "q8_0"  # adopted win, no guard
-        gemma = _resolve("gemma-4-12b-it", "/mnt/ai-models/gemma-4-12b-it.gguf")
-        assert "q8_0" not in gemma  # family guard pins f16, q8 deduped away
-        assert gemma[gemma.index("-ctk") + 1] == "f16"
+        cfg = {"profile": "vulkan", "port": 8096, "model": {"default": "qwen3-27b"}}
+        with patch("hal0.providers.container._resolve_profile", return_value=profile):
+            argv = resolved_command_for_slot(cfg, model_path="/mnt/ai-models/qwen3-27b.gguf")
+        assert argv is not None
+        assert "q8_0" not in argv  # basic seed forces no KV quant

--- a/tests/slots/test_device_profile_coherence.py
+++ b/tests/slots/test_device_profile_coherence.py
@@ -5,7 +5,7 @@ A GPU slot carries two fields that each imply a backend: ``device``
 (the ProfileConfig, whose ``backend`` selects the container image + flags).
 Before this guard they could diverge silently: the dashboard set the
 ``utility`` slot's ``device`` to ``gpu-vulkan`` while leaving its
-``profile`` at ``rocm-dnse``, so the slot reported ``backend=vulkan`` yet
+``profile`` at ``rocm``, so the slot reported ``backend=vulkan`` yet
 resolved the ROCm image + ROCm-only MTP draft flags — and re-picking the
 profile in the drawer never corrected the device.
 
@@ -41,17 +41,17 @@ def _gpu_cfg(name: str, *, device: str, profile: str, model: str = "m") -> dict:
 async def test_profile_change_drives_device(tmp_hal0_home: str) -> None:
     """Switching the profile re-derives device — the exact utility-slot bug.
 
-    A vulkan slot re-pointed at the rocm-dnse profile must end up on
+    A vulkan slot re-pointed at the rocm profile must end up on
     ``device=gpu-rocm``; otherwise the drawer 'changes' the profile but the
     backend stays vulkan forever.
     """
     sm = SlotManager()
     await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="vulkan"))
 
-    await sm.update_config("util", {"profile": "rocm-dnse"})
+    await sm.update_config("util", {"profile": "rocm"})
 
     cfg = await sm.get_config("util")
-    assert cfg["profile"] == "rocm-dnse"
+    assert cfg["profile"] == "rocm"
     assert cfg["device"] == "gpu-rocm"
 
 
@@ -60,10 +60,10 @@ async def test_device_change_reconciles_conflicting_profile(tmp_hal0_home: str) 
 
     The ``POST /api/slots/{name}/backend`` control writes only ``device``;
     a cross-backend flip must reconcile the profile to a compatible one so
-    no rocm-dnse+vulkan pair is ever persisted.
+    no rocm+vulkan pair is ever persisted.
     """
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm"))
 
     await sm.update_config("util", {"device": "gpu-vulkan"})
 
@@ -75,23 +75,23 @@ async def test_device_change_reconciles_conflicting_profile(tmp_hal0_home: str) 
 async def test_unrelated_update_preserves_coherent_pair(tmp_hal0_home: str) -> None:
     """A change that touches neither device nor profile leaves both intact."""
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm"))
 
     await sm.update_config("util", {"model": {"context_size": 32768}})
 
     cfg = await sm.get_config("util")
     assert cfg["device"] == "gpu-rocm"
-    assert cfg["profile"] == "rocm-dnse"
+    assert cfg["profile"] == "rocm"
     assert cfg["model"]["context_size"] == 32768
 
 
 async def test_explicit_contradiction_rejected(tmp_hal0_home: str) -> None:
     """Changing both fields to conflicting backends is an operator error."""
     sm = SlotManager()
-    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm-dnse"))
+    await sm.create("util", _gpu_cfg("util", device="gpu-rocm", profile="rocm"))
 
     with pytest.raises(SlotConfigError, match=r"(?i)backend"):
-        await sm.update_config("util", {"profile": "rocm-dnse", "device": "gpu-vulkan"})
+        await sm.update_config("util", {"profile": "rocm", "device": "gpu-vulkan"})
 
 
 async def test_create_rejects_incoherent_pair(tmp_hal0_home: str) -> None:
@@ -102,7 +102,7 @@ async def test_create_rejects_incoherent_pair(tmp_hal0_home: str) -> None:
     """
     sm = SlotManager()
     with pytest.raises(SlotConfigError, match=r"(?i)backend"):
-        await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="rocm-dnse"))
+        await sm.create("util", _gpu_cfg("util", device="gpu-vulkan", profile="rocm"))
 
 
 async def test_non_gpu_profile_untouched(tmp_hal0_home: str) -> None:

--- a/tests/slots/test_model_preferred_profile.py
+++ b/tests/slots/test_model_preferred_profile.py
@@ -73,7 +73,7 @@ async def test_apply_preferred_profile_swaps_when_compatible(tmp_hal0_home: str)
     _register("v2", profile="vulkan")
     sm = SlotManager()
     cfg0 = _gpu_vulkan_cfg("g", "v2")
-    cfg0["profile"] = "rocm-moe"  # a stale profile that doesn't match device
+    cfg0["profile"] = "rocm"  # a stale profile that doesn't match device
     # create would reconcile; write directly via create with a coherent profile
     cfg0["profile"] = "vulkan"
     await sm.create("g", cfg0)

--- a/tests/stacks/test_apply_plan.py
+++ b/tests/stacks/test_apply_plan.py
@@ -144,7 +144,7 @@ class TestGuardedReconcile:
                     slot="agent",
                     model="m",
                     device="gpu-vulkan",
-                    profile="rocm-dnse",  # rocm profile under a vulkan device
+                    profile="rocm",  # rocm profile under a vulkan device
                 )
             ],
         )

--- a/tests/stacks/test_apply_validate.py
+++ b/tests/stacks/test_apply_validate.py
@@ -31,9 +31,9 @@ def test_validate_flags_unknown_profile() -> None:
 def test_validate_flags_unknown_model() -> None:
     stack = StackConfig(
         name="Forge",
-        slots=[StackSlotEntry(slot="agent", model="ghost-model", profile="rocm-moe")],
+        slots=[StackSlotEntry(slot="agent", model="ghost-model", profile="rocm")],
     )
-    warnings = _engine().validate(stack, known_profiles={"rocm-moe"}, known_models=set())
+    warnings = _engine().validate(stack, known_profiles={"rocm"}, known_models=set())
     assert any("model 'ghost-model' not in registry" in w for w in warnings)
 
 

--- a/tests/stacks/test_snapshot.py
+++ b/tests/stacks/test_snapshot.py
@@ -73,7 +73,7 @@ class TestSnapshot:
             'type = "llm"\n'
             'device = "gpu-rocm"\n'
             'backend = "rocm"\n'
-            'profile = "rocm-moe"\n'
+            'profile = "rocm"\n'
             "port = 8082\n"
             "mtp = true\n\n"
             "[model]\n"
@@ -84,7 +84,7 @@ class TestSnapshot:
         agent = next(e for e in stack.slots if e.slot == "agent")
         assert agent.model == "ace-saber"
         assert agent.device == "gpu-rocm"
-        assert agent.profile == "rocm-moe"
+        assert agent.profile == "rocm"
         assert agent.mtp is True
 
     def test_legacy_backend_device_dropped(self, reg: ModelRegistry, tmp_hal0_home: str) -> None:


### PR DESCRIPTION
Seed-profile cleanup so `hal0 update` ships a coherent, minimal stack.

- Remove legacy MTP toolbox profiles `rocm-moe`/`rocm-dnse` (+ PROFILE_BENCH + the saber SEED_STACK ref). The ROCmFPX profiles are the MTP lanes now.
- Rename `rocmfpx-moe` → `vkfpx-moe` (name indicates the Vulkan lane).
- Reduce plain `rocm`/`vulkan` to basic flags (`-ngl 999 -fa on --jinja`); per-model KV/batch tuning lives in model defaults.
- Clean intent labels across the seed stack.
- `derive_profile`: dense gpu-rocm chat/coder → `rocm`.

**Update-safety (no migration needed):** `container._resolve_profile_or_base` falls back to the slot backend's basic profile (rocm/vulkan) when a pinned profile is gone from the catalog, so existing slots on rocm-moe/rocm-dnse keep launching after an update instead of hard-failing. 304 tests pass across 14 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)