### PR TITLE
installer-setup WS-J: extract one slot-render reconcile seam shared by install + update

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1141,43 +1141,26 @@ class ContainerProvider(Provider):
             extra={"slot": slot_name, "unit": self._unit_name(slot_name)},
         )
 
-    def load_sync(
-        self,
-        slot_cfg: dict[str, Any],
-        model_info: dict[str, Any],
-    ) -> None:
-        """Write systemd unit, daemon-reload, enable, start (synchronous).
+    def _render_unit_text(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> str:
+        """Render the desired systemd unit text for a slot — the ONE renderer.
 
-        Called from ``_spawn_locked`` (which is already inside an
-        asyncio.to_thread-friendly path — SlotManager awaits the slot spawn
-        via ``await self._spawn_locked(...)``).
+        Sole producer of slot-unit text: both :meth:`load_sync` (first install)
+        and :meth:`rerender_unit_sync` (update) render through here, so a fresh
+        box and an updated box emit **byte-identical** units for the same slot
+        config (#1103). Resolves the slot's runtime family to a provider via
+        :func:`_spec_provider_for` (FLM/NPU, Kokoro/TTS, ComfyUI/img — else this
+        GPU/llama-server provider), builds its :class:`RuntimeLaunchPlan` via
+        ``container_spec``, and turns it into ``hal0-slot@<name>.service`` text
+        via the one adapter :func:`_render_unit_from_plan`.
 
-        Single launch path: :func:`_spec_provider_for` resolves the slot's
-        runtime family to a provider (FLM/NPU, Kokoro/TTS, ComfyUI/img, or this
-        provider for GPU/llama-server); the provider builds a
-        :class:`RuntimeLaunchPlan` via ``container_spec``; and the one renderer
-        :func:`_render_unit_from_plan` turns it into the systemd unit.  GPU is
-        no longer a special argv branch here.
+        Crucially it threads the live ``[slots].publish_host`` into every
+        render. The update path used to drop that argument and fall back to the
+        loopback default, so re-rendering a slot on a LAN-exposed box
+        (``publish_host = 0.0.0.0``) silently narrowed the bind back to
+        ``127.0.0.1`` — the exact fresh-vs-updated divergence WS-J removes.
         """
         slot_name: str = str(slot_cfg.get("name", ""))
-
-        provider = _spec_provider_for(slot_cfg)
-        if provider is None:
-            provider = self  # GPU / llama-server
-        elif str(slot_cfg.get("device", "")) == "npu":
-            # Loud-fail for NPU slots only: a missing FLM tag must not silently
-            # fall through to FLM's legacy build_env default. Kokoro/ComfyUI are
-            # self-managed and need no registry tag — the check fires ONLY when
-            # device == "npu".
-            model_table = slot_cfg.get("model") or {}
-            tag = (
-                model_info.get("flm_tag")
-                or model_info.get("_model_key")
-                or (model_table.get("default") if isinstance(model_table, dict) else None)
-            )
-            if not tag:
-                raise ValueError("npu slot has no FLM model tag — set [model].default")
-
+        provider = _spec_provider_for(slot_cfg) or self
         plan = provider.container_spec(slot_cfg, model_info)
         log.info(
             "container.unit_render",
@@ -1189,12 +1172,46 @@ class ContainerProvider(Provider):
                 "provider": getattr(provider, "name", type(provider).__name__),
             },
         )
-        unit_text = _render_unit_from_plan(
+        return _render_unit_from_plan(
             slot_name,
             plan,
             runtime_bin=_container_runtime(),
             publish_host=_slot_publish_host(),
         )
+
+    def load_sync(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> None:
+        """Write systemd unit, daemon-reload, enable, start (synchronous).
+
+        Called from ``_spawn_locked`` (which is already inside an
+        asyncio.to_thread-friendly path — SlotManager awaits the slot spawn
+        via ``await self._spawn_locked(...)``).
+
+        Single launch path: unit text comes from the one renderer
+        :meth:`_render_unit_text` (shared with the update-time re-render), and
+        this method layers on the install-only steps — the NPU loud-fail guard
+        plus writing the file and enabling/starting the service.
+        """
+        slot_name: str = str(slot_cfg.get("name", ""))
+
+        # Loud-fail for NPU slots only: a missing FLM tag must not silently
+        # fall through to FLM's legacy build_env default. Kokoro/ComfyUI are
+        # self-managed and need no registry tag — the check fires ONLY when
+        # device == "npu" and the slot resolves to a spec provider.
+        if str(slot_cfg.get("device", "")) == "npu" and _spec_provider_for(slot_cfg) is not None:
+            model_table = slot_cfg.get("model") or {}
+            tag = (
+                model_info.get("flm_tag")
+                or model_info.get("_model_key")
+                or (model_table.get("default") if isinstance(model_table, dict) else None)
+            )
+            if not tag:
+                raise ValueError("npu slot has no FLM model tag — set [model].default")
+
+        unit_text = self._render_unit_text(slot_cfg, model_info)
         self._write_and_start_unit(slot_name, unit_text)
 
     def rerender_unit_sync(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> bool:
@@ -1204,10 +1221,15 @@ class ContainerProvider(Provider):
         The unit bakes the launch argv at load time, so after a hal0 update the
         on-disk ExecStart still carries pre-update flags: a bare ``systemctl
         restart`` (or a reboot!) re-runs stale config. This rewrites the unit
-        via the same plan path as :meth:`load_sync` but deliberately does NOT
-        enable/restart — serving is never bounced by an update; the new argv
+        via the same renderer as :meth:`load_sync` — :meth:`_render_unit_text`,
+        the sole producer of slot-unit text — but deliberately does NOT
+        enable/restart: serving is never bounced by an update; the new argv
         applies on the next start from any path. Callers batch one
         ``daemon_reload`` after a sweep.
+
+        Because both paths render through :meth:`_render_unit_text`, the unit an
+        update writes is byte-identical to the one a fresh install would write
+        for the same slot config — the WS-J guarantee (#1103).
 
         Returns True when the unit file changed. No-ops (False) when the slot
         has no unit on disk (never rendered → nothing stale) or the fresh
@@ -1217,9 +1239,7 @@ class ContainerProvider(Provider):
         unit_path = self._unit_path(slot_name)
         if not unit_path.exists():
             return False
-        provider = _spec_provider_for(slot_cfg) or self
-        plan = provider.container_spec(slot_cfg, model_info)
-        unit_text = _render_unit_from_plan(slot_name, plan, runtime_bin=_container_runtime())
+        unit_text = self._render_unit_text(slot_cfg, model_info)
         if unit_path.read_text() == unit_text:
             return False
         unit_path.write_text(unit_text)

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -728,6 +728,74 @@ class TestLoadSync:
 
         assert "--alias chadrock-35b-ace-saber" in unit_file.read_text()
 
+    def test_install_and_update_render_byte_identical_units(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """WS-J (#1103): install (``load_sync``) and update
+        (``rerender_unit_sync``) render **byte-identical** unit files for the
+        same slot config, because both go through the one renderer
+        ``_render_unit_text``.
+
+        Regression guard for the specific divergence WS-J removes: on a
+        LAN-exposed box (``[slots].publish_host = 0.0.0.0``) the pre-fix update
+        path dropped ``publish_host`` and silently narrowed the bind back to
+        loopback — so a fresh box and an updated box ended up with different
+        units for the same slot.
+        """
+        profile = _moe_profile()
+        slot_cfg = {
+            "name": "test-container",
+            "port": 8095,
+            "profile": "rocm",
+            "model": {"default": "m", "context_size": 131072},
+            "server": {"extra_args": "--override-kv k=bool:false"},
+        }
+        model_info = {"path": "/mnt/ai-models/model.gguf", "_model_key": "m"}
+
+        # LAN-exposed box: the operator widened the publish bind. Both render
+        # paths must honour it identically.
+        monkeypatch.setattr("hal0.providers.container._slot_publish_host", lambda: "0.0.0.0")
+
+        def fake_run(*args: str, check: bool = True) -> MagicMock:
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        # ── fresh install: load_sync writes the unit (systemctl mocked) ──
+        fresh_provider = ContainerProvider()
+        fresh_unit = tmp_path / "fresh.service"
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            patch.object(fresh_provider, "_run", side_effect=fake_run),
+            patch.object(fresh_provider, "_unit_path", return_value=fresh_unit),
+        ):
+            fresh_provider.load_sync(slot_cfg, model_info)
+        fresh_text = fresh_unit.read_text()
+        # Sanity: the widened bind actually rendered on the fresh install.
+        assert "--publish=0.0.0.0:8095:8095" in fresh_text
+
+        # ── updated box: a STALE unit already exists; rerender rewrites it ──
+        upd_provider = ContainerProvider()
+        upd_unit = tmp_path / "updated.service"
+        upd_unit.write_text("# stale pre-update unit — forces a rewrite\n")
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            patch.object(upd_provider, "_unit_path", return_value=upd_unit),
+        ):
+            changed = upd_provider.rerender_unit_sync(slot_cfg, model_info)
+
+        assert changed is True
+        # The WS-J guarantee: byte-for-byte identical units.
+        assert upd_unit.read_text() == fresh_text
+
     def test_resolved_command_includes_ctx_size(self) -> None:
         """The displayed resolved_command must show --ctx-size so it matches
         what actually launches."""


### PR DESCRIPTION
## Seam shape

**The routine:** `ContainerProvider._render_unit_text(self, slot_cfg, model_info) -> str` in `src/hal0/providers/container.py`.

It is the ONE renderer and sole producer of slot-unit text:
- resolves the slot's provider (`_spec_provider_for(slot_cfg) or self`),
- builds its `RuntimeLaunchPlan` via `container_spec`,
- renders through the single adapter `_render_unit_from_plan(...)` **with the live `[slots].publish_host`** (`publish_host=_slot_publish_host()`).

**Both call sites now route through it:**
- **Install** — `load_sync()` calls `self._render_unit_text(slot_cfg, model_info)`, then layers on the install-only steps (NPU loud-fail guard + `_write_and_start_unit`, which writes the file and enables/starts the service).
- **Update** — `rerender_unit_sync()` calls `self._render_unit_text(slot_cfg, model_info)`, then write-only (no enable/restart — serving is never bounced by an update). Updater sweep is unchanged (`rerender_slot_units` in `src/hal0/updater/updater.py` still calls `rerender_unit_sync` + batches one `daemon_reload`).

**What had to be unified:** the divergence was a single dropped argument. `load_sync` already passed `publish_host=_slot_publish_host()`; `rerender_unit_sync` called `_render_unit_from_plan(slot_name, plan, runtime_bin=_container_runtime())` and inherited the loopback default `127.0.0.1`. On a LAN-exposed box (`[slots].publish_host = 0.0.0.0`) a fresh install rendered `--publish=0.0.0.0:<port>:<port>` but an update silently narrowed it back to `--publish=127.0.0.1:<port>:<port>` — a fresh box and an updated box ending up with different units for the same slot. Pulling both paths through one renderer removes the second, drifting render path.

Extract-not-rewrite: the render log (`container.unit_render`) moved into the seam so both paths emit it consistently; no launch behavior changed.

## Proving byte-identical units

New test `tests/providers/test_container.py::TestLoadSync::test_install_and_update_render_byte_identical_units`:
1. monkeypatches `_slot_publish_host` -> `0.0.0.0` (the LAN-exposed box the pre-fix update path regressed),
2. runs `load_sync` (systemctl mocked) -> captures the fresh-install unit text; asserts `--publish=0.0.0.0:8095:8095` rendered,
3. seeds a **stale** unit file and runs `rerender_unit_sync` for the same slot config,
4. asserts `changed is True` **and** the rewritten unit is byte-for-byte equal to the fresh-install text.

This fails on the pre-fix code (update would render loopback) and passes on the seam.

## DoD
- `uv run ruff format --check src tests` -> `644 files already formatted`
- `uv run ruff check src tests` -> `All checks passed!`
- `uv run --extra dev pytest tests/providers/test_container.py` -> `60 passed`
- Broader `tests/providers tests/slots tests/updater` -> only `test_container_spec_dispatch.py::test_tts_kokoro_slot_renders_spec_unit` fails, confirmed **pre-existing** (fails on clean tree via `git stash -u`; matches the known "container spec dispatch" box-ordering failure).

## Files changed
- `src/hal0/providers/container.py` — new `_render_unit_text` seam; `load_sync` + `rerender_unit_sync` route through it.
- `tests/providers/test_container.py` — byte-identical regression test.

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)