### PR TITLE
fix(models): restore full model listing in slot pickers (v0.9.2 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-07-05
+
+Hotfix: restore the full model listing in every slot's model picker.
+
+### Highlights
+- Fix collapsed slot model dropdowns — `/api/models` rows again advertise the dispatcher-vocab `type` (`llm`/`embedding`/`reranking`) the pickers join on.
+
+### Fixed
+- **Slot model dropdowns (and the model→slot compatibility list) showed only the currently-assigned model.** `/api/models` stamped local- and upstream-registry rows' `type` with `classify()`'s coarse modality bucket (`chat` / `embed` / `rerank`) instead of the dispatcher vocabulary (`llm` / `embedding` / `reranking`) that the FLM path already emitted and that the UI joins on (`model.type === slot.type`), so every local model failed the picker filter and each dropdown collapsed to its default. Map the modality bucket → dispatcher type at both stamp sites; adds a local-row regression test (the FLM path was already covered, which is how this slipped through).
+
 ## [0.9.1] — 2026-07-05
 
 ROCmFPX llama.cpp runner support, plus a safer notes-aware self-update.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.9.1"
+version = "0.9.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -178,6 +178,29 @@ _FLM_DISPATCH_TYPE: dict[str, str] = {
     "image": "image",
 }
 
+# ``classify()`` returns a coarse MODALITY bucket (chat/embed/rerank/stt/tts/
+# img — the ``_TYPE_PRIORITY`` vocab), but every ``type`` we emit on an
+# /api/models row must speak the DISPATCHER vocabulary (llm/embedding/…), the
+# same one FLM rows carry above and slots use — the UI joins models↔slots on
+# ``model.type === slot.type`` (ui/lib/normalizeApiModel + slot pickers). Emit
+# the modality bucket verbatim and the picker matches nothing ("chat" ≠ "llm"),
+# collapsing every slot's model dropdown to just its current default. Map every
+# classify() output through here; ``img`` (classify) → ``image`` (dispatcher).
+_MODALITY_TO_SLOT_TYPE: dict[str, str] = {
+    "chat": "llm",
+    "embed": "embedding",
+    "rerank": "reranking",
+    "stt": "transcription",
+    "tts": "tts",
+    "img": "image",
+}
+
+
+def _dispatch_type(model_id: str = "", capabilities: Any = None) -> str:
+    """Dispatcher-vocab slot type for a row (classify → dispatcher)."""
+    modality = classify(model_id, capabilities=capabilities)
+    return _MODALITY_TO_SLOT_TYPE.get(modality, "llm")
+
 
 def _comfyui_category(path: Any) -> str | None:
     """ComfyUI models subdir for a path under ``.../comfyui/models/<subdir>/``.
@@ -216,7 +239,9 @@ async def list_models(request: Request) -> dict[str, Any]:
         dumped.setdefault("object", "model")
         dumped.setdefault("created", now)
         dumped.setdefault("owned_by", "local")
-        dumped["type"] = classify(dumped.get("id", ""), capabilities=dumped.get("capabilities"))
+        dumped["type"] = _dispatch_type(
+            dumped.get("id", ""), capabilities=dumped.get("capabilities")
+        )
         # ComfyUI discriminator + category for the dashboard's dedicated
         # image-gen surface. Path-derived so it self-heals rows an older pull
         # mis-tagged (capabilities=["chat"], backends=[]) with no migration:
@@ -293,7 +318,7 @@ async def list_models(request: Request) -> dict[str, Any]:
                     "ns": "pulled",
                     # Upstream rows carry no capabilities; classify from
                     # the id so W7 still counts embed/rerank/voice/img.
-                    "type": classify(mid),
+                    "type": _dispatch_type(mid),
                 }
             )
     # Installed FLM/NPU models — surfaced straight from the host-flm probe so

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -125,6 +125,35 @@ def test_get_model_attaches_ns(inspect_client: TestClient, tmp_hal0_home: str) -
     assert row["ns"] == "pulled"
 
 
+def test_list_models_type_is_dispatcher_vocab_for_local_rows(
+    inspect_client: TestClient,
+    tmp_hal0_home: str,
+) -> None:
+    """Local registry rows expose ``type`` in the DISPATCHER vocabulary
+    (llm/embedding/reranking), NOT ``classify()``'s modality bucket
+    (chat/embed/rerank). The UI joins slots↔models on ``model.type ===
+    slot.type`` (dispatcher vocab), so a modality value hides every model from
+    the slot pickers — the 0.9.1 regression where local rows leaked "chat"
+    (line-219 stamp) collapsed every slot's model dropdown to its current
+    default. The FLM path was already correct; only the local/upstream stamps
+    leaked modality, so this guards the local path specifically."""
+    cases = (
+        ("chatty", ["chat"], "llm"),
+        ("visionary", ["chat", "vision"], "llm"),  # multimodal → still llm
+        ("ranker", ["rerank"], "reranking"),
+        ("embedder", ["embed"], "embedding"),
+    )
+    for mid, caps, _want in cases:
+        fp = Path(tmp_hal0_home) / f"{mid}.gguf"
+        fp.write_bytes(b"\x00" * 8)
+        inspect_client.post("/api/models", json={"id": mid, "path": str(fp)})
+        inspect_client.put(f"/api/models/{mid}", json={"capabilities": caps})
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    for mid, _caps, want in cases:
+        assert rows[mid]["type"] == want, f"{mid}: {rows[mid]['type']!r} != {want!r}"
+
+
 # ── POST /api/models/inspect ───────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Hotfix — v0.9.2

### Symptom
Every slot's **model dropdown** (create/edit/swap) and the **model → compatible-slots** list collapsed to only the currently-assigned model. Reported on the box after the 0.9.1 update.

### Root cause
`GET /api/models` stamps each row's `type`. The **FLM path** correctly emits the **dispatcher vocabulary** (`llm` / `embedding` / `reranking`) — the vocab slots use and the UI joins on (`normalizeApiModel` → `model.type === slot.type`). But the **local-registry** (`models.py` L219) and **upstream** (L296) paths stamped `type` with `classify()`'s coarse **modality bucket** (`chat` / `embed` / `rerank`). So every local model's `type` was `"chat"`, which never equals a slot's `"llm"` → filtered out of every picker.

### Fix
Map the modality bucket → dispatcher type at both stamp sites via a shared `_dispatch_type()` helper (covers `img` → `image`, which `_FLM_DISPATCH_TYPE` lacked). `/api/models` now returns `llm` / `embedding` / `reranking` consistently across local, upstream, and FLM rows.

### Test gap closed
The only `type == "llm"` assertion covered the **FLM path** (already correct) — nothing covered the **local-registry** path, which is how this shipped. Adds `test_list_models_type_is_dispatcher_vocab_for_local_rows` asserting chat/vision → `llm`, rerank → `reranking`, embed → `embedding` for local rows.

### Versioning
Patch bump `0.9.1 → 0.9.2` — backward-compatible bug fix, no API or behaviour change (per the CHANGELOG's stated semver-pre-1.0 convention: patch releases inside a minor line carry no breaking changes).

### Pre-flight
- `ruff check src tests` ✓ · `ruff format --check` ✓
- `pytest tests/api/test_models_routes.py` ✓ (new regression test + existing FLM/ns tests pass)
- `gen_release_notes.py --tag v0.9.2` ✓ (1 highlight, not truncated)

Verified live on the box (hot-patched venv + restart): `/api/models` type counts went `chat:41/rerank:3/embed:2` → `llm:42/reranking:3/embedding:2`; dropdowns repopulated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)