### PR TITLE
installer-setup WS-H: apps skip/defer parity (openwebui install verb + gateway in deferred hermes)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -265,11 +265,17 @@ Walks `/etc/hal0/capabilities.toml`: selections whose backend can't serve the
 model are snapped to the model's first legal backend; selections whose model
 left the catalog are cleared. Idempotent.
 
+## `hal0 app` — optional apps
+
+| Command | Purpose | Key options |
+|---|---|---|
+| `app install <name>` | Install + enable an app skipped at install time (currently: `openwebui`). Runs the identical wiring as the install-time path (`HAL0_SKIP_OPENWEBUI=1`), so "skip now, install later" is lossless. | — |
+
 ## `hal0 agent` — bundled agents
 
 | Command | Purpose | Key options |
 |---|---|---|
-| `agent install <name>` | Install a bundled agent (`hermes` provisions a managed venv in the foreground). | `--switch` |
+| `agent install <name>` | Install a bundled agent (`hermes` provisions a managed venv in the foreground, including the Telegram/Discord gateway). | `--switch`, `--gateway`/`--no-gateway` |
 | `agent uninstall <name>` | Uninstall a bundled agent. | `--keep-memory` |
 | `agent list` | List installed bundled agents. | `--json` |
 | `agent peers` | List discoverable agent identity cards from the `agents` memory dataset. | — |

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1488,13 +1488,20 @@ else
         fi
     fi
 
+    # Escape hatch: HAL0_SKIP_OPENWEBUI=1 for operators who don't want the
+    # bundled chat UI — same "skip now, install later" contract as
+    # HAL0_SKIP_HERMES above. `hal0 app install openwebui` (issue #1102 / Q9)
+    # runs the identical enable+guard logic below, so skipping here is
+    # lossless.
     if [[ -f "${OPENWEBUI_UNIT_DST}" ]]; then
+        if [[ "${HAL0_SKIP_OPENWEBUI:-0}" -eq 1 ]]; then
+            info "skipping OpenWebUI (HAL0_SKIP_OPENWEBUI=1) — run '${HAL0_BIN} app install openwebui' later"
         # OpenWebUI runs as a podman container (ExecStart=podman run …) — the
         # same runtime as the slots, so the preflight that installed podman
         # already satisfies it. Without a usable runtime the unit would
         # restart-loop with status=203/EXEC, so guard the enable anyway — the
         # dashboard/API are unaffected and the built-in chat works without it.
-        if command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
+        elif command -v podman >/dev/null 2>&1 && podman info >/dev/null 2>&1; then
             systemctl enable --now hal0-openwebui
             # OpenWebUI can take a moment to come up while it pulls the
             # image / initialises its sqlite db. Don't fail the installer

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -66,6 +66,16 @@ def agent_install(
             "installing this one (single-pick enforced; ADR-0004 §2)."
         ),
     ),
+    gateway: bool = typer.Option(
+        True,
+        "--gateway/--no-gateway",
+        help=(
+            "Hermes only: also install + enable the Telegram/Discord gateway "
+            "(hermes-gateway.service), matching install-time wiring "
+            "(installer/install.sh). Use --no-gateway to provision Hermes "
+            "without the messaging bridge."
+        ),
+    ),
 ) -> None:
     """Install a bundled agent.
 
@@ -75,9 +85,14 @@ def agent_install(
     bootstrap pipeline locally in the foreground (streaming progress) and
     only consults the daemon at the end to honour ``--switch``. Other
     agents keep the thin API-driven path.
+
+    The Telegram/Discord gateway is enabled by default (``--gateway``) so
+    this "deferred" path (run after ``HAL0_SKIP_HERMES=1`` at install time,
+    or standalone) has NO downside vs. the install-time provision — issue
+    #1102 / decision Q9.
     """
     if name == "hermes":
-        _install_hermes(switch=switch)
+        _install_hermes(switch=switch, gateway=gateway)
         return
 
     url = _api_base()
@@ -98,10 +113,10 @@ def agent_install(
     )
 
 
-def _install_hermes(*, switch: bool) -> None:
+def _install_hermes(*, switch: bool, gateway: bool = True) -> None:
     """Foreground provision of Hermes into the hal0-managed venv.
 
-    Three steps, all local + foreground:
+    Four steps, all local + foreground:
 
     1. **Toolchain** — ``installer/agents/hermes-prereqs.sh`` ensures
        python3 (>=3.11), python3-venv (the clean-Ubuntu trap), python3-pip
@@ -113,6 +128,11 @@ def _install_hermes(*, switch: bool) -> None:
     3. **Switch** — best-effort daemon call so ``--switch`` still does the
        atomic single-pick swap; provisioning already registered hermes, so
        a daemon hiccup here doesn't un-provision it.
+    4. **Gateway** — (``gateway=True``, the default) install + enable the
+       Telegram/Discord gateway, the same wiring installer/install.sh runs
+       inline at install time. This is what makes the DEFERRED path (run
+       manually after ``HAL0_SKIP_HERMES=1``) lossless vs. install-time
+       (issue #1102 / Q9): whichever path runs, the gateway ends up wired.
     """
     import subprocess as _subprocess
 
@@ -160,6 +180,14 @@ def _install_hermes(*, switch: bool) -> None:
 
     # Bring the unit up so the agent actually runs (and survives reboot).
     _enable_and_start_hermes_unit()
+
+    # Telegram/Discord gateway — installer/install.sh runs this inline at
+    # install time; folding it in here means the DEFERRED path (this
+    # command, run after HAL0_SKIP_HERMES=1 or standalone) wires it too
+    # (issue #1102 / Q9). Best-effort: a gateway hiccup doesn't undo an
+    # otherwise-successful Hermes install.
+    if gateway:
+        _install_hermes_gateway()
 
     console.print(
         Panel(
@@ -266,6 +294,116 @@ def _enable_and_start_hermes_unit() -> None:
             "[yellow]Hermes provisioned, but the agent unit didn't start cleanly — "
             "check `systemctl status hal0-agent@hermes` / `hal0 agent log hermes`.[/yellow]"
         )
+
+
+# ── Gateway (Telegram/Discord) — issue #1102 / Q9 ────────────────────────────
+#
+# installer/install.sh wires the gateway inline (only reached when THAT run
+# just provisioned or already-provisioned Hermes). A box that skipped Hermes
+# at install time (HAL0_SKIP_HERMES=1) and installs it later via this CLI
+# never hit that bash block, so the gateway silently stayed unconfigured.
+# Porting the same steps here closes that gap — "install now" and "install
+# later" converge on identical wiring.
+
+_HERMES_BIN = f"{_HERMES_AGENT_TREES[0]}/bin/hermes"
+_HERMES_GATEWAY_UNIT = "/etc/systemd/system/hermes-gateway.service"
+
+
+def _hermes_venv_ready() -> bool:
+    """``-x /var/lib/hal0/venvs/hermes/bin/hermes`` — install.sh's own gate
+    for whether Hermes is actually provisioned before touching the gateway."""
+    from pathlib import Path as _Path
+
+    return _Path(_HERMES_BIN).is_file()
+
+
+def _install_hermes_gateway() -> None:
+    """`hermes gateway install --system --run-as-user hal0` + enable the unit.
+
+    Ports installer/install.sh's post-provision gateway block
+    (``env -u HERMES_HOME ... hermes gateway install --system ...`` through
+    the ``systemctl enable --now hermes-gateway`` + wait_active check).
+    Best-effort throughout: every failure mode here warns and returns rather
+    than raising, matching install.sh's ``|| warn ... continuing`` posture —
+    a broken gateway must never be reported as a failed Hermes install.
+    """
+    import os as _os
+    import shutil as _shutil
+    import subprocess as _subprocess
+    from pathlib import Path as _Path
+
+    if not _hermes_venv_ready():
+        # Provisioning didn't complete (or failed upstream) — nothing to
+        # wire the gateway onto. The caller already surfaced that failure.
+        return
+
+    console.print("[bold]Installing hermes gateway[/bold] (Telegram/Discord bridge)…")
+    # HERMES_HOME is unset so the generator bakes the hal0 default
+    # (~/.hermes) rather than a value inherited from the invoking shell.
+    env = dict(_os.environ)
+    env.pop("HERMES_HOME", None)
+    # `hermes gateway install` prompts interactively with no bypass flag;
+    # stdin=DEVNULL gives a clean EOF so it falls back to its built-in
+    # defaults (install + enable on boot + start now) instead of blocking.
+    rc = _subprocess.run(  # nosec B603 — fixed argv, known path
+        [_HERMES_BIN, "gateway", "install", "--system", "--run-as-user", "hal0"],
+        stdin=_subprocess.DEVNULL,
+        env=env,
+        check=False,
+    ).returncode
+    if rc != 0:
+        console.print(
+            "[yellow]hermes gateway install failed — Telegram/Discord bridge "
+            "unavailable; continuing.[/yellow]"
+        )
+
+    if not _Path(_HERMES_GATEWAY_UNIT).is_file():
+        console.print(
+            f"[yellow]hermes-gateway unit not installed ({_HERMES_GATEWAY_UNIT} missing) — "
+            "Telegram/Discord bridge unavailable.[/yellow]\n"
+            "[dim]retry with: sudo -u hal0 env -u HERMES_HOME "
+            f"{_HERMES_BIN} gateway install --system --run-as-user hal0 </dev/null[/dim]"
+        )
+        return
+
+    if _shutil.which("systemctl") is None:
+        return
+
+    _subprocess.run(["systemctl", "daemon-reload"], check=False)  # nosec B603 B607
+    rc = _subprocess.run(  # nosec B603 B607
+        ["systemctl", "enable", "--now", "hermes-gateway.service"], check=False
+    ).returncode
+    if rc != 0:
+        console.print(
+            "[yellow]hermes-gateway enable returned non-zero — continuing "
+            "(check `journalctl -u hermes-gateway -n 40`).[/yellow]"
+        )
+        return
+
+    if _wait_active_unit("hermes-gateway.service", timeout=20.0):
+        console.print("[dim]hermes-gateway is running (Telegram/Discord)[/dim]")
+    else:
+        console.print(
+            "[yellow]hermes-gateway not yet active; check "
+            "`journalctl -u hermes-gateway -n 40`.[/yellow]"
+        )
+
+
+def _wait_active_unit(unit: str, timeout: float = 15.0) -> bool:
+    """Poll ``systemctl is-active --quiet <unit>`` — Python port of
+    installer/install.sh's ``wait_active`` bash helper."""
+    import subprocess as _subprocess
+    import time as _time
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        rc = _subprocess.run(  # nosec B603 B607
+            ["systemctl", "is-active", "--quiet", unit], check=False
+        ).returncode
+        if rc == 0:
+            return True
+        _time.sleep(0.5)
+    return False
 
 
 @app.command("uninstall")

--- a/src/hal0/cli/app_commands.py
+++ b/src/hal0/cli/app_commands.py
@@ -1,0 +1,80 @@
+"""``hal0 app`` subcommands — deferred install verbs for optional apps.
+
+Companion to ``hal0 agent install <name>``: apps that were skipped at
+install time (``HAL0_SKIP_OPENWEBUI=1``) get a first-class "install later"
+verb instead of a manual ``systemctl enable`` incantation. See issue #1102
+(decision Q9): now-vs-later must be behaviourally identical, so this module
+calls the exact same wiring function (:func:`hal0.install.extensions.
+install_openwebui`) that ``apply_setup`` uses at install time.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from hal0.cli._shared import die
+
+app = typer.Typer(help="Manage optional apps (OpenWebUI, ...).")
+console = Console()
+
+# Apps with a wired "install later" verb. ComfyUI is intentionally absent —
+# it's owned by the seeded img slot (hal0-slot@img.service), not a
+# standalone app install path.
+_SUPPORTED = frozenset({"openwebui"})
+
+
+@app.command("install")
+def app_install(
+    name: str = typer.Argument(..., help="App id (currently: openwebui)."),
+) -> None:
+    """Install + enable an app that was skipped at install time.
+
+    Runs the identical enable+runtime-guard logic as the install-time path
+    (installer/install.sh's inline OpenWebUI block / ``apply_setup``), so
+    skipping now and installing later leave the box in the same state.
+    """
+    if name not in _SUPPORTED:
+        die(f"'hal0 app install {name}' isn't supported yet — known apps: {sorted(_SUPPORTED)}")
+        return
+
+    from hal0.install.extensions import install_openwebui
+
+    outcome = install_openwebui()
+
+    if outcome.skipped:
+        console.print(
+            Panel(
+                f"[yellow]OpenWebUI not started[/yellow] — {outcome.skipped.replace('_', ' ')}.\n"
+                "Install/start podman, then re-run [bold]hal0 app install openwebui[/bold].",
+                border_style="yellow",
+            )
+        )
+        raise typer.Exit(1)
+
+    if outcome.error and not outcome.installed:
+        die(f"openwebui install failed: {outcome.error}")
+        return
+
+    if outcome.error:
+        # installed=True but the active-confirmation lagged (slow first
+        # boot pulling the image / initialising sqlite) — not fatal.
+        console.print(
+            Panel(
+                "[bold green]Enabled[/bold green] openwebui  "
+                "[dim](not active yet — check 'journalctl -u hal0-openwebui -n 40')[/dim]",
+                border_style="yellow",
+            )
+        )
+        return
+
+    console.print(
+        Panel(
+            "[bold green]Installed[/bold green] openwebui  [dim](chat at :3001)[/dim]",
+            border_style="green",
+        )
+    )
+
+
+__all__ = ["app"]

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -29,6 +29,7 @@ from hal0.cli._shared import (
     die,
 )
 from hal0.cli.agent_commands import app as agent_app
+from hal0.cli.app_commands import app as app_ext_app
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
@@ -65,6 +66,9 @@ app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(agent_app, name="agent")
+# Issue #1102 — ``hal0 app install <name>`` (deferred install verb for apps
+# skipped via HAL0_SKIP_OPENWEBUI=1 at install time; Q9 skip/defer parity).
+app.add_typer(app_ext_app, name="app")
 app.add_typer(migrate_app, name="migrate")
 app.add_typer(registry_app, name="registry")
 # Issue #504 — ``hal0 mcp {list,status,install,uninstall,restart,catalog}``

--- a/src/hal0/install/extensions.py
+++ b/src/hal0/install/extensions.py
@@ -5,7 +5,9 @@ this makes them (and future entries) a selectable, wired set."""
 
 from __future__ import annotations
 
+import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from typing import Literal
 
@@ -42,18 +44,86 @@ def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _run_ok(cmd: list[str]) -> bool:
+    """Best-effort subprocess run — ``True`` on rc=0, never raises.
+
+    Mirrors installer/install.sh's ``|| true`` quiesce calls (e.g. the
+    OpenWebUI runtime-guard fallback) so the Python wiring can reproduce the
+    same "don't fail the flow" posture without a bare ``except``.
+    """
+    try:
+        return subprocess.run(cmd, check=False).returncode == 0
+    except OSError:
+        return False
+
+
+def _podman_usable() -> bool:
+    """``command -v podman && podman info`` — same check install.sh gates
+    the OpenWebUI unit on (installer/install.sh ~1497), since the unit is a
+    plain ``podman run`` ExecStart and would restart-loop with 203/EXEC
+    without a working runtime."""
+    if shutil.which("podman") is None:
+        return False
+    return _run_ok(["podman", "info"])
+
+
+def _wait_active(unit: str, timeout: float = 15.0) -> bool:
+    """Poll ``systemctl is-active --quiet <unit>`` — Python port of
+    install.sh's ``wait_active`` bash helper."""
+    if shutil.which("systemctl") is None:
+        return False
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _run_ok(["systemctl", "is-active", "--quiet", unit]):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def install_openwebui() -> ExtensionOutcome:
+    """Enable ``hal0-openwebui`` with the same runtime guard as
+    installer/install.sh's inline block: without a usable podman the unit
+    would restart-loop (203/EXEC), so quiesce it instead of enabling.
+
+    This is the ONE place both the install-time path (``apply_setup`` →
+    :func:`install_extension`) and the deferred ``hal0 app install
+    openwebui`` verb call into, so "skip now, install later" is lossless
+    (issue #1102 / decision Q9).
+    """
+    unit = "hal0-openwebui.service"
+    if not _podman_usable():
+        # A prior install (or an upgrade where openwebui was enabled) may
+        # have left the unit restart-looping with no runtime. Quiesce it so
+        # status reflects reality (inactive, not failed/looping) — mirrors
+        # install.sh's fallback branch.
+        _run_ok(["systemctl", "disable", "--now", unit])
+        _run_ok(["systemctl", "reset-failed", unit])
+        return ExtensionOutcome(ext_id="openwebui", skipped="no_container_runtime")
+
+    if not _run_ok(["systemctl", "enable", "--now", unit]):
+        return ExtensionOutcome(ext_id="openwebui", error=f"systemctl enable --now {unit} failed")
+
+    if not _wait_active(unit, timeout=30):
+        # Slow first boot (image pull / sqlite init) isn't fatal — the unit
+        # is enabled and will keep coming up; only the confirmation lagged.
+        return ExtensionOutcome(ext_id="openwebui", installed=True, error="not_active_yet")
+
+    return ExtensionOutcome(ext_id="openwebui", installed=True)
+
+
 def install_extension(ext_id: str) -> ExtensionOutcome:
     """Install + wire one extension. Apps enable their systemd unit; agents
     go through ``hal0 agent install <id>`` (which performs the wiring —
-    base_url routing, creds — that install.sh does today)."""
+    base_url routing, creds, and — for hermes — the Telegram/Discord
+    gateway — that install.sh does today)."""
     ext = get_extension(ext_id)
     if ext is None:
         return ExtensionOutcome(ext_id=ext_id, skipped="unknown_extension")
     try:
-        if ext.kind == "agent":
+        if ext.id == "openwebui":
+            return install_openwebui()
+        elif ext.kind == "agent":
             _run(["hal0", "agent", "install", ext.id])
-        elif ext.id == "openwebui":
-            _run(["systemctl", "enable", "--now", "hal0-openwebui.service"])
         elif ext.id == "comfyui":
             # ComfyUI is owned by the seeded img slot. The legacy
             # /opt/comfyui scripts remain manual operator tools only.

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -56,7 +56,10 @@ def test_install_hermes_runs_prereqs_then_bootstrap_then_register(
     monkeypatch.setattr("shutil.which", lambda _n: None)
     monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
 
-    ac._install_hermes(switch=True)
+    # Gateway wiring is its own concern (tested in the "gateway" section
+    # below) — disable it here so this test exercises only the
+    # toolchain->bootstrap->register sequence.
+    ac._install_hermes(switch=True, gateway=False)
 
     kinds = [e[0] for e in rec.events]
     # Toolchain prereqs run BEFORE provisioning; provisioning BEFORE register.
@@ -101,7 +104,7 @@ def test_install_hermes_aborts_when_provisioning_fails(monkeypatch) -> None:
     monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
 
     with pytest.raises((SystemExit, typer.Exit)):
-        ac._install_hermes(switch=False)
+        ac._install_hermes(switch=False, gateway=False)
 
     assert rec.events == [], "must not register after a failed provision"
 
@@ -192,3 +195,104 @@ def test_install_hermes_guard_noop_when_writable(monkeypatch) -> None:
     monkeypatch.setattr(os, "geteuid", lambda: 1000)
     monkeypatch.setattr("hal0.agents.hermes_provision.path_is_writable", lambda _p: True)
     ac._ensure_hermes_writable_or_die()  # no raise
+
+
+# ── Gateway (Telegram/Discord) fold-in — issue #1102 / Q9 ────────────────────
+#
+# installer/install.sh only wires the gateway when THAT run just provisioned
+# (or found already-provisioned) Hermes — a box that deferred Hermes at
+# install time (HAL0_SKIP_HERMES=1) and installs it later via this CLI never
+# hit that bash block. These tests pin the deferred path to the same wiring.
+
+
+def test_install_hermes_runs_gateway_by_default(monkeypatch) -> None:
+    """`hal0 agent install hermes` (no flags) enables the gateway — parity
+    with install-time provisioning, no opt-in required."""
+    rec = _Rec()
+
+    def _fake_subprocess_run(argv, *_a, **_k):  # type: ignore[no-untyped-def]
+        class _Done:
+            returncode = 0
+
+        return _Done()
+
+    monkeypatch.setattr(subprocess, "run", _fake_subprocess_run)
+    monkeypatch.setattr("hal0.agents.hermes_provision.bootstrap_cli", lambda **_k: 0, raising=True)
+    monkeypatch.setattr(ac, "api_post", lambda *_a, **_k: {})
+    monkeypatch.setattr(ac, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
+    monkeypatch.setattr("shutil.which", lambda _n: None)
+    monkeypatch.setattr(ac, "_install_hermes_gateway", lambda: rec.events.append(("gateway", None)))
+
+    ac._install_hermes(switch=False)  # gateway defaults to True
+
+    assert ("gateway", None) in rec.events
+
+
+def test_install_hermes_no_gateway_flag_skips_it(monkeypatch) -> None:
+    rec = _Rec()
+
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: type("_D", (), {"returncode": 0})())
+    monkeypatch.setattr("hal0.agents.hermes_provision.bootstrap_cli", lambda **_k: 0, raising=True)
+    monkeypatch.setattr(ac, "api_post", lambda *_a, **_k: {})
+    monkeypatch.setattr(ac, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
+    monkeypatch.setattr("shutil.which", lambda _n: None)
+    monkeypatch.setattr(ac, "_install_hermes_gateway", lambda: rec.events.append(("gateway", None)))
+
+    ac._install_hermes(switch=False, gateway=False)
+
+    assert rec.events == []
+
+
+def test_install_hermes_gateway_noop_when_venv_missing(monkeypatch) -> None:
+    """No provisioned hermes binary → nothing to wire the gateway onto."""
+    monkeypatch.setattr(ac, "_hermes_venv_ready", lambda: False)
+    called = {"ran": False}
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: called.__setitem__("ran", True))
+
+    ac._install_hermes_gateway()
+
+    assert called["ran"] is False
+
+
+def test_install_hermes_gateway_installs_and_enables_unit(monkeypatch, tmp_path) -> None:
+    """Happy path: gateway install runs, the unit file lands, systemctl
+    enables + confirms it active — mirrors installer/install.sh's block."""
+    gateway_unit = tmp_path / "hermes-gateway.service"
+
+    calls: list[list[str]] = []
+
+    def _fake_run(argv, *_a, **_k):  # type: ignore[no-untyped-def]
+        calls.append(list(argv))
+        # The real `hermes gateway install` writes the unit file as a side
+        # effect; simulate that here so the "unit landed" branch runs.
+        if argv[0] == ac._HERMES_BIN:
+            gateway_unit.write_text("[Unit]\n")
+
+        class _Done:
+            returncode = 0
+
+        return _Done()
+
+    monkeypatch.setattr(ac, "_hermes_venv_ready", lambda: True)
+    monkeypatch.setattr(ac, "_HERMES_GATEWAY_UNIT", str(gateway_unit))
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/bin/systemctl")
+    monkeypatch.setattr(ac, "_wait_active_unit", lambda _unit, timeout=15.0: True)
+
+    ac._install_hermes_gateway()
+
+    assert [ac._HERMES_BIN, "gateway", "install", "--system", "--run-as-user", "hal0"] in calls
+    assert ["systemctl", "daemon-reload"] in calls
+    assert ["systemctl", "enable", "--now", "hermes-gateway.service"] in calls
+
+
+def test_install_hermes_gateway_warns_without_raising_when_unit_missing(monkeypatch) -> None:
+    """`hermes gateway install` failing to lay down the unit must not raise —
+    best-effort, matches install.sh's `|| warn ... continuing` posture."""
+    monkeypatch.setattr(ac, "_hermes_venv_ready", lambda: True)
+    monkeypatch.setattr(ac, "_HERMES_GATEWAY_UNIT", "/nonexistent/hermes-gateway.service")
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: type("_D", (), {"returncode": 1})())
+
+    ac._install_hermes_gateway()  # must not raise

--- a/tests/cli/test_app_install_openwebui.py
+++ b/tests/cli/test_app_install_openwebui.py
@@ -1,0 +1,70 @@
+"""`hal0 app install openwebui` — deferred install verb (issue #1102 / Q9).
+
+Pins that the CLI verb delegates to the exact same wiring function the
+install-time path (`apply_setup` → `install_extension`) uses, so "skip now,
+install later" is behaviourally lossless.
+"""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+import hal0.cli.app_commands as app_cmds
+from hal0.install.orchestrate import ExtensionOutcome
+
+
+def test_app_install_openwebui_delegates_to_install_openwebui(monkeypatch) -> None:
+    calls = []
+
+    def _fake_install_openwebui():
+        calls.append("called")
+        return ExtensionOutcome(ext_id="openwebui", installed=True)
+
+    monkeypatch.setattr("hal0.install.extensions.install_openwebui", _fake_install_openwebui)
+
+    app_cmds.app_install(name="openwebui")
+
+    assert calls == ["called"]
+
+
+def test_app_install_openwebui_success_does_not_exit(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "hal0.install.extensions.install_openwebui",
+        lambda: ExtensionOutcome(ext_id="openwebui", installed=True),
+    )
+    # No exception / typer.Exit raised on the happy path.
+    app_cmds.app_install(name="openwebui")
+
+
+def test_app_install_openwebui_no_runtime_exits_nonzero(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "hal0.install.extensions.install_openwebui",
+        lambda: ExtensionOutcome(ext_id="openwebui", skipped="no_container_runtime"),
+    )
+    with pytest.raises(typer.Exit) as exc_info:
+        app_cmds.app_install(name="openwebui")
+    assert exc_info.value.exit_code == 1
+
+
+def test_app_install_openwebui_hard_failure_dies(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "hal0.install.extensions.install_openwebui",
+        lambda: ExtensionOutcome(ext_id="openwebui", error="systemctl enable --now failed"),
+    )
+    with pytest.raises((SystemExit, typer.Exit)):
+        app_cmds.app_install(name="openwebui")
+
+
+def test_app_install_openwebui_slow_start_is_not_fatal(monkeypatch) -> None:
+    """installed=True but the active-confirmation lagged — success, not error."""
+    monkeypatch.setattr(
+        "hal0.install.extensions.install_openwebui",
+        lambda: ExtensionOutcome(ext_id="openwebui", installed=True, error="not_active_yet"),
+    )
+    app_cmds.app_install(name="openwebui")  # must not raise
+
+
+def test_app_install_unknown_app_dies() -> None:
+    with pytest.raises((SystemExit, typer.Exit)):
+        app_cmds.app_install(name="comfyui")

--- a/tests/install/test_extensions.py
+++ b/tests/install/test_extensions.py
@@ -1,6 +1,8 @@
+from hal0.install import extensions as ext_mod
 from hal0.install.extensions import (
     get_extension,
     install_extension,
+    install_openwebui,
     list_extensions,
 )
 from hal0.install.orchestrate import ExtensionOutcome
@@ -30,3 +32,72 @@ def test_install_agent_runs_hal0_agent_install(monkeypatch):
 def test_install_unknown_extension_skips():
     out = install_extension("nope")
     assert out.installed is False and out.skipped == "unknown_extension"
+
+
+# ── OpenWebUI wiring (issue #1102 / Q9) ─────────────────────────────────────
+#
+# install_extension("openwebui") and the standalone install_openwebui() must
+# be the SAME code path so "install now" (apply_setup) and "install later"
+# (`hal0 app install openwebui`) are behaviourally identical.
+
+
+def test_install_extension_openwebui_delegates_to_install_openwebui(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        ext_mod,
+        "install_openwebui",
+        lambda: calls.append("called") or ExtensionOutcome(ext_id="openwebui", installed=True),
+    )
+    out = install_extension("openwebui")
+    assert calls == ["called"]
+    assert out.installed is True
+
+
+def test_install_openwebui_enables_unit_when_podman_usable(monkeypatch):
+    ran = []
+    monkeypatch.setattr(ext_mod, "_podman_usable", lambda: True)
+    monkeypatch.setattr(ext_mod, "_wait_active", lambda unit, timeout=15.0: True)
+    monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: ran.append(cmd) or True)
+
+    out = install_openwebui()
+
+    assert out.installed is True and out.error is None
+    assert ["systemctl", "enable", "--now", "hal0-openwebui.service"] in ran
+
+
+def test_install_openwebui_quiesces_unit_without_podman(monkeypatch):
+    ran = []
+    monkeypatch.setattr(ext_mod, "_podman_usable", lambda: False)
+    monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: ran.append(cmd) or True)
+
+    out = install_openwebui()
+
+    assert out.installed is False
+    assert out.skipped == "no_container_runtime"
+    assert ["systemctl", "disable", "--now", "hal0-openwebui.service"] in ran
+    assert ["systemctl", "reset-failed", "hal0-openwebui.service"] in ran
+    # No enable attempt when the runtime is unusable.
+    assert all(cmd[:2] != ["systemctl", "enable"] for cmd in ran)
+
+
+def test_install_openwebui_reports_error_when_enable_fails(monkeypatch):
+    monkeypatch.setattr(ext_mod, "_podman_usable", lambda: True)
+    monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: False)
+
+    out = install_openwebui()
+
+    assert out.installed is False
+    assert out.error is not None and "enable" in out.error
+
+
+def test_install_openwebui_surfaces_slow_start_without_failing(monkeypatch):
+    monkeypatch.setattr(ext_mod, "_podman_usable", lambda: True)
+    monkeypatch.setattr(ext_mod, "_wait_active", lambda unit, timeout=15.0: False)
+    monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: True)
+
+    out = install_openwebui()
+
+    # Enabled, but the active-confirmation lagged — not fatal (matches
+    # install.sh's "warn, don't fail" posture for a slow first boot).
+    assert out.installed is True
+    assert out.error == "not_active_yet"


### PR DESCRIPTION
## Summary

Closes #1102. Makes "skip now, install later" genuinely lossless for both
optional apps (Wave 3 / WS-H, decision Q9):

- **`hal0 app install openwebui`** — new CLI verb + `HAL0_SKIP_OPENWEBUI=1`
  install-time escape hatch (mirrors the existing `HAL0_SKIP_HERMES`
  pattern). Both the install-time path (`apply_setup` → `install_extension`)
  and the deferred CLI verb now call the SAME `install_openwebui()` function
  in `src/hal0/install/extensions.py`, which reproduces installer/install.sh's
  podman-runtime guard (enable+wait_active when podman is usable; quiesce
  the unit with `disable`/`reset-failed` otherwise) so now-vs-later behave
  identically.
- **Hermes gateway fold-in** — `hal0 agent install hermes` now installs +
  enables the Telegram/Discord gateway by default (new
  `--gateway`/`--no-gateway` flag, default on). This ports
  installer/install.sh's inline post-provision gateway block (`hermes
  gateway install --system --run-as-user hal0` → `systemctl enable --now
  hermes-gateway`) into `src/hal0/cli/agent_commands.py`, which previously
  only ran when install.sh itself provisioned Hermes in the same run — a
  box that deferred Hermes via `HAL0_SKIP_HERMES=1` and installed it later
  never got the gateway wired.

Both failure paths are best-effort (warn + continue), matching install.sh's
posture: a broken gateway or a missing container runtime must not be
reported as a failed install.

## Scope note

Per the isolation guardrails for this workstream, `answers.py` /
`setup_command.py` / `orchestrate.py` were left untouched — the
`apps.*.when` / `apps.hermes.gateway` answer-file keys (mentioned in the
issue's "Answer-file coverage" addendum) still warn-and-ignore pending
whoever owns that loader; wiring them cleanly would need a `Selections`
field this issue didn't add, to avoid conflicting with the parallel
answer-file PRs in flight.

## Changes

- `src/hal0/install/extensions.py` — `install_openwebui()` (shared wiring,
  runtime-guard ported from install.sh), `install_extension("openwebui")`
  delegates to it.
- `src/hal0/cli/app_commands.py` (new) — `hal0 app install <name>` Typer
  sub-app.
- `src/hal0/cli/main.py` — mounts the new `app` sub-app.
- `src/hal0/cli/agent_commands.py` — `--gateway`/`--no-gateway` flag on
  `agent install`; `_install_hermes_gateway()` / `_wait_active_unit()`
  ported from install.sh.
- `installer/install.sh` — `HAL0_SKIP_OPENWEBUI=1` escape hatch around the
  existing OpenWebUI enable block.
- `docs/reference/cli.mdx` — documents `hal0 app install` and the new
  hermes gateway flag.
- Tests: `tests/install/test_extensions.py`, `tests/cli/test_app_install_openwebui.py`,
  `tests/cli/test_agent_install_hermes.py` (gateway section; two
  pre-existing tests updated to pass `gateway=False` so they keep testing
  only the toolchain→bootstrap→register sequence).

## Test plan

- [x] `uv run ruff format --check src tests`
- [x] `uv run ruff check src tests`
- [x] `uv run pytest tests/install/test_extensions.py tests/cli/ -q` — 3
      pre-existing failures only (`test_install_hermes_runs_prereqs_then_bootstrap_then_register`,
      `test_agent_shim.py::TestHermesEnv` x2), confirmed via `git stash` to
      fail identically on `main` — caused by a live
      `/var/lib/hal0/venvs/hermes` on this box + running as root, unrelated
      to this change.
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 4630 passed, 14 failed,
      1 error, 8 skipped — matches the documented ~14 known pre-existing
      failures on this box (hardware/pve, comfyui_phase4, config_urls,
      models_preview, settings_models_store, hermes wrapper/state-render,
      container_spec_dispatch, openwebui prewire — none touch files this PR
      changes).
- [ ] Manual: fresh install with `HAL0_SKIP_OPENWEBUI=1 HAL0_SKIP_HERMES=1`,
      then `hal0 app install openwebui` + `hal0 agent install hermes` on a
      real box (not run here — no live installer target in this sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)