### PR TITLE
fix(slots): canon FLM-trio shadow slots to flm-stt/flm-embed + startup reconcile

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -799,6 +799,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # until the operator clicks each slot.
     await slot_manager.reconcile_unconfigured_slots()
 
+    # Reconcile the FLM-trio shadow slots (flm-stt / flm-embed) to canon:
+    # rename legacy stt-npu/embed-npu records, normalize device/profile/port/
+    # served_by/type, and seed any missing shadow so the slots page + trio
+    # dispatch are coherent on fresh installs and after upgrades. No-op when
+    # there is no container NPU anchor; best-effort so it never blocks startup.
+    try:
+        await slot_manager.reconcile_npu_trio_slots()
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("slot.reconcile_trio_failed", error=str(exc))
+
     # Idle monitor — demotes READY → IDLE after the configured timeout
     # (so the dashboard distinguishes "warm but quiet" from "warm and
     # actively serving") AND hard-evicts slots idle past their TTL to free
@@ -1045,7 +1055,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # one static port; chat routes through the slot upstream like any
     # other slot, while v1.py's STT/embed routes post the two shadow
     # roles straight to the container when they detect an enabled
-    # ``stt-npu`` / ``embed-npu`` slot record. Degrades cleanly when the
+    # ``flm-stt`` / ``flm-embed`` slot record. Degrades cleanly when the
     # container isn't dispatchable (NpuTrioNotAvailable raised at
     # dispatch time so the user sees a clear envelope).
     try:

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -17,7 +17,7 @@ PR-11 (plan §11 + ADR-0008 §5): list responses are enriched with
 config-derived fields (drawer seeds, declared backend) plus live
 container state (``container_status`` / ``container_health``), and a
 ``coresident_group`` ID grouping slots that back the same FLM process
-(the NPU trio: ``agent`` + ``stt-npu`` + ``embed-npu``). This is
+(the NPU trio: ``flm`` + ``flm-stt`` + ``flm-embed``). This is
 backward-compatible — every legacy field is preserved; new keys are
 purely additive.
 """

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -850,7 +850,7 @@ async def _is_npu_trio_request(
          ``device == "npu"`` AND ``type == slot_type``. We look at both
          ``slot.model.default`` AND ``slot.name`` so callers that pass
          either the model id or the slot name (e.g. dashboard cards
-         using ``model="stt-npu"``) hit the same path.
+         using ``model="flm-stt"``) hit the same path.
       2. The :class:`NpuTrioRouter` itself is attached on ``app.state``
          (lifespan didn't fail to construct it).
 

--- a/src/hal0/bundles/schema.py
+++ b/src/hal0/bundles/schema.py
@@ -47,7 +47,7 @@ class ModelEntry:
 
     ``slot`` is the hal0 slot id (``chat.primary``, ``chat.coder``,
     ``embed``, ``rerank``, ``stt``, ``tts``, ``img``, plus the FLM trio
-    slots ``agent`` / ``stt-npu`` / ``embed-npu`` when present).
+    slots ``flm-stt`` / ``flm-embed`` when present).
     ``model_name`` is the catalog model id (registry.toml key).
     ``size_gb`` is the on-disk pull size; informational only — the actual
     download honours whatever the pull engine resolves at pull time.

--- a/src/hal0/dispatcher/npu_trio.py
+++ b/src/hal0/dispatcher/npu_trio.py
@@ -45,7 +45,7 @@ _DEFAULT_TIMEOUT_S = 120.0
 
 class NpuTrioNotAvailable(Hal0Error):
     """The NPU container isn't dispatchable, so the trio's shadow roles
-    (``stt-npu`` / ``embed-npu``) have no backend to forward to.
+    (``flm-stt`` / ``flm-embed``) have no backend to forward to.
 
     Surfaced when the ``npu`` slot config is missing/not a container NPU
     slot, has no port, or isn't in the dispatchable ready-set (#696:

--- a/src/hal0/omni_router/dispatch.py
+++ b/src/hal0/omni_router/dispatch.py
@@ -36,7 +36,7 @@ Endpoints (per plan §7.2):
 
 The base URL is hal0-api's own loopback URL (``http://127.0.0.1:8080``
 by default per ADR-0008 §1). PR-19 introduces direct-to-FLM-child
-routing for ``stt-npu``/``embed-npu`` slots; PR-16 sticks to the
+routing for ``flm-stt``/``flm-embed`` slots; PR-16 sticks to the
 single-URL contract.
 """
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -108,11 +108,18 @@ SEEDED_SLOTS: tuple[str, ...] = (
 
 #: NPU FLM shadow slots seeded only when the FastFlowLM ``.deb`` is
 #: installed (``shutil.which('flm')`` truthy): the ASR + embed tags that
-#: ride the same coresident FLM process as the NPU chat anchor — which is
-#: the separate ``npu`` slot, NOT listed here. ``agent`` was previously
+#: ride the same coresident FLM process as the NPU chat anchor — the
+#: separate ``flm`` slot, NOT listed here. ``agent`` was previously
 #: (wrongly) in this set; it is a GPU chat-role slot and moved to
 #: SEEDED_SLOTS in #679. Opt-in at Pro+ bundle tier (ADR-0008 §5).
-NPU_SEEDED_SLOTS: tuple[str, ...] = ("stt-npu", "embed-npu")
+#:
+#: Named ``{anchor}-stt`` / ``{anchor}-embed`` (anchor is ``flm``) to match
+#: the occupancy-pane virtual sub-cards (:mod:`hal0.api.routes.npu` synthesises
+#: ``s.name + "-stt"``) and the ``_touch_npu_shadow_count`` activity counters
+#: (:mod:`hal0.api.routes.v1`), which both key off that convention. The legacy
+#: ``stt-npu`` / ``embed-npu`` names never matched either surface and are
+#: migrated forward by :meth:`SlotManager.reconcile_npu_trio_slots`.
+NPU_SEEDED_SLOTS: tuple[str, ...] = ("flm-stt", "flm-embed")
 
 #: Back-compat alias map: old slot names → canonical new names.
 #: Aliases resolve transparently for dispatch and config lookup but are
@@ -1500,7 +1507,7 @@ class SlotManager:
         """Return the seeded slot list, optionally including the NPU trio.
 
         :data:`SEEDED_SLOTS` lands on every hal0 install. The NPU trio
-        (``agent`` / ``stt-npu`` / ``embed-npu``) only seeds when the
+        shadows (``flm-stt`` / ``flm-embed``) only seed when the
         FastFlowLM ``.deb`` is installed (``shutil.which('flm')``
         truthy). Per plan §10.2 + §4.2 + ADR-0008 §5.
 
@@ -2154,6 +2161,154 @@ class SlotManager:
                     "slot.reconcile_unconfigured_failed",
                     extra={"slot": slot_name, "error": str(exc)},
                 )
+
+    #: FLM-trio shadow spec: (name suffix, slot type, anchor ``[npu]`` toggle
+    #: key, default model id). Drives :meth:`reconcile_npu_trio_slots`.
+    _TRIO_SHADOW_SPEC: tuple[tuple[str, str, str, str], ...] = (
+        ("stt", "transcription", "asr", "whisper-v3:turbo"),
+        ("embed", "embedding", "embed", "embed-gemma:300m"),
+    )
+
+    async def reconcile_npu_trio_slots(self) -> int:
+        """Startup pass: reconcile the FLM-trio shadow slots to canon.
+
+        The NPU runs one ``flm serve`` container (the ``device=npu type=llm``
+        anchor, canonically ``flm``) that also serves transcription +
+        embedding. Those two modalities surface as *shadow* slot records
+        (``{anchor}-stt`` / ``{anchor}-embed``) so they show on the slots
+        page and gate trio dispatch (:func:`hal0.api.routes.v1._is_npu_trio_request`).
+        This pass keeps them coherent on every API start — for fresh installs
+        (anchor present, shadows never seeded), existing installs (legacy
+        names / drifted fields), and post-upgrade:
+
+          1. **Legacy rename.** ``stt-npu`` / ``embed-npu`` TOMLs — the old
+             naming that matched neither the occupancy pane's ``s.name+"-stt"``
+             synthesis nor the ``_touch_npu_shadow_count`` counters, and that
+             (ending ``-npu``, not ``-stt``/``-embed``) even leaked in as a
+             standalone occupancy tile — are moved to ``{anchor}-stt`` /
+             ``{anchor}-embed``. Skipped (and logged) when the canon target
+             already exists, so operator state is never clobbered.
+          2. **Ensure + normalize.** Each shadow is created if missing and its
+             structural fields are forced to the coresident shape: ``device=npu``,
+             ``profile=flm`` (so ``slot_view`` lifts ``device_class=npu`` — a
+             shadow without a resolvable npu profile makes the edit drawer take
+             the wrong branch, per the flm-satellite-slots-fix incident),
+             ``served_by=<anchor>``, ``port=<anchor port>``, and the trio
+             ``type``. A newly-created shadow's ``enabled`` mirrors the anchor's
+             ``[npu]`` toggle (``asr`` / ``embed``) so trio dispatch works out
+             of the box; an existing shadow's ``enabled`` and ``model.default``
+             are the operator's and left untouched.
+
+        No-op when there is no container NPU anchor. Best-effort: per-shadow
+        failures are logged and never block startup.
+
+        Returns the number of shadow records created or rewritten.
+        """
+        import tomllib
+
+        from hal0.dispatcher._npu_common import is_container_npu_cfg
+
+        # Locate the container NPU anchor (type=llm, device=npu). Mirrors
+        # CapabilityOrchestrator._set_flm_modality's scan.
+        try:
+            configs = await self.iter_configs()
+        except Exception as exc:
+            log.warning("slot.reconcile_trio_iter_failed", extra={"error": str(exc)})
+            return 0
+        anchor_cfg: dict[str, Any] | None = None
+        for cfg in configs:
+            if cfg.get("type") == "llm" and cfg.get("device") == "npu":
+                anchor_cfg = cfg
+                break
+        if anchor_cfg is None or not is_container_npu_cfg(anchor_cfg):
+            return 0
+        anchor_name = str(anchor_cfg.get("name", "")).strip()
+        anchor_port = anchor_cfg.get("port")
+        if not anchor_name or not anchor_port:
+            return 0
+        npu_tbl = anchor_cfg.get("npu")
+        if not isinstance(npu_tbl, dict):
+            npu_tbl = {}
+
+        changed = 0
+        slots_dir = paths.slots_config_dir()
+        for suffix, slot_type, npu_field, default_model in self._TRIO_SHADOW_SPEC:
+            canon = f"{anchor_name}-{suffix}"
+            legacy = f"{suffix}-npu"  # stt-npu / embed-npu
+            canon_path = slots_dir / f"{canon}.toml"
+            legacy_path = slots_dir / f"{legacy}.toml"
+            try:
+                # 1. Legacy rename — only when the canon target is free.
+                if legacy_path.exists():
+                    if canon_path.exists():
+                        log.warning(
+                            "slot.trio_shadow_rename_skipped",
+                            extra={
+                                "legacy": legacy,
+                                "canon": canon,
+                                "reason": "canon target already exists",
+                            },
+                        )
+                    else:
+                        legacy_raw = tomllib.loads(legacy_path.read_text(encoding="utf-8"))
+                        legacy_raw["name"] = canon
+                        write_slot_toml(canon_path, legacy_raw)
+                        with contextlib.suppress(FileNotFoundError):
+                            legacy_path.unlink()
+                        self._invalidate_cfg_cache(legacy)
+                        self._invalidate_cfg_cache(canon)
+                        log.info(
+                            "slot.trio_shadow_renamed",
+                            extra={"from": legacy, "to": canon},
+                        )
+
+                # 2. Ensure + normalize the canon shadow record. After a rename
+                #    canon_path now exists, so the same iteration normalizes it.
+                if canon_path.exists():
+                    raw = tomllib.loads(canon_path.read_text(encoding="utf-8"))
+                    desired = {
+                        "device": "npu",
+                        "profile": "flm",
+                        "served_by": anchor_name,
+                        "port": int(anchor_port),
+                        "type": slot_type,
+                    }
+                    if any(raw.get(k) != v for k, v in desired.items()):
+                        raw.update(desired)
+                        raw.setdefault("name", canon)
+                        write_slot_toml(canon_path, raw)
+                        self._invalidate_cfg_cache(canon)
+                        changed += 1
+                        log.info("slot.trio_shadow_normalized", extra={"slot": canon})
+                    continue
+
+                # 3. Missing → create it. ``enabled`` mirrors the anchor toggle
+                #    so trio dispatch is live when the modality is on.
+                enabled = bool(npu_tbl.get(npu_field))
+                cfg_dict = {
+                    "name": canon,
+                    "port": int(anchor_port),
+                    "device": "npu",
+                    "backend": "flm",
+                    "provider": "flm",
+                    "profile": "flm",
+                    "served_by": anchor_name,
+                    "type": slot_type,
+                    "enabled": enabled,
+                    "model": {"default": default_model},
+                }
+                await self.create(canon, cfg_dict)
+                changed += 1
+                log.info(
+                    "slot.trio_shadow_created",
+                    extra={"slot": canon, "enabled": enabled},
+                )
+            except Exception as exc:
+                log.warning(
+                    "slot.reconcile_trio_shadow_failed",
+                    extra={"slot": canon, "error": str(exc)},
+                )
+        return changed
 
     async def _persist_model_default(self, slot_name: str, model_id: str) -> None:
         """Write ``[model] default = <model_id>`` into the slot's TOML.

--- a/tests/api/test_v1_npu_trio_routing.py
+++ b/tests/api/test_v1_npu_trio_routing.py
@@ -3,8 +3,8 @@
 A single ``flm serve`` process inside the containerized ``npu`` slot answers
 chat + STT + embed on ONE static port (from the npu slot's TOML). When a
 request lands on ``/v1/embeddings`` or ``/v1/audio/transcriptions`` and its
-``model`` matches an enabled ``device=npu`` shadow-role slot (``embed-npu``
-/ ``stt-npu``), v1.py forwards it straight to that port via
+``model`` matches an enabled ``device=npu`` shadow-role slot (``flm-embed``
+/ ``flm-stt``), v1.py forwards it straight to that port via
 ``app.state.npu_trio_router`` (:class:`hal0.dispatcher.npu_trio.NpuTrioRouter`).
 
 These tests drive the live FastAPI app via ``TestClient`` and verify:
@@ -58,8 +58,10 @@ def seed_npu_trio(tmp_hal0_home: str) -> None:
     """Lay down the NPU trio slot TOMLs on disk.
 
     ``flm`` is the containerized anchor (static port, runtime=container);
-    ``stt-npu`` / ``embed-npu`` are the shadow-role records whose model
-    ids gate the trio dispatch in v1.py.
+    ``flm-stt`` / ``flm-embed`` are the canonical shadow-role records whose
+    model ids gate the trio dispatch in v1.py. (These are already the names
+    ``reconcile_npu_trio_slots`` migrates legacy ``stt-npu``/``embed-npu`` to,
+    so the startup reconcile is a no-op here.)
     """
     _seed_slot_toml(
         tmp_hal0_home,
@@ -77,9 +79,9 @@ def seed_npu_trio(tmp_hal0_home: str) -> None:
     )
     _seed_slot_toml(
         tmp_hal0_home,
-        "stt-npu",
+        "flm-stt",
         [
-            'name = "stt-npu"',
+            'name = "flm-stt"',
             "port = 8084",
             'device = "npu"',
             'type = "transcription"',
@@ -90,9 +92,9 @@ def seed_npu_trio(tmp_hal0_home: str) -> None:
     )
     _seed_slot_toml(
         tmp_hal0_home,
-        "embed-npu",
+        "flm-embed",
         [
-            'name = "embed-npu"',
+            'name = "flm-embed"',
             "port = 8085",
             'device = "npu"',
             'type = "embedding"',
@@ -298,14 +300,14 @@ def test_embed_request_matches_trio_by_slot_name(
     trio_client: tuple[TestClient, dict[str, Any]],
 ) -> None:
     """Callers can pass either the slot's ``model.default`` OR the slot
-    name itself (``embed-npu``) as ``model`` — both route through the
-    trio. UI surfaces that show "embed-npu" as a dropdown option must
+    name itself (``flm-embed``) as ``model`` — both route through the
+    trio. UI surfaces that show "flm-embed" as a dropdown option must
     work without exposing the underlying model id."""
     client, captures = trio_client
 
     r = client.post(
         "/v1/embeddings",
-        json={"model": "embed-npu", "input": "by slot name"},
+        json={"model": "flm-embed", "input": "by slot name"},
     )
 
     assert r.status_code == 200, r.text
@@ -384,11 +386,11 @@ def test_stt_npu_skips_trio_when_slot_disabled(tmp_hal0_home: str) -> None:
 def test_stt_request_matches_trio_by_slot_name(
     trio_client: tuple[TestClient, dict[str, Any]],
 ) -> None:
-    """Passing ``model="stt-npu"`` (slot name) also routes through the trio."""
+    """Passing ``model="flm-stt"`` (slot name) also routes through the trio."""
     client, captures = trio_client
 
     files = {"file": ("clip.wav", b"RIFF\x00\x00", "audio/wav")}
-    data = {"model": "stt-npu"}
+    data = {"model": "flm-stt"}
     r = client.post("/v1/audio/transcriptions", files=files, data=data)
     assert r.status_code == 200, r.text
     stt_calls = [c for c in captures["calls"] if c["path"] == "/v1/audio/transcriptions"]

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -62,7 +62,10 @@ def test_seeded_slots_matches_plan_section_10_2() -> None:
 
 def test_npu_seeded_slots_matches_plan_section_10_2() -> None:
     # #679: agent dropped — it's a GPU chat-role slot, not the NPU FLM anchor.
-    assert NPU_SEEDED_SLOTS == ("stt-npu", "embed-npu")
+    # Named {anchor}-stt/{anchor}-embed (anchor = ``flm``) to match the
+    # occupancy pane's virtual sub-cards + the trio activity counters; the
+    # legacy stt-npu/embed-npu names are migrated by reconcile_npu_trio_slots.
+    assert NPU_SEEDED_SLOTS == ("flm-stt", "flm-embed")
 
 
 def test_builtin_slots_aliases_seeded_slots() -> None:

--- a/tests/slots/test_npu_trio_reconcile.py
+++ b/tests/slots/test_npu_trio_reconcile.py
@@ -1,0 +1,173 @@
+"""Tests for SlotManager.reconcile_npu_trio_slots (FLM-trio shadow canon).
+
+The reconcile pass keeps the ``flm-stt`` / ``flm-embed`` shadow records
+coherent on every API start: it renames legacy ``stt-npu`` / ``embed-npu``
+TOMLs to ``{anchor}-stt`` / ``{anchor}-embed``, normalizes the coresident
+structural fields (device=npu, profile=flm, served_by=<anchor>, port=<anchor
+port>, type), and seeds any missing shadow with ``enabled`` mirroring the
+anchor's ``[npu]`` toggle.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+
+pytestmark = pytest.mark.usefixtures("container_stub")
+
+
+def _slots_dir(tmp_hal0_home: str) -> Path:
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _write(root: Path, name: str, lines: list[str]) -> Path:
+    path = root / f"{name}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _anchor(root: Path, *, asr: bool = True, embed: bool = True, name: str = "flm") -> None:
+    _write(
+        root,
+        name,
+        [
+            f'name = "{name}"',
+            'type = "llm"',
+            'device = "npu"',
+            'backend = "flm"',
+            'runtime = "container"',
+            'profile = "flm"',
+            "port = 8088",
+            "[model]",
+            'default = "qwen3:4b"',
+            "[npu]",
+            "chat = true",
+            f"asr = {str(asr).lower()}",
+            f"embed = {str(embed).lower()}",
+        ],
+    )
+
+
+async def test_creates_missing_shadows_mirroring_anchor_toggles(tmp_hal0_home: str) -> None:
+    root = _slots_dir(tmp_hal0_home)
+    _anchor(root, asr=True, embed=False)
+
+    sm = SlotManager()
+    changed = await sm.reconcile_npu_trio_slots()
+
+    assert changed == 2
+    stt = tomllib.loads((root / "flm-stt.toml").read_text())
+    embed = tomllib.loads((root / "flm-embed.toml").read_text())
+    # Structural coresident shape.
+    for cfg, slot_type in ((stt, "transcription"), (embed, "embedding")):
+        assert cfg["device"] == "npu"
+        assert cfg["profile"] == "flm"
+        assert cfg["served_by"] == "flm"
+        assert cfg["port"] == 8088
+        assert cfg["type"] == slot_type
+    # enabled mirrors the anchor's [npu] toggle (asr on, embed off).
+    assert stt["enabled"] is True
+    assert embed["enabled"] is False
+
+
+async def test_renames_and_normalizes_legacy_shadow(tmp_hal0_home: str) -> None:
+    root = _slots_dir(tmp_hal0_home)
+    _anchor(root)
+    # Legacy stt-npu with a distinct (wrong) port and no profile/served_by,
+    # plus an operator-set enabled + model that must survive the rename.
+    _write(
+        root,
+        "stt-npu",
+        [
+            'name = "stt-npu"',
+            'device = "npu"',
+            'type = "transcription"',
+            "port = 8084",
+            "enabled = true",
+            "[model]",
+            'default = "whisper-v3:turbo"',
+        ],
+    )
+
+    sm = SlotManager()
+    await sm.reconcile_npu_trio_slots()
+
+    assert not (root / "stt-npu.toml").exists()
+    stt = tomllib.loads((root / "flm-stt.toml").read_text())
+    assert stt["name"] == "flm-stt"
+    assert stt["device"] == "npu"
+    assert stt["profile"] == "flm"
+    assert stt["served_by"] == "flm"
+    assert stt["port"] == 8088  # normalized to the anchor port
+    assert stt["type"] == "transcription"
+    # Operator state preserved across the rename.
+    assert stt["enabled"] is True
+    assert stt["model"]["default"] == "whisper-v3:turbo"
+
+
+async def test_rename_skipped_when_canon_exists(tmp_hal0_home: str) -> None:
+    root = _slots_dir(tmp_hal0_home)
+    _anchor(root)
+    _write(
+        root,
+        "stt-npu",
+        ['name = "stt-npu"', 'device = "npu"', 'type = "transcription"', "port = 8084"],
+    )
+    _write(
+        root,
+        "flm-stt",
+        [
+            'name = "flm-stt"',
+            'device = "npu"',
+            'type = "transcription"',
+            'profile = "flm"',
+            'served_by = "flm"',
+            "port = 8088",
+            "enabled = false",
+            "[model]",
+            'default = "whisper-v3:turbo"',
+        ],
+    )
+
+    sm = SlotManager()
+    await sm.reconcile_npu_trio_slots()
+
+    # Both remain — the legacy file is left in place, never clobbering canon.
+    assert (root / "stt-npu.toml").exists()
+    assert (root / "flm-stt.toml").exists()
+
+
+async def test_noop_without_container_npu_anchor(tmp_hal0_home: str) -> None:
+    root = _slots_dir(tmp_hal0_home)
+    # device=npu type=llm but NO profile / runtime=container → not an FLM
+    # container anchor (is_container_npu_cfg False).
+    _write(
+        root,
+        "agent",
+        ['name = "agent"', 'device = "npu"', 'type = "llm"', "port = 8082", "enabled = true"],
+    )
+
+    sm = SlotManager()
+    changed = await sm.reconcile_npu_trio_slots()
+
+    assert changed == 0
+    assert not (root / "flm-stt.toml").exists()
+    assert not (root / "flm-embed.toml").exists()
+
+
+async def test_idempotent_on_second_run(tmp_hal0_home: str) -> None:
+    root = _slots_dir(tmp_hal0_home)
+    _anchor(root)
+
+    sm = SlotManager()
+    first = await sm.reconcile_npu_trio_slots()
+    second = await sm.reconcile_npu_trio_slots()
+
+    assert first == 2
+    assert second == 0  # nothing left to change

--- a/tests/slots/test_slot_aliases.py
+++ b/tests/slots/test_slot_aliases.py
@@ -38,7 +38,7 @@ def test_agent_is_gpu_seeded_not_npu():
     assert "agent" in SEEDED_SLOTS
     assert "agent" not in NPU_SEEDED_SLOTS
     assert "agent-hermes" not in NPU_SEEDED_SLOTS
-    assert NPU_SEEDED_SLOTS == ("stt-npu", "embed-npu")
+    assert NPU_SEEDED_SLOTS == ("flm-stt", "flm-embed")
 
 
 def test_slot_aliases_map():


### PR DESCRIPTION
## Problem

The NPU FLM trio's STT/embed **shadow** slots were half-renamed across three inconsistent naming worlds:

- `NPU_SEEDED_SLOTS` reserved `stt-npu` / `embed-npu` — but these were **never materialized to disk** (only used for delete-protection / name-reservation).
- The occupancy pane (`api/routes/npu.py`) and the trio activity counters (`api/routes/v1.py`) hardcode `flm-stt` / `flm-embed` — the anchor name `flm` + suffix, which is what the occupancy pane *virtually synthesizes* (`s.name + "-stt"`).
- Nothing reconciled existing configs, so a **fresh FLM install got no real satellite records** on the slots page, and legacy `stt-npu` / `embed-npu` names — ending `-npu`, not `-stt`/`-embed` — even leaked in as a **standalone NPU occupancy tile** (they dodge `npu.py`'s `endswith("-stt")` skip).

## Fix

Canonicalize on **`flm-stt` / `flm-embed`** (matching the occupancy synthesis, the activity counters, and the deployed box) and add `SlotManager.reconcile_npu_trio_slots()` — a best-effort startup pass wired into the API lifespan next to `reconcile_unconfigured_slots()`. When a container NPU anchor exists it:

1. **Renames** legacy `stt-npu` / `embed-npu` TOMLs to `{anchor}-stt` / `{anchor}-embed` (skipped, never clobbered, when the canon target already exists);
2. **Normalizes** each shadow to the coresident shape — `device=npu`, `profile=flm` (so `slot_view` lifts `device_class=npu`; without a resolvable npu profile the edit drawer takes the wrong branch, per the flm-satellite-slots-fix incident), `served_by=<anchor>`, `port=<anchor port>`, trio `type`;
3. **Seeds** any missing shadow with `enabled` mirroring the anchor's `[npu]` `asr`/`embed` toggle, so trio dispatch (`v1._is_npu_trio_request`, which skips `enabled is False` shadows) is live out of the box.

Existing shadows keep their operator-set `enabled` + `model.default`. The pass is idempotent and self-heals fresh installs on the next API start (no dependency on `hal0 update`).

`NPU_SEEDED_SLOTS` is retargeted to `("flm-stt", "flm-embed")`; the `profile_derive` capability constants (`stt-npu`/`embed-npu` — a **separate** capability namespace that derives to `None`) are intentionally left unchanged. Remaining doc references to the old slot names were updated.

## Verification

- New unit suite `tests/slots/test_npu_trio_reconcile.py` (5 cases): create-missing (enabled mirrors toggle), legacy rename+normalize (operator state preserved), rename-skipped-when-canon-exists, no-op without a container NPU anchor, idempotent-on-second-run. All pass.
- Updated the `NPU_SEEDED_SLOTS` assertions in `test_manager.py` / `test_slot_aliases.py`.
- Ran against the **live box's real slot TOMLs**: already-canonical box → clean no-op (`changed=0`, nothing spurious); fresh-install (anchor only) → both satellites created `enabled=true`; legacy (`stt-npu`/`embed-npu`) → renamed + normalized, operator `enabled`/model preserved.
- `tests/slots/`, `tests/slot_view/`, `tests/api/test_slots_routes.py` green except one **pre-existing** unrelated failure (`test_aggregator.py::test_stopped_anchor_propagates`, `slot_view` — untouched by this PR, fails on `origin/main` in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)