### PR TITLE
fix(pymisc): honcho remediation opt-in path + guarded first-run sentinel write

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import re
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -490,6 +491,12 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
 _HEALTH_PROBE_TIMEOUT = 1.0
 
+#: systemd unit laid down only when the operator opts into Honcho at
+#: install time (``HAL0_INSTALL_HONCHO=1`` — see installer/install.sh). Its
+#: absence means the compose stack was never provisioned on this box, not
+#: merely stopped, so the remediation for those two cases must differ.
+_HONCHO_UNIT_PATH = Path("/etc/systemd/system/hal0-honcho.service")
+
 
 class MemoryProviderInvalid(Hal0Error):
     """Unknown ``provider`` value in a ``PUT /api/memory/provider`` body."""
@@ -602,11 +609,26 @@ async def set_memory_provider(request: Request) -> dict[str, Any]:
     if provider == "honcho":
         honcho_url = f"http://127.0.0.1:{cfg.honcho.port}"
         if not await _probe_health(f"{honcho_url}/health"):
+            provisioned = _HONCHO_UNIT_PATH.exists()
+            if provisioned:
+                remediation = (
+                    "start it (hal0 services start honcho) or enable it first "
+                    "(hal0.toml [honcho] enabled = true)"
+                )
+            else:
+                # Honcho is opt-in; a default install never lays down the
+                # unit, so "services start" would just fail with "Unit not
+                # found". Point at the real provisioning path instead.
+                remediation = (
+                    "it has never been provisioned on this box (Honcho is "
+                    "opt-in) — re-run the installer with "
+                    "HAL0_INSTALL_HONCHO=1 to provision the hal0-honcho "
+                    "service, then retry"
+                )
             raise MemoryProviderUnavailable(
-                f"honcho engine is not reachable at {honcho_url} — start it "
-                "(hal0 services start honcho) or enable it first "
-                "(hal0.toml [honcho] enabled = true) before routing an agent to it",
-                details={"url": honcho_url},
+                f"honcho engine is not reachable at {honcho_url} — {remediation} "
+                "before routing an agent to it",
+                details={"url": honcho_url, "provisioned": provisioned},
             )
 
     cfg.memory.agent_providers[agent] = provider

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -270,11 +270,27 @@ def _sentinel_path() -> Path:
 
 
 def mark_first_run_done() -> None:
+    """Write the first-run sentinel. Best-effort, like ``_persist_store_dir``
+    and the other setup-walk helpers: a non-root interactive ``hal0 setup``
+    run (e.g. while troubleshooting a down hal0-api, which routes ``apply_setup``
+    through the in-process path instead of the root-owned API) can't write
+    under ``/var/lib/hal0`` and would otherwise blow up with an unguarded
+    ``PermissionError`` after already creating/skipping every slot — the
+    operator needs the setup summary, not a raw traceback."""
     p = _sentinel_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_suffix(".tmp")
-    tmp.write_text("")
-    tmp.replace(p)  # atomic
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        tmp = p.with_suffix(".tmp")
+        tmp.write_text("")
+        tmp.replace(p)  # atomic
+    except OSError as exc:
+        log.warning(
+            "could not write first-run sentinel %s (%s) — re-run `hal0 setup` "
+            "with sudo/root, or ignore if hal0-api is already up and tracking "
+            "first-run state itself",
+            p,
+            exc,
+        )
 
 
 def _nearest_existing_ancestor(path: str) -> Path | None:

--- a/tests/api/test_memory_honcho_routes.py
+++ b/tests/api/test_memory_honcho_routes.py
@@ -398,3 +398,44 @@ def test_post_honcho_sync_run_reports_failure(client: TestClient) -> None:
     body = r.json()
     assert body["started"] is False
     assert "unit not found" in body["note"]
+
+
+# ── PUT /api/memory/provider (unreachable-honcho remediation) ──────────────
+
+
+def test_provider_switch_unreachable_and_unprovisioned_points_at_installer(
+    client: TestClient,
+) -> None:
+    """Default install (never opted into Honcho): don't tell the operator to
+    ``services start`` a unit that was never laid down — point at the real
+    provisioning path instead."""
+    with (
+        patch(f"{_ROUTE}._probe_health", new_callable=AsyncMock, return_value=False),
+        patch(f"{_ROUTE}._HONCHO_UNIT_PATH", new=Path("/nonexistent/hal0-honcho.service")),
+    ):
+        r = client.put("/api/memory/provider", json={"agent": "hermes", "provider": "honcho"})
+    assert r.status_code == 409
+    body = r.json()
+    message = body["error"]["message"]
+    assert "hal0 services start honcho" not in message
+    assert "HAL0_INSTALL_HONCHO=1" in message
+    assert body["error"]["details"]["provisioned"] is False
+
+
+def test_provider_switch_unreachable_but_provisioned_points_at_services_start(
+    client: TestClient, tmp_path: Path
+) -> None:
+    """Honcho was provisioned (unit exists) but is merely stopped/disabled:
+    the ``services start`` remediation is still valid here."""
+    fake_unit = tmp_path / "hal0-honcho.service"
+    fake_unit.write_text("")
+    with (
+        patch(f"{_ROUTE}._probe_health", new_callable=AsyncMock, return_value=False),
+        patch(f"{_ROUTE}._HONCHO_UNIT_PATH", new=fake_unit),
+    ):
+        r = client.put("/api/memory/provider", json={"agent": "hermes", "provider": "honcho"})
+    assert r.status_code == 409
+    body = r.json()
+    message = body["error"]["message"]
+    assert "hal0 services start honcho" in message
+    assert body["error"]["details"]["provisioned"] is True

--- a/tests/install/test_orchestrate.py
+++ b/tests/install/test_orchestrate.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from hal0.config.schema import GPUInfo, HardwareInfo, NPUInfo
@@ -371,6 +373,62 @@ def test_mark_first_run_done_writes_sentinel(tmp_path, monkeypatch):
     monkeypatch.setattr(orchestrate, "_sentinel_path", lambda: sentinel)
     orchestrate.mark_first_run_done()
     assert sentinel.exists()
+
+
+def test_mark_first_run_done_warns_instead_of_raising_on_permission_error(
+    tmp_path, caplog, monkeypatch
+):
+    """Non-root interactive ``hal0 setup`` against a root-owned
+    ``/var/lib/hal0`` (e.g. troubleshooting a down hal0-api, which routes
+    ``apply_setup`` through the in-process path) must not blow up with a raw
+    ``PermissionError`` after the slot walk already ran — it should log and
+    return so the caller still gets its ``SetupResult``."""
+    from hal0.install import orchestrate
+
+    sentinel = tmp_path / "unwritable" / ".first_run_done"
+    monkeypatch.setattr(orchestrate, "_sentinel_path", lambda: sentinel)
+
+    def _raise_mkdir(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_mkdir)
+    with caplog.at_level("WARNING", logger="hal0.install.orchestrate"):
+        orchestrate.mark_first_run_done()  # must not raise
+    assert "first-run sentinel" in caplog.text
+    assert not sentinel.exists()
+
+
+async def test_apply_setup_survives_sentinel_permission_error(tmp_hal0_home, tmp_path, monkeypatch):
+    """``apply_setup`` still returns a normal ``SetupResult`` (not a raw
+    traceback) end-to-end when the sentinel write hits a ``PermissionError``
+    — the non-root + API-down combo (issue: non-root interactive
+    ``hal0 setup`` crashing after already creating/skipping every slot)."""
+    from hal0.install import orchestrate
+
+    sentinel = tmp_path / "unwritable" / ".first_run_done"
+    monkeypatch.setattr(orchestrate, "_sentinel_path", lambda: sentinel)
+
+    def _raise_mkdir(*args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", _raise_mkdir)
+
+    sel = Selections(
+        storage_dir="",
+        slots=[SlotSelection(capability="embed", slot_name="embed", port=8083, model_id=None)],
+        extensions={},
+        npu_opt_in=False,
+    )
+    result = await orchestrate.apply_setup(
+        sel,
+        hardware=_strix_hw(),
+        slot_manager=_FakeSlotManager(),
+        registry={},
+        jobs={},
+        write_sentinel=True,
+    )
+    assert result.slots[0].created is True
+    assert not sentinel.exists()
 
 
 def test_install_extensions_dispatches(monkeypatch):


### PR DESCRIPTION
## Summary
- `src/hal0/api/routes/memory.py`: the 409 remediation for an unreachable Honcho engine told operators to `hal0 services start honcho`, which fails with "Unit not found" on a default install (Honcho is opt-in via `HAL0_INSTALL_HONCHO=1`). Now branches on whether `/etc/systemd/system/hal0-honcho.service` exists: unprovisioned boxes are pointed at re-running the installer with `HAL0_INSTALL_HONCHO=1`; provisioned-but-stopped boxes keep the `services start` guidance.
- `src/hal0/install/orchestrate.py`: `mark_first_run_done()` was an unguarded write under the root-owned `/var/lib/hal0`. Non-root interactive `hal0 setup` with hal0-api down routes `apply_setup` through the in-process path — every slot create fails best-effort, then the sentinel write threw a raw `PermissionError` traceback through `run_install -> _apply -> run_interactive`. Now wrapped like the sibling best-effort setup-walk helpers (`_persist_store_dir`, `_validate_store_mount`): logs a warning instead of raising.

## Test plan
- [x] `.venv/bin/python -m pytest -q -k "memory or orchestrate or setup"` — 586 passed, 2 pre-existing environment skips
- [x] `ruff check` + `ruff format` on both touched source files and their tests

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>