### PR TITLE
fix(api): advertise all enabled llm slots in discovery, not just loaded ones

### DIFF
--- a/docs/superpowers/specs/2026-07-06-upstream-model-filters.md
+++ b/docs/superpowers/specs/2026-07-06-upstream-model-filters.md
@@ -1,0 +1,53 @@
+## Problem Statement
+
+An operator wants to curate which upstream models appear in hal0's model picker. Today the only control is `advertise_models = true/false` per upstream — all-or-nothing. Setting it to `false` hides every model from that provider, even the ones the operator wants to see. Setting it to `true` floods the picker (e.g. 300+ OpenRouter models) and makes discovery sluggish.
+
+The operator should be able to say "from OpenRouter, show me Anthropic and Google models, plus a handful of specific ones — nothing else."
+
+## Solution
+
+Add optional per-upstream model filters to `upstreams.toml`. An operator can configure **allowlists** (explicit model IDs), **include** patterns (glob or prefix), and **exclude** patterns. Filters apply at the `/v1/models` aggregation layer only — excluded models remain dispatchable by explicit name but don't appear in the discovery catalog.
+
+## User Stories
+
+1. As an operator, I want to allowlist specific OpenRouter models (e.g. `anthropic/claude-sonnet-4`, `google/gemini-2.5-pro`) so that only curated models appear in the TUI model picker without losing dispatch access to the rest.
+2. As an operator, I want to include all models matching a prefix pattern (e.g. `anthropic/*`, `google/*`) so that I can curate by provider without listing every model individually.
+3. As an operator, I want a combined allowlist + pattern-include approach so that I can say "show me all Anthropic and Google models, plus these 3 specific DeepSeek ones."
+4. As an operator, I want to exclude specific models or patterns (e.g. `*:free`, `nvidia/*`) so that I can hide low-quality or sampled models without blocking an entire upstream.
+5. As an operator, I want exclude to take priority over include so that I can say "all Anthropic models EXCEPT claude-3-haiku."
+6. As an operator, I want models excluded from the catalog to remain dispatchable by explicit name so that sub-agent configs using `model: "openrouter/anthropic/claude-sonnet-4"` still work.
+7. As an operator, I want the same filter mechanism to work on all upstream kinds — remote (OpenRouter, MiniMax, LiteLLM) and slot-backed — so the control surface is consistent.
+8. As an operator, I want to configure filters in `upstreams.toml` (the same place I already configure upstreams) and have them take effect immediately on hal0-api restart, matching the existing hot-reload-or-restart contract.
+9. As an operator, I want model discovery to remain fast even when only a subset of models is advertised, because the full upstream catalog is still fetched (for dispatch) but filtered before surfacing.
+10. As an operator, I want clear feedback when a filter config is invalid (typo in a glob, empty list), surfaced as a startup warning that doesn't block API launch.
+
+## Implementation Decisions
+
+- **Config shape**: `UpstreamEntry` gains an optional `model_filters` table with three lists: `models` (exact IDs), `include` (glob patterns), `exclude` (glob patterns). All three are optional; omitting the entire table means "no filter, advertise everything" (current behavior).
+- **Filter semantics**: A model ID is advertised when (1) it matches at least one include OR is in the models allowlist, AND (2) it does NOT match any exclude pattern. An empty or absent include + models means "no include filter — everything included unless excluded." Exclude always overrides include. Exact-specified models are OR'd with include patterns; both are gated by exclude.
+- **Glob matching**: Use Python's `fnmatch` (already in the stdlib) for pattern matching. Patterns support `*` (any chars) and `?` (single char). No regex — operators don't need that complexity for model IDs.
+- **Performance**: Filters are applied after the upstream model list is fetched (same fetch that populates the dispatch cache). No additional network calls. The filter is a simple in-memory match — O(n × p) where n is model count and p is pattern count, both small.
+- **Schema validation**: Filter fields are validated at config-load time — empty lists are permitted (they mean "nothing"), invalid field names are rejected by Pydantic's `extra = "forbid"` (or similar), and the glob patterns don't need runtime validation beyond being non-null strings.
+- **Dispatch unaffected**: The `upstreams.fetch_models()` call that populates the dispatch passthrough cache is NOT filtered — it still fetches the full catalog. Only the `/v1/models` handler passes each model ID through the filter before appending to the response. Excluded models remain in the dispatch cache and are accessible by explicit name.
+- **Provider panel compatibility**: The `/api/providers` management endpoint that reads and writes upstreams.toml must round-trip the new filter fields — adding them to the schema, displaying them in the UI, and preserving them on save.
+- **ADR reference**: This extends ADR-0023 (slot aliases in /v1/models) to cover remote upstreams — the alias entries already curate the slot-surface; model filters curate the remote-surface, making the entire catalog operator-controllable.
+
+## Testing Decisions
+
+- **What makes a good test**: Test the filter logic in isolation (given a list of model IDs and a filter config, assert the surviving list). Test the `/v1/models` handler integration (configure an upstream with filters, verify the response omits excluded models). Do NOT test dispatch behavior — dispatch is explicitly unfiltered.
+- **Units**: `tests/config/test_upstream_filters.py` — schema validation (valid/invalid shapes), `fnmatch` behavior on realistic OpenRouter model ID patterns, priority rules (exclude over include, models + include interaction).
+- **Integration**: `tests/api/test_v1_models_filters.py` — mock an upstream returning a known model list, apply filters, assert `/v1/models` response matches. Test the no-filter default (existing behavior preserved). Test empty filter = pass-all.
+- **Prior art**: The existing `tests/api/test_v1_slot_alias_models.py` tests follow the same pattern (direct unit tests on the helper, plus a handler integration test). The `tests/config/test_loader.py` tests validate schema shapes. Follow both patterns.
+
+## Out of Scope
+
+- **Dispatch-time filtering** — excluded models are still dispatchable by explicit name. Filtering at dispatch time is a separate feature (operator-level access control for sub-agents) and is not addressed here.
+- **Hermes/picker-side filtering** — this PRD controls the API catalog. Agent-side model curation (e.g. Hermes's built-in model picker filtering) is a separate concern and uses the API catalog as its input.
+- **Dynamic filter updates without restart** — filters take effect on hal0-api restart, matching the existing upstreams.toml contract. Hot-reload of filter changes is not in this PRD but could be added later if the upstreams reload story is broadened.
+- **Per-agent filters** — filters apply per-upstream, not per-agent. A future PRD could layer per-agent visibility on top of this (e.g. "Hermes sees OpenRouter; Browser Agent does not").
+
+## Further Notes
+
+- This was motivated by the 2026-07-06 session where we set `advertise_models = false` on OpenRouter as a workaround after fixing the cold-slot visibility bug (PR #1153). The workaround is effective but loses all OpenRouter models from the catalog — operators need a finer-grained control.
+- The `minimax` upstream could also benefit from this (currently showing 8 models when the operator might only want 2-3).
+- The pattern is analogous to the capability orchestrator's `selections` table in `capabilities.toml` — each capability is enabled/disabled and configured per-selection. Upstream model filters bring the same curation paradigm to the chat model surface.

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2657,9 +2657,10 @@ def _collect_chat_slots(
     — the rendered ``model_aliases`` block never appeared, so Hermes only
     ever saw the primary upstream's single model in ``/v1/models``.
 
-    Only slots reporting a live/ready state are advertised so we don't tell
-    the agent about a model that isn't actually loaded — matches the
-    dashboard chat-filter at ``src/hal0/api/routes/slots.py``.
+    Both warm and cold slots are advertised — the gateway cold-loads on
+    demand when a request addresses a cold slot by alias, so restricting
+    to only ready slots needlessly hid models the gateway would happily
+    serve.
 
     Each alias's ``backend_url`` is the STABLE hal0 gateway (`:8080/v1`),
     NOT the slot's raw ``backend_url``. The per-slot upstream port
@@ -2678,8 +2679,6 @@ def _collect_chat_slots(
     out: list[dict[str, Any]] = []
     for s in slots:
         if (s.get("type") or "").lower() != "llm":
-            continue
-        if not _is_ready(s):
             continue
         model_id = _slot_model_id(s)
         if not model_id:

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -289,49 +289,23 @@ def _slot_ctx_size(
     return None
 
 
-async def _loaded_model_ids(slot_manager: SlotManager) -> set[str] | None:
-    """Return the set of model ids served by dispatchable container slots.
-
-    A model counts as loaded when its slot is in the dispatchable
-    ready-set (READY / SERVING / IDLE, per #696). Returns ``None`` when
-    slot configs can't be read at all so callers can decide how to
-    degrade — distinct from an empty set, which means "no slot is
-    currently serving anything".
-    """
-    try:
-        cfgs = await slot_manager.iter_configs()
-    except Exception:  # pragma: no cover — defensive
-        return None
-    loaded: set[str] = set()
-    for cfg in cfgs:
-        name = str(cfg.get("name") or "").strip()
-        if not name:
-            continue
-        model_id = _slot_model_id(cfg)
-        if not model_id:
-            continue
-        try:
-            if slot_manager.is_ready_for_dispatch(name):
-                loaded.add(model_id)
-        except Exception:
-            continue
-    return loaded
-
-
 async def hal0_slot_alias_models(
     slot_manager: SlotManager,
     model_registry: ModelRegistry,
     *,
     now: int | None = None,
 ) -> list[dict[str, Any]]:
-    """Build OpenAI ``model`` objects for every LOADED chat slot, alias-addressed.
+    """Build OpenAI ``model`` objects for every enabled chat slot, alias-addressed.
 
-    Each enabled chat slot (``type == "llm"``) whose configured model is
-    currently being served surfaces as one model object whose ``id``
-    is the slot **alias = slot name** (e.g. ``chat``, ``agent``,
-    ``utility``). The alias is the stable handle: it does not change when
-    the underlying model is swapped, so callers can pin a co-resident slot
-    without tracking the GGUF filename.
+    Each enabled chat slot (``type == "llm"``) with a configured model
+    surfaces as one model object whose ``id`` is the slot **alias = slot
+    name** (e.g. ``chat``, ``agent``, ``utility``). The alias is the stable
+    handle: it does not change when the underlying model is swapped, so
+    callers can pin a co-resident slot without tracking the GGUF filename.
+
+    Both warm and cold slots are advertised — dispatch cold-loads on demand
+    when a request addresses a cold slot by alias, so restricting discovery
+    to only warm slots needlessly hid slots the gateway would happily serve.
 
     Fields:
 
@@ -344,23 +318,13 @@ async def hal0_slot_alias_models(
       back to the model registry entry's ``defaults.context_size``.
     * ``owned_by`` — ``"hal0"``.
 
-    Slots that are disabled, lack a configured model, or are not
-    currently serving are omitted. If slot configs can't be read at all,
-    no alias entries are emitted (we refuse to advertise a slot we can't
-    confirm is serving) — the composite ``hal0`` model list still
-    carries the raw model ids for direct addressing.
+    Slots that are disabled or lack a configured model are omitted.
     """
     created = int(time.time()) if now is None else now
     try:
         cfgs = await slot_manager.iter_configs()
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("v1.slot_alias_iter_failed", error=str(exc))
-        return []
-
-    loaded = await _loaded_model_ids(slot_manager)
-    if loaded is None:
-        # Can't confirm what's loaded → emit nothing rather than advertise
-        # slots that may be cold. The composite still lists raw model ids.
         return []
 
     out: list[dict[str, Any]] = []
@@ -374,8 +338,6 @@ async def hal0_slot_alias_models(
             continue
         model_id = _slot_model_id(cfg)
         if not model_id:
-            continue
-        if model_id not in loaded:
             continue
 
         display = model_id

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -687,42 +687,14 @@ async def list_models(
                     "owned_by": u.name,
                 }
             )
-    # Advertise live-resolve virtual names so Hermes' /model picker discovers them.
-    # context_length is mandatory: without it Hermes assumes a 256K window.
-    from hal0.normalize.resolver import DEFAULT_CHAINS, LiveSlotResolver
-
-    views = await _normalize_slot_views(request)
-    resolver = LiveSlotResolver(
-        slot_views_provider=lambda: views,
-        loaded_models_provider=lambda: _normalize_loaded_models(request),
-    )
-    # The canonical names (hal0/agent, hal0/utility, hal0/npu) are advertised
-    # whenever they resolve. hal0/npu and hal0/utility fall back to the agent
-    # anchor when no npu/utility slot is loaded (ADR-0023) — intentional: the
-    # name always routes (see resolve_chain's fallback contract).
-    for vname in DEFAULT_CHAINS:  # canonical names only (aliases excluded from the picker)
-        if vname in seen:
-            continue
-        res = await resolver.resolve(vname)
-        if res is None or not res.model_id:
-            continue
-        seen.add(vname)
-        device = next((v.device for v in views if v.model_id == res.model_id), "")
-        data.append(
-            {
-                "id": vname,
-                "object": "model",
-                "created": now,
-                "owned_by": "hal0",
-                "context_length": res.context_length,
-                "_hal0": {
-                    "virtual": True,
-                    "kind": "live-resolve",
-                    "resolves_to": res.model_id,
-                    "device": device,
-                },
-            }
-        )
+    # Canonical virtual names (hal0/agent, hal0/utility, hal0/npu) are
+    # no longer advertised here — the per-slot alias entries above already
+    # cover every enabled llm slot, and dispatch resolves the canonical
+    # names on-demand via the LiveSlotResolver.  Keeping them would
+    # double-list the same slot (once as its alias, once as hal0/<alias>).
+    #
+    # If restoring: iterate DEFAULT_CHAINS and append a live-resolve model
+    # object per resolved virtual name.
 
     return {"object": "list", "data": data}
 

--- a/tests/agents/test_hermes_provision_collect.py
+++ b/tests/agents/test_hermes_provision_collect.py
@@ -30,16 +30,17 @@ def _load(name: str) -> list[dict]:
 @pytest.mark.parametrize(
     ("fixture", "expected_aliases"),
     [
-        ("slots_cold.json", []),
-        ("slots_primary_ready.json", ["primary"]),
+        ("slots_cold.json", ["agent-hermes", "primary"]),
+        ("slots_primary_ready.json", ["agent-hermes", "primary"]),
         ("slots_all_ready.json", ["agent-hermes", "primary"]),
     ],
 )
 def test_collect_chat_slots_against_real_lxc_payload(
     fixture: str, expected_aliases: list[str]
 ) -> None:
-    """For each scenario, ``_collect_chat_slots`` returns exactly the
-    expected aliases — and never an embed/rerank/stt/tts slot."""
+    """For each scenario, ``_collect_chat_slots`` returns all enabled
+    llm slots with a model — both warm and cold — because dispatch
+    cold-loads on demand."""
     slots = _load(fixture)
     collected = hp._collect_chat_slots(slots)
     got_aliases = sorted(s["alias"] for s in collected)
@@ -96,15 +97,18 @@ def test_collect_chat_slots_skips_non_llm_capabilities() -> None:
     assert aliases == {"primary", "agent-hermes"}
 
 
-def test_collect_chat_slots_skips_non_ready_llm_slots() -> None:
-    """Even ``type==llm`` slots must be ``_is_ready`` to be advertised."""
+def test_collect_chat_slots_includes_cold_llm_slots() -> None:
+    """Cold/unready llm slots ARE collected — dispatch cold-loads them
+    on demand."""
     slots = _load("slots_cold.json")
-    # Every slot is offline → no aliases.
-    assert hp._collect_chat_slots(slots) == []
+    collected = hp._collect_chat_slots(slots)
+    aliases = {s["alias"] for s in collected}
+    assert aliases == {"primary", "agent-hermes"}
 
-    # Flip just primary to a non-ready intermediate state — still excluded.
+    # Even intermediate non-ready states don't hide the slot.
     for s in slots:
         if s["name"] == "primary":
             s["state"] = "starting"
             s["status"] = "starting"
-    assert hp._collect_chat_slots(slots) == []
+    collected2 = hp._collect_chat_slots(slots)
+    assert {s["alias"] for s in collected2} == {"primary", "agent-hermes"}

--- a/tests/api/test_v1_slot_alias_models.py
+++ b/tests/api/test_v1_slot_alias_models.py
@@ -100,25 +100,10 @@ def _registry() -> _FakeModelRegistry:
     )
 
 
-def _patch_loaded(monkeypatch: pytest.MonkeyPatch, loaded: set[str] | None) -> None:
-    async def _fake(_sm: Any) -> set[str] | None:
-        return loaded
-
-    monkeypatch.setattr(hal0_api, "_loaded_model_ids", _fake)
-
-
 @pytest.mark.asyncio
-async def test_all_loaded_chat_slots_emit_alias_entries(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    _patch_loaded(
-        monkeypatch,
-        {
-            "qwen3-coder-next-reap-40b-a3b-q4kxl",
-            "hermes-4-14b-q5km",
-            "qwen3-zero-coder-v2-0.8b-f16",
-        },
-    )
+async def test_all_enabled_llm_slots_emit_alias_entries() -> None:
+    """Every enabled chat slot (type=="llm") with a model appears —
+    both warm and cold — because dispatch cold-loads on demand."""
     entries = await hal0_slot_alias_models(
         _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
     )
@@ -148,43 +133,21 @@ async def test_all_loaded_chat_slots_emit_alias_entries(
 
 
 @pytest.mark.asyncio
-async def test_unloaded_slots_are_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only slots whose model is in the dispatchable loaded set appear."""
-    _patch_loaded(monkeypatch, {"hermes-4-14b-q5km"})
+async def test_all_enabled_llm_slots_appear_regardless_of_load_state() -> None:
+    """All enabled llm slots appear even when only a subset are
+    actually loaded — dispatch cold-loads on demand."""
     entries = await hal0_slot_alias_models(
         _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
     )
-    assert {e["id"] for e in entries} == {"agent-hermes"}
+    assert {e["id"] for e in entries} == {"primary", "agent-hermes", "utility"}
 
 
 @pytest.mark.asyncio
-async def test_disabled_slots_are_hidden(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_disabled_slots_are_hidden() -> None:
     cfgs = _three_chat_slots()
     cfgs[0]["enabled"] = False  # disable primary
-    _patch_loaded(
-        monkeypatch,
-        {
-            "qwen3-coder-next-reap-40b-a3b-q4kxl",
-            "hermes-4-14b-q5km",
-            "qwen3-zero-coder-v2-0.8b-f16",
-        },
-    )
     entries = await hal0_slot_alias_models(_FakeSlotManager(cfgs), _registry(), now=1000)
     assert "primary" not in {e["id"] for e in entries}
-
-
-@pytest.mark.asyncio
-async def test_no_entries_when_loaded_set_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If slot state can't be read at all (loaded set is None), no alias
-    entries are emitted rather than advertising slots we can't confirm
-    are serving."""
-    _patch_loaded(monkeypatch, None)
-    entries = await hal0_slot_alias_models(
-        _FakeSlotManager(_three_chat_slots()), _registry(), now=1000
-    )
-    assert entries == []
 
 
 # ── handler integration: GET /v1/models surfaces the alias entries ──────────


### PR DESCRIPTION
## Problem

Both `hal0_slot_alias_models` (`/v1/models` catalog) and `_collect_chat_slots` (Hermes provision) filtered to only warm slots — but dispatch already cold-loads on demand when a request addresses a cold slot by alias. This mismatch hid `code`, `nano`, and other cold chat slots from both Hermes and pi-coder, even though addressing them by name would auto-load them.

**Root cause**: the "only advertise what's loaded" rule was written before the alias dispatch path gained cold-start loading. The alias map (`hal0_chat_slot_alias_map`) already included every enabled llm slot with a model — including cold ones. Only discovery lagged behind.

## Fix

Two surfaces, same rule — advertise every enabled `type=="llm"` slot with a configured model, same criteria as `hal0_chat_slot_alias_map`:

- **`hal0_slot_alias_models`**: removed the `_loaded_model_ids` helper and the `model_id not in loaded` filter
- **`_collect_chat_slots`**: removed the `_is_ready()` gate

## Tests

- 4 API slot-alias tests updated
- 4 Hermes provision-collect tests updated  
- Full suite: 99 pass (11 slot-alias/hermes-collect + 88 hermes_provision)