### PR TITLE
installer-setup WS-A: thread HF_TOKEN through apply_setup → in-process pulls

### DIFF
--- a/src/hal0/cli/setup_install.py
+++ b/src/hal0/cli/setup_install.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import os
 
 import httpx
 import typer
@@ -65,12 +66,14 @@ async def _apply_in_process(sel, hw, *, no_pull: bool = False) -> None:
     from hal0.install.orchestrate import apply_setup
 
     slot_manager, registry = setup_command._build_offline_deps()
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     result = await apply_setup(
         sel,
         hardware=hw,
         slot_manager=slot_manager,
         registry=registry,
         jobs={},
+        hf_token=hf_token,
         write_sentinel=True,
     )
 

--- a/tests/cli/test_setup_install.py
+++ b/tests/cli/test_setup_install.py
@@ -1,4 +1,5 @@
-from hal0.cli.setup_install import choose_apply_mode
+from hal0.cli.setup_install import _apply_in_process, choose_apply_mode
+from hal0.install.orchestrate import SetupResult
 
 
 def test_mode_in_process_when_api_down(monkeypatch):
@@ -9,3 +10,66 @@ def test_mode_in_process_when_api_down(monkeypatch):
 def test_mode_api_when_up(monkeypatch):
     monkeypatch.setattr("hal0.cli.setup_install._api_reachable", lambda **k: True)
     assert choose_apply_mode() == "api"
+
+
+def _stub_offline_deps(monkeypatch):
+    """Patch setup_command._build_offline_deps so _apply_in_process never
+    touches a real SlotManager/ModelRegistry."""
+    monkeypatch.setattr(
+        "hal0.cli.setup_command._build_offline_deps",
+        lambda: (object(), object()),
+    )
+
+
+def _capture_apply_setup(monkeypatch):
+    """Patch hal0.install.orchestrate.apply_setup (imported lazily inside
+    _apply_in_process) and return a dict that captures the kwargs it was
+    called with."""
+    captured: dict = {}
+
+    async def fake_apply_setup(
+        sel, *, hardware, slot_manager, registry, jobs, hf_token=None, write_sentinel=True
+    ):
+        captured["hf_token"] = hf_token
+        return SetupResult(slots=[], extensions=[], model_ids=[], pulls=[])
+
+    monkeypatch.setattr("hal0.install.orchestrate.apply_setup", fake_apply_setup)
+    return captured
+
+
+async def test_apply_in_process_threads_hf_token(monkeypatch):
+    """HF_TOKEN in the environment must reach apply_setup (issue #1094)."""
+    _stub_offline_deps(monkeypatch)
+    captured = _capture_apply_setup(monkeypatch)
+    monkeypatch.setenv("HF_TOKEN", "hf_test_token")
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+    await _apply_in_process(sel=object(), hw=object(), no_pull=True)
+
+    assert captured["hf_token"] == "hf_test_token"
+
+
+async def test_apply_in_process_falls_back_to_hugging_face_hub_token(monkeypatch):
+    """HUGGING_FACE_HUB_TOKEN is used when HF_TOKEN is unset, matching the API
+    route's precedence in hal0/api/routes/installer.py."""
+    _stub_offline_deps(monkeypatch)
+    captured = _capture_apply_setup(monkeypatch)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_fallback_token")
+
+    await _apply_in_process(sel=object(), hw=object(), no_pull=True)
+
+    assert captured["hf_token"] == "hf_fallback_token"
+
+
+async def test_apply_in_process_no_token_passes_none(monkeypatch):
+    """Neither var set: apply_setup receives hf_token=None (its own default),
+    not a hardcoded skip of the kwarg."""
+    _stub_offline_deps(monkeypatch)
+    captured = _capture_apply_setup(monkeypatch)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+
+    await _apply_in_process(sel=object(), hw=object(), no_pull=True)
+
+    assert captured["hf_token"] is None


### PR DESCRIPTION
Closes #1094

## Description

Install-time in-process model pulls (`hal0 setup --auto` when hal0-api is not up) called `apply_setup()` without `hf_token`, so it always defaulted to `None` — even when `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) was exported in the environment. This caused gated curated model pulls to 401 during a fresh install.

The API path (`src/hal0/api/routes/installer.py`) already reads `os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")` and threads it into `apply_setup(hf_token=...)`. This PR mirrors that exact precedence in `_apply_in_process` (`src/hal0/cli/setup_install.py`), so the in-process path now reaches parity with the API-up path.

`apply_setup` in `src/hal0/install/orchestrate.py` already accepted `hf_token: str | None = None` and threads it into `make_job`/`PullPlan.kwargs` — no changes needed there.

## Acceptance checklist

- [x] `HF_TOKEN` present in the environment reaches `run_pull` for install-time in-process pulls
- [x] Same env-var precedence as the API route (`HF_TOKEN` then `HUGGING_FACE_HUB_TOKEN` fallback, else `None`)
- [x] No token in env still works for public models (no regression — `hf_token=None` is `apply_setup`'s own default)
- [x] Unit coverage that the token is threaded (not hardcoded `None`): `HF_TOKEN` set, `HUGGING_FACE_HUB_TOKEN` fallback, and neither-set → `None`

## Test plan

- `uv run ruff format src tests` — clean
- `uv run ruff check src tests` — all checks passed
- `uv run ruff format --check src tests` — clean
- `uv run pytest tests/cli/test_setup_install.py tests/install/test_orchestrate.py -q` — 12 passed
- `uv run pytest tests/ -q --ignore=tests/e2e` — 4617 passed, 14 pre-existing failures unrelated to this change (hermes wrapper/state-render, comfyui phase4, proxmox host detection, container spec dispatch, config-url-proxy, models-preview, settings-store), none touching `setup_install.py`, `test_setup_install.py`, or `orchestrate.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)