### PR TITLE
installer: pick-free install + auto-resolve Hindsight-compatible Python

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -274,6 +274,18 @@ HAL0_VENV_REQUIRED=1 preflight_venv \
 HAL0_CONTAINER_REQUIRED=1 preflight_container_runtime \
     || die "no container runtime — install podman (see above), then re-run install.sh"
 
+# The Hindsight memory engine (installed much later) builds its own venv and
+# pulls litellm, which gates out Python 3.14 via requires-python metadata.
+# Resolve the interpreter for that venv NOW — auto-installing a compatible
+# 3.11-3.13 when the default python is 3.14+ and the package manager can supply
+# one — so the memory-engine step builds cleanly instead of dumping a wall of
+# pip resolver errors mid-install. Sets HINDSIGHT_PY / HINDSIGHT_PY_FALLBACK,
+# consumed in the Hindsight block below. Never fatal (the metadata-gate bypass
+# is the backstop). Skipped in dev mode and when HAL0_SKIP_HINDSIGHT=1.
+if [[ "${DEV_MODE}" -eq 0 && "${HAL0_SKIP_HINDSIGHT:-0}" -ne 1 ]]; then
+    HAL0_HINDSIGHT_AUTOINSTALL=1 resolve_hindsight_python
+fi
+
 # Disk + port-collision checks only matter for the live install — dev
 # mode lays files under $PWD/.hal0ai and never binds 8080/3001. We
 # aggregate both check results (so the operator sees *both* failures
@@ -1367,21 +1379,40 @@ else
         info "setting up Hindsight memory engine (venv + daemon) — this can take a few minutes…"
         mkdir -p "${HS_DIR}/hf-cache" "${HS_DIR}/.cache"
         if [[ ! -x "${HS_DIR}/.venv/bin/hindsight-api" ]]; then
-            "${PY}" -m venv "${HS_DIR}/.venv"
+            # Interpreter + gate decision were made up front by
+            # resolve_hindsight_python (preflight). HINDSIGHT_PY is a 3.11-3.13
+            # when one was found/installed; otherwise the default ${PY} with
+            # HINDSIGHT_PY_FALLBACK=1 (litellm's requires-python gate must be
+            # bypassed). Default to ${PY} if the resolver didn't run.
+            hs_py="${HINDSIGHT_PY:-${PY}}"
+            hs_fallback="${HINDSIGHT_PY_FALLBACK:-0}"
+            "${hs_py}" -m venv "${HS_DIR}/.venv"
             hs_pip="${HS_DIR}/.venv/bin/pip"
             "${hs_pip}" install --upgrade pip wheel -q 2>/dev/null || true
-            if ! "${hs_pip}" install "hindsight-api==0.7.2" -q; then
-                # Newer distros (Ubuntu 25.10+/26.04) ship Python 3.14, which
-                # litellm>=1.83.14 (a hindsight-api dep) gates out via its
-                # requires-python metadata — even though the pinned stack runs
-                # fine on 3.14 (litellm dropped the 3.14 classifier over a
-                # since-resolved fastuuid wheel gap; BerriAI/litellm#26343).
-                # Retry past the metadata gate; the hindsight-api /health poll
-                # below is the real gate on whether the engine actually came up.
-                hs_pyver="$("${HS_DIR}/.venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo '?')"
-                warn "hindsight-api hit a requires-python gate on Python ${hs_pyver}; retrying with --ignore-requires-python"
-                if ! "${hs_pip}" install --ignore-requires-python "hindsight-api==0.7.2" -q; then
+
+            # On a Python litellm rejects by metadata (3.14+ with no compatible
+            # interpreter available) skip the doomed first attempt — it spews a
+            # wall of "Could not find a version" resolver output — and bypass the
+            # gate directly. litellm runs fine on 3.14 (classifier dropped over a
+            # since-resolved fastuuid wheel gap; BerriAI/litellm#26343); the
+            # /health poll below is the real gate on whether the engine came up.
+            hs_installed=0
+            if [[ "${hs_fallback}" -ne 1 ]]; then
+                if "${hs_pip}" install "hindsight-api==0.7.2" -q; then
+                    hs_installed=1
+                else
+                    hs_pyver="$("${HS_DIR}/.venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo '?')"
+                    warn "hindsight-api install failed on Python ${hs_pyver}; retrying past the requires-python gate"
+                fi
+            fi
+            if [[ "${hs_installed}" -ne 1 ]]; then
+                [[ "${hs_fallback}" -eq 1 ]] && \
+                    info "installing hindsight-api with --ignore-requires-python (no Python 3.11-3.13 available; litellm's 3.14 gate is metadata-only)"
+                if "${hs_pip}" install --ignore-requires-python "hindsight-api==0.7.2" -q; then
+                    hs_installed=1
+                else
                     warn "hindsight-api install failed — memory engine will be unavailable"
+                    warn "  install a Python 3.11-3.13 and re-run, or set HAL0_HINDSIGHT_PYTHON=python3.12"
                 fi
             fi
         else

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -835,18 +835,20 @@ ui_step "Hardware probe"
 if [[ "${HAL0_SKIP_SETUP:-0}" == "1" || "${HAL0_NO_PROBE:-0}" == "1" ]]; then
     info "Skipping first-run setup (HAL0_SKIP_SETUP/HAL0_NO_PROBE set)."
 else
-    info "Running first-run setup (recommended defaults; models download later)"
-    # --auto: non-interactive, hardware-recommended Main slot. --no-pull seeds
-    # the slot config + first-run sentinel WITHOUT downloading models (the
-    # curl|bash installer must stay fast). --no-extensions: OpenWebUI + Hermes
-    # are installed by the dedicated stages below, not here. Interactive
-    # `hal0 setup` (post-install) handles model downloads + extension choices.
+    info "Running first-run setup (sentinel + wiring; no model picks, no downloads)"
+    # --auto: non-interactive first-run seeding. --no-slots seeds the first-run
+    # sentinel + wiring but ZERO model-slot picks — the installer no longer ships
+    # a hardware-recommended chat/coder/ComfyUI selection; the operator chooses
+    # every model later via the dashboard or `hal0 setup`. --no-pull keeps the
+    # path download-free regardless (belt-and-suspenders; with no slots there is
+    # nothing to pull anyway). --no-extensions: OpenWebUI + Hermes are installed
+    # by the dedicated stages below, not here.
     # Build argv as an array so --storage-dir and its value stay TWO separate
     # tokens. The old `${MODELS_DIR:+--storage-dir "${MODELS_DIR}"}` collapsed
     # into a single arg ("--storage-dir /mnt/ai-models") that typer rejected
     # with "No such option", silently skipping --auto seeding on --models-dir
     # installs.
-    _setup_args=(--auto --no-pull --no-extensions)
+    _setup_args=(--auto --no-pull --no-slots --no-extensions)
     [[ -n "${MODELS_DIR}" ]] && _setup_args+=(--storage-dir "${MODELS_DIR}")
     "${HAL0_BIN}" setup "${_setup_args[@]}" \
         || warn "first-run setup failed; run 'hal0 setup' after install"

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -93,6 +93,130 @@ preflight_python() {
     return 1
 }
 
+# ── Hindsight interpreter selection ─────────────────────────────────────────
+# The Hindsight memory engine runs in its OWN venv (${VAR_DIR}/memory/hindsight)
+# and pulls litellm, which publishes `requires-python >=3.10,<3.14`. The main
+# hal0 venv is happy on 3.14, but litellm's *metadata* gate makes
+# `pip install hindsight-api` fail with a wall of "Could not find a version"
+# resolver noise on a 3.14 host before the install can fall back. We resolve a
+# compatible interpreter (3.11-3.13) up front — auto-installing one when asked —
+# so the Hindsight venv builds clean; only when none exists do we fall back to
+# the default interpreter + --ignore-requires-python (litellm actually runs fine
+# on 3.14 — the classifier was dropped over a since-resolved fastuuid wheel gap,
+# BerriAI/litellm#26343).
+#
+# Range kept as constants so bumping the supported band is a one-line change.
+HINDSIGHT_PY_MIN_MINOR=11
+HINDSIGHT_PY_MAX_MINOR=13
+
+# Echo the 3.x minor (e.g. "14") of an interpreter; nothing + non-zero on error.
+_py_minor() { "${1}" -c 'import sys; print(sys.version_info[1])' 2>/dev/null; }
+
+# Is $1 an interpreter whose (3.x) minor is inside the Hindsight-supported band?
+_py_hindsight_ok() {
+    local m; m="$(_py_minor "${1}")" || return 1
+    [[ -n "${m}" ]] || return 1
+    (( m >= HINDSIGHT_PY_MIN_MINOR && m <= HINDSIGHT_PY_MAX_MINOR ))
+}
+
+# Best-effort: install a Hindsight-compatible Python (3.13→3.11) via the
+# detected package manager and set HINDSIGHT_PY to it. Returns 0 on success,
+# 1 otherwise (nothing installed / not resolvable). Only fires when
+# HAL0_HINDSIGHT_AUTOINSTALL=1 (install.sh sets it) so `hal0 doctor` and
+# read-only preflight never mutate the system. Never fatal — the caller falls
+# back to --ignore-requires-python.
+_hindsight_py_autoinstall() {
+    [[ "${HAL0_HINDSIGHT_AUTOINSTALL:-0}" == "1" ]] || return 1
+    pkg_mgr >/dev/null 2>&1 || return 1
+    local fam v cand; fam="$(distro_family)"
+    info "no Python 3.${HINDSIGHT_PY_MIN_MINOR}-3.${HINDSIGHT_PY_MAX_MINOR} found for the Hindsight venv — attempting to install one (${fam})"
+    for v in 13 12 11; do
+        cand="python3.${v}"
+        case "${fam}" in
+            debian)
+                DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
+                DEBIAN_FRONTEND=noninteractive apt-get install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || continue ;;
+            fedora) "$(pkg_mgr)" install -y "${cand}" >/dev/null 2>&1 || continue ;;
+            # Arch/openSUSE/Alpine ship a single rolling python; a pinned older
+            # minor isn't reliably in the base repos. Skip — the metadata-gate
+            # bypass covers these.
+            *) return 1 ;;
+        esac
+        if command -v "${cand}" >/dev/null 2>&1 && _py_hindsight_ok "${cand}"; then
+            info "installed ${cand} for the Hindsight memory engine"
+            HINDSIGHT_PY="${cand}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Resolve the interpreter the Hindsight venv should be built with into the
+# globals HINDSIGHT_PY and HINDSIGHT_PY_FALLBACK (1 = the chosen interpreter is
+# OUTSIDE litellm's supported band, so the caller must pass
+# --ignore-requires-python). Selection order:
+#   1. HAL0_HINDSIGHT_PYTHON override (honoured verbatim)
+#   2. the default ${PY} when it's already in-band (the common clean case)
+#   3. python3.13 → python3.11 already on PATH
+#   4. auto-install one (only when HAL0_HINDSIGHT_AUTOINSTALL=1)
+#   5. give up → default ${PY} with the metadata gate bypassed
+# Read-only unless step 4 fires; always returns 0 (it never blocks the install).
+resolve_hindsight_python() {
+    local def="${HAL0_PY:-${HAL0_PYTHON:-python3}}"
+    HINDSIGHT_PY=""
+    HINDSIGHT_PY_FALLBACK=0
+
+    if [[ -n "${HAL0_HINDSIGHT_PYTHON:-}" ]]; then
+        HINDSIGHT_PY="${HAL0_HINDSIGHT_PYTHON}"
+        if _py_hindsight_ok "${HINDSIGHT_PY}"; then
+            info "hindsight python: ${HINDSIGHT_PY} (HAL0_HINDSIGHT_PYTHON)"
+        else
+            HINDSIGHT_PY_FALLBACK=1
+            warn "hindsight python: ${HINDSIGHT_PY} is outside 3.${HINDSIGHT_PY_MIN_MINOR}-3.${HINDSIGHT_PY_MAX_MINOR}; will bypass litellm's requires-python gate"
+        fi
+        return 0
+    fi
+
+    if _py_hindsight_ok "${def}"; then
+        HINDSIGHT_PY="${def}"
+        info "hindsight python: ${def} ($("${def}" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null))"
+        return 0
+    fi
+
+    local v cand
+    for v in 13 12 11; do
+        cand="python3.${v}"
+        if command -v "${cand}" >/dev/null 2>&1 && _py_hindsight_ok "${cand}"; then
+            HINDSIGHT_PY="${cand}"
+            info "hindsight python: ${cand} (default ${def} is out of litellm's 3.10-3.13 range)"
+            return 0
+        fi
+    done
+
+    if _hindsight_py_autoinstall; then
+        return 0
+    fi
+
+    HINDSIGHT_PY="${def}"
+    HINDSIGHT_PY_FALLBACK=1
+    warn "hindsight python: no Python 3.${HINDSIGHT_PY_MIN_MINOR}-3.${HINDSIGHT_PY_MAX_MINOR} available — will build the memory-engine venv on ${def} and bypass litellm's requires-python gate"
+    warn "  for a clean install: $(pkg_install_cmd python3.12 python3.12-venv 2>/dev/null || echo 'install python3.12') and re-run, or set HAL0_HINDSIGHT_PYTHON=python3.12"
+    return 0
+}
+
+# Read-only wrapper for preflight_all / `hal0 doctor`: report the Hindsight
+# interpreter decision without mutating the system (auto-install suppressed).
+# Always returns 0 — the metadata-gate bypass means a 3.14 host is not a
+# failure, just a heads-up.
+preflight_hindsight_python() {
+    if [[ "${HAL0_SKIP_HINDSIGHT:-0}" == "1" ]]; then
+        info "hindsight memory engine: skipped (HAL0_SKIP_HINDSIGHT=1)"
+        return 0
+    fi
+    HAL0_HINDSIGHT_AUTOINSTALL=0 resolve_hindsight_python
+    return 0
+}
+
 # CPU architecture — hal0 ships x86_64-only binaries (FastFlowLM .deb,
 # toolbox container images). On ARM the install gets deep into apt
 # before failing cryptically, so refuse up front.
@@ -418,6 +542,7 @@ preflight_all() {
     preflight_systemd || rc=$?
     preflight_python  || rc=$?
     preflight_venv    || rc=$?
+    preflight_hindsight_python || rc=$?
     preflight_writable || rc=$?
     preflight_network || rc=$?
     preflight_container_runtime || rc=$?

--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -55,6 +55,7 @@ def build_auto_selections(
     *,
     storage_dir: str,
     with_extensions: bool = True,
+    with_slots: bool = True,
     existing_slots: frozenset[str] = frozenset(),
 ) -> Selections:
     """Non-interactive defaults for ``--auto`` (install.sh path): recommended
@@ -64,6 +65,13 @@ def build_auto_selections(
     present, all values ``False``).  The coder/agent slot is gated on an agent
     extension being enabled, so it is skipped when extensions are off.  The
     chat slot is always included.
+
+    When *with_slots* is ``False`` NO model picks are seeded at all — the
+    returned selection has an empty slot list and no ComfyUI capability
+    defaults.  This is the installer's mode (Task: don't ship model picks): a
+    fresh box gets the first-run sentinel + extension wiring but zero model
+    selections, so the operator chooses everything later via the dashboard or
+    ``hal0 setup``.  Extensions still honour *with_extensions*.
 
     *existing_slots* is the set of slot names whose config files already exist
     on disk.  Any slot in this set is skipped so that ``--auto`` on an existing
@@ -76,28 +84,32 @@ def build_auto_selections(
     else:
         ext = {e.id: False for e in EXTENSIONS}
     slots: list[SlotSelection] = []
-    # Main (chat) is always provisioned in --auto (OWUI + Hermes default on)
-    # — unless it was already configured by a prior install.
-    if "chat" not in existing_slots:
-        chat = suggest_models("chat", hw, limit=1)
-        if chat:
-            name, port = _SETUP_SLOTS["chat"]
-            slots.append(SlotSelection("chat", name, port, chat[0].model_id))
-    # Agent slot only if an agent extension is enabled and not already present.
-    if (
-        any(_kind(eid) == "agent" and on for eid, on in ext.items())
-        and "coder" not in existing_slots
-    ):
-        coder = suggest_models("coder", hw, limit=1, prefer_coder=True)
-        if coder:
-            name, port = _SETUP_SLOTS["coder"]
-            slots.append(SlotSelection("coder", name, port, coder[0].model_id))
-    # Record ComfyUI default capability picks as (capability_id, family) pairs.
-    # No model pull at install — operator triggers downloads later via
-    # POST /api/comfyui/models/fetch.
-    from hal0.comfyui.capabilities import CAPABILITIES as _CAPS
+    comfyui_defaults: tuple[tuple[str, str], ...] = ()
+    if with_slots:
+        # Main (chat) is always provisioned in --auto (OWUI + Hermes default on)
+        # — unless it was already configured by a prior install.
+        if "chat" not in existing_slots:
+            chat = suggest_models("chat", hw, limit=1)
+            if chat:
+                name, port = _SETUP_SLOTS["chat"]
+                slots.append(SlotSelection("chat", name, port, chat[0].model_id))
+        # Agent slot only if an agent extension is enabled and not already present.
+        if (
+            any(_kind(eid) == "agent" and on for eid, on in ext.items())
+            and "coder" not in existing_slots
+        ):
+            coder = suggest_models("coder", hw, limit=1, prefer_coder=True)
+            if coder:
+                name, port = _SETUP_SLOTS["coder"]
+                slots.append(SlotSelection("coder", name, port, coder[0].model_id))
+        # Record ComfyUI default capability picks as (capability_id, family) pairs.
+        # No model pull at install — operator triggers downloads later via
+        # POST /api/comfyui/models/fetch.
+        from hal0.comfyui.capabilities import CAPABILITIES as _CAPS
 
-    comfyui_defaults = tuple((cap_id, cap.alternatives[0].family) for cap_id, cap in _CAPS.items())
+        comfyui_defaults = tuple(
+            (cap_id, cap.alternatives[0].family) for cap_id, cap in _CAPS.items()
+        )
     return Selections(
         storage_dir=storage_dir,
         slots=slots,
@@ -124,6 +136,11 @@ def setup(
         "--no-extensions",
         help="Skip extension install/wiring in --auto mode.",
     ),
+    no_slots: bool = typer.Option(
+        False,
+        "--no-slots",
+        help="Seed the sentinel + extensions but NO model-slot picks (installer default; operator chooses models later).",
+    ),
 ) -> None:
     hw = HardwareProbe().probe()
     if auto:
@@ -131,6 +148,7 @@ def setup(
             hw,
             storage_dir=storage_dir,
             with_extensions=not no_extensions,
+            with_slots=not no_slots,
             existing_slots=_existing_slot_names(),
         )
         asyncio.run(_run_auto(sel, hw, no_pull=no_pull))


### PR DESCRIPTION
Two related installer-robustness changes, split into one commit each.

## 1. Auto-resolve a Hindsight-compatible Python (`60444fa`)

The Hindsight memory engine builds its own venv and pulls `litellm`, which publishes `requires-python >=3.10,<3.14`. On a Python **3.14** host (Ubuntu 25.10+/26.04) the main hal0 venv is fine, but litellm's *metadata* gate made `pip install hindsight-api` fail with a wall of "Could not find a version" resolver output before the install could fall back.

Now resolved **up front in preflight** (`resolve_hindsight_python`):
- prefer the default python when already in litellm's 3.11–3.13 band
- else pick `python3.13→3.11` from PATH
- else best-effort auto-install one via the distro package manager (apt/dnf)
- else fall back to the default interpreter and go **straight** to `--ignore-requires-python` (litellm runs fine on 3.14 — classifier dropped over a since-resolved fastuuid wheel gap, BerriAI/litellm#26343), skipping the doomed first attempt and its noise

Adds `HAL0_HINDSIGHT_PYTHON` override and a read-only `preflight_hindsight_python` wired into `preflight_all` so `hal0 doctor` reports the decision.

## 2. Stop shipping model picks (`fc50839`)

The installer already never downloaded weights (`--no-pull`); it only recorded a hardware-recommended model **name** per slot (chat always, coder if an agent extension is on, plus ComfyUI capability defaults) into the slot configs. We no longer ship those picks — a fresh box boots with services up and the operator chooses every model afterward.

- `build_auto_selections` gains `with_slots` (default `True`); `False` → zero slot picks, zero ComfyUI defaults, extensions untouched
- new `hal0 setup --no-slots` flag threads it through; interactive/manual `hal0 setup` still picks recommended models
- installer first-run setup now runs `--auto --no-pull --no-slots --no-extensions`

**Fresh-boot consequence:** OpenWebUI/Hermes come up with no model configured until the operator runs `hal0 setup` / `hal0 model pull`. Docs follow-up: Hal0ai/hal0#1082, #1083, #1084.

## Testing
- `bash -n` clean on `install.sh` + `preflight.sh`
- `resolve_hindsight_python` exercised across clean / PATH-scan / forced-fallback / override / skip cases
- `tests/cli/test_setup_command.py` → 6/6 pass; `with_slots=False` verified to seed 0 slots / 0 comfyui picks with extensions still on
- `--no-slots` confirmed registered on the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)