### PR TITLE
chore: #1182 review follow-ups — dev bench state wiring, manifest docstring, README de-rot

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ installed, a single FLM process inside the `hal0-toolbox-flm` container
 hosts chat + transcription + embedding concurrently on the one AMDXDNA
 hardware context — ~2 GB NPU memory, gemma3:1b at 40 tok/s +
 Whisper-V3-Turbo + Embedding-Gemma all coresident. hal0 exposes this
-as three slots (`npu`, `stt-npu`, `embed-npu`); the `npu.toml`
-`[npu]` table toggles ASR and embed. The host-side FLM `.deb` is
+as one seeded `flm` slot (chat-first) whose `[npu]` table — or the
+dashboard's NPU drawer — toggles ASR and embed on the running
+`flm serve`; the occupancy card shows the coresident STT/embed
+sub-cards. The host-side FLM `.deb` is
 installed for device-sanity probes only — inference runs in the
 container. See ADR-0009 (FLM trio NPU packing) for why.
 
@@ -151,12 +153,13 @@ be evicted out from under a streaming request.
 - **Slots** — each named target carries a `type`
   (`llm | embedding | reranking | transcription | tts | image`),
   a `device` (`gpu-rocm | gpu-vulkan | cpu | npu | img`), a `model`,
-  plus `enabled` and optional `default`. Five seeded slots (`npu`,
+  plus `enabled` and optional `default`. Five seeded slots (`flm`,
   `tts`, `rerank`, `utility`, `img`) are written to
-  `/etc/hal0/slots/<name>.toml` during install; `hal0 setup` scaffolds
+  `/etc/hal0/slots/<name>.toml` during install (each gates on its own
+  runtime validation at load time — the `flm` NPU slot simply stays
+  grey without FastFlowLM hardware); `hal0 setup` scaffolds
   additional capability slots (chat, coder, embed, stt, vision) with
-  empty model picks for the operator to fill. NPU slots (`npu`,
-  `embed-npu`, `stt-npu`) are seeded when FastFlowLM is installed.
+  empty model picks for the operator to fill.
   User-added slots via `hal0 slot create NAME --type TYPE --model MODEL`.
   Slots refer to a **profile** in `/etc/hal0/profiles.toml` that pins
   the container image + flag bundle for that backend.
@@ -306,7 +309,7 @@ hal0/
 │   └── omni_router/  # client-side tool-calling loop + tool definitions
 ├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard (v3)
 ├── installer/        # install.sh (writes /etc/hal0/, systemd units, hal0-api.service)
-│   ├── etc-hal0/     # seed slot TOMLs (npu, tts, rerank, utility, img) + profiles.toml
+│   ├── etc-hal0/     # seed slot TOMLs (flm, tts, rerank, utility, img) + profiles.toml
 │   └── systemd/      # hal0-agent@ template units
 ├── tests/            # pytest suite (α unit, β integration, γ release-gate)
 ├── docs/             # user docs (mirror of hal0.dev/docs); dev docs under docs/internal/
@@ -424,7 +427,8 @@ running on your box. Full version at [hal0.dev/#roadmap](https://hal0.dev/#roadm
 - **OmniRouter client-side tool-calling** — 8 tools, dynamic
   per-request filtering, `route_to_chat` cross-slot delegation
 - **`hal0 setup` TUI** — replaces the web FirstRun picker; the installer
-  seeds no model picks (`--auto --no-pull --no-slots`); the interactive
+  scaffolds model-less slot structure with no picks and no downloads
+  (`--auto --no-pull --no-extensions`); the interactive
   post-install flow covers storage, Extensions, models, and NPU opt-in
 - **`hal0 registry import`** — one-shot v0.1.x → v0.3 registry
   recovery from a backup tarball

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1036,15 +1036,32 @@ if [[ -f "${AGENT_UNIT_SRC}" ]]; then
         chown -R hal0:hal0 "${BENCH_STATE_DIR}" 2>/dev/null || true
         # Units: weekly scheduled session (timer→oneshot) + the run-queue worker
         # (long-running, inert until Started from the dashboard). The shipped
-        # ExecStart hardcodes the default FHS venv; rewrite it when this install
-        # uses a different prefix (HAL0_PREFIX override or --dev) so the units
-        # stay truthful about the binary they'd run.
+        # units hardcode the default FHS venv and the engine defaults its
+        # state root to /var/lib/hal0-bench; on a non-default prefix
+        # (HAL0_PREFIX override or --dev), rewrite ExecStart and inject
+        # Environment=HAL0_BENCH_STATE so the units actually run the prefix's
+        # binary against the prefix's state dir. Rewritten in python (not
+        # sed) so a prefix containing sed metacharacters can't corrupt the
+        # substitution.
         for _bench_unit in hal0-bench.service hal0-bench.timer hal0-bench-worker.service; do
             install -m 0644 "${REPO_ROOT}/installer/systemd/${_bench_unit}" "${UNIT_DIR}/${_bench_unit}"
-            if [[ "${VENV_DIR}" != "/usr/lib/hal0/venv" ]]; then
-                sed -i "s|/usr/lib/hal0/venv|${VENV_DIR}|g" "${UNIT_DIR}/${_bench_unit}"
-            fi
         done
+        if [[ "${VENV_DIR}" != "/usr/lib/hal0/venv" || "${BENCH_STATE_DIR}" != "/var/lib/hal0-bench" ]]; then
+            "${PY}" - "${UNIT_DIR}" "${VENV_DIR}" "${BENCH_STATE_DIR}" <<'PYEOF'
+import sys
+from pathlib import Path
+
+unit_dir, venv, state = sys.argv[1], sys.argv[2], sys.argv[3]
+for name in ("hal0-bench.service", "hal0-bench.timer", "hal0-bench-worker.service"):
+    p = Path(unit_dir) / name
+    text = p.read_text(encoding="utf-8").replace("/usr/lib/hal0/venv", venv)
+    if name.endswith(".service") and state != "/var/lib/hal0-bench":
+        text = text.replace(
+            "[Service]", f"[Service]\nEnvironment=HAL0_BENCH_STATE={state}", 1
+        )
+    p.write_text(text, encoding="utf-8")
+PYEOF
+        fi
         if [[ "${DEV_MODE}" -eq 0 ]]; then
             systemctl daemon-reload 2>/dev/null || true
             systemctl enable --now hal0-bench-worker.service >/dev/null 2>&1 || true

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -698,6 +698,14 @@ def _find_manifest_path() -> Path | None:
          ``HAL0_HOME`` is NOT set, so unit tests with isolated
          tmp_hal0_home don't accidentally pick up the repo-root copy.
 
+    Note the (2)-before-(3) consequence: on a box that carries BOTH a
+    production install and a bare git checkout (no ``HAL0_HOME``), code
+    imported from the checkout reads the *installed release's* pins from
+    ``current/``, not the checkout's repo-root manifest — deliberate, so
+    ad-hoc scripts on a prod box see the same images the running services
+    use. Set ``HAL0_HOME`` (or pass an explicit path) to pin a checkout to
+    its own manifest.
+
     Returns the first existing path, or None if none is found.  The
     loader's callers fall back to ":v1" tag pulls in that case.
     """


### PR DESCRIPTION
Lands the four non-blocking follow-ups from the #1182 review, in one commit:

- **Dev bench state dir is now actually wired.** On a non-default prefix (`HAL0_PREFIX` override or `--dev`), the installer injects `Environment=HAL0_BENCH_STATE=$PREFIX/var/lib/hal0-bench` (the prefix-relative state dir) into the two bench `.service` units alongside the existing ExecStart venv retarget — so `hal0 bench` run via those units targets the provisioned prefix state dir instead of silently defaulting to `/var/lib/hal0-bench`. Verified by simulating the rewrite against the shipped units (Environment lands under `[Service]`, ExecStart retargets, the timer is untouched).
- **`sed` metacharacter nit fixed by construction** — the unit rewrite moved from `sed -i "s|…|${VENV_DIR}|g"` to a python heredoc, so a prefix containing `|`/`&`/`\` can't corrupt the substitution.
- **`_find_manifest_path` docstring** now spells out the deliberate consequence of the #1182 resolution order: a bare git checkout on a box with a prod install (no `HAL0_HOME`) reads the *installed release's* pins from `current/`, matching what the running services use; set `HAL0_HOME` to pin a checkout to its own manifest.
- **Top-level README de-rotted:** the retired `npu`/`stt-npu`/`embed-npu` three-slot seed story replaced with the current single seeded `flm` slot + `[npu]`/drawer toggles; the seed list, directory-tree comment, and the installer's setup invocation (`--no-slots` is gone) corrected to match `install.sh`.

Testing: `bash -n install.sh` clean; unit-rewrite logic exercised standalone against the real shipped units; `tests/config/test_loader.py -k manifest` 8/8; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017U4kurZCVgTnheuFbEKosa