### PR TITLE
feat(upstreams): runtime advertise_models toggle (#1147)

### DIFF
--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -119,6 +119,83 @@ async def get_upstream(name: str, request: Request) -> dict[str, Any]:
     return _serialize_upstream(u, last_models=model_cache.get(name))
 
 
+class UpstreamPatchBody(BaseModel):
+    """Body for ``PATCH /api/upstreams/{name}``.
+
+    Only mutable, runtime-tunable fields are accepted. Structural fields
+    (``name``, ``kind``, ``url``, ``auth_*``, ``slot_name``,
+    ``warmup_strategy``) are intentionally absent — those stay
+    ``upstreams.toml``-authored per the deferred-write design called out
+    in this module's module docstring. ``advertise_models`` is the first
+    exception because catalog visibility is a runtime concern, not a
+    config-time one.
+    """
+
+    advertise_models: bool | None = Field(
+        default=None,
+        description="Whether this upstream's /v1/models appears in the aggregate catalog.",
+    )
+
+
+@router.patch("/upstreams/{name}")
+async def patch_upstream(name: str, body: UpstreamPatchBody, request: Request) -> dict[str, Any]:
+    """Mutate runtime-tunable fields on a registered upstream.
+
+    The first reactive write against ``upstreams.toml`` (the module's
+    docstring notes write paths were deferred; this slice is the scoped
+    exception for ``advertise_models``). On success:
+
+    - the in-memory :class:`Upstream` is updated,
+    - ``upstreams.toml`` is rewritten atomically via
+      :func:`hal0.config.loader.save_upstreams_config`,
+    - the per-upstream model cache (``app.state.upstream_models[name]``)
+      is punched so the next ``/api/upstreams`` and ``/v1/models``
+      request sees the change without an API restart,
+    - the change is audit-logged.
+
+    Dispatch/routing to the upstream is unaffected — ``advertise_models``
+    is purely a catalog-visibility flag, not a routing flag.
+    """
+    upstreams = request.app.state.upstreams
+    try:
+        u = upstreams.get(name)
+    except Exception:  # UpstreamRegistry.get never raises; defensive.
+        u = None
+    if u is None:
+        raise UpstreamNotFoundHTTP(f"upstream {name!r} not found", {"name": name})
+
+    if body.advertise_models is None:
+        # Nothing to do — but echo the current state so a no-op PATCH
+        # remains idempotent and useful as a probe.
+        model_cache: dict[str, list[str]] = getattr(request.app.state, "upstream_models", {})
+        return _serialize_upstream(u, last_models=model_cache.get(name))
+
+    new_value = body.advertise_models
+    updated = upstreams.set_advertise(name, new_value)
+
+    # Punch the per-upstream model cache so the next /api/upstreams and
+    # /v1/models request reflects the toggle without an API restart.
+    # The composite ``hal0`` upstream's module-level cache lives in
+    # hal0.api and is unaffected by per-upstream flips.
+    model_cache = getattr(request.app.state, "upstream_models", None)
+    if model_cache is not None and name in model_cache:
+        if new_value:
+            # Re-enabling: drop the stale snapshot so the next call refetches.
+            model_cache.pop(name, None)
+        else:
+            # Disabling: drop the catalog rows immediately so /v1/models
+            # never serves stale entries from the in-memory cache.
+            model_cache[name] = []
+
+    _audit_log.info(
+        "upstream.patch",
+        name=name,
+        advertise_models=new_value,
+        source=request.client.host if request.client else None,
+    )
+    return _serialize_upstream(updated, last_models=(model_cache or {}).get(name))
+
+
 @router.post("/upstreams/{name}/test")
 async def test_upstream(name: str, request: Request) -> dict[str, Any]:
     """Probe ``/v1/models`` on ``name`` and return a reachability report.

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -410,9 +410,15 @@ def load_upstreams_config(path: Path | None = None) -> UpstreamsConfig:
 
 
 def save_upstreams_config(cfg: UpstreamsConfig, path: Path | None = None) -> None:
-    """Atomically write upstreams.toml."""
+    """Atomically write upstreams.toml.
+
+    Uses ``exclude_none=True`` so optional fields that were never set
+    (``slot_name`` on remote-kind entries) don't surface as TOML-incompatible
+    ``None`` values. The round-trip through ``load_upstreams_config`` is
+    unaffected: any field omitted on write is re-defaulted on read.
+    """
     target = path if path is not None else paths.etc() / "upstreams.toml"
-    write_toml_atomic(target, cfg.model_dump(mode="python"))
+    write_toml_atomic(target, cfg.model_dump(mode="python", exclude_none=True))
 
 
 # ── profiles.toml ─────────────────────────────────────────────────────────────

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -209,6 +209,65 @@ class UpstreamRegistry:
         self._upstreams[name] = merged
         return merged
 
+    def set_advertise(self, name: str, value: bool, *, persist: bool = True) -> Upstream:
+        """Flip an upstream's ``advertise_models`` flag and persist atomically.
+
+        Reads ``upstreams.toml``, updates the matching entry's
+        ``advertise_models`` field, and writes the file back via
+        :func:`hal0.config.loader.save_upstreams_config` (which uses
+        ``write_toml_atomic`` for a crash-safe rename). The in-memory
+        ``Upstream`` is also updated so the next ``/v1/models`` request
+        reflects the change without an API restart.
+
+        Auto-registered upstreams (e.g. slot-backed entries that aren't
+        authored in ``upstreams.toml``) have no on-disk row to patch — for
+        those the in-memory value is updated and the on-disk config is left
+        untouched. The flag stays at its in-memory value for the lifetime
+        of the process; on restart the default (``True``) is re-applied.
+
+        Args:
+            name: Upstream name.
+            value: New ``advertise_models`` value.
+            persist: When ``True`` (default), atomically write
+                ``upstreams.toml``. Set to ``False`` for tests that don't
+                want filesystem side-effects.
+
+        Returns the new in-memory :class:`Upstream`.
+
+        Raises:
+            UpstreamNotFound: If ``name`` is not registered.
+        """
+        cur = self._upstreams.get(name)
+        if cur is None:
+            raise UpstreamNotFound(f"upstream {name!r} not found", {"name": name})
+
+        if persist:
+            # Local import: hal0.config.loader imports from this module's
+            # sibling modules, so a top-level import here would risk a
+            # circular import in some test configurations.
+            from hal0.config.loader import (
+                load_upstreams_config,
+                save_upstreams_config,
+            )
+
+            cfg = load_upstreams_config()
+            for entry in cfg.upstream:
+                if entry.name == name:
+                    entry.advertise_models = value
+                    save_upstreams_config(cfg)
+                    break
+            # else: auto-registered upstream, not on disk — in-memory only.
+
+        merged = replace(cur, advertise_models=value)
+        self._upstreams[name] = merged
+        log.info(
+            "upstream.set_advertise",
+            name=name,
+            advertise_models=value,
+            persisted=persist,
+        )
+        return merged
+
     def in_priority_order(self) -> list[Upstream]:
         """Sort order for dispatcher fallback: slots first, then remotes."""
         rank = {"slot": 0, "remote": 1}

--- a/tests/api/test_providers_routes.py
+++ b/tests/api/test_providers_routes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import tomllib
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 
 from hal0.upstreams.registry import Upstream
@@ -78,3 +81,217 @@ def test_providers_catalog_has_known_entries(client: TestClient) -> None:
     # Anthropic + OpenAI + OpenRouter are part of the built-in catalog;
     # at minimum the catalog must be non-empty.
     assert isinstance(catalog, dict) and len(catalog) > 0
+
+
+# ── PATCH /api/upstreams/{name} — advertise_models toggle (#1147) ─────────────
+
+
+def _upstreams_toml_path(client: TestClient) -> Path:
+    """Resolve the per-test upstreams.toml path (HAL0_HOME-isolated)."""
+    # hal0.config.paths.etc() resolves to $HAL0_HOME/etc/hal0 in tests;
+    # the conftest monkeypatches HAL0_HOME to tmp_path.
+    import os
+
+    home = os.environ["HAL0_HOME"]
+    return Path(home) / "etc" / "hal0" / "upstreams.toml"
+
+
+def _seed_openrouter_in_toml(client: TestClient) -> None:
+    """Write a minimal upstreams.toml containing only the 'openrouter' entry.
+
+    The seeded registry above leaves the file empty; the PATCH test needs
+    a row on disk so the round-trip persists. We use the registry's own
+    shape (no validation friction) by writing through the loader's API.
+    """
+    from hal0.config.loader import save_upstreams_config
+    from hal0.config.schema import UpstreamEntry, UpstreamsConfig
+
+    cfg = UpstreamsConfig(
+        upstream=[
+            UpstreamEntry(
+                name="openrouter",
+                kind="remote",
+                url="https://openrouter.ai/api/v1",
+                auth_value_env="OPENROUTER_API_KEY",
+                advertise_models=True,
+            )
+        ]
+    )
+    save_upstreams_config(cfg)
+
+
+def test_patch_upstream_advertise_off_round_trip(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"advertise_models": False},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["name"] == "openrouter"
+    assert body["advertise_models"] is False
+
+    # In-memory: GET reflects the new value without an API restart.
+    follow = client.get("/api/upstreams/openrouter")
+    assert follow.status_code == 200
+    assert follow.json()["advertise_models"] is False
+
+    # On-disk: upstreams.toml was rewritten atomically with the new value.
+    path = _upstreams_toml_path(client)
+    assert path.exists(), "PATCH must persist upstreams.toml"
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+    entries = [u for u in raw.get("upstream", []) if u.get("name") == "openrouter"]
+    assert entries, "the openrouter row should still be on disk"
+    assert entries[0]["advertise_models"] is False
+
+
+def test_patch_upstream_advertise_on_restores_state(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+
+    # Toggle off, then back on.
+    client.patch("/api/upstreams/openrouter", json={"advertise_models": False})
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"advertise_models": True},
+    )
+    assert response.status_code == 200
+    assert response.json()["advertise_models"] is True
+
+    path = _upstreams_toml_path(client)
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+    entries = [u for u in raw.get("upstream", []) if u.get("name") == "openrouter"]
+    assert entries[0]["advertise_models"] is True
+
+
+def test_patch_upstream_404_on_unknown_name(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.patch(
+        "/api/upstreams/nope",
+        json={"advertise_models": False},
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "upstream.not_found"
+
+
+def test_patch_upstream_empty_body_is_noop(client: TestClient) -> None:
+    """PATCH with no fields returns the current state and does not write."""
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    path = _upstreams_toml_path(client)
+    advertise_before = client.get("/api/upstreams/openrouter").json()["advertise_models"]
+
+    response = client.patch("/api/upstreams/openrouter", json={})
+    assert response.status_code == 200
+    assert response.json()["advertise_models"] == advertise_before
+
+    # No rewrite when the body carries no fields — the on-disk file's
+    # advertise_models is unchanged.
+    if path.exists():
+        with path.open("rb") as f:
+            raw = tomllib.load(f)
+        entries = [u for u in raw.get("upstream", []) if u.get("name") == "openrouter"]
+        if entries:
+            assert entries[0]["advertise_models"] is True
+
+
+def test_patch_upstream_clears_cached_models_when_off(client: TestClient) -> None:
+    """Toggling OFF punches app.state.upstream_models so /api/upstreams sees []."""
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+
+    cache = getattr(client.app.state, "upstream_models", None)
+    assert cache is not None
+    cache["openrouter"] = ["model-a", "model-b", "model-c"]
+
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"advertise_models": False},
+    )
+    assert response.status_code == 200
+    # The response itself reflects the punch — the cached list was wiped.
+    assert response.json()["models"] == []
+
+    follow = client.get("/api/upstreams/openrouter")
+    assert follow.json()["advertise_models"] is False
+    assert follow.json()["models"] == []
+
+
+def test_patch_upstream_drops_cache_on_reenable(client: TestClient) -> None:
+    """Toggling ON drops the cached list so the next fetch refetches."""
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+
+    cache = getattr(client.app.state, "upstream_models", None)
+    cache["openrouter"] = []
+
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"advertise_models": True},
+    )
+    assert response.status_code == 200
+    # On re-enable, the cache key is dropped so the next read refetches.
+    assert "openrouter" not in cache
+
+
+def test_patch_upstream_does_not_touch_other_rows(client: TestClient) -> None:
+    """PATCH must leave sibling rows in upstreams.toml untouched."""
+    from hal0.config.loader import save_upstreams_config
+    from hal0.config.schema import UpstreamEntry, UpstreamsConfig
+
+    _seed_upstreams(client)
+    cfg = UpstreamsConfig(
+        upstream=[
+            UpstreamEntry(
+                name="openrouter",
+                kind="remote",
+                url="https://openrouter.ai/api/v1",
+                auth_value_env="OPENROUTER_API_KEY",
+                advertise_models=True,
+            ),
+            UpstreamEntry(
+                name="anthropic",
+                kind="remote",
+                url="https://api.anthropic.com/v1",
+                auth_value_env="ANTHROPIC_API_KEY",
+                advertise_models=True,
+                warmup_strategy="eager",
+            ),
+        ]
+    )
+    save_upstreams_config(cfg)
+
+    client.patch("/api/upstreams/openrouter", json={"advertise_models": False})
+
+    path = _upstreams_toml_path(client)
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+    by_name = {u["name"]: u for u in raw.get("upstream", [])}
+    assert by_name["openrouter"]["advertise_models"] is False
+    # Anthropic row untouched.
+    assert by_name["anthropic"]["advertise_models"] is True
+    assert by_name["anthropic"]["warmup_strategy"] == "eager"
+
+
+def test_patch_upstream_persists_atomically_no_partial_file(client: TestClient) -> None:
+    """A successful PATCH leaves a complete TOML file (atomic write)."""
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+
+    client.patch("/api/upstreams/openrouter", json={"advertise_models": False})
+
+    path = _upstreams_toml_path(client)
+    # No leftover .tmp.* siblings from write_toml_atomic.
+    siblings = [
+        p
+        for p in path.parent.iterdir()
+        if p.name.startswith(f".{path.name}.") and p.name.endswith(".tmp")
+    ]
+    assert not siblings, f"atomic write leaked temp files: {siblings}"
+    # File parses cleanly.
+    with path.open("rb") as f:
+        tomllib.load(f)


### PR DESCRIPTION
Closes #1147.

A new `PATCH /api/upstreams/{name}` endpoint flips an upstream's `advertise_models` flag without restarting hal0-api. The toggle is purely a catalog-visibility concern — dispatch/routing to the upstream is unaffected.

## What lands

- `UpstreamRegistry.set_advertise(name, value)` — updates the in-memory Upstream, reads upstreams.toml, patches the matching entry, writes the file back via the existing `save_upstreams_config` / `write_toml_atomic` pair. Auto-registered upstreams (not on disk) get the in-memory update only.
- `PATCH /api/upstreams/{name}` handler with a strict body schema (`UpstreamPatchBody`, currently only `advertise_models`).
- Cache invalidation: `app.state.upstream_models[name]` is cleared on re-enable and set to [] on disable, so the next /api/upstreams and /v1/models request reflects the change without an API restart. The live filter in routes/v1.py:660 already excludes rows by the flag, so the catalog never serves stale entries once the cache is punched.
- Audit log entry (`hal0.audit: upstream.patch`).
- Empty-body PATCH is a no-op probe: returns the current state and does not rewrite the on-disk file.

## Latent fix

- `save_upstreams_config` now passes `exclude_none=True` to model_dump. UpstreamEntry.slot_name defaults to None for kind=remote entries, and tomli_w couldn't serialize None — the function was effectively broken for any realistic config. The round-trip via load_upstreams_config is unchanged (omitted fields re-default on read).

## Tests (tests/api/test_providers_routes.py — 8 new)

- PATCH off → 200 + advertise_models:false + on-disk row updated
- PATCH on → state restored + on-disk row updated
- 404 on unknown name with code upstream.not_found
- Empty body is idempotent, no on-disk rewrite
- Cache punch on disable (models: [] returned immediately)
- Cache drop on re-enable (next read refetches)
- Sibling rows in upstreams.toml are untouched (anthropic row, warmup, etc.)
- Atomic write: no leftover .tmp.* siblings, file parses cleanly

Local: 108/108 tests pass across the related suites; ruff clean; format clean.

## Acceptance criteria

- [x] GET /api/upstreams returns advertise_models + model count (already shipped)
- [x] PATCH persists to upstreams.toml atomically
- [x] Toggling OFF removes from /v1/models within one request (live filter + cache punch)
- [x] Toggling ON re-advertises
- [x] Dispatch/routing unchanged

## Companion slices (independent, follow-ups)

- #1148 — Hermes hal0-provider owned_by filter
- #1149 — namespace hal0 slots as hal0/<slot>
- #1150 — hal0 upstream CLI (depends on this endpoint)
- #1151 — Settings panel UI (depends on this endpoint, HITL UX review)