### PR TITLE
feat(models): HF update checks — row badge, Update all, notification-bell handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+- Model update checks against HuggingFace: `POST /api/models/check-updates` compares each installed model's recorded sha256 against the LFS sha HF currently serves at `main` (per-file 15-min cache, per-row errors). The Models page shows an amber `update` badge on outdated rows, an `Update all · N` header button that re-pulls every outdated model through the existing pull pipeline, a per-model Update button in the detail pane, and publishes a `hal0:notify` event for the topbar notification bell.
+
 ## [0.9.6] — 2026-07-10
 
 ### Highlights

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -34,6 +34,8 @@ from hal0.registry.pull import (
     PullInvalidSource,
     PullJob,
     PullJobNotFound,
+    _expected_sha256_from_response,
+    hf_download_url,
     list_persisted_jobs,
     make_job,
     run_flm_pull,
@@ -2236,6 +2238,184 @@ async def inspect_model(request: Request) -> dict[str, Any]:
     result = await _fetch_hf_repo(repo)
     _INSPECT_CACHE[repo] = (now, result)
     return {"repo": repo, "cached": False, **result}
+
+
+# ── HF update check (POST /api/models/check-updates) ─────────────────────────
+#
+# The pull engine treats a downloaded file as immutable (content-addressed,
+# no revalidation — registry/pull.py), but GGUF repos do move: quant authors
+# force-push fixed tensors under the same filename at ``main``. This check
+# compares each installed row's recorded content sha256 (written by
+# ``_register_pulled`` on every pull) against the LFS sha256 HF currently
+# advertises for the same repo/filename — the ``X-Linked-ETag`` on the
+# ``resolve/main`` endpoint, i.e. the exact digest the pull path verifies
+# against. "Update available" therefore means: a re-pull of this id would
+# land different bytes. Applying an update IS a re-pull
+# (POST /api/models/{id}/pull upserts the row and re-verifies the hash).
+#
+# The HF side is cached per (repo, filename) for ~15 minutes so the
+# dashboard can poll cheaply; the installed sha is read fresh from the
+# registry on every call, so a badge clears as soon as a re-pull lands
+# without any cache invalidation dance.
+
+_UPDATE_CHECK_TTL_SECONDS = 900.0
+_UPDATE_CHECK_CONCURRENCY = 6
+# (repo, filename) → (checked_at, latest_sha256 | None, error | None)
+_UPDATE_CHECK_CACHE: dict[tuple[str, str], tuple[float, str | None, str | None]] = {}
+
+
+async def _fetch_latest_sha256(
+    client: httpx.AsyncClient, repo: str, filename: str
+) -> tuple[str | None, str | None]:
+    """HEAD HF's ``resolve/main`` URL and return ``(lfs_sha256, error)``.
+
+    The client must be constructed with ``follow_redirects=False`` — HF
+    advertises the LFS sha256 as ``X-Linked-ETag`` on the huggingface.co
+    hop (a 302 to the CDN for LFS files), and following the redirect
+    would HEAD the CDN object for nothing.
+    """
+    url = hf_download_url(repo, filename)
+    try:
+        resp = await client.head(url)
+    except (httpx.TimeoutException, httpx.HTTPError) as exc:
+        return None, f"unreachable: {exc.__class__.__name__}"
+    if resp.status_code in (401, 403):
+        return None, f"HTTP {resp.status_code} (gated repo? set HF_TOKEN)"
+    if resp.status_code == 404:
+        return None, "file no longer exists in the repo at main"
+    if resp.status_code >= 400:
+        return None, f"HTTP {resp.status_code}"
+    sha = _expected_sha256_from_response(resp)
+    if sha is None:
+        # Non-LFS file (git-blob etag only) — no sha256 exists upstream,
+        # so there is nothing to compare against.
+        return None, "no LFS sha256 advertised"
+    return sha, None
+
+
+@router.post("/check-updates")
+async def check_model_updates(request: Request) -> dict[str, Any]:
+    """Compare every installed HF-backed model against HuggingFace ``main``.
+
+    Body (optional)::
+
+        {"force": true}   # bypass the per-file TTL cache
+
+    Response::
+
+        {
+          "checked_at": 1730000000,
+          "cached": true,              # every row answered from cache
+          "count": 3,                  # HF-backed rows examined
+          "updates_available": 1,
+          "models": [
+            {
+              "id": "qwen3-8b-q4_k_m",
+              "hf_repo": "unsloth/Qwen3-8B-GGUF",
+              "hf_filename": "qwen3-8b-q4_k_m.gguf",
+              "installed_sha256": "…" | null,
+              "latest_sha256": "…" | null,
+              "update_available": false,
+              "error": null | "HTTP 404"
+            }, …
+          ]
+        }
+
+    Rows without HF coordinates (hand-registered files, FLM tags) are
+    skipped; rows without a recorded local sha256 (registered before the
+    hash was captured) are reported but never flagged — hashing tens of
+    GB on request is not worth a badge. Per-file HF failures land in
+    ``error`` on that row; the endpoint itself stays 200.
+    """
+    force = False
+    try:
+        if int(request.headers.get("content-length") or 0) > 0:
+            body = await request.json()
+            if isinstance(body, dict):
+                force = bool(body.get("force"))
+    except Exception:
+        force = False
+
+    registry = request.app.state.model_registry
+    rows: list[tuple[str, str, str, str | None]] = []
+    for entry in registry.list():
+        repo = (entry.hf_repo or "").strip()
+        filename = (entry.hf_filename or "").strip()
+        if not repo or not filename:
+            continue
+        sha = entry.metadata.get("sha256") if isinstance(entry.metadata, dict) else None
+        installed_sha = sha.strip().lower() if isinstance(sha, str) and sha.strip() else None
+        rows.append((entry.id, repo, filename, installed_sha))
+
+    now = time.time()
+    stale = [
+        key
+        for key in {(repo, filename) for _, repo, filename, _ in rows}
+        if force
+        or key not in _UPDATE_CHECK_CACHE
+        or now - _UPDATE_CHECK_CACHE[key][0] >= _UPDATE_CHECK_TTL_SECONDS
+    ]
+    if stale:
+        headers = {"Accept": "application/json"}
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        if hf_token:
+            headers["Authorization"] = f"Bearer {hf_token}"
+        sem = asyncio.Semaphore(_UPDATE_CHECK_CONCURRENCY)
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(_INSPECT_TIMEOUT_SECONDS),
+            follow_redirects=False,
+            headers=headers,
+        ) as client:
+
+            async def _check_one(key: tuple[str, str]) -> None:
+                async with sem:
+                    latest, error = await _fetch_latest_sha256(client, *key)
+                _UPDATE_CHECK_CACHE[key] = (now, latest, error)
+
+            await asyncio.gather(*(_check_one(key) for key in stale))
+
+    models_out: list[dict[str, Any]] = []
+    updates_available = 0
+    for model_id, repo, filename, installed_sha in rows:
+        _, latest_sha, error = _UPDATE_CHECK_CACHE.get((repo, filename), (0.0, None, "not checked"))
+        available = bool(installed_sha and latest_sha and installed_sha != latest_sha)
+        if available:
+            updates_available += 1
+        models_out.append(
+            {
+                "id": model_id,
+                "hf_repo": repo,
+                "hf_filename": filename,
+                "installed_sha256": installed_sha,
+                "latest_sha256": latest_sha,
+                "update_available": available,
+                "error": error,
+            }
+        )
+
+    # Footer signal only when a live (non-cached) sweep found something new —
+    # the dashboard's poll would otherwise re-announce the same updates every
+    # cycle for the whole TTL window.
+    if stale and updates_available:
+        event_bus = getattr(request.app.state, "events", None)
+        if event_bus is not None:
+            outdated_ids = [m["id"] for m in models_out if m["update_available"]]
+            await event_bus.emit(
+                "models.updates_available",
+                "info",
+                "models:check-updates",
+                f"{updates_available} model update{'s' if updates_available != 1 else ''} "
+                "available on HuggingFace",
+                data={"count": updates_available, "ids": outdated_ids},
+            )
+
+    return {
+        "checked_at": int(now),
+        "cached": not stale,
+        "count": len(models_out),
+        "updates_available": updates_available,
+        "models": models_out,
+    }
 
 
 @router.post("/{model_id}/pull/cancel")

--- a/tests/api/test_models_update_check.py
+++ b/tests/api/test_models_update_check.py
@@ -1,0 +1,280 @@
+"""Tests for POST /api/models/check-updates (HF re-pull refresh).
+
+The check compares each installed row's recorded content sha256
+(``metadata["sha256"]``, written by ``_register_pulled`` on every pull)
+against the LFS sha256 HF currently advertises for the same
+repo/filename — the ``X-Linked-ETag`` on the ``resolve/main`` endpoint.
+
+httpx is mocked the same way as the inspect tests
+(tests/api/test_models_routes.py): the route builds its own AsyncClient,
+so the class is swapped for a factory that injects a MockTransport.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes import models as models_route
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+
+
+@pytest.fixture
+def updates_app(tmp_hal0_home: str) -> FastAPI:
+    """Fresh app with the update-check cache cleared (cold cache per test)."""
+    models_route._UPDATE_CHECK_CACHE.clear()
+    return create_app()
+
+
+@pytest.fixture
+def updates_client(updates_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(updates_app) as c:
+        yield c
+
+
+def _register(
+    client: TestClient,
+    tmp_home: str,
+    model_id: str,
+    *,
+    hf_repo: str = "",
+    hf_filename: str = "",
+    sha256: str | None = None,
+) -> None:
+    """Seed a registry row shaped like a completed pull."""
+    fpath = Path(tmp_home) / f"{model_id}.gguf"
+    fpath.write_bytes(b"\x00" * 8)
+    body: dict[str, Any] = {"id": model_id, "path": str(fpath)}
+    if hf_repo:
+        body["hf_repo"] = hf_repo
+    if hf_filename:
+        body["hf_filename"] = hf_filename
+    if sha256:
+        body["metadata"] = {"sha256": sha256}
+    r = client.post("/api/models", json=body)
+    assert r.status_code == 201, r.text
+
+
+def _head_handler(latest_sha: str | None, *, status: int = 302, calls: list[str] | None = None):
+    """MockTransport handler answering HEAD resolve/main like huggingface.co.
+
+    HF serves the LFS sha256 as ``X-Linked-ETag`` on the (unfollowed) 302
+    hop to the CDN; ``latest_sha=None`` omits the header (non-LFS file).
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if calls is not None:
+            calls.append(str(req.url))
+        headers = {}
+        if latest_sha is not None:
+            headers["x-linked-etag"] = f'"{latest_sha}"'
+        return httpx.Response(status, headers=headers)
+
+    return handler
+
+
+def _patch_httpx_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    real_cls = httpx.AsyncClient
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_cls(*args, **kwargs)
+
+    monkeypatch.setattr("hal0.api.routes.models.httpx.AsyncClient", factory)
+
+
+def _row(body: dict[str, Any], model_id: str) -> dict[str, Any]:
+    rows = {m["id"]: m for m in body["models"]}
+    assert model_id in rows, f"{model_id} missing from {sorted(rows)}"
+    return rows[model_id]
+
+
+def test_update_available_when_upstream_sha_differs(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "qwen",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B))
+
+    body = updates_client.post("/api/models/check-updates").json()
+    assert body["cached"] is False
+    assert body["count"] == 1
+    assert body["updates_available"] == 1
+    row = _row(body, "qwen")
+    assert row["installed_sha256"] == SHA_A
+    assert row["latest_sha256"] == SHA_B
+    assert row["update_available"] is True
+    assert row["error"] is None
+
+
+def test_no_update_when_sha_matches(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "qwen",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_A))
+
+    body = updates_client.post("/api/models/check-updates").json()
+    assert body["updates_available"] == 0
+    assert _row(body, "qwen")["update_available"] is False
+
+
+def test_rows_without_hf_coords_are_skipped(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hand-registered files (no hf_repo/hf_filename) never hit HF."""
+    _register(updates_client, tmp_hal0_home, "local-only", sha256=SHA_A)
+    calls: list[str] = []
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B, calls=calls))
+
+    body = updates_client.post("/api/models/check-updates").json()
+    assert body["count"] == 0
+    assert body["models"] == []
+    assert calls == []
+
+
+def test_missing_local_sha_is_reported_but_never_flagged(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-hash registrations can't be compared — no false-positive badge."""
+    _register(updates_client, tmp_hal0_home, "old", hf_repo="org/repo", hf_filename="q.gguf")
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B))
+
+    body = updates_client.post("/api/models/check-updates").json()
+    assert body["updates_available"] == 0
+    row = _row(body, "old")
+    assert row["installed_sha256"] is None
+    assert row["latest_sha256"] == SHA_B
+    assert row["update_available"] is False
+
+
+def test_second_call_is_served_from_cache(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "qwen",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    calls: list[str] = []
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B, calls=calls))
+
+    first = updates_client.post("/api/models/check-updates").json()
+    second = updates_client.post("/api/models/check-updates").json()
+    assert first["cached"] is False
+    assert second["cached"] is True
+    assert len(calls) == 1
+    assert second["updates_available"] == 1
+
+
+def test_force_bypasses_cache(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "qwen",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    calls: list[str] = []
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B, calls=calls))
+
+    updates_client.post("/api/models/check-updates")
+    updates_client.post("/api/models/check-updates", json={"force": True})
+    assert len(calls) == 2
+
+
+def test_cached_result_clears_after_repull_lands_new_sha(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The installed sha is read fresh each call — a completed re-pull flips
+    the row to up-to-date within the HF cache TTL, no invalidation needed."""
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "qwen",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    _patch_httpx_transport(monkeypatch, _head_handler(SHA_B))
+
+    first = updates_client.post("/api/models/check-updates").json()
+    assert first["updates_available"] == 1
+
+    # Simulate the re-pull's _register_pulled: registry row now carries the
+    # upstream sha.
+    r = updates_client.put("/api/models/qwen", json={"metadata": {"sha256": SHA_B}})
+    assert r.status_code == 200, r.text
+
+    second = updates_client.post("/api/models/check-updates").json()
+    assert second["cached"] is True
+    assert second["updates_available"] == 0
+    assert _row(second, "qwen")["update_available"] is False
+
+
+def test_hf_error_lands_on_the_row_not_the_response(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "gone",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    _patch_httpx_transport(monkeypatch, _head_handler(None, status=404))
+
+    r = updates_client.post("/api/models/check-updates")
+    assert r.status_code == 200
+    row = _row(r.json(), "gone")
+    assert row["update_available"] is False
+    assert row["latest_sha256"] is None
+    assert "404" in (row["error"] or "") or "no longer exists" in (row["error"] or "")
+
+
+def test_non_lfs_file_reports_no_upstream_sha(
+    updates_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200/302 without an X-Linked-ETag sha (non-LFS file) is unknowable."""
+    _register(
+        updates_client,
+        tmp_hal0_home,
+        "tiny",
+        hf_repo="org/repo",
+        hf_filename="q.gguf",
+        sha256=SHA_A,
+    )
+    _patch_httpx_transport(monkeypatch, _head_handler(None, status=200))
+
+    row = _row(updates_client.post("/api/models/check-updates").json(), "tiny")
+    assert row["update_available"] is False
+    assert row["latest_sha256"] is None
+    assert row["error"] == "no LFS sha256 advertised"

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -59,6 +59,9 @@ export const ENDPOINTS = {
   modelPulls: '/api/models/pulls',
   modelPullDelete: (id: string) => `/api/models/pulls/${encodeURIComponent(id)}`,
   modelInspect: '/api/models/inspect',
+  // HF re-pull refresh: sha-compares installed rows against what HF
+  // currently serves at main; applying an update is a normal re-pull.
+  modelCheckUpdates: '/api/models/check-updates',
   modelScanPreview: '/api/models/scan/preview',
   modelScanCommit: '/api/models/scan',
   modelAddFromPath: '/api/models/add-from-path',

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -134,6 +134,98 @@ export function useModelInspect() {
   })
 }
 
+// ─── Model update check (HF re-pull refresh) ──────────────────────────
+
+export interface ModelUpdateRow {
+  id: string
+  hf_repo: string
+  hf_filename: string
+  installed_sha256: string | null
+  latest_sha256: string | null
+  update_available: boolean
+  error: string | null
+}
+
+export interface ModelUpdatesResponse {
+  checked_at: number
+  cached: boolean
+  count: number
+  updates_available: number
+  models: ModelUpdateRow[]
+}
+
+const UPDATE_CHECK_POLL_MS = 60_000
+
+export function useModelUpdates() {
+  // POST /api/models/check-updates — sha-compares every installed
+  // HF-backed row against the LFS sha256 HF currently advertises at
+  // main. The backend caches the HF side per file for ~15 minutes and
+  // re-reads the registry sha on every call, so this 60s poll is a
+  // cheap local cross-check that clears row badges as soon as a
+  // re-pull lands new bytes — no HF hammering.
+  return useQuery<ModelUpdatesResponse, Hal0Error>({
+    queryKey: ['model-updates'],
+    queryFn: async () => {
+      const res = await apiPost<ModelUpdatesResponse>(ENDPOINTS.modelCheckUpdates, {})
+      const outdated = (res.models ?? []).filter((m) => m.update_available)
+      if (outdated.length > 0 && typeof window !== 'undefined') {
+        // Notification-bell handoff: the topbar bell (dash/chrome.jsx)
+        // listens for 'hal0:notify' and dedupes + persists dismissal by
+        // stable id, so this fires on every poll without re-nagging — the
+        // id changes (and the bell re-notifies) only when the outdated SET
+        // changes. Dispatching with no listener is a harmless no-op.
+        const ids = outdated.map((m) => m.id).sort()
+        window.dispatchEvent(
+          new CustomEvent('hal0:notify', {
+            detail: {
+              id: `model-updates:${ids.join(',')}`,
+              title: `${ids.length} model update${ids.length === 1 ? '' : 's'} available`,
+              body: ids.slice(0, 3).join(', ') + (ids.length > 3 ? ` +${ids.length - 3} more` : ''),
+              kind: 'update',
+              link: '#models',
+            },
+          }),
+        )
+      }
+      return res
+    },
+    refetchInterval: UPDATE_CHECK_POLL_MS,
+    staleTime: 30_000,
+    retry: 1,
+  })
+}
+
+export function useUpdateAllModels() {
+  // Re-pull every outdated model: an "update" is a plain POST /pull per
+  // id (the server upserts the row, re-verifies the hash, and dedups
+  // queued/running jobs). Progress lands in the Downloads pane via the
+  // existing 2s pulls poll; the per-id 'hal0:pull-started' event nudges
+  // that poll awake immediately. One failed start must not block the
+  // rest, so errors are collected rather than thrown — the mutation
+  // resolves with the ids that actually started.
+  const qc = useQueryClient()
+  return useMutation<string[], Hal0Error, string[]>({
+    mutationFn: async (ids: string[]) => {
+      const started: string[] = []
+      for (const id of ids) {
+        try {
+          await apiPost(ENDPOINTS.modelPull(id))
+          started.push(id)
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('hal0:pull-started', { detail: { modelId: id } }))
+          }
+        } catch {
+          /* keep going — surfaced as started.length < ids.length */
+        }
+      }
+      return started
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['pulls'] })
+    },
+  })
+}
+
 // ─── HF Hub free-text search (issue #311) ─────────────────────────────
 
 export interface HfSearchResult {

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, useModelUpdates, useUpdateAllModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
@@ -79,6 +79,33 @@ function ModelsView() {
 
   const modelsQuery = useModels();
   const modelList = modelsQuery.data ?? [];
+
+  // ── HF update check ─────────────────────────────────────────────────
+  // outdatedSet holds ids whose recorded sha256 no longer matches what HF
+  // serves at main — the row badge + "Update all" button key off it.
+  const updatesQuery = useModelUpdates();
+  const updateRows = updatesQuery.data?.models ?? [];
+  const outdatedSet = useMemoM(
+    () => new Set(updateRows.filter(u => u.update_available).map(u => u.id)),
+    [updateRows],
+  );
+  const updateAll = useUpdateAllModels();
+  const onUpdateAll = async () => {
+    const ids = [...outdatedSet];
+    try {
+      const started = await updateAll.mutateAsync(ids);
+      window.__hal0Toast && window.__hal0Toast(
+        started.length === ids.length
+          ? `Updating ${started.length} model${started.length === 1 ? "" : "s"} — progress in Downloads`
+          : `Started ${started.length}/${ids.length} updates — see Downloads`,
+        started.length === ids.length ? "info" : "warn",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Update all failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
 
   // Auto-pick the first installed model on first render so the detail
   // pane never opens empty.
@@ -189,6 +216,15 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
+        {outdatedSet.size > 0 && (
+          <button
+            className="btn"
+            data-testid="mdl-update-all"
+            disabled={updateAll.isPending}
+            title="Re-pull every installed model whose file changed on HuggingFace"
+            onClick={onUpdateAll}
+          >{Icons.download} {updateAll.isPending ? "Updating…" : `Update all · ${outdatedSet.size}`}</button>
+        )}
         <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
         <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
@@ -301,16 +337,16 @@ function ModelsView() {
             sectionedInference.map(item =>
               item.type === "label"
                 ? <div key={item.key} className="mdl-section-label">{item.text}</div>
-                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
+                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} updateAvailable={outdatedSet.has(item.model.id)} onSelect={() => setSelId(item.model.id)} />
             )
           ) : tab === "image" ? (
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} selected={selId === m.id} updateAvailable={outdatedSet.has(m.id)} onSelect={() => setSelId(m.id)} />
             ))
           ) : (
             /* upstream tab — flat paginated rows */
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} selected={selId === m.id} updateAvailable={outdatedSet.has(m.id)} onSelect={() => setSelId(m.id)} />
             ))
           )}
 
@@ -348,6 +384,7 @@ function ModelsView() {
         <div className="models-sidebar">
           <ModelDetail
             model={selected}
+            updateAvailable={!!selected && outdatedSet.has(selected.id)}
             onDelete={() => setDelModel(selected)}
             onEdit={() => setRecipeOpen(true)}
           />
@@ -433,7 +470,7 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
 }
 
 // ── ModelRow ──────────────────────────────────────────────────────────
-function ModelRow({ model, selected, onSelect }) {
+function ModelRow({ model, selected, updateAvailable, onSelect }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
@@ -455,6 +492,13 @@ function ModelRow({ model, selected, onSelect }) {
       </span>
       <span className="sz num">{model.size || (model.size_bytes ? fmtBytes(model.size_bytes) : "")}</span>
       <span className="tg">
+        {updateAvailable && (
+          <span
+            className="chip amber"
+            data-testid="mdl-row-update"
+            title="A newer build of this file is on HuggingFace — re-pull to update"
+          >update</span>
+        )}
         {isUpstreamModel(model)
           ? <span className="chip info" title={`Advertised by the "${model.upstream}" upstream — not stored on this host`}>upstream</span>
           : !model.installed
@@ -466,7 +510,7 @@ function ModelRow({ model, selected, onSelect }) {
 }
 
 // ── ModelDetail ───────────────────────────────────────────────────────
-function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
+function ModelDetail({ model, updateAvailable, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
   const swap = useSlotSwap();
@@ -529,7 +573,10 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
               : <span style={{color: "var(--fg-5)"}}>{Icons.download}</span>}
           </span>
           <div className="nm mono">{model.longName || model.name || model.id}</div>
-          <span style={{marginLeft: "auto"}}>
+          <span style={{marginLeft: "auto", display: "inline-flex", gap: 6}}>
+            {model.installed && updateAvailable && (
+              <span className="chip amber" title="A newer build of this file is on HuggingFace">update available</span>
+            )}
             {model.installed
               ? <span className="chip ok">installed</span>
               : isUpstreamModel(model)
@@ -575,6 +622,15 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
       <div className="mdl-detail-actions">
         {model.installed ? (
           <>
+            {updateAvailable && (
+              <button
+                className="btn"
+                data-testid="mdl-detail-update"
+                disabled={pull.inFlight}
+                title="Re-pull this model — its file changed on HuggingFace"
+                onClick={onPull}
+              >{Icons.download} {pull.inFlight ? `Updating ${pull.pct ?? 0}%` : "Update"}</button>
+            )}
             <button
               className="btn"
               disabled={swap.isPending}

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -227,11 +227,14 @@ test.describe('NPU occupancy card (/slots · Inference tab)', () => {
     await expect(card.locator('.aie-grid .aie-col')).toHaveCount(8)
   })
 
-  test('lists a per-FLM-slot card with lifecycle controls', async ({ page }) => {
+  test('lists a per-FLM-slot card with its toggle + header lifecycle controls', async ({ page }) => {
     await page.goto('/#slots')
     const card = page.locator('.npu-card')
     await expect(card.locator('.cslot').first()).toBeVisible()
-    await expect(card.locator('.cslot .slot-ctrls').first()).toBeVisible()
+    // Per-card control is now the modality pill toggle (trio-drawer rework,
+    // #1172); slot lifecycle moved to the card-header ▶/■/↻ buttons.
+    await expect(card.locator('.cslot .npu-switch').first()).toBeVisible()
+    await expect(card.locator('.wcard-h button[title="Stop"]')).toBeVisible()
   })
 })
 

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -204,4 +204,123 @@ test.describe('Models v3 (/models)', () => {
     await page.locator('button:has-text("Delete model")').click()
     await expect.poll(() => deleted).toBe(true)
   })
+  // ── HF update check (check-updates + Update all) ─────────────────────
+  const UPDATES_PAYLOAD = {
+    checked_at: 1730000000,
+    cached: false,
+    count: 2,
+    updates_available: 1,
+    models: [
+      {
+        id: 'qwen3.6-27b-mtp',
+        hf_repo: 'unsloth/Qwen3.6-27B-A3B-MTP-GGUF',
+        hf_filename: 'qwen3.6-27b-q4_k_m.gguf',
+        installed_sha256: 'a'.repeat(64),
+        latest_sha256: 'b'.repeat(64),
+        update_available: true,
+        error: null,
+      },
+      {
+        id: 'qwen3-coder-30b',
+        hf_repo: 'unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF',
+        hf_filename: 'qwen3-coder-30b-q4_k_m.gguf',
+        installed_sha256: 'c'.repeat(64),
+        latest_sha256: 'c'.repeat(64),
+        update_available: false,
+        error: null,
+      },
+    ],
+  }
+
+  test('update-available badge renders only on outdated rows', async ({ page }) => {
+    await page.route('**/api/models/check-updates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(UPDATES_PAYLOAD),
+      }),
+    )
+    await page.goto('/#models')
+    // Exactly one row is outdated in the payload → exactly one badge.
+    await expect(page.getByTestId('mdl-row-update')).toHaveCount(1)
+    const badged = page.locator('.mdl-row', { has: page.getByTestId('mdl-row-update') })
+    await expect(badged).toContainText('Qwen3.6-27B-MTP')
+  })
+
+  test('Update all button shows the outdated count and re-pulls each id', async ({ page }) => {
+    await page.route('**/api/models/check-updates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(UPDATES_PAYLOAD),
+      }),
+    )
+    const pulled: string[] = []
+    await page.route('**/api/models/qwen3.6-27b-mtp/pull', async (route) => {
+      if (route.request().method() === 'POST') {
+        pulled.push('qwen3.6-27b-mtp')
+        return route.fulfill({
+          status: 202,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'job-1', model_id: 'qwen3.6-27b-mtp', state: 'queued' }),
+        })
+      }
+      return route.fallback()
+    })
+
+    await page.goto('/#models')
+    const btn = page.getByTestId('mdl-update-all')
+    await expect(btn).toBeVisible()
+    await expect(btn).toContainText('Update all · 1')
+    await btn.click()
+    await expect.poll(() => pulled).toEqual(['qwen3.6-27b-mtp'])
+  })
+
+  test('no updates → no badge, no Update all button', async ({ page }) => {
+    await page.route('**/api/models/check-updates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          checked_at: 1730000000,
+          cached: true,
+          count: 0,
+          updates_available: 0,
+          models: [],
+        }),
+      }),
+    )
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-row').first()).toBeVisible()
+    await expect(page.getByTestId('mdl-row-update')).toHaveCount(0)
+    await expect(page.getByTestId('mdl-update-all')).toHaveCount(0)
+  })
+
+  test('outdated models publish a hal0:notify event for the topbar bell', async ({ page }) => {
+    // The notification bell (dash/chrome.jsx, separate PR) consumes
+    // 'hal0:notify' CustomEvents keyed by stable id — assert the update
+    // check publishes the contract shape even before the bell lands.
+    await page.addInitScript(() => {
+      ;(window as any).__notifEvents = []
+      window.addEventListener('hal0:notify', (e) =>
+        (window as any).__notifEvents.push((e as CustomEvent).detail),
+      )
+    })
+    await page.route('**/api/models/check-updates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(UPDATES_PAYLOAD),
+      }),
+    )
+    await page.goto('/#models')
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__notifEvents.length))
+      .toBeGreaterThan(0)
+    const detail = await page.evaluate(() => (window as any).__notifEvents[0])
+    expect(detail.id).toBe('model-updates:qwen3.6-27b-mtp')
+    expect(detail.kind).toBe('update')
+    expect(detail.link).toBe('#models')
+    expect(detail.title).toContain('1 model update')
+  })
 })

--- a/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
+++ b/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
@@ -89,23 +89,25 @@ test.describe('NPU occupancy card', () => {
     await expect(cslot.locator('.cslot-mx .tps')).toContainText('52')
   })
 
-  test('serving slot Stop control issues POST /api/slots/npu/unload', async ({ page }) => {
+  test('header Stop control issues POST /api/slots/flm/unload', async ({ page }) => {
     const unloads: string[] = []
-    await page.route('**/api/slots/npu/unload', async (route) => {
+    await page.route('**/api/slots/flm/unload', async (route) => {
       unloads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
 
-    await seedNpu(page, NPU_SERVING_SLOT)
+    // Lifecycle moved off the per-slot cards to the card-header ▶/■/↻
+    // buttons, which target the 'flm' anchor slot (npu→flm rename; the
+    // .sctrl controls were replaced by modality pill toggles in #1172).
+    await seedNpu(page, { ...NPU_SERVING_SLOT, name: 'flm' })
     await page.goto('/#slots')
 
-    const cslot = page.locator('.npu-card .cslot').filter({ hasText: 'npu' }).first()
-    const stop = cslot.locator('.sctrl.stop')
-    await expect(stop).toHaveCount(1)
+    const stop = page.locator('.npu-card .wcard-h button[title="Stop"]')
+    await expect(stop).toBeEnabled()
     await stop.click()
 
     await expect.poll(() => unloads.length, { timeout: 5_000 }).toBeGreaterThan(0)
-    expect(unloads[0]).toContain('/api/slots/npu/unload')
+    expect(unloads[0]).toContain('/api/slots/flm/unload')
   })
 
   test('degraded probe greys the grid and labels the gauge', async ({ page }) => {

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -39,7 +39,8 @@ test.describe('Slots v3 (/slots)', () => {
     await expect(card).toBeVisible()
     // 4×8 AIE-ML occupancy grid (single-tenant: one FLM claims the whole array)
     await expect(card.locator('.aie-grid .aie-col')).toHaveCount(8)
-    // at least one resident FLM slot card with its column strip
-    await expect(card.locator('.cslot .cslot-strip').first()).toBeVisible()
+    // at least one resident FLM slot card (name + metrics row — the card's
+    // inline TileStrip was removed in 86c73366, so assert the current shape)
+    await expect(card.locator('.cslot .cslot-top .nm').first()).toBeVisible()
   })
 })


### PR DESCRIPTION
## What

Lets users update installed models when their files change on HuggingFace:

- **`POST /api/models/check-updates`** — compares each installed HF-backed registry row's recorded content sha256 (written by `_register_pulled` on every pull) against the LFS sha256 HF currently advertises for the same repo/filename (the `X-Linked-ETag` on `resolve/main` — the exact digest the pull path verifies against). "Update available" means a re-pull would land different bytes.
- **Row indicator** — outdated rows in the Models catalog get an amber `update` chip; the detail pane shows an `update available` chip and a per-model **Update** button.
- **Update all** — an `Update all · N` header button re-pulls every outdated model through the existing pull pipeline (upsert + hash re-verify), with progress in the Downloads pane. One failed start doesn't block the rest.
- **Notification bell handoff** — `useModelUpdates` publishes a `hal0:notify` CustomEvent (stable id keyed on the outdated set, `kind: "update"`, `link: "#models"`) matching the topbar bell's dedupe + persistent-dismissal contract (bell lands separately in `claude/notification-bell-topnav-n8i58b`). The backend also emits `models.updates_available` on the EventBus when a live sweep finds updates.

## Design notes

- **No schema change.** Every pulled row already stores `metadata["sha256"]`, and HF advertises the current LFS sha on a cheap HEAD — detection is a pure comparison. Rows without HF coords are skipped; rows without a recorded local sha are reported but never flagged (hashing tens of GB on request isn't worth a badge).
- **Caching.** HF side cached per (repo, filename) for 15 min (`force: true` bypasses); the installed sha is read fresh from the registry on every call, so a badge clears as soon as a re-pull lands — no invalidation dance. The dashboard's 60s poll therefore costs one local registry read per cycle.
- **Applying an update IS a re-pull** — `POST /api/models/{id}/pull` already upserts, re-verifies the hash, and dedups queued/running jobs; no new download path.
- Per-file HF failures (404, gated, non-LFS) land on the row's `error` field; the endpoint stays 200.

## Tests

- `tests/api/test_models_update_check.py` — 9 cases (httpx `MockTransport`, same pattern as the inspect tests): sha diff/match, skip rules, missing-local-sha, TTL cache, `force`, self-healing after a re-pull, per-row errors, non-LFS files. All pass; `tests/api/test_models_routes.py` + `test_models_crud.py` + `tests/registry` (241) still green. `ruff` + `mypy` clean (no new mypy findings vs baseline).
- `ui/tests/e2e/specs/models-v3.spec.ts` — 4 new specs: badge only on outdated rows, Update all count + re-pull POSTs, empty state, and the `hal0:notify` contract shape. `tsc --noEmit` + `vite build` pass. Note: the full Playwright suite is flaky in my sandbox (pre-existing specs fail identically on a clean checkout — blank-page dev-server flake); a direct browser probe confirms the badge + button render correctly with a mocked outdated payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q)_