### PR TITLE
fix(slots): auto-recover a slot wedged in WARMING (stale-anchor watchdog)

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -173,6 +173,19 @@ _HEALTH_FAIL_STRIKES: int = 2
 # two while podman brings the container up — a warming slot must only be
 # flipped when the unit is *stably* down, never while a big model loads.
 _WARMING_INACTIVE_STRIKES: int = 3
+# WARMING-only staleness watchdog. /health is deliberately NOT probed while a
+# slot is WARMING (a large NPU/GGUF model can legitimately hold /health down
+# for minutes during a cold load — see ``_await_ready`` and its ceiling
+# ``providers.container._HEALTH_TIMEOUT_S`` = 180s per attempt), so a unit that
+# stays *active* forever while its model server never converges would otherwise
+# sit in WARMING indefinitely — 503ing every /v1/embeddings and NPU-trio
+# consumer with ``npu.trio_unavailable`` and never self-healing (a wedged FLM
+# NPU chat-anchor). This bound catches that: once a slot has been WARMING
+# longer than this, treat it as wedged and auto-recover (unload → load). It
+# MUST sit well ABOVE the legitimate cold-load ceiling so a slow-but-healthy
+# load is never demoted — 900s (15 min) is ~5x the 180s per-attempt health-wait
+# ceiling, comfortably clear of any real large-model load.
+_WARMING_STALE_AFTER_S: float = 900.0
 # Config-drift comparison keys. Spelling no longer needs to match the launch
 # renderer exactly: both sides of the comparison are canonicalized through
 # slots.argv.FLAG_ALIASES (so ``--batch-size`` in a running argv matches a
@@ -866,7 +879,40 @@ class SlotManager:
                         # the health probe entirely (a big-model load can hold
                         # /health down for minutes without being wedged).
                         health_failures = 0
-                        continue
+                        # …but an active unit whose model server never converges
+                        # would otherwise sit in WARMING forever, 503ing every
+                        # embed/STT consumer (a wedged FLM NPU anchor). Bound the
+                        # WARMING dwell: once it exceeds the cold-load ceiling,
+                        # treat the slot as wedged and auto-recover. WARMING →
+                        # STARTING is an illegal transition, so recovery is
+                        # unload → load (as ``restart()`` does), not a direct
+                        # reload.
+                        rec = self._states.get(slot_name)
+                        warming_elapsed = time.time() - rec.updated_at if rec is not None else 0.0
+                        if warming_elapsed <= _WARMING_STALE_AFTER_S:
+                            continue
+                        log.warning(
+                            "slot.fail_watch_warming_stale",
+                            extra={
+                                "slot": slot_name,
+                                "warming_elapsed_s": round(warming_elapsed, 1),
+                                "stale_after_s": _WARMING_STALE_AFTER_S,
+                            },
+                        )
+                        try:
+                            await self.unload(slot_name)
+                            await self.load(slot_name)
+                        except Exception as exc:
+                            log.warning(
+                                "slot.fail_watch_warming_recover_failed",
+                                extra={"slot": slot_name, "error": str(exc)},
+                            )
+                        # unload → load re-stamps ``updated_at`` (restarting the
+                        # staleness clock) and re-arms a fresh fail-watcher via
+                        # its own transitions, so this now-orphaned watcher
+                        # returns cleanly instead of racing the new one or
+                        # tight-looping recovery every tick.
+                        return
                     # #783/B4: active is necessary but not sufficient. Probe
                     # the model server's /health — a crashed/wedged server is
                     # active to systemd while /health fails, so an is-active-

--- a/tests/slots/test_fail_watcher_warming.py
+++ b/tests/slots/test_fail_watcher_warming.py
@@ -11,6 +11,7 @@ consecutive is-active failures flip the slot to ERROR.
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 from typing import Any
 
@@ -102,3 +103,79 @@ async def test_warming_slot_tolerates_a_transient_inactive_blip(
     await asyncio.sleep(0.5)
 
     assert sm._current_state("chat") == SlotState.WARMING
+
+
+def _spy_recovery(sm: SlotManager, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Record calls to sm.unload / sm.load while delegating to the originals."""
+    calls: list[tuple[str, str]] = []
+    orig_unload = sm.unload
+    orig_load = sm.load
+
+    async def spy_unload(name: str) -> Any:
+        calls.append(("unload", name))
+        return await orig_unload(name)
+
+    async def spy_load(name: str, model_id: str | None = None) -> Any:
+        calls.append(("load", name))
+        return await orig_load(name, model_id)
+
+    monkeypatch.setattr(sm, "unload", spy_unload)
+    monkeypatch.setattr(sm, "load", spy_load)
+    return calls
+
+
+async def test_warming_slot_with_fresh_timestamp_is_not_recovered(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A freshly-WARMING slot (active unit, /health still down) must NOT trip
+    the staleness watchdog — a slow cold load below the threshold is left alone.
+    """
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+    calls = _spy_recovery(sm, monkeypatch)
+
+    # Model server still loading: /health down, unit active, timestamp fresh.
+    container_stub.healthy = False
+    await asyncio.sleep(0.6)  # several poll intervals
+
+    assert calls == [], f"a fresh WARMING slot must not be recovered by the watchdog; got {calls}"
+    assert sm._current_state("chat") == SlotState.WARMING
+
+
+async def test_warming_slot_recovers_when_stale(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A WARMING slot stuck past _WARMING_STALE_AFTER_S (unit still active) is
+    auto-recovered via unload → load, self-healing the wedged anchor.
+    """
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+    assert "chat" in sm._fail_watchers
+    calls = _spy_recovery(sm, monkeypatch)
+
+    # On the reload, let the model converge so recovery lands in READY.
+    async def _wait_ok(port: int, timeout_s: float | None = None) -> None:
+        return None
+
+    container_stub.wait_ready = _wait_ok  # type: ignore[method-assign]
+
+    # Age the slot past the staleness ceiling (unit stays active throughout).
+    sm._states["chat"].updated_at = time.time() - mgr_mod._WARMING_STALE_AFTER_S - 1
+
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while asyncio.get_event_loop().time() < deadline:
+        if ("unload", "chat") in calls and ("load", "chat") in calls:
+            break
+        await asyncio.sleep(0.05)
+
+    assert ("unload", "chat") in calls, f"watchdog never unloaded wedged slot; {calls}"
+    assert ("load", "chat") in calls, f"watchdog never reloaded wedged slot; {calls}"
+    # unload must precede load (recovery order), and the reload converged.
+    assert calls.index(("unload", "chat")) < calls.index(("load", "chat"))
+    assert sm._current_state("chat") == SlotState.READY


### PR DESCRIPTION
## Problem

An `flm` NPU chat-anchor slot can adopt a container whose model server never becomes ready, and then sit **wedged in `WARMING` for hours** with a stale `updated_at` and no self-heal. Because `WARMING` is not dispatchable, every `/v1/embeddings` and NPU-trio call returns `503 npu.trio_unavailable` for the whole duration — silently breaking Honcho conclusion writes, Hindsight extraction, and every other embed consumer. The only fix was a manual `slot_unload <name>` + `slot_load <name>`.

### Why the existing fail-watcher misses it

`SlotManager._fail_watch_loop` deliberately **skips the `/health` probe while a slot is WARMING and its systemd unit is active** — a large NPU/GGUF model can legitimately hold `/health` down for minutes during a cold load (`_await_ready` / `_HEALTH_TIMEOUT_S = 180s` per attempt). It only strikes `WARMING → ERROR` after N consecutive *is-active=False* reads. A unit that stays **active forever** while the model server never converges hits neither path → indefinite WARMING with no bound. (Confirmed: no elapsed-time bound on WARMING existed anywhere.)

## Fix

Bound the WARMING dwell inside the existing per-slot fail-watcher (no new task/lifespan machinery):

- New tunable `_WARMING_STALE_AFTER_S = 900.0` (15 min). It **must** sit well above the legitimate cold-load ceiling (~5× the 180s per-attempt health-wait) — the whole reason `/health` is skipped during WARMING is to not demote a slow-but-healthy load.
- In the WARMING-active branch, compute `time.time() - rec.updated_at`. Under threshold → unchanged (slow cold loads left alone). Over threshold → log a warning and **auto-recover via `unload` → `load`**. `WARMING → STARTING` is an illegal transition, so a direct reload can't be used (this is exactly why the manual fix was unload+load).
- Recovery re-stamps `updated_at` and re-arms a fresh fail-watcher through its own transitions, so the now-orphaned watcher `return`s cleanly rather than racing the new one or tight-looping recovery every 2s tick.

## Tests

Two new tests in `tests/slots/test_fail_watcher_warming.py`:
- `test_warming_slot_with_fresh_timestamp_is_not_recovered` — fresh WARMING + active unit + failing `/health` → **not** recovered; existing slow-load behavior preserved.
- `test_warming_slot_recovers_when_stale` — `updated_at` aged past the threshold → watchdog drives `unload` then `load` and the slot converges to READY.

`tests/slots/test_fail_watcher_warming.py` → 6 passed; full `tests/slots` → 353 passed. `ruff check` / `ruff format --check` clean.

## Known follow-ups (out of scope here)

- **Surfacing:** the dispatcher still raises the generic `503 npu.trio_unavailable`; it could include the anchor's current slot state so a *wedged* anchor reads differently from a merely *loading* one (`src/hal0/dispatcher/npu_trio.py`). Skipped to avoid touching the dispatcher path.
- **Recovery-failure edge:** if `unload` itself throws, the watchdog logs and returns without re-arming — rare, and no worse than today's baseline, but a future revision could keep the watcher alive to retry.

## Context

This is issue 2 of 2 follow-ups from a live `migrate --to honcho` 500 incident — the **root cause** of that outage. Issue 1 (migration fragility — retry + surface the embed cause) is #1268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)