### PR TITLE
installer-setup WS-K: hal0 doctor --verify report card (checks + live URLs + doc links), auto-run at setup end

### DIFF
--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -98,6 +98,11 @@ def _locate_preflight() -> Path | None:
 @app.callback(invoke_without_command=True)
 def doctor(
     ctx: typer.Context,
+    verify: bool = typer.Option(
+        False,
+        "--verify",
+        help="Render the post-setup report card (checks + live URLs + doc links) against the live API.",
+    ),
     plain: bool = typer.Option(
         False,
         "--plain",
@@ -109,13 +114,23 @@ def doctor(
         help="Space-separated TCP ports for the port collision check (default: '8080 3001').",
     ),
 ) -> None:
-    """Re-run pre-flight checks (systemd, python, docker, disk, ports)."""
+    """Re-run pre-flight checks (systemd, python, docker, disk, ports).
+
+    ``--verify`` instead renders the WS-K report card: a pass/warn/fail summary
+    over the live health seams (API, runners, capability slots, hindsight,
+    OpenWebUI, Hermes) plus the computed URLs + help links. Non-blocking; exits
+    2 only on a critical (no reachable URL / zero healthy runners).
+    """
     # When a sub-command (e.g. ``toolbox-pull``) is invoked, Typer still
     # calls the callback first. Bail out without running preflight so the
     # sub-command handles the request on its own — preflight is the
     # "default" only when no sub-command is given.
     if ctx.invoked_subcommand is not None:
         return
+    if verify:
+        from hal0.cli.doctor_verify import run_verify
+
+        raise typer.Exit(run_verify(console=console))
     preflight = _locate_preflight()
     if preflight is None:
         console.print(

--- a/src/hal0/cli/doctor_verify.py
+++ b/src/hal0/cli/doctor_verify.py
@@ -1,0 +1,385 @@
+"""``hal0 doctor --verify`` — the post-setup report card (WS-K, issue #1114).
+
+A single reusable verb that composes the *already-existing* health seams into
+one visual pass/warn/fail report card, then prints the live URLs the operator
+should open next plus the canonical help links.
+
+Design: this module NEVER re-implements a check. Every row is sourced from a
+running-hal0 API endpoint that already aggregates the underlying probe::
+
+    check            source endpoint            underlying seam
+    ────────────────────────────────────────────────────────────────────────
+    Dashboard/API    GET /api/health            API liveness (installer hello)
+    mDNS (.local)    GET /api/config/urls host  socket resolution of the host
+    Runners          GET /api/health/system     SlotManager.list() errored dots
+    Capability slots GET /api/capabilities      CapabilityOrchestrator.get_state
+    Hindsight/banks  GET /api/memory/engine     :9177 /version + /v1/.../banks
+    OpenWebUI        GET /api/services/health    loopback :3001 /health probe
+    Hermes           GET /api/services/health   `systemctl is-active` hal0-agent
+
+The report is deliberately NON-BLOCKING: a warn never fails an install. Only two
+conditions are *critical* (rendered red): no reachable URL (the API/dashboard is
+down) and zero healthy runner slots. The guided setup auto-runs :func:`run_verify`
+at the very end; it is also runnable standalone anytime via ``hal0 doctor --verify``.
+"""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from typing import Any
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+# ── canonical help links (static — the "what next" footer) ────────────────────
+FIRST_RUN_GUIDE_URL = "https://hal0.dev/first-run-guide"
+DOCS_URL = "https://hal0.dev/docs/"
+DISCORD_URL = "https://discord.gg/7M4y6dcUyq"
+WEBSITE_URL = "https://hal0.dev"
+
+# Status vocabulary. A "fail" row that is also ``critical`` renders red and
+# drives the overall verdict; a plain "fail"/"warn" is amber and never blocks.
+_PASS = "pass"
+_WARN = "warn"
+_FAIL = "fail"
+
+
+@dataclass(frozen=True)
+class Check:
+    """One report-card row.
+
+    ``critical`` marks the two install-defining conditions (no reachable URL,
+    zero healthy runners). A critical ``fail`` is the only thing that flips the
+    overall verdict to "critical"; every other ``fail``/``warn`` is advisory.
+    """
+
+    key: str
+    label: str
+    status: str  # _PASS | _WARN | _FAIL
+    detail: str
+    critical: bool = False
+
+
+# ── per-check classifiers (pure — take parsed JSON, return a Check) ────────────
+
+
+def check_api(health: dict[str, Any] | None) -> Check:
+    """API/dashboard reachable — the anchor critical (no reachable URL)."""
+    if health is None:
+        return Check(
+            "api",
+            "Dashboard / API",
+            _FAIL,
+            "unreachable — start it with `hal0 serve`",
+            critical=True,
+        )
+    version = health.get("version") if isinstance(health, dict) else None
+    detail = f"serving (v{version})" if version else "serving"
+    return Check("api", "Dashboard / API", _PASS, detail)
+
+
+def check_dns(urls: dict[str, Any] | None) -> Check:
+    """mDNS/.local resolvability of the advertised host (warn-only).
+
+    A ``.local`` name that does not resolve is common on bridged LXC / VLANs
+    where multicast is filtered — a heads-up (use the LAN IP), never a blocker.
+    """
+    host = _url_host(urls.get("api")) if isinstance(urls, dict) else None
+    if not host:
+        return Check("dns", "mDNS (.local)", _WARN, "no host advertised yet")
+    if not host.endswith(".local"):
+        # A plain IP / real DNS name — nothing mDNS-specific to verify.
+        return Check("dns", "Hostname", _PASS, f"{host} (no mDNS needed)")
+    try:
+        socket.gethostbyname(host)
+    except OSError:
+        return Check(
+            "dns",
+            "mDNS (.local)",
+            _WARN,
+            f"{host} does not resolve here (multicast filtered? use the LAN IP)",
+        )
+    return Check("dns", "mDNS (.local)", _PASS, f"{host} resolves")
+
+
+def check_runners(system: dict[str, Any] | None) -> Check:
+    """Runner slots healthy — the second critical (zero healthy slots).
+
+    Sourced from ``/api/health/system`` → ``checks.slot_manager`` which already
+    walks ``SlotManager.list()`` and reports the total + the errored slot names.
+    """
+    if system is None:
+        return Check("runners", "Runners", _FAIL, "health/system unreachable", critical=True)
+    sm = (system.get("checks") or {}).get("slot_manager") if isinstance(system, dict) else None
+    if not isinstance(sm, dict) or "slots" not in sm:
+        return Check("runners", "Runners", _FAIL, "slot manager not wired", critical=True)
+    total = int(sm.get("slots") or 0)
+    errored = list(sm.get("errored") or [])
+    healthy = total - len(errored)
+    if healthy <= 0:
+        detail = "no healthy runner slots" if total else "no runner slots configured yet"
+        return Check("runners", "Runners", _FAIL, detail, critical=True)
+    if errored:
+        return Check(
+            "runners",
+            "Runners",
+            _WARN,
+            f"{healthy}/{total} healthy — errored: {', '.join(errored)}",
+        )
+    return Check("runners", "Runners", _PASS, f"{healthy}/{total} slot(s) healthy")
+
+
+def check_capabilities(capabilities: dict[str, Any] | None) -> Check:
+    """Capability slots (embed/voice/img) configured — advisory."""
+    if capabilities is None:
+        return Check("capabilities", "Capability slots", _WARN, "unreachable")
+    selections = capabilities.get("selections") if isinstance(capabilities, dict) else None
+    if not isinstance(selections, dict) or not selections:
+        return Check("capabilities", "Capability slots", _WARN, "none configured")
+    active = [k for k, v in selections.items() if v]
+    if not active:
+        return Check("capabilities", "Capability slots", _WARN, "none active")
+    return Check(
+        "capabilities",
+        "Capability slots",
+        _PASS,
+        f"{len(active)} active: {', '.join(sorted(active))}",
+    )
+
+
+def check_memory(memory: dict[str, Any] | None) -> Check:
+    """Hindsight memory engine + banks — advisory (memory is optional)."""
+    if memory is None:
+        return Check("memory", "Hindsight / banks", _WARN, "memory admin unreachable")
+    if not isinstance(memory, dict) or memory.get("engine") is None:
+        return Check("memory", "Hindsight / banks", _PASS, "disabled (no memory engine)")
+    if not memory.get("reachable"):
+        return Check("memory", "Hindsight / banks", _WARN, "engine enabled but :9177 unreachable")
+    banks = memory.get("banks_total")
+    detail = f"reachable — {banks} bank(s)" if banks is not None else "reachable"
+    return Check("memory", "Hindsight / banks", _PASS, detail)
+
+
+def _service_check(services: dict[str, Any] | None, sid: str, label: str) -> Check:
+    """Shared classifier for the two companion services (OWUI, Hermes)."""
+    if services is None:
+        return Check(sid, label, _WARN, "services health unreachable")
+    entries = services.get("services") if isinstance(services, dict) else None
+    entry = (
+        next((s for s in entries if isinstance(s, dict) and s.get("id") == sid), None)
+        if isinstance(entries, list)
+        else None
+    )
+    if entry is None:
+        return Check(sid, label, _WARN, "not reported")
+    if entry.get("up"):
+        return Check(sid, label, _PASS, str(entry.get("detail") or "up"))
+    return Check(sid, label, _WARN, str(entry.get("detail") or "down"))
+
+
+def check_openwebui(services: dict[str, Any] | None) -> Check:
+    return _service_check(services, "openwebui", "OpenWebUI")
+
+
+def check_hermes(services: dict[str, Any] | None) -> Check:
+    return _service_check(services, "hermes", "Hermes")
+
+
+def build_checks(
+    *,
+    health: dict[str, Any] | None,
+    urls: dict[str, Any] | None,
+    system: dict[str, Any] | None,
+    capabilities: dict[str, Any] | None,
+    memory: dict[str, Any] | None,
+    services: dict[str, Any] | None,
+) -> list[Check]:
+    """Compose the full ordered check suite from the fetched payloads (pure)."""
+    return [
+        check_api(health),
+        check_dns(urls),
+        check_runners(system),
+        check_capabilities(capabilities),
+        check_memory(memory),
+        check_openwebui(services),
+        check_hermes(services),
+    ]
+
+
+def overall_status(checks: list[Check]) -> str:
+    """Roll the rows up to ``ok`` | ``warn`` | ``critical``.
+
+    ``critical`` iff any critical row failed (the only blocking-*looking* state,
+    though even this never raises during auto-run). ``warn`` if any non-critical
+    fail/warn is present. ``ok`` when every row passed.
+    """
+    if any(c.status == _FAIL and c.critical for c in checks):
+        return "critical"
+    if any(c.status in (_FAIL, _WARN) for c in checks):
+        return "warn"
+    return "ok"
+
+
+# ── rendering ──────────────────────────────────────────────────────────────────
+
+_BADGE = {
+    _PASS: "[green]✔ PASS[/green]",
+    _WARN: "[yellow]▲ WARN[/yellow]",
+    _FAIL: "[red]✖ FAIL[/red]",
+}
+_CRIT_BADGE = "[bold red]✖ FAIL[/bold red]"
+
+
+def _url_host(url: Any) -> str | None:
+    """Extract the bare hostname from an ``http(s)://host[:port]`` URL."""
+    if not isinstance(url, str) or "://" not in url:
+        return None
+    rest = url.split("://", 1)[1]
+    hostport = rest.split("/", 1)[0]
+    if hostport.startswith("["):  # IPv6 literal
+        end = hostport.find("]")
+        return hostport[1:end] if end > 0 else hostport
+    return hostport.rsplit(":", 1)[0] if ":" in hostport else hostport
+
+
+def _lan_ip() -> str | None:
+    """Best-effort primary LAN IPv4 (no traffic sent — UDP connect is a no-op)."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        return None
+
+
+def render_report(console: Console, checks: list[Check], urls: dict[str, Any] | None) -> None:
+    """Print the report card, the live URLs, and the help-link footer."""
+    verdict = overall_status(checks)
+    border = {"ok": "green", "warn": "yellow", "critical": "red"}[verdict]
+    title = {
+        "ok": "[bold green]hal0 is ready ✔[/bold green]",
+        "warn": "[bold yellow]hal0 is up — with notes ▲[/bold yellow]",
+        "critical": "[bold red]hal0 needs attention ✖[/bold red]",
+    }[verdict]
+
+    table = Table.grid(padding=(0, 2))
+    table.add_column(justify="left", width=8)
+    table.add_column(style="bold", width=18)
+    table.add_column()
+    for c in checks:
+        badge = _CRIT_BADGE if (c.status == _FAIL and c.critical) else _BADGE[c.status]
+        table.add_row(badge, c.label, c.detail)
+
+    console.print(Panel(table, title=title, border_style=border, title_align="left"))
+
+    _render_urls(console, urls)
+    _render_links(console)
+
+
+def _render_urls(console: Console, urls: dict[str, Any] | None) -> None:
+    """Live URLs block — computed dashboard/chat + mDNS + LAN IP."""
+    lines: list[Text] = []
+    api_url = urls.get("api") if isinstance(urls, dict) else None
+    if api_url:
+        lines.append(Text.from_markup(f"  Dashboard    [cyan]{api_url}[/cyan]"))
+        # A LAN-IP alternative for when .local doesn't resolve on the client.
+        host = _url_host(api_url)
+        lan = _lan_ip()
+        if lan and host and lan != host:
+            lan_url = api_url.replace(host, lan, 1)
+            lines.append(Text.from_markup(f"  Dashboard IP [cyan]{lan_url}[/cyan]"))
+    if isinstance(urls, dict) and urls.get("openwebui_enabled") and urls.get("openwebui"):
+        lines.append(Text.from_markup(f"  Chat (OWUI)  [cyan]{urls['openwebui']}[/cyan]"))
+    if isinstance(urls, dict) and urls.get("hermes_enabled") and urls.get("hermes"):
+        lines.append(Text.from_markup(f"  Hermes       [cyan]{urls['hermes']}[/cyan]"))
+    if isinstance(urls, dict) and urls.get("comfyui"):
+        lines.append(Text.from_markup(f"  ComfyUI      [cyan]{urls['comfyui']}[/cyan]"))
+
+    if not lines:
+        lines.append(Text("  (no URLs — the API is not reachable)", style="dim"))
+    console.print("\n[bold]Open hal0[/bold]")
+    for line in lines:
+        console.print(line)
+
+
+def _render_links(console: Console) -> None:
+    """Static help-link footer."""
+    console.print("\n[bold]Next steps & help[/bold]")
+    console.print(f"  First-run guide  [cyan]{FIRST_RUN_GUIDE_URL}[/cyan]")
+    console.print(f"  Docs             [cyan]{DOCS_URL}[/cyan]")
+    console.print(f"  Discord          [cyan]{DISCORD_URL}[/cyan]")
+    console.print(f"  Website          [cyan]{WEBSITE_URL}[/cyan]")
+
+
+# ── orchestration (fetches + render; never raises on network failure) ──────────
+
+
+def _safe_get(path: str, base: str | None) -> dict[str, Any] | None:
+    """GET ``path`` and return the parsed dict, or ``None`` on any failure.
+
+    Tolerant by design — a down subsystem yields ``None`` and the classifier
+    turns that into a warn/fail row instead of crashing the report.
+    """
+    from hal0.cli._shared import CliApiError, api_get
+
+    try:
+        data = api_get(path, base=base)
+    except CliApiError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def gather_payloads(base: str | None = None) -> dict[str, dict[str, Any] | None]:
+    """Fetch every source endpoint the report card composes (tolerant)."""
+    return {
+        "health": _safe_get("/api/health", base),
+        "urls": _safe_get("/api/config/urls", base),
+        "system": _safe_get("/api/health/system", base),
+        "capabilities": _safe_get("/api/capabilities", base),
+        "memory": _safe_get("/api/memory/engine", base),
+        "services": _safe_get("/api/services/health", base),
+    }
+
+
+def run_verify(*, console: Console | None = None, base: str | None = None) -> int:
+    """Fetch → classify → render. Returns an exit code; NEVER raises.
+
+    Exit-code contract (for standalone scripting; the setup auto-run ignores it):
+      0 — ok or warn (non-blocking)
+      2 — critical (no reachable URL or zero healthy runners)
+    """
+    con = console or Console()
+    payloads = gather_payloads(base)
+    checks = build_checks(
+        health=payloads["health"],
+        urls=payloads["urls"],
+        system=payloads["system"],
+        capabilities=payloads["capabilities"],
+        memory=payloads["memory"],
+        services=payloads["services"],
+    )
+    render_report(con, checks, payloads["urls"])
+    return 2 if overall_status(checks) == "critical" else 0
+
+
+__all__ = [
+    "Check",
+    "build_checks",
+    "check_api",
+    "check_capabilities",
+    "check_dns",
+    "check_hermes",
+    "check_memory",
+    "check_openwebui",
+    "check_runners",
+    "gather_payloads",
+    "overall_status",
+    "render_report",
+    "run_verify",
+]

--- a/src/hal0/cli/setup_ui.py
+++ b/src/hal0/cli/setup_ui.py
@@ -574,3 +574,13 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
 
     # 11-13. apply → sentinel → verify
     _apply(plan)
+
+    # 14. WS-K report card (#1114): pass/warn/fail over the live health seams +
+    # computed URLs + help links. A SINGLE localized, best-effort call — the
+    # report is non-blocking, so a failure here must never abort a good setup.
+    try:
+        from hal0.cli.doctor_verify import run_verify
+
+        run_verify(console=_con)
+    except Exception as exc:  # pragma: no cover — defensive, never fail setup
+        _con.print(f"[dim]setup verify skipped ({exc})[/dim]")

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -67,7 +67,7 @@ def test_doctor_success_propagates_exit_code(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(ctx=_fake_ctx(), plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), verify=False, plain=False, ports=None)
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -84,7 +84,7 @@ def test_doctor_failure_propagates_exit_code(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(ctx=_fake_ctx(), plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), verify=False, plain=False, ports=None)
 
     assert _exit_code(exc) == 1
     captured = capfd.readouterr()
@@ -96,7 +96,7 @@ def test_doctor_missing_script_exits_2(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", "/definitely/not/a/real/path.sh")
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(ctx=_fake_ctx(), plain=False, ports=None)
+        doctor(ctx=_fake_ctx(), verify=False, plain=False, ports=None)
 
     assert _exit_code(exc) == 2
 
@@ -114,7 +114,7 @@ def test_doctor_forwards_plain_flag(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(ctx=_fake_ctx(), plain=True, ports=None)
+        doctor(ctx=_fake_ctx(), verify=False, plain=True, ports=None)
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -134,7 +134,7 @@ def test_doctor_forwards_ports_option(
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
 
     with pytest.raises(typer.Exit) as exc:
-        doctor(ctx=_fake_ctx(), plain=False, ports="9090 9091")
+        doctor(ctx=_fake_ctx(), verify=False, plain=False, ports="9090 9091")
 
     assert _exit_code(exc) == 0
     captured = capfd.readouterr()
@@ -387,6 +387,6 @@ def test_toolbox_pull_invoked_subcommand_skips_preflight(
 
     # Doctor callback should return None silently (no typer.Exit) when a
     # sub-command is present.
-    result = doctor(ctx=_CtxWithSubcommand(), plain=False, ports=None)  # type: ignore[arg-type]
+    result = doctor(ctx=_CtxWithSubcommand(), verify=False, plain=False, ports=None)  # type: ignore[arg-type]
     assert result is None
     assert "should-not-run" not in capfd.readouterr().out

--- a/tests/cli/test_doctor_verify.py
+++ b/tests/cli/test_doctor_verify.py
@@ -1,0 +1,243 @@
+"""Tests for ``hal0 doctor --verify`` — the WS-K report card (issue #1114).
+
+The classifiers are pure functions over parsed API payloads, so we exercise
+each check + the roll-up + the render + the tolerant orchestration without a
+live API (the fetch seam is monkeypatched).
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+import typer
+from rich.console import Console
+
+from hal0.cli import doctor_verify as dv
+from hal0.cli.doctor_commands import doctor
+
+# ── individual classifiers ─────────────────────────────────────────────────────
+
+
+def test_check_api_pass_and_critical_fail() -> None:
+    ok = dv.check_api({"status": "ok", "version": "0.9.1"})
+    assert ok.status == "pass" and not ok.critical and "0.9.1" in ok.detail
+
+    down = dv.check_api(None)
+    assert down.status == "fail" and down.critical is True
+
+
+def test_check_runners_zero_healthy_is_critical() -> None:
+    # slots present but ALL errored → zero healthy → critical fail
+    payload = {"checks": {"slot_manager": {"ok": False, "slots": 2, "errored": ["a", "b"]}}}
+    c = dv.check_runners(payload)
+    assert c.status == "fail" and c.critical is True
+
+    # no slots configured at all → still critical (zero healthy)
+    c0 = dv.check_runners({"checks": {"slot_manager": {"ok": True, "slots": 0, "errored": []}}})
+    assert c0.status == "fail" and c0.critical is True
+
+
+def test_check_runners_partial_errored_is_warn_not_critical() -> None:
+    payload = {"checks": {"slot_manager": {"ok": False, "slots": 3, "errored": ["b"]}}}
+    c = dv.check_runners(payload)
+    assert c.status == "warn" and not c.critical and "2/3" in c.detail
+
+
+def test_check_runners_all_healthy_pass() -> None:
+    payload = {"checks": {"slot_manager": {"ok": True, "slots": 2, "errored": []}}}
+    c = dv.check_runners(payload)
+    assert c.status == "pass" and "2/2" in c.detail
+
+
+def test_check_runners_unreachable_is_critical() -> None:
+    assert dv.check_runners(None).critical is True
+
+
+def test_check_dns_local_resolves_and_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dv.socket, "gethostbyname", lambda h: "192.0.2.1")
+    ok = dv.check_dns({"api": "http://hal0.local:8080"})
+    assert ok.status == "pass" and not ok.critical
+
+    def _boom(_h: str) -> str:
+        raise OSError("no mdns")
+
+    monkeypatch.setattr(dv.socket, "gethostbyname", _boom)
+    warn = dv.check_dns({"api": "http://hal0.local:8080"})
+    assert warn.status == "warn" and not warn.critical  # never blocks
+
+
+def test_check_dns_plain_ip_is_pass_no_mdns() -> None:
+    c = dv.check_dns({"api": "http://192.168.1.10:8080"})
+    assert c.status == "pass" and "no mDNS" in c.detail
+
+
+def test_check_capabilities_active_vs_none() -> None:
+    active = dv.check_capabilities({"selections": {"embed": {"x": 1}, "voice": {}}})
+    assert active.status == "pass" and "embed" in active.detail
+    assert dv.check_capabilities({"selections": {}}).status == "warn"
+    assert dv.check_capabilities(None).status == "warn"
+
+
+def test_check_memory_states() -> None:
+    assert dv.check_memory({"engine": None}).status == "pass"  # disabled is fine
+    assert dv.check_memory({"engine": "hindsight", "reachable": False}).status == "warn"
+    ok = dv.check_memory({"engine": "hindsight", "reachable": True, "banks_total": 3})
+    assert ok.status == "pass" and "3 bank" in ok.detail
+
+
+def test_service_checks_up_and_down() -> None:
+    services = {
+        "services": [
+            {"id": "openwebui", "up": True, "detail": "reachable — /health ok"},
+            {"id": "hermes", "up": False, "detail": "systemd unit inactive or absent"},
+        ]
+    }
+    assert dv.check_openwebui(services).status == "pass"
+    hermes = dv.check_hermes(services)
+    assert hermes.status == "warn" and not hermes.critical  # optional → never critical
+
+
+# ── roll-up ─────────────────────────────────────────────────────────────────────
+
+
+def test_overall_status_precedence() -> None:
+    crit = dv.build_checks(
+        health=None,  # critical fail
+        urls=None,
+        system={"checks": {"slot_manager": {"slots": 1, "errored": []}}},
+        capabilities={"selections": {"embed": {"x": 1}}},
+        memory={"engine": None},
+        services={"services": []},
+    )
+    assert dv.overall_status(crit) == "critical"
+
+    warn = dv.build_checks(
+        health={"version": "0.9.1"},
+        urls={"api": "http://192.168.1.10:8080"},
+        system={"checks": {"slot_manager": {"slots": 1, "errored": []}}},
+        capabilities={"selections": {}},  # warn
+        memory={"engine": None},
+        services={"services": [{"id": "openwebui", "up": True}, {"id": "hermes", "up": True}]},
+    )
+    assert dv.overall_status(warn) == "warn"
+
+    ok = dv.build_checks(
+        health={"version": "0.9.1"},
+        urls={"api": "http://192.168.1.10:8080"},
+        system={"checks": {"slot_manager": {"slots": 2, "errored": []}}},
+        capabilities={"selections": {"embed": {"x": 1}}},
+        memory={"engine": None},
+        services={"services": [{"id": "openwebui", "up": True}, {"id": "hermes", "up": True}]},
+    )
+    assert dv.overall_status(ok) == "ok"
+
+
+# ── render + orchestration ──────────────────────────────────────────────────────
+
+
+def _render_to_str(checks: list[dv.Check], urls: dict | None) -> str:
+    buf = io.StringIO()
+    con = Console(file=buf, force_terminal=False, width=100)
+    dv.render_report(con, checks, urls)
+    return buf.getvalue()
+
+
+def test_render_report_includes_urls_and_links() -> None:
+    checks = dv.build_checks(
+        health={"version": "0.9.1"},
+        urls={
+            "api": "http://hal0.local:8080",
+            "openwebui_enabled": True,
+            "openwebui": "http://hal0.local:3001",
+        },
+        system={"checks": {"slot_manager": {"slots": 1, "errored": []}}},
+        capabilities={"selections": {"embed": {"x": 1}}},
+        memory={"engine": None},
+        services={"services": [{"id": "openwebui", "up": True}, {"id": "hermes", "up": True}]},
+    )
+    out = _render_to_str(
+        checks,
+        {
+            "api": "http://hal0.local:8080",
+            "openwebui_enabled": True,
+            "openwebui": "http://hal0.local:3001",
+        },
+    )
+    assert "http://hal0.local:8080" in out
+    assert "http://hal0.local:3001" in out
+    assert dv.FIRST_RUN_GUIDE_URL in out
+    assert dv.DISCORD_URL in out
+    assert "PASS" in out
+
+
+def test_run_verify_returns_2_on_critical(monkeypatch: pytest.MonkeyPatch) -> None:
+    # API down → critical → exit 2, but no raise.
+    monkeypatch.setattr(
+        dv,
+        "gather_payloads",
+        lambda base=None: {
+            "health": None,
+            "urls": None,
+            "system": None,
+            "capabilities": None,
+            "memory": None,
+            "services": None,
+        },
+    )
+    buf = io.StringIO()
+    rc = dv.run_verify(console=Console(file=buf, force_terminal=False, width=100))
+    assert rc == 2
+    assert "unreachable" in buf.getvalue()
+
+
+def test_run_verify_returns_0_when_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        dv,
+        "gather_payloads",
+        lambda base=None: {
+            "health": {"version": "0.9.1"},
+            "urls": {"api": "http://192.168.1.10:8080"},
+            "system": {"checks": {"slot_manager": {"slots": 2, "errored": []}}},
+            "capabilities": {"selections": {"embed": {"x": 1}}},
+            "memory": {"engine": None},
+            "services": {
+                "services": [{"id": "openwebui", "up": True}, {"id": "hermes", "up": True}]
+            },
+        },
+    )
+    rc = dv.run_verify(console=Console(file=io.StringIO(), force_terminal=False, width=100))
+    assert rc == 0
+
+
+def test_gather_payloads_tolerates_api_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hal0.cli import _shared
+
+    def _boom(path: str, *, base=None, **kw):
+        raise _shared.CliApiError(f"{path} boom")
+
+    monkeypatch.setattr(_shared, "api_get", _boom)
+    payloads = dv.gather_payloads()
+    assert set(payloads) == {"health", "urls", "system", "capabilities", "memory", "services"}
+    assert all(v is None for v in payloads.values())
+
+
+# ── CLI wiring ──────────────────────────────────────────────────────────────────
+
+
+class _FakeCtx:
+    invoked_subcommand = None
+
+
+def test_doctor_verify_flag_invokes_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: dict[str, bool] = {}
+
+    def _fake_run_verify(*, console=None, base=None):
+        called["ran"] = True
+        return 2
+
+    monkeypatch.setattr("hal0.cli.doctor_verify.run_verify", _fake_run_verify)
+    with pytest.raises(typer.Exit) as exc:
+        doctor(ctx=_FakeCtx(), verify=True, plain=False, ports=None)  # type: ignore[arg-type]
+    assert called.get("ran") is True
+    assert exc.value.exit_code == 2

--- a/tests/cli/test_setup_ui.py
+++ b/tests/cli/test_setup_ui.py
@@ -274,6 +274,13 @@ def _stub_flow(monkeypatch, *, build: bool):
     monkeypatch.setattr(setup_ui.Confirm, "ask", lambda *a, **k: build)
     monkeypatch.setattr(setup_ui.Prompt, "ask", lambda *a, **k: "")
     monkeypatch.setattr(setup_ui, "_apply", lambda plan: rec.__setitem__("applied", plan))
+    # WS-K auto-run (#1114): stub the report card so run_interactive stays offline
+    # + deterministic; record that the hook fired.
+    from hal0.cli import doctor_verify
+
+    monkeypatch.setattr(
+        doctor_verify, "run_verify", lambda **k: rec.__setitem__("verified", True) or 0
+    )
     return setup_ui, rec
 
 
@@ -291,3 +298,17 @@ def test_review_yes_applies_plan(monkeypatch):
     assert rec["applied"] is not None
     assert rec["applied"].storage_dir == "/var/lib/hal0/models"
     assert rec["applied"].gen_mode == "off"
+
+
+def test_apply_auto_runs_verify_report(monkeypatch):
+    # WS-K (#1114): after a Yes-apply, the verify report card auto-runs.
+    setup_ui, rec = _stub_flow(monkeypatch, build=True)
+    setup_ui.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
+    assert rec.get("verified") is True
+
+
+def test_no_apply_skips_verify_report(monkeypatch):
+    # Aborting at the REVIEW gate must not auto-run the report either.
+    setup_ui, rec = _stub_flow(monkeypatch, build=False)
+    setup_ui.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
+    assert rec.get("verified") is None


### PR DESCRIPTION
## What

Adds a reusable `hal0 doctor --verify` verb — the WS-K post-setup **report card**. It composes the *already-existing* health seams into one visual pass/warn/fail summary, then prints the live URLs the operator should open next plus the canonical help links. The guided Stage-2 setup auto-runs it at the very end; it's also runnable standalone anytime.

**No check is re-implemented.** Every row is sourced from a running-hal0 API endpoint that already aggregates the underlying probe:

| Check | Source endpoint | Underlying seam |
|---|---|---|
| Dashboard / API | `GET /api/health` | API liveness (installer hello) |
| mDNS (.local) | `GET /api/config/urls` host | socket resolution of the advertised host |
| Runners | `GET /api/health/system` | `SlotManager.list()` errored dots |
| Capability slots | `GET /api/capabilities` | `CapabilityOrchestrator.get_state` |
| Hindsight / banks | `GET /api/memory/engine` | :9177 `/version` + `/v1/.../banks` |
| OpenWebUI | `GET /api/services/health` | loopback :3001 `/health` probe |
| Hermes | `GET /api/services/health` | `systemctl is-active` hal0-agent |

## Criticals vs warns

- **Critical (red, flips the verdict):** no reachable URL (API/dashboard down) or **zero healthy runner slots**. These are the only rows that can make the overall verdict `critical`.
- **Warn (amber):** everything else — a down OWUI/Hermes, memory disabled/unreachable, `.local` that won't resolve, no capability slots. **A warn never fails the install.**
- **Non-blocking:** the setup auto-run is a best-effort call wrapped in try/except and ignores the exit code. Standalone `hal0 doctor --verify` exits `2` only on a critical (for scripting), `0` on ok/warn.

## Auto-run hook

Single localized call at the very end of `run_interactive` in `src/hal0/cli/setup_ui.py` (step 14, after `_apply(plan)`). `_step_gen` / the gen path are untouched (owned by #1113).

## Sample report card (API down → critical)

```
╭─ hal0 needs attention ✖ ─────────────────────────────────────────────────────╮
│ ✖ FAIL    Dashboard / API     unreachable — start it with `hal0 serve`       │
│ ▲ WARN    mDNS (.local)       no host advertised yet                         │
│ ✖ FAIL    Runners             health/system unreachable                      │
│ ▲ WARN    Capability slots    unreachable                                    │
│ ▲ WARN    Hindsight / banks   memory admin unreachable                       │
│ ▲ WARN    OpenWebUI           services health unreachable                    │
│ ▲ WARN    Hermes              services health unreachable                    │
╰──────────────────────────────────────────────────────────────────────────────╯

Open hal0
  (no URLs — the API is not reachable)

Next steps & help
  First-run guide  https://hal0.dev/first-run-guide
  Docs             https://hal0.dev/docs/
  Discord          https://discord.gg/7M4y6dcUyq
  Website          https://hal0.dev
```

On a healthy box the card is green (`hal0 is ready ✔`), lists the computed Dashboard / Dashboard-IP / Chat (OWUI) / ComfyUI URLs, and every check reads PASS.

## Tests

- `tests/cli/test_doctor_verify.py` — per-check classifiers, criticals-vs-warns roll-up, render (URLs + links present), tolerant orchestration, and the `--verify` CLI wiring.
- `tests/cli/test_setup_ui.py` — asserts the report auto-runs after a Yes-apply and is skipped on a REVIEW-gate abort.
- Existing `tests/cli/test_doctor.py` direct-call sites updated for the new `verify` param.

DoD: `ruff format` / `ruff check` / `ruff format --check` clean; full `pytest` green except the 12 pre-existing box-noise failures (hermes venv, comfyui phase4, proxmox test_pve, container spec dispatch, config-url-proxy, models-preview, settings-store), confirmed present without this diff via `git stash`.

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
