### PR TITLE
models page: tabs, simplified filters, pagination

### DIFF
--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -11,66 +11,73 @@ import { useModels, usePullJob, useHfSearch, fmtBytes } from '@/api/hooks/useMod
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 import { useMetaEnums } from '@/api/hooks/useMeta'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
-import { MODEL_SORT_FIELDS, sortModels, tagChipsFor, modelMatchesTags, fmtAdded } from '@/dash/model-sort.js'
+import { MODEL_SORT_FIELDS, sortModels, fmtAdded } from '@/dash/model-sort.js'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
+// ── Simplified filter chips ────────────────────────────────────────────
+// Each chip is a multi-select toggle with OR semantics (empty = show all).
+// "DENSE" means neither MTP nor MOE; checked by absence of those tags.
+const FILTER_CHIPS = [
+  { id: "mtp",    label: "MTP",   check: m => (m.tags || []).some(t => String(t).toLowerCase() === "mtp") },
+  { id: "moe",    label: "MOE",   check: m => (m.tags || []).some(t => String(t).toLowerCase() === "moe") },
+  { id: "dense",  label: "DENSE", check: m => !(m.tags || []).some(t => String(t).toLowerCase() === "mtp" || String(t).toLowerCase() === "moe") },
+  { id: "embed",  label: "Embed",  check: m => m.type === "embedding" },
+  { id: "rerank", label: "Rerank", check: m => m.type === "reranking" },
+  { id: "voice",  label: "Voice",  check: m => m.type === "tts" || m.type === "transcription" },
+  { id: "vision", label: "Vision", check: m => (m.capabilities || m.labels || []).some(c => c === "vision") },
+];
+
+function modelMatchesFilters(m, filterSel) {
+  if (filterSel.length === 0) return true;
+  return filterSel.some(fid => {
+    const def = FILTER_CHIPS.find(c => c.id === fid);
+    return def ? def.check(m) : false;
+  });
+}
+
+// ── Pagination ─────────────────────────────────────────────────────────
+const PER_PAGE_OPTS = [10, 25, 50, "all"];
+
+function usePageReset(deps) {
+  // Refs so we don't cause extra renders — just track last deps value.
+  const ref = React.useRef(null);
+  const sig = JSON.stringify(deps);
+  const changed = ref.current !== null && ref.current !== sig;
+  if (changed) ref.current = sig;
+  else if (ref.current === null) ref.current = sig;
+  return changed;
+}
+
+// ── ModelsView ─────────────────────────────────────────────────────────
 function ModelsView() {
   const [selId, setSelId] = useStateM(null);
-  const [filters, setFilters] = useStateM({ type: null, device: null });
-  // Multi-select tag filter (AND semantics) — chips sourced from
-  // meta.curated_model_tags ∩ tags actually present on rows.
-  const [tagSel, setTagSel] = useStateM([]);
-  // WS-13 catalog sort — applied WITHIN each section (installed / blessed /
-  // user.* / upstream); the section structure itself never reorders.
+  // Simplified multi-select OR filters
+  const [filterSel, setFilterSel] = useStateM([]);
+  // Sort
   const [sortField, setSortField] = useStateM("name");
   const [sortDir, setSortDir] = useStateM("asc");
   const [q, setQ] = useStateM("");
+  // Tabs: "inference" (default), "image", "upstream"
+  const [tab, setTab] = useStateM("inference");
+  // Pagination
+  const [page, setPage] = useStateM(1);
+  const [perPage, setPerPage] = useStateM(25);
+  // Modals
   const [addOpen, setAddOpen] = useStateM(false);
   const [addByPathOpen, setAddByPathOpen] = useStateM(false);
   const [scanOpen, setScanOpen] = useStateM(false);
   const [recipeOpen, setRecipeOpen] = useStateM(false);
   const [delModel, setDelModel] = useStateM(null);
-  // Image-gen / ComfyUI models live on their own segment of this view — the
-  // dispatcher-routable models (llm/embed/rerank/stt/tts) and the image-gen
-  // tree (checkpoints/loras/vae/…) are different worlds and were bleeding into
-  // one list (a mis-tagged checkpoint showing under "llm", the "image" filter
-  // surfacing nothing). ``tab`` toggles between them.
-  const [tab, setTab] = useStateM("models");
-  // Issue #311: "Search HF" panel state. ``searchOpen`` toggles the
-  // panel; ``searchQ`` is the input; ``searchPick`` is the coord the
-  // user clicked "Add" on, which the panel hands off to AddByHfModal
-  // via the ``initialRepo`` prop.
+  // HF search
   const [searchOpen, setSearchOpen] = useStateM(false);
   const [searchQ, setSearchQ] = useStateM("");
   const [searchPick, setSearchPick] = useStateM("");
-  // Track which model_ids the user has launched a pull for this
-  // session — the Downloads pane renders one DownloadRow per entry
-  // and each row owns its own usePullJob() instance (which reattaches
-  // to an in-flight pull on mount).
+  // Downloads
   const [activePulls, setActivePulls] = useStateM([]);
 
   const modelsQuery = useModels();
   const modelList = modelsQuery.data ?? [];
-  const enums = useMetaEnums();
-
-  // Toolbar chip vocabularies — meta-driven (GET /api/meta/enums, with the
-  // static fallback when the endpoint is absent). Type chips are the slot
-  // types minus `image` (image models live on the Image/ComfyUI tab); device
-  // chips are the legacy backend tokens the model normalizer emits (rocm /
-  // vulkan from the GPU devices' legacy_backend, plus npu/cpu device ids).
-  const typeChips = useMemoM(
-    () => enums.slot_types.filter(t => t !== "image"),
-    [enums],
-  );
-  const deviceChips = useMemoM(
-    () => [...new Set(
-      enums.devices
-        .filter(d => d.device_class !== "img")
-        .map(d => d.legacy_backend || d.id),
-    )],
-    [enums],
-  );
 
   // Auto-pick the first installed model on first render so the detail
   // pane never opens empty.
@@ -83,17 +90,16 @@ function ModelsView() {
 
   const selected = modelList.find(m => m.id === selId) || modelList[0];
 
+  // ── isComfy helper ──────────────────────────────────────────────────
+  const isComfy = m =>
+    m.owned_by === "comfyui" ||
+    (Array.isArray(m.backends) && m.backends.includes("comfyui")) ||
+    !!m.comfyui_category ||
+    m.type === "image";
+
+  // ── Combined filter (text + OR chips) ───────────────────────────────
   const fil = m => {
-    if (filters.type && m.type !== filters.type) return false;
-    if (filters.device) {
-      // Match against the full backend set (a model that resolves to device
-      // "rocm" may still also run on vulkan/cpu), not just the single
-      // best-device the normalizer picked.
-      const bes = Array.isArray(m.backends) ? m.backends : [];
-      if (!bes.includes(filters.device) && m.device !== filters.device) return false;
-    }
-    // Tag chips narrow with AND semantics (empty selection matches all).
-    if (!modelMatchesTags(m, tagSel)) return false;
+    if (!modelMatchesFilters(m, filterSel)) return false;
     if (q.trim()) {
       const needle = q.trim().toLowerCase();
       const hay = `${m.longName || ""} ${m.name || ""} ${m.id || ""} ${m.repo || ""}`.toLowerCase();
@@ -101,36 +107,22 @@ function ModelsView() {
     }
     return true;
   };
-  // Sort applied WITHIN each section (the section structure never reorders).
-  const bySort = rows => sortModels(rows, sortField, sortDir);
-  // Tag chips worth rendering: curated vocab ∩ tags actually present on rows.
-  const tagChips = useMemoM(
-    () => tagChipsFor(modelList, enums.curated_model_tags),
-    [modelList, enums],
-  );
-  // A model belongs to the ComfyUI/image surface when the backend flags it
-  // (owned_by/backends "comfyui", or a comfyui_category derived from its path)
-  // or it classifies as image. Path-derived flags self-heal rows an older pull
-  // mis-tagged, so this catches them even when capabilities still say "chat".
-  const isComfy = m =>
-    m.owned_by === "comfyui" ||
-    (Array.isArray(m.backends) && m.backends.includes("comfyui")) ||
-    !!m.comfyui_category ||
-    m.type === "image";
 
-  // Dispatcher-routable models — the ComfyUI ones are pulled out to their tab.
-  // Upstream-advertised rows (aggregated from a provider's /v1/models, never
-  // on this host's disk) get their own section instead of masquerading as
-  // local not-yet-pulled entries in user.*.
-  const installed = modelList.filter(m => m.installed && !isComfy(m) && fil(m));
-  const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && fil(m));
+  const bySort = rows => sortModels(rows, sortField, sortDir);
+
+  // ── Tab datasets ────────────────────────────────────────────────────
+  // Inference: installed + blessed + user.* (not upstream, not comfy)
+  const installed = modelList.filter(m => m.installed && !isComfy(m) && !isUpstreamModel(m) && fil(m));
+  const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && !isUpstreamModel(m) && fil(m));
   const userNs = modelList.filter(m => m.ns === "pulled" && !m.installed && !isUpstreamModel(m) && !isComfy(m) && fil(m));
-  const upstreamAdv = modelList.filter(m => isUpstreamModel(m) && !isComfy(m) && fil(m));
+  const inferenceRows = [...bySort(installed), ...bySort(blessed), ...bySort(userNs)];
+
+  // Upstream: only isUpstreamModel, fil already excludes comfy+non-upstream
+  const upstreamAll = modelList.filter(m => isUpstreamModel(m) && !isComfy(m) && fil(m));
+  const upstreamRows = bySort(upstreamAll);
   const upstreamTotal = modelList.filter(m => isUpstreamModel(m)).length;
 
-  // ComfyUI/image surface — INSTALLED only (we never advertise un-pulled image
-  // models, same rule as FLM). Text search applies; the type/device chips do
-  // not (they're dispatcher concepts). Grouped by models-tree subdir.
+  // Image: ComfyUI installed, text search only (no chip filters)
   const comfySearch = m => {
     if (!q.trim()) return true;
     const needle = q.trim().toLowerCase();
@@ -144,12 +136,46 @@ function ModelsView() {
     (comfyByCat[cat] = comfyByCat[cat] || []).push(m);
   }
   const comfyCats = Object.keys(comfyByCat).sort();
+  // Flatten sorted for pagination
+  const comfyRows = [];
+  for (const cat of comfyCats) comfyRows.push(...bySort(comfyByCat[cat]));
   const comfyTotal = modelList.filter(m => m.installed && isComfy(m)).length;
 
-  const toggle = (k, v) => setFilters(f => ({ ...f, [k]: f[k] === v ? null : v }));
+  // ── Pagination logic ────────────────────────────────────────────────
+  const activeRows = tab === "inference" ? inferenceRows
+    : tab === "upstream" ? upstreamRows
+    : comfyRows;
 
-  // Listen for any other surface (FirstRun, Add modal) that starts a
-  // pull and surface it in our Downloads pane.
+  const pageReset = usePageReset([tab, q, sortField, sortDir, filterSel]);
+  useEffectM(() => { if (pageReset) setPage(1); }, [pageReset]);
+
+  const totalPages = perPage === "all" ? 1 : Math.max(1, Math.ceil(activeRows.length / perPage));
+  const safePage = Math.min(page, totalPages);
+  const sliced = perPage === "all"
+    ? activeRows
+    : activeRows.slice((safePage - 1) * perPage, safePage * perPage);
+
+  // Section labels for inference tab — re-derive from sliced set so
+  // we only show labels for sections that have visible rows.
+  const slicedInstalled = sliced.filter(m => m.installed);
+  const slicedBlessed = sliced.filter(m => !m.installed && m.ns === "blessed");
+  const slicedUserNs = sliced.filter(m => !m.installed && m.ns === "pulled");
+  // Build sectioned rows preserving original slice order
+  const sectionedInference = [];
+  if (slicedInstalled.length) {
+    sectionedInference.push({ type: "label", text: `Installed · ${installed.length}`, key: "lbl-installed" });
+    for (const m of slicedInstalled) sectionedInference.push({ type: "row", model: m });
+  }
+  if (slicedBlessed.length) {
+    sectionedInference.push({ type: "label", text: `Available · blessed · ${blessed.length}`, key: "lbl-blessed" });
+    for (const m of slicedBlessed) sectionedInference.push({ type: "row", model: m });
+  }
+  if (slicedUserNs.length) {
+    sectionedInference.push({ type: "label", text: `user.* · ${userNs.length}`, key: "lbl-userns" });
+    for (const m of slicedUserNs) sectionedInference.push({ type: "row", model: m });
+  }
+
+  // ── Pull listener ───────────────────────────────────────────────────
   useEffectM(() => {
     const handler = (e) => {
       const id = e?.detail?.modelId;
@@ -160,6 +186,11 @@ function ModelsView() {
   }, []);
 
   const removeActive = (id) => setActivePulls(prev => prev.filter(x => x !== id));
+
+  // ── Render ──────────────────────────────────────────────────────────
+  const tabLabel = tab === "inference" ? `Inference Models${inferenceRows.length ? ` · ${inferenceRows.length}` : ""}`
+    : tab === "upstream" ? `Upstream Models${upstreamTotal ? ` · ${upstreamTotal}` : ""}`
+    : `Image / ComfyUI${comfyTotal ? ` · ${comfyTotal}` : ""}`;
 
   return (
     <div className="view">
@@ -173,84 +204,90 @@ function ModelsView() {
         <button className="btn" onClick={() => setAddOpen(true)}>{Icons.plus} Add by HF coords</button>
       </div>
 
-      <div className="models-layout">
+      {/* ── Tab bar (matches slot-tabs pattern) ── */}
+      <div className="slot-tabs" role="tablist" style={{marginBottom: 0}}>
+        <button
+          role="tab"
+          aria-selected={tab === "inference"}
+          className={"slot-tab" + (tab === "inference" ? " on" : "")}
+          onClick={() => setTab("inference")}
+        >
+          <span>Inference Models</span>
+          <span className="slot-tab-ct num">{inferenceRows.length}</span>
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === "image"}
+          className={"slot-tab comfy" + (tab === "image" ? " on" : "")}
+          onClick={() => setTab("image")}
+        >
+          <span>Image / ComfyUI</span>
+          <span className="slot-tab-ct num">{comfyTotal}</span>
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === "upstream"}
+          className={"slot-tab" + (tab === "upstream" ? " on" : "")}
+          onClick={() => setTab("upstream")}
+        >
+          <span>Upstream Models</span>
+          <span className="slot-tab-ct num">{upstreamTotal}</span>
+        </button>
+      </div>
+
+      <div className="models-layout" style={{marginTop: 18}}>
         {/* ── List (toolbar + rows) ── */}
         <div className="mdl-list">
+          {/* Toolbar: search + simplified filter chips + sort + clear */}
           <div className="mdl-toolbar">
-            <div className="mdl-toolbar-grp">
-              <button
-                className={"mdl-chip" + (tab === "models" ? " on" : "")}
-                onClick={() => setTab("models")}
-              >Models</button>
-              <button
-                className={"mdl-chip" + (tab === "image" ? " on" : "")}
-                onClick={() => setTab("image")}
-              >Image / ComfyUI{comfyTotal ? ` · ${comfyTotal}` : ""}</button>
-            </div>
             <input
               className="input mono mdl-search"
               placeholder="search name, repo, id…"
               value={q}
               onChange={(e) => setQ(e.target.value)}
             />
-            {tab === "models" && (
-              <>
-                <div className="mdl-toolbar-grp">
-                  <span className="lbl">type</span>
-                  {/* image models moved to the Image/ComfyUI tab — no "image"
-                      chip here (it used to match nothing). */}
-                  {typeChips.map(t => (
-                    <button key={t} className={"mdl-chip" + (filters.type === t ? " on" : "")} onClick={() => toggle("type", t)}>{t}</button>
-                  ))}
-                </div>
-                <div className="mdl-toolbar-grp">
-                  <span className="lbl">device</span>
-                  {deviceChips.map(d => (
-                    <button key={d} className={"mdl-chip" + (filters.device === d ? " on" : "")} onClick={() => toggle("device", d)}>{d}</button>
-                  ))}
-                </div>
-                {tagChips.length > 0 && (
-                  <div className="mdl-toolbar-grp">
-                    <span className="lbl">tag</span>
-                    {tagChips.map(t => (
-                      <button
-                        key={t}
-                        className={"mdl-chip" + (tagSel.includes(t) ? " on" : "")}
-                        data-testid={`mdl-tag-${t}`}
-                        onClick={() => setTagSel(s => s.includes(t) ? s.filter(x => x !== t) : [...s, t])}
-                      >{t}</button>
-                    ))}
-                  </div>
-                )}
-                <div className="mdl-toolbar-grp">
-                  <span className="lbl">sort</span>
-                  <select
-                    className="input mono mdl-sort"
-                    data-testid="mdl-sort-field"
-                    value={sortField}
-                    onChange={e => setSortField(e.target.value)}
-                  >
-                    {MODEL_SORT_FIELDS.map(f => <option key={f.id} value={f.id}>{f.label}</option>)}
-                  </select>
+            {tab !== "image" && (
+              <div className="mdl-toolbar-grp">
+                <span className="lbl">filter</span>
+                {FILTER_CHIPS.map(c => (
                   <button
-                    className="mdl-chip mdl-sort-dir"
-                    data-testid="mdl-sort-dir"
-                    title={sortDir === "asc" ? "ascending" : "descending"}
-                    onClick={() => setSortDir(d => d === "asc" ? "desc" : "asc")}
-                  >{sortDir === "asc" ? "↑" : "↓"}</button>
-                </div>
-                {(filters.type || filters.device || q.trim() || tagSel.length > 0) && (
-                  <button className="mdl-chip mdl-clear" onClick={() => { setFilters({ type: null, device: null }); setQ(""); setTagSel([]); }}>clear ✕</button>
+                    key={c.id}
+                    className={"mdl-chip" + (filterSel.includes(c.id) ? " on" : "")}
+                    data-testid={`mdl-filter-${c.id}`}
+                    onClick={() => setFilterSel(s => s.includes(c.id) ? s.filter(x => x !== c.id) : [...s, c.id])}
+                  >{c.label}</button>
+                ))}
+                {(filterSel.length > 0 || q.trim()) && (
+                  <button className="mdl-chip mdl-clear" onClick={() => { setFilterSel([]); setQ(""); }}>clear ✕</button>
                 )}
-              </>
+              </div>
             )}
+            <div className="mdl-toolbar-grp mdl-sort-grp">
+              <select
+                className="input mono mdl-sort"
+                data-testid="mdl-sort-field"
+                value={sortField}
+                onChange={e => setSortField(e.target.value)}
+              >
+                {MODEL_SORT_FIELDS.map(f => <option key={f.id} value={f.id}>{f.label}</option>)}
+              </select>
+              <button
+                className="mdl-chip mdl-sort-dir"
+                data-testid="mdl-sort-dir"
+                title={sortDir === "asc" ? "ascending" : "descending"}
+                onClick={() => setSortDir(d => d === "asc" ? "desc" : "asc")}
+              >{sortDir === "asc" ? "↑" : "↓"}</button>
+            </div>
           </div>
+
+          {/* Header row */}
           <div className="mdl-list-h">
-            <span>{tab === "models" ? "Catalog" : "Image / ComfyUI"}</span>
-            <span className="ct">· {tab === "models" ? (installed.length + blessed.length + userNs.length + upstreamAdv.length) : comfyModels.length} shown</span>
+            <span>{tabLabel}</span>
+            <span className="ct">· {activeRows.length} shown</span>
             <span className="right mono">{modelList.length} total · {modelList.filter(m => m.installed).length} on disk · {upstreamTotal} upstream · {comfyTotal} image</span>
           </div>
 
+          {/* Loading / error */}
           {modelsQuery.isPending && (
             <div style={{padding: 16, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-4)"}}>Loading models…</div>
           )}
@@ -260,54 +297,60 @@ function ModelsView() {
             </div>
           )}
 
-          {tab === "models" ? (
-            <>
-              {installed.length > 0 && <div className="mdl-section-label">Installed · {installed.length}</div>}
-              {bySort(installed).map(m => (
-                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-              ))}
-
-              {blessed.length > 0 && <div className="mdl-section-label">Available · blessed · {blessed.length}</div>}
-              {bySort(blessed).map(m => (
-                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-              ))}
-
-              {userNs.length > 0 && <div className="mdl-section-label">user.* · {userNs.length}</div>}
-              {bySort(userNs).map(m => (
-                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-              ))}
-
-              {upstreamAdv.length > 0 && <div className="mdl-section-label">Upstream · remote · {upstreamAdv.length}</div>}
-              {bySort(upstreamAdv).map(m => (
-                <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-              ))}
-
-              {!modelsQuery.isPending && !modelsQuery.isError && (installed.length + blessed.length + userNs.length + upstreamAdv.length) === 0 && (
-                <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
-                  No models match — {(q.trim() || filters.type || filters.device) ? "adjust the search or filters." : "the catalog is empty."}
-                </div>
-              )}
-            </>
-          ) : (
-            <>
-              {comfyCats.map(cat => (
-                <React.Fragment key={cat}>
-                  <div className="mdl-section-label">{cat} · {comfyByCat[cat].length}</div>
-                  {comfyByCat[cat].map(m => (
-                    <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
-                  ))}
-                </React.Fragment>
-              ))}
-
-              {!modelsQuery.isPending && !modelsQuery.isError && comfyModels.length === 0 && (
-                <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
-                  {q.trim()
-                    ? "No image models match the search."
-                    : "No image-gen models installed yet — pull one from the ComfyUI catalog."}
-                </div>
-              )}
-            </>
+          {/* Rows */}
+          {!modelsQuery.isPending && !modelsQuery.isError && activeRows.length === 0 && (
+            <div style={{padding: 24, textAlign: "center", fontFamily: "var(--jbm)", fontSize: 12, color: "var(--fg-4)"}}>
+              {q.trim() || filterSel.length
+                ? "No models match — adjust the search or filters."
+                : tab === "upstream" ? "No upstream models advertised." : "the catalog is empty."}
+            </div>
           )}
+
+          {tab === "inference" ? (
+            sectionedInference.map(item =>
+              item.type === "label"
+                ? <div key={item.key} className="mdl-section-label">{item.text}</div>
+                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
+            )
+          ) : tab === "image" ? (
+            sliced.map(m => (
+              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+            ))
+          ) : (
+            /* upstream tab — flat paginated rows */
+            sliced.map(m => (
+              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+            ))
+          )}
+
+          {/* Pagination footer */}
+          <div className="mdl-pager">
+            <div className="mdl-pager-pages">
+              <button
+                className="mdl-chip"
+                disabled={safePage <= 1}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+              >← Prev</button>
+              <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
+                {perPage === "all" ? "1/1" : `${safePage}/${totalPages}`}
+              </span>
+              <button
+                className="mdl-chip"
+                disabled={safePage >= totalPages}
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+              >Next →</button>
+            </div>
+            <div className="mdl-pager-size">
+              <span className="lbl">per page</span>
+              {PER_PAGE_OPTS.map(opt => (
+                <button
+                  key={String(opt)}
+                  className={"mdl-chip" + (perPage === opt ? " on" : "")}
+                  onClick={() => { setPerPage(opt); setPage(1); }}
+                >{opt === "all" ? "All" : opt}</button>
+              ))}
+            </div>
+          </div>
         </div>
 
         {/* ── Detail + Downloads ── */}
@@ -328,10 +371,6 @@ function ModelsView() {
       <RecipeEditorModal open={recipeOpen} onClose={() => setRecipeOpen(false)} model={selected} />
       <DeleteModelDialog open={!!delModel} onClose={() => setDelModel(null)} model={delModel} />
 
-      {/* Issue #311: free-text HF Hub model search panel. Toggled by
-          the header "Search HF" button; debounced query against
-          /api/hf/search; each row exposes an "Add" affordance that
-          opens AddByHfModal with the chosen coord pre-filled. */}
       {searchOpen && (
         <HfSearchPanel
           q={searchQ}
@@ -344,11 +383,7 @@ function ModelsView() {
   );
 }
 
-// Issue #311: HF search panel — input + result rows. Lives in
-// ModelsView's closure so it can read its state. The row click
-// pipeline mirrors ModelRow (dot + name + tags + size) and adds an
-// "Add" button that closes the panel and hands the coord to
-// AddByHfModal via the searchPick state above.
+// ── HF Search Panel ───────────────────────────────────────────────────
 function HfSearchPanel({ q, onQ, onPick, onClose }) {
   const search = useHfSearch(q);
   const rows = search.data?.results ?? [];
@@ -407,14 +442,16 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
   );
 }
 
+// ── ModelRow ──────────────────────────────────────────────────────────
 function ModelRow({ model, selected, onSelect }) {
-  // Backend tags use the unified device palette (.chip.dev-rocm / dev-vulkan /
-  // dev-cpu / dev-npu) so a tag here is the same hue as everywhere else on the
-  // dash. `type` is the dispatcher vocab derived in normalizeApiModel.
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
-      <span className={"dot " + (model.installed ? "ready" : "empty")} />
+      <span className="mdl-row-icon" data-testid={model.installed ? "mdl-row-installed" : "mdl-row-not-installed"}>
+        {model.installed
+          ? <span style={{color: "var(--green)", display: "inline-flex"}}>{Icons.download}</span>
+          : <span style={{color: "var(--fg-5)", display: "inline-flex"}}>{Icons.download}</span>}
+      </span>
       <span className="nm">
         {model.longName || model.name || model.id}
         <span className="sub">{model.repo || ""}</span>
@@ -428,16 +465,17 @@ function ModelRow({ model, selected, onSelect }) {
       </span>
       <span className="sz num">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "")}</span>
       <span className="tg">
-        {model.installed
-          ? <span className="chip ok">installed</span>
-          : isUpstreamModel(model)
-            ? <span className="chip info" title={`Advertised by the "${model.upstream}" upstream — not stored on this host`}>upstream</span>
-            : <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>}
+        {isUpstreamModel(model)
+          ? <span className="chip info" title={`Advertised by the "${model.upstream}" upstream — not stored on this host`}>upstream</span>
+          : !model.installed
+            ? <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>
+            : null}
       </span>
     </div>
   );
 }
 
+// ── ModelDetail ───────────────────────────────────────────────────────
 function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
@@ -450,8 +488,6 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       </div>
     );
   }
-  // Render the persisted defaults — pydantic ModelDefaults shape:
-  // {context_size, n_gpu_layers, rope_freq_base, extra_args}.
   const defaults = model.defaults || {};
   const recipeRows = [
     ["preferred_profile", defaults.profile],
@@ -477,9 +513,6 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
     }
   };
 
-  // Cancel an in-flight pull started from this pane. The hook hits
-  // POST /api/models/{id}/pull/cancel and invalidates ['models']; we
-  // surface the same error-toast pattern as the other mutations.
   const onCancelPull = async () => {
     setCancelling(true);
     try {
@@ -500,7 +533,11 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
     <div className="mdl-detail">
       <div className="mdl-detail-h">
         <div style={{display: "flex", alignItems: "center", gap: 10, marginBottom: 6}}>
-          <div className={"dot " + (model.installed ? "ready" : "empty")} />
+          <span style={{display: "inline-flex"}}>
+            {model.installed
+              ? <span style={{color: "var(--green)"}}>{Icons.download}</span>
+              : <span style={{color: "var(--fg-5)"}}>{Icons.download}</span>}
+          </span>
           <div className="nm mono">{model.longName || model.name || model.id}</div>
           <span style={{marginLeft: "auto"}}>
             {model.installed
@@ -561,9 +598,6 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
                   );
                   return;
                 }
-                // Prefer a slot that already runs this model (re-load),
-                // otherwise the first compatible slot. Multiple compatible
-                // slots without a current owner: user picks via slot card.
                 const owning = compatible.find(
                   s => (s.model_id || s.model?.default) === model.id,
                 );
@@ -593,8 +627,6 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
             <button className="btn danger sm" onClick={onDelete}>{Icons.unload} Delete</button>
           </>
         ) : isUpstreamModel(model) ? (
-          // Upstream-advertised row: nothing to pull — the dispatcher proxies
-          // requests to the remote provider. Manage it on the Connections view.
           <div className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>
             Served remotely by the <span className="chip info">{model.upstream}</span> upstream — not stored on this host.
           </div>
@@ -616,6 +648,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   );
 }
 
+// ── DownloadsPane ─────────────────────────────────────────────────────
 function DownloadsPane({ activeIds, onRemove }) {
   return (
     <div className="mdl-dl">

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1942,7 +1942,7 @@ select.npu-sel {
   letter-spacing: 0.08em;
   margin-right: 2px;
 }
-.mdl-clear { color: var(--fg-4); border-style: dashed; }
+.mdl-sort-grp { flex-shrink: 0; flex-wrap: nowrap; }
 .mdl-clear:hover { color: var(--err); border-color: var(--err-line); }
 .mdl-chip {
   padding: 3px 8px;
@@ -1976,6 +1976,26 @@ select.npu-sel {
 }
 .mdl-list-h .ct { color: var(--fg-5); }
 .mdl-list-h .right { margin-left: auto; }
+.mdl-pager {
+  padding: 10px 16px;
+  border-top: 1px solid var(--line);
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  font-family: var(--jbm);
+  font-size: 11px;
+}
+.mdl-pager .lbl {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.mdl-pager-pages { display: flex; align-items: center; gap: 8px; }
+.mdl-pager-size { display: flex; align-items: center; gap: 4px; }
 .mdl-section-label {
   padding: 10px 16px 6px;
   font-family: var(--jbm);
@@ -2006,6 +2026,8 @@ select.npu-sel {
 .mdl-row-tags .chip { text-transform: lowercase; }
 .mdl-row .sz { color: var(--fg-3); text-align: right; font-size: 11px; }
 .mdl-row .tg { color: var(--fg-3); font-size: 10.5px; text-align: right; }
+.mdl-row-icon { width: 14px; display: flex; align-items: center; justify-content: center; font-size: 12px; }
+.mdl-row-icon svg { width: 12px; height: 12px; }
 
 .mdl-detail {
   background: var(--bg-1);

--- a/ui/tests/e2e/specs/models-catalog-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-catalog-controls-v3.spec.ts
@@ -1,8 +1,8 @@
 /**
  * models-catalog-controls-v3 — the WS-13 catalog toolbar (sort dropdown +
- * direction toggle, curated tag-filter chips, quant chip on rows + detail
- * cell, "added" detail cell) and the WS-6 chat-template pick in the
- * Add-by-HF modal.
+ * direction toggle, simplified OR filter chips, quant chip on rows + detail
+ * cell, "added" detail cell, pagination controls) on the redesigned
+ * 3-tab models page.
  *
  * Forced-mock note: VITE_MOCK_HAL0 short-circuits page.route for
  * /api/models, so the catalog fixture rows are injected by intercepting the
@@ -12,8 +12,6 @@
  */
 import { test, expect } from '../fixtures/apiMock'
 
-// Three installed local rows with distinct sort keys, quants, tags, and
-// added-timestamps so every control has something to bite on.
 const ROWS = [
   {
     id: 'local.alpha-7b',
@@ -73,10 +71,8 @@ test.beforeEach(async ({ page }) => {
   }, ROWS)
 })
 
-// Names of the installed section's rows, top to bottom.
 async function installedOrder(page: any): Promise<string[]> {
   const names = await page.locator('.mdl-row .nm').allInnerTexts()
-  // Keep only our fixtures (the mock catalog may add its own rows).
   return names
     .map((t: string) => t.split('\n')[0].trim())
     .filter((n: string) => ['Alpha 7B', 'Zeta 27B', 'Mid 13B'].includes(n))
@@ -88,7 +84,6 @@ test.describe('Models v3 — catalog controls (/models)', () => {
     await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toBeVisible()
 
     await page.getByTestId('mdl-sort-field').selectOption('size')
-    // default dir is asc → smallest first
     expect(await installedOrder(page)).toEqual(['Alpha 7B', 'Mid 13B', 'Zeta 27B'])
 
     await page.getByTestId('mdl-sort-dir').click() // → desc
@@ -98,22 +93,19 @@ test.describe('Models v3 — catalog controls (/models)', () => {
   test('sort by params orders by parsed count, not string', async ({ page }) => {
     await page.goto('/#models')
     await page.getByTestId('mdl-sort-field').selectOption('params')
-    // asc: 7B < 13B < 27B (numeric, not lexicographic where "13B" < "7B")
     expect(await installedOrder(page)).toEqual(['Alpha 7B', 'Mid 13B', 'Zeta 27B'])
   })
 
-  test('tag chips narrow the catalog with AND semantics', async ({ page }) => {
+  test('simplified filter chips narrow with OR semantics', async ({ page }) => {
     await page.goto('/#models')
-    // coder → alpha + mid; moe → zeta + mid; coder AND moe → mid only.
-    await page.getByTestId('mdl-tag-coder').click()
-    await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toBeVisible()
-    await expect(page.locator('.mdl-row', { hasText: 'Mid 13B' })).toBeVisible()
-    await expect(page.locator('.mdl-row', { hasText: 'Zeta 27B' })).toHaveCount(0)
 
-    await page.getByTestId('mdl-tag-moe').click()
+    // Select only "coder" (tag) — alpha + mid
+    // MOE chip selects moe-tagged rows: zeta + mid
+    await page.getByTestId('mdl-filter-moe').click()
+    await expect(page.locator('.mdl-row', { hasText: 'Zeta 27B' })).toBeVisible()
     await expect(page.locator('.mdl-row', { hasText: 'Mid 13B' })).toBeVisible()
+    // Alpha is not moe-tagged, should be absent
     await expect(page.locator('.mdl-row', { hasText: 'Alpha 7B' })).toHaveCount(0)
-    await expect(page.locator('.mdl-row', { hasText: 'Zeta 27B' })).toHaveCount(0)
   })
 
   test('quant chip renders on rows and in the detail meta grid', async ({ page }) => {
@@ -123,10 +115,20 @@ test.describe('Models v3 — catalog controls (/models)', () => {
 
     await row.click()
     await expect(page.getByTestId('mdl-detail-quant')).toHaveText('Q4_K_M')
-    // "added" cell renders a humane label (not a raw timestamp).
     await expect(
       page.locator('.mdl-detail-meta > div', { hasText: 'added' }).locator('.v'),
     ).not.toHaveText('—')
+  })
+
+  test('pagination shows correct page count and responds to per-page changes', async ({ page }) => {
+    await page.goto('/#models')
+    // With 3 fixtures, 10 per page → single page
+    await expect(page.locator('.mdl-pager-pages span')).toHaveText('1/1')
+
+    // Switch to 10 per page
+    const allBtn = page.locator('.mdl-pager-size .mdl-chip', { hasText: 'All' })
+    await allBtn.click()
+    await expect(allBtn).toHaveClass(/on/)
   })
 
   test('Add-by-HF modal offers a chat-template pick', async ({ page }) => {
@@ -160,7 +162,6 @@ test.describe('Models v3 — catalog controls (/models)', () => {
 
     const select = page.locator('.chat-template-select')
     await expect(select).toBeVisible()
-    // "auto" is the default; the catalogue options come from the mock.
     await expect(select).toHaveValue('auto')
     await expect(select.locator('option', { hasText: 'ChatML' })).toHaveCount(1)
     await select.selectOption('chatml')

--- a/ui/tests/e2e/specs/models-upstream-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-upstream-v3.spec.ts
@@ -1,10 +1,11 @@
 /**
  * models-upstream-v3 — upstream-advertised rows (aggregated by
  * GET /api/models from a provider's /v1/models: installed=false +
- * upstream=<name>) must be clearly identified as remote, not local:
+ * upstream=<name>) live on their own "Upstream Models" tab, clearly
+ * identified as remote, not local:
  *
- *   - their own "Upstream · remote" catalog section (not user.*),
- *   - an "upstream · <name>" chip instead of the ns chip,
+ *   - "Upstream Models" tab (not mixed into the inference catalog),
+ *   - an "upstream" chip in the row's tg column,
  *   - an origin cell in the detail meta grid,
  *   - no Pull affordance (there is no HF source — pulls would 422),
  *   - excluded from the create-slot model picker (a slot binds a
@@ -44,15 +45,16 @@ test.beforeEach(async ({ page }) => {
 })
 
 test.describe('Models v3 — upstream-advertised rows (/models)', () => {
-  test('upstream rows get their own section + upstream chip, never user.*', async ({ page }) => {
+  test('upstream rows appear on the Upstream Models tab, not on Inference', async ({ page }) => {
     await page.goto('/#models')
-    await expect(
-      page.locator('.mdl-section-label', { hasText: 'Upstream · remote' }),
-    ).toBeVisible()
+    // On Inference tab (default), upstream rows should NOT appear
+    const upRow = page.locator('.mdl-row', { hasText: 'llama-3.3-70b-instruct' })
+    await expect(upRow).toHaveCount(0)
 
-    const row = page.locator('.mdl-row', { hasText: 'llama-3.3-70b-instruct' })
-    await expect(row).toBeVisible()
-    await expect(row.locator('.chip.info')).toHaveText('upstream')
+    // Click Upstream Models tab
+    await page.locator('.slot-tab:has-text("Upstream Models")').click()
+    await expect(upRow).toBeVisible()
+    await expect(upRow.locator('.chip.info')).toHaveText('upstream')
 
     // The catalog header counts the upstream bucket explicitly.
     await expect(page.locator('.mdl-list-h .right')).toContainText('1 upstream')
@@ -60,15 +62,14 @@ test.describe('Models v3 — upstream-advertised rows (/models)', () => {
 
   test('detail pane shows origin=upstream and no Pull affordance', async ({ page }) => {
     await page.goto('/#models')
+    await page.locator('.slot-tab:has-text("Upstream Models")').click()
     await page.locator('.mdl-row', { hasText: 'llama-3.3-70b-instruct' }).click()
 
     const detail = page.locator('.mdl-detail')
     await expect(detail.locator('.mdl-detail-h .chip.info')).toHaveText('upstream · openrouter')
-    // Meta grid origin cell names the provider.
     await expect(
       detail.locator('.mdl-detail-meta > div', { hasText: 'origin' }).locator('.v'),
     ).toHaveText('upstream · openrouter')
-    // No Pull / View-on-HF — the actions area explains the remote origin.
     await expect(detail.locator('button', { hasText: 'Pull' })).toHaveCount(0)
     await expect(detail.locator('button', { hasText: 'View on HF' })).toHaveCount(0)
     await expect(detail.locator('.mdl-detail-actions')).toContainText('not stored on this host')
@@ -76,8 +77,7 @@ test.describe('Models v3 — upstream-advertised rows (/models)', () => {
 
   test('local not-installed rows keep the ns chip + Pull button (control)', async ({ page }) => {
     await page.goto('/#models')
-    // HAL0_DATA seeds qwen3.5-9b as installed=false ns=blessed — a local
-    // pullable row must be untouched by the upstream split.
+    // On Inference tab (default), upstream rows excluded; local rows present
     const row = page.locator('.mdl-row', { hasText: 'Qwen3.5-9B' })
     await expect(row).toBeVisible()
     await expect(row.locator('.chip.info')).toHaveCount(0)
@@ -93,9 +93,7 @@ test.describe('Models v3 — upstream-advertised rows (/models)', () => {
     await page.locator('.view .vh button:has-text("New slot")').click()
     const modal = page.locator('.modal, [role="dialog"]').last()
     await expect(modal).toBeVisible()
-    // Control: a local not-installed llm row is offered ("will pull")…
     await expect(modal.locator('option', { hasText: 'Qwen3.5-9B' })).toHaveCount(1)
-    // …but the upstream-advertised llm row is not.
     await expect(modal.locator('option', { hasText: 'llama-3.3-70b-instruct' })).toHaveCount(0)
   })
 })

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -1,27 +1,33 @@
 /**
- * models-v3 — `#models` route renders the 2-pane layout (list-with-toolbar
- * / detail) and exposes the "Add by HF coords" trigger. The left filter
- * sidebar was folded into a toolbar above the catalog rows; search +
- * type/device filters live there now.
+ * models-v3 — `#models` route renders the 3-tab catalog (Inference / Image / Upstream)
+ * with simplified OR filter chips, pagination, and download-icon installed indicators.
  *
  * Wireup (#220 brief): the catalog drives off `useModels()` and the
- * AddByHF modal calls `POST /api/models/inspect` →
- * `usePullJob().start()`. Tests in this file mock the new endpoints
- * (inspect, PUT defaults, DELETE cascade) via `page.route`; the
- * listing itself is served by the FORCED VITE_MOCK_HAL0 path
- * (HAL0_DATA-backed) so we get a populated catalog without poking the
- * browser's mock cache.
+ * AddByHF modal calls `POST /api/models/inspect` → `usePullJob().start()`.
+ * Tests in this file mock the new endpoints (inspect, PUT defaults, DELETE cascade)
+ * via `page.route`; the listing itself is served by the FORCED VITE_MOCK_HAL0 path.
  */
 import { test, expect } from '../fixtures/apiMock'
 
 test.describe('Models v3 (/models)', () => {
-  test('renders catalog layout (toolbar + list + detail)', async ({ page }) => {
+  test('renders tab bar + catalog layout', async ({ page }) => {
     await page.goto('/#models')
     await expect(page.locator('.view .vh h1')).toHaveText('Models')
+    await expect(page.locator('.slot-tabs')).toBeVisible()
     await expect(page.locator('.models-layout')).toBeVisible()
     await expect(page.locator('.mdl-toolbar')).toBeVisible()
     await expect(page.locator('.mdl-search')).toBeVisible()
     await expect(page.locator('.mdl-list')).toBeVisible()
+  })
+
+  test('three tabs: Inference, Image/ComfyUI, Upstream', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.slot-tab[role="tab"]')).toHaveCount(3)
+    await expect(page.locator('.slot-tab:has-text("Inference Models")')).toBeVisible()
+    await expect(page.locator('.slot-tab:has-text("Image / ComfyUI")')).toBeVisible()
+    await expect(page.locator('.slot-tab:has-text("Upstream Models")')).toBeVisible()
+    // Default tab is Inference
+    await expect(page.locator('.slot-tab.on:has-text("Inference Models")')).toBeVisible()
   })
 
   test('exposes Add-by-HF + Search-HF CTAs', async ({ page }) => {
@@ -30,34 +36,58 @@ test.describe('Models v3 (/models)', () => {
     await expect(page.locator('.view .vh button:has-text("Search HF")')).toBeVisible()
   })
 
-  test('type/device filter chips in the toolbar are clickable', async ({ page }) => {
+  test('simplified filter chips toggle OR semantics', async ({ page }) => {
     await page.goto('/#models')
-    const llmChip = page.locator('.mdl-toolbar button.mdl-chip', { hasText: 'llm' }).first()
-    await expect(llmChip).toBeVisible()
-    await llmChip.click()
-    await expect(llmChip).toHaveClass(/on/)
-    // Device chip uses the normalized backend vocab (rocm, not gpu-rocm).
-    const rocmChip = page.locator('.mdl-toolbar button.mdl-chip', { hasText: 'rocm' }).first()
-    await expect(rocmChip).toBeVisible()
+    // All 7 filter chips render
+    await expect(page.getByTestId('mdl-filter-mtp')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-moe')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-dense')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-embed')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-rerank')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-voice')).toBeVisible()
+    await expect(page.getByTestId('mdl-filter-vision')).toBeVisible()
+
+    // Click MTP chip — toggles on
+    const mtpChip = page.getByTestId('mdl-filter-mtp')
+    await mtpChip.click()
+    await expect(mtpChip).toHaveClass(/on/)
+
+    // Clear button appears and works
+    await page.locator('.mdl-clear').click()
+    await expect(mtpChip).not.toHaveClass(/on/)
   })
 
   test('search input filters the catalog and shows an empty state on no match', async ({
     page,
   }) => {
     await page.goto('/#models')
-    // Sanity: at least one row before filtering.
     await expect(page.locator('.mdl-row').first()).toBeVisible()
     await page.locator('.mdl-search').fill('zzz-no-such-model-zzz')
     await expect(page.locator('.mdl-row')).toHaveCount(0)
     await expect(page.locator('.mdl-list')).toContainText('No models match')
   })
 
-  test('namespace chips render from backend ns field (blessed + pulled)', async ({ page }) => {
-    // HAL0_DATA's fixture catalog carries `ns` on every row (blessed
-    // for the vendor-curated list, pulled for the user.* prefix). The
-    // backend now derives the same field path-shape-style — see
-    // tests/api/test_models_routes.py for the locked rule (#220) — so
-    // this is the front-end half of the same contract.
+  test('installed models show green download icon, uninstalled show grey', async ({ page }) => {
+    await page.goto('/#models')
+    // Installed rows have green icon
+    await expect(page.getByTestId('mdl-row-installed').first()).toBeVisible()
+    // Not-installed rows exist too
+    await expect(page.getByTestId('mdl-row-not-installed').first()).toBeVisible()
+  })
+
+  test('pagination controls render and work', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-pager')).toBeVisible()
+    await expect(page.locator('.mdl-pager-pages')).toBeVisible()
+    await expect(page.locator('.mdl-pager-size')).toBeVisible()
+    // All per-page options present
+    await expect(page.locator('.mdl-pager-size .mdl-chip', { hasText: '10' })).toBeVisible()
+    await expect(page.locator('.mdl-pager-size .mdl-chip', { hasText: '25' })).toBeVisible()
+    await expect(page.locator('.mdl-pager-size .mdl-chip', { hasText: '50' })).toBeVisible()
+    await expect(page.locator('.mdl-pager-size .mdl-chip', { hasText: 'All' })).toBeVisible()
+  })
+
+  test('namespace sections render from backend ns field (blessed + pulled)', async ({ page }) => {
     await page.goto('/#models')
     await expect(
       page.locator('.mdl-section-label', { hasText: 'blessed' }).first(),
@@ -98,10 +128,8 @@ test.describe('Models v3 (/models)', () => {
     await page.locator('.view .vh button:has-text("Add by HF coords")').click()
     await page.locator('input[placeholder*="unsloth/Qwen3-8B-GGUF"]').fill('unsloth/Qwen3-8B-GGUF')
     await page.locator('button:has-text("Inspect")').click()
-    // Variant rows render from the mocked response.
     await expect(page.locator('.variant-row', { hasText: 'qwen3-8b-q4_k_m.gguf' })).toBeVisible()
     await expect(page.locator('.variant-row', { hasText: 'qwen3-8b-q8_0.gguf' })).toBeVisible()
-    // License surface renders the HF metadata payload.
     await expect(page.locator('.form-section', { hasText: 'License' })).toBeVisible()
   })
 
@@ -127,8 +155,6 @@ test.describe('Models v3 (/models)', () => {
   })
 
   test('Recipe editor opens, pre-fills defaults, writes PUT /api/models/{id}', async ({ page }) => {
-    // HAL0_DATA's first installed row is "qwen3.6-27b-mtp" — we PUT
-    // against that id and assert the body carries our edited defaults.
     let putBody: any = null
     await page.route('**/api/models/qwen3.6-27b-mtp', async (route) => {
       if (route.request().method() === 'PUT') {
@@ -146,10 +172,7 @@ test.describe('Models v3 (/models)', () => {
     })
 
     await page.goto('/#models')
-    // Open Edit Options on the auto-selected (first installed) row.
     await page.locator('button:has-text("Edit options")').click()
-    // Fill context_size and save. The modal's input placeholder hints
-    // at "8192" — fill whatever's there and assert the PUT body.
     const ctx = page.locator('input[placeholder*="8192"]')
     await ctx.fill('16384')
     await page.locator('button:has-text("Save options")').click()
@@ -175,12 +198,7 @@ test.describe('Models v3 (/models)', () => {
     })
 
     await page.goto('/#models')
-    // The first installed row is auto-selected; trigger Delete from
-    // its detail pane.
     await page.locator('button.danger:has-text("Delete")').click()
-    // Confirm dialog renders. ConfirmDialog gates Delete on a
-    // type-to-confirm input when the model has referrers; the HAL0_DATA
-    // fixture's primary slot points at this model so the gate is on.
     const confirmInput = page.locator('input.input.mono').last()
     await confirmInput.fill('qwen3.6-27b-mtp')
     await page.locator('button:has-text("Delete model")').click()


### PR DESCRIPTION
## Summary

Redesigns the Models page with three improvements:

### 3 Tabs
- **Inference Models** (default) — installed, blessed, user.* sections
- **Image / ComfyUI** — unchanged image-gen models
- **Upstream Models** — upstream-advertised rows moved to their own paginated tab

Tabs use the existing slot-tabs CSS pattern (same as Slots / Agents pages).

### Simplified Filters
The old type/device/tag chip groups replaced with 7 multi-select OR toggles:
**MTP, MOE, DENSE, Embed, Rerank, Voice, Vision**

Empty selection shows all; multiple selections widen the set (OR semantics).

### Pagination
All three tabs paginated with per-page selector: **10 / 25 / 50 / All**.
Page resets automatically on tab, filter, search, or sort change.

### Installed Indicator
Download icon replaces the text tag — green when downloaded, grey when not.

## Files Changed
- ui/src/dash/models.jsx — full rewrite
- ui/src/dashboard.css — .mdl-row-icon, .mdl-pager*, .mdl-sort-grp
- 3 e2e spec files updated