### PR TITLE
fix(cli): handle 409 from apply-selections gracefully during setup (#1158)

### DIFF
--- a/src/hal0/cli/setup_install.py
+++ b/src/hal0/cli/setup_install.py
@@ -190,14 +190,58 @@ async def _run_pulls_with_progress(pulls, *, slot_manager) -> None:
                 typer.echo(f"pull failed for {p.model_id}: {err}", err=True)
 
 
+def _conflict_message(resp: httpx.Response) -> str:
+    """Best-effort human-readable detail from a 409 error envelope.
+
+    The live service renders conflicts through the structured envelope
+    ``{"error": {"code", "message", "details"}}`` (see
+    :mod:`hal0.api.middleware.error_codes`). Pull the ``message`` out when it
+    is there; fall back to the raw body so we never crash while trying to
+    describe a crash.
+    """
+    try:
+        body = resp.json()
+        err = body.get("error") if isinstance(body, dict) else None
+        if isinstance(err, dict) and err.get("message"):
+            return str(err["message"])
+    except Exception:
+        pass
+    text = (resp.text or "").strip()
+    return text or "no detail provided by the service"
+
+
 async def _apply_via_api(sel) -> None:
-    """API-up path: POST the selections to the live service."""
+    """API-up path: POST the selections to the live service.
+
+    ``apply-selections`` is idempotent server-side: re-applying over
+    already-created slots is a per-slot no-op (ADR-0010), and the route is
+    documented to be safely re-runnable at any time. A ``409 Conflict`` from
+    this endpoint therefore does NOT mean setup failed — it means the live
+    service reports the install as already applied, or that another apply is
+    in flight (a concurrent ``hal0 setup``, or the dashboard's first-run
+    wizard). Blindly calling ``resp.raise_for_status()`` turned that
+    recoverable state into an unhandled ``HTTPStatusError`` traceback that
+    aborted setup (issue #1158).
+
+    We now treat a 409 as a recoverable no-op: surface the service's own
+    message and continue cleanly, leaving any existing slots untouched. All
+    other non-2xx statuses still raise so genuine failures aren't hidden.
+    """
     payload = dataclasses.asdict(sel)
     url = f"{_api_base()}/api/install/apply-selections"
     async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
         resp = await client.post(url, json=payload)
-        resp.raise_for_status()
-        data = resp.json()
+    if resp.status_code == 409:
+        dashboard = await _dashboard_url()
+        typer.echo(
+            "hal0 setup: the live service reports the install is already "
+            f"applied or an apply is already in progress ({_conflict_message(resp)}). "
+            "Skipping re-apply — existing slots are left unchanged. "
+            f"Dashboard: {dashboard}"
+        )
+        return
+    resp.raise_for_status()
+    data = resp.json()
     n_models = len(data.get("model_ids", []))
     n_slots = len(data.get("slots", []))
     dashboard = await _dashboard_url()

--- a/tests/cli/test_setup_install.py
+++ b/tests/cli/test_setup_install.py
@@ -1,5 +1,7 @@
-from hal0.cli.setup_install import _apply_in_process, choose_apply_mode
-from hal0.install.orchestrate import SetupResult
+import httpx
+
+from hal0.cli.setup_install import _apply_in_process, _apply_via_api, choose_apply_mode
+from hal0.install.orchestrate import Selections, SetupResult
 
 
 def test_mode_in_process_when_api_down(monkeypatch):
@@ -73,3 +75,83 @@ async def test_apply_in_process_no_token_passes_none(monkeypatch):
     await _apply_in_process(sel=object(), hw=object(), no_pull=True)
 
     assert captured["hf_token"] is None
+
+
+# ── _apply_via_api: graceful 409 handling (issue #1158) ──────────────────────
+
+
+def _empty_selections() -> Selections:
+    return Selections(storage_dir="", slots=[], extensions={})
+
+
+class _FakeAsyncClient:
+    """Stand-in for ``httpx.AsyncClient`` that returns a canned POST response.
+
+    ``apply-selections`` is POSTed; ``_dashboard_url`` issues a GET we don't
+    care about here, so GET raises and the URL resolver falls back to the API
+    base (its documented degradation)."""
+
+    _post_response: httpx.Response
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, **kwargs):
+        return type(self)._post_response
+
+    async def get(self, url, **kwargs):
+        raise httpx.ConnectError("dashboard url probe not stubbed")
+
+
+def _install_fake_client(monkeypatch, response: httpx.Response) -> None:
+    _FakeAsyncClient._post_response = response
+    monkeypatch.setattr("hal0.cli.setup_install.httpx.AsyncClient", _FakeAsyncClient)
+
+
+async def test_apply_via_api_409_is_recoverable(monkeypatch, capsys):
+    """A 409 from apply-selections must NOT abort setup with an HTTPStatusError.
+
+    The endpoint is idempotent/re-runnable, so a conflict means "already applied
+    or apply in progress" — we surface the message and continue (issue #1158)."""
+    resp = httpx.Response(
+        status_code=409,
+        json={
+            "error": {
+                "code": "install.apply_in_progress",
+                "message": "an apply is already in progress",
+                "details": {},
+            }
+        },
+        request=httpx.Request("POST", "http://127.0.0.1:8080/api/install/apply-selections"),
+    )
+    _install_fake_client(monkeypatch, resp)
+
+    # Must not raise (previously raise_for_status() blew up here).
+    await _apply_via_api(_empty_selections())
+
+    out = capsys.readouterr().out
+    assert "already" in out.lower()
+    assert "an apply is already in progress" in out
+
+
+async def test_apply_via_api_non_conflict_error_still_raises(monkeypatch):
+    """A genuine server failure (500) still surfaces — we only soften 409."""
+    resp = httpx.Response(
+        status_code=500,
+        json={"error": {"code": "system.internal", "message": "boom"}},
+        request=httpx.Request("POST", "http://127.0.0.1:8080/api/install/apply-selections"),
+    )
+    _install_fake_client(monkeypatch, resp)
+
+    try:
+        await _apply_via_api(_empty_selections())
+    except httpx.HTTPStatusError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected HTTPStatusError for a 500 response")


### PR DESCRIPTION
## Summary
Fixes #1158. `hal0 setup` aborted with a raw `HTTPStatusError` traceback when `POST /api/install/apply-selections` returned `409 Conflict`.

## Root cause
`_apply_via_api` (`src/hal0/cli/setup_install.py`) called `resp.raise_for_status()` on every non-2xx, turning a recoverable 409 (install already applied / a concurrent apply in flight — e.g. install.sh `--auto` still settling, or the dashboard first-run wizard) into a fatal traceback. The server route (`_apply_selections_core` → `apply_setup`) is genuinely idempotent — it returned HTTP 200 in every reproducible state (fresh box, re-run, multi-slot, NPU present, pre-existing enabled flm slot); the fragile link was the CLI.

## Fix
`_apply_via_api` now detects a 409, surfaces the structured error-envelope message with a clean actionable line ("install already applied or an apply is already in progress … skipping re-apply — existing slots left unchanged"), and returns gracefully. All other non-2xx statuses still raise so genuine failures aren't hidden.

## Tests
- `test_apply_via_api_409_is_recoverable`, `test_apply_via_api_non_conflict_error_still_raises` in `tests/cli/test_setup_install.py`.
- `pytest tests/cli/test_setup_install.py` (7) + `tests/api/test_apply_selections.py` (2) green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDf84s6iKC4CuGUnyeH4kJ)_