### PR TITLE
feat(mcp): expand hal0-admin to the full platform surface for the Brain agent

### DIFF
--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -117,6 +117,13 @@ Tool surfaces:
 - Settings: get_orchestration / update_orchestration (board dispatcher knobs:
   orchestrator_profile, default_assignee, auto_decompose,
   auto_promote_children).
+- Full platform admin (hal0-admin catalog): model inspect/download/register/
+  organize (pulls always land in the operator's configured model store —
+  check model_store first), profile and stack CRUD, slot create/edit/delete,
+  hal0 settings, benchmarks, logs. Tools marked (gated) do NOT run
+  immediately: they return status=pending_approval with an approval_id and
+  execute only after the operator approves them in the dashboard's Approvals
+  panel — when that happens, say what you queued and why, then wait.
 
 Rules:
 - You cannot see state unless you look. Call the matching read tool first and
@@ -348,6 +355,121 @@ def _tool_schemas() -> list[dict[str, Any]]:
             [],
         ),
     ]
+
+
+# ── admin-MCP tool surface (the platform steward's hands) ───────────────────
+#
+# The slide-out chat embodies the hal0-brain persona, whose remit is the
+# whole platform — not just the board. Rather than hand-maintaining a
+# second tool table here, the chat surfaces the hal0-admin MCP catalog
+# (hal0.mcp.admin.TOOL_DESCRIPTIONS) as OpenAI tool schemas and routes
+# calls through the SAME ``dispatch`` core the /mcp/admin mount uses:
+# identical read/write/gated classification, the lifespan-scoped
+# ApprovalQueue (gated tools come back ``pending_approval`` and execute
+# only after the operator approves), and the same audit rows.
+#
+# Locals win on collision: the chat's own board tools and platform verbs
+# (slot_load/slot_unload/slot_restart, compact list_slots/list_models
+# reads) are purpose-tuned and already pinned by tests, so their admin
+# twins are excluded from the surfaced schemas. Imports stay lazy — the
+# ``mcp`` SDK is an optional dependency, and a box without it must still
+# serve the board-only chat (schemas degrade to the local list).
+
+_ADMIN_TOOL_EXCLUDES: frozenset[str] = frozenset(
+    {
+        # exact name collisions with the local platform verbs
+        "slot_load",
+        "slot_unload",
+        "slot_restart",
+        # semantic duplicates of the local compact reads
+        "slot_list",
+        "slot_status",
+        "model_list",
+        "hardware_probe",
+        # memory_* ride the persona's own namespace (private:hal0-brain)
+        # via Hindsight, not the agent memory engine's MCP dispatcher
+        "memory_add",
+        "memory_search",
+        "memory_list",
+        "memory_delete",
+    }
+)
+
+
+def _admin_tool_names() -> frozenset[str]:
+    """The admin catalog minus exclusions; empty when the SDK is absent."""
+    try:
+        from hal0.mcp.admin import (
+            AUTONOMOUS_READ_TOOLS,
+            AUTONOMOUS_WRITE_TOOLS,
+            GATED_TOOLS,
+        )
+    except ImportError:
+        return frozenset()
+    return (AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS) - _ADMIN_TOOL_EXCLUDES
+
+
+def _admin_tool_schemas() -> list[dict[str, Any]]:
+    """OpenAI tool schemas for the surfaced admin catalog.
+
+    Path args (from the admin server's ``_PATH_ARGS``) become required
+    string properties; ``additionalProperties`` stays open so the model
+    can pass body/query fields the descriptions call out (e.g.
+    ``model_pull``'s ``hf_repo``/``hf_filename``).
+    """
+    try:
+        from hal0.mcp.admin import _PATH_ARGS, TOOL_DESCRIPTIONS
+    except ImportError:
+        return []
+    schemas: list[dict[str, Any]] = []
+    for name, description in TOOL_DESCRIPTIONS.items():
+        if name in _ADMIN_TOOL_EXCLUDES:
+            continue
+        path_args = _PATH_ARGS.get(name, ())
+        schemas.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {arg: {"type": "string"} for arg in path_args},
+                        "required": list(path_args),
+                        "additionalProperties": True,
+                    },
+                },
+            }
+        )
+    return schemas
+
+
+async def _dispatch_admin_tool(request: Request, name: str, args: dict[str, Any]) -> Any:
+    """Route one admin-catalog call through the MCP dispatch core.
+
+    Reuses the lifespan-scoped ApprovalQueue so a gated tool queued from
+    the chat lands in the same dashboard Approvals panel as one queued
+    over /mcp/admin, and the audit trail records the persona as the
+    calling client.
+    """
+    try:
+        from hal0.mcp import admin
+    except ImportError:
+        return {"error": f"{name}: admin tools unavailable (mcp SDK not installed)"}
+    queue = getattr(request.app.state, "approval_queue", None)
+    if queue is None:
+        return {"error": f"{name}: admin tools unavailable (no approval queue)"}
+    bearer = request.headers.get("Authorization", "").removeprefix("Bearer ").strip() or None
+    base = getattr(request.app.state, "self_api_base_url", "http://127.0.0.1:8080")
+    return await admin.dispatch(
+        tool=name,
+        args=args,
+        client_id=BRAIN_PERSONA_ID,
+        bearer=bearer,
+        base_url=base,
+        approval_queue=queue,
+        memory_dispatcher=getattr(request.app.state, "memory_dispatcher", None),
+    )
 
 
 # ── read tools (allowlisted GETs — mirror the UNAUDITED REST read rows) ─────
@@ -584,6 +706,11 @@ async def _dispatch_tool(
 
     method, path, tool_params, body, target = _resolve_tool(name, args)
     if method is None:
+        # Not a local tool — the rest of the surface is the admin-MCP
+        # catalog, dispatched through the same gating/audit core as
+        # /mcp/admin (gated tools return ``pending_approval``).
+        if name in _admin_tool_names():
+            return await _dispatch_admin_tool(request, name, args)
         return {"error": f"unknown tool: {name}"}
 
     # Merge the board scope with any tool-specific query params (e.g.
@@ -760,7 +887,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     body: dict[str, Any] = {
         "model": payload.get("model") or default_model,
         "messages": messages,
-        "tools": _tool_schemas(),
+        "tools": _tool_schemas() + _admin_tool_schemas(),
         "stream": False,
     }
 
@@ -842,8 +969,11 @@ __all__ = [
     "BRAIN_PERSONA_ID",
     "BRAIN_SLOT_MODEL",
     "PRIMARY_SLOT_MODEL",
+    "_admin_tool_names",
+    "_admin_tool_schemas",
     "_chat_stream",
     "_compact_board",
+    "_dispatch_admin_tool",
     "_dispatch_platform_tool",
     "_dispatch_tool",
     "_resolve_platform_tool",

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1037,6 +1037,119 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
 }
 
 
+# ── Tool catalog descriptions ────────────────────────────────────────────────
+#
+# Single source of truth for the tool surface's names + descriptions.
+# build_server registers exactly this dict; the dashboard's agent chat
+# (hal0.api.routes.board_chat) surfaces the same catalog as OpenAI tool
+# schemas and routes calls through the same ``dispatch`` core — keep
+# descriptions agent-facing (state required args + side effects).
+
+TOOL_DESCRIPTIONS: dict[str, str] = {
+    # ── Autonomous read ─────────────────────────────────────────────────
+    "slot_list": "List every slot known to hal0 (local + remote).",
+    "slot_status": "Get one slot's lifecycle state + metadata.",
+    "slot_metrics": "Get per-slot performance metrics (tok/s, latency, queue depth).",
+    "slot_capacity": "Get GPU/NPU memory capacity and per-slot allocation.",
+    "model_list": "Aggregate models from local registry + upstreams.",
+    "model_show": "Show a single model's full metadata (registry + upstream).",
+    "model_scan_preview": "Preview what a model scan would register (dry run).",
+    "model_catalogue": "List the curated catalogue of blessed models.",
+    "model_update_check": "Check which HF-backed models have updates available.",
+    "model_pulls_list": "List all pull jobs (in-flight + terminal).",
+    "model_pull_status": "Get one model's pull-job progress (state, %, speed, ETA).",
+    "model_inspect": (
+        "Inspect a HuggingFace repo — returns detected .gguf/.mmproj files, quants and "
+        "capabilities WITHOUT registering anything. Use before model_register/model_pull."
+    ),
+    "model_store": (
+        "Show the operator's configured model-store directory ([models].store) and "
+        "candidate paths. Pulls always download into this store."
+    ),
+    "hardware_probe": "Live hardware probe — backends, memory, accelerators.",
+    "capability_list": "Capability overlay state — backends + selections.",
+    "provider_list": "List configured providers.",
+    "version_info": "hal0 version + runtime status.",
+    "upstream_list": "List all configured upstream LLM providers.",
+    "stack_list": "List every stack, with the active stack + drift status.",
+    "stack_status": "Get one stack's detail, active flag, and drift status.",
+    "profile_list": "List every profile in the catalog (seed + custom).",
+    "profile_status": "Get one profile's resolved detail (image, flags, backend, used-by).",
+    "profile_export": (
+        "Export a profile to a portable .hal0profile.json envelope (no secrets/host-paths)."
+    ),
+    "settings_get": "Get the current hal0 settings (pydantic schema validated).",
+    "settings_schema": "Get the JSON schema for hal0 settings validation.",
+    "settings_apply_plan": "Preview what settings changes would take effect.",
+    "bench_runs": "List benchmark runs (history + in-flight).",
+    "bench_run_status": "Get one benchmark run's detail + results.",
+    "bench_queue": "Show the benchmark queue (pending cells).",
+    "gpu_target_version": "Decode KFD's gfx_target_version to a gfxNNNN string (e.g. gfx1151).",
+    "npu_status": "Report XDNA NPU presence + driver binding (LXC-correct, no modinfo).",
+    "env_report": "Composite host snapshot — container, CPU, RAM, GPU, NPU, network, tooling.",
+    "model_store_probe": (
+        "Probe a model-store path: fstype, free/total bytes, writable, UMA-aware."
+    ),
+    # ── Autonomous write ────────────────────────────────────────────────
+    "model_swap": "Hot-swap the primary slot to a new model.",
+    "model_assign": "Assign a model to a slot's default (does not load the slot).",
+    "model_edit": "Update a model's metadata (name, capabilities, tags, mmproj, defaults).",
+    "model_scan": "Walk the configured model roots + store and register newly-found files.",
+    "model_pull_cancel": "Cancel an in-flight model pull job.",
+    "slot_load": "Load a slot (optionally assign a model first).",
+    "slot_unload": "Unload a running slot gracefully.",
+    "slot_edit": (
+        "Update one or more slot config fields (model, port, ctx-size, provider, hardware)."
+    ),
+    "settings_reload": "Ask the running hal0 daemon to reload configs (re-reads TOMLs).",
+    "memory_add": "Add an item to long-term memory.",
+    "memory_search": "Search long-term memory.",
+    "memory_list": "Page through long-term memory items.",
+    "memory_delete": (
+        "Delete one or more memory items (autonomous when len(ids)==1, gated otherwise)."
+    ),
+    # ── Gated write ─────────────────────────────────────────────────────
+    "model_pull": (
+        "Download a model from HuggingFace into the operator's configured model store "
+        "([models].store — check model_store first). Accepts "
+        "hf_repo/hf_filename/mmproj_filename body overrides for new models (gated)."
+    ),
+    "model_delete": "Delete a model from the local registry (gated).",
+    "model_register": "Register a model that's already on disk into the local registry (gated).",
+    "model_add": "Register an already-downloaded model file — capabilities auto-detected (gated).",
+    "model_store_set": (
+        "Set or change the model-store directory — future pulls download there; existing "
+        "files stay until model_store_migrate (gated)."
+    ),
+    "model_store_migrate": "Migrate model files from the current store to a new path (gated).",
+    "model_update": "Re-pull a model's HF file over its installed bytes (in place) (gated).",
+    "slot_create": "Create a new slot (gated).",
+    "slot_delete": "Delete a slot (gated).",
+    "slot_restart": "Restart a slot's systemd unit (gated).",
+    "capability_set": "Assign a capability child to a slot (gated).",
+    "config_write": "Update hal0.toml top-level settings (gated).",
+    "provider_credential_write": "Write provider credentials (gated; secrets never echoed back).",
+    "stack_create": "Create a stack from a slug + full stack body (gated).",
+    "stack_update": "Replace a custom stack's body wholesale (gated).",
+    "stack_apply": "Apply a stack — commit its slot config and converge runtime to match (gated).",
+    "stack_import": "Import a stack from a .hal0stack.json envelope (gated).",
+    "stack_export": "Serialize a stack into its portable .hal0stack.json envelope (gated).",
+    "stack_snapshot": "Build a stack from the current live slot + capability config (gated).",
+    "stack_delete": "Delete a custom stack from the catalog (gated).",
+    "profile_create": (
+        "Create a custom runtime profile (image, flags, device class) — e.g. authored "
+        "from a model card's requirements (gated)."
+    ),
+    "profile_update": "Update an existing custom profile (shallow merge) (gated).",
+    "profile_import": "Import a profile from a .hal0profile.json envelope (gated).",
+    "profile_delete": "Delete a custom profile from the catalog (gated).",
+    "bench_enqueue": "Enqueue benchmark cells (model x slot x settings) for the runner (gated).",
+    "bench_control": "Start/stop/pause the benchmark runner (gated).",
+    "logs_tail": "Tail journald for one systemd unit (gated).",
+    "slot_logs": "Tail one slot's journal output (gated).",
+}
+
+
 # ── Catalog consistency guard ────────────────────────────────────────────────
 #
 # The tool surface is spread over four tables (classification frozensets,
@@ -1067,6 +1180,12 @@ def _validate_catalog() -> None:
         problems.append(f"in _REST_MAP but never classified: {sorted(unclassified)}")
     if unannotated := catalog - set(_ANNOTATIONS):
         problems.append(f"classified but missing ToolAnnotations: {sorted(unannotated)}")
+    if set(TOOL_DESCRIPTIONS) != catalog:
+        problems.append(
+            "TOOL_DESCRIPTIONS out of sync with classification — "
+            f"missing: {sorted(catalog - set(TOOL_DESCRIPTIONS))}, "
+            f"extra: {sorted(set(TOOL_DESCRIPTIONS) - catalog)}"
+        )
 
     for tool, (_method, template) in _REST_MAP.items():
         placeholders = set(re.findall(r"{(\w+)}", template))
@@ -1117,16 +1236,10 @@ def build_server(
         return bearer_resolver()
 
     # Single tool factory — every tool in the catalog dispatches into
-    # the same ``dispatch`` core. We register each tool name explicitly
-    # so FastMCP's tool listing reports them as distinct entries (vs.
-    # a single catch-all tool that opaquely dispatches).
-    registered: set[str] = set()
-
+    # the same ``dispatch`` core. Registration iterates TOOL_DESCRIPTIONS
+    # verbatim, so FastMCP's tools/list is exactly the validated catalog
+    # (dict keys are unique; _validate_catalog pins keys == catalog).
     def _register(tool_name: str, description: str) -> None:
-        if tool_name in registered:
-            raise RuntimeError(f"hal0.mcp.admin: duplicate tool registration {tool_name!r}")
-        registered.add(tool_name)
-
         async def _tool(args: dict[str, Any] | None = None) -> dict[str, Any]:
             bearer, client_id = _resolve()
             return await dispatch(
@@ -1144,222 +1257,8 @@ def build_server(
         annotations = _ANNOTATIONS.get(tool_name)
         server.tool(name=tool_name, description=description, annotations=annotations)(_tool)
 
-    # ── Autonomous read ────────────────────────────────────────────────
-    # Slots
-    _register("slot_list", "List every slot known to hal0 (local + remote).")
-    _register("slot_status", "Get one slot's lifecycle state + metadata.")
-    _register("slot_metrics", "Get per-slot performance metrics (tok/s, latency, queue depth).")
-    _register("slot_capacity", "Get GPU/NPU memory capacity and per-slot allocation.")
-    # Models
-    _register("model_list", "Aggregate models from local registry + upstreams.")
-    _register("model_show", "Show a single model's full metadata (registry + upstream).")
-    _register("model_scan_preview", "Preview what a model scan would register (dry run).")
-    _register("model_catalogue", "List the curated catalogue of blessed models.")
-    _register("model_update_check", "Check which HF-backed models have updates available.")
-    _register("model_pulls_list", "List all pull jobs (in-flight + terminal).")
-    _register("model_pull_status", "Get one model's pull-job progress (state, %, speed, ETA).")
-    _register(
-        "model_inspect",
-        "Inspect a HuggingFace repo — returns detected .gguf/.mmproj files, quants and "
-        "capabilities WITHOUT registering anything. Use before model_register/model_pull.",
-    )
-    _register(
-        "model_store",
-        "Show the operator's configured model-store directory ([models].store) and "
-        "candidate paths. Pulls always download into this store.",
-    )
-    # System
-    _register("hardware_probe", "Live hardware probe — backends, memory, accelerators.")
-    _register("capability_list", "Capability overlay state — backends + selections.")
-    _register("provider_list", "List configured providers.")
-    _register("version_info", "hal0 version + runtime status.")
-    _register("upstream_list", "List all configured upstream LLM providers.")
-    # Stacks
-    _register("stack_list", "List every stack, with the active stack + drift status.")
-    _register("stack_status", "Get one stack's detail, active flag, and drift status.")
-    # Profiles
-    _register("profile_list", "List every profile in the catalog (seed + custom).")
-    _register(
-        "profile_status",
-        "Get one profile's resolved detail (image, flags, backend, used-by).",
-    )
-    # profile_export is a read-shaped POST — builds the envelope, no state change.
-    _register(
-        "profile_export",
-        "Export a profile to a portable .hal0profile.json envelope (no secrets/host-paths).",
-    )
-    # Settings
-    _register("settings_get", "Get the current hal0 settings (pydantic schema validated).")
-    _register("settings_schema", "Get the JSON schema for hal0 settings validation.")
-    _register("settings_apply_plan", "Preview what settings changes would take effect.")
-    # Benchmarks
-    _register("bench_runs", "List benchmark runs (history + in-flight).")
-    _register("bench_run_status", "Get one benchmark run's detail + results.")
-    _register("bench_queue", "Show the benchmark queue (pending cells).")
-    # Host-introspection probes (issue #237)
-    _register(
-        "gpu_target_version",
-        "Decode KFD's gfx_target_version to a gfxNNNN string (e.g. gfx1151).",
-    )
-    _register(
-        "npu_status",
-        "Report XDNA NPU presence + driver binding (LXC-correct, no modinfo).",
-    )
-    _register(
-        "env_report",
-        "Composite host snapshot — container, CPU, RAM, GPU, NPU, network, tooling.",
-    )
-    _register(
-        "model_store_probe",
-        "Probe a model-store path: fstype, free/total bytes, writable, UMA-aware.",
-    )
-    # ── Autonomous write ───────────────────────────────────────────────
-    # Model
-    _register("model_swap", "Hot-swap the primary slot to a new model.")
-    _register(
-        "model_assign",
-        "Assign a model to a slot's default (does not load the slot).",
-    )
-    _register(
-        "model_edit",
-        "Update a model's metadata (name, capabilities, tags, mmproj, defaults).",
-    )
-    _register(
-        "model_scan",
-        "Walk the configured model roots + store and register newly-found files.",
-    )
-    _register(
-        "model_pull_cancel",
-        "Cancel an in-flight model pull job.",
-    )
-    # Slot lifecycle
-    _register(
-        "slot_load",
-        "Load a slot (optionally assign a model first).",
-    )
-    _register(
-        "slot_unload",
-        "Unload a running slot gracefully.",
-    )
-    _register(
-        "slot_edit",
-        "Update one or more slot config fields (model, port, ctx-size, provider, hardware).",
-    )
-    # Settings
-    _register(
-        "settings_reload",
-        "Ask the running hal0 daemon to reload configs (re-reads TOMLs).",
-    )
-    # Memory
-    _register("memory_add", "Add an item to long-term memory.")
-    _register("memory_search", "Search long-term memory.")
-    _register("memory_list", "Page through long-term memory items.")
-    _register(
-        "memory_delete",
-        "Delete one or more memory items (autonomous when len(ids)==1, gated otherwise).",
-    )
-    # ── Gated write ────────────────────────────────────────────────────
-    # Model
-    _register(
-        "model_pull",
-        "Download a model from HuggingFace into the operator's configured "
-        "model store ([models].store — check model_store first). Accepts "
-        "hf_repo/hf_filename/mmproj_filename body overrides for new models "
-        "(gated).",
-    )
-    _register("model_delete", "Delete a model from the local registry (gated).")
-    _register(
-        "model_register",
-        "Register a model that's already on disk into the local registry (gated).",
-    )
-    _register(
-        "model_add",
-        "Register an already-downloaded model file — capabilities auto-detected (gated).",
-    )
-    _register(
-        "model_store_set",
-        "Set or change the model-store directory — future pulls download "
-        "there; existing files stay until model_store_migrate (gated).",
-    )
-    _register(
-        "model_store_migrate",
-        "Migrate model files from the current store to a new path (gated).",
-    )
-    _register(
-        "model_update",
-        "Re-pull a model's HF file over its installed bytes (in place) (gated).",
-    )
-    # Slot
-    _register("slot_create", "Create a new slot (gated).")
-    _register("slot_delete", "Delete a slot (gated).")
-    _register("slot_restart", "Restart a slot's systemd unit (gated).")
-    # Capability / config
-    _register("capability_set", "Assign a capability child to a slot (gated).")
-    _register("config_write", "Update hal0.toml top-level settings (gated).")
-    _register(
-        "provider_credential_write",
-        "Write provider credentials (gated; secrets never echoed back).",
-    )
-    # Stacks
-    _register(
-        "stack_create",
-        "Create a stack from a slug + full stack body (gated).",
-    )
-    _register(
-        "stack_update",
-        "Replace a custom stack's body wholesale (gated).",
-    )
-    _register(
-        "stack_apply",
-        "Apply a stack — commit its slot config and converge runtime to match (gated).",
-    )
-    _register("stack_import", "Import a stack from a .hal0stack.json envelope (gated).")
-    _register(
-        "stack_export",
-        "Serialize a stack into its portable .hal0stack.json envelope (gated).",
-    )
-    _register(
-        "stack_snapshot",
-        "Build a stack from the current live slot + capability config (gated).",
-    )
-    _register("stack_delete", "Delete a custom stack from the catalog (gated).")
-    # Profiles
-    _register(
-        "profile_create",
-        "Create a custom runtime profile (image, flags, device class) — e.g. "
-        "authored from a model card's requirements (gated).",
-    )
-    _register(
-        "profile_update",
-        "Update an existing custom profile (shallow merge) (gated).",
-    )
-    _register(
-        "profile_import",
-        "Import a profile from a .hal0profile.json envelope (gated).",
-    )
-    _register("profile_delete", "Delete a custom profile from the catalog (gated).")
-    # Benchmarks — runs load models onto slots (disruptive)
-    _register(
-        "bench_enqueue",
-        "Enqueue benchmark cells (model x slot x settings) for the runner (gated).",
-    )
-    _register(
-        "bench_control",
-        "Start/stop/pause the benchmark runner (gated).",
-    )
-    # Journald surfaces gated for security (MED-1)
-    _register("logs_tail", "Tail journald for one systemd unit (gated).")
-    _register("slot_logs", "Tail one slot's journal output (gated).")
-
-    # Every classified tool must be discoverable via tools/list and vice
-    # versa — a registration gap otherwise 404s at call time only.
-    catalog = AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS
-    if registered != catalog:
-        raise RuntimeError(
-            "hal0.mcp.admin: registration drift — "
-            f"unregistered: {sorted(catalog - registered)}, "
-            f"unclassified: {sorted(registered - catalog)}"
-        )
+    for _name, _description in TOOL_DESCRIPTIONS.items():
+        _register(_name, _description)
 
     return server
 
@@ -1368,6 +1267,7 @@ __all__ = [
     "AUTONOMOUS_READ_TOOLS",
     "AUTONOMOUS_WRITE_TOOLS",
     "GATED_TOOLS",
+    "TOOL_DESCRIPTIONS",
     "_ANNOTATIONS",
     "build_server",
     "dispatch",

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -40,19 +40,43 @@ Tool catalog (ADR-0004 §4)
 
 Autonomous read::
 
-    slot_list, slot_status, model_list, hardware_probe, logs_tail,
-    capability_list, provider_list, version_info
+    slot_list, slot_status, slot_metrics, slot_capacity,
+    model_list, model_show, model_scan_preview,
+    model_catalogue, model_update_check, model_pulls_list,
+    model_pull_status, model_inspect, model_store,
+    hardware_probe, capability_list, provider_list, version_info,
+    stack_list, stack_status, profile_list, profile_status,
+    profile_export, upstream_list,
+    settings_get, settings_schema, settings_apply_plan,
+    bench_runs, bench_run_status, bench_queue,
+    # Host-introspection probes (issue #237)
+    gpu_target_version, npu_status, env_report, model_store_probe
 
 Autonomous write::
 
-    model_swap, memory_add, memory_search, memory_list,
+    model_swap, model_assign, model_edit, model_scan,
+    model_pull_cancel,
+    slot_load, slot_unload, slot_edit,
+    settings_reload,
+    memory_add, memory_search, memory_list,
     memory_delete (when len(ids) == 1)
 
 Gated (destructive — enqueued for owner approval)::
 
-    model_pull, model_delete, slot_create, slot_delete, slot_restart,
+    model_pull, model_delete, model_register, model_add,
+    model_store_set, model_store_migrate, model_update,
+    slot_create, slot_delete, slot_restart,
     capability_set, config_write, provider_credential_write,
-    memory_delete (when len(ids) > 1)
+    memory_delete (when len(ids) > 1),
+    # Profile CRUD (create/update/import/delete)
+    profile_create, profile_update, profile_import, profile_delete,
+    # Stack CRUD (create/update/apply/import/export/snapshot/delete)
+    stack_create, stack_update, stack_apply, stack_import,
+    stack_export, stack_snapshot, stack_delete,
+    # Benchmarks — enqueue/control load models onto slots (disruptive)
+    bench_enqueue, bench_control,
+    # Journald surfaces gated for security (MED-1)
+    logs_tail, slot_logs
 
 The memory_* tools are delegates that forward into
 :mod:`hal0.mcp.memory` so we have a single tool surface per server
@@ -153,42 +177,51 @@ def _redact_log_line(line: str) -> str:
 # We wrap the list in a top-level object here — mirroring model_list's
 # ``{<key>: [...], "count": N}`` style — keeping the per-item dicts the
 # REST layer produced untouched. Maps tool name → the list's container
-# key in the wrapped object.
+# key in the wrapped object; every other tool falls back to ``items``
+# so a newly-mapped bare-list route can never crash the result model.
 _LIST_TOOL_WRAP_KEY: dict[str, str] = {
     "slot_list": "slots",
     "provider_list": "providers",
+    "upstream_list": "upstreams",
 }
 
 
 def _wrap_list_payload(tool: str, payload: Any) -> Any:
     """Wrap a bare-list REST response in a top-level dict for ``tool``.
 
-    ``slot_list`` / ``provider_list`` hit REST routes that return a bare
-    JSON array; the MCP result model requires a top-level object. We wrap
-    the list as ``{<key>: [...], "count": len(list)}`` mirroring
-    ``model_list``'s shape. Non-list payloads (e.g. the ``_call_rest``
-    error envelope, which is already a dict) round-trip unchanged so we
-    never mask a transport error.
+    Some REST routes return a bare JSON array; the MCP result model
+    requires a top-level object. We wrap the list as
+    ``{<key>: [...], "count": len(list)}`` mirroring ``model_list``'s
+    shape, with ``items`` as the generic fallback key. Non-list payloads
+    (e.g. the ``_call_rest`` error envelope, which is already a dict)
+    round-trip unchanged so we never mask a transport error.
     """
-    key = _LIST_TOOL_WRAP_KEY.get(tool)
-    if key is None or not isinstance(payload, list):
+    if not isinstance(payload, list):
         return payload
+    key = _LIST_TOOL_WRAP_KEY.get(tool, "items")
     return {key: payload, "count": len(payload)}
 
 
 def _redact_logs_payload(payload: Any) -> Any:
-    """Walk the GET /api/logs response and redact every line in ``lines``.
+    """Redact secrets from a journald-shaped response before it ships.
 
-    Non-dict payloads (or shapes missing ``lines``) round-trip unchanged
-    so a transport error or alternative-shape envelope still reaches the
-    agent — we never swallow content, only mask known secret tokens.
+    Covers both shapes the log surfaces return: ``logs_tail``'s
+    ``{"lines": [...]}`` list and ``slot_logs``'s ``{"logs": "..."}``
+    single string. Non-dict payloads (or shapes missing both keys)
+    round-trip unchanged so a transport error or alternative-shape
+    envelope still reaches the agent — we never swallow content, only
+    mask known secret tokens.
     """
     if not isinstance(payload, dict):
         return payload
     lines = payload.get("lines")
-    if not isinstance(lines, list):
-        return payload
-    payload["lines"] = [_redact_log_line(line) if isinstance(line, str) else line for line in lines]
+    if isinstance(lines, list):
+        payload["lines"] = [
+            _redact_log_line(line) if isinstance(line, str) else line for line in lines
+        ]
+    logs = payload.get("logs")
+    if isinstance(logs, str):
+        payload["logs"] = _redact_log_line(logs)
     return payload
 
 
@@ -216,30 +249,54 @@ log = structlog.get_logger(__name__)
 # Read-only tools — execute immediately, no approval prompt.
 AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
     {
+        # Slots
         "slot_list",
         "slot_status",
+        "slot_metrics",
+        "slot_capacity",
+        # Models. model_scan is NOT here — walking the roots registers new
+        # files (a mutation); model_scan_preview is the read-shaped dry run.
+        # model_inspect is a read-shaped POST: it fetches HF repo metadata
+        # and returns detection rows without registering anything.
         "model_list",
+        "model_show",
+        "model_scan_preview",
+        "model_catalogue",
+        "model_update_check",
+        "model_pulls_list",
+        "model_pull_status",
+        "model_inspect",
+        "model_store",
+        # Hardware / system. logs_tail / slot_logs are intentionally NOT
+        # here — journald output can carry secrets, so they stay in
+        # GATED_TOOLS until the logs.py redactor covers every key shape
+        # (security review MED-1).
         "hardware_probe",
-        # logs_tail is intentionally NOT here — moved to GATED_TOOLS
-        # until the ADR-0004 §7 redaction lands in logs.py. Per
-        # security review MED-1: an agent dumping raw journald is a
-        # potential exfiltration vector for whatever secrets the log
-        # redactor doesn't yet cover. Gating now is defensive-cheap;
-        # demote back to autonomous-read once the redaction is in.
         "capability_list",
         "provider_list",
         "version_info",
+        "upstream_list",
+        # Stacks
         "stack_list",
         "stack_status",
+        # Profiles
         "profile_list",
         "profile_status",
         # profile_export is a POST but performs no state change — it
         # builds a portable envelope from existing catalog data, so it
         # classifies read-shaped (autonomous) like the other reads.
         "profile_export",
+        # Settings
+        "settings_get",
+        "settings_schema",
+        "settings_apply_plan",
+        # Benchmarks — run history + queue state (reads; enqueue/control
+        # are gated because a run loads models onto slots).
+        "bench_runs",
+        "bench_run_status",
+        "bench_queue",
         # Host-introspection probes (issue #237). Pure-read against
         # /sys/, /proc/, and lsmod — no REST round-trip, no mutation.
-        # Hermes-Agent bootstrap consumes these in its env_probe phase.
         "gpu_target_version",
         "npu_status",
         "env_report",
@@ -251,7 +308,21 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
 # (reversible, scoped, low blast radius). Per ADR-0004 §4.
 AUTONOMOUS_WRITE_TOOLS: frozenset[str] = frozenset(
     {
+        # Model. model_scan only ADDS registry entries for files already
+        # on disk (reversible via model_delete); model_pull_cancel stops
+        # an in-flight download the agent (or operator) started.
         "model_swap",
+        "model_assign",
+        "model_edit",
+        "model_scan",
+        "model_pull_cancel",
+        # Slot lifecycle
+        "slot_load",
+        "slot_unload",
+        "slot_edit",
+        # Settings
+        "settings_reload",
+        # Memory
         "memory_add",
         "memory_search",
         "memory_list",
@@ -264,29 +335,48 @@ AUTONOMOUS_WRITE_TOOLS: frozenset[str] = frozenset(
 # Tools that always require approval.
 GATED_TOOLS: frozenset[str] = frozenset(
     {
+        # Model
         "model_pull",
         "model_delete",
+        "model_register",
+        "model_add",
+        "model_store_set",
+        "model_store_migrate",
+        "model_update",
+        # Slot
         "slot_create",
         "slot_delete",
         "slot_restart",
+        # Capability / config
         "capability_set",
         "config_write",
         "provider_credential_write",
         # Stacks: applying/importing reconfigures the whole inference surface
         # (loads/swaps/unloads slots) and deleting drops a saved bundle —
         # owner-approval gated, mirroring slot_create/capability_set.
+        "stack_create",
+        "stack_update",
         "stack_apply",
         "stack_import",
+        "stack_export",
+        "stack_snapshot",
         "stack_delete",
         # Profiles: importing creates a new catalog entry and deleting
         # drops a saved profile — owner-approval gated, mirroring
         # stack_import/stack_delete.
+        "profile_create",
+        "profile_update",
         "profile_import",
         "profile_delete",
-        # logs_tail is gated until the redactor in logs.py covers
-        # Bearer + X-API-Key + provider keys (sk-/hf-/etc.) — see
+        # Benchmarks: enqueue/control load models onto slots and can evict
+        # what's currently serving — disruptive, so owner-approval gated.
+        "bench_enqueue",
+        "bench_control",
+        # logs_tail / slot_logs are gated until the redactor in logs.py
+        # covers Bearer + X-API-Key + provider keys (sk-/hf-/etc.) — see
         # docs/internal/phase-8-pending/mcp-backend.md §2.
         "logs_tail",
+        "slot_logs",
         # memory_delete with len(ids) > 1 routes here at call time.
     }
 )
@@ -317,39 +407,85 @@ GATED_TOOLS: frozenset[str] = frozenset(
 #   version_info → /api/version         /api/status                   name diff
 
 _REST_MAP: dict[str, tuple[str, str]] = {
-    # Read
+    # ── Slots ──────────────────────────────────────────────────────────
     "slot_list": ("GET", "/api/slots"),
     "slot_status": ("GET", "/api/slots/{name}"),
+    "slot_metrics": ("GET", "/api/slots/metrics"),
+    "slot_capacity": ("GET", "/api/slots/capacity"),
+    "slot_load": ("POST", "/api/slots/{name}/load"),
+    "slot_unload": ("POST", "/api/slots/{name}/unload"),
+    "slot_edit": ("PUT", "/api/slots/{name}/config"),
+    "slot_logs": ("GET", "/api/slots/{name}/logs"),
+    # ── Models ─────────────────────────────────────────────────────────
     "model_list": ("GET", "/api/models"),
+    "model_show": ("GET", "/api/models/{model_id}"),
+    "model_scan": ("POST", "/api/models/scan"),
+    "model_scan_preview": ("POST", "/api/models/scan/preview"),
+    "model_catalogue": ("GET", "/api/models/catalogue"),
+    "model_update_check": ("GET", "/api/models/updates/check"),
+    "model_pulls_list": ("GET", "/api/models/pulls"),
+    "model_pull_status": ("GET", "/api/models/{model_id}/pull/status"),
+    # model_inspect is a read-shaped POST — fetches HF repo metadata and
+    # returns detection rows without touching the registry.
+    "model_inspect": ("POST", "/api/models/inspect"),
+    "model_store": ("GET", "/api/settings/models/store"),
+    # ── Profiles ───────────────────────────────────────────────────────
+    "profile_list": ("GET", "/api/profiles"),
+    "profile_status": ("GET", "/api/profiles/{name}"),
+    "profile_export": ("POST", "/api/profiles/{name}/export"),
+    # ── Stacks ─────────────────────────────────────────────────────────
+    "stack_list": ("GET", "/api/stacks"),
+    "stack_status": ("GET", "/api/stacks/{slug}"),
+    # ── Settings ───────────────────────────────────────────────────────
+    "settings_get": ("GET", "/api/settings"),
+    "settings_schema": ("GET", "/api/settings/schema"),
+    "settings_apply_plan": ("GET", "/api/settings/apply-plan"),
+    "settings_reload": ("POST", "/api/settings/reload"),
+    # ── Benchmarks ─────────────────────────────────────────────────────
+    "bench_runs": ("GET", "/api/benchmarks/runs"),
+    "bench_run_status": ("GET", "/api/benchmarks/runs/{run_id}"),
+    "bench_queue": ("GET", "/api/benchmarks/queue"),
+    "bench_enqueue": ("POST", "/api/benchmarks/queue"),
+    "bench_control": ("POST", "/api/benchmarks/control"),
+    # ── System ─────────────────────────────────────────────────────────
+    "version_info": ("GET", "/api/status"),
+    "upstream_list": ("GET", "/api/upstreams"),
     "hardware_probe": ("GET", "/api/stats/hardware"),
     "logs_tail": ("GET", "/api/logs"),
     "capability_list": ("GET", "/api/capabilities"),
     "provider_list": ("GET", "/api/providers"),
-    "version_info": ("GET", "/api/status"),
-    "stack_list": ("GET", "/api/stacks"),
-    "stack_status": ("GET", "/api/stacks/{slug}"),
-    "profile_list": ("GET", "/api/profiles"),
-    "profile_status": ("GET", "/api/profiles/{name}"),
-    # profile_export is a read-shaped POST — builds the envelope, no state change.
-    "profile_export": ("POST", "/api/profiles/{name}/export"),
-    # Autonomous write
+    # ── Autonomous write ───────────────────────────────────────────────
     "model_swap": ("POST", "/api/slots/{name}/swap"),
-    # Gated write
+    "model_assign": ("PUT", "/api/slots/{name}/config"),
+    # model_edit is the metadata PUT (name/caps/tags/mmproj enrichment);
+    # model_update (gated, below) is the in-place HF re-pull POST — the
+    # two routes are easy to cross, keep them adjacent to the comment.
+    "model_edit": ("PUT", "/api/models/{model_id}"),
+    "model_pull_cancel": ("POST", "/api/models/{model_id}/pull/cancel"),
+    # ── Gated write ────────────────────────────────────────────────────
     "model_pull": ("POST", "/api/models/{model_id}/pull"),
     "model_delete": ("DELETE", "/api/models/{model_id}"),
+    "model_register": ("POST", "/api/models"),
+    "model_add": ("POST", "/api/models/add-from-path"),
+    "model_store_set": ("POST", "/api/settings/models/store"),
+    "model_store_migrate": ("POST", "/api/settings/models/store/migrate"),
+    "model_update": ("POST", "/api/models/{model_id}/update"),
     "slot_create": ("POST", "/api/slots"),
     "slot_delete": ("DELETE", "/api/slots/{name}"),
     "slot_restart": ("POST", "/api/slots/{name}/restart"),
     "capability_set": ("POST", "/api/capabilities/{slot}/{child}"),
     "config_write": ("PUT", "/api/settings"),
+    "stack_create": ("POST", "/api/stacks"),
+    "stack_update": ("PUT", "/api/stacks/{slug}"),
     "stack_apply": ("POST", "/api/stacks/{slug}/apply"),
     "stack_import": ("POST", "/api/stacks/import"),
+    "stack_export": ("POST", "/api/stacks/{slug}/export"),
+    "stack_snapshot": ("POST", "/api/stacks/snapshot"),
     "stack_delete": ("DELETE", "/api/stacks/{slug}"),
+    "profile_create": ("POST", "/api/profiles"),
+    "profile_update": ("PUT", "/api/profiles/{name}"),
     "profile_import": ("POST", "/api/profiles/import"),
     "profile_delete": ("DELETE", "/api/profiles/{name}"),
-    # No live route yet — Memory-engine / Provider team must land the
-    # endpoint. We register the tool anyway so the catalog matches the
-    # ADR; calls land in a 404 surface until the route exists.
     "provider_credential_write": ("POST", "/api/providers/{name}/credentials"),
 }
 
@@ -357,20 +493,40 @@ _REST_MAP: dict[str, tuple[str, str]] = {
 # Path-arg keys per tool — pulled out of ``args`` for URL substitution;
 # the remainder become query string (GET) or JSON body (POST/PUT/DELETE).
 _PATH_ARGS: dict[str, tuple[str, ...]] = {
+    # Slots
     "slot_status": ("name",),
-    "model_swap": ("name",),
-    "model_pull": ("model_id",),
-    "model_delete": ("model_id",),
-    "slot_delete": ("name",),
+    "slot_load": ("name",),
+    "slot_unload": ("name",),
+    "slot_edit": ("name",),
+    "slot_logs": ("name",),
     "slot_restart": ("name",),
-    "capability_set": ("slot", "child"),
-    "provider_credential_write": ("name",),
-    "stack_status": ("slug",),
-    "stack_apply": ("slug",),
-    "stack_delete": ("slug",),
+    "slot_delete": ("name",),
+    "model_swap": ("name",),
+    "model_assign": ("name",),
+    # Models
+    "model_show": ("model_id",),
+    "model_pull": ("model_id",),
+    "model_pull_status": ("model_id",),
+    "model_pull_cancel": ("model_id",),
+    "model_delete": ("model_id",),
+    "model_edit": ("model_id",),
+    "model_update": ("model_id",),
+    # Benchmarks
+    "bench_run_status": ("run_id",),
+    # Profiles
     "profile_status": ("name",),
     "profile_export": ("name",),
+    "profile_update": ("name",),
     "profile_delete": ("name",),
+    # Stacks
+    "stack_status": ("slug",),
+    "stack_apply": ("slug",),
+    "stack_export": ("slug",),
+    "stack_update": ("slug",),
+    "stack_delete": ("slug",),
+    # Misc
+    "capability_set": ("slot", "child"),
+    "provider_credential_write": ("name",),
 }
 
 
@@ -600,13 +756,14 @@ async def _execute_tool(
         url=url,
         payload=payload,
     )
-    # Redact every Bearer / HAL0_BEARER_TOKEN occurrence before the
-    # logs_tail response leaves this process. The /api/logs route
-    # itself stays unredacted — REST consumers on the same host already
-    # have credential access; the MCP transport is the spot where a
-    # narrowly-scoped agent can otherwise siphon tokens out (security
-    # review MED-1).
-    if tool == "logs_tail":
+    # Redact every Bearer / HAL0_BEARER_TOKEN occurrence before a
+    # journald-backed response leaves this process. The REST routes
+    # themselves stay unredacted — REST consumers on the same host
+    # already have credential access; the MCP transport is the spot
+    # where a narrowly-scoped agent can otherwise siphon tokens out
+    # (security review MED-1). slot_logs proxies the same journald
+    # surface per-unit, so it gets the same treatment.
+    if tool in ("logs_tail", "slot_logs"):
         result = _redact_logs_payload(result)
     # Wrap bare-list REST responses (slot_list / provider_list) into a
     # top-level dict so the FastMCP result model validates. No-op for
@@ -633,20 +790,57 @@ async def _execute_tool(
 # the right approval-prompt language without having to read ADR-0004.
 
 _ANNOTATIONS: dict[str, ToolAnnotations] = {
-    # Autonomous read — pure reads against the local REST surface.
+    # ── Autonomous read — pure reads against the local REST surface. ─────
+    # Slots
     "slot_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "slot_status": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "slot_metrics": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_capacity": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Models
     "model_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "model_show": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_scan_preview": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_catalogue": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_update_check": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_pulls_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_pull_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Read-shaped POST that fetches HF repo metadata — open-world.
+    "model_inspect": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True
+    ),
+    "model_store": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # System. logs_tail / slot_logs read-only but server-gated (MED-1).
     "hardware_probe": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "logs_tail": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_logs": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "capability_list": ToolAnnotations(
@@ -658,21 +852,44 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "version_info": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    "upstream_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Stacks
     "stack_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "stack_status": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    # Profiles
     "profile_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "profile_status": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
-    # profile_export is a POST but builds an envelope from existing data —
-    # no state change, so it carries the read-shaped annotation.
     "profile_export": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Settings
+    "settings_get": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "settings_schema": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "settings_apply_plan": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Benchmarks — run history + queue reads.
+    "bench_runs": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "bench_run_status": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "bench_queue": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     # Host-introspection probes — pure sysfs/procfs reads.
@@ -695,29 +912,72 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "memory_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
-    # Mutating, reversible, idempotent end-state writes.
+    # ── Autonomous write — mutating, reversible, idempotent writes. ────
     "model_swap": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_assign": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_edit": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # Additive registration of files already on disk; re-scan converges.
+    "model_scan": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_pull_cancel": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_load": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_unload": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "slot_edit": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "settings_reload": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "capability_set": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
-    # Apply converges to a declared end-state (idempotent); import creates a
-    # new catalog entry (non-idempotent — re-import conflicts on slug).
+    "config_write": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "provider_credential_write": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # ── Gated write — mutating, non-idempotent or destructive. ────────
+    # Apply converges to a declared end-state (idempotent); import/create
+    # are non-idempotent (re-import/create conflicts on slug/name).
     "stack_apply": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "stack_import": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
     ),
-    # Import creates a new catalog entry (non-idempotent — re-import conflicts on name).
+    "stack_create": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "stack_update": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "stack_export": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "stack_snapshot": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
     "profile_import": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
     ),
-    "config_write": ToolAnnotations(
-        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    "profile_create": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
     ),
-    "provider_credential_write": ToolAnnotations(
+    "profile_update": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     # Mutating, reversible, non-idempotent (each call has additional effect).
@@ -733,6 +993,30 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     # Reaches outside hal0 (HuggingFace / upstream registries).
     "model_pull": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+    ),
+    "model_register": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "model_add": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "model_store_set": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "model_store_migrate": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    # In-place HF re-pull — hits the open network like model_pull.
+    "model_update": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True
+    ),
+    # Benchmarks — enqueue adds a run (non-idempotent); control start/stop
+    # converges the runner to the requested state.
+    "bench_enqueue": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "bench_control": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     # Destructive — re-delete is a no-op so idempotentHint stays true.
     "model_delete": ToolAnnotations(
@@ -751,6 +1035,53 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
         readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
     ),
 }
+
+
+# ── Catalog consistency guard ────────────────────────────────────────────────
+#
+# The tool surface is spread over four tables (classification frozensets,
+# _REST_MAP, _PATH_ARGS, _ANNOTATIONS) plus the _register calls in
+# build_server. A tool landing in some tables but not others fails at
+# call time with an opaque envelope — validate coherence at import so
+# drift surfaces in CI, not in an agent's chat.
+
+
+def _validate_catalog() -> None:
+    catalog = AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS
+    problems: list[str] = []
+
+    overlaps = (
+        (AUTONOMOUS_READ_TOOLS & AUTONOMOUS_WRITE_TOOLS)
+        | (AUTONOMOUS_READ_TOOLS & GATED_TOOLS)
+        | (AUTONOMOUS_WRITE_TOOLS & GATED_TOOLS)
+    )
+    if overlaps:
+        problems.append(f"tools in more than one classification: {sorted(overlaps)}")
+
+    # memory_* dispatch in-process (or report unconfigured); probes never
+    # touch REST. Everything else must route somewhere.
+    routed = {t for t in catalog if not t.startswith("memory_")} - PROBE_TOOLS
+    if unmapped := routed - set(_REST_MAP):
+        problems.append(f"classified but missing from _REST_MAP: {sorted(unmapped)}")
+    if unclassified := set(_REST_MAP) - catalog:
+        problems.append(f"in _REST_MAP but never classified: {sorted(unclassified)}")
+    if unannotated := catalog - set(_ANNOTATIONS):
+        problems.append(f"classified but missing ToolAnnotations: {sorted(unannotated)}")
+
+    for tool, (_method, template) in _REST_MAP.items():
+        placeholders = set(re.findall(r"{(\w+)}", template))
+        declared = set(_PATH_ARGS.get(tool, ()))
+        if placeholders != declared:
+            problems.append(
+                f"{tool}: _PATH_ARGS {sorted(declared)} != template placeholders "
+                f"{sorted(placeholders)}"
+            )
+
+    if problems:
+        raise RuntimeError("hal0.mcp.admin catalog drift: " + " | ".join(problems))
+
+
+_validate_catalog()
 
 
 # ── FastMCP server builder ───────────────────────────────────────────────────
@@ -789,7 +1120,13 @@ def build_server(
     # the same ``dispatch`` core. We register each tool name explicitly
     # so FastMCP's tool listing reports them as distinct entries (vs.
     # a single catch-all tool that opaquely dispatches).
+    registered: set[str] = set()
+
     def _register(tool_name: str, description: str) -> None:
+        if tool_name in registered:
+            raise RuntimeError(f"hal0.mcp.admin: duplicate tool registration {tool_name!r}")
+        registered.add(tool_name)
+
         async def _tool(args: dict[str, Any] | None = None) -> dict[str, Any]:
             bearer, client_id = _resolve()
             return await dispatch(
@@ -807,17 +1144,40 @@ def build_server(
         annotations = _ANNOTATIONS.get(tool_name)
         server.tool(name=tool_name, description=description, annotations=annotations)(_tool)
 
-    # Autonomous read
+    # ── Autonomous read ────────────────────────────────────────────────
+    # Slots
     _register("slot_list", "List every slot known to hal0 (local + remote).")
     _register("slot_status", "Get one slot's lifecycle state + metadata.")
+    _register("slot_metrics", "Get per-slot performance metrics (tok/s, latency, queue depth).")
+    _register("slot_capacity", "Get GPU/NPU memory capacity and per-slot allocation.")
+    # Models
     _register("model_list", "Aggregate models from local registry + upstreams.")
+    _register("model_show", "Show a single model's full metadata (registry + upstream).")
+    _register("model_scan_preview", "Preview what a model scan would register (dry run).")
+    _register("model_catalogue", "List the curated catalogue of blessed models.")
+    _register("model_update_check", "Check which HF-backed models have updates available.")
+    _register("model_pulls_list", "List all pull jobs (in-flight + terminal).")
+    _register("model_pull_status", "Get one model's pull-job progress (state, %, speed, ETA).")
+    _register(
+        "model_inspect",
+        "Inspect a HuggingFace repo — returns detected .gguf/.mmproj files, quants and "
+        "capabilities WITHOUT registering anything. Use before model_register/model_pull.",
+    )
+    _register(
+        "model_store",
+        "Show the operator's configured model-store directory ([models].store) and "
+        "candidate paths. Pulls always download into this store.",
+    )
+    # System
     _register("hardware_probe", "Live hardware probe — backends, memory, accelerators.")
-    _register("logs_tail", "Tail journald for one systemd unit.")
     _register("capability_list", "Capability overlay state — backends + selections.")
     _register("provider_list", "List configured providers.")
     _register("version_info", "hal0 version + runtime status.")
+    _register("upstream_list", "List all configured upstream LLM providers.")
+    # Stacks
     _register("stack_list", "List every stack, with the active stack + drift status.")
     _register("stack_status", "Get one stack's detail, active flag, and drift status.")
+    # Profiles
     _register("profile_list", "List every profile in the catalog (seed + custom).")
     _register(
         "profile_status",
@@ -828,6 +1188,14 @@ def build_server(
         "profile_export",
         "Export a profile to a portable .hal0profile.json envelope (no secrets/host-paths).",
     )
+    # Settings
+    _register("settings_get", "Get the current hal0 settings (pydantic schema validated).")
+    _register("settings_schema", "Get the JSON schema for hal0 settings validation.")
+    _register("settings_apply_plan", "Preview what settings changes would take effect.")
+    # Benchmarks
+    _register("bench_runs", "List benchmark runs (history + in-flight).")
+    _register("bench_run_status", "Get one benchmark run's detail + results.")
+    _register("bench_queue", "Show the benchmark queue (pending cells).")
     # Host-introspection probes (issue #237)
     _register(
         "gpu_target_version",
@@ -845,8 +1213,44 @@ def build_server(
         "model_store_probe",
         "Probe a model-store path: fstype, free/total bytes, writable, UMA-aware.",
     )
-    # Autonomous write
+    # ── Autonomous write ───────────────────────────────────────────────
+    # Model
     _register("model_swap", "Hot-swap the primary slot to a new model.")
+    _register(
+        "model_assign",
+        "Assign a model to a slot's default (does not load the slot).",
+    )
+    _register(
+        "model_edit",
+        "Update a model's metadata (name, capabilities, tags, mmproj, defaults).",
+    )
+    _register(
+        "model_scan",
+        "Walk the configured model roots + store and register newly-found files.",
+    )
+    _register(
+        "model_pull_cancel",
+        "Cancel an in-flight model pull job.",
+    )
+    # Slot lifecycle
+    _register(
+        "slot_load",
+        "Load a slot (optionally assign a model first).",
+    )
+    _register(
+        "slot_unload",
+        "Unload a running slot gracefully.",
+    )
+    _register(
+        "slot_edit",
+        "Update one or more slot config fields (model, port, ctx-size, provider, hardware).",
+    )
+    # Settings
+    _register(
+        "settings_reload",
+        "Ask the running hal0 daemon to reload configs (re-reads TOMLs).",
+    )
+    # Memory
     _register("memory_add", "Add an item to long-term memory.")
     _register("memory_search", "Search long-term memory.")
     _register("memory_list", "Page through long-term memory items.")
@@ -854,29 +1258,108 @@ def build_server(
         "memory_delete",
         "Delete one or more memory items (autonomous when len(ids)==1, gated otherwise).",
     )
-    # Gated
-    _register("model_pull", "Pull a model into the local registry (gated).")
+    # ── Gated write ────────────────────────────────────────────────────
+    # Model
+    _register(
+        "model_pull",
+        "Download a model from HuggingFace into the operator's configured "
+        "model store ([models].store — check model_store first). Accepts "
+        "hf_repo/hf_filename/mmproj_filename body overrides for new models "
+        "(gated).",
+    )
     _register("model_delete", "Delete a model from the local registry (gated).")
+    _register(
+        "model_register",
+        "Register a model that's already on disk into the local registry (gated).",
+    )
+    _register(
+        "model_add",
+        "Register an already-downloaded model file — capabilities auto-detected (gated).",
+    )
+    _register(
+        "model_store_set",
+        "Set or change the model-store directory — future pulls download "
+        "there; existing files stay until model_store_migrate (gated).",
+    )
+    _register(
+        "model_store_migrate",
+        "Migrate model files from the current store to a new path (gated).",
+    )
+    _register(
+        "model_update",
+        "Re-pull a model's HF file over its installed bytes (in place) (gated).",
+    )
+    # Slot
     _register("slot_create", "Create a new slot (gated).")
     _register("slot_delete", "Delete a slot (gated).")
     _register("slot_restart", "Restart a slot's systemd unit (gated).")
+    # Capability / config
     _register("capability_set", "Assign a capability child to a slot (gated).")
     _register("config_write", "Update hal0.toml top-level settings (gated).")
+    _register(
+        "provider_credential_write",
+        "Write provider credentials (gated; secrets never echoed back).",
+    )
+    # Stacks
+    _register(
+        "stack_create",
+        "Create a stack from a slug + full stack body (gated).",
+    )
+    _register(
+        "stack_update",
+        "Replace a custom stack's body wholesale (gated).",
+    )
     _register(
         "stack_apply",
         "Apply a stack — commit its slot config and converge runtime to match (gated).",
     )
     _register("stack_import", "Import a stack from a .hal0stack.json envelope (gated).")
+    _register(
+        "stack_export",
+        "Serialize a stack into its portable .hal0stack.json envelope (gated).",
+    )
+    _register(
+        "stack_snapshot",
+        "Build a stack from the current live slot + capability config (gated).",
+    )
     _register("stack_delete", "Delete a custom stack from the catalog (gated).")
+    # Profiles
+    _register(
+        "profile_create",
+        "Create a custom runtime profile (image, flags, device class) — e.g. "
+        "authored from a model card's requirements (gated).",
+    )
+    _register(
+        "profile_update",
+        "Update an existing custom profile (shallow merge) (gated).",
+    )
     _register(
         "profile_import",
         "Import a profile from a .hal0profile.json envelope (gated).",
     )
     _register("profile_delete", "Delete a custom profile from the catalog (gated).")
+    # Benchmarks — runs load models onto slots (disruptive)
     _register(
-        "provider_credential_write",
-        "Write provider credentials (gated; secrets never echoed back).",
+        "bench_enqueue",
+        "Enqueue benchmark cells (model x slot x settings) for the runner (gated).",
     )
+    _register(
+        "bench_control",
+        "Start/stop/pause the benchmark runner (gated).",
+    )
+    # Journald surfaces gated for security (MED-1)
+    _register("logs_tail", "Tail journald for one systemd unit (gated).")
+    _register("slot_logs", "Tail one slot's journal output (gated).")
+
+    # Every classified tool must be discoverable via tools/list and vice
+    # versa — a registration gap otherwise 404s at call time only.
+    catalog = AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS
+    if registered != catalog:
+        raise RuntimeError(
+            "hal0.mcp.admin: registration drift — "
+            f"unregistered: {sorted(catalog - registered)}, "
+            f"unclassified: {sorted(registered - catalog)}"
+        )
 
     return server
 

--- a/tests/board/test_board_chat_admin_tools.py
+++ b/tests/board/test_board_chat_admin_tools.py
@@ -1,0 +1,118 @@
+"""The sidebar Brain's admin-MCP tool surface (board_chat ↔ hal0.mcp.admin).
+
+The slide-out chat surfaces the hal0-admin catalog as OpenAI tool schemas
+and routes those calls through the same ``admin.dispatch`` core as the
+/mcp/admin mount — same classification, same ApprovalQueue, same audit.
+These tests pin the wiring: catalog surfaced minus exclusions, locals win
+on collision, gated tools come back ``pending_approval`` from the chat
+path, and the routing degrades to a typed error without app wiring.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hal0.api.routes import board_chat as bc
+from hal0.mcp import admin
+from hal0.mcp.approval_queue import ApprovalQueue
+
+
+def _fake_request(**state: Any) -> Any:
+    """A Request stand-in exposing exactly what the admin path reads."""
+    defaults: dict[str, Any] = {
+        "approval_queue": None,
+        "memory_dispatcher": None,
+        "self_api_base_url": "http://testserver",
+    }
+    defaults.update(state)
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(**defaults)), headers={})
+
+
+# ── surfaced schema shape ────────────────────────────────────────────────────
+
+
+def test_admin_schemas_surface_catalog_minus_exclusions() -> None:
+    names = {s["function"]["name"] for s in bc._admin_tool_schemas()}
+    catalog = admin.AUTONOMOUS_READ_TOOLS | admin.AUTONOMOUS_WRITE_TOOLS | admin.GATED_TOOLS
+    assert names == catalog - bc._ADMIN_TOOL_EXCLUDES
+    # The Brain's platform hands are actually in there.
+    for expected in ("model_pull", "profile_create", "stack_apply", "slot_edit", "model_store"):
+        assert expected in names
+
+
+def test_admin_schemas_do_not_collide_with_local_tools() -> None:
+    """One tool name = one schema across the combined list the LLM sees."""
+    local = [s["function"]["name"] for s in bc._tool_schemas()]
+    combined = local + [s["function"]["name"] for s in bc._admin_tool_schemas()]
+    assert len(combined) == len(set(combined)), "duplicate tool names in the LLM tool list"
+
+
+def test_admin_schemas_require_path_args() -> None:
+    """Path args (slot name, model id…) surface as required string props."""
+    by_name = {s["function"]["name"]: s["function"]["parameters"] for s in bc._admin_tool_schemas()}
+    assert by_name["model_pull"]["required"] == ["model_id"]
+    assert by_name["model_pull"]["properties"]["model_id"] == {"type": "string"}
+    # Body/query fields stay open for description-driven args (hf_repo etc.).
+    assert by_name["model_pull"]["additionalProperties"] is True
+    assert by_name["profile_list"]["required"] == []
+
+
+def test_excluded_memory_tools_not_surfaced() -> None:
+    names = {s["function"]["name"] for s in bc._admin_tool_schemas()}
+    assert not any(n.startswith("memory_") for n in names)
+
+
+# ── dispatch routing ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_routes_admin_names_through_mcp_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An admin-catalog name that no local resolver claims lands in
+    admin.dispatch with the persona as client_id."""
+    seen: dict[str, Any] = {}
+
+    async def _fake_dispatch(**kwargs: Any) -> dict[str, Any]:
+        seen.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(admin, "dispatch", _fake_dispatch)
+    request = _fake_request(approval_queue=ApprovalQueue())
+    result = await bc._dispatch_tool(request, client=None, name="profile_list", args={}, board=None)
+    assert result == {"ok": True}
+    assert seen["tool"] == "profile_list"
+    assert seen["client_id"] == bc.BRAIN_PERSONA_ID
+    assert seen["base_url"] == "http://testserver"
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_still_errors() -> None:
+    request = _fake_request(approval_queue=ApprovalQueue())
+    result = await bc._dispatch_tool(request, client=None, name="not_a_tool", args={}, board=None)
+    assert result == {"error": "unknown tool: not_a_tool"}
+
+
+@pytest.mark.asyncio
+async def test_gated_tool_returns_pending_approval_from_chat_path() -> None:
+    """model_pull from the sidebar enqueues on the SAME ApprovalQueue the
+    /mcp/admin mount uses — nothing executes until the operator approves."""
+    queue = ApprovalQueue()
+    request = _fake_request(approval_queue=queue)
+    result = await bc._dispatch_admin_tool(request, "model_pull", {"model_id": "m"})
+    assert result["status"] == "pending_approval"
+    assert result["approval_id"]
+    pending = queue.list_pending()
+    assert [p["tool"] for p in pending] == ["model_pull"]
+    assert pending[0]["client_id"] == bc.BRAIN_PERSONA_ID
+
+
+@pytest.mark.asyncio
+async def test_admin_dispatch_degrades_without_approval_queue() -> None:
+    """No lifespan wiring (approval_queue=None) → typed error, no crash."""
+    request = _fake_request(approval_queue=None)
+    result = await bc._dispatch_admin_tool(request, "model_pull", {"model_id": "m"})
+    assert "unavailable" in result["error"]

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -98,8 +98,10 @@ def test_classification_buckets_match_adr_0004() -> None:
     # `logs_tail` was promoted from autonomous-read to GATED per
     # security review MED-1 — it stays gated until the journald
     # redactor in routes/logs.py covers Bearer + X-API-Key + provider
-    # keys per ADR-0004 §7.
+    # keys per ADR-0004 §7. slot_logs proxies the same journald
+    # surface per-unit, so it carries the same classification.
     assert "logs_tail" in gated
+    assert "slot_logs" in gated
     # ADR-0004 §4 reads.
     for t in (
         "slot_list",
@@ -160,12 +162,13 @@ def test_destructive_tools_match_gated_destructive_set() -> None:
     assert destructive_per_annotation == destructive_per_adr
 
 
-def test_open_world_tool_is_model_pull_only() -> None:
-    """model_pull is the only tool that reaches outside hal0's own
-    surface (HuggingFace + upstream registries). Anything else with
+def test_open_world_tools_are_the_hf_surface_only() -> None:
+    """Exactly three tools reach outside hal0's own surface — all of
+    them HuggingFace-facing: pull downloads weights, update re-pulls in
+    place, inspect fetches repo metadata. Anything else with
     openWorldHint=True needs a deliberate ADR update."""
     open_world = {name for name, ann in admin._ANNOTATIONS.items() if ann.openWorldHint}
-    assert open_world == {"model_pull"}
+    assert open_world == {"model_pull", "model_update", "model_inspect"}
 
 
 @pytest.mark.asyncio
@@ -439,9 +442,54 @@ async def test_list_wrap_does_not_touch_dict_payloads(
     assert result == {"status": "error", "http_status": 503}
 
 
-def test_wrap_list_payload_noop_for_other_tools() -> None:
-    """Only slot_list / provider_list get wrapped; other tools (e.g.
-    model_list, whose REST route already returns a dict) pass through."""
+def test_wrap_list_payload_generic_fallback_and_dict_passthrough() -> None:
+    """Any bare-list payload wraps (named key when mapped, ``items``
+    otherwise) so a newly-mapped bare-list route can't crash FastMCP's
+    dict result model; dict payloads always pass through untouched."""
     data = [{"id": "x"}]
-    assert admin._wrap_list_payload("model_list", data) is data
+    assert admin._wrap_list_payload("upstream_list", data) == {"upstreams": data, "count": 1}
+    assert admin._wrap_list_payload("bench_runs", data) == {"items": data, "count": 1}
     assert admin._wrap_list_payload("hardware_probe", {"ok": 1}) == {"ok": 1}
+    assert admin._wrap_list_payload("model_list", {"data": data}) == {"data": data}
+
+
+def test_catalog_validation_catches_rest_map_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A classified tool losing its _REST_MAP row must fail at import
+    validation, not at call time with an opaque envelope."""
+    admin._validate_catalog()  # coherent as shipped
+    monkeypatch.delitem(admin._REST_MAP, "slot_list")
+    with pytest.raises(RuntimeError, match="slot_list"):
+        admin._validate_catalog()
+
+
+def test_catalog_validation_catches_path_arg_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_PATH_ARGS must mirror the {placeholders} in each route template."""
+    monkeypatch.delitem(admin._PATH_ARGS, "model_pull")
+    with pytest.raises(RuntimeError, match="model_pull"):
+        admin._validate_catalog()
+
+
+@pytest.mark.asyncio
+async def test_build_server_rejects_registration_drift(
+    queue: ApprovalQueue, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tool classified but never _register()ed (or vice versa) fails
+    loudly at build time instead of 404ing in an agent's chat."""
+    monkeypatch.setattr(admin, "GATED_TOOLS", admin.GATED_TOOLS | {"ghost_tool"})
+    with pytest.raises(RuntimeError, match="ghost_tool"):
+        admin.build_server(approval_queue=queue, base_url="http://t")
+
+
+def test_model_edit_and_model_update_route_to_distinct_endpoints() -> None:
+    """model_edit is the metadata PUT; model_update is the in-place HF
+    re-pull POST. The two are easy to cross-wire — pin them apart."""
+    assert admin._REST_MAP["model_edit"] == ("PUT", "/api/models/{model_id}")
+    assert admin._REST_MAP["model_update"] == ("POST", "/api/models/{model_id}/update")
+
+
+def test_model_scan_is_a_write_and_preview_is_a_read() -> None:
+    """Scanning registers new files (a mutation); only the dry-run
+    preview classifies as an autonomous read."""
+    assert "model_scan" in admin.AUTONOMOUS_WRITE_TOOLS
+    assert "model_scan_preview" in admin.AUTONOMOUS_READ_TOOLS
+    assert "model_scan" not in admin.AUTONOMOUS_READ_TOOLS

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -469,15 +469,15 @@ def test_catalog_validation_catches_path_arg_drift(monkeypatch: pytest.MonkeyPat
         admin._validate_catalog()
 
 
-@pytest.mark.asyncio
-async def test_build_server_rejects_registration_drift(
-    queue: ApprovalQueue, monkeypatch: pytest.MonkeyPatch
+def test_catalog_validation_catches_description_drift(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A tool classified but never _register()ed (or vice versa) fails
-    loudly at build time instead of 404ing in an agent's chat."""
+    """A tool classified but missing from TOOL_DESCRIPTIONS (or vice
+    versa) fails import validation — registration iterates that dict, so
+    a gap would otherwise silently drop the tool from tools/list."""
     monkeypatch.setattr(admin, "GATED_TOOLS", admin.GATED_TOOLS | {"ghost_tool"})
     with pytest.raises(RuntimeError, match="ghost_tool"):
-        admin.build_server(approval_queue=queue, base_url="http://t")
+        admin._validate_catalog()
 
 
 def test_model_edit_and_model_update_route_to_distinct_endpoints() -> None:

--- a/tests/mcp/test_logs_tail_redaction.py
+++ b/tests/mcp/test_logs_tail_redaction.py
@@ -74,13 +74,29 @@ def test_redact_logs_payload_walks_lines_array() -> None:
     assert redacted["lines"][2] == "[00:02] no secret here"
 
 
+def test_redact_logs_payload_masks_slot_logs_string_shape() -> None:
+    """slot_logs returns one ``logs`` string (not a ``lines`` array) —
+    the redactor must cover that shape too, since the route proxies the
+    same journald surface per slot unit."""
+    payload = {
+        "name": "agent",
+        "logs": "[00:00] boot\n[00:01] HAL0_BEARER_TOKEN=hal0_tok_leak\n[00:02] ready",
+    }
+    redacted = admin._redact_logs_payload(payload)
+    assert "hal0_tok_leak" not in str(redacted)
+    assert "***REDACTED***" in redacted["logs"]
+    assert "[00:00] boot" in redacted["logs"]
+
+
 def test_redact_logs_payload_tolerates_missing_or_malformed_shape() -> None:
     """If the upstream gives us an unexpected shape we return it
     unchanged — never swallow content, only mask known patterns."""
-    # No ``lines`` key.
+    # No ``lines`` / ``logs`` keys.
     assert admin._redact_logs_payload({"unit": "x"}) == {"unit": "x"}
     # ``lines`` is not a list.
     assert admin._redact_logs_payload({"lines": "oops"}) == {"lines": "oops"}
+    # ``logs`` is not a string.
+    assert admin._redact_logs_payload({"logs": 42}) == {"logs": 42}
     # Non-dict envelope.
     assert admin._redact_logs_payload("just a string") == "just a string"
 


### PR DESCRIPTION
## Context

The hal0-brain agent needs to drive every platform surface: find/download/organize/register models into the operator's chosen store, author profiles from model cards, manage slot lifecycle end-to-end, and manage stacks. This completes the in-flight admin-MCP expansion (picked up from an interrupted working session), fixes the bugs in that draft, **and wires the dashboard's sidebar Brain chat to the same catalog** — previously the sidebar had only its own hardcoded ~25-tool list and never consumed the MCP.

## 1. Admin MCP surface (28 → 74 tools)

| Surface | Added |
|---|---|
| Models | `model_inspect` (HF repo → detection rows, no registration), `model_show`, `model_register`, `model_add` (from path), `model_edit` (metadata PUT), `model_update` (in-place HF re-pull), `model_scan`(+`_preview`), `model_catalogue`, `model_update_check`, `model_pulls_list`, `model_pull_status`, `model_pull_cancel`, `model_store`/`_set`/`_migrate` |
| Slots | `slot_load`, `slot_unload`, `slot_edit` (config PUT), `slot_metrics`, `slot_capacity`, `slot_logs` |
| Stacks | `stack_create`, `stack_update`, `stack_export`, `stack_snapshot` |
| Profiles | `profile_create` (e.g. from a model card), `profile_update` |
| Settings | `settings_get`/`schema`/`apply_plan`/`reload`, `upstream_list` |
| Benchmarks | `bench_runs`/`run_status`/`queue` (reads), `bench_enqueue`/`bench_control` (gated) |

**Store contract:** pulls always land in the operator's configured `[models].store` — the pull engine re-reads it on every call (`hal0/registry/pull.py::_pull_root`), so `model_store_set` takes effect immediately; the `model_pull`/`model_store` descriptions state this so the agent checks the store before downloading.

## 2. Sidebar Brain chat wired to the catalog

`board_chat.py` now surfaces the admin catalog as OpenAI tool schemas (path args → required string props; `additionalProperties` open for body fields like `hf_repo`) and routes calls through the **same** `admin.dispatch` core as `/mcp/admin`: identical gating, the lifespan-scoped ApprovalQueue (gated tools return `pending_approval` and execute only after operator approval in the Approvals panel), and audit rows with `client_id=hal0-brain`. Locals win on collision (the chat keeps its purpose-tuned board tools + `slot_load/unload/restart`); `memory_*` excluded (the persona rides its Hindsight namespace); lazy imports keep the board-only chat alive if the `mcp` SDK is absent. Tool descriptions were hoisted into a module-level `TOOL_DESCRIPTIONS` dict — single source of truth for the MCP mount and the sidebar, pinned by import-time validation.

## 3. Fixes over the interrupted draft

- `logs_tail` was classified read **and** gated, and registered twice (FastMCP collision)
- `model_edit` classified/annotated but had no REST mapping
- `model_update` wired to the metadata `PUT /api/models/{id}` instead of the re-pull `POST /{id}/update` (now pinned apart by a test)
- `model_scan` classified as a read though it registers files — now an autonomous write; `_preview` stays the read
- `settings_reload` and `slot_logs` classified but unrouted
- `slot_logs` joins `logs_tail` behind the MED-1 journald gate; the secret redactor now also covers its single-string `logs` shape
- `_wrap_list_payload` gains a generic `items` fallback so any bare-list route validates through FastMCP

## 4. Drift guards (new)

Import-time `_validate_catalog()` (classification ↔ `_REST_MAP` ↔ `_ANNOTATIONS` ↔ `_PATH_ARGS`-vs-template-placeholders ↔ `TOOL_DESCRIPTIONS` coherence). Every bug class found in the draft now fails in CI, not in an agent's chat. Every route verified against the live `hal0.api.routes` surface.

## Tests

`tests/mcp` 130 passed; `tests/board` 52 passed incl. new `test_board_chat_admin_tools.py` (catalog surfaced minus exclusions, no name collisions, path-arg schemas, admin routing with persona client_id, gated-from-sidebar → `pending_approval` on the shared queue, degraded modes). MCP/approval API tests: 59 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)