### PR TITLE
fix(comfyui): FHS-aware fetch script + workflow asset resolution for wheel installs

### DIFF
--- a/src/hal0/comfyui/fetch.py
+++ b/src/hal0/comfyui/fetch.py
@@ -21,6 +21,15 @@ curated workflow JSON into the ComfyUI workflows dir so it is launchable.
 
 fetch_model returns immediately so POST /api/comfyui/models/fetch can reply
 202 without blocking the FastAPI request for a multi-hour download.
+
+Fix (Finding 5): ``_SCRIPTS_DIR`` / ``_WORKFLOWS_SRC_DIR`` used to be
+module-level constants resolved only via the editable-checkout path
+(``Path(__file__).parent * 4``), same class of bug as #1284/#1285. Under a
+non-editable wheel install that resolves into site-packages, where
+``installer/`` does not exist, so every download 202'd and then immediately
+failed. They are now resolver functions that try the editable candidate
+first and fall back to the FHS code root (``hal0.config.paths.usr_lib()``),
+mirroring ``hal0.agents.manager.installer_script_path``.
 """
 
 from __future__ import annotations
@@ -34,22 +43,70 @@ import uuid
 from pathlib import Path
 
 from hal0.comfyui.capabilities import ModelVariant
+from hal0.config import paths as _paths
 
 log = logging.getLogger(__name__)
 
-# Scripts live at <repo-root>/installer/comfyui/scripts/
-_SCRIPTS_DIR: Path = (
-    Path(__file__).parent.parent.parent.parent / "installer" / "comfyui" / "scripts"
-)
-
-# Curated workflow JSONs ship alongside the scripts and are provisioned into
-# the operational ComfyUI workflows dir when a variant is selected.
-_WORKFLOWS_SRC_DIR: Path = (
-    Path(__file__).parent.parent.parent.parent / "installer" / "comfyui" / "workflows"
-)
-
 # Module-level job registry
 _JOBS: dict[str, dict] = {}
+
+
+def _scripts_dir() -> Path:
+    """Return the directory holding the ComfyUI model-fetch scripts.
+
+    ``install.sh`` pip-installs hal0 as a NON-editable wheel in production
+    (v0.9.7.1+; only ``pip install -e <repo>`` dev checkouts differ) — see
+    the FHS-layout note in :mod:`hal0.config.paths`. The two install shapes
+    resolve ``__file__`` completely differently, so we try both candidates
+    and return whichever exists, mirroring
+    :func:`hal0.agents.manager.installer_script_path`:
+
+    * Editable / dev checkout — ``src/hal0/comfyui/fetch.py`` lives at
+      ``<repo_root>/src/hal0/comfyui/fetch.py``; ``parents[3]`` is the repo
+      root, so the scripts are at
+      ``<repo_root>/installer/comfyui/scripts/``.
+    * FHS / wheel install (the production case) — ``__file__`` resolves
+      into ``<venv>/lib/pythonX/site-packages/hal0/...``, which has no
+      ``installer/`` sibling. The scripts instead ship alongside the code
+      root :func:`hal0.config.paths.usr_lib` resolves
+      (``/usr/lib/hal0/current`` by default, honouring ``HAL0_HOME`` for
+      dev/test root overrides) — ``install.sh`` already rsyncs
+      ``installer/comfyui/scripts`` under ``PREFIX``.
+
+    If neither candidate exists we return the FHS candidate anyway, so a
+    downstream "no such file" subprocess error names the real production
+    path rather than a venv path the operator won't recognise.
+    """
+    editable_candidate = Path(__file__).resolve().parents[3] / "installer" / "comfyui" / "scripts"
+    fhs_candidate = _paths.usr_lib() / "installer" / "comfyui" / "scripts"
+
+    if editable_candidate.is_dir():
+        return editable_candidate
+    return fhs_candidate
+
+
+def _workflows_src_dir() -> Path:
+    """Return the directory holding curated ComfyUI workflow JSONs.
+
+    Ships alongside the fetch scripts (same source tree, same install-shape
+    ambiguity), so this resolves the same way as :func:`_scripts_dir` — see
+    that docstring for the editable-vs-FHS candidate rationale. Not to be
+    confused with :func:`_workflows_dir`, which is the DESTINATION the
+    curated JSON is copied to.
+    """
+    editable_candidate = Path(__file__).resolve().parents[3] / "installer" / "comfyui" / "workflows"
+    fhs_candidate = _paths.usr_lib() / "installer" / "comfyui" / "workflows"
+
+    if editable_candidate.is_dir():
+        return editable_candidate
+    return fhs_candidate
+
+
+# Back-compat module-level alias: hal0.comfyui.orchestrate imports this name
+# directly and uses it as a default-arg value. Now computed via the same
+# editable/FHS resolver as fetch_model() (instead of the broken
+# editable-only path), so that caller gets the fix too.
+_SCRIPTS_DIR: Path = _scripts_dir()
 
 
 def _fetch_env() -> dict[str, str]:
@@ -101,7 +158,7 @@ def _provision_workflow(variant: ModelVariant) -> str | None:
     name = variant.workflow
     if not name:
         return None
-    src = _WORKFLOWS_SRC_DIR / name
+    src = _workflows_src_dir() / name
     if not src.is_file():
         log.warning("comfyui.workflow_asset_missing", extra={"workflow": name})
         return None
@@ -157,7 +214,7 @@ def fetch_model(variant: ModelVariant) -> str:
     thread; poll status via get_job(). Non-blocking so the 202-returning API
     endpoint does not stall on multi-hour downloads.
     """
-    script_path = str(_SCRIPTS_DIR / variant.fetch_script)
+    script_path = str(_scripts_dir() / variant.fetch_script)
     job_id = str(uuid.uuid4())
 
     workflow_path = _provision_workflow(variant)

--- a/tests/comfyui/test_fetch_paths.py
+++ b/tests/comfyui/test_fetch_paths.py
@@ -1,0 +1,176 @@
+"""Finding 5: _scripts_dir() / _workflows_src_dir() FHS-aware resolution.
+
+Same class of bug as #1284 (preflight.sh) / #1285 (agent installer
+scripts): ``hal0.comfyui.fetch`` used to resolve its scripts + curated
+workflow assets ONLY via the editable-checkout path
+(``Path(__file__).parent * 4``). Under the non-editable wheel install
+``install.sh`` ships in production, ``__file__`` resolves into
+site-packages, which has no ``installer/`` sibling, so every ComfyUI
+model download 202'd and then immediately failed. These tests pin the
+fix: try the editable candidate first, fall back to the FHS code root
+(:func:`hal0.config.paths.usr_lib`), mirroring
+``hal0.agents.manager.installer_script_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.comfyui import fetch as fetch_mod
+
+# ── _scripts_dir ────────────────────────────────────────────────────────────
+
+
+def test_scripts_dir_resolves_editable_when_present() -> None:
+    """Editable / dev checkout: this test runs against the real checkout,
+    which has ``installer/comfyui/scripts`` three parents up from
+    ``src/hal0/comfyui/fetch.py`` — no monkeypatching needed, this
+    exercises the real resolution path."""
+    resolved = fetch_mod._scripts_dir()
+    assert resolved.is_dir()
+    assert resolved == (
+        Path(fetch_mod.__file__).resolve().parents[3] / "installer" / "comfyui" / "scripts"
+    )
+
+
+def test_scripts_dir_falls_back_to_fhs_for_wheel_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-editable wheel install has ``fetch.py`` under
+    ``<venv>/lib/pythonX/site-packages/hal0/comfyui/fetch.py`` — three
+    parents up from there is a venv dir, not a repo root, so it has no
+    ``installer/`` sibling. The function must fall back to the FHS code
+    root (:func:`hal0.config.paths.usr_lib`, ``/usr/lib/hal0/current`` in
+    production) and find the scripts dir there — this was the root cause
+    of ComfyUI model-fetch jobs 202-ing and then immediately failing on a
+    real FHS install."""
+    fake_module_path = (
+        tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "comfyui" / "fetch.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    scripts_dir = fhs_root / "installer" / "comfyui" / "scripts"
+    scripts_dir.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = fetch_mod._scripts_dir()
+    assert resolved == scripts_dir
+    assert resolved.is_dir()
+
+
+def test_scripts_dir_prefers_editable_when_both_exist(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When an editable-shaped repo root has the scripts dir, it wins over
+    the FHS candidate (resolution order: editable first, FHS fallback)."""
+    fake_module_path = tmp_path / "repo" / "src" / "hal0" / "comfyui" / "fetch.py"
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod, "__file__", str(fake_module_path))
+
+    editable_scripts_dir = tmp_path / "repo" / "installer" / "comfyui" / "scripts"
+    editable_scripts_dir.mkdir(parents=True)
+
+    fhs_root = tmp_path / "fhs"
+    fhs_scripts_dir = fhs_root / "installer" / "comfyui" / "scripts"
+    fhs_scripts_dir.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = fetch_mod._scripts_dir()
+    assert resolved == editable_scripts_dir
+
+
+def test_scripts_dir_missing_everywhere_returns_fhs_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the scripts dir exists in neither location, the function
+    still returns a path rather than raising/None — the FHS candidate —
+    so a downstream "no such file" subprocess error points at the real
+    production path, not a venv path nobody would recognise."""
+    fake_module_path = (
+        tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "comfyui" / "fetch.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    monkeypatch.setattr(fetch_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = fetch_mod._scripts_dir()
+    assert resolved == fhs_root / "installer" / "comfyui" / "scripts"
+
+
+# ── _workflows_src_dir ───────────────────────────────────────────────────────
+
+
+def test_workflows_src_dir_resolves_editable_when_present() -> None:
+    """Editable / dev checkout: real checkout has
+    ``installer/comfyui/workflows`` three parents up from
+    ``src/hal0/comfyui/fetch.py``."""
+    resolved = fetch_mod._workflows_src_dir()
+    assert resolved.is_dir()
+    assert resolved == (
+        Path(fetch_mod.__file__).resolve().parents[3] / "installer" / "comfyui" / "workflows"
+    )
+
+
+def test_workflows_src_dir_falls_back_to_fhs_for_wheel_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same FHS-fallback contract as _scripts_dir(), for the curated
+    workflow JSON source dir."""
+    fake_module_path = (
+        tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "comfyui" / "fetch.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    workflows_dir = fhs_root / "installer" / "comfyui" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod._paths, "usr_lib", lambda: fhs_root)
+
+    resolved = fetch_mod._workflows_src_dir()
+    assert resolved == workflows_dir
+    assert resolved.is_dir()
+
+
+# ── fetch_model() / _provision_workflow() actually use the FHS fallback ─────
+
+
+def test_provision_workflow_finds_asset_via_fhs_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: with fetch.py "installed" as a non-editable wheel,
+    _provision_workflow must still locate + copy the curated workflow
+    JSON by falling back to the FHS workflows dir, instead of silently
+    logging comfyui.workflow_asset_missing (the production symptom in
+    Finding 5)."""
+    fake_module_path = (
+        tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "hal0" / "comfyui" / "fetch.py"
+    )
+    fake_module_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(fetch_mod, "__file__", str(fake_module_path))
+
+    fhs_root = tmp_path / "usr-lib-hal0-current"
+    workflows_src_dir = fhs_root / "installer" / "comfyui" / "workflows"
+    workflows_src_dir.mkdir(parents=True)
+    (workflows_src_dir / "sdxl.json").write_text("{}")
+    monkeypatch.setattr(fetch_mod._paths, "usr_lib", lambda: fhs_root)
+
+    dest_dir = tmp_path / "workflows-dest"
+    monkeypatch.setattr(fetch_mod, "_workflows_dir", lambda: dest_dir)
+
+    variant = type("V", (), {"workflow": "sdxl.json"})()
+    result = fetch_mod._provision_workflow(variant)
+
+    assert result == str(dest_dir / "sdxl.json")
+    assert (dest_dir / "sdxl.json").is_file()


### PR DESCRIPTION
## Summary
- `hal0.comfyui.fetch` resolved its model-fetch script dir and curated workflow-asset dir only via the editable-checkout path (`Path(__file__).parent * 4`) — same bug class already fixed for `preflight.sh` (#1284) and the agent installer scripts (#1285).
- Under the non-editable wheel install `install.sh` ships in production, `__file__` resolves into site-packages (no `installer/` sibling), so every ComfyUI image/video model download 202'd and then immediately failed, and curated workflow JSON provisioning silently no-opped (`comfyui.workflow_asset_missing`).
- Converts `_SCRIPTS_DIR` / `_WORKFLOWS_SRC_DIR` into `_scripts_dir()` / `_workflows_src_dir()` resolver functions that try the editable candidate first, then fall back to the FHS code root (`hal0.config.paths.usr_lib()`), mirroring `hal0.agents.manager.installer_script_path`.
- Kept `_SCRIPTS_DIR` as a module-level alias computed via the new resolver, since `hal0.comfyui.orchestrate` imports it directly as a default-arg value — that caller now gets the fix too without needing its own edit.

## Test plan
- [x] Added `tests/comfyui/test_fetch_paths.py`: editable resolution (real checkout, no monkeypatch), FHS fallback under a simulated wheel install, editable-wins-when-both-exist, missing-everywhere-returns-FHS-candidate, and an end-to-end `_provision_workflow` FHS-fallback test.
- [x] `.venv/bin/python -m pytest -q -k "comfyui or fetch"` — 297 passed, 1 skipped (pre-existing/unrelated).
- [x] `.venv/bin/python -m pytest -q tests/comfyui/ tests/agents/` — 613 passed (confirms `orchestrate.py`'s import of `_SCRIPTS_DIR` still works).
- [x] `ruff check` + `ruff format` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)