### PR TITLE
fix(npu): purple running glow on NPU cards + occupancy hardening + CI green

### DIFF
--- a/src/hal0/api/routes/benchmarks.py
+++ b/src/hal0/api/routes/benchmarks.py
@@ -298,7 +298,9 @@ def get_history(cell_key: str | None = None, model: str | None = None) -> dict[s
 
 
 @router.get("/runs")
-def list_runs(suite: str | None = None, model: str | None = None, limit: int = 50) -> dict[str, Any]:
+def list_runs(
+    suite: str | None = None, model: str | None = None, limit: int = 50
+) -> dict[str, Any]:
     """Run records, newest first, optionally filtered by suite and/or model,
     with an outcome tally over the listed page. ``model`` filtering is what the
     model-detail panel's "Runs" list uses (design §8.2)."""
@@ -442,7 +444,9 @@ def post_control(body: dict[str, Any]) -> dict[str, Any]:
     bool}`` (the "shut down competing slots" toggle). Start arms the worker;
     Pause/Stop take effect between cells."""
     action = body.get("action")
-    state = {"start": "running", "pause": "paused", "stop": "stopped"}.get(action) if action else None
+    state = (
+        {"start": "running", "pause": "paused", "stop": "stopped"}.get(action) if action else None
+    )
     if action and state is None:
         raise HTTPException(status_code=400, detail=f"bad action {action!r} (start|pause|stop)")
     return control.set_control(state=state, exclusive=body.get("exclusive"))

--- a/src/hal0/api/routes/npu.py
+++ b/src/hal0/api/routes/npu.py
@@ -49,6 +49,10 @@ _NPU_TOPS_PEAK = 50
 # the NPU and therefore owns AIE columns. SERVING/READY/WARMING/IDLE all
 # hold weights in GTT; OFFLINE/PULLING/STARTING/UNLOADING/ERROR do not.
 _LOADED_STATES = frozenset({"serving", "ready", "warming", "idle"})
+# The _map_slot_state() outputs that count as "loaded" (warming → "loaded").
+# Used by the degraded single-tenant fallback, which works off the already-
+# mapped slot_view["state"] rather than the raw SlotState.
+_LOADED_VIEW_STATES = frozenset({"serving", "ready", "loaded", "idle"})
 
 
 def _occupancy_absent() -> dict[str, Any]:
@@ -245,14 +249,15 @@ async def npu_occupancy(request: Request) -> dict[str, Any]:
             except Exception:
                 pass
 
-        # Look up the real companion slot states — virtual subs ride
-        # coresident with the FLM anchor. They only claim columns when
-        # the corresponding real slot is enabled (operator-controlled).
-        real_stt = next((rs for rs in all_slots if rs.name == f"{s.name}-stt"), None)
-        real_embed = next((rs for rs in all_slots if rs.name == f"{s.name}-embed"), None)
-
+        # Virtual subs ride coresident with the FLM anchor: the [npu] toggle
+        # (asr/embed) IS the operator control — the single `flm serve` child
+        # serves them, so they're live whenever the modality is on and the
+        # anchor is loaded. (The old code gated on the shadow slot's own
+        # `enabled` flag, which reads false in embed/STT-primary mode where
+        # the operator disables chat but the modality is still served — so
+        # the sub-card wrongly showed "off"/dim.)
         if npu_cfg.get("asr"):
-            stt_live = is_loaded and real_stt is not None and getattr(real_stt, "enabled", False)
+            stt_live = is_loaded
             slots_out.append(
                 {
                     "name": s.name + "-stt",
@@ -263,9 +268,7 @@ async def npu_occupancy(request: Request) -> dict[str, Any]:
                 }
             )
         if npu_cfg.get("embed"):
-            embed_live = (
-                is_loaded and real_embed is not None and getattr(real_embed, "enabled", False)
-            )
+            embed_live = is_loaded
             slots_out.append(
                 {
                     "name": s.name + "-embed",
@@ -290,15 +293,16 @@ async def npu_occupancy(request: Request) -> dict[str, Any]:
     )
 
     # Degraded fallback: if xrt-smi never succeeded, every loaded slot owns
-    # all 8 columns (single-tenant binary occupancy).
+    # all 8 columns (single-tenant binary occupancy). Iterate slots_out on its
+    # own using each view's already-mapped state — the old code zipped it with
+    # flm_slots (strict=True), which crashed the whole endpoint: slots_out also
+    # carries the synthesised -stt/-embed sub-views AND is re-sorted, so it is
+    # both longer than and mis-ordered vs flm_slots. Triggered exactly when the
+    # NPU column probe is unavailable — i.e. while the FLM slot is offline.
     if not columns_available:
         any_loaded = False
-        for slot_view, s in zip(slots_out, flm_slots, strict=True):
-            raw_state = str(getattr(s, "state", "") or "").lower()
-            state_val = getattr(getattr(s, "state", None), "value", None)
-            if isinstance(state_val, str):
-                raw_state = state_val.lower()
-            if raw_state in _LOADED_STATES:
+        for slot_view in slots_out:
+            if slot_view["state"] in _LOADED_VIEW_STATES:
                 slot_view["cols"] = list(range(_NPU_COLS))
                 any_loaded = True
             else:

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -84,7 +84,9 @@ def _load_window() -> tuple[set[int], tuple[int, int], tuple[int, int], int]:
             doc = tomllib.loads(WINDOW_FILE.read_text())
             w = doc.get("window", {})
             raw_days = w.get("days") or ([w["day"]] if w.get("day") else [])
-            parsed = {_DAY_IDX[str(d)[:3].lower()] for d in raw_days if str(d)[:3].lower() in _DAY_IDX}
+            parsed = {
+                _DAY_IDX[str(d)[:3].lower()] for d in raw_days if str(d)[:3].lower() in _DAY_IDX
+            }
             if parsed:
                 days = parsed
             start = _parse_hm(w.get("start"), start)
@@ -310,7 +312,9 @@ def cmd_worker(args: argparse.Namespace) -> int:
     from . import control
 
     store = Store()
-    print(f"[worker] started; polling every {args.poll}s (state defaults to 'stopped' — idle until Start)")
+    print(
+        f"[worker] started; polling every {args.poll}s (state defaults to 'stopped' — idle until Start)"
+    )
     while True:
         if not control.worker_should_run():
             control.write_status(None, _now_stamp())
@@ -344,18 +348,31 @@ def cmd_worker(args: argparse.Namespace) -> int:
 
             cells = plan(suite, models, store)
             control.write_status(
-                {"item": item, "suite": suite.id, "cells": len(cells), "started": _now_stamp(),
-                 "exclusive": ctrl["exclusive"]},
+                {
+                    "item": item,
+                    "suite": suite.id,
+                    "cells": len(cells),
+                    "started": _now_stamp(),
+                    "exclusive": ctrl["exclusive"],
+                },
                 _now_stamp(),
             )
-            print(f"[worker] running {suite.id}: {len(cells)} cell(s), exclusive={ctrl['exclusive']}")
+            print(
+                f"[worker] running {suite.id}: {len(cells)} cell(s), exclusive={ctrl['exclusive']}"
+            )
             result = run_session(
-                cells, store, _session_host(args.api, ctrl["exclusive"]),
-                suite_id=suite.id, api=args.api, exclusive=ctrl["exclusive"],
+                cells,
+                store,
+                _session_host(args.api, ctrl["exclusive"]),
+                suite_id=suite.id,
+                api=args.api,
+                exclusive=ctrl["exclusive"],
                 should_continue=control.worker_should_run,
             )
             if result.aborted == "stopped":
-                print(f"[worker] {suite.id} stopped after {result.cells_ok} cell(s) — item stays queued")
+                print(
+                    f"[worker] {suite.id} stopped after {result.cells_ok} cell(s) — item stays queued"
+                )
                 control.write_status(None, _now_stamp())
                 continue  # leave the item queued; resumes on next Start
             if result.aborted == "gpu-contended":
@@ -484,8 +501,16 @@ def cmd_eval(args: argparse.Namespace) -> int:
         for model in models:
             for task in tasks:
                 if not args.force and traffic_in_flight(args.api):
-                    print(json.dumps({"event": "bench.eval.declined", "task": task.id,
-                                      "model": model, "reason": "live-traffic"}))
+                    print(
+                        json.dumps(
+                            {
+                                "event": "bench.eval.declined",
+                                "task": task.id,
+                                "model": model,
+                                "reason": "live-traffic",
+                            }
+                        )
+                    )
                     continue
                 print(f"[eval] {model} :: {task.id} …", flush=True)
                 rec = evalrun.run_task(task, model, run_id, args.api, workroot)
@@ -493,10 +518,12 @@ def cmd_eval(args: argparse.Namespace) -> int:
                 rows.append(rec)
                 mark = "OK " if rec.correct else ("~  " if rec.score > 0 else "X  ")
                 m = rec.metrics
-                print(f"  {mark} score={rec.score} got={rec.answer!r} "
-                      f"want={rec.expected!r} wall={m.get('wall_s')}s "
-                      f"tools={m.get('tool_calls')} tok_out={m.get('tokens_out')} "
-                      f"steps={len(rec.checkpoints_hit)}/{rec.checkpoints_total}")
+                print(
+                    f"  {mark} score={rec.score} got={rec.answer!r} "
+                    f"want={rec.expected!r} wall={m.get('wall_s')}s "
+                    f"tools={m.get('tool_calls')} tok_out={m.get('tokens_out')} "
+                    f"steps={len(rec.checkpoints_hit)}/{rec.checkpoints_total}"
+                )
 
     if rows:
         print("\n" + _eval_table(rows))
@@ -527,7 +554,11 @@ def _eval_table(rows: list) -> str:
 
 
 def _shquote(s: str) -> str:
-    return s if s and all(c.isalnum() or c in "-_./:=" for c in s) else "'" + s.replace("'", "'\\''") + "'"
+    return (
+        s
+        if s and all(c.isalnum() or c in "-_./:=" for c in s)
+        else "'" + s.replace("'", "'\\''") + "'"
+    )
 
 
 def cmd_import_v1(args: argparse.Namespace) -> int:
@@ -612,7 +643,7 @@ def _norm_v1_model_id(name: str | None) -> str:
     ``/mnt/ai-models/dir/File.gguf`` (verified on-box) — strip the model-root
     prefix + leading slash so both collapse to one id."""
     n = (name or "unknown").lstrip("/")
-    return n[len("mnt/ai-models/"):] if n.startswith("mnt/ai-models/") else n
+    return n[len("mnt/ai-models/") :] if n.startswith("mnt/ai-models/") else n
 
 
 def _v1_lane(backend: str | None) -> str:
@@ -690,8 +721,15 @@ def _import_v1_server_ab(sa_dir: Path, store: Store) -> int:
             if runs is None and "second_call" in block:
                 runs = [block["second_call"]]
             rec = _sa_generative_record(
-                mode, kind, slot, variant, block.get("extra_args", ""),
-                runs or [], max_tokens, stamp, path.name,
+                mode,
+                kind,
+                slot,
+                variant,
+                block.get("extra_args", ""),
+                runs or [],
+                max_tokens,
+                stamp,
+                path.name,
             )
             if rec is not None:
                 store.append_record(rec)
@@ -836,7 +874,9 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("run", help="execute the plan (or a slice)")
     p.add_argument("--suite", required=True)
     p.add_argument("--budget-min", type=int, default=0, help="override suite budget")
-    p.add_argument("--dry-run", action="store_true", help="print the worklist + commands, run nothing")
+    p.add_argument(
+        "--dry-run", action="store_true", help="print the worklist + commands, run nothing"
+    )
     p.add_argument(
         "--scheduled",
         action="store_true",
@@ -874,12 +914,16 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--site-ts", default=None, help="also emit the site data .ts to this path")
     p.set_defaults(func=cmd_publish)
 
-    p = sub.add_parser("eval", help="agentic task eval (quality tier): score a model as a real agent")
+    p = sub.add_parser(
+        "eval", help="agentic task eval (quality tier): score a model as a real agent"
+    )
     p.add_argument("--models", required=True, help="comma-separated model ids to eval/compare")
     p.add_argument("--task", action="append", help="limit to task id(s); repeatable (default: all)")
     p.add_argument("--api", default=DEFAULT_API, help=f"hal0 API base (default {DEFAULT_API})")
     p.add_argument("--dry-run", action="store_true", help="print the exact hermes commands; no GPU")
-    p.add_argument("--force", action="store_true", help="run even over live traffic (skip politeness)")
+    p.add_argument(
+        "--force", action="store_true", help="run even over live traffic (skip politeness)"
+    )
     p.set_defaults(func=cmd_eval)
 
     p = sub.add_parser("import-v1", help="import hal0 v1 results into v2 records")

--- a/src/hal0/bench/evalrun.py
+++ b/src/hal0/bench/evalrun.py
@@ -103,7 +103,9 @@ def _loop_answer() -> str:
 
     rows = list(csv.DictReader((_fx("loop-aggregate") / "orders.csv").read_text().splitlines()))
     shipped = sum(int(r["amount"]) for r in rows if r["status"] == "shipped")
-    refund = int(re.search(r"REFUND:\s*(\d+)", (_fx("loop-aggregate") / "notes.md").read_text()).group(1))
+    refund = int(
+        re.search(r"REFUND:\s*(\d+)", (_fx("loop-aggregate") / "notes.md").read_text()).group(1)
+    )
     return str(shipped - refund)
 
 
@@ -115,9 +117,15 @@ def _dep_answer() -> str:
 
 
 def _grep_answer() -> str:
-    seats = int(re.search(r"LICENSE_SEAT_COUNT\s*=\s*(\d+)",
-                          (_fx("grep-hunt") / "deep/nested/license.conf").read_text()).group(1))
-    per = int(re.search(r"SEATS_PER_POD:\s*(\d+)", (_fx("grep-hunt") / "pods.yaml").read_text()).group(1))
+    seats = int(
+        re.search(
+            r"LICENSE_SEAT_COUNT\s*=\s*(\d+)",
+            (_fx("grep-hunt") / "deep/nested/license.conf").read_text(),
+        ).group(1)
+    )
+    per = int(
+        re.search(r"SEATS_PER_POD:\s*(\d+)", (_fx("grep-hunt") / "pods.yaml").read_text()).group(1)
+    )
     return str(seats * per)
 
 
@@ -321,8 +329,17 @@ def hermes_cmd(task: Task, model: str, api: str) -> list[str]:
     """The exact headless Hermes invocation (pure — used by the runner and by
     `eval --dry-run`)."""
     return [
-        HERMES, "-z", task.prompt, "-m", model, "--provider", "custom",
-        "--yolo", "-t", task.toolsets, "--pass-session-id",
+        HERMES,
+        "-z",
+        task.prompt,
+        "-m",
+        model,
+        "--provider",
+        "custom",
+        "--yolo",
+        "-t",
+        task.toolsets,
+        "--pass-session-id",
     ]
 
 
@@ -338,8 +355,12 @@ def _collect_metrics(workdir: Path, wall_s: float) -> tuple[dict[str, Any], str]
     scan it for the intermediate checkpoint values. Falls back to wall time only
     if the export isn't available."""
     metrics: dict[str, Any] = {
-        "wall_s": round(wall_s, 1), "turns": None, "tool_calls": None,
-        "tokens_in": None, "tokens_out": None, "api_calls": None,
+        "wall_s": round(wall_s, 1),
+        "turns": None,
+        "tool_calls": None,
+        "tokens_in": None,
+        "tokens_out": None,
+        "api_calls": None,
     }
     trace = ""
     try:
@@ -360,8 +381,10 @@ def _collect_metrics(workdir: Path, wall_s: float) -> tuple[dict[str, Any], str]
         if not isinstance(d, dict) or d.get("cwd") != target:
             continue
         metrics.update(
-            turns=d.get("message_count"), tool_calls=d.get("tool_call_count"),
-            tokens_in=d.get("input_tokens"), tokens_out=d.get("output_tokens"),
+            turns=d.get("message_count"),
+            tool_calls=d.get("tool_call_count"),
+            tokens_in=d.get("input_tokens"),
+            tokens_out=d.get("output_tokens"),
             api_calls=d.get("api_call_count"),
         )
         msgs = d.get("messages")
@@ -456,19 +479,38 @@ def run_task(task: Task, model: str, run_id: str, api: str, workroot: Path) -> E
         expected = task.expected_fn()
     except Exception as exc:  # deriving the answer failed (e.g. hal0.dev unreachable)
         return EvalRecord(
-            run_id=run_id, suite="agentic", task_id=task.id, kind=task.kind, model=model,
-            outcome="failed", score=0.0, correct=False, expected="", answer="",
-            checkpoints_hit=[], checkpoints_total=len(task.checkpoints),
-            metrics={"wall_s": round(wall, 1)}, note=f"expected-derive failed: {exc}",
+            run_id=run_id,
+            suite="agentic",
+            task_id=task.id,
+            kind=task.kind,
+            model=model,
+            outcome="failed",
+            score=0.0,
+            correct=False,
+            expected="",
+            answer="",
+            checkpoints_hit=[],
+            checkpoints_total=len(task.checkpoints),
+            metrics={"wall_s": round(wall, 1)},
+            note=f"expected-derive failed: {exc}",
         )
 
     metrics, trace = _collect_metrics(workdir, wall)
     sc = score_task(task, stdout, expected, trace)
     note = f"{outcome}: {stdout[-200:]}" if outcome != "ok" and not sc.correct else ""
     return EvalRecord(
-        run_id=run_id, suite="agentic", task_id=task.id, kind=task.kind, model=model,
+        run_id=run_id,
+        suite="agentic",
+        task_id=task.id,
+        kind=task.kind,
+        model=model,
         outcome="ok" if sc.correct or outcome == "ok" else outcome,
-        score=sc.score, correct=sc.correct, expected=sc.expected, answer=sc.answer,
-        checkpoints_hit=sc.checkpoints_hit, checkpoints_total=sc.checkpoints_total,
-        metrics=metrics, note=note,
+        score=sc.score,
+        correct=sc.correct,
+        expected=sc.expected,
+        answer=sc.answer,
+        checkpoints_hit=sc.checkpoints_hit,
+        checkpoints_total=sc.checkpoints_total,
+        metrics=metrics,
+        note=note,
     )

--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -259,7 +259,11 @@ def _flag_tokens(flags: dict) -> list[str]:
 
 
 def _build_identity(
-    model: dict[str, Any], lane: str, kind: str, depth: int, sampler: str,
+    model: dict[str, Any],
+    lane: str,
+    kind: str,
+    depth: int,
+    sampler: str,
     flags: dict | None = None,
 ) -> Identity:
     """Resolve one candidate cell's identity from a registry entry + axis point.
@@ -320,7 +324,9 @@ def _validated_configs(configs: list[dict]) -> list[dict]:
             if k in _TUNE_FLAGS:
                 flags[k] = v
             else:
-                print(f"[plan] ignoring non-whitelisted config flag {k!r} in variant {c.get('label')!r}")
+                print(
+                    f"[plan] ignoring non-whitelisted config flag {k!r} in variant {c.get('label')!r}"
+                )
         out.append({"label": c.get("label") or "default", "flags": flags})
     return out or [{"label": "default", "flags": {}}]
 

--- a/src/hal0/bench/runner.py
+++ b/src/hal0/bench/runner.py
@@ -62,8 +62,14 @@ MODEL_ROOT = "/mnt/ai-models/"
 # Rough per-cell expected wall-clock (seconds) for the watchdog (fires at 3x).
 # Generous on purpose — it catches a hang, it is not an SLA.
 _EXPECTED_S = {
-    "pp": 120, "tg": 180, "chat": 240, "reuse": 180,
-    "embed": 120, "rerank": 120, "batch": 600, "mtp": 300,
+    "pp": 120,
+    "tg": 180,
+    "chat": 240,
+    "reuse": 180,
+    "embed": 120,
+    "rerank": 120,
+    "batch": 600,
+    "mtp": 300,
 }
 _TIER_A_KINDS = {"pp", "tg"}
 # Tier-B cell kind -> server_ab.py --mode (this build: ab/reuse/embed/rerank).
@@ -184,7 +190,7 @@ def _gpu_slot_serving(api: str) -> bool:
 def _rel_gguf(gguf: str) -> str:
     """The model path the seam expects: relative to /mnt/ai-models, ending .gguf
     (hal0-benchctl validate_model). Absolute registry paths are stripped."""
-    return gguf[len(MODEL_ROOT):] if gguf.startswith(MODEL_ROOT) else gguf.lstrip("/")
+    return gguf[len(MODEL_ROOT) :] if gguf.startswith(MODEL_ROOT) else gguf.lstrip("/")
 
 
 def _run_subprocess(cmd: list[str], timeout_s: float, log_path: Path) -> tuple[int, str]:
@@ -226,8 +232,7 @@ def _locate_sweep_output(lane: str, since_wall: float) -> tuple[list[dict], dict
     if not V1_RUNS_DIR.is_dir():
         return None
     cands = [
-        p for p in V1_RUNS_DIR.glob(f"*__{lane}__sweep.json")
-        if p.stat().st_mtime >= since_wall - 5
+        p for p in V1_RUNS_DIR.glob(f"*__{lane}__sweep.json") if p.stat().st_mtime >= since_wall - 5
     ]
     if not cands:
         return None
@@ -276,11 +281,22 @@ def _tier_a_cmd(cell, exclusive: bool, tg_gen: int) -> list[str]:
     return cmd
 
 
-def _tier_bc_cmd(cell, slot: str, api: str, out: Path | str = "<artifacts>/server-ab.json") -> list[str]:
+def _tier_bc_cmd(
+    cell, slot: str, api: str, out: Path | str = "<artifacts>/server-ab.json"
+) -> list[str]:
     """The exact `server_ab.py` argv for a Tier-B/C cell."""
     return [
-        SERVER_AB, "--mode", _KIND_TO_MODE.get(cell.kind, "ab"),
-        "--slot", slot, "--api", api, "--n", str(cell.reps), "--out", str(out),
+        SERVER_AB,
+        "--mode",
+        _KIND_TO_MODE.get(cell.kind, "ab"),
+        "--slot",
+        slot,
+        "--api",
+        api,
+        "--n",
+        str(cell.reps),
+        "--out",
+        str(out),
     ]
 
 
@@ -293,7 +309,9 @@ def describe_worklist(cells: list[Cell], exclusive: bool, api: str) -> list[str]
     seen: set[tuple] = set()
     lines: list[str] = []
     for i, c in enumerate(cells, 1):
-        cfg = f"  cfg:{c.config_label}" if getattr(c, "config_label", "default") != "default" else ""
+        cfg = (
+            f"  cfg:{c.config_label}" if getattr(c, "config_label", "default") != "default" else ""
+        )
         label = f"{i:2d}. {c.model_id}  {c.lane}  {c.kind}  d{c.depth}{cfg}  ({c.reason})"
         if c.kind in _TIER_A_KINDS:
             key = _group_key(c)
@@ -367,12 +385,27 @@ def run_session(
 
             if cell.kind in _TIER_A_KINDS:
                 record = _tier_a_record(
-                    cell, artifacts, watchdog_s, exclusive, tg_gen, sweep_cache,
-                    host, suite_id, run_id, api,
+                    cell,
+                    artifacts,
+                    watchdog_s,
+                    exclusive,
+                    tg_gen,
+                    sweep_cache,
+                    host,
+                    suite_id,
+                    run_id,
+                    api,
                 )
             else:
                 record = _tier_bc_record(
-                    cell, artifacts, watchdog_s, api, exclusive, host, suite_id, run_id,
+                    cell,
+                    artifacts,
+                    watchdog_s,
+                    api,
+                    exclusive,
+                    host,
+                    suite_id,
+                    run_id,
                 )
 
             store.append_record(record)  # append-as-we-go = resumable
@@ -409,7 +442,16 @@ def _tg_gen_by_group(cells: list[Cell]) -> dict[tuple, int]:
 
 
 def _tier_a_record(
-    cell, artifacts, timeout_s, exclusive, tg_gen_map, cache, host, suite_id, run_id, api,
+    cell,
+    artifacts,
+    timeout_s,
+    exclusive,
+    tg_gen_map,
+    cache,
+    host,
+    suite_id,
+    run_id,
+    api,
 ) -> Record:
     """Run (or reuse) the Tier-A sweep for this cell's group and parse its kind."""
     key = _group_key(cell)
@@ -445,7 +487,14 @@ def _tier_a_record(
 
 
 def _tier_bc_record(
-    cell, artifacts, timeout_s, api, exclusive, host, suite_id, run_id,
+    cell,
+    artifacts,
+    timeout_s,
+    api,
+    exclusive,
+    host,
+    suite_id,
+    run_id,
 ) -> Record:
     """Run a Tier-B/C server_ab cell and parse it. Slot name resolves from the
     registry model id via /api/slots (a live server_ab slot), falling back to the
@@ -479,7 +528,15 @@ def _slot_for_model(api: str, model_id: str) -> str | None:
 
 
 def _assemble(
-    cell, parsed, outcome, host, suite_id, run_id, artifacts, tail, api,
+    cell,
+    parsed,
+    outcome,
+    host,
+    suite_id,
+    run_id,
+    artifacts,
+    tail,
+    api,
 ) -> Record:
     """Build the schema-2 record from a Parsed result + the planned cell.
 
@@ -508,7 +565,11 @@ def _assemble(
     # to publish (DESIGN §4 smoke): downgrade an otherwise-ok outcome.
     if outcome is Outcome.OK and not host.exclusive and _gpu_slot_serving(api):
         outcome = Outcome.SKIPPED_CONTENDED
-    note = "" if outcome is Outcome.OK else (f"{outcome.value}: {tail[-200:]}" if tail else outcome.value)
+    note = (
+        ""
+        if outcome is Outcome.OK
+        else (f"{outcome.value}: {tail[-200:]}" if tail else outcome.value)
+    )
     return Record(
         run_id=run_id,
         suite=suite_id,

--- a/src/hal0/bench/store.py
+++ b/src/hal0/bench/store.py
@@ -37,7 +37,9 @@ DEFAULT_STATE_ROOT = "/var/lib/hal0-bench"
 def state_root() -> Path:
     """Resolve the state root: ``$BENCHLAB_STATE`` or the default. Read live (not
     a module constant) so tests can point it at a tmp dir per-call."""
-    return Path(os.environ.get("HAL0_BENCH_STATE", os.environ.get("BENCHLAB_STATE", DEFAULT_STATE_ROOT)))
+    return Path(
+        os.environ.get("HAL0_BENCH_STATE", os.environ.get("BENCHLAB_STATE", DEFAULT_STATE_ROOT))
+    )
 
 
 class Store:

--- a/tests/api/test_slots_npu_fields.py
+++ b/tests/api/test_slots_npu_fields.py
@@ -100,7 +100,7 @@ def test_slot_list_includes_npu_toggles(
     assert "npu" in by_name, "npu slot must appear in list"
     slot = by_name["npu"]
     assert "npu" in slot, f"npu key must be present; got keys: {list(slot.keys())}"
-    assert slot["npu"] == {"asr": True, "embed": False}
+    assert slot["npu"] == {"asr": True, "embed": False, "chat": True}
 
 
 def test_slot_without_npu_table_omits_field(

--- a/tests/api/test_v1_npu_trio_routing.py
+++ b/tests/api/test_v1_npu_trio_routing.py
@@ -57,15 +57,15 @@ def _seed_slot_toml(home: str, name: str, lines: list[str]) -> Path:
 def seed_npu_trio(tmp_hal0_home: str) -> None:
     """Lay down the NPU trio slot TOMLs on disk.
 
-    ``npu`` is the containerized anchor (static port, runtime=container);
+    ``flm`` is the containerized anchor (static port, runtime=container);
     ``stt-npu`` / ``embed-npu`` are the shadow-role records whose model
     ids gate the trio dispatch in v1.py.
     """
     _seed_slot_toml(
         tmp_hal0_home,
-        "npu",
+        "flm",
         [
-            'name = "npu"',
+            'name = "flm"',
             f"port = {_NPU_PORT}",
             'device = "npu"',
             'type = "llm"',
@@ -131,18 +131,18 @@ def _make_capture_transport(captures: dict[str, Any]) -> httpx.MockTransport:
 
 
 def _pin_npu_ready(client: TestClient) -> None:
-    """Force the npu slot into the dispatchable ready-set (READY).
+    """Force the flm slot into the dispatchable ready-set (READY).
 
     ``NpuTrioRouter.resolve_npu_url`` gates on
-    ``SlotManager.is_ready_for_dispatch("npu")`` — no container runs under
+    ``SlotManager.is_ready_for_dispatch("flm")`` — no container runs under
     test, so the slot would otherwise be OFFLINE and every trio dispatch
     would 503.
     """
     from hal0.slots.state import SlotState, SlotStateRecord
 
     sm = client.app.state.slot_manager
-    sm._states["npu"] = SlotStateRecord(
-        name="npu",
+    sm._states["flm"] = SlotStateRecord(
+        name="flm",
         state=SlotState.READY,
         model_id="gemma3:1b",
         port=_NPU_PORT,

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -346,14 +346,14 @@ async def test_legacy_fallback_routes_embeddings_to_embed_slot() -> None:
 
 @pytest.mark.asyncio
 async def test_legacy_fallback_routes_colon_model_to_npu_slot() -> None:
-    """Rule 5: an FLM tag-style ``name:tag`` model id routes to the npu slot.
+    """Rule 5: an FLM tag-style ``name:tag`` model id routes to the flm slot.
 
     Locks the capability/path heuristic that pins ``qwen3:0.6b`` (and any
-    ``name:tag`` id) to the ``npu`` slot when the registry and warm caches
+    ``name:tag`` id) to the ``flm`` slot when the registry and warm caches
     have nothing to say — the last-resort step in ``dispatch()``.
     """
-    npu = make_slot("npu", "http://127.0.0.1:8089/v1")
-    upstreams = FakeUpstreamRegistry([npu])
+    flm = make_slot("flm", "http://127.0.0.1:8089/v1")
+    upstreams = FakeUpstreamRegistry([flm])
     models = FakeModelRegistry(routes={})
 
     dispatcher = Dispatcher(upstream_registry=upstreams, model_registry=models)
@@ -361,8 +361,8 @@ async def test_legacy_fallback_routes_colon_model_to_npu_slot() -> None:
         make_request(),
         body={"model": "qwen3:0.6b"},
     )
-    assert call.resolution_path == "legacy_slot:npu"
-    assert call.upstream_name == "npu"
+    assert call.resolution_path == "legacy_slot:flm"
+    assert call.upstream_name == "flm"
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_image_resolution.py
+++ b/tests/providers/test_image_resolution.py
@@ -105,16 +105,17 @@ def test_profile_image_and_flags_default_when_nothing_set() -> None:
     "seed_name,expected_image",
     [
         # The 2x2 (backend x {dense,moe}) ROCmFPX grid consolidated in 0.9.5.
-        ("rocm-dense", "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"),
-        ("rocm-moe", "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"),
-        ("vulkan-dense", "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"),
-        ("vulkan-moe", "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"),
+        # c077206 became the default runner in #1173 (hal0-bench in-tree).
+        ("rocm-dense", "ghcr.io/hal0ai/hal0-rocmfpx:c077206"),
+        ("rocm-moe", "ghcr.io/hal0ai/hal0-rocmfpx:c077206"),
+        ("vulkan-dense", "ghcr.io/hal0ai/hal0-rocmfpx:c077206"),
+        ("vulkan-moe", "ghcr.io/hal0ai/hal0-rocmfpx:c077206"),
     ],
 )
-def test_seed_profiles_image_pinned_to_vulkan_minicpm5(seed_name: str, expected_image: str) -> None:
-    """The three ROCmFPX runner seed profiles use the new default image.
+def test_seed_profiles_image_pinned_to_c077206(seed_name: str, expected_image: str) -> None:
+    """The ROCmFPX runner seed profiles use the current default image.
 
-    Pins the rollout: every fresh install gets the v0.9.5 ROCmFPX
+    Pins the rollout: every fresh install gets the c077206 ROCmFPX
     runner on its first launch unless the operator pins a different
     image in their slot TOML.
     """

--- a/tests/slots/test_upstream_reconcile.py
+++ b/tests/slots/test_upstream_reconcile.py
@@ -1,6 +1,6 @@
 """#732: upstream-registry restart drop — reconciliation + idempotent load.
 
-Per-slot ``kind="remote"`` upstreams live only in the in-memory
+Per-slot ``kind="slot"`` upstreams live only in the in-memory
 ``UpstreamRegistry`` and die with the api process, while the podman
 containers (and their loaded models) survive a restart. Pre-fix, every
 ``systemctl restart hal0-api`` left "ready" slots unroutable
@@ -54,7 +54,7 @@ class TestReconcileContainerUpstreams:
         assert restored == ["chat"]
         up = reg2.get("chat")
         assert up is not None
-        assert up.kind == "remote"
+        assert up.kind == "slot"
         assert up.slot_name == "chat"
         assert ":8081" in up.url
 
@@ -120,7 +120,7 @@ class TestReconcileAdoptsOfflineButActive:
         assert restored == ["chat"]
         up = reg.get("chat")
         assert up is not None
-        assert up.kind == "remote"
+        assert up.kind == "slot"
         assert ":8081" in up.url
         # FSM state reconciled to READY by the reconcile pass itself, so
         # /api/status stops emitting "offline" over the running container.
@@ -155,7 +155,7 @@ class TestIdempotentLoadReregisters:
         # …but the route comes back.
         up = reg2.get("chat")
         assert up is not None
-        assert up.kind == "remote"
+        assert up.kind == "slot"
         assert ":8081" in up.url
 
     async def test_load_on_ready_trio_shadow_does_not_register(

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -273,19 +273,24 @@ export function TileStrip({ owners, ownerName, act = 0, w = 10, h = 10 }) {
 // ═══ per-slot card (right rail) ════════════════════════════════════════
 function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
   const ind = slotIndicatorFromPhase(slot)
-  // Prefer the NPU occupancy's synthesised state: it knows the coresident
-  // stt/embed sub-slots are live off the anchor's [npu] toggles (the shadow
-  // slot's own phase reads "offline" since it runs no unit of its own). Fall
-  // back to the slot's own phase for the anchor / non-trio cases.
+  // Signal from BOTH the slot's own phase and the NPU occupancy's synthesised
+  // state. The slot phase is authoritative for the anchor (esp. actively
+  // serving); the occupancy state knows the coresident stt/embed sub-slots are
+  // live off the anchor's [npu] toggles (their own phase reads "offline" since
+  // they run no unit of their own).
   const occState = String(occ?.state || '').toLowerCase()
-  const rawCls = occState || ind.cls
-  const serving = rawCls === 'serving'
-  // "running" = up & resident on the NPU (serving, ready/idle/loaded/warming,
-  // or the "stale" ready alias). These glow purple; offline/off/error stay
-  // dim. Previously every non-serving state (incl. offline) fell through to a
-  // flat green dot, so all three trio cards read green regardless of reality.
-  const running = ['serving', 'ready', 'idle', 'loaded', 'warming', 'stale'].includes(rawCls)
-  const dotCls = serving ? 'serving' : rawCls === 'error' ? 'error' : running ? 'running' : 'offline'
+  const RUNNING_STATES = ['serving', 'ready', 'idle', 'loaded', 'warming', 'stale']
+  const serving = ind.cls === 'serving' || occState === 'serving'
+  // "running" = up & resident on the NPU. These glow purple; offline/off/error
+  // stay dim. Previously every non-serving state (incl. offline) fell through
+  // to a flat green dot, so all three trio cards read green regardless.
+  const running =
+    serving ||
+    RUNNING_STATES.includes(occState) ||
+    ind.cls === 'stale' ||
+    ind.cls === 'warming'
+  const isError = ind.cls === 'error' || occState === 'error'
+  const dotCls = serving ? 'serving' : isError ? 'error' : running ? 'running' : 'offline'
   const m = slot.metrics || {}
   const tps = typeof m.toks === 'number' && m.toks > 0 ? Math.round(m.toks) : null
   const ttft = typeof m.ttft === 'number' && m.ttft > 0 ? Math.round(m.ttft) : null

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -273,16 +273,28 @@ export function TileStrip({ owners, ownerName, act = 0, w = 10, h = 10 }) {
 // ═══ per-slot card (right rail) ════════════════════════════════════════
 function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
   const ind = slotIndicatorFromPhase(slot)
-  const serving = ind.cls === 'serving'
+  // Prefer the NPU occupancy's synthesised state: it knows the coresident
+  // stt/embed sub-slots are live off the anchor's [npu] toggles (the shadow
+  // slot's own phase reads "offline" since it runs no unit of its own). Fall
+  // back to the slot's own phase for the anchor / non-trio cases.
+  const occState = String(occ?.state || '').toLowerCase()
+  const rawCls = occState || ind.cls
+  const serving = rawCls === 'serving'
+  // "running" = up & resident on the NPU (serving, ready/idle/loaded/warming,
+  // or the "stale" ready alias). These glow purple; offline/off/error stay
+  // dim. Previously every non-serving state (incl. offline) fell through to a
+  // flat green dot, so all three trio cards read green regardless of reality.
+  const running = ['serving', 'ready', 'idle', 'loaded', 'warming', 'stale'].includes(rawCls)
+  const dotCls = serving ? 'serving' : rawCls === 'error' ? 'error' : running ? 'running' : 'offline'
   const m = slot.metrics || {}
   const tps = typeof m.toks === 'number' && m.toks > 0 ? Math.round(m.toks) : null
   const ttft = typeof m.ttft === 'number' && m.ttft > 0 ? Math.round(m.ttft) : null
   const gb = occ && typeof occ.gb === 'number' ? round1(occ.gb) : typeof m.mem === 'number' ? round1(m.mem) : null
   const model = String(slot.model_id || slot.model || occ?.model || '').replace(/-FLM$/, '')
   return (
-    <div className={'cslot' + (serving ? '' : ' dim')} style={{ '--slot-hue': hue.hue, '--slot-fg': hue.fg }}>
+    <div className={'cslot' + (running ? ' running' : ' dim')} style={{ '--slot-hue': hue.hue, '--slot-fg': hue.fg }}>
       <div className="cslot-top">
-        <span className={'ldot ' + (serving ? 'serving' : ind.cls === 'error' ? 'offline' : 'ready')} />
+        <span className={'ldot ' + dotCls} />
         <span className="nm">{slot.name}</span>
         <span className="md">{model || '—'}</span>
         <span className="grow" />

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -132,21 +132,37 @@
   background: var(--fg-5);
   flex-shrink: 0;
 }
+/* Actively serving a request — strong, fast purple pulse. */
 .npu-card .ldot.serving {
   background: var(--npu);
   box-shadow: 0 0 7px var(--npu-glow);
   animation: pulse 1.5s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) infinite;
 }
+/* Up & resident on the NPU but not mid-request — a steady purple glow that
+   gently breathes, so "running" reads clearly as alive (distinct from the
+   flat green that used to blanket every state). */
+.npu-card .ldot.running {
+  background: var(--npu);
+  box-shadow:
+    0 0 6px var(--npu-glow),
+    0 0 12px -2px var(--npu-glow);
+  animation: pulse 2.6s var(--ease, cubic-bezier(0.22, 1, 0.36, 1)) infinite;
+}
 .npu-card .ldot.ready {
   background: var(--ok);
+}
+.npu-card .ldot.error {
+  background: var(--err);
+  box-shadow: 0 0 6px -1px var(--err);
 }
 .npu-card .ldot.offline {
   background: var(--fg-5);
 }
 /* @keyframes pulse is defined globally in dashboard.css — do NOT redefine it
-   (overhaul.css carries the same warning). .ldot.serving reuses that one. */
+   (overhaul.css carries the same warning). .ldot.serving/.running reuse it. */
 @media (prefers-reduced-motion: reduce) {
-  .npu-card .ldot.serving {
+  .npu-card .ldot.serving,
+  .npu-card .ldot.running {
     animation: none;
   }
 }
@@ -481,6 +497,16 @@
 }
 .npu-card .cslot.dim {
   opacity: 0.62;
+}
+/* Running slot — faint purple halo + a lit accent bar so a live NPU slot is
+   unmistakable at a glance. The pulsing purple .ldot is the primary signal;
+   this reinforces it without flattening the per-slot hue on the bar. */
+.npu-card .cslot.running {
+  box-shadow: 0 0 16px -6px var(--npu-glow);
+}
+.npu-card .cslot.running::before {
+  opacity: 1;
+  box-shadow: 0 0 10px var(--slot-hue);
 }
 .npu-card .cslot.free {
   background: transparent;


### PR DESCRIPTION
Follow-up to #1172 (FLM trio wiring) and #1173 (bench in-tree): adds the purple "running" indicator to the NPU slot cards, hardens the occupancy endpoint, and clears the real CI failures those two PRs left on `main` (the lint gate had been masking them).

## NPU cards — purple "running" glow
The occupancy cards read flat **green** for every up/idle/offline state (only serving/error differed), so the whole trio looked identically green. Now a slot that's up & resident on the NPU glows **purple** — a breathing `.ldot.running` dot + a faint purple card halo — distinct from the fast serving pulse; offline/error stay dim (error = red dot). Verified live on CT105 in embed-primary, STT-primary, and full-trio.

## Occupancy endpoint hardening
- **Crash fix:** the degraded single-tenant fallback did `zip(slots_out, flm_slots, strict=True)` — `slots_out` also carries the synthesised `-stt`/`-embed` sub-views and is re-sorted, so it's longer than and mis-ordered vs `flm_slots`. Any request while the FLM slot was **offline** 500'd the whole `/api/npu/occupancy`. Now iterates `slots_out` alone off each view's mapped state.
- **Coresident live state:** stt/embed sub-slots are marked live off the anchor's `[npu]` toggles + loaded state (not the legacy shadow-slot `enabled` flag), so in embed/STT-primary mode the sub-cards correctly glow.

## CI green (real failures cleared)
`main` was red behind the lint gate; with lint fixed the full pipeline surfaced pre-existing + newly-introduced failures. This PR clears the real ones:
- `ruff format` — the 6 in-tree bench files #1173 merged unformatted.
- `test_slots_npu_fields` — expect `"chat"` in the serialized npu dict (#1172 gap).
- `test_v1_npu_trio_routing` / `test_router` — seed the anchor as `flm` (npu→flm rename) + `kind=slot` upstream.
- `test_upstream_reconcile` — assert `kind=="slot"` (intentional a0d500a7).
- `test_image_resolution` — pin the `c077206` runner default (#1173).

Every test change was traced to an intentional source commit (no source behaviour changed, no regressions masked). Remaining python failures are live-box environment leakage (root runner, /etc/hal0, Proxmox, docker fallback) that pass in clean CI. Remaining e2e failures (board-chat / board-drawer / activity-log) are pre-existing debt in unrelated feature areas, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)