### PR TITLE
fix(flm): FLM model pulls die instantly in prod — uvloop rejects user/group spawn kwargs

### DIFF
--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -690,7 +690,7 @@ def _classify_flm_model(entry: dict[str, Any]) -> list[str]:
 
 
 def flm_host_spawn_kwargs() -> dict[str, Any]:
-    """subprocess/asyncio kwargs to run host ``flm`` as the hal0 identity.
+    """``subprocess.run`` kwargs to run host ``flm`` as the hal0 identity.
 
     Sets ``HOME`` so flm resolves ``~/.config/flm/models`` to the real on-disk
     cache, and drops to the ``hal0`` user/group when we have the privilege
@@ -698,9 +698,10 @@ def flm_host_spawn_kwargs() -> dict[str, Any]:
     user (dev/test), ``user=`` would raise ``PermissionError``, so we skip it
     and rely on the caller already being the model owner.
 
-    Accepted by both :func:`subprocess.run` and
-    :func:`asyncio.create_subprocess_exec` (the ``user``/``group`` kwargs are
-    available on Python ≥ 3.9).
+    SYNC CALLERS ONLY: ``user``/``group`` are Popen kwargs (Python ≥ 3.9) that
+    uvloop's ``subprocess_exec`` rejects (``ValueError: unexpected kwargs``),
+    and hal0-api serves under uvicorn/uvloop — async callers must use
+    :func:`flm_host_async_spawn` instead.
     """
     import pwd
 
@@ -714,6 +715,32 @@ def flm_host_spawn_kwargs() -> dict[str, Any]:
         # Unknown user, or geteuid unavailable (non-POSIX) — run as-is.
         pass
     return kwargs
+
+
+def flm_host_async_spawn(argv: list[str]) -> tuple[list[str], dict[str, Any]]:
+    """Return ``(argv, kwargs)`` for spawning host ``flm`` from async code.
+
+    Same identity semantics as :func:`flm_host_spawn_kwargs`, but safe for
+    ``asyncio.create_subprocess_exec`` under uvloop: uvloop rejects the
+    ``user``/``group`` Popen kwargs (``ValueError: unexpected kwargs``), so
+    the drop to the hal0 user happens on the command line instead — via
+    ``setpriv`` (util-linux), falling back to ``runuser``. If neither tool
+    exists we spawn undemoted rather than fail the pull; the weights then
+    land root-owned but world-readable, so serving still works.
+    """
+    import shutil
+
+    kwargs = flm_host_spawn_kwargs()
+    user = kwargs.pop("user", None)
+    kwargs.pop("group", None)
+    if user:
+        setpriv = shutil.which("setpriv")
+        runuser = shutil.which("runuser")
+        if setpriv:
+            argv = [setpriv, f"--reuid={user}", f"--regid={user}", "--init-groups", "--", *argv]
+        elif runuser:
+            argv = [runuser, "-u", user, "--", *argv]
+    return argv, kwargs
 
 
 def _extract_json_object(text: str) -> dict[str, Any] | None:

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1198,7 +1198,7 @@ async def run_flm_pull(
     # base pull module's import graph (tests pull this module in
     # environments without docker).
     from hal0.providers.flm import (
-        flm_host_spawn_kwargs,
+        flm_host_async_spawn,
         flm_pull_command,
         flm_served_models,
         reset_flm_catalog_cache,
@@ -1225,6 +1225,10 @@ async def run_flm_pull(
         job.bytes_total = advertised_total
         job._signal()
 
+    # uvloop (hal0-api's event loop) rejects the user/group Popen kwargs, so
+    # the drop to the hal0 user rides the argv (setpriv/runuser) instead.
+    argv, spawn_kwargs = flm_host_async_spawn(argv)
+
     proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
@@ -1232,7 +1236,7 @@ async def run_flm_pull(
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-            **flm_host_spawn_kwargs(),
+            **spawn_kwargs,
         )
         assert proc.stdout is not None
         last_emit = time.monotonic()

--- a/tests/providers/test_flm.py
+++ b/tests/providers/test_flm.py
@@ -553,6 +553,39 @@ def test_spawn_kwargs_sets_home_and_skips_user_when_not_root() -> None:
     assert "user" not in kw
 
 
+def test_async_spawn_demotes_via_setpriv_not_kwargs() -> None:
+    """As root, the drop to hal0 rides the argv (setpriv) — never user=/group=
+    kwargs, which uvloop's subprocess_exec rejects (the prod FLM-pull bug)."""
+    import os
+    import pwd
+
+    import hal0.providers.flm as flm
+
+    fake_pw = pwd.getpwuid(os.getuid())
+    with (
+        patch("os.geteuid", lambda: 0),
+        patch("pwd.getpwnam", lambda _name: fake_pw),
+        patch("shutil.which", lambda tool: f"/usr/bin/{tool}" if tool == "setpriv" else None),
+    ):
+        argv, kwargs = flm.flm_host_async_spawn(["/usr/bin/flm", "pull", "x:1b"])
+    assert "user" not in kwargs and "group" not in kwargs
+    assert kwargs["env"]["HOME"] == flm._HOST_FLM_HOME
+    assert argv[0] == "/usr/bin/setpriv"
+    assert argv[-3:] == ["/usr/bin/flm", "pull", "x:1b"]
+    u = flm._HOST_FLM_USER
+    assert f"--reuid={u}" in argv and f"--regid={u}" in argv
+
+
+def test_async_spawn_passes_through_when_not_root() -> None:
+    """Non-root (dev/test): argv untouched, no demotion tools involved."""
+    import hal0.providers.flm as flm
+
+    with patch("os.geteuid", lambda: 1000):
+        argv, kwargs = flm.flm_host_async_spawn(["/usr/bin/flm", "pull", "x:1b"])
+    assert argv == ["/usr/bin/flm", "pull", "x:1b"]
+    assert "user" not in kwargs and "group" not in kwargs
+
+
 # ─── is_installed_flm_id (slot-apply provider-resolvability) ─────────────────
 
 


### PR DESCRIPTION
## Problem

Every FLM dropdown download fails instantly in prod at 0 bytes with:

```
ValueError: unexpected kwargs: user, group
```

`run_flm_pull` (src/hal0/registry/pull.py) passed `**flm_host_spawn_kwargs()` — which adds `user="hal0"` / `group="hal0"` when running as root — to `asyncio.create_subprocess_exec`. Those are `subprocess.Popen` kwargs; hal0-api serves under uvicorn/**uvloop**, whose `subprocess_exec` rejects Popen-only kwargs.

**Why no test or dev run ever caught it:** non-root skips the kwargs entirely, and the stdlib event loop accepts them anyway (verified both on the prod box, Python 3.12.3 / uvloop 0.22.1). Only root + uvloop — i.e. exactly prod — hits it. The helper's docstring even claimed asyncio compatibility; that claim was wrong and is corrected here.

## Fix

New `flm_host_async_spawn(argv)` in providers/flm.py: same hal0-identity semantics, but the privilege drop rides the argv — `setpriv --reuid=hal0 --regid=hal0 --init-groups`, falling back to `runuser`, falling back to undemoted (weights land root-owned but world-readable rather than failing the pull). `flm_host_spawn_kwargs` stays for the sync `subprocess.run` callers, where `user=`/`group=` work fine.

## Verification

- Live on the prod box (root, uvloop): `phi4-mini-it:4b` (3.4 GB) pulled to completion, `flm pull` process confirmed running as user `hal0`, model registered at `/mnt/ai-models/flm/models/Phi4-mini-Instruct-NPU2`.
- Unit tests: setpriv-prefix + no user/group kwargs as root; pass-through when non-root. `tests/providers/test_flm.py` (36) and `tests/registry/test_pull*.py` (32) green; ruff clean.

## Known follow-ups (not in this PR)

- FLM pull progress reports 0 bytes / 0 MB/s for the whole download (dir-size poller target resolution) — cosmetic, download completes and registers correctly.
- `profiles.in_use_scan_error` warning spam: `flm-embed.toml` / `flm-stt.toml` satellite slots lack the SlotConfig-required `port`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)