### PR TITLE
docs(installer): loud LAN-only bind warning + auth-hygiene audit outcome

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -110,8 +110,25 @@ ui_banner
 HAL0_PORT="${HAL0_PORT:-8080}"
 PY="${HAL0_PYTHON:-python3}"
 
-# API binds 0.0.0.0:8080 unconditionally. TLS is upstream's job — see
-# the comment on TLS posture near the flag parser.
+# ==========================================================================
+# SECURITY — LAN-ONLY BIND. READ BEFORE CHANGING.
+# --------------------------------------------------------------------------
+# hal0-api binds 0.0.0.0:8080, i.e. EVERY network interface. This is a
+# deliberate zero-config choice so the dashboard is reachable from any
+# device on the *local network* without setup. It is NOT hardened for the
+# public internet: hal0 ships NO TLS, NO edge auth, NO rate limiting on
+# this bind.
+#
+#   * SAFE:   a trusted LAN / VPN / private subnet behind a firewall.
+#   * UNSAFE: exposing 0.0.0.0:8080 directly to the internet (port-forward,
+#             cloud VM with a public IP, DMZ). Anyone who can reach the
+#             port can drive the API.
+#
+# To expose hal0 externally, put a reverse proxy (Traefik / nginx /
+# Cloudflare Tunnel) in FRONT of it for TLS + auth — see docs/operate/tls.md
+# — and firewall :8080 off from the public interface. Do NOT flip this to a
+# loopback-only bind: 127.0.0.1 breaks the zero-config LAN dashboard.
+# ==========================================================================
 API_BIND_HOST="0.0.0.0"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Team AUTH & SECURITY — hal0 bones review v0.9.7.1

Two audit items assigned. Findings + actions below.

### Task 2 — Auth comment hygiene (audit 3.1): ALREADY DONE ✅
No changes needed. This was already resolved and merged in commit `7aba0b3f` — *"fix(auth): comment hygiene — drop phantom require_token/require_writer refs + thinmint.dev default origin (closes #619) (#648)"*.

Verified in the current tree:
- `require_token` in `src/`: **0 occurrences** (phantom comments gone)
- `AuthIdentity`: **0 occurrences** (stale ref gone)
- `hal0.thinmint.dev` in `DEFAULT_ALLOWED_ORIGINS` (`api/agents/_auth.py`): **gone** — list is now `hal0.local`, `localhost:5173`, `127.0.0.1:8080`
- Remaining `thinmint` hits are legit **test fixtures** + a docstring example, not the audit target.

The cited line numbers reference a pre-#648 revision.

### Task 1 — Non-root runtime (audit 3.2): partial, by design
**Delivered (this PR):** a loud LAN-only security banner where the installer selects the `0.0.0.0:8080` bind — spells out no-TLS/no-auth/no-rate-limit, safe-on-trusted-LAN vs unsafe-on-internet, and points at a reverse proxy (`docs/operate/tls.md`) + firewall. Bind kept at `0.0.0.0` (loopback breaks the zero-config LAN dashboard).

**Deliberately NOT done — `User=hal0` flip + chown:** this would ship a **broken installer**. Verified:
- `providers/container.py` writes slot units to `/etc/systemd/system` and runs `systemctl daemon-reload/enable/restart` **directly** — requires root.
- The `hal0-slotctl` privilege seam (sudoers + euid routing) that formerly let an unprivileged API do this was **deliberately removed** (`install/perms.py:102-105`, `install.sh:846-852,935-942`).
- Flipping `User=root`→`User=hal0` without re-introducing that seam → the API can no longer create/start slots.

Re-introducing the privilege seam is a cross-cutting refactor that reverses a recent, documented decision; it needs explicit sign-off, not an autonomous flip. Filed as the blocker for audit 3.2.

### Tests
`tests/systemd/`, `tests/api/test_mcp_transport_security.py`, `tests/api/test_middleware.py`, `tests/api/test_chat_proxy_auth.py` → **69 passed**. `bash -n install.sh` clean.

Ref audit 3.1, audit 3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)