### PR TITLE
installer-setup WS-D: co-locate [models].flm_store + free-space validation on chosen mount

### DIFF
--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -7,6 +7,9 @@ post-install. Deps are injected so there is no hidden ``app.state`` coupling.
 
 from __future__ import annotations
 
+import logging
+import os
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -16,6 +19,13 @@ from hal0.config.schema import HardwareInfo
 from hal0.install.profile_derive import derive_device, derive_profile
 from hal0.registry.curated import get_curated
 from hal0.registry.pull import get_job, make_job
+
+log = logging.getLogger(__name__)
+
+# Mirrors ``cli.setup_plan.MIN_FREE_GIB`` — duplicated (not imported) so this
+# install-time validation path stays independent of the CLI module (isolation
+# guardrail: setup_plan.py is owned by a sibling workstream).
+MIN_FREE_GIB = 10.0
 
 
 @dataclass(frozen=True)
@@ -132,8 +142,112 @@ def mark_first_run_done() -> None:
     tmp.replace(p)  # atomic
 
 
+def _nearest_existing_ancestor(path: str) -> Path | None:
+    """Walk up from *path* to the nearest ancestor that actually exists.
+
+    A chosen store dir usually doesn't exist yet at persist time, so free-space
+    and writability checks need to land on the mount it *will* be created on.
+    Mirrors the ancestor-walk in ``cli.setup_plan._free_space_gib``. Returns
+    ``None`` if no ancestor can be resolved (e.g. a bare relative fragment).
+    """
+    p = Path(path)
+    seen: set[Path] = set()
+    while p not in seen:
+        seen.add(p)
+        if p.exists():
+            return p
+        if p.parent == p:
+            return None
+        p = p.parent
+    return None
+
+
+def _free_space_gib(path: str) -> float | None:
+    """Available GiB on the mount containing *path*.
+
+    Duplicated from (not imported off) ``cli.setup_plan._free_space_gib`` per
+    the isolation guardrail that keeps this install-time path independent of
+    the CLI module. Returns ``None`` if no ancestor can be stat'd.
+    """
+    ancestor = _nearest_existing_ancestor(path)
+    if ancestor is None:
+        return None
+    try:
+        return shutil.disk_usage(ancestor).free / (1024**3)
+    except OSError:
+        return None
+
+
+def _is_root_fs(ancestor: Path) -> bool:
+    """True if *ancestor* lives on the same filesystem as ``/``.
+
+    Compares ``st_dev`` (same pattern as ``registry.model_store``'s same-fs
+    bind-mount check) rather than string-prefix matching ``/`` so bind mounts
+    and nested mount points are handled correctly. Fails closed (``False``) on
+    a stat error — a validation warning is best-effort, never fatal.
+    """
+    try:
+        return ancestor.stat().st_dev == Path("/").stat().st_dev
+    except OSError:
+        return False
+
+
+def _is_writable(ancestor: Path) -> bool:
+    return os.access(ancestor, os.W_OK)
+
+
+def _validate_store_mount(storage_dir: str) -> None:
+    """Best-effort writability + free-space check on the chosen store mount.
+
+    Warns (logs only — never raises) when the mount is unwritable, sits on
+    the root filesystem, or is short on space (issue #1100 / decision Q4).
+    Non-fatal: a bad pick is surfaced to the operator via logs/``hal0
+    doctor`` rather than aborting the setup walk (ADR-0010).
+    """
+    ancestor = _nearest_existing_ancestor(storage_dir)
+    if ancestor is None:
+        log.warning(
+            "model store %s: could not resolve an existing ancestor to validate", storage_dir
+        )
+        return
+
+    if not _is_writable(ancestor):
+        log.warning("model store %s is not writable (checked %s)", storage_dir, ancestor)
+
+    if _is_root_fs(ancestor):
+        log.warning(
+            "model store %s is on the root filesystem — model + FLM/NPU weights "
+            "will consume root-FS space; consider a dedicated mount",
+            storage_dir,
+        )
+
+    free_gib = _free_space_gib(storage_dir)
+    if free_gib is None:
+        log.warning("model store %s: could not determine free space", storage_dir)
+    elif free_gib < MIN_FREE_GIB:
+        log.warning(
+            "model store %s has only %.1f GiB free (< %.0f GiB threshold)",
+            storage_dir,
+            free_gib,
+            MIN_FREE_GIB,
+        )
+
+
+def _colocated_flm_store(store_dir: str) -> str:
+    """Compute the FLM (NPU) store path co-located under the chosen model store.
+
+    Mirrors the convention documented on ``ModelsConfig.flm_store`` and used by
+    ``installer/install.sh`` (``<store>/flm/models``) so NPU weights land on
+    the same mount as the rest of the model store rather than stranding on the
+    root FS.
+    """
+    return str(Path(store_dir) / "flm" / "models")
+
+
 def _persist_store_dir(storage_dir: str) -> None:
-    """Persist a chosen model-store directory to ``[models].store`` in hal0.toml.
+    """Persist a chosen model-store directory to ``[models].store`` AND
+    co-locate ``[models].flm_store`` alongside it in hal0.toml (issue #1100,
+    decision Q4 — extends #1095's WS-A store threading).
 
     ``Selections.storage_dir`` (WS-A, issue #1095) is the operator's pull
     destination pick from ``/apply``, ``/apply-selections`` and
@@ -142,23 +256,37 @@ def _persist_store_dir(storage_dir: str) -> None:
     (``registry.pull._pull_root`` → ``ModelsConfig.effective_store``), so
     writing the pick here — before the planned pulls run — is what makes a
     custom store actually land pulls in that directory rather than silently
-    no-op'ing the field.
+    no-op'ing the field. ``[models].flm_store`` is resolved the same way
+    (``config.paths.flm_models_dir``), so NPU weights need the same treatment
+    or they strand under the default ``/var/lib/hal0`` cache on the root FS.
+
+    Also runs a non-fatal writability + free-space check on the chosen mount
+    (``_validate_store_mount``), warning on an unwritable dir, a root-FS pick,
+    or low free space — never blocking the walk.
 
     Best-effort per ADR-0010: an empty or relative value is ignored (the pull
     engine keeps its default store), and a config-write failure is swallowed so
-    a bad storage pick never aborts the slot/extension walk. Idempotent — skips
-    the rewrite when ``[models].store`` already points at the chosen path.
+    a bad storage pick never aborts the slot/extension walk. Idempotent —
+    skips the rewrite when both ``[models].store`` and ``[models].flm_store``
+    already point at the chosen (co-located) paths.
     """
     s = (storage_dir or "").strip()
     if not s or not Path(s).is_absolute():
         return
+
+    _validate_store_mount(s)
+    flm_target = _colocated_flm_store(s)
+
     try:
         from hal0.config.loader import load_hal0_config, save_hal0_config
 
         cfg = load_hal0_config()
-        if (cfg.models.store or "").strip() == s:
+        store_ok = (cfg.models.store or "").strip() == s
+        flm_ok = (cfg.models.flm_store or "").strip() == flm_target
+        if store_ok and flm_ok:
             return
         cfg.models.store = s
+        cfg.models.flm_store = flm_target
         save_hal0_config(cfg)
     except Exception:
         # Config persistence is best-effort: pulls fall back to the default

--- a/tests/install/test_orchestrate.py
+++ b/tests/install/test_orchestrate.py
@@ -160,6 +160,164 @@ async def test_apply_setup_persists_custom_store_dir(tmp_hal0_home, tmp_path):
     assert pull_mod._pull_root() == custom
 
 
+async def test_apply_setup_colocates_flm_store(tmp_hal0_home, tmp_path):
+    """A custom ``storage_dir`` also seeds ``[models].flm_store`` co-located
+    under it (``<store>/flm/models``), so NPU/FLM weights don't strand on the
+    root FS (issue #1100, decision Q4 — extends #1095's WS-A store thread)."""
+    from hal0.config.loader import load_hal0_config
+    from hal0.install import orchestrate
+
+    custom = tmp_path / "custom-store"
+    sel = Selections(
+        storage_dir=str(custom),
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    cfg = load_hal0_config()
+    assert cfg.models.store == str(custom)
+    assert cfg.models.flm_store == str(custom / "flm" / "models")
+
+
+def test_colocated_flm_store_path():
+    from hal0.install import orchestrate
+
+    assert orchestrate._colocated_flm_store("/mnt/ai-models") == "/mnt/ai-models/flm/models"
+
+
+def test_persist_store_dir_idempotent_when_both_already_set(tmp_hal0_home, tmp_path, monkeypatch):
+    """No rewrite when both ``store`` and the co-located ``flm_store`` already
+    match the chosen dir (the existing #1095 idempotency guard extended to
+    cover the new field)."""
+    from hal0.config.loader import load_hal0_config, save_hal0_config
+    from hal0.install import orchestrate
+
+    custom = tmp_path / "custom-store"
+    cfg = load_hal0_config()
+    cfg.models.store = str(custom)
+    cfg.models.flm_store = str(custom / "flm" / "models")
+    save_hal0_config(cfg)
+
+    calls = []
+    monkeypatch.setattr("hal0.config.loader.save_hal0_config", lambda c, path=None: calls.append(c))
+    orchestrate._persist_store_dir(str(custom))
+    assert calls == []  # save_hal0_config never invoked — already up to date
+
+
+def test_persist_store_dir_rewrites_flm_store_when_store_already_set(tmp_hal0_home, tmp_path):
+    """A pre-#1100 config with ``store`` set but no ``flm_store`` still gets
+    the co-located ``flm_store`` seeded on the next persist (store already
+    matching must not short-circuit the flm_store write)."""
+    from hal0.config.loader import load_hal0_config, save_hal0_config
+    from hal0.install import orchestrate
+
+    custom = tmp_path / "custom-store"
+    cfg = load_hal0_config()
+    cfg.models.store = str(custom)  # pre-existing, store already correct
+    save_hal0_config(cfg)
+    assert load_hal0_config().models.flm_store == ""  # sanity: unset before
+
+    orchestrate._persist_store_dir(str(custom))
+
+    assert load_hal0_config().models.flm_store == str(custom / "flm" / "models")
+
+
+async def test_apply_setup_ignores_relative_storage_dir_for_flm_store_too(tmp_hal0_home):
+    """A relative ``storage_dir`` leaves ``flm_store`` untouched too (mirrors
+    the existing relative-store guard)."""
+    from hal0.config.loader import load_hal0_config
+    from hal0.install import orchestrate
+
+    sel = Selections(
+        storage_dir="relative/models",
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    assert load_hal0_config().models.flm_store == ""
+
+
+def test_validate_store_mount_warns_on_unwritable(tmp_path, caplog, monkeypatch):
+    from hal0.install import orchestrate
+
+    monkeypatch.setattr(orchestrate, "_is_writable", lambda ancestor: False)
+    monkeypatch.setattr(orchestrate, "_is_root_fs", lambda ancestor: False)
+    monkeypatch.setattr(orchestrate, "_free_space_gib", lambda path: 999.0)
+    with caplog.at_level("WARNING", logger="hal0.install.orchestrate"):
+        orchestrate._validate_store_mount(str(tmp_path / "store"))
+    assert "not writable" in caplog.text
+
+
+def test_validate_store_mount_warns_on_root_fs(tmp_path, caplog, monkeypatch):
+    from hal0.install import orchestrate
+
+    monkeypatch.setattr(orchestrate, "_is_writable", lambda ancestor: True)
+    monkeypatch.setattr(orchestrate, "_is_root_fs", lambda ancestor: True)
+    monkeypatch.setattr(orchestrate, "_free_space_gib", lambda path: 999.0)
+    with caplog.at_level("WARNING", logger="hal0.install.orchestrate"):
+        orchestrate._validate_store_mount(str(tmp_path / "store"))
+    assert "root filesystem" in caplog.text
+
+
+def test_validate_store_mount_warns_on_low_free_space(tmp_path, caplog, monkeypatch):
+    from hal0.install import orchestrate
+
+    monkeypatch.setattr(orchestrate, "_is_writable", lambda ancestor: True)
+    monkeypatch.setattr(orchestrate, "_is_root_fs", lambda ancestor: False)
+    monkeypatch.setattr(orchestrate, "_free_space_gib", lambda path: 1.0)
+    with caplog.at_level("WARNING", logger="hal0.install.orchestrate"):
+        orchestrate._validate_store_mount(str(tmp_path / "store"))
+    assert "GiB free" in caplog.text
+
+
+def test_validate_store_mount_silent_when_healthy(tmp_path, caplog, monkeypatch):
+    from hal0.install import orchestrate
+
+    monkeypatch.setattr(orchestrate, "_is_writable", lambda ancestor: True)
+    monkeypatch.setattr(orchestrate, "_is_root_fs", lambda ancestor: False)
+    monkeypatch.setattr(orchestrate, "_free_space_gib", lambda path: 999.0)
+    with caplog.at_level("WARNING", logger="hal0.install.orchestrate"):
+        orchestrate._validate_store_mount(str(tmp_path / "store"))
+    assert caplog.text == ""
+
+
+def test_free_space_gib_walks_to_existing_ancestor(tmp_path):
+    from hal0.install import orchestrate
+
+    missing = tmp_path / "does" / "not" / "exist" / "yet"
+    free = orchestrate._free_space_gib(str(missing))
+    assert free is not None and free > 0
+
+
+def test_is_root_fs_false_for_tmp_path(tmp_path):
+    """A pytest tmp_path is essentially never the same device as ``/`` in CI
+    sandboxes/containers; this pins the comparison direction (not a hard
+    filesystem-topology assertion)."""
+    from pathlib import Path
+
+    from hal0.install import orchestrate
+
+    if orchestrate._is_root_fs(Path("/")) and orchestrate._is_root_fs(tmp_path):
+        pytest.skip("test root and / share a device in this sandbox — inconsistent host")
+    assert orchestrate._is_root_fs(tmp_path) == (tmp_path.stat().st_dev == Path("/").stat().st_dev)
+
+
 async def test_apply_setup_ignores_relative_storage_dir(tmp_hal0_home):
     """A relative ``storage_dir`` is not persisted (best-effort guard); the
     store stays at its default so a bad pick never corrupts config."""


### PR DESCRIPTION
## Summary

Closes #1100. Part of the guided Hal0 Installer Setup redesign (Wave 2 / WS-D, decision Q4). Extends #1095's `_persist_store_dir()` (which threads `Selections.storage_dir` into `[models].store`) to also handle the FLM/NPU side of the store:

- Setting the model store now seeds `[models].store` **and** co-locates `[models].flm_store` at `<store>/flm/models` (the convention already documented on `ModelsConfig.flm_store` and used by `installer/install.sh`), so NPU weights no longer strand on the root filesystem when `--models-dir` is set.
- Added a non-fatal writability + free-space check (`_validate_store_mount`) on the chosen mount: warns (log only, never raises) when the mount isn't writable, sits on the root filesystem, or has less than 10 GiB free — mirroring the ancestor-walk pattern in `cli.setup_plan._free_space_gib` without importing from it (isolation guardrail — that file is owned by a sibling workstream).
- Idempotent: skips the rewrite only when *both* `[models].store` and the co-located `[models].flm_store` already match; a config that pre-dates this change (store set, flm_store empty) still gets the co-located value seeded on the next persist.
- Best-effort per ADR-0010, matching #1095's existing behavior: empty/relative `storage_dir` values are ignored, and config-write failures are swallowed so a bad pick never aborts the slot/extension walk.

## Files changed

- `src/hal0/install/orchestrate.py` — `_persist_store_dir` extended; new helpers `_colocated_flm_store`, `_validate_store_mount`, `_free_space_gib`, `_nearest_existing_ancestor`, `_is_root_fs`, `_is_writable`.
- `tests/install/test_orchestrate.py` — new coverage for co-location, idempotency (including the pre-#1100-config upgrade path), relative/empty no-ops, and each validation warning branch.

No changes needed in `src/hal0/config/schema.py` — `ModelsConfig.flm_store` (with its absolute-path validator and `effective_store`-style resolution via `config.paths.flm_models_dir`) already existed and needed no changes.

## Test plan

- [x] `uv run ruff format src tests` — clean
- [x] `uv run ruff check src tests` — all checks passed
- [x] `uv run ruff format --check src tests` — 639 files already formatted
- [x] `uv run pytest tests/install/test_orchestrate.py -q` — 20 passed, 1 skipped (host-topology guard skips when tmp and `/` share a device, e.g. some sandboxes)
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 4680 passed, 14 failed, 9 skipped, 1 error; confirmed via `git stash` that the same 14 failures + 1 error pre-exist on `main` (hermes venv/state-render, comfyui phase4, proxmox host detection, container spec dispatch, config-urls proxy, models-preview, settings-store writability) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)