### PR TITLE
installer-setup WS-G: ComfyUI gen branch — scaffold-only default + per-variant download picker

### DIFF
--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -247,10 +247,18 @@ def setup(
         # result still drives this run; the daemon persists it later.
         typer.echo(f"warning: could not persist hardware.json ({exc})", err=True)
     if answers is not None:
-        from hal0.install.answers import load_answers
+        from hal0.install.answers import gen_download_requested, load_answers
 
         sel = load_answers(answers, hw)
         asyncio.run(_run_auto(sel, hw, no_pull=no_pull))
+        # WS-G (#1113): gen.mode: scaffold_and_download opts into the ComfyUI
+        # per-variant fetch. The loader records the picks in comfyui_defaults;
+        # perform the working download here (skipped under --no-pull, matching
+        # the LLM-slot pull deferral). The img slot activates on the first land.
+        if not no_pull and gen_download_requested(answers) and sel.comfyui_defaults:
+            from hal0.comfyui.provision import provision_comfyui_downloads
+
+            provision_comfyui_downloads(sel.comfyui_defaults)
         return
     if auto:
         sel = build_auto_selections(

--- a/src/hal0/cli/setup_ui.py
+++ b/src/hal0/cli/setup_ui.py
@@ -331,6 +331,73 @@ def _comfyui_defaults() -> tuple[tuple[str, str], ...]:
     return tuple((cap_id, cap.alternatives[0].family) for cap_id, cap in _CAPS.items())
 
 
+def _fmt_duration(seconds: int) -> str:
+    """Compact human ETA for a fetch: ``45s`` / ``6m`` / ``1h05m``."""
+    seconds = int(seconds or 0)
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h{minutes:02d}m"
+
+
+def _variant_label(v) -> str:
+    """One-line human label for a ComfyUI variant: family + precision + lora."""
+    bits = [v.family]
+    if v.precision:
+        bits.append(v.precision)
+    if v.lora:
+        bits.append(v.lora)
+    return " · ".join(bits)
+
+
+def _render_gen_variants(cap) -> RenderableType:
+    """Per-capability variant table: number, model, size + time estimates.
+
+    Row 1 is the default (first) variant; ``s`` scaffolds the capability without
+    downloading anything, so the operator can gate each pull independently."""
+    t = Table(title=f"{cap.label}", expand=True)
+    t.add_column(" ", width=2)
+    t.add_column("Variant")
+    t.add_column("Size", justify="right")
+    t.add_column("Est. time", justify="right")
+    for i, v in enumerate(cap.alternatives):
+        star = "★" if i == 0 else " "
+        t.add_row(
+            star, _variant_label(v), f"~{v.approx_gb:.1f}GB", f"~{_fmt_duration(v.est_seconds)}"
+        )
+    return Group(
+        t, Text("number = download that variant now · s = scaffold (download later)", style="dim")
+    )
+
+
+def _pick_gen_variants(hw: HardwareInfo) -> tuple[tuple[str, str], ...]:
+    """Per-capability variant picker for ``scaffold + download`` (WS-G, #1113).
+
+    Walks every ComfyUI capability (txt2img/img2img/txt2video/img2video/upscale),
+    shows its variants with size + time estimates, and returns the selected
+    ``(capability_id, family)`` picks. Choosing ``s`` (scaffold) for a capability
+    omits it — no download is queued for it. The default is the recommended
+    (first) variant so pressing Enter through the walk pulls the curated set."""
+    from hal0.comfyui.capabilities import CAPABILITIES as _CAPS
+
+    picks: list[tuple[str, str]] = []
+    for cap_id, cap in _CAPS.items():
+        _draw("gen", _render_gen_variants(cap), hw)
+        choices = [str(i + 1) for i in range(len(cap.alternatives))] + ["s"]
+        choice = Prompt.ask(
+            f"{cap.label}: variant number or [s]caffold (download later)",
+            choices=choices,
+            default="1",
+        )
+        if choice == "s":
+            continue
+        picks.append((cap_id, cap.alternatives[int(choice) - 1].family))
+    return tuple(picks)
+
+
 # ── REVIEW gate ──────────────────────────────────────────────────────────────
 
 
@@ -417,6 +484,19 @@ def render_review(plan: SetupPlan) -> RenderableType:
         Text(f"Apps/agents: {enabled}"),
         Text(f"Total download: ~{total_gb:.1f} GB"),
     ]
+    # Opt-in ComfyUI downloads (scaffold + download): surface the extra pull cost
+    # so the size/time estimate gates the decision at the review gate too.
+    if plan.gen_mode == "scaffold_and_download" and plan.comfyui_defaults:
+        from hal0.comfyui.provision import estimate_totals, resolve_variants
+
+        gen_variants, _unknown = resolve_variants(plan.comfyui_defaults)
+        gen_gb, gen_s = estimate_totals(gen_variants)
+        parts.append(
+            Text(
+                f"Generation models: {len(gen_variants)} variant(s), "
+                f"~{gen_gb:.1f} GB, ~{_fmt_duration(gen_s)}"
+            )
+        )
     issues = _port_issues(plan.slots)
     if issues:
         parts.append(Text(""))
@@ -476,7 +556,47 @@ def _apply(plan: SetupPlan) -> None:
     from hal0.cli.setup_install import run_install
 
     asyncio.run(run_install(plan.selections(), plan.hw))
+    _provision_gen_downloads(plan)
     _verify_report(plan)
+
+
+def _provision_gen_downloads(plan: SetupPlan) -> None:
+    """Queue the ComfyUI per-variant fetch for a ``scaffold + download`` plan and
+    activate the img slot once the first model lands (WS-G, #1113).
+
+    No-op for ``off`` / ``scaffold_only`` — those never download here. Reuses the
+    working fetch (#1110) via :func:`hal0.comfyui.provision.provision_comfyui_downloads`;
+    the img slot flips live on the first landed model (enable-on-pull-success,
+    #1108). Progress prints one line per settled variant."""
+    if plan.gen_mode != "scaffold_and_download" or not plan.comfyui_defaults:
+        return
+    from hal0.comfyui.provision import (
+        estimate_totals,
+        provision_comfyui_downloads,
+        resolve_variants,
+    )
+
+    variants, _unknown = resolve_variants(plan.comfyui_defaults)
+    total_gb, total_s = estimate_totals(variants)
+    typer.echo(
+        f"Downloading {len(variants)} generation model(s) "
+        f"(~{total_gb:.1f} GB, ~{_fmt_duration(total_s)}). The img slot activates "
+        "when the first model lands…"
+    )
+
+    def _on_status(_job_id, variant, status) -> None:
+        mark = "done" if status == "done" else status.upper()
+        typer.echo(f"  {_variant_label(variant)}: {mark}")
+
+    result = provision_comfyui_downloads(plan.comfyui_defaults, on_status=_on_status)
+    if result.activated:
+        typer.echo(f"Image generation ready — {len(result.landed)} model(s) landed.")
+    elif result.failed:
+        typer.echo(
+            "No generation model finished downloading — the img slot stays inactive. "
+            "Retry later from the dashboard (Image-Gen tab).",
+            err=True,
+        )
 
 
 def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
@@ -551,8 +671,20 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
 
     # 9. ComfyUI / image+video generation — gen.mode drives the comfyui extension
     gen_mode = _step_gen(hw)
-    state["comfyui"] = gen_mode in _GEN_MODES_ON
-    comfyui_defaults = _comfyui_defaults() if gen_mode in _GEN_MODES_ON else ()
+    if gen_mode == "scaffold_and_download":
+        # Opt-in downloads: a per-capability variant picker (size + time) gates
+        # each pull. The engine is NOT wired up-front — activation is deferred to
+        # enable-on-pull-success (after the first model lands, in _apply), so we
+        # never advertise an empty img slot. If every variant is scaffolded
+        # (nothing picked), fall back to wiring the engine now (grey, no models).
+        comfyui_defaults = _pick_gen_variants(hw)
+        state["comfyui"] = not comfyui_defaults
+    elif gen_mode == "scaffold_only":
+        comfyui_defaults = _comfyui_defaults()
+        state["comfyui"] = True
+    else:  # off
+        comfyui_defaults = ()
+        state["comfyui"] = False
 
     plan = SetupPlan(
         hw=hw,

--- a/src/hal0/comfyui/capabilities.py
+++ b/src/hal0/comfyui/capabilities.py
@@ -17,6 +17,12 @@ class ModelVariant:
     # Each inner tuple = positional/flag args for ONE subprocess invocation.
     # Empty tuple = one call with no extra args (e.g. get_esrgan.sh).
     fetch_steps: tuple[tuple[str, ...], ...] = field(default_factory=tuple)
+    # Approximate on-disk download size in GB, surfaced (with est_seconds) by the
+    # guided-setup variant picker (WS-G, #1113) so the operator sees the cost
+    # before opting into a large pull. These are rough estimates of the total
+    # weights the fetch_steps download (diffusion/checkpoint + LoRA), NOT exact
+    # byte counts — sibling encoders/VAE are shared across variants.
+    approx_gb: float = 0.0
 
 
 @dataclass
@@ -48,6 +54,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_qwen_image.sh",
                 "Qwen-Image-2512-BF16-4-Step-LoRA.json",
                 fetch_steps=(("1", "bf16"), ("3", "bf16")),
+                approx_gb=41.0,
             ),
             ModelVariant(
                 "qwen-image",
@@ -57,6 +64,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_qwen_image.sh",
                 "Qwen-Image-2512-BF16-20-Steps.json",
                 fetch_steps=(("1", "bf16"),),
+                approx_gb=41.0,
             ),
             ModelVariant(
                 "sdxl",
@@ -66,6 +74,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_sdxl.sh",
                 "SDXL-Lightning-8step.json",
                 fetch_steps=(("--precision", "fp16"),),
+                approx_gb=7.0,
             ),
         ],
     ),
@@ -82,6 +91,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_qwen_image.sh",
                 "Qwen-Image-Edit-2511-BF16-4-Step-LoRA.json",
                 fetch_steps=(("2", "bf16"), ("4", "bf16")),
+                approx_gb=54.0,
             ),
             ModelVariant(
                 "qwen-image-edit",
@@ -91,6 +101,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_qwen_image.sh",
                 "Qwen-Image-Edit-2511-BF16-20-Steps.json",
                 fetch_steps=(("2", "bf16"),),
+                approx_gb=54.0,
             ),
         ],
     ),
@@ -107,6 +118,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_ltx2.sh",
                 "LTX2-T2V-BF16.json",
                 fetch_steps=(("common",), ("checkpoint", "bf16"), ("lora",)),
+                approx_gb=32.0,
             ),
             ModelVariant(
                 "hunyuan15",
@@ -116,6 +128,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_hunyuan15.sh",
                 "Hunyuan-Video-1.5_720p_t2v-4-step-lora.json",
                 fetch_steps=(("common",), ("720p-t2v",), ("lora",)),
+                approx_gb=48.0,
             ),
             ModelVariant(
                 "wan22",
@@ -125,6 +138,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_wan22.sh",
                 "Wan2.2-T2V-A14B-FP16-4steps-lora-rank64-Seko-V2.json",
                 fetch_steps=(("common", "fp16"), ("14b-t2v", "fp16"), ("lora",)),
+                approx_gb=62.0,
             ),
         ],
     ),
@@ -141,6 +155,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_ltx2.sh",
                 "LTX2-I2V-BF16.json",
                 fetch_steps=(("common",), ("checkpoint", "bf16"), ("lora",)),
+                approx_gb=32.0,
             ),
             ModelVariant(
                 "hunyuan15",
@@ -150,6 +165,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_hunyuan15.sh",
                 "Hunyuan-Video-1.5_720p_i2v-4-step-lora.json",
                 fetch_steps=(("common",), ("720p-i2v",), ("lora",)),
+                approx_gb=48.0,
             ),
             ModelVariant(
                 "wan22",
@@ -159,6 +175,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_wan22.sh",
                 "Wan2.2-I2V-A14B-4steps-lora-rank64-Seko-V1-FP16.json",
                 fetch_steps=(("common", "fp16"), ("14b-i2v", "fp16"), ("lora",)),
+                approx_gb=62.0,
             ),
         ],
     ),
@@ -175,6 +192,7 @@ CAPABILITIES: dict[str, Capability] = {
                 "get_esrgan.sh",
                 "ESRGAN-4x-Upscale.json",
                 fetch_steps=((),),
+                approx_gb=0.1,
             ),
         ],
     ),

--- a/src/hal0/comfyui/provision.py
+++ b/src/hal0/comfyui/provision.py
@@ -1,0 +1,159 @@
+"""WS-G (#1113): drive the ComfyUI per-variant download + img-slot activation.
+
+Both entry points that opt into ``scaffold_and_download`` — the guided-setup
+variant picker (:mod:`hal0.cli.setup_ui`) and the headless answer file's
+``gen.mode: scaffold_and_download`` (:mod:`hal0.install.answers`) — funnel their
+selected ``(capability_id, family)`` picks here.
+
+Each pick resolves to a :class:`~hal0.comfyui.capabilities.ModelVariant`, whose
+WORKING fetch (#1110's :func:`hal0.comfyui.fetch.fetch_model` — the non-blocking
+bash-script downloader, which also provisions the matching workflow JSON and the
+correct ``model_meta``/family) is queued. The img slot is activated ONLY after
+the first model lands — a ComfyUI analog of WS-E's enable-on-pull-success
+(#1108, :func:`hal0.install.orchestrate.run_pull_and_activate`): we never
+advertise the img engine against an empty model dir. ``run_pull_and_activate``
+itself cannot be reused verbatim (it drives a registry ``PullJob``, not a
+ComfyUI subprocess fetch), so this module mirrors its discipline: create the
+engine wiring, queue the fetch, and flip the slot live only once the bytes land.
+If every fetch fails the img slot stays inactive (grey) and the caller is told.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+from hal0.comfyui.capabilities import ModelVariant
+from hal0.comfyui.fetch import fetch_model, get_job
+from hal0.comfyui.selection import variant_for
+
+log = logging.getLogger(__name__)
+
+#: fetch-job statuses that mean the job is no longer running.
+_TERMINAL = frozenset({"done", "failed", "cancelled"})
+
+
+@dataclass
+class ProvisionResult:
+    """Outcome of a ComfyUI download provisioning run."""
+
+    #: job_id → the variant it fetches (queued this run).
+    jobs: dict[str, ModelVariant] = field(default_factory=dict)
+    #: families whose fetch finished ``done``.
+    landed: list[str] = field(default_factory=list)
+    #: families whose fetch finished ``failed``/``cancelled``.
+    failed: list[str] = field(default_factory=list)
+    #: (capability_id, family) picks the resolver could not map to a variant.
+    unknown: list[tuple[str, str]] = field(default_factory=list)
+    #: True once the img slot was activated (first model landed).
+    activated: bool = False
+
+
+def resolve_variants(
+    comfyui_defaults: tuple[tuple[str, str], ...],
+) -> tuple[list[ModelVariant], list[tuple[str, str]]]:
+    """Map ``(capability_id, family)`` picks to variants.
+
+    Returns ``(variants, unknown)`` — unknown picks (bad capability/family) are
+    collected rather than raised so one stale pick never blocks the rest.
+    """
+    variants: list[ModelVariant] = []
+    unknown: list[tuple[str, str]] = []
+    for cap_id, family in comfyui_defaults:
+        try:
+            variants.append(variant_for(cap_id, family))
+        except KeyError as exc:
+            log.warning(
+                "comfyui.provision.unknown_variant",
+                extra={"capability": cap_id, "family": family, "error": str(exc)},
+            )
+            unknown.append((cap_id, family))
+    return variants, unknown
+
+
+def estimate_totals(variants: list[ModelVariant]) -> tuple[float, int]:
+    """Total ``(approx_gb, est_seconds)`` across *variants* — the picker/review
+    'this download costs …' summary."""
+    return (
+        sum(v.approx_gb for v in variants),
+        sum(v.est_seconds for v in variants),
+    )
+
+
+def _activate_img_slot() -> None:
+    """Bring the ComfyUI img slot live (enable ``hal0-slot@img.service``).
+
+    Delegates to :func:`hal0.install.extensions.install_extension` so activation
+    goes through the SAME wiring the extension walk uses. Best-effort: a failure
+    is logged, never raised — a landed model with an un-activatable slot is still
+    a better state than crash-looping the caller (ADR-0010)."""
+    try:
+        from hal0.install.extensions import install_extension
+
+        install_extension("comfyui")
+    except Exception as exc:  # pragma: no cover - defensive
+        log.warning("comfyui.provision.activate_failed", extra={"error": str(exc)})
+
+
+def provision_comfyui_downloads(
+    comfyui_defaults: tuple[tuple[str, str], ...],
+    *,
+    fetch=fetch_model,
+    poll=get_job,
+    activate=_activate_img_slot,
+    sleep=time.sleep,
+    poll_interval: float = 1.0,
+    on_status=None,
+) -> ProvisionResult:
+    """Queue the working per-variant fetch for every pick, then wait — activating
+    the img slot as soon as the FIRST model lands (enable-on-pull-success).
+
+    Dependencies are injected (``fetch``/``poll``/``activate``/``sleep``) so the
+    poll loop is deterministically unit-testable without real subprocesses.
+    ``on_status(job_id, variant, status)`` is called on each observed terminal
+    transition so a caller (the TUI) can render progress.
+
+    Blocks until every queued fetch settles. Returns a :class:`ProvisionResult`.
+    """
+    variants, unknown = resolve_variants(comfyui_defaults)
+    result = ProvisionResult(unknown=unknown)
+    if not variants:
+        return result
+
+    for v in variants:
+        job_id = fetch(v)
+        result.jobs[job_id] = v
+
+    remaining = set(result.jobs)
+    while remaining:
+        for job_id in list(remaining):
+            job = poll(job_id)
+            status = job.get("status") if job else "done"
+            if status not in _TERMINAL:
+                continue
+            remaining.discard(job_id)
+            variant = result.jobs[job_id]
+            if status == "done":
+                result.landed.append(variant.family)
+                # Enable-on-pull-success: the first landed model makes the img
+                # slot serviceable — flip it live now, never before.
+                if not result.activated:
+                    activate()
+                    result.activated = True
+            else:
+                result.failed.append(variant.family)
+            if on_status is not None:
+                on_status(job_id, variant, status)
+        if remaining:
+            sleep(poll_interval)
+
+    return result
+
+
+__all__ = [
+    "ProvisionResult",
+    "estimate_totals",
+    "provision_comfyui_downloads",
+    "resolve_variants",
+]

--- a/src/hal0/install/answers.py
+++ b/src/hal0/install/answers.py
@@ -220,12 +220,6 @@ def _resolve_gen(doc: dict[str, Any]) -> tuple[bool, tuple[tuple[str, str], ...]
         raise AnswersError(f"gen.mode must be one of {sorted(_GEN_MODES)}, got {mode!r}")
     comfyui_enabled = mode in _GEN_MODES_ON
 
-    if mode == "scaffold_and_download":
-        _warn(
-            "gen.mode: scaffold_and_download — the download side is not yet applied (#1108); "
-            "only scaffolding is performed"
-        )
-
     caps_raw = gen.get("capabilities") or {}
     if not isinstance(caps_raw, dict):
         raise AnswersError("gen.capabilities must be a mapping")
@@ -250,6 +244,26 @@ def _resolve_gen(doc: dict[str, Any]) -> tuple[bool, tuple[tuple[str, str], ...]
         defaults.append((cap_id, family))
 
     return comfyui_enabled, tuple(defaults)
+
+
+def gen_download_requested(path: str) -> bool:
+    """True iff the answer file's ``gen.mode`` is ``scaffold_and_download``.
+
+    Read WITHOUT applying anything so the real-apply path (setup_command) can
+    decide whether to run the ComfyUI per-variant fetch (WS-G, #1113) after
+    ``load_answers`` produces the ``Selections`` (whose ``comfyui_defaults`` carry
+    the picks). ``scaffold_only`` / ``off`` return ``False`` — those never
+    download here. Malformed files return ``False`` rather than raising; the
+    apply path's :func:`load_answers` is the single source of validation errors.
+    """
+    try:
+        doc = _load_yaml(path)
+    except (OSError, AnswersError):
+        return False
+    gen = doc.get("gen") or {}
+    if not isinstance(gen, dict):
+        return False
+    return _yaml_word(gen.get("mode", "off")) == "scaffold_and_download"
 
 
 def _resolve_extensions(doc: dict[str, Any], comfyui_enabled: bool) -> dict[str, bool]:
@@ -454,4 +468,10 @@ def write_answers(sel: Selections, path: str) -> None:
     out_path.write_text(header + body, encoding="utf-8")
 
 
-__all__ = ["AnswersError", "dump_answers", "load_answers", "write_answers"]
+__all__ = [
+    "AnswersError",
+    "dump_answers",
+    "gen_download_requested",
+    "load_answers",
+    "write_answers",
+]

--- a/tests/cli/test_setup_ui.py
+++ b/tests/cli/test_setup_ui.py
@@ -312,3 +312,133 @@ def test_no_apply_skips_verify_report(monkeypatch):
     setup_ui, rec = _stub_flow(monkeypatch, build=False)
     setup_ui.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
     assert rec.get("verified") is None
+
+
+# ── WS-G ComfyUI gen branch (issue #1113) ────────────────────────────────────
+
+
+def test_fmt_duration_buckets():
+    from hal0.cli import setup_ui
+
+    assert setup_ui._fmt_duration(45) == "45s"
+    assert setup_ui._fmt_duration(360) == "6m"
+    assert setup_ui._fmt_duration(3900) == "1h05m"
+
+
+def test_render_gen_variants_shows_size_and_time():
+    from hal0.cli import setup_ui
+    from hal0.comfyui.capabilities import CAPABILITIES
+
+    con = Console(width=100, record=True)
+    con.print(setup_ui._render_gen_variants(CAPABILITIES["txt2img"]))
+    text = con.export_text()
+    assert "qwen-image" in text and "sdxl" in text
+    assert "GB" in text  # size estimate column
+    assert "~" in text  # time estimate
+
+
+def test_pick_gen_variants_picks_and_scaffolds(monkeypatch):
+    from hal0.cli import setup_ui
+
+    monkeypatch.setattr(setup_ui, "_draw", lambda *a, **k: None)
+    # txt2img→2 (second variant), img2img→1, everything else→scaffold ("s").
+    answers = iter(["2", "1", "s", "s", "s"])
+    monkeypatch.setattr(setup_ui.Prompt, "ask", lambda *a, **k: next(answers))
+    picks = setup_ui._pick_gen_variants(_hw())
+    from hal0.comfyui.capabilities import CAPABILITIES
+
+    assert picks[0][0] == "txt2img"
+    # choice "2" → the 2nd txt2img alternative (family from the registry order).
+    assert picks[0][1] == CAPABILITIES["txt2img"].alternatives[1].family
+    assert picks[1][0] == "img2img"
+    assert len(picks) == 2  # the three "s" caps were scaffolded (omitted)
+
+
+def test_scaffold_and_download_defers_engine_and_runs_picker(monkeypatch):
+    setup_ui2, rec = _stub_flow(monkeypatch, build=True)
+    monkeypatch.setattr(setup_ui2, "_step_gen", lambda hw: "scaffold_and_download")
+    monkeypatch.setattr(setup_ui2, "_pick_gen_variants", lambda hw: (("txt2img", "sdxl"),))
+    setup_ui2.run_interactive(_hw(), storage_dir="/var/lib/hal0/models")
+    plan = rec["applied"]
+    assert plan.gen_mode == "scaffold_and_download"
+    assert plan.comfyui_defaults == (("txt2img", "sdxl"),)
+    # Engine activation deferred to enable-on-pull-success → not pre-enabled.
+    assert plan.extensions["comfyui"] is False
+
+
+def test_provision_gen_downloads_noop_for_scaffold_only(monkeypatch):
+    from hal0.cli import setup_ui
+    from hal0.cli.setup_ui import NetworkChoice, SetupPlan
+
+    called = {"n": 0}
+    import hal0.comfyui.provision as prov
+
+    monkeypatch.setattr(
+        prov, "provision_comfyui_downloads", lambda *a, **k: called.__setitem__("n", 1)
+    )
+    plan = SetupPlan(
+        hw=_hw(),
+        network=NetworkChoice("127.0.0.1", "h", None),
+        storage_dir="/s",
+        hf_token=None,
+        extensions={"comfyui": True},
+        slots=[],
+        npu_opt_in=False,
+        gen_mode="scaffold_only",
+        comfyui_defaults=(("txt2img", "sdxl"),),
+    )
+    setup_ui._provision_gen_downloads(plan)
+    assert called["n"] == 0  # scaffold_only never downloads here
+
+
+def test_provision_gen_downloads_runs_for_scaffold_and_download(monkeypatch):
+    from hal0.cli import setup_ui
+    from hal0.cli.setup_ui import NetworkChoice, SetupPlan
+    from hal0.comfyui.provision import ProvisionResult
+
+    seen = {}
+
+    def fake_provision(defaults, **kw):
+        seen["defaults"] = defaults
+        return ProvisionResult(landed=["sdxl"], activated=True)
+
+    monkeypatch.setattr(setup_ui, "_fmt_duration", lambda s: "1m")
+    import hal0.comfyui.provision as prov
+
+    monkeypatch.setattr(prov, "provision_comfyui_downloads", fake_provision)
+    plan = SetupPlan(
+        hw=_hw(),
+        network=NetworkChoice("127.0.0.1", "h", None),
+        storage_dir="/s",
+        hf_token=None,
+        extensions={"comfyui": False},
+        slots=[],
+        npu_opt_in=False,
+        gen_mode="scaffold_and_download",
+        comfyui_defaults=(("txt2img", "sdxl"),),
+    )
+    setup_ui._provision_gen_downloads(plan)
+    assert seen["defaults"] == (("txt2img", "sdxl"),)
+
+
+def test_render_review_shows_gen_download_estimate():
+    from hal0.cli import setup_ui
+    from hal0.cli.setup_ui import NetworkChoice, SetupPlan
+    from hal0.install.orchestrate import SlotSelection
+
+    plan = SetupPlan(
+        hw=_hw(),
+        network=NetworkChoice("127.0.0.1", "box", None),
+        storage_dir="/mnt/ai-models",
+        hf_token=None,
+        extensions={"comfyui": False},
+        slots=[SlotSelection("chat", "chat", 8081, None)],
+        npu_opt_in=False,
+        gen_mode="scaffold_and_download",
+        comfyui_defaults=(("txt2img", "sdxl"), ("image_upscale", "esrgan")),
+    )
+    con = Console(width=120, record=True)
+    con.print(setup_ui.render_review(plan))
+    text = con.export_text()
+    assert "Generation models" in text
+    assert "2 variant" in text

--- a/tests/comfyui/test_provision.py
+++ b/tests/comfyui/test_provision.py
@@ -1,0 +1,107 @@
+"""WS-G (#1113): ComfyUI per-variant download driver + img-slot activation."""
+
+from __future__ import annotations
+
+from hal0.comfyui.provision import (
+    estimate_totals,
+    provision_comfyui_downloads,
+    resolve_variants,
+)
+
+
+def test_resolve_variants_maps_and_collects_unknown():
+    variants, unknown = resolve_variants(
+        (("txt2img", "sdxl"), ("txt2img", "nope"), ("bogus_cap", "x"))
+    )
+    assert [v.family for v in variants] == ["sdxl"]
+    assert unknown == [("txt2img", "nope"), ("bogus_cap", "x")]
+
+
+def test_estimate_totals_sums_size_and_time():
+    variants, _ = resolve_variants((("txt2img", "sdxl"), ("image_upscale", "esrgan")))
+    total_gb, total_s = estimate_totals(variants)
+    assert total_gb == 7.1  # 7.0 + 0.1
+    assert total_s == 20  # 10 + 10
+
+
+class _FakeClock:
+    """Injectable sleep that advances a step counter so poll loops progress."""
+
+    def __init__(self, jobs_status):
+        # jobs_status: job_id -> list of statuses to return on successive polls
+        self.status = jobs_status
+        self.poll_count: dict[str, int] = {}
+
+    def poll(self, job_id):
+        i = self.poll_count.get(job_id, 0)
+        seq = self.status[job_id]
+        status = seq[min(i, len(seq) - 1)]
+        self.poll_count[job_id] = i + 1
+        return {"id": job_id, "status": status}
+
+    def sleep(self, _):  # no real waiting
+        return None
+
+
+def test_queues_fetch_and_activates_on_first_landed():
+    fetched: list[str] = []
+    activations: list[int] = []
+
+    def fake_fetch(v):
+        job_id = f"job-{v.family}"
+        fetched.append(v.family)
+        return job_id
+
+    clock = _FakeClock(
+        {
+            "job-sdxl": ["running", "done"],
+            "job-esrgan": ["running", "running", "done"],
+        }
+    )
+
+    result = provision_comfyui_downloads(
+        (("txt2img", "sdxl"), ("image_upscale", "esrgan")),
+        fetch=fake_fetch,
+        poll=clock.poll,
+        activate=lambda: activations.append(1),
+        sleep=clock.sleep,
+    )
+
+    assert set(fetched) == {"sdxl", "esrgan"}
+    assert set(result.landed) == {"sdxl", "esrgan"}
+    assert result.failed == []
+    assert result.activated is True
+    # img slot activated exactly ONCE (on the first landed model).
+    assert activations == [1]
+
+
+def test_no_activation_when_every_fetch_fails():
+    activations: list[int] = []
+    clock = _FakeClock({"job-sdxl": ["failed"]})
+
+    result = provision_comfyui_downloads(
+        (("txt2img", "sdxl"),),
+        fetch=lambda v: f"job-{v.family}",
+        poll=clock.poll,
+        activate=lambda: activations.append(1),
+        sleep=clock.sleep,
+    )
+
+    assert result.failed == ["sdxl"]
+    assert result.landed == []
+    assert result.activated is False
+    assert activations == []
+
+
+def test_empty_selection_is_a_noop():
+    called = {"fetch": 0, "activate": 0}
+    result = provision_comfyui_downloads(
+        (),
+        fetch=lambda v: called.__setitem__("fetch", called["fetch"] + 1) or "j",
+        poll=lambda j: {"status": "done"},
+        activate=lambda: called.__setitem__("activate", called["activate"] + 1),
+        sleep=lambda _: None,
+    )
+    assert result.jobs == {}
+    assert result.activated is False
+    assert called == {"fetch": 0, "activate": 0}

--- a/tests/install/test_answers.py
+++ b/tests/install/test_answers.py
@@ -6,7 +6,7 @@ import pytest
 
 from hal0.cli.setup_command import build_auto_selections
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
-from hal0.install.answers import AnswersError, load_answers
+from hal0.install.answers import AnswersError, gen_download_requested, load_answers
 
 
 def _hw(ram_gb=96, npu_present=True, npu_validated=True):
@@ -173,6 +173,45 @@ def test_gen_mode_off_disables_comfyui(tmp_path):
     sel = load_answers(path, _hw())
     assert sel.extensions["comfyui"] is False
     assert sel.comfyui_defaults == ()
+
+
+def test_gen_download_requested_only_for_scaffold_and_download(tmp_path):
+    base = """
+        version: 1
+        model_store: {{ path: /var/lib/hal0/models }}
+        slots: []
+        npu: {{ opt_in: false }}
+        gen: {{ mode: {mode}, capabilities: {{ txt2img: auto }} }}
+        apps: {{ openwebui: {{ enabled: true }}, hermes: {{ enabled: false }}, pi: {{ enabled: false }} }}
+    """
+    off = _write(tmp_path, base.format(mode="off"))
+    assert gen_download_requested(off) is False
+    scaffold = _write(tmp_path, base.format(mode="scaffold_only"))
+    assert gen_download_requested(scaffold) is False
+    download = _write(tmp_path, base.format(mode="scaffold_and_download"))
+    assert gen_download_requested(download) is True
+    # A missing / unreadable file degrades to False (never raises here).
+    assert gen_download_requested(str(tmp_path / "nope.yaml")) is False
+
+
+def test_scaffold_and_download_no_longer_warns_and_records_defaults(tmp_path):
+    path = _write(
+        tmp_path,
+        """
+        version: 1
+        model_store: { path: /var/lib/hal0/models }
+        slots: []
+        npu: { opt_in: false }
+        gen: { mode: scaffold_and_download, capabilities: { txt2img: sdxl } }
+        apps: { openwebui: { enabled: true }, hermes: { enabled: false }, pi: { enabled: false } }
+        """,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning → failure
+        sel = load_answers(path, _hw())
+    assert sel.extensions["comfyui"] is True
+    assert sel.comfyui_defaults == (("txt2img", "sdxl"),)
+    assert gen_download_requested(path) is True
 
 
 def test_gen_mode_scaffold_only_enables_comfyui_and_populates_defaults(tmp_path):


### PR DESCRIPTION
Wave 3 / WS-G (decision Q8): wire the ComfyUI/gen branch into the guided
`hal0 setup` flow. Builds on #1110 (working fetch + curated workflow JSONs) and
#1112 (guided TUI host), reusing #1108's enable-on-pull-success discipline.

## What changed
- **Default is scaffold-only** (unchanged): engine wired, empty model dirs, img
  slot grey — no blind large pulls.
- **Opt-in scaffold + download** now runs a **per-capability variant picker**
  (`_pick_gen_variants`) over all five caps (txt2img / img2img / txt2video /
  img2video / image_upscale). Each variant shows a **size estimate**
  (`ModelVariant.approx_gb`, new) + **time estimate** (`est_seconds`); the
  operator picks a variant or `s`caffolds (downloads later) per capability.
- Selected variants queue **#1110's working fetch** (`comfyui.fetch.fetch_model`
  — which also provisions the matching workflow JSON + correct `family`) through
  a new driver `comfyui.provision.provision_comfyui_downloads`.
- **img slot activates only after its model lands** — a ComfyUI analog of WS-E's
  `run_pull_and_activate` (#1108): engine activation is deferred, and the img
  slot flips live on the FIRST landed model. If every fetch fails the slot stays
  inactive (grey) and the operator is told. (`run_pull_and_activate` drives a
  registry `PullJob`, not a ComfyUI subprocess fetch, so the discipline is
  mirrored, not reused verbatim.)
- **Answer file**: `gen.mode: scaffold_and_download` (+ `gen.capabilities`) now
  triggers the same per-variant fetch from the headless apply path. The loader
  records the picks in `comfyui_defaults` (unchanged) and no longer warns that
  the download side is unapplied; `answers.gen_download_requested()` gates the
  post-apply fetch in `setup_command`.
- The REVIEW gate surfaces the extra gen-download cost (variant count + ~GB +
  ~time) so the estimate gates the decision there too.

## Files
- `src/hal0/comfyui/capabilities.py` — `approx_gb` on `ModelVariant`
- `src/hal0/comfyui/provision.py` (new) — resolve/estimate + fetch-and-activate
- `src/hal0/cli/setup_ui.py` — picker, gen-mode branch, apply-path fetch, review
- `src/hal0/install/answers.py` — drop stale warning; `gen_download_requested()`
- `src/hal0/cli/setup_command.py` — fetch on `--answers scaffold_and_download`
- tests: `tests/comfyui/test_provision.py` (new), `tests/cli/test_setup_ui.py`,
  `tests/install/test_answers.py`

## Testing (CI parity)
- `uv run ruff format --check src tests` — clean
- `uv run ruff check src tests` — All checks passed
- `uv run --extra dev pytest` targeted: `test_provision` + `test_setup_ui` +
  `test_answers` + `test_emit_answers` + `test_setup_command` + `test_setup_plan`
  all green. Remaining full-suite failures are the documented pre-existing
  box-noise set (hermes venv, comfyui-phase4 WorkflowList, proxmox test_pve,
  container-spec-dispatch, config-url-proxy, models-preview, settings-store) —
  confirmed unrelated on a stashed clean tree.

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)