### PR TITLE
feat(models): HF update checks + Update all + cached model cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+- HF model update checks: `GET /api/models/updates` probes each HF-sourced registry row's `resolve/main` URL (HEAD, `X-Linked-ETag` sha256 vs the sha recorded at pull time) and reports which installed models have a newer build upstream; results are TTL-cached and shared per (repo, file) coordinate.
+- `POST /api/models/updates/apply` — "Update all": re-pulls every outdated model (or an explicit `model_ids` subset) through the existing pull machinery (same jobs, SSE progress, footer events, atomic in-place swap).
+- Models dashboard: an amber `update` chip on catalog rows with a newer HF build, an `Update all · N` header button, and an update chip + one-click `Update` action in the detail pane.
+- Model cards: `GET /api/models/{id}/card` downloads the repo's `README.md` once and caches it under `/var/lib/hal0/model-cards/` (stale-cache fallback when HF is unreachable; cache dropped on model delete). The detail sidebar grows a collapsible "Model card" section with a View README toggle and a Refresh action.
+
 ## [0.9.6] — 2026-07-10
 
 ### Highlights

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -70,6 +70,7 @@ from hal0.api.routes import (
     images,
     installer,
     logs,
+    model_updates,
     models,
     npu,
     power,
@@ -1118,6 +1119,9 @@ def create_app() -> FastAPI:
     # Read-only ComfyUI "generation engine" status for the slots-page Image-Gen
     # tab (docker + systemd + ComfyUI HTTP), plus arbiter switchover controls.
     app.include_router(comfyui.router, prefix="/api/comfyui", tags=["comfyui"])
+    # HF update checks — registered BEFORE the main models router so the
+    # literal /api/models/updates path wins over its /{model_id} route.
+    app.include_router(model_updates.router, prefix="/api/models/updates", tags=["models"])
     app.include_router(models.router, prefix="/api/models", tags=["models"])
     # Issue #311: HuggingFace Hub discovery (search proxy). Sits next
     # to the models surface so the dashboard's "Search HF" button has a

--- a/src/hal0/api/routes/model_updates.py
+++ b/src/hal0/api/routes/model_updates.py
@@ -1,0 +1,188 @@
+"""Model update-check endpoints (mounted under /api/models/updates).
+
+The Models dashboard needs two things for HF-sourced rows:
+
+* ``GET  /api/models/updates``        — which installed models have a newer
+  build of their file sitting in the HF repo (sha probe, TTL-cached)?
+* ``POST /api/models/updates/apply``  — re-pull the outdated ones (all of
+  them, or an explicit subset) through the existing pull machinery so
+  progress/SSE/footer events work unchanged.
+
+Lives in its own module (mounted BEFORE the main models router so the
+literal ``/updates`` path wins over ``/{model_id}``) to keep
+routes/models.py from growing further. The comparison logic itself is
+:mod:`hal0.registry.updates`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Request
+
+from hal0.api.middleware.error_codes import BadRequest
+from hal0.registry.pull import PullJob, make_job, persist_pull_job
+from hal0.registry.updates import check_for_updates, clear_check_cache
+
+router = APIRouter()
+
+log = logging.getLogger(__name__)
+
+
+def _hf_token() -> str | None:
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+
+@router.get("")
+async def list_updates(request: Request, refresh: bool = False) -> dict[str, Any]:
+    """Return per-model update statuses for every HF-sourced registry row.
+
+    ``?refresh=true`` drops the probe cache and re-HEADs huggingface.co;
+    otherwise probes within the TTL are reused. Rows without HF
+    coordinates (scanned files, FLM tags, upstream-only ids) are not in
+    the response at all — they have no update story.
+
+    Response::
+
+        {
+          "updates": [ {model_id, status, update_available, ...}, ... ],
+          "available": ["model-id", ...],
+          "count": <checked rows>,
+          "available_count": <len(available)>
+        }
+    """
+    registry = request.app.state.model_registry
+    if refresh:
+        clear_check_cache()
+    statuses = await check_for_updates(registry.list(), hf_token=_hf_token())
+    available = [s["model_id"] for s in statuses if s["update_available"]]
+
+    event_bus = getattr(request.app.state, "events", None)
+    if refresh and available and event_bus is not None:
+        await event_bus.emit(
+            "model.updates_available",
+            "info",
+            "models:updates",
+            f"{len(available)} model update(s) available on Hugging Face",
+            data={"model_ids": available, "count": len(available)},
+        )
+
+    return {
+        "updates": statuses,
+        "available": available,
+        "count": len(statuses),
+        "available_count": len(available),
+    }
+
+
+@router.post("/apply", status_code=202)
+async def apply_updates(
+    request: Request,
+    background: BackgroundTasks,
+) -> dict[str, Any]:
+    """Re-pull outdated models — the dashboard's "Update all" button.
+
+    Body (optional)::
+
+        {"model_ids": ["qwen3-4b-q4_k_m", ...]}
+
+    Without a body (or without ``model_ids``) every model whose cached
+    check says ``update_available`` is re-pulled. Each update is a
+    normal HF pull: same job store, same SSE stream, same footer
+    events, same atomic on-disk swap — so the existing downloads pane
+    shows progress with zero new plumbing.
+
+    Response ``{"started": [...], "skipped": [...]}`` where a skip
+    carries a ``reason`` (``pull_active`` / ``no_hf_source``).
+    """
+    # Local import — these helpers live beside the pull route and pulling
+    # them at call time keeps this module import-light (mirrors the
+    # models.py convention for cross-module helpers).
+    from hal0.api.routes.models import (
+        _resolve_pull_capability,
+        _resolve_pull_source_with_body,
+        _run_pull_with_events,
+    )
+
+    registry = request.app.state.model_registry
+    jobs: dict[str, PullJob] = request.app.state.model_pull_jobs
+    event_bus = getattr(request.app.state, "events", None)
+    hf_token = _hf_token()
+
+    body: dict[str, Any] = {}
+    try:
+        if int(request.headers.get("content-length") or 0) > 0:
+            parsed = await request.json()
+            if isinstance(parsed, dict):
+                body = parsed
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+
+    raw_ids = body.get("model_ids")
+    if raw_ids is not None and not isinstance(raw_ids, list):
+        raise BadRequest("'model_ids' must be a list of model id strings")
+
+    if isinstance(raw_ids, list):
+        targets = [str(m).strip() for m in raw_ids if isinstance(m, str) and str(m).strip()]
+        if not targets:
+            raise BadRequest("'model_ids' must contain at least one model id")
+    else:
+        # No explicit subset → everything the (cached) check flags.
+        statuses = await check_for_updates(registry.list(), hf_token=hf_token)
+        targets = [s["model_id"] for s in statuses if s["update_available"]]
+
+    started: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for model_id in targets:
+        existing = jobs.get(model_id)
+        if existing is not None and existing.state in ("queued", "running"):
+            skipped.append({"model_id": model_id, "reason": "pull_active"})
+            continue
+        try:
+            hf_repo, hf_file, mmproj_file, _ = _resolve_pull_source_with_body(
+                request, model_id, None
+            )
+        except Exception:
+            skipped.append({"model_id": model_id, "reason": "no_hf_source"})
+            continue
+
+        job = make_job(model_id)
+        jobs[model_id] = job
+        persist_pull_job(job)
+
+        if event_bus is not None:
+            await event_bus.emit(
+                "pull.queued",
+                "info",
+                f"pull:{model_id}",
+                f"{model_id}: queued (update from {hf_repo}/{hf_file})",
+                data={
+                    "model_id": model_id,
+                    "hf_repo": hf_repo,
+                    "hf_file": hf_file,
+                    "update": True,
+                },
+            )
+
+        capability, comfyui_subdir = _resolve_pull_capability(request, model_id, None)
+        background.add_task(
+            _run_pull_with_events,
+            job,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            registry=registry,
+            hf_token=hf_token,
+            event_bus=event_bus,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
+            mmproj_file=mmproj_file,
+        )
+        started.append({"model_id": model_id, "job_id": job.job_id, "state": job.state})
+
+    return {
+        "started": started,
+        "skipped": skipped,
+        "count": len(started),
+    }

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -1282,6 +1282,11 @@ async def delete_model(
         # startup sweep reaps anything we miss here.
         with contextlib.suppress(OSError):
             _pull_job_file(model_id).unlink(missing_ok=True)
+        # Same for the cached model card — reference material for a row
+        # that no longer exists.
+        from hal0.registry.cards import drop_cached_card
+
+        drop_cached_card(model_id)
         rec.after = {
             "id": model_id,
             "deleted": bool(removed),
@@ -1839,6 +1844,39 @@ async def _start_flm_pull(
         "state": job.state,
         "source": "flm",
     }
+
+
+@router.get("/{model_id}/card")
+async def model_card(model_id: str, request: Request, refresh: bool = False) -> dict[str, Any]:
+    """Return the model's HF README (model card), cached locally on disk.
+
+    First hit downloads ``README.md`` from the row's ``hf_repo`` and
+    persists it under ``<var_lib>/model-cards/``; subsequent reads are
+    served from disk so the card stays referenceable offline.
+    ``?refresh=true`` re-fetches (falling back to the stale cache when
+    huggingface.co is unreachable).
+
+    Errors: 404 ``model.not_found`` / ``model.card_no_source`` (row has
+    no ``hf_repo``) / ``model.card_not_found`` (repo has no README);
+    502 ``model.card_unavailable`` (no cache and HF unreachable).
+    """
+    from hal0.registry.cards import get_card
+    from hal0.registry.store import ModelNotFound
+
+    registry = request.app.state.model_registry
+    if not registry.has(model_id):
+        raise ModelNotFound(
+            f"model {model_id!r} not in registry",
+            details={"model_id": model_id},
+        )
+    model = registry.get(model_id)
+    hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    return await get_card(
+        model_id,
+        (model.hf_repo or "").strip(),
+        refresh=refresh,
+        hf_token=hf_token,
+    )
 
 
 @router.get("/{model_id}/pull/status")

--- a/src/hal0/registry/cards.py
+++ b/src/hal0/registry/cards.py
@@ -1,0 +1,207 @@
+"""Model cards — download + local cache of HF README.md per registry model.
+
+The dashboard's model detail pane wants the upstream model card (README)
+for reference without leaving hal0. We fetch it once from
+``https://huggingface.co/<repo>/raw/main/README.md`` (READMEs are plain
+git blobs — ``raw`` works, no LFS dance) and persist it under
+``<var_lib>/model-cards/<sanitised-id>.md`` so subsequent reads are
+offline and instant. A ``refresh`` flag re-fetches; the cached copy is
+the fallback when huggingface.co is unreachable.
+
+Size is capped: a model card is documentation, and anything past the cap
+is truncated with a marker rather than ballooning the state dir.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from hal0.config import paths
+from hal0.errors import Hal0Error
+from hal0.registry.pull import _sanitise_id
+
+log = logging.getLogger(__name__)
+
+_CARD_TIMEOUT_S: float = 10.0
+# Hard cap on stored/served markdown. HF cards are typically a few KB;
+# 512 KiB tolerates image-heavy monsters without letting one repo fill
+# the state dir.
+_CARD_MAX_BYTES: int = 512 * 1024
+_TRUNCATION_MARKER = "\n\n…\n*(model card truncated by hal0)*\n"
+
+
+class CardUnavailable(Hal0Error):
+    """No local cache and huggingface.co could not serve the card."""
+
+    code = "model.card_unavailable"
+    status = 502
+
+
+class CardNoSource(Hal0Error):
+    """The registry row has no hf_repo — nowhere to fetch a card from."""
+
+    code = "model.card_no_source"
+    status = 404
+
+
+def cards_dir() -> Path:
+    """Return ``<var_lib>/model-cards`` (HAL0_HOME-aware via config paths)."""
+    return paths.var_lib() / "model-cards"
+
+
+def card_path(model_id: str) -> Path:
+    """On-disk cache location of ``model_id``'s card."""
+    return cards_dir() / f"{_sanitise_id(model_id)}.md"
+
+
+def read_cached_card(model_id: str) -> tuple[str, float] | None:
+    """Return ``(markdown, fetched_at)`` from the disk cache, or None."""
+    p = card_path(model_id)
+    try:
+        text = p.read_text(encoding="utf-8")
+        return text, p.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _persist_card(model_id: str, markdown: str) -> None:
+    """Best-effort write of the card cache — a failure never breaks the read."""
+    p = card_path(model_id)
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(markdown, encoding="utf-8")
+    except OSError as exc:
+        log.warning("model.card_persist_failed model_id=%s error=%s", model_id, exc)
+
+
+def card_url(hf_repo: str, revision: str = "main") -> str:
+    """README location — ``raw`` (not ``resolve``): cards are plain git blobs."""
+    return f"https://huggingface.co/{hf_repo.strip('/')}/raw/{revision}/README.md"
+
+
+async def fetch_card(
+    hf_repo: str,
+    *,
+    hf_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> str:
+    """Download the README for ``hf_repo``; raises :class:`CardUnavailable`.
+
+    Truncates past the size cap so one image-base64-laden card can't
+    balloon the response or the on-disk cache.
+    """
+    headers: dict[str, str] = {"User-Agent": "hal0/model-card"}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(
+            timeout=httpx.Timeout(_CARD_TIMEOUT_S),
+            follow_redirects=True,
+        )
+    try:
+        resp = await client.get(card_url(hf_repo), headers=headers)
+    except httpx.HTTPError as exc:
+        raise CardUnavailable(
+            f"failed to reach huggingface.co for {hf_repo!r} model card: {exc.__class__.__name__}",
+            details={"repo": hf_repo, "error": str(exc)},
+        ) from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+    if resp.status_code == 404:
+        raise CardUnavailable(
+            f"hugging face repo {hf_repo!r} has no README.md at main",
+            code="model.card_not_found",
+            details={"repo": hf_repo},
+        )
+    if resp.status_code >= 400:
+        raise CardUnavailable(
+            f"hugging face returned HTTP {resp.status_code} for {hf_repo!r} model card",
+            details={"repo": hf_repo, "status": resp.status_code},
+        )
+    text = resp.text
+    if len(text.encode("utf-8", errors="ignore")) > _CARD_MAX_BYTES:
+        text = text[:_CARD_MAX_BYTES] + _TRUNCATION_MARKER
+    return text
+
+
+async def get_card(
+    model_id: str,
+    hf_repo: str,
+    *,
+    refresh: bool = False,
+    hf_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Return the card for ``model_id`` — disk cache first, HF on miss.
+
+    ``refresh`` forces a re-fetch; if that fails but a cached copy
+    exists, the cache is served with ``stale=True`` rather than erroring
+    — the reference use-case prefers an old card over none.
+    """
+    if not (hf_repo or "").strip():
+        raise CardNoSource(
+            f"model {model_id!r} has no hf_repo — no model card source",
+            details={"model_id": model_id},
+        )
+    cached = read_cached_card(model_id)
+    if cached is not None and not refresh:
+        markdown, fetched_at = cached
+        return {
+            "model_id": model_id,
+            "hf_repo": hf_repo,
+            "markdown": markdown,
+            "cached": True,
+            "stale": False,
+            "fetched_at": fetched_at,
+        }
+    try:
+        markdown = await fetch_card(hf_repo, hf_token=hf_token, client=client)
+    except CardUnavailable:
+        if cached is not None:
+            markdown, fetched_at = cached
+            return {
+                "model_id": model_id,
+                "hf_repo": hf_repo,
+                "markdown": markdown,
+                "cached": True,
+                "stale": True,
+                "fetched_at": fetched_at,
+            }
+        raise
+    _persist_card(model_id, markdown)
+    return {
+        "model_id": model_id,
+        "hf_repo": hf_repo,
+        "markdown": markdown,
+        "cached": False,
+        "stale": False,
+        "fetched_at": time.time(),
+    }
+
+
+def drop_cached_card(model_id: str) -> None:
+    """Remove the cached card (model delete cascade). Best-effort."""
+    import contextlib
+
+    with contextlib.suppress(OSError):
+        card_path(model_id).unlink(missing_ok=True)
+
+
+__all__ = [
+    "CardNoSource",
+    "CardUnavailable",
+    "card_path",
+    "card_url",
+    "cards_dir",
+    "drop_cached_card",
+    "fetch_card",
+    "get_card",
+    "read_cached_card",
+]

--- a/src/hal0/registry/updates.py
+++ b/src/hal0/registry/updates.py
@@ -1,0 +1,229 @@
+"""HF model update checks — is a newer build of a pulled file available?
+
+hal0 treats a downloaded GGUF as immutable (see registry/pull.py), but
+HF repos routinely re-upload the *same filename* with a newer build
+(fixed chat template, re-quantised weights, …). This module answers
+"did the bytes behind ``<repo>/resolve/main/<file>`` change since we
+pulled?" without downloading anything: a ``HEAD`` on the resolve URL
+advertises the current LFS object's sha256 in ``X-Linked-ETag`` — the
+same header the pull path already verifies against (WS-12) — and the
+pull recorded the local file's sha256 in ``model.metadata["sha256"]``.
+Remote sha != local sha ⇒ an update is available; re-running the
+existing pull machinery atomically swaps the file in place.
+
+Rows that can't be compared stay honest:
+
+* no ``hf_repo``/``hf_filename``  → not checkable (scanned/FLM/upstream)
+* no local sha256 (hand-registered / scanned file) → ``unknown``
+* non-LFS file (no ``X-Linked-ETag`` sha256)       → ``unknown``
+* transport / HTTP failure                          → ``error``
+
+Results are cached in-process: the *remote* sha + checked_at per model.
+``update_available`` is always recomputed against the registry's
+*current* local sha at read time, so a completed re-pull flips a row to
+up-to-date immediately — no cache invalidation dance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from hal0.registry.model import Model
+from hal0.registry.pull import _expected_sha256_from_response, hf_download_url
+
+log = logging.getLogger(__name__)
+
+# ── Tunables ─────────────────────────────────────────────────────────────────
+
+# How long a remote-sha probe result stays fresh. Model repos update on
+# human timescales; half an hour keeps the Models view snappy without
+# hammering HF on every 30s poll. ``refresh=true`` bypasses.
+CHECK_TTL_S: float = 30 * 60
+
+# Per-HEAD timeout + fan-out cap. A registry with dozens of HF-sourced
+# rows must not open dozens of sockets at once.
+_HEAD_TIMEOUT_S: float = 10.0
+_MAX_CONCURRENT_CHECKS: int = 8
+
+
+# ── Result shape ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RemoteCheck:
+    """One cached remote-sha probe for a (repo, filename) coordinate."""
+
+    remote_sha256: str | None  # None → HF exposed no LFS sha (non-LFS file)
+    checked_at: float
+    error: str | None = None  # transport/HTTP failure message, sha unusable
+
+
+# Module-level cache keyed by (hf_repo, hf_filename) — coordinate-level,
+# not model-id-level, so two registry rows pointing at the same file
+# share one probe. Process-local by design (mirrors _INSPECT_CACHE /
+# _SEARCH_CACHE in the api routes).
+_CHECK_CACHE: dict[tuple[str, str], RemoteCheck] = {}
+
+
+def clear_check_cache() -> None:
+    """Drop all cached probes (tests + explicit refresh)."""
+    _CHECK_CACHE.clear()
+
+
+def local_sha256(model: Model) -> str | None:
+    """The sha256 recorded for the installed file, or None if unknown."""
+    meta = getattr(model, "metadata", None) or {}
+    sha = meta.get("sha256")
+    if isinstance(sha, str) and sha.strip():
+        return sha.strip().lower()
+    return None
+
+
+def is_checkable(model: Model) -> bool:
+    """True when the row carries HF coordinates we can probe."""
+    return bool((model.hf_repo or "").strip() and (model.hf_filename or "").strip())
+
+
+async def _probe_remote_sha(
+    client: httpx.AsyncClient,
+    hf_repo: str,
+    hf_filename: str,
+) -> RemoteCheck:
+    """HEAD the resolve URL and extract the advertised LFS sha256.
+
+    Never raises — a failed probe is a data point (``error`` set), not an
+    exception, so one flaky repo can't fail the whole registry sweep.
+    """
+    url = hf_download_url(hf_repo, hf_filename)
+    try:
+        resp = await client.head(url)
+    except httpx.HTTPError as exc:
+        return RemoteCheck(
+            remote_sha256=None,
+            checked_at=time.time(),
+            error=f"{exc.__class__.__name__}: {exc}",
+        )
+    if resp.status_code >= 400:
+        return RemoteCheck(
+            remote_sha256=None,
+            checked_at=time.time(),
+            error=f"HTTP {resp.status_code} from huggingface.co",
+        )
+    # Same header dance as the pull path (WS-12): the LFS sha256 rides
+    # ``X-Linked-ETag`` on the redirect hop or the final response.
+    sha = _expected_sha256_from_response(resp)
+    return RemoteCheck(remote_sha256=sha, checked_at=time.time())
+
+
+async def check_for_updates(
+    models: list[Model],
+    *,
+    refresh: bool = False,
+    hf_token: str | None = None,
+    client: httpx.AsyncClient | None = None,
+    ttl_s: float = CHECK_TTL_S,
+) -> list[dict[str, Any]]:
+    """Probe HF for every checkable row and return per-model statuses.
+
+    Each returned dict has the stable wire shape the dashboard reads::
+
+        {
+          "model_id": "...",
+          "hf_repo": "...", "hf_filename": "...",
+          "local_sha256": "..."|None, "remote_sha256": "..."|None,
+          "status": "update_available"|"up_to_date"|"unknown"|"error",
+          "update_available": bool,
+          "checked_at": <epoch float>|None,
+          "error": "..."|None,
+        }
+
+    Rows without HF coordinates are omitted entirely — they are not
+    "up to date", they are simply not this feature's business.
+
+    Cached probes within ``ttl_s`` are reused unless ``refresh`` is set.
+    ``update_available`` is computed against the *current* local sha, so
+    a stale cache never claims an update for a file that was just
+    re-pulled.
+    """
+    now = time.time()
+    checkable = [m for m in models if is_checkable(m)]
+
+    to_probe: list[tuple[str, str]] = []
+    seen_coords: set[tuple[str, str]] = set()
+    for m in checkable:
+        coord = (m.hf_repo.strip(), m.hf_filename.strip())
+        if coord in seen_coords:
+            continue
+        seen_coords.add(coord)
+        cached = _CHECK_CACHE.get(coord)
+        if refresh or cached is None or (now - cached.checked_at) > ttl_s:
+            to_probe.append(coord)
+
+    if to_probe:
+        headers: dict[str, str] = {"User-Agent": "hal0/update-check"}
+        if hf_token:
+            headers["Authorization"] = f"Bearer {hf_token}"
+        owns_client = client is None
+        if client is None:
+            client = httpx.AsyncClient(
+                timeout=httpx.Timeout(_HEAD_TIMEOUT_S),
+                follow_redirects=True,
+                headers=headers,
+            )
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_CHECKS)
+
+        async def _one(coord: tuple[str, str]) -> None:
+            async with sem:
+                _CHECK_CACHE[coord] = await _probe_remote_sha(client, coord[0], coord[1])
+
+        try:
+            await asyncio.gather(*(_one(c) for c in to_probe))
+        finally:
+            if owns_client:
+                await client.aclose()
+
+    results: list[dict[str, Any]] = []
+    for m in checkable:
+        coord = (m.hf_repo.strip(), m.hf_filename.strip())
+        cached = _CHECK_CACHE.get(coord)
+        local = local_sha256(m)
+        remote = cached.remote_sha256 if cached is not None else None
+        error = cached.error if cached is not None else None
+        if error:
+            status = "error"
+        elif local and remote:
+            status = "update_available" if local != remote else "up_to_date"
+        else:
+            # Non-LFS file (no remote sha) or a row we never hashed
+            # locally (scan / add-from-path) — can't compare honestly.
+            status = "unknown"
+        results.append(
+            {
+                "model_id": m.id,
+                "hf_repo": coord[0],
+                "hf_filename": coord[1],
+                "local_sha256": local,
+                "remote_sha256": remote,
+                "status": status,
+                "update_available": status == "update_available",
+                "checked_at": cached.checked_at if cached is not None else None,
+                "error": error,
+            }
+        )
+    return results
+
+
+__all__ = [
+    "CHECK_TTL_S",
+    "RemoteCheck",
+    "check_for_updates",
+    "clear_check_cache",
+    "is_checkable",
+    "local_sha256",
+]

--- a/tests/api/test_model_card_route.py
+++ b/tests/api/test_model_card_route.py
@@ -1,0 +1,69 @@
+"""GET /api/models/{id}/card — model card fetch + cache route."""
+
+from __future__ import annotations
+
+import pytest
+
+import hal0.registry.cards as cards
+
+CARD = "# Test model\n\nHello.\n"
+
+
+@pytest.fixture
+def _fake_hf(monkeypatch):
+    calls: list[str] = []
+
+    async def fake_fetch(hf_repo, *, hf_token=None, client=None):
+        calls.append(hf_repo)
+        return CARD
+
+    monkeypatch.setattr(cards, "fetch_card", fake_fetch)
+    return calls
+
+
+def _register(client, mid: str, *, hf: bool = True):
+    body = {"id": mid, "name": mid, "path": f"/tmp/{mid}/model.gguf"}
+    if hf:
+        body["hf_repo"] = f"org/{mid}"
+        body["hf_filename"] = "model.gguf"
+    assert client.post("/api/models", json=body).status_code == 201
+
+
+def test_card_fetches_then_serves_from_cache(isolated_client, _fake_hf):
+    _register(isolated_client, "m1")
+    res = isolated_client.get("/api/models/m1/card")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["markdown"] == CARD
+    assert body["cached"] is False
+    assert body["hf_repo"] == "org/m1"
+
+    res = isolated_client.get("/api/models/m1/card")
+    assert res.json()["cached"] is True
+    assert _fake_hf == ["org/m1"]
+
+    res = isolated_client.get("/api/models/m1/card?refresh=true")
+    assert res.json()["cached"] is False
+    assert _fake_hf == ["org/m1", "org/m1"]
+
+
+def test_card_unknown_model_404(isolated_client):
+    res = isolated_client.get("/api/models/nope/card")
+    assert res.status_code == 404
+    assert res.json()["error"]["code"] == "model.not_found"
+
+
+def test_card_without_hf_repo_404(isolated_client, _fake_hf):
+    _register(isolated_client, "scanned", hf=False)
+    res = isolated_client.get("/api/models/scanned/card")
+    assert res.status_code == 404
+    assert res.json()["error"]["code"] == "model.card_no_source"
+    assert _fake_hf == []
+
+
+def test_delete_model_drops_cached_card(isolated_client, _fake_hf):
+    _register(isolated_client, "m1")
+    isolated_client.get("/api/models/m1/card")
+    assert cards.card_path("m1").exists()
+    assert isolated_client.delete("/api/models/m1").status_code == 200
+    assert not cards.card_path("m1").exists()

--- a/tests/api/test_model_updates_routes.py
+++ b/tests/api/test_model_updates_routes.py
@@ -1,0 +1,186 @@
+"""/api/models/updates — HF update-check list + apply (update-all) routes."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+
+import hal0.api.routes.model_updates as mu
+from hal0.registry.updates import clear_check_cache
+
+LOCAL_SHA = hashlib.sha256(b"old").hexdigest()
+REMOTE_SHA = hashlib.sha256(b"new").hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    clear_check_cache()
+    yield
+    clear_check_cache()
+
+
+def _register(client, mid: str, *, hf: bool = True) -> None:
+    body: dict[str, Any] = {
+        "id": mid,
+        "name": mid,
+        "path": f"/tmp/{mid}/model.gguf",
+        "metadata": {"sha256": LOCAL_SHA},
+    }
+    if hf:
+        body["hf_repo"] = f"org/{mid}"
+        body["hf_filename"] = "model.gguf"
+    res = client.post("/api/models", json=body)
+    assert res.status_code == 201
+
+
+def _stub_check(monkeypatch, statuses: list[dict[str, Any]]):
+    calls: list[dict[str, Any]] = []
+
+    async def fake_check(models, *, refresh=False, hf_token=None, **kw):
+        calls.append({"models": [m.id for m in models], "refresh": refresh})
+        return statuses
+
+    monkeypatch.setattr(mu, "check_for_updates", fake_check)
+    return calls
+
+
+def _status_row(mid: str, *, available: bool) -> dict[str, Any]:
+    return {
+        "model_id": mid,
+        "hf_repo": f"org/{mid}",
+        "hf_filename": "model.gguf",
+        "local_sha256": LOCAL_SHA,
+        "remote_sha256": REMOTE_SHA if available else LOCAL_SHA,
+        "status": "update_available" if available else "up_to_date",
+        "update_available": available,
+        "checked_at": 1.0,
+        "error": None,
+    }
+
+
+# ── GET /api/models/updates ───────────────────────────────────────────────────
+
+
+def test_list_updates_route_not_shadowed_by_model_id(isolated_client, monkeypatch):
+    """The literal /updates path must win over GET /api/models/{model_id}."""
+    _stub_check(monkeypatch, [])
+    res = isolated_client.get("/api/models/updates")
+    assert res.status_code == 200
+    assert res.json() == {"updates": [], "available": [], "count": 0, "available_count": 0}
+
+
+def test_list_updates_reports_available(isolated_client, monkeypatch):
+    _register(isolated_client, "m1")
+    _register(isolated_client, "m2")
+    _stub_check(
+        monkeypatch,
+        [_status_row("m1", available=True), _status_row("m2", available=False)],
+    )
+    res = isolated_client.get("/api/models/updates")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["available"] == ["m1"]
+    assert body["available_count"] == 1
+    assert body["count"] == 2
+    by_id = {r["model_id"]: r for r in body["updates"]}
+    assert by_id["m1"]["update_available"] is True
+    assert by_id["m2"]["status"] == "up_to_date"
+
+
+def test_refresh_clears_cache_and_emits_event(isolated_app_client, monkeypatch):
+    _, client = isolated_app_client
+    _register(client, "m1")
+    _stub_check(monkeypatch, [_status_row("m1", available=True)])
+    cleared: list[bool] = []
+    monkeypatch.setattr(mu, "clear_check_cache", lambda: cleared.append(True))
+
+    res = client.get("/api/models/updates?refresh=true")
+    assert res.status_code == 200
+    assert cleared == [True]
+
+    events = client.get("/api/events", params={"type": "model.updates_available"})
+    rows = events.json()["events"]
+    assert len(rows) == 1
+    assert rows[0]["data"]["model_ids"] == ["m1"]
+
+
+# ── POST /api/models/updates/apply ────────────────────────────────────────────
+
+
+@pytest.fixture
+def _no_real_pull(monkeypatch):
+    """Stub the background pull body so apply never touches the network."""
+    ran: list[str] = []
+
+    async def fake_run(job, **kwargs):
+        ran.append(job.model_id)
+        job.state = "completed"
+
+    # Patched on THIS module: apply_updates imports the helper lazily from
+    # routes.models, so patch it there.
+    import hal0.api.routes.models as models_routes
+
+    monkeypatch.setattr(models_routes, "_run_pull_with_events", fake_run)
+    return ran
+
+
+def test_apply_all_available(isolated_client, monkeypatch, _no_real_pull):
+    _register(isolated_client, "m1")
+    _register(isolated_client, "m2")
+    _stub_check(
+        monkeypatch,
+        [_status_row("m1", available=True), _status_row("m2", available=False)],
+    )
+    res = isolated_client.post("/api/models/updates/apply")
+    assert res.status_code == 202
+    body = res.json()
+    assert [s["model_id"] for s in body["started"]] == ["m1"]
+    assert body["count"] == 1
+    assert body["skipped"] == []
+    assert _no_real_pull == ["m1"]
+
+
+def test_apply_explicit_subset(isolated_client, monkeypatch, _no_real_pull):
+    _register(isolated_client, "m1")
+    _register(isolated_client, "m2")
+    calls = _stub_check(monkeypatch, [])
+    res = isolated_client.post("/api/models/updates/apply", json={"model_ids": ["m2"]})
+    assert res.status_code == 202
+    body = res.json()
+    assert [s["model_id"] for s in body["started"]] == ["m2"]
+    # Explicit ids skip the check round-trip entirely.
+    assert calls == []
+
+
+def test_apply_skips_models_without_hf_source(isolated_client, monkeypatch, _no_real_pull):
+    _register(isolated_client, "scanned", hf=False)
+    res = isolated_client.post("/api/models/updates/apply", json={"model_ids": ["scanned"]})
+    assert res.status_code == 202
+    body = res.json()
+    assert body["started"] == []
+    assert body["skipped"] == [{"model_id": "scanned", "reason": "no_hf_source"}]
+
+
+def test_apply_skips_active_pull(isolated_app_client, monkeypatch, _no_real_pull):
+    app, client = isolated_app_client
+    _register(client, "m1")
+    from hal0.registry.pull import make_job
+
+    job = make_job("m1")
+    job.state = "running"
+    app.state.model_pull_jobs["m1"] = job
+
+    res = client.post("/api/models/updates/apply", json={"model_ids": ["m1"]})
+    assert res.status_code == 202
+    body = res.json()
+    assert body["started"] == []
+    assert body["skipped"] == [{"model_id": "m1", "reason": "pull_active"}]
+
+
+def test_apply_rejects_bad_model_ids_shape(isolated_client):
+    res = isolated_client.post("/api/models/updates/apply", json={"model_ids": "m1"})
+    assert res.status_code == 400
+    res = isolated_client.post("/api/models/updates/apply", json={"model_ids": []})
+    assert res.status_code == 400

--- a/tests/registry/test_cards.py
+++ b/tests/registry/test_cards.py
@@ -1,0 +1,103 @@
+"""registry.cards — HF model card (README) fetch + disk cache."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from hal0.registry.cards import (
+    CardNoSource,
+    CardUnavailable,
+    card_path,
+    card_url,
+    get_card,
+    read_cached_card,
+)
+
+CARD = "# Qwen3\n\nA fine model.\n"
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+
+
+def _ok_handler(body: str = CARD, status: int = 200, calls: list | None = None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if calls is not None:
+            calls.append(str(request.url))
+        return httpx.Response(status, text=body)
+
+    return handler
+
+
+def test_card_url_is_raw_main():
+    assert card_url("org/repo") == "https://huggingface.co/org/repo/raw/main/README.md"
+
+
+async def test_fetch_persists_and_second_read_is_cached(tmp_hal0_home):
+    calls: list[str] = []
+    async with _client(_ok_handler(calls=calls)) as client:
+        out = await get_card("m1", "org/repo", client=client)
+        assert out["markdown"] == CARD
+        assert out["cached"] is False
+        assert card_path("m1").read_text() == CARD
+
+        again = await get_card("m1", "org/repo", client=client)
+    assert again["cached"] is True
+    assert again["markdown"] == CARD
+    assert len(calls) == 1  # second read never hit HF
+
+
+async def test_refresh_refetches(tmp_hal0_home):
+    calls: list[str] = []
+    async with _client(_ok_handler(calls=calls)) as client:
+        await get_card("m1", "org/repo", client=client)
+        out = await get_card("m1", "org/repo", refresh=True, client=client)
+    assert len(calls) == 2
+    assert out["cached"] is False
+
+
+async def test_refresh_falls_back_to_stale_cache_when_hf_down(tmp_hal0_home):
+    async with _client(_ok_handler()) as client:
+        await get_card("m1", "org/repo", client=client)
+
+    def down(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async with _client(down) as client:
+        out = await get_card("m1", "org/repo", refresh=True, client=client)
+    assert out["markdown"] == CARD
+    assert out["stale"] is True
+
+
+async def test_no_cache_and_hf_down_raises(tmp_hal0_home):
+    def down(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async with _client(down) as client:
+        with pytest.raises(CardUnavailable):
+            await get_card("m1", "org/repo", client=client)
+
+
+async def test_missing_readme_raises_not_found(tmp_hal0_home):
+    async with _client(_ok_handler(status=404)) as client:
+        with pytest.raises(CardUnavailable) as exc:
+            await get_card("m1", "org/repo", client=client)
+    assert exc.value.code == "model.card_not_found"
+
+
+async def test_no_hf_repo_raises_no_source(tmp_hal0_home):
+    with pytest.raises(CardNoSource):
+        await get_card("m1", "")
+
+
+async def test_oversized_card_is_truncated(tmp_hal0_home):
+    big = "x" * (600 * 1024)
+    async with _client(_ok_handler(body=big)) as client:
+        out = await get_card("m1", "org/repo", client=client)
+    assert len(out["markdown"]) < len(big)
+    assert "truncated by hal0" in out["markdown"]
+
+
+async def test_read_cached_card_absent(tmp_hal0_home):
+    assert read_cached_card("nope") is None

--- a/tests/registry/test_updates.py
+++ b/tests/registry/test_updates.py
@@ -1,0 +1,171 @@
+"""registry.updates — HF sha probe + update-available comparison."""
+
+from __future__ import annotations
+
+import hashlib
+
+import httpx
+import pytest
+
+from hal0.registry.model import Model
+from hal0.registry.updates import (
+    check_for_updates,
+    clear_check_cache,
+    is_checkable,
+    local_sha256,
+)
+
+LOCAL_SHA = hashlib.sha256(b"old bytes").hexdigest()
+REMOTE_SHA = hashlib.sha256(b"new bytes").hexdigest()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    clear_check_cache()
+    yield
+    clear_check_cache()
+
+
+def _model(
+    mid: str = "m1",
+    *,
+    repo: str = "org/repo",
+    filename: str = "model.gguf",
+    sha: str | None = LOCAL_SHA,
+) -> Model:
+    meta = {"sha256": sha} if sha else {}
+    return Model(
+        id=mid,
+        path=f"/tmp/{mid}/model.gguf",
+        hf_repo=repo,
+        hf_filename=filename,
+        metadata=meta,
+    )
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), follow_redirects=True)
+
+
+def _head_handler(remote_sha: str | None, status: int = 200, calls: list | None = None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        if calls is not None:
+            calls.append(str(request.url))
+        assert request.method == "HEAD"
+        headers = {}
+        if remote_sha is not None:
+            headers["X-Linked-ETag"] = f'"{remote_sha}"'
+        return httpx.Response(status, headers=headers)
+
+    return handler
+
+
+# ── field helpers ─────────────────────────────────────────────────────────────
+
+
+def test_is_checkable_requires_both_coords():
+    assert is_checkable(_model())
+    assert not is_checkable(_model(repo=""))
+    assert not is_checkable(_model(filename=""))
+
+
+def test_local_sha256_missing_and_normalised():
+    assert local_sha256(_model(sha=None)) is None
+    assert local_sha256(_model(sha=LOCAL_SHA.upper())) == LOCAL_SHA
+
+
+# ── check_for_updates ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_available_when_remote_sha_differs():
+    async with _client(_head_handler(REMOTE_SHA)) as client:
+        out = await check_for_updates([_model()], client=client)
+    assert len(out) == 1
+    row = out[0]
+    assert row["model_id"] == "m1"
+    assert row["status"] == "update_available"
+    assert row["update_available"] is True
+    assert row["local_sha256"] == LOCAL_SHA
+    assert row["remote_sha256"] == REMOTE_SHA
+
+
+@pytest.mark.asyncio
+async def test_up_to_date_when_shas_match():
+    async with _client(_head_handler(LOCAL_SHA)) as client:
+        out = await check_for_updates([_model()], client=client)
+    assert out[0]["status"] == "up_to_date"
+    assert out[0]["update_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_without_local_sha():
+    async with _client(_head_handler(REMOTE_SHA)) as client:
+        out = await check_for_updates([_model(sha=None)], client=client)
+    assert out[0]["status"] == "unknown"
+    assert out[0]["update_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_without_remote_sha():
+    # Non-LFS file: HEAD succeeds but exposes no sha256-shaped linked etag.
+    async with _client(_head_handler(None)) as client:
+        out = await check_for_updates([_model()], client=client)
+    assert out[0]["status"] == "unknown"
+    assert out[0]["update_available"] is False
+
+
+@pytest.mark.asyncio
+async def test_error_status_on_http_failure():
+    async with _client(_head_handler(REMOTE_SHA, status=500)) as client:
+        out = await check_for_updates([_model()], client=client)
+    assert out[0]["status"] == "error"
+    assert out[0]["update_available"] is False
+    assert "500" in out[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_transport_error_is_captured_not_raised():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async with _client(handler) as client:
+        out = await check_for_updates([_model()], client=client)
+    assert out[0]["status"] == "error"
+    assert "ConnectError" in out[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_rows_without_hf_coords_are_omitted():
+    async with _client(_head_handler(REMOTE_SHA)) as client:
+        out = await check_for_updates([_model(), _model("scanned", repo="")], client=client)
+    assert [r["model_id"] for r in out] == ["m1"]
+
+
+@pytest.mark.asyncio
+async def test_probe_cached_within_ttl_and_shared_across_rows():
+    calls: list[str] = []
+    async with _client(_head_handler(REMOTE_SHA, calls=calls)) as client:
+        # Two rows pointing at the same (repo, filename) → one probe.
+        out = await check_for_updates([_model("a"), _model("b")], client=client)
+        assert len(calls) == 1
+        assert all(r["update_available"] for r in out)
+        # Second sweep inside the TTL reuses the cache — no new HEAD.
+        await check_for_updates([_model("a")], client=client)
+        assert len(calls) == 1
+        # refresh=True re-probes.
+        await check_for_updates([_model("a")], refresh=True, client=client)
+        assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_cached_remote_sha_recomputed_against_current_local_sha():
+    """A re-pull flips the row to up_to_date without a cache refresh."""
+    async with _client(_head_handler(REMOTE_SHA)) as client:
+        out = await check_for_updates([_model()], client=client)
+        assert out[0]["update_available"] is True
+        # Simulate the pull completing: local sha now matches remote.
+        updated = _model(sha=REMOTE_SHA)
+        out = await check_for_updates([updated], client=client)
+    assert out[0]["status"] == "up_to_date"
+    assert out[0]["update_available"] is False

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -59,6 +59,12 @@ export const ENDPOINTS = {
   modelPulls: '/api/models/pulls',
   modelPullDelete: (id: string) => `/api/models/pulls/${encodeURIComponent(id)}`,
   modelInspect: '/api/models/inspect',
+  // HF update checks — which installed models have a newer file in their
+  // HF repo (sha probe), and the "Update all" re-pull action.
+  modelUpdates: '/api/models/updates',
+  modelUpdatesApply: '/api/models/updates/apply',
+  // Model card (README.md) — fetched from HF once, cached server-side.
+  modelCard: (id: string) => `/api/models/${encodeURIComponent(id)}/card`,
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',
   modelAddFromPath: '/api/models/add-from-path',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -169,6 +169,125 @@ export function useHfSearch(q: string, type?: string | null) {
   })
 }
 
+// ─── HF model updates (update-available check + update-all) ────────────
+
+export interface ModelUpdateStatus {
+  model_id: string
+  hf_repo: string
+  hf_filename: string
+  local_sha256: string | null
+  remote_sha256: string | null
+  status: 'update_available' | 'up_to_date' | 'unknown' | 'error' | string
+  update_available: boolean
+  checked_at: number | null
+  error: string | null
+}
+
+export interface ModelUpdatesResponse {
+  updates: ModelUpdateStatus[]
+  available: string[]
+  count: number
+  available_count: number
+}
+
+const MODEL_UPDATES_POLL_MS = 5 * 60_000
+
+export function useModelUpdates() {
+  // GET /api/models/updates — server-side TTL-cached HF sha probe. The
+  // poll here just re-reads the cache; the backend only re-HEADs
+  // huggingface.co when its own TTL lapses. Fail-soft: an old backend
+  // (or the e2e catch-all mock) returns {} → no badges, no errors.
+  const query = useQuery<ModelUpdatesResponse>({
+    queryKey: ['model-updates'],
+    queryFn: async () => {
+      const body = await apiGet<any>(ENDPOINTS.modelUpdates)
+      return {
+        updates: Array.isArray(body?.updates) ? body.updates : [],
+        available: Array.isArray(body?.available) ? body.available : [],
+        count: body?.count ?? 0,
+        available_count: body?.available_count ?? 0,
+      }
+    },
+    refetchInterval: MODEL_UPDATES_POLL_MS,
+    retry: false,
+  })
+  const available = query.data?.available ?? []
+  return {
+    ...query,
+    available,
+    availableSet: new Set(available),
+    statuses: query.data?.updates ?? [],
+  }
+}
+
+export interface ModelUpdatesApplyResponse {
+  started: { model_id: string; job_id: string; state: string }[]
+  skipped: { model_id: string; reason: string }[]
+  count: number
+}
+
+export function useModelUpdatesApply() {
+  // POST /api/models/updates/apply — re-pulls every outdated model (or an
+  // explicit subset). Each update is a normal pull job, so invalidating
+  // ['pulls'] + firing hal0:pull-started lights up the Downloads pane.
+  const qc = useQueryClient()
+  return useMutation<ModelUpdatesApplyResponse, Hal0Error, { model_ids?: string[] } | void>({
+    mutationFn: (body) =>
+      apiPost<ModelUpdatesApplyResponse>(
+        ENDPOINTS.modelUpdatesApply,
+        (body ?? undefined) as Record<string, unknown> | undefined,
+      ),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: ['pulls'] })
+      qc.invalidateQueries({ queryKey: ['model-updates'] })
+      if (typeof window !== 'undefined') {
+        for (const s of res?.started ?? []) {
+          window.dispatchEvent(
+            new CustomEvent('hal0:pull-started', { detail: { modelId: s.model_id } }),
+          )
+        }
+      }
+    },
+  })
+}
+
+// ─── Model card (HF README, cached server-side) ─────────────────────────
+
+export interface ModelCardResponse {
+  model_id: string
+  hf_repo: string
+  markdown: string
+  cached: boolean
+  stale: boolean
+  fetched_at: number
+}
+
+export function useModelCard(id: string | null | undefined) {
+  // GET /api/models/{id}/card — lazy (enabled only once the detail pane's
+  // Model-card section is opened, callers pass null until then). The
+  // backend serves its disk cache after the first fetch, so re-opening
+  // the section is instant and works offline.
+  return useQuery<ModelCardResponse, Hal0Error>({
+    queryKey: ['model-card', id],
+    queryFn: () => apiGet<ModelCardResponse>(ENDPOINTS.modelCard(id as string)),
+    enabled: !!id,
+    staleTime: Infinity,
+    retry: false,
+  })
+}
+
+export function useModelCardRefresh() {
+  // Force a re-fetch from HF (?refresh=true) and update the cache entry.
+  const qc = useQueryClient()
+  return useMutation<ModelCardResponse, Hal0Error, string>({
+    mutationFn: (id: string) =>
+      apiGet<ModelCardResponse>(`${ENDPOINTS.modelCard(id)}?refresh=true`),
+    onSuccess: (data, id) => {
+      qc.setQueryData(['model-card', id], data)
+    },
+  })
+}
+
 export interface ModelDeleteResponse {
   id: string
   deleted: boolean

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, useModelUpdates, useModelUpdatesApply, useModelCard, useModelCardRefresh, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
@@ -79,6 +79,27 @@ function ModelsView() {
 
   const modelsQuery = useModels();
   const modelList = modelsQuery.data ?? [];
+
+  // HF update availability — server-side sha probe, cached. availableSet
+  // drives the per-row indicator; the header button updates everything.
+  const updates = useModelUpdates();
+  const updatesApply = useModelUpdatesApply();
+  const onUpdateAll = async () => {
+    try {
+      const res = await updatesApply.mutateAsync();
+      const n = res?.count ?? 0;
+      window.__hal0Toast && window.__hal0Toast(
+        n > 0
+          ? `Updating ${n} model${n === 1 ? "" : "s"} from Hugging Face…`
+          : "Nothing to update.",
+        "info",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Update all failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
 
   // Auto-pick the first installed model on first render so the detail
   // pane never opens empty.
@@ -189,6 +210,17 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
+        {updates.available.length > 0 && (
+          <button
+            className="btn"
+            data-testid="mdl-update-all"
+            disabled={updatesApply.isPending}
+            title={`Newer builds on Hugging Face: ${updates.available.join(", ")}`}
+            onClick={onUpdateAll}
+          >
+            {Icons.restart} {updatesApply.isPending ? "Updating…" : `Update all · ${updates.available.length}`}
+          </button>
+        )}
         <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
         <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
@@ -301,16 +333,16 @@ function ModelsView() {
             sectionedInference.map(item =>
               item.type === "label"
                 ? <div key={item.key} className="mdl-section-label">{item.text}</div>
-                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
+                : <ModelRow key={item.model.id} model={item.model} updatable={updates.availableSet.has(item.model.id)} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
             )
           ) : tab === "image" ? (
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} updatable={updates.availableSet.has(m.id)} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
             ))
           ) : (
             /* upstream tab — flat paginated rows */
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} updatable={updates.availableSet.has(m.id)} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
             ))
           )}
 
@@ -348,6 +380,7 @@ function ModelsView() {
         <div className="models-sidebar">
           <ModelDetail
             model={selected}
+            updatable={selected ? updates.availableSet.has(selected.id) : false}
             onDelete={() => setDelModel(selected)}
             onEdit={() => setRecipeOpen(true)}
           />
@@ -433,7 +466,7 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
 }
 
 // ── ModelRow ──────────────────────────────────────────────────────────
-function ModelRow({ model, selected, onSelect }) {
+function ModelRow({ model, selected, onSelect, updatable }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
@@ -447,6 +480,11 @@ function ModelRow({ model, selected, onSelect }) {
         <span className="sub">{model.repo || ""}</span>
       </span>
       <span className="mdl-row-tags">
+        {updatable && (
+          <span className="chip amber" data-testid="mdl-row-update-available" title="A newer build of this file is available in the HF repo">
+            {Icons.restart} update
+          </span>
+        )}
         {model.type && <span className="chip">{model.type}</span>}
         {model.quant && <span className="chip quant" data-testid="mdl-row-quant">{model.quant}</span>}
         {backends.map(b => (
@@ -465,8 +503,85 @@ function ModelRow({ model, selected, onSelect }) {
   );
 }
 
+// ── ModelCardPanel ────────────────────────────────────────────────────
+// Collapsible "Model card" section in the detail sidebar. The README is
+// fetched lazily on first expand (then served from the backend's disk
+// cache under /var/lib/hal0/model-cards/) so selecting models stays
+// cheap and the card stays readable offline. Hidden entirely for rows
+// with no hf_repo — there is nowhere to fetch a card from.
+function ModelCardPanel({ model }) {
+  const [open, setOpen] = useStateM(false);
+  // hf_repo is authoritative; the normalizer's derived `repo` is the
+  // fallback for rows serialised before hf_repo surfaced (or mock rows).
+  // `local/<id>` and `via <upstream>` repos have no HF card to fetch.
+  const repo = String(model?.hf_repo || model?.repo || "").trim();
+  const hasSource = !!repo && !repo.startsWith("local/") && !repo.startsWith("via ");
+  const card = useModelCard(open && hasSource ? model.id : null);
+  const refresh = useModelCardRefresh();
+  if (!hasSource) return null;
+  return (
+    <div className="mdl-detail-recipe">
+      <div style={{display: "flex", alignItems: "center", gap: 6}}>
+        <div className="lbl" style={{marginBottom: 0}}>Model card</div>
+        <span className="vh-spacer" />
+        {open && (
+          <button
+            className="btn ghost sm"
+            disabled={refresh.isPending}
+            title="Re-fetch the README from Hugging Face"
+            onClick={async () => {
+              try {
+                await refresh.mutateAsync(model.id);
+              } catch (e) {
+                window.__hal0Toast && window.__hal0Toast(
+                  `Card refresh failed — ${e?.message || "see logs"}`, "err",
+                );
+              }
+            }}
+          >{refresh.isPending ? "Refreshing…" : "↻ Refresh"}</button>
+        )}
+        <button className="btn ghost sm" data-testid="mdl-card-toggle" onClick={() => setOpen(v => !v)}>
+          {open ? "Hide" : "View README"}
+        </button>
+      </div>
+      {open && (
+        <div style={{marginTop: 8}}>
+          {card.isPending && (
+            <div className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>Fetching model card…</div>
+          )}
+          {card.isError && (
+            <div className="mono" style={{fontSize: 11, color: "var(--err)"}}>
+              {card.error?.message || "Model card unavailable."}
+            </div>
+          )}
+          {card.data && (
+            <>
+              {card.data.stale && (
+                <div className="mono" style={{fontSize: 10.5, color: "var(--warn)", marginBottom: 6}}>
+                  huggingface.co unreachable — showing the cached copy.
+                </div>
+              )}
+              <pre
+                data-testid="mdl-card-body"
+                style={{
+                  margin: 0, maxHeight: 320, overflow: "auto",
+                  whiteSpace: "pre-wrap", wordBreak: "break-word",
+                  fontFamily: "var(--jbm)", fontSize: 11, lineHeight: 1.55,
+                  color: "var(--fg-3)", background: "transparent",
+                  padding: "8px 10px", border: "1px solid var(--line-soft)",
+                  borderRadius: "var(--rad-sm)",
+                }}
+              >{card.data.markdown}</pre>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── ModelDetail ───────────────────────────────────────────────────────
-function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
+function ModelDetail({ model, onDelete, onEdit, onPullStarted, updatable }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
   const swap = useSlotSwap();
@@ -529,7 +644,12 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
               : <span style={{color: "var(--fg-5)"}}>{Icons.download}</span>}
           </span>
           <div className="nm mono">{model.longName || model.name || model.id}</div>
-          <span style={{marginLeft: "auto"}}>
+          <span style={{marginLeft: "auto", display: "inline-flex", gap: 6}}>
+            {updatable && (
+              <span className="chip amber" data-testid="mdl-detail-update-available" title="A newer build of this file is available in the HF repo">
+                {Icons.restart} update available
+              </span>
+            )}
             {model.installed
               ? <span className="chip ok">installed</span>
               : isUpstreamModel(model)
@@ -572,9 +692,31 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       </div>
       <UsedByPanel model={model} />
       <OnDiskPanel model={model} />
+      <ModelCardPanel key={model.id} model={model} />
       <div className="mdl-detail-actions">
         {model.installed ? (
           <>
+            {updatable && (
+              <button
+                className="btn"
+                data-testid="mdl-detail-update"
+                disabled={pull.inFlight}
+                title="Re-pull this file from the HF repo (atomic in-place swap)"
+                onClick={async () => {
+                  try {
+                    await pull.start(model.id);
+                    window.dispatchEvent(new CustomEvent("hal0:pull-started", { detail: { modelId: model.id } }));
+                    window.__hal0Toast && window.__hal0Toast(
+                      `Updating ${model.longName || model.id} from ${model.hf_repo || "HF"}…`, "info",
+                    );
+                  } catch (e) {
+                    window.__hal0Toast && window.__hal0Toast(
+                      `Update failed — ${e?.message || "see logs"}`, "err",
+                    );
+                  }
+                }}
+              >{Icons.restart} {pull.inFlight ? `Updating ${pull.pct ?? 0}%` : "Update"}</button>
+            )}
             <button
               className="btn"
               disabled={swap.isPending}
@@ -746,4 +888,4 @@ function DownloadsPane() {
   );
 }
 
-Object.assign(window, { ModelsView, ModelRow, ModelDetail, DownloadsPane, DownloadRow, HfSearchPanel });
+Object.assign(window, { ModelsView, ModelRow, ModelDetail, ModelCardPanel, DownloadsPane, DownloadRow, HfSearchPanel });

--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -16,6 +16,8 @@
 import { test as base, Page, Route } from '@playwright/test'
 import {
   MOCK_DATA,
+  MODEL_UPDATES,
+  MODEL_CARD_MARKDOWN,
   BOARD_BOARDS,
   BOARD_PROFILES,
   BOARD_ASSIGNEES,
@@ -89,6 +91,38 @@ export async function installDefaultMocks(page: Page, state: MockState) {
   await page.route('**/api/models', (route) =>
     json(route, { models: state.models, count: state.models.length }),
   )
+  // Downloads-pane job list. Must be an ARRAY — the broad `{}` catch-all
+  // crashes usePullsList (`jobs.some is not a function`) which takes the
+  // Footer (and with it the whole page) down in mock mode.
+  await page.route('**/api/models/pulls', (route) => json(route, []))
+  // HF update-availability probe + update-all apply + cached model card.
+  // Regexes anchor the path segment so `updates` never swallows
+  // `updates/apply` and `card` matches with or without ?refresh=.
+  await page.route(/\/api\/models\/updates(\?|$)/, (route) =>
+    json(route, MODEL_UPDATES),
+  )
+  await page.route('**/api/models/updates/apply', (route) =>
+    json(route, {
+      started: MODEL_UPDATES.available.map((id, i) => ({
+        model_id: id,
+        job_id: `mock-upd-${i}`,
+        state: 'queued',
+      })),
+      skipped: [],
+      count: MODEL_UPDATES.available.length,
+    }, 202),
+  )
+  await page.route(/\/api\/models\/[^/]+\/card(\?|$)/, (route) => {
+    const m = route.request().url().match(/\/api\/models\/([^/]+)\/card/)
+    return json(route, {
+      model_id: decodeURIComponent(m?.[1] ?? ''),
+      hf_repo: 'unsloth/Qwen3.6-27B-GGUF',
+      markdown: MODEL_CARD_MARKDOWN,
+      cached: false,
+      stale: false,
+      fetched_at: 1_720_000_000,
+    })
+  })
   await page.route('**/api/slots', (route) => json(route, { slots: state.slots }))
   await page.route('**/api/slots/metrics', (route) => json(route, {}))
   await page.route('**/api/backends', (route) => json(route, { backends: state.backends }))

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -345,6 +345,48 @@ export const MOCK_DATA = {
 
 export type MockData = typeof MOCK_DATA
 
+// ── HF model updates + model card (feat: hf-model-updates) ────────────────
+//
+// IDs match HAL0_DATA.models (src/dash/data.jsx) — the forced-mock
+// (VITE_MOCK_HAL0=1) catalog the e2e suite renders — NOT the
+// MOCK_DATA.models list above. One installed model (qwen3.6-27b-mtp) is
+// flagged update_available so the row badge + "Update all" header button
+// render; the coder row is up_to_date so specs can assert the badge is
+// per-row, not global.
+
+export const MODEL_UPDATES = {
+  updates: [
+    {
+      model_id: 'qwen3.6-27b-mtp',
+      hf_repo: 'unsloth/Qwen3.6-27B-A3B-MTP-GGUF',
+      hf_filename: 'Qwen3.6-27B-MTP-Q4_K_M.gguf',
+      local_sha256: 'a'.repeat(64),
+      remote_sha256: 'b'.repeat(64),
+      status: 'update_available',
+      update_available: true,
+      checked_at: 1_720_000_000,
+      error: null,
+    },
+    {
+      model_id: 'qwen3-coder-30b',
+      hf_repo: 'unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF',
+      hf_filename: 'Qwen3-Coder-30B-A3B-Q4_K_M.gguf',
+      local_sha256: 'c'.repeat(64),
+      remote_sha256: 'c'.repeat(64),
+      status: 'up_to_date',
+      update_available: false,
+      checked_at: 1_720_000_000,
+      error: null,
+    },
+  ],
+  available: ['qwen3.6-27b-mtp'],
+  count: 2,
+  available_count: 1,
+}
+
+export const MODEL_CARD_MARKDOWN =
+  '# Qwen3.6 27B\n\nMock model card for e2e — quantised GGUF build.\n'
+
 // ── Operator Board mock data (feat/operator-board) ─────────────────────────
 //
 // Ported from /home/halo/Development/Projects/hal0/kanban/board/board-data.jsx.

--- a/ui/tests/e2e/specs/models-updates-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-updates-v3.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * models-updates-v3 — HF update-availability surface on the Models page.
+ *
+ * Backed by GET /api/models/updates (sha probe, mocked via MODEL_UPDATES):
+ * qwen3.6-27b-q5kxl has a newer build upstream, qwen3-coder-next-q4kxl is
+ * up to date. Asserts the per-row badge, the header "Update all" button
+ * (→ POST /api/models/updates/apply), the detail-pane update affordances,
+ * and the Model card section (GET /api/models/{id}/card).
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+test.describe('Models v3 — HF updates + model card', () => {
+  test('update badge renders only on outdated rows', async ({ page }) => {
+    await page.goto('/#models')
+    const outdated = page.locator('.mdl-row', { hasText: 'Qwen3.6-27B-MTP' })
+    await expect(outdated.getByTestId('mdl-row-update-available')).toBeVisible()
+    const upToDate = page.locator('.mdl-row', { hasText: 'Qwen3-Coder-30B-A3B' })
+    await expect(upToDate.getByTestId('mdl-row-update-available')).toHaveCount(0)
+  })
+
+  test('Update all header button posts to updates/apply', async ({ page }) => {
+    await page.goto('/#models')
+    const btn = page.getByTestId('mdl-update-all')
+    await expect(btn).toBeVisible()
+    await expect(btn).toContainText('Update all · 1')
+    const [req] = await Promise.all([
+      page.waitForRequest(
+        (r) => r.url().includes('/api/models/updates/apply') && r.method() === 'POST',
+      ),
+      btn.click(),
+    ])
+    expect(req).toBeTruthy()
+  })
+
+  test('detail pane shows update chip + per-model Update action', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.mdl-row', { hasText: 'Qwen3.6-27B-MTP' }).click()
+    await expect(page.getByTestId('mdl-detail-update-available')).toBeVisible()
+    await expect(page.getByTestId('mdl-detail-update')).toBeVisible()
+    // Selecting the up-to-date model hides both affordances.
+    await page.locator('.mdl-row', { hasText: 'Qwen3-Coder-30B-A3B' }).click()
+    await expect(page.getByTestId('mdl-detail-update-available')).toHaveCount(0)
+    await expect(page.getByTestId('mdl-detail-update')).toHaveCount(0)
+  })
+
+  test('model card section fetches and renders the README', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.mdl-row', { hasText: 'Qwen3.6-27B-MTP' }).click()
+    const toggle = page.getByTestId('mdl-card-toggle')
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+    await expect(page.getByTestId('mdl-card-body')).toContainText('Mock model card for e2e')
+    // Collapses back.
+    await toggle.click()
+    await expect(page.getByTestId('mdl-card-body')).toHaveCount(0)
+  })
+})

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## What

Lets users update their models when the HF repo re-uploads a newer build of the same file, and read each model's README/model card in the dashboard.

### Update checks (backend)

- **`hal0/registry/updates.py`** — `HEAD`s each HF-sourced row's `resolve/main` URL and compares the advertised `X-Linked-ETag` LFS sha256 against the sha256 the pull recorded in `metadata.sha256` (the same header the pull path already verifies against, WS-12). Remote ≠ local ⇒ update available. Rows that can't be compared honestly report `unknown` (no local sha — scanned/hand-registered files; non-LFS files) or `error` (HF unreachable), never a false positive.
- Probes are TTL-cached (30 min) per `(repo, filename)` coordinate; `update_available` is recomputed against the registry's *current* local sha at read time, so a completed re-pull flips a row to up-to-date with no cache invalidation.
- **`GET /api/models/updates`** — statuses + `available` list; `?refresh=true` re-probes and emits a `model.updates_available` event.
- **`POST /api/models/updates/apply`** — "Update all": re-pulls every outdated model (or an explicit `model_ids` subset) through the existing pull machinery — same job store, SSE progress, footer events, and atomic in-place `os.replace` swap. Active pulls and rows without HF coords are skipped with reasons.
- Mounted before the main models router so the literal `/api/models/updates` path wins over `GET /{model_id}`.

### Model cards (backend)

- **`hal0/registry/cards.py`** + **`GET /api/models/{id}/card`** — downloads the repo's `README.md` (`raw/main`, plain git blob) once and caches it under `/var/lib/hal0/model-cards/<id>.md`; subsequent reads are offline-fast. 512 KiB cap with a truncation marker; `?refresh=true` re-fetches with a stale-cache fallback when HF is down; the cache is dropped on model delete.

### Dashboard

- Amber **`update` chip** on catalog rows whose file has a newer build upstream (`data-testid="mdl-row-update-available"`).
- **`Update all · N`** button in the Models page header (`mdl-update-all`) → `POST /updates/apply`, jobs land in the existing Downloads pane.
- Detail pane: **update chip + one-click Update** action for the selected model.
- Collapsible **"Model card"** section in the detail sidebar — View README / Refresh, rendered from the server cache.
- New hooks (`useModelUpdates`, `useModelUpdatesApply`, `useModelCard`, `useModelCardRefresh`) fail soft against older backends.

## Tests

- `tests/registry/test_updates.py` (11) — sha compare matrix, TTL/refresh caching, coordinate dedup, error capture, post-re-pull recompute.
- `tests/registry/test_cards.py` (9) — fetch/persist/cache, refresh, stale fallback, truncation, 404s.
- `tests/api/test_model_updates_routes.py` (8) + `tests/api/test_model_card_route.py` (4) — route shapes, path-shadowing guard, apply skip reasons, delete cascade.
- `ui/tests/e2e/specs/models-updates-v3.spec.ts` (4) — row badge, Update all → POST, detail affordances, model card render.
- Fixture fix: mocked `/api/models/pulls` as an array — the `{}` catch-all crashed `usePullsList` and took the whole page down in mock mode, which un-breaks the pre-existing `models-v3.spec.ts` (1/12 → 12/12 passing).

`tests/registry` + `tests/api`: 1443 passed; the single failure (`test_settings_models_store::test_set_store_rejects_non_writable_path`) also fails on a clean `main` checkout — pre-existing, unrelated.

## CI status note

The γ-suite (chromium) check on this PR reports **3 failed / 385 passed** — the 3 failures are the NPU-occupancy specs (`slots-v3.spec.ts:36`, `npu-occupancy-v3.spec.ts:92`, `inference-pane-v3.spec.ts:230`). These same specs already fail on `main`: the base commit's run ([66726e6e, run 29120417175](https://github.com/Hal0ai/hal0/actions/runs/29120417175)) shows **29 failed / 349 passed**, a superset including these 3. This PR's `/api/models/pulls` fixture fix repairs the other 26; the remaining 3 are unrelated to this diff (NPU occupancy card / FLM slot card mocks) and are left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJfPACpbJTUBsokg4wKZUw