### PR TITLE
fix(dispatcher): make direct_read_timeout configurable via [dispatcher] TOML

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -782,6 +782,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         upstream_registry=upstreams,
         model_registry=model_registry,
         prefetch_timeout_s=hal0_cfg.dispatcher.prefetch_timeout_s,
+        direct_read_timeout_s=hal0_cfg.dispatcher.direct_read_timeout_s,
         prefetch_parallel_cap=hal0_cfg.dispatcher.prefetch_parallel_cap,
         cached_models=lambda name: model_cache.get(name, []),
         fetch_models=_fetch_and_cache,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1943,6 +1943,17 @@ class DispatcherConfig(BaseModel):
         gt=0.0,
         description="Cold-cache prefetch timeout (PLAN.md §5 Tier 2).",
     )
+
+    direct_read_timeout_s: float = Field(
+        default=300.0,
+        ge=30.0,
+        le=600.0,
+        description=(
+            "Non-streaming upstream read timeout in seconds. "
+            "Large consolidation/extraction prompts can exceed 60s on slow slots. "
+            "Streaming paths are unaffected. Range 30–600."
+        ),
+    )
     prefetch_parallel_cap: int = Field(
         default=4,
         ge=1,

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -417,6 +417,8 @@ class Dispatcher:
         model_registry:     Source of truth for model→upstream bindings.
         prefetch_timeout_s: Cold-cache prefetch fanout timeout
                             (PLAN.md §5 Tier 2 — was hardcoded 4s, now 8s).
+        direct_read_timeout_s: Non-streaming upstream read timeout in seconds.
+                            Configurable via [dispatcher].direct_read_timeout_s.
         prefetch_parallel_cap: Max concurrent cold-prefetch legs
                             ([dispatcher].prefetch_parallel_cap, default 4).
         cached_models:      Returns the cached /v1/models for an upstream.
@@ -431,6 +433,7 @@ class Dispatcher:
         model_registry: ModelRegistry | None = None,
         *,
         prefetch_timeout_s: float = 8.0,  # TIER2 — configurable (was hardcoded 4s)
+        direct_read_timeout_s: float = _DIRECT_READ_TIMEOUT_S,
         prefetch_parallel_cap: int = 4,  # max concurrent cold-prefetch legs
         cached_models: CachedModelsFn | None = None,
         is_online: IsOnlineFn | None = None,
@@ -454,6 +457,8 @@ class Dispatcher:
         # only exercise dispatch() don't open sockets.
         self._http_client: httpx.AsyncClient | None = http_client
         self._owns_http_client: bool = http_client is None
+        # Non-streaming read timeout — configurable via TOML (default 300s).
+        self._direct_read_timeout_s: float = direct_read_timeout_s
         # SlotManager — when supplied, forward() wraps slot-kind calls in
         # SlotManager.serving() so the slot transitions READY/IDLE →
         # SERVING → READY around each /v1 request (task #10 SERVING).
@@ -463,14 +468,14 @@ class Dispatcher:
     def _get_http_client(self) -> httpx.AsyncClient:
         if self._http_client is None:
             # Short connect/write/pool; non-streaming read capped at
-            # _DIRECT_READ_TIMEOUT_S (streaming paths ignore the read timeout
+            # _direct_read_timeout_s (streaming paths ignore the read timeout
             # once the first byte arrives — see httpx docs on stream=True).
             # Connection limits match registry.py to prevent pool starvation
             # under sustained slow-upstream load (#415).
             self._http_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(
                     connect=5.0,
-                    read=_DIRECT_READ_TIMEOUT_S,
+                    read=self._direct_read_timeout_s,
                     write=10.0,
                     pool=5.0,
                 ),


### PR DESCRIPTION
## Problem

The non-streaming upstream read timeout was hardcoded at 60s (`_DIRECT_READ_TIMEOUT_S`). Large consolidation/extraction prompts on slow slots (e.g., Grug-12B processing 3K-token prompts at ~25 tok/s) exceed this and get killed mid-generation with:

```
HTTP 502: {"code": "dispatch.upstream_unavailable", "message": "upstream utility unreachable: ReadTimeout"}
```

## Root cause

Hindsight consolidation tasks on the utility slot take >60s for large prompts. Every retry hits the same 60s ceiling — the tasks never complete.

## Fix

- Add `direct_read_timeout_s` to `[dispatcher]` section in `DispatcherConfig` (range 30-600, default 300)
- Thread it through `Dispatcher.__init__` → `_get_http_client()`
- Pass it from the hal0_api lifespan via `hal0_cfg.dispatcher.direct_read_timeout_s`

## Verification

- hal0-api restarted and Hindsight consolidation tasks now running past 240s without 502 errors
- Default of 300s provides generous headroom for slow slots without being unbounded
- Streaming paths unaffected (httpx ignores read timeout after first byte)
- No breaking config changes — if `[dispatcher]` section is absent, the Field default (300) is used