### PR TITLE
installer-setup WS-B: run preflight_gpu during install — LXC smart-block + dev0 remedy

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -274,6 +274,52 @@ HAL0_VENV_REQUIRED=1 preflight_venv \
 HAL0_CONTAINER_REQUIRED=1 preflight_container_runtime \
     || die "no container runtime — install podman (see above), then re-run install.sh"
 
+# ── GPU / NPU device gate (WS-B, #1104) ─────────────────────────────────────
+# preflight_gpu detects GPU/NPU device visibility and, inside an LXC, whether
+# the render node's gid maps to a real group. In `hal0 doctor` it is
+# advisory-only; run here in GATE mode (HAL0_GPU_GATE=1) it returns a code we
+# smart-block on, so a box with broken Proxmox passthrough never installs
+# "successfully" and then silently runs every slot CPU-only:
+#   HAL0_GPU_RC_BROKEN_GID → devices visible but the render gid maps to no group
+#     inside this container (the #1 broken-install shape). HARD STOP with the
+#     dev0 remedy preflight_gpu just printed; the operator fixes the host dev0
+#     line and re-runs.
+#   HAL0_GPU_RC_NO_DEVICE  → no GPU devices inside an LXC. Allow an EXPLICIT
+#     CPU-only opt-in: HAL0_ALLOW_CPU_ONLY=1, or a y/N confirm on a real TTY;
+#     otherwise stop with the passthrough remedy.
+#   0 → GPU present + wired, or a genuine bare-metal CPU box: proceed silently.
+# Skipped in dev mode (no system slots there). This block is self-contained so
+# later install.sh edits merge around it cleanly.
+_confirm_cpu_only() {
+    # y/N confirm read from the controlling terminal, so it works even when
+    # stdin is the piped install script (`curl … | bash`). Default No; any
+    # read failure (no TTY) also means No.
+    local reply=""
+    printf '%s' "Continue with a CPU-only install anyway? [y/N] " >/dev/tty 2>/dev/null || return 1
+    IFS= read -r reply </dev/tty 2>/dev/null || return 1
+    [[ "${reply}" =~ ^[Yy]([Ee][Ss])?$ ]]
+}
+
+if [[ "${DEV_MODE}" -eq 0 ]]; then
+    gpu_rc=0
+    HAL0_GPU_GATE=1 preflight_gpu || gpu_rc=$?
+    if (( gpu_rc == HAL0_GPU_RC_BROKEN_GID )); then
+        err "GPU passthrough is broken: the render device is visible but its gid maps to no group in this container."
+        err "Every GPU slot would silently fall back to CPU. Apply the dev0/gid fix shown above on the Proxmox host, then re-run install.sh."
+        exit 1
+    elif (( gpu_rc == HAL0_GPU_RC_NO_DEVICE )); then
+        if [[ "${HAL0_ALLOW_CPU_ONLY:-0}" == "1" ]]; then
+            warn "No GPU devices inside this container — proceeding CPU-only (HAL0_ALLOW_CPU_ONLY=1)."
+        elif [[ -r /dev/tty ]] && _confirm_cpu_only; then
+            warn "Proceeding with a CPU-only install (confirmed at the prompt)."
+        else
+            err "No GPU devices inside this container. Forward them from the Proxmox host (remedy above), then re-run install.sh."
+            err "To install CPU-only anyway, re-run with HAL0_ALLOW_CPU_ONLY=1."
+            exit 1
+        fi
+    fi
+fi
+
 # The Hindsight memory engine (installed much later) builds its own venv and
 # pulls litellm, which gates out Python 3.14 via requires-python metadata.
 # Resolve the interpreter for that venv NOW — auto-installing a compatible

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -25,10 +25,17 @@
 #                                slot dead ("no container runtime found").
 #                                `preflight_docker` is a back-compat alias.
 #   preflight_gpu              — GPU/NPU device nodes visible + group wiring
-#                                sane. Soft (always returns 0; CPU-only is a
-#                                valid install) but prints the exact Proxmox
-#                                LXC dev0/gid fix when devices are missing
-#                                inside a container.
+#                                sane. Soft by default (always returns 0;
+#                                CPU-only is a valid install) but prints the
+#                                exact Proxmox LXC dev0/gid fix when devices
+#                                are missing or mis-mapped inside a container.
+#                                Set HAL0_GPU_GATE=1 to flip it into the
+#                                install-time GATE: same detection + messages,
+#                                but the return code classifies the platform so
+#                                install.sh can smart-block a broken passthrough
+#                                (HAL0_GPU_RC_BROKEN_GID / HAL0_GPU_RC_NO_DEVICE)
+#                                instead of installing "successfully" and then
+#                                silently running CPU-only.
 #   preflight_disk MIN_GB DIR  — at least MIN_GB free in DIR (default 20 / /var/lib)
 #   preflight_ports P1 [P2…]   — none of the named TCP ports are LISTENing
 #   preflight_all              — run all of the above; aggregate non-zero
@@ -46,6 +53,10 @@
 #                        manager) and hard-fails (returns non-zero) when it
 #                        can't. Default empty → soft mode for `hal0 doctor`.
 #                        Legacy HAL0_DOCKER_REQUIRED is still honoured.
+#   HAL0_GPU_GATE      — when "1", preflight_gpu returns a classification code
+#                        (see HAL0_GPU_RC_*) instead of always 0, so install.sh
+#                        can smart-block a broken LXC passthrough. Default 0 →
+#                        soft/advisory mode for `hal0 doctor`.
 
 # shellcheck shell=bash
 
@@ -459,24 +470,48 @@ preflight_podman_forward() {
     return 0
 }
 
-# GPU / NPU device visibility. Soft check (always returns 0): CPU-only
-# installs are valid, but a Proxmox LXC with the GPU forwarded wrong is the
-# single most common broken-install shape — so when devices are missing or
-# their group wiring is off, print the exact host-side fix instead of a
-# generic warning. See docs/guides/proxmox.md for the full walkthrough.
+# GPU / NPU device visibility.
+#
+# Two modes, selected by HAL0_GPU_GATE:
+#   unset / 0 (default — `hal0 doctor`, preflight_all): SOFT. Always returns 0;
+#     prints device visibility + the Proxmox LXC dev0/gid remedy as advisories
+#     so the full report never aborts.
+#   1 (install.sh Stage-1 gate, #1104): GATED. Identical detection + messages,
+#     but the return code classifies the platform so install.sh can smart-block
+#     the single most common broken-install shape — a Proxmox LXC with the GPU
+#     forwarded but the render-node gid mis-mapped, which otherwise installs
+#     "successfully" and then silently runs every slot CPU-only:
+#       0                         → GPU present + wired, or a genuine bare-metal
+#                                    CPU box: proceed.
+#       HAL0_GPU_RC_BROKEN_GID(3) → render device visible but its gid maps to
+#                                    NO group inside this LXC (dev0 miswire):
+#                                    caller HARD STOPS with the printed remedy.
+#       HAL0_GPU_RC_NO_DEVICE(4)  → no GPU devices inside an LXC: caller allows
+#                                    an EXPLICIT CPU-only opt-in.
+# Test seams (only consulted here, never set in production): HAL0_GPU_DRI_GLOB,
+# HAL0_GPU_CONTAINER_OVERRIDE, HAL0_GPU_RENDER_GID_OVERRIDE.
+# See docs/guides/proxmox.md for the full walkthrough.
+HAL0_GPU_RC_BROKEN_GID=3
+HAL0_GPU_RC_NO_DEVICE=4
 preflight_gpu() {
+    local gate="${HAL0_GPU_GATE:-0}"
+
     local in_container=""
     if [[ -f /run/systemd/container ]] || grep -qa 'container=lxc' /proc/1/environ 2>/dev/null; then
         in_container="lxc"
     fi
+    # Test seam: force the container classification (unit tests can't fake
+    # /proc/1/environ). Never set in production.
+    [[ -n "${HAL0_GPU_CONTAINER_OVERRIDE:-}" ]] && in_container="${HAL0_GPU_CONTAINER_OVERRIDE}"
 
+    local dri_glob="${HAL0_GPU_DRI_GLOB:-/dev/dri/renderD*}"
     local have_render="" have_kfd="" have_accel=""
-    compgen -G "/dev/dri/renderD*" >/dev/null 2>&1 && have_render=1
+    compgen -G "${dri_glob}" >/dev/null 2>&1 && have_render=1
     [[ -e /dev/kfd ]] && have_kfd=1
     [[ -e /dev/accel/accel0 ]] && have_accel=1
 
     if [[ -n "${have_render}" ]]; then
-        info "gpu: $(ls /dev/dri/renderD* 2>/dev/null | tr '\n' ' ')present"
+        info "gpu: $(compgen -G "${dri_glob}" 2>/dev/null | tr '\n' ' ')present"
     fi
     [[ -n "${have_kfd}"   ]] && info "gpu: /dev/kfd present (ROCm compute)"
     [[ -n "${have_accel}" ]] && info "npu: /dev/accel/accel0 present (AMD XDNA)"
@@ -489,10 +524,13 @@ preflight_gpu() {
             warn "    dev1: /dev/kfd                    # ROCm compute (optional)"
             warn "    dev2: /dev/accel/accel0,gid=<render gid>   # XDNA NPU (Strix Halo only)"
             warn "  then: pct stop <CTID> && pct start <CTID>. Full guide: docs/guides/proxmox.md"
+            # Gated install: no devices in an LXC is the opt-in CPU-only case.
+            [[ "${gate}" == "1" ]] && return "${HAL0_GPU_RC_NO_DEVICE}"
         else
             warn "gpu: no /dev/dri/renderD* — no GPU driver bound (CPU-only install?)"
             warn "  AMD: check 'lspci -nnk' shows 'Kernel driver in use: amdgpu'; very new"
             warn "  silicon (Strix Halo) needs kernel >= 6.14 + current firmware."
+            # Bare-metal CPU box → proceed silently even when gated.
         fi
         return 0
     fi
@@ -502,9 +540,9 @@ preflight_gpu() {
     # a dev0 entry with the HOST's gid leaves the node owned by an unmapped
     # gid inside the container — userspace then gets Permission denied.
     local node gid grpname
-    node="$(ls /dev/dri/renderD* 2>/dev/null | head -1)"
+    node="$(compgen -G "${dri_glob}" 2>/dev/null | head -1)"
     if [[ -n "${node}" ]]; then
-        gid="$(stat -c '%g' "${node}" 2>/dev/null)"
+        gid="${HAL0_GPU_RENDER_GID_OVERRIDE:-$(stat -c '%g' "${node}" 2>/dev/null)}"
         grpname="$(getent group "${gid}" 2>/dev/null | cut -d: -f1)"
         if [[ -z "${grpname}" ]]; then
             warn "gpu: ${node} is owned by gid ${gid}, which maps to NO group in this container"
@@ -513,6 +551,9 @@ preflight_gpu() {
                 want_gid="$(getent group render 2>/dev/null | cut -d: -f3)"
                 warn "  Fix on the Proxmox host: dev0: ${node},gid=${want_gid:-<render gid>}"
                 warn "  (gid= must be the group id INSIDE the container, not the host's)"
+                # Gated install: devices present but a mis-mapped gid → silent
+                # CPU-only fallback. This is the #1 broken-install shape.
+                [[ "${gate}" == "1" ]] && return "${HAL0_GPU_RC_BROKEN_GID}"
             fi
         else
             info "gpu: ${node} → group ${grpname} (gid ${gid})"

--- a/tests/installer/test_preflight_gpu_gate.py
+++ b/tests/installer/test_preflight_gpu_gate.py
@@ -1,0 +1,147 @@
+"""Contract tests for ``preflight_gpu``'s install-time gate (WS-B, #1104).
+
+``preflight_gpu`` runs in two modes. Under ``hal0 doctor`` (the default) it is
+advisory-only and must always return 0 so the report never aborts. Under the
+Stage-1 installer gate (``HAL0_GPU_GATE=1``) it must classify the platform via
+its return code so ``install.sh`` can smart-block the single most common
+broken-install shape: a Proxmox LXC with the GPU forwarded but the render-node
+gid mis-mapped, which otherwise installs "successfully" then silently runs
+every slot CPU-only.
+
+The function reads real ``/dev`` nodes and ``/proc/1/environ``; these tests
+drive it through the documented test seams (``HAL0_GPU_DRI_GLOB``,
+``HAL0_GPU_CONTAINER_OVERRIDE``, ``HAL0_GPU_RENDER_GID_OVERRIDE``) so the
+outcome is independent of the host that runs the suite (which may itself be an
+LXC with a real GPU, as the maintainer's box is).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PREFLIGHT = Path(__file__).resolve().parents[2] / "installer" / "lib" / "preflight.sh"
+
+# Return codes exported by preflight.sh — kept in lock-step with the shell.
+RC_OK = 0
+RC_BROKEN_GID = 3
+RC_NO_DEVICE = 4
+
+# A gid with no matching group on any sane host — forces "maps to NO group".
+UNMAPPED_GID = "61999"
+
+
+def _run_gpu_gate(env_overrides: dict[str, str]) -> int:
+    """Source preflight.sh and run ``preflight_gpu``, returning its rc.
+
+    ``set -euo pipefail`` mirrors install.sh so we also prove the function is
+    safe to source there. The ``|| rc=$?`` guard captures a non-zero return
+    without tripping ``set -e``.
+    """
+    script = (
+        "set -euo pipefail\n"
+        f"source {PREFLIGHT!s}\n"
+        "rc=0\n"
+        "preflight_gpu >/dev/null 2>&1 || rc=$?\n"
+        "exit $rc\n"
+    )
+    env = {**os.environ, **env_overrides}
+    proc = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+    return proc.returncode
+
+
+@pytest.fixture
+def render_glob(tmp_path: Path) -> str:
+    """A glob that matches a fake render node, so 'device present' is testable."""
+    (tmp_path / "renderD128").touch()
+    return str(tmp_path / "renderD*")
+
+
+def test_gate_broken_gid_lxc_hard_stops(render_glob: str) -> None:
+    """Device present + unmapped render gid + LXC → BROKEN_GID (hard stop)."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": UNMAPPED_GID,
+        }
+    )
+    assert rc == RC_BROKEN_GID
+
+
+def test_gate_no_device_lxc_opt_in(tmp_path: Path) -> None:
+    """No device + LXC → NO_DEVICE, so install.sh can offer a CPU-only opt-in."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": str(tmp_path / "NONE*"),
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+        }
+    )
+    assert rc == RC_NO_DEVICE
+
+
+def test_gate_bare_metal_no_gpu_proceeds(tmp_path: Path) -> None:
+    """Genuine bare-metal CPU box → proceed (0), no friction."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": str(tmp_path / "NONE*"),
+            "HAL0_GPU_CONTAINER_OVERRIDE": "none",
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_gate_device_good_gid_proceeds(render_glob: str) -> None:
+    """Device present + gid maps to a real group → proceed (0)."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            # gid 0 always maps to the 'root' group.
+            "HAL0_GPU_RENDER_GID_OVERRIDE": "0",
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_gate_broken_gid_on_bare_metal_does_not_block(render_glob: str) -> None:
+    """Only an LXC miswire blocks — a bare-metal unmapped gid still proceeds."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_GATE": "1",
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "none",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": UNMAPPED_GID,
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_doctor_mode_broken_gid_is_soft(render_glob: str) -> None:
+    """Without the gate flag (doctor), the same broken LXC stays soft (0)."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_DRI_GLOB": render_glob,
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+            "HAL0_GPU_RENDER_GID_OVERRIDE": UNMAPPED_GID,
+        }
+    )
+    assert rc == RC_OK
+
+
+def test_doctor_mode_no_device_lxc_is_soft(tmp_path: Path) -> None:
+    """Without the gate flag, a no-device LXC also stays soft (0)."""
+    rc = _run_gpu_gate(
+        {
+            "HAL0_GPU_DRI_GLOB": str(tmp_path / "NONE*"),
+            "HAL0_GPU_CONTAINER_OVERRIDE": "lxc",
+        }
+    )
+    assert rc == RC_OK


### PR DESCRIPTION
## What & why

`preflight_gpu` (LXC detection + the Proxmox `dev0`/render-gid check) existed but only ran in `hal0 doctor`, **never during install** — so a box with broken GPU passthrough installed "successfully" and then silently ran every slot CPU-only. This is the #1 broken-install shape (Proxmox LXC with the GPU forwarded but the render-node gid mis-mapped).

This wires `preflight_gpu` into the Stage-1 install gate with a **smart block**, reusing the existing detection logic (not reimplementing it).

## How

New GATE mode on `preflight_gpu`, selected by `HAL0_GPU_GATE=1`. Same detection + operator messages, but the return code now classifies the platform:

| Situation | rc | install.sh behaviour |
|---|---|---|
| render device present but its gid maps to **no group** inside an LXC (miswire) | `HAL0_GPU_RC_BROKEN_GID` (3) | **HARD STOP** — prints the exact `/etc/pve/lxc/<CTID>.conf` `dev0` remedy, `exit 1` so the operator fixes the host and re-runs |
| **no** GPU devices inside an LXC | `HAL0_GPU_RC_NO_DEVICE` (4) | loud warn + **explicit** CPU-only opt-in: `HAL0_ALLOW_CPU_ONLY=1` or a `y/N` confirm on a real TTY; otherwise stop with the passthrough remedy |
| GPU present + wired, or genuine bare-metal CPU box | `0` | proceed silently — no friction |

`hal0 doctor` leaves `HAL0_GPU_GATE` unset → `preflight_gpu` stays soft (always returns 0), so the full diagnostic report never aborts. A bare-metal unmapped gid does **not** block (only the LXC miswire does).

### How the smart-block detects a broken gid
Inside the render-node wiring branch: `gid=$(stat -c %g <renderD*>)`, then `getent group "$gid"`. If that resolves to **no group name** *and* we're inside an LXC, the render node is owned by the host's gid with no in-container mapping → GPU access would `EACCES` and fall back to CPU. In gate mode that returns `HAL0_GPU_RC_BROKEN_GID`.

## Tests
`tests/installer/test_preflight_gpu_gate.py` — 7 subprocess tests source the real `preflight.sh` and drive `preflight_gpu` through documented test seams (`HAL0_GPU_DRI_GLOB`, `HAL0_GPU_CONTAINER_OVERRIDE`, `HAL0_GPU_RENDER_GID_OVERRIDE`) so the outcome is independent of the CI host (which may itself be an LXC with a real GPU). Covers all three gate cases, the bare-metal non-block, and both doctor-soft paths.

## Files
- `installer/lib/preflight.sh` — `preflight_gpu` GATE mode + `HAL0_GPU_RC_*` codes + test seams; header docs
- `installer/install.sh` — Stage-1 gate block (self-contained) + `_confirm_cpu_only` TTY helper
- `tests/installer/test_preflight_gpu_gate.py` — new

## DoD
`ruff format` / `ruff check` / `ruff format --check` clean. Full `pytest`: the new test passes 7/7; the pre-existing failures (hermes venv/wrapper/state-render, comfyui phase4, `test_pve` host detection, container-spec dispatch, config-urls-proxy, models-preview, settings-store, emit-answers, setup-plan) were confirmed present on the stashed tree — this change touches only installer shell.

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)