### PR TITLE
feat(upstreams): upstream model controls — reactive CRUD, model filters, enabled kill-switch, CLI + MCP + dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+- **Upstream model controls** — full management surface for external LLM providers (OpenRouter, Anthropic, OpenAI, Google AI Studio, Ollama, custom):
+  - Reactive CRUD: `POST/PATCH/DELETE /api/upstreams` (create prefills from the provider catalog via `catalog_id`); `upstreams.toml` stays canonical — every write rewrites it atomically before touching the running registry.
+  - `hal0 upstream` CLI group (`list/show/create/update/delete/test/set-credentials`); `create --catalog openrouter --api-key` wires a provider end-to-end in one command.
+  - MCP admin tools `upstream_create`/`upstream_update`/`upstream_delete` (gated) + `upstream_test`.
+  - Dashboard **Upstream providers** panel (Slots → Endpoints / Connections): add-from-catalog form, write-only key entry, test-connection with latency + model count, enable/advertise toggles, filter editor with live preview, delete-with-confirm.
+  - Per-upstream `model_filters` (`models` allowlist + `include`/`exclude` globs, exclude wins) curating `/v1/models` and `/api/models` advertising — dispatch stays unfiltered so hidden models remain addressable by name (per the 2026-07-06 upstream-model-filters spec).
+  - `enabled` kill-switch on every upstream: `false` removes it from dispatch routing and the model catalog while retaining config + credentials.
+  - `auth_key_present` in upstream serializations — whether the declared env-var actually holds a key (drives the dashboard auth badge), distinct from `auth_configured`.
+
+### Fixed
+- `upstreams.toml` schema drift: `auth_style = "anthropic"`/`"google_query"` (long implemented by the dispatcher) now validate; `auth_header` is a real schema field so `auth_style = "header"` works; warmup vocabulary canonicalized to `none|ondemand|always` with `lazy`/`eager` accepted as normalizing aliases — a TOML authored in the runtime vocabulary no longer fails validation and silently empties the upstream registry.
+- `/api/models` no longer stamps slot-backed advertisements as `origin="upstream"`: the composite `hal0` aggregate and container slots serve local models, but a raw GGUF id whose casing differed from the registry id (e.g. `Qwopus3.5-4B-Coder-MTP-Q6_K`) surfaced in the Models page Upstream tab as "via hal0". Only genuine remotes contribute upstream rows, honoring `enabled`/`advertise_models`/`model_filters`.
+- `hal0 upstream` first cut sent field names the API rejects (`openai_base_url`, `kind`, `allow`/`deny`, `api_key`) — every write 422'd; request bodies now match the route contracts exactly and are pinned by tests.
+
 ## [0.9.6.1] — 2026-07-11
 
 ### Added

--- a/docs/guides/connect-external-providers.mdx
+++ b/docs/guides/connect-external-providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect external providers
-description: Wire up OpenAI, Anthropic, OpenRouter, Ollama, or any OpenAI-compatible provider by editing upstreams.toml, writing credentials, and testing reachability.
+description: Wire up OpenAI, Anthropic, OpenRouter, Ollama, or any OpenAI-compatible provider from the dashboard, the hal0 upstream CLI, the REST API, or upstreams.toml.
 sidebar:
   order: 40
 ---
@@ -9,26 +9,33 @@ import { Steps, Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components
 
 hal0 can route requests to **external upstreams** — third-party
 OpenAI-compatible APIs like OpenAI, Anthropic, OpenRouter, Google AI
-Studio, Ollama, or any custom endpoint. You wire them up by editing
-`/etc/hal0/upstreams.toml` (the source of truth) and then writing the
-credential and testing reachability through the API.
+Studio, Ollama, or any custom endpoint. There are four equivalent ways to
+manage them, all backed by the same source of truth
+(`/etc/hal0/upstreams.toml`):
+
+- **Dashboard** — Slots → Endpoints → *Upstream providers* (also on the
+  Connections view): add from the catalog, paste the key, test, curate
+  models, toggle, delete.
+- **CLI** — `hal0 upstream {list,show,create,update,delete,test,set-credentials}`
+  (see the [CLI reference](/docs/reference/cli#hal0-upstream--external-llm-providers)).
+- **REST API** — `GET/POST /api/upstreams`, `PATCH/DELETE /api/upstreams/{name}`,
+  `POST /api/upstreams/{name}/test` (what the dashboard, CLI, and the
+  bundled MCP admin tools all call).
+- **The TOML file itself** — hand-edit and restart; every reactive write
+  rewrites the same file atomically, so hand-edits and API edits coexist.
 
 <Aside type="note">
-Upstreams are authored by editing the TOML file — there is no dashboard
-UI yet for browsing the catalog, adding an upstream, or testing a
-connection; those all live behind the REST API described below (also
-what the bundled MCP admin tools use). The one piece that *is*
-dashboard-reachable today is the credential value itself, via Settings →
-Secrets — see "Write the credential" below. Creating and deleting
-upstreams reactively is intentionally deferred — the TOML is canonical.
+`upstreams.toml` stays canonical: API/CLI/dashboard writes go through a
+single lock-guarded write path that rewrites the file atomically *before*
+updating the running registry, so a crash can never leave the two out of
+sync, and a `git diff` of `/etc/hal0` always tells the whole story.
 </Aside>
 
 ## See what's available
 
-The integration catalog is a static reference of known provider
-templates — base URL, auth style, capabilities — intended for a future
-dashboard "add upstream" form. Today it's most useful as a copy/paste
-source for the TOML block below:
+The integration catalog is a static reference of known provider templates
+— base URL, auth style, capabilities. It feeds the dashboard's **Add
+upstream** dropdown and the CLI's `--catalog` flag:
 
 ```sh
 curl http://localhost:8080/api/providers/catalog
@@ -38,9 +45,40 @@ It includes OpenAI, Anthropic, OpenRouter, Google AI Studio, Ollama, and a
 generic **custom** OpenAI-compatible entry, each with its default base URL
 and auth style.
 
-## Define the upstream
+## Add an upstream
 
-Add a `[[upstream]]` block to `/etc/hal0/upstreams.toml`:
+<Tabs>
+<TabItem label="CLI">
+
+```sh
+# From the catalog, key included — one command, ready to route:
+hal0 upstream create openrouter --catalog openrouter --api-key
+# (prompts for the key with hidden input; or pass -k <key>)
+
+# Fully custom endpoint:
+hal0 upstream create corp \
+  --url https://llm.corp.internal/v1 \
+  --auth-style header --auth-header X-Api-Key --auth-env CORP_LLM_KEY
+```
+
+</TabItem>
+<TabItem label="REST">
+
+```sh
+curl -X POST http://localhost:8080/api/upstreams \
+  -H 'content-type: application/json' \
+  -d '{"name": "openrouter", "catalog_id": "openrouter"}'
+```
+
+`catalog_id` prefills `url`, `auth_style`, and a default
+`auth_value_env` of `<CATALOG_ID>_API_KEY`; explicit body fields win over
+the prefill. Without `catalog_id`, `url` is required. The upstream is
+always `kind = "remote"`; names must match `^[a-z0-9][a-z0-9_-]{0,63}$`
+(`hal0` is reserved). Returns `201` with the created entry — plus a
+`hint` pointing at the credentials route when the key still needs writing.
+
+</TabItem>
+<TabItem label="upstreams.toml">
 
 ```toml
 [[upstream]]
@@ -51,7 +89,18 @@ auth_style = "bearer"
 auth_value_env = "OPENROUTER_API_KEY"
 timeout_seconds = 300.0
 advertise_models = true
+enabled = true
+
+[upstream.model_filters]
+include = ["anthropic/*", "google/*"]
+exclude = ["*:free"]
 ```
+
+Run `hal0 config validate` after any hand-edit, then restart `hal0-api`
+(hand-edits are read at startup; only API/CLI/dashboard writes apply live).
+
+</TabItem>
+</Tabs>
 
 The fields:
 
@@ -64,57 +113,90 @@ The fields:
 
 3. **`url`** — the base URL (required, non-empty).
 
-4. **`auth_style`** — how the key is sent. `upstreams.toml`'s schema
-   validates exactly three values: `bearer` (`Authorization: Bearer <key>`
-   — the default, and what OpenRouter, Ollama, and most OpenAI-compatible
-   endpoints expect, including Google AI Studio's `/v1beta/openai` layer),
-   `header` (a custom header — reserved for a future header-name field;
-   nothing in the current schema lets you name the header, so it has no
-   effect yet), or `none` (no auth header, e.g. an unauthenticated local
-   Ollama).
+4. **`auth_style`** — how the key is sent: `bearer`
+   (`Authorization: Bearer <key>` — the default, and what OpenRouter,
+   Ollama, and most OpenAI-compatible endpoints expect, including Google
+   AI Studio's `/v1beta/openai` layer), `anthropic` (`x-api-key` +
+   `anthropic-version`), `google_query` (`?key=` on the URL), `header`
+   (a custom header — name it with `auth_header`), or `none` (no auth,
+   e.g. an unauthenticated local Ollama).
 
-5. **`auth_value_env`** — the **name** of the environment variable that
+5. **`auth_header`** — the header **name** when `auth_style = "header"`
+   (e.g. `X-Api-Key`); required for that style, ignored otherwise.
+
+6. **`auth_value_env`** — the **name** of the environment variable that
    holds the secret. The key itself is never written to TOML — only the
    env-var name lives here.
 
-6. **`timeout_seconds`** — request timeout (default `300`).
+7. **`timeout_seconds`** — request timeout (default `300`).
 
-7. **`advertise_models`** — whether this upstream's models appear in the
-   aggregated model list (default `true`).
+8. **`enabled`** — the routing kill-switch (default `true`). When `false`
+   the dispatcher skips the upstream entirely and it vanishes from
+   `/v1/models`; config and credentials are retained, so it's a pause,
+   not a deletion.
+
+9. **`advertise_models`** — whether this upstream's models appear in the
+   aggregated model list (default `true`). Routing is unaffected.
+
+10. **`model_filters`** — optional per-upstream curation of what appears
+    in `/v1/models`; see below.
 
 </Steps>
 
-<Aside type="caution">
-The provider catalog's own metadata (above) lists `anthropic` and
-`google_query` as auth styles for Anthropic and Google AI Studio, and the
-dispatcher's header-building code still knows how to construct both —
-but `upstreams.toml`'s validator doesn't accept them (see the field list
-above). Writing `auth_style = "anthropic"` by hand fails config
-validation, and because the whole file is validated as one unit, a
-single bad entry silently drops **every** upstream in `upstreams.toml` at
-the next `hal0-api` restart (logged as `upstreams.config_parse_failed`,
-not a crash — the API still starts, just with an empty upstream list).
-Run `hal0 config validate` after any hand-edit, before restarting. For
-Anthropic specifically, the catalog's own notes point out its native API
+<Aside type="note">
+For Anthropic specifically, the catalog's notes point out its native API
 speaks `/v1/messages`, not OpenAI's `/v1/chat/completions` — route
 through a compatible proxy rather than pointing an upstream straight at
-`api.anthropic.com`.
+`api.anthropic.com` for chat-completions traffic.
 </Aside>
+
+## Curate the advertised models
+
+An upstream like OpenRouter advertises hundreds of models; without a
+filter they all land in `/v1/models` and flood every model picker.
+`model_filters` curates the **discovery catalog only** — filtered-out
+models remain fully dispatchable by explicit name, so agent configs
+pinned to `openrouter/some-model` keep working.
+
+- **`models`** — exact ids to allowlist.
+- **`include`** — glob patterns (`fnmatch`: `*` and `?`, case-sensitive).
+- **`exclude`** — glob patterns that always win over `models` + `include`.
+- Empty `models` + `include` means "everything included unless excluded".
+
+```sh
+# "Anthropic and Google models, plus one DeepSeek — but nothing :free"
+hal0 upstream update openrouter \
+  --include 'anthropic/*' --include 'google/*' \
+  --model deepseek/deepseek-r1 \
+  --exclude '*:free'
+
+# Back to advertising everything:
+hal0 upstream update openrouter --clear-filters
+```
+
+Or over REST (an all-empty object clears the filters):
+
+```sh
+curl -X PATCH http://localhost:8080/api/upstreams/openrouter \
+  -H 'content-type: application/json' \
+  -d '{"model_filters": {"include": ["anthropic/*"], "exclude": ["*:free"]}}'
+```
+
+The dashboard's filter editor shows a live `advertised/total` preview
+against the upstream's cached model list as you type.
 
 ## Write the credential
 
 The secret lives in `/etc/hal0/api.env` (a systemd `EnvironmentFile`),
-not in the TOML. There are two ways to write it today:
+not in the TOML. Three ways to write it:
 
-- **The dashboard** — Settings → Secrets has presets for `OPENAI_API_KEY`,
-  `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY` (labelled "fallback
-  provider" keys) plus a paired AWS Bedrock entry and a free-form custom
-  name. It writes the same `api.env` file through `POST /api/secrets/{name}`,
-  but it does **not** check the name against any upstream's
-  `auth_value_env` — type the exact env-var name your upstream declares.
-- **The API**, which binds the credential to the upstream's declared
-  `auth_value_env` so you can't accidentally write a key the upstream
-  won't read (this is also what the bundled MCP admin tool's
+- **Dashboard** — the key field on the upstream's row (or Settings →
+  Secrets for free-form names).
+- **CLI** — `hal0 upstream set-credentials openrouter` (hidden prompt),
+  or fold it into creation with `create --api-key`.
+- **REST** — the credentials route, which binds the write to the
+  upstream's declared `auth_value_env` so you can't accidentally store a
+  key the upstream won't read (also what the MCP admin tool
   `provider_credential_write` uses):
 
 ```sh
@@ -124,11 +206,11 @@ curl -X POST http://localhost:8080/api/providers/openrouter/credentials \
 ```
 
 The `key` must match the upstream's `auth_value_env` exactly and be a
-valid `ALL_CAPS` env-var name — the upstream named in the URL must
-already exist (a 404 if it doesn't). The endpoint writes the value
-atomically to `api.env` with `0600` permissions, updates the running
-process environment so the change takes effect immediately, and **never
-echoes the secret back** — the response carries `"value": "***REDACTED***"`.
+valid `ALL_CAPS` env-var name. The endpoint writes the value atomically to
+`api.env` with `0600` permissions, updates the running process environment
+so the change takes effect immediately, and **never echoes the secret
+back**. Deleting an upstream deliberately leaves its credential in
+`api.env` — remove it via `/api/secrets` if truly unwanted.
 
 <Aside type="caution">
 There is no built-in authentication on the hal0 API (ADR-0012) — it binds
@@ -139,58 +221,59 @@ any secret-bearing service and reverse-proxy it if it needs to be exposed.
 ## List configured providers
 
 ```sh
-# remote providers only
-curl http://localhost:8080/api/providers
+hal0 upstream list          # table: enabled/advertise/auth/filter summary
+hal0 upstream show openrouter
 
-# all upstreams (remote + local slots)
-curl http://localhost:8080/api/upstreams
-
-# one upstream
-curl http://localhost:8080/api/upstreams/openrouter
+# or over REST:
+curl http://localhost:8080/api/providers    # remote providers only
+curl http://localhost:8080/api/upstreams    # all upstreams (remote + local slots)
 ```
 
-Each entry reports `auth_configured` — whether the upstream *declares* an
-`auth_value_env` at all, not whether the credential has actually been
-written yet. It's `true` the moment your TOML entry names an env var,
-even before you've written anything to `api.env` — check with `test`
-(below) to confirm the credential itself is actually set.
+Each entry reports two auth booleans: `auth_configured` (an
+`auth_value_env` is *declared*) and `auth_key_present` (the env var
+actually *holds a value* — this is what the dashboard's auth badge shows).
 
 ## Test the connection
 
 ```sh
-curl -X POST http://localhost:8080/api/upstreams/openrouter/test
+hal0 upstream test openrouter
+# or: curl -X POST http://localhost:8080/api/upstreams/openrouter/test
 ```
 
 This probes the upstream's `/models` endpoint (appended to the configured
 base URL) and returns a reachability report:
 `{ok, status, latency_ms, models_count, error?}`. If `auth_value_env` is
-declared but the env var itself is empty, the probe fails fast with
-`{"ok": false, "error": "env var $X is not set", "latency_ms": 0.0}`
-without making an HTTP call. An unhealthy result also fires a dashboard
-footer event so the outage is visible.
+declared but the env var itself is empty, the probe fails fast without
+making an HTTP call. An unhealthy result also fires a dashboard footer
+event so the outage is visible.
+
+## Disable vs. hide vs. delete
+
+Three different levers, in decreasing severity:
+
+| Lever | Routing | /v1/models | Config + key kept? |
+|---|---|---|---|
+| `enabled = false` | ✗ skipped entirely | ✗ hidden | ✓ |
+| `advertise_models = false` | ✓ still routable | ✗ hidden | ✓ |
+| `model_filters` | ✓ still routable | partially hidden | ✓ |
+| `delete` | ✗ | ✗ | key kept, config gone |
 
 ## Picking up changes
 
-Credential writes through either the API or the dashboard's Settings →
-Secrets panel apply to the running process immediately — no restart
-needed. Structural edits to `upstreams.toml` (adding, removing, or
-retiming an upstream) are a different story: they're only read once, at
-`hal0-api` startup. `hal0 config reload` / `POST /api/settings/reload`
-re-reads `hal0.toml`, **not** `upstreams.toml` — there is no lighter-weight
-reload for upstream edits today. Run `hal0 config validate` to check the
-file, then `systemctl restart hal0-api` to pick up the change.
+Every write through the dashboard, CLI, or REST API applies **live** — the
+in-memory registry updates in the same request that rewrites
+`upstreams.toml`, so no restart is needed for create, update, delete,
+credential writes, toggles, or filters.
 
-The `advertise_models` field is an exception: it has a dedicated runtime
-toggle that doesn't require a restart. To toggle whether an upstream appears
-in the aggregated model list:
+Hand-edits to `upstreams.toml` are the one path that still needs a
+restart: the file is read once at `hal0-api` startup. Run
+`hal0 config validate` first — the whole file is validated as one unit,
+and a single bad entry drops **every** upstream at the next start (logged
+as `upstreams.config_parse_failed`; the API still boots, just with an
+empty upstream list).
 
-```sh
-curl -X PATCH http://localhost:8080/api/upstreams/openrouter \
-  -H 'content-type: application/json' \
-  -d '{"advertise_models": false}'
-```
-
-The change takes effect immediately, persists to `upstreams.toml` on disk,
-and is audit-logged — no `hal0-api` restart needed. All other structural
-fields (name, kind, url, auth_*, slot_name, warmup_strategy) require the
-TOML-edit + validate + restart workflow described above.
+<Aside type="note">
+Older TOMLs written with `warmup_strategy = "lazy"` or `"eager"` still
+load — they normalize to the canonical `ondemand`/`always` vocabulary on
+read and are rewritten in normalized form on the next reactive write.
+</Aside>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -178,6 +178,29 @@ shows (and can move) the store path. `hal0 doctor models` audits the whole
 pipeline — dangling registry paths, unregistered files in the store, and the
 NPU/FLM store directory — and names the exact fix command for each finding.
 
+## `hal0 upstream` — external LLM providers
+
+| Command | Purpose | Key options |
+|---|---|---|
+| `upstream list` | List configured upstreams (enabled/advertise/auth/filter summary). | `--json` |
+| `upstream show <name>` | Full detail for one upstream. | `--json` |
+| `upstream create <name>` | Register a remote provider (persists to `upstreams.toml`). | `--catalog`/`-c`, `--url`, `--auth-style`, `--auth-header`, `--auth-env`, `--timeout`, `--api-key`/`-k`, `--advertise-models/--hide-models`, `--enabled/--disabled` |
+| `upstream update <name>` | Partial update: settings, toggles, model filters. | `--url`, `--auth-style`, `--auth-header`, `--auth-env`, `--timeout`, `--advertise-models/--hide-models`, `--enabled/--disabled`, `--model`, `--include`, `--exclude`, `--clear-filters` |
+| `upstream delete <name>` | Remove a remote upstream (credential in `api.env` is retained). | `--force`/`-f` |
+| `upstream test <name>` | Probe reachability + auth; prints latency and model count. | — |
+| `upstream set-credentials <name>` | Write the provider's API key to `api.env` (hidden prompt). | `--key`, `--env-var` |
+
+`upstream create` with `--catalog openrouter` (or `anthropic`, `openai`,
+`google_ai_studio`, `ollama`) prefills the URL and auth style from the
+built-in provider catalog; `--api-key` chains the credential write in the
+same command. Model filters curate what the upstream advertises in
+`/v1/models`: `--include 'anthropic/*' --exclude '*:free'` (exclude wins;
+filtered-out models stay dispatchable by explicit name). `--enabled/--disabled`
+is the routing kill-switch — a disabled upstream is skipped by dispatch
+entirely. Slot-backed upstreams and the composite `hal0` entry are managed by
+the slot lifecycle and reject structural edits/deletion. See
+[Connect external providers](/docs/guides/connect-external-providers).
+
 ## Profiles and stacks — no CLI command
 
 <Aside type="caution">

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -129,7 +129,7 @@ from hal0.hardware.probe import HardwareProbe
 from hal0.registry.discover import scan_and_register
 from hal0.registry.store import ModelRegistry
 from hal0.slots.manager import SlotManager
-from hal0.upstreams.registry import Upstream, UpstreamRegistry
+from hal0.upstreams.registry import Upstream, UpstreamRegistry, upstream_from_entry
 
 log = structlog.get_logger(__name__)
 
@@ -660,19 +660,7 @@ def _hydrate_upstreams(registry: UpstreamRegistry) -> None:
         return
     for entry in cfg.upstream:
         try:
-            registry.upsert(
-                Upstream(
-                    name=entry.name,
-                    kind=entry.kind,
-                    url=entry.url,
-                    auth_style=entry.auth_style,
-                    auth_value_env=entry.auth_value_env,
-                    timeout_seconds=entry.timeout_seconds,
-                    slot_name=entry.slot_name,
-                    warmup_strategy=entry.warmup_strategy,
-                    advertise_models=entry.advertise_models,
-                )
-            )
+            registry.upsert(upstream_from_entry(entry))
         except Exception as exc:
             log.warning(
                 "upstreams.entry_skipped",

--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -526,6 +526,50 @@ _ADMIN_TOOL_PARAM_OVERRIDES: dict[str, dict[str, Any]] = {
         },
         "required": ["name", "model"],
     },
+    "upstream_create": {
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "New upstream name — lowercase alnum plus -/_ ('hal0' reserved)",
+            },
+            "catalog_id": {
+                "type": "string",
+                "description": (
+                    "Optional provider template: openai|anthropic|openrouter|"
+                    "google_ai_studio|ollama — prefills url/auth"
+                ),
+            },
+            "url": {
+                "type": "string",
+                "description": "OpenAI-compatible base URL (required without catalog_id)",
+            },
+            "auth_value_env": {
+                "type": "string",
+                "description": "Env-var NAME for the API key (never the key itself)",
+            },
+        },
+        "required": ["name"],
+    },
+    "upstream_update": {
+        "properties": {
+            "name": {"type": "string", "description": "Upstream name to update"},
+            "enabled": {
+                "type": "boolean",
+                "description": "Routing kill-switch — false removes it from dispatch",
+            },
+            "advertise_models": {
+                "type": "boolean",
+                "description": "Whether its models list in /v1/models",
+            },
+            "model_filters": {
+                "type": "object",
+                "description": (
+                    "{models: [exact ids], include: [globs], exclude: [globs]} — "
+                    "exclude wins; all-empty clears"
+                ),
+            },
+        },
+    },
 }
 
 

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -42,6 +42,7 @@ from hal0.registry.pull import (
 from hal0.registry.pull import persist_pull_job as _persist_pull_job
 from hal0.registry.pull import pull_job_file as _pull_job_file
 from hal0.registry.update_check import evaluate_model_update, fetch_remote_lfs_shas
+from hal0.upstreams.filters import apply_filters
 
 # See slots.py for the writer-gate rationale.
 
@@ -302,11 +303,26 @@ async def list_models(request: Request) -> dict[str, Any]:
         # Probe unavailable (no flm binary / dev host) — nothing to skip.
         pass
     for u in upstreams.list():
+        # Slot-backed entries serve LOCAL models: the composite ``hal0``
+        # aggregate (kind="slot") and container slots (kind="remote" with
+        # slot_name) advertise ids that live on this host's disk — labeling
+        # them origin="upstream" put local slot models in the Models page
+        # Upstream tab whenever the advertised id differed from the registry
+        # id (raw GGUF casing vs normalized alias). Only genuine remotes
+        # contribute upstream rows here.
+        if u.kind != "remote" or u.slot_name:
+            continue
+        if not getattr(u, "enabled", True) or not getattr(u, "advertise_models", True):
+            continue
         try:
             ids = cache.get(u.name) or await upstreams.fetch_models(u.name)
             cache[u.name] = ids
         except Exception:
             ids = []
+        # Same operator curation as /v1/models — the Models page is a
+        # discovery surface, so per-upstream filters apply here too
+        # (dispatch stays unfiltered; hidden models remain addressable).
+        ids = apply_filters(ids, getattr(u, "model_filters", None))
         for mid in ids:
             if mid in seen:
                 continue

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -2,15 +2,20 @@
 
 Endpoints:
   GET    /api/upstreams                  — list registered routing targets
+  POST   /api/upstreams                  — create a remote upstream (reactive)
   GET    /api/upstreams/{name}           — single upstream
+  PATCH  /api/upstreams/{name}           — mutate settings (visibility + structural)
+  DELETE /api/upstreams/{name}           — remove a remote upstream
   POST   /api/upstreams/{name}/test      — probe reachability + auth
   GET    /api/providers/catalog          — static integration catalog
   GET    /api/providers                  — configured providers (alias of upstreams)
+  POST   /api/providers/{name}/credentials — write one API key to api.env
 
-Write paths (create/update/delete) are intentionally deferred — providers are
-authored by editing /etc/hal0/upstreams.toml and reloading, which the
-``hal0 config reload`` CLI surfaces. The Phase 1 design (PLAN §6) treats the
-TOML files as the source of truth; a fully reactive editor lands later.
+``/etc/hal0/upstreams.toml`` remains the source of truth (PLAN §6): every
+write path funnels through :class:`~hal0.upstreams.registry.UpstreamRegistry`'s
+persistent mutators, which rewrite the TOML atomically before touching the
+in-memory registry — hand-editing the file plus ``hal0 config reload`` keeps
+working alongside the reactive editor.
 """
 
 from __future__ import annotations
@@ -22,14 +27,20 @@ from typing import Any
 
 import structlog
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from hal0.api._env_store import upsert_env_value
 from hal0.api._redact import redact_config
 from hal0.api.middleware.error_codes import Hal0Error
 from hal0.config import paths
+from hal0.config.schema import UpstreamEntry, UpstreamModelFilters
 from hal0.upstreams.integrations import get_catalog
-from hal0.upstreams.registry import UpstreamNotFound
+from hal0.upstreams.registry import (
+    COMPOSITE_UPSTREAM_NAME,
+    UpstreamAlreadyExists,
+    UpstreamNotFound,
+    UpstreamProtected,
+)
 
 _audit_log = structlog.get_logger("hal0.audit")
 _log = structlog.get_logger(__name__)
@@ -50,9 +61,43 @@ class UpstreamNotFoundHTTP(Hal0Error):
     status = 404
 
 
+class UpstreamProtectedHTTP(Hal0Error):
+    code = "upstream.protected"
+    status = 400
+
+
+class UpstreamConflictHTTP(Hal0Error):
+    code = "upstream.already_exists"
+    status = 409
+
+
+class UpstreamInvalidHTTP(Hal0Error):
+    code = "upstream.invalid"
+    status = 400
+
+
 class ProviderCredentialError(Hal0Error):
     code = "provider.credential_write_failed"
     status = 400
+
+
+# Upstream names double as TOML keys, URL path segments, and env-var stems —
+# keep them boring: lowercase alnum plus - and _, max 64 chars.
+_UPSTREAM_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _validation_summaries(exc: ValidationError) -> list[str]:
+    """Flatten pydantic errors to JSON-safe strings (ctx can hold raw exceptions)."""
+    return [f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()]
+
+
+# Fields editable on any upstream (catalog visibility / routing kill-switch).
+_VISIBILITY_FIELDS = frozenset({"advertise_models", "enabled", "model_filters"})
+# Fields only editable on TOML-authored remote upstreams — the composite and
+# slot-backed entries get their structure from the slot lifecycle.
+_STRUCTURAL_FIELDS = frozenset(
+    {"url", "auth_style", "auth_header", "auth_value_env", "timeout_seconds", "warmup_strategy"}
+)
 
 
 class ProviderCredentialBody(BaseModel):
@@ -79,17 +124,32 @@ def _serialize_upstream(u: Any, *, last_models: list[str] | None = None) -> dict
     today — but if a future field lands here whose name matches a
     sensitive pattern, the walk catches it without a round of edits.
     """
+    filters = getattr(u, "model_filters", None)
     out = {
         "name": u.name,
         "kind": u.kind,
         "url": u.url,
         "auth_style": u.auth_style,
+        "auth_header": getattr(u, "auth_header", ""),
         "auth_value_env": u.auth_value_env,  # env-var *name*, not value
         "auth_configured": bool(u.auth_value_env),
+        # Unlike auth_configured (env-var *declared*), this reports whether
+        # the key has actually been written — drives the UI's auth badge.
+        "auth_key_present": bool(u.auth_value_env and os.environ.get(u.auth_value_env)),
         "timeout_seconds": u.timeout_seconds,
         "slot_name": u.slot_name,
         "warmup_strategy": u.warmup_strategy,
         "advertise_models": u.advertise_models,
+        "enabled": getattr(u, "enabled", True),
+        "model_filters": (
+            None
+            if filters is None
+            else {
+                "models": list(filters.models),
+                "include": list(filters.include),
+                "exclude": list(filters.exclude),
+            }
+        ),
         "models": last_models or [],
     }
     return redact_config(out)
@@ -119,42 +179,177 @@ async def get_upstream(name: str, request: Request) -> dict[str, Any]:
     return _serialize_upstream(u, last_models=model_cache.get(name))
 
 
+class UpstreamCreateBody(BaseModel):
+    """Body for ``POST /api/upstreams`` — always creates a ``kind="remote"``.
+
+    ``catalog_id`` prefills ``url``/``auth_style``/``auth_header`` from the
+    integrations catalog (explicit body fields win over the prefill); without
+    it ``url`` is required. Credentials are NOT accepted here — write the key
+    afterwards via ``POST /api/providers/{name}/credentials`` so secrets never
+    transit the CRUD surface.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    name: str = Field(..., min_length=1, max_length=64)
+    catalog_id: str | None = Field(default=None)
+    url: str | None = Field(default=None)
+    auth_style: str | None = Field(default=None)
+    auth_header: str | None = Field(default=None)
+    auth_value_env: str | None = Field(default=None)
+    timeout_seconds: float | None = Field(default=None, gt=0.0)
+    warmup_strategy: str | None = Field(default=None)
+    advertise_models: bool = Field(default=True)
+    enabled: bool = Field(default=True)
+    model_filters: UpstreamModelFilters | None = Field(default=None)
+
+
+@router.post("/upstreams", status_code=201)
+async def create_upstream(body: UpstreamCreateBody, request: Request) -> dict[str, Any]:
+    """Create a remote upstream reactively.
+
+    Appends a row to ``upstreams.toml`` (atomic write, TOML stays canonical)
+    and registers the upstream live — no API restart needed. Guards: the
+    composite name is reserved, names must be unique, and slot upstreams
+    can't be created here (they're owned by the slot lifecycle).
+    """
+    name = body.name.strip()
+    if not _UPSTREAM_NAME_RE.match(name):
+        raise UpstreamInvalidHTTP(
+            "upstream name must be lowercase alphanumeric plus '-'/'_' (max 64 chars)",
+            details={"name": body.name},
+        )
+
+    prefill: dict[str, Any] = {}
+    if body.catalog_id is not None:
+        entry = get_catalog().get(body.catalog_id)
+        if entry is None:
+            raise UpstreamInvalidHTTP(
+                f"unknown catalog_id {body.catalog_id!r}",
+                details={"catalog_id": body.catalog_id, "known": sorted(get_catalog())},
+            )
+        prefill = {
+            "url": entry.get("base_url") or None,
+            "auth_style": entry.get("auth") or None,
+            "auth_header": (
+                entry.get("auth_header_name") if entry.get("auth") == "header" else None
+            ),
+            "auth_value_env": f"{body.catalog_id.upper()}_API_KEY",
+        }
+
+    def pick(field: str, default: Any = None) -> Any:
+        explicit = getattr(body, field)
+        if explicit is not None:
+            return explicit
+        prefilled = prefill.get(field)
+        return prefilled if prefilled is not None else default
+
+    url = pick("url")
+    if not url:
+        raise UpstreamInvalidHTTP(
+            "url is required (or supply a catalog_id with a known base_url)",
+            details={"name": name},
+        )
+
+    try:
+        entry_model = UpstreamEntry(
+            name=name,
+            kind="remote",
+            url=url,
+            auth_style=pick("auth_style", "bearer"),
+            auth_header=pick("auth_header", ""),
+            auth_value_env=pick("auth_value_env", ""),
+            timeout_seconds=body.timeout_seconds if body.timeout_seconds is not None else 300.0,
+            warmup_strategy=body.warmup_strategy or "none",
+            advertise_models=body.advertise_models,
+            enabled=body.enabled,
+            model_filters=(
+                None
+                if body.model_filters is None or body.model_filters.is_empty()
+                else body.model_filters
+            ),
+        )
+    except ValidationError as exc:
+        raise UpstreamInvalidHTTP(
+            "invalid upstream configuration",
+            details={"name": name, "errors": _validation_summaries(exc)},
+        ) from exc
+
+    upstreams = request.app.state.upstreams
+    try:
+        created = upstreams.create_persistent(entry_model)
+    except UpstreamProtected as exc:
+        raise UpstreamProtectedHTTP(str(exc), {"name": name}) from exc
+    except UpstreamAlreadyExists as exc:
+        raise UpstreamConflictHTTP(str(exc), {"name": name}) from exc
+
+    _audit_log.info(
+        "upstream.created",
+        name=name,
+        url=url,
+        catalog_id=body.catalog_id,
+        source=request.client.host if request.client else None,
+    )
+    out = _serialize_upstream(created)
+    if created.auth_value_env and not os.environ.get(created.auth_value_env):
+        out["hint"] = (
+            f"write the API key next: POST /api/providers/{name}/credentials "
+            f'{{"key": "{created.auth_value_env}", "value": "<secret>"}}'
+        )
+    return out
+
+
 class UpstreamPatchBody(BaseModel):
     """Body for ``PATCH /api/upstreams/{name}``.
 
-    Only mutable, runtime-tunable fields are accepted. Structural fields
-    (``name``, ``kind``, ``url``, ``auth_*``, ``slot_name``,
-    ``warmup_strategy``) are intentionally absent — those stay
-    ``upstreams.toml``-authored per the deferred-write design called out
-    in this module's module docstring. ``advertise_models`` is the first
-    exception because catalog visibility is a runtime concern, not a
-    config-time one.
+    Visibility fields (``advertise_models``, ``enabled``, ``model_filters``)
+    are editable on every upstream kind. Structural fields (``url``,
+    ``auth_*``, ``timeout_seconds``, ``warmup_strategy``) only on
+    TOML-authored remote upstreams — the composite and slot-backed entries
+    get their structure from the slot lifecycle. ``name``/``kind``/
+    ``slot_name`` stay immutable (delete + recreate to rename).
+
+    ``model_filters`` set to ``null`` or an all-empty object clears the
+    filters; omitting the field leaves them unchanged.
     """
+
+    model_config = {"extra": "forbid"}
 
     advertise_models: bool | None = Field(
         default=None,
         description="Whether this upstream's /v1/models appears in the aggregate catalog.",
     )
+    enabled: bool | None = Field(
+        default=None,
+        description="Routing kill-switch — false removes the upstream from dispatch entirely.",
+    )
+    model_filters: UpstreamModelFilters | None = Field(default=None)
+    url: str | None = Field(default=None)
+    auth_style: str | None = Field(default=None)
+    auth_header: str | None = Field(default=None)
+    auth_value_env: str | None = Field(default=None)
+    timeout_seconds: float | None = Field(default=None, gt=0.0)
+    warmup_strategy: str | None = Field(default=None)
 
 
 @router.patch("/upstreams/{name}")
 async def patch_upstream(name: str, body: UpstreamPatchBody, request: Request) -> dict[str, Any]:
-    """Mutate runtime-tunable fields on a registered upstream.
+    """Mutate settings on a registered upstream.
 
-    The first reactive write against ``upstreams.toml`` (the module's
-    docstring notes write paths were deferred; this slice is the scoped
-    exception for ``advertise_models``). On success:
+    On success:
 
     - the in-memory :class:`Upstream` is updated,
-    - ``upstreams.toml`` is rewritten atomically via
-      :func:`hal0.config.loader.save_upstreams_config`,
+    - the matching ``upstreams.toml`` row is rewritten atomically via
+      :func:`hal0.config.loader.save_upstreams_config` (auto-registered
+      upstreams with no TOML row get an in-memory-only update that resets
+      on restart — same contract ``set_advertise`` always had),
     - the per-upstream model cache (``app.state.upstream_models[name]``)
-      is punched so the next ``/api/upstreams`` and ``/v1/models``
-      request sees the change without an API restart,
+      is punched on visibility flips so the next ``/api/upstreams`` and
+      ``/v1/models`` request sees the change without an API restart,
     - the change is audit-logged.
 
-    Dispatch/routing to the upstream is unaffected — ``advertise_models``
-    is purely a catalog-visibility flag, not a routing flag.
+    ``advertise_models``/``model_filters`` are catalog-visibility knobs;
+    ``enabled`` is the routing kill-switch; the rest are structural.
     """
     upstreams = request.app.state.upstreams
     try:
@@ -164,22 +359,51 @@ async def patch_upstream(name: str, body: UpstreamPatchBody, request: Request) -
     if u is None:
         raise UpstreamNotFoundHTTP(f"upstream {name!r} not found", {"name": name})
 
-    if body.advertise_models is None:
+    # Only fields the caller actually sent — model_filters=null means
+    # "clear", so presence must be distinguished from an omitted field.
+    fields: dict[str, Any] = {
+        k: getattr(body, k) for k in body.model_fields_set if k in body.model_fields
+    }
+
+    # Composite, slot-kind, and container-backed remotes (slot_name set)
+    # get their structure from the slot lifecycle.
+    protected = name == COMPOSITE_UPSTREAM_NAME or u.kind == "slot" or bool(u.slot_name)
+    structural_requested = sorted(set(fields) & _STRUCTURAL_FIELDS)
+    if protected and structural_requested:
+        raise UpstreamProtectedHTTP(
+            f"upstream {name!r} is {'the composite' if name == COMPOSITE_UPSTREAM_NAME else 'slot-backed'}; "
+            f"structural fields are managed by the slot lifecycle",
+            details={"name": name, "fields": structural_requested},
+        )
+
+    if not fields:
         # Nothing to do — but echo the current state so a no-op PATCH
         # remains idempotent and useful as a probe.
         model_cache: dict[str, list[str]] = getattr(request.app.state, "upstream_models", {})
         return _serialize_upstream(u, last_models=model_cache.get(name))
 
-    new_value = body.advertise_models
-    updated = upstreams.set_advertise(name, new_value)
+    if "model_filters" in fields and fields["model_filters"] is not None:
+        mf = fields["model_filters"]
+        if mf.is_empty():
+            fields["model_filters"] = None
+
+    try:
+        updated = upstreams.apply_persistent_patch(name, fields)
+    except ValidationError as exc:
+        raise UpstreamInvalidHTTP(
+            "invalid upstream configuration",
+            details={"name": name, "errors": _validation_summaries(exc)},
+        ) from exc
 
     # Punch the per-upstream model cache so the next /api/upstreams and
-    # /v1/models request reflects the toggle without an API restart.
+    # /v1/models request reflects visibility flips without an API restart.
     # The composite ``hal0`` upstream's module-level cache lives in
     # hal0.api and is unaffected by per-upstream flips.
     model_cache = getattr(request.app.state, "upstream_models", None)
-    if model_cache is not None and name in model_cache:
-        if new_value:
+    visibility_flip = {"advertise_models", "enabled"} & set(fields)
+    if model_cache is not None and name in model_cache and visibility_flip:
+        now_visible = updated.advertise_models and getattr(updated, "enabled", True)
+        if now_visible:
             # Re-enabling: drop the stale snapshot so the next call refetches.
             model_cache.pop(name, None)
         else:
@@ -190,10 +414,44 @@ async def patch_upstream(name: str, body: UpstreamPatchBody, request: Request) -
     _audit_log.info(
         "upstream.patch",
         name=name,
-        advertise_models=new_value,
+        fields=sorted(fields),
         source=request.client.host if request.client else None,
     )
     return _serialize_upstream(updated, last_models=(model_cache or {}).get(name))
+
+
+@router.delete("/upstreams/{name}")
+async def delete_upstream(name: str, request: Request) -> dict[str, Any]:
+    """Delete a remote upstream from the registry and ``upstreams.toml``.
+
+    The composite and slot-backed upstreams are protected. Credentials in
+    ``api.env`` are deliberately retained — deleting an upstream must never
+    destroy a secret (remove it via ``/api/secrets`` if truly unwanted).
+    """
+    upstreams = request.app.state.upstreams
+    try:
+        removed_from_toml = upstreams.remove_persistent(name)
+    except UpstreamNotFound as exc:
+        raise UpstreamNotFoundHTTP(str(exc), {"name": name}) from exc
+    except UpstreamProtected as exc:
+        raise UpstreamProtectedHTTP(str(exc), {"name": name}) from exc
+
+    model_cache = getattr(request.app.state, "upstream_models", None)
+    if model_cache is not None:
+        model_cache.pop(name, None)
+
+    _audit_log.info(
+        "upstream.deleted",
+        name=name,
+        removed_from_toml=removed_from_toml,
+        source=request.client.host if request.client else None,
+    )
+    return {
+        "ok": True,
+        "name": name,
+        "removed_from_toml": removed_from_toml,
+        "hint": "credentials in api.env are retained; remove via /api/secrets if unwanted",
+    }
 
 
 @router.post("/upstreams/{name}/test")

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -35,6 +35,7 @@ from fastapi.responses import Response, StreamingResponse
 
 from hal0.api import image_cache
 from hal0.api.deps import DispatcherDep
+from hal0.upstreams.filters import apply_filters
 
 log = structlog.get_logger("hal0-v1")
 
@@ -737,6 +738,8 @@ async def list_models(
             chat_model_ids = set()
 
     for u in upstreams.list():
+        if not getattr(u, "enabled", True):
+            continue
         if not getattr(u, "advertise_models", True):
             continue
         # The composite ``hal0`` upstream's URL is hal0-api itself —
@@ -751,6 +754,9 @@ async def list_models(
                 advertised = await upstreams.fetch_models(u.name)
             except Exception:
                 advertised = []
+        # Per-upstream curation of the discovery catalog only — the dispatch
+        # cache keeps the full list, so filtered-out ids stay addressable.
+        advertised = apply_filters(advertised, getattr(u, "model_filters", None))
         for mid in advertised:
             if mid in seen:
                 continue

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -35,6 +35,7 @@ from hal0.cli.bench_commands import bench as bench_command
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
+from hal0.cli.upstream_commands import app as upstream_app
 from hal0.cli.mcp_commands import app as mcp_app
 from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
@@ -66,6 +67,7 @@ app.add_typer(model_app, name="model")
 app.add_typer(memory_app, name="memory")
 app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
+app.add_typer(upstream_app, name="upstream")
 app.add_typer(capabilities_app, name="capabilities")
 app.add_typer(agent_app, name="agent")
 # Issue #1102 — ``hal0 app install <name>`` (deferred install verb for apps

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -35,7 +35,6 @@ from hal0.cli.bench_commands import bench as bench_command
 from hal0.cli.capabilities_commands import app as capabilities_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
-from hal0.cli.upstream_commands import app as upstream_app
 from hal0.cli.mcp_commands import app as mcp_app
 from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
@@ -44,6 +43,7 @@ from hal0.cli.registry_commands import app as registry_app
 from hal0.cli.setup_command import app as setup_app
 from hal0.cli.slot_commands import app as slot_app
 from hal0.cli.update_commands import update_app
+from hal0.cli.upstream_commands import app as upstream_app
 
 console = Console()
 

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -1,6 +1,12 @@
 """hal0 upstream subcommands — thin HTTP client to the hal0 API.
 
 Provides ``hal0 upstream {list,show,create,update,delete,test,set-credentials}``.
+
+Request/response shapes mirror ``hal0.api.routes.providers`` exactly:
+create/update bodies are ``extra="forbid"`` on the server, so every flag
+here maps 1:1 onto a real body field. Credentials go through the separate
+``/api/providers/{name}/credentials`` route (``{key, value}``) so secrets
+never transit the CRUD surface; ``create --api-key`` chains the two calls.
 """
 
 from __future__ import annotations
@@ -29,14 +35,34 @@ app = typer.Typer(help="Manage upstream LLM providers.")
 console = Console()
 
 
+def _filters_summary(filters: Any) -> str:
+    if not isinstance(filters, dict):
+        return "all"
+    parts = []
+    for key in ("models", "include", "exclude"):
+        vals = filters.get(key) or []
+        if vals:
+            parts.append(f"{key}:{len(vals)}")
+    return ", ".join(parts) if parts else "all"
+
+
+def _print_json(data: Any) -> None:
+    console.print(
+        Syntax(
+            jsonlib.dumps(data, indent=2),
+            "json",
+            theme="ansi_dark",
+            background_color="default",
+        )
+    )
+
+
 # ── list ──────────────────────────────────────────────────────────────────
 
 
 @app.command("list")
 def list_upstreams(
-    json_out: bool = typer.Option(
-        False, "--json", help="Output raw JSON instead of a table."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Output raw JSON instead of a table."),
 ) -> None:
     """List every configured upstream provider."""
     url = _api_base()
@@ -61,33 +87,25 @@ def list_upstreams(
     table.add_column("Kind")
     table.add_column("URL")
     table.add_column("Enabled")
-    table.add_column("Models")
+    table.add_column("Advertise")
+    table.add_column("Auth")
+    table.add_column("Filters")
 
     for u in ups:
-        enabled = "✓" if u.get("enabled", True) else "✗"
-        filters = u.get("model_filters")
-        models = ""
-        if isinstance(filters, dict):
-            allow = filters.get("allow") or []
-            deny = filters.get("deny") or []
-            has_filters = allow or deny
-            if has_filters:
-                parts = []
-                if allow:
-                    parts.append(f"allow:{len(allow)}")
-                if deny:
-                    parts.append(f"deny:{len(deny)}")
-                models = ", ".join(parts)
-            else:
-                models = "all"
+        if u.get("auth_key_present"):
+            auth = "✓ key set"
+        elif u.get("auth_value_env"):
+            auth = f"✗ {u['auth_value_env']} unset"
         else:
-            models = "all"
+            auth = "—"
         table.add_row(
             u.get("name", "—"),
             u.get("kind", "—"),
-            u.get("openai_base_url", "—"),
-            enabled,
-            models,
+            u.get("url", "—"),
+            "✓" if u.get("enabled", True) else "✗",
+            "✓" if u.get("advertise_models", True) else "✗",
+            auth,
+            _filters_summary(u.get("model_filters")),
         )
     console.print(table)
 
@@ -98,9 +116,7 @@ def list_upstreams(
 @app.command("show")
 def show_upstream(
     name: str = typer.Argument(..., help="Upstream name."),
-    json_out: bool = typer.Option(
-        False, "--json", help="Output raw JSON."
-    ),
+    json_out: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
     """Show full detail for one upstream provider."""
     url = _api_base()
@@ -136,20 +152,43 @@ def show_upstream(
 @app.command("create")
 def create_upstream(
     name: str = typer.Argument(..., help="Upstream name (unique, lowercase)."),
-    kind: str = typer.Option(
-        "remote",
-        "--kind",
-        help="Provider kind: 'remote' (default) or 'slot'.",
+    catalog: str = typer.Option(
+        None,
+        "--catalog",
+        "-c",
+        help="Prefill url/auth from the provider catalog (e.g. openrouter, anthropic).",
     ),
     base_url: str = typer.Option(
-        ...,
+        None,
+        "--url",
         "--base-url",
-        help="OpenAI-compatible base URL (e.g. https://api.openai.com/v1).",
+        help="OpenAI-compatible base URL (required unless --catalog supplies one).",
+    ),
+    auth_style: str = typer.Option(
+        None,
+        "--auth-style",
+        help="Auth style: bearer | anthropic | google_query | header | none.",
     ),
     auth_header: str = typer.Option(
         None,
         "--auth-header",
-        help="HTTP header for auth (default: Authorization: Bearer <key>).",
+        help="Header NAME when --auth-style header (e.g. X-Api-Key).",
+    ),
+    auth_env: str = typer.Option(
+        None,
+        "--auth-env",
+        help="Env-var name holding the API key (e.g. OPENROUTER_API_KEY).",
+    ),
+    timeout: float = typer.Option(
+        None,
+        "--timeout",
+        help="Request timeout in seconds (default 300).",
+    ),
+    api_key: str = typer.Option(
+        None,
+        "--api-key",
+        "-k",
+        help="API key value — written via the credentials route after create.",
     ),
     advertise_models: bool = typer.Option(
         True,
@@ -162,20 +201,28 @@ def create_upstream(
         help="Enable or disable this upstream (disabled = no routing).",
     ),
 ) -> None:
-    """Register a new upstream LLM provider."""
+    """Register a new upstream LLM provider (always kind=remote)."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
 
     body: dict[str, Any] = {
         "name": name,
-        "kind": kind,
-        "openai_base_url": base_url.rstrip("/"),
         "advertise_models": advertise_models,
         "enabled": enabled,
     }
+    if catalog is not None:
+        body["catalog_id"] = catalog
+    if base_url is not None:
+        body["url"] = base_url.rstrip("/")
+    if auth_style is not None:
+        body["auth_style"] = auth_style
     if auth_header is not None:
         body["auth_header"] = auth_header
+    if auth_env is not None:
+        body["auth_value_env"] = auth_env
+    if timeout is not None:
+        body["timeout_seconds"] = timeout
 
     try:
         result = api_post("/api/upstreams", json=body)
@@ -184,7 +231,25 @@ def create_upstream(
         return
 
     console.print(f"[green]✓[/green] Created upstream [bold]{name}[/bold]")
-    console.print(Syntax(jsonlib.dumps(result, indent=2), "json", theme="ansi_dark", background_color="default"))
+    _print_json(result)
+
+    env_name = result.get("auth_value_env") or ""
+    if api_key is not None:
+        if not env_name:
+            die(f"upstream {name!r} declares no auth_value_env; cannot store a key")
+            return
+        try:
+            api_post(
+                f"/api/providers/{name}/credentials",
+                json={"key": env_name, "value": api_key},
+            )
+        except CliApiError as exc:
+            die(f"upstream created, but storing the key failed: {exc}")
+            return
+        console.print(f"[green]✓[/green] Credential stored in api.env as [bold]{env_name}[/bold]")
+        console.print(f"[dim]Try it: hal0 upstream test {name}[/dim]")
+    elif hint := result.get("hint"):
+        console.print(f"[dim]{hint}[/dim]")
 
 
 # ── update ────────────────────────────────────────────────────────────────
@@ -193,16 +258,17 @@ def create_upstream(
 @app.command("update")
 def update_upstream(
     name: str = typer.Argument(..., help="Upstream name to update."),
-    base_url: str = typer.Option(
+    base_url: str = typer.Option(None, "--url", "--base-url", help="New base URL."),
+    auth_style: str = typer.Option(
         None,
-        "--base-url",
-        help="New base URL.",
+        "--auth-style",
+        help="Auth style: bearer | anthropic | google_query | header | none.",
     ),
     auth_header: str = typer.Option(
-        None,
-        "--auth-header",
-        help="New auth header.",
+        None, "--auth-header", help="Header NAME when auth-style is 'header'."
     ),
+    auth_env: str = typer.Option(None, "--auth-env", help="Env-var name holding the API key."),
+    timeout: float = typer.Option(None, "--timeout", help="Request timeout in seconds."),
     advertise_models: bool | None = typer.Option(
         None,
         "--advertise-models/--hide-models",
@@ -213,20 +279,25 @@ def update_upstream(
         "--enabled/--disabled",
         help="Toggle routing enable/disable.",
     ),
-    allow_models: list[str] | None = typer.Option(
+    models: list[str] | None = typer.Option(
         None,
-        "--allow",
-        help="Model allowlist glob (repeatable, e.g. --allow 'gpt-4*').",
+        "--model",
+        help="Exact model id to allowlist (repeatable).",
     ),
-    deny_models: list[str] | None = typer.Option(
+    include: list[str] | None = typer.Option(
         None,
-        "--deny",
-        help="Model denylist glob (repeatable, e.g. --deny '*vision*').",
+        "--include",
+        help="Glob of model ids to advertise (repeatable, e.g. --include 'anthropic/*').",
+    ),
+    exclude: list[str] | None = typer.Option(
+        None,
+        "--exclude",
+        help="Glob of model ids to hide (repeatable, e.g. --exclude '*:free'). Wins over include.",
     ),
     clear_filters: bool = typer.Option(
         False,
         "--clear-filters",
-        help="Clear all model allow/deny filters.",
+        help="Clear all model filters (advertise everything again).",
     ),
 ) -> None:
     """Update an upstream provider's settings (partial update)."""
@@ -236,19 +307,27 @@ def update_upstream(
 
     body: dict[str, Any] = {}
     if base_url is not None:
-        body["openai_base_url"] = base_url.rstrip("/")
+        body["url"] = base_url.rstrip("/")
+    if auth_style is not None:
+        body["auth_style"] = auth_style
     if auth_header is not None:
         body["auth_header"] = auth_header
+    if auth_env is not None:
+        body["auth_value_env"] = auth_env
+    if timeout is not None:
+        body["timeout_seconds"] = timeout
     if advertise_models is not None:
         body["advertise_models"] = advertise_models
     if enabled is not None:
         body["enabled"] = enabled
     if clear_filters:
-        body["model_filters"] = {}
-    elif allow_models is not None or deny_models is not None:
+        # All-empty filters ≡ clear on the API side.
+        body["model_filters"] = {"models": [], "include": [], "exclude": []}
+    elif models is not None or include is not None or exclude is not None:
         body["model_filters"] = {
-            "allow": allow_models or [],
-            "deny": deny_models or [],
+            "models": models or [],
+            "include": include or [],
+            "exclude": exclude or [],
         }
 
     if not body:
@@ -262,7 +341,7 @@ def update_upstream(
         return
 
     console.print(f"[green]✓[/green] Updated upstream [bold]{name}[/bold]")
-    console.print(Syntax(jsonlib.dumps(result, indent=2), "json", theme="ansi_dark", background_color="default"))
+    _print_json(result)
 
 
 # ── delete ────────────────────────────────────────────────────────────────
@@ -278,11 +357,9 @@ def delete_upstream(
         help="Skip confirmation prompt.",
     ),
 ) -> None:
-    """Remove an upstream provider."""
+    """Remove an upstream provider (its api.env credential is retained)."""
     if not force:
-        confirm = typer.confirm(
-            f"Delete upstream [bold]{name}[/bold]? This cannot be undone."
-        )
+        confirm = typer.confirm(f"Delete upstream {name!r}? This cannot be undone.")
         if not confirm:
             console.print("Aborted.")
             raise typer.Exit(0)
@@ -292,12 +369,14 @@ def delete_upstream(
         raise typer.Exit(1)
 
     try:
-        api_delete(f"/api/upstreams/{name}")
+        result = api_delete(f"/api/upstreams/{name}")
     except CliApiError as exc:
         die(str(exc))
         return
 
     console.print(f"[green]✓[/green] Deleted upstream [bold]{name}[/bold]")
+    if isinstance(result, dict) and (hint := result.get("hint")):
+        console.print(f"[dim]{hint}[/dim]")
 
 
 # ── test ──────────────────────────────────────────────────────────────────
@@ -319,11 +398,20 @@ def test_upstream(
         return
 
     ok = result.get("ok", False)
-    status = result.get("status", "unknown")
     if ok:
-        console.print(f"[green]✓[/green] Upstream [bold]{name}[/bold] is reachable ({status})")
+        latency = result.get("latency_ms")
+        count = result.get("models_count")
+        detail = []
+        if latency is not None:
+            detail.append(f"{latency:.0f} ms")
+        if count is not None:
+            detail.append(f"{count} models")
+        suffix = f" ({', '.join(detail)})" if detail else ""
+        console.print(f"[green]✓[/green] Upstream [bold]{name}[/bold] is reachable{suffix}")
     else:
-        console.print(f"[red]✗[/red] Upstream [bold]{name}[/bold] is unreachable: {result.get('error', status)}")
+        err = result.get("error") or result.get("status", "unknown")
+        console.print(f"[red]✗[/red] Upstream [bold]{name}[/bold] is unreachable: {err}")
+        raise typer.Exit(1)
 
 
 # ── set-credentials ───────────────────────────────────────────────────────
@@ -337,7 +425,12 @@ def set_credentials(
         "--key",
         prompt="API key",
         hide_input=True,
-        help="API key (secret; prompted securely if omitted).",
+        help="API key VALUE (secret; prompted securely if omitted).",
+    ),
+    env_var: str = typer.Option(
+        None,
+        "--env-var",
+        help="Env-var name to write (defaults to the upstream's declared auth_value_env).",
     ),
 ) -> None:
     """Set an API key for a provider (writes to api.env)."""
@@ -345,13 +438,32 @@ def set_credentials(
     if _api_unreachable(url):
         raise typer.Exit(1)
 
+    if env_var is None:
+        # The credentials route binds the key to the upstream's declared
+        # env-var — resolve it so the caller doesn't have to look it up.
+        try:
+            up = api_get(f"/api/upstreams/{name}")
+        except CliApiError as exc:
+            die(str(exc))
+            return
+        env_var = up.get("auth_value_env") or ""
+        if not env_var:
+            die(
+                f"upstream {name!r} declares no auth_value_env; "
+                "pass --env-var or set one via `hal0 upstream update --auth-env`"
+            )
+            return
+
     try:
-        result = api_post(f"/api/providers/{name}/credentials", json={"api_key": key})
+        api_post(
+            f"/api/providers/{name}/credentials",
+            json={"key": env_var, "value": key},
+        )
     except CliApiError as exc:
         die(str(exc))
         return
 
     console.print(
-        f"[green]✓[/green] Credentials stored for provider [bold]{name}[/bold] "
-        f"({result.get('provider')})"
+        f"[green]✓[/green] Credential stored for [bold]{name}[/bold] "
+        f"in api.env as [bold]{env_var}[/bold]"
     )

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -1,0 +1,357 @@
+"""hal0 upstream subcommands — thin HTTP client to the hal0 API.
+
+Provides ``hal0 upstream {list,show,create,update,delete,test,set-credentials}``.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+
+from hal0.cli._shared import (
+    CliApiError,
+    _api_base,
+    _api_unreachable,
+    api_delete,
+    api_get,
+    api_patch,
+    api_post,
+    die,
+)
+
+app = typer.Typer(help="Manage upstream LLM providers.")
+console = Console()
+
+
+# ── list ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def list_upstreams(
+    json_out: bool = typer.Option(
+        False, "--json", help="Output raw JSON instead of a table."
+    ),
+) -> None:
+    """List every configured upstream provider."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        ups = api_get("/api/upstreams")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        console.print(jsonlib.dumps(ups, indent=2))
+        return
+
+    if not ups:
+        console.print("[dim]No upstream providers configured.[/dim]")
+        return
+
+    table = Table(title="Upstream Providers")
+    table.add_column("Name", style="bold")
+    table.add_column("Kind")
+    table.add_column("URL")
+    table.add_column("Enabled")
+    table.add_column("Models")
+
+    for u in ups:
+        enabled = "✓" if u.get("enabled", True) else "✗"
+        filters = u.get("model_filters")
+        models = ""
+        if isinstance(filters, dict):
+            allow = filters.get("allow") or []
+            deny = filters.get("deny") or []
+            has_filters = allow or deny
+            if has_filters:
+                parts = []
+                if allow:
+                    parts.append(f"allow:{len(allow)}")
+                if deny:
+                    parts.append(f"deny:{len(deny)}")
+                models = ", ".join(parts)
+            else:
+                models = "all"
+        else:
+            models = "all"
+        table.add_row(
+            u.get("name", "—"),
+            u.get("kind", "—"),
+            u.get("openai_base_url", "—"),
+            enabled,
+            models,
+        )
+    console.print(table)
+
+
+# ── show ──────────────────────────────────────────────────────────────────
+
+
+@app.command("show")
+def show_upstream(
+    name: str = typer.Argument(..., help="Upstream name."),
+    json_out: bool = typer.Option(
+        False, "--json", help="Output raw JSON."
+    ),
+) -> None:
+    """Show full detail for one upstream provider."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        up = api_get(f"/api/upstreams/{name}")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    if json_out:
+        console.print(jsonlib.dumps(up, indent=2))
+        return
+
+    console.print(
+        Panel(
+            Syntax(
+                jsonlib.dumps(up, indent=2),
+                "json",
+                theme="ansi_dark",
+                background_color="default",
+            ),
+            title=f"Upstream: {name}",
+            border_style="cyan",
+        )
+    )
+
+
+# ── create ────────────────────────────────────────────────────────────────
+
+
+@app.command("create")
+def create_upstream(
+    name: str = typer.Argument(..., help="Upstream name (unique, lowercase)."),
+    kind: str = typer.Option(
+        "remote",
+        "--kind",
+        help="Provider kind: 'remote' (default) or 'slot'.",
+    ),
+    base_url: str = typer.Option(
+        ...,
+        "--base-url",
+        help="OpenAI-compatible base URL (e.g. https://api.openai.com/v1).",
+    ),
+    auth_header: str = typer.Option(
+        None,
+        "--auth-header",
+        help="HTTP header for auth (default: Authorization: Bearer <key>).",
+    ),
+    advertise_models: bool = typer.Option(
+        True,
+        "--advertise-models/--hide-models",
+        help="Whether to expose this upstream's models in /v1/models.",
+    ),
+    enabled: bool = typer.Option(
+        True,
+        "--enabled/--disabled",
+        help="Enable or disable this upstream (disabled = no routing).",
+    ),
+) -> None:
+    """Register a new upstream LLM provider."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    body: dict[str, Any] = {
+        "name": name,
+        "kind": kind,
+        "openai_base_url": base_url.rstrip("/"),
+        "advertise_models": advertise_models,
+        "enabled": enabled,
+    }
+    if auth_header is not None:
+        body["auth_header"] = auth_header
+
+    try:
+        result = api_post("/api/upstreams", json=body)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    console.print(f"[green]✓[/green] Created upstream [bold]{name}[/bold]")
+    console.print(Syntax(jsonlib.dumps(result, indent=2), "json", theme="ansi_dark", background_color="default"))
+
+
+# ── update ────────────────────────────────────────────────────────────────
+
+
+@app.command("update")
+def update_upstream(
+    name: str = typer.Argument(..., help="Upstream name to update."),
+    base_url: str = typer.Option(
+        None,
+        "--base-url",
+        help="New base URL.",
+    ),
+    auth_header: str = typer.Option(
+        None,
+        "--auth-header",
+        help="New auth header.",
+    ),
+    advertise_models: bool | None = typer.Option(
+        None,
+        "--advertise-models/--hide-models",
+        help="Toggle /v1/models visibility.",
+    ),
+    enabled: bool | None = typer.Option(
+        None,
+        "--enabled/--disabled",
+        help="Toggle routing enable/disable.",
+    ),
+    allow_models: list[str] | None = typer.Option(
+        None,
+        "--allow",
+        help="Model allowlist glob (repeatable, e.g. --allow 'gpt-4*').",
+    ),
+    deny_models: list[str] | None = typer.Option(
+        None,
+        "--deny",
+        help="Model denylist glob (repeatable, e.g. --deny '*vision*').",
+    ),
+    clear_filters: bool = typer.Option(
+        False,
+        "--clear-filters",
+        help="Clear all model allow/deny filters.",
+    ),
+) -> None:
+    """Update an upstream provider's settings (partial update)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    body: dict[str, Any] = {}
+    if base_url is not None:
+        body["openai_base_url"] = base_url.rstrip("/")
+    if auth_header is not None:
+        body["auth_header"] = auth_header
+    if advertise_models is not None:
+        body["advertise_models"] = advertise_models
+    if enabled is not None:
+        body["enabled"] = enabled
+    if clear_filters:
+        body["model_filters"] = {}
+    elif allow_models is not None or deny_models is not None:
+        body["model_filters"] = {
+            "allow": allow_models or [],
+            "deny": deny_models or [],
+        }
+
+    if not body:
+        console.print("[yellow]Nothing to update.[/yellow]")
+        raise typer.Exit(0)
+
+    try:
+        result = api_patch(f"/api/upstreams/{name}", json=body)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    console.print(f"[green]✓[/green] Updated upstream [bold]{name}[/bold]")
+    console.print(Syntax(jsonlib.dumps(result, indent=2), "json", theme="ansi_dark", background_color="default"))
+
+
+# ── delete ────────────────────────────────────────────────────────────────
+
+
+@app.command("delete")
+def delete_upstream(
+    name: str = typer.Argument(..., help="Upstream name to delete."),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip confirmation prompt.",
+    ),
+) -> None:
+    """Remove an upstream provider."""
+    if not force:
+        confirm = typer.confirm(
+            f"Delete upstream [bold]{name}[/bold]? This cannot be undone."
+        )
+        if not confirm:
+            console.print("Aborted.")
+            raise typer.Exit(0)
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    try:
+        api_delete(f"/api/upstreams/{name}")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    console.print(f"[green]✓[/green] Deleted upstream [bold]{name}[/bold]")
+
+
+# ── test ──────────────────────────────────────────────────────────────────
+
+
+@app.command("test")
+def test_upstream(
+    name: str = typer.Argument(..., help="Upstream name to probe."),
+) -> None:
+    """Probe an upstream's reachability and auth."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    try:
+        result = api_post(f"/api/upstreams/{name}/test")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    ok = result.get("ok", False)
+    status = result.get("status", "unknown")
+    if ok:
+        console.print(f"[green]✓[/green] Upstream [bold]{name}[/bold] is reachable ({status})")
+    else:
+        console.print(f"[red]✗[/red] Upstream [bold]{name}[/bold] is unreachable: {result.get('error', status)}")
+
+
+# ── set-credentials ───────────────────────────────────────────────────────
+
+
+@app.command("set-credentials")
+def set_credentials(
+    name: str = typer.Argument(..., help="Provider name."),
+    key: str = typer.Option(
+        ...,
+        "--key",
+        prompt="API key",
+        hide_input=True,
+        help="API key (secret; prompted securely if omitted).",
+    ),
+) -> None:
+    """Set an API key for a provider (writes to api.env)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    try:
+        result = api_post(f"/api/providers/{name}/credentials", json={"api_key": key})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    console.print(
+        f"[green]✓[/green] Credentials stored for provider [bold]{name}[/bold] "
+        f"({result.get('provider')})"
+    )

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1592,8 +1592,36 @@ def resolve_chat_template(slot_cfg: dict, model_info: dict) -> str | None:
 
 
 _VALID_UPSTREAM_KINDS = frozenset({"slot", "remote"})
-_VALID_AUTH_STYLES = frozenset({"bearer", "header", "none"})
-_VALID_WARMUP = frozenset({"none", "lazy", "eager"})
+# The full set implemented by UpstreamRegistry.auth_headers().
+_VALID_AUTH_STYLES = frozenset({"bearer", "anthropic", "google_query", "header", "none"})
+# Canonical vocabulary matches the Upstream dataclass; "lazy"/"eager" were the
+# original schema-only spellings and are still accepted as aliases on read.
+_VALID_WARMUP = frozenset({"none", "ondemand", "always"})
+_WARMUP_ALIASES = {"lazy": "ondemand", "eager": "always"}
+
+
+class UpstreamModelFilters(BaseModel):
+    """Optional [upstream.model_filters] table — curates /v1/models advertising.
+
+    A model id is advertised when it is in ``models`` OR matches any ``include``
+    glob (both empty ⇒ everything included), AND it does not match any
+    ``exclude`` glob. Exclude always wins. Dispatch is unfiltered — excluded
+    models stay reachable by explicit name.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    models: list[str] = Field(default_factory=list, description="Exact model ids to allowlist.")
+    include: list[str] = Field(default_factory=list, description="fnmatch globs to include.")
+    exclude: list[str] = Field(default_factory=list, description="fnmatch globs to exclude.")
+
+    @field_validator("models", "include", "exclude")
+    @classmethod
+    def drop_empty_entries(cls, v: list[str]) -> list[str]:
+        return [s.strip() for s in v if s and s.strip()]
+
+    def is_empty(self) -> bool:
+        return not (self.models or self.include or self.exclude)
 
 
 class UpstreamEntry(BaseModel):
@@ -1605,11 +1633,17 @@ class UpstreamEntry(BaseModel):
     kind: str = Field(default="remote", description="'slot' | 'remote'.")
     url: str = Field(..., description="Base URL.")
     auth_style: str = Field(default="bearer")
+    auth_header: str = Field(default="", description="Header name when auth_style='header'.")
     auth_value_env: str = Field(default="")
     timeout_seconds: float = Field(default=300.0, gt=0.0)
     slot_name: str | None = Field(default=None)
     warmup_strategy: str = Field(default="none")
     advertise_models: bool = Field(default=True)
+    enabled: bool = Field(
+        default=True,
+        description="When false the upstream is skipped by routing and /v1/models.",
+    )
+    model_filters: UpstreamModelFilters | None = Field(default=None)
 
     @field_validator("name")
     @classmethod
@@ -1646,6 +1680,7 @@ class UpstreamEntry(BaseModel):
     @field_validator("warmup_strategy")
     @classmethod
     def warmup_valid(cls, v: str) -> str:
+        v = _WARMUP_ALIASES.get(v, v)
         if v not in _VALID_WARMUP:
             raise ValueError(
                 f"warmup_strategy {v!r} is not valid; choose from {sorted(_VALID_WARMUP)}"
@@ -1659,6 +1694,14 @@ class UpstreamEntry(BaseModel):
         # Catch this at load rather than at dispatch time.
         if self.kind == "slot" and not (self.slot_name and self.slot_name.strip()):
             raise ValueError(f"upstream {self.name!r}: kind='slot' requires slot_name to be set")
+        return self
+
+    @model_validator(mode="after")
+    def header_style_has_header_name(self) -> UpstreamEntry:
+        if self.auth_style == "header" and not self.auth_header.strip():
+            raise ValueError(
+                f"upstream {self.name!r}: auth_style='header' requires auth_header to be set"
+            )
         return self
 
 

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -570,6 +570,16 @@ class Dispatcher:
                 # isn't being served anywhere right now.
                 upstream = None
                 registry_entry = None
+            if upstream is not None and not getattr(upstream, "enabled", True):
+                # Operator kill-switch: a disabled upstream behaves like an
+                # offline one — fall through rather than erroring.
+                log.info(
+                    "registry binding disabled; falling through",
+                    upstream=upstream.name,
+                    model=model_id,
+                )
+                upstream = None
+                registry_entry = None
             if registry_entry is not None and upstream is None:
                 # Explicit binding to a missing upstream — config error, not a
                 # silent fallthrough.  Mirrors haloai's UnknownUpstream raise.
@@ -1254,7 +1264,9 @@ class Dispatcher:
 
     def _upstreams_in_priority_order(self) -> list[Upstream]:
         try:
-            return list(self._upstreams.list())
+            # Disabled upstreams are invisible to routing (operator
+            # kill-switch). getattr-guard keeps cross-subtree stubs working.
+            return [u for u in self._upstreams.list() if getattr(u, "enabled", True)]
         except NotImplementedError:
             # Cross-subtree stub fallback.
             return []

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -406,7 +406,7 @@ GATED_TOOLS: frozenset[str] = frozenset(
 #   model_swap → /api/slots/{n}/model   /api/slots/{n}/swap           name diff
 #   model_pull → /api/models/pull       /api/models/{id}/pull         id-in-path
 #   capability_set → /api/capabilities  /api/capabilities/{slot}/{c}  composite key
-#   provider_credential_write → /api/providers/{n}/credentials  NO LIVE ROUTE
+#   provider_credential_write → /api/providers/{n}/credentials  live (providers.py)
 #   version_info → /api/version         /api/status                   name diff
 
 _REST_MAP: dict[str, tuple[str, str]] = {

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -46,7 +46,7 @@ Autonomous read::
     model_pull_status, model_inspect, model_store,
     hardware_probe, capability_list, provider_list, version_info,
     stack_list, stack_status, profile_list, profile_status,
-    profile_export, upstream_list,
+    profile_export, upstream_list, upstream_get, upstream_test,
     settings_get, settings_schema, settings_apply_plan,
     bench_runs, bench_run_status, bench_queue,
     # Host-introspection probes (issue #237)
@@ -73,6 +73,8 @@ Gated (destructive — enqueued for owner approval)::
     # Stack CRUD (create/update/apply/import/export/snapshot/delete)
     stack_create, stack_update, stack_apply, stack_import,
     stack_export, stack_snapshot, stack_delete,
+    # Upstream provider CRUD (create/update/delete; test is a read)
+    upstream_create, upstream_update, upstream_delete,
     # Benchmarks — enqueue/control load models onto slots (disruptive)
     bench_enqueue, bench_control,
     # Journald surfaces gated for security (MED-1)
@@ -304,6 +306,10 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
         "npu_status",
         "env_report",
         "model_store_probe",
+        # Upstream provider reads (upstream_list is with the other list
+        # reads above); test probes the provider but changes no state.
+        "upstream_get",
+        "upstream_test",
     }
 )
 
@@ -380,6 +386,12 @@ GATED_TOOLS: frozenset[str] = frozenset(
         # docs/internal/phase-8-pending/mcp-backend.md §2.
         "logs_tail",
         "slot_logs",
+        # Upstream provider CRUD — config-surface writes (delete is
+        # destructive; the credential itself goes through the separately
+        # gated provider_credential_write).
+        "upstream_create",
+        "upstream_update",
+        "upstream_delete",
         # memory_delete with len(ids) > 1 routes here at call time.
     }
 )
@@ -491,6 +503,12 @@ _REST_MAP: dict[str, tuple[str, str]] = {
     "profile_import": ("POST", "/api/profiles/import"),
     "profile_delete": ("DELETE", "/api/profiles/{name}"),
     "provider_credential_write": ("POST", "/api/providers/{name}/credentials"),
+    # Upstream CRUD (upstream_list is in the System section above)
+    "upstream_get": ("GET", "/api/upstreams/{name}"),
+    "upstream_create": ("POST", "/api/upstreams"),
+    "upstream_update": ("PATCH", "/api/upstreams/{name}"),
+    "upstream_delete": ("DELETE", "/api/upstreams/{name}"),
+    "upstream_test": ("POST", "/api/upstreams/{name}/test"),
 }
 
 
@@ -528,6 +546,11 @@ _PATH_ARGS: dict[str, tuple[str, ...]] = {
     "stack_export": ("slug",),
     "stack_update": ("slug",),
     "stack_delete": ("slug",),
+    # Upstream providers
+    "upstream_get": ("name",),
+    "upstream_update": ("name",),
+    "upstream_delete": ("name",),
+    "upstream_test": ("name",),
     # Misc
     "capability_set": ("slot", "child"),
     "provider_credential_write": ("name",),
@@ -1122,6 +1145,22 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "profile_update": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
+    # Upstream CRUD (upstream_list is annotated with the list reads above)
+    "upstream_get": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "upstream_test": ToolAnnotations(
+        readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "upstream_create": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
+    ),
+    "upstream_update": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False
+    ),
+    "upstream_delete": ToolAnnotations(
+        readOnlyHint=False, destructiveHint=True, idempotentHint=True, openWorldHint=False
+    ),
     # Mutating, reversible, non-idempotent (each call has additional effect).
     "memory_add": ToolAnnotations(
         readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False
@@ -1219,6 +1258,13 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
     "provider_list": "List configured providers.",
     "version_info": "hal0 version + runtime status.",
     "upstream_list": "List all configured upstream LLM providers.",
+    "upstream_get": "Get one upstream provider's full detail.",
+    "upstream_test": "Probe an upstream's reachability and auth status.",
+    "upstream_create": "Register a new remote upstream LLM provider (gated).",
+    "upstream_update": (
+        "Update an upstream provider's settings (url/auth/visibility/filters/enabled) (gated)."
+    ),
+    "upstream_delete": "Remove an upstream provider; its api.env credential is kept (gated).",
     "stack_list": "List every stack, with the active stack + drift status.",
     "stack_status": "Get one stack's detail, active flag, and drift status.",
     "profile_list": "List every profile in the catalog (seed + custom).",

--- a/src/hal0/upstreams/__init__.py
+++ b/src/hal0/upstreams/__init__.py
@@ -18,13 +18,18 @@ See PLAN.md §3 and §5 Tier 1.
 Key exports:
     Upstream         — frozen dataclass representing one routing target.
     UpstreamRegistry — runtime registry of all upstreams.
+    ModelFilters     — per-upstream /v1/models advertising filters.
 """
 
 from __future__ import annotations
 
+from hal0.upstreams.filters import ModelFilters, apply_filters, is_advertised
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 __all__ = [
+    "ModelFilters",
     "Upstream",
     "UpstreamRegistry",
+    "apply_filters",
+    "is_advertised",
 ]

--- a/src/hal0/upstreams/filters.py
+++ b/src/hal0/upstreams/filters.py
@@ -22,11 +22,11 @@ This module must stay import-light (stdlib only) — it is shared by the
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
-from typing import Iterable, Sequence
 
-__all__ = ["ModelFilters", "is_advertised", "apply_filters"]
+__all__ = ["ModelFilters", "apply_filters", "is_advertised"]
 
 
 @dataclass(frozen=True)

--- a/src/hal0/upstreams/filters.py
+++ b/src/hal0/upstreams/filters.py
@@ -1,0 +1,75 @@
+"""Per-upstream model-advertising filters.
+
+Implements docs/superpowers/specs/2026-07-06-upstream-model-filters.md:
+an operator curates which of an upstream's models appear in the aggregated
+``/v1/models`` catalog. Dispatch is deliberately unfiltered — an excluded
+model stays reachable by explicit name.
+
+Semantics
+    A model id is advertised when
+      (1) ``models`` and ``include`` are both empty (no include filter), OR
+          the id is an exact member of ``models``, OR it matches at least
+          one ``include`` glob;
+    AND
+      (2) it does not match any ``exclude`` glob.
+    Exclude always overrides include.
+
+Globs use :func:`fnmatch.fnmatchcase` (``*`` and ``?``; no regex).
+
+This module must stay import-light (stdlib only) — it is shared by the
+``/v1/models`` handler and the config layer without risking circular imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from fnmatch import fnmatchcase
+from typing import Iterable, Sequence
+
+__all__ = ["ModelFilters", "is_advertised", "apply_filters"]
+
+
+@dataclass(frozen=True)
+class ModelFilters:
+    """Immutable runtime form of an [upstream.model_filters] table."""
+
+    models: tuple[str, ...] = field(default_factory=tuple)
+    """Exact model ids to allowlist (OR'd with `include`)."""
+
+    include: tuple[str, ...] = field(default_factory=tuple)
+    """Globs to include; empty together with `models` means include-all."""
+
+    exclude: tuple[str, ...] = field(default_factory=tuple)
+    """Globs to exclude; always wins over models/include."""
+
+    @classmethod
+    def from_lists(
+        cls,
+        models: Sequence[str] | None = None,
+        include: Sequence[str] | None = None,
+        exclude: Sequence[str] | None = None,
+    ) -> ModelFilters:
+        """Build from plain lists (e.g. a parsed UpstreamModelFilters dump)."""
+        clean = lambda xs: tuple(s.strip() for s in (xs or ()) if s and s.strip())  # noqa: E731
+        return cls(models=clean(models), include=clean(include), exclude=clean(exclude))
+
+    def is_empty(self) -> bool:
+        return not (self.models or self.include or self.exclude)
+
+
+def is_advertised(model_id: str, filters: ModelFilters | None) -> bool:
+    """Return True when `model_id` should appear in /v1/models."""
+    if filters is None or filters.is_empty():
+        return True
+    if any(fnmatchcase(model_id, pat) for pat in filters.exclude):
+        return False
+    if not filters.models and not filters.include:
+        return True
+    if model_id in filters.models:
+        return True
+    return any(fnmatchcase(model_id, pat) for pat in filters.include)
+
+
+def apply_filters(model_ids: Iterable[str], filters: ModelFilters | None) -> list[str]:
+    """Filter an iterable of model ids, preserving order."""
+    return [m for m in model_ids if is_advertised(m, filters)]

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -24,16 +24,21 @@ import asyncio
 import json
 import os
 import random
+import threading
 import time
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import structlog
 
 from hal0.config import paths as _paths
 from hal0.errors import Hal0Error
+from hal0.upstreams.filters import ModelFilters
+
+if TYPE_CHECKING:
+    from hal0.config.schema import UpstreamEntry
 
 log = structlog.get_logger(__name__)
 
@@ -69,6 +74,18 @@ class UpstreamNotFound(UpstreamError, KeyError):
 class UpstreamAlreadyExists(UpstreamError):
     code = "system.upstream_already_exists"
     status = 409
+
+
+class UpstreamProtected(UpstreamError):
+    """Raised when mutating the synthetic composite or a slot-backed upstream."""
+
+    code = "system.upstream_protected"
+    status = 400
+
+
+# Name of the synthetic composite upstream auto-registered at startup for
+# /v1/models aggregation. Never authored in TOML, never CRUD-mutable.
+COMPOSITE_UPSTREAM_NAME = "hal0"
 
 
 # ── Upstream dataclass ────────────────────────────────────────────────────────
@@ -121,6 +138,76 @@ class Upstream:
     backoff_steps: tuple[float, ...] = field(default_factory=lambda: TIER1_BACKOFF_STEPS)
     """TIER1: per-slot probe interval steps.  Override via hardware.json."""
 
+    enabled: bool = True
+    """When False the dispatcher and /v1/models skip this upstream entirely;
+    config and credentials are retained (kill-switch, not deletion)."""
+
+    model_filters: ModelFilters | None = None
+    """Optional /v1/models advertising filters.  Dispatch is unfiltered."""
+
+
+# ── Config-layer ↔ runtime conversion ─────────────────────────────────────────
+
+
+def _filters_to_runtime(value: Any) -> ModelFilters | None:
+    """Normalise any model_filters representation to a runtime ModelFilters.
+
+    Accepts UpstreamModelFilters (pydantic), plain dicts, ModelFilters, or
+    None. Empty filters collapse to None (no-filter fast path).
+    """
+    if value is None:
+        return None
+    if isinstance(value, ModelFilters):
+        return None if value.is_empty() else value
+    if not isinstance(value, dict):
+        value = value.model_dump()
+    mf = ModelFilters.from_lists(
+        models=value.get("models"),
+        include=value.get("include"),
+        exclude=value.get("exclude"),
+    )
+    return None if mf.is_empty() else mf
+
+
+def _filters_to_config(value: Any) -> dict[str, list[str]] | None:
+    """Normalise any model_filters representation to entry-dump shape."""
+    mf = _filters_to_runtime(value)
+    if mf is None:
+        return None
+    return {"models": list(mf.models), "include": list(mf.include), "exclude": list(mf.exclude)}
+
+
+def _fields_for_entry(fields: dict[str, Any]) -> dict[str, Any]:
+    out = dict(fields)
+    if "model_filters" in out:
+        out["model_filters"] = _filters_to_config(out["model_filters"])
+    return out
+
+
+def _fields_for_dataclass(fields: dict[str, Any]) -> dict[str, Any]:
+    out = dict(fields)
+    if "model_filters" in out:
+        out["model_filters"] = _filters_to_runtime(out["model_filters"])
+    return out
+
+
+def upstream_from_entry(entry: UpstreamEntry) -> Upstream:
+    """Build the runtime Upstream for a validated UpstreamEntry."""
+    return Upstream(
+        name=entry.name,
+        kind=entry.kind,
+        url=entry.url,
+        auth_style=entry.auth_style,
+        auth_header=entry.auth_header,
+        auth_value_env=entry.auth_value_env,
+        timeout_seconds=entry.timeout_seconds,
+        slot_name=entry.slot_name,
+        warmup_strategy=entry.warmup_strategy,
+        advertise_models=entry.advertise_models,
+        enabled=entry.enabled,
+        model_filters=_filters_to_runtime(entry.model_filters),
+    )
+
 
 # ── Warmup state ──────────────────────────────────────────────────────────────
 
@@ -162,6 +249,10 @@ class UpstreamRegistry:
         # TIER1: per-slot backoff overrides loaded from hardware.json
         self._slot_overrides: dict[str, dict[str, Any]] = {}
         self._client: httpx.AsyncClient | None = None
+        # Serialises every load→mutate→save of upstreams.toml so concurrent
+        # reactive writes can't lose updates (the atomic rename in
+        # write_toml_atomic prevents torn files, not lost updates).
+        self._persist_lock = threading.Lock()
 
     # ── CRUD ──────────────────────────────────────────────────────────────────
 
@@ -212,22 +303,36 @@ class UpstreamRegistry:
     def set_advertise(self, name: str, value: bool, *, persist: bool = True) -> Upstream:
         """Flip an upstream's ``advertise_models`` flag and persist atomically.
 
-        Reads ``upstreams.toml``, updates the matching entry's
-        ``advertise_models`` field, and writes the file back via
-        :func:`hal0.config.loader.save_upstreams_config` (which uses
-        ``write_toml_atomic`` for a crash-safe rename). The in-memory
-        ``Upstream`` is also updated so the next ``/v1/models`` request
-        reflects the change without an API restart.
+        Thin wrapper over :meth:`apply_persistent_patch` — see there for the
+        persistence contract.
+        """
+        return self.apply_persistent_patch(name, {"advertise_models": value}, persist=persist)
 
-        Auto-registered upstreams (e.g. slot-backed entries that aren't
-        authored in ``upstreams.toml``) have no on-disk row to patch — for
-        those the in-memory value is updated and the on-disk config is left
-        untouched. The flag stays at its in-memory value for the lifetime
-        of the process; on restart the default (``True``) is re-applied.
+    def apply_persistent_patch(
+        self, name: str, fields: dict[str, Any], *, persist: bool = True
+    ) -> Upstream:
+        """Merge ``fields`` into the named upstream and persist atomically.
+
+        Reads ``upstreams.toml``, applies ``fields`` to the matching entry
+        (re-validated through :class:`~hal0.config.schema.UpstreamEntry`),
+        and writes the file back via
+        :func:`hal0.config.loader.save_upstreams_config` (``write_toml_atomic``
+        gives a crash-safe rename). Only after the save succeeds is the
+        in-memory :class:`Upstream` updated — a failed write leaves memory
+        consistent with disk (TOML stays canonical).
+
+        ``fields`` uses config-layer values; ``model_filters`` may be an
+        :class:`~hal0.config.schema.UpstreamModelFilters`, a plain dict, or
+        ``None`` (clears filters). An empty filters object also clears.
+
+        Auto-registered upstreams (slot-backed entries and the synthetic
+        composite, which aren't authored in ``upstreams.toml``) have no
+        on-disk row to patch — for those the in-memory value is updated and
+        the on-disk config is left untouched; the value resets on restart.
 
         Args:
             name: Upstream name.
-            value: New ``advertise_models`` value.
+            fields: Field-name → new-value mapping.
             persist: When ``True`` (default), atomically write
                 ``upstreams.toml``. Set to ``False`` for tests that don't
                 want filesystem side-effects.
@@ -236,6 +341,7 @@ class UpstreamRegistry:
 
         Raises:
             UpstreamNotFound: If ``name`` is not registered.
+            ValidationError: If the patched entry fails schema validation.
         """
         cur = self._upstreams.get(name)
         if cur is None:
@@ -249,24 +355,111 @@ class UpstreamRegistry:
                 load_upstreams_config,
                 save_upstreams_config,
             )
+            from hal0.config.schema import UpstreamEntry
 
-            cfg = load_upstreams_config()
-            for entry in cfg.upstream:
-                if entry.name == name:
-                    entry.advertise_models = value
-                    save_upstreams_config(cfg)
-                    break
-            # else: auto-registered upstream, not on disk — in-memory only.
+            with self._persist_lock:
+                cfg = load_upstreams_config()
+                for i, entry in enumerate(cfg.upstream):
+                    if entry.name == name:
+                        data = entry.model_dump()
+                        data.update(_fields_for_entry(fields))
+                        cfg.upstream[i] = UpstreamEntry.model_validate(data)
+                        save_upstreams_config(cfg)
+                        break
+                # else: auto-registered upstream, not on disk — in-memory only.
 
-        merged = replace(cur, advertise_models=value)
+        merged = replace(cur, **_fields_for_dataclass(fields))
         self._upstreams[name] = merged
         log.info(
-            "upstream.set_advertise",
+            "upstream.patch",
             name=name,
-            advertise_models=value,
+            fields=sorted(fields),
             persisted=persist,
         )
         return merged
+
+    def create_persistent(self, entry: UpstreamEntry, *, persist: bool = True) -> Upstream:
+        """Append a new upstream to ``upstreams.toml`` and register it.
+
+        Guards: the composite name and ``kind="slot"`` entries are rejected —
+        slot upstreams are owned by SlotManager, not this surface.
+
+        Raises:
+            UpstreamProtected: Reserved name or slot kind.
+            UpstreamAlreadyExists: Name collision in registry or TOML.
+        """
+        if entry.name == COMPOSITE_UPSTREAM_NAME:
+            raise UpstreamProtected(
+                f"upstream name {entry.name!r} is reserved", {"name": entry.name}
+            )
+        if entry.kind == "slot":
+            raise UpstreamProtected(
+                "slot upstreams are managed by the slot lifecycle, not created here",
+                {"name": entry.name},
+            )
+        if entry.name in self._upstreams:
+            raise UpstreamAlreadyExists(
+                f"upstream {entry.name!r} already exists", {"name": entry.name}
+            )
+
+        if persist:
+            from hal0.config.loader import (
+                load_upstreams_config,
+                save_upstreams_config,
+            )
+
+            with self._persist_lock:
+                cfg = load_upstreams_config()
+                if any(e.name == entry.name for e in cfg.upstream):
+                    raise UpstreamAlreadyExists(
+                        f"upstream {entry.name!r} already exists in upstreams.toml",
+                        {"name": entry.name},
+                    )
+                cfg.upstream.append(entry)
+                save_upstreams_config(cfg)
+
+        upstream = upstream_from_entry(entry)
+        self.add(upstream)
+        return upstream
+
+    def remove_persistent(self, name: str, *, persist: bool = True) -> bool:
+        """Delete an upstream from ``upstreams.toml`` and the registry.
+
+        Credentials referenced via ``auth_value_env`` are deliberately left
+        in ``api.env`` — deleting an upstream must never destroy a secret.
+
+        Returns True when a TOML row was removed (False for auto-registered
+        upstreams that only existed in memory).
+
+        Raises:
+            UpstreamNotFound: If ``name`` is not registered.
+            UpstreamProtected: Composite or slot-backed upstream.
+        """
+        cur = self._upstreams.get(name)
+        if cur is None:
+            raise UpstreamNotFound(f"upstream {name!r} not found", {"name": name})
+        if name == COMPOSITE_UPSTREAM_NAME or cur.kind == "slot":
+            raise UpstreamProtected(
+                f"upstream {name!r} is protected and cannot be deleted", {"name": name}
+            )
+
+        removed_from_toml = False
+        if persist:
+            from hal0.config.loader import (
+                load_upstreams_config,
+                save_upstreams_config,
+            )
+
+            with self._persist_lock:
+                cfg = load_upstreams_config()
+                kept = [e for e in cfg.upstream if e.name != name]
+                if len(kept) != len(cfg.upstream):
+                    cfg.upstream = kept
+                    save_upstreams_config(cfg)
+                    removed_from_toml = True
+
+        self.remove(name)
+        return removed_from_toml
 
     def in_priority_order(self) -> list[Upstream]:
         """Sort order for dispatcher fallback: slots first, then remotes."""

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -438,7 +438,9 @@ class UpstreamRegistry:
         cur = self._upstreams.get(name)
         if cur is None:
             raise UpstreamNotFound(f"upstream {name!r} not found", {"name": name})
-        if name == COMPOSITE_UPSTREAM_NAME or cur.kind == "slot":
+        # Composite, slot-kind, AND container-backed remotes (kind="remote"
+        # with slot_name set) are all owned by the slot lifecycle.
+        if name == COMPOSITE_UPSTREAM_NAME or cur.kind == "slot" or cur.slot_name:
             raise UpstreamProtected(
                 f"upstream {name!r} is protected and cannot be deleted", {"name": name}
             )

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -559,3 +559,91 @@ def test_list_models_surfaces_installed_flm_models(
     assert rows["embed-gemma-300m-FLM"]["type"] == "embedding"
     # not-installed FLM tag omitted.
     assert "qwen3-0.6b-FLM" not in rows
+
+
+# ── upstream provenance in /api/models ─────────────────────────────────────
+
+
+def test_slot_backed_upstreams_never_stamp_origin_upstream(
+    inspect_client: TestClient,
+) -> None:
+    """The composite ``hal0`` aggregate and container slots serve LOCAL
+    models — their advertised ids must not appear as origin="upstream"
+    rows. Regression: a chat slot's raw GGUF id (casing differs from the
+    normalized registry id) surfaced in the Models page Upstream tab as
+    "via hal0"."""
+    from hal0.upstreams.registry import Upstream
+
+    app = inspect_client.app
+    reg = app.state.upstreams
+    for u in list(reg.list()):
+        reg.remove(u.name)
+    reg.add(Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1"))
+    reg.add(
+        Upstream(
+            name="ops",
+            kind="remote",
+            url="http://127.0.0.1:8091/v1",
+            slot_name="ops",
+        )
+    )
+    reg.add(
+        Upstream(
+            name="openrouter",
+            kind="remote",
+            url="https://openrouter.ai/api/v1",
+        )
+    )
+    app.state.upstream_models = {
+        "hal0": ["Qwopus3.5-4B-Coder-MTP-Q6_K"],
+        "ops": ["qwopus3-5-4b-coder-mtp-q6-k"],
+        "openrouter": ["anthropic/claude-sonnet-4"],
+    }
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    # Slot-backed advertisements are suppressed entirely.
+    assert "Qwopus3.5-4B-Coder-MTP-Q6_K" not in rows
+    assert "qwopus3-5-4b-coder-mtp-q6-k" not in rows
+    # Genuine remotes still contribute upstream rows.
+    assert rows["anthropic/claude-sonnet-4"]["origin"] == "upstream"
+    assert rows["anthropic/claude-sonnet-4"]["upstream"] == "openrouter"
+
+
+def test_disabled_or_filtered_remote_curates_api_models(
+    inspect_client: TestClient,
+) -> None:
+    """/api/models honors enabled + advertise_models + model_filters for
+    remote upstreams (same curation as /v1/models)."""
+    import dataclasses
+
+    from hal0.upstreams.filters import ModelFilters
+    from hal0.upstreams.registry import Upstream
+
+    app = inspect_client.app
+    reg = app.state.upstreams
+    for u in list(reg.list()):
+        reg.remove(u.name)
+    base = Upstream(name="openrouter", kind="remote", url="https://openrouter.ai/api/v1")
+    reg.add(
+        dataclasses.replace(
+            base,
+            model_filters=ModelFilters.from_lists(include=["anthropic/*"], exclude=["*:free"]),
+        )
+    )
+    reg.add(
+        dataclasses.replace(base, name="disabled-one", enabled=False),
+    )
+    app.state.upstream_models = {
+        "openrouter": [
+            "anthropic/claude-sonnet-4",
+            "anthropic/claude-haiku:free",
+            "nvidia/nemotron-70b",
+        ],
+        "disabled-one": ["mistral/mistral-large"],
+    }
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    assert "anthropic/claude-sonnet-4" in rows
+    assert "anthropic/claude-haiku:free" not in rows  # exclude wins
+    assert "nvidia/nemotron-70b" not in rows  # not included
+    assert "mistral/mistral-large" not in rows  # disabled upstream

--- a/tests/api/test_providers_routes.py
+++ b/tests/api/test_providers_routes.py
@@ -296,3 +296,251 @@ def test_patch_upstream_persists_atomically_no_partial_file(client: TestClient) 
     # File parses cleanly.
     with path.open("rb") as f:
         tomllib.load(f)
+
+
+# ── POST/PATCH/DELETE /api/upstreams — reactive CRUD ──────────────────────────
+
+
+def _toml_rows(client: TestClient) -> dict[str, dict]:
+    path = _upstreams_toml_path(client)
+    if not path.exists():
+        return {}
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+    return {u["name"]: u for u in raw.get("upstream", [])}
+
+
+def test_create_upstream_minimal(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.post(
+        "/api/upstreams",
+        json={"name": "corp", "url": "https://llm.corp.internal/v1"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["name"] == "corp"
+    assert body["kind"] == "remote"
+    assert body["enabled"] is True
+    # Registered live + persisted to TOML.
+    assert client.get("/api/upstreams/corp").status_code == 200
+    assert _toml_rows(client)["corp"]["url"] == "https://llm.corp.internal/v1"
+
+
+def test_create_upstream_from_catalog_prefills(client: TestClient, monkeypatch: object) -> None:
+    # Earlier tests may have written OPENROUTER_API_KEY into os.environ via
+    # the credentials route — the "write the key next" hint needs it absent.
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)  # type: ignore[attr-defined]
+    _seed_upstreams(client)
+    response = client.post(
+        "/api/upstreams",
+        json={"name": "my-openrouter", "catalog_id": "openrouter"},
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["url"] == "https://openrouter.ai/api/v1"
+    assert body["auth_style"] == "bearer"
+    assert body["auth_value_env"] == "OPENROUTER_API_KEY"
+    # Key not yet written → hint chains to the credentials route.
+    assert "credentials" in body.get("hint", "")
+
+
+def test_create_upstream_explicit_fields_beat_catalog(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.post(
+        "/api/upstreams",
+        json={
+            "name": "or-proxy",
+            "catalog_id": "openrouter",
+            "url": "http://10.0.1.200:4000/v1",
+            "auth_value_env": "LITELLM_KEY",
+        },
+    )
+    assert response.status_code == 201, response.text
+    assert response.json()["url"] == "http://10.0.1.200:4000/v1"
+    assert response.json()["auth_value_env"] == "LITELLM_KEY"
+
+
+def test_create_upstream_with_filters_and_flags(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.post(
+        "/api/upstreams",
+        json={
+            "name": "curated",
+            "url": "https://openrouter.ai/api/v1",
+            "advertise_models": True,
+            "enabled": False,
+            "model_filters": {"include": ["anthropic/*"], "exclude": ["*:free"]},
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["model_filters"] == {
+        "models": [],
+        "include": ["anthropic/*"],
+        "exclude": ["*:free"],
+    }
+    row = _toml_rows(client)["curated"]
+    assert row["enabled"] is False
+    assert row["model_filters"]["include"] == ["anthropic/*"]
+
+
+def test_create_upstream_duplicate_409(client: TestClient) -> None:
+    _seed_upstreams(client)  # registers "openrouter"
+    response = client.post(
+        "/api/upstreams",
+        json={"name": "openrouter", "url": "https://openrouter.ai/api/v1"},
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "upstream.already_exists"
+
+
+def test_create_upstream_reserved_name_400(client: TestClient) -> None:
+    response = client.post("/api/upstreams", json={"name": "hal0", "url": "http://x/v1"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.protected"
+
+
+def test_create_upstream_bad_name_400(client: TestClient) -> None:
+    for bad in ("UPPER", "has space", "-leading"):
+        response = client.post("/api/upstreams", json={"name": bad, "url": "http://x/v1"})
+        assert response.status_code == 400, bad
+        assert response.json()["error"]["code"] == "upstream.invalid"
+    # Over-length names are rejected at the pydantic layer (422).
+    response = client.post("/api/upstreams", json={"name": "a" * 65, "url": "http://x/v1"})
+    assert response.status_code == 422
+
+
+def test_create_upstream_unknown_catalog_400(client: TestClient) -> None:
+    response = client.post("/api/upstreams", json={"name": "x", "catalog_id": "nope"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.invalid"
+
+
+def test_create_upstream_url_required_without_catalog(client: TestClient) -> None:
+    response = client.post("/api/upstreams", json={"name": "x"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.invalid"
+
+
+def test_create_upstream_never_echoes_secrets(client: TestClient) -> None:
+    import os
+
+    os.environ["OPENROUTER_API_KEY"] = "sk-super-secret"
+    try:
+        response = client.post("/api/upstreams", json={"name": "orx", "catalog_id": "openrouter"})
+        assert "sk-super-secret" not in response.text
+    finally:
+        os.environ.pop("OPENROUTER_API_KEY", None)
+
+
+def test_patch_upstream_enabled_and_filters(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={
+            "enabled": False,
+            "model_filters": {"include": ["anthropic/*"], "exclude": [], "models": []},
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["model_filters"]["include"] == ["anthropic/*"]
+    row = _toml_rows(client)["openrouter"]
+    assert row["enabled"] is False
+    assert row["model_filters"]["include"] == ["anthropic/*"]
+
+
+def test_patch_upstream_clear_filters_with_empty_object(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    client.patch("/api/upstreams/openrouter", json={"model_filters": {"include": ["a/*"]}})
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"model_filters": {"models": [], "include": [], "exclude": []}},
+    )
+    assert response.status_code == 200
+    assert response.json()["model_filters"] is None
+    assert "model_filters" not in _toml_rows(client)["openrouter"]
+
+
+def test_patch_upstream_structural_fields_on_remote(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    response = client.patch(
+        "/api/upstreams/openrouter",
+        json={"url": "http://10.0.1.200:4000/v1", "timeout_seconds": 60.0},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["url"] == "http://10.0.1.200:4000/v1"
+    assert _toml_rows(client)["openrouter"]["url"] == "http://10.0.1.200:4000/v1"
+
+
+def test_patch_slot_upstream_structural_rejected_visibility_allowed(
+    client: TestClient,
+) -> None:
+    _seed_upstreams(client)  # includes slot-kind "primary"
+    response = client.patch("/api/upstreams/primary", json={"url": "http://elsewhere/v1"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.protected"
+    # Visibility fields still work (in-memory-only — no TOML row).
+    response = client.patch("/api/upstreams/primary", json={"advertise_models": False})
+    assert response.status_code == 200
+    assert response.json()["advertise_models"] is False
+
+
+def test_patch_upstream_invalid_auth_style_400(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    response = client.patch("/api/upstreams/openrouter", json={"auth_style": "basic"})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.invalid"
+    # Memory and disk untouched.
+    assert client.get("/api/upstreams/openrouter").json()["auth_style"] == "bearer"
+    assert _toml_rows(client)["openrouter"].get("auth_style", "bearer") == "bearer"
+
+
+def test_delete_upstream_removes_row_and_registry(client: TestClient) -> None:
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    response = client.delete("/api/upstreams/openrouter")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["removed_from_toml"] is True
+    assert "openrouter" not in _toml_rows(client)
+    assert client.get("/api/upstreams/openrouter").status_code == 404
+
+
+def test_delete_upstream_protects_slot_and_composite(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.delete("/api/upstreams/primary")
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "upstream.protected"
+
+
+def test_delete_upstream_404(client: TestClient) -> None:
+    _seed_upstreams(client)
+    response = client.delete("/api/upstreams/ghost")
+    assert response.status_code == 404
+
+
+def test_delete_upstream_retains_credentials(client: TestClient) -> None:
+    """Deleting an upstream must never destroy the secret in api.env."""
+    import os
+
+    _seed_upstreams(client)
+    _seed_openrouter_in_toml(client)
+    client.post(
+        "/api/providers/openrouter/credentials",
+        json={"key": "OPENROUTER_API_KEY", "value": "sk-keepme"},
+    )
+    try:
+        response = client.delete("/api/upstreams/openrouter")
+        assert response.status_code == 200
+        api_env = _upstreams_toml_path(client).parent / "api.env"
+        assert "sk-keepme" in api_env.read_text()
+    finally:
+        os.environ.pop("OPENROUTER_API_KEY", None)

--- a/tests/api/test_providers_routes.py
+++ b/tests/api/test_providers_routes.py
@@ -272,9 +272,10 @@ def test_patch_upstream_does_not_touch_other_rows(client: TestClient) -> None:
         raw = tomllib.load(f)
     by_name = {u["name"]: u for u in raw.get("upstream", [])}
     assert by_name["openrouter"]["advertise_models"] is False
-    # Anthropic row untouched.
+    # Anthropic row untouched (modulo warmup alias normalization: the
+    # legacy "eager" spelling is written back as canonical "always").
     assert by_name["anthropic"]["advertise_models"] is True
-    assert by_name["anthropic"]["warmup_strategy"] == "eager"
+    assert by_name["anthropic"]["warmup_strategy"] == "always"
 
 
 def test_patch_upstream_persists_atomically_no_partial_file(client: TestClient) -> None:

--- a/tests/api/test_v1_models_filters.py
+++ b/tests/api/test_v1_models_filters.py
@@ -1,0 +1,93 @@
+"""Integration tests — per-upstream model filters + enabled flag on /v1/models.
+
+Spec: docs/superpowers/specs/2026-07-06-upstream-model-filters.md. The
+filter applies at the aggregation layer only; the dispatch cache keeps the
+full catalog (dispatch behavior is deliberately untested here — see spec
+"Testing Decisions").
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from hal0.upstreams.filters import ModelFilters
+from hal0.upstreams.registry import Upstream
+
+OPENROUTER_MODELS = [
+    "anthropic/claude-sonnet-4",
+    "anthropic/claude-3-haiku",
+    "google/gemini-2.5-pro",
+    "deepseek/deepseek-r1:free",
+    "nvidia/llama-3.1-nemotron-70b",
+]
+
+
+def _seed_remote(client: TestClient, **upstream_kw: object) -> None:
+    reg = client.app.state.upstreams
+    for u in list(reg.list()):
+        reg.remove(u.name)
+    reg.add(
+        Upstream(
+            name="openrouter",
+            kind="remote",
+            url="https://openrouter.ai/api/v1",
+            auth_value_env="OPENROUTER_API_KEY",
+            **upstream_kw,  # type: ignore[arg-type]
+        )
+    )
+
+    async def fake_fetch(name: str) -> list[str]:
+        return list(OPENROUTER_MODELS) if name == "openrouter" else []
+
+    reg.fetch_models = fake_fetch  # type: ignore[method-assign]
+
+
+def _listed_ids(client: TestClient) -> list[str]:
+    response = client.get("/v1/models")
+    assert response.status_code == 200, response.text
+    return [m["id"] for m in response.json()["data"]]
+
+
+def test_no_filter_advertises_everything(client: TestClient) -> None:
+    _seed_remote(client)
+    ids = _listed_ids(client)
+    for mid in OPENROUTER_MODELS:
+        assert mid in ids
+
+
+def test_include_globs_curate_the_catalog(client: TestClient) -> None:
+    _seed_remote(
+        client,
+        model_filters=ModelFilters.from_lists(include=["anthropic/*", "google/*"]),
+    )
+    ids = _listed_ids(client)
+    assert "anthropic/claude-sonnet-4" in ids
+    assert "google/gemini-2.5-pro" in ids
+    assert "deepseek/deepseek-r1:free" not in ids
+    assert "nvidia/llama-3.1-nemotron-70b" not in ids
+
+
+def test_exclude_overrides_include(client: TestClient) -> None:
+    _seed_remote(
+        client,
+        model_filters=ModelFilters.from_lists(
+            include=["anthropic/*"], exclude=["anthropic/claude-3-haiku"]
+        ),
+    )
+    ids = _listed_ids(client)
+    assert "anthropic/claude-sonnet-4" in ids
+    assert "anthropic/claude-3-haiku" not in ids
+
+
+def test_empty_filters_pass_all(client: TestClient) -> None:
+    _seed_remote(client, model_filters=ModelFilters())
+    ids = _listed_ids(client)
+    for mid in OPENROUTER_MODELS:
+        assert mid in ids
+
+
+def test_disabled_upstream_contributes_nothing(client: TestClient) -> None:
+    _seed_remote(client, enabled=False)
+    ids = _listed_ids(client)
+    for mid in OPENROUTER_MODELS:
+        assert mid not in ids

--- a/tests/cli/test_upstream_commands.py
+++ b/tests/cli/test_upstream_commands.py
@@ -1,0 +1,232 @@
+"""Tests for ``hal0 upstream`` command request shapes.
+
+The API's create/update bodies are ``extra="forbid"`` — a CLI flag that
+maps to a wrong field name 422s against the live server. These tests pin
+every body the CLI sends to the exact field names the routes accept
+(regression for the first cut, which sent ``openai_base_url``/``kind``/
+``allow``/``deny``/``api_key`` and failed on every write).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import upstream_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def api(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub the API client surface and capture calls."""
+    calls: dict[str, Any] = {"posts": [], "patches": [], "deletes": [], "gets": []}
+
+    monkeypatch.setattr(upstream_commands, "_api_unreachable", lambda _url: False)
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        calls["gets"].append(path)
+        if path == "/api/upstreams":
+            return calls.get("list_response", [])
+        return calls.get(
+            "get_response",
+            {"name": path.rsplit("/", 1)[-1], "auth_value_env": "OPENROUTER_API_KEY"},
+        )
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        calls["posts"].append((path, json))
+        if path == "/api/upstreams":
+            return {**(json or {}), "auth_value_env": (json or {}).get("auth_value_env", "")}
+        return {"ok": True}
+
+    def fake_patch(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        calls["patches"].append((path, json))
+        return json or {}
+
+    def fake_delete(path: str, **_kw: Any) -> dict[str, Any]:
+        calls["deletes"].append(path)
+        return {"ok": True, "removed_from_toml": True}
+
+    monkeypatch.setattr(upstream_commands, "api_get", fake_get)
+    monkeypatch.setattr(upstream_commands, "api_post", fake_post)
+    monkeypatch.setattr(upstream_commands, "api_patch", fake_patch)
+    monkeypatch.setattr(upstream_commands, "api_delete", fake_delete)
+    return calls
+
+
+def test_create_sends_url_not_openai_base_url(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        ["create", "corp", "--url", "https://llm.corp/v1/"],
+    )
+    assert result.exit_code == 0, result.output
+    path, body = api["posts"][0]
+    assert path == "/api/upstreams"
+    assert body["url"] == "https://llm.corp/v1"  # trailing slash stripped
+    assert "openai_base_url" not in body
+    assert "kind" not in body  # server forces remote; body forbids the field
+
+
+def test_create_with_catalog_and_flags(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        ["create", "orx", "--catalog", "openrouter", "--disabled", "--hide-models"],
+    )
+    assert result.exit_code == 0, result.output
+    _, body = api["posts"][0]
+    assert body == {
+        "name": "orx",
+        "advertise_models": False,
+        "enabled": False,
+        "catalog_id": "openrouter",
+    }
+
+
+def test_create_with_api_key_chains_credentials(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        [
+            "create",
+            "orx",
+            "--url",
+            "https://openrouter.ai/api/v1",
+            "--auth-env",
+            "OPENROUTER_API_KEY",
+            "--api-key",
+            "sk-test",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(api["posts"]) == 2
+    cred_path, cred_body = api["posts"][1]
+    assert cred_path == "/api/providers/orx/credentials"
+    # The credentials route contract: {key: ENV_NAME, value: secret}.
+    assert cred_body == {"key": "OPENROUTER_API_KEY", "value": "sk-test"}
+
+
+def test_update_sends_spec_filter_fields(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        [
+            "update",
+            "orx",
+            "--include",
+            "anthropic/*",
+            "--include",
+            "google/*",
+            "--exclude",
+            "*:free",
+            "--model",
+            "deepseek/deepseek-r1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    _, body = api["patches"][0]
+    assert body["model_filters"] == {
+        "models": ["deepseek/deepseek-r1"],
+        "include": ["anthropic/*", "google/*"],
+        "exclude": ["*:free"],
+    }
+    assert "allow" not in str(body)
+    assert "deny" not in str(body)
+
+
+def test_update_clear_filters_sends_all_empty(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["update", "orx", "--clear-filters"])
+    assert result.exit_code == 0, result.output
+    _, body = api["patches"][0]
+    assert body["model_filters"] == {"models": [], "include": [], "exclude": []}
+
+
+def test_update_toggles_and_structural(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        ["update", "orx", "--disabled", "--url", "http://proxy/v1", "--timeout", "60"],
+    )
+    assert result.exit_code == 0, result.output
+    _, body = api["patches"][0]
+    assert body == {"url": "http://proxy/v1", "timeout_seconds": 60.0, "enabled": False}
+
+
+def test_update_nothing_is_noop(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["update", "orx"])
+    assert result.exit_code == 0
+    assert "Nothing to update" in result.output
+    assert api["patches"] == []
+
+
+def test_delete_requires_confirm_and_force_skips(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["delete", "orx"], input="n\n")
+    assert result.exit_code == 0
+    assert api["deletes"] == []
+    result = runner.invoke(upstream_commands.app, ["delete", "orx", "--force"])
+    assert result.exit_code == 0, result.output
+    assert api["deletes"] == ["/api/upstreams/orx"]
+
+
+def test_set_credentials_resolves_env_var_and_sends_key_value(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        ["set-credentials", "openrouter", "--key", "sk-test"],
+    )
+    assert result.exit_code == 0, result.output
+    # Resolved the env-var name from GET /api/upstreams/{name}.
+    assert api["gets"] == ["/api/upstreams/openrouter"]
+    path, body = api["posts"][0]
+    assert path == "/api/providers/openrouter/credentials"
+    assert body == {"key": "OPENROUTER_API_KEY", "value": "sk-test"}
+
+
+def test_set_credentials_explicit_env_var_skips_lookup(api: dict[str, Any]) -> None:
+    result = runner.invoke(
+        upstream_commands.app,
+        ["set-credentials", "corp", "--key", "sk-x", "--env-var", "CORP_KEY"],
+    )
+    assert result.exit_code == 0, result.output
+    assert api["gets"] == []
+    _, body = api["posts"][0]
+    assert body == {"key": "CORP_KEY", "value": "sk-x"}
+
+
+def test_list_renders_url_and_filter_summary(api: dict[str, Any]) -> None:
+    # Short values throughout — Rich truncates wide cells at the 80-col
+    # test terminal, so realistic-length URLs can't be asserted verbatim.
+    api["list_response"] = [
+        {
+            "name": "orx",
+            "kind": "remote",
+            "url": "http://gw/v1",
+            "enabled": True,
+            "advertise_models": True,
+            "auth_value_env": "ORX_KEY",
+            "auth_key_present": True,
+            "model_filters": {"models": [], "include": ["anthropic/*"], "exclude": ["*:free"]},
+        }
+    ]
+    result = runner.invoke(upstream_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "orx" in result.output
+    assert "include:1" in result.output
+    assert "exclude:1" in result.output
+
+
+def test_test_command_reports_latency_and_fails_on_unreachable(
+    api: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def ok_post(path: str, **_kw: Any) -> dict[str, Any]:
+        return {"ok": True, "latency_ms": 123.4, "models_count": 42}
+
+    monkeypatch.setattr(upstream_commands, "api_post", ok_post)
+    result = runner.invoke(upstream_commands.app, ["test", "orx"])
+    assert result.exit_code == 0
+    assert "123 ms" in result.output and "42 models" in result.output
+
+    def bad_post(path: str, **_kw: Any) -> dict[str, Any]:
+        return {"ok": False, "error": "401 unauthorized"}
+
+    monkeypatch.setattr(upstream_commands, "api_post", bad_post)
+    result = runner.invoke(upstream_commands.app, ["test", "orx"])
+    assert result.exit_code == 1
+    assert "401" in result.output

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -280,6 +280,38 @@ class TestUpstreamEntry:
         with pytest.raises(ValidationError):
             UpstreamEntry(name="x", url="http://x", timeout_seconds=-1.0)
 
+    def test_anthropic_and_google_auth_styles_accepted(self) -> None:
+        # These were rejected pre-fix even though the runtime implements them.
+        assert UpstreamEntry(name="a", url="http://x", auth_style="anthropic").auth_style == (
+            "anthropic"
+        )
+        assert UpstreamEntry(name="g", url="http://x", auth_style="google_query").auth_style == (
+            "google_query"
+        )
+
+    def test_warmup_canonical_vocabulary_accepted(self) -> None:
+        for v in ("none", "ondemand", "always"):
+            assert UpstreamEntry(name="x", url="http://x", warmup_strategy=v).warmup_strategy == v
+
+    def test_warmup_legacy_aliases_normalize(self) -> None:
+        assert UpstreamEntry(name="x", url="http://x", warmup_strategy="lazy").warmup_strategy == (
+            "ondemand"
+        )
+        assert UpstreamEntry(name="x", url="http://x", warmup_strategy="eager").warmup_strategy == (
+            "always"
+        )
+
+    def test_header_style_requires_header_name(self) -> None:
+        with pytest.raises(ValidationError) as ei:
+            UpstreamEntry(name="x", url="http://x", auth_style="header")
+        assert "auth_header" in str(ei.value)
+        e = UpstreamEntry(name="x", url="http://x", auth_style="header", auth_header="X-Api-Key")
+        assert e.auth_header == "X-Api-Key"
+
+    def test_enabled_defaults_true(self) -> None:
+        assert UpstreamEntry(name="x", url="http://x").enabled is True
+        assert UpstreamEntry(name="x", url="http://x", enabled=False).enabled is False
+
 
 class TestUpstreamsConfig:
     def test_duplicate_upstream_names_raise(self) -> None:

--- a/tests/config/test_upstream_filters.py
+++ b/tests/config/test_upstream_filters.py
@@ -1,0 +1,131 @@
+"""Schema + engine tests for per-upstream model filters.
+
+Spec: docs/superpowers/specs/2026-07-06-upstream-model-filters.md.
+The pure-filter tests exercise realistic OpenRouter-style model ids.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import UpstreamEntry, UpstreamModelFilters
+from hal0.upstreams.filters import ModelFilters, apply_filters, is_advertised
+
+OPENROUTER_IDS = [
+    "anthropic/claude-sonnet-4",
+    "anthropic/claude-3-haiku",
+    "google/gemini-2.5-pro",
+    "deepseek/deepseek-r1",
+    "deepseek/deepseek-r1:free",
+    "nvidia/llama-3.1-nemotron-70b",
+    "meta-llama/llama-4-maverick:free",
+]
+
+
+# ── UpstreamModelFilters schema ───────────────────────────────────────────────
+
+
+class TestFilterSchema:
+    def test_defaults_are_empty(self) -> None:
+        f = UpstreamModelFilters()
+        assert f.models == [] and f.include == [] and f.exclude == []
+        assert f.is_empty()
+
+    def test_unknown_field_rejected(self) -> None:
+        # extra="forbid" — a typo'd field name must not silently pass-all.
+        with pytest.raises(ValidationError):
+            UpstreamModelFilters(includes=["anthropic/*"])  # type: ignore[call-arg]
+
+    def test_empty_strings_dropped(self) -> None:
+        f = UpstreamModelFilters(models=["", "  ", "a/b"], include=["", "x/*"])
+        assert f.models == ["a/b"]
+        assert f.include == ["x/*"]
+
+    def test_round_trips_on_upstream_entry(self) -> None:
+        e = UpstreamEntry(
+            name="openrouter",
+            url="https://openrouter.ai/api/v1",
+            model_filters=UpstreamModelFilters(include=["anthropic/*"], exclude=["*:free"]),
+        )
+        dumped = e.model_dump()
+        e2 = UpstreamEntry.model_validate(dumped)
+        assert e2.model_filters is not None
+        assert e2.model_filters.include == ["anthropic/*"]
+        assert e2.model_filters.exclude == ["*:free"]
+
+    def test_absent_filters_default_none(self) -> None:
+        assert UpstreamEntry(name="x", url="http://x").model_filters is None
+
+
+# ── ModelFilters engine ───────────────────────────────────────────────────────
+
+
+class TestFilterEngine:
+    def test_none_or_empty_pass_all(self) -> None:
+        assert apply_filters(OPENROUTER_IDS, None) == OPENROUTER_IDS
+        assert apply_filters(OPENROUTER_IDS, ModelFilters()) == OPENROUTER_IDS
+
+    def test_models_allowlist_exact(self) -> None:
+        f = ModelFilters.from_lists(models=["anthropic/claude-sonnet-4"])
+        assert apply_filters(OPENROUTER_IDS, f) == ["anthropic/claude-sonnet-4"]
+        # exact match only — no implicit prefixing
+        assert not is_advertised("anthropic/claude-sonnet-4:beta", f)
+
+    def test_include_glob_by_provider_prefix(self) -> None:
+        f = ModelFilters.from_lists(include=["anthropic/*", "google/*"])
+        assert apply_filters(OPENROUTER_IDS, f) == [
+            "anthropic/claude-sonnet-4",
+            "anthropic/claude-3-haiku",
+            "google/gemini-2.5-pro",
+        ]
+
+    def test_models_and_include_are_ored(self) -> None:
+        # "all Anthropic and Google models, plus these specific DeepSeek ones"
+        f = ModelFilters.from_lists(
+            models=["deepseek/deepseek-r1"], include=["anthropic/*", "google/*"]
+        )
+        got = apply_filters(OPENROUTER_IDS, f)
+        assert "deepseek/deepseek-r1" in got
+        assert "anthropic/claude-sonnet-4" in got
+        assert "nvidia/llama-3.1-nemotron-70b" not in got
+
+    def test_exclude_only_hides_from_pass_all(self) -> None:
+        f = ModelFilters.from_lists(exclude=["*:free", "nvidia/*"])
+        got = apply_filters(OPENROUTER_IDS, f)
+        assert got == [
+            "anthropic/claude-sonnet-4",
+            "anthropic/claude-3-haiku",
+            "google/gemini-2.5-pro",
+            "deepseek/deepseek-r1",
+        ]
+
+    def test_exclude_overrides_include(self) -> None:
+        # "all Anthropic models EXCEPT claude-3-haiku"
+        f = ModelFilters.from_lists(include=["anthropic/*"], exclude=["anthropic/claude-3-haiku"])
+        assert apply_filters(OPENROUTER_IDS, f) == ["anthropic/claude-sonnet-4"]
+
+    def test_exclude_overrides_exact_allowlist(self) -> None:
+        f = ModelFilters.from_lists(models=["deepseek/deepseek-r1:free"], exclude=["*:free"])
+        assert not is_advertised("deepseek/deepseek-r1:free", f)
+
+    def test_question_mark_glob(self) -> None:
+        f = ModelFilters.from_lists(include=["deepseek/deepseek-r?"])
+        assert is_advertised("deepseek/deepseek-r1", f)
+        assert not is_advertised("deepseek/deepseek-r1:free", f)
+
+    def test_case_sensitive_matching(self) -> None:
+        f = ModelFilters.from_lists(include=["Anthropic/*"])
+        assert not is_advertised("anthropic/claude-sonnet-4", f)
+
+    def test_from_lists_strips_and_drops_empty(self) -> None:
+        f = ModelFilters.from_lists(models=[" a/b ", ""], include=None, exclude=["  "])
+        assert f.models == ("a/b",)
+        assert f.include == ()
+        assert f.exclude == ()
+        assert not f.is_empty()
+
+    def test_order_preserved(self) -> None:
+        f = ModelFilters.from_lists(exclude=["google/*"])
+        got = apply_filters(OPENROUTER_IDS, f)
+        assert got == [m for m in OPENROUTER_IDS if not m.startswith("google/")]

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -698,3 +698,102 @@ def test_resolve_by_capability_reexported_from_router() -> None:
     # by external callers from router — the identity must be preserved too.
     assert r.LegacyResolutionFailed is cr.LegacyResolutionFailed
     assert "LegacyResolutionFailed" in r.__all__
+
+
+# ── enabled=False gating (operator kill-switch) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disabled_remote_skipped_on_warm_cache() -> None:
+    """A disabled remote must not win passthrough even with a warm cache."""
+    import dataclasses
+
+    remote = dataclasses.replace(
+        make_remote("openrouter", "https://openrouter.ai/api/v1"), enabled=False
+    )
+    upstreams = FakeUpstreamRegistry([remote])
+    models = FakeModelRegistry(routes={})
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["meta/llama-3.1-405b"] if name == "openrouter" else [],
+    )
+
+    with pytest.raises((NoRouteFound, LegacyResolutionFailed)):
+        await dispatcher.dispatch(
+            make_request(), body={"model": "meta/llama-3.1-405b", "messages": []}
+        )
+
+
+@pytest.mark.asyncio
+async def test_registry_binding_to_disabled_upstream_falls_through() -> None:
+    """An explicit ModelRegistry binding to a disabled upstream behaves like
+    an offline one — fall through, not UnknownUpstream."""
+    import dataclasses
+
+    slot = make_slot("chat")
+    remote = dataclasses.replace(
+        make_remote("openrouter", "https://openrouter.ai/api/v1"), enabled=False
+    )
+    upstreams = FakeUpstreamRegistry([slot, remote])
+    models = FakeModelRegistry(routes={"meta/llama-3.1-405b": "openrouter"})
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        # Slot cache warm so Step 2 can still route slot-served models.
+        cached_models=lambda name: ["qwen3-4b"] if name == "chat" else [],
+    )
+
+    with pytest.raises((NoRouteFound, LegacyResolutionFailed)):
+        await dispatcher.dispatch(
+            make_request(), body={"model": "meta/llama-3.1-405b", "messages": []}
+        )
+
+
+@pytest.mark.asyncio
+async def test_enabled_remote_still_routes() -> None:
+    """Control: the same setup with enabled=True routes via passthrough."""
+    remote = make_remote("openrouter", "https://openrouter.ai/api/v1")
+    upstreams = FakeUpstreamRegistry([remote])
+    models = FakeModelRegistry(routes={})
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        cached_models=lambda name: ["meta/llama-3.1-405b"] if name == "openrouter" else [],
+    )
+
+    call = await dispatcher.dispatch(
+        make_request(), body={"model": "meta/llama-3.1-405b", "messages": []}
+    )
+    assert call.upstream_name == "openrouter"
+    assert call.resolution_path == "passthrough:openrouter"
+
+
+@pytest.mark.asyncio
+async def test_disabled_remote_excluded_from_cold_prefetch() -> None:
+    """Step 3 must not fan /v1/models fetches out to disabled remotes."""
+    import dataclasses
+
+    fetched: list[str] = []
+    remote = dataclasses.replace(
+        make_remote("openrouter", "https://openrouter.ai/api/v1"), enabled=False
+    )
+    upstreams = FakeUpstreamRegistry([remote])
+    models = FakeModelRegistry(routes={})
+
+    async def fetch(u: Upstream) -> list[str]:
+        fetched.append(u.name)
+        return ["meta/llama-3.1-405b"]
+
+    dispatcher = Dispatcher(
+        upstream_registry=upstreams,
+        model_registry=models,
+        fetch_models=fetch,
+        cached_models=lambda name: [],
+    )
+
+    with pytest.raises((NoRouteFound, LegacyResolutionFailed)):
+        await dispatcher.dispatch(
+            make_request(), body={"model": "meta/llama-3.1-405b", "messages": []}
+        )
+    assert fetched == []

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -155,6 +155,7 @@ def test_destructive_tools_match_gated_destructive_set() -> None:
         "memory_delete",
         "stack_delete",
         "profile_delete",
+        "upstream_delete",
     }
     destructive_per_annotation = {
         name for name, ann in admin._ANNOTATIONS.items() if ann.destructiveHint

--- a/tests/upstreams/test_registry.py
+++ b/tests/upstreams/test_registry.py
@@ -486,3 +486,217 @@ def test_tps_zero_delta_t_keeps_value_non_negative() -> None:
     tps = r.record_tokens("primary", token_counter=200, now=1.0)
     # Same instant — tps holds at the previous (clamped) value, which was 0.
     assert tps >= 0.0
+
+
+# ── Persistent mutations (upstreams.toml round-trip) ─────────────────────────
+
+
+def _write_upstreams_toml(body: str) -> Path:
+    from hal0.config import paths
+
+    etc = paths.etc()
+    etc.mkdir(parents=True, exist_ok=True)
+    p = etc / "upstreams.toml"
+    p.write_text(body)
+    return p
+
+
+_OPENROUTER_TOML = """
+[[upstream]]
+name = "openrouter"
+kind = "remote"
+url = "https://openrouter.ai/api/v1"
+auth_value_env = "OPENROUTER_API_KEY"
+"""
+
+
+def _registry_with_openrouter() -> UpstreamRegistry:
+    r = UpstreamRegistry()
+    r.add(_remote("openrouter"))
+    return r
+
+
+class TestApplyPersistentPatch:
+    def test_persists_fields_to_toml(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        path = _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+
+        merged = r.apply_persistent_patch(
+            "openrouter",
+            {"enabled": False, "model_filters": {"include": ["anthropic/*"], "exclude": ["*:free"]}},
+        )
+        assert merged.enabled is False
+        assert merged.model_filters is not None
+        assert merged.model_filters.include == ("anthropic/*",)
+
+        on_disk = tomllib.loads(path.read_text())["upstream"][0]
+        assert on_disk["enabled"] is False
+        assert on_disk["model_filters"]["include"] == ["anthropic/*"]
+        assert on_disk["model_filters"]["exclude"] == ["*:free"]
+
+    def test_empty_filters_clear_to_none(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        path = _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+        r.apply_persistent_patch("openrouter", {"model_filters": {"include": ["a/*"]}})
+        merged = r.apply_persistent_patch(
+            "openrouter", {"model_filters": {"models": [], "include": [], "exclude": []}}
+        )
+        assert merged.model_filters is None
+        on_disk = tomllib.loads(path.read_text())["upstream"][0]
+        assert "model_filters" not in on_disk  # exclude_none drops the cleared table
+
+    def test_auto_registered_upstream_is_memory_only(self, tmp_hal0_home: str) -> None:
+        from hal0.config import paths
+
+        r = _registry_with_openrouter()  # no TOML row at all
+        merged = r.apply_persistent_patch("openrouter", {"enabled": False})
+        assert merged.enabled is False
+        assert not (paths.etc() / "upstreams.toml").exists()
+
+    def test_unknown_upstream_raises(self, tmp_hal0_home: str) -> None:
+        r = UpstreamRegistry()
+        with pytest.raises(UpstreamNotFound):
+            r.apply_persistent_patch("ghost", {"enabled": False})
+
+    def test_invalid_patch_rejected_and_memory_untouched(self, tmp_hal0_home: str) -> None:
+        _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+        with pytest.raises(Exception):
+            r.apply_persistent_patch("openrouter", {"auth_style": "basic"})
+        assert r.get("openrouter").auth_style == "bearer"  # type: ignore[union-attr]
+
+    def test_failed_save_leaves_memory_unchanged(
+        self, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+
+        import hal0.config.loader as loader
+
+        def boom(*a: Any, **kw: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(loader, "save_upstreams_config", boom)
+        with pytest.raises(OSError):
+            r.apply_persistent_patch("openrouter", {"enabled": False})
+        assert r.get("openrouter").enabled is True  # type: ignore[union-attr]
+
+    def test_set_advertise_still_works_as_wrapper(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        path = _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+        merged = r.set_advertise("openrouter", False)
+        assert merged.advertise_models is False
+        assert tomllib.loads(path.read_text())["upstream"][0]["advertise_models"] is False
+
+
+class TestCreateRemovePersistent:
+    def _entry(self, name: str = "minimax", **kw: Any) -> Any:
+        from hal0.config.schema import UpstreamEntry
+
+        defaults: dict[str, Any] = dict(
+            name=name,
+            kind="remote",
+            url="https://api.minimax.io/v1",
+            auth_value_env="MINIMAX_API_KEY",
+        )
+        defaults.update(kw)
+        return UpstreamEntry(**defaults)
+
+    def test_create_appends_row_and_registers(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        path = _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+        upstream = r.create_persistent(self._entry())
+        assert upstream.kind == "remote"
+        assert r.get("minimax") is not None
+        rows = tomllib.loads(path.read_text())["upstream"]
+        assert [row["name"] for row in rows] == ["openrouter", "minimax"]
+
+    def test_create_works_without_existing_toml(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        from hal0.config import paths
+
+        r = UpstreamRegistry()
+        r.create_persistent(self._entry())
+        rows = tomllib.loads((paths.etc() / "upstreams.toml").read_text())["upstream"]
+        assert rows[0]["name"] == "minimax"
+
+    def test_create_duplicate_in_registry_raises(self, tmp_hal0_home: str) -> None:
+        r = _registry_with_openrouter()
+        with pytest.raises(UpstreamAlreadyExists):
+            r.create_persistent(self._entry(name="openrouter"))
+
+    def test_create_duplicate_in_toml_only_raises(self, tmp_hal0_home: str) -> None:
+        _write_upstreams_toml(_OPENROUTER_TOML)
+        r = UpstreamRegistry()  # registry empty, TOML row present
+        with pytest.raises(UpstreamAlreadyExists):
+            r.create_persistent(self._entry(name="openrouter"))
+
+    def test_create_rejects_reserved_and_slot_kind(self, tmp_hal0_home: str) -> None:
+        from hal0.upstreams.registry import UpstreamProtected
+
+        r = UpstreamRegistry()
+        with pytest.raises(UpstreamProtected):
+            r.create_persistent(self._entry(name="hal0"))
+        with pytest.raises(UpstreamProtected):
+            r.create_persistent(self._entry(kind="slot", slot_name="primary"))
+
+    def test_remove_deletes_row_and_registry_entry(self, tmp_hal0_home: str) -> None:
+        import tomllib
+
+        path = _write_upstreams_toml(_OPENROUTER_TOML)
+        r = _registry_with_openrouter()
+        assert r.remove_persistent("openrouter") is True
+        assert r.get("openrouter") is None
+        assert tomllib.loads(path.read_text()).get("upstream", []) == []
+
+    def test_remove_auto_registered_returns_false(self, tmp_hal0_home: str) -> None:
+        r = _registry_with_openrouter()  # in-memory only
+        assert r.remove_persistent("openrouter") is False
+        assert r.get("openrouter") is None
+
+    def test_remove_protects_composite_and_slots(self, tmp_hal0_home: str) -> None:
+        from hal0.upstreams.registry import UpstreamProtected
+
+        r = UpstreamRegistry()
+        r.add(Upstream(name="hal0", kind="slot", url="http://127.0.0.1:8080/v1"))
+        r.add(_slot("primary"))
+        with pytest.raises(UpstreamProtected):
+            r.remove_persistent("hal0")
+        with pytest.raises(UpstreamProtected):
+            r.remove_persistent("primary")
+
+    def test_remove_unknown_raises(self, tmp_hal0_home: str) -> None:
+        with pytest.raises(UpstreamNotFound):
+            UpstreamRegistry().remove_persistent("ghost")
+
+
+def test_upstream_from_entry_maps_all_fields(tmp_hal0_home: str) -> None:
+    from hal0.config.schema import UpstreamEntry, UpstreamModelFilters
+    from hal0.upstreams.registry import upstream_from_entry
+
+    entry = UpstreamEntry(
+        name="corp",
+        kind="remote",
+        url="https://llm.corp.internal/v1",
+        auth_style="header",
+        auth_header="X-Api-Key",
+        auth_value_env="CORP_KEY",
+        timeout_seconds=42.0,
+        warmup_strategy="lazy",  # alias — normalizes to ondemand
+        enabled=False,
+        model_filters=UpstreamModelFilters(exclude=["*-draft"]),
+    )
+    u = upstream_from_entry(entry)
+    assert u.auth_header == "X-Api-Key"
+    assert u.enabled is False
+    assert u.warmup_strategy == "ondemand"
+    assert u.model_filters is not None and u.model_filters.exclude == ("*-draft",)

--- a/tests/upstreams/test_registry.py
+++ b/tests/upstreams/test_registry.py
@@ -525,7 +525,10 @@ class TestApplyPersistentPatch:
 
         merged = r.apply_persistent_patch(
             "openrouter",
-            {"enabled": False, "model_filters": {"include": ["anthropic/*"], "exclude": ["*:free"]}},
+            {
+                "enabled": False,
+                "model_filters": {"include": ["anthropic/*"], "exclude": ["*:free"]},
+            },
         )
         assert merged.enabled is False
         assert merged.model_filters is not None
@@ -563,9 +566,11 @@ class TestApplyPersistentPatch:
             r.apply_persistent_patch("ghost", {"enabled": False})
 
     def test_invalid_patch_rejected_and_memory_untouched(self, tmp_hal0_home: str) -> None:
+        from pydantic import ValidationError
+
         _write_upstreams_toml(_OPENROUTER_TOML)
         r = _registry_with_openrouter()
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             r.apply_persistent_patch("openrouter", {"auth_style": "basic"})
         assert r.get("openrouter").auth_style == "bearer"  # type: ignore[union-attr]
 

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -276,6 +276,18 @@ export const ENDPOINTS = {
   // Secrets
   secrets: '/api/secrets',
   secret: (name: string) => `/api/secrets/${encodeURIComponent(name)}`,
+
+  // ── Upstream providers (external LLM endpoints) ──────────────────
+  // GET list / POST create; PATCH settings / DELETE per name; POST test
+  // probes reachability. providersCatalog feeds the "Add upstream" form;
+  // providerCredentials writes ONE api-key to api.env ({key, value} —
+  // the secret never transits the upstream CRUD surface).
+  upstreams: '/api/upstreams',
+  upstream: (name: string) => `/api/upstreams/${encodeURIComponent(name)}`,
+  upstreamTest: (name: string) => `/api/upstreams/${encodeURIComponent(name)}/test`,
+  providersCatalog: '/api/providers/catalog',
+  providerCredentials: (name: string) =>
+    `/api/providers/${encodeURIComponent(name)}/credentials`,
   // Service URL discovery — the dashboard reads this to resolve the
   // reachable hostnames for sibling services (OpenWebUI, Hermes) from the
   // request host, so links work on any install (localhost / LAN IP /

--- a/ui/src/api/hooks/useUpstreams.ts
+++ b/ui/src/api/hooks/useUpstreams.ts
@@ -1,0 +1,156 @@
+// hal0 v3 dashboard — upstream-provider hooks (upstream controls).
+//
+// Backs Connections → Upstream providers (and the Slots → Endpoints tab).
+// List + create + patch + delete + test, plus the static provider catalog
+// for the "Add upstream" form and the credentials write. Secrets never
+// round-trip: the API returns env-var NAMES and boolean presence only.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiDelete, apiGet, apiPatch, apiPost } from '../client'
+import { ENDPOINTS } from '../endpoints'
+
+export interface UpstreamModelFilters {
+  models: string[]
+  include: string[]
+  exclude: string[]
+}
+
+export interface UpstreamEntry {
+  name: string
+  kind: 'slot' | 'remote'
+  url: string
+  auth_style: string
+  auth_header: string
+  /** Env-var NAME the key lives under — never the value. */
+  auth_value_env: string
+  auth_configured: boolean
+  /** True when the env-var actually holds a value (drives the auth badge). */
+  auth_key_present: boolean
+  timeout_seconds: number
+  slot_name: string | null
+  warmup_strategy: string
+  advertise_models: boolean
+  enabled: boolean
+  model_filters: UpstreamModelFilters | null
+  models: string[]
+  hint?: string
+}
+
+export interface CatalogEntry {
+  id: string
+  name: string
+  base_url: string
+  auth: string
+  auth_header_name: string
+  models_path: string
+  default_models: string[]
+  default_model: string
+  capabilities: string[]
+  docs_url: string
+  category: 'cloud' | 'local' | 'custom'
+  notes: string
+}
+
+// Type aliases (not interfaces) so they satisfy the api client's
+// Record<string, unknown> body parameter via implicit index signatures.
+export type UpstreamCreateBody = {
+  name: string
+  catalog_id?: string
+  url?: string
+  auth_style?: string
+  auth_header?: string
+  auth_value_env?: string
+  timeout_seconds?: number
+  advertise_models?: boolean
+  enabled?: boolean
+  model_filters?: UpstreamModelFilters
+}
+
+export type UpstreamPatchBody = {
+  advertise_models?: boolean
+  enabled?: boolean
+  /** All-empty object clears the filters; omit to leave unchanged. */
+  model_filters?: UpstreamModelFilters
+  url?: string
+  auth_style?: string
+  auth_header?: string
+  auth_value_env?: string
+  timeout_seconds?: number
+  warmup_strategy?: string
+}
+
+export interface UpstreamTestResult {
+  ok: boolean
+  status?: number | string
+  latency_ms?: number
+  models_count?: number
+  error?: string
+}
+
+/** A row the operator manages here — genuine remotes only. Slot-backed
+ * upstreams (kind=slot, container remotes with slot_name, the composite
+ * `hal0` aggregate) are owned by the slot lifecycle and live on Slots. */
+export function isManagedRemote(u: UpstreamEntry): boolean {
+  return u.kind === 'remote' && !u.slot_name
+}
+
+export function useUpstreams() {
+  return useQuery({
+    queryKey: ['upstreams'],
+    queryFn: () => apiGet<UpstreamEntry[]>(ENDPOINTS.upstreams),
+  })
+}
+
+export function useProvidersCatalog() {
+  return useQuery({
+    queryKey: ['providers', 'catalog'],
+    queryFn: () => apiGet<Record<string, CatalogEntry>>(ENDPOINTS.providersCatalog),
+    staleTime: Infinity, // static, ships with the build
+  })
+}
+
+export function useUpstreamCreate() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body: UpstreamCreateBody) =>
+      apiPost<UpstreamEntry>(ENDPOINTS.upstreams, body),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['upstreams'] }),
+  })
+}
+
+export function useUpstreamUpdate() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ name, patch }: { name: string; patch: UpstreamPatchBody }) =>
+      apiPatch<UpstreamEntry>(ENDPOINTS.upstream(name), patch),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['upstreams'] }),
+  })
+}
+
+export function useUpstreamDelete() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) => apiDelete(ENDPOINTS.upstream(name)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['upstreams'] }),
+  })
+}
+
+export function useUpstreamTest() {
+  // No invalidation — a probe doesn't change config; callers keep the
+  // result in local state next to the Test button.
+  return useMutation({
+    mutationFn: (name: string) =>
+      apiPost<UpstreamTestResult>(ENDPOINTS.upstreamTest(name)),
+  })
+}
+
+export function useProviderCredentialSet() {
+  const qc = useQueryClient()
+  return useMutation({
+    // Contract: {key: <ENV_VAR_NAME>, value: <secret>} — key must match
+    // the upstream's declared auth_value_env (server-enforced binding).
+    mutationFn: ({ name, key, value }: { name: string; key: string; value: string }) =>
+      apiPost(ENDPOINTS.providerCredentials(name), { key, value }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['upstreams'] }),
+  })
+}

--- a/ui/src/dash/connections.css
+++ b/ui/src/dash/connections.css
@@ -370,3 +370,45 @@
   .ep-cols { grid-template-columns: 1fr; }
   .mcp-tools { grid-template-columns: 1fr; }
 }
+
+/* ─── Upstream providers pane ─────────────────────────────────────── */
+/* Row grid mirrors .eprow but with auth/filter columns instead of
+   device/port/tps. */
+.up-head, .uprow .up-main { grid-template-columns: 9px 110px minmax(0,1fr) 140px 150px 24px; }
+.uprow .ep-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--jbm); font-size: 11px; color: var(--fg-3); }
+.up-auth { display: flex; }
+.up-filters { font-size: 10px; color: var(--fg-4); text-align: right; }
+.up-head span:nth-child(5) { text-align: right; }
+
+.up-controls { display: flex; align-items: center; gap: 18px; padding: 4px 0 10px; flex-wrap: wrap; }
+.up-toggle { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--fg-2); cursor: pointer; }
+.up-toggle input { accent-color: var(--accent); }
+.up-toggle .meta { color: var(--fg-4); font-size: 11px; }
+
+.up-test { padding: 6px 10px; margin-bottom: 10px; border-radius: var(--rad-sm); font-size: 11px; border: 1px solid var(--line); }
+.up-test.ok { color: var(--ok); border-color: var(--ok-line); background: var(--ok-soft); }
+.up-test.err { color: var(--err); border-color: var(--err-line); background: rgba(255,90,90,0.07); }
+
+.up-filter-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; padding: 10px 0; }
+.up-filter-grid label, .up-add-grid label { display: flex; flex-direction: column; gap: 4px; }
+.up-filter-grid .k, .up-add-grid .k { font-family: var(--jbm); font-size: 8.5px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--fg-5); }
+.up-input { height: 28px; padding: 4px 8px; font-size: 11.5px; background: var(--bg); color: var(--fg); border: 1px solid var(--line-strong); border-radius: var(--rad-sm); }
+.up-input:focus { outline: none; border-color: var(--accent); }
+.up-filter-actions { display: flex; align-items: center; gap: 8px; padding-top: 6px; }
+.up-filter-actions .meta { font-size: 10.5px; color: var(--fg-5); }
+
+.up-foot { display: flex; align-items: center; gap: 10px; padding-top: 12px; margin-top: 12px; border-top: 1px solid var(--line-soft); flex-wrap: wrap; }
+.up-key { display: inline-flex; align-items: center; gap: 8px; flex: 1 1 auto; min-width: 0; }
+.up-key .k { font-size: 10px; color: var(--fg-4); white-space: nowrap; }
+.up-key .up-input { flex: 1 1 220px; min-width: 140px; }
+
+.up-add { padding: 12px 14px; margin-bottom: 12px; border: 1px solid var(--line); border-radius: var(--rad); background: var(--bg-1); }
+.up-add-grid { display: grid; grid-template-columns: 160px 140px minmax(0,1fr) minmax(0,1fr); gap: 10px; }
+.up-add-notes { padding-top: 8px; font-size: 11px; color: var(--fg-4); }
+
+@media (max-width: 900px) {
+  .up-head, .uprow .up-main { grid-template-columns: 9px 90px minmax(0,1fr) 24px; }
+  .up-head span:nth-child(4), .up-head span:nth-child(5),
+  .uprow .up-main .up-auth, .uprow .up-main .up-filters { display: none; }
+  .up-filter-grid, .up-add-grid { grid-template-columns: 1fr; }
+}

--- a/ui/src/dash/connections.jsx
+++ b/ui/src/dash/connections.jsx
@@ -23,6 +23,16 @@ import { useSlots } from '@/api/hooks/useSlots'
 import { slotIndicatorFromPhase } from './slot-status.js'
 import { useMcpServers } from '@/api/hooks/useMcp'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
+import {
+  isManagedRemote,
+  useProviderCredentialSet,
+  useProvidersCatalog,
+  useUpstreamCreate,
+  useUpstreamDelete,
+  useUpstreams,
+  useUpstreamTest,
+  useUpstreamUpdate,
+} from '@/api/hooks/useUpstreams'
 
 const { useState: useCS } = React
 
@@ -983,6 +993,469 @@ function McpServersPanel() {
   )
 }
 
+// ─── Upstream providers (external LLM endpoints) ──────────────────────
+// The reactive editor over /api/upstreams: add a cloud provider from the
+// catalog, store its key (via the credentials route — the CRUD surface
+// never carries secrets), test the connection, curate which models it
+// advertises (include/exclude globs, exclude wins), toggle routing on/off,
+// delete. Slot-backed upstreams and the composite `hal0` aggregate are
+// hidden here — they're owned by the slot lifecycle (Slots page).
+
+// fnmatch-lite for the client-side filter preview: * and ? only, mirroring
+// the server's fnmatchcase semantics (case-sensitive, no regex).
+function globMatch(id, pat) {
+  const rx = new RegExp(
+    '^' + pat.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.') + '$',
+  )
+  return rx.test(id)
+}
+
+function filterPreview(ids, { models, include, exclude }) {
+  return ids.filter((id) => {
+    if (exclude.some((p) => globMatch(id, p))) return false
+    if (!models.length && !include.length) return true
+    return models.includes(id) || include.some((p) => globMatch(id, p))
+  })
+}
+
+function csvList(text) {
+  return String(text || '')
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function upFilterSummary(f) {
+  if (!f) return 'all models'
+  const parts = []
+  if (f.models?.length) parts.push(`${f.models.length} pinned`)
+  if (f.include?.length) parts.push(`include ${f.include.length}`)
+  if (f.exclude?.length) parts.push(`exclude ${f.exclude.length}`)
+  return parts.length ? parts.join(' · ') : 'all models'
+}
+
+function UpstreamAuthChip({ up }) {
+  if (!up.auth_value_env) return <span className="chip outlined">no auth</span>
+  if (up.auth_key_present) return <span className="chip ok">key set</span>
+  return <span className="chip warn">{up.auth_value_env} unset</span>
+}
+
+function UpstreamRow({ up, defaultOpen }) {
+  const [open, setOpen] = useCS(!!defaultOpen)
+  const [testResult, setTestResult] = useCS(null)
+  const [keyValue, setKeyValue] = useCS('')
+  const [confirmDelete, setConfirmDelete] = useCS(false)
+  const [modelsText, setModelsText] = useCS((up.model_filters?.models || []).join(', '))
+  const [includeText, setIncludeText] = useCS((up.model_filters?.include || []).join(', '))
+  const [excludeText, setExcludeText] = useCS((up.model_filters?.exclude || []).join(', '))
+
+  const update = useUpstreamUpdate()
+  const remove = useUpstreamDelete()
+  const test = useUpstreamTest()
+  const setCredential = useProviderCredentialSet()
+
+  const draft = {
+    models: csvList(modelsText),
+    include: csvList(includeText),
+    exclude: csvList(excludeText),
+  }
+  const known = up.models || []
+  const previewCount = known.length ? filterPreview(known, draft).length : null
+
+  function runTest() {
+    setTestResult(null)
+    test.mutate(up.name, {
+      onSuccess: setTestResult,
+      onError: (e) => setTestResult({ ok: false, error: String(e?.message || e) }),
+    })
+  }
+
+  function applyFilters() {
+    update.mutate({ name: up.name, patch: { model_filters: draft } })
+  }
+
+  function clearFilters() {
+    setModelsText('')
+    setIncludeText('')
+    setExcludeText('')
+    update.mutate({
+      name: up.name,
+      patch: { model_filters: { models: [], include: [], exclude: [] } },
+    })
+  }
+
+  function saveKey() {
+    if (!keyValue || !up.auth_value_env) return
+    setCredential.mutate(
+      { name: up.name, key: up.auth_value_env, value: keyValue },
+      { onSuccess: () => setKeyValue('') }, // write-only: never keep the secret around
+    )
+  }
+
+  return (
+    <div className={'eprow uprow' + (open ? ' expanded' : '') + (up.enabled ? '' : ' dim')}>
+      <div className="eprow-main up-main" onClick={() => setOpen((o) => !o)}>
+        <span className={'ep-dot ' + (up.enabled ? 'serving' : 'offline')} />
+        <span className="ep-name">{up.name}</span>
+        <span className="ep-model">{up.url}</span>
+        <span className="up-auth">
+          <UpstreamAuthChip up={up} />
+        </span>
+        <span className="up-filters mono">{upFilterSummary(up.model_filters)}</span>
+        <span className="ep-caret">
+          <CIcon name="chev" size={14} />
+        </span>
+      </div>
+
+      <div className="ep-drawer">
+        <div className="ep-drawer-in">
+          <div className="up-controls">
+            <label className="up-toggle">
+              <input
+                type="checkbox"
+                checked={up.enabled}
+                onChange={(e) =>
+                  update.mutate({ name: up.name, patch: { enabled: e.target.checked } })
+                }
+              />
+              <span>
+                enabled <span className="meta">— off removes it from routing entirely</span>
+              </span>
+            </label>
+            <label className="up-toggle">
+              <input
+                type="checkbox"
+                checked={up.advertise_models}
+                onChange={(e) =>
+                  update.mutate({ name: up.name, patch: { advertise_models: e.target.checked } })
+                }
+              />
+              <span>
+                advertise models <span className="meta">— list in /v1/models</span>
+              </span>
+            </label>
+            <span className="grow" />
+            <button className="btn sm" onClick={runTest} disabled={test.isPending}>
+              {test.isPending ? 'Testing…' : 'Test connection'}
+            </button>
+          </div>
+
+          {testResult && (
+            <div className={'up-test mono ' + (testResult.ok ? 'ok' : 'err')}>
+              {testResult.ok
+                ? `✓ reachable · ${Math.round(testResult.latency_ms ?? 0)} ms · ${testResult.models_count ?? '?'} models`
+                : `✗ ${testResult.error || testResult.status || 'unreachable'}`}
+            </div>
+          )}
+
+          <div className="ep-block">
+            <div className="ep-block-h">
+              <span className="ic">
+                <CIcon name="gauge" size={12} />
+              </span>{' '}
+              model filters<span className="grow" />
+              <span className="chip outlined">
+                {previewCount == null
+                  ? 'no catalog cached'
+                  : `${previewCount}/${known.length} advertised`}
+              </span>
+            </div>
+            <div className="up-filter-grid">
+              <label>
+                <span className="k">pinned ids</span>
+                <input
+                  className="up-input mono"
+                  placeholder="anthropic/claude-sonnet-4, …"
+                  value={modelsText}
+                  onChange={(e) => setModelsText(e.target.value)}
+                />
+              </label>
+              <label>
+                <span className="k">include globs</span>
+                <input
+                  className="up-input mono"
+                  placeholder="anthropic/*, google/*"
+                  value={includeText}
+                  onChange={(e) => setIncludeText(e.target.value)}
+                />
+              </label>
+              <label>
+                <span className="k">exclude globs (win)</span>
+                <input
+                  className="up-input mono"
+                  placeholder="*:free, nvidia/*"
+                  value={excludeText}
+                  onChange={(e) => setExcludeText(e.target.value)}
+                />
+              </label>
+            </div>
+            <div className="up-filter-actions">
+              <span className="meta">
+                curates /v1/models only — filtered-out models stay dispatchable by name
+              </span>
+              <span className="grow" />
+              <button className="btn sm" onClick={clearFilters} disabled={update.isPending}>
+                Clear
+              </button>
+              <button className="btn sm primary" onClick={applyFilters} disabled={update.isPending}>
+                Apply filters
+              </button>
+            </div>
+          </div>
+
+          <div className="up-foot">
+            {up.auth_value_env ? (
+              <span className="up-key">
+                <span className="k mono">{up.auth_value_env}</span>
+                <input
+                  className="up-input mono"
+                  type="password"
+                  placeholder={up.auth_key_present ? '•••••• (set — paste to replace)' : 'paste API key'}
+                  value={keyValue}
+                  onChange={(e) => setKeyValue(e.target.value)}
+                  autoComplete="off"
+                />
+                <button
+                  className="btn sm"
+                  onClick={saveKey}
+                  disabled={!keyValue || setCredential.isPending}
+                >
+                  {setCredential.isPending ? 'Saving…' : 'Save key'}
+                </button>
+              </span>
+            ) : (
+              <span className="meta">no credential declared (auth: {up.auth_style})</span>
+            )}
+            <span className="grow" />
+            {confirmDelete ? (
+              <>
+                <span className="meta">delete {up.name}? key in api.env is kept</span>
+                <button className="btn sm" onClick={() => setConfirmDelete(false)}>
+                  Cancel
+                </button>
+                <button
+                  className="btn sm danger"
+                  onClick={() => remove.mutate(up.name)}
+                  disabled={remove.isPending}
+                >
+                  Confirm delete
+                </button>
+              </>
+            ) : (
+              <button className="btn sm danger" onClick={() => setConfirmDelete(true)}>
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AddUpstreamForm({ onClose }) {
+  const catalogQuery = useProvidersCatalog()
+  const create = useUpstreamCreate()
+  const setCredential = useProviderCredentialSet()
+
+  const [catalogId, setCatalogId] = useCS('')
+  const [name, setName] = useCS('')
+  const [url, setUrl] = useCS('')
+  const [apiKey, setApiKey] = useCS('')
+  const [error, setError] = useCS(null)
+
+  const catalog = catalogQuery.data || {}
+  const entry = catalogId ? catalog[catalogId] : null
+
+  function pickCatalog(id) {
+    setCatalogId(id)
+    const e = catalog[id]
+    if (e) {
+      if (!name) setName(id.replace(/_/g, '-'))
+      setUrl(e.base_url || '')
+    }
+  }
+
+  function submit() {
+    setError(null)
+    const body = { name: name.trim() }
+    if (catalogId) body.catalog_id = catalogId
+    if (url.trim()) body.url = url.trim()
+    create.mutate(body, {
+      onSuccess: (created) => {
+        const env = created?.auth_value_env
+        if (apiKey && env) {
+          setCredential.mutate(
+            { name: created.name, key: env, value: apiKey },
+            { onSettled: () => onClose() },
+          )
+        } else {
+          onClose()
+        }
+      },
+      onError: (e) => setError(String(e?.message || e)),
+    })
+  }
+
+  return (
+    <div className="up-add">
+      <div className="up-add-grid">
+        <label>
+          <span className="k">provider</span>
+          <select
+            className="up-input"
+            value={catalogId}
+            onChange={(e) => pickCatalog(e.target.value)}
+          >
+            <option value="">custom…</option>
+            {Object.values(catalog)
+              .filter((c) => c.id !== 'hal0')
+              .map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+          </select>
+        </label>
+        <label>
+          <span className="k">name</span>
+          <input
+            className="up-input mono"
+            placeholder="openrouter"
+            value={name}
+            onChange={(e) => setName(e.target.value.toLowerCase())}
+          />
+        </label>
+        <label>
+          <span className="k">base url</span>
+          <input
+            className="up-input mono"
+            placeholder="https://…/v1"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+        </label>
+        <label>
+          <span className="k">api key {entry?.auth === 'none' ? '(not needed)' : '(optional)'}</span>
+          <input
+            className="up-input mono"
+            type="password"
+            placeholder="stored via api.env, never echoed"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            autoComplete="off"
+          />
+        </label>
+      </div>
+      {entry?.notes && <div className="meta up-add-notes">{entry.notes}</div>}
+      {error && <div className="up-test mono err">✗ {error}</div>}
+      <div className="up-filter-actions">
+        <span className="grow" />
+        <button className="btn sm" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          className="btn sm primary"
+          onClick={submit}
+          disabled={!name.trim() || (!url.trim() && !catalogId) || create.isPending}
+        >
+          {create.isPending ? 'Adding…' : 'Add upstream'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function UpstreamProvidersPanel() {
+  const upstreamsQuery = useUpstreams()
+  const [adding, setAdding] = useCS(false)
+
+  const remotes = (upstreamsQuery.data ?? []).filter(isManagedRemote)
+  const enabledCount = remotes.filter((u) => u.enabled).length
+  const keyed = remotes.filter((u) => u.auth_key_present).length
+
+  return (
+    <EnginePane
+      glyph="connections"
+      eyebrow={
+        <>
+          <b>upstreams</b>
+          <span className="dim">·</span>
+          <span className="meta">external providers</span>
+          <span className="dim">·</span>
+          <span className="mono" style={{ color: 'var(--fg-3)' }}>
+            {remotes.length} configured
+          </span>
+          <span className="grow" />
+          <span className="meta">upstreams.toml · reactive</span>
+        </>
+      }
+      title="Upstream providers"
+      sub="cloud + remote endpoints · /api/upstreams"
+      pill={{
+        tone: enabledCount ? 'live' : 'off',
+        text: `${enabledCount} enabled · ${keyed} with keys`,
+      }}
+      headRight={
+        <button
+          className="btn sm primary"
+          onClick={(e) => {
+            e.stopPropagation()
+            setAdding((a) => !a)
+          }}
+        >
+          {adding ? 'Close' : '+ Add upstream'}
+        </button>
+      }
+      strip={
+        <>
+          <span className="ss-summary">
+            <b>{enabledCount}</b> enabled · {remotes.length} configured · {keyed} with keys
+          </span>
+          <span className="grow" />
+          <span className="ss-summary" style={{ fontFamily: 'var(--jbm)', color: 'var(--fg-4)' }}>
+            OpenRouter · Anthropic · OpenAI · custom
+          </span>
+        </>
+      }
+      foot={
+        <>
+          <span className="k">source</span>
+          <span className="v">/etc/hal0/upstreams.toml</span>
+          <span className="sep">·</span>
+          <span className="k">keys</span>
+          <span className="v">api.env · never echoed</span>
+          <span className="sep">·</span>
+          <span className="k">filters</span>
+          <span className="v amber">exclude wins</span>
+        </>
+      }
+    >
+      {adding && <AddUpstreamForm onClose={() => setAdding(false)} />}
+      <div className="eplist uplist">
+        <div className="ep-head up-head">
+          <span />
+          <span>name</span>
+          <span>base url</span>
+          <span>auth</span>
+          <span>advertising</span>
+          <span />
+        </div>
+        {upstreamsQuery.isPending && <div className="cn-empty mono">Loading upstreams…</div>}
+        {!upstreamsQuery.isPending && remotes.length === 0 && (
+          <div className="cn-empty mono">
+            No external providers configured. Add one from the catalog, or author
+            /etc/hal0/upstreams.toml by hand.
+          </div>
+        )}
+        {remotes.map((u, i) => (
+          <UpstreamRow key={u.name} up={u} defaultOpen={remotes.length === 1 && i === 0} />
+        ))}
+      </div>
+    </EnginePane>
+  )
+}
+
 // ─── the view (legacy #connections → redirected to #slots/endpoints) ──
 // Kept as a composed fallback so any direct render still works; the route
 // alias in main.jsx means users no longer land here.
@@ -995,10 +1468,19 @@ function ConnectionsView() {
       </div>
       <div className="conn">
         <LocalEndpointsPanel />
+        <UpstreamProvidersPanel />
         <McpServersPanel />
       </div>
     </div>
   )
 }
 
-Object.assign(window, { ConnectionsView, LocalEndpointsPanel, McpServersPanel, EnginePane, EndpointRow, McpServerRow })
+Object.assign(window, {
+  ConnectionsView,
+  LocalEndpointsPanel,
+  UpstreamProvidersPanel,
+  McpServersPanel,
+  EnginePane,
+  EndpointRow,
+  McpServerRow,
+})

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -961,6 +961,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       {tab === "endpoints" ? (
         <div className="conn">
           {window.LocalEndpointsPanel ? <window.LocalEndpointsPanel /> : null}
+          {window.UpstreamProvidersPanel ? <window.UpstreamProvidersPanel /> : null}
         </div>
       ) : tab === "profiles" ? (
         window.ProfilesView ? <window.ProfilesView /> : null

--- a/uv.lock
+++ b/uv.lock
@@ -1240,7 +1240,7 @@ wheels = [
 
 [[package]]
 name = "hal0"
-version = "0.9.6"
+version = "0.9.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "cognee" },


### PR DESCRIPTION
## Summary

Full management surface for external LLM providers (OpenRouter, Anthropic, OpenAI, Google AI Studio, Ollama, custom), implementing the 2026-07-06 upstream-model-filters spec plus the deferred reactive-write surface:

- **Reactive CRUD** — `POST/PATCH/DELETE /api/upstreams`. `upstreams.toml` stays canonical: every write funnels through lock-guarded registry mutators that rewrite the file atomically *before* touching the in-memory registry (a failed save never diverges memory from disk). Create prefills from the provider catalog via `catalog_id`. The composite `hal0` aggregate and slot-backed upstreams reject structural edits/deletion.
- **Per-upstream `model_filters`** — `models` allowlist + `include`/`exclude` fnmatch globs, exclude wins. Curates `/v1/models` and `/api/models` advertising only; dispatch stays unfiltered so hidden models remain addressable by explicit name.
- **`enabled` kill-switch** — `false` removes an upstream from dispatch routing (steps 0–3) and the model catalog while retaining config + credentials.
- **`hal0 upstream` CLI** — `list/show/create/update/delete/test/set-credentials`; `create --catalog openrouter --api-key` wires a provider end-to-end in one command (credentials chained through the hardened `/api/providers/{name}/credentials` route — secrets never transit the CRUD surface).
- **MCP admin tools** — `upstream_create/update/delete` (gated) + `upstream_get/test` (autonomous reads), wired through the full catalog invariant; brain-chat param schemas added so the agent doesn't guess arg names.
- **Dashboard** — "Upstream providers" pane on Slots → Endpoints (and the Connections fallback): add-from-catalog form, write-only key entry, test-connection with latency + model count, enable/advertise toggles, filter editor with live client-side preview, delete-with-confirm.

## Fixes

- **Schema drift**: `auth_style = "anthropic"`/`"google_query"` (long implemented by the dispatcher) now validate; `auth_header` is a real schema field so `auth_style = "header"` works; warmup vocabulary canonicalized to `none|ondemand|always` with `lazy`/`eager` as normalizing aliases — a TOML authored in the runtime vocabulary no longer fails validation and silently empties the whole upstream registry at startup.
- **`/api/models` provenance**: slot-backed advertisements (composite `hal0`, container slots) no longer stamp local slot models `origin="upstream"` — a raw GGUF id whose casing differed from the registry id surfaced in the Models page Upstream tab as "via hal0". Only genuine remotes contribute upstream rows, honoring `enabled`/`advertise_models`/`model_filters`.
- `auth_configured` semantics preserved; new `auth_key_present` reports whether the declared env-var actually holds a value (drives the UI auth badge).

## Docs

`docs/guides/connect-external-providers.mdx` rewritten for the four management surfaces (dashboard/CLI/REST/TOML) including a disable-vs-hide-vs-delete matrix; `docs/reference/cli.mdx` gains the `hal0 upstream` section; CHANGELOG entry under Unreleased.

## Testing

- New: `tests/config/test_upstream_filters.py`, `tests/api/test_v1_models_filters.py`, `tests/cli/test_upstream_commands.py` (pins every CLI request body against the `extra="forbid"` route contracts), registry persistence + dispatcher-gating + `/api/models` provenance regression tests.
- 462 targeted tests green on the rebased branch; full suite green modulo the pre-existing environmental failures (#1227-adjacent).
- Verified end-to-end on a live box: create → credential → test → filter → delete cycle with TOML round-trip; Qwopus provenance regression confirmed fixed.

## Known follow-up (not in this PR)

An upstream whose `url` points at hal0's own `/v1` makes `/v1/models` recurse into itself over HTTP (the composite guard is by-name only). Found while smoke-testing; the create/update routes should reject self-pointing URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)