### PR TITLE
installer-setup: answer-file core loader (hal0 setup --answers)

### DIFF
--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -162,8 +162,19 @@ def setup(
         "--no-slots",
         help="Seed the sentinel + extensions but NO model-slot picks (installer default; operator chooses models later).",
     ),
+    answers: str | None = typer.Option(
+        None,
+        "--answers",
+        help="Path to a hal0-setup.yaml answer file for a fully non-interactive run.",
+    ),
 ) -> None:
     hw = HardwareProbe().probe()
+    if answers is not None:
+        from hal0.install.answers import load_answers
+
+        sel = load_answers(answers, hw)
+        asyncio.run(_run_auto(sel, hw, no_pull=no_pull))
+        return
     if auto:
         sel = build_auto_selections(
             hw,

--- a/src/hal0/install/answers.py
+++ b/src/hal0/install/answers.py
@@ -1,0 +1,322 @@
+"""Headless answer-file loader for ``hal0 setup --answers`` (issue #1115).
+
+Spec: ``handoffs/hal0-setup-answers-spec-2026-07-05.md``. This module
+implements ONLY the subset of the schema that maps to
+:class:`hal0.install.orchestrate.Selections` today (§5 "wired now" column):
+``model_store.path``, ``slots[]``, ``apps.*.enabled`` + ``gen.mode``
+(→ ``extensions``), ``npu.opt_in``, and ``gen.capabilities``
+(→ ``comfyui_defaults``). Every other top-level key (``network``,
+``huggingface``, ``apps.*.when``, ``apps.hermes.gateway``, the download side
+of ``gen.mode: scaffold_and_download``, ``slots[].context_size``,
+``slots[].enabled_on_pull``) is accepted and warned about, not applied — their
+workstreams wire them in later per the field→destination map (§5).
+
+``auto`` values resolve through the SAME resolvers ``build_auto_selections``
+uses (``suggest_models``, ``derive_device``/``derive_profile`` via
+``apply_setup``), so an all-``auto`` file is equivalent to today's
+``--auto`` path (spec §3).
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import yaml
+
+from hal0.config.schema import HardwareInfo
+from hal0.install.extensions import EXTENSIONS
+from hal0.install.orchestrate import Selections, SlotSelection
+from hal0.install.suggest import suggest_models
+
+#: Top-level keys this loader recognizes at all (wired or not-yet-wired).
+#: Anything outside this set is "unknown" (§4: reject unless strict: false).
+_KNOWN_TOP_LEVEL = frozenset(
+    {
+        "version",
+        "strict",
+        "network",
+        "model_store",
+        "huggingface",
+        "slots",
+        "npu",
+        "gen",
+        "apps",
+    }
+)
+
+#: capabilities valid for a slot entry (spec §3/§8: "chat" | "coder").
+_VALID_SLOT_CAPABILITIES = frozenset({"chat", "coder"})
+
+#: gen.mode values that enable the comfyui extension.
+_GEN_MODES_ON = frozenset({"scaffold_only", "scaffold_and_download"})
+_GEN_MODES = _GEN_MODES_ON | {"off"}
+
+
+class AnswersError(ValueError):
+    """Raised when the answer file fails validation."""
+
+
+def _warn(msg: str) -> None:
+    warnings.warn(msg, stacklevel=3)
+
+
+def _yaml_word(value: Any) -> Any:
+    """Undo PyYAML's YAML-1.1 bareword-bool coercion for our own enum words.
+
+    The schema uses bare ``off``/``on`` as enum values (``gen.mode: off``,
+    ``gen.capabilities.<cap>: off``), but ``yaml.safe_load`` parses unquoted
+    ``off``/``no``/``false`` as Python ``False`` and ``on``/``yes``/``true`` as
+    ``True`` (YAML 1.1 bool resolver). Map those back to the words the spec
+    documents so downstream comparisons see ``"off"``/``"on"`` as intended.
+    """
+    if value is False:
+        return "off"
+    if value is True:
+        return "on"
+    return value
+
+
+def _load_yaml(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise AnswersError(f"answer file must be a mapping at the top level, got {type(data)!r}")
+    return data
+
+
+def _check_version(doc: dict[str, Any]) -> None:
+    version = doc.get("version")
+    if version != 1:
+        raise AnswersError(
+            f"answer file must declare 'version: 1' (got {version!r}); "
+            "this loader only understands schema version 1"
+        )
+
+
+def _check_top_level_keys(doc: dict[str, Any]) -> None:
+    strict = bool(doc.get("strict", False))
+    unknown = set(doc.keys()) - _KNOWN_TOP_LEVEL
+    if not unknown:
+        return
+    if strict:
+        raise AnswersError(f"unknown top-level key(s) in answer file: {sorted(unknown)}")
+    for key in sorted(unknown):
+        _warn(f"answer file key '{key}' is not recognized and was ignored (not yet applied)")
+
+
+def _resolve_storage_dir(doc: dict[str, Any]) -> str:
+    model_store = doc.get("model_store") or {}
+    if not isinstance(model_store, dict):
+        raise AnswersError("model_store must be a mapping")
+    path = model_store.get("path")
+    if not path or not isinstance(path, str):
+        raise AnswersError("model_store.path is required and must be a non-empty string")
+    if not path.startswith("/"):
+        raise AnswersError(f"model_store.path must be absolute, got {path!r}")
+    return path
+
+
+def _resolve_slots(doc: dict[str, Any], hw: HardwareInfo) -> list[SlotSelection]:
+    raw_slots = doc.get("slots") or []
+    if not isinstance(raw_slots, list):
+        raise AnswersError("slots must be a list")
+
+    slots: list[SlotSelection] = []
+    seen_ports: dict[int, str] = {}
+    for i, entry in enumerate(raw_slots):
+        if not isinstance(entry, dict):
+            raise AnswersError(f"slots[{i}] must be a mapping")
+
+        capability = entry.get("capability")
+        if capability not in _VALID_SLOT_CAPABILITIES:
+            raise AnswersError(
+                f"slots[{i}].capability must be one of "
+                f"{sorted(_VALID_SLOT_CAPABILITIES)}, got {capability!r}"
+            )
+
+        name = entry.get("name")
+        if not name or not isinstance(name, str):
+            raise AnswersError(f"slots[{i}].name is required and must be a non-empty string")
+
+        port = entry.get("port")
+        if not isinstance(port, int) or isinstance(port, bool):
+            raise AnswersError(f"slots[{i}].port must be an integer, got {port!r}")
+        if port in seen_ports:
+            raise AnswersError(
+                f"slots[{i}].port {port} collides with slot {seen_ports[port]!r} "
+                "(slot ports must be unique)"
+            )
+        seen_ports[port] = name
+
+        model_id_raw = entry.get("model_id", "auto")
+        if model_id_raw == "auto":
+            picks = suggest_models(capability, hw, limit=1, prefer_coder=(capability == "coder"))
+            if not picks:
+                _warn(
+                    f"slot '{name}' ({capability}): no model suggestion available for this "
+                    "hardware; skipping slot"
+                )
+                continue
+            model_id = picks[0].model_id
+        else:
+            model_id = model_id_raw or None
+
+        # Not-yet-wired per-slot keys (spec §5, WS-E / Q7).
+        if "context_size" in entry:
+            _warn(f"slots[{i}].context_size is not yet applied (#1108)")
+        if "enabled_on_pull" in entry:
+            _warn(f"slots[{i}].enabled_on_pull is not yet applied (#1108)")
+
+        device = entry.get("device")
+        device = None if device in (None, "auto") else device
+        profile = entry.get("profile")
+        profile = None if profile in (None, "auto") else profile
+
+        slots.append(
+            SlotSelection(
+                capability=capability,
+                slot_name=name,
+                port=port,
+                model_id=model_id,
+                device=device,
+                profile=profile,
+            )
+        )
+    return slots
+
+
+def _resolve_npu_opt_in(doc: dict[str, Any], hw: HardwareInfo) -> bool:
+    npu = doc.get("npu") or {}
+    if not isinstance(npu, dict):
+        raise AnswersError("npu must be a mapping")
+    opt_in = npu.get("opt_in", "auto")
+    if opt_in == "auto":
+        return bool(hw.npu.present)
+    if isinstance(opt_in, bool):
+        return opt_in
+    raise AnswersError(f"npu.opt_in must be true, false, or 'auto', got {opt_in!r}")
+
+
+def _resolve_gen(doc: dict[str, Any]) -> tuple[bool, tuple[tuple[str, str], ...]]:
+    """Return (comfyui_enabled, comfyui_defaults)."""
+    from hal0.comfyui.capabilities import CAPABILITIES
+
+    gen = doc.get("gen") or {}
+    if not isinstance(gen, dict):
+        raise AnswersError("gen must be a mapping")
+
+    mode = _yaml_word(gen.get("mode", "off"))
+    if mode not in _GEN_MODES:
+        raise AnswersError(f"gen.mode must be one of {sorted(_GEN_MODES)}, got {mode!r}")
+    comfyui_enabled = mode in _GEN_MODES_ON
+
+    if mode == "scaffold_and_download":
+        _warn(
+            "gen.mode: scaffold_and_download — the download side is not yet applied (#1108); "
+            "only scaffolding is performed"
+        )
+
+    caps_raw = gen.get("capabilities") or {}
+    if not isinstance(caps_raw, dict):
+        raise AnswersError("gen.capabilities must be a mapping")
+
+    defaults: list[tuple[str, str]] = []
+    for cap_id, family in caps_raw.items():
+        if cap_id not in CAPABILITIES:
+            raise AnswersError(
+                f"gen.capabilities key {cap_id!r} is not a known ComfyUI capability "
+                f"(known: {sorted(CAPABILITIES)})"
+            )
+        family = _yaml_word(family)
+        if family == "off":
+            continue
+        if family == "auto":
+            family = CAPABILITIES[cap_id].default_family
+        elif not isinstance(family, str):
+            raise AnswersError(
+                f"gen.capabilities[{cap_id!r}] must be a family string, 'auto', or 'off', "
+                f"got {family!r}"
+            )
+        defaults.append((cap_id, family))
+
+    return comfyui_enabled, tuple(defaults)
+
+
+def _resolve_extensions(doc: dict[str, Any], comfyui_enabled: bool) -> dict[str, bool]:
+    apps = doc.get("apps") or {}
+    if not isinstance(apps, dict):
+        raise AnswersError("apps must be a mapping")
+
+    known_ids = {e.id for e in EXTENSIONS}
+    unknown_ids = set(apps.keys()) - known_ids
+    if unknown_ids:
+        raise AnswersError(f"apps has unknown extension id(s): {sorted(unknown_ids)}")
+
+    extensions: dict[str, bool] = {}
+    for ext in EXTENSIONS:
+        if ext.id == "comfyui":
+            # gen.mode drives the comfyui extension (spec §3 note); don't
+            # read apps.comfyui even if present.
+            extensions["comfyui"] = comfyui_enabled
+            continue
+        entry = apps.get(ext.id)
+        if entry is None:
+            extensions[ext.id] = ext.default_enabled
+            continue
+        if not isinstance(entry, dict):
+            raise AnswersError(f"apps.{ext.id} must be a mapping")
+        enabled = entry.get("enabled", ext.default_enabled)
+        if not isinstance(enabled, bool):
+            raise AnswersError(f"apps.{ext.id}.enabled must be a boolean, got {enabled!r}")
+        extensions[ext.id] = enabled
+
+        if "when" in entry:
+            _warn(f"apps.{ext.id}.when is not yet applied (#1108)")
+        if ext.id == "hermes" and "gateway" in entry:
+            _warn("apps.hermes.gateway is not yet applied (#1108)")
+
+    return extensions
+
+
+def _warn_not_yet_wired(doc: dict[str, Any]) -> None:
+    """Warn about known-but-not-yet-wired top-level blocks (spec §5)."""
+    if "network" in doc:
+        _warn("network is not yet applied (#1108)")
+    if "huggingface" in doc:
+        _warn(
+            "huggingface token settings are not yet applied (#1108); "
+            "set HF_TOKEN/HUGGING_FACE_HUB_TOKEN in the environment instead"
+        )
+
+
+def load_answers(path: str, hw: HardwareInfo) -> Selections:
+    """Load a ``hal0-setup.yaml`` answer file and resolve it into a
+    :class:`~hal0.install.orchestrate.Selections`.
+
+    Only the subset that maps onto ``Selections`` today is applied; other
+    keys are accepted and warned about (forward-compatible, spec §4).
+    """
+    doc = _load_yaml(path)
+    _check_version(doc)
+    _check_top_level_keys(doc)
+    _warn_not_yet_wired(doc)
+
+    storage_dir = _resolve_storage_dir(doc)
+    slots = _resolve_slots(doc, hw)
+    npu_opt_in = _resolve_npu_opt_in(doc, hw)
+    comfyui_enabled, comfyui_defaults = _resolve_gen(doc)
+    extensions = _resolve_extensions(doc, comfyui_enabled)
+
+    return Selections(
+        storage_dir=storage_dir,
+        slots=slots,
+        extensions=extensions,
+        npu_opt_in=npu_opt_in,
+        comfyui_defaults=comfyui_defaults,
+    )
+
+
+__all__ = ["AnswersError", "load_answers"]

--- a/tests/install/test_answers.py
+++ b/tests/install/test_answers.py
@@ -1,0 +1,286 @@
+import textwrap
+import warnings
+
+import pytest
+
+from hal0.cli.setup_command import build_auto_selections
+from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+from hal0.install.answers import AnswersError, load_answers
+
+
+def _hw(ram_gb=96, npu_present=True):
+    return HardwareInfo(
+        platform="strix-halo",
+        ram_mb=ram_gb * 1024,
+        ram_available_mb=ram_gb * 1024,
+        unified_memory_mb=ram_gb * 1024,
+        gpus=[GPUInfo(vendor="amd", vram_mb=512, compute_capable=True, vulkan_capable=True)],
+        npu=NPUInfo(present=npu_present),
+    )
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "hal0-setup.yaml"
+    p.write_text(textwrap.dedent(text))
+    return str(p)
+
+
+_ALL_AUTO = """
+version: 1
+model_store:
+  path: /var/lib/hal0/models
+slots:
+  - capability: chat
+    name: chat
+    port: 8081
+    model_id: auto
+  - capability: coder
+    name: coder
+    port: 8082
+    model_id: auto
+npu:
+  opt_in: auto
+gen:
+  mode: scaffold_only
+  capabilities:
+    txt2img: auto
+    img2img: auto
+    txt2video: auto
+    img2video: auto
+    image_upscale: auto
+apps:
+  openwebui: { enabled: true }
+  hermes: { enabled: true }
+  pi: { enabled: false }
+"""
+
+
+def test_all_auto_matches_build_auto_selections(tmp_path):
+    hw = _hw()
+    path = _write(tmp_path, _ALL_AUTO)
+    sel = load_answers(path, hw)
+
+    auto_sel = build_auto_selections(hw, storage_dir="/var/lib/hal0/models")
+
+    assert sel.storage_dir == auto_sel.storage_dir
+    assert {s.capability for s in sel.slots} == {"chat", "coder"}
+    assert sel.extensions["openwebui"] is True
+    assert sel.extensions["hermes"] is True
+    assert sel.extensions["pi"] is False
+    assert sel.extensions["comfyui"] is True
+    assert sel.npu_opt_in == auto_sel.npu_opt_in
+    assert sel.npu_opt_in is True
+    # every model_id resolved to a real suggestion (not left as the literal "auto")
+    assert all(s.model_id and s.model_id != "auto" for s in sel.slots)
+    # comfyui_defaults populated for every capability requested as auto
+    assert {cap_id for cap_id, _family in sel.comfyui_defaults} == {
+        "txt2img",
+        "img2img",
+        "txt2video",
+        "img2video",
+        "image_upscale",
+    }
+
+
+def test_missing_version_raises(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        """,
+    )
+    with pytest.raises(AnswersError):
+        load_answers(path, _hw())
+
+
+def test_unknown_version_raises(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 2
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        """,
+    )
+    with pytest.raises(AnswersError):
+        load_answers(path, _hw())
+
+
+def test_bad_slot_capability_raises_naming_value(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots:
+          - { capability: embed, name: embed, port: 8083, model_id: auto }
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    with pytest.raises(AnswersError, match="embed"):
+        load_answers(path, _hw())
+
+
+def test_unknown_extension_id_raises_naming_value(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { bogus_app: { enabled: true } }
+        """,
+    )
+    with pytest.raises(AnswersError, match="bogus_app"):
+        load_answers(path, _hw())
+
+
+def test_unknown_gen_capability_raises_naming_value(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: scaffold_only, capabilities: { bogus_cap: auto } }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    with pytest.raises(AnswersError, match="bogus_cap"):
+        load_answers(path, _hw())
+
+
+def test_gen_mode_off_disables_comfyui(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    sel = load_answers(path, _hw())
+    assert sel.extensions["comfyui"] is False
+    assert sel.comfyui_defaults == ()
+
+
+def test_gen_mode_scaffold_only_enables_comfyui_and_populates_defaults(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: scaffold_only, capabilities: { txt2img: auto } }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    sel = load_answers(path, _hw())
+    assert sel.extensions["comfyui"] is True
+    assert sel.comfyui_defaults == (("txt2img", "qwen-image"),)
+
+
+def test_network_and_huggingface_blocks_warn_but_do_not_raise(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        network:
+          bind_host: 0.0.0.0
+          hostname: hal0
+        model_store: { path: /var/lib/hal0/models }
+        huggingface:
+          token_env: HF_TOKEN
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sel = load_answers(path, _hw())
+    assert sel.storage_dir == "/var/lib/hal0/models"
+    messages = [str(w.message) for w in caught]
+    assert any("network" in m for m in messages)
+    assert any("huggingface" in m for m in messages)
+
+
+def test_unknown_top_level_key_warns_by_default(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        totally_unknown_key: 42
+        """,
+    )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        load_answers(path, _hw())
+    assert any("totally_unknown_key" in str(w.message) for w in caught)
+
+
+def test_unknown_top_level_key_raises_when_strict(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        strict: true
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        totally_unknown_key: 42
+        """,
+    )
+    with pytest.raises(AnswersError, match="totally_unknown_key"):
+        load_answers(path, _hw())
+
+
+def test_relative_storage_dir_raises(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: relative/path }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    with pytest.raises(AnswersError):
+        load_answers(path, _hw())
+
+
+def test_npu_opt_in_explicit_bool_passes_through(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: true }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    # even on a box without an NPU, explicit true passes through unchanged.
+    sel = load_answers(path, _hw(npu_present=False))
+    assert sel.npu_opt_in is True


### PR DESCRIPTION
Closes #1115

## Summary

Adds a headless answer-file loader so `hal0 setup` can run fully
non-interactively from a `hal0-setup.yaml` (`version: 1`), per
`handoffs/hal0-setup-answers-spec-2026-07-05.md`. This slice implements
**only** the subset of the schema that maps onto the existing
`hal0.install.orchestrate.Selections` and applies through the existing
apply path (`setup_install.run_install`) — no new apply plumbing, network
wiring, token persistence, or ComfyUI downloads (those are other issues,
tracked in the spec's field→destination map as WS-C/D/E/G/H).

- New `src/hal0/install/answers.py`: `load_answers(path, hw) -> Selections`
  - `version: 1` is mandatory; anything else raises.
  - `model_store.path` → `Selections.storage_dir` (must be absolute).
  - `slots[]` → `SlotSelection`s; `model_id: auto` resolves via
    `suggest_models(capability, hw, limit=1, prefer_coder=...)` (same
    resolver `--auto` uses); unresolvable slots are skipped with a warning.
    `device`/`profile: auto` (or absent) stay `None` so `apply_setup`
    derives them.
  - `apps.{openwebui,hermes,pi}.enabled` → `Selections.extensions`;
    `gen.mode` (`off` / `scaffold_only` / `scaffold_and_download`) drives
    the `comfyui` extension flag.
  - `npu.opt_in: auto` → `bool(hw.npu.present)`; explicit bool passes
    through.
  - `gen.capabilities` (cap → family, `auto`/`off`) → validated against
    `hal0.comfyui.capabilities.CAPABILITIES` and mapped to
    `Selections.comfyui_defaults`.
  - Bad `capability`, unknown extension id, or unknown gen capability id
    raise a `ValueError` naming the offending value.
  - Unknown top-level keys and not-yet-wired keys (`network`,
    `huggingface`, `apps.*.when`, `apps.hermes.gateway`,
    `slots[].context_size`/`enabled_on_pull`, the download side of
    `gen.mode: scaffold_and_download`) are accepted and warned about
    ("not yet applied"), not rejected — unless top-level `strict: true`,
    in which case unknown top-level keys error.
  - Handles the classic YAML-1.1 barewords gotcha (`off`/`on` parsing as
    Python bools) for `gen.mode` and `gen.capabilities.<cap>` values.
- `src/hal0/cli/setup_command.py`: new `--answers PATH` option on
  `hal0 setup`; when set, loads the `Selections` via `load_answers` and
  runs it through the same `run_install(sel, hw, no_pull=no_pull)` path
  `--auto` uses (works whether hal0-api is up or down).
- `tests/install/test_answers.py`: all-`auto` file ≡ `build_auto_selections`
  for the same hardware, version validation, vocabulary validation
  (capability/extension id/gen capability id), `gen.mode` off vs.
  scaffold_only behavior, warn-not-raise for `network`/`huggingface`
  blocks and unknown top-level keys, `strict: true` escalation, and
  explicit `npu.opt_in` passthrough.

## Acceptance criteria

- [x] `load_answers(path, hw) -> Selections` implemented per spec §4
- [x] `version: 1` required; missing/other version raises
- [x] `model_store.path` → `storage_dir` (wired)
- [x] `slots[]` → `SlotSelection`s, `model_id: auto` via `suggest_models`
- [x] `device`/`profile: auto` left `None` for `apply_setup` to derive
- [x] `apps.*.enabled` + `gen.mode` → `extensions` (comfyui driven by `gen.mode`)
- [x] `npu.opt_in: auto` → `hw.npu.present`; explicit bool passes through
- [x] `gen.capabilities` → `comfyui_defaults`, validated against `CAPABILITIES`
- [x] Vocabulary validation raises `ValueError` naming the bad value
- [x] Unwired keys (network/huggingface/apps.*.when/gateway/context_size/
      enabled_on_pull/scaffold_and_download-download) warn, not error
- [x] `--answers PATH` wired into `hal0 setup`, routed through the existing
      `run_install` apply path (honors `--no-pull`)
- [x] Tests added covering the above
- [x] `ruff format`, `ruff check`, `ruff format --check` all pass
- [x] Targeted + broader `pytest` pass (pre-existing unrelated failures noted below)

## Test plan

```
uv run ruff format src tests      # 633 files left unchanged
uv run ruff check src tests       # All checks passed!
uv run ruff format --check src tests   # 633 files already formatted
uv run pytest tests/install/test_answers.py tests/install/test_orchestrate.py tests/cli/ -q
# 279 passed, 3 pre-existing unrelated failures (hermes venv/env state on this box)
```

Broader `uv run pytest tests/ -q --ignore=tests/e2e`: 4614 passed, 14
failed, 8 skipped, 1 error — all pre-existing and unrelated to this change
(hermes venv/env state, Proxmox host detection, ComfyUI phase4 routes,
container spec dispatch, config URL behind proxy). None touch
`hal0.install.answers`, `setup_command`, or `setup_install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)