### PR TITLE
feat(brain-chat): Agents/Brain settings section + slot override for the steward chat

### DIFF
--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -176,6 +176,14 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     "activity.enabled": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "activity.retention_days": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "activity.max_rows": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
+    # [brain_chat] — every key is read live per chat turn via
+    # board_chat._brain_chat_config() off app.state.hal0_config, which the
+    # settings PUT refreshes in place, so all of them apply immediately.
+    "brain_chat.enabled": {"apply_class": "immediate", "services": []},
+    "brain_chat.read_only": {"apply_class": "immediate", "services": []},
+    "brain_chat.model": {"apply_class": "immediate", "services": []},
+    "brain_chat.max_rounds": {"apply_class": "immediate", "services": []},
+    "brain_chat.completion_timeout_s": {"apply_class": "immediate", "services": []},
     # [meta]
     "meta.schema_version": {"apply_class": "manual-restart", "services": []},
 }

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -999,8 +999,12 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     if not messages or not (isinstance(messages[0], dict) and messages[0].get("role") == "system"):
         messages.insert(0, {"role": "system", "content": system_prompt})
 
+    # Model precedence: an explicit per-request model wins, then the
+    # [brain_chat] model override (e.g. hal0/npu to run on the NPU chat slot),
+    # then the persona's preferred_model / built-in default.
+    model = payload.get("model") or (cfg.model or None) or default_model
     body: dict[str, Any] = {
-        "model": payload.get("model") or default_model,
+        "model": model,
         "messages": messages,
         "tools": _surfaced_tool_schemas(request),
         "stream": False,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2637,13 +2637,20 @@ class BrainChatConfig(BaseModel):
     and reading state but refuses every mutating or admin-write tool
     server-side — a guardrail that holds INDEPENDENTLY of the ``hal0-brain``
     persona's ``tools_allowed`` / approval policy (a persona edit can loosen
-    the persona, never this). ``max_rounds`` bounds the per-turn tool loop
-    (runaway backstop); ``completion_timeout_s`` is the transport timeout for
-    each LLM round against the brain/agent slot.
+    the persona, never this). ``model`` overrides which model/slot the chat
+    drives (e.g. ``hal0/npu`` to run the steward on the NPU chat slot); empty
+    keeps the persona's ``preferred_model`` (``hal0/brain``, which itself
+    falls back to the ``agent`` slot). ``max_rounds`` bounds the per-turn tool
+    loop (runaway backstop); ``completion_timeout_s`` is the transport timeout
+    for each LLM round against the target slot.
     """
 
     enabled: bool = True
     read_only: bool = False
+    # Empty → persona preferred_model (hal0/brain). Set to a virtual slot model
+    # like "hal0/npu" / "hal0/utility" to drive the steward on that slot; an
+    # explicit per-request ``model`` in the chat body still wins over this.
+    model: str = ""
     max_rounds: int = Field(default=8, ge=1, le=100)
     completion_timeout_s: float = Field(default=300.0, gt=0)
 

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -983,3 +983,37 @@ def test_is_read_tool_classification() -> None:
     assert _is_read_tool("slot_load", {"name": "img"}) is False
     # An unknown tool fails closed (treated as NOT a read).
     assert _is_read_tool("definitely_not_a_tool", {}) is False
+
+
+def test_model_override_from_config_drives_target_slot(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    app, client = _make_app(rec, stub, tmp_path)
+    # Operator points the steward at the NPU chat slot.
+    _set_brain_chat_config(app, model="hal0/npu")
+
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert stub.calls[0]["model"] == "hal0/npu"
+
+
+def test_empty_model_override_keeps_default(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, model="")  # explicit empty → persona/default
+
+    client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert stub.calls[0]["model"] == BRAIN_SLOT_MODEL == "hal0/brain"
+
+
+def test_explicit_request_model_wins_over_config_override(tmp_path) -> None:
+    rec = _Recorder()
+    stub = _StubLLM([_final_response("hi")])
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, model="hal0/npu")
+
+    client.post(
+        "/api/board/chat",
+        json={"model": "hal0/utility", "messages": [{"role": "user", "content": "x"}]},
+    )
+    assert stub.calls[0]["model"] == "hal0/utility"

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -38,11 +38,16 @@ class TestBrainChatConfig:
         bc = BrainChatConfig()
         assert bc.enabled is True
         assert bc.read_only is False
+        assert bc.model == ""
         assert bc.max_rounds == 8
         assert bc.completion_timeout_s == 300.0
 
     def test_present_on_hal0config_by_default(self) -> None:
         assert Hal0Config().brain_chat == BrainChatConfig()
+
+    def test_model_override_round_trips(self) -> None:
+        cfg = Hal0Config(**tomllib.loads('[brain_chat]\nmodel = "hal0/npu"\n'))
+        assert cfg.brain_chat.model == "hal0/npu"
 
     def test_guardrail_flags_round_trip_from_toml(self) -> None:
         raw = tomllib.loads(

--- a/ui/src/dash/settings.jsx
+++ b/ui/src/dash/settings.jsx
@@ -38,7 +38,7 @@ import { useQueryClient } from '@tanstack/react-query'
 const { useState: useStateSet, useEffect: useEffectSet, useRef: useRefSet } = React;
 
 function SettingsView({ param }) {
-  const VALID_IDS = ["general", "slots", "npu", "memory", "voice", "imagegen", "storage", "secrets", "updates", "advanced", "about"];
+  const VALID_IDS = ["general", "slots", "npu", "memory", "agents", "voice", "imagegen", "storage", "secrets", "updates", "advanced", "about"];
   const initialSection = param && VALID_IDS.includes(param) ? param : "general";
   const [section, setSection] = useStateSet(initialSection);
   const sections = [
@@ -46,6 +46,7 @@ function SettingsView({ param }) {
     { id: "slots",     label: "Slots" },
     { id: "npu",       label: "NPU" },
     { id: "memory",    label: "Memory" },
+    { id: "agents",    label: "Agents / Brain" },
     { id: "voice",     label: "Voice" },
     { id: "imagegen",  label: "Image-gen" },
     { id: "storage",   label: "Storage" },
@@ -81,6 +82,7 @@ function SettingsView({ param }) {
           {section === "slots" && <SlotsSection />}
           {section === "npu" && <NpuSection />}
           {section === "memory" && <MemorySection />}
+          {section === "agents" && <AgentsBrainSection />}
           {section === "voice" && <VoiceSection />}
           {section === "imagegen" && <ImageGenSection />}
           {section === "storage" && <StorageSection />}
@@ -788,6 +790,148 @@ function MemorySection() {
       <MemoryEnginePanel registry={registry} />
       <MemoryGraphPanel />
       <MemoryRerankerPanel registry={registry} />
+    </div>
+  );
+}
+
+// ─── Agents / Brain — the dashboard steward chat ([brain_chat]) ──────────────
+//
+// Wires the [brain_chat] config (schema.BrainChatConfig) into the UI: the hard
+// kill switch, read-only guardrail, target-slot override, and loop knobs. Every
+// key applies live (board_chat._brain_chat_config reads app.state per turn), so
+// the ApplyBadge shows "live". Saves via the generic PUT /api/settings.
+function AgentsBrainSection() {
+  const applyPlanQuery = useApplyPlan();
+  const registry = applyPlanQuery.data?.registry || {};
+  const settings = useSettings();
+  const update = useSettingsUpdate();
+  const slotsQuery = useSlots();
+
+  const live = settings.data?.brain_chat || {};
+  const liveEnabled = live.enabled !== false;
+  const liveReadOnly = live.read_only === true;
+  const liveModel = live.model || "";
+  const liveRounds = live.max_rounds ?? 8;
+  const liveTimeout = live.completion_timeout_s ?? 300;
+
+  const [enabled, setEnabled] = useStateSet(liveEnabled);
+  const [readOnly, setReadOnly] = useStateSet(liveReadOnly);
+  const [model, setModel] = useStateSet(liveModel);
+  const [rounds, setRounds] = useStateSet(String(liveRounds));
+  const [timeoutS, setTimeoutS] = useStateSet(String(liveTimeout));
+
+  useEffectSet(() => { setEnabled(liveEnabled); }, [liveEnabled]);
+  useEffectSet(() => { setReadOnly(liveReadOnly); }, [liveReadOnly]);
+  useEffectSet(() => { setModel(liveModel); }, [liveModel]);
+  useEffectSet(() => { setRounds(String(liveRounds)); }, [liveRounds]);
+  useEffectSet(() => { setTimeoutS(String(liveTimeout)); }, [liveTimeout]);
+
+  // Slot picker: "" = persona default (hal0/brain), plus hal0/<slot> for every
+  // configured slot so the operator can target e.g. the NPU chat slot.
+  const slotModels = (slotsQuery.data || []).map(s => `hal0/${s.name}`);
+  // Keep a currently-set custom value visible even if its slot isn't listed.
+  const modelOptions = ["", ...new Set([...slotModels, ...(liveModel ? [liveModel] : [])])];
+
+  const roundsNum = Number(rounds);
+  const timeoutNum = Number(timeoutS);
+  const roundsValid = Number.isInteger(roundsNum) && roundsNum >= 1 && roundsNum <= 100;
+  const timeoutValid = timeoutNum > 0;
+  const dirty =
+    enabled !== liveEnabled || readOnly !== liveReadOnly || model !== liveModel ||
+    roundsNum !== liveRounds || timeoutNum !== liveTimeout;
+
+  const doSave = async () => {
+    if (!roundsValid || !timeoutValid) {
+      window.__hal0Toast && window.__hal0Toast("Fix the highlighted fields first", "err");
+      return;
+    }
+    try {
+      await update.mutateAsync({
+        brain_chat: {
+          enabled, read_only: readOnly, model,
+          max_rounds: roundsNum, completion_timeout_s: timeoutNum,
+        },
+      });
+      window.__hal0Toast && window.__hal0Toast("Brain chat settings saved", "ok");
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Save failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  const reset = () => {
+    setEnabled(liveEnabled); setReadOnly(liveReadOnly); setModel(liveModel);
+    setRounds(String(liveRounds)); setTimeoutS(String(liveTimeout));
+  };
+
+  return (
+    <div className="s-section">
+      <h2>Agents / Brain</h2>
+      <p className="desc">
+        The dashboard's agent-chat steward (<span className="mono">hal0-brain</span>): the
+        slide-out chat that administers this instance via tools. These guardrails hold
+        server-side, independent of the persona's tool allowlist, and apply live.
+      </p>
+
+      <div className="s-panel" style={{marginBottom: 12}}>
+        <SRow
+          k="Enabled"
+          sub="Master switch. When off, the chat refuses every turn (no model call)."
+          v={
+            <input type="checkbox" checked={enabled}
+              onChange={e => setEnabled(e.target.checked)} style={{accentColor: "var(--accent)"}} />
+          }
+          actions={<ApplyBadge settingsKey="brain_chat.enabled" registry={registry} />}
+        />
+        <SRow
+          k="Read-only"
+          sub="Reads still answer, but every mutating / admin-write tool is refused."
+          v={
+            <input type="checkbox" checked={readOnly}
+              onChange={e => setReadOnly(e.target.checked)} style={{accentColor: "var(--accent)"}} />
+          }
+          actions={<ApplyBadge settingsKey="brain_chat.read_only" registry={registry} />}
+        />
+        <SRow
+          k="Model / slot override"
+          sub="Which slot the steward drives. Empty = persona default (hal0/brain → agent)."
+          v={
+            <select value={model} onChange={e => setModel(e.target.value)} style={_advInputStyle}>
+              {modelOptions.map(m => (
+                <option key={m || "__default"} value={m}>
+                  {m === "" ? "Persona default (hal0/brain)" : m}
+                </option>
+              ))}
+            </select>
+          }
+          actions={<ApplyBadge settingsKey="brain_chat.model" registry={registry} />}
+        />
+        <SRow
+          k="Max rounds"
+          sub="Per-turn tool-loop cap (1–100). Runaway backstop."
+          v={
+            <input type="number" min={1} max={100} value={rounds}
+              onChange={e => setRounds(e.target.value)}
+              style={{..._advInputStyle, width: 80, borderColor: roundsValid ? "var(--line)" : "var(--err)"}} />
+          }
+          actions={<ApplyBadge settingsKey="brain_chat.max_rounds" registry={registry} />}
+        />
+        <SRow
+          k="Completion timeout (s)"
+          sub="Transport timeout for each LLM round against the target slot."
+          v={
+            <input type="number" min={1} step={5} value={timeoutS}
+              onChange={e => setTimeoutS(e.target.value)}
+              style={{..._advInputStyle, width: 80, borderColor: timeoutValid ? "var(--line)" : "var(--err)"}} />
+          }
+          actions={<ApplyBadge settingsKey="brain_chat.completion_timeout_s" registry={registry} />}
+        />
+        <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
+          {dirty && <button className="btn ghost sm" onClick={reset}>Reset</button>}
+          <button className="btn sm" disabled={!dirty || update.isPending} onClick={doSave}>
+            {update.isPending ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/tests/e2e/specs/settings-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-v3.spec.ts
@@ -15,11 +15,11 @@
 import { test, expect } from '../fixtures/apiMock'
 
 const SECTIONS = [
-  'General', 'Slots', 'NPU', 'Memory', 'Voice', 'Image-gen', 'Storage', 'Secrets', 'Updates', 'Advanced', 'About',
+  'General', 'Slots', 'NPU', 'Memory', 'Agents / Brain', 'Voice', 'Image-gen', 'Storage', 'Secrets', 'Updates', 'Advanced', 'About',
 ]
 
 test.describe('Settings v3 (/settings)', () => {
-  test('renders rail nav with all 11 sections', async ({ page }) => {
+  test('renders rail nav with all 12 sections', async ({ page }) => {
     await page.goto('/#settings')
     await expect(page.locator('.view .vh h1')).toHaveText('Settings')
     const nav = page.locator('.settings-nav .nav-item')


### PR DESCRIPTION
Adds a dashboard **Settings → Agents / Brain** category surfacing the `[brain_chat]` config (shipped in #1221), plus a new **model/slot override** so the operator can point the steward chat at a specific slot — e.g. `hal0/npu` to attempt running it on the NPU chat slot instead of the default `hal0/brain`.

## What
- **Schema** — `BrainChatConfig.model` (str, default `""`). Empty keeps the persona's `preferred_model` (`hal0/brain`, which falls back to the `agent` slot); set to a virtual slot model to drive the chat there.
- **board_chat** — model precedence: explicit per-request `model` > `[brain_chat].model` override > persona/default.
- **Settings UI** — new `AgentsBrainSection`: `enabled` + `read_only` toggles, a **slot-override picker** built from the live slots list (`hal0/<slot>`, with "Persona default" as the empty option), and `max_rounds` / `completion_timeout_s` number inputs. Saves via the generic `PUT /api/settings`; each row shows the "live" apply badge.
- **apply-plan** — `brain_chat.*` registered `immediate` (read live per chat turn), so the badges render green "live".

No new backend endpoint: `GET`/`PUT /api/settings` already round-trips the whole `Hal0Config`.

## Tests
`tests/board/test_board_chat.py`: model-override precedence (config drives target slot, empty keeps `hal0/brain`, explicit request model wins). `tests/config/test_schema.py`: `model` default + TOML round-trip. 169 board/config/api-settings tests pass; `vite build` clean; ruff clean. (eslint runs in CI — the dev boxes lack the `globals` dev-dep locally.)

## Follow-up still pending (unrelated)
The global `board_chat → brain_chat` module/endpoint/UI rename (PR B) remains on hold per operator request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)