### PR TITLE
fix(installer): harden Honcho memory standup (F24/F26/F27/F28)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1979,6 +1979,56 @@ HC_APPARMOR_EOF
                 # the rest of this block reports for a missing prerequisite
                 # (same defensive posture as the openwebui/hindsight blocks).
                 if podman image exists "${HC_IMAGE_TAG}" >/dev/null 2>&1; then
+                    # ── pgvector dim reconciliation (#F27, HIGH) ───────────
+                    # Honcho's pgvector schema initializes at its OWN
+                    # default embedding dimension (1536) on first DB boot —
+                    # it has no idea hal0 already pinned
+                    # EMBEDDING_VECTOR_DIMENSIONS to whatever hal0's actual
+                    # embedding model produces (1024 for qwen3-embedding).
+                    # honcho-api treats that mismatch as fatal
+                    # (StartupValidationError) and crash-loops forever
+                    # rather than reconciling itself — live-reproduced on
+                    # Ubuntu 24.04 LXC. Bring up ONLY database+redis first,
+                    # run honcho's own scripts/configure_embeddings.py
+                    # --yes (inside the honcho image, against the compose
+                    # DB) to align the schema, THEN start the full stack —
+                    # so api/deriver boot against an already-correct schema
+                    # instead of racing it during compose's
+                    # dependency-ordered startup. Verified manually: this
+                    # is the exact fix that gets honcho-api healthy.
+                    hc_embed_dim="$(sed -n 's/^EMBEDDING_VECTOR_DIMENSIONS=//p' /etc/hal0/honcho.env 2>/dev/null | tail -1)"
+                    hc_embed_dim="${hc_embed_dim:-1024}"
+                    hc_db_uri="postgresql+psycopg://postgres:postgres@database:5432/postgres"
+                    info "reconciling Honcho pgvector schema to ${hc_embed_dim} dims…"
+                    if podman compose --project-name hal0-honcho -f "${HC_DIR}/docker-compose.yml" \
+                        up -d --no-build database redis >/dev/null 2>&1; then
+                        hc_db_up=0
+                        for _ in $(seq 1 20); do
+                            if podman run --rm --network hal0-honcho_default pgvector/pgvector:pg15 \
+                                pg_isready -h database -U postgres >/dev/null 2>&1; then
+                                hc_db_up=1
+                                break
+                            fi
+                            sleep 3
+                        done
+                        if [[ "${hc_db_up}" -eq 1 ]]; then
+                            if podman run --rm --network hal0-honcho_default \
+                                -e DB_CONNECTION_URI="${hc_db_uri}" \
+                                -e EMBEDDING_VECTOR_DIMENSIONS="${hc_embed_dim}" \
+                                --entrypoint /app/.venv/bin/python \
+                                "${HC_IMAGE_TAG}" scripts/configure_embeddings.py --yes >/dev/null 2>&1; then
+                                info "Honcho pgvector schema reconciled to ${hc_embed_dim} dims"
+                            else
+                                warn "configure_embeddings.py failed — honcho-api may crash-loop on a dimension mismatch"
+                                warn "  rerun by hand: podman run --rm --network hal0-honcho_default -e DB_CONNECTION_URI=${hc_db_uri} -e EMBEDDING_VECTOR_DIMENSIONS=${hc_embed_dim} --entrypoint /app/.venv/bin/python ${HC_IMAGE_TAG} scripts/configure_embeddings.py --yes"
+                            fi
+                        else
+                            warn "Honcho database did not become reachable in time — skipping pgvector dim reconciliation (honcho-api may crash-loop)"
+                        fi
+                    else
+                        warn "failed to start Honcho database+redis ahead of schema reconciliation — honcho-api may crash-loop"
+                    fi
+
                     systemctl enable --now hal0-honcho
 
                     # Persist [honcho].enabled=true so hal0's own config

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1856,39 +1856,62 @@ else
         info "setting up Honcho memory engine (podman compose stack) — this can take a few minutes…"
 
         # podman-native (see hal0-honcho.service): `podman compose`
-        # delegates to the docker-compose v2 binary over podman.socket —
-        # no docker engine (whose default AppArmor profile can't even load
-        # inside an unprivileged LXC).
+        # delegates to a compose provider binary over podman.socket — no
+        # docker engine required.
         hc_compose_ok=0
         if podman compose version >/dev/null 2>&1; then
             hc_compose_ok=1
         else
-            # Package NAME differs by distro ecosystem (docker-compose-v2 on
-            # Debian/Ubuntu, podman-compose on Fedora/Arch/openSUSE) — route
-            # through lib/distro.sh's pkg_mgr/distro_family dispatch instead
-            # of a bare apt-get, which was a silent no-op on every non-apt
-            # host (the only unguarded apt-get in this script; every FLM
-            # apt-get elsewhere sits behind a `command -v apt-get` gate).
-            hc_compose_pkg=""
-            case "$(distro_family 2>/dev/null)" in
-                debian) hc_compose_pkg="docker-compose-v2" ;;
-                fedora | suse | arch) hc_compose_pkg="podman-compose" ;;
+            # Prefer podman-compose (pure-Python, no Docker engine, no
+            # AppArmor profile pull) on EVERY distro — honcho's own unit
+            # (hal0-honcho.service) invokes `podman compose`, so podman is
+            # always the runtime here regardless of distro ecosystem.
+            # Live-reproduced on Ubuntu 24.04 (unprivileged LXC, #F26):
+            # this block used to install docker-compose-v2 on every Debian
+            # family host, which drags in Docker's AppArmor integration —
+            # "install profile containers-default apparmor: exit 243" —
+            # and broke `podman run` entirely, taking down the box's
+            # PRIMARY runtime while standing up an *optional* memory
+            # backend. podman-compose carries no such dependency chain.
+            case "$(pkg_mgr 2>/dev/null)" in
+                apt-get) apt-get install -y podman-compose >/dev/null 2>&1 || true ;;
+                dnf) dnf install -y podman-compose >/dev/null 2>&1 || true ;;
+                yum) yum install -y podman-compose >/dev/null 2>&1 || true ;;
+                zypper) zypper install -y podman-compose >/dev/null 2>&1 || true ;;
+                pacman) pacman -S --noconfirm podman-compose >/dev/null 2>&1 || true ;;
             esac
-            if [[ -n "${hc_compose_pkg}" ]]; then
-                warn "podman compose provider missing — attempting to install ${hc_compose_pkg}"
-                case "$(pkg_mgr 2>/dev/null)" in
-                    apt-get) apt-get install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
-                    dnf) dnf install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
-                    yum) yum install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
-                    zypper) zypper install -y "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
-                    pacman) pacman -S --noconfirm "${hc_compose_pkg}" >/dev/null 2>&1 || true ;;
-                esac
-            fi
             if podman compose version >/dev/null 2>&1; then
                 hc_compose_ok=1
-            else
-                hc_compose_hint="$(pkg_install_cmd "${hc_compose_pkg:-docker-compose-v2}" 2>/dev/null \
-                    || echo "install a docker-compose-v2-compatible provider")"
+            elif [[ "$(distro_family 2>/dev/null)" == "debian" ]]; then
+                # podman-compose isn't packaged (older Debian/Ubuntu):
+                # fall back to docker-compose-v2, but harden podman's own
+                # AppArmor posture FIRST via a containers.conf.d drop-in
+                # (survives package upgrades, never touches an
+                # operator-owned containers.conf) so the primary runtime
+                # keeps working even after docker-compose-v2's
+                # containerd.io/docker.io dependency chain lands.
+                warn "podman-compose unavailable — falling back to docker-compose-v2 (hardening podman's apparmor profile first)"
+                mkdir -p /etc/containers/containers.conf.d
+                cat > /etc/containers/containers.conf.d/99-hal0-honcho-apparmor.conf <<'HC_APPARMOR_EOF'
+# Written by hal0's installer (Honcho standup, #F26): installing
+# docker-compose-v2 as the podman-compose fallback pulls Docker's
+# AppArmor integration, which in an unprivileged LXC can leave podman's
+# own "containers-default" profile unloadable. Pin podman to
+# apparmor_profile=unconfined so it keeps working regardless.
+[containers]
+apparmor_profile = "unconfined"
+HC_APPARMOR_EOF
+                apt-get install -y docker-compose-v2 >/dev/null 2>&1 || true
+                if podman compose version >/dev/null 2>&1; then
+                    hc_compose_ok=1
+                fi
+                if ! podman info >/dev/null 2>&1; then
+                    warn "podman appears broken after installing docker-compose-v2 — check 'podman info' (apparmor hardening is at /etc/containers/containers.conf.d/99-hal0-honcho-apparmor.conf)"
+                fi
+            fi
+            if [[ "${hc_compose_ok}" -ne 1 ]]; then
+                hc_compose_hint="$(pkg_install_cmd podman-compose 2>/dev/null \
+                    || echo "install podman-compose or a docker-compose-v2-compatible provider")"
                 warn "podman compose still unavailable — Honcho will be skipped (${hc_compose_hint} and re-run)"
             fi
         fi

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -72,8 +72,13 @@
 #                        bound almost always means hal0's OWN hal0-api /
 #                        hal0-openwebui units are up and healthy, not a
 #                        collision. install.sh's pre-install gate never
-#                        sets it, so a real collision before install still
-#                        hard-fails.
+#                        sets it — but even there, a port held by hal0's
+#                        OWN hal0-api/hal0-openwebui unit (the documented
+#                        `HAL0_INSTALL_HONCHO=1 sudo bash install.sh`
+#                        re-install-over-a-live-box path, #F24) is
+#                        auto-detected via _preflight_port_is_own_service
+#                        and treated as OK; a FOREIGN process holding the
+#                        port still hard-fails unconditionally.
 #   HAL0_CONTAINER_REQUIRED — when "1", preflight_container_runtime
 #                        auto-installs podman (via the detected package
 #                        manager) and hard-fails (returns non-zero) when it
@@ -790,6 +795,39 @@ _preflight_port_in_use() {
     return 1
 }
 
+# The PID of the process LISTENing on ``port``, or empty when it can't be
+# determined (no `ss`, unreadable, or nothing listening). Requires `ss -p`,
+# which needs root (or the socket's owning uid) to resolve — install.sh
+# always runs as root, so this is reliable there; `hal0 doctor` may run
+# unprivileged, in which case this silently yields nothing and callers fall
+# back to the generic "already in use" message.
+_preflight_port_owner_pid() {
+    local port="$1"
+    command -v ss >/dev/null 2>&1 || return 1
+    ss -ltnp "sport = :${port}" 2>/dev/null \
+        | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2
+}
+
+# True when the process holding ``port`` is the MainPID of one of hal0's own
+# systemd units (hal0-api.service, hal0-openwebui.service) — i.e. re-running
+# the installer over a live, healthy hal0 rather than colliding with an
+# unrelated process (#F24). Never hard-fails the caller: on any ambiguity
+# (no systemctl, no PID, no match) this returns non-zero so preflight_ports
+# keeps its existing hard-fail-on-foreign-holder behaviour.
+_preflight_port_is_own_service() {
+    local port="$1" pid unit mainpid
+    command -v systemctl >/dev/null 2>&1 || return 1
+    pid="$(_preflight_port_owner_pid "${port}")"
+    [[ -n "${pid}" ]] || return 1
+    for unit in hal0-api.service hal0-openwebui.service; do
+        mainpid="$(systemctl show -p MainPID --value "${unit}" 2>/dev/null)"
+        if [[ -n "${mainpid}" && "${mainpid}" != "0" && "${mainpid}" == "${pid}" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 preflight_ports() {
     local ports=("$@")
     if (( ${#ports[@]} == 0 )); then
@@ -804,6 +842,8 @@ preflight_ports() {
         if _preflight_port_in_use "${port}"; then
             if [[ "${HAL0_DOCTOR_PORTS_SOFT:-0}" == "1" ]]; then
                 warn "port ${port}: already in use (expected if hal0's own services are running; find the owner with 'ss -ltnp \"sport = :${port}\"')"
+            elif _preflight_port_is_own_service "${port}"; then
+                info "port ${port}: in use by hal0's own service — OK for a re-install"
             else
                 err "port ${port}: already in use (find with 'ss -ltnp \"sport = :${port}\"')"
                 rc=1

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -581,6 +581,43 @@ CURATED_MODELS: list[CuratedModel] = [
         capability="embed",
         backend="llamacpp",
     ),
+    # qwen3-embedding-0-6b-q8-0 is the memory pipeline's default embedding
+    # pick (hal0.memory.honcho_env.DEFAULT_FEATURE_MODELS["embedding"] and
+    # HonchoLLMConfig.embedding_dimensions both default to it/1024) — it
+    # must stay pullable via the curated catalogue or the Honcho/Hindsight
+    # embedding pipeline has no model to pull (#F28, live-reproduced: `hal0
+    # model pull qwen3-embedding-0-6b-q8-0` 422'd with "no hugging face
+    # source" before this entry existed). Qwen's own GGUF quant natively
+    # emits 1024-dim vectors, matching hal0's EMBEDDING_VECTOR_DIMENSIONS
+    # default exactly — no truncation/padding needed.
+    CuratedModel(
+        id="qwen3-embedding-0-6b-q8-0",
+        display_name="Qwen3 Embedding 0.6B (Q8_0)",
+        description=(
+            "Qwen's own 1024-dim embedding model. Default pick for hal0's "
+            "memory pipeline (Hindsight + Honcho) — its native output "
+            "dimension matches hal0's EMBEDDING_VECTOR_DIMENSIONS default."
+        ),
+        family="qwen",
+        size_gb=0.64,
+        vram_gb_min=0.5,
+        license="Apache-2.0",
+        license_url="https://www.apache.org/licenses/LICENSE-2.0",
+        hf_repo="Qwen/Qwen3-Embedding-0.6B-GGUF",
+        hf_file="Qwen3-Embedding-0.6B-Q8_0.gguf",
+        context_length=32768,
+        recommended_slot="embed",
+        tags=["embed", "light"],
+        notes=(
+            "1024-dim native output — the memory pipeline (Hindsight "
+            "retain + the Honcho deriver) is wired to this id by default; "
+            "changing it means also updating "
+            "[honcho.llm.embedding]/EMBEDDING_VECTOR_DIMENSIONS to match "
+            "the replacement's dimension."
+        ),
+        capability="embed",
+        backend="llamacpp",
+    ),
     CuratedModel(
         id="bge-base-en-v1.5-q4_k_m",
         display_name="BGE Base EN v1.5 (Q4_K_M)",

--- a/tests/installer/test_preflight_ports_own_service.py
+++ b/tests/installer/test_preflight_ports_own_service.py
@@ -52,11 +52,7 @@ def _fake_systemctl(tmp_path: Path, unit_to_pid: dict[str, str]) -> None:
 
 def _run_preflight_ports(tmp_path: Path, env_overrides: dict[str, str]) -> tuple[int, str]:
     script = (
-        "set -uo pipefail\n"
-        f"source {PREFLIGHT!s}\n"
-        "rc=0\n"
-        f"preflight_ports {PORT} || rc=$?\n"
-        "exit $rc\n"
+        f"set -uo pipefail\nsource {PREFLIGHT!s}\nrc=0\npreflight_ports {PORT} || rc=$?\nexit $rc\n"
     )
     env = {**os.environ, "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}", **env_overrides}
     proc = subprocess.run(

--- a/tests/installer/test_preflight_ports_own_service.py
+++ b/tests/installer/test_preflight_ports_own_service.py
@@ -1,0 +1,108 @@
+"""Contract tests for ``preflight_ports``' own-service detection (#F24).
+
+install.sh's pre-install port gate used to hard-fail whenever 8080/3001
+were already LISTENing — including the documented
+``HAL0_INSTALL_HONCHO=1 sudo bash install.sh`` re-install-over-a-live-box
+path, where the listener is hal0's own hal0-api/hal0-openwebui unit. These
+tests drive ``preflight_ports`` through fake ``ss``/``systemctl`` shims on
+PATH (real port binding + real systemd units aren't available in CI) to
+prove: a port held by hal0's own unit passes; a port held by a foreign
+process still hard-fails; and ``HAL0_DOCTOR_PORTS_SOFT`` keeps its existing
+blanket-warn behaviour regardless of ownership.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PREFLIGHT = Path(__file__).resolve().parents[2] / "installer" / "lib" / "preflight.sh"
+
+PORT = "9999"
+OWN_PID = "4242"
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _fake_ss(tmp_path: Path, pid: str) -> None:
+    _write_exec(
+        tmp_path / "ss",
+        (
+            'echo "State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process"\n'
+            f'echo "LISTEN 0 128 0.0.0.0:{PORT} 0.0.0.0:* '
+            f'users:((\\"fake\\",pid={pid},fd=3))"\n'
+        ),
+    )
+
+
+def _fake_systemctl(tmp_path: Path, unit_to_pid: dict[str, str]) -> None:
+    branches = []
+    for unit, pid in unit_to_pid.items():
+        branches.append(f'if [[ "$5" == "{unit}" ]]; then echo "{pid}"; exit 0; fi')
+    body = "\n".join(branches) + '\necho "0"\n'
+    _write_exec(tmp_path / "systemctl", body)
+
+
+def _run_preflight_ports(tmp_path: Path, env_overrides: dict[str, str]) -> tuple[int, str]:
+    script = (
+        "set -uo pipefail\n"
+        f"source {PREFLIGHT!s}\n"
+        "rc=0\n"
+        f"preflight_ports {PORT} || rc=$?\n"
+        "exit $rc\n"
+    )
+    env = {**os.environ, "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}", **env_overrides}
+    proc = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True, cwd=str(tmp_path)
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_own_service_port_passes(tmp_path: Path) -> None:
+    """Port held by hal0-api's own MainPID → OK (0), not a hard fail."""
+    _fake_ss(tmp_path, OWN_PID)
+    _fake_systemctl(tmp_path, {"hal0-api.service": OWN_PID})
+    rc, out = _run_preflight_ports(tmp_path, {})
+    assert rc == 0, out
+    assert "OK for a re-install" in out
+
+
+def test_foreign_process_port_hard_fails(tmp_path: Path) -> None:
+    """Port held by an unrelated process (no unit MainPID match) → hard fail."""
+    _fake_ss(tmp_path, "9999")
+    _fake_systemctl(tmp_path, {"hal0-api.service": OWN_PID})
+    rc, out = _run_preflight_ports(tmp_path, {})
+    assert rc != 0, out
+    assert "already in use" in out
+
+
+def test_no_systemctl_hard_fails_like_before(tmp_path: Path) -> None:
+    """No systemctl on PATH (non-systemd host) → falls back to the old hard fail."""
+    _fake_ss(tmp_path, OWN_PID)
+    rc, out = _run_preflight_ports(tmp_path, {})
+    assert rc != 0, out
+
+
+def test_soft_mode_warns_regardless_of_ownership(tmp_path: Path) -> None:
+    """HAL0_DOCTOR_PORTS_SOFT=1 (hal0 doctor) still just warns — unchanged."""
+    _fake_ss(tmp_path, "1")
+    _fake_systemctl(tmp_path, {"hal0-api.service": OWN_PID})
+    rc, out = _run_preflight_ports(tmp_path, {"HAL0_DOCTOR_PORTS_SOFT": "1"})
+    assert rc == 0, out
+    assert "expected if hal0's own services are running" in out
+
+
+@pytest.mark.parametrize("unit", ["hal0-api.service", "hal0-openwebui.service"])
+def test_either_own_unit_is_recognised(tmp_path: Path, unit: str) -> None:
+    """Both hal0-api and hal0-openwebui are recognised as own-service owners."""
+    _fake_ss(tmp_path, OWN_PID)
+    _fake_systemctl(tmp_path, {unit: OWN_PID})
+    rc, out = _run_preflight_ports(tmp_path, {})
+    assert rc == 0, out

--- a/tests/registry/test_curated.py
+++ b/tests/registry/test_curated.py
@@ -67,3 +67,23 @@ def test_curated_model_validates_required_fields() -> None:
 def test_lookup_index_matches_list() -> None:
     """CURATED_BY_ID is the same set as the list."""
     assert set(CURATED_BY_ID.keys()) == {m.id for m in CURATED_MODELS}
+
+
+def test_memory_pipeline_default_embed_model_is_pullable() -> None:
+    """The memory pipeline's default embed id must resolve to a real curated pull source (#F28).
+
+    ``hal0.memory.honcho_env.DEFAULT_FEATURE_MODELS["embedding"]`` (and
+    ``HonchoLLMConfig.embedding_dimensions``' default) both point at this
+    id — without a curated ``hf_repo``/``hf_file`` for it, `hal0 model pull
+    qwen3-embedding-0-6b-q8-0` 422s and the memory pipeline (Hindsight
+    retain + the Honcho deriver) has no embedding model to actually pull.
+    """
+    from hal0.memory.honcho_env import DEFAULT_FEATURE_MODELS
+
+    embed_id = DEFAULT_FEATURE_MODELS["embedding"]
+    model = get_curated(embed_id)
+    assert model is not None, (
+        f"{embed_id!r} (memory pipeline's default embed model) has no curated catalogue entry"
+    )
+    assert model.hf_repo and model.hf_file
+    assert model.capability == "embed"


### PR DESCRIPTION
## Summary
Four live-discovered defects found standing up the opt-in Honcho memory stack + embed model on a real Ubuntu 24.04 LXC, each fixed in its own commit:

- **F24** (medium): `preflight_ports` hard-failed re-running install.sh over a live hal0 (ports held by hal0's own hal0-api/hal0-openwebui). Added `_preflight_port_is_own_service`, matching the port's listener PID against `hal0-api.service`/`hal0-openwebui.service`'s systemctl MainPID (mirrors the `HAL0_DOCTOR_PORTS_SOFT` pattern from #1284). A foreign holder still hard-fails.
- **F26** (medium): the Honcho compose-provider step installed `docker-compose-v2` on every Debian-family host, dragging in Docker's AppArmor integration and breaking `podman run` in an unprivileged LXC (exit 243). Now prefers `podman-compose` on every distro; falls back to `docker-compose-v2` only on Debian/Ubuntu when unavailable, hardening podman via a `containers.conf.d` apparmor drop-in first.
- **F27** (HIGH): honcho-api crash-looped on first start — pgvector schema initializes at Honcho's default dim (1536) but hal0 pins `EMBEDDING_VECTOR_DIMENSIONS=1024`. install.sh now brings up database+redis first, runs Honcho's `scripts/configure_embeddings.py --yes` inside the honcho image against the compose DB to reconcile the schema, then starts the full stack.
- **F28** (medium): the memory pipeline's default embed model id (`qwen3-embedding-0-6b-q8-0`) had no curated `hf_repo`/`hf_file`, so `hal0 model pull` 422'd. Added a curated catalogue entry (`Qwen/Qwen3-Embedding-0.6B-GGUF`) — native 1024-dim output matches hal0's default exactly.

## Test plan
- [x] `bash -n` clean on `installer/install.sh` and `installer/lib/preflight.sh`
- [x] `shellcheck` diff vs origin/main baseline is empty (no new warnings) on both files
- [x] New test `tests/installer/test_preflight_ports_own_service.py` (own-service pass / foreign-holder fail / no-systemctl fallback / soft-mode unchanged / both units recognised) — 6 passed
- [x] New test `test_memory_pipeline_default_embed_model_is_pullable` in `tests/registry/test_curated.py`
- [x] `tests/installer/ tests/install/ tests/registry/ tests/memory/test_honcho_env.py` — 442 passed, 1 pre-existing unrelated skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)