### PR TITLE
fix(honcho-migrate): retry transient embed 5xx and surface the cause

### DIFF
--- a/src/hal0/memory/honcho_migrate.py
+++ b/src/hal0/memory/honcho_migrate.py
@@ -23,6 +23,7 @@ threaded through as an injected client.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -37,6 +38,18 @@ DEFAULT_STATE_PATH = Path("/var/lib/hal0/honcho/migrate-state.json")
 _MAX_CONTENT_CHARS = 60_000
 
 _CONCLUSION_BATCH = 25
+
+#: Honcho embeds each conclusion synchronously on write via hal0's
+#: ``/v1/embeddings`` (an NPU embed slot). When that slot is transiently
+#: unavailable Honcho surfaces a 5xx; a single such blip shouldn't abort a
+#: multi-thousand-item backfill, so the POST is retried with exponential
+#: backoff. 4xx (client errors) are permanent and never retried.
+_CONCLUSION_MAX_RETRIES = 3
+
+#: Base seconds for the exponential backoff between conclusion-POST retries
+#: (``_RETRY_BASE_DELAY * 2 ** attempt``). Kept small and module-level so
+#: tests can monkeypatch ``time.sleep`` to run instantly.
+_RETRY_BASE_DELAY = 0.5
 
 #: Session-name prefix stamped on every hindsight->honcho migration session,
 #: so the reverse (honcho->hindsight) direction can recognise + skip its own
@@ -191,13 +204,70 @@ def _ensure_session(client: httpx.Client, workspace: str, session: str) -> None:
     client.post(f"/v3/workspaces/{workspace}/sessions", json={"id": session}).raise_for_status()
 
 
+def _post_conclusions_batch(
+    client: httpx.Client, workspace: str, batch: list[dict[str, Any]]
+) -> None:
+    """POST one batch of conclusions, retrying transient backend failures.
+
+    Honcho embeds each conclusion synchronously on write; when the embed
+    backend (an NPU slot behind hal0's ``/v1/embeddings``) is transiently
+    down, Honcho returns a 5xx whose body carries the real cause (e.g.
+    ``503 npu.trio_unavailable``). We retry such 5xx responses and transport
+    errors with exponential backoff up to ``_CONCLUSION_MAX_RETRIES`` times.
+    4xx responses are permanent client errors and are raised immediately.
+
+    On any raised error the Honcho response body (``resp.text``) is attached
+    to the message — the bare :class:`httpx.HTTPStatusError` omits it — so
+    the operator sees the cause instead of an opaque ``500``. The original
+    exception is chained via ``raise ... from``.
+    """
+    url = f"/v3/workspaces/{workspace}/conclusions"
+    last_exc: Exception | None = None
+    for attempt in range(_CONCLUSION_MAX_RETRIES + 1):
+        try:
+            resp = client.post(url, json={"conclusions": batch})
+        except httpx.TransportError as exc:
+            last_exc = exc
+            if attempt < _CONCLUSION_MAX_RETRIES:
+                time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise RuntimeError(
+                f"honcho conclusions POST failed after {attempt + 1} attempts: {exc}"
+            ) from exc
+
+        status = resp.status_code
+        if status < 400:
+            return
+        # 4xx: permanent client error — do not retry, but still surface body.
+        if status < 500:
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise RuntimeError(
+                    f"honcho conclusions POST failed with {status}: {resp.text}"
+                ) from exc
+        # 5xx: transient — retry with backoff, then give up with the body.
+        try:
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            last_exc = exc
+            if attempt < _CONCLUSION_MAX_RETRIES:
+                time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise RuntimeError(
+                f"honcho conclusions POST failed with {status} after "
+                f"{attempt + 1} attempts: {resp.text}"
+            ) from exc
+    # Unreachable: loop either returns or raises. Guard for type-checkers.
+    raise RuntimeError("honcho conclusions POST failed") from last_exc
+
+
 def _create_conclusions(
     client: httpx.Client, workspace: str, conclusions: list[dict[str, Any]]
 ) -> None:
     for i in range(0, len(conclusions), _CONCLUSION_BATCH):
         batch = conclusions[i : i + _CONCLUSION_BATCH]
-        resp = client.post(f"/v3/workspaces/{workspace}/conclusions", json={"conclusions": batch})
-        resp.raise_for_status()
+        _post_conclusions_batch(client, workspace, batch)
 
 
 def _session_name(dataset: str) -> str:

--- a/tests/memory/test_honcho_migrate.py
+++ b/tests/memory/test_honcho_migrate.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 
+from hal0.memory import honcho_migrate
 from hal0.memory.honcho_migrate import (
     MigrateState,
     migrate_hindsight_to_honcho,
@@ -214,6 +216,122 @@ def test_forward_migration_private_dataset_sets_private_header(tmp_path):
     assert report[f"private:{AGENT}"]["migrated"] == 1
     list_calls = [r for r in calls if r.url.path == "/api/memory/list"]
     assert list_calls[0].headers.get("x-hal0-private") == "1"
+
+
+def _honcho_handler_with_conclusion_responses(recorder, conclusion_responder):
+    """Honcho MockTransport handler where each /conclusions POST is answered by
+    ``conclusion_responder(n_calls, body)`` -> httpx.Response. ``n_calls`` is the
+    1-based count of conclusion POSTs seen so far (so the first POST is 1)."""
+    state = {"conclusion_calls": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorder.append(request)
+        path = request.url.path
+        if path.endswith("/peers") or path == "/v3/workspaces" or path.endswith("/sessions"):
+            return httpx.Response(201, json={"id": "ok"})
+        if path.endswith("/conclusions"):
+            state["conclusion_calls"] += 1
+            return conclusion_responder(state["conclusion_calls"], httpx_json(request))
+        return httpx.Response(404, json={"error": "unhandled"})
+
+    return handler
+
+
+def _run_forward_with_honcho(honcho_handler, tmp_path):
+    """Run a single-item forward migration against ``honcho_handler`` and return
+    (report, state). One shared-dataset item => exactly one /conclusions batch."""
+    page = {"items": [{"id": "h1", "text": "fact"}], "next_cursor": None}
+    hal0_handler, _ = _hal0_pages({"shared": [page], "private": []})
+
+    hal0_transport = httpx.MockTransport(hal0_handler)
+    honcho_transport = httpx.MockTransport(honcho_handler)
+
+    with (
+        httpx.Client(transport=hal0_transport, base_url="http://127.0.0.1:8080") as hal0_client,
+        httpx.Client(transport=honcho_transport, base_url="http://127.0.0.1:8000") as honcho_client,
+    ):
+        state = MigrateState(tmp_path / "state.json")
+        report = migrate_hindsight_to_honcho(
+            honcho_base="http://127.0.0.1:8000",
+            workspace=WORKSPACE,
+            user_peer=USER_PEER,
+            agent_id=AGENT,
+            datasets=["shared"],
+            state=state,
+            hal0_http_client=hal0_client,
+            honcho_http_client=honcho_client,
+        )
+    return report, state
+
+
+def test_create_conclusions_retries_transient_503_then_succeeds(tmp_path, monkeypatch):
+    """A 503 (transient embed-backend outage) is retried; the migration then
+    completes and the expected number of /conclusions POSTs (initial + retries)
+    are observed. time.sleep is patched so the backoff is instant."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(honcho_migrate.time, "sleep", lambda s: sleeps.append(s))
+
+    honcho_calls: list[httpx.Request] = []
+
+    def responder(n_calls, _body):
+        # Fail the first two attempts with 503, succeed on the third.
+        if n_calls <= 2:
+            return httpx.Response(503, json={"detail": "503 npu.trio_unavailable"})
+        return httpx.Response(201, json=[{"id": "c0"}])
+
+    handler = _honcho_handler_with_conclusion_responses(honcho_calls, responder)
+    report, state = _run_forward_with_honcho(handler, tmp_path)
+
+    assert report["shared"]["migrated"] == 1
+    conclusion_posts = [r for r in honcho_calls if r.url.path.endswith("/conclusions")]
+    assert len(conclusion_posts) == 3  # two failed retries + one success
+    assert len(sleeps) == 2  # slept once before each retry
+    assert state.migrated_ids("shared") == {"h1"}
+
+
+def test_create_conclusions_persistent_500_raises_with_body(tmp_path, monkeypatch):
+    """A 500 on every attempt exhausts retries and raises; the raised error
+    string carries the Honcho response body so the operator sees the cause."""
+    monkeypatch.setattr(honcho_migrate.time, "sleep", lambda _s: None)
+
+    honcho_calls: list[httpx.Request] = []
+    body_text = "503 npu.trio_unavailable (embed slot down)"
+
+    def responder(_n_calls, _body):
+        return httpx.Response(500, json={"detail": body_text})
+
+    handler = _honcho_handler_with_conclusion_responses(honcho_calls, responder)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_forward_with_honcho(handler, tmp_path)
+
+    assert body_text in str(excinfo.value)
+    conclusion_posts = [r for r in honcho_calls if r.url.path.endswith("/conclusions")]
+    # 1 initial + _CONCLUSION_MAX_RETRIES retries.
+    assert len(conclusion_posts) == 4
+
+
+def test_create_conclusions_4xx_raises_immediately_without_retry(tmp_path, monkeypatch):
+    """A 4xx is a permanent client error: raise immediately, no retries, and
+    still attach the response body."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(honcho_migrate.time, "sleep", lambda s: sleeps.append(s))
+
+    honcho_calls: list[httpx.Request] = []
+    body_text = "422 validation error: content too long"
+
+    def responder(_n_calls, _body):
+        return httpx.Response(422, json={"detail": body_text})
+
+    handler = _honcho_handler_with_conclusion_responses(honcho_calls, responder)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_forward_with_honcho(handler, tmp_path)
+
+    assert body_text in str(excinfo.value)
+    conclusion_posts = [r for r in honcho_calls if r.url.path.endswith("/conclusions")]
+    assert len(conclusion_posts) == 1  # no retries on 4xx
+    assert sleeps == []
 
 
 def _reverse_conclusions_handler(pages, add_calls):


### PR DESCRIPTION
## Problem

`hal0 memory migrate --from hindsight --to honcho` aborted with a bare `500` mid-run. Root cause chain:

1. The migration POSTs facts to Honcho `POST /v3/workspaces/<ws>/conclusions`.
2. Honcho **embeds each conclusion synchronously on write** → calls hal0 `/v1/embeddings` → NPU trio embed slot.
3. When the NPU `flm` anchor is transiently unavailable, `/v1/embeddings` returns `503 npu.trio_unavailable`, Honcho surfaces `500`.
4. `_create_conclusions`' bare `resp.raise_for_status()` aborted the whole (2600-item) run **and discarded `resp.text`**, so the operator saw an opaque `500` with no cause.

## Fix

`_create_conclusions` now delegates each batch to a new `_post_conclusions_batch`, which:

- **Retries** 5xx responses and `httpx.TransportError` with exponential backoff (`_RETRY_BASE_DELAY * 2**attempt`, up to `_CONCLUSION_MAX_RETRIES = 3` → 4 attempts). One transient embed blip no longer aborts a multi-thousand-item backfill.
- **Raises 4xx immediately** — permanent client errors are not retried.
- **Attaches `resp.text`** to every raised error, so the real cause (e.g. `503 npu.trio_unavailable`) reaches the operator instead of a bare `500`.

Function signature and batching (`_CONCLUSION_BATCH` chunks) unchanged. The migration already checkpoints (`state.mark_migrated`) so re-runs resume — this removes the need for a human to babysit a transient outage.

## Tests

Three new `MockTransport` tests in `tests/memory/test_honcho_migrate.py`:
- `test_create_conclusions_retries_transient_503_then_succeeds` — 503×2 then 201; migration completes, 3 POSTs, 2 backoff sleeps (patched).
- `test_create_conclusions_persistent_500_raises_with_body` — 500 on all attempts; raises, body substring present in the error, exactly 4 POSTs.
- `test_create_conclusions_4xx_raises_immediately_without_retry` — 422; raises, exactly 1 POST, no retries.

`tests/memory/test_honcho_migrate.py` → 11 passed. `ruff check` / `ruff format --check` clean.

## Context

This is issue 1 of 2 follow-ups from a live `migrate --to honcho` 500 incident (the migration itself completed after a manual NPU slot bounce). Issue 2 (the anchor-wedge root cause — a WARMING-staleness watchdog) is #1269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
