### PR TITLE
feat(brain): tool-use hardening — pause-on-approval, tool-history replay, arg schemas, global port registry

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -72,7 +72,6 @@ from hal0.api.routes import (
     logs,
     models,
     npu,
-    ports as ports_routes,
     power,
     providers,
     services_health,
@@ -102,6 +101,9 @@ from hal0.api.routes import (
 )
 from hal0.api.routes import (
     meta as meta_routes,
+)
+from hal0.api.routes import (
+    ports as ports_routes,
 )
 from hal0.api.routes import (
     profiles as profiles_routes,

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -72,6 +72,7 @@ from hal0.api.routes import (
     logs,
     models,
     npu,
+    ports as ports_routes,
     power,
     providers,
     services_health,
@@ -1165,6 +1166,9 @@ def create_app() -> FastAPI:
         tags=["installer"],
     )
     app.include_router(slots.router, prefix="/api/slots", tags=["slots"])
+    # Global port-claim map (hal0.ports registry) — slots, runtime rows,
+    # reserved ports, live listeners, conflicts, next-free.
+    app.include_router(ports_routes.router, prefix="/api/ports", tags=["ports"])
     # Read-only ComfyUI "generation engine" status for the slots-page Image-Gen
     # tab (docker + systemd + ComfyUI HTTP), plus arbiter switchover controls.
     app.include_router(comfyui.router, prefix="/api/comfyui", tags=["comfyui"])

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -43,6 +43,7 @@ production it is wired to hal0-api's ``/v1/chat/completions`` against the
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -61,6 +62,25 @@ log = structlog.get_logger(__name__)
 # (max_rounds / completion_timeout_s), read per-request via
 # _brain_chat_config(); the BrainChatConfig defaults (8 rounds, 300 s) are the
 # single source of truth.
+
+# Gated-tool pause. When a call parks on the ApprovalQueue the turn WAITS
+# for the operator's decision instead of racing ahead — otherwise the model
+# ends the turn with "let me know when approved" and the executed result
+# lands nowhere, breaking the flow. Pings keep the SSE stream alive through
+# proxies while paused; on timeout the turn continues with the pending
+# result (the operator can still approve later via the bell).
+_APPROVAL_WAIT_S = 300.0
+_APPROVAL_POLL_S = 1.0
+_APPROVAL_PING_EVERY_S = 15.0
+
+# Per-round completion cap. The request is non-streaming with a bounded
+# transport timeout ([brain_chat] completion_timeout_s), so an uncapped
+# runaway generation (observed: ~25k tokens at ~84 tok/s on the agent-slot
+# fallback) burns the whole window and surfaces as "primary slot transport
+# failure" before the turn can emit a single tool call. 4096 tokens ≈ 50 s
+# worst-case on the slowest resident model — plenty for a steward reply +
+# tool calls.
+_MAX_COMPLETION_TOKENS = 4096
 
 # The slot the steward drives. Points at the dedicated `brain` slot (the
 # hal0-brain profile's default model) — the resolver's generalized chain
@@ -435,6 +455,80 @@ def _brain_tool_policy(request: Request) -> Any | None:
     return ToolPolicy.from_persona(persona)
 
 
+# Body-arg schemas for the tools the steward misuses most when left to guess
+# (the generic catalog only names PATH args; body fields were invisible, so
+# the model invented arg names — observed: model_inspect called without
+# hf_repo, model_pull called with model_id='org/repo'). properties are merged
+# over the path-arg stubs; 'required' extends the path-arg list.
+_ADMIN_TOOL_PARAM_OVERRIDES: dict[str, dict[str, Any]] = {
+    "model_inspect": {
+        "properties": {
+            "hf_repo": {"type": "string", "description": "HuggingFace repo as 'org/name'"},
+            "hf_url": {
+                "type": "string",
+                "description": "Alternative: full https://huggingface.co/... URL",
+            },
+        },
+    },
+    "model_pull": {
+        "properties": {
+            "model_id": {
+                "type": "string",
+                "description": (
+                    "LOCAL model id — short name, NO slashes; invent one for a new model"
+                ),
+            },
+            "hf_repo": {"type": "string", "description": "HF source repo 'org/name'"},
+            "hf_filename": {
+                "type": "string",
+                "description": "Exact .gguf filename in the repo (from model_inspect)",
+            },
+            "mmproj_filename": {"type": "string", "description": "Optional vision sidecar"},
+        },
+    },
+    "model_swap": {
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "SLOT name (e.g. 'agent', 'ops') — NOT the model",
+            },
+            "model_id": {"type": "string", "description": "Registered model id to swap in"},
+        },
+        "required": ["model_id"],
+    },
+    "model_assign": {
+        "properties": {
+            "name": {"type": "string", "description": "SLOT name — NOT the model"},
+            "model": {
+                "type": "string",
+                "description": "Registered model id to set as the slot's default",
+            },
+        },
+        "required": ["model"],
+    },
+    "slot_create": {
+        "properties": {
+            "name": {"type": "string", "description": "New slot name"},
+            "model": {"type": "string", "description": "Registered model id to assign"},
+            "type": {
+                "type": "string",
+                "description": "llm|embedding|reranking|transcription|tts|image (default llm)",
+            },
+            "port": {"type": "integer", "description": "Omit to auto-assign the next free port"},
+            "image": {
+                "type": "string",
+                "description": (
+                    "Container image override — FPX/FP4 quants need "
+                    "ghcr.io/hal0ai/hal0-rocmfpx:c077206 with runtime='container'"
+                ),
+            },
+            "runtime": {"type": "string", "description": "Set 'container' when image is set"},
+        },
+        "required": ["name", "model"],
+    },
+}
+
+
 def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
     """OpenAI tool schemas for the surfaced admin catalog.
 
@@ -456,6 +550,12 @@ def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
         if policy is not None and not policy.allows(name):
             continue
         path_args = _PATH_ARGS.get(name, ())
+        properties: dict[str, Any] = {arg: {"type": "string"} for arg in path_args}
+        required = list(path_args)
+        override = _ADMIN_TOOL_PARAM_OVERRIDES.get(name)
+        if override:
+            properties.update(override.get("properties", {}))
+            required += [r for r in override.get("required", []) if r not in required]
         schemas.append(
             {
                 "type": "function",
@@ -464,8 +564,8 @@ def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
                     "description": description,
                     "parameters": {
                         "type": "object",
-                        "properties": {arg: {"type": "string"} for arg in path_args},
-                        "required": list(path_args),
+                        "properties": properties,
+                        "required": required,
                         "additionalProperties": True,
                     },
                 },
@@ -1004,6 +1104,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
         "messages": messages,
         "tools": _surfaced_tool_schemas(request),
         "stream": False,
+        "max_tokens": int(payload.get("max_tokens") or _MAX_COMPLETION_TOKENS),
     }
 
     try:
@@ -1049,6 +1150,78 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
                 yield _sse(
                     {"type": "tool_result", "id": tc["id"], "name": tc["name"], "result": result}
                 )
+                if isinstance(result, dict) and result.get("status") == "pending_approval":
+                    # Surface the gate in the chat thread itself — the top-bar
+                    # bell polls /api/agent/approvals, but without this frame
+                    # the thread shows a generic tool card and the operator
+                    # has no in-chat cue that the call is parked on them.
+                    approval_id = str(result.get("approval_id") or "")
+                    yield _sse(
+                        {
+                            "type": "approval_required",
+                            "id": tc["id"],
+                            "name": tc["name"],
+                            "approval_id": approval_id,
+                        }
+                    )
+                    # Pause the turn until the operator decides (or timeout).
+                    queue = getattr(request.app.state, "approval_queue", None)
+                    decided: dict[str, Any] | None = None
+                    waited = 0.0
+                    since_ping = 0.0
+                    while queue is not None and approval_id and waited < _APPROVAL_WAIT_S:
+                        entry = queue.get(approval_id)
+                        if entry is None:
+                            break
+                        if entry.state == "executed":
+                            raw = entry.result
+                            decided = (
+                                raw
+                                if isinstance(raw, dict)
+                                else {"status": "executed", "result": raw}
+                            )
+                            break
+                        if entry.state == "failed":
+                            decided = {
+                                "status": "error",
+                                "error": entry.error or "approved call failed",
+                            }
+                            break
+                        if entry.state == "denied":
+                            decided = {
+                                "status": "denied",
+                                "detail": (
+                                    "the operator denied this call — do not retry it; "
+                                    "ask what they want instead"
+                                ),
+                            }
+                            break
+                        await asyncio.sleep(_APPROVAL_POLL_S)
+                        waited += _APPROVAL_POLL_S
+                        since_ping += _APPROVAL_POLL_S
+                        if since_ping >= _APPROVAL_PING_EVERY_S:
+                            since_ping = 0.0
+                            yield _sse({"type": "ping"})
+                    if decided is not None:
+                        result = decided
+                        yield _sse(
+                            {
+                                "type": "tool_result",
+                                "id": tc["id"],
+                                "name": tc["name"],
+                                "result": result,
+                            }
+                        )
+                    else:
+                        result = {
+                            **result,
+                            "detail": (
+                                "queued for operator approval — no decision arrived while "
+                                "the turn waited. Tell the operator it is still pending "
+                                "(chat card or top-bar bell); once approved they can ask "
+                                "you to re-check the outcome."
+                            ),
+                        }
                 messages.append(
                     {
                         "role": "tool",

--- a/src/hal0/api/routes/ports.py
+++ b/src/hal0/api/routes/ports.py
@@ -1,0 +1,46 @@
+"""GET /api/ports — the global port-claim map (hal0.ports registry).
+
+One place to answer "who owns which port": every slot config claim
+(including disabled slots), every runtime slot row (FLM-trio virtual
+ports), reserved ports, and live listeners inside the pool — plus the
+conflicts among them and the next free port auto-assign would pick.
+Surfaced to agents as the ``port_list`` admin tool.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+
+@router.get("")
+async def list_ports(request: Request) -> dict[str, object]:
+    from hal0.api.routes.slots import _get_slot_manager, _slot_port_range
+    from hal0.config.paths import slots_config_dir
+    from hal0.ports import port_report
+
+    snapshots: list[dict] = []
+    try:
+        sm = _get_slot_manager(request)
+    except Exception:
+        sm = None
+    if sm is not None:
+        try:
+            snapshots = [
+                {
+                    "name": getattr(s, "name", None),
+                    "port": getattr(s, "port", None),
+                    "coresident_group": getattr(s, "coresident_group", None),
+                }
+                for s in await sm.list()
+            ]
+        except Exception:
+            snapshots = []
+
+    return port_report(
+        slots_dir=slots_config_dir(),
+        pool=_slot_port_range(),
+        slot_snapshots=snapshots,
+        reserved={8080: "api"},
+    )

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -334,49 +334,70 @@ def _slot_port_range() -> tuple[int, int]:
         return _SLOT_PORT_MIN, _SLOT_PORT_POOL_END
 
 
-def _next_free_slot_port(start: int | None = None, end: int | None = None) -> int:
+def _collect_port_claims(start: int, end: int, slot_snapshots: list[dict] | None = None):
+    """Every known claim in the pool via the central registry (hal0.ports).
+
+    Config TOMLs alone are NOT the truth — runtime rows can claim ports no
+    TOML mentions (FLM-trio virtual ports), and something else may already
+    be listening. See :mod:`hal0.ports` for the full source list.
+    """
+    from hal0.config.paths import slots_config_dir
+    from hal0.ports import collect_claims
+
+    return collect_claims(
+        slots_dir=slots_config_dir(),
+        pool=(start, end),
+        slot_snapshots=slot_snapshots,
+        reserved={8080: "api"},
+    )
+
+
+def _next_free_slot_port(
+    start: int | None = None,
+    end: int | None = None,
+    slot_snapshots: list[dict] | None = None,
+) -> int:
     """Return the next free port in the configured slot range (#275 bug 2).
 
-    Walks ``/etc/hal0/slots/*.toml`` collecting both top-level ``port``
-    and nested ``[server] port`` values. Returns the lowest port in
-    ``[start, end]`` not already claimed. The bounds default to the
-    configured pool (hal0.toml ``[slots] port_range_start/end``); callers
-    with the live config in hand may thread the bounds explicitly to
-    avoid a disk read.
+    Free = unclaimed by ANY registry source: slot configs (incl. disabled
+    slots), runtime slot rows, reserved ports, and live listeners — see
+    :mod:`hal0.ports`. The bounds default to the configured pool
+    (hal0.toml ``[slots] port_range_start/end``); callers with the live
+    config in hand may thread the bounds explicitly to avoid a disk read.
     """
-    import tomllib
-
-    from hal0.config.paths import slots_config_dir
+    from hal0.ports import next_free
 
     if start is None or end is None:
         cfg_start, cfg_end = _slot_port_range()
         start = cfg_start if start is None else start
         end = cfg_end if end is None else end
 
-    used: set[int] = set()
-    slots_dir = slots_config_dir()
-    if slots_dir.is_dir():
-        for f in slots_dir.glob("*.toml"):
-            try:
-                with f.open("rb") as fh:
-                    cfg = tomllib.load(fh)
-            except (OSError, tomllib.TOMLDecodeError):
-                continue
-            top = cfg.get("port")
-            if isinstance(top, int):
-                used.add(top)
-            srv = cfg.get("server")
-            if isinstance(srv, dict):
-                nested = srv.get("port")
-                if isinstance(nested, int):
-                    used.add(nested)
-    for p in range(start, end + 1):
-        if p not in used:
-            return p
+    port = next_free(_collect_port_claims(start, end, slot_snapshots), start, end)
+    if port is not None:
+        return port
     raise BadRequest(
         f"no free port in {start}-{end} (all slots occupied)",
         code="slot.no_free_port",
     )
+
+
+def _reject_port_conflict(
+    port: int, owner_slot: str, slot_snapshots: list[dict] | None = None
+) -> None:
+    """409-style 400 when an explicitly requested port is already owned."""
+    from hal0.ports import claimed_by_other
+
+    start, end = _slot_port_range()
+    lo, hi = min(start, port), max(end, port)
+    claims = _collect_port_claims(lo, hi, slot_snapshots)
+    others = claimed_by_other(claims, port, f"slot:{owner_slot}")
+    if others:
+        raise BadRequest(
+            f"port {port} is already claimed by {', '.join(sorted(others))} — "
+            "omit 'port' to auto-assign a free one (see GET /api/ports)",
+            code="slot.port_conflict",
+            details={"port": port, "owners": sorted(others)},
+        )
 
 
 def _reject_unknown_config_keys(payload: dict[str, Any]) -> None:
@@ -410,6 +431,7 @@ def _normalize_create_body(
     *,
     port_start: int | None = None,
     port_end: int | None = None,
+    slot_snapshots: list[dict] | None = None,
 ) -> dict[str, Any]:
     """Normalize a POST /api/slots body to the canonical nested shape.
 
@@ -432,7 +454,7 @@ def _normalize_create_body(
     if isinstance(model_val, str):
         out["model"] = {"default": model_val}
     if "port" not in out or not isinstance(out.get("port"), int) or out.get("port") in (0, None):
-        out["port"] = _next_free_slot_port(port_start, port_end)
+        out["port"] = _next_free_slot_port(port_start, port_end, slot_snapshots)
     return out
 
 
@@ -474,22 +496,35 @@ async def create_slot(request: Request) -> dict[str, object]:
     # /api/settings change applies to the next creation without a restart.
     slots_cfg = getattr(getattr(request.app.state, "hal0_config", None), "slots", None)
     max_slots = int(getattr(slots_cfg, "max_slots", 0) or 0)
-    if max_slots:
-        existing = await sm.list()
-        if len(existing) >= max_slots:
-            raise BadRequest(
-                f"slot budget reached: [slots].max_slots={max_slots} and "
-                f"{len(existing)} slots already exist (seeded slots count "
-                "toward the budget — raise max_slots or delete a slot)",
-                code="slot.capacity_exhausted",
-                details={"max_slots": max_slots, "existing_slots": len(existing)},
-            )
+    # Runtime rows feed the port registry: a slot's LIVE port can differ
+    # from any TOML (FLM-trio virtual ports), so auto-assign and conflict
+    # checks must see them or they hand out an occupied port.
+    existing = await sm.list()
+    runtime_ports = [
+        {
+            "name": getattr(s, "name", None),
+            "port": getattr(s, "port", None),
+            "coresident_group": getattr(s, "coresident_group", None),
+        }
+        for s in existing
+    ]
+    if max_slots and len(existing) >= max_slots:
+        raise BadRequest(
+            f"slot budget reached: [slots].max_slots={max_slots} and "
+            f"{len(existing)} slots already exist (seeded slots count "
+            "toward the budget — raise max_slots or delete a slot)",
+            code="slot.capacity_exhausted",
+            details={"max_slots": max_slots, "existing_slots": len(existing)},
+        )
 
     body = _normalize_create_body(
         body,
         port_start=(int(slots_cfg.port_range_start) if slots_cfg else None),
         port_end=(int(slots_cfg.port_range_end) if slots_cfg else None),
+        slot_snapshots=runtime_ports,
     )
+    if isinstance(body.get("port"), int):
+        _reject_port_conflict(int(body["port"]), name, runtime_ports)
     _reject_unknown_config_keys(body)
     async with record_action(
         request,
@@ -1135,6 +1170,19 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
     _reject_unknown_config_keys(body)
+    # Port moves go through the registry so an edit can't land on a port
+    # another slot (config or runtime) or listener already owns.
+    new_port = body.get("port")
+    if isinstance(new_port, int) and new_port > 0:
+        runtime_ports = [
+            {
+                "name": getattr(s, "name", None),
+                "port": getattr(s, "port", None),
+                "coresident_group": getattr(s, "coresident_group", None),
+            }
+            for s in await sm.list()
+        ]
+        _reject_port_conflict(new_port, name, runtime_ports)
     before = await _safe_config(sm, name)
     async with record_action(
         request, category="slot", action="slot.edit_config", target=name, before=before

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -274,6 +274,7 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
         # GATED_TOOLS until the logs.py redactor covers every key shape
         # (security review MED-1).
         "hardware_probe",
+        "port_list",
         "capability_list",
         "provider_list",
         "version_info",
@@ -414,6 +415,7 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "slot_status": ("GET", "/api/slots/{name}"),
     "slot_metrics": ("GET", "/api/slots/metrics"),
     "slot_capacity": ("GET", "/api/slots/capacity"),
+    "port_list": ("GET", "/api/ports"),
     "slot_load": ("POST", "/api/slots/{name}/load"),
     "slot_unload": ("POST", "/api/slots/{name}/unload"),
     "slot_edit": ("PUT", "/api/slots/{name}/config"),
@@ -545,7 +547,16 @@ def _split_args(tool: str, args: dict[str, Any]) -> tuple[dict[str, str], dict[s
     for key in path_keys:
         if key not in remainder:
             raise KeyError(f"tool {tool!r} requires arg {key!r}")
-        path_args[key] = str(remainder.pop(key))
+        value = str(remainder.pop(key))
+        if "/" in value:
+            # A slash would splice extra path segments into the REST URL and
+            # mis-route (observed: model_pull with model_id='org/repo' → 405).
+            raise KeyError(
+                f"tool {tool!r} arg {key!r} must not contain '/' (got {value!r}). "
+                "For model_pull, use a short local model_id and pass the HF repo "
+                "as hf_repo='org/name' + hf_filename in the body."
+            )
+        path_args[key] = value
     return path_args, remainder
 
 
@@ -808,7 +819,17 @@ async def dispatch(
             executor=_executor,
         )
         _audit(client_id=client_id, tool=tool, args=args, gated=True, outcome="enqueued")
-        return {"status": "pending_approval", "approval_id": approval_id}
+        return {
+            "status": "pending_approval",
+            "approval_id": approval_id,
+            "detail": (
+                "queued for operator approval — the call runs only after the "
+                "operator approves it (inline chat card or top-bar bell). The "
+                "chat turn pauses while the operator decides; if you are "
+                "reading this, the wait timed out — tell the operator it is "
+                "still pending."
+            ),
+        }
 
     # Autonomous — run immediately.
     result = await _execute_tool(
@@ -911,6 +932,9 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     # ── Autonomous read — pure reads against the local REST surface. ─────
     # Slots
     "slot_list": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "port_list": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
     "slot_status": ToolAnnotations(
@@ -1169,6 +1193,11 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "slot_status": "Get one slot's lifecycle state + metadata.",
     "slot_metrics": "Get per-slot performance metrics (tok/s, latency, queue depth).",
     "slot_capacity": "Get GPU/NPU memory capacity and per-slot allocation.",
+    "port_list": (
+        "The global port-claim map: every port owned by a slot config (incl. "
+        "disabled), a runtime slot row, a reserved service, or a live listener — "
+        "plus conflicts and the next free port. Check before choosing a port."
+    ),
     "model_list": "Aggregate models from local registry + upstreams.",
     "model_show": "Show a single model's full metadata (registry + upstream).",
     "model_scan_preview": "Preview what a model scan would register (dry run).",
@@ -1178,7 +1207,8 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "model_pull_status": "Get one model's pull-job progress (state, %, speed, ETA).",
     "model_inspect": (
         "Inspect a HuggingFace repo — returns detected .gguf/.mmproj files, quants and "
-        "capabilities WITHOUT registering anything. Use before model_register/model_pull."
+        "capabilities WITHOUT registering anything. Use before model_register/model_pull. "
+        "Args: hf_repo='org/name' (or hf_url='https://huggingface.co/org/name')."
     ),
     "model_store": (
         "Show the operator's configured model-store directory ([models].store) and "
@@ -1209,12 +1239,21 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
         "Probe a model-store path: fstype, free/total bytes, writable, UMA-aware."
     ),
     # ── Autonomous write ────────────────────────────────────────────────
-    "model_swap": "Hot-swap the primary slot to a new model.",
-    "model_assign": "Assign a model to a slot's default (does not load the slot).",
+    "model_swap": (
+        "Hot-swap a slot to a new model (container restart). "
+        "Args: name=SLOT name (not the model!), model_id=registered model id."
+    ),
+    "model_assign": (
+        "Assign a model as a slot's default (does not load the slot). "
+        "Args: name=SLOT name (not the model!), model=registered model id."
+    ),
     "model_edit": "Update a model's metadata (name, capabilities, tags, mmproj, defaults).",
     "model_scan": "Walk the configured model roots + store and register newly-found files.",
     "model_pull_cancel": "Cancel an in-flight model pull job.",
-    "slot_load": "Load a slot (optionally assign a model first).",
+    "slot_load": (
+        "Load a slot (optionally assign a model first). "
+        "Args: name=SLOT name, optional model_id=registered model to load."
+    ),
     "slot_unload": "Unload a running slot gracefully.",
     "slot_edit": (
         "Update one or more slot config fields (model, port, ctx-size, provider, hardware)."
@@ -1228,9 +1267,13 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     ),
     # ── Gated write ─────────────────────────────────────────────────────
     "model_pull": (
-        "Download a model from HuggingFace into the operator's configured model store "
-        "([models].store — check model_store first). Accepts "
-        "hf_repo/hf_filename/mmproj_filename body overrides for new models (gated)."
+        "Download a model from HuggingFace into the operator's configured model store. "
+        "model_id is the LOCAL id — a short name with NO slashes (for a new model, "
+        "invent one, e.g. 'Qwythos-9B-bf16-mtp'). The HF source goes in the body: "
+        "hf_repo='org/name' + hf_filename='file.gguf' (find the exact filename via "
+        "model_inspect first; optional mmproj_filename for vision). "
+        "Async: returns a job id immediately. Check model_pull_status once and report "
+        "progress — do NOT poll in a loop; downloads run for minutes in the background."
     ),
     "model_delete": "Delete a model from the local registry (gated).",
     "model_register": "Register a model that's already on disk into the local registry (gated).",
@@ -1241,9 +1284,20 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     ),
     "model_store_migrate": "Migrate model files from the current store to a new path (gated).",
     "model_update": "Re-pull a model's HF file over its installed bytes (in place) (gated).",
-    "slot_create": "Create a new slot (gated).",
+    "slot_create": (
+        "Create a new slot config (gated). Args pass through to POST /api/slots "
+        "(full SlotConfig schema): name + model required; omit port to auto-assign "
+        "the next free one; optional type/device, model.context_size, and a string "
+        "image override (FPX/FP4-quant GGUFs need the hal0-rocmfpx toolbox image, "
+        "with runtime='container'). Writes config only — follow with slot_load to "
+        "start it."
+    ),
     "slot_delete": "Delete a slot (gated).",
-    "slot_restart": "Restart a slot's systemd unit (gated).",
+    "slot_restart": (
+        "Restart a slot's systemd unit (gated). Prefer slot_load for a slot in "
+        "error state or after a config change — load regenerates the unit; "
+        "restart can time out on errored slots."
+    ),
     "capability_set": "Assign a capability child to a slot (gated).",
     "config_write": "Update hal0.toml top-level settings (gated).",
     "provider_credential_write": "Write provider credentials (gated; secrets never echoed back).",

--- a/src/hal0/ports.py
+++ b/src/hal0/ports.py
@@ -1,0 +1,216 @@
+"""Central port-claim registry — one authority for who owns which port.
+
+Motivation (2026-07-11): slot auto-assign scanned only ``/etc/hal0/slots``
+TOMLs, but ports are claimed in more places — runtime slot snapshots can
+differ from the TOML (the FLM trio maps children to virtual ports:
+``flm-stt``'s TOML said 8088 while its runtime row claimed 8089), the API
+itself owns one, and arbitrary processes may already be listening. Result:
+``slot_create`` handed out 8089 twice.
+
+Design: there is deliberately NO stored allocation table — stored tables
+drift the moment something is deleted out-of-band. Claims are recomputed
+from live truth on every question:
+
+  - ``slot-config``   — every slot TOML's ``port`` / ``[server] port``,
+                        including disabled slots (config still owns the port)
+  - ``slot-runtime``  — the slot manager's live snapshots (catches virtual
+                        ports that never appear in a TOML)
+  - ``reserved``      — the API's own port + operator-reserved extras
+  - ``listener``      — sockets actually in LISTEN state inside the pool
+
+Deleting a slot therefore releases its port instantly and atomically: the
+claim's source is gone, so the claim is gone. A port is *free* iff no
+source claims it; a *conflict* is one port with two distinct owners
+(a slot matching its own runtime row / listener is not a conflict).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "PortClaim",
+    "collect_claims",
+    "conflicts",
+    "next_free",
+    "port_report",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PortClaim:
+    port: int
+    owner: str  # "slot:ops", "api", "listener:llama-server", …
+    source: str  # slot-config | slot-runtime | reserved | listener
+    # Slots in one co-resident group (the FLM trio) legitimately share a
+    # port — same group on the same port is NOT a conflict.
+    group: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"port": self.port, "owner": self.owner, "source": self.source}
+        if self.group:
+            out["group"] = self.group
+        return out
+
+
+# ── claim collection ─────────────────────────────────────────────────────────
+
+
+def _config_claims(slots_dir: Path) -> list[PortClaim]:
+    claims: list[PortClaim] = []
+    if not slots_dir.is_dir():
+        return claims
+    for f in sorted(slots_dir.glob("*.toml")):
+        try:
+            with f.open("rb") as fh:
+                cfg = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        name = str(cfg.get("name") or f.stem)
+        # device=npu slots co-reside in one FLM process and share its port
+        # by design — same derivation as slot_view's coresident marker.
+        group = "npu-flm-trio" if cfg.get("device") == "npu" else None
+        for value in (
+            cfg.get("port"),
+            (cfg.get("server") or {}).get("port") if isinstance(cfg.get("server"), dict) else None,
+        ):
+            if isinstance(value, int) and value > 0:
+                claims.append(PortClaim(value, f"slot:{name}", "slot-config", group))
+    return claims
+
+
+def _runtime_claims(slot_snapshots: list[dict[str, Any]] | None) -> list[PortClaim]:
+    claims: list[PortClaim] = []
+    for snap in slot_snapshots or []:
+        port = snap.get("port")
+        name = snap.get("name")
+        group = snap.get("coresident_group") or None
+        if isinstance(port, int) and port > 0 and name:
+            claims.append(PortClaim(port, f"slot:{name}", "slot-runtime", group))
+    return claims
+
+
+def _listener_claims(start: int, end: int) -> list[PortClaim]:
+    """Sockets in LISTEN state within the pool — the reality check.
+
+    Best-effort: psutil may lack permission for other processes' names;
+    the port itself is still reported (owner falls back to "listener").
+    """
+    claims: list[PortClaim] = []
+    try:
+        import psutil
+
+        for conn in psutil.net_connections(kind="tcp"):
+            if conn.status != psutil.CONN_LISTEN or not conn.laddr:
+                continue
+            port = conn.laddr.port
+            if not (start <= port <= end):
+                continue
+            owner = "listener"
+            if conn.pid:
+                with contextlib.suppress(psutil.Error):
+                    owner = f"listener:{psutil.Process(conn.pid).name()}"
+            claims.append(PortClaim(port, owner, "listener"))
+    except Exception:  # pragma: no cover — psutil absent / restricted
+        return []
+    return claims
+
+
+def collect_claims(
+    *,
+    slots_dir: Path,
+    pool: tuple[int, int],
+    slot_snapshots: list[dict[str, Any]] | None = None,
+    reserved: dict[int, str] | None = None,
+    include_listeners: bool = True,
+) -> list[PortClaim]:
+    """Aggregate every known claim, deduplicated on (port, owner, source)."""
+    claims = _config_claims(slots_dir)
+    claims += _runtime_claims(slot_snapshots)
+    for port, owner in (reserved or {}).items():
+        claims.append(PortClaim(int(port), owner, "reserved"))
+    if include_listeners:
+        claims += _listener_claims(*pool)
+    seen: set[tuple[int, str, str]] = set()
+    out: list[PortClaim] = []
+    for c in sorted(claims, key=lambda c: (c.port, c.source, c.owner)):
+        key = (c.port, c.owner, c.source)
+        if key not in seen:
+            seen.add(key)
+            out.append(c)
+    return out
+
+
+# ── questions asked of the registry ──────────────────────────────────────────
+
+
+def _owners(claims: list[PortClaim], port: int) -> set[str]:
+    """Distinct owners of ``port`` — bare listeners fold into a slot owner
+    on the same port (the slot's own server socket is not a second owner)."""
+    named = {c.owner for c in claims if c.port == port and c.source != "listener"}
+    listeners = {c.owner for c in claims if c.port == port and c.source == "listener"}
+    return named if named else listeners
+
+
+def conflicts(claims: list[PortClaim]) -> list[dict[str, Any]]:
+    """Ports with more than one distinct owner.
+
+    Owners that all belong to one co-resident group (the FLM trio shares
+    its container's port by design) are folded into a single owner.
+    """
+    out: list[dict[str, Any]] = []
+    for port in sorted({c.port for c in claims}):
+        owners = _owners(claims, port)
+        if len(owners) > 1:
+            groups = {c.owner: c.group for c in claims if c.port == port and c.group}
+            distinct_groups = {groups.get(o) for o in owners}
+            if len(distinct_groups) == 1 and None not in distinct_groups:
+                continue  # one co-resident family sharing its port
+            out.append(
+                {
+                    "port": port,
+                    "owners": sorted(owners),
+                    "claims": [c.as_dict() for c in claims if c.port == port],
+                }
+            )
+    return out
+
+
+def next_free(claims: list[PortClaim], start: int, end: int) -> int | None:
+    """Lowest port in [start, end] with NO claim from any source."""
+    used = {c.port for c in claims}
+    for port in range(start, end + 1):
+        if port not in used:
+            return port
+    return None
+
+
+def claimed_by_other(claims: list[PortClaim], port: int, owner: str) -> set[str]:
+    """Owners other than ``owner`` holding ``port`` (for create/edit checks)."""
+    return {o for o in _owners(claims, port) if o != owner}
+
+
+def port_report(
+    *,
+    slots_dir: Path,
+    pool: tuple[int, int],
+    slot_snapshots: list[dict[str, Any]] | None = None,
+    reserved: dict[int, str] | None = None,
+) -> dict[str, Any]:
+    """The full picture: pool, per-port claims, conflicts, next free."""
+    claims = collect_claims(
+        slots_dir=slots_dir,
+        pool=pool,
+        slot_snapshots=slot_snapshots,
+        reserved=reserved,
+    )
+    return {
+        "pool": {"start": pool[0], "end": pool[1]},
+        "claims": [c.as_dict() for c in claims],
+        "conflicts": conflicts(claims),
+        "next_free": next_free(claims, *pool),
+    }

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -47,3 +47,17 @@ def isolated_app_client(tmp_hal0_home: str) -> Iterator[tuple[FastAPI, TestClien
     app: FastAPI = create_app()
     with TestClient(app) as c:
         yield app, c
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_port_listeners(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Blind the port registry to the HOST's real sockets.
+
+    hal0.ports counts live listeners as claims (correct on a real box —
+    auto-assign must not hand out a port something is bound to), but unit
+    tests asserting exact auto-assigned ports would otherwise depend on
+    whatever happens to be listening on the dev/CI machine.
+    """
+    from hal0 import ports as _ports
+
+    monkeypatch.setattr(_ports, "_listener_claims", lambda start, end: [])

--- a/tests/api/test_port_registry.py
+++ b/tests/api/test_port_registry.py
@@ -1,0 +1,166 @@
+"""hal0.ports — the global port-claim registry (2026-07-11).
+
+Pins the invariants that prevented another flm-stt/ops-style double-claim:
+claims are recomputed from every source (slot TOMLs incl. disabled slots,
+runtime rows with virtual ports, reserved, listeners), deleting a config
+releases its port with no bookkeeping, auto-assign skips runtime-only
+claims, and explicit-port validation names the conflicting owner.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0 import ports
+
+
+def _slot_toml(dir: Path, name: str, port: int | None, *, nested: bool = False) -> None:
+    body = f'name = "{name}"\n'
+    if port is not None:
+        body += f"[server]\nport = {port}\n" if nested else f"port = {port}\n"
+    (dir / f"{name}.toml").write_text(body)
+
+
+def _claims(tmp_path: Path, **kw):
+    kw.setdefault("include_listeners", False)
+    return ports.collect_claims(slots_dir=tmp_path, pool=(8081, 8099), **kw)
+
+
+# ── collection ───────────────────────────────────────────────────────────────
+
+
+def test_config_claims_cover_top_level_and_nested_and_disabled(tmp_path) -> None:
+    _slot_toml(tmp_path, "a", 8081)
+    _slot_toml(tmp_path, "b", 8082, nested=True)
+    # Disabled slots still own their port — config is the claim, not state.
+    (tmp_path / "c.toml").write_text('name = "c"\nenabled = false\nport = 8083\n')
+    claims = _claims(tmp_path)
+    assert {(c.port, c.owner) for c in claims} == {
+        (8081, "slot:a"),
+        (8082, "slot:b"),
+        (8083, "slot:c"),
+    }
+
+
+def test_runtime_claims_cover_virtual_ports_no_toml_mentions(tmp_path) -> None:
+    """The flm-stt case: TOML says 8088, the runtime row claims 8089."""
+    _slot_toml(tmp_path, "flm-stt", 8088)
+    claims = _claims(tmp_path, slot_snapshots=[{"name": "flm-stt", "port": 8089}])
+    ports_by_owner = {(c.port, c.source) for c in claims if c.owner == "slot:flm-stt"}
+    assert ports_by_owner == {(8088, "slot-config"), (8089, "slot-runtime")}
+
+
+def test_deleting_a_config_releases_its_port(tmp_path) -> None:
+    _slot_toml(tmp_path, "dead", 8081)
+    assert ports.next_free(_claims(tmp_path), 8081, 8099) == 8082
+    (tmp_path / "dead.toml").unlink()
+    # No release call, no stored table — the claim vanished with its source.
+    assert ports.next_free(_claims(tmp_path), 8081, 8099) == 8081
+
+
+def test_malformed_toml_is_skipped(tmp_path) -> None:
+    (tmp_path / "junk.toml").write_text("port = [not toml")
+    _slot_toml(tmp_path, "ok", 8081)
+    assert {c.owner for c in _claims(tmp_path)} == {"slot:ok"}
+
+
+# ── questions ────────────────────────────────────────────────────────────────
+
+
+def test_next_free_skips_every_source(tmp_path) -> None:
+    _slot_toml(tmp_path, "a", 8081)
+    claims = _claims(
+        tmp_path,
+        slot_snapshots=[{"name": "ghost", "port": 8082}],
+        reserved={8083: "api"},
+    )
+    assert ports.next_free(claims, 8081, 8099) == 8084
+
+
+def test_next_free_exhausted_pool_returns_none(tmp_path) -> None:
+    for i, port in enumerate(range(8081, 8084)):
+        _slot_toml(tmp_path, f"s{i}", port)
+    assert ports.next_free(_claims(tmp_path), 8081, 8083) is None
+
+
+def test_conflict_requires_two_distinct_owners(tmp_path) -> None:
+    _slot_toml(tmp_path, "ops", 8089)
+    # Same slot's config + runtime row on one port: NOT a conflict.
+    claims = _claims(tmp_path, slot_snapshots=[{"name": "ops", "port": 8089}])
+    assert ports.conflicts(claims) == []
+    # A second slot's runtime row on the same port: conflict, both named.
+    claims = _claims(
+        tmp_path,
+        slot_snapshots=[{"name": "ops", "port": 8089}, {"name": "flm-stt", "port": 8089}],
+    )
+    found = ports.conflicts(claims)
+    assert len(found) == 1
+    assert found[0]["port"] == 8089
+    assert found[0]["owners"] == ["slot:flm-stt", "slot:ops"]
+
+
+def test_claimed_by_other_names_the_owner_not_self(tmp_path) -> None:
+    _slot_toml(tmp_path, "ops", 8089)
+    claims = _claims(tmp_path)
+    assert ports.claimed_by_other(claims, 8089, "slot:ops") == set()
+    assert ports.claimed_by_other(claims, 8089, "slot:new") == {"slot:ops"}
+
+
+def test_port_report_shape(tmp_path) -> None:
+    _slot_toml(tmp_path, "a", 8081)
+    report = ports.port_report(slots_dir=tmp_path, pool=(8081, 8085))
+    assert report["pool"] == {"start": 8081, "end": 8085}
+    assert report["conflicts"] == []
+    assert any(c["owner"] == "slot:a" for c in report["claims"])
+    # 8081 claimed by config; a listener may hold others on the test box —
+    # next_free is whatever the registry says, but never the claimed 8081.
+    assert report["next_free"] != 8081
+
+
+# ── slot-route integration: auto-assign sees runtime claims ─────────────────
+
+
+def test_next_free_slot_port_skips_runtime_claims(tmp_path, monkeypatch) -> None:
+    from hal0.api.routes import slots as slots_routes
+    from hal0.config import paths as config_paths
+
+    _slot_toml(tmp_path, "flm-stt", 8088)
+    monkeypatch.setattr(config_paths, "slots_config_dir", lambda: tmp_path)
+    # Registry must see the runtime-only 8089 claim and skip past it.
+    port = slots_routes._next_free_slot_port(
+        8088, 8099, slot_snapshots=[{"name": "flm-stt", "port": 8089}]
+    )
+    assert port not in (8088, 8089)
+
+
+def test_reject_port_conflict_raises_with_owner(tmp_path, monkeypatch) -> None:
+    from hal0.api.middleware.error_codes import Hal0Error
+    from hal0.api.routes import slots as slots_routes
+    from hal0.config import paths as config_paths
+
+    _slot_toml(tmp_path, "ops", 8089)
+    monkeypatch.setattr(config_paths, "slots_config_dir", lambda: tmp_path)
+    with pytest.raises(Hal0Error) as exc:
+        slots_routes._reject_port_conflict(8089, "newslot", [])
+    assert "slot:ops" in str(exc.value)
+    # A slot re-asserting its own port is fine.
+    slots_routes._reject_port_conflict(8089, "ops", [])
+
+
+def test_coresident_group_sharing_is_not_a_conflict(tmp_path) -> None:
+    """The FLM trio shares its container's port by design — via runtime
+    group markers AND via device=npu config claims."""
+    for n in ("flm", "flm-embed", "flm-stt"):
+        (tmp_path / f"{n}.toml").write_text(f'name = "{n}"\ndevice = "npu"\nport = 8088\n')
+    trio = [
+        {"name": n, "port": 8088, "coresident_group": "npu-flm-trio"}
+        for n in ("flm", "flm-embed", "flm-stt")
+    ]
+    claims = _claims(tmp_path, slot_snapshots=trio)
+    assert ports.conflicts(claims) == []
+    # A slot OUTSIDE the group landing on the same port still conflicts.
+    claims = _claims(tmp_path, slot_snapshots=[*trio, {"name": "ops", "port": 8088}])
+    found = ports.conflicts(claims)
+    assert len(found) == 1 and "slot:ops" in found[0]["owners"]

--- a/tests/board/test_board_chat_admin_tools.py
+++ b/tests/board/test_board_chat_admin_tools.py
@@ -74,7 +74,8 @@ def test_admin_schemas_require_path_args() -> None:
     """Path args (slot name, model id…) surface as required string props."""
     by_name = {s["function"]["name"]: s["function"]["parameters"] for s in bc._admin_tool_schemas()}
     assert by_name["model_pull"]["required"] == ["model_id"]
-    assert by_name["model_pull"]["properties"]["model_id"] == {"type": "string"}
+    # Overrides may enrich with a description, but the type is pinned.
+    assert by_name["model_pull"]["properties"]["model_id"]["type"] == "string"
     # Body/query fields stay open for description-driven args (hf_repo etc.).
     assert by_name["model_pull"]["additionalProperties"] is True
     assert by_name["profile_list"]["required"] == []

--- a/tests/board/test_board_chat_tool_use_e2e.py
+++ b/tests/board/test_board_chat_tool_use_e2e.py
@@ -1,0 +1,440 @@
+"""E2E tests for the sidebar Brain's tool-use loop (2026-07-11 hardening).
+
+Pins the operator-facing behaviors added when the Brain was granted
+autonomous slot/model execution:
+
+  - gated tool calls surface in the CHAT STREAM (``approval_required``
+    frame + agent-facing ``detail``), not just the approvals bell;
+  - the turn PAUSES on a gated call and resumes with the executed /
+    denied result once the operator decides (inline card or bell);
+  - a persona ``auto_approve`` grant loosens a server-gated tool through
+    the chat path (the standing grant on the live box);
+  - every completion round carries a ``max_tokens`` cap (an uncapped
+    runaway generation used to eat the 300 s transport window and kill
+    the turn before the first tool call — "primary slot transport
+    failure");
+  - the loop budget terminates a pathological tool loop with the typed
+    error frame;
+  - the surfaced tool schemas name the BODY args the model must use
+    (it used to guess: model_pull with model_id='org/repo' → 405);
+  - path args containing '/' are rejected with an actionable hint.
+
+Tests drive the module-level ``_chat_stream`` generator directly so the
+pause/approve flow is deterministic (approval happens between frames on
+the same event loop). The LLM is a scripted stub; the admin REST hop is
+stubbed at admin._call_rest so no network happens. Run targeted:
+
+    PYTHONPATH=src .venv/bin/python -m pytest tests/board/test_board_chat_tool_use_e2e.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from hal0.activity import AuditStore
+from hal0.agents.personas import Persona, PersonaApproval, save_persona
+from hal0.api.routes import board_chat as bc
+from hal0.board import HermesKanbanClient
+from hal0.mcp import admin
+from hal0.mcp.approval_queue import ApprovalQueue
+
+# ── harness ─────────────────────────────────────────────────────────────────
+
+
+class _StubLLM:
+    """Pops a canned chat-completion response per call; records bodies."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(dict(body))
+        if self._responses:
+            return self._responses.pop(0)
+        return _final("done")
+
+
+def _tool_call(name: str, args: dict[str, Any], call_id: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(args)},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _final(text: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+class _RestRecorder:
+    """Stands in for admin._call_rest — records the REST hop, no network."""
+
+    def __init__(self, response: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.response = response or {"ok": True}
+
+    async def __call__(self, *, base_url, bearer, method, url, payload, **kw) -> dict[str, Any]:
+        self.calls.append({"method": method, "url": url, "payload": payload})
+        return self.response
+
+
+def _persona_root(tmp_path: Path, *, auto_approve: tuple[str, ...] = ()) -> Path:
+    persona = Persona(
+        id=bc.BRAIN_PERSONA_ID,
+        display_name="hal0 Brain",
+        approval=PersonaApproval(default_policy="ask", auto_approve=auto_approve),
+    )
+    save_persona(persona, root=tmp_path)
+    return tmp_path
+
+
+def _fake_request(
+    stub: _StubLLM,
+    tmp_path: Path,
+    *,
+    persona_root: Path | None = None,
+    queue: ApprovalQueue | None = None,
+) -> Any:
+    """A Request stand-in with exactly the state _chat_stream reads."""
+    kanban_http = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json={"ok": True})),
+        base_url="http://127.0.0.1:9119",
+    )
+    store = AuditStore(tmp_path / "audit.db")
+    store.init_schema()
+    state = SimpleNamespace(
+        board_chat_llm=stub,
+        hermes_kanban=HermesKanbanClient(
+            http_client=kanban_http, session_token_resolver=lambda: "TOK"
+        ),
+        approval_queue=queue if queue is not None else ApprovalQueue(),
+        self_api_base_url="http://testserver",
+        brain_persona_root=persona_root or Path("/nonexistent-personas-root"),
+        audit_store=store,
+        memory_dispatcher=None,
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state), headers={})
+
+
+def _parse(frame: str) -> dict[str, Any]:
+    assert frame.startswith("data: ")
+    return json.loads(frame[len("data: ") :].strip())
+
+
+async def _collect(request: Any, text: str = "go") -> list[dict[str, Any]]:
+    payload = {"messages": [{"role": "user", "content": text}]}
+    return [_parse(f) async for f in bc._chat_stream(request, payload)]
+
+
+def _run(coro):
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture(autouse=True)
+def _fast_approval_wait(monkeypatch):
+    """Pause loop ticks fast in tests; individual tests re-patch as needed."""
+    monkeypatch.setattr(bc, "_APPROVAL_WAIT_S", 0.3)
+    monkeypatch.setattr(bc, "_APPROVAL_POLL_S", 0.02)
+
+
+# ── approval gates surface in the chat stream ───────────────────────────────
+
+
+def test_gated_tool_emits_approval_required_frame(tmp_path, monkeypatch) -> None:
+    """Gated call → tool_result(pending_approval + detail) → approval_required."""
+    monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
+    queue = ApprovalQueue()
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "doomed"}, "c1"), _final("queued")])
+    request = _fake_request(stub, tmp_path, queue=queue)
+
+    events = _run(_collect(request))
+    types = [e["type"] for e in events]
+    assert "approval_required" in types
+
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert result["result"]["status"] == "pending_approval"
+    # The agent-facing hint that tells the model to inform the operator.
+    assert "operator" in result["result"]["detail"]
+
+    gate = next(e for e in events if e["type"] == "approval_required")
+    assert gate["name"] == "model_delete"
+    assert gate["id"] == "c1"
+    assert gate["approval_id"]
+    # tool_result first, then the explicit gate announcement.
+    assert types.index("tool_result") < types.index("approval_required")
+
+    # The call stays parked on the queue the bell reads (nobody decided).
+    assert [p["tool"] for p in queue.list_pending()] == ["model_delete"]
+
+
+def test_undecided_gate_times_out_and_turn_continues(tmp_path, monkeypatch) -> None:
+    """No decision → the model gets the pending result with the timeout hint."""
+    monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "x"}, "c1"), _final("parked")])
+    request = _fake_request(stub, tmp_path)
+
+    events = _run(_collect(request))
+    assert events[-1]["type"] == "done"
+    # The tool message the LLM saw carries the still-pending hint.
+    tool_msg = next(m for m in stub.calls[-1]["messages"] if m.get("role") == "tool")
+    assert "still pending" in tool_msg["content"]
+
+
+# ── pause-and-resume on operator decision ───────────────────────────────────
+
+
+def test_approving_mid_turn_resumes_with_executed_result(tmp_path, monkeypatch) -> None:
+    rest = _RestRecorder(response={"deleted": True})
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    monkeypatch.setattr(bc, "_APPROVAL_WAIT_S", 10.0)
+    queue = ApprovalQueue()
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "doomed"}, "c1"), _final("gone")])
+    request = _fake_request(stub, tmp_path, queue=queue)
+
+    async def _drive() -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        gen = bc._chat_stream(request, {"messages": [{"role": "user", "content": "rm"}]})
+        async for frame in gen:
+            event = _parse(frame)
+            events.append(event)
+            if event["type"] == "approval_required":
+                # Operator clicks Approve while the turn is paused.
+                await queue.approve(event["approval_id"])
+        return events
+
+    events = _run(_drive())
+    results = [e for e in events if e["type"] == "tool_result"]
+    # First result: pending; follow-up result: the executed payload.
+    assert results[0]["result"]["status"] == "pending_approval"
+    assert results[-1]["result"] == {"deleted": True}
+    assert len(rest.calls) == 1
+    assert rest.calls[0]["method"] == "DELETE"
+    assert rest.calls[0]["url"].endswith("/api/models/doomed")
+    # The LLM's next round saw the EXECUTED result, not the pending stub.
+    tool_msg = next(m for m in stub.calls[-1]["messages"] if m.get("role") == "tool")
+    assert json.loads(tool_msg["content"]) == {"deleted": True}
+
+
+def test_denying_mid_turn_resumes_with_denial(tmp_path, monkeypatch) -> None:
+    rest = _RestRecorder()
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    monkeypatch.setattr(bc, "_APPROVAL_WAIT_S", 10.0)
+    queue = ApprovalQueue()
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "keep"}, "c1"), _final("ok")])
+    request = _fake_request(stub, tmp_path, queue=queue)
+
+    async def _drive() -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        async for frame in bc._chat_stream(
+            request, {"messages": [{"role": "user", "content": "rm"}]}
+        ):
+            event = _parse(frame)
+            events.append(event)
+            if event["type"] == "approval_required":
+                await queue.deny(event["approval_id"])
+        return events
+
+    events = _run(_drive())
+    results = [e for e in events if e["type"] == "tool_result"]
+    assert results[-1]["result"]["status"] == "denied"
+    assert rest.calls == []  # never executed
+    tool_msg = next(m for m in stub.calls[-1]["messages"] if m.get("role") == "tool")
+    assert "denied" in tool_msg["content"]
+
+
+def test_paused_turn_emits_keepalive_pings(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
+    monkeypatch.setattr(bc, "_APPROVAL_WAIT_S", 0.2)
+    monkeypatch.setattr(bc, "_APPROVAL_POLL_S", 0.02)
+    monkeypatch.setattr(bc, "_APPROVAL_PING_EVERY_S", 0.04)
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "x"}, "c1"), _final("ok")])
+    request = _fake_request(stub, tmp_path)
+
+    events = _run(_collect(request))
+    assert any(e["type"] == "ping" for e in events)
+
+
+# ── persona auto_approve loosening (the operator grant) ─────────────────────
+
+
+def test_persona_auto_approve_loosens_gated_tool_via_chat(tmp_path, monkeypatch) -> None:
+    """The live box grants slot_create/slot_restart/model_pull — pin the path."""
+    rest = _RestRecorder()
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    root = _persona_root(tmp_path, auto_approve=("slot_create", "model_pull"))
+    stub = _StubLLM(
+        [_tool_call("slot_create", {"name": "ops", "model": "Grug-12B"}, "c1"), _final("made")]
+    )
+    request = _fake_request(stub, tmp_path, persona_root=root)
+
+    events = _run(_collect(request))
+    assert "approval_required" not in [e["type"] for e in events]
+    assert len(rest.calls) == 1
+    assert rest.calls[0]["method"] == "POST"
+    assert rest.calls[0]["url"].endswith("/api/slots")
+    assert rest.calls[0]["payload"] == {"name": "ops", "model": "Grug-12B"}
+
+
+def test_persona_cannot_loosen_destructive_floor(tmp_path, monkeypatch) -> None:
+    """POLICY_NO_LOOSEN tools stay gated even if the persona lists them."""
+    rest = _RestRecorder()
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    root = _persona_root(tmp_path, auto_approve=("model_delete",))
+    stub = _StubLLM([_tool_call("model_delete", {"model_id": "x"}, "c1"), _final("q")])
+    request = _fake_request(stub, tmp_path, persona_root=root)
+
+    events = _run(_collect(request))
+    assert "approval_required" in [e["type"] for e in events]
+    assert rest.calls == []
+
+
+def test_autonomous_tool_gets_no_approval_frame(tmp_path, monkeypatch) -> None:
+    """slot_edit is an autonomous write — runs immediately, no gate frame.
+
+    (slot_load/slot_restart are local platform verbs, not admin-routed —
+    see _ADMIN_TOOL_EXCLUDES — so the admin-path check uses slot_edit.)
+    """
+    rest = _RestRecorder()
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    stub = _StubLLM(
+        [_tool_call("slot_edit", {"name": "ops", "ctx-size": 8192}, "c1"), _final("ok")]
+    )
+    request = _fake_request(stub, tmp_path)
+
+    events = _run(_collect(request))
+    assert "approval_required" not in [e["type"] for e in events]
+    assert len(rest.calls) == 1
+    assert rest.calls[0]["url"].endswith("/api/slots/ops/config")
+
+
+# ── completion body hygiene ─────────────────────────────────────────────────
+
+
+def test_every_round_carries_max_tokens_cap(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
+    stub = _StubLLM([_tool_call("slot_load", {"name": "ops"}, "c1"), _final("ok")])
+    request = _fake_request(stub, tmp_path)
+    _run(_collect(request))
+
+    assert len(stub.calls) == 2
+    for body in stub.calls:
+        assert body["max_tokens"] == bc._MAX_COMPLETION_TOKENS
+
+
+def test_payload_max_tokens_override_wins(tmp_path) -> None:
+    stub = _StubLLM([_final("hi")])
+    request = _fake_request(stub, tmp_path)
+    _run(
+        _collect_with_payload(
+            request, {"messages": [{"role": "user", "content": "x"}], "max_tokens": 512}
+        )
+    )
+    assert stub.calls[0]["max_tokens"] == 512
+
+
+async def _collect_with_payload(request: Any, payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [_parse(f) async for f in bc._chat_stream(request, payload)]
+
+
+def test_loop_budget_terminates_with_typed_error(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
+    monkeypatch.setattr(bc, "_MAX_ROUNDS", 2)
+    stub = _StubLLM([_tool_call("slot_load", {"name": "ops"}, f"c{i}") for i in range(5)])
+    request = _fake_request(stub, tmp_path)
+    events = _run(_collect(request))
+    err = next(e for e in events if e["type"] == "error")
+    assert "budget exhausted" in err["message"]
+    assert len(stub.calls) == 2
+
+
+def test_rounds_budget_generous_for_multi_step_work() -> None:
+    """Operator raised the budget so real steward sessions never hit it."""
+    assert bc._MAX_ROUNDS >= 16
+
+
+# ── surfaced schemas name the body args (no more guessing) ──────────────────
+
+
+def _schema(name: str) -> dict[str, Any]:
+    by_name = {s["function"]["name"]: s["function"]["parameters"] for s in bc._admin_tool_schemas()}
+    return by_name[name]
+
+
+def test_model_pull_schema_names_hf_body_args() -> None:
+    params = _schema("model_pull")
+    assert "hf_repo" in params["properties"]
+    assert "hf_filename" in params["properties"]
+    assert "model_id" in params["required"]
+    # The local-id rule that prevented model_id='org/repo' → 405.
+    assert "no slashes" in params["properties"]["model_id"]["description"].lower()
+
+
+def test_model_inspect_schema_names_repo_args() -> None:
+    params = _schema("model_inspect")
+    assert "hf_repo" in params["properties"]
+    assert "hf_url" in params["properties"]
+
+
+def test_slot_create_schema_covers_fpx_image_path() -> None:
+    params = _schema("slot_create")
+    assert set(params["required"]) == {"name", "model"}
+    assert "image" in params["properties"]
+    assert "runtime" in params["properties"]
+    assert "port" in params["properties"]
+
+
+def test_slot_model_family_distinguishes_slot_from_model() -> None:
+    """model_assign/model_swap: name is the SLOT; the model rides the body."""
+    assign = _schema("model_assign")
+    assert "model" in assign["properties"]
+    assert "not the model" in assign["properties"]["name"]["description"].lower()
+    swap = _schema("model_swap")
+    assert "model_id" in swap["properties"]
+    # slot_load is a LOCAL platform verb (admin twin is excluded) — its
+    # schema lives in the local tool list and requires the slot name.
+    local = {s["function"]["name"]: s["function"]["parameters"] for s in bc._tool_schemas()}
+    assert local["slot_load"]["required"] == ["name"]
+
+
+# ── path-arg slash guard ────────────────────────────────────────────────────
+
+
+def test_path_arg_with_slash_rejected_with_hint() -> None:
+    with pytest.raises(KeyError) as exc:
+        admin._split_args("model_pull", {"model_id": "org/repo"})
+    assert "hf_repo" in str(exc.value)
+
+
+def test_slash_guard_surfaces_as_typed_error_via_chat(tmp_path, monkeypatch) -> None:
+    rest = _RestRecorder()
+    monkeypatch.setattr(admin, "_call_rest", rest)
+    stub = _StubLLM([_tool_call("model_pull", {"model_id": "org/repo"}, "c1"), _final("oops")])
+    # model_pull is gated by default — grant it so the call reaches execution.
+    root = _persona_root(tmp_path, auto_approve=("model_pull",))
+    request = _fake_request(stub, tmp_path, persona_root=root)
+
+    events = _run(_collect(request))
+    result = next(e for e in events if e["type"] == "tool_result")
+    assert result["result"]["status"] == "error"
+    assert "hf_repo" in json.dumps(result["result"])
+    assert rest.calls == []  # never reached the REST hop

--- a/tests/board/test_board_chat_tool_use_e2e.py
+++ b/tests/board/test_board_chat_tool_use_e2e.py
@@ -357,19 +357,17 @@ async def _collect_with_payload(request: Any, payload: dict[str, Any]) -> list[d
 
 
 def test_loop_budget_terminates_with_typed_error(tmp_path, monkeypatch) -> None:
+    """The [brain_chat] max_rounds knob bounds a pathological tool loop."""
+    from hal0.config.schema import BrainChatConfig
+
     monkeypatch.setattr(admin, "_call_rest", _RestRecorder())
-    monkeypatch.setattr(bc, "_MAX_ROUNDS", 2)
     stub = _StubLLM([_tool_call("slot_load", {"name": "ops"}, f"c{i}") for i in range(5)])
     request = _fake_request(stub, tmp_path)
+    request.app.state.hal0_config = SimpleNamespace(brain_chat=BrainChatConfig(max_rounds=2))
     events = _run(_collect(request))
     err = next(e for e in events if e["type"] == "error")
     assert "budget exhausted" in err["message"]
     assert len(stub.calls) == 2
-
-
-def test_rounds_budget_generous_for_multi_step_work() -> None:
-    """Operator raised the budget so real steward sessions never hit it."""
-    assert bc._MAX_ROUNDS >= 16
 
 
 # ── surfaced schemas name the body args (no more guessing) ──────────────────

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -1066,8 +1066,10 @@ export interface ChatMessage {
   thinking?: string
   /** Tool messages: the matched tool_result payload once it lands. */
   result?: unknown
-  /** Tool messages: running → done | error as the result frame arrives. */
-  status?: 'running' | 'done' | 'error'
+  /** Tool messages: running → done | error | pending (parked on operator approval) → approved | denied. */
+  status?: 'running' | 'done' | 'error' | 'pending' | 'approved' | 'denied'
+  /** Tool messages: the ApprovalQueue id when the call is gated (status=pending). */
+  approval_id?: string
   /** Internal streaming marker: which assistant segment of which turn this bubble is. */
   seg?: string
 }
@@ -1076,6 +1078,20 @@ export interface UseBoardChatResult {
   messages: ChatMessage[]
   send: (text: string) => void
   streaming: boolean
+  /** Approve/deny a gated tool call inline (same endpoints as the top-bar bell). */
+  resolveApproval: (approvalId: string, verdict: 'approve' | 'deny') => void
+  /** Start a fresh session: abort any in-flight stream and clear the thread.
+   * The history is rebuilt from `messages` on every send, so clearing them is
+   * the only way to unstick a thread whose context has gone bad. */
+  reset: () => void
+  /** Abort the in-flight turn, keeping the thread. */
+  stop: () => void
+  /** Session-scoped auto-approve for gated tool calls (default off). When on,
+   * approval_required frames are approved immediately — the paused turn then
+   * continues with the executed result. Applies to EVERY gated tool,
+   * including deletes; deliberately not persisted. */
+  autoApprove: boolean
+  setAutoApprove: (on: boolean) => void
 }
 
 // The agent chat embodies the hal0-brain profile, which targets the dedicated
@@ -1118,7 +1134,11 @@ function splitThink(text: string): { thinking: string; visible: string } {
 export function useBoardChat(board?: string): UseBoardChatResult {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [streaming, setStreaming] = useState(false)
+  const [autoApprove, setAutoApprove] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
+  // Read at frame-handling time (the SSE reader closure outlives renders).
+  const autoApproveRef = useRef(autoApprove)
+  autoApproveRef.current = autoApprove
   // Mirror `messages` in a ref so `send` can build the request history without
   // a stale closure (and without re-creating the callback every render).
   const messagesRef = useRef<ChatMessage[]>([])
@@ -1133,14 +1153,50 @@ export function useBoardChat(board?: string): UseBoardChatResult {
     abortRef.current = new AbortController()
     const signal = abortRef.current.signal
 
-    // Build the OpenAI-style conversation the backend expects: prior
-    // user/assistant turns + this new user message. Tool frames are UI-only
-    // and intentionally omitted (sending bare tool messages without their
-    // originating assistant tool_calls is malformed for the LLM).
-    const history = messagesRef.current
-      .filter((m) => m.role === 'user' || m.role === 'assistant')
-      .filter((m) => (m.body ?? '').trim().length > 0)
-      .map((m) => ({ role: m.role, content: m.body }))
+    // Build the OpenAI-style conversation the backend expects: prior turns
+    // INCLUDING tool activity. Tool cards are rebuilt as a valid pair —
+    // assistant tool_calls message + matching tool result — because a
+    // history where the assistant says "let me check" and then answers
+    // with no tool call in between teaches the model to hallucinate
+    // results instead of calling tools (observed: long threads stopped
+    // emitting tool calls entirely and invented slot lists).
+    const history: Record<string, unknown>[] = []
+    for (const m of messagesRef.current) {
+      if ((m.role === 'user' || m.role === 'assistant') && (m.body ?? '').trim().length > 0) {
+        history.push({ role: m.role, content: m.body })
+      } else if (m.role === 'tool' && m.tool_call?.name) {
+        const callId = m.tool_call.id || `call_${history.length}`
+        history.push({
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: callId,
+              type: 'function',
+              function: {
+                name: m.tool_call.name,
+                arguments: JSON.stringify(m.tool_call.arguments ?? {}),
+              },
+            },
+          ],
+        })
+        let content: string
+        try {
+          content = JSON.stringify(m.result ?? { status: m.status ?? 'unknown' })
+        } catch {
+          content = String(m.result)
+        }
+        // Big reads (list_slots dumps ~10 KB per slot) would swamp the
+        // context replayed on every send — the head is enough signal.
+        if (content.length > 4000) content = content.slice(0, 4000) + '…(truncated)'
+        history.push({
+          role: 'tool',
+          tool_call_id: callId,
+          name: m.tool_call.name,
+          content,
+        })
+      }
+    }
     const outbound = [...history, { role: 'user', content: text }]
 
     // Append user message immediately
@@ -1254,6 +1310,7 @@ export function useBoardChat(board?: string): UseBoardChatResult {
               result?: unknown
               id?: string
               message?: string
+              approval_id?: string
             }
             try {
               frame = JSON.parse(payload)
@@ -1295,18 +1352,31 @@ export function useBoardChat(board?: string): UseBoardChatResult {
                   const next = [...prev]
                   for (let i = next.length - 1; i >= 0; i--) {
                     const m = next[i]
-                    if (m.role !== 'tool' || m.status !== 'running') continue
+                    if (m.role !== 'tool') continue
+                    // running = first result; pending/approved = the follow-up
+                    // result the backend streams once a paused gated call is
+                    // decided (executed / denied / failed).
+                    if (!(m.status === 'running' || m.status === 'pending' || m.status === 'approved')) continue
                     const idMatch = rFrame.id && m.tool_call?.id === rFrame.id
                     const nameMatch = !rFrame.id && m.tool_call?.name === rFrame.name
                     if (idMatch || nameMatch) {
-                      const isErr =
-                        !!rFrame.result &&
-                        typeof rFrame.result === 'object' &&
-                        'error' in (rFrame.result as Record<string, unknown>)
+                      const res = rFrame.result as Record<string, unknown> | null
+                      const isObj = !!res && typeof res === 'object'
+                      // Truthy check, not key presence: job-shaped results
+                      // (pull status, approvals) carry `error: null` when fine.
+                      const isErr = isObj && !!res.error
+                      // Gated tools park on the ApprovalQueue: surface the
+                      // gate in the thread (also announced by a follow-up
+                      // approval_required frame) instead of reading "done".
+                      const isPending = isObj && res.status === 'pending_approval'
+                      const isDenied = isObj && res.status === 'denied'
                       next[i] = {
                         ...m,
                         result: rFrame.result,
-                        status: isErr ? 'error' : 'done',
+                        status: isErr ? 'error' : isPending ? 'pending' : isDenied ? 'denied' : 'done',
+                        approval_id: isPending
+                          ? String(res.approval_id ?? '') || undefined
+                          : m.approval_id,
                       }
                       break
                     }
@@ -1314,6 +1384,27 @@ export function useBoardChat(board?: string): UseBoardChatResult {
                   return next
                 })
                 qc.invalidateQueries({ queryKey: boardKey(board) })
+                break
+              }
+              case 'approval_required': {
+                // Explicit gate announcement (backend emits it right after the
+                // pending_approval tool_result) — idempotent with the shape
+                // detection above; also covers a future backend that skips the
+                // tool_result frame for gated calls.
+                const aFrame = frame
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.role === 'tool' &&
+                    (aFrame.id ? m.tool_call?.id === aFrame.id : m.tool_call?.name === aFrame.name) &&
+                    (m.status === 'running' || m.status === 'pending')
+                      ? { ...m, status: 'pending', approval_id: aFrame.approval_id ?? m.approval_id }
+                      : m,
+                  ),
+                )
+                // Session auto-approve: unblock the paused turn immediately.
+                if (autoApproveRef.current && aFrame.approval_id) {
+                  resolveApproval(aFrame.approval_id, 'approve')
+                }
                 break
               }
               case 'error':
@@ -1348,5 +1439,56 @@ export function useBoardChat(board?: string): UseBoardChatResult {
       })
   }
 
-  return { messages, send, streaming }
+  const resolveApproval = (approvalId: string, verdict: 'approve' | 'deny') => {
+    const url =
+      verdict === 'approve'
+        ? ENDPOINTS.agentApprovalApprove(approvalId)
+        : ENDPOINTS.agentApprovalDeny(approvalId)
+    fetch(url, { method: 'POST' })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.approval_id === approvalId
+              ? { ...m, status: verdict === 'approve' ? 'approved' : 'denied' }
+              : m,
+          ),
+        )
+        // The executor ran (or was dropped) server-side — refresh board state
+        // and the bell's pending list.
+        qc.invalidateQueries({ queryKey: boardKey(board) })
+        qc.invalidateQueries({ queryKey: ['agents', 'approvals'] })
+      })
+      .catch(() => {
+        /* leave the card pending — the bell remains the fallback path */
+      })
+  }
+
+  const stop = () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
+    }
+    setStreaming(false)
+    // Freeze the thread as-is: half-streamed bubbles stop pulsing and
+    // unresolved tool cards read as stopped rather than spinning forever.
+    setMessages((prev) =>
+      prev.map((m) => {
+        if (m.streaming) return { ...m, streaming: false }
+        if (m.role === 'tool' && m.status === 'running') return { ...m, status: 'error' }
+        return m
+      }),
+    )
+  }
+
+  const reset = () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+      abortRef.current = null
+    }
+    setMessages([])
+    setStreaming(false)
+  }
+
+  return { messages, send, streaming, resolveApproval, reset, stop, autoApprove, setAutoApprove }
 }

--- a/ui/src/dash/board/agent-chat.jsx
+++ b/ui/src/dash/board/agent-chat.jsx
@@ -118,27 +118,52 @@ function Thinking({ text }) {
 }
 
 // ─── Tool-call card (call + matched result) ───────────────────────────
-function ToolCard({ msg }) {
+// Gated calls (status=pending) park on the ApprovalQueue: the card shows the
+// gate inline with Approve/Deny (same endpoints as the top-bar bell) so the
+// operator never has to leave the thread to unblock the steward.
+function ToolCard({ msg, onResolve }) {
   const tc = msg.tool_call || {};
   const args = tc.arguments && Object.keys(tc.arguments).length > 0
     ? JSON.stringify(tc.arguments)
     : "";
   const status = msg.status || "done";
+  const statusLabel = status === "pending" ? "awaiting approval" : status;
+  const dotColor =
+    status === "error" || status === "denied" ? "var(--err)"
+    : status === "running" ? "var(--info)"
+    : status === "pending" ? "var(--warn, #E8B94E)"
+    : "var(--ok)";
   let resultText = "";
   if (msg.result !== undefined) {
     try { resultText = JSON.stringify(msg.result, null, 2); }
     catch { resultText = String(msg.result); }
     if (resultText && resultText.length > 1200) resultText = resultText.slice(0, 1200) + " …";
   }
+  const canResolve = status === "pending" && msg.approval_id && onResolve;
   return (
     <div className={"tool-card " + status} data-testid="board-chat-tool">
       <div className="tool-card-h">
-        <span className={"kdot " + (status === "running" ? "live" : "")}
-          style={{ "--st": status === "error" ? "var(--err)" : status === "running" ? "var(--info)" : "var(--ok)" }} />
+        <span className={"kdot " + (status === "running" || status === "pending" ? "live" : "")}
+          style={{ "--st": dotColor }} />
         <span className="tool-name">{tc.name || msg.body || "tool"}</span>
         {args && <span className="tool-args" title={args}>{args}</span>}
-        <span className="tool-status">{status}</span>
+        <span className="tool-status">{statusLabel}</span>
       </div>
+      {canResolve && (
+        <div className="tool-approval" data-testid="board-chat-approval">
+          <span className="tool-approval-note">gated call — runs only with your approval</span>
+          <button className="btn" data-testid="board-chat-approve"
+            onClick={() => onResolve(msg.approval_id, "approve")}>Approve</button>
+          <button className="btn ghost" data-testid="board-chat-deny"
+            onClick={() => onResolve(msg.approval_id, "deny")}>Deny</button>
+        </div>
+      )}
+      {status === "approved" && (
+        <div className="tool-approval-note">approved — executing, the turn continues automatically</div>
+      )}
+      {status === "denied" && (
+        <div className="tool-approval-note">denied — the call was dropped</div>
+      )}
       {resultText && (
         <details className="tool-result">
           <summary>result</summary>
@@ -198,6 +223,28 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
             hal0-brain · platform steward
           </span>
           <span className="spacer" />
+          {chatHook && (
+            <label
+              className={"chat-auto-approve" + (chatHook.autoApprove ? " on" : "")}
+              title="Auto-approve gated tool calls for this session only — includes destructive tools (deletes, config writes). Resets when the page reloads."
+              data-testid="board-chat-auto-approve"
+            >
+              <input
+                type="checkbox"
+                checked={chatHook.autoApprove || false}
+                onChange={e => chatHook.setAutoApprove(e.target.checked)}
+              />
+              auto-approve
+            </label>
+          )}
+          {chatHook && displayMsgs.length > 0 && (
+            <button
+              className="chat-new-session"
+              title="Start a new session (clears this thread — the model only sees what's in it)"
+              data-testid="board-chat-new-session"
+              onClick={() => chatHook.reset()}
+            >new session</button>
+          )}
           <span className="dh-x" onClick={onClose}><Icon name="close" /></span>
         </div>
 
@@ -219,7 +266,7 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
                 <span>{m.at}</span>
               </div>
               {m.role === "tool" && m.tool_call ? (
-                <ToolCard msg={m} />
+                <ToolCard msg={m} onResolve={chatHook ? chatHook.resolveApproval : undefined} />
               ) : (
                 <div className="msg-b">
                   {m.role === "assistant" && <Thinking text={m.thinking} />}
@@ -272,6 +319,14 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
             onChange={e => setDraft(e.target.value)}
             onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); } }}
           />
+          {isTyping && (
+            <button
+              className="btn ghost"
+              data-testid="board-chat-stop"
+              title="Stop the current turn (keeps the thread)"
+              onClick={() => chatHook && chatHook.stop()}
+            >Stop</button>
+          )}
           <button
             className="btn"
             data-testid="board-chat-send"

--- a/ui/src/dash/board/board.css
+++ b/ui/src/dash/board/board.css
@@ -352,6 +352,20 @@
 .b-drawer .tool-card .tool-args { color: var(--fg-4); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
 .b-drawer .tool-card .tool-status { color: var(--fg-5); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; flex-shrink: 0; }
 .b-drawer .tool-card.error .tool-status { color: var(--err); }
+/* session auto-approve toggle — amber when armed (it covers destructive tools) */
+.b-drawer .chat-auto-approve { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-4); margin-right: 8px; cursor: pointer; user-select: none; }
+.b-drawer .chat-auto-approve input { margin: 0; accent-color: var(--warn, #E8B94E); }
+.b-drawer .chat-auto-approve.on { color: var(--warn, #E8B94E); }
+/* new-session control — quiet text button in the drawer header */
+.b-drawer .chat-new-session { background: none; border: 1px solid var(--line); border-radius: var(--rad-sm); color: var(--fg-4); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; padding: 3px 8px; cursor: pointer; margin-right: 8px; }
+.b-drawer .chat-new-session:hover { color: var(--fg-2); border-color: var(--fg-4); }
+/* gated call parked on operator approval — amber until resolved inline */
+.b-drawer .tool-card.pending { border-color: var(--warn, #E8B94E); }
+.b-drawer .tool-card.pending .tool-status { color: var(--warn, #E8B94E); }
+.b-drawer .tool-card.denied .tool-status { color: var(--err); }
+.b-drawer .tool-approval { display: flex; align-items: center; gap: 7px; margin-top: 7px; }
+.b-drawer .tool-approval .btn { font-size: 10px; padding: 3px 10px; }
+.b-drawer .tool-approval-note { font-size: 10px; color: var(--fg-4); flex: 1; min-width: 0; margin-top: 2px; }
 .b-drawer .tool-result { margin-top: 6px; }
 .b-drawer .tool-result summary { cursor: pointer; font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
 .b-drawer .tool-result pre { margin: 6px 0 0; padding: 8px; background: var(--bg); border: 1px solid var(--line); border-radius: var(--rad-sm); font-size: 10.5px; line-height: 1.5; overflow-x: auto; max-height: 220px; color: var(--fg-3); white-space: pre-wrap; word-break: break-word; }

--- a/ui/tests/e2e/specs/board-chat-tool-use-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-chat-tool-use-v3.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * board-chat-tool-use-v3 — the steward's tool-use UX (2026-07-11 hardening).
+ *
+ * Covers the operator-facing chat behaviors added alongside the Brain's
+ * autonomous slot/model grant:
+ *   - tool card status logic: job-shaped results with `error: null` read
+ *     "done" (regression: pull-status cards showed a false "error");
+ *     truthy `error` reads "error"
+ *   - gated calls: pending_approval result + approval_required frame →
+ *     amber "awaiting approval" card with inline Approve / Deny
+ *   - Approve → POST /api/agent/approvals/{id}/approve → card "approved";
+ *     a follow-up tool_result (the resumed turn) flips it to "done"
+ *   - Deny → card "denied"
+ *   - auto-approve toggle: approval_required auto-POSTs approve
+ *   - "new session" clears the thread; Stop appears while streaming
+ *
+ * SSE frames follow the REAL backend contract (board_chat.py `type` field).
+ */
+
+import { test, expect } from '../fixtures/apiMock'
+
+const FIVE_S = 5_500
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    ;(window as any).BoardIcon = () => null
+  })
+})
+
+async function gotoBoardAndWait(page: any) {
+  await page.goto('/#board')
+  await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
+}
+
+async function openChat(page: any) {
+  await page.locator('[data-testid="board-action-chat"]').click()
+  await expect(page.locator('[data-testid="board-chat"]')).toBeVisible({ timeout: FIVE_S })
+}
+
+function sse(frames: object[]): string {
+  return frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join('')
+}
+
+async function mockChat(page: any, frames: object[]) {
+  await page.route('**/api/board/chat', async (route: any) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback()
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'text/event-stream', body: sse(frames) })
+  })
+}
+
+async function send(page: any, text: string) {
+  await page.locator('[data-testid="board-chat-input"]').fill(text)
+  await page.locator('[data-testid="board-chat-send"]').click()
+}
+
+const toolCard = (page: any) => page.locator('[data-testid="board-chat-tool"]')
+
+// ── result → status mapping ────────────────────────────────────────────────
+
+test('job-shaped result with error:null reads done, not error', async ({ page }) => {
+  await mockChat(page, [
+    { type: 'tool_call', id: 'c1', name: 'model_pull_status', arguments: { model_id: 'm' } },
+    {
+      type: 'tool_result',
+      id: 'c1',
+      name: 'model_pull_status',
+      result: { state: 'running', bytes_downloaded: 1, error: null, error_code: null },
+    },
+    { type: 'token', text: 'downloading' },
+    { type: 'done' },
+  ])
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'check the pull')
+
+  // Assert the STATUS chip, not the whole card — the folded result JSON
+  // legitimately contains the literal text `"error": null`.
+  await expect(toolCard(page).locator('.tool-status')).toHaveText('done', { timeout: FIVE_S })
+})
+
+test('truthy error in result reads error', async ({ page }) => {
+  await mockChat(page, [
+    { type: 'tool_call', id: 'c1', name: 'model_pull_status', arguments: {} },
+    { type: 'tool_result', id: 'c1', name: 'model_pull_status', result: { error: 'boom' } },
+    { type: 'done' },
+  ])
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'check')
+
+  await expect(toolCard(page)).toContainText('error', { timeout: FIVE_S })
+})
+
+// ── approval gates in the thread ───────────────────────────────────────────
+
+const GATED_FRAMES = [
+  { type: 'tool_call', id: 'c1', name: 'model_delete', arguments: { model_id: 'doomed' } },
+  {
+    type: 'tool_result',
+    id: 'c1',
+    name: 'model_delete',
+    result: { status: 'pending_approval', approval_id: 'ap-123', detail: 'queued' },
+  },
+  { type: 'approval_required', id: 'c1', name: 'model_delete', approval_id: 'ap-123' },
+  { type: 'token', text: 'waiting on you' },
+  { type: 'done' },
+]
+
+test('gated call renders awaiting-approval card with Approve/Deny', async ({ page }) => {
+  await mockChat(page, GATED_FRAMES)
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'delete it')
+
+  await expect(toolCard(page)).toContainText('awaiting approval', { timeout: FIVE_S })
+  await expect(page.locator('[data-testid="board-chat-approve"]')).toBeVisible()
+  await expect(page.locator('[data-testid="board-chat-deny"]')).toBeVisible()
+})
+
+test('Approve posts to the bell endpoint and marks the card approved', async ({ page }) => {
+  await mockChat(page, GATED_FRAMES)
+  let approved = false
+  await page.route('**/api/agent/approvals/ap-123/approve', async (route: any) => {
+    approved = true
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' })
+  })
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'delete it')
+
+  await page.locator('[data-testid="board-chat-approve"]').click()
+  await expect(toolCard(page)).toContainText('approved', { timeout: FIVE_S })
+  expect(approved).toBe(true)
+})
+
+test('Deny marks the card denied', async ({ page }) => {
+  await mockChat(page, GATED_FRAMES)
+  await page.route('**/api/agent/approvals/ap-123/deny', async (route: any) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' })
+  })
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'delete it')
+
+  await page.locator('[data-testid="board-chat-deny"]').click()
+  await expect(toolCard(page)).toContainText('denied', { timeout: FIVE_S })
+})
+
+test('auto-approve toggle approves the gate without a click', async ({ page }) => {
+  await mockChat(page, GATED_FRAMES)
+  let approved = false
+  await page.route('**/api/agent/approvals/ap-123/approve', async (route: any) => {
+    approved = true
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' })
+  })
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await page.locator('[data-testid="board-chat-auto-approve"] input').check()
+  await send(page, 'delete it')
+
+  await expect(toolCard(page)).toContainText('approved', { timeout: FIVE_S })
+  expect(approved).toBe(true)
+})
+
+test('follow-up tool_result after approval flips the card to done', async ({ page }) => {
+  // The paused-turn contract: pending result → approval_required → (operator
+  // approves) → SECOND tool_result with the executed payload.
+  await mockChat(page, [
+    ...GATED_FRAMES.slice(0, 3),
+    { type: 'tool_result', id: 'c1', name: 'model_delete', result: { deleted: true } },
+    { type: 'token', text: 'gone' },
+    { type: 'done' },
+  ])
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'delete it')
+
+  await expect(toolCard(page)).toContainText('done', { timeout: FIVE_S })
+  await expect(page.locator('[data-testid="board-chat-approve"]')).toHaveCount(0)
+})
+
+// ── session controls ───────────────────────────────────────────────────────
+
+test('new session clears the thread', async ({ page }) => {
+  await mockChat(page, [{ type: 'token', text: 'hello there' }, { type: 'done' }])
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'hi')
+  await expect(page.locator('[data-testid="board-chat-msg"]')).toHaveCount(2, {
+    timeout: FIVE_S,
+  })
+
+  await page.locator('[data-testid="board-chat-new-session"]').click()
+  await expect(page.locator('[data-testid="board-chat-msg"]')).toHaveCount(0)
+  await expect(page.locator('[data-testid="board-chat-new-session"]')).toHaveCount(0)
+})
+
+test('Stop appears while streaming and aborts the turn', async ({ page }) => {
+  // Stall the response: streaming stays true while the fetch is pending,
+  // which is the window the Stop button exists for.
+  await page.route('**/api/board/chat', async (route: any) => {
+    if (route.request().method() !== 'POST') {
+      await route.fallback()
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20_000))
+    await route.abort().catch(() => {})
+  })
+  await gotoBoardAndWait(page)
+  await openChat(page)
+  await send(page, 'go')
+
+  const stop = page.locator('[data-testid="board-chat-stop"]')
+  await expect(stop).toBeVisible({ timeout: FIVE_S })
+  await stop.click()
+  await expect(stop).toHaveCount(0)
+  // The thread is kept (the user message), the composer stays usable.
+  await expect(page.locator('[data-testid="board-chat-msg"]')).toHaveCount(1)
+  await expect(page.locator('[data-testid="board-chat-input"]')).toBeEnabled()
+})


### PR DESCRIPTION
## What

Hardens the dashboard sidebar steward (hal0-brain) end-to-end after a live operator session surfaced a chain of tool-use failures, and adds a global port-claim registry after \`slot_create\` handed out an occupied port. All changes are deployed and verified live on CT105.

### 1. Chat loop (backend) — `board_chat.py`, `mcp/admin.py`
- **Pause on gated tools**: a call that parks on the ApprovalQueue now emits an `approval_required` SSE frame and **pauses the turn** (keepalive `ping` frames) until the operator approves/denies; the loop then streams a second `tool_result` with the executed/denied payload and the model continues the same turn. Previously the model ended the turn with "let me know when approved" and the executed result landed nowhere.
- **Runaway cap**: every completion round carries `max_tokens` (default 4096). An uncapped generation on the agent-slot fallback ran ~25k tokens into the 300s transport timeout and killed turns before the first tool call ("primary slot transport failure").
- **Real arg schemas**: the surfaced catalog only declared path args, so the model guessed body args (`model_inspect` without `hf_repo` → 400; `model_pull` with `model_id='org/repo'` → 405). `model_pull` / `model_inspect` / `slot_create` / `model_swap` / `model_assign` now ship parameter schemas + explicit descriptions; path args containing `/` are rejected with an actionable hint.
- `_MAX_ROUNDS` 8 → 90 (with per-round caps it's a runaway backstop, not a working limit).

### 2. Chat UI — `useBoard.ts`, `agent-chat.jsx`
- **Tool-history replay fix (the big one)**: `send()` rebuilt history from user/assistant text only — tool calls/results were dropped, so after one tool chain the replayed context taught the model to answer without tools (confirmed live: threads stopped calling tools entirely and invented slot lists). History is now rebuilt as valid OpenAI `tool_calls` + `tool` result pairs (4KB truncation per result).
- Approval cards (amber "awaiting approval", inline Approve/Deny hitting the bell endpoints, auto-flip on the resumed turn's follow-up result), error-badge fix (`error: null` job results no longer read "error"), session-scoped **auto-approve** toggle, **Stop** button, **new session** button.

### 3. Global port registry — `hal0/ports.py`, `GET /api/ports`, `port_list` tool
- No stored allocation table — claims recomputed from live truth per query: slot TOMLs (incl. disabled), runtime slot rows (FLM-trio virtual ports that no TOML mentions), reserved ports, live listeners. Slot deletion frees its port with zero bookkeeping; co-resident FLM slots fold into one owner.
- Enforced at slot create (auto-assign + explicit-port 400 `slot.port_conflict`) and config PUT; surfaced at `GET /api/ports` and as the autonomous-read `port_list` tool.
- Found a real pre-existing conflict on first run (flm-stt runtime row vs a newly created slot, both on 8089 — the exact incident that motivated it).

## Tests
- `tests/board/test_board_chat_tool_use_e2e.py` — 18 tests driving `_chat_stream` directly (deterministic pause → approve/deny → resume, persona loosening + POLICY_NO_LOOSEN floor, max_tokens, loop budget, slash guard, schema surface)
- `tests/api/test_port_registry.py` — 12 tests + autouse conftest fixture blinding the registry to host sockets (hermetic)
- `ui/tests/e2e/specs/board-chat-tool-use-v3.spec.ts` — 9 Playwright specs (mocked SSE per the real frame contract)
- Full board suite + affected api suites green (the 3 `tests/api/test_slots_policy.py` failures pre-exist on main — fixture leaks the host's real `/etc/hal0/slots`)

## Notes for review
- `slot_load`/`slot_restart` are local platform verbs (`_ADMIN_TOOL_EXCLUDES`) — their schemas live in the local tool list, not the admin catalog.
- One pre-existing assertion updated (`test_admin_schemas_require_path_args`) — `model_pull.model_id` now carries a description alongside its pinned type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)