### PR TITLE
fix(comfyui): ESRGAN source, hf-CLI compat, curated model orchestration

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -350,6 +350,16 @@ Walks `/etc/hal0/capabilities.toml`: selections whose backend can't serve the
 model are snapped to the model's first legal backend; selections whose model
 left the catalog are cleared. Idempotent.
 
+## `hal0 comfyui` — ComfyUI model provisioning
+
+| Command | Purpose | Key options |
+|---|---|---|
+| `comfyui orchestrate-models` | Pull the curated ComfyUI model set (the default variant of every capability — SDXL/Qwen/Wan/LTX-2/Hunyuan/ESRGAN) in one logged sequence. A failed *optional* asset (e.g. the ESRGAN 4x-UltraSharp mirror) never blocks the others; the run exits non-zero only when a *required* family fails. Already-present files are skipped, so it is safe to re-run. | `--dry-run`, `--log-dir` |
+
+Each step's start and exit code plus a final summary are written to
+`<model-store>/comfyui/logs/orchestrate-<timestamp>.log`; the path is printed on
+completion.
+
 ## `hal0 app` — optional apps
 
 | Command | Purpose | Key options |

--- a/installer/comfyui/scripts/get_esrgan.sh
+++ b/installer/comfyui/scripts/get_esrgan.sh
@@ -3,6 +3,13 @@
 # Targets: upscale_models/4x-UltraSharp.pth + upscale_models/RealESRGAN_x4plus.pth
 # hal0 model store: /mnt/ai-models/comfyui/models
 # Follows kyuz0 vendored-script conventions (curl download, dry-run).
+#
+# #1200: the previous 4x-UltraSharp source (Kim2091/4x-UltraSharp) began
+# returning HTTP 401, silently breaking the upscale workflow path. It is now
+# pulled from the stable public mirror lokCX/4x-Ultrasharp. Each asset reports
+# the specific source it failed on; 4x-UltraSharp is treated as OPTIONAL (a
+# 401/404 there logs a skip and does not fail the run) while RealESRGAN_x4plus
+# is REQUIRED (its failure exits non-zero).
 set -euo pipefail
 
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
@@ -17,32 +24,63 @@ done
 if [[ "$DRY_RUN" -eq 1 ]]; then
   echo "[dry-run] MODEL_DIR=$MODEL_DIR"
   echo "[dry-run] Would download to:"
-  echo "  upscale_models/  4x-UltraSharp.pth"
-  echo "  upscale_models/  RealESRGAN_x4plus.pth"
+  echo "  upscale_models/  4x-UltraSharp.pth     (optional)"
+  echo "  upscale_models/  RealESRGAN_x4plus.pth (required)"
   exit 0
 fi
 
 mkdir -p "$MODEL_DIR/upscale_models"
 
+# download_if_missing <url> <optional|required>
+#   Returns 0 on success or when the file is already present. On failure it
+#   prints the exact asset + source that failed and returns 1; the caller
+#   decides whether that is fatal (required) or skippable (optional).
 download_if_missing() {
   local url="$1"
-  local dest_file="$MODEL_DIR/upscale_models/$(basename "$url")"
+  local kind="${2:-required}"
+  local name
+  name="$(basename "$url")"
+  local dest_file="$MODEL_DIR/upscale_models/$name"
 
   if [[ -f "$dest_file" ]]; then
     echo "✓ Already present: $dest_file"
-    return
+    return 0
   fi
 
-  echo "↓ Downloading $(basename "$url") → $dest_file"
-  curl -fL --progress-bar -o "$dest_file" "$url"
+  echo "↓ Downloading $name ($kind) → $dest_file"
+  # Stage to a temp file so a partial/failed download never leaves a truncated
+  # .pth in place (preserves idempotency on re-run).
+  local tmp="${dest_file}.part"
+  if curl -fL --progress-bar -o "$tmp" "$url"; then
+    mv -f "$tmp" "$dest_file"
+    echo "✓ Downloaded $name"
+    return 0
+  fi
+  rm -f "$tmp"
+  echo "✗ FAILED to download $name [$kind] from: $url" >&2
+  return 1
 }
 
-# 4x-UltraSharp (widely used ESRGAN upscale model)
-download_if_missing \
-  "https://huggingface.co/Kim2091/4x-UltraSharp/resolve/main/4x-UltraSharp.pth"
+rc=0
 
-# RealESRGAN x4plus (xinntao/Real-ESRGAN official release)
-download_if_missing \
-  "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth"
+# 4x-UltraSharp — OPTIONAL. Widely used ESRGAN upscale model; served from the
+# stable public mirror lokCX/4x-Ultrasharp (#1200: the old Kim2091 source 401s).
+if ! download_if_missing \
+  "https://huggingface.co/lokCX/4x-Ultrasharp/resolve/main/4x-UltraSharp.pth" \
+  "optional"; then
+  echo "⚠ 4x-UltraSharp.pth unavailable — skipping (optional asset)." >&2
+fi
+
+# RealESRGAN x4plus — REQUIRED (xinntao/Real-ESRGAN official release).
+if ! download_if_missing \
+  "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth" \
+  "required"; then
+  rc=1
+fi
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "✗ ESRGAN: a required model failed to download (see errors above)." >&2
+  exit "$rc"
+fi
 
 echo "✓ ESRGAN models ready in $MODEL_DIR/upscale_models"

--- a/installer/comfyui/scripts/get_hunyuan15.sh
+++ b/installer/comfyui/scripts/get_hunyuan15.sh
@@ -12,6 +12,20 @@ export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
 # container venv path for in-container execution.
 HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
+# Fail early with a clear remediation message if no usable Hugging Face CLI was
+# resolved (#1196). Checked lazily at first real download so --dry-run and the
+# idempotent "already present" paths never require hf to be installed.
+_require_hf() {
+  if command -v "$HF" >/dev/null 2>&1 || [[ -x "$HF" ]]; then
+    return 0
+  fi
+  echo "✗ Hugging Face CLI not found (resolution order: \$HF, 'hf' on PATH, /opt/venv/bin/hf)." >&2
+  echo "  Install it with:  pipx install 'huggingface_hub[hf_transfer]'" >&2
+  echo "               or:  pip install --user 'huggingface_hub[hf_transfer]'" >&2
+  echo "  Or point \$HF at an existing binary:  HF=/path/to/hf $0 ..." >&2
+  exit 127
+}
+
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_hunyuan15"
 
@@ -41,9 +55,9 @@ download_if_missing () {
   mkdir -p "$(dirname "$staged")"
   mkdir -p "$dest_dir"
 
+  _require_hf
   "$HF" download "$repo" "$remote" \
       --repo-type model \
-      --cache-dir "$HF_HOME" \
       --local-dir "$STAGE"
   mv -f "$staged" "$dest_file"
 }

--- a/installer/comfyui/scripts/get_ltx2.sh
+++ b/installer/comfyui/scripts/get_ltx2.sh
@@ -11,6 +11,20 @@ export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
 # container venv path for in-container execution.
 HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
+# Fail early with a clear remediation message if no usable Hugging Face CLI was
+# resolved (#1196). Checked lazily at first real download so --dry-run and the
+# idempotent "already present" paths never require hf to be installed.
+_require_hf() {
+  if command -v "$HF" >/dev/null 2>&1 || [[ -x "$HF" ]]; then
+    return 0
+  fi
+  echo "✗ Hugging Face CLI not found (resolution order: \$HF, 'hf' on PATH, /opt/venv/bin/hf)." >&2
+  echo "  Install it with:  pipx install 'huggingface_hub[hf_transfer]'" >&2
+  echo "               or:  pip install --user 'huggingface_hub[hf_transfer]'" >&2
+  echo "  Or point \$HF at an existing binary:  HF=/path/to/hf $0 ..." >&2
+  exit 127
+}
+
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_ltx2"                     # persistent staging (enables resume)
 
@@ -35,9 +49,9 @@ download_if_missing () {
   mkdir -p "$(dirname "$staged")"        # ensure stage path exists
   mkdir -p "$dest_dir"                   # ensure dest dir exists
 
+  _require_hf
   "$HF" download "$repo" "$remote" \
       --repo-type model \
-      --cache-dir "$HF_HOME" \
       --local-dir "$STAGE"
   mv -f "$staged" "$dest_file"
 }
@@ -56,7 +70,7 @@ Maintenance:
   clean-cache   Remove Hugging Face cache (~/.cache/huggingface)
 
 Notes:
-- Downloads RESUME automatically via persistent --cache-dir and --local-dir.
+- Downloads RESUME automatically via the persistent staging dir (--local-dir "$STAGE").
 USAGE
 }
 

--- a/installer/comfyui/scripts/get_qwen_image.sh
+++ b/installer/comfyui/scripts/get_qwen_image.sh
@@ -11,6 +11,20 @@ export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
 # container venv path for in-container execution.
 HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
+# Fail early with a clear remediation message if no usable Hugging Face CLI was
+# resolved (#1196). Checked lazily at first real download so --dry-run and the
+# idempotent "already present" paths never require hf to be installed.
+_require_hf() {
+  if command -v "$HF" >/dev/null 2>&1 || [[ -x "$HF" ]]; then
+    return 0
+  fi
+  echo "✗ Hugging Face CLI not found (resolution order: \$HF, 'hf' on PATH, /opt/venv/bin/hf)." >&2
+  echo "  Install it with:  pipx install 'huggingface_hub[hf_transfer]'" >&2
+  echo "               or:  pip install --user 'huggingface_hub[hf_transfer]'" >&2
+  echo "  Or point \$HF at an existing binary:  HF=/path/to/hf $0 ..." >&2
+  exit 127
+}
+
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_qwen"                      # persistent staging (resume support)
 
@@ -31,9 +45,9 @@ dl() {
 
   echo "↓ Downloading $(basename "$remote") → $dest"
   mkdir -p "$(dirname "$staged")"
+  _require_hf
   "$HF" download "$repo" "$remote" \
       --repo-type model \
-      --cache-dir "$HF_HOME" \
       --local-dir "$STAGE"
   mv -f "$staged" "$dest"
 }

--- a/installer/comfyui/scripts/get_sdxl.sh
+++ b/installer/comfyui/scripts/get_sdxl.sh
@@ -11,6 +11,20 @@ export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
 # container venv path for in-container execution.
 HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
+# Fail early with a clear remediation message if no usable Hugging Face CLI was
+# resolved (#1196). Checked lazily at first real download so --dry-run and the
+# idempotent "already present" paths never require hf to be installed.
+_require_hf() {
+  if command -v "$HF" >/dev/null 2>&1 || [[ -x "$HF" ]]; then
+    return 0
+  fi
+  echo "✗ Hugging Face CLI not found (resolution order: \$HF, 'hf' on PATH, /opt/venv/bin/hf)." >&2
+  echo "  Install it with:  pipx install 'huggingface_hub[hf_transfer]'" >&2
+  echo "               or:  pip install --user 'huggingface_hub[hf_transfer]'" >&2
+  echo "  Or point \$HF at an existing binary:  HF=/path/to/hf $0 ..." >&2
+  exit 127
+}
+
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_sdxl"
 
@@ -57,9 +71,9 @@ download_if_missing() {
   mkdir -p "$(dirname "$staged")"
   mkdir -p "$dest_dir"
 
+  _require_hf
   "$HF" download "$repo" "$remote" \
       --repo-type model \
-      --cache-dir "$HF_HOME" \
       --local-dir "$STAGE"
   mv -f "$staged" "$dest_file"
 }

--- a/installer/comfyui/scripts/get_wan22.sh
+++ b/installer/comfyui/scripts/get_wan22.sh
@@ -11,6 +11,20 @@ export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"   # persistent HF cache
 # container venv path for in-container execution.
 HF="${HF:-$(command -v hf 2>/dev/null || echo /opt/venv/bin/hf)}"
 
+# Fail early with a clear remediation message if no usable Hugging Face CLI was
+# resolved (#1196). Checked lazily at first real download so --dry-run and the
+# idempotent "already present" paths never require hf to be installed.
+_require_hf() {
+  if command -v "$HF" >/dev/null 2>&1 || [[ -x "$HF" ]]; then
+    return 0
+  fi
+  echo "✗ Hugging Face CLI not found (resolution order: \$HF, 'hf' on PATH, /opt/venv/bin/hf)." >&2
+  echo "  Install it with:  pipx install 'huggingface_hub[hf_transfer]'" >&2
+  echo "               or:  pip install --user 'huggingface_hub[hf_transfer]'" >&2
+  echo "  Or point \$HF at an existing binary:  HF=/path/to/hf $0 ..." >&2
+  exit 127
+}
+
 MODEL_DIR="${MODEL_DIR:-/mnt/ai-models/comfyui/models}"
 STAGE="$MODEL_DIR/.hf_stage_wan22"                     # persistent staging (enables resume)
 
@@ -45,9 +59,9 @@ download_if_missing () {
   mkdir -p "$(dirname "$staged")"        # ensure stage path exists
   mkdir -p "$dest_dir"                   # ensure dest dir exists
 
+  _require_hf
   "$HF" download "$repo" "$remote" \
       --repo-type model \
-      --cache-dir "$HF_HOME" \
       --local-dir "$STAGE"
   mv -f "$staged" "$dest_file"
 }
@@ -67,7 +81,7 @@ Maintenance:
   clean-cache   Remove Hugging Face cache (~/.cache/huggingface)
 
 Notes:
-- Downloads RESUME automatically via persistent --cache-dir and --local-dir.
+- Downloads RESUME automatically via the persistent staging dir (--local-dir "$STAGE").
 USAGE
 }
 

--- a/src/hal0/cli/comfyui_commands.py
+++ b/src/hal0/cli/comfyui_commands.py
@@ -1,0 +1,85 @@
+"""hal0 comfyui subcommands — ComfyUI model provisioning helpers.
+
+Currently exposes ``orchestrate-models`` (#1199): pull the curated ComfyUI model
+set (the default variant of every capability) in one sequence, logging each step
+and writing an operator-readable log.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(help="ComfyUI model provisioning.")
+console = Console()
+
+
+@app.command("orchestrate-models")
+def orchestrate_models_cmd(
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="List the curated families and their scripts without downloading.",
+    ),
+    log_dir: str = typer.Option(
+        "",
+        "--log-dir",
+        help="Directory for the run log (default: <model-store>/comfyui/logs).",
+    ),
+) -> None:
+    """Pull the curated ComfyUI model set end-to-end, logging each step.
+
+    Runs the default variant of every capability (SDXL/Qwen/Wan/LTX-2/Hunyuan/
+    ESRGAN) in sequence via the vendored ``get_*.sh`` scripts. A failed *optional*
+    asset (e.g. the ESRGAN 4x-UltraSharp mirror) does not block the other
+    families; the command exits non-zero only if a *required* family fails.
+    Already-present files are skipped, so it is safe to re-run.
+    """
+    from pathlib import Path
+
+    from hal0.comfyui.orchestrate import OPTIONAL_FAMILIES, curated_set, orchestrate_models
+
+    pairs = curated_set()
+
+    if dry_run:
+        table = Table(title="Curated ComfyUI model set")
+        table.add_column("Capability")
+        table.add_column("Family")
+        table.add_column("Script")
+        table.add_column("Steps", justify="right")
+        table.add_column("Kind")
+        for cap_id, variant in pairs:
+            kind = "optional" if variant.family in OPTIONAL_FAMILIES else "required"
+            table.add_row(
+                cap_id,
+                variant.family,
+                variant.fetch_script,
+                str(len(variant.fetch_steps or ((),))),
+                kind,
+            )
+        console.print(table)
+        return
+
+    console.print("[bold]Pulling curated ComfyUI model set…[/bold]")
+    result = orchestrate_models(
+        pairs,
+        log_dir=Path(log_dir) if log_dir else None,
+        on_line=lambda line: console.print(line, highlight=False),
+    )
+
+    console.print()
+    console.print(f"[bold]landed[/bold]: {', '.join(result.landed) or '—'}")
+    if result.failed_optional:
+        console.print(
+            f"[yellow]failed (optional, skipped)[/yellow]: {', '.join(result.failed_optional)}"
+        )
+    if result.failed_required:
+        console.print(f"[red]failed (required)[/red]: {', '.join(result.failed_required)}")
+    console.print(f"log written to: {result.log_path}")
+
+    if not result.ok:
+        raise typer.Exit(1)
+
+
+__all__ = ["app"]

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -33,6 +33,7 @@ from hal0.cli.app_commands import app as app_ext_app
 from hal0.cli.bench_commands import BENCH_CONTEXT_SETTINGS, BENCH_HELP
 from hal0.cli.bench_commands import bench as bench_command
 from hal0.cli.capabilities_commands import app as capabilities_app
+from hal0.cli.comfyui_commands import app as comfyui_app
 from hal0.cli.config_commands import app as config_app
 from hal0.cli.doctor_commands import app as doctor_app
 from hal0.cli.mcp_commands import app as mcp_app
@@ -69,6 +70,9 @@ app.add_typer(config_app, name="config")
 app.add_typer(doctor_app, name="doctor")
 app.add_typer(upstream_app, name="upstream")
 app.add_typer(capabilities_app, name="capabilities")
+# Issue #1199 — ``hal0 comfyui orchestrate-models`` pulls the curated ComfyUI
+# model set in one logged sequence.
+app.add_typer(comfyui_app, name="comfyui")
 app.add_typer(agent_app, name="agent")
 # Issue #1102 — ``hal0 app install <name>`` (deferred install verb for apps
 # skipped via HAL0_SKIP_OPENWEBUI=1 at install time; Q9 skip/defer parity).

--- a/src/hal0/comfyui/orchestrate.py
+++ b/src/hal0/comfyui/orchestrate.py
@@ -1,0 +1,221 @@
+"""#1199: orchestrate the curated ComfyUI model set in one command.
+
+Operators previously had to know the right invocation sequence and per-variant
+argv for each of the individual ``get_*.sh`` scripts (SDXL, Qwen Image, Wan 2.2,
+LTX-2, Hunyuan 1.5, ESRGAN). This module drives the curated *default* variant of
+every :data:`~hal0.comfyui.capabilities.CAPABILITIES` entry end-to-end, running
+each script's ``fetch_steps`` in sequence, logging every step's start and exit
+code, and writing a single operator-readable log.
+
+Discipline mirrors the rest of the ComfyUI provisioning stack:
+
+* A failed **optional** asset (ESRGAN's ``4x-UltraSharp`` mirror, #1200) never
+  blocks the unrelated model families — the sequence continues and the run only
+  reports non-``ok`` when a **required** family fails.
+* The underlying scripts skip already-present destination files, so the whole
+  command is safe to re-run (idempotent).
+
+The heavy lifting (subprocess spawn, HF-credential env, script dir) is shared
+with :mod:`hal0.comfyui.fetch`; the ``runner``/``clock``/``log_dir`` seams are
+injectable so the orchestration loop is unit-testable without real downloads.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TextIO
+
+from hal0.comfyui.capabilities import CAPABILITIES, ModelVariant, default_variant
+from hal0.comfyui.fetch import _SCRIPTS_DIR, _fetch_env, _provision_workflow
+
+log = logging.getLogger(__name__)
+
+#: Families whose absence must NOT fail the curated run (optional assets, #1200).
+OPTIONAL_FAMILIES: frozenset[str] = frozenset({"esrgan"})
+
+_TAG = "[comfyui-orchestrate]"
+
+
+@dataclass
+class FamilyResult:
+    """Per-family outcome of an orchestration run."""
+
+    capability: str
+    family: str
+    script: str
+    steps: int
+    ok: bool
+    optional: bool
+    #: exit code of the first failing step, or ``None`` when every step exited 0.
+    returncode: int | None = None
+    #: 1-indexed step that failed, or ``None`` on success.
+    failed_step: int | None = None
+
+
+@dataclass
+class OrchestrationResult:
+    """Summary of a curated-model orchestration run."""
+
+    results: list[FamilyResult] = field(default_factory=list)
+    log_path: str | None = None
+
+    @property
+    def landed(self) -> list[str]:
+        return [r.family for r in self.results if r.ok]
+
+    @property
+    def failed_required(self) -> list[str]:
+        return [r.family for r in self.results if not r.ok and not r.optional]
+
+    @property
+    def failed_optional(self) -> list[str]:
+        return [r.family for r in self.results if not r.ok and r.optional]
+
+    @property
+    def ok(self) -> bool:
+        """True when no *required* family failed (optional failures tolerated)."""
+        return not self.failed_required
+
+
+def curated_set() -> list[tuple[str, ModelVariant]]:
+    """Curated ``(capability_id, default variant)`` pairs, in CAPABILITIES order."""
+    return [(cap_id, default_variant(cap)) for cap_id, cap in CAPABILITIES.items()]
+
+
+def _default_runner(cmd: list[str], env: dict[str, str], log_fh: TextIO) -> int:
+    """Run *cmd*, streaming combined stdout/stderr into *log_fh*; return exit code."""
+    import subprocess
+
+    log_fh.flush()
+    proc = subprocess.Popen(cmd, stdout=log_fh, stderr=subprocess.STDOUT, env=env)
+    return proc.wait()
+
+
+def _default_log_path(log_dir: Path | None, clock: Callable[[], float]) -> Path:
+    """Resolve the orchestration log path, honouring the model-store layout."""
+    if log_dir is None:
+        try:
+            from hal0.config.paths import model_store_root
+
+            log_dir = Path(model_store_root()) / "comfyui" / "logs"
+        except Exception:
+            log_dir = Path("/tmp/hal0-comfyui-logs")
+    stamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(clock()))
+    return Path(log_dir) / f"orchestrate-{stamp}.log"
+
+
+def orchestrate_models(
+    pairs: list[tuple[str, ModelVariant]] | None = None,
+    *,
+    scripts_dir: Path = _SCRIPTS_DIR,
+    env_fn: Callable[[], dict[str, str]] = _fetch_env,
+    provision_workflow: Callable[[ModelVariant], str | None] = _provision_workflow,
+    runner: Callable[[list[str], dict[str, str], TextIO], int] = _default_runner,
+    log_dir: Path | None = None,
+    log_path: Path | None = None,
+    clock: Callable[[], float] = time.time,
+    on_line: Callable[[str], None] | None = None,
+) -> OrchestrationResult:
+    """Run the curated ComfyUI model pull sequence end-to-end, writing a log.
+
+    Each variant's ``fetch_steps`` are run in order; the first non-zero step marks
+    that family failed and moves on to the next family (so unrelated families
+    still download). Optional families (:data:`OPTIONAL_FAMILIES`) never affect
+    :attr:`OrchestrationResult.ok`. The variant's curated workflow JSON is
+    provisioned before its download, matching :func:`hal0.comfyui.fetch.fetch_model`.
+
+    Dependencies (``runner``/``env_fn``/``clock``/``log_dir``) are injected so the
+    loop runs deterministically under test without real subprocesses.
+    """
+    if pairs is None:
+        pairs = curated_set()
+
+    resolved_log = Path(log_path) if log_path is not None else _default_log_path(log_dir, clock)
+    resolved_log.parent.mkdir(parents=True, exist_ok=True)
+
+    result = OrchestrationResult(log_path=str(resolved_log))
+    env = env_fn()
+
+    def emit(line: str, fh: TextIO) -> None:
+        fh.write(line + "\n")
+        fh.flush()
+        if on_line is not None:
+            on_line(line)
+
+    with resolved_log.open("w", encoding="utf-8") as fh:
+        emit(f"{_TAG} curated ComfyUI model set — {len(pairs)} families", fh)
+        for cap_id, variant in pairs:
+            optional = variant.family in OPTIONAL_FAMILIES
+            tag = "optional" if optional else "required"
+            emit(f"{_TAG} === {variant.family} ({cap_id}, {tag}) ===", fh)
+
+            # Provision the curated workflow JSON (best-effort; a copy hiccup must
+            # not fail the download) before pulling weights.
+            try:
+                wf = provision_workflow(variant)
+                if wf:
+                    emit(f"{_TAG} provisioned workflow → {wf}", fh)
+            except Exception as exc:  # pragma: no cover - defensive
+                emit(f"{_TAG} workflow provision skipped: {exc}", fh)
+
+            script_path = str(scripts_dir / variant.fetch_script)
+            steps = variant.fetch_steps or ((),)
+            fam_ok = True
+            fam_rc: int | None = None
+            failed_step: int | None = None
+
+            for idx, step_args in enumerate(steps, 1):
+                cmd = ["bash", script_path, *step_args]
+                emit(f"{_TAG} step {idx}/{len(steps)}: {' '.join(cmd)}", fh)
+                rc = runner(cmd, env, fh)
+                emit(f"{_TAG} {variant.family} step {idx} exit={rc}", fh)
+                if rc != 0:
+                    fam_ok = False
+                    fam_rc = rc
+                    failed_step = idx
+                    break
+
+            if fam_ok:
+                emit(f"{_TAG} {variant.family}: OK", fh)
+            else:
+                emit(
+                    f"{_TAG} {variant.family}: FAILED at step {failed_step} "
+                    f"(exit={fam_rc}){' [optional — skipped]' if optional else ''}",
+                    fh,
+                )
+
+            result.results.append(
+                FamilyResult(
+                    capability=cap_id,
+                    family=variant.family,
+                    script=variant.fetch_script,
+                    steps=len(steps),
+                    ok=fam_ok,
+                    optional=optional,
+                    returncode=fam_rc,
+                    failed_step=failed_step,
+                )
+            )
+
+        emit(
+            f"{_TAG} summary: landed={result.landed} "
+            f"failed_required={result.failed_required} "
+            f"failed_optional={result.failed_optional}",
+            fh,
+        )
+        emit(f"{_TAG} log written to: {resolved_log}", fh)
+
+    return result
+
+
+__all__ = [
+    "OPTIONAL_FAMILIES",
+    "FamilyResult",
+    "OrchestrationResult",
+    "curated_set",
+    "orchestrate_models",
+]

--- a/tests/comfyui/test_orchestrate.py
+++ b/tests/comfyui/test_orchestrate.py
@@ -1,0 +1,123 @@
+"""#1199: curated ComfyUI model-set orchestration.
+
+The orchestration loop is exercised with an injected ``runner`` so no real
+subprocess/download runs — we assert sequencing, per-step exit logging, the
+optional-vs-required failure policy, and the operator log contents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.comfyui.orchestrate import (
+    OPTIONAL_FAMILIES,
+    curated_set,
+    orchestrate_models,
+)
+
+
+def _noop_workflow(_variant):
+    return None
+
+
+def _all_ok_runner(cmd, env, fh):
+    fh.write(f"[fake] ran {' '.join(cmd)}\n")
+    return 0
+
+
+def _make_runner(fail_families):
+    """Runner that returns exit=1 whenever the invoked script matches a family."""
+
+    def runner(cmd, env, fh):
+        script = cmd[1]  # ["bash", <script_path>, *args]
+        for fam_script in fail_families:
+            if fam_script in script:
+                return 1
+        return 0
+
+    return runner
+
+
+def test_curated_set_covers_all_capabilities():
+    pairs = curated_set()
+    cap_ids = [c for c, _ in pairs]
+    assert cap_ids == ["txt2img", "img2img", "txt2video", "img2video", "image_upscale"]
+    # esrgan is the curated upscale default and must be flagged optional.
+    assert any(v.family in OPTIONAL_FAMILIES for _, v in pairs)
+
+
+def test_all_success(tmp_path):
+    log = tmp_path / "run.log"
+    result = orchestrate_models(
+        provision_workflow=_noop_workflow,
+        runner=_all_ok_runner,
+        log_path=log,
+        env_fn=lambda: {},
+    )
+    assert result.ok
+    assert not result.failed_required
+    assert not result.failed_optional
+    assert result.landed  # every family landed
+    assert result.log_path == str(log)
+
+    text = log.read_text()
+    assert "curated ComfyUI model set" in text
+    assert "summary:" in text
+    assert f"log written to: {log}" in text
+
+
+def test_optional_failure_tolerated(tmp_path):
+    log = tmp_path / "run.log"
+    result = orchestrate_models(
+        provision_workflow=_noop_workflow,
+        runner=_make_runner({"get_esrgan.sh"}),
+        log_path=log,
+        env_fn=lambda: {},
+    )
+    # Optional (esrgan) failure must NOT fail the overall run.
+    assert result.ok
+    assert "esrgan" in result.failed_optional
+    assert "esrgan" not in result.failed_required
+    assert "[optional — skipped]" in log.read_text()
+
+
+def test_required_failure_fails_run_but_continues(tmp_path):
+    log = tmp_path / "run.log"
+    # Fail the SDXL/Qwen txt2img family (required); later families must still run.
+    pairs = curated_set()
+    first_script = pairs[0][1].fetch_script
+    result = orchestrate_models(
+        pairs,
+        provision_workflow=_noop_workflow,
+        runner=_make_runner({first_script}),
+        log_path=log,
+        env_fn=lambda: {},
+    )
+    assert not result.ok
+    assert result.failed_required
+    # Unrelated families still attempted: esrgan (last) recorded a result.
+    families_run = {r.family for r in result.results}
+    assert "esrgan" in families_run
+
+
+def test_default_log_path_used_when_unspecified(tmp_path, monkeypatch):
+    # Point the model store at tmp so the default <store>/comfyui/logs path lands
+    # under tmp rather than the real appliance path.
+    import hal0.comfyui.orchestrate as orch
+
+    monkeypatch.setattr("hal0.config.paths.model_store_root", lambda: str(tmp_path), raising=False)
+    result = orch.orchestrate_models(
+        provision_workflow=_noop_workflow,
+        runner=_all_ok_runner,
+        env_fn=lambda: {},
+        clock=lambda: 0.0,
+    )
+    assert result.log_path is not None
+    assert Path(result.log_path).exists()
+    assert "comfyui/logs" in result.log_path
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
Team COMFYUI — hal0 bones review. Four ComfyUI integration fixes; one issue found stale.

## Fixes

- **#1200 — ESRGAN 4x-UltraSharp 401** (`get_esrgan.sh`): repoint to stable mirror `lokCX/4x-Ultrasharp` (verified 200; old `Kim2091/4x-UltraSharp` returns 401). 4x-UltraSharp now OPTIONAL (skip on failure), RealESRGAN_x4plus REQUIRED. Per-asset failure names exact asset+source. Stages to `.part` for idempotent re-runs.
- **#1197 — modern hf CLI**: dropped the `--cache-dir "$HF_HOME"` + `--local-dir "$STAGE"` combo (rejected by newer `huggingface_hub`) from all 5 pull scripts; downloads still stage via `--local-dir` and move into the model subdir.
- **#1196 — dynamic hf resolution**: added a lazy `_require_hf` guard (order `$HF` → `command -v hf` → `/opt/venv/bin/hf`) that fails with a clear pipx/pip remediation message; checked at first real download so `--dry-run`/idempotent paths don't need hf. Applied to all 5 scripts.
- **#1199 — orchestration command**: new `hal0 comfyui orchestrate-models [--dry-run] [--log-dir]` + `hal0.comfyui.orchestrate`. Runs the curated default variant of every capability in sequence, logs each step start/exit + summary to `<model-store>/comfyui/logs/orchestrate-<ts>.log`. Optional-asset failures don't block others; exits non-zero only on required failure. Deterministic unit tests via injected runner/clock/log-dir.

## #1198 — NOT actionable (stale)

Issue targets `comfy-postinstall.sh` / `comfy-up.sh` / `.node-install.sh`. Those docker control scripts were **deliberately retired in #984** (podman img slot is sole `:8188` owner). `tests/install/test_comfyui_scripts_shipped.py::test_retired_docker_scripts_removed` asserts they must NOT exist. Recreating a postinstall script to satisfy the paraphrase would break that test and reverse #984. Left untouched — recommend closing #1198 as obsolete.

## Test

`pytest tests/comfyui/ tests/api/test_comfyui*.py tests/install/test_comfyui_scripts_shipped.py` → **171 passed**, 3 pre-existing failures unrelated to this branch (verified failing on base `e9639de1`): `test_comfyui_phase4::TestWorkflowList::*`, `test_comfyui_proxy::test_switchover_unwired_returns_503_not_501`.

ruff check + ruff format clean. All get_*.sh bash -n clean.

Closes #1196, #1197, #1199, #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)