### PR TITLE
fix(dash): real update-banner actions + NPU grid colours by the primary FLM slot

### DIFF
--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -390,8 +390,16 @@ export function NpuOccupancyCard({ slots }) {
   // One owner object per slot, shared by reference across every column it
   // owns — the grid's partition-merge keys off identity, so distinct objects
   // would fragment a single slot into one bracket per column.
+  // The single-tenant NPU is held by ONE FLM process — the anchor (type=llm).
+  // The stt/embed shadows are coresident modalities of that same process and
+  // report the SAME columns in the occupancy probe; letting them paint would
+  // overwrite the anchor's colour (grid turns green + labels "flm-stt"). Only
+  // non-shadow slots own grid columns, so the grid always reads as the primary
+  // FLM slot. Shadow cards keep their own accent via ComboSlot's `hue` prop.
+  const isNpuShadow = (s) => s.type === 'transcription' || s.type === 'embedding'
   const owners = Array(NPU_COLS).fill(null)
   npuSlots.forEach((s, idx) => {
+    if (isNpuShadow(s)) return
     const o = occByName[s.name]
     const cols = o?.cols || []
     const ind = slotIndicatorFromPhase(s)

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -1,7 +1,7 @@
 // hal0 dashboard — reusable primitives
 // Modal, Drawer, ConfirmDialog, Banner, BannerStack, Dropdown menu
 
-import { useUpdateState } from '@/api/hooks/useUpdates'
+import { useUpdateState, useUpdateApply, useUpdateJob } from '@/api/hooks/useUpdates'
 import { useInstallState, bundleNameOr } from '@/api/hooks/useInstallState'
 import { useComfyui } from '@/api/hooks/useComfyui'
 
@@ -498,15 +498,51 @@ const BANNER_CATALOG = [
 // The catalog entry of the same id is kept around so the Tweaks panel
 // can still preview-toggle a static demo banner, but the source of truth
 // for the real surface is this component.
+// Public changelog on the marketing site (same URL the Settings → Updates
+// surface links to). Kept as a bare page URL — the site owns per-version
+// anchoring, and an unknown hash degrades gracefully to the page top.
+const HAL0_CHANGELOG_URL = "https://hal0.dev/changelog";
+
 function UpdateBanner() {
   const { data: state } = useUpdateState();
   const [dismissed, setDismissed] = useStateP(false);
+  const applyM = useUpdateApply();
+  const [jobId, setJobId] = useStateP(null);
+  const { job, terminal } = useUpdateJob(jobId);
+
+  // Fire one terminal toast when the self-update job resolves. hal0-api
+  // restarts mid-apply, so useUpdateJob tolerates transient poll failures;
+  // we only react once it lands on applied/failed.
+  useEffectP(() => {
+    if (!terminal || !job) return;
+    if (job.state === "applied") {
+      toast(`hal0 ${job.version || ""} applied — reload to load the new dashboard`, "ok");
+    } else if (job.state === "failed") {
+      toast(`Update failed: ${job.error || "see server logs"}`, "err");
+    }
+  }, [terminal, job]);
+
   const hal0 = state && state.hal0;
   const current = hal0 && hal0.current;
   const available = hal0 && hal0.available;
   const hasUpdate = !!available && available !== current;
   if (!hasUpdate || dismissed) return null;
   const channel = (hal0 && hal0.channel) || "stable";
+
+  // Busy across both phases: the POST /apply round-trip and the queued job
+  // running to a terminal state.
+  const updating = applyM.isPending || (!!jobId && !terminal);
+  const onUpdateNow = () => {
+    if (updating) return;
+    applyM.mutate(undefined, {
+      onSuccess: (j) => {
+        setJobId(j && j.id);
+        toast(`Updating hal0 to ${available}… expect a brief outage during restart`, "info");
+      },
+      onError: (e) => toast(`Couldn't start update: ${(e && e.message) || "see server logs"}`, "err"),
+    });
+  };
+
   return (
     <Banner
       kind="info"
@@ -519,12 +555,19 @@ function UpdateBanner() {
         </span>
       }
       actions={
-        <button
-          className="btn ghost sm"
-          onClick={() =>
-            window.__hal0Toast && window.__hal0Toast(`Opening hal0 ${available} release notes`, "info")
-          }
-        >Read release notes</button>
+        <>
+          <button
+            className="btn sm"
+            onClick={onUpdateNow}
+            disabled={updating}
+          >{updating ? "Updating…" : "Update now"}</button>
+          <a
+            className="btn ghost sm"
+            href={HAL0_CHANGELOG_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >Read release notes ↗</a>
+        </>
       }
       onDismiss={() => setDismissed(true)}
     />


### PR DESCRIPTION
Two dashboard fixes, both verified live on the box.

## 1. Update-available banner actions

- **"Read release notes"** was a toast stub (`window.__hal0Toast('Opening … release notes')`). It's now a real `<a target="_blank" rel="noopener noreferrer">` to the public changelog — `https://hal0.dev/changelog`, the same URL Settings → Updates already links — opening in a new tab, with a `↗` affordance.
- **Added "Update now"** — triggers the self-update via the existing `useUpdateApply` (POST `/api/updates/apply`) and tracks the queued job to a terminal toast (applied / failed) with `useUpdateJob`, which already tolerates the mid-apply `hal0-api` restart. Disabled + "Updating…" while in flight.

## 2. NPU occupancy grid coloured by the wrong slot

The single-tenant NPU is held by one FLM process — the `type=llm` anchor. The stt/embed **shadows are coresident modalities** of that same process and report the **same columns** in `/api/npu/occupancy`. The `owners`-array fill iterated all npu slots, so the shadows overwrote the anchor: the grid turned **green** and labelled the column bracket **"flm-stt"** instead of the primary FLM slot's colour.

Fix: skip shadow slots (`type` transcription/embedding) when painting grid columns, so the grid always reads as the primary FLM slot (`flm`, purple). Shadow cards keep their own accent via `ComboSlot`'s `hue` prop, unaffected.

> Note: this was latent but only became visible once the box's `flm-stt`/`flm-embed` slots were repaired into valid NPU shadows (they previously failed SlotConfig validation and claimed no columns).

## Verification

Built and hot-deployed to the live box; screenshotted both: the banner now shows **Update now** + **Read release notes ↗**, and the NPU grid reads **"flm · 8c"** in the anchor's purple, not green/"STT".

🤖 Generated with [Claude Code](https://claude.com/claude-code)