### PR TITLE
feat(agents): ship hal0-brain persona on every install path; retire coder seed

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1623,11 +1623,11 @@ def _phase_mcp_wire(ctx: PhaseContext) -> PhaseResult:
 #
 # Seeds the operator-visible personas hal0 manages on top of Hermes's own
 # personality slot. Two personas land on first install — ``hermes``
-# (default, helpful) and ``coder`` (software focus, narrower auto-approve).
-# Operator edits survive re-runs; ``--repair`` re-writes the seeds back to
-# their canonical content. The active pointer flips to ``hermes`` only
-# when missing or dangling — an operator-chosen active persona survives
-# re-seed.
+# (default, helpful) and ``hal0-brain`` (the dashboard agent chat's
+# platform steward). Operator edits survive re-runs; ``--repair``
+# re-writes the seeds back to their canonical content. The active pointer
+# flips to ``hermes`` only when missing or dangling — an operator-chosen
+# active persona survives re-seed.
 
 
 def _phase_persona_seed(ctx: PhaseContext) -> PhaseResult:

--- a/src/hal0/agents/personas.py
+++ b/src/hal0/agents/personas.py
@@ -375,11 +375,13 @@ def activate(
 
 # ── Seed personas (Phase 8) ─────────────────────────────────────────────────
 #
-# The personas seeded at provision time. Per master-plan §6 the user picked
-# ``hermes`` (default) + ``coder``; ``hal0-brain`` was added for the
-# dashboard's agent-chat slide-out. They share the hal0 MCP tooling but
-# differ on tone, tools-allowed, and memory namespace so context from one
-# surface doesn't bleed into another.
+# The personas seeded at provision time: ``hermes`` (default) and
+# ``hal0-brain`` (the dashboard's agent-chat slide-out). They share the
+# hal0 MCP tooling but differ on tone, tools-allowed, and memory namespace
+# so context from one surface doesn't bleed into another. ``coder`` (per
+# master-plan §6) was a third seed until it was retired; its canonical
+# definition stays below so the seeder can recognise — and remove —
+# pristine copies left on boxes seeded before the retirement.
 
 
 def _seed_hermes(agent_id: str) -> Persona:
@@ -409,6 +411,9 @@ def _seed_hermes(agent_id: str) -> Persona:
 
 
 def _seed_coder(agent_id: str) -> Persona:
+    """RETIRED seed — kept only so :func:`seed_default_personas` can match
+    (and delete) untouched ``coder.toml`` files written by older seeders.
+    Never add this back to the seeds list."""
     return Persona(
         id="coder",
         display_name="Coder",
@@ -513,15 +518,20 @@ def seed_default_personas(
     root: Path | None = None,
     overwrite: bool = False,
 ) -> list[Persona]:
-    """Idempotently seed ``hermes`` + ``coder`` + ``hal0-brain`` + active pointer.
+    """Idempotently seed ``hermes`` + ``hal0-brain`` + active pointer.
 
     On first install the files are written and ``active.txt`` is set to
     ``hermes``. On re-run (``overwrite=False``) existing files are left
     alone so operator edits survive — only missing personas get written.
     With ``overwrite=True`` the seeds are forcibly re-written; used by
     ``--repair`` to recover from a corrupted operator edit.
+
+    Retired seeds (``coder``) are swept on every run: an on-disk copy is
+    deleted only when it still equals its canonical seed AND isn't the
+    active persona — an operator edit or an active selection turns the
+    file into operator data the seeder must not touch.
     """
-    seeds = [_seed_hermes(agent_id), _seed_coder(agent_id), _seed_hal0_brain(agent_id)]
+    seeds = [_seed_hermes(agent_id), _seed_hal0_brain(agent_id)]
     written: list[Persona] = []
     for persona in seeds:
         path = _personas_root(root) / f"{persona.id}.toml"
@@ -529,6 +539,16 @@ def seed_default_personas(
             continue
         save_persona(persona, root=root)
         written.append(persona)
+    for retired in (_seed_coder(agent_id),):
+        path = _personas_root(root) / f"{retired.id}.toml"
+        if not path.exists() or get_active(root=root) == retired.id:
+            continue
+        try:
+            existing = load_persona(retired.id, root=root)
+        except (FileNotFoundError, PersonaError, OSError):
+            continue  # malformed = operator territory; leave it alone
+        if existing == retired:
+            path.unlink()
     # active pointer: only set if missing or pointing at a now-missing
     # persona. Operator-chosen active values survive re-seeding.
     pointer = _personas_root(root) / ACTIVE_POINTER

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -911,6 +911,31 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.slot_manager = slot_manager
     app.state.model_cache = model_cache
 
+    # Agent personas — idempotently seed any missing defaults (hermes /
+    # coder / hal0-brain). The dashboard's agent-chat slide-out embodies the
+    # hal0-brain profile (routes/board_chat), so a box updated from a release
+    # that predates a seed must still grow its editable TOML: provisioning's
+    # persona_seed phase is checkpointed and never re-runs on `hal0 update`,
+    # which makes the post-update API restart the only hook every install
+    # path (update, editable/dev, fresh) shares. Existing files are never
+    # touched (overwrite=False); `hal0 agent install hermes --repair` stays
+    # the reset-to-canonical path. The root goes through paths.var_lib()
+    # rather than the module's PERSONAS_ROOT constant so HAL0_HOME installs
+    # (tests, dev boxes) seed under their own tree instead of the host's
+    # /var/lib/hal0 — in FHS production the two resolve identically.
+    try:
+        from hal0.agents.personas import seed_default_personas
+        from hal0.config import paths as _hal0_paths
+
+        seeded_personas = await asyncio.to_thread(
+            seed_default_personas,
+            root=_hal0_paths.var_lib() / ".hermes" / "personas",
+        )
+        if seeded_personas:
+            log.info("personas.startup_seed", ids=[p.id for p in seeded_personas])
+    except Exception as exc:  # seeding must never block startup
+        log.warning("personas.startup_seed_failed", error=str(exc))
+
     # Capability orchestrator — overlay that maps the dashboard's
     # capability-grouped children (embed/voice/img) onto regular slots.
     # The orchestrator is intentionally constructed AFTER the slot

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -239,7 +239,7 @@ def test_two_consecutive_runs_converge(
 
     persona_root = Path(hermetic_state.hermes_home) / "personas"
     hermes_toml_1 = (persona_root / "hermes.toml").read_text(encoding="utf-8")
-    coder_toml_1 = (persona_root / "coder.toml").read_text(encoding="utf-8")
+    brain_toml_1 = (persona_root / "hal0-brain.toml").read_text(encoding="utf-8")
     active_1 = (persona_root / "active.txt").read_text(encoding="utf-8")
 
     provision_1 = _strip_volatile(result_1.phases)
@@ -250,14 +250,16 @@ def test_two_consecutive_runs_converge(
     result_2 = hp.run(state_root=state_root, io=hermetic_io)
     config_after_2 = config_path.read_text(encoding="utf-8")
     hermes_toml_2 = (persona_root / "hermes.toml").read_text(encoding="utf-8")
-    coder_toml_2 = (persona_root / "coder.toml").read_text(encoding="utf-8")
+    brain_toml_2 = (persona_root / "hal0-brain.toml").read_text(encoding="utf-8")
     active_2 = (persona_root / "active.txt").read_text(encoding="utf-8")
     provision_2 = _strip_volatile(result_2.phases)
 
     assert config_after_1 == config_after_2, "config.yaml drifted on re-run"
     assert hermes_toml_1 == hermes_toml_2, "hermes persona TOML drifted"
-    assert coder_toml_1 == coder_toml_2, "coder persona TOML drifted"
+    assert brain_toml_1 == brain_toml_2, "hal0-brain persona TOML drifted"
     assert active_1 == active_2, "active pointer drifted"
+    # The retired coder seed must not reappear on either run.
+    assert not (persona_root / "coder.toml").exists()
     # Every phase status should be OK or SKIP on both runs.
     for name in hp.PHASE_NAMES:
         s1 = provision_1.get(name, {}).get("status")

--- a/tests/agents/test_personas.py
+++ b/tests/agents/test_personas.py
@@ -118,9 +118,9 @@ def test_set_active_refuses_missing_persona(tmp_path: Path) -> None:
 
 def test_seed_default_personas_writes_files_and_pointer(tmp_path: Path) -> None:
     written = P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
-    assert {p.id for p in written} == {"hermes", "coder", "hal0-brain"}
+    assert {p.id for p in written} == {"hermes", "hal0-brain"}
     assert (tmp_path / "hermes.toml").exists()
-    assert (tmp_path / "coder.toml").exists()
+    assert not (tmp_path / "coder.toml").exists()  # retired seed never lands
     assert (tmp_path / "hal0-brain.toml").exists()
     assert (tmp_path / P.ACTIVE_POINTER).read_text().strip() == "hermes"
 
@@ -133,7 +133,7 @@ def test_seed_hal0_brain_targets_brain_slot_with_own_memory(tmp_path: Path) -> N
     assert brain.preferred_upstream == "hal0"
     assert brain.memory_namespace == "private:hal0-brain"
     # Its memory bank is its own — distinct from the other seeds.
-    others = {P.load_persona(p, root=tmp_path).memory_namespace for p in ("hermes", "coder")}
+    others = {P.load_persona(p, root=tmp_path).memory_namespace for p in ("hermes",)}
     assert brain.memory_namespace not in others
     assert "platform steward" in brain.system_prompt
 
@@ -161,7 +161,7 @@ def test_seed_default_personas_overwrite_restores_defaults(tmp_path: Path) -> No
         encoding="utf-8",
     )
     written = P.seed_default_personas(agent_id="hermes-agent", root=tmp_path, overwrite=True)
-    assert {p.id for p in written} == {"hermes", "coder", "hal0-brain"}
+    assert {p.id for p in written} == {"hermes", "hal0-brain"}
     loaded = P.load_persona("hermes", root=tmp_path)
     assert loaded.display_name == "Hermes"
 
@@ -169,8 +169,37 @@ def test_seed_default_personas_overwrite_restores_defaults(tmp_path: Path) -> No
 def test_seed_preserves_operator_active_choice(tmp_path: Path) -> None:
     """Operator-chosen active persona survives re-seeding."""
     P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    P.set_active("hal0-brain", root=tmp_path)
+    P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    assert P.get_active(root=tmp_path) == "hal0-brain"
+
+
+def test_seed_removes_pristine_retired_coder(tmp_path: Path) -> None:
+    """The retirement sweep: an untouched coder.toml from an older seeder
+    disappears on the next seed pass."""
+    P.save_persona(P._seed_coder("hermes-agent"), root=tmp_path)
+    P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    assert not (tmp_path / "coder.toml").exists()
+
+
+def test_seed_keeps_operator_edited_retired_coder(tmp_path: Path) -> None:
+    """Any divergence from the canonical retired seed = operator data."""
+    import dataclasses
+
+    edited = dataclasses.replace(
+        P._seed_coder("hermes-agent"), system_prompt="operator-edited prompt"
+    )
+    P.save_persona(edited, root=tmp_path)
+    P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    assert P.load_persona("coder", root=tmp_path).system_prompt == "operator-edited prompt"
+
+
+def test_seed_keeps_active_retired_coder(tmp_path: Path) -> None:
+    """A pristine but ACTIVE coder is in use — never delete it."""
+    P.save_persona(P._seed_coder("hermes-agent"), root=tmp_path)
     P.set_active("coder", root=tmp_path)
     P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
+    assert (tmp_path / "coder.toml").exists()
     assert P.get_active(root=tmp_path) == "coder"
 
 
@@ -218,10 +247,10 @@ def test_activate_writes_active_and_returns_payload(
     propagation on failure."""
     P.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
     monkeypatch.setattr(P, "hermes_reload", lambda **_: (False, "unreachable"))
-    result = P.activate("coder", root=tmp_path)
-    assert result["persona_id"] == "coder"
-    assert result["display_name"] == "Coder"
-    assert P.get_active(root=tmp_path) == "coder"
+    result = P.activate("hal0-brain", root=tmp_path)
+    assert result["persona_id"] == "hal0-brain"
+    assert result["display_name"] == "hal0 Brain"
+    assert P.get_active(root=tmp_path) == "hal0-brain"
     assert result["hot_reload"]["ok"] is False
     assert result["hot_reload"]["error"] == "unreachable"
 

--- a/tests/agents/test_personas_budget_roundtrip.py
+++ b/tests/agents/test_personas_budget_roundtrip.py
@@ -69,13 +69,13 @@ def test_seed_personas_have_empty_budget_by_default(tmp_path: Path) -> None:
     """Default seeds ship an empty budget — operator opts in."""
     personas_mod.seed_default_personas(agent_id="hermes-agent", root=tmp_path)
     hermes = personas_mod.load_persona("hermes", root=tmp_path)
-    coder = personas_mod.load_persona("coder", root=tmp_path)
+    brain = personas_mod.load_persona("hal0-brain", root=tmp_path)
     assert hermes.budget.is_empty()
-    assert coder.budget.is_empty()
+    assert brain.budget.is_empty()
     # …but hard_cap defaults to True so a later operator edit doesn't have
     # to remember to flip it.
     assert hermes.budget.hard_cap is True
-    assert coder.budget.hard_cap is True
+    assert brain.budget.hard_cap is True
 
 
 def test_persona_with_budget_preserves_other_fields(tmp_path: Path) -> None:

--- a/tests/api/test_agents_budget.py
+++ b/tests/api/test_agents_budget.py
@@ -43,7 +43,7 @@ def state_root(
 
 @pytest.fixture
 def seeded(state_root: Path) -> Path:
-    """Seed the hermes + coder personas at the redirected root."""
+    """Seed the hermes + hal0-brain personas at the redirected root."""
     personas_dir = state_root / "hermes-agent" / "personas"
     personas_mod.seed_default_personas(agent_id="hermes-agent", root=personas_dir)
     return state_root

--- a/tests/api/test_agents_personas.py
+++ b/tests/api/test_agents_personas.py
@@ -41,7 +41,7 @@ def personas_root(
 
 @pytest.fixture
 def seeded_personas(personas_root: Path) -> Path:
-    """Seed the hermes + coder personas + the active pointer (= hermes)."""
+    """Seed the hermes + hal0-brain personas + the active pointer (= hermes)."""
     personas_mod.seed_default_personas(agent_id="hermes-agent", root=personas_root)
     return personas_root
 
@@ -56,13 +56,13 @@ def test_list_returns_seeded_personas(client: TestClient, seeded_personas: Path)
     assert body["agent_id"] == "hermes"
     assert body["active"] == "hermes"
     ids = sorted(row["id"] for row in body["personas"])
-    assert ids == ["coder", "hal0-brain", "hermes"]
+    assert ids == ["hal0-brain", "hermes"]
     hermes_row = next(row for row in body["personas"] if row["id"] == "hermes")
     assert hermes_row["active"] is True
     assert hermes_row["display_name"] == "Hermes"
     assert "summary" in hermes_row
-    coder_row = next(row for row in body["personas"] if row["id"] == "coder")
-    assert coder_row["active"] is False
+    brain_row = next(row for row in body["personas"] if row["id"] == "hal0-brain")
+    assert brain_row["active"] is False
 
 
 def test_list_empty_when_store_empty(client: TestClient, personas_root: Path) -> None:
@@ -102,10 +102,10 @@ def test_detail_returns_parsed_and_raw_toml(client: TestClient, seeded_personas:
 def test_detail_inactive_persona_reports_active_false(
     client: TestClient, seeded_personas: Path
 ) -> None:
-    r = client.get("/api/agents/hermes/personas/coder")
+    r = client.get("/api/agents/hermes/personas/hal0-brain")
     assert r.status_code == 200
     body = r.json()
-    assert body["id"] == "coder"
+    assert body["id"] == "hal0-brain"
     assert body["active"] is False
 
 
@@ -187,16 +187,16 @@ def test_activate_switches_active_and_invokes_hot_reload(
 
     monkeypatch.setattr(personas_mod, "hermes_reload", _fake_reload)
 
-    r = client.post("/api/agents/hermes/personas/coder/activate", json={})
+    r = client.post("/api/agents/hermes/personas/hal0-brain/activate", json={})
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["agent_id"] == "hermes"
-    assert body["active"] == "coder"
+    assert body["active"] == "hal0-brain"
     assert body["previous"] == "hermes"
     assert body["reloaded"] is True
     assert body["reload_error"] is None
     # The pointer file actually moved.
-    assert personas_mod.get_active(root=seeded_personas) == "coder"
+    assert personas_mod.get_active(root=seeded_personas) == "hal0-brain"
     # And the hot-reload nudge actually fired once.
     assert len(calls) == 1
 
@@ -216,17 +216,17 @@ def test_activate_reload_false_skips_hot_reload(
     monkeypatch.setattr(personas_mod, "hermes_reload", _fake_reload)
 
     r = client.post(
-        "/api/agents/hermes/personas/coder/activate",
+        "/api/agents/hermes/personas/hal0-brain/activate",
         json={"reload": False},
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["active"] == "coder"
+    assert body["active"] == "hal0-brain"
     assert body["previous"] == "hermes"
     assert body["reloaded"] is False
     assert body["reload_error"] is None
     # Pointer moved …
-    assert personas_mod.get_active(root=seeded_personas) == "coder"
+    assert personas_mod.get_active(root=seeded_personas) == "hal0-brain"
     # … but hermes_reload was NEVER called.
     assert calls == []
 
@@ -239,13 +239,13 @@ def test_activate_reports_failed_hot_reload(
     """Failed hot-reload is non-fatal; response carries ``reloaded=false``."""
     monkeypatch.setattr(personas_mod, "hermes_reload", lambda **_: (False, "connection refused"))
 
-    r = client.post("/api/agents/hermes/personas/coder/activate", json={})
+    r = client.post("/api/agents/hermes/personas/hal0-brain/activate", json={})
     assert r.status_code == 200
     body = r.json()
-    assert body["active"] == "coder"
+    assert body["active"] == "hal0-brain"
     assert body["reloaded"] is False
     assert body["reload_error"] == "connection refused"
-    assert personas_mod.get_active(root=seeded_personas) == "coder"
+    assert personas_mod.get_active(root=seeded_personas) == "hal0-brain"
 
 
 def test_activate_unknown_persona_returns_404(
@@ -286,7 +286,7 @@ def test_activate_no_body_defaults_to_reload_true(
         lambda **kwargs: calls.append(kwargs) or (True, None),
     )
 
-    r = client.post("/api/agents/hermes/personas/coder/activate")
+    r = client.post("/api/agents/hermes/personas/hal0-brain/activate")
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["reloaded"] is True

--- a/tests/api/test_persona_update.py
+++ b/tests/api/test_persona_update.py
@@ -83,7 +83,7 @@ def test_update_cannot_change_id(client: TestClient, seeded: Path) -> None:
     assert r.status_code == 200, r.text
     assert r.json()["id"] == "hermes"
     # No stray persona file was created.
-    assert {p.stem for p in seeded.glob("*.toml")} == {"hermes", "coder", "hal0-brain"}
+    assert {p.stem for p in seeded.glob("*.toml")} == {"hermes", "hal0-brain"}
 
 
 def test_update_preserves_budget(client: TestClient, seeded: Path) -> None:

--- a/tests/api/test_startup_persona_seed.py
+++ b/tests/api/test_startup_persona_seed.py
@@ -1,0 +1,63 @@
+"""Startup persona seeding — the lifespan hook that ships hal0-brain.
+
+The dashboard's agent-chat slide-out embodies the ``hal0-brain`` persona
+(routes/board_chat), but the only writer used to be provisioning's
+checkpointed ``persona_seed`` phase — boxes provisioned before a seed
+existed never grew its TOML on ``hal0 update``. The lifespan now seeds
+missing defaults on every API start (overwrite=False), so the post-update
+restart converges old boxes while operator edits survive untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+def _personas_root(tmp_hal0_home: str) -> Path:
+    # Mirrors the lifespan's paths.var_lib()-based resolution under HAL0_HOME.
+    return Path(tmp_hal0_home) / "var-lib" / "hal0" / ".hermes" / "personas"
+
+
+def test_lifespan_seeds_default_personas(tmp_hal0_home: str) -> None:
+    """A blank box grows all three seeds + the active pointer at startup."""
+    root = _personas_root(tmp_hal0_home)
+    assert not root.exists()
+
+    with TestClient(create_app()):
+        pass
+
+    assert {p.stem for p in root.glob("*.toml")} == {"hermes", "coder", "hal0-brain"}
+    assert (root / "active.txt").read_text(encoding="utf-8").strip() == "hermes"
+
+
+def test_lifespan_seed_adds_missing_brain_without_touching_edits(
+    tmp_hal0_home: str,
+) -> None:
+    """The pre-hal0-brain upgrade case: hermes/coder exist (one operator-
+    edited), hal0-brain is missing — startup adds only the missing seed."""
+    from hal0.agents import personas as personas_mod
+
+    root = _personas_root(tmp_hal0_home)
+    personas_mod.seed_default_personas(root=root)
+    (root / "hal0-brain.toml").unlink()
+    import dataclasses
+
+    edited = dataclasses.replace(
+        personas_mod.load_persona("hermes", root=root),
+        system_prompt="operator-edited prompt",
+    )
+    personas_mod.save_persona(edited, root=root)
+
+    with TestClient(create_app()):
+        pass
+
+    assert (root / "hal0-brain.toml").exists()
+    brain = personas_mod.load_persona("hal0-brain", root=root)
+    assert brain.memory_namespace == "private:hal0-brain"
+    assert brain.preferred_model == "hal0/brain"
+    hermes = personas_mod.load_persona("hermes", root=root)
+    assert hermes.system_prompt == "operator-edited prompt"

--- a/tests/api/test_startup_persona_seed.py
+++ b/tests/api/test_startup_persona_seed.py
@@ -23,39 +23,41 @@ def _personas_root(tmp_hal0_home: str) -> Path:
 
 
 def test_lifespan_seeds_default_personas(tmp_hal0_home: str) -> None:
-    """A blank box grows all three seeds + the active pointer at startup."""
+    """A blank box grows both seeds + the active pointer at startup."""
     root = _personas_root(tmp_hal0_home)
     assert not root.exists()
 
     with TestClient(create_app()):
         pass
 
-    assert {p.stem for p in root.glob("*.toml")} == {"hermes", "coder", "hal0-brain"}
+    assert {p.stem for p in root.glob("*.toml")} == {"hermes", "hal0-brain"}
     assert (root / "active.txt").read_text(encoding="utf-8").strip() == "hermes"
 
 
-def test_lifespan_seed_adds_missing_brain_without_touching_edits(
+def test_lifespan_seed_converges_old_box_without_touching_edits(
     tmp_hal0_home: str,
 ) -> None:
-    """The pre-hal0-brain upgrade case: hermes/coder exist (one operator-
-    edited), hal0-brain is missing — startup adds only the missing seed."""
+    """The upgrade case: an old box has hermes (operator-edited) + a
+    pristine retired coder, no hal0-brain — startup adds the missing
+    seed, sweeps the retired one, and leaves the edit alone."""
+    import dataclasses
+
     from hal0.agents import personas as personas_mod
 
     root = _personas_root(tmp_hal0_home)
-    personas_mod.seed_default_personas(root=root)
-    (root / "hal0-brain.toml").unlink()
-    import dataclasses
-
+    root.mkdir(parents=True)
     edited = dataclasses.replace(
-        personas_mod.load_persona("hermes", root=root),
+        personas_mod._seed_hermes("hermes"),
         system_prompt="operator-edited prompt",
     )
     personas_mod.save_persona(edited, root=root)
+    personas_mod.save_persona(personas_mod._seed_coder("hermes"), root=root)
+    personas_mod.set_active("hermes", root=root)
 
     with TestClient(create_app()):
         pass
 
-    assert (root / "hal0-brain.toml").exists()
+    assert not (root / "coder.toml").exists()  # pristine retired seed swept
     brain = personas_mod.load_persona("hal0-brain", root=root)
     assert brain.memory_namespace == "private:hal0-brain"
     assert brain.preferred_model == "hal0/brain"

--- a/tests/cli/test_agents_personas.py
+++ b/tests/cli/test_agents_personas.py
@@ -44,7 +44,7 @@ def test_personas_list_after_seed(cli_runner: CliRunner, isolated_personas: Path
     assert result.exit_code == 0
     # Both seeded personas appear; the default is marked active.
     assert "hermes" in result.stdout
-    assert "coder" in result.stdout
+    assert "hal0-brain" in result.stdout
     # Some part of "yes" appears on the active row's column.
     assert "yes" in result.stdout
 
@@ -81,12 +81,12 @@ def test_personas_activate_writes_pointer_and_emits_status(
     # asserts the success path explicitly; the failure path lives in
     # test_personas.py's activate test.
     monkeypatch.setattr(P, "hermes_reload", lambda **_kw: (True, None))
-    result = cli_runner.invoke(agent_app, ["personas", "activate", "coder"])
+    result = cli_runner.invoke(agent_app, ["personas", "activate", "hal0-brain"])
     assert result.exit_code == 0
-    # active.txt now points at coder.
-    assert (isolated_personas / P.ACTIVE_POINTER).read_text().strip() == "coder"
+    # active.txt now points at hal0-brain.
+    assert (isolated_personas / P.ACTIVE_POINTER).read_text().strip() == "hal0-brain"
     assert "Activated" in result.stdout
-    assert "Coder" in result.stdout
+    assert "Brain" in result.stdout
 
 
 def test_personas_activate_failed_reload_warns_but_succeeds(
@@ -98,11 +98,11 @@ def test_personas_activate_failed_reload_warns_but_succeeds(
     succeeds — the file write is the durable part."""
     P.seed_default_personas(agent_id="hermes-agent", root=isolated_personas)
     monkeypatch.setattr(P, "hermes_reload", lambda **_kw: (False, "Connection refused"))
-    result = cli_runner.invoke(agent_app, ["personas", "activate", "coder"])
+    result = cli_runner.invoke(agent_app, ["personas", "activate", "hal0-brain"])
     assert result.exit_code == 0
     assert "Hot-reload nudge skipped" in result.stdout
     # Activation still went through.
-    assert (isolated_personas / P.ACTIVE_POINTER).read_text().strip() == "coder"
+    assert (isolated_personas / P.ACTIVE_POINTER).read_text().strip() == "hal0-brain"
 
 
 def test_personas_activate_missing_persona_exits_nonzero(

--- a/tests/harness/integration/test_v0_3_persona_activate.py
+++ b/tests/harness/integration/test_v0_3_persona_activate.py
@@ -46,7 +46,7 @@ from hal0.api.agents import personas as personas_route
 @pytest.fixture
 def seeded_personas_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     """Redirect the personas store to a tmp dir + seed the default
-    hermes + coder personas + the active pointer (= hermes)."""
+    hermes + hal0-brain personas + the active pointer (= hermes)."""
     root = tmp_path / "personas"
     root.mkdir()
     monkeypatch.setattr(personas_mod, "PERSONAS_ROOT", root)
@@ -65,7 +65,7 @@ def test_persona_list_reflects_seeded_personas(
     assert body["agent_id"] == "hermes"
     assert body["active"] == "hermes"
     ids = sorted(row["id"] for row in body["personas"])
-    assert ids == ["coder", "hal0-brain", "hermes"]
+    assert ids == ["hal0-brain", "hermes"]
 
 
 def test_persona_activate_writes_active_txt(
@@ -74,21 +74,21 @@ def test_persona_activate_writes_active_txt(
     fake_hermes: FakeWsServer,
 ) -> None:
     """The activate POST persists ``active.txt`` to the persona root."""
-    # Hermes is already active per seed. Switch to coder.
+    # Hermes is already active per seed. Switch to hal0-brain.
     r = harness_client.post(
-        "/api/agents/hermes/personas/coder/activate",
+        "/api/agents/hermes/personas/hal0-brain/activate",
         json={"reload": False},
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["active"] == "coder"
+    assert body["active"] == "hal0-brain"
     assert body["previous"] == "hermes"
     assert body["reloaded"] is False  # because we passed reload=false
 
     # On-disk active.txt must reflect the swap.
     active_file = seeded_personas_root / "active.txt"
     assert active_file.exists()
-    assert active_file.read_text().strip() == "coder"
+    assert active_file.read_text().strip() == "hal0-brain"
 
 
 def test_persona_activate_with_reload_calls_hermes(
@@ -118,12 +118,12 @@ def test_persona_activate_with_reload_calls_hermes(
     monkeypatch.setenv("HAL0_HERMES_PORT", str(port))
 
     r = harness_client.post(
-        "/api/agents/hermes/personas/coder/activate",
+        "/api/agents/hermes/personas/hal0-brain/activate",
         json={"reload": True},
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["active"] == "coder"
+    assert body["active"] == "hal0-brain"
     # ``reloaded`` reflects whether the nudge succeeded. If the helper
     # uses a different protocol or wasn't wired to use the env vars,
     # the call still wrote active.txt and the endpoint returned 200 —
@@ -151,7 +151,7 @@ def test_persona_activate_unknown_agent_returns_404(
     seeded_personas_root: Path,
 ) -> None:
     r = harness_client.post(
-        "/api/agents/pi-coder/personas/coder/activate",
+        "/api/agents/pi-coder/personas/hal0-brain/activate",
         json={"reload": False},
     )
     assert r.status_code == 404
@@ -163,17 +163,17 @@ def test_persona_detail_after_activate_shows_new_active(
     harness_client: TestClient,
     seeded_personas_root: Path,
 ) -> None:
-    """Round-trip: activate coder → GET coder → ``active=true``."""
+    """Round-trip: activate hal0-brain → GET hal0-brain → ``active=true``."""
     r = harness_client.post(
-        "/api/agents/hermes/personas/coder/activate",
+        "/api/agents/hermes/personas/hal0-brain/activate",
         json={"reload": False},
     )
     assert r.status_code == 200
 
-    r = harness_client.get("/api/agents/hermes/personas/coder")
+    r = harness_client.get("/api/agents/hermes/personas/hal0-brain")
     assert r.status_code == 200
     body = r.json()
-    assert body["id"] == "coder"
+    assert body["id"] == "hal0-brain"
     assert body["active"] is True
 
     # And the previously-active hermes is now inactive.


### PR DESCRIPTION
## Problem

The dashboard's sidebar agent chat embodies the `hal0-brain` persona (`routes/board_chat.py`), but the persona TOML was only ever written by hermes provisioning's `persona_seed` phase — checkpointed, never re-run on `hal0 update`, and the updater has no persona hooks. Old boxes ran the sidebar chat on built-in fallbacks with no operator-editable profile. Separately, the `coder` seed persona is being retired.

## Changes

**1. Seed missing default personas at API startup** — the post-update restart is the one hook every install path shares (packaged update, editable/dev, fresh). Updater-commit migrations run under the *old* code, so they'd be one release late. `overwrite=False` keeps operator edits; root resolves via `paths.var_lib()` so `HAL0_HOME` installs stay isolated.

**2. Retire the `coder` seed** — the shipped personas are now `hermes` (default chat) and `hal0-brain` (dashboard agent chat). The canonical `_seed_coder` stays so the seeder can sweep retired copies on old boxes: `coder.toml` is deleted only when it still equals the pristine seed AND isn't active; an operator edit or active selection makes it untouchable operator data.

## Tests

- `tests/api/test_startup_persona_seed.py`: blank box grows both seeds + pointer; upgrade case (edited hermes + pristine coder, no brain) converges without touching the edit.
- `tests/agents/test_personas.py`: retirement sweep (pristine removed / edited kept / active kept).
- 224 tests across persona, board-chat, budget, CLI, provisioning and harness suites pass; full `tests/api` green minus 5 pre-existing environmental failures (reproduce with changes stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)