### PR TITLE
fix(flm): wire NPU trio drawer end-to-end + real 0.9.44 toolbox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
     "flm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
       "digest": "sha256:644c7d1ec0463a21159e291c91a01eeba256b5a0b29fea3ffa54ffd8a065f53b",
-      "_notes": "FastFlowLM v0.9.44 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-07-10)."
+      "_notes": "hal0 toolbox image 0.9.44 — bundles FastFlowLM binary v0.9.43 (the image tag is the toolbox build number, NOT the FLM version; 0.9.44 is a toolbox rebuild over the same FLM v0.9.43 binary). AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-07-10). To ship FLM v0.9.44, rebuild the toolbox with the newer flm binary before bumping again."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/manifest.json
+++ b/manifest.json
@@ -16,8 +16,8 @@
     },
     "flm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
-      "digest": "sha256:644c7d1ec0463a21159e291c91a01eeba256b5a0b29fea3ffa54ffd8a065f53b",
-      "_notes": "hal0 toolbox image 0.9.44 — bundles FastFlowLM binary v0.9.43 (the image tag is the toolbox build number, NOT the FLM version; 0.9.44 is a toolbox rebuild over the same FLM v0.9.43 binary). AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-07-10). To ship FLM v0.9.44, rebuild the toolbox with the newer flm binary before bumping again."
+      "digest": "sha256:49c175ce799061b07d3c84b1bdece9d8dcb74be5f9717f95fb52f51bd5020fc9",
+      "_notes": "FastFlowLM v0.9.44 on AMD XDNA2 NPU (toolbox rebuilt from packaging/toolbox/flm.Dockerfile FLM_REF=v0.9.44 — `flm version` inside reports v0.9.44). Requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest via scripts/update-toolbox-digests.sh accept-set (confirmed post-push 2026-07-10)."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,9 @@
       "_notes": "llama.cpp ROCm backend; multi-arch (gfx1030..gfx1151)"
     },
     "flm": {
-      "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
-      "digest": "sha256:5f4c8a08a269077d8d24b1a93cfa39aebd1bfa10c868048796e8d2e5f589fcad",
-      "_notes": "FastFlowLM v0.9.43 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-06-14)."
+      "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
+      "digest": "sha256:644c7d1ec0463a21159e291c91a01eeba256b5a0b29fea3ffa54ffd8a065f53b",
+      "_notes": "FastFlowLM v0.9.44 on AMD XDNA2 NPU; requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest (confirmed post-push 2026-07-10)."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/src/hal0/api/routes/benchmarks.py
+++ b/src/hal0/api/routes/benchmarks.py
@@ -4,36 +4,30 @@ Benchmarks API — read-only over bench.db + one action.
 Registered like throughput.py.
 """
 
-from fastapi import APIRouter, Query, HTTPException
-from typing import Optional
 import json
 from pathlib import Path
 
+from fastapi import APIRouter, HTTPException
+
 try:
-    from installer.bench.v2_store import (
-        ensure_v2_dir,
-        DEFAULT_V2_DIR,
-        DEFAULT_RECORDS_PATH,
-        DEFAULT_DB_PATH,
-        search_records,
-        count_records,
-        get_trend,
-    )
     from installer.bench.planner import plan
+    from installer.bench.v2_store import (
+        DEFAULT_RECORDS_PATH,
+        ensure_v2_dir,
+        get_trend,
+        search_records,
+    )
 except ImportError:
     # Fallback for direct execution
     import sys
     sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "installer" / "bench"))
-    from v2_store import (
-        ensure_v2_dir,
-        DEFAULT_V2_DIR,
-        DEFAULT_RECORDS_PATH,
-        DEFAULT_DB_PATH,
-        search_records,
-        count_records,
-        get_trend,
-    )
     from planner import plan
+    from v2_store import (
+        DEFAULT_RECORDS_PATH,
+        ensure_v2_dir,
+        get_trend,
+        search_records,
+    )
 
 router = APIRouter(prefix="/api/benchmarks", tags=["benchmarks"])
 
@@ -55,7 +49,7 @@ def get_roster():
     }
 
     for row in records:
-        run_id, suite, trigger, cell_key, outcome, summary = row
+        run_id, suite, _trigger, cell_key, outcome, summary = row
         if outcome != "ok":
             continue
         try:
@@ -74,18 +68,18 @@ def get_roster():
 
 @router.get("/cells")
 def get_cells(
-    model: Optional[str] = None,
-    lane: Optional[str] = None,
-    depth: Optional[int] = None,
-    kind: Optional[str] = None,
-    since: Optional[str] = None,
+    model: str | None = None,
+    lane: str | None = None,
+    depth: int | None = None,
+    kind: str | None = None,
+    since: str | None = None,
 ):
     """Filtered current-value matrix (compare view)."""
     ensure_v2_dir()
     records = search_records(limit=1000)
     results = []
     for row in records:
-        run_id, suite, trigger, cell_key, outcome, summary = row
+        run_id, suite, _trigger, cell_key, outcome, summary = row
         if outcome != "ok":
             continue
         try:
@@ -102,7 +96,7 @@ def get_cells(
 
 
 @router.get("/runs")
-def get_runs(suite: Optional[str] = None, limit: int = 10):
+def get_runs(suite: str | None = None, limit: int = 10):
     """Session list (run groups w/ outcome counts)."""
     ensure_v2_dir()
     records = search_records(suite=suite, limit=limit)

--- a/src/hal0/api/routes/benchmarks.py
+++ b/src/hal0/api/routes/benchmarks.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
     # Fallback for direct execution
     import sys
+
     sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "installer" / "bench"))
     from planner import plan
     from v2_store import (
@@ -54,12 +55,14 @@ def get_roster():
             continue
         try:
             summary_data = json.loads(summary) if summary else {}
-            roster["models"].append({
-                "run_id": run_id,
-                "suite": suite,
-                "cell_key": cell_key,
-                "summary": summary_data,
-            })
+            roster["models"].append(
+                {
+                    "run_id": run_id,
+                    "suite": suite,
+                    "cell_key": cell_key,
+                    "summary": summary_data,
+                }
+            )
         except (json.JSONDecodeError, TypeError):
             pass
 
@@ -84,12 +87,14 @@ def get_cells(
             continue
         try:
             summary_data = json.loads(summary) if summary else {}
-            results.append({
-                "run_id": run_id,
-                "suite": suite,
-                "cell_key": cell_key,
-                "summary": summary_data,
-            })
+            results.append(
+                {
+                    "run_id": run_id,
+                    "suite": suite,
+                    "cell_key": cell_key,
+                    "summary": summary_data,
+                }
+            )
         except (json.JSONDecodeError, TypeError):
             pass
     return results
@@ -145,6 +150,7 @@ def post_run(suite: str):
     """Kick a session (guarded; same GPU gate applies)."""
     # TODO: Add proper auth/gating
     from installer.bench.runner import run_worklist
+
     worklist = plan(suite_id=suite)
     if not worklist:
         return {"status": "no_stale_cells", "worklist": []}

--- a/src/hal0/api/routes/npu.py
+++ b/src/hal0/api/routes/npu.py
@@ -263,7 +263,9 @@ async def npu_occupancy(request: Request) -> dict[str, Any]:
                 }
             )
         if npu_cfg.get("embed"):
-            embed_live = is_loaded and real_embed is not None and getattr(real_embed, "enabled", False)
+            embed_live = (
+                is_loaded and real_embed is not None and getattr(real_embed, "enabled", False)
+            )
             slots_out.append(
                 {
                     "name": s.name + "-embed",

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -51,23 +51,35 @@ router = APIRouter()
 
 @router.get("/flm/models")
 async def list_flm_models(request: Request):
-    """Return installed FLM models (parsed from the NPU slot's container)."""
-    import json as _json
-    import subprocess
+    """Return the FLM catalog for the drawer's NPU model dropdowns.
+
+    Sourced from the HOST ``flm list`` probe (:func:`flm_served_models`), NOT
+    ``podman exec`` into the running container: the drawer is most often opened
+    to *enable* a cold/disabled NPU slot, and an exec against a stopped
+    container returns nothing — leaving every model dropdown empty exactly when
+    the operator needs to pick one. The host probe reads the same on-disk cache
+    the slot serves with and works whether or not the container is up.
+
+    Shape is ``{"models": [{"model": tag, "installed": bool,
+    "capabilities": [...]}]}`` — ``model`` (not the probe's native ``tag``) so
+    the dashboard filter contract (``m.model``, ``m.installed``) is preserved.
+    """
+    from hal0.providers.flm import flm_served_models
 
     try:
-        raw = subprocess.run(
-            ["podman", "exec", "hal0-slot-flm", "/opt/fastflowlm/bin/flm", "list", "--json"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        raw.check_returncode()
-        data = _json.loads(raw.stdout)
-        models = data if isinstance(data, list) else data.get("models", [])
-        return {"models": models}
+        catalog = flm_served_models()
     except Exception:
         return {"models": []}
+    models = [
+        {
+            "model": e.get("tag"),
+            "installed": bool(e.get("installed")),
+            "capabilities": e.get("capabilities", []),
+        }
+        for e in catalog
+        if e.get("tag")
+    ]
+    return {"models": models}
 
 
 class NotImplementedYet(Hal0Error):

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -51,34 +51,86 @@ router = APIRouter()
 
 @router.get("/flm/models")
 async def list_flm_models(request: Request):
-    """Return the FLM catalog for the drawer's NPU model dropdowns.
+    """Return the full FLM catalog for the drawer's NPU model dropdowns.
 
-    Sourced from the HOST ``flm list`` probe (:func:`flm_served_models`), NOT
-    ``podman exec`` into the running container: the drawer is most often opened
-    to *enable* a cold/disabled NPU slot, and an exec against a stopped
-    container returns nothing — leaving every model dropdown empty exactly when
-    the operator needs to pick one. The host probe reads the same on-disk cache
-    the slot serves with and works whether or not the container is up.
+    The dashboard shows the WHOLE catalog (installed or not) so the operator
+    can pick any tag and trigger a download for the ones not yet on disk
+    (``POST /api/models/{tag}/pull`` handles FLM tags). Each entry carries an
+    ``installed`` flag so the UI can mark/act on the difference.
 
-    Shape is ``{"models": [{"model": tag, "installed": bool,
-    "capabilities": [...]}]}`` — ``model`` (not the probe's native ``tag``) so
-    the dashboard filter contract (``m.model``, ``m.installed``) is preserved.
+    Two sources, container-exec primary:
+
+      1. ``<runtime> exec`` into the running FLM container and run ``flm list``.
+         This reads the store the slot ACTUALLY serves with — on a box that
+         relocates the model store (``[models].flm_store``) the store is a
+         bind-mount that only exists inside the container, so the container is
+         the only place ``installed`` is accurate. Full list + correct flags.
+      2. When the container is down (cold/disabled slot), fall back to the HOST
+         ``flm list`` probe (:func:`flm_served_models`). It still knows every
+         catalog tag (from the bundled ``model_list.json``) so the dropdowns
+         populate; ``installed`` may read false on relocated-store boxes since
+         the host can't see the container-only mount — acceptable for the cold
+         case, and correct on default-store boxes.
+
+    Shape: ``{"models": [{"model": tag, "installed": bool,
+    "capabilities": [...], "family": str}]}`` — ``model``/``installed`` keep the
+    dashboard filter contract.
     """
-    from hal0.providers.flm import flm_served_models
+    import json as _json
+    import subprocess
 
-    try:
-        catalog = flm_served_models()
-    except Exception:
-        return {"models": []}
-    models = [
-        {
-            "model": e.get("tag"),
-            "installed": bool(e.get("installed")),
-            "capabilities": e.get("capabilities", []),
-        }
-        for e in catalog
-        if e.get("tag")
-    ]
+    from hal0.providers.flm import _classify_flm_model, flm_served_models
+
+    def _from_container() -> list[dict[str, Any]] | None:
+        # Container name convention: hal0-slot-<name>; the NPU anchor is "flm".
+        try:
+            raw = subprocess.run(
+                ["podman", "exec", "hal0-slot-flm", "/opt/fastflowlm/bin/flm", "list", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            raw.check_returncode()
+            data = _json.loads(raw.stdout)
+        except Exception:
+            return None
+        entries = data if isinstance(data, list) else data.get("models", [])
+        out: list[dict[str, Any]] = []
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            tag = e.get("model") or e.get("name")
+            if not tag:
+                continue
+            details = e.get("details") if isinstance(e.get("details"), dict) else {}
+            out.append(
+                {
+                    "model": tag,
+                    "installed": bool(e.get("installed")),
+                    "capabilities": _classify_flm_model(e),
+                    "family": str(details.get("family") or ""),
+                }
+            )
+        return out or None
+
+    models = _from_container()
+    if models is None:
+        # Cold-slot fallback — host probe knows every tag; installed may be
+        # understated on relocated-store boxes (see docstring).
+        try:
+            catalog = flm_served_models()
+        except Exception:
+            catalog = []
+        models = [
+            {
+                "model": e.get("tag"),
+                "installed": bool(e.get("installed")),
+                "capabilities": e.get("capabilities", []),
+                "family": e.get("family", ""),
+            }
+            for e in catalog
+            if e.get("tag")
+        ]
     return {"models": models}
 
 

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -388,7 +388,7 @@ def _parse_flm_version(raw: str | None) -> str | None:
 
 
 def _parse_flm_version_from_image(image_ref: str | None) -> str | None:
-    """``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43`` → ``0.9.43``.
+    """``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44`` → ``0.9.44``.
 
     Parses the tag off an OCI image reference (everything after the last
     ``:``) and returns it, or ``None`` if the ref is empty / has no tag.

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -139,7 +139,7 @@ def tts_profile_for_device(device: str) -> str:
 # ── Backends ──────────────────────────────────────────────────────────────────
 
 
-_FLM_TOOLBOX_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
+_FLM_TOOLBOX_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44"
 
 
 # FLM tags hidden from the dashboard catalog because of upstream FLM

--- a/src/hal0/cli/bench_commands.py
+++ b/src/hal0/cli/bench_commands.py
@@ -35,9 +35,11 @@ def cmd_plan(args):
     else:
         print(f"Planned {len(worklist)} cells")
         for item in worklist[:10]:
-            print(f"  {item['cell']['model']} / {item['cell']['lane']} / "
-                  f"{item['cell']['kind']} / {item['cell']['depth']} "
-                  f"({item['stale_reason']})")
+            print(
+                f"  {item['cell']['model']} / {item['cell']['lane']} / "
+                f"{item['cell']['kind']} / {item['cell']['depth']} "
+                f"({item['stale_reason']})"
+            )
         if len(worklist) > 10:
             print(f"  ... and {len(worklist) - 10} more")
 
@@ -56,9 +58,11 @@ def cmd_run(args):
         dry_run=args.dry_run,
     )
 
-    print(f"\n{'='*60}")
-    print(f"Results: {results['ok']} ok, {results['failed']} failed, "
-          f"{results['skipped']} skipped, {results['total']} total")
+    print(f"\n{'=' * 60}")
+    print(
+        f"Results: {results['ok']} ok, {results['failed']} failed, "
+        f"{results['skipped']} skipped, {results['total']} total"
+    )
 
 
 def cmd_status(args):
@@ -160,7 +164,7 @@ def cmd_reindex(args):
                                 row.get("cell_key"),
                                 row.get("outcome"),
                                 json.dumps(row.get("summary", {})),
-                            )
+                            ),
                         )
                 except (json.JSONDecodeError, KeyError):
                     pass
@@ -168,6 +172,7 @@ def cmd_reindex(args):
     conn.close()
     # Count from SQLite now
     import sqlite3
+
     conn2 = sqlite3.connect(str(db_path))
     count = conn2.execute("SELECT COUNT(*) FROM records").fetchone()[0]
     conn2.close()
@@ -198,12 +203,14 @@ def cmd_publish(args):
             continue
         try:
             summary_data = json.loads(summary) if summary else {}
-            roster["models"].append({
-                "run_id": run_id,
-                "suite": suite,
-                "cell_key": cell_key,
-                "summary": summary_data,
-            })
+            roster["models"].append(
+                {
+                    "run_id": run_id,
+                    "suite": suite,
+                    "cell_key": cell_key,
+                    "summary": summary_data,
+                }
+            )
         except (json.JSONDecodeError, TypeError):
             pass
 
@@ -223,6 +230,7 @@ def cmd_import_v1(args):
         return
 
     import json
+
     with open(v1_index) as f:
         index = json.load(f)
 
@@ -247,6 +255,7 @@ def cmd_import_v1(args):
             "artifacts": "",
         }
         from v2_store import write_record
+
         write_record(v2_record)
         records_written += 1
 
@@ -254,10 +263,7 @@ def cmd_import_v1(args):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        prog="hal0 bench",
-        description="Benchmarks CLI for hal0"
-    )
+    parser = argparse.ArgumentParser(prog="hal0 bench", description="Benchmarks CLI for hal0")
     subparsers = parser.add_subparsers(dest="command")
 
     # plan

--- a/src/hal0/cli/bench_commands.py
+++ b/src/hal0/cli/bench_commands.py
@@ -14,16 +14,16 @@ from pathlib import Path
 BENCH_DIR = Path(__file__).parent.parent.parent.parent / "installer" / "bench"
 sys.path.insert(0, str(BENCH_DIR))
 
-from planner import plan, load_suites, get_installed_models
-from runner import run_worklist
-from v2_store import (
-    ensure_v2_dir,
-    DEFAULT_V2_DIR,
-    DEFAULT_RECORDS_PATH,
+from planner import plan  # noqa: E402
+from runner import run_worklist  # noqa: E402
+from v2_store import (  # noqa: E402
     DEFAULT_DB_PATH,
-    search_records,
+    DEFAULT_RECORDS_PATH,
+    DEFAULT_V2_DIR,
     count_records,
+    ensure_v2_dir,
     get_trend,
+    search_records,
 )
 
 
@@ -78,7 +78,7 @@ def cmd_status(args):
     # Show recent records
     records = search_records(limit=5)
     if records:
-        print(f"\nRecent records:")
+        print("\nRecent records:")
         for row in records:
             print(f"  {row[0]} | {row[1]} | {row[2]} | {row[3]} | {row[4]}")
 
@@ -112,11 +112,11 @@ def cmd_history(args):
 def cmd_reindex(args):
     """Rebuild bench.db from records.jsonl."""
     ensure_v2_dir()
-    from v2_store import _refresh_sqlite
     # Rebuild by reading all records
     import json
-    from v2_store import DEFAULT_RECORDS_PATH, DEFAULT_DB_PATH
     import sqlite3
+
+    from v2_store import DEFAULT_DB_PATH, DEFAULT_RECORDS_PATH
 
     db_path = DEFAULT_DB_PATH
     conn = sqlite3.connect(str(db_path))
@@ -193,7 +193,7 @@ def cmd_publish(args):
     }
 
     for row in records:
-        run_id, suite, trigger, cell_key, outcome, summary = row
+        run_id, suite, _trigger, cell_key, outcome, summary = row
         if outcome != "ok":
             continue
         try:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -192,6 +192,22 @@ class NpuConfig(BaseModel):
         default=True,
         description="Enable chat (LLM) modality on the FLM slot. Default ON.",
     )
+    asr_model: str | None = Field(
+        default=None,
+        description=(
+            "FLM tag to serve for ASR (e.g. 'whisper-v3:turbo'). None → FLM's "
+            "default whisper model. Emitted as ``--asr-model`` only when it "
+            "differs from the default. Ignored unless ``asr`` is on."
+        ),
+    )
+    embed_model: str | None = Field(
+        default=None,
+        description=(
+            "FLM tag to serve for embeddings (e.g. 'embed-gemma:300m'). None → "
+            "FLM's default embed model. Emitted as ``--embed-model`` only when "
+            "it differs from the default. Ignored unless ``embed`` is on."
+        ),
+    )
 
 
 class ImageGenConfig(BaseModel):

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -192,22 +192,10 @@ class NpuConfig(BaseModel):
         default=True,
         description="Enable chat (LLM) modality on the FLM slot. Default ON.",
     )
-    asr_model: str | None = Field(
-        default=None,
-        description=(
-            "FLM tag to serve for ASR (e.g. 'whisper-v3:turbo'). None → FLM's "
-            "default whisper model. Emitted as ``--asr-model`` only when it "
-            "differs from the default. Ignored unless ``asr`` is on."
-        ),
-    )
-    embed_model: str | None = Field(
-        default=None,
-        description=(
-            "FLM tag to serve for embeddings (e.g. 'embed-gemma:300m'). None → "
-            "FLM's default embed model. Emitted as ``--embed-model`` only when "
-            "it differs from the default. Ignored unless ``embed`` is on."
-        ),
-    )
+    # NOTE: FLM has no per-role model selection — ``--asr`` / ``--embed`` are
+    # boolean flags that load FLM's single bundled whisper + embed-gemma. There
+    # is deliberately no asr_model/embed_model here; the chat model is the
+    # ``flm serve`` positional tag ([model].default) and is the only choice.
 
 
 class ImageGenConfig(BaseModel):

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1012,7 +1012,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         "quant": "",
     },
     "flm": {
-        "image": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
+        "image": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
         "flags": "",
         "mtp": False,
         "device_class": "npu",

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -141,6 +141,14 @@ def _ensure_flm_models_dir(path: str) -> None:
         pass
 
 
+# ── FLM per-role model defaults ────────────────────────────────────────────────
+# The tags FLM loads for the shadow roles when no explicit override is given.
+# An override equal to the default is elided from the argv (the bare ``--asr 1``
+# / ``--embed 1`` already selects it), so these must match FLM's own defaults.
+_DEFAULT_ASR_MODEL = "whisper-v3:turbo"
+_DEFAULT_EMBED_MODEL = "embed-gemma:300m"
+
+
 # ── Timeouts ───────────────────────────────────────────────────────────────────
 # TIER1: separate health budget from infer budget.
 _HEALTH_TIMEOUT = httpx.Timeout(5.0)
@@ -199,6 +207,29 @@ def _npu_device_nodes() -> list[str]:
     except Exception:
         pass
     return [accel or _DEFAULT_NPU_ACCEL_NODE, render or _DEFAULT_NPU_RENDER_NODE]
+
+
+def _flm_shadow_role_args(env: dict[str, str]) -> list[str]:
+    """Build the ``--embed`` / ``--asr`` (+ per-role ``--*-model``) argv tail.
+
+    Shared by :meth:`FLMProvider.start_cmd` (native) and
+    :meth:`FLMProvider.container_spec` (primary) so the two paths can never
+    drift. A per-role model override is emitted only when it is set AND
+    differs from FLM's bundled default — the bare ``--embed 1`` / ``--asr 1``
+    already selects the default, and passing it explicitly is redundant.
+    """
+    args: list[str] = []
+    if env.get("HAL0_FLM_LOAD_EMBED") == "1":
+        args += ["--embed", "1"]
+        embed_model = env.get("HAL0_FLM_EMBED_MODEL") or ""
+        if embed_model and embed_model != _DEFAULT_EMBED_MODEL:
+            args += ["--embed-model", embed_model]
+    if env.get("HAL0_FLM_LOAD_ASR") == "1":
+        args += ["--asr", "1"]
+        asr_model = env.get("HAL0_FLM_ASR_MODEL") or ""
+        if asr_model and asr_model != _DEFAULT_ASR_MODEL:
+            args += ["--asr-model", asr_model]
+    return args
 
 
 def _resolve_render_gid() -> int | None:
@@ -270,6 +301,12 @@ class FLMProvider(Provider):
 
         npu_table = slot_cfg.get("npu") or {}
         defaults = slot_cfg.get("defaults") or {}
+        # Per-role model overrides live on the [npu] table (asr_model /
+        # embed_model). Empty string when unset → argv construction elides
+        # the ``--asr-model`` / ``--embed-model`` flag and FLM serves its
+        # bundled default.
+        asr_model = str(npu_table.get("asr_model") or "")
+        embed_model = str(npu_table.get("embed_model") or "")
         if slot_cfg.get("npu") is not None:
             # [npu] table is PRIMARY when present — explicit asr=false must
             # win even if stale legacy defaults say otherwise.
@@ -293,6 +330,8 @@ class FLMProvider(Provider):
             "HAL0_FLM_LOAD_ASR": load_asr,
             "HAL0_FLM_LOAD_EMBED": load_embed,
             "HAL0_FLM_LOAD_CHAT": load_chat,
+            "HAL0_FLM_ASR_MODEL": asr_model,
+            "HAL0_FLM_EMBED_MODEL": embed_model,
         }
 
     def start_cmd(self, env: dict[str, str]) -> list[str]:
@@ -301,9 +340,10 @@ class FLMProvider(Provider):
         Used by tests and the fallback systemd-without-Docker path. The
         primary deployment path is ``container_spec``.
 
-        Reads per-capability model preferences from shadow TOMLs
-        (flm-stt.toml, flm-embed.toml) so the operator can change
-        STT/embed models without editing the flm slot config.
+        Per-role model overrides come from the [npu] table via
+        :meth:`build_env` (``HAL0_FLM_ASR_MODEL`` / ``HAL0_FLM_EMBED_MODEL``);
+        an override equal to FLM's default is elided so the argv matches the
+        container path exactly.
         """
         binary = os.environ.get("HAL0_FLM_BINARY", f"{_NATIVE_FLM_ROOT}/bin/flm")
         argv = [binary, "serve"]
@@ -317,16 +357,7 @@ class FLMProvider(Provider):
             "--ctx-len",
             env["HAL0_FLM_CTX"],
         ]
-        if env.get("HAL0_FLM_LOAD_EMBED") == "1":
-            embed_model = _read_shadow_model("flm-embed")
-            argv += ["--embed", "1"]
-            if embed_model and embed_model != "embed-gemma:300m":
-                argv += ["--embed-model", embed_model]
-        if env.get("HAL0_FLM_LOAD_ASR") == "1":
-            stt_model = _read_shadow_model("flm-stt")
-            argv += ["--asr", "1"]
-            if stt_model and stt_model != "whisper-v3:turbo":
-                argv += ["--asr-model", stt_model]
+        argv += _flm_shadow_role_args(env)
         return argv
 
     # ── Image / container spec ─────────────────────────────────────────────────
@@ -386,9 +417,15 @@ class FLMProvider(Provider):
         # subcommand + flags — NOT a binary path. Passing an absolute
         # binary path here would be treated by flm as a stray positional
         # argument and rejected with "too many positional options".
-        command: list[str] = [
-            "serve",
-            env["HAL0_FLM_TAG"],
+        command: list[str] = ["serve"]
+        # Chat modality is the positional tag. Gate it on HAL0_FLM_LOAD_CHAT so
+        # toggling NPU · Chat off actually stops serving chat on the container
+        # path (previously the tag was passed unconditionally, so the toggle
+        # only worked on the native start_cmd fallback). With chat off, FLM
+        # serves only the shadow roles (--embed / --asr) and has no LLM.
+        if env.get("HAL0_FLM_LOAD_CHAT", "1") == "1":
+            command += [env["HAL0_FLM_TAG"]]
+        command += [
             "--host",
             "0.0.0.0",
             "--port",
@@ -396,10 +433,7 @@ class FLMProvider(Provider):
             "--ctx-len",
             env["HAL0_FLM_CTX"],
         ]
-        if env["HAL0_FLM_LOAD_EMBED"] == "1":
-            command += ["--embed", "1"]
-        if env["HAL0_FLM_LOAD_ASR"] == "1":
-            command += ["--asr", "1"]
+        command += _flm_shadow_role_args(env)
 
         # render group resolves dynamically at run-time; use the numeric gid
         # so the spec doesn't depend on /etc/group in the container.
@@ -744,31 +778,6 @@ def flm_validate() -> bool | None:
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return None
     return proc.returncode == 0
-
-
-def _read_shadow_model(slot_name: str) -> str | None:
-    """Read the model.default from a shadow slot TOML.
-
-    Returns the model tag (e.g. 'whisper-v3:turbo') or None if the
-    shadow TOML doesn't exist or can't be parsed.
-    """
-    from pathlib import Path
-
-    toml_path = Path("/etc/hal0/slots") / f"{slot_name}.toml"
-    if not toml_path.exists():
-        return None
-    try:
-        import tomllib
-    except ImportError:
-        import tomli as tomllib
-    try:
-        data = tomllib.loads(toml_path.read_text())
-        model = data.get("model", {})
-        if isinstance(model, dict):
-            return str(model.get("default", "")).strip() or None
-    except Exception:
-        pass
-    return None
 
 
 def flm_served_models() -> list[dict[str, Any]]:

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -141,14 +141,6 @@ def _ensure_flm_models_dir(path: str) -> None:
         pass
 
 
-# ── FLM per-role model defaults ────────────────────────────────────────────────
-# The tags FLM loads for the shadow roles when no explicit override is given.
-# An override equal to the default is elided from the argv (the bare ``--asr 1``
-# / ``--embed 1`` already selects it), so these must match FLM's own defaults.
-_DEFAULT_ASR_MODEL = "whisper-v3:turbo"
-_DEFAULT_EMBED_MODEL = "embed-gemma:300m"
-
-
 # ── Timeouts ───────────────────────────────────────────────────────────────────
 # TIER1: separate health budget from infer budget.
 _HEALTH_TIMEOUT = httpx.Timeout(5.0)
@@ -210,25 +202,19 @@ def _npu_device_nodes() -> list[str]:
 
 
 def _flm_shadow_role_args(env: dict[str, str]) -> list[str]:
-    """Build the ``--embed`` / ``--asr`` (+ per-role ``--*-model``) argv tail.
+    """Build the ``--embed`` / ``--asr`` argv tail.
 
     Shared by :meth:`FLMProvider.start_cmd` (native) and
     :meth:`FLMProvider.container_spec` (primary) so the two paths can never
-    drift. A per-role model override is emitted only when it is set AND
-    differs from FLM's bundled default — the bare ``--embed 1`` / ``--asr 1``
-    already selects the default, and passing it explicitly is redundant.
+    drift. FLM's ``--embed`` / ``--asr`` are booleans: each loads FLM's single
+    bundled model (embed-gemma / whisper) — there is NO ``--embed-model`` /
+    ``--asr-model`` flag, so nothing per-role to emit here.
     """
     args: list[str] = []
     if env.get("HAL0_FLM_LOAD_EMBED") == "1":
         args += ["--embed", "1"]
-        embed_model = env.get("HAL0_FLM_EMBED_MODEL") or ""
-        if embed_model and embed_model != _DEFAULT_EMBED_MODEL:
-            args += ["--embed-model", embed_model]
     if env.get("HAL0_FLM_LOAD_ASR") == "1":
         args += ["--asr", "1"]
-        asr_model = env.get("HAL0_FLM_ASR_MODEL") or ""
-        if asr_model and asr_model != _DEFAULT_ASR_MODEL:
-            args += ["--asr-model", asr_model]
     return args
 
 
@@ -301,12 +287,6 @@ class FLMProvider(Provider):
 
         npu_table = slot_cfg.get("npu") or {}
         defaults = slot_cfg.get("defaults") or {}
-        # Per-role model overrides live on the [npu] table (asr_model /
-        # embed_model). Empty string when unset → argv construction elides
-        # the ``--asr-model`` / ``--embed-model`` flag and FLM serves its
-        # bundled default.
-        asr_model = str(npu_table.get("asr_model") or "")
-        embed_model = str(npu_table.get("embed_model") or "")
         if slot_cfg.get("npu") is not None:
             # [npu] table is PRIMARY when present — explicit asr=false must
             # win even if stale legacy defaults say otherwise.
@@ -330,20 +310,14 @@ class FLMProvider(Provider):
             "HAL0_FLM_LOAD_ASR": load_asr,
             "HAL0_FLM_LOAD_EMBED": load_embed,
             "HAL0_FLM_LOAD_CHAT": load_chat,
-            "HAL0_FLM_ASR_MODEL": asr_model,
-            "HAL0_FLM_EMBED_MODEL": embed_model,
         }
 
     def start_cmd(self, env: dict[str, str]) -> list[str]:
         """Return argv for the native ``flm serve`` invocation.
 
         Used by tests and the fallback systemd-without-Docker path. The
-        primary deployment path is ``container_spec``.
-
-        Per-role model overrides come from the [npu] table via
-        :meth:`build_env` (``HAL0_FLM_ASR_MODEL`` / ``HAL0_FLM_EMBED_MODEL``);
-        an override equal to FLM's default is elided so the argv matches the
-        container path exactly.
+        primary deployment path is ``container_spec``. Shares the
+        ``--embed`` / ``--asr`` tail with it via :func:`_flm_shadow_role_args`.
         """
         binary = os.environ.get("HAL0_FLM_BINARY", f"{_NATIVE_FLM_ROOT}/bin/flm")
         argv = [binary, "serve"]
@@ -591,6 +565,58 @@ class FLMProvider(Provider):
                         "status": "sentinel_completion_no_choices",
                         "model": model_id,
                     }
+            return {"ok": True, "status": "ready", "model": model_id}
+        except httpx.HTTPError as exc:
+            return {"ok": False, "status": "http_error", "detail": str(exc)}
+        except Exception as exc:
+            return {"ok": False, "status": "exception", "detail": str(exc)}
+
+    async def verify_embed(self, port: int) -> dict[str, Any]:
+        """One-shot embeddings gate — a single ``/v1/embeddings`` call.
+
+        The warm→ready sentinel for FLM slots serving EMBED without CHAT
+        (``[npu].chat=false``): :meth:`verify_inference`'s chat completion
+        would fail because no chat model is loaded, wedging the slot in
+        WARMING forever. This exercises the embed path instead — the actual
+        role the slot serves — so an embed-primary slot can promote to READY.
+
+        Mirrors :meth:`verify_inference`: reads ``/v1/models`` for the served
+        model id, then a single shielded ``/v1/embeddings`` POST (shield: never
+        hand FLM a cancelled request → NPU double-free). Never raises; a
+        transport failure resolves to ``ok=False`` (retryable WARMING).
+        """
+        models_url = f"http://127.0.0.1:{port}/v1/models"
+        embed_url = f"http://127.0.0.1:{port}/v1/embeddings"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+                models_resp = await client.get(models_url)
+                models_resp.raise_for_status()
+                data = models_resp.json()
+                models = data.get("data", [])
+                if not models:
+                    return {
+                        "ok": False,
+                        "status": "models_endpoint_empty",
+                        "detail": "/v1/models returned no entries",
+                    }
+                model_id = models[0].get("id")
+
+            async with httpx.AsyncClient(timeout=_HEALTH_INFER_TIMEOUT) as client:
+                probe_body = {"model": model_id, "input": "ping"}
+                resp = await asyncio.shield(client.post(embed_url, json=probe_body))
+                if resp.status_code != 200:
+                    return {
+                        "ok": False,
+                        "status": f"sentinel_embed_http_{resp.status_code}",
+                        "detail": resp.text[:200],
+                        "model": model_id,
+                    }
+                try:
+                    body = resp.json()
+                except Exception:
+                    return {"ok": False, "status": "sentinel_embed_unparseable", "model": model_id}
+                if not body.get("data"):
+                    return {"ok": False, "status": "sentinel_embed_no_data", "model": model_id}
             return {"ok": True, "status": "ready", "model": model_id}
         except httpx.HTTPError as exc:
             return {"ok": False, "status": "http_error", "detail": str(exc)}

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -344,8 +344,6 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
                 # chat defaults ON (NpuConfig.chat=True) when the key is absent,
                 # so the drawer's Chat pill seeds from the real persisted value.
                 "chat": npu_table.get("chat", True) is not False,
-                "asr_model": npu_table.get("asr_model") or None,
-                "embed_model": npu_table.get("embed_model") or None,
             }
 
         # declared_backend: normalized token (rocm|vulkan|cpu|flm) from the
@@ -465,8 +463,6 @@ async def container_enrichment(
                 # chat defaults ON (NpuConfig.chat=True) when the key is absent,
                 # so the drawer's Chat pill seeds from the real persisted value.
                 "chat": npu_table.get("chat", True) is not False,
-                "asr_model": npu_table.get("asr_model") or None,
-                "embed_model": npu_table.get("embed_model") or None,
             }
 
         # Emit runtime / profile / image so the UI doesn't have to dig

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -341,6 +341,11 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
             entry["npu"] = {
                 "asr": bool(npu_table.get("asr")),
                 "embed": bool(npu_table.get("embed")),
+                # chat defaults ON (NpuConfig.chat=True) when the key is absent,
+                # so the drawer's Chat pill seeds from the real persisted value.
+                "chat": npu_table.get("chat", True) is not False,
+                "asr_model": npu_table.get("asr_model") or None,
+                "embed_model": npu_table.get("embed_model") or None,
             }
 
         # declared_backend: normalized token (rocm|vulkan|cpu|flm) from the
@@ -457,6 +462,11 @@ async def container_enrichment(
             entry["npu"] = {
                 "asr": bool(npu_table.get("asr")),
                 "embed": bool(npu_table.get("embed")),
+                # chat defaults ON (NpuConfig.chat=True) when the key is absent,
+                # so the drawer's Chat pill seeds from the real persisted value.
+                "chat": npu_table.get("chat", True) is not False,
+                "asr_model": npu_table.get("asr_model") or None,
+                "embed_model": npu_table.get("embed_model") or None,
             }
 
         # Emit runtime / profile / image so the UI doesn't have to dig

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3265,7 +3265,22 @@ class SlotManager:
 
         provider = _spec_provider_for(cfg)
         if isinstance(provider, FLMProvider):
-            verdict = await provider.verify_inference(slot_port)
+            # Pick the sentinel by which modality the slot actually serves.
+            # An embed/STT-primary slot ([npu].chat=false) has no chat model,
+            # so the chat completion sentinel would fail and wedge it in
+            # WARMING forever. Probe the real role instead.
+            npu_cfg = cfg.get("npu") or (cfg.get("extra") or {}).get("npu") or {}
+            chat_on = npu_cfg.get("chat", True) is not False
+            embed_on = bool(npu_cfg.get("embed"))
+            if chat_on:
+                verdict = await provider.verify_inference(slot_port)
+            elif embed_on:
+                verdict = await provider.verify_embed(slot_port)
+            else:
+                # ASR-only (no chat, no embed): a transcription sentinel needs
+                # an audio upload, so fall back to the cheap /v1/models liveness
+                # — the slot is ready once it lists its served model.
+                verdict = await provider.health(slot_port)
             if not verdict.get("ok"):
                 log.warning(
                     "slot.flm_inference_gate_failed",

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -70,7 +70,7 @@ def test_state_returns_shape_expected_by_dashboard(
 
     # Stub the image-ref helper so the test is independent of the real constant.
     monkeypatch.setattr(
-        u_mod, "_flm_toolbox_image", lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
+        u_mod, "_flm_toolbox_image", lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44"
     )
 
     r = isolated_client.get("/api/updates/state")
@@ -82,7 +82,7 @@ def test_state_returns_shape_expected_by_dashboard(
     assert body["hal0"]["available"] == "9.9.9"
     assert body["hal0"]["channel"] == "stable"
     # flm.current comes from the image tag; source is "toolbox-image".
-    assert body["flm"]["current"] == "0.9.43"
+    assert body["flm"]["current"] == "0.9.44"
     assert body["flm"]["source"] == "toolbox-image"
     assert body["autoCheck"] is True
 
@@ -93,7 +93,7 @@ def test_state_flm_version_from_image_tag(
     """flm.current is derived from the bundled toolbox image tag, not a probe.
 
     The source of truth post-PR #822 is the ``_DEFAULT_FLM_IMAGE`` /
-    ``_FLM_TOOLBOX_IMAGE`` constant (``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43``).
+    ``_FLM_TOOLBOX_IMAGE`` constant (``ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44``).
     The route parses the tag off the image ref and reports it with
     ``source="toolbox-image"`` — no subprocess probe required.
     """
@@ -104,13 +104,13 @@ def test_state_flm_version_from_image_tag(
     monkeypatch.setattr(
         u_mod,
         "_flm_toolbox_image",
-        lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43",
+        lambda: "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
     )
 
     r = isolated_client.get("/api/updates/state")
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["flm"]["current"] == "0.9.43"
+    assert body["flm"]["current"] == "0.9.44"
     assert body["flm"]["source"] == "toolbox-image"
 
 

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -58,15 +58,8 @@ def test_npu_tucked_into_extra_on_dump() -> None:
     )
     data = slot.model_dump()
     assert "npu" not in data
-    # chat defaults to True (4d7a5745 feat(schema): add chat field to NpuConfig);
-    # asr_model/embed_model default to None (per-role FLM tag overrides).
-    assert data["extra"]["npu"] == {
-        "asr": True,
-        "embed": False,
-        "chat": True,
-        "asr_model": None,
-        "embed_model": None,
-    }
+    # chat defaults to True (4d7a5745 feat(schema): add chat field to NpuConfig).
+    assert data["extra"]["npu"] == {"asr": True, "embed": False, "chat": True}
 
 
 def test_npu_chat_default_on() -> None:

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -83,7 +83,7 @@ def test_npu_chat_default_on() -> None:
 
 def test_flm_npu_seed_profile() -> None:
     prof = SEED_PROFILES["flm"]
-    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.43"
+    assert prof["image"] == "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44"
     assert prof["flags"] == ""
     assert prof["mtp"] is False
 

--- a/tests/config/test_schema_npu.py
+++ b/tests/config/test_schema_npu.py
@@ -58,8 +58,15 @@ def test_npu_tucked_into_extra_on_dump() -> None:
     )
     data = slot.model_dump()
     assert "npu" not in data
-    # chat defaults to True (4d7a5745 feat(schema): add chat field to NpuConfig)
-    assert data["extra"]["npu"] == {"asr": True, "embed": False, "chat": True}
+    # chat defaults to True (4d7a5745 feat(schema): add chat field to NpuConfig);
+    # asr_model/embed_model default to None (per-role FLM tag overrides).
+    assert data["extra"]["npu"] == {
+        "asr": True,
+        "embed": False,
+        "chat": True,
+        "asr_model": None,
+        "embed_model": None,
+    }
 
 
 def test_npu_chat_default_on() -> None:

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -311,6 +311,40 @@ async def test_verify_inference_requires_round_trip(provider: FLMProvider) -> No
 
 
 @pytest.mark.asyncio
+async def test_verify_embed_exercises_embeddings(provider: FLMProvider) -> None:
+    """The embed gate (chat-off slots) MUST POST /v1/embeddings, not chat.
+
+    An embed/STT-primary slot has no chat model, so the chat sentinel would
+    fail; verify_embed probes the real embed path so the slot can promote.
+    """
+    models_payload = {"data": [{"id": "embed-gemma:300m"}]}
+    embed_payload = {"data": [{"embedding": [0.1, 0.2]}]}
+
+    sentinel_was_called = {"value": False}
+
+    async def _fake_get(url: str) -> httpx.Response:
+        assert url.endswith("/v1/models")
+        return _mock_response(status_code=200, json_payload=models_payload)
+
+    async def _fake_post(url: str, json: dict[str, Any]) -> httpx.Response:
+        assert url.endswith("/v1/embeddings")
+        assert json["model"] == "embed-gemma:300m"
+        sentinel_was_called["value"] = True
+        return _mock_response(status_code=200, json_payload=embed_payload)
+
+    with patch("hal0.providers.flm.httpx.AsyncClient") as MockClient:
+        client = MockClient.return_value.__aenter__.return_value
+        client.get = _fake_get
+        client.post = _fake_post
+        result = await provider.verify_embed(8086)
+
+    assert sentinel_was_called["value"], "verify_embed MUST issue the embeddings sentinel."
+    assert result["ok"] is True
+    assert result["status"] == "ready"
+    assert result["model"] == "embed-gemma:300m"
+
+
+@pytest.mark.asyncio
 async def test_verify_inference_rejects_empty_models(provider: FLMProvider) -> None:
     """Empty /v1/models → not ready; the gate must not POST."""
 

--- a/tests/providers/test_flm_container_spec.py
+++ b/tests/providers/test_flm_container_spec.py
@@ -72,59 +72,27 @@ def test_chat_on_keeps_positional_tag() -> None:
     assert spec.command[:2] == ["serve", "gemma3:4b"]
 
 
-def test_asr_model_override_emits_flag() -> None:
-    """A non-default [npu].asr_model reaches --asr-model on the container path."""
+def test_no_per_role_model_flags() -> None:
+    """FLM has no --asr-model / --embed-model — --asr / --embed are booleans
+    that load FLM's single bundled whisper / embed-gemma. We must NEVER emit a
+    per-role model flag (passing an unknown option crashes ``flm serve``)."""
     spec = FLMProvider().container_spec(
-        _slot_cfg(npu={"asr": True, "asr_model": "whisper-v3:large"}), _model_info()
-    )
-    idx = spec.command.index("--asr-model")
-    assert spec.command[idx + 1] == "whisper-v3:large"
-
-
-def test_embed_model_override_emits_flag() -> None:
-    spec = FLMProvider().container_spec(
-        _slot_cfg(npu={"embed": True, "embed_model": "embed-gemma:1b"}), _model_info()
-    )
-    idx = spec.command.index("--embed-model")
-    assert spec.command[idx + 1] == "embed-gemma:1b"
-
-
-def test_default_role_model_is_elided() -> None:
-    """An override equal to FLM's default is NOT re-emitted — the bare
-    ``--asr 1`` / ``--embed 1`` already selects it."""
-    spec = FLMProvider().container_spec(
-        _slot_cfg(
-            npu={
-                "asr": True,
-                "asr_model": "whisper-v3:turbo",
-                "embed": True,
-                "embed_model": "embed-gemma:300m",
-            }
-        ),
-        _model_info(),
+        _slot_cfg(npu={"chat": True, "asr": True, "embed": True}), _model_info()
     )
     assert "--asr-model" not in spec.command
     assert "--embed-model" not in spec.command
-
-
-def test_role_model_ignored_when_modality_off() -> None:
-    """A model override for a disabled modality is not emitted."""
-    spec = FLMProvider().container_spec(
-        _slot_cfg(npu={"asr": False, "asr_model": "whisper-v3:large"}), _model_info()
-    )
-    assert "--asr" not in spec.command
-    assert "--asr-model" not in spec.command
+    assert "--asr" in spec.command and "--embed" in spec.command
 
 
 def test_start_cmd_matches_container_role_args() -> None:
-    """Native start_cmd and container_spec build the same shadow-role tail so
+    """Native start_cmd and container_spec build the same --asr/--embed tail so
     the two paths can never drift (they share _flm_shadow_role_args)."""
-    cfg = _slot_cfg(npu={"asr": True, "asr_model": "whisper-v3:large", "embed": True})
+    cfg = _slot_cfg(npu={"asr": True, "embed": True})
     provider = FLMProvider()
     env = provider.build_env(cfg, _model_info())
     argv = provider.start_cmd(env)
     spec = provider.container_spec(cfg, _model_info())
-    for flag in ("--asr", "--asr-model", "whisper-v3:large", "--embed"):
+    for flag in ("--asr", "--embed"):
         assert flag in argv and flag in spec.command
 
 

--- a/tests/providers/test_flm_container_spec.py
+++ b/tests/providers/test_flm_container_spec.py
@@ -49,6 +49,85 @@ def test_npu_table_overrides_legacy_defaults() -> None:
     assert "--asr" not in spec.command
 
 
+def test_chat_off_drops_positional_tag() -> None:
+    """[npu].chat=false must stop the container serving chat.
+
+    Regression: container_spec passed the positional chat tag
+    unconditionally, so toggling Chat off in the drawer still served chat
+    (only the native start_cmd honoured HAL0_FLM_LOAD_CHAT). With chat off
+    the tag must be absent — 'serve' then flags, no model positional.
+    """
+    spec = FLMProvider().container_spec(
+        _slot_cfg(npu={"chat": False, "embed": True}), _model_info()
+    )
+    assert "gemma3:4b" not in spec.command
+    assert spec.command[0] == "serve"
+    # First arg after 'serve' is a flag, not a positional model tag.
+    assert spec.command[1].startswith("--")
+    assert "--embed" in spec.command
+
+
+def test_chat_on_keeps_positional_tag() -> None:
+    spec = FLMProvider().container_spec(_slot_cfg(npu={"chat": True}), _model_info())
+    assert spec.command[:2] == ["serve", "gemma3:4b"]
+
+
+def test_asr_model_override_emits_flag() -> None:
+    """A non-default [npu].asr_model reaches --asr-model on the container path."""
+    spec = FLMProvider().container_spec(
+        _slot_cfg(npu={"asr": True, "asr_model": "whisper-v3:large"}), _model_info()
+    )
+    idx = spec.command.index("--asr-model")
+    assert spec.command[idx + 1] == "whisper-v3:large"
+
+
+def test_embed_model_override_emits_flag() -> None:
+    spec = FLMProvider().container_spec(
+        _slot_cfg(npu={"embed": True, "embed_model": "embed-gemma:1b"}), _model_info()
+    )
+    idx = spec.command.index("--embed-model")
+    assert spec.command[idx + 1] == "embed-gemma:1b"
+
+
+def test_default_role_model_is_elided() -> None:
+    """An override equal to FLM's default is NOT re-emitted — the bare
+    ``--asr 1`` / ``--embed 1`` already selects it."""
+    spec = FLMProvider().container_spec(
+        _slot_cfg(
+            npu={
+                "asr": True,
+                "asr_model": "whisper-v3:turbo",
+                "embed": True,
+                "embed_model": "embed-gemma:300m",
+            }
+        ),
+        _model_info(),
+    )
+    assert "--asr-model" not in spec.command
+    assert "--embed-model" not in spec.command
+
+
+def test_role_model_ignored_when_modality_off() -> None:
+    """A model override for a disabled modality is not emitted."""
+    spec = FLMProvider().container_spec(
+        _slot_cfg(npu={"asr": False, "asr_model": "whisper-v3:large"}), _model_info()
+    )
+    assert "--asr" not in spec.command
+    assert "--asr-model" not in spec.command
+
+
+def test_start_cmd_matches_container_role_args() -> None:
+    """Native start_cmd and container_spec build the same shadow-role tail so
+    the two paths can never drift (they share _flm_shadow_role_args)."""
+    cfg = _slot_cfg(npu={"asr": True, "asr_model": "whisper-v3:large", "embed": True})
+    provider = FLMProvider()
+    env = provider.build_env(cfg, _model_info())
+    argv = provider.start_cmd(env)
+    spec = provider.container_spec(cfg, _model_info())
+    for flag in ("--asr", "--asr-model", "whisper-v3:large", "--embed"):
+        assert flag in argv and flag in spec.command
+
+
 def test_default_models_dir_is_flm_cache() -> None:
     spec = FLMProvider().container_spec(_slot_cfg(), _model_info())
     # Source follows the resolver default (HAL0_HOME-aware); the target is

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -327,7 +327,13 @@ class TestConfigEnrichment:
         assert e["idle_timeout_s"] == 900
         assert e["workers"] == 2
         assert e["llamacpp_args"] == "--flash-attn on"
-        assert e["npu"] == {"asr": True, "embed": False}
+        assert e["npu"] == {
+            "asr": True,
+            "embed": False,
+            "chat": True,
+            "asr_model": None,
+            "embed_model": None,
+        }
 
     def test_ctx_max_from_context_size(self) -> None:
         # The Inference engine pane reads ctx_max to render "ctx used / max".
@@ -528,7 +534,13 @@ class TestContainerEnrichment:
             pull_jobs={},
             provider=FakeContainerProvider(active=False),
         )
-        assert out["gpu-chat"]["npu"] == {"asr": True, "embed": True}
+        assert out["gpu-chat"]["npu"] == {
+            "asr": True,
+            "embed": True,
+            "chat": True,
+            "asr_model": None,
+            "embed_model": None,
+        }
 
 
 class MapContainerProvider(FakeContainerProvider):

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -327,13 +327,7 @@ class TestConfigEnrichment:
         assert e["idle_timeout_s"] == 900
         assert e["workers"] == 2
         assert e["llamacpp_args"] == "--flash-attn on"
-        assert e["npu"] == {
-            "asr": True,
-            "embed": False,
-            "chat": True,
-            "asr_model": None,
-            "embed_model": None,
-        }
+        assert e["npu"] == {"asr": True, "embed": False, "chat": True}
 
     def test_ctx_max_from_context_size(self) -> None:
         # The Inference engine pane reads ctx_max to render "ctx used / max".
@@ -534,13 +528,7 @@ class TestContainerEnrichment:
             pull_jobs={},
             provider=FakeContainerProvider(active=False),
         )
-        assert out["gpu-chat"]["npu"] == {
-            "asr": True,
-            "embed": True,
-            "chat": True,
-            "asr_model": None,
-            "embed_model": None,
-        }
+        assert out["gpu-chat"]["npu"] == {"asr": True, "embed": True, "chat": True}
 
 
 class MapContainerProvider(FakeContainerProvider):

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -19,7 +19,7 @@ const { useState: useStateSM } = React;
 
 import { useNpuOccupancy } from '@/api/hooks/useNpuOccupancy'
 import { useStatsHardware } from '@/api/hooks/useStatsHardware'
-import { useSlotRestart, useSlotUnload, useSlotLoad, useSlotEdit } from '@/api/hooks/useSlots'
+import { useSlotRestart, useSlotUnload, useSlotLoad, useSlotEdit, useSlotConfig } from '@/api/hooks/useSlots'
 import { SlotControls, slotCtrlPhase } from './inference-pane.jsx'
 import { slotIndicatorFromPhase } from './slot-status.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
@@ -338,20 +338,16 @@ export function NpuOccupancyCard({ slots }) {
   const unloadMut = useSlotUnload()
   const loadMut = useSlotLoad()
   const editMut = useSlotEdit()
-  const [flmNpuConfig, setFlmNpuConfig] = useStateSM({})
-
-  // Fetch flm slot config for full npu dict (asr/embed/chat)
-  React.useEffect(() => {
-    fetch('/api/slots/flm/config').then(r => r.json()).then(d => {
-      setFlmNpuConfig(d?.npu || {})
-    }).catch(() => {})
-  }, [])
+  // Full npu dict (chat/asr/embed) via react-query so the drawer's edit
+  // (which invalidates ['slot-config','flm']) refreshes the card toggles in
+  // lockstep — the old one-shot fetch went stale after every drawer change.
+  const flmCfgQuery = useSlotConfig('flm')
 
   const npuSlots = (slots || []).filter(isNpuSlot)
   if (npuSlots.length === 0) return null
 
   const flmSlot = npuSlots.find(s => s.name === 'flm')
-  const mainFlmNpu = flmNpuConfig || flmSlot?.npu || {}
+  const mainFlmNpu = flmCfgQuery.data?.npu || flmSlot?.npu || {}
 
   const occ = occQuery.data || {}
   const occSlots = occ.slots || []

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -499,6 +499,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
       setVisionErr(null);
       setNpuAsr(slot.npu?.asr === true);
       setNpuEmbed(slot.npu?.embed === true);
+      // Re-seed the chat pill + all three model selects too, so a save +
+      // refetch keeps the drawer in sync with server truth instead of
+      // drifting until the drawer is remounted.
+      setNpuChat(slot.npu?.chat !== false);
+      setNpuChatModel(slot.model_id || slot.model || 'qwen3:4b');
+      setNpuAsrModel(slot.npu?.asr_model || 'whisper-v3:turbo');
+      setNpuEmbedModel(slot.npu?.embed_model || 'embed-gemma:300m');
       setNpuPending(false);
       setNpuErr(null);
     }
@@ -1080,15 +1087,31 @@ function EditSlotDrawer({ open, slot, onClose }) {
       )}
       {/* NPU capability matrix — replaces Model+Template for NPU slots */}
       {slot.device === "npu" && (() => {
-        const applyNpu = async (nextChat, nextAsr, nextEmbed, field) => {
+        // Persist a modality/model change and cold-restart the container.
+        // `over` carries only the field(s) the caller changed; everything
+        // else falls back to the current (pre-change) state captured in this
+        // closure — which is also what we revert to on error. Model selects
+        // and toggles both route here so every control actually takes effect.
+        const applyNpu = async (over = {}, field = "modality") => {
+          const chat = over.chat ?? npuChat;
+          const asr = over.asr ?? npuAsr;
+          const embed = over.embed ?? npuEmbed;
+          const chatModel = over.chatModel ?? npuChatModel;
+          const asrModel = over.asrModel ?? npuAsrModel;
+          const embedModel = over.embedModel ?? npuEmbedModel;
           setNpuPending(true);
           setNpuErr(null);
-          // Determine primary model from first ON capability
-          const npuBody = { chat: nextChat, asr: nextAsr, embed: nextEmbed };
+          // [npu] carries the modality toggles + the per-role model overrides;
+          // FLM emits --asr-model / --embed-model from these (elided when they
+          // equal the default). The chat model is FLM's positional tag, sent
+          // as a nested [model] table so the backend merge preserves sibling
+          // keys (context_size, n_gpu_layers) instead of clobbering them with
+          // a bare string.
+          const npuBody = { chat, asr, embed };
+          if (asr && asrModel) npuBody.asr_model = asrModel;
+          if (embed && embedModel) npuBody.embed_model = embedModel;
           const body = { npu: npuBody };
-          if (nextChat && npuChatModel) body.model = npuChatModel;
-          else if (nextAsr && npuAsrModel) body.model = npuAsrModel;
-          else if (nextEmbed && npuEmbedModel) body.model = npuEmbedModel;
+          if (chat && chatModel) body.model = { default: chatModel };
           try {
             await editMut.mutateAsync({ name: slot.name, body });
             restartMut.mutate(slot.name, {
@@ -1097,14 +1120,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
             window.__hal0Toast && window.__hal0Toast(`${slot.name} NPU ${field} updated — restarting`, "info");
           } catch (err) {
             setNpuChat(npuChat); setNpuAsr(npuAsr); setNpuEmbed(npuEmbed);
+            setNpuChatModel(npuChatModel); setNpuAsrModel(npuAsrModel); setNpuEmbedModel(npuEmbedModel);
             setNpuErr(err?.message || "NPU toggle failed");
           } finally {
             setNpuPending(false);
           }
         };
         const chatModels = flmModels.filter(m => m.model && !m.model?.toLowerCase().includes('whisper') && !m.model?.toLowerCase().includes('embed') && m.installed);
-        const sttModels = flmModels.filter(m => m.model?.toLowerCase().includes('whisper'));
-        const embedModels = flmModels.filter(m => m.model?.toLowerCase().includes('embed'));
+        const sttModels = flmModels.filter(m => m.model?.toLowerCase().includes('whisper') && m.installed);
+        const embedModels = flmModels.filter(m => m.model?.toLowerCase().includes('embed') && m.installed);
         return (
           <>
             <div className="form-row">
@@ -1119,10 +1143,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     disabled={npuPending || saving}
                     label="Chat"
                     stateText={npuChat ? "On" : "Off"}
-                    onToggle={(next) => { setNpuChat(next); applyNpu(next, npuAsr, npuEmbed, "chat"); }}
+                    onToggle={(next) => { setNpuChat(next); applyNpu({ chat: next }, "chat"); }}
                   />
                   <select className="input mono" style={{width: 160}} value={npuChatModel}
-                    onChange={e => setNpuChatModel(e.target.value)}
+                    onChange={e => { const v = e.target.value; setNpuChatModel(v); applyNpu({ chatModel: v }, "chat model"); }}
                     disabled={npuPending || saving || !npuChat}
                   >
                     {chatModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}
@@ -1143,10 +1167,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     disabled={npuPending || saving}
                     label="ASR"
                     stateText={npuAsr ? "On" : "Off"}
-                    onToggle={(next) => { setNpuAsr(next); applyNpu(npuChat, next, npuEmbed, "ASR"); }}
+                    onToggle={(next) => { setNpuAsr(next); applyNpu({ asr: next }, "ASR"); }}
                   />
                   <select className="input mono" style={{width: 160}} value={npuAsrModel}
-                    onChange={e => setNpuAsrModel(e.target.value)}
+                    onChange={e => { const v = e.target.value; setNpuAsrModel(v); applyNpu({ asrModel: v }, "ASR model"); }}
                     disabled={npuPending || saving || !npuAsr}
                   >
                     {sttModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}
@@ -1167,10 +1191,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     disabled={npuPending || saving}
                     label="Embed"
                     stateText={npuEmbed ? "On" : "Off"}
-                    onToggle={(next) => { setNpuEmbed(next); applyNpu(npuChat, npuAsr, next, "Embed"); }}
+                    onToggle={(next) => { setNpuEmbed(next); applyNpu({ embed: next }, "Embed"); }}
                   />
                   <select className="input mono" style={{width: 160}} value={npuEmbedModel}
-                    onChange={e => setNpuEmbedModel(e.target.value)}
+                    onChange={e => { const v = e.target.value; setNpuEmbedModel(v); applyNpu({ embedModel: v }, "Embed model"); }}
                     disabled={npuPending || saving || !npuEmbed}
                   >
                     {embedModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -16,7 +16,7 @@ import {
   useSlotResolved,
 } from '@/api/hooks/useSlots'
 import { useHardware } from '@/api/hooks/useHardware'
-import { useModels } from '@/api/hooks/useModels'
+import { useModels, usePullJob } from '@/api/hooks/useModels'
 import { useProfiles } from '@/api/hooks/useProfiles'
 import { useChatTemplates } from '@/api/hooks/useChatTemplates'
 import { useMetaEnums } from '@/api/hooks/useMeta'
@@ -456,14 +456,94 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const [npuPending, setNpuPending] = useStateSM(false);
   const [npuErr, setNpuErr] = useStateSM(null);
   const [flmModels, setFlmModels] = useStateSM([]);
+  // Pull-on-select: usePullJob owns one FLM download (SSE progress). pullTarget
+  // remembers which role+tag is downloading so we auto-apply it on completion.
+  const pull = usePullJob();
+  const [pullTarget, setPullTarget] = useStateSM(null); // {role, field, tag} | null
 
-  // Fetch available FLM models when NPU slot editor is open
-  React.useEffect(() => {
-    if (slot?.device !== 'npu') return;
+  // Fetch the full FLM catalogue (installed + downloadable) when the NPU slot
+  // editor is open. Extracted so we can re-fetch after a download completes
+  // (the tag flips installed=true).
+  const refreshFlmModels = React.useCallback(() => {
     fetch('/api/slots/flm/models').then(r => r.json()).then(d => {
       setFlmModels(d.models || d || []);
     }).catch(() => {});
+  }, []);
+  React.useEffect(() => {
+    if (slot?.device !== 'npu') return;
+    refreshFlmModels();
   }, [slot?.name]);
+
+  // Apply an NPU modality/model change and cold-restart the container. Lifted
+  // to component scope (out of the render IIFE) so the pull-completion effect
+  // can call it too. `over` carries only the changed field(s); the rest fall
+  // back to current state — which is also what we revert to on error.
+  const applyNpu = async (over = {}, field = "modality") => {
+    const chat = over.chat ?? npuChat;
+    const asr = over.asr ?? npuAsr;
+    const embed = over.embed ?? npuEmbed;
+    const chatModel = over.chatModel ?? npuChatModel;
+    const asrModel = over.asrModel ?? npuAsrModel;
+    const embedModel = over.embedModel ?? npuEmbedModel;
+    setNpuPending(true);
+    setNpuErr(null);
+    // [npu] carries the modality toggles + per-role model overrides; FLM emits
+    // --asr-model / --embed-model from these (elided when they equal the
+    // default). The chat model is FLM's positional tag, sent as a nested
+    // [model] table so the backend merge preserves sibling keys
+    // (context_size, n_gpu_layers) instead of clobbering them with a string.
+    const npuBody = { chat, asr, embed };
+    if (asr && asrModel) npuBody.asr_model = asrModel;
+    if (embed && embedModel) npuBody.embed_model = embedModel;
+    const body = { npu: npuBody };
+    if (chat && chatModel) body.model = { default: chatModel };
+    try {
+      await editMut.mutateAsync({ name: slot.name, body });
+      restartMut.mutate(slot.name, {
+        onError: (err) => window.__hal0Toast && window.__hal0Toast(`NPU restart failed — ${err?.message || "see logs"}`, "err"),
+      });
+      window.__hal0Toast && window.__hal0Toast(`${slot.name} NPU ${field} updated — restarting`, "info");
+    } catch (err) {
+      setNpuChat(npuChat); setNpuAsr(npuAsr); setNpuEmbed(npuEmbed);
+      setNpuChatModel(npuChatModel); setNpuAsrModel(npuAsrModel); setNpuEmbedModel(npuEmbedModel);
+      setNpuErr(err?.message || "NPU toggle failed");
+    } finally {
+      setNpuPending(false);
+    }
+  };
+
+  // Pick a model in a role's dropdown. Installed → apply immediately.
+  // Not-yet-downloaded → start the FLM pull and remember the target; the
+  // completion effect below auto-applies it once the weights land.
+  const onPickNpuModel = (role, field, tag) => {
+    if (field === "chatModel") setNpuChatModel(tag);
+    else if (field === "asrModel") setNpuAsrModel(tag);
+    else if (field === "embedModel") setNpuEmbedModel(tag);
+    const entry = flmModels.find(m => m.model === tag);
+    if (entry && entry.installed === false) {
+      setNpuErr(null);
+      setPullTarget({ role, field, tag });
+      pull.start(tag).catch(() => {}); // failure surfaces via the effect below
+    } else {
+      applyNpu({ [field]: tag }, role);
+    }
+  };
+
+  // Auto-apply a freshly-downloaded model, or surface a failed/cancelled pull.
+  React.useEffect(() => {
+    if (!pullTarget || pull.modelId !== pullTarget.tag) return;
+    if (pull.state === "completed") {
+      refreshFlmModels();
+      applyNpu({ [pullTarget.field]: pullTarget.tag }, pullTarget.role);
+      setPullTarget(null);
+      pull.reset();
+    } else if (pull.state === "failed" || pull.state === "cancelled") {
+      setNpuErr(pull.error?.message || `Download ${pull.state}`);
+      setPullTarget(null);
+      pull.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pull.state, pull.modelId, pullTarget]);
 
   // Resolved command provenance — only fetched while the drawer is open.
   // Falls back gracefully when null (non-llama slots) or on error.
@@ -1087,54 +1167,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
       )}
       {/* NPU capability matrix — replaces Model+Template for NPU slots */}
       {slot.device === "npu" && (() => {
-        // Persist a modality/model change and cold-restart the container.
-        // `over` carries only the field(s) the caller changed; everything
-        // else falls back to the current (pre-change) state captured in this
-        // closure — which is also what we revert to on error. Model selects
-        // and toggles both route here so every control actually takes effect.
-        const applyNpu = async (over = {}, field = "modality") => {
-          const chat = over.chat ?? npuChat;
-          const asr = over.asr ?? npuAsr;
-          const embed = over.embed ?? npuEmbed;
-          const chatModel = over.chatModel ?? npuChatModel;
-          const asrModel = over.asrModel ?? npuAsrModel;
-          const embedModel = over.embedModel ?? npuEmbedModel;
-          setNpuPending(true);
-          setNpuErr(null);
-          // [npu] carries the modality toggles + the per-role model overrides;
-          // FLM emits --asr-model / --embed-model from these (elided when they
-          // equal the default). The chat model is FLM's positional tag, sent
-          // as a nested [model] table so the backend merge preserves sibling
-          // keys (context_size, n_gpu_layers) instead of clobbering them with
-          // a bare string.
-          const npuBody = { chat, asr, embed };
-          if (asr && asrModel) npuBody.asr_model = asrModel;
-          if (embed && embedModel) npuBody.embed_model = embedModel;
-          const body = { npu: npuBody };
-          if (chat && chatModel) body.model = { default: chatModel };
-          try {
-            await editMut.mutateAsync({ name: slot.name, body });
-            restartMut.mutate(slot.name, {
-              onError: (err) => window.__hal0Toast && window.__hal0Toast(`NPU restart failed — ${err?.message || "see logs"}`, "err"),
-            });
-            window.__hal0Toast && window.__hal0Toast(`${slot.name} NPU ${field} updated — restarting`, "info");
-          } catch (err) {
-            setNpuChat(npuChat); setNpuAsr(npuAsr); setNpuEmbed(npuEmbed);
-            setNpuChatModel(npuChatModel); setNpuAsrModel(npuAsrModel); setNpuEmbedModel(npuEmbedModel);
-            setNpuErr(err?.message || "NPU toggle failed");
-          } finally {
-            setNpuPending(false);
-          }
-        };
-        const chatModels = flmModels.filter(m => m.model && !m.model?.toLowerCase().includes('whisper') && !m.model?.toLowerCase().includes('embed') && m.installed);
-        const sttModels = flmModels.filter(m => m.model?.toLowerCase().includes('whisper') && m.installed);
-        const embedModels = flmModels.filter(m => m.model?.toLowerCase().includes('embed') && m.installed);
+        // Full catalogue per lane (installed + downloadable) — NOT filtered by
+        // `installed`, so any tag can be picked and pulled on demand. Lane
+        // split by tag family (whisper → ASR, embed → Embed, else Chat).
+        const chatModels = flmModels.filter(m => m.model && !m.model?.toLowerCase().includes('whisper') && !m.model?.toLowerCase().includes('embed'));
+        const sttModels = flmModels.filter(m => m.model?.toLowerCase().includes('whisper'));
+        const embedModels = flmModels.filter(m => m.model?.toLowerCase().includes('embed'));
+        // Non-installed options carry a ⬇ marker; picking one downloads first.
+        const optLabel = (m) => m.installed ? m.model : `${m.model}  ⬇ download`;
+        // True while THIS tag is downloading (used to gate + show progress).
+        const pulling = (tag) => pull.inFlight && pull.modelId === tag;
+        const pullPct = pull.pct != null ? `${pull.pct}%` : '…';
         return (
           <>
             <div className="form-row">
               <div className="form-lbl">
                 <span>NPU · Chat</span>
-                <span className="sub">Primary LLM model. First ON capability becomes the slot{'\u2019'}s model. Restarts the container.</span>
+                <span className="sub">LLM served on the NPU. Pick any catalogue model{'\u2014'}{'\u2b07'} entries download first, then apply. Restarts the container.</span>
               </div>
               <div className="form-ctl">
                 <span style={{display: 'flex', alignItems: 'center', gap: 8}}>
@@ -1145,13 +1194,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     stateText={npuChat ? "On" : "Off"}
                     onToggle={(next) => { setNpuChat(next); applyNpu({ chat: next }, "chat"); }}
                   />
-                  <select className="input mono" style={{width: 160}} value={npuChatModel}
-                    onChange={e => { const v = e.target.value; setNpuChatModel(v); applyNpu({ chatModel: v }, "chat model"); }}
-                    disabled={npuPending || saving || !npuChat}
+                  <select className="input mono" style={{width: 200}} value={npuChatModel}
+                    onChange={e => onPickNpuModel("chat", "chatModel", e.target.value)}
+                    disabled={npuPending || saving || !npuChat || pull.inFlight}
                   >
-                    {chatModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}
+                    {chatModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
                   </select>
-                  {!npuChat && npuAsr && npuAsrModel === npuChatModel && <span style={{fontSize:11,color:'var(--fg-5)'}}>→ primary</span>}
+                  {pulling(npuChatModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
+                  {!pulling(npuChatModel) && !npuChat && npuAsr && npuAsrModel === npuChatModel && <span style={{fontSize:11,color:'var(--fg-5)'}}>→ primary</span>}
                 </span>
               </div>
             </div>
@@ -1169,13 +1219,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     stateText={npuAsr ? "On" : "Off"}
                     onToggle={(next) => { setNpuAsr(next); applyNpu({ asr: next }, "ASR"); }}
                   />
-                  <select className="input mono" style={{width: 160}} value={npuAsrModel}
-                    onChange={e => { const v = e.target.value; setNpuAsrModel(v); applyNpu({ asrModel: v }, "ASR model"); }}
-                    disabled={npuPending || saving || !npuAsr}
+                  <select className="input mono" style={{width: 200}} value={npuAsrModel}
+                    onChange={e => onPickNpuModel("ASR", "asrModel", e.target.value)}
+                    disabled={npuPending || saving || !npuAsr || pull.inFlight}
                   >
-                    {sttModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}
+                    {sttModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
                   </select>
-                  {!npuChat && npuAsr && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
+                  {pulling(npuAsrModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
+                  {!pulling(npuAsrModel) && !npuChat && npuAsr && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
                 </span>
               </div>
             </div>
@@ -1193,13 +1244,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     stateText={npuEmbed ? "On" : "Off"}
                     onToggle={(next) => { setNpuEmbed(next); applyNpu({ embed: next }, "Embed"); }}
                   />
-                  <select className="input mono" style={{width: 160}} value={npuEmbedModel}
-                    onChange={e => { const v = e.target.value; setNpuEmbedModel(v); applyNpu({ embedModel: v }, "Embed model"); }}
-                    disabled={npuPending || saving || !npuEmbed}
+                  <select className="input mono" style={{width: 200}} value={npuEmbedModel}
+                    onChange={e => onPickNpuModel("Embed", "embedModel", e.target.value)}
+                    disabled={npuPending || saving || !npuEmbed || pull.inFlight}
                   >
-                    {embedModels.map(m => <option key={m.model} value={m.model}>{m.model}</option>)}
+                    {embedModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
                   </select>
-                  {!npuChat && !npuAsr && npuEmbed && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
+                  {pulling(npuEmbedModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
+                  {!pulling(npuEmbedModel) && !npuChat && !npuAsr && npuEmbed && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
                 </span>
               </div>
             </div>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -451,8 +451,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
   const [npuEmbed, setNpuEmbed] = useStateSM(slot?.npu?.embed === true);
   const [npuChat, setNpuChat] = useStateSM(slot?.npu?.chat !== false);
   const [npuChatModel, setNpuChatModel] = useStateSM(slot?.model_id || slot?.model || 'qwen3:4b');
-  const [npuAsrModel, setNpuAsrModel] = useStateSM(slot?.npu?.asr_model || 'whisper-v3:turbo');
-  const [npuEmbedModel, setNpuEmbedModel] = useStateSM(slot?.npu?.embed_model || 'embed-gemma:300m');
   const [npuPending, setNpuPending] = useStateSM(false);
   const [npuErr, setNpuErr] = useStateSM(null);
   const [flmModels, setFlmModels] = useStateSM([]);
@@ -483,19 +481,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
     const asr = over.asr ?? npuAsr;
     const embed = over.embed ?? npuEmbed;
     const chatModel = over.chatModel ?? npuChatModel;
-    const asrModel = over.asrModel ?? npuAsrModel;
-    const embedModel = over.embedModel ?? npuEmbedModel;
     setNpuPending(true);
     setNpuErr(null);
-    // [npu] carries the modality toggles + per-role model overrides; FLM emits
-    // --asr-model / --embed-model from these (elided when they equal the
-    // default). The chat model is FLM's positional tag, sent as a nested
-    // [model] table so the backend merge preserves sibling keys
-    // (context_size, n_gpu_layers) instead of clobbering them with a string.
-    const npuBody = { chat, asr, embed };
-    if (asr && asrModel) npuBody.asr_model = asrModel;
-    if (embed && embedModel) npuBody.embed_model = embedModel;
-    const body = { npu: npuBody };
+    // [npu] carries the modality toggles (asr/embed are boolean — FLM loads its
+    // one bundled whisper / embed-gemma, no per-role model choice). The chat
+    // model is FLM's positional tag, sent as a nested [model] table so the
+    // backend merge preserves sibling keys (context_size, n_gpu_layers)
+    // instead of clobbering them with a bare string.
+    const body = { npu: { chat, asr, embed } };
     if (chat && chatModel) body.model = { default: chatModel };
     try {
       await editMut.mutateAsync({ name: slot.name, body });
@@ -505,20 +498,18 @@ function EditSlotDrawer({ open, slot, onClose }) {
       window.__hal0Toast && window.__hal0Toast(`${slot.name} NPU ${field} updated — restarting`, "info");
     } catch (err) {
       setNpuChat(npuChat); setNpuAsr(npuAsr); setNpuEmbed(npuEmbed);
-      setNpuChatModel(npuChatModel); setNpuAsrModel(npuAsrModel); setNpuEmbedModel(npuEmbedModel);
+      setNpuChatModel(npuChatModel);
       setNpuErr(err?.message || "NPU toggle failed");
     } finally {
       setNpuPending(false);
     }
   };
 
-  // Pick a model in a role's dropdown. Installed → apply immediately.
-  // Not-yet-downloaded → start the FLM pull and remember the target; the
-  // completion effect below auto-applies it once the weights land.
+  // Pick the chat model. Installed → apply immediately. Not-yet-downloaded →
+  // start the FLM pull and remember the target; the completion effect below
+  // auto-applies it once the weights land. (ASR/Embed have no model choice.)
   const onPickNpuModel = (role, field, tag) => {
-    if (field === "chatModel") setNpuChatModel(tag);
-    else if (field === "asrModel") setNpuAsrModel(tag);
-    else if (field === "embedModel") setNpuEmbedModel(tag);
+    setNpuChatModel(tag);
     const entry = flmModels.find(m => m.model === tag);
     if (entry && entry.installed === false) {
       setNpuErr(null);
@@ -584,8 +575,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
       // drifting until the drawer is remounted.
       setNpuChat(slot.npu?.chat !== false);
       setNpuChatModel(slot.model_id || slot.model || 'qwen3:4b');
-      setNpuAsrModel(slot.npu?.asr_model || 'whisper-v3:turbo');
-      setNpuEmbedModel(slot.npu?.embed_model || 'embed-gemma:300m');
       setNpuPending(false);
       setNpuErr(null);
     }
@@ -1171,8 +1160,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
         // `installed`, so any tag can be picked and pulled on demand. Lane
         // split by tag family (whisper → ASR, embed → Embed, else Chat).
         const chatModels = flmModels.filter(m => m.model && !m.model?.toLowerCase().includes('whisper') && !m.model?.toLowerCase().includes('embed'));
-        const sttModels = flmModels.filter(m => m.model?.toLowerCase().includes('whisper'));
-        const embedModels = flmModels.filter(m => m.model?.toLowerCase().includes('embed'));
         // Non-installed options carry a ⬇ marker; picking one downloads first.
         const optLabel = (m) => m.installed ? m.model : `${m.model}  ⬇ download`;
         // True while THIS tag is downloading (used to gate + show progress).
@@ -1201,57 +1188,42 @@ function EditSlotDrawer({ open, slot, onClose }) {
                     {chatModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
                   </select>
                   {pulling(npuChatModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
-                  {!pulling(npuChatModel) && !npuChat && npuAsr && npuAsrModel === npuChatModel && <span style={{fontSize:11,color:'var(--fg-5)'}}>→ primary</span>}
                 </span>
               </div>
             </div>
             <div className="form-row">
               <div className="form-lbl">
                 <span>NPU · ASR</span>
-                <span className="sub">Serve speech-to-text on the coresident NPU process. Restarts the container.</span>
+                <span className="sub">Serve speech-to-text (whisper) on the coresident NPU process. Restarts the container.</span>
               </div>
               <div className="form-ctl">
                 <span style={{display: 'flex', alignItems: 'center', gap: 8}}>
                   <PillToggle
                     on={npuAsr}
-                    disabled={npuPending || saving}
+                    disabled={npuPending || saving || pull.inFlight}
                     label="ASR"
                     stateText={npuAsr ? "On" : "Off"}
                     onToggle={(next) => { setNpuAsr(next); applyNpu({ asr: next }, "ASR"); }}
                   />
-                  <select className="input mono" style={{width: 200}} value={npuAsrModel}
-                    onChange={e => onPickNpuModel("ASR", "asrModel", e.target.value)}
-                    disabled={npuPending || saving || !npuAsr || pull.inFlight}
-                  >
-                    {sttModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
-                  </select>
-                  {pulling(npuAsrModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
-                  {!pulling(npuAsrModel) && !npuChat && npuAsr && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
+                  <span style={{fontSize:11,color:'var(--fg-5)'}}>whisper-v3 (fixed)</span>
                 </span>
               </div>
             </div>
             <div className="form-row">
               <div className="form-lbl">
                 <span>NPU · Embed</span>
-                <span className="sub">Serve embeddings on the coresident NPU process. Restarts the container.</span>
+                <span className="sub">Serve embeddings (embed-gemma) on the coresident NPU process. Restarts the container.</span>
               </div>
               <div className="form-ctl">
                 <span style={{display: 'flex', alignItems: 'center', gap: 8}}>
                   <PillToggle
                     on={npuEmbed}
-                    disabled={npuPending || saving}
+                    disabled={npuPending || saving || pull.inFlight}
                     label="Embed"
                     stateText={npuEmbed ? "On" : "Off"}
                     onToggle={(next) => { setNpuEmbed(next); applyNpu({ embed: next }, "Embed"); }}
                   />
-                  <select className="input mono" style={{width: 200}} value={npuEmbedModel}
-                    onChange={e => onPickNpuModel("Embed", "embedModel", e.target.value)}
-                    disabled={npuPending || saving || !npuEmbed || pull.inFlight}
-                  >
-                    {embedModels.map(m => <option key={m.model} value={m.model}>{optLabel(m)}</option>)}
-                  </select>
-                  {pulling(npuEmbedModel) && <span style={{fontSize:11,color:'var(--accent)'}}>⬇ {pullPct}</span>}
-                  {!pulling(npuEmbedModel) && !npuChat && !npuAsr && npuEmbed && <span style={{fontSize:11,color:'var(--ok)'}}>primary</span>}
+                  <span style={{fontSize:11,color:'var(--fg-5)'}}>embed-gemma (fixed)</span>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
Reviews and fixes the FLM NPU-trio slot wiring (card toggles ↔ edit drawer ↔ running `flm serve` process), corrects the toolbox version story, and ships a genuinely-rebuilt FLM v0.9.44 image.

## Trio wiring fixes
- **Chat toggle is real on the container path.** `container_spec` passed the positional chat tag unconditionally, so "Chat off" was cosmetic (only native `start_cmd` honoured it). Now both paths gate the tag via a shared `_flm_shadow_role_args`.
- **No more `[model]` clobber.** The drawer sent `model` as a bare top-level string, which `merge_slot_config` used to replace the whole `[model]` table with — dropping `context_size`/`n_gpu_layers`. Now sent as `{model:{default}}`. (This is the exact bug that broke the live slot under the old deployed code.)
- **Card ↔ drawer sync.** `NpuOccupancyCard` fetched `/api/slots/flm/config` once on mount and went stale after edits; now uses `useSlotConfig('flm')` (invalidated by the drawer's edit).

## FLM capability corrections
- **No per-role model flags.** `flm serve --help` confirms `-a/--asr` / `-e/--embed` are booleans that load FLM's single bundled whisper / embed-gemma — there is no `--asr-model`/`--embed-model`. Removed the invalid `NpuConfig.asr_model/embed_model`, the flag emission, and the ASR/Embed model dropdowns (kept on/off toggles + the Chat model picker, which *is* the `serve` positional).
- **Chat-aware readiness (embed/STT-primary).** `_await_ready` fired a `/v1/chat/completions` sentinel for every FLM slot, wedging chat-off slots in `WARMING`. Now picks the sentinel by modality: chat→`verify_inference`, chat-off+embed→new `verify_embed` (`/v1/embeddings`), asr-only→`/v1/models` liveness.

## Drawer catalogue + downloads
- `/api/slots/flm/models` sources the running container first (full catalogue + accurate `installed`), host-probe fallback when cold.
- Drawer shows the whole catalogue; picking a not-yet-downloaded chat model pulls it (`usePullJob` → `POST /api/models/{tag}/pull`) with inline progress and auto-applies on completion.

## Real 0.9.44 toolbox
- Both prior `0.9.43`/`0.9.44` images bundled FLM **v0.9.43** (tag ≠ binary version). Rebuilt from `packaging/toolbox/flm.Dockerfile` (`FLM_REF=v0.9.44`) → `flm version` = **v0.9.44**, pushed to ghcr (public), `manifest.json` pinned to `sha256:49c175ce…`.
- Repo defaults unified on `0.9.44` (manifest, flm seed profile, `_FLM_TOOLBOX_IMAGE`).

## Verification
- Full affected suite green (FLM provider, container_spec, schema, slot_view, updater, virtual-models) — 2 pre-existing env failures unrelated to this branch.
- Rendered `container_spec` against the real box config; **live slot now runs FLM v0.9.44, `ready`, serving the expanded v0.9.44 catalogue.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)