### PR TITLE
fix(hermes): require a 3.11-3.13 venv interpreter + floor hermes-agent at 0.16.0

### DIFF
--- a/installer/agents/hermes/requirements.txt
+++ b/installer/agents/hermes/requirements.txt
@@ -11,13 +11,17 @@
 # OWN the whole $HERMES_HOME/config.yaml, so a hermes minor bump could rewrite
 # the schema underneath us. The fix is that hermes owns + migrates its own
 # config.yaml (`hermes config migrate`) and hal0 applies only its specific keys
-# on top — so hermes can move freely. We keep a FLOOR (the oldest release whose
-# config CLI + `custom` provider we rely on) and a MAJOR CAP (1.0 may break the
-# CLI contract; lift the cap deliberately after validating). Operators who want
-# a specific build use `hal0 agent upgrade hermes --to=<version>`.
+# on top — so hermes can move freely. We keep a FLOOR (the oldest release with
+# a working wheel: 0.15.2 imports hermes_cli.dashboard_auth but its wheel
+# omits the subpackage — on Python 3.14, where every 0.16+ wheel is filtered
+# out by its `requires-python <3.14` cap, pip silently resolved that broken
+# build and the gateway crash-looped on ModuleNotFoundError, #1247) and a
+# MAJOR CAP (1.0 may break the CLI contract; lift the cap deliberately after
+# validating). Operators who want a specific build use
+# `hal0 agent upgrade hermes --to=<version>`.
 #
 # The `web` extra pulls fastapi + uvicorn[standard], which the hal0 agent
 # unit needs: it runs `hermes serve` in web/dashboard mode (HERMES_WEB_DIST
 # + HERMES_DASHBOARD_TUI in the unit drop-in). Without it the unit
 # crash-loops on `No module named 'fastapi'`.
-hermes-agent[web]>=0.14.0,<1.0
+hermes-agent[web]>=0.16.0,<1.0

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -214,6 +214,15 @@ def _stub(name: str) -> Callable[[PhaseContext], PhaseResult]:
 # requirements.txt and the wrapper script. The constants are exposed
 # at module scope so tests can monkey-patch them onto a tmp path.
 PYTHON_MIN = (3, 11)
+# Exclusive cap for the hermes venv interpreter, mirroring hermes-agent's
+# wheel metadata: every release since 0.16.0 pins `requires-python
+# >=3.11,<3.14`. On a >=3.14 interpreter pip filters those wheels out and
+# falls back to 0.15.2 — whose wheel is broken (imports
+# hermes_cli.dashboard_auth, ships without the subpackage) — so 3.14 must be
+# rejected, not merely deprioritized (#1248). Single source of truth for the
+# resolver, the preflight message, and the stale-venv rebuild; relax it here
+# when upstream ships 3.14 support (#1249).
+PYTHON_MAX_EXCLUSIVE = (3, 14)
 MIN_FREE_GIB = 4
 DAEMON_HEALTH_URL = "http://127.0.0.1:8080/api/status"
 WRAPPER_INSTALL_PATH = Path("/usr/local/bin/hal0-hermes")
@@ -474,9 +483,10 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
 
     Documented blockers (plan §4):
 
-    * Python ≥ 3.11 available — bootstrap shells out to a venv with
-      explicit Python; we verify the running interpreter qualifies so
-      we can re-use ``sys.executable`` instead of hunting PATH.
+    * A hermes-compatible Python (3.11-3.13) resolvable — the venv is
+      built with an explicit interpreter, and hermes-agent wheels cap
+      ``requires-python <3.14``, so \"≥ 3.11\" alone is not enough
+      (Ubuntu 26.04 ships 3.14 only, #1248).
     * ``hal0`` daemon reachable at ``/api/status`` — agents that can't
       reach hal0 are useless. Catch it now instead of during config_write.
     * venv tree + ``$HERMES_HOME`` write-probed — we create both in later
@@ -491,11 +501,13 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
 
     py_version = sys.version_info[:3]
     details["python_version"] = ".".join(str(p) for p in py_version)
-    if py_version < PYTHON_MIN:
-        failures.append(
-            f"python {'.'.join(str(p) for p in PYTHON_MIN)}+ required, "
-            f"have {details['python_version']} — run `apt install python3.11`",
-        )
+    # What matters is the VENV interpreter, not the running one — resolve it
+    # the same way the install phase will, so a 3.14-only host fails here
+    # with a real explanation instead of three phases later inside pip.
+    venv_python = _resolve_supported_python()
+    details["venv_python"] = venv_python
+    if venv_python is None:
+        failures.append(_python_range_error())
 
     rc = ctx.io.http_get(DAEMON_HEALTH_URL)
     details["daemon_http_status"] = rc
@@ -580,18 +592,41 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
 # ── Phase B: install ────────────────────────────────────────────────────────
 
 
-def _resolve_python311(prober: Callable[[str], str | None] = shutil.which) -> str | None:
-    """Find a python3.11 interpreter; fall back to the running one when it qualifies.
+def _python_range_error() -> str:
+    """Actionable failure text for hosts with no hermes-compatible Python."""
+    lo = ".".join(str(p) for p in PYTHON_MIN)
+    hi = f"{PYTHON_MAX_EXCLUSIVE[0]}.{PYTHON_MAX_EXCLUSIVE[1] - 1}"
+    cap = ".".join(str(p) for p in PYTHON_MAX_EXCLUSIVE)
+    return (
+        f"no Python {lo}-{hi} interpreter found — hermes-agent wheels pin "
+        f"`requires-python <{cap}`, so the hermes venv needs {lo}-{hi}. "
+        f"Install one and re-run, e.g. `apt install python{hi} python{hi}-venv`; "
+        f"on distros that ship only {cap}+ (Ubuntu 26.04) use the deadsnakes "
+        f"PPA or `uv python install {hi}`"
+    )
 
-    Prefers an explicit ``python3.11`` on PATH so the venv pins minor
-    version regardless of what ``sys.executable`` is. Falls back to
-    ``sys.executable`` only when the running interpreter is itself
-    3.11+ — keeps tests usable on Python 3.12+ CI shards.
+
+def _resolve_supported_python(
+    prober: Callable[[str], str | None] = shutil.which,
+    *,
+    running: tuple[int, int] | None = None,
+) -> str | None:
+    """Find an interpreter in hermes-agent's supported range, newest first.
+
+    Probes explicit ``python3.13`` → ``python3.11`` binaries on PATH so the
+    venv pins its minor version regardless of what ``sys.executable`` is.
+    Falls back to the running interpreter only when it is itself inside the
+    range — NOT merely ``>= 3.11``: on a Python-3.14-only host (Ubuntu 26.04)
+    the old fallback built the venv on 3.14, where pip filters out every
+    hermes-agent 0.16+ wheel (``requires-python <3.14``) and resolution
+    lands on the broken 0.15.2 build (#1248).
     """
-    explicit = prober("python3.11")
-    if explicit:
-        return explicit
-    if sys.version_info[:2] >= PYTHON_MIN:
+    for minor in range(PYTHON_MAX_EXCLUSIVE[1] - 1, PYTHON_MIN[1] - 1, -1):
+        explicit = prober(f"python3.{minor}")
+        if explicit:
+            return explicit
+    current = running if running is not None else sys.version_info[:2]
+    if PYTHON_MIN <= current < PYTHON_MAX_EXCLUSIVE:
         return sys.executable
     return None
 
@@ -600,23 +635,47 @@ def _venv_python(venv: Path) -> Path:
     return venv / "bin" / "python"
 
 
+def _venv_python_minor(venv: Path) -> tuple[int, int] | None:
+    """Minor version of an existing venv, read from its ``lib/pythonX.Y`` dir.
+
+    Filesystem-only on purpose — the venv may be too broken to execute
+    (that's exactly the case we're probing for). ``None`` when the layout
+    is unrecognizable; callers should treat that as \"leave it alone\".
+    """
+    for entry in sorted(venv.glob("lib/python3.*")):
+        try:
+            major, minor = entry.name.removeprefix("python").split(".", 1)
+            return (int(major), int(minor))
+        except ValueError:
+            continue
+    return None
+
+
 def _install_venv(
     venv: Path,
     requirements: Path,
     *,
     runner: Any = subprocess,
-    python_resolver: Callable[[], str | None] = _resolve_python311,
+    python_resolver: Callable[[], str | None] = _resolve_supported_python,
 ) -> None:
     """Create the venv at ``venv`` and install ``requirements`` into it.
 
-    Two-step: ``python3.11 -m venv`` then ``pip install -r``. We don't
+    Two-step: ``python3.x -m venv`` then ``pip install -r``. We don't
     use ``uv`` here to keep the dependency footprint zero — the
     runtime venv is small and pip is universally available.
     """
     py = python_resolver()
     if py is None:
-        raise RuntimeError("no python 3.11 interpreter found on PATH")
+        raise RuntimeError(_python_range_error())
     venv.parent.mkdir(parents=True, exist_ok=True)
+    existing_minor = _venv_python_minor(venv) if venv.exists() else None
+    if existing_minor is not None and not (PYTHON_MIN <= existing_minor < PYTHON_MAX_EXCLUSIVE):
+        # A previous run built this venv on an unsupported interpreter (the
+        # pre-guard fallback happily used 3.14). pip-installing into it can
+        # never converge — every supported hermes-agent wheel is filtered out
+        # by requires-python — so rebuild on the resolved interpreter. Venv
+        # holds packages only; $HERMES_HOME state is untouched.
+        shutil.rmtree(venv)
     if not venv.exists():
         runner.run([py, "-m", "venv", str(venv)], check=True)  # nosec B603
     pip = _venv_python(venv)

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import dataclasses
 import json
 import os
+import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -558,15 +560,106 @@ def test_install_phase_runs_venv_install_when_binary_missing(
     assert install_calls == [venv]
 
 
-def test_resolve_python311_prefers_explicit_when_available() -> None:
-    out = hp._resolve_python311(prober=lambda _name: "/opt/python3.11/bin/python3.11")
-    assert out == "/opt/python3.11/bin/python3.11"
+def test_resolve_python_prefers_newest_explicit_in_range() -> None:
+    # All of 3.11-3.13 on PATH → the newest wins; 3.14 is never probed.
+    probed: list[str] = []
+
+    def _prober(name: str) -> str | None:
+        probed.append(name)
+        return f"/opt/{name}/bin/{name}"
+
+    out = hp._resolve_supported_python(prober=_prober)
+    assert out == "/opt/python3.13/bin/python3.13"
+    assert "python3.14" not in probed
 
 
-def test_resolve_python311_falls_back_to_sys_executable() -> None:
-    out = hp._resolve_python311(prober=lambda _name: None)
-    # CI runs on >= 3.11 (pyproject pin); falls back to sys.executable.
-    assert out is not None
+def test_resolve_python_walks_down_to_oldest_supported() -> None:
+    out = hp._resolve_supported_python(
+        prober=lambda name: "/usr/bin/python3.11" if name == "python3.11" else None
+    )
+    assert out == "/usr/bin/python3.11"
+
+
+def test_resolve_python_falls_back_to_sys_executable_in_range() -> None:
+    out = hp._resolve_supported_python(prober=lambda _name: None, running=(3, 12))
+    assert out == sys.executable
+
+
+def test_resolve_python_rejects_unsupported_running_interpreter() -> None:
+    # The Ubuntu 26.04 case (#1248): only a 3.14 interpreter exists. The old
+    # ">= 3.11" fallback accepted it and pip resolved the broken
+    # hermes-agent 0.15.2; now the resolver must return None so the
+    # preflight fails with the actionable range message.
+    assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 14)) is None
+    assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 10)) is None
+
+
+def test_preflight_fails_actionably_when_no_supported_python(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    state = hp.BootstrapState(
+        venv=str(var_lib / "venvs" / "hermes"), hermes_home=str(var_lib / ".hermes")
+    )
+    monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
+    monkeypatch.setattr(hp, "_resolve_supported_python", lambda *a, **k: None)
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
+    assert out.status == hp.PhaseStatus.FAIL
+    assert "3.11-3.13" in (out.reason or "")
+    assert "deadsnakes" in (out.reason or "")
+
+
+def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path) -> None:
+    # A venv already built on 3.14 (the pre-guard fallback) can never
+    # converge by pip alone — _install_venv must detect it from the
+    # lib/pythonX.Y layout and rebuild on the resolved interpreter.
+    venv = tmp_path / "venv"
+    (venv / "lib" / "python3.14" / "site-packages").mkdir(parents=True)
+    stale_marker = venv / "lib" / "python3.14" / "site-packages" / "hermes_cli"
+    stale_marker.mkdir()
+    calls: list[list[str]] = []
+
+    class _Runner:
+        @staticmethod
+        def run(argv: list[str], check: bool) -> None:
+            calls.append(argv)
+
+    hp._install_venv(
+        venv, tmp_path / "req.txt", runner=_Runner, python_resolver=lambda: "/usr/bin/python3.13"
+    )
+    assert not stale_marker.exists()  # stale 3.14 tree removed
+    assert calls[0][:3] == ["/usr/bin/python3.13", "-m", "venv"]
+
+
+def test_install_venv_keeps_supported_venv(tmp_path: Path) -> None:
+    venv = tmp_path / "venv"
+    (venv / "lib" / "python3.12" / "site-packages").mkdir(parents=True)
+    calls: list[list[str]] = []
+
+    class _Runner:
+        @staticmethod
+        def run(argv: list[str], check: bool) -> None:
+            calls.append(argv)
+
+    hp._install_venv(
+        venv, tmp_path / "req.txt", runner=_Runner, python_resolver=lambda: "/usr/bin/python3.12"
+    )
+    # No `-m venv` call — straight to pip into the existing venv.
+    assert all(argv[2] != "venv" for argv in calls if len(argv) > 2)
+
+
+def test_requirements_floor_blocks_broken_hermes_agent() -> None:
+    # Regression guard for #1247: hermes-agent 0.15.2's wheel is broken
+    # (imports hermes_cli.dashboard_auth, ships without it). The floor must
+    # stay >= 0.16.0 so no resolver — including old-Python fallbacks — can
+    # ever select it.
+    req = hp.HERMES_REQUIREMENTS
+    line = next(ln for ln in req.read_text().splitlines() if ln.startswith("hermes-agent"))
+    m = re.search(r">=\s*(\d+)\.(\d+)\.(\d+)", line)
+    assert m, f"no version floor in: {line!r}"
+    assert tuple(int(g) for g in m.groups()) >= (0, 16, 0)
 
 
 # ── #241 phase impls — env_probe / config_write ─────────────────────────────

--- a/tests/agents/test_hermes_upgrade.py
+++ b/tests/agents/test_hermes_upgrade.py
@@ -112,4 +112,4 @@ def test_requirements_floor_not_hard_pinned() -> None:
         ln.strip() for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith("#")
     ]
     # The single requirement line is the floored+capped spec, not a hard pin.
-    assert reqs == ["hermes-agent[web]>=0.14.0,<1.0"]
+    assert reqs == ["hermes-agent[web]>=0.16.0,<1.0"]


### PR DESCRIPTION
## Summary

Fresh installs on Python-3.14-only distros (Ubuntu 26.04, the Strix Halo target) crash-loop with `ModuleNotFoundError: No module named 'hermes_cli.dashboard_auth'`. Diagnosed chain:

1. Ubuntu 26.04 ships **only** Python 3.14 (no 3.11-3.13 in the archive).
2. The interpreter resolver probed literal `python3.11` then fell back to any running interpreter `>= 3.11` — so the hermes venv got built on 3.14.
3. hermes-agent wheels 0.16.0+ pin `requires-python >=3.11,<3.14`; on 3.14 pip filters them all out and silently resolves **0.15.2** (last uncapped release, still inside our `>=0.14.0,<1.0` constraint).
4. The 0.15.2 wheel is broken: its code imports `hermes_cli.dashboard_auth.*` but the wheel omits the entire subpackage (fixed upstream in 0.16.0 without a yank).

Confirmed against a real user log — traceback line numbers match the 0.15.2 wheel exactly, and the venv path shows `lib/python3.14`.

## Changes

- **Floor bump (#1247)**: `hermes-agent[web]>=0.16.0,<1.0` — the broken 0.15.2 can never be resolved again on any interpreter; on 3.14 pip now fails loudly at resolution.
- **Interpreter guard (#1248)**: resolver probes `python3.13` → `python3.12` → `python3.11` (newest first — previously a box with only 3.12/3.13 on PATH was ignored), and accepts the running interpreter only inside `[3.11, 3.14)`. Range lives in one constant (`PYTHON_MAX_EXCLUSIVE`) — relaxing it when upstream ships 3.14 support (#1249) is a one-liner.
- **Actionable preflight**: preflight now resolves the *venv* interpreter (not the running one) and fails with: range, why (`requires-python <3.14`), and remediation (`apt install python3.13` / deadsnakes / `uv python install 3.13`) — instead of detonating three phases later inside pip.
- **Broken-box convergence**: `_install_venv` detects an existing venv built on an out-of-range interpreter (from its `lib/pythonX.Y` layout, filesystem-only — the venv may be too broken to execute) and rebuilds it, so users already bitten converge via `hal0 agent bootstrap hermes --repair` with no manual `rm`.

## Testing

- 8 new unit tests: resolver preference order + 3.14/3.10 rejection, preflight failure message, stale-venv rebuild vs supported-venv reuse, requirements-floor regression guard.
- `tests/agents/ + tests/cli/`: 754 passed; the 3 failures are pre-existing environment failures on the dev box (identical set on pristine main, #1227).
- Live smoke on this host: resolver now picks `/usr/bin/python3.12` explicitly; simulated 3.14-only host returns `None` with the actionable message.

Closes #1247
Closes #1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)