### PR TITLE
installer-setup WS-C: network coherence backend (unify HAL0_BIND_HOST + seed origins)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -540,11 +540,35 @@ else
 fi
 
 API_ENV="${ETC_DIR}/api.env"
+# Network coherence (WS-C): derive HAL0_BIND_HOST + HAL0_HOSTNAME +
+# HAL0_ALLOWED_ORIGINS from ONE bind choice so the hal0-api unit, `hal0
+# serve`, mDNS, and the chat-proxy WS origin gate all agree. The unit's
+# ExecStart no longer passes --host — it reads HAL0_BIND_HOST from this
+# file, the same var `hal0 serve` honours (main.py). HAL0_ALLOWED_ORIGINS
+# is seeded with the hostname + every LAN IP + localhost on the API port
+# so whatever URL /api/config/urls advertises passes the WS gate (no 4403
+# mismatch). All derivation lives in src/hal0/install/network.py (single
+# source), invoked via the just-installed venv; a failure degrades to a
+# bare bind var rather than aborting the install.
+NETWORK_ENV_LINES="$(
+    HAL0_BIND_HOST="${API_BIND_HOST}" \
+    HAL0_PORT="${HAL0_PORT}" \
+    HAL0_LAN_IPS="$(hostname -I 2>/dev/null || true)" \
+    "${VENV_DIR}/bin/python" -c 'from hal0.install.network import main; raise SystemExit(main())' 2>/dev/null
+)" || NETWORK_ENV_LINES="HAL0_BIND_HOST=${API_BIND_HOST}"
+if [[ -z "${NETWORK_ENV_LINES}" ]]; then
+    NETWORK_ENV_LINES="HAL0_BIND_HOST=${API_BIND_HOST}"
+fi
 if [[ ! -f "${API_ENV}" ]]; then
     cat > "${API_ENV}" <<EOF
 HAL0_PORT=${HAL0_PORT}
 HAL0_LOG_LEVEL=info
 HAL0_UI_DIST=${HAL0_UI_DIST_VAL}
+# Network shape — derived from one bind choice (WS-C). HAL0_BIND_HOST is
+# read by BOTH this file's consumer (\`hal0 serve\`) and the hal0-api unit;
+# HAL0_HOSTNAME feeds mDNS; HAL0_ALLOWED_ORIGINS gates the chat-proxy WS
+# upgrade. Regenerate with: hal0 doctor / rerun installer.
+${NETWORK_ENV_LINES}
 # Memory subsystem (Hindsight engine + /mcp/memory + the Agent → Memory tab)
 # is ENABLED by default as of v0.5 (brain re-enablement). Comment out to ship
 # with memory dark. Needs the shared hindsight-api daemon (installer/systemd/
@@ -619,7 +643,10 @@ User=root
 UMask=0002
 WorkingDirectory=${API_WORKDIR}
 EnvironmentFile=${API_ENV}
-ExecStart=${HAL0_BIN} serve --host ${API_BIND_HOST} --port \${HAL0_PORT}
+# No --host here (WS-C): the bind host comes from HAL0_BIND_HOST in the
+# EnvironmentFile above — the SAME var \`hal0 serve\` reads — so the unit
+# and the CLI can never disagree on the bind address.
+ExecStart=${HAL0_BIN} serve --port \${HAL0_PORT}
 Restart=on-failure
 RestartSec=3
 StandardOutput=journal

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -187,8 +187,19 @@ app.command(name="update")(_update_impl)
 
 @app.command()
 def serve(
-    host: str = typer.Option("127.0.0.1", "--host", help="Bind host for the hal0 API."),
-    port: int = typer.Option(8080, "--port", help="Bind port for the hal0 API."),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        envvar="HAL0_BIND_HOST",
+        help=(
+            "Bind host for the hal0 API. Defaults to $HAL0_BIND_HOST — the "
+            "SAME var the hal0-api systemd unit reads from /etc/hal0/api.env "
+            "(WS-C network coherence) — then 127.0.0.1 when neither is set."
+        ),
+    ),
+    port: int = typer.Option(
+        8080, "--port", envvar="HAL0_PORT", help="Bind port for the hal0 API."
+    ),
     reload: bool = typer.Option(False, "--reload", help="Enable auto-reload (dev mode)."),
 ) -> None:
     """Start the hal0 API server (used by hal0-api.service)."""

--- a/src/hal0/install/answers.py
+++ b/src/hal0/install/answers.py
@@ -19,6 +19,7 @@ uses (``suggest_models``, ``derive_device``/``derive_profile`` via
 
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,7 @@ import yaml
 
 from hal0.config.schema import HardwareInfo
 from hal0.install.extensions import EXTENSIONS
+from hal0.install.network import network_env
 from hal0.install.orchestrate import Selections, SlotSelection
 from hal0.install.suggest import suggest_models
 
@@ -282,10 +284,51 @@ def _resolve_extensions(doc: dict[str, Any], comfyui_enabled: bool) -> dict[str,
     return extensions
 
 
+def _apply_network(doc: dict[str, Any]) -> dict[str, str] | None:
+    """Validate + apply the ``network`` block (spec §5, WS-C / #1099).
+
+    ``network.bind_host`` / ``network.hostname`` / ``network.public_url`` are
+    resolved through :func:`hal0.install.network.network_env` — the SAME
+    derivation the installer uses to seed ``/etc/hal0/api.env`` — into the
+    coherent triple ``HAL0_BIND_HOST`` (read by both the ``hal0-api`` unit and
+    ``hal0 serve``), ``HAL0_HOSTNAME`` (mDNS), and ``HAL0_ALLOWED_ORIGINS`` (the
+    chat-proxy WS allowlist). The resolved values are exported into
+    ``os.environ`` so the in-process apply run inherits the operator's bind
+    choice; the answer file is authoritative over detected defaults (spec §2
+    precedence). Returns the applied triple (or ``None`` when no ``network``
+    block is present) so callers can persist it.
+
+    No disk write happens here — ``load_answers`` is shared with the ``--plan``
+    preview path, so it stays free of file side effects; the persistent
+    ``api.env`` seeding is owned by the installer (``install.sh``, WS-C).
+    """
+    net = doc.get("network")
+    if net is None:
+        return None
+    if not isinstance(net, dict):
+        raise AnswersError("network must be a mapping")
+
+    resolved: dict[str, str | None] = {}
+    for key in ("bind_host", "hostname", "public_url"):
+        value = net.get(key)
+        if value is not None and not isinstance(value, str):
+            raise AnswersError(f"network.{key} must be a string or null, got {value!r}")
+        resolved[key] = value
+
+    env = network_env(
+        bind_host=resolved["bind_host"],
+        hostname=resolved["hostname"],
+        public_url=resolved["public_url"],
+    )
+    # Answer-file bind choice is authoritative over detected defaults; export
+    # so the same-process apply (and any env-reading step it triggers) agrees
+    # with what /api/config/urls will advertise.
+    os.environ.update(env)
+    return env
+
+
 def _warn_not_yet_wired(doc: dict[str, Any]) -> None:
     """Warn about known-but-not-yet-wired top-level blocks (spec §5)."""
-    if "network" in doc:
-        _warn("network is not yet applied (#1108)")
     if "huggingface" in doc:
         _warn(
             "huggingface token settings are not yet applied (#1108); "
@@ -303,6 +346,7 @@ def load_answers(path: str, hw: HardwareInfo) -> Selections:
     doc = _load_yaml(path)
     _check_version(doc)
     _check_top_level_keys(doc)
+    _apply_network(doc)
     _warn_not_yet_wired(doc)
 
     storage_dir = _resolve_storage_dir(doc)

--- a/src/hal0/install/network.py
+++ b/src/hal0/install/network.py
@@ -1,0 +1,245 @@
+"""Network-coherence derivation for the installer / answer-file (WS-C).
+
+One ``HAL0_BIND_HOST`` drives BOTH the ``hal0-api`` systemd unit and
+``hal0 serve`` (the unit used to hardcode ``0.0.0.0`` while ``serve``
+defaulted to ``127.0.0.1`` — two sources that could disagree). From that
+same bind + hostname choice we derive:
+
+* ``HAL0_HOSTNAME`` — advertised over mDNS (``services/mdns.py`` reads it)
+  and used to build the origin allowlist.
+* ``HAL0_ALLOWED_ORIGINS`` — the browser-origin allowlist the chat-proxy
+  WS gate (``api/agents/_auth.check_ws_origin_and_cookie``) checks. It is
+  seeded with the chosen hostname, every detected LAN IP, and localhost —
+  all on the API port — so that whatever host the operator typed into
+  their browser (and therefore whatever ``GET /api/config/urls``
+  advertises) is guaranteed to be in the allowlist. That closes the 4403
+  "policy violation" WS-upgrade rejection that happened when the
+  advertised URL (e.g. ``http://192.168.1.20:8080``) was not one of the
+  three hardcoded defaults.
+
+This module is the single derivation path: the installer (``install.sh``)
+calls :func:`main` to seed ``/etc/hal0/api.env``, and the headless
+answer-file loader (``hal0.install.answers.load_answers``, WS-C
+answer-key wiring) calls :func:`network_env` with ``network.bind_host`` /
+``network.hostname`` / ``network.public_url`` from ``hal0-setup.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from collections.abc import Iterable, Sequence
+
+# mDNS alias every hal0 box answers to (matches the port-less default the
+# WS gate has always shipped and the avahi ``hal0.service`` advertisement).
+MDNS_ALIAS = "hal0.local"
+
+# Vite dev server — kept in the allowlist so UI hot-reload (`npm run dev`
+# on :5173) still upgrades the chat-proxy WS during development. This is
+# one of the three historical defaults in ``api/agents/_auth`` and must
+# survive the env override (which *replaces* rather than unions).
+DEV_ORIGINS: tuple[str, ...] = ("http://localhost:5173",)
+
+DEFAULT_BIND_HOST = "0.0.0.0"
+DEFAULT_PORT = 8080
+
+
+def resolve_hostname(choice: str | None = None) -> str:
+    """Return the hostname to advertise (mDNS + origin allowlist).
+
+    Precedence: explicit ``choice`` → ``HAL0_HOSTNAME`` env →
+    ``socket.gethostname()``. Mirrors ``services.mdns.mdns_hostname`` so
+    the advertised name and the seeded ``HAL0_HOSTNAME`` never diverge.
+    """
+    resolved = (choice or os.environ.get("HAL0_HOSTNAME", "")).strip()
+    return resolved or socket.gethostname()
+
+
+def detect_lan_ips(override: str | None = None) -> list[str]:
+    """Best-effort list of the host's routable LAN IPv4 addresses.
+
+    ``override`` (or the ``HAL0_LAN_IPS`` env var — comma/space
+    separated) short-circuits detection; the installer passes
+    ``hostname -I`` through it so the box's real addresses are used even
+    inside containers where Python's resolver is unreliable.
+
+    Detection uses the connect-a-UDP-socket trick to learn the primary
+    outbound interface IP (no packets are actually sent) and augments it
+    with ``getaddrinfo`` on the hostname. Loopback (``127.*``) is dropped
+    — localhost origins are added separately. All failures degrade to an
+    empty list rather than raising.
+    """
+    raw = override if override is not None else os.environ.get("HAL0_LAN_IPS", "")
+    raw = (raw or "").strip()
+    if raw:
+        candidates = [ip.strip() for ip in raw.replace(",", " ").split() if ip.strip()]
+        return _dedupe(ip for ip in candidates if _is_lan_ipv4(ip))
+
+    ips: list[str] = []
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # TEST-NET-1 (RFC 5737) — routable-looking but never real, so the
+        # kernel picks our egress interface without any traffic leaving.
+        sock.connect(("192.0.2.1", 9))
+        ips.append(sock.getsockname()[0])
+    except OSError:
+        pass
+    finally:
+        sock.close()
+
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None, family=socket.AF_INET):
+            ips.append(info[4][0])
+    except OSError:
+        pass
+
+    return _dedupe(ip for ip in ips if _is_lan_ipv4(ip))
+
+
+def derive_allowed_origins(
+    hostname: str,
+    port: int,
+    *,
+    public_url: str | None = None,
+    lan_ips: Sequence[str] | None = None,
+) -> list[str]:
+    """Build the WS-origin allowlist for the given bind/hostname choice.
+
+    The list covers every way a browser can legitimately reach the
+    dashboard on ``port``: localhost, each LAN IP, the chosen hostname
+    (plus its ``.local`` mDNS form), and the ``hal0.local`` alias — so
+    the URL ``GET /api/config/urls`` advertises always matches. When the
+    operator declared a reverse-proxy ``public_url`` its scheme://host
+    origin is added too (the proxy terminates TLS on 443, so it carries
+    no port). Dev origins (Vite) are always appended.
+    """
+    port_hosts: list[str] = ["localhost", "127.0.0.1"]
+    port_hosts.extend(lan_ips or [])
+    hostname = (hostname or "").strip()
+    if hostname and hostname not in ("localhost", "127.0.0.1"):
+        port_hosts.append(hostname)
+        if "." not in hostname:
+            port_hosts.append(f"{hostname}.local")
+    port_hosts.append(MDNS_ALIAS)
+
+    origins: list[str] = [f"http://{host}:{port}" for host in port_hosts]
+    # Port-less mDNS alias — the historical default and what a browser
+    # sends when hal0.local is reached on the default HTTP port.
+    origins.append(f"http://{MDNS_ALIAS}")
+    origins.extend(DEV_ORIGINS)
+
+    proxy_origin = _origin_of(public_url)
+    if proxy_origin:
+        origins.append(proxy_origin)
+
+    return _dedupe(origins)
+
+
+def network_env(
+    *,
+    bind_host: str | None = None,
+    hostname: str | None = None,
+    public_url: str | None = None,
+    port: int | None = None,
+    lan_ips: Sequence[str] | None = None,
+) -> dict[str, str]:
+    """Resolve the three coherent network env vars from a bind choice.
+
+    Returns ``HAL0_BIND_HOST`` (read by the unit *and* ``hal0 serve``),
+    ``HAL0_HOSTNAME`` (mDNS + origin derivation), and
+    ``HAL0_ALLOWED_ORIGINS`` (comma-joined WS allowlist). Unset args fall
+    back to env vars then the shipped defaults, so an all-default call
+    still produces a working, coherent triple.
+    """
+    resolved_bind = (bind_host or os.environ.get("HAL0_BIND_HOST", "")).strip() or DEFAULT_BIND_HOST
+    resolved_port = _coerce_port(port if port is not None else os.environ.get("HAL0_PORT"))
+    resolved_host = resolve_hostname(hostname)
+    resolved_public = (public_url or os.environ.get("HAL0_PUBLIC_URL", "")).strip() or None
+    ips = list(lan_ips) if lan_ips is not None else detect_lan_ips()
+
+    origins = derive_allowed_origins(
+        resolved_host,
+        resolved_port,
+        public_url=resolved_public,
+        lan_ips=ips,
+    )
+    return {
+        "HAL0_BIND_HOST": resolved_bind,
+        "HAL0_HOSTNAME": resolved_host,
+        "HAL0_ALLOWED_ORIGINS": ",".join(origins),
+    }
+
+
+def main() -> int:
+    """Emit ``KEY=value`` env lines for the installer to append to api.env.
+
+    Invoked by ``install.sh`` via the freshly-installed venv so the whole
+    derivation lives in exactly one place. Reads ``HAL0_BIND_HOST`` /
+    ``HAL0_HOSTNAME`` / ``HAL0_PORT`` / ``HAL0_PUBLIC_URL`` / ``HAL0_LAN_IPS``
+    from the environment.
+    """
+    for key, value in network_env().items():
+        print(f"{key}={value}")
+    return 0
+
+
+# ── internals ──────────────────────────────────────────────────────────────
+
+
+def _coerce_port(value: object) -> int:
+    """Parse a port from an int/str, falling back to the default."""
+    if value is None:
+        return DEFAULT_PORT
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return DEFAULT_PORT
+
+
+def _is_lan_ipv4(ip: str) -> bool:
+    """True for a plausible non-loopback IPv4 dotted-quad."""
+    if not ip or ip.startswith("127.") or ":" in ip:
+        return False
+    parts = ip.split(".")
+    if len(parts) != 4:
+        return False
+    return all(p.isdigit() and 0 <= int(p) <= 255 for p in parts)
+
+
+def _origin_of(url: str | None) -> str | None:
+    """Return the ``scheme://host[:port]`` origin of a URL, or None.
+
+    Tolerant of a bare host (assumes https) and trailing paths so an
+    operator's ``public_url: chat.example.com`` or
+    ``https://hal0.example.com/`` both resolve to a clean origin.
+    """
+    if not url:
+        return None
+    url = url.strip().rstrip("/")
+    if not url:
+        return None
+    if "://" not in url:
+        url = f"https://{url}"
+    scheme, _, rest = url.partition("://")
+    host = rest.split("/", 1)[0]
+    if not host:
+        return None
+    return f"{scheme}://{host}"
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    """Order-preserving de-duplication."""
+    return list(dict.fromkeys(items))
+
+
+__all__ = [
+    "DEFAULT_BIND_HOST",
+    "DEFAULT_PORT",
+    "DEV_ORIGINS",
+    "MDNS_ALIAS",
+    "derive_allowed_origins",
+    "detect_lan_ips",
+    "main",
+    "network_env",
+    "resolve_hostname",
+]

--- a/tests/cli/test_serve_bind_host.py
+++ b/tests/cli/test_serve_bind_host.py
@@ -1,0 +1,57 @@
+"""``hal0 serve`` honours HAL0_BIND_HOST (WS-C network coherence).
+
+The hal0-api systemd unit's ExecStart no longer passes --host; it relies
+on serve reading HAL0_BIND_HOST from the EnvironmentFile. These tests pin
+that env → bind-host contract (and the --host flag still overriding it)
+so the unit and the CLI can never disagree on the bind address.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import main as cli_main
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_bind(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub uvicorn.run so serve resolves the bind args without a server."""
+    captured: dict[str, Any] = {}
+
+    def _fake_run(_app: str, **kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli_main.uvicorn, "run", _fake_run)
+    return captured
+
+
+def test_serve_defaults_to_loopback(
+    captured_bind: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)
+    result = runner.invoke(cli_main.app, ["serve"])
+    assert result.exit_code == 0, result.output
+    assert captured_bind["host"] == "127.0.0.1"
+
+
+def test_serve_reads_bind_host_env(
+    captured_bind: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    result = runner.invoke(cli_main.app, ["serve"])
+    assert result.exit_code == 0, result.output
+    assert captured_bind["host"] == "0.0.0.0"
+
+
+def test_serve_flag_overrides_env(
+    captured_bind: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    result = runner.invoke(cli_main.app, ["serve", "--host", "192.0.2.7"])
+    assert result.exit_code == 0, result.output
+    assert captured_bind["host"] == "192.0.2.7"

--- a/tests/install/test_answers.py
+++ b/tests/install/test_answers.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 import warnings
 
@@ -190,7 +191,13 @@ def test_gen_mode_scaffold_only_enables_comfyui_and_populates_defaults(tmp_path)
     assert sel.comfyui_defaults == (("txt2img", "qwen-image"),)
 
 
-def test_network_and_huggingface_blocks_warn_but_do_not_raise(tmp_path):
+def test_network_block_applied_huggingface_still_warns(tmp_path, monkeypatch):
+    """WS-C (#1099): the network block is now APPLIED (bind_host → the coherent
+    HAL0_BIND_HOST/HAL0_HOSTNAME/HAL0_ALLOWED_ORIGINS triple), no longer a
+    warn-ignore; huggingface stays a warn-ignore until its workstream lands."""
+    for var in ("HAL0_BIND_HOST", "HAL0_HOSTNAME", "HAL0_ALLOWED_ORIGINS", "HAL0_LAN_IPS"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HAL0_LAN_IPS", "192.168.1.42")  # deterministic derivation
     path = _write(
         tmp_path,
         """
@@ -212,8 +219,34 @@ def test_network_and_huggingface_blocks_warn_but_do_not_raise(tmp_path):
         sel = load_answers(path, _hw())
     assert sel.storage_dir == "/var/lib/hal0/models"
     messages = [str(w.message) for w in caught]
-    assert any("network" in m for m in messages)
+    # network is applied, so it must NOT emit a "not yet applied" warning.
+    assert not any("network is not yet applied" in m for m in messages)
     assert any("huggingface" in m for m in messages)
+    # The bind choice was resolved into the coherent env triple.
+    assert os.environ["HAL0_BIND_HOST"] == "0.0.0.0"
+    assert os.environ["HAL0_HOSTNAME"] == "hal0"
+    origins = os.environ["HAL0_ALLOWED_ORIGINS"].split(",")
+    assert "http://192.168.1.42:8080" in origins  # advertised URL passes WS gate
+    assert "http://hal0:8080" in origins
+
+
+def test_network_block_bad_type_raises(tmp_path):
+    """A malformed network value is rejected, not silently ignored."""
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        network:
+          bind_host: [not, a, string]
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: {}
+        """,
+    )
+    with pytest.raises(AnswersError, match=r"network\.bind_host"):
+        load_answers(path, _hw())
 
 
 def test_unknown_top_level_key_warns_by_default(tmp_path):

--- a/tests/install/test_network.py
+++ b/tests/install/test_network.py
@@ -1,0 +1,112 @@
+"""Tests for WS-C network-coherence derivation (``hal0.install.network``).
+
+Covers the invariant that closes the 4403 mismatch: whatever host the
+operator reaches the dashboard on — and therefore whatever URL
+``GET /api/config/urls`` advertises — is present in the derived
+``HAL0_ALLOWED_ORIGINS`` that the chat-proxy WS gate checks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.install import network
+
+
+def test_resolve_hostname_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit choice wins over env, env wins over gethostname()."""
+    monkeypatch.setenv("HAL0_HOSTNAME", "from-env")
+    assert network.resolve_hostname("explicit") == "explicit"
+    assert network.resolve_hostname() == "from-env"
+    monkeypatch.delenv("HAL0_HOSTNAME", raising=False)
+    assert network.resolve_hostname() == __import__("socket").gethostname()
+
+
+def test_detect_lan_ips_override_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAL0_LAN_IPS (space or comma separated) short-circuits detection."""
+    monkeypatch.setenv("HAL0_LAN_IPS", "192.168.1.5 10.0.0.2, 127.0.0.1")
+    ips = network.detect_lan_ips()
+    assert ips == ["192.168.1.5", "10.0.0.2"]  # loopback filtered, order kept
+
+
+def test_detect_lan_ips_override_arg_filters_junk() -> None:
+    """A garbage/IPv6 entry is dropped; valid IPv4 survive."""
+    assert network.detect_lan_ips("::1 not-an-ip 172.16.0.9") == ["172.16.0.9"]
+
+
+def test_derive_allowed_origins_covers_advertised_url() -> None:
+    """The advertised http://<lan-ip>:<port> URL is in the allowlist."""
+    origins = network.derive_allowed_origins("myhost", 8080, lan_ips=["192.168.1.20"])
+    # This is exactly what /api/config/urls advertises when reached on the
+    # LAN IP — it MUST be allowlisted or the WS upgrade 4403s.
+    assert "http://192.168.1.20:8080" in origins
+    assert "http://myhost:8080" in origins
+    assert "http://myhost.local:8080" in origins  # bare name gets .local
+    assert "http://localhost:8080" in origins
+    assert "http://127.0.0.1:8080" in origins
+    assert "http://hal0.local" in origins  # historical port-less default
+    assert "http://localhost:5173" in origins  # vite dev preserved
+
+
+def test_derive_allowed_origins_dotted_hostname_no_local_suffix() -> None:
+    """An already-qualified hostname is not given a spurious .local."""
+    origins = network.derive_allowed_origins("box.lan", 8080)
+    assert "http://box.lan:8080" in origins
+    assert "http://box.lan.local:8080" not in origins
+
+
+def test_derive_allowed_origins_public_url() -> None:
+    """A reverse-proxy public_url contributes its bare scheme://host origin."""
+    origins = network.derive_allowed_origins("myhost", 8080, public_url="https://hal0.example.com/")
+    assert "https://hal0.example.com" in origins
+    # bare host public_url is assumed https
+    origins2 = network.derive_allowed_origins("h", 8080, public_url="chat.example.com")
+    assert "https://chat.example.com" in origins2
+
+
+def test_derive_allowed_origins_is_deduped() -> None:
+    """No duplicate origins even when hostname collides with a default."""
+    origins = network.derive_allowed_origins("localhost", 8080, lan_ips=["127.0.0.1"])
+    assert len(origins) == len(set(origins))
+
+
+def test_network_env_triple(monkeypatch: pytest.MonkeyPatch) -> None:
+    """network_env returns the three coherent keys with the bind choice."""
+    monkeypatch.delenv("HAL0_HOSTNAME", raising=False)
+    env = network.network_env(
+        bind_host="0.0.0.0",
+        hostname="hal0",
+        port=8080,
+        lan_ips=["192.168.1.50"],
+    )
+    assert env["HAL0_BIND_HOST"] == "0.0.0.0"
+    assert env["HAL0_HOSTNAME"] == "hal0"
+    origins = env["HAL0_ALLOWED_ORIGINS"].split(",")
+    assert "http://192.168.1.50:8080" in origins
+    assert "http://hal0:8080" in origins
+
+
+def test_network_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """All-unset call still yields a working bind host + origins."""
+    for var in ("HAL0_BIND_HOST", "HAL0_PORT", "HAL0_PUBLIC_URL", "HAL0_LAN_IPS"):
+        monkeypatch.delenv(var, raising=False)
+    env = network.network_env(lan_ips=[])
+    assert env["HAL0_BIND_HOST"] == network.DEFAULT_BIND_HOST
+    assert env["HAL0_ALLOWED_ORIGINS"]  # non-empty
+
+
+def test_network_env_port_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAL0_PORT flows into the derived origin ports."""
+    monkeypatch.setenv("HAL0_PORT", "9090")
+    monkeypatch.delenv("HAL0_LAN_IPS", raising=False)
+    env = network.network_env(hostname="hal0", lan_ips=["10.1.1.1"])
+    assert "http://10.1.1.1:9090" in env["HAL0_ALLOWED_ORIGINS"].split(",")
+
+
+def test_main_emits_env_lines(capsys: pytest.CaptureFixture[str]) -> None:
+    """main() prints KEY=value lines the installer appends to api.env."""
+    rc = network.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    keys = {line.split("=", 1)[0] for line in out.strip().splitlines()}
+    assert keys == {"HAL0_BIND_HOST", "HAL0_HOSTNAME", "HAL0_ALLOWED_ORIGINS"}


### PR DESCRIPTION
## installer-setup WS-C — network coherence backend

Closes #1099.

Makes the network shape coherent from **one source** so the advertised URL and the WS-origin allowlist always agree (closes the 4403 mismatch).

### What changed
- **One `HAL0_BIND_HOST` for both the unit and `hal0 serve`.** `hal0 serve --host` now defaults from `$HAL0_BIND_HOST` (Typer `envvar=`) — the same var the `hal0-api` systemd unit reads from `/etc/hal0/api.env`. The unit's `ExecStart` drops the hardcoded `--host 0.0.0.0`; the unit and a bare `hal0 serve` can no longer disagree. `--port` gains the `HAL0_PORT` envvar for symmetry.
- **Single derivation path — `src/hal0/install/network.py`.** `network_env()` resolves `HAL0_BIND_HOST` + `HAL0_HOSTNAME` (mDNS) + `HAL0_ALLOWED_ORIGINS` from one bind choice. The allowlist covers the chosen hostname (+ its `.local` form), every detected LAN IP, and localhost — all on the API port — plus the port-less `hal0.local` alias, the Vite dev origin, and an optional reverse-proxy `public_url` origin. So whatever host the browser used (and therefore whatever `GET /api/config/urls` advertises) is guaranteed to pass the chat-proxy WS gate.
- **`install.sh` seeds the triple into `api.env`** (LAN IPs from `hostname -I`), invoking `network.main()` via the freshly-installed venv so the derivation lives in exactly one place; degrades to a bare `HAL0_BIND_HOST` line on any failure.
- **Answer-file keys wired (spec §5).** `network.bind_host` / `network.hostname` / `network.public_url` in `hal0-setup.yaml` are now validated and applied via `network_env()` (into the coherent env triple) instead of a blanket warn-ignore. Kept free of disk side effects since `load_answers` is shared with the `--plan` preview.

`GET /api/config/urls` remains the single source of truth for the advertised URLs (unchanged; it already mirrors the request host).

### Acceptance criteria
- [x] Unit and `serve` read the same bind host var (`HAL0_BIND_HOST`)
- [x] `HAL0_ALLOWED_ORIGINS` + `HAL0_HOSTNAME` seeded from the bind choice
- [x] Reaching the dashboard by the advertised URL passes the WS origin gate (derived origins include the hostname + LAN IPs + localhost on the API port)
- [x] `network.bind_host`/`hostname`/`public_url` accepted from the answer file and applied (no longer loader warn-ignore)
- [ ] Hermes dashboard URL derives from `/api/config/urls` — out of scope here (Hermes provisioning); tracked as the #1092 follow-up

### Tests
- `tests/install/test_network.py` — derivation, LAN-IP detection, allowlist coverage of the advertised URL, `network_env` triple.
- `tests/cli/test_serve_bind_host.py` — `serve` reads `HAL0_BIND_HOST`; `--host` flag overrides.
- `tests/install/test_answers.py` — network block applied (env triple set), malformed network rejected; huggingface still warn-ignored.

Full suite: 4652 passed; the 14 pre-existing failures on this environment (hermes venv, comfyui phase4, proxmox host detection, container-spec dispatch, config-url-proxy, models-preview, settings-store) are unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)