### PR TITLE
release: bundle RELEASE_NOTES.md + release.json into the tarball (updater notes producer)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,20 @@ jobs:
           echo "${VERSION}" > "${STAGE}/VERSION"
           echo "stage=${STAGE}"      >> "$GITHUB_OUTPUT"
 
+      # ── 2b. Stage release notes INTO the tarball ────────────────────────────
+      # The updater's prepare() reads RELEASE_NOTES.md + release.json from the
+      # extracted (cosign-verified) tree to show notes before commit
+      # (src/hal0/updater/updater.py::_read_release_notes). These must be inside
+      # the tarball root, so generate them here — before the tarball is built.
+      # Notes are optional: an un-noted release degrades to a one-liner + empty
+      # structured lists, which the CLI renders as no callouts.
+      - name: Stage release notes
+        run: |
+          python3 scripts/gen_release_notes.py \
+            --tag "${{ steps.ver.outputs.tag }}" \
+            --channel "${{ steps.ver.outputs.channel }}" \
+            --out-dir "${{ steps.stage.outputs.stage }}"
+
       - name: Build tarball
         id: tarball
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ page; this CHANGELOG starts at v0.2.0 (the Lemonade migration cut).
 ADR-level architecture decisions are kept internal (the `docs/internal/`
 tree is gitignored, #638) and referenced by number throughout the code.
 
+**Release automation.** On a tagged release the matching `## [<version>]`
+section below is bundled into the release tarball as `RELEASE_NOTES.md`, and its
+optional `### Highlights`, `### Breaking`, and `### Migrations` subsections are
+extracted into `release.json`. `hal0 update` shows both — rendering
+breaking/migrations as callouts — from the cosign-verified tarball, before
+applying. Add those subsections to a version's section to surface them; see
+`scripts/gen_release_notes.py`.
+
 ## [Unreleased]
 
 ### Added

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate ``RELEASE_NOTES.md`` + ``release.json`` into a release tarball root.
+
+The release workflow stages these two files at the tarball root
+(``hal0-<version>/``) so the updater's ``prepare()`` step can show
+cosign-verified release notes before ``commit``
+(``src/hal0/updater/updater.py::_read_release_notes``). ``RELEASE_NOTES.md`` is
+the human-facing markdown; ``release.json`` carries the structured
+``{highlights, breaking, migrations}`` the ``hal0 update`` CLI renders as
+callouts. Because they live inside the cosign-verified tarball (not a plain-TLS
+URL), what an operator reviews is exactly what was signed.
+
+Source of truth: the matching ``## [<version>]`` section of CHANGELOG.md (Keep a
+Changelog). Its ``### Highlights`` / ``### Breaking`` / ``### Migrations``
+subsections populate ``release.json``. For the ``nightly`` channel (which has no
+changelog section) the markdown is a commit log since the previous nightly tag
+and the structured lists are empty. If nothing resolves, notes degrade to a
+one-liner — the updater treats notes as optional, so an un-noted release still
+installs cleanly.
+
+Run from the repo root (needs full git history for the nightly / fallback ranges,
+i.e. an ``actions/checkout`` with ``fetch-depth: 0``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Import the pure helpers without an editable install (mirrors the workflow's
+# ``PYTHONPATH=src python3 -c …`` convention).
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from hal0.release.notes import extract_changelog_section, extract_structured
+
+
+def _git(*args: str) -> str:
+    """Run a git command, returning trimmed stdout or ``""`` on any failure."""
+    try:
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except Exception:
+        return ""
+
+
+def _prev_tag(tag: str, *, nightly: bool) -> str:
+    """Most recent release tag before *tag* (nightly picks the prior nightly)."""
+    tags = [t for t in _git("tag", "--list", "v*", "--sort=-creatordate").splitlines() if t != tag]
+    if nightly:
+        nightlies = [t for t in tags if "-nightly." in t]
+        stables = [t for t in tags if "-nightly." not in t]
+        return (nightlies or stables or [""])[0]
+    stables = [t for t in tags if "-nightly." not in t]
+    return (stables or [""])[0]
+
+
+def _git_changelog(tag: str, *, nightly: bool) -> str:
+    """Fallback markdown: a commit log since the previous relevant tag."""
+    prev = _prev_tag(tag, nightly=nightly)
+    rng = f"{prev}..HEAD" if prev else "HEAD"
+    log = _git("log", "--no-merges", "--pretty=- %s", rng) or "- (no changelog available)"
+    label = f"since {prev}" if prev else "since the initial commit"
+    return f"# hal0 {tag.lstrip('v')}\n\nChanges {label}:\n\n{log}\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Generate RELEASE_NOTES.md + release.json")
+    ap.add_argument("--tag", required=True, help="release tag, e.g. v0.10.0")
+    ap.add_argument("--channel", default="stable", choices=["stable", "nightly"])
+    ap.add_argument("--out-dir", required=True, help="tarball root dir to write into")
+    ap.add_argument("--changelog", default="CHANGELOG.md")
+    args = ap.parse_args()
+
+    version = args.tag.lstrip("v")
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    markdown = ""
+    structured: dict[str, list[str]] = {"highlights": [], "breaking": [], "migrations": []}
+    source = ""
+
+    if args.channel != "nightly":
+        changelog_path = Path(args.changelog)
+        section = ""
+        if changelog_path.is_file():
+            section = extract_changelog_section(
+                changelog_path.read_text(encoding="utf-8"), args.tag
+            )
+        if section:
+            markdown = f"# hal0 {version}\n\n{section}\n"
+            structured = extract_structured(section)
+            source = f"{args.changelog}#{version}"
+
+    if not markdown:
+        markdown = _git_changelog(args.tag, nightly=(args.channel == "nightly"))
+        source = "git-log"
+
+    (out / "RELEASE_NOTES.md").write_text(markdown, encoding="utf-8")
+    release = {"version": version, "channel": args.channel, "source": source, **structured}
+    (out / "release.json").write_text(json.dumps(release, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        f"release-notes → {out}: RELEASE_NOTES.md ({len(markdown)}B) + release.json "
+        f"(highlights={len(structured['highlights'])} breaking={len(structured['breaking'])} "
+        f"migrations={len(structured['migrations'])}, source={source})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hal0/release/notes.py
+++ b/src/hal0/release/notes.py
@@ -94,7 +94,5 @@ def extract_structured(section_md: str) -> dict[str, list[str]]:
     for heading, body in zip(pairs, pairs, strict=False):
         key = heading.strip().lower()
         if key in out:
-            out[key] = [
-                line[2:].strip() for line in body.splitlines() if line[:2] in ("- ", "* ")
-            ]
+            out[key] = [line[2:].strip() for line in body.splitlines() if line[:2] in ("- ", "* ")]
     return out

--- a/src/hal0/release/notes.py
+++ b/src/hal0/release/notes.py
@@ -65,3 +65,36 @@ def extract_changelog_section(changelog: str, version: str) -> str:
     body_end = n.start() if n else len(changelog)
 
     return changelog[body_start:body_end].strip()
+
+
+#: The ``### `` subsections of a changelog version section that map to the
+#: structured ``release.json`` lists the updater CLI renders as callouts.
+_STRUCTURED_KEYS = ("highlights", "breaking", "migrations")
+
+
+def extract_structured(section_md: str) -> dict[str, list[str]]:
+    """Pull the optional ``### Highlights`` / ``### Breaking`` / ``### Migrations``
+    subsections of a changelog version section into structured lists.
+
+    Only **top-level** bullet headlines (a line beginning ``- `` or ``* `` with
+    no leading indent) are collected — nested/continuation lines are skipped so
+    each entry stays a concise one-liner suitable for a CLI callout. Subsection
+    headings are matched case-insensitively; any missing subsection yields an
+    empty list. This feeds ``release.json`` (consumed by
+    ``hal0.updater.updater._read_release_notes`` → the ``hal0 update`` notes
+    render). The full markdown section stays the human-facing RELEASE_NOTES.md;
+    this is just the machine-readable digest for the breaking/migration banner.
+    """
+    out: dict[str, list[str]] = {k: [] for k in _STRUCTURED_KEYS}
+    if not section_md:
+        return out
+    # Split on "### <heading>" lines → [pre, h1, body1, h2, body2, ...].
+    parts = re.split(r"^###\s+(.+?)\s*$", section_md, flags=re.MULTILINE)
+    pairs = iter(parts[1:])
+    for heading, body in zip(pairs, pairs, strict=False):
+        key = heading.strip().lower()
+        if key in out:
+            out[key] = [
+                line[2:].strip() for line in body.splitlines() if line[:2] in ("- ", "* ")
+            ]
+    return out

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -221,9 +221,19 @@ def test_gen_release_notes_script_writes_both_files(tmp_path):
     out = tmp_path / "stage"
 
     r = subprocess.run(
-        [sys.executable, str(script), "--tag", "v0.10.0",
-         "--out-dir", str(out), "--changelog", str(changelog)],
-        capture_output=True, text=True, cwd=tmp_path,
+        [
+            sys.executable,
+            str(script),
+            "--tag",
+            "v0.10.0",
+            "--out-dir",
+            str(out),
+            "--changelog",
+            str(changelog),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
     )
     assert r.returncode == 0, r.stderr
     assert "Seed-profile cleanup" in (out / "RELEASE_NOTES.md").read_text(encoding="utf-8")

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from hal0.release.notes import extract_changelog_section
+from hal0.release.notes import extract_changelog_section, extract_structured
 
 # ── Sample CHANGELOG document used across tests ────────────────────────────
 
@@ -155,3 +155,79 @@ def test_header_line_excluded():
     """The ## [vX.Y.Z] header line itself is not in the output."""
     body = extract_changelog_section(_CHANGELOG, "v0.5.1-alpha.1")
     assert "## [v0.5.1-alpha.1]" not in body
+
+
+# ── Structured extraction (release.json callouts) ────────────────────────────
+
+_CHANGELOG_STRUCTURED = """\
+## [v0.10.0] — 2026-07-05
+
+Seed-profile cleanup + updater notes.
+
+### Highlights
+- 12 seed profiles; simpler rocm/vulkan flags
+- release notes shown before commit
+
+### Breaking
+- removed rocm-moe / rocm-dnse
+- renamed rocmfpx-moe -> vkfpx-moe
+
+### Migrations
+- slots on removed profiles auto-fall-back to rocm/vulkan
+
+### Added
+- something unrelated
+"""
+
+
+def test_extract_structured_pulls_all_three_lists():
+    section = extract_changelog_section(_CHANGELOG_STRUCTURED, "v0.10.0")
+    s = extract_structured(section)
+    assert s["highlights"] == [
+        "12 seed profiles; simpler rocm/vulkan flags",
+        "release notes shown before commit",
+    ]
+    assert s["breaking"] == ["removed rocm-moe / rocm-dnse", "renamed rocmfpx-moe -> vkfpx-moe"]
+    assert s["migrations"] == ["slots on removed profiles auto-fall-back to rocm/vulkan"]
+
+
+def test_extract_structured_missing_subsections_are_empty():
+    """A section with only Keep-a-Changelog ### Added yields empty callout lists."""
+    section = extract_changelog_section(_CHANGELOG, "v0.5.0-alpha.1")
+    assert extract_structured(section) == {"highlights": [], "breaking": [], "migrations": []}
+
+
+def test_extract_structured_empty_input():
+    assert extract_structured("") == {"highlights": [], "breaking": [], "migrations": []}
+
+
+def test_extract_structured_case_insensitive_and_skips_nested_bullets():
+    md = "### BREAKING\n- top level\n  - nested is skipped\n- another top\n"
+    assert extract_structured(md)["breaking"] == ["top level", "another top"]
+
+
+# ── gen_release_notes.py script (produces the two tarball-root files) ─────────
+
+
+def test_gen_release_notes_script_writes_both_files(tmp_path):
+    import json as _json
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    script = Path(__file__).resolve().parents[2] / "scripts" / "gen_release_notes.py"
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(_CHANGELOG_STRUCTURED, encoding="utf-8")
+    out = tmp_path / "stage"
+
+    r = subprocess.run(
+        [sys.executable, str(script), "--tag", "v0.10.0",
+         "--out-dir", str(out), "--changelog", str(changelog)],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "Seed-profile cleanup" in (out / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+    data = _json.loads((out / "release.json").read_text(encoding="utf-8"))
+    assert data["version"] == "0.10.0"
+    assert data["breaking"] == ["removed rocm-moe / rocm-dnse", "renamed rocmfpx-moe -> vkfpx-moe"]
+    assert data["migrations"] == ["slots on removed profiles auto-fall-back to rocm/vulkan"]


### PR DESCRIPTION
The **producer** side for the updater's release-notes review (companion to `feat/updater-prepare-commit`, which is the consumer). Without this, that feature reads empty notes.

**What it does:** the release build now stages `RELEASE_NOTES.md` + `release.json` **inside** the cosign-verified tarball root (`hal0-<version>/`), exactly where `updater._read_release_notes` reads them at `prepare()` time.

- `hal0.release.notes.extract_structured()` — pulls optional `### Highlights` / `### Breaking` / `### Migrations` subsections of a CHANGELOG version section into structured lists (top-level bullets only) → `release.json`, which `hal0 update` renders as callouts.
- `scripts/gen_release_notes.py` — writes `RELEASE_NOTES.md` (CHANGELOG section, or a git-log fallback for nightly / un-noted releases) + `release.json` (`{version, channel, source, highlights, breaking, migrations}`).
- `release.yml` — new **"Stage release notes"** step runs it into `${STAGE}` **before** the tarball is built (step 6 only fed the GitHub Release *page*, after the tarball). Purely additive; existing steps untouched.
- `CHANGELOG.md` — documents the convention.

Notes are optional: no CHANGELOG section → one-liner + empty lists → no callouts, still installs cleanly. `extract_structured` + the script are unit-tested (19 pass); `release.yml` validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)