### PR TITLE
feat(models): HF update check + per-row indicator + Update all

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -41,6 +41,7 @@ from hal0.registry.pull import (
 )
 from hal0.registry.pull import persist_pull_job as _persist_pull_job
 from hal0.registry.pull import pull_job_file as _pull_job_file
+from hal0.registry.update_check import evaluate_model_update, fetch_remote_lfs_shas
 
 # See slots.py for the writer-gate rationale.
 
@@ -234,9 +235,29 @@ async def list_models(request: Request) -> dict[str, Any]:
     data: list[dict[str, Any]] = []
     seen: set[str] = set()
     filtered = 0
+    # Last HF update-check snapshot (populated by /api/models/updates/check;
+    # never fetched on this hot path). The flag is recomputed against the
+    # row's CURRENT metadata.sha256 rather than replayed from the snapshot,
+    # so applying an update clears the badge on the next poll without
+    # waiting for the check TTL to expire.
+    update_checks: dict[str, Any] = {}
+    _upd_state = getattr(request.app.state, "model_update_state", None)
+    if isinstance(_upd_state, dict):
+        update_checks = _upd_state.get("models") or {}
     for entry in registry.list():
         dumped = _model_to_dict(entry)
         dumped["installed"] = True
+        chk = update_checks.get(entry.id)
+        if isinstance(chk, dict):
+            remote_sha = chk.get("remote_sha256")
+            local_sha = (entry.metadata or {}).get("sha256")
+            dumped["update_available"] = bool(
+                isinstance(remote_sha, str)
+                and remote_sha
+                and isinstance(local_sha, str)
+                and local_sha
+                and remote_sha != local_sha.lower()
+            )
         dumped.setdefault("object", "model")
         dumped.setdefault("created", now)
         dumped.setdefault("owned_by", "local")
@@ -1058,6 +1079,152 @@ def _hf_repo_for_model(registry: Any, model_id: str) -> str | None:
         return None
 
 
+# ── HF update check (models with newer bytes on the Hub) ─────────────────────
+#
+# NOTE: registered BEFORE the ``/{model_id}`` catch-all below — FastAPI
+# matches in definition order, same reason ``/pulls`` sits above it.
+
+_UPDATE_CHECK_TTL_S = 3600.0
+
+
+@router.get("/updates/check")
+async def check_model_updates(request: Request, refresh: bool = False) -> dict[str, Any]:
+    """Probe HuggingFace for newer versions of installed HF-pulled models.
+
+    Compares each registry row's recorded ``metadata.sha256`` against the
+    repo's current LFS sha256 for the same ``hf_repo``/``hf_filename``
+    (one tree fetch per unique repo). The result snapshot is cached on
+    app state for an hour — ``?refresh=1`` forces a re-probe — and
+    :func:`list_models` merges a per-row ``update_available`` flag from
+    it so the catalog poll never touches huggingface.co.
+
+    Fail-soft: an unreachable repo marks its models ``reason=
+    "repo_unreachable"`` rather than failing the whole check; the route
+    never 500s on upstream trouble.
+    """
+    state = request.app.state
+    lock = getattr(state, "model_update_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        state.model_update_lock = lock
+    async with lock:
+        cached = getattr(state, "model_update_state", None)
+        now = time.time()
+        if (
+            not refresh
+            and isinstance(cached, dict)
+            and now - cached.get("checked_at", 0) < _UPDATE_CHECK_TTL_S
+        ):
+            return cached
+
+        registry = state.model_registry
+        entries = [
+            m
+            for m in registry.list()
+            if (m.hf_repo or "").strip() and (m.hf_filename or "").strip()
+        ]
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        repo_files = await fetch_remote_lfs_shas(
+            {m.hf_repo.strip() for m in entries}, hf_token=hf_token
+        )
+        checks: dict[str, dict[str, Any]] = {}
+        for m in entries:
+            verdict = evaluate_model_update(m, repo_files)
+            if verdict is not None:
+                checks[m.id] = verdict
+        payload: dict[str, Any] = {
+            "checked_at": now,
+            "checked": len(checks),
+            "updates_available": sum(1 for v in checks.values() if v["update_available"]),
+            "models": checks,
+        }
+        state.model_update_state = payload
+        return payload
+
+
+@router.post("/{model_id}/update", status_code=202)
+async def update_model_from_hf(
+    model_id: str,
+    request: Request,
+    background: BackgroundTasks,
+) -> dict[str, object]:
+    """Re-pull a model's HF file over its installed bytes (in place).
+
+    The pull streams to staging, verifies HF's advertised sha256, then
+    atomically replaces the file at the registry row's EXISTING ``path``
+    (``dest_override``) — deliberately not re-deriving the destination,
+    which would relocate pre-capability-layout models and orphan their
+    old bytes. Job tracking, SSE progress, and the downloads pane all
+    reuse the standard pull machinery under the same ``model_id`` key.
+
+    Idempotent-ish like ``pull_model``: an in-flight job for the id is
+    returned rather than duplicated.
+    """
+    registry = request.app.state.model_registry
+    try:
+        existing = registry.get(model_id)
+    except Exception:
+        raise NotFound(f"model {model_id!r} not found", code="model.not_found") from None
+    hf_repo = (existing.hf_repo or "").strip()
+    hf_file = (existing.hf_filename or "").strip()
+    if not hf_repo or not hf_file:
+        raise PullInvalidSource(
+            f"model {model_id!r} has no hugging face source — set hf_repo + hf_filename",
+            details={"model_id": model_id},
+        )
+    dest = (existing.path or "").strip()
+    if not dest or Path(dest).is_dir():
+        raise PullInvalidSource(
+            f"model {model_id!r} has no single-file install path to update in place",
+            details={"model_id": model_id, "path": dest},
+        )
+
+    jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
+    in_flight = jobs.get(model_id)
+    if in_flight is not None and in_flight.state in ("queued", "running"):
+        return {
+            "id": in_flight.job_id,
+            "model_id": model_id,
+            "state": in_flight.state,
+            "resumed": True,
+        }
+
+    job = make_job(model_id)
+    jobs[model_id] = job
+    _persist_pull_job(job)
+
+    event_bus = getattr(request.app.state, "events", None)
+    if event_bus is not None:
+        await event_bus.emit(
+            "pull.queued",
+            "info",
+            f"pull:{model_id}",
+            f"{model_id}: update queued ({hf_repo}/{hf_file})",
+            data={"model_id": model_id, "hf_repo": hf_repo, "hf_file": hf_file, "update": True},
+        )
+
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    background.add_task(
+        _run_pull_with_events,
+        job,
+        hf_repo=hf_repo,
+        hf_file=hf_file,
+        registry=registry,
+        hf_token=hf_token,
+        event_bus=event_bus,
+        dest_override=dest,
+    )
+    return {
+        "id": job.job_id,
+        "model_id": model_id,
+        "state": job.state,
+        "hf_repo": hf_repo,
+        "hf_file": hf_file,
+        "dest_path": dest,
+        "update": True,
+    }
+
+
 @router.get("/{model_id}")
 async def get_model(model_id: str, request: Request) -> dict[str, Any]:
     """Return a single model by id, preferring the local registry then
@@ -1524,6 +1691,7 @@ async def _run_pull_with_events(
     capability: str | None = None,
     comfyui_subdir: str | None = None,
     mmproj_file: str | None = None,
+    dest_override: str | None = None,
 ) -> None:
     """Wrap ``run_pull`` so footer-visible progress events fan out.
 
@@ -1547,6 +1715,7 @@ async def _run_pull_with_events(
                 capability=capability,
                 comfyui_subdir=comfyui_subdir,
                 mmproj_file=mmproj_file,
+                dest_override=dest_override,
             )
         finally:
             # Persist terminal state so a restart-surviving status poll resolves
@@ -1596,6 +1765,7 @@ async def _run_pull_with_events(
             capability=capability,
             comfyui_subdir=comfyui_subdir,
             mmproj_file=mmproj_file,
+            dest_override=dest_override,
         )
     finally:
         progress_task.cancel()

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -927,6 +927,7 @@ async def run_pull(
     comfyui_subdir: str | None = None,
     capability: str | None = None,
     mmproj_file: str | None = None,
+    dest_override: str | None = None,
 ) -> None:
     """Background-task body: stream the file(s), hash, install, register.
 
@@ -953,6 +954,13 @@ async def run_pull(
         mmproj_file: Optional multimodal-projector filename within the same
             HF repo (the Add-by-HF modal's vision pick, or a curated
             entry's ``mmproj_file``). Downloaded after the main file.
+        dest_override: Absolute final path for the MAIN file. The update
+            flow (``POST /api/models/{id}/update``) pins this to the
+            registry row's existing ``path`` so a re-pull replaces the
+            installed bytes in place — never relocating an older
+            flat-layout model into the capability-grouped tree and
+            orphaning the previous file. When set, ``capability`` /
+            ``comfyui_subdir`` routing is bypassed for the main file.
     """
     job.state = "running"
     job.started_at = time.time()
@@ -976,7 +984,10 @@ async def run_pull(
     try:
         # ── Main model file ────────────────────────────────────────────────
         main_rec = job.files[0]
-        final = _final_path_for_entry(job.model_id, hf_file, comfyui_subdir, capability)
+        if dest_override:
+            final = Path(dest_override)
+        else:
+            final = _final_path_for_entry(job.model_id, hf_file, comfyui_subdir, capability)
         digest = await _download_one(
             job,
             main_rec,
@@ -1109,12 +1120,16 @@ def _register_pulled(
     no directory scan needed. ``None`` leaves any existing association
     (e.g. one a prior scan discovered) untouched.
     """
+    # ``pulled_at`` provenance lets the dashboard show when the installed
+    # bytes were fetched — and thereby how stale they are vs an available
+    # HF update (registry/update_check.py compares the shas).
+    fresh_meta = {"sha256": sha256, "pulled_at": int(time.time())}
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
         "hf_repo": hf_repo,
         "hf_filename": hf_filename,
-        "metadata": {"sha256": sha256},
+        "metadata": fresh_meta,
     }
     if mmproj is not None:
         updates["mmproj"] = mmproj
@@ -1136,7 +1151,7 @@ def _register_pulled(
                 capabilities=caps,
                 backends=backends,
                 mmproj=mmproj,
-                metadata={"sha256": sha256},
+                metadata=dict(fresh_meta),
             )
         )
         return
@@ -1144,7 +1159,7 @@ def _register_pulled(
     # call (e.g. pick-default seeded the entry from the curated catalogue
     # before kicking off the pull).
     merged_meta = dict(existing.metadata)
-    merged_meta["sha256"] = sha256
+    merged_meta.update(fresh_meta)
     updates["metadata"] = merged_meta
     registry.update(model_id, updates)
 

--- a/src/hal0/registry/update_check.py
+++ b/src/hal0/registry/update_check.py
@@ -1,0 +1,149 @@
+"""HF update detection for pulled models.
+
+A registry row pulled from HuggingFace records the sha256 of the bytes it
+streamed (``metadata.sha256`` — for LFS-backed files this equals the LFS
+object id HF advertises). HF's tree API exposes the CURRENT LFS oid per
+file, so "an update is available" reduces to: the stored sha no longer
+matches the repo's sha for the same ``hf_repo``/``hf_filename``.
+
+This module owns the two halves of that comparison:
+
+* :func:`fetch_remote_lfs_shas` — one tree fetch per unique repo,
+  fail-soft (an unreachable/gated repo yields ``None``, never raises).
+* :func:`evaluate_model_update` — the pure per-model verdict.
+
+The route layer (``api/routes/models.py``) composes them behind
+``GET /api/models/updates/check`` and caches the result on app state so
+the 30s ``/api/models`` poll never touches huggingface.co.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_TREE_TIMEOUT_S = 15.0
+# Parallel tree fetches per check run. HF rate-limits anonymous clients
+# aggressively; four concurrent GETs keeps a 30-repo registry check quick
+# without tripping 429s.
+_FETCH_CONCURRENCY = 4
+
+
+def _tree_url(repo: str) -> str:
+    # ``recursive=true`` because hf_filename may live in a subdirectory
+    # (e.g. multi-part GGUF layouts store variants under ``<quant>/``).
+    return f"https://huggingface.co/api/models/{repo}/tree/main?recursive=true"
+
+
+async def fetch_remote_lfs_shas(
+    repos: set[str],
+    *,
+    hf_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, dict[str, str] | None]:
+    """Fetch the current LFS sha256 per file for each repo.
+
+    Returns ``{repo: {path: sha256}}``; a repo whose tree fetch failed
+    (network, 4xx, gated) maps to ``None`` so callers can distinguish
+    "couldn't check" from "file gone". Non-LFS entries are omitted —
+    they carry only a git blob sha1, which is not comparable to the
+    sha256 the pull recorded.
+    """
+    headers = {"Accept": "application/json", "User-Agent": "hal0/update-check"}
+    token = hf_token or os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(_TREE_TIMEOUT_S),
+            follow_redirects=True,
+        )
+
+    sem = asyncio.Semaphore(_FETCH_CONCURRENCY)
+    results: dict[str, dict[str, str] | None] = {}
+
+    async def _one(repo: str) -> None:
+        async with sem:
+            try:
+                resp = await client.get(_tree_url(repo), headers=headers)
+                if resp.status_code >= 400:
+                    results[repo] = None
+                    return
+                payload = resp.json()
+            except Exception as exc:
+                log.debug("update_check.tree_fetch_failed", extra={"repo": repo, "error": str(exc)})
+                results[repo] = None
+                return
+            files: dict[str, str] = {}
+            for entry in payload if isinstance(payload, list) else []:
+                if not isinstance(entry, dict):
+                    continue
+                rel = entry.get("path")
+                lfs = entry.get("lfs")
+                if not (isinstance(rel, str) and rel and isinstance(lfs, dict)):
+                    continue
+                oid = lfs.get("oid")
+                if isinstance(oid, str) and oid:
+                    files[rel] = oid.removeprefix("sha256:").lower()
+            results[repo] = files
+
+    try:
+        await asyncio.gather(*(_one(r) for r in {r for r in repos if r}))
+    finally:
+        if owns_client:
+            await client.aclose()
+    return results
+
+
+def evaluate_model_update(
+    model: Any,
+    repo_files: dict[str, dict[str, str] | None],
+) -> dict[str, Any] | None:
+    """Pure per-model update verdict against pre-fetched repo trees.
+
+    Returns ``None`` for a model with no HF coordinates (not updatable
+    from HF at all — hand-registered or scan-discovered rows). Otherwise
+    a verdict dict; ``update_available`` is only ever True when BOTH a
+    local sha and a remote sha exist and disagree, so a hand-registered
+    row (no recorded sha) or a non-LFS file never shows a phantom update.
+    """
+    repo = (getattr(model, "hf_repo", "") or "").strip()
+    filename = (getattr(model, "hf_filename", "") or "").strip()
+    if not repo or not filename:
+        return None
+    meta = getattr(model, "metadata", None)
+    local_sha = meta.get("sha256") if isinstance(meta, dict) else None
+    if not isinstance(local_sha, str) or not local_sha:
+        local_sha = None
+
+    verdict: dict[str, Any] = {
+        "hf_repo": repo,
+        "hf_filename": filename,
+        "local_sha256": local_sha,
+        "remote_sha256": None,
+        "update_available": False,
+        "reason": None,
+    }
+    files = repo_files.get(repo)
+    if files is None:
+        verdict["reason"] = "repo_unreachable"
+        return verdict
+    remote_sha = files.get(filename)
+    if remote_sha is None:
+        # File renamed/removed upstream, or a non-LFS object (no sha256).
+        verdict["reason"] = "file_missing_or_not_lfs"
+        return verdict
+    verdict["remote_sha256"] = remote_sha
+    if local_sha is None:
+        verdict["reason"] = "no_local_sha256"
+        return verdict
+    verdict["update_available"] = remote_sha != local_sha.lower()
+    return verdict

--- a/tests/api/test_models_updates.py
+++ b/tests/api/test_models_updates.py
@@ -1,0 +1,201 @@
+"""Tests for the model HF-update surface.
+
+Covers:
+  * ``GET /api/models/updates/check`` — verdicts, TTL cache, ?refresh=1.
+  * ``/api/models`` rows carrying the merged ``update_available`` flag —
+    including the self-heal recompute after an applied update changes
+    the row's stored sha without a fresh check.
+  * ``POST /api/models/{id}/update`` — 202 job handle with the dest
+    pinned to the row's existing path, plus the 404/422 error envelopes.
+
+The HF tree fetch is monkeypatched at the route module boundary
+(``models.fetch_remote_lfs_shas``), same style as the inspect tests'
+``_fetch_hf_repo`` interception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api.routes import models as models_route
+
+SHA_OLD = "a" * 64
+SHA_NEW = "b" * 64
+
+
+def _register(client: TestClient, tmp_hal0_home: str, model_id: str, **overrides: Any) -> Path:
+    """POST a registry row whose file exists on disk; return its path."""
+    fpath = Path(tmp_hal0_home) / f"{model_id}.gguf"
+    fpath.write_bytes(b"GGUF" + b"\x00" * 8)
+    body: dict[str, Any] = {
+        "id": model_id,
+        "path": str(fpath),
+        "hf_repo": f"org/{model_id}",
+        "hf_filename": f"{model_id}.gguf",
+        "metadata": {"sha256": SHA_OLD},
+    }
+    body.update(overrides)
+    res = client.post("/api/models", json=body)
+    assert res.status_code == 201, res.text
+    return fpath
+
+
+def _patch_tree_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+    repo_files: dict[str, dict[str, str] | None],
+) -> list[set[str]]:
+    """Replace the route's tree fetch with a canned map; record call args."""
+    calls: list[set[str]] = []
+
+    async def fake_fetch(repos: set[str], **_kw: Any) -> dict[str, dict[str, str] | None]:
+        calls.append(set(repos))
+        return {r: repo_files.get(r) for r in repos}
+
+    monkeypatch.setattr(models_route, "fetch_remote_lfs_shas", fake_fetch)
+    return calls
+
+
+# ── GET /api/models/updates/check ────────────────────────────────────────────
+
+
+def test_check_reports_updates_and_reasons(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(client, tmp_hal0_home, "stale")
+    _register(client, tmp_hal0_home, "fresh")
+    _register(client, tmp_hal0_home, "gated")
+    # No HF coords → not part of the check at all.
+    _register(client, tmp_hal0_home, "handmade", hf_repo="", hf_filename="")
+
+    _patch_tree_fetch(
+        monkeypatch,
+        {
+            "org/stale": {"stale.gguf": SHA_NEW},
+            "org/fresh": {"fresh.gguf": SHA_OLD},
+            "org/gated": None,
+        },
+    )
+
+    body = client.get("/api/models/updates/check").json()
+    assert body["checked"] == 3
+    assert body["updates_available"] == 1
+    assert body["models"]["stale"]["update_available"] is True
+    assert body["models"]["stale"]["remote_sha256"] == SHA_NEW
+    assert body["models"]["fresh"]["update_available"] is False
+    assert body["models"]["gated"]["reason"] == "repo_unreachable"
+    assert "handmade" not in body["models"]
+
+
+def test_check_is_ttl_cached_until_refresh(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(client, tmp_hal0_home, "m1")
+    calls = _patch_tree_fetch(monkeypatch, {"org/m1": {"m1.gguf": SHA_OLD}})
+
+    client.get("/api/models/updates/check")
+    client.get("/api/models/updates/check")
+    assert len(calls) == 1, "second call within the TTL must serve the snapshot"
+
+    client.get("/api/models/updates/check?refresh=1")
+    assert len(calls) == 2, "?refresh=1 must force a re-probe"
+
+
+# ── /api/models row merge ────────────────────────────────────────────────────
+
+
+def test_list_models_merges_update_available_flag(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(client, tmp_hal0_home, "stale")
+    _register(client, tmp_hal0_home, "fresh")
+    _patch_tree_fetch(
+        monkeypatch,
+        {"org/stale": {"stale.gguf": SHA_NEW}, "org/fresh": {"fresh.gguf": SHA_OLD}},
+    )
+
+    # Before any check ran: no flag on any row (absent, not False).
+    rows = {m["id"]: m for m in client.get("/api/models").json()["models"]}
+    assert "update_available" not in rows["stale"]
+
+    client.get("/api/models/updates/check")
+    rows = {m["id"]: m for m in client.get("/api/models").json()["models"]}
+    assert rows["stale"]["update_available"] is True
+    assert rows["fresh"]["update_available"] is False
+
+
+def test_list_models_flag_self_heals_after_sha_refresh(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Applying an update rewrites metadata.sha256; the badge must clear on
+    the next catalog poll WITHOUT waiting for the check TTL to expire."""
+    _register(client, tmp_hal0_home, "stale")
+    _patch_tree_fetch(monkeypatch, {"org/stale": {"stale.gguf": SHA_NEW}})
+    client.get("/api/models/updates/check")
+
+    rows = {m["id"]: m for m in client.get("/api/models").json()["models"]}
+    assert rows["stale"]["update_available"] is True
+
+    # Simulate the completed update: the pull registrar rewrote the sha.
+    client.app.state.model_registry.update("stale", {"metadata": {"sha256": SHA_NEW}})
+    rows = {m["id"]: m for m in client.get("/api/models").json()["models"]}
+    assert rows["stale"]["update_available"] is False
+
+
+# ── POST /api/models/{id}/update ─────────────────────────────────────────────
+
+
+def test_update_pins_dest_to_existing_path(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fpath = _register(client, tmp_hal0_home, "stale")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(job: Any, **kwargs: Any) -> None:
+        captured.update(kwargs)
+        job.state = "completed"
+
+    monkeypatch.setattr(models_route, "_run_pull_with_events", fake_run)
+
+    res = client.post("/api/models/stale/update")
+    assert res.status_code == 202, res.text
+    body = res.json()
+    assert body["model_id"] == "stale"
+    assert body["state"] == "queued"
+    assert body["dest_path"] == str(fpath)
+    assert body["update"] is True
+    # The background task must receive the pinned destination + coords.
+    assert captured["dest_override"] == str(fpath)
+    assert captured["hf_repo"] == "org/stale"
+    assert captured["hf_file"] == "stale.gguf"
+
+
+def test_update_returns_in_flight_job_instead_of_duplicating(
+    client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(client, tmp_hal0_home, "stale")
+
+    async def fake_run(job: Any, **kwargs: Any) -> None:
+        # Leave the job non-terminal so the second POST sees it in flight.
+        job.state = "running"
+
+    monkeypatch.setattr(models_route, "_run_pull_with_events", fake_run)
+    first = client.post("/api/models/stale/update").json()
+    second = client.post("/api/models/stale/update").json()
+    assert second["resumed"] is True
+    assert second["id"] == first["id"]
+
+
+def test_update_unknown_model_is_404(client: TestClient) -> None:
+    res = client.post("/api/models/nope/update")
+    assert res.status_code == 404
+
+
+def test_update_without_hf_coords_is_422(client: TestClient, tmp_hal0_home: str) -> None:
+    _register(client, tmp_hal0_home, "handmade", hf_repo="", hf_filename="")
+    res = client.post("/api/models/handmade/update")
+    assert res.status_code == 422

--- a/tests/registry/test_update_check.py
+++ b/tests/registry/test_update_check.py
@@ -1,0 +1,210 @@
+"""Tests for HF update detection (registry/update_check.py).
+
+Mirrors the pull-engine test style: ``httpx.MockTransport`` stands in for
+huggingface.co's tree API, and the pure verdict helper is exercised
+directly against pre-baked repo trees.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.registry.model import Model
+from hal0.registry.pull import make_job, run_pull
+from hal0.registry.store import ModelRegistry
+from hal0.registry.update_check import evaluate_model_update, fetch_remote_lfs_shas
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+def _model(**overrides: Any) -> Model:
+    base: dict[str, Any] = {
+        "id": "qwen3-4b",
+        "path": "/var/lib/hal0/models/qwen3-4b/qwen3-4b.gguf",
+        "hf_repo": "Qwen/Qwen3-4B-GGUF",
+        "hf_filename": "qwen3-4b.gguf",
+        "metadata": {"sha256": SHA_A},
+    }
+    base.update(overrides)
+    return Model(**base)
+
+
+def _tree_transport(trees: dict[str, list[dict[str, Any]] | int]) -> httpx.MockTransport:
+    """Serve ``/api/models/{repo}/tree/main`` from a repo→entries map.
+
+    An int value is returned as that HTTP status instead of a body.
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        path = req.url.path  # /api/models/<org>/<repo>/tree/main
+        repo = path.removeprefix("/api/models/").removesuffix("/tree/main")
+        entries = trees.get(repo)
+        if entries is None:
+            return httpx.Response(404, json={"error": "not found"})
+        if isinstance(entries, int):
+            return httpx.Response(entries, content=b"")
+        return httpx.Response(200, json=entries)
+
+    return httpx.MockTransport(handler)
+
+
+# ── evaluate_model_update (pure) ─────────────────────────────────────────────
+
+
+def test_evaluate_none_for_rows_without_hf_coords() -> None:
+    """Hand-registered rows (no repo/filename) are not HF-updatable at all."""
+    assert evaluate_model_update(_model(hf_repo=""), {}) is None
+    assert evaluate_model_update(_model(hf_filename=""), {}) is None
+
+
+def test_evaluate_update_available_when_shas_differ() -> None:
+    verdict = evaluate_model_update(_model(), {"Qwen/Qwen3-4B-GGUF": {"qwen3-4b.gguf": SHA_B}})
+    assert verdict is not None
+    assert verdict["update_available"] is True
+    assert verdict["remote_sha256"] == SHA_B
+    assert verdict["local_sha256"] == SHA_A
+    assert verdict["reason"] is None
+
+
+def test_evaluate_up_to_date_when_shas_match_case_insensitively() -> None:
+    verdict = evaluate_model_update(
+        _model(metadata={"sha256": SHA_A.upper()}),
+        {"Qwen/Qwen3-4B-GGUF": {"qwen3-4b.gguf": SHA_A}},
+    )
+    assert verdict is not None
+    assert verdict["update_available"] is False
+
+
+def test_evaluate_repo_unreachable_never_flags_update() -> None:
+    """A failed tree fetch (mapped to None) is 'couldn't check', not 'update'."""
+    verdict = evaluate_model_update(_model(), {"Qwen/Qwen3-4B-GGUF": None})
+    assert verdict is not None
+    assert verdict["update_available"] is False
+    assert verdict["reason"] == "repo_unreachable"
+
+
+def test_evaluate_missing_remote_file_never_flags_update() -> None:
+    """File renamed/removed upstream (or non-LFS) → no phantom update."""
+    verdict = evaluate_model_update(_model(), {"Qwen/Qwen3-4B-GGUF": {}})
+    assert verdict is not None
+    assert verdict["update_available"] is False
+    assert verdict["reason"] == "file_missing_or_not_lfs"
+
+
+def test_evaluate_no_local_sha_never_flags_update() -> None:
+    """Rows registered before sha recording can't be compared — no badge."""
+    verdict = evaluate_model_update(
+        _model(metadata={}), {"Qwen/Qwen3-4B-GGUF": {"qwen3-4b.gguf": SHA_B}}
+    )
+    assert verdict is not None
+    assert verdict["update_available"] is False
+    assert verdict["reason"] == "no_local_sha256"
+    assert verdict["remote_sha256"] == SHA_B
+
+
+# ── fetch_remote_lfs_shas ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_surfaces_lfs_oids_and_skips_non_lfs() -> None:
+    transport = _tree_transport(
+        {
+            "Qwen/Qwen3-4B-GGUF": [
+                {"path": "qwen3-4b.gguf", "lfs": {"oid": f"sha256:{SHA_A.upper()}", "size": 9}},
+                {"path": "README.md", "size": 100},  # non-LFS: git blob only
+                {"path": "sub/dir/part2.gguf", "lfs": {"oid": SHA_B}},
+                "garbage-entry",
+            ]
+        }
+    )
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        out = await fetch_remote_lfs_shas({"Qwen/Qwen3-4B-GGUF"}, client=client)
+    finally:
+        await client.aclose()
+    files = out["Qwen/Qwen3-4B-GGUF"]
+    assert files == {"qwen3-4b.gguf": SHA_A, "sub/dir/part2.gguf": SHA_B}
+
+
+@pytest.mark.asyncio
+async def test_fetch_maps_failed_repos_to_none_without_raising() -> None:
+    transport = _tree_transport({"ok/repo": [{"path": "m.gguf", "lfs": {"oid": SHA_A}}]})
+    client = httpx.AsyncClient(transport=transport)
+    try:
+        out = await fetch_remote_lfs_shas({"ok/repo", "gone/repo"}, client=client)
+    finally:
+        await client.aclose()
+    assert out["ok/repo"] == {"m.gguf": SHA_A}
+    assert out["gone/repo"] is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_sends_bearer_token_when_provided() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["auth"] = req.headers.get("authorization", "")
+        return httpx.Response(200, json=[])
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        await fetch_remote_lfs_shas({"a/b"}, hf_token="tok123", client=client)
+    finally:
+        await client.aclose()
+    assert seen["auth"] == "Bearer tok123"
+
+
+# ── run_pull dest_override (the in-place update path) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pull_dest_override_replaces_in_place(tmp_hal0_home: str, tmp_path: Path) -> None:
+    """An update re-pull must land at the row's EXISTING path, not the
+    layout-derived one — and refresh sha256 + pulled_at provenance."""
+    old_body = b"GGUF" + b"o" * 60
+    new_body = b"GGUF" + b"n" * 1024
+    dest = tmp_path / "store" / "qwen3-4b" / "qwen3-4b.gguf"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(old_body)
+
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="qwen3-4b",
+            path=str(dest),
+            hf_repo="Qwen/Qwen3-4B-GGUF",
+            hf_filename="qwen3-4b.gguf",
+            metadata={"sha256": hashlib.sha256(old_body).hexdigest()},
+        )
+    )
+
+    job = make_job("qwen3-4b")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda req: httpx.Response(200, content=new_body))
+    )
+    try:
+        await run_pull(
+            job,
+            hf_repo="Qwen/Qwen3-4B-GGUF",
+            hf_file="qwen3-4b.gguf",
+            registry=registry,
+            client=client,
+            dest_override=str(dest),
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert dest.read_bytes() == new_body
+    row = registry.get("qwen3-4b")
+    assert row.path == str(dest)
+    assert row.metadata["sha256"] == hashlib.sha256(new_body).hexdigest()
+    assert isinstance(row.metadata.get("pulled_at"), int)

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -59,6 +59,11 @@ export const ENDPOINTS = {
   modelPulls: '/api/models/pulls',
   modelPullDelete: (id: string) => `/api/models/pulls/${encodeURIComponent(id)}`,
   modelInspect: '/api/models/inspect',
+  // HF update check + in-place update. Check is GET (TTL-cached server-side,
+  // ?refresh=1 forces); update re-pulls the row's hf_repo/hf_filename over
+  // its installed path and reports through the standard pull job surface.
+  modelUpdatesCheck: '/api/models/updates/check',
+  modelUpdate: (id: string) => `/api/models/${encodeURIComponent(id)}/update`,
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',
   modelAddFromPath: '/api/models/add-from-path',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -532,7 +532,10 @@ export function usePullsList({ enabled = true }: { enabled?: boolean } = {}) {
     refetchInterval: enabled ? 2_000 : false,
   })
 
-  const jobs = query.data ?? []
+  // Guard: a mocked/misbehaving backend can answer /api/models/pulls with a
+  // non-array (the e2e fixture's catch-all returns {}); jobs.some on that
+  // TypeErrors during render and unmounts the whole app tree.
+  const jobs = Array.isArray(query.data) ? query.data : []
   const hasActive = jobs.some((j: PullJob) => j.state === 'queued' || j.state === 'running')
 
   return { jobs, hasActive, ...query }

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -195,6 +195,91 @@ export function useModelUpdate() {
   })
 }
 
+// ─── HF update check + in-place update ────────────────────────────────
+
+export interface ModelUpdateVerdict {
+  hf_repo: string
+  hf_filename: string
+  local_sha256: string | null
+  remote_sha256: string | null
+  update_available: boolean
+  reason: string | null
+}
+
+export interface ModelUpdatesCheckResponse {
+  checked_at: number
+  checked: number
+  updates_available: number
+  models: Record<string, ModelUpdateVerdict>
+}
+
+const MODEL_UPDATES_POLL_MS = 30 * 60_000
+
+export function useModelUpdatesCheck() {
+  // GET /api/models/updates/check — the server probes HF (one tree fetch
+  // per unique repo, TTL-cached an hour) and stashes the snapshot that
+  // /api/models merges per-row `update_available` flags from. Invalidate
+  // the catalog after each check so badges appear on the next render
+  // instead of waiting out the 30s models poll.
+  const qc = useQueryClient()
+  return useQuery<ModelUpdatesCheckResponse, Hal0Error>({
+    queryKey: ['model-updates'],
+    queryFn: async () => {
+      const res = await apiGet<ModelUpdatesCheckResponse>(ENDPOINTS.modelUpdatesCheck)
+      qc.invalidateQueries({ queryKey: ['models'] })
+      return res
+    },
+    staleTime: MODEL_UPDATES_POLL_MS,
+    refetchInterval: MODEL_UPDATES_POLL_MS,
+  })
+}
+
+export function useModelUpdateApply() {
+  // POST /api/models/{id}/update — re-pull the row's HF file over its
+  // installed path. Progress reports through the standard pull surface
+  // (usePullsList / DownloadsPane pick the job up via the started event).
+  // NOT the same as useModelUpdate above, which is the PUT metadata edit.
+  const qc = useQueryClient()
+  return useMutation<unknown, Hal0Error, string>({
+    mutationFn: (id: string) => apiPost(ENDPOINTS.modelUpdate(id)),
+    onSuccess: (_res, id) => {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: { modelId: id } }))
+      }
+      qc.invalidateQueries({ queryKey: ['pulls'] })
+    },
+  })
+}
+
+export interface ModelUpdateAllResult {
+  started: string[]
+  failed: { id: string; message: string }[]
+}
+
+export function useModelUpdateAll() {
+  // Fan a POST /update out to every id. Failures are collected, not
+  // thrown — one gated repo must not abort the rest of the batch.
+  const qc = useQueryClient()
+  return useMutation<ModelUpdateAllResult, Hal0Error, string[]>({
+    mutationFn: async (ids: string[]) => {
+      const settled = await Promise.allSettled(ids.map((id) => apiPost(ENDPOINTS.modelUpdate(id))))
+      const started: string[] = []
+      const failed: { id: string; message: string }[] = []
+      settled.forEach((r, i) => {
+        if (r.status === 'fulfilled') started.push(ids[i])
+        else failed.push({ id: ids[i], message: (r.reason as Error)?.message ?? String(r.reason) })
+      })
+      return { started, failed }
+    },
+    onSuccess: () => {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: {} }))
+      }
+      qc.invalidateQueries({ queryKey: ['pulls'] })
+    },
+  })
+}
+
 // ─── usePullJob ─────────────────────────────────────────────────────
 
 export type PullState =

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -335,6 +335,13 @@ function buildUpdateState() {
   }
 }
 
+// HF model update check — a "nothing checked yet" snapshot so mock/dev
+// renders without hammering the (absent) backend with 500-retries. A live
+// backend or a page.route override stays authoritative via networkFirst.
+function buildModelUpdatesCheck() {
+  return { checked_at: 0, checked: 0, updates_available: 0, models: {} }
+}
+
 function buildAuthToken() {
   return {
     token_masked: 'hal0-•••••••••••••••••••••••••••••••••',
@@ -1034,6 +1041,7 @@ export const MOCK_ALLOWLIST: ReadonlyArray<AllowRow> = Object.freeze([
   { re: /^\/api\/slots$/, build: buildSlots },
   { re: /^\/api\/slots\/[^/]+$/, build: () => null }, // 404-style — Slot detail not in mock
   { re: /^\/api\/models$/, build: buildModels },
+  { re: /^\/api\/models\/updates\/check$/, build: buildModelUpdatesCheck, networkFirst: true },
   { re: /^\/api\/backends$/, build: buildBackends },
   { re: /^\/api\/capabilities$/, build: buildCapabilities },
   { re: /^\/api\/hardware$/, build: buildHardware },

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, useModelUpdatesCheck, useModelUpdateApply, useModelUpdateAll, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
@@ -79,6 +79,34 @@ function ModelsView() {
 
   const modelsQuery = useModels();
   const modelList = modelsQuery.data ?? [];
+
+  // HF update check — the hook triggers the (server-TTL-cached) probe on
+  // mount; /api/models then carries per-row `update_available` flags.
+  useModelUpdatesCheck();
+  const updateAll = useModelUpdateAll();
+  const updatable = modelList.filter(m => m.installed && m.update_available);
+  const onUpdateAll = async () => {
+    if (!updatable.length) return;
+    try {
+      const res = await updateAll.mutateAsync(updatable.map(m => m.id));
+      if (res.started.length) {
+        window.__hal0Toast && window.__hal0Toast(
+          `Updating ${res.started.length} model${res.started.length === 1 ? "" : "s"} from Hugging Face`,
+          "info",
+        );
+      }
+      if (res.failed.length) {
+        window.__hal0Toast && window.__hal0Toast(
+          `${res.failed.length} update${res.failed.length === 1 ? "" : "s"} failed to start — ${res.failed[0].message}`,
+          "err",
+        );
+      }
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Update all failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
 
   // Auto-pick the first installed model on first render so the detail
   // pane never opens empty.
@@ -189,6 +217,15 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
+        {updatable.length > 0 && (
+          <button
+            className="btn"
+            data-testid="mdl-update-all"
+            disabled={updateAll.isPending}
+            title="Re-pull every installed model whose HuggingFace file has changed"
+            onClick={onUpdateAll}
+          >{Icons.download} {updateAll.isPending ? "Starting…" : `Update all (${updatable.length})`}</button>
+        )}
         <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
         <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
@@ -459,7 +496,9 @@ function ModelRow({ model, selected, onSelect }) {
           ? <span className="chip info" title={`Advertised by the "${model.upstream}" upstream — not stored on this host`}>upstream</span>
           : !model.installed
             ? <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>
-            : null}
+            : model.update_available
+              ? <span className="chip amber" data-testid="mdl-row-update" title="A newer version of this file is available on Hugging Face">update ↑</span>
+              : null}
       </span>
     </div>
   );
@@ -470,6 +509,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
   const swap = useSlotSwap();
+  const hfUpdate = useModelUpdateApply();
   const [cancelling, setCancelling] = useStateM(false);
   if (!model) {
     return (
@@ -529,7 +569,10 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
               : <span style={{color: "var(--fg-5)"}}>{Icons.download}</span>}
           </span>
           <div className="nm mono">{model.longName || model.name || model.id}</div>
-          <span style={{marginLeft: "auto"}}>
+          <span style={{marginLeft: "auto", display: "inline-flex", gap: 6}}>
+            {model.installed && model.update_available && (
+              <span className="chip amber" title="A newer version of this file is available on Hugging Face">update available</span>
+            )}
             {model.installed
               ? <span className="chip ok">installed</span>
               : isUpstreamModel(model)
@@ -575,6 +618,27 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       <div className="mdl-detail-actions">
         {model.installed ? (
           <>
+            {model.update_available && (
+              <button
+                className="btn"
+                data-testid="mdl-detail-update"
+                disabled={hfUpdate.isPending}
+                title="Re-pull the newer file from Hugging Face over the installed one"
+                onClick={async () => {
+                  try {
+                    await hfUpdate.mutateAsync(model.id);
+                    window.__hal0Toast && window.__hal0Toast(
+                      `Updating ${model.longName || model.id} from ${model.hf_repo || "Hugging Face"}`,
+                      "info",
+                    );
+                  } catch (e) {
+                    window.__hal0Toast && window.__hal0Toast(
+                      `Update failed — ${e?.message || "see logs"}`, "err",
+                    );
+                  }
+                }}
+              >{Icons.download} {hfUpdate.isPending ? "Starting…" : "Update"}</button>
+            )}
             <button
               className="btn"
               disabled={swap.isPending}

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -36,6 +36,11 @@ export interface ApiModelRaw {
   tags?: string[]
   /** Unix seconds the row was registered / first seen. */
   created?: number
+  /** True when the last HF update check (GET /api/models/updates/check)
+   * found a newer LFS sha256 for this row's hf_repo/hf_filename than the
+   * one recorded at pull time. Merged server-side into /api/models rows;
+   * absent until a check has run or for rows without HF provenance. */
+  update_available?: boolean
   // ── Legacy HAL0_DATA mock shape (data.jsx fixtures / mock.ts 404
   // fallback). Real /api/models rows never carry these; the normalizer
   // tolerates them so mock mode keeps working through the same code path.

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## What

Lets operators update installed models when their HuggingFace files change upstream: each catalog row shows an **update ↑** indicator when a newer version exists, the detail pane gets an **Update** action, and a top **Update all (N)** button re-pulls everything stale in one click.

## How it works

**Detection (no schema migration).** A pulled model already records the sha256 of its bytes (`metadata.sha256` — the LFS object id for HF-hosted files). HF's tree API exposes the *current* LFS sha256 per file, so "update available" is simply: stored sha ≠ repo sha for the same `hf_repo`/`hf_filename`. Existing installs become update-aware without re-registration.

**Backend**
- `hal0/registry/update_check.py` (new): `fetch_remote_lfs_shas()` — one tree fetch per unique repo, concurrency-capped, fail-soft (unreachable/gated repo → "couldn't check", never a phantom update); `evaluate_model_update()` — the pure per-model verdict.
- `GET /api/models/updates/check` — runs the probe behind a 1-hour app-state cache (`?refresh=1` forces), single-flighted with a lock. Registered above the `/{model_id}` catch-all, like `/pulls`.
- `/api/models` rows now carry `update_available`, merged from the snapshot but **recomputed against the row's current sha** — so applying an update clears the badge on the next 30s poll without waiting out the check TTL. The list path never touches huggingface.co.
- `POST /api/models/{id}/update` — an update is a re-pull pinned to the row's **existing** path via a new `dest_override` threaded through `run_pull` (staging + checksum verify + atomic `os.replace` all unchanged). Pinning matters: a plain re-pull re-derives the destination through the capability-grouped layout and would relocate pre-layout models, orphaning their old bytes. Jobs are keyed by `model_id` as usual, so pull status/SSE/downloads-pane machinery works untouched.
- `_register_pulled` now also records `metadata.pulled_at` provenance.

**UI (Models view)**
- `useModelUpdatesCheck()` triggers the (server-cached) probe on mount and refreshes the catalog so badges appear immediately.
- `ModelRow` shows the amber `update ↑` chip; `ModelDetail` shows an "update available" chip plus the Update button (`useModelUpdateApply`).
- Header "Update all (N)" (`useModelUpdateAll`) fans out per-model updates with `Promise.allSettled` — one gated repo can't abort the batch. Progress surfaces in the existing Downloads pane.

## Safety / edge cases

- `update_available` is only ever true when **both** a local and remote sha exist and disagree — hand-registered rows (no recorded sha), non-LFS files, renamed/removed upstream files, and unreachable repos never flag.
- Update refuses rows without HF coordinates (422) and directory-shaped paths (FLM trees).
- A corrupt/tampered download fails HF's advertised-sha check *before* install, leaving the current file in place.

## Testing

- `tests/registry/test_update_check.py` — verdict matrix (differing/matching/unreachable/missing/no-local-sha), tree-fetch behaviour via `httpx.MockTransport` (LFS oid extraction, `sha256:` prefix strip, non-LFS skip, token header, failed-repo → `None`), and a full `run_pull(dest_override=…)` in-place replacement asserting bytes, path stability, and refreshed sha/`pulled_at`.
- `tests/api/test_models_updates.py` — check verdicts + TTL cache + `?refresh=1`, row-merge including the post-update self-heal, and the update route's 202/pinned-dest/in-flight-dedupe/404/422 envelopes.
- 18 new tests pass; registry + models suites (258 tests) green; UI `tsc --noEmit` and `vite build` clean. Full suite: 1281 passed, 1 pre-existing environment failure (`test_set_store_rejects_non_writable_path` expects a chmod-0555 dir to be unwritable, but CI-as-root bypasses permission bits — unrelated to this change).

## Notes / follow-ups

- `mmproj` sidecars are not re-pulled by an update (association is preserved); could be added by extending the update route with the row's sidecar filename.
- The check compares `main` — per-revision pinning is plumbed (`hf_download_url(revision=…)`) but not exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWJUJweDSUspKGGxKrKqHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWJUJweDSUspKGGxKrKqHD)_