### PR TITLE
fix(installer): harden install.sh + preflight.sh for environment robustness

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -651,11 +651,23 @@ elif command -v npm >/dev/null 2>&1; then
     # Two phases — install can dominate first-boot time, build is steady.
     # Wrap each so the user sees what npm is doing instead of staring at
     # a blank line for several minutes.
-    ui_spinner_run "Installing dashboard npm packages" \
-        bash -c "cd '${UI_DIR}' && npm install --no-audit --no-fund"
-    ui_spinner_run "Building dashboard (npm run build)" \
-        bash -c "cd '${UI_DIR}' && npm run build"
-    info "wrote ${UI_DIST}"
+    #
+    # Non-fatal: a registry flake, an OOM'd `vite build` on a small LXC, or
+    # a peer-dep error here used to trip the ERR trap and abort the WHOLE
+    # install — after the venv, hal0 wheel, config, and (partially) systemd
+    # units were already written — even though the API itself doesn't need
+    # the built UI (`_mount_dashboard` degrades to "no dashboard" when dist
+    # is absent). Degrade to the same soft warning as the npm-absent
+    # branch below instead.
+    if ui_spinner_run "Installing dashboard npm packages" \
+            bash -c "cd '${UI_DIR}' && npm install --no-audit --no-fund" \
+        && ui_spinner_run "Building dashboard (npm run build)" \
+            bash -c "cd '${UI_DIR}' && npm run build"; then
+        info "wrote ${UI_DIST}"
+    else
+        warn "dashboard build failed — the API still serves; the UI at :${HAL0_PORT}/ will 404 until you build it"
+        warn "  scroll up for the real npm error; retry later: cd ${UI_DIR} && npm install && npm run build"
+    fi
 else
     warn "npm not found — dashboard at :${HAL0_PORT}/ will return 404 until you build the UI"
     warn "  install Node 20 LTS, then: cd ${UI_DIR} && npm install && npm run build"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -17,6 +17,18 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+# A hardened root umask (0027/0077 from a CIS/STIG host, or a login shell
+# that sets `umask 077`) leaks into everything this script creates — the
+# venv, the FHS code tree, /etc/hal0, /var/lib/hal0 — leaving it 0700 and
+# breaking the non-root `hal0` CLI (PermissionError reading /usr/lib/hal0,
+# /etc/hal0/slots, /var/lib/hal0/{registry,models}). Chmod-patching one
+# path at a time (as the /etc/hal0 fix below already does) doesn't scale;
+# normalize to the conventional 022 for the whole install body instead.
+# Restored at the very end of the script — this process's umask never
+# escapes to the caller's shell anyway, but symmetry is cheap.
+_HAL0_ORIG_UMASK="$(umask)"
+umask 022
+
 # Shared UI helpers — banner, step counter, spinner, boxed summary, plus
 # info / warn / err / die. ui_step maintains CURRENT_STEP for the ERR
 # trap below. Honors HAL0_PLAIN=1 and NO_COLOR=1 for non-fancy terms.
@@ -2141,3 +2153,6 @@ if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 && "${HAL0_SKIP_SETUP:-0}" != "
         info "  (guided: network, model store, slots, NPU, image gen, apps)"
     fi
 fi
+
+# Restore the caller's umask (see the save near the top of the file).
+umask "${_HAL0_ORIG_UMASK}"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1893,9 +1893,10 @@ else
                     warn "hal0 CLI not available yet — skipping honcho.env render (rerun 'hal0 memory honcho render-env' later)"
                 fi
 
+                HC_IMAGE_TAG="hal0-honcho:main-73453f8"
                 info "building Honcho image (podman build — this is slow on first run)…"
-                if ! podman image exists "hal0-honcho:main-73453f8" \
-                    && ! (cd "${HC_DIR}/src" && podman build -t "hal0-honcho:main-73453f8" .); then
+                if ! podman image exists "${HC_IMAGE_TAG}" \
+                    && ! (cd "${HC_DIR}/src" && podman build -t "${HC_IMAGE_TAG}" .); then
                     warn "Honcho image build failed; check the build log above"
                 fi
 
@@ -1903,17 +1904,30 @@ else
                 install -m644 "${HONCHO_SYNC_UNIT_SRC}" /etc/systemd/system/hal0-honcho-sync.service
                 install -m644 "${HONCHO_SYNC_TIMER_SRC}" /etc/systemd/system/hal0-honcho-sync.timer
                 systemctl daemon-reload
-                systemctl enable --now hal0-honcho
 
                 hc_up=0
-                for _ in $(seq 1 40); do
-                    if curl -fsS "http://127.0.0.1:8000/health" >/dev/null 2>&1; then hc_up=1; break; fi
-                    sleep 3
-                done
-                if [[ "${hc_up}" -eq 1 ]]; then
-                    info "Honcho is running (memory engine on 127.0.0.1:8000)"
+                # Only enable the unit when the image actually exists — its
+                # ExecStart is `podman compose ... up --no-build`, so on a
+                # missing image (build failed above) it would just
+                # restart-loop until systemd's StartLimitBurst trips and
+                # then sit `failed`, instead of the honest "not installed"
+                # the rest of this block reports for a missing prerequisite
+                # (same defensive posture as the openwebui/hindsight blocks).
+                if podman image exists "${HC_IMAGE_TAG}" >/dev/null 2>&1; then
+                    systemctl enable --now hal0-honcho
+
+                    for _ in $(seq 1 40); do
+                        if curl -fsS "http://127.0.0.1:8000/health" >/dev/null 2>&1; then hc_up=1; break; fi
+                        sleep 3
+                    done
+                    if [[ "${hc_up}" -eq 1 ]]; then
+                        info "Honcho is running (memory engine on 127.0.0.1:8000)"
+                    else
+                        warn "Honcho not healthy yet; check 'journalctl -u hal0-honcho -n 40' or 'docker compose --project-name hal0-honcho -f ${HC_DIR}/docker-compose.yml ps'"
+                    fi
                 else
-                    warn "Honcho not healthy yet; check 'journalctl -u hal0-honcho -n 40' or 'docker compose --project-name hal0-honcho -f ${HC_DIR}/docker-compose.yml ps'"
+                    warn "skipping 'systemctl enable --now hal0-honcho' — no local ${HC_IMAGE_TAG} image (build failed above); the unit would just restart-loop"
+                    warn "  fix the build (see the log above) then: systemctl enable --now hal0-honcho"
                 fi
             fi
         fi

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -277,14 +277,27 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
 fi
 
 # preflight_python returns 1 when python is missing OR the version is
-# outside 3.11–3.14 (it logs an `err` / `warn` itself). The installer
-# only treats *missing* python as fatal — a wrong-version warning is OK
-# because pip may still work. We disambiguate by re-checking PATH.
+# below hal0's floor (pyproject.toml requires-python >=3.12; it logs an
+# `err`/`warn` itself). A below-floor interpreter is NOT survivable — pip
+# install "${REPO_ROOT}" always fails on it — so unlike a merely-missing
+# python (which just needs installing per the hint below), we actively try
+# to resolve or auto-install a compatible interpreter (mirrors the
+# Hindsight venv's resolve_hindsight_python) instead of limping ahead only
+# to die minutes later, deep inside "pip install", on Debian 12 (python3
+# 3.11) / Ubuntu 22.04 (python3 3.10) — every stock LTS whose system
+# python3 predates 3.12.
 if ! preflight_python; then
     if ! command -v "${PY}" >/dev/null 2>&1; then
         die "python interpreter '${PY}' not found — install with: $(python_venv_hint)"
     fi
-    # Version warning already printed; keep going.
+    if resolved_py="$(HAL0_PY_AUTOINSTALL=1 resolve_main_python)" && [[ -n "${resolved_py}" ]]; then
+        info "using ${resolved_py} for the main hal0 venv (default ${PY} is below hal0's 3.12 floor)"
+        PY="${resolved_py}"
+        export HAL0_PYTHON="${PY}"
+    else
+        die "python '${PY}' is below hal0's floor (pyproject.toml requires-python >=3.12) and no compatible interpreter could be found or installed.
+  install one manually, e.g.: $(pkg_install_cmd python3.12 python3.12-venv 2>/dev/null || echo 'install python3.12'), then re-run with HAL0_PYTHON=python3.12"
+    fi
 fi
 
 # `python3 -m venv` capability is a hard requirement — the install always

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -226,7 +226,7 @@ info "Pull destination: ${MODELS_DIR}"
 
 # Step total. Kept here so editors who add or remove a ui_step bump the
 # visible counter in the same diff.
-UI_STEP_TOTAL=12
+UI_STEP_TOTAL=13
 
 trap 'err "install failed at line ${LINENO} during: ${CURRENT_STEP:-pre-init}"
     case "${CURRENT_STEP}" in
@@ -657,6 +657,29 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     else
         warn "hal0-agent shim not found at ${HAL0_AGENT_BIN} — agent units will fail until it is linked"
     fi
+fi
+
+ui_step "Node.js toolchain"
+
+# Node/npm is a hard dependency for THREE things: the dashboard UI build
+# right below, and the pi-coder + opencode bundled agents (both shell out to
+# npm; `hal0 agent install pi-coder`/`opencode` fail with a misleading
+# "upstream breaking change" message when npm is simply absent — the real
+# cause is no Node on the box). Provisioning it here, once, up front covers
+# all three instead of only warning in the Dashboard UI step below and
+# leaving the agent installs to fail later with no clue why. Best-effort:
+# resolve_node tries an already-present Node >=20 first, then auto-installs
+# via the detected package manager (NodeSource setup script on Debian/
+# Ubuntu, since their base repos ship an ancient Node; direct package
+# install elsewhere); never fatal — a Node-less box still installs, just
+# without the dashboard build / those two agents until Node is added later.
+if [[ "${DEV_MODE}" -eq 1 ]]; then
+    info "dev mode — skipping Node.js auto-provisioning (install manually if exercising the dashboard build / pi-coder / opencode agents)"
+elif HAL0_NODE_AUTOINSTALL=1 resolve_node; then
+    info "node: $(node -v 2>/dev/null || echo present) (>= ${NODE_MIN_MAJOR} LTS)"
+else
+    warn "could not provision Node.js ${NODE_MIN_MAJOR}+ LTS — dashboard UI build will be skipped; pi-coder/opencode agent installs will fail until Node is installed"
+    warn "  install manually: https://nodejs.org/en/download (or your distro's nodejs/NodeSource package), then re-run install.sh"
 fi
 
 ui_step "Dashboard UI"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -648,25 +648,42 @@ UI_DIST="${UI_DIR}/dist"
 if [[ -f "${UI_DIST}/index.html" ]]; then
     info "ui/dist already built — left alone"
 elif command -v npm >/dev/null 2>&1; then
-    # Two phases — install can dominate first-boot time, build is steady.
-    # Wrap each so the user sees what npm is doing instead of staring at
-    # a blank line for several minutes.
-    #
-    # Non-fatal: a registry flake, an OOM'd `vite build` on a small LXC, or
-    # a peer-dep error here used to trip the ERR trap and abort the WHOLE
-    # install — after the venv, hal0 wheel, config, and (partially) systemd
-    # units were already written — even though the API itself doesn't need
-    # the built UI (`_mount_dashboard` degrades to "no dashboard" when dist
-    # is absent). Degrade to the same soft warning as the npm-absent
-    # branch below instead.
-    if ui_spinner_run "Installing dashboard npm packages" \
-            bash -c "cd '${UI_DIR}' && npm install --no-audit --no-fund" \
-        && ui_spinner_run "Building dashboard (npm run build)" \
-            bash -c "cd '${UI_DIR}' && npm run build"; then
-        info "wrote ${UI_DIST}"
+    # ui/package.json pins vite ^6.0.3 + @tailwindcss/vite ^4.2.2, both of
+    # which need a modern Node; `command -v npm` alone doesn't catch a Node
+    # older than that (Debian 11 / older-Ubuntu apt nodejs, a stale nvm
+    # default) — it fails deep inside esbuild/oxide with a cryptic version
+    # error instead of a clear message. Gate on the major version and take
+    # the same soft-skip path as the npm-absent branch below rather than
+    # attempting a build that's certain to fail.
+    _ui_node_ver="" _ui_node_major=0
+    if command -v node >/dev/null 2>&1; then
+        _ui_node_ver="$(node -v 2>/dev/null || true)"
+        [[ "${_ui_node_ver}" =~ ^v([0-9]+) ]] && _ui_node_major="${BASH_REMATCH[1]}"
+    fi
+    if (( _ui_node_major < 20 )); then
+        warn "node ${_ui_node_ver:-not found} is too old to build the dashboard (need Node >=20 LTS) — skipping"
+        warn "  install Node 20 LTS, then: cd ${UI_DIR} && npm install && npm run build"
     else
-        warn "dashboard build failed — the API still serves; the UI at :${HAL0_PORT}/ will 404 until you build it"
-        warn "  scroll up for the real npm error; retry later: cd ${UI_DIR} && npm install && npm run build"
+        # Two phases — install can dominate first-boot time, build is
+        # steady. Wrap each so the user sees what npm is doing instead of
+        # staring at a blank line for several minutes.
+        #
+        # Non-fatal: a registry flake, an OOM'd `vite build` on a small
+        # LXC, or a peer-dep error here used to trip the ERR trap and abort
+        # the WHOLE install — after the venv, hal0 wheel, config, and
+        # (partially) systemd units were already written — even though the
+        # API itself doesn't need the built UI (`_mount_dashboard`
+        # degrades to "no dashboard" when dist is absent). Degrade to the
+        # same soft warning as the npm-absent branch below instead.
+        if ui_spinner_run "Installing dashboard npm packages" \
+                bash -c "cd '${UI_DIR}' && npm install --no-audit --no-fund" \
+            && ui_spinner_run "Building dashboard (npm run build)" \
+                bash -c "cd '${UI_DIR}' && npm run build"; then
+            info "wrote ${UI_DIST}"
+        else
+            warn "dashboard build failed — the API still serves; the UI at :${HAL0_PORT}/ will 404 until you build it"
+            warn "  scroll up for the real npm error; retry later: cd ${UI_DIR} && npm install && npm run build"
+        fi
     fi
 else
     warn "npm not found — dashboard at :${HAL0_PORT}/ will return 404 until you build the UI"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1793,12 +1793,33 @@ else
         if podman compose version >/dev/null 2>&1; then
             hc_compose_ok=1
         else
-            warn "podman compose provider missing — attempting docker-compose-v2 install"
-            apt-get install -y docker-compose-v2 >/dev/null 2>&1 || true
+            # Package NAME differs by distro ecosystem (docker-compose-v2 on
+            # Debian/Ubuntu, podman-compose on Fedora/Arch/openSUSE) — route
+            # through lib/distro.sh's pkg_mgr/distro_family dispatch instead
+            # of a bare apt-get, which was a silent no-op on every non-apt
+            # host (the only unguarded apt-get in this script; every FLM
+            # apt-get elsewhere sits behind a `command -v apt-get` gate).
+            hc_compose_pkg=""
+            case "$(distro_family 2>/dev/null)" in
+                debian) hc_compose_pkg="docker-compose-v2" ;;
+                fedora | suse | arch) hc_compose_pkg="podman-compose" ;;
+            esac
+            if [[ -n "${hc_compose_pkg}" ]]; then
+                warn "podman compose provider missing — attempting to install ${hc_compose_pkg}"
+                case "$(pkg_mgr 2>/dev/null)" in
+                    apt-get) apt-get install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
+                    dnf) dnf install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
+                    yum) yum install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
+                    zypper) zypper install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
+                    pacman) pacman -S --noconfirm "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
+                esac
+            fi
             if podman compose version >/dev/null 2>&1; then
                 hc_compose_ok=1
             else
-                warn "podman compose still unavailable — Honcho will be skipped (install docker-compose-v2 and re-run)"
+                hc_compose_hint="$(pkg_install_cmd "${hc_compose_pkg:-docker-compose-v2}" 2>/dev/null \
+                    || echo "install a docker-compose-v2-compatible provider")"
+                warn "podman compose still unavailable — Honcho will be skipped (${hc_compose_hint} and re-run)"
             fi
         fi
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1916,6 +1916,30 @@ else
                 if podman image exists "${HC_IMAGE_TAG}" >/dev/null 2>&1; then
                     systemctl enable --now hal0-honcho
 
+                    # Persist [honcho].enabled=true so hal0's own config
+                    # agrees with the unit it just enabled. Without this,
+                    # `hal0-honcho.service` runs but HonchoConfig.enabled
+                    # (default False) stays false — GET
+                    # /api/memory/honcho/stats reports the stack as
+                    # "disabled" while it's actually reachable, and the
+                    # dashboard Honcho card shows a running stack as off.
+                    # Best-effort: the venv/CLI are already up by this
+                    # point, but a config-write hiccup here must not abort
+                    # an otherwise-good install.
+                    if [[ -x "${VENV_DIR}/bin/python" ]]; then
+                        if "${VENV_DIR}/bin/python" -c '
+from hal0.config.loader import load_hal0_config, save_hal0_config
+cfg = load_hal0_config()
+if not cfg.honcho.enabled:
+    cfg.honcho.enabled = True
+    save_hal0_config(cfg)
+' 2>/dev/null; then
+                            info "set [honcho].enabled=true in ${ETC_DIR}/hal0.toml"
+                        else
+                            warn "could not persist [honcho].enabled=true — set it manually: hal0 config edit"
+                        fi
+                    fi
+
                     for _ in $(seq 1 40); do
                         if curl -fsS "http://127.0.0.1:8000/health" >/dev/null 2>&1; then hc_up=1; break; fi
                         sleep 3

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -411,6 +411,24 @@ if [[ "${DEV_MODE}" -eq 0 ]]; then
     # `hal0 setup` / the pull gate re-validates before any download lands.
     preflight_disk "${HAL0_MODELS_DISK_MIN_GB:-20}" "${MODELS_DIR}" \
         || warn "model store ${MODELS_DIR} is low on free space — model pulls may fail until freed"
+    # Container-runtime graphroot disk check: same cross-mount blind spot as
+    # the model-store check above, but for image storage. The VAR_DIR probe
+    # only measures VAR_DIR's own mount; multi-GB toolbox runners +
+    # OpenWebUI + ComfyUI + Honcho images land in the runtime's graphroot
+    # (/var/lib/containers for podman, /var/lib/docker for docker), which is
+    # frequently a separate mount when an operator relocates var-dir or
+    # deliberately puts container storage on its own volume. Without this, a
+    # box passes pre-flight with "20 GB free" and then image pulls fill the
+    # container store and fail. Non-fatal (warn only) — same posture as the
+    # model-store check.
+    if command -v podman >/dev/null 2>&1; then
+        HAL0_GRAPHROOT="$(podman info --format '{{.Store.GraphRoot}}' 2>/dev/null || echo /var/lib/containers)"
+        preflight_disk "${HAL0_CONTAINER_DISK_MIN_GB:-20}" "${HAL0_GRAPHROOT}" \
+            || warn "container image store ${HAL0_GRAPHROOT} is low on free space — image pulls may fail until freed"
+    elif command -v docker >/dev/null 2>&1; then
+        preflight_disk "${HAL0_CONTAINER_DISK_MIN_GB:-20}" /var/lib/docker \
+            || warn "container image store /var/lib/docker is low on free space — image pulls may fail until freed"
+    fi
     preflight_ports "${HAL0_PORT}" 3001       || pf_rc=$?
     if (( pf_rc != 0 )); then
         false

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2233,7 +2233,14 @@ if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 && "${HAL0_SKIP_SETUP:-0}" != "
         [[ -z "${reply}" || "${reply}" =~ ^[Yy]([Ee][Ss])?$ ]]
     }
     if [[ -r /dev/tty ]] && _confirm_launch_setup; then
-        "${HAL0_BIN}" setup \
+        # Redirect stdin to the controlling terminal (the confirm prompt
+        # above already does this for exactly this reason). Without it, a
+        # piped install (`curl … | bash`) run from a real terminal answers
+        # "Y" here but the launched `hal0 setup` inherits the INSTALLER'S
+        # pipe as stdin — sys.stdin.isatty() is False, so setup_command
+        # prints "run it from a terminal" and exits 0 without ever running
+        # the wizard the operator just opted into.
+        HAL0_FORCE_INTERACTIVE=1 "${HAL0_BIN}" setup </dev/tty \
             || warn "guided setup exited non-zero — re-run '${BOLD}hal0 setup${RST}' anytime"
     else
         printf '\n'

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -40,6 +40,12 @@
 #                                (HAL0_GPU_RC_BROKEN_GID / HAL0_GPU_RC_NO_DEVICE)
 #                                instead of installing "successfully" and then
 #                                silently running CPU-only.
+#   preflight_node             — node on PATH + version >= NODE_MIN_MAJOR
+#                                (default 20). Soft, always returns 0 — a
+#                                Node-less box is a valid install; the
+#                                dashboard UI build / pi-coder / opencode
+#                                agents just aren't available until Node is
+#                                installed (install.sh auto-provisions it).
 #   preflight_disk MIN_GB DIR  — at least MIN_GB free in DIR (default 20 / /var/lib)
 #   preflight_ports P1 [P2…]   — none of the named TCP ports are LISTENing
 #                                (soft — informational only — when
@@ -803,6 +809,31 @@ preflight_ports() {
     return "${rc}"
 }
 
+# Node.js / npm — needed for the dashboard UI build (Vite 6 / Tailwind v4;
+# ui/package.json has no `engines` floor to surface a mismatch) and for the
+# pi-coder / opencode bundled agents, which both shell out to npm. Soft:
+# always returns 0 (a Node-less box is a valid install — the dashboard build
+# and those two agents just aren't available until Node is installed). This
+# is the read-only `hal0 doctor` view; install.sh's own "Node.js toolchain"
+# step actually provisions Node when it's missing/too old.
+NODE_MIN_MAJOR=20
+preflight_node() {
+    if ! command -v node >/dev/null 2>&1; then
+        warn "node: not found — dashboard UI build + pi-coder/opencode agents need Node ${NODE_MIN_MAJOR}+ LTS"
+        return 0
+    fi
+    local ver major
+    ver="$(node -v 2>/dev/null || true)"
+    major=0
+    [[ "${ver}" =~ ^v([0-9]+) ]] && major="${BASH_REMATCH[1]}"
+    if (( major >= NODE_MIN_MAJOR )); then
+        info "node: ${ver}"
+    else
+        warn "node: ${ver} — below the ${NODE_MIN_MAJOR}+ LTS floor (dashboard build / pi-coder / opencode may fail)"
+    fi
+    return 0
+}
+
 # ── aggregate runner ────────────────────────────────────────────────────────
 
 # Run every check; return non-zero if any failed. We deliberately don't
@@ -821,6 +852,7 @@ preflight_all() {
     preflight_container_runtime || rc=$?
     preflight_podman_forward || rc=$?
     preflight_gpu     || rc=$?
+    preflight_node    || rc=$?
     preflight_disk    || rc=$?
     preflight_ports   || rc=$?
     if (( rc == 0 )); then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -9,7 +9,11 @@
 # Public API (all functions return 0 on success, non-zero on failure;
 # none of them exit the calling shell):
 #   preflight_systemd          — systemctl on PATH
-#   preflight_python           — `${PY:-python3}` resolvable + version 3.11–3.14
+#   preflight_python           — `${PY:-python3}` resolvable + version 3.12–3.14
+#                                (matches pyproject.toml's requires-python
+#                                floor). resolve_main_python (below) can
+#                                resolve/auto-install a compatible interpreter
+#                                when the default is below the floor.
 #   preflight_container_runtime — a usable container runtime (podman
 #                                preferred, docker accepted). Soft by
 #                                default (returns 0 with a warning, since
@@ -117,12 +121,81 @@ preflight_python() {
         err "could not read Python version from ${py}"
         return 1
     fi
-    if [[ "${ver}" =~ ^3\.(11|12|13|14)$ ]]; then
+    if [[ "${ver}" =~ ^3\.(12|13|14)$ ]]; then
         info "python: ${py} (${ver})"
         return 0
     fi
-    warn "python: ${py} (${ver}) — hal0 is tested on 3.11-3.14"
+    warn "python: ${py} (${ver}) — hal0 requires >=3.12 (pyproject.toml requires-python; tested on 3.12-3.14)"
     return 1
+}
+
+# ── Main hal0 venv interpreter selection ────────────────────────────────────
+# pyproject.toml pins `requires-python = ">=3.12"`. Stock Debian 12 (python3
+# = 3.11) and Ubuntu 22.04 (python3 = 3.10) both fail preflight_python's
+# floor check above; historically install.sh treated that as a non-fatal
+# warning ("pip may still work") and only hard-failed minutes later at
+# `pip install`, with a recovery hint (HAL0_PYTHON=python3.12) that's a dead
+# end on those distros' base repos. resolve_main_python finds — or, when
+# asked, installs — a floor-compatible interpreter up front, mirroring
+# resolve_hindsight_python's pattern for the (separate) Hindsight venv.
+MAIN_PY_MIN_MINOR=12
+
+# Best-effort: install python3.MAIN_PY_MIN_MINOR via the detected package
+# manager. Echoes the resolved interpreter name on success; returns 1
+# otherwise (nothing installed / no recognised manager / distro doesn't
+# package a pinned minor). Only fires when HAL0_PY_AUTOINSTALL=1 (install.sh
+# sets it) so `hal0 doctor` and read-only preflight never mutate the system.
+_main_py_autoinstall() {
+    [[ "${HAL0_PY_AUTOINSTALL:-0}" == "1" ]] || return 1
+    pkg_mgr >/dev/null 2>&1 || return 1
+    local fam cand; fam="$(distro_family)"
+    cand="python3.${MAIN_PY_MIN_MINOR}"
+    info "no Python >=3.${MAIN_PY_MIN_MINOR} found — attempting to install ${cand} (${fam})"
+    case "${fam}" in
+        debian)
+            DEBIAN_FRONTEND=noninteractive apt-get update -qq >/dev/null 2>&1 || true
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -q "${cand}" "${cand}-venv" >/dev/null 2>&1 || return 1 ;;
+        fedora) "$(pkg_mgr)" install -y "${cand}" >/dev/null 2>&1 || return 1 ;;
+        # Arch/openSUSE/Alpine ship a single rolling python; a pinned older
+        # minor isn't reliably in the base repos (mirrors
+        # _hindsight_py_autoinstall's same limitation).
+        *) return 1 ;;
+    esac
+    if command -v "${cand}" >/dev/null 2>&1; then
+        info "installed ${cand} for the main hal0 venv"
+        printf '%s\n' "${cand}"
+        return 0
+    fi
+    return 1
+}
+
+# Resolve the interpreter the MAIN hal0 venv should be built with. Selection
+# order:
+#   1. the default ${HAL0_PY:-${HAL0_PYTHON:-python3}} when already >=3.12
+#   2. python3.14 → python3.12 already on PATH
+#   3. auto-install python3.12 (only when HAL0_PY_AUTOINSTALL=1)
+# Echoes the resolved interpreter name and returns 0, or returns 1 if none
+# could be resolved. Unlike resolve_hindsight_python there is no
+# metadata-gate bypass to fall back on here — `pip install "${REPO_ROOT}"`
+# hard-requires >=3.12 — so callers must die on a 1 return.
+resolve_main_python() {
+    local def="${HAL0_PY:-${HAL0_PYTHON:-python3}}"
+    if command -v "${def}" >/dev/null 2>&1; then
+        local m; m="$(_py_minor "${def}" 2>/dev/null)" || m=""
+        if [[ -n "${m}" ]] && (( m >= MAIN_PY_MIN_MINOR )); then
+            printf '%s\n' "${def}"
+            return 0
+        fi
+    fi
+    local v cand
+    for v in 14 13 12; do
+        cand="python3.${v}"
+        if command -v "${cand}" >/dev/null 2>&1; then
+            printf '%s\n' "${cand}"
+            return 0
+        fi
+    done
+    _main_py_autoinstall
 }
 
 # ── Hindsight interpreter selection ─────────────────────────────────────────

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -834,6 +834,68 @@ preflight_node() {
     return 0
 }
 
+# ── Node.js provisioning ────────────────────────────────────────────────────
+# Node/npm is a HARD dependency for three hal0 features: the dashboard Vite
+# build (see the "Dashboard UI" step in install.sh), and the pi-coder +
+# opencode bundled agents (installer/agents/*.sh both shell out to npm and
+# fail with a misleading "upstream breaking change" message when npm is
+# simply absent). install.sh used to only WARN on a missing/old npm; this
+# resolves — or, when asked, auto-installs — a Node >= NODE_MIN_MAJOR via the
+# detected package manager, mirroring resolve_main_python's pattern.
+# Best-effort and never fatal: a Node-less box still installs, just without
+# the dashboard build / those two agents until Node is added later.
+
+# Echo the Node major version (e.g. "20") of the `node` on PATH; nothing +
+# non-zero if node isn't found or its version can't be parsed.
+_node_major() {
+    command -v node >/dev/null 2>&1 || return 1
+    local ver; ver="$(node -v 2>/dev/null || true)"
+    [[ "${ver}" =~ ^v([0-9]+) ]] || return 1
+    printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+# Best-effort: install a Node >= NODE_MIN_MAJOR via the detected package
+# manager. Debian/Ubuntu's own repos ship an ancient Node (10-18 depending
+# on release), so this adds the NodeSource setup script for a current LTS
+# instead of trusting the base repo; other ecosystems' current/rolling
+# nodejs packages are close enough to install directly. Returns 0 on
+# success. Only fires when HAL0_NODE_AUTOINSTALL=1 (install.sh sets it) so
+# `hal0 doctor` and read-only preflight never mutate the system.
+_node_autoinstall() {
+    [[ "${HAL0_NODE_AUTOINSTALL:-0}" == "1" ]] || return 1
+    local fam; fam="$(distro_family 2>/dev/null)" || return 1
+    info "node >=${NODE_MIN_MAJOR} not found — attempting to install Node ${NODE_MIN_MAJOR} LTS (${fam})"
+    case "${fam}" in
+        debian)
+            if curl -fsSL "https://deb.nodesource.com/setup_${NODE_MIN_MAJOR}.x" -o /tmp/hal0-nodesource-setup.sh 2>/dev/null \
+                && DEBIAN_FRONTEND=noninteractive bash /tmp/hal0-nodesource-setup.sh >/dev/null 2>&1; then
+                DEBIAN_FRONTEND=noninteractive apt-get install -y -q nodejs >/dev/null 2>&1
+            fi
+            rm -f /tmp/hal0-nodesource-setup.sh
+            ;;
+        fedora) dnf install -y nodejs >/dev/null 2>&1 || dnf module install -y "nodejs:${NODE_MIN_MAJOR}" >/dev/null 2>&1 ;;
+        arch) pacman -S --noconfirm nodejs npm >/dev/null 2>&1 ;;
+        suse) zypper install -y "nodejs${NODE_MIN_MAJOR}" >/dev/null 2>&1 || zypper install -y nodejs npm >/dev/null 2>&1 ;;
+        alpine) apk add nodejs npm >/dev/null 2>&1 ;;
+        *) return 1 ;;
+    esac
+    command -v node >/dev/null 2>&1
+}
+
+# Resolve a Node interpreter meeting NODE_MIN_MAJOR. Returns 0 when a usable
+# Node is on PATH afterwards (already present, or just auto-installed); 1
+# when none is found and auto-install is disabled/unavailable/failed.
+# Read-only unless HAL0_NODE_AUTOINSTALL=1.
+resolve_node() {
+    local m
+    if m="$(_node_major)" && (( m >= NODE_MIN_MAJOR )); then
+        return 0
+    fi
+    _node_autoinstall || return 1
+    m="$(_node_major)" || return 1
+    (( m >= NODE_MIN_MAJOR ))
+}
+
 # ── aggregate runner ────────────────────────────────────────────────────────
 
 # Run every check; return non-zero if any failed. We deliberately don't

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -449,14 +449,52 @@ _resolve_container_runtime() {
     return 1
 }
 
+# `<rt> info`/`podman pull` (the probes above) can succeed in an unprivileged
+# Proxmox/LXC container WITHOUT `features: nesting=1` — podman reports itself
+# usable, but every actual `<rt> run` fails on cgroup/mount-namespace setup it
+# can't do without nesting. That's the false-OK this closes: pre-flight
+# passes, install reports success, then every hal0-slot@ inference slot,
+# hal0-openwebui, ComfyUI, and the Honcho compose stack die at runtime with
+# cgroup/mount errors the operator never saw at install time. Bounded with
+# `timeout` so an offline host fails fast instead of hanging the install;
+# HAL0_CONTAINER_SMOKE_IMAGE overrides the pulled image for air-gapped/
+# mirrored registries.
+_container_run_smoke_test() {
+    local rt="$1" image="${HAL0_CONTAINER_SMOKE_IMAGE:-quay.io/podman/hello}"
+    timeout 30 "${rt}" run --rm "${image}" true >/dev/null 2>&1
+}
+
+# Run the real `<rt> run` smoke test and print the LXC-nesting remedy on
+# failure. Only called in REQUIRED mode (install.sh) — `hal0 doctor` stays
+# fast and side-effect-free (no image pull) in the default soft mode.
+_container_runtime_gate() {
+    local rt="$1"
+    if _container_run_smoke_test "${rt}"; then
+        return 0
+    fi
+    err "${rt} info/version succeeded but '${rt} run' failed — the runtime can't actually launch a container"
+    if grep -qa 'container=lxc' /proc/1/environ 2>/dev/null; then
+        warn "  inside an unprivileged Proxmox/LXC container this needs 'features: nesting=1' (and often keyctl=1)"
+        warn "  set it in /etc/pve/lxc/<CTID>.conf on the PROXMOX HOST, then: pct stop <CTID> && pct start <CTID>"
+    else
+        warn "  inspect the error above (cgroup/mount-namespace setup, subuid/newuidmap, or a daemon issue)"
+    fi
+    return 1
+}
+
 preflight_container_runtime() {
-    # Fast path: a runtime is already installed and working.
+    local required="${HAL0_CONTAINER_REQUIRED:-${HAL0_DOCKER_REQUIRED:-0}}"
+
+    # Fast path: a runtime is already installed and working per `<rt> info`.
     local rt
     if rt="$(_resolve_container_runtime)"; then
         if [[ "${rt}" == podman ]]; then
             info "podman: $(podman version --format '{{.Version}}' 2>/dev/null || echo unknown)"
         else
             info "docker: $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo unknown)"
+        fi
+        if [[ "${required}" == "1" ]]; then
+            _container_runtime_gate "${rt}" || return 1
         fi
         return 0
     fi
@@ -508,6 +546,7 @@ preflight_container_runtime() {
         esac
         if [[ "${ok}" -eq 1 ]] && rt="$(_resolve_container_runtime)" && [[ "${rt}" == podman ]]; then
             info "podman: $(podman version --format '{{.Version}}' 2>/dev/null || echo unknown)"
+            _container_runtime_gate "${rt}" || return 1
             return 0
         fi
         err "podman install/initialisation failed — see output above; check 'podman info'"

--- a/tests/installer/test_preflight_python_floor.py
+++ b/tests/installer/test_preflight_python_floor.py
@@ -1,0 +1,191 @@
+"""Python floor parity — installer/lib/preflight.sh vs pyproject.toml.
+
+pyproject.toml pins ``requires-python = ">=3.12"``, but preflight_python
+used to accept 3.11 and only warn (not fail) on 3.10 — every stock Debian
+12 / Ubuntu 22.04 system python3. install.sh treated that as non-fatal
+("pip may still work") and only died minutes later, deep inside
+``pip install``, with a recovery hint (``HAL0_PYTHON=python3.12``) that's a
+dead end on those distros' base repos (no python3.12 package).
+
+preflight_python now enforces the same >=3.12 floor as pyproject.toml, and
+resolve_main_python (+ _main_py_autoinstall) resolves — or, when asked,
+auto-installs — a compatible interpreter, mirroring
+resolve_hindsight_python's pattern for the (separate) Hindsight venv.
+
+These tests exercise the shell functions directly (subprocess, real bash —
+same technique as ``tests/installer/test_bootstrap_prereq_parity.py`` and
+``tests/installer/test_preflight_gpu_gate.py``) against FAKE python
+interpreters that report a fixed version regardless of the real
+interpreter running the test suite, plus a couple of static-text
+assertions against install.sh proving the die-on-unresolved wiring exists.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+_STUBS = (
+    "info() { printf 'INFO: %s\\n' \"$*\"; }\n"
+    "warn() { printf 'WARN: %s\\n' \"$*\"; }\n"
+    "err()  { printf 'ERR: %s\\n' \"$*\" >&2; }\n"
+    'die()  { err "$*"; exit 1; }\n'
+    "pkg_install_cmd() { :; }\n"
+)
+
+
+def _write_fake_python(path: Path, version: str) -> None:
+    """A fake `pythonX` that reports ``version`` (e.g. "3.11") regardless
+    of the code it's asked to run — it only pattern-matches the two exact
+    snippets preflight.sh feeds an interpreter."""
+    major, minor = version.split(".")
+    body = f"""#!/usr/bin/env bash
+if [[ "$1" == "-c" ]]; then
+    case "$2" in
+        *'sys.version_info[:2]'*) echo "{major}.{minor}" ;;
+        *'sys.version_info[1]'*) echo "{minor}" ;;
+        *) exit 1 ;;
+    esac
+    exit 0
+fi
+exit 0
+"""
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(script_body: str, bin_dir: Path, extra_env: dict[str, str] | None = None):
+    # subprocess.run(["bash", ...]) resolves "bash" against the PATH we
+    # hand it (not the test runner's own PATH), so the restricted bin_dir
+    # needs a real bash alongside the fake python interpreters the test
+    # seeded — same technique as test_bootstrap_prereq_parity.py's
+    # full_bin_dir fixture.
+    if not (bin_dir / "bash").exists():
+        found = shutil.which("bash")
+        assert found is not None, "no bash on the test runner's PATH"
+        os.symlink(found, bin_dir / "bash")
+    script = "set -euo pipefail\n" + _STUBS + f"source {_PREFLIGHT!s}\n" + script_body
+    env = {"PATH": str(bin_dir), **(extra_env or {})}
+    return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+
+
+class TestPreflightPythonFloor:
+    @pytest.mark.parametrize("version", ["3.12", "3.13", "3.14"])
+    def test_at_or_above_floor_passes(self, tmp_path: Path, version: str) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", version)
+        proc = _run("preflight_python; exit $?\n", d)
+        assert proc.returncode == 0, proc.stderr
+        assert version in proc.stdout
+
+    @pytest.mark.parametrize("version", ["3.11", "3.10"])
+    def test_below_floor_fails(self, tmp_path: Path, version: str) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", version)
+        proc = _run("rc=0; preflight_python || rc=$?; exit $rc\n", d)
+        assert proc.returncode != 0
+        out = proc.stdout + proc.stderr
+        assert "hal0 requires >=3.12" in out
+
+    def test_3_11_is_no_longer_accepted(self, tmp_path: Path) -> None:
+        # Regression guard: 3.11 used to be in the accepted regex
+        # (^3\.(11|12|13|14)$) — pin the floor at 3.12 going forward.
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", "3.11")
+        proc = _run("rc=0; preflight_python || rc=$?; exit $rc\n", d)
+        assert proc.returncode != 0
+
+
+class TestResolveMainPython:
+    def test_default_already_at_floor_is_used_as_is(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", "3.13")
+        proc = _run("resolve_main_python\n", d)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip().endswith("python3")
+
+    def test_finds_a_floor_python_already_on_path(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", "3.11")  # below floor
+        _write_fake_python(d / "python3.12", "3.12")  # on PATH, in-band
+        proc = _run("resolve_main_python\n", d)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip().endswith("python3.12")
+
+    def test_no_floor_python_and_no_autoinstall_fails(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", "3.11")
+        # HAL0_PY_AUTOINSTALL unset — resolve_main_python must not attempt
+        # to mutate the system (mirrors resolve_hindsight_python's same
+        # read-only-by-default contract) and must fail closed.
+        proc = _run("rc=0; resolve_main_python || rc=$?; exit $rc\n", d)
+        assert proc.returncode != 0
+
+    def test_autoinstall_failure_is_non_fatal_and_returns_1(self, tmp_path: Path) -> None:
+        # HAL0_PY_AUTOINSTALL=1 but no real apt-get on PATH (restricted bin
+        # dir) — the auto-install attempt fails harmlessly (command not
+        # found -> `|| return 1`), never touching the network or the host.
+        d = tmp_path / "bin"
+        d.mkdir()
+        _write_fake_python(d / "python3", "3.11")
+        script = (
+            "pkg_mgr() { echo apt-get; return 0; }\n"
+            "distro_family() { echo debian; return 0; }\n"
+            "rc=0; resolve_main_python || rc=$?; exit $rc\n"
+        )
+        proc = _run(script, d, extra_env={"HAL0_PY_AUTOINSTALL": "1"})
+        assert proc.returncode != 0
+
+
+class TestInstallShWiring:
+    """install.sh must hard-die on an unresolved below-floor interpreter,
+    not fall through with just a warning (the old "pip may still work"
+    posture)."""
+
+    def test_install_sh_calls_resolve_main_python(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        assert "resolve_main_python" in text
+
+    def test_unresolved_floor_mismatch_is_fatal(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        m = re.search(
+            r"if ! preflight_python; then(.*?)\nfi\n",
+            text,
+            re.DOTALL,
+        )
+        assert m is not None, "preflight_python guard block not found in install.sh"
+        body = m.group(1)
+        assert "resolve_main_python" in body
+        assert re.search(r"\bdie\b", body), (
+            "a below-floor interpreter that can't be resolved must die(), "
+            "not just warn and continue"
+        )
+
+    def test_preflight_regex_floor_is_3_12(self) -> None:
+        text = _PREFLIGHT.read_text(encoding="utf-8")
+        assert r"^3\.(12|13|14)$" in text
+        assert r"^3\.(11|12|13|14)$" not in text
+
+
+def test_bash_syntax_check() -> None:
+    for path in (_INSTALL_SH, _PREFLIGHT):
+        proc = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, f"{path}: {proc.stderr}"


### PR DESCRIPTION
## Summary

11 confirmed, adversarially-verified installer defects fixed, plus one env-robustness finding added mid-review (Node.js LTS auto-provisioning). Scope: `installer/install.sh` + `installer/lib/preflight.sh` only. One commit per finding.

- **Python floor (3.11→3.12)**: `preflight_python` now enforces pyproject.toml's `requires-python >=3.12` floor; `resolve_main_python`/`_main_py_autoinstall` resolve or auto-install a compatible interpreter (mirrors the Hindsight venv's pattern) instead of a dead-end hint; install.sh now hard-`die`s early on an unresolved floor mismatch instead of limping into `pip install`.
- **Root umask**: install body now runs under `umask 022` (save/restore), so a hardened root umask (0027/0077) no longer leaves the venv/FHS tree/`/var/lib/hal0`/`/etc/hal0/slots` at 0700 and breaking the non-root `hal0` CLI.
- **Honcho compose-provider install**: routed through `lib/distro.sh`'s `pkg_mgr`/`distro_family` dispatch instead of a hardcoded `apt-get install docker-compose-v2`, which was a silent no-op on non-apt hosts.
- **Dashboard build non-fatal**: `npm install`/`npm run build` failures now warn + degrade (same posture as the npm-absent path) instead of aborting the whole install after the venv/wheel/config/units were already written.
- **Node version gate**: the dashboard build now checks `node -v` major >=20 before attempting the build, taking the soft-skip path on an old/missing Node instead of failing deep inside esbuild/oxide.
- **Honcho enabled flag**: `[honcho].enabled=true` is now persisted via `hal0.config.loader` after a successful `systemctl enable --now hal0-honcho`, so hal0's own config agrees with the running unit.
- **Stage-2 `hal0 setup` dead-end**: the launched setup's stdin is now redirected to `/dev/tty` (+ `HAL0_FORCE_INTERACTIVE=1`), fixing the piped-install (`curl | bash`) dead-end where the wizard silently no-op'd.
- **Container-runtime false OK**: `preflight_container_runtime` in REQUIRED mode now runs a real `podman run --rm <image> true` smoke test (bounded with `timeout`), catching the unprivileged-LXC-without-nesting false-OK and printing the `nesting=1` remedy.
- **`preflight_node`**: added to `preflight_all` so `hal0 doctor` reports Node presence/version.
- **hal0-honcho enable guard**: `systemctl enable --now hal0-honcho` is now gated on the image actually existing, avoiding a restart-loop on a failed build.
- **Container graphroot disk check**: `preflight_disk` now also probes the podman/docker graphroot (`/var/lib/containers` / `/var/lib/docker`), warn-only, closing the same cross-mount blind spot already patched for the model store.
- **Node.js LTS auto-provisioning** (added mid-review): new "Node.js toolchain" install.sh step provisions Node >=20 via the detected package manager (NodeSource on Debian/Ubuntu, distro packages elsewhere) — fixes the dashboard build AND unblocks `hal0 agent install pi-coder`/`opencode`, which previously failed with a misleading "upstream breaking change" message when npm was simply absent.

## Test plan
- [x] `bash -n installer/install.sh installer/lib/preflight.sh` — clean
- [x] `shellcheck installer/install.sh installer/lib/preflight.sh` — no new warnings vs origin/main baseline (pre-existing SC1091/SC2034/SC2119/SC2120 only)
- [x] `uv sync --extra dev && .venv/bin/python -m pytest tests/installer/ tests/install/ -q` — 202 passed, 1 skipped (pre-existing, host-dependent)
- [x] Added `tests/installer/test_preflight_python_floor.py` (14 tests) covering the 3.12 floor + `resolve_main_python` resolution/autoinstall paths
- [x] Manually smoke-tested `preflight_container_runtime`'s new `podman run` gate and `resolve_node` against stubbed binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)