### PR TITLE
test(e2e): fix red γ suite — stub /api/upstreams so ConnectionsView stops blanking

### DIFF
--- a/ui/tests/e2e/fixtures/apiMock.ts
+++ b/ui/tests/e2e/fixtures/apiMock.ts
@@ -92,6 +92,13 @@ export async function installDefaultMocks(page: Page, state: MockState) {
   await page.route('**/api/slots', (route) => json(route, { slots: state.slots }))
   await page.route('**/api/slots/metrics', (route) => json(route, {}))
   await page.route('**/api/backends', (route) => json(route, { backends: state.backends }))
+  // GET /api/upstreams returns a bare UpstreamEntry[] (providers.py). Without
+  // this stub the `/api/` catch-all above answers `{}`, and Connections' pane
+  // does `(upstreamsQuery.data ?? []).filter(…)` — `{}` is truthy so the
+  // `?? []` misses and `{}.filter` throws, blanking the whole ConnectionsView
+  // (the #slots/endpoints "Local endpoints" pane then renders 0 rows). An empty
+  // list means no managed remotes, so the local-endpoint row count is unaffected.
+  await page.route('**/api/upstreams', (route) => json(route, []))
   await page.route('**/api/profiles', (route) => json(route, MOCK_DATA.profiles ?? []))
   await page.route('**/api/agent/approvals', (route) =>
     json(route, { approvals: state.approvals }),


### PR DESCRIPTION
## Problem

The `Playwright (γ)` CI suite has been **red on `main`** since #1228 (upstream model controls) — failing on every subsequent push, including docs-only commits and unrelated PRs (e.g. #1239). It blocks a clean signal for everyone.

Failure scope: **4 failed / 395 passed**, all four in `ui/tests/e2e/specs/connections-v3.spec.ts`' *Local endpoints* block. The pane renders **0 rows** (`.eplist .eprow` count 0 vs 9), and `.cpane-title 'Local endpoints'` / the Slots `h1` never appear — i.e. the whole `ConnectionsView` blanks.

## Root cause

#1228's `ConnectionsView` (`ui/src/dash/connections.jsx`) added an upstreams query and does:

```js
const remotes = (upstreamsQuery.data ?? []).filter(isManagedRemote)
```

The e2e `apiMock` fixture has a broad `/api/` catch-all that answers `{}`, and #1228 never added an `/api/upstreams` stub. `{}` is **truthy**, so `?? []` doesn't apply → `{}.filter` **throws during render** → the entire ConnectionsView unmounts/blanks → every `#slots/endpoints` assertion fails. (The sibling providers-catalog query is safe — it uses `catalogQuery.data || {}` + `Object.values(...)`; only the upstreams path is fragile against `{}`.)

## Fix

Stub `**/api/upstreams` → bare `[]` in the apiMock fixture (the real `GET /api/upstreams` in `providers.py` returns `UpstreamEntry[]`), registered after the catch-all so it wins (Playwright matches routes in reverse-registration order). Empty list = no managed remotes, so the local-endpoint row count (9) is unchanged — the pre-#1228 assertions hold as-is.

One-line test-fixture change; no product code touched.

## Verification

Local (chromium), `connections-v3.spec.ts`:
- **without** the stub: 4 failed / 3 passed (reproduces CI exactly — lines 108/116/126/138)
- **with** the stub: **7 passed**

Full γ suite result added below once the CI run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
