### PR TITLE
fix(slots): errored-slot restart recovery + drift/image_status false positives

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -108,12 +108,17 @@ def _resolve_profile_or_base(profile_name: str, slot_cfg: dict[str, Any]) -> Any
         backend = str(slot_cfg.get("backend") or "")
         catalog = load_profiles_config().profile
         base = backend if backend in catalog else "rocm"
-        log.warning(
-            "profile %r not found; falling back to base profile %r",
-            profile_name,
-            base,
-            extra={"event": "profile.fallback", "missing": profile_name, "base": base},
-        )
+        # An empty profile is a legitimate "no profile declared" slot running
+        # on the default toolbox — not a stale/renamed profile. Falling back is
+        # expected, so don't warn on every health probe (#1226); reserve the
+        # warning for a NON-empty name the catalog no longer knows.
+        if profile_name:
+            log.warning(
+                "profile %r not found; falling back to base profile %r",
+                profile_name,
+                base,
+                extra={"event": "profile.fallback", "missing": profile_name, "base": base},
+            )
         return _resolve_profile(base)
 
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1327,6 +1327,10 @@ class ContainerProvider(Provider):
         unit = self._unit_name(slot_name)
         log.info("container.unit_stop", extra={"slot": slot_name, "unit": unit})
         self._run("systemctl", "stop", unit, check=False)
+        # Clear a ``failed`` sub-state left by a crash-looped/OOM-killed unit
+        # (#1224). Without this, systemd's StartLimit can refuse the next
+        # ``systemctl restart``, wedging a slot that a restart should recover.
+        self._run("systemctl", "reset-failed", unit, check=False)
         # Disable so it doesn't re-start on reboot.
         self._run("systemctl", "disable", unit, check=False)
         # Remove unit file so daemon-reload leaves no stale entry.

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -393,8 +393,9 @@ async def container_enrichment(
 
     plus image facts: ``actual_image`` (podman inspect, #663),
     ``image_mismatch`` against the declared profile image, and
-    ``image_status`` (present | pulling | missing — an in-flight job in
-    ``pull_jobs`` wins without an inspect syscall).
+    ``image_status`` (present | pulling | missing | not-configured — an
+    in-flight job in ``pull_jobs`` wins without an inspect syscall;
+    ``not-configured`` marks a slot with no declared profile/image, #1226).
 
     ``provider`` is injectable for unit tests; ``None`` resolves the real
     ContainerProvider lazily so route-level patches on the class keep
@@ -518,7 +519,7 @@ async def container_enrichment(
             if image:
                 entry["image_mismatch"] = _image_mismatch(running_image, image)
 
-        # image_status: present | pulling | missing
+        # image_status: present | pulling | missing | not-configured
         # Check the pull-jobs registry first so an in-flight pull
         # surfaces as "pulling" without an extra inspect syscall.
         active_job = jobs.get(name)
@@ -534,7 +535,11 @@ async def container_enrichment(
             except Exception:
                 entry["image_status"] = "missing"
         else:
-            entry["image_status"] = "missing"
+            # No profile/image declared — the slot runs on the default toolbox.
+            # "No expected image" is NOT a missing-image fault (#1226): report
+            # it distinctly so operators (and the hal0-brain steward) don't
+            # learn to ignore a real "missing" every 30s.
+            entry["image_status"] = "not-configured"
 
         out[name] = entry
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1273,9 +1273,28 @@ class SlotManager:
             return await self.status(slot_name)
 
     async def restart(self, slot_name: str) -> Slot:
-        """Restart a slot without changing its model assignment."""
+        """Restart a slot without changing its model assignment.
+
+        A slot wedged in ERROR must NOT go through the graceful ``unload()``
+        drain: its systemd unit may be ``failed``, where the stop path can
+        hang and leave the CLI ReadTimeout'ing with the unit never relaunched
+        (#1224). For an errored slot, force a best-effort terminate (which now
+        also ``reset-failed``s the unit) and drop straight to OFFLINE, then run
+        the full load — never short-circuiting on an "already loaded" state,
+        which ERROR is not.
+        """
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
+        if self._current_state(slot_name) == SlotState.ERROR:
+            async with self._lock(slot_name):
+                # Best-effort cleanup of the wedged unit; never let a stuck
+                # stop wedge the restart itself. ``terminate`` resets the
+                # failed unit so the subsequent ``load`` isn't blocked by
+                # systemd's StartLimit.
+                with contextlib.suppress(Exception):
+                    await self.terminate(slot_name)
+                await self._transition(slot_name, SlotState.OFFLINE, force=True)
+            return await self.load(slot_name)
         await self.unload(slot_name)
         return await self.load(slot_name)
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -1498,6 +1498,15 @@ class SlotManager:
 
         running_flags = _argv_values(running, _CONFIG_DRIFT_KEYS)
         rendered_flags = _argv_values(rendered, _CONFIG_DRIFT_KEYS)
+        # #1226: the renderer resolves a registry model id to its on-disk path
+        # (``--model``) and slugifies it for the advertised ``--alias``. A raw
+        # id on either side must be run through the SAME resolution before
+        # comparison, else a slot created with a registry id permanently
+        # false-warns (running path/slug vs rendered id). Resolve both sides.
+        model_key = model_info.get("_model_key") or _model_default(cfg)
+        model_path = model_info.get("path")
+        running_flags = _resolve_drift_flags(running_flags, model_key, model_path)
+        rendered_flags = _resolve_drift_flags(rendered_flags, model_key, model_path)
         diffs = [
             {"key": key, "running": running_flags.get(key), "rendered": rendered_flags.get(key)}
             for key in _CONFIG_DRIFT_KEYS
@@ -3804,6 +3813,36 @@ def _argv_values(argv: list[str], keys: tuple[str, ...]) -> dict[str, str | None
         else:
             out[key] = argv[i + 1] if i + 1 < len(argv) else None
             i += 2
+    return out
+
+
+def _resolve_drift_flags(
+    flags: dict[str, str | None],
+    model_key: str | None,
+    model_path: str | None,
+) -> dict[str, str | None]:
+    """Canonicalize the id-bearing drift flags the way the renderer does.
+
+    ``--model`` and ``--alias`` carry a model identity that the unit renderer
+    resolves (registry id → on-disk path for ``--model``; slugified id for
+    ``--alias``). A raw id surfaced on either side of the drift comparison is
+    put through the SAME resolution so a slot created with a registry id does
+    not permanently false-warn (#1226). Values already resolved (a real path,
+    an already-slugified alias) pass through unchanged.
+    """
+    from hal0.registry.discover import _normalise_id
+
+    out = dict(flags)
+    model_val = out.get("--model")
+    # Rendered/running may carry the bare registry id instead of the resolved
+    # path; substitute the known on-disk path so the realpath compare matches.
+    if model_val is not None and model_path and model_key and model_val == model_key:
+        out["--model"] = str(model_path)
+    alias_val = out.get("--alias")
+    if alias_val is not None:
+        # Slug is idempotent: slugifying an already-slugified alias is a no-op,
+        # so both a raw id and a rendered slug collapse to the same token.
+        out["--alias"] = _normalise_id(alias_val)
     return out
 
 

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -325,7 +325,8 @@ def test_profileless_slot_has_null_image_and_command(
     client_with_container_slot: TestClient,
 ) -> None:
     """A profile-less slot is still probed but carries no image facts:
-    profile='', image=None, resolved_command=None, image_status=missing."""
+    profile='', image=None, resolved_command=None, image_status=not-configured
+    (#1226: no declared image is not a missing-image fault)."""
     with (
         patch(
             "hal0.providers.container.ContainerProvider.is_active",
@@ -346,7 +347,7 @@ def test_profileless_slot_has_null_image_and_command(
     assert chat["profile"] == ""
     assert chat["image"] is None
     assert chat["resolved_command"] is None
-    assert chat["image_status"] == "missing"
+    assert chat["image_status"] == "not-configured"
 
 
 # ── #663: actual_image + image_mismatch via running_image (podman inspect) ──────

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -514,13 +514,15 @@ class TestContainerEnrichment:
         )
         assert out["gpu-chat"]["image_status"] == "pulling"
 
-    async def test_no_image_means_missing_status(self) -> None:
+    async def test_no_image_means_not_configured_status(self) -> None:
+        # #1226: no profile/image declared → "not-configured", not "missing"
+        # (a real missing-image fault). The slot runs on the default toolbox.
         out = await container_enrichment(
             [_container_cfg()],
             pull_jobs={},
             provider=FakeContainerProvider(active=False),
         )
-        assert out["gpu-chat"]["image_status"] == "missing"
+        assert out["gpu-chat"]["image_status"] == "not-configured"
 
     async def test_npu_table_surfaced(self) -> None:
         out = await container_enrichment(

--- a/tests/slots/test_config_drift_aliases.py
+++ b/tests/slots/test_config_drift_aliases.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from hal0.slots.manager import _CONFIG_DRIFT_KEYS, SlotManager, _argv_values
 from tests.slots.conftest import FakeContainerProvider
 
@@ -89,3 +91,77 @@ async def test_real_drift_still_detected_across_spellings(
     drift = snap.metadata.get("config_drift")
     assert drift is not None and drift["drifted"] is True
     assert {"key": "-b", "running": "512", "rendered": "2048"} in drift["diffs"]
+
+
+async def test_no_false_drift_for_registry_id_model_and_alias(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1226: a slot created with a registry id must not permanently warn.
+
+    The renderer resolves the id → on-disk path (``--model``) and slugifies it
+    for the advertised ``--alias``; the drift preview may surface the raw id.
+    Both sides run through the same resolution, so this is NOT drift.
+    """
+    model_id = "Qwopus3.5-4B-Coder-MTP-Q6_K"
+    model_path = "/mnt/ai-models/qwopus/Qwopus3.5-4B-Coder-MTP-Q6_K.gguf"
+
+    async def _fake_info(self: SlotManager, mid: str | None) -> dict[str, object]:
+        return {"_model_key": model_id, "path": model_path}
+
+    monkeypatch.setattr(SlotManager, "_resolve_model_info", _fake_info)
+
+    # Running container: id already resolved to a path + slugified alias.
+    container_stub.running_argv_by_slot["chat"] = [
+        "--model",
+        model_path,
+        "--alias",
+        "qwopus3-5-4b-coder-mtp-q6-k",
+    ]
+    # Rendered preview: raw registry id on both flags.
+    container_stub.expected_argv_by_slot["chat"] = [
+        "--model",
+        model_id,
+        "--alias",
+        model_id,
+    ]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    assert snap.metadata.get("config_drift") == {"drifted": False, "diffs": []}
+
+
+async def test_real_model_drift_still_flagged_after_resolution(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resolution must not mask a genuinely different running --model path."""
+    model_id = "Qwopus3.5-4B-Coder-MTP-Q6_K"
+    model_path = "/mnt/ai-models/qwopus/Qwopus3.5-4B-Coder-MTP-Q6_K.gguf"
+
+    async def _fake_info(self: SlotManager, mid: str | None) -> dict[str, object]:
+        return {"_model_key": model_id, "path": model_path}
+
+    monkeypatch.setattr(SlotManager, "_resolve_model_info", _fake_info)
+
+    # Running container is on a DIFFERENT file than the config resolves to.
+    container_stub.running_argv_by_slot["chat"] = [
+        "--model",
+        "/mnt/ai-models/other/stale-model.gguf",
+        "--alias",
+        "qwopus3-5-4b-coder-mtp-q6-k",
+    ]
+    container_stub.expected_argv_by_slot["chat"] = ["--model", model_id, "--alias", model_id]
+
+    sm = SlotManager()
+    await sm.load("chat")
+    snap = await sm.status("chat", include_config_drift=True)
+
+    drift = snap.metadata.get("config_drift")
+    assert drift is not None and drift["drifted"] is True
+    keys = {d["key"] for d in drift["diffs"]}
+    assert "--model" in keys

--- a/tests/slots/test_fail_watcher_warming.py
+++ b/tests/slots/test_fail_watcher_warming.py
@@ -179,3 +179,67 @@ async def test_warming_slot_recovers_when_stale(
     # unload must precede load (recovery order), and the reload converged.
     assert calls.index(("unload", "chat")) < calls.index(("load", "chat"))
     assert sm._current_state("chat") == SlotState.READY
+
+
+async def _await_state(
+    sm: SlotManager, name: str, target: SlotState, timeout_s: float = 5.0
+) -> Any:
+    """Poll until *name* reaches *target* or the deadline lapses."""
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    observed: Any = None
+    while asyncio.get_event_loop().time() < deadline:
+        observed = sm._current_state(name)
+        if observed == target:
+            return observed
+        await asyncio.sleep(0.05)
+    return observed
+
+
+async def test_repeated_warming_error_cycles_recover_without_watcher_leak(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """A slot that keeps dying while WARMING must resolve to ERROR every cycle,
+    re-arm cleanly on the next load, and never accumulate stale watchers.
+    """
+    sm = SlotManager()
+
+    for cycle in range(3):
+        await _load_into_warming(sm, container_stub)
+        # Exactly one live watcher per slot — no accumulation across cycles.
+        live = [t for t in sm._fail_watchers.values() if not t.done()]
+        assert len(live) <= 1, f"cycle {cycle}: watcher leak ({len(live)} live)"
+
+        # Unit dies while warming → the watcher strikes it to ERROR.
+        container_stub.active.discard("chat")
+        observed = await _await_state(sm, "chat", SlotState.ERROR)
+        assert observed == SlotState.ERROR, f"cycle {cycle}: never reached ERROR ({observed})"
+
+        # The watcher self-retired on its own ERROR transition.
+        w = sm._fail_watchers.get("chat")
+        assert w is None or w.done(), f"cycle {cycle}: watcher not retired after ERROR"
+
+
+async def test_warming_stale_recovery_that_fails_lands_error(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    fast_fail_watch: None,
+) -> None:
+    """A wedged WARMING slot whose staleness-triggered recovery reload ALSO
+    fails must settle in a clean ERROR — not silently re-wedge (the
+    WARMING → recover → ERROR cycle).
+    """
+    sm = SlotManager()
+    await _load_into_warming(sm, container_stub)
+
+    # Recovery reload can't spawn → load() stamps ERROR and re-raises; the
+    # watchdog swallows the exception and returns, leaving the slot ERROR.
+    container_stub.fail_load = RuntimeError("spawn failed on recovery")
+    sm._states["chat"].updated_at = time.time() - mgr_mod._WARMING_STALE_AFTER_S - 1
+
+    observed = await _await_state(sm, "chat", SlotState.ERROR)
+    assert observed == SlotState.ERROR, f"failed recovery never surfaced ERROR ({observed})"
+    # No orphaned live watcher after the terminal ERROR.
+    w = sm._fail_watchers.get("chat")
+    assert w is None or w.done()

--- a/tests/slots/test_restart_errored_slot.py
+++ b/tests/slots/test_restart_errored_slot.py
@@ -1,0 +1,91 @@
+"""Restarting an ERROR slot must run the full stop→create→load, not wedge.
+
+Issue #1224: ``POST /api/slots/{name}/restart`` on a slot in ``error`` hung —
+``restart()`` funnelled through the graceful ``unload()`` drain against a unit
+that had already failed, and the slot never relaunched. ``restart()`` now
+force-terminates a wedged unit (clearing systemd's ``failed`` sub-state) and
+drops straight to OFFLINE before the reload, so an errored slot recovers to
+READY without a manual ``reset-failed``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def _drive_into_error(sm: SlotManager, container_stub: FakeContainerProvider) -> None:
+    """Fail the spawn so ``load()`` stamps the slot ERROR and re-raises."""
+    container_stub.fail_load = RuntimeError("spawn boom")
+    with pytest.raises(RuntimeError):
+        await sm.load("chat")
+    assert sm._current_state("chat") == SlotState.ERROR
+
+
+async def test_restart_from_error_reaches_ready(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """An errored slot restarted after the fault clears lands READY."""
+    sm = SlotManager()
+    await _drive_into_error(sm, container_stub)
+
+    # Fault cleared — restart must force the full stop→create→load.
+    container_stub.fail_load = None
+    await sm.restart("chat")
+
+    assert sm._current_state("chat") == SlotState.READY
+    assert container_stub.unload_calls, "restart must terminate the wedged unit"
+    assert container_stub.load_calls, "restart must re-spawn the container"
+
+
+async def test_restart_from_error_does_not_short_circuit(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """ERROR is not a live state — restart must never no-op it as 'loaded'."""
+    sm = SlotManager()
+    await _drive_into_error(sm, container_stub)
+
+    container_stub.fail_load = None
+    container_stub.load_calls.clear()
+    container_stub.unload_calls.clear()
+
+    await sm.restart("chat")
+
+    # Both halves of the sequence ran: the unit was torn down and re-spawned.
+    assert len(container_stub.unload_calls) >= 1
+    assert len(container_stub.load_calls) >= 1
+    assert sm._current_state("chat") == SlotState.READY
+
+
+async def test_restart_from_error_survives_a_hanging_terminate(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminate that blows up must not wedge the restart — it is best-effort
+    and the reload still runs (#1224 robustness)."""
+    sm = SlotManager()
+    await _drive_into_error(sm, container_stub)
+
+    orig_unload_sync = container_stub.unload_sync
+    calls = {"n": 0}
+
+    def _boom_once(cfg: dict) -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("systemctl stop wedged")
+        orig_unload_sync(cfg)
+
+    monkeypatch.setattr(container_stub, "unload_sync", _boom_once)
+    container_stub.fail_load = None
+
+    await sm.restart("chat")
+
+    assert sm._current_state("chat") == SlotState.READY

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -116,9 +116,10 @@ export interface Slot {
   /** Container image ref (from the resolved profile). E.g.
    *  "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server". */
   image?: string | null
-  /** Container image availability: "present" | "pulling" | "missing".
-   *  Populated by the backend when image_status is tracked. */
-  image_status?: 'present' | 'pulling' | 'missing' | null
+  /** Container image availability: "present" | "pulling" | "missing" |
+   *  "not-configured" (no profile/image declared — runs on the default
+   *  toolbox, #1226). Populated by the backend when image_status is tracked. */
+  image_status?: 'present' | 'pulling' | 'missing' | 'not-configured' | null
   /** ACTUAL running container image ref, read from ``podman inspect`` by
    *  _container_state_enrichment (#663). Omitted/null when the container is
    *  not running or inspect fails — treat absence as "unknown". */


### PR DESCRIPTION
Team SLOTS bones review — three slot correctness fixes. Separate commit per fix.

## 1. Restart wedges on errored slot (#1224)
`restart()` sent an `ERROR` slot through the graceful `unload()` drain against an already-failed unit — the stop path could hang, the CLI ReadTimeout'd, and the unit never relaunched. An errored slot now force-terminates (clearing systemd's `failed` sub-state via `reset-failed`) and drops straight to `OFFLINE` before the full load, reaching `READY` without a manual `reset-failed`. `ERROR` is never treated as an "already loaded" live state.

## 2. Status false positives (#1226)
- **Config drift:** compared pre-resolution values, so a slot created with a registry model id permanently warned (running resolved `--model` path / slugified `--alias` vs raw rendered id). Both sides now go through the same id→path and alias-slug resolution the unit renderer applies.
- **image_status:** reported `"missing"` for a slot with no profile/image (runs on the default toolbox). Now `"not-configured"`, and the empty-profile fallback no longer warns every health probe.

## 3. Wedged WARMING watchdog (#1269)
Verified the stale-anchor auto-recovery handles WARMING↔ERROR cycles; added integration tests: repeated WARMING-death cycles resolve to `ERROR` each time with no watcher leak, and a failed staleness-recovery reload settles in a clean `ERROR`.

## Tests
`python -m pytest tests/slots/` → **362 passed**. Updated `test_config_drift_aliases.py`, `test_fail_watcher_warming.py`, `test_aggregator.py`, `test_slots_container_state.py`; added `test_restart_errored_slot.py`. 6 unrelated failures (kokoro/flm spec, NPU shadow inheritance) pre-exist on `main`, untouched by this branch.

Ref #1224, #1226, #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)