### PR TITLE
feat(ui): notification bell in the topbar — attention items, downloads, updates, dev messages

### DIFF
--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -447,7 +447,9 @@ export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {
     refetchInterval: enabled ? 2_000 : false,
   })
 
-  const jobs = query.data ?? []
+  // Defensive: an unrouted mock (or an older backend) can answer `{}` —
+  // never let a non-array shape throw inside every subscriber's render.
+  const jobs = Array.isArray(query.data) ? query.data : []
   const hasActive = jobs.some((j: PullJob) => j.state === 'queued' || j.state === 'running')
 
   return { jobs, hasActive, ...query }

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -11,12 +11,12 @@ import { useModels, usePullsList, useClearPullJob, fmtSpeed, fmtEta } from '@/ap
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useMemoryEnabled } from '@/api/hooks/useMemory'
-import { useUpdateState } from '@/api/hooks/useUpdates'
+import { useUpdateState, useSlotDrift, useRestartDriftedSlots } from '@/api/hooks/useUpdates'
 import { useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 
-const { useState: useStateC, useEffect: useEffectC } = React;
+const { useState: useStateC, useEffect: useEffectC, useRef: useRefC } = React;
 
 // ─── Wordmark — inline SVG, "hal" in currentColor + amber "0" ───
 function Wordmark({ size = 16, mono = false }) {
@@ -140,6 +140,298 @@ const Icons = {
   bench:     <Icon><path d="M3 13V9l2.5-2.5M3 13l2.5-2.5M3 13h3M13 3v4l-2.5 2.5M13 3l-2.5 2.5M13 3h-3M8 8l-2 2"/><circle cx="4" cy="13" r="1.5"/><circle cx="8" cy="8" r="1.5"/><circle cx="12" cy="3" r="1.5"/></Icon>,
 };
 
+// ─── Notification center (topbar bell) ───
+// One aggregation point for everything that wants the operator's eye:
+//   - items needing attention (pending approvals + slots in error) — the same
+//     sources as the dashboard's Needs Attention card, so counts never drift;
+//   - model downloads (queued/running pulls, plus failed ones with retry);
+//   - updates (hal0 release available, post-update slot drift);
+//   - developer/system messages pushed via `window.hal0Notify({...})` or a
+//     `hal0:notify` CustomEvent (detail: {id?, title, body?, kind?, link?}).
+// The bell shows a live count badge; the panel groups rows by section. Rows
+// route to the surface that already owns the action (ApprovalModal, footer
+// downloads pane, Settings → Updates) instead of duplicating it.
+
+const NOTIF_LS_KEY = "hal0:notif-dismissed";
+function _notifLoadDismissed() {
+  try {
+    const v = JSON.parse(localStorage.getItem(NOTIF_LS_KEY) || "[]");
+    return Array.isArray(v) ? v : [];
+  } catch { return []; }
+}
+// Module-level store (not React state) so messages published before the bell
+// mounts — or while it's unmounted on a crashed view — are never lost.
+const _notifStore = {
+  msgs: [],
+  dismissed: new Set(_notifLoadDismissed()),
+  listeners: new Set(),
+};
+function _notifEmit() { _notifStore.listeners.forEach((l) => l()); }
+function hal0Notify(raw) {
+  const d = raw || {};
+  const title = String(d.title || d.msg || "").trim();
+  if (!title) return null;
+  const id = String(d.id || ("msg-" + Date.now().toString(36) + Math.random().toString(36).slice(2, 6)));
+  // A stable id makes a message dismissible forever (localStorage) — the
+  // channel for "developer important messages" that shouldn't re-nag.
+  if (_notifStore.dismissed.has(id)) return id;
+  if (_notifStore.msgs.some((m) => m.id === id)) return id;
+  _notifStore.msgs = [
+    ..._notifStore.msgs,
+    {
+      id,
+      title,
+      body: d.body ? String(d.body) : "",
+      kind: ["info", "warn", "error", "update"].includes(d.kind) ? d.kind : "info",
+      link: typeof d.link === "string" ? d.link : "",
+      ts: Date.now(),
+    },
+  ];
+  _notifEmit();
+  return id;
+}
+function _notifDismiss(id) {
+  _notifStore.msgs = _notifStore.msgs.filter((m) => m.id !== id);
+  _notifStore.dismissed.add(id);
+  try {
+    localStorage.setItem(NOTIF_LS_KEY, JSON.stringify([..._notifStore.dismissed].slice(-100)));
+  } catch { /* private mode — dismissal just won't persist */ }
+  _notifEmit();
+}
+if (typeof window !== "undefined") {
+  window.hal0Notify = hal0Notify;
+  window.addEventListener("hal0:notify", (e) => hal0Notify(e.detail));
+}
+
+const _NOTIF_KIND_HUE = {
+  info: "var(--info, var(--fg-3))",
+  warn: "var(--warn)",
+  error: "var(--err)",
+  update: "var(--accent)",
+};
+
+function NotificationBell() {
+  const [open, setOpen] = useStateC(false);
+  const [, bump] = useStateC(0);
+  useEffectC(() => {
+    const l = () => bump((t) => t + 1);
+    _notifStore.listeners.add(l);
+    return () => _notifStore.listeners.delete(l);
+  }, []);
+  const devMsgs = _notifStore.msgs;
+
+  // Attention sources — same rule as the dashboard's Needs Attention card.
+  const slots = useSlots().data ?? [];
+  const approvals = useApprovalList()?.data?.approvals ?? [];
+  const errorSlots = slots.filter((s) => s.state === "error" || s.container_status === "crashed");
+
+  // Downloads — the pulls list is a tiny local endpoint; the shared query key
+  // dedupes against the footer pane's copy when both are live.
+  const pulls = usePullsList({ enabled: true });
+  const jobs = Array.isArray(pulls.jobs) ? pulls.jobs : [];
+  const activePulls = jobs.filter((j) => j.state === "queued" || j.state === "running");
+  const failedPulls = jobs.filter((j) => j.state === "failed");
+  const clearJob = useClearPullJob();
+
+  // Updates — hal0 release channel + post-update slot drift (WS-J).
+  const updates = useUpdateState();
+  const hal0Ch = updates.data?.hal0;
+  const hasUpdate = !!(hal0Ch && hal0Ch.available && hal0Ch.available !== hal0Ch.current);
+  const drift = useSlotDrift();
+  const driftCount = drift.data?.count ?? 0;
+  const restartDrifted = useRestartDriftedSlots();
+
+  const count =
+    approvals.length + errorSlots.length +
+    activePulls.length + failedPulls.length +
+    (hasUpdate ? 1 : 0) + (driftCount > 0 ? 1 : 0) +
+    devMsgs.length;
+
+  // Close on outside click / Escape while open.
+  const popRef = useRefC(null);
+  useEffectC(() => {
+    if (!open) return;
+    const onDown = (e) => { if (popRef.current && !popRef.current.contains(e.target)) setOpen(false); };
+    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Any surface can pop the panel (command palette, banners, …).
+  useEffectC(() => {
+    const onOpen = () => setOpen(true);
+    window.addEventListener("hal0:open-notifications", onOpen);
+    return () => window.removeEventListener("hal0:open-notifications", onOpen);
+  }, []);
+
+  const go = (hash) => { setOpen(false); window.location.hash = hash; };
+  const sections = [];
+
+  if (approvals.length + errorSlots.length > 0) {
+    sections.push(
+      <div className="notif-sec" data-testid="notif-sec-attention" key="attention">
+        <div className="notif-sec-h mono">needs attention</div>
+        {approvals.map((a) => (
+          <div className="notif-row" key={"ap-" + a.id}>
+            <span className="notif-dot" style={{ background: "var(--warn)" }} />
+            <span className="notif-msg">
+              <b>{a.client_id || "hermes"}</b> wants <span className="mono">{a.tool}</span> — approval pending
+            </span>
+            <button
+              className="notif-act"
+              onClick={() => { setOpen(false); window.dispatchEvent(new CustomEvent("hal0:open-approvals")); }}
+            >Review</button>
+          </div>
+        ))}
+        {errorSlots.map((s) => (
+          <div className="notif-row" key={"slot-" + s.name}>
+            <span className="notif-dot" style={{ background: "var(--err)" }} />
+            <span className="notif-msg">
+              slot <b className="mono">{s.name}</b> failed — restart to recover
+            </span>
+            <button
+              className="notif-act"
+              onClick={() => window.dispatchEvent(new CustomEvent("hal0:slot-restart", { detail: { name: s.name } }))}
+            >Restart</button>
+            <button className="notif-act" onClick={() => go("#slots/" + s.name)}>View</button>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (activePulls.length + failedPulls.length > 0) {
+    sections.push(
+      <div className="notif-sec" data-testid="notif-sec-downloads" key="downloads">
+        <div className="notif-sec-h mono">downloads</div>
+        {activePulls.map((j) => {
+          const pct = j.bytes_total ? Math.round((j.bytes_downloaded / (j.bytes_total || 1)) * 100) : 0;
+          return (
+            <div className="notif-row" key={"dl-" + (j.job_id || j.model_id)}>
+              <span className="notif-dot pulse" style={{ background: "var(--accent)" }} />
+              <span className="notif-msg">
+                <span className="mono">{j.hf_repo || j.model_id}</span>
+                {j.state === "queued"
+                  ? " — queued"
+                  : <> — {pct}%{j.speed_bps > 0 && <> · {fmtSpeed(j.speed_bps)}</>}{j.eta_s > 0 && <> · {fmtEta(j.eta_s)} left</>}</>}
+              </span>
+              <button
+                className="notif-act"
+                onClick={() => apiPost(ENDPOINTS.modelPullCancel(j.model_id))}
+              >Cancel</button>
+            </div>
+          );
+        })}
+        {failedPulls.map((j) => (
+          <div className="notif-row" key={"dlf-" + (j.job_id || j.model_id)}>
+            <span className="notif-dot" style={{ background: "var(--err)" }} />
+            <span className="notif-msg">
+              <span className="mono">{j.hf_repo || j.model_id}</span> — download failed
+            </span>
+            <button className="notif-act" onClick={() => apiPost(ENDPOINTS.modelPull(j.model_id))}>Retry</button>
+            <button className="notif-act" onClick={() => clearJob.mutate(j.model_id)}>Clear</button>
+          </div>
+        ))}
+        <button
+          className="notif-link mono"
+          onClick={() => { setOpen(false); window.dispatchEvent(new CustomEvent("hal0:open-downloads")); }}
+        >Open downloads pane →</button>
+      </div>
+    );
+  }
+
+  if (hasUpdate || driftCount > 0) {
+    sections.push(
+      <div className="notif-sec" data-testid="notif-sec-updates" key="updates">
+        <div className="notif-sec-h mono">updates</div>
+        {hasUpdate && (
+          <div className="notif-row">
+            <span className="notif-dot" style={{ background: "var(--accent)" }} />
+            <span className="notif-msg">
+              hal0 <b className="mono">{hal0Ch.available}</b> available
+              {hal0Ch.current && <> (current {hal0Ch.current})</>}
+            </span>
+            <button className="notif-act" onClick={() => go("#settings/updates")}>Update</button>
+          </div>
+        )}
+        {driftCount > 0 && (
+          <div className="notif-row">
+            <span className="notif-dot" style={{ background: "var(--warn)" }} />
+            <span className="notif-msg">
+              {driftCount} slot{driftCount !== 1 ? "s" : ""} running a pre-update config — restart to apply
+            </span>
+            <button
+              className="notif-act"
+              disabled={restartDrifted.isPending}
+              onClick={() => restartDrifted.mutate(undefined)}
+            >{restartDrifted.isPending ? "Restarting…" : "Restart"}</button>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (devMsgs.length > 0) {
+    sections.push(
+      <div className="notif-sec" data-testid="notif-sec-messages" key="messages">
+        <div className="notif-sec-h mono">messages</div>
+        {devMsgs.map((m) => (
+          <div className="notif-row" key={m.id} data-testid="notif-msg">
+            <span className="notif-dot" style={{ background: _NOTIF_KIND_HUE[m.kind] }} />
+            <span className="notif-msg">
+              <b>{m.title}</b>
+              {m.body && <span className="notif-body">{m.body}</span>}
+            </span>
+            {m.link && (
+              <button className="notif-act" onClick={() => {
+                if (/^#/.test(m.link)) go(m.link);
+                else window.open(m.link, "_blank", "noopener");
+              }}>Open</button>
+            )}
+            <button className="notif-act" onClick={() => _notifDismiss(m.id)} aria-label="Dismiss message">×</button>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tb-bell-wrap" ref={popRef}>
+      <button
+        className={"tb-bell" + (count > 0 ? " has" : "") + (open ? " on" : "")}
+        data-testid="tb-bell"
+        onClick={() => setOpen((o) => !o)}
+        title="Notifications"
+        aria-label={"Notifications" + (count > 0 ? ` (${count})` : "")}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        {Icons.bell}
+        {count > 0 && <span className="tb-bell-badge num" data-testid="tb-bell-badge">{count > 99 ? "99+" : count}</span>}
+      </button>
+      {open && (
+        <div className="notif-pop" data-testid="notif-pop" role="dialog" aria-label="Notifications">
+          <div className="notif-pop-h mono">
+            <span>Notifications</span>
+            <span className="ct">{count > 0 ? count : "all clear"}</span>
+          </div>
+          <div className="notif-pop-body">
+            {sections.length > 0 ? sections : (
+              <div className="notif-empty mono" data-testid="notif-empty">
+                nothing needs your attention
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── TopBar ───
 function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false }) {
   // Mirror the global agent-chat open state so the Agent Chat launcher lights
@@ -208,6 +500,7 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
           {Icons.agent}<span>Agent Chat</span>
         </button>
       </div>
+      <NotificationBell />
       {/* Mobile-only nav launcher (hidden ≤720px sidebar is gone) → opens NavDrawer. */}
       <button
         className="tb-menu"
@@ -494,7 +787,13 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       if (!expanded && onToggle) onToggle();
     };
     window.addEventListener("hal0:pull-started", onPullStarted);
-    return () => window.removeEventListener("hal0:pull-started", onPullStarted);
+    // The notification bell's "Open downloads pane →" row reuses the same
+    // expand-and-switch behaviour.
+    window.addEventListener("hal0:open-downloads", onPullStarted);
+    return () => {
+      window.removeEventListener("hal0:pull-started", onPullStarted);
+      window.removeEventListener("hal0:open-downloads", onPullStarted);
+    };
   }, [expanded, onToggle]);
   const { jobs, hasActive } = usePullsList({ enabled: expanded && footerTab === "downloads" });
   const clearJob = useClearPullJob();
@@ -931,7 +1230,7 @@ function NavDrawer({ open, route, param, onGo, onClose, onCmdK }) {
   );
 }
 
-Object.assign(window, { Wordmark, Icons, GLYPHS, Icon, TopBar, Sidebar, Footer, ApprovalModal, NavDrawer });
+Object.assign(window, { Wordmark, Icons, GLYPHS, Icon, TopBar, Sidebar, Footer, ApprovalModal, NavDrawer, NotificationBell });
 
 // Bridge approval hooks so main.jsx (strict no-ES-imports prototype) can call
 // them via window globals — same pattern as memory-tab-hook-bridge.ts.

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -129,7 +129,7 @@ function App() {
   const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS);
   const { active: activeBanners } = useBanners();
   const [{ route, param }, setRouteState] = useStateA(parseRoute());
-  const [bellOpen, setBellOpen] = useStateA(false);
+  const [approvalsOpen, setApprovalsOpen] = useStateA(false);
   const [heroDismissed, setHeroDismissed] = useStateA(false);
   const [toast, setToast] = useStateA(null);
   const [composerState, setComposerState] = useStateA("idle");
@@ -200,7 +200,7 @@ function App() {
   useEffectA(() => {
     // global keyboard shortcuts
     const onKey = (e) => {
-      if (e.key === "Escape") { setBellOpen(false); setNavOpen(false); setChatOpen(false); return; }
+      if (e.key === "Escape") { setApprovalsOpen(false); setNavOpen(false); setChatOpen(false); return; }
       const tgt = e.target;
       const typing = tgt && (tgt.tagName === "INPUT" || tgt.tagName === "TEXTAREA" || tgt.isContentEditable);
       if (typing) return;
@@ -226,7 +226,7 @@ function App() {
 
   useEffectA(() => {
     // bridge command-palette actions into App state
-    const onApprovals = () => setBellOpen(true);
+    const onApprovals = () => setApprovalsOpen(true);
     window.addEventListener("hal0:open-approvals", onApprovals);
     // dashboard-redesign: the Activity card's "Open journal →" expands the
     // footer journal pane from anywhere.
@@ -382,8 +382,8 @@ function App() {
       />
 
       <ApprovalModal
-        open={bellOpen}
-        onClose={() => setBellOpen(false)}
+        open={approvalsOpen}
+        onClose={() => setApprovalsOpen(false)}
         items={approvalItems}
         onApprove={id => approveApproval && approveApproval.mutate(id)}
         onDeny={id => denyApproval && denyApproval.mutate(id)}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -307,6 +307,146 @@ a { color: inherit; text-decoration: none; }
   box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
 }
 
+/* Notification bell — icon-only launcher + anchored dropdown panel. */
+.tb-bell-wrap { position: relative; display: inline-flex; }
+.tb-bell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 28px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  cursor: pointer;
+  transition: color .16s ease, border-color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.tb-bell svg {
+  color: #fff;
+  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55));
+  transition: color .16s ease, filter .16s ease;
+}
+.tb-bell:hover { border-color: var(--accent-line); background: var(--accent-soft); }
+.tb-bell:hover svg,
+.tb-bell.on svg,
+.tb-bell.has svg {
+  color: var(--accent);
+  filter: drop-shadow(0 0 5px var(--accent)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.tb-bell.on {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
+}
+.tb-bell-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #1a1408;
+  font-family: var(--jbm);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 0 0 2px var(--bg-1);
+}
+.notif-pop {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(380px, calc(100vw - 24px));
+  background: var(--bg-1);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--rad-lg);
+  box-shadow: 0 18px 60px -12px rgba(0, 0, 0, 0.8);
+  z-index: 90;
+  overflow: hidden;
+}
+.notif-pop-h {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line-soft);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+.notif-pop-h .ct { color: var(--fg-4); text-transform: none; letter-spacing: 0; }
+.notif-pop-body { max-height: min(60vh, 480px); overflow-y: auto; }
+.notif-sec { padding: 6px 0; border-bottom: 1px solid var(--line-soft); }
+.notif-sec:last-child { border-bottom: none; }
+.notif-sec-h {
+  padding: 4px 14px;
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-4);
+}
+.notif-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 7px 14px;
+  font-size: 12px;
+  color: var(--fg-2);
+}
+.notif-row:hover { background: var(--bg-2); }
+.notif-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-top: 4.5px;
+}
+.notif-dot.pulse { animation: notif-pulse 1.6s ease-in-out infinite; }
+@keyframes notif-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .notif-dot.pulse { animation: none; }
+}
+.notif-row .notif-msg { flex: 1; min-width: 0; line-height: 1.45; overflow-wrap: anywhere; }
+.notif-row .notif-msg b { color: var(--fg); font-weight: 500; }
+.notif-row .notif-msg .mono { font-family: var(--jbm); font-size: 11px; }
+.notif-row .notif-body { display: block; color: var(--fg-3); font-size: 11.5px; margin-top: 2px; }
+.notif-act {
+  flex: none;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  background: transparent;
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 10.5px;
+  cursor: pointer;
+}
+.notif-act:hover { color: var(--fg); border-color: var(--line-strong); }
+.notif-act:disabled { opacity: 0.5; cursor: default; }
+.notif-link {
+  display: block;
+  padding: 5px 14px 4px;
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  font-size: 10.5px;
+  cursor: pointer;
+  text-align: left;
+}
+.notif-link:hover { text-decoration: underline; }
+.notif-empty { padding: 22px 14px; text-align: center; color: var(--fg-4); font-size: 11.5px; }
+
 /* wordmark — inline SVG renders at currentColor */
 .wm svg { display: block; }
 .wm .zero { fill: var(--accent); }

--- a/ui/tests/e2e/specs/dashboard-v3.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-v3.spec.ts
@@ -28,7 +28,7 @@ test.describe('Dashboard v3 (/)', () => {
     await expect(page.locator('.sb-row.active .lbl')).toHaveText('Overview')
   })
 
-  test('topbar exposes brand + Kanban/Agent Chat launchers without stale host/bell chrome', async ({ page }) => {
+  test('topbar exposes brand + Kanban/Agent Chat launchers + notification bell without stale host chrome', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('.tb-brand')).toBeVisible()
     // The old "Quick actions" button was replaced by two launchers.
@@ -38,6 +38,9 @@ test.describe('Dashboard v3 (/)', () => {
     await expect(page.locator('[data-testid="tb-launch-chat"]')).toContainText('Agent Chat')
     await expect(page.locator('.tb-cmdk')).toHaveCount(0)
     await expect(page.locator('.tb-host')).toHaveCount(0)
-    await expect(page.locator('.tb-bell')).toHaveCount(0)
+    // The notification bell is LIVE chrome (notification-bell-v3.spec.ts owns
+    // its behaviour) — distinct from the stale prototype bell this test used
+    // to pin the removal of.
+    await expect(page.locator('[data-testid="tb-bell"]')).toBeVisible()
   })
 })

--- a/ui/tests/e2e/specs/notification-bell-v3.spec.ts
+++ b/ui/tests/e2e/specs/notification-bell-v3.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * notification-bell-v3 — topbar notification center.
+ *
+ * The bell aggregates every "wants the operator's eye" source into one
+ * topbar surface:
+ *   1. items needing attention (pending approvals, slots in error) — same
+ *      sources as the dashboard's Needs Attention card;
+ *   2. model downloads (queued/running pulls + failed ones);
+ *   3. updates (hal0 release available via useUpdateState);
+ *   4. developer messages published via `window.hal0Notify(...)` or the
+ *      `hal0:notify` CustomEvent.
+ *
+ * Badge count = live actionable items; rows route to the surface that owns
+ * the action (ApprovalModal via hal0:open-approvals, footer downloads pane
+ * via hal0:open-downloads, Settings → Updates).
+ *
+ * Forced-mock notes: /api/updates/state is short-circuited by mockFetch and
+ * its seed always offers an update, so specs pin the payload through the
+ * `window.__hal0UpdateStateOverride` seam (same as footer-update-chip-v3).
+ * /api/models/pulls and /api/agent/approvals ARE reachable via page.route.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const NO_UPDATE = {
+  hal0: { current: '0.3.0-alpha.1', available: null, channel: 'stable' },
+  flm: { current: 'v0.9.42', source: 'manual-deb' },
+  autoCheck: true,
+}
+
+async function withUpdateState(page: import('@playwright/test').Page, payload: unknown) {
+  await page.addInitScript((p) => {
+    ;(window as any).__hal0UpdateStateOverride = p
+  }, payload)
+}
+
+test.describe('Notification bell (topbar)', () => {
+  test('all clear — no badge, empty panel', async ({ page }) => {
+    await withUpdateState(page, NO_UPDATE)
+    await page.goto('/')
+    const bell = page.getByTestId('tb-bell')
+    await expect(bell).toBeVisible()
+    await expect(page.getByTestId('tb-bell-badge')).toHaveCount(0)
+    await bell.click()
+    await expect(page.getByTestId('notif-pop')).toBeVisible()
+    await expect(page.getByTestId('notif-empty')).toBeVisible()
+    // Escape closes the panel.
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('notif-pop')).toHaveCount(0)
+  })
+
+  test('update available — badge counts it, updates section renders', async ({ page }) => {
+    await withUpdateState(page, {
+      ...NO_UPDATE,
+      hal0: { current: '0.3.0-alpha.1', available: '0.9.9', channel: 'stable' },
+    })
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1', { timeout: 6_000 })
+    await page.getByTestId('tb-bell').click()
+    const sec = page.getByTestId('notif-sec-updates')
+    await expect(sec).toBeVisible()
+    await expect(sec).toContainText('0.9.9')
+    // The Update action deep-links to Settings → Updates.
+    await sec.getByRole('button', { name: 'Update' }).click()
+    await expect(page).toHaveURL(/#settings\/updates/)
+  })
+
+  test('pending approvals — attention section, Review opens the approval modal', async ({
+    page,
+    mockState,
+  }) => {
+    await withUpdateState(page, NO_UPDATE)
+    mockState.approvals = [
+      {
+        id: 'ap-1',
+        tool: 'fs_write',
+        args: { path: '/etc/hal0.toml' },
+        client_id: 'hermes',
+        enqueued_at: Date.now() / 1000 - 120,
+        state: 'pending',
+      },
+      {
+        id: 'ap-2',
+        tool: 'shell_exec',
+        args: { cmd: 'systemctl restart hal0-api' },
+        client_id: 'coder',
+        enqueued_at: Date.now() / 1000 - 60,
+        state: 'pending',
+      },
+    ]
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('2', { timeout: 6_000 })
+    await page.getByTestId('tb-bell').click()
+    const sec = page.getByTestId('notif-sec-attention')
+    await expect(sec).toBeVisible()
+    await expect(sec).toContainText('fs_write')
+    await expect(sec).toContainText('shell_exec')
+    await sec.getByRole('button', { name: 'Review' }).first().click()
+    // Bell panel closes; the existing ApprovalModal takes over.
+    await expect(page.getByTestId('notif-pop')).toHaveCount(0)
+    await expect(page.locator('.approval-modal')).toBeVisible()
+    await expect(page.locator('.approval-modal')).toContainText('fs_write')
+  })
+
+  test('running download — downloads section with progress, link opens footer pane', async ({
+    page,
+  }) => {
+    await withUpdateState(page, NO_UPDATE)
+    await page.route('**/api/models/pulls', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            job_id: 'job-1',
+            model_id: 'qwen3-8b',
+            hf_repo: 'Qwen/Qwen3-8B-GGUF',
+            dest_path: '/var/lib/hal0/models/qwen3-8b.gguf',
+            state: 'running',
+            bytes_downloaded: 2_500_000_000,
+            bytes_total: 5_000_000_000,
+            speed_bps: 50_000_000,
+            eta_s: 50,
+            error: null,
+            started_at: Date.now() / 1000,
+            finished_at: null,
+          },
+        ]),
+      }),
+    )
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1', { timeout: 6_000 })
+    await page.getByTestId('tb-bell').click()
+    const sec = page.getByTestId('notif-sec-downloads')
+    await expect(sec).toBeVisible()
+    await expect(sec).toContainText('Qwen/Qwen3-8B-GGUF')
+    await expect(sec).toContainText('50%')
+    // "Open downloads pane →" expands the footer on its downloads tab.
+    await sec.getByRole('button', { name: /Open downloads pane/ }).click()
+    await expect(page.getByTestId('notif-pop')).toHaveCount(0)
+    await expect(page.locator('.footer.expanded')).toBeVisible()
+    await expect(page.locator('.foot-tab.active')).toHaveText('downloads')
+  })
+
+  test('developer messages — hal0Notify shows a dismissible message', async ({ page }) => {
+    await withUpdateState(page, NO_UPDATE)
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell')).toBeVisible()
+    await page.evaluate(() => {
+      ;(window as any).hal0Notify({
+        id: 'dev-note-1',
+        title: 'Heads up from the hal0 team',
+        body: 'v0.10 changes the slot config format — back up hal0.toml first.',
+        kind: 'warn',
+      })
+    })
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1')
+    await page.getByTestId('tb-bell').click()
+    const sec = page.getByTestId('notif-sec-messages')
+    await expect(sec).toBeVisible()
+    await expect(sec).toContainText('Heads up from the hal0 team')
+    await expect(sec).toContainText('back up hal0.toml')
+    // Dismiss removes the message and clears the badge.
+    await sec.getByRole('button', { name: 'Dismiss message' }).click()
+    await expect(page.getByTestId('notif-sec-messages')).toHaveCount(0)
+    await expect(page.getByTestId('tb-bell-badge')).toHaveCount(0)
+    // Dismissal persists — re-publishing the same id is a no-op.
+    await page.evaluate(() => {
+      ;(window as any).hal0Notify({ id: 'dev-note-1', title: 'Heads up from the hal0 team' })
+    })
+    await expect(page.getByTestId('tb-bell-badge')).toHaveCount(0)
+  })
+
+  test('hal0:notify CustomEvent is an equivalent publish channel', async ({ page }) => {
+    await withUpdateState(page, NO_UPDATE)
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell')).toBeVisible()
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('hal0:notify', {
+          detail: { title: 'Nightly channel now available', kind: 'update' },
+        }),
+      )
+    })
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1')
+    await page.getByTestId('tb-bell').click()
+    await expect(page.getByTestId('notif-sec-messages')).toContainText(
+      'Nightly channel now available',
+    )
+  })
+})


### PR DESCRIPTION
## What

Adds a notification bell to the top-right nav bar — one aggregation point for everything that wants the operator's eye, with a live count badge and a grouped dropdown panel:

- **Needs attention** — pending agent approvals (Review opens the existing ApprovalModal via `hal0:open-approvals`) and slots in error (Restart / View). Reads the same sources as the dashboard's Needs Attention card, so the counts can never drift apart.
- **Downloads** — queued/running model pulls with live %, speed, and ETA plus cancel; failed pulls with retry/clear; and an "Open downloads pane →" row that expands the footer on its downloads tab (new `hal0:open-downloads` event, reusing the footer's existing pull-started handler).
- **Updates** — hal0 release available (deep-links to Settings → Updates) and post-update slot drift with a one-click restart of the drifted slots (`useRestartDriftedSlots`).
- **Developer messages** — a publish channel for important messages: `window.hal0Notify({id?, title, body?, kind?, link?})` or a `hal0:notify` CustomEvent. Messages with a stable id are dismissible forever (localStorage-persisted), so a shipped notice never re-nags after dismissal. The store is module-level, so messages published before the bell mounts are not lost.

The bell can also be popped open from anywhere via a `hal0:open-notifications` event (command palette, banners, …).

## Also in this PR

- **Bugfix:** `usePullsList` now guards against a non-array `/api/models/pulls` payload. An unrouted mock answering `{}` made `jobs.some(...)` throw inside every subscriber's render and unmounted the entire dashboard tree (found by the new spec's e2e run).
- `main.jsx`'s `bellOpen` state renamed to `approvalsOpen` — the bell is its own surface now; the approval modal keeps its own state and its `hal0:open-approvals` wiring unchanged.
- Panel styling follows the existing topbar launcher language (amber glow, `--accent` badge); the pulse dot honours `prefers-reduced-motion`.

## Tests

- New `notification-bell-v3.spec.ts` (6 tests): all-clear/empty state, update badge + Settings deep-link, approvals section → ApprovalModal, running download progress + footer pane hand-off, `hal0Notify` publish/dismiss/persist, `hal0:notify` event channel.
- Updated the `dashboard-v3` topbar pin, which previously asserted the *stale prototype* bell stayed removed — the new bell is live chrome owned by its own spec.
- `tsc --noEmit` clean; hooks-order static test clean; production build clean.
- Full Playwright suite: **382 passed**; the 3 failing NPU-occupancy specs fail identically on a clean checkout (pre-existing, unrelated — verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019g25FQjFg5h5oJfHdcjEeT

---
_Generated by [Claude Code](https://claude.ai/code/session_019g25FQjFg5h5oJfHdcjEeT)_