### PR TITLE
feat(chat): retarget agent-chat slide-out to the hal0-brain profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,9 @@ A persona is a TOML file under `/var/lib/hal0/agents/hermes/personas/`
 declaring (`id`, `display_name`, `summary`, `system_prompt`,
 `tools_allowed`, `memory_namespace`, `preferred_upstream`,
 `preferred_model`, `approval.{default_policy, auto_approve,
-require_approval}`). The provisioner seeds two: `hermes` (general) and `coder`.
+require_approval}`). The provisioner seeds three: `hermes` (general), `coder`,
+and `hal0-brain` (the dashboard agent-chat platform steward — own memory
+namespace, targets the `brain` slot via `hal0/brain` by default).
 The active persona is the contents of `active.txt`; switching personas
 swaps the system-prompt scope on the next turn without restarting the
 agent process. Configured per-agent via `GET/POST

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+- `hal0-brain` agent profile: a third seeded persona (alongside `hermes` and `coder`) that stewards the platform from the dashboard's agent-chat slide-out — its own memory namespace (`private:hal0-brain`), a hal0-heavy system prompt (slot lifecycle, model setup, benchmarking), and the dedicated `brain` slot (`hal0/brain`) as the default model.
+- Board/agent chat streams a `{type:"thinking"}` SSE frame: explicit `reasoning_content` and inline `<think>…</think>` blocks are split out of the reply and rendered as a folded "thinking" section instead of raw tags.
+
+### Changed
+- The top-bar agent chat now embodies the `hal0-brain` profile: it runs on `hal0/brain` (falls back to the `agent` slot via the resolver chain), and an operator-edited `hal0-brain` persona TOML overrides its system prompt/model without a code change.
+- Agent-chat suggestion chips are now platform-steward starters ("Help me create a new slot", "Download and set up a model", "Benchmark the model on a slot", "How's the hardware doing?").
+- Agent-chat replies render markdown (fences, lists, headings, bold/italic/inline code, links); tool calls render as structured cards with args, live status, and a folded result — replacing the raw `→ tool({json})` text rows.
+
 ## [0.9.6] — 2026-07-10
 
 ### Highlights

--- a/src/hal0/agents/personas.py
+++ b/src/hal0/agents/personas.py
@@ -375,10 +375,11 @@ def activate(
 
 # ── Seed personas (Phase 8) ─────────────────────────────────────────────────
 #
-# The two personas seeded at provision time. Per master-plan §6 the
-# user picked ``hermes`` (default) + ``coder`` — they share the hal0 MCP
-# tooling but differ on tone, tools-allowed, and memory namespace so
-# context from coding sessions doesn't bleed into general chat.
+# The personas seeded at provision time. Per master-plan §6 the user picked
+# ``hermes`` (default) + ``coder``; ``hal0-brain`` was added for the
+# dashboard's agent-chat slide-out. They share the hal0 MCP tooling but
+# differ on tone, tools-allowed, and memory namespace so context from one
+# surface doesn't bleed into another.
 
 
 def _seed_hermes(agent_id: str) -> Persona:
@@ -450,21 +451,77 @@ def _seed_coder(agent_id: str) -> Persona:
     )
 
 
+def _seed_hal0_brain(agent_id: str) -> Persona:
+    """The dashboard agent-chat profile — the platform steward.
+
+    This is the persona the top-bar slide-out chat embodies (see
+    ``hal0.api.routes.board_chat``): its own memory bank so platform-admin
+    context never bleeds into the operator's general Hermes chat, a
+    hal0-heavy system prompt, and the dedicated ``brain`` slot as the
+    default model (``hal0/brain`` falls back to the ``agent`` slot via the
+    resolver chain when the brain slot isn't loaded).
+    """
+    return Persona(
+        id="hal0-brain",
+        display_name="hal0 Brain",
+        summary="Platform steward behind the dashboard agent chat — slots, models, benchmarks.",
+        system_prompt=(
+            "You are hal0-brain, the resident platform steward of this hal0 home "
+            "AI box, embedded in the dashboard's agent chat. You administer the "
+            "instance itself: inference slots (create, configure, load/unload/"
+            "restart), the model library (find, download, set up models), "
+            "benchmarks (prepare a slot and interpret hal0-bench runs), hardware "
+            "headroom (RAM/VRAM/GTT, GPU/NPU), the Operator Board, and "
+            "orchestration settings. Read state before mutating it and never "
+            "guess slot names or task ids. Slot load/unload/restart are "
+            "disruptive — only on explicit operator request. For multi-step work "
+            "(new slot, model setup, benchmark run) lay out a short plan, then "
+            "execute step by step. Keep replies short and technical."
+        ),
+        tools_allowed=("*",),
+        # A dedicated private bank: platform-admin context (slot layouts, model
+        # choices, benchmark history) stays out of the general Hermes chat and
+        # the coder persona. Created lazily by Hindsight on first write.
+        memory_namespace="private:hal0-brain",
+        approval=PersonaApproval(
+            default_policy="ask",
+            auto_approve=(
+                "memory.read.*",
+                "search.*",
+                "slot.read.*",
+                "hal0_admin.read.*",
+                "kanban.read.*",
+                "bench.read.*",
+            ),
+            require_approval=(
+                "files.*",
+                "shell.*",
+                "admin.*",
+                "slot.write.*",
+                "hal0_admin.write.*",
+                "kanban.write.*",
+            ),
+        ),
+        preferred_upstream="hal0",
+        preferred_model="hal0/brain",
+    )
+
+
 def seed_default_personas(
     agent_id: str = "hermes",
     *,
     root: Path | None = None,
     overwrite: bool = False,
 ) -> list[Persona]:
-    """Idempotently seed the ``hermes`` + ``coder`` personas + active pointer.
+    """Idempotently seed ``hermes`` + ``coder`` + ``hal0-brain`` + active pointer.
 
-    On first install both files are written and ``active.txt`` is set to
+    On first install the files are written and ``active.txt`` is set to
     ``hermes``. On re-run (``overwrite=False``) existing files are left
     alone so operator edits survive — only missing personas get written.
     With ``overwrite=True`` the seeds are forcibly re-written; used by
     ``--repair`` to recover from a corrupted operator edit.
     """
-    seeds = [_seed_hermes(agent_id), _seed_coder(agent_id)]
+    seeds = [_seed_hermes(agent_id), _seed_coder(agent_id), _seed_hal0_brain(agent_id)]
     written: list[Persona] = []
     for persona in seeds:
         path = _personas_root(root) / f"{persona.id}.toml"

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -1,9 +1,12 @@
 """Platform assistant chat orchestrator — ``POST /api/board/chat`` (SSE).
 
 SPEC §2.D grown into the platform surface: a hal0-NATIVE conversational agent
-that administers the whole instance, not just the board. hal0-api runs a
-client-side OpenAI tool-calling loop whose LLM is the hal0 ``agent`` slot
-(reached via hal0-api's own ``/v1/chat/completions`` surface, mirroring
+that administers the whole instance, not just the board. The surface embodies
+the ``hal0-brain`` profile (separate memory namespace, hal0-heavy context;
+persona TOML overrides the built-in prompt/model when present) and hal0-api
+runs a client-side OpenAI tool-calling loop whose LLM is the hal0 ``brain``
+slot, falling back to ``agent`` via the resolver chain (reached via hal0-api's
+own ``/v1/chat/completions`` surface, mirroring
 :class:`hal0.omni_router.OmniRouter`). Three tool families:
 
 * **Board reads** (unaudited, via :class:`HermesKanbanClient` — mirrors the
@@ -25,6 +28,7 @@ Hermes agent via chat_proxy WITHOUT any UI change):
 
     SSE events, one JSON object per ``data:`` line:
       {"type": "token",  "text": "..."}            assistant token delta
+      {"type": "thinking", "text": "..."}           model reasoning (never shown inline)
       {"type": "tool_call",   "name": "...", "arguments": {...}, "id": "..."}
       {"type": "tool_result", "name": "...", "id": "...", "result": {...}}
       {"type": "done"}                              end of turn
@@ -40,6 +44,7 @@ production it is wired to hal0-api's ``/v1/chat/completions`` against the
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
@@ -56,32 +61,59 @@ log = structlog.get_logger(__name__)
 # forever (mirrors OmniRouter._MAX_LOOP_ROUNDS).
 _MAX_ROUNDS = 8
 
-# The slot the orchestrator drives. Points at the `agent` slot — the
-# tool-calling orchestrator model — rather than the conversational `chat`
-# slot (hal0/chat): board chat IS an agentic surface (it drives audited
-# board mutations via tool-calls), so the agent model is the correct brain.
-# (Named PRIMARY_SLOT_MODEL for back-compat; resolves via the resolver chains.)
-PRIMARY_SLOT_MODEL = "hal0/agent"
+# The slot the steward drives. Points at the dedicated `brain` slot (the
+# hal0-brain profile's default model) — the resolver's generalized chain
+# (`hal0/<slot>` → (<slot>, agent)) falls back to the `agent` slot when no
+# brain slot is loaded, so the chat degrades to the orchestrator model
+# instead of failing. (PRIMARY_SLOT_MODEL kept as a back-compat alias.)
+BRAIN_SLOT_MODEL = "hal0/brain"
+PRIMARY_SLOT_MODEL = BRAIN_SLOT_MODEL
+
+# The agent profile (persona) this surface embodies. When a persona TOML with
+# this id exists in the personas store, its system prompt / preferred model
+# override the built-in defaults below — the operator edits ONE file and the
+# slide-out chat follows.
+BRAIN_PERSONA_ID = "hal0-brain"
 
 # Injected as the leading system message when the client doesn't send one.
 # Without it the LLM had ten write tools, no read tools, and no idea what the
 # lanes mean — it could mutate the board but never see it, so "what's
 # blocked?" or "move the auth task to review" was unanswerable.
 _SYSTEM_PROMPT = """\
-You are the hal0 platform assistant: a terse operations agent that
-administers this hal0 instance via tools — the Operator Board (kanban),
-inference slots, models, agent profiles, and orchestration settings.
+You are hal0-brain: the resident platform steward of this hal0 home AI box.
+You run as the dashboard's agent chat and administer the whole instance via
+tools — inference slots, the model library, benchmarks, hardware, the
+Operator Board (kanban), and orchestration settings. You keep your own
+memory, separate from the Hermes chat agent (namespace private:hal0-brain).
 
-Surfaces:
+hal0 context:
+- A *slot* is a named inference unit (systemd hal0-slot@<name>) binding one
+  model to a backend (llama.cpp Vulkan/ROCm, FLM on the NPU) with device,
+  context-length and throughput settings. Canonical slots: `agent` (the
+  tool-calling anchor every fallback chain ends in), `brain` (you),
+  `utility` (cheap helper), `npu` (NPU chat edge). Any enabled slot X is
+  addressable as the virtual model `hal0/X` via /v1/chat/completions.
+- Setting up a model means: find it in the library (list_models), download
+  the artifact (GGUF or FLM package), then bind it to a slot and load it.
+  Walk the operator through it step by step and confirm before each
+  disruptive move.
+- Benchmarking: hal0-bench drives a model on a slot and records throughput/
+  latency runs (dash → Benchmarks). You can prepare the slot (right model
+  loaded, others unloaded on request) and read hardware_stats to sanity-check
+  headroom before a run.
 - Board: lanes (the `status` values) are triage (new, awaiting spec), todo
   (specified and queued), scheduled (time-triggered), ready (claimed for
   dispatch), running (worker active), blocked (waiting on input; carries
   block_reason), review (needs operator sign-off), done, archived.
-- Slots: list_slots / get_slot report each inference slot's state (serving,
-  ready, warming, idle, offline, error), model and throughput;
-  slot_load / slot_unload / slot_restart change them.
+
+Tool surfaces:
+- Slots: list_slots / get_slot report each slot's state (serving, ready,
+  warming, idle, offline, error), model and throughput; slot_load /
+  slot_unload / slot_restart change them.
 - Catalogue: list_models (model library), list_agents (installed platform
   agents), hardware_stats (RAM/VRAM/GTT, GPU util, NPU status).
+- Board reads + audited mutations (get_board, move/assign/create/comment,
+  dependencies, specify/decompose, nudge_dispatcher).
 - Settings: get_orchestration / update_orchestration (board dispatcher knobs:
   orchestrator_profile, default_assignee, auto_decompose,
   auto_promote_children).
@@ -93,8 +125,31 @@ Rules:
 - Slot load/unload/restart are DISRUPTIVE (they can evict models and drop
   in-flight requests): do them only when the operator explicitly asks, and
   state what you did.
+- For multi-step work (create a slot, set up a model, run a benchmark) lay
+  out the short plan first, then execute step by step, reporting progress.
 - Prefer a clarifying question over a destructive guess. Keep replies short.
 """
+
+
+def _resolve_profile(request: Request) -> tuple[str, str]:
+    """Resolve (system_prompt, default_model) from the hal0-brain profile.
+
+    Reads the ``hal0-brain`` persona TOML from the personas store (root
+    overridable via ``app.state.brain_persona_root`` for tests). A missing or
+    malformed persona falls back to the built-in ``_SYSTEM_PROMPT`` /
+    ``BRAIN_SLOT_MODEL`` so the chat never breaks on a half-provisioned box.
+    """
+    from hal0.agents.personas import PersonaError, load_persona
+
+    root = getattr(request.app.state, "brain_persona_root", None)
+    try:
+        persona = load_persona(BRAIN_PERSONA_ID, root=root)
+    except (FileNotFoundError, PersonaError, OSError):
+        return _SYSTEM_PROMPT, BRAIN_SLOT_MODEL
+    prompt = persona.system_prompt.strip() or _SYSTEM_PROMPT
+    model = persona.preferred_model.strip() or BRAIN_SLOT_MODEL
+    return prompt, model
+
 
 #: LLM backend signature: an OpenAI chat-completion request body in, the
 #: parsed response dict out.
@@ -635,6 +690,40 @@ def _assistant_text(response: dict[str, Any]) -> str:
     return content if isinstance(content, str) else ""
 
 
+# Reasoning models interleave chain-of-thought with the reply, either as a
+# separate message field (DeepSeek-style ``reasoning_content``) or inline
+# ``<think>…</think>`` tags (Qwen-style). Both are split out and streamed as
+# ``thinking`` frames so the UI can fold them away instead of rendering raw
+# think-tags in the chat bubble.
+_THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+
+
+def _split_thinking(content: str) -> tuple[str, str]:
+    """Split ``<think>`` blocks out of assistant content → (thinking, visible)."""
+    if "<think>" not in content:
+        return "", content
+    thinking_parts = _THINK_RE.findall(content)
+    visible = _THINK_RE.sub("", content)
+    rest = visible.split("<think>", 1)
+    if len(rest) == 2:  # unterminated trailing <think> — all of it is reasoning
+        visible = rest[0]
+        thinking_parts.append(rest[1])
+    return "\n".join(p.strip() for p in thinking_parts if p.strip()), visible.strip()
+
+
+def _assistant_thinking(response: dict[str, Any]) -> str:
+    """Pull explicit reasoning fields off the assistant message."""
+    choices = response.get("choices") or []
+    if not choices:
+        return ""
+    msg = choices[0].get("message") or {}
+    for key in ("reasoning_content", "reasoning"):
+        value = msg.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
 def _assistant_message(response: dict[str, Any]) -> dict[str, Any] | None:
     choices = response.get("choices") or []
     if not choices:
@@ -656,14 +745,15 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
 
     llm = _resolve_llm(request)
     board = payload.get("board")
+    system_prompt, default_model = _resolve_profile(request)
     messages: list[dict[str, Any]] = list(payload.get("messages") or [])
     # Seed the system prompt unless the client sent its own — the model needs
     # the lane vocabulary and the read-before-write rule to act on the board.
     if not messages or not (isinstance(messages[0], dict) and messages[0].get("role") == "system"):
-        messages.insert(0, {"role": "system", "content": _SYSTEM_PROMPT})
+        messages.insert(0, {"role": "system", "content": system_prompt})
 
     body: dict[str, Any] = {
-        "model": payload.get("model") or PRIMARY_SLOT_MODEL,
+        "model": payload.get("model") or default_model,
         "messages": messages,
         "tools": _tool_schemas(),
         "stream": False,
@@ -677,7 +767,11 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
                 yield _sse({"type": "done"})
                 return
 
-            text = _assistant_text(response)
+            explicit_thinking = _assistant_thinking(response)
+            inline_thinking, text = _split_thinking(_assistant_text(response))
+            thinking = "\n".join(t for t in (explicit_thinking, inline_thinking) if t)
+            if thinking:
+                yield _sse({"type": "thinking", "text": thinking})
             if text:
                 yield _sse({"type": "token", "text": text})
 
@@ -740,6 +834,8 @@ async def run_board_chat(request: Request) -> StreamingResponse:
 
 
 __all__ = [
+    "BRAIN_PERSONA_ID",
+    "BRAIN_SLOT_MODEL",
     "PRIMARY_SLOT_MODEL",
     "_chat_stream",
     "_compact_board",

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -701,6 +701,11 @@ _THINK_RE = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 def _split_thinking(content: str) -> tuple[str, str]:
     """Split ``<think>`` blocks out of assistant content → (thinking, visible)."""
     if "<think>" not in content:
+        # DeepSeek-R1-style chat templates prefill the opening tag, so the
+        # completion can start mid-reasoning and carry only a closing tag.
+        if "</think>" in content:
+            reasoning, _, visible = content.partition("</think>")
+            return reasoning.strip(), visible.strip()
         return "", content
     thinking_parts = _THINK_RE.findall(content)
     visible = _THINK_RE.sub("", content)

--- a/src/hal0/normalize/resolver.py
+++ b/src/hal0/normalize/resolver.py
@@ -28,6 +28,10 @@ DEFAULT_CHAINS: dict[str, tuple[str, ...]] = {
     # hal0/utility → the cheap helper slot; falls back to the anchor when unloaded.
     "hal0/utility": ("utility", _ANCHOR_NAME),
     "hal0/npu": ("npu", "utility", _ANCHOR_NAME),
+    # hal0/brain → the dashboard agent-chat persona. No installer seeds a `brain`
+    # slot, so without a canonical entry the generalized chain below would pass the
+    # name through unresolved and every chat turn would 404 on a stock box.
+    "hal0/brain": ("brain", _ANCHOR_NAME),
 }
 
 

--- a/tests/agents/test_personas.py
+++ b/tests/agents/test_personas.py
@@ -116,12 +116,26 @@ def test_set_active_refuses_missing_persona(tmp_path: Path) -> None:
         P.set_active("ghost", root=tmp_path)
 
 
-def test_seed_default_personas_writes_two_files_and_pointer(tmp_path: Path) -> None:
+def test_seed_default_personas_writes_files_and_pointer(tmp_path: Path) -> None:
     written = P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
-    assert {p.id for p in written} == {"hermes", "coder"}
+    assert {p.id for p in written} == {"hermes", "coder", "hal0-brain"}
     assert (tmp_path / "hermes.toml").exists()
     assert (tmp_path / "coder.toml").exists()
+    assert (tmp_path / "hal0-brain.toml").exists()
     assert (tmp_path / P.ACTIVE_POINTER).read_text().strip() == "hermes"
+
+
+def test_seed_hal0_brain_targets_brain_slot_with_own_memory(tmp_path: Path) -> None:
+    """The dashboard agent-chat profile: brain slot default + separate memory."""
+    P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    brain = P.load_persona("hal0-brain", root=tmp_path)
+    assert brain.preferred_model == "hal0/brain"
+    assert brain.preferred_upstream == "hal0"
+    assert brain.memory_namespace == "private:hal0-brain"
+    # Its memory bank is its own — distinct from the other seeds.
+    others = {P.load_persona(p, root=tmp_path).memory_namespace for p in ("hermes", "coder")}
+    assert brain.memory_namespace not in others
+    assert "platform steward" in brain.system_prompt
 
 
 def test_seed_default_personas_idempotent_no_overwrite(tmp_path: Path) -> None:
@@ -147,7 +161,7 @@ def test_seed_default_personas_overwrite_restores_defaults(tmp_path: Path) -> No
         encoding="utf-8",
     )
     written = P.seed_default_personas(agent_id="hermes-agent", root=tmp_path, overwrite=True)
-    assert {p.id for p in written} == {"hermes", "coder"}
+    assert {p.id for p in written} == {"hermes", "coder", "hal0-brain"}
     loaded = P.load_persona("hermes", root=tmp_path)
     assert loaded.display_name == "Hermes"
 

--- a/tests/api/test_agents_personas.py
+++ b/tests/api/test_agents_personas.py
@@ -56,7 +56,7 @@ def test_list_returns_seeded_personas(client: TestClient, seeded_personas: Path)
     assert body["agent_id"] == "hermes"
     assert body["active"] == "hermes"
     ids = sorted(row["id"] for row in body["personas"])
-    assert ids == ["coder", "hermes"]
+    assert ids == ["coder", "hal0-brain", "hermes"]
     hermes_row = next(row for row in body["personas"] if row["id"] == "hermes")
     assert hermes_row["active"] is True
     assert hermes_row["display_name"] == "Hermes"

--- a/tests/api/test_persona_update.py
+++ b/tests/api/test_persona_update.py
@@ -83,7 +83,7 @@ def test_update_cannot_change_id(client: TestClient, seeded: Path) -> None:
     assert r.status_code == 200, r.text
     assert r.json()["id"] == "hermes"
     # No stray persona file was created.
-    assert {p.stem for p in seeded.glob("*.toml")} == {"hermes", "coder"}
+    assert {p.stem for p in seeded.glob("*.toml")} == {"hermes", "coder", "hal0-brain"}
 
 
 def test_update_preserves_budget(client: TestClient, seeded: Path) -> None:

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -691,6 +691,14 @@ def test_split_thinking_unterminated_tag() -> None:
     assert visible == ""
 
 
+def test_split_thinking_closing_tag_only() -> None:
+    """R1-style chat templates prefill the opening <think>, so the completion
+    can carry only the closing tag — everything before it is reasoning."""
+    thinking, visible = _split_thinking("chain of thought here</think>the reply")
+    assert thinking == "chain of thought here"
+    assert visible == "the reply"
+
+
 def test_split_thinking_passthrough_without_tags() -> None:
     thinking, visible = _split_thinking("plain reply")
     assert thinking == ""

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -23,11 +23,13 @@ from hal0.api.middleware import error_codes
 from hal0.api.routes import board
 from hal0.api.routes.board_chat import (
     _SYSTEM_PROMPT,
+    BRAIN_SLOT_MODEL,
     _compact_board,
     _extract_tool_calls,
     _resolve_platform_tool,
     _resolve_read_tool,
     _resolve_tool,
+    _split_thinking,
     _tool_schemas,
 )
 from hal0.board import KANBAN_BASE_PATH, HermesKanbanClient
@@ -173,6 +175,9 @@ def _make_app(
     store.init_schema()
     app.state.audit = store
     app.state.board_chat_llm = stub
+    # Isolate from any real hal0-brain persona on the test box — an empty
+    # root makes _resolve_profile fall back to the built-in prompt/model.
+    app.state.brain_persona_root = tmp_path / "personas"
     return app, TestClient(app)
 
 
@@ -593,6 +598,103 @@ def test_system_prompt_not_duplicated_when_client_sends_one(tmp_path) -> None:
     sent = stub.calls[0]["messages"]
     assert sent[0] == {"role": "system", "content": "custom"}
     assert sum(1 for m in sent if m.get("role") == "system") == 1
+
+
+# ── hal0-brain profile (model default + persona override) ───────────────────
+
+
+def test_default_model_is_brain_slot(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "hello"}]})
+    assert stub.calls[0]["model"] == BRAIN_SLOT_MODEL == "hal0/brain"
+
+
+def test_payload_model_overrides_default(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    client.post(
+        "/api/board/chat",
+        json={"messages": [{"role": "user", "content": "hello"}], "model": "hal0/utility"},
+    )
+    assert stub.calls[0]["model"] == "hal0/utility"
+
+
+def test_hal0_brain_persona_overrides_prompt_and_model(tmp_path) -> None:
+    from hal0.agents.personas import Persona, save_persona
+
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    app, client = _make_app(rec, stub, tmp_path)
+    save_persona(
+        Persona(
+            id="hal0-brain",
+            display_name="hal0 Brain",
+            system_prompt="operator-tuned steward prompt",
+            preferred_model="hal0/custom-brain",
+        ),
+        root=app.state.brain_persona_root,
+    )
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "hello"}]})
+    sent = stub.calls[0]
+    assert sent["model"] == "hal0/custom-brain"
+    assert sent["messages"][0] == {"role": "system", "content": "operator-tuned steward prompt"}
+
+
+# ── thinking frames (reasoning models) ──────────────────────────────────────
+
+
+def test_reasoning_content_streams_as_thinking_frame(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM(
+        [
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "the answer",
+                            "reasoning_content": "let me check the slots",
+                        }
+                    }
+                ]
+            }
+        ]
+    )
+    _app, client = _make_app(rec, stub, tmp_path)
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    events = _sse_events(resp.text)
+    thinking = next(e for e in events if e["type"] == "thinking")
+    assert thinking["text"] == "let me check the slots"
+    token = next(e for e in events if e["type"] == "token")
+    assert token["text"] == "the answer"
+    assert events.index(thinking) < events.index(token)
+
+
+def test_inline_think_tags_split_into_thinking_frame(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("<think>ponder ponder</think>the reply")])
+    _app, client = _make_app(rec, stub, tmp_path)
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    events = _sse_events(resp.text)
+    thinking = next(e for e in events if e["type"] == "thinking")
+    assert thinking["text"] == "ponder ponder"
+    token = next(e for e in events if e["type"] == "token")
+    assert token["text"] == "the reply"
+
+
+def test_split_thinking_unterminated_tag() -> None:
+    thinking, visible = _split_thinking("<think>still going")
+    assert thinking == "still going"
+    assert visible == ""
+
+
+def test_split_thinking_passthrough_without_tags() -> None:
+    thinking, visible = _split_thinking("plain reply")
+    assert thinking == ""
+    assert visible == "plain reply"
 
 
 # ── loop termination + errors ───────────────────────────────────────────────

--- a/tests/harness/integration/test_v0_3_persona_activate.py
+++ b/tests/harness/integration/test_v0_3_persona_activate.py
@@ -65,7 +65,7 @@ def test_persona_list_reflects_seeded_personas(
     assert body["agent_id"] == "hermes"
     assert body["active"] == "hermes"
     ids = sorted(row["id"] for row in body["personas"])
-    assert ids == ["coder", "hermes"]
+    assert ids == ["coder", "hal0-brain", "hermes"]
 
 
 def test_persona_activate_writes_active_txt(

--- a/tests/normalize/test_resolver.py
+++ b/tests/normalize/test_resolver.py
@@ -36,6 +36,26 @@ def test_removed_aliases_are_unknown():
     assert resolve_chain("hal0/flm", _slots(), loaded={"qwen3-4b-FLM"}) is None
 
 
+def test_brain_falls_back_to_agent_when_no_brain_slot():
+    """hal0/brain is the dashboard agent-chat default. No installer seeds a
+    `brain` slot, so the canonical chain must degrade to the agent anchor on a
+    stock box instead of passing the name through unresolved (404)."""
+    r = resolve_chain("hal0/brain", _slots(), loaded={"big-35b"})
+    assert r is not None
+    assert r.model_id == "big-35b"
+    assert r.matched_name == "agent"
+
+
+def test_brain_prefers_brain_slot_when_present():
+    slots = [
+        *_slots(),
+        SlotView(name="brain", device="gpu-vulkan", model_id="brainy-8b", context_length=32768),
+    ]
+    r = resolve_chain("hal0/brain", slots, loaded={"brainy-8b", "big-35b"})
+    assert r.model_id == "brainy-8b"
+    assert r.matched_name == "brain"
+
+
 def test_npu_picks_npu_first_never_commandeers_agent():
     r = resolve_chain("hal0/npu", _slots(), loaded={"qwen3-4b-FLM", "big-35b"})
     assert r.model_id == "qwen3-4b-FLM"

--- a/ui/CONTRACTS.md
+++ b/ui/CONTRACTS.md
@@ -233,9 +233,12 @@ flat task list the hook buckets by `status`). Empty board ⇒ all 8 lanes render
 - Orchestration popover: only the 4 PUT knobs are editable (no auto/manual "mode" — the
   server has no such field). tick-interval / failure-limit / claim-TTL / max-in-flight are
   read from `/config` and rendered **read-only with a note**.
-- The `/chat` agent is the PLATFORM assistant: board tools (reads + audited mutations,
-  incl. get/update_orchestration) plus hal0-api self-HTTP tools (slots list/get/
-  load/unload/restart, models, hardware stats, installed agents). Same SSE frame contract.
+- The `/chat` agent is the hal0-brain PLATFORM steward (profile `hal0-brain`, default
+  model `hal0/brain` → falls back to the `agent` slot via the resolver chain): board
+  tools (reads + audited mutations, incl. get/update_orchestration) plus hal0-api
+  self-HTTP tools (slots list/get/load/unload/restart, models, hardware stats,
+  installed agents). SSE frame contract adds `{type:"thinking",text}` (model
+  reasoning, rendered folded) alongside token/tool_call/tool_result/done/error.
 - Drag-and-drop outside any lane ARCHIVES the card (`board-drop-archive` /
   `board-archive-veil`); nothing on the board hard-deletes without an explicit action.
 - "Nudge dispatcher" = one-shot `POST /dispatch?max=N`. No continuous start/stop.

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -1049,13 +1049,27 @@ export function useBoardEventsStream(
 
 // ── Board chat (SSE via fetch) ────────────────────────────────────────
 
+export interface ChatToolCall {
+  name?: string
+  arguments?: unknown
+  id?: string
+}
+
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'tool'
   body: string
   at?: string
   refs?: string[]
   streaming?: boolean
-  tool_call?: unknown
+  tool_call?: ChatToolCall
+  /** Model reasoning (`thinking` SSE frames / `<think>` blocks) — folded away by the UI. */
+  thinking?: string
+  /** Tool messages: the matched tool_result payload once it lands. */
+  result?: unknown
+  /** Tool messages: running → done | error as the result frame arrives. */
+  status?: 'running' | 'done' | 'error'
+  /** Internal streaming marker: which assistant segment of which turn this bubble is. */
+  seg?: string
 }
 
 export interface UseBoardChatResult {
@@ -1064,10 +1078,31 @@ export interface UseBoardChatResult {
   streaming: boolean
 }
 
-// Board chat runs on the `agent` slot (the tool-calling orchestrator model),
-// not the conversational `chat` slot. Sent explicitly so it routes correctly
-// regardless of the backend's PRIMARY_SLOT_MODEL default.
-const BOARD_CHAT_MODEL = 'hal0/agent'
+// The agent chat embodies the hal0-brain profile, which targets the dedicated
+// `brain` slot by default (hal0/brain falls back to the `agent` slot via the
+// resolver chain when no brain slot is loaded). Sent explicitly so it routes
+// correctly regardless of the backend's default.
+const BOARD_CHAT_MODEL = 'hal0/brain'
+
+// Client-side guard for reasoning models that inline `<think>…</think>` in
+// content: the backend already splits these into `thinking` frames, but an
+// older backend streaming raw think-tags must never show them in the bubble.
+function splitThink(text: string): { thinking: string; visible: string } {
+  if (!text.includes('<think>')) return { thinking: '', visible: text }
+  const parts: string[] = []
+  let visible = text.replace(/<think>([\s\S]*?)<\/think>/g, (_m, inner: string) => {
+    if (inner.trim()) parts.push(inner.trim())
+    return ''
+  })
+  const open = visible.indexOf('<think>')
+  if (open !== -1) {
+    // Unterminated trailing block — everything after the tag is reasoning.
+    const inner = visible.slice(open + '<think>'.length)
+    if (inner.trim()) parts.push(inner.trim())
+    visible = visible.slice(0, open)
+  }
+  return { thinking: parts.join('\n'), visible }
+}
 
 export function useBoardChat(board?: string): UseBoardChatResult {
   const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -1134,39 +1169,51 @@ export function useBoardChat(board?: string): UseBoardChatResult {
         const reader = res.body.getReader()
         const decoder = new TextDecoder()
         let accBody = ''
-        let assistantIdx = -1
+        let accThinking = ''
         let buf = ''
+        // Assistant "segment" tracking. Tool calls split the assistant text
+        // into separate bubbles (before/after the call). React batches the
+        // queued setMessages updaters, so the updater must not read shared
+        // mutable stream state — everything it needs is captured BY VALUE at
+        // queue time and the target bubble is found by its segment tag.
+        const turnTag = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+        let segment = 0
 
-        const appendAssistant = (delta: string) => {
-          accBody += delta
+        const upsertAssistant = () => {
+          // Re-split on every delta: think-tags can close in a later chunk.
+          const { thinking, visible } = splitThink(accBody)
+          const allThinking = [accThinking, thinking].filter(Boolean).join('\n')
+          const seg = `${turnTag}:${segment}`
           setMessages((prev) => {
             const next = [...prev]
-            if (assistantIdx === -1 || assistantIdx >= next.length) {
-              next.push({
-                role: 'assistant',
-                body: accBody,
-                streaming: true,
-              })
-              assistantIdx = next.length - 1
-            } else {
-              next[assistantIdx] = {
-                ...next[assistantIdx],
-                body: accBody,
-                streaming: true,
-              }
+            const msg: ChatMessage = {
+              role: 'assistant',
+              body: visible,
+              thinking: allThinking || undefined,
+              streaming: true,
+              seg,
             }
+            const idx = next.findIndex((m) => m.role === 'assistant' && m.seg === seg)
+            if (idx === -1) next.push(msg)
+            else next[idx] = { ...next[idx], ...msg }
             return next
           })
         }
 
+        const appendAssistant = (delta: string) => {
+          accBody += delta
+          upsertAssistant()
+        }
+
+        const appendThinking = (delta: string) => {
+          accThinking = accThinking ? `${accThinking}\n${delta}` : delta
+          upsertAssistant()
+        }
+
         const finaliseAssistant = () => {
-          setMessages((prev) => {
-            const next = [...prev]
-            if (assistantIdx >= 0 && assistantIdx < next.length) {
-              next[assistantIdx] = { ...next[assistantIdx], streaming: false }
-            }
-            return next
-          })
+          setMessages((prev) =>
+            prev.map((m) => (m.streaming ? { ...m, streaming: false } : m)),
+          )
         }
 
         // eslint-disable-next-line no-constant-condition
@@ -1207,21 +1254,57 @@ export function useBoardChat(board?: string): UseBoardChatResult {
                 // Assistant text delta (backend sends per-round content).
                 if (frame.text) appendAssistant(frame.text)
                 break
+              case 'thinking':
+                // Model reasoning — kept off the reply body, folded in the UI.
+                if (frame.text) appendThinking(frame.text)
+                break
               case 'tool_call':
-                // The orchestrator is invoking an audited board mutation.
+                // The steward is invoking a platform/board tool. Any assistant
+                // text that follows belongs to a NEW bubble, not the one
+                // preceding the call.
+                accBody = ''
+                accThinking = ''
+                segment += 1
                 setMessages((prev) => [
                   ...prev,
                   {
                     role: 'tool',
-                    body: `→ ${frame.name ?? 'tool'}(${JSON.stringify(frame.arguments ?? {})})`,
+                    body: frame.name ?? 'tool',
                     tool_call: { name: frame.name, arguments: frame.arguments, id: frame.id },
+                    status: 'running',
                   },
                 ])
                 break
-              case 'tool_result':
-                // Mutation landed — refresh the board so the change shows live.
+              case 'tool_result': {
+                // Attach the result to its tool message (matched by call id,
+                // falling back to the last unresolved call with that name),
+                // then refresh the board so mutations show live.
+                const rFrame = frame
+                setMessages((prev) => {
+                  const next = [...prev]
+                  for (let i = next.length - 1; i >= 0; i--) {
+                    const m = next[i]
+                    if (m.role !== 'tool' || m.status !== 'running') continue
+                    const idMatch = rFrame.id && m.tool_call?.id === rFrame.id
+                    const nameMatch = !rFrame.id && m.tool_call?.name === rFrame.name
+                    if (idMatch || nameMatch) {
+                      const isErr =
+                        !!rFrame.result &&
+                        typeof rFrame.result === 'object' &&
+                        'error' in (rFrame.result as Record<string, unknown>)
+                      next[i] = {
+                        ...m,
+                        result: rFrame.result,
+                        status: isErr ? 'error' : 'done',
+                      }
+                      break
+                    }
+                  }
+                  return next
+                })
                 qc.invalidateQueries({ queryKey: boardKey(board) })
                 break
+              }
               case 'error':
                 setMessages((prev) => [
                   ...prev,

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -1088,7 +1088,18 @@ const BOARD_CHAT_MODEL = 'hal0/brain'
 // content: the backend already splits these into `thinking` frames, but an
 // older backend streaming raw think-tags must never show them in the bubble.
 function splitThink(text: string): { thinking: string; visible: string } {
-  if (!text.includes('<think>')) return { thinking: '', visible: text }
+  if (!text.includes('<think>')) {
+    // R1-style templates prefill the opening tag, so content may carry only
+    // the closing tag — everything before it is reasoning.
+    const close = text.indexOf('</think>')
+    if (close !== -1) {
+      return {
+        thinking: text.slice(0, close).trim(),
+        visible: text.slice(close + '</think>'.length).replace(/^\s+/, ''),
+      }
+    }
+    return { thinking: '', visible: text }
+  }
   const parts: string[] = []
   let visible = text.replace(/<think>([\s\S]*?)<\/think>/g, (_m, inner: string) => {
     if (inner.trim()) parts.push(inner.trim())

--- a/ui/src/dash/board/agent-chat.jsx
+++ b/ui/src/dash/board/agent-chat.jsx
@@ -10,13 +10,139 @@ function Icon(props) {
   return BI ? <BI {...props} /> : null;
 }
 
-// Grounded in real tools: board reads/mutations + slot/model/hardware reads.
+// Grounded in the hal0-brain profile's real responsibilities: slot lifecycle,
+// model download/setup, benchmarking, hardware.
 const AGENT_SUGGEST = window.AGENT_SUGGEST || [
-  "what's blocked?",
-  "which slots are serving?",
-  "triage everything",
-  "how's the hardware doing?",
+  "Help me create a new slot",
+  "Download and set up a model",
+  "Benchmark the model on a slot",
+  "How's the hardware doing?",
 ];
+
+// ─── Minimal markdown → React (no deps, no innerHTML) ─────────────────
+// The brain slot replies in markdown; render the common subset (fences,
+// lists, headings, bold/italic/inline-code, links) instead of raw text.
+// Anything unrecognised falls through as plain text — never worse than before.
+
+function mdInline(text, keyBase) {
+  const out = [];
+  // Tokenise inline code first so `**x**` inside backticks stays literal.
+  const parts = String(text).split(/(`[^`]+`)/g);
+  parts.forEach((part, pi) => {
+    if (!part) return;
+    if (part.startsWith("`") && part.endsWith("`") && part.length > 2) {
+      out.push(<code className="md-code" key={`${keyBase}-c${pi}`}>{part.slice(1, -1)}</code>);
+      return;
+    }
+    // bold / italic / links on the remaining plain runs
+    const rx = /(\*\*[^*]+\*\*|\*[^*]+\*|\[[^\]]+\]\([^)]+\))/g;
+    part.split(rx).forEach((seg, si) => {
+      if (!seg) return;
+      const key = `${keyBase}-${pi}-${si}`;
+      if (seg.startsWith("**") && seg.endsWith("**")) {
+        out.push(<strong key={key}>{seg.slice(2, -2)}</strong>);
+      } else if (seg.startsWith("*") && seg.endsWith("*") && seg.length > 2) {
+        out.push(<em key={key}>{seg.slice(1, -1)}</em>);
+      } else if (seg.startsWith("[")) {
+        const m = seg.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+        if (m) out.push(<a href={m[2]} target="_blank" rel="noreferrer" key={key}>{m[1]}</a>);
+        else out.push(seg);
+      } else {
+        out.push(seg);
+      }
+    });
+  });
+  return out;
+}
+
+function Markdown({ text }) {
+  const src = String(text || "");
+  const blocks = [];
+  // Split out fenced code blocks first; everything between is prose.
+  const segments = src.split(/```(\w*)\n?([\s\S]*?)(?:```|$)/g);
+  // split() with 2 capture groups yields [prose, lang, code, prose, ...]
+  for (let i = 0; i < segments.length; i += 3) {
+    const prose = segments[i];
+    if (prose && prose.trim()) {
+      let list = null;
+      const flushList = (key) => {
+        if (!list) return;
+        blocks.push(list.ordered
+          ? <ol className="md-list" key={key}>{list.items}</ol>
+          : <ul className="md-list" key={key}>{list.items}</ul>);
+        list = null;
+      };
+      prose.split("\n").forEach((line, li) => {
+        const key = `b${i}-l${li}`;
+        const bullet = line.match(/^\s*[-*]\s+(.*)$/);
+        const ordered = line.match(/^\s*\d+[.)]\s+(.*)$/);
+        const heading = line.match(/^\s*#{1,4}\s+(.*)$/);
+        if (bullet || ordered) {
+          const item = <li key={key}>{mdInline((bullet || ordered)[1], key)}</li>;
+          if (list && list.ordered === !!ordered) list.items.push(item);
+          else { flushList(key + "-fl"); list = { ordered: !!ordered, items: [item] }; }
+        } else {
+          flushList(key + "-fl");
+          if (heading) blocks.push(<div className="md-h" key={key}>{mdInline(heading[1], key)}</div>);
+          else if (line.trim()) blocks.push(<p className="md-p" key={key}>{mdInline(line, key)}</p>);
+        }
+      });
+      flushList(`b${i}-end`);
+    }
+    const code = segments[i + 2];
+    if (code != null && code.trim()) {
+      blocks.push(
+        <pre className="md-pre" key={`b${i}-pre`} data-lang={segments[i + 1] || undefined}>
+          <code>{code.replace(/\n$/, "")}</code>
+        </pre>
+      );
+    }
+  }
+  return <React.Fragment>{blocks}</React.Fragment>;
+}
+
+// ─── Folded model reasoning ───────────────────────────────────────────
+function Thinking({ text }) {
+  if (!text) return null;
+  return (
+    <details className="msg-think" data-testid="board-chat-thinking">
+      <summary>thinking</summary>
+      <pre>{text}</pre>
+    </details>
+  );
+}
+
+// ─── Tool-call card (call + matched result) ───────────────────────────
+function ToolCard({ msg }) {
+  const tc = msg.tool_call || {};
+  const args = tc.arguments && Object.keys(tc.arguments).length > 0
+    ? JSON.stringify(tc.arguments)
+    : "";
+  const status = msg.status || "done";
+  let resultText = "";
+  if (msg.result !== undefined) {
+    try { resultText = JSON.stringify(msg.result, null, 2); }
+    catch { resultText = String(msg.result); }
+    if (resultText && resultText.length > 1200) resultText = resultText.slice(0, 1200) + " …";
+  }
+  return (
+    <div className={"tool-card " + status} data-testid="board-chat-tool">
+      <div className="tool-card-h">
+        <span className={"kdot " + (status === "running" ? "live" : "")}
+          style={{ "--st": status === "error" ? "var(--err)" : status === "running" ? "var(--info)" : "var(--ok)" }} />
+        <span className="tool-name">{tc.name || msg.body || "tool"}</span>
+        {args && <span className="tool-args" title={args}>{args}</span>}
+        <span className="tool-status">{status}</span>
+      </div>
+      {resultText && (
+        <details className="tool-result">
+          <summary>result</summary>
+          <pre>{resultText}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
 
 // ─── Agent chat slide-out (the orchestrator) ──────────────────────────
 function AgentChat({ chat, byId, onClose, onOpenTask }) {
@@ -47,9 +173,9 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
     chatHook.send(t);
   };
 
-  // `tool` frames are the orchestrator's audited board mutations — label them
-  // as tool activity, not as operator messages.
-  const roleLabel = (role) => role === "assistant" ? "agent" : role === "tool" ? "tool" : "operator";
+  // `tool` frames are the steward's audited platform/board mutations — label
+  // them as tool activity, not as operator messages.
+  const roleLabel = (role) => role === "assistant" ? "hal0-brain" : role === "tool" ? "tool" : "operator";
   const roleCls   = (role) => role === "assistant" ? "agent" : role === "tool" ? "tool" : "operator";
 
   return (
@@ -58,13 +184,13 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
       <aside
         className="b-drawer chat"
         role="dialog"
-        aria-label="platform assistant"
+        aria-label="hal0-brain platform steward"
         data-testid="board-chat"
       >
         <div className="b-drawer-h">
           <span className="dh-title">
             <span className="kdot live" style={{ "--st": "var(--ok)" }} />
-            agent · platform assistant
+            hal0-brain · platform steward
           </span>
           <span className="spacer" />
           <span className="dh-x" onClick={onClose}><Icon name="close" /></span>
@@ -73,7 +199,7 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
         <div className="chat-thread" ref={threadRef}>
           <div className="chat-intro">
             {chatHook
-              ? "administers this hal0 instance · board · slots · models · settings"
+              ? "stewards this hal0 instance · slots · models · benchmarks · board"
               : "chat backend unavailable — hook bridge not loaded"}
           </div>
 
@@ -87,30 +213,35 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
                 <span className="who">{roleLabel(m.role)}</span>
                 <span>{m.at}</span>
               </div>
-              <div className="msg-b">
-                {m.body}
-                {m.refs && m.refs.length > 0 && (
-                  <div className="msg-refs">
-                    {m.refs.map(id => byId[id] && (
-                      <span
-                        className="msg-ref"
-                        key={id}
-                        data-testid={`board-chat-ref-${id}`}
-                        onClick={() => onOpenTask(id)}
-                      >
-                        <span className={window.liveDot ? window.liveDot(byId[id].status) : "kdot glow"} />
-                        {id}
-                      </span>
-                    ))}
-                  </div>
-                )}
-              </div>
+              {m.role === "tool" && m.tool_call ? (
+                <ToolCard msg={m} />
+              ) : (
+                <div className="msg-b">
+                  {m.role === "assistant" && <Thinking text={m.thinking} />}
+                  {m.role === "assistant" ? <Markdown text={m.body} /> : m.body}
+                  {m.refs && m.refs.length > 0 && (
+                    <div className="msg-refs">
+                      {m.refs.map(id => byId[id] && (
+                        <span
+                          className="msg-ref"
+                          key={id}
+                          data-testid={`board-chat-ref-${id}`}
+                          onClick={() => onOpenTask(id)}
+                        >
+                          <span className={window.liveDot ? window.liveDot(byId[id].status) : "kdot glow"} />
+                          {id}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           ))}
 
           {isTyping && (
             <div className="msg agent" data-testid="board-chat-msg">
-              <div className="msg-meta"><span className="who">agent</span></div>
+              <div className="msg-meta"><span className="who">hal0-brain</span></div>
               <div className="msg-b"><span className="typing"><i /><i /><i /></span></div>
             </div>
           )}
@@ -131,7 +262,7 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
           <textarea
             value={draft}
             disabled={!chatHook}
-            placeholder={chatHook ? "Ask the orchestrator…  (Enter to send)" : "chat unavailable"}
+            placeholder={chatHook ? "Ask hal0-brain…  (Enter to send)" : "chat unavailable"}
             data-testid="board-chat-input"
             onChange={e => setDraft(e.target.value)}
             onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); } }}

--- a/ui/src/dash/board/agent-chat.jsx
+++ b/ui/src/dash/board/agent-chat.jsx
@@ -45,8 +45,13 @@ function mdInline(text, keyBase) {
         out.push(<em key={key}>{seg.slice(1, -1)}</em>);
       } else if (seg.startsWith("[")) {
         const m = seg.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
-        if (m) out.push(<a href={m[2]} target="_blank" rel="noreferrer" key={key}>{m[1]}</a>);
-        else out.push(seg);
+        // Model output is attacker-influenceable (tool results, task titles fed
+        // back into context) — only linkify http(s); anything else stays text.
+        if (m && /^https?:\/\//i.test(m[2].trim())) {
+          out.push(<a href={m[2].trim()} target="_blank" rel="noreferrer" key={key}>{m[1]}</a>);
+        } else {
+          out.push(seg);
+        }
       } else {
         out.push(seg);
       }

--- a/ui/src/dash/board/board.css
+++ b/ui/src/dash/board/board.css
@@ -339,10 +339,38 @@
 .b-drawer .msg-ref { display: inline-flex; align-items: center; gap: 6px; font-family: var(--jbm); font-size: 10.5px; color: var(--fg-2); border: 1px solid var(--line-strong); border-radius: var(--rad-sm); padding: 2px 7px; cursor: pointer; background: var(--bg-1); }
 .b-drawer .msg-ref:hover { border-color: var(--accent-line); color: var(--accent); }
 .b-drawer .msg-ref .kdot { width: 5px; height: 5px; }
-/* tool frames — the orchestrator's audited board mutations: compact + mono */
+/* tool frames — the steward's audited platform/board mutations: compact + mono */
 .b-drawer .msg.tool { align-self: flex-start; max-width: 100%; }
 .b-drawer .msg.tool .msg-meta .who { color: var(--info); }
 .b-drawer .msg.tool .msg-b { background: var(--bg-1); border-style: dashed; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); word-break: break-word; }
+/* structured tool-call card: name + args + status dot, result folded away */
+.b-drawer .tool-card { border: 1px dashed var(--line); border-radius: var(--rad-lg); background: var(--bg-1); padding: 8px 11px; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); }
+.b-drawer .tool-card.error { border-color: var(--err); }
+.b-drawer .tool-card-h { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.b-drawer .tool-card-h .kdot { width: 5px; height: 5px; flex-shrink: 0; }
+.b-drawer .tool-card .tool-name { color: var(--fg-2); font-weight: 600; flex-shrink: 0; }
+.b-drawer .tool-card .tool-args { color: var(--fg-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+.b-drawer .tool-card .tool-status { color: var(--fg-5); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; flex-shrink: 0; }
+.b-drawer .tool-card.error .tool-status { color: var(--err); }
+.b-drawer .tool-result { margin-top: 6px; }
+.b-drawer .tool-result summary { cursor: pointer; font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
+.b-drawer .tool-result pre { margin: 6px 0 0; padding: 8px; background: var(--bg); border: 1px solid var(--line); border-radius: var(--rad-sm); font-size: 10.5px; line-height: 1.5; overflow-x: auto; max-height: 220px; color: var(--fg-3); white-space: pre-wrap; word-break: break-word; }
+/* folded model reasoning — subdued, collapsed by default */
+.b-drawer .msg-think { margin: 0 0 8px; }
+.b-drawer .msg-think summary { cursor: pointer; font-family: var(--jbm); font-size: 10px; color: var(--fg-5); text-transform: uppercase; letter-spacing: 0.08em; }
+.b-drawer .msg-think pre { margin: 6px 0 0; padding: 8px 10px; border-left: 2px solid var(--line-strong); background: var(--bg-1); font-family: var(--jbm); font-size: 11px; line-height: 1.55; color: var(--fg-4); white-space: pre-wrap; word-break: break-word; max-height: 240px; overflow-y: auto; }
+/* markdown subset inside agent replies */
+.b-drawer .msg-b .md-p { margin: 0 0 8px; }
+.b-drawer .msg-b .md-p:last-child { margin-bottom: 0; }
+.b-drawer .msg-b .md-h { font-weight: 600; color: var(--fg); margin: 10px 0 6px; }
+.b-drawer .msg-b .md-h:first-child { margin-top: 0; }
+.b-drawer .msg-b .md-list { margin: 0 0 8px; padding-left: 18px; display: flex; flex-direction: column; gap: 3px; }
+.b-drawer .msg-b .md-list:last-child { margin-bottom: 0; }
+.b-drawer .msg-b .md-code { font-family: var(--jbm); font-size: 11.5px; background: var(--bg-1); border: 1px solid var(--line); border-radius: 4px; padding: 1px 5px; color: var(--fg-2); }
+.b-drawer .msg-b .md-pre { margin: 0 0 8px; padding: 9px 11px; background: var(--bg-1); border: 1px solid var(--line); border-radius: var(--rad-sm); overflow-x: auto; }
+.b-drawer .msg-b .md-pre:last-child { margin-bottom: 0; }
+.b-drawer .msg-b .md-pre code { font-family: var(--jbm); font-size: 11.5px; line-height: 1.55; color: var(--fg-2); white-space: pre; }
+.b-drawer .msg-b a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
 .b-drawer .chat-suggest { display: flex; flex-wrap: wrap; gap: 7px; padding: 0 14px 10px; flex-shrink: 0; }
 .b-drawer .sugg { font-family: var(--jbm); font-size: 11px; color: var(--fg-3); border: 1px solid var(--line); border-radius: var(--rad-pill); padding: 5px 11px; cursor: pointer; background: var(--bg); }
 .b-drawer .sugg:hover { border-color: var(--accent-line); color: var(--accent); }

--- a/ui/tests/e2e/specs/board-chat-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-chat-v3.spec.ts
@@ -182,9 +182,10 @@ test.describe('BoardView — agent chat', () => {
     await expect(msgs.nth(1)).toBeVisible({ timeout: FIVE_S })
     await expect(msgs.nth(1)).toContainText('Hello')
 
-    // Board chat must run on the agent slot (orchestrator model), and send
-    // OpenAI-style `messages` (not the legacy `{message}`).
-    expect(postBody.model).toBe('hal0/agent')
+    // Board chat embodies the hal0-brain profile — it must run on the brain
+    // slot (falls back to `agent` via the resolver chain) and send OpenAI-style
+    // `messages` (not the legacy `{message}`).
+    expect(postBody.model).toBe('hal0/brain')
     expect(Array.isArray(postBody.messages)).toBe(true)
     expect(postBody.messages.at(-1)).toMatchObject({ role: 'user', content: 'what is blocked?' })
   })
@@ -239,6 +240,81 @@ test.describe('BoardView — agent chat', () => {
     const msgs = page.locator('[data-testid="board-chat-msg"]')
     await expect(msgs.nth(1)).toBeVisible({ timeout: FIVE_S })
     await expect(msgs.nth(1)).toContainText('Moving task')
+  })
+
+  // ── Reply formatting: thinking fold, markdown, structured tool card ────
+
+  test('thinking frame folds away, markdown renders, tool card shows result', async ({ page }) => {
+    await page.route('**/api/board/chat', async (route) => {
+      if (route.request().method() !== 'POST') { await route.fallback(); return }
+      const sseBody = [
+        'data: {"type":"thinking","text":"checking the slots first"}\n\n',
+        'data: {"type":"tool_call","name":"list_slots","id":"c1","arguments":{}}\n\n',
+        'data: {"type":"tool_result","name":"list_slots","id":"c1","result":{"slots":[]}}\n\n',
+        'data: {"type":"token","text":"The `brain` slot is **ready**."}\n\n',
+        'data: {"type":"done"}\n\n',
+      ].join('')
+      await route.fulfill({ status: 200, contentType: 'text/event-stream', body: sseBody })
+    })
+
+    await gotoBoardAndWait(page)
+    await openChat(page)
+
+    await page.locator('[data-testid="board-chat-input"]').fill('is the brain slot up?')
+    await page.locator('[data-testid="board-chat-send"]').click()
+
+    // Structured tool card with the call name; result is folded behind <details>.
+    const toolCard = page.locator('[data-testid="board-chat-tool"]')
+    await expect(toolCard).toBeVisible({ timeout: FIVE_S })
+    await expect(toolCard).toContainText('list_slots')
+    await expect(toolCard.locator('.tool-result pre')).not.toBeVisible()
+    await toolCard.locator('.tool-result summary').click()
+    await expect(toolCard.locator('.tool-result pre')).toContainText('slots')
+
+    // Thinking is present but folded (collapsed <details>), never inline text.
+    const think = page.locator('[data-testid="board-chat-thinking"]')
+    await expect(think).toBeVisible({ timeout: FIVE_S })
+    await expect(think.locator('pre')).not.toBeVisible()
+    await think.locator('summary').click()
+    await expect(think.locator('pre')).toContainText('checking the slots first')
+
+    // Markdown: inline code + bold rendered as elements, not raw markers.
+    const reply = page.locator('[data-testid="board-chat-msg"]').last()
+    await expect(reply.locator('code.md-code')).toHaveText('brain')
+    await expect(reply.locator('strong')).toHaveText('ready')
+    await expect(reply).not.toContainText('**')
+  })
+
+  test('inline <think> tags in token stream never render raw', async ({ page }) => {
+    await page.route('**/api/board/chat', async (route) => {
+      if (route.request().method() !== 'POST') { await route.fallback(); return }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: 'data: {"type":"token","text":"<think>hidden reasoning</think>visible reply"}\n\ndata: {"type":"done"}\n\n',
+      })
+    })
+
+    await gotoBoardAndWait(page)
+    await openChat(page)
+    await page.locator('[data-testid="board-chat-input"]').fill('hi')
+    await page.locator('[data-testid="board-chat-send"]').click()
+
+    const reply = page.locator('[data-testid="board-chat-msg"]').nth(1)
+    await expect(reply).toContainText('visible reply', { timeout: FIVE_S })
+    await expect(reply.locator('.msg-b')).not.toContainText('<think>')
+    // Reasoning still reachable behind the fold.
+    const think = reply.locator('[data-testid="board-chat-thinking"]')
+    await think.locator('summary').click()
+    await expect(think.locator('pre')).toContainText('hidden reasoning')
+  })
+
+  test('suggestion chips are the hal0-brain starters', async ({ page }) => {
+    await gotoBoardAndWait(page)
+    await openChat(page)
+    await expect(page.locator('[data-testid="board-chat-suggest-0"]')).toContainText('create a new slot')
+    await expect(page.locator('[data-testid="board-chat-suggest-1"]')).toContainText('set up a model')
+    await expect(page.locator('[data-testid="board-chat-suggest-2"]')).toContainText('Benchmark')
   })
 
   // Ref-chip rendering is driven through a CONTROLLED hook (the stub-reply

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.9.4"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## Summary

The top-bar agent-chat slide-out previously ran a generic "platform assistant" prompt on the `hal0/agent` slot. It now embodies a dedicated **`hal0-brain` profile** — separate memories, hal0-heavy context, targeting the `brain` slot by default — with platform-steward chat starters and proper rendering of replies, tool calls, and model thinking.

### hal0-brain profile
- New seed persona `hal0-brain` (alongside `hermes` + `coder`) in `personas.py`: own memory namespace `private:hal0-brain` (platform-admin context never bleeds into the general Hermes chat), a system prompt covering slot lifecycle / model download+setup / benchmarking / hardware / board orchestration, and `preferred_model = "hal0/brain"`.
- `board_chat.py` resolves the `hal0-brain` persona TOML at request time (`app.state.brain_persona_root` seam for tests): an operator-edited profile overrides the built-in prompt/model with no code change; missing/malformed persona falls back to the built-ins.
- Default chat model is now `hal0/brain` (UI sends it explicitly too). The resolver's generalized chain (`hal0/<slot>` → `(<slot>, agent)`) degrades to the `agent` slot when no brain slot is loaded.
- Rewrote the built-in system prompt to reflect the new responsibilities (slot creation, model setup walk-throughs, benchmark prep, disruptive-action rules, plan-then-execute for multi-step work).

### Suggested chat starters
`Help me create a new slot` · `Download and set up a model` · `Benchmark the model on a slot` · `How's the hardware doing?`

### Chat panel formatting
- **Replies**: markdown rendering (code fences, lists, headings, bold/italic/inline code, links) via a small dependency-free renderer — no innerHTML.
- **Thinking**: new `{type:"thinking"}` SSE frame; the backend splits `reasoning_content` and inline `<think>…</think>` out of replies (client-side guard as well) and the panel renders them as a folded `thinking` section — raw think-tags never hit the bubble.
- **Tool calls**: structured cards with tool name, args, live status dot (`running → done | error`), and the matched `tool_result` folded behind a disclosure — replacing the raw `→ tool({json})` text rows.
- Fixed a latent streaming bug surfaced by segmenting bubbles around tool calls: `setMessages` updaters shared mutable stream indices, which React's update batching corrupted (post-tool text overwrote the pre-tool bubble). Segments are now tagged by value.

## Testing
- `tests/board/test_board_chat.py` — 44 passed (new: brain default model, payload override, persona override, thinking frames, `<think>` splitting).
- `tests/agents`, `tests/board`, persona API/CLI/harness suites — 472 passed.
- `ruff check` + `ruff format` clean on touched Python files.
- UI: `tsc --noEmit` clean, `vite build` green, Playwright `board-chat-v3` 14/14 (new: thinking fold, markdown, tool-card result, raw-think-tag guard, starter chips) plus `board-render-v3` / `board-drawer-v3` / `dashboard-v3` — 39 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWv2AmAL5o91w3bP2p64vG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWv2AmAL5o91w3bP2p64vG)_