### PR TITLE
fix(ui): mock GET /api/upstreams + /api/providers/catalog for γ-suite

### DIFF
--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -1007,6 +1007,23 @@ function buildBankReflect() {
   }
 }
 
+// #1228 upstream model controls — UpstreamProvidersPanel (Slots ▸ Endpoints)
+// calls useUpstreams()/useProvidersCatalog() unconditionally on mount. Never
+// baked into HAL0_DATA, so under forced-mock the GET fell through to the
+// dev-server proxy (no backend behind it), returning a non-array body and
+// crashing `(upstreamsQuery.data ?? []).filter` — took the whole Endpoints
+// tab down via the view error boundary. Empty defaults match the real
+// fresh-install state (no upstreams.toml entries) and keep the row count at
+// zero so LocalEndpointsPanel's `.eplist .eprow` count assertions (which
+// share the `.eprow` class with UpstreamRow) aren't inflated.
+function buildUpstreams() {
+  return data().upstreams ?? []
+}
+
+function buildProvidersCatalog() {
+  return data().providersCatalog ?? {}
+}
+
 // ADR-0023 graph-extraction gate status (served by routes/memory.py, not the
 // admin proxy). Mocked so the Agent pointer's "Graph extraction" panel renders
 // a clean OFF state in forced-mock mode instead of a 500.
@@ -1055,6 +1072,8 @@ export const MOCK_ALLOWLIST: ReadonlyArray<AllowRow> = Object.freeze([
   { re: /^\/api\/profiles$/, build: buildProfiles, networkFirst: true },
   { re: /^\/api\/stacks$/, build: buildStacksList, networkFirst: true },
   { re: /^\/api\/chat-templates$/, build: buildChatTemplates, networkFirst: true },
+  { re: /^\/api\/upstreams$/, build: buildUpstreams },
+  { re: /^\/api\/providers\/catalog$/, build: buildProvidersCatalog },
   // ── Memory (Hindsight) — engine + bank-scoped surface ────────────
   // Forced-mock + 404-fallback story for the Memory graph overhaul. The
   // bank id is captured as group 1. ORDER MATTERS: the more-specific

--- a/ui/tests/e2e/specs/connections-v3.spec.ts
+++ b/ui/tests/e2e/specs/connections-v3.spec.ts
@@ -111,12 +111,22 @@ test.describe('Local endpoints (Slots ▸ Endpoints, #slots/endpoints)', () => {
     await expect(page.locator('.view .vh h1')).toHaveText('Slots')
     await expect(page.locator('.cpane.live')).toBeVisible()
     await expect(page.locator('.cpane-title', { hasText: 'Local endpoints' })).toBeVisible()
+    // Regression (#1228 introduced UpstreamProvidersPanel on this same tab,
+    // reading GET /api/upstreams via useUpstreams() — unmocked in mock.ts
+    // meant the fetch fell through to the (absent) backend and threw on
+    // render, taking the whole Endpoints tab down via the view error
+    // boundary, not just its own pane). Assert it renders its legitimate
+    // empty state instead of crashing.
+    await expect(page.locator('.cpane-title', { hasText: 'Upstream providers' })).toBeVisible()
+    await expect(page.getByText('No external providers configured.')).toBeVisible()
   })
 
   test('local endpoints list one row per slot', async ({ page }) => {
     // The default mock state carries 9 slots (one row per useSlots() entry,
     // including the disabled `legacy` slot; the synthetic hal0 endpoint is
-    // filtered out).
+    // filtered out). UpstreamRow shares the `.eprow` class with EndpointRow,
+    // so this count also pins that the (empty-by-default) upstreams mock
+    // contributes zero rows.
     await expect(page.locator('.eplist .eprow')).toHaveCount(9)
     const primary = page.locator('.eprow').filter({ hasText: 'primary' }).first()
     await expect(primary.locator('.ep-dot.serving')).toBeVisible()


### PR DESCRIPTION
## Summary
- `Playwright (γ)` / `γ-suite (chromium)` has been red on `main` since PR #1228 (upstream model controls). It added `UpstreamProvidersPanel` to the Slots ▸ Endpoints tab, which calls `useUpstreams()` (`GET /api/upstreams`) unconditionally on mount — but never added a forced-mock fixture for it in `ui/src/api/mock.ts`.
- Under `VITE_MOCK_HAL0=1` (how the e2e harness runs), the unmocked GET fell through to the dev-server proxy with no real backend behind it, returned a non-array body, and `(upstreamsQuery.data ?? []).filter is not a function` threw during render — crashing the *entire* Endpoints tab via the view error boundary, not just the Upstream providers pane. That's why `connections-v3.spec.ts` saw `.eplist .eprow` count **0** (not 8-vs-9): the whole tab, including the unrelated `LocalEndpointsPanel`, never rendered.
- A prior handoff bisected the break to PR #1230 ("agent + brain slot seeds") by CI-run timeline, but that PR touches **zero** `ui/` files. Direct reproduction (Playwright trace + `error-context.md` showing the exact TypeError) traces it to #1228 instead, which landed seconds earlier in the same merge batch.

## Fix
- `buildUpstreams()` / `buildProvidersCatalog()` mock builders in `ui/src/api/mock.ts`, registered in `MOCK_ALLOWLIST`, returning empty defaults — matches a real fresh install's state (no `upstreams.toml` entries configured yet).
- Strengthened `connections-v3.spec.ts` to assert the Upstream providers pane renders its empty state directly, instead of relying on the row-count assertion as an incidental proxy for "didn't crash."

## Test plan
- [x] Reproduced locally without the fix — confirmed via Playwright trace/error-context that the crash is `(upstreamsQuery.data ?? []).filter is not a function`, not a slot-count drift
- [x] Confirmed the new assertions fail without `mock.ts` fix, pass with it (`git stash` sanity check)
- [x] Full local γ-suite: **399 passed / 11 skipped / 0 failed** (up from 395 passed / 4 failed on `main`)
- [x] `tsc --noEmit` clean
- [ ] Watch `γ-suite (chromium)` go green in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)