### PR TITLE
feat(install): seed static slot TOMLs on hal0-api startup, not just fresh install

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -946,6 +946,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     except Exception as exc:  # seeding must never block startup
         log.warning("personas.startup_seed_failed", error=str(exc))
 
+    # Static slot seeds (flm/tts/rerank/utility/img/agent/brain) — same
+    # fresh-install-only gap as the persona seed above: install.sh's copy
+    # loop never re-runs on `hal0 update`, so a box upgrading past a
+    # release that added a new seed (e.g. `brain`, the dashboard
+    # steward's slot) never grows the file. Copy-if-absent; an existing
+    # <name>.toml (operator edit or prior seed) is never touched.
+    try:
+        from hal0.install.static_seeds import seed_static_slots
+
+        seeded_slots = await asyncio.to_thread(seed_static_slots)
+        if seeded_slots:
+            log.info("slots.startup_seed", names=seeded_slots)
+    except Exception as exc:  # seeding must never block startup
+        log.warning("slots.startup_seed_failed", error=str(exc))
+
     # Capability orchestrator — overlay that maps the dashboard's
     # capability-grouped children (embed/voice/img) onto regular slots.
     # The orchestrator is intentionally constructed AFTER the slot

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -1,0 +1,87 @@
+"""Static slot-config seeds shipped in ``installer/etc-hal0/slots/``.
+
+``install.sh``'s "Container slot seeds" loop copies these files
+(``flm``/``tts``/``rerank``/``utility``/``img``/``agent``/``brain``)
+into ``/etc/hal0/slots/`` on a FRESH install only — bash, so it runs
+before hal0's own venv exists. That loop never re-runs on ``hal0
+update``: an existing box upgrading past a release that adds a new
+seed (e.g. ``brain``, added alongside the dashboard steward) never
+grows the file. This module is the same copy-if-absent logic, callable
+from Python, so the hal0-api lifespan can close that gap the way it
+already does for persona seeding (:func:`hal0.agents.personas.seed_default_personas`).
+
+Keep :data:`STATIC_SEED_SLOTS` in sync with install.sh's
+``for seed_slot in ...`` line by hand — bash and Python don't share a
+source here, mirroring how ``setup_command._SETUP_SLOTS`` and
+``routes.installer._SLOT_META`` already hand-mirror each other.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import structlog
+
+from hal0.config import paths
+
+log = structlog.get_logger(__name__)
+
+#: Slot names with a static seed TOML in installer/etc-hal0/slots/.
+#: MUST mirror install.sh's:
+#:   for seed_slot in flm tts rerank utility img agent brain; do
+STATIC_SEED_SLOTS: tuple[str, ...] = (
+    "flm",
+    "tts",
+    "rerank",
+    "utility",
+    "img",
+    "agent",
+    "brain",
+)
+
+
+def seed_static_slots(
+    *,
+    installer_root: Path | None = None,
+    slots_dir: Path | None = None,
+) -> list[str]:
+    """Copy any missing static seed TOML into the slots config dir.
+
+    Idempotent and non-destructive: an existing ``<name>.toml`` — an
+    operator edit, a seed from a prior run, or a slot the operator
+    created by hand under that name — is left untouched. Returns the
+    slot names actually seeded this call (empty on a converged box).
+
+    ``installer_root`` defaults to :data:`hal0.agents.hermes_provision.
+    REPO_ROOT_FOR_INSTALLER`, the same dev/editable-vs-FHS probe every
+    other installer-tree reader uses (imported lazily to dodge an
+    import cycle at module load); ``slots_dir`` defaults to
+    :func:`hal0.config.paths.slots_config_dir`. Both are injectable for
+    tests.
+    """
+    if installer_root is None:
+        from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER
+
+        installer_root = REPO_ROOT_FOR_INSTALLER
+    dest_dir = slots_dir if slots_dir is not None else paths.slots_config_dir()
+    src_dir = installer_root / "installer" / "etc-hal0" / "slots"
+
+    seeded: list[str] = []
+    for name in STATIC_SEED_SLOTS:
+        dest = dest_dir / f"{name}.toml"
+        if dest.exists():
+            continue
+        src = src_dir / f"{name}.toml"
+        if not src.is_file():
+            log.warning("install.static_seed_missing", slot=name, src=str(src))
+            continue
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)
+        dest.chmod(0o644)
+        seeded.append(name)
+        log.info("install.static_seed_applied", slot=name, dest=str(dest))
+    return seeded
+
+
+__all__ = ["STATIC_SEED_SLOTS", "seed_static_slots"]

--- a/tests/api/test_startup_slot_seed.py
+++ b/tests/api/test_startup_slot_seed.py
@@ -1,0 +1,58 @@
+"""Startup slot seeding — the lifespan hook that ships agent/brain/etc.
+
+install.sh's static slot-TOML copy loop only runs on a fresh install; it
+never re-runs on ``hal0 update``, so a box upgrading past a release that
+added a new seed (``brain``, the dashboard steward's slot) never grew the
+file. The lifespan now copies any missing seed on every API start
+(copy-if-absent), mirroring the persona startup seed
+(tests/api/test_startup_persona_seed.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.install.static_seeds import STATIC_SEED_SLOTS
+
+
+def _slots_dir(tmp_hal0_home: str) -> Path:
+    # Mirrors paths.slots_config_dir() under HAL0_HOME.
+    return Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+
+
+def test_lifespan_seeds_static_slots(tmp_hal0_home: str) -> None:
+    """A blank box grows every static seed at startup."""
+    slots_dir = _slots_dir(tmp_hal0_home)
+    assert not slots_dir.exists()
+
+    with TestClient(create_app()):
+        pass
+
+    names = {p.stem for p in slots_dir.glob("*.toml")}
+    assert set(STATIC_SEED_SLOTS) <= names
+    assert "brain" in names
+    assert "agent" in names
+
+
+def test_lifespan_slot_seed_converges_old_box_without_touching_edits(
+    tmp_hal0_home: str,
+) -> None:
+    """The upgrade case: an old box has agent (operator-edited), no
+    brain — startup adds the missing seed and leaves the edit alone."""
+    slots_dir = _slots_dir(tmp_hal0_home)
+    slots_dir.mkdir(parents=True)
+    (slots_dir / "agent.toml").write_text(
+        'name = "agent"\nport = 9999\nenabled = true\n', encoding="utf-8"
+    )
+
+    with TestClient(create_app()):
+        pass
+
+    assert (slots_dir / "brain.toml").exists()
+    # Operator edit survives untouched.
+    edited = (slots_dir / "agent.toml").read_text(encoding="utf-8")
+    assert "port = 9999" in edited
+    assert "enabled = true" in edited

--- a/tests/install/test_static_seeds.py
+++ b/tests/install/test_static_seeds.py
@@ -1,0 +1,90 @@
+"""Unit tests for :mod:`hal0.install.static_seeds`.
+
+Closes the same fresh-install-only gap the persona startup seed does
+(tests/api/test_startup_persona_seed.py): install.sh's slot-TOML copy
+loop never re-runs on ``hal0 update``, so these tests pin the
+copy-if-absent contract independently of the lifespan wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hal0.install.static_seeds import STATIC_SEED_SLOTS, seed_static_slots
+
+
+def _fake_installer_root(tmp_path: Path, names: tuple[str, ...] = STATIC_SEED_SLOTS) -> Path:
+    root = tmp_path / "installer-root"
+    src_dir = root / "installer" / "etc-hal0" / "slots"
+    src_dir.mkdir(parents=True)
+    for name in names:
+        (src_dir / f"{name}.toml").write_text(f'name = "{name}"\nport = 9000\n', encoding="utf-8")
+    return root
+
+
+def test_seed_static_slots_copies_all_missing(tmp_path: Path) -> None:
+    installer_root = _fake_installer_root(tmp_path)
+    dest = tmp_path / "slots"
+    seeded = seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert set(seeded) == set(STATIC_SEED_SLOTS)
+    for name in STATIC_SEED_SLOTS:
+        assert (dest / f"{name}.toml").exists()
+
+
+def test_seed_static_slots_skips_existing(tmp_path: Path) -> None:
+    installer_root = _fake_installer_root(tmp_path)
+    dest = tmp_path / "slots"
+    dest.mkdir()
+    (dest / "agent.toml").write_text('name = "agent"\nport = 1234\n', encoding="utf-8")
+    seeded = seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert "agent" not in seeded
+    assert "brain" in seeded
+    # Operator/prior file untouched.
+    assert "port = 1234" in (dest / "agent.toml").read_text(encoding="utf-8")
+
+
+def test_seed_static_slots_idempotent_second_run_noop(tmp_path: Path) -> None:
+    installer_root = _fake_installer_root(tmp_path)
+    dest = tmp_path / "slots"
+    first = seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert first  # something was seeded
+    second = seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert second == []
+
+
+def test_seed_static_slots_missing_source_logs_and_continues(tmp_path: Path) -> None:
+    """A partially-shipped installer tree (missing one seed source) must
+    not abort seeding the rest."""
+    names = tuple(n for n in STATIC_SEED_SLOTS if n != "brain")
+    installer_root = _fake_installer_root(tmp_path, names=names)
+    dest = tmp_path / "slots"
+    seeded = seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert "brain" not in seeded
+    assert set(seeded) == set(names)
+
+
+def test_seed_static_slots_creates_dest_dir(tmp_path: Path) -> None:
+    installer_root = _fake_installer_root(tmp_path)
+    dest = tmp_path / "nested" / "slots"
+    assert not dest.exists()
+    seed_static_slots(installer_root=installer_root, slots_dir=dest)
+    assert dest.is_dir()
+
+
+def test_static_seed_slots_matches_shipped_files() -> None:
+    """Every name in STATIC_SEED_SLOTS must have a real TOML in
+    installer/etc-hal0/slots/ — catches "added the name, forgot the
+    file" drift (install.sh's list is the sibling that must also stay
+    in sync, checked only by review since it's bash)."""
+    repo_root = Path(__file__).resolve().parents[2]
+    src_dir = repo_root / "installer" / "etc-hal0" / "slots"
+    for name in STATIC_SEED_SLOTS:
+        assert (src_dir / f"{name}.toml").is_file(), f"missing seed source for {name!r}"
+
+
+def test_seed_static_slots_default_args_seed_real_tree(tmp_path: Path) -> None:
+    """Default args (no installer_root/slots_dir override) resolve the
+    real repo tree in this dev/editable checkout and seed every slot."""
+    dest = tmp_path / "slots"
+    seeded = seed_static_slots(slots_dir=dest)
+    assert set(seeded) == set(STATIC_SEED_SLOTS)


### PR DESCRIPTION
## Problem

`install.sh`'s slot-TOML copy loop (`flm`/`tts`/`rerank`/`utility`/`img`/`agent`/`brain`) only runs on a fresh install. `hal0 update` never re-runs it — an existing box upgrading past a release that adds a new seed (`brain`, the dashboard steward's slot, landed in #1217 this session) never grows the file. Same gap class as the persona startup seed (#1204): fresh-install-only logic that update never reaches.

## Fix

`hal0.install.static_seeds.seed_static_slots()` — copy-if-absent, mirrors install.sh's loop in Python. Wired into the hal0-api lifespan right after the persona-seed block, same fail-soft `try`/`except` (seeding failure never blocks API startup). Existing `<name>.toml` (operator edit or prior seed) is never touched. `installer_root` resolution reuses `hermes_provision.REPO_ROOT_FOR_INSTALLER` — the dev/editable-vs-FHS probe every other installer-tree reader already uses.

Combined with #1204's persona seed and the try-restart in `updater.commit()`, a box on `hal0 update` now converges: code lands → hal0-api restarts → persona TOML seeds → slot TOMLs seed → sidebar Brain has both a persona and a slot to route `hal0/brain` to.

## Tests

- `tests/install/test_static_seeds.py`: copy-all-missing, skip-existing (operator file untouched), idempotent no-op on reseed, partial-installer-tree tolerance, dest-dir creation, and a real-tree consistency check (`STATIC_SEED_SLOTS` names all have a shipped TOML — catches list/file drift)
- `tests/api/test_startup_slot_seed.py`: blank box grows every seed at startup; upgrade case (edited `agent.toml`, missing `brain`) converges without touching the edit
- 162 passed across install/setup/startup-seed suites; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)