### PR TITLE
feat(brain-chat): [brain_chat] guardrails — kill switch, read-only mode, config-backed loop knobs

### DIFF
--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -57,9 +57,10 @@ from hal0.api._audit import record_action
 
 log = structlog.get_logger(__name__)
 
-# Loop budget — terminate even against a pathological LLM emitting tool_calls
-# forever (mirrors OmniRouter._MAX_LOOP_ROUNDS).
-_MAX_ROUNDS = 8
+# Loop budget and per-round transport timeout live in ``[brain_chat]``
+# (max_rounds / completion_timeout_s), read per-request via
+# _brain_chat_config(); the BrainChatConfig defaults (8 rounds, 300 s) are the
+# single source of truth.
 
 # The slot the steward drives. Points at the dedicated `brain` slot (the
 # hal0-brain profile's default model) — the resolver's generalized chain
@@ -716,6 +717,45 @@ def _resolve_tool(
     return None, "", {}, None, None
 
 
+def _brain_chat_config(request: Request) -> Any:
+    """The ``[brain_chat]`` config off app.state, or defaults.
+
+    Falls back to a fresh ``BrainChatConfig()`` (enabled, not read-only, 8
+    rounds, 300 s) when app.state carries no ``hal0_config`` — so bare test
+    apps and older configs behave exactly as before.
+    """
+    from hal0.config.schema import BrainChatConfig
+
+    cfg = getattr(request.app.state, "hal0_config", None)
+    bc = getattr(cfg, "brain_chat", None)
+    return bc if isinstance(bc, BrainChatConfig) else BrainChatConfig()
+
+
+def _is_read_tool(name: str, args: dict[str, Any]) -> bool:
+    """True when ``name`` only READS state (safe under read-only mode).
+
+    Mirrors the branch order of :func:`_dispatch_tool`: board reads, then
+    non-mutating platform tools, then GET-method local tools, then the admin
+    catalog's autonomous-read set. An unknown tool is treated as NOT a read,
+    so read-only fails closed.
+    """
+    if _resolve_read_tool(name, args)[0] is not None:
+        return True
+    p_method, _p_path, p_mutating = _resolve_platform_tool(name, args)
+    if p_method is not None:
+        return not p_mutating
+    method, _path, _tool_params, _body, _target = _resolve_tool(name, args)
+    if method is not None:
+        return method.upper() == "GET"
+    if name in _admin_tool_names():
+        try:
+            from hal0.mcp.admin import AUTONOMOUS_READ_TOOLS
+        except ImportError:
+            return False
+        return name in AUTONOMOUS_READ_TOOLS
+    return False
+
+
 async def _dispatch_tool(
     request: Request,
     client: Any,
@@ -738,6 +778,17 @@ async def _dispatch_tool(
     policy = _brain_tool_policy(request)
     if policy is not None and not policy.allows(name):
         return {"error": f"tool {name!r} is outside the hal0-brain persona's tools_allowed"}
+
+    # Read-only guardrail — refuses every mutating/admin-write tool regardless
+    # of the persona's tools_allowed / approval policy ([brain_chat]
+    # read_only=true). Reads still pass so the steward can answer questions.
+    if _brain_chat_config(request).read_only and not _is_read_tool(name, args):
+        return {
+            "error": (
+                f"tool {name!r} refused: the hal0-brain chat is in read-only mode "
+                "([brain_chat] read_only=true) — mutating and admin-write tools are disabled"
+            )
+        }
 
     read_method, read_path = _resolve_read_tool(name, args)
     if read_method is not None:
@@ -809,9 +860,10 @@ def _resolve_llm(request: Request) -> LlmFn:
         return injected
 
     base_url = getattr(request.app.state, "self_api_base_url", "http://127.0.0.1:8080")
+    timeout_s = _brain_chat_config(request).completion_timeout_s
 
     async def _primary_completion(body: dict[str, Any]) -> dict[str, Any]:
-        async with httpx.AsyncClient(timeout=300.0) as http:
+        async with httpx.AsyncClient(timeout=timeout_s) as http:
             try:
                 resp = await http.post(f"{base_url.rstrip('/')}/v1/chat/completions", json=body)
             except httpx.HTTPError as exc:
@@ -927,6 +979,17 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
         yield _sse({"type": "done"})
         return
 
+    cfg = _brain_chat_config(request)
+    if not cfg.enabled:
+        yield _sse(
+            {
+                "type": "error",
+                "message": "the hal0-brain agent chat is disabled ([brain_chat] enabled=false)",
+            }
+        )
+        yield _sse({"type": "done"})
+        return
+
     llm = _resolve_llm(request)
     board = payload.get("board")
     system_prompt, default_model = _resolve_profile(request)
@@ -944,7 +1007,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     }
 
     try:
-        for _round in range(_MAX_ROUNDS):
+        for _round in range(cfg.max_rounds):
             response = await llm(body)
             if isinstance(response, dict) and response.get("error"):
                 yield _sse({"type": "error", "message": str(response["error"])})
@@ -1023,12 +1086,14 @@ __all__ = [
     "PRIMARY_SLOT_MODEL",
     "_admin_tool_names",
     "_admin_tool_schemas",
+    "_brain_chat_config",
     "_brain_tool_policy",
     "_chat_stream",
     "_compact_board",
     "_dispatch_admin_tool",
     "_dispatch_platform_tool",
     "_dispatch_tool",
+    "_is_read_tool",
     "_resolve_platform_tool",
     "_resolve_read_tool",
     "_resolve_tool",

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2626,6 +2626,28 @@ class ActivityConfig(BaseModel):
     max_rows: int | None = Field(default=50_000, ge=100)
 
 
+class BrainChatConfig(BaseModel):
+    """``[brain_chat]`` — the dashboard's agent-chat steward (hal0-brain).
+
+    Guardrails and loop tuning for the slide-out chat that administers the
+    instance through tools (slots, models, benchmarks, the Operator Board).
+
+    ``enabled`` is a hard kill switch: when false the endpoint refuses every
+    turn, so the steward chat is off. ``read_only`` keeps the chat answering
+    and reading state but refuses every mutating or admin-write tool
+    server-side — a guardrail that holds INDEPENDENTLY of the ``hal0-brain``
+    persona's ``tools_allowed`` / approval policy (a persona edit can loosen
+    the persona, never this). ``max_rounds`` bounds the per-turn tool loop
+    (runaway backstop); ``completion_timeout_s`` is the transport timeout for
+    each LLM round against the brain/agent slot.
+    """
+
+    enabled: bool = True
+    read_only: bool = False
+    max_rounds: int = Field(default=8, ge=1, le=100)
+    completion_timeout_s: float = Field(default=300.0, gt=0)
+
+
 class Hal0Config(BaseModel):
     """Top-level hal0.toml pydantic model.
 
@@ -2646,6 +2668,7 @@ class Hal0Config(BaseModel):
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     memory: MemoryConfig = Field(default_factory=MemoryConfig)
     activity: ActivityConfig = Field(default_factory=ActivityConfig)
+    brain_chat: BrainChatConfig = Field(default_factory=BrainChatConfig)
 
 
 __all__ = [
@@ -2667,6 +2690,7 @@ __all__ = [
     "AgentConfig",
     "AgentMCPConfig",
     "AgentMetadataConfig",
+    "BrainChatConfig",
     "DeviceLiteral",
     "DispatcherConfig",
     "GPUInfo",

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -24,8 +24,10 @@ from hal0.api.routes import board
 from hal0.api.routes.board_chat import (
     _SYSTEM_PROMPT,
     BRAIN_SLOT_MODEL,
+    _brain_chat_config,
     _compact_board,
     _extract_tool_calls,
+    _is_read_tool,
     _resolve_platform_tool,
     _resolve_read_tool,
     _resolve_tool,
@@ -33,6 +35,7 @@ from hal0.api.routes.board_chat import (
     _tool_schemas,
 )
 from hal0.board import KANBAN_BASE_PATH, HermesKanbanClient
+from hal0.config.schema import BrainChatConfig, Hal0Config
 
 P = KANBAN_BASE_PATH
 
@@ -878,3 +881,105 @@ def test_extract_tool_calls_parses_string_args() -> None:
 
 def test_extract_tool_calls_empty_when_none() -> None:
     assert _extract_tool_calls(_final_response("hi")) == []
+
+
+# ── [brain_chat] guardrails: kill switch, read-only, config-backed knobs ─────
+
+
+class _FakeRequest:
+    def __init__(self, app) -> None:
+        self.app = app
+
+
+def _set_brain_chat_config(app, **kwargs) -> None:
+    """Attach a Hal0Config carrying a [brain_chat] override to app.state."""
+    app.state.hal0_config = Hal0Config(brain_chat=BrainChatConfig(**kwargs))
+
+
+def test_config_accessor_defaults_when_absent(tmp_path) -> None:
+    # The harness never sets app.state.hal0_config → defaults, behaviour-identical.
+    rec = _Recorder()
+    app, _client = _make_app(rec, _StubLLM([]), tmp_path)
+    cfg = _brain_chat_config(_FakeRequest(app))
+    assert (cfg.enabled, cfg.read_only, cfg.max_rounds) == (True, False, 8)
+
+
+def test_kill_switch_disables_chat_before_any_llm_call(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("should never run")])
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, enabled=False)
+
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "go"}]})
+    assert resp.status_code == 200
+    events = _sse_events(resp.text)
+    err = next(e for e in events if e["type"] == "error")
+    assert "disabled" in err["message"]
+    assert events[-1]["type"] == "done"
+    # The LLM was never invoked and no board request went out.
+    assert stub.calls == []
+    assert rec.requests == []
+
+
+def test_read_only_refuses_board_mutation_no_request_sent(tmp_path) -> None:
+    rec = _Recorder()
+    # The model tries to mutate; read-only must refuse before the PATCH.
+    stub = _StubLLM(
+        [
+            _tool_call_response("move_task", {"task_id": "t1", "status": "done"}, "c1"),
+            _final_response("ok"),
+        ]
+    )
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, read_only=True)
+
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "do"}]})
+    assert resp.status_code == 200
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert "read-only mode" in result["result"]["error"]
+    # No PATCH ever reached the board backend, and nothing was audited.
+    assert rec.recorded("PATCH", "/tasks/t1") == []
+    assert app.state.audit.query(action="board.chat.turn") == []
+
+
+def test_read_only_still_allows_reads(tmp_path) -> None:
+    rec = _Recorder()
+    rec.respond("GET", "/board", {"columns": []})
+    stub = _StubLLM([_tool_call_response("get_board", {}, "c_gb"), _final_response("ok")])
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, read_only=True)
+
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert resp.status_code == 200
+    # The read passed straight through — one GET, no refusal on it.
+    assert len(rec.recorded("GET", "/board")) == 1
+    events = _sse_events(resp.text)
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert "read-only mode" not in json.dumps(result["result"])
+
+
+def test_max_rounds_from_config_bounds_the_loop(tmp_path) -> None:
+    rec = _Recorder()
+    # A pathological model that ALWAYS emits a tool call and never terminates.
+    never_ends = [_tool_call_response("get_board", {}, f"c{i}") for i in range(10)]
+    rec.respond("GET", "/board", {"columns": []})
+    stub = _StubLLM(never_ends)
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, max_rounds=2)
+
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert resp.status_code == 200
+    # The loop ran exactly max_rounds times, not the stub's 10.
+    assert len(stub.calls) == 2
+
+
+def test_is_read_tool_classification() -> None:
+    # Board reads and non-mutating platform reads are safe.
+    assert _is_read_tool("get_board", {}) is True
+    assert _is_read_tool("list_slots", {}) is True
+    # Board and platform mutations are not.
+    assert _is_read_tool("move_task", {"task_id": "t1", "status": "done"}) is False
+    assert _is_read_tool("slot_load", {"name": "img"}) is False
+    # An unknown tool fails closed (treated as NOT a read).
+    assert _is_read_tool("definitely_not_a_tool", {}) is False

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
+    BrainChatConfig,
     DispatcherConfig,
     GPUInfo,
     Hal0Config,
@@ -30,6 +31,42 @@ from hal0.config.schema import (
     UpstreamEntry,
     UpstreamsConfig,
 )
+
+
+class TestBrainChatConfig:
+    def test_defaults_are_permissive_and_stable(self) -> None:
+        bc = BrainChatConfig()
+        assert bc.enabled is True
+        assert bc.read_only is False
+        assert bc.max_rounds == 8
+        assert bc.completion_timeout_s == 300.0
+
+    def test_present_on_hal0config_by_default(self) -> None:
+        assert Hal0Config().brain_chat == BrainChatConfig()
+
+    def test_guardrail_flags_round_trip_from_toml(self) -> None:
+        raw = tomllib.loads(
+            "[brain_chat]\n"
+            "enabled = false\n"
+            "read_only = true\n"
+            "max_rounds = 20\n"
+            "completion_timeout_s = 45.0\n"
+        )
+        cfg = Hal0Config(**raw)
+        assert cfg.brain_chat.enabled is False
+        assert cfg.brain_chat.read_only is True
+        assert cfg.brain_chat.max_rounds == 20
+        assert cfg.brain_chat.completion_timeout_s == 45.0
+
+    def test_max_rounds_bounds_enforced(self) -> None:
+        with pytest.raises(ValidationError):
+            BrainChatConfig(max_rounds=0)
+        with pytest.raises(ValidationError):
+            BrainChatConfig(max_rounds=101)
+
+    def test_completion_timeout_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            BrainChatConfig(completion_timeout_s=0)
 
 
 class TestServerConfigEnv:


### PR DESCRIPTION
Adds a `[brain_chat]` config section (`BrainChatConfig`) for the dashboard's agent-chat steward (hal0-brain), enforced server-side and **independent of the operator-editable persona TOML**.

## Why
Before this, the steward chat's only guardrails lived in the `hal0-brain` persona (`tools_allowed` + approval policy), and its loop budget + transport timeout were hardcoded module constants in `board_chat.py`. There was no operator-level off-switch and no way to make the chat advisory-only without hand-editing the persona.

## What
- **`enabled`** (default `true`) — hard kill switch. When false the endpoint refuses every turn: no LLM call, no board request.
- **`read_only`** (default `false`) — advisory mode. Reads still pass, but every mutating/admin-write tool is refused at the single `_dispatch_tool` chokepoint, regardless of the persona's `tools_allowed`/approval policy. Admin tools are classified via `admin.AUTONOMOUS_READ_TOOLS`; unknown tools **fail closed**.
- **`max_rounds`** / **`completion_timeout_s`** — the previously-hardcoded loop budget (8) and per-round transport timeout (300 s), now tunable without a code edit. The schema is the single source of truth; the dead module constants were removed.

`_brain_chat_config()` reads `app.state.hal0_config.brain_chat` with a defaults fallback, so bare test apps and existing configs are **behaviour-identical**.

## Naming
Named `brain_chat` from the start (the feature is the hal0-**brain** steward). The pre-existing `board_chat` module / `/api/board/chat` endpoint / UI rename is a separate mechanical follow-up PR, to keep this reviewable and avoid colliding with in-flight brain branches.

## Tests
`tests/config/test_schema.py` (defaults, bounds, TOML round-trip) + `tests/board/test_board_chat.py` (kill switch skips the LLM, read-only refuses a mutation with no request sent, read-only still allows reads, `max_rounds` bounds the loop, `_is_read_tool` classification incl. fail-closed). 563 passed across tests/board + tests/config + persona-seed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)