### PR TITLE
fix(bench): resume eval runs across defers instead of restarting + duplicating records

### DIFF
--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -339,7 +339,9 @@ def _worker_eval(model: str, api: str, item: dict) -> bool:
             if not control.worker_should_run():
                 return False
             if traffic_in_flight(api):
-                print(f"[worker] live traffic — backing off eval {model} (resumes where it left off)")
+                print(
+                    f"[worker] live traffic — backing off eval {model} (resumes where it left off)"
+                )
                 return False
             print(f"[worker] eval {model} :: {task.id} …", flush=True)
             rec = evalrun.run_task(task, model, run_id, api, workroot)
@@ -397,7 +399,9 @@ def cmd_worker(args: argparse.Namespace) -> int:
                         # Stop/Pause: leave the item at the queue head so Start
                         # resumes THIS eval (its completed tasks persist under the
                         # stable run_id) — mirrors the suite path's "stopped" branch.
-                        print(f"[worker] eval {resolved} paused — item stays queued (resumes on Start)")
+                        print(
+                            f"[worker] eval {resolved} paused — item stays queued (resumes on Start)"
+                        )
                         continue
                     # Deferred over live traffic. Eval is polite by design (never
                     # piles onto production), but shouldn't stall the whole queue

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -299,25 +299,47 @@ def _worklist_suite(item: dict, base: Suite | None) -> Suite:
     )
 
 
-def _worker_eval(model: str, api: str) -> bool:
+def _eval_run_id(item: dict) -> str:
+    """A STABLE run_id for a queued eval, derived from the queue item id.
+
+    The suite path is resumable because it appends per-cell as it goes and, on a
+    defer, leaves the item queued so the next tick re-plans only what's still
+    stale — the same records never get rewritten. Eval has no planner, so we get
+    the same property by deriving a run_id from the (unique, ``token_hex``) queue
+    item id: an eval that defers (Stop/Pause or live traffic) resumes under the
+    SAME run_id on the next tick instead of restarting under a fresh ``_now_stamp``
+    and duplicating the records of tasks that already completed. A fresh enqueue
+    gets a new item id → new run_id → a clean full re-run."""
+    return f"eval-{item.get('id') or 'adhoc'}"
+
+
+def _worker_eval(model: str, api: str, item: dict) -> bool:
     """Run the full agentic-eval task set for one queued model (the dashboard's
     Tool Bench). Unlike suite runs this drives the LIVE inference endpoint via
     Hermes, so it never takes the GPU seam. Same politeness rule as cmd_eval:
     re-check for live traffic before each task and back off (leave the item
     queued) rather than pile onto production. Returns True when every task ran;
-    False when the operator hit Stop/Pause or traffic appeared mid-run."""
+    False when the operator hit Stop/Pause or traffic appeared mid-run.
+
+    Resumable across defers (like the suite path): tasks already recorded under
+    this item's stable run_id in a prior tick are skipped, so a resumed eval runs
+    only the remainder and never double-writes a record."""
     import tempfile
 
     from . import control, evalrun
 
-    run_id = _now_stamp()
+    run_id = _eval_run_id(item)
+    done = {r.get("task_id") for r in evalrun.read_evals() if r.get("run_id") == run_id}
+    pending = [t for t in evalrun.TASKS if t.id not in done]
+    if not pending:
+        return True
     with tempfile.TemporaryDirectory(prefix="hal0-bench-eval-") as tmp:
         workroot = Path(tmp)
-        for task in evalrun.TASKS:
+        for task in pending:
             if not control.worker_should_run():
                 return False
             if traffic_in_flight(api):
-                print(f"[worker] live traffic — backing off eval {model}")
+                print(f"[worker] live traffic — backing off eval {model} (resumes where it left off)")
                 return False
             print(f"[worker] eval {model} :: {task.id} …", flush=True)
             rec = evalrun.run_task(task, model, run_id, api, workroot)
@@ -369,9 +391,22 @@ def cmd_worker(args: argparse.Namespace) -> int:
                     },
                     _now_stamp(),
                 )
-                if not _worker_eval(resolved, args.api):
-                    print(f"[worker] eval {resolved} deferred — item stays queued")
+                if not _worker_eval(resolved, args.api, item):
                     control.write_status(None, _now_stamp())
+                    if not control.worker_should_run():
+                        # Stop/Pause: leave the item at the queue head so Start
+                        # resumes THIS eval (its completed tasks persist under the
+                        # stable run_id) — mirrors the suite path's "stopped" branch.
+                        print(f"[worker] eval {resolved} paused — item stays queued (resumes on Start)")
+                        continue
+                    # Deferred over live traffic. Eval is polite by design (never
+                    # piles onto production), but shouldn't stall the whole queue
+                    # while it waits — yield head-of-line so non-eval items behind
+                    # it can drain. The item keeps its id, so it resumes where it
+                    # left off when it next reaches the head on a quiet box.
+                    print(f"[worker] eval {resolved} deferred (live traffic) — yielding queue head")
+                    control.dequeue(item.get("id"))
+                    control.enqueue(item)
                     time.sleep(args.poll)
                     continue
                 control.dequeue(item.get("id"))

--- a/tests/bench/test_worker_eval.py
+++ b/tests/bench/test_worker_eval.py
@@ -1,0 +1,169 @@
+"""test_worker_eval.py — the queued-eval worker path (resume + queue politeness).
+
+Two behaviours, both exercised without a live agent or GPU:
+
+  * Resume (bug A): an eval that defers after N of M tasks resumes under the SAME
+    run_id and runs only the remaining tasks — it never re-runs or double-writes a
+    record for a task that already completed. Contrast the old behaviour, which
+    minted a fresh ``_now_stamp`` run_id every tick and re-ran the whole set.
+  * Head-of-line politeness (bug B): an eval that defers over live traffic yields
+    its head-of-line position so a non-eval item behind it can drain, while an eval
+    paused by Stop stays at the head so Start resumes the same item.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from hal0.bench import cli, control, evalrun
+
+
+def _fake_tasks(n: int) -> list:
+    return [types.SimpleNamespace(id=f"t{i}") for i in range(n)]
+
+
+def _rec(run_id: str, task_id: str) -> evalrun.EvalRecord:
+    return evalrun.EvalRecord(
+        run_id=run_id,
+        suite="agentic",
+        task_id=task_id,
+        kind="code",
+        model="m",
+        outcome="ok",
+        score=1.0,
+        correct=True,
+        expected="x",
+        answer="x",
+        checkpoints_hit=[],
+        checkpoints_total=0,
+        metrics={"wall_s": 0.1},
+    )
+
+
+def test_worker_eval_resumes_without_duplicate_records(monkeypatch, tmp_path):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    control.set_control(state="running")
+
+    tasks = _fake_tasks(4)
+    monkeypatch.setattr(evalrun, "TASKS", tasks)
+
+    ran: list[str] = []
+
+    def fake_run_task(task, model, run_id, api, workroot):
+        ran.append(task.id)
+        return _rec(run_id, task.id)
+
+    monkeypatch.setattr(evalrun, "run_task", fake_run_task)
+
+    # Live traffic appears once 2 tasks have landed on the first tick, then clears
+    # before the second tick (a transient burst).
+    gate = {"busy": True, "after": 2}
+
+    def fake_traffic(api, *a, **k):
+        return gate["busy"] and len(evalrun.read_evals()) >= gate["after"]
+
+    monkeypatch.setattr(cli, "traffic_in_flight", fake_traffic)
+
+    item = {"id": "abcd1234", "model": "m", "kind": "eval"}
+
+    # Tick 1: runs t0, t1, then backs off on traffic -> deferred.
+    assert cli._worker_eval("m", "http://x", item) is False
+    assert ran == ["t0", "t1"]
+    evals = evalrun.read_evals()
+    assert len(evals) == 2
+    run_id = cli._eval_run_id(item)
+    assert {r["run_id"] for r in evals} == {run_id}
+
+    # Traffic clears; Tick 2 resumes and finishes only the remainder.
+    gate["busy"] = False
+    assert cli._worker_eval("m", "http://x", item) is True
+
+    # Each task ran exactly once across both ticks — no re-runs, no duplicates.
+    assert ran == ["t0", "t1", "t2", "t3"]
+    evals = evalrun.read_evals()
+    assert len(evals) == 4
+    assert sorted(r["task_id"] for r in evals) == ["t0", "t1", "t2", "t3"]
+    assert {r["run_id"] for r in evals} == {run_id}  # one stable run_id throughout
+
+
+def test_worker_eval_noop_when_all_tasks_already_done(monkeypatch, tmp_path):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    control.set_control(state="running")
+    monkeypatch.setattr(evalrun, "TASKS", _fake_tasks(2))
+    item = {"id": "deadbeef", "model": "m", "kind": "eval"}
+    run_id = cli._eval_run_id(item)
+    for tid in ("t0", "t1"):
+        evalrun.append_eval(_rec(run_id, tid))
+
+    def boom(*a, **k):  # must not run any task
+        raise AssertionError("run_task called for an already-completed run")
+
+    monkeypatch.setattr(evalrun, "run_task", boom)
+    monkeypatch.setattr(cli, "traffic_in_flight", lambda *a, **k: False)
+
+    assert cli._worker_eval("m", "http://x", item) is True
+    assert len(evalrun.read_evals()) == 2  # unchanged
+
+
+class _StopLoop(BaseException):
+    # BaseException (not Exception) so the worker's broad ``except Exception``
+    # guard doesn't swallow our loop-breaker and drop the item under test.
+    pass
+
+
+def _worker_args() -> types.SimpleNamespace:
+    return types.SimpleNamespace(api="http://x", poll=0)
+
+
+def test_deferred_eval_yields_head_of_line(monkeypatch, tmp_path):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    control.set_control(state="running")
+    control.enqueue({"id": "ev1", "model": "m-eval", "kind": "eval"})
+    control.enqueue({"id": "su1", "suite": "roster"})
+
+    monkeypatch.setattr(cli, "fetch_registry_models", lambda api: [])
+    # eval always defers over (simulated) live traffic
+    monkeypatch.setattr(cli, "_worker_eval", lambda model, api, item: False)
+
+    import time as _time
+
+    def fake_sleep(_):
+        raise _StopLoop  # break out of the worker's forever-loop after one tick
+
+    monkeypatch.setattr(_time, "sleep", fake_sleep)
+
+    with pytest.raises(_StopLoop):
+        cli.cmd_worker(_worker_args())
+
+    # The eval rotated to the tail; the suite item is now head and can drain.
+    assert [i["id"] for i in control.read_queue()] == ["su1", "ev1"]
+
+
+def test_stopped_eval_keeps_head_of_line(monkeypatch, tmp_path):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    control.set_control(state="running")
+    control.enqueue({"id": "ev1", "model": "m-eval", "kind": "eval"})
+    control.enqueue({"id": "su1", "suite": "roster"})
+
+    monkeypatch.setattr(cli, "fetch_registry_models", lambda api: [])
+
+    def stop_then_defer(model, api, item):
+        control.set_control(state="stopped")  # operator hits Stop mid-eval
+        return False
+
+    monkeypatch.setattr(cli, "_worker_eval", stop_then_defer)
+
+    import time as _time
+
+    def fake_sleep(_):
+        raise _StopLoop
+
+    monkeypatch.setattr(_time, "sleep", fake_sleep)
+
+    with pytest.raises(_StopLoop):
+        cli.cmd_worker(_worker_args())
+
+    # Stopped: the eval stays at the head so Start resumes THIS item.
+    assert [i["id"] for i in control.read_queue()] == ["ev1", "su1"]


### PR DESCRIPTION
## Bugs (PR #1255, `_worker_eval`)
**(A)** Eval had no resume: on Stop/Pause/live-traffic it re-queued, and the next tick restarted with a fresh `run_id`, re-appending duplicate eval records for already-completed tasks (the suite path resumes via `cells_ok`).
**(B)** Eval backed off on **any** live traffic and kept head-of-line, so a queued eval could block the whole bench queue on a busy box.

## Fix
- **(A)** Stable `run_id` derived from the queue-item id (`eval-<item id>`, minted once per enqueue). On re-entry, read existing eval records for that run_id and run only pending task ids → no duplicates, resumes where it left off. Fresh enqueue → new id → clean full re-run.
- **(B)** On a live-traffic defer the item rotates to the queue **tail** (yields head-of-line) so non-eval items drain; a Stop/Pause defer keeps its place so Start resumes the same eval — mirroring the suite path's `stopped` vs `gpu-contended` handling. Preserves eval's "don't pile onto production" contract.

## Tests (4 new)
resume-without-duplicates, all-done no-op, deferred-eval-yields-head-of-line, stopped-eval-keeps-head. **47 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)