### PR TITLE
fix(mcp): unique approval id per gated tool call (fixes stuck operator-approval gate)

### DIFF
--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1000,10 +1000,12 @@ async def dispatch(
             "approval_id": approval_id,
             "detail": (
                 "queued for operator approval — the call runs only after the "
-                "operator approves it (inline chat card or top-bar bell). The "
-                "chat turn pauses while the operator decides; if you are "
-                "reading this, the wait timed out — tell the operator it is "
-                "still pending."
+                "operator approves it (top-bar bell / approvals inbox). This "
+                "response returns immediately; nothing waits on this transport, "
+                "so the outcome is NOT returned inline here. Tell the operator "
+                "the call is pending and, once they approve, the tool executes "
+                "out-of-band — re-check the result via slot/model/profile reads "
+                "rather than expecting it in this reply."
             ),
         }
 

--- a/src/hal0/mcp/approval_queue.py
+++ b/src/hal0/mcp/approval_queue.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import json
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -67,16 +69,39 @@ _PRIMARY_TARGET_ARG: dict[str, str] = {
 }
 
 
+def _hash_args(args: dict[str, Any]) -> str:
+    """Stable short digest of a full arg dict, for dedup fallback.
+
+    Canonicalises with ``sort_keys`` so key order can't split a genuine
+    retry into two rows, and ``default=str`` so any non-JSON value
+    (rare in tool args) still hashes rather than raising. Truncated —
+    collision risk across a per-process inbox is negligible.
+    """
+    canonical = json.dumps(args, sort_keys=True, default=str)
+    return hashlib.sha1(canonical.encode()).hexdigest()[:16]
+
+
 def _primary_target(tool: str, args: dict[str, Any]) -> str:
     """Return the dedup key suffix for a tool invocation.
 
-    Falls back to ``""`` when the tool has no registered primary arg —
-    that bucket then dedups all instances of that tool to a single
-    pending row, which is the conservative default.
+    For a tool with a registered primary arg, the dedup key is that
+    arg's value so retries of the same operation (``model_pull qwen3``)
+    collapse to one pending row even when incidental body fields differ.
+
+    For a tool WITHOUT a registered primary arg we fall back to a digest
+    of the *full* arg set — NOT ``""``. The empty-string fallback was a
+    collapse-all footgun: every distinct call to an unmapped gated tool
+    (``profile_delete{name=A}`` vs ``profile_delete{name=B}``, every
+    ``stack_*`` / ``upstream_*`` / ``profile_*`` op, …) shared the dedup
+    key ``(tool, "")`` and so the SAME approval_id, silently discarding
+    all but the first call's args. Approving then ran the wrong (first)
+    target. Hashing the args keeps true retries deduped while giving
+    distinct calls distinct approvals, and it self-maintains for any new
+    gated tool added without a primary-arg entry.
     """
     key = _PRIMARY_TARGET_ARG.get(tool)
     if key is None:
-        return ""
+        return _hash_args(args)
     value = args.get(key)
     if isinstance(value, list | tuple):
         return ",".join(sorted(str(v) for v in value))

--- a/tests/mcp/test_approval_queue.py
+++ b/tests/mcp/test_approval_queue.py
@@ -80,6 +80,94 @@ async def test_enqueue_distinct_targets_not_deduped() -> None:
 
 
 @pytest.mark.asyncio
+async def test_unmapped_tool_distinct_args_get_distinct_ids() -> None:
+    """Regression: gated tools with no registered primary-target arg
+    (``profile_delete``, ``stack_*``, ``upstream_*``, …) used to fall
+    back to a ``""`` dedup key, collapsing EVERY distinct call onto one
+    approval_id and silently discarding all but the first call's args.
+
+    Distinct targets must now mint distinct approvals so approving one
+    runs the operator's actual target, not the first-ever call's.
+    """
+    q = ApprovalQueue()
+    a = await q.enqueue(
+        tool="profile_delete",
+        args={"name": "profile-a"},
+        client_id="claude-code",
+        executor=_noop_executor,
+    )
+    b = await q.enqueue(
+        tool="profile_delete",
+        args={"name": "profile-b"},
+        client_id="claude-code",
+        executor=_noop_executor,
+    )
+    assert a != b, "distinct profile_delete targets collapsed onto one approval_id"
+    pending = q.list_pending()
+    assert len(pending) == 2
+    names = sorted(e["args"]["name"] for e in pending)
+    assert names == ["profile-a", "profile-b"]
+    assert all(e["hit_count"] == 1 for e in pending)
+
+
+@pytest.mark.asyncio
+async def test_unmapped_tool_identical_args_still_dedup() -> None:
+    """A genuine retry of an unmapped gated tool (identical args) should
+    still collapse to one row — the hash-of-args fallback keeps
+    retry-dedup working, only distinct args diverge."""
+    q = ApprovalQueue()
+    first = await q.enqueue(
+        tool="stack_delete",
+        args={"slug": "prod"},
+        client_id="claude-code",
+        executor=_noop_executor,
+    )
+    second = await q.enqueue(
+        tool="stack_delete",
+        args={"slug": "prod"},
+        client_id="claude-code",
+        executor=_noop_executor,
+    )
+    assert first == second
+    pending = q.list_pending()
+    assert len(pending) == 1
+    assert pending[0]["hit_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_unmapped_tool_approve_runs_correct_target() -> None:
+    """After the collapse fix, approving the second-target entry must run
+    the executor with THAT target's args — not the first call's."""
+    captured: list[dict[str, Any]] = []
+
+    async def _exec(args: dict[str, Any]) -> dict[str, Any]:
+        captured.append(dict(args))
+        return {"deleted": args.get("name")}
+
+    q = ApprovalQueue()
+    await q.enqueue(
+        tool="profile_delete",
+        args={"name": "keep-a"},
+        client_id="claude-code",
+        executor=_exec,
+    )
+    bid = await q.enqueue(
+        tool="profile_delete",
+        args={"name": "delete-b"},
+        client_id="claude-code",
+        executor=_exec,
+    )
+    result = await q.approve(bid)
+    assert result["state"] == "executed"
+    assert result["result"] == {"deleted": "delete-b"}
+    assert captured == [{"name": "delete-b"}]
+    # The other target is untouched and still pending.
+    still = q.list_pending()
+    assert len(still) == 1
+    assert still[0]["args"] == {"name": "keep-a"}
+
+
+@pytest.mark.asyncio
 async def test_approve_runs_executor_and_records_result() -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Problem
Gated `hal0-admin` MCP tools that lack a registered primary-arg (e.g. `profile_delete`, all `stack_*`/`upstream_*`/`profile_*`, `model_register/add/update`, `bench_*`, `logs_tail`, `slot_logs`) never execute their intended target. Every distinct call returns the **same** static `approval_id`, and approving it runs the *first* call's args (or errors), silently dropping the rest — a stuck, un-clearable gate. Surfaced live via `profile_delete` (reused id `111be7ac…`, approved-but-not-executed).

## Root cause
`approval_queue._primary_target()` returned `""` for any gated tool absent from `_PRIMARY_TARGET_ARG`, so the dedup key `(tool, "")` collapsed every distinct call of that tool onto one pending row (`enqueue()` bumps `hit_count` and returns the existing id). The surviving row carries only the first call's args. The approval channel itself is fine (single shared queue; dashboard approvals reach headless-queued entries) — the bug is dedup-key collapse. The misleading "chat turn pauses… timed out" `detail` is brain-chat language that's false on the headless MCP transport.

## Fix
- `approval_queue.py`: unmapped tools fall back to a stable `sha1(json.dumps(args, sort_keys=True))` digest instead of `""`. Distinct calls → distinct approvals; genuine retries (identical args) still dedup; self-maintaining for future gated tools. Mapped tools unchanged.
- `admin.py`: corrected the headless `pending_approval` detail (returns immediately, nothing waits, re-check via reads). board_chat overrides this on its own path, so inert there.
- `tests/mcp/test_approval_queue.py`: +3 regression tests.

## Tests
- On buggy base: the 2 distinct-id tests fail (collapse reproduced); retry-dedup passes both ways.
- With fix: `tests/mcp/test_approval_queue.py` 13 passed; related `tests/mcp/ tests/api/test_approvals.py tests/board/ tests/cli/test_agent_approvals_list.py` 327 passed; ruff clean.

## Not weakened
`POLICY_NO_LOOSEN` and gating are untouched — destructive ops still require approval.

## Follow-ups (not in this PR)
- Optional: give headless MCP a true round-trip result via an opt-in short server-side wait in dispatch (mirroring board_chat).
- A live zombie approval (`111be7ac…`) predates this fix on the running box; clears non-destructively via deny or an hal0-api restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)