### PR TITLE
release: v0.9.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [0.9.6.1] — 2026-07-11
+
 ### Added
 - `hal0-brain` agent profile: a third seeded persona (alongside `hermes` and `coder`) that stewards the platform from the dashboard's agent-chat slide-out — its own memory namespace (`private:hal0-brain`), a hal0-heavy system prompt (slot lifecycle, model setup, benchmarking), and the dedicated `brain` slot (`hal0/brain`) as the default model.
 - Board/agent chat streams a `{type:"thinking"}` SSE frame: explicit `reasoning_content` and inline `<think>…</think>` blocks are split out of the reply and rendered as a folded "thinking" section instead of raw tags.
@@ -29,6 +31,12 @@ applying. Add those subsections to a version's section to surface them; see
 - The top-bar agent chat now embodies the `hal0-brain` profile: it runs on `hal0/brain` (falls back to the `agent` slot via the resolver chain), and an operator-edited `hal0-brain` persona TOML overrides its system prompt/model without a code change.
 - Agent-chat suggestion chips are now platform-steward starters ("Help me create a new slot", "Download and set up a model", "Benchmark the model on a slot", "How's the hardware doing?").
 - Agent-chat replies render markdown (fences, lists, headings, bold/italic/inline code, links); tool calls render as structured cards with args, live status, and a folded result — replacing the raw `→ tool({json})` text rows.
+
+### Fixed
+- FLM NPU slots no longer wedge in `warming` forever: the warm→ready inference sentinel now probes the slot's **assigned** model instead of `models[0]` from FLM's full catalogue. Probing an arbitrary other model forced FLM to reload the wrong weights onto its single NPU context mid-gate and deadlocked the load (#1171).
+- `hal0 setup` no longer aborts with a raw `HTTPStatusError` traceback when `apply-selections` returns `409 Conflict`: the setup CLI now treats a 409 (install already applied / a concurrent apply in flight) as a recoverable no-op with a clean message, and still raises on genuine errors (#1158).
+- Unified the dashboard warming-state color to a single canonical `--warn: #f2792b` token in `dashboard.css`, removing the divergent local redefinitions in `engine-panes.css`/`overhaul.css` so every warming indicator renders the same orange-yellow (#1156, #1155).
+- Added an ESLint `no-undef` guard (enforced in CI) over the dash `.jsx` prototype so an undefined identifier like the one behind the Create Slot crash can't ship again (#1170).
 
 ## [0.9.6] — 2026-07-10
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md §12 (toolbox images) and §17 (Risks).",
-  "version": "0.9.6",
+  "version": "0.9.6.1",
   "channel": "stable",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hal0"
-version = "0.9.6"
+version = "0.9.6.1"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
Cuts the **v0.9.6.1** patch release. Bumps `pyproject.toml` + `manifest.json` `0.9.6 → 0.9.6.1` and promotes the accumulated `[Unreleased]` CHANGELOG notes into a dated `[0.9.6.1]` section.

## Bundled fixes (all merged to `main`)
- **#1171** — FLM slot warm→ready sentinel probes the slot's assigned model instead of `models[0]`, ending the permanent-`warming` NPU deadlock (PR #1185).
- **#1158** — `hal0 setup` treats a `409 Conflict` from `apply-selections` as a recoverable no-op instead of crashing with a traceback (PR #1187).
- **#1156 / #1155** — unified the warming-state color to a single canonical `--warn: #f2792b` token (PR #1186).
- **#1170** — dash-JSX `no-undef` ESLint guard, enforced in CI (PR #1188).

## Release gate
- All toolbox_images digests pinned (release manifest generation would refuse otherwise).
- `pyproject.toml` version (`0.9.6.1`) matches the tag to be cut (`v0.9.6.1`).

## After merge
Tag `v0.9.6.1` on the merge commit and push it to trigger `release.yml`.

## Not included
- **#1159** (cosign) — held in draft PR #1189 pending validation (unverifiable without a real post-expiry release; manifest-schema back-compat needs work).
- **#1157** (warm-color e2e snapshots) — deferred (Playwright screenshot baselines are CI-environment-fragile; no committed PNG baselines exist yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDf84s6iKC4CuGUnyeH4kJ)_