### PR TITLE
feat(models): HuggingFace model update detection + one-click Update all

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1058,6 +1058,120 @@ def _hf_repo_for_model(registry: Any, model_id: str) -> str | None:
         return None
 
 
+# ── HF model updates (compare installed sha vs repo main) ─────────────────────
+#
+# These static-path routes are declared BEFORE ``/{model_id}`` so FastAPI's
+# in-order matcher resolves ``/updates`` / ``/update-all`` here instead of
+# treating "updates" as a model id (same ordering trick as ``/pulls``).
+
+
+@router.get("/updates")
+async def list_model_updates(request: Request, force: bool = False) -> dict[str, Any]:
+    """Report which installed HF models have a newer file on their repo.
+
+    Compares each checkable registry row's pull-time content sha256 against
+    the repo's current ``main`` LFS oid (see :mod:`hal0.registry.updates`).
+    ``?force=true`` bypasses the per-repo tree cache to re-probe HF.
+
+    Response::
+
+        {
+          "updates": [{"model_id", "hf_repo", "hf_filename",
+                       "update_available", "current_sha", "remote_sha",
+                       "reason"}, ...],
+          "count": <models checked>,
+          "available": <models with an update>
+        }
+
+    Never 500s the dashboard: an unreachable repo degrades that row to
+    ``update_available=false`` with ``reason="repo_unreachable"``.
+    """
+    from hal0.registry.updates import check_updates
+
+    registry = request.app.state.model_registry
+    infos = await check_updates(list(registry.list()), force=force)
+    updates = [i.as_dict() for i in infos]
+    available = sum(1 for u in updates if u["update_available"])
+    return {"updates": updates, "count": len(updates), "available": available}
+
+
+@router.post("/updates/check")
+async def check_model_updates(request: Request) -> dict[str, Any]:
+    """Force a fresh HF probe (cache-bypass) and return the update report.
+
+    POST sibling of ``GET /updates`` mirroring the app-updater's
+    ``/api/updates/check`` — the dashboard's "Check for updates" affordance
+    calls this to re-probe HF regardless of the tree cache.
+    """
+    return await list_model_updates(request, force=True)
+
+
+@router.post("/update-all", status_code=202)
+async def update_all_models(request: Request, background: BackgroundTasks) -> dict[str, Any]:
+    """Re-pull every installed HF model that has an available update.
+
+    Detection reuses the cached ``/updates`` report (no ``force``); each stale
+    model is re-pulled from its repo's ``main`` via the same background-pull
+    plumbing as a single pull, so progress streams over the existing SSE /
+    footer-event rails and the registry row's sha256 is refreshed on
+    completion. A model already mid-pull is skipped (its in-flight job is
+    returned instead of a duplicate).
+
+    Response (202)::
+
+        {"started": [{"model_id", "id", "state"}...], "skipped": [...],
+         "count": <jobs started>}
+    """
+    from hal0.registry.updates import check_updates
+
+    registry = request.app.state.model_registry
+    jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
+
+    infos = await check_updates(list(registry.list()))
+    stale = [i for i in infos if i.update_available]
+
+    started: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for info in stale:
+        model_id = info.model_id
+        existing = jobs.get(model_id)
+        if existing is not None and existing.state in ("queued", "running"):
+            skipped.append({"model_id": model_id, "id": existing.job_id, "state": existing.state})
+            continue
+        try:
+            hf_repo, hf_file, mmproj_file, _ = _resolve_pull_source_with_body(
+                request, model_id, None
+            )
+        except Hal0Error:
+            # A row that reported stale but whose source no longer resolves
+            # (coords cleared between the check and the kick) — skip, don't 500.
+            skipped.append({"model_id": model_id, "state": "unresolved"})
+            continue
+        capability, comfyui_subdir = _resolve_pull_capability(request, model_id, None)
+        job = await _spawn_hf_pull(
+            request,
+            background,
+            jobs,
+            model_id=model_id,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
+            mmproj_file=mmproj_file,
+        )
+        started.append({"model_id": model_id, "id": job.job_id, "state": job.state})
+
+    async with record_action(
+        request,
+        category="model",
+        action="model.update_all",
+        target=None,
+        message=f"{len(started)} started, {len(skipped)} skipped",
+    ):
+        pass
+    return {"started": started, "skipped": skipped, "count": len(started)}
+
+
 @router.get("/{model_id}")
 async def get_model(model_id: str, request: Request) -> dict[str, Any]:
     """Return a single model by id, preferring the local registry then
@@ -1745,35 +1859,17 @@ async def pull_model(
         if not isinstance(chat_template, str):
             chat_template = None
         _seed_registry_from_body(request, model_id, hf_repo, hf_file, labels, chat_template)
-    job = make_job(model_id)
-    jobs[model_id] = job
-    # Persist the queued snapshot before returning so a status poll resolves
-    # even if the daemon restarts before the background task runs (#626).
-    _persist_pull_job(job)
 
-    event_bus = getattr(request.app.state, "events", None)
-    if event_bus is not None:
-        await event_bus.emit(
-            "pull.queued",
-            "info",
-            f"pull:{model_id}",
-            f"{model_id}: queued ({hf_repo}/{hf_file})",
-            data={"model_id": model_id, "hf_repo": hf_repo, "hf_file": hf_file},
-        )
-
-    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    registry = request.app.state.model_registry
     # P3: route the download into the capability-grouped store layout when the
     # capability is resolvable (body → registry → curated); None → flat fallback.
     capability, comfyui_subdir = _resolve_pull_capability(request, model_id, body)
-    background.add_task(
-        _run_pull_with_events,
-        job,
+    job = await _spawn_hf_pull(
+        request,
+        background,
+        jobs,
+        model_id=model_id,
         hf_repo=hf_repo,
         hf_file=hf_file,
-        registry=registry,
-        hf_token=hf_token,
-        event_bus=event_bus,
         capability=capability,
         comfyui_subdir=comfyui_subdir,
         mmproj_file=mmproj_file,
@@ -1788,6 +1884,58 @@ async def pull_model(
     if mmproj_file:
         out["mmproj_file"] = mmproj_file
     return out
+
+
+async def _spawn_hf_pull(
+    request: Request,
+    background: BackgroundTasks,
+    jobs: dict[str, PullJob],
+    *,
+    model_id: str,
+    hf_repo: str,
+    hf_file: str,
+    capability: str | None,
+    comfyui_subdir: str | None,
+    mmproj_file: str | None,
+) -> PullJob:
+    """Queue a background HF pull for ``model_id`` and return the job record.
+
+    Owns the shared plumbing every HF-pull entrypoint needs: make the job,
+    register it on ``app.state.model_pull_jobs``, persist the queued snapshot
+    (so a status poll resolves across a restart, #626), emit the ``pull.queued``
+    footer event, and schedule the streaming background task. Both the
+    per-model pull route and the batch ``update-all`` route go through here so
+    they stay in lockstep.
+    """
+    job = make_job(model_id)
+    jobs[model_id] = job
+    _persist_pull_job(job)
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "pull.queued",
+            "info",
+            f"pull:{model_id}",
+            f"{model_id}: queued ({hf_repo}/{hf_file})",
+            data={"model_id": model_id, "hf_repo": hf_repo, "hf_file": hf_file},
+        )
+
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    registry = request.app.state.model_registry
+    background.add_task(
+        _run_pull_with_events,
+        job,
+        hf_repo=hf_repo,
+        hf_file=hf_file,
+        registry=registry,
+        hf_token=hf_token,
+        event_bus=event_bus,
+        capability=capability,
+        comfyui_subdir=comfyui_subdir,
+        mmproj_file=mmproj_file,
+    )
+    return job
 
 
 async def _start_flm_pull(

--- a/src/hal0/registry/updates.py
+++ b/src/hal0/registry/updates.py
@@ -1,0 +1,290 @@
+"""HuggingFace model update detection.
+
+An installed HF model is "stale" when the repo's ``main`` branch now serves
+a *different* file than the one on disk. We detect that by comparing the
+content SHA-256 we captured at pull time (``Model.metadata["sha256"]`` — the
+streamed digest, which for an LFS-backed file equals HF's advertised LFS
+``oid``) against the repo's *current* ``main`` LFS ``oid`` for the same
+filename.
+
+Only LFS-backed files carry an ``oid`` we can compare, and only rows that
+recorded a ``sha256`` at pull time have a local anchor. When either side is
+missing we report ``update_available=False`` rather than guess — the dashboard
+must never nag about a model whose freshness it can't actually verify.
+
+The check is a read-only HF metadata fetch (``/api/models/<repo>/tree/main``),
+the same endpoint :mod:`hal0.api.routes.models` already uses for inspect. We
+do NOT add a ``huggingface_hub`` dependency (see routes/hf.py for the
+rationale). Results are cached per repo with a short TTL so the dashboard can
+poll the ``/api/models/updates`` surface without hammering HF.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+# ── Tunables ─────────────────────────────────────────────────────────────────
+
+# Per-repo tree cache TTL. A freshly-uploaded quant surfaces within this
+# window; between polls the dashboard re-reads the cached verdict for free.
+_TREE_CACHE_TTL_S: float = 600.0  # 10 minutes
+
+_TREE_FETCH_TIMEOUT_S: float = 8.0
+
+# Bound the concurrent HF fanout when checking a whole registry so a large
+# catalog doesn't open dozens of sockets at once.
+_MAX_CONCURRENCY: int = 6
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+# repo → (fetched_at, {repo_relative_path: lfs_oid_hex})
+_TREE_CACHE: dict[str, tuple[float, dict[str, str]]] = {}
+
+
+# ── SHA / oid helpers ────────────────────────────────────────────────────────
+
+
+def _normalise_oid(raw: Any) -> str | None:
+    """Return a lowercase 64-hex sha256, or None if ``raw`` isn't one.
+
+    HF's tree API reports the LFS object hash as ``lfs.oid``; it is usually
+    bare 64-hex but is occasionally prefixed (``sha256:<hex>``). Our stored
+    ``metadata.sha256`` is always bare hex. Normalise both through here so the
+    comparison is apples-to-apples.
+    """
+    if not isinstance(raw, str):
+        return None
+    val = raw.strip().lower()
+    if val.startswith("sha256:"):
+        val = val[len("sha256:") :]
+    return val if _SHA256_HEX_RE.match(val) else None
+
+
+def _stored_sha256(model: Any) -> str | None:
+    """Extract the pull-time content sha256 from a registry model, or None."""
+    meta = getattr(model, "metadata", None)
+    if not isinstance(meta, dict):
+        return None
+    return _normalise_oid(meta.get("sha256"))
+
+
+# ── HF tree fetch ────────────────────────────────────────────────────────────
+
+
+async def _fetch_repo_oids(
+    repo: str,
+    *,
+    client: httpx.AsyncClient,
+    hf_token: str | None,
+    force: bool = False,
+) -> dict[str, str] | None:
+    """Return ``{repo_relative_path: lfs_oid_hex}`` for ``repo``'s main branch.
+
+    Returns ``None`` on any failure (unreachable, 4xx/5xx, bad JSON) so a
+    single flaky repo degrades to "unknown" rather than failing the whole
+    batch. Cached per repo for :data:`_TREE_CACHE_TTL_S`; ``force`` bypasses
+    the cache to re-probe.
+    """
+    now = time.monotonic()
+    if not force:
+        cached = _TREE_CACHE.get(repo)
+        if cached is not None and (now - cached[0]) < _TREE_CACHE_TTL_S:
+            return cached[1]
+
+    headers = {"Accept": "application/json"}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    url = f"https://huggingface.co/api/models/{repo}/tree/main"
+
+    try:
+        resp = await client.get(url, headers=headers)
+    except (httpx.TimeoutException, httpx.HTTPError) as exc:
+        log.warning("model.update_tree_unreachable repo=%s error=%s", repo, exc)
+        return None
+    if resp.status_code >= 400:
+        log.warning("model.update_tree_upstream_error repo=%s status=%s", repo, resp.status_code)
+        return None
+    try:
+        payload = resp.json()
+    except ValueError:
+        log.warning("model.update_tree_bad_json repo=%s", repo)
+        return None
+    if not isinstance(payload, list):
+        return None
+
+    oids: dict[str, str] = {}
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        rel = entry.get("path") or entry.get("rfilename")
+        if not isinstance(rel, str) or not rel:
+            continue
+        lfs = entry.get("lfs")
+        if not isinstance(lfs, dict):
+            continue
+        oid = _normalise_oid(lfs.get("oid"))
+        if oid is not None:
+            oids[rel] = oid
+
+    _TREE_CACHE[repo] = (now, oids)
+    return oids
+
+
+# ── Result record ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModelUpdateInfo:
+    """Per-model freshness verdict for the ``/api/models/updates`` surface."""
+
+    model_id: str
+    hf_repo: str
+    hf_filename: str
+    update_available: bool
+    current_sha: str | None = None
+    remote_sha: str | None = None
+    # Why an install could NOT be checked (no stored sha, non-LFS remote,
+    # repo unreachable). None on a clean checked verdict. Purely diagnostic —
+    # the dashboard keys its indicator off ``update_available`` alone.
+    reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "hf_repo": self.hf_repo,
+            "hf_filename": self.hf_filename,
+            "update_available": self.update_available,
+            "current_sha": self.current_sha,
+            "remote_sha": self.remote_sha,
+            "reason": self.reason,
+        }
+
+
+def _remote_oid_for_file(oids: dict[str, str], hf_filename: str) -> str | None:
+    """Resolve the remote LFS oid for ``hf_filename`` within a repo tree.
+
+    Prefers an exact repo-relative-path match; falls back to a basename match
+    so a stored coordinate that dropped a subdir prefix still resolves.
+    """
+    exact = oids.get(hf_filename)
+    if exact is not None:
+        return exact
+    base = hf_filename.rsplit("/", 1)[-1]
+    for rel, oid in oids.items():
+        if rel.rsplit("/", 1)[-1] == base:
+            return oid
+    return None
+
+
+async def _check_one(
+    model: Any,
+    *,
+    client: httpx.AsyncClient,
+    hf_token: str | None,
+    force: bool,
+) -> ModelUpdateInfo:
+    """Compute the freshness verdict for a single installed HF model."""
+    model_id = getattr(model, "id", "")
+    hf_repo = (getattr(model, "hf_repo", "") or "").strip()
+    hf_filename = (getattr(model, "hf_filename", "") or "").strip()
+    current = _stored_sha256(model)
+
+    info = ModelUpdateInfo(
+        model_id=model_id,
+        hf_repo=hf_repo,
+        hf_filename=hf_filename,
+        update_available=False,
+        current_sha=current,
+    )
+    if current is None:
+        info.reason = "no_local_sha"
+        return info
+
+    oids = await _fetch_repo_oids(hf_repo, client=client, hf_token=hf_token, force=force)
+    if oids is None:
+        info.reason = "repo_unreachable"
+        return info
+    remote = _remote_oid_for_file(oids, hf_filename)
+    if remote is None:
+        # File isn't LFS-backed on main (no oid) or was renamed/removed —
+        # nothing we can compare against, so don't claim staleness.
+        info.reason = "no_remote_sha"
+        return info
+
+    info.remote_sha = remote
+    info.update_available = remote != current
+    return info
+
+
+def is_checkable(model: Any) -> bool:
+    """True when ``model`` is an installed HF pull we can update-check.
+
+    Requires both HF coordinates (repo + filename) and a pull-time sha to
+    anchor the comparison. FLM/NPU rows (no hf_repo) and hand-registered rows
+    without a sha are skipped.
+    """
+    if not (getattr(model, "hf_repo", "") or "").strip():
+        return False
+    if not (getattr(model, "hf_filename", "") or "").strip():
+        return False
+    return _stored_sha256(model) is not None
+
+
+async def check_updates(
+    models: list[Any],
+    *,
+    force: bool = False,
+    client: httpx.AsyncClient | None = None,
+) -> list[ModelUpdateInfo]:
+    """Check a list of registry models for available HF updates.
+
+    Only rows passing :func:`is_checkable` are probed; everything else is
+    omitted from the result. Fetches run concurrently (bounded by
+    :data:`_MAX_CONCURRENCY`) and share the per-repo tree cache, so N models
+    from the same repo cost one HF call.
+    """
+    checkable = [m for m in models if is_checkable(m)]
+    if not checkable:
+        return []
+
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(_TREE_FETCH_TIMEOUT_S),
+            follow_redirects=True,
+        )
+    sem = asyncio.Semaphore(_MAX_CONCURRENCY)
+
+    async def _guarded(model: Any) -> ModelUpdateInfo:
+        async with sem:
+            return await _check_one(model, client=client, hf_token=hf_token, force=force)
+
+    try:
+        return await asyncio.gather(*(_guarded(m) for m in checkable))
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+def clear_cache() -> None:
+    """Drop the per-repo tree cache (test hook / forced global refresh)."""
+    _TREE_CACHE.clear()
+
+
+__all__ = [
+    "ModelUpdateInfo",
+    "check_updates",
+    "clear_cache",
+    "is_checkable",
+]

--- a/tests/api/test_model_updates_routes.py
+++ b/tests/api/test_model_updates_routes.py
@@ -75,7 +75,9 @@ def _register(app: FastAPI, model_id: str, *, sha: str = SHA_OLD) -> None:
 def _patch_check(monkeypatch: pytest.MonkeyPatch, infos: list[ModelUpdateInfo]) -> dict[str, Any]:
     seen: dict[str, Any] = {"force": None, "calls": 0}
 
-    async def fake_check(models: list[Any], *, force: bool = False, client: Any = None) -> list[ModelUpdateInfo]:
+    async def fake_check(
+        models: list[Any], *, force: bool = False, client: Any = None
+    ) -> list[ModelUpdateInfo]:
         seen["force"] = force
         seen["calls"] += 1
         return infos

--- a/tests/api/test_model_updates_routes.py
+++ b/tests/api/test_model_updates_routes.py
@@ -1,0 +1,229 @@
+"""Route tests for the HF model-update surface.
+
+Covers:
+  * GET  /api/models/updates          — report available updates
+  * POST /api/models/updates/check    — force-refresh variant
+  * POST /api/models/update-all       — re-pull every stale model
+
+The real HF probe (``check_updates``) and the streaming ``run_pull`` are
+patched so tests exercise routing + orchestration, not the network.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.registry import pull as pull_module
+from hal0.registry import updates as upd_module
+from hal0.registry.model import Model
+from hal0.registry.pull import PullJob
+from hal0.registry.updates import ModelUpdateInfo
+
+SHA_OLD = "a" * 64
+SHA_NEW = "b" * 64
+
+
+@pytest.fixture
+def app_isolated(tmp_hal0_home: str) -> Iterator[FastAPI]:
+    yield create_app()
+
+
+@pytest.fixture
+def client_isolated(app_isolated: FastAPI) -> Iterator[TestClient]:
+    with TestClient(app_isolated) as c:
+        yield c
+
+
+@pytest.fixture
+def fake_run_pull(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def fake(job: PullJob, *, hf_repo: str, hf_file: str, **kw: Any) -> None:
+        calls.append({"job": job, "hf_repo": hf_repo, "hf_file": hf_file, **kw})
+        job.state = "completed"
+        job.finished_at = time.time()
+        job._signal()
+
+    monkeypatch.setattr(pull_module, "run_pull", fake)
+    from hal0.api.routes import models as model_routes
+
+    monkeypatch.setattr(model_routes, "run_pull", fake)
+    return calls
+
+
+def _register(app: FastAPI, model_id: str, *, sha: str = SHA_OLD) -> None:
+    app.state.model_registry.add(
+        Model(
+            id=model_id,
+            name=model_id,
+            path=f"/var/lib/hal0/models/{model_id}/m.gguf",
+            hf_repo="org/repo",
+            hf_filename="m.gguf",
+            capabilities=["chat"],
+            metadata={"sha256": sha},
+        )
+    )
+
+
+def _patch_check(monkeypatch: pytest.MonkeyPatch, infos: list[ModelUpdateInfo]) -> dict[str, Any]:
+    seen: dict[str, Any] = {"force": None, "calls": 0}
+
+    async def fake_check(models: list[Any], *, force: bool = False, client: Any = None) -> list[ModelUpdateInfo]:
+        seen["force"] = force
+        seen["calls"] += 1
+        return infos
+
+    monkeypatch.setattr(upd_module, "check_updates", fake_check)
+    return seen
+
+
+# ── GET /api/models/updates ─────────────────────────────────────────────────
+
+
+def test_list_updates_reports_available_count(
+    client_isolated: TestClient, app_isolated: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(app_isolated, "qwen")
+    seen = _patch_check(
+        monkeypatch,
+        [
+            ModelUpdateInfo(
+                model_id="qwen",
+                hf_repo="org/repo",
+                hf_filename="m.gguf",
+                update_available=True,
+                current_sha=SHA_OLD,
+                remote_sha=SHA_NEW,
+            )
+        ],
+    )
+    r = client_isolated.get("/api/models/updates")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 1
+    assert body["available"] == 1
+    assert body["updates"][0]["model_id"] == "qwen"
+    assert body["updates"][0]["update_available"] is True
+    assert seen["force"] is False
+
+
+def test_list_updates_does_not_collide_with_model_id_route(
+    client_isolated: TestClient, app_isolated: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression guard: "/updates" must resolve to the report route, not
+    # GET /{model_id} with model_id="updates".
+    _patch_check(monkeypatch, [])
+    r = client_isolated.get("/api/models/updates")
+    assert r.status_code == 200
+    assert "updates" in r.json()
+
+
+# ── POST /api/models/updates/check ──────────────────────────────────────────
+
+
+def test_check_forces_refresh(
+    client_isolated: TestClient, app_isolated: FastAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen = _patch_check(monkeypatch, [])
+    r = client_isolated.post("/api/models/updates/check")
+    assert r.status_code == 200, r.text
+    assert seen["force"] is True
+
+
+# ── POST /api/models/update-all ─────────────────────────────────────────────
+
+
+def test_update_all_kicks_pull_for_stale_models(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _register(app_isolated, "qwen")
+    _patch_check(
+        monkeypatch,
+        [
+            ModelUpdateInfo(
+                model_id="qwen",
+                hf_repo="org/repo",
+                hf_filename="m.gguf",
+                update_available=True,
+                current_sha=SHA_OLD,
+                remote_sha=SHA_NEW,
+            )
+        ],
+    )
+    r = client_isolated.post("/api/models/update-all")
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["count"] == 1
+    assert body["started"][0]["model_id"] == "qwen"
+    # The pull background task actually ran against the resolved coords.
+    assert len(fake_run_pull) == 1
+    assert fake_run_pull[0]["hf_repo"] == "org/repo"
+    assert fake_run_pull[0]["hf_file"] == "m.gguf"
+
+
+def test_update_all_skips_when_nothing_stale(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _register(app_isolated, "qwen")
+    _patch_check(
+        monkeypatch,
+        [
+            ModelUpdateInfo(
+                model_id="qwen",
+                hf_repo="org/repo",
+                hf_filename="m.gguf",
+                update_available=False,
+                current_sha=SHA_OLD,
+                remote_sha=SHA_OLD,
+            )
+        ],
+    )
+    r = client_isolated.post("/api/models/update-all")
+    assert r.status_code == 202, r.text
+    assert r.json()["count"] == 0
+    assert fake_run_pull == []
+
+
+def test_update_all_skips_model_already_pulling(
+    client_isolated: TestClient,
+    app_isolated: FastAPI,
+    fake_run_pull: list[dict[str, Any]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _register(app_isolated, "qwen")
+    # Seed an in-flight job so update-all defers to it instead of duplicating.
+    running = PullJob(job_id="existing", model_id="qwen", state="running")
+    app_isolated.state.model_pull_jobs["qwen"] = running
+    _patch_check(
+        monkeypatch,
+        [
+            ModelUpdateInfo(
+                model_id="qwen",
+                hf_repo="org/repo",
+                hf_filename="m.gguf",
+                update_available=True,
+                current_sha=SHA_OLD,
+                remote_sha=SHA_NEW,
+            )
+        ],
+    )
+    r = client_isolated.post("/api/models/update-all")
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["count"] == 0
+    assert body["skipped"][0]["model_id"] == "qwen"
+    assert body["skipped"][0]["state"] == "running"
+    assert fake_run_pull == []

--- a/tests/registry/test_updates.py
+++ b/tests/registry/test_updates.py
@@ -19,7 +19,9 @@ SHA_A = "a" * 64
 SHA_B = "b" * 64
 
 
-def _model(model_id: str, *, sha: str | None, repo: str = "org/repo", filename: str = "m.gguf") -> Model:
+def _model(
+    model_id: str, *, sha: str | None, repo: str = "org/repo", filename: str = "m.gguf"
+) -> Model:
     meta: dict[str, Any] = {}
     if sha is not None:
         meta["sha256"] = sha
@@ -153,5 +155,7 @@ async def test_shared_repo_fetched_once(monkeypatch: pytest.MonkeyPatch) -> None
 def test_is_checkable_gates_on_coords_and_sha() -> None:
     assert upd.is_checkable(_model("ok", sha=SHA_A)) is True
     assert upd.is_checkable(_model("no-sha", sha=None)) is False
-    flm = Model(id="flm", name="flm", path="/x", hf_repo="", hf_filename="", metadata={"sha256": SHA_A})
+    flm = Model(
+        id="flm", name="flm", path="/x", hf_repo="", hf_filename="", metadata={"sha256": SHA_A}
+    )
     assert upd.is_checkable(flm) is False

--- a/tests/registry/test_updates.py
+++ b/tests/registry/test_updates.py
@@ -1,0 +1,157 @@
+"""Tests for HF model update detection (hal0.registry.updates).
+
+Uses ``httpx.MockTransport`` to stub HuggingFace's ``/tree/main`` so the
+sha-vs-oid comparison runs without touching the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.registry import updates as upd
+from hal0.registry.model import Model
+
+# A canonical 64-hex sha256 and a differing one.
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+def _model(model_id: str, *, sha: str | None, repo: str = "org/repo", filename: str = "m.gguf") -> Model:
+    meta: dict[str, Any] = {}
+    if sha is not None:
+        meta["sha256"] = sha
+    return Model(
+        id=model_id,
+        name=model_id,
+        path=f"/var/lib/hal0/models/{model_id}/{filename}",
+        hf_repo=repo,
+        hf_filename=filename,
+        metadata=meta,
+    )
+
+
+def _tree_transport(oid_by_path: dict[str, str | None]) -> httpx.MockTransport:
+    """Return a transport whose ``/tree/main`` serves the given LFS oids.
+
+    A ``None`` oid emits a non-LFS entry (no ``lfs`` block) so the "no remote
+    sha" path is exercised.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/tree/main")
+        entries = []
+        for path, oid in oid_by_path.items():
+            entry: dict[str, Any] = {"type": "file", "path": path, "size": 100}
+            if oid is not None:
+                entry["lfs"] = {"oid": oid, "size": 100}
+            entries.append(entry)
+        return httpx.Response(200, json=entries)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> Any:
+    upd.clear_cache()
+    yield
+    upd.clear_cache()
+
+
+@pytest.mark.asyncio
+async def test_update_available_when_remote_oid_differs() -> None:
+    client = httpx.AsyncClient(transport=_tree_transport({"m.gguf": SHA_B}))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.update_available is True
+    assert info.current_sha == SHA_A
+    assert info.remote_sha == SHA_B
+
+
+@pytest.mark.asyncio
+async def test_no_update_when_oid_matches() -> None:
+    client = httpx.AsyncClient(transport=_tree_transport({"m.gguf": SHA_A}))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert infos[0].update_available is False
+    assert infos[0].reason is None
+
+
+@pytest.mark.asyncio
+async def test_oid_prefixed_form_normalises() -> None:
+    # HF sometimes reports "sha256:<hex>" — must compare equal to bare hex.
+    client = httpx.AsyncClient(transport=_tree_transport({"m.gguf": f"sha256:{SHA_A}"}))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert infos[0].update_available is False
+
+
+@pytest.mark.asyncio
+async def test_row_without_stored_sha_is_skipped() -> None:
+    # is_checkable rejects a row with no metadata.sha256 → omitted entirely.
+    client = httpx.AsyncClient(transport=_tree_transport({"m.gguf": SHA_B}))
+    infos = await upd.check_updates([_model("qwen", sha=None)], client=client)
+    await client.aclose()
+    assert infos == []
+
+
+@pytest.mark.asyncio
+async def test_non_lfs_remote_reports_no_remote_sha() -> None:
+    client = httpx.AsyncClient(transport=_tree_transport({"m.gguf": None}))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert infos[0].update_available is False
+    assert infos[0].reason == "no_remote_sha"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_repo_degrades_to_unknown() -> None:
+    def boom(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(boom))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert infos[0].update_available is False
+    assert infos[0].reason == "repo_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_basename_fallback_matches_subdir_filename() -> None:
+    # Stored coord is a bare basename; remote path carries a subdir prefix.
+    client = httpx.AsyncClient(transport=_tree_transport({"gguf/m.gguf": SHA_B}))
+    infos = await upd.check_updates([_model("qwen", sha=SHA_A)], client=client)
+    await client.aclose()
+    assert infos[0].update_available is True
+    assert infos[0].remote_sha == SHA_B
+
+
+@pytest.mark.asyncio
+async def test_shared_repo_fetched_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(200, json=[{"type": "file", "path": "m.gguf", "lfs": {"oid": SHA_B}}])
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    infos = await upd.check_updates(
+        [_model("a", sha=SHA_A), _model("b", sha=SHA_A)],
+        client=client,
+    )
+    await client.aclose()
+    assert len(infos) == 2
+    assert all(i.update_available for i in infos)
+    # Two models, one repo → a single tree fetch thanks to the per-repo cache.
+    assert calls["n"] == 1
+
+
+def test_is_checkable_gates_on_coords_and_sha() -> None:
+    assert upd.is_checkable(_model("ok", sha=SHA_A)) is True
+    assert upd.is_checkable(_model("no-sha", sha=None)) is False
+    flm = Model(id="flm", name="flm", path="/x", hf_repo="", hf_filename="", metadata={"sha256": SHA_A})
+    assert upd.is_checkable(flm) is False

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -59,6 +59,11 @@ export const ENDPOINTS = {
   modelPulls: '/api/models/pulls',
   modelPullDelete: (id: string) => `/api/models/pulls/${encodeURIComponent(id)}`,
   modelInspect: '/api/models/inspect',
+  // HF model-update detection: report stale installed models (current sha vs
+  // repo main LFS oid), force-refresh, and re-pull every stale model.
+  modelUpdates: '/api/models/updates',
+  modelUpdatesCheck: '/api/models/updates/check',
+  modelUpdateAll: '/api/models/update-all',
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',
   modelAddFromPath: '/api/models/add-from-path',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -195,6 +195,85 @@ export function useModelUpdate() {
   })
 }
 
+// ─── Model updates (HF sha vs repo main) ────────────────────────────
+//
+// A separate, slower-polled surface from useModels(): the /api/models list
+// stays a cheap disk read, while freshness needs a per-repo HF probe. The
+// dashboard fetches this report and joins it onto rows by model_id so a
+// stale model shows an "update" indicator and the "Update all" button knows
+// how many pulls to kick.
+
+export interface ModelUpdateInfo {
+  model_id: string
+  hf_repo: string
+  hf_filename: string
+  update_available: boolean
+  current_sha: string | null
+  remote_sha: string | null
+  reason: string | null
+}
+
+export interface ModelUpdatesResponse {
+  updates: ModelUpdateInfo[]
+  count: number
+  available: number
+}
+
+const MODEL_UPDATES_POLL_MS = 5 * 60_000 // 5 min — matches the backend tree cache TTL
+
+export function useModelUpdates({ enabled = true }: { enabled?: boolean } = {}) {
+  const query = useQuery<ModelUpdatesResponse>({
+    queryKey: ['model-updates'],
+    queryFn: () => apiGet<ModelUpdatesResponse>(ENDPOINTS.modelUpdates),
+    enabled,
+    refetchInterval: enabled ? MODEL_UPDATES_POLL_MS : false,
+    // A soft failure (HF down) should keep the last verdict rather than
+    // flash the indicator off — react-query keeps previous data by default.
+    staleTime: MODEL_UPDATES_POLL_MS,
+  })
+  const updates = query.data?.updates ?? []
+  // Set of model ids with an available update — cheap membership test for rows.
+  const staleIds = new Set(updates.filter(u => u.update_available).map(u => u.model_id))
+  return { ...query, updates, staleIds, available: query.data?.available ?? 0 }
+}
+
+// Force a fresh HF probe (cache bypass), then re-pull every stale model.
+export function useCheckModelUpdates() {
+  const qc = useQueryClient()
+  return useMutation<ModelUpdatesResponse, Hal0Error, void>({
+    mutationFn: () => apiPost<ModelUpdatesResponse>(ENDPOINTS.modelUpdatesCheck, {}),
+    onSuccess: (data) => {
+      // Seed the query cache with the fresh verdict so the indicator updates
+      // immediately, then invalidate to resume the normal poll cadence.
+      qc.setQueryData(['model-updates'], data)
+      qc.invalidateQueries({ queryKey: ['model-updates'] })
+    },
+  })
+}
+
+export interface UpdateAllResponse {
+  started: Array<{ model_id: string; id: string; state: string }>
+  skipped: Array<{ model_id: string; id?: string; state: string }>
+  count: number
+}
+
+export function useUpdateAllModels() {
+  const qc = useQueryClient()
+  return useMutation<UpdateAllResponse, Hal0Error, void>({
+    mutationFn: () => apiPost<UpdateAllResponse>(ENDPOINTS.modelUpdateAll, {}),
+    onSuccess: () => {
+      // Pulls started — refresh the downloads pane + models list, and let the
+      // update report re-probe once the re-pulls complete.
+      qc.invalidateQueries({ queryKey: ['pulls'] })
+      qc.invalidateQueries({ queryKey: ['models'] })
+      qc.invalidateQueries({ queryKey: ['model-updates'] })
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: { modelId: null } }))
+      }
+    },
+  })
+}
+
 // ─── usePullJob ─────────────────────────────────────────────────────
 
 export type PullState =

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, useModelUpdates, useUpdateAllModels, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
@@ -178,6 +178,28 @@ function ModelsView() {
 
   const pullsList = usePullsList();
 
+  // ── HF model updates (freshness vs repo main) ───────────────────────
+  const modelUpdates = useModelUpdates();
+  const staleIds = modelUpdates.staleIds;
+  const updatesAvailable = modelUpdates.available;
+  const updateAll = useUpdateAllModels();
+
+  const onUpdateAll = async () => {
+    try {
+      const res = await updateAll.mutateAsync();
+      window.__hal0Toast && window.__hal0Toast(
+        res.count > 0
+          ? `Updating ${res.count} model${res.count === 1 ? "" : "s"} from HuggingFace…`
+          : "No updates to apply — models are up to date.",
+        res.count > 0 ? "info" : "success",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Update all failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
+
   // ── Render ──────────────────────────────────────────────────────────
   const tabLabel = tab === "inference" ? `Inference Models${inferenceRows.length ? ` · ${inferenceRows.length}` : ""}`
     : tab === "upstream" ? `Upstream Models${upstreamTotal ? ` · ${upstreamTotal}` : ""}`
@@ -189,6 +211,17 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
+        {updatesAvailable > 0 && (
+          <button
+            className="btn mdl-update-all"
+            data-testid="mdl-update-all"
+            disabled={updateAll.isPending}
+            onClick={onUpdateAll}
+            title={`${updatesAvailable} model${updatesAvailable === 1 ? "" : "s"} have a newer file on HuggingFace`}
+          >
+            {Icons.restart} {updateAll.isPending ? "Updating…" : `Update all · ${updatesAvailable}`}
+          </button>
+        )}
         <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
         <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
@@ -301,16 +334,16 @@ function ModelsView() {
             sectionedInference.map(item =>
               item.type === "label"
                 ? <div key={item.key} className="mdl-section-label">{item.text}</div>
-                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
+                : <ModelRow key={item.model.id} model={item.model} updateAvailable={staleIds.has(item.model.id)} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
             )
           ) : tab === "image" ? (
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} updateAvailable={staleIds.has(m.id)} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
             ))
           ) : (
             /* upstream tab — flat paginated rows */
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} updateAvailable={staleIds.has(m.id)} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
             ))
           )}
 
@@ -433,7 +466,7 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
 }
 
 // ── ModelRow ──────────────────────────────────────────────────────────
-function ModelRow({ model, selected, onSelect }) {
+function ModelRow({ model, selected, onSelect, updateAvailable }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
@@ -447,6 +480,13 @@ function ModelRow({ model, selected, onSelect }) {
         <span className="sub">{model.repo || ""}</span>
       </span>
       <span className="mdl-row-tags">
+        {updateAvailable && (
+          <span
+            className="chip mdl-update-chip"
+            data-testid="mdl-row-update"
+            title="A newer file is available on this model's HuggingFace repo"
+          >{Icons.restart} update</span>
+        )}
         {model.type && <span className="chip">{model.type}</span>}
         {model.quant && <span className="chip quant" data-testid="mdl-row-quant">{model.quant}</span>}
         {backends.map(b => (

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2024,6 +2024,29 @@ select.npu-sel {
 .mdl-row .nm .sub { color: var(--fg-4); font-weight: 400; font-size: 10.5px; display: block; margin-top: 2px; overflow: hidden; text-overflow: ellipsis; }
 .mdl-row-tags { display: flex; flex-wrap: nowrap; gap: 4px; justify-content: flex-end; overflow: hidden; }
 .mdl-row-tags .chip { text-transform: lowercase; }
+
+/* "update available" — a newer file exists on the model's HF repo. Warm
+   accent so it reads as an actionable nudge, not an error. */
+.chip.mdl-update-chip {
+  background: color-mix(in srgb, var(--warming, #f2792b) 16%, transparent);
+  color: var(--warming, #f2792b);
+  border-color: color-mix(in srgb, var(--warming, #f2792b) 40%, transparent);
+  display: inline-flex; align-items: center; gap: 3px; white-space: nowrap;
+}
+.chip.mdl-update-chip svg { width: 10px; height: 10px; }
+
+/* Top-of-page "Update all" — same warm accent as the per-row chip so the
+   two read as one feature. */
+.btn.mdl-update-all {
+  background: color-mix(in srgb, var(--warming, #f2792b) 16%, transparent);
+  color: var(--warming, #f2792b);
+  border-color: color-mix(in srgb, var(--warming, #f2792b) 40%, transparent);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.btn.mdl-update-all:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--warming, #f2792b) 26%, transparent);
+}
+.btn.mdl-update-all svg { width: 12px; height: 12px; }
 .mdl-row .sz { color: var(--fg-3); text-align: right; font-size: 11px; }
 .mdl-row .tg { color: var(--fg-3); font-size: 10.5px; text-align: right; }
 .mdl-row-icon { width: 14px; display: flex; align-items: center; justify-content: center; font-size: 12px; }

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -89,6 +89,17 @@ export async function installDefaultMocks(page: Page, state: MockState) {
   await page.route('**/api/models', (route) =>
     json(route, { models: state.models, count: state.models.length }),
   )
+  // Pull-job list — returns a bare array (usePullsList calls .some on it, so a
+  // catch-all object would crash the Models view). Empty = no active pulls.
+  await page.route('**/api/models/pulls', (route) => json(route, []))
+  // Model-update report — default "nothing stale" so the Update-all button and
+  // per-row update chips stay hidden unless a spec overrides this route.
+  await page.route('**/api/models/updates', (route) =>
+    json(route, { updates: [], count: 0, available: 0 }),
+  )
+  await page.route('**/api/models/update-all', (route) =>
+    json(route, { started: [], skipped: [], count: 0 }),
+  )
   await page.route('**/api/slots', (route) => json(route, { slots: state.slots }))
   await page.route('**/api/slots/metrics', (route) => json(route, {}))
   await page.route('**/api/backends', (route) => json(route, { backends: state.backends }))

--- a/ui/tests/e2e/specs/model-updates-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-updates-v3.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * model-updates-v3 — HF model-update feature on the `#models` catalog.
+ *
+ * Backend surface: GET /api/models/updates reports which installed models
+ * have a newer file on their HuggingFace repo; POST /api/models/update-all
+ * re-pulls every stale one. The UI shows a per-row "update" chip and a
+ * top-of-page "Update all · N" button that appears only when something is
+ * stale.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+// An installed model id from the forced-mock HAL0_DATA catalog (src/dash/data.jsx)
+// that renders on the default Inference tab.
+const STALE_ID = 'qwen3.6-27b-mtp'
+
+async function mockUpdates(page: import('@playwright/test').Page, available: number) {
+  await page.route('**/api/models/updates', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        updates: [
+          {
+            model_id: STALE_ID,
+            hf_repo: 'unsloth/Qwen3.6-27B-A3B-MTP-GGUF',
+            hf_filename: 'Qwen3.6-27B-A3B-MTP-Q4_K_M.gguf',
+            update_available: available > 0,
+            current_sha: 'a'.repeat(64),
+            remote_sha: 'b'.repeat(64),
+            reason: null,
+          },
+        ],
+        count: 1,
+        available,
+      }),
+    }),
+  )
+}
+
+test.describe('Model updates (/models)', () => {
+  test('no update chip or Update-all button when everything is fresh', async ({ page }) => {
+    // Fixture default already returns available:0; assert the absence.
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-list')).toBeVisible()
+    await expect(page.locator('[data-testid="mdl-update-all"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="mdl-row-update"]')).toHaveCount(0)
+  })
+
+  test('stale model shows a row indicator and the Update-all button', async ({ page }) => {
+    await mockUpdates(page, 1)
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-list')).toBeVisible()
+    // Top button reflects the count.
+    const btn = page.locator('[data-testid="mdl-update-all"]')
+    await expect(btn).toBeVisible()
+    await expect(btn).toContainText('Update all · 1')
+    // Exactly the stale row carries the update chip.
+    await expect(page.locator('[data-testid="mdl-row-update"]')).toHaveCount(1)
+  })
+
+  test('Update-all button POSTs to /api/models/update-all', async ({ page }) => {
+    await mockUpdates(page, 1)
+    let posted = false
+    await page.route('**/api/models/update-all', (route) => {
+      posted = true
+      return route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          started: [{ model_id: STALE_ID, id: 'job1', state: 'queued' }],
+          skipped: [],
+          count: 1,
+        }),
+      })
+    })
+    await page.goto('/#models')
+    await page.locator('[data-testid="mdl-update-all"]').click()
+    await expect.poll(() => posted).toBe(true)
+  })
+})

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## What & why

Installed HF models can silently go stale when the source repo re-uploads a quant (same filename, new bytes). Today there's no signal and no easy refresh. This adds:

- an **"update available" indicator** on each stale model row, and
- a **"Update all · N"** top button that re-pulls every stale model in one click.

## How it works

The key realisation: the content SHA-256 we already capture at pull time (`Model.metadata["sha256"]`, the streamed digest) equals HuggingFace's advertised LFS `oid`. So "is this stale?" is just: **stored sha ≠ the repo's current `main` LFS oid** for that filename. No new dependency, no re-download to check — one metadata read against `/api/models/<repo>/tree/main` (the same endpoint inspect already uses).

## Backend (`src/hal0`)

- **`registry/updates.py`** (new): `check_updates()` compares each checkable installed model against its repo tree.
  - LFS-only + anchored-only: a row without a stored sha, or whose remote file isn't LFS-backed, reports `update_available=false` rather than guess — the dashboard never nags about a model it can't actually verify.
  - Per-repo tree cache (10-min TTL) so N models from one repo cost a single HF call; bounded concurrent fanout; every failure path degrades to "unknown", never 500s.
- **`api/routes/models.py`**:
  - `GET /api/models/updates` — freshness report (`?force=true` bypasses the cache).
  - `POST /api/models/updates/check` — force-refresh sibling.
  - `POST /api/models/update-all` — re-pull every stale model (skips any already mid-pull).
  - Extracted **`_spawn_hf_pull`** so the batch update and the single-model pull share identical job / persist / event / SSE-stream plumbing. New static-path routes are declared before `/{model_id}` so the matcher doesn't treat `updates` as a model id.

## Frontend (`ui`)

- **Hooks** (`useModels.ts`): `useModelUpdates` / `useCheckModelUpdates` / `useUpdateAllModels`, polled on a separate 5-min cadence so the main `/api/models` list stays a cheap disk read.
- **`models.jsx`**: `ModelRow` renders a warm `update` chip when stale; a `Update all · N` button appears in the page header only when something is stale, kicks the batch re-pull, and reuses the existing SSE + footer-event progress rails.
- Styling matches the existing pulling/warming accent convention.

## Tests

- `tests/registry/test_updates.py` — sha-vs-oid comparison, `sha256:` prefix normalisation, non-LFS / no-sha / unreachable degradation, per-repo fetch dedup.
- `tests/api/test_model_updates_routes.py` — report counts, `force` refresh, update-all kicks pulls / skips fresh / defers to in-flight jobs, and the `/updates` vs `/{model_id}` route-ordering guard.
- `ui/tests/e2e/specs/model-updates-v3.spec.ts` — indicator + button visibility and the update-all POST.
- Fixture fix: `apiMock` now mocks `/api/models/pulls` to return a list (the catch-all object was crashing `usePullsList`), which also repaired several pre-existing models-v3 e2e failures.

All backend (`ruff`, `mypy`, pytest) and UI (`tsc`, unit, models e2e) checks pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JUyAmsZs6eFRJNij7UBZx

---
_Generated by [Claude Code](https://claude.ai/code/session_018JUyAmsZs6eFRJNij7UBZx)_