### PR TITLE
fix(ui): consolidate --warn color token to a single source (#1156)

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -26,10 +26,7 @@
   --comfy-line: rgba(229, 184, 79, 0.34);
   --comfy-bg: #1b1605;
   --comfy-glow: rgba(229, 184, 79, 0.2);
-  /* warming / pressure → a clear orange, far enough from the yellow accent */
-  --warn: #f2792b;
-  --warn-soft: rgba(242, 121, 43, 0.12);
-  --warn-line: rgba(242, 121, 43, 0.38);
+  /* --warn/--warn-soft/--warn-line inherit from dashboard.css (canonical #f2792b) */
   font-family: var(--geist);
   color: var(--fg);
 }

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -3,9 +3,10 @@
 /* (already defined in dashboard.css line 673). This file appends to that base. */
 
 /* ─── design tokens added for the overhaul ─────────────────────────────────── */
-/* --warming is NEW — not in dashboard.css. Amber-orange for warming/starting.  */
+/* --warming aliases the canonical --warn (dashboard.css) so the warming color   */
+/* has a single source of truth. --warming-glow is a glow rgba, kept local.      */
 :root {
-  --warming: #F2792B;
+  --warming: var(--warn);
   --warming-glow: rgba(242, 121, 43, 0.35);
   --ok-glow:  rgba(111, 207, 151, 0.35);
 }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -38,9 +38,9 @@
   --ok:           #6fcf97;
   --ok-soft:      rgba(111, 207, 151, 0.10);
   --ok-line:      rgba(111, 207, 151, 0.30);
-  --warn:         #e8b94e;
-  --warn-soft:    rgba(232, 185, 78, 0.10);
-  --warn-line:    rgba(232, 185, 78, 0.30);
+  --warn:         #f2792b;
+  --warn-soft:    rgba(242, 121, 43, 0.10);
+  --warn-line:    rgba(242, 121, 43, 0.30);
   --err:          #ef6b6b;
   --err-soft:     rgba(239, 107, 107, 0.10);
   --err-line:     rgba(239, 107, 107, 0.30);
@@ -1774,7 +1774,7 @@ a { color: inherit; text-decoration: none; }
   opacity: 0.9;
 }
 .slot.slot--warming::before {
-  background: var(--warming, #f2792b);
+  background: var(--warn);
   opacity: 0.9;
 }
 .slot.slot--error::before {


### PR DESCRIPTION
## Summary
Fixes #1156 (and completes the implementation tracked by #1155). Consolidates the warming-state color to a single canonical token `--warn: #f2792b` in `ui/src/dashboard.css`.

## Changes
- `ui/src/dashboard.css`: `--warn` `#e8b94e` → `#f2792b`; `--warn-soft`/`--warn-line` RGB → `242,121,43` (alphas unchanged). `.slot.slot--warming::before` now uses `var(--warn)` instead of the hardcoded `var(--warming, #f2792b)` fallback.
- `ui/src/dash/engine-panes.css`: removed local `--warn`/`--warn-soft`/`--warn-line` redefinitions — indicators now inherit the canonical tokens.
- `ui/src/dash/overhaul.css`: `--warming` aliased to `var(--warn)` (single source), `--warming-glow` preserved.

## Verification
- `grep -rn "^\s*--warn:" ui/src/` → exactly one definition (dashboard.css).
- `npm ci && npm run build` succeeds.
- No change to `--ok`/green, `--fg-*`, or the ready palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDf84s6iKC4CuGUnyeH4kJ)_