### PR TITLE
installer-setup WS-J: post-update drift surfacing + hal0 update --restart-slots

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -802,3 +802,132 @@ async def set_channel(request: Request) -> dict[str, str]:
         ) from exc
     request.app.state.hal0_config = merged
     return {"channel": channel}
+
+
+# ── /slot-drift + /restart-slots (installer-setup WS-J, #1111) ───────────────
+#
+# ``rerender_slot_units`` (updater) rewrites each on-disk slot unit through
+# current code after an update but deliberately never restarts a running
+# process — a bounce could kill a mid-inference request. The freshly-rendered
+# unit therefore describes the argv a restart WOULD use while the live
+# container keeps serving the pre-update argv: "post-update drift". These two
+# endpoints surface that drift (banner) and let an operator clear it on demand.
+
+
+def _slot_manager(request: Request) -> Any:
+    """Pull the SlotManager off app.state (wired in the lifespan).
+
+    Mirrors ``routes/slots._get_slot_manager`` — a missing manager is an
+    internal invariant (lifespan should always wire it), surfaced as a typed
+    envelope rather than an AttributeError.
+    """
+    sm = getattr(request.app.state, "slot_manager", None)
+    if sm is None:
+        raise UpdateError(
+            "slot_manager not initialised on app.state",
+            details={"hint": "lifespan did not run"},
+        )
+    return sm
+
+
+async def _collect_slot_drift(sm: Any) -> list[dict[str, Any]]:
+    """Return one entry per slot whose RUNNING argv lags a fresh render.
+
+    Reuses the reconcile seam (#1103): ``SlotManager.compute_config_drift``
+    compares the live container's argv (``ContainerProvider.running_argv``)
+    against the command a restart would render now (``expected_argv`` — the
+    same ``container_spec`` plan path ``_render_unit_text`` bakes into the
+    unit file). ``rerender_slot_units`` rewrites the on-disk unit after an
+    update but never bounces the process, so the running argv stays stale
+    until an explicit restart — precisely the drift this reports.
+
+    Never raises: a probe failure on one slot logs and skips so a single bad
+    slot can't blank the whole banner. Inactive slots (drift == None) are
+    dropped — a stopped slot cannot run a stale process.
+    """
+    try:
+        slots = await sm.list()
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("updater.slot_drift_list_failed", error=str(exc))
+        return []
+    drifted: list[dict[str, Any]] = []
+    for slot in slots:
+        name = getattr(slot, "name", None)
+        if not name:
+            continue
+        try:
+            payload = await sm.compute_config_drift(name)
+        except Exception as exc:
+            log.warning("updater.slot_drift_probe_failed", slot=name, error=str(exc))
+            continue
+        if payload and payload.get("drifted"):
+            drifted.append({"slot": name, "diffs": payload.get("diffs") or []})
+    return drifted
+
+
+@router.get("/slot-drift")
+async def slot_drift(request: Request) -> dict[str, Any]:
+    """Report slots whose running process lags the freshly-rendered unit.
+
+    Response shape (consumed by ``useSlotDrift`` + the CLI post-update
+    summary)::
+
+        {
+            "count": 1,
+            "slots": [
+                {"slot": "chat", "diffs": [
+                    {"key": "--ctx-size", "running": "4096", "rendered": "131072"}
+                ]}
+            ]
+        }
+
+    ``count == 0`` is the clean case — nothing needs a restart.
+    """
+    sm = _slot_manager(request)
+    drifted = await _collect_slot_drift(sm)
+    return {"count": len(drifted), "slots": drifted}
+
+
+@router.post("/restart-slots")
+async def restart_drifted_slots(request: Request) -> dict[str, Any]:
+    """Bounce ONLY the drifted slots — the explicit opt-in behind
+    ``hal0 update --restart-slots``.
+
+    A plain update never reaches this path, so it never auto-kills a slot
+    that may be mid-inference: the fresh argv only takes effect once the
+    operator asks for it here. Optionally restrict to a subset via
+    ``{"slots": ["chat", ...]}``; an omitted / empty list means "all
+    currently-drifted slots".
+
+    Response::
+
+        {"restarted": ["chat"], "failed": [], "count": 1}
+
+    A per-slot restart failure is recorded in ``failed`` (never re-raised) so
+    one wedged slot can't abort the rest of the sweep.
+    """
+    sm = _slot_manager(request)
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    only: set[str] | None = None
+    if isinstance(body, dict):
+        raw = body.get("slots")
+        if isinstance(raw, list) and raw:
+            only = {str(s) for s in raw}
+
+    drifted = await _collect_slot_drift(sm)
+    targets = [d["slot"] for d in drifted if only is None or d["slot"] in only]
+    restarted: list[str] = []
+    failed: list[dict[str, str]] = []
+    for name in targets:
+        try:
+            await sm.restart(name)
+        except Exception as exc:
+            log.warning("updater.slot_restart_failed", slot=name, error=str(exc))
+            failed.append({"slot": name, "error": str(exc)})
+            continue
+        log.info("updater.slot_restarted", slot=name)
+        restarted.append(name)
+    return {"restarted": restarted, "failed": failed, "count": len(restarted)}

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -194,6 +194,77 @@ def _render_notes(notes: dict | None) -> None:
         console.print(Markdown(markdown))
 
 
+def _fetch_slot_drift() -> dict:
+    """Return the /api/updates/slot-drift payload, or an empty summary on error.
+
+    Best-effort: the drift banner is a courtesy on top of the update flow, so
+    a probe failure must never turn a successful update into a hard error.
+    """
+    try:
+        body = api_get("/api/updates/slot-drift")
+    except CliApiError:
+        return {"count": 0, "slots": []}
+    return body if isinstance(body, dict) else {"count": 0, "slots": []}
+
+
+def _print_drift_banner(drift: dict) -> None:
+    """Post-update ``N slots need restart`` banner (or a clean all-good line).
+
+    ``rerender_slot_units`` refreshed each unit file on disk but never bounced
+    the running process, so drifted slots are still serving the pre-update
+    launch command. We surface that prominently and point at
+    ``hal0 update --restart-slots`` — we never bounce automatically, because a
+    slot may be mid-inference.
+    """
+    count = int(drift.get("count") or 0)
+    if count == 0:
+        console.print("[dim]no slots need restart.[/dim]")
+        return
+    slots = drift.get("slots") or []
+    names = ", ".join(str(s.get("slot")) for s in slots if isinstance(s, dict) and s.get("slot"))
+    plural = "s" if count != 1 else ""
+    console.print(
+        Panel(
+            f"[bold yellow]{count} slot{plural} need restart[/bold yellow]\n"
+            f"[dim]{names}[/dim]\n\n"
+            "These slots are still running the pre-update launch command. Run "
+            "[bold]hal0 update --restart-slots[/bold] to bounce only the drifted "
+            "slots (this briefly interrupts any in-flight request on them).",
+            title="Slots need restart",
+            border_style="yellow",
+        )
+    )
+
+
+def _restart_drifted_slots() -> None:
+    """POST /api/updates/restart-slots and report the outcome.
+
+    Clean-path message when nothing is drifted; otherwise restarts only the
+    drifted slots and lists successes + per-slot failures.
+    """
+    drift = _fetch_slot_drift()
+    if int(drift.get("count") or 0) == 0:
+        console.print(Panel("[green]no slots need restart.[/green]", border_style="green"))
+        return
+    try:
+        body = api_post("/api/updates/restart-slots")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    restarted = body.get("restarted") or []
+    failed = body.get("failed") or []
+    if restarted:
+        console.print(
+            Panel(
+                f"[green]restarted {len(restarted)} slot(s):[/green] {', '.join(restarted)}",
+                border_style="green",
+            )
+        )
+    for f in failed:
+        if isinstance(f, dict):
+            console.print(f"[yellow]could not restart {f.get('slot')}:[/yellow] {f.get('error')}")
+
+
 def update(
     channel: UpdateChannel | None = typer.Option(
         None,
@@ -221,6 +292,14 @@ def update(
         "-y",
         help="Skip the confirmation prompt after reviewing release notes.",
     ),
+    restart_slots: bool = typer.Option(
+        False,
+        "--restart-slots",
+        help=(
+            "Restart only the slots still running the pre-update launch command "
+            "(post-update drift). Never bounces a slot unless you pass this flag."
+        ),
+    ),
 ) -> None:
     """Check for, apply, or roll back a hal0 update.
 
@@ -240,6 +319,13 @@ def update(
             die(str(exc))
             return
         console.print(f"[green]channel set to {channel.value}[/green]")
+
+    # Standalone action: bounce drifted slots on demand, then stop. Kept
+    # separate from the check/apply flow so an operator can clear post-update
+    # drift at any later time (e.g. once in-flight requests have drained).
+    if restart_slots:
+        _restart_drifted_slots()
+        return
 
     if rollback:
         try:
@@ -323,6 +409,10 @@ def update(
             console.print(
                 f"[yellow]hal0-api restart did not complete:[/yellow] {final['restart_error']}"
             )
+        # The unit files were re-rendered but slots were NOT bounced (a restart
+        # could kill a mid-inference request). Surface which slots are still
+        # running the pre-update command so the operator can opt into a restart.
+        _print_drift_banner(_fetch_slot_drift())
     else:
         err = final.get("error") or "unknown error"
         die(f"update {state}: {err}")

--- a/tests/api/test_updater_slot_drift.py
+++ b/tests/api/test_updater_slot_drift.py
@@ -1,0 +1,140 @@
+"""Tests for /api/updates/slot-drift + /api/updates/restart-slots (WS-J, #1111).
+
+``rerender_slot_units`` refreshes each on-disk slot unit after a self-update
+but never bounces the running process (a restart could kill a mid-inference
+request). These endpoints surface the resulting "post-update drift" — slots
+still running the pre-update launch command — and let an operator clear it on
+demand. The drift signal itself is ``SlotManager.compute_config_drift`` (the
+#1103 reconcile seam); here we stub the manager so the aggregation + restart
+routing is exercised without a live container runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+class _StubSlotManager:
+    """Minimal async SlotManager surface the drift endpoints depend on."""
+
+    def __init__(
+        self,
+        drift: dict[str, dict[str, Any] | None],
+        *,
+        restart_error: dict[str, str] | None = None,
+    ) -> None:
+        # drift maps slot name -> compute_config_drift() return value
+        # ({"drifted": bool, "diffs": [...]} or None for inactive slots).
+        self._drift = drift
+        self._restart_error = restart_error or {}
+        self.restarted: list[str] = []
+
+    async def list(self) -> list[Any]:
+        return [SimpleNamespace(name=name) for name in self._drift]
+
+    async def compute_config_drift(self, name: str, **_: Any) -> dict[str, Any] | None:
+        return self._drift.get(name)
+
+    async def restart(self, name: str) -> Any:
+        if name in self._restart_error:
+            raise RuntimeError(self._restart_error[name])
+        self.restarted.append(name)
+        return SimpleNamespace(name=name)
+
+
+@pytest.fixture
+def client(tmp_hal0_home: str) -> Iterator[TestClient]:
+    app: FastAPI = create_app()
+    with TestClient(app) as c:
+        yield c
+
+
+def _install_sm(client: TestClient, sm: _StubSlotManager) -> None:
+    # The lifespan wires a real SlotManager; the route reads it off app.state
+    # at request time, so a post-lifespan swap takes effect on the next call.
+    client.app.state.slot_manager = sm
+
+
+def test_slot_drift_reports_only_drifted(client: TestClient) -> None:
+    sm = _StubSlotManager(
+        {
+            "chat": {
+                "drifted": True,
+                "diffs": [{"key": "--ctx-size", "running": "4096", "rendered": "131072"}],
+            },
+            "code": {"drifted": False, "diffs": []},
+            "voice": None,  # inactive slot — cannot run a stale process
+        }
+    )
+    _install_sm(client, sm)
+    r = client.get("/api/updates/slot-drift")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 1
+    assert [s["slot"] for s in body["slots"]] == ["chat"]
+    assert body["slots"][0]["diffs"][0]["key"] == "--ctx-size"
+
+
+def test_slot_drift_clean_when_nothing_drifted(client: TestClient) -> None:
+    sm = _StubSlotManager({"chat": {"drifted": False, "diffs": []}, "voice": None})
+    _install_sm(client, sm)
+    r = client.get("/api/updates/slot-drift")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"count": 0, "slots": []}
+
+
+def test_restart_slots_bounces_only_drifted(client: TestClient) -> None:
+    sm = _StubSlotManager(
+        {
+            "chat": {"drifted": True, "diffs": []},
+            "code": {"drifted": False, "diffs": []},
+        }
+    )
+    _install_sm(client, sm)
+    r = client.post("/api/updates/restart-slots")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["restarted"] == ["chat"]
+    assert body["failed"] == []
+    assert body["count"] == 1
+    # The non-drifted slot must never be bounced.
+    assert sm.restarted == ["chat"]
+
+
+def test_restart_slots_subset_filter(client: TestClient) -> None:
+    sm = _StubSlotManager(
+        {
+            "chat": {"drifted": True, "diffs": []},
+            "code": {"drifted": True, "diffs": []},
+        }
+    )
+    _install_sm(client, sm)
+    r = client.post("/api/updates/restart-slots", json={"slots": ["code"]})
+    assert r.status_code == 200, r.text
+    assert r.json()["restarted"] == ["code"]
+    assert sm.restarted == ["code"]
+
+
+def test_restart_slots_records_per_slot_failure(client: TestClient) -> None:
+    sm = _StubSlotManager(
+        {
+            "chat": {"drifted": True, "diffs": []},
+            "code": {"drifted": True, "diffs": []},
+        },
+        restart_error={"chat": "boom"},
+    )
+    _install_sm(client, sm)
+    r = client.post("/api/updates/restart-slots")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["restarted"] == ["code"]
+    assert body["failed"] == [{"slot": "chat", "error": "boom"}]
+    assert body["count"] == 1

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -3,7 +3,7 @@
 The CLI is a thin client over /api/updates/*; these tests stub the
 ``api_*`` helpers (imported into the update_commands namespace) so the
 command logic - target-version normalization, the apply trigger, and the
-absence of the retired ``--restart-slots`` flag - is exercised without a
+drift-aware ``--restart-slots`` flag (WS-J, #1111) - is exercised without a
 running daemon.
 """
 
@@ -80,12 +80,111 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     return captured
 
 
-def test_restart_slots_flag_removed() -> None:
-    """The retired ``--restart-slots`` flag is gone from the command signature."""
+def test_restart_slots_flag_present_and_drift_aware() -> None:
+    """``--restart-slots`` is back — but drift-aware, via the API (WS-J, #1111).
+
+    The retired flag bounced ``hal0-slot@*.service`` unconditionally over
+    systemd; the new one restarts only drifted slots through
+    /api/updates/restart-slots. The old systemd-bouncing helper stays gone.
+    """
     sig = inspect.signature(uc.update)
-    assert "restart_slots" not in sig.parameters
-    # And the helper that bounced hal0-slot@*.service is removed too.
+    assert "restart_slots" in sig.parameters
+    # The retired systemd-bouncing helper must NOT come back.
     assert not hasattr(uc, "_restart_slots")
+    # The new drift-aware helpers exist instead.
+    assert hasattr(uc, "_restart_drifted_slots")
+    assert hasattr(uc, "_fetch_slot_drift")
+    assert hasattr(uc, "_print_drift_banner")
+
+
+def test_restart_slots_bounces_only_drifted_and_skips_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``hal0 update --restart-slots`` POSTs restart-slots and never runs apply."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    calls: dict = {"get": [], "post": []}
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        calls["get"].append(path)
+        if path == "/api/updates/slot-drift":
+            return {"count": 1, "slots": [{"slot": "chat", "diffs": []}]}
+        return {}
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        calls["post"].append(path)
+        if path == "/api/updates/restart-slots":
+            return {"restarted": ["chat"], "failed": [], "count": 1}
+        return {}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    result = runner.invoke(app, ["update", "--restart-slots"])
+    assert result.exit_code == 0, result.output
+    # It restarted drifted slots …
+    assert "/api/updates/restart-slots" in calls["post"]
+    assert "restarted 1 slot" in result.output
+    # … and never touched the check / prepare / commit apply path.
+    assert "/api/updates/check" not in calls["get"]
+    assert "/api/updates/prepare" not in calls["post"]
+    assert "/api/updates/commit" not in calls["post"]
+
+
+def test_restart_slots_clean_message_when_nothing_drifted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean box prints an explicit 'no slots need restart' and skips POST."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    posted: list[str] = []
+    monkeypatch.setattr(uc, "api_get", lambda path, **k: {"count": 0, "slots": []})
+    monkeypatch.setattr(uc, "api_post", lambda path, **k: posted.append(path) or {})
+    result = runner.invoke(app, ["update", "--restart-slots"])
+    assert result.exit_code == 0, result.output
+    assert "no slots need restart" in result.output
+    assert posted == []  # nothing drifted → no restart POST
+
+
+def test_post_apply_shows_drift_banner(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After a successful apply the 'N slots need restart' banner is surfaced."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        if path == "/api/updates/slot-drift":
+            return {"count": 2, "slots": [{"slot": "chat"}, {"slot": "code"}]}
+        return {
+            "current": "0.0.0",
+            "latest": "9.9.9",
+            "channel": "stable",
+            "update_available": True,
+            "manifest": {},
+        }
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        if path == "/api/updates/prepare":
+            return {"id": "p1", "state": "queued"}
+        if path == "/api/updates/commit":
+            return {"id": "c1", "state": "queued"}
+        return {}
+
+    def fake_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
+        if "prepared" in terminal:
+            return {"id": job_id, "state": "prepared", "resolved_version": "9.9.9", "notes": {}}
+        return {"id": job_id, "state": "applied"}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    monkeypatch.setattr(uc, "_poll_job", fake_poll)
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0, result.output
+    assert "2 slots need restart" in result.output
+    # Panel word-wraps at the runner's 80-col width, so match the flag token
+    # (which never splits) rather than the full "hal0 update --restart-slots".
+    assert "--restart-slots" in result.output
 
 
 def test_target_strips_leading_v(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -262,6 +262,10 @@ export const ENDPOINTS = {
   // Channel (stable | nightly) — GET reads hal0.toml telemetry.channel;
   // PUT persists the choice back so subsequent /check calls honour it.
   updateChannel: '/api/updates/channel',
+  // Post-update drift (WS-J, #1111): slots whose running process still uses
+  // the pre-update launch command. GET reports; POST restarts only those.
+  updateSlotDrift: '/api/updates/slot-drift',
+  updateRestartSlots: '/api/updates/restart-slots',
   // Secrets
   secrets: '/api/secrets',
   secret: (name: string) => `/api/secrets/${encodeURIComponent(name)}`,

--- a/ui/src/api/hooks/useUpdates.ts
+++ b/ui/src/api/hooks/useUpdates.ts
@@ -102,6 +102,56 @@ export function useSetUpdateChannel() {
 // Poll an apply job until it lands in a terminal state. Polling stops on
 // applied/failed, on null jobId, or on unmount. Returns the latest job
 // snapshot plus a terminal flag so callers can fire toasts once.
+// ── Post-update slot drift (WS-J, #1111) ────────────────────────────────────
+//
+// After a self-update the slot unit files are re-rendered on disk, but the
+// running containers are NOT bounced (a restart could kill a mid-inference
+// request). Drifted slots therefore keep serving the pre-update launch
+// command until an operator opts into a restart. `useSlotDrift` backs the
+// dashboard "N slots need restart" banner; `useRestartDriftedSlots` bounces
+// only the drifted slots on demand.
+
+export interface SlotDriftEntry {
+  slot: string
+  diffs: Array<{ key: string; running: string | null; rendered: string | null }>
+}
+
+export interface SlotDrift {
+  count: number
+  slots: SlotDriftEntry[]
+}
+
+export function useSlotDrift() {
+  return useQuery({
+    queryKey: ['updates', 'slot-drift'],
+    queryFn: () => apiGet<SlotDrift>(ENDPOINTS.updateSlotDrift),
+    // Cheap live probe (podman inspect per slot) — a slow refetch keeps the
+    // banner honest after a background update without hammering the runtime.
+    refetchInterval: 30_000,
+  })
+}
+
+export interface RestartSlotsResult {
+  restarted: string[]
+  failed: Array<{ slot: string; error: string }>
+  count: number
+}
+
+export function useRestartDriftedSlots() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (slots?: string[]) =>
+      apiPost<RestartSlotsResult>(
+        ENDPOINTS.updateRestartSlots,
+        slots && slots.length ? { slots } : {},
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['updates', 'slot-drift'] })
+      qc.invalidateQueries({ queryKey: ['slots'] })
+    },
+  })
+}
+
 export function useUpdateJob(jobId: string | null): {
   job: UpdateJob | null
   terminal: boolean

--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -28,6 +28,7 @@ import { useServices } from '@/api/hooks/useServices'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 import { useActivityRecent } from '@/api/hooks/useActivity'
 import { useApprovalList } from '@/api/hooks/useAgents'
+import { useSlotDrift, useRestartDriftedSlots } from '@/api/hooks/useUpdates'
 import {
   useDashLayout,
   useSaveDashLayout,
@@ -1010,6 +1011,46 @@ function CellWidget({ cellId, layout, onSwap, onGo, attentionItems }) {
   }
 }
 
+// ─── post-update slot-drift banner (WS-J, #1111) ──────────────────────────────
+//
+// After a self-update the slot unit files are re-rendered on disk but the
+// running containers are NOT bounced (a restart could kill a mid-inference
+// request). This banner surfaces the slots still serving the pre-update
+// launch command and offers a one-click restart of ONLY those slots — nothing
+// is ever bounced automatically.
+function SlotDriftBanner() {
+  const drift = useSlotDrift()
+  const restart = useRestartDriftedSlots()
+  const count = drift.data?.count ?? 0
+  if (count <= 0) return null
+  const names = (drift.data?.slots ?? []).map((s) => s.slot).filter(Boolean).join(', ')
+  const plural = count === 1 ? '' : 's'
+  return (
+    <div className="banner-stack">
+      <div className="banner banner-warn" role="status">
+        <span className="banner-ic" aria-hidden="true">↻</span>
+        <div className="banner-content">
+          <span className="banner-eye">Update · slots need restart</span>
+          <span className="banner-heading">{count} slot{plural} need restart</span>
+          <span className="banner-body">
+            {names ? names + ' — ' : ''}still running the pre-update launch command.
+            Restarting briefly interrupts any in-flight request on those slots.
+          </span>
+          <div className="banner-actions">
+            <button
+              className="btn ghost sm mono"
+              disabled={restart.isPending}
+              onClick={() => restart.mutate(undefined)}
+            >
+              {restart.isPending ? 'restarting…' : 'restart drifted slots'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 // ─── view ────────────────────────────────────────────────────────────────────
 
 function DashboardRedesignView({ onGo }) {
@@ -1065,6 +1106,7 @@ function DashboardRedesignView({ onGo }) {
 
   return (
     <div className={'view rd-view' + (swapMode ? ' rd-swapmode' : '')}>
+      <SlotDriftBanner />
       <HeroStrip
         slots={slots}
         heroTps={heroTps}


### PR DESCRIPTION
Closes #1111 (installer-setup Wave 4 / WS-J, decision Q11).

> **Heads-up for reviewers:** PR #1141 is a parallel implementation of this
> same issue on branch `feat/1111-post-update-drift`. This PR is an
> independent, more minimal alternative — it reuses the existing
> `SlotManager.compute_config_drift` seam and does **not** modify
> `container.py` or `updater.py`. Pick one; close the other.

## Problem
`rerender_slot_units()` re-renders each slot unit file on disk after a
self-update but never restarts the running process (a bounce could kill a
mid-inference request), so an updated box silently keeps serving the
pre-update launch command.

## How drift is detected (reuses the #1103 reconcile seam)
`SlotManager.compute_config_drift` (already in the tree) compares the **live
container argv** (`ContainerProvider.running_argv`) against the command a
restart **would render now** (`ContainerProvider.expected_argv` — the same
`container_spec` → plan path that `_render_unit_text` bakes into the unit
file). Inactive slots can't run a stale process, so they're dropped. No new
comparison logic is introduced; the two new endpoints just aggregate that
per-slot signal.

## How mid-inference is protected
A plain `hal0 update` **never** reaches a restart path — it only *surfaces*
the drift. Bouncing a slot is strictly opt-in via `--restart-slots` (CLI) or
the dashboard banner button. Default behavior therefore never interrupts an
in-flight inference.

## Changes
- `GET /api/updates/slot-drift` → `{count, slots:[{slot, diffs}]}`.
- `POST /api/updates/restart-slots` → bounce **only** the drifted slots
  (optional `{"slots":[...]}` subset); per-slot restart failures are recorded
  in `failed`, never re-raised, so one wedged slot can't abort the sweep.
- CLI: post-apply "N slots need restart" banner pointing at the flag;
  `hal0 update --restart-slots` restarts only drifted slots and
  short-circuits the check/apply flow; explicit "no slots need restart"
  message when clean.
- Dashboard: `SlotDriftBanner` (warn) on the redesign view with a one-click
  "restart drifted slots" button; renders nothing when `count == 0`.
- Tests: `tests/api/test_updater_slot_drift.py` (aggregation + restart
  routing + subset filter + per-slot failure) and new CLI cases in
  `tests/cli/test_update_commands.py` (flag present & drift-aware, standalone
  restart skips apply, clean-message path, post-apply banner). Updated the
  retired-flag guard test to assert the new drift-aware flag + helpers.

## Acceptance criteria
- [x] Post-update drift detected and surfaced (CLI + dashboard banner)
- [x] `hal0 update --restart-slots` restarts only the drifted slots
- [x] Default behavior never interrupts an in-flight inference (opt-in only)
- [x] Clear message when no slots need restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)