### PR TITLE
installer-setup WS-D: gather + persist HF_TOKEN to secrets/ EnvironmentFile

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -577,13 +577,67 @@ ${NETWORK_ENV_LINES}
 HAL0_MEMORY_ENABLED=1
 # HF_TOKEN — HuggingFace token for gated / large model pulls. Easiest path:
 # set it in the dashboard (Settings -> Secrets -> HuggingFace token) for a live,
-# no-restart update. Or uncomment below and \`systemctl restart hal0-api\`.
+# no-restart update. If HF_TOKEN/HUGGING_FACE_HUB_TOKEN was present in the
+# installer's own environment it was already gathered and persisted to a
+# root-only secrets/ EnvironmentFile below (NOT here — api.env is 0644,
+# world-readable). Uncommenting below also works, but lands the token in
+# that world-readable file; prefer the secrets file or the dashboard.
+# \`systemctl restart hal0-api\` either way.
 # HF_TOKEN=
 # HAL0_TOOLBOX_IMAGE_VULKAN / HAL0_TOOLBOX_IMAGE_ROCM — optional overrides for
 # the per-backend container image refs used by providers/llama_server.py.
 # Unset = use the image pinned in the provider at release time.
 EOF
     info "wrote ${API_ENV}"
+fi
+
+# ── HF_TOKEN gather + persist (WS-D, #1106) ─────────────────────────────────
+# Gather: pre-fill from the installer's own env — HF_TOKEN first, falling
+# back to HUGGING_FACE_HUB_TOKEN — the same precedence already used by the
+# `hal0 setup` in-process apply path and the /api/install/* + /api/models
+# pull routes (#1094). install.sh is non-interactive (see the file header),
+# so there is no TTY prompt here; a headless `HF_TOKEN=hf_xxx sudo -E bash
+# install.sh` run IS the "prompt". No token in either var is a clean,
+# silent skip — public model pulls need none.
+HF_TOKEN_VAL="${HF_TOKEN:-${HUGGING_FACE_HUB_TOKEN:-}}"
+SECRETS_DIR="${VAR_DIR}/secrets"
+HF_SECRETS_ENV="${SECRETS_DIR}/hal0-api.env"
+if [[ -n "${HF_TOKEN_VAL}" ]]; then
+    # Optional `hf whoami` validation — warns on a bad/expired token but
+    # NEVER hard-fails the install (acceptance criterion). Guarded on the
+    # venv's `hf` console script (shipped by the huggingface-hub dependency,
+    # already installed by the "Python environment" step above) existing.
+    HF_CLI="${VENV_DIR}/bin/hf"
+    if [[ -x "${HF_CLI}" ]]; then
+        if HF_TOKEN="${HF_TOKEN_VAL}" "${HF_CLI}" auth whoami >/dev/null 2>&1; then
+            info "HuggingFace token validated (hf auth whoami)"
+        else
+            warn "hf auth whoami could not validate the HuggingFace token — continuing anyway (gated/large model pulls may fail until it's fixed)"
+        fi
+    fi
+
+    # Persist: root:root 0600, under secrets/ — NOT api.env (0644). Re-running
+    # install.sh with HF_TOKEN set rewrites this file (an explicit env var is
+    # an explicit rotate signal); with no token set, any existing file here is
+    # left untouched — never deleted just because the env var was omitted on
+    # a later run.
+    mkdir -p "${SECRETS_DIR}"
+    HF_SECRETS_TMP="$(mktemp "${HF_SECRETS_ENV}.XXXXXX")"
+    cat > "${HF_SECRETS_TMP}" <<EOF
+# HuggingFace token for gated / large model pulls — gathered at install time
+# from HF_TOKEN / HUGGING_FACE_HUB_TOKEN. Root-only (0600); loaded by
+# hal0-api.service as an EnvironmentFile (see the "Systemd units" step).
+# Rotate by re-running install.sh with a new HF_TOKEN in env, or:
+#   sudo install -m 0600 -o root -g root /dev/stdin ${HF_SECRETS_ENV} <<<"HF_TOKEN=..."
+#   sudo systemctl restart hal0-api
+HF_TOKEN=${HF_TOKEN_VAL}
+EOF
+    chown root:root "${HF_SECRETS_TMP}" 2>/dev/null || true
+    chmod 0600 "${HF_SECRETS_TMP}"
+    mv -f "${HF_SECRETS_TMP}" "${HF_SECRETS_ENV}"
+    info "wrote ${HF_SECRETS_ENV} (0600 root:root — not ${API_ENV})"
+else
+    info "no HF_TOKEN / HUGGING_FACE_HUB_TOKEN in env — skipping (gated model pulls will need one later via the dashboard Settings -> Secrets tab, or rerun install.sh with HF_TOKEN set)"
 fi
 
 UPSTREAMS_TOML="${ETC_DIR}/upstreams.toml"
@@ -643,6 +697,10 @@ User=root
 UMask=0002
 WorkingDirectory=${API_WORKDIR}
 EnvironmentFile=${API_ENV}
+# Optional (leading \`-\`): the HF_TOKEN secrets file (WS-D, #1106) — absent
+# on a fresh box with no token gathered at install time, and a missing
+# EnvironmentFile= target must not block the unit from starting.
+EnvironmentFile=-${HF_SECRETS_ENV}
 # No --host here (WS-C): the bind host comes from HAL0_BIND_HOST in the
 # EnvironmentFile above — the SAME var \`hal0 serve\` reads — so the unit
 # and the CLI can never disagree on the bind address.

--- a/tests/systemd/test_hf_token_secrets.py
+++ b/tests/systemd/test_hf_token_secrets.py
@@ -1,0 +1,197 @@
+"""Assert install.sh gathers + persists HF_TOKEN to a secrets/ EnvironmentFile.
+
+WS-D (#1106): the HuggingFace token is gathered at install time (pre-filled
+from HF_TOKEN / HUGGING_FACE_HUB_TOKEN in the installer's own env — install.sh
+is non-interactive, see its own header, so there is no TTY prompt) and
+persisted to a root:root 0600 ``secrets/`` EnvironmentFile — deliberately NOT
+``api.env``, which stays 0644/world-readable. ``hal0-api.service`` loads the
+secrets file as an *optional* EnvironmentFile so a fresh box with no token
+still starts cleanly.
+
+These tests parse ``installer/install.sh`` as text (the same approach
+``tests/systemd/test_unit_files.py::TestInstallerGatewayWiring`` uses for the
+hermes-gateway wiring) rather than actually running the installer — running
+it end-to-end needs root, systemd, a venv build, etc., which is exercised
+instead by the black-box harness at ``tests/harness/installer-test.sh``.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+@pytest.fixture(scope="module")
+def install_sh_text() -> str:
+    assert _INSTALL_SH.exists(), f"missing {_INSTALL_SH}"
+    return _INSTALL_SH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def gather_block(install_sh_text: str) -> str:
+    """The HF_TOKEN gather+persist block, isolated from the rest of the file.
+
+    Scoping assertions to this block (rather than the whole file) keeps the
+    tests precise about *which* code path they're checking — e.g. "no die
+    call in the whoami validation" would be meaningless if it just grepped
+    the entire 1000+ line script.
+    """
+    m = re.search(
+        r"# ── HF_TOKEN gather \+ persist \(WS-D, #1106\).*?\nUPSTREAMS_TOML=",
+        install_sh_text,
+        re.DOTALL,
+    )
+    assert m is not None, "HF_TOKEN gather+persist block not found in install.sh"
+    return m.group(0)
+
+
+class TestGather:
+    """Pre-fill from env; install.sh itself never prompts (non-interactive)."""
+
+    def test_reads_hf_token_env_var(self, gather_block: str) -> None:
+        assert "HF_TOKEN_VAL=" in gather_block
+        assert re.search(r'HF_TOKEN_VAL="\$\{HF_TOKEN:-', gather_block)
+
+    def test_falls_back_to_hugging_face_hub_token(self, gather_block: str) -> None:
+        # Same precedence as hal0.api.routes.installer / cli.setup_install
+        # (#1094): HF_TOKEN first, HUGGING_FACE_HUB_TOKEN second.
+        assert "HUGGING_FACE_HUB_TOKEN" in gather_block
+
+    def test_missing_token_is_a_clean_skip(self, gather_block: str) -> None:
+        # The else branch must not die()/exit — just log and move on.
+        m = re.search(r"else\n(.*?)\nfi", gather_block, re.DOTALL)
+        assert m is not None, "no else (skip) branch found"
+        skip_branch = m.group(1)
+        assert "die" not in skip_branch
+        assert "exit" not in skip_branch
+        assert "no HF_TOKEN" in skip_branch
+
+
+class TestWhoamiValidation:
+    """Optional `hf auth whoami` validation warns, never hard-fails."""
+
+    def test_whoami_invoked_via_venv_hf_cli(self, gather_block: str) -> None:
+        assert "${VENV_DIR}/bin/hf" in gather_block
+        assert "auth whoami" in gather_block
+
+    def test_failure_path_warns_not_dies(self, gather_block: str) -> None:
+        m = re.search(
+            r"if HF_TOKEN=.*?auth whoami.*?\n(.*?)\nfi",
+            gather_block,
+            re.DOTALL,
+        )
+        assert m is not None, "whoami if/else block not found"
+        whoami_block = m.group(1)
+        assert "warn " in whoami_block
+        assert "die" not in whoami_block
+        assert "exit" not in whoami_block
+
+    def test_whoami_call_is_guarded_not_bare(self, gather_block: str) -> None:
+        # A bare (non-conditional) invocation would trip `set -e` on a bad
+        # token and abort the whole installer — it must live inside an
+        # `if`/`[[ -x ]]` guard.
+        assert re.search(r"if \[\[ -x \"\$\{HF_CLI\}\" \]\]", gather_block)
+        assert re.search(r"if HF_TOKEN=\S+ \"\$\{HF_CLI\}\" auth whoami", gather_block)
+
+
+class TestPersistence:
+    """Root:root 0600 secrets/ EnvironmentFile — never api.env."""
+
+    def test_secrets_dir_under_var_lib_secrets(self, gather_block: str) -> None:
+        assert 'SECRETS_DIR="${VAR_DIR}/secrets"' in gather_block
+
+    def test_secrets_file_is_not_api_env(self, gather_block: str) -> None:
+        assert 'HF_SECRETS_ENV="${SECRETS_DIR}/hal0-api.env"' in gather_block
+        # Sanity: the two paths must differ.
+        assert "HF_SECRETS_ENV" != "API_ENV"
+
+    def test_written_mode_0600(self, gather_block: str) -> None:
+        assert "chmod 0600" in gather_block
+
+    def test_owned_root_root(self, gather_block: str) -> None:
+        assert "chown root:root" in gather_block
+
+    def test_written_atomically(self, gather_block: str) -> None:
+        # mktemp + mv, not an in-place redirect — avoids a torn read by a
+        # concurrent `systemctl daemon-reload`/restart.
+        assert re.search(r"mktemp \"\$\{HF_SECRETS_ENV\}", gather_block)
+        assert "mv -f" in gather_block
+
+    def test_token_value_written_to_secrets_file_only(self, gather_block: str) -> None:
+        # HF_TOKEN=${HF_TOKEN_VAL} must appear inside the persistence
+        # heredoc (targeting HF_SECRETS_TMP), not assigned anywhere that
+        # would land it in api.env.
+        assert "HF_TOKEN=${HF_TOKEN_VAL}" in gather_block
+
+
+class TestSystemdWiring:
+    """hal0-api.service must load the secrets file as an EnvironmentFile."""
+
+    def test_api_env_still_wired(self, install_sh_text: str) -> None:
+        assert re.search(r"^EnvironmentFile=\$\{API_ENV\}$", install_sh_text, re.MULTILINE)
+
+    def test_hf_secrets_env_wired_optionally(self, install_sh_text: str) -> None:
+        # Leading `-` makes a missing file non-fatal (mirrors
+        # hal0-agent@.service's `EnvironmentFile=-/etc/hal0/agents/%i.env`
+        # and the hermes-gateway secrets drop-in) — a fresh box with no
+        # HF_TOKEN gathered at install time must still start hal0-api.
+        assert re.search(r"^EnvironmentFile=-\$\{HF_SECRETS_ENV\}$", install_sh_text, re.MULTILINE)
+
+    def test_hf_secrets_env_wiring_precedes_execstart(self, install_sh_text: str) -> None:
+        api_unit = re.search(
+            r"API_UNIT=.*?\ncat > \"\$\{API_UNIT\}\" <<EOF\n(.*?)\nEOF",
+            install_sh_text,
+            re.DOTALL,
+        )
+        assert api_unit is not None, "hal0-api.service heredoc not found"
+        body = api_unit.group(1)
+        assert "EnvironmentFile=-${HF_SECRETS_ENV}" in body
+        env_idx = body.index("EnvironmentFile=-${HF_SECRETS_ENV}")
+        exec_idx = body.index("ExecStart=")
+        assert env_idx < exec_idx, "EnvironmentFile must be declared before ExecStart"
+
+
+class TestApiEnvNotClobbered:
+    """api.env keeps its (commented, non-secret) HF_TOKEN placeholder only."""
+
+    def test_api_env_heredoc_has_no_live_hf_token_assignment(self, install_sh_text: str) -> None:
+        api_env_heredoc = re.search(
+            r'API_ENV="\$\{ETC_DIR\}/api\.env".*?cat > "\$\{API_ENV\}" <<EOF\n(.*?)\nEOF',
+            install_sh_text,
+            re.DOTALL,
+        )
+        assert api_env_heredoc is not None, "api.env heredoc not found"
+        body = api_env_heredoc.group(1)
+        # Only a commented-out placeholder — never a live assignment.
+        assert "# HF_TOKEN=" in body
+        assert not re.search(r"^HF_TOKEN=", body, re.MULTILINE)
+
+
+class TestShellcheckClean:
+    """No NEW shellcheck findings from this change (baseline stays flat)."""
+
+    def test_no_new_shellcheck_errors(self, install_sh_text: str) -> None:
+        if shutil.which("shellcheck") is None:
+            pytest.skip("shellcheck not installed")
+        proc = subprocess.run(
+            ["shellcheck", "--severity=error", str(_INSTALL_SH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, f"shellcheck reported errors:\n{proc.stdout}\n{proc.stderr}"
+
+
+def test_bash_syntax_check() -> None:
+    """`bash -n` must pass — the DoD's cheapest, fastest correctness gate."""
+    proc = subprocess.run(
+        ["bash", "-n", str(_INSTALL_SH)], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Closes #1106

## Summary

WS-D (decision Q5): install.sh gathers the HuggingFace token up front — before any HF download — and persists it to a root-only `secrets/` EnvironmentFile instead of the world-readable `api.env`. Complements #1094 (merged), which threaded `HF_TOKEN` from the calling env into the in-process `apply_setup`/CLI path; this issue is the install-time GATHER + secure PERSISTENCE side that also feeds the "apply via API" path (`/api/install/*`, `/api/models` pull routes), since `hal0-api.service` is the process that actually performs HF pulls in-process (`src/hal0/registry/pull.py::run_pull`, called from `api/routes/models.py` / `installer.py`, which each do `os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")` at request time).

- **Gather**: pre-fills from `HF_TOKEN`, falling back to `HUGGING_FACE_HUB_TOKEN` — same precedence #1094 already uses. `install.sh` is documented non-interactive (see its own header), so there's no TTY prompt; a headless `HF_TOKEN=hf_xxx sudo -E bash install.sh` run *is* the "prompt" for this surface.
- **Validate (optional, warn-only)**: if the venv's `hf` console script (shipped by the `huggingface-hub` dependency) is present, runs `hf auth whoami` with the gathered token. A bad/expired token only warns — it never aborts the install.
- **Persist**: writes `/var/lib/hal0/secrets/hal0-api.env` (root:root, 0600, atomic mktemp+mv) — NOT `api.env` (0644, world-readable). Missing token is a clean, silent skip; an existing secrets file is never deleted just because a later re-run omitted the env var (re-running *with* a new token rewrites it — an explicit rotate signal).
- **Wire**: `hal0-api.service` gets a second `EnvironmentFile=-/var/lib/hal0/secrets/hal0-api.env` (leading `-` = optional, mirrors `hal0-agent@.service` and the hermes-gateway secrets drop-in), declared before `ExecStart=` so a fresh box with no token still starts cleanly.

## Isolation

Touches only `installer/install.sh` + a new test file. Does not touch `src/hal0/install/orchestrate.py`, `src/hal0/config/schema.py`, `setup_command.py`, `answers.py`, `api/routes/*`, or `comfyui/*` (sibling workstreams).

## Testing

- `tests/systemd/test_hf_token_secrets.py` (new, 18 tests) — static-text assertions against `install.sh` (same pattern as `TestInstallerGatewayWiring` in `tests/systemd/test_unit_files.py`): env precedence, clean skip on missing token, whoami warn-not-die, 0600/root:root persistence, atomic write, optional `EnvironmentFile=` wiring order, and that `api.env` never gets a live `HF_TOKEN=` assignment.
- Manual smoke test (`installer/install.sh --dev --no-start`), twice:
  - With `HF_TOKEN` set to a bogus value: `hf auth whoami` warned (did not abort), `/var/lib/hal0/secrets/hal0-api.env` written `0600 root:root`, unit wired with both `EnvironmentFile=` lines.
  - With no token in env: clean skip logged, no `secrets/` dir created at all.
- `bash -n installer/install.sh` passes; `shellcheck` reports the same baseline (info/warning only, no new findings).

## DoD

```
uv run ruff format src tests        # 1 file reformatted (the new test), then clean
uv run ruff check src tests         # All checks passed
uv run ruff format --check src tests # clean
bash -n installer/install.sh        # OK
uv run pytest tests/ -q --ignore=tests/e2e
# 14 failed, 4720 passed, 9 skipped, 1 error — matches the known pre-existing
# baseline (hermes venv/wrapper, comfyui phase4, proxmox host detection,
# container spec, config-url-proxy, models-preview, settings-store),
# confirmed identical via `git stash` before/after this change.
```

## Checklist

- [x] Token prompt (gather) appears before any HF download; skippable (missing token = clean skip)
- [x] Optional whoami validation warns, never hard-fails, on a bad token
- [x] Token persisted to a root-only secrets EnvironmentFile, not api.env
- [x] Pre-filled from env when present; threaded into pulls (hal0-api.service EnvironmentFile reaches the routes that already read HF_TOKEN from os.environ, per #1094)

🤖 Generated with [Claude Code](https://claude.com/claude-code)