### PR TITLE
feat(dash): brain icon w/ pinkish-purple glow for Agent Chat launcher

### DIFF
--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -104,6 +104,8 @@ const Icons = {
   // issue #549 — two linked rings echo the "remote ↔ local" connection metaphor.
   connections: <Icon><circle cx="6" cy="8" r="2.5"/><circle cx="11" cy="11" r="1.5" fill="currentColor" stroke="none"/><path d="M8 9.5l2 1M3.5 4.5h4M3.5 6.5h3"/></Icon>,
   agent:     <Icon><circle cx="8" cy="6" r="2.5"/><path d="M3 14c0-2.5 2.2-4.5 5-4.5s5 2 5 4.5"/><circle cx="13" cy="3" r="1.5"/></Icon>,
+  // Two-hemisphere brain (reuses the GLYPHS.brain glyph) — the Agent Chat launcher.
+  brain:     <Icon name="brain" />,
   // Hindsight memory — stacked store with an orbiting fact node.
   memory:    <Icon><ellipse cx="8" cy="4" rx="5" ry="2"/><path d="M3 4v5c0 1.1 2.2 2 5 2s5-.9 5-2V4"/><path d="M3 6.5c0 1.1 2.2 2 5 2s5-.9 5-2"/><circle cx="13" cy="12.5" r="1.5"/></Icon>,
   settings:  <Icon><circle cx="8" cy="8" r="2"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3 3l1.5 1.5M11.5 11.5L13 13M3 13l1.5-1.5M11.5 4.5L13 3"/></Icon>,
@@ -405,13 +407,13 @@ function TopBar({ route, onCmdK, onBoard, onAgentChat, onMenu, menuOpen = false 
           glowing amber on hover/active. */}
       <div className="tb-launch">
         <button
-          className={"tb-launch-btn" + (chatOn ? " on" : "")}
+          className={"tb-launch-btn tb-brain" + (chatOn ? " on" : "")}
           data-testid="tb-launch-chat"
           onClick={onAgentChat}
           title="Open the agent chat"
           aria-pressed={chatOn}
         >
-          {Icons.agent}<span>Agent Chat</span>
+          {Icons.brain}<span>Agent Chat</span>
         </button>
       </div>
       <NotificationBell />

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -307,6 +307,30 @@ a { color: inherit; text-decoration: none; }
   box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
 }
 
+/* Agent Chat launcher — brain icon with a persistent pinkish-purple glow
+   (overrides the amber launcher default). Intensifies on hover / when the
+   chat slide-out is open. */
+.tb-launch-btn.tb-brain svg {
+  color: #d074ff;
+  filter: drop-shadow(0 0 5px rgba(208, 116, 255, 0.75)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.tb-launch-btn.tb-brain:hover svg,
+.tb-launch-btn.tb-brain.on svg {
+  color: #e29bff;
+  filter: drop-shadow(0 0 8px rgba(208, 116, 255, 0.95)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+.tb-launch-btn.tb-brain:hover {
+  color: var(--fg);
+  border-color: rgba(208, 116, 255, 0.5);
+  background: rgba(208, 116, 255, 0.10);
+}
+.tb-launch-btn.tb-brain.on {
+  color: #e29bff;
+  border-color: rgba(208, 116, 255, 0.5);
+  background: rgba(208, 116, 255, 0.10);
+  box-shadow: 0 0 0 1px rgba(208, 116, 255, 0.4), 0 0 14px -4px #d074ff;
+}
+
 /* Notification bell — icon-only launcher + anchored dropdown panel. */
 .tb-bell-wrap { position: relative; display: inline-flex; }
 .tb-bell {


### PR DESCRIPTION
Swaps the topbar **Agent Chat** launcher icon from the person glyph to a two-hemisphere **brain**, glowing pinkish-purple.

> **Stacked on #1202** (feat/kanban-to-services) — both touch the topbar in `chrome.jsx`. Base retargets to `main` as the stack merges.

## Change

- `Icons.brain` added (reuses the existing `GLYPHS.brain` two-hemisphere glyph).
- The Agent Chat launcher uses `Icons.brain` and carries a `tb-brain` class.
- CSS: `.tb-launch-btn.tb-brain svg` gets a persistent pinkish-purple colour (`#d074ff`) + drop-shadow glow, overriding the default amber launcher styling; it intensifies on hover and when the chat slide-out is open (`.on`).

## Verified live

Computed style on the box: icon `color: rgb(208, 116, 255)` with a matching `drop-shadow(...)` glow; the button renders the 2-path brain glyph labelled "Agent Chat".

🤖 Generated with [Claude Code](https://claude.com/claude-code)