### PR TITLE
installer-setup WS-E: safe slot activation (enable-on-pull-success + clamp context to hw budget)

### DIFF
--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -56,9 +56,13 @@ from hal0.api.middleware.error_codes import BadRequest, Conflict, Hal0Error
 from hal0.bundles import tiers as bundle_tiers
 from hal0.config import paths
 from hal0.hardware.probe import HardwareProbe
-from hal0.install.orchestrate import Selections, SlotSelection, apply_setup
+from hal0.install.orchestrate import (
+    Selections,
+    SlotSelection,
+    apply_setup,
+    run_pull_and_activate,
+)
 from hal0.registry.curated import CURATED_MODELS
-from hal0.registry.pull import run_pull
 from hal0.slot_config import write_slot_toml
 
 # Auth was removed in ADR-0012. All endpoints are open on the local
@@ -431,8 +435,12 @@ async def _apply_selections_core(
         hf_token=hf_token,
         write_sentinel=True,
     )
+    # WS-E (#1108): drive each pull through run_pull_and_activate so the slot,
+    # created DISABLED, flips enabled=True only after its bytes land (and a
+    # failed pull leaves a marked, disabled slot instead of a crash-loop).
+    slot_manager = request.app.state.slot_manager
     for plan in result.pulls:
-        background.add_task(run_pull, plan.job, **plan.kwargs)
+        background.add_task(run_pull_and_activate, plan, slot_manager=slot_manager)
     return result
 
 

--- a/src/hal0/cli/setup_install.py
+++ b/src/hal0/cli/setup_install.py
@@ -84,7 +84,7 @@ async def _apply_in_process(sel, hw, *, no_pull: bool = False) -> None:
         )
         return
 
-    await _run_pulls_with_progress(result.pulls)
+    await _run_pulls_with_progress(result.pulls, slot_manager=slot_manager)
 
     n_slots = sum(1 for s in result.slots if getattr(s, "created", False))
     typer.echo(
@@ -93,22 +93,23 @@ async def _apply_in_process(sel, hw, *, no_pull: bool = False) -> None:
     )
 
 
-async def _run_pulls_with_progress(pulls) -> None:
-    """Drive ``run_pull`` for each plan while rendering one rich bar per model.
+async def _run_pulls_with_progress(pulls, *, slot_manager) -> None:
+    """Drive each plan while rendering one rich bar per model.
 
-    ``run_pull`` takes no progress callback — it mutates the ``PullJob`` in
-    place (``job.state``, ``job.bytes_downloaded``, ``job.bytes_total``). So we
-    launch all pulls as a single ``gather`` task and poll the job objects in a
-    :class:`rich.progress.Progress` loop until the gather completes, updating
-    each bar's total/completed from the live job fields.
+    Each pull runs through :func:`~hal0.install.orchestrate.run_pull_and_activate`
+    (WS-E, #1108): it calls ``run_pull`` (which mutates the ``PullJob`` in place
+    — ``job.state`` / ``job.bytes_downloaded`` / ``job.bytes_total``) and then
+    flips the slot ``enabled=True`` on success / marks it disabled on failure.
+    We launch all of them as a single ``gather`` task and poll the job objects
+    in a :class:`rich.progress.Progress` loop until the gather completes.
     """
     if not pulls:
         return
 
-    from hal0.registry.pull import run_pull
+    from hal0.install.orchestrate import run_pull_and_activate
 
     gather_task = asyncio.gather(
-        *(run_pull(p.job, **p.kwargs) for p in pulls),
+        *(run_pull_and_activate(p, slot_manager=slot_manager) for p in pulls),
         return_exceptions=True,
     )
 

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -7,6 +7,7 @@ post-install. Deps are injected so there is no hidden ``app.state`` coupling.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
@@ -89,11 +90,21 @@ class ExtensionOutcome:
 @dataclass
 class PullPlan:
     """A registered-but-not-yet-run pull. The caller decides how to run it
-    (``background.add_task`` for the route; ``await`` with progress for the TUI)."""
+    (``background.add_task`` for the route; ``await`` with progress for the TUI).
+
+    ``slot_names`` are the slots created DISABLED for this model (WS-E, #1108).
+    The caller MUST drive each plan through :func:`run_pull_and_activate` so the
+    slot(s) flip ``enabled=True`` only after the bytes land — never before the
+    model exists on disk (the start-before-model race). A FAILED pull leaves the
+    slot(s) disabled and marked (``[meta].pull_failed``), so a half-provisioned
+    box parks the slot instead of crash-looping a container against a missing
+    model.
+    """
 
     model_id: str
     job: Any  # registry.pull.PullJob
     kwargs: dict[str, Any]
+    slot_names: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -107,16 +118,140 @@ class SetupResult:
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 
-def _build_slot_cfg(*, slot, model_id, device, profile, port, context_size=4096):
-    """Podman-aware slot config dict (device+profile, NOT backend — #807)."""
+def _build_slot_cfg(*, slot, model_id, device, profile, port, context_size=4096, enabled=False):
+    """Podman-aware slot config dict (device+profile, NOT backend — #807).
+
+    Born DISABLED by default (WS-E, #1108): the guided apply path creates the
+    slot, THEN queues the pull, and only flips ``enabled=True`` once the pull
+    completes (:func:`run_pull_and_activate`). Seeding ``enabled=True`` here
+    would let the slot start before its model exists on disk.
+    """
     return {
         "name": slot,
         "port": port,
         "device": device,
         "profile": profile,
-        "enabled": True,
+        "enabled": enabled,
         "model": {"default": model_id, "context_size": context_size},
     }
+
+
+# ── Context budget (WS-E / #1108) ───────────────────────────────────────────────
+
+# Conservative KV-cache cost per context token (bytes): fp16 K+V for a mid-size
+# dense GGUF (~32 layers, GQA 8 kv-heads, head_dim 128):
+#   2 (K+V) * 32 * 8 * 128 * 2 bytes ≈ 128 KiB / token.
+# Over-estimating KV clamps HARDER → strictly safer against first-warm OOM. MoE/
+# MTP primaries have a far smaller hybrid KV, so this only ever under-fits (more
+# headroom), never OOMs.
+_KV_BYTES_PER_TOKEN = 128 * 1024
+# Server + activation/compute-buffer headroom held back off the memory pool
+# before any of it funds KV cache.
+_RUNTIME_RESERVE_GB = 1.0
+# Never clamp below this — a sub-2K window slot is useless.
+_MIN_CONTEXT = 2048
+# Round the derived budget down to a whole multiple of this (llama.cpp likes
+# power-of-two-ish windows; keeps the number legible in the TOML).
+_CTX_ALIGN = 1024
+_BYTES_PER_GB = 1024**3
+
+
+def _memory_budget_gb(hw: HardwareInfo) -> float:
+    """GB of host memory available to load a model (weights + KV).
+
+    Derived from the authoritative ``hardware.json`` facts (#1097), NOT a Strix
+    constant. Mirrors ``hardware.recommend._vram_budget_gb`` but ALSO honours a
+    cgroup memory cap (#372) so an LXC/container-capped host — the box that
+    produced the ``oom`` artifact — clamps against its real ceiling:
+
+      * AMD UMA (Strix Halo): the model pool is host RAM shared via GTT, so a
+        cgroup cap binds it. Half the pool — leave RAM for the OS + the rest of
+        the stack (OpenWebUI, FastAPI, ...).
+      * discrete GPU: dedicated VRAM, which a host cgroup does not cap.
+      * CPU-only / GPU with no usable VRAM: half of MemAvailable, itself capped
+        by any cgroup limit.
+    """
+    if hw.gpus:
+        g = hw.gpus[0]
+        if g.vendor == "amd" and hw.unified_memory_mb >= hw.ram_mb * 0.95:
+            pool_gb = hw.unified_memory_mb / 1024
+            if hw.cgroup_max_mb:
+                pool_gb = min(pool_gb, hw.cgroup_max_mb / 1024)
+            return max(pool_gb * 0.5, 0.0)
+        if g.vram_mb > 0:
+            return g.vram_mb / 1024
+    avail_gb = max(hw.ram_available_mb / 1024, 1.0)
+    if hw.cgroup_max_mb:
+        avail_gb = min(avail_gb, hw.cgroup_max_mb / 1024)
+    return max(avail_gb * 0.5, 0.0)
+
+
+def _clamp_context_size(requested: int, hw: HardwareInfo, *, weights_gb: float = 0.0) -> int:
+    """Clamp a requested context window to what host memory can actually fund.
+
+    Model weights + a runtime reserve come off the memory budget first; the
+    remainder funds the KV cache at a conservative bytes-per-token rate. Returns
+    ``min(requested, budget)`` floored at ``_MIN_CONTEXT``. A falsy/zero
+    ``requested`` means "use the whole budget". This replaces blindly trusting
+    ``curated.context_length`` (which is the model's *native* window, not a
+    hardware budget — the first-warm OOM, #1108).
+    """
+    budget_gb = _memory_budget_gb(hw)
+    kv_gb = budget_gb - max(weights_gb, 0.0) - _RUNTIME_RESERVE_GB
+    if kv_gb <= 0:
+        return _MIN_CONTEXT
+    budget_tokens = int(kv_gb * _BYTES_PER_GB / _KV_BYTES_PER_TOKEN)
+    budget_tokens = (budget_tokens // _CTX_ALIGN) * _CTX_ALIGN
+    budget_tokens = max(budget_tokens, _MIN_CONTEXT)
+    if not requested or requested <= 0:
+        return budget_tokens
+    return max(min(int(requested), budget_tokens), _MIN_CONTEXT)
+
+
+# ── Enable-on-pull-success (WS-E / #1108) ───────────────────────────────────────
+
+
+async def _set_slot_enabled(slot_manager, slot_name: str, enabled: bool, *, failed: bool) -> None:
+    """Best-effort flip of a slot's ``enabled`` flag after its pull settles.
+
+    Non-aborting per ADR-0010: a failed config rewrite must not crash the pull
+    driver. On a FAILED pull we also stamp ``[meta].pull_failed`` so the parked
+    slot is clearly marked (the dashboard / ``hal0 doctor`` can surface it).
+    """
+    updates: dict[str, Any] = {"enabled": enabled}
+    if failed:
+        updates["meta"] = {"pull_failed": True}
+    # Activation is best-effort — the model still downloaded; the operator can
+    # enable the slot by hand. Never let this abort the pull driver (ADR-0010).
+    with contextlib.suppress(Exception):
+        await slot_manager.update_config(slot_name, updates)
+
+
+async def run_pull_and_activate(plan: PullPlan, *, slot_manager) -> None:
+    """Run one planned pull, then activate its slot(s) — WS-E (#1108).
+
+    On SUCCESS: flip every ``plan.slot_names`` slot to ``enabled=True`` (the
+    model now exists on disk, so a start is safe). On FAILURE (``run_pull``
+    raised, or the job settled ``state == "failed"``): leave the slot(s)
+    disabled and mark them, so nothing crash-loops against a missing model.
+
+    Re-raises the original exception after marking, so callers that inspect
+    ``gather(..., return_exceptions=True)`` results still see the failure.
+    """
+    from hal0.registry.pull import run_pull
+
+    try:
+        await run_pull(plan.job, **plan.kwargs)
+    except BaseException:
+        for name in plan.slot_names:
+            await _set_slot_enabled(slot_manager, name, False, failed=True)
+        raise
+    if getattr(plan.job, "state", None) == "failed":
+        for name in plan.slot_names:
+            await _set_slot_enabled(slot_manager, name, False, failed=True)
+        return
+    for name in plan.slot_names:
+        await _set_slot_enabled(slot_manager, name, True, failed=False)
 
 
 def _ensure_registry_entry(registry, model_id) -> None:
@@ -334,6 +469,11 @@ async def apply_setup(
     slot_outcomes: list[SlotOutcome] = []
     model_ids: list[str] = []
     pulls: list[PullPlan] = []
+    # WS-E (#1108): map model_id → the plan WE created this run, so two slots
+    # sharing one model_id (e.g. chat + coder on the same pick) both get
+    # enabled off the single pull rather than the second slot being stranded
+    # disabled.
+    plans_by_model: dict[str, PullPlan] = {}
 
     # Honour the operator's chosen store BEFORE planning pulls: the pull engine
     # reads ``[models].store`` lazily at pull time, so persisting it here is
@@ -375,7 +515,16 @@ async def apply_setup(
             continue
 
         _ensure_registry_entry(registry, s.model_id)
-        ctx = int(curated.context_length or 0) or 4096
+        # WS-E (#1108): clamp the native curated window to a VRAM/RAM-aware
+        # budget derived from hardware.json (#1097), not the raw
+        # curated.context_length that produced the first-warm ``oom``. Model
+        # weights come off the budget first; the remainder funds the KV cache.
+        ctx = _clamp_context_size(
+            int(curated.context_length or 0),
+            hardware,
+            weights_gb=float(getattr(curated, "size_gb", 0.0) or 0.0),
+        )
+        # Born DISABLED — flipped to enabled only after the pull completes.
         cfg = _build_slot_cfg(
             slot=s.slot_name,
             model_id=s.model_id,
@@ -383,6 +532,7 @@ async def apply_setup(
             profile=profile,
             port=s.port,
             context_size=ctx,
+            enabled=False,
         )
         try:
             await slot_manager.create(s.slot_name, cfg)
@@ -393,25 +543,36 @@ async def apply_setup(
             continue
 
         existing = get_job(jobs, s.model_id)
-        if existing is not None and getattr(existing, "state", None) in ("queued", "running"):
+        own_plan = plans_by_model.get(s.model_id)
+        if own_plan is not None:
+            # Second slot for a model WE already planned this run — ride the
+            # same pull so it, too, gets enabled on success.
+            own_plan.slot_names.append(s.slot_name)
+            job = own_plan.job
+        elif existing is not None and getattr(existing, "state", None) in ("queued", "running"):
+            # A pull for this model is already in flight from elsewhere; don't
+            # double-run it. The slot stays disabled (safer than the old
+            # enabled-before-model default) for the operator to enable once the
+            # in-flight pull lands.
             job = existing
         else:
             job = make_job(s.model_id)
             jobs[s.model_id] = job
-            pulls.append(
-                PullPlan(
-                    model_id=s.model_id,
-                    job=job,
-                    kwargs=dict(
-                        hf_repo=curated.hf_repo,
-                        hf_file=curated.hf_file,
-                        registry=registry,
-                        hf_token=hf_token,
-                        comfyui_subdir=curated.comfyui_subdir or None,
-                        capability=s.capability,
-                    ),
-                )
+            plan = PullPlan(
+                model_id=s.model_id,
+                job=job,
+                kwargs=dict(
+                    hf_repo=curated.hf_repo,
+                    hf_file=curated.hf_file,
+                    registry=registry,
+                    hf_token=hf_token,
+                    comfyui_subdir=curated.comfyui_subdir or None,
+                    capability=s.capability,
+                ),
+                slot_names=[s.slot_name],
             )
+            plans_by_model[s.model_id] = plan
+            pulls.append(plan)
         rec.pull_job_id = job.job_id
         model_ids.append(s.model_id)
         slot_outcomes.append(rec)

--- a/tests/api/test_apply_selections.py
+++ b/tests/api/test_apply_selections.py
@@ -42,12 +42,12 @@ def test_apply_selections_creates_only_selected_slots(
     app, client = isolated_app_client
     app.state.hardware_probe = _FakeProbe()
 
-    import hal0.api.routes.installer as inst
-
+    # WS-E (#1108): run_pull_and_activate imports run_pull lazily from
+    # hal0.registry.pull — patch it there.
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     payload = {
         "storage_dir": tmp_hal0_home,
@@ -84,12 +84,10 @@ def test_apply_selections_writes_first_run_sentinel(
     app, client = isolated_app_client
     app.state.hardware_probe = _FakeProbe()
 
-    import hal0.api.routes.installer as inst
-
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     sentinel = Path(tmp_hal0_home) / "var-lib" / "hal0" / ".first_run_done"
     assert not sentinel.exists()

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -53,7 +53,8 @@ def test_build_slot_cfg_sets_device_profile_model():
     assert cfg["name"] == "chat"
     assert cfg["device"] == "gpu-rocm"
     assert cfg["profile"] == "rocm"
-    assert cfg["enabled"] is True
+    # WS-E (#1108): born DISABLED — enable-on-pull-success flips it later.
+    assert cfg["enabled"] is False
     assert cfg["model"]["default"] == "qwen3.6-27b"
     assert cfg["model"]["context_size"] == 32768
     # v2 sets device+profile, NOT the legacy `backend` field.
@@ -91,12 +92,12 @@ def test_apply_seeds_jobs_and_creates_slots(isolated_app_client, tmp_hal0_home, 
 
     # Stub the actual download so the test is hermetic — assert orchestration,
     # not network. run_pull is patched to mark the job completed immediately.
-    import hal0.api.routes.installer as inst
-
+    # WS-E (#1108): the background task now runs run_pull_and_activate, which
+    # imports run_pull lazily from hal0.registry.pull — patch it there.
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     r = client.post(
         "/api/install/apply",
@@ -114,6 +115,9 @@ def test_apply_seeds_jobs_and_creates_slots(isolated_app_client, tmp_hal0_home, 
     cfg = tomllib.loads(toml.read_text())
     assert cfg["model"]["default"] == "qwen3.5-9b"
     assert "profile" in cfg
+    # WS-E (#1108): the fake pull completed successfully → the slot, created
+    # DISABLED, was flipped enabled=True by run_pull_and_activate.
+    assert cfg["enabled"] is True
 
 
 def test_apply_unknown_tier_400(isolated_app_client):
@@ -128,12 +132,10 @@ def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monk
     app, client = isolated_app_client
     app.state.hardware_probe = _FakeProbe()
 
-    import hal0.api.routes.installer as inst
-
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     r = client.post(
         "/api/install/apply",
@@ -169,12 +171,10 @@ def test_apply_writes_first_run_sentinel(isolated_app_client, tmp_hal0_home, mon
     app, client = isolated_app_client
     app.state.hardware_probe = _FakeProbe()
 
-    import hal0.api.routes.installer as inst
-
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     sentinel = Path(tmp_hal0_home) / "var-lib" / "hal0" / ".first_run_done"
     assert not sentinel.exists()
@@ -203,7 +203,7 @@ def test_apply_delegates_to_apply_selections_core(isolated_app_client, tmp_hal0_
     async def _fake_run_pull(job, **kw):
         job.state = "completed"
 
-    monkeypatch.setattr(inst, "run_pull", _fake_run_pull)
+    monkeypatch.setattr("hal0.registry.pull.run_pull", _fake_run_pull)
 
     calls: list[str] = []
     real_core = inst._apply_selections_core

--- a/tests/api/test_pull_routes.py
+++ b/tests/api/test_pull_routes.py
@@ -58,12 +58,13 @@ def fake_run_pull(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
         job._signal()
 
     monkeypatch.setattr(pull_module, "run_pull", fake)
-    # The routes import run_pull at module load — also patch their
-    # binding so the fake reaches the BackgroundTasks invocation.
-    from hal0.api.routes import installer as installer_routes
+    # The models route imports run_pull at module load — also patch its
+    # binding so the fake reaches the BackgroundTasks invocation. (The
+    # installer route no longer binds run_pull directly: WS-E / #1108 moved
+    # it behind run_pull_and_activate, which imports run_pull lazily from
+    # hal0.registry.pull — already patched above via pull_module.)
     from hal0.api.routes import models as model_routes
 
-    monkeypatch.setattr(installer_routes, "run_pull", fake)
     monkeypatch.setattr(model_routes, "run_pull", fake)
     return calls
 

--- a/tests/install/test_orchestrate.py
+++ b/tests/install/test_orchestrate.py
@@ -387,3 +387,201 @@ def test_install_extensions_dispatches(monkeypatch):
     outs = orchestrate._install_extensions({"openwebui": True, "pi": False, "hermes": True})
     assert set(calls) == {"openwebui", "hermes"}  # only enabled
     assert all(o.installed for o in outs)
+
+
+# ── WS-E (#1108): safe slot activation ──────────────────────────────────────────
+
+
+class _RecordingSlotManager:
+    """Fake slot manager that records create() cfgs + update_config() flips."""
+
+    def __init__(self):
+        self.created = {}
+        self.enabled = {}
+        self.updates = []  # list of (name, updates_dict)
+
+    async def create(self, name, cfg):
+        self.created[name] = cfg
+        self.enabled[name] = cfg.get("enabled")
+        return object()
+
+    async def update_config(self, name, updates):
+        self.updates.append((name, updates))
+        if "enabled" in updates:
+            self.enabled[name] = updates["enabled"]
+        return object()
+
+
+class _Job:
+    def __init__(self, job_id="job-1"):
+        self.job_id = job_id
+        self.state = "queued"
+
+
+async def test_apply_setup_creates_slot_disabled_and_plan_carries_slot():
+    """The guided path seeds the slot DISABLED and the plan remembers which
+    slot to enable once the pull lands (no start-before-model race)."""
+    from hal0.install import orchestrate
+
+    sm = _RecordingSlotManager()
+    sel = Selections(
+        storage_dir="",
+        slots=[SlotSelection(capability="chat", slot_name="chat", port=8081, model_id="qwen3-4b")],
+        extensions={},
+        npu_opt_in=False,
+    )
+    res = await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=sm,
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    # Born disabled — never enabled at create time.
+    assert sm.created["chat"]["enabled"] is False
+    # The plan carries the slot so the pull driver can enable it on success.
+    assert res.pulls[0].slot_names == ["chat"]
+
+
+async def test_apply_setup_shared_model_enables_both_slots():
+    """Two slots on the SAME model_id ride one pull — both get enabled."""
+    from hal0.install import orchestrate
+
+    sm = _RecordingSlotManager()
+    sel = Selections(
+        storage_dir="",
+        slots=[
+            SlotSelection(capability="chat", slot_name="chat", port=8081, model_id="qwen3-4b"),
+            SlotSelection(capability="coder", slot_name="coder", port=8082, model_id="qwen3-4b"),
+        ],
+        extensions={},
+        npu_opt_in=False,
+    )
+    res = await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=sm,
+        registry={},
+        jobs={},
+        write_sentinel=False,
+    )
+    # One pull, but both slots attached to it.
+    assert len(res.pulls) == 1
+    assert set(res.pulls[0].slot_names) == {"chat", "coder"}
+
+
+async def test_run_pull_and_activate_enables_slot_on_success(monkeypatch):
+    from hal0.install import orchestrate
+    from hal0.registry import pull as pull_mod
+
+    job = _Job()
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "completed"
+
+    monkeypatch.setattr(pull_mod, "run_pull", _fake_run_pull)
+
+    sm = _RecordingSlotManager()
+    sm.enabled["chat"] = False
+    plan = orchestrate.PullPlan(model_id="qwen3-4b", job=job, kwargs={}, slot_names=["chat"])
+    await orchestrate.run_pull_and_activate(plan, slot_manager=sm)
+
+    assert sm.enabled["chat"] is True
+    assert ("chat", {"enabled": True}) in sm.updates
+
+
+async def test_run_pull_and_activate_marks_disabled_on_failed_job(monkeypatch):
+    """A pull that settles state=='failed' leaves the slot disabled + marked."""
+    from hal0.install import orchestrate
+    from hal0.registry import pull as pull_mod
+
+    job = _Job()
+
+    async def _fake_run_pull(job, **kw):
+        job.state = "failed"
+
+    monkeypatch.setattr(pull_mod, "run_pull", _fake_run_pull)
+
+    sm = _RecordingSlotManager()
+    sm.enabled["chat"] = False
+    plan = orchestrate.PullPlan(model_id="qwen3-4b", job=job, kwargs={}, slot_names=["chat"])
+    await orchestrate.run_pull_and_activate(plan, slot_manager=sm)
+
+    assert sm.enabled["chat"] is False
+    name, updates = sm.updates[-1]
+    assert name == "chat"
+    assert updates["enabled"] is False
+    assert updates["meta"] == {"pull_failed": True}
+
+
+async def test_run_pull_and_activate_marks_and_reraises_on_exception(monkeypatch):
+    """run_pull raising leaves the slot disabled+marked and re-raises so the
+    caller's gather sees the failure."""
+    import pytest as _pytest
+
+    from hal0.install import orchestrate
+    from hal0.registry import pull as pull_mod
+
+    job = _Job()
+
+    async def _boom(job, **kw):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(pull_mod, "run_pull", _boom)
+
+    sm = _RecordingSlotManager()
+    sm.enabled["chat"] = False
+    plan = orchestrate.PullPlan(model_id="qwen3-4b", job=job, kwargs={}, slot_names=["chat"])
+    with _pytest.raises(RuntimeError, match="network down"):
+        await orchestrate.run_pull_and_activate(plan, slot_manager=sm)
+
+    assert sm.enabled["chat"] is False
+    assert sm.updates[-1][1]["meta"] == {"pull_failed": True}
+
+
+def test_clamp_context_size_passes_through_on_ample_hw():
+    """A big unified pool funds the model's native window unchanged."""
+    from hal0.install.orchestrate import _clamp_context_size
+
+    # 96 GB unified Strix box → half-pool budget dwarfs a 32K KV cache.
+    assert _clamp_context_size(32768, _strix_hw(), weights_gb=2.5) == 32768
+
+
+def test_clamp_context_size_clamps_on_tight_cpu_host():
+    """A memory-tight CPU-only host clamps a huge native window down to a
+    budget the KV cache actually fits — the first-warm OOM fix (#1108)."""
+    from hal0.install.orchestrate import _clamp_context_size
+
+    hw = HardwareInfo(ram_mb=8192, ram_available_mb=8192)  # no GPU
+    clamped = _clamp_context_size(131072, hw, weights_gb=2.0)
+    assert clamped < 131072
+    # budget = 0.5*8 = 4 GB; kv = 4 - 2(weights) - 1(reserve) = 1 GB;
+    # 1 GiB / 128 KiB ≈ 8192 tokens.
+    assert clamped == 8192
+
+
+def test_clamp_context_size_honors_cgroup_cap():
+    """An LXC/container memory cap binds the UMA budget so a capped box clamps
+    even though the raw unified pool looks huge (the `oom` artifact box)."""
+    from hal0.install.orchestrate import _clamp_context_size
+
+    hw = HardwareInfo(
+        platform="strix-halo",
+        ram_mb=98304,
+        ram_available_mb=90000,
+        unified_memory_mb=98304,
+        cgroup_max_mb=8192,  # LXC-capped to 8 GB
+        gpus=[GPUInfo(vendor="amd", vram_mb=512, compute_capable=True, vulkan_capable=True)],
+        npu=NPUInfo(present=True),
+    )
+    clamped = _clamp_context_size(131072, hw, weights_gb=2.0)
+    assert clamped < 131072
+
+
+def test_clamp_context_size_never_below_floor():
+    """Even a starved host keeps a minimally usable window."""
+    from hal0.install.orchestrate import _MIN_CONTEXT, _clamp_context_size
+
+    hw = HardwareInfo(ram_mb=2048, ram_available_mb=1024)  # ~0.5 GB budget
+    assert _clamp_context_size(131072, hw, weights_gb=8.0) == _MIN_CONTEXT


### PR DESCRIPTION
## installer-setup WS-E — safe slot activation (#1108)

Fixes the two hazards in the guided apply path that produced the `oom` artifact and the start-before-model race.

### Problem
1. Slots were seeded `enabled=true` while the pull was queued separately, so a slot could start before its model existed on disk.
2. `context_size` trusted `curated.context_length` (the model's *native* window) instead of a hardware budget, OOMing on first warm.

### Fix
- **Born disabled → enable-on-pull-success.** `_build_slot_cfg` now creates the slot `enabled=false`; `apply_setup` records the slot on its `PullPlan.slot_names`. New `run_pull_and_activate()` runs the pull, then flips `enabled=true` only on success. A failed pull (raise, or job settling `state=="failed"`) leaves the slot disabled and stamps `[meta].pull_failed`, so a half-provisioned box parks the slot instead of crash-looping a container against a missing model. Two slots sharing one `model_id` both ride the single pull and both get enabled.
- **Hardware-aware context clamp.** `_clamp_context_size()` derives a VRAM/RAM budget from the authoritative `hardware.json` facts (#1097): half the UMA pool / discrete VRAM / half `MemAvailable`, and **also honors a cgroup memory cap** (#372) so an LXC/container-capped host (the `oom` box) clamps against its real ceiling. Model weights + a runtime reserve come off the budget first; the remainder funds the KV cache at a conservative 128 KiB/token, aligned to 1024 and floored at 2048. A big box passes the native window through unchanged.
- **Callers wired.** The installer `/apply` + `/apply-selections` route (via `_apply_selections_core`) and the CLI `_run_pulls_with_progress` now drive pulls through `run_pull_and_activate`.

### Context budget
`budget_gb = _memory_budget_gb(hw)` → for AMD UMA: `min(unified_pool, cgroup_cap) * 0.5`; discrete GPU: dedicated VRAM (cgroup does not cap it); CPU-only: `min(MemAvailable, cgroup_cap) * 0.5`. Then `kv_gb = budget_gb - weights_gb - 1.0` reserve; `tokens = kv_gb * 1GiB / 128KiB`, aligned to 1024, floored at 2048; final `min(requested, tokens)`.

### Tests
- enable-on-success transition; failed-job leaves disabled + `pull_failed` mark; `run_pull` raise marks-and-re-raises; shared-model dual enable; born-disabled create + plan carries slot.
- clamp: pass-through on ample hw, clamp on tight CPU host (131072 → 8192), cgroup cap binds a big UMA pool, never below the 2048 floor.
- Route/CLI tests updated to patch `hal0.registry.pull.run_pull` (the lazy import inside `run_pull_and_activate`) and assert the slot flips enabled after a fake successful pull.

Full `ruff format`/`ruff check`/`ruff format --check` clean. `pytest`: no new failures vs. base — the ~18 red tests (hermes venv, comfyui phase4, proxmox host detection, container spec dispatch, config-url-proxy, models-preview, settings-store, emit-answers/setup-plan CLI, openwebui smoke) all reproduce with this diff stashed.

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
