### PR TITLE
fix(flm): probe the slot's assigned model in verify_inference, not models[0] (#1171)

### DIFF
--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -498,7 +498,9 @@ class FLMProvider(Provider):
             # Do not silently swallow — surface the failure to the fail-watcher.
             return {"ok": False, "status": "exception", "detail": str(exc)}
 
-    async def verify_inference(self, port: int) -> dict[str, Any]:
+    async def verify_inference(
+        self, port: int, expected_model: str | None = None
+    ) -> dict[str, Any]:
         """One-shot real-inference gate — a single ``/v1/chat/completions``.
 
         Run EXACTLY ONCE at the warm→ready promotion (see
@@ -506,6 +508,15 @@ class FLMProvider(Provider):
         path. This is the Tier-1 check that ``/v1/models`` listing a model is
         not proof the NPU can actually produce a token (haloai
         lib/slots.py:899-920).
+
+        ``expected_model`` is the slot's assigned tag (the one it serves). The
+        sentinel MUST probe that model, not ``models[0]``: FLM's ``/v1/models``
+        returns its whole installed catalogue (sorted), so ``models[0]`` is an
+        arbitrary OTHER model. Probing it makes FLM switch/reload the wrong
+        weights onto its single NPU context mid-gate, which deadlocks the
+        in-flight load — the slot then sits in ``warming`` forever (#1171). We
+        fall back to ``models[0]`` only when the expected tag isn't advertised,
+        so this can never make an otherwise-working slot worse.
 
         The sentinel POST is wrapped in :func:`asyncio.shield`: if the load
         coroutine is cancelled mid-flight we must NOT abort an in-progress NPU
@@ -532,7 +543,8 @@ class FLMProvider(Provider):
                         "status": "models_endpoint_empty",
                         "detail": "/v1/models returned no entries",
                     }
-                model_id = models[0].get("id")
+                ids = [m.get("id") for m in models]
+                model_id = expected_model if expected_model in ids else models[0].get("id")
 
             async with httpx.AsyncClient(timeout=_HEALTH_INFER_TIMEOUT) as client:
                 probe_body = {

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3273,7 +3273,27 @@ class SlotManager:
             chat_on = npu_cfg.get("chat", True) is not False
             embed_on = bool(npu_cfg.get("embed"))
             if chat_on:
-                verdict = await provider.verify_inference(slot_port)
+                # Probe the slot's ASSIGNED model, not FLM's models[0]. FLM's
+                # /v1/models lists the whole installed catalogue, so models[0]
+                # is an arbitrary OTHER model; probing it reloads the wrong
+                # weights onto the single NPU context and deadlocks the load,
+                # wedging the slot in WARMING forever (#1171). Translate the
+                # persisted default to the served colon tag the same way the
+                # serve path does (build_env uses flm_tag), so the expected id
+                # matches what FLM advertises regardless of whether the config
+                # stores the "-FLM" id or the native tag.
+                expected_model = _model_default(cfg)
+                try:
+                    from hal0.providers.flm import flm_id_to_tag
+
+                    resolved_tag = flm_id_to_tag(expected_model)
+                    if resolved_tag:
+                        expected_model = resolved_tag
+                except ImportError:
+                    pass
+                verdict = await provider.verify_inference(
+                    slot_port, expected_model=expected_model or None
+                )
             elif embed_on:
                 verdict = await provider.verify_embed(slot_port)
             else:

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -311,6 +311,77 @@ async def test_verify_inference_requires_round_trip(provider: FLMProvider) -> No
 
 
 @pytest.mark.asyncio
+async def test_verify_inference_probes_expected_model_not_models0(
+    provider: FLMProvider,
+) -> None:
+    """Regression (#1171): the sentinel must probe the slot's ASSIGNED model.
+
+    FLM's /v1/models returns its whole installed catalogue (sorted), so
+    ``models[0]`` is an arbitrary OTHER model. Probing it makes FLM reload
+    the wrong weights onto its single NPU context mid-gate and deadlocks the
+    load, wedging the slot in WARMING forever. Given ``expected_model``, the
+    sentinel must target that tag, not the catalogue head.
+    """
+    # Sorted catalogue — models[0] is deepseek, NOT the slot's qwen3:0.6b.
+    models_payload = {
+        "data": [
+            {"id": "deepseek-r1:8b"},
+            {"id": "gemma3:1b"},
+            {"id": "qwen3:0.6b"},
+        ]
+    }
+    chat_payload = {"choices": [{"message": {"content": "x"}}]}
+
+    async def _fake_get(url: str) -> httpx.Response:
+        return _mock_response(status_code=200, json_payload=models_payload)
+
+    async def _fake_post(url: str, json: dict[str, Any]) -> httpx.Response:
+        assert json["model"] == "qwen3:0.6b", (
+            "sentinel probed the wrong model — would reload wrong weights and "
+            f"deadlock the NPU; got {json['model']!r}"
+        )
+        return _mock_response(status_code=200, json_payload=chat_payload)
+
+    with patch("hal0.providers.flm.httpx.AsyncClient") as MockClient:
+        client = MockClient.return_value.__aenter__.return_value
+        client.get = _fake_get
+        client.post = _fake_post
+        result = await provider.verify_inference(8086, expected_model="qwen3:0.6b")
+
+    assert result["ok"] is True
+    assert result["model"] == "qwen3:0.6b"
+
+
+@pytest.mark.asyncio
+async def test_verify_inference_falls_back_to_models0_when_expected_absent(
+    provider: FLMProvider,
+) -> None:
+    """When the expected tag isn't advertised, fall back to models[0].
+
+    Keeps a slot whose expected model somehow isn't in /v1/models from being
+    made worse than the pre-fix behaviour.
+    """
+    models_payload = {"data": [{"id": "deepseek-r1:8b"}, {"id": "gemma3:1b"}]}
+    chat_payload = {"choices": [{"message": {"content": "x"}}]}
+
+    async def _fake_get(url: str) -> httpx.Response:
+        return _mock_response(status_code=200, json_payload=models_payload)
+
+    async def _fake_post(url: str, json: dict[str, Any]) -> httpx.Response:
+        assert json["model"] == "deepseek-r1:8b"
+        return _mock_response(status_code=200, json_payload=chat_payload)
+
+    with patch("hal0.providers.flm.httpx.AsyncClient") as MockClient:
+        client = MockClient.return_value.__aenter__.return_value
+        client.get = _fake_get
+        client.post = _fake_post
+        result = await provider.verify_inference(8086, expected_model="qwen3:0.6b")
+
+    assert result["ok"] is True
+    assert result["model"] == "deepseek-r1:8b"
+
+
+@pytest.mark.asyncio
 async def test_verify_embed_exercises_embeddings(provider: FLMProvider) -> None:
     """The embed gate (chat-off slots) MUST POST /v1/embeddings, not chat.
 

--- a/tests/slots/test_manager_npu_container.py
+++ b/tests/slots/test_manager_npu_container.py
@@ -280,6 +280,40 @@ async def test_flm_inference_gate_runs_once_and_promotes_to_ready(
 
 
 @pytest.mark.anyio
+async def test_flm_inference_gate_passes_assigned_model(
+    slot_root: Path,
+    tmp_hal0_home: str,
+) -> None:
+    """Regression (#1171): the warm→ready gate must tell verify_inference which
+    model the slot serves, so the sentinel probes that model rather than FLM's
+    ``models[0]`` (an arbitrary other model whose reload deadlocks the NPU)."""
+    from hal0.providers.flm import FLMProvider
+    from hal0.slots.manager import SlotState
+
+    _write_npu_container_slot(slot_root, "npu")
+    fake_provider = _make_container_provider_mock()
+    gate = AsyncMock(return_value={"ok": True, "status": "ready", "model": "gemma3:4b"})
+
+    with (
+        patch("hal0.providers.container.container_provider", return_value=fake_provider),
+        patch.object(FLMProvider, "verify_inference", gate),
+        patch(
+            "hal0.providers.flm.flm_served_models",
+            return_value=[{"tag": "gemma3:4b", "installed": True}],
+        ),
+        patch("hal0.agents.hermes_refresh.spawn_context_refresh", lambda *a, **k: None),
+    ):
+        mgr = SlotManager()
+        await mgr.load("npu", "gemma3:4b")
+
+        assert mgr.state("npu") == SlotState.READY
+        assert gate.call_args.kwargs.get("expected_model") == "gemma3:4b", (
+            "the gate must pass the slot's assigned model as expected_model so "
+            f"the sentinel probes it, not models[0]; got {gate.call_args!r}"
+        )
+
+
+@pytest.mark.anyio
 async def test_flm_inference_gate_wedged_npu_stays_warming(
     slot_root: Path,
     tmp_hal0_home: str,


### PR DESCRIPTION
## Summary

Fixes #1171. On an NPU (FLM) slot the warm→ready inference sentinel probed `models[0]` — the head of FLM's **entire installed catalogue** — instead of the slot's assigned model. FLM served that request by reloading the wrong weights onto its single NPU context mid-gate, deadlocking the in-flight load. The slot then sat in `warming` forever and never became dispatchable.

## Root cause

`FLMProvider.verify_inference` picked the probe model as `models[0].get("id")`. FLM's `/v1/models` returns the whole installed catalogue, sorted (e.g. `deepseek-r1:8b, gemma3:1b, … qwen3:0.6b, …`), so `models[0]` is an arbitrary *other* model. The sentinel `POST /v1/chat/completions` therefore asked FLM to serve a different model than the slot loaded; the second, different load overlapped the first on the single NPU context and parked on a futex — permanent `warming`.

## Fix

- `verify_inference(port, expected_model=None)` now probes `expected_model` and only falls back to `models[0]` when the expected tag isn't advertised, so an otherwise-working slot can't be made worse.
- `SlotManager._await_ready` passes the slot's assigned model. Crucially it translates the persisted default through `flm_id_to_tag` the **same way the serve path builds `flm_tag`**, so the expected id matches what FLM advertises whether the config stores the native colon tag (`qwen3:0.6b`) or the hal0 `-FLM` id (`qwen3-0.6b-FLM`). Passing the raw `[model].default` would miss on the `-FLM` form and fall straight back into the deadlock.

The `verify_embed` / ASR-only paths are unchanged — they don't load a foreign chat model, so they don't hit this failure mode.

## Testing

- New `test_verify_inference_probes_expected_model_not_models0` — with a sorted catalogue whose head is `deepseek-r1:8b`, the sentinel targets the assigned `qwen3:0.6b`.
- New `test_verify_inference_falls_back_to_models0_when_expected_absent` — fallback preserved when the expected tag isn't listed.
- New `test_flm_inference_gate_passes_assigned_model` — the manager gate passes the slot's assigned model (post-`flm_id_to_tag`) as `expected_model`.
- Full `tests/providers/test_flm.py` + `tests/slots/test_manager_npu_container.py` suites pass (43 tests); ruff clean; no new mypy errors on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDf84s6iKC4CuGUnyeH4kJ)_