### PR TITLE
fix(cli+update): editable-install refusal, footgun gates, command consolidation

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -31,7 +31,7 @@ directly so they work without a running daemon.
 |---|---|---|
 | `hal0 --version` / `-V` | Print the version and exit. | — |
 | `hal0 status` | System + slot summary (name, version, slot/upstream counts, slot table). | — |
-| `hal0 probe` | Re-run hardware detection (`POST /api/hardware/probe`) and update `hardware.json`. | — |
+| `hal0 probe` | **[Deprecated]** hidden alias for `hal0 config hardware --refresh` — re-runs hardware detection (`POST /api/hardware/probe`) and updates `hardware.json`. | — |
 | `hal0 setup` | First-run (or re-run) provisioning: seed slots, pull starter models, wire extensions. See the section below. | `--auto`, `--storage-dir`, `--no-pull`, `--no-extensions` |
 | `hal0 serve` | Start the hal0 API server (used by `hal0-api.service`). | `--host` (default `127.0.0.1`), `--port` (default `8080`), `--reload` |
 | `hal0 update` | Check, apply, or roll back an update (thin client over `/api/updates/*`). | `--check`, `--rollback`, `--channel {stable\|nightly}`, `--target VER`, `--yes`/`-y`, `--restart-slots`, `--source {release\|git}` |
@@ -99,6 +99,8 @@ hal0 setup --auto --no-pull --no-extensions
 | `slot edit <name>` | Update one or more slot config fields. | `--model`/`-m`, `--port`/`-p`, `--ctx-size`, `--provider`, `--hardware` |
 | `slot delete <name>` | Delete a slot (stops the unit, removes config). | `--force`/`-f` |
 | `slot logs <name>` | Print or follow slot logs. | `--follow`/`-f`, `--lines`/`-n` (default 200) |
+| `slot metrics [name]` | Live per-slot runtime metrics (tok/s, KV%, mem, uptime, queue depth). Omit `name` for all slots. | `--json` |
+| `slot capacity` | Per-slot resident memory + the `[slots].max_slots` budget. | `--json` |
 
 `slot create` flags:
 
@@ -153,13 +155,14 @@ default.
 | `model list` | List registry + upstream models. | `--json` |
 | `model show <ref>` | Show a model's metadata. | `--json` |
 | `model pull <ref>` | Download a model from Hugging Face into the registry (with progress). | — |
-| `model add <path>` | Register an already-downloaded file; id/capabilities auto-detected from the header. | `--id`, `--name`, `--overwrite` |
+| `model add <path>` | Register an already-downloaded file; id/capabilities auto-detected from the header. | `--id`, `--name`, `--license`, `--overwrite` |
 | `model scan` | Walk the configured roots + store and register new files (no api restart needed). | — |
 | `model store [path]` | Show — or change — the single directory hal0 pulls to, scans, and mounts into slots. | `--migrate` |
 | `model run <ref>` | Assign to a slot, load it, and wait until it serves — the one-command first-run path. | `--slot`/`-s`, `--timeout` |
-| `model register <id>` | Register a model already on disk (explicit id; prefer `model add`). | `--path`/`-p` (required), `--name`, `--license` |
 | `model rm <ref>` | Remove a model from the registry. | `--force`/`-f` |
-| `model assign <ref>` | Assign a model to a slot's default (does not load). | `--slot`/`-s` (required) |
+| `model import-backup <path>` | Restore `registry.toml` from a v0.1.x backup tarball (disaster recovery). | `--force`/`-f`, `--dest` |
+| `model register <id>` | **[Deprecated]** hidden alias for `model add` — its `--id`/`--name`/`--license` flags are folded into `add`. | `--path`/`-p` (required), `--name`, `--license` |
+| `model assign <ref>` | **[Deprecated]** hidden alias for `slot edit --model` (same `PUT /api/slots/{slot}/config` endpoint). | `--slot`/`-s` (required) |
 
 `model pull` accepts a curated alias (e.g. `qwen3-4b`) or a registered model
 id. It starts a background pull on the daemon and polls
@@ -188,7 +191,8 @@ NPU/FLM store directory — and names the exact fix command for each finding.
 | `upstream update <name>` | Partial update: settings, toggles, model filters. | `--url`, `--auth-style`, `--auth-header`, `--auth-env`, `--timeout`, `--advertise-models/--hide-models`, `--enabled/--disabled`, `--model`, `--include`, `--exclude`, `--clear-filters` |
 | `upstream delete <name>` | Remove a remote upstream (credential in `api.env` is retained). | `--force`/`-f` |
 | `upstream test <name>` | Probe reachability + auth; prints latency and model count. | — |
-| `upstream set-credentials <name>` | Write the provider's API key to `api.env` (hidden prompt). | `--key`, `--env-var` |
+| `upstream credentials set <name>` | Write the provider's API key to `api.env` (hidden prompt). | `--key`, `--env-var` |
+| `upstream set-credentials <name>` | **[Deprecated]** hidden alias for `upstream credentials set`. | `--key`, `--env-var` |
 
 `upstream create` with `--catalog openrouter` (or `anthropic`, `openai`,
 `google_ai_studio`, `ollama`) prefills the URL and auth style from the
@@ -227,15 +231,24 @@ the walkthrough.
 
 ## `hal0 registry` — registry repair
 
+<Aside type="note">
+`hal0 registry import` is a **deprecated hidden alias** for `hal0 model
+import-backup` (the `model` group already owns registry CRUD, and a
+standalone `registry` group holding one verb collided in name with it).
+The `registry` group itself now exposes nothing in `--help`; the command
+below still works for existing scripts.
+</Aside>
+
 | Command | Purpose | Key options |
 |---|---|---|
-| `registry import <path>` | Restore `registry.toml` from a v0.1.x backup tarball. | `--force`/`-f`, `--dest` |
+| `registry import <path>` | Restore `registry.toml` from a v0.1.x backup tarball. Prefer `hal0 model import-backup <path>`. | `--force`/`-f`, `--dest` |
 
-`registry import` extracts the backup into a tempdir (with path-traversal
-protection), locates `registry.toml`, and atomically copies it to the
-canonical path. It refuses to overwrite an existing registry unless `--force`
-is set. Only the registry is restored — slot selections, `capabilities.toml`,
-and per-slot TOMLs are **not** migrated (v0.1.x → v0.2 is a clean break).
+`registry import` (and its canonical form, `model import-backup`) extracts the
+backup into a tempdir (with path-traversal protection), locates
+`registry.toml`, and atomically copies it to the canonical path. It refuses to
+overwrite an existing registry unless `--force` is set. Only the registry is
+restored — slot selections, `capabilities.toml`, and per-slot TOMLs are **not**
+migrated (v0.1.x → v0.2 is a clean break).
 
 ## `hal0 memory` — memory + graph extraction
 
@@ -311,16 +324,20 @@ either way. See [Enable memory](/docs/guides/enable-memory).
 
 ## `hal0 config` — configuration
 
-| Command | Purpose |
-|---|---|
-| `config show` | Print `hal0.toml` from disk. |
-| `config edit` | Open `hal0.toml` in `$EDITOR` (then `$VISUAL`, then `vi`). |
-| `config migrate` | Migrate `hal0.toml` forward to the latest config schema version. |
-| `config validate` | Validate `hal0.toml`, `upstreams.toml`, and `providers.toml` against the schema. |
-| `config reload` | Ask the running daemon to re-read its TOML configs (`POST /api/settings/reload`). |
-| `config hardware` | Show the cached hardware probe payload (`GET /api/hardware`). |
+| Command | Purpose | Key options |
+|---|---|---|
+| `config show [which]` | Print a config file from disk (`hal0`, `upstreams`, or `providers`; default `hal0`). | — |
+| `config edit [which]` | Open a config file in `$EDITOR` (then `$VISUAL`, then `vi`); same file choices as `show`. | — |
+| `config migrate` | Migrate `hal0.toml` forward to the latest config schema version. | — |
+| `config validate` | Validate `hal0.toml`, `upstreams.toml`, and `providers.toml` against the schema. | — |
+| `config reload` | Ask the running daemon to re-read its TOML configs (`POST /api/settings/reload`). | — |
+| `config hardware` | Show the cached hardware probe payload (`GET /api/hardware`), or force a fresh probe. | `--refresh` |
 
-The config path honours `HAL0_HOME`; under FHS it is `/etc/hal0/hal0.toml`.
+`config show`/`config edit` default to `hal0.toml`; pass `upstreams` or
+`providers` to target the other two files `config validate` already checks —
+useful when validate reports an error in one of them. The config path honours
+`HAL0_HOME`; under FHS it is `/etc/hal0/hal0.toml` (siblings `upstreams.toml`,
+`providers.toml` live alongside it).
 
 ## `hal0 doctor` — preflight checks
 
@@ -360,6 +377,8 @@ left the catalog are cleared. Idempotent. Default is a dry-run preview; pass
 | Command | Purpose | Key options |
 |---|---|---|
 | `app install <name>` | Install + enable an app skipped at install time (currently: `openwebui`). Runs the identical wiring as the install-time path (`HAL0_SKIP_OPENWEBUI=1`), so "skip now, install later" is lossless. | — |
+| `app list` | List known apps and their systemd enabled/active state. | — |
+| `app uninstall <name>` | Stop + disable an app's systemd unit (does not remove its container image or data). | `--force`/`-f` |
 
 ## `hal0 agent` — bundled agents
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -327,9 +327,11 @@ The config path honours `HAL0_HOME`; under FHS it is `/etc/hal0/hal0.toml`.
 | Command | Purpose | Key options |
 |---|---|---|
 | `doctor` | Re-run the installer's preflight battery (systemd, python, container runtime, disk, ports). | `--plain`, `--ports "8080 3001"` |
+| `doctor verify` | Render the post-setup report card (checks + live URLs + doc links) against the live API. The bare `--verify` flag on `hal0 doctor` still works as a deprecated pass-through. | — |
+| `doctor logs` | Print or follow hal0-api's own systemd journal (`GET /api/logs`); `doctor` had no surface for hal0's *own* log before, only `slot logs` (per-slot) and `agent log` (per-agent). | `--unit` (default `hal0-api`), `--follow`/`-f`, `--lines`/`-n`, `--level`, `--since` |
 | `doctor toolbox-pull` | Verify each pinned toolbox image is anonymously pullable from ghcr.io. | `--json`, `--manifest` |
-| `doctor perms` | Audit ownership for the editable-checkout root-clobber regression (group-share drift). | `--fix` (repair in place; needs root) |
-| `doctor models` | Audit the model pipeline: registry entries whose file is gone, unregistered files in the store, FLM/NPU store dir presence + container-uid writability, env-vs-TOML store divergence, and an unmounted external store path. | `--fix` (repair FLM store ownership/mode; needs root) |
+| `doctor perms` | Audit ownership for the editable-checkout root-clobber regression (group-share drift). | `--fix` (repair in place; needs root + confirmation, `--force`/`-f` skips the prompt) |
+| `doctor models` | Audit the model pipeline: registry entries whose file is gone, unregistered files in the store, FLM/NPU store dir presence + container-uid writability, env-vs-TOML store divergence, and an unmounted external store path. | `--fix` (repair FLM store ownership/mode; needs root + confirmation, `--force`/`-f` skips the prompt) |
 | `doctor migrations` | Surface a pending v0.1→v0.2 model-layout migration (dry-run of the symlink planner; points at `hal0 migrate model-layout --apply`). | — |
 | `doctor profiles` | Audit the slot↔profile layer: slots referencing a missing profile (fails), and in-use profile images not pulled locally (advisory). | — |
 
@@ -340,15 +342,18 @@ when the manifest has no toolbox images. `doctor models` exits `1` on any
 actionable finding; `doctor migrations` exits `1` when links are pending;
 `doctor profiles` exits `1` only when a slot references a missing profile.
 
-## `hal0 capabilities` — capability-slot repair
+## `hal0 capabilities` — capability-slot list/set + repair
 
 | Command | Purpose | Key options |
 |---|---|---|
-| `capabilities migrate` | Rewrite persisted capability selections that are illegal against the live catalog. | `--dry-run` |
+| `capabilities list` | List capability-slot selections (embed/voice/img/vision) from the live API (`GET /api/capabilities`). | — |
+| `capabilities set <slot> <child>` | Apply a partial capability selection update (`POST /api/capabilities/{slot}/{child}`); reconciles slot lifecycle via the running orchestrator, same path the dashboard uses. | `--model`, `--backend`, `--provider`, `--enabled`/`--disabled` |
+| `capabilities migrate` | Rewrite persisted capability selections that are illegal against the live catalog. | `--apply` (default is dry-run, matching `migrate model-layout`) |
 
 Walks `/etc/hal0/capabilities.toml`: selections whose backend can't serve the
 model are snapped to the model's first legal backend; selections whose model
-left the catalog are cleared. Idempotent.
+left the catalog are cleared. Idempotent. Default is a dry-run preview; pass
+`--apply` to write.
 
 ## `hal0 app` — optional apps
 
@@ -361,7 +366,7 @@ left the catalog are cleared. Idempotent.
 | Command | Purpose | Key options |
 |---|---|---|
 | `agent install <name>` | Install a bundled agent (`hermes` provisions a managed venv in the foreground, including the Telegram/Discord gateway). | `--switch`, `--gateway`/`--no-gateway` |
-| `agent uninstall <name>` | Uninstall a bundled agent. | `--keep-memory` |
+| `agent uninstall <name>` | Uninstall a bundled agent. Deletes the agent's private memory unless `--keep-memory` is passed; prompts for confirmation unless `--force`/`-f`. | `--keep-memory`, `--force`/`-f` |
 | `agent list` | List installed bundled agents. | `--json` |
 | `agent peers` | List discoverable agent identity cards from the `agents` memory dataset. | — |
 | `agent status [name]` | Pretty-print the agent's `provision.json` checkpoint (default `hermes`). | — |

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -116,8 +116,9 @@ API_BIND_HOST="0.0.0.0"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ "${DEV_MODE}" -eq 1 ]]; then
-    # Dev: editable checkout, everything under one prefix. Updater.apply()
-    # hard-refuses in this mode — run `git pull && pip install -e .` to update.
+    # Dev: editable checkout, everything under one prefix. `hal0 update`
+    # hard-refuses in this mode (the updater detects the editable install via
+    # PEP 610 metadata) — run `git pull && pip install -e .` to update.
     PREFIX="${HAL0_PREFIX:-${PWD}/.hal0ai}"
     ETC_DIR="${PREFIX}/etc/hal0"
     VAR_DIR="${PREFIX}/var/lib/hal0"

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -72,6 +72,34 @@ class UpdateJobNotFound(Hal0Error):
     status = 404
 
 
+class UpdateEditableRefused(Hal0Error):
+    """Refuses an update on an editable/dev install (409, not a 500)."""
+
+    code = "system.update_editable_install"
+    status = 409
+
+
+def _refuse_if_editable() -> None:
+    """Preflight: hard-refuse an update on an editable/dev install (audit 4.1).
+
+    The ``Updater`` re-checks this inside apply/prepare/commit, but surfacing
+    it at the route boundary turns a background-job failure into an immediate,
+    actionable 409 instead of a queued job that silently fails later. Detection
+    is metadata-driven (:func:`~hal0.updater.updater._editable_install_path`)
+    so an editable checkout cloned from git is caught too.
+    """
+    from hal0.updater.updater import _editable_install_path, _is_editable_install
+
+    if not _is_editable_install():
+        return
+    path = _editable_install_path() or "the current source tree"
+    raise UpdateEditableRefused(
+        f"hal0 is installed in editable mode from {path}. "
+        "Install from release wheel with `pip install hal0`.",
+        details={"editable_path": path},
+    )
+
+
 def _version_tuple(v: str) -> tuple[int, ...]:
     """Parse a dotted version string into a sortable tuple.
 
@@ -557,6 +585,7 @@ async def apply_update(request: Request) -> dict[str, Any]:
     endpoints (issue #37). Failure paths still raise typed 4xx envelopes
     via the middleware.
     """
+    _refuse_if_editable()
     try:
         body = await request.json()
     except Exception:
@@ -631,6 +660,7 @@ async def prepare_update(request: Request) -> dict[str, Any]:
 
     Body (optional): ``{"version": "0.1.0"}`` — pin a version; omit for latest.
     """
+    _refuse_if_editable()
     try:
         body = await request.json()
     except Exception:

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -468,8 +468,25 @@ def agent_uninstall(
             "its identity card. Default: full teardown including memory."
         ),
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip confirmation prompt.",
+    ),
 ) -> None:
     """Uninstall a bundled agent."""
+    if not force:
+        memory_note = (
+            "its memory will be preserved"
+            if keep_memory
+            else "this also deletes its private memory"
+        )
+        typer.confirm(
+            f"Uninstall agent {name!r}? {memory_note} — this cannot be undone.",
+            abort=True,
+        )
+
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)

--- a/src/hal0/cli/app_commands.py
+++ b/src/hal0/cli/app_commands.py
@@ -1,4 +1,4 @@
-"""``hal0 app`` subcommands — deferred install verbs for optional apps.
+"""``hal0 app`` subcommands — deferred install/uninstall verbs for optional apps.
 
 Companion to ``hal0 agent install <name>``: apps that were skipped at
 install time (``HAL0_SKIP_OPENWEBUI=1``) get a first-class "install later"
@@ -6,13 +6,21 @@ verb instead of a manual ``systemctl enable`` incantation. See issue #1102
 (decision Q9): now-vs-later must be behaviourally identical, so this module
 calls the exact same wiring function (:func:`hal0.install.extensions.
 install_openwebui`) that ``apply_setup`` uses at install time.
+
+CLI consolidation (2026-07): added ``list``/``uninstall`` alongside
+``install`` — every sibling cluster (``agent``, ``mcp``, ``upstream``) has
+list/status/remove for its resources; this one only had ``install``.
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+
 import typer
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from hal0.cli._shared import die
 
@@ -23,6 +31,9 @@ console = Console()
 # it's owned by the seeded img slot (hal0-slot@img.service), not a
 # standalone app install path.
 _SUPPORTED = frozenset({"openwebui"})
+
+# App id -> the systemd unit `install`/`list`/`uninstall` operate on.
+_APP_UNITS: dict[str, str] = {"openwebui": "hal0-openwebui.service"}
 
 
 @app.command("install")
@@ -75,6 +86,73 @@ def app_install(
             border_style="green",
         )
     )
+
+
+def _systemctl_query(unit: str, prop: str) -> str:
+    """Best-effort ``systemctl is-<prop> <unit>`` — returns the raw stdout
+    (e.g. 'active'/'inactive'/'failed', 'enabled'/'disabled') or '?' when
+    systemctl is unavailable."""
+    if shutil.which("systemctl") is None:
+        return "?"
+    try:
+        result = subprocess.run(
+            ["systemctl", f"is-{prop}", unit],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return "?"
+    return (result.stdout or "").strip() or "?"
+
+
+@app.command("list")
+def app_list() -> None:
+    """List known apps and their systemd enabled/active state."""
+    table = Table(title="Apps")
+    table.add_column("Name", style="bold")
+    table.add_column("Unit")
+    table.add_column("Enabled")
+    table.add_column("Active")
+    for name in sorted(_SUPPORTED):
+        unit = _APP_UNITS.get(name, "—")
+        enabled = _systemctl_query(unit, "enabled") if unit != "—" else "—"
+        active = _systemctl_query(unit, "active") if unit != "—" else "—"
+        table.add_row(name, unit, enabled, active)
+    console.print(table)
+
+
+@app.command("uninstall")
+def app_uninstall(
+    name: str = typer.Argument(..., help="App id (currently: openwebui)."),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip the confirmation prompt."),
+) -> None:
+    """Stop + disable an app installed via `hal0 app install`.
+
+    Only tears down the systemd unit — it does not remove the container
+    image or any data volumes, mirroring the conservative default of
+    `hal0 uninstall` (no `--purge` equivalent here yet).
+    """
+    if name not in _SUPPORTED:
+        die(f"'hal0 app uninstall {name}' isn't supported yet — known apps: {sorted(_SUPPORTED)}")
+        return
+    unit = _APP_UNITS.get(name)
+    if unit is None:
+        die(f"no service unit known for app {name!r}")
+        return
+    if not force:
+        typer.confirm(
+            f"Uninstall app {name!r}? This stops and disables {unit}.",
+            abort=True,
+        )
+    if shutil.which("systemctl") is None:
+        die("systemctl not available on this host — cannot uninstall.")
+        return
+    ok = subprocess.run(["systemctl", "disable", "--now", unit], check=False).returncode == 0
+    if not ok:
+        die(f"systemctl disable --now {unit} failed")
+        return
+    console.print(f"[green]Uninstalled[/green] {name}  [dim]({unit} stopped + disabled)[/dim]")
 
 
 __all__ = ["app"]

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -1,30 +1,37 @@
 """``hal0 capabilities`` subcommands.
 
-Operator tooling that touches ``/etc/hal0/capabilities.toml`` directly,
-bypassing the running API. Used during upgrades and for repair after
-a manual edit goes wrong.
+Operator tooling for the capability-slot surface (embed/voice/img/vision).
+Two kinds of command live here:
 
-Currently exposes::
-
-    hal0 capabilities migrate
-        Rewrite illegal (backend, model) pairs against the live catalog.
+* ``list`` / ``set`` — thin clients over the live API
+  (``GET /api/capabilities``, ``POST /api/capabilities/{slot}/{child}``),
+  the same endpoints the dashboard's Capability slots section and the
+  hal0-admin MCP (``capability_list``/``capability_set``) already use.
+  These need a *running* ``hal0-api`` — they go through the orchestrator
+  so slot lifecycle (start/stop/reconcile) stays consistent.
+* ``migrate`` — repair tooling that touches
+  ``/etc/hal0/capabilities.toml`` directly, bypassing the running API.
+  Used during upgrades and for repair after a manual edit goes wrong.
 
 (The schema_version=1 → 2 migration that used to live here as a CLI
 command now runs automatically on config load — see
 ``hal0.capabilities.config``. The old ``sync`` command is gone too:
 ``registry.toml`` is the sole model catalog.)
 
-Migration is the first reason this module exists: when the catalog
-reshape landed (model-first grouped rows + per-(backend, model)
-validation), any previously-persisted selection that mixed an FLM
-chat tag with a GGUF backend (or vice-versa) became illegal. The
-runtime orchestrator now rejects such writes, but already-on-disk
-selections survive until a write touches them. ``migrate`` walks the
-file, snaps illegal pairs to a legal one (or clears the selection
-when the model is gone entirely), and writes back atomically.
+Migration is the reason ``migrate`` exists: when the catalog reshape
+landed (model-first grouped rows + per-(backend, model) validation), any
+previously-persisted selection that mixed an FLM chat tag with a GGUF
+backend (or vice-versa) became illegal. The runtime orchestrator now
+rejects such writes, but already-on-disk selections survive until a
+write touches them. ``migrate`` walks the file, snaps illegal pairs to a
+legal one (or clears the selection when the model is gone entirely), and
+writes back atomically. Default is dry-run (matching
+``hal0 migrate model-layout``'s contract) — pass ``--apply`` to write.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -37,17 +44,126 @@ from hal0.capabilities.config import (
     load_capabilities_config,
     save_capabilities_config,
 )
-from hal0.capabilities.orchestrator import _CHILD_TO_CAPABILITY
+from hal0.capabilities.orchestrator import _CHILD_TO_CAPABILITY, LEGAL_SLOTS, legal_children
+from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, api_post, die
 from hal0.config.locking import file_lock
 from hal0.registry.store import ModelRegistry
 
 app = typer.Typer(
     name="capabilities",
-    help="Capability-slot configuration repair + migration.",
+    help="Capability-slot configuration: list, set, repair + migration.",
     no_args_is_help=True,
 )
 
 console = Console()
+
+
+# ── `hal0 capabilities list` — GET /api/capabilities ────────────────────────
+
+
+@app.command("list")
+def list_capabilities() -> None:
+    """List capability-slot selections (embed/voice/img/vision) from the live API.
+
+    Thin client over ``GET /api/capabilities`` — the same payload the
+    dashboard's Capability slots section renders. Shows the persisted
+    (backend, provider, model, enabled) selection for every (slot, child)
+    pair the orchestrator knows about.
+    """
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        data = api_get("/api/capabilities")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    selections = data.get("selections") if isinstance(data, dict) else None
+    if not isinstance(selections, dict) or not selections:
+        console.print("[dim]no capability selections configured.[/dim]")
+        return
+
+    table = Table(title="Capability selections")
+    table.add_column("Slot", style="bold")
+    table.add_column("Child")
+    table.add_column("Backend")
+    table.add_column("Provider")
+    table.add_column("Model")
+    table.add_column("Enabled")
+    for slot, children in sorted(selections.items()):
+        if not isinstance(children, dict):
+            continue
+        for child, sel in sorted(children.items()):
+            if not isinstance(sel, dict):
+                continue
+            enabled = sel.get("enabled")
+            table.add_row(
+                slot,
+                child,
+                str(sel.get("backend") or "—"),
+                str(sel.get("provider") or "—"),
+                str(sel.get("model") or "—"),
+                "[green]yes[/green]" if enabled else "[dim]no[/dim]",
+            )
+    console.print(table)
+
+
+# ── `hal0 capabilities set` — POST /api/capabilities/{slot}/{child} ─────────
+
+
+@app.command("set")
+def set_capability(
+    slot: str = typer.Argument(..., help=f"Capability slot: {', '.join(LEGAL_SLOTS)}."),
+    child: str = typer.Argument(..., help="Child within the slot (e.g. 'default')."),
+    model: str | None = typer.Option(None, "--model", help="Model id to select."),
+    backend: str | None = typer.Option(None, "--backend", help="Backend id to select."),
+    provider: str | None = typer.Option(None, "--provider", help="Provider tag for the backend."),
+    enabled: bool | None = typer.Option(
+        None,
+        "--enabled/--disabled",
+        help="Enable or disable this (slot, child) selection.",
+    ),
+) -> None:
+    """Apply a partial capability selection update.
+
+    Thin client over ``POST /api/capabilities/{slot}/{child}`` — reconciles
+    slot lifecycle via the running ``CapabilityOrchestrator`` (starts/stops/
+    swaps the backing slot as needed), the same path the dashboard uses.
+    Only the flags you pass are sent; omitted fields keep their current value.
+    """
+    if slot not in LEGAL_SLOTS:
+        die(f"unknown capability slot {slot!r} — legal: {', '.join(LEGAL_SLOTS)}")
+        return
+    legal = legal_children(slot)
+    if child not in legal:
+        die(f"child {child!r} not valid for slot {slot!r} — legal: {', '.join(legal)}")
+        return
+
+    body: dict[str, Any] = {}
+    if model is not None:
+        body["model"] = model
+    if backend is not None:
+        body["backend"] = backend
+    if provider is not None:
+        body["provider"] = provider
+    if enabled is not None:
+        body["enabled"] = enabled
+    if not body:
+        die("nothing to set — pass at least one of --model/--backend/--provider/--enabled.")
+        return
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        result = api_post(f"/api/capabilities/{slot}/{child}", json=body)
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    selection = result.get("selection") if isinstance(result, dict) else None
+    console.print(f"[green]✓[/green]  {slot}/{child} → {selection or body}")
 
 
 def _classify_pair(
@@ -88,10 +204,16 @@ def _classify_pair(
 
 @app.command()
 def migrate(
+    apply: bool = typer.Option(
+        False,
+        "--apply",
+        help="Apply the migration. Without this, the command is a dry-run.",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
-        help="Show what would change without writing the file.",
+        hidden=True,
+        help="Deprecated no-op — dry-run is now the default; pass --apply to write.",
     ),
 ) -> None:
     """Rewrite persisted selections that are illegal against the live catalog.
@@ -103,8 +225,12 @@ def migrate(
     whose model is no longer in the catalog are cleared (backend stays
     intact so the dashboard can still show what was previously chosen).
 
-    Idempotent — running it twice is a no-op once everything is legal.
+    Default is dry-run (no flags = safe preview); pass ``--apply`` to
+    write, matching ``hal0 migrate model-layout --apply``'s contract.
+    Idempotent — running ``--apply`` twice is a no-op once everything is
+    legal.
     """
+    del dry_run  # deprecated hidden flag — dry-run is the unconditional default now
     # SC-10: the load → diff → save is one read-modify-write. Hold the same
     # capabilities.toml advisory lock the running API uses so a ``migrate``
     # invoked while hal0-api is applying a selection cannot read a stale copy
@@ -149,7 +275,7 @@ def migrate(
                             "reason": "backend cannot serve model",
                         }
                     )
-                    if not dry_run:
+                    if apply:
                         children[child] = CapabilitySelection(
                             backend=new_backend,
                             provider=new_provider,
@@ -167,7 +293,7 @@ def migrate(
                             "reason": "model not in catalog",
                         }
                     )
-                    if not dry_run:
+                    if apply:
                         children[child] = CapabilitySelection(
                             backend=sel.backend,
                             provider=sel.provider,
@@ -193,10 +319,10 @@ def migrate(
             table.add_row(c["slot"], c["child"], c["model"], c["before"], c["after"], c["reason"])
         console.print(table)
 
-        if dry_run:
+        if not apply:
             console.print(
-                f"\n[yellow]--dry-run[/yellow] — {len(changes)} selection(s) "
-                f"would be rewritten in {capabilities_toml_path()}."
+                f"\n[yellow]--dry-run[/yellow] — would rewrite {len(changes)} selection(s) "
+                f"in {capabilities_toml_path()}; pass --apply to write."
             )
             raise typer.Exit(0)
 

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json as jsonlib
 import os
 import subprocess
+from enum import StrEnum
 from pathlib import Path
 
 import typer
@@ -18,18 +19,51 @@ app = typer.Typer(help="Inspect and manage hal0 configuration.")
 console = Console()
 
 
-def _hal0_toml_path() -> Path:
-    """Return the on-disk hal0.toml path, honouring HAL0_HOME."""
+class ConfigFile(StrEnum):
+    """Which on-disk config file a `config show`/`config edit` targets.
+
+    Mirrors the three files ``hal0 config validate`` already checks
+    (hal0.toml, upstreams.toml, providers.toml) — before this, ``show``/
+    ``edit`` were hardcoded to hal0.toml only, so a validate failure in
+    upstreams.toml or providers.toml had no matching ``edit`` target.
+    """
+
+    hal0 = "hal0"
+    upstreams = "upstreams"
+    providers = "providers"
+
+
+_CONFIG_FILENAMES: dict[ConfigFile, str] = {
+    ConfigFile.hal0: "hal0.toml",
+    ConfigFile.upstreams: "upstreams.toml",
+    ConfigFile.providers: "providers.toml",
+}
+
+
+def _config_path(which: ConfigFile) -> Path:
+    """Return the on-disk path for one of hal0's config files, honouring HAL0_HOME."""
+    filename = _CONFIG_FILENAMES[which]
     base = os.environ.get("HAL0_HOME")
     if base:
-        return Path(base) / "etc" / "hal0" / "hal0.toml"
-    return Path("/etc/hal0/hal0.toml")
+        return Path(base) / "etc" / "hal0" / filename
+    return Path("/etc/hal0") / filename
+
+
+def _hal0_toml_path() -> Path:
+    """Return the on-disk hal0.toml path, honouring HAL0_HOME."""
+    return _config_path(ConfigFile.hal0)
 
 
 @app.command("show")
-def config_show() -> None:
-    """Print the current hal0 configuration (hal0.toml on disk)."""
-    path = _hal0_toml_path()
+def config_show(
+    which: ConfigFile = typer.Argument(
+        ConfigFile.hal0,
+        help="Which config file to show: hal0 | upstreams | providers.",
+        case_sensitive=False,
+    ),
+) -> None:
+    """Print a hal0 config file as it exists on disk (default: hal0.toml)."""
+    path = _config_path(which)
     if not path.exists():
         console.print(f"[dim]No config at {path}[/dim]")
         raise typer.Exit(0)
@@ -59,17 +93,28 @@ def config_show() -> None:
 
 
 @app.command("edit")
-def config_edit() -> None:
-    """Open hal0.toml in $EDITOR (falls back to $VISUAL then 'vi')."""
+def config_edit(
+    which: ConfigFile = typer.Argument(
+        ConfigFile.hal0,
+        help="Which config file to edit: hal0 | upstreams | providers.",
+        case_sensitive=False,
+    ),
+) -> None:
+    """Open a hal0 config file in $EDITOR (default: hal0.toml; falls back to $VISUAL then 'vi')."""
     editor = os.environ.get("EDITOR") or os.environ.get("VISUAL") or "vi"
-    path = _hal0_toml_path()
+    path = _config_path(which)
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
-        path.write_text(
-            "# hal0 configuration — see `hal0 config show` for the live shape.\n"
-            "[meta]\nschema_version = 1\n\n"
-            "[slots]\nport_range_start = 8081\nport_range_end = 8099\n"
-        )
+        if which == ConfigFile.hal0:
+            path.write_text(
+                "# hal0 configuration — see `hal0 config show` for the live shape.\n"
+                "[meta]\nschema_version = 1\n\n"
+                "[slots]\nport_range_start = 8081\nport_range_end = 8099\n"
+            )
+        else:
+            path.write_text(
+                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n"
+            )
     try:
         subprocess.run([editor, str(path)], check=True)
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
@@ -176,13 +221,25 @@ def config_reload() -> None:
 
 
 @app.command("hardware")
-def config_hardware() -> None:
-    """Show the cached hardware probe payload."""
+def config_hardware(
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Force a fresh hardware probe (POST /api/hardware/probe) instead "
+        "of showing the cached payload. Equivalent to the deprecated `hal0 probe`.",
+    ),
+) -> None:
+    """Show the cached hardware probe payload (or force a fresh one with --refresh)."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        hw = api_get("/api/hardware")
+        if refresh:
+            from hal0.cli._shared import api_post
+
+            hw = api_post("/api/hardware/probe")
+        else:
+            hw = api_get("/api/hardware")
     except CliApiError as exc:
         die(str(exc))
         return
@@ -194,7 +251,7 @@ def config_hardware() -> None:
                 theme="ansi_dark",
                 background_color="default",
             ),
-            title="hardware",
+            title="hardware (refreshed)" if refresh else "hardware",
             border_style="cyan",
         )
     )

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import contextlib
 import grp
+import json as jsonlib
 import os
 import pwd
 import shutil
@@ -102,7 +103,8 @@ def doctor(
     verify: bool = typer.Option(
         False,
         "--verify",
-        help="Render the post-setup report card (checks + live URLs + doc links) against the live API.",
+        hidden=True,
+        help="Deprecated — use `hal0 doctor verify`.",
     ),
     plain: bool = typer.Option(
         False,
@@ -117,10 +119,11 @@ def doctor(
 ) -> None:
     """Re-run pre-flight checks (systemd, python, docker, disk, ports).
 
-    ``--verify`` instead renders the WS-K report card: a pass/warn/fail summary
-    over the live health seams (API, runners, capability slots, hindsight,
+    ``hal0 doctor verify`` instead renders the WS-K report card: a pass/warn/fail
+    summary over the live health seams (API, runners, capability slots, hindsight,
     OpenWebUI, Hermes) plus the computed URLs + help links. Non-blocking; exits
-    2 only on a critical (no reachable URL / zero healthy runners).
+    2 only on a critical (no reachable URL / zero healthy runners). The bare
+    ``--verify`` flag on this callback still works as a deprecated pass-through.
     """
     # When a sub-command (e.g. ``toolbox-pull``) is invoked, Typer still
     # calls the callback first. Bail out without running preflight so the
@@ -167,6 +170,100 @@ def doctor(
     # Preserve the script's exit code verbatim so chained shells see a
     # non-zero on the first failed check.
     raise typer.Exit(result.returncode)
+
+
+# ── hal0 doctor verify ──────────────────────────────────────────────────────
+
+
+@app.command("verify")
+def doctor_verify_cmd() -> None:
+    """Render the post-setup report card (checks + live URLs + doc links).
+
+    First-class home for what used to be reachable only via the hidden
+    ``hal0 doctor --verify`` flag — every other doctor audit (``perms``,
+    ``models``, ``migrations``, ``profiles``, ``toolbox-pull``) is a
+    discoverable subcommand, so this one is now too. See the module-level
+    docstring for the health seams this composes.
+    """
+    from hal0.cli.doctor_verify import run_verify
+
+    raise typer.Exit(run_verify(console=console))
+
+
+# ── hal0 doctor logs ─────────────────────────────────────────────────────────
+
+
+@app.command("logs")
+def doctor_logs(
+    unit: str = typer.Option(
+        "hal0-api",
+        "--unit",
+        help="systemd unit to tail (default: hal0-api — hal0's own daemon).",
+    ),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Stream logs (SSE tail)."),
+    lines: int = typer.Option(
+        200, "--lines", "-n", min=1, max=5000, help="Trailing line count (ignored with --follow)."
+    ),
+    level: str | None = typer.Option(
+        None, "--level", help="Filter to this journald priority and higher (e.g. 'warning')."
+    ),
+    since: str | None = typer.Option(
+        None, "--since", help="journalctl --since value (ISO timestamp or '5min ago')."
+    ),
+) -> None:
+    """Print or follow hal0-api's own systemd journal.
+
+    ``hal0 slot logs`` covers per-slot logs and ``hal0 agent log`` covers
+    per-agent provisioning logs, but nothing surfaced hal0-api's *own*
+    log — operators were pushed to ``journalctl -u hal0-api`` by hand,
+    defeating the point of ``doctor`` as the diagnostics entry point.
+    Thin client over ``GET /api/logs`` (and ``/api/logs/stream`` with
+    ``--follow``), the same endpoints the dashboard's log panel uses.
+    """
+    from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, die
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    if not follow:
+        params: dict[str, object] = {"unit": unit, "n": lines}
+        if level is not None:
+            params["level"] = level
+        if since is not None:
+            params["since"] = since
+        try:
+            data = api_get("/api/logs", params=params)
+        except CliApiError as exc:
+            die(str(exc))
+            return
+        log_lines = data.get("lines") or [] if isinstance(data, dict) else []
+        if not log_lines:
+            hint = data.get("hint") if isinstance(data, dict) else None
+            console.print(f"[dim]no logs{f' ({hint})' if hint else ''}.[/dim]")
+            return
+        for line in log_lines:
+            console.print(line)
+        return
+
+    # Stream SSE — line-buffered passthrough (mirrors `hal0 slot logs --follow`).
+    stream_params: dict[str, object] = {"unit": unit}
+    if level is not None:
+        stream_params["level"] = level
+    if since is not None:
+        stream_params["since"] = since
+    try:
+        with httpx.stream("GET", url + "/api/logs/stream", params=stream_params, timeout=None) as r:
+            for raw in r.iter_lines():
+                if not raw or not raw.startswith("data:"):
+                    continue
+                payload = raw[5:].strip()
+                try:
+                    console.print(jsonlib.loads(payload))
+                except ValueError:
+                    console.print(payload)
+    except (httpx.HTTPError, KeyboardInterrupt):
+        return
 
 
 # ── hal0 doctor toolbox-pull ──────────────────────────────────────────────────
@@ -586,14 +683,24 @@ def perms(
         "--fix",
         help="Repair editable-checkout group-share drift in place (needs root).",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the confirmation prompt before applying --fix.",
+    ),
 ) -> None:
     """Audit ownership for the root-clobber regression (#843) + the path table.
 
     Covers three surfaces: Hermes runtime state (/var/lib/hal0/.hermes), the
     editable code checkout's group-share, and the canonical path-ownership table
-    (:mod:`hal0.install.perms`, overhaul plan §5). ``--fix`` repairs the
-    group-share in place AND applies the ownership table (both need root); Hermes
-    drift is still reconciled via ``sudo hal0 agent bootstrap hermes --repair``.
+    (:mod:`hal0.install.perms`, overhaul plan §5). The audit tables above print
+    the concrete before/after (path, current owner:group:mode, wanted
+    owner:group:mode) before anything is touched. ``--fix`` then repairs the
+    group-share in place AND applies the ownership table (both need root, and
+    both prompt for confirmation unless ``--force``/``-f`` is also passed);
+    Hermes drift is still reconciled via ``sudo hal0 agent bootstrap hermes
+    --repair``.
     """
 
     def _owner(p: Path) -> str | None:
@@ -659,6 +766,12 @@ def perms(
         elif os.geteuid() != 0:
             console.print("[red]✗[/red]  --fix needs root — re-run `sudo hal0 doctor perms --fix`.")
             raise typer.Exit(1)
+        elif not force and not typer.confirm(
+            f"Apply group-share repair to {root}? (chgrp -R {_SHARED_GROUP}, chmod g+rwX, "
+            "setgid on every dir — see the drift rows above)",
+            default=False,
+        ):
+            console.print("[dim]group-share repair skipped (not confirmed).[/dim]")
         else:
             ok, msg = repair_tree_group_share(root, _SHARED_GROUP)
             if not ok:
@@ -675,15 +788,23 @@ def perms(
                     "re-run `sudo hal0 doctor perms --fix`."
                 )
                 raise typer.Exit(1)
-            try:
-                changed = perms_mod.commit(own_plan)
-            except (OSError, KeyError) as exc:
-                console.print(f"[red]✗[/red]  ownership repair failed: {exc}")
-                raise typer.Exit(1) from exc
-            console.print(
-                f"[green]✓[/green]  ownership table applied ({len(changed)} path(s) reconciled)."
-            )
-            own_drift = False
+            elif not force and not typer.confirm(
+                f"Apply the ownership table to {len(own_plan.drifted)} drifted path(s)? "
+                "(see the 'is X, want Y' rows above)",
+                default=False,
+            ):
+                console.print("[dim]ownership repair skipped (not confirmed).[/dim]")
+            else:
+                try:
+                    changed = perms_mod.commit(own_plan)
+                except (OSError, KeyError) as exc:
+                    console.print(f"[red]✗[/red]  ownership repair failed: {exc}")
+                    raise typer.Exit(1) from exc
+                console.print(
+                    f"[green]✓[/green]  ownership table applied "
+                    f"({len(changed)} path(s) reconciled)."
+                )
+                own_drift = False
 
     hermes_drift = has_ownership_drift(hermes_rows)
     if hermes_drift:
@@ -849,6 +970,12 @@ def doctor_models(
         "--fix",
         help="Repair FLM store ownership/mode drift in place (needs root).",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Skip the confirmation prompt before applying --fix.",
+    ),
 ) -> None:
     """Audit the model pipeline: registry paths, store/roots agreement, FLM dir.
 
@@ -866,7 +993,8 @@ def doctor_models(
         (the classic post-reboot exit-125 before the disk is up)
 
     ``--fix`` repairs FLM store ownership/mode drift in place (chown 1000:hal0,
-    chmod 2775 — needs root). Exits non-zero when anything actionable is found.
+    chmod 2775 — needs root, and prompts for confirmation unless ``--force``/
+    ``-f`` is also passed). Exits non-zero when anything actionable is found.
     """
     from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get
     from hal0.config import paths as cfg_paths
@@ -962,6 +1090,13 @@ def doctor_models(
                     f"[red]✗[/red]  FLM store {flm_dir}: {writ['detail']}\n"
                     "      --fix needs root — re-run `sudo hal0 doctor models --fix`."
                 )
+            elif not force and not typer.confirm(
+                f"Apply chown {_FLM_CONTAINER_UID}:hal0 + chmod 2775 to {flm_dir}? "
+                f"(currently: {writ['detail']})",
+                default=False,
+            ):
+                problems += 1
+                console.print(f"[dim]FLM store repair skipped (not confirmed): {flm_dir}[/dim]")
             else:
                 ok, msg = repair_flm_store(flm_dir)
                 if ok:

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -7,7 +7,6 @@ Entry point declared in pyproject.toml:
 
 from __future__ import annotations
 
-import json as jsonlib
 import os
 import sys
 from pathlib import Path
@@ -16,7 +15,6 @@ import typer
 import uvicorn
 from rich.console import Console
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.table import Table
 
 import hal0
@@ -25,7 +23,6 @@ from hal0.cli._shared import (
     _api_base,
     _api_unreachable,
     api_get,
-    api_post,
     die,
 )
 from hal0.cli.agent_commands import app as agent_app
@@ -150,38 +147,17 @@ def status() -> None:
     console.print(table)
 
 
-@app.command()
+@app.command(hidden=True)
 def probe() -> None:
-    """Re-run hardware detection and update hardware.json."""
-    url = _api_base()
-    if _api_unreachable(url):
-        raise typer.Exit(1)
-    try:
-        hw = api_post("/api/hardware/probe")
-    except CliApiError as exc:
-        die(str(exc))
-        return
-    summary = {
-        "cpu": hw.get("cpu_name"),
-        "ram_mb": hw.get("ram_mb"),
-        "unified_memory_mb": hw.get("unified_memory_mb"),
-        "gpu": hw.get("gpu_name"),
-        "gtt_total_mb": hw.get("gtt_total_mb"),
-        "vram_total_mb": hw.get("vram_total_mb"),
-        "npu": hw.get("npu_name"),
-    }
-    console.print(
-        Panel(
-            Syntax(
-                jsonlib.dumps(summary, indent=2),
-                "json",
-                theme="ansi_dark",
-                background_color="default",
-            ),
-            title="hardware probe",
-            border_style="cyan",
-        )
+    """[DEPRECATED] alias for `hal0 config hardware --refresh`; use that instead."""
+    typer.echo(
+        "[deprecated] `hal0 probe` is replaced by `hal0 config hardware --refresh`; "
+        "use `hal0 config hardware --refresh`.",
+        err=True,
     )
+    from hal0.cli.config_commands import config_hardware
+
+    config_hardware(refresh=True)
 
 
 # ---------------------------------------------------------------------------

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json as jsonlib
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -17,6 +18,7 @@ from hal0.cli._shared import (
     api_put,
     die,
 )
+from hal0.cli.registry_commands import DEFAULT_REGISTRY_PATH, _do_import_backup
 
 app = typer.Typer(help="Manage the local model registry.")
 console = Console()
@@ -137,31 +139,20 @@ def model_pull(
         time.sleep(0.5)
 
 
-@app.command("register")
+@app.command("register", hidden=True)
 def model_register(
     model_id: str = typer.Argument(..., help="Model id, e.g. 'qwen3-4b-q4_k_m'"),
     path: str = typer.Option(..., "--path", "-p", help="Absolute path to the model file."),
     name: str = typer.Option("", "--name", help="Display name."),
     license_id: str = typer.Option("unknown", "--license", help="SPDX license id."),
 ) -> None:
-    """Register a model that's already on disk into the local registry."""
-    url = _api_base()
-    if _api_unreachable(url):
-        raise typer.Exit(1)
-    payload = {
-        "id": model_id,
-        "path": path,
-        "name": name or model_id,
-        "license": license_id,
-    }
-    try:
-        from hal0.cli._shared import api_post
-
-        m = api_post("/api/models", json=payload)
-    except CliApiError as exc:
-        die(str(exc))
-        return
-    console.print(f"Registered [bold]{m.get('id', model_id)}[/bold] → {m.get('path', path)}")
+    """[DEPRECATED] alias for `model add`; use `hal0 model add <path> --id --license` instead."""
+    typer.echo(
+        "[deprecated] `model register` is replaced by `model add`; "
+        "use `hal0 model add <path> --id <id> --license <license>`.",
+        err=True,
+    )
+    model_add(path=path, model_id=model_id, name=name, license_id=license_id, overwrite=False)
 
 
 @app.command("rm")
@@ -210,21 +201,28 @@ def model_show(
     console.print(table)
 
 
-@app.command("assign")
+@app.command("assign", hidden=True)
 def model_assign(
     ref: str = typer.Argument(..., help="Model ref to assign"),
     slot: str = typer.Option(..., "--slot", "-s", help="Slot name to assign the model to"),
 ) -> None:
-    """Assign a model to a slot's default (does not load the slot)."""
-    url = _api_base()
-    if _api_unreachable(url):
-        raise typer.Exit(1)
-    try:
-        api_put(f"/api/slots/{slot}/config", json={"model": {"default": ref}})
-    except CliApiError as exc:
-        die(str(exc))
-        return
-    console.print(f"Assigned [bold]{ref}[/bold] → slot [bold]{slot}[/bold]")
+    """[DEPRECATED] alias for `slot edit --model`; use `hal0 slot edit <slot> --model` instead."""
+    typer.echo(
+        "[deprecated] `model assign` is replaced by `slot edit --model`; "
+        "use `hal0 slot edit <slot> --model <ref>`.",
+        err=True,
+    )
+    from hal0.cli.slot_commands import slot_edit
+
+    slot_edit(
+        name=slot,
+        model=ref,
+        port=None,
+        ctx_size=None,
+        provider=None,
+        hardware=None,
+        backend=None,
+    )
 
 
 @app.command("scan")
@@ -265,12 +263,17 @@ def model_add(
     path: str = typer.Argument(..., help="Absolute path to a model file (.gguf/.safetensors)"),
     model_id: str = typer.Option("", "--id", help="Explicit registry id (default: derived)"),
     name: str = typer.Option("", "--name", help="Display name."),
+    license_id: str = typer.Option(
+        "", "--license", help="SPDX license id (optional; default: 'unknown')."
+    ),
     overwrite: bool = typer.Option(False, "--overwrite", help="Replace an existing entry."),
 ) -> None:
     """Register an already-downloaded model file — capabilities auto-detected.
 
-    Unlike ``register`` this reads the file header to derive id,
-    capabilities and backends; the file stays where it is (no copy).
+    Reads the file header to derive id, capabilities and backends; the
+    file stays where it is (no copy). Folds in the explicit-metadata flags
+    (``--id``, ``--name``, ``--license``) that the old ``model register``
+    command exposed, so this command now covers both cases.
     """
     url = _api_base()
     if _api_unreachable(url):
@@ -288,6 +291,12 @@ def model_add(
         die(str(exc))
         return
     mid = m.get("id", model_id or "?")
+    if license_id:
+        try:
+            m = api_put(f"/api/models/{mid}", json={"license": license_id})
+        except CliApiError as exc:
+            die(f"registered {mid}, but setting --license failed: {exc}")
+            return
     console.print(f"Registered [bold]{mid}[/bold] → {m.get('path', path)}")
     caps = ", ".join(m.get("capabilities", []) or []) or "—"
     console.print(f"  capabilities: {caps}")
@@ -452,3 +461,36 @@ def model_run(
         console.print(f"  [dim]{state}…[/dim]", end="\r")
         time.sleep(2.0)
     die(f"timed out after {timeout_s}s waiting for slot {target} (last state: {state})")
+
+
+@app.command("import-backup")
+def model_import_backup(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to hal0-v0.1-backup-YYYY-MM-DD.tar.gz produced by the "
+        "v0.1.x backup instructions in install.sh.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite an existing registry.toml at the destination. "
+        "Without this, the command refuses to clobber a registry that "
+        "may already hold v0.2 selections.",
+    ),
+    dest: Path = typer.Option(
+        DEFAULT_REGISTRY_PATH,
+        "--dest",
+        help="Destination registry.toml path. Test/dev escape hatch — "
+        "production always uses /var/lib/hal0/registry/registry.toml.",
+    ),
+) -> None:
+    """Restore ``registry.toml`` from a v0.1.x disaster-recovery backup.
+
+    v0.1.x → v0.2 disaster recovery command (formerly ``hal0 registry
+    import``, moved here because ``hal0 model`` already owns registry
+    CRUD). Slot selections, ``capabilities.toml``, and per-slot TOML files
+    are NOT restored — v0.1.x → v0.2 is a clean break; redo slot selection
+    via the bundle picker or ``hal0 slot create`` after importing.
+    """
+    _do_import_backup(path, force, dest)

--- a/src/hal0/cli/registry_commands.py
+++ b/src/hal0/cli/registry_commands.py
@@ -7,6 +7,13 @@ extracted from a ``hal0-v0.1-backup-YYYY-MM-DD.tar.gz`` tarball
 produced by following the v0.1.x backup instructions in install.sh
 (see the v0.2 adoption plan §9).
 
+CLI consolidation (2026-07): the standalone ``hal0 registry`` group
+collided in name with the much larger ``hal0 model`` group, which already
+claims to "manage the local model registry". The canonical command is now
+``hal0 model import-backup`` (in ``model_commands.py``, reusing
+:func:`_do_import_backup` from this module); ``hal0 registry import``
+remains as a hidden deprecated alias so existing scripts keep working.
+
 Design contract (from plan §11 PR-21):
 
 * **Registry only.** v0.1.x → v0.2 is a clean break. Slot selections,
@@ -61,10 +68,11 @@ app = typer.Typer(
 def _registry_callback() -> None:
     """Inspect + repair the hal0 model registry.
 
-    Currently exposes ``import`` (v0.1.x backup recovery). Future
-    subcommands will live here; the callback keeps Typer from
-    auto-collapsing the single-command group, which would make a
-    second subcommand a breaking change at the CLI surface.
+    ``import`` (v0.1.x backup recovery) has moved to ``hal0 model
+    import-backup`` — the ``model`` group already owns registry CRUD, and a
+    standalone ``registry`` group holding a single verb collided in name
+    with it. This callback stays so a future second subcommand here isn't a
+    breaking change at the CLI surface.
     """
 
 
@@ -175,37 +183,16 @@ def _atomic_copy(source: Path, dest: Path) -> None:
                     tmp_path.unlink(missing_ok=True)
 
 
-@app.command("import")
-def import_backup(
-    path: Path = typer.Argument(
-        ...,
-        help="Path to hal0-v0.1-backup-YYYY-MM-DD.tar.gz produced by the "
-        "v0.1.x backup instructions in install.sh.",
-    ),
-    force: bool = typer.Option(
-        False,
-        "--force",
-        "-f",
-        help="Overwrite an existing registry.toml at the destination. "
-        "Without this, the command refuses to clobber a registry that "
-        "may already hold v0.2 selections.",
-    ),
-    dest: Path = typer.Option(
-        DEFAULT_REGISTRY_PATH,
-        "--dest",
-        help="Destination registry.toml path. Test/dev escape hatch — "
-        "production always uses /var/lib/hal0/registry/registry.toml.",
-    ),
-) -> None:
+def _do_import_backup(path: Path, force: bool, dest: Path) -> None:
     """Restore ``registry.toml`` from a v0.1.x backup tarball.
 
-    Reads the tarball at ``PATH``, extracts it into a tempdir, locates
+    Reads the tarball at ``path``, extracts it into a tempdir, locates
     ``registry.toml`` inside (canonical layout is
     ``var/lib/hal0/registry/registry.toml``; bare ``registry/`` and
     flat layouts also accepted for hand-repacked backups), and atomically
-    copies it to ``--dest`` (default: ``/var/lib/hal0/registry/registry.toml``).
+    copies it to ``dest`` (default: ``/var/lib/hal0/registry/registry.toml``).
 
-    Refuses to overwrite an existing destination unless ``--force`` is
+    Refuses to overwrite an existing destination unless ``force`` is
     passed — a freshly-installed v0.2 box may already have curated picks
     from the bundle picker.
 
@@ -213,6 +200,10 @@ def import_backup(
     other v0.1.x state are NOT restored. Plan §9 is explicit: v0.1.x →
     v0.2 is a clean break. After import, redo slot selection via the
     bundle picker or ``hal0 slot create``.
+
+    Shared implementation behind both the canonical ``hal0 model
+    import-backup`` command and the deprecated ``hal0 registry import``
+    alias — see the module docstring for the rename rationale.
     """
     # ── 1. Validate the source tarball ────────────────────────────────
     if not path.exists():
@@ -283,3 +274,34 @@ def import_backup(
         f"Slot selections from v0.1.x are NOT migrated. Use the bundle\n"
         f"picker or [bold]hal0 slot create[/bold] to declare slots."
     )
+
+
+@app.command("import", hidden=True)
+def import_backup(
+    path: Path = typer.Argument(
+        ...,
+        help="Path to hal0-v0.1-backup-YYYY-MM-DD.tar.gz produced by the "
+        "v0.1.x backup instructions in install.sh.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite an existing registry.toml at the destination. "
+        "Without this, the command refuses to clobber a registry that "
+        "may already hold v0.2 selections.",
+    ),
+    dest: Path = typer.Option(
+        DEFAULT_REGISTRY_PATH,
+        "--dest",
+        help="Destination registry.toml path. Test/dev escape hatch — "
+        "production always uses /var/lib/hal0/registry/registry.toml.",
+    ),
+) -> None:
+    """[DEPRECATED] alias for `hal0 model import-backup`; use that instead."""
+    typer.echo(
+        "[deprecated] `hal0 registry import` is renamed to "
+        "`hal0 model import-backup`; use `hal0 model import-backup`.",
+        err=True,
+    )
+    _do_import_backup(path, force, dest)

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -673,3 +673,106 @@ def slot_show(
             border_style="cyan",
         )
     )
+
+
+@app.command("metrics")
+def slot_metrics(
+    name: str | None = typer.Argument(None, help="Slot name (omit to show all slots)."),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/slots/metrics JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
+    """Show live per-slot runtime metrics (tok/s, KV%, mem, uptime, queue depth)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        data = api_get("/api/slots/metrics")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if name is not None:
+        entry = data.get(name) if isinstance(data, dict) else None
+        if entry is None:
+            die(f"no metrics for slot {name!r} (unknown slot, or it has never served a request)")
+            return
+        data = {name: entry}
+    if json_out:
+        typer.echo(jsonlib.dumps(data, indent=2))
+        return
+    table = Table(title="hal0 slot metrics")
+    table.add_column("Name", style="bold")
+    table.add_column("tok/s", justify="right")
+    table.add_column("KV%", justify="right")
+    table.add_column("Mem MB", justify="right")
+    table.add_column("Uptime s", justify="right")
+    table.add_column("Reqs", justify="right")
+    if not data:
+        console.print("[dim]No slot metrics available.[/dim]")
+        return
+    for slot_name, m in data.items():
+        if not isinstance(m, dict):
+            continue
+        tps = m.get("tokens_per_sec")
+        kv = m.get("kv_cache_usage")
+        table.add_row(
+            slot_name,
+            f"{tps:.1f}" if isinstance(tps, (int, float)) else "—",
+            f"{kv * 100:.0f}" if isinstance(kv, (int, float)) else "—",
+            str(m.get("mem_rss_mb", "—")),
+            str(m.get("uptime_seconds", "—")),
+            str(m.get("requests_processing", "—")),
+        )
+    console.print(table)
+
+
+@app.command("capacity")
+def slot_capacity(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/slots/capacity JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
+    """Show per-slot resident memory and the slot-count budget."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        data = api_get("/api/slots/capacity")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(data, indent=2))
+        return
+    budget = data.get("slot_budget") or {}
+    used = budget.get("used_slots", "—")
+    max_slots = budget.get("max_slots", 0)
+    cap = "unlimited" if not max_slots else str(max_slots)
+    console.print(f"Slot budget: [bold]{used}[/bold] / {cap}")
+    per_slot = data.get("per_slot") or {}
+    table = Table(title="Per-slot memory")
+    table.add_column("Name", style="bold")
+    table.add_column("State")
+    table.add_column("Model")
+    table.add_column("VRAM MB", justify="right")
+    table.add_column("RAM MB", justify="right")
+    table.add_column("Total MB", justify="right")
+    if not per_slot:
+        console.print("[dim]No slot capacity data.[/dim]")
+        return
+    for slot_name, s in per_slot.items():
+        if not isinstance(s, dict):
+            continue
+        table.add_row(
+            slot_name,
+            _fmt_state(s.get("state")),
+            s.get("model_id") or "—",
+            str(s.get("vram_mb", "—")),
+            str(s.get("ram_mb", "—")),
+            str(s.get("mem_mb", "—")),
+        )
+    console.print(table)

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -397,6 +397,20 @@ def update(
         return
 
     if rollback:
+        # Same confirm gate as the apply path below: interactive TTY without
+        # --yes prompts, headless/piped invocations proceed unattended. A
+        # rollback reverts the whole install tree — at least as consequential
+        # as an apply, so it shouldn't fire on zero confirmation.
+        if (
+            not yes
+            and _interactive()
+            and not typer.confirm(
+                "Roll back to the previous hal0 install? This reverts the entire install tree.",
+                default=False,
+            )
+        ):
+            console.print("[dim]rollback cancelled.[/dim]")
+            return
         try:
             body = api_post("/api/updates/rollback")
         except CliApiError as exc:

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -144,6 +144,25 @@ def _print_check(body: dict) -> None:
         console.print(table)
 
 
+def _refuse_if_editable() -> None:
+    """Die early on an editable/dev install — `hal0 update` can't swap the FHS tree.
+
+    Mirrors the daemon-side refusal (audit 4.1) so an operator on a
+    `pip install -e` checkout gets an immediate, actionable message instead of
+    a background prepare job that silently fails. Detection is metadata-driven
+    so an editable install cloned from git is caught too.
+    """
+    from hal0.updater.updater import _editable_install_path, _is_editable_install
+
+    if not _is_editable_install():
+        return
+    path = _editable_install_path() or "the current source tree"
+    die(
+        f"hal0 is installed in editable mode from {path}. "
+        "Install from release wheel with `pip install hal0`."
+    )
+
+
 def _poll_job(
     job_id: str,
     *,
@@ -438,6 +457,11 @@ def update(
     if not body.get("update_available") and not target_version:
         console.print("[dim]nothing to apply.[/dim]")
         return
+
+    # Refuse before staging: an editable/dev install has no FHS tree to swap,
+    # so a prepare/commit would either 409 at the daemon or phantom-succeed
+    # (audit 4.1). Fail fast with an actionable message.
+    _refuse_if_editable()
 
     # ── Stage → review notes → confirm → activate (prepare/commit split) ────────
     # prepare downloads + cosign-verifies + extracts WITHOUT touching the running

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -1,12 +1,20 @@
 """hal0 upstream subcommands — thin HTTP client to the hal0 API.
 
-Provides ``hal0 upstream {list,show,create,update,delete,test,set-credentials}``.
+Provides ``hal0 upstream {list,show,create,update,delete,test}`` plus the
+``hal0 upstream credentials set`` noun-subgroup.
 
 Request/response shapes mirror ``hal0.api.routes.providers`` exactly:
 create/update bodies are ``extra="forbid"`` on the server, so every flag
 here maps 1:1 onto a real body field. Credentials go through the separate
 ``/api/providers/{name}/credentials`` route (``{key, value}``) so secrets
 never transit the CRUD surface; ``create --api-key`` chains the two calls.
+
+CLI consolidation (2026-07): ``hal0 upstream set-credentials`` is renamed to
+``hal0 upstream credentials set`` — every other multi-facet resource in this
+cluster (``agent bootstrap``, ``mcp catalog``, ``memory graph``) uses a
+noun-subgroup, and the flat verb left no home for a future ``credentials
+show``/``credentials clear``. ``set-credentials`` remains as a hidden
+deprecated alias.
 """
 
 from __future__ import annotations
@@ -414,26 +422,15 @@ def test_upstream(
         raise typer.Exit(1)
 
 
-# ── set-credentials ───────────────────────────────────────────────────────
+# ── credentials ──────────────────────────────────────────────────────────
+
+credentials_app = typer.Typer(help="Manage upstream provider credentials.")
+app.add_typer(credentials_app, name="credentials")
 
 
-@app.command("set-credentials")
-def set_credentials(
-    name: str = typer.Argument(..., help="Provider name."),
-    key: str = typer.Option(
-        ...,
-        "--key",
-        prompt="API key",
-        hide_input=True,
-        help="API key VALUE (secret; prompted securely if omitted).",
-    ),
-    env_var: str = typer.Option(
-        None,
-        "--env-var",
-        help="Env-var name to write (defaults to the upstream's declared auth_value_env).",
-    ),
-) -> None:
-    """Set an API key for a provider (writes to api.env)."""
+def _do_set_credentials(name: str, key: str, env_var: str | None) -> None:
+    """Shared implementation behind ``upstream credentials set`` and the
+    deprecated ``upstream set-credentials`` alias."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)
@@ -467,3 +464,48 @@ def set_credentials(
         f"[green]✓[/green] Credential stored for [bold]{name}[/bold] "
         f"in api.env as [bold]{env_var}[/bold]"
     )
+
+
+@credentials_app.command("set")
+def credentials_set(
+    name: str = typer.Argument(..., help="Provider name."),
+    key: str = typer.Option(
+        ...,
+        "--key",
+        prompt="API key",
+        hide_input=True,
+        help="API key VALUE (secret; prompted securely if omitted).",
+    ),
+    env_var: str = typer.Option(
+        None,
+        "--env-var",
+        help="Env-var name to write (defaults to the upstream's declared auth_value_env).",
+    ),
+) -> None:
+    """Set an API key for a provider (writes to api.env)."""
+    _do_set_credentials(name, key, env_var)
+
+
+@app.command("set-credentials", hidden=True)
+def set_credentials(
+    name: str = typer.Argument(..., help="Provider name."),
+    key: str = typer.Option(
+        ...,
+        "--key",
+        prompt="API key",
+        hide_input=True,
+        help="API key VALUE (secret; prompted securely if omitted).",
+    ),
+    env_var: str = typer.Option(
+        None,
+        "--env-var",
+        help="Env-var name to write (defaults to the upstream's declared auth_value_env).",
+    ),
+) -> None:
+    """[DEPRECATED] alias for `upstream credentials set`; use that instead."""
+    typer.echo(
+        "[deprecated] `upstream set-credentials` is renamed to "
+        "`upstream credentials set`; use `hal0 upstream credentials set`.",
+        err=True,
+    )
+    _do_set_credentials(name, key, env_var)

--- a/src/hal0/install/extensions.py
+++ b/src/hal0/install/extensions.py
@@ -27,9 +27,22 @@ EXTENSIONS: list[Extension] = [
     Extension("openwebui", "app", "Open WebUI", "Chat web UI for your models", True),
     Extension("comfyui", "app", "ComfyUI", "Image & video generation (iGPU)", True),
     Extension("hermes", "agent", "Hermes", "Conversational agent with memory", True),
+    # Extension id stays "pi" (setup answers/state dicts + UI keys are keyed
+    # off this id across several other CLI modules) even though the bundled
+    # agent driver's canonical id is "pi-coder" (agents/manager.BUNDLED_AGENTS).
+    # See _AGENT_ID_ALIASES below for the translation at the install boundary.
     Extension("pi", "agent", "Pi", "Coding agent", False),
 ]
 _BY_ID = {e.id: e for e in EXTENSIONS}
+
+# Extension id -> the bundled-agent id ``hal0 agent install`` actually
+# recognises (``hal0.agents.manager.BUNDLED_AGENTS``). Today only "pi"
+# diverges: the setup screen's "Pi" label maps to extension id "pi", but the
+# driver module is registered as "pi-coder". Without this translation,
+# enabling "Pi" during setup silently failed — ``install_extension("pi")``
+# shelled out to ``hal0 agent install pi``, which AgentManager rejects with
+# "unknown bundled agent" since "pi" isn't in BUNDLED_AGENTS.
+_AGENT_ID_ALIASES: dict[str, str] = {"pi": "pi-coder"}
 
 
 def list_extensions(kind: str | None = None) -> list[Extension]:
@@ -123,7 +136,8 @@ def install_extension(ext_id: str) -> ExtensionOutcome:
         if ext.id == "openwebui":
             return install_openwebui()
         elif ext.kind == "agent":
-            _run(["hal0", "agent", "install", ext.id])
+            agent_id = _AGENT_ID_ALIASES.get(ext.id, ext.id)
+            _run(["hal0", "agent", "install", agent_id])
         elif ext.id == "comfyui":
             # ComfyUI is owned by the seeded img slot. The legacy
             # /opt/comfyui scripts remain manual operator tools only.

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -843,12 +843,55 @@ def _current_symlink() -> Path:
     return _usr_lib_root() / "current"
 
 
+def _editable_install_path() -> str | None:
+    """Return the source-tree path if hal0 is a pip *editable* install, else None.
+
+    Authoritative detection via PEP 610 installer metadata: pip records an
+    editable install's source tree in the package's ``direct_url.json`` with
+    ``dir_info.editable`` true. This is reliable even when the editable
+    checkout is itself a git clone — the ``__file__``-outside-``sys.prefix``
+    heuristic (below) misclassifies that as a git-tracked FHS install and lets
+    ``hal0 update`` silently no-op while reporting success (audit 4.1). The
+    recorded ``file://`` URL is returned as a plain path so a refusal can name
+    exactly where the editable tree lives.
+    """
+    try:
+        from importlib.metadata import distribution
+
+        raw = distribution("hal0").read_text("direct_url.json")
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    dir_info = data.get("dir_info")
+    if not isinstance(dir_info, dict) or not dir_info.get("editable"):
+        return None
+    url = str(data.get("url") or "")
+    parsed = urlparse(url)
+    if parsed.scheme == "file":
+        return parsed.path or url
+    return url or None
+
+
 def _is_editable_install() -> bool:
     """True when hal0 runs from an editable/dev checkout, not the FHS venv.
+
+    Metadata (PEP 610 ``direct_url.json``) is authoritative — it catches an
+    editable install cloned from git, which the ``__file__`` heuristic below
+    would wave through as a git-tracked FHS install (audit 4.1). The heuristic
+    is the fallback when installer metadata is absent (e.g. a bare source
+    checkout on ``sys.path``).
 
     Returns ``False`` for git-tracked installs under the FHS layout
     (``/usr/lib/hal0/hal0-<version>/``)— those are hosted by `prepare_git()`.
     """
+    if _editable_install_path() is not None:
+        return True
+
     import hal0
 
     try:
@@ -859,6 +902,31 @@ def _is_editable_install() -> bool:
     # Git-tracked FHS installs: code lives in a versioned dir under
     # /usr/lib/hal0/ — not truly editable. Let prepare_git handle them.
     return not _is_git_install()
+
+
+def _raise_if_editable_install() -> None:
+    """Hard-refuse an update when hal0 runs from an editable/dev install.
+
+    ``apply()`` / ``commit()`` manipulate the FHS layout (the
+    ``/usr/lib/hal0/current`` symlink + the shared venv's site-packages),
+    none of which exist in an editable checkout — so proceeding would extract
+    a tree that is never imported and report a phantom success (audit 4.1).
+    The single chokepoint for that refusal; detection is metadata-driven so an
+    editable install cloned from git is caught too.
+    """
+    if not _is_editable_install():
+        return
+    import hal0
+
+    path = _editable_install_path() or str(Path(hal0.__file__).resolve().parent)
+    raise UpdateError(
+        f"hal0 is installed in editable mode from {path}. "
+        "Install from release wheel with `pip install hal0`.",
+        details={
+            "editable_path": path,
+            "hint": "for a dev checkout run 'git pull && pip install -e .' to update",
+        },
+    )
 
 
 def _is_git_install() -> bool:
@@ -1475,13 +1543,7 @@ class Updater:
         # the FHS layout (/usr/lib/hal0/current symlink + venv site-packages)
         # which does not exist in an editable checkout.  Continuing would
         # silently extract a tarball that is never actually loaded.
-        # Re-run `git pull && pip install -e .` instead.
-        if _is_editable_install():
-            raise UpdateError(
-                "update is not supported on an editable (dev) install — "
-                "run 'git pull && pip install -e .' to update",
-                details={"hint": "editable install detected via hal0.__file__ outside sys.prefix"},
-            )
+        _raise_if_editable_install()
 
         # Step 1: fetch + validate manifest.
         log.info("updater.prepare_start", job_id=self.job_id, channel=self.channel, pinned=version)
@@ -1606,12 +1668,7 @@ class Updater:
         fail-soft after a successful commit. Returns the same breadcrumb dict
         shape as the old single-step apply.
         """
-        if _is_editable_install():
-            raise UpdateError(
-                "update is not supported on an editable (dev) install — "
-                "run 'git pull && pip install -e .' to update",
-                details={"hint": "editable install detected via hal0.__file__ outside sys.prefix"},
-            )
+        _raise_if_editable_install()
         target_version = (version or "").strip()
         if not target_version:
             raise UpdateManifestInvalid(
@@ -1792,6 +1849,10 @@ class Updater:
         that want to show release notes / gate on confirmation between the two
         phases call :meth:`prepare` then :meth:`commit` directly instead.
         """
+        # Single chokepoint: hard-refuse on editable/dev installs before any
+        # download/extract work (prepare/commit re-check, so the two-phase
+        # route path is covered too).
+        _raise_if_editable_install()
         prepared = await self.prepare(version)
         return await self.commit(str(prepared["version"]))
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -24,6 +24,17 @@ def _write_manifest(path: Path, payload: dict) -> Path:
     return path
 
 
+@pytest.fixture(autouse=True)
+def _not_editable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the editable-install check off (the test venv is itself editable).
+
+    The apply/prepare routes hard-refuse an editable install with a 409
+    (audit 4.1); without this the whole suite would trip that preflight. The
+    dedicated refusal test flips it back on explicitly.
+    """
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+
+
 @pytest.fixture
 def isolated_client(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -243,6 +254,35 @@ def test_apply_creates_a_queued_job_returning_id(isolated_client: TestClient) ->
     assert "id" in body and isinstance(body["id"], str)
     assert body["state"] in ("queued", "running", "failed")
     assert body["channel"] == "stable"
+
+
+def test_apply_refuses_editable_install_with_409(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An editable/dev install is refused at the route boundary (audit 4.1).
+
+    Preflight returns a typed 409 before any job is queued, so the operator
+    gets an immediate, actionable error instead of a background job that
+    silently fails later.
+    """
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: "/opt/hal0")
+    r = isolated_client.post("/api/updates/apply", json={})
+    assert r.status_code == 409, r.text
+    err = r.json()["error"]
+    assert err["code"] == "system.update_editable_install"
+    assert "editable mode from /opt/hal0" in err["message"]
+
+
+def test_prepare_refuses_editable_install_with_409(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The prepare route shares the same editable preflight (audit 4.1)."""
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: "/opt/hal0")
+    r = isolated_client.post("/api/updates/prepare", json={})
+    assert r.status_code == 409, r.text
+    assert r.json()["error"]["code"] == "system.update_editable_install"
 
 
 def test_status_unknown_job_returns_envelope(isolated_client: TestClient) -> None:

--- a/tests/cli/test_agent_uninstall_memory.py
+++ b/tests/cli/test_agent_uninstall_memory.py
@@ -262,7 +262,7 @@ def test_cli_silent_on_deleted_outcome(
             url="http://127.0.0.1:8080",
         ),
     )
-    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--force"])
     assert result.exit_code == 0, result.output
     # No warning markup on stderr.
     assert "warning" not in (result.stderr or "")
@@ -283,7 +283,7 @@ def test_cli_silent_on_not_found_outcome(
             url="http://127.0.0.1:8080",
         ),
     )
-    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--force"])
     assert result.exit_code == 0, result.output
     assert "warning" not in (result.stderr or "")
 
@@ -304,7 +304,7 @@ def test_cli_warns_on_unreachable_outcome(
     # Pin a wide console so Rich doesn't truncate the URL we assert on.
     monkeypatch.setenv("COLUMNS", "200")
 
-    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--force"])
 
     assert result.exit_code == 0, result.output
     assert "warning" in result.stderr
@@ -327,7 +327,7 @@ def test_cli_warns_on_leftover_outcome(
     )
     monkeypatch.setenv("COLUMNS", "200")
 
-    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"])
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--force"])
 
     assert result.exit_code == 0, result.output
     assert "warning" in result.stderr
@@ -351,8 +351,45 @@ def test_cli_keep_memory_skips_outcome_path(
 
     monkeypatch.setattr(agent_commands, "_uninstall_hermes_memory", _should_not_run)
 
-    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--keep-memory"])
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes", "--keep-memory", "--force"])
     assert result.exit_code == 0, result.output
     assert called["n"] == 0
     # Stdout still surfaces the preservation hint.
     assert "memory preserved" in result.output
+
+
+# ── confirmation gate (footgun fix) ───────────────────────────────────────────
+
+
+def test_cli_aborts_without_force_when_declined(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No --force, operator declines the prompt → aborts before any teardown."""
+    stub_uninstall_api()
+    called: dict[str, int] = {"n": 0}
+
+    def _should_not_run() -> agent_commands.MemoryUninstallOutcome:
+        called["n"] += 1
+        raise AssertionError("memory teardown ran despite declined confirm")
+
+    monkeypatch.setattr(agent_commands, "_uninstall_hermes_memory", _should_not_run)
+
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"], input="n\n")
+    assert result.exit_code != 0
+    assert called["n"] == 0
+
+
+def test_cli_proceeds_without_force_when_confirmed(
+    stub_uninstall_api: Callable[..., None], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No --force, operator confirms → teardown proceeds as usual."""
+    stub_uninstall_api()
+    _stub_memory_outcome(
+        monkeypatch,
+        agent_commands.MemoryUninstallOutcome(
+            outcome="deleted", deleted_count=1, leftover_count=0, url="http://127.0.0.1:8080"
+        ),
+    )
+    result = runner.invoke(agent_commands.app, ["uninstall", "hermes"], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert "Uninstalled" in result.output

--- a/tests/cli/test_app_list_uninstall.py
+++ b/tests/cli/test_app_list_uninstall.py
@@ -1,0 +1,84 @@
+"""Tests for `hal0 app list` / `hal0 app uninstall <name>` (CLI
+consolidation, 2026-07) — previously `app_commands.py` only had `install`,
+with no way to check state or remove an app via the CLI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import hal0.cli.app_commands as app_cmds
+
+runner = CliRunner()
+
+
+def test_app_list_queries_systemctl_for_known_apps(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kw: Any):
+        calls.append(cmd)
+
+        class _R:
+            stdout = "active\n" if cmd[1] == "is-active" else "enabled\n"
+
+        return _R()
+
+    monkeypatch.setattr(app_cmds.shutil, "which", lambda _name: "/usr/bin/systemctl")
+    monkeypatch.setattr(app_cmds.subprocess, "run", fake_run)
+
+    result = runner.invoke(app_cmds.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "openwebui" in result.output
+    assert "active" in result.output
+    assert "enabled" in result.output
+    assert any(c[:2] == ["systemctl", "is-enabled"] for c in calls)
+    assert any(c[:2] == ["systemctl", "is-active"] for c in calls)
+
+
+def test_app_list_without_systemctl_shows_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app_cmds.shutil, "which", lambda _name: None)
+    result = runner.invoke(app_cmds.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "?" in result.output
+
+
+def test_app_uninstall_unknown_app_dies() -> None:
+    with pytest.raises((SystemExit, typer.Exit)):
+        app_cmds.app_uninstall(name="comfyui", force=True)
+
+
+def test_app_uninstall_disables_and_stops_the_unit(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kw: Any):
+        calls.append(cmd)
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr(app_cmds.shutil, "which", lambda _name: "/usr/bin/systemctl")
+    monkeypatch.setattr(app_cmds.subprocess, "run", fake_run)
+
+    result = runner.invoke(app_cmds.app, ["uninstall", "openwebui", "--force"])
+    assert result.exit_code == 0, result.output
+    assert ["systemctl", "disable", "--now", "hal0-openwebui.service"] in calls
+
+
+def test_app_uninstall_requires_confirmation_without_force(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(app_cmds.shutil, "which", lambda _name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        app_cmds.subprocess,
+        "run",
+        lambda cmd, **_kw: calls.append(cmd) or type("R", (), {"returncode": 0})(),
+    )
+
+    result = runner.invoke(app_cmds.app, ["uninstall", "openwebui"], input="n\n")
+    assert result.exit_code != 0
+    assert calls == []

--- a/tests/cli/test_capabilities_commands.py
+++ b/tests/cli/test_capabilities_commands.py
@@ -1,0 +1,161 @@
+"""Tests for ``hal0 capabilities`` — list/set (live API) + migrate (footgun fix).
+
+``migrate`` used to default to a live write of ``/etc/hal0/capabilities.toml``
+(``--dry-run`` was opt-in). That inverted the safety contract every sibling
+repair command uses (``hal0 migrate model-layout`` is dry-run by default,
+``--apply`` opts into the write). These tests pin the new default: no flags =
+preview only, ``--apply`` = write.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.capabilities.config import CapabilityConfig, CapabilitySelection
+from hal0.cli import capabilities_commands as cc
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def stub_config(monkeypatch: pytest.MonkeyPatch):
+    """Stub load/save so migrate never touches a real capabilities.toml."""
+    saved: dict[str, Any] = {"cfg": None}
+
+    def _install(selections: dict[str, dict[str, CapabilitySelection]]) -> CapabilityConfig:
+        cfg = CapabilityConfig(selections=selections)
+        monkeypatch.setattr(cc, "load_capabilities_config", lambda: cfg)
+
+        def _save(c: CapabilityConfig) -> None:
+            saved["cfg"] = c
+
+        monkeypatch.setattr(cc, "save_capabilities_config", _save)
+        monkeypatch.setattr(cc, "file_lock", lambda *_a, **_k: _NullLock())
+        return cfg
+
+    _install.saved = saved  # type: ignore[attr-defined]
+    return _install
+
+
+class _NullLock:
+    def __enter__(self) -> _NullLock:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+
+def _illegal_selection() -> dict[str, dict[str, CapabilitySelection]]:
+    # A model no longer in the catalog — models_for_capability() stubbed to
+    # return nothing, so this always classifies as "unknown_model". "embed" is
+    # a legal child of the "embed" slot (see _CHILD_TO_CAPABILITY).
+    return {"embed": {"embed": CapabilitySelection(backend="cpu", provider="", model="ghost")}}
+
+
+def test_migrate_default_is_dry_run_and_does_not_write(
+    stub_config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub_config(_illegal_selection())
+    monkeypatch.setattr(cc, "models_for_capability", lambda *_a, **_k: [])
+
+    result = runner.invoke(cc.app, ["migrate"])
+
+    assert result.exit_code == 0, result.output
+    assert "--dry-run" in result.output
+    assert stub_config.saved["cfg"] is None  # never written
+
+
+def test_migrate_apply_writes(stub_config, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_config(_illegal_selection())
+    monkeypatch.setattr(cc, "models_for_capability", lambda *_a, **_k: [])
+
+    result = runner.invoke(cc.app, ["migrate", "--apply"])
+
+    assert result.exit_code == 0, result.output
+    assert "migrated" in result.output
+    assert stub_config.saved["cfg"] is not None
+
+
+def test_migrate_deprecated_dry_run_flag_is_still_a_noop_preview(
+    stub_config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The old ``--dry-run`` flag is hidden but harmless — still previews."""
+    stub_config(_illegal_selection())
+    monkeypatch.setattr(cc, "models_for_capability", lambda *_a, **_k: [])
+
+    result = runner.invoke(cc.app, ["migrate", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert stub_config.saved["cfg"] is None
+
+
+def test_migrate_nothing_to_do(stub_config, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_config({})
+    result = runner.invoke(cc.app, ["migrate"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to migrate" in result.output
+
+
+# ── list / set — thin clients over the live API ─────────────────────────────
+
+
+def test_list_renders_selections(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
+    monkeypatch.setattr(
+        cc,
+        "api_get",
+        lambda path, **_k: {
+            "selections": {
+                "embed": {
+                    "default": {
+                        "backend": "cpu",
+                        "provider": "",
+                        "model": "bge-small",
+                        "enabled": True,
+                    }
+                }
+            }
+        },
+    )
+    result = runner.invoke(cc.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "bge-small" in result.output
+
+
+def test_list_empty_selections(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
+    monkeypatch.setattr(cc, "api_get", lambda path, **_k: {"selections": {}})
+    result = runner.invoke(cc.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "no capability selections" in result.output
+
+
+def test_set_unknown_slot_dies() -> None:
+    result = runner.invoke(cc.app, ["set", "not-a-slot", "default", "--model", "x"])
+    assert result.exit_code != 0
+    assert "unknown capability slot" in result.output
+
+
+def test_set_requires_at_least_one_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = runner.invoke(cc.app, ["set", "embed", "embed"])
+    assert result.exit_code != 0
+    assert "nothing to set" in result.output
+
+
+def test_set_posts_only_provided_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, *, json: Any = None, **_k: Any) -> dict:
+        captured["path"] = path
+        captured["json"] = json
+        return {"ok": True, "selection": json}
+
+    monkeypatch.setattr(cc, "api_post", fake_post)
+    result = runner.invoke(cc.app, ["set", "embed", "embed", "--model", "bge-small"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/capabilities/embed/embed"
+    assert captured["json"] == {"model": "bge-small"}

--- a/tests/cli/test_config_hardware_probe.py
+++ b/tests/cli/test_config_hardware_probe.py
@@ -1,0 +1,80 @@
+"""Tests for `hal0 config hardware [--refresh]` and the deprecated `hal0
+probe` alias (CLI consolidation, 2026-07).
+
+`probe` and `config hardware` hit the identical hardware-probe payload —
+`probe` always forces a fresh POST, `config hardware` only GETs the cached
+payload. `--refresh` on `config hardware` does what `probe` did; `probe`
+becomes a thin hidden alias.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import config_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _api_reachable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(config_commands, "_api_unreachable", lambda _url: False)
+
+
+def test_config_hardware_default_gets_cached_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_get(path: str, **_kw: Any) -> dict[str, Any]:
+        calls.append(path)
+        return {"cpu_name": "demo-cpu"}
+
+    monkeypatch.setattr(config_commands, "api_get", fake_get)
+    result = runner.invoke(config_commands.app, ["hardware"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["/api/hardware"]
+    assert "demo-cpu" in result.output
+
+
+def test_config_hardware_refresh_posts_a_fresh_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_post(path: str, **_kw: Any) -> dict[str, Any]:
+        calls.append(path)
+        return {"cpu_name": "fresh-cpu"}
+
+    import hal0.cli._shared as shared
+
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(config_commands.app, ["hardware", "--refresh"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["/api/hardware/probe"]
+    assert "fresh-cpu" in result.output
+
+
+def test_probe_is_hidden_deprecated_alias_for_config_hardware_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hal0.cli.main import app as main_app
+
+    help_result = runner.invoke(main_app, ["--help"])
+    assert help_result.exit_code == 0, help_result.output
+    assert "probe" not in help_result.output
+
+    calls: list[str] = []
+
+    def fake_post(path: str, **_kw: Any) -> dict[str, Any]:
+        calls.append(path)
+        return {"cpu_name": "fresh-cpu"}
+
+    import hal0.cli._shared as shared
+
+    monkeypatch.setattr(config_commands, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(main_app, ["probe"])
+    assert result.exit_code == 0, result.output
+    assert calls == ["/api/hardware/probe"]
+    assert "deprecat" in result.stderr.lower()
+    assert "config hardware --refresh" in result.stderr.lower()

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -1,0 +1,72 @@
+"""Tests for the `hal0 config show [hal0|upstreams|providers]` and `config
+edit [...]` file selector (CLI consolidation, 2026-07).
+
+Previously both commands were hardcoded to hal0.toml, even though `hal0
+config validate` already checks three files — when validate reported an
+error in upstreams.toml, there was no `edit`/`show` target for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from hal0.cli import config_commands
+
+runner = CliRunner()
+
+
+def _set_home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    (home / "etc" / "hal0").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HAL0_HOME", str(home))
+    return home / "etc" / "hal0"
+
+
+def test_config_show_defaults_to_hal0_toml(monkeypatch, tmp_path: Path) -> None:
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    (cfg_dir / "hal0.toml").write_text("[meta]\nschema_version = 1\n")
+
+    result = runner.invoke(config_commands.app, ["show"])
+    assert result.exit_code == 0, result.output
+    assert "schema_version" in result.output
+
+
+def test_config_show_upstreams_selects_upstreams_toml(monkeypatch, tmp_path: Path) -> None:
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    (cfg_dir / "upstreams.toml").write_text("[[upstream]]\nname = 'demo'\n")
+
+    result = runner.invoke(config_commands.app, ["show", "upstreams"])
+    assert result.exit_code == 0, result.output
+    assert "demo" in result.output
+
+
+def test_config_show_providers_selects_providers_toml(monkeypatch, tmp_path: Path) -> None:
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    (cfg_dir / "providers.toml").write_text("[[provider]]\nname = 'demo-provider'\n")
+
+    result = runner.invoke(config_commands.app, ["show", "providers"])
+    assert result.exit_code == 0, result.output
+    assert "demo-provider" in result.output
+
+
+def test_config_show_missing_file_reports_dim_notice(monkeypatch, tmp_path: Path) -> None:
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    assert not (cfg_dir / "upstreams.toml").exists()
+
+    result = runner.invoke(config_commands.app, ["show", "upstreams"])
+    assert result.exit_code == 0, result.output
+    assert "No config at" in result.output
+
+
+def test_config_edit_upstreams_seeds_and_opens_upstreams_toml(monkeypatch, tmp_path: Path) -> None:
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")  # no-op editor available on any *nix box
+
+    result = runner.invoke(config_commands.app, ["edit", "upstreams"])
+    assert result.exit_code == 0, result.output
+    seeded = cfg_dir / "upstreams.toml"
+    assert seeded.exists()
+    # hal0.toml's bespoke seed content must NOT leak into other files.
+    assert "port_range_start" not in seeded.read_text()

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -71,6 +71,141 @@ def test_model_add_posts_add_from_path(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "hal0 model run" in result.output
 
 
+def test_model_add_with_license_follows_up_with_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI consolidation: `add` folded in `register`'s explicit-metadata
+    flags — `--license` isn't accepted by add-from-path, so it's applied
+    via a follow-up PUT /api/models/{id}."""
+    put_calls: list[tuple[str, Any]] = []
+
+    monkeypatch.setattr(
+        shared,
+        "api_post",
+        lambda path, **_kw: {"id": "demo-model", "path": "/mnt/ai-models/demo.gguf"},
+    )
+    monkeypatch.setattr(
+        model_commands,
+        "api_put",
+        lambda path, *, json=None, **_kw: (
+            put_calls.append((path, json))
+            or {"id": "demo-model", "path": "/mnt/ai-models/demo.gguf", "license": json["license"]}
+        ),
+    )
+    result = runner.invoke(
+        model_commands.app,
+        ["add", "/mnt/ai-models/demo.gguf", "--license", "Apache-2.0"],
+    )
+    assert result.exit_code == 0, result.output
+    assert put_calls == [("/api/models/demo-model", {"license": "Apache-2.0"})]
+
+
+def test_model_add_without_license_skips_put(monkeypatch: pytest.MonkeyPatch) -> None:
+    put_calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(
+        shared,
+        "api_post",
+        lambda path, **_kw: {"id": "demo-model", "path": "/mnt/ai-models/demo.gguf"},
+    )
+    monkeypatch.setattr(
+        model_commands,
+        "api_put",
+        lambda path, *, json=None, **_kw: put_calls.append((path, json)),
+    )
+    result = runner.invoke(model_commands.app, ["add", "/mnt/ai-models/demo.gguf"])
+    assert result.exit_code == 0, result.output
+    assert put_calls == []
+
+
+def _visible_command_names(typer_app) -> set[str]:
+    """Return the subcommand names Click would actually list in --help
+    (i.e. excluding ``hidden=True`` commands) — substring checks against
+    rendered --help text are unreliable since command names can appear
+    inside *other* commands' help strings (e.g. "add" mentions "Register")."""
+    import click
+    import typer
+
+    click_cmd = typer.main.get_command(typer_app)
+    ctx = click.Context(click_cmd)
+    return {
+        name for name in click_cmd.list_commands(ctx) if not click_cmd.get_command(ctx, name).hidden
+    }
+
+
+def test_model_register_is_hidden_deprecated_alias_for_add(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`model register` still works (no breaking removal), delegates to
+    `model add`, and is no longer advertised in `--help`."""
+    assert "register" not in _visible_command_names(model_commands.app)
+
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> dict[str, Any]:
+        captured["post_path"] = path
+        captured["post_json"] = json
+        return {"id": json["id"], "path": json["path"]}
+
+    put_calls: list[tuple[str, Any]] = []
+
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    monkeypatch.setattr(
+        model_commands,
+        "api_put",
+        lambda path, *, json=None, **_kw: (
+            put_calls.append((path, json))
+            or {"id": "demo-model", "path": "/mnt/ai-models/demo.gguf", "license": json["license"]}
+        ),
+    )
+    result = runner.invoke(
+        model_commands.app,
+        ["register", "demo-model", "--path", "/mnt/ai-models/demo.gguf"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecat" in result.stderr.lower()
+    assert "model add" in result.stderr.lower()
+    # Delegated straight through to add-from-path with the explicit id.
+    assert captured["post_path"] == "/api/models/add-from-path"
+    assert captured["post_json"]["id"] == "demo-model"
+    # register's default license ("unknown") is applied via the follow-up PUT.
+    assert put_calls == [("/api/models/demo-model", {"license": "unknown"})]
+
+
+def test_model_assign_is_hidden_deprecated_alias_for_slot_edit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`model assign` still works, delegates to the same PUT
+    /api/slots/{slot}/config endpoint `slot edit --model` uses, and is no
+    longer advertised in `--help`."""
+    from hal0.cli import slot_commands
+
+    assert "assign" not in _visible_command_names(model_commands.app)
+
+    put_calls: list[tuple[str, Any]] = []
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(
+        slot_commands,
+        "api_get",
+        lambda path, **_kw: {"model": {"default": "old-model", "context_size": 4096}},
+    )
+    monkeypatch.setattr(
+        slot_commands,
+        "api_put",
+        lambda path, *, json=None, **_kw: put_calls.append((path, json)) or {"state": "idle"},
+    )
+    result = runner.invoke(
+        model_commands.app,
+        ["assign", "demo-model", "--slot", "primary"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecat" in result.stderr.lower()
+    assert "slot edit" in result.stderr.lower()
+    assert put_calls == [
+        (
+            "/api/slots/primary/config",
+            {"model": {"default": "demo-model", "context_size": 4096}},
+        )
+    ]
+
+
 def test_model_store_show_reports_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         model_commands,

--- a/tests/cli/test_model_import_backup.py
+++ b/tests/cli/test_model_import_backup.py
@@ -1,0 +1,73 @@
+"""Tests for ``hal0 model import-backup`` (CLI consolidation, 2026-07).
+
+``hal0 registry import`` collided in name with the much bigger ``hal0
+model`` group; the canonical home is now ``hal0 model import-backup``,
+reusing :func:`hal0.cli.registry_commands._do_import_backup` so the
+tarball-handling/atomic-copy logic isn't duplicated. Full behavioural
+coverage (path traversal, atomic copy, tempdir cleanup, ...) lives in
+``tests/cli/test_registry_import.py`` against the shared implementation;
+these tests just pin the new command's wiring.
+"""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from hal0.cli.model_commands import app as model_app
+
+runner = CliRunner()
+
+REGISTRY_PAYLOAD = b"""# hal0 v0.1.x registry snapshot
+[models.hermes-4-14b]
+path = "/mnt/ai-models/local/hermes-4-14b.gguf"
+backends = ["vulkan"]
+capabilities = ["chat"]
+"""
+
+
+def _make_backup(tmp_path: Path) -> Path:
+    staging = tmp_path / "staging"
+    target = staging / "var" / "lib" / "hal0" / "registry" / "registry.toml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(REGISTRY_PAYLOAD)
+    tar_path = tmp_path / "hal0-v0.1-backup.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        for item in staging.rglob("*"):
+            if item.is_file():
+                tar.add(item, arcname=str(item.relative_to(staging)))
+    return tar_path
+
+
+def test_model_import_backup_is_registered_and_not_hidden() -> None:
+    """Unlike the deprecated ``registry import`` alias, this is the
+    canonical command and must show up in ``model --help``."""
+    from hal0.cli.main import app as main_app
+
+    result = runner.invoke(main_app, ["model", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "import-backup" in result.output
+
+
+def test_model_import_backup_happy_path(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path)
+    dest = tmp_path / "out" / "registry.toml"
+
+    result = runner.invoke(model_app, ["import-backup", str(tar_path), "--dest", str(dest)])
+    assert result.exit_code == 0, result.output
+    assert dest.read_bytes() == REGISTRY_PAYLOAD
+    # No deprecation notice on the canonical command.
+    assert "deprecat" not in result.output.lower()
+
+
+def test_model_import_backup_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    tar_path = _make_backup(tmp_path)
+    dest = tmp_path / "registry.toml"
+    dest.write_bytes(b"# pre-existing v0.2 registry -- do not clobber\n")
+
+    result = runner.invoke(model_app, ["import-backup", str(tar_path), "--dest", str(dest)])
+    assert result.exit_code != 0
+    assert "--force" in result.output
+    assert dest.read_bytes() == b"# pre-existing v0.2 registry -- do not clobber\n"

--- a/tests/cli/test_registry_import.py
+++ b/tests/cli/test_registry_import.py
@@ -364,16 +364,32 @@ def test_import_cleans_tempdir_on_failure(tmp_path: Path) -> None:
 
 
 def test_registry_command_registered_on_main_app() -> None:
-    """``hal0 registry import`` must be reachable from the top-level app.
+    """``hal0 registry import`` must still be reachable from the top-level
+    app, even though it's now a hidden deprecated alias for ``hal0 model
+    import-backup`` (CLI consolidation) — it should NOT be advertised in
+    ``--help`` any more, but direct invocation must keep working so
+    existing scripts don't break.
 
     Guards against forgetting the ``app.add_typer(registry_app, ...)``
-    wire-up in ``hal0.cli.main`` after the command was added.
+    wire-up in ``hal0.cli.main``.
     """
     from hal0.cli.main import app as main_app
 
-    result = runner.invoke(main_app, ["registry", "--help"])
+    help_result = runner.invoke(main_app, ["registry", "--help"])
+    assert help_result.exit_code == 0, help_result.output
+    assert "import" not in help_result.output
+
+    reach_result = runner.invoke(main_app, ["registry", "import", "--help"])
+    assert reach_result.exit_code == 0, reach_result.output
+
+
+def test_registry_import_prints_deprecation_notice(tmp_path) -> None:
+    tar_path = _make_backup(tmp_path, layout="var-lib")
+    dest = tmp_path / "out" / "registry.toml"
+    result = _invoke(tar_path=tar_path, dest=dest)
     assert result.exit_code == 0, result.output
-    assert "import" in result.output
+    assert "deprecat" in result.output.lower()
+    assert "model import-backup" in result.output
 
 
 def test_registry_import_help_mentions_force_and_dest() -> None:

--- a/tests/cli/test_slot_metrics_capacity.py
+++ b/tests/cli/test_slot_metrics_capacity.py
@@ -1,0 +1,92 @@
+"""Tests for `hal0 slot metrics [name]` / `hal0 slot capacity` (CLI
+consolidation, 2026-07) — `/api/slots/metrics` and `/api/slots/capacity`
+were already live endpoints (and hal0-admin MCP tools) with no CLI surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _api_reachable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+
+
+def test_slot_metrics_all_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(path: str, **_kw: Any) -> Any:
+        assert path == "/api/slots/metrics"
+        return {
+            "primary": {"tokens_per_sec": 42.5, "kv_cache_usage": 0.5, "mem_rss_mb": 1024},
+            "embed": {"tokens_per_sec": 0, "mem_rss_mb": 512},
+        }
+
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+    result = runner.invoke(slot_commands.app, ["metrics"])
+    assert result.exit_code == 0, result.output
+    assert "primary" in result.output
+    assert "embed" in result.output
+    assert "42.5" in result.output
+
+
+def test_slot_metrics_filters_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        slot_commands,
+        "api_get",
+        lambda path, **_kw: {
+            "primary": {"tokens_per_sec": 42.5},
+            "embed": {"tokens_per_sec": 0},
+        },
+    )
+    result = runner.invoke(slot_commands.app, ["metrics", "primary", "--json"])
+    assert result.exit_code == 0, result.output
+    assert "primary" in result.output
+    assert "embed" not in result.output
+
+
+def test_slot_metrics_unknown_name_dies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slot_commands, "api_get", lambda path, **_kw: {"primary": {}})
+    result = runner.invoke(slot_commands.app, ["metrics", "nope"])
+    assert result.exit_code != 0
+    assert "no metrics" in result.output.lower()
+
+
+def test_slot_capacity_reports_budget_and_per_slot_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(path: str, **_kw: Any) -> Any:
+        assert path == "/api/slots/capacity"
+        return {
+            "per_slot": {
+                "primary": {
+                    "state": "ready",
+                    "model_id": "qwen3-4b",
+                    "vram_mb": 4096,
+                    "ram_mb": 512,
+                    "mem_mb": 4608,
+                }
+            },
+            "slot_budget": {"used_slots": 1, "max_slots": 0},
+        }
+
+    monkeypatch.setattr(slot_commands, "api_get", fake_get)
+    result = runner.invoke(slot_commands.app, ["capacity"])
+    assert result.exit_code == 0, result.output
+    assert "unlimited" in result.output
+    assert "qwen3-4b" in result.output
+
+
+def test_slot_capacity_json_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        slot_commands,
+        "api_get",
+        lambda path, **_kw: {"per_slot": {}, "slot_budget": {"used_slots": 0, "max_slots": 4}},
+    )
+    result = runner.invoke(slot_commands.app, ["capacity", "--json"])
+    assert result.exit_code == 0, result.output
+    assert '"max_slots": 4' in result.output

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -35,6 +35,9 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     }
 
     monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    # The test venv is itself an editable install, so the audit-4.1 refusal
+    # would fire before staging; pin it off so the apply flow is exercised.
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
 
     def fake_get(path: str, **kwargs: object) -> dict:
         captured["get_paths"].append(path)
@@ -150,6 +153,7 @@ def test_post_apply_shows_drift_banner(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
     monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
     monkeypatch.setattr(uc, "_interactive", lambda: False)
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
 
     def fake_get(path: str, **kwargs: object) -> dict:
         if path == "/api/updates/slot-drift":
@@ -211,6 +215,26 @@ def test_prepare_then_commit_flow(stub_api: dict, monkeypatch: pytest.MonkeyPatc
     # prepare got the (normalized) target; commit got the resolved_version from the poll.
     assert stub_api["prepare_json"] == {"version": "0.1.1"}
     assert stub_api["commit_json"] == {"version": "0.1.1"}
+
+
+def test_update_refuses_on_editable_install(
+    stub_api: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An editable/dev install is hard-refused before staging (audit 4.1).
+
+    The refusal names the editable tree and points at the release wheel; it
+    must never reach /prepare or /commit.
+    """
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    monkeypatch.setattr("hal0.updater.updater._editable_install_path", lambda: "/opt/hal0")
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+    assert result.exit_code != 0
+    assert "editable mode from /opt/hal0" in result.output
+    assert "pip install hal0" in result.output
+    # Never staged or committed.
+    assert stub_api["prepare_json"] is None
+    assert stub_api["commit_json"] is None
 
 
 def test_yes_flag_present_and_skips_confirm(

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -243,6 +243,57 @@ def test_tty_decline_stages_without_commit(stub_api: dict, monkeypatch: pytest.M
     assert stub_api["commit_json"] is None  # declined → no commit
 
 
+def test_rollback_headless_proceeds_without_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Headless/piped (non-TTY) rollback proceeds unattended, like apply."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+    posted: list[str] = []
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        posted.append(path)
+        return {"channel": "stable"}
+
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    result = runner.invoke(app, ["update", "--rollback"])
+    assert result.exit_code == 0, result.output
+    assert "/api/updates/rollback" in posted
+    assert "rolled back" in result.output
+
+
+def test_rollback_yes_flag_skips_confirm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--yes`` drives straight to the rollback POST even on a TTY."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr(uc, "_interactive", lambda: True)
+    called = {"confirm": False}
+    monkeypatch.setattr(
+        uc.typer, "confirm", lambda *a, **k: called.__setitem__("confirm", True) or True
+    )
+    posted: list[str] = []
+    monkeypatch.setattr(
+        uc, "api_post", lambda path, **k: posted.append(path) or {"channel": "stable"}
+    )
+    result = runner.invoke(app, ["update", "--rollback", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert called["confirm"] is False
+    assert "/api/updates/rollback" in posted
+
+
+def test_rollback_tty_decline_never_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a TTY without --yes, declining the prompt never issues the rollback POST."""
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr(uc, "_warn_editable_version_drift", lambda: None)
+    monkeypatch.setattr(uc, "_interactive", lambda: True)
+    monkeypatch.setattr(uc.typer, "confirm", lambda *a, **k: False)
+    posted: list[str] = []
+    monkeypatch.setattr(uc, "api_post", lambda path, **k: posted.append(path) or {})
+    result = runner.invoke(app, ["update", "--rollback"])
+    assert result.exit_code == 0, result.output
+    assert posted == []
+    assert "cancelled" in result.output
+
+
 def test_render_notes_shows_breaking_and_migrations(capsys: pytest.CaptureFixture[str]) -> None:
     """_render_notes surfaces breaking/migration callouts and highlights."""
     uc._render_notes(

--- a/tests/cli/test_upstream_commands.py
+++ b/tests/cli/test_upstream_commands.py
@@ -190,6 +190,44 @@ def test_set_credentials_explicit_env_var_skips_lookup(api: dict[str, Any]) -> N
     assert body == {"key": "CORP_KEY", "value": "sk-x"}
 
 
+# ── `credentials set` (canonical) + `set-credentials` (deprecated alias) ──
+
+
+def test_credentials_set_is_the_canonical_command(api: dict[str, Any]) -> None:
+    """`upstream credentials set` — the noun-subgroup rename — behaves
+    identically to the old flat `set-credentials` verb."""
+    result = runner.invoke(
+        upstream_commands.app,
+        ["credentials", "set", "openrouter", "--key", "sk-test"],
+    )
+    assert result.exit_code == 0, result.output
+    assert api["gets"] == ["/api/upstreams/openrouter"]
+    path, body = api["posts"][0]
+    assert path == "/api/providers/openrouter/credentials"
+    assert body == {"key": "OPENROUTER_API_KEY", "value": "sk-test"}
+    # No deprecation notice on the canonical command.
+    assert "deprecat" not in result.output.lower()
+
+
+def test_set_credentials_is_hidden_deprecated_alias(api: dict[str, Any]) -> None:
+    from hal0.cli.main import app as main_app
+
+    help_result = runner.invoke(main_app, ["upstream", "--help"])
+    assert help_result.exit_code == 0, help_result.output
+    assert "set-credentials" not in help_result.output
+
+    result = runner.invoke(
+        upstream_commands.app,
+        ["set-credentials", "openrouter", "--key", "sk-test"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "deprecat" in result.stderr.lower()
+    assert "credentials set" in result.stderr.lower()
+    path, body = api["posts"][0]
+    assert path == "/api/providers/openrouter/credentials"
+    assert body == {"key": "OPENROUTER_API_KEY", "value": "sk-test"}
+
+
 def test_list_renders_url_and_filter_summary(api: dict[str, Any]) -> None:
     # Short values throughout — Rich truncates wide cells at the 80-col
     # test terminal, so realistic-length URLs can't be asserted verbatim.

--- a/tests/install/test_extensions.py
+++ b/tests/install/test_extensions.py
@@ -34,6 +34,21 @@ def test_install_unknown_extension_skips():
     assert out.installed is False and out.skipped == "unknown_extension"
 
 
+def test_install_pi_extension_resolves_to_bundled_agent_id(monkeypatch):
+    """Extension id "pi" must translate to the "pi-coder" bundled-agent id
+    at the ``hal0 agent install`` boundary (BUNDLED_AGENTS in
+    agents/manager.py only recognises "pi-coder") — without this, enabling
+    "Pi" during setup silently failed with "unknown bundled agent"."""
+    from hal0.agents.manager import BUNDLED_AGENTS
+
+    ran = []
+    monkeypatch.setattr(ext_mod, "_run", lambda *a, **k: ran.append(a[0]))
+    out = install_extension("pi")
+    assert isinstance(out, ExtensionOutcome) and out.installed is True
+    assert ran == [["hal0", "agent", "install", "pi-coder"]]
+    assert "pi-coder" in BUNDLED_AGENTS
+
+
 # ── OpenWebUI wiring (issue #1102 / Q9) ─────────────────────────────────────
 #
 # install_extension("openwebui") and the standalone install_openwebui() must


### PR DESCRIPTION
## hal0 bones review — Team CLI + Update Reliability

Three CLI/updater reliability fixes on one branch.

### 1. Hard-refuse `hal0 update` on an editable install (audit 4.1)
`hal0 update` on a `pip install -e` checkout silently no-ops while reporting success — apply() swaps the FHS `current` symlink + re-pips the venv, neither of which exists in an editable install, so the extracted tree is never imported.

- Detect via PEP 610 `direct_url.json` (`dir_info.editable`) — authoritative even when the editable checkout is a git clone (the old `__file__`-outside-`sys.prefix` heuristic misclassified that as a git-tracked FHS install).
- `updater.py`: `_raise_if_editable_install()` chokepoint wired into prepare/commit/apply.
- CLI: refuse before staging with an actionable message.
- Route: preflight **409** (`system.update_editable_install`) on `/apply` + `/prepare` instead of a queued job that fails later.
- `install.sh`: corrected the DEV_MODE comment.
- Tests: CLI + route refusal coverage; editable check pinned off in the (editable) test venv.

No `--force` override, by design.

### 2. Gate destructive CLI footguns behind confirm/--force (prior art)
`0e8417ed` — carried from `wt-fix-cli-footguns`.

### 3. Consolidate overlapping commands into deprecated-alias pairs (prior art)
`3820250e` — carried from `wt-fix-cli-consolidate`.

### Tests
`tests/cli/test_update_commands.py tests/updater/ tests/api/test_updater_routes.py` → **120 passed**. `ruff check` + `ruff format` clean.

Ref #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)