### PR TITLE
feat(agents): add OpenCode as a bundled agent (hal0 provider + hindsight memory)

### DIFF
--- a/docs/guides/run-agents.mdx
+++ b/docs/guides/run-agents.mdx
@@ -51,6 +51,37 @@ hint rather than crashing mid-build.
 Pass `--switch` to atomically uninstall whatever agent is currently
 installed before installing this one.
 
+## Install OpenCode
+
+[OpenCode](https://opencode.ai) is a terminal coding agent with native
+OpenAI-compatible providers and MCP support. It's a lightweight alternative
+to Hermes — no managed venv, just a CLI plus a single JSON config.
+
+```sh
+hal0 agent install opencode
+```
+
+This runs `installer/agents/opencode.sh` (a track-latest `npm install -g
+opencode-ai`; no version pin per ADR-0004 §3) and writes
+`~/.config/opencode/opencode.json` wiring:
+
+- **Provider** — hal0 as an `@ai-sdk/openai-compatible` provider at
+  `$HAL0_API_URL/v1` (the hal0-api gateway), with the `hal0/*` slot virtuals
+  as the model set and `hal0/agent` as the default. The gateway
+  live-resolves to whichever slot is loaded — warm the slot you want first
+  (a cold slot returns `slot … is warming — not ready to serve`).
+- **Memory** — the hindsight-backed `hal0-memory` MCP mount
+  (`/mcp/memory/mcp`, agent-scoped via `X-hal0-Agent`).
+
+<Aside type="note">
+Single-pick still applies: OpenCode and Hermes can't both be the active
+on-box agent — use `--switch`, or run OpenCode on a **separate box/container**
+and export `HAL0_API_URL=http://<hal0-lan-ip>:8080` so it points at hal0 over
+the LAN. To also give a remote OpenCode the full 30-tool *native* hindsight
+MCP (loopback-only by default), LAN-expose `hindsight-api` and add an
+`mcp.hindsight` entry pointing at `http://<hal0-lan-ip>:9177/mcp`.
+</Aside>
+
 ## Manage the lifecycle
 
 <Tabs>

--- a/installer/agents/opencode.sh
+++ b/installer/agents/opencode.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# hal0 — opencode bundled-agent installer (ADR-0004 §6, sibling of pi-coder.sh).
+#
+# POSIX shell, dash-safe. Track-latest of the opencode CLI (NO version pin
+# per ADR-0004 §3; the nightly agent-shim smoke test catches upstream
+# breakage instead of freezing users on a stale release).
+#
+# opencode ([opencode.ai](https://opencode.ai)) is a terminal coding agent
+# with native OpenAI-compatible providers + MCP. Its whole hal0 wiring
+# (provider + memory MCP) lives in ~/.config/opencode/opencode.json, which
+# the Python driver (hal0.agents.opencode.driver) writes after this script
+# lands the binary — so this script only installs the CLI.
+#
+# Inputs (set by the driver; safe to override for manual invocation):
+#   HAL0_AGENT_DATA_DIR  per-agent data dir (default:
+#                        /var/lib/hal0/agents/opencode)
+#   HAL0_API_URL         hal0 API base URL (default: http://127.0.0.1:8080)
+#   HAL0_BEARER_TOKEN    Bearer token the driver wires into opencode.json
+#                        (this script does not consume it)
+#
+# Idempotent: re-runs cleanly. Stops at the first install step that
+# materially fails, emitting an actionable error so the operator (or the
+# nightly smoke test) can grep the upstream change.
+
+set -eu
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+info()  { printf '[opencode] %s\n' "$*"; }
+warn()  { printf '[opencode] WARN: %s\n' "$*" >&2; }
+die()   { printf '[opencode] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+HAL0_AGENT_DATA_DIR="${HAL0_AGENT_DATA_DIR:-/var/lib/hal0/agents/opencode}"
+HAL0_API_URL="${HAL0_API_URL:-http://127.0.0.1:8080}"
+
+mkdir -p "$HAL0_AGENT_DATA_DIR"
+
+# ── Install opencode CLI upstream (track-latest) ─────────────────────────────
+#
+# Upstream distribution: `opencode-ai` on npm. Binary: `opencode`. NO
+# version pin (ADR-0004 §3). No cargo path — upstream ships a JS package
+# (and a standalone installer at https://opencode.ai/install, used as the
+# fallback when npm is unavailable).
+
+install_opencode() {
+    if command -v npm >/dev/null 2>&1; then
+        info "Installing opencode-ai via npm (track-latest)"
+        npm install -g opencode-ai \
+            || die "npm install -g opencode-ai failed — upstream may have renamed; check https://opencode.ai/docs"
+    elif command -v curl >/dev/null 2>&1; then
+        info "npm not found — installing opencode via the official installer"
+        curl -fsSL https://opencode.ai/install | bash \
+            || die "opencode installer failed — check https://opencode.ai/docs"
+    else
+        die "neither npm nor curl found on PATH. Install Node.js (https://nodejs.org/) first."
+    fi
+}
+
+install_opencode
+
+# ── Verify the binary landed ─────────────────────────────────────────────────
+if command -v opencode >/dev/null 2>&1; then
+    info "opencode installed: $(opencode --version 2>/dev/null | head -1)"
+else
+    warn "opencode not on PATH after install — the CLI may live under ~/.opencode/bin; ensure it is on PATH."
+fi
+
+info "CLI ready. The driver now writes ~/.config/opencode/opencode.json (hal0 provider + memory MCP)."
+info "hal0 API target: ${HAL0_API_URL}"

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -85,7 +85,7 @@ HermesNotHal0AwareError = HermesUpstreamMissingError
 
 # ── Bundled catalog ──────────────────────────────────────────────────────────
 
-BUNDLED_AGENTS: tuple[str, ...] = ("pi-coder", "hermes")
+BUNDLED_AGENTS: tuple[str, ...] = ("pi-coder", "opencode", "hermes")
 """Canonical names for bundled agents. Adding to this list requires a
 matching driver module + ``installer/agents/<name>.sh``."""
 
@@ -165,6 +165,10 @@ def _driver_for(name: str) -> AgentDriver:
         from hal0.agents.pi_coder import PiCoderDriver
 
         return PiCoderDriver()
+    if name == "opencode":
+        from hal0.agents.opencode import OpenCodeDriver
+
+        return OpenCodeDriver()
     if name == "hermes":
         from hal0.agents.hermes import HermesDriver
 

--- a/src/hal0/agents/opencode/__init__.py
+++ b/src/hal0/agents/opencode/__init__.py
@@ -1,0 +1,7 @@
+"""opencode bundled agent (ADR-0004 §6). See :mod:`.driver` for details."""
+
+from __future__ import annotations
+
+from hal0.agents.opencode.driver import OpenCodeDriver
+
+__all__ = ["OpenCodeDriver"]

--- a/src/hal0/agents/opencode/driver.py
+++ b/src/hal0/agents/opencode/driver.py
@@ -1,0 +1,164 @@
+"""opencode bundled-agent driver (ADR-0004 §6, sibling of pi-coder).
+
+[OpenCode](https://opencode.ai) is a terminal coding agent with native
+OpenAI-compatible providers + MCP support. Unlike pi-coder — whose model
+autodiscovery and memory ride vendored TypeScript extensions — opencode's
+whole hal0 wiring lives in a single JSON config, so this driver only:
+
+1. Runs ``installer/agents/opencode.sh`` (track-latest npm install of the
+   ``opencode-ai`` CLI; NO version pin per ADR-0004 §3 — the nightly smoke
+   catches upstream breakage).
+2. Writes ``~/.config/opencode/opencode.json`` wiring:
+   - **Provider** — hal0 as an ``@ai-sdk/openai-compatible`` provider at
+     ``HAL0_API_URL/v1`` (the hal0-api gateway, ``discover_models``), with
+     the ``hal0/*`` slot virtuals as the model picker set and ``hal0/agent``
+     as the default. Live-resolves whatever slots are loaded.
+   - **Memory** — the hindsight-backed ``hal0-memory`` MCP mount
+     (``<api>/mcp/memory/mcp``, 5 tools: add/search/recall/list/delete),
+     the same LAN-reachable surface hermes uses, scoped by the
+     ``X-hal0-Agent`` header. The 30-tool *native* hindsight MCP is
+     loopback-only by default (see ``/etc/hal0/mcp-servers/hindsight.toml``)
+     and is intentionally NOT wired here — operators who LAN-expose it can
+     add an ``mcp.hindsight`` entry by hand.
+
+Idempotent: every write is an atomic tmp+rename overwrite. ``HAL0_API_URL``
+is honoured the same way the CLI does, so a remote install (opencode in its
+own container/box) points at hal0 over the LAN by exporting it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404 — required for shim
+from pathlib import Path
+from typing import Any
+
+from hal0.agents.manager import AgentDriver, AgentError, installer_script_path
+from hal0.config import paths as _paths
+
+# 127.0.0.1 mirrors pi-coder's default: the bundled-agent path runs on the
+# hal0 box; remote installs override via HAL0_API_URL.
+_HAL0_API_BASE_DEFAULT = "http://127.0.0.1:8080"
+
+# hal0-api's stable slot virtuals (served on /v1 regardless of which
+# physical slot is loaded). Kept as the opencode model picker set so the
+# config is deterministic; the gateway live-resolves to the active slot.
+_HAL0_MODELS: tuple[str, ...] = ("agent", "code", "brain", "flm", "nano", "ops", "utility")
+
+# Dev-mode sentinel: hal0-api runs auth-disabled by default, but opencode
+# still treats a provider as requiring a key, so we always write one.
+_DEV_API_KEY = "hal0-local"
+
+
+def _api_base() -> str:
+    """Honour HAL0_API_URL the same way the CLI does."""
+    return os.environ.get("HAL0_API_URL", _HAL0_API_BASE_DEFAULT).rstrip("/")
+
+
+class OpenCodeDriver(AgentDriver):
+    """Driver for the opencode bundled agent."""
+
+    name = "opencode"
+
+    def __init__(self, *, runner: object | None = None) -> None:
+        # Tests inject a fake subprocess module to assert correct argv +
+        # avoid spawning a real shell / npm / network.
+        self._runner = runner if runner is not None else subprocess
+
+    # ── AgentDriver protocol ────────────────────────────────────────────
+
+    def install(self, *, bearer_token: str | None = None) -> None:
+        script = installer_script_path(self.name)
+        if not script.is_file():
+            raise AgentError(
+                f"installer script missing at {script}. This hal0 install looks "
+                "packaged without the bundled-agent scripts — reinstall hal0 from "
+                "a release tarball or git clone."
+            )
+
+        env = os.environ.copy()
+        data_dir = self._data_dir()
+        data_dir.mkdir(parents=True, exist_ok=True)
+        env["HAL0_AGENT_DATA_DIR"] = str(data_dir)
+        env["HAL0_API_URL"] = _api_base()
+        if bearer_token:
+            env["HAL0_BEARER_TOKEN"] = bearer_token
+
+        try:
+            self._runner.run(  # type: ignore[attr-defined]
+                ["bash", str(script)],
+                env=env,
+                check=True,
+            )
+        except Exception as exc:  # subprocess.CalledProcessError or others
+            raise AgentError(
+                f"opencode install failed ({type(exc).__name__}: {exc}). "
+                "Upstream opencode may have shipped a breaking change — the "
+                "nightly smoke test exists to catch this; check "
+                "https://github.com/Hal0ai/hal0/actions for the latest run."
+            ) from exc
+
+        # Provider + memory MCP wiring — a single source-of-truth JSON so we
+        # have full control over the shape.
+        self._write_config(bearer_token=bearer_token)
+
+    def uninstall(self) -> None:
+        # opencode's config is hal0-authored data, always safe to remove.
+        cfg = self._config_path()
+        if cfg.exists():
+            cfg.unlink()
+
+    def status(self) -> str:
+        """Return ``"installed"`` when the hal0 opencode config is present."""
+        return "installed" if self._config_path().exists() else "broken"
+
+    # ── config helpers ──────────────────────────────────────────────────
+
+    def _data_dir(self) -> Path:
+        return _paths.var_lib() / "agents" / self.name
+
+    def _config_path(self) -> Path:
+        # opencode reads global config from XDG ``~/.config/opencode/``.
+        return Path.home() / ".config" / "opencode" / "opencode.json"
+
+    def _write_config(self, *, bearer_token: str | None) -> None:
+        """Atomic write of opencode.json — provider (hal0 slots) + the
+        hindsight-backed hal0-memory MCP. Overwriting is the idempotent
+        path."""
+        api = _api_base()
+
+        headers: dict[str, str] = {"X-hal0-Agent": self.name}
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+
+        config: dict[str, Any] = {
+            "$schema": "https://opencode.ai/config.json",
+            "model": "hal0/agent",
+            "provider": {
+                "hal0": {
+                    "npm": "@ai-sdk/openai-compatible",
+                    "name": "hal0 (hal0-api gateway)",
+                    "options": {
+                        "baseURL": f"{api}/v1",
+                        "apiKey": bearer_token or _DEV_API_KEY,
+                    },
+                    "models": {model: {"name": model} for model in _HAL0_MODELS},
+                }
+            },
+            "mcp": {
+                "hal0-memory": {
+                    "type": "remote",
+                    "url": f"{api}/mcp/memory/mcp",
+                    "enabled": True,
+                    "headers": headers,
+                    "timeout": 30000,
+                }
+            },
+        }
+
+        cfg = self._config_path()
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        tmp = cfg.with_suffix(".tmp")
+        tmp.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        tmp.replace(cfg)

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -57,7 +57,7 @@ app.add_typer(personas_app, name="personas")
 
 @app.command("install")
 def agent_install(
-    name: str = typer.Argument(..., help="Bundled agent name (pi-coder | hermes)."),
+    name: str = typer.Argument(..., help="Bundled agent name (pi-coder | opencode | hermes)."),
     switch: bool = typer.Option(
         False,
         "--switch",

--- a/tests/agents/test_opencode_shim.py
+++ b/tests/agents/test_opencode_shim.py
@@ -1,0 +1,161 @@
+"""Unit tests for hal0.agents.opencode.OpenCodeDriver.
+
+Asserts the shim invokes ``installer/agents/opencode.sh`` with the right
+argv/env and writes ``~/.config/opencode/opencode.json`` wiring hal0 as an
+OpenAI-compatible provider plus the hindsight-backed ``hal0-memory`` MCP
+mount. Subprocess is faked so the suite stays hermetic (no npm / network).
+
+opencode's config tree is resolved from ``Path.home()`` per call (see
+driver.py) — the ``oc_home`` fixture redirects ``HOME`` to a temp dir so
+these tests never touch the real operator home.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.agents.opencode import OpenCodeDriver
+
+# ── Fake subprocess ──────────────────────────────────────────────────────────
+
+
+class _FakeCompleted:
+    returncode = 0
+
+
+class _FakeRunner:
+    """Replaces ``subprocess`` for the driver. Records every ``run()`` call
+    so tests can assert on argv + env without spawning a real shell."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._fail = fail
+
+    def run(
+        self,
+        argv: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        check: bool = False,
+    ) -> _FakeCompleted:
+        self.calls.append({"argv": list(argv), "env": dict(env or {}), "check": check})
+        if self._fail:
+            raise RuntimeError("fake subprocess failure")
+        return _FakeCompleted()
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def oc_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect Path.home() to a temp dir for the duration of the test."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def driver(tmp_hal0_home: str, oc_home: Path) -> OpenCodeDriver:
+    """Driver with the default subprocess module — overridden per-test via
+    ``driver._runner = ...`` when subprocess assertions matter.
+
+    ``tmp_hal0_home`` (autouse via the project conftest) routes
+    ``/var/lib/hal0`` + ``/etc/hal0`` under tmp_path; ``oc_home`` does the
+    same for opencode's ``~/.config/opencode`` tree.
+    """
+    return OpenCodeDriver()
+
+
+def _config_path(oc_home: Path) -> Path:
+    return oc_home / ".config" / "opencode" / "opencode.json"
+
+
+# ── install: subprocess + env ────────────────────────────────────────────────
+
+
+def test_install_invokes_installer_script_with_correct_argv(driver: OpenCodeDriver) -> None:
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.install(bearer_token="hal0_tok_xyz")
+
+    bash_calls = [c for c in runner.calls if c["argv"][0] == "bash"]
+    assert len(bash_calls) == 1
+    argv = bash_calls[0]["argv"]
+    assert argv[1].endswith("/installer/agents/opencode.sh")
+    env = bash_calls[0]["env"]
+    assert env["HAL0_BEARER_TOKEN"] == "hal0_tok_xyz"
+    assert env["HAL0_AGENT_DATA_DIR"].endswith("/agents/opencode")
+    assert env["HAL0_API_URL"].startswith("http")
+
+
+def test_install_writes_provider_and_memory_mcp(driver: OpenCodeDriver, oc_home: Path) -> None:
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token="hal0_tok_xyz")
+
+    cfg_path = _config_path(oc_home)
+    assert cfg_path.exists()
+    cfg = json.loads(cfg_path.read_text())
+
+    # hal0 provider (OpenAI-compatible) with the slot virtuals + default model.
+    assert cfg["model"] == "hal0/agent"
+    prov = cfg["provider"]["hal0"]
+    assert prov["npm"] == "@ai-sdk/openai-compatible"
+    assert prov["options"]["baseURL"].endswith("/v1")
+    assert prov["options"]["apiKey"] == "hal0_tok_xyz"
+    assert "agent" in prov["models"] and "code" in prov["models"]
+
+    # hindsight-backed memory MCP, agent-scoped, bearer wired when present.
+    mem = cfg["mcp"]["hal0-memory"]
+    assert mem["type"] == "remote"
+    assert mem["url"].endswith("/mcp/memory/mcp")
+    assert mem["headers"]["X-hal0-Agent"] == "opencode"
+    assert mem["headers"]["Authorization"] == "Bearer hal0_tok_xyz"
+
+
+def test_install_dev_mode_uses_sentinel_key_and_no_auth_header(
+    driver: OpenCodeDriver, oc_home: Path
+) -> None:
+    """No bearer token (auth-disabled dev install) → sentinel api key and no
+    Authorization header on the memory mount."""
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    driver.install(bearer_token=None)
+
+    cfg = json.loads(_config_path(oc_home).read_text())
+    assert cfg["provider"]["hal0"]["options"]["apiKey"] == "hal0-local"
+    assert "Authorization" not in cfg["mcp"]["hal0-memory"]["headers"]
+
+
+def test_install_propagates_installer_failure(driver: OpenCodeDriver) -> None:
+    from hal0.agents.manager import AgentError
+
+    driver._runner = _FakeRunner(fail=True)  # type: ignore[assignment]
+    with pytest.raises(AgentError):
+        driver.install(bearer_token="tok")
+
+
+def test_status_and_uninstall_roundtrip(driver: OpenCodeDriver, oc_home: Path) -> None:
+    driver._runner = _FakeRunner()  # type: ignore[assignment]
+    assert driver.status() == "broken"  # nothing written yet
+
+    driver.install(bearer_token="tok")
+    assert driver.status() == "installed"
+    assert _config_path(oc_home).exists()
+
+    driver.uninstall()
+    assert not _config_path(oc_home).exists()
+    assert driver.status() == "broken"
+
+
+def test_registered_as_bundled_agent() -> None:
+    from hal0.agents.manager import BUNDLED_AGENTS, _driver_for
+
+    assert "opencode" in BUNDLED_AGENTS
+    drv = _driver_for("opencode")
+    assert drv.name == "opencode"


### PR DESCRIPTION
Adds **OpenCode** ([opencode.ai](https://opencode.ai)) as a third bundled agent alongside `hermes` and `pi-coder`. Lighter than Hermes — no managed venv, just a track-latest npm CLI plus a single JSON config.

## What it does
`hal0 agent install opencode` runs `installer/agents/opencode.sh` (track-latest `npm i -g opencode-ai`, curl-installer fallback; **no version pin** per ADR-0004 §3), then `OpenCodeDriver` writes `~/.config/opencode/opencode.json`:

- **Provider** — hal0 as an `@ai-sdk/openai-compatible` provider at `$HAL0_API_URL/v1` (the hal0-api gateway), `hal0/*` slot virtuals as the model set, default `hal0/agent`.
- **Memory** — the hindsight-backed `hal0-memory` MCP mount (`/mcp/memory/mcp`), agent-scoped via `X-hal0-Agent`.

`HAL0_API_URL` is honoured like the CLI, so OpenCode can run on a **separate box/container** pointed at hal0 over the LAN (useful given single-pick — only one on-box agent at a time).

## Why
The pi-coder path is fragile on current upstream `pi` (extension API drift, cold-slot hangs). OpenCode has native OpenAI-compatible providers + MCP and proved robust against hal0's gateway in testing — a clean, low-maintenance local-agent option.

## Notes
- The **native 30-tool hindsight MCP is loopback-only by default**, so the driver wires only the LAN-reachable 5-tool memory mount. Operators who LAN-expose `hindsight-api` add an `mcp.hindsight` entry by hand (documented in the guide).
- Follows ADR-0004 §3 track-latest; the nightly agent-shim smoke should gain an `opencode` lane in a follow-up.

## Changes
- `src/hal0/agents/opencode/{__init__,driver}.py` — `OpenCodeDriver` (mirrors the pi-coder shim)
- `installer/agents/opencode.sh` — POSIX installer
- `manager.py` — register `opencode` in `BUNDLED_AGENTS` + `_driver_for`
- `agent_commands.py` — install help lists `opencode`
- `docs/guides/run-agents.mdx` — Install OpenCode section
- `tests/agents/test_opencode_shim.py` — argv/env, config shape, dev-mode key, installer-failure, status/uninstall roundtrip, registration

## Test
`ruff check`/`format --check` clean; new shim tests + `tests/cli/test_agent_*` green locally. (The 2 `test_hermes_provision` preflight failures in my sandbox are pre-existing/environmental — they fail on pristine `main` too, and are untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)