### PR TITLE
feat: downloads pane in footer with pull job tracking

### DIFF
--- a/docs/superpowers/specs/2026-07-08-downloads-pane-design.md
+++ b/docs/superpowers/specs/2026-07-08-downloads-pane-design.md
@@ -1,0 +1,189 @@
+# Downloads pane — footer tab for model pull tracking
+
+**Date**: 2026-07-08
+**Status**: draft
+
+## Scope
+
+Add a "downloads" tab to the hal0 dashboard footer, giving the user a single
+glanceable pane to monitor all model downloads (active + recent history) with
+per-download controls: cancel, retry, and clear.
+
+## Architecture
+
+Two changes, one backend, one frontend.
+
+### Backend — `GET /api/models/pulls`
+
+Returns a merged list of all pull jobs:
+
+- **In-memory active jobs** from `app.state.model_pull_jobs` (queued, running)
+- **Persisted terminal jobs** from `/var/lib/hal0/model-pull-jobs/*.json` (completed, failed, cancelled)
+
+Dedup rule: if a model_id appears in both, the in-memory copy wins.
+Persisted jobs are filtered to terminal states only (non-terminal on disk
+with no matching in-memory copy is an edge case from a crash — skip it).
+
+Each entry shape:
+
+```jsonc
+{
+  "model_id": "org/repo",
+  "job_id": "abc123",
+  "state": "running",        // queued | running | completed | failed | cancelled
+  "bytes_downloaded": 104857600,
+  "bytes_total": 4194304000,
+  "speed_bps": 3200000,
+  "eta_s": 72,
+  "hf_repo": "org/repo",     // from model registry (or null if registry row missing)
+  "dest_path": "/var/lib/hal0/models/org/repo.gguf",
+  "error": null,             // {code, message} when state == "failed"
+  "started_at": 1720400000.0,
+  "finished_at": null
+}
+```
+
+Polling interval on the frontend: 2s while the footer is expanded and the
+downloads tab is active.
+
+### Backend — `DELETE /api/models/pulls/{model_id}`
+
+Clears a terminal pull job from both in-memory (`app.state.model_pull_jobs`
+pop) and disk (delete the snapshot `.json`). Returns 409 Conflict if the job
+is still active (queued or running). Returns 204 on success.
+
+### Frontend — `usePullsList` hook
+
+Wraps `GET /api/models/pulls` with React Query. Polls every 2s only when the
+footer is expanded AND the downloads tab is active (`enabled` gate). Returns
+`jobs`, `hasActive` (boolean — true if any job is queued or running).
+
+Also wraps `DELETE /api/models/pulls/{id}` as a mutation with query
+invalidation on success.
+
+Listens for `hal0:pull-started` and `hal0:pull-ended` custom events to
+invalidate the query immediately (the existing `usePullJob` hook already
+dispatches `hal0:pull-ended` on terminal state; we add `hal0:pull-started`
+to match).
+
+### Frontend — Footer tab structure
+
+The footer gains a tab bar above the expanded pane:
+
+```
+[journal] [downloads]
+─────────────────────
+  pane content
+─────────────────────
+  foot-chips (runtimes, services, update chip, toggle)
+```
+
+- "journal" tab → existing `foot-pane` with source chips, search, log lines
+- "downloads" tab → new `foot-downloads` pane with download rows
+- The tab state is local React state in the Footer component (reset to
+  "journal" when the pane is collapsed).
+
+### Download row design
+
+Each row:
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ ●  hf.co/org/repo  →  /var/lib/hal0/models/name.gguf                     │
+│ ████████████░░░░░░░░  42%    3.2 MB/s · 1m 12s left          [× cancel] │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**State indicator** (left-most column):
+- Running: green animated spinner
+- Queued: clock icon, muted
+- Completed: green check ✓
+- Failed: red ✗
+- Cancelled: grey dash —
+
+**Progress bar**: only for queued and running. Width = pct, amber fill.
+
+**Speed + ETA**: only for running. Format: `{fmtBytes}/s · {fmtEta}` or
+"calculating…" when speed is still 0.
+
+**Actions column** (right-aligned):
+- Queued/Running: `[× cancel]` button, calls `POST /api/models/{id}/pull/cancel`
+- Failed: `[↻ retry]` button, calls `POST /api/models/{id}/pull`
+- Completed/Cancelled/Failed: `[clear]` button, calls `DELETE /api/models/pulls/{id}`
+
+### Empty state
+
+When no downloads exist (no active, no recent history): a centered message
+"No downloads yet" with a link to the Models catalogue (`#models`).
+
+### Auto-expand
+
+When a download starts (the `hal0:pull-started` event fires before any SSE
+frame lands), the footer auto-expands and switches to the downloads tab.
+Collapse is always manual — the user clicks the toggle.
+
+The existing `usePullJob.start()` method dispatches:
+```js
+window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: { modelId } }))
+```
+
+The Footer listens for this event and calls `onToggle` + switches to
+downloads tab.
+
+### Interaction with existing per-row pull UI
+
+The existing `usePullJob` hook is used per-model-row in `models.jsx` for
+in-place progress within the models table. That stays unchanged. The
+downloads pane is a separate consumer of the same backend pull state via
+the new `/pulls` endpoint — it is read-only display plus cancel/retry/clear,
+not a replacement for the per-row flow.
+
+## Data flow
+
+```
+┌─────────────┐   POST /pull     ┌──────────────┐
+│ models.jsx  │ ────────────────> │  hal0-api    │
+│ per-row UI  │ <── SSE stream ── │  pull engine │
+└─────────────┘                   └──────┬───────┘
+                                         │ writes snapshots
+┌─────────────┐  GET /pulls (2s)  ┌──────▼───────┐
+│ Footer      │ ────────────────> │ model-pull-  │
+│ downloads   │ <──────────────── │ jobs/*.json  │
+│ pane        │                   │ + in-memory  │
+└─────────────┘                   └──────────────┘
+```
+
+## CSS
+
+New CSS class: `.foot-downloads` — a scrollable vertical list of download
+rows. Each row uses a 2-line grid:
+
+```
+.foot-dl-row {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  grid-template-rows: auto auto;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line);
+}
+```
+
+Row 1: state indicator | repo link → dest path | actions (cancel/retry/clear)
+Row 2: empty (spans col 1) | progress bar + stats | empty
+
+Hover: subtle bg shift (`var(--bg-2)`).
+
+Vertical scroll with `max-height` matching the journal pane height
+(`~280px`). Newest first (active jobs first, then terminal by `started_at`).
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `src/hal0/api/routes/models.py` | Add `GET /api/models/pulls` and `DELETE /api/models/pulls/{model_id}` |
+| `src/hal0/registry/pull.py` | Expose `list_persisted_jobs()` helper (or inline in route) |
+| `ui/src/api/endpoints.ts` | Add `pulls`, `pullsDelete` endpoints |
+| `ui/src/api/hooks/useModels.ts` | Add `usePullsList` hook, add pull-started event dispatch |
+| `ui/src/dash/chrome.jsx` | Add tab bar, downloads pane, auto-expand listener |
+| `ui/src/dashboard.css` | Add `.foot-downloads` and `.foot-dl-row` styles |
+| `ui/src/dash/models.jsx` | No changes needed (existing per-row pull UI unchanged) |

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -34,6 +34,7 @@ from hal0.registry.pull import (
     PullInvalidSource,
     PullJob,
     PullJobNotFound,
+    list_persisted_jobs,
     make_job,
     run_flm_pull,
     run_pull,
@@ -956,6 +957,95 @@ def _lazy_quant(dumped: dict[str, Any]) -> str | None:
     return None
 
 
+@router.get("/pulls")
+async def list_pulls(request: Request) -> list[dict[str, Any]]:
+    """Return all pull jobs (active in-memory + persisted terminal from disk).
+
+    Dedup: in-memory jobs win over persisted snapshots for the same model_id.
+    """
+    jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
+    registry = request.app.state.model_registry
+
+    # Start with persisted terminal jobs from disk
+    persisted = list_persisted_jobs()
+    by_model: dict[str, dict[str, Any]] = {}
+    for p in persisted:
+        mid = p.get("model_id")
+        if isinstance(mid, str) and mid:
+            by_model[mid] = p
+
+    # Overlay in-memory jobs (they win — reflect live state)
+    for mid, job in jobs.items():
+        by_model[mid] = job.as_dict()
+
+    # Build response entries enriched with registry data
+    result: list[dict[str, Any]] = []
+    for mid, data in by_model.items():
+        entry = _pull_entry(data, mid, registry)
+        result.append(entry)
+
+    # Sort: active first, then by started_at descending
+    result.sort(key=lambda e: (
+        0 if e.get("state") in ("queued", "running") else 1,
+        -(e.get("started_at") or 0),
+    ))
+    return result
+
+
+def _pull_entry(data: dict[str, Any], model_id: str, registry: Any) -> dict[str, Any]:
+    """Build a downloads-pane entry from a pull-job snapshot dict."""
+    state = data.get("state", "unknown")
+    speed = _speed_for_entry(data, state)
+    eta = _eta_for_entry(data, state, speed)
+    hf_repo = _hf_repo_for_model(registry, model_id)
+
+    return {
+        "model_id": model_id,
+        "job_id": data.get("id"),
+        "state": state,
+        "bytes_downloaded": data.get("bytes_downloaded", 0),
+        "bytes_total": data.get("bytes_total", 0),
+        "speed_bps": speed,
+        "eta_s": eta,
+        "hf_repo": hf_repo,
+        "dest_path": data.get("path"),
+        "error": data.get("error"),
+        "started_at": data.get("started_at"),
+        "finished_at": data.get("finished_at"),
+    }
+
+
+def _speed_for_entry(data: dict[str, Any], state: str) -> float:
+    """Compute average bytes/s for a pull-job entry snapshot."""
+    if state not in ("queued", "running"):
+        return 0.0
+    started = data.get("started_at")
+    if not isinstance(started, (int, float)) or started <= 0:
+        return 0.0
+    elapsed = max(time.time() - started, 0.001)
+    return data.get("bytes_downloaded", 0) / elapsed
+
+
+def _eta_for_entry(data: dict[str, Any], state: str, speed: float) -> float | None:
+    """Estimate seconds-to-completion for a pull-job entry snapshot."""
+    if state not in ("queued", "running") or speed <= 0:
+        return None
+    total = data.get("bytes_total", 0)
+    if total <= 0:
+        return None
+    remaining = max(total - data.get("bytes_downloaded", 0), 0)
+    return remaining / speed
+
+
+def _hf_repo_for_model(registry: Any, model_id: str) -> str | None:
+    """Resolve the HF repo from the model registry, or None if unknown."""
+    try:
+        model = registry.get(model_id)
+        return getattr(model, "hf_repo", None) or None
+    except Exception:
+        return None
+
+
 @router.get("/{model_id}")
 async def get_model(model_id: str, request: Request) -> dict[str, Any]:
     """Return a single model by id, preferring the local registry then
@@ -1201,6 +1291,45 @@ async def delete_model(
         "deleted": bool(removed),
         "affected_slots": affected_names,
     }
+
+
+@router.delete("/pulls/{model_id}")
+async def delete_pull(model_id: str, request: Request) -> dict[str, object]:
+    """Clear a terminal pull job from memory + disk.
+
+    Returns 409 if the job is still active (queued/running).
+    """
+    jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
+
+    # Check in-memory first — active jobs must not be cleared
+    job = jobs.get(model_id)
+    if job is not None and job.state in ("queued", "running"):
+        from hal0.errors import Conflict
+
+        raise Conflict(
+            f"pull job for {model_id!r} is still active (state={job.state})",
+            code="pull.active",
+            details={"model_id": model_id, "state": job.state},
+        )
+
+    # Remove from in-memory dict
+    deleted_mem = jobs.pop(model_id, None) is not None
+
+    # Remove persisted file
+    deleted_disk = False
+    with contextlib.suppress(OSError):
+        p = _pull_job_file(model_id)
+        if p.exists():
+            p.unlink()
+            deleted_disk = True
+
+    if not deleted_mem and not deleted_disk:
+        raise PullJobNotFound(
+            f"no pull job for model {model_id!r}",
+            details={"model_id": model_id},
+        )
+
+    return {"model_id": model_id, "deleted": True}
 
 
 def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, BackgroundTasks, Request, Response
 from fastapi.responses import StreamingResponse
 
 from hal0.api._audit import record_action
@@ -966,10 +966,15 @@ async def list_pulls(request: Request) -> list[dict[str, Any]]:
     jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
     registry = request.app.state.model_registry
 
-    # Start with persisted terminal jobs from disk
+    # Start with persisted TERMINAL jobs from disk.
+    # Non-terminal snapshots (e.g. "running" from a crash) are skipped
+    # — there is no matching in-memory job to reconcile them.
     persisted = list_persisted_jobs()
     by_model: dict[str, dict[str, Any]] = {}
     for p in persisted:
+        state = p.get("state")
+        if state not in ("completed", "failed", "cancelled"):
+            continue
         mid = p.get("model_id")
         if isinstance(mid, str) and mid:
             by_model[mid] = p
@@ -1293,8 +1298,8 @@ async def delete_model(
     }
 
 
-@router.delete("/pulls/{model_id}")
-async def delete_pull(model_id: str, request: Request) -> dict[str, object]:
+@router.delete("/pulls/{model_id}", status_code=204)
+async def delete_pull(model_id: str, request: Request):
     """Clear a terminal pull job from memory + disk.
 
     Returns 409 if the job is still active (queued/running).
@@ -1329,7 +1334,7 @@ async def delete_pull(model_id: str, request: Request) -> dict[str, object]:
             details={"model_id": model_id},
         )
 
-    return {"model_id": model_id, "deleted": True}
+    return Response(status_code=204)
 
 
 def _resolve_pull_source(request: Request, model_id: str) -> tuple[str, str]:

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -482,6 +482,26 @@ def sweep_pull_jobs(max_age_days: int = 14) -> int:
     return removed
 
 
+def list_persisted_jobs() -> list[dict[str, Any]]:
+    """Read all ``.json`` files from the pull-jobs directory and return a list of dicts.
+
+    Best-effort: malformed or unreadable files are silently skipped.
+    An absent jobs directory returns an empty list.
+    """
+    jobs_dir = _pull_jobs_dir()
+    if not jobs_dir.is_dir():
+        return []
+    results: list[dict[str, Any]] = []
+    for path in sorted(jobs_dir.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                results.append(data)
+        except (OSError, ValueError):
+            continue
+    return results
+
+
 # ── resume / partial-download support (MR-7) ──────────────────────────────────
 #
 # A prior interrupted pull leaves a deterministic ``<id>.part`` in the staging
@@ -1425,6 +1445,7 @@ __all__ = [
     "pull_job_file",
     "run_flm_pull",
     "run_pull",
+    "list_persisted_jobs",
     "sweep_orphaned_partials",
     "sweep_pull_jobs",
 ]

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -56,6 +56,8 @@ export const ENDPOINTS = {
   modelPullStatus: (id: string) => `/api/models/${encodeURIComponent(id)}/pull/status`,
   modelPullStream: (id: string) => `/api/models/${encodeURIComponent(id)}/pull/stream`,
   modelPullCancel: (id: string) => `/api/models/${encodeURIComponent(id)}/pull/cancel`,
+  modelPulls: '/api/models/pulls',
+  modelPullDelete: (id: string) => `/api/models/pulls/${encodeURIComponent(id)}`,
   modelInspect: '/api/models/inspect',
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -442,7 +442,7 @@ export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {
 
   const query = useQuery<PullJob[]>({
     queryKey: ['pulls'],
-    queryFn: () => apiGet<PullJob[]>(ENDPOINTS.pulls),
+    queryFn: () => apiGet<PullJob[]>(ENDPOINTS.modelPulls),
     enabled,
     refetchInterval: enabled ? 2_000 : false,
   })
@@ -456,7 +456,7 @@ export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {
 export function useClearPullJob() {
   const qc = useQueryClient()
   return useMutation<void, Hal0Error, string>({
-    mutationFn: (id: string) => apiDelete(ENDPOINTS.pullsDelete(id)),
+    mutationFn: (id: string) => apiDelete(ENDPOINTS.modelPullDelete(id)),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['pulls'] }),
   })
 }

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -411,18 +411,18 @@ export function usePullJob(): PullSnapshot {
 // ─── usePullsList ─────────────────────────────────────────────────
 
 export interface PullJob {
-  id: string
+  job_id: string
   model_id: string
-  repo: string
-  dest: string
+  hf_repo: string | null
+  dest_path: string | null
   state: PullState
-  downloaded: number
-  total: number
+  bytes_downloaded: number
+  bytes_total: number
   speed_bps: number
   eta_s: number
   error: { code: string; message: string } | null
-  pct: number | null
-  created_at: string
+  started_at: number | null
+  finished_at: number | null
 }
 
 export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -330,6 +330,10 @@ export function usePullJob(): PullSnapshot {
     try {
       const res = await apiPost<any>(ENDPOINTS.modelPull(id), body)
       setJobId(res?.id ?? res?.job_id ?? null)
+      // Dispatch pull-started event so the downloads pane can open / refresh
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: { modelId: id } }))
+      }
       attachStream(id)
       return res
     } catch (e) {
@@ -403,6 +407,60 @@ export function usePullJob(): PullSnapshot {
     reattach,
   }
 }
+
+// ─── usePullsList ─────────────────────────────────────────────────
+
+export interface PullJob {
+  id: string
+  model_id: string
+  repo: string
+  dest: string
+  state: PullState
+  downloaded: number
+  total: number
+  speed_bps: number
+  eta_s: number
+  error: { code: string; message: string } | null
+  pct: number | null
+  created_at: string
+}
+
+export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {
+  const qc = useQueryClient()
+
+  // Listen for pull lifecycle events to force a refetch
+  useEffect(() => {
+    if (!enabled) return
+    const invalidate = () => qc.invalidateQueries({ queryKey: ['pulls'] })
+    window.addEventListener('hal0:pull-started', invalidate)
+    window.addEventListener('hal0:pull-ended', invalidate)
+    return () => {
+      window.removeEventListener('hal0:pull-started', invalidate)
+      window.removeEventListener('hal0:pull-ended', invalidate)
+    }
+  }, [enabled, qc])
+
+  const query = useQuery<PullJob[]>({
+    queryKey: ['pulls'],
+    queryFn: () => apiGet<PullJob[]>(ENDPOINTS.pulls),
+    enabled,
+    refetchInterval: enabled ? 2_000 : false,
+  })
+
+  const jobs = query.data ?? []
+  const hasActive = jobs.some((j: PullJob) => j.state === 'queued' || j.state === 'running')
+
+  return { jobs, hasActive, ...query }
+}
+
+export function useClearPullJob() {
+  const qc = useQueryClient()
+  return useMutation<void, Hal0Error, string>({
+    mutationFn: (id: string) => apiDelete(ENDPOINTS.pullsDelete(id)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['pulls'] }),
+  })
+}
+
 
 export function fmtBytes(b: number) {
   if (!b || b < 0) return '—'

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -628,7 +628,7 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
                 </div>
               ) : (
                 jobs.map((j) => {
-                  const pct = j.pct != null ? j.pct : (j.total ? Math.round((j.downloaded / j.total) * 100) : 0);
+                  const pct = j.bytes_total ? Math.round((j.bytes_downloaded / (j.bytes_total || 1)) * 100) : 0;
                   const isRunning = j.state === 'running';
                   const isQueued = j.state === 'queued';
                   const isCompleted = j.state === 'completed';
@@ -636,13 +636,13 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
                   const isCancelled = j.state === 'cancelled';
                   const barClass = isCompleted ? ' completed' : isFailed ? ' failed' : '';
                   return (
-                    <div key={j.id} className="foot-dl-row">
+                    <div key={j.job_id || j.model_id} className="foot-dl-row">
                       <span className={"foot-dl-state " + j.state}>
                         {isRunning ? '⟳' : isQueued ? '⏰' : isCompleted ? '✓' : isFailed ? '✗' : '—'}
                       </span>
                       <span className="foot-dl-repo">
-                        {j.repo || j.model_id}
-                        {j.dest && (<><span className="foot-dl-arrow">→</span><span className="foot-dl-dest">{j.dest}</span></>)}
+                        {j.hf_repo || j.model_id}
+                        {j.dest_path && (<><span className="foot-dl-arrow">→</span><span className="foot-dl-dest">{j.dest_path}</span></>)}
                       </span>
                       <span className="foot-dl-act">
                         {(isRunning || isQueued) && (
@@ -651,14 +651,14 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
                         {isFailed && (
                           <>
                             <button className="retry" onClick={() => apiPost(ENDPOINTS.modelPull(j.model_id))}>↻ retry</button>
-                            <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                            <button onClick={() => clearJob.mutate(j.model_id)}>clear</button>
                           </>
                         )}
                         {isCompleted && (
-                          <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                          <button onClick={() => clearJob.mutate(j.model_id)}>clear</button>
                         )}
                         {isCancelled && (
-                          <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                          <button onClick={() => clearJob.mutate(j.model_id)}>clear</button>
                         )}
                       </span>
                       {!isCompleted && !isFailed && !isCancelled && (
@@ -668,7 +668,7 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
                           </div>
                           <span className="foot-dl-stats">
                             <span>{pct}%</span>
-                            {isRunning && j.speed_bps > 0 && <span>{fmtSpeed(j.speed_bps)}</span>}
+                            {isRunning && (j.speed_bps > 0 ? <span>{fmtSpeed(j.speed_bps)}</span> : <span>calculating…</span>)}
                             {isRunning && j.eta_s > 0 && <span>{fmtEta(j.eta_s)} left</span>}
                           </span>
                         </div>

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -7,7 +7,9 @@
 import { useRuntimeRollup, useHealthSystem, failingChecks } from '@/api/hooks/useRuntime'
 import { useLogsStream } from '@/api/hooks/useLogs'
 import { useSlots } from '@/api/hooks/useSlots'
-import { useModels } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { apiPost } from '@/api/client'
+import { ENDPOINTS } from '@/api/endpoints'
 import { useMemoryEnabled } from '@/api/hooks/useMemory'
 import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
@@ -476,6 +478,22 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   const serviceHealth = useServicesHealth();
   const [paneSrc, setPaneSrc] = useStateC("merged");
   const [paneQ, setPaneQ] = useStateC("");
+  const [footerTab, setFooterTab] = useStateC("journal");
+  // Reset to journal when pane collapses
+  useEffectC(() => {
+    if (!expanded) setFooterTab("journal");
+  }, [expanded]);
+  // Auto-expand and switch to downloads on pull-started
+  useEffectC(() => {
+    const onPullStarted = () => {
+      setFooterTab("downloads");
+      if (!expanded && onToggle) onToggle();
+    };
+    window.addEventListener("hal0:pull-started", onPullStarted);
+    return () => window.removeEventListener("hal0:pull-started", onPullStarted);
+  }, [expanded, onToggle]);
+  const { jobs, hasActive } = usePullsList({ enabled: expanded && footerTab === "downloads" });
+  const clearJob = useClearPullJob();
   // Stream the full (merged) event feed and filter by source group
   // CLIENT-SIDE. This keeps every source chip available regardless of the
   // active filter (deriving chips from a server-narrowed ring would drop
@@ -548,6 +566,12 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
   return (
     <div className={"footer" + (expanded ? " expanded" : "")}>
       {expanded && (
+        <>
+          <div className="foot-tabs">
+            <button className={"foot-tab" + (footerTab === "journal" ? " active" : "")} onClick={() => setFooterTab("journal")}>journal</button>
+            <button className={"foot-tab" + (footerTab === "downloads" ? " active" : "")} onClick={() => setFooterTab("downloads")}>downloads</button>
+          </div>
+          {footerTab === "journal" ? (
         <div className="foot-pane">
           <div className="foot-pane-h mono">
             <span>Live journal</span>
@@ -595,6 +619,77 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
             ))}
           </div>
         </div>
+      
+          ) : (
+            <div className="foot-downloads">
+              {jobs.length === 0 ? (
+                <div className="foot-dl-empty">
+                  No downloads yet — <a href="#models">browse models</a>
+                </div>
+              ) : (
+                jobs.map((j) => {
+                  const pct = j.pct != null ? j.pct : (j.total ? Math.round((j.downloaded / j.total) * 100) : 0);
+                  const isRunning = j.state === 'running';
+                  const isQueued = j.state === 'queued';
+                  const isCompleted = j.state === 'completed';
+                  const isFailed = j.state === 'failed';
+                  const isCancelled = j.state === 'cancelled';
+                  const barClass = isCompleted ? ' completed' : isFailed ? ' failed' : '';
+                  return (
+                    <div key={j.id} className="foot-dl-row">
+                      <span className={"foot-dl-state " + j.state}>
+                        {isRunning ? '⟳' : isQueued ? '⏰' : isCompleted ? '✓' : isFailed ? '✗' : '—'}
+                      </span>
+                      <span className="foot-dl-repo">
+                        {j.repo || j.model_id}
+                        {j.dest && (<><span className="foot-dl-arrow">→</span><span className="foot-dl-dest">{j.dest}</span></>)}
+                      </span>
+                      <span className="foot-dl-act">
+                        {(isRunning || isQueued) && (
+                          <button className="cancel" onClick={() => apiPost(ENDPOINTS.modelPullCancel(j.model_id))}>× cancel</button>
+                        )}
+                        {isFailed && (
+                          <>
+                            <button className="retry" onClick={() => apiPost(ENDPOINTS.modelPull(j.model_id))}>↻ retry</button>
+                            <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                          </>
+                        )}
+                        {isCompleted && (
+                          <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                        )}
+                        {isCancelled && (
+                          <button onClick={() => clearJob.mutate(j.id)}>clear</button>
+                        )}
+                      </span>
+                      {!isCompleted && !isFailed && !isCancelled && (
+                        <div className="foot-dl-bar">
+                          <div className="foot-dl-bar-track">
+                            <div className={"foot-dl-bar-fill" + barClass} style={{width: pct + '%'}} />
+                          </div>
+                          <span className="foot-dl-stats">
+                            <span>{pct}%</span>
+                            {isRunning && j.speed_bps > 0 && <span>{fmtSpeed(j.speed_bps)}</span>}
+                            {isRunning && j.eta_s > 0 && <span>{fmtEta(j.eta_s)} left</span>}
+                          </span>
+                        </div>
+                      )}
+                      {!isRunning && !isQueued && isCompleted && (
+                        <div className="foot-dl-bar">
+                          <div className="foot-dl-bar-track">
+                            <div className="foot-dl-bar-fill completed" style={{width: '100%'}} />
+                          </div>
+                        </div>
+                      )}
+                      {isFailed && (
+                        <div className="foot-dl-err">{j.error?.message || 'Download failed'}</div>
+                      )}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </>
       )}
       <div className="foot-chips">
         {/* runtimes — one LED pip per enabled slot + ready count */}

--- a/ui/src/dash/memory-overhaul.css
+++ b/ui/src/dash/memory-overhaul.css
@@ -194,6 +194,9 @@
 /* Embedded tools grid inside the primary bank display — keeps its own sub-card
    chrome; just trims the standalone-page top spacing. */
 .mo-main .mt-embedded { margin: 4px 0 6px; }
+/* Documents card sits below the 2×2 grid as a full-width sibling. */
+.mt > .mt-card { margin-top: 14px; }
+.mt-embedded > .mt-card { margin-top: 14px; }
 
 /* Consolidate action sits under the operations list. */
 .mo-ops-actions { display: flex; justify-content: flex-end; margin: 10px 0 4px; }
@@ -282,6 +285,7 @@
    stacks on its own regardless of the other's height. */
 .mt-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start; }
 .mt-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }
+.mt-col > .mt-card { flex: 1; }
 @media (max-width: 760px) {
   .mt-cols { grid-template-columns: 1fr; }
 }

--- a/ui/src/dash/memory-tools.jsx
+++ b/ui/src/dash/memory-tools.jsx
@@ -564,13 +564,13 @@ function MemToolsPanel({ bank: bankProp, embedded } = {}) {
         <div className="mt-col">
           <MemReflectPlayground bank={bank} />
           <MemRecallConsole bank={bank} />
-          <MemDocuments bank={bank} />
         </div>
         <div className="mt-col">
-          <MemMentalModels bank={bank} />
           <MemDirectives bank={bank} />
+          <MemMentalModels bank={bank} />
         </div>
       </div>
+      <MemDocuments bank={bank} />
     </div>
   );
 }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -607,6 +607,165 @@ a { color: inherit; text-decoration: none; }
 }
 .foot-toggle:hover { color: var(--accent); }
 
+
+/* ─── Footer Downloads pane ────────────────────────────────────── */
+.foot-tabs {
+  display: flex;
+  gap: 0;
+  font-family: var(--jbm);
+  font-size: 11px;
+  border-bottom: 1px solid var(--line);
+  padding: 0 8px;
+  background: var(--bg);
+}
+.foot-tab {
+  padding: 10px 14px;
+  cursor: pointer;
+  color: var(--fg-4);
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s ease, border-color 0.15s ease;
+  background: transparent;
+  border-top: none;
+  border-left: none;
+  border-right: none;
+  font-family: var(--jbm);
+  font-size: 11px;
+}
+.foot-tab:hover { color: var(--fg-2); }
+.foot-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.foot-downloads {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.foot-dl-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 120px;
+  color: var(--fg-4);
+  font-family: var(--jbm);
+  font-size: 12px;
+  text-align: center;
+}
+.foot-dl-empty a { color: var(--accent); text-decoration: none; }
+.foot-dl-empty a:hover { text-decoration: underline; }
+
+.foot-dl-row {
+  display: grid;
+  grid-template-columns: 20px 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px 10px;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line-soft);
+  font-family: var(--jbm);
+  font-size: 11.5px;
+}
+.foot-dl-row:hover { background: var(--bg-2); }
+.foot-dl-row:last-child { border-bottom: none; }
+
+.foot-dl-state {
+  grid-row: 1 / 3;
+  grid-column: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  width: 20px;
+}
+.foot-dl-state.running {
+  color: var(--ok);
+  animation: foot-dl-spin 0.9s linear infinite;
+}
+.foot-dl-state.queued { color: var(--fg-4); }
+.foot-dl-state.completed { color: var(--ok); }
+.foot-dl-state.failed { color: var(--err); }
+.foot-dl-state.cancelled { color: var(--fg-5); }
+
+@keyframes foot-dl-spin {
+  to { transform: rotate(360deg); }
+}
+
+.foot-dl-repo {
+  grid-row: 1;
+  grid-column: 2;
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.foot-dl-arrow { color: var(--fg-4); margin: 0 4px; }
+.foot-dl-dest {
+  color: var(--fg-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.foot-dl-act {
+  grid-row: 1;
+  grid-column: 3;
+  display: inline-flex;
+  gap: 4px;
+}
+.foot-dl-act button {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  color: var(--fg-4);
+  font-family: var(--jbm);
+  font-size: 10px;
+  padding: 2px 7px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.foot-dl-act button:hover { color: var(--fg); border-color: var(--line-strong); }
+.foot-dl-act button.cancel:hover { color: var(--err); border-color: var(--err-line); }
+.foot-dl-act button.retry:hover { color: var(--accent); border-color: var(--accent-line); }
+
+.foot-dl-bar {
+  grid-row: 2;
+  grid-column: 2 / 4;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.foot-dl-bar-track {
+  flex: 1;
+  max-width: 200px;
+  height: 3px;
+  background: var(--bg-4);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.foot-dl-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+.foot-dl-bar-fill.completed { background: var(--ok); }
+.foot-dl-bar-fill.failed { background: var(--err); }
+
+.foot-dl-stats {
+  color: var(--fg-5);
+  font-size: 10px;
+  display: inline-flex;
+  gap: 6px;
+}
+.foot-dl-err {
+  grid-row: 2;
+  grid-column: 2 / 4;
+  color: var(--err);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Always-on journal chyron (collapsed footer): a thin scrolling tail of the
    most recent entries. Each entry is a device-hued source dot + name · short
    ts · message, separated by a vertical divider so entries read distinctly. */


### PR DESCRIPTION
## Summary

Adds a **Downloads** tab to the footer pane for tracking model download progress, with history of completed/failed/cancelled pulls.

### Backend
- `GET /api/models/pulls` — merged list of active (in-memory) + terminal (persisted) jobs
- `DELETE /api/models/pulls/{model_id}` — clear terminal jobs (409 if active)
- `list_persisted_jobs()` helper to read persisted JSON job snapshots
- `hal0:pull-started` custom event dispatched from `usePullJob` for auto-expand

### Frontend
- Two-tab footer: **Journal** | **Downloads**
- Downloads pane with row-per-job: HF repo link, progress bar, speed, destination path
- Per-row actions: cancel (running), retry (failed), clear (terminal)
- `usePullsList` hook with 2s polling (gated on footer visibility)
- Empty state with link to models page
- Footer auto-expands when a pull starts

### Design
- Spec: `docs/superpowers/specs/2026-07-08-downloads-pane-design.md`