### PR TITLE
fix(test): don't write through seeded uname symlink in prereq-parity tests (unblock CI)

### DIFF
--- a/tests/installer/test_bootstrap_prereq_parity.py
+++ b/tests/installer/test_bootstrap_prereq_parity.py
@@ -39,6 +39,12 @@ _INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
 
 
 def _write_exe(path: Path, body: str = "#!/usr/bin/env bash\nexit 0\n") -> None:
+    # Replace any existing entry (full_bin_dir seeds tools as symlinks to the
+    # real binaries) rather than writing THROUGH it: write_text() follows a
+    # symlink, so overwriting the seeded `uname` symlink would try to rewrite
+    # the host's /usr/bin/uname — PermissionError on a locked-down CI runner,
+    # or silent mutation of the real binary when the test runs as root.
+    path.unlink(missing_ok=True)
     path.write_text(body, encoding="utf-8")
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 


### PR DESCRIPTION
`tests/installer/test_bootstrap_prereq_parity.py::TestNonLinuxHost` fails on the GitHub runner with `PermissionError: [Errno 13] ... /bin/uname` — currently **red on main** (regression from #1098/#1139, which merged green off a box-local run).

**Cause:** `full_bin_dir` seeds PATH tools as symlinks to the real binaries; `_fake_uname` → `_write_exe` used `write_text()`, which **follows the symlink** and rewrites the host's `/usr/bin/uname`. Denied on a locked-down runner; on a root box it silently mutates the real binary.

**Fix:** `_write_exe` unlinks the path first, replacing the seeded symlink with a regular file.

Verified: `pytest tests/installer/test_bootstrap_prereq_parity.py` → 15 passed; ruff clean. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)