### PR TITLE
feat(install): seed agent + brain slots; agent replaces chat as the LLM anchor

### DIFF
--- a/installer/etc-hal0/slots/agent.toml
+++ b/installer/etc-hal0/slots/agent.toml
@@ -1,0 +1,25 @@
+# Agent LLM slot — vulkan llama-server container (hal0-slot@agent).
+#
+# ADR-0023: `agent` is the default LLM anchor every `hal0/<slot>` fallback
+# chain ends in (chat routing, the sidebar steward's hal0/brain fallback,
+# Hermes delegation). Seeding it at install time keeps those chains from
+# dead-ending on a fresh box; `hal0 setup` scaffolds the same slot when this
+# seed is absent (setup_command._SETUP_SLOTS — chat capability, same name +
+# port), and never overwrites an existing file.
+#
+# Clean seed (WS-E, #1107 pattern): ships WITHOUT a `[model].default` and
+# DISABLED, so a fresh, deliberately model-less box boots a GREY tile — no
+# surprise multi-GB download and no crash-loop. The operator assigns a model
+# later (dashboard / `hal0 setup`), which flips the slot enabled. device/
+# profile are the widest-compatible GPU-Vulkan tile defaults; the guided /
+# answer-file setup path derives them from the up-front preflight instead.
+name = "agent"
+type = "llm"
+device = "gpu-vulkan"
+runtime = "container"
+profile = "vulkan"
+enabled = false
+port = 8081
+
+[model]
+context_size = 65536

--- a/installer/etc-hal0/slots/brain.toml
+++ b/installer/etc-hal0/slots/brain.toml
@@ -1,0 +1,23 @@
+# Brain LLM slot — vulkan llama-server container (hal0-slot@brain).
+#
+# The dashboard's sidebar agent chat (the hal0-brain platform steward)
+# targets the virtual model `hal0/brain`, which resolves here once a model
+# is bound and falls back to the `agent` slot meanwhile. Seeding the slot
+# makes that intent visible as a grey tile instead of the chat's model
+# routing failing opaquely on fresh boxes. `hal0 setup` scaffolds the same
+# slot when this seed is absent (setup_command._BRAIN_SLOT — chat
+# capability, same name + port), and never overwrites an existing file.
+#
+# Clean seed (WS-E, #1107 pattern): ships WITHOUT a `[model].default` and
+# DISABLED — the operator assigns a model later (dashboard / `hal0 setup`),
+# which flips the slot enabled. Port 8089: 8088 belongs to the flm seed.
+name = "brain"
+type = "llm"
+device = "gpu-vulkan"
+runtime = "container"
+profile = "vulkan"
+enabled = false
+port = 8089
+
+[model]
+context_size = 65536

--- a/installer/etc-hal0/slots/utility.toml
+++ b/installer/etc-hal0/slots/utility.toml
@@ -17,7 +17,9 @@ device = "gpu-vulkan"
 runtime = "container"
 profile = "vulkan"
 enabled = false
-port = 8081
+# Port 8090: 8081 is the `agent` seed's canonical primary port (ADR-0023);
+# existing installs keep whatever their file says (seeds never overwrite).
+port = 8090
 
 [model]
 context_size = 65536

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1338,7 +1338,8 @@ else
 fi
 
 # ── Container slot seeds (A10) ────────────────────────────────────────────
-# Pre-populate /etc/hal0/slots/{flm,tts,rerank,utility,img}.toml if absent
+# Pre-populate /etc/hal0/slots/{flm,tts,rerank,utility,img,agent,brain}.toml
+# if absent
 # (the loop below is the single source of truth). Idempotent: never
 # overwrite an operator-edited file. Each slot is seeded unconditionally so
 # the dashboard can show its tile on any hal0 install; each gates on its own
@@ -1352,7 +1353,7 @@ fi
 # `cp -a installer "${STAGE}/"`), git checkouts carry it, and the prod
 # rsync to ${PREFIX} (which REPO_ROOT is re-pointed at) has no exclude
 # that touches installer/.
-for seed_slot in flm tts rerank utility img; do
+for seed_slot in flm tts rerank utility img agent brain; do
     SLOT_TOML="${ETC_DIR}/slots/${seed_slot}.toml"
     SLOT_SRC="${REPO_ROOT}/installer/etc-hal0/slots/${seed_slot}.toml"
     if [[ -f "${SLOT_TOML}" ]]; then

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -284,7 +284,9 @@ async def curated_models() -> dict[str, Any]:
 #: capability drives both the on-disk store group (design D2) and the
 #: device/profile derivation (design D4).
 _SLOT_META: dict[str, tuple[str, str, int]] = {
-    "chat.primary": ("chat", "chat", 8081),
+    # The chat capability's slot is NAMED `agent` (ADR-0023 LLM anchor) —
+    # mirrors setup_command._SETUP_SLOTS so both first-run paths agree.
+    "chat.primary": ("chat", "agent", 8081),
     "chat.coder": ("coder", "coder", 8082),
     "embed": ("embed", "embed", 8083),
     "stt": ("stt", "stt", 8084),

--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -26,8 +26,11 @@ from hal0.install.profile_derive import npu_healthy
 #: installer.py:_SLOT_META for the shared capabilities (chat/coder/embed/stt/
 #: tts) and adds rerank/vision on free ports in the 8081-8099 pool. ``img`` is
 #: handled via the ComfyUI ``comfyui_defaults`` sidecar, not this table.
+#: The chat capability's slot is NAMED ``agent`` per ADR-0023: `agent` is the
+#: default LLM anchor every ``hal0/<slot>`` fallback chain ends in, so first
+#: run must seed a slot by that name or the chains dead-end on fresh boxes.
 _SETUP_SLOTS = {
-    "chat": ("chat", 8081),
+    "chat": ("agent", 8081),
     "coder": ("coder", 8082),
     "embed": ("embed", 8083),
     "stt": ("stt", 8084),
@@ -35,6 +38,14 @@ _SETUP_SLOTS = {
     "rerank": ("rerank", 8086),
     "vision": ("vision", 8087),
 }
+
+#: The dashboard steward's dedicated slot, scaffolded (empty, chat-capability
+#: device derivation) alongside the table above. The sidebar agent chat targets
+#: ``hal0/brain`` and falls back to ``agent`` while this slot has no model —
+#: seeding it makes the intent visible in the dashboard instead of the chat
+#: failing opaquely on fresh installs. Port 8089: 8088 belongs to the flm
+#: static seed (installer/etc-hal0/slots/flm.toml).
+_BRAIN_SLOT = ("brain", 8089)
 
 #: Capabilities scaffolded (empty, no model) by ``--auto``. ``coder`` is added
 #: separately, gated on an agent extension. ``apply_setup`` derives each slot's
@@ -85,9 +96,10 @@ def build_auto_selections(
     unset for the operator to choose later.  We never pick a model for the user.
 
     When *with_extensions* is ``False`` every extension is disabled (all keys
-    present, all values ``False``).  The coder/agent slot is gated on an agent
+    present, all values ``False``).  The coder slot is gated on an agent
     extension being enabled, so it is skipped when extensions are off.  The
-    chat slot is always included.
+    ``agent`` slot (the chat capability's slot — ADR-0023's LLM anchor) and
+    the ``brain`` scaffold are always included.
 
     When *with_slots* is ``False`` NO model picks are seeded at all — the
     returned selection has an empty slot list and no ComfyUI capability
@@ -119,6 +131,12 @@ def build_auto_selections(
             name, port = _SETUP_SLOTS[cap]
             if name not in existing_slots:
                 slots.append(SlotSelection(cap, name, port, None))
+        # The steward's `brain` slot — an empty chat-capability scaffold so
+        # hal0/brain has a visible home (falls back to `agent` until a model
+        # is bound). Same never-overwrite rule as the capability slots.
+        brain_name, brain_port = _BRAIN_SLOT
+        if brain_name not in existing_slots:
+            slots.append(SlotSelection("chat", brain_name, brain_port, None))
         # Coder slot only when an agent extension is enabled (and not present).
         if (
             any(_kind(eid) == "agent" and on for eid, on in ext.items())

--- a/src/hal0/cli/setup_ui.py
+++ b/src/hal0/cli/setup_ui.py
@@ -16,7 +16,7 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
 
-from hal0.cli.setup_command import _SETUP_SLOTS
+from hal0.cli.setup_command import _BRAIN_SLOT, _SETUP_SLOTS, _existing_slot_names
 from hal0.cli.setup_copy import PANE_COPY
 from hal0.cli.setup_plan import _free_space_gib, _port_in_use
 from hal0.config.schema import HardwareInfo
@@ -630,6 +630,13 @@ def run_interactive(hw: HardwareInfo, *, storage_dir: str) -> None:
         s = _provision_slot("main", "chat", hw, name, port)
         if s:
             slots.append(s)
+        # The steward's `brain` slot rides along silently — an empty
+        # chat-capability scaffold (no model prompt): the sidebar agent
+        # chat targets hal0/brain and falls back to `agent` until the
+        # operator binds a model. Never overwrites an existing config.
+        brain_name, brain_port = _BRAIN_SLOT
+        if brain_name not in _existing_slot_names():
+            slots.append(SlotSelection("chat", brain_name, brain_port, None))
     if "agent" in steps:
         name, port = _SETUP_SLOTS["coder"]
         s = _provision_slot("agent", "coder", hw, name, port, prefer_coder=True)

--- a/tests/api/test_install_apply.py
+++ b/tests/api/test_install_apply.py
@@ -107,11 +107,12 @@ def test_apply_seeds_jobs_and_creates_slots(isolated_app_client, tmp_hal0_home, 
     body = r.json()
     # The default tier's primary is a curated chat model → a job + slot exist.
     assert "qwen3.5-9b" in body["model_ids"]
-    chat = next(s for s in body["slots"] if s["slot"] == "chat")
+    # chat.primary -> slot_name "agent" (ADR-0023 LLM anchor).
+    chat = next(s for s in body["slots"] if s["slot"] == "agent")
     assert chat["profile"] in ("rocm", "vulkan")
     assert chat["created"] is True
     # Slot TOML written OFFLINE (not started).
-    toml = Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "chat.toml"
+    toml = Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "agent.toml"
     cfg = tomllib.loads(toml.read_text())
     assert cfg["model"]["default"] == "qwen3.5-9b"
     assert "profile" in cfg
@@ -143,22 +144,23 @@ def test_apply_honors_per_slot_override(isolated_app_client, tmp_hal0_home, monk
             "tier": "hal0-default",
             "storage_dir": tmp_hal0_home,
             "npu_opt_in": False,
-            # Override chat: a different curated model + the vulkan profile/device
-            # (coherent pair) instead of the auto-derived rocm.
+            # Override the agent slot (chat.primary -> "agent"): a different
+            # curated model + the vulkan profile/device (coherent pair)
+            # instead of the auto-derived rocm.
             "overrides": {
-                "chat": {"model_id": "qwen3.6-27b", "profile": "vulkan", "device": "gpu-vulkan"}
+                "agent": {"model_id": "qwen3.6-27b", "profile": "vulkan", "device": "gpu-vulkan"}
             },
         },
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    chat = next(s for s in body["slots"] if s["slot"] == "chat")
+    chat = next(s for s in body["slots"] if s["slot"] == "agent")
     assert chat["model_id"] == "qwen3.6-27b"
     assert chat["profile"] == "vulkan"
     assert chat["device"] == "gpu-vulkan"
     assert "qwen3.6-27b" in body["model_ids"]
 
-    cfg = tomllib.loads((Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "chat.toml").read_text())
+    cfg = tomllib.loads((Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "agent.toml").read_text())
     assert cfg["model"]["default"] == "qwen3.6-27b"
     assert cfg["profile"] == "vulkan"
     assert cfg["device"] == "gpu-vulkan"

--- a/tests/cli/test_setup_command.py
+++ b/tests/cli/test_setup_command.py
@@ -43,14 +43,29 @@ def test_auto_selections_scaffolds_capability_slots_empty():
     sel = build_auto_selections(_hw(96), storage_dir="/var/lib/hal0/models")
     names = {s.slot_name for s in sel.slots}
     # the capability slot STRUCTURE is scaffolded (device/profile/port), but no
-    # model is chosen — pick-free: slots yes, models no.
-    assert {"chat", "embed", "rerank", "stt", "tts", "vision"} <= names
+    # model is chosen — pick-free: slots yes, models no. The chat capability's
+    # slot is NAMED `agent` (ADR-0023 LLM anchor) and the steward's `brain`
+    # scaffold rides along.
+    assert {"agent", "brain", "embed", "rerank", "stt", "tts", "vision"} <= names
     assert all(s.model_id is None for s in sel.slots)  # every slot empty
     assert sel.extensions["openwebui"] is True
     assert sel.extensions["hermes"] is True
     assert sel.extensions["pi"] is False
-    # an agent is enabled by default → coder slot is scaffolded too
+    # an agent extension is enabled by default → coder slot is scaffolded too
     assert "coder" in names
+
+
+def test_auto_selections_brain_scaffold_is_chat_capability():
+    """`brain` rides the chat-capability device/profile derivation and, like
+    every scaffold, ships without a model (hal0/brain falls back to `agent`
+    until the operator binds one)."""
+    sel = build_auto_selections(_hw(96), storage_dir="/var/lib/hal0/models")
+    brain = next(s for s in sel.slots if s.slot_name == "brain")
+    assert brain.capability == "chat"
+    assert brain.model_id is None
+    agent = next(s for s in sel.slots if s.slot_name == "agent")
+    assert agent.capability == "chat"
+    assert brain.port != agent.port
 
 
 def test_auto_selections_no_slots_seeds_nothing():
@@ -62,8 +77,8 @@ def test_auto_selections_no_slots_seeds_nothing():
 def test_auto_selections_no_extensions_disables_all_and_skips_agent_slot():
     sel = build_auto_selections(_hw(96), storage_dir="/var/lib/hal0/models", with_extensions=False)
     assert all(v is False for v in sel.extensions.values())
-    # chat (Main) slot still seeded; agent/coder slot NOT seeded (no agent ext on)
-    assert any(s.slot_name == "chat" for s in sel.slots)
+    # agent (Main) slot still seeded; coder slot NOT seeded (no agent ext on)
+    assert any(s.slot_name == "agent" for s in sel.slots)
     assert not any(s.slot_name == "coder" for s in sel.slots)
 
 
@@ -77,13 +92,15 @@ def test_auto_selections_skips_existing_slots():
     sel = build_auto_selections(
         _hw(96),
         storage_dir="/var/lib/hal0/models",
-        existing_slots=frozenset({"chat"}),
+        existing_slots=frozenset({"agent", "brain"}),
     )
-    # chat already exists on disk → not re-seeded; coder (agent default on) still seeded
-    assert not any(s.slot_name == "chat" for s in sel.slots)
+    # agent + brain already exist on disk → not re-seeded; coder (agent
+    # extension default on) still seeded
+    assert not any(s.slot_name == "agent" for s in sel.slots)
+    assert not any(s.slot_name == "brain" for s in sel.slots)
     assert any(s.slot_name == "coder" for s in sel.slots)
 
 
 def test_auto_selections_no_existing_seeds_all_default():
     sel = build_auto_selections(_hw(96), storage_dir="/var/lib/hal0/models")
-    assert any(s.slot_name == "chat" for s in sel.slots)
+    assert any(s.slot_name == "agent" for s in sel.slots)

--- a/tests/config/test_schema_seeds_c5.py
+++ b/tests/config/test_schema_seeds_c5.py
@@ -28,7 +28,9 @@ def test_seed_utility_toml_validates() -> None:
     assert slot.runtime == "container"
     assert slot.profile == "vulkan"
     assert slot.device == "gpu-vulkan"
-    assert slot.port == 8081
+    # 8090: 8081 was reclaimed as the `agent` seed's canonical primary port
+    # (ADR-0023 LLM anchor); utility moved off it on new installs.
+    assert slot.port == 8090
     # Clean seed (WS-E, #1107): the ghost id `gemma-4-12b-it` pin is gone — the
     # slot boots grey (no crash-loop, no surprise download). context_size is a
     # tuning default that applies once the operator assigns a model.

--- a/tests/install/test_emit_answers.py
+++ b/tests/install/test_emit_answers.py
@@ -93,9 +93,12 @@ def test_round_trip_from_build_auto_selections(tmp_path):
     # build_auto_selections also scaffolds embed/rerank/stt/tts/vision slots;
     # the answer-file slots schema only supports chat/coder today (spec §3/§5)
     # so dump_answers must warn-and-skip those rather than emit an invalid file.
+    # Both chat-capability slots survive — `agent` (the ADR-0023 anchor) and
+    # the steward's `brain` scaffold — so an --answers replay reproduces them.
     with pytest.warns(UserWarning, match="does not yet support"):
         doc = dump_answers(sel)
     assert {s["capability"] for s in doc["slots"]} == {"chat", "coder"}
+    assert {s["name"] for s in doc["slots"]} == {"agent", "brain", "coder"}
 
     path = tmp_path / "hal0-setup.yaml"
     write_answers(sel, str(path))
@@ -106,10 +109,11 @@ def test_round_trip_from_build_auto_selections(tmp_path):
     assert loaded.extensions == sel.extensions
     assert loaded.comfyui_defaults == sel.comfyui_defaults
     assert {s.capability for s in loaded.slots} == {"chat", "coder"}
-    orig_by_cap = {s.capability: s for s in sel.slots if s.capability in ("chat", "coder")}
+    orig_by_name = {s.slot_name: s for s in sel.slots if s.capability in ("chat", "coder")}
+    assert {s.slot_name for s in loaded.slots} == set(orig_by_name)
     for s in loaded.slots:
-        assert s.model_id == orig_by_cap[s.capability].model_id
-        assert s.port == orig_by_cap[s.capability].port
+        assert s.model_id == orig_by_name[s.slot_name].model_id
+        assert s.port == orig_by_name[s.slot_name].port
 
 
 def test_write_answers_creates_parent_dirs_and_header(tmp_path):


### PR DESCRIPTION
## Problem

ADR-0023 made `agent` the default LLM anchor every `hal0/<slot>` fallback chain ends in, and the sidebar steward (hal0-brain) targets `hal0/brain` with an `agent` fallback — but **neither slot was ever seeded**. First-run setup scaffolded a slot named `chat` (the pre-ADR name) and no `brain`, so on a fresh box the sidebar agent chat had no model to route to even with the persona + 74-tool surface in place (#1204/#1208). The `agent`/`brain` slots on existing boxes are hand-made.

## Change

| Path | Before | After |
|---|---|---|
| `hal0 setup --auto` / guided | `chat` @8081, no brain | `agent` @8081 + `brain` scaffold @8089 (chat-capability derivation, empty) |
| Dashboard first-run (`_SLOT_META`) | `chat.primary` → slot `chat` | `chat.primary` → slot `agent` |
| `install.sh` static seeds | flm/tts/rerank/utility/img | + `agent.toml`, `brain.toml` (utility pattern: disabled, no model default) — present even on `--no-slots` installs |

Port notes: `brain`=8089 because 8088 is flm's static seed; `utility.toml` moves 8081→8090 on **new** installs to free the canonical primary port for `agent` (seeds are copy-if-absent, so existing boxes keep their files — no migration). The rerank/tts static-vs-table port overlaps predate this PR and are left alone.

With `agent` seeded, the existing `hal0/brain → agent` resolver chain lands on a real slot with **no resolver changes** — once the operator binds a model to either slot, the sidebar Brain routes.

## Tests

- `build_auto_selections`: agent+brain scaffolded (chat capability, empty, distinct ports), skipped when existing, coder gating unchanged
- Answers round-trip: both chat-capability slots emit + reload (re-keyed by slot name)
- New seed TOMLs picked up automatically by the config schema suite
- 217 passed across config/install/setup/installer-routes; `bash -n install.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)