### PR TITLE
feat(mcp): enforce per-persona tool policy on the Brain's admin surface

### DIFF
--- a/src/hal0/agents/personas.py
+++ b/src/hal0/agents/personas.py
@@ -488,23 +488,29 @@ def _seed_hal0_brain(agent_id: str) -> Persona:
         # choices, benchmark history) stays out of the general Hermes chat and
         # the coder persona. Created lazily by Hindsight on first write.
         memory_namespace="private:hal0-brain",
+        # Patterns are fnmatch globs over ADMIN TOOL NAMES (slot_create,
+        # model_pull, …) — enforced on the sidebar chat via
+        # hal0.mcp.admin.ToolPolicy, layered onto the server-side
+        # read/write/gated classification. Conservative canonical: nothing
+        # is loosened (gated tools still queue for operator approval);
+        # require_approval redundantly pins the destructive floor
+        # (POLICY_NO_LOOSEN) so the operator sees it in the TOML. To let
+        # the Brain e.g. download models without per-pull approval, add
+        # "model_pull" to auto_approve.
         approval=PersonaApproval(
             default_policy="ask",
             auto_approve=(
-                "memory.read.*",
-                "search.*",
-                "slot.read.*",
-                "hal0_admin.read.*",
-                "kanban.read.*",
-                "bench.read.*",
+                "memory_search",
+                "memory_list",
+                "memory_add",
             ),
             require_approval=(
-                "files.*",
-                "shell.*",
-                "admin.*",
-                "slot.write.*",
-                "hal0_admin.write.*",
-                "kanban.write.*",
+                "model_delete",
+                "slot_delete",
+                "stack_delete",
+                "profile_delete",
+                "config_write",
+                "provider_credential_write",
             ),
         ),
         preferred_upstream="hal0",

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -409,13 +409,40 @@ def _admin_tool_names() -> frozenset[str]:
     return (AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS) - _ADMIN_TOOL_EXCLUDES
 
 
-def _admin_tool_schemas() -> list[dict[str, Any]]:
+def _brain_tool_policy(request: Request) -> Any | None:
+    """The hal0-brain persona's :class:`ToolPolicy` overlay, or ``None``.
+
+    Loaded per request from the persona TOML (same store + fallback
+    semantics as :func:`_resolve_profile`): missing/malformed persona or
+    absent mcp SDK → ``None`` → the server classification stands. This
+    is what makes the persona's ``tools_allowed`` / ``[persona.approval]``
+    tables ENFORCED on the sidebar surface rather than decorative — the
+    operator edits one file to hide tools, tighten an autonomous tool
+    behind approval, or grant standing approval to a gated one
+    (destructive tools excepted; see admin.POLICY_NO_LOOSEN).
+    """
+    try:
+        from hal0.agents.personas import PersonaError, load_persona
+        from hal0.mcp.admin import ToolPolicy
+    except ImportError:
+        return None
+    root = getattr(request.app.state, "brain_persona_root", None)
+    try:
+        persona = load_persona(BRAIN_PERSONA_ID, root=root)
+    except (FileNotFoundError, PersonaError, OSError):
+        return None
+    return ToolPolicy.from_persona(persona)
+
+
+def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
     """OpenAI tool schemas for the surfaced admin catalog.
 
     Path args (from the admin server's ``_PATH_ARGS``) become required
     string properties; ``additionalProperties`` stays open so the model
     can pass body/query fields the descriptions call out (e.g.
-    ``model_pull``'s ``hf_repo``/``hf_filename``).
+    ``model_pull``'s ``hf_repo``/``hf_filename``). A ``policy`` narrows
+    the surface to its ``tools_allowed`` globs — hidden tools never
+    reach the LLM's tool list (dispatch still refuses them if guessed).
     """
     try:
         from hal0.mcp.admin import _PATH_ARGS, TOOL_DESCRIPTIONS
@@ -424,6 +451,8 @@ def _admin_tool_schemas() -> list[dict[str, Any]]:
     schemas: list[dict[str, Any]] = []
     for name, description in TOOL_DESCRIPTIONS.items():
         if name in _ADMIN_TOOL_EXCLUDES:
+            continue
+        if policy is not None and not policy.allows(name):
             continue
         path_args = _PATH_ARGS.get(name, ())
         schemas.append(
@@ -442,6 +471,20 @@ def _admin_tool_schemas() -> list[dict[str, Any]]:
             }
         )
     return schemas
+
+
+def _surfaced_tool_schemas(request: Request) -> list[dict[str, Any]]:
+    """The combined tool list the LLM sees, persona-policy filtered.
+
+    Local board/platform schemas plus the admin catalog, both narrowed
+    to the hal0-brain persona's ``tools_allowed`` globs when a policy
+    resolves (no persona / default ``["*"]`` → everything surfaces).
+    """
+    policy = _brain_tool_policy(request)
+    local = _tool_schemas()
+    if policy is not None:
+        local = [s for s in local if policy.allows(s["function"]["name"])]
+    return local + _admin_tool_schemas(policy)
 
 
 async def _dispatch_admin_tool(request: Request, name: str, args: dict[str, Any]) -> Any:
@@ -469,6 +512,7 @@ async def _dispatch_admin_tool(request: Request, name: str, args: dict[str, Any]
         base_url=base,
         approval_queue=queue,
         memory_dispatcher=getattr(request.app.state, "memory_dispatcher", None),
+        policy=_brain_tool_policy(request),
     )
 
 
@@ -687,6 +731,14 @@ async def _dispatch_tool(
     audit row with ``rec.after`` = result; reads write none — matching the
     REST proxy's audited-mutations / unaudited-reads split.
     """
+    # Persona surface filter applies to LOCAL tools too — the admin path
+    # enforces it inside admin.dispatch, but a narrowed tools_allowed
+    # must also hold against board/platform tools the model might guess
+    # (they're filtered from its schema list, but never trust the list).
+    policy = _brain_tool_policy(request)
+    if policy is not None and not policy.allows(name):
+        return {"error": f"tool {name!r} is outside the hal0-brain persona's tools_allowed"}
+
     read_method, read_path = _resolve_read_tool(name, args)
     if read_method is not None:
         params = {"board": board} if board else None
@@ -887,7 +939,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     body: dict[str, Any] = {
         "model": payload.get("model") or default_model,
         "messages": messages,
-        "tools": _tool_schemas() + _admin_tool_schemas(),
+        "tools": _surfaced_tool_schemas(request),
         "stream": False,
     }
 
@@ -971,6 +1023,7 @@ __all__ = [
     "PRIMARY_SLOT_MODEL",
     "_admin_tool_names",
     "_admin_tool_schemas",
+    "_brain_tool_policy",
     "_chat_stream",
     "_compact_board",
     "_dispatch_admin_tool",
@@ -979,6 +1032,7 @@ __all__ = [
     "_resolve_platform_tool",
     "_resolve_read_tool",
     "_resolve_tool",
+    "_surfaced_tool_schemas",
     "_tool_schemas",
     "run_board_chat",
 ]

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -107,10 +107,12 @@ install missing the SDK still boots — the dashboard surfaces the
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import re
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -628,6 +630,92 @@ def _audit(*, client_id: str, tool: str, args: dict[str, Any], gated: bool, outc
     )
 
 
+# ── Per-persona tool policy (overlay on the server classification) ──────────
+#
+# The classification frozensets above are the FLOOR every caller gets.
+# A persona TOML (hal0.agents.personas) can overlay them per agent:
+# hide tools entirely (tools_allowed), force approval onto autonomous
+# tools (require_approval), or grant standing approval to gated ones
+# (auto_approve / default_policy="auto-approve"). Loosening is an
+# operator decision — the TOML is operator-owned, editing it IS the
+# approval, granted standingly instead of per-call — EXCEPT for the
+# no-loosen floor below: destructive/secret-bearing tools stay at the
+# server verdict no matter what the persona says, so a persona edit can
+# never fully disarm the approval queue.
+
+#: Tools whose server gating can never be loosened by persona policy.
+POLICY_NO_LOOSEN: frozenset[str] = frozenset(
+    {
+        "model_delete",
+        "slot_delete",
+        "stack_delete",
+        "profile_delete",
+        "memory_delete",  # keeps the bulk-delete arity gate intact
+        "config_write",
+        "provider_credential_write",
+    }
+)
+
+
+def _matches(patterns: tuple[str, ...], tool: str) -> bool:
+    return any(fnmatch.fnmatchcase(tool, p) for p in patterns)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolPolicy:
+    """One persona's tool-policy overlay, resolved at dispatch time.
+
+    Field semantics mirror the persona TOML 1:1 (``[persona.tools]`` +
+    ``[persona.approval]``); patterns are fnmatch globs matched against
+    ADMIN TOOL NAMES (``slot_create``, ``model_pull``, …), not REST
+    paths. Precedence per call: tools_allowed (hide) → require_approval
+    (tighten) → auto_approve / default_policy (loosen, no-loosen floor
+    permitting) → server classification.
+    """
+
+    tools_allowed: tuple[str, ...] = ("*",)
+    default_policy: str = "ask"  # ask | auto-approve | never
+    auto_approve: tuple[str, ...] = ()
+    require_approval: tuple[str, ...] = ()
+
+    @classmethod
+    def from_persona(cls, persona: Any) -> ToolPolicy:
+        """Build from a :class:`hal0.agents.personas.Persona` (duck-typed
+        so this module keeps zero imports from the agents package)."""
+        return cls(
+            tools_allowed=tuple(persona.tools_allowed or ("*",)),
+            default_policy=str(persona.approval.default_policy or "ask"),
+            auto_approve=tuple(persona.approval.auto_approve),
+            require_approval=tuple(persona.approval.require_approval),
+        )
+
+    def allows(self, tool: str) -> bool:
+        """Whether the tool is on this persona's surface at all."""
+        return _matches(self.tools_allowed or ("*",), tool)
+
+    def classify(self, tool: str, *, server_gated: bool) -> str:
+        """Resolve one call → ``run`` | ``gated`` | ``denied`` | ``refused``.
+
+        ``denied`` = not in tools_allowed (the tool shouldn't even be
+        surfaced); ``refused`` = the call needs approval but the persona's
+        default_policy is ``never`` (refuse outright instead of queueing).
+        """
+        if not self.allows(tool):
+            return "denied"
+        gated = server_gated
+        if _matches(self.require_approval, tool):
+            gated = True
+        elif (
+            gated
+            and tool not in POLICY_NO_LOOSEN
+            and (_matches(self.auto_approve, tool) or self.default_policy == "auto-approve")
+        ):
+            gated = False
+        if gated and self.default_policy == "never":
+            return "refused"
+        return "gated" if gated else "run"
+
+
 # ── Dispatch core ────────────────────────────────────────────────────────────
 
 
@@ -655,6 +743,7 @@ async def dispatch(
     base_url: str,
     approval_queue: ApprovalQueue,
     memory_dispatcher: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    policy: ToolPolicy | None = None,
 ) -> dict[str, Any]:
     """Run one tool. Autonomous tools execute now; gated tools enqueue.
 
@@ -666,11 +755,40 @@ async def dispatch(
     exposes for direct invocation (avoiding the HTTP round-trip for
     Cognee calls). When ``None``, memory tools route through REST like
     everything else, which is the safer default.
+
+    ``policy`` is the caller persona's :class:`ToolPolicy` overlay;
+    ``None`` (every pre-existing caller) means the server classification
+    stands unmodified.
     """
     if tool not in (AUTONOMOUS_READ_TOOLS | AUTONOMOUS_WRITE_TOOLS | GATED_TOOLS):
         return {"status": "error", "error": {"code": "mcp.unknown_tool", "tool": tool}}
 
     gated = is_gated(tool, args)
+    if policy is not None:
+        verdict = policy.classify(tool, server_gated=gated)
+        if verdict == "denied":
+            _audit(client_id=client_id, tool=tool, args=args, gated=gated, outcome="denied")
+            return {
+                "status": "error",
+                "error": {
+                    "code": "mcp.tool_not_allowed",
+                    "tool": tool,
+                    "detail": "tool is outside this persona's tools_allowed surface",
+                },
+            }
+        if verdict == "refused":
+            _audit(client_id=client_id, tool=tool, args=args, gated=True, outcome="refused")
+            return {
+                "status": "error",
+                "error": {
+                    "code": "mcp.gated_tool_refused",
+                    "tool": tool,
+                    "detail": (
+                        "call requires approval but the persona's default_policy is 'never'"
+                    ),
+                },
+            }
+        gated = verdict == "gated"
 
     if gated:
         # Build the bound executor that runs when the owner approves.
@@ -1267,8 +1385,10 @@ __all__ = [
     "AUTONOMOUS_READ_TOOLS",
     "AUTONOMOUS_WRITE_TOOLS",
     "GATED_TOOLS",
+    "POLICY_NO_LOOSEN",
     "TOOL_DESCRIPTIONS",
     "_ANNOTATIONS",
+    "ToolPolicy",
     "build_server",
     "dispatch",
     "is_gated",

--- a/tests/board/test_board_chat_admin_tools.py
+++ b/tests/board/test_board_chat_admin_tools.py
@@ -10,25 +10,45 @@ path, and the routing degrades to a typed error without app wiring.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
+from hal0.agents.personas import Persona, PersonaApproval, save_persona
 from hal0.api.routes import board_chat as bc
 from hal0.mcp import admin
 from hal0.mcp.approval_queue import ApprovalQueue
 
 
 def _fake_request(**state: Any) -> Any:
-    """A Request stand-in exposing exactly what the admin path reads."""
+    """A Request stand-in exposing exactly what the admin path reads.
+
+    ``brain_persona_root`` defaults to a nonexistent dir so the policy
+    loader resolves to None — never the test box's live persona store.
+    """
     defaults: dict[str, Any] = {
         "approval_queue": None,
         "memory_dispatcher": None,
         "self_api_base_url": "http://testserver",
+        "brain_persona_root": Path("/nonexistent-personas-root"),
     }
     defaults.update(state)
     return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(**defaults)), headers={})
+
+
+def _brain_persona_root(tmp_path: Path, **overrides: Any) -> Path:
+    """Write a hal0-brain persona TOML into ``tmp_path`` and return it."""
+    approval = overrides.pop("approval", PersonaApproval())
+    persona = Persona(
+        id=bc.BRAIN_PERSONA_ID,
+        display_name="hal0 Brain",
+        approval=approval,
+        **overrides,
+    )
+    save_persona(persona, root=tmp_path)
+    return tmp_path
 
 
 # ── surfaced schema shape ────────────────────────────────────────────────────
@@ -116,3 +136,76 @@ async def test_admin_dispatch_degrades_without_approval_queue() -> None:
     request = _fake_request(approval_queue=None)
     result = await bc._dispatch_admin_tool(request, "model_pull", {"model_id": "m"})
     assert "unavailable" in result["error"]
+
+
+# ── persona ToolPolicy enforcement on the sidebar surface ────────────────────
+
+
+def test_brain_policy_none_when_persona_missing(tmp_path: Path) -> None:
+    request = _fake_request(brain_persona_root=tmp_path)  # empty store
+    assert bc._brain_tool_policy(request) is None
+
+
+def test_brain_policy_loads_from_persona_toml(tmp_path: Path) -> None:
+    root = _brain_persona_root(
+        tmp_path,
+        approval=PersonaApproval(auto_approve=("model_pull",), require_approval=("slot_load",)),
+    )
+    policy = bc._brain_tool_policy(_fake_request(brain_persona_root=root))
+    assert policy is not None
+    assert policy.classify("model_pull", server_gated=True) == "run"
+    assert policy.classify("slot_load", server_gated=False) == "gated"
+
+
+def test_surfaced_schemas_filtered_by_tools_allowed(tmp_path: Path) -> None:
+    """tools_allowed narrows BOTH the local and admin schema lists."""
+    root = _brain_persona_root(tmp_path, tools_allowed=("get_board", "profile_*"))
+    request = _fake_request(brain_persona_root=root)
+    names = {s["function"]["name"] for s in bc._surfaced_tool_schemas(request)}
+    assert "get_board" in names
+    assert "profile_list" in names and "profile_create" in names
+    assert "model_pull" not in names  # admin tool hidden
+    assert "slot_load" not in names  # local tool hidden
+    # No persona → everything surfaces.
+    full = {s["function"]["name"] for s in bc._surfaced_tool_schemas(_fake_request())}
+    assert "model_pull" in full and "slot_load" in full
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_refuses_disallowed_local_tool(tmp_path: Path) -> None:
+    root = _brain_persona_root(tmp_path, tools_allowed=("get_board",))
+    request = _fake_request(brain_persona_root=root, approval_queue=ApprovalQueue())
+    result = await bc._dispatch_tool(request, client=None, name="slot_load", args={}, board=None)
+    assert "tools_allowed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_persona_loosening_skips_approval_from_sidebar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """auto_approve=model_pull in the persona TOML → the sidebar call
+    executes immediately instead of queueing."""
+    executed: dict[str, Any] = {}
+
+    async def _fake_execute(**kwargs: Any) -> dict[str, Any]:
+        executed.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr(admin, "_execute_tool", _fake_execute)
+    root = _brain_persona_root(tmp_path, approval=PersonaApproval(auto_approve=("model_pull",)))
+    queue = ApprovalQueue()
+    request = _fake_request(brain_persona_root=root, approval_queue=queue)
+    result = await bc._dispatch_admin_tool(request, "model_pull", {"model_id": "m"})
+    assert result == {"ok": True}
+    assert executed["tool"] == "model_pull"
+    assert queue.list_pending() == []
+
+
+@pytest.mark.asyncio
+async def test_persona_cannot_loosen_destructive_floor(tmp_path: Path) -> None:
+    root = _brain_persona_root(tmp_path, approval=PersonaApproval(auto_approve=("model_delete",)))
+    queue = ApprovalQueue()
+    request = _fake_request(brain_persona_root=root, approval_queue=queue)
+    result = await bc._dispatch_admin_tool(request, "model_delete", {"model_id": "m"})
+    assert result["status"] == "pending_approval"
+    assert [p["tool"] for p in queue.list_pending()] == ["model_delete"]

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -493,3 +493,164 @@ def test_model_scan_is_a_write_and_preview_is_a_read() -> None:
     assert "model_scan" in admin.AUTONOMOUS_WRITE_TOOLS
     assert "model_scan_preview" in admin.AUTONOMOUS_READ_TOOLS
     assert "model_scan" not in admin.AUTONOMOUS_READ_TOOLS
+
+
+# ── per-persona ToolPolicy overlay ───────────────────────────────────────────
+
+
+def _policy(**kw: Any) -> admin.ToolPolicy:
+    return admin.ToolPolicy(**kw)
+
+
+def test_policy_classify_default_ask_mirrors_server_verdict() -> None:
+    p = _policy()
+    assert p.classify("slot_load", server_gated=False) == "run"
+    assert p.classify("model_pull", server_gated=True) == "gated"
+
+
+def test_policy_tools_allowed_hides_everything_else() -> None:
+    p = _policy(tools_allowed=("slot_*", "model_list"))
+    assert p.allows("slot_create")
+    assert p.allows("model_list")
+    assert not p.allows("model_pull")
+    assert p.classify("model_pull", server_gated=True) == "denied"
+
+
+def test_policy_require_approval_tightens_autonomous_tool() -> None:
+    p = _policy(require_approval=("slot_load",))
+    assert p.classify("slot_load", server_gated=False) == "gated"
+
+
+def test_policy_auto_approve_loosens_gated_tool_but_not_floor() -> None:
+    p = _policy(auto_approve=("model_pull", "model_delete"))
+    assert p.classify("model_pull", server_gated=True) == "run"
+    # model_delete is on POLICY_NO_LOOSEN — the grant is ignored.
+    assert p.classify("model_delete", server_gated=True) == "gated"
+
+
+def test_policy_default_auto_approve_respects_floor() -> None:
+    p = _policy(default_policy="auto-approve")
+    assert p.classify("stack_apply", server_gated=True) == "run"
+    assert p.classify("config_write", server_gated=True) == "gated"
+
+
+def test_policy_require_approval_beats_auto_approve() -> None:
+    p = _policy(auto_approve=("slot_*",), require_approval=("slot_edit",))
+    assert p.classify("slot_edit", server_gated=False) == "gated"
+
+
+def test_policy_never_refuses_gated_and_runs_autonomous() -> None:
+    p = _policy(default_policy="never")
+    assert p.classify("model_pull", server_gated=True) == "refused"
+    assert p.classify("slot_list", server_gated=False) == "run"
+
+
+def test_policy_from_persona_duck_types() -> None:
+    class _Approval:
+        default_policy = "ask"
+        auto_approve = ("model_pull",)
+        require_approval = ("slot_load",)
+
+    class _Persona:
+        tools_allowed = ("slot_*", "model_*")
+        approval = _Approval()
+
+    p = admin.ToolPolicy.from_persona(_Persona())
+    assert p.classify("model_pull", server_gated=True) == "run"
+    assert p.classify("slot_load", server_gated=False) == "gated"
+    assert p.classify("stack_apply", server_gated=True) == "denied"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_denied_returns_typed_error(queue: ApprovalQueue) -> None:
+    result = await admin.dispatch(
+        tool="model_pull",
+        args={"model_id": "m"},
+        client_id="brain",
+        bearer=None,
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(tools_allowed=("slot_*",)),
+    )
+    assert result["error"]["code"] == "mcp.tool_not_allowed"
+    assert queue.list_pending() == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_never_refuses_instead_of_queueing(queue: ApprovalQueue) -> None:
+    result = await admin.dispatch(
+        tool="model_pull",
+        args={"model_id": "m"},
+        client_id="brain",
+        bearer=None,
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(default_policy="never"),
+    )
+    assert result["error"]["code"] == "mcp.gated_tool_refused"
+    assert queue.list_pending() == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_loosened_pull_runs_immediately(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    """auto_approve=model_pull → no approval hop; REST POST fires now."""
+    result = await admin.dispatch(
+        tool="model_pull",
+        args={"model_id": "m"},
+        client_id="brain",
+        bearer="tok",
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(auto_approve=("model_pull",)),
+    )
+    assert result == {"ok": "post"}
+    assert queue.list_pending() == []
+    methods = [c[0] for c in mock_transport["calls"]]
+    assert methods == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_floor_still_queues_despite_grant(queue: ApprovalQueue) -> None:
+    result = await admin.dispatch(
+        tool="model_delete",
+        args={"model_id": "m"},
+        client_id="brain",
+        bearer=None,
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(auto_approve=("model_delete",)),
+    )
+    assert result["status"] == "pending_approval"
+    assert [p["tool"] for p in queue.list_pending()] == ["model_delete"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_tightened_autonomous_tool_queues(queue: ApprovalQueue) -> None:
+    result = await admin.dispatch(
+        tool="slot_load",
+        args={"name": "agent"},
+        client_id="brain",
+        bearer=None,
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(require_approval=("slot_load",)),
+    )
+    assert result["status"] == "pending_approval"
+    assert [p["tool"] for p in queue.list_pending()] == ["slot_load"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_policy_bulk_memory_delete_stays_gated(queue: ApprovalQueue) -> None:
+    """memory_delete is on the floor — a grant can't disarm the bulk gate."""
+    result = await admin.dispatch(
+        tool="memory_delete",
+        args={"ids": ["a", "b"]},
+        client_id="brain",
+        bearer=None,
+        base_url="http://t",
+        approval_queue=queue,
+        policy=_policy(auto_approve=("memory_delete",)),
+    )
+    assert result["status"] == "pending_approval"


### PR DESCRIPTION
## Problem

The hal0-brain persona TOML carries `tools_allowed` and `[persona.approval]` tables, but on the sidebar chat they were **decorative** — `_resolve_profile` read only `system_prompt`/`preferred_model`, and the seeded globs (`slot.read.*`, `hal0_admin.write.*`) used a dotted namespace that matches no actual tool name. Gating was one-size-fits-all: `model_pull` queued for approval for every caller, with no way to grant the Brain standing approval short of editing code.

## Change

**`admin.ToolPolicy`** — a per-persona overlay resolved at dispatch time, fnmatch globs over admin tool names (`slot_create`, `model_pull`, …). Precedence per call:

1. `tools_allowed` **hides**: non-matching tools are filtered from the LLM's schema list *and* refused at dispatch (`mcp.tool_not_allowed`)
2. `require_approval` **tightens**: forces an autonomous tool through the approval queue
3. `auto_approve` / `default_policy="auto-approve"` **loosens**: standing approval for gated tools — the TOML is operator-owned, editing it *is* the approval
4. `default_policy="never"` refuses gated calls outright (`mcp.gated_tool_refused`) instead of queueing

**`POLICY_NO_LOOSEN` floor**: `model_delete`, `slot_delete`, `stack_delete`, `profile_delete`, `memory_delete` (bulk), `config_write`, `provider_credential_write` can never be loosened — a persona edit cannot disarm the queue for destructive/secret-bearing tools.

`dispatch(policy=...)` is opt-in: `policy=None` (every pre-existing caller — /mcp/admin mount, tests) is behaviour-identical. `board_chat` loads the Brain persona per request and enforces the policy across both its local and admin tool surfaces.

**Seed fix**: the hal0-brain persona's approval lists now use real tool names. Canonical stays conservative (nothing loosened; `require_approval` documents the destructive floor) — to let the Brain download models without per-pull approval, the operator adds `"model_pull"` to `auto_approve` in one TOML edit. Existing boxes keep their TOML (seeding is overwrite=False); old dotted globs match nothing → server defaults, no behaviour change until edited.

## Tests

- `tests/mcp/test_admin.py` +14: classify matrix (hide/tighten/loosen/floor/never/precedence), `from_persona`, dispatch integration (denied/refused/loosened-runs-now/floor-still-queues/bulk-memory-delete-stays-gated)
- `tests/board/test_board_chat_admin_tools.py` +6: policy loads from persona TOML, schema filtering across both surfaces, local-tool refusal, loosening skips approval from the sidebar, floor holds from the sidebar
- 310 tests across mcp/board/persona/provisioning suites pass; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)