### PR TITLE
installer-setup WS-A: honor or remove Selections.storage_dir

### DIFF
--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -132,6 +132,40 @@ def mark_first_run_done() -> None:
     tmp.replace(p)  # atomic
 
 
+def _persist_store_dir(storage_dir: str) -> None:
+    """Persist a chosen model-store directory to ``[models].store`` in hal0.toml.
+
+    ``Selections.storage_dir`` (WS-A, issue #1095) is the operator's pull
+    destination pick from ``/apply``, ``/apply-selections`` and
+    ``hal0 setup --storage-dir``. The pull engine resolves its destination from
+    ``[models].store`` *lazily at pull time*
+    (``registry.pull._pull_root`` → ``ModelsConfig.effective_store``), so
+    writing the pick here — before the planned pulls run — is what makes a
+    custom store actually land pulls in that directory rather than silently
+    no-op'ing the field.
+
+    Best-effort per ADR-0010: an empty or relative value is ignored (the pull
+    engine keeps its default store), and a config-write failure is swallowed so
+    a bad storage pick never aborts the slot/extension walk. Idempotent — skips
+    the rewrite when ``[models].store`` already points at the chosen path.
+    """
+    s = (storage_dir or "").strip()
+    if not s or not Path(s).is_absolute():
+        return
+    try:
+        from hal0.config.loader import load_hal0_config, save_hal0_config
+
+        cfg = load_hal0_config()
+        if (cfg.models.store or "").strip() == s:
+            return
+        cfg.models.store = s
+        save_hal0_config(cfg)
+    except Exception:
+        # Config persistence is best-effort: pulls fall back to the default
+        # store and the rest of setup must proceed regardless.
+        pass
+
+
 def install_extension(ext_id: str) -> ExtensionOutcome:
     """Install + wire one extension. Delegates to extensions.install_extension
     (Task 1.2); imported lazily to avoid a cycle."""
@@ -172,6 +206,11 @@ async def apply_setup(
     slot_outcomes: list[SlotOutcome] = []
     model_ids: list[str] = []
     pulls: list[PullPlan] = []
+
+    # Honour the operator's chosen store BEFORE planning pulls: the pull engine
+    # reads ``[models].store`` lazily at pull time, so persisting it here is
+    # what threads ``storage_dir`` all the way to the pull destination (#1095).
+    _persist_store_dir(selections.storage_dir)
 
     for s in selections.slots:
         rec = SlotOutcome(slot=s.slot_name, model_id=s.model_id or "")

--- a/tests/install/test_orchestrate.py
+++ b/tests/install/test_orchestrate.py
@@ -53,7 +53,7 @@ def _strix_hw():
     )
 
 
-async def test_apply_setup_creates_chat_slot_and_plans_pull():
+async def test_apply_setup_creates_chat_slot_and_plans_pull(tmp_hal0_home):
     from hal0.install import orchestrate
 
     sm = _FakeSlotManager()
@@ -80,7 +80,7 @@ async def test_apply_setup_creates_chat_slot_and_plans_pull():
     assert len(res.pulls) == 1 and res.pulls[0].model_id == "qwen3-4b"
 
 
-async def test_apply_setup_scaffolds_modelless_slot_without_pull():
+async def test_apply_setup_scaffolds_modelless_slot_without_pull(tmp_hal0_home):
     """A SlotSelection with model_id=None creates an empty slot (device/profile
     wired, model.default unset) and plans NO pull."""
     from hal0.install import orchestrate
@@ -108,7 +108,7 @@ async def test_apply_setup_scaffolds_modelless_slot_without_pull():
     assert res.pulls == [] and res.model_ids == []  # pick-free: no downloads
 
 
-async def test_apply_setup_skips_uncurated_model():
+async def test_apply_setup_skips_uncurated_model(tmp_hal0_home):
     from hal0.install import orchestrate
 
     sel = Selections(
@@ -127,6 +127,83 @@ async def test_apply_setup_skips_uncurated_model():
     )
     assert res.slots[0].skipped == "needs_upstream_routing"
     assert res.slots[0].created is False
+
+
+async def test_apply_setup_persists_custom_store_dir(tmp_hal0_home, tmp_path):
+    """A non-empty absolute ``storage_dir`` is written to ``[models].store`` so
+    the pull engine (which reads it lazily at pull time) lands pulls there
+    (issue #1095 threading decision)."""
+    from hal0.config.loader import load_hal0_config
+    from hal0.install import orchestrate
+    from hal0.registry import pull as pull_mod
+
+    custom = tmp_path / "custom-store"
+    sel = Selections(
+        storage_dir=str(custom),
+        # scaffold slot — exercises the store write without needing a curated
+        # model or a network pull.
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    # Persisted to config …
+    assert load_hal0_config().models.store == str(custom)
+    # … and the pull engine now resolves its destination root to it.
+    assert pull_mod._pull_root() == custom
+
+
+async def test_apply_setup_ignores_relative_storage_dir(tmp_hal0_home):
+    """A relative ``storage_dir`` is not persisted (best-effort guard); the
+    store stays at its default so a bad pick never corrupts config."""
+    from hal0.config.loader import load_hal0_config
+    from hal0.install import orchestrate
+
+    sel = Selections(
+        storage_dir="relative/models",
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    assert load_hal0_config().models.store == ""  # untouched
+
+
+async def test_apply_setup_empty_storage_dir_is_noop(tmp_hal0_home):
+    """An empty ``storage_dir`` leaves ``[models].store`` unset (the default
+    store keeps applying)."""
+    from hal0.config.loader import load_hal0_config
+    from hal0.install import orchestrate
+
+    sel = Selections(
+        storage_dir="",
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    assert load_hal0_config().models.store == ""
 
 
 def test_mark_first_run_done_writes_sentinel(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1095

## Decision: THREAD (not remove)

`Selections.storage_dir` is accepted by `POST /apply`, `POST /apply-selections`, and `hal0 setup --storage-dir` (and surfaced by the interactive setup UI's "Model storage directory" prompt), but `apply_setup` never used it — pulls always went to the default `[models].store`, so choosing a custom store was a silent no-op.

I threaded it rather than removing it because the plumbing is clean and the field is a real, user-facing pick (CLI flag + TUI prompt), not vestigial:

- The pull engine already resolves its destination from `[models].store` **lazily at pull time** (`registry.pull._pull_root` → `ModelsConfig.effective_store`).
- So `apply_setup` now persists a non-empty **absolute** `storage_dir` to `[models].store` (via `load_hal0_config`/`save_hal0_config`) **before** planning pulls. The deferred pulls (`BackgroundTasks` for the routes, awaited-with-progress for the TUI) then land in the chosen directory with zero extra plumbing.

Removing would have meant also ripping out the `--storage-dir` flag and the TUI prompt for a capability operators clearly expect — strictly worse.

### Behavior / safety
- Best-effort per ADR-0010: empty or **relative** `storage_dir` values are ignored (default store keeps applying), and a config-write failure is swallowed so a bad storage pick never aborts the slot/extension walk.
- Idempotent: skips the rewrite when `[models].store` already points at the chosen path.
- `[models].flm_store` co-location is intentionally out of scope (#1100) — only `[models].store` is written.

## Files changed
- `src/hal0/install/orchestrate.py` — new `_persist_store_dir()` helper; `apply_setup` calls it before the slot loop.
- `tests/install/test_orchestrate.py` — new tests: custom store persisted + `_pull_root()` resolves to it; relative and empty values leave `[models].store` untouched. Existing `apply_setup` tests gained `tmp_hal0_home` isolation (they now trigger a config write).

## Tests
- `uv run ruff format --check src tests` — clean
- `uv run ruff check src tests` — clean
- `tests/install/test_orchestrate.py` — 10 passed (7 existing + 3 new)
- Full suite: only the ~14 documented pre-existing failures remain (hermes venv, comfyui phase4, proxmox host detection, container spec dispatch, config-url-proxy, models-preview, settings-store) — confirmed unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)