### PR TITLE
fix(container): docker/podman runtime portability (--replace, runtime probe, OpenWebUI skip reason)

### DIFF
--- a/src/hal0/install/extensions.py
+++ b/src/hal0/install/extensions.py
@@ -80,6 +80,22 @@ def _podman_usable() -> bool:
     return _run_ok(["podman", "info"])
 
 
+def _docker_present() -> bool:
+    """``command -v docker`` — used only to make the OpenWebUI skip reason
+    honest (see :func:`install_openwebui`); it never makes docker a usable
+    runtime for the companion.
+
+    The packaged ``hal0-openwebui.service`` hardcodes ``/usr/bin/podman`` in
+    every ExecStart* line (unlike the per-slot ContainerProvider unit, which
+    is runtime-templated). Force-starting it on a docker-only host would
+    restart-loop with 203/EXEC on the missing podman binary, so the
+    companion genuinely requires podman today — this only distinguishes
+    "docker is present but podman is required" from "no runtime at all" in
+    the skip outcome, so a docker-only operator isn't told there's no
+    runtime when there's one hal0 just can't use for this unit yet."""
+    return shutil.which("docker") is not None
+
+
 def _wait_active(unit: str, timeout: float = 15.0) -> bool:
     """Poll ``systemctl is-active --quiet <unit>`` — Python port of
     install.sh's ``wait_active`` bash helper."""
@@ -111,6 +127,13 @@ def install_openwebui() -> ExtensionOutcome:
         # install.sh's fallback branch.
         _run_ok(["systemctl", "disable", "--now", unit])
         _run_ok(["systemctl", "reset-failed", unit])
+        # The packaged unit is podman-only (hardcoded /usr/bin/podman); a
+        # docker-only host isn't "no container runtime" — it's "the wrong
+        # one for this companion". Surface that distinction instead of
+        # silently implying docker is a viable fallback here (it is for
+        # slots, via ContainerProvider, but not for this unit).
+        if _docker_present():
+            return ExtensionOutcome(ext_id="openwebui", skipped="docker_present_podman_required")
         return ExtensionOutcome(ext_id="openwebui", skipped="no_container_runtime")
 
     if not _run_ok(["systemctl", "enable", "--now", unit]):

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -373,6 +373,13 @@ def _unit_skeleton(
     Read-only sources are deliberately NOT auto-created — silently mounting
     an empty model store would mask a broken mount with a confusing
     model-not-found error further down.
+
+    An unclean shutdown can leave a stale same-name container record behind
+    (``--rm`` never ran), which fails the next start with "name already in
+    use" (#721). ``_render_unit_from_plan`` handles this for podman via
+    ``--replace`` (docker has no such flag), so EVERY runtime also gets a
+    tolerant ``ExecStartPre=-{runtime} rm -f <container_name>`` here — a
+    no-op when no stale record exists, and the only cleanup docker gets.
     """
     container_name = f"hal0-slot-{slot_name}"
     exec_stop = f"{runtime} stop -t 20 {container_name}"
@@ -392,6 +399,7 @@ def _unit_skeleton(
         "StandardOutput=journal",
         "StandardError=journal",
         "",
+        f"ExecStartPre=-{runtime} rm -f {container_name}",
     ]
     if mkdir_sources:
         joined = " ".join(shlex.quote(s) if " " in s else s for s in mkdir_sources)
@@ -447,25 +455,32 @@ def _render_unit_from_plan(
     """
     runtime = runtime_bin or _container_runtime()
     container_name = f"hal0-slot-{slot_name}"
+    # docker has no --replace flag ("unknown flag: --replace") — a plain
+    # docker run aborts outright, which took EVERY slot down on a docker-only
+    # host. podman gets --replace; docker instead relies on the
+    # ExecStartPre=-{runtime} rm -f cleanup _unit_skeleton emits for every
+    # runtime (same #721 stale-record fix, docker-safe).
+    is_podman = "docker" not in os.path.basename(runtime)
 
     argv: list[str] = [
         runtime,
         "run",
         "--rm",
         f"--name={container_name}",
+    ]
+    if is_podman:
         # Unclean shutdown leaves a stale same-name container record (--rm
         # never ran) → exit 125 "name already in use" at next boot (#721).
         # --replace removes it first; no-op when no stale record exists.
-        "--replace",
-        # B3: the unit already routes conmon's inherited container stdout to
-        # journald via StandardOutput=journal. podman's DEFAULT journald log
-        # driver ALSO writes the same stdout to journald (tagged CONTAINER_NAME),
-        # so `journalctl -u hal0-slot@<name>` matched both copies and every
-        # line appeared twice. Disable podman's own log driver so conmon→unit
-        # is the single sink. (docker ignores an unknown value gracefully; it
-        # accepts --log-driver=none too.)
-        "--log-driver=none",
-    ]
+        argv.append("--replace")
+    # B3: the unit already routes conmon's inherited container stdout to
+    # journald via StandardOutput=journal. podman's DEFAULT journald log
+    # driver ALSO writes the same stdout to journald (tagged CONTAINER_NAME),
+    # so `journalctl -u hal0-slot@<name>` matched both copies and every
+    # line appeared twice. Disable podman's own log driver so conmon→unit
+    # is the single sink. (docker ignores an unknown value gracefully; it
+    # accepts --log-driver=none too.)
+    argv.append("--log-driver=none")
     if plan.network_mode:
         argv.append(f"--network={plan.network_mode}")
     # Explicit device nodes (podman won't recurse the /dev/dri directory, #674).

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -287,15 +287,23 @@ _MODEL_STORE_MOUNT = DEFAULT_MODEL_STORE
 def _container_runtime() -> str:
     """Resolve the container runtime binary path.
 
-    Priority: $HAL0_CONTAINER_RUNTIME > /usr/bin/podman > /usr/bin/docker.
-    Raises RuntimeError if neither is found.
+    Priority: $HAL0_CONTAINER_RUNTIME > /usr/bin/podman > /usr/bin/docker >
+    ``podman`` on PATH > ``docker`` on PATH.  The absolute-path candidates
+    are checked first (the common, package-manager-installed location); the
+    bare-name PATH lookups are the fallback for a runtime installed
+    somewhere else (snap, /usr/local/bin, nix, ...) — a plain
+    ``shutil.which("/usr/bin/podman")`` never matches those, so without this
+    fallback a perfectly usable runtime not living at /usr/bin/ is invisible
+    to hal0.
+    Raises RuntimeError if none is found.
     """
     override = os.environ.get("HAL0_CONTAINER_RUNTIME")
     if override:
         return override
-    for candidate in ("/usr/bin/podman", "/usr/bin/docker"):
-        if shutil.which(candidate):
-            return candidate
+    for candidate in ("/usr/bin/podman", "/usr/bin/docker", "podman", "docker"):
+        found = shutil.which(candidate)
+        if found:
+            return found
     raise RuntimeError(
         "no container runtime found; install podman or docker or set HAL0_CONTAINER_RUNTIME"
     )

--- a/tests/install/test_extensions.py
+++ b/tests/install/test_extensions.py
@@ -83,6 +83,7 @@ def test_install_openwebui_enables_unit_when_podman_usable(monkeypatch):
 def test_install_openwebui_quiesces_unit_without_podman(monkeypatch):
     ran = []
     monkeypatch.setattr(ext_mod, "_podman_usable", lambda: False)
+    monkeypatch.setattr(ext_mod, "_docker_present", lambda: False)
     monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: ran.append(cmd) or True)
 
     out = install_openwebui()
@@ -93,6 +94,37 @@ def test_install_openwebui_quiesces_unit_without_podman(monkeypatch):
     assert ["systemctl", "reset-failed", "hal0-openwebui.service"] in ran
     # No enable attempt when the runtime is unusable.
     assert all(cmd[:2] != ["systemctl", "enable"] for cmd in ran)
+
+
+def test_install_openwebui_docker_only_host_gets_explicit_skip_reason(monkeypatch):
+    """A docker-present/podman-absent host must NOT collapse into the generic
+    "no_container_runtime" skip — that reads as "no runtime at all", which is
+    false and hides that OpenWebUI's packaged unit (hardcoded /usr/bin/podman)
+    is the thing that's unusable, not the host's container runtime."""
+    ran = []
+    monkeypatch.setattr(ext_mod, "_podman_usable", lambda: False)
+    monkeypatch.setattr(ext_mod, "_docker_present", lambda: True)
+    monkeypatch.setattr(ext_mod, "_run_ok", lambda cmd: ran.append(cmd) or True)
+
+    out = install_openwebui()
+
+    assert out.installed is False
+    assert out.skipped == "docker_present_podman_required"
+    assert ["systemctl", "disable", "--now", "hal0-openwebui.service"] in ran
+    assert ["systemctl", "reset-failed", "hal0-openwebui.service"] in ran
+    assert all(cmd[:2] != ["systemctl", "enable"] for cmd in ran)
+
+
+def test_docker_present_reflects_shutil_which(monkeypatch):
+    from hal0.install.extensions import _docker_present
+
+    monkeypatch.setattr(
+        ext_mod.shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None
+    )
+    assert _docker_present() is True
+
+    monkeypatch.setattr(ext_mod.shutil, "which", lambda name: None)
+    assert _docker_present() is False
 
 
 def test_install_openwebui_reports_error_when_enable_fails(monkeypatch):

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -32,6 +32,7 @@ from hal0.providers.base import RuntimeLaunchPlan
 from hal0.providers.container import (
     _MODEL_STORE_MOUNT,
     ContainerProvider,
+    _container_runtime,
     _image_mismatch,
     _render_unit,
     _render_unit_from_plan,
@@ -106,6 +107,72 @@ class TestResolveProfileFlags:
 
     def test_mtp_flag_bundle_constant_nonempty(self) -> None:
         assert "--spec-type draft-mtp" in MTP_FLAG_BUNDLE
+
+
+# ── Runtime probe (_container_runtime) ─────────────────────────────────────────
+
+
+class TestContainerRuntimeProbe:
+    """``_container_runtime`` must find podman/docker wherever PATH puts them,
+    not just at the hardcoded /usr/bin/ prefix (snap, /usr/local/bin, nix, ...)."""
+
+    def test_env_override_wins_over_everything(self, monkeypatch) -> None:
+        monkeypatch.setenv("HAL0_CONTAINER_RUNTIME", "/opt/custom/podman")
+        monkeypatch.setattr("hal0.providers.container.shutil.which", lambda _c: "/usr/bin/podman")
+        assert _container_runtime() == "/opt/custom/podman"
+
+    def test_prefers_absolute_usr_bin_podman(self, monkeypatch) -> None:
+        monkeypatch.delenv("HAL0_CONTAINER_RUNTIME", raising=False)
+        monkeypatch.setattr(
+            "hal0.providers.container.shutil.which",
+            lambda c: c if c == "/usr/bin/podman" else None,
+        )
+        assert _container_runtime() == "/usr/bin/podman"
+
+    def test_falls_back_to_absolute_usr_bin_docker(self, monkeypatch) -> None:
+        monkeypatch.delenv("HAL0_CONTAINER_RUNTIME", raising=False)
+        monkeypatch.setattr(
+            "hal0.providers.container.shutil.which",
+            lambda c: c if c == "/usr/bin/docker" else None,
+        )
+        assert _container_runtime() == "/usr/bin/docker"
+
+    def test_falls_back_to_bare_podman_on_path(self, monkeypatch) -> None:
+        """podman installed somewhere other than /usr/bin/ (snap, nix, ...)
+        must still resolve via a bare PATH lookup — a pinned absolute-path
+        check misses it entirely otherwise."""
+        monkeypatch.delenv("HAL0_CONTAINER_RUNTIME", raising=False)
+
+        def fake_which(c: str) -> str | None:
+            if c in ("/usr/bin/podman", "/usr/bin/docker"):
+                return None
+            if c == "podman":
+                return "/snap/bin/podman"
+            return None
+
+        monkeypatch.setattr("hal0.providers.container.shutil.which", fake_which)
+        assert _container_runtime() == "/snap/bin/podman"
+
+    def test_falls_back_to_bare_docker_on_path(self, monkeypatch) -> None:
+        monkeypatch.delenv("HAL0_CONTAINER_RUNTIME", raising=False)
+
+        def fake_which(c: str) -> str | None:
+            if c == "docker":
+                return "/usr/local/bin/docker"
+            return None
+
+        monkeypatch.setattr("hal0.providers.container.shutil.which", fake_which)
+        assert _container_runtime() == "/usr/local/bin/docker"
+
+    def test_raises_when_no_runtime_found_anywhere(self, monkeypatch) -> None:
+        monkeypatch.delenv("HAL0_CONTAINER_RUNTIME", raising=False)
+        monkeypatch.setattr("hal0.providers.container.shutil.which", lambda _c: None)
+        try:
+            _container_runtime()
+        except RuntimeError as exc:
+            assert "no container runtime found" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
 
 
 # ── Unit rendering ────────────────────────────────────────────────────────────

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -201,11 +201,37 @@ class TestRenderUnit:
         exec_start = self._get_exec_start(unit)
         assert exec_start.startswith(f"{_TEST_RUNTIME} run")
 
-    def test_replace_flag_clears_stale_container_records(self) -> None:
+    def test_replace_flag_clears_stale_container_records_podman(self) -> None:
         """An unclean shutdown leaves a stale container record with the slot
         name (``--rm`` never ran), so the next boot fails with podman exit 125
         "name already in use" (#721). ``--replace`` removes any pre-existing
-        same-name container before starting; no-op when none exists."""
+        same-name container before starting; no-op when none exists.
+
+        ``--replace`` is podman-only — see
+        ``test_docker_runtime_omits_replace_flag`` for the docker branch."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin="/usr/bin/podman",
+        )
+        tokens = shlex.split(self._get_exec_start(unit))
+        assert "--replace" in tokens, f"--replace missing from argv: {tokens}"
+        # Must follow --name so the pairing is obvious in the rendered unit.
+        assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
+
+    def test_docker_runtime_omits_replace_flag(self) -> None:
+        """docker has no ``--replace`` flag ("unknown flag: --replace") — a
+        plain ``docker run --replace ...`` aborts immediately, which took
+        every container slot down on a docker-only host. The rendered argv
+        for a docker runtime must NOT carry --replace; the stale-record
+        cleanup instead comes from the ExecStartPre=-docker rm -f the unit
+        skeleton emits for every runtime (see
+        test_docker_runtime_gets_execstartpre_rm_cleanup)."""
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
         unit = _render_unit(
@@ -217,9 +243,26 @@ class TestRenderUnit:
             runtime_bin=_TEST_RUNTIME,
         )
         tokens = shlex.split(self._get_exec_start(unit))
-        assert "--replace" in tokens, f"--replace missing from argv: {tokens}"
-        # Must follow --name so the pairing is obvious in the rendered unit.
-        assert tokens.index("--replace") == tokens.index("--name=hal0-slot-test-slot") + 1
+        assert "--replace" not in tokens, f"--replace must not render for docker: {tokens}"
+        assert tokens[0] == _TEST_RUNTIME
+        assert tokens[1] == "run"
+
+    def test_docker_runtime_gets_execstartpre_rm_cleanup(self) -> None:
+        """Every runtime (podman AND docker) gets a tolerant
+        ``ExecStartPre=-{runtime} rm -f <container_name>`` — the docker-safe
+        equivalent of podman's --replace, so an unclean-shutdown stale
+        container record doesn't fail the next docker start either."""
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_unit(
+            "test-slot",
+            profile.image,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            runtime_bin=_TEST_RUNTIME,
+        )
+        assert f"ExecStartPre=-{_TEST_RUNTIME} rm -f hal0-slot-test-slot" in unit.splitlines()
 
     def test_identical_path_mount_readonly(self, monkeypatch) -> None:
         """Model store mounted identical-path, read-only, SELinux-relabelled."""
@@ -283,7 +326,8 @@ class TestRenderUnit:
     def test_readonly_mount_not_auto_created(self, monkeypatch) -> None:
         """The read-only model store must NOT get an ExecStartPre mkdir —
         silently creating an empty store would mask a broken mount behind a
-        model-not-found error."""
+        model-not-found error. It still gets the unconditional stale-record
+        rm -f cleanup (every runtime gets that one)."""
         monkeypatch.setenv("HAL0_MODEL_STORE", _MODEL_STORE_MOUNT)
         profile = _moe_profile()
         flags = resolve_profile_flags(profile)
@@ -295,12 +339,15 @@ class TestRenderUnit:
             flags,
             runtime_bin=_TEST_RUNTIME,
         )
-        assert "ExecStartPre" not in unit, unit
+        pre = [ln for ln in unit.splitlines() if ln.startswith("ExecStartPre=")]
+        assert pre == [f"ExecStartPre=-{_TEST_RUNTIME} rm -f hal0-slot-test-slot"], unit
+        assert "mkdir" not in unit, unit
 
     def test_writable_mount_gets_execstartpre_mkdir(self) -> None:
         """Writable bind sources (FLM cache & co) get a tolerant
         ExecStartPre=-mkdir -p so a source dir that vanished across a reboot
-        can't fail every start with podman exit 125."""
+        can't fail every start with podman exit 125 — alongside the
+        unconditional stale-record rm -f cleanup every runtime gets."""
         plan = RuntimeLaunchPlan(
             image="ghcr.io/hal0ai/hal0-toolbox-flm:test",
             command=["serve", "x"],
@@ -310,7 +357,10 @@ class TestRenderUnit:
         )
         unit = _render_unit_from_plan("npu", plan, runtime_bin=_TEST_RUNTIME)
         pre = [ln for ln in unit.splitlines() if ln.startswith("ExecStartPre=")]
-        assert pre == ["ExecStartPre=-/usr/bin/mkdir -p /mnt/ai-models/flm/models"], unit
+        assert pre == [
+            f"ExecStartPre=-{_TEST_RUNTIME} rm -f hal0-slot-npu",
+            "ExecStartPre=-/usr/bin/mkdir -p /mnt/ai-models/flm/models",
+        ], unit
         req = [ln for ln in unit.splitlines() if ln.startswith("RequiresMountsFor=")]
         assert req == ["RequiresMountsFor=/mnt/ai-models/flm/models"], unit
 

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -79,13 +79,29 @@ class TestRenderUnitFromSpec:
         unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
         assert "--name=hal0-slot-npu" in unit
 
-    def test_replace_flag_clears_stale_container_records(self) -> None:
-        """Spec-rendered units need ``--replace`` too — same #721 boot race as
-        the llama-server builder (stale name record after unclean shutdown)."""
-        unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
+    def test_replace_flag_clears_stale_container_records_podman(self) -> None:
+        """Spec-rendered podman units need ``--replace`` too — same #721 boot
+        race as the llama-server builder (stale name record after unclean
+        shutdown). docker has no --replace flag; see
+        test_docker_runtime_omits_replace_flag below."""
+        unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin="/usr/bin/podman")
         argv = _exec_start(unit)
         assert "--replace" in argv, f"--replace missing from argv: {argv}"
         assert argv.index("--replace") == argv.index("--name=hal0-slot-npu") + 1
+
+    def test_docker_runtime_omits_replace_flag(self) -> None:
+        """docker aborts outright on an unknown --replace flag, which took
+        every NPU slot down on a docker-only host. The spec-rendered path
+        must not emit --replace for a docker runtime_bin."""
+        unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
+        argv = _exec_start(unit)
+        assert "--replace" not in argv, f"--replace must not render for docker: {argv}"
+
+    def test_docker_runtime_gets_execstartpre_rm_cleanup(self) -> None:
+        """docker instead relies on the tolerant ExecStartPre=-{runtime} rm -f
+        cleanup the unit skeleton emits for every runtime."""
+        unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)
+        assert f"ExecStartPre=-{_TEST_RUNTIME} rm -f hal0-slot-npu" in unit.splitlines()
 
     def test_security_opts_included(self) -> None:
         unit = _render_unit_from_spec("npu", _flm_spec(), runtime_bin=_TEST_RUNTIME)


### PR DESCRIPTION
## Summary
- **Finding 8** (`src/hal0/providers/container.py:446`): `_render_unit_from_plan` unconditionally emitted podman-only `--replace`, aborting every container slot's ExecStart under docker (`unknown flag: --replace`). Now only emitted for podman; every runtime (podman + docker) gets a tolerant `ExecStartPre=-{runtime} rm -f <container_name>` from `_unit_skeleton` as the docker-safe stale-record cleanup.
- **Finding 9** (`src/hal0/install/extensions.py:60`): `install_openwebui()` collapsed every non-podman host into `skipped="no_container_runtime"`, which is misleading on a docker-only box (the packaged unit hardcodes `/usr/bin/podman`, out of scope for this PR). Added `_docker_present()` so the skip reason is now `docker_present_podman_required` when docker is present but podman isn't — honest instead of implying no runtime exists.
- **Finding 17** (`src/hal0/providers/container.py:291`): `_container_runtime()` only checked `shutil.which("/usr/bin/podman"/"/usr/bin/docker")`, missing a runtime installed elsewhere (snap, nix, /usr/local/bin). Added bare-name PATH fallback (`shutil.which("podman")` / `shutil.which("docker")`) after the absolute-path candidates.

Scope: only `src/hal0/providers/container.py` and `src/hal0/install/extensions.py` (+ their tests) were touched, per the hardening brief.

## Test plan
- [x] `.venv/bin/python -m pytest tests/providers/ tests/install/ -q -k "container or extensions or runtime"` — 236 passed
- [x] `.venv/bin/python -m pytest tests/providers/ tests/install/ -q` (full suite for owned dirs) — 486 passed, 1 skipped (pre-existing sandbox skip)
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)