### PR TITLE
feat(ui): polish image-gen header + size Local endpoints heading

### DIFF
--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -121,6 +121,8 @@
   background: var(--warn-soft); white-space: nowrap;
 }
 .comfy-page .gpu-note .b { color: var(--fg-2); }
+/* Banner variant — sits above the active render (out of the header). */
+.comfy-page .render-warn { display: inline-flex; margin: 0 0 14px; }
 
 /* ── Live dot ───────────────────────────────────────────────────────────────── */
 .comfy-page .ldot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-5); flex-shrink: 0; }

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -390,7 +390,7 @@ export const COMFYUI_V2_MOCK = {
 }
 
 // ── Card header ───────────────────────────────────────────────────────────────
-function CardHead({ engine, run, pct }) {
+function CardHead({ run, pct, onStop, onRestart, onLogs }) {
   const hasRun = run != null
   return (
     <div className="engine-h wcard-h">
@@ -406,23 +406,25 @@ function CardHead({ engine, run, pct }) {
         <span className="dot" />
         {hasRun ? `generating · ${Math.round(pct)}%` : 'idle'}
       </span>
-      <span className="cf-pill">
-        <span className="d" />
-        iGPU · exclusive
-      </span>
       <span className="grow" />
       <span className="eh-right">
-        <span className="gpu-note">
-          <Ci name="bolt" size={11} /> inference slots <span className="b">paused</span> while rendering
+        <span className="cf-pill">
+          <span className="d" />
+          iGPU · exclusive
         </span>
-        <span className="meta">docker · <b>{engine.endpoint}</b></span>
+        {/* Container controls — moved up from the footer to the header far right. */}
+        <span className="foot-ctrls">
+          <button className="sctrl stop" title="Stop container" onClick={onStop}><Ci name="stop" size={12} /></button>
+          <button className="sctrl restart" title="Restart" onClick={onRestart}><Ci name="refresh" size={12} /></button>
+          <button className="sctrl" title="Logs" onClick={onLogs}><Ci name="logs" size={12} /></button>
+        </span>
       </span>
     </div>
   )
 }
 
 // ── Card footer ───────────────────────────────────────────────────────────────
-function CardFoot({ engine, onRestart, onLogs }) {
+function CardFoot({ engine }) {
   return (
     <div className="wfoot">
       <div className="foot-id">
@@ -438,12 +440,6 @@ function CardFoot({ engine, onRestart, onLogs }) {
         <span className="k">endpoint</span>
         <span className="v acc">{engine.endpoint}</span>
       </div>
-      <span className="grow" />
-      <span className="foot-ctrls">
-        <button className="sctrl stop" title="Stop container"><Ci name="stop" size={12} /></button>
-        <button className="sctrl restart" title="Restart" onClick={onRestart}><Ci name="refresh" size={12} /></button>
-        <button className="sctrl" title="Logs" onClick={onLogs}><Ci name="logs" size={12} /></button>
-      </span>
     </div>
   )
 }
@@ -513,8 +509,17 @@ export function ImageGenCard({
 
   return (
     <div className="engine wcard active">
-      <CardHead engine={engine} run={run} pct={pct} />
+      <CardHead run={run} pct={pct} onRestart={onRestart} onLogs={onLogs} />
       <div className="wcard-b">
+
+        {/* Render-active notice — moved out of the card header so it sits
+            directly above the active render. Only shown while a render is
+            running, since it describes what's paused *while rendering*. */}
+        {hasRun && (
+          <div className="gpu-note render-warn">
+            <Ci name="bolt" size={11} /> inference slots <span className="b">paused</span> while rendering
+          </div>
+        )}
 
         {/* ── Top row: active render activity (60%) + metrics (40%) ── */}
         <div className="activity-metrics-row">
@@ -705,7 +710,7 @@ export function ImageGenCard({
         )}
       </div>
 
-      <CardFoot engine={engine} onRestart={onRestart} onLogs={onLogs} />
+      <CardFoot engine={engine} />
     </div>
   )
 }

--- a/ui/src/dash/connections.css
+++ b/ui/src/dash/connections.css
@@ -60,8 +60,9 @@
 }
 .cpane.live .cpane-glyph { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-line); }
 .cpane-titles { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-.engine-title,
-.cpane-title { font-family: var(--jbm); font-size: 15px; font-weight: 500; color: var(--fg); white-space: nowrap; }
+.engine-title { font-family: var(--jbm); font-size: 15px; font-weight: 500; color: var(--fg); white-space: nowrap; }
+/* Match the inference/NPU engine-pane titles (.infer-pane .sec-label → 12px). */
+.cpane-title { font-family: var(--jbm); font-size: 12px; font-weight: 500; color: var(--fg); white-space: nowrap; }
 .engine-sub,
 .cpane-sub { font-family: var(--jbm); font-size: 11px; color: var(--fg-4); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .cpane-h .grow { flex: 1; }


### PR DESCRIPTION
Follow-up UI polish on the Slots page, in the same spirit as #1205 (which merged while this was in review).

## Image Gen tab (`comfyui-pane`)
- Moved the **"inference slots paused while rendering"** notice out of the card header into a banner **above the active render** (shown only while a render is running).
- Slid the **"iGPU · exclusive"** tag to the header right; moved the **container controls** (stop/restart/logs) up to the **header far right**; dropped the redundant **"docker · :8188"** meta.

## Endpoints tab (`connections`)
- Sized `.cpane-title` to **12px** so **"Local endpoints"** matches the inference/NPU engine-pane titles on the sibling tabs (was 15px). `.engine-title` (unused in JSX) is left at 15px.

## Verification
Built the UI and previewed the `dist` against the live backend; confirmed in-browser at desktop (1440) and narrow (780) widths:
- Header shows `iGPU · exclusive` + controls at the far right, no `:8188`.
- Warning renders above the active render (active-render state exercised via the e2e mock-override seam).
- `.conn .cpane-title` computed size is `12px` uppercase, matching the peer titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)