### PR TITLE
feat(ui): unify slots-page headings and slot-status indicators

### DIFF
--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -395,9 +395,12 @@ function CardHead({ engine, run, pct }) {
   return (
     <div className="engine-h wcard-h">
       <span className="engine-glyph"><Ci name="comfy" size={16} /></span>
-      <span className="col">
-        <span className="engine-title">ComfyUI</span>
-        <span className="engine-sub">image-gen engine · docker</span>
+      <span className="sec-label">
+        <b>ComfyUI</b>
+        <span className="dim">·</span>
+        <span className="meta">image-gen engine</span>
+        <span className="dim">·</span>
+        <span className="meta">docker</span>
       </span>
       <span className={'epill' + (hasRun ? ' generating' : '')}>
         <span className="dot" />

--- a/ui/src/dash/connections.css
+++ b/ui/src/dash/connections.css
@@ -132,11 +132,15 @@
 .eprow.expanded > .eprow-main { background: var(--bg-2); }
 .eprow.dim .eprow-main { opacity: 0.5; }
 
+/* ONE status vocabulary — matches .sdot (overhaul.css / engine-panes.css) so an
+   endpoint row and its slot card always show the same colour for the same phase:
+   serving = green + pulse · stale/ready = amber (idle-but-up) · warming = orange
+   pulse · error = red · offline = grey. */
 .ep-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-5); justify-self: center; }
-.ep-dot.serving { background: var(--accent); box-shadow: 0 0 8px var(--accent); animation: pulse 1.4s ease-in-out infinite; }
-.ep-dot.ready { background: var(--ok); box-shadow: 0 0 7px var(--ok); }
+.ep-dot.serving { background: var(--ok); box-shadow: 0 0 8px var(--ok); animation: pulse 1.4s ease-in-out infinite; }
+.ep-dot.stale { background: var(--hal0-accent); }
 .ep-dot.warming { background: var(--warn); box-shadow: 0 0 7px var(--warn); animation: pulse 1.4s ease-in-out infinite; }
-.ep-dot.idle { background: var(--ok); opacity: 0.4; }
+.ep-dot.error { background: var(--err); box-shadow: 0 0 7px var(--err); }
 .ep-dot.offline { background: var(--fg-5); }
 .ep-name { color: var(--fg); font-weight: 500; display: inline-flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .ep-name .star { color: var(--accent); font-size: 9px; }

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -20,6 +20,7 @@
 // from GET /api/mcp/servers (`tool_details`).
 
 import { useSlots } from '@/api/hooks/useSlots'
+import { slotIndicatorFromPhase } from './slot-status.js'
 import { useMcpServers } from '@/api/hooks/useMcp'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
 
@@ -124,14 +125,13 @@ function modelId(s) {
   return s.model_id || s.model || s.name
 }
 
-// Lifecycle → the five dot states the pane styles. Unknown / transitional
-// backend states fold into the nearest visual bucket.
+// Lifecycle → dot state. Derived from the SAME container-aware classifier the
+// slot cards use (slot-status.js) so an endpoint row and its slot card can
+// never disagree — the old raw-`state` heuristic here flagged a healthy-but-
+// quiet slot as "warming" while the card showed it "ready". cls is one of
+// serving | stale | warming | error | offline (see .ep-dot in connections.css).
 function epState(s) {
-  const st = s.state
-  if (['serving', 'ready', 'warming', 'idle', 'offline'].includes(st)) return st
-  if (st === 'loading' || st === 'starting' || st === 'pending') return 'warming'
-  if (st === 'error' || st === 'failed' || st === 'stopped' || st === 'unloaded') return 'offline'
-  return 'idle'
+  return slotIndicatorFromPhase(s).cls
 }
 
 // Slot → the OpenAI route family. Maps the slot `type` (a true modality) onto
@@ -436,19 +436,23 @@ function CopyBtn({ text, label, icon, cls }) {
 }
 
 // ─── reusable engine-block pane ──────────────────────────────────────
-function EnginePane({ live, glyph, eyebrow, title, sub, pill, headRight, strip, foot, defaultOpen, children }) {
+function EnginePane({ live, glyph, title, sub, pill, headRight, strip, foot, defaultOpen, children }) {
   const [open, setOpen] = useCS(defaultOpen !== false)
   return (
     <section>
-      <div className="conn-eyebrow">{eyebrow}</div>
       <div className={'engine cpane' + (live ? ' live active' : '') + (open ? ' open' : '')}>
         <div className="engine-h cpane-h" onClick={() => setOpen((o) => !o)}>
           <span className="engine-glyph cpane-glyph">
             <CIcon name={glyph} size={16} />
           </span>
-          <span className="cpane-titles">
-            <span className="engine-title cpane-title">{title}</span>
-            <span className="engine-sub cpane-sub">{sub}</span>
+          <span className="sec-label">
+            <b className="cpane-title">{title}</b>
+            {sub && (
+              <>
+                <span className="dim">·</span>
+                <span className="meta cpane-sub">{sub}</span>
+              </>
+            )}
           </span>
           <span className={'cpill ' + (pill.tone || '')}>
             <span className="dot" />
@@ -848,25 +852,12 @@ function LocalEndpointsPanel() {
   const tls = typeof window !== 'undefined' && window.location.protocol === 'https:'
 
   const serving = slots.filter((s) => epState(s) === 'serving').length
-  const reachable = slots.filter((s) => epState(s) !== 'offline').length
+  const reachable = slots.filter((s) => !['offline', 'error'].includes(epState(s))).length
 
   return (
     <EnginePane
       live
       glyph="connections"
-      eyebrow={
-        <>
-          <b>local endpoints</b>
-          <span className="dim">·</span>
-          <span className="meta">openai-compatible</span>
-          <span className="dim">·</span>
-          <span className="mono" style={{ color: 'var(--fg-3)' }}>
-            {slots.length} ports
-          </span>
-          <span className="grow" />
-          <span className="meta">gateway · :{port}</span>
-        </>
-      }
       title="Local endpoints"
       sub="openai-compatible · /v1/*"
       pill={{ tone: 'live', text: serving + ' serving · ' + reachable + ' reachable' }}
@@ -942,21 +933,6 @@ function McpServersPanel() {
   return (
     <EnginePane
       glyph="agent"
-      eyebrow={
-        <>
-          <b>mcp</b>
-          <span className="dim">·</span>
-          <span className="meta">model context protocol</span>
-          <span className="dim">·</span>
-          <span className="mono" style={{ color: 'var(--fg-3)' }}>
-            {servers.length} servers
-          </span>
-          <span className="grow" />
-          <span className="meta">
-            {host}:{port}/mcp/*
-          </span>
-        </>
-      }
       title="MCP servers"
       sub="model context protocol · bundled"
       pill={{ tone: 'ok', text: mcpUp + ' up · ' + toolTotal + ' tools' }}

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -56,6 +56,63 @@
 }
 
 /* ─── Section label ─────────────────────────────────────────────────── */
+/* Generic in-header variant — any pane header (.engine-h / .cpane-h /
+   .wcard-h) or view header (.vh) can host the same single-row heading
+   family the Inference pane uses: bold uppercase name · dim dots ·
+   uppercase meta segments. The pane-scoped rules below come later in the
+   file so their per-pane accent (--comfy) wins inside .infer-pane/.npu-pane. */
+.engine-h .sec-label,
+.cpane-h .sec-label,
+.wcard-h .sec-label,
+.vh .sec-label {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-family: var(--jbm);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--fg-3);
+  margin: 0;
+  min-width: 0;
+}
+.engine-h .sec-label b,
+.cpane-h .sec-label b,
+.wcard-h .sec-label b,
+.vh .sec-label b {
+  color: var(--accent);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.engine-h .sec-label .dim,
+.cpane-h .sec-label .dim,
+.wcard-h .sec-label .dim,
+.vh .sec-label .dim {
+  color: var(--fg-5);
+}
+.engine-h .sec-label .meta,
+.cpane-h .sec-label .meta,
+.wcard-h .sec-label .meta,
+.vh .sec-label .meta {
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+}
+.engine-h .sec-label .grow,
+.cpane-h .sec-label .grow,
+.wcard-h .sec-label .grow,
+.vh .sec-label .grow {
+  flex: 1;
+}
+.engine-h .sec-label .mono,
+.cpane-h .sec-label .mono,
+.wcard-h .sec-label .mono,
+.vh .sec-label .mono {
+  font-family: var(--jbm);
+}
+
 .infer-pane .sec-label,
 .npu-pane .sec-label {
   display: flex;
@@ -84,6 +141,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-size: 11px;
+}
+/* sec-label hoisted into the engine header row (single NPU-style heading) —
+   drop the block margin it carries as a standalone section label */
+.infer-pane .engine-h .sec-label,
+.npu-pane .engine-h .sec-label {
+  margin: 0;
 }
 .infer-pane .sec-label .grow,
 .npu-pane .sec-label .grow,
@@ -951,13 +1014,15 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-/* ── ONE status vocabulary (round dot), yellow-family · scoped to .infer-pane ──
-   ready   = solid yellow (loaded, healthy, idle-but-up) — no glow
-   serving = yellow + glow + pulse (active / working)
-   warming = orange + glow + pulse
+/* ── ONE status vocabulary (round dot) · shared across every slot indicator ──
+   The colours here MUST match the generic .sdot (overhaul.css) and the
+   endpoint .ep-dot (connections.css) so a slot's card, its endpoint row, and
+   its list entry can never show different colours for the same phase:
+   serving = GREEN + glow + pulse (actively processing a request now)
+   ready   = solid YELLOW/amber (loaded, healthy, idle-but-up) — no glow
+   warming = orange + glow + pulse (starting / pulling)
    error   = red + glow
-   offline = grey, no glow
-   Green (--ok) no longer appears for any slot status in this pane. */
+   offline = grey, no glow */
 .infer-pane .sdot {
   width: 8px;
   height: 8px;
@@ -966,11 +1031,11 @@
   flex-shrink: 0;
 }
 .infer-pane .sdot.ready {
-  background: var(--comfy);
+  background: var(--hal0-accent);
 }
 .infer-pane .sdot.serving {
-  background: var(--comfy);
-  box-shadow: 0 0 8px var(--comfy);
+  background: var(--ok);
+  box-shadow: 0 0 8px var(--ok-glow, rgba(111, 207, 151, 0.35));
   animation: pulse 1.4s ease-in-out infinite;
 }
 .infer-pane .sdot.warming {

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -534,14 +534,6 @@ export function InferencePane() {
     },
   }
 
-  const epillCls = servingN > 0 ? 'serving' : loadedN > 0 ? 'ready' : 'stopped'
-  const epillLabel =
-    servingN > 0
-      ? `${servingN} serving · ${loadedN} loaded`
-      : loadedN > 0
-        ? `${loadedN} loaded`
-        : 'idle'
-
   const newSlot = () => window.dispatchEvent(new CustomEvent('hal0:create-slot'))
   const openLogs = () => {
     window.location.hash = '#logs'
@@ -550,37 +542,29 @@ export function InferencePane() {
   return (
     <div className="infer-pane">
       <div className="proto">
-        <div className="sec-label">
-          <b>Inference Engine</b>
-          <span className="dim">·</span>
-          <span className="meta">slots</span>
-          <span className="mono" style={{ color: 'var(--comfy)' }}>
-            {gpuN} iGPU
-          </span>
-          {npuN > 0 && (
-            <>
-              <span className="dim">·</span>
-              <span className="mono" style={{ color: 'var(--dev-npu)' }}>
-                {npuN} FLM
-              </span>
-            </>
-          )}
-          <span className="grow" style={{ flex: 1 }} />
-          <span className="meta">podman · :8080</span>
-        </div>
-
+        {/* Single NPU-card-style header row — the old two-row stack (sec-label
+            above + "Inference / inference engine · podman" title block + green
+            loaded epill) collapsed into one heading. */}
         <div className={'engine' + (loadedN > 0 ? ' active' : '')}>
           <div className="engine-h">
             <span className="engine-glyph">
               <Ic name="slots" size={16} />
             </span>
-            <span className="col">
-              <span className="engine-title">Inference</span>
-              <span className="engine-sub">inference engine · podman</span>
-            </span>
-            <span className={'epill ' + epillCls} data-testid="infer-epill">
-              <span className="dot" />
-              {epillLabel}
+            <span className="sec-label">
+              <b>Inference Engine</b>
+              <span className="dim">·</span>
+              <span className="meta">slots</span>
+              <span className="mono" style={{ color: 'var(--comfy)' }}>
+                {gpuN} iGPU
+              </span>
+              {npuN > 0 && (
+                <>
+                  <span className="dim">·</span>
+                  <span className="mono" style={{ color: 'var(--dev-npu)' }}>
+                    {npuN} FLM
+                  </span>
+                </>
+              )}
             </span>
             <span className="grow" style={{ flex: 1 }} />
             <span className="eh-right">

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -446,23 +446,23 @@ export function NpuOccupancyCard({ slots }) {
             XDNA 2 · npu
           </span>
           <span className="grow" />
-          <button className="btn ghost sm" title="Start"
+          <button className="btn ghost sm ctl-start" title="Start"
             onClick={() => handlers.onStart(flmSlot)} disabled={!flmSlot}>
             ▶
           </button>
-          <button className="btn ghost sm" title="Stop"
+          <button className="btn ghost sm ctl-stop" title="Stop"
             onClick={() => handlers.onStop(flmSlot)} disabled={!flmSlot}>
             ■
           </button>
-          <button className="btn ghost sm" title="Restart"
+          <button className="btn ghost sm ctl-restart" title="Restart"
             onClick={() => handlers.onRestart(flmSlot)} disabled={!flmSlot}>
             ↻
           </button>
-          <button className="btn ghost sm" title="Logs"
+          <button className="btn ghost sm ctl-logs" title="Logs"
             onClick={() => handlers.onLogs(flmSlot)} disabled={!flmSlot}>
             📋
           </button>
-          <button className="btn ghost sm" title="Edit FLM slot" onClick={() => window.location.hash = '#slots/flm'} style={{fontSize: 13}}>✎ Edit</button>
+          <button className="btn ghost sm" title="Configure FLM slot" onClick={() => window.location.hash = '#slots/flm'} style={{fontSize: 13}}>✎ Configure</button>
         </div>
         <div className="wcard-b">
           <div className="combo">

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -101,6 +101,33 @@
   padding: 16px;
 }
 
+/* header lifecycle controls — each action carries its own hue:
+   start purple (NPU accent) · stop red · restart yellow · logs grey */
+.npu-card .wcard-h .btn.ctl-start {
+  color: var(--npu);
+  border-color: var(--npu-line);
+}
+.npu-card .wcard-h .btn.ctl-start:hover {
+  background: var(--npu-soft);
+}
+.npu-card .wcard-h .btn.ctl-stop {
+  color: var(--err);
+  border-color: var(--err-line);
+}
+.npu-card .wcard-h .btn.ctl-stop:hover {
+  background: var(--err-soft);
+}
+.npu-card .wcard-h .btn.ctl-restart {
+  color: var(--warn);
+  border-color: var(--warn-line);
+}
+.npu-card .wcard-h .btn.ctl-restart:hover {
+  background: var(--warn-soft);
+}
+.npu-card .wcard-h .btn.ctl-logs {
+  color: var(--fg-3);
+}
+
 /* device pill — [ XDNA 2 · npu ] */
 .npu-card .npu-pill {
   display: inline-flex;

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -1444,6 +1444,7 @@
   background: var(--bg-1);
   overflow: hidden;
   container-type: inline-size;
+  margin-bottom: 16px; /* breathing room above the slots-page tab bar */
 }
 /* Base = auto-fit (also the fallback for pre-container-query browsers);
    the ruler is a strip item spanning the full row. Container queries

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -541,9 +541,12 @@ function ProfilesHeader({ count, onNew, onImport }) {
   return (
     <div className="engine-h pf-engine-h">
       <span className="engine-glyph">{Icons.slots}</span>
-      <span className="cpane-titles">
-        <span className="engine-title">Profiles</span>
-        <span className="engine-sub">launch profiles · image + bench-tuned flags per workload</span>
+      <span className="sec-label">
+        <b>Profiles</b>
+        <span className="dim">·</span>
+        <span className="meta">launch profiles</span>
+        <span className="dim">·</span>
+        <span className="meta">bench-tuned flags per workload</span>
       </span>
       {count != null && (
         <span className="cpill">

--- a/ui/src/dash/stacks.jsx
+++ b/ui/src/dash/stacks.jsx
@@ -764,10 +764,14 @@ function StacksView() {
   function Header() {
     return (
       <div className="vh">
-        <span className="vh-eye mono">RUNTIME</span>
-        <h1>Stacks</h1>
+        <span className="sec-label">
+          <b>Stacks</b>
+          <span className="dim">·</span>
+          <span className="meta">runtime</span>
+          <span className="dim">·</span>
+          <span className="meta">slot + profile + model bundles</span>
+        </span>
         <div className="vh-spacer" />
-        <span className="hint mono">preconfigured slot + profile + model bundles</span>
         <button className="btn ghost sm" onClick={() => setImporting(true)} data-testid="st-btn-import">{Icons.attach} Import</button>
         <button className="btn ghost sm" onClick={onSnapshot} data-testid="st-btn-snapshot">{Icons.copy} Snapshot</button>
         <button className="btn sm" onClick={() => setDrawer({ mode: 'create' })} data-testid="st-btn-new">{Icons.plus} New stack</button>

--- a/ui/tests/e2e/specs/inference-pane-v3.spec.ts
+++ b/ui/tests/e2e/specs/inference-pane-v3.spec.ts
@@ -5,7 +5,9 @@
  * Behaviour under test:
  *   - the page-level telemetry header (TelemetryHeader, above the tabs)
  *     renders the combined metrics card: throughput cell + memory rack ruler
- *   - the engine pane renders the epill + ALL slots as full cards, always
+ *   - the engine pane renders a single NPU-card-style heading (Inference
+ *     Engine · slots · N iGPU · N FLM — the old sec-label row + title/sub +
+ *     green loaded epill collapsed into it) + ALL slots as full cards, always
  *     visible (the old collapse/expand accordion + qcaret were removed)
  *   - the serving card's status pill shows live tok/s (no fabricated numbers)
  *   - the profile pill surfaces the slot's runtime profile name (slot.profile)
@@ -32,7 +34,7 @@ const body = (page: Page) => pane(page).locator('.engine-b').first()
 const hero = (page: Page) => page.getByTestId('telemetry-header')
 
 test.describe('Inference engine pane (/slots · Inference tab)', () => {
-  test('telemetry header renders throughput cell + memory ruler; engine renders epill + full slot cards', async ({ page }) => {
+  test('telemetry header renders throughput cell + memory ruler; engine renders single heading + full slot cards', async ({ page }) => {
     await page.goto('/#slots')
     // page-level telemetry header (above the tabs): throughput cell + memory
     // rack ruler. Forced-mock has no throughput-history endpoint, so the cell
@@ -40,9 +42,14 @@ test.describe('Inference engine pane (/slots · Inference tab)', () => {
     await expect(hero(page)).toBeVisible()
     await expect(hero(page).locator('.th-ruler-h')).toContainText('memory ·')
     await expect(hero(page).locator('.th-cell-tps')).toBeVisible()
-    // engine pane: state pill summarises serving/loaded counts (primary serving).
+    // engine pane: one NPU-card-style heading — "Inference Engine · slots ·
+    // N iGPU" with the FLM count; the old green loaded epill is gone.
     await expect(pane(page)).toBeVisible()
-    await expect(page.getByTestId('infer-epill')).toContainText('serving')
+    const head = engine(page).locator('.engine-h')
+    await expect(head).toContainText('Inference Engine')
+    await expect(head).toContainText('iGPU')
+    await expect(page.getByTestId('infer-epill')).toHaveCount(0)
+    await expect(head.locator('.epill')).toHaveCount(0)
     // headline (chat · agent) slots render as FULL cards. The status pill is
     // gone — the header now shows the slot PORT (mono, pushed right); readiness
     // is the dot, and tok/s lives in the meta row.


### PR DESCRIPTION
## Summary

Two threads of slots-page UI polish, done together because they touch the same panes.

### 1. One heading style across all slots-page tabs
Every tab heading now reads as a single row — `[glyph]  BOLD NAME · dim-dot · meta segments` — instead of the previous mix of two-line title/sub blocks, `<h1>` view headers, and eyebrow strips.

- **Inference** — collapsed the standalone section label + two-line title + green "N loaded" pill into one heading row.
- **Image Gen (ComfyUI)** / **Profiles** — two-line title/sub → single `sec-label` row.
- **Endpoints / MCP** (shared `EnginePane`) — dropped the redundant eyebrow and folded the two-line title into the `sec-label` row. Kept the `.cpane-title` text/class so existing locators resolve; the eyebrow's counts still live in the summary strip below.
- **Stacks** — `RUNTIME` / `<h1>Stacks</h1>` view header → single `sec-label` row.
- Added generic in-header `.sec-label` rules so any `.engine-h` / `.cpane-h` / `.wcard-h` / `.vh` can host the same heading family.

Also on the NPU card: colorized the header lifecycle controls (**start** purple · **stop** red · **restart** yellow · **logs** grey) and renamed **Edit → Configure**. And added bottom margin to the telemetry/metrics header so it no longer sits flush against the tab bar.

### 2. One slot-status vocabulary everywhere
There were three status-dot systems that had drifted apart. Unified them onto one classifier and one color language:

| phase | color | animation |
|-------|-------|-----------|
| serving | green (`--ok`) | pulse |
| ready / idle | amber (`--hal0-accent`) | static |
| warming | orange (`--warn`) | pulse |
| error | red (`--err`) | static |
| offline | grey (`--fg-5`) | static |

- **Inference slot cards** — serving dot was hard-coded to the yellow `--comfy` accent; now green, with ready as amber. (Answers "serving = green, yellow = idle".)
- **Endpoints** — the real inconsistency: `epState()` keyed off the raw `state` string and flagged a healthy-but-quiet slot as **warming** while its container-aware slot card showed **ready**. Rewrote `epState()` to derive from the shared `slotIndicatorFromPhase()` classifier, and realigned `.ep-dot` colors to match.

**Intentional exception:** the NPU occupancy card dots stay purple — that's the NPU's device-identity color, not a drifted status system. Easy to fold into the shared vocabulary later if desired.

## Testing
- `npm run build` clean.
- Full Playwright e2e suite: **388 passed / 10 skipped**.
- Updated `inference-pane-v3.spec.ts` for the collapsed heading (asserts the single heading row and the removed epill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)