### PR TITLE
test(hermeticity): isolate 19 tests that leaked live-host state

### DIFF
--- a/tests/api/test_comfyui_phase4.py
+++ b/tests/api/test_comfyui_phase4.py
@@ -388,6 +388,10 @@ class TestWorkflowList:
         (wf_dir / "beta.json").write_text("{}")
         (wf_dir / "notes.txt").write_text("ignore me")  # non-json skipped
         monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(wf_dir))
+        # Isolate the user/default fallback too — otherwise it defaults to the
+        # real /mnt/ai-models/comfyui bind mount on hosts that have one, and
+        # real workflow files leak into the result set.
+        monkeypatch.setenv("COMFYUI_DATA_DIR", str(tmp_path / "comfyui"))
 
         r = client.get("/api/comfyui/workflows")
         assert r.status_code == 200
@@ -431,6 +435,9 @@ class TestWorkflowList:
         # A file whose stem carries a path-ish char must not surface.
         (wf_dir / "a b.json").write_text("{}")  # space fails the name regex
         monkeypatch.setenv("COMFYUI_WORKFLOWS_DIR", str(wf_dir))
+        # Isolate the user/default fallback too — see comment in
+        # test_lists_json_files_from_primary_dir above.
+        monkeypatch.setenv("COMFYUI_DATA_DIR", str(tmp_path / "comfyui"))
 
         r = client.get("/api/comfyui/workflows")
         names = {w["name"] for w in r.json()["workflows"]}

--- a/tests/api/test_comfyui_proxy.py
+++ b/tests/api/test_comfyui_proxy.py
@@ -526,8 +526,18 @@ def test_switchover_is_not_env_gated(client: TestClient) -> None:
 
 
 def test_switchover_unwired_returns_503_not_501(client: TestClient) -> None:
+    # No arbiter wired → the route falls back to the legacy docker/systemd
+    # probe to check "already there". That probe hits the REAL host (systemctl
+    # is-active hal0-slot@img / docker inspect) unless stubbed, so on a box
+    # that actually has ComfyUI running this would resolve "already in
+    # generation mode" and short-circuit to a 200 noop before ever reaching
+    # the arbiter-unavailable check. Stub it down to "absent" (mirrors
+    # test_switchover_503_when_arbiter_unwired above) so the assertion holds
+    # regardless of what's really running on this machine.
     client.app.state.slot_manager = None
-    r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
+    c, s, f = _patch(container="absent", hermes=True, fetch=_fetch_down)
+    with c, s, f:
+        r = client.post("/api/comfyui/switchover", json={"mode": "generation"})
     assert r.status_code == 503
     assert r.json()["error"]["code"] == "comfyui.arbiter_unavailable"
 

--- a/tests/api/test_config_urls.py
+++ b/tests/api/test_config_urls.py
@@ -7,6 +7,8 @@ saying whether the OpenWebUI unit is actually up.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 from fastapi.testclient import TestClient
 
 
@@ -58,13 +60,23 @@ def test_urls_openwebui_enabled_false_when_systemctl_missing(
 
 def test_urls_behind_proxy_without_public_url_uses_openwebui_port(client: TestClient) -> None:
     """Proxy deploys without custom DNS still get the default :3001 link."""
-    resp = client.get(
-        "/api/config/urls",
-        headers={
-            "x-forwarded-host": "ai-dev.thinmint.dev",
-            "x-forwarded-proto": "https",
-        },
-    )
+    # `openwebui_enabled` shells out to the *real* systemctl on whatever host
+    # runs this test — on a dev box with hal0-openwebui.service genuinely
+    # active it would come back True regardless of test config, leaking host
+    # state into an assertion that only cares about URL shape. Stub it so
+    # the test is hermetic across hosts.
+    with patch(
+        "hal0.api.routes.config._openwebui_is_active",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        resp = client.get(
+            "/api/config/urls",
+            headers={
+                "x-forwarded-host": "ai-dev.thinmint.dev",
+                "x-forwarded-proto": "https",
+            },
+        )
     assert resp.status_code == 200
     body = resp.json()
     assert body["openwebui"] == "http://ai-dev.thinmint.dev:3001", body

--- a/tests/api/test_memory_honcho_routes.py
+++ b/tests/api/test_memory_honcho_routes.py
@@ -185,7 +185,20 @@ _TIMER_SCHEDULE = {
 }
 
 
-def test_honcho_sync_status_fresh_state_is_all_none(client: TestClient) -> None:
+def test_honcho_sync_status_fresh_state_is_all_none(client: TestClient, tmp_path: Path) -> None:
+    from hal0.memory.honcho_migrate import MigrateState
+
+    # The route builds its own `MigrateState()` with no args, whose default
+    # ``path`` is the module-level ``DEFAULT_STATE_PATH`` constant
+    # (``/var/lib/hal0/honcho/migrate-state.json``) — a hardcoded absolute
+    # path, not derived from HAL0_HOME. On a host that has ever actually run
+    # `hal0 memory sync-graph` (or the recurring timer), that real file
+    # exists with real prior-run data, so this "fresh state" assertion
+    # leaks it. Point MigrateState at an empty tmp path instead, matching
+    # the pattern already used by the sibling
+    # ``test_honcho_sync_status_reflects_recorded_run``/``..._failed_run``
+    # tests below.
+    state_path = tmp_path / "migrate-state.json"
     with (
         patch(
             "hal0.services.systemd.unit_state",
@@ -197,6 +210,7 @@ def test_honcho_sync_status_fresh_state_is_all_none(client: TestClient) -> None:
             new_callable=AsyncMock,
             return_value=_TIMER_SCHEDULE,
         ),
+        patch("hal0.memory.honcho_migrate.MigrateState", lambda: MigrateState(state_path)),
     ):
         r = client.get("/api/memory/honcho/sync")
     assert r.status_code == 200

--- a/tests/api/test_models_preview.py
+++ b/tests/api/test_models_preview.py
@@ -38,9 +38,17 @@ def preview_client(
 
 def test_preview_returns_detection_rows_without_registering(
     preview_client: tuple[TestClient, Path],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Preview must NOT mutate the registry — that's the whole point."""
     client, root = preview_client
+    # GET /api/models also merges in whatever the host's real FLM toolbox
+    # reports (hal0.providers.flm.flm_served_models probes the live `flm`
+    # binary, uncached per-process on first call). On a box with FLM
+    # actually installed that injects real rows unrelated to this
+    # registry-mutation check — neutralise it so the assertion below is
+    # hermetic regardless of host FLM state.
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: [])
     # Plain .gguf — header read will fail (no magic) so detect() falls
     # back to filename heuristic. confidence stays "low" but the row is
     # still emitted with the GGUF backend seed.

--- a/tests/api/test_services_page.py
+++ b/tests/api/test_services_page.py
@@ -67,6 +67,16 @@ def _stub_all_down() -> list:
             new_callable=AsyncMock,
             return_value=(False, "unreachable (ConnectError)"),
         ),
+        # honcho (and n8n, when its probe env is set) go through the generic
+        # loopback HTTP probe. Left unstubbed, this hits the REAL
+        # 127.0.0.1:8000/health on any host that happens to be running a
+        # honcho stack, silently flipping "up" to True and leaking host
+        # state into an "everything stubbed down" assertion.
+        patch(
+            f"{_ROUTE}._probe_http_env",
+            new_callable=AsyncMock,
+            return_value=(False, "unreachable"),
+        ),
         patch(
             f"{_ROUTE}.svc_systemd.unit_state",
             new_callable=AsyncMock,

--- a/tests/api/test_settings_models_store.py
+++ b/tests/api/test_settings_models_store.py
@@ -15,6 +15,7 @@ Exercises:
 
 from __future__ import annotations
 
+import os
 import tomllib
 from collections.abc import Iterator
 from pathlib import Path
@@ -240,10 +241,27 @@ def test_set_store_rejects_file_not_directory(isolated_client: TestClient, tmp_p
     assert r.json()["error"]["code"] == "models.store_not_directory"
 
 
-def test_set_store_rejects_non_writable_path(isolated_client: TestClient, tmp_path: Path) -> None:
+def test_set_store_rejects_non_writable_path(
+    isolated_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     ro = tmp_path / "readonly"
     ro.mkdir()
     ro.chmod(0o555)
+    # The route probes writability via os.access(candidate, os.W_OK). That
+    # probe reflects the *real* filesystem permission bits only for a
+    # non-root process — running as root (as CI/this host sometimes does),
+    # the kernel grants root write access regardless of the 0o555 mode, so
+    # the 400 never fires. Force the probe's outcome directly so the test
+    # asserts the route's handling of "not writable" rather than the
+    # euid-dependent behavior of chmod.
+    real_access = os.access
+
+    def _fake_access(path: object, mode: int) -> bool:
+        if Path(path) == ro and mode == os.W_OK:
+            return False
+        return real_access(path, mode)
+
+    monkeypatch.setattr("hal0.api.routes.settings.os.access", _fake_access)
     try:
         r = isolated_client.post(
             "/api/settings/models/store",

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -55,6 +55,15 @@ def test_install_hermes_runs_prereqs_then_bootstrap_then_register(
     # it here so this test exercises only the toolchain→bootstrap→register order.
     monkeypatch.setattr("shutil.which", lambda _n: None)
     monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
+    # _chown_hermes_trees_to_agent_user() only no-ops when euid != 0 OR the
+    # `hal0` agent user doesn't exist. On a real hal0 box (running as root,
+    # with the agent user provisioned and its trees already present on
+    # disk) both guards pass, so it shells out to `chown` once per existing
+    # tree — extra "subprocess" events this test never expects. That step
+    # is its own concern (untested here); neutralise it so this test
+    # exercises only the toolchain->bootstrap->register sequence regardless
+    # of host euid/user state.
+    monkeypatch.setattr(ac, "_chown_hermes_trees_to_agent_user", lambda: None)
 
     # Gateway wiring is its own concern (tested in the "gateway" section
     # below) — disable it here so this test exercises only the

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -267,8 +267,21 @@ class TestHermesEnv:
         # A stale python3.12 path inherited from an old unit drop-in does NOT
         # exist → must be replaced by the auto-resolved python3.14 dir. This is
         # the in-place fix for boxes that didn't re-run the installer.
+        #
+        # NB: the stale path must live under tmp_path — a hardcoded
+        # ``/var/lib/hal0/...`` literal collides with the real hermes install
+        # on a live hal0 box (this suite runs on the host itself), where that
+        # directory genuinely exists and would be wrongly "honored" as valid.
         dist = self._mk_web_dist(tmp_path, "python3.14")
-        stale = "/var/lib/hal0/venvs/hermes/lib/python3.12/site-packages/hermes_cli/web_dist"
+        stale = str(
+            tmp_path
+            / "old-venv"
+            / "lib"
+            / "python3.12"
+            / "site-packages"
+            / "hermes_cli"
+            / "web_dist"
+        )
         with patch.dict(os.environ, {"HERMES_WEB_DIST": stale}):
             env = agent_shim._build_hermes_env(_cfg(venv=tmp_path))
         assert env["HERMES_WEB_DIST"] == str(dist)
@@ -287,7 +300,20 @@ class TestHermesEnv:
     def test_web_dist_env_dropped_when_missing(self, tmp_path: Path) -> None:
         # No built dist anywhere + a stale inherited value → pop it so hermes
         # falls back to its own __file__ default, not a known-wrong path.
-        stale = "/var/lib/hal0/venvs/hermes/lib/python3.12/site-packages/hermes_cli/web_dist"
+        #
+        # NB: see test_stale_web_dist_env_replaced_with_resolved above — the
+        # stale path must be guaranteed not to exist, so it's scoped under
+        # tmp_path rather than a hardcoded absolute path that may be real on
+        # the host running the suite.
+        stale = str(
+            tmp_path
+            / "old-venv"
+            / "lib"
+            / "python3.12"
+            / "site-packages"
+            / "hermes_cli"
+            / "web_dist"
+        )
         with patch.dict(os.environ, {"HERMES_WEB_DIST": stale}):
             env = agent_shim._build_hermes_env(_cfg(venv=tmp_path))
         assert "HERMES_WEB_DIST" not in env

--- a/tests/hardware/test_pve.py
+++ b/tests/hardware/test_pve.py
@@ -345,6 +345,22 @@ def test_pve_status_fetch_error_recorded(
 class TestDetectProxmoxHost:
     """detect_proxmox_host() is best-effort, signal-driven, and never raises."""
 
+    @pytest.fixture(autouse=True)
+    def _no_host_container_markers(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Point the cgroup-v2 container markers at guaranteed-missing paths.
+
+        Without this, tests that don't explicitly set _PROC_1_ENVIRON /
+        _DEV_LXC / _RUN_SYSTEMD_CONTAINER fall through to the REAL host
+        paths (/proc/1/environ, /dev/.lxc, /run/systemd/container). On a
+        real Proxmox LXC those exist and leak host state into the test,
+        making bare-metal/pve-only fixtures falsely detect as LXC. Tests
+        that want the marker present override these with their own
+        monkeypatch.setattr calls after this fixture runs.
+        """
+        monkeypatch.setattr(pve, "_PROC_1_ENVIRON", tmp_path / "no-environ")
+        monkeypatch.setattr(pve, "_DEV_LXC", tmp_path / "no-dev-lxc")
+        monkeypatch.setattr(pve, "_RUN_SYSTEMD_CONTAINER", tmp_path / "no-systemd-container")
+
     def test_returns_detected_when_pve_kernel_and_lxc_cgroup(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -68,8 +68,16 @@ def test_spec_provider_vulkan_returns_none() -> None:
 # ── load_sync kokoro TTS path ──────────────────────────────────────────────────
 
 
-def test_tts_kokoro_slot_renders_spec_unit() -> None:
-    """TTS/kokoro slot: spec unit rendered with --model_path, no --device=, correct --publish."""
+def test_tts_kokoro_slot_renders_spec_unit(tmp_hal0_home: str) -> None:
+    """TTS/kokoro slot: spec unit rendered with --model_path, no --device=, correct --publish.
+
+    Isolated via ``tmp_hal0_home`` (tests/conftest.py): ``_render_unit_text``
+    threads the live ``[slots].publish_host`` into every render
+    (``_slot_publish_host()`` -> ``load_hal0_config()``), so without this
+    fixture a host with a non-default ``publish_host`` (e.g. LAN-exposed
+    0.0.0.0) renders a different --publish= address than the default
+    asserted here.
+    """
     provider = ContainerProvider()
     slot_cfg = {
         "name": "tts",

--- a/tests/providers/test_flm_container_spec.py
+++ b/tests/providers/test_flm_container_spec.py
@@ -96,7 +96,13 @@ def test_start_cmd_matches_container_role_args() -> None:
         assert flag in argv and flag in spec.command
 
 
-def test_default_models_dir_is_flm_cache() -> None:
+def test_default_models_dir_is_flm_cache(tmp_hal0_home: str) -> None:
+    """Isolated via ``tmp_hal0_home`` (tests/conftest.py): without it this
+    reads the box's real /etc/hal0/hal0.toml through
+    ``flm_models_dir()`` -> ``load_hal0_config()``, so a host with
+    ``[models].flm_store`` set (e.g. relocated to /mnt/ai-models/FLM)
+    fails here even though the DEFAULT-path assertion is correct.
+    """
     spec = FLMProvider().container_spec(_slot_cfg(), _model_info())
     # Source follows the resolver default (HAL0_HOME-aware); the target is
     # FLM's hardcoded in-container HOME cache and never moves.

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -571,6 +571,25 @@ class TestShadowSlotStatusInheritance:
     the npu anchor's FLM process serves them coresident, so their live
     container status must be the anchor's, not their (always-absent) own."""
 
+    @pytest.fixture(autouse=True)
+    def no_real_systemctl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """container_enrichment's stopped-vs-crashed escalation shells out
+        to a real ``systemctl is-active hal0-slot@{name}.service`` whenever
+        the (fake, injected) provider reports a slot inactive — that raw
+        subprocess call is not mediated by FakeContainerProvider /
+        MapContainerProvider at all. On a live host with real hal0 slot
+        units installed (e.g. ``hal0-slot@embed.service`` /
+        ``hal0-slot@npu.service`` in a ``failed`` state), this leaks real
+        host state into the test and flips the expected ``stopped`` into
+        ``crashed``. Force the escalation probe to see a bare "inactive"
+        unit so status is derived purely from the injected provider."""
+        import subprocess
+
+        class _FakeCompletedProcess:
+            stdout = b"inactive\n"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _FakeCompletedProcess())
+
     async def test_shadow_inherits_running_anchor(self) -> None:
         out = await container_enrichment(
             [


### PR DESCRIPTION
## Summary

19 tests were **green in CI but red when the suite runs on a real hal0 box** (Proxmox LXC, root user, live slots / ComfyUI / OpenWebUI / honcho services, customized `/etc/hal0` + `/var/lib/hal0` config, polluted `os.environ`). In every case the **assertion was correct** — the test *setup* leaked ambient host state (an unpatched module constant, a real filesystem path, a live `systemctl`/HTTP probe, `os.environ`, or root privilege).

This makes the suite unrunnable for anyone developing on an actual hal0 deployment, and means these tests silently depend on the CI runner being pristine. All fixes are **test-only**; **no production behavior changed**. Each was verified to pass **both on the live host and under a fully scrubbed `env -i` environment** (simulating clean CI).

## Root causes → fixes

| Test | Leak | Fix |
|------|------|-----|
| `hardware/test_pve` (2) | `detect_proxmox_host()` cgroup-v2 marker read real `/proc/1/environ` (`container=lxc`), `/dev/.lxc`, `/run/systemd/container` — never patched | autouse fixture points all three at missing tmp paths |
| `cli/test_agent_shim` (2) | hardcoded "stale" `HERMES_WEB_DIST` path is a real dir on the box | scope under `tmp_path` |
| `api/test_comfyui_phase4` (2) | `COMFYUI_DATA_DIR` fallback scanned real `/mnt/ai-models/comfyui` | point at tmp |
| `api/test_comfyui_proxy` (1) | switchover fell back to real `systemctl`/`docker` probes | use existing `_patch()` stub |
| `providers/test_flm_container_spec` + `test_container_spec_dispatch` (2) | spec renderer read real `hal0.toml` (`flm_store`, `slots.publish_host`) | `tmp_hal0_home` fixture |
| `slot_view/test_aggregator` (4) | status escalation shelled out to real `systemctl is-active` | autouse fixture stubs `subprocess.run` |
| `api/test_config_urls` + `test_services_page` (2) | live `systemctl is-active` + real `127.0.0.1:8000/health` probe | mock the probes |
| `api/test_models_preview` (1) | `/api/models` merged live `flm_served_models()` | stub to `[]` |
| `api/test_settings_models_store` (1) | root bypasses `os.access(W_OK)` on a `0o555` dir | monkeypatch `os.access` for the read-only path |
| `api/test_memory_honcho_routes` (1) | `MigrateState()` default is hardcoded abs path with a real prior run | patch to tmp (matches sibling tests) |
| `cli/test_agent_install_hermes` (1) | `_chown_hermes_trees` ran real `chown` as root | neutralize, matching existing stub style |

## Verification
- Full suite on-box: **5442 passed, 9 skipped, 0 failed**.
- Every touched test also green under `env -i PATH=... HOME=tmp HAL0_HOME=tmp`.
- `ruff check src tests` clean; `ruff format --check` clean.

Ref #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)