### PR TITLE
feat(memory): replace HAL0_MEMORY_ENABLED env var with [memory].enabled + CLI toggle

### DIFF
--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -1,6 +1,6 @@
 ---
 title: Memory
-description: hal0's memory subsystem — a Hindsight-backed brain that operators and agents share. Gated by HAL0_MEMORY_ENABLED (on by default on a fresh install) and degrades cleanly to a no-op when off.
+description: hal0's memory subsystem — a Hindsight-backed brain that operators and agents share. Gated by [memory].enabled in hal0.toml (on by default) and degrades cleanly to a no-op when off.
 sidebar:
   order: 50
 ---
@@ -9,10 +9,10 @@ import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 hal0 can give your platform a persistent **memory** — a store of facts that both
 the operator surfaces and the bundled agent can write to and recall from. It's a
-deliberate, gated subsystem behind a single flag: powerful when it's on, and
-completely absent when it's off. A fresh install turns it on for you; it stays
-a conscious, revertible choice rather than something that silently accumulates
-data on an existing box.
+deliberate, gated subsystem behind a single config flag: powerful when it's on,
+and completely absent when it's off. It ships **on by default**; it stays
+a conscious, revertible choice (`hal0 memory disable`) rather than something
+that silently accumulates data you didn't ask for.
 
 ## What memory is
 
@@ -44,11 +44,11 @@ provider is selected from config, so the surfaces (REST + MCP) stay the same
 regardless of which engine backs them.
 </Aside>
 
-## Memory is gated by one flag
+## Memory is gated by one config flag
 
 This is the most important thing to know: hal0 only constructs a memory
-provider when `HAL0_MEMORY_ENABLED=1` is set in the environment. When it
-isn't:
+provider when `[memory].enabled` in `hal0.toml` is `true` — the default.
+When it's `false`:
 
 - No memory provider is built.
 - Every downstream caller degrades to a no-op or a clean error — the
@@ -57,19 +57,18 @@ isn't:
 - The dashboard hides the Memory navigation.
 
 Flipping the flag is the *entire* toggle — no code change required either way.
-The one-line installer writes `HAL0_MEMORY_ENABLED=1` into `/etc/hal0/api.env`
-and stands up the local Hindsight daemon for you, so **a fresh install has
-memory on out of the box**; the underlying default (a box with no `api.env`
-entry at all — a manual/source setup, or one that predates the flip) is off.
-An upgrade never rewrites an existing `api.env`, so a box that was installed
-before memory shipped on by default, or that had the flag removed by hand,
-stays off until you set it yourself. Either way it's a conscious, revertible
-choice, not something that quietly starts accumulating data you didn't ask
-for.
+Toggle it with `hal0 memory enable` / `hal0 memory disable` (or by hand-editing
+`hal0.toml`); either way the value is consumed once at `hal0-api` startup, so
+follow up with `systemctl restart hal0-api` to apply it. A fresh install has
+memory **on out of the box** and stands up the local Hindsight daemon for you;
+an operator who wants it off runs `hal0 memory disable && systemctl restart
+hal0-api`. It's a conscious, revertible choice, not something that quietly
+starts accumulating data you didn't ask for.
 
 <Aside type="caution">
-The flag is the whole toggle. Until `HAL0_MEMORY_ENABLED=1` is set (by the
-installer or by hand) and the API is restarted, the memory surfaces are inert.
+The flag is the whole toggle. Until `[memory].enabled=true` (the default, or
+set via `hal0 memory enable`) and the API is restarted, the memory surfaces
+are inert.
 </Aside>
 
 ## What memory powers

--- a/docs/guides/enable-memory.mdx
+++ b/docs/guides/enable-memory.mdx
@@ -1,45 +1,43 @@
 ---
 title: Enable memory
-description: hal0's memory subsystem is gated by HAL0_MEMORY_ENABLED (on by default on a fresh install). Control graph extraction with hal0 memory graph --slot, and migrate any legacy store.
+description: hal0's memory subsystem is gated by [memory].enabled in hal0.toml (on by default). Toggle it with hal0 memory enable/disable, control graph extraction with hal0 memory graph --slot, and migrate any legacy store.
 sidebar:
   order: 50
 ---
 
 import { Steps, Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components';
 
-hal0's memory subsystem is gated by a single environment flag,
-`HAL0_MEMORY_ENABLED`. When it's on, hal0 gives agents a persistent recall
-store — **Hindsight** — plus an optional knowledge-graph extraction layer.
-Flipping the flag is a single environment change — no code change, no
-reinstall.
+hal0's memory subsystem is gated by a single config flag, `[memory].enabled`
+in `hal0.toml` — **on by default**. When it's on, hal0 gives agents a
+persistent recall store — **Hindsight** — plus an optional knowledge-graph
+extraction layer. Toggle it with `hal0 memory enable` / `hal0 memory
+disable` — no code change, no reinstall.
 
 <Aside type="note">
-A fresh install turns this on for you: the one-line installer writes
-`HAL0_MEMORY_ENABLED=1` into `/etc/hal0/api.env` and stands up the local
-Hindsight daemon automatically (skip it at install time with
-`HAL0_SKIP_HINDSIGHT=1`). The steps below are for the cases the installer
-doesn't cover: a box that predates the default flip, a manual/source
-install, or re-enabling memory after you turned it off. In every case, every
-downstream caller — the admin MCP tools, the `/api/memory/*` routes, the
-agent memory provider — degrades to a no-op or `503` when memory is off, so
-flipping the flag is the whole toggle either way.
+A fresh install ships with this on and stands up the local Hindsight daemon
+automatically (skip it at install time with `HAL0_SKIP_HINDSIGHT=1`). The
+steps below are for re-enabling memory after you turned it off, or checking
+its state. In every case, every downstream caller — the admin MCP tools, the
+`/api/memory/*` routes, the agent memory provider — degrades to a no-op or
+`503` when memory is off, so flipping the flag is the whole toggle either
+way.
 </Aside>
 
 Hermes ships with its own durable-memory wiring already pointed at this
 subsystem (`memory.provider=hal0-memory`, two banks — `private:hermes` and
 `shared`) — see [What memory powers](/docs/concepts/memory#what-memory-powers)
 for how that fits together. Hermes's memory calls still need
-`HAL0_MEMORY_ENABLED=1` on the hal0-api side to actually work; without it they
-degrade the same as every other caller.
+`[memory].enabled=true` on the hal0-api side to actually work; without it
+they degrade the same as every other caller.
 
 ## Turn it on
 
 <Steps>
 
-1. **Set the flag.** Add `HAL0_MEMORY_ENABLED=1` to `/etc/hal0/api.env`:
+1. **Set the flag.**
 
    ```sh
-   echo 'HAL0_MEMORY_ENABLED=1' | sudo tee -a /etc/hal0/api.env
+   hal0 memory enable
    ```
 
 2. **Restart the API** so `create_app` constructs the memory provider:
@@ -48,14 +46,17 @@ degrade the same as every other caller.
    sudo systemctl restart hal0-api
    ```
 
-3. **Confirm it's wired.** The graph status endpoint now responds with
-   real state instead of degrading:
+3. **Confirm it's wired.**
 
    ```sh
+   hal0 memory status
    hal0 memory graph status
    ```
 
 </Steps>
+
+Turning it back off is the mirror image: `hal0 memory disable && sudo
+systemctl restart hal0-api`.
 
 When the flag is set, hal0 builds the memory provider from your config.
 The engine is **Hindsight**; if the Hindsight daemon is unreachable at

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -241,6 +241,9 @@ and per-slot TOMLs are **not** migrated (v0.1.x → v0.2 is a clean break).
 
 | Command | Purpose | Key options |
 |---|---|---|
+| `memory status` | Show whether the memory subsystem is enabled and live. | `--json` |
+| `memory enable` | Enable the memory subsystem (persists `[memory].enabled=true`). | `--json` |
+| `memory disable` | Disable the memory subsystem (persists `[memory].enabled=false`). | `--json` |
 | `memory graph status` | Show graph-extraction state (enabled, extraction slot, available slots, counters). | `--json` |
 | `memory graph enable` | Turn graph extraction on (optionally repoint the extraction slot). | `--slot <name>`, `--json` |
 | `memory graph disable` | Turn graph extraction off (cancels any in-flight build). | `--json` |

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -82,18 +82,15 @@ reverse proxy, or when a service binds loopback-only. See
 
 ## Memory & MCP
 
+The memory subsystem (Hindsight-backed, `/mcp/memory`, `/api/memory/*`) is no
+longer gated by an env var — it's controlled by `[memory].enabled` in
+`hal0.toml`, defaulting to `true`. Toggle it with `hal0 memory enable` /
+`hal0 memory disable` (see [Enable memory](/guides/enable-memory/)).
+
 | Variable                  | What it does                                                       | Default |
 |---------------------------|-------------------------------------------------------------------|---------|
-| `HAL0_MEMORY_ENABLED`     | Enable the memory subsystem (Hindsight-backed, `/mcp/memory`, `/api/memory/*`). | `0` (disabled) if unset |
 | `HAL0_MCP_ALLOWED_HOSTS`  | Comma-separated `Host` headers (or `host:port` / `host:*`) added to the MCP mounts' localhost allowlist. `*` disables the DNS-rebinding check entirely. | unset (localhost only) |
 | `HAL0_MCP_ALLOWED_ORIGINS`| Comma-separated browser origins for MCP transport requests. When unset, `http`/`https` origins are derived from `HAL0_MCP_ALLOWED_HOSTS`. | unset (derived from hosts) |
-
-<Aside type="note">
-The code-level default for `HAL0_MEMORY_ENABLED` is off, but a fresh install's
-`/etc/hal0/api.env` explicitly sets `HAL0_MEMORY_ENABLED=1` — so a new install
-ships with memory **on**. An in-place upgrade never rewrites an existing
-`api.env`, so an install that previously had it unset (or off) stays off.
-</Aside>
 
 ## Models & providers
 

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -30,9 +30,10 @@ secret. Each tool call is written to the audit log.
 
 ## Memory MCP (`/mcp/memory`)
 
-Hindsight-backed long-term memory. The memory subsystem is **opt-in** — these tools
-only function when the server is started with `HAL0_MEMORY_ENABLED=1`; otherwise
-calls degrade to a no-op / unavailable surface.
+Hindsight-backed long-term memory. The memory subsystem is gated by
+`[memory].enabled` in `hal0.toml` (**on by default**; toggle with `hal0
+memory enable`/`disable`) — these tools only function when it's on;
+otherwise calls degrade to a no-op / unavailable surface.
 
 | Tool            | Tier              | Effect                                                                 |
 |-----------------|-------------------|------------------------------------------------------------------------|

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -696,11 +696,12 @@ HAL0_UI_DIST=${HAL0_UI_DIST_VAL}
 # upgrade. Regenerate with: hal0 doctor / rerun installer.
 ${NETWORK_ENV_LINES}
 # Memory subsystem (Hindsight engine + /mcp/memory + the Agent → Memory tab)
-# is ENABLED by default as of v0.5 (brain re-enablement). Comment out to ship
-# with memory dark. Needs the shared hindsight-api daemon (installer/systemd/
-# hindsight-api.service). If the daemon is unreachable, hal0 degrades to the
-# in-memory pgvector provider (ADR-0023; the cognee engine was removed).
-HAL0_MEMORY_ENABLED=1
+# is ENABLED by default via [memory].enabled=true in hal0.toml — no env var
+# needed here (HAL0_MEMORY_ENABLED was removed; use 'hal0 memory enable' /
+# 'hal0 memory disable' to toggle it, or hand-edit hal0.toml). Needs the
+# shared hindsight-api daemon (installer/systemd/hindsight-api.service). If
+# the daemon is unreachable, hal0 degrades to the in-memory pgvector
+# provider (ADR-0023; the cognee engine was removed).
 # HF_TOKEN — HuggingFace token for gated / large model pulls. Easiest path:
 # set it in the dashboard (Settings -> Secrets -> HuggingFace token) for a live,
 # no-restart update. If HF_TOKEN/HUGGING_FACE_HUB_TOKEN was present in the
@@ -1633,7 +1634,7 @@ else
     # Stand up the local hindsight-api daemon (the shared memory brain) and seed
     # the global shared bank + the hermes private bank. The unit ships in
     # installer/systemd/ but was never installed before, so a fresh box had
-    # HAL0_MEMORY_ENABLED=1 (api.env above) pointing at a dead engine. The daemon
+    # [memory].enabled=true (hal0.toml default) pointing at a dead engine. The daemon
     # runs in its own venv at ${VAR_DIR}/memory/hindsight/.venv (pinned to the
     # version CT105 runs) with an embedded postgres + local BGE/MiniLM models;
     # its extraction/reflection LLM is hal0/utility on :8080 (used lazily — the

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1593,24 +1593,30 @@ def create_app() -> FastAPI:
     app.state.approval_queue = ApprovalQueue()
 
     memory_provider = None
-    # 0.4 release gate — memory subsystem deferred. The memory engine
-    # (Cognee), its MCP server (/mcp/memory), the REST surface
-    # (/api/memory/*), and the dashboard's Agent → Memory tab ship
-    # DISABLED by default and return in a later release once the two-tier
-    # brain redesign (Hindsight + hal0-wiki) lands. Set HAL0_MEMORY_ENABLED=1
-    # to reintroduce it with NO code change — every downstream caller
+    # Gated by [memory].enabled in hal0.toml (default True) — see
+    # 'hal0 memory enable'/'hal0 memory disable'. Every downstream caller
     # (admin MCP routing, /api/memory/* routes, the Hermes memory provider,
     # per-agent memory stats) already degrades to a no-op / 503 when
     # app.state.memory_provider is None, so flipping the flag is the whole
-    # toggle. Default off so behaviour is identical on fresh AND upgraded
-    # installs (api.env is not rewritten on upgrade).
-    if os.environ.get("HAL0_MEMORY_ENABLED", "0") != "1":
-        log.info("hal0.memory.disabled", reason="HAL0_MEMORY_ENABLED!=1")
+    # toggle. Consumed once here at create_app() — a change needs a
+    # hal0-api restart to take effect (memory.enabled is registered
+    # service-restart[hal0-api] in _settings_apply.py). create_app() runs
+    # before lifespan(), so this is a fresh load rather than the cached
+    # app.state.hal0_config lifespan() sets up later.
+    try:
+        create_app_cfg = load_hal0_config()
+    except ConfigParseError as exc:
+        log.warning("hal0.config.parse_failed", error=str(exc))
+        from hal0.config.schema import Hal0Config
+
+        create_app_cfg = Hal0Config()
+    if not create_app_cfg.memory.enabled:
+        log.info("hal0.memory.disabled", reason="memory.enabled=false")
     else:
         try:
             from hal0.memory import provider_from_config
 
-            memory_provider = provider_from_config(load_hal0_config())
+            memory_provider = provider_from_config(create_app_cfg)
         except Exception as exc:  # pragma: no cover — defensive
             log.warning("hal0.memory.init_failed", error=str(exc))
     app.state.memory_provider = memory_provider

--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -140,8 +140,10 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     # created) on the next slot load, so a restart of the slot picks it up.
     "models.flm_store": {"apply_class": "service-restart", "services": [SERVICE_SLOTS]},
     # [memory]
-    # engine is consumed once at create_app when the memory provider is
-    # constructed (api/__init__.py) — a change only lands on restart.
+    # enabled + engine are both consumed once at create_app when the memory
+    # provider is constructed (api/__init__.py) — a change only lands on
+    # restart. enabled replaced the old HAL0_MEMORY_ENABLED env var.
+    "memory.enabled": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     "memory.engine": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
     # [memory.embedding] — hindsight-era reranker knobs, all threaded into
     # Hal0Reranker at startup (memory/__init__.py), hence service-restart.

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -125,16 +125,16 @@ async def get_status(request: Request) -> dict[str, Any]:
         "hardware": None,  # populated by /api/hardware on demand
         "slots": slot_list,
         "upstreams": upstream_summary,
-        # 0.4: single source of truth for whether the memory subsystem is
-        # live (gated by HAL0_MEMORY_ENABLED at create_app). The dashboard
-        # reads this to show/hide the Agent → Memory nav so the UI and the
-        # backend can never disagree. Reflects the real wrapper, so an init
-        # failure also reads as off.
+        # Single source of truth for whether the memory subsystem is live
+        # (gated by [memory].enabled at create_app — see 'hal0 memory
+        # enable'/'disable'). The dashboard reads this to show/hide the
+        # Agent → Memory nav so the UI and the backend can never disagree.
+        # Reflects the real wrapper, so an init failure also reads as off.
         "memory_enabled": getattr(request.app.state, "memory_provider", None) is not None,
         # True  → memory is enabled but running on the volatile in-memory
         #         PgVectorProvider fallback (writes will be lost on restart).
         # False → memory is enabled and using a real durable provider.
-        # None  → memory is disabled (HAL0_MEMORY_ENABLED not set / init failed).
+        # None  → memory is disabled ([memory].enabled=false or init failed).
         "memory_degraded": _memory_degraded(request),
     }
 
@@ -264,7 +264,7 @@ async def list_features(request: Request) -> dict[str, Any]:
     Flat ``feature → bool | str`` map:
 
       - ``comfyui_switchover``: image-gen engine switchover route is present.
-      - ``memory``: a memory provider is wired (HAL0_MEMORY_ENABLED + a
+      - ``memory``: a memory provider is wired ([memory].enabled + a
         successful init).
       - ``memory_engine``: the configured engine name (``hindsight`` |
         ``cognee`` | ``mem0`` | …) — a string, not a bool.

--- a/src/hal0/cli/memory_commands.py
+++ b/src/hal0/cli/memory_commands.py
@@ -4,10 +4,20 @@ Mirrors the slot / model CLI shape: a thin HTTP client to the local
 hal0 API. The ``graph`` sub-sub-app maps 1:1 to the routes in
 :mod:`hal0.api.routes.memory`:
 
+    hal0 memory status                                  → GET  /api/status (memory_enabled)
+    hal0 memory enable                                  → PUT  /api/settings (memory.enabled=true)
+    hal0 memory disable                                 → PUT  /api/settings (memory.enabled=false)
     hal0 memory graph status                            → GET  /api/memory/graph/status
     hal0 memory graph enable [--route ...] [--provider …] [--model …]
                                                         → PUT  /api/memory/graph (enabled=true …)
     hal0 memory graph disable                           → PUT  /api/memory/graph (enabled=false)
+
+``hal0 memory enable``/``disable`` replace the old ``HAL0_MEMORY_ENABLED``
+env var (removed) — the whole subsystem (Hindsight engine, /mcp/memory,
+/api/memory/*, the dashboard's Agent → Memory tab) is gated by
+``[memory].enabled`` in hal0.toml, defaulting to True. The provider is
+built once at ``create_app()``, so flipping it needs a ``hal0-api``
+restart, same as ``hal0 memory graph`` needs one for ``memory.engine``.
 
 PLAN.md §13 ("CLI is a thin client") — every command hits 127.0.0.1:8080.
 """
@@ -39,6 +49,106 @@ console = Console()
 # alongside ``hal0 memory --help``. Same pattern as ``hal0 agent approvals``.
 graph_app = typer.Typer(help="Graph-extraction settings (ADR-0023).")
 app.add_typer(graph_app, name="graph")
+
+
+# ── ``hal0 memory status`` ─────────────────────────────────────────────────
+
+
+@app.command("status")
+def status_cmd(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit raw JSON instead of the human-readable panel.",
+    ),
+) -> None:
+    """Show whether the memory subsystem is enabled and live."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        s = api_get("/api/status")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if not isinstance(s, dict):
+        die(f"unexpected status payload: {s!r}")
+        return
+    if json_out:
+        typer.echo(
+            jsonlib.dumps(
+                {
+                    "memory_enabled": s.get("memory_enabled"),
+                    "memory_degraded": s.get("memory_degraded"),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return
+
+    enabled = bool(s.get("memory_enabled"))
+    state = "[bold green]ON[/bold green]" if enabled else "[bold]OFF[/bold]"
+    degraded = s.get("memory_degraded")
+    t = Table.grid(padding=(0, 2))
+    t.add_column("k", style="dim")
+    t.add_column("v")
+    t.add_row("State", state)
+    if enabled and degraded is True:
+        t.add_row(
+            "Provider",
+            "[yellow]in-memory fallback (volatile — Hindsight unreachable)[/yellow]",
+        )
+    elif enabled:
+        t.add_row("Provider", "[green]durable[/green]")
+    console.print(Panel(t, title="memory · status", border_style="dim"))
+
+
+# ── ``hal0 memory enable`` / ``hal0 memory disable`` ───────────────────────
+
+
+def _set_enabled(enabled: bool, json_out: bool) -> None:
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_put("/api/settings", json={"memory": {"enabled": enabled}})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(result, indent=2, sort_keys=True))
+        return
+    verb = "enabled" if enabled else "disabled"
+    color = "green" if enabled else "yellow"
+    console.print(
+        Panel(
+            f"[bold {color}]Memory subsystem {verb}[/bold {color}]\n"
+            "[dim]Takes effect on the next hal0-api restart: "
+            "systemctl restart hal0-api[/dim]",
+            border_style=color,
+        )
+    )
+
+
+@app.command("enable")
+def enable_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response instead of a panel."
+    ),
+) -> None:
+    """Enable the memory subsystem (persists [memory].enabled=true)."""
+    _set_enabled(True, json_out)
+
+
+@app.command("disable")
+def disable_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit the raw JSON response instead of a panel."
+    ),
+) -> None:
+    """Disable the memory subsystem (persists [memory].enabled=false)."""
+    _set_enabled(False, json_out)
 
 
 # ── ``hal0 memory graph status`` ──────────────────────────────────────────────

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2489,6 +2489,16 @@ class MemoryConfig(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Whether the memory subsystem (Hindsight engine, /mcp/memory, "
+            "/api/memory/*, the dashboard's Agent -> Memory tab) is built at "
+            "startup. Replaces the old HAL0_MEMORY_ENABLED env var — toggle via "
+            "'hal0 memory enable' / 'hal0 memory disable'. Consumed once at "
+            "create_app(), so a change needs a hal0-api restart."
+        ),
+    )
     graph: MemoryGraphConfig = Field(default_factory=MemoryGraphConfig)
     embedding: MemoryEmbeddingConfig = Field(default_factory=MemoryEmbeddingConfig)
     engine: str = Field(

--- a/src/hal0/memory/pgvector_provider.py
+++ b/src/hal0/memory/pgvector_provider.py
@@ -54,8 +54,7 @@ class PgVectorProvider(MemoryProvider):
             detail=(
                 "Memory is running on the in-memory PgVectorProvider fallback. "
                 "All writes are VOLATILE and will be LOST on restart. "
-                "Ensure Hindsight is reachable and HAL0_MEMORY_ENABLED=1 "
-                "to enable durable storage."
+                "Ensure Hindsight is reachable to enable durable storage."
             ),
         )
 

--- a/tests/api/test_features_health.py
+++ b/tests/api/test_features_health.py
@@ -37,8 +37,8 @@ def test_features_comfyui_switchover_always_available(
 
 
 def test_features_memory_reflects_state(client: TestClient) -> None:
-    """``memory`` mirrors app.state.memory_provider (HAL0_MEMORY_ENABLED=1
-    in the test env → a provider is wired)."""
+    """``memory`` mirrors app.state.memory_provider ([memory].enabled
+    defaults to True → a provider is wired)."""
     expected = getattr(client.app.state, "memory_provider", None) is not None
     assert client.get("/api/features").json()["memory"] is expected
 

--- a/tests/api/test_memory_degraded_status.py
+++ b/tests/api/test_memory_degraded_status.py
@@ -10,17 +10,15 @@ Verifies:
 
 from __future__ import annotations
 
-import pytest
 from fastapi.testclient import TestClient
 
 from hal0.api import create_app
+from hal0.config.loader import save_hal0_config
+from hal0.config.schema import Hal0Config, MemoryConfig
 
 
-def _build(monkeypatch: pytest.MonkeyPatch, value: str | None):
-    if value is None:
-        monkeypatch.delenv("HAL0_MEMORY_ENABLED", raising=False)
-    else:
-        monkeypatch.setenv("HAL0_MEMORY_ENABLED", value)
+def _build(enabled: bool):
+    save_hal0_config(Hal0Config(memory=MemoryConfig(enabled=enabled)))
     app = create_app()
     return app, TestClient(app)
 
@@ -37,11 +35,9 @@ def test_status_exposes_memory_degraded_field(client: TestClient) -> None:
 # ── memory disabled → None ────────────────────────────────────────────────────
 
 
-def test_status_memory_degraded_none_when_disabled(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_status_memory_degraded_none_when_disabled(tmp_hal0_home: str) -> None:
     """memory_degraded=None when no memory provider is wired."""
-    _app, client = _build(monkeypatch, None)
+    _app, client = _build(False)
     with client:
         body = client.get("/api/status").json()
     assert body["memory_enabled"] is False
@@ -51,13 +47,11 @@ def test_status_memory_degraded_none_when_disabled(
 # ── in-memory fallback → True ─────────────────────────────────────────────────
 
 
-def test_status_memory_degraded_true_for_pgvector_fallback(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_status_memory_degraded_true_for_pgvector_fallback(tmp_hal0_home: str) -> None:
     """memory_degraded=True when PgVectorProvider (in-memory fallback) is wired."""
     from hal0.memory.pgvector_provider import PgVectorProvider
 
-    app, client = _build(monkeypatch, "1")
+    app, client = _build(True)
     # Replace whatever provider was built with the explicit in-memory fallback.
     app.state.memory_provider = PgVectorProvider()
 
@@ -71,13 +65,11 @@ def test_status_memory_degraded_true_for_pgvector_fallback(
 # ── real provider → False ─────────────────────────────────────────────────────
 
 
-def test_status_memory_degraded_false_for_real_provider(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_status_memory_degraded_false_for_real_provider(tmp_hal0_home: str) -> None:
     """memory_degraded=False when a durable provider (no degraded attr) is wired."""
     from unittest.mock import MagicMock
 
-    app, client = _build(monkeypatch, "1")
+    app, client = _build(True)
     # Simulate a real provider: no 'degraded' attribute (getattr fallback → False).
     fake_real_provider = MagicMock(spec=[])  # no attributes
     app.state.memory_provider = fake_real_provider

--- a/tests/api/test_memory_gate.py
+++ b/tests/api/test_memory_gate.py
@@ -1,41 +1,36 @@
-"""0.4 memory gate — ``HAL0_MEMORY_ENABLED`` toggles the whole subsystem.
+"""Memory gate — ``[memory].enabled`` toggles the whole subsystem.
 
-The memory engine (Cognee), its MCP server (``/mcp/memory``), the REST
-surface (``/api/memory/*``), and the dashboard's Agent → Memory tab ship
-DISABLED by default and return in a later release. The gate lives in
-``create_app`` (``src/hal0/api/__init__.py``); ``/api/status`` reports the
-resulting state as ``memory_enabled`` so the SPA and backend cannot
-disagree. When off, ``app.state.memory_wrapper`` is ``None`` and the REST
-routes degrade to ``503`` rather than ``500``.
+The memory engine (Hindsight), its MCP server (``/mcp/memory``), the REST
+surface (``/api/memory/*``), and the dashboard's Agent → Memory tab are
+gated by ``[memory].enabled`` in ``hal0.toml`` (schema default ``True``).
+The gate lives in ``create_app`` (``src/hal0/api/__init__.py``);
+``/api/status`` reports the resulting state as ``memory_enabled`` so the
+SPA and backend cannot disagree. When off, ``app.state.memory_provider`` is
+``None`` and the REST routes degrade to ``503`` rather than ``500``.
 """
 
 from __future__ import annotations
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hal0.api import create_app
+from hal0.config.loader import save_hal0_config
+from hal0.config.schema import Hal0Config, MemoryConfig
 
 
-def _build(monkeypatch: pytest.MonkeyPatch, value: str | None) -> tuple[FastAPI, TestClient]:
-    """Build a fresh app + client with HAL0_MEMORY_ENABLED set (or cleared)."""
-    if value is None:
-        monkeypatch.delenv("HAL0_MEMORY_ENABLED", raising=False)
-    else:
-        monkeypatch.setenv("HAL0_MEMORY_ENABLED", value)
+def _build(enabled: bool | None) -> tuple[FastAPI, TestClient]:
+    """Build a fresh app + client with ``[memory].enabled`` set (or left at
+    its schema default of True when ``enabled`` is ``None``)."""
+    if enabled is not None:
+        save_hal0_config(Hal0Config(memory=MemoryConfig(enabled=enabled)))
     app = create_app()
     return app, TestClient(app)
 
 
-# Anything other than the literal "1" leaves memory off — including unset,
-# empty, and stray truthy-looking strings. This pins the `!= "1"` contract.
-@pytest.mark.parametrize("flag", [None, "0", "", "no", "true", "2"])
-def test_memory_disabled_unless_flag_is_one(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, flag: str | None
-) -> None:
-    app, client = _build(monkeypatch, flag)
-    # The wrapper is constructed at create_app time, before lifespan.
+def test_memory_disabled_when_config_says_so(tmp_hal0_home: str) -> None:
+    app, client = _build(False)
+    # The provider is constructed at create_app time, before lifespan.
     assert app.state.memory_provider is None
     with client:
         body = client.get("/api/status").json()
@@ -45,15 +40,21 @@ def test_memory_disabled_unless_flag_is_one(
         assert client.get("/api/memory/list").status_code == 503
 
 
-def test_status_exposes_memory_enabled_as_bool(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_memory_enabled_by_default(tmp_hal0_home: str) -> None:
+    """No hal0.toml at all → the schema default (`enabled=True`) applies."""
+    app, client = _build(None)
+    with client:
+        body = client.get("/api/status").json()
+    assert body["memory_enabled"] is (app.state.memory_provider is not None)
+
+
+def test_status_exposes_memory_enabled_as_bool(tmp_hal0_home: str) -> None:
     """/api/status always carries a boolean memory_enabled field."""
-    app, client = _build(monkeypatch, "1")
+    app, client = _build(True)
     with client:
         body = client.get("/api/status").json()
         assert "memory_enabled" in body
         assert isinstance(body["memory_enabled"], bool)
-        # The reported flag must mirror the real wrapper state so the field
-        # is trustworthy even if Cognee fails to construct in this image.
+        # The reported flag must mirror the real provider state so the field
+        # is trustworthy even if Hindsight fails to construct in this image.
         assert body["memory_enabled"] is (app.state.memory_provider is not None)

--- a/tests/api/test_memory_provider_rename.py
+++ b/tests/api/test_memory_provider_rename.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 
-def test_app_state_has_memory_provider(monkeypatch):
-    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+def test_app_state_has_memory_provider(tmp_hal0_home: str):
+    # [memory].enabled defaults to True — no config needed to exercise this.
     from hal0.api import create_app
 
     app = create_app()
@@ -15,8 +15,7 @@ def test_app_state_has_memory_provider(monkeypatch):
     assert not hasattr(app.state, "memory_wrapper")
 
 
-def test_health_memory_enabled_reads_provider(monkeypatch):
-    monkeypatch.setenv("HAL0_MEMORY_ENABLED", "1")
+def test_health_memory_enabled_reads_provider(tmp_hal0_home: str):
     from hal0.api import create_app
 
     with TestClient(create_app()) as client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Iterator
 
 import pytest
@@ -11,13 +10,12 @@ from fastapi.testclient import TestClient
 
 from hal0.api import create_app
 
-# 0.4: the memory subsystem ships disabled by default (HAL0_MEMORY_ENABLED
-# gate in create_app). The bulk of the suite exercises the memory MCP, the
-# /api/memory/* routes, and the Hermes memory provider with memory PRESENT,
-# so default the flag on for tests. `setdefault` runs once at import — before
-# any app is built — and respects an explicit override, so the dedicated gate
-# test (tests/api/test_memory_gate.py) can still set it to "0" per-test.
-os.environ.setdefault("HAL0_MEMORY_ENABLED", "1")
+# [memory].enabled defaults to True in the schema, so the bulk of the suite
+# — which exercises the memory MCP, the /api/memory/* routes, and the
+# Hermes memory provider with memory PRESENT — gets it for free via the
+# `app`/`client` fixtures' `tmp_hal0_home` isolation, no env var needed. The
+# dedicated gate test (tests/api/test_memory_gate.py) writes memory.enabled
+# = false explicitly per-test to cover the off path.
 
 pytest_plugins = ()
 

--- a/ui/src/api/hooks/useMemory.ts
+++ b/ui/src/api/hooks/useMemory.ts
@@ -153,8 +153,8 @@ export function useUpdateMemoryGraph() {
 }
 
 // 0.4 release gate. /api/status carries `memory_enabled`, gated by
-// HAL0_MEMORY_ENABLED at create_app. The dashboard reads it to show/hide
-// the Agent → Memory nav so the UI and backend can never disagree.
+// [memory].enabled in hal0.toml at create_app. The dashboard reads it to
+// show/hide the Agent → Memory nav so the UI and backend can never disagree.
 //
 // Treat the loading/unknown state as OFF (`=== true`): 0.4 ships memory
 // disabled, so the common case stays hidden with no flicker; a dev build

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -33,8 +33,8 @@ function buildStatus() {
   const d = data()
   // 0.4 gate: forced-mock dev/preview build keeps the memory surface ON so
   // the Agent → Memory tab stays reachable for layout/screenshot work. The
-  // shipped backend defaults this OFF (HAL0_MEMORY_ENABLED). Because
-  // forced-mock short-circuits `page.route`, a spec can't override
+  // shipped backend defaults this ON too ([memory].enabled in hal0.toml).
+  // Because forced-mock short-circuits `page.route`, a spec can't override
   // /api/status the usual way — it sets `window.__hal0MockMemoryEnabled =
   // false` via addInitScript to exercise the disabled path. Default ON.
   const memoryOff =

--- a/ui/src/dash/agents/agent-view.jsx
+++ b/ui/src/dash/agents/agent-view.jsx
@@ -8,7 +8,7 @@
 //                This is the default landing — always present, ungated.
 //   - Memory — the full Hindsight memory page (window.MemoryView), moved in
 //              from the standalone #memory route. Gated on the memory
-//              subsystem (HAL0_MEMORY_ENABLED) via the window bridge.
+//              subsystem ([memory].enabled) via the window bridge.
 //   - MCP    — the bundled FastMCP servers (window.McpServersPanel), moved in
 //              from the dissolved Connections page.
 //

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -470,7 +470,7 @@ function useNavItems() {
   const slotCount   = slotsQuery.data?.length  ?? 0;
   const modelCount  = modelsQuery.data?.length ?? 0;
   // 0.4 gate: the Agent route is reduced to the Memory tab, so when the
-  // memory subsystem is disabled (HAL0_MEMORY_ENABLED!=1) there is nothing
+  // memory subsystem is disabled ([memory].enabled=false) there is nothing
   // to show — drop the nav item entirely. Driven by /api/status so the UI
   // can never disagree with the backend. main.jsx applies the matching
   // route guard for deep links.

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -148,7 +148,7 @@ function App() {
   const agentChat = useBoardChatHook ? useBoardChatHook() : undefined;
 
   // 0.4 gate: the Agent route is reduced to the Memory tab, so it only
-  // renders when the memory subsystem is live (HAL0_MEMORY_ENABLED, surfaced
+  // renders when the memory subsystem is live ([memory].enabled, surfaced
   // via /api/status). Read through the window bridge to keep this strict
   // no-ES-imports prototype file within the dash/*.jsx contract — the bridge
   // is imported in main.tsx before main.jsx evaluates, so the ref is stable.

--- a/ui/tests/e2e/specs/memory-gate-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-gate-v3.spec.ts
@@ -1,10 +1,11 @@
 /**
  * memory-gate-v3 — 0.4 release gate for the memory subsystem.
  *
- * The memory engine (Cognee), its MCP server, the REST surface, and the
- * dashboard's Agent ▸ Memory tab ship DISABLED by default and return in a
- * later release. The backend gates them behind HAL0_MEMORY_ENABLED and
- * reports the resulting state via /api/status `memory_enabled`.
+ * The memory engine (Hindsight), its MCP server, the REST surface, and the
+ * dashboard's Agent ▸ Memory tab ship ENABLED by default. The backend gates
+ * them behind [memory].enabled in hal0.toml and reports the resulting state
+ * via /api/status `memory_enabled`. This spec pins the (still-supported) OFF
+ * state.
  *
  * v0.5 nav: Memory is no longer a top-level page — it is a tab inside the
  * Agent page, alongside MCP. The Agent nav item itself ALWAYS renders (the
@@ -24,7 +25,7 @@ import { test, expect, json } from '../fixtures/apiMock'
 
 const FIVE_S = 5_500
 
-test.describe('memory gate OFF (HAL0_MEMORY_ENABLED unset)', () => {
+test.describe('memory gate OFF ([memory].enabled=false)', () => {
   test.beforeEach(async ({ page }) => {
     // The γ-suite runs under forced-mock (VITE_MOCK_HAL0), which
     // short-circuits page.route for allowlisted URLs like /api/status. The


### PR DESCRIPTION
## Summary
- Memory subsystem gating moves from the `HAL0_MEMORY_ENABLED` env var (written into `/etc/hal0/api.env` by the installer) to `[memory].enabled` in `hal0.toml`, defaulting to `true`.
- Adds `hal0 memory enable` / `hal0 memory disable` / `hal0 memory status` CLI commands (thin `PUT`/`GET /api/settings`, `/api/status` clients), mirroring the existing `hal0 memory graph` pattern. Toggling requires a `hal0-api` restart (registered as `service-restart[hal0-api]` in `_settings_apply.py`, same as `memory.engine`), and the CLI prints a reminder.
- Installer no longer writes the env var — the schema default (`true`) covers the "on by default" behavior.
- Docs (`docs/concepts/memory.mdx`, `docs/guides/enable-memory.mdx`, `docs/reference/env-vars.mdx`, `docs/reference/mcp-tools.mdx`) and stale UI/test comments updated to match.
- Tests converted from env-var `monkeypatch.setenv("HAL0_MEMORY_ENABLED", ...)` to `save_hal0_config(Hal0Config(memory=MemoryConfig(enabled=...)))`.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on all touched Python files
- [x] Targeted pytest slice (`tests/api/`, `tests/config/`, `tests/cli/` filtered on memory/settings/config) — 703 passed; the only 2 failures reproduce identically on unmodified `main` (pre-existing environment issues, unrelated to this change)
- [x] Live end-to-end smoke test: booted `hal0-api` against a temp `HAL0_HOME`, drove `hal0 memory status/disable/enable` against it over HTTP — config persists to `hal0.toml`, CLI shows the restart hint, and the live provider correctly stays unchanged until restart (matches documented `service-restart` semantics)
- [ ] Manual verification on a real box (installer run + `hal0 memory disable/enable` + restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)