### PR TITLE
test(e2e): fix γ gate — follow container controls into the ComfyUI card header

### DIFF
--- a/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
+++ b/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
@@ -192,8 +192,9 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
   })
 
   // ── 6. Restart button fires POST /api/comfyui/restart ────────────────────
+  // Container controls moved from the footer into the card header (#1209).
 
-  test('footer Restart button fires POST /restart', async ({ page }) => {
+  test('header Restart button fires POST /restart', async ({ page }) => {
     const posts: string[] = []
     await page.route('**/api/comfyui/status', (route: any) => json(route, comfyV2Status()))
     await page.route('**/api/comfyui/restart', (route: any) => {
@@ -203,7 +204,7 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
 
     await gotoImageTab(page)
 
-    const restartBtn = page.locator('.comfy-v2-pane .wfoot .sctrl.restart')
+    const restartBtn = page.locator('.comfy-v2-pane .wcard-h .sctrl.restart')
     await expect(restartBtn).toBeVisible()
     await restartBtn.click()
 

--- a/ui/tests/e2e/specs/imagegen-v2.spec.ts
+++ b/ui/tests/e2e/specs/imagegen-v2.spec.ts
@@ -177,8 +177,10 @@ test.describe('ImageGen V2 render-hero pane', () => {
     await expect(pane.locator('.inv-pill').first()).toContainText('6')
   })
 
-  // ── 6. Container footer ─────────────────────────────────────────────────
-  test('footer: container identity + controls render', async ({ page }) => {
+  // ── 6. Container footer + header controls ────────────────────────────────
+  // #1209 moved the stop/restart/logs controls from the footer up into the
+  // card header's far right; the container identity row stays in the footer.
+  test('footer identity + header controls render', async ({ page }) => {
     await gotoImageTab(page)
     const pane = page.locator('.comfy-v2-pane')
 
@@ -186,9 +188,10 @@ test.describe('ImageGen V2 render-hero pane', () => {
     await expect(foot).toBeVisible()
     await expect(foot).toContainText('comfyui')
     await expect(foot).toContainText(':8188')
-    // stop, restart, logs controls
-    await expect(foot.locator('.sctrl.stop')).toBeVisible()
-    await expect(foot.locator('.sctrl.restart')).toBeVisible()
+    // stop, restart controls — now in the header far right
+    const head = pane.locator('.wcard-h')
+    await expect(head.locator('.sctrl.stop')).toBeVisible()
+    await expect(head.locator('.sctrl.restart')).toBeVisible()
   })
 
   // ── 7. Empty-queue state: NO click-blocking overlay ─────────────────────


### PR DESCRIPTION
The γ-suite has been red on `main` since #1209 merged: that PR (intentionally) moved the image-gen pane's stop/restart/logs controls from the card footer into the header far right (`.wcard-h .foot-ctrls`), keeping only the container-identity row in `.wfoot` — but two specs still asserted footer controls:

- `comfyui-arbiter-v3.spec.ts` › *footer Restart button fires POST /restart*
- `imagegen-v2.spec.ts` › *footer: container identity + controls render*

This repoints both at the header (identity assertions on `.wfoot` unchanged). Both spec files pass locally: 18/18 chromium.

This red gate is currently failing every PR's γ check, including #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)