### PR TITLE
docs(adr-0023): scrub stale hal0/chat default refs → hal0/agent

### DIFF
--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -272,11 +272,11 @@ container provider.
 ### Example slot TOML
 
 <Tabs>
-<TabItem label="GPU chat slot">
+<TabItem label="GPU agent (LLM) slot">
 
 ```toml
 [slot]
-name = "chat"
+name = "agent"
 port = 8081
 device = "gpu-rocm"
 profile = "rocm"

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1448,7 +1448,7 @@ def _live_resolve_enabled() -> bool:
     """Single source of truth for live-resolve mode.
 
     Live-resolve is the hal0 default: ``model.default`` → the virtual
-    ``hal0/chat`` and ``providers.custom`` → the hal0-api gateway
+    ``hal0/agent`` and ``providers.custom`` → the hal0-api gateway
     (:8080/v1) with ``discover_models`` + an api_key, so Hermes' model picker
     live-discovers every loaded slot (responsive, auto-updating, context-aware)
     instead of pinning one physical backend. hal0-api always serves
@@ -1534,7 +1534,7 @@ def _build_config_overlay(
     from live ``/v1/models`` discovery instead).
 
     Under live-resolve (the hal0 default) ``model.default`` is the virtual
-    ``hal0/chat`` against the gateway with ``discover_models`` on, so the
+    ``hal0/agent`` against the gateway with ``discover_models`` on, so the
     picker live-discovers every loaded slot. ``HAL0_HERMES_LIVE_RESOLVE=0``
     pins the single physical backend instead.
 
@@ -2012,7 +2012,7 @@ def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
                 "site": "primary_slot",
                 "detail": (
                     "no ready llm slot — overlay points model.default at the "
-                    "hal0/chat virtual against the gateway"
+                    "hal0/agent virtual against the gateway"
                 ),
             }
         )


### PR DESCRIPTION
## Summary

ADR-0023 (canonical LLM roles: `agent` default anchor + `utility` cheap helper; `chat`/`primary` retired) is **already functionally complete on main** at e9639de1. Team ADR-0023 audit confirmed every migration subtask landed:

| Mission item | State |
|---|---|
| Seed `utility` slot | ✅ `SEEDED_SLOTS` carries `utility`; `installer/etc-hal0/slots/utility.toml` + `agent.toml` ship (clean grey-tile seeds) |
| Hindsight extraction path | ✅ `HINDSIGHT_API_LLM_MODEL=hal0/utility`; resolver `hal0/utility → (utility, agent)` |
| Default model | ✅ `_capability_resolve._DEFAULT_MODEL = "agent"` |
| Hermes default | ✅ renders `model.default = hal0/agent` |
| Published aliases | ✅ per-slot alias entries (`agent`, `utility`); canonical virtuals deliberately not double-advertised (locked by `test_virtual_models.py`) |

The repo went **further** than the v0.9.7.1 brief: `chat`/`primary` are fully retired as virtual names, not kept as aliases — locked by `test_resolver.py::test_removed_aliases_are_unknown`. This PR does **not** reinstate them.

## What this changes (doc/comment drift only)

- **`hermes_provision.py`** — three live-resolve docstrings/detail strings still said the default virtual was `hal0/chat`; the code emits `hal0/agent`. Prose synced.
- **`config-schema.mdx`** — the "GPU chat slot" example TOML used the retired slot name `name = "chat"`; renamed to canonical `agent` (port 8081 unchanged = agent seed's canonical port).

No behavior change.

## Tests

`142 passed` — `tests/agents/test_hermes_live_resolve_render.py`, `tests/agents/test_hermes_provision.py`, `tests/normalize/test_resolver.py`, `tests/api/test_virtual_models.py`. Ruff clean.

> Note: two failures in the broader `tests/api` run (`test_set_store_rejects_non_writable_path`, `test_preview_returns_detection_rows_without_registering`) are **environmental** (tests run as root → chmod 0o555 ignored; FLM installed on the audit box → NPU models seed the registry), pre-existing on the untouched tree, and unrelated to this change.

Ref #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)