### PR TITLE
feat(dash): unify Needs Attention + bell into one notifications source

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -15,6 +15,7 @@ import { useUpdateState, useSlotDrift, useRestartDriftedSlots } from '@/api/hook
 import { useApprovalList, useApproveApproval, useDenyApproval } from '@/api/hooks/useAgents'
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
+import { useNotifications, hal0Notify, dismissNotifMessage, NOTIF_KIND_HUE } from './notifications.jsx'
 
 const { useState: useStateC, useEffect: useEffectC, useRef: useRefC } = React;
 
@@ -152,100 +153,21 @@ const Icons = {
 // route to the surface that already owns the action (ApprovalModal, footer
 // downloads pane, Settings → Updates) instead of duplicating it.
 
-const NOTIF_LS_KEY = "hal0:notif-dismissed";
-function _notifLoadDismissed() {
-  try {
-    const v = JSON.parse(localStorage.getItem(NOTIF_LS_KEY) || "[]");
-    return Array.isArray(v) ? v : [];
-  } catch { return []; }
-}
-// Module-level store (not React state) so messages published before the bell
-// mounts — or while it's unmounted on a crashed view — are never lost.
-const _notifStore = {
-  msgs: [],
-  dismissed: new Set(_notifLoadDismissed()),
-  listeners: new Set(),
-};
-function _notifEmit() { _notifStore.listeners.forEach((l) => l()); }
-function hal0Notify(raw) {
-  const d = raw || {};
-  const title = String(d.title || d.msg || "").trim();
-  if (!title) return null;
-  const id = String(d.id || ("msg-" + Date.now().toString(36) + Math.random().toString(36).slice(2, 6)));
-  // A stable id makes a message dismissible forever (localStorage) — the
-  // channel for "developer important messages" that shouldn't re-nag.
-  if (_notifStore.dismissed.has(id)) return id;
-  if (_notifStore.msgs.some((m) => m.id === id)) return id;
-  _notifStore.msgs = [
-    ..._notifStore.msgs,
-    {
-      id,
-      title,
-      body: d.body ? String(d.body) : "",
-      kind: ["info", "warn", "error", "update"].includes(d.kind) ? d.kind : "info",
-      link: typeof d.link === "string" ? d.link : "",
-      ts: Date.now(),
-    },
-  ];
-  _notifEmit();
-  return id;
-}
-function _notifDismiss(id) {
-  _notifStore.msgs = _notifStore.msgs.filter((m) => m.id !== id);
-  _notifStore.dismissed.add(id);
-  try {
-    localStorage.setItem(NOTIF_LS_KEY, JSON.stringify([..._notifStore.dismissed].slice(-100)));
-  } catch { /* private mode — dismissal just won't persist */ }
-  _notifEmit();
-}
-if (typeof window !== "undefined") {
-  window.hal0Notify = hal0Notify;
-  window.addEventListener("hal0:notify", (e) => hal0Notify(e.detail));
-}
-
-const _NOTIF_KIND_HUE = {
-  info: "var(--info, var(--fg-3))",
-  warn: "var(--warn)",
-  error: "var(--err)",
-  update: "var(--accent)",
-};
+// The dev-message store, hal0Notify(), dismissNotifMessage(), NOTIF_KIND_HUE,
+// and the whole data-gathering for the bell now live in ./notifications.jsx —
+// the single source shared with the dashboard's Needs Attention card so their
+// counts can never drift. This component only renders that shared data.
 
 function NotificationBell() {
   const [open, setOpen] = useStateC(false);
-  const [, bump] = useStateC(0);
-  useEffectC(() => {
-    const l = () => bump((t) => t + 1);
-    _notifStore.listeners.add(l);
-    return () => _notifStore.listeners.delete(l);
-  }, []);
-  const devMsgs = _notifStore.msgs;
 
-  // Attention sources — same rule as the dashboard's Needs Attention card.
-  const slots = useSlots().data ?? [];
-  const approvals = useApprovalList()?.data?.approvals ?? [];
-  const errorSlots = slots.filter((s) => s.state === "error" || s.container_status === "crashed");
-
-  // Downloads — the pulls list is a tiny local endpoint; the shared query key
-  // dedupes against the footer pane's copy when both are live.
-  const pulls = usePullsList({ enabled: true });
-  const jobs = Array.isArray(pulls.jobs) ? pulls.jobs : [];
-  const activePulls = jobs.filter((j) => j.state === "queued" || j.state === "running");
-  const failedPulls = jobs.filter((j) => j.state === "failed");
-  const clearJob = useClearPullJob();
-
-  // Updates — hal0 release channel + post-update slot drift (WS-J).
-  const updates = useUpdateState();
-  const hal0Ch = updates.data?.hal0;
-  const hasUpdate = !!(hal0Ch && hal0Ch.available && hal0Ch.available !== hal0Ch.current);
-  const drift = useSlotDrift();
-  const driftCount = drift.data?.count ?? 0;
-  const restartDrifted = useRestartDriftedSlots();
-
-  const count =
-    approvals.length + errorSlots.length +
-    activePulls.length + failedPulls.length +
-    (hasUpdate ? 1 : 0) + (driftCount > 0 ? 1 : 0) +
-    devMsgs.length;
+  // One shared source for every "needs the operator's eye" signal.
+  const {
+    approvals, errorSlots, activePulls, failedPulls,
+    hasUpdate, hal0Ch, driftCount,
+    devMsgs, clearJob, restartDrifted,
+    count,
+  } = useNotifications();
 
   // Close on outside click / Escape while open.
   const popRef = useRefC(null);
@@ -381,7 +303,7 @@ function NotificationBell() {
         <div className="notif-sec-h mono">messages</div>
         {devMsgs.map((m) => (
           <div className="notif-row" key={m.id} data-testid="notif-msg">
-            <span className="notif-dot" style={{ background: _NOTIF_KIND_HUE[m.kind] }} />
+            <span className="notif-dot" style={{ background: NOTIF_KIND_HUE[m.kind] }} />
             <span className="notif-msg">
               <b>{m.title}</b>
               {m.body && <span className="notif-body">{m.body}</span>}
@@ -392,7 +314,7 @@ function NotificationBell() {
                 else window.open(m.link, "_blank", "noopener");
               }}>Open</button>
             )}
-            <button className="notif-act" onClick={() => _notifDismiss(m.id)} aria-label="Dismiss message">×</button>
+            <button className="notif-act" onClick={() => dismissNotifMessage(m.id)} aria-label="Dismiss message">×</button>
           </div>
         ))}
       </div>

--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -39,6 +39,7 @@ import {
 } from '@/api/hooks/useDashLayout'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 import { useMemoryMapModel } from './memory-map'
+import { useNotifications } from './notifications.jsx'
 
 const { useState, useEffect, useRef, useMemo, useCallback } = React
 
@@ -148,79 +149,15 @@ function SwapButton({ cellId, current, onSwap }) {
 }
 
 // ─── attention items (shared: health strip + Needs Attention card) ──────────
-// Derived from existing sources only: pending agent approvals + slots in
-// error. (Disk-preflight warnings join once a live storage-pressure source
-// ships — no fabricated storage rows.) The health-strip count and the card
-// count read the same list so they can never disagree.
-
-function fmtWaiting(enqueuedAt) {
-  if (typeof enqueuedAt !== 'number') return null
-  const mins = Math.max(0, Math.round((Date.now() / 1000 - enqueuedAt) / 60))
-  if (mins < 60) return `${mins} min`
-  return `${Math.floor(mins / 60)} h ${mins % 60} min`
-}
+// The list now comes from the ONE shared notifications source (notifications.jsx),
+// the same hook the topbar bell reads — so the card, the health-strip count, and
+// the bell badge can never disagree. `actionableItems` is the actionable subset:
+// approvals, error slots, failed downloads, update-available, slot drift, and dev
+// messages. In-progress downloads are intentionally excluded (they carry no
+// action and live on the bell only).
 
 function useAttentionItems() {
-  const slotsQuery = useSlots()
-  const approvalQuery = useApprovalList()
-  const slots = slotsQuery.data ?? []
-  const approvals = approvalQuery?.data?.approvals ?? []
-
-  return useMemo(() => {
-    const items = []
-    for (const s of slots) {
-      if (s.state !== 'error' && s.container_status !== 'crashed') continue
-      const msg = s?.metadata?.message || s?.message || ''
-      items.push({
-        key: `slot:${s.name}`,
-        kind: 'warn',
-        eyebrow: 'slot · error',
-        body: (
-          <>
-            <span className="mono rd-attn-ident">{s.name}</span> failed
-            {msg ? <> — {msg}</> : ' — container crashed'}. Restart to recover.
-          </>
-        ),
-        actions: [
-          {
-            label: 'Restart',
-            onClick: () =>
-              window.dispatchEvent(new CustomEvent('hal0:slot-restart', { detail: { name: s.name } })),
-          },
-          { label: 'View slot', onClick: () => { window.location.hash = '#slots/' + s.name } },
-        ],
-      })
-    }
-    for (const a of approvals) {
-      const agent = a.client_id || 'hermes'
-      const waiting = fmtWaiting(a.enqueued_at)
-      let arg = ''
-      try {
-        const vals = a.args ? Object.values(a.args).filter((v) => typeof v === 'string') : []
-        arg = vals[0] || ''
-      } catch { /* unparseable args → omit */ }
-      items.push({
-        key: `approval:${a.id}`,
-        kind: 'approval',
-        eyebrow: 'agent · approval',
-        body: (
-          <>
-            {agent} wants <span className="mono rd-attn-ident">{a.tool}</span>
-            {arg && <> · <span className="mono rd-attn-ident">{arg}</span></>}.
-            {waiting && <> Waiting {waiting}.</>}
-          </>
-        ),
-        actions: [
-          {
-            label: 'Review',
-            primary: true,
-            onClick: () => window.dispatchEvent(new CustomEvent('hal0:open-approvals')),
-          },
-        ],
-      })
-    }
-    return items
-  }, [slots, approvals])
+  return useNotifications().actionableItems
 }
 
 // ─── hero strip ──────────────────────────────────────────────────────────────
@@ -311,11 +248,13 @@ function HeroStrip({ slots, heroTps, layout, swapMode, onToggleSwapMode, onToggl
 
 function HealthStrip({ slots, heroTps, attentionItems }) {
   const attentionCount = attentionItems.length
-  const warnCount = attentionItems.filter((it) => it.kind === 'warn').length
+  // Compact summary across the broadened set: approvals vs everything else
+  // (error slots, failed downloads, update, drift, messages) as "alerts".
   const approvalCount = attentionItems.filter((it) => it.kind === 'approval').length
+  const alertCount = attentionCount - approvalCount
   const attnSummary = [
-    warnCount > 0 ? `${warnCount} warn` : null,
     approvalCount > 0 ? `${approvalCount} approval${approvalCount !== 1 ? 's' : ''}` : null,
+    alertCount > 0 ? `${alertCount} alert${alertCount !== 1 ? 's' : ''}` : null,
   ].filter(Boolean).join(' · ')
   const stats = useStatsHardware()
   const st = stats.data
@@ -950,7 +889,7 @@ function RDAttentionCard({ items }) {
             <div key={it.key} className="rd-attn-item">
               <div
                 className="rd-attn-eyebrow mono"
-                style={{ color: it.kind === 'approval' ? 'var(--accent)' : 'var(--warn)' }}
+                style={{ color: it.tone === 'accent' ? 'var(--accent)' : it.tone === 'err' ? 'var(--err)' : 'var(--warn)' }}
               >
                 {it.eyebrow}
               </div>

--- a/ui/src/dash/notifications.jsx
+++ b/ui/src/dash/notifications.jsx
@@ -1,0 +1,281 @@
+// hal0 dashboard — unified notifications source.
+//
+// ONE hook, useNotifications(), is the single source of truth for everything
+// that wants the operator's eye. Two surfaces render from it so their counts
+// can never drift:
+//   • the topbar bell (chrome.jsx) — shows every section, including transient
+//     in-progress downloads (status the operator watches but can't act on);
+//   • the dashboard "Needs attention" card (dashboard-redesign.jsx) — shows the
+//     ACTIONABLE subset (`actionableItems`): approvals, error slots, failed
+//     downloads, update-available, slot drift, and dev messages. In-progress
+//     downloads are excluded there (they carry no action).
+//
+// The dev/system message store also lives here (moved from chrome.jsx) so a
+// message published via window.hal0Notify({...}) or a `hal0:notify` event is
+// captured even before either surface mounts.
+
+import { useSlots } from '@/api/hooks/useSlots'
+import { usePullsList, useClearPullJob } from '@/api/hooks/useModels'
+import { useUpdateState, useSlotDrift, useRestartDriftedSlots } from '@/api/hooks/useUpdates'
+import { useApprovalList } from '@/api/hooks/useAgents'
+import { apiPost } from '@/api/client'
+import { ENDPOINTS } from '@/api/endpoints'
+
+const { useState: useSN, useEffect: useEN, useMemo: useMN } = React
+
+// ─── dev/system message store (module-level; survives unmount) ───────────────
+const NOTIF_LS_KEY = 'hal0:notif-dismissed'
+function _loadDismissed() {
+  try {
+    const v = JSON.parse(localStorage.getItem(NOTIF_LS_KEY) || '[]')
+    return Array.isArray(v) ? v : []
+  } catch { return [] }
+}
+const _store = { msgs: [], dismissed: new Set(_loadDismissed()), listeners: new Set() }
+function _emit() { _store.listeners.forEach((l) => l()) }
+
+// Publish a message. A stable `id` makes it dismissible forever (localStorage),
+// so "developer important messages" don't re-nag. Returns the id (or null when
+// there's no title). Mirrors the pre-refactor chrome.jsx contract exactly.
+export function hal0Notify(raw) {
+  const d = raw || {}
+  const title = String(d.title || d.msg || '').trim()
+  if (!title) return null
+  const id = String(d.id || ('msg-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6)))
+  if (_store.dismissed.has(id)) return id
+  if (_store.msgs.some((m) => m.id === id)) return id
+  _store.msgs = [
+    ..._store.msgs,
+    {
+      id,
+      title,
+      body: d.body ? String(d.body) : '',
+      kind: ['info', 'warn', 'error', 'update'].includes(d.kind) ? d.kind : 'info',
+      link: typeof d.link === 'string' ? d.link : '',
+      ts: Date.now(),
+    },
+  ]
+  _emit()
+  return id
+}
+
+export function dismissNotifMessage(id) {
+  _store.msgs = _store.msgs.filter((m) => m.id !== id)
+  _store.dismissed.add(id)
+  try {
+    localStorage.setItem(NOTIF_LS_KEY, JSON.stringify([..._store.dismissed].slice(-100)))
+  } catch { /* private mode — dismissal just won't persist */ }
+  _emit()
+}
+
+if (typeof window !== 'undefined') {
+  window.hal0Notify = hal0Notify
+  window.addEventListener('hal0:notify', (e) => hal0Notify(e.detail))
+}
+
+export const NOTIF_KIND_HUE = {
+  info: 'var(--info, var(--fg-3))',
+  warn: 'var(--warn)',
+  error: 'var(--err)',
+  update: 'var(--accent)',
+}
+
+function useDevMessages() {
+  const [, bump] = useSN(0)
+  useEN(() => {
+    const l = () => bump((t) => t + 1)
+    _store.listeners.add(l)
+    return () => _store.listeners.delete(l)
+  }, [])
+  return _store.msgs
+}
+
+function fmtWaiting(enqueuedAt) {
+  if (typeof enqueuedAt !== 'number') return null
+  const mins = Math.max(0, Math.round((Date.now() / 1000 - enqueuedAt) / 60))
+  if (mins < 60) return `${mins} min`
+  return `${Math.floor(mins / 60)} h ${mins % 60} min`
+}
+
+// ─── the shared hook ─────────────────────────────────────────────────────────
+export function useNotifications() {
+  const slots = useSlots().data ?? []
+  const approvals = useApprovalList()?.data?.approvals ?? []
+  const errorSlots = slots.filter((s) => s.state === 'error' || s.container_status === 'crashed')
+
+  const pulls = usePullsList({ enabled: true })
+  const jobs = Array.isArray(pulls.jobs) ? pulls.jobs : []
+  const activePulls = jobs.filter((j) => j.state === 'queued' || j.state === 'running')
+  const failedPulls = jobs.filter((j) => j.state === 'failed')
+  const clearJob = useClearPullJob()
+
+  const updates = useUpdateState()
+  const hal0Ch = updates.data?.hal0
+  const hasUpdate = !!(hal0Ch && hal0Ch.available && hal0Ch.available !== hal0Ch.current)
+  const drift = useSlotDrift()
+  const driftCount = drift.data?.count ?? 0
+  const restartDrifted = useRestartDriftedSlots()
+
+  const devMsgs = useDevMessages()
+
+  // Badge count — every actionable/transient signal (unchanged from the
+  // pre-refactor bell so the badge number is stable).
+  const count =
+    approvals.length + errorSlots.length +
+    activePulls.length + failedPulls.length +
+    (hasUpdate ? 1 : 0) + (driftCount > 0 ? 1 : 0) +
+    devMsgs.length
+
+  const driftBusy = restartDrifted.isPending
+
+  // Normalized ACTIONABLE items for the "Needs attention" card. Excludes
+  // in-progress downloads (no action) — those live on the bell only. Shape
+  // matches RDAttentionCard: { key, section, kind, tone, eyebrow, body, actions }.
+  const actionableItems = useMN(() => {
+    const items = []
+
+    for (const a of approvals) {
+      const agent = a.client_id || 'hermes'
+      const waiting = fmtWaiting(a.enqueued_at)
+      let arg = ''
+      try {
+        const vals = a.args ? Object.values(a.args).filter((v) => typeof v === 'string') : []
+        arg = vals[0] || ''
+      } catch { /* unparseable args → omit */ }
+      items.push({
+        key: `approval:${a.id}`,
+        section: 'attention',
+        kind: 'approval',
+        tone: 'accent',
+        eyebrow: 'agent · approval',
+        body: (
+          <>
+            {agent} wants <span className="mono rd-attn-ident">{a.tool}</span>
+            {arg && <> · <span className="mono rd-attn-ident">{arg}</span></>}.
+            {waiting && <> Waiting {waiting}.</>}
+          </>
+        ),
+        actions: [
+          { label: 'Review', primary: true, onClick: () => window.dispatchEvent(new CustomEvent('hal0:open-approvals')) },
+        ],
+      })
+    }
+
+    for (const s of errorSlots) {
+      const msg = s?.metadata?.message || s?.message || ''
+      items.push({
+        key: `slot:${s.name}`,
+        section: 'attention',
+        kind: 'error',
+        tone: 'warn',
+        eyebrow: 'slot · error',
+        body: (
+          <>
+            <span className="mono rd-attn-ident">{s.name}</span> failed
+            {msg ? <> — {msg}</> : ' — container crashed'}. Restart to recover.
+          </>
+        ),
+        actions: [
+          { label: 'Restart', onClick: () => window.dispatchEvent(new CustomEvent('hal0:slot-restart', { detail: { name: s.name } })) },
+          { label: 'View slot', onClick: () => { window.location.hash = '#slots/' + s.name } },
+        ],
+      })
+    }
+
+    for (const j of failedPulls) {
+      items.push({
+        key: `dlf:${j.job_id || j.model_id}`,
+        section: 'downloads',
+        kind: 'download',
+        tone: 'err',
+        eyebrow: 'download · failed',
+        body: (
+          <>
+            <span className="mono rd-attn-ident">{j.hf_repo || j.model_id}</span> download failed.
+          </>
+        ),
+        actions: [
+          { label: 'Retry', primary: true, onClick: () => apiPost(ENDPOINTS.modelPull(j.model_id)) },
+          { label: 'Clear', onClick: () => clearJob.mutate(j.model_id) },
+        ],
+      })
+    }
+
+    if (hasUpdate) {
+      items.push({
+        key: 'update:hal0',
+        section: 'updates',
+        kind: 'update',
+        tone: 'accent',
+        eyebrow: 'update · available',
+        body: (
+          <>
+            hal0 <span className="mono rd-attn-ident">{hal0Ch.available}</span> available
+            {hal0Ch.current && <> (current {hal0Ch.current})</>}.
+          </>
+        ),
+        actions: [
+          { label: 'Update', primary: true, onClick: () => { window.location.hash = '#settings/updates' } },
+        ],
+      })
+    }
+
+    if (driftCount > 0) {
+      items.push({
+        key: 'update:drift',
+        section: 'updates',
+        kind: 'drift',
+        tone: 'warn',
+        eyebrow: 'update · slot drift',
+        body: (
+          <>
+            {driftCount} slot{driftCount !== 1 ? 's' : ''} running a pre-update config — restart to apply.
+          </>
+        ),
+        actions: [
+          { label: driftBusy ? 'Restarting…' : 'Restart', disabled: driftBusy, onClick: () => restartDrifted.mutate(undefined) },
+        ],
+      })
+    }
+
+    for (const m of devMsgs) {
+      const acts = []
+      if (m.link) {
+        acts.push({
+          label: 'Open',
+          primary: true,
+          onClick: () => {
+            if (/^#/.test(m.link)) { window.location.hash = m.link }
+            else window.open(m.link, '_blank', 'noopener')
+          },
+        })
+      }
+      acts.push({ label: 'Dismiss', onClick: () => dismissNotifMessage(m.id) })
+      items.push({
+        key: `msg:${m.id}`,
+        section: 'messages',
+        kind: 'message',
+        tone: m.kind === 'error' ? 'err' : m.kind === 'warn' ? 'warn' : 'accent',
+        eyebrow: 'message',
+        body: (
+          <>
+            <b>{m.title}</b>{m.body && <> — {m.body}</>}
+          </>
+        ),
+        actions: acts,
+      })
+    }
+
+    return items
+  }, [approvals, errorSlots, failedPulls, hasUpdate, hal0Ch, driftCount, devMsgs, driftBusy, clearJob, restartDrifted])
+
+  return {
+    // raw derived values — the bell renders its existing per-section JSX from these
+    approvals, errorSlots, activePulls, failedPulls,
+    hasUpdate, hal0Ch, driftCount,
+    devMsgs, clearJob, restartDrifted,
+    count,
+    // normalized actionable subset — the dashboard card renders these
+    actionableItems,
+  }
+}

--- a/ui/tests/e2e/specs/dashboard-redesign-v3.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-redesign-v3.spec.ts
@@ -81,6 +81,21 @@ async function gotoDashboard(page: Page, slots: any[]) {
   await page.goto('/#dashboard')
 }
 
+// The forced-mock seed always offers a hal0 update, and the Needs Attention
+// card now surfaces update-available alongside approvals/error-slots (shared
+// with the topbar bell). Suppress it via the same override seam the bell spec
+// uses so the attention-specific assertions test one signal at a time.
+const NO_UPDATE = {
+  hal0: { current: '0.3.0-alpha.1', available: null, channel: 'stable' },
+  flm: { current: 'v0.9.44', source: 'manual-deb' },
+  autoCheck: true,
+}
+async function suppressAmbientUpdate(page: Page) {
+  await page.addInitScript((p) => {
+    ;(window as any).__hal0UpdateStateOverride = p
+  }, NO_UPDATE)
+}
+
 test.describe('dashboard redesign — status dot acceptance gate', () => {
   test('serving slot renders a GREEN dot with the looping pulse animation', async ({
     page,
@@ -234,6 +249,7 @@ test.describe('dashboard redesign — no stub data', () => {
 
 test.describe('dashboard redesign — needs attention', () => {
   test('derives real items with inline actions from an error slot', async ({ page }) => {
+    await suppressAmbientUpdate(page)
     const slots = [
       { ...servingSlot(), name: 'ok' },
       { name: 'broke', state: 'error', device: 'gpu-rocm', model: 'm', type: 'llm', group: 'chat', enabled: true, container_status: 'crashed', metrics: { toks: 0 } },
@@ -249,10 +265,31 @@ test.describe('dashboard redesign — needs attention', () => {
   })
 
   test('healthy board reads "nothing needs you" with an all-clear strip', async ({ page }) => {
+    await suppressAmbientUpdate(page)
     await gotoDashboard(page, [servingSlot(), readySlot()])
     const attn = page.locator('.rd-card', { has: page.locator('.rd-card-title', { hasText: /needs attention/i }) })
     await expect(attn).toBeVisible({ timeout: 10_000 })
     await expect(attn).toContainText(/nothing needs you/i)
     await expect(page.locator('.rd-health-cell').last()).toContainText(/all clear/i)
+  })
+
+  test('surfaces an available hal0 update as an actionable item (shared with the bell)', async ({ page }) => {
+    // The Needs Attention card and the topbar bell read ONE shared source, so an
+    // available update shows in the card too — with an Update action deep-linking
+    // to Settings → Updates.
+    await page.addInitScript((p) => {
+      ;(window as any).__hal0UpdateStateOverride = p
+    }, {
+      hal0: { current: '0.3.0-alpha.1', available: '0.9.9', channel: 'stable' },
+      flm: { current: 'v0.9.44', source: 'manual-deb' },
+      autoCheck: true,
+    })
+    await gotoDashboard(page, [servingSlot(), readySlot()])
+    const attn = page.locator('.rd-card', { has: page.locator('.rd-card-title', { hasText: /needs attention/i }) })
+    await expect(attn).toBeVisible({ timeout: 10_000 })
+    await expect(attn.locator('.rd-attn-eyebrow', { hasText: /update · available/i })).toBeVisible()
+    await expect(attn).toContainText('0.9.9')
+    await attn.getByRole('button', { name: 'Update' }).click()
+    await expect(page).toHaveURL(/#settings\/updates/)
   })
 })


### PR DESCRIPTION
## What

The dashboard **"Needs attention"** card and the topbar **bell** each independently recomputed the same attention sources (pending approvals + slots in error), and the card couldn't see the bell's other important signals. This extracts a single hook — `useNotifications()` in `ui/src/dash/notifications.jsx` — that **both surfaces read**, so their counts can never drift, and expands the card to the full actionable set.

## Where the content came from (answering the original question)

- **Needs attention** (`dashboard-redesign.jsx` → `useAttentionItems`): slots in `error`/`crashed` + pending agent approvals.
- **Bell** (`chrome.jsx` → `NotificationBell`): the same two, plus downloads (active + failed pulls), updates (release available + post-update slot drift), and dev messages (`window.hal0Notify`).

## Change

- New `useNotifications()` is the single source. It returns the raw per-section values (the bell renders its existing JSX from these, unchanged) **and** a normalized `actionableItems` list for the card.
- The card now surfaces the **actionable** subset: approvals, error slots, **failed** downloads, update-available, slot drift, and dev messages. **In-progress downloads stay bell-only** (transient status, no action).
- The dev/system message store (`hal0Notify` / `window.hal0Notify` / `hal0:notify` event / dismiss-persistence) moved from `chrome.jsx` into the shared module. No external callers.
- `HealthStrip` summary generalized to "N approvals · M alerts"; card eyebrow colours by a `tone` field.

## Tests

- `notification-bell-v3` (6) — **green, unchanged** (bell DOM/testids preserved).
- `dashboard-redesign-v3` — the two attention specs now suppress the mock's ambient update (via the same `__hal0UpdateStateOverride` seam the bell spec uses) to isolate attention behaviour; **added** a spec asserting an available update surfaces in the card with an Update deep-link to Settings → Updates. 11/11 green.

## Verified live

On the box (which has 0.9.6.1 available), the card now reads **"UPDATE · AVAILABLE — hal0 0.9.6.1 available (current 0.9.6)"** with an Update button, and the bell badge reads the same count from the shared source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)