### PR TITLE
installer-setup WS-F: thread single npu_opt_in through suggest+apply; gate NPU intro on present+healthy

### DIFF
--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -18,6 +18,7 @@ from hal0.config.schema import HardwareInfo
 from hal0.hardware.probe import HardwareProbe, HardwareProbeError
 from hal0.install.extensions import EXTENSIONS, get_extension
 from hal0.install.orchestrate import Selections, SlotSelection
+from hal0.install.profile_derive import npu_healthy
 
 #: capability → (slot_name, port) for the slots first-run provisions. Mirrors
 #: installer.py:_SLOT_META for the shared capabilities (chat/coder/embed/stt/
@@ -135,7 +136,10 @@ def build_auto_selections(
         storage_dir=storage_dir,
         slots=slots,
         extensions=ext,
-        npu_opt_in=bool(hw.npu.present),
+        # NPU routing on ONLY when present AND healthy (#1109): a present-but-
+        # broken NPU (npu.validated False/None) must not auto-advertise a lane
+        # apply_setup would skip. Same single npu_opt_in the picker + apply use.
+        npu_opt_in=npu_healthy(hw),
         comfyui_defaults=comfyui_defaults,
     )
 

--- a/src/hal0/cli/setup_copy.py
+++ b/src/hal0/cli/setup_copy.py
@@ -40,6 +40,14 @@ PANE_COPY: dict[str, PaneCopy] = {
         "Your NPU can run embeddings, speech-to-text, and text-to-speech in "
         "parallel — leaving the GPU for chat. Recommended when present.",
     ),
+    "npu_broken": PaneCopy(
+        "NPU needs attention",
+        "An NPU was detected but `flm validate` failed, so we're leaving it "
+        "off — enabling it would create slots that never start. Usual causes: "
+        "the amdxdna accel device isn't passed through to this container, or "
+        "libxrt-npu2 doesn't match the host driver. Fix the passthrough / "
+        "driver, then re-run `hal0 setup` to enable the NPU.",
+    ),
     "capabilities": PaneCopy(
         "Capability slots",
         "Wire up embeddings, rerank, speech, and vision. For each, pick a "

--- a/src/hal0/cli/setup_ui.py
+++ b/src/hal0/cli/setup_ui.py
@@ -17,6 +17,7 @@ from hal0.cli.setup_copy import PANE_COPY
 from hal0.config.schema import HardwareInfo
 from hal0.install.extensions import EXTENSIONS, get_extension
 from hal0.install.orchestrate import Selections, SlotSelection
+from hal0.install.profile_derive import npu_healthy
 from hal0.install.suggest import suggest_models
 
 _con = Console()
@@ -91,10 +92,16 @@ def _any_agent(extensions: dict) -> bool:
     )
 
 
-def plan_steps(*, extensions: dict, npu_present: bool) -> list[str]:
+def plan_steps(*, extensions: dict, npu_present: bool, npu_ok: bool = False) -> list[str]:
     """Ordered list of step keys to show, gated on extension picks (spec §6.3).
     Main shows whenever OWUI OR any agent is enabled; Agent shows iff any agent
-    is enabled; NPU shows iff hardware present."""
+    is enabled.
+
+    NPU gating (WS-F / #1109): the ``npu`` enable offer shows ONLY when the NPU
+    is present AND healthy (``npu_ok`` — the #1097 ``npu.validated`` fact via
+    :func:`~hal0.install.profile_derive.npu_healthy`). A present-but-broken NPU
+    gets the ``npu_broken`` remedy step instead of the enable offer, so we never
+    advertise an NPU lane the operator can't actually use."""
     steps = ["welcome", "storage", "extensions"]
     needs_main = bool(extensions.get("openwebui")) or _any_agent(extensions)
     if needs_main:
@@ -102,7 +109,7 @@ def plan_steps(*, extensions: dict, npu_present: bool) -> list[str]:
     if _any_agent(extensions):
         steps.append("agent")
     if npu_present:
-        steps.append("npu")
+        steps.append("npu" if npu_ok else "npu_broken")
     # Capability slots (embed/rerank/stt/tts/vision) are always offered — they
     # don't depend on a chat consumer.
     steps.append("capabilities")
@@ -137,11 +144,17 @@ def _provision_body(slot_name, suggestions) -> RenderableType:
     )
 
 
-def _provision_slot(step_key, capability, hw, slot_name, port, *, prefer_coder=False):
+def _provision_slot(
+    step_key, capability, hw, slot_name, port, *, prefer_coder=False, npu_opt_in=False
+):
     """Guide the operator through one slot: pick a fitting model, scaffold the
     slot empty (``model_id=None``), or skip it. Returns a ``SlotSelection`` or
-    ``None`` to skip. Never auto-selects a model on the operator's behalf."""
-    sugg = suggest_models(capability, hw, limit=3, prefer_coder=prefer_coder)
+    ``None`` to skip. Never auto-selects a model on the operator's behalf.
+
+    ``npu_opt_in`` is passed straight through to :func:`suggest_models` so the
+    advertised ``device`` matches the lane ``apply_setup`` will use (e.g. the
+    NPU-only ``stt`` slot only shows an NPU device once the operator opted in)."""
+    sugg = suggest_models(capability, hw, limit=3, prefer_coder=prefer_coder, npu_opt_in=npu_opt_in)
     _draw(step_key, _provision_body(slot_name, sugg), hw)
     choices = [str(i + 1) for i in range(len(sugg))] + ["s", "x"]
     # Default to the recommended pick when one fits; otherwise to "scaffold".
@@ -195,7 +208,7 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
     state = {e.id: e.default_enabled for e in EXTENSIONS}
     _toggle_extensions(state, hw)
 
-    steps = plan_steps(extensions=state, npu_present=bool(hw.npu.present))
+    steps = plan_steps(extensions=state, npu_present=bool(hw.npu.present), npu_ok=npu_healthy(hw))
     slots: list[SlotSelection] = []
     if "main" in steps:
         name, port = _SETUP_SLOTS["chat"]
@@ -209,8 +222,22 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
             slots.append(s)
     npu_opt_in = False
     if "npu" in steps:
+        # Present + healthy: offer to route the NPU trio.
         _draw("npu", "Run embed + STT + TTS on the NPU?", hw)
         npu_opt_in = Confirm.ask("Enable NPU trio?", default=True)
+    elif "npu_broken" in steps:
+        # Present but NOT healthy (npu.validated is False/None): show the remedy,
+        # never the enable offer — apply_setup would skip an NPU lane here.
+        _draw(
+            "npu_broken",
+            Text(
+                "NPU detected but functional validation failed — leaving it off. "
+                "See the remedy on the right, then re-run `hal0 setup` once it validates.",
+                style="yellow",
+            ),
+            hw,
+        )
+        Prompt.ask("Press Enter to continue", default="")
     if "capabilities" in steps:
         # STT is NPU-only (derive_device returns None without an NPU), so only
         # offer it when the NPU trio is on.
@@ -219,7 +246,7 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
             caps.insert(2, "stt")
         for cap in caps:
             name, port = _SETUP_SLOTS[cap]
-            s = _provision_slot("capabilities", cap, hw, name, port)
+            s = _provision_slot("capabilities", cap, hw, name, port, npu_opt_in=npu_opt_in)
             if s:
                 slots.append(s)
 

--- a/src/hal0/install/answers.py
+++ b/src/hal0/install/answers.py
@@ -28,6 +28,7 @@ import yaml
 from hal0.config.schema import HardwareInfo
 from hal0.install.extensions import EXTENSIONS
 from hal0.install.orchestrate import Selections, SlotSelection
+from hal0.install.profile_derive import npu_healthy
 from hal0.install.suggest import suggest_models
 
 #: Top-level keys this loader recognizes at all (wired or not-yet-wired).
@@ -195,7 +196,10 @@ def _resolve_npu_opt_in(doc: dict[str, Any], hw: HardwareInfo) -> bool:
         raise AnswersError("npu must be a mapping")
     opt_in = npu.get("opt_in", "auto")
     if opt_in == "auto":
-        return bool(hw.npu.present)
+        # `auto` resolves to present-AND-healthy (#1109): the same single
+        # npu_opt_in the picker + apply use, so an unvalidated / broken NPU
+        # (npu.validated False/None) never auto-advertises a lane apply skips.
+        return npu_healthy(hw)
     if isinstance(opt_in, bool):
         return opt_in
     raise AnswersError(f"npu.opt_in must be true, false, or 'auto', got {opt_in!r}")

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -38,6 +38,24 @@ NPU_ONLY_CHAT_CAPS = frozenset({"agent"})
 NPU_FALLBACK_CHAT_CAPS = frozenset({"utility"})
 
 
+def npu_healthy(hw: HardwareInfo) -> bool:
+    """True only when the NPU is present AND functionally healthy.
+
+    "Healthy" means device-node detection (:attr:`NPUInfo.present`) *and* the
+    functional ``flm validate`` pass recorded at install/setup time
+    (:attr:`NPUInfo.validated` is ``True`` — the #1097 hardware.json fact,
+    passthrough + render-group GID reachable). ``validated is False``
+    (present-but-broken: libxrt-npu2 mismatch / passthrough gap) and
+    ``validated is None`` (present but never validated) are both **unhealthy**:
+    we never advertise / auto-enable a device we cannot confirm works.
+
+    This is the single source of truth that folds NPU health into the one
+    ``npu_opt_in`` boolean threaded through suggest + apply, so the picker never
+    advertises an NPU slot that ``apply_setup`` would then skip.
+    """
+    return bool(hw.npu.present and hw.npu.validated is True)
+
+
 def npu_takes_utility(hw: HardwareInfo, *, npu_opt_in: bool) -> bool:
     """True when the NPU claims the ``utility`` role on this box.
 

--- a/src/hal0/install/suggest.py
+++ b/src/hal0/install/suggest.py
@@ -53,13 +53,26 @@ def _is_coder(m: CuratedModel) -> bool:
 
 
 def suggest_models(
-    capability: str, hw: HardwareInfo, *, limit: int = 3, prefer_coder: bool = False
+    capability: str,
+    hw: HardwareInfo,
+    *,
+    limit: int = 3,
+    prefer_coder: bool = False,
+    npu_opt_in: bool = False,
 ) -> list[Suggestion]:
     """Return up to ``limit`` curated picks for ``capability`` that fit the
-    detected RAM, largest-first, with exactly one marked ``recommended``."""
+    detected RAM, largest-first, with exactly one marked ``recommended``.
+
+    ``npu_opt_in`` is threaded straight into :func:`derive_device` — the SAME
+    value ``apply_setup`` uses — so the ``device`` a suggestion advertises is
+    exactly the lane the slot will land on. It defaults to ``False`` (never
+    advertise an NPU lane) because an NPU device is only ever offered once the
+    operator has opted in via a present-AND-healthy NPU step. This closes the
+    old mismatch where the picker hardcoded ``npu_opt_in=True`` and advertised
+    an NPU slot that ``apply_setup`` then skipped."""
     wanted = _CAP_MATCH.get(capability, (capability,))
     ram = _ram_gb(hw)
-    device = derive_device(capability, hw, npu_opt_in=True)
+    device = derive_device(capability, hw, npu_opt_in=npu_opt_in)
     profile = derive_profile(capability, device) if device else None
 
     cands = [

--- a/tests/cli/test_setup_ui.py
+++ b/tests/cli/test_setup_ui.py
@@ -123,3 +123,20 @@ def test_nothing_consuming_chat_hides_main():
 def test_no_npu_skips_npu_step():
     steps = plan_steps(extensions={"openwebui": True}, npu_present=False)
     assert "npu" not in steps
+    assert "npu_broken" not in steps
+
+
+def test_present_and_healthy_npu_shows_enable_offer():
+    # present + healthy → the "npu" enable offer, NOT the remedy (#1109).
+    steps = plan_steps(extensions={"openwebui": True}, npu_present=True, npu_ok=True)
+    assert "npu" in steps and "npu_broken" not in steps
+
+
+def test_present_but_broken_npu_shows_remedy_not_offer():
+    # present but NOT healthy → the "npu_broken" remedy, never the enable offer.
+    steps = plan_steps(extensions={"openwebui": True}, npu_present=True, npu_ok=False)
+    assert "npu_broken" in steps and "npu" not in steps
+
+
+def test_pane_copy_has_npu_broken_remedy():
+    assert "npu_broken" in PANE_COPY and PANE_COPY["npu_broken"].body

--- a/tests/install/test_answers.py
+++ b/tests/install/test_answers.py
@@ -8,14 +8,15 @@ from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 from hal0.install.answers import AnswersError, load_answers
 
 
-def _hw(ram_gb=96, npu_present=True):
+def _hw(ram_gb=96, npu_present=True, npu_validated=True):
     return HardwareInfo(
         platform="strix-halo",
         ram_mb=ram_gb * 1024,
         ram_available_mb=ram_gb * 1024,
         unified_memory_mb=ram_gb * 1024,
         gpus=[GPUInfo(vendor="amd", vram_mb=512, compute_capable=True, vulkan_capable=True)],
-        npu=NPUInfo(present=npu_present),
+        # Default fixture is a present-AND-healthy NPU (#1109 auto → opt-in True).
+        npu=NPUInfo(present=npu_present, validated=npu_validated if npu_present else None),
     )
 
 
@@ -284,3 +285,34 @@ def test_npu_opt_in_explicit_bool_passes_through(tmp_path):
     # even on a box without an NPU, explicit true passes through unchanged.
     sel = load_answers(path, _hw(npu_present=False))
     assert sel.npu_opt_in is True
+
+
+_AUTO_NPU = """
+version: 1
+model_store: { path: /var/lib/hal0/models }
+slots: []
+npu: { opt_in: auto }
+gen: { mode: off }
+apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+"""
+
+
+def test_npu_opt_in_auto_resolves_present_and_healthy(tmp_path):
+    # `auto` on a present + validated NPU → opt-in True (#1109).
+    path = _write(tmp_path, _AUTO_NPU)
+    sel = load_answers(path, _hw(npu_present=True, npu_validated=True))
+    assert sel.npu_opt_in is True
+
+
+def test_npu_opt_in_auto_off_when_present_but_broken(tmp_path):
+    # `auto` on a present-but-BROKEN NPU (validated False) → opt-in False: never
+    # auto-advertise a lane apply_setup would skip (#1109).
+    path = _write(tmp_path, _AUTO_NPU)
+    sel = load_answers(path, _hw(npu_present=True, npu_validated=False))
+    assert sel.npu_opt_in is False
+
+
+def test_npu_opt_in_auto_off_when_absent(tmp_path):
+    path = _write(tmp_path, _AUTO_NPU)
+    sel = load_answers(path, _hw(npu_present=False))
+    assert sel.npu_opt_in is False

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -6,6 +6,7 @@ from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
 from hal0.install.profile_derive import (
     derive_device,
     derive_profile,
+    npu_healthy,
     npu_takes_utility,
 )
 
@@ -103,6 +104,24 @@ def test_utility_capability_routes_like_chat_lane():
     # NPU-absent → utility stays on the iGPU.
     igpu_box = _hw(npu=False, compute=True)
     assert derive_device("utility", igpu_box, npu_opt_in=False) == "gpu-rocm"
+
+
+def test_npu_healthy_requires_present_and_validated_true():
+    """npu_healthy is True ONLY for present + validated=True (#1109). A present-
+    but-broken (False) or never-validated (None) NPU is unhealthy, and an absent
+    NPU is unhealthy regardless of the validated flag."""
+    from hal0.config.schema import NPUInfo
+
+    def _with(present, validated):
+        hw = _hw(npu=present)
+        hw.npu = NPUInfo(present=present, validated=validated)
+        return hw
+
+    assert npu_healthy(_with(True, True)) is True
+    assert npu_healthy(_with(True, False)) is False
+    assert npu_healthy(_with(True, None)) is False
+    assert npu_healthy(_with(False, True)) is False
+    assert npu_healthy(_with(False, None)) is False
 
 
 def test_tts_is_cpu_kokoro():

--- a/tests/install/test_suggest.py
+++ b/tests/install/test_suggest.py
@@ -61,3 +61,14 @@ def test_stt_suggestions_use_stt_capability():
 def test_embed_suggestions_returned():
     out = suggest_models("embed", _hw(96), limit=3)
     assert out and all(s.capability == "embed" for s in out)
+
+
+def test_npu_opt_in_threads_into_advertised_device():
+    # STT is NPU-only. With npu_opt_in=True the picker advertises the NPU lane;
+    # with the default (False) it advertises NO device — the SAME value apply
+    # uses, so the picker never advertises a lane apply_setup would skip (#1109).
+    hw = _hw(96, npu=True)
+    on = suggest_models("stt", hw, limit=3, npu_opt_in=True)
+    assert on and all(s.device == "npu" and s.profile == "flm" for s in on)
+    off = suggest_models("stt", hw, limit=3)  # default npu_opt_in=False
+    assert off and all(s.device is None and s.profile is None for s in off)


### PR DESCRIPTION
## What

Part of the guided **Hal0 Installer Setup** redesign (Wave 3 / WS-F, decision Q15).

`suggest_models()` hardcoded `npu_opt_in=True` while `apply_setup` used the real value, so the picker could advertise an NPU slot that `apply_setup` then skipped. This threads ONE `npu_opt_in` through **both** suggest + apply, and folds NPU **health** into that single boolean at every decision point — so the picker never advertises a lane apply will skip.

## Changes

- **`suggest.py`** — `suggest_models` gains `npu_opt_in` (default `False`), threaded straight into `derive_device` (the SAME value `apply_setup` uses). Stops hardcoding `True`.
- **`profile_derive.py`** — new `npu_healthy(hw)`: single source of truth = `present AND npu.validated is True` (the #1097 `hardware.json` fact — passthrough / render-group GID reachable). Present-but-broken (`validated is False`) and never-validated (`None`) are both **unhealthy**.
- **`setup_ui.py`** — the `npu` enable-offer step shows **only when present + healthy**; a present-but-broken NPU gets a new **`npu_broken` remedy step** (explains the amdxdna passthrough / libxrt-npu2 fix) instead of the enable offer. `npu_opt_in` also threads into the capability-slot picker so the NPU-only `stt` slot advertises the NPU lane only once opted in.
- **`setup_copy.py`** — adds the `npu_broken` pane copy.
- **`setup_command.py`** / **`answers.py`** — `--auto` (`build_auto_selections`) and the answer-file `npu.opt_in: auto` both now resolve to **present-AND-healthy** via `npu_healthy`, so an unvalidated / broken NPU never auto-advertises a lane apply skips.

`apply_setup`'s slot-creation / enable / context-clamp region (issue #1108) is untouched: NPU health is carried by the single `npu_opt_in` boolean rather than re-checked in the slot loop.

## Acceptance criteria

- [x] A single `npu_opt_in` flows through suggest + apply (picker never advertises a device it will skip)
- [x] NPU intro shown only when present + healthy
- [x] Present-but-broken shows the remedy, not the enable offer
- [x] Answer-file `npu.opt_in` feeds the single threaded `npu_opt_in`; `auto` resolves to present-AND-healthy

## Tests

Added: `npu_healthy` truth-table, `suggest_models` device threading (stt lane on/off), `plan_steps` present-healthy→`npu` vs present-broken→`npu_broken`, `npu_broken` pane copy, and answer-file `auto` → present-AND-healthy / off-when-broken / off-when-absent.

`ruff format` / `ruff check` / `ruff format --check` clean. Full `pytest`: 4681 passed; the 18 failures + 1 error are all pre-existing on `origin/main` (confirmed via `git stash`) — hermes venv, comfyui phase4, proxmox host detection, container spec dispatch, config-url-proxy, models-preview, settings-store, and the `_StubProbe.probe(validate_npu=…)` fixture gap from #1118 (setup-plan / emit-answers CLI). No new failures.

Closes #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)