### PR TITLE
installer-setup WS-I: converge /apply onto /apply-selections + write first-run sentinel from endpoint

### DIFF
--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -13,9 +13,15 @@ Endpoints:
     POST /api/install/complete — marker call after the wizard finishes;
                                  writes ``/var/lib/hal0/.first_run_done``
                                  so subsequent boots skip the wizard.
+                                 Idempotent alongside the apply endpoints
+                                 below, which also write the sentinel.
 
 The curated-models picker feeds into POST /apply and POST /apply-selections
-for multi-slot orchestrated install (design D3/D6).
+for multi-slot orchestrated install (design D3/D6). Both converge on the
+same :func:`_apply_selections_core` provisioning path and both write the
+first-run sentinel on success (WS-I, issue #1101) — a UI or answer-file
+install no longer depends on an explicit ``POST /complete`` to flip
+``first_run``.
 """
 
 from __future__ import annotations
@@ -333,6 +339,43 @@ def _bundle_to_selections(bundle, overrides, npu_opt_in, *, storage_dir):
     )
 
 
+async def _apply_selections_core(
+    selections: Selections,
+    *,
+    request: Request,
+    background: BackgroundTasks,
+):
+    """Shared provisioning core for both apply endpoints (WS-I, issue #1101).
+
+    ``/apply`` (tier manifest) and ``/apply-selections`` (raw selections) both
+    reduce to a :class:`~hal0.install.orchestrate.Selections` and funnel
+    through here — one slot-provisioning path, no duplicated logic between
+    the two routes.
+
+    Writes the first-run sentinel on success (``write_sentinel=True``) so an
+    API-driven install (UI wizard *or* ``hal0 setup --answers`` over a live
+    service) converges with the CLI in-process path, which has always written
+    it directly. Previously only ``/apply-selections`` deferred to the
+    dashboard's explicit ``POST /complete``, which left ``first_run``
+    oscillating on the ``has_models`` heuristic alone for any client that
+    never called ``/complete``. ``mark_first_run_done`` is idempotent, so a
+    later ``/complete`` call (the wizard still makes one) is a harmless no-op.
+    """
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    result = await apply_setup(
+        selections,
+        hardware=request.app.state.hardware_probe.probe(),
+        slot_manager=request.app.state.slot_manager,
+        registry=request.app.state.model_registry,
+        jobs=request.app.state.model_pull_jobs,
+        hf_token=hf_token,
+        write_sentinel=True,
+    )
+    for plan in result.pulls:
+        background.add_task(run_pull, plan.job, **plan.kwargs)
+    return result
+
+
 @router.post("/apply")
 async def install_apply(request: Request, background: BackgroundTasks) -> dict[str, Any]:
     """Orchestrated FirstRun install (design D3).
@@ -342,10 +385,13 @@ async def install_apply(request: Request, background: BackgroundTasks) -> dict[s
         { "tier": "hal0-Default", "storage_dir": "/srv/models",
           "npu_opt_in": false, "overrides": { "<slot>": {model_id, profile, ...} } }
 
-    Thin wrapper: builds a :class:`~hal0.install.orchestrate.Selections` from the
-    tier manifest and delegates to :func:`~hal0.install.orchestrate.apply_setup`.
-    Best-effort, non-aborting per row (ADR-0010). The UI reattaches per model via
-    the existing ``/api/models/{id}/pull/stream`` SSE.
+    Thin tier→selections adapter: builds a
+    :class:`~hal0.install.orchestrate.Selections` from the tier manifest via
+    :func:`_bundle_to_selections`, then delegates to the same
+    :func:`_apply_selections_core` that ``/apply-selections`` uses — one
+    shared provisioning path (WS-I, issue #1101). Best-effort, non-aborting
+    per row (ADR-0010). The UI reattaches per model via the existing
+    ``/api/models/{id}/pull/stream`` SSE.
     """
     try:
         body = await request.json()
@@ -370,18 +416,7 @@ async def install_apply(request: Request, background: BackgroundTasks) -> dict[s
         npu_opt_in,
         storage_dir=body.get("storage_dir") or "",
     )
-    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    result = await apply_setup(
-        selections,
-        hardware=request.app.state.hardware_probe.probe(),
-        slot_manager=request.app.state.slot_manager,
-        registry=request.app.state.model_registry,
-        jobs=request.app.state.model_pull_jobs,
-        hf_token=hf_token,
-        write_sentinel=False,  # the dashboard still POSTs /complete explicitly
-    )
-    for plan in result.pulls:
-        background.add_task(run_pull, plan.job, **plan.kwargs)
+    result = await _apply_selections_core(selections, request=request, background=background)
 
     return {
         "tier": canonical,
@@ -396,7 +431,8 @@ async def install_apply_selections(request: Request, background: BackgroundTasks
     """Tier-less orchestrated install: accepts a Selections JSON directly and
     provisions exactly the chosen slots (no tier manifest expansion). Used by
     the `hal0 setup` TUI's API-up branch (roster coherence — the running
-    service registers the slots itself)."""
+    service registers the slots itself) and by ``/apply``'s tier adapter,
+    via the shared :func:`_apply_selections_core`."""
     try:
         body = await request.json()
     except Exception as exc:
@@ -422,18 +458,7 @@ async def install_apply_selections(request: Request, background: BackgroundTasks
         extensions=body.get("extensions") or {},
         npu_opt_in=bool(body.get("npu_opt_in", False)),
     )
-    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    result = await apply_setup(
-        selections,
-        hardware=request.app.state.hardware_probe.probe(),
-        slot_manager=request.app.state.slot_manager,
-        registry=request.app.state.model_registry,
-        jobs=request.app.state.model_pull_jobs,
-        hf_token=hf_token,
-        write_sentinel=False,
-    )
-    for plan in result.pulls:
-        background.add_task(run_pull, plan.job, **plan.kwargs)
+    result = await _apply_selections_core(selections, request=request, background=background)
     return {"model_ids": result.model_ids, "slots": [vars(s) for s in result.slots]}
 
 

--- a/tests/api/test_apply_selections.py
+++ b/tests/api/test_apply_selections.py
@@ -9,6 +9,8 @@ is hermetic — assert orchestration, not network).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 
 
@@ -69,3 +71,47 @@ def test_apply_selections_creates_only_selected_slots(
     # ONLY the one selected slot is created — not a whole tier.
     assert len(data["slots"]) == 1
     assert "qwen3-4b" in data["model_ids"]
+
+
+def test_apply_selections_writes_first_run_sentinel(
+    isolated_app_client, tmp_hal0_home, monkeypatch
+):
+    """WS-I (#1101): the apply-selections endpoint itself writes the
+    first-run sentinel on success — this is the endpoint the `hal0 setup`
+    API-up branch and answer-file installs POST to, so an install that
+    never hits the wizard's explicit POST /complete must still converge
+    with the CLI in-process path (which has always written it directly)."""
+    app, client = isolated_app_client
+    app.state.hardware_probe = _FakeProbe()
+
+    import hal0.api.routes.installer as inst
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "completed"
+
+    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+
+    sentinel = Path(tmp_hal0_home) / "var-lib" / "hal0" / ".first_run_done"
+    assert not sentinel.exists()
+
+    payload = {
+        "storage_dir": tmp_hal0_home,
+        "npu_opt_in": False,
+        "extensions": {},
+        "slots": [
+            {
+                "capability": "chat",
+                "slot_name": "chat",
+                "port": 8081,
+                "model_id": "qwen3-4b",
+                "device": None,
+                "profile": None,
+            },
+        ],
+    }
+    r = client.post("/api/install/apply-selections", json=payload)
+    assert r.status_code == 200, r.text
+    assert sentinel.exists()
+
+    state = client.get("/api/install/state")
+    assert state.json()["first_run"] is False

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -160,3 +160,63 @@ def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monk
     assert cfg["model"]["default"] == "qwen3.6-27b"
     assert cfg["profile"] == "vulkan"
     assert cfg["device"] == "gpu-vulkan"
+
+
+def test_apply_writes_first_run_sentinel(isolated_app_client, tmp_hal0_home, monkeypatch):
+    """WS-I (#1101): the /apply endpoint itself writes the first-run sentinel
+    on success — a UI client that never POSTs /complete must still converge
+    with the CLI in-process path, which has always written it directly."""
+    app, client = isolated_app_client
+    app.state.hardware_probe = _FakeProbe()
+
+    import hal0.api.routes.installer as inst
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "completed"
+
+    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+
+    sentinel = Path(tmp_hal0_home) / "var-lib" / "hal0" / ".first_run_done"
+    assert not sentinel.exists()
+
+    r = client.post(
+        "/api/install/apply",
+        json={"tier": "hal0-default", "storage_dir": tmp_hal0_home, "npu_opt_in": False},
+    )
+    assert r.status_code == 200, r.text
+    assert sentinel.exists()
+
+    # first_run flips false without ever calling POST /complete.
+    state = client.get("/api/install/state")
+    assert state.json()["first_run"] is False
+
+
+def test_apply_delegates_to_apply_selections_core(isolated_app_client, tmp_hal0_home, monkeypatch):
+    """/apply is a thin tier→selections adapter over the same core that
+    /apply-selections uses — one shared provisioning path, no duplicated
+    slot-provisioning logic (WS-I, issue #1101)."""
+    app, client = isolated_app_client
+    app.state.hardware_probe = _FakeProbe()
+
+    import hal0.api.routes.installer as inst
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "completed"
+
+    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+
+    calls: list[str] = []
+    real_core = inst._apply_selections_core
+
+    async def _spy_core(selections, *, request, background):
+        calls.append("core")
+        return await real_core(selections, request=request, background=background)
+
+    monkeypatch.setattr(inst, "_apply_selections_core", _spy_core)
+
+    r = client.post(
+        "/api/install/apply",
+        json={"tier": "hal0-default", "storage_dir": tmp_hal0_home, "npu_opt_in": False},
+    )
+    assert r.status_code == 200, r.text
+    assert calls == ["core"]


### PR DESCRIPTION
## Summary

Closes #1101.

- `/apply` (tier-manifest) and `/apply-selections` (raw selections) now both delegate to a single new `_apply_selections_core` helper in `src/hal0/api/routes/installer.py` — the `apply_setup` call and background-pull scheduling live in exactly one place. `/apply` is now a thin tier→selections adapter (`_bundle_to_selections`) over that shared core, matching the pattern `/apply-selections` already used.
- `_apply_selections_core` now calls `apply_setup(..., write_sentinel=True)` (previously both routes passed `write_sentinel=False` and relied on the wizard UI explicitly calling `POST /api/install/complete`). A UI client that never calls `/complete`, or an answer-file/API-up `hal0 setup` install, previously left `first_run` depending only on the `has_models` heuristic. Now any successful apply — CLI in-process, `/apply`, or `/apply-selections` — writes the sentinel itself.
- `mark_first_run_done()` is idempotent, so the wizard's existing `POST /complete` call after apply remains a harmless no-op — no behavior change there.
- Response shapes are unchanged: `/apply` still returns `{tier, model_ids, slots, next}`, `/apply-selections` still returns `{model_ids, slots}`.
- Did not touch `setup_command.py`, `answers.py`, `setup_plan.py`, `setup_install.py`, or add any `/api/config/urls` route (owned by sibling PR #1099).

## Test plan

- [x] `uv run ruff format src tests` — 1 file reformatted (test file), rest unchanged
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run ruff format --check src tests` — all files already formatted
- [x] `uv run pytest tests/api/test_installer_routes.py tests/api/test_install_apply.py tests/api/test_apply_selections.py tests/install/test_orchestrate.py -q` — 34 passed
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 4617 passed, 14 failed, 1 error, all pre-existing/unrelated (hermes venv/wrapper, comfyui phase4, proxmox host detection, container spec dispatch, config-url-proxy, models-preview, settings-store, openwebui prewire smoke)
- New tests added:
  - `tests/api/test_install_apply.py::test_apply_writes_first_run_sentinel` — `/apply` writes the sentinel and flips `first_run` without any `POST /complete`.
  - `tests/api/test_install_apply.py::test_apply_delegates_to_apply_selections_core` — asserts `/apply` calls the shared `_apply_selections_core` (spies on it).
  - `tests/api/test_apply_selections.py::test_apply_selections_writes_first_run_sentinel` — `/apply-selections` writes the sentinel and flips `first_run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)