### PR TITLE
upstream controls + registry/UI: close #1148 #1150 #1157 + #1256 audit

### DIFF
--- a/docs/internal/split-gguf-audit.md
+++ b/docs/internal/split-gguf-audit.md
@@ -1,0 +1,80 @@
+# Split/multi-file GGUF audit (issue #1256)
+
+This document catalogs every place in the registry code that assumes a model
+is exactly one file, so a future implementer can add first-class support for
+split GGUFs (`model-00001-of-00003.gguf`, produced by `gguf-split` and
+increasingly common for large HF uploads). It is a research artifact, not a
+design doc — no source files were changed to produce it. All line numbers
+were verified against the current tree on `claude/hal0-bones-09-issues`
+(2026-07-12); the issue's own line refs (`pull.py:935`, `discover.py:84`/`158`,
+`models.py:503`) are all still accurate as of this audit.
+
+## Lifecycle stages
+
+| Stage | Split-GGUF today | Why |
+|---|---|---|
+| **Pull** | No | `run_pull` (`pull.py:935`) seeds `job.files` with exactly one `PullFile(kind="model")` plus an optional `mmproj` sidecar (`pull.py:984-986`). There is no shard enumeration — pulling a sharded HF repo downloads whichever single filename the caller passed, which is unloadable alone. |
+| **Scan / Discover** | No | `_SHARD_RE` (`discover.py:84`) matches any `-NNNNN-of-NNNNN` stem and `_is_skippable` (`discover.py:158`) drops every match unconditionally — first shard included. `hal0 model scan` and `POST /api/models/scan/preview` (`models.py:503`) both route through this, so a split GGUF set never surfaces as a candidate, complete or not. |
+| **Metadata** | No | Neither `gguf_header.py` nor `detect.py` reads or reasons about the GGUF `split.count` / `split.no` / `split.tensors.count` KV keys. A hand-registered first shard reports the tensor count, size, and any derived params of shard 1 only — the header parser has no concept of "this file is 1 of N." |
+| **Register** | Partial (unsafe) | `POST /api/models` (`models.py:897-926`) and `POST /api/models/add-from-path` (`models.py:743-894`) perform **no shard check at all** — they'll happily register a bare first-shard path with `size_bytes` = that one file's `stat()`. This is the "current workaround" the issue documents: it works but under-reports size and carries no shard awareness for downstream consumers (FLM/NPU routing, `model rm`, dashboard display). |
+| **Run** | **Yes — already works** | The slot manager resolves a single `Model.path` string and passes it straight through as `--model <path>` (`providers/container.py:594-595`, fed from `model_path=str(model_info.get("path") or "")` at `providers/container.py:1608`). llama.cpp itself auto-discovers `-0000N-of-` siblings in the same directory from the first shard's filename, so a registry row that happens to point at shard 1 of a complete, correctly-named set loads correctly today. No change needed here. |
+
+## Assumption locations
+
+### `src/hal0/registry/model.py`
+- `model.py:89-95` — `path: str = Field(...)` on `Model`. The registry's data model has exactly one path per model, singular, not a list. This is the root single-file assumption everything else inherits: any split-aware design either keeps `path` pointing at shard 1 (cheapest — matches how the run path already works) or needs a new `shards: int` / `paths: list[str]` field plus a migration.
+
+### `src/hal0/registry/pull.py`
+- `pull.py:122-149` — `PullFile` dataclass. `kind: str = "model"  # "model" | "mmproj"` (line 133) is the only two kinds today. Docstring (120-130) states explicitly: "A plain pull has exactly one entry (the main GGUF); a vision pull adds an `mmproj` sidecar entry." No shard kind exists yet, though the issue proposes `kind="shard"`.
+- `pull.py:152-176` — `PullJob.files: list[PullFile]`. Comment: "Per-file manifest (multi-file pulls, e.g. main GGUF + mmproj)." The list shape already supports N entries mechanically; nothing in `run_pull` populates more than 2.
+- `pull.py:935-987` (`run_pull` signature + manifest seed) — takes a single `hf_file: str` and optional `mmproj_file: str | None`; no `shard_files` / repo-listing parameter. Line 984: `job.files = [PullFile(hf_filename=hf_file, kind="model")]`; line 985-986 appends at most one `mmproj` entry. A split-aware version needs a third branch here that appends one `PullFile(kind="shard")` per sibling shard filename.
+- `pull.py:1001-1017` — main-file download block downloads exactly `job.files[0]`; `pull.py:1022-1035` downloads `job.files[1]` (mmproj) if present. Both are hardcoded by list index, not a loop — adding shards requires generalizing this to iterate `job.files[i]` for `i >= (2 if mmproj_file else 1)`.
+- `pull.py:243-291` (`_final_path` / `_final_path_for_entry`) — resolves one destination filename per model id; no shard-index-aware naming, but since shard filenames already carry their own `-NNNNN-of-NNNNN` suffix from HF, this mostly needs to be called per-shard rather than restructured.
+- `pull.py:1039-1050` (`_register_pulled` call site) — registers with a single `size_bytes=size_bytes` computed as `main_rec.bytes_done` (line 1017), i.e. shard-1-only size even if shards were downloaded alongside it in a hypothetical partial implementation. Needs the aggregate-sum fix described in the proposed sketch.
+
+### `src/hal0/registry/discover.py`
+- `discover.py:80-84` — 
+  ```python
+  # HF Transformers multi-file shard pattern (e.g. model-00001-of-00003.safetensors).
+  # These need the transformers library to stitch back together; hal0's
+  # llama-server / FLM providers expect a single-file GGUF or single
+  # .safetensors checkpoint, so a lone shard isn't loadable on its own.
+  _SHARD_RE = re.compile(r"^.+-\d{5}-of-\d{5}$")
+  ```
+  The comment's premise ("a lone shard isn't loadable on its own") is true but overbroad: it's used to reject *every* shard, not just incomplete sets — including a complete, correctly-ordered set whose first member llama.cpp can load standalone.
+- `discover.py:147-160` (`_is_skippable`) — line 158: `if _SHARD_RE.match(p.stem): return True`. Unconditional skip, no sibling-completeness check. A split-aware version needs to detect "is this `-00001-of-000NN`, and are shards `2..N` present in the same directory" before deciding to skip vs. surface-as-one-candidate.
+- `discover.py:166-256` (`find_candidates`) — the walk that calls `_is_skippable` per file; this is where a shard-set detection pass (grouping siblings by directory + base name before the stat/curated-match logic) would need to live, since today each file is evaluated independently with no cross-file state except the existing `mmproj_by_dir` association pattern (lines 180-183, 207-217, 251-255) — which is a workable precedent to copy for shard grouping.
+- `discover.py:405-409` — public `is_skippable()` wrapper re-exported for `models.py`'s scan-preview route; any fix to `_is_skippable`'s shard logic automatically propagates here.
+
+### `src/hal0/registry/gguf_header.py`
+- `gguf_header.py:85-96` — `_INTERESTING_KEYS_STATIC` frozenset, the fixed list of KV keys the parser extracts (`general.architecture`, `general.embedding_length`, `general.name`, `general.basename`, `general.size_label`, `general.file_type`). It does **not** include `split.count`, `split.no`, or `split.tensors.count` — the GGUF spec's split-file KV trio. The parser has no split awareness at all; adding these three keys to the static set is the entire fix needed here (the existing single-pass KV scan at `gguf_header.py:275-295` already handles arbitrary static keys generically, so no structural change is needed, just three more dict entries).
+- `gguf_header.py:205-222` (`read_gguf_header` docstring) — enumerates exactly the four keys it extracts; needs updating once split keys are added.
+
+### `src/hal0/registry/detect.py`
+- Whole file has zero references to `split`, shard, or multi-file anything. `detect()` (`detect.py:327-405`) calls `read_gguf_header` and reads `general.architecture` / `pooling_type` / `general.file_type` but never checks for `split.count`/`split.no`. A hand-registered or scanned first shard runs through here unchanged from a full single-file GGUF — `detect()` has no way to know it's looking at a fragment, so `confidence="high"` is reported on data that's numerically wrong for aggregate size (size comes from the caller's `stat()`, not from `detect()` itself, but nothing here flags the discrepancy either).
+
+### `src/hal0/api/routes/models.py`
+- `models.py:443-569` (`POST /api/models/scan/preview`, `scan_preview`) — line 503: `if is_skippable(p): continue` inside the directory-walk branch (lines 495-514). This is the exact call the issue references at `~503`; verified current. Same shard-rejection behavior as `discover.py`, applied to the HF-cache / arbitrary-path preview flow rather than the configured-roots auto-scan.
+- `models.py:520-524` — deliberate *non*-application of `is_skippable` to the *resolved* path (only the symlink name is checked) so HF-cache blob symlinks survive; this same resolved-path handling would need to carry through any shard-set-completeness check added to `_is_skippable`/`is_skippable`.
+- `models.py:743-894` (`POST /api/models/add-from-path`) — no shard reference anywhere in this handler. `size_bytes = resolved.stat().st_size` (line 848) is single-file only; `detect(resolved)` (line 823) inherits `detect.py`'s blindness. This is the "current workaround #2" path the issue describes (`hal0 model register <id> --path .../<name>-00001-of-0000N.gguf`) — it succeeds today with silently wrong size metadata.
+- `models.py:897-942` (`POST /api/models`, `create_model`) — raw `Model(**body)` passthrough, no validation beyond pydantic's field types. Whatever `size_bytes`/`path` the caller supplies is trusted as-is; this is the second workaround path and the natural home for a future "does this path look like an incomplete/lone shard, warn or reject" guardrail if one is wanted at the API boundary (independent of the scan-side fix).
+
+### `src/hal0/providers/container.py` (slot manager's launch-plan builder)
+- `container.py:561-603` (`_llama_argv_segments`) — line 594-595: `if model_path: base += ["--model", model_path]`. Single string, single `--model` flag — confirmed this is the actual `-m`/`--model` argv construction site (not `slots/manager.py` itself, which only orchestrates state and calls into this module).
+- `container.py:1587-1608` — `model_path=str(model_info.get("path") or "")`, i.e. resolves from the registry row's single `path` field. **This is the one stage that already works for split GGUFs**: as long as `Model.path` points at a well-formed `*-00001-of-000NN.gguf` and the remaining shards sit alongside it, llama.cpp's own loader stitches the set together — hal0 doesn't need to enumerate shards to launch a slot, only to register/scan/report on them correctly.
+
+## Proposed implementation sketch
+
+Issue #1256 proposes four changes; tying each to the functions found above:
+
+1. **Pull — shard enumeration.** Extend `run_pull` (`pull.py:935`) to accept a shard-file list (or detect the `-00001-of-` pattern in `hf_file` and derive sibling filenames), append one `PullFile(kind="shard")` per shard to `job.files` (generalizing the current hardcoded 2-slot manifest at `pull.py:984-1035`), and download each through the existing per-file `_download_one` (`pull.py:659-932`) — that function is already file-agnostic and needs no change. Register the row's `path` pointing at shard 1 (matches what the run path already expects); `size_bytes` becomes the sum across `job.files` (mirroring the existing `job.bytes_downloaded = sum(f.bytes_done for f in job.files)` aggregation already done for the job-level total at `pull.py:1068-1070` — the same pattern, just also written into the registry's `size_bytes` field in `_register_pulled`, `pull.py:1111-1180`).
+
+2. **Scan/discover — exemption for complete sets.** Change `_is_skippable` (`discover.py:147-160`, specifically the shard check at line 158) to: match `-00001-of-000NN`, then check the same directory for shards `2..N` (`_SHARD_RE`'s pattern gives you `N` directly); skip only if the set is incomplete or if the file is shard `2..N` of an otherwise-complete set. Surface exactly one `CandidateModel` for a complete set. This can reuse the same directory-keyed grouping technique `find_candidates` (`discover.py:166-256`) already uses for mmproj sidecar association (`mmproj_by_dir`, lines 180-183 / 207-217 / 251-255) — a `shard_groups_by_dir` dict populated during the same walk.
+
+3. **Metadata — `split.count` sum.** Add `split.count`, `split.no`, `split.tensors.count` to `_INTERESTING_KEYS_STATIC` (`gguf_header.py:85-96`) — no other change needed in the parser, since the KV loop is already generic over the static-key set. `detect.py`'s `detect()` (`detect.py:327-405`) can then read `header.get("split.count")` and, when present, the caller (scan/register path) sums sibling shard file sizes into `size_bytes` and stamps a `shards: N` marker into `Model.metadata` (a free-form dict already, `model.py` — no schema migration needed) so the dashboard can display it.
+
+4. **Guardrails.** `model rm` (registry `remove()`, `store.py:404-419`) operates on a single `path` per row and has no shard awareness — removing a split-GGUF row today deletes only the registry entry, not the on-disk shard files (this is true for single-file models too, so it's not a regression, but a shard set left with N-1 orphaned files on disk is a bigger footgun than one orphaned file). A shard-aware `model rm` would need to read the new `shards: N` metadata and unlink the sibling files, or at minimum warn. FLM/NPU capability routing (`pull.py:1183-1421`, `run_flm_pull` and the FLM provider dispatch) has no path-shape check at all today; rejecting a `shards > 1` row before handing it to FLM (which has no split-GGUF concept) needs a check added wherever FLM capability eligibility is currently decided.
+
+## Out of scope / already works
+
+The **run path is not part of this audit's problem set.** `providers/container.py:594-595` / `:1608` pass a single `--model <path>` to llama-server exactly as they do for single-file GGUFs, and llama.cpp's own loader auto-discovers the `-0000N-of-` siblings from the first shard's filename and directory. A registry row whose `path` already points at a correctly-named, complete shard-1 file loads and serves today with zero code changes — confirmed by tracing the same `model_info.get("path")` → `--model` flow used for every other model kind. The gap is entirely upstream of Run: nothing in Pull, Scan/Discover, or Metadata will get a registry row into that state safely today.

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -184,6 +184,7 @@ NPU/FLM store directory — and names the exact fix command for each finding.
 |---|---|---|
 | `upstream list` | List configured upstreams (enabled/advertise/auth/filter summary). | `--json` |
 | `upstream show <name>` | Full detail for one upstream. | `--json` |
+| `upstream advertise <name> <on\|off>` | Flip `/v1/models` visibility live (no restart); dispatch unaffected. | — |
 | `upstream create <name>` | Register a remote provider (persists to `upstreams.toml`). | `--catalog`/`-c`, `--url`, `--auth-style`, `--auth-header`, `--auth-env`, `--timeout`, `--api-key`/`-k`, `--advertise-models/--hide-models`, `--enabled/--disabled` |
 | `upstream update <name>` | Partial update: settings, toggles, model filters. | `--url`, `--auth-style`, `--auth-header`, `--auth-env`, `--timeout`, `--advertise-models/--hide-models`, `--enabled/--disabled`, `--model`, `--include`, `--exclude`, `--clear-filters` |
 | `upstream delete <name>` | Remove a remote upstream (credential in `api.env` is retained). | `--force`/`-f` |

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1564,9 +1564,18 @@ def _build_config_overlay(
     if live_resolve_enabled:
         # hermes's picker only runs /v1/models discovery when an api_key is
         # present; the gateway ignores the value (it's unauthenticated).
+        #
+        # extra_headers is forwarded by hermes onto the discovery GET, so we
+        # tag it with X-hal0-Model-Filter: hal0 (#1148) — the gateway then
+        # returns ONLY owned_by==hal0 rows (local slots + hal0 virtuals),
+        # keeping the ~340 openrouter / minimax passthroughs out of the
+        # picker. Parity with pi's client-side owned_by filter; dispatch by
+        # explicit remote id is unaffected. Same nested-scalar `config set`
+        # mechanism as mcp_servers.<name>.headers.X-hal0-Agent below.
         pairs += [
             ("providers.custom.api_key", "hal0-local"),
             ("providers.custom.discover_models", True),
+            ("providers.custom.extra_headers.X-hal0-Model-Filter", "hal0"),
         ]
 
     for slot in chat_slots:

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -782,6 +782,20 @@ async def list_models(
     # If restoring: iterate DEFAULT_CHAINS and append a live-resolve model
     # object per resolved virtual name.
 
+    # Optional per-consumer owner filter (#1148). A consumer that only wants
+    # hal0-local slots — e.g. Hermes' model picker, which floods with ~340
+    # openrouter passthroughs otherwise — asks for just the hal0-owned rows
+    # via either the ``X-hal0-Model-Filter: hal0`` request header (how Hermes
+    # is provisioned) or a ``?owned_by=hal0`` query param (curl-debuggable).
+    # This is discovery-surface only; dispatch by explicit id is unaffected,
+    # and the default response (no header, no param) is byte-identical to
+    # before, so pi and third-party SDKs are untouched.
+    owner_filter = request.query_params.get("owned_by") or request.headers.get(
+        "x-hal0-model-filter"
+    )
+    if owner_filter:
+        data = [d for d in data if d.get("owned_by") == owner_filter]
+
     return {"object": "list", "data": data}
 
 

--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -110,6 +110,51 @@ def list_upstreams(
     console.print(table)
 
 
+# ── advertise ──────────────────────────────────────────────────────────────
+
+_ADVERTISE_ON = {"on", "true", "yes", "1", "enable", "show"}
+_ADVERTISE_OFF = {"off", "false", "no", "0", "disable", "hide"}
+
+
+@app.command("advertise")
+def advertise_upstream(
+    name: str = typer.Argument(..., help="Upstream name."),
+    state: str = typer.Argument(..., help="on | off — toggle /v1/models visibility."),
+) -> None:
+    """Flip an upstream's ``advertise_models`` flag live (no hal0-api restart).
+
+    Advertising controls catalog visibility only — dispatch/routing to the
+    upstream by explicit id is unaffected. The change takes effect on the next
+    ``/v1/models`` request (the API punches the composite catalog cache).
+    """
+    key = state.strip().lower()
+    if key in _ADVERTISE_ON:
+        value = True
+    elif key in _ADVERTISE_OFF:
+        value = False
+    else:
+        die(f"Invalid state {state!r} — expected 'on' or 'off'.")
+        return
+
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+
+    try:
+        result = api_patch(f"/api/upstreams/{name}", json={"advertise_models": value})
+    except CliApiError as exc:
+        die(str(exc))
+        return
+
+    now_on = bool(result.get("advertise_models", value)) if isinstance(result, dict) else value
+    label = "advertised" if now_on else "hidden"
+    mark = "✓" if now_on else "✗"
+    console.print(
+        f"[green]{mark}[/green] Upstream [bold]{name}[/bold] is now [bold]{label}[/bold] "
+        f"in /v1/models (advertise_models={str(now_on).lower()})."
+    )
+
+
 # ── show ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/agents/test_hermes_live_resolve_render.py
+++ b/tests/agents/test_hermes_live_resolve_render.py
@@ -50,12 +50,21 @@ def test_live_resolve_enables_live_model_discovery():
     assert keys["providers.custom.api_key"] == "hal0-local"
 
 
+def test_live_resolve_tags_discovery_with_owned_by_filter():
+    """#1148: under live-resolve, providers.custom.extra_headers carries the
+    X-hal0-Model-Filter: hal0 header so /v1/models discovery returns only
+    owned_by==hal0 rows — remote passthroughs stay out of the picker."""
+    keys = _overlay(live_resolve_enabled=True)
+    assert keys["providers.custom.extra_headers.X-hal0-Model-Filter"] == "hal0"
+
+
 def test_disabled_omits_live_model_discovery():
     """With live-resolve OFF, base_url is a single physical slot backend, so
     live discovery is intentionally not enabled."""
     keys = _overlay(live_resolve_enabled=False)
     assert "providers.custom.discover_models" not in keys
     assert "providers.custom.api_key" not in keys
+    assert "providers.custom.extra_headers.X-hal0-Model-Filter" not in keys
 
 
 def test_live_resolve_forces_gateway_for_nonlocal_primary():

--- a/tests/api/test_v1_models_filters.py
+++ b/tests/api/test_v1_models_filters.py
@@ -91,3 +91,45 @@ def test_disabled_upstream_contributes_nothing(client: TestClient) -> None:
     ids = _listed_ids(client)
     for mid in OPENROUTER_MODELS:
         assert mid not in ids
+
+
+# ── owned_by filter (#1148) — Hermes de-pollution ─────────────────────────
+#
+# The raw upstream rows carry owned_by == the upstream name ("openrouter"),
+# so ?owned_by=hal0 (or the X-hal0-Model-Filter header Hermes sends) drops
+# them all, while ?owned_by=openrouter keeps exactly them. Dispatch is
+# unaffected — this only curates the discovery surface.
+
+
+def test_owned_by_query_filters_out_passthroughs(client: TestClient) -> None:
+    _seed_remote(client)
+    resp = client.get("/v1/models", params={"owned_by": "hal0"})
+    assert resp.status_code == 200, resp.text
+    ids = [m["id"] for m in resp.json()["data"]]
+    for mid in OPENROUTER_MODELS:
+        assert mid not in ids
+    # Every surviving row is genuinely hal0-owned.
+    assert all(m["owned_by"] == "hal0" for m in resp.json()["data"])
+
+
+def test_owned_by_query_keeps_matching_owner(client: TestClient) -> None:
+    _seed_remote(client)
+    resp = client.get("/v1/models", params={"owned_by": "openrouter"})
+    assert resp.status_code == 200, resp.text
+    ids = [m["id"] for m in resp.json()["data"]]
+    for mid in OPENROUTER_MODELS:
+        assert mid in ids
+
+
+def test_model_filter_header_matches_query_param(client: TestClient) -> None:
+    _seed_remote(client)
+    resp = client.get("/v1/models", headers={"X-hal0-Model-Filter": "openrouter"})
+    assert resp.status_code == 200, resp.text
+    ids = [m["id"] for m in resp.json()["data"]]
+    for mid in OPENROUTER_MODELS:
+        assert mid in ids
+    # And the hal0 filter header excludes them.
+    resp2 = client.get("/v1/models", headers={"X-hal0-Model-Filter": "hal0"})
+    ids2 = [m["id"] for m in resp2.json()["data"]]
+    for mid in OPENROUTER_MODELS:
+        assert mid not in ids2

--- a/tests/cli/test_upstream_commands.py
+++ b/tests/cli/test_upstream_commands.py
@@ -157,6 +157,41 @@ def test_update_nothing_is_noop(api: dict[str, Any]) -> None:
     assert api["patches"] == []
 
 
+def test_advertise_on_patches_true_and_echoes_state(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["advertise", "orx", "on"])
+    assert result.exit_code == 0, result.output
+    path, body = api["patches"][0]
+    assert path == "/api/upstreams/orx"
+    assert body == {"advertise_models": True}
+    assert "advertised" in result.output
+
+
+def test_advertise_off_patches_false_and_echoes_state(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["advertise", "orx", "off"])
+    assert result.exit_code == 0, result.output
+    _, body = api["patches"][0]
+    assert body == {"advertise_models": False}
+    assert "hidden" in result.output
+
+
+def test_advertise_rejects_bad_state(api: dict[str, Any]) -> None:
+    result = runner.invoke(upstream_commands.app, ["advertise", "orx", "maybe"])
+    assert result.exit_code != 0
+    assert api["patches"] == []
+
+
+def test_advertise_unknown_upstream_errors_clearly(
+    api: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def raising_patch(path: str, **_kw: Any) -> dict[str, Any]:
+        raise upstream_commands.CliApiError("404 upstream 'nope' not found")
+
+    monkeypatch.setattr(upstream_commands, "api_patch", raising_patch)
+    result = runner.invoke(upstream_commands.app, ["advertise", "nope", "off"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
 def test_delete_requires_confirm_and_force_skips(api: dict[str, Any]) -> None:
     result = runner.invoke(upstream_commands.app, ["delete", "orx"], input="n\n")
     assert result.exit_code == 0

--- a/ui/tests/e2e/README.md
+++ b/ui/tests/e2e/README.md
@@ -1,0 +1,29 @@
+# hal0 dashboard E2E (Playwright)
+
+Specs live in `specs/`, shared fixtures in `fixtures/` (`apiMock` seeds the
+`/api/*` + `/v1/*` stubs). Run the suite from `ui/`:
+
+```bash
+npx playwright test                 # full suite (mock data, Vite dev server)
+npx playwright test warm-color      # one spec by name substring
+HAL0_E2E_LIVE=1 npx playwright test # live mode: proxy to real hal0-api :8080
+```
+
+The suite asserts **DOM and computed style**, not committed image snapshots —
+there are no PNG baselines to update. A visual contract is pinned by reading
+the value the browser resolves (e.g. `getComputedStyle(el).color`) and
+asserting it.
+
+## Retinting the unified warm color (`warm-color-tones.spec.ts`)
+
+Every warming-state indicator (slot dots, infer/NPU epills, connections dot)
+renders the single `--warn` token from `src/dashboard.css`; the overhaul-era
+`--warming` alias points at it. To change the warm color:
+
+1. Edit `--warn` (and, if you also want to adjust the glow, `--warming-glow`)
+   in `src/dashboard.css`.
+2. Update the `WARM_RGB` constant at the top of
+   `specs/warm-color-tones.spec.ts` to the new `rgb(...)` value.
+3. `npx playwright test warm-color` — a green run confirms every warming site
+   still resolves to the one token (a stray hex or a divergent `--warming`
+   re-fork fails here).

--- a/ui/tests/e2e/specs/warm-color-tones.spec.ts
+++ b/ui/tests/e2e/specs/warm-color-tones.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * warm-color-tones — regression for the UNIFIED warming color (#1157, epic #1156).
+ *
+ * Every warming-state indicator across the dashboard must render the one
+ * canonical warm token, `--warn` (dashboard.css), so a retint is a
+ * single-line change. #1156 consolidated the scattered oranges into `--warn`
+ * and pointed the overhaul-era `--warming` alias at it; this spec pins that
+ * so a future stray hex or a divergent `--warming` re-fork fails CI.
+ *
+ * WHY COMPUTED-COLOR, NOT PNG SNAPSHOTS
+ * The originating issue framed this as committed PNG screenshots, citing a
+ * "dashboard-overhaul" snapshot spec as prior art. That pattern does not
+ * exist in this repo — the entire e2e suite asserts DOM/computed style
+ * (see slot-indicator.spec.ts), and there are zero committed image
+ * baselines. Container-rendered PNG baselines also flake against CI on font
+ * anti-aliasing, which would violate the issue's own AC ("green in CI on
+ * first run"). So this enforces the SAME contract deterministically: it
+ * reads the color the browser actually resolves from the var() chain at
+ * each warming site and asserts they're all the one token. To retint, change
+ * `--warn` in dashboard.css and update WARM_RGB below.
+ *
+ * Covered warming sites (issue AC — at least slot dot, infer epill, NPU epill):
+ *   - slot dot            → `.infer-pane .sdot.warming`   (engine-panes.css)
+ *   - connections dot     → `.ep-dot.warming`             (connections.css)
+ *   - infer pane epill    → `.infer-pane .epill.starting` (engine-panes.css)
+ *   - NPU pane epill      → `.npu-pane .epill.starting`   (engine-panes.css)
+ *   - overhaul slot dot   → `.sdot.warming` via `--warming` alias (overhaul.css)
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+// Canonical --warn (dashboard.css). Retint contract: change --warn there,
+// then update this one constant. rgb() is how getComputedStyle reports it.
+const WARM_RGB = 'rgb(242, 121, 43)'
+
+type Probe = { site: string; ancestor: string; el: string; prop: 'backgroundColor' | 'color' }
+
+// Each probe injects the REAL selector chain and reads the color the browser
+// resolves from the live stylesheet — proving that site is wired to --warn.
+const PROBES: Probe[] = [
+  { site: 'slot dot (infer pane)', ancestor: 'infer-pane', el: 'sdot warming', prop: 'backgroundColor' },
+  { site: 'connections dot', ancestor: '', el: 'ep-dot warming', prop: 'backgroundColor' },
+  { site: 'infer pane epill', ancestor: 'infer-pane', el: 'epill starting', prop: 'color' },
+  { site: 'NPU pane epill', ancestor: 'npu-pane', el: 'epill starting', prop: 'color' },
+  { site: 'overhaul slot dot (--warming alias)', ancestor: '', el: 'sdot warming', prop: 'backgroundColor' },
+]
+
+test.describe('unified warm color', () => {
+  test.beforeEach(async ({ page }) => {
+    // Any route loads the full dashboard CSS bundle; #slots is cheap.
+    await page.goto('/#slots')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('--warn resolves to the canonical warm rgb', async ({ page }) => {
+    const resolved = await page.evaluate((v) => {
+      const probe = document.createElement('span')
+      probe.style.color = `var(${v})`
+      document.body.appendChild(probe)
+      const c = getComputedStyle(probe).color
+      probe.remove()
+      return c
+    }, '--warn')
+    expect(resolved).toBe(WARM_RGB)
+  })
+
+  test('--warming aliases --warn (no re-fork of the overhaul token)', async ({ page }) => {
+    const [warn, warming] = await page.evaluate(() => {
+      const read = (v: string) => {
+        const p = document.createElement('span')
+        p.style.color = `var(${v})`
+        document.body.appendChild(p)
+        const c = getComputedStyle(p).color
+        p.remove()
+        return c
+      }
+      return [read('--warn'), read('--warming')]
+    })
+    expect(warming).toBe(warn)
+    expect(warming).toBe(WARM_RGB)
+  })
+
+  for (const probe of PROBES) {
+    test(`${probe.site} renders the unified warm color`, async ({ page }) => {
+      const resolved = await page.evaluate((p) => {
+        const root = document.createElement('div')
+        if (p.ancestor) root.className = p.ancestor
+        const el = document.createElement('span')
+        el.className = p.el
+        root.appendChild(el)
+        document.body.appendChild(root)
+        const value = getComputedStyle(el)[p.prop as 'backgroundColor' | 'color']
+        root.remove()
+        return value
+      }, probe)
+      expect(resolved, `${probe.site} must resolve to --warn`).toBe(WARM_RGB)
+    })
+  }
+})


### PR DESCRIPTION
Autonomous batch across the v0.9.7.1 bones-review issues. Four separable commits.

## #1148 — Hermes model picker → `owned_by==hal0`
Hermes' live `/v1/models` discovery listed every catalog row (~340 openrouter + minimax passthroughs), burying local slots. Pi already filters client-side; this brings Hermes to parity **without forking hermes-agent**:
- `/v1/models` gains an optional owner filter — `?owned_by=<name>` query param **or** `X-hal0-Model-Filter` header, exact-match on `owned_by`. Default response is byte-identical (pi + SDKs untouched). Discovery-surface only; dispatch by explicit id is unaffected.
- Hermes provisioning tags its custom-provider discovery with `extra_headers.X-hal0-Model-Filter: hal0` (live-resolve only), which hermes forwards onto the `/models` GET.
- Tests: `/v1/models` owner filter (query + header) + hermes overlay assertion.

## #1150 — `hal0 upstream advertise <name> on|off`
Convenience verb over the runtime advertise_models toggle (#1147). Accepts on/off (+ true/false/yes/no/enable/disable/show/hide), PATCHes `/api/upstreams/{name}`, echoes resulting state. Live (cache-punch), dispatch unaffected, clear error on unknown upstream. `upstream list` (AC #1) already shipped in #1228. Doc line added to `cli.mdx` (docs-parity guard). Tests added.

## #1256 — split/multi-file GGUF audit
`docs/internal/split-gguf-audit.md`: catalogs every registry site assuming one file per model, with **verified** `path:line` citations (issue refs confirmed accurate) across pull/discover/detect/gguf_header/models plus the root `model.py` `path: str`. Lifecycle table (Run already works via llama.cpp shard auto-load; Pull/Scan/Metadata/Register don't) + 4-point implementation sketch. Docs-only.
> Note: `docs/internal/` is gitignored (operator-only notes) so the file is force-added — it's a shared engineering reference.

## #1157 — unified warm-color regression spec
`ui/tests/e2e/specs/warm-color-tones.spec.ts` pins that every warming indicator (slot dot, connections dot, infer + NPU epills, overhaul `--warming` alias) resolves to the one `--warn` token #1156 consolidated.
> **Deviation (justified):** implemented as a deterministic computed-color spec, not committed PNG baselines. The repo's entire e2e suite asserts DOM/computed style with zero image baselines, and container-rendered PNGs flake on CI font AA — which would break the issue's own "green on first run" AC. Reads each site's resolved var() chain and asserts they're the one token. README documents the retint flow. 7/7 green locally.

## #1154 — already shipped
Per-upstream model filters landed via **PR #1228** (filters.py, schema, `/v1/models` wiring, CLI, tests). Verified green on this branch; no code needed here.

## Tests
`pytest tests/api tests/config tests/cli tests/agents -k "models or upstream or catalog or filter or hermes or docs_parity or advertise"` → **248 passed**. New: 3 owner-filter + 4 advertise + 1 hermes-overlay + 7 warm-color e2e.
3 pre-existing failures (comfyui traversal, models_preview, settings non-writable-path) are env/root-user artifacts present before this branch — untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)