### PR TITLE
installer-setup: hal0 setup --plan dry-run preview

### DIFF
--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -172,8 +172,26 @@ def setup(
         "--emit-answers",
         help="Write the resolved choices to a hal0-setup.yaml and exit.",
     ),
+    plan: bool = typer.Option(
+        False,
+        "--plan",
+        "--dry-run",
+        help="Resolve + print the plan; write nothing (no slots, sentinel, pulls, or extensions).",
+    ),
 ) -> None:
     hw = HardwareProbe().probe()
+    if plan:
+        from hal0.cli.setup_plan import run_plan
+
+        raise typer.Exit(
+            code=run_plan(
+                hw,
+                answers=answers,
+                storage_dir=storage_dir,
+                no_extensions=no_extensions,
+                no_slots=no_slots,
+            )
+        )
     if emit_answers is not None:
         from hal0.install.answers import load_answers, write_answers
 

--- a/src/hal0/cli/setup_plan.py
+++ b/src/hal0/cli/setup_plan.py
@@ -1,0 +1,219 @@
+"""``hal0 setup --plan`` / ``--dry-run`` (issue #1116, spec §2/§8).
+
+Resolves the same :class:`~hal0.install.orchestrate.Selections` the real run
+would apply — via ``load_answers`` when ``--answers`` is given, else
+``build_auto_selections`` — and prints a "will create" table. Writes NOTHING:
+no slot TOML, no first-run sentinel, no pulls, no extension installs.  This is
+the safe preview / CI-gate surface (spec §8): "``--plan`` runs all validation
+and prints the will-create table ... with zero writes".
+
+Kept in its own module (rather than growing ``setup_command.py`` in place) so
+the sibling ``--emit-answers`` change (#1117) touching the same callback stays
+a small, mergeable diff.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+from pathlib import Path
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from hal0.config.schema import HardwareInfo
+from hal0.install.answers import AnswersError
+from hal0.install.orchestrate import Selections
+
+#: Below this many free GiB on the resolved model-store mount, flag a warning
+#: (or an error, under a strict answer file — spec §8).
+MIN_FREE_GIB = 10.0
+
+console = Console()
+
+
+def _answer_file_strict(path: str) -> bool:
+    """Best-effort peek at the answer file's top-level ``strict`` flag.
+
+    Mirrors ``hal0.install.answers._check_top_level_keys``'s ``strict``
+    read, but only for gating the *plan's own* integration checks
+    (free space / port-in-use) — it does not duplicate schema validation.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+    except OSError:
+        return False
+    if not isinstance(doc, dict):
+        return False
+    return bool(doc.get("strict", False))
+
+
+def _free_space_gib(path: str) -> float | None:
+    """Available GiB on the mount containing *path*.
+
+    Walks up to the nearest existing ancestor so a not-yet-created
+    ``storage_dir`` still reports the free space of the mount it will land
+    on. Returns ``None`` if no ancestor can be stat'd (e.g. permission
+    error).
+    """
+    p = Path(path)
+    seen = set()
+    while p not in seen:
+        seen.add(p)
+        if p.exists():
+            try:
+                usage = shutil.disk_usage(p)
+            except OSError:
+                return None
+            return usage.free / (1024**3)
+        if p.parent == p:
+            return None
+        p = p.parent
+    return None
+
+
+def _port_in_use(port: int) -> bool:
+    """True if binding ``127.0.0.1:port`` fails (something is already there)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError:
+            return True
+        return False
+
+
+def resolve_plan_selections(
+    hw: HardwareInfo,
+    *,
+    answers: str | None,
+    storage_dir: str,
+    no_extensions: bool,
+    no_slots: bool,
+) -> Selections:
+    """Resolve a :class:`Selections` the SAME way the real run would.
+
+    Raises :class:`~hal0.install.answers.AnswersError` on a bad answer file —
+    the caller turns that into a non-zero exit so ``--plan`` is a usable CI
+    gate (spec §8).
+    """
+    if answers is not None:
+        from hal0.install.answers import load_answers
+
+        return load_answers(answers, hw)
+
+    from hal0.cli.setup_command import _existing_slot_names, build_auto_selections
+
+    return build_auto_selections(
+        hw,
+        storage_dir=storage_dir,
+        with_extensions=not no_extensions,
+        with_slots=not no_slots,
+        existing_slots=_existing_slot_names(),
+    )
+
+
+def _render_plan_table(sel: Selections, *, strict: bool) -> bool:
+    """Print the "will create" table. Returns True if a ``strict``-gated
+    integration check failed (caller maps that to a non-zero exit)."""
+    has_error = False
+
+    console.print(f"[bold]Model store:[/bold] {sel.storage_dir}")
+    free_gib = _free_space_gib(sel.storage_dir)
+    if free_gib is None:
+        console.print("  [yellow]WARN[/yellow] could not determine free space on this mount")
+    else:
+        low = free_gib < MIN_FREE_GIB
+        if low:
+            console.print(
+                f"  [red]WARN[/red] only {free_gib:.1f} GiB free "
+                f"(< {MIN_FREE_GIB:.0f} GiB threshold)"
+            )
+            if strict:
+                has_error = True
+        else:
+            console.print(f"  {free_gib:.1f} GiB free")
+    console.print(f"[bold]NPU opt-in:[/bold] {sel.npu_opt_in}")
+    console.print()
+
+    # Headers are printed as plain lines (not ``Table(title=...)``) — a
+    # title longer than the table's content-driven width wraps mid-word,
+    # which makes output brittle to assert on in tests and ugly in a
+    # narrow terminal.
+    console.print("[bold]Slots to create[/bold]")
+    slot_table = Table()
+    slot_table.add_column("Name")
+    slot_table.add_column("Port", justify="right")
+    slot_table.add_column("Model")
+    slot_table.add_column("Device")
+    slot_table.add_column("Profile")
+    slot_table.add_column("Status")
+    for s in sel.slots:
+        device = s.device or "auto→derive"
+        profile = s.profile or "auto→derive"
+        model_id = s.model_id or "(none — scaffold only)"
+        in_use = _port_in_use(s.port)
+        if in_use:
+            status = "[red]port in use[/red]"
+            if strict:
+                has_error = True
+        else:
+            status = "[green]free[/green]"
+        slot_table.add_row(s.slot_name, str(s.port), model_id, device, profile, status)
+    if not sel.slots:
+        slot_table.add_row("[dim]-- none --[/dim]", "", "", "", "", "")
+    console.print(slot_table)
+
+    console.print("[bold]Extensions to enable[/bold]")
+    ext_table = Table()
+    ext_table.add_column("Extension")
+    enabled_exts = [eid for eid, on in sel.extensions.items() if on]
+    for eid in enabled_exts:
+        ext_table.add_row(eid)
+    if not enabled_exts:
+        ext_table.add_row("[dim]-- none --[/dim]")
+    console.print(ext_table)
+
+    if sel.comfyui_defaults:
+        console.print("[bold]ComfyUI defaults[/bold]")
+        comfy_table = Table()
+        comfy_table.add_column("Capability")
+        comfy_table.add_column("Family")
+        for cap_id, family in sel.comfyui_defaults:
+            comfy_table.add_row(cap_id, family)
+        console.print(comfy_table)
+
+    console.print()
+    console.print("[dim]--plan: nothing was written (no slots, no sentinel, no pulls).[/dim]")
+    return has_error
+
+
+def run_plan(
+    hw: HardwareInfo,
+    *,
+    answers: str | None,
+    storage_dir: str,
+    no_extensions: bool,
+    no_slots: bool,
+) -> int:
+    """Resolve + render the plan. Returns the process exit code."""
+    strict = _answer_file_strict(answers) if answers is not None else False
+    try:
+        sel = resolve_plan_selections(
+            hw,
+            answers=answers,
+            storage_dir=storage_dir,
+            no_extensions=no_extensions,
+            no_slots=no_slots,
+        )
+    except AnswersError as exc:
+        console.print(f"[bold red]error:[/bold red] {exc}")
+        return 1
+
+    has_error = _render_plan_table(sel, strict=strict)
+    return 1 if has_error else 0
+
+
+__all__ = ["resolve_plan_selections", "run_plan"]

--- a/tests/install/test_setup_plan.py
+++ b/tests/install/test_setup_plan.py
@@ -1,0 +1,172 @@
+"""Tests for ``hal0 setup --plan`` / ``--dry-run`` (issue #1116).
+
+``--plan`` must resolve the SAME ``Selections`` the real run would (via
+``load_answers`` or ``build_auto_selections``), print a "will create" table,
+and write NOTHING — no slot TOML, no first-run sentinel, no pulls, no
+extension installs. It is the safe preview / CI-gate surface (spec §8).
+"""
+
+from __future__ import annotations
+
+import socket
+import textwrap
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli.setup_command import app
+
+runner = CliRunner()
+
+
+def _write(tmp_path: Path, text: str) -> str:
+    p = tmp_path / "hal0-setup.yaml"
+    p.write_text(textwrap.dedent(text))
+    return str(p)
+
+
+_GOOD_ANSWERS = """
+version: 1
+model_store:
+  path: /var/lib/hal0/models
+slots:
+  - capability: chat
+    name: chat
+    port: 8081
+    model_id: auto
+  - capability: coder
+    name: coder
+    port: 8082
+    model_id: auto
+npu:
+  opt_in: auto
+gen:
+  mode: off
+apps:
+  openwebui: { enabled: true }
+  hermes: { enabled: true }
+  pi: { enabled: false }
+"""
+
+_BAD_ANSWERS = """
+version: 2
+model_store:
+  path: /var/lib/hal0/models
+slots: []
+"""
+
+
+def _fail_if_called(*_a, **_k):
+    raise AssertionError("run_install must NOT be called under --plan")
+
+
+@pytest.fixture(autouse=True)
+def _hal0_home(tmp_path, monkeypatch):
+    """Hermetic HAL0_HOME so slot/sentinel writes (if any leaked) land in a
+    throwaway dir, and existing-slot detection starts empty."""
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _no_real_apply(monkeypatch):
+    """--plan must never reach the apply path. Make that path explode."""
+    monkeypatch.setattr("hal0.cli.setup_install.run_install", _fail_if_called)
+
+
+def test_plan_auto_prints_table_and_writes_nothing(_hal0_home):
+    result = runner.invoke(app, ["--plan", "--auto"])
+
+    assert result.exit_code == 0, result.output
+    assert "Slots to create" in result.output
+    assert "Extensions to enable" in result.output
+    assert "nothing was written" in result.output
+
+    # zero writes: no slot TOML, no sentinel, anywhere under HAL0_HOME.
+    written = list(_hal0_home.rglob("*"))
+    assert written == [] or all(p.is_dir() for p in written), written
+
+
+def test_plan_dry_run_alias_behaves_identically(_hal0_home):
+    result = runner.invoke(app, ["--dry-run", "--auto"])
+
+    assert result.exit_code == 0, result.output
+    assert "Slots to create" in result.output
+
+
+def test_plan_answers_good_file_prints_resolved_slots(tmp_path, _hal0_home):
+    path = _write(tmp_path, _GOOD_ANSWERS)
+
+    result = runner.invoke(app, ["--plan", "--answers", path])
+
+    assert result.exit_code == 0, result.output
+    assert "chat" in result.output
+    assert "coder" in result.output
+    assert "Extensions to enable" in result.output
+
+
+def test_plan_answers_bad_file_exits_nonzero(tmp_path, _hal0_home):
+    path = _write(tmp_path, _BAD_ANSWERS)
+
+    result = runner.invoke(app, ["--plan", "--answers", path])
+
+    assert result.exit_code != 0
+    assert "version" in result.output
+
+
+def _bind_free_port() -> socket.socket:
+    """Bind an OS-assigned free port and hold it open; caller reads
+    ``sock.getsockname()[1]`` and closes it when done."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    return sock
+
+
+def test_plan_detects_port_in_use(tmp_path, _hal0_home):
+    sock = _bind_free_port()
+    try:
+        port = sock.getsockname()[1]
+        path = _write(
+            tmp_path,
+            f"""
+            version: 1
+            model_store: {{ path: /var/lib/hal0/models }}
+            slots:
+              - {{ capability: chat, name: chat, port: {port}, model_id: auto }}
+            npu: {{ opt_in: false }}
+            gen: {{ mode: off }}
+            apps: {{ openwebui: {{ enabled: true }}, hermes: {{ enabled: false }}, pi: {{ enabled: false }} }}
+            """,
+        )
+        result = runner.invoke(app, ["--plan", "--answers", path])
+        assert result.exit_code == 0, result.output
+        assert "port in use" in result.output
+    finally:
+        sock.close()
+
+
+def test_plan_strict_answers_port_in_use_is_an_error(tmp_path, _hal0_home):
+    sock = _bind_free_port()
+    try:
+        port = sock.getsockname()[1]
+        path = _write(
+            tmp_path,
+            f"""
+            version: 1
+            strict: true
+            model_store: {{ path: /var/lib/hal0/models }}
+            slots:
+              - {{ capability: chat, name: chat, port: {port}, model_id: auto }}
+            npu: {{ opt_in: false }}
+            gen: {{ mode: off }}
+            apps: {{ openwebui: {{ enabled: true }}, hermes: {{ enabled: false }}, pi: {{ enabled: false }} }}
+            """,
+        )
+        result = runner.invoke(app, ["--plan", "--answers", path])
+        assert result.exit_code != 0, result.output
+        assert "port in use" in result.output
+    finally:
+        sock.close()


### PR DESCRIPTION
Closes #1116

## Summary

Adds `hal0 setup --plan` (alias `--dry-run`): resolves the answer file (or
`--auto` defaults) into a concrete `Selections` the SAME way the real run
would, then prints a "will create" table and writes NOTHING — no slot TOML,
no first-run sentinel, no pulls, no extension installs. This is the safe
preview / CI-gate surface from `handoffs/hal0-setup-answers-spec-2026-07-05.md`
§2 and §8.

- New `src/hal0/cli/setup_plan.py` (kept separate from `setup_command.py` to
  minimize merge conflicts with the sibling `--emit-answers` PR #1117 touching
  the same callback): resolves selections via `load_answers` (when
  `--answers` is given) or `build_auto_selections` (otherwise), then renders:
  - Model store path + free space (`shutil.disk_usage`, warns below 10 GiB)
  - NPU opt-in
  - Slots table: name, port, resolved model, device/profile ("auto→derive"
    when not explicit), and a port-in-use check (`socket` bind probe)
  - Extensions to enable
  - ComfyUI capability defaults, if any
- `src/hal0/cli/setup_command.py`: one new `--plan`/`--dry-run` typer.Option
  and one early-return branch — before any `run_install`/`apply_setup` call.
- Resolution failures (e.g. a bad answer file) print the error and exit
  non-zero, so `--plan` is a usable CI gate. An answer file's `strict: true`
  flag additionally promotes the port-in-use check from a warning to an
  error exit.

## Test plan

- [x] `uv run ruff format src tests` — 635 files unchanged
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run ruff format --check src tests` — 635 files already formatted
- [x] `uv run pytest tests/install/test_setup_plan.py tests/cli/ -q` — 265 passed, 3 pre-existing hermes-venv failures (unrelated)
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 4620 passed, 14 known pre-existing failures (hermes venv/wrapper, comfyui phase4, proxmox host detection, container spec, config-url-proxy, models-preview, settings-store) — none touch files this PR changes
- [x] `--plan --auto` prints the table and makes zero filesystem writes
- [x] `--plan --answers <good file>` prints resolved slots
- [x] `--plan --answers <bad file>` exits non-zero with the validation error
- [x] port-in-use is detected and flagged (and errors under `strict: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)