### PR TITLE
fix(ui): don't render pi-mark <img> with empty src when agent art is missing

### DIFF
--- a/ui/src/dash/agents/agent-card.jsx
+++ b/ui/src/dash/agents/agent-card.jsx
@@ -146,12 +146,14 @@ function LiveAgentCard({ agent, health, statusCls, statusLabel, restart, onLogs,
                 <div className="pi-stage">
                   <span className="pi-grid" />
                   <div className="pi-mark-wrap">
-                    <img
-                      className="pi-mark"
-                      src={a.logo}
-                      alt={a.name + " logo"}
-                      style={{ width: (a.logoScale || 0.86) * 100 + "%", height: (a.logoScale || 0.86) * 100 + "%" }}
-                    />
+                    {a.logo ? (
+                      <img
+                        className="pi-mark"
+                        src={a.logo}
+                        alt={a.name + " logo"}
+                        style={{ width: (a.logoScale || 0.86) * 100 + "%", height: (a.logoScale || 0.86) * 100 + "%" }}
+                      />
+                    ) : null}
                   </div>
                 </div>
               )}
@@ -274,12 +276,14 @@ function LockedAgentCard({ agent }) {
               <div className="pi-stage">
                 <span className="pi-grid" />
                 <div className="pi-mark-wrap">
-                  <img
-                    className="pi-mark"
-                    src={a.logo}
-                    alt={a.name + " logo"}
-                    style={{ width: (a.logoScale || 0.86) * 100 + "%", height: (a.logoScale || 0.86) * 100 + "%" }}
-                  />
+                  {a.logo ? (
+                    <img
+                      className="pi-mark"
+                      src={a.logo}
+                      alt={a.name + " logo"}
+                      style={{ width: (a.logoScale || 0.86) * 100 + "%", height: (a.logoScale || 0.86) * 100 + "%" }}
+                    />
+                  ) : null}
                 </div>
               </div>
 


### PR DESCRIPTION
## Bug (PR #1254)
When `window.__hal0AgentArt.pi` is absent the Pi card's `logo` resolves to `""`, producing `<img src="">` which some browsers re-request as the document URL. Guards both `pi-mark` renders in `agent-card.jsx` on `a.logo` truthiness.

Cosmetic, no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)