### PR TITLE
fix(api): stop model pulls from blocking a graceful hal0-api restart (#1225)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -679,6 +679,121 @@ def _hydrate_upstreams(registry: UpstreamRegistry) -> None:
             )
 
 
+def _auto_resume_interrupted_pulls(app: FastAPI) -> None:
+    """Auto-resume pulls that were mid-flight when a prior process died.
+
+    A persisted pull-job snapshot in a non-terminal state (``queued`` or
+    ``running``) means the process that owned it never reached a terminal
+    state — either a pre-#1225 build that got SIGKILLed by systemd
+    mid-download, or a genuine crash. ``run_pull`` only durably persists a
+    snapshot at pull START (``queued``) and again at a TERMINAL state
+    (``completed``/``failed``/``cancelled``) — there is no mid-flight
+    "running" flush — so ``queued`` left on disk is the normal footprint
+    of an interrupted download, not just a job that never started.
+
+    The download's own resume sidecar (hal0.registry.pull's Range-request
+    support) means picking the pull back up is just calling ``run_pull``
+    again with the same ``(model_id, hf_repo, hf_filename)``; this does
+    that automatically instead of leaving it to the operator to notice and
+    re-POST.
+
+    Scope: only plain HF pulls whose registry row still carries
+    ``hf_repo`` + ``hf_filename``, and whose bytes aren't already sitting
+    on disk (a terminal persist can itself fail-soft, leaving a stale
+    non-terminal snapshot for a pull that actually completed — nothing to
+    resume there). FLM/NPU tag pulls and ad-hoc (hand-registered, no HF
+    coords) entries are left alone — there is no safe way to resume those
+    here, and the reconciliation in
+    ``routes.models._reconcile_persisted_pull_job`` already surfaces them
+    as ``failed`` (or ``completed``, if the bytes actually landed) on the
+    next status poll.
+    """
+    from pathlib import Path
+
+    from hal0.registry.curated import get_curated
+    from hal0.registry.pull import list_persisted_jobs, make_job, persist_pull_job
+
+    registry = app.state.model_registry
+    jobs: dict[str, Any] = app.state.model_pull_jobs
+    event_bus = getattr(app.state, "events", None)
+
+    for snapshot in list_persisted_jobs():
+        if snapshot.get("state") not in ("queued", "running"):
+            continue
+        model_id = snapshot.get("model_id")
+        if not isinstance(model_id, str) or not model_id or model_id in jobs:
+            continue
+        try:
+            entry = registry.get(model_id)
+        except Exception:
+            continue
+        hf_repo = (getattr(entry, "hf_repo", "") or "").strip()
+        hf_file = (getattr(entry, "hf_filename", "") or "").strip()
+        if not hf_repo or not hf_file:
+            continue
+        existing_path = (getattr(entry, "path", "") or "").strip()
+        if existing_path and Path(existing_path).exists():
+            continue  # bytes already landed — the terminal persist just didn't
+
+        caps = list(getattr(entry, "capabilities", None) or [])
+        capability = caps[0] if caps else None
+        curated = get_curated(model_id)
+        comfyui_subdir = (getattr(curated, "comfyui_subdir", "") or "").strip() or None
+
+        job = make_job(model_id)
+        jobs[model_id] = job
+        persist_pull_job(job)
+
+        from hal0.api.routes.models import _run_pull_with_events, _schedule_pull_task
+
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+        _schedule_pull_task(
+            app.state,
+            model_id,
+            _run_pull_with_events(
+                job,
+                hf_repo=hf_repo,
+                hf_file=hf_file,
+                registry=registry,
+                hf_token=hf_token,
+                event_bus=event_bus,
+                capability=capability,
+                comfyui_subdir=comfyui_subdir,
+            ),
+        )
+        log.info("model.pull_auto_resumed", model_id=model_id, hf_repo=hf_repo, hf_file=hf_file)
+
+
+_PULL_SHUTDOWN_TIMEOUT_S = 10.0
+
+
+async def _shutdown_pull_jobs(app: FastAPI, timeout_s: float = _PULL_SHUTDOWN_TIMEOUT_S) -> None:
+    """Cancel every in-flight model pull so shutdown doesn't wait on them.
+
+    Issue #1225: pulls run as detached ``asyncio.Task``\\ s (see
+    ``routes.models._schedule_pull_task``) precisely so a live download
+    doesn't keep an HTTP connection open for the whole transfer — but a
+    detached task still has to be told to stop. Cancelling raises
+    ``asyncio.CancelledError`` inside the download's chunk loop, which
+    (per ``_download_one``'s contract) preserves the partial file and
+    writes a resume sidecar, so the next pull attempt — a manual re-POST,
+    or the startup auto-resume above — continues from the last complete
+    chunk rather than restarting from zero. Bounded so shutdown itself
+    stays fast even if a task is slow to unwind.
+    """
+    app.state.shutting_down.set()
+    tasks: dict[str, asyncio.Task[None]] = getattr(app.state, "model_pull_tasks", {}) or {}
+    live = [t for t in tasks.values() if not t.done()]
+    if not live:
+        return
+    log.info("hal0.api.shutdown_cancelling_pulls", count=len(live))
+    for t in live:
+        t.cancel()
+    _done, pending = await asyncio.wait(live, timeout=timeout_s)
+    if pending:
+        log.warning("hal0.api.shutdown_pull_cancel_timed_out", count=len(pending))
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     log.info("hal0.api.startup", version=__version__)
@@ -867,6 +982,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # and status routes snapshot ``as_dict()`` rather than hold the
     # dataclass across event-loop ticks.
     app.state.model_pull_jobs = {}
+    # Task handles for the SAME keys (issue #1225). A pull is launched as a
+    # detached ``asyncio.Task`` (routes.models._schedule_pull_task), not a
+    # Starlette BackgroundTask, specifically so its HTTP request can return
+    # immediately instead of keeping the connection open for the whole
+    # download — this dict is what lets the shutdown path below (
+    # _shutdown_pull_jobs) find and cancel any still-running pull.
+    app.state.model_pull_tasks = {}
+    # Flipped at the START of shutdown (see the lifespan finally block) so
+    # long-lived generators (the pull SSE stream) can notice a restart is in
+    # progress and close promptly instead of blocking uvicorn's connection
+    # drain indefinitely.
+    app.state.shutting_down = asyncio.Event()
     # Reap orphaned *.part staging files left by a SIGKILL/OOM mid-pull
     # (MR-9). Age-gated so an in-flight pull from another worker is never
     # touched; housekeeping must never block startup.
@@ -887,6 +1014,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             log.info("model.pull_jobs_swept", count=reaped)
     except Exception as exc:
         log.warning("model.pull_jobs_sweep_failed", error=str(exc))
+    # Auto-resume any pull left mid-flight by a prior hal0-api process that
+    # died without a clean shutdown (issue #1225) — e.g. an older build (pre
+    # this fix) that got SIGKILLed by systemd, or a hard crash. Best-effort:
+    # only resumes plain HF pulls whose registry row still carries hf_repo +
+    # hf_filename; anything else is left for the operator to re-POST.
+    try:
+        _auto_resume_interrupted_pulls(app)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("model.pull_auto_resume_failed", error=str(exc))
     # Container image-pull job registry — keyed by slot name, value is a
     # dict with keys: state (pulling|completed|failed), layer, total_layers,
     # error, and a threading.Event for SSE fan-out.
@@ -1119,6 +1255,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             stack.push_async_callback(_stop_gpu_arbiter_idle_loop)
             yield
     finally:
+        # First — issue #1225: cancel any in-flight model pull before doing
+        # anything else, so a live multi-GB download doesn't keep this
+        # shutdown (and thus `systemctl restart hal0-api`) waiting.
+        with contextlib.suppress(Exception):
+            await _shutdown_pull_jobs(app)
         if omni_router_client is not None:
             with contextlib.suppress(Exception):
                 await omni_router_client.aclose()

--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -14,11 +14,12 @@ import json
 import logging
 import os
 import time
+from collections.abc import Coroutine
 from pathlib import Path
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Request, Response
+from fastapi import APIRouter, Request, Response
 from fastapi.responses import StreamingResponse
 
 from hal0.api._audit import record_action
@@ -1146,7 +1147,6 @@ async def check_model_updates(request: Request, refresh: bool = False) -> dict[s
 async def update_model_from_hf(
     model_id: str,
     request: Request,
-    background: BackgroundTasks,
 ) -> dict[str, object]:
     """Re-pull a model's HF file over its installed bytes (in place).
 
@@ -1204,15 +1204,18 @@ async def update_model_from_hf(
         )
 
     hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    background.add_task(
-        _run_pull_with_events,
-        job,
-        hf_repo=hf_repo,
-        hf_file=hf_file,
-        registry=registry,
-        hf_token=hf_token,
-        event_bus=event_bus,
-        dest_override=dest,
+    _schedule_pull_task(
+        request.app.state,
+        model_id,
+        _run_pull_with_events(
+            job,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            registry=registry,
+            hf_token=hf_token,
+            event_bus=event_bus,
+            dest_override=dest,
+        ),
     )
     return {
         "id": job.job_id,
@@ -1680,6 +1683,37 @@ def _resolve_pull_source_with_body(
     return repo, file, mmproj, False
 
 
+def _schedule_pull_task(
+    app_state: Any,
+    model_id: str,
+    coro: Coroutine[Any, Any, None],
+) -> asyncio.Task[None]:
+    """Launch a pull body as a detached ``asyncio.Task``, tracked for shutdown.
+
+    Deliberately NOT a Starlette ``BackgroundTasks`` entry (issue #1225):
+    those run to completion inside the same ASGI call that sent the
+    response, which keeps the HTTP connection "in flight" for the whole
+    download — uvicorn won't dispatch the ASGI ``lifespan.shutdown`` event
+    until every connection (including that one) closes, so a live multi-GB
+    pull blocks `systemctl restart hal0-api` until systemd's own stop
+    timeout SIGKILLs the process mid-write. Scheduling a detached task lets
+    the request return immediately (closing its connection) while the
+    download keeps running independently; ``app_state.model_pull_tasks``
+    gives the lifespan shutdown path (hal0.api._shutdown_pull_jobs) a
+    handle to find and cancel it with a bounded wait.
+    """
+    task = asyncio.create_task(coro)
+    tasks: dict[str, asyncio.Task[None]] = app_state.model_pull_tasks
+    tasks[model_id] = task
+
+    def _untrack(t: asyncio.Task[None], _model_id: str = model_id) -> None:
+        if tasks.get(_model_id) is t:
+            tasks.pop(_model_id, None)
+
+    task.add_done_callback(_untrack)
+    return task
+
+
 async def _run_pull_with_events(
     job: PullJob,
     *,
@@ -1755,6 +1789,7 @@ async def _run_pull_with_events(
                     )
 
     progress_task = asyncio.create_task(_emit_progress())
+    task_cancelled = False
     try:
         await run_pull(
             job,
@@ -1767,12 +1802,25 @@ async def _run_pull_with_events(
             mmproj_file=mmproj_file,
             dest_override=dest_override,
         )
+    except asyncio.CancelledError:
+        # The TASK was cancelled (issue #1225: hal0-api's lifespan shutdown
+        # does this to every in-flight pull). run_pull already recorded
+        # job.state = "cancelled" before re-raising, but the terminal
+        # footer event below sits AFTER this try/finally, which a
+        # propagating CancelledError would otherwise skip — the operator
+        # would never see a "pull cancelled" toast. Emit it from here
+        # instead, then let the cancellation continue propagating.
+        task_cancelled = True
+        raise
     finally:
         progress_task.cancel()
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await progress_task
         # Persist terminal state so a restart-surviving status poll resolves (#626).
         _persist_pull_job(job)
+        if task_cancelled:
+            with contextlib.suppress(Exception):
+                await _emit_terminal_pull_event(event_bus, job)
 
     await _emit_terminal_pull_event(event_bus, job)
 
@@ -1845,7 +1893,6 @@ def _eta_s(job: PullJob, speed_bps: float) -> float | None:
 async def pull_model(
     model_id: str,
     request: Request,
-    background: BackgroundTasks,
 ) -> dict[str, object]:
     """Start a background HuggingFace pull and return a job handle.
 
@@ -1891,7 +1938,7 @@ async def pull_model(
     from hal0.providers.flm import is_flm_tag
 
     if is_flm_tag(model_id):
-        return await _start_flm_pull(model_id, request, background, jobs)
+        return await _start_flm_pull(model_id, request, jobs)
 
     # Body is optional — an empty / non-JSON request is the legacy
     # "pull by id" path used by the wizard's Pull-against-curated row.
@@ -1936,17 +1983,20 @@ async def pull_model(
     # P3: route the download into the capability-grouped store layout when the
     # capability is resolvable (body → registry → curated); None → flat fallback.
     capability, comfyui_subdir = _resolve_pull_capability(request, model_id, body)
-    background.add_task(
-        _run_pull_with_events,
-        job,
-        hf_repo=hf_repo,
-        hf_file=hf_file,
-        registry=registry,
-        hf_token=hf_token,
-        event_bus=event_bus,
-        capability=capability,
-        comfyui_subdir=comfyui_subdir,
-        mmproj_file=mmproj_file,
+    _schedule_pull_task(
+        request.app.state,
+        model_id,
+        _run_pull_with_events(
+            job,
+            hf_repo=hf_repo,
+            hf_file=hf_file,
+            registry=registry,
+            hf_token=hf_token,
+            event_bus=event_bus,
+            capability=capability,
+            comfyui_subdir=comfyui_subdir,
+            mmproj_file=mmproj_file,
+        ),
     )
     out: dict[str, object] = {
         "id": job.job_id,
@@ -1963,7 +2013,6 @@ async def pull_model(
 async def _start_flm_pull(
     model_id: str,
     request: Request,
-    background: BackgroundTasks,
     jobs: dict[str, PullJob],
 ) -> dict[str, object]:
     """Spawn a background ``flm pull`` job and return the job handle.
@@ -2002,7 +2051,7 @@ async def _start_flm_pull(
             if event_bus is not None:
                 await _emit_terminal_pull_event(event_bus, job)
 
-    background.add_task(_run_flm_with_events)
+    _schedule_pull_task(request.app.state, model_id, _run_flm_with_events())
     return {
         "id": job.job_id,
         "model_id": model_id,
@@ -2068,15 +2117,31 @@ async def pull_stream(model_id: str, request: Request) -> StreamingResponse:
             details={"model_id": model_id},
         )
 
+    shutting_down: asyncio.Event | None = getattr(request.app.state, "shutting_down", None)
+
     async def _gen() -> Any:
         # Emit an immediate snapshot so SSE clients don't sit at zero
         # while waiting for the first progress signal.
         yield f"data: {json.dumps(job.as_dict())}\n\n"
         while job.state in ("queued", "running"):
+            # hal0-api shutdown (issue #1225): don't leave this generator
+            # dangling open — it's a live HTTP connection that would
+            # otherwise block uvicorn's graceful-shutdown connection drain
+            # for as long as the job stays non-terminal. In the common case
+            # the job itself flips to "cancelled" promptly once the
+            # lifespan shutdown path cancels its pull task (see
+            # hal0.api._shutdown_pull_jobs), which already unblocks the
+            # loop condition above; this flag additionally bounds the wait
+            # for any stream whose job doesn't (e.g. one already terminal
+            # on disk but still being polled by a stale in-memory handle).
+            if shutting_down is not None and shutting_down.is_set():
+                break
             event = job.progress_event
             try:
                 await asyncio.wait_for(event.wait(), timeout=5.0)
             except TimeoutError:
+                if shutting_down is not None and shutting_down.is_set():
+                    break
                 # Keep-alive — surfaces stuck downloads without closing
                 # the stream.
                 yield f"data: {json.dumps(job.as_dict())}\n\n"

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -215,7 +215,22 @@ def serve(
 ) -> None:
     """Start the hal0 API server (used by hal0-api.service)."""
     console.print(f"Starting hal0 API on [bold]{host}:{port}[/bold]")
-    uvicorn.run("hal0.api:app", host=host, port=port, reload=reload)
+    # Bounded graceful shutdown (issue #1225): uvicorn's default
+    # timeout_graceful_shutdown is None (wait forever for open connections —
+    # e.g. an in-flight model pull request or a live SSE progress stream —
+    # to close on their own) before it ever sends the ASGI lifespan.shutdown
+    # event. Since hal0-api's lifespan is where in-flight pulls get cancelled
+    # (see hal0.api.lifespan), that cancellation would never run in time and
+    # `systemctl restart hal0-api` would hang until systemd's own
+    # TimeoutStopSec (default ~90s) SIGKILLs the process mid-download. This
+    # bound guarantees lifespan.shutdown fires promptly either way.
+    uvicorn.run(
+        "hal0.api:app",
+        host=host,
+        port=port,
+        reload=reload,
+        timeout_graceful_shutdown=20,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -683,6 +683,15 @@ async def _download_one(
                              the sidecar, raise :class:`PullChecksumMismatch`
       * permanent Hal0Error→ discard partial + sidecar, re-raise
       * transient httpx err→ preserve ``.part`` + write resume sidecar, re-raise
+      * task cancelled     → preserve ``.part`` + write resume sidecar, re-raise
+                             (issue #1225: hal0-api's lifespan shutdown
+                             cancels in-flight pull TASKS so a
+                             ``systemctl restart`` doesn't hang — that must
+                             behave like a transient interruption, not a
+                             user-requested "stop and clean up", so the next
+                             pull attempt (manual or startup auto-resume)
+                             continues from the last complete chunk instead
+                             of restarting from zero)
       * anything else      → discard (unknown state must not poison a resume)
     """
     url = hf_download_url(hf_repo, rec.hf_filename)
@@ -895,9 +904,16 @@ async def _download_one(
     except PullChecksumMismatch:
         raise  # .part intentionally preserved for diagnosis (sidecar dropped)
     except asyncio.CancelledError:
-        # Task itself was cancelled by the event loop — treat as an explicit
-        # cancel: discard the partial + sidecar (MR-7).
-        _discard_partial(part, sidecar)
+        # The TASK was cancelled (issue #1225: hal0-api's lifespan shutdown
+        # does this to every in-flight pull so a `systemctl restart` doesn't
+        # have to wait out a multi-GB download). Unlike the cooperative
+        # ``job.cancel_requested`` flag above — an explicit user "stop and
+        # clean up" — this is an interruption outside the download's
+        # control, so it gets the same treatment as a transient transport
+        # error: preserve the ``.part`` and write a resume sidecar so the
+        # next pull attempt (manual re-POST or startup auto-resume) picks
+        # up from the last complete chunk rather than restarting from zero.
+        _write_resume_sidecar(part, sidecar, url=url, etag=captured_etag, total=rec.bytes_total)
         raise
     except Hal0Error:
         # Permanent failures (4xx PullError, insufficient disk) are not

--- a/tests/api/test_pull_shutdown.py
+++ b/tests/api/test_pull_shutdown.py
@@ -1,0 +1,257 @@
+"""Issue #1225: `systemctl restart hal0-api` must not hang on a live model pull.
+
+Covers the three pieces of the fix:
+
+  * an in-flight pull is tracked as a detached ``asyncio.Task``
+    (``app.state.model_pull_tasks``), not a Starlette BackgroundTask, so its
+    HTTP request returns immediately instead of keeping the connection open
+    for the whole download;
+  * lifespan shutdown cancels those tasks and waits for them with a bound,
+    so shutdown itself stays fast;
+  * the pull SSE stream notices a shutdown in progress and closes promptly
+    instead of blocking on it.
+
+``run_pull`` itself is patched with fakes — the streaming/resume mechanics
+are covered separately in ``tests/registry/test_pull.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+from hal0.api.routes import models as model_routes
+from hal0.registry.pull import PullJob
+
+pytestmark = pytest.mark.usefixtures("tmp_hal0_home")
+
+
+@pytest.fixture
+def app_isolated(tmp_hal0_home: str) -> Iterator[FastAPI]:
+    yield create_app()
+
+
+@pytest.fixture
+def hanging_run_pull(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch run_pull with a fake that hangs until its task is cancelled.
+
+    Mirrors the real contract (hal0.registry.pull.run_pull): on
+    asyncio.CancelledError it records ``state = "cancelled"``, signals, and
+    re-raises — this is exactly the behaviour the shutdown path depends on.
+    """
+    state: dict[str, Any] = {"started": asyncio.Event()}
+
+    async def fake(job: PullJob, *, hf_repo: str, hf_file: str, **kw: Any) -> None:
+        job.state = "running"
+        job.bytes_total = 1024
+        job._signal()
+        state["started"].set()
+        try:
+            await asyncio.Event().wait()  # hangs forever unless cancelled
+        except asyncio.CancelledError:
+            job.state = "cancelled"
+            job.finished_at = time.time()
+            job._signal()
+            raise
+
+    monkeypatch.setattr(model_routes, "run_pull", fake)
+    return state
+
+
+def _wait_for(predicate: Any, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def test_pull_request_returns_before_download_finishes(
+    app_isolated: FastAPI, hanging_run_pull: dict[str, Any]
+) -> None:
+    """The POST must not block on the (never-finishing) fake download —
+    proof that the pull no longer keeps its HTTP connection open for the
+    whole transfer."""
+    with TestClient(app_isolated) as c:
+        started = time.monotonic()
+        r = c.post("/api/models/qwen3-4b/pull")
+        elapsed = time.monotonic() - started
+        assert r.status_code == 202, r.text
+        assert elapsed < 2.0, f"POST /pull took {elapsed}s against a hanging download"
+
+        _wait_for(hanging_run_pull["started"].is_set)
+        task = app_isolated.state.model_pull_tasks.get("qwen3-4b")
+        assert task is not None
+        assert not task.done(), "the detached pull task must still be running"
+
+        # Cancel via the shutdown machinery below rather than leaving a
+        # hanging task across the TestClient's own teardown.
+        task.cancel()
+
+
+def test_shutdown_cancels_inflight_pull_within_bound(
+    app_isolated: FastAPI, hanging_run_pull: dict[str, Any]
+) -> None:
+    """Shutdown must cancel a still-running pull and finish promptly — the
+    core of #1225 (previously the lifespan finally block never touched
+    in-flight pulls at all, so shutdown could hang indefinitely)."""
+    cm = TestClient(app_isolated)
+    client = cm.__enter__()
+    try:
+        r = client.post("/api/models/qwen3-4b/pull")
+        assert r.status_code == 202, r.text
+        _wait_for(hanging_run_pull["started"].is_set)
+
+        task = app_isolated.state.model_pull_tasks.get("qwen3-4b")
+        assert task is not None and not task.done()
+
+        shutdown_started = time.monotonic()
+    finally:
+        cm.__exit__(None, None, None)
+    shutdown_elapsed = time.monotonic() - shutdown_started
+
+    assert shutdown_elapsed < 5.0, f"shutdown took {shutdown_elapsed}s to cancel the pull"
+    assert task.cancelled() or task.done()
+    job = app_isolated.state.model_pull_jobs["qwen3-4b"]
+    assert job.state == "cancelled"
+    assert app_isolated.state.shutting_down.is_set()
+
+
+def test_shutdown_with_no_active_pulls_is_a_no_op(app_isolated: FastAPI) -> None:
+    """No in-flight pulls → shutdown doesn't wait on anything (regression
+    guard: the new cancellation step must be a fast no-op in the common
+    case, not add latency to every restart)."""
+    with TestClient(app_isolated):
+        pass  # nothing else to assert — a hang here would time out the test
+
+
+def test_pull_stream_closes_promptly_once_shutdown_flag_is_set(
+    app_isolated: FastAPI, hanging_run_pull: dict[str, Any]
+) -> None:
+    """A client (re)subscribing to the SSE progress stream while hal0-api is
+    shutting down must not be left hanging on the connection — the generator
+    checks ``app.state.shutting_down`` each iteration and closes rather than
+    waiting out its normal 5s keep-alive tick (or the job reaching a terminal
+    state, which depends on the pull's own task being cancelled first)."""
+    with TestClient(app_isolated) as c:
+        r = c.post("/api/models/qwen3-4b/pull")
+        assert r.status_code == 202, r.text
+        _wait_for(hanging_run_pull["started"].is_set)
+
+        # Simulate the flag flip that _shutdown_pull_jobs performs, without
+        # tearing down the whole app — isolates the generator's own
+        # responsiveness to the flag from the task-cancellation path
+        # exercised by test_shutdown_cancels_inflight_pull_within_bound.
+        app_isolated.state.shutting_down.set()
+
+        started = time.monotonic()
+        with c.stream("GET", "/api/models/qwen3-4b/pull/stream") as resp:
+            body = "".join(resp.iter_text())
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 2.0, f"SSE stream took {elapsed}s to close once shutting_down was set"
+        assert "data:" in body
+
+        task = app_isolated.state.model_pull_tasks.get("qwen3-4b")
+        if task is not None:
+            task.cancel()
+
+
+def test_startup_auto_resumes_interrupted_pull(tmp_hal0_home: str) -> None:
+    """A pull-job snapshot left non-terminal by a killed prior process (its
+    on-disk state is "queued" — run_pull only durably persists at pull START
+    and at a TERMINAL state, so a crash mid-download never gets to flush
+    "running") is automatically resumed on the next hal0-api startup rather
+    than requiring the operator to notice and re-POST.
+    """
+    from hal0.registry.model import Model
+    from hal0.registry.pull import make_job, persist_pull_job
+    from hal0.registry.store import ModelRegistry
+
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="user.Interrupted",
+            name="user.Interrupted",
+            path="/tmp/does-not-exist-yet.gguf",
+            hf_repo="org/interrupted-GGUF",
+            hf_filename="interrupted.gguf",
+        )
+    )
+    stuck_job = make_job("user.Interrupted")
+    persist_pull_job(stuck_job)  # writes state="queued" — the pre-crash snapshot
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_run_pull(job: PullJob, *, hf_repo: str, hf_file: str, **kw: Any) -> None:
+        calls.append({"hf_repo": hf_repo, "hf_file": hf_file})
+        job.state = "completed"
+        job.bytes_downloaded = job.bytes_total = 2048
+        job.finished_at = time.time()
+        job._signal()
+
+    import pytest as _pytest
+
+    mp = _pytest.MonkeyPatch()
+    mp.setattr(model_routes, "run_pull", fake_run_pull)
+    try:
+        app = create_app()
+        with TestClient(app) as c:
+            _wait_for(lambda: len(calls) == 1)
+            r = c.get("/api/models/user.Interrupted/pull/status")
+            assert r.status_code == 200, r.text
+            assert r.json()["state"] == "completed"
+    finally:
+        mp.undo()
+
+    assert calls == [{"hf_repo": "org/interrupted-GGUF", "hf_file": "interrupted.gguf"}]
+
+
+def test_startup_does_not_auto_resume_a_completed_pull(tmp_hal0_home: str) -> None:
+    """A stale non-terminal snapshot for a model whose bytes already landed
+    on disk (the terminal persist can itself fail-soft) must not trigger a
+    wasteful re-pull."""
+    from hal0.registry.model import Model
+    from hal0.registry.pull import make_job, persist_pull_job
+    from hal0.registry.store import ModelRegistry
+
+    installed = tmp_hal0_home + "/already-installed.gguf"
+    with open(installed, "wb") as f:
+        f.write(b"gguf-bytes")
+
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="user.AlreadyDone",
+            name="user.AlreadyDone",
+            path=installed,
+            hf_repo="org/already-done-GGUF",
+            hf_filename="done.gguf",
+        )
+    )
+    stuck_job = make_job("user.AlreadyDone")
+    persist_pull_job(stuck_job)
+
+    calls: list[dict[str, Any]] = []
+
+    async def fake_run_pull(job: PullJob, **kw: Any) -> None:
+        calls.append(kw)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(model_routes, "run_pull", fake_run_pull)
+    try:
+        app = create_app()
+        with TestClient(app):
+            pass
+    finally:
+        mp.undo()
+
+    assert calls == [], "a model whose bytes already exist must not be re-pulled"

--- a/tests/cli/test_serve_bind_host.py
+++ b/tests/cli/test_serve_bind_host.py
@@ -55,3 +55,17 @@ def test_serve_flag_overrides_env(
     result = runner.invoke(cli_main.app, ["serve", "--host", "192.0.2.7"])
     assert result.exit_code == 0, result.output
     assert captured_bind["host"] == "192.0.2.7"
+
+
+def test_serve_bounds_graceful_shutdown(captured_bind: dict[str, Any]) -> None:
+    """Issue #1225: uvicorn's default timeout_graceful_shutdown is None (wait
+    forever for open connections before ever dispatching ASGI lifespan.shutdown),
+    which is what let a live model pull or SSE stream hang `systemctl restart
+    hal0-api` until systemd's own stop timeout SIGKILLed the process. `serve`
+    must pass a positive bound so hal0.api.lifespan's shutdown path (which
+    cancels in-flight pulls) always gets a chance to run.
+    """
+    result = runner.invoke(cli_main.app, ["serve"])
+    assert result.exit_code == 0, result.output
+    assert isinstance(captured_bind.get("timeout_graceful_shutdown"), int)
+    assert captured_bind["timeout_graceful_shutdown"] > 0

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -7,6 +7,7 @@ redirect handling, and partial downloads / cancellation.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -545,6 +546,95 @@ async def test_run_pull_resumes_from_partial_with_range(tmp_hal0_home: str) -> N
     assert job2.sha256 == digest, "resume must produce a byte-identical hash"
     assert job2.bytes_downloaded == total
     # Staging cleaned up on success.
+    assert not part.exists()
+    assert not sidecar.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_pull_task_cancel_preserves_partial_for_resume(tmp_hal0_home: str) -> None:
+    """Issue #1225: cancelling the asyncio TASK running a pull (what hal0-api's
+    lifespan shutdown does to every in-flight pull so a `systemctl restart`
+    doesn't have to wait out a multi-GB download) must land the partial file
+    at a consistent checkpoint and write a resume sidecar — same contract as
+    a transient transport error — so the NEXT run_pull for the same model_id
+    resumes via Range instead of restarting from zero. This is deliberately
+    different from the cooperative ``job.cancel_requested`` user-cancel path
+    (test_run_pull_cancellation_removes_partial), which discards on purpose.
+    """
+    total = _CHUNK_BYTES * 3
+    body = _payload(total)
+    digest = hashlib.sha256(body).hexdigest()
+    registry = ModelRegistry()
+
+    reached_second_chunk = asyncio.Event()
+    hang_forever = asyncio.Event()
+
+    async def handler(req: httpx.Request) -> httpx.Response:
+        async def agen():  # type: ignore[no-untyped-def]
+            yield body[:_CHUNK_BYTES]
+            reached_second_chunk.set()
+            await hang_forever.wait()  # never set — task.cancel() interrupts this
+            yield body[_CHUNK_BYTES:]
+
+        return httpx.Response(200, headers={"Content-Length": str(len(body))}, content=agen())
+
+    job = make_job("cancel-resume")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    task = asyncio.create_task(
+        run_pull(
+            job,
+            hf_repo="Org/CancelResume-GGUF",
+            hf_file="cr.gguf",
+            registry=registry,
+            client=client,
+        )
+    )
+    try:
+        await asyncio.wait_for(reached_second_chunk.wait(), timeout=2.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        await client.aclose()
+
+    assert job.state == "cancelled"
+    part, sidecar = _part_paths("cancel-resume", "cr.gguf")
+    assert part.exists(), "a task-cancelled pull must PRESERVE the .part for resume"
+    assert sidecar.exists(), "a task-cancelled pull must write a resume sidecar"
+    assert part.stat().st_size == _CHUNK_BYTES
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["bytes"] == _CHUNK_BYTES
+
+    # ── Resume: fresh job, same model_id → continues via a Range request. ──
+    job2 = make_job("cancel-resume")
+    seen: dict[str, str] = {}
+
+    async def resume_handler(req: httpx.Request) -> httpx.Response:
+        seen["range"] = req.headers.get("range", "")
+        remainder = body[_CHUNK_BYTES:]
+        return httpx.Response(
+            206,
+            headers={
+                "Content-Length": str(len(remainder)),
+                "Content-Range": f"bytes {_CHUNK_BYTES}-{total - 1}/{total}",
+            },
+            content=remainder,
+        )
+
+    client2 = httpx.AsyncClient(transport=httpx.MockTransport(resume_handler))
+    try:
+        await run_pull(
+            job2,
+            hf_repo="Org/CancelResume-GGUF",
+            hf_file="cr.gguf",
+            registry=registry,
+            client=client2,
+        )
+    finally:
+        await client2.aclose()
+
+    assert seen["range"] == f"bytes={_CHUNK_BYTES}-"
+    assert job2.state == "completed", f"got {job2.state}: {job2.error}"
+    assert job2.sha256 == digest, "resume must produce a byte-identical hash"
     assert not part.exists()
     assert not sidecar.exists()
 


### PR DESCRIPTION
Model pulls no longer block a graceful hal0-api shutdown/restart — prevents the 90s SIGKILL that was killing in-flight pulls. Closes #1225.