### PR TITLE
fix(agents): FHS-aware installer path + crash-safe agent switch

### DIFF
--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -538,12 +538,36 @@ class AgentManager:
 def installer_script_path(name: str) -> Path:
     """Return the absolute path to ``installer/agents/<name>.sh``.
 
-    Resolution mirrors the uninstall CLI wrapper: editable install →
-    ``src/hal0/agents/manager.py`` lives at ``parents[3]/installer/...``.
+    ``install.sh`` pip-installs hal0 as a NON-editable wheel in production
+    (v0.9.7.1+; only ``pip install -e <repo>`` dev checkouts differ) — see
+    the FHS-layout note in :mod:`hal0.config.paths`. The two install shapes
+    resolve ``__file__`` completely differently, so we try both candidates
+    and return whichever exists:
+
+    * Editable / dev checkout — ``src/hal0/agents/manager.py`` lives at
+      ``<repo_root>/src/hal0/agents/manager.py``; ``parents[3]`` is the
+      repo root, so the script is ``<repo_root>/installer/agents/<name>.sh``.
+    * FHS / wheel install (the production case) — ``__file__`` resolves
+      into ``<venv>/lib/pythonX/site-packages/hal0/...``, which has no
+      ``installer/`` sibling. The scripts instead ship alongside the code
+      root :func:`hal0.config.paths.usr_lib` resolves
+      (``/usr/lib/hal0/current`` by default, honouring ``HAL0_HOME`` for
+      dev/test root overrides — same convention the rest of the manager
+      uses for its own etc/var roots).
+
+    If neither candidate exists we return the FHS candidate anyway, so the
+    caller's "installer script missing" error points at the real
+    production path rather than a venv path the operator won't recognise.
     """
     # parents[0]=agents, [1]=hal0, [2]=src, [3]=repo root
-    repo_root = Path(__file__).resolve().parents[3]
-    return repo_root / "installer" / "agents" / f"{name}.sh"
+    editable_candidate = (
+        Path(__file__).resolve().parents[3] / "installer" / "agents" / f"{name}.sh"
+    )
+    fhs_candidate = _paths.usr_lib() / "installer" / "agents" / f"{name}.sh"
+
+    if editable_candidate.is_file():
+        return editable_candidate
+    return fhs_candidate
 
 
 def _all_known_drivers() -> Iterable[str]:

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -106,6 +106,13 @@ _HAL0_MANAGED_MARKER = ".hal0-managed"
 # ``var_lib()``. Agents not listed here keep the per-name layout.
 _AGENT_HOME_SUBDIR: dict[str, str] = {"hermes": ".hermes"}
 
+# Agents that install by shelling out to ``installer/agents/<name>.sh``
+# (see :func:`installer_script_path`). Hermes provisions through a
+# separate bootstrap pipeline (:mod:`hal0.agents.hermes_provision`) with
+# no matching shell script, so it's excluded from the switch-safety
+# precondition in :meth:`AgentManager._verify_installable`.
+_SCRIPT_INSTALLED_AGENTS = frozenset({"pi-coder", "opencode"})
+
 
 # ── Records ──────────────────────────────────────────────────────────────────
 
@@ -253,6 +260,17 @@ class AgentManager:
         would still re-run the shell script, but we refuse here to keep
         the surface predictable — callers wanting re-run should
         ``uninstall`` then ``install``).
+
+        The swap is crash-safe: before the incumbent is touched, we
+        run a cheap precondition check on the target
+        (:meth:`_verify_installable`) so a target that can't possibly
+        install (e.g. a wheel install missing its bundled installer
+        script) never costs the operator a working agent. If the real
+        install still fails after the incumbent is gone — the
+        precondition passed but the driver blew up deeper in — we make
+        a best-effort attempt to reinstall the incumbent before
+        re-raising, so a broken target leaves the box in its previous
+        state rather than with nothing installed.
         """
         if name not in BUNDLED_AGENTS:
             raise AgentNotFoundError(
@@ -264,27 +282,83 @@ class AgentManager:
             # Already installed — return the existing record. Idempotent.
             return self._read_record(name)
 
-        if current:
-            if not switch:
-                raise AgentAlreadyInstalledError(
-                    f"agent {current[0]!r} already installed; "
-                    f"pass switch=True to atomically swap to {name!r}",
-                )
-            # Atomic swap: tear down the existing one first. If the
-            # tear-down fails we surface the error and DO NOT proceed
-            # — better to leave the old one installed than land in a
-            # half-state.
-            for existing in current:
-                self.uninstall(existing)
+        if not current:
+            return self._install_and_seed(name, bearer_token=bearer_token)
 
+        if not switch:
+            raise AgentAlreadyInstalledError(
+                f"agent {current[0]!r} already installed; "
+                f"pass switch=True to atomically swap to {name!r}",
+            )
+
+        # Verify the target can plausibly install BEFORE tearing down
+        # the incumbent. Raises without touching anything on disk when
+        # the check fails — a missing installer script used to only
+        # surface AFTER the incumbent was already uninstalled, bricking
+        # a working agent for a swap that could never have succeeded.
+        self._verify_installable(name)
+
+        # Atomic swap: tear down the existing one first. If the
+        # tear-down fails we surface the error and DO NOT proceed
+        # — better to leave the old one installed than land in a
+        # half-state.
+        for existing in current:
+            self.uninstall(existing)
+
+        try:
+            return self._install_and_seed(name, bearer_token=bearer_token)
+        except Exception:
+            # The precondition check can't catch every failure mode
+            # (the script can exist and still fail once actually run).
+            # Best-effort restore the incumbent(s) so the operator
+            # isn't left with NO agent installed; rollback failures are
+            # swallowed — the original error is what the caller needs
+            # to see and act on.
+            for existing in current:
+                with contextlib.suppress(Exception):
+                    self._install_and_seed(existing, bearer_token=bearer_token)
+            raise
+
+    def _install_and_seed(self, name: str, *, bearer_token: str | None = None) -> AgentRecord:
+        """Drive the install + seed-write pair.
+
+        Shared by the main ``install()`` path and the switch-failure
+        rollback path below.
+        """
         driver = _driver_for(name)
         # Driver does the heavy lifting (shells out to the installer
         # script). On any exception, the manager rolls back the seed
         # TOML so list() doesn't show a phantom row.
         driver.install(bearer_token=bearer_token)
+        return self._write_seed(name)
 
-        rec = self._write_seed(name)
-        return rec
+    def _verify_installable(self, name: str) -> None:
+        """Cheap precondition check run before ``install(switch=True)``
+        tears down the incumbent agent.
+
+        Only the script-based drivers (:data:`_SCRIPT_INSTALLED_AGENTS`)
+        are checked — Hermes provisions through a separate bootstrap
+        pipeline with no matching shell script, so
+        :func:`installer_script_path` doesn't apply to it; its own
+        precondition (the managed venv being provisioned) can only be
+        evaluated by actually running the driver.
+
+        This doesn't guarantee the install will succeed — the driver
+        can still fail once it actually shells out — it exists to
+        catch the common "packaged without bundled-agent scripts"
+        failure mode up front, before anything is uninstalled.
+        """
+        if name not in _SCRIPT_INSTALLED_AGENTS:
+            return
+        script = installer_script_path(name)
+        if not script.is_file():
+            raise AgentError(
+                f"installer script missing at {script}. This hal0 install "
+                "looks packaged without the bundled-agent scripts — "
+                "reinstall hal0 from a release tarball or git clone. "
+                f"Refusing to switch to {name!r} — the currently-installed "
+                "agent was left in place."
+            )
 
     def uninstall(self, name: str) -> bool:
         """Tear down ``name`` — driver uninstall + seed + data dir + state dir.

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -634,9 +634,7 @@ def installer_script_path(name: str) -> Path:
     production path rather than a venv path the operator won't recognise.
     """
     # parents[0]=agents, [1]=hal0, [2]=src, [3]=repo root
-    editable_candidate = (
-        Path(__file__).resolve().parents[3] / "installer" / "agents" / f"{name}.sh"
-    )
+    editable_candidate = Path(__file__).resolve().parents[3] / "installer" / "agents" / f"{name}.sh"
     fhs_candidate = _paths.usr_lib() / "installer" / "agents" / f"{name}.sh"
 
     if editable_candidate.is_file():

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -542,3 +542,108 @@ def test_hermes_uninstall_refuses_unmanaged_home(
     assert home.exists()
     assert (home / "user-data.txt").exists()
     assert not manager._config_path("hermes").exists()
+
+
+# ── installer_script_path: FHS-aware resolution for wheel installs ───────────
+
+
+def test_installer_script_path_resolves_editable_when_present() -> None:
+    """Editable / dev checkout: this test runs against the real
+    checkout, which has ``installer/agents/pi-coder.sh`` three parents
+    up from ``src/hal0/agents/manager.py`` — no monkeypatching needed,
+    this exercises the real resolution path."""
+    resolved = mgr_mod.installer_script_path("pi-coder")
+    assert resolved.is_file()
+    assert resolved == (
+        Path(mgr_mod.__file__).resolve().parents[3] / "installer" / "agents" / "pi-coder.sh"
+    )
+
+
+def test_installer_script_path_falls_back_to_fhs_for_wheel_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-editable wheel install has ``manager.py`` under
+    ``<venv>/lib/pythonX/site-packages/hal0/agents/manager.py`` — three
+    parents up from there is a venv dir, not a repo root, so it has no
+    ``installer/`` sibling. The function must fall back to the FHS code
+    root (:func:`hal0.config.paths.usr_lib`, ``/usr/lib/hal0/current``
+    in production) and find the script there — this was the root cause
+    of ``hal0 agent install pi-coder`` 500ing on a real FHS install."""
+    fake_module_path = (
+        tmp_path
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "hal0"
+        / "agents"
+        / "manager.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(mgr_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    script_dir = fhs_root / "installer" / "agents"
+    script_dir.mkdir(parents=True)
+    fhs_script = script_dir / "pi-coder.sh"
+    fhs_script.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(mgr_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = mgr_mod.installer_script_path("pi-coder")
+    assert resolved == fhs_script
+    assert resolved.is_file()
+
+
+def test_installer_script_path_prefers_editable_when_both_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an editable-shaped repo root has the script, it wins over
+    the FHS candidate (resolution order: editable first, FHS fallback)."""
+    fake_module_path = tmp_path / "repo" / "src" / "hal0" / "agents" / "manager.py"
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(mgr_mod, "__file__", str(fake_module_path))
+
+    editable_script_dir = tmp_path / "repo" / "installer" / "agents"
+    editable_script_dir.mkdir(parents=True)
+    editable_script = editable_script_dir / "pi-coder.sh"
+    editable_script.write_text("#!/bin/sh\n")
+
+    fhs_root = tmp_path / "fhs"
+    fhs_script_dir = fhs_root / "installer" / "agents"
+    fhs_script_dir.mkdir(parents=True)
+    (fhs_script_dir / "pi-coder.sh").write_text("#!/bin/sh\n")
+    monkeypatch.setattr(mgr_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = mgr_mod.installer_script_path("pi-coder")
+    assert resolved == editable_script
+
+
+def test_installer_script_path_missing_everywhere_returns_fhs_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the script exists in neither location, the function still
+    returns a path rather than raising/None — the FHS candidate — so
+    the caller's "installer script missing" error points at the real
+    production path, not a venv path nobody would recognise."""
+    fake_module_path = (
+        tmp_path
+        / "venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "hal0"
+        / "agents"
+        / "manager.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(mgr_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    monkeypatch.setattr(mgr_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = mgr_mod.installer_script_path("pi-coder")
+    assert resolved == fhs_root / "installer" / "agents" / "pi-coder.sh"
+    assert not resolved.is_file()

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -444,21 +444,29 @@ def test_is_present_on_disk_predicate(
 # ── atomic --switch: failure rollback ────────────────────────────────────────
 
 
-def test_switch_failed_install_leaves_no_installed_agent(
+def test_switch_failed_install_rolls_back_incumbent(
     manager: AgentManager,
     stub_drivers: dict[str, _StubDriver],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If the new agent's install fails mid-swap, neither agent is
-    installed — the old one is gone (uninstalled atomically first), the
-    new one rolled back via the seed not being written.
+    """If the target's install fails AFTER the incumbent was torn down
+    (precondition passed, but the driver blew up deeper in), the
+    manager makes a best-effort attempt to reinstall the incumbent
+    rather than leaving the operator with NO agent installed.
 
-    This is the explicit ADR-0004 §2 promise: "Operator never end up
-    with two bundled agents partially installed."
+    Regression test: switching pi-coder→hermes used to uninstall
+    pi-coder unconditionally, then leave the box with nothing installed
+    (and a crash-looping systemd unit) when hermes' install blew up.
+    ADR-0004 §2 promises the operator never ends up with two bundled
+    agents partially installed — it does NOT say they should end up
+    with zero.
     """
     manager.install("pi-coder")
 
-    # Make hermes' install raise after pi-coder is uninstalled.
+    # Make hermes' install raise after pi-coder is uninstalled. Hermes
+    # has no installer script (_SCRIPT_INSTALLED_AGENTS excludes it),
+    # so the pre-uninstall precondition check is a no-op here and the
+    # failure surfaces from the driver itself, same as upstream really
+    # blowing up mid-install.
     stubs = stub_drivers
 
     def _boom(*, bearer_token: str | None = None) -> None:
@@ -469,9 +477,39 @@ def test_switch_failed_install_leaves_no_installed_agent(
     with pytest.raises(RuntimeError, match="simulated upstream-broke"):
         manager.install("hermes", switch=True)
 
-    # pi-coder was torn down; hermes never got a seed written.
-    assert manager.installed_names() == []
+    # pi-coder was uninstalled then rolled back; hermes never got a
+    # seed written.
+    assert manager.installed_names() == ["pi-coder"]
     assert stubs["pi-coder"].uninstalls == 1
+    assert stubs["pi-coder"].installs == [None, None]  # initial install + rollback
+
+
+def test_switch_aborts_without_uninstalling_when_target_script_missing(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#<bug2>: when the target's installer script doesn't exist on
+    disk, ``install(switch=True)`` must refuse the swap WITHOUT
+    uninstalling the incumbent — the precondition check runs before
+    any teardown. Regression for the "switching to a wheel install
+    missing its bundled-agent scripts bricked the incumbent" bug.
+    """
+    manager.install("pi-coder")
+
+    monkeypatch.setattr(
+        mgr_mod,
+        "installer_script_path",
+        lambda name: Path("/nonexistent/installer/agents") / f"{name}.sh",
+    )
+
+    with pytest.raises(mgr_mod.AgentError, match="installer script missing"):
+        manager.install("opencode", switch=True)
+
+    # Incumbent untouched — precondition failed before any teardown.
+    assert manager.installed_names() == ["pi-coder"]
+    assert stub_drivers["pi-coder"].uninstalls == 0
+    assert stub_drivers["opencode"].installs == []
 
 
 # ── #453: converge hermes data_dir onto HERMES_HOME (.hermes) ─────────────────


### PR DESCRIPTION
## Summary
- `installer_script_path()` assumed an editable `pip install -e` checkout (`Path(__file__).resolve().parents[3]`). Production installs (v0.9.7.1+) pip-install hal0 as a NON-editable wheel, so this resolved into `<venv>/lib/pythonX` instead of the repo root, and `hal0 agent install pi-coder`/`opencode` 500'd with "installer script missing" even though the scripts ship at `/usr/lib/hal0/current/installer/agents/<name>.sh`. Fixed by trying the editable candidate first, then falling back to `hal0.config.paths.usr_lib()` (the same HAL0_HOME-aware FHS code root used elsewhere in the manager).
- `AgentManager.install(name, switch=True)` uninstalled the incumbent agent BEFORE attempting to install the target, so a failing target install (e.g. the FHS bug above) left the box with NO agent installed instead of the previous one — repro was switching hermes→pi-coder while pi-coder's install was broken, bricking hermes and crash-looping hermes-gateway. Fixed with a pre-uninstall precondition check (`_verify_installable`, script-based drivers only) plus a best-effort rollback that reinstalls the incumbent if the target install still fails after teardown.

## Test plan
- [x] `uv sync --extra dev` then `.venv/bin/python -m pytest tests/agents/ -q` — 511 passed
- [x] `.venv/bin/python -m ruff check src/hal0/agents/manager.py tests/agents/test_manager.py` — clean
- [x] Added tests: FHS/editable resolution order for `installer_script_path`; switch aborts without uninstalling incumbent when target script missing; switch failure rolls the incumbent back in

🤖 Generated with [Claude Code](https://claude.com/claude-code)