### PR TITLE
installer-setup WS-J: post-update drift surfacing + hal0 update --restart-slots

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -222,6 +222,7 @@ async def _run_apply_job(
     job_id: str,
     channel: str,
     version: str | None,
+    restart_slots: bool = False,
 ) -> None:
     """Background task that drives ``Updater.apply()`` and records progress.
 
@@ -229,7 +230,9 @@ async def _run_apply_job(
     doesn't strand the CLI's status poll. On a successful apply it
     try-restarts ``hal0-api.service`` fail-soft - a restart failure is
     recorded on the job (``restarted`` / ``restart_error``) but never
-    re-fails the apply or tears down the new tree.
+    re-fails the apply or tears down the new tree. ``drifted_slots`` /
+    ``restarted_slots`` (#1111) come straight off ``Updater.apply()``'s
+    result — see :meth:`hal0.updater.updater.Updater.commit`.
     """
     job = jobs[job_id]
     job["state"] = "running"
@@ -237,7 +240,7 @@ async def _run_apply_job(
     _persist_job(job)
     try:
         updater = Updater(channel=channel)
-        await updater.apply(version)
+        result = await updater.apply(version, restart_slots=restart_slots)
     except Exception as exc:
         job["state"] = "failed"
         job["error"] = str(exc)
@@ -251,6 +254,8 @@ async def _run_apply_job(
         restarted, restart_error = await asyncio.to_thread(_try_restart_hal0_api)
         job["restarted"] = restarted
         job["restart_error"] = restart_error
+        job["drifted_slots"] = result.get("drifted_slots", [])
+        job["restarted_slots"] = result.get("restarted_slots", [])
         job["state"] = "applied"
     finally:
         job["updated_at"] = time.time()
@@ -297,13 +302,16 @@ async def _run_commit_job(
     job_id: str,
     channel: str,
     version: str,
+    restart_slots: bool = False,
 ) -> None:
     """Background task that ACTIVATES a prepared version via ``Updater.commit()``.
 
     Runs the migrations + symlink swap + venv re-pip, then try-restarts
     ``hal0-api.service`` fail-soft (same policy as ``_run_apply_job``). Requires
     that ``/prepare`` staged ``version`` first; ``commit()`` raises otherwise and
-    the job goes to ``failed``.
+    the job goes to ``failed``. ``drifted_slots`` / ``restarted_slots`` (#1111)
+    come straight off ``Updater.commit()``'s result — the CLI's post-update
+    banner and the dashboard drift signal both read these off the job.
     """
     job = jobs[job_id]
     job["state"] = "running"
@@ -311,7 +319,7 @@ async def _run_commit_job(
     _persist_job(job)
     try:
         updater = Updater(channel=channel)
-        await updater.commit(version)
+        result = await updater.commit(version, restart_slots=restart_slots)
     except Exception as exc:
         job["state"] = "failed"
         job["error"] = str(exc)
@@ -320,6 +328,8 @@ async def _run_commit_job(
         restarted, restart_error = await asyncio.to_thread(_try_restart_hal0_api)
         job["restarted"] = restarted
         job["restart_error"] = restart_error
+        job["drifted_slots"] = result.get("drifted_slots", [])
+        job["restarted_slots"] = result.get("restarted_slots", [])
         job["state"] = "applied"
     finally:
         job["updated_at"] = time.time()
@@ -540,17 +550,31 @@ async def check_updates(request: Request) -> dict[str, Any]:
 # ── /apply ─────────────────────────────────────────────────────────────────
 
 
+def _body_restart_slots(body: Any) -> bool:
+    """Extract the opt-in ``restart_slots`` flag (#1111) from a request body.
+
+    Defaults to False — ``hal0 update`` must never bounce a slot unless the
+    operator explicitly asks for it.
+    """
+    if isinstance(body, dict):
+        return bool(body.get("restart_slots", False))
+    return False
+
+
 @router.post("/apply", status_code=202)
 async def apply_update(request: Request) -> dict[str, Any]:
     """Kick off an update job in the background; return a job id.
 
     Body (optional)::
 
-        {"version": "0.1.0"}   # pin a specific version; omit for latest
+        {"version": "0.1.0", "restart_slots": false}   # pin a version; omit for latest
 
     The actual update work happens in ``_run_apply_job`` which calls
     ``Updater.apply()``. The route returns immediately with the queued-job
     snapshot; poll ``/api/updates/status/{job_id}`` for state transitions.
+    ``restart_slots`` (#1111, default False) is the opt-in flag that bounces
+    exactly the slots detected as drifted after the swap — never on by
+    default, so an in-flight inference is never interrupted.
 
     Returns **202 Accepted** because the work is queued, not completed —
     matches ``/api/models/{id}/pull`` and the rest of hal0's async-job
@@ -569,6 +593,7 @@ async def apply_update(request: Request) -> dict[str, Any]:
             # drive the same target - matches the CLI's --target handling
             # (#510). lstrip is fine here: versions never start with "v".
             version = v.strip().lstrip("v") or None
+    restart_slots = _body_restart_slots(body)
 
     channel = _current_channel(request)
     jobs = _update_jobs(request)
@@ -578,6 +603,7 @@ async def apply_update(request: Request) -> dict[str, Any]:
         "state": "queued",
         "channel": channel,
         "version": version,
+        "restart_slots": restart_slots,
         "created_at": time.time(),
         "updated_at": time.time(),
         "error": None,
@@ -593,7 +619,7 @@ async def apply_update(request: Request) -> dict[str, Any]:
     if bg_tasks is None:
         bg_tasks = set()
         request.app.state._update_bg_tasks = bg_tasks
-    task = asyncio.create_task(_run_apply_job(jobs, job_id, channel, version))
+    task = asyncio.create_task(_run_apply_job(jobs, job_id, channel, version, restart_slots))
     bg_tasks.add(task)
     task.add_done_callback(bg_tasks.discard)
     return dict(jobs[job_id])
@@ -659,9 +685,13 @@ async def commit_update(request: Request) -> dict[str, Any]:
     """Activate a previously ``/prepare``d version.
 
     Body (required): ``{"version": "0.1.0"}`` — the ``resolved_version`` returned
-    by the prepare job. Returns a queued-job snapshot (202); poll
-    ``/status/{job_id}`` until ``applied`` | ``failed``. The daemon try-restarts
-    hal0-api fail-soft after a successful commit.
+    by the prepare job. Optional ``"restart_slots": true`` (#1111, default
+    False) bounces exactly the slots detected as drifted after the swap —
+    the opt-in ``hal0 update --restart-slots`` path; omitted or False never
+    restarts anything. Returns a queued-job snapshot (202); poll
+    ``/status/{job_id}`` until ``applied`` | ``failed`` — the job carries
+    ``drifted_slots`` / ``restarted_slots`` once applied. The daemon
+    try-restarts hal0-api fail-soft after a successful commit.
     """
     try:
         body = await request.json()
@@ -673,6 +703,7 @@ async def commit_update(request: Request) -> dict[str, Any]:
             "commit requires a 'version' — the resolved_version from /prepare",
             details={"hint": "POST /api/updates/prepare first, then commit its resolved_version"},
         )
+    restart_slots = _body_restart_slots(body)
     channel = _current_channel(request)
     jobs = _update_jobs(request)
     job_id = uuid.uuid4().hex[:12]
@@ -682,12 +713,13 @@ async def commit_update(request: Request) -> dict[str, Any]:
         "phase": "commit",
         "channel": channel,
         "version": version,
+        "restart_slots": restart_slots,
         "created_at": time.time(),
         "updated_at": time.time(),
         "error": None,
     }
     _persist_job(jobs[job_id])
-    _spawn_update_task(request, _run_commit_job(jobs, job_id, channel, version))
+    _spawn_update_task(request, _run_commit_job(jobs, job_id, channel, version, restart_slots))
     return dict(jobs[job_id])
 
 
@@ -712,6 +744,27 @@ async def update_status(job_id: str, request: Request) -> dict[str, Any]:
             details={"job_id": job_id},
         )
     return dict(job)
+
+
+# ── /drift ─────────────────────────────────────────────────────────────────
+
+
+@router.get("/drift")
+async def update_drift(request: Request) -> dict[str, Any]:
+    """Report which configured slots have a stale on-disk unit right now.
+
+    On-demand dashboard/API signal for post-update drift (#1111) —
+    complements the per-job ``drifted_slots`` on ``/status/{job_id}``, which
+    only exists right after an update job runs. This is safe to poll any
+    time: it never writes anything (:func:`detect_drifted_slots`, the
+    read-only sibling of the update-time unit-rewrite sweep), and — unlike
+    that sweep — it runs live in THIS already-current process, so it needs
+    no subprocess trick to see fresh code.
+    """
+    from hal0.updater.updater import detect_drifted_slots
+
+    drifted = await asyncio.to_thread(detect_drifted_slots)
+    return {"drifted_slots": drifted, "count": len(drifted)}
 
 
 # ── /rollback ──────────────────────────────────────────────────────────────

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -6,12 +6,23 @@ is exercised whether you trigger an update from the dashboard or the
 shell. After a successful apply the daemon try-restarts hal0-api itself
 (see ``routes/updater._run_apply_job``); the CLI does not touch systemd.
 
+``--restart-slots`` (#1111) is the one exception, and it still doesn't
+reach around the API: it's a flag forwarded in the ``/commit`` body, and the
+actual bounce happens server-side, scoped to exactly the slots the commit's
+own reconcile sweep found drifted (see ``Updater.commit`` step 8c /
+``post_commit_slot_sweep``). Without the flag, ``hal0 update`` only prints a
+banner naming the drifted slots — it never restarts anything. A prior,
+unrelated ``--restart-slots`` (removed in #539/#510) reached around the API
+to blind-restart every ``hal0-slot@*.service`` unconditionally; this one
+never restarts a slot that wasn't detected as drifted.
+
 Surface:
     hal0 update                 # check + apply if newer
     hal0 update --check         # check only
     hal0 update --rollback      # roll back to previous tree
     hal0 update --channel CH    # set channel (persists), then check
     hal0 update --target VER    # pin a specific version
+    hal0 update --restart-slots # also bounce slots detected as drifted
 """
 
 from __future__ import annotations
@@ -194,6 +205,56 @@ def _render_notes(notes: dict | None) -> None:
         console.print(Markdown(markdown))
 
 
+def _print_drift_banner(final: dict, *, restart_slots: bool) -> None:
+    """Print the post-update slot-drift banner (#1111).
+
+    ``final`` is the terminal ``/api/updates/status/<id>`` job snapshot —
+    ``drifted_slots`` lists slots whose on-disk unit was stale and just got
+    rewritten by the commit's sweep (still running pre-update argv);
+    ``restarted_slots`` lists which of those were actually bounced (only
+    populated when ``--restart-slots`` was passed).
+
+    Three cases:
+      - no drift → a quiet confirmation that nothing needs a restart.
+      - drift, ``--restart-slots`` not passed → a loud warning naming the
+        affected slots and pointing at the opt-in flag. Never restarts
+        anything itself — the hard safety rule that plain ``hal0 update``
+        must never bounce a slot that may be mid-inference.
+      - drift, ``--restart-slots`` passed → reports what got bounced, and
+        calls out any drifted slot that failed to restart.
+    """
+    drifted = list(final.get("drifted_slots") or [])
+    restarted = list(final.get("restarted_slots") or [])
+
+    if not drifted:
+        console.print("[dim]all slots are in sync — no restart needed.[/dim]")
+        return
+
+    if not restart_slots:
+        console.print(
+            Panel(
+                f"[yellow]{len(drifted)} slot(s) need a restart to pick up this update:[/yellow] "
+                f"{', '.join(drifted)}\n"
+                "[dim]slots are never bounced automatically — re-run with "
+                "`hal0 update --restart-slots` to bounce just these, or "
+                "`hal0 slot restart <name>` for one at a time.[/dim]",
+                title="slots need restart",
+                border_style="yellow",
+            )
+        )
+        return
+
+    failed = [name for name in drifted if name not in restarted]
+    if restarted:
+        console.print(
+            f"[green]restarted {len(restarted)} drifted slot(s):[/green] {', '.join(restarted)}"
+        )
+    if failed:
+        console.print(
+            f"[red]{len(failed)} drifted slot(s) failed to restart:[/red] {', '.join(failed)}"
+        )
+
+
 def update(
     channel: UpdateChannel | None = typer.Option(
         None,
@@ -220,6 +281,15 @@ def update(
         "--yes",
         "-y",
         help="Skip the confirmation prompt after reviewing release notes.",
+    ),
+    restart_slots: bool = typer.Option(
+        False,
+        "--restart-slots",
+        help=(
+            "Opt-in: bounce (systemctl restart) exactly the slots detected as "
+            "drifted after the swap. Never on by default — hal0 update alone "
+            "only warns, it never restarts a slot that may be mid-inference."
+        ),
     ),
 ) -> None:
     """Check for, apply, or roll back a hal0 update.
@@ -305,7 +375,10 @@ def update(
         return
 
     try:
-        cjob = api_post("/api/updates/commit", json={"version": resolved})
+        cjob = api_post(
+            "/api/updates/commit",
+            json={"version": resolved, "restart_slots": restart_slots},
+        )
     except CliApiError as exc:
         die(str(exc))
         return
@@ -323,6 +396,10 @@ def update(
             console.print(
                 f"[yellow]hal0-api restart did not complete:[/yellow] {final['restart_error']}"
             )
+        # #1111: loud, non-blocking slot-drift banner — never restarts
+        # anything itself; that only happens server-side, and only when
+        # --restart-slots was passed on this invocation.
+        _print_drift_banner(final, restart_slots=restart_slots)
     else:
         err = final.get("error") or "unknown error"
         die(f"update {state}: {err}")

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1253,6 +1253,38 @@ class ContainerProvider(Provider):
         """``systemctl daemon-reload`` — public for the unit-rerender sweep."""
         self._run("systemctl", "daemon-reload")
 
+    def unit_is_stale(self, slot_cfg: dict[str, Any], model_info: dict[str, Any]) -> bool:
+        """Read-only companion to :meth:`rerender_unit_sync` (#1111).
+
+        Reports whether a fresh render would differ from what's on disk —
+        the same comparison :meth:`rerender_unit_sync` makes before it
+        writes — WITHOUT writing anything. Lets a caller ask "is this slot
+        drifted?" (e.g. an on-demand dashboard poll) without mutating state
+        or requiring a daemon-reload afterwards.
+
+        False for a slot with no unit on disk (never rendered → nothing
+        stale), matching :meth:`rerender_unit_sync`'s no-op contract.
+        """
+        slot_name: str = str(slot_cfg.get("name", ""))
+        unit_path = self._unit_path(slot_name)
+        if not unit_path.exists():
+            return False
+        return unit_path.read_text() != self._render_unit_text(slot_cfg, model_info)
+
+    def restart_unit_sync(self, slot_name: str) -> None:
+        """Bounce ``hal0-slot@<slot_name>.service`` — restart, nothing else.
+
+        Used ONLY by the opt-in ``hal0 update --restart-slots`` path
+        (#1111): the default update flow never restarts a slot that may be
+        mid-inference — see :func:`hal0.updater.updater.restart_drifted_slots`,
+        which is the sole caller and only ever passes slot names already
+        confirmed drifted. Assumes the unit file is already current on disk
+        (``rerender_unit_sync`` plus the batched ``daemon_reload`` earlier in
+        the same sweep) — this just asks systemd to relaunch the service so
+        the fresh argv takes effect.
+        """
+        self._run("systemctl", "restart", self._unit_name(slot_name))
+
     def expected_argv(
         self, slot_cfg: dict[str, Any], model_info: dict[str, Any]
     ) -> list[str] | None:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -46,6 +46,7 @@ import sys
 import tarfile
 import tempfile
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -1132,31 +1133,22 @@ def clear_stale_mtp_overrides(*, job_id: str | None = None, registry: Any = None
     return cleared
 
 
-def rerender_slot_units(*, job_id: str | None = None) -> int:
-    """Re-render every existing container slot unit through current code.
+def _iter_slot_configs(
+    *, job_id: str | None = None
+) -> Iterator[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Yield ``(slot_name, cfg, model_info)`` for every configured slot TOML.
 
-    A slot's systemd unit bakes the launch argv at load time. Updating hal0
-    changes the code that WOULD render but not the file that DID — so
-    ``systemctl restart``, crash-restarts, and reboots keep running pre-update
-    flags until an operator remembers a hal0-level reload (field finding,
-    CT105). This sweep rewrites each on-disk unit via the same plan path a
-    load uses and batches one ``daemon-reload`` — it never enables, starts, or
-    restarts anything, so serving is not bounced; the fresh argv applies on
-    the next start from ANY path. The dashboard's drift indicator covers the
-    remaining "process still running old argv" window.
-
-    Per-slot failures (unresolvable model/profile, malformed TOML) log and
-    skip — a bad slot must never wedge an update.
-
-    Returns the number of unit files rewritten.
+    Shared enumeration used by the update-time unit sweep
+    (:func:`rerender_slot_units`) and its read-only sibling
+    (:func:`detect_drifted_slots`) so both see exactly the same slot set and
+    the same never-raising model resolution. Per-slot parse/resolve failures
+    log a warning and are skipped — a bad slot must never wedge the caller.
     """
     import tomllib
 
     from hal0.config.paths import slots_config_dir
-    from hal0.providers.container import ContainerProvider, _best_effort_model_info
+    from hal0.providers.container import _best_effort_model_info
 
-    provider = ContainerProvider()
-    rewritten = 0
     slots_dir = slots_config_dir()
     for toml_path in sorted(slots_dir.glob("*.toml")) if slots_dir.is_dir() else []:
         slot_name = toml_path.stem
@@ -1171,8 +1163,60 @@ def rerender_slot_units(*, job_id: str | None = None) -> int:
             # Same registry-backed, never-raising resolver the preview path
             # uses — a registry miss degrades to a minimal path dict.
             model_info = _best_effort_model_info(cfg, None)
+        except Exception as exc:
+            log.warning(
+                "updater.slot_config_skipped",
+                job_id=job_id,
+                slot=slot_name,
+                error=str(exc),
+            )
+            continue
+        yield slot_name, cfg, model_info
+
+
+def rerender_slot_units(*, job_id: str | None = None) -> int:
+    """Re-render every existing container slot unit through current code.
+
+    A slot's systemd unit bakes the launch argv at load time. Updating hal0
+    changes the code that WOULD render but not the file that DID — so
+    ``systemctl restart``, crash-restarts, and reboots keep running pre-update
+    flags until an operator remembers a hal0-level reload (field finding,
+    CT105). This sweep rewrites each on-disk unit via the same plan path a
+    load uses and batches one ``daemon-reload`` — it never enables, starts, or
+    restarts anything, so serving is not bounced; the fresh argv applies on
+    the next start from ANY path. ``hal0 update --restart-slots`` (#1111) is
+    the only path that bounces the drifted slots this sweep finds — see
+    :func:`post_commit_slot_sweep`.
+
+    Per-slot failures (unresolvable model/profile, malformed TOML) log and
+    skip — a bad slot must never wedge an update.
+
+    Returns the number of unit files rewritten. Thin wrapper over
+    :func:`_rerender_slot_units_impl` that keeps this function's long-standing
+    int-count contract (see ``tests/updater/test_unit_rerender.py``) while the
+    new #1111 callers get at the actual slot NAMES.
+    """
+    return len(_rerender_slot_units_impl(job_id=job_id))
+
+
+def _rerender_slot_units_impl(*, job_id: str | None = None) -> list[str]:
+    """Do the rewrite sweep :func:`rerender_slot_units` describes; return names.
+
+    A slot appears in the returned list exactly when its on-disk unit was
+    stale (the reconcile seam's fresh render differed from what was on
+    disk) and got rewritten — i.e. this list IS the post-update drift set
+    (#1111): each of these slots is still running the pre-update argv until
+    something restarts it (any path — a plain ``systemctl restart``, a
+    reboot, or the opt-in ``hal0 update --restart-slots``).
+    """
+    from hal0.providers.container import ContainerProvider
+
+    provider = ContainerProvider()
+    rewritten: list[str] = []
+    for slot_name, cfg, model_info in _iter_slot_configs(job_id=job_id):
+        try:
             if provider.rerender_unit_sync(cfg, model_info):
-                rewritten += 1
+                rewritten.append(slot_name)
                 log.info("updater.unit_rerendered", job_id=job_id, slot=slot_name)
         except Exception as exc:
             log.warning(
@@ -1186,8 +1230,95 @@ def rerender_slot_units(*, job_id: str | None = None) -> int:
             provider.daemon_reload()
         except Exception as exc:
             log.warning("updater.unit_rerender_daemon_reload_failed", job_id=job_id, error=str(exc))
-        log.info("updater.unit_rerender_complete", job_id=job_id, rewritten=rewritten)
+        log.info("updater.unit_rerender_complete", job_id=job_id, rewritten=len(rewritten))
     return rewritten
+
+
+def detect_drifted_slots(*, job_id: str | None = None) -> list[str]:
+    """Report which configured slots have a stale on-disk unit — read-only.
+
+    Companion to :func:`rerender_slot_units` that answers the same "stale
+    vs freshly-rendered" question (via :meth:`ContainerProvider.unit_is_stale`,
+    the reconcile seam from #1103) WITHOUT writing anything or touching
+    systemd. Safe to call any time — e.g. a dashboard poll — since a normal
+    ``hal0 update`` already rewrites stale units via :func:`rerender_slot_units`
+    and this never mutates state.
+
+    Per-slot failures log and skip, matching :func:`rerender_slot_units`.
+    """
+    from hal0.providers.container import ContainerProvider
+
+    provider = ContainerProvider()
+    drifted: list[str] = []
+    for slot_name, cfg, model_info in _iter_slot_configs(job_id=job_id):
+        try:
+            if provider.unit_is_stale(cfg, model_info):
+                drifted.append(slot_name)
+        except Exception as exc:
+            log.warning(
+                "updater.drift_check_skipped",
+                job_id=job_id,
+                slot=slot_name,
+                error=str(exc),
+            )
+    return drifted
+
+
+def restart_drifted_slots(slot_names: list[str], *, job_id: str | None = None) -> list[str]:
+    """Bounce (``systemctl restart``) exactly *slot_names* — nothing else.
+
+    The ONLY path that ever restarts a slot as part of ``hal0 update``
+    (#1111), and only when an operator opts in with ``--restart-slots``.
+    Never called from the default update flow. Callers must only pass
+    already-confirmed-drifted slot names (:func:`_rerender_slot_units_impl` /
+    :func:`detect_drifted_slots`) — this function does not itself check for
+    drift, so it must never be pointed at an unfiltered slot list; a slot
+    mid-inference must never be bounced implicitly.
+
+    Per-slot restart failures log and skip — one stuck unit must not stop
+    the rest from bouncing. Returns the slot names actually restarted.
+    """
+    from hal0.providers.container import ContainerProvider
+
+    provider = ContainerProvider()
+    restarted: list[str] = []
+    for slot_name in slot_names:
+        try:
+            provider.restart_unit_sync(slot_name)
+            restarted.append(slot_name)
+            log.info("updater.slot_restarted", job_id=job_id, slot=slot_name)
+        except Exception as exc:
+            log.warning(
+                "updater.slot_restart_failed",
+                job_id=job_id,
+                slot=slot_name,
+                error=str(exc),
+            )
+    return restarted
+
+
+def post_commit_slot_sweep(*, restart: bool = False, job_id: str | None = None) -> dict[str, Any]:
+    """The full post-commit slot maintenance sweep (#1111).
+
+    Rewrites every stale on-disk unit (:func:`_rerender_slot_units_impl`),
+    which doubles as the post-update drift detection — a slot only appears
+    in ``drifted`` when its unit was actually stale. Only when *restart* is
+    True (the opt-in ``hal0 update --restart-slots`` path) are those exact
+    drifted slots then bounced (:func:`restart_drifted_slots`); the default
+    (*restart* False) never restarts anything, matching the hard safety
+    requirement that ``hal0 update`` alone must never bounce a slot that may
+    be mid-inference.
+
+    Must run in a FRESH interpreter of the just re-pipped venv — see
+    :meth:`Updater.commit` step 8c, which is the sole caller (via a
+    subprocess so the sweep sees the NEW code, not the still-old in-memory
+    module of the process driving the update).
+
+    Returns ``{"rewritten": int, "drifted": [str, ...], "restarted": [str, ...]}``.
+    """
+    rewritten = _rerender_slot_units_impl(job_id=job_id)
+    restarted = restart_drifted_slots(rewritten, job_id=job_id) if restart else []
+    return {"rewritten": len(rewritten), "drifted": rewritten, "restarted": restarted}
 
 
 # ── Updater class ──────────────────────────────────────────────────────────────
@@ -1412,7 +1543,7 @@ class Updater:
             "notes": notes,
         }
 
-    async def commit(self, version: str) -> dict[str, Any]:
+    async def commit(self, version: str, *, restart_slots: bool = False) -> dict[str, Any]:
         """Activate a previously :meth:`prepare`d ``version`` (§9 steps 7-9+).
 
         Runs forward config migrations, prunes materialised seed profiles, clears
@@ -1423,8 +1554,13 @@ class Updater:
 
         Slot units are NOT restarted and ``hal0-api`` is not bounced here; the
         route layer (``routes/updater._run_commit_job``) try-restarts hal0-api
-        fail-soft after a successful commit. Returns the same breadcrumb dict
-        shape as the old single-step apply.
+        fail-soft after a successful commit. The returned dict's
+        ``drifted_slots`` lists slots whose on-disk unit was stale and just
+        got rewritten (#1111) — still running pre-update argv until
+        something restarts them. Pass *restart_slots* (the opt-in
+        ``hal0 update --restart-slots`` path) to also bounce exactly those
+        drifted slots (``restarted_slots``); the default never restarts
+        anything, so an in-flight inference is never interrupted.
         """
         if _is_editable_install():
             raise UpdateError(
@@ -1531,10 +1667,15 @@ class Updater:
 
         # Step 8c: re-render existing slot units through the NEW code so any
         # subsequent start (systemctl restart, crash-restart, reboot) uses
-        # current argv — never bounces serving (write + daemon-reload only).
+        # current argv, detect which slots were stale (#1111 drift signal),
+        # and — ONLY when restart_slots is True — bounce exactly those. The
+        # default never enables/starts/restarts anything, so serving is not
+        # bounced; the fresh argv applies on the next start from ANY path.
         # Must run AFTER the 8b venv reinstall and in a FRESH interpreter:
         # this (still-old) process would render pre-update argv, defeating the
         # point; a subprocess of the re-pipped venv executes the new module.
+        drifted_slots: list[str] = []
+        restarted_slots: list[str] = []
         if not _is_editable_install():
             try:
                 proc = await asyncio.to_thread(
@@ -1542,18 +1683,25 @@ class Updater:
                     [
                         sys.executable,
                         "-c",
-                        "from hal0.updater.updater import rerender_slot_units; "
-                        "print(rerender_slot_units())",
+                        "import json, sys; "
+                        "from hal0.updater.updater import post_commit_slot_sweep; "
+                        "print(json.dumps(post_commit_slot_sweep(restart=(sys.argv[1] == '1'))))",
+                        "1" if restart_slots else "0",
                     ],
                     capture_output=True,
                     text=True,
                     timeout=300,
                 )
                 if proc.returncode == 0:
+                    sweep = json.loads((proc.stdout or "").strip() or "{}")
+                    drifted_slots = list(sweep.get("drifted") or [])
+                    restarted_slots = list(sweep.get("restarted") or [])
                     log.info(
                         "updater.unit_rerender_done",
                         job_id=self.job_id,
-                        rewritten=(proc.stdout or "").strip(),
+                        rewritten=sweep.get("rewritten"),
+                        drifted=drifted_slots,
+                        restarted=restarted_slots,
                     )
                 else:
                     log.warning(
@@ -1589,9 +1737,13 @@ class Updater:
             "migrations": {"from": migration_info[0], "to": migration_info[1]},
             "cosign_skipped": _cosign_skip(),
             "installed_at": time.time(),
+            "drifted_slots": drifted_slots,
+            "restarted_slots": restarted_slots,
         }
 
-    async def apply(self, version: str | None = None) -> dict[str, Any]:
+    async def apply(
+        self, version: str | None = None, *, restart_slots: bool = False
+    ) -> dict[str, Any]:
         """Prepare + commit in one call — the back-compat single-step update.
 
         Equivalent to the pre-split ``apply()``: stages the release
@@ -1600,7 +1752,7 @@ class Updater:
         phases call :meth:`prepare` then :meth:`commit` directly instead.
         """
         prepared = await self.prepare(version)
-        return await self.commit(str(prepared["version"]))
+        return await self.commit(str(prepared["version"]), restart_slots=restart_slots)
 
     # ── rollback ───────────────────────────────────────────────────────────────
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -401,7 +401,9 @@ def test_apply_success_tries_restart_hal0_api_fail_soft(
     """
     from hal0.api.routes import updater as u_mod
 
-    async def fake_apply(self: object, version: str | None = None) -> dict:
+    async def fake_apply(
+        self: object, version: str | None = None, *, restart_slots: bool = False
+    ) -> dict:
         return {"version": "0.0.9", "installed_at": time.time()}
 
     monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
@@ -443,7 +445,9 @@ def test_apply_success_restart_failure_is_fail_soft(
     """If the restart raises, the job is still 'applied' with a breadcrumb."""
     from hal0.api.routes import updater as u_mod
 
-    async def fake_apply(self: object, version: str | None = None) -> dict:
+    async def fake_apply(
+        self: object, version: str | None = None, *, restart_slots: bool = False
+    ) -> dict:
         return {"version": "0.0.9"}
 
     monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
@@ -482,7 +486,9 @@ def test_apply_target_strips_leading_v(
 
     seen: list[str | None] = []
 
-    async def fake_apply(self: object, version: str | None = None) -> dict:
+    async def fake_apply(
+        self: object, version: str | None = None, *, restart_slots: bool = False
+    ) -> dict:
         seen.append(version)
         return {"version": version or "latest"}
 
@@ -576,3 +582,104 @@ def test_commit_route_accepts_version(isolated_client: TestClient) -> None:
     assert body["phase"] == "commit"
     assert body["state"] == "queued"
     assert body["version"] == "0.0.1"
+
+
+# ── #1111: post-update drift surfacing + opt-in --restart-slots ────────────
+
+
+def test_commit_defaults_restart_slots_false_when_omitted(isolated_client: TestClient) -> None:
+    """Omitting restart_slots on /commit defaults to False — never implicitly True."""
+    r = isolated_client.post("/api/updates/commit", json={"version": "0.0.1"})
+    assert r.status_code == 202, r.text
+    assert r.json()["restart_slots"] is False
+
+
+def test_commit_forwards_restart_slots_to_updater(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /commit with restart_slots=true threads it to Updater.commit()."""
+    from hal0.api.routes import updater as u_mod
+
+    seen: dict[str, object] = {}
+
+    async def fake_commit(self: object, version: str, *, restart_slots: bool = False) -> dict:
+        seen["version"] = version
+        seen["restart_slots"] = restart_slots
+        return {"version": version, "drifted_slots": ["chat"], "restarted_slots": ["chat"]}
+
+    monkeypatch.setattr(u_mod.Updater, "commit", fake_commit)
+    monkeypatch.setattr(u_mod.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0})())
+
+    r = isolated_client.post(
+        "/api/updates/commit", json={"version": "0.0.1", "restart_slots": True}
+    )
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("applied", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert seen == {"version": "0.0.1", "restart_slots": True}
+    assert final["state"] == "applied", final
+    assert final["drifted_slots"] == ["chat"]
+    assert final["restarted_slots"] == ["chat"]
+
+
+def test_commit_job_reports_drift_with_no_restart_by_default(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A default (restart_slots omitted) commit surfaces drift but restarted_slots is empty."""
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_commit(self: object, version: str, *, restart_slots: bool = False) -> dict:
+        assert restart_slots is False
+        return {"version": version, "drifted_slots": ["chat", "embed"], "restarted_slots": []}
+
+    monkeypatch.setattr(u_mod.Updater, "commit", fake_commit)
+    monkeypatch.setattr(u_mod.subprocess, "run", lambda *a, **k: type("R", (), {"returncode": 0})())
+
+    r = isolated_client.post("/api/updates/commit", json={"version": "0.0.1"})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("applied", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert final["state"] == "applied", final
+    assert final["drifted_slots"] == ["chat", "embed"]
+    assert final["restarted_slots"] == []
+
+
+def test_drift_endpoint_reports_live_drifted_slots(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/updates/drift is a read-only, on-demand drift signal."""
+    from hal0.updater import updater as updater_mod
+
+    monkeypatch.setattr(updater_mod, "detect_drifted_slots", lambda **_k: ["chat"])
+
+    r = isolated_client.get("/api/updates/drift")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body == {"drifted_slots": ["chat"], "count": 1}
+
+
+def test_drift_endpoint_empty_when_nothing_drifted(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No drifted slots -> a clear empty/zero response, not an error."""
+    from hal0.updater import updater as updater_mod
+
+    monkeypatch.setattr(updater_mod, "detect_drifted_slots", lambda **_k: [])
+
+    r = isolated_client.get("/api/updates/drift")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"drifted_slots": [], "count": 0}

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -1,10 +1,17 @@
-"""Tests for the ``hal0 update`` CLI subcommand (#510).
+"""Tests for the ``hal0 update`` CLI subcommand (#510, #1111).
 
 The CLI is a thin client over /api/updates/*; these tests stub the
 ``api_*`` helpers (imported into the update_commands namespace) so the
 command logic - target-version normalization, the apply trigger, and the
-absence of the retired ``--restart-slots`` flag - is exercised without a
+``--restart-slots`` / drift-banner behaviour - is exercised without a
 running daemon.
+
+``--restart-slots`` was removed in #539/#510 (it blind-restarted every
+``hal0-slot@*.service`` unconditionally — dead code targeting a naming
+scheme that no longer applied) and reintroduced in #1111 with a completely
+different, safe shape: it's forwarded to ``/commit`` as a body flag, and the
+server only ever bounces the slots its own reconcile sweep found drifted.
+The CLI itself never touches systemd.
 """
 
 from __future__ import annotations
@@ -80,12 +87,80 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     return captured
 
 
-def test_restart_slots_flag_removed() -> None:
-    """The retired ``--restart-slots`` flag is gone from the command signature."""
+def test_restart_slots_flag_present_and_defaults_false() -> None:
+    """``--restart-slots`` (#1111) exists and defaults to False (opt-in only)."""
     sig = inspect.signature(uc.update)
-    assert "restart_slots" not in sig.parameters
-    # And the helper that bounced hal0-slot@*.service is removed too.
+    assert "restart_slots" in sig.parameters
+    default = sig.parameters["restart_slots"].default
+    assert default.default is False  # typer.Option(False, ...)
+    # The old (#539/#510-removed) helper that reached around the API to
+    # blind-restart every hal0-slot@*.service is gone for good — the new
+    # flag never touches systemd from the CLI process.
     assert not hasattr(uc, "_restart_slots")
+
+
+def test_default_update_sends_restart_slots_false(
+    stub_api: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without the flag, /commit is sent restart_slots=False — never implicitly True."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["commit_json"] == {"version": "0.1.1", "restart_slots": False}
+
+
+def test_restart_slots_flag_forwarded_to_commit_body(
+    stub_api: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--restart-slots`` is forwarded as a /commit body flag, not a local systemctl call."""
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    result = runner.invoke(app, ["update", "--target", "0.1.1", "--restart-slots"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["commit_json"] == {"version": "0.1.1", "restart_slots": True}
+
+
+def test_drift_banner_clean_when_no_drifted_slots(capsys: pytest.CaptureFixture[str]) -> None:
+    """No drifted slots -> a quiet confirmation, no restart language."""
+    uc._print_drift_banner({"drifted_slots": []}, restart_slots=False)
+    out = capsys.readouterr().out
+    assert "no restart needed" in out
+    assert "restart" not in out.lower().replace("no restart needed", "")
+
+
+def test_drift_banner_warns_without_restart_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """Drifted slots + no --restart-slots -> a loud warning naming the slots, no restart claim."""
+    uc._print_drift_banner(
+        {"drifted_slots": ["chat", "embed"], "restarted_slots": []}, restart_slots=False
+    )
+    out = capsys.readouterr().out
+    assert "2 slot(s)" in out
+    assert "chat" in out and "embed" in out
+    assert "--restart-slots" in out
+
+
+def test_drift_banner_reports_restarted_slots(capsys: pytest.CaptureFixture[str]) -> None:
+    """Drifted slots + --restart-slots -> reports what was actually bounced."""
+    uc._print_drift_banner(
+        {"drifted_slots": ["chat", "embed"], "restarted_slots": ["chat", "embed"]},
+        restart_slots=True,
+    )
+    out = capsys.readouterr().out
+    assert "restarted 2 drifted slot(s)" in out
+    assert "chat" in out and "embed" in out
+    assert "failed to restart" not in out
+
+
+def test_drift_banner_flags_slots_that_failed_to_restart(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A drifted slot missing from restarted_slots is called out as a failure."""
+    uc._print_drift_banner(
+        {"drifted_slots": ["chat", "embed"], "restarted_slots": ["chat"]}, restart_slots=True
+    )
+    out = capsys.readouterr().out
+    assert "restarted 1 drifted slot(s)" in out
+    assert "1 drifted slot(s) failed to restart" in out
+    assert "embed" in out
 
 
 def test_target_strips_leading_v(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -111,7 +186,7 @@ def test_prepare_then_commit_flow(stub_api: dict, monkeypatch: pytest.MonkeyPatc
     assert result.exit_code == 0, result.output
     # prepare got the (normalized) target; commit got the resolved_version from the poll.
     assert stub_api["prepare_json"] == {"version": "0.1.1"}
-    assert stub_api["commit_json"] == {"version": "0.1.1"}
+    assert stub_api["commit_json"] == {"version": "0.1.1", "restart_slots": False}
 
 
 def test_yes_flag_present_and_skips_confirm(
@@ -130,7 +205,7 @@ def test_yes_flag_present_and_skips_confirm(
     result = runner.invoke(app, ["update", "--target", "0.1.1", "--yes"])
     assert result.exit_code == 0, result.output
     assert called["confirm"] is False
-    assert stub_api["commit_json"] == {"version": "0.1.1"}
+    assert stub_api["commit_json"] == {"version": "0.1.1", "restart_slots": False}
 
 
 def test_tty_decline_stages_without_commit(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -796,6 +796,75 @@ class TestLoadSync:
         # The WS-J guarantee: byte-for-byte identical units.
         assert upd_unit.read_text() == fresh_text
 
+    def test_unit_is_stale_true_when_on_disk_differs_from_fresh_render(
+        self, tmp_path: Path
+    ) -> None:
+        """unit_is_stale (#1111) reports True for a stale on-disk unit —
+        WITHOUT writing anything, unlike its mutating sibling rerender_unit_sync."""
+        profile = _moe_profile()
+        provider = ContainerProvider()
+        unit_path = tmp_path / "stale.service"
+        stale_text = "# stale pre-update unit\n"
+        unit_path.write_text(stale_text)
+        slot_cfg = {"name": "test-container", "port": 8095, "profile": "rocm"}
+        model_info = {"path": "/mnt/ai-models/model.gguf", "_model_key": "m"}
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            patch.object(provider, "_unit_path", return_value=unit_path),
+        ):
+            assert provider.unit_is_stale(slot_cfg, model_info) is True
+
+        # Read-only: the stale content on disk is untouched.
+        assert unit_path.read_text() == stale_text
+
+    def test_unit_is_stale_false_when_up_to_date(self, tmp_path: Path) -> None:
+        """A unit that already matches the fresh render is not stale."""
+        profile = _moe_profile()
+        provider = ContainerProvider()
+        unit_path = tmp_path / "fresh.service"
+        slot_cfg = {"name": "test-container", "port": 8095, "profile": "rocm"}
+        model_info = {"path": "/mnt/ai-models/model.gguf", "_model_key": "m"}
+
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=["/dev/kfd", "/dev/dri/renderD128"],
+            ),
+            patch.object(provider, "_unit_path", return_value=unit_path),
+        ):
+            unit_path.write_text(provider._render_unit_text(slot_cfg, model_info))
+            assert provider.unit_is_stale(slot_cfg, model_info) is False
+
+    def test_unit_is_stale_false_when_no_unit_on_disk(self, tmp_path: Path) -> None:
+        """A slot never rendered (no unit file yet) is never reported stale —
+        matches rerender_unit_sync's no-op contract for the same case."""
+        provider = ContainerProvider()
+        with patch.object(provider, "_unit_path", return_value=tmp_path / "never.service"):
+            assert provider.unit_is_stale({"name": "never-loaded"}, {}) is False
+
+    def test_restart_unit_sync_calls_systemctl_restart_only(self) -> None:
+        """restart_unit_sync (#1111) issues exactly one systemctl restart —
+        never enable/start/daemon-reload; those belong to other call sites."""
+        provider = ContainerProvider()
+        calls: list[tuple[str, ...]] = []
+
+        def fake_run(*args: str, check: bool = True) -> MagicMock:
+            calls.append(args)
+            m = MagicMock()
+            m.returncode = 0
+            return m
+
+        with patch.object(provider, "_run", side_effect=fake_run):
+            provider.restart_unit_sync("chat")
+
+        assert calls == [("systemctl", "restart", "hal0-slot@chat.service")]
+
     def test_resolved_command_includes_ctx_size(self) -> None:
         """The displayed resolved_command must show --ctx-size so it matches
         what actually launches."""

--- a/tests/updater/test_unit_rerender.py
+++ b/tests/updater/test_unit_rerender.py
@@ -22,7 +22,12 @@ from hal0.config.schema import ProfileConfig
 from hal0.providers import container as container_mod
 from hal0.slots.manager import SlotManager
 from hal0.updater import updater as updater_mod
-from hal0.updater.updater import rerender_slot_units
+from hal0.updater.updater import (
+    detect_drifted_slots,
+    post_commit_slot_sweep,
+    rerender_slot_units,
+    restart_drifted_slots,
+)
 
 _PROFILE = ProfileConfig(
     image="ghcr.io/test/toolbox:v2",
@@ -143,3 +148,102 @@ async def test_per_slot_failure_does_not_wedge_sweep(rerender_env, monkeypatch) 
 async def test_updater_module_reexports(rerender_env) -> None:
     # install.sh + Step 8c import it from the updater module.
     assert callable(updater_mod.rerender_slot_units)
+
+
+# ── #1111: post-update drift detection + opt-in restart ─────────────────────
+#
+# The reconcile seam from #1103 (rerender_unit_sync) already answers "is this
+# slot's on-disk unit stale vs. a fresh render?" — a slot is "drifted" exactly
+# when that comparison differs. detect_drifted_slots is the read-only sibling
+# (never writes); restart_drifted_slots is the ONLY thing that ever bounces a
+# slot as part of hal0 update, and only for names the caller already confirmed
+# drifted (the opt-in ``hal0 update --restart-slots`` path).
+
+
+def _restart_calls(calls: list[tuple[str, ...]]) -> list[tuple[str, ...]]:
+    return [c for c in calls if c[0] == "systemctl" and c[1] == "restart"]
+
+
+async def test_detect_drifted_slots_finds_stale_unit(rerender_env) -> None:
+    """A stale on-disk unit is reported drifted — and left untouched (read-only)."""
+    unit_dir, _calls = rerender_env
+    await _mk_slot("a", 8095)
+    stale_text = "# stale pre-update unit\n"
+    _unit_path(unit_dir, "a").write_text(stale_text)
+
+    assert detect_drifted_slots() == ["a"]
+    # Read-only: unlike rerender_slot_units, nothing was written.
+    assert _unit_path(unit_dir, "a").read_text() == stale_text
+
+
+async def test_detect_drifted_slots_empty_once_rewritten(rerender_env) -> None:
+    """After the sweep rewrites a slot, it no longer reports as drifted."""
+    unit_dir, _calls = rerender_env
+    await _mk_slot("a", 8095)
+    _unit_path(unit_dir, "a").write_text("stale")
+
+    assert detect_drifted_slots() == ["a"]
+    assert rerender_slot_units() == 1
+    assert detect_drifted_slots() == []
+
+
+async def test_detect_drifted_slots_skips_slot_with_no_unit(rerender_env) -> None:
+    """A slot that has never been loaded (no unit file) is never 'drifted'."""
+    await _mk_slot("never-loaded", 8096)
+    assert detect_drifted_slots() == []
+
+
+async def test_restart_drifted_slots_only_touches_named_slots(rerender_env) -> None:
+    """restart_drifted_slots bounces exactly the names it's given — not every slot."""
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    await _mk_slot("b", 8096)
+    _unit_path(unit_dir, "a").write_text("stale")
+    _unit_path(unit_dir, "b").write_text("stale")
+
+    restarted = restart_drifted_slots(["a"])
+
+    assert restarted == ["a"]
+    assert _restart_calls(calls) == [("systemctl", "restart", "hal0-slot@a.service")]
+
+
+async def test_post_commit_slot_sweep_default_never_restarts(rerender_env) -> None:
+    """restart=False (the plain ``hal0 update`` default): report drift, bounce nothing."""
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    _unit_path(unit_dir, "a").write_text("stale")
+
+    result = post_commit_slot_sweep(restart=False)
+
+    assert result == {"rewritten": 1, "drifted": ["a"], "restarted": []}
+    assert _restart_calls(calls) == []
+
+
+async def test_post_commit_slot_sweep_restarts_when_opted_in(rerender_env) -> None:
+    """restart=True (``hal0 update --restart-slots``): bounce the drifted slot."""
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    _unit_path(unit_dir, "a").write_text("stale")
+
+    result = post_commit_slot_sweep(restart=True)
+
+    assert result == {"rewritten": 1, "drifted": ["a"], "restarted": ["a"]}
+    assert _restart_calls(calls) == [("systemctl", "restart", "hal0-slot@a.service")]
+
+
+async def test_post_commit_slot_sweep_restarts_only_drifted_of_several(rerender_env) -> None:
+    """With two slots, only the one that was actually stale gets bounced."""
+    unit_dir, calls = rerender_env
+    await _mk_slot("a", 8095)
+    await _mk_slot("b", 8096)
+    _unit_path(unit_dir, "a").write_text("stale")
+    # Seed "b" as already current so only "a" is drifted going into the sweep.
+    rerender_slot_units()
+    _unit_path(unit_dir, "a").write_text("stale again")
+    calls.clear()
+
+    result = post_commit_slot_sweep(restart=True)
+
+    assert result["drifted"] == ["a"]
+    assert result["restarted"] == ["a"]
+    assert _restart_calls(calls) == [("systemctl", "restart", "hal0-slot@a.service")]


### PR DESCRIPTION
Closes #1111

## Summary

`rerender_slot_units()` (from #1103) rewrites a slot's on-disk systemd unit during `hal0 update` but never bounces the running container, so serving quietly diverges from what the fresh code would launch until an operator remembers a manual restart. This surfaces that drift loudly and adds an opt-in way to fix it, without ever risking an implicit mid-inference restart.

- **Drift detection reuses the #1103 reconcile seam directly.** `ContainerProvider.rerender_unit_sync` already compares a fresh render (`_render_unit_text`) against what's on disk before deciding whether to write — a slot is "drifted" exactly when that comparison differs. Added a read-only sibling (`ContainerProvider.unit_is_stale` / `updater.detect_drifted_slots`) plus a shared slot-config enumerator (`_iter_slot_configs`) so the update-time rewrite sweep and the read-only check see the same slot set.
- **`Updater.commit()`** now runs a combined `post_commit_slot_sweep()` inside the same fresh-interpreter subprocess step 8c already used (it has to run there — the process driving the update itself has stale in-memory code until it restarts). The sweep rewrites stale units (unchanged behavior) and reports which slots were drifted; `commit()`'s result now carries `drifted_slots` / `restarted_slots`, which flow through to the update job (`/api/updates/status/{id}`).
- **CLI:** `hal0 update` prints a banner after a successful apply — a quiet confirmation when nothing drifted, a loud warning naming the affected slots when something did — and never restarts anything itself.
- **`hal0 update --restart-slots`** (opt-in, defaults to `False` everywhere — the CLI flag, the `/commit` request body, and both `Updater` methods) bounces *exactly* the slots the sweep found drifted, via a new `ContainerProvider.restart_unit_sync`. Plain `hal0 update` never restarts a slot — a slot mid-inference is never bounced implicitly.
- **API:** new `GET /api/updates/drift` — an on-demand, read-only signal (safe to poll any time, unlike the job-scoped fields which only exist right after an update runs) for a dashboard drift banner.

### On the reused/removed `--restart-slots` name

A prior, unrelated `--restart-slots` flag existed and was removed in #539/#510 — it blind-restarted every `hal0-slot@*.service` unconditionally, targeting a unit-naming scheme that no longer applied, and reached around the API straight to `systemctl` from the CLI process. This reintroduction is a different, safe design: the flag is forwarded to `/commit` as a request-body field, the server-side sweep is the only thing that ever restarts a slot, and it only ever restarts slots it just confirmed are drifted. The CLI itself never touches systemd. `tests/cli/test_update_commands.py`'s docstring and test names call out this history explicitly.

## Acceptance criteria

- [x] Post-update drift detected and surfaced (CLI banner + `drifted_slots`/`restarted_slots` on the update job + new `GET /api/updates/drift` for an on-demand dashboard/API signal)
- [x] `hal0 update --restart-slots` restarts only the drifted slots (`restart_drifted_slots` only ever receives already-confirmed-drifted names; new tests assert only the named slots get a `systemctl restart`)
- [x] Default behavior never interrupts an in-flight inference (`restart_slots` defaults to `False` end-to-end; new tests assert zero `systemctl restart` calls without the flag, even when slots are drifted)
- [x] Clear message when no slots need restart (`_print_drift_banner` prints "all slots are in sync — no restart needed." when `drifted_slots` is empty)

## Files changed

- `src/hal0/providers/container.py` — `ContainerProvider.unit_is_stale` (read-only stale check) + `restart_unit_sync` (scoped bounce)
- `src/hal0/updater/updater.py` — `_iter_slot_configs` (shared enumerator), `detect_drifted_slots`, `restart_drifted_slots`, `post_commit_slot_sweep`; `Updater.commit`/`apply` gain `restart_slots`; `rerender_slot_units` refactored (unchanged public int contract) onto a shared `_rerender_slot_units_impl`
- `src/hal0/api/routes/updater.py` — `restart_slots` threaded through `/apply` and `/commit`; job dict carries `drifted_slots`/`restarted_slots`; new `GET /api/updates/drift`
- `src/hal0/cli/update_commands.py` — `--restart-slots` flag, `_print_drift_banner`
- `tests/providers/test_container.py`, `tests/updater/test_unit_rerender.py`, `tests/api/test_updater_routes.py`, `tests/cli/test_update_commands.py` — new coverage for all of the above

## Test plan

- [x] `uv run ruff format --check src tests` — clean
- [x] `uv run ruff check src tests` — clean
- [x] `uv run pytest tests/cli/ tests/slots/ -q` — passes (3 known pre-existing hermes-venv failures, unrelated)
- [x] `uv run pytest tests/ -q --ignore=tests/e2e` — 4769 passed, 12 failed / 1 error, all pre-existing (confirmed via `git stash` — identical failure set on the unmodified tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)