### PR TITLE
feat(ui): model updates in the notification bell + always-visible Check updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ applying. Add those subsections to a version's section to surface them; see
 ## [Unreleased]
 
 ### Added
+- Model updates surface in the topbar notification bell: the update check now runs app-level, so "N model updates available" appears (with an Update all action) without opening the Models page, and the row self-clears once updates land. The Models page gains an always-visible "Check updates" button that bypasses the check's TTL cache when nothing is currently flagged.
 - `hal0-brain` agent profile: a third seeded persona (alongside `hermes` and `coder`) that stewards the platform from the dashboard's agent-chat slide-out — its own memory namespace (`private:hal0-brain`), a hal0-heavy system prompt (slot lifecycle, model setup, benchmarking), and the dedicated `brain` slot (`hal0/brain`) as the default model.
 - Board/agent chat streams a `{type:"thinking"}` SSE frame: explicit `reasoning_content` and inline `<think>…</think>` blocks are split out of the reply and rendered as a folded "thinking" section instead of raw tags.
 

--- a/ui/src/api/hooks/useModels.ts
+++ b/ui/src/api/hooks/useModels.ts
@@ -234,6 +234,22 @@ export function useModelUpdatesCheck() {
   })
 }
 
+export function useModelUpdatesForceCheck() {
+  // GET /api/models/updates/check?refresh=1 — bypass the server's TTL
+  // cache. Backs the Models page's explicit "Check updates" affordance:
+  // the fresh snapshot is written into ['model-updates'] and the catalog
+  // is refetched so row badges flip immediately.
+  const qc = useQueryClient()
+  return useMutation<ModelUpdatesCheckResponse, Hal0Error, void>({
+    mutationFn: () =>
+      apiGet<ModelUpdatesCheckResponse>(`${ENDPOINTS.modelUpdatesCheck}?refresh=1`),
+    onSuccess: (res) => {
+      qc.setQueryData(['model-updates'], res)
+      qc.invalidateQueries({ queryKey: ['models'] })
+    },
+  })
+}
+
 export function useModelUpdateApply() {
   // POST /api/models/{id}/update — re-pull the row's HF file over its
   // installed path. Progress reports through the standard pull surface

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -7,7 +7,7 @@
 import { useRuntimeRollup, useHealthSystem, failingChecks } from '@/api/hooks/useRuntime'
 import { useLogsStream } from '@/api/hooks/useLogs'
 import { useSlots } from '@/api/hooks/useSlots'
-import { useModels, usePullsList, useClearPullJob, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, useModelUpdatesCheck, useModelUpdateAll, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useMemoryEnabled } from '@/api/hooks/useMemory'
@@ -241,10 +241,21 @@ function NotificationBell() {
   const driftCount = drift.data?.count ?? 0;
   const restartDrifted = useRestartDriftedSlots();
 
+  // Model updates (HF) — probed app-level so the bell fires without the
+  // Models page ever being opened. The row derives LIVE from /api/models
+  // update_available flags rather than a message store, so it self-clears
+  // the moment updates land and never duplicates when the outdated set
+  // changes (#1181 review follow-up).
+  useModelUpdatesCheck();
+  const models = useModels().data ?? [];
+  const updatableModels = models.filter((m) => m.installed && m.update_available);
+  const updateAllModels = useModelUpdateAll();
+
   const count =
     approvals.length + errorSlots.length +
     activePulls.length + failedPulls.length +
     (hasUpdate ? 1 : 0) + (driftCount > 0 ? 1 : 0) +
+    (updatableModels.length > 0 ? 1 : 0) +
     devMsgs.length;
 
   // Close on outside click / Escape while open.
@@ -344,10 +355,24 @@ function NotificationBell() {
     );
   }
 
-  if (hasUpdate || driftCount > 0) {
+  if (hasUpdate || driftCount > 0 || updatableModels.length > 0) {
     sections.push(
       <div className="notif-sec" data-testid="notif-sec-updates" key="updates">
         <div className="notif-sec-h mono">updates</div>
+        {updatableModels.length > 0 && (
+          <div className="notif-row" data-testid="notif-model-updates">
+            <span className="notif-dot" style={{ background: "var(--accent)" }} />
+            <span className="notif-msg">
+              {updatableModels.length} model update{updatableModels.length !== 1 ? "s" : ""} available on HuggingFace
+            </span>
+            <button
+              className="notif-act"
+              disabled={updateAllModels.isPending}
+              onClick={() => updateAllModels.mutate(updatableModels.map((m) => m.id))}
+            >{updateAllModels.isPending ? "Starting…" : "Update all"}</button>
+            <button className="notif-act" onClick={() => go("#models")}>View</button>
+          </div>
+        )}
         {hasUpdate && (
           <div className="notif-row">
             <span className="notif-dot" style={{ background: "var(--accent)" }} />

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -7,7 +7,7 @@
 // /api/models/{id}, and the Downloads pane is a thin shell around
 // per-row usePullJob() instances tracked by model_id.
 
-import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, useModelUpdatesCheck, useModelUpdateApply, useModelUpdateAll, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
+import { useModels, usePullsList, useClearPullJob, usePullJob, useHfSearch, useModelUpdatesCheck, useModelUpdatesForceCheck, useModelUpdateApply, useModelUpdateAll, fmtBytes, fmtSpeed, fmtEta } from '@/api/hooks/useModels'
 import { apiPost } from '@/api/client'
 import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
@@ -17,7 +17,7 @@ import { MODEL_SORT_FIELDS, sortModels, fmtAdded } from '@/dash/model-sort.js'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
-// ── Simplified filter chips ────────────────────────────────────────────
+// ── Simplified filter chips ───────────────────────────────────────
 // Each chip is a multi-select toggle with OR semantics (empty = show all).
 // "DENSE" means neither MTP nor MOE; checked by absence of those tags.
 const FILTER_CHIPS = [
@@ -38,7 +38,7 @@ function modelMatchesFilters(m, filterSel) {
   });
 }
 
-// ── Pagination ─────────────────────────────────────────────────────────
+// ── Pagination ─────────────────────────────────────────────────
 const PER_PAGE_OPTS = [10, 25, 50, "all"];
 
 function usePageReset(deps) {
@@ -51,7 +51,7 @@ function usePageReset(deps) {
   return changed;
 }
 
-// ── ModelsView ─────────────────────────────────────────────────────────
+// ── ModelsView ────────────────────────────────────────────────
 function ModelsView() {
   const [selId, setSelId] = useStateM(null);
   // Simplified multi-select OR filters
@@ -84,6 +84,22 @@ function ModelsView() {
   // mount; /api/models then carries per-row `update_available` flags.
   useModelUpdatesCheck();
   const updateAll = useModelUpdateAll();
+  const forceCheck = useModelUpdatesForceCheck();
+  const onCheckUpdates = async () => {
+    try {
+      const res = await forceCheck.mutateAsync();
+      window.__hal0Toast && window.__hal0Toast(
+        res.updates_available > 0
+          ? `${res.updates_available} model update${res.updates_available === 1 ? "" : "s"} available`
+          : `All ${res.checked} checked model${res.checked === 1 ? "" : "s"} up to date`,
+        "info",
+      );
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(
+        `Update check failed — ${e?.message || "see logs"}`, "err",
+      );
+    }
+  };
   const updatable = modelList.filter(m => m.installed && m.update_available);
   const onUpdateAll = async () => {
     if (!updatable.length) return;
@@ -119,14 +135,14 @@ function ModelsView() {
 
   const selected = modelList.find(m => m.id === selId) || modelList[0];
 
-  // ── isComfy helper ──────────────────────────────────────────────────
+  // ── isComfy helper ───────────────────────────────────────────
   const isComfy = m =>
     m.owned_by === "comfyui" ||
     (Array.isArray(m.backends) && m.backends.includes("comfyui")) ||
     !!m.comfyui_category ||
     m.type === "image";
 
-  // ── Combined filter (text + OR chips) ───────────────────────────────
+  // ── Combined filter (text + OR chips) ──────────────────────────────
   const fil = m => {
     if (!modelMatchesFilters(m, filterSel)) return false;
     if (q.trim()) {
@@ -139,7 +155,7 @@ function ModelsView() {
 
   const bySort = rows => sortModels(rows, sortField, sortDir);
 
-  // ── Tab datasets ────────────────────────────────────────────────────
+  // ── Tab datasets ────────────────────────────────────────────
   // Inference: installed + blessed + user.* (not upstream, not comfy)
   const installed = modelList.filter(m => m.installed && !isComfy(m) && !isUpstreamModel(m) && fil(m));
   const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && !isUpstreamModel(m) && fil(m));
@@ -170,7 +186,7 @@ function ModelsView() {
   for (const cat of comfyCats) comfyRows.push(...bySort(comfyByCat[cat]));
   const comfyTotal = modelList.filter(m => m.installed && isComfy(m)).length;
 
-  // ── Pagination logic ────────────────────────────────────────────────
+  // ── Pagination logic ───────────────────────────────────────
   const activeRows = tab === "inference" ? inferenceRows
     : tab === "upstream" ? upstreamRows
     : comfyRows;
@@ -206,7 +222,7 @@ function ModelsView() {
 
   const pullsList = usePullsList();
 
-  // ── Render ──────────────────────────────────────────────────────────
+  // ── Render ─────────────────────────────────────────────────
   const tabLabel = tab === "inference" ? `Inference Models${inferenceRows.length ? ` · ${inferenceRows.length}` : ""}`
     : tab === "upstream" ? `Upstream Models${upstreamTotal ? ` · ${upstreamTotal}` : ""}`
     : `Image / ComfyUI${comfyTotal ? ` · ${comfyTotal}` : ""}`;
@@ -217,7 +233,7 @@ function ModelsView() {
         <span className="vh-eye mono">Catalog</span>
         <h1>Models</h1>
         <span className="vh-spacer" />
-        {updatable.length > 0 && (
+        {updatable.length > 0 ? (
           <button
             className="btn"
             data-testid="mdl-update-all"
@@ -225,6 +241,17 @@ function ModelsView() {
             title="Re-pull every installed model whose HuggingFace file has changed"
             onClick={onUpdateAll}
           >{Icons.download} {updateAll.isPending ? "Starting…" : `Update all (${updatable.length})`}</button>
+        ) : (
+          /* Everything current → the update surface would otherwise be
+             invisible. Keep an explicit check affordance so the feature is
+             discoverable and the TTL cache can be bypassed on demand. */
+          <button
+            className="btn ghost"
+            data-testid="mdl-check-updates"
+            disabled={forceCheck.isPending}
+            title="Compare every installed model against its HuggingFace repo now"
+            onClick={onCheckUpdates}
+          >{Icons.download} {forceCheck.isPending ? "Checking…" : "Check updates"}</button>
         )}
         <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
         <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
@@ -410,7 +437,7 @@ function ModelsView() {
   );
 }
 
-// ── HF Search Panel ───────────────────────────────────────────────────
+// ── HF Search Panel ──────────────────────────────────────────────
 function HfSearchPanel({ q, onQ, onPick, onClose }) {
   const search = useHfSearch(q);
   const rows = search.data?.results ?? [];
@@ -469,7 +496,7 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
   );
 }
 
-// ── ModelRow ──────────────────────────────────────────────────────────
+// ── ModelRow ──────────────────────────────────────────────────
 function ModelRow({ model, selected, onSelect }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
@@ -504,7 +531,7 @@ function ModelRow({ model, selected, onSelect }) {
   );
 }
 
-// ── ModelDetail ───────────────────────────────────────────────────────
+// ── ModelDetail ──────────────────────────────────────────────
 function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
@@ -702,7 +729,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   );
 }
 
-// ── DownloadRow ───────────────────────────────────────────────────────
+// ── DownloadRow ──────────────────────────────────────────────
 // One row in the Downloads pane. Owns its own cancelling state via
 // useStateM — must be its own component because it is rendered from a
 // list (jobs.map). Calling a hook inside a .map() callback causes
@@ -786,7 +813,7 @@ function DownloadRow({ job, clearJob }) {
   );
 }
 
-// ── DownloadsPane ─────────────────────────────────────────────────────
+// ── DownloadsPane ────────────────────────────────────────────
 function DownloadsPane() {
   const { jobs } = usePullsList();
   const clearJob = useClearPullJob();

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -17,7 +17,7 @@ import { MODEL_SORT_FIELDS, sortModels, fmtAdded } from '@/dash/model-sort.js'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
-// ── Simplified filter chips ───────────────────────────────────────
+// ── Simplified filter chips ────────────────────────────────────────────
 // Each chip is a multi-select toggle with OR semantics (empty = show all).
 // "DENSE" means neither MTP nor MOE; checked by absence of those tags.
 const FILTER_CHIPS = [
@@ -38,7 +38,7 @@ function modelMatchesFilters(m, filterSel) {
   });
 }
 
-// ── Pagination ─────────────────────────────────────────────────
+// ── Pagination ─────────────────────────────────────────────────────────
 const PER_PAGE_OPTS = [10, 25, 50, "all"];
 
 function usePageReset(deps) {
@@ -51,7 +51,7 @@ function usePageReset(deps) {
   return changed;
 }
 
-// ── ModelsView ────────────────────────────────────────────────
+// ── ModelsView ─────────────────────────────────────────────────────────
 function ModelsView() {
   const [selId, setSelId] = useStateM(null);
   // Simplified multi-select OR filters
@@ -135,14 +135,14 @@ function ModelsView() {
 
   const selected = modelList.find(m => m.id === selId) || modelList[0];
 
-  // ── isComfy helper ───────────────────────────────────────────
+  // ── isComfy helper ──────────────────────────────────────────────────
   const isComfy = m =>
     m.owned_by === "comfyui" ||
     (Array.isArray(m.backends) && m.backends.includes("comfyui")) ||
     !!m.comfyui_category ||
     m.type === "image";
 
-  // ── Combined filter (text + OR chips) ──────────────────────────────
+  // ── Combined filter (text + OR chips) ───────────────────────────────
   const fil = m => {
     if (!modelMatchesFilters(m, filterSel)) return false;
     if (q.trim()) {
@@ -155,7 +155,7 @@ function ModelsView() {
 
   const bySort = rows => sortModels(rows, sortField, sortDir);
 
-  // ── Tab datasets ────────────────────────────────────────────
+  // ── Tab datasets ────────────────────────────────────────────────────
   // Inference: installed + blessed + user.* (not upstream, not comfy)
   const installed = modelList.filter(m => m.installed && !isComfy(m) && !isUpstreamModel(m) && fil(m));
   const blessed = modelList.filter(m => !m.installed && m.ns === "blessed" && !isComfy(m) && !isUpstreamModel(m) && fil(m));
@@ -186,7 +186,7 @@ function ModelsView() {
   for (const cat of comfyCats) comfyRows.push(...bySort(comfyByCat[cat]));
   const comfyTotal = modelList.filter(m => m.installed && isComfy(m)).length;
 
-  // ── Pagination logic ───────────────────────────────────────
+  // ── Pagination logic ────────────────────────────────────────────────
   const activeRows = tab === "inference" ? inferenceRows
     : tab === "upstream" ? upstreamRows
     : comfyRows;
@@ -222,7 +222,7 @@ function ModelsView() {
 
   const pullsList = usePullsList();
 
-  // ── Render ─────────────────────────────────────────────────
+  // ── Render ──────────────────────────────────────────────────────────
   const tabLabel = tab === "inference" ? `Inference Models${inferenceRows.length ? ` · ${inferenceRows.length}` : ""}`
     : tab === "upstream" ? `Upstream Models${upstreamTotal ? ` · ${upstreamTotal}` : ""}`
     : `Image / ComfyUI${comfyTotal ? ` · ${comfyTotal}` : ""}`;
@@ -437,7 +437,7 @@ function ModelsView() {
   );
 }
 
-// ── HF Search Panel ──────────────────────────────────────────────
+// ── HF Search Panel ───────────────────────────────────────────────────
 function HfSearchPanel({ q, onQ, onPick, onClose }) {
   const search = useHfSearch(q);
   const rows = search.data?.results ?? [];
@@ -496,7 +496,7 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
   );
 }
 
-// ── ModelRow ──────────────────────────────────────────────────
+// ── ModelRow ──────────────────────────────────────────────────────────
 function ModelRow({ model, selected, onSelect }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
   return (
@@ -531,7 +531,7 @@ function ModelRow({ model, selected, onSelect }) {
   );
 }
 
-// ── ModelDetail ──────────────────────────────────────────────
+// ── ModelDetail ───────────────────────────────────────────────────────
 function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   const pull = usePullJob();
   const slotsQuery = useSlots();
@@ -729,7 +729,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
   );
 }
 
-// ── DownloadRow ──────────────────────────────────────────────
+// ── DownloadRow ───────────────────────────────────────────────────────
 // One row in the Downloads pane. Owns its own cancelling state via
 // useStateM — must be its own component because it is rendered from a
 // list (jobs.map). Calling a hook inside a .map() callback causes
@@ -813,7 +813,7 @@ function DownloadRow({ job, clearJob }) {
   );
 }
 
-// ── DownloadsPane ────────────────────────────────────────────
+// ── DownloadsPane ─────────────────────────────────────────────────────
 function DownloadsPane() {
   const { jobs } = usePullsList();
   const clearJob = useClearPullJob();

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -204,4 +204,24 @@ test.describe('Models v3 (/models)', () => {
     await page.locator('button:has-text("Delete model")').click()
     await expect.poll(() => deleted).toBe(true)
   })
+
+  test('Check updates affordance forces a refresh when nothing is outdated', async ({ page }) => {
+    const checks: string[] = []
+    await page.route('**/api/models/updates/check*', async (route) => {
+      checks.push(route.request().url())
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ checked_at: 1730000000, checked: 5, updates_available: 0, models: {} }),
+      })
+    })
+    await page.goto('/#models')
+    // Nothing outdated in the mock catalog → the explicit check affordance
+    // renders instead of Update-all (the surface must never be invisible).
+    const btn = page.getByTestId('mdl-check-updates')
+    await expect(btn).toBeVisible()
+    await expect(page.getByTestId('mdl-update-all')).toHaveCount(0)
+    await btn.click()
+    await expect.poll(() => checks.some((u) => u.includes('refresh=1'))).toBe(true)
+  })
 })

--- a/ui/tests/e2e/specs/notification-bell-v3.spec.ts
+++ b/ui/tests/e2e/specs/notification-bell-v3.spec.ts
@@ -187,4 +187,40 @@ test.describe('Notification bell (topbar)', () => {
       'Nightly channel now available',
     )
   })
+
+  test('model updates — badge + row render app-level, Update all fans out', async ({ page }) => {
+    await withUpdateState(page, NO_UPDATE)
+    // Flag one installed mock model as updatable — forced-mock serves
+    // HAL0_DATA.models verbatim, and update_available flows through
+    // normalizeApiModel untouched. Note: no navigation to #models — the
+    // bell must fire from the app shell alone.
+    await page.addInitScript(() => {
+      document.addEventListener('DOMContentLoaded', () => {
+        const D = (window as any).HAL0_DATA
+        const m = D?.models?.find((x: any) => x.id === 'qwen3.6-27b-mtp')
+        if (m) m.update_available = true
+      })
+    })
+    const updates: string[] = []
+    await page.route('**/api/models/qwen3.6-27b-mtp/update', async (route) => {
+      updates.push(route.request().url())
+      await route.fulfill({ status: 202, contentType: 'application/json', body: '{}' })
+    })
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveText('1', { timeout: 6_000 })
+    await page.getByTestId('tb-bell').click()
+    const row = page.getByTestId('notif-model-updates')
+    await expect(row).toBeVisible()
+    await expect(row).toContainText('1 model update available on HuggingFace')
+    await row.getByRole('button', { name: 'Update all' }).click()
+    await expect.poll(() => updates.length).toBeGreaterThan(0)
+  })
+
+  test('no outdated models — the model-updates row self-clears (absent)', async ({ page }) => {
+    await withUpdateState(page, NO_UPDATE)
+    await page.goto('/')
+    await expect(page.getByTestId('tb-bell-badge')).toHaveCount(0)
+    await page.getByTestId('tb-bell').click()
+    await expect(page.getByTestId('notif-model-updates')).toHaveCount(0)
+  })
 })


### PR DESCRIPTION
## What

The two follow-ups recommended by #1181's review, built on #1178 as landed — plus the discoverability gap that prompted "I don't see the update models UI element anywhere":

**1. Model updates surface in the topbar notification bell (app-level).**
`NotificationBell` now runs `useModelUpdatesCheck()` itself, so the HF probe fires from the app shell — the operator gets notified without ever opening the Models page. The bell's *updates* section gains an "N model updates available on HuggingFace" row with **Update all** (fans out via `useModelUpdateAll`) and **View** (→ `#models`) actions, and the badge counts it.

Rather than porting the `hal0:notify` message approach from #1181, the row derives **live** from `/api/models` `update_available` flags: it self-clears the moment updates land and a changed outdated set can never leave a stale duplicate behind — which is exactly the clear-on-empty-set rule the review asked for, with no message-store bookkeeping.

**2. The update surface is no longer invisible when everything is current.**
Previously every element (header button, row badge, detail Update) was gated on `update_available`, so with all models up to date the feature had zero footprint. The Models header now shows an explicit **Check updates** button in that state, backed by a new `useModelUpdatesForceCheck()` (`GET /api/models/updates/check?refresh=1`) that bypasses the server's TTL cache and toasts the verdict ("All N checked models up to date" / "N updates available"). This also resolves the review's "errors are negatively cached for the full TTL with no recover affordance" point.

No backend changes — everything rides #1178's endpoints.

## Testing

- `notification-bell-v3.spec.ts` +2: app-level badge/row rendering with **no navigation to `#models`**, Update all fan-out asserting `POST /api/models/{id}/update`, and the self-clearing empty state.
- `models-v3.spec.ts` +1: the Check-updates affordance renders when nothing is outdated and forces `?refresh=1`.
- All 21 specs across both files pass locally against the pinned Chromium; `tsc --noEmit` + `vite build` clean.

Note: `git push` is broken in this container, so the branch was pushed via the GitHub API in chunked commits (content verified byte-exact against the locally tested tree via blob-SHA compare) — a squash-merge will collapse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q

---
_Generated by [Claude Code](https://claude.ai/code/session_014gj5YALNZfAHb7qMvdCr8Q)_