### PR TITLE
installer-setup WS-C: network coherence backend (unify HAL0_BIND_HOST + seed origins/hostname)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -110,9 +110,13 @@ ui_banner
 HAL0_PORT="${HAL0_PORT:-8080}"
 PY="${HAL0_PYTHON:-python3}"
 
-# API binds 0.0.0.0:8080 unconditionally. TLS is upstream's job — see
-# the comment on TLS posture near the flag parser.
-API_BIND_HOST="0.0.0.0"
+# API binds 0.0.0.0:8080 (LAN-reachable) by default; TLS is upstream's job —
+# see the comment on TLS posture near the flag parser. HAL0_BIND_HOST (env,
+# pre-set by the operator or a Proxmox/community-scripts wrapper) overrides
+# the default — this is the SAME var the unit and `hal0 serve` both read
+# (#1099 WS-C), seeded into api.env below so a fresh install and a manual
+# `hal0 serve` never disagree about how far the API is reachable.
+API_BIND_HOST="${HAL0_BIND_HOST:-0.0.0.0}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "${DEV_MODE}" -eq 1 ]]; then
@@ -541,10 +545,33 @@ fi
 
 API_ENV="${ETC_DIR}/api.env"
 if [[ ! -f "${API_ENV}" ]]; then
+    # Network coherence (#1099 WS-C): HAL0_HOSTNAME + HAL0_ALLOWED_ORIGINS are
+    # derived from the SAME API_BIND_HOST decision above, so the dashboard's
+    # advertised URL (GET /api/config/urls) and the WS chat-proxy origin gate
+    # (api/agents/_auth.py) always agree — closes the WS-4403 mismatch a
+    # LAN-bound API + a loopback-only allowlist used to cause. LAN IPs are
+    # only added to the allowlist when the API actually binds beyond
+    # loopback; a fresh `hostname -I` read is best-effort (empty is fine —
+    # the allowlist still has localhost/127.0.0.1/hostname.local).
+    API_HOSTNAME="${HAL0_HOSTNAME:-$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo hal0)}"
+    API_ALLOWED_ORIGINS="http://localhost:${HAL0_PORT},http://127.0.0.1:${HAL0_PORT},http://${API_HOSTNAME}.local:${HAL0_PORT}"
+    if [[ "${API_BIND_HOST}" != "127.0.0.1" && "${API_BIND_HOST}" != "localhost" ]]; then
+        API_LAN_IP="$(hostname -I 2>/dev/null | awk '{print $1}')"
+        if [[ -n "${API_LAN_IP}" ]]; then
+            API_ALLOWED_ORIGINS="${API_ALLOWED_ORIGINS},http://${API_LAN_IP}:${HAL0_PORT}"
+        fi
+    fi
     cat > "${API_ENV}" <<EOF
 HAL0_PORT=${HAL0_PORT}
 HAL0_LOG_LEVEL=info
 HAL0_UI_DIST=${HAL0_UI_DIST_VAL}
+# Network shape (#1099 WS-C) — the SAME HAL0_BIND_HOST hal0-api.service's
+# ExecStart binds to and \`hal0 serve\` defaults to when run directly.
+# HAL0_HOSTNAME/HAL0_ALLOWED_ORIGINS are derived from it at install time;
+# GET /api/config/urls echoes all three back as the single source of truth.
+HAL0_BIND_HOST=${API_BIND_HOST}
+HAL0_HOSTNAME=${API_HOSTNAME}
+HAL0_ALLOWED_ORIGINS=${API_ALLOWED_ORIGINS}
 # Memory subsystem (Hindsight engine + /mcp/memory + the Agent → Memory tab)
 # is ENABLED by default as of v0.5 (brain re-enablement). Comment out to ship
 # with memory dark. Needs the shared hindsight-api daemon (installer/systemd/

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2291,6 +2291,9 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
 HAL0_API_URL = "http://127.0.0.1:8080"
 
 
+_dashboard_url_cache: str | None = None
+
+
 def _dashboard_url() -> str:
     """Resolve the URL Hermes's rendered docs should link back to the dashboard.
 
@@ -2298,7 +2301,8 @@ def _dashboard_url() -> str:
     /api/config/urls"):
 
     1. An explicit ``HAL0_DASHBOARD_URL`` always wins — operator override,
-       e.g. a reverse-proxy hostname distinct from the local API.
+       e.g. a reverse-proxy hostname distinct from the local API. Always
+       re-checked (cheap env read); never cached.
     2. Otherwise ask the local hal0-api for its own canonical URL via
        ``GET /api/config/urls`` (the single source of truth this issue
        establishes — same env-derived ``bind_host``/``hostname`` the
@@ -2307,25 +2311,43 @@ def _dashboard_url() -> str:
        default when the daemon can't be reached (e.g. during
        ExecStartPre, before hal0-api is up) — matches the previous
        behaviour exactly so a degraded daemon never breaks rendering.
+
+    The network/fallback resolution (2/3) is memoised per-process
+    (``_dashboard_url_cache``): ``render_live_context``/
+    ``_phase_context_link`` are content-hash gated — STATE.md/HERMES.md
+    are only rewritten when substantive content changes — so a network
+    round-trip that's merely SLOW (not down) on one call and fast on the
+    next would make ``dashboard_url`` flap between the live value and the
+    fallback across two calls a few seconds apart, defeating that
+    idempotency check and causing spurious rewrites. Dashboard network
+    shape doesn't change without a restart in practice, so resolving it
+    once per process (like the ``HAL0_API_URL`` module constant itself)
+    is the right cost/freshness trade-off here.
     """
     override = os.environ.get("HAL0_DASHBOARD_URL", "").strip()
     if override:
         return override.rstrip("/")
 
+    global _dashboard_url_cache
+    if _dashboard_url_cache is not None:
+        return _dashboard_url_cache
+
     from urllib.error import URLError
     from urllib.request import Request, urlopen
 
+    resolved = os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/")
     req = Request(f"{HAL0_API_URL}/api/config/urls", headers={"Accept": "application/json"})
     try:
         with urlopen(req, timeout=3.0) as resp:
             data = json.loads(resp.read().decode("utf-8"))
         api_url = data.get("api") if isinstance(data, dict) else None
         if isinstance(api_url, str) and api_url.strip():
-            return api_url.strip().rstrip("/")
+            resolved = api_url.strip().rstrip("/")
     except (URLError, OSError, json.JSONDecodeError, TimeoutError, ValueError):
         pass
 
-    return os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/")
+    _dashboard_url_cache = resolved
+    return resolved
 
 
 def _fetch_slots() -> list[dict[str, Any]]:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1861,10 +1861,7 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
         "primary": primary_for_template,
         "chat_slots": chat_slots,
         "peer_agents": [],
-        "dashboard_url": os.environ.get(
-            "HAL0_DASHBOARD_URL",
-            os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
-        ),
+        "dashboard_url": _dashboard_url(),
     }
 
     rendered: dict[str, str] = {}
@@ -2294,6 +2291,43 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
 HAL0_API_URL = "http://127.0.0.1:8080"
 
 
+def _dashboard_url() -> str:
+    """Resolve the URL Hermes's rendered docs should link back to the dashboard.
+
+    Precedence (#1099 WS-C — "Hermes dashboard URL derives from
+    /api/config/urls"):
+
+    1. An explicit ``HAL0_DASHBOARD_URL`` always wins — operator override,
+       e.g. a reverse-proxy hostname distinct from the local API.
+    2. Otherwise ask the local hal0-api for its own canonical URL via
+       ``GET /api/config/urls`` (the single source of truth this issue
+       establishes — same env-derived ``bind_host``/``hostname`` the
+       dashboard and the WS origin gate agree on).
+    3. Falls back to the legacy ``HAL0_API_URL`` env var / hardcoded
+       default when the daemon can't be reached (e.g. during
+       ExecStartPre, before hal0-api is up) — matches the previous
+       behaviour exactly so a degraded daemon never breaks rendering.
+    """
+    override = os.environ.get("HAL0_DASHBOARD_URL", "").strip()
+    if override:
+        return override.rstrip("/")
+
+    from urllib.error import URLError
+    from urllib.request import Request, urlopen
+
+    req = Request(f"{HAL0_API_URL}/api/config/urls", headers={"Accept": "application/json"})
+    try:
+        with urlopen(req, timeout=3.0) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        api_url = data.get("api") if isinstance(data, dict) else None
+        if isinstance(api_url, str) and api_url.strip():
+            return api_url.strip().rstrip("/")
+    except (URLError, OSError, json.JSONDecodeError, TimeoutError, ValueError):
+        pass
+
+    return os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/")
+
+
 def _fetch_slots() -> list[dict[str, Any]]:
     """Pull the full slot list from the local hal0 daemon.
 
@@ -2558,10 +2592,7 @@ def render_live_context(
         "capabilities": capabilities,
         "npu": npu,
         "igpu_sclk_mhz": _igpu_sclk_mhz(),
-        "dashboard_url": os.environ.get(
-            "HAL0_DASHBOARD_URL",
-            os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
-        ),
+        "dashboard_url": _dashboard_url(),
         "inference_base": os.environ.get("HAL0_INFERENCE_BASE", "http://127.0.0.1:8080"),
         "daemon": "degraded" if degraded else "reachable",
         "as_of": now,
@@ -2622,10 +2653,7 @@ def render_live_context(
             primary=primary_for_template,
             chat_slots=chat_slots,
             peer_agents=[],
-            dashboard_url=os.environ.get(
-                "HAL0_DASHBOARD_URL",
-                os.environ.get("HAL0_API_URL", "http://hal0.local:8080").rstrip("/"),
-            ),
+            dashboard_url=_dashboard_url(),
         )
         hpath = RUNTIME_SNAPSHOT_DIR / "HERMES.md"
         out["hermes_path"] = str(hpath)

--- a/src/hal0/api/agents/_auth.py
+++ b/src/hal0/api/agents/_auth.py
@@ -10,10 +10,15 @@ hermes's tool surface.
 This module fixes that for the chat-proxy WebSocket routes by:
 
 1. Origin allowlist on every WS upgrade. Configured via
-   ``HAL0_ALLOWED_ORIGINS`` (comma-separated). Default covers the
-   hal0.local hostname and dev origins (``localhost:5173`` for Vite,
-   ``127.0.0.1:8080`` for the bundled SPA). The check is FREE; missing
-   it leaves the rest of this scheme
+   ``HAL0_ALLOWED_ORIGINS`` (comma-separated); when unset, derived from
+   ``HAL0_BIND_HOST``/``HAL0_HOSTNAME`` via
+   ``hal0.config.network.derive_allowed_origins`` (#1099 WS-C) so it
+   covers the hal0.local hostname, LAN IPs (when LAN-bound), and dev
+   origins (``localhost:5173`` for Vite, ``127.0.0.1:8080`` for the
+   bundled SPA) — the same bind-host value ``GET /api/config/urls``
+   advertises, so the WS gate never 4403s a URL the dashboard just told
+   the operator to use. The check is FREE; missing it leaves the rest of
+   this scheme
    moot because any drive-by site could WebSocket into hal0-api from
    the user's own browser session.
 
@@ -50,10 +55,16 @@ from typing import Final
 from fastapi import HTTPException, Request, Response
 from starlette.websockets import WebSocket
 
+from hal0.config import network
+
 # Default-deny set of browser origins permitted to upgrade to chat-proxy
 # WebSockets. Operators can override at boot via ``HAL0_ALLOWED_ORIGINS``
-# (comma-separated). The default covers:
-#   - http://hal0.local         — mDNS / hosts-file alias
+# (comma-separated). Absent an override, :func:`allowed_origins` unions
+# this static set with the hostname/LAN-derived set from
+# ``hal0.config.network`` — this set alone covers the historical
+# loopback/dev-only defaults so pre-#1099 behaviour never regresses:
+#   - http://hal0.local         — mDNS / hosts-file alias (port-less, for
+#                                 reverse-proxy deploys on :80)
 #   - http://localhost:5173     — Vite dev server (UI hot-reload)
 #   - http://127.0.0.1:8080     — bundled SPA served from hal0-api
 DEFAULT_ALLOWED_ORIGINS: Final[tuple[str, ...]] = (
@@ -124,14 +135,28 @@ def _b64url_decode(s: str) -> bytes:
 def allowed_origins() -> tuple[str, ...]:
     """Effective allowlist, including the env override when set.
 
-    A misconfigured env (empty string) falls back to the default rather
-    than denying everything — first-run dev convenience.
+    A misconfigured env (empty string) falls back to the derived default
+    rather than denying everything — first-run dev convenience.
+
+    Absent an explicit ``HAL0_ALLOWED_ORIGINS`` override, the default is
+    DERIVED from ``HAL0_BIND_HOST``/``HAL0_HOSTNAME`` (#1099 WS-C) via
+    :func:`hal0.config.network.derive_allowed_origins`, unioned with the
+    static :data:`DEFAULT_ALLOWED_ORIGINS` so the historical loopback/dev
+    entries (including the port-less ``http://hal0.local`` reverse-proxy
+    entry) are always present. This is what closes the WS-4403 mismatch:
+    the allowlist now agrees with whatever hostname/LAN-IP ``GET
+    /api/config/urls`` just advertised to the browser.
     """
     raw = os.environ.get("HAL0_ALLOWED_ORIGINS", "").strip()
-    if not raw:
-        return DEFAULT_ALLOWED_ORIGINS
-    parsed = tuple(o.strip() for o in raw.split(",") if o.strip())
-    return parsed or DEFAULT_ALLOWED_ORIGINS
+    if raw:
+        parsed = tuple(o.strip() for o in raw.split(",") if o.strip())
+        if parsed:
+            return parsed
+    try:
+        derived = network.derive_allowed_origins()
+    except Exception:
+        derived = ()
+    return tuple(sorted(set(DEFAULT_ALLOWED_ORIGINS) | set(derived)))
 
 
 def mint_session_cookie(now: float | None = None) -> str:

--- a/src/hal0/api/routes/config.py
+++ b/src/hal0/api/routes/config.py
@@ -22,7 +22,9 @@ from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
 from hal0.api._redact import redact_config
+from hal0.api.agents._auth import allowed_origins as _ws_allowed_origins
 from hal0.api.middleware.error_codes import Hal0Error
+from hal0.config import network as network_config
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import ModelsConfig
 from hal0.registry.discover import scan_and_register
@@ -166,6 +168,26 @@ def _comfyui_link(request: Request) -> str:
     return f"http://{_host_without_port(host)}:{_COMFYUI_PORT}"
 
 
+def _network_fields() -> dict[str, object]:
+    """The network-coherence fields (#1099 WS-C).
+
+    ``bind_host``/``hostname`` are read from the exact same
+    ``HAL0_BIND_HOST``/``HAL0_HOSTNAME`` env vars the systemd unit and
+    ``hal0 serve`` consume (``hal0.config.network``); ``allowed_origins``
+    is the WS-upgrade allowlist the chat-proxy origin gate
+    (``hal0.api.agents._auth.allowed_origins``) actually checks against.
+    Surfacing all three here makes this endpoint the single source of
+    truth the issue asks for: a client can confirm, before opening a
+    WebSocket, that the URL it's about to use is on the allowlist rather
+    than discovering a 4403 after the fact.
+    """
+    return {
+        "bind_host": network_config.bind_host(),
+        "hostname": network_config.hostname(),
+        "allowed_origins": list(_ws_allowed_origins()),
+    }
+
+
 @router.get("/urls")
 async def get_urls(request: Request) -> dict[str, object]:
     """Return the canonical URLs the dashboard should advertise.
@@ -180,7 +202,16 @@ async def get_urls(request: Request) -> dict[str, object]:
           "hermes":            "" | "https://hermes.<host>",
           "hermes_enabled":    true | false,
           "comfyui":           "http://<host>:8188" | "https://comfyui.<host>",
+          "bind_host":         "0.0.0.0" | "127.0.0.1" | "<lan-ip>",
+          "hostname":          "hal0",
+          "allowed_origins":   ["http://hal0.local:8080", ...],
         }
+
+    ``bind_host``/``hostname``/``allowed_origins`` (#1099 WS-C) are the
+    same values the ``hal0-api`` unit and the WS chat-proxy origin gate
+    read — this endpoint is the single source of truth for "what network
+    shape is this box running", so a reverse-proxy/health-check client
+    doesn't need to re-derive it from env vars itself.
 
     ``HAL0_OPENWEBUI_PUBLIC_URL`` (set in /etc/hal0/api.env) wins
     whenever it's defined — it's how a reverse-proxy deploy declares the
@@ -210,6 +241,7 @@ async def get_urls(request: Request) -> dict[str, object]:
     host = _resolve_host(request)
     enabled = await _openwebui_is_active()
     comfyui = _comfyui_link(request)
+    network_fields = _network_fields()
 
     if public:
         if _behind_proxy(request):
@@ -225,6 +257,7 @@ async def get_urls(request: Request) -> dict[str, object]:
             "hermes": hermes,
             "hermes_enabled": bool(hermes),
             "comfyui": comfyui,
+            **network_fields,
         }
 
     if _behind_proxy(request):
@@ -238,6 +271,7 @@ async def get_urls(request: Request) -> dict[str, object]:
             "hermes": hermes,
             "hermes_enabled": bool(hermes),
             "comfyui": comfyui,
+            **network_fields,
         }
     return {
         "api": f"http://{host}:{_api_port()}",
@@ -246,6 +280,7 @@ async def get_urls(request: Request) -> dict[str, object]:
         "hermes": hermes,
         "hermes_enabled": bool(hermes),
         "comfyui": comfyui,
+        **network_fields,
     }
 
 

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -191,7 +191,17 @@ app.command(name="update")(_update_impl)
 
 @app.command()
 def serve(
-    host: str = typer.Option("127.0.0.1", "--host", help="Bind host for the hal0 API."),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        envvar="HAL0_BIND_HOST",
+        help=(
+            "Bind host for the hal0 API. Reads HAL0_BIND_HOST when not "
+            "passed explicitly — the SAME env var hal0-api.service sources "
+            "from /etc/hal0/api.env (#1099 WS-C), so a bare `hal0 serve` "
+            "run outside systemd binds identically to the service."
+        ),
+    ),
     port: int = typer.Option(8080, "--port", help="Bind port for the hal0 API."),
     reload: bool = typer.Option(False, "--reload", help="Enable auto-reload (dev mode)."),
 ) -> None:

--- a/src/hal0/config/network.py
+++ b/src/hal0/config/network.py
@@ -1,0 +1,137 @@
+"""Network-shape resolution — the single source both the systemd unit and
+``hal0 serve`` read from (#1099, installer-setup WS-C, decisions Q3/Q17).
+
+Before this module, ``hal0-api.service``'s ``ExecStart`` baked in a
+hardcoded ``--host 0.0.0.0`` at install time while ``hal0 serve`` (run
+directly, e.g. in dev) defaulted to ``127.0.0.1`` — the two could disagree
+about how far the API is reachable. Nothing derived
+``HAL0_ALLOWED_ORIGINS``/``HAL0_HOSTNAME`` from that choice either, so a
+LAN-reachable install with an unseeded allowlist would advertise
+``http://<lan-ip>:8080`` on the dashboard while the WS origin gate
+(``hal0.api.agents._auth.allowed_origins``) still only recognised the
+loopback/dev defaults — the WS-4403 mismatch the issue closes.
+
+``HAL0_BIND_HOST`` is now the one env var both sides read:
+
+- The unit's ``EnvironmentFile=/etc/hal0/api.env`` sets it; ``ExecStart``
+  substitutes it into ``--host ${HAL0_BIND_HOST}`` at service-start time.
+- ``hal0 serve`` (``src/hal0/cli/main.py``) reads the same var as its
+  Typer ``envvar=`` default, so a bare ``hal0 serve`` (no ``--host`` flag)
+  run outside systemd resolves the exact same value.
+
+Everything else in this module derives from that one value: the canonical
+hostname (mDNS-style, matching ``services/mdns.py``) and the WS/CORS
+origin allowlist (loopback + LAN IPs + hostname), so ``GET
+/api/config/urls`` (``api/routes/config.py``), the WS origin gate, and
+mDNS/avahi (``services/mdns.py``) all agree on the same network shape.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+_DEFAULT_BIND_HOST = "127.0.0.1"
+_DEFAULT_API_PORT = 8080
+_LOOPBACK_BIND_HOSTS = ("127.0.0.1", "localhost", "::1")
+_WILDCARD_BIND_HOSTS = ("0.0.0.0", "::")
+
+
+def bind_host() -> str:
+    """The canonical bind host — read by BOTH the unit and ``hal0 serve``.
+
+    Defaults to loopback-only (``127.0.0.1``) when unset, matching
+    ``hal0 serve``'s historical default; the installer seeds an explicit
+    LAN-reachable value (``0.0.0.0`` by default) into ``/etc/hal0/api.env``.
+    """
+    raw = os.environ.get("HAL0_BIND_HOST", "").strip()
+    return raw or _DEFAULT_BIND_HOST
+
+
+def hostname() -> str:
+    """The canonical operator-facing hostname (bare, no ``.local`` suffix).
+
+    ``HAL0_HOSTNAME`` (the install wizard's choice) wins when set — same
+    precedence ``services/mdns.py::mdns_hostname`` already uses — so the
+    dashboard's advertised URL, mDNS, and the derived origin allowlist
+    never disagree about the machine's name.
+    """
+    raw = os.environ.get("HAL0_HOSTNAME", "").strip() or socket.gethostname()
+    return raw.removesuffix(".local").strip(".") or "hal0"
+
+
+def _api_port() -> int:
+    raw = os.environ.get("HAL0_PORT", "").strip()
+    if not raw:
+        return _DEFAULT_API_PORT
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_API_PORT
+
+
+def detect_lan_ips() -> list[str]:
+    """Best-effort enumeration of this host's non-loopback IPv4 addresses.
+
+    Tries ``psutil`` (already a hal0 dependency, see
+    ``api/routes/hardware.py``) for a full multi-interface scan first; a
+    box that binds a single expected LAN nic won't need it, so a UDP
+    "connect" trick (never sends a packet, just resolves routing) is the
+    fallback for the common single-NIC case, or when psutil is
+    unavailable. Any failure yields an empty list — the allowlist derived
+    from it still contains loopback + hostname either way.
+    """
+    ips: set[str] = set()
+    try:
+        import psutil
+
+        for addrs in psutil.net_if_addrs().values():
+            for addr in addrs:
+                if addr.family == socket.AF_INET and not addr.address.startswith("127."):
+                    ips.add(addr.address)
+    except Exception:
+        pass
+    if not ips:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.connect(("8.8.8.8", 80))
+                ip = sock.getsockname()[0]
+            if ip and not ip.startswith("127."):
+                ips.add(ip)
+        except OSError:
+            pass
+    return sorted(ips)
+
+
+def derive_allowed_origins(port: int | None = None) -> tuple[str, ...]:
+    """Derive the WS/CORS origin allowlist from the bind host + hostname.
+
+    Always includes loopback (``localhost``/``127.0.0.1``) and the mDNS
+    hostname — dev access and the standard LAN URL always work. LAN IPs
+    (and the bind host itself, if it's a concrete address rather than a
+    wildcard) are only added when the API is actually bound to something
+    other than loopback, so the allowlist's reach matches how far the
+    service is actually reachable rather than over- or under-shooting it.
+    """
+    p = port if port is not None else _api_port()
+    host = hostname()
+    origins = {
+        f"http://localhost:{p}",
+        f"http://127.0.0.1:{p}",
+        f"http://{host}.local:{p}",
+    }
+    bh = bind_host()
+    if bh not in _LOOPBACK_BIND_HOSTS:
+        for ip in detect_lan_ips():
+            origins.add(f"http://{ip}:{p}")
+        if bh not in _WILDCARD_BIND_HOSTS:
+            origins.add(f"http://{bh}:{p}")
+    return tuple(sorted(origins))
+
+
+__all__ = [
+    "bind_host",
+    "derive_allowed_origins",
+    "detect_lan_ips",
+    "hostname",
+]

--- a/tests/agents/test_hermes_dashboard_url.py
+++ b/tests/agents/test_hermes_dashboard_url.py
@@ -18,6 +18,19 @@ import pytest
 from hal0.agents import hermes_provision as hp
 
 
+@pytest.fixture(autouse=True)
+def _reset_dashboard_url_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force a fresh network/fallback resolution in every test.
+
+    ``_dashboard_url`` memoises its network/fallback result per-process
+    (see its docstring — this is what fixes the STATE.md/HERMES.md
+    idempotency flake this issue's network call introduced), so without
+    resetting it here, whichever test runs first would poison every test
+    after it with a stale cached value.
+    """
+    monkeypatch.setattr(hp, "_dashboard_url_cache", None)
+
+
 def test_explicit_env_override_always_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     """An explicit override short-circuits before any network call is made."""
     monkeypatch.setenv("HAL0_DASHBOARD_URL", "https://hal0.example.com/")
@@ -107,3 +120,49 @@ def test_ignores_malformed_response_and_falls_back(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
     assert hp._dashboard_url() == "http://hal0.local:8080"
+
+
+def test_network_result_is_cached_across_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The network/fallback resolution only hits urlopen once per process.
+
+    This is the fix for the STATE.md/HERMES.md content-hash idempotency
+    flake (#1099): ``render_live_context`` calls ``_dashboard_url`` on
+    every invocation, but the value must be stable across nearby calls in
+    the same process even if the daemon's reachability is momentarily
+    flaky — otherwise "same substantive state, different clock-time ->
+    NOT rewritten" trips over dashboard_url alone flapping.
+    """
+    monkeypatch.delenv("HAL0_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("HAL0_API_URL", raising=False)
+
+    calls = {"n": 0}
+
+    class _FakeResp:
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"api": "http://10.0.1.5:8080"}).encode("utf-8")
+
+    def fake_urlopen(*_a: object, **_k: object) -> _FakeResp:
+        calls["n"] += 1
+        return _FakeResp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    first = hp._dashboard_url()
+    second = hp._dashboard_url()
+    assert first == second == "http://10.0.1.5:8080"
+    assert calls["n"] == 1
+
+
+def test_explicit_override_is_never_cached(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unlike the network path, an explicit override is re-read every call."""
+    monkeypatch.setenv("HAL0_DASHBOARD_URL", "https://first.example.com")
+    assert hp._dashboard_url() == "https://first.example.com"
+    monkeypatch.setenv("HAL0_DASHBOARD_URL", "https://second.example.com")
+    assert hp._dashboard_url() == "https://second.example.com"

--- a/tests/agents/test_hermes_dashboard_url.py
+++ b/tests/agents/test_hermes_dashboard_url.py
@@ -1,0 +1,109 @@
+"""Tests for ``hermes_provision._dashboard_url`` (#1099 WS-C).
+
+Acceptance criterion: "Hermes dashboard URL derives from
+``/api/config/urls``." Precedence: an explicit ``HAL0_DASHBOARD_URL``
+always wins; otherwise the local hal0-api's ``GET /api/config/urls`` is
+queried for its ``api`` field; a failed/unreachable daemon falls back to
+the legacy ``HAL0_API_URL`` env var / hardcoded default (unchanged
+behaviour from before this issue).
+"""
+
+from __future__ import annotations
+
+import json
+from urllib.error import URLError
+
+import pytest
+
+from hal0.agents import hermes_provision as hp
+
+
+def test_explicit_env_override_always_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit override short-circuits before any network call is made."""
+    monkeypatch.setenv("HAL0_DASHBOARD_URL", "https://hal0.example.com/")
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise AssertionError("must not reach the network when an override is set")
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    assert hp._dashboard_url() == "https://hal0.example.com"
+
+
+def test_derives_from_config_urls_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Absent an override, the local /api/config/urls "api" field wins."""
+    monkeypatch.delenv("HAL0_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("HAL0_API_URL", raising=False)
+
+    class _FakeResp:
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"api": "http://10.0.1.5:8080"}).encode("utf-8")
+
+    def fake_urlopen(req: object, timeout: float = 3.0) -> _FakeResp:
+        assert "/api/config/urls" in req.full_url  # type: ignore[attr-defined]
+        return _FakeResp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert hp._dashboard_url() == "http://10.0.1.5:8080"
+
+
+def test_falls_back_when_daemon_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreachable local daemon falls back to the legacy env/default chain."""
+    monkeypatch.delenv("HAL0_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("HAL0_API_URL", raising=False)
+
+    def fake_urlopen(*_a: object, **_k: object) -> None:
+        raise URLError("connection refused")
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert hp._dashboard_url() == "http://hal0.local:8080"
+
+
+def test_falls_back_to_hal0_api_url_env_when_daemon_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HAL0_DASHBOARD_URL", raising=False)
+    monkeypatch.setenv("HAL0_API_URL", "https://fallback.example.com/")
+
+    def fake_urlopen(*_a: object, **_k: object) -> None:
+        raise URLError("connection refused")
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert hp._dashboard_url() == "https://fallback.example.com"
+
+
+def test_ignores_malformed_response_and_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 with an unexpected body shape falls back rather than raising."""
+    monkeypatch.delenv("HAL0_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("HAL0_API_URL", raising=False)
+
+    class _FakeResp:
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"not json"
+
+    def fake_urlopen(*_a: object, **_k: object) -> _FakeResp:
+        return _FakeResp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert hp._dashboard_url() == "http://hal0.local:8080"

--- a/tests/api/test_chat_proxy_auth.py
+++ b/tests/api/test_chat_proxy_auth.py
@@ -103,9 +103,22 @@ def test_allowed_origins_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_allowed_origins_empty_env_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
-    """An empty override falls back to the default allowlist (dev convenience)."""
+    """An empty override falls back to the derived default (dev convenience).
+
+    #1099 WS-C: the derived default always includes the historical
+    static ``DEFAULT_ALLOWED_ORIGINS`` set, unioned with whatever
+    ``hal0.config.network.derive_allowed_origins`` adds for the current
+    ``HAL0_BIND_HOST``/``HAL0_HOSTNAME``/``HAL0_PORT`` — pinned here so
+    the loopback-bind case stays deterministic.
+    """
     monkeypatch.setenv("HAL0_ALLOWED_ORIGINS", "")
-    assert _auth.allowed_origins() == _auth.DEFAULT_ALLOWED_ORIGINS
+    monkeypatch.setenv("HAL0_BIND_HOST", "127.0.0.1")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.delenv("HAL0_PORT", raising=False)
+    origins = _auth.allowed_origins()
+    assert set(_auth.DEFAULT_ALLOWED_ORIGINS) <= set(origins)
+    assert "http://hal0.local:8080" in origins
+    assert "http://127.0.0.1:8080" in origins
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_config_urls.py
+++ b/tests/api/test_config_urls.py
@@ -202,3 +202,105 @@ def test_urls_comfyui_behind_proxy_without_env_uses_port_8188(client: TestClient
     assert resp.status_code == 200
     body = resp.json()
     assert body["comfyui"] == "http://hal0.thinmint.dev:8188", body
+
+
+# ── #1099 WS-C: network coherence (bind_host / hostname / allowed_origins) ──
+
+
+def test_urls_network_coherence_keys_present(client: TestClient) -> None:
+    """bind_host/hostname/allowed_origins are always present (#1099 WS-C).
+
+    These are the single-source-of-truth fields: the same values the
+    hal0-api unit binds to and the WS chat-proxy origin gate
+    (``api/agents/_auth.allowed_origins``) checks against.
+    """
+    resp = client.get("/api/config/urls")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) >= {"bind_host", "hostname", "allowed_origins"}
+    assert isinstance(body["bind_host"], str) and body["bind_host"]
+    assert isinstance(body["hostname"], str) and body["hostname"]
+    assert isinstance(body["allowed_origins"], list) and body["allowed_origins"]
+
+
+def test_urls_bind_host_defaults_to_loopback(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """Unset HAL0_BIND_HOST resolves to 127.0.0.1 — hal0 serve's historical default."""
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)
+    resp = client.get("/api/config/urls")
+    assert resp.json()["bind_host"] == "127.0.0.1"
+
+
+def test_urls_bind_host_honours_env(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """HAL0_BIND_HOST echoes through — the same var the unit's ExecStart reads."""
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    resp = client.get("/api/config/urls")
+    assert resp.json()["bind_host"] == "0.0.0.0"
+
+
+def test_urls_hostname_honours_env(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """HAL0_HOSTNAME (the install wizard's choice) wins for the hostname field."""
+    monkeypatch.setenv("HAL0_HOSTNAME", "mybox")
+    resp = client.get("/api/config/urls")
+    assert resp.json()["hostname"] == "mybox"
+
+
+def test_urls_allowed_origins_honours_explicit_env(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """An explicit HAL0_ALLOWED_ORIGINS is echoed back verbatim."""
+    monkeypatch.setenv(
+        "HAL0_ALLOWED_ORIGINS",
+        "https://demo.example.com,http://other.example.com",
+    )
+    resp = client.get("/api/config/urls")
+    body = resp.json()
+    assert body["allowed_origins"] == [
+        "https://demo.example.com",
+        "http://other.example.com",
+    ], body
+
+
+def test_urls_allowed_origins_derives_lan_ip_when_lan_bound(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """Binding beyond loopback pulls in a detected LAN IP (#1099 WS-C).
+
+    This is the fix for the WS-4403 mismatch: a LAN-reachable install
+    must advertise (and accept) the LAN URL, not just loopback/mDNS.
+    """
+    from hal0.config import network as network_config
+
+    monkeypatch.delenv("HAL0_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.setattr(network_config, "detect_lan_ips", lambda: ["192.0.2.10"])
+    resp = client.get("/api/config/urls")
+    body = resp.json()
+    assert "http://192.0.2.10:8080" in body["allowed_origins"], body
+    assert "http://hal0.local:8080" in body["allowed_origins"], body
+
+
+def test_urls_allowed_origins_loopback_bind_skips_lan_ips(
+    monkeypatch,
+    client: TestClient,
+) -> None:
+    """A loopback-only bind never leaks LAN IPs into the allowlist."""
+    from hal0.config import network as network_config
+
+    monkeypatch.delenv("HAL0_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("HAL0_BIND_HOST", "127.0.0.1")
+    monkeypatch.setattr(network_config, "detect_lan_ips", lambda: ["192.0.2.10"])
+    resp = client.get("/api/config/urls")
+    body = resp.json()
+    assert "http://192.0.2.10:8080" not in body["allowed_origins"], body

--- a/tests/cli/test_serve_bind_host.py
+++ b/tests/cli/test_serve_bind_host.py
@@ -1,0 +1,71 @@
+"""Tests for ``hal0 serve``'s bind-host resolution (#1099 WS-C).
+
+Before this fix, ``hal0-api.service``'s ExecStart baked a hardcoded
+``--host 0.0.0.0`` into the unit at install time while ``hal0 serve`` run
+directly (no ``--host`` flag) defaulted to ``127.0.0.1`` — the two could
+disagree about how far the API is reachable. ``HAL0_BIND_HOST`` is now the
+one env var both sides read; these tests lock ``hal0 serve``'s side of
+that contract (the CLI's ``--host`` Typer option resolves from the env
+var when the flag isn't passed explicitly).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import main as cli_main
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured_uvicorn_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub ``uvicorn.run`` so the test never actually binds a socket."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(app_path: str, *, host: str, port: int, reload: bool) -> None:
+        captured["app_path"] = app_path
+        captured["host"] = host
+        captured["port"] = port
+        captured["reload"] = reload
+
+    monkeypatch.setattr(cli_main.uvicorn, "run", fake_run)
+    return captured
+
+
+def test_serve_defaults_to_loopback_without_env(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_uvicorn_run: dict[str, Any],
+) -> None:
+    """No --host flag, no HAL0_BIND_HOST env → historical 127.0.0.1 default."""
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)
+    result = runner.invoke(cli_main.app, ["serve"])
+    assert result.exit_code == 0, result.output
+    assert captured_uvicorn_run["host"] == "127.0.0.1"
+
+
+def test_serve_reads_hal0_bind_host_env(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_uvicorn_run: dict[str, Any],
+) -> None:
+    """HAL0_BIND_HOST — the SAME var the unit's EnvironmentFile sets —
+    becomes the effective default when --host isn't passed explicitly.
+    """
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    result = runner.invoke(cli_main.app, ["serve"])
+    assert result.exit_code == 0, result.output
+    assert captured_uvicorn_run["host"] == "0.0.0.0"
+
+
+def test_serve_explicit_flag_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+    captured_uvicorn_run: dict[str, Any],
+) -> None:
+    """An explicit --host always overrides HAL0_BIND_HOST."""
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    result = runner.invoke(cli_main.app, ["serve", "--host", "192.0.2.5"])
+    assert result.exit_code == 0, result.output
+    assert captured_uvicorn_run["host"] == "192.0.2.5"

--- a/tests/config/test_network.py
+++ b/tests/config/test_network.py
@@ -1,0 +1,114 @@
+"""Tests for ``hal0.config.network`` — the #1099 WS-C bind-host/allowed-
+origins/hostname derivation the systemd unit, ``hal0 serve``, ``GET
+/api/config/urls``, and the WS chat-proxy origin gate all share.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config import network
+
+
+def test_bind_host_defaults_to_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_BIND_HOST", raising=False)
+    assert network.bind_host() == "127.0.0.1"
+
+
+def test_bind_host_honours_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    assert network.bind_host() == "0.0.0.0"
+
+
+def test_bind_host_strips_and_ignores_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "   ")
+    assert network.bind_host() == "127.0.0.1"
+
+
+def test_hostname_defaults_to_system_hostname(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_HOSTNAME", raising=False)
+    monkeypatch.setattr(network.socket, "gethostname", lambda: "some-box.local")
+    assert network.hostname() == "some-box"
+
+
+def test_hostname_honours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_HOSTNAME", "mybox.local")
+    assert network.hostname() == "mybox"
+    monkeypatch.setenv("HAL0_HOSTNAME", "mybox")
+    assert network.hostname() == "mybox"
+
+
+def test_hostname_falls_back_to_hal0_when_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_HOSTNAME", raising=False)
+    monkeypatch.setattr(network.socket, "gethostname", lambda: "")
+    assert network.hostname() == "hal0"
+
+
+def test_derive_allowed_origins_loopback_bind_has_no_lan_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loopback-bound API never leaks LAN IPs into the allowlist."""
+    monkeypatch.setenv("HAL0_BIND_HOST", "127.0.0.1")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.5"])
+    origins = network.derive_allowed_origins(port=8080)
+    assert origins == (
+        "http://127.0.0.1:8080",
+        "http://hal0.local:8080",
+        "http://localhost:8080",
+    )
+
+
+def test_derive_allowed_origins_wildcard_bind_adds_lan_ips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """0.0.0.0 (the installer default) pulls in detected LAN IPs."""
+    monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.5", "10.0.0.6"])
+    origins = network.derive_allowed_origins(port=8080)
+    assert "http://10.0.0.5:8080" in origins
+    assert "http://10.0.0.6:8080" in origins
+    # The wildcard bind host itself is never added as a literal origin.
+    assert "http://0.0.0.0:8080" not in origins
+
+
+def test_derive_allowed_origins_concrete_lan_bind_adds_itself(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concrete LAN bind address (not a wildcard) is added as its own origin."""
+    monkeypatch.setenv("HAL0_BIND_HOST", "192.0.2.50")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.setattr(network, "detect_lan_ips", lambda: [])
+    origins = network.derive_allowed_origins(port=8080)
+    assert "http://192.0.2.50:8080" in origins
+
+
+def test_derive_allowed_origins_uses_hal0_port_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_BIND_HOST", "127.0.0.1")
+    monkeypatch.setenv("HAL0_HOSTNAME", "hal0")
+    monkeypatch.setenv("HAL0_PORT", "9090")
+    origins = network.derive_allowed_origins()
+    assert "http://127.0.0.1:9090" in origins
+    assert "http://hal0.local:9090" in origins
+
+
+def test_derive_allowed_origins_explicit_port_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HAL0_PORT", "9090")
+    origins = network.derive_allowed_origins(port=1234)
+    assert any(o.endswith(":1234") for o in origins)
+    assert not any(o.endswith(":9090") for o in origins)
+
+
+def test_detect_lan_ips_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Best-effort — a fully broken network stack yields an empty list, not a crash."""
+    import psutil
+
+    def _boom(*_a: object, **_k: object) -> None:
+        raise OSError("no network")
+
+    monkeypatch.setattr(psutil, "net_if_addrs", _boom)
+    monkeypatch.setattr(network.socket, "socket", _boom)
+    assert network.detect_lan_ips() == []


### PR DESCRIPTION
## Summary

- Unify `HAL0_BIND_HOST` as the single env var read by **both** `hal0-api.service`'s `ExecStart` (via `installer/install.sh`) and `hal0 serve`'s `--host` default (`src/hal0/cli/main.py`, via Typer's `envvar=`) — previously the unit hardcoded `0.0.0.0` while `serve` defaulted to `127.0.0.1`.
- `GET /api/config/urls` (`src/hal0/api/routes/config.py`) is now the single source of truth: it returns `bind_host`, `hostname`, and `allowed_origins` alongside the existing url fields, all derived from the same env vars the unit/serve read.
- New `src/hal0/config/network.py` module derives the WS/CORS `allowed_origins` allowlist (loopback + LAN IPs + hostname) from `HAL0_BIND_HOST`/`HAL0_HOSTNAME`, and the chat-proxy WS origin gate (`src/hal0/api/agents/_auth.py::allowed_origins`) now falls back to this derived set (unioned with the historical static defaults) instead of a fixed loopback-only default — this closes the WS-4403 mismatch where a LAN-reachable install would advertise a LAN URL the WS gate didn't actually accept.
- `installer/install.sh` seeds `HAL0_BIND_HOST`, `HAL0_HOSTNAME`, and `HAL0_ALLOWED_ORIGINS` into `/etc/hal0/api.env` from one bind-host decision (tight, scoped edit — no other install.sh behavior touched).
- Hermes' rendered `dashboard_url` (`src/hal0/agents/hermes_provision.py`) now derives from the local `GET /api/config/urls` (falling back to the legacy `HAL0_DASHBOARD_URL`/`HAL0_API_URL` env chain when the daemon is unreachable), memoized per-process so the STATE.md/HERMES.md content-hash idempotency check stays stable.

## Acceptance criteria

- [x] Unit and `serve` read the same bind host var
- [x] `HAL0_ALLOWED_ORIGINS` + `HAL0_HOSTNAME` seeded from the bind choice
- [x] Reaching the dashboard by the advertised URL passes the WS origin gate (derived allowlist now includes it)
- [x] Hermes dashboard URL derives from `/api/config/urls`

Answer-file coverage (`network.bind_host`/`hostname`/`public_url`) is intentionally left as-is in `src/hal0/install/answers.py` — that loader is owned by a sibling PR per the isolation plan; this PR lands the derivation + endpoint + seeding it will eventually call into.

Closes #1099

## Test plan

- [x] `uv run ruff format src tests` / `ruff check src tests` / `ruff format --check` — clean
- [x] `uv run pytest tests/api/ -q` — passes except 5 pre-existing failures (comfyui_phase4 x2, config_urls proxy test, models_preview, settings_models_store) confirmed identical on `main` via a parent-commit comparison run
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 14 failed + 1 error, confirmed byte-identical (same test names) on `main` via a side-by-side full-suite run at the parent commit — none caused by this change
- [x] New tests: `tests/config/test_network.py`, `tests/cli/test_serve_bind_host.py`, `tests/agents/test_hermes_dashboard_url.py`, plus extensions to `tests/api/test_config_urls.py` and `tests/api/test_chat_proxy_auth.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)