### PR TITLE
installer-setup WS-F: guided Stage-2 setup TUI with review gate + two-stage handoff

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1921,3 +1921,30 @@ SUMMARY_LINES+=(
 )
 
 ui_box "hal0 is ready" "${SUMMARY_LINES[@]}"
+
+# ── Stage-2 guided setup handoff (issue #1112) ──────────────────────────────
+# Stage-1 (everything above) did system prep + the platform/GPU gate + the
+# --auto slot/sentinel seed. Stage-2 is the INTERACTIVE `hal0 setup` flow
+# (network → store → HF token → slots → NPU → gen → apps → review → apply).
+# On a real terminal, offer to drop the operator straight into it; on a piped
+# / headless (`curl … | bash`) run there is no interactive stdin, so just
+# print the command. Self-contained so later install.sh edits merge around it.
+if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 && "${HAL0_SKIP_SETUP:-0}" != "1" ]]; then
+    _confirm_launch_setup() {
+        # y/N read from the controlling terminal so it works even when stdin is
+        # the piped installer. Default Yes; any read failure (no TTY) → No, and
+        # the caller falls through to just printing the command.
+        local reply=""
+        printf '\n%s' "Launch the guided hal0 setup now? [Y/n] " >/dev/tty 2>/dev/null || return 1
+        IFS= read -r reply </dev/tty 2>/dev/null || return 1
+        [[ -z "${reply}" || "${reply}" =~ ^[Yy]([Ee][Ss])?$ ]]
+    }
+    if [[ -r /dev/tty ]] && _confirm_launch_setup; then
+        "${HAL0_BIN}" setup \
+            || warn "guided setup exited non-zero — re-run '${BOLD}hal0 setup${RST}' anytime"
+    else
+        printf '\n'
+        info "Finish setup any time from a terminal: ${BOLD}hal0 setup${RST}"
+        info "  (guided: network, model store, slots, NPU, image gen, apps)"
+    fi
+fi

--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -8,6 +8,8 @@ spec §11)."""
 from __future__ import annotations
 
 import asyncio
+import os
+import sys
 
 import httpx
 import typer
@@ -183,6 +185,21 @@ def setup(
         help="Resolve + print the plan; write nothing (no slots, sentinel, pulls, or extensions).",
     ),
 ) -> None:
+    # Two-stage handoff (issue #1112): the guided Stage-2 flow is interactive
+    # (rich prompts on a real TTY). When it is requested (no --auto / --answers /
+    # --plan / --emit-answers) but stdin is NOT a terminal — a piped/headless
+    # `curl … | hal0 setup` or CI run — DON'T launch rich prompts (they would
+    # EOF immediately). Print the exact command to run instead, mirroring what
+    # install.sh's Stage-1 tail prints on a headless install. HAL0_FORCE_INTERACTIVE
+    # bypasses the guard so tests can drive the flow over a pipe.
+    interactive = not (auto or plan or answers is not None or emit_answers is not None)
+    if interactive and not sys.stdin.isatty() and not os.environ.get("HAL0_FORCE_INTERACTIVE"):
+        typer.echo("hal0 setup is interactive — run it from a terminal:")
+        typer.echo("  hal0 setup")
+        typer.echo("or run non-interactively with recommended defaults:")
+        typer.echo("  hal0 setup --auto")
+        return
+
     probe = HardwareProbe()
     # --plan / --emit-answers are side-effect-free preview paths: a light probe
     # (no NPU validation, no hardware.json write) so they honour their

--- a/src/hal0/cli/setup_copy.py
+++ b/src/hal0/cli/setup_copy.py
@@ -16,9 +16,33 @@ PANE_COPY: dict[str, PaneCopy] = {
         "Welcome to hal0",
         "We detected your hardware and tuned the defaults on the left. Press Enter to continue.",
     ),
+    "network": PaneCopy(
+        "How hal0 is reached",
+        "Bind loopback (127.0.0.1) to keep hal0 private behind a reverse proxy, "
+        "or all interfaces (0.0.0.0) to reach it directly on your LAN. The "
+        "hostname seeds mDNS (<name>.local) and the browser-origin allowlist.",
+    ),
     "storage": PaneCopy(
         "Where models live",
-        "Downloaded models are stored here. Pick a disk with room — chat models run 2-30 GB each.",
+        "Downloaded models are stored here. Pick a disk with room — chat models run 2-30 GB each. "
+        "This is mandatory: nothing downloads until a writable store is set.",
+    ),
+    "hf": PaneCopy(
+        "Hugging Face access",
+        "Some curated models live in gated repos. Paste a read token to pull "
+        "them (used for background downloads this run), or leave blank — open "
+        "models still work. HF_TOKEN in the environment always wins.",
+    ),
+    "gen": PaneCopy(
+        "Image & video generation",
+        "ComfyUI runs on the iGPU. Scaffold-only wires the slot without "
+        "downloading weights (default — fast install); scaffold+download also "
+        "pulls the default generation models. Off skips image/video gen.",
+    ),
+    "verify": PaneCopy(
+        "All set",
+        "Slots are created and the first-run sentinel is written. Models "
+        "download in the background — start chatting as soon as Main lands.",
     ),
     "extensions": PaneCopy(
         "One-shot perfection",

--- a/src/hal0/cli/setup_ui.py
+++ b/src/hal0/cli/setup_ui.py
@@ -4,7 +4,11 @@ step. Left = the step body; right = the always-on context pane."""
 from __future__ import annotations
 
 import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
 
+import typer
 from rich.console import Console, Group, RenderableType
 from rich.layout import Layout
 from rich.panel import Panel
@@ -14,11 +18,21 @@ from rich.text import Text
 
 from hal0.cli.setup_command import _SETUP_SLOTS
 from hal0.cli.setup_copy import PANE_COPY
+from hal0.cli.setup_plan import _free_space_gib, _port_in_use
 from hal0.config.schema import HardwareInfo
 from hal0.install.extensions import EXTENSIONS, get_extension
+from hal0.install.network import network_env, resolve_hostname
 from hal0.install.orchestrate import Selections, SlotSelection
-from hal0.install.profile_derive import npu_healthy
+from hal0.install.profile_derive import derive_device, derive_profile, npu_healthy
 from hal0.install.suggest import suggest_models
+from hal0.registry.curated import get_curated
+from hal0.registry.model_store import describe_store_state
+
+#: ComfyUI generation modes (mirrors ``hal0.install.answers._GEN_MODES``). The
+#: interactive default is ``scaffold_only`` — wire the slot without downloading
+#: weights, so a first install stays fast.
+GEN_MODES = ("off", "scaffold_only", "scaffold_and_download")
+_GEN_MODES_ON = ("scaffold_only", "scaffold_and_download")
 
 _con = Console()
 
@@ -186,29 +200,310 @@ def _toggle_extensions(state: dict, hw: HardwareInfo) -> None:
                 state[eid] = not state.get(eid, False)
 
 
-def _review_table(sel: Selections):
-    t = Table(title="Will create", expand=True)
-    t.add_column("Slot")
-    t.add_column("Model")
-    t.add_column("Extensions")
-    enabled = ", ".join(k for k, v in sel.extensions.items() if v)
-    for i, s in enumerate(sel.slots):
-        model = s.model_id or "(scaffold — choose later)"
-        t.add_row(s.slot_name, model, enabled if i == 0 else "")
-    return t
+# ── Resolved-choice model ───────────────────────────────────────────────────
+
+#: Ports hal0 itself owns — the API (8080) and the chat-proxy front door
+#: (3001). A slot that lands on one of these would shadow a core service.
+_RESERVED_PORTS = {8080, 3001}
+
+
+@dataclass
+class NetworkChoice:
+    """The bind / mDNS / origins shape chosen in the network step."""
+
+    bind_host: str  # "127.0.0.1" (loopback) | "0.0.0.0" (LAN)
+    hostname: str
+    public_url: str | None = None
+
+
+@dataclass
+class SetupPlan:
+    """Every interactive choice, resolved — the single object the REVIEW gate
+    renders and the apply step consumes. Building it writes NOTHING."""
+
+    hw: HardwareInfo
+    network: NetworkChoice
+    storage_dir: str
+    hf_token: str | None
+    extensions: dict[str, bool]
+    slots: list[SlotSelection]
+    npu_opt_in: bool
+    gen_mode: str
+    comfyui_defaults: tuple[tuple[str, str], ...] = ()
+
+    def selections(self) -> Selections:
+        """The apply-core :class:`Selections` view of this plan."""
+        return Selections(
+            storage_dir=self.storage_dir,
+            slots=self.slots,
+            extensions=self.extensions,
+            npu_opt_in=self.npu_opt_in,
+            comfyui_defaults=self.comfyui_defaults,
+        )
+
+
+# ── Step functions (each draws, prompts, returns a choice) ───────────────────
+
+
+def _step_network(hw: HardwareInfo) -> NetworkChoice:
+    """Bind shape + advertised hostname. Nothing is written — the resolved env
+    triple is only applied at :func:`_apply` time."""
+    _draw("network", "Choose how the dashboard + API are reached.", hw)
+    lan = Confirm.ask(
+        "Expose hal0 on your LAN (bind 0.0.0.0)? No keeps it loopback-only",
+        default=False,
+    )
+    bind_host = "0.0.0.0" if lan else "127.0.0.1"
+    hostname = Prompt.ask("Hostname to advertise (mDNS + origins)", default=resolve_hostname())
+    public_url = Prompt.ask("Public reverse-proxy URL (optional, blank to skip)", default="")
+    return NetworkChoice(bind_host=bind_host, hostname=hostname, public_url=public_url or None)
+
+
+def _validate_store(path: str) -> tuple[bool, str]:
+    """Return ``(ok, reason)``. A store is usable when it is an absolute path
+    that — if it already exists — is a writable directory. A not-yet-created
+    path is accepted (the installer / apply step own creation) as long as its
+    nearest existing ancestor is reachable (non-zero free space)."""
+    path = (path or "").strip()
+    if not path:
+        return False, "a model store path is required (nothing downloads without one)"
+    if not Path(path).is_absolute():
+        return False, f"store path {path!r} must be absolute"
+    probe = describe_store_state(path)
+    if probe.exists and not probe.is_dir:
+        return False, f"{path} exists but is not a directory"
+    if probe.exists and not probe.writable:
+        return False, f"{path} is not writable by this user"
+    if not probe.exists and probe.free_bytes == 0:
+        return False, f"cannot reach {path} — no writable parent directory exists yet"
+    return True, ""
+
+
+def _step_store(hw: HardwareInfo, default_dir: str) -> str:
+    """Mandatory, validated model-store selection. Loops until a usable path is
+    entered — this gates every model download downstream."""
+    current = default_dir
+    while True:
+        _draw("storage", f"Default: {current}", hw)
+        path = Prompt.ask("Model storage directory", default=current).strip()
+        ok, reason = _validate_store(path)
+        if ok:
+            return path
+        _con.print(f"[red]✗ {reason}[/red]")
+        current = path or default_dir
+
+
+def _step_hf_token(hw: HardwareInfo) -> str | None:
+    """Optional Hugging Face token for gated pulls. An ``HF_TOKEN`` already in
+    the environment wins and is kept without re-prompting."""
+    env = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    _draw("hf", "Paste a read token for gated models, or skip.", hw)
+    if env:
+        _con.print("[dim]HF_TOKEN found in the environment — using it.[/dim]")
+        return None
+    tok = Prompt.ask(
+        "Hugging Face token (optional, blank to skip)", default="", password=True
+    ).strip()
+    return tok or None
+
+
+def _step_gen(hw: HardwareInfo) -> str:
+    """ComfyUI image/video generation mode. Default is scaffold-only (wire the
+    slot, download weights later) so a first install stays fast."""
+    _draw(
+        "gen",
+        Group(
+            Text("1) off — no image/video generation"),
+            Text("2) scaffold only — wire ComfyUI, download weights later  [default]"),
+            Text("3) scaffold + download — wire ComfyUI and pull default models now"),
+        ),
+        hw,
+    )
+    choice = Prompt.ask("Image/video generation", choices=["1", "2", "3"], default="2")
+    return {"1": "off", "2": "scaffold_only", "3": "scaffold_and_download"}[choice]
+
+
+def _comfyui_defaults() -> tuple[tuple[str, str], ...]:
+    """Default ``(capability_id, family)`` pairs for ComfyUI, mirroring
+    ``build_auto_selections`` / the answer-file resolver."""
+    from hal0.comfyui.capabilities import CAPABILITIES as _CAPS
+
+    return tuple((cap_id, cap.alternatives[0].family) for cap_id, cap in _CAPS.items())
+
+
+# ── REVIEW gate ──────────────────────────────────────────────────────────────
+
+
+def _slot_size_gb(model_id: str | None) -> float:
+    """Curated download size for a model id (0.0 for a scaffold / unknown)."""
+    if not model_id:
+        return 0.0
+    curated = get_curated(model_id)
+    return float(getattr(curated, "size_gb", 0.0) or 0.0) if curated else 0.0
+
+
+def _port_issues(slots: list[SlotSelection]) -> list[str]:
+    """Human-readable port problems: duplicates within the plan, reserved-port
+    shadows, and ports already bound on this host."""
+    issues: list[str] = []
+    seen: dict[int, str] = {}
+    for s in slots:
+        if s.port in seen:
+            issues.append(f"port {s.port}: '{seen[s.port]}' and '{s.slot_name}' both claim it")
+        seen[s.port] = s.slot_name
+    for s in slots:
+        if s.port in _RESERVED_PORTS:
+            issues.append(f"port {s.port} ('{s.slot_name}') is a reserved hal0 port")
+        elif _port_in_use(s.port):
+            issues.append(f"port {s.port} ('{s.slot_name}') is already in use on this host")
+    return issues
+
+
+def render_review(plan: SetupPlan) -> RenderableType:
+    """Accurate 'will create' summary the REVIEW gate shows. Reflects the
+    resolved plan exactly — slots (with derived device/profile + a live port
+    check), store + free space, bind / mDNS / origins, HF token, gen mode,
+    extensions, and total download size. Renders only; writes nothing."""
+    hw, net = plan.hw, plan.network
+    free_gib = _free_space_gib(plan.storage_dir)
+    free_txt = f"{free_gib:.1f} GiB free" if free_gib is not None else "free space unknown"
+
+    facts = Table.grid(padding=(0, 2))
+    facts.add_column(style="bold")
+    facts.add_column()
+    facts.add_row("Model store", f"{plan.storage_dir}  ({free_txt})")
+    bind_label = "LAN (0.0.0.0)" if net.bind_host == "0.0.0.0" else "loopback (127.0.0.1)"
+    facts.add_row("Bind", bind_label)
+    facts.add_row("mDNS", f"{net.hostname}.local")
+    origins = network_env(
+        bind_host=net.bind_host, hostname=net.hostname, public_url=net.public_url
+    )["HAL0_ALLOWED_ORIGINS"]
+    facts.add_row("Origins", f"{len(origins.split(','))} allowed")
+    facts.add_row("HF token", "set" if plan.hf_token else "not set (open models only)")
+    facts.add_row("Gen", plan.gen_mode)
+
+    slot_table = Table(title="Slots to create", expand=True)
+    slot_table.add_column("Name")
+    slot_table.add_column("Port", justify="right")
+    slot_table.add_column("Model")
+    slot_table.add_column("Device")
+    slot_table.add_column("Profile")
+    slot_table.add_column("Size", justify="right")
+    slot_table.add_column("Port state")
+    total_gb = 0.0
+    for s in plan.slots:
+        device = s.device or derive_device(s.capability, hw, npu_opt_in=plan.npu_opt_in)
+        profile = s.profile or (derive_profile(s.capability, device) if device else None)
+        size = _slot_size_gb(s.model_id)
+        total_gb += size
+        clash = s.port in _RESERVED_PORTS or _port_in_use(s.port)
+        slot_table.add_row(
+            s.slot_name,
+            str(s.port),
+            s.model_id or "(scaffold — choose later)",
+            device or "—",
+            profile or "—",
+            f"{size:.1f}GB" if size else "—",
+            "[red]IN USE[/red]" if clash else "free",
+        )
+    if not plan.slots:
+        slot_table.add_row("(none)", "", "", "", "", "", "")
+
+    enabled = ", ".join(k for k, v in plan.extensions.items() if v) or "(none)"
+    parts: list[RenderableType] = [
+        facts,
+        Text(""),
+        slot_table,
+        Text(f"Apps/agents: {enabled}"),
+        Text(f"Total download: ~{total_gb:.1f} GB"),
+    ]
+    issues = _port_issues(plan.slots)
+    if issues:
+        parts.append(Text(""))
+        parts.append(Text("Port conflicts:", style="bold red"))
+        parts.extend(Text(f"  • {msg}", style="red") for msg in issues)
+    parts.append(Text(""))
+    parts.append(Text("Nothing has been written yet.", style="dim"))
+    return Group(*parts)
+
+
+# ── Apply / verify ───────────────────────────────────────────────────────────
+
+
+def _persist_store(storage_dir: str) -> None:
+    """Persist ``[models].store`` so downloads land in the chosen store. Best-
+    effort: a non-root ``hal0 setup`` that can't write hal0.toml still proceeds
+    (the daemon persists it later)."""
+    try:
+        from hal0.config.loader import load_hal0_config, save_hal0_config
+
+        cfg = load_hal0_config()
+        merged_models = cfg.models.model_copy(update={"store": storage_dir})
+        save_hal0_config(cfg.model_copy(update={"models": merged_models}))
+    except Exception as exc:  # best-effort — never abort the apply on this
+        _con.print(f"[yellow]note: could not persist model store to hal0.toml ({exc})[/yellow]")
+
+
+def _verify_report(plan: SetupPlan) -> None:
+    """Post-apply confirmation: what landed on disk (sentinel + slot count) and
+    how hal0 is reached."""
+    from hal0.config import paths
+
+    sentinel = paths.var_lib() / ".first_run_done"
+    typer.echo("")
+    typer.echo("Setup verification:")
+    typer.echo(f"  model store         {plan.storage_dir}")
+    typer.echo(f"  bind / mDNS         {plan.network.bind_host} · {plan.network.hostname}.local")
+    typer.echo(f"  slots configured    {len(plan.slots)}")
+    typer.echo(f"  first-run sentinel  {'written' if sentinel.exists() else 'MISSING'}")
+
+
+def _apply(plan: SetupPlan) -> None:
+    """Persist the network + store choices, then run the hybrid apply. Env
+    exports (network + HF token) happen HERE — never during plan building — so a
+    'No' at the review gate leaves the environment untouched too."""
+    os.environ.update(
+        network_env(
+            bind_host=plan.network.bind_host,
+            hostname=plan.network.hostname,
+            public_url=plan.network.public_url,
+        )
+    )
+    if plan.hf_token:
+        os.environ["HF_TOKEN"] = plan.hf_token
+    _persist_store(plan.storage_dir)
+
+    from hal0.cli.setup_install import run_install
+
+    asyncio.run(run_install(plan.selections(), plan.hw))
+    _verify_report(plan)
 
 
 def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
+    """The guided Stage-2 flow (issue #1112). Decision tree, in order:
+    Platform → network → model store (mandatory) → HF token → apps → LLM slots
+    → NPU intro → capability slots → ComfyUI/gen → REVIEW gate → apply →
+    sentinel → verify. Choosing 'No' at the REVIEW gate writes NOTHING."""
+    # 1. Platform Report
     _draw("welcome", "Detected hardware shown on the right.", hw)
     Prompt.ask("Press Enter to begin", default="")
 
-    _draw("storage", f"Default: {storage_dir}", hw)
-    storage_dir = Prompt.ask("Model storage directory", default=storage_dir)
+    # 2. Network shape (bind / mDNS / origins)
+    network = _step_network(hw)
 
+    # 3. Model store — MANDATORY + validated (gates every download)
+    storage_dir = _step_store(hw, storage_dir)
+
+    # 4. Hugging Face token (optional)
+    hf_token = _step_hf_token(hw)
+
+    # 5. Apps / agents (gates which LLM slots are offered — spec §6.3)
     state = {e.id: e.default_enabled for e in EXTENSIONS}
     _toggle_extensions(state, hw)
 
     steps = plan_steps(extensions=state, npu_present=bool(hw.npu.present), npu_ok=npu_healthy(hw))
+
+    # 6. LLM slots (main + coder)
     slots: list[SlotSelection] = []
     if "main" in steps:
         name, port = _SETUP_SLOTS["chat"]
@@ -220,6 +515,8 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
         s = _provision_slot("agent", "coder", hw, name, port, prefer_coder=True)
         if s:
             slots.append(s)
+
+    # 7. NPU intro (only when present + healthy)
     npu_opt_in = False
     if "npu" in steps:
         # Present + healthy: offer to route the NPU trio.
@@ -238,6 +535,8 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
             hw,
         )
         Prompt.ask("Press Enter to continue", default="")
+
+    # 8. Capability slots (embed/rerank/tts/vision, +stt when the NPU trio is on)
     if "capabilities" in steps:
         # STT is NPU-only (derive_device returns None without an NPU), so only
         # offer it when the NPU trio is on.
@@ -250,12 +549,28 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
             if s:
                 slots.append(s)
 
-    sel = Selections(storage_dir=storage_dir, slots=slots, extensions=state, npu_opt_in=npu_opt_in)
-    _draw("review", _review_table(sel), hw)
+    # 9. ComfyUI / image+video generation — gen.mode drives the comfyui extension
+    gen_mode = _step_gen(hw)
+    state["comfyui"] = gen_mode in _GEN_MODES_ON
+    comfyui_defaults = _comfyui_defaults() if gen_mode in _GEN_MODES_ON else ()
+
+    plan = SetupPlan(
+        hw=hw,
+        network=network,
+        storage_dir=storage_dir,
+        hf_token=hf_token,
+        extensions=state,
+        slots=slots,
+        npu_opt_in=npu_opt_in,
+        gen_mode=gen_mode,
+        comfyui_defaults=comfyui_defaults,
+    )
+
+    # 10. REVIEW gate — accurate 'will create' table; 'No' writes NOTHING
+    _draw("review", render_review(plan), hw)
     if not Confirm.ask("Build now?", default=True):
-        _con.print("Aborted — nothing was written.")
+        _con.print("Aborted — nothing was written (no slots, sentinel, or downloads).")
         return
 
-    from hal0.cli.setup_install import run_install  # Task 4.1 (lazy — not yet present)
-
-    asyncio.run(run_install(sel, hw))
+    # 11-13. apply → sentinel → verify
+    _apply(plan)

--- a/tests/cli/test_setup_command.py
+++ b/tests/cli/test_setup_command.py
@@ -1,5 +1,23 @@
-from hal0.cli.setup_command import _api_reachable, build_auto_selections
+from typer.testing import CliRunner
+
+from hal0.cli.setup_command import _api_reachable, app, build_auto_selections
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+
+
+def test_headless_interactive_prints_stage2_command(monkeypatch):
+    """Two-stage handoff (issue #1112): a piped / non-TTY `hal0 setup` (no
+    --auto) must NOT launch rich prompts — it prints the command to run and
+    exits 0 without probing hardware or applying anything."""
+    monkeypatch.delenv("HAL0_FORCE_INTERACTIVE", raising=False)
+
+    def boom(*a, **k):  # would blow up if the probe were reached
+        raise AssertionError("hardware probe should not run on the headless guard path")
+
+    monkeypatch.setattr("hal0.cli.setup_command.HardwareProbe", boom)
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 0
+    assert "hal0 setup" in result.output
+    assert "--auto" in result.output
 
 
 def _hw(ram_gb=96):

--- a/tests/cli/test_setup_ui.py
+++ b/tests/cli/test_setup_ui.py
@@ -140,3 +140,154 @@ def test_present_but_broken_npu_shows_remedy_not_offer():
 
 def test_pane_copy_has_npu_broken_remedy():
     assert "npu_broken" in PANE_COPY and PANE_COPY["npu_broken"].body
+
+
+# ── WS-F guided flow (issue #1112) ──────────────────────────────────────────
+
+
+def _hw(npu=False, validated=None, ram_gb=96):
+    from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
+
+    return HardwareInfo(
+        platform="strix-halo",
+        ram_mb=ram_gb * 1024,
+        unified_memory_mb=ram_gb * 1024,
+        gpus=[GPUInfo(vendor="amd", vram_mb=512, compute_capable=True)],
+        npu=NPUInfo(present=npu, validated=validated),
+    )
+
+
+def test_pane_copy_has_new_flow_steps():
+    for key in ("network", "hf", "gen", "verify"):
+        assert key in PANE_COPY and PANE_COPY[key].body
+
+
+def test_validate_store_gate():
+    from hal0.cli import setup_ui
+
+    ok, reason = setup_ui._validate_store("")
+    assert not ok and "required" in reason
+    ok, _ = setup_ui._validate_store("relative/path")
+    assert not ok  # must be absolute
+
+
+def test_validate_store_accepts_writable_dir(tmp_path):
+    from hal0.cli import setup_ui
+
+    ok, reason = setup_ui._validate_store(str(tmp_path))
+    assert ok and reason == ""
+
+
+def test_step_gen_mode_mapping(monkeypatch):
+    from hal0.cli import setup_ui
+
+    monkeypatch.setattr(setup_ui, "_draw", lambda *a, **k: None)
+    for pick, expected in (("1", "off"), ("2", "scaffold_only"), ("3", "scaffold_and_download")):
+        monkeypatch.setattr(setup_ui.Prompt, "ask", lambda *a, _p=pick, **k: _p)
+        assert setup_ui._step_gen(_hw()) == expected
+
+
+def test_port_issues_flags_duplicates_and_reserved(monkeypatch):
+    from hal0.cli import setup_ui
+    from hal0.install.orchestrate import SlotSelection
+
+    monkeypatch.setattr(setup_ui, "_port_in_use", lambda p: False)
+    dupes = setup_ui._port_issues(
+        [SlotSelection("chat", "chat", 9000, "m"), SlotSelection("embed", "embed", 9000, None)]
+    )
+    assert any("both claim it" in m for m in dupes)
+    reserved = setup_ui._port_issues([SlotSelection("chat", "chat", 8080, "m")])
+    assert any("reserved" in m for m in reserved)
+
+
+def test_setup_plan_selections_roundtrip():
+    from hal0.cli.setup_ui import NetworkChoice, SetupPlan
+    from hal0.install.orchestrate import SlotSelection
+
+    plan = SetupPlan(
+        hw=_hw(),
+        network=NetworkChoice("0.0.0.0", "box", None),
+        storage_dir="/srv/models",
+        hf_token="tok",
+        extensions={"openwebui": True, "comfyui": False},
+        slots=[SlotSelection("chat", "chat", 8081, "m1")],
+        npu_opt_in=False,
+        gen_mode="scaffold_only",
+        comfyui_defaults=(("txt2img", "sdxl"),),
+    )
+    sel = plan.selections()
+    assert sel.storage_dir == "/srv/models"
+    assert sel.comfyui_defaults == (("txt2img", "sdxl"),)
+    assert sel.extensions == {"openwebui": True, "comfyui": False}
+    assert [s.model_id for s in sel.slots] == ["m1"]
+
+
+def test_render_review_shows_slots_store_bind_and_download(monkeypatch):
+    from rich.console import Console
+
+    from hal0.cli import setup_ui
+    from hal0.cli.setup_ui import NetworkChoice, SetupPlan
+    from hal0.install.orchestrate import SlotSelection
+
+    monkeypatch.setattr(setup_ui, "_port_in_use", lambda p: False)
+    monkeypatch.setattr(setup_ui, "_free_space_gib", lambda p: 512.0)
+    monkeypatch.setattr(setup_ui, "_slot_size_gb", lambda mid: 4.0 if mid else 0.0)
+
+    plan = SetupPlan(
+        hw=_hw(),
+        network=NetworkChoice("0.0.0.0", "mybox", None),
+        storage_dir="/mnt/ai-models",
+        hf_token="tok",
+        extensions={"openwebui": True, "comfyui": True},
+        slots=[
+            SlotSelection("chat", "chat", 8081, "qwen3-4b"),
+            SlotSelection("embed", "embed", 8083, None),
+        ],
+        npu_opt_in=False,
+        gen_mode="scaffold_only",
+    )
+    con = Console(width=120, record=True)
+    con.print(setup_ui.render_review(plan))
+    text = con.export_text()
+    assert "/mnt/ai-models" in text and "512.0 GiB free" in text
+    assert "LAN (0.0.0.0)" in text and "mybox.local" in text
+    assert "qwen3-4b" in text and "8081" in text
+    assert "scaffold — choose later" in text  # the empty embed slot
+    assert "set" in text  # HF token
+    assert "~4.0 GB" in text  # total download
+
+
+def _stub_flow(monkeypatch, *, build: bool):
+    """Stub every interactive step so run_interactive is deterministic. Returns
+    a dict recording whether _apply ran."""
+    from hal0.cli import setup_ui
+    from hal0.cli.setup_ui import NetworkChoice
+
+    rec: dict = {"applied": None}
+    monkeypatch.setattr(setup_ui, "_draw", lambda *a, **k: None)
+    monkeypatch.setattr(setup_ui, "_step_network", lambda hw: NetworkChoice("127.0.0.1", "h", None))
+    monkeypatch.setattr(setup_ui, "_step_store", lambda hw, d: "/var/lib/hal0/models")
+    monkeypatch.setattr(setup_ui, "_step_hf_token", lambda hw: None)
+    monkeypatch.setattr(setup_ui, "_toggle_extensions", lambda state, hw: None)
+    monkeypatch.setattr(setup_ui, "_provision_slot", lambda *a, **k: None)
+    monkeypatch.setattr(setup_ui, "_step_gen", lambda hw: "off")
+    monkeypatch.setattr(setup_ui.Confirm, "ask", lambda *a, **k: build)
+    monkeypatch.setattr(setup_ui.Prompt, "ask", lambda *a, **k: "")
+    monkeypatch.setattr(setup_ui, "_apply", lambda plan: rec.__setitem__("applied", plan))
+    return setup_ui, rec
+
+
+def test_review_no_writes_nothing(monkeypatch):
+    # Build? == No → _apply is never called (no slots, sentinel, or pulls).
+    setup_ui, rec = _stub_flow(monkeypatch, build=False)
+    setup_ui.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
+    assert rec["applied"] is None
+
+
+def test_review_yes_applies_plan(monkeypatch):
+    # Build? == Yes → _apply runs with the resolved plan.
+    setup_ui, rec = _stub_flow(monkeypatch, build=True)
+    setup_ui.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
+    assert rec["applied"] is not None
+    assert rec["applied"].storage_dir == "/var/lib/hal0/models"
+    assert rec["applied"].gen_mode == "off"


### PR DESCRIPTION
Closes #1112

Extends the interactive `hal0 setup` flow (`setup_ui.run_interactive`) into the full WS-F guided Stage-2 decision tree, adds the accurate REVIEW gate, and wires the two-stage (Stage-1 → Stage-2) handoff. This is a UX-reviewed HITL issue — the flow + a rendered sample table are below.

## Flow walkthrough (in order)

Each step draws the two-column shell (step body + context pane) and returns a resolved choice. Building the plan writes **nothing**.

1. **Platform Report** — detected hardware in the context pane; Enter to begin.
2. **Network shape** — bind loopback (`127.0.0.1`) vs LAN (`0.0.0.0`), advertised hostname (mDNS + origins), optional reverse-proxy URL. Resolved through the existing `network_env()` (#1099) — the *same* derivation the installer uses.
3. **Model store (MANDATORY, validated)** — loops until an absolute, writable path is entered (validated via `describe_store_state`, #1100). This gates every download.
4. **HF token** — optional read token for gated pulls; an `HF_TOKEN` already in the environment wins and is kept without re-prompting.
5. **Apps / agents** — OWUI / Hermes / Pi toggle (gates which LLM slots are offered, per spec §6.3).
6. **LLM slots (main + coder)** — `suggest_models(..., npu_opt_in)` picks, hw-budgeted; pick / scaffold-empty / skip.
7. **NPU intro** — offered **only when present AND healthy** (`npu_healthy(hw)`, #1109); a present-but-broken NPU gets the `npu_broken` remedy step instead of the enable offer.
8. **Capability slots** — embed / rerank / tts / vision (+ stt when the NPU trio is on).
9. **ComfyUI / gen** — `off | scaffold_only [DEFAULT] | scaffold_and_download`; `gen.mode` drives the `comfyui` extension + `comfyui_defaults`.
10. **REVIEW "will create" table** — see below.
11. **Build?** → **apply** (`apply_setup` via `run_install`, #1101) → **first-run sentinel** (`mark_first_run_done`) → **verify report**.

## REVIEW table (accurate "will create")

`render_review(plan)` reflects the resolved `Selections` exactly — real slots, live port checks, derived device/profile, per-model + total download size, store + free space, bind, origin count, HF-token state, gen mode:

```
  Model store   /mnt/ai-models  (512.0 GiB free)
  Bind          LAN (0.0.0.0)
  mDNS          mybox.local
  Origins       7 allowed
  HF token      set
  Gen           scaffold_only

                         Slots to create
 ┏━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━━━━━┓
 ┃ Name  ┃ Port ┃ Model                   ┃ Device  ┃ Profile ┃ Size ┃ Port st. ┃
 ┡━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━━━━━┩
 │ chat  │ 8081 │ qwen3-4b                │ gpu-rocm│ rocm    │ 4.0GB│ free     │
 │ embed │ 8083 │ (scaffold — choose …)   │ gpu-rocm│ embed   │  —   │ free     │
 └───────┴──────┴─────────────────────────┴─────────┴─────────┴──────┴──────────┘
 Apps/agents: openwebui, comfyui
 Total download: ~4.0 GB

 Nothing has been written yet.
```

Port collisions (duplicates within the plan, reserved hal0 ports 8080/3001, and ports already bound on the host via `_port_in_use`) are surfaced as a red "Port conflicts" block.

## "No" writes NOTHING

The apply step (`_apply`) is the only writer. It performs the network/HF env exports, `[models].store` persistence, `apply_setup`, and the sentinel. `run_interactive` calls `_apply` **only after** `Confirm("Build now?")` returns true — a "No" prints `Aborted — nothing was written` and returns before any slot, sentinel, env export, or pull. Covered by `test_review_no_writes_nothing` (asserts `_apply` never runs) and `test_review_yes_applies_plan`.

## Stage-1 → Stage-2 handoff

- **Python** (`setup_command`): when interactive setup is requested (no `--auto` / `--answers` / `--plan` / `--emit-answers`) but stdin is **not** a TTY, it prints the Stage-2 command (`hal0 setup` / `hal0 setup --auto`) and exits instead of EOF-ing on rich prompts. `HAL0_FORCE_INTERACTIVE` bypasses the guard.
- **install.sh** (localized tail block only): on a real terminal it offers to launch `hal0 setup` inline (reads `/dev/tty`, default Yes); on a piped/headless `curl … | bash` run it prints the command. Does not touch the network-seed / GPU-gate / platform-gate blocks.

## Tests

New: store-validation gate, `_step_gen` mode mapping, `_port_issues` (dupes + reserved), `SetupPlan.selections` round-trip, `render_review` accuracy, No-writes-nothing / yes-applies, and the headless Stage-2 command-print guard.

## DoD (CI parity)

- `ruff format src tests` — 646 files unchanged
- `ruff check src tests` — All checks passed
- `ruff format --check src tests` — 646 files already formatted
- `pytest` — 4786 passed; the 14 failures + 1 error are all pre-existing box-noise (hermes venv, comfyui phase4, proxmox `test_pve`, container spec dispatch, config-urls-proxy, models-preview, settings-store, openwebui prewire) — confirmed failing on a clean tree via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
