### PR TITLE
fix(agents): hermes single-pick bypass + opencode installer uninstall/PATH gaps

### DIFF
--- a/installer/agents/opencode.sh
+++ b/installer/agents/opencode.sh
@@ -38,6 +38,10 @@ LINK_DIR="${HAL0_AGENT_LINK_DIR:-/usr/local/bin}"
 
 mkdir -p "$HAL0_AGENT_DATA_DIR"
 
+# Records which branch install_opencode() took so the uninstall companion
+# (below) knows what to clean up.
+OPENCODE_INSTALL_METHOD=""
+
 # ── Install opencode CLI upstream (track-latest) ─────────────────────────────
 #
 # Upstream distribution: `opencode-ai` on npm. Binary: `opencode`. NO
@@ -50,10 +54,12 @@ install_opencode() {
         info "Installing opencode-ai via npm (track-latest)"
         npm install -g opencode-ai \
             || die "npm install -g opencode-ai failed — upstream may have renamed; check https://opencode.ai/docs"
+        OPENCODE_INSTALL_METHOD="npm"
     elif command -v curl >/dev/null 2>&1; then
         info "npm not found — installing opencode via the official installer"
         curl -fsSL https://opencode.ai/install | bash \
             || die "opencode installer failed — check https://opencode.ai/docs"
+        OPENCODE_INSTALL_METHOD="curl"
     else
         die "neither npm nor curl found on PATH. Install Node.js (https://nodejs.org/) first."
     fi
@@ -114,3 +120,30 @@ fi
 
 info "CLI ready. The driver now writes ~/.config/opencode/opencode.json (hal0 provider + memory MCP)."
 info "hal0 API target: ${HAL0_API_URL}"
+
+# ── Uninstall companion ───────────────────────────────────────────────────────
+#
+# installer/uninstall.sh's uninstall_agents() runs
+# ${VAR_DIR}/agents/<name>/uninstall.sh per agent (mirrors pi-coder.sh).
+# Without this, a full hal0 uninstall left the globally-installed
+# opencode-ai npm package (and its node_modules tree) — or the curl
+# fallback's ~/.opencode tree and our LINK_DIR symlink — orphaned forever.
+{
+    printf '#!/bin/sh\n'
+    printf '# hal0 — opencode uninstall companion (called from installer/uninstall.sh)\n'
+    printf 'set -eu\n'
+    if [ "${OPENCODE_INSTALL_METHOD}" = "npm" ]; then
+        printf 'if command -v npm >/dev/null 2>&1; then\n'
+        printf '    npm uninstall -g opencode-ai 2>/dev/null || true\n'
+        printf 'fi\n'
+    else
+        printf 'rm -rf "%s/.opencode" 2>/dev/null || true\n' "${HOME:-/root}"
+        printf 'rm -rf "/root/.opencode" 2>/dev/null || true\n'
+    fi
+    printf 'if [ -L "%s/opencode" ]; then\n' "${LINK_DIR}"
+    printf '    rm -f "%s/opencode"\n' "${LINK_DIR}"
+    printf 'fi\n'
+} > "$HAL0_AGENT_DATA_DIR/uninstall.sh"
+chmod +x "$HAL0_AGENT_DATA_DIR/uninstall.sh"
+
+exit 0

--- a/installer/agents/opencode.sh
+++ b/installer/agents/opencode.sh
@@ -26,12 +26,15 @@ set -eu
 
 # ── Logging ──────────────────────────────────────────────────────────────────
 info()  { printf '[opencode] %s\n' "$*"; }
-warn()  { printf '[opencode] WARN: %s\n' "$*" >&2; }
 die()   { printf '[opencode] ERROR: %s\n' "$*" >&2; exit 1; }
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 HAL0_AGENT_DATA_DIR="${HAL0_AGENT_DATA_DIR:-/var/lib/hal0/agents/opencode}"
 HAL0_API_URL="${HAL0_API_URL:-http://127.0.0.1:8080}"
+# /usr/local/bin is the hal0 shim convention (installer/install.sh's
+# HAL0_PATH_LINK, installer/uninstall.sh's SHIM sweep) — on default PATH
+# for bash/zsh/fish login and non-interactive (systemd) shells alike.
+LINK_DIR="${HAL0_AGENT_LINK_DIR:-/usr/local/bin}"
 
 mkdir -p "$HAL0_AGENT_DATA_DIR"
 
@@ -58,11 +61,55 @@ install_opencode() {
 
 install_opencode
 
-# ── Verify the binary landed ─────────────────────────────────────────────────
+# ── Locate the installed binary when it isn't already on PATH ────────────────
+#
+# npm -g normally drops `opencode` straight on PATH via npm's global bin
+# dir, but that dir itself isn't guaranteed to be on PATH (nvm/asdf-managed
+# npm, custom prefix). The curl fallback (https://opencode.ai/install)
+# always installs off-PATH, to ~/.opencode/bin, and only patches PATH in
+# shell rc files — invisible to non-interactive shells (systemd units, the
+# hal0 dashboard's status check) that never source one.
+locate_opencode_bin() {
+    _prefix="$(npm config get prefix 2>/dev/null || true)"
+    if [ -n "${_prefix}" ] && [ -x "${_prefix}/bin/opencode" ]; then
+        printf '%s\n' "${_prefix}/bin/opencode"
+        return 0
+    fi
+    for _candidate in "${HOME:-/root}/.opencode/bin/opencode" "/root/.opencode/bin/opencode"; do
+        if [ -x "${_candidate}" ]; then
+            printf '%s\n' "${_candidate}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ── Verify the binary is actually reachable before reporting success ─────────
+#
+# A prior version of this script only warned when `opencode` wasn't on PATH
+# and still exited 0 — the driver's status() reports "installed" purely from
+# opencode.json presence, so the dashboard showed opencode healthy while the
+# operator (and any non-interactive caller) got "command not found". Make the
+# binary genuinely reachable — symlink it into LINK_DIR when it's off PATH —
+# and refuse to report success if we can't.
 if command -v opencode >/dev/null 2>&1; then
     info "opencode installed: $(opencode --version 2>/dev/null | head -1)"
 else
-    warn "opencode not on PATH after install — the CLI may live under ~/.opencode/bin; ensure it is on PATH."
+    RESOLVED_BIN="$(locate_opencode_bin || true)"
+    if [ -z "${RESOLVED_BIN}" ]; then
+        die "opencode installer reported success but no binary found on PATH, the npm global bin dir, or ~/.opencode/bin — install may have failed silently."
+    fi
+    if [ -w "${LINK_DIR}" ] || [ "$(id -u)" -eq 0 ]; then
+        mkdir -p "${LINK_DIR}"
+        ln -sf "${RESOLVED_BIN}" "${LINK_DIR}/opencode"
+        info "linked ${RESOLVED_BIN} -> ${LINK_DIR}/opencode"
+    else
+        die "opencode installed at ${RESOLVED_BIN} but ${LINK_DIR} isn't writable (not root) — re-run as root, or add $(dirname "${RESOLVED_BIN}") to PATH yourself."
+    fi
+    if ! command -v opencode >/dev/null 2>&1; then
+        die "opencode still not reachable on PATH after linking ${RESOLVED_BIN} — aborting rather than reporting a false-green status."
+    fi
+    info "opencode installed: $(opencode --version 2>/dev/null | head -1)"
 fi
 
 info "CLI ready. The driver now writes ~/.config/opencode/opencode.json (hal0 provider + memory MCP)."

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -124,8 +124,12 @@ def agent_install(
 def _install_hermes(*, switch: bool, gateway: bool = True, adopt: bool = False) -> None:
     """Foreground provision of Hermes into the hal0-managed venv.
 
-    Four steps, all local + foreground:
+    Five steps, all local + foreground:
 
+    0. **Single-pick** — :func:`_enforce_hermes_single_pick` refuses (or,
+       with ``--switch``, uninstalls) a different incumbent bundled agent
+       BEFORE any provisioning side effect — see its docstring for why this
+       can't wait for the daemon call in step 3.
     1. **Toolchain** — ``installer/agents/hermes-prereqs.sh`` ensures
        python3 (>=3.11), python3-venv (the clean-Ubuntu trap), python3-pip
        and pipx via the distro helper. Idempotent.
@@ -145,6 +149,19 @@ def _install_hermes(*, switch: bool, gateway: bool = True, adopt: bool = False) 
     import subprocess as _subprocess
 
     from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER, bootstrap_cli
+
+    # Enforce single-pick BEFORE any provisioning side effect. Hermes
+    # provisions locally (this function) and only calls the daemon's
+    # /api/agents/install at the very end (see step 3 below) — by then
+    # hermes_provision._write_seed_toml has already dropped
+    # /etc/hal0/agents/hermes.toml, so AgentManager.install() sees
+    # "hermes" already in installed_names() and takes its idempotent
+    # no-op path instead of raising AgentAlreadyInstalledError. That let
+    # `hal0 agent install hermes` (no --switch) land ALONGSIDE an
+    # existing pi-coder/opencode install. Check disk truth here, up
+    # front, so hermes gets the same guarantee the manager enforces for
+    # the other bundled agents.
+    _enforce_hermes_single_pick(switch=switch)
 
     # Bail out cleanly (before the toolchain shell-out) when we can't write the
     # provisioning trees — otherwise the bootstrap crashes several phases deep
@@ -204,6 +221,51 @@ def _install_hermes(*, switch: bool, gateway: bool = True, adopt: bool = False) 
             border_style="green",
         )
     )
+
+
+def _bundled_agent_manager() -> Any:
+    """Construct the :class:`~hal0.agents.manager.AgentManager` used for the
+    hermes single-pick check. Imported lazily (mirrors the rest of this
+    module's ``hermes_provision`` imports) so plain ``hal0 agent`` commands
+    that never touch hermes don't pay the import cost. Factored out as a
+    seam so tests can monkeypatch ``ac._bundled_agent_manager`` to return a
+    manager rooted at a tmp_path instead of the real ``/etc`` and
+    ``/var/lib`` trees.
+    """
+    from hal0.agents.manager import AgentManager
+
+    return AgentManager()
+
+
+def _enforce_hermes_single_pick(*, switch: bool) -> None:
+    """Refuse (or atomically clear) a different incumbent bundled agent
+    before hermes provisioning writes anything to disk.
+
+    Mirrors the contract :meth:`hal0.agents.manager.AgentManager.install`
+    enforces for pi-coder/opencode: at most one bundled agent installed at
+    a time, ``switch=True`` required to swap. Hermes can't just call
+    ``AgentManager.install()`` up front (provisioning has to happen first —
+    there's no venv/binary for the manager to register yet), so this checks
+    the same disk-truth ``installed_names()`` the manager uses and either
+    dies with the same message shape as ``AgentAlreadyInstalledError``, or
+    — with ``--switch`` — uninstalls the incumbent(s) before provisioning
+    starts.
+    """
+    mgr = _bundled_agent_manager()
+    current = [n for n in mgr.installed_names() if n != "hermes"]
+    if not current:
+        return
+    if not switch:
+        die(
+            f"agent {current[0]!r} already installed; pass --switch to "
+            "atomically swap to 'hermes' (single-pick enforced)."
+        )
+        return
+    console.print(
+        f"[bold]--switch[/bold]: uninstalling {', '.join(current)} before provisioning hermes…"
+    )
+    for existing in current:
+        mgr.uninstall(existing)
 
 
 # The agent unit runs as this user (User= in installer/systemd/hal0-agent@.service).

--- a/tests/cli/test_agent_install_hermes.py
+++ b/tests/cli/test_agent_install_hermes.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
+import pytest
+
 import hal0.cli.agent_commands as ac
 
 
@@ -20,6 +22,43 @@ class _Rec:
 
     def __init__(self) -> None:
         self.events: list[tuple[str, Any]] = []
+
+
+class _FakeAgentManager:
+    """Stand-in for :class:`hal0.agents.manager.AgentManager` — records
+    ``uninstall`` calls without touching disk, and reports a fixed
+    ``installed_names()`` so tests control the single-pick check
+    (:func:`hal0.cli.agent_commands._enforce_hermes_single_pick`)
+    deterministically, independent of whatever's really on the host box.
+    """
+
+    def __init__(self, installed: list[str] | None = None) -> None:
+        self._installed = list(installed or [])
+        self.uninstalled: list[str] = []
+
+    def installed_names(self) -> list[str]:
+        return list(self._installed)
+
+    def uninstall(self, name: str) -> bool:
+        self.uninstalled.append(name)
+        if name in self._installed:
+            self._installed.remove(name)
+            return True
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _fake_bundled_agent_manager(monkeypatch: pytest.MonkeyPatch) -> _FakeAgentManager:
+    """Insulate every test in this module from real host `/etc/hal0` agent
+    state and from single-pick enforcement (Finding 11) by default — no
+    incumbent, so ``_install_hermes`` proceeds exactly like before this
+    fixture existed. Tests exercising the single-pick check itself
+    override this via their own ``monkeypatch.setattr(ac,
+    "_bundled_agent_manager", ...)`` call (last setattr wins).
+    """
+    fake = _FakeAgentManager([])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+    return fake
 
 
 def test_install_hermes_runs_prereqs_then_bootstrap_then_register(
@@ -408,3 +447,106 @@ def test_install_hermes_gateway_warns_without_raising_when_unit_missing(monkeypa
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: type("_D", (), {"returncode": 1})())
 
     ac._install_hermes_gateway()  # must not raise
+
+
+# ── Single-pick enforcement (Finding 11) ─────────────────────────────────────
+#
+# `hal0 agent install hermes` provisions locally (toolchain + bootstrap_cli)
+# and writes the manager's seed TOML itself, well before it ever calls the
+# daemon's /api/agents/install to honour --switch. That ordering used to let
+# hermes install ALONGSIDE an existing pi-coder/opencode: by the time the
+# daemon saw the request, hermes was already on disk, so AgentManager.install()
+# took its "already installed" idempotent no-op path instead of raising
+# AgentAlreadyInstalledError. _enforce_hermes_single_pick() closes the gap by
+# checking disk-truth installed_names() up front, before any provisioning
+# side effect.
+
+
+def test_enforce_single_pick_noop_when_nothing_installed(monkeypatch) -> None:
+    fake = _FakeAgentManager([])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    ac._enforce_hermes_single_pick(switch=False)  # must not raise
+
+    assert fake.uninstalled == []
+
+
+def test_enforce_single_pick_noop_when_only_hermes_installed(monkeypatch) -> None:
+    """A bare re-install of hermes itself (no other incumbent) is not a
+    single-pick conflict — the manager's own idempotent no-op handles it
+    downstream."""
+    fake = _FakeAgentManager(["hermes"])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    ac._enforce_hermes_single_pick(switch=False)  # must not raise
+
+    assert fake.uninstalled == []
+
+
+def test_enforce_single_pick_dies_on_incumbent_without_switch(monkeypatch) -> None:
+    fake = _FakeAgentManager(["pi-coder"])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    with pytest.raises(SystemExit):
+        ac._enforce_hermes_single_pick(switch=False)
+
+    # Refused before touching the incumbent.
+    assert fake.uninstalled == []
+
+
+def test_enforce_single_pick_uninstalls_incumbent_with_switch(monkeypatch) -> None:
+    fake = _FakeAgentManager(["opencode"])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    ac._enforce_hermes_single_pick(switch=True)  # must not raise
+
+    assert fake.uninstalled == ["opencode"]
+
+
+def test_install_hermes_refuses_when_incumbent_present_without_switch(monkeypatch) -> None:
+    """End-to-end: `hal0 agent install hermes` (no --switch) against an
+    existing pi-coder install must abort BEFORE the toolchain/bootstrap run
+    — the actual regression this finding covers."""
+    fake = _FakeAgentManager(["pi-coder"])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    ran = {"toolchain": False, "bootstrap": False}
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: ran.__setitem__("toolchain", True))
+    monkeypatch.setattr(
+        "hal0.agents.hermes_provision.bootstrap_cli",
+        lambda **_k: ran.__setitem__("bootstrap", True),
+        raising=True,
+    )
+
+    with pytest.raises(SystemExit):
+        ac._install_hermes(switch=False, gateway=False)
+
+    assert ran == {"toolchain": False, "bootstrap": False}
+    assert fake.uninstalled == []
+
+
+def test_install_hermes_switch_uninstalls_incumbent_before_provisioning(monkeypatch) -> None:
+    """`--switch` clears the incumbent first, THEN provisioning proceeds —
+    same atomic-swap contract as AgentManager.install(switch=True)."""
+    fake = _FakeAgentManager(["pi-coder"])
+    monkeypatch.setattr(ac, "_bundled_agent_manager", lambda: fake)
+
+    events: list[str] = []
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: type("_D", (), {"returncode": 0})())
+
+    def _fake_bootstrap_cli(**_k):  # type: ignore[no-untyped-def]
+        events.append("bootstrap_cli")
+        return 0
+
+    monkeypatch.setattr(
+        "hal0.agents.hermes_provision.bootstrap_cli", _fake_bootstrap_cli, raising=True
+    )
+    monkeypatch.setattr(ac, "api_post", lambda *_a, **_k: {})
+    monkeypatch.setattr(ac, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(ac, "_ensure_hermes_writable_or_die", lambda: None)
+    monkeypatch.setattr("shutil.which", lambda _n: None)
+
+    ac._install_hermes(switch=True, gateway=False)
+
+    assert fake.uninstalled == ["pi-coder"]
+    assert events == ["bootstrap_cli"]


### PR DESCRIPTION
## Summary

Three bundled-agent lifecycle defects (worktree brief E-agents):

- **Finding 11** [`src/hal0/cli/agent_commands.py`] — `hal0 agent install hermes` (no `--switch`) bypassed single-pick enforcement: hermes provisions locally and writes the manager's seed TOML before ever calling the daemon's `/api/agents/install`, so by the time `AgentManager.install()` saw the request, hermes was already on disk and took its idempotent no-op path instead of raising `AgentAlreadyInstalledError`. hermes could land ALONGSIDE an existing pi-coder/opencode install. Added `_enforce_hermes_single_pick()`, called before any provisioning side effect, checking the same disk-truth `installed_names()` the manager uses.
- **Finding 20** [`installer/agents/opencode.sh`] — the curl-fallback install path (used when npm is unavailable) drops `opencode` under `~/.opencode/bin`, off PATH for any non-interactive shell (systemd, the dashboard's status check); the script only warned and still exited 0. Added `locate_opencode_bin()` + a symlink into `/usr/local/bin` (existing hal0 shim convention) when the binary is off PATH, and the script now `die`s instead of reporting false-green success if it can't make the binary reachable.
- **Finding 19** [`installer/agents/opencode.sh`] — no uninstall companion (unlike `pi-coder.sh`), so `hal0` uninstall left the globally-installed `opencode-ai` npm package (or the curl fallback's `~/.opencode` tree) orphaned. Added a companion script mirroring pi-coder.sh's pattern, method-aware (npm vs curl) plus cleanup of the PATH symlink from Finding 20.

One commit per finding (3 commits total). `manager.py`, `install.sh`, and other files outside scope were not touched.

## Test plan
- [x] `.venv/bin/python -m pytest -q -k "agent"` — 769 passed, 2 skipped
- [x] `ruff check` + `ruff format --check` on touched Python files
- [x] `bash -n` + `shellcheck -s sh` clean on `opencode.sh`
- [x] Manually exercised `opencode.sh` end-to-end against faked npm/curl for: npm-on-PATH, npm-off-PATH-resolvable-via-prefix (symlinked), curl-fallback (symlinked + correct uninstall companion), and genuine-failure (dies loudly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)