### PR TITLE
docs: sweep stale ADR/Cognee refs, deprecate gttsize, document fresh-box journey

### DIFF
--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -9,8 +9,8 @@ import { Aside, Card, CardGrid, LinkCard, Steps } from '@astrojs/starlight/compo
 
 hal0 makes one security decision explicit and central: it does **not** ship
 built-in authentication or TLS. The API binds `0.0.0.0:8080` and every endpoint
-is open to anything that can reach that port. This is a deliberate design choice
-(ADR-0012), and the rest of your security posture is built on top of it rather
+is open to anything that can reach that port. This is a deliberate design choice,
+and the rest of your security posture is built on top of it rather
 than inside it.
 
 <Aside type="caution">
@@ -23,7 +23,7 @@ it for anything beyond a single trusted LAN.
 ## Why no built-in auth?
 
 Earlier designs bundled an auth layer and a TLS-terminating proxy. That was
-removed (ADR-0012) because it duplicated, badly, what every operator already
+removed because it duplicated, badly, what every operator already
 runs better elsewhere: a real reverse proxy. Bundling auth meant maintaining
 credential storage, token rotation, and TLS certificate plumbing inside the
 inference server — surface area that is someone else's core competency.

--- a/docs/getting-started/baremetal-ubuntu.mdx
+++ b/docs/getting-started/baremetal-ubuntu.mdx
@@ -51,19 +51,23 @@ on the host kernel command line:
 
 ```sh
 # /etc/default/grub — append to GRUB_CMDLINE_LINUX_DEFAULT
-amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856
+amd_iommu=off ttm.pages_limit=32505856
 ```
 
 ```sh
 sudo update-grub && sudo reboot
 ```
 
-`amdgpu.gttsize` is in **MiB** (`126976` ≈ 124 GiB); `ttm.pages_limit` is
-in **4 KiB pages** (`32505856` ≈ 124 GiB — keep it equal to `gttsize`);
-`amd_iommu=off` is worth ~5–12% on this workload. These reference values
-target a 128 GB box and leave only ~4 GB for the host — scale both down
-together to reserve more host RAM. After rebooting, confirm with
-`cat /proc/cmdline`.
+`ttm.pages_limit` is the GTT cap in **4 KiB pages** (`32505856` ≈ 124 GiB);
+`amd_iommu=off` is worth ~5–12% on this workload. This reference value
+targets a 128 GB box and leaves only ~4 GB for the host — scale it down to
+reserve more host RAM. After rebooting, confirm with `cat /proc/cmdline`.
+
+<Aside type="caution">
+The old `amdgpu.gttsize` parameter is **deprecated** — it is ignored on
+Linux 6.10+ (the GTT window is now driven entirely by `ttm.pages_limit`).
+Set only `ttm.pages_limit`; drop `amdgpu.gttsize` from any older guide.
+</Aside>
 
 ## 3. Install hal0
 

--- a/docs/getting-started/first-chat.mdx
+++ b/docs/getting-started/first-chat.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 40
 ---
 
-import { Tabs, TabItem, Steps, Aside } from '@astrojs/starlight/components';
+import { Tabs, TabItem, Steps, Aside, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 With a model pulled and assigned to a slot, you can chat through the
 prewired web UI or directly against the OpenAI-compatible API.
@@ -118,3 +118,25 @@ native path), `audio/transcriptions`, `audio/speech`, and
 `images/generations` — each routed to the appropriate slot. `GET
 /v1/models` lists everything the configured slots and upstreams
 advertise.
+
+## Next
+
+With a working chat loop, from here you can grow the install out:
+
+<CardGrid>
+  <LinkCard
+    title="Manage slots"
+    href="/docs/guides/manage-slots/"
+    description="Create, load, swap, and restart the podman-backed inference slots behind each capability."
+  />
+  <LinkCard
+    title="Choose models"
+    href="/docs/guides/choose-models/"
+    description="The curated catalogue for chat, embed, rerank, and image models, sized for your hardware."
+  />
+  <LinkCard
+    title="Run agents"
+    href="/docs/guides/run-agents/"
+    description="Install and manage the bundled Hermes agent — provisioning, personas, and spending budgets."
+  />
+</CardGrid>

--- a/docs/getting-started/first-model.mdx
+++ b/docs/getting-started/first-model.mdx
@@ -12,6 +12,34 @@ Hugging Face coordinates, SHA-256 digests, and curated filenames. A fresh
 install seeds **zero** model slots — you pick the first model yourself,
 and the fastest path is two commands.
 
+## Starting from zero — no models yet
+
+Every fresh install boots with services up but nothing to serve — first-run
+setup scaffolds slot *structure* only, no model picks (see
+[First-run setup](/docs/getting-started/setup/)). Until you pull one, that
+shows up in a few places:
+
+- The dashboard shows a passive banner — "No models configured yet" —
+  whenever the API reports `first_run: true`. It's dismissible and never
+  auto-routes you anywhere.
+- The **Models** view has an empty registry (the Inference tab reads "the
+  catalog is empty"), and the Downloads panel prompts you to add a model
+  from the catalog or via **Add by HF coords**.
+- The **Slots** view shows a **no slots configured** hint if no capability
+  slots exist yet.
+- `GET /v1/models` returns an empty list, and a chat request against an
+  unconfigured slot has nothing to dispatch to.
+
+`first_run` is computed from two conditions: `/var/lib/hal0/models/` is
+empty **and** the first-run sentinel (`/var/lib/hal0/.first_run_done`)
+doesn't exist yet. Either one flips it to `false` — so pulling or adding
+any model (or the setup TUI writing the sentinel) is enough to clear the
+banner for good in normal use.
+
+Getting out of this state is the rest of this page: the two-command path
+right below, the dashboard's **Models** view, or the
+[`hal0 setup`](/docs/getting-started/setup/) TUI.
+
 ## The two-command path
 
 ```sh

--- a/docs/getting-started/proxmox-lxc.mdx
+++ b/docs/getting-started/proxmox-lxc.mdx
@@ -80,20 +80,25 @@ hal0's profile-tuning work are:
 
 ```sh
 # /etc/default/grub — append to GRUB_CMDLINE_LINUX_DEFAULT, then update-grub && reboot
-amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856
+amd_iommu=off ttm.pages_limit=32505856
 ```
 
 | Parameter | Value | Meaning |
 |---|---|---|
-| `amdgpu.gttsize` | `126976` | GTT window in **MiB** (≈ 124 GiB) |
-| `ttm.pages_limit` | `32505856` | TTM page cap in **4 KiB pages** (≈ 124 GiB — keep it equal to `gttsize`) |
+| `ttm.pages_limit` | `32505856` | GTT cap in **4 KiB pages** (≈ 124 GiB) |
 | `amd_iommu=off` | — | Disables the IOMMU; measured worth ~5–12% on this workload |
 
 <Aside type="tip">
-`126976` MiB leaves only ~4 GB for the host on a 128 GB machine — fine for
-a dedicated inference LXC, aggressive if the host runs other tenants.
-Scale both numbers down together (they must stay equal) to reserve more
-host RAM. After rebooting, `cat /proc/cmdline` should show the params.
+`32505856` pages ≈ 124 GiB leaves only ~4 GB for the host on a 128 GB
+machine — fine for a dedicated inference LXC, aggressive if the host runs
+other tenants. Scale it down to reserve more host RAM. After rebooting,
+`cat /proc/cmdline` should show the params.
+</Aside>
+
+<Aside type="caution">
+The old `amdgpu.gttsize` parameter is **deprecated** — it is ignored on
+Linux 6.10+ (the GTT window is now driven entirely by `ttm.pages_limit`).
+Set only `ttm.pages_limit`; drop `amdgpu.gttsize` from any older guide.
 </Aside>
 
 ## 2. Create the container

--- a/docs/guides/connect-external-providers.mdx
+++ b/docs/guides/connect-external-providers.mdx
@@ -213,7 +213,7 @@ back**. Deleting an upstream deliberately leaves its credential in
 `api.env` — remove it via `/api/secrets` if truly unwanted.
 
 <Aside type="caution">
-There is no built-in authentication on the hal0 API (ADR-0012) — it binds
+There is no built-in authentication on the hal0 API — it binds
 to the LAN. `api.env` is a LAN-writable file; treat the host as you would
 any secret-bearing service and reverse-proxy it if it needs to be exposed.
 </Aside>

--- a/docs/guides/connect-mcp.mdx
+++ b/docs/guides/connect-mcp.mdx
@@ -17,7 +17,7 @@ servers, mounted on the API as Streamable-HTTP sub-apps:
   to the memory server.
 
 <Aside type="caution">
-hal0 has **no built-in network auth** (ADR-0012). The MCP mounts are
+hal0 has **no built-in network auth**. The MCP mounts are
 reachable to anything that can reach the API. Run hal0 on a trusted LAN
 or behind your own reverse proxy — do not expose `/mcp/*` to the
 internet.
@@ -34,8 +34,8 @@ http://localhost:8080/mcp/memory
 
 ### Identify with X-hal0-Agent
 
-Caller identity flows on the **`X-hal0-Agent`** request header (Bearer
-auth was removed in ADR-0012). The value must match
+Caller identity flows on the **`X-hal0-Agent`** request header (hal0 has
+no bearer-token auth to carry identity instead). The value must match
 `^[a-zA-Z0-9_-]{1,64}$`. It stamps the audit trail and powers the
 `private:<agent>` memory namespace.
 

--- a/docs/guides/honcho-memory.mdx
+++ b/docs/guides/honcho-memory.mdx
@@ -75,7 +75,7 @@ renders them to `/etc/hal0/honcho.env`, which the compose stack mounts via
 | `honcho.port` | `8000` | Host port Honcho's API listens on (loopback). |
 | `honcho.workspace` | `"hal0"` | Unified workspace name shared by non-private agents. |
 | `honcho.user_peer` | `"operator"` | Single human peer id shared by all clients in the unified workspace. |
-| `honcho.auth_enabled` | `false` | Require Bearer auth on the Honcho API (loopback-only posture by default — ADR-0012). |
+| `honcho.auth_enabled` | `false` | Require Bearer auth on the Honcho API (loopback-only posture by default). |
 
 `[honcho.llm]` routes five features independently — `deriver`, `dialectic`,
 `summary`, `dream`, `embedding` — each with `transport` (`openai` \|

--- a/docs/guides/run-agents.mdx
+++ b/docs/guides/run-agents.mdx
@@ -62,7 +62,7 @@ hal0 agent install opencode
 ```
 
 This runs `installer/agents/opencode.sh` (a track-latest `npm install -g
-opencode-ai`; no version pin per ADR-0004 §3) and writes
+opencode-ai`; no version pin, by design) and writes
 `~/.config/opencode/opencode.json` wiring:
 
 - **Provider** — hal0 as an `@ai-sdk/openai-compatible` provider at

--- a/docs/operate/auth.mdx
+++ b/docs/operate/auth.mdx
@@ -9,9 +9,9 @@ import { Aside, Steps, Tabs, TabItem, Code } from '@astrojs/starlight/components
 
 hal0 has no built-in authentication CLI, no user/password store, and no
 bundled reverse proxy. `hal0-api` binds `0.0.0.0:8080` and every endpoint is
-reachable by anything that can reach that port. This was a deliberate cut
-(ADR-0012, "remove-auth-and-caddy") — earlier betas bundled a password store
-and a Caddy TLS-terminating proxy, and both were removed because they
+reachable by anything that can reach that port. This was a deliberate cut —
+earlier betas bundled a password store and a Caddy TLS-terminating proxy,
+and both were removed because they
 duplicated, badly, what a real reverse proxy already does better. There is no
 `--auth=basic` install flag and no `hal0 auth` subcommand.
 

--- a/docs/reference/api/openai-compat.mdx
+++ b/docs/reference/api/openai-compat.mdx
@@ -21,7 +21,7 @@ binary for audio speech) and non-streaming responses are both handled by the
 forwarder.
 
 <Aside type="caution">
-There is no built-in authentication (ADR-0012). The server binds open on the
+There is no built-in authentication. The server binds open on the
 local network; put it behind your own reverse proxy if you need auth or TLS.
 `GET /v1/models` and `/v1/models/{id}` are deliberately auth-free so SDKs can
 probe the catalog before sending any `Authorization` header.

--- a/docs/reference/api/rest-api.mdx
+++ b/docs/reference/api/rest-api.mdx
@@ -13,8 +13,8 @@ router groups. For the inference surface see the OpenAI-compat and streaming
 references.
 
 <Aside type="note">
-All endpoints are open on the local network — auth and TLS were removed in
-ADR-0012 and are your reverse proxy's job. The OpenAPI spec is served live at
+All endpoints are open on the local network — there's no built-in auth or
+TLS; that's your reverse proxy's job. The OpenAPI spec is served live at
 `/api/openapi.json` (interactive docs at `/api/docs`).
 </Aside>
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -392,8 +392,8 @@ left the catalog are cleared. Idempotent.
 | `agent personas activate <id>` | Switch the active persona and nudge Hermes to hot-reload. | `--reload-url` |
 
 <Aside type="note">
-There is no `rotate-token` subcommand. The daemon has no built-in auth
-(ADR-0012); agent identity flows through the `X-hal0-Agent` header the wrapper
+There is no `rotate-token` subcommand. The daemon has no built-in auth;
+agent identity flows through the `X-hal0-Agent` header the wrapper
 sets from `$HAL0_AGENT_ID`.
 </Aside>
 
@@ -420,7 +420,7 @@ hits `127.0.0.1:8080`. Manage the bundled MCP servers (`hal0-admin`,
 
 <Aside type="note">
 `mcp restart` currently surfaces the `501` supervisor-stub gracefully — live
-MCP process restart lands with ADR-0015. Until then, `restart` reports the
+MCP process restart is a planned follow-up. Until then, `restart` reports the
 stub instead of bouncing the server.
 </Aside>
 

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -116,7 +116,7 @@ NPU weights off the root filesystem too.
 
 | Key | Type | Default | Notes |
 |---|---|---|---|
-| `engine` | str | `"hindsight"` | Active memory engine: `cognee` \| `hindsight` \| `mem0` \| `pgvector`. `hindsight` is the current default. |
+| `engine` | str | `"hindsight"` | Active memory engine: `hindsight` (default) \| `mem0` \| `pgvector`. `cognee` is **deprecated** — accepted for back-compat but resolves to `hindsight`. |
 
 <Aside type="note">
 The validator also accepts `cognee`/`mem0`, but the Advanced Settings dropdown

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -30,7 +30,7 @@ config by env-var name. Never commit a populated `api.env`.
 | `HAL0_ACTIVITY_RETENTION_DAYS` | Override the activity/audit store retention window.          | from `hal0.toml` (`[activity].retention_days`, `30`) |
 
 <Aside type="note">
-hal0 ships with **no built-in auth or TLS** (ADR-0012). The API is open on the
+hal0 ships with **no built-in auth or TLS**. The API is open on the
 local network; put it behind your own reverse proxy for TLS and access control.
 There is no bearer-token or basic-auth flag to enable.
 </Aside>

--- a/docs/reference/mcp-tools.mdx
+++ b/docs/reference/mcp-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP tools
-description: Reference for hal0's two MCP servers — memory and admin tools, classified as autonomous-read, autonomous-write, or approval-gated per ADR-0004 and ADR-0005.
+description: Reference for hal0's two MCP servers — memory and admin tools, classified as autonomous-read, autonomous-write, or approval-gated by blast radius.
 sidebar:
   order: 60
 ---
@@ -20,7 +20,7 @@ autonomous-write, or approval-gated. Gated tools enqueue for owner approval
 before they run; autonomous tools execute immediately.
 
 <Aside type="note">
-hal0 has no built-in auth (ADR-0012) — there are no bearer tokens. When Hermes
+hal0 has no built-in auth — there are no bearer tokens. When Hermes
 or another bundled agent calls the MCP server, it identifies itself with the
 `X-hal0-Agent` header (set from `$HAL0_AGENT_ID` by the agent wrapper). The
 server stamps that identity on every audit row and carries it onto the internal

--- a/installer/agents/hermes/plugins/hal0-memory/_client.py
+++ b/installer/agents/hermes/plugins/hal0-memory/_client.py
@@ -8,7 +8,7 @@ on the 2nd call (one ``AsyncClient`` reused across per-call event loops →
 is reused safely for the session.
 
 Talks to hal0-api's ``/api/memory/*`` routes, NOT the ``/mcp/memory``
-JSON-RPC transport. Identity is carried via ``X-hal0-Agent`` per ADR-0012;
+JSON-RPC transport. Identity is carried via ``X-hal0-Agent``;
 there is no Bearer auth on the hal0 LAN.
 
 Two banks, selected per write by ``X-hal0-Private``:

--- a/src/hal0/agents/__init__.py
+++ b/src/hal0/agents/__init__.py
@@ -4,8 +4,8 @@ Bundled third-party agent apps. Single-pick at install. Shim-first
 ownership: hal0 owns the install scripts under ``installer/agents/*.sh``;
 this package wraps them in Python so the CLI + API speak one interface.
 
-This is NOT a first-party agent runtime — see ADR-0004 §1 ("Bundle,
-don't build"). The drivers in :mod:`hal0.agents.pi_coder` and
+This is NOT a first-party agent runtime — by design: "Bundle,
+don't build". The drivers in :mod:`hal0.agents.pi_coder` and
 :mod:`hal0.agents.hermes` only handle install/uninstall wiring + config
 writes. Runtime is whatever the bundled upstream does natively.
 """

--- a/src/hal0/agents/hermes/driver.py
+++ b/src/hal0/agents/hermes/driver.py
@@ -1,4 +1,4 @@
-"""Hermes-Agent driver (ADR-0004 §6).
+"""Hermes-Agent driver.
 
 Hermes is user-owned upstream — and crucially, the user cannot PR
 upstream NousResearch/hermes-agent. So hal0-awareness lives on the
@@ -262,7 +262,7 @@ class HermesDriver(AgentDriver):
         return _paths.var_lib() / "agents" / self.name
 
     def _env_file_path(self) -> Path:
-        # ADR-0004 §6: "writes /etc/hal0/agents/hermes.env". Lives in
+        # Writes /etc/hal0/agents/hermes.env. Lives in
         # /etc so the user/admin can tweak it without disturbing
         # /var/lib state, same posture as openwebui.env. The wrapper
         # sources this file on every hermes invocation.

--- a/src/hal0/agents/hermes/plugins/memory_hindsight/_client.py
+++ b/src/hal0/agents/hermes/plugins/memory_hindsight/_client.py
@@ -8,7 +8,7 @@ on the 2nd call (one ``AsyncClient`` reused across per-call event loops →
 is reused safely for the session.
 
 Talks to hal0-api's ``/api/memory/*`` routes, NOT the ``/mcp/memory``
-JSON-RPC transport. Identity is carried via ``X-hal0-Agent`` per ADR-0012;
+JSON-RPC transport. Identity is carried via ``X-hal0-Agent``;
 there is no Bearer auth on the hal0 LAN.
 
 Two banks, selected per write by ``X-hal0-Private``:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -2697,7 +2697,7 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
 
 # ── Phase H: namespace_register ─────────────────────────────────────────────
 #
-# Writes the Hermes-Agent identity card to the `agents` Cognee dataset.
+# Writes the Hermes-Agent identity card to the `agents` memory dataset.
 # Card is immutable post-write — re-bootstrap deletes the
 # existing card and writes a fresh one to refresh metadata (the only
 # legitimate post-install write). On hal0-memory failure, log + continue
@@ -2843,7 +2843,7 @@ def _mcp_memory_call(
 
 
 def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
-    """Write the Hermes identity card to the `agents` Cognee dataset.
+    """Write the Hermes identity card to the `agents` memory dataset.
 
     Idempotency: search for an existing card by ``agent_id`` first;
     if present, delete it before writing the fresh one (cards are

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1585,7 +1585,7 @@ def _build_config_overlay(
             ("delegation.base_url", delegation["base_url"]),
         ]
 
-    # memory.graph.* (ADR-0014) configured hal0's OWN Hindsight
+    # memory.graph.* configured hal0's OWN Hindsight
     # graph-extraction engine — hermes never reads it, so forwarding it into
     # hermes's config.yaml was dead config. Dropped for both branches rather
     # than ported to honcho (feat/honcho-memory).
@@ -1597,7 +1597,7 @@ def _build_config_overlay(
     ]
 
     # mcp_servers via config set (NOT `hermes mcp add` — interactive/hangs).
-    # ADR-0012: no Bearer; agent identity flows via X-hal0-Agent.
+    # No Bearer; agent identity flows via X-hal0-Agent.
     for srv in mcp_servers:
         name = srv["name"]
         pairs += [
@@ -2109,8 +2109,8 @@ def _utility_aux_model(auxiliary_tasks: dict[str, dict[str, Any]] | None) -> str
 #
 # Verifies hal0-admin + hal0-memory MCP servers respond to tools/list +
 # records the discovered tool surface in provision.json for downstream
-# phases (#243 namespace_register, #245 model_automap). Honors ADR-0013:
-# the per-agent allow-list at /etc/hal0/agents/hermes.toml gates which
+# phases (#243 namespace_register, #245 model_automap). Honors the
+# per-agent allow-list at /etc/hal0/agents/hermes.toml, which gates which
 # servers the bootstrap will attempt to connect to.
 
 
@@ -2124,7 +2124,7 @@ def _load_agent_allowlist(
 
     Returns ``None`` when the file is missing (the agent installer
     drops it during install; absence means "allow everything that's
-    builtin" per ADR-0013's installer-managed convention). Returns
+    builtin" per the installer-managed convention). Returns
     ``{server_name: section_dict}`` when present.
     """
     target = path or AGENT_ALLOWLIST_PATH
@@ -2262,7 +2262,7 @@ def _probe_mcp_server(
 def _phase_mcp_wire(ctx: PhaseContext) -> PhaseResult:
     """Verify the two hal0-bundled MCP servers respond + record their tool list.
 
-    ADR-0013 compliance: when an allow-list exists at
+    When an allow-list exists at
     ``/etc/hal0/agents/hermes.toml``, the bootstrap only attempts
     connection for servers listed under ``[mcp.servers.*]``. A
     missing entry (or a missing allow-list file entirely) is a
@@ -2309,7 +2309,7 @@ def _phase_mcp_wire(ctx: PhaseContext) -> PhaseResult:
 
     # Even with warnings we return OK — degraded MCP connectivity is
     # surfaced for smoke_tests + self_report to display, not a fatal
-    # bootstrap blocker (per ADR-0013 + the plan §9 contract).
+    # bootstrap blocker (per the plan §9 contract).
     #
     # ``rendered_servers`` is consumed by Phase 5 (config_write) on the
     # next bootstrap run — it's how Phase 6 hands the template the live
@@ -2697,11 +2697,11 @@ def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
 
 # ── Phase H: namespace_register ─────────────────────────────────────────────
 #
-# Writes the Hermes-Agent identity card to the `agents` Cognee dataset
-# (ADR-0011). Card is immutable post-write — re-bootstrap deletes the
+# Writes the Hermes-Agent identity card to the `agents` Cognee dataset.
+# Card is immutable post-write — re-bootstrap deletes the
 # existing card and writes a fresh one to refresh metadata (the only
 # legitimate post-install write). On hal0-memory failure, log + continue
-# (per #243 sharpening + ADR-0013); the card is nice-to-have and
+# (per #243 sharpening); the card is nice-to-have and
 # bootstrap MUST NOT fail because the peer registry is down.
 
 
@@ -2731,7 +2731,7 @@ def _hal0_version_string() -> str:
 
 
 def _build_identity_card(state: BootstrapState) -> dict[str, Any]:
-    """Schema v1 per ADR-0011 §4. Text + structured metadata."""
+    """Schema v1. Text + structured metadata."""
     return {
         "text": (
             "I am Hermes, the hal0 admin agent. I have read/write access to the slot "
@@ -2847,7 +2847,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
 
     Idempotency: search for an existing card by ``agent_id`` first;
     if present, delete it before writing the fresh one (cards are
-    immutable per ADR-0011 §2, but bootstrap rewrites refresh the
+    immutable, but bootstrap rewrites refresh the
     snapshot of hal0_version + hermes_version).
 
     Failure mode: any MCP transport error logs + returns OK with a
@@ -3004,7 +3004,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
 
 
 def _build_brain_identity_card() -> dict[str, Any]:
-    """Identity card for the hal0-brain profile (schema v1, ADR-0011 §4).
+    """Identity card for the hal0-brain profile (schema v1).
 
     Mirrors :func:`_build_identity_card` (the default agent's card) so the
     dashboard steward registers as a first-class agent identity rather than a
@@ -3872,7 +3872,7 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
     without a full re-render. ``config set`` is idempotent, so a no-drift run
     just re-writes the same values.
 
-    Embed/rerank/img slots are deliberately NOT mapped per ADR-0011 §3
+    Embed/rerank/img slots are deliberately NOT mapped
     (Hermes has no top-level embed abstraction; memory MCP handles it).
     """
     state = ctx.state
@@ -3930,8 +3930,8 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
 # ── Phase J: voice_wire ─────────────────────────────────────────────────────
 #
 # Conditional. Emits STT/TTS provider config + writes
-# /var/lib/hal0/secrets/agents/hermes.env. Per the post-ADR-0012
-# correction on #246, that secrets file is OUTBOUND credentials only
+# /var/lib/hal0/secrets/agents/hermes.env. Per the #246
+# correction, that secrets file is OUTBOUND credentials only
 # now (HF token + external MCP tokens + STT_/TTS_OPENAI_BASE_URL).
 # voice_wire skips with reason when neither slot is `ready`.
 
@@ -4641,7 +4641,7 @@ def _seed_payload(state: BootstrapState) -> dict[str, Any]:
         "agent": {
             "name": "hermes",
             "installed_at": datetime.datetime.now(tz=datetime.UTC).isoformat(),
-            # Track-latest by design (ADR-0004 §3). No version pin.
+            # Track-latest by design. No version pin.
             "version_pin": False,
         },
         "data_dir": str(Path("/var/lib/hal0/agents/hermes")),

--- a/src/hal0/agents/hermes_templates/AGENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/AGENTS.md.j2
@@ -48,7 +48,7 @@ live state.
 ## MCP surfaces
 
 - `hal0_admin` MCP — slots, models, capabilities, hardware probes.
-- `hal0_memory` MCP — Cognee-backed durable memory; agents own
+- `hal0_memory` MCP — Hindsight-backed durable memory; agents own
   `private:<agent_id>` namespaces; identity cards live in the
   `agents` dataset.
 

--- a/src/hal0/agents/hermes_templates/AGENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/AGENTS.md.j2
@@ -50,7 +50,7 @@ live state.
 - `hal0_admin` MCP — slots, models, capabilities, hardware probes.
 - `hal0_memory` MCP — Cognee-backed durable memory; agents own
   `private:<agent_id>` namespaces; identity cards live in the
-  `agents` dataset (see ADR-0011).
+  `agents` dataset.
 
 ## Conventions
 

--- a/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
@@ -12,7 +12,7 @@ Connect external tools (Claude Code, OpenWebUI, etc.) to hal0's MCP servers.
 | Server | URL | Transport | Description |
 |--------|-----|-----------|-------------|
 | hal0-admin | `http://127.0.0.1:8080/mcp/admin/mcp` | `http` (POST-only) | Slot/model management, system admin, hardware probes |
-| hal0-memory | `http://127.0.0.1:8080/mcp/memory/mcp` | `http` (POST-only) | Cognee vector/graph memory, agent identity cards |
+| hal0-memory | `http://127.0.0.1:8080/mcp/memory/mcp` | `http` (POST-only) | Hindsight vector/graph memory, agent identity cards |
 
 **Important:** hal0 MCP servers only support plain HTTP POST transport. Do NOT use `streamable-http` or SSE — these will fail with HTTP 406 or 405.
 

--- a/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
@@ -1,5 +1,5 @@
 {# /etc/hal0/MCP-CLIENTS.md — hal0 MCP wiring reference for external clients.
-   Rendered by context_link phase per ADR-0021 post-provision hook.
+   Rendered by context_link phase's post-provision hook.
    This file documents the MCP connection contract for tools like
    Claude Code, OpenWebUI, and other external MCP consumers.
    hal0 does not manage these tools — it documents how to wire them. #}
@@ -20,7 +20,7 @@ Connect external tools (Claude Code, OpenWebUI, etc.) to hal0's MCP servers.
 
 > **Planned:** a `hal0 connect <client>` helper that auto-discovers MCP
 > servers and wires them into your client (with `--dry-run` /
-> `--repair`) is planned per ADR-0021 but **not yet implemented** —
+> `--repair`) is planned but **not yet implemented** —
 > running it today yields a "no such command" error. Until it ships,
 > wire clients with the manual configuration below.
 
@@ -84,10 +84,10 @@ Should return the tool count (typically 25+ for admin, 4 for memory).
 | HTTP 405 Method Not Allowed | URL missing `/mcp` suffix (e.g. `/mcp/admin`) | Use full path: `/mcp/admin/mcp` |
 | HTTP 406 Not Acceptable | Using `streamable-http` transport (sends GET + POST) | Use `http` transport (POST-only) |
 | Connection refused | hal0 API not running | `systemctl status hal0-api` |
-| Unknown tool | MCP server not connected | Re-apply the manual configuration above (the `hal0 connect <client>` helper is planned, ADR-0021, not yet shipped) |
+| Unknown tool | MCP server not connected | Re-apply the manual configuration above (the `hal0 connect <client>` helper is planned, not yet shipped) |
 
 ## See Also
 
 - `/etc/hal0/AGENTS.md` — agent-facing project context
 - `/root/.dexto/agents/hal0-services/agent.yml` — working reference config
-- `hal0 connect --list` (planned, ADR-0021) — will list all supported connectors and their status once implemented
+- `hal0 connect --list` (planned) — will list all supported connectors and their status once implemented

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -1,4 +1,4 @@
-"""Bundled-agent lifecycle manager (Phase 8, ADR-0004 §2 + §6).
+"""Bundled-agent lifecycle manager (Phase 8).
 
 State on disk:
 
@@ -27,7 +27,7 @@ was still on disk (#346).
 Single-pick is enforced here, not in the API or CLI. ``install()``
 refuses to add a second agent unless ``switch=True``, in which case it
 performs an atomic uninstall-then-install so the operator never ends up
-with two bundled agents partially installed (ADR-0004 §2).
+with two bundled agents partially installed.
 
 The actual install work is delegated to per-agent driver modules
 (:mod:`hal0.agents.pi_coder`, :mod:`hal0.agents.hermes`) which in turn
@@ -64,13 +64,13 @@ class AgentNotFoundError(AgentError):
 
 class AgentAlreadyInstalledError(AgentError):
     """Raised when ``install()`` is called and a different agent is already
-    bundled (single-pick enforcement, ADR-0004 §2). Pass ``switch=True``
+    bundled (single-pick enforcement). Pass ``switch=True``
     to atomically swap."""
 
 
 class HermesUpstreamMissingError(AgentError):
     """Raised by the Hermes driver when the hal0-owned ``hal0-hermes``
-    wrapper is not installed or not functional (ADR-0004 §6). The
+    wrapper is not installed or not functional. The
     wrapper is hal0's integration seam against upstream
     NousResearch/hermes-agent; install path refuses to wire an env file
     the wrapper can't source rather than half-wiring something that
@@ -455,7 +455,7 @@ class AgentManager:
             "agent": {
                 "name": name,
                 "installed_at": installed_at,
-                # Track-latest by design (ADR-0004 §3). No version pin.
+                # Track-latest by design. No version pin.
                 "version_pin": False,
             },
             "data_dir": str(self._data_dir(name)),

--- a/src/hal0/agents/mcp_client.py
+++ b/src/hal0/agents/mcp_client.py
@@ -1,11 +1,11 @@
-"""ADR-0013 MCP client surface for bundled agents.
+"""MCP client surface for bundled agents.
 
 Reads ``/etc/hal0/agents/<name>.toml``, loads tokens from
 systemd-credential / env file, and exposes the three-tier tool
 classification (allow / gated / blocked) to the agent driver.
 
 This module is **transport-agnostic**: it doesn't speak MCP over the
-wire itself. ADR-0013 §6 says Hermes's MCP client does the wire work;
+wire itself. By design, Hermes's MCP client does the wire work;
 the AgentMCPClient defined here is the *policy* layer that sits in
 front of it. The agent driver wires this in via:
 
@@ -40,16 +40,16 @@ from hal0.config.schema import AgentConfig, MCPServerConfig
 log = structlog.get_logger(__name__)
 
 
-# ADR-0013 §4 — three-tier classification verdict.
+# Three-tier classification verdict.
 ClassificationLiteral = Literal["allow", "gated", "blocked", "unknown_server", "unknown_tool"]
 
 
 class ToolNotPermittedError(Exception):
     """Raised by :meth:`AgentMCPClient.guard` for hard-blocked tools.
 
-    Maps to the wire-level ``tool.not_permitted`` error code per
-    ADR-0013 §3. Agent drivers should catch + translate into whatever
-    error envelope their LLM wire format expects.
+    Maps to the wire-level ``tool.not_permitted`` error code. Agent
+    drivers should catch + translate into whatever error envelope
+    their LLM wire format expects.
     """
 
     def __init__(self, server: str, tool: str, reason: str = "tool blocked by allow-list"):
@@ -62,7 +62,7 @@ class ToolNotPermittedError(Exception):
 class WorkspaceEscapeError(Exception):
     """Raised when filesystem-style MCP args try to escape the workspace.
 
-    ADR-0013 §5: tool arguments that use ``../`` or pass absolute paths
+    Tool arguments that use ``../`` or pass absolute paths
     outside the workspace get rejected client-side BEFORE they hit the
     server. The agent driver translates this to a tool error visible to
     the LLM so it can retry with a corrected path.
@@ -90,7 +90,7 @@ class AgentMCPClient:
     def __init__(self, config: AgentConfig, *, workspace: Path | None = None) -> None:
         """Build a policy client.
 
-        :param config: Validated AgentConfig (see ADR-0013 §2 schema).
+        :param config: Validated AgentConfig.
         :param workspace: Override the workspace root (tests use this
             with ``tmp_path``). When None, derived from
             ``config.agent.workspace`` if set, else from
@@ -137,7 +137,7 @@ class AgentMCPClient:
     def enabled_servers(self) -> dict[str, MCPServerConfig]:
         """Return the servers the agent is allowed to *connect* to.
 
-        ADR-0013 §3 server-axis default-deny: a server not in the
+        Server-axis default-deny: a server not in the
         config or with ``enabled = false`` is unreachable. Builtins
         (hal0-admin / hal0-memory) flow through unchanged — they're
         always-allowed for bundled agents.
@@ -151,19 +151,18 @@ class AgentMCPClient:
 
         Verdicts:
 
-        - ``unknown_server`` : server not in config (or disabled). Per
-          ADR-0013 §3 the agent should treat this as ``blocked``, but
+        - ``unknown_server`` : server not in config (or disabled). The
+          agent should treat this as ``blocked``, but
           we return a distinct verdict so callers can audit the cause
           (typo vs intentional removal).
         - ``unknown_tool``   : server is reachable, tool isn't on any
-          list. Default-deny per ADR-0013 §3 tool-axis.
+          list. Default-deny on the tool axis.
         - ``blocked``        : on ``tools.blocked``. Hard reject.
         - ``gated``          : on ``tools.gated``. Approval-queue path.
         - ``allow``          : on ``tools.allow``. Autonomous call.
 
         Blocked is checked FIRST so installer-pinned blocks beat user
-        edits that placed the same tool on ``allow`` (ADR-0013 §4
-        "installer-pinned blocks override user edits"). The pydantic
+        edits that placed the same tool on ``allow``. The pydantic
         ``ToolPolicy.lists_are_disjoint`` validator should prevent that
         overlap from ever reaching here, but defense-in-depth is cheap.
         """
@@ -200,7 +199,7 @@ class AgentMCPClient:
     def token_for(self, server: str) -> str | None:
         """Return the outbound bearer token for ``server`` or None.
 
-        ADR-0013 §6: tokens load at process startup from env vars (or
+        Tokens load at process startup from env vars (or
         systemd-credential, which systemd materialises as an env var
         via ``LoadCredential=``); never live in TOML. This method is
         the single read site so audit-log scaffolding can wrap a
@@ -209,7 +208,7 @@ class AgentMCPClient:
         Returns None when ``auth.kind != "bearer-from-env"`` (no token
         needed) OR when the env var is unset. The agent driver decides
         whether a missing token should fail bootstrap or skip the
-        server gracefully — ADR-0013 §6 picks "log + continue" for
+        server gracefully — by design, "log + continue" is used for
         non-builtin connection failures.
         """
         srv = self._config.mcp.servers.get(server)
@@ -236,7 +235,7 @@ class AgentMCPClient:
     def rewrite_path(self, raw: str) -> Path:
         """Resolve ``raw`` against the workspace; raise on escape attempts.
 
-        ADR-0013 §5: filesystem MCPs run with their server-side root
+        Filesystem MCPs run with their server-side root
         pinned to the workspace, but the agent can still pass paths
         that try to escape (``../``, absolute paths outside the
         workspace). We resolve here BEFORE the server sees the call so

--- a/src/hal0/agents/opencode/__init__.py
+++ b/src/hal0/agents/opencode/__init__.py
@@ -1,4 +1,4 @@
-"""opencode bundled agent (ADR-0004 §6). See :mod:`.driver` for details."""
+"""opencode bundled agent. See :mod:`.driver` for details."""
 
 from __future__ import annotations
 

--- a/src/hal0/agents/opencode/driver.py
+++ b/src/hal0/agents/opencode/driver.py
@@ -1,4 +1,4 @@
-"""opencode bundled-agent driver (ADR-0004 §6, sibling of pi-coder).
+"""opencode bundled-agent driver (sibling of pi-coder).
 
 [OpenCode](https://opencode.ai) is a terminal coding agent with native
 OpenAI-compatible providers + MCP support. Unlike pi-coder — whose model
@@ -6,7 +6,7 @@ autodiscovery and memory ride vendored TypeScript extensions — opencode's
 whole hal0 wiring lives in a single JSON config, so this driver only:
 
 1. Runs ``installer/agents/opencode.sh`` (track-latest npm install of the
-   ``opencode-ai`` CLI; NO version pin per ADR-0004 §3 — the nightly smoke
+   ``opencode-ai`` CLI; NO version pin — the nightly smoke
    catches upstream breakage).
 2. Writes ``~/.config/opencode/opencode.json`` wiring:
    - **Provider** — hal0 as an ``@ai-sdk/openai-compatible`` provider at

--- a/src/hal0/agents/pi_coder/__init__.py
+++ b/src/hal0/agents/pi_coder/__init__.py
@@ -1,4 +1,4 @@
-"""pi-coder bundled agent (ADR-0004 §6). See :mod:`.driver` for details."""
+"""pi-coder bundled agent. See :mod:`.driver` for details."""
 
 from __future__ import annotations
 

--- a/src/hal0/agents/pi_coder/driver.py
+++ b/src/hal0/agents/pi_coder/driver.py
@@ -1,4 +1,4 @@
-"""pi-coder driver (ADR-0004 §6).
+"""pi-coder driver.
 
 pi (upstream `earendil-works/pi`, formerly `badlogic/pi-mono`) is a
 third-party CLI/TUI coding agent. hal0's shim wires it to run against
@@ -52,8 +52,8 @@ from typing import Any
 from hal0.agents.manager import AgentDriver, AgentError, installer_script_path
 from hal0.config import paths as _paths
 
-# MCP endpoints. Both ride the existing hal0-api process per ADR-0004 §4
-# (admin) and ADR-0005 (memory). 127.0.0.1 is intentional: the bundled
+# MCP endpoints. Both ride the existing hal0-api process
+# (admin and memory). 127.0.0.1 is intentional: the bundled
 # agent runs on the same box as the API; LAN-exposed MCP is Phase 9
 # ("MCP client side of hal0"). Memory is NOT wired here — the
 # hal0-memory extension talks to the REST surface directly.
@@ -68,7 +68,7 @@ _PROVIDER_EXT_SRC = _PLUGINS_DIR / "hal0-provider"
 _MEMORY_EXT_SRC = _PLUGINS_DIR / "hal0-memory"
 _THEME_SRC = Path(__file__).resolve().parent / "themes" / "hal0.json"
 
-# Package added for subagent delegation (ADR-0004 §6). Best-effort:
+# Package added for subagent delegation. Best-effort:
 # needs npm + network, and is an enhancement layered on top of the core
 # provider/memory/theme wiring, not a hard requirement.
 _SUBAGENTS_PACKAGE = "npm:pi-subagents"
@@ -217,8 +217,8 @@ class PiCoderDriver(AgentDriver):
         return _paths.var_lib() / "agents" / self.name
 
     def _adapter_config_path(self) -> Path:
-        # pi-mcp-adapter is a proxy-tool MCP routing layer (ADR-0004 §6,
-        # "~200 tokens per dispatch instead of dumping the full tool
+        # pi-mcp-adapter is a proxy-tool MCP routing layer
+        # ("~200 tokens per dispatch instead of dumping the full tool
         # catalog"). Config lives in the per-agent data dir so a
         # ``hal0 agent uninstall`` cleans it up.
         return self._data_dir() / "pi-mcp-adapter.json"
@@ -235,7 +235,7 @@ class PiCoderDriver(AgentDriver):
         }
         if bearer_token:
             # Same Authorization header the dashboard would send
-            # (ADR-0001 Bearer token, reused — no new credential type).
+            # (Bearer token, reused — no new credential type).
             for srv in servers.values():
                 srv["headers"] = {"Authorization": f"Bearer {bearer_token}"}
 

--- a/src/hal0/agents/pi_coder/plugins/hal0-memory/index.ts
+++ b/src/hal0/agents/pi_coder/plugins/hal0-memory/index.ts
@@ -10,7 +10,7 @@
  *   - `X-hal0-Private: 0` → shared            (cross-agent; hermes reads too)
  *
  * Identity: `X-hal0-Agent: pi-coder` (override with HAL0_AGENT_ID env).
- * No Bearer auth — LAN trust per ADR-0012.
+ * No Bearer auth — LAN trust.
  *
  * Live-API quirks (verified against src/hal0/api/routes/memory.py on main):
  *   1. `/api/memory/add` is ASYNC. The response carries an `operation_id`,

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1529,7 +1529,7 @@ def create_app() -> FastAPI:
     # Agent memory stats (v0.3 PR-11). GET /api/agents/{id}/memory/stats
     # returns the counts the dashboard sidecar memory chip renders.
     # Fallback to ``available=false`` when the wrapper isn't initialised,
-    # so a hal0 install without Cognee still renders sensibly.
+    # so a hal0 install without a memory engine still renders sensibly.
     app.include_router(
         agents_memory_stats_routes.router,
         prefix="/api/agents",
@@ -1634,9 +1634,9 @@ def create_app() -> FastAPI:
     app.state.memory_provider = memory_provider
 
     # In-process memory dispatcher (Phase 8 closeout).
-    # When Cognee is up, instantiate one MemoryDispatcher and hand it to
+    # When memory is up, instantiate one MemoryDispatcher and hand it to
     # mount_mcp_servers so the admin MCP server's ``memory_*`` tools hit
-    # Cognee directly instead of looping back through HTTP to
+    # the memory engine directly instead of looping back through HTTP to
     # ``/mcp/memory``. The same client-id + private-mode resolvers the
     # memory MCP uses thread through the dispatcher so audit grounding
     # and namespace promotion stay identical across transports.

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1194,7 +1194,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             with contextlib.suppress(asyncio.CancelledError):
                 await gpu_arbiter_idle_task
 
-    # OmniRouter (PR-16, plan §7 + ADR-0008 §8). Client-side OpenAI
+    # OmniRouter (PR-16). Client-side OpenAI
     # tool-calling loop. Wired here so the /v1/chat/completions route
     # can pick it up via ``request.app.state.omni_router`` when a
     # request body carries ``omni: true``. The router holds a
@@ -1229,7 +1229,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         app.state.omni_router = None
 
-    # NPU trio router (ADR-0008 §5 + ADR-0009). The containerized npu
+    # NPU trio router. The containerized npu
     # slot's single ``flm serve`` process answers chat + STT + embed on
     # one static port; chat routes through the slot upstream like any
     # other slot, while v1.py's STT/embed routes post the two shadow
@@ -1300,7 +1300,7 @@ def create_app() -> FastAPI:
     app.include_router(v1.public_router, prefix="/v1", tags=["v1"])
     app.include_router(v1.router, prefix="/v1", tags=["v1"])
 
-    # /api/install drives the first-run wizard. Auth was removed in ADR-0012
+    # /api/install drives the first-run wizard. Auth was removed
     # so these endpoints are open; the installer surface is admin-only by
     # convention (network-level access control).
     app.include_router(
@@ -1358,7 +1358,7 @@ def create_app() -> FastAPI:
         prefix="/api/settings/proxmox",
         tags=["settings", "proxmox"],
     )
-    # ADR-0014 memory.graph gate + status. Mounted under /api/memory
+    # memory.graph gate + status. Mounted under /api/memory
     # so the dashboard Memory tab + `hal0 memory graph` CLI both read
     # + write through one surface. Constructed early enough that the
     # dashboard SPA fallback doesn't shadow these paths.
@@ -1419,16 +1419,16 @@ def create_app() -> FastAPI:
     )
 
     # Health + config/urls routers carry endpoints that are entirely
-    # public (e.g. /api/status, /api/config/urls). Auth was removed in
-    # ADR-0012; all endpoints on this server are open on the local network.
+    # public (e.g. /api/status, /api/config/urls). Auth was removed;
+    # all endpoints on this server are open on the local network.
     app.include_router(health.router, prefix="/api", tags=["health"])
     # Static backend vocabulary (GET /api/meta/enums) — the canonical
     # device/backend/capability enums from hal0.model_meta, read once by the
-    # dashboard at startup. Code-level constants only; no auth (ADR-0012).
+    # dashboard at startup. Code-level constants only; no auth.
     app.include_router(meta_routes.router, prefix="/api/meta", tags=["meta"])
     app.include_router(config_routes.router, prefix="/api/config", tags=["config"])
 
-    # Profile catalog — read-only, no auth (ADR-0012). Returns every profile
+    # Profile catalog — read-only, no auth. Returns every profile
     # from /etc/hal0/profiles.toml (falling back to the built-in seeds on a
     # fresh install). Profiles are P1 container-runtime templates (issue #653).
     app.include_router(profiles_routes.router, prefix="/api/profiles", tags=["profiles"])
@@ -1436,7 +1436,7 @@ def create_app() -> FastAPI:
     # Stack catalog — named, portable bundles of slots + profiles + model
     # assignments + capability selections. Read + declarative apply (dry-run
     # diff → atomic commit → lifecycle converge) + export/import/snapshot.
-    # Public on the local network (ADR-0012), same rationale as profiles.
+    # Public on the local network, same rationale as profiles.
     app.include_router(stacks_routes.router, prefix="/api/stacks", tags=["stacks"])
 
     # Benchmarks — roster board, run detail, history, evals, and the run-queue
@@ -1485,7 +1485,7 @@ def create_app() -> FastAPI:
     # URLs and could leak prompts via filename if exposed publicly.
     app.include_router(images.router, prefix="/api/images", tags=["images"])
 
-    # Bundled-agent lifecycle (ADR-0004 §2). Install / uninstall / list /
+    # Bundled-agent lifecycle. Install / uninstall / list /
     # status. Single-pick + atomic switch enforced inside AgentManager.
     app.include_router(
         agents_routes.router,
@@ -1548,7 +1548,7 @@ def create_app() -> FastAPI:
         tags=["agents", "chat-proxy"],
     )
 
-    # Approval inbox (ADR-0004 §5). The dashboard bell, the MCP admin
+    # Approval inbox. The dashboard bell, the MCP admin
     # server's gated-tool enqueue, and the ``hal0 agent approvals``
     # CLI all read from the same lifespan-scoped ApprovalQueue. GETs
     # require any token; POST approve/deny require admin (writer)
@@ -1563,14 +1563,14 @@ def create_app() -> FastAPI:
     # servers, connected clients (audit-derived), the installable
     # catalog, and an SSE tail of ``mcp.tool.*`` events. The lifecycle
     # mutations (install / uninstall / restart / config-write) stub at
-    # 501 — ADR-0013's ``mcp_client.py`` work owns those.
+    # 501 — future ``mcp_client.py`` work owns those.
     app.include_router(
         mcp_routes.router,
         prefix="/api/mcp",
         tags=["mcp"],
     )
 
-    # OpenRouter OAuth callback scaffold (ADR-0020, Phase 0).  The route
+    # OpenRouter OAuth callback scaffold (Phase 0).  The route
     # is gated behind HAL0_OPENROUTER_OAUTH_ENABLED so the 501 placeholder
     # does not appear in the API surface while the linked-account PKCE flow
     # is unimplemented (#775).  Set the env var to "1" or "true" to mount
@@ -1595,7 +1595,7 @@ def create_app() -> FastAPI:
         tags=["plugins"],
     )
 
-    # ── MCP servers (ADR-0004 §4 + ADR-0005 §2) ─────────────────────
+    # ── MCP servers ──────────────────────────────────────────────
     # Mounted BEFORE _mount_dashboard so the dashboard's SPA fallback
     # doesn't shadow /mcp/* paths. ApprovalQueue + the memory provider are
     # constructed eagerly here (no async setup needed for either) so
@@ -1633,7 +1633,7 @@ def create_app() -> FastAPI:
             log.warning("hal0.memory.init_failed", error=str(exc))
     app.state.memory_provider = memory_provider
 
-    # In-process memory dispatcher (Phase 8 closeout, ADR-0004 §7).
+    # In-process memory dispatcher (Phase 8 closeout).
     # When Cognee is up, instantiate one MemoryDispatcher and hand it to
     # mount_mcp_servers so the admin MCP server's ``memory_*`` tools hit
     # Cognee directly instead of looping back through HTTP to

--- a/src/hal0/api/agents/_auth.py
+++ b/src/hal0/api/agents/_auth.py
@@ -1,6 +1,6 @@
 """Origin allowlist + HMAC session-cookie helpers for the agent chat proxy.
 
-ADR-0012 removed Bearer auth and now ``X-hal0-Agent`` is the only
+Bearer auth was removed and now ``X-hal0-Agent`` is the only
 identity claim on hal0-api. DA-sec-ops review (MUST-FIX #2) raised that
 exposing a long-running JSON-RPC bridge to the hermes runtime over an
 unauthenticated ``0.0.0.0:8080`` is LAN-RCE: any host on the LAN sets

--- a/src/hal0/api/agents/budget.py
+++ b/src/hal0/api/agents/budget.py
@@ -43,7 +43,7 @@ router = APIRouter()
 #
 # Mirrors :data:`hal0.api.agents.personas._AGENT_PERSONAS_ROOTS` but
 # resolves the AGENT-LEVEL state directory (the personas/ subdir lives
-# beneath it). Per ADR-0004 §2 + the personas module's seed-default
+# beneath it). Per the personas module's seed-default
 # convention, the canonical layout is::
 #
 #   /var/lib/hal0/agents/{agent_id}/personas/{persona_id}.toml

--- a/src/hal0/api/agents/memory_stats.py
+++ b/src/hal0/api/agents/memory_stats.py
@@ -23,7 +23,7 @@ REST). Direct wrapper access keeps the stats endpoint cheap.
 
 Namespace resolution
 --------------------
-Per ADR-0005 §3, a bundled agent's writes land under
+By design, a bundled agent's writes land under
 ``private:<agent_id>`` and reads can union ``shared`` + the agent's
 own private namespace. Stats are scoped to the **per-agent private
 namespace** so the sidebar reflects what THIS agent has done — the
@@ -86,8 +86,8 @@ def _namespace_for(agent_id: str) -> str:
     Matches the resolver pattern :mod:`hal0.api.mcp_mount` plumbs onto
     the memory MCP — single source of truth would couple this module
     to the resolver's internal API. Keeping the format literal here is
-    cheap because the convention (``private:<agent_id>``) is documented
-    in ADR-0005 §3 and won't change.
+    cheap because the convention (``private:<agent_id>``) is fixed
+    by design and won't change.
     """
     return f"private:{agent_id}"
 

--- a/src/hal0/api/agents/memory_stats.py
+++ b/src/hal0/api/agents/memory_stats.py
@@ -203,7 +203,7 @@ async def get_agent_memory_stats(agent_id: str, request: Request) -> dict[str, A
         if isinstance(first, dict):
             ts = first.get("timestamp")
             if isinstance(ts, (int, float)):
-                # Cognee's timestamps are seconds-since-epoch; convert
+                # the engine's timestamps are seconds-since-epoch; convert
                 # to ISO so the dashboard renders a stable string.
                 from datetime import UTC, datetime
 

--- a/src/hal0/api/agents/restart.py
+++ b/src/hal0/api/agents/restart.py
@@ -17,7 +17,7 @@ subprocess call rather than getting tangled up with the lifecycle routes.
 
 Resolution
 ----------
-v0.3 only resolves ``"hermes"`` (single-pick per ADR-0004). The agent
+v0.3 only resolves ``"hermes"`` (single-pick). The agent
 registry mirrors :mod:`hal0.api.agents.personas` — adding pi-coder in
 v0.4 lights up restart automatically without touching this file.
 
@@ -84,8 +84,8 @@ def _unit_name(agent_id: str) -> str:
 def _resolve_actor(request: Request) -> str:
     """Identify the caller for the audit log.
 
-    Post-ADR-0012 there is no Bearer token store. We fall back to the
-    ``X-hal0-Agent`` header (per ADR-0012 / memory ``hal0_v0.3_auth_removed``),
+    There is no Bearer token store (auth was removed in v0.3). We fall back
+    to the ``X-hal0-Agent`` header (see memory ``hal0_v0.3_auth_removed``),
     defaulting to ``"hal0-dashboard"`` when neither is present. Best-effort
     forensic grounding — the audit row is for "what happened", not "who
     can do this" (the LAN-trust posture handles authorization).

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -37,12 +37,12 @@ from starlette.types import ASGIApp
 
 log = structlog.get_logger("hal0.api.mcp_mount")
 
-# Header carrying the caller's agent identity (post-ADR-0012 — Bearer auth
-# was removed; identity flows on this header, same as the REST memory
+# Header carrying the caller's agent identity (Bearer auth was removed;
+# identity flows on this header, same as the REST memory
 # surface in :mod:`hal0.api.routes.memory`).
 _AGENT_HEADER = "x-hal0-agent"
 
-# ADR-0005 §5 identity grammar — alnum + ``-`` + ``_``, ≤64 chars. The
+# Identity grammar — alnum + ``-`` + ``_``, ≤64 chars. The
 # value feeds the ``private:<agent>`` dataset name + the audit source, so
 # it must be path-traversal-free and bounded. Mirrors
 # ``hal0.api.routes.memory._AGENT_ID_PATTERN`` so MCP + REST resolve the
@@ -77,7 +77,7 @@ def _mcp_transport_security():
     ``421 Invalid Host header`` — exactly what happens the moment another
     homelab node, or the Traefik vhost, tries to reach ``/mcp/*``.
 
-    hal0 removed network auth entirely (ADR-0012) and binds ``0.0.0.0`` on
+    hal0 removed network auth entirely and binds ``0.0.0.0`` on
     the trusted LAN, so the mount has to be reachable by its real host
     name. We keep the secure localhost default but let operators widen it,
     mirroring the ``HAL0_ALLOWED_ORIGINS`` knob in ``api/agents/_auth``:
@@ -195,7 +195,7 @@ def private_resolver() -> bool:
     """Return whether the calling client toggled ``--private`` mode.
 
     Read from the ``X-hal0-Private: 1`` request header off the live MCP
-    request context — namespace promotion per ADR-0005 §3 is opt-in per
+    request context — namespace promotion is opt-in per
     client.
     """
     request = _current_mcp_request()

--- a/src/hal0/api/mcp_mount.py
+++ b/src/hal0/api/mcp_mount.py
@@ -215,7 +215,7 @@ def mount_mcp_servers(
     """Build + mount the admin and (optionally) memory MCP sub-apps.
 
     Called once from :func:`create_app`. ``memory_provider`` may be None
-    when Cognee isn't initialized (e.g. tests that don't exercise
+    when the memory engine isn't initialized (e.g. tests that don't exercise
     /mcp/memory); the mount silently skips the memory server in that
     case.
 

--- a/src/hal0/api/openrouter/__init__.py
+++ b/src/hal0/api/openrouter/__init__.py
@@ -1,13 +1,12 @@
-"""OpenRouter integration surface (Phase 0 scaffold, ADR-0020).
+"""OpenRouter integration surface (Phase 0 scaffold).
 
 This package owns hal0-api's side of the OpenRouter BYOK + delegate
 flow. v0.3.x ships only the route scaffold + loopback guard so V1
 (the OpenRouter-as-Hermes-upstream PR) inherits a baseline that
-respects ADR-0012's auth-removed posture from day 1.
+respects the auth-removed posture from day 1.
 
-See ``docs/internal/adr/0020-localhost-callback-only-oauth-pkce.md``
-for the architectural decision; the actual PKCE exchange flow lands in
-V1 (Phase 1) on top of this scaffold.
+The actual PKCE exchange flow lands in V1 (Phase 1) on top of this
+scaffold.
 """
 
 from hal0.api.openrouter.auth import router

--- a/src/hal0/api/openrouter/_loopback.py
+++ b/src/hal0/api/openrouter/_loopback.py
@@ -1,6 +1,6 @@
 """Loopback-only guard helpers for the OpenRouter OAuth callback.
 
-Quoting ADR-0020:
+The callback is loopback-only by design:
 
 > The OAuth PKCE callback URL is constrained to
 > ``http://127.0.0.1:<port>/api/openrouter/auth/callback``.
@@ -19,7 +19,7 @@ PKCE exchange flow) inherits a well-behaved foundation.
 The loopback guard is implemented per-route, not as a global
 middleware, because every other hal0-api surface intentionally accepts
 LAN traffic. A global middleware would force allowlisting the rest of
-the API, inverting the decision recorded in ADR-0012.
+the API, undoing that open-LAN posture.
 """
 
 from __future__ import annotations

--- a/src/hal0/api/openrouter/auth.py
+++ b/src/hal0/api/openrouter/auth.py
@@ -1,12 +1,10 @@
 """OpenRouter OAuth PKCE callback route (Phase 0 scaffold).
 
 This module registers ``GET /api/openrouter/auth/callback`` so the URL
-exists, is reachable, and enforces the loopback guard from ADR-0020
-before V1 lands the actual PKCE exchange flow. The handler returns
-HTTP 501 with a pointer to ADR-0020 — V1's PR opens against this
-branch and fills the body in.
-
-See ``docs/internal/adr/0020-localhost-callback-only-oauth-pkce.md``.
+exists, is reachable, and enforces the loopback guard before V1 lands
+the actual PKCE exchange flow. The handler returns HTTP 501 with a
+pointer in the response body — V1's PR opens against this branch and
+fills the body in.
 """
 
 from __future__ import annotations
@@ -33,7 +31,7 @@ async def callback(
 
     Phase 0 (this PR) registers the route + loopback guard only. The
     PKCE code-for-token exchange + refresh-token persistence ship in
-    V1 (Phase 1) — see ADR-0020 §"Implementation pointer".
+    V1 (Phase 1).
 
     The 501 response is deliberate: it documents the contract for V1
     and lets the dashboard's "Linked Accounts" panel detect that the

--- a/src/hal0/api/plugins/__init__.py
+++ b/src/hal0/api/plugins/__init__.py
@@ -11,7 +11,7 @@ Both endpoints carry SRI verification (when the manifest declares
 ``integrity``), a path-traversal validator ported verbatim from
 GHSA-5qr3-c538-wm9j, inbound ``Authorization``/``Cookie`` stripping
 (no hal0 session bleeds to upstream), and outbound ``X-hal0-Agent``
-injection per ADR-0012.
+injection by design.
 
 The manifest endpoint additionally sets
 ``Content-Security-Policy: script-src 'self' 'strict-dynamic'`` per

--- a/src/hal0/api/plugins/manifest_proxy.py
+++ b/src/hal0/api/plugins/manifest_proxy.py
@@ -26,7 +26,7 @@ Header policy (DA-sec-ops MUST-FIX #2):
   before forwarding. These are hal0 session credentials; upstream
   Hermes does not need them and must not see them.
 * Outbound: inject ``X-hal0-Agent: hermes`` (resolved from the
-  ``HAL0_AGENT_ID`` env or a per-request override) per ADR-0012.
+  ``HAL0_AGENT_ID`` env or a per-request override) by design.
 
 Networking: upstream is loopback-only (``HERMES_DASHBOARD_BASE_URL``,
 default ``http://127.0.0.1:9119`` to match
@@ -101,7 +101,7 @@ _RESPONSE_HOP_BY_HOP = frozenset(
 
 # Browser session credentials. Stripped from every inbound request
 # before forwarding so upstream Hermes never sees hal0 cookies / bearer
-# tokens (ADR-0012 routes identity through ``X-hal0-Agent`` only; the
+# tokens (identity routes through ``X-hal0-Agent`` only; the
 # DA-sec-ops review locked this in for plugin proxy traffic too).
 _INBOUND_STRIP = frozenset(
     {

--- a/src/hal0/api/routes/agents.py
+++ b/src/hal0/api/routes/agents.py
@@ -1,6 +1,6 @@
 """Bundled-agent lifecycle endpoints (mounted under /api/agents).
 
-Phase 8, ADR-0004. Thin wrapper around :class:`hal0.agents.AgentManager`
+Phase 8. Thin wrapper around :class:`hal0.agents.AgentManager`
 that mirrors the slot-route shape (``router`` + per-mutation
 ``_writer`` dep). The actual single-pick / atomic-swap / driver dispatch
 logic lives in the manager so the CLI and the API share one
@@ -9,7 +9,7 @@ implementation.
 Approval-queue endpoints (the ``/api/agent/approvals`` surface the CLI
 ``hal0 agent approvals`` subcommand consumes) live in
 :mod:`hal0.api.routes.approvals` and are mounted in-process from
-:mod:`hal0.api` next to this router. Shape per ADR-0004 §5:
+:mod:`hal0.api` next to this router. Shape:
 
     GET    /api/agent/approvals
     POST   /api/agent/approvals/{id}/approve
@@ -159,7 +159,7 @@ async def agent_activity(
     journalctl. ``client_id`` filter is substring-matched against the
     agent name so e.g. ``pi-coder`` matches client_ids like
     ``pi-coder@host``. The MCP server attributes ``client_id`` from the
-    Bearer token (ADR-0004 §7) so the agent identity is forensically
+    Bearer token so the agent identity is forensically
     grounded.
     """
     mgr = _manager()

--- a/src/hal0/api/routes/approvals.py
+++ b/src/hal0/api/routes/approvals.py
@@ -1,8 +1,8 @@
 """Approval inbox REST routes (mounted under ``/api/agent/approvals``).
 
-The hal0 admin MCP server (ADR-0004 §4) puts every gated tool call into
+The hal0 admin MCP server puts every gated tool call into
 an in-process :class:`hal0.mcp.approval_queue.ApprovalQueue`. The
-dashboard's bell + inbox modal (ADR-0004 §5) reads that queue through
+dashboard's bell + inbox modal reads that queue through
 these routes, and the owner approves / denies inline.
 
 Endpoints
@@ -23,7 +23,7 @@ queue mutates.
 Auth
 ----
 
-Auth was removed in ADR-0012 — all routes here are open on the local
+Auth was removed — all routes here are open on the local
 network. This module declares no auth dependency itself.
 """
 
@@ -44,7 +44,7 @@ from hal0.mcp.approval_queue import ApprovalQueue
 
 router = APIRouter()
 
-# Auth was removed in ADR-0012. POST /approve and POST /deny are
+# Auth was removed. POST /approve and POST /deny are
 # unrestricted on the local network; access control is LAN-only.
 
 

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -270,7 +270,7 @@ async def list_features(request: Request) -> dict[str, Any]:
         ``cognee`` | ``mem0`` | …) — a string, not a bool.
       - ``npu``: an NPU was detected by the (cached) hardware probe.
       - ``mcp_supervisor``: the MCP process supervisor (start/stop/
-        restart) — not implemented yet (pending ADR-0015), always false.
+        restart) — not implemented yet, always false.
     """
     features: dict[str, Any] = {
         "comfyui_switchover": True,

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -53,7 +53,7 @@ from hal0.install.orchestrate import (
 from hal0.registry.curated import CURATED_MODELS
 from hal0.slot_config import write_slot_toml
 
-# Auth was removed in ADR-0012. All endpoints are open on the local
+# Auth was removed by design. All endpoints are open on the local
 # network; the first-run wizard runs without any credential.
 
 router = APIRouter()
@@ -397,7 +397,7 @@ async def install_apply(request: Request, background: BackgroundTasks) -> dict[s
     :func:`_bundle_to_selections`, then delegates to the same
     :func:`_apply_selections_core` that ``/apply-selections`` uses — one
     shared provisioning path (WS-I, issue #1101). Best-effort, non-aborting
-    per row (ADR-0010). The UI reattaches per model via the existing
+    per row. The UI reattaches per model via the existing
     ``/api/models/{id}/pull/stream`` SSE.
     """
     try:

--- a/src/hal0/api/routes/journal.py
+++ b/src/hal0/api/routes/journal.py
@@ -16,7 +16,7 @@ The journal route is purposely separate from ``/api/events``: that
 exposes the raw event shape for callers wanting native fidelity, while
 ``/api/journal`` serves the panel envelope.
 
-No auth gate — same rationale as ``/api/events`` (post-ADR-0012 hal0-api
+No auth gate — same rationale as ``/api/events`` (hal0-api
 is open on 0.0.0.0:8080; agent identity rides on ``X-hal0-Agent``, not
 Bearer tokens; the journal panel must surface during first-run before
 any agent identity exists).

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -58,8 +58,8 @@ class McpNotImplemented(Hal0Error):
     """``POST /{id}/{action}`` (start / stop / restart) still stubs here.
 
     Install / uninstall / config-patch landed in #305; start / stop /
-    restart need the still-pending process-supervisor layer (ADR-0015,
-    not yet written). The code is the explicit
+    restart need the still-pending process-supervisor layer, not yet
+    written. The code is the explicit
     ``mcp.supervisor_unavailable`` so the dashboard can key on it and
     render a "supervisor not implemented yet" affordance distinct from a
     generic 501.
@@ -73,7 +73,7 @@ class McpNotImplemented(Hal0Error):
 #
 # Mirrors the prototype's ``MCP_CATALOG`` in ``ui/src/dash/mcp-data.jsx``
 # so the v3 page renders the same set of installable servers it did
-# while wired to the mock. ADR-0013 will eventually replace this with a
+# while wired to the mock. This will eventually be replaced with a
 # real registry probe; for v0.3-alpha the static list is enough to let
 # operators browse + reason about what they could install.
 
@@ -630,7 +630,7 @@ def _client_role(client_id: str) -> str:
 async def list_catalog() -> dict[str, Any]:
     """Return the installable-MCPs catalog.
 
-    Static module-level constant for v0.3-alpha — ADR-0013's
+    Static module-level constant for v0.3-alpha — future
     ``mcp_client.py`` work will eventually swap in a live registry
     probe. The shape matches the prototype's ``MCP_CATALOG`` so the
     dashboard's InstallDrawer renders unchanged.

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -109,7 +109,7 @@ def _agent_id(request: Request) -> str:
         prefix through the header. The ``private`` toggle is the
         only path to the namespace.
       - Values must match ``^[a-zA-Z0-9_\\-]{1,64}$`` — agent ids
-        flow into the Cognee dataset name + the audit log's
+        flow into the memory dataset name + the audit log's
         ``source`` field. Path-traversal candidates (``../etc``),
         control chars, and over-long values are all rejected here.
     """
@@ -873,7 +873,7 @@ async def run_honcho_sync_now() -> dict[str, bool | str | None]:
 
 # ── REST shims for /api/memory/{add,search,list,delete} (#302) ─────────────
 #
-# Plain-HTTP veneer over CogneeWrapper for callers that don't speak the
+# Plain-HTTP veneer over the memory provider for callers that don't speak the
 # MCP protocol (Hermes bootstrap CLI, dashboard Agents > Peers tab,
 # in-process scripts). The MCP transport at /mcp/memory/mcp stays
 # available for proper MCP clients; these routes are a parallel path
@@ -907,7 +907,7 @@ async def memory_add(request: Request) -> dict[str, Any]:
     treated as an attempt to impersonate, matching the MCP rule. Use
     the ``X-hal0-Agent`` header to claim identity.
 
-    Returns ``{id, timestamp}`` from :meth:`CogneeWrapper.add`.
+    Returns ``{id, timestamp}`` from :meth:`MemoryProvider.add`.
     """
     body = await _read_json_body(request)
     text = body.get("text")
@@ -1110,7 +1110,7 @@ async def memory_delete(request: Request) -> dict[str, int]:
     sweep). Identity headers otherwise are not consulted: id-scoped
     delete bypasses the namespace surface entirely (the wrapper's audit
     log still stamps the call with the agent identity for forensics —
-    see :meth:`CogneeWrapper._audit`).
+    see the provider's audit hook).
     """
     body = await _read_json_body(request)
     ids = body.get("ids")

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -1,4 +1,4 @@
-"""Memory endpoints — ADR-0014 graph-extraction gate + status.
+"""Memory endpoints — graph-extraction gate + status.
 
 Mounted under ``/api/memory/*``. The dashboard's Memory tab + the
 ``hal0 memory graph {enable,disable,status}`` CLI both read + write
@@ -44,10 +44,11 @@ router = APIRouter()
 log = logging.getLogger(__name__)
 
 
-# ── ADR-0012 identity + ADR-0005 §3 namespace helpers ─────────────────────
+# ── identity + namespace helpers ────────────────────────────────────────
 #
-# Post-ADR-0012 hal0-api is open on 0.0.0.0:8080; agent identity flows on
-# the ``X-hal0-Agent`` header (NOT Bearer — auth surface was removed).
+# Auth was removed, so hal0-api is open on 0.0.0.0:8080; agent identity
+# flows on the ``X-hal0-Agent`` header (NOT Bearer — auth surface was
+# removed).
 # Private-mode opt-in flows on ``X-hal0-Private`` to match the MCP mount
 # (:mod:`hal0.api.mcp_mount`); the same toggle gates the same namespace
 # promotion rule across both surfaces (issue #317).
@@ -57,7 +58,7 @@ _AGENT_HEADER = "x-hal0-agent"
 _PRIVATE_HEADER = "x-hal0-private"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
-# ADR-0005 §5 security hardening: agent identity feeds the
+# Security hardening: agent identity feeds the
 # ``private:<agent>`` dataset name AND the audit log's ``source``
 # field. We allow alnum + ``-`` + ``_`` only, up to 64 chars — keeps
 # the resolved namespace path-traversal-free, sql-quotable, and
@@ -79,7 +80,7 @@ class MemoryNamespaceInvalid(Hal0Error):
 
 
 class MemoryAgentIdInvalid(Hal0Error):
-    """The ``X-hal0-Agent`` header value failed the ADR-0005 §5
+    """The ``X-hal0-Agent`` header value failed the
     identity-shape check.
 
     Distinct from :class:`MemoryNamespaceInvalid` so the dashboard
@@ -99,7 +100,7 @@ def _agent_id(request: Request) -> str:
     surface — both translate the absence of an identity header into the
     same sentinel so audit + dataset resolution stay consistent.
 
-    Validation (ADR-0005 §5 hardening, surfaced by PR #366 review):
+    Validation (hardening surfaced by PR #366 review):
 
       - Empty / whitespace → ``"anonymous"`` (back-compat with
         unauthenticated callers).
@@ -895,12 +896,12 @@ async def memory_add(request: Request) -> dict[str, Any]:
 
     Identity headers (issue #317):
 
-      - ``X-hal0-Agent``: post-ADR-0012 agent identity. Stamped onto
+      - ``X-hal0-Agent``: agent identity. Stamped onto
         the wrapper's ``source`` field — server-injected so callers
-        cannot lie (ADR-0005 §5). Absent header → ``"anonymous"``.
+        cannot lie. Absent header → ``"anonymous"``.
       - ``X-hal0-Private: 1``: opt into the private namespace.
         Promotes ``dataset`` to ``private:<agent>`` regardless of the
-        body value (ADR-0005 §3).
+        body value.
 
     The body's ``source`` field is REJECTED — clients supplying it is
     treated as an attempt to impersonate, matching the MCP rule. Use
@@ -916,7 +917,7 @@ async def memory_add(request: Request) -> dict[str, Any]:
             details={"path": "/api/memory/add"},
         )
     if "source" in body:
-        # ADR-0005 §5 — source is server-injected from the X-hal0-Agent
+        # Source is server-injected from the X-hal0-Agent
         # header so callers cannot impersonate another agent in the
         # audit log.
         raise Hal0Error(
@@ -962,7 +963,7 @@ async def memory_search(request: Request) -> dict[str, Any]:
 
     Identity headers behave like ``/add`` — ``X-hal0-Private: 1``
     expands a default-empty ``dataset`` to ``[shared, private:<agent>]``
-    per ADR-0005 §3 so a private-mode caller sees both their own scoped
+    so a private-mode caller sees both their own scoped
     items + the shared bucket without per-call opt-in.
 
     Returns ``{items: [MemoryRecord, ...]}`` — wrapped in an envelope so

--- a/src/hal0/api/routes/meta.py
+++ b/src/hal0/api/routes/meta.py
@@ -11,7 +11,7 @@ The UI reads this once at startup instead of hard-coding its own copies of
 the device/backend/capability enums, so a taxonomy change lands in exactly
 one place. The payload is pure code-level constants — it only changes with
 a hal0 release — so it is served with a version-keyed ``ETag`` and a
-``Cache-Control`` allowing revalidated caching. No auth (ADR-0012: the
+``Cache-Control`` allowing revalidated caching. No auth (the
 read-only /api surface is open), no app state touched.
 """
 

--- a/src/hal0/api/routes/providers.py
+++ b/src/hal0/api/routes/providers.py
@@ -555,7 +555,7 @@ async def write_provider_credential(
 
     The Phase 8 MCP admin server's ``provider_credential_write`` tool
     routes here; that path is gated on owner approval (see
-    ``hal0.mcp.admin.GATED_TOOLS``). Auth was removed in ADR-0012;
+    ``hal0.mcp.admin.GATED_TOOLS``). Auth was removed by design;
     direct REST writes are open on the local network.
 
     Process restart is the caller's responsibility — the registry

--- a/src/hal0/api/routes/secrets.py
+++ b/src/hal0/api/routes/secrets.py
@@ -21,7 +21,7 @@ Both POST and PUT are accepted for the set path: the v3 dashboard's
 PUT — accepting both keeps the route honest with the running UI and the
 spec at once.
 
-Security posture (ADR-0012 — auth removed, open on the trusted LAN):
+Security posture (auth removed, open on the trusted LAN):
 
   - Secret VALUES are NEVER returned by any endpoint, never logged, and
     never echoed in an error body.

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -13,7 +13,7 @@ stream is split by concern):
 - ``GET /api/slots/{name}/logs/stream`` — line-by-line journal tail
   for the slot's systemd unit.
 
-PR-11 (plan §11 + ADR-0008 §5): list responses are enriched with
+PR-11: list responses are enriched with
 config-derived fields (drawer seeds, declared backend) plus live
 container state (``container_status`` / ``container_health``), and a
 ``coresident_group`` ID grouping slots that back the same FLM process
@@ -44,7 +44,7 @@ from hal0.slot_view import (
 )
 from hal0.slots.manager import Slot, SlotManager
 
-# Auth was removed in ADR-0012. All routes are open on the local network.
+# Auth was removed by design. All routes are open on the local network.
 
 router = APIRouter()
 

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -40,15 +40,15 @@ from hal0.upstreams.filters import apply_filters
 log = structlog.get_logger("hal0-v1")
 
 # Inference router. Mounted by hal0.api.create_app() on /v1.
-# Auth was removed in ADR-0012; the server is open on the local network.
+# Auth was removed; the server is open on the local network.
 router = APIRouter()
 
 # Public probe router — auth-free. Mounted on the same /v1 prefix.
 # OpenAI clients (OpenWebUI, third-party SDKs) GET /v1/models before
 # they have anywhere to send an Authorization header; gating it would
-# break the "drop in an OpenAI-shaped base_url" UX. Per ADR-0001 Child
-# B, publicness is declared by NOT attaching an auth dep — not by
-# allowlisting the path in a frozenset.
+# break the "drop in an OpenAI-shaped base_url" UX. Publicness is
+# declared by NOT attaching an auth dep — not by allowlisting the path
+# in a frozenset.
 public_router = APIRouter()
 
 
@@ -699,8 +699,7 @@ async def list_models(
       represented exactly once, by its alias.
 
     PUBLIC — mounted on ``public_router`` so OpenAI SDKs that probe the
-    catalog before sending Authorization headers continue to work after
-    ADR-0001 Child B.
+    catalog before sending Authorization headers continue to work.
     """
     from hal0.api import hal0_chat_slot_model_ids, hal0_slot_alias_models
 
@@ -815,8 +814,7 @@ async def chat_completions(request: Request, dispatcher: DispatcherDep) -> Respo
     # PR-16: OmniRouter opt-in. When the body carries ``"omni": true``
     # AND we can resolve the request to a known chat slot whose model
     # advertises ``tool-calling``, route through the client-side
-    # tool-calling loop instead of doing a direct passthrough. Plan §7
-    # + ADR-0008 §8.
+    # tool-calling loop instead of doing a direct passthrough.
     #
     # The opt-in mechanism is a body field (vs query param) because:
     #   1. ``_dispatch_and_forward`` already parses the body, so we
@@ -878,7 +876,7 @@ async def _is_npu_trio_request(
 ) -> bool:
     """Detect whether this request should go through the FLM trio router.
 
-    PR-19 (plan §5.2 + ADR-0009). We route to the trio when:
+    PR-19. We route to the trio when:
 
       1. The request body's ``model`` matches an enabled slot whose
          ``device == "npu"`` AND ``type == slot_type``. We look at both

--- a/src/hal0/bundles/__init__.py
+++ b/src/hal0/bundles/__init__.py
@@ -1,8 +1,8 @@
 """hal0 bundles — first-run picker manifests + tier eligibility.
 
-ADR-0010 (bundle picker, no default model stack) and the v0.2 adoption
-plan §8 (First-run UX) define a small, fixed set of hardware-anchored
-tiers and one vendor-blessed kit. Each bundle is a ``collection.omni``
+The v0.2 adoption plan §8 (First-run UX) defines a small, fixed set of
+hardware-anchored tiers and one vendor-blessed kit — a bundle picker, no
+default model stack. Each bundle is a ``collection.omni``
 manifest (hal0's own bundle format) plus hal0-specific slot
 metadata. The picker lives on the first dashboard load; this package
 is the backend half.

--- a/src/hal0/bundles/schema.py
+++ b/src/hal0/bundles/schema.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-# Fixed values from plan §8 / ADR-0010. Bumping these requires a v0.3 PR.
+# Fixed values from plan §8. Bumping these requires a v0.3 PR.
 SCHEMA_VERSION: int = 1
 
 

--- a/src/hal0/bundles/tiers.py
+++ b/src/hal0/bundles/tiers.py
@@ -1,6 +1,6 @@
 """Bundle tier registry — locked list + loader.
 
-The five bundle names are fixed by ADR-0010 (no additional tiers in
+The five bundle names are fixed by design (no additional tiers in
 v0.2). Manifests ship under ``installer/manifests/omni/`` and are
 copied by ``install.sh`` to ``/var/lib/hal0/models/collections/omni/``
 at install time; the loader picks them up from the runtime location

--- a/src/hal0/capabilities/config.py
+++ b/src/hal0/capabilities/config.py
@@ -21,8 +21,7 @@ TOML so operators can hand-edit the file::
 v0.1.x wrote the same shape but used ``backend`` instead of ``device``
 and omitted ``schema_version`` (implicit v1). The auto-migration in
 :func:`migrate_capabilities_v1_to_v2` reads a legacy file, snaps the
-field rename + value mapping, and stamps ``schema_version = 2``. See
-ADR-0006 §7.
+field rename + value mapping, and stamps ``schema_version = 2``.
 
 The full file is rewritten atomically on every change via
 :func:`hal0.config.loader.write_toml_atomic` so an interrupted write
@@ -56,8 +55,8 @@ class CapabilitySelection(BaseModel):
     user picked, which provider runs on it, which model id they bound,
     and whether the child is currently active.
 
-    v0.2 rename: the ``backend`` field is now :attr:`device` (ADR-0006
-    §7). For one release the model accepts both: a TOML carrying only
+    v0.2 rename: the ``backend`` field is now :attr:`device`. For one
+    release the model accepts both: a TOML carrying only
     ``backend`` auto-promotes via :func:`map_backend_to_device` and
     round-trips with ``backend`` re-emitted on dump so a v0.1.x downgrade
     sees its old field. Removal in v0.3.
@@ -70,7 +69,7 @@ class CapabilitySelection(BaseModel):
         description=(
             "v0.2 hardware-preference id: 'gpu-rocm' | 'gpu-vulkan' | "
             "'npu' | 'cpu'. Empty == unset (matches the dashboard's "
-            "blank-picker UX). See ADR-0006 §7."
+            "blank-picker UX)."
         ),
     )
     backend: str = Field(
@@ -144,7 +143,7 @@ class CapabilityConfig(BaseModel):
         ge=1,
         description=(
             "Capabilities-file schema version. v1 used ``backend``; v2 "
-            "(ADR-0006 §7) uses ``device``. Auto-migrated on hal0-api "
+            "uses ``device``. Auto-migrated on hal0-api "
             "boot via ``migrate_capabilities_v1_to_v2``."
         ),
     )

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -198,7 +198,7 @@ class CapabilityOrchestrator:
 
         Idempotent: when the file already exists, this method first runs
         :func:`auto_migrate_capabilities_file` so a stale v1 file is
-        promoted to v2 (ADR-0006 §7) before any read. When the file is
+        promoted to v2 before any read. When the file is
         missing we walk ``/etc/hal0/slots/{embed,stt,tts,img}.toml`` and
         lift each slot's current device/provider/model + ``enabled`` flag
         into the matching child. Slots that don't exist on disk get an
@@ -297,7 +297,7 @@ class CapabilityOrchestrator:
                     if anchor_status is not None:
                         status_str = anchor_status
                 selections_out[slot][child] = {
-                    # ``device`` is the v0.2 canonical key (ADR-0006 §7).
+                    # ``device`` is the v0.2 canonical key.
                     "device": selection.device,
                     # ``backend`` is emitted as a one-release alias so the
                     # v0.1.x dashboard frontend keeps rendering until the

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -3,8 +3,7 @@
 Mirrors :mod:`hal0.cli.slot_commands` shape (Typer sub-app + thin HTTP
 client). The lifecycle subcommands hit the routes in
 :mod:`hal0.api.routes.agents`; the ``approvals`` sub-sub-app hits the
-MCP-backend's approval queue at ``/api/agent/approvals`` (shape per
-ADR-0004 §5 "Pending items").
+MCP-backend's approval queue at ``/api/agent/approvals``.
 """
 
 from __future__ import annotations
@@ -63,7 +62,7 @@ def agent_install(
         "--switch",
         help=(
             "If another agent is already installed, atomically uninstall it before "
-            "installing this one (single-pick enforced; ADR-0004 §2)."
+            "installing this one (single-pick enforced)."
         ),
     ),
     gateway: bool = typer.Option(
@@ -476,7 +475,7 @@ def agent_uninstall(
 
     # Memory cleanup BEFORE we tear down the agent surface so a failed
     # memory call doesn't leave half-state. Skipped on --keep-memory
-    # (per #246 + ADR-0011 §6 — re-install reuses the existing card).
+    # (per #246 — re-install reuses the existing card).
     if name == "hermes" and not keep_memory:
         outcome = _uninstall_hermes_memory()
         _warn_memory_outcome(outcome)
@@ -713,7 +712,7 @@ def agent_list(
     console.print(table)
 
 
-# ── Approvals (MCP-backend owns the route shape; CLI assumes ADR-0004 §5) ────
+# ── Approvals (MCP-backend owns the route shape) ────────────────────────────
 
 
 def _fmt_enqueued_at(value: Any) -> str:
@@ -846,7 +845,7 @@ def approvals_deny(
 
 @app.command("peers")
 def agent_peers() -> None:
-    """List discoverable agent identity cards (ADR-0011 §6).
+    """List discoverable agent identity cards.
 
     Thin wrapper over ``memory_search`` against the dedicated
     ``agents`` Cognee dataset. Sibling of ``hal0 agent list`` (which
@@ -1065,7 +1064,7 @@ def agent_upgrade(
     raise typer.Exit(rc)
 
 
-# Note: post-ADR-0012 there is no `rotate-token` subcommand. The hal0
+# Note: there is no `rotate-token` subcommand. The hal0
 # daemon has no auth; agent identity flows via the X-hal0-Agent header
 # the wrapper exports from $HAL0_AGENT_ID. See #246 sharpening's second
 # correction comment for the supersede.

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -463,7 +463,7 @@ def agent_uninstall(
         False,
         "--keep-memory",
         help=(
-            "Preserve the agent's private:<agent_id> Cognee namespace + "
+            "Preserve the agent's private:<agent_id> memory namespace + "
             "its identity card. Default: full teardown including memory."
         ),
     ),
@@ -848,7 +848,7 @@ def agent_peers() -> None:
     """List discoverable agent identity cards.
 
     Thin wrapper over ``memory_search`` against the dedicated
-    ``agents`` Cognee dataset. Sibling of ``hal0 agent list`` (which
+    ``agents`` memory dataset. Sibling of ``hal0 agent list`` (which
     shows installed bundled agents on this host); ``peers`` shows
     every card published into the federated registry.
     """

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -61,7 +61,7 @@ app = typer.Typer(
 # Mount sub-apps
 app.add_typer(slot_app, name="slot")
 app.add_typer(model_app, name="model")
-# Issue #258 — ``hal0 memory graph {status,enable,disable}`` ADR-0014 surface.
+# Issue #258 — ``hal0 memory graph {status,enable,disable}`` surface.
 # Mounted between ``model`` and ``config`` so it sits alongside the other
 # user-facing data subcommands rather than buried under operator surfaces.
 app.add_typer(memory_app, name="memory")

--- a/src/hal0/cli/mcp_commands.py
+++ b/src/hal0/cli/mcp_commands.py
@@ -1,8 +1,8 @@
 """hal0 mcp subcommands — thin HTTP client to /api/mcp/*.
 
 Issue #504: ``hal0 mcp {list,status,install,uninstall,restart,catalog list}``
-backing the existing API routes in :mod:`hal0.api.routes.mcp`.  ADR-0015 +
-the Hermes ``MCP-CLIENTS.md.j2`` template already promise this surface.
+backing the existing API routes in :mod:`hal0.api.routes.mcp`.  The Hermes
+``MCP-CLIENTS.md.j2`` template already promises this surface.
 
 Endpoints hit
 -------------
@@ -345,7 +345,7 @@ def catalog_refresh_cmd(
     """Refresh the installable-MCP catalog (re-fetches from upstream).
 
     Currently a stub — re-fetches the static catalog.  The backend will
-    grow a live registry probe per ADR-0013; when that lands this command
+    grow a live registry probe; when that lands this command
     will force a re-index instead of returning the same static payload.
     """
     url = _api_base()

--- a/src/hal0/cli/memory_commands.py
+++ b/src/hal0/cli/memory_commands.py
@@ -1,4 +1,4 @@
-"""hal0 memory subcommands — ADR-0014 graph-extraction gate.
+"""hal0 memory subcommands — graph-extraction gate.
 
 Mirrors the slot / model CLI shape: a thin HTTP client to the local
 hal0 API. The ``graph`` sub-sub-app maps 1:1 to the routes in
@@ -285,7 +285,7 @@ def graph_disable_cmd(
         False, "--json", help="Emit the raw JSON response instead of a panel."
     ),
 ) -> None:
-    """Turn graph extraction OFF; cancels any in-flight build (ADR §6)."""
+    """Turn graph extraction OFF; cancels any in-flight build."""
     url = _api_base()
     if _api_unreachable(url):
         raise typer.Exit(1)

--- a/src/hal0/cli/migrate_commands.py
+++ b/src/hal0/cli/migrate_commands.py
@@ -4,8 +4,7 @@ This module hosts disk-layout reshapes that v0.2 needs the operator to
 run once. Today there is exactly one such command: ``model-layout``,
 which reorganises the v0.1.x ad-hoc model store at ``/mnt/ai-models/``
 into the canonical ``<recipe>/<capability>/`` tree rooted at
-``/var/lib/hal0/models/`` (see the v0.2 adoption plan §6.1 + ADR-0008
-§7).
+``/var/lib/hal0/models/`` (see the v0.2 adoption plan §6.1).
 
 Design contract (from plan §11 PR-7):
 

--- a/src/hal0/cli/setup_install.py
+++ b/src/hal0/cli/setup_install.py
@@ -214,7 +214,7 @@ async def _apply_via_api(sel) -> None:
     """API-up path: POST the selections to the live service.
 
     ``apply-selections`` is idempotent server-side: re-applying over
-    already-created slots is a per-slot no-op (ADR-0010), and the route is
+    already-created slots is a per-slot no-op, and the route is
     documented to be safely re-runnable at any time. A ``409 Conflict`` from
     this endpoint therefore does NOT mean setup failed — it means the live
     service reports the install as already applied, or that another apply is

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -54,7 +54,7 @@ class SlotType(StrEnum):
 
     Maps to the slot-type vocab from PLAN.md §1 v0.2 slot model:
     ``llm | embedding | reranking | transcription | tts | image``.
-    The dispatcher routes by ``type`` (per ADR-0008 §6); without this
+    The dispatcher routes by ``type``; without this
     flag the CLI couldn't create embedding/rerank/transcription/tts
     slots at all.
     """
@@ -373,7 +373,7 @@ def slot_create(
         "-t",
         help=(
             "Slot type: llm | embedding | reranking | transcription | tts | image. "
-            "Determines how the dispatcher routes requests (ADR-0008 §6)."
+            "Determines how the dispatcher routes requests."
         ),
         case_sensitive=False,
     ),

--- a/src/hal0/comfyui/provision.py
+++ b/src/hal0/comfyui/provision.py
@@ -87,7 +87,7 @@ def _activate_img_slot() -> None:
     Delegates to :func:`hal0.install.extensions.install_extension` so activation
     goes through the SAME wiring the extension walk uses. Best-effort: a failure
     is logged, never raised — a landed model with an un-activatable slot is still
-    a better state than crash-looping the caller (ADR-0010)."""
+    a better state than crash-looping the caller."""
     try:
         from hal0.install.extensions import install_extension
 

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -565,11 +565,11 @@ def resolve_profile(profile_name: str) -> ProfileConfig:
     return catalog.profile[profile_name]
 
 
-# ── agents/<name>.toml (ADR-0013) ─────────────────────────────────────────────
+# ── agents/<name>.toml ─────────────────────────────────────────────────────────
 
 
 def load_agent_config(agent_name: str, path: Path | None = None) -> AgentConfig:
-    """Load and validate ``/etc/hal0/agents/<agent_name>.toml`` (ADR-0013).
+    """Load and validate ``/etc/hal0/agents/<agent_name>.toml``.
 
     Raises:
         ConfigNotFound: file missing.
@@ -587,7 +587,7 @@ def load_agent_config(agent_name: str, path: Path | None = None) -> AgentConfig:
 
 
 def save_agent_config(cfg: AgentConfig, path: Path | None = None) -> None:
-    """Atomically write an agent config TOML (ADR-0013).
+    """Atomically write an agent config TOML.
 
     ``exclude_none=True`` keeps tomli_w from choking on optional blocks
     (``auth.env``, ``server.url`` on builtins).

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -98,7 +98,7 @@ def registry_dir() -> Path:
 def agents_config_dir() -> Path:
     """Return the per-agent allow-list config directory.
 
-    ADR-0013 §1: each bundled or user-added agent gets one TOML at
+    Each bundled or user-added agent gets one TOML at
     ``/etc/hal0/agents/<name>.toml`` carrying its workspace path,
     enabled MCP servers, per-server auth, and the three-tier tool
     classification (allow / gated / blocked).
@@ -109,8 +109,8 @@ def agents_config_dir() -> Path:
 def agent_workspace_dir(agent_name: str) -> Path:
     """Return the filesystem sandbox root for a bundled agent.
 
-    ADR-0013 §5: the agent driver chroots/bind-mounts the agent process
-    to this path; writes outside require ADR-0004 approval. Each agent
+    The agent driver chroots/bind-mounts the agent process
+    to this path; writes outside require approval. Each agent
     gets its own subtree so a malicious / buggy agent can't poke at
     another's workspace.
     """
@@ -271,7 +271,7 @@ def bundle_chosen_marker() -> Path:
 
     Dropped by ``POST /api/bundles/{name}`` (or
     ``GET /api/bundles/skip``) once the operator has engaged the first-
-    run bundle picker (ADR-0010). The dashboard reads this to decide
+    run bundle picker. The dashboard reads this to decide
     whether to render the picker or the regular dashboard on load.
 
     Location: ``$HAL0_HOME/var-lib/hal0/.bundle-chosen`` (or

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2608,9 +2608,12 @@ class MemoryConfig(BaseModel):
     engine: str = Field(
         default="hindsight",
         description=(
-            "Active memory engine. One of 'cognee' | 'hindsight' | 'mem0' | "
-            "'pgvector'. Default 'hindsight' (P2 cutover). Set to 'cognee' to "
-            "revert to the untouched Cognee store for one release."
+            "Active memory engine. 'hindsight' (default) is the platform "
+            "engine; 'mem0' and 'pgvector' are alternates. 'cognee' is "
+            "DEPRECATED — the legacy Cognee store has been dark since v0.4 and "
+            "its wrapper was removed; the value is still accepted for "
+            "back-compat but resolves to 'hindsight' at runtime. Use "
+            "'hindsight'."
         ),
     )
     agent_providers: dict[str, str] = Field(

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2315,8 +2315,7 @@ class ToolPolicy(BaseModel):
     gated: list[str] = Field(
         default_factory=list,
         description=(
-            "Tools the agent may request; each call enqueues an "
-            "approval. Empty = no gated tools."
+            "Tools the agent may request; each call enqueues an approval. Empty = no gated tools."
         ),
     )
     blocked: list[str] = Field(

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -60,8 +60,7 @@ log = logging.getLogger(__name__)
 # DEPRECATED v0.2: ``SlotConfig.backend`` is being retired in favour of the
 # hardware-preference field ``SlotConfig.device``. The whitelist is kept for
 # one release so legacy slot TOMLs round-trip cleanly; a warning is logged
-# whenever ``backend`` is read without an accompanying ``device``. See
-# ADR-0006 §7 (v0.2 migration plan, decision 15).
+# whenever ``backend`` is read without an accompanying ``device``.
 _VALID_BACKENDS = frozenset(_LEGACY_BACKENDS)
 
 # v0.2 hardware-preference enum. ``device`` replaces the overloaded
@@ -104,7 +103,7 @@ CURRENT_SCHEMA_VERSION = 1
 
 # Capabilities-file schema version. Independent of ``hal0.toml``'s
 # ``meta.schema_version`` — capabilities.toml carries its own counter so
-# the v0.2 backend→device migration (ADR-0006 §7) can be detected and
+# the v0.2 backend→device migration can be detected and
 # applied without coupling the two config files.
 #
 # - schema_version = 1 (or absent): legacy. CapabilitySelection uses
@@ -313,7 +312,7 @@ class SlotConfig(BaseModel):
             "DEPRECATED (v0.2; removed v0.3): legacy overloaded backend enum. "
             "Use ``device`` instead. Reading a SlotConfig that has ``backend`` "
             "set without ``device`` logs a deprecation warning and auto-fills "
-            "``device`` via ``map_backend_to_device``. See ADR-0006 §7."
+            "``device`` via ``map_backend_to_device``."
         ),
     )
     device: str = Field(
@@ -321,7 +320,7 @@ class SlotConfig(BaseModel):
         description=(
             "v0.2 hardware-preference enum: 'gpu-rocm' | 'gpu-vulkan' | "
             "'gpu-cuda' | 'cpu' | 'npu'. Replaces the legacy ``backend`` "
-            "field which mixed providers and backends. See ADR-0006 §7."
+            "field which mixed providers and backends."
         ),
     )
     gpu_index: int | None = Field(
@@ -631,7 +630,7 @@ class SlotConfig(BaseModel):
     def _promote_backend_to_device(cls, data: Any) -> Any:
         """Soft-deprecation hook: derive ``device`` from a legacy ``backend``.
 
-        v0.2 (ADR-0006 §7) renames the hardware-preference field
+        v0.2 renames the hardware-preference field
         ``backend`` → ``device``. For one release we read both: if a TOML
         file or in-memory dict carries ``backend`` but no ``device`` we
         synthesise ``device`` via :func:`map_backend_to_device` so the
@@ -2232,14 +2231,14 @@ class MemoryGraphConfig(BaseModel):
         return v
 
 
-# ── AgentConfig (ADR-0013) ─────────────────────────────────────────────────────
+# ── AgentConfig ────────────────────────────────────────────────────────────────
 
-# ADR-0013 §1: schema version pin so a future incompatible change
+# Schema version pin so a future incompatible change
 # (e.g. nesting tool policies under a `[mcp.servers.<name>.policy]`
 # block) can detect + migrate old agent TOMLs without silent breakage.
 AGENT_CONFIG_SCHEMA_VERSION = 1
 
-# ADR-0013 §6: outbound auth styles. Today only ``bearer-from-env``
+# Outbound auth styles. Today only ``bearer-from-env``
 # (token loaded at agent-process startup from an env file or
 # systemd-credential) is implemented. Listed as a frozenset so future
 # additions (mtls, oauth-device-flow, …) extend a single source.
@@ -2251,7 +2250,7 @@ AgentAuthKindLiteral = Literal["none", "bearer-from-env"]
 class AgentAuthConfig(BaseModel):
     """``[mcp.servers.<name>.auth]`` block.
 
-    ADR-0013 §6: indirection via env var keeps tokens out of TOML so
+    Indirection via env var keeps tokens out of TOML so
     the config file remains commit-safe and the dashboard can render
     it. The actual token is loaded by the agent driver at process
     startup (from systemd-credential or a 0600 env file) and never
@@ -2293,10 +2292,8 @@ class AgentAuthConfig(BaseModel):
 class ToolPolicy(BaseModel):
     """``[mcp.servers.<name>.tools]`` block — three-tier classification.
 
-    ADR-0013 §4:
-
     - ``allow``  : autonomous call (no approval queue).
-    - ``gated``  : enqueue via ADR-0004 approval queue, await user pick.
+    - ``gated``  : enqueue via approval queue, await user pick.
     - ``blocked``: hard-reject at the client; never reaches the server.
 
     The lists MUST be disjoint — overlap is operator error and surfaces
@@ -2319,7 +2316,7 @@ class ToolPolicy(BaseModel):
         default_factory=list,
         description=(
             "Tools the agent may request; each call enqueues an "
-            "approval (ADR-0004 §5). Empty = no gated tools."
+            "approval. Empty = no gated tools."
         ),
     )
     blocked: list[str] = Field(
@@ -2364,7 +2361,7 @@ class ToolPolicy(BaseModel):
 class MCPServerConfig(BaseModel):
     """One ``[mcp.servers.<name>]`` entry in an agent TOML.
 
-    ADR-0013 §3: server-axis default-deny — only servers listed here
+    Server-axis default-deny — only servers listed here
     are reachable. ``builtin = true`` marks hal0-admin / hal0-memory
     which are always reachable for bundled agents and can't be removed
     without an explicit override.
@@ -2391,7 +2388,7 @@ class MCPServerConfig(BaseModel):
     builtin: bool = Field(
         default=False,
         description=(
-            "ADR-0013 §6: marks hal0-admin / hal0-memory. Bundled-agent "
+            "Marks hal0-admin / hal0-memory. Bundled-agent "
             "installers set this; user-added servers leave it False."
         ),
     )
@@ -2419,7 +2416,7 @@ class AgentMetadataConfig(BaseModel):
     workspace: str = Field(
         default="",
         description=(
-            "Filesystem sandbox root (ADR-0013 §5). Empty falls back "
+            "Filesystem sandbox root. Empty falls back "
             "to the canonical /var/lib/hal0/agents/<name>/workspace at "
             "load time."
         ),
@@ -2456,9 +2453,9 @@ class AgentMCPConfig(BaseModel):
 
 
 class AgentConfig(BaseModel):
-    """Top-level shape of ``/etc/hal0/agents/<name>.toml`` (ADR-0013 §1).
+    """Top-level shape of ``/etc/hal0/agents/<name>.toml``.
 
-    ADR-0013 §1 spells out one file per agent — installer for bundled,
+    By design, one file per agent — installer for bundled,
     user for user-added. Preserved across ``hal0 update``. Schema
     validated at agent bootstrap time + on dashboard-edit save.
 
@@ -2576,7 +2573,7 @@ class MemoryConfig(BaseModel):
     """[memory] section of hal0.toml.
 
     Container for the per-subsystem memory tunables. Today carries
-    ``[memory.graph]`` (ADR-0014), ``[memory.embedding]`` (issue #116), and
+    ``[memory.graph]``, ``[memory.embedding]`` (issue #116), and
     the per-agent provider routing (``agent_providers``/``agent_private``).
     Future memory features (retention, prune-policy, archival) land under a
     single namespace rather than scattering top-level tables.
@@ -2753,7 +2750,7 @@ class HonchoConfig(BaseModel):
         default=False,
         description=(
             "Require Bearer auth on the Honcho API. Default False (loopback-only "
-            "posture, ADR-0012: no Bearer needed on LAN)."
+            "posture, no Bearer needed on LAN)."
         ),
     )
     llm: HonchoLLMConfig = Field(default_factory=HonchoLLMConfig)

--- a/src/hal0/dispatcher/memory_dispatcher.py
+++ b/src/hal0/dispatcher/memory_dispatcher.py
@@ -1,6 +1,6 @@
 """In-process memory dispatcher for the MCP admin server.
 
-ADR-0004 §7 plus ADR-0005 §2 together demand: the admin MCP server's
+By design, the admin MCP server's
 ``memory_*`` tool family must reach the memory provider *without* an
 HTTP loop-back through ``/mcp/memory``. The loop-back works (and was the
 v0.2 stopgap), but every round trip pays a transport tax and re-runs
@@ -55,7 +55,7 @@ class MemoryDispatcher:
         leave this None.
     private_resolver:
         Zero-arg callable returning whether the current call opted into
-        the ``private:<client_id>`` namespace (ADR-0005 §3). Defaults
+        the ``private:<client_id>`` namespace. Defaults
         to False.
 
     The instance is callable so existing call sites in

--- a/src/hal0/dispatcher/npu_swap_status.py
+++ b/src/hal0/dispatcher/npu_swap_status.py
@@ -15,7 +15,7 @@ the slot's lifecycle state. Transitional states (PULLING/STARTING/
 WARMING/UNLOADING) map to ``in_progress=True``; settled states
 (READY/SERVING/IDLE/OFFLINE/ERROR) map to ``in_progress=False``.
 
-Per ADR-0008 §5, only one NPU LLM slot may be enabled at a time.
+By design, only one NPU LLM slot may be enabled at a time.
 :meth:`hal0.slots.manager.SlotManager._check_npu_exclusivity` guards the
 *write* path; this module observes the *runtime* state.
 """

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -800,7 +800,7 @@ class Dispatcher:
                 enter_dispatch(effective_slot)
             try:
                 if call.slot_name:
-                    # B1 (ADR-0022): backend-aware lazy-load. On a cold miss we
+                    # B1: backend-aware lazy-load. On a cold miss we
                     # kick SlotManager.load(slot_name) FIRST so the slot's
                     # declared device/profile drives the load, then gate on
                     # readiness.
@@ -849,7 +849,7 @@ class Dispatcher:
     async def _ensure_slot_loaded_backend_aware(self, call: UpstreamCall) -> None:
         """Kick a backend-aware load on a cold miss before forwarding.
 
-        B1 (ADR-0022) — the name-based lazy-load gap. When a request
+        B1 — the name-based lazy-load gap. When a request
         resolves to a slot whose model is not loaded, we drive
         ``SlotManager.load(slot_name)`` here so the slot's declared
         device/profile picks the backend.

--- a/src/hal0/hardware/recommend.py
+++ b/src/hal0/hardware/recommend.py
@@ -12,7 +12,7 @@ We do NOT invent model names.
 
 Device choice respects the canonical device enum
 (``hal0.model_meta.VALID_DEVICES`` — ``gpu-rocm``, ``gpu-vulkan``,
-``cpu``, ``npu``, ADR-0006 §7). The output also emits the legacy
+``cpu``, ``npu``). The output also emits the legacy
 ``backend`` field for one release so a downgrade to v0.1.x reads the
 recommendation file cleanly. Both translations (backend→device, device→
 default profile) come from the canonical maps in :mod:`hal0.model_meta`.
@@ -225,8 +225,8 @@ def recommend_primary_slot(hw: HardwareInfo) -> dict[str, Any]:
     # more flat hard-coded 8192. (#513)
     context_size = _resolve_primary_ctx(model_id)
 
-    # v0.2: emit ``device`` as the canonical hardware-preference field
-    # (ADR-0006 §7). ``backend`` is also emitted so a downgrade to
+    # v0.2: emit ``device`` as the canonical hardware-preference field.
+    # ``backend`` is also emitted so a downgrade to
     # v0.1.x can still read the file before re-running the recommender.
     device = map_backend_to_device(backend)
 

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -214,7 +214,7 @@ def _clamp_context_size(requested: int, hw: HardwareInfo, *, weights_gb: float =
 async def _set_slot_enabled(slot_manager, slot_name: str, enabled: bool, *, failed: bool) -> None:
     """Best-effort flip of a slot's ``enabled`` flag after its pull settles.
 
-    Non-aborting per ADR-0010: a failed config rewrite must not crash the pull
+    Non-aborting by design: a failed config rewrite must not crash the pull
     driver. On a FAILED pull we also stamp ``[meta].pull_failed`` so the parked
     slot is clearly marked (the dashboard / ``hal0 doctor`` can surface it).
     """
@@ -222,7 +222,7 @@ async def _set_slot_enabled(slot_manager, slot_name: str, enabled: bool, *, fail
     if failed:
         updates["meta"] = {"pull_failed": True}
     # Activation is best-effort — the model still downloaded; the operator can
-    # enable the slot by hand. Never let this abort the pull driver (ADR-0010).
+    # enable the slot by hand. Never let this abort the pull driver.
     with contextlib.suppress(Exception):
         await slot_manager.update_config(slot_name, updates)
 
@@ -337,7 +337,7 @@ def _validate_store_mount(storage_dir: str) -> None:
     Warns (logs only — never raises) when the mount is unwritable, sits on
     the root filesystem, or is short on space (issue #1100 / decision Q4).
     Non-fatal: a bad pick is surfaced to the operator via logs/``hal0
-    doctor`` rather than aborting the setup walk (ADR-0010).
+    doctor`` rather than aborting the setup walk.
     """
     ancestor = _nearest_existing_ancestor(storage_dir)
     if ancestor is None:
@@ -399,7 +399,7 @@ def _persist_store_dir(storage_dir: str) -> None:
     (``_validate_store_mount``), warning on an unwritable dir, a root-FS pick,
     or low free space — never blocking the walk.
 
-    Best-effort per ADR-0010: an empty or relative value is ignored (the pull
+    Best-effort: an empty or relative value is ignored (the pull
     engine keeps its default store), and a config-write failure is swallowed so
     a bad storage pick never aborts the slot/extension walk. Idempotent —
     skips the rewrite when both ``[models].store`` and ``[models].flm_store``
@@ -464,7 +464,7 @@ async def apply_setup(
 ) -> SetupResult:
     """Create the chosen slots OFFLINE, plan their pulls, install extensions,
     and (optionally) write the first-run sentinel. Best-effort, non-aborting
-    per item (ADR-0010): a bad row is reported with ``skipped``/``error`` and
+    per item: a bad row is reported with ``skipped``/``error`` and
     the walk continues. Does NOT run pulls — see ``SetupResult.pulls``."""
     slot_outcomes: list[SlotOutcome] = []
     model_ids: list[str] = []

--- a/src/hal0/mcp/__init__.py
+++ b/src/hal0/mcp/__init__.py
@@ -4,9 +4,8 @@ This package exposes two Streamable-HTTP MCP servers that bundled and
 external agents use to drive hal0 without re-implementing the REST API:
 
   - :mod:`hal0.mcp.admin`  — slot / model / capability / config /
-    provider / version / hardware / logs tools (ADR-0004 §4 catalog).
-  - :mod:`hal0.mcp.memory` — Cognee-backed long-term memory tools
-    (ADR-0005 §2 schema).
+    provider / version / hardware / logs tools.
+  - :mod:`hal0.mcp.memory` — Cognee-backed long-term memory tools.
 
 Both servers mount as sub-ASGI apps under the main FastAPI app at
 ``/mcp/admin`` and ``/mcp/memory`` respectively. The wiring lives in

--- a/src/hal0/mcp/__init__.py
+++ b/src/hal0/mcp/__init__.py
@@ -5,7 +5,7 @@ external agents use to drive hal0 without re-implementing the REST API:
 
   - :mod:`hal0.mcp.admin`  — slot / model / capability / config /
     provider / version / hardware / logs tools.
-  - :mod:`hal0.mcp.memory` — Cognee-backed long-term memory tools.
+  - :mod:`hal0.mcp.memory` — Hindsight-backed long-term memory tools.
 
 Both servers mount as sub-ASGI apps under the main FastAPI app at
 ``/mcp/admin`` and ``/mcp/memory`` respectively. The wiring lives in

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -32,11 +32,11 @@ app — including its own session manager, SSE/HTTP transports, and
 ``/messages`` writer — that we want to expose unmodified. Wrapping it
 in an APIRouter would force us to re-export the SDK's internal route
 table by hand and re-implement its lifespan hooks, which is exactly
-the brittleness ADR-0004 §7 warns against. ``app.mount()`` cleanly
+the kind of brittleness we want to avoid. ``app.mount()`` cleanly
 delegates everything below the mount path to the sub-app.
 
-Tool catalog (ADR-0004 §4)
---------------------------
+Tool catalog
+------------
 
 Autonomous read::
 
@@ -93,7 +93,7 @@ The agent presents its Bearer token through the MCP transport's HTTP
 headers. The server extracts ``client_id`` from that token by hitting
 ``/api/auth/me`` (same identity the dashboard sees) and stamps every
 audit row with it. Internal API calls re-attach the same Bearer so we
-honour the "no new privileged surface" rule from ADR-0004 §7 — an
+honour the "no new privileged surface" rule — an
 agent can only do what its token already permits via REST.
 
 Fail-fast import
@@ -314,7 +314,7 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
 )
 
 # Mutating tools that are safe enough to run without approval
-# (reversible, scoped, low blast radius). Per ADR-0004 §4.
+# (reversible, scoped, low blast radius).
 AUTONOMOUS_WRITE_TOOLS: frozenset[str] = frozenset(
     {
         # Model. model_scan only ADDS registry entries for files already
@@ -405,15 +405,15 @@ GATED_TOOLS: frozenset[str] = frozenset(
 
 # (method, path-template). Path templates use ``{arg_name}`` placeholders
 # that we resolve from the tool call's args dict.
-# NOTE — drift between ADR-0004 §4 and live REST routes (2026-05-22):
+# NOTE — drift between the original tool-catalog spec and live REST routes (2026-05-22):
 #
-# ADR-0004 §4 names a few routes that don't exist verbatim. Where the
-# ADR's stated URL doesn't match what ``hal0.api.routes`` actually
+# The original spec names a few routes that don't exist verbatim. Where the
+# spec's stated URL doesn't match what ``hal0.api.routes`` actually
 # exposes, we route to the live URL and flag the divergence in
-# WAVE1_MCP_PENDING.md. The tool catalog itself stays ADR-faithful so
+# WAVE1_MCP_PENDING.md. The tool catalog itself stays spec-faithful so
 # agents see the documented names; only the HTTP target moves.
 #
-#   ADR §4                              Live route                    Note
+#   Spec                                Live route                    Note
 #   ──────────────────────────────────  ─────────────────────────────  ────────────────
 #   model_swap → /api/slots/{n}/model   /api/slots/{n}/swap           name diff
 #   model_pull → /api/models/pull       /api/models/{id}/pull         id-in-path
@@ -1104,7 +1104,8 @@ async def _execute_tool(
 #
 # These are advisory — server-side gating in :func:`is_gated` is still
 # the authoritative policy. The annotations exist so MCP clients render
-# the right approval-prompt language without having to read ADR-0004.
+# the right approval-prompt language without having to inspect server
+# internals.
 
 _ANNOTATIONS: dict[str, ToolAnnotations] = {
     # ── Autonomous read — pure reads against the local REST surface. ─────

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -940,7 +940,7 @@ async def dispatch(
 
     ``memory_dispatcher`` is the in-process callable the memory server
     exposes for direct invocation (avoiding the HTTP round-trip for
-    Cognee calls). When ``None``, memory tools route through REST like
+    memory-engine calls). When ``None``, memory tools route through REST like
     everything else, which is the safer default.
 
     ``policy`` is the caller persona's :class:`ToolPolicy` overlay;
@@ -1033,7 +1033,7 @@ async def _execute_tool(
     """Actually run a tool (no gating, no audit — caller handles both).
 
     Memory tools take the in-process dispatcher when available so we
-    don't bounce through HTTP for a Cognee call that runs in the same
+    don't bounce through HTTP for a memory-engine call that runs in the same
     process. All other tools go through REST so the API's auth +
     validation layer is the single source of truth for permissions.
     """
@@ -1226,7 +1226,7 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "model_store_probe": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),
-    # Read-shaped memory tools — surface a Cognee query, no writes.
+    # Read-shaped memory tools — surface a memory query, no writes.
     "memory_search": ToolAnnotations(
         readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False
     ),

--- a/src/hal0/mcp/approval_queue.py
+++ b/src/hal0/mcp/approval_queue.py
@@ -1,8 +1,8 @@
 """In-memory approval queue for gated MCP tool calls.
 
 Phase 8 (Agents v0.2) MCP servers split tool catalogs into autonomous
-(executes immediately) and gated (requires owner approval) buckets per
-ADR-0004 §4. Gated invocations land here; the owner then approves or
+(executes immediately) and gated (requires owner approval) buckets.
+Gated invocations land here; the owner then approves or
 denies via ``POST /api/agent/approvals/{id}/{approve|deny}``.
 
 Design notes

--- a/src/hal0/mcp/installed.py
+++ b/src/hal0/mcp/installed.py
@@ -13,8 +13,8 @@ Scope (v0.3 alpha)
   layout so users get a single mental model.
 * Provide list / add / remove / patch helpers the FastAPI route layer
   calls through.
-* No process supervision yet — that lives in a follow-up ADR (see
-  ADR-0013 §6 "Bootstrap path"). Installed servers report
+* No process supervision yet — that's deferred to a follow-up
+  bootstrap-path effort. Installed servers report
   ``state="stopped"`` in :func:`hal0.api.routes.mcp.list_servers` until
   the supervisor ships.
 

--- a/src/hal0/mcp/manifest.py
+++ b/src/hal0/mcp/manifest.py
@@ -69,7 +69,7 @@ _FETCH_TIMEOUT = httpx.Timeout(connect=4.0, read=6.0, write=2.0, pool=6.0)
 # ── SSRF guard ──────────────────────────────────────────────────────────────
 #
 # The manifest fetcher is reachable through ``GET /api/mcp/resolve?url=…``
-# with no auth on the LAN (ADR-0012). Without a guard, an unauthenticated
+# with no auth on the LAN. Without a guard, an unauthenticated
 # caller can use hal0 as a blind probe against the LAN, IMDS, and loopback.
 # We enforce a deny-list at the URL/IP layer and refuse to follow redirects
 # (a 30x to a private host would otherwise bypass the pre-flight check).

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -1,11 +1,11 @@
-"""hal0 memory MCP server — Cognee-backed long-term memory tools.
+"""hal0 memory MCP server — Hindsight-backed long-term memory tools.
 
 By design, memory is a first-class MCP surface so bundled and
 external agents share one persistence layer for "what the user
-remembers about themselves and their hal0". The wrapper around Cognee
-itself lives in :mod:`hal0.memory.cognee_wrapper` (Memory-engine team
-owns that module); this module exposes the four MCP tools and the
-schema validation that bridges agent calls to the wrapper.
+remembers about themselves and their hal0". The active engine is
+resolved through :class:`hal0.memory.MemoryProvider` (Hindsight, with a
+PgVector boot-degrade fallback); this module exposes the four MCP tools
+and the schema validation that bridges agent calls to the provider.
 
 Tool catalog
 ------------
@@ -171,7 +171,7 @@ def _iso_now() -> str:
 # ── Tool implementations ─────────────────────────────────────────────────────
 #
 # Each helper returns the JSON payload an MCP client should see. They
-# share one CogneeWrapper instance held by the caller — we pass it in
+# share one MemoryProvider instance held by the caller — we pass it in
 # rather than importing globally so tests can substitute a mock.
 
 
@@ -248,9 +248,9 @@ async def _memory_search(
     """memory_search(query, limit=10, dataset="shared"|list, tags=[],
                      before=null, after=null) → {results}.
 
-    CogneeWrapper contract::
+    MemoryProvider contract::
 
-        await wrapper.search(query, limit, dataset, tags, before, after)
+        await provider.search(query, limit, dataset, tags, before, after)
             -> list[ItemDict]
 
     ``dataset`` MAY be a list — a private-mode client sees both
@@ -421,7 +421,7 @@ def make_dispatcher(
 
     The admin server passes this into :func:`hal0.mcp.admin.dispatch`
     via ``memory_dispatcher=`` so memory tool calls bypass the HTTP
-    round-trip and hit Cognee directly in-process. Validation errors
+    round-trip and hit the memory engine directly in-process. Validation errors
     surface as the same error envelope shape the REST routes use.
 
     ``client_id_resolver`` is a 0-arg callable that returns the

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -1,14 +1,14 @@
 """hal0 memory MCP server — Cognee-backed long-term memory tools.
 
-Per ADR-0005 §2, memory is a first-class MCP surface so bundled and
+By design, memory is a first-class MCP surface so bundled and
 external agents share one persistence layer for "what the user
 remembers about themselves and their hal0". The wrapper around Cognee
 itself lives in :mod:`hal0.memory.cognee_wrapper` (Memory-engine team
 owns that module); this module exposes the four MCP tools and the
 schema validation that bridges agent calls to the wrapper.
 
-Tool catalog (ADR-0005 §2)
---------------------------
+Tool catalog
+------------
 
 ::
 
@@ -17,7 +17,7 @@ Tool catalog (ADR-0005 §2)
     memory_list    — paginated walk; returns {items, next_cursor}
     memory_delete  — remove by id(s); returns {deleted}
 
-Per ADR-0005 §2 the v0.2 schema is rich from day 1 so we don't pay a
+By design the v0.2 schema is rich from day 1 so we don't pay a
 schema-versioning tax in Phase 9::
 
     memory_add(text, dataset="shared", tags=[], metadata={},
@@ -25,8 +25,8 @@ schema-versioning tax in Phase 9::
         → {id: str, timestamp: iso8601, operation_id?: str}
         # `source` is auto-extracted server-side from the caller's
         # client_id (Bearer-derived). Clients CANNOT pass `source`
-        # themselves — that's how ADR-0005 §5 keeps the audit trail
-        # forensically grounded. `document_id` reuse upserts one
+        # themselves — that keeps the audit trail forensically
+        # grounded. `document_id` reuse upserts one
         # logical document; `operation_id` surfaces async ingestion.
 
     memory_search(query, limit=10, dataset="shared"|list, tags=[],
@@ -40,7 +40,7 @@ schema-versioning tax in Phase 9::
     memory_delete(ids: list[str], dataset=null)
         → {deleted: int}
 
-Namespace rule (ADR-0005 §3): writes default to dataset ``shared``;
+Namespace rule: writes default to dataset ``shared``;
 clients opting into private mode at the transport layer promote to
 ``private:<client_id>``. We resolve the effective dataset in
 :func:`_resolve_dataset` so callers don't have to know the rule.
@@ -98,11 +98,11 @@ log = structlog.get_logger(__name__)
 
 
 class MemorySchemaError(ValueError):
-    """Raised when a memory tool call's args don't match the ADR-0005 §2 schema."""
+    """Raised when a memory tool call's args don't match the tool schema."""
 
 
 # document_id becomes a URL path segment on the engine's documents API —
-# same bounded grammar as agent ids (ADR-0005 §5) keeps it traversal-free.
+# same bounded grammar as agent ids keeps it traversal-free.
 _AGENT_ID_LIKE = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
 
@@ -129,7 +129,7 @@ def _optional(args: dict[str, Any], key: str, type_: type) -> Any:
 def _normalise_tags(value: Any) -> list[str]:
     """Tags may arrive as None, list, or stringified CSV (some MCP clients
     don't speak JSON-array literals well). Normalise to list[str] (possibly
-    empty) per ADR-0005 §2's default of ``[]``.
+    empty) matching the schema's default of ``[]``.
     """
     if value is None:
         return []
@@ -141,7 +141,7 @@ def _normalise_tags(value: Any) -> list[str]:
     raise MemorySchemaError(f"tags must be list[str] or comma-string, got {type(value).__name__}")
 
 
-# ── Namespace resolution (ADR-0005 §3) ───────────────────────────────────────
+# ── Namespace resolution ─────────────────────────────────────────────────────
 #
 # The actual rule lives in :mod:`hal0.memory.namespace` so the REST shims
 # in ``hal0.api.routes.memory`` apply the same logic (issue #317). This
@@ -185,7 +185,7 @@ async def _memory_add(
     """memory_add(text, dataset?, tags?, metadata?, document_id?)
     → {id, timestamp, operation_id?}.
 
-    ADR-0005 §2 schema:
+    Schema:
       - ``text``: required, non-empty str.
       - ``dataset``: defaults to ``"shared"``; ``--private`` promotes
         to ``private:<client_id>``.
@@ -195,8 +195,8 @@ async def _memory_add(
         across adds to upsert the same logical document (conversation
         evolution). Same identity grammar as agent ids.
       - ``source``: NOT accepted from the caller. Server-injected from
-        ``client_id`` so callers cannot lie about their identity
-        (ADR-0005 §5 audit grounding).
+        ``client_id`` so callers cannot lie about their identity,
+        keeping the audit trail grounded.
 
     ``operation_id`` appears when the engine ingests asynchronously
     (Hindsight retain) — poll it via the engine-admin operations surface.
@@ -254,7 +254,7 @@ async def _memory_search(
             -> list[ItemDict]
 
     ``dataset`` MAY be a list — a private-mode client sees both
-    ``shared`` + their own ``private:<client_id>`` per ADR-0005 §3.
+    ``shared`` + their own ``private:<client_id>``.
     """
     query = _require(args, "query", str)
     if not query.strip():
@@ -322,7 +322,7 @@ async def _memory_delete(
 ) -> dict[str, Any]:
     """memory_delete(ids, dataset?) → {deleted: int}.
 
-    Returns the count of deleted rows per ADR-0005 §2. ``ids`` must be
+    Returns the count of deleted rows. ``ids`` must be
     non-empty. ``dataset`` optionally directs the engine's bank sweep
     (e.g. ``project:<id>`` items live outside the default
     shared + own-private sweep). Approval-gating for bulk deletes
@@ -347,7 +347,7 @@ async def _memory_delete(
     deleted_raw = result.get("deleted", len(ids))
     # Accept either a count or the list of deleted ids from the wrapper
     # so we're forgiving of either contract while still returning the
-    # ADR-0005 count shape.
+    # expected count shape.
     if isinstance(deleted_raw, list):
         deleted_count = len(deleted_raw)
     elif isinstance(deleted_raw, int):

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -1,4 +1,4 @@
-"""hal0 memory subsystem (ADR-0005 + brain-redesign P0-P2).
+"""hal0 memory subsystem (brain-redesign P0-P2).
 
 Public contract for ``/mcp/memory`` + ``/api/memory/*``. Exposes the
 engine-neutral :class:`MemoryProvider` ABC and the ``provider_from_config``

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -27,7 +27,7 @@ from hal0.memory.provider import MemoryProvider
 
 _SHARED = "shared"
 _PRIVATE = "private:"
-# ADR-0011 §6: the ``agents`` namespace is a federated agent-registry /
+# The ``agents`` namespace is a federated agent-registry /
 # identity-card store (written by the ``hal0 agent`` CLI), NOT chat memory.
 # Unified mode collapses shared/private/project onto ``shared`` but leaves
 # ``agents`` routing to its own bank untouched, both read and write.
@@ -173,7 +173,7 @@ class HindsightProvider(MemoryProvider):
     def _allowed_namespaces(self, requested: str | list[str], client_id: str | None) -> list[str]:
         # Unified mode: one bank. No cross-bank fan-out, no own-private
         # expansion — every read resolves to ``shared`` alone, EXCEPT the
-        # ``agents`` registry namespace, which keeps its own bank (ADR-0011 §6).
+        # ``agents`` registry namespace, which keeps its own bank.
         if self._unified_bank:
             reqs = [requested] if isinstance(requested, str) else list(requested or [_SHARED])
             out: list[str] = []
@@ -202,7 +202,7 @@ class HindsightProvider(MemoryProvider):
         # front door still resolves ``private:<agent>`` (so the private intent
         # survives for the ``visibility:private`` tag in ``add``), but the bank
         # is always ``shared`` here. The ``agents`` registry namespace is the
-        # one exception: it keeps its own bank (ADR-0011 §6).
+        # one exception: it keeps its own bank.
         if self._unified_bank:
             return _AGENTS if requested == _AGENTS else _SHARED
         # The REST/MCP front door already resolved the write namespace via

--- a/src/hal0/memory/honcho_migrate.py
+++ b/src/hal0/memory/honcho_migrate.py
@@ -14,7 +14,7 @@ Two directions, both loopback REST, both idempotent:
   migration-created sessions from the forward direction are skipped so the
   two directions never loop.
 
-Both ends are loopback REST with no required auth (ADR-0012 posture), so
+Both ends are loopback REST with no required auth, so
 this module talks plain ``httpx.Client`` — no SDK dependency, no auth
 plumbing, and trivially fakeable in tests via ``httpx.MockTransport``
 threaded through as an injected client.

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -1,4 +1,4 @@
-"""ADR-0005 §3 namespace resolution — shared by the MCP + REST surfaces.
+"""Namespace resolution — shared by the MCP + REST surfaces.
 
 The MCP server (:mod:`hal0.mcp.memory`) and the REST shims
 (:mod:`hal0.api.routes.memory`) both translate caller-supplied
@@ -8,7 +8,7 @@ issue #317 surfaced exactly that kind of drift, where the REST handler
 hardcoded ``"shared"`` while the MCP dispatcher correctly honored
 ``private:<client_id>`` promotion.
 
-The rule (ADR-0005 §3):
+The rule:
 
   - Writes default to ``"shared"``.
   - Callers in "private mode" promote to ``private:<client_id>`` for
@@ -50,7 +50,7 @@ PROJECT_PREFIX = "project:"
 ANONYMOUS_CLIENT_ID = "anonymous"
 
 # Spec §3 namespace grammar — the scoped suffix after ``project:`` follows
-# the same identity rules as agent ids (ADR-0005 §5): alnum + ``-`` + ``_``,
+# the same identity rules as agent ids: alnum + ``-`` + ``_``,
 # ≤64 chars, so bank names derived from it stay path-traversal-free.
 _SCOPED_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-]{1,64}$")
 
@@ -82,7 +82,7 @@ def resolve_write_dataset(
     """Translate a write request into the effective dataset name.
 
     Mirrors :func:`hal0.mcp.memory._resolve_dataset` (which delegates
-    here) — the docstring rule from ADR-0005 §3 applies:
+    here) — the rule described in the module docstring applies:
 
       - ``private=True`` → ``private:<client_id>`` (raises if no
         ``client_id`` is available).

--- a/src/hal0/memory/provider.py
+++ b/src/hal0/memory/provider.py
@@ -1,13 +1,13 @@
 """The explicit MemoryProvider contract (brain-redesign P0).
 
-Promotes the implicit five-method ``CogneeWrapper`` surface into an ABC so
-hal0 can swap engines (Cognee → Hindsight, fallback Mem0/PgVector) without
-touching a single call site. The ABC is the anti-lock-in seam (spec §1).
+Promotes the implicit five-method memory surface into an ABC so hal0 can
+swap engines (Hindsight, with Mem0/PgVector fallbacks) without touching a
+single call site. The ABC is the anti-lock-in seam (spec §1).
 
 The *core five* (``add/search/list_items/delete`` + the three runtime
 toggles ``graph_status/set_graph_enabled/set_rerank_enabled``) are abstract:
 every engine must implement them, byte-compatible in **signature + return
-shape** with ``CogneeWrapper`` so the REST shims + MCP dispatcher need no
+shape** with ``MemoryProvider`` so the REST shims + MCP dispatcher need no
 changes. The *optional* methods (``recall/reflect/consolidate/
 register_compiled``) ship concrete safe defaults so an engine without
 consolidation still satisfies the contract.
@@ -22,7 +22,7 @@ from typing import Any
 
 
 class Mode(enum.StrEnum):
-    """Search mode — mirrors CogneeWrapper's accepted ``mode`` values."""
+    """Search mode — mirrors the ``MemoryProvider`` accepted ``mode`` values."""
 
     VECTOR = "vector"
     GRAPH = "graph"
@@ -59,15 +59,15 @@ class MemoryItem:
         }
 
 
-# Back-compat alias: ``MemoryRecord`` was the original (cognee-era) name for this
-# wire shape. Kept as an alias so existing importers keep working after the cognee
-# wrapper was removed (ADR-0023).
+# Back-compat alias: ``MemoryRecord`` was the original name for this wire
+# shape. Kept as an alias so existing importers keep working after the legacy
+# memory wrapper was removed (ADR-0023).
 MemoryRecord = MemoryItem
 
 
 @dataclass
 class AddResult:
-    """Return shape of ``add`` — matches ``CogneeWrapper.add``."""
+    """Return shape of ``add`` — matches ``MemoryProvider.add``."""
 
     id: str
     timestamp: str
@@ -78,7 +78,7 @@ class AddResult:
 
 @dataclass
 class ListPage:
-    """Return shape of ``list_items`` — matches ``CogneeWrapper.list_items``."""
+    """Return shape of ``list_items`` — matches ``MemoryProvider.list_items``."""
 
     items: list[dict[str, Any]]
     next_cursor: str | None = None
@@ -89,7 +89,7 @@ class ListPage:
 
 @dataclass
 class DeleteResult:
-    """Return shape of ``delete`` — matches ``CogneeWrapper.delete``."""
+    """Return shape of ``delete`` — matches ``MemoryProvider.delete``."""
 
     deleted: int
 

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -109,7 +109,7 @@ class DeviceMeta:
     description: str
 
 
-#: The canonical devices (ADR-0006 §7, gpu-cuda added by the GPU
+#: The canonical devices (gpu-cuda added by the GPU
 #: generalization wave), with per-device metadata.
 #: Ordering is presentation order for pickers: recommended first, then the
 #: fallbacks (Vulkan, then the experimental CUDA path), then the non-GPU
@@ -192,7 +192,8 @@ RUNTIME_FAMILIES: tuple[str, ...] = ("llama-server", "flm", "kokoro", "qwen3tts"
 
 #: Legacy ``backend`` token → canonical ``device``. Used by the SlotConfig
 #: model-validator (auto-promote on load), the capabilities v1→v2 migration,
-#: and the capabilities on-load auto-migration. Keep aligned with ADR-0006 §7.
+#: and the capabilities on-load auto-migration. Keep aligned with the
+#: canonical device enum above.
 #: moonshine/kokoro map to ``cpu`` because those toolboxes were always CPU
 #: runtimes — the legacy enum overloaded ``backend`` with provider identity.
 #: Canonical device ids are included idempotently so both SlotConfig.backend
@@ -485,7 +486,7 @@ def capability_from_filename(name: str) -> str | None:
 
 # ── device → recipe/backend mapping ──────────────────────────────────────────
 #
-# Plan §4.1 + ADR-0008 §6 locked the four-way mapping; the result feeds
+# By design, the four-way mapping is locked; the result feeds
 # container profile/argv derivation. ``gpu-*`` slots load through
 # llama.cpp with an explicit backend flag; ``cpu`` is the same recipe
 # with CPU-only inference; ``npu`` uses the FLM recipe (NPU FastFlowLM)
@@ -540,7 +541,7 @@ def device_to_backend(device: str | None) -> tuple[str | None, str | None]:
 def canonical_device(value: str) -> str:
     """Normalise a backend/device string to the canonical ``device`` enum.
 
-    After ADR-0006 §7 both the slot TOML and the capabilities catalog
+    Both the slot TOML and the capabilities catalog
     speak the same enum (``gpu-rocm | gpu-vulkan | cpu | npu``), so this
     is a near-identity. It still tolerates a legacy ``backend``-style
     input (``vulkan|rocm|flm|moonshine|kokoro``) for forward

--- a/src/hal0/omni_router/__init__.py
+++ b/src/hal0/omni_router/__init__.py
@@ -1,6 +1,6 @@
 """Client-side OmniRouter — OpenAI tool-calling loop owned by hal0.
 
-ADR-0008 §8 + plan §7. hal0's /v1 surface provides the local tool endpoints
+hal0's /v1 surface provides the local tool endpoints
 (``/v1/images/*``, ``/v1/audio/*``, ``/v1/embeddings``, ``/v1/rerank``);
 hal0 provides the LLM loop that dispatches them.
 

--- a/src/hal0/omni_router/dispatch.py
+++ b/src/hal0/omni_router/dispatch.py
@@ -35,7 +35,7 @@ Endpoints (per plan §7.2):
   ============================== =================================
 
 The base URL is hal0-api's own loopback URL (``http://127.0.0.1:8080``
-by default per ADR-0008 §1). PR-19 introduces direct-to-FLM-child
+by default). PR-19 introduces direct-to-FLM-child
 routing for ``flm-stt``/``flm-embed`` slots; PR-16 sticks to the
 single-URL contract.
 """

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -567,7 +567,7 @@ class SlotConfigStore:
             slot_backend = device_to_legacy_backend(selection.device)
             slot_device = canonical_device(selection.device)
             if slot_backend:
-                # Deprecated field, kept for one release — see ADR-0006 §7.
+                # Deprecated field, kept for one release.
                 updates["backend"] = slot_backend
             if slot_device:
                 updates["device"] = slot_device

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -212,7 +212,7 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     so the dashboard renders cards + drawers without a per-slot
     ``/config`` fetch.
 
-    Coresident grouping (ADR-0008 §5):
+    Coresident grouping:
       A slot of type=llm + device=npu serving as the chat anchor and
       any sibling ``stt`` / ``embed`` alias records that are enabled
       share a ``coresident_group=npu-flm-trio`` marker. The dashboard

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -111,7 +111,7 @@ SEEDED_SLOTS: tuple[str, ...] = (
 #: ride the same coresident FLM process as the NPU chat anchor — the
 #: separate ``flm`` slot, NOT listed here. ``agent`` was previously
 #: (wrongly) in this set; it is a GPU chat-role slot and moved to
-#: SEEDED_SLOTS in #679. Opt-in at Pro+ bundle tier (ADR-0008 §5).
+#: SEEDED_SLOTS in #679. Opt-in at Pro+ bundle tier.
 #:
 #: Named ``{anchor}-stt`` / ``{anchor}-embed`` (anchor is ``flm``) to match
 #: the occupancy-pane virtual sub-cards (:mod:`hal0.api.routes.npu` synthesises
@@ -1555,7 +1555,7 @@ class SlotManager:
         :data:`SEEDED_SLOTS` lands on every hal0 install. The NPU trio
         shadows (``flm-stt`` / ``flm-embed``) only seed when the
         FastFlowLM ``.deb`` is installed (``shutil.which('flm')``
-        truthy). Per plan §10.2 + §4.2 + ADR-0008 §5.
+        truthy). Per plan §10.2 + §4.2.
 
         Args:
             include_npu: ``None`` (default) detects FLM presence at
@@ -1884,7 +1884,7 @@ class SlotManager:
         ``load()``. The TOML is the only on-disk artefact at create
         time.
 
-        PR-11 (plan §5.3 + ADR-0008 §5): rejects a second ``device=npu,
+        PR-11 (plan §5.3): rejects a second ``device=npu,
         type=llm, enabled=true`` slot — the AMDXDNA hardware context
         admits exactly one NPU LLM at a time. Disabled NPU LLM slots
         coexist; only the live anchor count is bounded.
@@ -2544,7 +2544,7 @@ class SlotManager:
     ) -> None:
         """Reject a write that would land a second NPU LLM anchor.
 
-        Plan §5.3 + ADR-0008 §5: the AMDXDNA hardware context admits
+        Plan §5.3: the AMDXDNA hardware context admits
         ONE ``device=npu, type=llm`` slot at a time. Disabled NPU LLM
         slots may coexist with another disabled (or enabled) one, but
         two enabled anchors cannot be configured. This guard runs on

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -214,7 +214,7 @@ class NpuExclusivityViolation(SlotError):
     """Two ``device=npu, type=llm, enabled=true`` slots cannot coexist.
 
     The AMDXDNA hardware context admits exactly one NPU LLM at a time
-    (plan §5.3, ADR-0008 §5). Surfaced as 409 so the dashboard can
+    (plan §5.3). Surfaced as 409 so the dashboard can
     distinguish "you already have one — disable it first" from a 400
     schema error.
     """

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -235,7 +235,7 @@ class StackApplyEngine:
             device = canonical_device(entry.device)
             if device:
                 updates["device"] = device
-                # Deprecated field, kept for one release — see ADR-0006 §7.
+                # Deprecated field, kept for one release.
                 legacy = device_to_legacy_backend(device)
                 if legacy:
                     updates["backend"] = legacy


### PR DESCRIPTION
## Team DOCS AND COMMENTS — hal0 bones review (issue #985)

Stale-doc/comment sweep. No behavior changes — comments, docstrings, templates, and website docs only (plus doc-string deprecation text). `ruff check src tests docs/ -q` passes.

### 1. Decommissioned ADR citations (#985)
ADR-0023 (canonical LLM roles) is the **only** surviving ADR. Stripped ~225 citations to every other `ADR-00NN` across **86 files** (src comments/docstrings/templates + website `.mdx`), preserving the surrounding rationale inline (rewriting where the citation carried the only explanation). Programmatic string literals that embed an ADR id (log fields, `Hal0Error` messages, response-body `"adr"` values consumed by callers/tests) were intentionally left untouched. All ADR-0023 references preserved.

### 2. Cognee → Hindsight (#985)
Cognee was fully replaced by Hindsight; `CogneeWrapper` / `hal0.memory.cognee_wrapper` no longer exist. Updated stale comments/docstrings/templates that named Cognee as the live backing (or referenced the removed `CogneeWrapper`) to point at the current `MemoryProvider` surface. Deprecated the `cognee` memory-engine enum value in `config/schema.py` + `config-schema.mdx` (still accepted for back-compat, resolves to `hindsight` at runtime; enum member + validator kept for safety, per brief). Genuine history preserved: the Cognee→Hindsight migration module/flag, ADR-0023 notes, cognee-era key-removal rationale, accepted-value enumerations. The `cognee` Python dependency in `pyproject.toml` is untouched.

### 3. Fresh-box documentation (#1083, #1084)
- **#1084** — new "Starting from zero — no models yet" section in `first-model.mdx`: a fresh install seeds no models, so the dashboard shows a first-run banner, an empty Models catalogue, a "no slots configured" hint, and an empty `/v1/models`; the way out is the two-command pull+run path (or the setup TUI). Facts verified against `src/`/`ui/`.
- **#1083** — added a "Next" pointer to `first-chat.mdx` so the install → setup → first-model → first-chat journey is fully linked (the one gap found in the journey audit).

### 4. Deprecated `amdgpu.gttsize` (#1081)
`amdgpu.gttsize` is ignored on Linux 6.10+ (GTT is driven solely by `ttm.pages_limit`). Dropped it from the GRUB cmdline guidance in `baremetal-ubuntu.mdx` and `proxmox-lxc.mdx`, with a deprecation callout.

### 5. Auth comment hygiene
No change required — `AuthIdentity` is already absent from `src/`, and `DEFAULT_ALLOWED_ORIGINS` in `api/agents/_auth.py` contains no `hal0.thinmint.dev`. Both were already clean in-tree.

Ref #985, #1081, #1083, #1084