### PR TITLE
test(npu): align stale NPU occupancy γ-specs with the reworked card

### DIFF
--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -227,11 +227,14 @@ test.describe('NPU occupancy card (/slots · Inference tab)', () => {
     await expect(card.locator('.aie-grid .aie-col')).toHaveCount(8)
   })
 
-  test('lists a per-FLM-slot card with lifecycle controls', async ({ page }) => {
+  test('lists a per-FLM-slot card with its toggle + header lifecycle controls', async ({ page }) => {
     await page.goto('/#slots')
     const card = page.locator('.npu-card')
     await expect(card.locator('.cslot').first()).toBeVisible()
-    await expect(card.locator('.cslot .slot-ctrls').first()).toBeVisible()
+    // Per-card control is now the modality pill toggle (trio-drawer rework,
+    // #1172); slot lifecycle moved to the card-header ▶/■/↻ buttons.
+    await expect(card.locator('.cslot .npu-switch').first()).toBeVisible()
+    await expect(card.locator('.wcard-h button[title="Stop"]')).toBeVisible()
   })
 })
 

--- a/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
+++ b/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
@@ -89,23 +89,25 @@ test.describe('NPU occupancy card', () => {
     await expect(cslot.locator('.cslot-mx .tps')).toContainText('52')
   })
 
-  test('serving slot Stop control issues POST /api/slots/npu/unload', async ({ page }) => {
+  test('header Stop control issues POST /api/slots/flm/unload', async ({ page }) => {
     const unloads: string[] = []
-    await page.route('**/api/slots/npu/unload', async (route) => {
+    await page.route('**/api/slots/flm/unload', async (route) => {
       unloads.push(route.request().url())
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
     })
 
-    await seedNpu(page, NPU_SERVING_SLOT)
+    // Lifecycle moved off the per-slot cards to the card-header ▶/■/↻
+    // buttons, which target the 'flm' anchor slot (npu→flm rename; the
+    // .sctrl controls were replaced by modality pill toggles in #1172).
+    await seedNpu(page, { ...NPU_SERVING_SLOT, name: 'flm' })
     await page.goto('/#slots')
 
-    const cslot = page.locator('.npu-card .cslot').filter({ hasText: 'npu' }).first()
-    const stop = cslot.locator('.sctrl.stop')
-    await expect(stop).toHaveCount(1)
+    const stop = page.locator('.npu-card .wcard-h button[title="Stop"]')
+    await expect(stop).toBeEnabled()
     await stop.click()
 
     await expect.poll(() => unloads.length, { timeout: 5_000 }).toBeGreaterThan(0)
-    expect(unloads[0]).toContain('/api/slots/npu/unload')
+    expect(unloads[0]).toContain('/api/slots/flm/unload')
   })
 
   test('degraded probe greys the grid and labels the gauge', async ({ page }) => {

--- a/ui/tests/e2e/specs/slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-v3.spec.ts
@@ -39,7 +39,8 @@ test.describe('Slots v3 (/slots)', () => {
     await expect(card).toBeVisible()
     // 4×8 AIE-ML occupancy grid (single-tenant: one FLM claims the whole array)
     await expect(card.locator('.aie-grid .aie-col')).toHaveCount(8)
-    // at least one resident FLM slot card with its column strip
-    await expect(card.locator('.cslot .cslot-strip').first()).toBeVisible()
+    // at least one resident FLM slot card (name + metrics row — the card's
+    // inline TileStrip was removed in 86c73366, so assert the current shape)
+    await expect(card.locator('.cslot .cslot-top .nm').first()).toBeVisible()
   })
 })


### PR DESCRIPTION
## What

Extracts the γ-spec repairs from #1181 (per its review — "worth extracting into their own PR regardless of this one's fate"). Test-only; no product code.

Three Playwright specs still assert DOM the trio-drawer/NPU-card rework (#1172–#1174) removed, so the γ-suite has been **red on main — and on every open PR — since the merge** (verified by reproducing the identical failures locally on plain `main` and on two unrelated PR branches):

- **`slots-v3.spec.ts`** — asserted the per-slot card's inline TileStrip (`.cslot-strip`), removed in `86c73366`. Now asserts the card's current shape (`.cslot-top .nm`).
- **`inference-pane-v3.spec.ts`** — asserted per-card `.slot-ctrls`, which no longer exist. The per-card control is now the modality pill toggle (`.npu-switch`), with lifecycle moved to the card-header ▶/■/↻ buttons; both are asserted.
- **`npu-occupancy-v3.spec.ts`** — asserted a per-card `.sctrl.stop` Stop control. Stop now lives in the card header and targets the `flm` anchor slot, so the test seeds the slot as `flm` and asserts `POST /api/slots/flm/unload` fires.

## Verification

All 20 specs across the three files pass locally against the pinned Chromium (the three repaired ones were the only failures before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q)_