### PR TITLE
test(coverage): entry-point smoke tests for five 0%-coverage modules

### DIFF
--- a/tests/agents/hermes/__init__.py
+++ b/tests/agents/hermes/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for src/hal0/agents/hermes/ (Hermes agent internals)."""

--- a/tests/agents/hermes/plugins/__init__.py
+++ b/tests/agents/hermes/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for src/hal0/agents/hermes/plugins/ (canonical Hermes plugin sources)."""

--- a/tests/agents/hermes/plugins/test_memory_hindsight_plugin.py
+++ b/tests/agents/hermes/plugins/test_memory_hindsight_plugin.py
@@ -1,0 +1,665 @@
+"""hal0-memory Hermes plugin (canonical src copy) — hermetic unit coverage.
+
+``src/hal0/agents/hermes/plugins/memory_hindsight/`` is the canonical source
+for the shipped hal0-memory plugin (its installer seed at
+``installer/agents/hermes/plugins/hal0-memory/`` is pinned byte-identical in
+``tests/agents/hermes_plugins/test_seed_parity.py``). The seed's REST-client
+contract is already exercised via importlib against the *installer* copy in
+``tests/agents/test_hal0_memory_client.py`` — that suite never imports this
+package directly, so this file's own statements stay at 0% coverage without
+it. This file imports the package the normal way (``hal0.agents.hermes...``)
+so coverage attributes to the real source file.
+
+Everything here is pure / mocked:
+
+* ``register(ctx)`` is exercised with a stub ``ctx``.
+* ``Hal0MemoryProvider`` is exercised with an injected ``Hal0MemoryClient``
+  mock (or ``client=None`` for the not-yet-initialized paths) — no network.
+* ``Hal0MemoryClient`` is exercised against a duck-typed fake HTTP client
+  (same shape as ``tests/agents/test_hal0_memory_client.py``'s
+  ``_FakeHttpClient``) that records calls and never touches a socket.
+
+``provider.py`` falls back to a vendored ``MemoryProvider`` ABC stub when the
+real ``agent.memory_provider`` module (only importable inside the Hermes
+agent venv) is absent, so no ``importorskip`` is needed here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from hal0.agents.hermes.plugins.memory_hindsight import Hal0MemoryProvider, register
+from hal0.agents.hermes.plugins.memory_hindsight._client import (
+    DEFAULT_AGENT_ID,
+    DEFAULT_BASE_URL,
+    Hal0MemoryClient,
+    Hal0MemoryClientError,
+    _resolve_agent_id,
+    _resolve_base_url,
+)
+from hal0.agents.hermes.plugins.memory_hindsight.provider import ALL_TOOL_SCHEMAS
+
+# ── register(ctx) / construction ──────────────────────────────────────────
+
+
+class _FakeCtx:
+    """Stub loader context — records ``register_memory_provider`` calls."""
+
+    def __init__(self) -> None:
+        self.registered: list[object] = []
+
+    def register_memory_provider(self, provider: object) -> None:
+        self.registered.append(provider)
+
+
+def test_register_registers_a_hal0_memory_provider() -> None:
+    ctx = _FakeCtx()
+    register(ctx)
+    assert len(ctx.registered) == 1
+    assert isinstance(ctx.registered[0], Hal0MemoryProvider)
+
+
+def test_hal0_memory_provider_is_constructable_and_named() -> None:
+    provider = Hal0MemoryProvider()
+    assert provider.name == "hal0-memory"
+    assert provider.is_available() is True
+
+
+# ── _resolve_base_url / _resolve_agent_id ─────────────────────────────────
+
+
+def test_resolve_base_url_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_MEMORY_BASE", "http://env-host:1/")
+    assert _resolve_base_url("http://override:9/") == "http://override:9"
+
+
+def test_resolve_base_url_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_MEMORY_BASE", "http://env-host:1/")
+    assert _resolve_base_url(None) == "http://env-host:1"
+
+
+def test_resolve_base_url_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_MEMORY_BASE", raising=False)
+    assert _resolve_base_url(None) == DEFAULT_BASE_URL
+
+
+def test_resolve_agent_id_prefers_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_AGENT_ID", "other")
+    assert _resolve_agent_id("mine") == "mine"
+
+
+def test_resolve_agent_id_falls_back_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_AGENT_ID", "other")
+    assert _resolve_agent_id(None) == "other"
+
+
+def test_resolve_agent_id_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_AGENT_ID", raising=False)
+    assert _resolve_agent_id(None) == DEFAULT_AGENT_ID
+
+
+# ── Hal0MemoryClient: request shaping over a fake HTTP client ─────────────
+
+
+class _FakeResponse:
+    """Duck-typed stand-in for ``httpx.Response`` — no network involved."""
+
+    def __init__(self, *, status_code: int = 200, json_body: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+
+    def json(self) -> Any:
+        if self._json_body is None:
+            raise ValueError("no JSON body configured")
+        return self._json_body
+
+
+class _FakeHttpClient:
+    """Duck-typed stand-in for ``httpx.Client`` — records calls, no sockets."""
+
+    def __init__(
+        self, *, response: _FakeResponse | None = None, raises: Exception | None = None
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._response = (
+            response if response is not None else _FakeResponse(json_body={"status": "ok"})
+        )
+        self._raises = raises
+        self.closed = False
+
+    def request(self, method, path, *, headers=None, json=None, params=None):
+        self.calls.append(
+            {"method": method, "path": path, "headers": headers, "json": json, "params": params}
+        )
+        if self._raises is not None:
+            raise self._raises
+        return self._response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_client_error_carries_message_and_optional_status_code() -> None:
+    err = Hal0MemoryClientError("boom")
+    assert str(err) == "boom"
+    assert err.status_code is None
+
+    err2 = Hal0MemoryClientError("boom2", status_code=500)
+    assert err2.status_code == 500
+
+
+def test_client_defaults_base_url_and_agent_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_MEMORY_BASE", raising=False)
+    monkeypatch.delenv("HAL0_AGENT_ID", raising=False)
+    client = Hal0MemoryClient()
+    try:
+        assert client.base_url == DEFAULT_BASE_URL
+        assert client.agent_id == DEFAULT_AGENT_ID
+    finally:
+        client.close()
+
+
+def test_client_add_posts_expected_payload_and_headers() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"status": "ok", "id": "m1"}))
+    client = Hal0MemoryClient(agent_id="hermes", http_client=http)
+
+    result = client.add("hello", tags=["a"], metadata={"k": "v"}, private=True)
+
+    assert len(http.calls) == 1
+    call = http.calls[0]
+    assert call["method"] == "POST"
+    assert call["path"] == "/api/memory/add"
+    assert call["json"] == {"text": "hello", "tags": ["a"], "metadata": {"k": "v"}}
+    assert "dataset" not in call["json"]  # #317: never send a dataset field
+    assert call["headers"]["X-hal0-Agent"] == "hermes"
+    assert call["headers"]["X-hal0-Private"] == "1"
+    assert result == {"status": "ok", "id": "m1"}
+
+
+def test_client_add_shared_sets_private_header_zero() -> None:
+    http = _FakeHttpClient()
+    client = Hal0MemoryClient(agent_id="hermes", http_client=http)
+    client.add("hello", private=False)
+    assert http.calls[0]["headers"]["X-hal0-Private"] == "0"
+
+
+def test_client_add_omits_tags_and_metadata_when_none() -> None:
+    http = _FakeHttpClient()
+    client = Hal0MemoryClient(http_client=http)
+    client.add("hello")
+    assert http.calls[0]["json"] == {"text": "hello"}
+
+
+def test_client_search_posts_query_and_limit() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"items": []}))
+    client = Hal0MemoryClient(http_client=http)
+    client.search("hello", limit=5)
+    call = http.calls[0]
+    assert call["method"] == "POST"
+    assert call["path"] == "/api/memory/search"
+    assert call["json"] == {"query": "hello", "limit": 5}
+    assert call["headers"]["X-hal0-Private"] == "1"
+
+
+def test_client_recall_omits_types_by_default() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"items": []}))
+    client = Hal0MemoryClient(http_client=http)
+    client.recall("hello", max_tokens=123)
+    assert http.calls[0]["json"] == {"query": "hello", "max_tokens": 123}
+
+
+def test_client_recall_includes_types_when_given() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"items": []}))
+    client = Hal0MemoryClient(http_client=http)
+    client.recall("hello", types=["world"], max_tokens=99)
+    assert http.calls[0]["json"]["types"] == ["world"]
+
+
+def test_client_list_items_is_a_get_with_limit_param() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"items": []}))
+    client = Hal0MemoryClient(http_client=http)
+    client.list_items(limit=7)
+    call = http.calls[0]
+    assert call["method"] == "GET"
+    assert call["path"] == "/api/memory/list"
+    assert call["params"] == {"limit": 7}
+    assert call["json"] is None
+
+
+def test_client_delete_posts_ids_list() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body={"status": "ok"}))
+    client = Hal0MemoryClient(http_client=http)
+    client.delete("mem-1")
+    assert http.calls[0]["json"] == {"ids": ["mem-1"]}
+
+
+def test_client_request_raises_on_4xx_with_status_code() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(status_code=404, text="nope"))
+    client = Hal0MemoryClient(http_client=http)
+    with pytest.raises(Hal0MemoryClientError) as excinfo:
+        client.search("q")
+    assert excinfo.value.status_code == 404
+    assert "nope" in str(excinfo.value)
+
+
+def test_client_request_wraps_transport_error() -> None:
+    http = _FakeHttpClient(raises=httpx.ConnectError("boom"))
+    client = Hal0MemoryClient(http_client=http)
+    with pytest.raises(Hal0MemoryClientError):
+        client.search("q")
+
+
+def test_client_request_falls_back_to_raw_text_on_non_json_response() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body=None, text="not-json"))
+    client = Hal0MemoryClient(http_client=http)
+    assert client.search("q") == {"status": "ok", "raw": "not-json"}
+
+
+def test_client_request_wraps_non_dict_json_body() -> None:
+    http = _FakeHttpClient(response=_FakeResponse(json_body=[1, 2, 3]))
+    client = Hal0MemoryClient(http_client=http)
+    assert client.search("q") == {"status": "ok", "raw": [1, 2, 3]}
+
+
+def test_client_close_closes_owned_client() -> None:
+    client = Hal0MemoryClient(base_url="http://testserver")
+    client.close()
+    assert client._client.is_closed
+
+
+def test_client_close_does_not_close_injected_client() -> None:
+    http = _FakeHttpClient()
+    client = Hal0MemoryClient(http_client=http)
+    client.close()
+    assert http.closed is False
+
+
+# ── Hal0MemoryProvider: lifecycle ─────────────────────────────────────────
+
+
+def test_initialize_builds_client_from_env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HAL0_MEMORY_BASE", raising=False)
+    monkeypatch.delenv("HAL0_AGENT_ID", raising=False)
+    provider = Hal0MemoryProvider()
+    provider.initialize("session-1")
+    try:
+        assert provider._session_id == "session-1"
+        assert provider._agent_context == "primary"
+        assert provider._client is not None
+        assert provider._client.base_url == DEFAULT_BASE_URL
+        assert provider._client.agent_id == DEFAULT_AGENT_ID
+    finally:
+        provider.shutdown()
+
+
+def test_initialize_respects_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HAL0_MEMORY_BASE", "http://box:8080/")
+    monkeypatch.setenv("HAL0_AGENT_ID", "custom-agent")
+    provider = Hal0MemoryProvider()
+    provider.initialize()
+    try:
+        assert provider._client.base_url == "http://box:8080"
+        assert provider._client.agent_id == "custom-agent"
+    finally:
+        provider.shutdown()
+
+
+def test_initialize_uses_client_override_and_skips_env_lookup() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize("s1", agent_context="flush")
+    assert provider._client is fake_client
+    assert provider._agent_context == "flush"
+
+
+def test_initialize_session_id_kwarg_fallback() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize(session_id="from-kwarg")
+    assert provider._session_id == "from-kwarg"
+    assert provider._agent_context == "primary"
+
+
+def test_agent_id_defaults_before_initialize() -> None:
+    provider = Hal0MemoryProvider()
+    assert provider._agent_id() == "hermes"
+
+
+def test_agent_id_reflects_client_after_initialize() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.agent_id = "hermes-2"
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    assert provider._agent_id() == "hermes-2"
+
+
+def test_shutdown_closes_client_and_clears_reference() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.shutdown()
+    fake_client.close.assert_called_once()
+    assert provider._client is None
+
+
+def test_shutdown_is_a_noop_without_initialize() -> None:
+    provider = Hal0MemoryProvider()
+    provider.shutdown()  # must not raise
+    assert provider._client is None
+
+
+# ── system_prompt_block ───────────────────────────────────────────────────
+
+
+def test_system_prompt_block_mentions_private_bank_name() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.agent_id = "hermes"
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    block = provider.system_prompt_block()
+    assert "private:hermes" in block
+    assert "hal0_memory_search" in block
+    assert "hal0_memory_add" in block
+
+
+# ── prefetch ───────────────────────────────────────────────────────────────
+
+
+def test_prefetch_returns_empty_for_empty_query() -> None:
+    provider = Hal0MemoryProvider(client=Mock(spec=Hal0MemoryClient))
+    provider.initialize()
+    assert provider.prefetch("") == ""
+
+
+def test_prefetch_returns_empty_when_client_not_initialized() -> None:
+    provider = Hal0MemoryProvider()
+    assert provider.prefetch("query") == ""
+
+
+def test_prefetch_formats_items_as_bullets() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.return_value = {
+        "items": [{"text": "fact one"}, {"content": "fact two"}, {"text": ""}]
+    }
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = provider.prefetch("q")
+    fake_client.recall.assert_called_once_with("q", max_tokens=2048)
+    assert out == "## hal0-memory recall\n- fact one\n- fact two"
+
+
+def test_prefetch_returns_empty_when_no_usable_items() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.return_value = {"items": [{}, {"text": ""}]}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    assert provider.prefetch("q") == ""
+
+
+def test_prefetch_skips_non_dict_items() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.return_value = {"items": ["not-a-dict", {"text": "kept"}]}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    assert provider.prefetch("q") == "## hal0-memory recall\n- kept"
+
+
+def test_prefetch_returns_empty_when_items_missing_or_not_a_list() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.return_value = {"items": None}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    assert provider.prefetch("q") == ""
+
+
+def test_prefetch_swallows_client_error() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.side_effect = Hal0MemoryClientError("boom")
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    assert provider.prefetch("q") == ""
+
+
+# ── sync_turn ────────────────────────────────────────────────────────────
+
+
+def test_sync_turn_noop_when_no_client() -> None:
+    provider = Hal0MemoryProvider()
+    provider.sync_turn("hi", "hello")  # must not raise
+
+
+def test_sync_turn_noop_when_both_contents_empty() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.sync_turn("", "")
+    fake_client.add.assert_not_called()
+
+
+@pytest.mark.parametrize("context", ["cron", "flush", "subagent"])
+def test_sync_turn_noop_for_skip_write_contexts(context: str) -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize(agent_context=context)
+    provider.sync_turn("hi", "hello")
+    fake_client.add.assert_not_called()
+
+
+def test_sync_turn_writes_formatted_transcript() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.sync_turn("hi", "hello")
+    fake_client.add.assert_called_once_with(
+        "User: hi\nAssistant: hello", tags=["chat", "agent:hermes"], private=True
+    )
+
+
+def test_sync_turn_swallows_client_error() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.add.side_effect = Hal0MemoryClientError("boom")
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.sync_turn("hi", "hello")  # must not raise
+
+
+# ── tool schemas + dispatch ────────────────────────────────────────────────
+
+
+def test_get_tool_schemas_returns_a_copy_of_all_three() -> None:
+    provider = Hal0MemoryProvider()
+    schemas = provider.get_tool_schemas()
+    assert schemas == ALL_TOOL_SCHEMAS
+    assert schemas is not ALL_TOOL_SCHEMAS
+    assert {s["name"] for s in schemas} == {
+        "hal0_memory_search",
+        "hal0_memory_recall",
+        "hal0_memory_add",
+    }
+
+
+def test_handle_tool_call_errors_without_client() -> None:
+    provider = Hal0MemoryProvider()
+    out = json.loads(provider.handle_tool_call("hal0_memory_search", {"query": "q"}))
+    assert out["status"] == "error"
+
+
+def test_handle_tool_call_search_missing_query() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_search", {"query": "  "}))
+    assert out["status"] == "error"
+    fake_client.search.assert_not_called()
+
+
+def test_handle_tool_call_search_dispatches_with_limit() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.search.return_value = {"items": []}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_search", {"query": "q", "limit": 3}))
+    fake_client.search.assert_called_once_with("q", limit=3)
+    assert out == {"items": []}
+
+
+def test_handle_tool_call_search_default_limit_is_ten() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.search.return_value = {"items": []}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.handle_tool_call("hal0_memory_search", {"query": "q"})
+    fake_client.search.assert_called_once_with("q", limit=10)
+
+
+def test_handle_tool_call_recall_missing_query() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_recall", {"query": ""}))
+    assert out["status"] == "error"
+
+
+def test_handle_tool_call_recall_dispatches_with_max_tokens() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.recall.return_value = {"items": []}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.handle_tool_call("hal0_memory_recall", {"query": "q", "max_tokens": 512})
+    fake_client.recall.assert_called_once_with("q", max_tokens=512)
+
+
+def test_handle_tool_call_add_missing_text() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_add", {"text": "   "}))
+    assert out["status"] == "error"
+    fake_client.add.assert_not_called()
+
+
+def test_handle_tool_call_add_private_default_sets_bank() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.agent_id = "hermes"
+    fake_client.add.return_value = {"status": "ok", "id": "m1"}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_add", {"text": "fact"}))
+    fake_client.add.assert_called_once_with("fact", tags=["agent:hermes"], private=True)
+    assert out["bank"] == "private:hermes"
+
+
+def test_handle_tool_call_add_shared_sets_bank_and_private_false() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.add.return_value = {"status": "ok"}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_add", {"text": "fact", "shared": True}))
+    fake_client.add.assert_called_once_with("fact", tags=["agent:hermes"], private=False)
+    assert out["bank"] == "shared"
+
+
+def test_handle_tool_call_add_custom_tags() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.add.return_value = {"status": "ok"}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.handle_tool_call("hal0_memory_add", {"text": "fact", "tags": ["a", "b"]})
+    fake_client.add.assert_called_once_with("fact", tags=["a", "b"], private=True)
+
+
+def test_handle_tool_call_add_does_not_overwrite_existing_error_result() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.add.return_value = {"error": "boom"}
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_add", {"text": "fact"}))
+    assert "bank" not in out
+
+
+def test_handle_tool_call_unknown_tool() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("nope", {}))
+    assert out["status"] == "error"
+    assert "nope" in out["error"]
+
+
+def test_handle_tool_call_swallows_client_error() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.search.side_effect = Hal0MemoryClientError("boom")
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    out = json.loads(provider.handle_tool_call("hal0_memory_search", {"query": "q"}))
+    assert out == {"status": "error", "error": "boom"}
+
+
+# ── on_memory_write ─────────────────────────────────────────────────────
+
+
+def test_on_memory_write_noop_for_non_add_action() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.on_memory_write("delete", "t", "content")
+    fake_client.add.assert_not_called()
+
+
+def test_on_memory_write_noop_without_client() -> None:
+    provider = Hal0MemoryProvider()
+    provider.on_memory_write("add", "t", "content")  # must not raise
+
+
+def test_on_memory_write_noop_for_empty_content() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.on_memory_write("add", "t", "")
+    fake_client.add.assert_not_called()
+
+
+@pytest.mark.parametrize("context", ["cron", "flush", "subagent"])
+def test_on_memory_write_noop_for_skip_write_contexts(context: str) -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize(agent_context=context)
+    provider.on_memory_write("add", "t", "content")
+    fake_client.add.assert_not_called()
+
+
+def test_on_memory_write_adds_with_target_tag() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.on_memory_write("add", "note", "content", metadata={"k": "v"})
+    fake_client.add.assert_called_once_with(
+        "content",
+        tags=["builtin-memory", "agent:hermes", "note"],
+        metadata={"k": "v"},
+        private=True,
+    )
+
+
+def test_on_memory_write_without_target_uses_base_tags() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.on_memory_write("add", "", "content")
+    fake_client.add.assert_called_once_with(
+        "content", tags=["builtin-memory", "agent:hermes"], metadata=None, private=True
+    )
+
+
+def test_on_memory_write_swallows_client_error() -> None:
+    fake_client = Mock(spec=Hal0MemoryClient)
+    fake_client.add.side_effect = Hal0MemoryClientError("boom")
+    provider = Hal0MemoryProvider(client=fake_client)
+    provider.initialize()
+    provider.on_memory_write("add", "t", "content")  # must not raise

--- a/tests/config/test_network.py
+++ b/tests/config/test_network.py
@@ -1,0 +1,278 @@
+"""Tests for hal0.config.network — the HAL0_BIND_HOST-derived network shape.
+
+Covers bind_host()'s env precedence/defaulting, hostname()'s HAL0_HOSTNAME
+override + gethostname() fallback + .local-suffix stripping,
+detect_lan_ips()'s psutil-then-UDP-trick fallback chain, and
+derive_allowed_origins()'s loopback/wildcard/concrete-bind_host branches
+(#1099, installer-setup WS-C).
+
+Fully hermetic: an autouse fixture clears HAL0_BIND_HOST/HAL0_HOSTNAME/
+HAL0_PORT and pins socket.gethostname() to a fixed value, so nothing here
+depends on the host running the suite.
+"""
+
+from __future__ import annotations
+
+import socket
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from hal0.config import network
+
+_FIXED_HOSTNAME = "cibox"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_network_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear the module's env vars and pin gethostname() for every test."""
+    for var in ("HAL0_BIND_HOST", "HAL0_HOSTNAME", "HAL0_PORT"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(socket, "gethostname", lambda: _FIXED_HOSTNAME)
+
+
+# ── module surface ───────────────────────────────────────────────────────────
+
+
+def test_all_exports_are_callable() -> None:
+    assert set(network.__all__) == {
+        "bind_host",
+        "derive_allowed_origins",
+        "detect_lan_ips",
+        "hostname",
+    }
+    for name in network.__all__:
+        assert callable(getattr(network, name)), f"network.{name} is not callable"
+
+
+# ── bind_host() ───────────────────────────────────────────────────────────────
+
+
+class TestBindHost:
+    def test_default_when_unset(self) -> None:
+        assert network.bind_host() == "127.0.0.1"
+
+    def test_explicit_value_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+        assert network.bind_host() == "0.0.0.0"
+
+    def test_strips_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "  10.0.0.5  ")
+        assert network.bind_host() == "10.0.0.5"
+
+    def test_empty_string_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "")
+        assert network.bind_host() == "127.0.0.1"
+
+    def test_whitespace_only_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "   ")
+        assert network.bind_host() == "127.0.0.1"
+
+
+# ── hostname() ────────────────────────────────────────────────────────────────
+
+
+class TestHostname:
+    def test_default_uses_gethostname(self) -> None:
+        assert network.hostname() == _FIXED_HOSTNAME
+
+    def test_env_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_HOSTNAME", "myhost")
+        assert network.hostname() == "myhost"
+
+    def test_env_local_suffix_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_HOSTNAME", "myhost.local")
+        assert network.hostname() == "myhost"
+
+    def test_env_trailing_dots_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_HOSTNAME", "myhost.")
+        assert network.hostname() == "myhost"
+
+    def test_gethostname_local_suffix_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(socket, "gethostname", lambda: "box.local")
+        assert network.hostname() == "box"
+
+    def test_dots_only_falls_back_to_hal0(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_HOSTNAME", ".")
+        assert network.hostname() == "hal0"
+
+    def test_env_whitespace_only_falls_back_to_gethostname(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HAL0_HOSTNAME", "   ")
+        assert network.hostname() == _FIXED_HOSTNAME
+
+
+# ── detect_lan_ips() ──────────────────────────────────────────────────────────
+
+
+class TestDetectLanIps:
+    def test_psutil_finds_non_loopback_ipv4(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            psutil,
+            "net_if_addrs",
+            lambda: {
+                "eth0": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.5")],
+                "lo": [SimpleNamespace(family=socket.AF_INET, address="127.0.0.1")],
+                "eth1": [SimpleNamespace(family=socket.AF_INET6, address="fe80::1")],
+            },
+        )
+        assert network.detect_lan_ips() == ["10.0.0.5"]
+
+    def test_dedupes_and_sorts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            psutil,
+            "net_if_addrs",
+            lambda: {
+                "eth0": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.5")],
+                "eth1": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.5")],
+                "eth2": [SimpleNamespace(family=socket.AF_INET, address="10.0.0.1")],
+            },
+        )
+        assert network.detect_lan_ips() == ["10.0.0.1", "10.0.0.5"]
+
+    def test_falls_back_to_udp_trick_when_psutil_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            psutil,
+            "net_if_addrs",
+            lambda: {"lo": [SimpleNamespace(family=socket.AF_INET, address="127.0.0.1")]},
+        )
+
+        class _FakeSocket:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def __enter__(self) -> _FakeSocket:
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+            def connect(self, addr: tuple[str, int]) -> None:
+                pass
+
+            def getsockname(self) -> tuple[str, int]:
+                return ("192.168.1.50", 0)
+
+        monkeypatch.setattr(socket, "socket", lambda *a, **kw: _FakeSocket())
+        assert network.detect_lan_ips() == ["192.168.1.50"]
+
+    def test_udp_fallback_filters_loopback_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(psutil, "net_if_addrs", dict)
+
+        class _LoopbackSocket:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def __enter__(self) -> _LoopbackSocket:
+                return self
+
+            def __exit__(self, *exc: object) -> bool:
+                return False
+
+            def connect(self, addr: tuple[str, int]) -> None:
+                pass
+
+            def getsockname(self) -> tuple[str, int]:
+                return ("127.0.0.1", 0)
+
+        monkeypatch.setattr(socket, "socket", lambda *a, **kw: _LoopbackSocket())
+        assert network.detect_lan_ips() == []
+
+    def test_returns_empty_when_all_sources_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom_psutil() -> dict[str, object]:
+            raise RuntimeError("psutil unavailable")
+
+        def _boom_socket(*args: object, **kwargs: object) -> socket.socket:
+            raise OSError("no route to host")
+
+        monkeypatch.setattr(psutil, "net_if_addrs", _boom_psutil)
+        monkeypatch.setattr(socket, "socket", _boom_socket)
+        assert network.detect_lan_ips() == []
+
+
+# ── derive_allowed_origins() ──────────────────────────────────────────────────
+
+
+class TestDeriveAllowedOrigins:
+    def test_default_loopback_bind_excludes_lan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert origins == (
+            "http://127.0.0.1:8080",
+            f"http://{_FIXED_HOSTNAME}.local:8080",
+            "http://localhost:8080",
+        )
+
+    def test_hal0_port_env_used_when_no_arg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_PORT", "9090")
+        origins = network.derive_allowed_origins()
+        assert all(o.endswith(":9090") for o in origins)
+
+    def test_explicit_port_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_PORT", "9090")
+        origins = network.derive_allowed_origins(port=1234)
+        assert all(o.endswith(":1234") for o in origins)
+
+    def test_invalid_port_env_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_PORT", "not-a-number")
+        origins = network.derive_allowed_origins()
+        assert all(o.endswith(":8080") for o in origins)
+
+    def test_localhost_bind_host_excludes_lan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "localhost")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert not any("10.0.0.9" in o for o in origins)
+
+    def test_ipv6_loopback_bind_host_excludes_lan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "::1")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert not any("10.0.0.9" in o for o in origins)
+
+    def test_wildcard_bind_adds_lan_but_not_bind_host_itself(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "0.0.0.0")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9", "10.0.0.10"])
+        origins = network.derive_allowed_origins()
+        assert "http://10.0.0.9:8080" in origins
+        assert "http://10.0.0.10:8080" in origins
+        assert not any("0.0.0.0" in o for o in origins)
+
+    def test_ipv6_wildcard_bind_adds_lan_but_not_bind_host_itself(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "::")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert "http://10.0.0.9:8080" in origins
+        assert not any(o.startswith("http://:") for o in origins)
+
+    def test_concrete_lan_bind_host_adds_lan_and_itself(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "192.168.1.20")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert "http://10.0.0.9:8080" in origins
+        assert "http://192.168.1.20:8080" in origins
+
+    def test_always_includes_loopback_and_hostname(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "192.168.1.20")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: [])
+        origins = network.derive_allowed_origins()
+        assert "http://localhost:8080" in origins
+        assert "http://127.0.0.1:8080" in origins
+        assert f"http://{_FIXED_HOSTNAME}.local:8080" in origins
+
+    def test_result_is_sorted_tuple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HAL0_BIND_HOST", "192.168.1.20")
+        monkeypatch.setattr(network, "detect_lan_ips", lambda: ["10.0.0.9"])
+        origins = network.derive_allowed_origins()
+        assert isinstance(origins, tuple)
+        assert origins == tuple(sorted(origins))

--- a/tests/mcp/test_browser_server_smoke.py
+++ b/tests/mcp/test_browser_server_smoke.py
@@ -1,0 +1,148 @@
+"""hal0.mcp.browser_server — smoke coverage for the pure, browser-free surface.
+
+``browser_server.py`` imports Playwright at module scope (to launch a real
+persistent Chromium instance) and the real ``mcp`` SDK's ``FastMCP``. Neither
+is guaranteed in a clean CI environment, so this whole module is guarded with
+``importorskip`` — it skips cleanly wherever playwright/chromium isn't
+installed, same as a dev box without the browser extra.
+
+Where the deps ARE present, this exercises:
+
+* ``_selector`` — pure by-strategy selector string builder (no browser).
+* ``_trim_snapshot`` — pure recursive accessibility-tree trimmer (no browser).
+* Tool registration — that every ``@mcp.tool()`` primitive is present in
+  ``mcp.list_tools()`` (registration/wiring only; no tool is ever called,
+  since every one of them requires a live ``Page``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_playwright = pytest.importorskip("playwright", reason="playwright/chromium not installed")
+_fastmcp = pytest.importorskip("mcp.server.fastmcp", reason="mcp SDK not installed")
+
+from hal0.mcp import browser_server as bs  # noqa: E402
+
+# ── _selector ──────────────────────────────────────────────────────────────
+
+
+def test_selector_css_is_passthrough() -> None:
+    assert bs._selector("css", ".foo") == ".foo"
+
+
+def test_selector_text_wraps_in_text_equals() -> None:
+    assert bs._selector("text", "Submit") == 'text="Submit"'
+
+
+def test_selector_xpath_is_passthrough() -> None:
+    assert bs._selector("xpath", "//button") == "//button"
+
+
+def test_selector_id_prefixes_hash() -> None:
+    assert bs._selector("id", "myid") == "#myid"
+
+
+def test_selector_role_builds_attribute_selector() -> None:
+    assert bs._selector("role", "button") == '[role="button"]'
+
+
+def test_selector_testid_builds_data_testid_selector() -> None:
+    assert bs._selector("testid", "submit-btn") == '[data-testid="submit-btn"]'
+
+
+def test_selector_placeholder_builds_attribute_selector() -> None:
+    assert bs._selector("placeholder", "Email") == '[placeholder="Email"]'
+
+
+def test_selector_unknown_strategy_falls_back_to_raw_value() -> None:
+    assert bs._selector("bogus-strategy", "whatever") == "whatever"
+
+
+# ── _trim_snapshot ─────────────────────────────────────────────────────────
+
+
+def test_trim_snapshot_basic_shape() -> None:
+    node = {"role": "button", "name": "Submit", "children": []}
+    out = bs._trim_snapshot(node, max_depth=6, max_children=30)
+    assert out == {"role": "button", "name": "Submit"}
+
+
+def test_trim_snapshot_defaults_missing_role_and_name() -> None:
+    out = bs._trim_snapshot({}, max_depth=6, max_children=30)
+    assert out["role"] == "unknown"
+    assert out["name"] == ""
+
+
+def test_trim_snapshot_truncates_name_to_200_chars() -> None:
+    node = {"role": "text", "name": "x" * 500}
+    out = bs._trim_snapshot(node, max_depth=6, max_children=30)
+    assert len(out["name"]) == 200
+
+
+def test_trim_snapshot_returns_none_past_max_depth() -> None:
+    assert bs._trim_snapshot({"role": "a"}, max_depth=0, max_children=5, depth=1) is None
+
+
+def test_trim_snapshot_recurses_into_children() -> None:
+    node = {
+        "role": "list",
+        "name": "",
+        "children": [
+            {"role": "item", "name": "one"},
+            {"role": "item", "name": "two"},
+        ],
+    }
+    out = bs._trim_snapshot(node, max_depth=6, max_children=30)
+    assert [c["role"] for c in out["children"]] == ["item", "item"]
+
+
+def test_trim_snapshot_caps_children_at_max_children() -> None:
+    node = {
+        "role": "list",
+        "name": "",
+        "children": [{"role": "item", "name": str(i)} for i in range(50)],
+    }
+    out = bs._trim_snapshot(node, max_depth=6, max_children=5)
+    assert len(out["children"]) == 5
+
+
+def test_trim_snapshot_omits_children_key_at_max_depth() -> None:
+    node = {"role": "list", "name": "", "children": [{"role": "item", "name": "x"}]}
+    out = bs._trim_snapshot(node, max_depth=0, max_children=30)
+    assert "children" not in out
+
+
+def test_trim_snapshot_recurses_multiple_levels_within_max_depth() -> None:
+    node = {
+        "role": "root",
+        "name": "",
+        "children": [
+            {"role": "leaf", "name": "deep", "children": [{"role": "leaf2", "name": "deeper"}]}
+        ],
+    }
+    out = bs._trim_snapshot(node, max_depth=2, max_children=30)
+    assert out["children"][0]["name"] == "deep"
+    assert out["children"][0]["children"][0]["name"] == "deeper"
+
+
+# ── Tool registration (wiring only, no browser calls) ─────────────────────
+
+
+def test_mcp_server_is_named_hal0_browser() -> None:
+    assert bs.mcp.name == "hal0-browser"
+
+
+async def test_all_browser_tools_are_registered() -> None:
+    tools = await bs.mcp.list_tools()
+    names = {t.name for t in tools}
+    assert names == {
+        "browser_navigate",
+        "browser_screenshot",
+        "browser_click",
+        "browser_type",
+        "browser_extract",
+        "browser_evaluate",
+        "browser_snapshot",
+        "browser_close_page",
+    }

--- a/tests/slots/test_ttft_samples.py
+++ b/tests/slots/test_ttft_samples.py
@@ -1,0 +1,207 @@
+"""Tests for the rolling TTFT sample window + fleet-wide aggregation.
+
+``hal0.slots.ttft_samples`` is pure stdlib (time, collections.deque,
+dataclasses) — no I/O, no asyncio. Every test here drives the module
+with explicit ``now``/timestamp values so nothing depends on
+wall-clock timing or real sleeps; the module's own ``time.monotonic()``
+fallback is only exercised implicitly (its return type, not its value,
+matters) so tests stay deterministic under CI load.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from hal0.slots.ttft_samples import (
+    DEFAULT_WINDOW_S,
+    SlotSamples,
+    avg_kv_cache_across,
+    avg_ttft_across,
+    samples_from_events,
+)
+
+
+def test_default_window_matches_module_constant() -> None:
+    s = SlotSamples()
+    assert s.window_s == DEFAULT_WINDOW_S == 60.0
+    assert s.ttft_samples.maxlen == 128
+    assert s.inflight == {}
+    assert s.throughput_tps == 0.0
+    assert s.kv_occupancy_pct == 0.0
+
+
+def test_request_started_then_first_chunk_records_ttft() -> None:
+    s = SlotSamples()
+    s.request_started("req-1", now=100.0)
+    ttft = s.first_chunk("req-1", now=100.25)
+    assert ttft == 0.25
+    assert list(s.ttft_samples) == [(100.25, 0.25)]
+    # The request is no longer tracked as inflight once its first chunk lands.
+    assert "req-1" not in s.inflight
+
+
+def test_first_chunk_for_unknown_request_returns_none_and_records_nothing() -> None:
+    s = SlotSamples()
+    assert s.first_chunk("never-started", now=10.0) is None
+    assert list(s.ttft_samples) == []
+
+
+def test_first_chunk_clamps_negative_delta_to_zero() -> None:
+    """Defensive clamp: if `now` regresses relative to the recorded start
+    (clock skew / bad caller), the TTFT floors at 0.0 instead of going
+    negative."""
+    s = SlotSamples()
+    s.request_started("req-1", now=100.0)
+    ttft = s.first_chunk("req-1", now=99.0)
+    assert ttft == 0.0
+    assert list(s.ttft_samples) == [(99.0, 0.0)]
+
+
+def test_request_cancelled_drops_inflight_without_recording_a_sample() -> None:
+    s = SlotSamples()
+    s.request_started("req-1", now=100.0)
+    s.request_cancelled("req-1")
+    assert "req-1" not in s.inflight
+    # A subsequent first_chunk for the same id is now untracked.
+    assert s.first_chunk("req-1", now=101.0) is None
+    assert list(s.ttft_samples) == []
+
+
+def test_request_cancelled_is_a_noop_for_unknown_id() -> None:
+    s = SlotSamples()
+    s.request_cancelled("ghost")  # must not raise
+    assert s.inflight == {}
+
+
+def test_current_ttft_and_avg_with_no_samples_is_none() -> None:
+    s = SlotSamples()
+    assert s.current_ttft(now=100.0) is None
+    assert s.avg_ttft(now=100.0) is None
+    assert s.sample_count(now=100.0) == 0
+
+
+def test_current_ttft_returns_the_latest_sample() -> None:
+    s = SlotSamples()
+    s.ttft_samples.append((10.0, 0.1))
+    s.ttft_samples.append((20.0, 0.3))
+    s.ttft_samples.append((30.0, 0.5))
+    assert s.current_ttft(now=30.0) == 0.5
+
+
+def test_avg_ttft_is_windowed_mean_of_recent_samples() -> None:
+    s = SlotSamples(window_s=60.0)
+    s.ttft_samples.append((0.0, 0.1))
+    s.ttft_samples.append((10.0, 0.2))
+    s.ttft_samples.append((20.0, 0.3))
+    # All three are within 60s of now=20.0.
+    assert s.avg_ttft(now=20.0) == pytest.approx((0.1 + 0.2 + 0.3) / 3)
+    assert s.sample_count(now=20.0) == 3
+
+
+def test_stale_samples_are_evicted_from_reads_past_the_window() -> None:
+    """A sample older than `window_s` must be excluded from current/avg/count
+    reads, without a real sleep — we just advance the injected `now`."""
+    s = SlotSamples(window_s=60.0)
+    s.ttft_samples.append((0.0, 0.9))  # will go stale
+    s.ttft_samples.append((100.0, 0.1))  # stays fresh
+
+    # now=100.0: the ts=0.0 sample is exactly 100s old > 60s window -> stale.
+    assert s.sample_count(now=100.0) == 1
+    assert s.current_ttft(now=100.0) == 0.1
+    assert s.avg_ttft(now=100.0) == 0.1
+
+    # Advance further: still just the one fresh sample, until it too ages out.
+    assert s.sample_count(now=159.9) == 1
+    assert s.sample_count(now=200.0) == 0
+    assert s.current_ttft(now=200.0) is None
+    assert s.avg_ttft(now=200.0) is None
+
+
+def test_window_cutoff_boundary_is_inclusive() -> None:
+    """`_recent` keeps samples with ``ts >= now - window_s`` (a sample
+    landing exactly on the cutoff is still in-window, not stale)."""
+    s = SlotSamples(window_s=60.0)
+    s.ttft_samples.append((40.0, 0.4))
+    # now - window_s == 40.0 == ts -> included (">=", not ">").
+    assert s.sample_count(now=100.0) == 1
+    assert s.current_ttft(now=100.0) == 0.4
+    # One tick past the boundary, it drops out.
+    assert s.sample_count(now=100.0000001) == 0
+
+
+def test_ttft_samples_deque_maxlen_bounds_memory() -> None:
+    s = SlotSamples()
+    assert s.ttft_samples.maxlen == 128
+    for i in range(200):
+        s.ttft_samples.append((float(i), 0.01))
+    assert len(s.ttft_samples) == 128
+    # Oldest entries were evicted; the deque holds the most recent 128.
+    assert s.ttft_samples[0][0] == 72.0
+    assert s.ttft_samples[-1][0] == 199.0
+
+
+def test_avg_ttft_across_returns_none_when_no_slot_has_data() -> None:
+    empty_a, empty_b = SlotSamples(), SlotSamples()
+    assert avg_ttft_across([empty_a, empty_b], now=100.0) is None
+    assert avg_ttft_across([], now=100.0) is None
+
+
+def test_avg_ttft_across_equally_weights_slots_regardless_of_sample_count() -> None:
+    """One slot's churn shouldn't drown another's single sample: the fleet
+    average is the mean of *per-slot* averages, not a pooled mean over all
+    samples."""
+    busy = SlotSamples()
+    for i in range(10):
+        busy.ttft_samples.append((float(i), 1.0))  # per-slot avg == 1.0
+    quiet = SlotSamples()
+    quiet.ttft_samples.append((0.0, 3.0))  # per-slot avg == 3.0
+
+    fleet_avg = avg_ttft_across([busy, quiet], now=9.0)
+    assert fleet_avg == (1.0 + 3.0) / 2  # == 2.0, NOT the pooled mean (~1.18)
+
+
+def test_avg_ttft_across_skips_slots_with_no_in_window_data() -> None:
+    has_data = SlotSamples()
+    has_data.ttft_samples.append((100.0, 0.5))
+    no_data = SlotSamples()  # never recorded anything
+    stale = SlotSamples(window_s=60.0)
+    stale.ttft_samples.append((0.0, 9.0))  # will be stale at now=100.0
+
+    fleet_avg = avg_ttft_across([has_data, no_data, stale], now=100.0)
+    assert fleet_avg == 0.5
+
+
+def test_avg_kv_cache_across_empty_dict_is_none() -> None:
+    assert avg_kv_cache_across({}) is None
+
+
+def test_avg_kv_cache_across_means_reported_slots_only() -> None:
+    kv = {"chat": 40.0, "coder": 60.0}
+    assert avg_kv_cache_across(kv) == 50.0
+
+
+def test_samples_from_events_wraps_the_live_deque_by_reference() -> None:
+    """samples_from_events is a lazy, read-only *view* over the caller's
+    deque (no copy) — mutations to the original app.state deque must be
+    visible through the returned SlotSamples, since the capture path
+    appends directly to it outside of this view."""
+    events: deque[tuple[float, float]] = deque(maxlen=128)
+    events.append((10.0, 0.2))
+    view = samples_from_events(events, window_s=30.0)
+
+    assert view.window_s == 30.0
+    assert view.ttft_samples is events
+    assert view.current_ttft(now=10.0) == 0.2
+
+    # Mutate the original deque after the view was built.
+    events.append((20.0, 0.4))
+    assert view.current_ttft(now=20.0) == 0.4
+    assert view.sample_count(now=20.0) == 2
+
+
+def test_samples_from_events_defaults_to_module_window() -> None:
+    events: deque[tuple[float, float]] = deque(maxlen=128)
+    view = samples_from_events(events)
+    assert view.window_s == DEFAULT_WINDOW_S


### PR DESCRIPTION
## Summary

Follow-up to #1281 (hermeticity fixes, merged). Adds hermetic, CI-safe entry-point tests for the
five highest-statement **0%-coverage** modules found in the CI-confidence coverage sweep (suite
total 78%). All new tests are deterministic — no network, no sleeps, no host state — and verified
green both on a live hal0 box and under a scrubbed `env -i` environment.

| Module | Before | After | Tests |
|--------|-------:|------:|-------|
| `config/network.py` | 0% | **100%** | 29 — `bind_host`, `hostname` (gethostname mocked), `detect_lan_ips` (psutil + UDP-trick mocked, no real sockets), `derive_allowed_origins` branches |
| `slots/ttft_samples.py` | 0% | **100%** | 19 — `SlotSamples` record/read/avg, injected-clock stale eviction, window-boundary semantics, `avg_*_across` fleet aggregation |
| `agents/hermes/plugins/memory_hindsight/` (`__init__`+`provider`+`_client`) | 0% | **100%** | 70 — `register(ctx)` via fake ctx, provider lifecycle/tools, client url/agent-id/payload shaping with HTTP mocked |
| `mcp/browser_server.py` | 0% | smoke | `pytest.importorskip("playwright")` — skips cleanly in CI (no chromium), runs pure `_selector`/`_trim_snapshot` + tool-registration where available |

## Verification
- `pytest <4 files>` → **118 passed, 1 skipped** (browser skip), on-host **and** scrubbed `env -i`.
- `ruff check` + `ruff format --check` clean.

Ref #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)