### PR TITLE
feat(dash): topbar tidy — move Kanban to Services + brain icon for Agent Chat

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -399,19 +399,11 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
         </div>
       )}
       <div className="tb-spacer" />
-      {/* Primary launchers — Kanban board + the agent-chat slide-out. These
-          replace the old "Quick actions" button (the ⌘K command palette is
-          still reachable via the shortcut). White icons by default, glowing
-          amber on hover/active. */}
+      {/* Primary launcher — the agent-chat slide-out. (Kanban moved to the
+          sidebar Services zone; ⌘B still opens the board. The ⌘K command
+          palette is reachable via its shortcut.) White icon by default,
+          glowing amber on hover/active. */}
       <div className="tb-launch">
-        <button
-          className={"tb-launch-btn" + (route === "board" ? " on" : "")}
-          data-testid="tb-launch-board"
-          onClick={onBoard}
-          title="Open the Kanban board (⌘B)"
-        >
-          {Icons.board}<span>Kanban</span>
-        </button>
         <button
           className={"tb-launch-btn" + (chatOn ? " on" : "")}
           data-testid="tb-launch-chat"
@@ -462,10 +454,9 @@ function useNavItems() {
       { id: "slots/stacks",    label: "Stacks" },
     ] },
     { id: "models", label: "Models", icon: Icons.models, cnt: modelCount },
-    // Operator Board (#board) — hal0-skinned kanban over the Hermes kanban
-    // backend. No live count here (it's per-board; the board's own selector
-    // shows task counts).
-    { id: "board", label: "Board", icon: Icons.board },
+    // The Operator Board (#board) is no longer a top-level nav row — it lives
+    // in the sidebar Services zone (ServiceLinks) as the "Kanban" option, and
+    // stays reachable via ⌘B.
     { id: "benchmarks", label: "Benchmarks", icon: Icons.bench },
     // v0.5 nav: clicking Agents lands on the Overview (the agent-card library,
     // with Hermes wired live) — that's the parent row's target, so no separate
@@ -560,11 +551,11 @@ function NavList({ route, param, onGo, testPrefix }) {
 
 // ─── ServiceLinks (sidebar bottom) ───
 // A separate launch zone, pinned to the sidebar bottom below the spacer, away
-// from the app/config nav above. Holds the external sibling-service shortcuts:
+// from the app/config nav above. Holds:
+//   - Kanban    → the internal Operator Board (#board), the only in-app option
+//                 here (routes via onGo, not an external link); also on ⌘B.
 //   - OpenWebUI → external chat UI, link host-derived by GET /api/config/urls.
 //   - Hermes    → external Hermes dashboard, likewise host-derived.
-// (The Kanban shortcut moved to the topbar launcher; the Operator Board is
-// also in the main nav and on ⌘B.)
 // The external links come from `useConfigUrls`, whose backend resolves the
 // hostname from the *request* (loopback, LAN IP, mDNS, or proxy domain) — so
 // they resolve correctly on every install, not just this dev box. Each is gated
@@ -572,7 +563,7 @@ function NavList({ route, param, onGo, testPrefix }) {
 // is simply omitted when the service isn't reachable on this host.
 // `testPrefix` keeps desktop ("svc-") vs drawer ("svc-drawer-") ids apart;
 // `onLaunch` lets the mobile drawer close itself after a tap.
-function ServiceLinks({ onGo, onLaunch, testPrefix }) {
+function ServiceLinks({ route, onGo, onLaunch, testPrefix }) {
   const cfg = useConfigUrls();
   const owui = cfg.data?.openwebui_enabled ? (cfg.data.openwebui || "") : "";
   const hermes = cfg.data?.hermes_enabled ? (cfg.data.hermes || "") : "";
@@ -580,6 +571,18 @@ function ServiceLinks({ onGo, onLaunch, testPrefix }) {
     <div className="sb-services">
       <div className="sb-section">Services</div>
       <div className="sb-svc-list">
+        <div
+          className={"sb-row sb-svc" + (route === "board" ? " active" : "")}
+          data-testid={testPrefix + "board"}
+          role="button"
+          tabIndex={0}
+          onClick={() => { onGo("board"); onLaunch && onLaunch(); }}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onGo("board"); onLaunch && onLaunch(); } }}
+          title="Open the Kanban board (⌘B)"
+        >
+          {Icons.board}
+          <span className="lbl">Kanban</span>
+        </div>
         {owui && (
           <a
             className="sb-row sb-svc"
@@ -620,7 +623,7 @@ function Sidebar({ route, param, onGo }) {
       <div className="sb-section">Navigate</div>
       <NavList route={route} param={param} onGo={onGo} testPrefix="nav-" />
       <div className="sb-spacer" />
-      <ServiceLinks onGo={onGo} testPrefix="svc-" />
+      <ServiceLinks route={route} onGo={onGo} testPrefix="svc-" />
     </div>
   );
 }
@@ -1145,7 +1148,7 @@ function NavDrawer({ open, route, param, onGo, onClose, onCmdK }) {
         </button>
         <NavList route={route} param={param} onGo={onGo} testPrefix="nav-drawer-" />
         <div className="sb-spacer" />
-        <ServiceLinks onGo={onGo} onLaunch={onClose} testPrefix="svc-drawer-" />
+        <ServiceLinks route={route} onGo={onGo} onLaunch={onClose} testPrefix="svc-drawer-" />
         </>)}
       </aside>
     </>

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -104,6 +104,8 @@ const Icons = {
   // issue #549 — two linked rings echo the "remote ↔ local" connection metaphor.
   connections: <Icon><circle cx="6" cy="8" r="2.5"/><circle cx="11" cy="11" r="1.5" fill="currentColor" stroke="none"/><path d="M8 9.5l2 1M3.5 4.5h4M3.5 6.5h3"/></Icon>,
   agent:     <Icon><circle cx="8" cy="6" r="2.5"/><path d="M3 14c0-2.5 2.2-4.5 5-4.5s5 2 5 4.5"/><circle cx="13" cy="3" r="1.5"/></Icon>,
+  // Two-hemisphere brain (reuses the GLYPHS.brain glyph) — the Agent Chat launcher.
+  brain:     <Icon name="brain" />,
   // Hindsight memory — stacked store with an orbiting fact node.
   memory:    <Icon><ellipse cx="8" cy="4" rx="5" ry="2"/><path d="M3 4v5c0 1.1 2.2 2 5 2s5-.9 5-2V4"/><path d="M3 6.5c0 1.1 2.2 2 5 2s5-.9 5-2"/><circle cx="13" cy="12.5" r="1.5"/></Icon>,
   settings:  <Icon><circle cx="8" cy="8" r="2"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3 3l1.5 1.5M11.5 11.5L13 13M3 13l1.5-1.5M11.5 4.5L13 3"/></Icon>,
@@ -405,13 +407,13 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
           glowing amber on hover/active. */}
       <div className="tb-launch">
         <button
-          className={"tb-launch-btn" + (chatOn ? " on" : "")}
+          className={"tb-launch-btn tb-brain" + (chatOn ? " on" : "")}
           data-testid="tb-launch-chat"
           onClick={onAgentChat}
           title="Open the agent chat"
           aria-pressed={chatOn}
         >
-          {Icons.agent}<span>Agent Chat</span>
+          {Icons.brain}<span>Agent Chat</span>
         </button>
       </div>
       <NotificationBell />

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -307,6 +307,30 @@ a { color: inherit; text-decoration: none; }
   box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
 }
 
+/* Agent Chat launcher — brain icon with a persistent pinkish-purple glow
+   (overrides the amber launcher default). Intensifies on hover / when the
+   chat slide-out is open. */
+.tb-launch-btn.tb-brain svg {
+  color: #d074ff;
+  filter: drop-shadow(0 0 5px rgba(208, 116, 255, 0.75)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.tb-launch-btn.tb-brain:hover svg,
+.tb-launch-btn.tb-brain.on svg {
+  color: #e29bff;
+  filter: drop-shadow(0 0 8px rgba(208, 116, 255, 0.95)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.tb-launch-btn.tb-brain:hover {
+  color: var(--fg);
+  border-color: rgba(208, 116, 255, 0.5);
+  background: rgba(208, 116, 255, 0.10);
+}
+.tb-launch-btn.tb-brain.on {
+  color: #e29bff;
+  border-color: rgba(208, 116, 255, 0.5);
+  background: rgba(208, 116, 255, 0.10);
+  box-shadow: 0 0 0 1px rgba(208, 116, 255, 0.4), 0 0 14px -4px #d074ff;
+}
+
 /* Notification bell — icon-only launcher + anchored dropdown panel. */
 .tb-bell-wrap { position: relative; display: inline-flex; }
 .tb-bell {

--- a/ui/tests/e2e/specs/board-render-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-render-v3.spec.ts
@@ -69,17 +69,12 @@ test.describe('BoardView — render', () => {
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 
-  test('entry via sidebar nav-board link', async ({ page }) => {
+  test('entry via sidebar Services Kanban link', async ({ page }) => {
+    // Kanban moved from the top-level nav + topbar launcher into the sidebar
+    // Services zone as the only in-app option there.
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
-    await page.locator('[data-testid="nav-board"]').click()
-    await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
-  })
-
-  test('entry via topbar Kanban launcher', async ({ page }) => {
-    await page.goto('/')
-    await page.waitForLoadState('domcontentloaded')
-    await page.locator('[data-testid="tb-launch-board"]').click()
+    await page.locator('[data-testid="svc-board"]').click()
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })
 

--- a/ui/tests/e2e/specs/dashboard-v3.spec.ts
+++ b/ui/tests/e2e/specs/dashboard-v3.spec.ts
@@ -28,12 +28,12 @@ test.describe('Dashboard v3 (/)', () => {
     await expect(page.locator('.sb-row.active .lbl')).toHaveText('Overview')
   })
 
-  test('topbar exposes brand + Kanban/Agent Chat launchers + notification bell without stale host chrome', async ({ page }) => {
+  test('topbar exposes brand + Agent Chat launcher + notification bell without stale host chrome', async ({ page }) => {
     await page.goto('/')
     await expect(page.locator('.tb-brand')).toBeVisible()
-    // The old "Quick actions" button was replaced by two launchers.
-    await expect(page.locator('[data-testid="tb-launch-board"]')).toBeVisible()
-    await expect(page.locator('[data-testid="tb-launch-board"]')).toContainText('Kanban')
+    // Kanban moved to the sidebar Services zone; the topbar keeps only the
+    // Agent Chat launcher (⌘K palette + ⌘B board reachable via shortcuts).
+    await expect(page.locator('[data-testid="tb-launch-board"]')).toHaveCount(0)
     await expect(page.locator('[data-testid="tb-launch-chat"]')).toBeVisible()
     await expect(page.locator('[data-testid="tb-launch-chat"]')).toContainText('Agent Chat')
     await expect(page.locator('.tb-cmdk')).toHaveCount(0)

--- a/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
+++ b/ui/tests/e2e/specs/sidebar-accordion-v3.spec.ts
@@ -67,15 +67,16 @@ test.describe('sidebar accordion', () => {
 })
 
 test.describe('sidebar Services zone', () => {
-  test('renders install-derived OpenWebUI/Hermes links (no Kanban — moved to topbar)', async ({ page }) => {
+  test('holds the internal Kanban option + install-derived OpenWebUI/Hermes links', async ({ page }) => {
     await mockConfigUrls(page)
     await page.goto('/#dashboard')
     const svc = page.locator('.sb-services')
     await expect(svc).toBeVisible({ timeout: FIVE_S })
 
-    // Kanban moved to the topbar launcher; Services now holds only the external
-    // OpenWebUI/Hermes <a>s, hrefs straight from the backend-resolved config.
-    await expect(svc.locator('[data-testid="svc-kanban"]')).toHaveCount(0)
+    // Kanban is the only in-app option here — an internal #board route, not an
+    // external <a> — followed by the external OpenWebUI/Hermes links whose
+    // hrefs come straight from the backend-resolved config.
+    await expect(svc.locator('[data-testid="svc-board"]')).toContainText('Kanban')
     await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute(
       'href',
       'http://hal0.example:3001',
@@ -89,9 +90,9 @@ test.describe('sidebar Services zone', () => {
     await expect(svc.locator('[data-testid="svc-openwebui"]')).toHaveAttribute('rel', /noopener/)
   })
 
-  test('topbar Kanban launcher routes to the Operator Board', async ({ page }) => {
+  test('sidebar Services Kanban option routes to the Operator Board', async ({ page }) => {
     await page.goto('/#dashboard')
-    await page.locator('[data-testid="tb-launch-board"]').click()
+    await page.locator('[data-testid="svc-board"]').click()
     await expect(page).toHaveURL(/#board/)
     await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
   })


### PR DESCRIPTION
Two related topbar/nav changes, combined into one PR.

> **Stacked on #1195** (feat/unified-notifications) — all touch `chrome.jsx`. Base retargets to `main` once #1195 merges; review the commits or merge #1195 first.

## 1. Move Kanban from topbar/nav into the sidebar Services zone

- **TopBar** — removed the Kanban launcher button (Agent Chat launcher stays; ⌘B still opens the board, ⌘K palette unchanged).
- **Sidebar nav** (`useNavItems`) — removed the top-level "Board" row.
- **Services zone** (`ServiceLinks`) — added **Kanban** as the first option (`data-testid="svc-board"`), above OpenWebUI/Hermes. Unlike those external `<a>` links it's an internal `#board` route via `onGo` with an active-state highlight. Threaded `route` into `ServiceLinks` from both the desktop `Sidebar` and the mobile `NavDrawer`.

## 2. Brain icon w/ pinkish-purple glow for the Agent Chat launcher

- `Icons.brain` added (reuses the existing `GLYPHS.brain` two-hemisphere glyph).
- The Agent Chat launcher uses it with a `tb-brain` class; CSS gives a persistent pinkish-purple colour (`#d074ff`) + drop-shadow glow that overrides the default amber launcher styling and intensifies on hover / when the chat slide-out is open.

## Tests

- `dashboard-v3` — topbar no longer exposes a Kanban launcher; Agent Chat + bell still asserted.
- `sidebar-accordion-v3` — Services zone holds the Kanban option and routes to the Operator Board.
- `board-render-v3` — entry via the Services Kanban link; dropped the removed `nav-board` / topbar-launcher entry paths (⌘B, ⌘K, `#board` hash retained).
- 21/21 green.

## Verified live

Top bar shows Agent Chat with a pinkish-purple brain icon (computed `color: rgb(208,116,255)` + glow); nav has no Board; the SERVICES zone shows Kanban (board icon) then OpenWebUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)