### PR TITLE
feat(memory): dry-run item-count preview on unconfirmed bank delete (#1024)

### DIFF
--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -275,6 +275,33 @@ async def bank_subgraph(request: Request, bank_id: str) -> dict[str, Any]:
 # and/or a JSON body ``{"confirm": ...}``. Registered before the _FORWARDS loop
 # so the guarded route owns the verb; only forwards once confirmation matches.
 
+#: #1024 dry-run preview: bank-stats keys carrying stored-item counts. Best
+#: effort — Hindsight versions differ, so absent keys are simply omitted.
+_PREVIEW_COUNT_KEYS = ("memory_count", "document_count", "entity_count")
+
+
+async def _delete_preview(client: Any, bank_id: str) -> dict[str, Any]:
+    """Fail-soft blast-radius preview for a bank delete (#1024).
+
+    Returns ``{bank_id, item_count, counts, stats_available}`` so the confirm
+    dialog can show *how much* a wipe would destroy before the operator echoes
+    the id back. ``item_count`` is the headline memory-unit count when known.
+    The stats probe is a convenience, never a gate: any failure degrades to
+    ``stats_available=False`` and the request is still rejected loudly below.
+    """
+    preview: dict[str, Any] = {"bank_id": bank_id, "item_count": None, "stats_available": False}
+    try:
+        stats = await client.request_json("GET", f"/v1/default/banks/{bank_id}/stats")
+    except Exception:
+        return preview
+    if not isinstance(stats, dict):
+        return preview
+    counts = {k: stats[k] for k in _PREVIEW_COUNT_KEYS if isinstance(stats.get(k), int)}
+    preview["stats_available"] = True
+    preview["counts"] = counts
+    preview["item_count"] = counts.get("memory_count")
+    return preview
+
 
 @router.delete("/banks/{bank_id}")
 async def delete_bank(request: Request, bank_id: str) -> Any:
@@ -285,10 +312,14 @@ async def delete_bank(request: Request, bank_id: str) -> Any:
     if confirm is None and isinstance(body, dict):
         confirm = body.get("confirm")
     if confirm != bank_id:
+        # #1024: return a dry-run preview (bank id + item counts) instead of a
+        # bare rejection so operators see the blast radius. Status stays 400 and
+        # the DELETE is NOT forwarded — the echoed-id confirm is still required.
+        preview = await _delete_preview(client, bank_id)
         raise BadRequest(
             f"confirm={bank_id} required to delete bank {bank_id}",
             code="memory.confirm_required",
-            details={"bank_id": bank_id},
+            details={"bank_id": bank_id, "requires_confirm": True, "preview": preview},
         )
     log.warning("memory_admin: deleting bank %r (confirmed)", bank_id)
     # #1024 hardening: every confirmed destructive op lands in the audit store

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -224,22 +224,62 @@ def test_bank_create_put_and_delete_forward(client: TestClient, recorder: _Recor
     assert recorder.requests[-1]["path"] == "/v1/default/banks/scratch"
 
     # Bank deletion is guarded: without a matching ?confirm= it is rejected
-    # (400) and NOT forwarded upstream.
-    before = len(recorder.requests)
+    # (400) with a dry-run preview, and the DELETE is NOT forwarded upstream
+    # (a read-only stats probe for the preview is allowed).
     r = client.delete("/api/memory/banks/scratch")
     assert r.status_code == 400
-    assert len(recorder.requests) == before
+    details = r.json()["error"]["details"]
+    assert details["bank_id"] == "scratch" and details["requires_confirm"] is True
+    assert details["preview"]["bank_id"] == "scratch"
+    assert not any(rq["method"] == "DELETE" for rq in recorder.requests)
 
-    # Mismatched confirmation is likewise rejected.
+    # Mismatched confirmation is likewise rejected without forwarding a DELETE.
     r = client.delete("/api/memory/banks/scratch?confirm=other")
     assert r.status_code == 400
-    assert len(recorder.requests) == before
+    assert not any(rq["method"] == "DELETE" for rq in recorder.requests)
 
     # Matching confirmation forwards the DELETE.
     r = client.delete("/api/memory/banks/scratch?confirm=scratch")
     assert r.status_code == 200
     assert recorder.requests[-1]["method"] == "DELETE"
     assert recorder.requests[-1]["path"] == "/v1/default/banks/scratch"
+
+
+def test_unconfirmed_bank_delete_returns_stats_preview(
+    client: TestClient, recorder: _Recorder
+) -> None:
+    """#1024: an unconfirmed bank delete surfaces a dry-run item-count preview."""
+    recorder.respond(
+        "GET",
+        "/v1/default/banks/scratch/stats",
+        200,
+        {"memory_count": 42, "document_count": 7, "entity_count": 3, "unrelated": "x"},
+    )
+    r = client.delete("/api/memory/banks/scratch")
+    assert r.status_code == 400
+    preview = r.json()["error"]["details"]["preview"]
+    assert preview["stats_available"] is True
+    assert preview["item_count"] == 42
+    assert preview["counts"] == {"memory_count": 42, "document_count": 7, "entity_count": 3}
+    # The rejection still forwarded no DELETE upstream.
+    assert not any(rq["method"] == "DELETE" for rq in recorder.requests)
+
+
+def test_unconfirmed_bank_delete_preview_failsoft_when_stats_unreachable(
+    recorder: _Recorder,
+) -> None:
+    """The preview degrades gracefully when the stats probe fails — still 400."""
+    recorder.fail_connect = True
+    transport = httpx.MockTransport(recorder.handler)
+    http = httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177")
+    rest = HindsightRestClient(http_client=http, api_key="hal0-local-noauth")
+    app = _build_app(_HindsightStubProvider(rest))
+    with TestClient(app) as c:
+        r = c.delete("/api/memory/banks/scratch")
+    assert r.status_code == 400
+    preview = r.json()["error"]["details"]["preview"]
+    assert preview["stats_available"] is False
+    assert preview["item_count"] is None
 
 
 def test_operation_retry_and_consolidate_forward(client: TestClient, recorder: _Recorder) -> None:


### PR DESCRIPTION
## Context — team MEMORY & DURABILITY bones review (v0.9.7.1)

Audit assigned three durability gaps. On investigation, **all three were already closed and green on `main` (e9639de1)**:

1. **pgvector degrade safety (audit 4.3)** — `PgVectorProvider.degraded=True`, WARN on construction + first write, and `/api/status` exposes `memory_degraded`. Covered by `tests/memory/test_pgvector_degrade_safety.py` + `tests/api/test_memory_degraded_status.py`.
2. **unguarded memory delete (#1024)** — `DELETE /api/memory/banks/{id}` already requires an **echoed** `?confirm=<bank_id>` (stronger than the audit's proposed `confirm=true`) and is audited via `record_action`.
3. **model-pull job persistence (audit 4.2)** — already disk-mirrored via `hal0.registry.pull` (`persist_pull_job` / `pull_job_file` / `list_persisted_jobs` + startup reconcile). Covered by `test_pull_routes.py` / `test_pull_shutdown.py`.

## What this PR adds

The one genuine remaining sub-gap from #1024: the **dry-run preview**. Previously an unconfirmed bank delete returned a bare 400 (bank id only). Now it returns a fail-soft preview with item counts (memory/document/entity) so operators see the blast radius before echoing the id back.

- Status stays **400**, echo-confirm guard **unchanged**, DELETE **never forwarded** on rejection.
- Stats probe is fail-soft: degrades to `stats_available=false` if Hindsight is unreachable — a convenience, never a gate.
- Two new tests (preview content + fail-soft path); existing delete/audit tests updated to assert "no DELETE forwarded" rather than "zero upstream calls".

## Test
`pytest tests/memory/ tests/api/test_memory_admin_routes.py tests/api/test_memory_rest_routes.py tests/api/test_pull_routes.py tests/api/test_pull_shutdown.py tests/api/test_memory_degraded_status.py` → **199 passed**. `ruff check src tests` clean.

Ref #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)