### PR TITLE
fix(memory-cli): tolerate operation_id in ops retry + scope migrate-unify retag to transferred docs

### DIFF
--- a/src/hal0/cli/memory_migrate_commands.py
+++ b/src/hal0/cli/memory_migrate_commands.py
@@ -455,11 +455,15 @@ def migrate_unify_cmd(
             src = row["source"]
             tags = row["tags_to_add"]
             _progress.print(f"[dim]exporting {src} → importing into {target}…[/dim]")
-            # Only bother listing the target bank's documents (an extra
-            # network round-trip) when there are tags to apply — the
-            # before/after diff is how a document-transfer with no
-            # tag-rewrite option gets retagged after the fact.
+            # Only bother listing documents (an extra network round-trip)
+            # when there are tags to apply — the before/after diff is how a
+            # document-transfer with no tag-rewrite option gets retagged
+            # after the fact. We also capture the *source* bank's own
+            # document-id set so the retag can be scoped to docs this
+            # migration actually transferred (see below), not every id that
+            # appeared in the target during the transfer window.
             ids_before = _document_ids(target) if tags else None
+            source_doc_ids = _document_ids(src) if tags else None
             try:
                 zip_bytes, _ct = api_get_bytes(
                     f"/api/memory/banks/{src}/document-transfer",
@@ -485,8 +489,23 @@ def migrate_unify_cmd(
             retagged: dict[str, str] = {}
             if tags:
                 ids_after = _document_ids(target)
-                new_ids = ids_after - (ids_before or set())
+                # Scope the retag to docs THIS migration transferred. The
+                # document-transfer import returns only counts
+                # (result_metadata), never the ids it created, so the
+                # tightest scoping available without an upstream change is
+                # to intersect the target's before/after diff with the
+                # source bank's own document ids. A doc another writer lands
+                # in the target during the transfer window carries a
+                # foreign id (not in the source bank) and is thus excluded,
+                # instead of being mis-attributed to this source.
+                new_ids = (ids_after - (ids_before or set())) & (source_doc_ids or set())
                 if new_ids:
+                    _progress.print(
+                        "[yellow]-- retag is scoped to documents whose ids match the "
+                        "source bank; under --on-conflict new-id transferred docs receive "
+                        "fresh ids and are not retagged, and a concurrent writer reusing a "
+                        "source id could still be mis-attributed.[/yellow]"
+                    )
                     _progress.print(
                         f"[yellow]retagging {len(new_ids)} document(s) from {src} → "
                         f"queues {len(new_ids)} re-consolidation pass(es); slow on a local "

--- a/src/hal0/cli/memory_ops_commands.py
+++ b/src/hal0/cli/memory_ops_commands.py
@@ -136,7 +136,18 @@ def ops_retry_cmd(
             banks = [bank] if bank else _all_bank_ids()
             for b in banks:
                 for op in _list_bank_ops(b, failed_only=True):
-                    targets.append((b, str(op["id"])))
+                    # The live Hindsight operations schema (0.8.x) isn't
+                    # runtime-verified here — accept either ``id`` or
+                    # ``operation_id`` and skip-with-warning rather than
+                    # KeyError the whole retry loop on an unexpected row.
+                    oid = op.get("id") or op.get("operation_id")
+                    if not oid:
+                        console.print(
+                            f"[yellow]skipping failed op in {b!r} with no "
+                            f"id/operation_id: {op!r}[/yellow]"
+                        )
+                        continue
+                    targets.append((b, str(oid)))
             for b, oid in targets:
                 r = api_post(f"/api/memory/banks/{b}/operations/{oid}/retry")
                 r["bank_id"] = b

--- a/tests/cli/test_memory_migrate_unify.py
+++ b/tests/cli/test_memory_migrate_unify.py
@@ -34,12 +34,25 @@ def stub_api(monkeypatch: pytest.MonkeyPatch):
             {"bank_id": "private__hermes", "fact_count": 12, "last_document_at": "t1"},
             {"bank_id": "private__pi-coder", "fact_count": 7, "last_document_at": None},
         ],
-        # documents-in-target-bank state, mutated by the fake import so the
-        # before/after diff in _document_ids has something to find.
-        "target_documents": [{"id": "d1", "tags": ["old"]}],
+        # Per-bank document state. ``_document_ids(bank)`` reads the bank in
+        # the path, so source and target banks hold distinct id sets — this
+        # is what lets the retag scope itself to docs the source actually
+        # transferred (vs. anything that appears in the target concurrently).
+        "documents": {
+            "shared": [{"id": "d1", "tags": ["old"]}],
+            "private__hermes": [{"id": "d2"}],
+            "private__pi-coder": [{"id": "d5"}],
+        },
+        # Extra docs a *concurrent* foreign writer lands in the target during
+        # the transfer window — the fake import appends these too, so tests
+        # can assert they are NOT swept into the retag set.
+        "concurrent_docs": [],
         "operation": {"status": "completed", "result_metadata": {"documents_imported": 1}},
         "doc_tags": {"d2": ["existing"]},
     }
+
+    def _bank_of(path: str) -> str:
+        return path.split("/banks/", 1)[1].split("/", 1)[0]
 
     def fake_get(path: str, **kw: Any) -> Any:
         calls["get"].append((path, kw.get("params")))
@@ -48,7 +61,7 @@ def stub_api(monkeypatch: pytest.MonkeyPatch):
         if path == "/api/memory/banks":
             return {"banks": state["banks"]}
         if path.endswith("/documents") and "/documents/" not in path:
-            return {"documents": list(state["target_documents"])}
+            return {"documents": list(state["documents"].get(_bank_of(path), []))}
         if path.endswith("/operations/op-1"):
             return {"operation_id": "op-1", **state["operation"]}
         if "/documents/" in path:
@@ -62,9 +75,12 @@ def stub_api(monkeypatch: pytest.MonkeyPatch):
 
     def fake_post(path: str, **kw: Any) -> Any:
         calls["post"].append((path, kw.get("params"), bool(kw.get("files"))))
-        # Simulate the import landing a new document so the before/after
-        # diff in _document_ids has something to retag.
-        state["target_documents"].append({"id": "d2", "tags": []})
+        # Simulate the import landing the source's document (id d2) in the
+        # target so the before/after diff in _document_ids has something to
+        # retag, plus any concurrent foreign writes.
+        target = _bank_of(path)
+        landed = [{"id": "d2", "tags": []}, *state["concurrent_docs"]]
+        state["documents"].setdefault(target, []).extend(landed)
         return {"operation_id": "op-1", "status": "queued"}
 
     def fake_patch(path: str, **kw: Any) -> Any:
@@ -191,6 +207,22 @@ def test_unify_apply_success_exports_imports_polls_and_retags(stub_api) -> None:
     patch_path, patch_body = stub_api["calls"]["patch"][0]
     assert patch_path == "/api/memory/banks/shared/documents/d2"
     assert set(patch_body["tags"]) == {"existing", "agent:hermes", "visibility:private"}
+
+
+def test_unify_apply_retag_ignores_concurrent_foreign_doc(stub_api) -> None:
+    # A doc another writer lands in the target during the transfer window
+    # (foreign id, not in the source bank) must NOT be retagged/mis-attributed.
+    stub_api["state"]["features"] = {"document_export_api": True, "document_import_api": True}
+    stub_api["state"]["concurrent_docs"] = [{"id": "foreign-1", "tags": []}]
+    result = runner.invoke(mgc.app, ["unify", "--source", "private__hermes", "--apply", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    tr = payload["transfers"][0]
+    # Only the source's own doc (d2) is retagged; the concurrent foreign doc is not.
+    assert tr["retagged_documents"] == {"d2": "ok"}
+    patched_ids = [path.rsplit("/", 1)[-1] for path, _body in stub_api["calls"]["patch"]]
+    assert patched_ids == ["d2"]
+    assert "foreign-1" not in patched_ids
 
 
 def test_unify_apply_on_conflict_and_skip_observations_thread_through(stub_api) -> None:

--- a/tests/cli/test_memory_ops_commands.py
+++ b/tests/cli/test_memory_ops_commands.py
@@ -136,3 +136,34 @@ def test_ops_retry_all_failed_scoped_to_bank(stub_api) -> None:
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert {r["operation_id"] for r in payload["retried"]} == {"op-1"}
+
+
+def test_ops_retry_all_failed_tolerates_operation_id_key(
+    monkeypatch: pytest.MonkeyPatch, stub_api
+) -> None:
+    # If the live Hindsight schema keys the field ``operation_id`` (not
+    # ``id``), retry must still find and post it rather than KeyError.
+    def one_op(bank: str, *, failed_only: bool):
+        return [{"operation_id": "op-x", "status": "failed", "bank_id": bank}]
+
+    monkeypatch.setattr(oc, "_list_bank_ops", one_op)
+    result = runner.invoke(oc.app, ["retry", "--bank", "shared", "--all-failed", "--json"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["post"] == ["/api/memory/banks/shared/operations/op-x/retry"]
+
+
+def test_ops_retry_all_failed_skips_op_with_no_id(
+    monkeypatch: pytest.MonkeyPatch, stub_api
+) -> None:
+    # An op row missing both id keys is skipped-with-warning, not crashed on;
+    # the well-formed op alongside it is still retried.
+    def mixed_ops(bank: str, *, failed_only: bool):
+        return [
+            {"status": "failed", "task_type": "retain", "bank_id": bank},  # no id/operation_id
+            {"id": "op-ok", "status": "failed", "bank_id": bank},
+        ]
+
+    monkeypatch.setattr(oc, "_list_bank_ops", mixed_ops)
+    result = runner.invoke(oc.app, ["retry", "--bank", "shared", "--all-failed", "--json"])
+    assert result.exit_code == 0, result.output
+    assert stub_api["post"] == ["/api/memory/banks/shared/operations/op-ok/retry"]


### PR DESCRIPTION
## Two hardening fixes (PR #1257)
**1. `ops retry --all-failed`** read `op["id"]` → KeyError if the live Hindsight schema keys it `operation_id`. Now `op.get("id") or op.get("operation_id")`, skip-with-warning if neither (one bad row can't abort the fan-out).

**2. `migrate unify` retag** attributed "new docs" via an unbounded before/after id-diff of the target bank, so a concurrent foreign writer's doc got mis-tagged with the migrated agent's `agent:<x>` / `visibility:private`. Now scoped to `(after − before) ∩ source_doc_ids` — foreign ids are excluded. (Per-document created-ids are unavailable from the import API, which returns only `{operation_id}`; a `--` warning documents the residual under `--on-conflict new-id`.)

## Tests (3 new)
retry tolerates `operation_id`, retry skips a no-id row without crashing, concurrent foreign doc not retagged (bank-aware fixture). **151 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)