### PR TITLE
installer-setup WS-G: fix ComfyUI fetch (podman-exec/host hf + forward HF_TOKEN) + ship workflow JSONs

### DIFF
--- a/installer/comfyui/scripts/get_hunyuan15.sh
+++ b/installer/comfyui/scripts/get_hunyuan15.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
-HF="/opt/venv/bin/hf"
+# Resolve the Hugging Face CLI: prefer an explicit $HF override, then a
+# host-PATH `hf` (installer-provisioned), and fall back to the ComfyUI
+# container venv path for in-container execution.
+HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_hunyuan15"

--- a/installer/comfyui/scripts/get_ltx2.sh
+++ b/installer/comfyui/scripts/get_ltx2.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
-HF="/opt/venv/bin/hf"
+# Resolve the Hugging Face CLI: prefer an explicit $HF override, then a
+# host-PATH `hf` (installer-provisioned), and fall back to the ComfyUI
+# container venv path for in-container execution.
+HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_ltx2"                     # persistent staging (enables resume)

--- a/installer/comfyui/scripts/get_qwen_image.sh
+++ b/installer/comfyui/scripts/get_qwen_image.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
-HF="/opt/venv/bin/hf"
+# Resolve the Hugging Face CLI: prefer an explicit $HF override, then a
+# host-PATH `hf` (installer-provisioned), and fall back to the ComfyUI
+# container venv path for in-container execution.
+HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_qwen"                      # persistent staging (resume support)

--- a/installer/comfyui/scripts/get_sdxl.sh
+++ b/installer/comfyui/scripts/get_sdxl.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
-HF="/opt/venv/bin/hf"
+# Resolve the Hugging Face CLI: prefer an explicit $HF override, then a
+# host-PATH `hf` (installer-provisioned), and fall back to the ComfyUI
+# container venv path for in-container execution.
+HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_sdxl"

--- a/installer/comfyui/scripts/get_wan22.sh
+++ b/installer/comfyui/scripts/get_wan22.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 export HF_HUB_ENABLE_HF_TRANSFER=1
 export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
-HF="/opt/venv/bin/hf"
+# Resolve the Hugging Face CLI: prefer an explicit $HF override, then a
+# host-PATH `hf` (installer-provisioned), and fall back to the ComfyUI
+# container venv path for in-container execution.
+HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_wan22"                     # persistent staging (enables resume)

--- a/installer/comfyui/workflows/ESRGAN-4x-Upscale.json
+++ b/installer/comfyui/workflows/ESRGAN-4x-Upscale.json
@@ -1,0 +1,49 @@
+{
+    "1": {
+        "inputs": {
+            "image": "example.png"
+        },
+        "class_type": "LoadImage",
+        "_meta": {
+            "title": "Load Image"
+        }
+    },
+    "2": {
+        "inputs": {
+            "model_name": "4x-UltraSharp.pth"
+        },
+        "class_type": "UpscaleModelLoader",
+        "_meta": {
+            "title": "Load Upscale Model"
+        }
+    },
+    "3": {
+        "inputs": {
+            "upscale_model": [
+                "2",
+                0
+            ],
+            "image": [
+                "1",
+                0
+            ]
+        },
+        "class_type": "ImageUpscaleWithModel",
+        "_meta": {
+            "title": "Upscale Image (using Model)"
+        }
+    },
+    "4": {
+        "inputs": {
+            "filename_prefix": "ESRGAN-4x",
+            "images": [
+                "3",
+                0
+            ]
+        },
+        "class_type": "SaveImage",
+        "_meta": {
+            "title": "Save Image"
+        }
+    }
+}

--- a/installer/comfyui/workflows/Hunyuan-Video-1.5_720p_i2v-4-step-lora.json
+++ b/installer/comfyui/workflows/Hunyuan-Video-1.5_720p_i2v-4-step-lora.json
@@ -1,0 +1,283 @@
+{
+  "10": {
+    "inputs": {
+      "vae_name": "hunyuanvideo15_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "11": {
+    "inputs": {
+      "clip_name1": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "clip_name2": "byt5_small_glyphxl_fp16.safetensors",
+      "type": "hunyuan_video_15",
+      "device": "default"
+    },
+    "class_type": "DualCLIPLoader",
+    "_meta": {
+      "title": "DualCLIPLoader"
+    }
+  },
+  "12": {
+    "inputs": {
+      "unet_name": "hunyuanvideo1.5_720p_i2v_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "44": {
+    "inputs": {
+      "text": "Cinematic product showcase of a modern white PC tower with transparent glass side panel. Slow smooth camera orbit from front-left to rear-right, revealing internal components and glowing green RGB fans. Subtle light reflections on glass, soft studio lighting, clean background. Fans spinning gently, RGB breathing effect. Premium tech commercial style, ultra sharp, realistic materials, shallow depth of field, no text, no people.",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "78": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "length": 61,
+      "batch_size": 1,
+      "positive": [
+        "44",
+        0
+      ],
+      "negative": [
+        "93",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ],
+      "start_image": [
+        "80",
+        0
+      ],
+      "clip_vision_output": [
+        "79",
+        0
+      ]
+    },
+    "class_type": "HunyuanVideo15ImageToVideo",
+    "_meta": {
+      "title": "HunyuanVideo15ImageToVideo"
+    }
+  },
+  "79": {
+    "inputs": {
+      "crop": "center",
+      "clip_vision": [
+        "81",
+        0
+      ],
+      "image": [
+        "80",
+        0
+      ]
+    },
+    "class_type": "CLIPVisionEncode",
+    "_meta": {
+      "title": "CLIP Vision Encode"
+    }
+  },
+  "80": {
+    "inputs": {
+      "image": "ai-server-2.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "81": {
+    "inputs": {
+      "clip_name": "sigclip_vision_patch14_384.safetensors"
+    },
+    "class_type": "CLIPVisionLoader",
+    "_meta": {
+      "title": "Load CLIP Vision"
+    }
+  },
+  "93": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "101": {
+    "inputs": {
+      "fps": 24,
+      "images": [
+        "120",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "102": {
+    "inputs": {
+      "filename_prefix": "video/hunyuan_video_1.5",
+      "format": "auto",
+      "codec": "h264",
+      "video": [
+        "101",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "120": {
+    "inputs": {
+      "tile_size": 512,
+      "overlap": 64,
+      "temporal_size": 64,
+      "temporal_overlap": 4096,
+      "samples": [
+        "125",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEDecodeTiled",
+    "_meta": {
+      "title": "VAE Decode (Tiled)"
+    }
+  },
+  "125": {
+    "inputs": {
+      "noise": [
+        "127",
+        0
+      ],
+      "guider": [
+        "129",
+        0
+      ],
+      "sampler": [
+        "128",
+        0
+      ],
+      "sigmas": [
+        "126",
+        0
+      ],
+      "latent_image": [
+        "78",
+        2
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "126": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": 4,
+      "denoise": 1,
+      "model": [
+        "142",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "BasicScheduler"
+    }
+  },
+  "127": {
+    "inputs": {
+      "noise_seed": 887963123424675
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "128": {
+    "inputs": {
+      "sampler_name": "euler"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "129": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "130",
+        0
+      ],
+      "positive": [
+        "78",
+        0
+      ],
+      "negative": [
+        "78",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "130": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "142",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "142": {
+    "inputs": {
+      "lora_name": "hunyuanvideo1.5_t2v_480p_lightx2v_4step_lora_rank_32_bf16.safetensors",
+      "strength_model": 1,
+      "model": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Hunyuan-Video-1.5_720p_t2v-4-step-lora.json
+++ b/installer/comfyui/workflows/Hunyuan-Video-1.5_720p_t2v-4-step-lora.json
@@ -1,0 +1,245 @@
+{
+  "8": {
+    "inputs": {
+      "samples": [
+        "127",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "10": {
+    "inputs": {
+      "vae_name": "hunyuanvideo15_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "11": {
+    "inputs": {
+      "clip_name1": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "clip_name2": "byt5_small_glyphxl_fp16.safetensors",
+      "type": "hunyuan_video_15",
+      "device": "default"
+    },
+    "class_type": "DualCLIPLoader",
+    "_meta": {
+      "title": "DualCLIPLoader"
+    }
+  },
+  "12": {
+    "inputs": {
+      "unet_name": "hunyuanvideo1.5_720p_t2v_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "44": {
+    "inputs": {
+      "text": "A paper airplane released from the top of a skyscraper, gliding through urban canyons, crossing traffic, flying over streets, spiraling upward between buildings. The camera follows the paper airplane's perspective, shooting cityscape in first-person POV, finally flying toward the sunset, disappearing in golden light. Creative camera movement, free perspective, dreamlike colors.",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "93": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "11",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "101": {
+    "inputs": {
+      "fps": 24,
+      "images": [
+        "120",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "102": {
+    "inputs": {
+      "filename_prefix": "video/hunyuan_video_1.5",
+      "format": "auto",
+      "codec": "h264",
+      "video-preview": "",
+      "video": [
+        "101",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "120": {
+    "inputs": {
+      "tile_size": 512,
+      "overlap": 64,
+      "temporal_size": 64,
+      "temporal_overlap": 8,
+      "samples": [
+        "127",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEDecodeTiled",
+    "_meta": {
+      "title": "VAE Decode (Tiled)"
+    }
+  },
+  "124": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "length": 61,
+      "batch_size": 1
+    },
+    "class_type": "EmptyHunyuanVideo15Latent",
+    "_meta": {
+      "title": "Empty HunyuanVideo 1.5 Latent"
+    }
+  },
+  "127": {
+    "inputs": {
+      "noise": [
+        "129",
+        0
+      ],
+      "guider": [
+        "131",
+        0
+      ],
+      "sampler": [
+        "130",
+        0
+      ],
+      "sigmas": [
+        "128",
+        0
+      ],
+      "latent_image": [
+        "124",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "128": {
+    "inputs": {
+      "scheduler": "simple",
+      "steps": 4,
+      "denoise": 1,
+      "model": [
+        "148",
+        0
+      ]
+    },
+    "class_type": "BasicScheduler",
+    "_meta": {
+      "title": "BasicScheduler"
+    }
+  },
+  "129": {
+    "inputs": {
+      "noise_seed": 887963123424675
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "130": {
+    "inputs": {
+      "sampler_name": "euler"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "131": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "132",
+        0
+      ],
+      "positive": [
+        "44",
+        0
+      ],
+      "negative": [
+        "93",
+        0
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "132": {
+    "inputs": {
+      "shift": 5,
+      "model": [
+        "148",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "148": {
+    "inputs": {
+      "lora_name": "hunyuanvideo1.5_t2v_480p_lightx2v_4step_lora_rank_32_bf16.safetensors",
+      "strength_model": 1,
+      "model": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  }
+}

--- a/installer/comfyui/workflows/LTX2-I2V-BF16.json
+++ b/installer/comfyui/workflows/LTX2-I2V-BF16.json
@@ -1,0 +1,618 @@
+{
+  "75": {
+    "inputs": {
+      "filename_prefix": "video/LTX_2.0_i2v",
+      "format": "auto",
+      "codec": "auto",
+      "video-preview": "",
+      "video": [
+        "92:97",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "98": {
+    "inputs": {
+      "image": "example2.jpg"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "102": {
+    "inputs": {
+      "resize_type": "scale dimensions",
+      "resize_type.width": 1280,
+      "resize_type.height": 720,
+      "resize_type.crop": "center",
+      "scale_method": "lanczos",
+      "input": [
+        "98",
+        0
+      ]
+    },
+    "class_type": "ResizeImageMaskNode",
+    "_meta": {
+      "title": "Resize Image/Mask"
+    }
+  },
+  "92:8": {
+    "inputs": {
+      "sampler_name": "euler"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "92:9": {
+    "inputs": {
+      "steps": 20,
+      "max_shift": 2.05,
+      "base_shift": 0.95,
+      "stretch": true,
+      "terminal": 0.1,
+      "latent": [
+        "92:56",
+        0
+      ]
+    },
+    "class_type": "LTXVScheduler",
+    "_meta": {
+      "title": "LTXVScheduler"
+    }
+  },
+  "92:60": {
+    "inputs": {
+      "text_encoder": "gemma_3_12B_it_fp4_mixed.safetensors",
+      "ckpt_name": "ltx-2-19b-dev.safetensors",
+      "device": "default"
+    },
+    "class_type": "LTXAVTextEncoderLoader",
+    "_meta": {
+      "title": "LTXV Audio Text Encoder Loader"
+    }
+  },
+  "92:66": {
+    "inputs": {
+      "sampler_name": "gradient_estimation"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "92:73": {
+    "inputs": {
+      "sigmas": "0.909375, 0.725, 0.421875, 0.0"
+    },
+    "class_type": "ManualSigmas",
+    "_meta": {
+      "title": "ManualSigmas"
+    }
+  },
+  "92:76": {
+    "inputs": {
+      "model_name": "ltx-2-spatial-upscaler-x2-1.0.safetensors"
+    },
+    "class_type": "LatentUpscaleModelLoader",
+    "_meta": {
+      "title": "Load Latent Upscale Model"
+    }
+  },
+  "92:81": {
+    "inputs": {
+      "positive": [
+        "92:22",
+        0
+      ],
+      "negative": [
+        "92:22",
+        1
+      ],
+      "latent": [
+        "92:80",
+        0
+      ]
+    },
+    "class_type": "LTXVCropGuides",
+    "_meta": {
+      "title": "LTXVCropGuides"
+    }
+  },
+  "92:82": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "92:68",
+        0
+      ],
+      "positive": [
+        "92:81",
+        0
+      ],
+      "negative": [
+        "92:81",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "92:51": {
+    "inputs": {
+      "frames_number": [
+        "92:62",
+        0
+      ],
+      "frame_rate": 25,
+      "batch_size": 1,
+      "audio_vae": [
+        "92:48",
+        0
+      ]
+    },
+    "class_type": "LTXVEmptyLatentAudio",
+    "_meta": {
+      "title": "LTXV Empty Latent Audio"
+    }
+  },
+  "92:22": {
+    "inputs": {
+      "frame_rate": 25,
+      "positive": [
+        "92:3",
+        0
+      ],
+      "negative": [
+        "92:4",
+        0
+      ]
+    },
+    "class_type": "LTXVConditioning",
+    "_meta": {
+      "title": "LTXVConditioning"
+    }
+  },
+  "92:4": {
+    "inputs": {
+      "text": "blurry, low quality, still frame, frames, watermark, overlay, titles, has blurbox, has subtitles",
+      "clip": [
+        "92:60",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "92:89": {
+    "inputs": {
+      "width": [
+        "92:105",
+        0
+      ],
+      "height": [
+        "92:105",
+        1
+      ],
+      "batch_size": 1,
+      "color": 0
+    },
+    "class_type": "EmptyImage",
+    "_meta": {
+      "title": "EmptyImage"
+    }
+  },
+  "92:41": {
+    "inputs": {
+      "noise": [
+        "92:11",
+        0
+      ],
+      "guider": [
+        "92:47",
+        0
+      ],
+      "sampler": [
+        "92:8",
+        0
+      ],
+      "sigmas": [
+        "92:9",
+        0
+      ],
+      "latent_image": [
+        "92:56",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "92:67": {
+    "inputs": {
+      "noise_seed": 0
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "92:11": {
+    "inputs": {
+      "noise_seed": 10
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "92:3": {
+    "inputs": {
+      "text": "A wide, dynamic tracking shot follows a group of mountain bikers as they race across a pristine snow-covered landscape on a brilliant winter morning. The camera moves at speed, keeping pace with the lead biker in a vibrant yellow jacket and orange helmet, who launches into the air over a snow mound, their bike suspended against the clear blue sky. Snow particles explode around them, catching the golden light of the low sun that creates dramatic backlighting and long shadows across the terrain. Several other bikers follow closely behind, their dark silhouettes kicking up plumes of powdery snow as they navigate the undulating mounds. The only sounds are the crunch of tires biting into packed snow, the whoosh of air as they fly through jumps, and the distant sound of heavy breathing and excited shouts. One biker calls out to another with exhilaration: “This is incredible! The light is perfect!” Another responds with a breathless laugh: “Keep pushing! We’re almost at the ridge!” The camera glides smoothly alongside the group, occasionally pulling back to reveal the full expanse of the snowy landscape with bare birch trees and dark evergreens lining the edge. The mood is exhilarating, fast-paced, and full of the raw energy of winter mountain biking, with every jump and turn captured in crisp detail against the brilliant white snow and vibrant sky.\n",
+      "clip": [
+        "92:60",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "92:97": {
+    "inputs": {
+      "fps": 25,
+      "images": [
+        "92:95",
+        0
+      ],
+      "audio": [
+        "92:96",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "92:80": {
+    "inputs": {
+      "av_latent": [
+        "92:41",
+        0
+      ]
+    },
+    "class_type": "LTXVSeparateAVLatent",
+    "_meta": {
+      "title": "LTXVSeparateAVLatent"
+    }
+  },
+  "92:94": {
+    "inputs": {
+      "av_latent": [
+        "92:70",
+        1
+      ]
+    },
+    "class_type": "LTXVSeparateAVLatent",
+    "_meta": {
+      "title": "LTXVSeparateAVLatent"
+    }
+  },
+  "92:70": {
+    "inputs": {
+      "noise": [
+        "92:67",
+        0
+      ],
+      "guider": [
+        "92:82",
+        0
+      ],
+      "sampler": [
+        "92:66",
+        0
+      ],
+      "sigmas": [
+        "92:73",
+        0
+      ],
+      "latent_image": [
+        "92:83",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "92:96": {
+    "inputs": {
+      "samples": [
+        "92:94",
+        1
+      ],
+      "audio_vae": [
+        "92:48",
+        0
+      ]
+    },
+    "class_type": "LTXVAudioVAEDecode",
+    "_meta": {
+      "title": "LTXV Audio VAE Decode"
+    }
+  },
+  "92:48": {
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-dev.safetensors"
+    },
+    "class_type": "LTXVAudioVAELoader",
+    "_meta": {
+      "title": "LTXV Audio VAE Loader"
+    }
+  },
+  "92:56": {
+    "inputs": {
+      "video_latent": [
+        "92:107",
+        0
+      ],
+      "audio_latent": [
+        "92:51",
+        0
+      ]
+    },
+    "class_type": "LTXVConcatAVLatent",
+    "_meta": {
+      "title": "LTXVConcatAVLatent"
+    }
+  },
+  "92:84": {
+    "inputs": {
+      "samples": [
+        "92:81",
+        2
+      ],
+      "upscale_model": [
+        "92:76",
+        0
+      ],
+      "vae": [
+        "92:1",
+        2
+      ]
+    },
+    "class_type": "LTXVLatentUpsampler",
+    "_meta": {
+      "title": "spatial"
+    }
+  },
+  "92:90": {
+    "inputs": {
+      "upscale_method": "lanczos",
+      "scale_by": 0.5,
+      "image": [
+        "92:89",
+        0
+      ]
+    },
+    "class_type": "ImageScaleBy",
+    "_meta": {
+      "title": "Upscale Image By"
+    }
+  },
+  "92:62": {
+    "inputs": {
+      "value": 121
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "Length"
+    }
+  },
+  "92:91": {
+    "inputs": {
+      "image": [
+        "92:90",
+        0
+      ]
+    },
+    "class_type": "GetImageSize",
+    "_meta": {
+      "title": "Get Image Size"
+    }
+  },
+  "92:105": {
+    "inputs": {
+      "image": [
+        "102",
+        0
+      ]
+    },
+    "class_type": "GetImageSize",
+    "_meta": {
+      "title": "Get Image Size"
+    }
+  },
+  "92:99": {
+    "inputs": {
+      "img_compression": 33,
+      "image": [
+        "92:106",
+        0
+      ]
+    },
+    "class_type": "LTXVPreprocess",
+    "_meta": {
+      "title": "LTXVPreprocess"
+    }
+  },
+  "92:43": {
+    "inputs": {
+      "width": [
+        "92:91",
+        0
+      ],
+      "height": [
+        "92:91",
+        1
+      ],
+      "length": [
+        "92:62",
+        0
+      ],
+      "batch_size": 1
+    },
+    "class_type": "EmptyLTXVLatentVideo",
+    "_meta": {
+      "title": "EmptyLTXVLatentVideo"
+    }
+  },
+  "92:107": {
+    "inputs": {
+      "strength": 1,
+      "bypass": false,
+      "vae": [
+        "92:1",
+        2
+      ],
+      "image": [
+        "92:99",
+        0
+      ],
+      "latent": [
+        "92:43",
+        0
+      ]
+    },
+    "class_type": "LTXVImgToVideoInplace",
+    "_meta": {
+      "title": "LTXVImgToVideoInplace"
+    }
+  },
+  "92:83": {
+    "inputs": {
+      "video_latent": [
+        "92:108",
+        0
+      ],
+      "audio_latent": [
+        "92:80",
+        1
+      ]
+    },
+    "class_type": "LTXVConcatAVLatent",
+    "_meta": {
+      "title": "LTXVConcatAVLatent"
+    }
+  },
+  "92:108": {
+    "inputs": {
+      "strength": 1,
+      "bypass": false,
+      "vae": [
+        "92:1",
+        2
+      ],
+      "image": [
+        "92:99",
+        0
+      ],
+      "latent": [
+        "92:84",
+        0
+      ]
+    },
+    "class_type": "LTXVImgToVideoInplace",
+    "_meta": {
+      "title": "LTXVImgToVideoInplace"
+    }
+  },
+  "92:47": {
+    "inputs": {
+      "cfg": 4,
+      "model": [
+        "92:1",
+        0
+      ],
+      "positive": [
+        "92:22",
+        0
+      ],
+      "negative": [
+        "92:22",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "92:68": {
+    "inputs": {
+      "lora_name": "ltx-2-19b-distilled-lora-384.safetensors",
+      "strength_model": 1,
+      "model": [
+        "92:1",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "92:106": {
+    "inputs": {
+      "longer_edge": 1536,
+      "images": [
+        "102",
+        0
+      ]
+    },
+    "class_type": "ResizeImagesByLongerEdge",
+    "_meta": {
+      "title": "Resize Images by Longer Edge"
+    }
+  },
+  "92:1": {
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-dev.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "92:95": {
+    "inputs": {
+      "samples": [
+        "92:94",
+        0
+      ],
+      "vae": [
+        "92:1",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  }
+}

--- a/installer/comfyui/workflows/LTX2-T2V-BF16.json
+++ b/installer/comfyui/workflows/LTX2-T2V-BF16.json
@@ -1,0 +1,535 @@
+{
+  "75": {
+    "inputs": {
+      "filename_prefix": "video/LTX-2",
+      "format": "mp4",
+      "codec": "auto",
+      "video-preview": "",
+      "video": [
+        "92:97",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "92:9": {
+    "inputs": {
+      "steps": 20,
+      "max_shift": 2.05,
+      "base_shift": 0.95,
+      "stretch": true,
+      "terminal": 0.1,
+      "latent": [
+        "92:56",
+        0
+      ]
+    },
+    "class_type": "LTXVScheduler",
+    "_meta": {
+      "title": "LTXVScheduler"
+    }
+  },
+  "92:73": {
+    "inputs": {
+      "sigmas": "0.909375, 0.725, 0.421875, 0.0"
+    },
+    "class_type": "ManualSigmas",
+    "_meta": {
+      "title": "ManualSigmas"
+    }
+  },
+  "92:76": {
+    "inputs": {
+      "model_name": "ltx-2-spatial-upscaler-x2-1.0.safetensors"
+    },
+    "class_type": "LatentUpscaleModelLoader",
+    "_meta": {
+      "title": "Load Latent Upscale Model"
+    }
+  },
+  "92:81": {
+    "inputs": {
+      "positive": [
+        "92:22",
+        0
+      ],
+      "negative": [
+        "92:22",
+        1
+      ],
+      "latent": [
+        "92:80",
+        0
+      ]
+    },
+    "class_type": "LTXVCropGuides",
+    "_meta": {
+      "title": "LTXVCropGuides"
+    }
+  },
+  "92:82": {
+    "inputs": {
+      "cfg": 1,
+      "model": [
+        "92:68",
+        0
+      ],
+      "positive": [
+        "92:81",
+        0
+      ],
+      "negative": [
+        "92:81",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "92:90": {
+    "inputs": {
+      "upscale_method": "lanczos",
+      "scale_by": 0.5,
+      "image": [
+        "92:89",
+        0
+      ]
+    },
+    "class_type": "ImageScaleBy",
+    "_meta": {
+      "title": "Upscale Image By"
+    }
+  },
+  "92:91": {
+    "inputs": {
+      "image": [
+        "92:90",
+        0
+      ]
+    },
+    "class_type": "GetImageSize",
+    "_meta": {
+      "title": "Get Image Size"
+    }
+  },
+  "92:51": {
+    "inputs": {
+      "frames_number": [
+        "92:62",
+        0
+      ],
+      "frame_rate": [
+        "92:99",
+        0
+      ],
+      "batch_size": 1,
+      "audio_vae": [
+        "92:48",
+        0
+      ]
+    },
+    "class_type": "LTXVEmptyLatentAudio",
+    "_meta": {
+      "title": "LTXV Empty Latent Audio"
+    }
+  },
+  "92:22": {
+    "inputs": {
+      "frame_rate": [
+        "92:102",
+        0
+      ],
+      "positive": [
+        "92:3",
+        0
+      ],
+      "negative": [
+        "92:4",
+        0
+      ]
+    },
+    "class_type": "LTXVConditioning",
+    "_meta": {
+      "title": "LTXVConditioning"
+    }
+  },
+  "92:43": {
+    "inputs": {
+      "width": [
+        "92:91",
+        0
+      ],
+      "height": [
+        "92:91",
+        1
+      ],
+      "length": [
+        "92:62",
+        0
+      ],
+      "batch_size": 1
+    },
+    "class_type": "EmptyLTXVLatentVideo",
+    "_meta": {
+      "title": "EmptyLTXVLatentVideo"
+    }
+  },
+  "92:56": {
+    "inputs": {
+      "video_latent": [
+        "92:43",
+        0
+      ],
+      "audio_latent": [
+        "92:51",
+        0
+      ]
+    },
+    "class_type": "LTXVConcatAVLatent",
+    "_meta": {
+      "title": "LTXVConcatAVLatent"
+    }
+  },
+  "92:4": {
+    "inputs": {
+      "text": "blurry, low quality, still frame, frames, watermark, overlay, titles, has blurbox, has subtitles",
+      "clip": [
+        "92:60",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "92:89": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "batch_size": 1,
+      "color": 0
+    },
+    "class_type": "EmptyImage",
+    "_meta": {
+      "title": "EmptyImage"
+    }
+  },
+  "92:62": {
+    "inputs": {
+      "value": 121
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "Length"
+    }
+  },
+  "92:41": {
+    "inputs": {
+      "noise": [
+        "92:11",
+        0
+      ],
+      "guider": [
+        "92:47",
+        0
+      ],
+      "sampler": [
+        "92:8",
+        0
+      ],
+      "sigmas": [
+        "92:9",
+        0
+      ],
+      "latent_image": [
+        "92:56",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "92:67": {
+    "inputs": {
+      "noise_seed": 0
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "92:11": {
+    "inputs": {
+      "noise_seed": 10
+    },
+    "class_type": "RandomNoise",
+    "_meta": {
+      "title": "RandomNoise"
+    }
+  },
+  "92:80": {
+    "inputs": {
+      "av_latent": [
+        "92:41",
+        0
+      ]
+    },
+    "class_type": "LTXVSeparateAVLatent",
+    "_meta": {
+      "title": "LTXVSeparateAVLatent"
+    }
+  },
+  "92:83": {
+    "inputs": {
+      "video_latent": [
+        "92:84",
+        0
+      ],
+      "audio_latent": [
+        "92:80",
+        1
+      ]
+    },
+    "class_type": "LTXVConcatAVLatent",
+    "_meta": {
+      "title": "LTXVConcatAVLatent"
+    }
+  },
+  "92:84": {
+    "inputs": {
+      "samples": [
+        "92:81",
+        2
+      ],
+      "upscale_model": [
+        "92:76",
+        0
+      ],
+      "vae": [
+        "92:1",
+        2
+      ]
+    },
+    "class_type": "LTXVLatentUpsampler",
+    "_meta": {
+      "title": "spatial"
+    }
+  },
+  "92:70": {
+    "inputs": {
+      "noise": [
+        "92:67",
+        0
+      ],
+      "guider": [
+        "92:82",
+        0
+      ],
+      "sampler": [
+        "92:66",
+        0
+      ],
+      "sigmas": [
+        "92:73",
+        0
+      ],
+      "latent_image": [
+        "92:83",
+        0
+      ]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {
+      "title": "SamplerCustomAdvanced"
+    }
+  },
+  "92:3": {
+    "inputs": {
+      "text": "A close-up of a cheerful girl puppet with curly auburn yarn hair and wide button eyes, holding a small red umbrella above her head. Rain falls gently around her. She looks upward and begins to sing with joy in English: \"It's raining, it's raining, I love it when its raining.\" Her fabric mouth opening and closing to a melodic tune. Her hands grip the umbrella handle as she sways slightly from side to side in rhythm. The camera holds steady as the rain sparkles against the soft lighting. Her eyes blink occasionally as she sings.",
+      "clip": [
+        "92:60",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "92:97": {
+    "inputs": {
+      "fps": [
+        "92:102",
+        0
+      ],
+      "images": [
+        "92:98",
+        0
+      ],
+      "audio": [
+        "92:96",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "92:94": {
+    "inputs": {
+      "av_latent": [
+        "92:70",
+        1
+      ]
+    },
+    "class_type": "LTXVSeparateAVLatent",
+    "_meta": {
+      "title": "LTXVSeparateAVLatent"
+    }
+  },
+  "92:98": {
+    "inputs": {
+      "tile_size": 512,
+      "overlap": 64,
+      "temporal_size": 4096,
+      "temporal_overlap": 8,
+      "samples": [
+        "92:94",
+        0
+      ],
+      "vae": [
+        "92:1",
+        2
+      ]
+    },
+    "class_type": "VAEDecodeTiled",
+    "_meta": {
+      "title": "VAE Decode (Tiled)"
+    }
+  },
+  "92:96": {
+    "inputs": {
+      "samples": [
+        "92:94",
+        1
+      ],
+      "audio_vae": [
+        "92:48",
+        0
+      ]
+    },
+    "class_type": "LTXVAudioVAEDecode",
+    "_meta": {
+      "title": "LTXV Audio VAE Decode"
+    }
+  },
+  "92:47": {
+    "inputs": {
+      "cfg": 4,
+      "model": [
+        "92:1",
+        0
+      ],
+      "positive": [
+        "92:22",
+        0
+      ],
+      "negative": [
+        "92:22",
+        1
+      ]
+    },
+    "class_type": "CFGGuider",
+    "_meta": {
+      "title": "CFGGuider"
+    }
+  },
+  "92:102": {
+    "inputs": {
+      "value": 24
+    },
+    "class_type": "PrimitiveFloat",
+    "_meta": {
+      "title": "Frame Rate(float)"
+    }
+  },
+  "92:99": {
+    "inputs": {
+      "value": 24
+    },
+    "class_type": "PrimitiveInt",
+    "_meta": {
+      "title": "Frame Rate(int)"
+    }
+  },
+  "92:68": {
+    "inputs": {
+      "lora_name": "ltx-2-19b-distilled-lora-384.safetensors",
+      "strength_model": 1,
+      "model": [
+        "92:1",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "92:8": {
+    "inputs": {
+      "sampler_name": "euler_ancestral"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "92:66": {
+    "inputs": {
+      "sampler_name": "euler_ancestral"
+    },
+    "class_type": "KSamplerSelect",
+    "_meta": {
+      "title": "KSamplerSelect"
+    }
+  },
+  "92:60": {
+    "inputs": {
+      "text_encoder": "gemma_3_12B_it_fp4_mixed.safetensors",
+      "ckpt_name": "ltx-2-19b-dev.safetensors",
+      "device": "default"
+    },
+    "class_type": "LTXAVTextEncoderLoader",
+    "_meta": {
+      "title": "LTXV Audio Text Encoder Loader"
+    }
+  },
+  "92:1": {
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-dev.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "92:48": {
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-dev.safetensors"
+    },
+    "class_type": "LTXVAudioVAELoader",
+    "_meta": {
+      "title": "LTXV Audio VAE Loader"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Qwen-Image-2512-BF16-20-Steps.json
+++ b/installer/comfyui/workflows/Qwen-Image-2512-BF16-20-Steps.json
@@ -1,0 +1,141 @@
+{
+  "3": {
+    "inputs": {
+      "seed": 274481695318855,
+      "steps": 20,
+      "cfg": 2.5,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "66",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "58",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "Cinematic close-up of a futuristic CPU on a high-end motherboard, intense electric sparks flowing between circuits, ultra-detailed microchips, dramatic cyberpunk lighting, high contrast, metallic textures with reflections, shallow depth of field, sci-fi technology photography, sharp focus, no text.\n",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "qwen_image_2512_bf16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "58": {
+    "inputs": {
+      "width": 1328,
+      "height": 1328,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "EmptySD3LatentImage"
+    }
+  },
+  "60": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "66": {
+    "inputs": {
+      "shift": 3.1000000000000005,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Qwen-Image-2512-BF16-4-Step-LoRA.json
+++ b/installer/comfyui/workflows/Qwen-Image-2512-BF16-4-Step-LoRA.json
@@ -1,0 +1,155 @@
+{
+  "3": {
+    "inputs": {
+      "seed": 695101294492382,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "66",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "58",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "Cinematic close-up of a futuristic CPU on a high-end motherboard, intense electric sparks flowing between circuits, ultra-detailed microchips, dramatic cyberpunk lighting, high contrast, metallic textures with reflections, shallow depth of field, sci-fi technology photography, sharp focus, no text.\n",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "qwen_image_2512_bf16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "58": {
+    "inputs": {
+      "width": 1328,
+      "height": 1328,
+      "batch_size": 1
+    },
+    "class_type": "EmptySD3LatentImage",
+    "_meta": {
+      "title": "EmptySD3LatentImage"
+    }
+  },
+  "60": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "66": {
+    "inputs": {
+      "shift": 3.1000000000000005,
+      "model": [
+        "73",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "73": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Qwen-Image-Edit-2511-BF16-20-Steps.json
+++ b/installer/comfyui/workflows/Qwen-Image-Edit-2511-BF16-20-Steps.json
@@ -1,0 +1,225 @@
+{
+  "8": {
+    "inputs": {
+      "samples": [
+        "65",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "10": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "12": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2511_bf16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "41": {
+    "inputs": {
+      "image": "ai-server.jpg"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "61": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "64": {
+    "inputs": {
+      "strength": 1,
+      "model": [
+        "67",
+        0
+      ]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "65": {
+    "inputs": {
+      "seed": 1051543365768624,
+      "steps": 20,
+      "cfg": 4,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "64",
+        0
+      ],
+      "positive": [
+        "70",
+        0
+      ],
+      "negative": [
+        "71",
+        0
+      ],
+      "latent_image": [
+        "75",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "67": {
+    "inputs": {
+      "shift": 3.1,
+      "model": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "68": {
+    "inputs": {
+      "prompt": "Turn this into a professional marketing photo of the server. Remove all cables, wires, and background objects so only the server remains. Place it on a clean white or light gray studio background.\n",
+      "clip": [
+        "61",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ],
+      "image1": [
+        "79",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "TextEncodeQwenImageEditPlus (Positive)"
+    }
+  },
+  "69": {
+    "inputs": {
+      "prompt": "",
+      "clip": [
+        "61",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ],
+      "image1": [
+        "79",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "TextEncodeQwenImageEditPlus"
+    }
+  },
+  "70": {
+    "inputs": {
+      "reference_latents_method": "index_timestep_zero",
+      "conditioning": [
+        "68",
+        0
+      ]
+    },
+    "class_type": "FluxKontextMultiReferenceLatentMethod",
+    "_meta": {
+      "title": "Edit Model Reference Method"
+    }
+  },
+  "71": {
+    "inputs": {
+      "reference_latents_method": "index_timestep_zero",
+      "conditioning": [
+        "69",
+        0
+      ]
+    },
+    "class_type": "FluxKontextMultiReferenceLatentMethod",
+    "_meta": {
+      "title": "Edit Model Reference Method"
+    }
+  },
+  "75": {
+    "inputs": {
+      "pixels": [
+        "79",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "VAE Encode"
+    }
+  },
+  "79": {
+    "inputs": {
+      "upscale_method": "lanczos",
+      "megapixels": 1.6,
+      "resolution_steps": 1,
+      "image": [
+        "41",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "ImageScaleToTotalPixels"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Qwen-Image-Edit-2511-BF16-4-Step-LoRA.json
+++ b/installer/comfyui/workflows/Qwen-Image-Edit-2511-BF16-4-Step-LoRA.json
@@ -1,0 +1,239 @@
+{
+  "8": {
+    "inputs": {
+      "samples": [
+        "65",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "10": {
+    "inputs": {
+      "vae_name": "qwen_image_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "12": {
+    "inputs": {
+      "unet_name": "qwen_image_edit_2511_bf16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "41": {
+    "inputs": {
+      "image": "ai-server.jpg"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "61": {
+    "inputs": {
+      "clip_name": "qwen_2.5_vl_7b_fp8_scaled.safetensors",
+      "type": "qwen_image",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "64": {
+    "inputs": {
+      "strength": 1,
+      "model": [
+        "67",
+        0
+      ]
+    },
+    "class_type": "CFGNorm",
+    "_meta": {
+      "title": "CFGNorm"
+    }
+  },
+  "65": {
+    "inputs": {
+      "seed": 224883477692338,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "64",
+        0
+      ],
+      "positive": [
+        "70",
+        0
+      ],
+      "negative": [
+        "71",
+        0
+      ],
+      "latent_image": [
+        "75",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "67": {
+    "inputs": {
+      "shift": 3.1,
+      "model": [
+        "74",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingAuraFlow",
+    "_meta": {
+      "title": "ModelSamplingAuraFlow"
+    }
+  },
+  "68": {
+    "inputs": {
+      "prompt": "Turn this into a professional marketing photo of the server. Remove all cables, wires, and background objects so only the server remains. Place it on a clean white or light gray studio background.\n",
+      "clip": [
+        "61",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ],
+      "image1": [
+        "79",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "TextEncodeQwenImageEditPlus (Positive)"
+    }
+  },
+  "69": {
+    "inputs": {
+      "prompt": "",
+      "clip": [
+        "61",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ],
+      "image1": [
+        "79",
+        0
+      ]
+    },
+    "class_type": "TextEncodeQwenImageEditPlus",
+    "_meta": {
+      "title": "TextEncodeQwenImageEditPlus"
+    }
+  },
+  "70": {
+    "inputs": {
+      "reference_latents_method": "index_timestep_zero",
+      "conditioning": [
+        "68",
+        0
+      ]
+    },
+    "class_type": "FluxKontextMultiReferenceLatentMethod",
+    "_meta": {
+      "title": "Edit Model Reference Method"
+    }
+  },
+  "71": {
+    "inputs": {
+      "reference_latents_method": "index_timestep_zero",
+      "conditioning": [
+        "69",
+        0
+      ]
+    },
+    "class_type": "FluxKontextMultiReferenceLatentMethod",
+    "_meta": {
+      "title": "Edit Model Reference Method"
+    }
+  },
+  "74": {
+    "inputs": {
+      "lora_name": "Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors",
+      "strength_model": 1,
+      "model": [
+        "12",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "75": {
+    "inputs": {
+      "pixels": [
+        "79",
+        0
+      ],
+      "vae": [
+        "10",
+        0
+      ]
+    },
+    "class_type": "VAEEncode",
+    "_meta": {
+      "title": "VAE Encode"
+    }
+  },
+  "79": {
+    "inputs": {
+      "upscale_method": "lanczos",
+      "megapixels": 1.6,
+      "resolution_steps": 1,
+      "image": [
+        "41",
+        0
+      ]
+    },
+    "class_type": "ImageScaleToTotalPixels",
+    "_meta": {
+      "title": "ImageScaleToTotalPixels"
+    }
+  }
+}

--- a/installer/comfyui/workflows/SDXL-Lightning-8step.json
+++ b/installer/comfyui/workflows/SDXL-Lightning-8step.json
@@ -1,0 +1,135 @@
+{
+    "4": {
+        "inputs": {
+            "ckpt_name": "sd_xl_base_1.0.safetensors"
+        },
+        "class_type": "CheckpointLoaderSimple",
+        "_meta": {
+            "title": "Load Checkpoint"
+        }
+    },
+    "10": {
+        "inputs": {
+            "lora_name": "sdxl_lightning_8step_lora.safetensors",
+            "strength_model": 1.0,
+            "strength_clip": 1.0,
+            "model": [
+                "4",
+                0
+            ],
+            "clip": [
+                "4",
+                1
+            ]
+        },
+        "class_type": "LoraLoader",
+        "_meta": {
+            "title": "Load SDXL-Lightning 8-step LoRA"
+        }
+    },
+    "6": {
+        "inputs": {
+            "text": "a cinematic photo of a futuristic city at golden hour, ultra detailed, sharp focus",
+            "clip": [
+                "10",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+            "title": "CLIP Text Encode (Positive Prompt)"
+        }
+    },
+    "7": {
+        "inputs": {
+            "text": "text, watermark, blurry, low quality",
+            "clip": [
+                "10",
+                1
+            ]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+            "title": "CLIP Text Encode (Negative Prompt)"
+        }
+    },
+    "5": {
+        "inputs": {
+            "width": 1024,
+            "height": 1024,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": {
+            "title": "Empty Latent Image"
+        }
+    },
+    "3": {
+        "inputs": {
+            "seed": 42,
+            "steps": 8,
+            "cfg": 1.0,
+            "sampler_name": "euler",
+            "scheduler": "sgm_uniform",
+            "denoise": 1.0,
+            "model": [
+                "10",
+                0
+            ],
+            "positive": [
+                "6",
+                0
+            ],
+            "negative": [
+                "7",
+                0
+            ],
+            "latent_image": [
+                "5",
+                0
+            ]
+        },
+        "class_type": "KSampler",
+        "_meta": {
+            "title": "KSampler"
+        }
+    },
+    "11": {
+        "inputs": {
+            "vae_name": "sdxl_vae_fp16_fix.safetensors"
+        },
+        "class_type": "VAELoader",
+        "_meta": {
+            "title": "Load VAE (fp16-fix)"
+        }
+    },
+    "8": {
+        "inputs": {
+            "samples": [
+                "3",
+                0
+            ],
+            "vae": [
+                "11",
+                0
+            ]
+        },
+        "class_type": "VAEDecode",
+        "_meta": {
+            "title": "VAE Decode"
+        }
+    },
+    "9": {
+        "inputs": {
+            "filename_prefix": "SDXL-Lightning",
+            "images": [
+                "8",
+                0
+            ]
+        },
+        "class_type": "SaveImage",
+        "_meta": {
+            "title": "Save Image"
+        }
+    }
+}

--- a/installer/comfyui/workflows/Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1-FP16.json
+++ b/installer/comfyui/workflows/Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1-FP16.json
@@ -1,0 +1,270 @@
+{
+  "6": {
+    "inputs": {
+      "text": "Cinematic product showcase of a modern white PC tower with transparent glass side panel. Slow smooth camera orbit from front-left to rear-right, revealing internal components and glowing green RGB fans. Subtle light reflections on glass, soft studio lighting, clean background. Fans spinning gently, RGB breathing effect. Premium tech commercial style, ultra sharp, realistic materials, shallow depth of field, no text, no people.",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "58",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_high_noise_14B_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "umt5_xxl_fp16.safetensors",
+      "type": "wan",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "54": {
+    "inputs": {
+      "shift": 5.000000000000001,
+      "model": [
+        "67",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "55": {
+    "inputs": {
+      "shift": 5.000000000000001,
+      "model": [
+        "68",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "56": {
+    "inputs": {
+      "unet_name": "wan2.2_i2v_low_noise_14B_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "57": {
+    "inputs": {
+      "add_noise": "enable",
+      "noise_seed": 42,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 0,
+      "end_at_step": 2,
+      "return_with_leftover_noise": "enable",
+      "model": [
+        "54",
+        0
+      ],
+      "positive": [
+        "73",
+        0
+      ],
+      "negative": [
+        "73",
+        1
+      ],
+      "latent_image": [
+        "73",
+        2
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced)"
+    }
+  },
+  "58": {
+    "inputs": {
+      "add_noise": "disable",
+      "noise_seed": 42,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 2,
+      "end_at_step": 4,
+      "return_with_leftover_noise": "disable",
+      "model": [
+        "55",
+        0
+      ],
+      "positive": [
+        "73",
+        0
+      ],
+      "negative": [
+        "73",
+        1
+      ],
+      "latent_image": [
+        "57",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced)"
+    }
+  },
+  "60": {
+    "inputs": {
+      "fps": 16,
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "61": {
+    "inputs": {
+      "filename_prefix": "WanVideo2_2_I2V_Lightning",
+      "format": "mp4",
+      "codec": "h264",
+      "video-preview": "",
+      "video": [
+        "60",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "67": {
+    "inputs": {
+      "lora_name": "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/high_noise_model.safetensors",
+      "strength_model": 1.0000000000000002,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "68": {
+    "inputs": {
+      "lora_name": "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1/low_noise_model.safetensors",
+      "strength_model": 1.0000000000000002,
+      "model": [
+        "56",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "71": {
+    "inputs": {
+      "image": "ai-server-2.png"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "73": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "length": 41,
+      "batch_size": 1,
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ],
+      "start_image": [
+        "71",
+        0
+      ]
+    },
+    "class_type": "WanImageToVideo",
+    "_meta": {
+      "title": "WanImageToVideo"
+    }
+  }
+}

--- a/installer/comfyui/workflows/Wan2.2-T2V-A14B-FP16-4steps-lora-rank64-Seko-V2.json
+++ b/installer/comfyui/workflows/Wan2.2-T2V-A14B-FP16-4steps-lora-rank64-Seko-V2.json
@@ -1,0 +1,244 @@
+{
+  "6": {
+    "inputs": {
+      "text": "Static camera shot, wide shot, sunrise time, side lighting, warm colors. A dinosaur runs swiftly through a savanna, sunlight casting long shadows on the grassy terrain. The lions cower and scatter as the dinosaur approaches, bushes and trees swaying slightly in the breeze. The sky is a beautiful blend of orange and pink hues, highlighting the dramatic scene.",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "",
+      "clip": [
+        "38",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "58",
+        0
+      ],
+      "vae": [
+        "39",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "37": {
+    "inputs": {
+      "unet_name": "wan2.2_t2v_high_noise_14B_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "38": {
+    "inputs": {
+      "clip_name": "umt5_xxl_fp16.safetensors",
+      "type": "wan",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load CLIP"
+    }
+  },
+  "39": {
+    "inputs": {
+      "vae_name": "wan_2.1_vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "54": {
+    "inputs": {
+      "shift": 5.000000000000001,
+      "model": [
+        "67",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "55": {
+    "inputs": {
+      "shift": 5.000000000000001,
+      "model": [
+        "68",
+        0
+      ]
+    },
+    "class_type": "ModelSamplingSD3",
+    "_meta": {
+      "title": "ModelSamplingSD3"
+    }
+  },
+  "56": {
+    "inputs": {
+      "unet_name": "wan2.2_t2v_low_noise_14B_fp16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "57": {
+    "inputs": {
+      "add_noise": "enable",
+      "noise_seed": 42,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 0,
+      "end_at_step": 2,
+      "return_with_leftover_noise": "enable",
+      "model": [
+        "54",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "59",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced)"
+    }
+  },
+  "58": {
+    "inputs": {
+      "add_noise": "disable",
+      "noise_seed": 42,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "start_at_step": 2,
+      "end_at_step": 4,
+      "return_with_leftover_noise": "disable",
+      "model": [
+        "55",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "57",
+        0
+      ]
+    },
+    "class_type": "KSamplerAdvanced",
+    "_meta": {
+      "title": "KSampler (Advanced)"
+    }
+  },
+  "59": {
+    "inputs": {
+      "width": 1280,
+      "height": 720,
+      "length": 41,
+      "batch_size": 1
+    },
+    "class_type": "EmptyHunyuanLatentVideo",
+    "_meta": {
+      "title": "Empty HunyuanVideo 1.0 Latent"
+    }
+  },
+  "60": {
+    "inputs": {
+      "fps": 16,
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "CreateVideo",
+    "_meta": {
+      "title": "Create Video"
+    }
+  },
+  "61": {
+    "inputs": {
+      "filename_prefix": "WanVideo2_2_T2V_Lightning",
+      "format": "mp4",
+      "codec": "h264",
+      "video": [
+        "60",
+        0
+      ]
+    },
+    "class_type": "SaveVideo",
+    "_meta": {
+      "title": "Save Video"
+    }
+  },
+  "67": {
+    "inputs": {
+      "lora_name": "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V2.0/high_noise_model.safetensors",
+      "strength_model": 1.0000000000000002,
+      "model": [
+        "37",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  },
+  "68": {
+    "inputs": {
+      "lora_name": "Wan2.2-T2V-A14B-4steps-lora-rank64-Seko-V2.0/low_noise_model.safetensors",
+      "strength_model": 1.0000000000000002,
+      "model": [
+        "56",
+        0
+      ]
+    },
+    "class_type": "LoraLoaderModelOnly",
+    "_meta": {
+      "title": "LoraLoaderModelOnly"
+    }
+  }
+}

--- a/src/hal0/comfyui/fetch.py
+++ b/src/hal0/comfyui/fetch.py
@@ -10,12 +10,24 @@ MULTIPLE invocations per variant.  fetch_steps on ModelVariant encodes the
 exact argv for each invocation; a background worker iterates them
 sequentially, stopping on the first nonzero exit.
 
+Fix #1110 (WS-G): the ``get_*.sh`` scripts run as HOST subprocesses but used
+to hard-code the ComfyUI container's ``hf`` path (``/opt/venv/bin/hf``), so
+every download failed with "no such file"; and no HF credential was ever
+forwarded.  The scripts now resolve ``hf`` from the host PATH (falling back to
+the container venv path), and this wrapper forwards ``HF_TOKEN`` /
+``HF_HOME`` (the token source plumbed in #1094) into each subprocess env so
+gated repos authenticate.  Selecting a variant also provisions its matching
+curated workflow JSON into the ComfyUI workflows dir so it is launchable.
+
 fetch_model returns immediately so POST /api/comfyui/models/fetch can reply
 202 without blocking the FastAPI request for a multi-hour download.
 """
 
 from __future__ import annotations
 
+import logging
+import os
+import shutil
 import subprocess
 import threading
 import uuid
@@ -23,13 +35,88 @@ from pathlib import Path
 
 from hal0.comfyui.capabilities import ModelVariant
 
+log = logging.getLogger(__name__)
+
 # Scripts live at <repo-root>/installer/comfyui/scripts/
 _SCRIPTS_DIR: Path = (
     Path(__file__).parent.parent.parent.parent / "installer" / "comfyui" / "scripts"
 )
 
+# Curated workflow JSONs ship alongside the scripts and are provisioned into
+# the operational ComfyUI workflows dir when a variant is selected.
+_WORKFLOWS_SRC_DIR: Path = (
+    Path(__file__).parent.parent.parent.parent / "installer" / "comfyui" / "workflows"
+)
+
 # Module-level job registry
 _JOBS: dict[str, dict] = {}
+
+
+def _fetch_env() -> dict[str, str]:
+    """Build the subprocess env for a fetch step, forwarding HF credentials.
+
+    Inherits the hal0 process env and normalises the Hugging Face token so the
+    ``hf`` CLI in the vendored scripts authenticates gated pulls:
+
+    * ``HF_TOKEN`` — set from ``HF_TOKEN`` or the legacy
+      ``HUGGING_FACE_HUB_TOKEN`` (the token source plumbed in #1094). When only
+      the legacy name is present it is mirrored to ``HF_TOKEN`` so both the CLI
+      and the scripts see it.
+    * ``HF_HOME`` — forwarded when set so the persistent cache is shared; the
+      scripts default it to ``$HOME/.cache/huggingface`` otherwise.
+    """
+    env = dict(os.environ)
+    token = env.get("HF_TOKEN") or env.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        env["HF_TOKEN"] = token
+        env["HUGGING_FACE_HUB_TOKEN"] = token
+    return env
+
+
+def _workflows_dir() -> Path:
+    """Target dir to provision curated workflow JSONs into.
+
+    Honours ``COMFYUI_WORKFLOWS_DIR`` (same override the launch route reads),
+    else ``<model-store>/comfyui/workflows`` (default ``/mnt/ai-models``).
+    """
+    override = os.environ.get("COMFYUI_WORKFLOWS_DIR", "").strip()
+    if override:
+        return Path(override)
+    try:
+        from hal0.config.paths import model_store_root
+
+        return Path(model_store_root()) / "comfyui" / "workflows"
+    except Exception:
+        return Path("/mnt/ai-models/comfyui/workflows")
+
+
+def _provision_workflow(variant: ModelVariant) -> str | None:
+    """Copy the variant's curated workflow JSON into the workflows dir.
+
+    Best-effort: returns the destination path on success, or ``None`` when the
+    source asset is missing or the copy fails (a workflow-copy hiccup must not
+    fail the model download). The launch route then discovers it via
+    ``GET /api/comfyui/workflows``.
+    """
+    name = variant.workflow
+    if not name:
+        return None
+    src = _WORKFLOWS_SRC_DIR / name
+    if not src.is_file():
+        log.warning("comfyui.workflow_asset_missing", extra={"workflow": name})
+        return None
+    try:
+        dest_dir = _workflows_dir()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / name
+        shutil.copyfile(src, dest)
+        return str(dest)
+    except OSError as exc:
+        log.warning(
+            "comfyui.workflow_provision_failed",
+            extra={"workflow": name, "error": str(exc)},
+        )
+        return None
 
 
 def _run_sequence(rec: dict, script_path: str, fetch_steps: tuple[tuple[str, ...], ...]) -> None:
@@ -39,12 +126,13 @@ def _run_sequence(rec: dict, script_path: str, fetch_steps: tuple[tuple[str, ...
     (status='cancelled', set by cancel_job).  Marks 'done' when all
     steps exit 0.
     """
+    env = _fetch_env()
     for step_args in fetch_steps:
         if rec["status"] == "cancelled":
             return
 
         cmd = ["bash", script_path, *step_args]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
         rec["_proc"] = proc
 
         rc = proc.wait()
@@ -64,11 +152,15 @@ def _run_sequence(rec: dict, script_path: str, fetch_steps: tuple[tuple[str, ...
 def fetch_model(variant: ModelVariant) -> str:
     """Start a background fetch for *variant* and return its job_id immediately.
 
-    Steps run in a daemon thread; poll status via get_job().  Non-blocking so
-    the 202-returning API endpoint does not stall on multi-hour downloads.
+    Provisions the variant's curated workflow JSON synchronously (a fast file
+    copy) before the download starts, then runs the fetch steps in a daemon
+    thread; poll status via get_job(). Non-blocking so the 202-returning API
+    endpoint does not stall on multi-hour downloads.
     """
     script_path = str(_SCRIPTS_DIR / variant.fetch_script)
     job_id = str(uuid.uuid4())
+
+    workflow_path = _provision_workflow(variant)
 
     rec: dict = {
         "id": job_id,
@@ -76,6 +168,7 @@ def fetch_model(variant: ModelVariant) -> str:
         "status": "running",
         "returncode": None,
         "script": script_path,
+        "workflow": workflow_path,
         "_proc": None,
         "_thread": None,
     }

--- a/tests/comfyui/test_fetch_ws_g.py
+++ b/tests/comfyui/test_fetch_ws_g.py
@@ -1,0 +1,177 @@
+"""#1110 (WS-G): ComfyUI fetch fixes.
+
+Covers the three ways the fetch was feature-dead before this change:
+  1. The vendored ``get_*.sh`` scripts hard-coded the ComfyUI container's
+     ``hf`` path (``/opt/venv/bin/hf``) but run as HOST subprocesses, so every
+     download failed with "no such file". They must now resolve ``hf`` from the
+     host PATH, falling back to the container venv path.
+  2. ``HF_TOKEN`` / ``HF_HOME`` were never forwarded to the fetch subprocess.
+  3. Most curated workflow JSONs were never shipped, and selecting a variant
+     never provisioned its matching workflow.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from hal0.comfyui.capabilities import CAPABILITIES, default_variant
+from hal0.comfyui.fetch import _fetch_env, _provision_workflow, fetch_model, get_job
+
+REPO = Path(__file__).parent.parent.parent
+SCRIPTS_DIR = REPO / "installer" / "comfyui" / "scripts"
+WORKFLOWS_SRC = REPO / "installer" / "comfyui" / "workflows"
+
+# Scripts that use the `hf` CLI (get_esrgan.sh uses curl only).
+HF_SCRIPTS = [
+    "get_ltx2.sh",
+    "get_sdxl.sh",
+    "get_qwen_image.sh",
+    "get_hunyuan15.sh",
+    "get_wan22.sh",
+]
+
+
+def _wait_done(job_id, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        job = get_job(job_id)
+        if job is not None and job["status"] != "running":
+            return job
+        time.sleep(0.005)
+    raise AssertionError(f"job {job_id} still running after {timeout}s")
+
+
+class _PopenRecorder:
+    def __init__(self, procs):
+        self._procs = list(procs)
+        self._idx = 0
+        self.calls: list[list[str]] = []
+        self.envs: list[dict | None] = []
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(list(cmd))
+        self.envs.append(kw.get("env"))
+        p = self._procs[self._idx % len(self._procs)]
+        self._idx += 1
+        return p
+
+
+def _make_proc(returncode=0):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ── (1) host-resolvable hf ────────────────────────────────────────────────────
+
+
+def test_no_script_hardcodes_container_hf_path():
+    """No get_*.sh may pin the download tool to the container venv path alone."""
+    offenders = []
+    for name in HF_SCRIPTS:
+        text = (SCRIPTS_DIR / name).read_text()
+        if re.search(r'^HF="/opt/venv/bin/hf"\s*$', text, flags=re.MULTILINE):
+            offenders.append(name)
+    assert not offenders, (
+        f"scripts still hard-code the container hf path: {offenders} — "
+        "they must resolve `hf` from the host PATH"
+    )
+
+
+def test_hf_scripts_resolve_from_path_with_container_fallback():
+    """Each hf-using script resolves `hf` from PATH, keeping the venv fallback."""
+    for name in HF_SCRIPTS:
+        text = (SCRIPTS_DIR / name).read_text()
+        assert "command -v hf" in text, f"{name} does not resolve hf from PATH"
+        assert "/opt/venv/bin/hf" in text, f"{name} dropped the container fallback"
+
+
+# ── (2) HF_TOKEN / HF_HOME forwarding ─────────────────────────────────────────
+
+
+def test_fetch_env_promotes_hf_token(monkeypatch):
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.setenv("HF_TOKEN", "hf_secret_abc")
+    env = _fetch_env()
+    assert env["HF_TOKEN"] == "hf_secret_abc"
+    assert env["HUGGING_FACE_HUB_TOKEN"] == "hf_secret_abc"
+
+
+def test_fetch_env_mirrors_legacy_token_name(monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hf_legacy_xyz")
+    env = _fetch_env()
+    assert env["HF_TOKEN"] == "hf_legacy_xyz"
+
+
+def test_fetch_env_forwards_hf_home(monkeypatch):
+    monkeypatch.setenv("HF_HOME", "/mnt/ai-models/hf-cache")
+    assert _fetch_env()["HF_HOME"] == "/mnt/ai-models/hf-cache"
+
+
+def test_fetch_subprocess_receives_hf_token(monkeypatch, tmp_path):
+    monkeypatch.setenv("HF_TOKEN", "hf_run_token")
+    monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(tmp_path / "wf"))
+    rec = _PopenRecorder([_make_proc(0)])
+    monkeypatch.setattr("hal0.comfyui.fetch.subprocess.Popen", rec)
+
+    job_id = fetch_model(default_variant("image_upscale"))
+    _wait_done(job_id)
+
+    assert rec.envs and rec.envs[0] is not None
+    assert rec.envs[0]["HF_TOKEN"] == "hf_run_token"
+
+
+# ── (3) curated workflow provisioning ─────────────────────────────────────────
+
+
+def _registry_workflow_names() -> set[str]:
+    names = set()
+    for cap in CAPABILITIES.values():
+        for v in cap.alternatives:
+            names.add(v.workflow)
+    return names
+
+
+def test_every_registry_workflow_json_is_shipped():
+    missing = [n for n in _registry_workflow_names() if not (WORKFLOWS_SRC / n).is_file()]
+    assert not missing, f"curated workflow JSONs not shipped: {missing}"
+
+
+def test_shipped_workflows_are_api_format_json():
+    import json
+
+    for name in _registry_workflow_names():
+        data = json.loads((WORKFLOWS_SRC / name).read_text())
+        assert isinstance(data, dict) and data, f"{name} is not a non-empty object"
+        # API-format ComfyUI graphs are keyed by node id → {class_type, inputs}.
+        assert all("class_type" in node for node in data.values()), (
+            f"{name} is not API-format (missing class_type on some node)"
+        )
+
+
+def test_provision_workflow_copies_matching_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(tmp_path / "wf"))
+    variant = CAPABILITIES["txt2img"].alternatives[2]  # sdxl
+    dest = _provision_workflow(variant)
+    assert dest is not None
+    assert Path(dest).is_file()
+    assert Path(dest).name == variant.workflow
+
+
+def test_fetch_model_provisions_workflow(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(tmp_path / "wf"))
+    rec = _PopenRecorder([_make_proc(0)])
+    monkeypatch.setattr("hal0.comfyui.fetch.subprocess.Popen", rec)
+
+    variant = CAPABILITIES["txt2img"].alternatives[2]  # sdxl
+    job_id = fetch_model(variant)
+    job = _wait_done(job_id)
+
+    assert job["workflow"] is not None
+    assert Path(job["workflow"]).name == variant.workflow
+    assert Path(job["workflow"]).is_file()


### PR DESCRIPTION
## What this fixes (Closes #1110)

ComfyUI image-gen was feature-dead: the `get_*.sh` fetch scripts hard-coded the ComfyUI container's `hf` path (`/opt/venv/bin/hf`) but run as **host** subprocesses (`bash <script>` from `hal0.comfyui.fetch`), so every download failed with "no such file"; `HF_TOKEN` was never forwarded; and most curated workflow JSONs were never shipped.

## Approach: host-resolvable `hf` (not podman-exec)

The existing fetch path (`fetch.py._run_sequence`) runs the scripts as host subprocesses writing to the host model store (`/mnt/ai-models/comfyui/models`). Podman-exec into the img container would require path-translating `MODEL_DIR` to the container's `/root/comfy-models` bind mount and copying the scripts in — a rearchitecture. The host already ships `hf` (confirmed at `/root/.local/bin/hf`, installer-provisioned), so the natural, minimal fix that fits the existing code is to make the scripts **resolve `hf` from the host PATH**, keeping the container venv path as a fallback for in-container use:

```bash
HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
```

Applied to `get_ltx2/sdxl/qwen_image/hunyuan15/wan22.sh` (`get_esrgan.sh` uses `curl`, no `hf`).

## Changes
- **HF credential forwarding**: `fetch.py` now builds an explicit subprocess env (`_fetch_env`) that forwards `HF_TOKEN`/`HF_HOME` — the token source plumbed in #1094 — and mirrors the legacy `HUGGING_FACE_HUB_TOKEN` name so the `hf` CLI authenticates gated pulls. Passed via `subprocess.Popen(..., env=env)`.
- **Ship workflow JSONs**: all 12 curated **API-format** workflows now live under `installer/comfyui/workflows/` (10 vendored from the kyuz0 toolboxes `workflows/API/` dir that the scripts are vendored from; `SDXL-Lightning-8step.json` + `ESRGAN-4x-Upscale.json` authored to match the get-script model filenames). `fetch_model()` provisions the selected variant's workflow into the ComfyUI workflows dir (`COMFYUI_WORKFLOWS_DIR` / `<model-store>/comfyui/workflows` — the same dir the launch route reads) and records it on the job.

## Verified live vs by test
- **By test** (this env has no ComfyUI container / GPU): `tests/comfyui/test_fetch_ws_g.py` asserts no script hard-codes the container `hf` path, each resolves via `command -v hf` with the venv fallback, `HF_TOKEN`/`HF_HOME` are forwarded into the Popen env, all 12 registry workflows are shipped + API-format, and `fetch_model` provisions the matching JSON. All get scripts pass `bash -n`; the SDXL txt2img variant path is exercised end-to-end through `fetch_model` (workflow provisioned, subprocess env carries the token).
- **Could not run live**: an actual model download / ComfyUI render — no container, GPU, or network-gated HF creds in this environment.

## CI parity (run from repo root, in order)
1. `ruff format src tests` — 1 file reformatted (fetch.py)
2. `ruff check src tests` — All checks passed
3. `ruff format --check src tests` — 637 files already formatted
4. `pytest` — 4647 passed, 14 failed + 1 error, all pre-existing (hermes venv, comfyui-phase4 `TestWorkflowList` [confirmed pre-existing via `git stash`], proxmox pve detection, container-spec-dispatch, config-urls-proxy, models-preview, settings-store, openwebui prewire). No new failures; none touch the ComfyUI fetch/scripts/workflows changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)