### PR TITLE
installer-setup WS-E: clean seeded slots (no model pins, derived device) + resolve gemma-4-12b-it

### DIFF
--- a/installer/etc-hal0/slots/img.toml
+++ b/installer/etc-hal0/slots/img.toml
@@ -4,6 +4,12 @@
 # holds GPU memory — LLM slots are unloaded while generation is active, and
 # ComfyUI's models are freed (POST /free) when LLM slots come back after
 # [image].idle_restore_minutes with no jobs (spec §7).
+#
+# Clean seed (WS-E, #1107): no `[model].default` pin and DISABLED, so a model-less
+# box boots a grey tile — no surprise multi-GB checkpoint download (the previous
+# `sdxl-turbo` pin) and no crash-loop. ComfyUI capability picks land via the
+# guided setup's `comfyui_defaults` sidecar → POST /api/comfyui/models/fetch; the
+# operator enables this slot once a checkpoint is present.
 
 name = "img"
 type = "image"
@@ -11,11 +17,8 @@ provider = "comfyui"
 device = "gpu-rocm"
 runtime = "container"
 profile = "comfyui"
-enabled = true
+enabled = false
 port = 8188
-
-[model]
-default = "sdxl-turbo"
 
 [image]                       # persisted image-gen settings (#599)
 idle_restore_minutes = 60

--- a/installer/etc-hal0/slots/npu.toml
+++ b/installer/etc-hal0/slots/npu.toml
@@ -1,6 +1,10 @@
 # NPU LLM slot — FastFlowLM in a podman container (hal0-slot@npu).
-# Chat-only utility slot: gemma4-it:e2b, no trio (asr/embed disabled).
+# Chat-only utility slot: no trio (asr/embed disabled).
 # role="utility" lets hal0/utility resolve here; hal0/npu still matches by device.
+#
+# Clean seed (WS-E, #1107): no `[model].default` pin and DISABLED, so a model-less
+# box boots a grey tile (no surprise FLM download, no crash-loop). The operator
+# assigns an FLM model later, which flips the slot enabled.
 name = "npu"
 port = 8088
 device = "npu"
@@ -8,7 +12,7 @@ runtime = "container"
 profile = "flm"
 type = "llm"
 role = "utility"
+enabled = false
 
 [model]
-default = "gemma4-it-e2b-FLM"
 context_size = 16384

--- a/installer/etc-hal0/slots/qwen3tts.toml
+++ b/installer/etc-hal0/slots/qwen3tts.toml
@@ -1,8 +1,13 @@
 # Qwen3-TTS slot — multilingual GPU TTS in a podman container
 # (hal0-slot@qwen3tts). The GPU sibling of the cpu `tts`/kokoro slot; both
-# implement the OpenAI /v1/audio/speech contract. Disabled by default so a
-# fresh install boots with the lighter CPU Kokoro slot; enable this to make
-# the GPU multilingual engine available.
+# implement the OpenAI /v1/audio/speech contract.
+#
+# EXPLICITLY OUT of the installer's seed loop (WS-E, #1107): install.sh only
+# copies `npu tts rerank utility img` into /etc/hal0/slots. This file is an
+# opt-in TEMPLATE the operator drops in by hand (or a future picker enables) to
+# add the GPU multilingual engine alongside the lighter default CPU Kokoro slot.
+# Like the seeded slots it ships DISABLED with no `[model].default` pin, so
+# copying it in never triggers a surprise download or a crash-loop.
 name = "qwen3tts"
 type = "tts"
 device = "gpu-rocm"
@@ -10,6 +15,3 @@ runtime = "container"
 profile = "tts-qwen3"
 enabled = false
 port = 8095
-
-[model]
-default = "qwen3-tts"

--- a/installer/etc-hal0/slots/rerank.toml
+++ b/installer/etc-hal0/slots/rerank.toml
@@ -1,14 +1,19 @@
 # Rerank slot — llama-server --reranking in a podman container (hal0-slot@rerank).
+#
+# Clean seed (WS-E, #1107): no `[model].default` pin and DISABLED, so a model-less
+# box boots a grey tile (no surprise download, no crash-loop). The operator picks
+# a reranker later; that flips the slot enabled. device/profile are the widest-
+# compatible GPU-Vulkan tile defaults — the guided / answer-file setup path
+# derives them from the up-front preflight (hardware.json, #1097).
 name = "rerank"
 type = "reranking"
 device = "gpu-vulkan"
 runtime = "container"
 profile = "vulkan"
-enabled = true
+enabled = false
 port = 8083
 
 [model]
-default = "bge-reranker-v2-m3-q4_k_m"
 context_size = 4096
 
 [server]

--- a/installer/etc-hal0/slots/tts.toml
+++ b/installer/etc-hal0/slots/tts.toml
@@ -1,11 +1,12 @@
 # TTS slot — kokoro-onnx in a podman container (hal0-slot@tts), CPU-only.
+#
+# Clean seed (WS-E, #1107): no `[model].default` pin and DISABLED, so a model-less
+# box boots a grey tile (no surprise download, no crash-loop). The operator picks
+# a voice model later, which flips the slot enabled.
 name = "tts"
 type = "tts"
 device = "cpu"
 runtime = "container"
 profile = "tts"
-enabled = true
+enabled = false
 port = 8084
-
-[model]
-default = "kokoro-v1"

--- a/installer/etc-hal0/slots/utility.toml
+++ b/installer/etc-hal0/slots/utility.toml
@@ -1,12 +1,23 @@
 # Utility LLM slot — vulkan llama-server container (hal0-slot@utility).
+#
+# Clean seed (WS-E, #1107): ships WITHOUT a `[model].default` and DISABLED, so a
+# fresh, deliberately model-less box boots a GREY tile — no surprise multi-GB
+# download and no crash-loop. The previous pin was the GHOST id `gemma-4-12b-it`:
+# a catalog/marketing id with NO registry file and NO curated coords (the real
+# GGUF is `gemma-4-12b-it-ud-q4-k-xl` → `unsloth/gemma-4-12b-it-GGUF`). Pinned to
+# the ghost on a box with nothing to fall back to, the slot crash-looped.
+#
+# The operator assigns a model later (dashboard / `hal0 setup`), which flips the
+# slot enabled. device/profile here are the widest-compatible GPU-Vulkan tile
+# defaults; the guided / answer-file setup path derives them from the up-front
+# preflight (hardware.json, #1097) via `derive_device`/`derive_profile`.
 name = "utility"
 type = "llm"
 device = "gpu-vulkan"
 runtime = "container"
 profile = "vulkan"
-enabled = true
+enabled = false
 port = 8081
 
 [model]
-default = "gemma-4-12b-it"
 context_size = 65536

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -31,11 +31,17 @@ Environment=HINDSIGHT_API_LLM_PROVIDER=openai
 Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1
 # [Q5''] Moved NPU -> utility slot. The [Q5'] NPU rationale (below) predates
 # the podman container runtime: it freed a Lemonade-era iGPU that evicted
-# models on contention. Slots are resident containers now — `utility`
-# (gemma-4-12b-it, iGPU) is always loaded, so routing Hindsight there adds
-# no GTT pressure, and the Memory dashboard (#748) made reflect / mental
+# models on contention. Slots are resident containers now — the `utility`
+# slot (iGPU) carries chat + Hindsight extraction, so routing Hindsight there
+# adds no GTT pressure, and the Memory dashboard (#748) made reflect / mental
 # models / consolidation user-facing: ~2s/turn on utility vs 77-160s on the
 # NPU (FLM serializes, so memory ops also queued behind NPU chat traffic).
+# NOTE (WS-E, #1107): the utility slot now SEEDS GREY — model-less and disabled
+# until the operator assigns one (the old `gemma-4-12b-it` pin was a ghost id
+# that crash-looped a model-less box). Hindsight tolerates that: extraction /
+# reflection run lazily and fall back to the agent anchor when utility is
+# unloaded (see the startup-verification note below), so a fresh box never
+# blocks on a not-yet-loaded utility model.
 # [Q5'] history, kept for the record:
 #  - qwen3-it-4b-FLM (NPU): ignores response_format -> bare JSON *list* -> rejected.
 #  - gemma-4-26b-a4b-it-q4kxl (iGPU GGUF): {"facts":[...]} ok but Lemonade-era

--- a/tests/api/test_backends_npu_canonical_fields.py
+++ b/tests/api/test_backends_npu_canonical_fields.py
@@ -284,7 +284,9 @@ def test_seeded_npu_toml_fields_survive_model_update(
     slot_toml = _seed_slot_toml(
         tmp_hal0_home,
         "npu",
-        # Mirrors installer/etc-hal0/slots/npu.toml exactly
+        # Canonical npu-slot shape AFTER a model has been assigned (the seed
+        # itself ships grey/model-less per WS-E #1107; this fixture exercises the
+        # post-assignment PUT-preserves-fields path).
         "\n".join(
             [
                 "# NPU LLM slot",

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -77,7 +77,11 @@ def test_seed_npu_toml_validates() -> None:
     # chat-only utility: no [npu] trio table, role aliased to utility
     assert slot.npu is None
     assert slot.role == "utility"
-    assert slot.model is not None and slot.model.default == "gemma4-it-e2b-FLM"
+    # Clean seed (WS-E, #1107): no FLM model pin — boots grey, no surprise
+    # download, no crash-loop. context_size is a tuning default for later.
+    assert slot.model is not None and slot.model.default == ""
+    assert slot.model.context_size == 16384
+    assert slot.enabled is False
 
 
 def test_seed_tts_toml_validates() -> None:

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -17,7 +17,9 @@ def test_seed_rerank_toml_validates() -> None:
     assert slot.device == "gpu-vulkan"
     assert slot.port == 8083
     assert "--reranking" in (slot.server.extra_args or "")
-    assert slot.model.default == "bge-reranker-v2-m3-q4_k_m"
+    # Clean seed (WS-E, #1107): no model pin — boots grey, no surprise download.
+    assert slot.model.default == ""
+    assert slot.enabled is False
 
 
 def test_seed_utility_toml_validates() -> None:
@@ -27,8 +29,12 @@ def test_seed_utility_toml_validates() -> None:
     assert slot.profile == "vulkan"
     assert slot.device == "gpu-vulkan"
     assert slot.port == 8081
-    assert slot.model.default == "gemma-4-12b-it"
+    # Clean seed (WS-E, #1107): the ghost id `gemma-4-12b-it` pin is gone — the
+    # slot boots grey (no crash-loop, no surprise download). context_size is a
+    # tuning default that applies once the operator assigns a model.
+    assert slot.model.default == ""
     assert slot.model.context_size == 65536
+    assert slot.enabled is False
 
 
 def test_rerank_defaults_are_hindsight_era() -> None:

--- a/tests/install/test_answers.py
+++ b/tests/install/test_answers.py
@@ -349,3 +349,61 @@ def test_npu_opt_in_auto_off_when_absent(tmp_path):
     path = _write(tmp_path, _AUTO_NPU)
     sel = load_answers(path, _hw(npu_present=False))
     assert sel.npu_opt_in is False
+
+
+# ── slots[].device / profile passthrough (WS-E, #1107) ───────────────────────
+
+
+def test_slot_device_and_profile_pass_through(tmp_path):
+    """Explicit slots[].device / profile on an answer-file entry ride onto the
+    resulting SlotSelection verbatim (clean-seed derivation override, #1107).
+
+    apply_setup honours these via ``s.device or derive_device(...)`` /
+    ``s.profile or derive_profile(...)``, so an operator can pin a lane the
+    preflight would otherwise derive differently."""
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots:
+          - capability: chat
+            name: chat
+            port: 8081
+            model_id: null
+            device: gpu-vulkan
+            profile: vulkan
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    sel = load_answers(path, _hw())
+    (slot,) = sel.slots
+    assert slot.slot_name == "chat"
+    assert slot.device == "gpu-vulkan"
+    assert slot.profile == "vulkan"
+    # model_id: null → a grey scaffold slot (no pick, no pull).
+    assert slot.model_id is None
+
+
+def test_slot_device_profile_omitted_and_auto_derive(tmp_path):
+    """Omitted or ``auto`` device/profile leave the SlotSelection fields None so
+    apply_setup derives them from the preflight (clean-seed default path)."""
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots:
+          - { capability: chat, name: chat, port: 8081, model_id: null }
+          - { capability: coder, name: coder, port: 8082, model_id: null, device: auto, profile: auto }
+        npu: { opt_in: false }
+        gen: { mode: off }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    sel = load_answers(path, _hw())
+    for slot in sel.slots:
+        assert slot.device is None
+        assert slot.profile is None


### PR DESCRIPTION
Part of the guided **Hal0 Installer Setup** redesign (Wave 2 / WS-E, decision Q6).

## Problem
All six seeded slot TOMLs shipped `enabled=true` + a hardcoded `[model].default` pin. On a deliberately model-less box that meant surprise multi-GB downloads and, for `utility.toml`, a **crash-loop** on the id `gemma-4-12b-it`.

## What changed
- **Clean seeds** — stripped every `[model].default` pin and set `enabled=false` across `utility`, `rerank`, `tts`, `npu`, `img`, `qwen3tts`. Slots now boot **grey**: no surprise download, no crash-loop. Model + enable are operator/pull-driven (enable-on-pull-success, #1108).
- **`gemma-4-12b-it` verdict: GHOST.** It is a catalog/marketing id with **no** registry file and **no** curated coords. The real GGUF stays curated as `gemma-4-12b-it-ud-q4-k-xl` → `unsloth/gemma-4-12b-it-GGUF` / `gemma-4-12b-it-UD-Q4_K_XL.gguf`, so `tests/registry/test_curated_pull_coords.py` needs **no** change. Removing the seed pin is the fix. Updated the `hindsight-api.service` "utility (gemma-4-12b-it, iGPU) is always loaded" assumption: utility now seeds grey; Hindsight tolerates it (lazy extraction, falls back to the agent anchor when unloaded).
- **`qwen3tts` decision: EXPLICITLY OUT of the seed loop.** `install.sh` only copies `npu tts rerank utility img`; `qwen3tts.toml` is documented as an opt-in template the operator drops in, itself cleaned (grey, no pin).
- **Device/profile derivation.** The static seeds keep coherent GPU-Vulkan/NPU/CPU tile defaults (the coupled seed tests assert on them). The *preflight-derived* device/profile (`derive_device`/`derive_profile`, #1097 hardware.json / #1104) is delivered by the guided + `--auto` + answer-file setup path (`build_auto_selections` → `apply_setup`) and honored via `slots[].device`/`profile` passthrough on each `SlotSelection` in `src/hal0/install/answers.py` (already wired; now locked in with tests).
- **Coupled tests updated** (green, intentional): `test_schema_seeds_c5.py` (utility/rerank) and `test_schema_npu.py` (npu) now assert grey seeds (`model.default == ""`, `enabled` False); tuning `context_size` retained. New passthrough tests added to `tests/install/test_answers.py`.

## Acceptance criteria
- [x] Seeded slots ship with no `[model].default`; boot grey on a model-less box
- [x] Device/profile derived from preflight (provisioning path), not hardcoded in the guided flow
- [x] gemma-4-12b-it resolution documented (GHOST) with coupled test + hindsight assumption updated — no red tests
- [x] qwen3tts reconciled (explicitly out of the seed loop)
- [x] `slots[].device`/`profile` overrides honored via the answer file (passthrough on each `SlotSelection`)

Closes #1107

🤖 Generated with [Claude Code](https://claude.com/claude-code)