### PR TITLE
fix(flm): land host pulls in the resolved store + robust 0-byte progress

### DIFF
--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -141,6 +141,97 @@ def _ensure_flm_models_dir(path: str) -> None:
         pass
 
 
+def ensure_host_flm_store_link() -> str:
+    """Point flm's hardcoded host cache at the resolved store; return the store.
+
+    The host ``flm pull`` (and ``flm list``) always read/write
+    ``$HOME/.config/flm/models`` — flm hardcodes it, with no dir flag or env
+    override (confirmed via ``flm --help``). When the operator relocates the
+    store via ``[models].flm_store`` / ``HAL0_FLM_MODELS_DIR``
+    (:func:`~hal0.config.paths.flm_models_dir`), that path diverges from flm's
+    default (:func:`~hal0.config.paths.default_flm_models_dir`), so a host pull
+    silently lands weights on the default root-fs cache instead of the store —
+    where the serving container (which bind-mounts the store at flm's hardcoded
+    path) can't see them, and where the pull-progress poller (which watches the
+    store) reads 0 bytes for the whole download.
+
+    Make flm's default path a **symlink** to the store — the host analog of the
+    container bind-mount — so one host pull lands in the store, progress tracks
+    it, and serving finds it. When the default path is already a real directory
+    with content (legacy / previously-mispulled weights), best-effort migrate
+    its children into the store first (never clobbering existing store files),
+    then replace it with the symlink.
+
+    Best-effort and idempotent: a no-op when the store IS the default, or when
+    the link already points at the store. Any error leaves the filesystem
+    untouched and still returns the store path, so a pull is never crashed by
+    store housekeeping (progress may read 0 on that one box until resolved).
+
+    Not for the async event loop's thread: the one-time migration can copy
+    multi-GB weights across filesystems. Callers on the loop must offload it
+    (e.g. ``asyncio.to_thread``).
+    """
+    import logging
+    import shutil
+    from pathlib import Path
+
+    from hal0.config.paths import default_flm_models_dir
+
+    log = logging.getLogger(__name__)
+    store = _host_flm_models_dir()
+    default = default_flm_models_dir()
+    store_p = Path(store)
+    default_p = Path(default)
+
+    # Default box: flm already writes to the store — nothing to reconcile.
+    if os.path.normpath(store) == os.path.normpath(default):
+        return store
+
+    try:
+        _ensure_flm_models_dir(store)
+
+        # Already a symlink → repoint only if it aims elsewhere.
+        if default_p.is_symlink():
+            if os.path.realpath(default_p) != os.path.realpath(store_p):
+                default_p.unlink()
+                default_p.symlink_to(store_p)
+                log.info(
+                    "flm.store_link_repointed",
+                    extra={"link": default, "target": store},
+                )
+            return store
+
+        if default_p.exists():
+            if not default_p.is_dir():
+                # A file where the models dir should be — don't touch it.
+                log.warning("flm.store_link_unexpected_file", extra={"path": default})
+                return store
+            # Real dir: migrate children into the store, skipping name
+            # collisions so we never clobber weights already in the store.
+            for child in default_p.iterdir():
+                dest = store_p / child.name
+                if dest.exists():
+                    continue
+                shutil.move(str(child), str(dest))
+            if any(default_p.iterdir()):
+                # Something couldn't move (collision) — leave the dir in place
+                # rather than orphan it behind a symlink.
+                log.warning("flm.store_link_skipped_nonempty", extra={"path": default})
+                return store
+            default_p.rmdir()
+
+        # Path now absent → create the symlink.
+        default_p.parent.mkdir(parents=True, exist_ok=True)
+        default_p.symlink_to(store_p)
+        log.info("flm.store_link_created", extra={"link": default, "target": store})
+    except OSError as exc:
+        log.warning(
+            "flm.store_link_failed",
+            extra={"error": str(exc), "store": store, "default": default},
+        )
+    return store
+
+
 # ── Timeouts ───────────────────────────────────────────────────────────────────
 # TIER1: separate health budget from infer budget.
 _HEALTH_TIMEOUT = httpx.Timeout(5.0)
@@ -981,9 +1072,14 @@ def flm_pull_command(tag: str) -> tuple[list[str], str]:
     Uses the host ``/usr/bin/flm`` (same binary the NPU slot serves with),
     NOT a docker toolbox. The caller spawns ``argv`` with
     :func:`flm_host_spawn_kwargs` so it runs as the ``hal0`` user with ``HOME``
-    set; downloads land in ``~/.config/flm/models`` (the real cache) owned by
-    ``hal0``, matching serving. ``host_models_dir`` is returned so callers can
-    locate the weights for progress polling + registry bookkeeping.
+    set; flm writes to its hardcoded ``$HOME/.config/flm/models``. The returned
+    ``host_models_dir`` is the RESOLVED store (:func:`_host_flm_models_dir`),
+    which the caller uses for progress polling + registry bookkeeping and which
+    the serving container bind-mounts — so when the store is relocated it
+    differs from flm's default path. :func:`ensure_host_flm_store_link` (call
+    it before the pull) symlinks flm's default path onto the store so the two
+    agree; without it a relocated-store pull lands weights on the root-fs cache
+    and progress reads 0.
 
     No ``--device``: ``flm pull`` downloads files; it doesn't touch the NPU,
     so it still runs on dev hosts without XDNA passthrough.

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1198,6 +1198,7 @@ async def run_flm_pull(
     # base pull module's import graph (tests pull this module in
     # environments without docker).
     from hal0.providers.flm import (
+        ensure_host_flm_store_link,
         flm_host_async_spawn,
         flm_pull_command,
         flm_served_models,
@@ -1210,10 +1211,26 @@ async def run_flm_pull(
 
     argv, host_models_dir = flm_pull_command(tag)
 
+    # flm hardcodes ~/.config/flm/models and has no dir flag, so a host pull
+    # writes to that default path — NOT the (possibly relocated) store the
+    # progress poller + serving container use. Point flm's default at the store
+    # via a symlink (host analog of the container bind-mount) before we spawn,
+    # so weights land in the store, progress tracks the real bytes, and serving
+    # finds them. Off-loaded to a thread: the one-time legacy-content migration
+    # can copy multi-GB weights and must not block the event loop.
+    await asyncio.to_thread(ensure_host_flm_store_link)
+
     # Resolve the install path + advertised total upfront so progress
     # reporting is monotonic. _flm_install_path reads the same cached
     # catalog flm_served_models uses; both fall back gracefully when
     # the probe failed (host without docker / image not present).
+    #
+    # These two probes (``flm list``) can transiently return an EMPTY catalog
+    # right at pull start — observed live: the dir grew steadily on disk while
+    # the job reported ``0/0`` the whole download because ``target_dir`` was
+    # ``None`` here and never retried. So they are NOT resolved once-and-for-
+    # all: :func:`_resolve_target_dir` / :func:`_resolve_advertised_total` below
+    # re-attempt each tick until they succeed, then progress tracks growth.
     target_dir = _flm_install_path(host_models_dir, tag)
     advertised_total = 0
     for entry in flm_served_models():
@@ -1241,9 +1258,40 @@ async def run_flm_pull(
         assert proc.stdout is not None
         last_emit = time.monotonic()
 
+        def _resolve_target_dir() -> None:
+            """Retry the install-path probe until it resolves (see above).
+
+            A fresh pull creates ``target_dir`` from scratch, so when we
+            resolve it late its whole on-disk size IS this pull's progress —
+            baseline 0 is correct. A re-pull of a partially-present model would
+            undercount by the pre-existing bytes, a harmless display nuance
+            versus the alternative of reporting 0 for the entire download.
+            """
+            nonlocal target_dir, baseline_size
+            if target_dir:
+                return
+            resolved = _flm_install_path(host_models_dir, tag)
+            if resolved:
+                target_dir = resolved
+                baseline_size = 0
+
+        def _resolve_advertised_total() -> None:
+            """Retry the advertised-size probe so the bar shows a real total."""
+            nonlocal advertised_total
+            if advertised_total > 0:
+                return
+            for entry in flm_served_models():
+                if entry["tag"] == tag:
+                    advertised_total = int(entry.get("size_bytes") or 0)
+                    if advertised_total > job.bytes_total:
+                        job.bytes_total = advertised_total
+                    break
+
         def _tick_progress() -> None:
             """Refresh bytes_downloaded from on-disk dir size if it grew."""
             nonlocal last_emit
+            _resolve_target_dir()
+            _resolve_advertised_total()
             if not target_dir:
                 return
             now = time.monotonic()

--- a/tests/providers/test_flm_store_link.py
+++ b/tests/providers/test_flm_store_link.py
@@ -1,0 +1,117 @@
+"""Tests for ensure_host_flm_store_link (host flm pull → configured store).
+
+flm hardcodes ``$HOME/.config/flm/models`` and has no dir flag, so a host
+``flm pull`` writes there — not the (possibly relocated) ``flm_store`` the
+progress poller + serving container use. ``ensure_host_flm_store_link``
+symlinks flm's default path onto the resolved store (migrating any legacy
+content first) so the two agree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.providers import flm
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Patch flm's default path + resolved store to tmp dirs; return (default, store)."""
+    default = tmp_path / "home" / ".config" / "flm" / "models"
+    store = tmp_path / "mnt" / "flm-store"
+    monkeypatch.setattr("hal0.config.paths.default_flm_models_dir", lambda: str(default))
+    monkeypatch.setattr("hal0.config.paths.flm_models_dir", lambda: str(store))
+    return default, store
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def test_noop_when_store_is_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    same = tmp_path / ".config" / "flm" / "models"
+    monkeypatch.setattr("hal0.config.paths.default_flm_models_dir", lambda: str(same))
+    monkeypatch.setattr("hal0.config.paths.flm_models_dir", lambda: str(same))
+    out = flm.ensure_host_flm_store_link()
+    assert out == str(same)
+    # No symlink is fabricated when there is nothing to reconcile.
+    assert not same.is_symlink()
+
+
+def test_symlinks_default_to_store_when_absent(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    out = flm.ensure_host_flm_store_link()
+    assert out == str(store)
+    assert default.is_symlink()
+    assert Path(default).resolve() == store.resolve()
+
+
+def test_replaces_empty_default_dir_with_symlink(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    default.mkdir(parents=True)
+    assert default.is_dir() and not default.is_symlink()
+    flm.ensure_host_flm_store_link()
+    assert default.is_symlink()
+    assert Path(default).resolve() == store.resolve()
+
+
+def test_migrates_legacy_content_then_symlinks(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    # A previously-mispulled model dir sitting in flm's default path.
+    model = default / "Phi4-mini-Instruct-NPU2"
+    model.mkdir(parents=True)
+    (model / "model.q4nx").write_text("weights", encoding="utf-8")
+    (model / "config.json").write_text("{}", encoding="utf-8")
+
+    flm.ensure_host_flm_store_link()
+
+    # Default path is now a symlink; the weights moved into the store.
+    assert default.is_symlink()
+    assert Path(default).resolve() == store.resolve()
+    moved = store / "Phi4-mini-Instruct-NPU2" / "model.q4nx"
+    assert moved.exists()
+    assert _read(moved) == "weights"
+
+
+def test_migration_skips_collisions_and_leaves_dir(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    # Same-named model already in the store — must not be clobbered.
+    (store / "Model-NPU2").mkdir(parents=True)
+    (store / "Model-NPU2" / "keep.bin").write_text("store-copy", encoding="utf-8")
+    (default / "Model-NPU2").mkdir(parents=True)
+    (default / "Model-NPU2" / "keep.bin").write_text("home-copy", encoding="utf-8")
+
+    flm.ensure_host_flm_store_link()
+
+    # Store copy preserved; default dir left in place (not symlinked over a
+    # collision), so nothing is orphaned or lost.
+    assert _read(store / "Model-NPU2" / "keep.bin") == "store-copy"
+    assert not default.is_symlink()
+    assert (default / "Model-NPU2" / "keep.bin").exists()
+
+
+def test_repoints_stale_symlink(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    stale = store.parent / "old-store"
+    stale.mkdir(parents=True)
+    default.parent.mkdir(parents=True)
+    default.symlink_to(stale)
+
+    flm.ensure_host_flm_store_link()
+
+    assert default.is_symlink()
+    assert Path(default).resolve() == store.resolve()
+
+
+def test_idempotent_when_symlink_already_correct(stores: tuple[Path, Path]) -> None:
+    default, store = stores
+    store.mkdir(parents=True)
+    default.parent.mkdir(parents=True)
+    default.symlink_to(store)
+
+    # Second run is a clean no-op — no exception, link unchanged.
+    flm.ensure_host_flm_store_link()
+    assert default.is_symlink()
+    assert Path(default).resolve() == store.resolve()

--- a/tests/registry/test_flm_pull_progress.py
+++ b/tests/registry/test_flm_pull_progress.py
@@ -1,0 +1,91 @@
+"""Regression test for FLM pull progress recovering a transient-None target_dir.
+
+The install-path probe (``flm list``) can transiently return an empty catalog
+right at pull start, leaving ``target_dir`` None. Before the fix that killed
+progress for the whole download — the dir grew on disk but the job reported
+``0/0`` until completion. ``run_flm_pull`` now re-resolves ``target_dir`` each
+tick, so progress recovers mid-download.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hal0.registry import pull as pull_mod
+from hal0.registry.pull import PullJob, run_flm_pull
+
+# A fake "flm pull": create <host_models_dir>/Repo and grow model.bin in
+# chunks, printing an FLM-style Downloading line + flushing between writes so
+# the poller sees real on-disk growth across several ticks.
+_FAKE_PULL = """
+import os, sys, time
+target = os.path.join(sys.argv[1], "Repo")
+os.makedirs(target, exist_ok=True)
+p = os.path.join(target, "model.bin")
+with open(p, "wb") as f:
+    for i in range(5):
+        f.write(b"x" * (2 * 1024 * 1024))
+        f.flush(); os.fsync(f.fileno())
+        print(f"Downloading: {(i + 1) * 20}%", flush=True)
+        time.sleep(0.4)
+"""
+
+
+class _RecordingJob(PullJob):
+    """PullJob that snapshots (state, bytes_downloaded) on every _signal()."""
+
+    def __init__(self) -> None:
+        super().__init__(job_id="j1", model_id="fake:tag")
+        self.snapshots: list[tuple[str, int]] = []
+
+    def _signal(self) -> None:
+        self.snapshots.append((self.state, self.bytes_downloaded))
+        super()._signal()
+
+
+async def test_progress_recovers_transient_none_target_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    host_models_dir = str(tmp_path)
+    target = tmp_path / "Repo"
+
+    import hal0.capabilities.catalog as cat_mod
+    import hal0.providers.flm as flm_mod
+
+    monkeypatch.setattr(
+        flm_mod,
+        "flm_pull_command",
+        lambda tag: ([sys.executable, "-c", _FAKE_PULL, host_models_dir], host_models_dir),
+    )
+    monkeypatch.setattr(flm_mod, "ensure_host_flm_store_link", lambda: host_models_dir)
+    monkeypatch.setattr(flm_mod, "flm_host_async_spawn", lambda argv: (argv, {}))
+    monkeypatch.setattr(flm_mod, "flm_served_models", lambda: [])
+    monkeypatch.setattr(flm_mod, "reset_flm_catalog_cache", lambda: None)
+    monkeypatch.setattr(cat_mod, "reset_flm_image_present_cache", lambda: None)
+    monkeypatch.setattr(pull_mod, "_register_flm_pulled", lambda *a, **k: None)
+
+    # Simulate the transient: the probe returns None for the first two calls
+    # (pull-start + first tick), then resolves. Without the per-tick retry this
+    # would strand target_dir at None for the whole download.
+    calls = {"n": 0}
+
+    def _flaky_install_path(hmd: str, tag: str) -> str | None:
+        calls["n"] += 1
+        return None if calls["n"] <= 2 else str(target)
+
+    monkeypatch.setattr(pull_mod, "_flm_install_path", _flaky_install_path)
+
+    job = _RecordingJob()
+    registry = object()  # unused: _register_flm_pulled is stubbed
+    await run_flm_pull(job, tag="fake:tag", registry=registry)
+
+    assert job.state == "completed"
+    # The fix: at least one signal WHILE running carried non-zero bytes — i.e.
+    # progress moved mid-download, not only at completion.
+    running_progress = [b for (state, b) in job.snapshots if state == "running" and b > 0]
+    assert running_progress, f"no mid-download progress; snapshots={job.snapshots}"
+    # And it ended reporting the full on-disk size.
+    assert job.bytes_downloaded == 10 * 1024 * 1024


### PR DESCRIPTION
## Problem

FLM host pulls reported **`0 bytes / 0 MB/s` for the whole download** (they completed + registered fine). Reproduced live on a relocated-store box — two independent bugs:

### 1. Wrong write location (correctness, not just cosmetic)
flm **hardcodes `~/.config/flm/models`** with no dir flag or env override (confirmed via `flm --help`). The host `flm pull` is only given `HOME`, so on a box whose store is relocated (`[models].flm_store` / `HAL0_FLM_MODELS_DIR` → `flm_models_dir()`), it wrote weights to the default **root-fs** cache — NOT the store the progress poller watches and the serving container bind-mounts. So progress read 0 the whole pull, **and** the model was invisible to serving (a wasteful re-download on first serve).

Confirmed on box: a pull put **3.6 GB** in `/var/lib/hal0/.config/flm/models/Phi4-mini-Instruct-NPU2/` while the polled store dir stayed **empty**.

### 2. `target_dir` stranded at None (the poll target)
`_flm_install_path` (and the advertised total) come from `flm list`, which can **transiently return an empty catalog right at pull start**. `run_flm_pull` resolved `target_dir` once and never retried, so a single empty probe killed progress for the entire download — observed live: the dir grew steadily on disk (1→70→253→576→711 MB) while the job reported `0/0` the whole time. Only the completion path re-resolved, so bytes jumped to full at the end.

## Fix

- **`ensure_host_flm_store_link()`** (providers/flm.py): symlinks flm's hardcoded default path onto the resolved store — the host analog of the container's bind-mount — before the pull. Best-effort migrates any legacy/mispulled content into the store first (never clobbering existing store files), then symlinks. Idempotent; a no-op when the store IS the default. Called from `run_flm_pull` via `asyncio.to_thread` (the one-time migration can copy multi-GB weights, so it must not block the loop).
- **Per-tick re-resolve** (registry/pull.py): `_resolve_target_dir` / `_resolve_advertised_total` retry each tick until they succeed, then progress tracks on-disk growth. A transient start-time probe failure now self-heals instead of stranding the whole download at 0.

## Verification (live on box + unit)

- **lsof proof** of the write-location fix: `flm pull gemma3:4b` writes `model.q4nx` straight into the store `/mnt/ai-models/.../Gemma3-4B-NPU2/` via the symlink.
- Reproduced bug #2 on the pre-fix (== `origin/main`) code: 30 s download, disk climbing, job stuck `0/0`. Post-fix the advertised total resolves live (`running 0MB/8000MB`, previously `0/0`).
- `tests/providers/test_flm_store_link.py` — symlink / migrate-legacy / skip-collision / repoint-stale / idempotent (7 cases).
- `tests/registry/test_flm_pull_progress.py` — progress recovers a transient-None `target_dir` mid-download (the old one-shot resolve fails this assertion).
- `tests/registry/` + `tests/providers/test_flm*.py`: 260 passed.

## Note (out of scope)

Diagnosis surfaced a **pre-existing** config inconsistency on the test box: the API's `HAL0_FLM_MODELS_DIR` env (`/mnt/ai-models/flm/models`) overrides `[models].flm_store` in the toml (`/mnt/ai-models/FLM`), so two store dirs exist. This fix correctly follows `flm_models_dir()` (env > toml > default) everywhere; reconciling the env-vs-toml split is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)