### PR TITLE
fix(ui): make documents card full-width in memory tools

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -990,10 +990,12 @@ async def list_pulls(request: Request) -> list[dict[str, Any]]:
         result.append(entry)
 
     # Sort: active first, then by started_at descending
-    result.sort(key=lambda e: (
-        0 if e.get("state") in ("queued", "running") else 1,
-        -(e.get("started_at") or 0),
-    ))
+    result.sort(
+        key=lambda e: (
+            0 if e.get("state") in ("queued", "running") else 1,
+            -(e.get("started_at") or 0),
+        )
+    )
     return result
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1951,7 +1951,7 @@ class DispatcherConfig(BaseModel):
         description=(
             "Non-streaming upstream read timeout in seconds. "
             "Large consolidation/extraction prompts can exceed 60s on slow slots. "
-            "Streaming paths are unaffected. Range 30–600."
+            "Streaming paths are unaffected. Range 30-600."
         ),
     )
     prefetch_parallel_cap: int = Field(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1440,12 +1440,12 @@ __all__ = [
     "_sanitise_id",
     "get_job",
     "hf_download_url",
+    "list_persisted_jobs",
     "make_job",
     "persist_pull_job",
     "pull_job_file",
     "run_flm_pull",
     "run_pull",
-    "list_persisted_jobs",
     "sweep_orphaned_partials",
     "sweep_pull_jobs",
 ]

--- a/tests/slots/test_manager_npu_container.py
+++ b/tests/slots/test_manager_npu_container.py
@@ -291,9 +291,7 @@ async def test_flm_inference_gate_wedged_npu_stays_warming(
 
     _write_npu_container_slot(slot_root, "npu")
     fake_provider = _make_container_provider_mock()
-    gate = AsyncMock(
-        return_value={"ok": False, "status": "sentinel_completion_http_500"}
-    )
+    gate = AsyncMock(return_value={"ok": False, "status": "sentinel_completion_http_500"})
 
     with (
         patch("hal0.providers.container.container_provider", return_value=fake_provider),

--- a/ui/src/dash/memory-overhaul.css
+++ b/ui/src/dash/memory-overhaul.css
@@ -280,8 +280,8 @@
 .mt-bankbar .input { padding: 6px 9px; }
 .mt-hint { color: var(--fg-5); margin-left: 6px; }
 .mt-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start; }
-/* Two independent stacks: left = reflect · recall · documents, right =
-   mental models · directives. Flex columns (not grid auto-flow) so each side
+/* Two independent stacks: left = reflect · recall, right =
+   directives · mental models. Flex columns (not grid auto-flow) so each side
    stacks on its own regardless of the other's height. */
 .mt-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; align-items: start; }
 .mt-col { display: flex; flex-direction: column; gap: 14px; min-width: 0; }


### PR DESCRIPTION
## What

The documents list in the memory tools panel was trapped inside a two-column grid, getting only half the container width while lines extended past the card boundary.

## Changes

- **Restructure `MemToolsPanel` layout**: Documents moved out of the `mt-cols` grid and rendered as a full-width sibling below
  - Left column: Reflect + Recall
  - Right column: Directives + Mental Models  
  - Full-width below: Documents
- **CSS**: `.mt-col > .mt-card { flex: 1 }` so card pairs in each column share equal height
- **CSS**: `.mt > .mt-card` margin-top for the now-sibling documents card (both embedded and standalone modes)