### PR TITLE
fix(doctor): FHS-aware preflight.sh resolution + skip own-port false failure

### DIFF
--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -38,6 +38,8 @@
 #                                silently running CPU-only.
 #   preflight_disk MIN_GB DIR  — at least MIN_GB free in DIR (default 20 / /var/lib)
 #   preflight_ports P1 [P2…]   — none of the named TCP ports are LISTENing
+#                                (soft — informational only — when
+#                                HAL0_DOCTOR_PORTS_SOFT=1)
 #   preflight_bootstrap_prereqs — Linux host + curl/tar/sha256sum on PATH,
 #                                mirroring bootstrap.sh's own preflight() so
 #                                the direct `sudo bash install.sh` path
@@ -53,6 +55,15 @@
 #                        when running `hal0 doctor` on a fresh container)
 #   HAL0_DOCTOR_PORTS  — space-separated port list for preflight_ports
 #                        (default "8080 3001")
+#   HAL0_DOCTOR_PORTS_SOFT — when "1", preflight_ports treats "already in
+#                        use" as informational (warn, doesn't flip the
+#                        aggregate rc) instead of a hard failure. `hal0
+#                        doctor` sets this: post-install, 8080/3001 being
+#                        bound almost always means hal0's OWN hal0-api /
+#                        hal0-openwebui units are up and healthy, not a
+#                        collision. install.sh's pre-install gate never
+#                        sets it, so a real collision before install still
+#                        hard-fails.
 #   HAL0_CONTAINER_REQUIRED — when "1", preflight_container_runtime
 #                        auto-installs podman (via the detected package
 #                        manager) and hard-fails (returns non-zero) when it
@@ -667,8 +678,12 @@ preflight_ports() {
     local rc=0 port
     for port in "${ports[@]}"; do
         if _preflight_port_in_use "${port}"; then
-            err "port ${port}: already in use (find with 'ss -ltnp \"sport = :${port}\"')"
-            rc=1
+            if [[ "${HAL0_DOCTOR_PORTS_SOFT:-0}" == "1" ]]; then
+                warn "port ${port}: already in use (expected if hal0's own services are running; find the owner with 'ss -ltnp \"sport = :${port}\"')"
+            else
+                err "port ${port}: already in use (find with 'ss -ltnp \"sport = :${port}\"')"
+                rc=1
+            fi
         else
             info "port ${port}: free"
         fi

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -8,11 +8,20 @@ preflight battery post-install without touching the installer.
 Locating the script:
 
 * ``HAL0_PREFLIGHT_SH`` env var wins, when set — useful for tests and
-  for the eventual FHS install layout (``/opt/hal0/installer/lib/...``).
-* Otherwise we walk up from this module's path to find a sibling
-  ``installer/lib/preflight.sh``. ``install.sh`` does an editable
-  ``pip install -e <repo>`` today, so ``Path(hal0.__file__).parents[2]``
-  resolves to the repo root in every install.sh-produced environment.
+  for install layouts this module doesn't know about.
+* In an editable checkout (``pip install -e <repo>``, e.g. ``--dev``
+  installs) ``hal0.__file__`` is ``<repo>/src/hal0/__init__.py``, so
+  ``Path(hal0.__file__).parents[2]`` resolves to the repo root.
+* ``installer/install.sh`` normally builds a real wheel into a shared
+  venv (prod FHS layout), so ``hal0.__file__`` lives under
+  ``site-packages/`` with no repo neighbours and the editable probe
+  above always misses. We fall back to the FHS release tree instead:
+  ``<HAL0_FHS_ROOT or HAL0_PREFIX>/current/installer/lib/preflight.sh``,
+  defaulting to ``/usr/lib/hal0/current`` (via
+  :func:`hal0.config.paths.usr_lib`, which also honours ``HAL0_HOME``
+  for tests) when neither env var is set, plus a bare
+  ``HAL0_PREFIX/installer/lib/preflight.sh`` for dev-prefix installs
+  that have no ``current`` symlink.
 
 The command preserves the script's exit code so it composes with other
 shell tooling (``hal0 doctor && hal0 status``).
@@ -76,25 +85,49 @@ def _locate_preflight() -> Path | None:
 
     Returns ``None`` when the script is missing — the caller surfaces a
     clear error rather than a confused subprocess failure. We check the
-    explicit env-var first, then derive from the package location.
+    explicit env-var first, then the editable-checkout layout, then the
+    FHS release-tree layout (see the module docstring for the full
+    precedence). The first candidate that exists on disk wins.
     """
     override = os.environ.get("HAL0_PREFLIGHT_SH", "").strip()
     if override:
         candidate = Path(override)
         return candidate if candidate.is_file() else None
 
-    # In an editable install, ``hal0.__file__`` is
-    # ``<repo>/src/hal0/__init__.py``; parents[2] is the repo root.
-    # In a future wheel-style install the file may live under
-    # ``site-packages/hal0/`` with no repo neighbours — at that point
-    # the install layout will need to bundle ``installer/lib/`` and
-    # set ``HAL0_PREFLIGHT_SH``.
+    candidates: list[Path] = []
+
+    # Editable install: ``hal0.__file__`` is ``<repo>/src/hal0/__init__.py``;
+    # parents[2] is the repo root.
     try:
         repo_root = Path(hal0.__file__).resolve().parents[2]
     except (AttributeError, IndexError):
-        return None
-    candidate = repo_root / "installer" / "lib" / "preflight.sh"
-    return candidate if candidate.is_file() else None
+        pass
+    else:
+        candidates.append(repo_root / "installer" / "lib" / "preflight.sh")
+
+    # FHS install (installer/install.sh's default, non-editable wheel in a
+    # shared venv): the script ships inside the versioned release tree,
+    # reachable through the ``current`` symlink. Honour an explicit root
+    # override first, then fall back to the compiled-in default.
+    fhs_root = os.environ.get("HAL0_FHS_ROOT", "").strip()
+    if fhs_root:
+        candidates.append(Path(fhs_root) / "current" / "installer" / "lib" / "preflight.sh")
+
+    # ``HAL0_PREFIX`` — dev-prefix installs (``installer/install.sh --dev``)
+    # point straight at the prefix with no ``current`` symlink.
+    prefix = os.environ.get("HAL0_PREFIX", "").strip()
+    if prefix:
+        candidates.append(Path(prefix) / "installer" / "lib" / "preflight.sh")
+
+    if not fhs_root:
+        from hal0.config import paths as cfg_paths
+
+        candidates.append(cfg_paths.usr_lib() / "installer" / "lib" / "preflight.sh")
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 @app.callback(invoke_without_command=True)
@@ -154,6 +187,11 @@ def doctor(
         env["HAL0_PLAIN"] = "1"
     if ports is not None:
         env["HAL0_DOCTOR_PORTS"] = ports
+    # This is a post-install self-check, not the pre-install gate — on a
+    # healthy box the default ports are bound by hal0's own hal0-api /
+    # hal0-openwebui units. Don't fail the whole run over that (see
+    # preflight_ports in installer/lib/preflight.sh).
+    env["HAL0_DOCTOR_PORTS_SOFT"] = "1"
 
     try:
         result = subprocess.run(

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 
 import json as jsonlib
 import os
+import socket
 import stat
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -26,6 +28,7 @@ import httpx
 import pytest
 import typer
 
+import hal0
 from hal0.cli.doctor_commands import _locate_preflight, doctor, toolbox_pull
 
 pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="preflight.sh is Linux-only")
@@ -170,6 +173,176 @@ def test_locate_preflight_missing_override_returns_none(
     """A bogus HAL0_PREFLIGHT_SH path resolves to None, not a falsy default."""
     monkeypatch.setenv("HAL0_PREFLIGHT_SH", "/no/such/file.sh")
     assert _locate_preflight() is None
+
+
+def _patch_non_editable_hal0(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``hal0.__file__`` at a site-packages-shaped path with no repo
+    neighbours, simulating install.sh's default non-editable wheel install
+    (``pip install <wheel>`` into a shared venv, not ``pip install -e``).
+    """
+    fake_pkg = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "__init__.py"
+    fake_pkg.parent.mkdir(parents=True)
+    fake_pkg.write_text("")
+    monkeypatch.setattr(hal0, "__file__", str(fake_pkg))
+
+
+def test_locate_preflight_fhs_root_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """HAL0_FHS_ROOT resolves ``<root>/current/installer/lib/preflight.sh``.
+
+    Reproduces the reported bug: a non-editable FHS install (real wheel in
+    the shared venv) where the editable ``parents[2]`` probe can't find a
+    repo checkout, so the locator must fall back to the FHS release tree.
+    """
+    monkeypatch.delenv("HAL0_PREFLIGHT_SH", raising=False)
+    monkeypatch.delenv("HAL0_PREFIX", raising=False)
+    _patch_non_editable_hal0(tmp_path, monkeypatch)
+
+    fhs_root = tmp_path / "fhs"
+    script = fhs_root / "current" / "installer" / "lib" / "preflight.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    monkeypatch.setenv("HAL0_FHS_ROOT", str(fhs_root))
+
+    assert _locate_preflight() == script
+
+
+def test_locate_preflight_prefix_env_no_current_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HAL0_PREFIX resolves ``<prefix>/installer/lib/preflight.sh`` directly.
+
+    Dev-prefix installs (``installer/install.sh --dev``) have no ``current``
+    symlink, unlike the prod FHS layout.
+    """
+    monkeypatch.delenv("HAL0_PREFLIGHT_SH", raising=False)
+    monkeypatch.delenv("HAL0_FHS_ROOT", raising=False)
+    _patch_non_editable_hal0(tmp_path, monkeypatch)
+
+    prefix = tmp_path / "prefix"
+    script = prefix / "installer" / "lib" / "preflight.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    monkeypatch.setenv("HAL0_PREFIX", str(prefix))
+
+    assert _locate_preflight() == script
+
+
+def test_locate_preflight_default_fhs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no override env vars set, falls back to the compiled-in default
+    (``/usr/lib/hal0/current`` via :func:`hal0.config.paths.usr_lib`, which
+    is itself ``HAL0_HOME``-aware — exercised here via ``HAL0_HOME`` so the
+    test doesn't need real root-owned ``/usr/lib/hal0``).
+    """
+    monkeypatch.delenv("HAL0_PREFLIGHT_SH", raising=False)
+    monkeypatch.delenv("HAL0_FHS_ROOT", raising=False)
+    monkeypatch.delenv("HAL0_PREFIX", raising=False)
+    _patch_non_editable_hal0(tmp_path, monkeypatch)
+
+    home = tmp_path / "home"
+    script = home / "usr-lib" / "hal0" / "current" / "installer" / "lib" / "preflight.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("#!/usr/bin/env bash\nexit 0\n")
+    monkeypatch.setenv("HAL0_HOME", str(home))
+
+    assert _locate_preflight() == script
+
+
+def test_locate_preflight_env_override_wins_over_fhs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HAL0_PREFLIGHT_SH still wins even when an FHS candidate also resolves."""
+    custom = tmp_path / "custom.sh"
+    custom.write_text("#!/usr/bin/env bash\nexit 0\n")
+    monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(custom))
+
+    fhs_root = tmp_path / "fhs"
+    other = fhs_root / "current" / "installer" / "lib" / "preflight.sh"
+    other.parent.mkdir(parents=True)
+    other.write_text("#!/usr/bin/env bash\nexit 0\n")
+    monkeypatch.setenv("HAL0_FHS_ROOT", str(fhs_root))
+
+    assert _locate_preflight() == custom
+
+
+def test_locate_preflight_editable_still_wins_over_fhs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The editable-checkout probe is tried before the FHS fallbacks.
+
+    Regression guard: this test suite runs from a real repo checkout, so
+    ``hal0.__file__`` genuinely resolves to it — even with FHS env vars set
+    (pointing at a script that doesn't exist), the editable probe must still
+    win rather than the locator returning None.
+    """
+    monkeypatch.delenv("HAL0_PREFLIGHT_SH", raising=False)
+    monkeypatch.setenv("HAL0_FHS_ROOT", str(tmp_path / "no-such-fhs-root"))
+    monkeypatch.setenv("HAL0_PREFIX", str(tmp_path / "no-such-prefix"))
+
+    found = _locate_preflight()
+    assert found is not None
+    assert found.name == "preflight.sh"
+    assert "installer" in found.parts
+
+
+def test_doctor_sets_ports_soft_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """`hal0 doctor` doesn't fail solely because hal0's own ports are bound.
+
+    The stub mirrors the contract ``preflight_ports`` in
+    ``installer/lib/preflight.sh`` implements: a bound port is a hard
+    failure by default, but ``HAL0_DOCTOR_PORTS_SOFT=1`` (which the ``doctor``
+    command sets unconditionally — it's the post-install self-check, not
+    the pre-install gate) downgrades it to a warning.
+    """
+    stub = _make_stub(
+        tmp_path,
+        (
+            'if [[ "${HAL0_DOCTOR_PORTS_SOFT:-0}" == "1" ]]; then\n'
+            '  printf "port 8080: already in use (expected — hal0 is running)\\n"\n'
+            "  exit 0\n"
+            "else\n"
+            '  printf "port 8080: already in use\\n"\n'
+            "  exit 1\n"
+            "fi\n"
+        ),
+    )
+    monkeypatch.setenv("HAL0_PREFLIGHT_SH", str(stub))
+
+    with pytest.raises(typer.Exit) as exc:
+        doctor(ctx=_fake_ctx(), verify=False, plain=False, ports=None)
+
+    assert _exit_code(exc) == 0
+    captured = capfd.readouterr()
+    assert "expected — hal0 is running" in captured.out
+
+
+def test_preflight_ports_soft_mode_downgrades_to_warning() -> None:
+    """Direct contract test against the real script (not a stub).
+
+    Binds a real listening TCP socket so ``preflight_ports`` observes a
+    genuine ``ss -ltn`` hit, then asserts: hard mode (install.sh's
+    pre-install gate, the default) still fails on a real collision, while
+    ``HAL0_DOCTOR_PORTS_SOFT=1`` (set by `hal0 doctor`) does not.
+    """
+    preflight_sh = Path(__file__).resolve().parents[2] / "installer" / "lib" / "preflight.sh"
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+        script = f"source {preflight_sh!s}\npreflight_ports {port}\n"
+
+        hard = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert hard.returncode != 0, hard.stdout + hard.stderr
+
+        soft_env = {**os.environ, "HAL0_DOCTOR_PORTS_SOFT": "1"}
+        soft = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=soft_env)
+        assert soft.returncode == 0, soft.stdout + soft.stderr
+    finally:
+        sock.close()
 
 
 # ── hal0 doctor toolbox-pull ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `hal0 doctor` failed on a fresh non-editable FHS install (v0.9.7.1) with `Could not locate installer/lib/preflight.sh` — `_locate_preflight()` only knew how to resolve the script via the editable-install path (`Path(hal0.__file__).parents[2]`), which only works for `pip install -e`. `install.sh` builds a real (non-editable) wheel into the venv, so that probe always misses.
- Added FHS-aware fallbacks to `_locate_preflight()` (`src/hal0/cli/doctor_commands.py`): after the `HAL0_PREFLIGHT_SH` override and the editable probe, it now also tries `HAL0_FHS_ROOT`/`current`, `HAL0_PREFIX` (dev-prefix, no `current` symlink), and finally the compiled-in default `/usr/lib/hal0/current` via `hal0.config.paths.usr_lib()` (which is itself `HAL0_HOME`-aware).
- Also fixed a false-failure finding: `hal0 doctor`'s post-install port-free check flagged `:8080`/`:3001` as "in use" even when it's hal0's own `hal0-api`/`hal0-openwebui` units running healthily. Added a `HAL0_DOCTOR_PORTS_SOFT` toggle to `preflight_ports()` in `installer/lib/preflight.sh` that downgrades "already in use" from a hard failure to an informational warning; `doctor()` sets it unconditionally since it's a post-install self-check, not the pre-install gate (`install.sh`'s own `preflight_ports` call never sets it, so a real pre-install collision still hard-fails).

## Test plan
- [x] `.venv/bin/python -m pytest tests/cli/test_doctor.py tests/cli/test_doctor_verify.py -q` — 37 passed (7 new tests: env override wins over FHS, HAL0_FHS_ROOT resolution, HAL0_PREFIX resolution, default-FHS-root resolution, editable still wins when FHS env vars point nowhere, doctor forwards `HAL0_DOCTOR_PORTS_SOFT=1`, and a direct contract test of `preflight_ports` against a real bound socket in both hard/soft mode)
- [x] `.venv/bin/python -m pytest tests/installer/ tests/cli/ -q` — 523 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] `bash -n installer/lib/preflight.sh` + `shellcheck` — no new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)