### PR TITLE
fix(installer): init hc_cur_tag (unbound var aborted Honcho standup)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1899,6 +1899,7 @@ else
             # Idempotent shallow clone: skip re-cloning if src is already
             # checked out at HONCHO_REF.
             hc_cur_ref=""
+            hc_cur_tag=""
             if [[ -d "${HC_DIR}/src/.git" ]]; then
                 hc_cur_ref="$(git -C "${HC_DIR}/src" rev-parse HEAD 2>/dev/null || true)"
                 hc_cur_tag="$(git -C "${HC_DIR}/src" describe --tags --exact-match 2>/dev/null || true)"


### PR DESCRIPTION
Under `set -u`, `hc_cur_tag` was only assigned inside the `[[ -d src/.git ]]` branch but read unconditionally at the clone-skip check → `HAL0_INSTALL_HONCHO=1` on a fresh box aborted with `hc_cur_tag: unbound variable`. Init to `""` next to `hc_cur_ref`. Found on the live LXC standing up the Honcho stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)