### PR TITLE
feat(setup): persist authoritative hardware.json at install (incl. NPU functional result)

### DIFF
--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -15,7 +15,7 @@ import typer
 from hal0.cli._shared import _api_base
 from hal0.config import paths
 from hal0.config.schema import HardwareInfo
-from hal0.hardware.probe import HardwareProbe
+from hal0.hardware.probe import HardwareProbe, HardwareProbeError
 from hal0.install.extensions import EXTENSIONS, get_extension
 from hal0.install.orchestrate import Selections, SlotSelection
 
@@ -179,7 +179,18 @@ def setup(
         help="Resolve + print the plan; write nothing (no slots, sentinel, pulls, or extensions).",
     ),
 ) -> None:
-    hw = HardwareProbe().probe()
+    # Persist an authoritative hardware.json at install/setup time so slots
+    # and the FLM container spec read REAL device facts (not the Strix-Halo
+    # constant fallbacks). validate_npu=True records the functional
+    # `flm validate` result (npu.validated) before any slot launches.
+    probe = HardwareProbe()
+    hw = probe.probe(validate_npu=True)
+    try:
+        probe.write(hw)
+    except HardwareProbeError as exc:
+        # Non-fatal: a non-root `hal0 setup` can't write /etc/hal0. The probe
+        # result still drives this run; the daemon persists it later.
+        typer.echo(f"warning: could not persist hardware.json ({exc})", err=True)
     if plan:
         from hal0.cli.setup_plan import run_plan
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1701,6 +1701,17 @@ class NPUInfo(BaseModel):
             "0 = unknown; consumers fall back to the Strix Halo constant 8."
         ),
     )
+    validated: bool | None = Field(
+        default=None,
+        description=(
+            "Functional NPU validation result from `flm validate`, run at "
+            "install/setup time (not by the fast presence probe). None = not "
+            "yet validated (presence is node-detection only); True = the NPU "
+            "runtime is reachable; False = flm validate ran but failed (NPU "
+            "absent or libxrt-npu2 mismatched). Distinct from `present`, which "
+            "only reflects device-node detection."
+        ),
+    )
 
 
 class HardwareInfo(BaseModel):

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -878,7 +878,7 @@ class HardwareProbe:
     runs in a threadpool when called from an async context.
     """
 
-    def probe(self) -> HardwareInfo:
+    def probe(self, *, validate_npu: bool = False) -> HardwareInfo:
         """Run hardware detection and return a HardwareInfo snapshot.
 
         Detects: GPU (NVIDIA / AMD / Vulkan / lspci fallbacks), NPU
@@ -888,6 +888,12 @@ class HardwareProbe:
         Never raises for individual probe failures — each detector returns
         an empty result and logs a warning. Only catastrophic failures
         (e.g. /proc not mounted) raise HardwareProbeError.
+
+        ``validate_npu`` (install/setup only): when True and an NPU node was
+        detected, additionally run ``flm validate`` (which touches the XDNA
+        runtime and can take seconds) and record the functional result in
+        ``npu.validated``. The default keeps the presence probe fast + pure —
+        node detection only — for the many callers that run it hot.
         """
         try:
             cpu_model, cpu_cores, cpu_threads = _parse_cpuinfo()
@@ -897,6 +903,12 @@ class HardwareProbe:
             # detection, unified-memory derivation, card rendering).
             gpu = gpus[0] if gpus else GPUInfo(vendor="unknown")
             npu = _detect_npu()
+            if validate_npu and npu.present:
+                # Functional check — the ONLY place the probe touches the NPU
+                # runtime. Lazy import avoids a hardware→providers cycle.
+                from hal0.providers.flm import flm_validate
+
+                npu = npu.model_copy(update={"validated": flm_validate()})
             disk_mb = _disk_free_mb(_paths.var_lib())
 
             uname = ""

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -642,6 +642,38 @@ def _probe_flm_catalog() -> list[dict[str, Any]] | None:
     return models
 
 
+def flm_validate() -> bool | None:
+    """Run host ``flm validate`` — the upstream NPU-runtime health check.
+
+    Unlike :func:`_probe_flm_catalog` (``flm list``, which never touches the
+    NPU), ``flm validate`` exercises the actual XDNA runtime. Returns:
+
+    * ``True``  — validation passed (NPU runtime reachable); rc 0.
+    * ``False`` — the binary ran but validation failed (NPU hardware absent
+      or ``libxrt-npu2`` mismatched); non-zero rc.
+    * ``None``  — could not run at all (flm not installed / OS error /
+      timeout), so functional state is unknown.
+
+    This mirrors the installer's ``flm validate`` smoke test but records the
+    result into ``hardware.json`` (``npu.validated``) so slots and the FLM
+    container spec have an authoritative functional signal, not just node
+    presence. Runs as the hal0 identity via :func:`flm_host_spawn_kwargs`.
+    """
+    import subprocess
+
+    try:
+        proc = subprocess.run(
+            [_HOST_FLM_BIN, "validate"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=60.0,
+            **flm_host_spawn_kwargs(),
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    return proc.returncode == 0
+
+
 def flm_served_models() -> list[dict[str, Any]]:
     """Return what the FLM toolbox can serve, classified into hal0 capabilities.
 

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -859,3 +859,79 @@ def test_probe_cgroup_max_mb_none_when_unlimited(
 
     info = HardwareProbe().probe()
     assert info.cgroup_max_mb is None
+
+
+# ── NPU functional validation (validate_npu, issue #1097) ──────────────────────
+
+
+def _stub_probe_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the heavy detectors so probe() is hermetic; NPU is left to the test."""
+    monkeypatch.setattr(probe_mod, "_parse_cpuinfo", lambda: ("Test CPU", 4, 8))
+    monkeypatch.setattr(probe_mod, "_parse_meminfo", lambda: (16384, 8192))
+    monkeypatch.setattr(probe_mod, "_detect_gpus", lambda: [])
+    monkeypatch.setattr(probe_mod, "_gpu_group_gids", lambda: {})
+    monkeypatch.setattr(probe_mod, "_disk_free_mb", lambda _: 1024)
+    monkeypatch.setattr(probe_mod, "_read_text", lambda _: None)
+    monkeypatch.setattr(probe_mod, "_detect_platform", lambda *_: "bare-metal")
+    monkeypatch.setattr(probe_mod, "_read_cgroup_memory_max_mb", lambda: None)
+
+
+def test_probe_validate_npu_records_functional_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """probe(validate_npu=True) runs flm validate and records npu.validated."""
+    import hal0.providers.flm as flm_mod
+
+    _stub_probe_env(monkeypatch)
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=True))
+    monkeypatch.setattr(flm_mod, "flm_validate", lambda: True)
+
+    info = probe_mod.HardwareProbe().probe(validate_npu=True)
+    assert info.npu.present is True
+    assert info.npu.validated is True
+
+
+def test_probe_validate_npu_records_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing flm validate is recorded as validated=False (distinct from None)."""
+    import hal0.providers.flm as flm_mod
+
+    _stub_probe_env(monkeypatch)
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=True))
+    monkeypatch.setattr(flm_mod, "flm_validate", lambda: False)
+
+    info = probe_mod.HardwareProbe().probe(validate_npu=True)
+    assert info.npu.validated is False
+
+
+def test_probe_default_does_not_validate_npu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default (fast) probe never touches the NPU runtime; validated stays None."""
+    import hal0.providers.flm as flm_mod
+
+    _stub_probe_env(monkeypatch)
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=True))
+
+    def _boom() -> bool:
+        raise AssertionError("flm_validate must not run in the default probe")
+
+    monkeypatch.setattr(flm_mod, "flm_validate", _boom)
+
+    info = probe_mod.HardwareProbe().probe()
+    assert info.npu.present is True
+    assert info.npu.validated is None
+
+
+def test_probe_validate_npu_skipped_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """validate_npu=True with no NPU node present must not run flm validate."""
+    import hal0.providers.flm as flm_mod
+
+    _stub_probe_env(monkeypatch)
+    monkeypatch.setattr(probe_mod, "_detect_npu", lambda: probe_mod.NPUInfo(present=False))
+
+    def _boom() -> bool:
+        raise AssertionError("flm_validate must not run when NPU is absent")
+
+    monkeypatch.setattr(flm_mod, "flm_validate", _boom)
+
+    info = probe_mod.HardwareProbe().probe(validate_npu=True)
+    assert info.npu.present is False
+    assert info.npu.validated is None

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -414,6 +414,41 @@ def test_probe_returns_none_when_binary_missing() -> None:
         assert flm._probe_flm_catalog() is None
 
 
+def test_flm_validate_true_on_rc0() -> None:
+    """flm_validate() returns True when host `flm validate` exits 0."""
+    import hal0.providers.flm as flm
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run(argv: list[str], **kwargs: Any) -> Any:
+        captured["argv"] = argv
+        return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    with patch("subprocess.run", _fake_run):
+        assert flm.flm_validate() is True
+    assert captured["argv"] == [flm._HOST_FLM_BIN, "validate"]
+    assert "docker" not in captured["argv"]
+
+
+def test_flm_validate_false_on_nonzero_rc() -> None:
+    """A non-zero exit means the binary ran but validation failed (NPU absent)."""
+    import hal0.providers.flm as flm
+
+    with patch("subprocess.run", lambda *a, **k: MagicMock(returncode=1)):
+        assert flm.flm_validate() is False
+
+
+def test_flm_validate_none_when_binary_missing() -> None:
+    """Unknown functional state (flm not installed) is None, distinct from False."""
+    import hal0.providers.flm as flm
+
+    def _boom(*a: Any, **k: Any) -> Any:
+        raise FileNotFoundError
+
+    with patch("subprocess.run", _boom):
+        assert flm.flm_validate() is None
+
+
 def test_pull_command_is_host_flm_and_real_cache_dir() -> None:
     import hal0.providers.flm as flm
 


### PR DESCRIPTION
Closes #1097. First implementation slice of the guided **Hal0 Installer Setup** redesign (Wave 1 / WS-B) — the foundation that #1104 / #1107 / #1108 / #1109 build on.

## Problem
`hal0 setup` probes hardware but never calls `probe.write()`, so:
- FLM silently falls back to hardcoded Strix-Halo device constants.
- `npu.present` reflects only device-node detection — there's no functional signal that the NPU runtime actually works before slots launch.

## What changed
- **schema** — add `NPUInfo.validated` (`bool | None`): `None` = not yet validated (presence is node-detection only), `True` = `flm validate` passed, `False` = ran but failed (NPU absent / libxrt-npu2 mismatch). Distinct from `present`.
- **flm** — add `flm_validate()`: runs host `flm validate` as the hal0 identity (mirrors `_probe_flm_catalog`'s subprocess model), returning `True`/`False`/`None`.
- **probe** — add opt-in `probe(validate_npu=True)`: when an NPU node is present, runs `flm validate` and records the result in `npu.validated`. The default stays fast + pure (node detection only) for the many hot callers — the probe still never touches the NPU runtime unless asked.
- **setup** — probe with `validate_npu=True` and persist `hardware.json` **before** slots are created. A non-root `hal0 setup` that can't write `/etc/hal0` warns instead of aborting (the daemon persists it later).

## Acceptance criteria (from #1097)
- [x] Install writes `hardware.json` before slots are created
- [x] `hardware.json` includes GPU device visibility + NPU functional (`flm validate`) result
- [x] `npu.validated` reflects a functional probe, distinct from `npu.present`
- [x] FLM no longer silently uses Strix-Halo constants when real facts are available

## Tests
7 new: `flm_validate` rc0/nonzero/missing → True/False/None; `probe(validate_npu=True)` records success/failure and skips when the NPU is absent; the default probe never runs `flm validate`. Full touched-area suite green (96 passed); ruff clean.

Note: one pre-existing failure on `main` (`test_container_spec_dispatch.py::test_tts_kokoro_slot_renders_spec_unit`) is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)