### PR TITLE
installer-setup WS-B: platform-gate hardening (bootstrap-prereq parity, disk-on-store, early hal0 user)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -231,6 +231,18 @@ fi
 
 info "system: $(uname -srm)"
 
+# ── Bootstrap-prereq parity (#1098) ─────────────────────────────────────────
+# bootstrap.sh (the curl|bash one-liner) hard-requires a Linux host plus
+# curl/tar/sha256sum in its own preflight() before it ever fetches the
+# release tarball (installer/bootstrap.sh). install.sh itself leans on all
+# three later in this same run (preflight_network's curl probe, the
+# rsync-fallback tar copy below, the FLM .deb sha256 check) — but a direct
+# `sudo bash install.sh`, with no bootstrap in front, never checked for
+# them up front. Run the same check bootstrap.sh does so a minimal host
+# missing one of them fails here with an actionable message instead of a
+# bare "command not found" deep in the install.
+preflight_bootstrap_prereqs || die "missing base prereqs — see above (installer/bootstrap.sh's one-liner preflight requires the same tools)"
+
 # Architecture is a hard requirement in every mode — all shipped binaries
 # (FastFlowLM .deb, toolbox container images) are amd64-only.
 preflight_arch || die "hal0 requires an x86_64 host (see the message above)"
@@ -343,9 +355,77 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     preflight_writable "${PREFIX}" /usr/lib/hal0 "${ETC_DIR}" "${UNIT_DIR}" \
         "${VAR_DIR}" /usr/local/bin || pf_rc=$?
     preflight_disk 20 "${VAR_DIR}"            || pf_rc=$?
+    # Model-store disk check (#1098): the probe above only measures
+    # VAR_DIR's own mount (venv, container images, config, registry). Model
+    # weights land at MODELS_DIR, which is frequently a *different* mount
+    # (--models-dir=/data/models, a mounted NAS/NVMe) that the VAR_DIR probe
+    # never touches — a box could sail through pre-flight with 20 GB free on
+    # / while the actual model store is nearly full. Measure it too, but
+    # non-fatal (warn only, per the Q4 posture in
+    # handoffs/installer-setup-plan-2026-07-05.md): no model has been picked
+    # yet at install time, so an undersized store shouldn't hard-block the
+    # rest of the platform gate the way a genuinely full root disk should —
+    # `hal0 setup` / the pull gate re-validates before any download lands.
+    preflight_disk "${HAL0_MODELS_DISK_MIN_GB:-20}" "${MODELS_DIR}" \
+        || warn "model store ${MODELS_DIR} is low on free space — model pulls may fail until freed"
     preflight_ports "${HAL0_PORT}" 3001       || pf_rc=$?
     if (( pf_rc != 0 )); then
         false
+    fi
+fi
+
+# ── hal0 system user (early, #1098) ─────────────────────────────────────────
+# A dedicated `hal0` system user/group runs the non-root hal0 services:
+# hal0-agent@<id> (the Hermes runner), hermes-gateway, and the shared
+# hindsight-api memory engine. It also owns the HF cache under
+# ${VAR_DIR}/.cache so agent-side HuggingFace pulls work without
+# escalating. Slot inference itself runs in podman containers supervised
+# by hal0-slot@<name>.service — no daemon user needed there.
+#
+# Created here, immediately after pre-flight and BEFORE any filesystem
+# mutation (was previously created much later, after directories/units/
+# config were already written — handoffs/installer-setup-plan-2026-07-05.md
+# Q1), so the render/video group membership below is settled before any
+# later step that depends on group membership or on the user existing
+# (the FLM cache / HF cache / STATE.md ownership work further down).
+ui_step "System user"
+
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    # Dev installs never create system users or touch systemd.
+    info "dev mode — skipping hal0 system user creation"
+else
+    # hal0 system user/group. System user (UID < 1000), no login shell,
+    # home at ${VAR_DIR} so any stray `~`-relative writes from agent
+    # processes land somewhere sane. ${VAR_DIR} itself doesn't need to
+    # exist yet — useradd only records the home path (no -m flag).
+    # Idempotent via `getent`.
+    if ! getent group hal0 >/dev/null 2>&1; then
+        groupadd --system hal0
+        info "created group hal0"
+    fi
+    if ! getent passwd hal0 >/dev/null 2>&1; then
+        useradd --system --gid hal0 --home-dir "${VAR_DIR}" \
+            --shell /usr/sbin/nologin \
+            --comment "hal0 service user" \
+            hal0
+        info "created user hal0 (system, no login)"
+    fi
+
+    # GPU device access (issue #420). Keeps hal0-user processes (agents,
+    # diagnostics) able to read /dev/kfd + /dev/dri/renderD* when they
+    # probe the GPU. Slot containers get their devices from podman
+    # directly and don't depend on this. Idempotent; only adds groups
+    # that actually exist on the host (a non-GPU box / CI runner simply
+    # has neither).
+    KFD_GROUPS=""
+    for _g in render video; do
+        if getent group "${_g}" >/dev/null 2>&1; then
+            KFD_GROUPS="${KFD_GROUPS:+${KFD_GROUPS},}${_g}"
+        fi
+    done
+    if [[ -n "${KFD_GROUPS}" ]]; then
+        usermod -aG "${KFD_GROUPS}" hal0
+        info "added hal0 to groups: ${KFD_GROUPS}"
     fi
 fi
 
@@ -1350,51 +1430,16 @@ else
     fi
 fi
 
-# ── hal0 system user ────────────────────────────────────────────────────────
-# A dedicated `hal0` system user/group runs the non-root hal0 services:
-# hal0-agent@<id> (the Hermes runner), hermes-gateway, and the shared
-# hindsight-api memory engine. It also owns the HF cache under
-# ${VAR_DIR}/.cache so agent-side HuggingFace pulls work without
-# escalating. Slot inference itself runs in podman containers supervised
-# by hal0-slot@<name>.service — no daemon user needed there.
-ui_step "System user"
-
+# ── hal0 system user: device/dir-dependent follow-up (#1098) ───────────────
+# The user/group + render/video membership themselves are created MUCH
+# earlier now (see "── hal0 system user (early, #1098) ──" right after
+# pre-flight, before any filesystem mutation). What's left here needs
+# directories that only exist from this point on (VAR_DIR's tree, created
+# in "Filesystem layout" above) — the hal0 user's HF cache, the FLM (NPU)
+# cache, and the shared STATE.md.
 if [[ "${DEV_MODE}" -eq 1 ]]; then
-    # Dev installs never create system users or touch systemd.
-    info "dev mode — skipping hal0 system user creation"
+    : # dev mode never created the hal0 user above; nothing to follow up.
 else
-    # 1. hal0 system user/group. System user (UID < 1000), no login
-    #    shell, home at ${VAR_DIR} so any stray `~`-relative writes from
-    #    agent processes land somewhere sane. Idempotent via `getent`.
-    if ! getent group hal0 >/dev/null 2>&1; then
-        groupadd --system hal0
-        info "created group hal0"
-    fi
-    if ! getent passwd hal0 >/dev/null 2>&1; then
-        useradd --system --gid hal0 --home-dir "${VAR_DIR}" \
-            --shell /usr/sbin/nologin \
-            --comment "hal0 service user" \
-            hal0
-        info "created user hal0 (system, no login)"
-    fi
-
-    # GPU device access (issue #420). Keeps hal0-user processes (agents,
-    # diagnostics) able to read /dev/kfd + /dev/dri/renderD* when they
-    # probe the GPU. Slot containers get their devices from podman
-    # directly and don't depend on this. Idempotent; only adds groups
-    # that actually exist on the host (a non-GPU box / CI runner simply
-    # has neither).
-    KFD_GROUPS=""
-    for _g in render video; do
-        if getent group "${_g}" >/dev/null 2>&1; then
-            KFD_GROUPS="${KFD_GROUPS:+${KFD_GROUPS},}${_g}"
-        fi
-    done
-    if [[ -n "${KFD_GROUPS}" ]]; then
-        usermod -aG "${KFD_GROUPS}" hal0
-        info "added hal0 to groups: ${KFD_GROUPS}"
-    fi
-
     # FLM (NPU) model cache. The npu slot bind-mounts this dir into the FLM
     # container, which runs as uid 1000 — NOT the host hal0 uid (a system
     # uid < 1000). If the dir is missing at container start podman fails

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -38,6 +38,11 @@
 #                                silently running CPU-only.
 #   preflight_disk MIN_GB DIR  — at least MIN_GB free in DIR (default 20 / /var/lib)
 #   preflight_ports P1 [P2…]   — none of the named TCP ports are LISTENing
+#   preflight_bootstrap_prereqs — Linux host + curl/tar/sha256sum on PATH,
+#                                mirroring bootstrap.sh's own preflight() so
+#                                the direct `sudo bash install.sh` path
+#                                enforces the same floor as the curl|bash
+#                                one-liner (#1098)
 #   preflight_all              — run all of the above; aggregate non-zero
 #
 # Globals honoured
@@ -562,6 +567,38 @@ preflight_gpu() {
     return 0
 }
 
+# ── Bootstrap-prereq parity (#1098) ────────────────────────────────────────
+# bootstrap.sh (the curl|bash one-liner) hard-requires a Linux host plus
+# curl/tar/sha256sum in its own preflight() before it ever fetches the
+# release tarball. install.sh leans on all three later in its own run
+# (preflight_network's curl probe, the rsync-fallback tar copy, the FLM
+# .deb sha256 check) but a direct `sudo bash install.sh` — no bootstrap in
+# front — never checked for them up front: a minimal host missing one
+# would sail past "Pre-flight checks" and die deep in the run with a bare
+# "command not found" instead of an actionable message. This mirrors
+# bootstrap.sh's preflight() (same checks, same die-style message) so both
+# entry points enforce the same floor. python3 is deliberately NOT
+# re-checked here — preflight_python (below) already does a stricter,
+# version-aware check with a better error message; duplicating a bare
+# `command -v python3` here would just produce a redundant, less useful
+# failure.
+preflight_bootstrap_prereqs() {
+    local rc=0
+    if [[ "$(uname -s)" != "Linux" ]]; then
+        err "hal0 only supports Linux right now (got $(uname -s))"
+        rc=1
+    fi
+    local dep
+    for dep in curl tar sha256sum; do
+        if ! command -v "${dep}" >/dev/null 2>&1; then
+            err "missing dependency: ${dep} — install it and re-run"
+            rc=1
+        fi
+    done
+    [[ "${rc}" -eq 0 ]] && info "bootstrap prereqs: curl, tar, sha256sum present (Linux)"
+    return "${rc}"
+}
+
 preflight_disk() {
     local min_gb="${1:-${HAL0_DISK_MIN_GB:-20}}"
     local target="${2:-${HAL0_DISK_TARGET:-/var/lib}}"
@@ -646,6 +683,7 @@ preflight_ports() {
 # picture, not the first failure.
 preflight_all() {
     local rc=0
+    preflight_bootstrap_prereqs || rc=$?
     preflight_arch    || rc=$?
     preflight_systemd || rc=$?
     preflight_python  || rc=$?

--- a/tests/installer/test_bootstrap_prereq_parity.py
+++ b/tests/installer/test_bootstrap_prereq_parity.py
@@ -1,0 +1,198 @@
+"""Bootstrap-prereq parity — WS-B (#1098).
+
+``installer/bootstrap.sh`` (the ``curl|bash`` one-liner) hard-requires a
+Linux host plus ``curl``/``tar``/``sha256sum`` in its own ``preflight()``
+before it ever fetches the release tarball. ``installer/install.sh`` leans
+on all three later in its own run (the network probe's curl call, the
+rsync-fallback tar copy, the FLM ``.deb`` sha256 check) but a direct
+``sudo bash install.sh`` — no bootstrap in front — never checked for them
+up front, so a minimal host missing one would sail past "Pre-flight
+checks" and die deep in the run with a bare "command not found" instead
+of an actionable message.
+
+``preflight_bootstrap_prereqs`` (added to ``installer/lib/preflight.sh``)
+closes that gap: it mirrors bootstrap.sh's checks and message style, and
+``install.sh`` calls it, hard (``die`` on failure), as part of its
+"Pre-flight checks" step — before any filesystem mutation.
+
+These tests exercise the shell function directly (subprocess, real bash —
+the same technique ``tests/installer/test_preflight_gpu_gate.py`` uses for
+``preflight_gpu``) plus a couple of static-text assertions against
+``install.sh`` proving the call site exists and runs early.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+_BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+def _write_exe(path: Path, body: str = "#!/usr/bin/env bash\nexit 0\n") -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+# preflight.sh only sources ui.sh / distro.sh when `info` / `pkg_install_cmd`
+# aren't already defined (guards it uses so install.sh, which has already
+# sourced both, doesn't source them twice). Pre-defining stubs here means
+# preflight_bootstrap_prereqs's own `info`/`err` calls still work (and are
+# capturable), while the *only* external binaries our restricted PATH needs
+# to supply are the ones the test is deliberately controlling (uname, curl,
+# tar, sha256sum) — not the dozen coreutils ui.sh/distro.sh would otherwise
+# need (dirname, cd, pwd, grep, ...).
+_STUBS = (
+    "info() { printf 'INFO: %s\\n' \"$*\"; }\n"
+    "warn() { printf 'WARN: %s\\n' \"$*\"; }\n"
+    "err()  { printf 'ERR: %s\\n' \"$*\" >&2; }\n"
+    'die()  { err "$*"; exit 1; }\n'
+    "pkg_install_cmd() { :; }\n"
+)
+
+
+def _run_prereqs(
+    bin_dir: Path, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess:
+    """Source preflight.sh with PATH pinned to ``bin_dir`` and run the check.
+
+    Pinning PATH to a controlled, minimal directory (rather than unsetting
+    real tools from the test runner's PATH) is what makes "missing X" and
+    "wrong OS" reproducible independent of the host running the suite.
+    """
+    script = (
+        "set -euo pipefail\n" + _STUBS + f"source {_PREFLIGHT!s}\n"
+        "rc=0\n"
+        "preflight_bootstrap_prereqs || rc=$?\n"
+        "exit $rc\n"
+    )
+    env = {"PATH": str(bin_dir), **(extra_env or {})}
+    return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+
+
+@pytest.fixture
+def full_bin_dir(tmp_path: Path) -> Path:
+    """A PATH dir with real bash/curl/tar/sha256sum/uname — the happy path."""
+    d = tmp_path / "bin"
+    d.mkdir()
+    for tool in ("bash", "curl", "tar", "sha256sum", "uname"):
+        found = shutil.which(tool)
+        if found:
+            os.symlink(found, d / tool)
+    return d
+
+
+def _fake_uname(d: Path, os_name: str) -> None:
+    _write_exe(d / "uname", f'#!/usr/bin/env bash\necho "{os_name}"\n')
+
+
+class TestAllPresentOnLinux:
+    def test_returns_zero(self, full_bin_dir: Path) -> None:
+        proc = _run_prereqs(full_bin_dir)
+        assert proc.returncode == 0, proc.stderr
+
+    def test_reports_ok(self, full_bin_dir: Path) -> None:
+        proc = _run_prereqs(full_bin_dir)
+        assert "curl, tar, sha256sum present" in proc.stdout + proc.stderr
+
+
+class TestMissingDependency:
+    @pytest.mark.parametrize("missing", ["curl", "tar", "sha256sum"])
+    def test_missing_tool_is_fatal(self, full_bin_dir: Path, missing: str) -> None:
+        (full_bin_dir / missing).unlink()
+        proc = _run_prereqs(full_bin_dir)
+        assert proc.returncode != 0
+        assert f"missing dependency: {missing}" in proc.stdout + proc.stderr
+
+    def test_missing_tool_message_says_install_and_rerun(self, full_bin_dir: Path) -> None:
+        (full_bin_dir / "tar").unlink()
+        proc = _run_prereqs(full_bin_dir)
+        assert "install it and re-run" in proc.stdout + proc.stderr
+
+    def test_all_missing_reports_all_three(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        for tool in ("bash", "uname"):
+            found = shutil.which(tool)
+            if found:
+                os.symlink(found, d / tool)
+        proc = _run_prereqs(d)
+        assert proc.returncode != 0
+        out = proc.stdout + proc.stderr
+        assert "missing dependency: curl" in out
+        assert "missing dependency: tar" in out
+        assert "missing dependency: sha256sum" in out
+
+
+class TestNonLinuxHost:
+    def test_darwin_is_rejected(self, full_bin_dir: Path) -> None:
+        _fake_uname(full_bin_dir, "Darwin")
+        proc = _run_prereqs(full_bin_dir)
+        assert proc.returncode != 0
+        assert "only supports Linux" in proc.stdout + proc.stderr
+        assert "Darwin" in proc.stdout + proc.stderr
+
+    def test_linux_is_accepted(self, full_bin_dir: Path) -> None:
+        _fake_uname(full_bin_dir, "Linux")
+        proc = _run_prereqs(full_bin_dir)
+        assert proc.returncode == 0, proc.stderr
+
+
+class TestMirrorsBootstrapSh:
+    """Same checks bootstrap.sh's own ``preflight()`` performs."""
+
+    def test_bootstrap_sh_checks_the_same_four_things(self) -> None:
+        text = _BOOTSTRAP.read_text(encoding="utf-8")
+        m = re.search(r"preflight\(\) \{(.*?)\n\}", text, re.DOTALL)
+        assert m is not None, "bootstrap.sh preflight() not found"
+        body = m.group(1)
+        assert "uname -s" in body and "Linux" in body
+        assert "need curl" in body
+        assert "need tar" in body
+        assert "need sha256sum" in body
+
+
+class TestInstallShWiring:
+    """install.sh must call the parity check, hard, early in its own run."""
+
+    def test_install_sh_calls_preflight_bootstrap_prereqs(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        assert "preflight_bootstrap_prereqs" in text
+
+    def test_failure_is_fatal_not_a_warning(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        m = re.search(r"preflight_bootstrap_prereqs \|\| (\w+)", text)
+        assert m is not None, "no `preflight_bootstrap_prereqs || ...` call site in install.sh"
+        assert m.group(1) == "die", "a missing base prereq must abort the install, not just warn"
+
+    def test_runs_before_any_filesystem_mutation(self) -> None:
+        # "Filesystem layout" is the first ui_step that actually mutates the
+        # host (mkdir -p ...). The prereq check must run strictly before it.
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        prereq_idx = text.index("preflight_bootstrap_prereqs ||")
+        mkdir_step_idx = text.index('ui_step "Filesystem layout"')
+        assert prereq_idx < mkdir_step_idx
+
+    def test_preflight_all_also_runs_it(self) -> None:
+        # `hal0 doctor` (preflight_all) should report the same floor.
+        text = _PREFLIGHT.read_text(encoding="utf-8")
+        m = re.search(r"preflight_all\(\) \{(.*?)\n\}", text, re.DOTALL)
+        assert m is not None
+        assert "preflight_bootstrap_prereqs" in m.group(1)
+
+
+def test_bash_syntax_check() -> None:
+    for path in (_INSTALL_SH, _PREFLIGHT, _BOOTSTRAP):
+        proc = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, f"{path}: {proc.stderr}"

--- a/tests/installer/test_platform_gate_hardening.py
+++ b/tests/installer/test_platform_gate_hardening.py
@@ -1,0 +1,164 @@
+"""Platform-gate hardening — WS-B (#1098): early hal0 user + disk-on-store.
+
+Two more gaps closed alongside bootstrap-prereq parity
+(``test_bootstrap_prereq_parity.py``):
+
+1. The ``hal0`` system user/group (and its render/video group membership)
+   used to be created very late — after directories, the source copy,
+   hal0.toml patching, and the systemd-unit render had already mutated the
+   host (handoffs/installer-setup-plan-2026-07-05.md, decision Q1). It is
+   now created immediately after pre-flight, before the first mutating
+   step ("Filesystem layout"'s ``mkdir -p``).
+2. The disk-space pre-flight only ever measured ``VAR_DIR``, never the
+   models store the operator actually picked via ``--models-dir`` /
+   ``HAL0_MODELS_DIR`` — a separate mount in the "big NVMe/NAS for
+   weights" case. It now also measures ``MODELS_DIR`` (warn-only, per the
+   Q4 posture: no model is chosen yet at install time, so an undersized
+   store shouldn't hard-block the rest of the platform gate).
+
+These are static-text/ordering assertions against ``installer/install.sh``
+(the same technique ``tests/systemd/test_hf_token_secrets.py`` uses) —
+actually creating a system user or exhausting a mount needs root / a
+disposable filesystem, which the black-box harness
+(``tests/harness/installer-test.sh``) exercises instead.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+@pytest.fixture(scope="module")
+def install_sh_text() -> str:
+    assert _INSTALL_SH.exists(), f"missing {_INSTALL_SH}"
+    return _INSTALL_SH.read_text(encoding="utf-8")
+
+
+# ── early hal0 user ─────────────────────────────────────────────────────────
+
+
+class TestEarlyHal0User:
+    def test_group_and_user_creation_present(self, install_sh_text: str) -> None:
+        assert "groupadd --system hal0" in install_sh_text
+        assert re.search(r"useradd --system --gid hal0", install_sh_text)
+
+    def test_render_video_group_membership_present(self, install_sh_text: str) -> None:
+        assert re.search(r"for _g in render video", install_sh_text)
+        assert "usermod -aG" in install_sh_text
+
+    def test_user_and_group_created_exactly_once(self, install_sh_text: str) -> None:
+        # A prior version of this block ran twice (once — the real one —
+        # having been left behind after the move). Guard the merge.
+        assert install_sh_text.count("groupadd --system hal0") == 1
+        assert install_sh_text.count("useradd --system --gid hal0") == 1
+
+    def test_user_creation_precedes_filesystem_layout_step(self, install_sh_text: str) -> None:
+        # "Filesystem layout" is the first ui_step that mutates the host
+        # (mkdir -p PREFIX/ETC_DIR/MODELS_DIR/...). The hal0 user must exist
+        # before that, not after.
+        useradd_idx = install_sh_text.index("useradd --system --gid hal0")
+        mkdir_step_idx = install_sh_text.index('ui_step "Filesystem layout"')
+        assert useradd_idx < mkdir_step_idx, (
+            "hal0 user must be created before the 'Filesystem layout' mutation step"
+        )
+
+    def test_user_creation_precedes_source_copy_and_toml_patch(self, install_sh_text: str) -> None:
+        # Belt-and-suspenders on top of the ui_step check: also strictly
+        # before the rsync/tar source copy and the hal0.toml [models] patch,
+        # both of which are mutation the user must predate per Q1.
+        useradd_idx = install_sh_text.index("useradd --system --gid hal0")
+        rsync_idx = install_sh_text.index("Copying source to")
+        toml_idx = install_sh_text.index('HAL0_TOML="${ETC_DIR}/hal0.toml"')
+        assert useradd_idx < rsync_idx
+        assert useradd_idx < toml_idx
+
+    def test_user_creation_precedes_preflight_gpu_group_dependent_followups(
+        self, install_sh_text: str
+    ) -> None:
+        # The FLM cache dir is chowned to `1000:hal0` — it depends on the
+        # hal0 group existing. It must come after the early user/group block.
+        useradd_idx = install_sh_text.index("useradd --system --gid hal0")
+        flm_chown_idx = install_sh_text.index("chown 1000:hal0")
+        assert useradd_idx < flm_chown_idx
+
+    def test_dev_mode_still_skips_user_creation(self, install_sh_text: str) -> None:
+        assert "dev mode — skipping hal0 system user creation" in install_sh_text
+
+    def test_followup_block_does_not_recreate_user(self, install_sh_text: str) -> None:
+        # The later (device/dir-dependent) block must not re-run getent/
+        # groupadd/useradd — that work already happened earlier.
+        m = re.search(
+            r"── hal0 system user: device/dir-dependent follow-up.*?\nif.*?\nelse\n(.*?)\nfi\n",
+            install_sh_text,
+            re.DOTALL,
+        )
+        assert m is not None, "device/dir-dependent follow-up block not found"
+        followup = m.group(1)
+        # (Comments in this block legitimately reference "useradd above" as
+        # documentation of the split — check for the actual invocations,
+        # not the bare substring.)
+        assert "groupadd --system hal0" not in followup
+        assert "useradd --system --gid hal0" not in followup
+
+
+# ── disk-on-store ────────────────────────────────────────────────────────────
+
+
+class TestDiskOnStore:
+    def test_models_dir_is_probed(self, install_sh_text: str) -> None:
+        assert re.search(
+            r'preflight_disk\s+"\$\{HAL0_MODELS_DISK_MIN_GB:-\d+\}"\s+"\$\{MODELS_DIR\}"',
+            install_sh_text,
+        )
+
+    def test_var_dir_probe_is_unchanged(self, install_sh_text: str) -> None:
+        # The original VAR_DIR probe (system reqs: venv, container images,
+        # config) must still be there — this is additive, not a swap.
+        assert 'preflight_disk 20 "${VAR_DIR}"' in install_sh_text
+
+    def test_models_dir_probe_is_warn_only_not_fatal(self, install_sh_text: str) -> None:
+        # Unlike the VAR_DIR probe (`|| pf_rc=$?`, aggregated into the hard
+        # abort below), the models-store probe must not feed pf_rc — a
+        # small/undersized store at install time (before any model is
+        # picked) is a warning, not a hard stop.
+        m = re.search(
+            r'preflight_disk\s+"\$\{HAL0_MODELS_DISK_MIN_GB:-\d+\}"\s+"\$\{MODELS_DIR\}"\s*\\\n\s*\|\|\s*(\w+)',
+            install_sh_text,
+        )
+        assert m is not None
+        assert m.group(1) == "warn", "the model-store disk check must warn, not set pf_rc / die"
+
+    def test_models_dir_probe_happens_within_preflight_step(self, install_sh_text: str) -> None:
+        preflight_step_idx = install_sh_text.index('ui_step "Pre-flight checks"')
+        filesystem_step_idx = install_sh_text.index('ui_step "Filesystem layout"')
+        models_probe_idx = install_sh_text.index('preflight_disk "${HAL0_MODELS_DISK_MIN_GB:-20}"')
+        assert preflight_step_idx < models_probe_idx < filesystem_step_idx
+
+
+def test_bash_syntax_check() -> None:
+    proc = subprocess.run(
+        ["bash", "-n", str(_INSTALL_SH)], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+class TestShellcheckClean:
+    def test_no_new_shellcheck_errors(self, install_sh_text: str) -> None:
+        import shutil
+
+        if shutil.which("shellcheck") is None:
+            pytest.skip("shellcheck not installed")
+        proc = subprocess.run(
+            ["shellcheck", "--severity=error", str(_INSTALL_SH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode == 0, f"shellcheck reported errors:\n{proc.stdout}\n{proc.stderr}"


### PR DESCRIPTION
## Summary

Closes #1098.

Three up-front gate gaps closed in `installer/install.sh` / `installer/lib/preflight.sh`:

1. **Bootstrap-prereq parity** — `installer/bootstrap.sh` (the `curl|bash` one-liner) hard-requires a Linux host plus `curl`/`tar`/`sha256sum` in its own `preflight()` before it ever fetches the release tarball. `install.sh` leans on all three later in its own run (the network probe's curl call, the rsync-fallback tar copy, the FLM `.deb` sha256 check) but a direct `sudo bash install.sh` — no bootstrap in front — never checked for them up front. Added `preflight_bootstrap_prereqs()` to `installer/lib/preflight.sh` (mirrors bootstrap.sh's checks/message style) and call it, hard (`die` on failure), as the first thing install.sh does in its "Pre-flight checks" step. Also wired into `preflight_all` so `hal0 doctor` reports the same floor.
2. **Disk-space check on the chosen model store** — the existing disk probe only ever measured `VAR_DIR`. Model weights land at `MODELS_DIR`, which is frequently a *different* mount (`--models-dir=/data/models`, a NAS/NVMe). Added a second `preflight_disk` call against `MODELS_DIR`, warn-only (non-fatal) — no model is picked yet at install time, so an undersized store shouldn't hard-block the rest of the platform gate the way a genuinely full root disk should.
3. **Early `hal0` user creation** — the `hal0` system user/group + render/video group membership used to be created very late (after directories, the source copy, and hal0.toml were already mutated). Moved to immediately after pre-flight, before the first mutating step ("Filesystem layout"'s `mkdir -p`). The directory-dependent follow-up work that needs `VAR_DIR` to exist (FLM cache, HF cache, `STATE.md` ownership) stays where it was, in its own now-`ui_step`-free block.

No regression to the one-liner path: bootstrap.sh is unchanged, and install.sh's new checks are strictly additive.

## Test plan

- [x] `bash -n installer/install.sh`
- [x] `uv run ruff format src tests` / `ruff check` / `ruff format --check` — clean
- [x] New tests: `tests/installer/test_bootstrap_prereq_parity.py` (function-level, via subprocess+stubs — asserts Linux/curl/tar/sha256sum checks, install.sh wiring + ordering) and `tests/installer/test_platform_gate_hardening.py` (static-text/ordering assertions: early user creation precedes mutation, no duplicate user/group creation, models-store disk check present and warn-only)
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — same ~14 pre-existing failures as `main` (confirmed via `git stash`: hermes venv, comfyui phase4, proxmox host detection, container spec, config-url-proxy, models-preview, settings-store), no new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)