### PR TITLE
feat(doctor): FLM/migration/profile audits + --force delete for seeded slots

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -257,12 +257,16 @@ The config path honours `HAL0_HOME`; under FHS it is `/etc/hal0/hal0.toml`.
 | `doctor` | Re-run the installer's preflight battery (systemd, python, container runtime, disk, ports). | `--plain`, `--ports "8080 3001"` |
 | `doctor toolbox-pull` | Verify each pinned toolbox image is anonymously pullable from ghcr.io. | `--json`, `--manifest` |
 | `doctor perms` | Audit ownership for the editable-checkout root-clobber regression (group-share drift). | `--fix` (repair in place; needs root) |
-| `doctor models` | Audit the model pipeline: registry entries whose file is gone, unregistered files in the store, FLM/NPU store dir presence + container-uid writability. | — |
+| `doctor models` | Audit the model pipeline: registry entries whose file is gone, unregistered files in the store, FLM/NPU store dir presence + container-uid writability, env-vs-TOML store divergence, and an unmounted external store path. | `--fix` (repair FLM store ownership/mode; needs root) |
+| `doctor migrations` | Surface a pending v0.1→v0.2 model-layout migration (dry-run of the symlink planner; points at `hal0 migrate model-layout --apply`). | — |
+| `doctor profiles` | Audit the slot↔profile layer: slots referencing a missing profile (fails), and in-use profile images not pulled locally (advisory). | — |
 
 `hal0 doctor` shells out to `installer/lib/preflight.sh` and preserves its exit
 code. `doctor toolbox-pull` exits `0` when every image is reachable (digest
 drift is reported but does not fail), `1` if any image is unreachable, and `2`
-when the manifest has no toolbox images.
+when the manifest has no toolbox images. `doctor models` exits `1` on any
+actionable finding; `doctor migrations` exits `1` when links are pending;
+`doctor profiles` exits `1` only when a slot references a missing profile.
 
 ## `hal0 capabilities` — capability-slot repair
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1044,17 +1044,18 @@ async def _safe_config(sm: Any, name: str) -> dict[str, Any] | None:
 
 
 @router.delete("/{name}")
-async def delete_slot(name: str, request: Request) -> dict[str, object]:
+async def delete_slot(name: str, request: Request, force: bool = False) -> dict[str, object]:
     """Delete a slot. If the slot is running, it is stopped first.
 
-    Built-in slots (primary/embed/stt/tts) cannot be deleted — the
-    SlotManager raises a typed error which the envelope middleware
-    surfaces as 4xx.
+    Built-in (seeded) slots — primary/embed/stt/tts + the NPU trio — are
+    protected: the SlotManager raises a typed error the envelope middleware
+    surfaces as 4xx. Pass ``?force=true`` to delete a seeded slot anyway (an
+    install/update reconcile may re-seed it later).
     """
     sm = _get_slot_manager(request)
     async with record_action(request, category="slot", action="slot.delete", target=name):
-        await sm.delete(name)
-    return {"name": name, "deleted": True}
+        await sm.delete(name, force=force)
+    return {"name": name, "deleted": True, "forced": force}
 
 
 @router.get("/{name}/config")

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -26,6 +26,7 @@ Sub-commands:
 
 from __future__ import annotations
 
+import contextlib
 import grp
 import os
 import pwd
@@ -706,11 +707,149 @@ def perms(
     raise typer.Exit(0)
 
 
+# ── hal0 doctor models — FLM (NPU) store pure helpers ─────────────────────────
+#
+# The FLM store is the single most reboot-fragile surface on the box: the NPU
+# slot bind-mounts it, and a missing / non-writable / not-yet-mounted source
+# makes podman exit 125 ("statfs ... no such file or directory") — a silent,
+# post-reboot slot death. These three pure classifiers cover the incident modes
+# the old inline check missed, and feed a root-gated ``--fix``.
+
+# uid the FLM toolbox container runs as — fixed by the image (mirror of
+# hal0.providers.flm._FLM_CONTAINER_UID; kept local to avoid importing the
+# provider, which pulls in podman spec machinery, into the CLI path).
+_FLM_CONTAINER_UID = 1000
+# Path prefixes that almost always denote an external mount (an off-root
+# filesystem). A store here that isn't backed by a live mount is the classic
+# "NPU slot exits 125 after reboot because /mnt wasn't up yet" trap.
+_EXTERNAL_MOUNT_PREFIXES = ("/mnt/", "/srv/", "/media/")
+
+
+def flm_store_divergence(env_val: str | None, toml_val: str | None) -> dict[str, str] | None:
+    """Warn when the env var and the TOML field name *different* FLM stores.
+
+    ``HAL0_FLM_MODELS_DIR`` wins over ``[models].flm_store`` (see
+    :func:`hal0.config.paths.flm_models_dir`), so an operator who relocates the
+    store by editing hal0.toml while a stale env var is still exported gets a
+    silently-ignored edit — pulls land in one dir, the slot mounts the other,
+    and every model reports installed=False. Returns a row only on genuine
+    disagreement; equal values or either side unset is fine.
+    """
+    env = (env_val or "").strip().rstrip("/")
+    toml = (toml_val or "").strip().rstrip("/")
+    if env and toml and env != toml:
+        return {
+            "status": "warn",
+            "detail": (
+                f"HAL0_FLM_MODELS_DIR={env} overrides [models].flm_store={toml} — "
+                f"the env var wins; unset it or align the TOML to avoid a split store."
+            ),
+        }
+    return None
+
+
+def _deepest_mountpoint(path: Path, *, ismount: Callable[[str], bool]) -> str:
+    """Return the deepest ancestor of ``path`` (incl. itself) that is a mountpoint.
+
+    Falls back to ``/`` which is always a mountpoint — so a store sitting on the
+    root filesystem resolves here to ``/``.
+    """
+    for cand in (path, *path.parents):
+        if ismount(str(cand)):
+            return str(cand)
+    return "/"
+
+
+def flm_mount_guard(
+    store: Path,
+    *,
+    ismount: Callable[[str], bool] = os.path.ismount,
+) -> dict[str, str] | None:
+    """Warn when the store lives under an external mount prefix that isn't mounted.
+
+    Matches the documented reboot failure: the store is configured under
+    ``/mnt/...`` (an off-root disk) but nothing along that path is a live
+    mountpoint, so the directory is either absent or an empty stub on the root
+    filesystem. At the next NPU slot start podman bind-mounts a phantom source
+    and dies with exit 125. Advisory (warn), because a deliberate on-root
+    ``/mnt`` dir is legal, just unusual.
+    """
+    s = str(store).rstrip("/")
+    if not any(s.startswith(p) for p in _EXTERNAL_MOUNT_PREFIXES):
+        return None
+    if _deepest_mountpoint(store, ismount=ismount) != "/":
+        return None  # a real mount backs the path — all good
+    return {
+        "status": "warn",
+        "detail": (
+            f"{s} is under an external mount path that is not mounted — the NPU slot "
+            f"will exit 125 at boot until it is up. Order the slot after the mount "
+            f"(systemd RequiresMountsFor=) or move the store onto the root fs."
+        ),
+    }
+
+
+def flm_store_writability(
+    store: Path,
+    *,
+    stat_of: Callable[[Path], os.stat_result],
+) -> dict[str, object] | None:
+    """Classify FLM-store writability for the container uid; ``None`` when fine.
+
+    The container runs as uid 1000 (image-fixed, not the host hal0 uid). The
+    store is writable for it when owned by 1000 *or* group/other-writable. When
+    neither holds, returns a row carrying the repair target so ``--fix`` can
+    apply ``chown 1000:hal0`` + ``chmod 2775`` without re-deriving it.
+    """
+    st = stat_of(store)
+    world_or_group_w = bool(st.st_mode & 0o020) or bool(st.st_mode & 0o002)
+    if st.st_uid == _FLM_CONTAINER_UID or world_or_group_w:
+        return None
+    return {
+        "status": "fail",
+        "uid": st.st_uid,
+        "mode": st.st_mode & 0o7777,
+        "detail": (
+            f"not writable by the FLM container uid ({_FLM_CONTAINER_UID}): "
+            f"owner uid {st.st_uid}, mode {oct(st.st_mode & 0o7777)}"
+        ),
+    }
+
+
+def repair_flm_store(
+    store: Path,
+    *,
+    group: str = "hal0",
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> tuple[bool, str]:
+    """Apply ``chown {uid}:{group}`` + ``chmod 2775`` to the FLM store (needs root).
+
+    Idempotent and matches the guidance the audit prints. Returns ``(ok, msg)``;
+    the first failing step short-circuits with its stderr.
+    """
+    steps = (
+        (["chown", f"{_FLM_CONTAINER_UID}:{group}", str(store)], "chown"),
+        (["chmod", "2775", str(store)], "chmod 2775"),
+    )
+    for argv, label in steps:
+        proc = run(argv, capture_output=True, text=True)
+        if proc.returncode != 0:
+            detail = (proc.stderr or "").strip() or f"exit {proc.returncode}"
+            return False, f"{label} failed: {detail}"
+    return True, f"FLM store {store} → uid {_FLM_CONTAINER_UID}:{group} mode 2775"
+
+
 # ── hal0 doctor models ────────────────────────────────────────────────────────
 
 
 @app.command("models")
-def doctor_models() -> None:
+def doctor_models(
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help="Repair FLM store ownership/mode drift in place (needs root).",
+    ),
+) -> None:
     """Audit the model pipeline: registry paths, store/roots agreement, FLM dir.
 
     Catches the classic install failures in one pass:
@@ -721,8 +860,13 @@ def doctor_models() -> None:
         (pull_root/store not scanned on older installs)
       * an FLM (NPU) store dir that is missing or not writable by the
         container uid (podman exit 125 statfs after a reboot)
+      * an FLM store split between HAL0_FLM_MODELS_DIR and [models].flm_store
+        (the env var silently wins — pulls and the slot mount diverge)
+      * an FLM store under an external mount (/mnt/...) that isn't mounted
+        (the classic post-reboot exit-125 before the disk is up)
 
-    Exits non-zero when anything actionable is found.
+    ``--fix`` repairs FLM store ownership/mode drift in place (chown 1000:hal0,
+    chmod 2775 — needs root). Exits non-zero when anything actionable is found.
     """
     from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get
     from hal0.config import paths as cfg_paths
@@ -790,24 +934,314 @@ def doctor_models() -> None:
                 console.print(f"      {f}")
         console.print(f"[dim]store: {effective}  ·  scan roots: {', '.join(scan_roots)}[/dim]")
 
-    # 3. FLM (NPU) store: exists + writable by the container uid (1000).
+    # 3a. FLM store divergence: env var silently overriding the TOML field.
+    env_flm = os.environ.get("HAL0_FLM_MODELS_DIR")
+    toml_flm = None
+    with contextlib.suppress(Exception):  # already surfaced under step 2's hal0.toml read
+        toml_flm = load_hal0_config().models.flm_store
+    divergence = flm_store_divergence(env_flm, toml_flm)
+    if divergence:
+        problems += 1
+        console.print(f"[yellow]![/yellow]  {divergence['detail']}")
+
+    # 3b. FLM (NPU) store: mount-backed, exists, writable by the container uid.
     flm_dir = Path(cfg_paths.flm_models_dir())
+    mount_warn = flm_mount_guard(flm_dir)
+    if mount_warn:
+        problems += 1
+        console.print(f"[yellow]![/yellow]  {mount_warn['detail']}")
+
     if flm_dir.exists():
-        st = flm_dir.stat()
-        world_or_group_w = bool(st.st_mode & 0o020) or bool(st.st_mode & 0o002)
-        if st.st_uid != 1000 and not world_or_group_w:
+        writ = flm_store_writability(flm_dir, stat_of=lambda p: p.stat())
+        if writ is None:
+            console.print(f"[green]✓[/green]  FLM store {flm_dir} present.")
+        elif fix:
+            if os.geteuid() != 0:
+                problems += 1
+                console.print(
+                    f"[red]✗[/red]  FLM store {flm_dir}: {writ['detail']}\n"
+                    "      --fix needs root — re-run `sudo hal0 doctor models --fix`."
+                )
+            else:
+                ok, msg = repair_flm_store(flm_dir)
+                if ok:
+                    console.print(f"[green]✓[/green]  repaired {msg}")
+                else:
+                    problems += 1
+                    console.print(f"[red]✗[/red]  repair failed: {msg}")
+        else:
             problems += 1
             console.print(
-                f"[yellow]![/yellow]  FLM store {flm_dir} is not writable by the FLM "
-                f"container uid (1000): owner uid {st.st_uid}, mode {oct(st.st_mode & 0o7777)}.\n"
-                f"      Fix: sudo chown 1000:hal0 {flm_dir} && sudo chmod 2775 {flm_dir}"
+                f"[yellow]![/yellow]  FLM store {flm_dir} {writ['detail']}.\n"
+                "      Fix: sudo hal0 doctor models --fix   "
+                f"(chown {_FLM_CONTAINER_UID}:hal0 + chmod 2775)"
             )
-        else:
-            console.print(f"[green]✓[/green]  FLM store {flm_dir} present.")
-    else:
+    elif not mount_warn:
         console.print(
             f"[dim]FLM store {flm_dir} absent (fine unless you use the NPU slot — "
             f"it is created on the next NPU slot start).[/dim]"
         )
 
     raise typer.Exit(1 if problems else 0)
+
+
+# ── hal0 doctor migrations ────────────────────────────────────────────────────
+
+
+def pending_layout_migration() -> tuple[int, int] | None:
+    """Dry-run the v0.1→v0.2 model-layout migration; return ``(create, overwrite)``.
+
+    Returns the count of symlinks the migration *would* write (``create`` +
+    ``would-overwrite`` kinds), or ``None`` when the migration machinery can't be
+    consulted at all (e.g. running from a build with no migrate module). A box
+    that is already on the canonical layout — or a fresh install with no v0.1.x
+    store — yields ``(0, 0)``: nothing pending. Never raises; a missing store or
+    registry degrades to an empty plan inside ``plan_migration``.
+    """
+    try:
+        from hal0.cli.migrate_commands import (
+            DEFAULT_CANONICAL_ROOT,
+            DEFAULT_MOUNT_ROOT,
+            DEFAULT_REGISTRY_PATH,
+            plan_migration,
+        )
+    except ImportError:
+        return None
+    try:
+        report = plan_migration(
+            registry_path=DEFAULT_REGISTRY_PATH,
+            mount_root=DEFAULT_MOUNT_ROOT,
+            canonical_root=DEFAULT_CANONICAL_ROOT,
+            force=False,
+        )
+    except Exception:
+        return None
+    create = sum(1 for a in report.actions if a.kind == "create")
+    overwrite = sum(1 for a in report.actions if a.kind == "would-overwrite")
+    return (create, overwrite)
+
+
+@app.command("migrations")
+def doctor_migrations() -> None:
+    """Surface a pending v0.1→v0.2 model-layout migration (read-only).
+
+    The canonical ``<recipe>/<capability>/`` symlink farm is populated by
+    ``hal0 migrate model-layout --apply``, but nothing tells an upgrading
+    operator it's outstanding — so slots that expect the canonical paths quietly
+    find nothing. This dry-runs the same planner and reports how many links are
+    missing, pointing at the apply command. It never writes.
+
+    Exit codes:
+      0 — up to date (or nothing to migrate).
+      1 — links are pending (advisory; run the apply command to reconcile).
+    """
+    pending = pending_layout_migration()
+    if pending is None:
+        console.print("[dim]model-layout migration: planner unavailable — skipped.[/dim]")
+        raise typer.Exit(0)
+    create, overwrite = pending
+    if not create and not overwrite:
+        console.print("[green]✓[/green]  model layout is current — no migration pending.")
+        raise typer.Exit(0)
+    detail = f"{create} link(s) to create"
+    if overwrite:
+        detail += f", {overwrite} to overwrite (needs --force)"
+    console.print(
+        f"[yellow]![/yellow]  model-layout migration pending: {detail}.\n"
+        "      Preview: hal0 migrate model-layout        (dry-run)\n"
+        "      Apply:   hal0 migrate model-layout --apply"
+    )
+    raise typer.Exit(1)
+
+
+# ── hal0 doctor profiles — the slot↔profile referential + fitness layer ────────
+#
+# Profiles sit between a slot and the runtime image/backend. Nothing validates
+# that layer until a slot actually *starts* (resolve_slot_profile raises
+# KeyError late, on the start path), so a dangling reference or an un-pulled
+# image is invisible to an operator staring at a "degraded" slot. These pure
+# classifiers surface it up front. Check 1 (broken refs) is the hard failure;
+# check 2 (image-present) is advisory.
+
+
+def check_slot_profile_refs(
+    slot_profiles: list[tuple[str, str | None]],
+    valid_names: set[str],
+) -> list[dict[str, str]]:
+    """Flag slots whose ``profile = "..."`` names a profile not in the catalog.
+
+    ``resolve_slot_profile`` raises ``KeyError`` for a missing name only when the
+    slot starts — so a renamed/deleted profile is a latent slot-start failure.
+    A slot with ``profile = None`` (base-image resolution) is legal and skipped.
+    Returns one row per slot: ``ok`` when the reference resolves, ``drift`` when
+    it dangles.
+    """
+    rows: list[dict[str, str]] = []
+    for slot, profile in slot_profiles:
+        if not profile:
+            continue  # base-image slot — no profile to resolve
+        if profile in valid_names:
+            rows.append(
+                {"label": slot, "status": "ok", "detail": f"→ {profile}"},
+            )
+        else:
+            rows.append(
+                {
+                    "label": slot,
+                    "status": "drift",
+                    "detail": (
+                        f"references missing profile {profile!r} — the slot will fail "
+                        f"to start (KeyError). Repoint it: hal0 slot edit {slot} "
+                        f"--profile <name>, or recreate {profile!r}."
+                    ),
+                },
+            )
+    return rows
+
+
+def _image_repo(ref: str) -> str:
+    """Strip the tag/digest → the bare ``registry/repo`` of an image ref."""
+    body = ref.split("@", 1)[0]  # drop @sha256:... digest
+    # A ':' after the last '/' is a tag; a ':' inside the host part is a port.
+    head, _, tail = body.rpartition("/")
+    tail = tail.split(":", 1)[0]
+    return f"{head}/{tail}" if head else tail
+
+
+def check_profile_images_present(
+    profiles: list[Any],
+    local_repos: set[str] | None,
+) -> list[dict[str, str]]:
+    """Warn when an *in-use* profile's image repo isn't present locally.
+
+    ``local_repos`` is the set of ``registry/repo`` strings from ``podman
+    images`` (tag-insensitive to avoid false alarms on a re-pinned tag), or
+    ``None`` when podman couldn't be queried — in which case the whole check is
+    skipped (no rows). Only profiles referenced by a slot are checked: an unused
+    profile whose image was never pulled is not a live problem.
+    """
+    if local_repos is None:
+        return []
+    rows: list[dict[str, str]] = []
+    for p in profiles:
+        if not getattr(p, "used_by", ()) or not getattr(p, "image", ""):
+            continue
+        repo = _image_repo(p.image)
+        if repo in local_repos:
+            rows.append({"label": p.name, "status": "ok", "detail": f"image {repo} present"})
+        else:
+            rows.append(
+                {
+                    "label": p.name,
+                    "status": "warn",
+                    "detail": (
+                        f"image repo {repo} not pulled (used by "
+                        f"{', '.join(p.used_by)}) — first slot start will pull it, "
+                        f"or pre-pull: podman pull {p.image}"
+                    ),
+                },
+            )
+    return rows
+
+
+def _local_image_repos() -> set[str] | None:
+    """Query ``podman images`` for the set of local ``registry/repo`` strings.
+
+    Returns ``None`` (→ image check skipped) when podman is absent or errors, so
+    a box without podman never gets spurious "not pulled" rows.
+    """
+    podman = shutil.which("podman")
+    if podman is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [podman, "images", "--format", "{{.Repository}}"],
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip() and line != "<none>"}
+
+
+def _render_profiles(title: str, rows: list[dict[str, str]]) -> None:
+    """Print profile audit rows with an ok/warn/drift badge, drift/warn detailed."""
+    badge = {
+        "ok": "[green]ok[/green]",
+        "warn": "[yellow]warn[/yellow]",
+        "drift": "[red]DRIFT[/red]",
+    }
+    console.print(f"\n[bold]{title}[/bold]")
+    if not rows:
+        console.print("  [dim](nothing to check)[/dim]")
+        return
+    for r in rows:
+        # ``ok`` rows stay terse; warn/drift carry the actionable detail.
+        if r["status"] == "ok":
+            console.print(f"  {badge['ok']}  {r['label']}  [dim]{r['detail']}[/dim]")
+        else:
+            console.print(f"  {badge[r['status']]}  {r['label']} — {r['detail']}")
+
+
+@app.command("profiles")
+def doctor_profiles() -> None:
+    """Audit the slot↔profile layer: dangling references + un-pulled images.
+
+    Two checks, surfaced before a slot has to fail on start:
+
+      * broken refs — a slot's ``profile = "..."`` names a profile that no longer
+        exists (the slot dies with KeyError at start). This is the only failing
+        check.
+      * image present — an in-use profile's toolbox image isn't pulled locally
+        (advisory; the first slot start pulls it).
+
+    Exit codes:
+      0 — no broken references (advisory warnings may still be printed).
+      1 — at least one slot references a missing profile.
+    """
+    try:
+        from hal0.config.loader import list_slots, load_slot_config
+        from hal0.profiles import ProfileCatalog
+    except ImportError as exc:  # pragma: no cover — profile layer always present
+        console.print(f"[red]✗[/red]  profile layer unavailable: {exc}")
+        raise typer.Exit(2) from exc
+
+    catalog = ProfileCatalog()
+    try:
+        profiles = catalog.list()
+    except Exception as exc:
+        console.print(f"[red]✗[/red]  could not read the profile catalog: {exc}")
+        raise typer.Exit(2) from exc
+    valid_names = {p.name for p in profiles}
+
+    # Scan slots → (slot, profile_name) here (not via the catalog's private
+    # helper) so a malformed slot is surfaced, not silently skipped.
+    slot_profiles: list[tuple[str, str | None]] = []
+    for slot_name in list_slots():
+        try:
+            cfg = load_slot_config(slot_name)
+        except Exception as exc:
+            console.print(
+                f"[yellow]![/yellow]  slot {slot_name}: unreadable TOML ({exc}) — skipped."
+            )
+            continue
+        slot_profiles.append((slot_name, cfg.profile))
+
+    ref_rows = check_slot_profile_refs(slot_profiles, valid_names)
+    img_rows = check_profile_images_present(profiles, _local_image_repos())
+
+    _render_profiles("Slot → profile references", ref_rows)
+    _render_profiles("Profile images (in-use)", img_rows)
+
+    broken = [r for r in ref_rows if r["status"] == "drift"]
+    if broken:
+        console.print(
+            f"\n[red]✗[/red]  {len(broken)} slot(s) reference a missing profile — "
+            "fix before those slots can start."
+        )
+        raise typer.Exit(1)
+    console.print("\n[green]✓[/green]  every slot resolves to a real profile.")
+    raise typer.Exit(0)

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -576,7 +576,12 @@ def slot_delete(
     name: str = typer.Argument(..., help="Slot name to delete"),
     force: bool = typer.Option(False, "--force", "-f"),
 ) -> None:
-    """Delete a slot (DELETE /api/slots/{name})."""
+    """Delete a slot (DELETE /api/slots/{name}).
+
+    ``--force`` skips the confirm prompt AND deletes a seeded slot
+    (primary/embed/stt/tts + the NPU trio), which is otherwise protected. A
+    seeded slot may be re-seeded by a later install/update reconcile.
+    """
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
@@ -586,7 +591,8 @@ def slot_delete(
             abort=True,
         )
     try:
-        api_delete(f"/api/slots/{name}")
+        # ``force`` also bypasses the server-side seeded-slot guard.
+        api_delete(f"/api/slots/{name}", params={"force": "true"} if force else None)
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -280,9 +280,15 @@ class ProfileCatalog:
 
     def _guard_custom(self, name: str) -> None:
         if name in SEED_PROFILES:
+            # Seed profiles are VIRTUAL — overlaid from SEED_PROFILES in code on
+            # every load (see loader.load_profiles_config), so there is nowhere on
+            # disk to record a deletion: a force-delete would reappear on the next
+            # load. There is deliberately no --force here; clone to customise, or
+            # disable the slot that uses it via capabilities.toml.
             raise Conflict(
-                f"profile {name!r} is a seed profile — seed profiles are immutable; "
-                "clone under a new name",
+                f"profile {name!r} is a seed profile — seeds are virtual (re-applied "
+                "from code on every load) and cannot be deleted or edited; clone it "
+                "under a new name to customise, or disable the slot in capabilities.toml.",
                 code="profiles.seed_immutable",
                 details={"profile": name},
             )

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1928,13 +1928,21 @@ class SlotManager:
             )
         return await self.status(slot_name)
 
-    async def delete(self, slot_name: str) -> None:
-        """Delete a dynamic slot. Seeded slots cannot be deleted."""
+    async def delete(self, slot_name: str, *, force: bool = False) -> None:
+        """Delete a slot. Seeded slots are protected unless ``force=True``.
+
+        A seeded slot (``primary`` / ``embed`` / … + the NPU trio) is normally
+        undeletable — disable it via ``capabilities.toml`` instead. ``force``
+        overrides that guard so an operator can remove a seeded slot outright;
+        note an install/update reconcile may re-seed it later, and the name stays
+        reserved (``create`` still rejects it) until then.
+        """
         slot_name = self._resolve_alias(slot_name)
-        if slot_name in self.seeded_slots():
+        if slot_name in self.seeded_slots() and not force:
             raise SlotConfigError(
-                f"cannot delete seeded slot {slot_name!r}",
-                details={"slot": slot_name},
+                f"cannot delete seeded slot {slot_name!r} — disable it via "
+                "capabilities.toml, or pass force to delete it anyway",
+                details={"slot": slot_name, "seeded": True},
             )
         self._ensure_known(slot_name)
         # Make sure it's stopped first.

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -469,6 +469,26 @@ def test_disable_offline_slot_does_not_unload(
     )
 
 
+def test_delete_forwards_force_query_param(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """DELETE ?force=true binds + forwards to the manager and echoes ``forced``.
+
+    'chat' is a non-seeded slot, so it deletes with or without force — this
+    covers the query-param wiring; the seeded-guard bypass itself is unit-tested
+    on SlotManager.delete.
+    """
+    r = isolated_client.delete("/api/slots/chat?force=true")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["deleted"] is True
+    assert body["forced"] is True
+    # The config is gone; a follow-up GET 404s.
+    assert isolated_client.get("/api/slots/chat/config").status_code == 404
+
+
 def test_invalid_enable_surfaces_conflict(
     tmp_hal0_home: str,
     container_stub: dict[str, Any],

--- a/tests/cli/test_doctor_models.py
+++ b/tests/cli/test_doctor_models.py
@@ -1,0 +1,171 @@
+"""Tests for the FLM (NPU) store audit helpers behind ``hal0 doctor models``.
+
+These are the pure classifiers + repair seam that harden the single most
+reboot-fragile surface on the box (the FLM store the NPU slot bind-mounts).
+They are unit-tested directly — no live API, no real privileged filesystem —
+because each maps to a documented install/reboot incident:
+
+  * ``flm_store_divergence`` — env var silently overriding the TOML field.
+  * ``flm_mount_guard``      — store under an unmounted /mnt path (exit 125).
+  * ``flm_store_writability``— store not writable by the container uid (1000).
+  * ``repair_flm_store``     — the ``--fix`` chown/chmod, first-failure-wins.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hal0.cli.doctor_commands import (
+    _FLM_CONTAINER_UID,
+    flm_mount_guard,
+    flm_store_divergence,
+    flm_store_writability,
+    repair_flm_store,
+)
+
+
+class _Stat:
+    """Minimal os.stat_result stand-in — only st_uid / st_mode are read."""
+
+    def __init__(self, uid: int, mode: int) -> None:
+        self.st_uid = uid
+        self.st_mode = mode
+
+
+# ── flm_store_divergence ──────────────────────────────────────────────────────
+
+
+def test_divergence_flags_conflicting_env_and_toml() -> None:
+    row = flm_store_divergence("/mnt/ai-models/flm/models", "/var/lib/hal0/.config/flm/models")
+    assert row is not None
+    assert row["status"] == "warn"
+    assert "HAL0_FLM_MODELS_DIR" in row["detail"]
+
+
+def test_divergence_ignores_trailing_slash_only_difference() -> None:
+    assert flm_store_divergence("/mnt/store/", "/mnt/store") is None
+
+
+def test_divergence_none_when_either_side_unset() -> None:
+    assert flm_store_divergence(None, "/mnt/store") is None
+    assert flm_store_divergence("/mnt/store", None) is None
+    assert flm_store_divergence("", "") is None
+
+
+# ── flm_mount_guard ───────────────────────────────────────────────────────────
+
+
+def test_mount_guard_warns_when_external_path_not_mounted() -> None:
+    # Nothing along /mnt/ai-models/... is a mountpoint → deepest is "/".
+    row = flm_mount_guard(Path("/mnt/ai-models/flm/models"), ismount=lambda _p: False)
+    assert row is not None
+    assert row["status"] == "warn"
+    assert "exit 125" in row["detail"]
+
+
+def test_mount_guard_ok_when_external_path_is_mounted() -> None:
+    # The mount root is live → no warning.
+    def ismount(p: str) -> bool:
+        return p == "/mnt/ai-models"
+
+    assert flm_mount_guard(Path("/mnt/ai-models/flm/models"), ismount=ismount) is None
+
+
+def test_mount_guard_ignores_on_root_store() -> None:
+    # A store on the root fs is not an external-mount concern.
+    assert (
+        flm_mount_guard(Path("/var/lib/hal0/.config/flm/models"), ismount=lambda _p: False) is None
+    )
+
+
+# ── flm_store_writability ─────────────────────────────────────────────────────
+
+
+def test_writability_ok_when_owned_by_container_uid() -> None:
+    assert (
+        flm_store_writability(Path("/x"), stat_of=lambda _p: _Stat(_FLM_CONTAINER_UID, 0o700))
+        is None
+    )
+
+
+def test_writability_ok_when_group_writable() -> None:
+    # Owned by a different uid but group-writable (2775) is fine for the group member.
+    assert flm_store_writability(Path("/x"), stat_of=lambda _p: _Stat(0, 0o2775)) is None
+
+
+def test_writability_fails_when_not_writable_and_carries_repair_target() -> None:
+    row = flm_store_writability(Path("/x"), stat_of=lambda _p: _Stat(0, 0o755))
+    assert row is not None
+    assert row["status"] == "fail"
+    assert row["uid"] == 0
+    assert row["mode"] == 0o755
+
+
+# ── repair_flm_store ──────────────────────────────────────────────────────────
+
+
+def test_repair_runs_chown_then_chmod_and_reports_ok() -> None:
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **_kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    ok, msg = repair_flm_store(Path("/srv/flm"), run=run)
+    assert ok
+    assert calls[0][:2] == ["chown", f"{_FLM_CONTAINER_UID}:hal0"]
+    assert calls[1][:2] == ["chmod", "2775"]
+    assert "/srv/flm" in msg
+
+
+def test_repair_short_circuits_on_first_failure() -> None:
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **_kw: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 1, "", "chown: operation not permitted")
+
+    ok, msg = repair_flm_store(Path("/srv/flm"), run=run)
+    assert not ok
+    assert "chown failed" in msg
+    assert "operation not permitted" in msg
+    assert len(calls) == 1  # chmod never attempted
+
+
+# ── doctor migrations (pending_layout_migration) ──────────────────────────────
+
+
+def test_pending_migration_reports_create_counts(monkeypatch) -> None:
+    import hal0.cli.migrate_commands as mig
+    from hal0.cli.doctor_commands import pending_layout_migration
+
+    report = mig.MigrationReport(
+        actions=[
+            mig.SymlinkAction("create", Path("/a"), Path("/t1"), "registry:x"),
+            mig.SymlinkAction("create", Path("/b"), Path("/t2"), "registry:y"),
+            mig.SymlinkAction("would-overwrite", Path("/c"), Path("/t3"), "registry:z"),
+            mig.SymlinkAction("skip-exists", Path("/d"), Path("/t4"), "registry:w"),
+        ]
+    )
+    monkeypatch.setattr(mig, "plan_migration", lambda **_kw: report)
+    assert pending_layout_migration() == (2, 1)
+
+
+def test_pending_migration_zero_on_current_layout(monkeypatch) -> None:
+    import hal0.cli.migrate_commands as mig
+    from hal0.cli.doctor_commands import pending_layout_migration
+
+    monkeypatch.setattr(mig, "plan_migration", lambda **_kw: mig.MigrationReport())
+    assert pending_layout_migration() == (0, 0)
+
+
+def test_pending_migration_none_when_planner_raises(monkeypatch) -> None:
+    import hal0.cli.migrate_commands as mig
+    from hal0.cli.doctor_commands import pending_layout_migration
+
+    def boom(**_kw: object) -> object:
+        raise RuntimeError("registry unreadable")
+
+    monkeypatch.setattr(mig, "plan_migration", boom)
+    assert pending_layout_migration() is None

--- a/tests/cli/test_doctor_profiles.py
+++ b/tests/cli/test_doctor_profiles.py
@@ -1,0 +1,97 @@
+"""Tests for the ``hal0 doctor profiles`` slot↔profile audit classifiers.
+
+Pure functions over plain fixtures (no catalog, no filesystem, no podman) —
+each maps to a real failure mode:
+
+  * ``check_slot_profile_refs``       — slot points at a deleted profile
+                                        (KeyError at slot start).
+  * ``check_profile_images_present``  — in-use profile's image not pulled.
+  * ``_image_repo``                   — tag/digest stripping for image match.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hal0.cli.doctor_commands import (
+    _image_repo,
+    check_profile_images_present,
+    check_slot_profile_refs,
+)
+
+
+def _profile(name, *, seed=False, cloned_from=None, flags="", image="", used_by=()):
+    """Build a ResolvedProfile-shaped stand-in (only the read attrs matter)."""
+    return SimpleNamespace(
+        name=name,
+        seed=seed,
+        cloned_from=cloned_from,
+        flags=flags,
+        image=image,
+        used_by=tuple(used_by),
+    )
+
+
+# ── check_slot_profile_refs ───────────────────────────────────────────────────
+
+
+def test_refs_ok_when_slot_profile_exists() -> None:
+    rows = check_slot_profile_refs([("primary", "rocm")], {"rocm", "tts"})
+    assert rows == [{"label": "primary", "status": "ok", "detail": "→ rocm"}]
+
+
+def test_refs_drift_when_profile_missing() -> None:
+    rows = check_slot_profile_refs([("primary", "ghost")], {"rocm"})
+    assert len(rows) == 1
+    assert rows[0]["status"] == "drift"
+    assert "ghost" in rows[0]["detail"]
+    assert "fail to start" in rows[0]["detail"]
+
+
+def test_refs_skip_base_image_slots() -> None:
+    # profile=None is a base-image slot — legal, not a reference to resolve.
+    assert check_slot_profile_refs([("primary", None), ("x", "")], {"rocm"}) == []
+
+
+# ── check_profile_images_present ──────────────────────────────────────────────
+
+
+def test_images_skipped_entirely_when_podman_unavailable() -> None:
+    p = _profile("rocm", image="ghcr.io/hal0ai/tb:v1", used_by=("primary",))
+    assert check_profile_images_present([p], None) == []
+
+
+def test_images_warn_when_in_use_image_not_pulled() -> None:
+    p = _profile("rocm", image="ghcr.io/hal0ai/tb:v1", used_by=("primary",))
+    rows = check_profile_images_present([p], set())
+    assert rows[0]["status"] == "warn"
+    assert "not pulled" in rows[0]["detail"]
+
+
+def test_images_ok_when_repo_present_regardless_of_tag() -> None:
+    # Local box has the repo at a different tag — still counts as present.
+    p = _profile("rocm", image="ghcr.io/hal0ai/tb:v2", used_by=("primary",))
+    rows = check_profile_images_present([p], {"ghcr.io/hal0ai/tb"})
+    assert rows[0]["status"] == "ok"
+
+
+def test_images_ignore_unused_profiles() -> None:
+    # An unused profile whose image is absent is not a live problem.
+    p = _profile("rocm", image="ghcr.io/hal0ai/tb:v1", used_by=())
+    assert check_profile_images_present([p], set()) == []
+
+
+# ── _image_repo ───────────────────────────────────────────────────────────────
+
+
+def test_image_repo_strips_tag() -> None:
+    assert _image_repo("ghcr.io/hal0ai/toolbox:v1.2") == "ghcr.io/hal0ai/toolbox"
+
+
+def test_image_repo_strips_digest() -> None:
+    assert _image_repo("ghcr.io/hal0ai/toolbox@sha256:abc") == "ghcr.io/hal0ai/toolbox"
+
+
+def test_image_repo_keeps_host_port() -> None:
+    # A registry port (host:5000) must survive; only the trailing tag is dropped.
+    assert _image_repo("localhost:5000/tb:latest") == "localhost:5000/tb"

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -233,6 +233,25 @@ async def test_agent_slot_non_deletable_without_flm(
         await sm.delete("agent")
 
 
+async def test_seeded_slot_deletable_with_force(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # force=True overrides the seeded-slot guard so an operator can remove one
+    # outright. Seed the config on disk, confirm the guard still refuses without
+    # force, then force-delete it.
+    monkeypatch.setattr("hal0.slots.manager.shutil.which", lambda name: None)
+    sm = SlotManager()
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "agent.toml").write_text(
+        'name = "agent"\nport = 8081\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
+    )
+    with pytest.raises(SlotConfigError, match="seeded"):
+        await sm.delete("agent")
+    await sm.delete("agent", force=True)
+    assert not (slots_dir / "agent.toml").exists()
+
+
 async def test_add_slot_rejects_invalid_type(tmp_hal0_home: str) -> None:
     sm = SlotManager()
     with pytest.raises(SlotConfigError, match="slot type"):


### PR DESCRIPTION
## Why

Extends `hal0 doctor` to remedy the install/reboot failures operators hit most, and adds a `--force` escape hatch for deleting seeded slots. Grounded in the documented incident history (FLM store exit-125 after reboot, un-run model-layout migration, latent slot→profile breakage) and driven against a live box.

## `hal0 doctor` remedies

- **`doctor models` + `--fix`** — repairs the FLM/NPU store writability failure that dies as `podman exit 125` after a reboot (chown 1000:hal0 + chmod 2775, root-gated). Also detects **env-vs-TOML store divergence** (`HAL0_FLM_MODELS_DIR` silently overriding `[models].flm_store`) and an **unmounted external store path** (`/mnt/...` not up at boot).
- **`doctor migrations` (new)** — dry-runs the v0.1→v0.2 model-layout planner and surfaces pending symlinks (points at `hal0 migrate model-layout --apply`). Surfaced a real 1360-link pending migration on the live box.
- **`doctor profiles` (new)** — slot→profile referential integrity (a slot naming a deleted profile is a latent KeyError-at-start — the only failing check) + advisory in-use image-present. A clone-drift check was prototyped and **dropped** after it produced only false positives on intentionally-customized clones.

## `--force` delete (seeded slots)

- `SlotManager.delete(force=True)` bypasses the seeded-slot guard; `DELETE /api/slots/{name}?force=true` and `hal0 slot delete --force` forward it (a later install/update reconcile may re-seed).
- **Profiles intentionally keep the immutability guard**: seeds are virtual (re-applied from code on every load), so a force-delete would silently reappear. The `seed_immutable` error now explains that and points at clone / capabilities.toml.

## Tests

214 tests pass; ruff check + format clean; CLI docs-parity gate updated. New pure-classifier unit tests for every doctor check, force-delete coverage at both the `SlotManager` and route layers. New commands/flags driven end-to-end through the real CLI/API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)