### PR TITLE
feat(hermes): provision a uv-managed Python when no system 3.11-3.13 exists

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -486,7 +486,9 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
     * A hermes-compatible Python (3.11-3.13) resolvable — the venv is
       built with an explicit interpreter, and hermes-agent wheels cap
       ``requires-python <3.14``, so \"≥ 3.11\" alone is not enough
-      (Ubuntu 26.04 ships 3.14 only, #1248).
+      (Ubuntu 26.04 ships 3.14 only, #1248). A host with uv passes even
+      without one — the install phase provisions a managed interpreter
+      (#1250).
     * ``hal0`` daemon reachable at ``/api/status`` — agents that can't
       reach hal0 are useless. Catch it now instead of during config_write.
     * venv tree + ``$HERMES_HOME`` write-probed — we create both in later
@@ -507,7 +509,14 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
     venv_python = _resolve_supported_python()
     details["venv_python"] = venv_python
     if venv_python is None:
-        failures.append(_python_range_error())
+        # No system interpreter in range. uv can still provision one during
+        # the install phase (#1250) — we only check availability here, not
+        # download: preflight must stay fast and side-effect free. Fail only
+        # when that fallback is closed too.
+        uv = _uv_available()
+        details["uv_python_fallback"] = uv is not None
+        if uv is None:
+            failures.append(_python_range_error())
 
     rc = ctx.io.http_get(DAEMON_HEALTH_URL)
     details["daemon_http_status"] = rc
@@ -602,8 +611,79 @@ def _python_range_error() -> str:
         f"`requires-python <{cap}`, so the hermes venv needs {lo}-{hi}. "
         f"Install one and re-run, e.g. `apt install python{hi} python{hi}-venv`; "
         f"on distros that ship only {cap}+ (Ubuntu 26.04) use the deadsnakes "
-        f"PPA or `uv python install {hi}`"
+        f"PPA — or install uv (https://astral.sh/uv), and hal0 will provision "
+        f"Python {UV_PYTHON_FALLBACK} itself"
     )
+
+
+#: Minor version uv provisions when no system interpreter qualifies (#1250).
+#: Newest supported release — keep inside [PYTHON_MIN, PYTHON_MAX_EXCLUSIVE).
+UV_PYTHON_FALLBACK = "3.13"
+
+#: Where uv-managed interpreters land. uv's default (~/.local/share/uv) is
+#: under /root with mode 0700 when provisioning runs as root — but the hermes
+#: venv executes as the ``hal0`` user via a symlinked base interpreter, which
+#: would then be unreachable. A world-readable tree under /var/lib/hal0 keeps
+#: the interpreter usable by the service and survives root-homedir cleanups.
+UV_PYTHON_INSTALL_DIR = Path("/var/lib/hal0/python")
+
+
+def _uv_available(prober: Callable[[str], str | None] = shutil.which) -> str | None:
+    return prober("uv")
+
+
+def _provision_python_via_uv(
+    prober: Callable[[str], str | None] = shutil.which,
+    runner: Any = subprocess,
+) -> str | None:
+    """Fetch a uv-managed Python as the last resort (#1250).
+
+    ``uv python install`` is idempotent (a no-op when the version is already
+    present), and ``uv python find`` returns a stable path under
+    ``UV_PYTHON_INSTALL_DIR`` — so repeat runs and ``--repair`` deterministically
+    reuse the interpreter from the first provisioning instead of hunting anew.
+    Returns ``None`` when uv is absent or the fetch fails (offline) — callers
+    fall through to the actionable range error.
+    """
+    uv = _uv_available(prober)
+    if uv is None:
+        return None
+    env = {**os.environ, "UV_PYTHON_INSTALL_DIR": str(UV_PYTHON_INSTALL_DIR)}
+    try:
+        runner.run(  # nosec B603 — argv is a constant uv invocation
+            [uv, "python", "install", UV_PYTHON_FALLBACK],
+            check=True,
+            env=env,
+        )
+        found = runner.run(  # nosec B603
+            [uv, "python", "find", UV_PYTHON_FALLBACK],
+            check=True,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    path = (found.stdout or "").strip()
+    return path or None
+
+
+def _ensure_supported_python(
+    prober: Callable[[str], str | None] = shutil.which,
+    *,
+    runner: Any = subprocess,
+    running: tuple[int, int] | None = None,
+) -> str | None:
+    """Resolve a venv interpreter: system Python first, uv-managed as fallback.
+
+    A qualifying system interpreter always wins — the uv download only fires
+    when PATH and the running interpreter both fail the range check, so hosts
+    with a packaged 3.11-3.13 never pull a managed build (#1250).
+    """
+    found = _resolve_supported_python(prober, running=running)
+    if found is not None:
+        return found
+    return _provision_python_via_uv(prober, runner)
 
 
 def _resolve_supported_python(
@@ -656,13 +736,13 @@ def _install_venv(
     requirements: Path,
     *,
     runner: Any = subprocess,
-    python_resolver: Callable[[], str | None] = _resolve_supported_python,
+    python_resolver: Callable[[], str | None] = _ensure_supported_python,
 ) -> None:
     """Create the venv at ``venv`` and install ``requirements`` into it.
 
-    Two-step: ``python3.x -m venv`` then ``pip install -r``. We don't
-    use ``uv`` here to keep the dependency footprint zero — the
-    runtime venv is small and pip is universally available.
+    Two-step: ``python3.x -m venv`` then ``pip install -r``. The venv itself
+    is stdlib-built — uv enters only inside the resolver, as the last-resort
+    interpreter fetch on hosts with no packaged 3.11-3.13 (#1250).
     """
     py = python_resolver()
     if py is None:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -604,11 +604,99 @@ def test_preflight_fails_actionably_when_no_supported_python(
     )
     monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
     monkeypatch.setattr(hp, "_resolve_supported_python", lambda *a, **k: None)
+    monkeypatch.setattr(hp, "_uv_available", lambda *a, **k: None)
     io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
     out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
     assert "3.11-3.13" in (out.reason or "")
     assert "deadsnakes" in (out.reason or "")
+    assert "uv" in (out.reason or "")
+
+
+def test_preflight_passes_when_uv_can_provision_python(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # 3.14-only host WITH uv: preflight must pass (availability check only,
+    # no download) and flag the fallback — the install phase does the fetch.
+    var_lib = tmp_path / "var" / "lib" / "hal0"
+    var_lib.mkdir(parents=True)
+    state = hp.BootstrapState(
+        venv=str(var_lib / "venvs" / "hermes"), hermes_home=str(var_lib / ".hermes")
+    )
+    monkeypatch.setattr(hp, "MIN_FREE_GIB", 0)
+    monkeypatch.setattr(hp, "_resolve_supported_python", lambda *a, **k: None)
+    monkeypatch.setattr(hp, "_uv_available", lambda *a, **k: "/usr/local/bin/uv")
+    io = hp.PhaseIO(http_get=lambda *_a, **_kw: 200)
+    out = hp._phase_preflight(hp.context_for("preflight", state, io=io))
+    assert out.status == hp.PhaseStatus.OK
+    assert out.details["uv_python_fallback"] is True
+
+
+def test_ensure_python_prefers_system_interpreter_over_uv() -> None:
+    # A qualifying system Python must win without uv ever being invoked.
+    ran: list[list[str]] = []
+
+    class _Runner:
+        @staticmethod
+        def run(argv: list[str], **_kw: Any) -> None:
+            ran.append(argv)
+
+    out = hp._ensure_supported_python(
+        prober=lambda name: "/usr/bin/python3.12" if name == "python3.12" else None,
+        runner=_Runner,
+    )
+    assert out == "/usr/bin/python3.12"
+    assert ran == []
+
+
+def test_ensure_python_provisions_via_uv_when_no_system_interpreter() -> None:
+    ran: list[list[str]] = []
+    envs: list[dict[str, str] | None] = []
+
+    class _Result:
+        stdout = "/var/lib/hal0/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13\n"
+
+    class _Runner:
+        @staticmethod
+        def run(argv: list[str], *, env: dict[str, str] | None = None, **_kw: Any) -> _Result:
+            ran.append(argv)
+            envs.append(env)
+            return _Result()
+
+    out = hp._ensure_supported_python(
+        prober=lambda name: "/usr/local/bin/uv" if name == "uv" else None,
+        runner=_Runner,
+        running=(3, 14),
+    )
+    assert out == "/var/lib/hal0/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13"
+    # install runs before find, both pinned to UV_PYTHON_FALLBACK...
+    assert [a[1:3] for a in ran] == [["python", "install"], ["python", "find"]]
+    assert all(a[3] == hp.UV_PYTHON_FALLBACK for a in ran)
+    # ...and both redirected to the world-readable install dir (the default
+    # ~/.local/share/uv under root's 0700 home would be unreachable by the
+    # hal0 user the venv runs as).
+    assert all(
+        e is not None and e["UV_PYTHON_INSTALL_DIR"] == str(hp.UV_PYTHON_INSTALL_DIR) for e in envs
+    )
+
+
+def test_ensure_python_returns_none_without_uv() -> None:
+    out = hp._ensure_supported_python(prober=lambda _name: None, running=(3, 14))
+    assert out is None
+
+
+def test_ensure_python_returns_none_when_uv_fetch_fails() -> None:
+    class _Runner:
+        @staticmethod
+        def run(argv: list[str], **_kw: Any) -> None:
+            raise subprocess.CalledProcessError(1, argv)
+
+    out = hp._ensure_supported_python(
+        prober=lambda name: "/usr/local/bin/uv" if name == "uv" else None,
+        runner=_Runner,
+        running=(3, 14),
+    )
+    assert out is None
 
 
 def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Completes the Ubuntu 26.04 install story started in #1251. The interpreter guard (#1248) makes a Python-3.14-only host fail preflight with a manual remediation; this PR makes it succeed instead: when no system 3.11-3.13 exists but uv is on PATH, the install phase provisions a managed Python 3.13 and builds the hermes venv on it. **Stock Ubuntu 26.04 → zero manual steps.**

## Design

- **System Python always wins.** `_ensure_supported_python` tries the #1248 resolver first; the uv fetch fires only when PATH and the running interpreter both fail the range check. Hosts with a packaged 3.11-3.13 never download anything.
- **`UV_PYTHON_INSTALL_DIR=/var/lib/hal0/python`.** uv's default (`~/.local/share/uv`) sits under root's 0700 home — the hermes venv executes as the `hal0` user via a symlinked base interpreter, which would be unreachable. Verified: `sudo -u hal0 <managed python> --version` works.
- **Deterministic reuse.** `uv python install` is idempotent and `uv python find` returns the same stable path (uv maintains a minor-version symlink), so venv rebuilds and `--repair` reuse the first-provisioned interpreter.
- **Preflight stays fast and side-effect free** — it only probes uv availability and flags `uv_python_fallback` in details; the download happens in the install phase. With uv absent, preflight fails with the #1248 range error, now extended with the uv remediation.
- **Offline/uv-fetch failure** degrades to the existing actionable error; no partial venv is left behind (venv creation only starts after an interpreter is resolved).

## Testing

- 6 new unit tests: system-preference (uv never invoked), uv fallback happy path (install-before-find, version pin, env override), uv-absent and fetch-failure degradation, preflight pass-with-uv and fail-without-uv.
- `tests/agents/ + tests/cli/`: 759 passed; 3 failures are the known pre-existing env failures on the dev box (identical set on pristine main).
- **Live end-to-end on this host** simulating a 3.14-only box (prober hiding system pythons): uv fetched cpython-3.13.13 into `/var/lib/hal0/python`, second resolve returned the identical path with no re-download, a venv built from it, and pip on it resolved `hermes-agent==0.18.2` (dry-run) — the exact chain a fresh Ubuntu 26.04 install will follow.

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)