### PR TITLE
refactor(mcp): share per-tool param schemas between board_chat and admin MCP

### DIFF
--- a/src/hal0/api/routes/board_chat.py
+++ b/src/hal0/api/routes/board_chat.py
@@ -455,136 +455,20 @@ def _brain_tool_policy(request: Request) -> Any | None:
     return ToolPolicy.from_persona(persona)
 
 
-# Body-arg schemas for the tools the steward misuses most when left to guess
-# (the generic catalog only names PATH args; body fields were invisible, so
-# the model invented arg names — observed: model_inspect called without
-# hf_repo, model_pull called with model_id='org/repo'). properties are merged
-# over the path-arg stubs; 'required' extends the path-arg list.
-_ADMIN_TOOL_PARAM_OVERRIDES: dict[str, dict[str, Any]] = {
-    "model_inspect": {
-        "properties": {
-            "hf_repo": {"type": "string", "description": "HuggingFace repo as 'org/name'"},
-            "hf_url": {
-                "type": "string",
-                "description": "Alternative: full https://huggingface.co/... URL",
-            },
-        },
-    },
-    "model_pull": {
-        "properties": {
-            "model_id": {
-                "type": "string",
-                "description": (
-                    "LOCAL model id — short name, NO slashes; invent one for a new model"
-                ),
-            },
-            "hf_repo": {"type": "string", "description": "HF source repo 'org/name'"},
-            "hf_filename": {
-                "type": "string",
-                "description": "Exact .gguf filename in the repo (from model_inspect)",
-            },
-            "mmproj_filename": {"type": "string", "description": "Optional vision sidecar"},
-        },
-    },
-    "model_swap": {
-        "properties": {
-            "name": {
-                "type": "string",
-                "description": "SLOT name (e.g. 'agent', 'ops') — NOT the model",
-            },
-            "model_id": {"type": "string", "description": "Registered model id to swap in"},
-        },
-        "required": ["model_id"],
-    },
-    "model_assign": {
-        "properties": {
-            "name": {"type": "string", "description": "SLOT name — NOT the model"},
-            "model": {
-                "type": "string",
-                "description": "Registered model id to set as the slot's default",
-            },
-        },
-        "required": ["model"],
-    },
-    "slot_create": {
-        "properties": {
-            "name": {"type": "string", "description": "New slot name"},
-            "model": {"type": "string", "description": "Registered model id to assign"},
-            "type": {
-                "type": "string",
-                "description": "llm|embedding|reranking|transcription|tts|image (default llm)",
-            },
-            "port": {"type": "integer", "description": "Omit to auto-assign the next free port"},
-            "image": {
-                "type": "string",
-                "description": (
-                    "Container image override — FPX/FP4 quants need "
-                    "ghcr.io/hal0ai/hal0-rocmfpx:c077206 with runtime='container'"
-                ),
-            },
-            "runtime": {"type": "string", "description": "Set 'container' when image is set"},
-        },
-        "required": ["name", "model"],
-    },
-    "upstream_create": {
-        "properties": {
-            "name": {
-                "type": "string",
-                "description": "New upstream name — lowercase alnum plus -/_ ('hal0' reserved)",
-            },
-            "catalog_id": {
-                "type": "string",
-                "description": (
-                    "Optional provider template: openai|anthropic|openrouter|"
-                    "google_ai_studio|ollama — prefills url/auth"
-                ),
-            },
-            "url": {
-                "type": "string",
-                "description": "OpenAI-compatible base URL (required without catalog_id)",
-            },
-            "auth_value_env": {
-                "type": "string",
-                "description": "Env-var NAME for the API key (never the key itself)",
-            },
-        },
-        "required": ["name"],
-    },
-    "upstream_update": {
-        "properties": {
-            "name": {"type": "string", "description": "Upstream name to update"},
-            "enabled": {
-                "type": "boolean",
-                "description": "Routing kill-switch — false removes it from dispatch",
-            },
-            "advertise_models": {
-                "type": "boolean",
-                "description": "Whether its models list in /v1/models",
-            },
-            "model_filters": {
-                "type": "object",
-                "description": (
-                    "{models: [exact ids], include: [globs], exclude: [globs]} — "
-                    "exclude wins; all-empty clears"
-                ),
-            },
-        },
-    },
-}
-
-
 def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
     """OpenAI tool schemas for the surfaced admin catalog.
 
-    Path args (from the admin server's ``_PATH_ARGS``) become required
-    string properties; ``additionalProperties`` stays open so the model
-    can pass body/query fields the descriptions call out (e.g.
-    ``model_pull``'s ``hf_repo``/``hf_filename``). A ``policy`` narrows
-    the surface to its ``tools_allowed`` globs — hidden tools never
-    reach the LLM's tool list (dispatch still refuses them if guessed).
+    The per-tool ``parameters`` come straight from
+    :func:`hal0.mcp.admin.tool_param_schema` — the SAME schema the MCP
+    server advertises (path args as required strings, curated body-field
+    hints, ``additionalProperties`` open). Keeping the builder in
+    ``admin`` means a hint authored once reaches both surfaces and can't
+    drift. A ``policy`` narrows the surface to its ``tools_allowed`` globs
+    — hidden tools never reach the LLM's tool list (dispatch still refuses
+    them if guessed).
     """
     try:
-        from hal0.mcp.admin import _PATH_ARGS, TOOL_DESCRIPTIONS
+        from hal0.mcp.admin import TOOL_DESCRIPTIONS, tool_param_schema
     except ImportError:
         return []
     schemas: list[dict[str, Any]] = []
@@ -593,25 +477,13 @@ def _admin_tool_schemas(policy: Any | None = None) -> list[dict[str, Any]]:
             continue
         if policy is not None and not policy.allows(name):
             continue
-        path_args = _PATH_ARGS.get(name, ())
-        properties: dict[str, Any] = {arg: {"type": "string"} for arg in path_args}
-        required = list(path_args)
-        override = _ADMIN_TOOL_PARAM_OVERRIDES.get(name)
-        if override:
-            properties.update(override.get("properties", {}))
-            required += [r for r in override.get("required", []) if r not in required]
         schemas.append(
             {
                 "type": "function",
                 "function": {
                     "name": name,
                     "description": description,
-                    "parameters": {
-                        "type": "object",
-                        "properties": properties,
-                        "required": required,
-                        "additionalProperties": True,
-                    },
+                    "parameters": tool_param_schema(name),
                 },
             }
         )

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -557,6 +557,159 @@ _PATH_ARGS: dict[str, tuple[str, ...]] = {
 }
 
 
+# ── Per-tool call-arg schemas (shared with the dashboard agent chat) ─────────
+#
+# _PATH_ARGS names only the URL path args; the body/query fields stay
+# invisible to a caller reading tools/list, so the model invented arg
+# names (observed: model_inspect called without hf_repo, model_pull
+# called with model_id='org/repo'). These hints enrich the tools the
+# agent misuses most: they extend the generated schema with named body
+# fields + descriptions and add to 'required'. This dict is the SINGLE
+# source of truth — both surfaces build their advertised schema from
+# :func:`tool_param_schema` (the dashboard chat wraps it as an OpenAI
+# function's ``parameters``; :func:`build_server` nests it under the MCP
+# passthrough ``args`` object), so a hint authored once reaches every
+# agent that can call the tool. Keys must be catalog tools (guarded by
+# :func:`_validate_catalog`).
+TOOL_PARAM_HINTS: dict[str, dict[str, Any]] = {
+    "model_inspect": {
+        "properties": {
+            "hf_repo": {"type": "string", "description": "HuggingFace repo as 'org/name'"},
+            "hf_url": {
+                "type": "string",
+                "description": "Alternative: full https://huggingface.co/... URL",
+            },
+        },
+    },
+    "model_pull": {
+        "properties": {
+            "model_id": {
+                "type": "string",
+                "description": (
+                    "LOCAL model id — short name, NO slashes; invent one for a new model"
+                ),
+            },
+            "hf_repo": {"type": "string", "description": "HF source repo 'org/name'"},
+            "hf_filename": {
+                "type": "string",
+                "description": "Exact .gguf filename in the repo (from model_inspect)",
+            },
+            "mmproj_filename": {"type": "string", "description": "Optional vision sidecar"},
+        },
+    },
+    "model_swap": {
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "SLOT name (e.g. 'agent', 'ops') — NOT the model",
+            },
+            "model_id": {"type": "string", "description": "Registered model id to swap in"},
+        },
+        "required": ["model_id"],
+    },
+    "model_assign": {
+        "properties": {
+            "name": {"type": "string", "description": "SLOT name — NOT the model"},
+            "model": {
+                "type": "string",
+                "description": "Registered model id to set as the slot's default",
+            },
+        },
+        "required": ["model"],
+    },
+    "slot_create": {
+        "properties": {
+            "name": {"type": "string", "description": "New slot name"},
+            "model": {"type": "string", "description": "Registered model id to assign"},
+            "type": {
+                "type": "string",
+                "description": "llm|embedding|reranking|transcription|tts|image (default llm)",
+            },
+            "port": {"type": "integer", "description": "Omit to auto-assign the next free port"},
+            "image": {
+                "type": "string",
+                "description": (
+                    "Container image override — FPX/FP4 quants need "
+                    "ghcr.io/hal0ai/hal0-rocmfpx:c077206 with runtime='container'"
+                ),
+            },
+            "runtime": {"type": "string", "description": "Set 'container' when image is set"},
+        },
+        "required": ["name", "model"],
+    },
+    "upstream_create": {
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "New upstream name — lowercase alnum plus -/_ ('hal0' reserved)",
+            },
+            "catalog_id": {
+                "type": "string",
+                "description": (
+                    "Optional provider template: openai|anthropic|openrouter|"
+                    "google_ai_studio|ollama — prefills url/auth"
+                ),
+            },
+            "url": {
+                "type": "string",
+                "description": "OpenAI-compatible base URL (required without catalog_id)",
+            },
+            "auth_value_env": {
+                "type": "string",
+                "description": "Env-var NAME for the API key (never the key itself)",
+            },
+        },
+        "required": ["name"],
+    },
+    "upstream_update": {
+        "properties": {
+            "name": {"type": "string", "description": "Upstream name to update"},
+            "enabled": {
+                "type": "boolean",
+                "description": "Routing kill-switch — false removes it from dispatch",
+            },
+            "advertise_models": {
+                "type": "boolean",
+                "description": "Whether its models list in /v1/models",
+            },
+            "model_filters": {
+                "type": "object",
+                "description": (
+                    "{models: [exact ids], include: [globs], exclude: [globs]} — "
+                    "exclude wins; all-empty clears"
+                ),
+            },
+        },
+    },
+}
+
+
+def tool_param_schema(tool: str) -> dict[str, Any]:
+    """The flat JSON-Schema for one tool's call args — shared by both surfaces.
+
+    Path args (:data:`_PATH_ARGS`) become required string properties;
+    :data:`TOOL_PARAM_HINTS` merge over them with named body/query fields +
+    descriptions and extend ``required``. ``additionalProperties`` stays
+    open so an agent can still pass undeclared body fields a description
+    calls out (e.g. ``slot_edit``'s arbitrary config keys) without the
+    schema rejecting them. Returns the object schema itself; callers wrap
+    it into their own envelope.
+    """
+    path_args = _PATH_ARGS.get(tool, ())
+    properties: dict[str, Any] = {arg: {"type": "string"} for arg in path_args}
+    required = list(path_args)
+    hint = TOOL_PARAM_HINTS.get(tool)
+    if hint:
+        properties.update(hint.get("properties", {}))
+        required += [r for r in hint.get("required", ()) if r not in required]
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": True,
+    }
+
+
 def _split_args(tool: str, args: dict[str, Any]) -> tuple[dict[str, str], dict[str, Any]]:
     """Separate path-substitution args from body/query args.
 
@@ -1414,6 +1567,19 @@ def _validate_catalog() -> None:
                 f"{sorted(placeholders)}"
             )
 
+    # Param hints must reference real catalog tools, and every 'required'
+    # field they add must actually be declared (as a hint property or a
+    # path arg) — else the shared schema advertises a required field with
+    # no matching property.
+    if stray := set(TOOL_PARAM_HINTS) - catalog:
+        problems.append(f"TOOL_PARAM_HINTS references unknown tools: {sorted(stray)}")
+    for tool, hint in TOOL_PARAM_HINTS.items():
+        declared = set(hint.get("properties", {})) | set(_PATH_ARGS.get(tool, ()))
+        if orphan := set(hint.get("required", ())) - declared:
+            problems.append(
+                f"{tool}: TOOL_PARAM_HINTS required {sorted(orphan)} not in properties/path args"
+            )
+
     if problems:
         raise RuntimeError("hal0.mcp.admin catalog drift: " + " | ".join(problems))
 
@@ -1475,6 +1641,21 @@ def build_server(
         annotations = _ANNOTATIONS.get(tool_name)
         server.tool(name=tool_name, description=description, annotations=annotations)(_tool)
 
+        # The wrapper's ``args: dict`` signature is deliberate — it passes the
+        # whole arg dict through to ``dispatch`` untouched (a flat signature
+        # would make FastMCP silently drop undeclared body fields). But that
+        # signature also advertises an opaque ``{args: object}`` in tools/list,
+        # leaving the caller to guess every field. Override the ADVERTISED
+        # schema (not the validation model, which stays permissive) so the
+        # nested ``args`` object carries the SAME per-tool schema the dashboard
+        # agent chat surfaces — one source of truth, two envelopes.
+        schema = tool_param_schema(tool_name)
+        server._tool_manager.get_tool(tool_name).parameters = {
+            "type": "object",
+            "properties": {"args": schema},
+            "required": ["args"] if schema["required"] else [],
+        }
+
     for _name, _description in TOOL_DESCRIPTIONS.items():
         _register(_name, _description)
 
@@ -1487,9 +1668,11 @@ __all__ = [
     "GATED_TOOLS",
     "POLICY_NO_LOOSEN",
     "TOOL_DESCRIPTIONS",
+    "TOOL_PARAM_HINTS",
     "_ANNOTATIONS",
     "ToolPolicy",
     "build_server",
     "dispatch",
     "is_gated",
+    "tool_param_schema",
 ]

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -185,6 +185,51 @@ async def test_registered_tools_carry_their_annotations(queue: ApprovalQueue) ->
     assert by_name[sample].annotations.readOnlyHint is False
 
 
+def test_tool_param_schema_is_the_shared_flat_shape() -> None:
+    """The shared builder yields path args as required strings, merges
+    curated body hints, and stays open for undeclared fields — the exact
+    shape the dashboard agent chat pins on its side."""
+    pull = admin.tool_param_schema("model_pull")
+    assert pull["required"] == ["model_id"]
+    assert pull["properties"]["model_id"]["type"] == "string"
+    # Curated body hint from TOOL_PARAM_HINTS reached the schema.
+    assert "hf_repo" in pull["properties"]
+    assert pull["additionalProperties"] is True
+    # A no-arg read has empty properties/required but still open.
+    reads = admin.tool_param_schema("profile_list")
+    assert reads["required"] == []
+    assert reads["properties"] == {}
+
+
+@pytest.mark.asyncio
+async def test_build_server_advertises_shared_param_schema(queue: ApprovalQueue) -> None:
+    """tools/list must carry the shared per-tool schema under the nested
+    ``args`` object — not the opaque ``{args: object}`` FastMCP derives
+    from the passthrough signature. Same source of truth as the chat."""
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    by_name = {t.name: t for t in await server.list_tools()}
+
+    pull = by_name["model_pull"].inputSchema
+    inner = pull["properties"]["args"]
+    assert inner["properties"]["model_id"]["type"] == "string"
+    assert "hf_repo" in inner["properties"]
+    assert inner["required"] == ["model_id"]
+    assert inner["additionalProperties"] is True
+    # A tool with a required field makes the nested ``args`` object required.
+    assert pull["required"] == ["args"]
+
+    # A no-arg read leaves ``args`` optional.
+    assert by_name["profile_list"].inputSchema["required"] == []
+
+
+def test_catalog_validation_catches_param_hint_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A TOOL_PARAM_HINTS entry naming a non-catalog tool must fail import
+    validation rather than advertise a schema for a tool that isn't there."""
+    monkeypatch.setitem(admin.TOOL_PARAM_HINTS, "ghost_tool", {"properties": {}})
+    with pytest.raises(RuntimeError, match="ghost_tool"):
+        admin._validate_catalog()
+
+
 @pytest.mark.asyncio
 async def test_autonomous_read_dispatches_get_with_bearer(
     queue: ApprovalQueue, mock_transport: dict[str, Any]


### PR DESCRIPTION
## Problem

The dashboard agent chat (`board_chat.py`) and the hal0-admin MCP server (`admin.py`) expose the **same** tool catalog through the **same** `dispatch()` core, but advertised their parameters two incompatible ways:

- `board_chat._admin_tool_schemas` hand-built rich **flat** schemas — path args as required strings + curated body-field hints (`hf_repo`, `hf_filename`, `slot_create` fields…).
- `admin.build_server` registered every tool as `_tool(args: dict)`, so `tools/list` advertised an **opaque `{args: object}`** with zero hints.

Result: the curated hints — authored precisely because the model kept inventing arg names (`model_pull` with `model_id='org/repo'`, `model_inspect` without `hf_repo`) — reached only the in-dashboard surface. Every agent on the MCP transport (hermes, `hermes__hal0-brain`, external clients) got no parameter guidance. The param metadata also lived in a route module instead of next to `TOOL_DESCRIPTIONS`/`_PATH_ARGS`/`_ANNOTATIONS`, the exact drift `admin.py` already guards against for every other table.

## Change

Make `admin.py` the single source of truth for per-tool parameter schemas — one source, two envelopes:

- **`TOOL_PARAM_HINTS`** — the curated body-field table, moved in from `board_chat`.
- **`tool_param_schema(tool)`** — shared builder (path args + hints + `additionalProperties: True`).
- **`build_server`** overrides the *advertised* schema (not the validation model, which stays permissive) so `tools/list` carries the real per-tool params under the nested passthrough `args` object.
- **`board_chat._admin_tool_schemas`** consumes `tool_param_schema()` — behaviour identical, ~110-line override table removed.
- **`_validate_catalog`** guards hint drift (hints must name catalog tools; every `required` field must be declared) so drift fails at import, in CI.

### Why the MCP side stays nested

The `args: dict` signature is a deliberate passthrough — flattening it makes FastMCP silently drop undeclared body fields, which would quietly break open-body tools (`slot_edit`, `model_register`, `config_write`, `stack_create`). So the wire contract is unchanged; only the advertised schema got richer.

## Tests

3 new tests: shared-schema shape, MCP advertises it under `args`, hint-drift guard. **73 pass** across `tests/mcp` + the board-chat admin/e2e suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)