### PR TITLE
feat(images): rocmfpx as universal default + hal0 update slot migration

### DIFF
--- a/docs/design/container-image-overhaul.md
+++ b/docs/design/container-image-overhaul.md
@@ -122,6 +122,41 @@ install/update slot-render reconcile seam (#1138). Changes:
 - **Custom `profiles.toml`** (hand-tuned boxes) keep overriding by design; those
   images are operator pins and out of scope for auto-reconcile.
 
+## Addendum — current-state findings (narrows scope)
+
+Investigation showed most of the machinery **already exists and is wired**, so this
+is "finish the half-done migration", not a greenfield build:
+
+- **`DEFAULT_ROCMFPX_IMAGE = ghcr.io/hal0ai/hal0-rocmfpx:c077206`** is already the
+  canonical constant (`config/schema.py:852`); FPX seed profiles already use it.
+- **`_resolve_image_ref`** (`providers/container.py:120`) already falls through
+  `slot.image → profile.image → DEFAULT_ROCMFPX_IMAGE`.
+- **`retag_stale_slot_images()`** (`updater/updater.py:1190`) already migrates slot
+  TOML + custom-profile `image` pins that match `STALE_ROCMFPX_IMAGE_REFS` →
+  `DEFAULT_ROCMFPX_IMAGE`, preserves operator pins, is idempotent, and **is already
+  called in the update apply path** (`updater.py:1684`, `:1918`). The updater also
+  mirrors the manifest `toolbox_images` block (`updater.py:224`). Tested by
+  `tests/updater/test_image_retag.py`, `tests/providers/test_image_resolution.py`.
+
+### The actual remaining gaps (surgical)
+1. **Basic seed profiles still hardcode the old toolbox.** `rocm`, `vulkan`,
+   `rocm-longctx`, `embed`, `rerank`, `vulkan-embed`, `vulkan-rerank`, `cpu-llm`
+   pin `amd-strix-halo-toolboxes:{vulkan-radv-server, rocm-7.2.4-rocmfp4-server}`.
+   → Fresh installs land on the old image.
+2. **`STALE_ROCMFPX_IMAGE_REFS` omits those two toolbox refs** → `hal0 update`'s
+   retag skips slots on them. Add both (incl. `localhost/` prefixes) so existing
+   installs migrate.
+3. **No HW gate.** `DEFAULT_ROCMFPX_IMAGE` (and the retag target) is unconditional;
+   rocmfpx is a gfx1151/Strix-Halo build. Make the default *resolve* per probed
+   GPU (rocmfpx on gfx1151, generic RADV vulkan / rocm toolbox elsewhere, cuda,
+   cpu-llm) so retag + fresh-install don't force rocmfpx onto incompatible hosts.
+   Note embed/rerank need `--embedding`/`--reranking` and cpu-llm needs CPU mode —
+   verify the rocmfpx image serves those before repointing those lanes.
+4. **Versioning.** `DEFAULT_ROCMFPX_IMAGE` is a raw sha (`c077206`). Move to rolling
+   `hal0-rocmfpx:stable` + `manifest.json` digest pin via `update-toolbox-digests.sh`;
+   add `.github/workflows/toolbox.yml` build/push so `release.yml`'s null-digest gate
+   passes. Keep prior sha refs in `STALE_ROCMFPX_IMAGE_REFS` so each bump auto-retags.
+
 ## Phasing (stacked PRs)
 
 1. **Resolver unification** — `resolve_slot_image`, `base.image_ref` default,

--- a/docs/design/container-image-overhaul.md
+++ b/docs/design/container-image-overhaul.md
@@ -1,0 +1,134 @@
+# Container Image System Overhaul
+
+Status: proposed · Branch: `feat/container-image-overhaul` · Owner: platform
+
+## Problem
+
+hal0's runtime container image for each slot is chosen **inconsistently** and the
+shipped default is **stale/wrong**, so fresh installs come up on old toolbox
+images while the real, working runner (`hal0-rocmfpx`) only exists as a
+**local one-off** on hand-tuned boxes.
+
+Concretely (verified 2026-07-12):
+
+1. **Fragmented resolution.** `image_ref()` is implemented by `comfyui`, `flm`,
+   `kokoro`, `qwen3tts` (each with its own `HAL0_TOOLBOX_IMAGE_<X>` env +
+   `_DEFAULT_<X>` constant; only comfyui consults `manifest_image_ref`).
+   **`llama_server` has no `image_ref`** — the LLM/embed/rerank lanes read the
+   *profile's literal `image`* from `config/schema.py` seed profiles or the slot
+   TOML. So the manifest digest-pin never reaches the LLM lanes.
+2. **Seed ≠ manifest.** Seed profiles hardcode
+   `amd-strix-halo-toolboxes:{vulkan-radv-server, rocm-7.2.4-rocmfp4-server}`;
+   `manifest.json.toolbox_images` names `hal0-toolbox-{vulkan,rocm}:v1`. Neither
+   is the unified `hal0-rocmfpx` runner the platform actually wants.
+3. **No propagation.** New defaults never reach existing users' slots except by
+   hand-editing each slot TOML (`image = ghcr.io/hal0ai/hal0-rocmfpx:c077206`) —
+   the current "FPX gotcha".
+
+## The unified runner: `hal0-rocmfpx`
+
+`ghcr.io/hal0ai/hal0-rocmfpx:c077206` is **one image serving all GPU LLM lanes**:
+live slots run it for `vulkan` (agent/utility/ops) *and* `rocm` (code) backends,
+*and* it adds FP4/FPX support. It supersedes **both** legacy toolboxes and
+removes the per-slot FPX hand-add.
+
+## Decisions (locked)
+
+- **`hal0-rocmfpx` is the shipped platform default** for GPU LLM/embed/rerank
+  lanes — in `manifest.json` + seed profiles, **not** a per-box `profiles.toml`
+  override. The local one-off is promoted into the codebase.
+- **Hardware-gated.** `derive_profile` picks `hal0-rocmfpx` on gfx1151/Strix-Halo;
+  falls back to the generic `amd-strix-halo-toolboxes:vulkan-radv-server` (RADV)
+  on other AMD GPUs, and `llama.cpp:server-cuda` / cpu-llm as today. rocmfpx is
+  never forced onto hardware that can't run it.
+- **Rolling tag + digest pin.** Publish a rolling `hal0-rocmfpx:stable` tag;
+  `manifest.json` stores it resolved to an immutable `@sha256` digest via
+  `scripts/update-toolbox-digests.sh`. Bump = move tag → re-run script → release.
+- **`hal0 update` reconciles existing slots** onto the new default image via the
+  existing slot-drift + reconcile seam (#1138), not just fresh installs.
+
+## Design
+
+### 1. One resolver (`config/loader.py`)
+
+Add `resolve_slot_image(*, backend, device_class, slot_cfg, manifest=None)` as the
+single decision point, with strict precedence:
+
+```
+per-slot [model].image (explicit operator pin)
+  → HAL0_TOOLBOX_IMAGE_<KEY>            (dev/test override)
+  → manifest_image_ref(<key>)          (release-pinned tag@digest)  ← authoritative default
+  → seed-profile fallback tag          (last resort; warns)
+```
+
+`<key>` comes from the profile/backend, not a hardcoded per-provider constant.
+`base.image_ref` gains a concrete default that calls this; `llama_server` stops
+reading the literal profile image and calls `image_ref` like every other
+provider. The 4 special providers drop their bespoke constants and pass their
+manifest key through the same resolver.
+
+### 2. Manifest keys (`manifest.json`)
+
+Add the unified runner and a portability fallback; keep genuinely-distinct images
+separate:
+
+```jsonc
+"toolbox_images": {
+  "rocmfpx":  {"tag": "ghcr.io/hal0ai/hal0-rocmfpx:stable",                    "digest": "sha256:…"},
+  "vulkan":   {"tag": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server", "digest": "sha256:…"},  // fallback lane
+  "flm":      {…}, "kokoro": {…}, "qwen3tts": {…}, "comfyui": {…}
+}
+```
+
+Seed profiles reference the manifest **key** (or leave `image` empty and let the
+resolver fill it) instead of hardcoding a registry tag.
+
+### 3. Hardware gate (`slots/profile_derive.py` + `providers/_gpu.py`)
+
+`derive_profile` already selects the profile (hence lane). Extend it to choose the
+image **key** by probed GPU: `gfx1151`/Strix-Halo → `rocmfpx`; other AMD → `vulkan`
+(RADV); NVIDIA → `cuda`; no GPU → `cpu-llm`. Reads the existing `hardware.json`
+probe (`_gpu.py`), never raises on a missing probe (defaults to `vulkan`).
+
+### 4. Update propagation (`cli/update_commands.py`)
+
+The seam exists: `_fetch_slot_drift()` / `_print_drift_banner()` /
+`_restart_drifted_slots()` + `hal0 update --restart-slots`, plus the shared
+install/update slot-render reconcile seam (#1138). Changes:
+- Extend the drift definition to include **image drift**: a slot whose resolved
+  image ≠ the manifest-pinned default for its lane (the `image_mismatch` signal
+  already surfaced in `slot_status`).
+- On `hal0 update` (and `--restart-slots`), the reconcile seam regenerates the
+  unit with the new image and reloads the slot — gated by the operator-approval
+  flow for anything destructive.
+- Operator-pinned slots (explicit `[model].image`) are **left alone** — image
+  drift only auto-reconciles lane-default slots.
+
+### 5. Versioning / CI
+
+- `scripts/update-toolbox-digests.sh` already resolves tag→digest for every
+  `toolbox_images` entry; adding `rocmfpx` makes it tracked automatically.
+- `.github/workflows/toolbox.yml` must build/push `hal0-rocmfpx:stable` (or mirror
+  it under `ghcr.io/hal0ai/`) so `release.yml`'s null-digest gate passes.
+- `doctor` already probes `toolbox_images` reachability — extend to flag drift
+  (installed slot image ≠ manifest pin), not just reachability.
+
+## Rollout / risks
+
+- **Size:** rocmfpx ≈ 7.5 GB vs 1.98 GB for vulkan-radv — bigger fresh pull; HW
+  gate keeps non-Strix hosts on the small image.
+- **Back-compat:** old tags stay resolvable; existing slot TOMLs with explicit
+  `image` are never rewritten.
+- **Custom `profiles.toml`** (hand-tuned boxes) keep overriding by design; those
+  images are operator pins and out of scope for auto-reconcile.
+
+## Phasing (stacked PRs)
+
+1. **Resolver unification** — `resolve_slot_image`, `base.image_ref` default,
+   `llama_server` uses it, providers consolidated. No behavior change (manifest
+   still names old images). Tests: precedence + parity with current output.
+2. **Repoint to rocmfpx + HW gate** — manifest `rocmfpx` key, seed profiles by
+   key, `derive_profile` gate, `update-toolbox-digests` + CI. Fresh installs land
+   on rocmfpx on Strix-Halo.
+3. **Update propagation** — image-drift in `_fetch_slot_drift`, reconcile on
+   `hal0 update`, doctor drift flag.

--- a/docs/design/container-image-overhaul.md
+++ b/docs/design/container-image-overhaul.md
@@ -37,10 +37,15 @@ removes the per-slot FPX hand-add.
 - **`hal0-rocmfpx` is the shipped platform default** for GPU LLM/embed/rerank
   lanes — in `manifest.json` + seed profiles, **not** a per-box `profiles.toml`
   override. The local one-off is promoted into the codebase.
-- **Hardware-gated.** `derive_profile` picks `hal0-rocmfpx` on gfx1151/Strix-Halo;
-  falls back to the generic `amd-strix-halo-toolboxes:vulkan-radv-server` (RADV)
-  on other AMD GPUs, and `llama.cpp:server-cuda` / cpu-llm as today. rocmfpx is
-  never forced onto hardware that can't run it.
+- **Universal default (NOT hardware-gated).** `hal0-rocmfpx` is the default for
+  every AMD GPU lane. It ships `mesa-vulkan-drivers` + a compiled Vulkan/RADV
+  backend (the live Strix slots already run it via `-dev Vulkan0`), so it runs on
+  any AMD GPU — the `CMAKE_HIP_ARCHITECTURES=gfx1151` pin only constrains the HIP
+  kernels, not the portable Vulkan path. Carve-outs: CUDA → `llama.cpp:server-cuda`,
+  CPU-only → the lean vulkan toolbox (a 7.5 GB ROCm image is wasteful for CPU).
+  _(Superseded the earlier "gfx1151 HW-gate" idea — verified the image is
+  Vulkan-portable, so gating added complexity + a hot-path `hardware.json` read
+  for no benefit.)_
 - **Rolling tag + digest pin.** Publish a rolling `hal0-rocmfpx:stable` tag;
   `manifest.json` stores it resolved to an immutable `@sha256` digest via
   `scripts/update-toolbox-digests.sh`. Bump = move tag → re-run script → release.
@@ -83,12 +88,14 @@ separate:
 Seed profiles reference the manifest **key** (or leave `image` empty and let the
 resolver fill it) instead of hardcoding a registry tag.
 
-### 3. Hardware gate (`slots/profile_derive.py` + `providers/_gpu.py`)
+### 3. Default resolver (universal — no hardware probe)
 
-`derive_profile` already selects the profile (hence lane). Extend it to choose the
-image **key** by probed GPU: `gfx1151`/Strix-Halo → `rocmfpx`; other AMD → `vulkan`
-(RADV); NVIDIA → `cuda`; no GPU → `cpu-llm`. Reads the existing `hardware.json`
-probe (`_gpu.py`), never raises on a missing probe (defaults to `vulkan`).
+`resolve_default_image(backend, device_class)` (`config/schema.py`) is a pure,
+deterministic map: CUDA → the cuda image, CPU-only → the lean vulkan toolbox,
+every other (AMD GPU) lane → `hal0-rocmfpx`. No `hardware.json` read, so nothing
+on the hot render path and no test host-dependence. _(As-built. An earlier draft
+gated this on a gfx1151 probe; dropped once the rocmfpx image was confirmed
+Vulkan-portable — see Decisions.)_
 
 ### 4. Update propagation (`cli/update_commands.py`)
 
@@ -115,8 +122,12 @@ install/update slot-render reconcile seam (#1138). Changes:
 
 ## Rollout / risks
 
-- **Size:** rocmfpx ≈ 7.5 GB vs 1.98 GB for vulkan-radv — bigger fresh pull; HW
-  gate keeps non-Strix hosts on the small image.
+- **Size:** rocmfpx ≈ 7.5 GB vs 1.98 GB for vulkan-radv — a bigger pull for every
+  AMD GPU host (accepted: it's the unified runner). Only CUDA / CPU-only hosts stay
+  on a leaner image.
+- **FPX quant off gfx1151:** standard GGUF quants run everywhere via Vulkan; the
+  FPX-specific quant path was tuned on gfx1151, so "unvalidated, not unsupported"
+  elsewhere (non-Strix users typically don't run FPX weights).
 - **Back-compat:** old tags stay resolvable; existing slot TOMLs with explicit
   `image` are never rewritten.
 - **Custom `profiles.toml`** (hand-tuned boxes) keep overriding by design; those
@@ -138,32 +149,30 @@ is "finish the half-done migration", not a greenfield build:
   mirrors the manifest `toolbox_images` block (`updater.py:224`). Tested by
   `tests/updater/test_image_retag.py`, `tests/providers/test_image_resolution.py`.
 
-### The actual remaining gaps (surgical)
-1. **Basic seed profiles still hardcode the old toolbox.** `rocm`, `vulkan`,
+### The remaining gaps
+
+**Consumer side — DONE (PR #1297):**
+1. ✅ **Basic seed profiles no longer hardcode the old toolbox.** `rocm`, `vulkan`,
    `rocm-longctx`, `embed`, `rerank`, `vulkan-embed`, `vulkan-rerank`, `cpu-llm`
-   pin `amd-strix-halo-toolboxes:{vulkan-radv-server, rocm-7.2.4-rocmfp4-server}`.
-   → Fresh installs land on the old image.
-2. **`STALE_ROCMFPX_IMAGE_REFS` omits those two toolbox refs** → `hal0 update`'s
-   retag skips slots on them. Add both (incl. `localhost/` prefixes) so existing
-   installs migrate.
-3. **No HW gate.** `DEFAULT_ROCMFPX_IMAGE` (and the retag target) is unconditional;
-   rocmfpx is a gfx1151/Strix-Halo build. Make the default *resolve* per probed
-   GPU (rocmfpx on gfx1151, generic RADV vulkan / rocm toolbox elsewhere, cuda,
-   cpu-llm) so retag + fresh-install don't force rocmfpx onto incompatible hosts.
-   Note embed/rerank need `--embedding`/`--reranking` and cpu-llm needs CPU mode —
-   verify the rocmfpx image serves those before repointing those lanes.
-4. **Versioning.** `DEFAULT_ROCMFPX_IMAGE` is a raw sha (`c077206`). Move to rolling
-   `hal0-rocmfpx:stable` + `manifest.json` digest pin via `update-toolbox-digests.sh`;
-   add `.github/workflows/toolbox.yml` build/push so `release.yml`'s null-digest gate
+   blank their `image` and defer to `resolve_default_image` (`ProfileConfig` now
+   permits an empty image = "defer").
+2. ✅ **`STALE_ROCMFPX_IMAGE_REFS` gained the two old toolbox refs** so `hal0 update`'s
+   retag migrates existing slots off them.
+3. ✅ **Universal default (no HW gate).** `resolve_default_image` maps every AMD GPU
+   lane → rocmfpx, CUDA → cuda, CPU-only → lean toolbox — deterministic, probe-free.
+   (Confirmed rocmfpx serves `--embedding`/`--reranking` and is Vulkan-portable, so
+   no gfx1151 gate.) The retag resolves its target through the same function.
+
+**Producer side — TODO (see `toolbox-repo-consolidation.md`):**
+4. **Versioning.** `DEFAULT_ROCMFPX_IMAGE` is still a raw sha (`c077206`). Move to a
+   rolling `:rocmfpx-stable` + `manifest.json` digest pin via `update-toolbox-digests.sh`;
+   publish it from `Hal0_ROCmFPX`'s inherited CI so `release.yml`'s null-digest gate
    passes. Keep prior sha refs in `STALE_ROCMFPX_IMAGE_REFS` so each bump auto-retags.
 
-## Phasing (stacked PRs)
+## Phasing
 
-1. **Resolver unification** — `resolve_slot_image`, `base.image_ref` default,
-   `llama_server` uses it, providers consolidated. No behavior change (manifest
-   still names old images). Tests: precedence + parity with current output.
-2. **Repoint to rocmfpx + HW gate** — manifest `rocmfpx` key, seed profiles by
-   key, `derive_profile` gate, `update-toolbox-digests` + CI. Fresh installs land
-   on rocmfpx on Strix-Halo.
-3. **Update propagation** — image-drift in `_fetch_slot_drift`, reconcile on
-   `hal0 update`, doctor drift flag.
+1. ✅ **HW-gated resolver** (superseded by 2 — the gate was dropped for a universal
+   default once the image was confirmed Vulkan-portable).
+2. ✅ **Universal rocmfpx default + seed-profile repoint + retag** — shipped in PR #1297.
+3. **Producer side** — rolling tag + manifest digest pin + toolbox-repo consolidation
+   (Gap 0 / Gap 3).

--- a/docs/design/toolbox-repo-consolidation.md
+++ b/docs/design/toolbox-repo-consolidation.md
@@ -124,7 +124,8 @@ lands here. Keep third-party comfyui / cuda external.
 - `manifest.json.toolbox_images`: every entry → `amd-strix-halo-toolboxes:<flavor>`
   + digest.
 - `DEFAULT_ROCMFPX_IMAGE` → `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-stable`
-  (feeds the HW-gated resolver already built in `feat/container-image-overhaul`).
+  (feeds the universal `resolve_default_image` already built in
+  `feat/container-image-overhaul` / PR #1297).
 - `scripts/update-toolbox-digests.sh`: already iterates `toolbox_images`; no change
   beyond the retargeted tags.
 - `STALE_ROCMFPX_IMAGE_REFS`: add the old `hal0-rocmfpx:*` and per-flavor sha tags
@@ -132,9 +133,10 @@ lands here. Keep third-party comfyui / cuda external.
 
 ## Sequencing vs the image overhaul
 
-The `feat/container-image-overhaul` work (HW-gated resolver ✓, repoint seed
-profiles, retag) is the **consumer** side and can land first pointing at the
-existing `hal0-rocmfpx:c077206`. T0 (this doc) is the **producer** side —
+The `feat/container-image-overhaul` work (universal `resolve_default_image` ✓,
+seed-profile repoint ✓, retag ✓ — PR #1297) is the **consumer** side and lands
+first pointing at the existing `hal0-rocmfpx:c077206`. T0 (this doc) is the
+**producer** side —
 publishing `:rocmfpx-stable` from the unified repo — and lets us flip
 `DEFAULT_ROCMFPX_IMAGE` from a hand-built sha to a CI-published rolling tag. They
 meet at `manifest.json` + `DEFAULT_ROCMFPX_IMAGE`.

--- a/docs/design/toolbox-repo-consolidation.md
+++ b/docs/design/toolbox-repo-consolidation.md
@@ -57,17 +57,52 @@ for one release for back-compat, then drop).
 
 ## Work plan
 
-### T0-A — Add the rocmfpx flavor to the toolbox repo
-Add `toolboxes/Dockerfile.rocmfpx` that builds the gfx1151 ROCmFPX runner. It
-needs the ROCmFPX-patched llama.cpp (the FPX quant support lives in the
-`Hal0_ROCmFPX` fork, not stock llama.cpp), so the Dockerfile checks out a
-**pinned `Hal0_ROCmFPX` ref** and builds the `server` target
-(`ENTRYPOINT llama-server`, `CMAKE_HIP_ARCHITECTURES=gfx1151`) — reuse
-`.devops/strix-rocmfp4.Dockerfile` from that fork as the basis. The toolbox repo
-stays the single *publish* point; the fork stays the llama.cpp *source of truth*.
-(Alternative: keep the compile in `Hal0_ROCmFPX/docker.yml` but repoint its push
-to `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-*`. Decide by where the heavy
-gfx1151 build should run.)
+### ROCmFPX upstream topology (where the FPX llama.cpp comes from)
+
+The rocmfpx runner's llama.cpp is maintained in `Hal0ai/Hal0_ROCmFPX`, a **fork of
+`charlie12345/ROCmFPX`** (the root ROCmFPX-family repo, actively developed). Keep
+the FPX upstreams as git remotes *on that fork* (the integration workspace), not on
+the toolbox repo:
+
+| Remote | Role | Track |
+|---|---|---|
+| `charlie12345/ROCmFPX` | **Primary** (fork parent) | merge `main`; watch `experimental-rocmfpx-branch`, `agent/promote-experimental-to-main-*` |
+| `ciru-ai/ROCmFPX` | **Secondary** — FP3 Vulkan matvec/dequant speed path | cherry-pick speed-path commits |
+
+**Fork decision is the OPPOSITE of the toolbox repo:** `Hal0_ROCmFPX` should STAY a
+fork of `charlie12345` — hal0 is a downstream *integrator* of active upstream FPX
+llama.cpp work, not its maintainer. (Contrast: `amd-strix-halo-toolboxes` should
+detach from kyuz0 because hal0 *is* becoming that layer's maintainer.) The unified
+toolbox repo consumes `Hal0_ROCmFPX` at a pinned ref; charlie/ciru-ai syncing
+happens one layer down in the fork.
+
+### T0-A — Publish rocmfpx from the fork's existing (inherited) CI  ✅ decided
+
+**Don't rebuild the wheel or move the heavy compile.** `charlie12345/ROCmFPX`
+already ships a working `docker.yml` that builds `.devops/strix-rocmfp4.Dockerfile`
+(full/light/**server** targets, gfx1151) and pushes to
+`ghcr.io/<owner>/<repo>:strix-rocmfp4`, plus a `release.yml` that tags the source.
+`Hal0ai/Hal0_ROCmFPX` **inherited that same `docker.yml`** — it's just not
+enabled/repointed (why `c077206` was hand-pushed to a `hal0-rocmfpx` package).
+
+Plan:
+1. In `Hal0_ROCmFPX`, **enable + repoint its `docker.yml`** to push the `server`
+   target to the unified package namespace:
+   `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-<llamacpp_ver>-<ref>`
+   (a workflow can push to any package the org grants it — the image repo is just
+   a variable; overrides the inherited `ghcr.io/${owner}/${repo}` default, which
+   would otherwise be the underscore package `hal0_rocmfpx` ≠ the current
+   dash `hal0-rocmfpx`).
+2. Move the rolling `:rocmfpx-stable` alias on release.
+3. The **compile stays in `Hal0_ROCmFPX`** (it's the llama.cpp fork of charlie —
+   the natural home for a from-source gfx1151 HIP build; charlie's flow is
+   `scripts/build-strix-rocmfp4-mtp.sh`). The unified toolbox repo owns the
+   *namespace/manifest*, not this compile. This keeps "one package" without
+   duplicating charlie's build into the toolbox repo.
+
+Note the build is heavy (from-source HIP + FPX); if `ubuntu-24.04` GitHub runners
+are too slow/small, use the `build-self-hosted.yml` path already present in the
+fork.
 
 ### T0-B — Fold in the NPU/TTS/STT toolboxes
 Move `hal0/packaging/toolbox/{flm,kokoro,qwen3tts,moonshine,cpu}.Dockerfile`
@@ -123,12 +158,13 @@ Do NOT detach if the repo stays a thin kyuz0 overlay and rocmfpx/NPU live
 elsewhere — but that contradicts "one unified repo".
 
 ## Open decisions
-1. **rocmfpx build home** — build in the toolbox repo (checkout the `Hal0_ROCmFPX`
-   fork at a pinned ref) vs. keep the compile in `Hal0_ROCmFPX` and only repoint
-   its push target. Compile is heavy (gfx1151 HIP + FPX); a self-hosted/large
-   runner may be needed either way — `Hal0_ROCmFPX` already has
-   `build-self-hosted.yml`.
+1. ~~rocmfpx build home~~ — **RESOLVED (T0-A):** compile stays in `Hal0_ROCmFPX`
+   (fork of charlie); enable + repoint its inherited `docker.yml` to publish the
+   `server` target into the unified package. Runner size TBD (GitHub vs
+   self-hosted).
 2. **NPU/TTS scope** — consolidate flm/kokoro/qwen3tts/moonshine here now, or leave
    in `hal0` for a later pass (they're not llama.cpp GPU toolboxes).
-3. **Package rename** — one unified package with flavor tags (recommended) vs.
-   keeping distinct `hal0-toolbox-*` packages built from one repo.
+3. **Package name** — one unified package `amd-strix-halo-toolboxes` with flavor
+   tags (recommended; note the current `hal0-rocmfpx` dash vs inherited-CI
+   `hal0_rocmfpx` underscore mismatch to reconcile) vs. keeping distinct
+   `hal0-toolbox-*` / `hal0-rocmfpx` packages built from one repo.

--- a/docs/design/toolbox-repo-consolidation.md
+++ b/docs/design/toolbox-repo-consolidation.md
@@ -1,0 +1,134 @@
+# Toolbox Repo Consolidation
+
+Status: proposed · Companion to `container-image-overhaul.md` (this is its "Gap 0")
+
+## Goal
+
+Make **`github.com/Hal0ai/amd-strix-halo-toolboxes`** the single repo where every
+hal0 runtime container image is generated, versioned, and published. Today image
+builds are scattered across three places; consolidate them so `hal0`'s
+`manifest.json` points at one package namespace and `hal0 update` rolls forward
+from one source of truth.
+
+## Current state (verified 2026-07-12)
+
+**Three build origins, one target registry (`ghcr.io/hal0ai`):**
+
+| Image | Built where today | Notes |
+|---|---|---|
+| `hal0-rocmfpx` (the wanted default) | `Hal0ai/Hal0_ROCmFPX` (llama.cpp fork) via `.devops/strix-rocmfp4.Dockerfile` + `docker.yml`; also **hand-built/pushed** (`c077206`, local origin) | gfx1151 HIP + FPX; heavy from-source compile |
+| `amd-strix-halo-toolboxes:{vulkan-radv-server, rocm-7.2.4-rocmfp4-server, …}` | `Hal0ai/amd-strix-halo-toolboxes` (fork of `kyuz0/…`) `toolboxes/Dockerfile.<flavor>` | mature CI already here |
+| `hal0-toolbox-{flm,kokoro,qwen3tts,moonshine}` | `Hal0ai/hal0` `packaging/toolbox/*.Dockerfile` (only qwen3tts has durable CI) | NPU/TTS/STT backends |
+| `comfyui`, `llama.cpp:server-cuda` | third-party (`docker.io/kyuz0`, `ghcr.io/ggml-org`) | pinned, stay external |
+
+**`amd-strix-halo-toolboxes` already has the right bones:**
+- `toolboxes/Dockerfile.<flavor>` — per-image Dockerfiles (rocm 6.4.4 / 7.2.2 /
+  7.2.4 / 7.2.4-rocmfp4[-server] / turboquant / nightlies; vulkan amdvlk / radv /
+  radv-server).
+- Workflows: `build_and_publish.yml` (dispatch + matrix), `ghcr-publish.yml`,
+  `poll-llama-cpp.yaml` (auto-rebuild on new llama.cpp), `prune-old-toolboxes.yml`,
+  `upstream-sync.yml` (sync from kyuz0 upstream).
+- Package model: **one package, a tag per flavor** — exactly the unified shape.
+
+**Gaps preventing it from being *the* repo:**
+1. No `rocmfpx` flavor here (lives in the `Hal0_ROCmFPX` fork).
+2. No flm/kokoro/qwen3tts/moonshine here (live in `hal0/packaging/toolbox/`).
+3. `build_and_publish.yml` still targets the **upstream `docker.io/kyuz0`** repo
+   (inherited from the fork) and its default matrix omits the `-server` /
+   `rocmfp4` flavors hal0 actually seeds.
+4. Stale — last built 2026-06-25.
+
+## Target architecture
+
+**One package:** `ghcr.io/hal0ai/amd-strix-halo-toolboxes`, **tag per flavor**:
+
+```
+:rocmfpx-<llamacpp_ver>-<fpx_ref>   # the unified GPU runner (chat+embed+rerank+FPX)
+:rocmfpx-stable                     # rolling alias → the current rocmfpx-* the platform defaults to
+:vulkan-radv-server                 # portability Vulkan lane (non-Strix / fallback)
+:rocm-7.2.4-rocmfp4-server          # portability ROCm lane
+:flm-<ver> :kokoro-<ver> :qwen3tts-<ver> :moonshine-<ver>   # NPU/TTS/STT backends
+```
+
+`hal0`'s `manifest.json.toolbox_images` points every entry at this package + a
+digest, resolved by `scripts/update-toolbox-digests.sh`. Retire the scattered
+`hal0-rocmfpx` and `hal0-toolbox-*` package names (keep them as pushed aliases
+for one release for back-compat, then drop).
+
+## Work plan
+
+### T0-A — Add the rocmfpx flavor to the toolbox repo
+Add `toolboxes/Dockerfile.rocmfpx` that builds the gfx1151 ROCmFPX runner. It
+needs the ROCmFPX-patched llama.cpp (the FPX quant support lives in the
+`Hal0_ROCmFPX` fork, not stock llama.cpp), so the Dockerfile checks out a
+**pinned `Hal0_ROCmFPX` ref** and builds the `server` target
+(`ENTRYPOINT llama-server`, `CMAKE_HIP_ARCHITECTURES=gfx1151`) — reuse
+`.devops/strix-rocmfp4.Dockerfile` from that fork as the basis. The toolbox repo
+stays the single *publish* point; the fork stays the llama.cpp *source of truth*.
+(Alternative: keep the compile in `Hal0_ROCmFPX/docker.yml` but repoint its push
+to `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-*`. Decide by where the heavy
+gfx1151 build should run.)
+
+### T0-B — Fold in the NPU/TTS/STT toolboxes
+Move `hal0/packaging/toolbox/{flm,kokoro,qwen3tts,moonshine,cpu}.Dockerfile`
+(+ contexts) into `amd-strix-halo-toolboxes/toolboxes/` and add them to the build
+matrix. Delete `hal0/.github/workflows/toolbox.yml` (qwen3tts) once its build
+lands here. Keep third-party comfyui / cuda external.
+
+### T0-C — Repoint + harden the publish CI
+- `build_and_publish.yml`: push to `ghcr.io/hal0ai/amd-strix-halo-toolboxes`
+  (not `docker.io/kyuz0`); default matrix = the flavors hal0 seeds (incl.
+  `-server`, `rocmfp4-server`, `rocmfpx`, and the NPU/TTS set).
+- Tag scheme: immutable `:<flavor>-<ver>` on every build + move the rolling
+  `:<flavor>-stable` alias (esp. `:rocmfpx-stable`) on release.
+- Keep `poll-llama-cpp.yaml` (auto-rebuild), `prune-old-toolboxes.yml`,
+  `upstream-sync.yml`. Add a `workflow_dispatch` + `repository_dispatch` hook so a
+  hal0 release can trigger a coordinated rebuild.
+
+### T0-D — Wire `hal0` to the unified package
+- `manifest.json.toolbox_images`: every entry → `amd-strix-halo-toolboxes:<flavor>`
+  + digest.
+- `DEFAULT_ROCMFPX_IMAGE` → `ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-stable`
+  (feeds the HW-gated resolver already built in `feat/container-image-overhaul`).
+- `scripts/update-toolbox-digests.sh`: already iterates `toolbox_images`; no change
+  beyond the retargeted tags.
+- `STALE_ROCMFPX_IMAGE_REFS`: add the old `hal0-rocmfpx:*` and per-flavor sha tags
+  so `hal0 update` retags existing slots onto the unified package.
+
+## Sequencing vs the image overhaul
+
+The `feat/container-image-overhaul` work (HW-gated resolver ✓, repoint seed
+profiles, retag) is the **consumer** side and can land first pointing at the
+existing `hal0-rocmfpx:c077206`. T0 (this doc) is the **producer** side —
+publishing `:rocmfpx-stable` from the unified repo — and lets us flip
+`DEFAULT_ROCMFPX_IMAGE` from a hand-built sha to a CI-published rolling tag. They
+meet at `manifest.json` + `DEFAULT_ROCMFPX_IMAGE`.
+
+## Detach from the kyuz0 fork — recommended
+
+**Detach `Hal0ai/amd-strix-halo-toolboxes` from being a GitHub *fork* of
+`kyuz0/amd-strix-halo-toolboxes`, but keep kyuz0 as a plain `upstream` git
+remote.** Rationale:
+
+- Once this repo hosts the `rocmfpx` gfx1151 runner + the NPU/TTS/STT toolboxes,
+  it is hal0's release-critical image factory, not a thin overlay on kyuz0.
+- Fork constraints hurt a *publishing* repo: Actions restricted by default,
+  read-only `GITHUB_TOKEN` on fork PRs, secret/`packages: write` friction (likely
+  why `build_and_publish.yml` still targets `docker.io/kyuz0` unrepointed).
+  Standalone gets clean CODEOWNERS, branch protection, release tags, own issues.
+- Keep the leverage without the fork: `upstream-sync.yml` merges/cherry-picks
+  from kyuz0 as a tracked remote. Keep `LICENSE` + `FORK_NOTES.md` attribution.
+
+Do NOT detach if the repo stays a thin kyuz0 overlay and rocmfpx/NPU live
+elsewhere — but that contradicts "one unified repo".
+
+## Open decisions
+1. **rocmfpx build home** — build in the toolbox repo (checkout the `Hal0_ROCmFPX`
+   fork at a pinned ref) vs. keep the compile in `Hal0_ROCmFPX` and only repoint
+   its push target. Compile is heavy (gfx1151 HIP + FPX); a self-hosted/large
+   runner may be needed either way — `Hal0_ROCmFPX` already has
+   `build-self-hosted.yml`.
+2. **NPU/TTS scope** — consolidate flm/kokoro/qwen3tts/moonshine here now, or leave
+   in `hal0` for a later pass (they're not llama.cpp GPU toolboxes).
+3. **Package rename** — one unified package with flavor tags (recommended) vs.
+   keeping distinct `hal0-toolbox-*` packages built from one repo.

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -933,7 +933,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # live in rocm-dense / rocm-moe (and the vulkan-dense / vulkan-moe
         # pair on the Vulkan backend); the old rocmfpx-rocm / vkfpx-* slugs
         # were consolidated into the 2x2 (backend x {dense,moe}) grid in 0.9.5.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
@@ -1045,7 +1045,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # more context fits in the shared pool, plus `--poll` tuning for steady
         # decode. Safe on gemma models — FAMILY_DEFAULTS pins the gemma family
         # back to f16 KV (iSWA regresses on quantized KV). mtp False.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "-ngl 999 -fa on -dev ROCm0 -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 --parallel 1 --threads 16 --no-mmap --no-context-shift --poll 100 --poll-batch 1 --jinja --metrics --no-webui",
         "mtp": False,
         "device_class": "gpu",
@@ -1058,7 +1058,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # minimal: -ngl 999, -fa on, --jinja. No KV quant (defaults to f16, which
         # is gemma-safe) — per-model KV/batch tuning lives in the model's
         # defaults.extra_args.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
@@ -1091,7 +1091,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # (Qwen3-Embedding pins --pooling last via its model defaults); no KV
         # quant — meaningless for a single-pass encoder. GPU because these
         # tiny encoders are prefill-bound and cost ~nothing in the 128 GB pool.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "--embedding -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1107,7 +1107,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # combining --embedding and --reranking on one server yields all-zero
         # scores (llama.cpp #20085). For parallel scoring raise ctx via the
         # slot (-c 65536 --parallel 8 = n_seq x 8192, ggerganov's PR #9510).
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "--reranking -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1123,7 +1123,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # profile, which never emits --embedding and silently serves
         # /v1/completions instead of /v1/embeddings. Same llama-server / flag
         # bundle as `embed`, just on the RADV image. See profile_derive.derive_profile.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "--embedding -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1136,7 +1136,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # exists). MUST be a SEPARATE instance from vulkan-embed — combining
         # --embedding and --reranking on one server yields all-zero scores
         # (llama.cpp #20085).
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
+        "image": DEFAULT_ROCMFPX_IMAGE,  # universal AMD-GPU default (Vulkan-portable)
         "flags": "--reranking -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1183,7 +1183,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # (2026-07-04 Strix Halo consolidation, fact 6): CPU-only wants the page
         # cache (faster re-loads, no GTT involved); --no-mmap would force the
         # whole model into anonymous RAM and forfeit page-cache-backed reloads.
-        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
+        "image": FALLBACK_VULKAN_IMAGE,  # CPU-only: lean toolbox in CPU mode (rocmfpx is wasteful)
         "flags": "--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --jinja",
         "mtp": False,
         "device_class": "cpu",
@@ -1344,14 +1344,9 @@ class ProfileConfig(BaseModel):
 
     @field_validator("image")
     @classmethod
-    def image_blank_or_valid(cls, v: str) -> str:
-        # An EMPTY image is intentional and means "defer to the HW-gated default"
-        # (:func:`resolve_default_image`, applied by the launch renderer via
-        # providers.container._resolve_image_ref) — the basic seed profiles leave
-        # it blank so Strix-Halo boxes land on the rocmfpx runner and other hosts
-        # on the lean toolbox. A whitespace-only value is a typo, not intent.
-        if v and not v.strip():
-            raise ValueError("profile image must not be whitespace-only")
+    def image_nonempty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("profile image must not be empty")
         return v
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -868,6 +868,12 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
         "localhost/hal0-rocmfpx:vulkan-minicpm5",
         "ghcr.io/hal0ai/hal0-rocmfpx:server",
         "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-7aa484a",
+        # Former basic-lane seed defaults (pre HW-gated default). A slot pinned to
+        # one of these is materialised-default debris — the updater re-resolves it
+        # through the HW gate (:func:`resolve_default_image`): Strix boxes migrate
+        # to the rocmfpx runner, other hosts stay on the same toolbox (no-op).
+        "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
     }
 )
 
@@ -892,7 +898,7 @@ FALLBACK_ROCM_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp
 FALLBACK_CUDA_IMAGE = "ghcr.io/ggml-org/llama.cpp:server-cuda"
 
 
-def rocmfpx_capable(hw: "HardwareInfo | None") -> bool:
+def rocmfpx_capable(hw: HardwareInfo | None) -> bool:
     """True when the host GPU is Strix-Halo-class (gfx1151) — the ISA the
     ``hal0-rocmfpx`` runner image is built for.
 
@@ -910,10 +916,10 @@ def rocmfpx_capable(hw: "HardwareInfo | None") -> bool:
 
 
 def resolve_default_image(
-    backend: "str | None",
-    device_class: "str | None" = None,
+    backend: str | None,
+    device_class: str | None = None,
     *,
-    hw: "HardwareInfo | None" = None,
+    hw: HardwareInfo | None = None,
 ) -> str:
     """Hardware-gated default container image for a slot with no explicit pin.
 
@@ -936,7 +942,7 @@ def resolve_default_image(
             from hal0.config.loader import load_hardware_info
 
             hw = load_hardware_info()
-        except Exception:  # noqa: BLE001 — image resolution must never hard-fail
+        except Exception:
             hw = None
     be = (backend or "").lower()
     dc = (device_class or "").lower()
@@ -974,7 +980,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # live in rocm-dense / rocm-moe (and the vulkan-dense / vulkan-moe
         # pair on the Vulkan backend); the old rocmfpx-rocm / vkfpx-* slugs
         # were consolidated into the 2x2 (backend x {dense,moe}) grid in 0.9.5.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
         "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
@@ -1086,7 +1092,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # more context fits in the shared pool, plus `--poll` tuning for steady
         # decode. Safe on gemma models — FAMILY_DEFAULTS pins the gemma family
         # back to f16 KV (iSWA regresses on quantized KV). mtp False.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
         "flags": "-ngl 999 -fa on -dev ROCm0 -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 --parallel 1 --threads 16 --no-mmap --no-context-shift --poll 100 --poll-batch 1 --jinja --metrics --no-webui",
         "mtp": False,
         "device_class": "gpu",
@@ -1099,7 +1105,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # minimal: -ngl 999, -fa on, --jinja. No KV quant (defaults to f16, which
         # is gemma-safe) — per-model KV/batch tuning lives in the model's
         # defaults.extra_args.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
         "flags": "-ngl 999 -fa on --jinja",
         "mtp": False,
         "device_class": "gpu",
@@ -1132,7 +1138,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # (Qwen3-Embedding pins --pooling last via its model defaults); no KV
         # quant — meaningless for a single-pass encoder. GPU because these
         # tiny encoders are prefill-bound and cost ~nothing in the 128 GB pool.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
         "flags": "--embedding -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1148,7 +1154,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # combining --embedding and --reranking on one server yields all-zero
         # scores (llama.cpp #20085). For parallel scoring raise ctx via the
         # slot (-c 65536 --parallel 8 = n_seq x 8192, ggerganov's PR #9510).
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, rocm toolbox elsewhere)
         "flags": "--reranking -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1164,7 +1170,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # profile, which never emits --embedding and silently serves
         # /v1/completions instead of /v1/embeddings. Same llama-server / flag
         # bundle as `embed`, just on the RADV image. See profile_derive.derive_profile.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
         "flags": "--embedding -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1177,7 +1183,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # exists). MUST be a SEPARATE instance from vulkan-embed — combining
         # --embedding and --reranking on one server yields all-zero scores
         # (llama.cpp #20085).
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
         "flags": "--reranking -ngl 999 -fa on -b 8192 -ub 8192 --no-mmap",
         "mtp": False,
         "device_class": "gpu",
@@ -1224,7 +1230,7 @@ SEED_PROFILES: dict[str, dict[str, object]] = {
         # (2026-07-04 Strix Halo consolidation, fact 6): CPU-only wants the page
         # cache (faster re-loads, no GTT involved); --no-mmap would force the
         # whole model into anonymous RAM and forfeit page-cache-backed reloads.
-        "image": "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server",
+        "image": "",  # empty → HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere)
         "flags": "--threads 4 --threads-batch 8 -b 256 -ub 256 --parallel 1 --jinja",
         "mtp": False,
         "device_class": "cpu",
@@ -1385,9 +1391,14 @@ class ProfileConfig(BaseModel):
 
     @field_validator("image")
     @classmethod
-    def image_nonempty(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("profile image must not be empty")
+    def image_blank_or_valid(cls, v: str) -> str:
+        # An EMPTY image is intentional and means "defer to the HW-gated default"
+        # (:func:`resolve_default_image`, applied by the launch renderer via
+        # providers.container._resolve_image_ref) — the basic seed profiles leave
+        # it blank so Strix-Halo boxes land on the rocmfpx runner and other hosts
+        # on the lean toolbox. A whitespace-only value is a typo, not intent.
+        if v and not v.strip():
+            raise ValueError("profile image must not be whitespace-only")
         return v
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -877,86 +877,39 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
     }
 )
 
-#: Strix-Halo / gfx1151 identity markers. The ``hal0-rocmfpx`` runner image is
-#: built for gfx1151 (AMD Ryzen AI Max "Strix Halo" APUs); on any other GPU it
-#: is the wrong ISA, so the HW-gated default (:func:`resolve_default_image`)
-#: only selects it when one of these appears in the probed CPU model or a GPU
-#: name. Extend as new gfx1151-class SKUs ship.
-STRIX_HALO_HW_MARKERS: tuple[str, ...] = (
-    "ryzen ai max",  # CPU brand shared by every Strix Halo APU
-    "radeon 8060s",  # Strix Halo top iGPU marketing name
-    "radeon 8050s",
-    "device 1586",  # gfx1151 iGPU PCI device id, as it appears in lspci names
-    "strix halo",
-)
-
-#: Generic fallback toolbox images for hosts the rocmfpx runner does NOT target
-#: (non-Strix AMD GPUs, ROCm-less Vulkan, CPU-only). The lean
-#: ``amd-strix-halo-toolboxes`` builds — the portability lane.
+#: Lean fallback toolbox images for the two non-rocmfpx lanes. The rocmfpx
+#: runner is Vulkan-portable — its Mesa/RADV Vulkan backend runs on any AMD GPU
+#: (the gfx1151 HIP kernels are a bonus on Strix Halo, not a requirement) — so
+#: it serves every AMD GPU lane. Only a CUDA host and a CPU-only host want a
+#: different/leaner image (the 7.5 GB ROCm-based rocmfpx image is pointless for
+#: CPU-only inference).
 FALLBACK_VULKAN_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
-FALLBACK_ROCM_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
 FALLBACK_CUDA_IMAGE = "ghcr.io/ggml-org/llama.cpp:server-cuda"
 
 
-def rocmfpx_capable(hw: HardwareInfo | None) -> bool:
-    """True when the host GPU is Strix-Halo-class (gfx1151) — the ISA the
-    ``hal0-rocmfpx`` runner image is built for.
+def resolve_default_image(backend: str | None, device_class: str | None = None) -> str:
+    """Default container image for a slot lane with no explicit image pin.
 
-    Conservative by design: returns ``False`` whenever the signal is absent or
-    ambiguous, so a missing/empty probe falls back to the generic toolbox image
-    rather than launching the wrong-ISA rocmfpx runner. Never raises.
-    """
-    if hw is None:
-        return False
-    haystacks = [getattr(hw, "cpu_model", "") or ""]
-    for gpu in getattr(hw, "gpus", None) or []:
-        haystacks.append(getattr(gpu, "name", "") or "")
-    blob = " ".join(haystacks).lower()
-    return any(marker in blob for marker in STRIX_HALO_HW_MARKERS)
+    Precedence is handled by the caller (slot ``image`` override → profile
+    ``image`` → *this*). ``hal0-rocmfpx`` is the universal AMD-GPU default —
+    its Vulkan/RADV backend is GPU-agnostic, so it is not gated on Strix-Halo —
+    with two carve-outs:
 
-
-def resolve_default_image(
-    backend: str | None,
-    device_class: str | None = None,
-    *,
-    hw: HardwareInfo | None = None,
-) -> str:
-    """Hardware-gated default container image for a slot with no explicit pin.
-
-    Precedence handled by the caller (slot ``image`` override → profile
-    ``image`` → *this*). Resolution here:
-
-    * Strix-Halo/gfx1151 GPU lanes → :data:`DEFAULT_ROCMFPX_IMAGE` (the unified
-      ROCmFPX runner; serves chat + ``--embedding`` + ``--reranking``).
-    * Non-Strix AMD GPU lanes → the lean toolbox for the backend (portability).
     * CUDA lanes → the upstream llama.cpp CUDA image.
-    * CPU / unknown → the Vulkan toolbox (llama-server runs CPU-only when no GPU
-      devices are passed).
+    * CPU-only lanes → the lean Vulkan toolbox (llama-server runs CPU-only when
+      no GPU devices are passed; the big rocmfpx image is wasteful for CPU).
+    * Every other (AMD GPU: ``rocm`` / ``vulkan``) lane → :data:`DEFAULT_ROCMFPX_IMAGE`
+      (the unified ROCmFPX runner; serves chat + ``--embedding`` + ``--reranking``).
 
-    ``hw`` defaults to the probed ``/etc/hal0/hardware.json``, loaded lazily to
-    avoid a schema→loader import cycle; a missing/unreadable probe yields the
-    generic fallback (``rocmfpx_capable`` → ``False``), never an exception.
+    Deterministic and probe-free — no hardware read on the hot render path.
     """
-    if hw is None:
-        try:
-            from hal0.config.loader import load_hardware_info
-
-            hw = load_hardware_info()
-        except Exception:
-            hw = None
     be = (backend or "").lower()
     dc = (device_class or "").lower()
     if be == "cuda":
         return FALLBACK_CUDA_IMAGE
     if dc == "cpu" or be == "cpu":
-        # CPU-only lane never runs the big GPU runner (lean image, CPU mode).
         return FALLBACK_VULKAN_IMAGE
-    if rocmfpx_capable(hw):
-        # Strix-Halo/gfx1151 GPU lane (chat/embed/rerank all served by rocmfpx).
-        return DEFAULT_ROCMFPX_IMAGE
-    if be == "rocm":
-        return FALLBACK_ROCM_IMAGE
-    return FALLBACK_VULKAN_IMAGE
+    return DEFAULT_ROCMFPX_IMAGE
 
 
 #: Seed profile catalog.  Slugs are backend-agnostic workload names — the

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -871,6 +871,88 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
     }
 )
 
+#: Strix-Halo / gfx1151 identity markers. The ``hal0-rocmfpx`` runner image is
+#: built for gfx1151 (AMD Ryzen AI Max "Strix Halo" APUs); on any other GPU it
+#: is the wrong ISA, so the HW-gated default (:func:`resolve_default_image`)
+#: only selects it when one of these appears in the probed CPU model or a GPU
+#: name. Extend as new gfx1151-class SKUs ship.
+STRIX_HALO_HW_MARKERS: tuple[str, ...] = (
+    "ryzen ai max",  # CPU brand shared by every Strix Halo APU
+    "radeon 8060s",  # Strix Halo top iGPU marketing name
+    "radeon 8050s",
+    "device 1586",  # gfx1151 iGPU PCI device id, as it appears in lspci names
+    "strix halo",
+)
+
+#: Generic fallback toolbox images for hosts the rocmfpx runner does NOT target
+#: (non-Strix AMD GPUs, ROCm-less Vulkan, CPU-only). The lean
+#: ``amd-strix-halo-toolboxes`` builds — the portability lane.
+FALLBACK_VULKAN_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
+FALLBACK_ROCM_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server"
+FALLBACK_CUDA_IMAGE = "ghcr.io/ggml-org/llama.cpp:server-cuda"
+
+
+def rocmfpx_capable(hw: "HardwareInfo | None") -> bool:
+    """True when the host GPU is Strix-Halo-class (gfx1151) — the ISA the
+    ``hal0-rocmfpx`` runner image is built for.
+
+    Conservative by design: returns ``False`` whenever the signal is absent or
+    ambiguous, so a missing/empty probe falls back to the generic toolbox image
+    rather than launching the wrong-ISA rocmfpx runner. Never raises.
+    """
+    if hw is None:
+        return False
+    haystacks = [getattr(hw, "cpu_model", "") or ""]
+    for gpu in getattr(hw, "gpus", None) or []:
+        haystacks.append(getattr(gpu, "name", "") or "")
+    blob = " ".join(haystacks).lower()
+    return any(marker in blob for marker in STRIX_HALO_HW_MARKERS)
+
+
+def resolve_default_image(
+    backend: "str | None",
+    device_class: "str | None" = None,
+    *,
+    hw: "HardwareInfo | None" = None,
+) -> str:
+    """Hardware-gated default container image for a slot with no explicit pin.
+
+    Precedence handled by the caller (slot ``image`` override → profile
+    ``image`` → *this*). Resolution here:
+
+    * Strix-Halo/gfx1151 GPU lanes → :data:`DEFAULT_ROCMFPX_IMAGE` (the unified
+      ROCmFPX runner; serves chat + ``--embedding`` + ``--reranking``).
+    * Non-Strix AMD GPU lanes → the lean toolbox for the backend (portability).
+    * CUDA lanes → the upstream llama.cpp CUDA image.
+    * CPU / unknown → the Vulkan toolbox (llama-server runs CPU-only when no GPU
+      devices are passed).
+
+    ``hw`` defaults to the probed ``/etc/hal0/hardware.json``, loaded lazily to
+    avoid a schema→loader import cycle; a missing/unreadable probe yields the
+    generic fallback (``rocmfpx_capable`` → ``False``), never an exception.
+    """
+    if hw is None:
+        try:
+            from hal0.config.loader import load_hardware_info
+
+            hw = load_hardware_info()
+        except Exception:  # noqa: BLE001 — image resolution must never hard-fail
+            hw = None
+    be = (backend or "").lower()
+    dc = (device_class or "").lower()
+    if be == "cuda":
+        return FALLBACK_CUDA_IMAGE
+    if dc == "cpu" or be == "cpu":
+        # CPU-only lane never runs the big GPU runner (lean image, CPU mode).
+        return FALLBACK_VULKAN_IMAGE
+    if rocmfpx_capable(hw):
+        # Strix-Halo/gfx1151 GPU lane (chat/embed/rerank all served by rocmfpx).
+        return DEFAULT_ROCMFPX_IMAGE
+    if be == "rocm":
+        return FALLBACK_ROCM_IMAGE
+    return FALLBACK_VULKAN_IMAGE
+
+
 #: Seed profile catalog.  Slugs are backend-agnostic workload names — the
 #: ``backend`` field (not the slug) carries the ROCm/Vulkan choice, and the
 #: card chip renders the backend as colour, so the slug no longer repeats it.

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -129,10 +129,12 @@ def _resolve_image_ref(slot_cfg: Mapping[str, Any] | None, profile: Any) -> str:
 
       1. ``slot_cfg["image"]`` (top-level string override in the slot TOML).
       2. ``slot_cfg["slot"]["image"]`` (nested under the ``[slot]`` table).
-      3. ``profile.image`` (the profile's own image — kept for back-compat
-         so existing operator-custom profiles that pin ``image`` round-trip
-         cleanly through 0.9.5; targeted for removal in 0.9.6).
-      4. ``DEFAULT_ROCMFPX_IMAGE`` (the code-pinned ROCmFPX runner tag).
+      3. ``profile.image`` (a deliberate profile/operator pin) — honored verbatim.
+         The basic seed profiles intentionally leave this empty so they fall
+         through to (4); the ROCmFPX/custom profiles pin it explicitly.
+      4. :func:`~hal0.config.schema.resolve_default_image` — the HW-gated
+         default: the rocmfpx runner on gfx1151/Strix-Halo, the lean toolbox
+         (or cuda / cpu image) elsewhere.
 
     Only STRING values are treated as image-ref overrides. The
     ``[image]`` TOML section that holds image-gen settings (#599) shares
@@ -156,12 +158,20 @@ def _resolve_image_ref(slot_cfg: Mapping[str, Any] | None, profile: Any) -> str:
                 return c
     profile_image = getattr(profile, "image", None)
     if isinstance(profile_image, str) and profile_image:
-        return profile_image
-    # Code default — imported lazily to avoid an import cycle (schema imports
-    # from providers in some test fixtures).
-    from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
+        return profile_image  # deliberate profile/operator pin — honored verbatim
+    # No image pin anywhere → HW-gated default: the rocmfpx runner on
+    # gfx1151/Strix-Halo, the lean toolbox (or cuda / cpu image) elsewhere.
+    # Backend comes from the slot override when set, else the profile;
+    # device_class from the profile. Lazy import avoids a schema→providers cycle.
+    from hal0.config.schema import resolve_default_image
 
-    return DEFAULT_ROCMFPX_IMAGE
+    backend = getattr(profile, "backend", None)
+    device_class = getattr(profile, "device_class", None)
+    if isinstance(slot_cfg, Mapping):
+        sb = slot_cfg.get("backend")
+        if isinstance(sb, str) and sb:
+            backend = sb
+    return resolve_default_image(backend, device_class)
 
 
 def _profile_image_and_flags(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1291,7 +1291,30 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
 
     from hal0.config.loader import _read_toml, write_toml_atomic
     from hal0.config.paths import profiles_toml, slots_config_dir
-    from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, STALE_ROCMFPX_IMAGE_REFS
+    from hal0.config.schema import STALE_ROCMFPX_IMAGE_REFS, resolve_default_image
+
+    def _cfg_str(cfg: dict, key: str) -> str:
+        """Read a string field top-level or nested under ``[slot]``."""
+        v = cfg.get(key)
+        if isinstance(v, str):
+            return v
+        slot = cfg.get("slot")
+        if isinstance(slot, dict) and isinstance(slot.get(key), str):
+            return slot[key]
+        return ""
+
+    def _backend_of(cfg: dict) -> str:
+        be = _cfg_str(cfg, "backend")
+        if be:
+            return be
+        dev = _cfg_str(cfg, "device")  # "gpu-rocm" / "gpu-vulkan" / "cpu" / "npu"
+        return dev.split("-", 1)[1] if dev.startswith("gpu-") else ""
+
+    def _device_class_of(cfg: dict) -> str:
+        dev = _cfg_str(cfg, "device") or _cfg_str(cfg, "device_class")
+        if dev == "cpu":
+            return "cpu"
+        return "gpu" if dev.startswith("gpu") else dev
 
     retagged = 0
     slots_dir = slots_config_dir()
@@ -1313,7 +1336,13 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
         if holder is None or holder["image"] not in STALE_ROCMFPX_IMAGE_REFS:
             continue
         old_ref = holder["image"]
-        holder["image"] = DEFAULT_ROCMFPX_IMAGE
+        # HW-gated target: rocmfpx on a Strix GPU lane, the lean toolbox
+        # elsewhere. When the host/lane default already equals the pin (e.g. a
+        # non-Strix box on the vulkan toolbox), it's a no-op — leave it be.
+        new_ref = resolve_default_image(_backend_of(raw), _device_class_of(raw))
+        if new_ref == old_ref:
+            continue
+        holder["image"] = new_ref
         try:
             write_toml_atomic(toml_path, raw)
         except Exception as exc:
@@ -1325,10 +1354,10 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
             job_id=job_id,
             slot=slot_name,
             old=old_ref,
-            new=DEFAULT_ROCMFPX_IMAGE,
+            new=new_ref,
             note=(
                 "slot image pin matched a stale former default runner; rolled to "
-                "the current default (applies on the slot's next start)"
+                "the current HW-gated default (applies on the slot's next start)"
             ),
         )
 
@@ -1347,7 +1376,10 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
                 continue
             if entry.get("image") in STALE_ROCMFPX_IMAGE_REFS:
                 old_ref = entry["image"]
-                entry["image"] = DEFAULT_ROCMFPX_IMAGE
+                new_ref = resolve_default_image(entry.get("backend"), entry.get("device_class"))
+                if new_ref == old_ref:
+                    continue
+                entry["image"] = new_ref
                 changed = True
                 retagged += 1
                 log.warning(
@@ -1355,10 +1387,10 @@ def retag_stale_slot_images(*, job_id: str | None = None) -> int:
                     job_id=job_id,
                     profile=name,
                     old=old_ref,
-                    new=DEFAULT_ROCMFPX_IMAGE,
+                    new=new_ref,
                     note=(
                         "custom profile image matched a stale former default "
-                        "runner; rolled to the current default (flags untouched)"
+                        "runner; rolled to the current HW-gated default (flags untouched)"
                     ),
                 )
         if changed:

--- a/tests/api/test_profiles_route.py
+++ b/tests/api/test_profiles_route.py
@@ -143,10 +143,13 @@ class TestListProfiles:
         dense = next(item for item in data if item["name"] == "rocm-dense")
         assert dense["mtp"] is True
 
-    def test_vulkan_std_image_contains_vulkan(self, client: TestClient) -> None:
+    def test_vulkan_std_image_is_rocmfpx_default(self, client: TestClient) -> None:
+        # The vulkan lane now pins the universal rocmfpx runner (Vulkan-portable).
+        from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
+
         data = client.get("/api/profiles").json()
         vulkan = next(item for item in data if item["name"] == "vulkan")
-        assert "vulkan" in vulkan["image"]
+        assert vulkan["image"] == DEFAULT_ROCMFPX_IMAGE
 
     def test_mtp_true_resolved_flags_contains_spec_type(self, client: TestClient) -> None:
         data = client.get("/api/profiles").json()

--- a/tests/config/test_default_image_gate.py
+++ b/tests/config/test_default_image_gate.py
@@ -1,9 +1,8 @@
-"""HW-gated default container image (:func:`resolve_default_image`).
+"""Default container image resolver (:func:`resolve_default_image`).
 
-Covers the gfx1151/Strix-Halo gate that decides whether a slot with no explicit
-image pin runs the unified ``hal0-rocmfpx`` runner or a generic toolbox image.
-The gate is conservative: an absent/ambiguous probe must fall back to the lean
-toolbox, never the wrong-ISA rocmfpx runner.
+``hal0-rocmfpx`` is the universal AMD-GPU default — its Mesa/RADV Vulkan backend
+runs on any AMD GPU, so it is NOT gated on Strix-Halo. Only CUDA and CPU-only
+lanes get their own leaner images. The resolver is deterministic and probe-free.
 """
 
 from __future__ import annotations
@@ -13,76 +12,27 @@ import pytest
 from hal0.config.schema import (
     DEFAULT_ROCMFPX_IMAGE,
     FALLBACK_CUDA_IMAGE,
-    FALLBACK_ROCM_IMAGE,
     FALLBACK_VULKAN_IMAGE,
-    GPUInfo,
-    HardwareInfo,
     resolve_default_image,
-    rocmfpx_capable,
 )
 
 
-def _strix_by_cpu() -> HardwareInfo:
-    return HardwareInfo(cpu_model="AMD RYZEN AI MAX+ 395 w/ Radeon 8060S")
+@pytest.mark.parametrize("backend", ["rocm", "vulkan"])
+def test_amd_gpu_lanes_get_rocmfpx(backend: str) -> None:
+    assert resolve_default_image(backend, "gpu") == DEFAULT_ROCMFPX_IMAGE
 
 
-def _strix_by_gpu() -> HardwareInfo:
-    return HardwareInfo(
-        cpu_model="Some Generic CPU",
-        gpus=[GPUInfo(name="Advanced Micro Devices Device 1586 (rev c1)", vram_mb=98304)],
-    )
+def test_unspecified_lane_defaults_to_rocmfpx() -> None:
+    # GPU-first platform: an unknown/empty lane defaults to the rocmfpx runner.
+    assert resolve_default_image("", "gpu") == DEFAULT_ROCMFPX_IMAGE
+    assert resolve_default_image(None, None) == DEFAULT_ROCMFPX_IMAGE
 
 
-def _non_strix() -> HardwareInfo:
-    return HardwareInfo(
-        cpu_model="AMD Ryzen 9 7950X",
-        gpus=[GPUInfo(name="AMD Radeon RX 7900 XTX", vram_mb=24576)],
-    )
+def test_cuda_lane_gets_cuda_image() -> None:
+    assert resolve_default_image("cuda", "gpu") == FALLBACK_CUDA_IMAGE
 
 
-# ── rocmfpx_capable: the raw gate ─────────────────────────────────────────── #
-
-
-def test_capable_by_cpu_marker() -> None:
-    assert rocmfpx_capable(_strix_by_cpu()) is True
-
-
-def test_capable_by_gpu_name_marker() -> None:
-    assert rocmfpx_capable(_strix_by_gpu()) is True
-
-
-def test_not_capable_on_non_strix() -> None:
-    assert rocmfpx_capable(_non_strix()) is False
-
-
-def test_not_capable_on_none() -> None:
-    assert rocmfpx_capable(None) is False
-
-
-def test_not_capable_on_empty_probe() -> None:
-    assert rocmfpx_capable(HardwareInfo()) is False
-
-
-# ── resolve_default_image: HW-gated lane selection ────────────────────────── #
-
-
-@pytest.mark.parametrize("backend", ["vulkan", "rocm"])
-def test_strix_gpu_lanes_get_rocmfpx(backend: str) -> None:
-    assert resolve_default_image(backend, "gpu", hw=_strix_by_cpu()) == DEFAULT_ROCMFPX_IMAGE
-
-
-def test_non_strix_rocm_falls_back_to_rocm_toolbox() -> None:
-    assert resolve_default_image("rocm", "gpu", hw=_non_strix()) == FALLBACK_ROCM_IMAGE
-
-
-def test_non_strix_vulkan_falls_back_to_vulkan_toolbox() -> None:
-    assert resolve_default_image("vulkan", "gpu", hw=_non_strix()) == FALLBACK_VULKAN_IMAGE
-
-
-def test_cpu_lane_never_rocmfpx_even_on_strix() -> None:
-    # A cpu device_class on a Strix box must still get the lean CPU-mode image.
-    assert resolve_default_image("vulkan", "cpu", hw=_strix_by_cpu()) == FALLBACK_VULKAN_IMAGE
-
-
-def test_cuda_lane() -> None:
-    assert resolve_default_image("cuda", "gpu", hw=_non_strix()) == FALLBACK_CUDA_IMAGE
+def test_cpu_lane_gets_lean_toolbox() -> None:
+    # A 7.5 GB ROCm image is pointless for CPU-only; use the lean toolbox.
+    assert resolve_default_image("vulkan", "cpu") == FALLBACK_VULKAN_IMAGE
+    assert resolve_default_image("cpu", None) == FALLBACK_VULKAN_IMAGE

--- a/tests/config/test_default_image_gate.py
+++ b/tests/config/test_default_image_gate.py
@@ -1,0 +1,88 @@
+"""HW-gated default container image (:func:`resolve_default_image`).
+
+Covers the gfx1151/Strix-Halo gate that decides whether a slot with no explicit
+image pin runs the unified ``hal0-rocmfpx`` runner or a generic toolbox image.
+The gate is conservative: an absent/ambiguous probe must fall back to the lean
+toolbox, never the wrong-ISA rocmfpx runner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import (
+    DEFAULT_ROCMFPX_IMAGE,
+    FALLBACK_CUDA_IMAGE,
+    FALLBACK_ROCM_IMAGE,
+    FALLBACK_VULKAN_IMAGE,
+    GPUInfo,
+    HardwareInfo,
+    resolve_default_image,
+    rocmfpx_capable,
+)
+
+
+def _strix_by_cpu() -> HardwareInfo:
+    return HardwareInfo(cpu_model="AMD RYZEN AI MAX+ 395 w/ Radeon 8060S")
+
+
+def _strix_by_gpu() -> HardwareInfo:
+    return HardwareInfo(
+        cpu_model="Some Generic CPU",
+        gpus=[GPUInfo(name="Advanced Micro Devices Device 1586 (rev c1)", vram_mb=98304)],
+    )
+
+
+def _non_strix() -> HardwareInfo:
+    return HardwareInfo(
+        cpu_model="AMD Ryzen 9 7950X",
+        gpus=[GPUInfo(name="AMD Radeon RX 7900 XTX", vram_mb=24576)],
+    )
+
+
+# ── rocmfpx_capable: the raw gate ─────────────────────────────────────────── #
+
+
+def test_capable_by_cpu_marker() -> None:
+    assert rocmfpx_capable(_strix_by_cpu()) is True
+
+
+def test_capable_by_gpu_name_marker() -> None:
+    assert rocmfpx_capable(_strix_by_gpu()) is True
+
+
+def test_not_capable_on_non_strix() -> None:
+    assert rocmfpx_capable(_non_strix()) is False
+
+
+def test_not_capable_on_none() -> None:
+    assert rocmfpx_capable(None) is False
+
+
+def test_not_capable_on_empty_probe() -> None:
+    assert rocmfpx_capable(HardwareInfo()) is False
+
+
+# ── resolve_default_image: HW-gated lane selection ────────────────────────── #
+
+
+@pytest.mark.parametrize("backend", ["vulkan", "rocm"])
+def test_strix_gpu_lanes_get_rocmfpx(backend: str) -> None:
+    assert resolve_default_image(backend, "gpu", hw=_strix_by_cpu()) == DEFAULT_ROCMFPX_IMAGE
+
+
+def test_non_strix_rocm_falls_back_to_rocm_toolbox() -> None:
+    assert resolve_default_image("rocm", "gpu", hw=_non_strix()) == FALLBACK_ROCM_IMAGE
+
+
+def test_non_strix_vulkan_falls_back_to_vulkan_toolbox() -> None:
+    assert resolve_default_image("vulkan", "gpu", hw=_non_strix()) == FALLBACK_VULKAN_IMAGE
+
+
+def test_cpu_lane_never_rocmfpx_even_on_strix() -> None:
+    # A cpu device_class on a Strix box must still get the lean CPU-mode image.
+    assert resolve_default_image("vulkan", "cpu", hw=_strix_by_cpu()) == FALLBACK_VULKAN_IMAGE
+
+
+def test_cuda_lane() -> None:
+    assert resolve_default_image("cuda", "gpu", hw=_non_strix()) == FALLBACK_CUDA_IMAGE

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -54,9 +54,11 @@ class TestProfileConfigValidation:
         with pytest.raises(ValidationError):
             ProfileConfig(image="x", backend="metal")
 
-    def test_empty_image_raises(self) -> None:
-        with pytest.raises(Exception, match="image"):
-            ProfileConfig(image="")
+    def test_empty_image_allowed_means_defer(self) -> None:
+        # Empty image is intentional: "defer to the HW-gated default"
+        # (resolve_default_image), used by the basic seed profiles. A
+        # whitespace-only value is still a typo (see test_whitespace_image_raises).
+        assert ProfileConfig(image="").image == ""
 
     def test_whitespace_image_raises(self) -> None:
         with pytest.raises(Exception, match="image"):
@@ -204,9 +206,12 @@ class TestLoadProfilesConfig:
         for name in ("rocm-dense", "rocm-moe", "vulkan-dense", "vulkan-moe"):
             assert cfg.profile[name].mtp is True
 
-    def test_seed_vulkan_correct_image(self, tmp_path: Path) -> None:
+    def test_seed_vulkan_defers_to_hw_gated_default(self, tmp_path: Path) -> None:
+        """The basic vulkan profile carries no hardcoded image — it defers to the
+        HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere), resolved at
+        launch by providers.container._resolve_image_ref → resolve_default_image."""
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert "vulkan-radv-server" in cfg.profile["vulkan"].image
+        assert cfg.profile["vulkan"].image == ""
 
     def test_seed_gpu_profiles_have_backend(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -54,11 +54,9 @@ class TestProfileConfigValidation:
         with pytest.raises(ValidationError):
             ProfileConfig(image="x", backend="metal")
 
-    def test_empty_image_allowed_means_defer(self) -> None:
-        # Empty image is intentional: "defer to the HW-gated default"
-        # (resolve_default_image), used by the basic seed profiles. A
-        # whitespace-only value is still a typo (see test_whitespace_image_raises).
-        assert ProfileConfig(image="").image == ""
+    def test_empty_image_raises(self) -> None:
+        with pytest.raises(Exception, match="image"):
+            ProfileConfig(image="")
 
     def test_whitespace_image_raises(self) -> None:
         with pytest.raises(Exception, match="image"):
@@ -206,12 +204,13 @@ class TestLoadProfilesConfig:
         for name in ("rocm-dense", "rocm-moe", "vulkan-dense", "vulkan-moe"):
             assert cfg.profile[name].mtp is True
 
-    def test_seed_vulkan_defers_to_hw_gated_default(self, tmp_path: Path) -> None:
-        """The basic vulkan profile carries no hardcoded image — it defers to the
-        HW-gated default (rocmfpx on Strix, vulkan toolbox elsewhere), resolved at
-        launch by providers.container._resolve_image_ref → resolve_default_image."""
+    def test_seed_vulkan_uses_rocmfpx_default(self, tmp_path: Path) -> None:
+        """The basic vulkan profile pins the universal rocmfpx runner (rocmfpx is
+        Vulkan-portable, so it is the default for every AMD GPU lane)."""
+        from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
+
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")
-        assert cfg.profile["vulkan"].image == ""
+        assert cfg.profile["vulkan"].image == DEFAULT_ROCMFPX_IMAGE
 
     def test_seed_gpu_profiles_have_backend(self, tmp_path: Path) -> None:
         cfg = load_profiles_config(path=tmp_path / "nonexistent.toml")

--- a/tests/providers/test_image_resolution.py
+++ b/tests/providers/test_image_resolution.py
@@ -12,11 +12,24 @@ from types import SimpleNamespace
 
 import pytest
 
-from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, ProfileConfig
+from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, FALLBACK_VULKAN_IMAGE, ProfileConfig
 from hal0.providers.container import (
     _profile_image_and_flags,
     _resolve_image_ref,
 )
+
+
+@pytest.fixture
+def strix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the gfx1151/Strix-Halo capability signal so the HW-gated default
+    resolves to the rocmfpx runner, deterministically on any host."""
+    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: True)
+
+
+@pytest.fixture
+def non_strix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force a non-Strix host so the HW-gated default resolves to the lean toolbox."""
+    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
 
 
 def _profile(image: str | None = None) -> ProfileConfig:
@@ -55,10 +68,24 @@ def test_resolve_image_ref_falls_back_to_profile_image() -> None:
     assert _resolve_image_ref(None, profile) == "ghcr.io/hal0ai/hal0-rocmfpx:server"
 
 
-def test_resolve_image_ref_falls_back_to_default_when_profile_has_no_image() -> None:
-    """No slot override AND no profile.image -> DEFAULT_ROCMFPX_IMAGE."""
+def test_resolve_image_ref_falls_back_to_default_on_strix(strix: None) -> None:
+    """No slot override AND no profile.image -> HW-gated default; on Strix that
+    is the rocmfpx runner."""
     profile = SimpleNamespace(image=None)
     assert _resolve_image_ref(None, profile) == DEFAULT_ROCMFPX_IMAGE
+
+
+def test_resolve_image_ref_falls_back_to_toolbox_off_strix(non_strix: None) -> None:
+    """Same fallback on a non-Strix host resolves to the lean vulkan toolbox."""
+    profile = SimpleNamespace(image=None)
+    assert _resolve_image_ref(None, profile) == FALLBACK_VULKAN_IMAGE
+
+
+def test_resolve_image_ref_honors_explicit_profile_pin_verbatim(strix: None) -> None:
+    """An explicit profile.image is honored verbatim even on Strix — it is NOT
+    re-gated (that would break the spec.image == profile.image invariant)."""
+    profile = SimpleNamespace(image=FALLBACK_VULKAN_IMAGE, backend="vulkan", device_class="gpu")
+    assert _resolve_image_ref(None, profile) == FALLBACK_VULKAN_IMAGE
 
 
 def test_resolve_image_ref_ignores_image_gen_dict() -> None:
@@ -94,8 +121,8 @@ def test_profile_image_and_flags_honours_slot_override() -> None:
     assert image == "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"
 
 
-def test_profile_image_and_flags_default_when_nothing_set() -> None:
-    """No slot image, profile has no image -> DEFAULT_ROCMFPX_IMAGE."""
+def test_profile_image_and_flags_default_when_nothing_set(strix: None) -> None:
+    """No slot image, profile has no image -> HW-gated default (rocmfpx on Strix)."""
     profile = SimpleNamespace(image=None, flags="-ngl 999", mtp=False)
     image, _flags = _profile_image_and_flags(profile)
     assert image == DEFAULT_ROCMFPX_IMAGE

--- a/tests/providers/test_image_resolution.py
+++ b/tests/providers/test_image_resolution.py
@@ -19,19 +19,6 @@ from hal0.providers.container import (
 )
 
 
-@pytest.fixture
-def strix(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the gfx1151/Strix-Halo capability signal so the HW-gated default
-    resolves to the rocmfpx runner, deterministically on any host."""
-    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: True)
-
-
-@pytest.fixture
-def non_strix(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force a non-Strix host so the HW-gated default resolves to the lean toolbox."""
-    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
-
-
 def _profile(image: str | None = None) -> ProfileConfig:
     """Build a minimal ProfileConfig (or pass image=None to drop the field)."""
     raw: dict[str, object] = {
@@ -68,22 +55,22 @@ def test_resolve_image_ref_falls_back_to_profile_image() -> None:
     assert _resolve_image_ref(None, profile) == "ghcr.io/hal0ai/hal0-rocmfpx:server"
 
 
-def test_resolve_image_ref_falls_back_to_default_on_strix(strix: None) -> None:
-    """No slot override AND no profile.image -> HW-gated default; on Strix that
-    is the rocmfpx runner."""
-    profile = SimpleNamespace(image=None)
+def test_resolve_image_ref_falls_back_to_rocmfpx_default() -> None:
+    """No slot override AND no profile.image on a GPU lane -> the universal
+    rocmfpx runner."""
+    profile = SimpleNamespace(image=None, backend="vulkan", device_class="gpu")
     assert _resolve_image_ref(None, profile) == DEFAULT_ROCMFPX_IMAGE
 
 
-def test_resolve_image_ref_falls_back_to_toolbox_off_strix(non_strix: None) -> None:
-    """Same fallback on a non-Strix host resolves to the lean vulkan toolbox."""
-    profile = SimpleNamespace(image=None)
+def test_resolve_image_ref_cpu_lane_falls_back_to_toolbox() -> None:
+    """A CPU-only lane with no image gets the lean toolbox, not the big runner."""
+    profile = SimpleNamespace(image=None, backend=None, device_class="cpu")
     assert _resolve_image_ref(None, profile) == FALLBACK_VULKAN_IMAGE
 
 
-def test_resolve_image_ref_honors_explicit_profile_pin_verbatim(strix: None) -> None:
-    """An explicit profile.image is honored verbatim even on Strix — it is NOT
-    re-gated (that would break the spec.image == profile.image invariant)."""
+def test_resolve_image_ref_honors_explicit_profile_pin_verbatim() -> None:
+    """An explicit profile.image is honored verbatim — never re-resolved (keeps
+    the spec.image == profile.image invariant)."""
     profile = SimpleNamespace(image=FALLBACK_VULKAN_IMAGE, backend="vulkan", device_class="gpu")
     assert _resolve_image_ref(None, profile) == FALLBACK_VULKAN_IMAGE
 
@@ -121,8 +108,8 @@ def test_profile_image_and_flags_honours_slot_override() -> None:
     assert image == "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"
 
 
-def test_profile_image_and_flags_default_when_nothing_set(strix: None) -> None:
-    """No slot image, profile has no image -> HW-gated default (rocmfpx on Strix)."""
+def test_profile_image_and_flags_default_when_nothing_set() -> None:
+    """No slot image, profile has no image -> the universal rocmfpx default."""
     profile = SimpleNamespace(image=None, flags="-ngl 999", mtp=False)
     image, _flags = _profile_image_and_flags(profile)
     assert image == DEFAULT_ROCMFPX_IMAGE

--- a/tests/updater/test_image_retag.py
+++ b/tests/updater/test_image_retag.py
@@ -99,7 +99,8 @@ def test_gpu_slot_on_old_toolbox_migrates_to_rocmfpx(tmp_hal0_home: str) -> None
     """A GPU slot pinned to the old vulkan toolbox (now a stale former-default
     ref) migrates to the universal rocmfpx runner."""
     _write_slot(
-        "g", f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "g"\nbackend = "vulkan"\ndevice = "gpu-vulkan"\n'
+        "g",
+        f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "g"\nbackend = "vulkan"\ndevice = "gpu-vulkan"\n',
     )
     assert retag_stale_slot_images() == 1
     assert _image_of("g") == DEFAULT_ROCMFPX_IMAGE
@@ -108,8 +109,6 @@ def test_gpu_slot_on_old_toolbox_migrates_to_rocmfpx(tmp_hal0_home: str) -> None
 def test_cpu_slot_on_toolbox_pin_is_noop(tmp_hal0_home: str) -> None:
     """A CPU-only slot already on the lean vulkan toolbox resolves back to
     itself → no rewrite, not counted (rocmfpx is wasteful for CPU)."""
-    _write_slot(
-        "c", f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "c"\ndevice = "cpu"\n'
-    )
+    _write_slot("c", f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "c"\ndevice = "cpu"\n')
     assert retag_stale_slot_images() == 0
     assert _image_of("c") == FALLBACK_VULKAN_IMAGE

--- a/tests/updater/test_image_retag.py
+++ b/tests/updater/test_image_retag.py
@@ -1,10 +1,12 @@
 """Upgrade migration: retag stale former-default runner-image pins.
 
 Covers :func:`hal0.updater.updater.retag_stale_slot_images` — slot ``image``
-pins exactly equal to a KNOWN former default roll to the current
-``DEFAULT_ROCMFPX_IMAGE``; any other pin is a deliberate operator override
-and must survive untouched, as must the ``[image]`` TOML table (image-gen
-settings) that shares the key.
+pins exactly equal to a KNOWN former default roll to the current **HW-gated**
+default (:func:`hal0.config.schema.resolve_default_image`): a gfx1151/Strix-Halo
+box migrates to the rocmfpx runner, any other host stays on the lean toolbox for
+its backend (a no-op). Any non-default pin is a deliberate operator override and
+must survive untouched, as must the ``[image]`` TOML table (image-gen settings)
+that shares the key.
 """
 
 from __future__ import annotations
@@ -14,11 +16,25 @@ import tomllib
 import pytest
 
 from hal0.config.paths import slots_config_dir
-from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, STALE_ROCMFPX_IMAGE_REFS
+from hal0.config.schema import (
+    DEFAULT_ROCMFPX_IMAGE,
+    FALLBACK_ROCM_IMAGE,
+    FALLBACK_VULKAN_IMAGE,
+    STALE_ROCMFPX_IMAGE_REFS,
+)
 from hal0.updater.updater import retag_stale_slot_images
 
 STALE = "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"
 CUSTOM = "ghcr.io/hal0ai/hal0-rocmfpx:my-debug-build"
+
+
+@pytest.fixture(autouse=True)
+def _force_strix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The retag target is HW-gated. Most tests here assert migration to the
+    rocmfpx runner — hal0's gfx1151/Strix-Halo target — so force the capability
+    signal to keep them deterministic on any CI host. The non-Strix tests below
+    opt back out explicitly."""
+    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: True)
 
 
 def _write_slot(name: str, body: str) -> None:
@@ -55,10 +71,8 @@ def test_stale_pins_retag_and_custom_pins_survive(tmp_hal0_home: str) -> None:
 @pytest.mark.parametrize("ref", sorted(STALE_ROCMFPX_IMAGE_REFS))
 def test_every_stale_ref_retags(tmp_hal0_home: str, ref: str) -> None:
     """Every known former-default ref in STALE_ROCMFPX_IMAGE_REFS rolls to the
-    current DEFAULT_ROCMFPX_IMAGE — not just the single ghcr ref the other tests
-    drive. Regression-proofs a future frozenset addition whose retag path might
-    diverge (e.g. the localhost/ prefix or the amd-strix-halo-toolboxes ref).
-    DEFAULT_ROCMFPX_IMAGE is intentionally NOT in the set, so no case is a no-op.
+    current default. On the forced-Strix platform the target is the rocmfpx
+    runner, which is intentionally NOT in the set, so no case is a no-op.
     """
     _write_slot("s", f'image = "{ref}"\nname = "s"\n')
     assert retag_stale_slot_images() == 1
@@ -87,3 +101,27 @@ def test_custom_profile_stale_image_retagged_flags_kept(tmp_hal0_home: str) -> N
     assert raw["profile"]["moe-tuned"]["image"] == DEFAULT_ROCMFPX_IMAGE
     assert raw["profile"]["moe-tuned"]["flags"] == "-fa off -b 2048"
     assert raw["profile"]["pinned"]["image"] == CUSTOM
+
+
+# ── non-Strix hosts: HW gate rolls to the toolbox, and toolbox pins are no-ops ─ #
+
+
+def test_non_strix_gpu_slot_migrates_to_toolbox(tmp_hal0_home: str, monkeypatch) -> None:
+    """On a non-Strix host, a stale rocmfpx pin on a ROCm GPU lane rolls to the
+    lean rocm toolbox for its backend, not the rocmfpx runner."""
+    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
+    _write_slot("g", f'image = "{STALE}"\nname = "g"\nbackend = "rocm"\ndevice = "gpu-rocm"\n')
+    assert retag_stale_slot_images() == 1
+    assert _image_of("g") == FALLBACK_ROCM_IMAGE
+
+
+def test_non_strix_toolbox_pin_is_noop(tmp_hal0_home: str, monkeypatch) -> None:
+    """On a non-Strix host, a slot already on the vulkan toolbox (now a stale
+    former-default ref) resolves back to itself → no rewrite, not counted."""
+    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
+    _write_slot(
+        "v",
+        f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "v"\nbackend = "vulkan"\ndevice = "gpu-vulkan"\n',
+    )
+    assert retag_stale_slot_images() == 0
+    assert _image_of("v") == FALLBACK_VULKAN_IMAGE

--- a/tests/updater/test_image_retag.py
+++ b/tests/updater/test_image_retag.py
@@ -1,10 +1,10 @@
 """Upgrade migration: retag stale former-default runner-image pins.
 
 Covers :func:`hal0.updater.updater.retag_stale_slot_images` — slot ``image``
-pins exactly equal to a KNOWN former default roll to the current **HW-gated**
-default (:func:`hal0.config.schema.resolve_default_image`): a gfx1151/Strix-Halo
-box migrates to the rocmfpx runner, any other host stays on the lean toolbox for
-its backend (a no-op). Any non-default pin is a deliberate operator override and
+pins exactly equal to a KNOWN former default roll to the current default
+(:func:`hal0.config.schema.resolve_default_image`): AMD GPU lanes migrate to the
+universal ``hal0-rocmfpx`` runner, while a CPU-only lane stays on the lean
+toolbox (a no-op). Any non-default pin is a deliberate operator override and
 must survive untouched, as must the ``[image]`` TOML table (image-gen settings)
 that shares the key.
 """
@@ -18,7 +18,6 @@ import pytest
 from hal0.config.paths import slots_config_dir
 from hal0.config.schema import (
     DEFAULT_ROCMFPX_IMAGE,
-    FALLBACK_ROCM_IMAGE,
     FALLBACK_VULKAN_IMAGE,
     STALE_ROCMFPX_IMAGE_REFS,
 )
@@ -26,15 +25,6 @@ from hal0.updater.updater import retag_stale_slot_images
 
 STALE = "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5"
 CUSTOM = "ghcr.io/hal0ai/hal0-rocmfpx:my-debug-build"
-
-
-@pytest.fixture(autouse=True)
-def _force_strix(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The retag target is HW-gated. Most tests here assert migration to the
-    rocmfpx runner — hal0's gfx1151/Strix-Halo target — so force the capability
-    signal to keep them deterministic on any CI host. The non-Strix tests below
-    opt back out explicitly."""
-    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: True)
 
 
 def _write_slot(name: str, body: str) -> None:
@@ -70,10 +60,9 @@ def test_stale_pins_retag_and_custom_pins_survive(tmp_hal0_home: str) -> None:
 
 @pytest.mark.parametrize("ref", sorted(STALE_ROCMFPX_IMAGE_REFS))
 def test_every_stale_ref_retags(tmp_hal0_home: str, ref: str) -> None:
-    """Every known former-default ref in STALE_ROCMFPX_IMAGE_REFS rolls to the
-    current default. On the forced-Strix platform the target is the rocmfpx
-    runner, which is intentionally NOT in the set, so no case is a no-op.
-    """
+    """Every known former-default ref rolls to the current default. A GPU
+    (backend-less) slot resolves to the rocmfpx runner, which is intentionally
+    NOT in the set, so no case is a no-op."""
     _write_slot("s", f'image = "{ref}"\nname = "s"\n')
     assert retag_stale_slot_images() == 1
     assert _image_of("s") == DEFAULT_ROCMFPX_IMAGE
@@ -103,25 +92,24 @@ def test_custom_profile_stale_image_retagged_flags_kept(tmp_hal0_home: str) -> N
     assert raw["profile"]["pinned"]["image"] == CUSTOM
 
 
-# ── non-Strix hosts: HW gate rolls to the toolbox, and toolbox pins are no-ops ─ #
+# ── lane carve-outs: GPU migrates, CPU-only is a no-op ────────────────────── #
 
 
-def test_non_strix_gpu_slot_migrates_to_toolbox(tmp_hal0_home: str, monkeypatch) -> None:
-    """On a non-Strix host, a stale rocmfpx pin on a ROCm GPU lane rolls to the
-    lean rocm toolbox for its backend, not the rocmfpx runner."""
-    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
-    _write_slot("g", f'image = "{STALE}"\nname = "g"\nbackend = "rocm"\ndevice = "gpu-rocm"\n')
-    assert retag_stale_slot_images() == 1
-    assert _image_of("g") == FALLBACK_ROCM_IMAGE
-
-
-def test_non_strix_toolbox_pin_is_noop(tmp_hal0_home: str, monkeypatch) -> None:
-    """On a non-Strix host, a slot already on the vulkan toolbox (now a stale
-    former-default ref) resolves back to itself → no rewrite, not counted."""
-    monkeypatch.setattr("hal0.config.schema.rocmfpx_capable", lambda hw: False)
+def test_gpu_slot_on_old_toolbox_migrates_to_rocmfpx(tmp_hal0_home: str) -> None:
+    """A GPU slot pinned to the old vulkan toolbox (now a stale former-default
+    ref) migrates to the universal rocmfpx runner."""
     _write_slot(
-        "v",
-        f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "v"\nbackend = "vulkan"\ndevice = "gpu-vulkan"\n',
+        "g", f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "g"\nbackend = "vulkan"\ndevice = "gpu-vulkan"\n'
+    )
+    assert retag_stale_slot_images() == 1
+    assert _image_of("g") == DEFAULT_ROCMFPX_IMAGE
+
+
+def test_cpu_slot_on_toolbox_pin_is_noop(tmp_hal0_home: str) -> None:
+    """A CPU-only slot already on the lean vulkan toolbox resolves back to
+    itself → no rewrite, not counted (rocmfpx is wasteful for CPU)."""
+    _write_slot(
+        "c", f'image = "{FALLBACK_VULKAN_IMAGE}"\nname = "c"\ndevice = "cpu"\n'
     )
     assert retag_stale_slot_images() == 0
-    assert _image_of("v") == FALLBACK_VULKAN_IMAGE
+    assert _image_of("c") == FALLBACK_VULKAN_IMAGE


### PR DESCRIPTION
## Why

A fresh hal0 install brought GPU slots up on the stale `amd-strix-halo-toolboxes:vulkan-radv-server` image (e.g. the utility slot on `:8081`) instead of the unified `hal0-rocmfpx` runner the platform actually uses. Reproduced on the `hal0-fresh` box (0.9.7.3): `utility`/`agent`/`vision`/`brain`/`embed`/`rerank` all resolved to `vulkan-radv-server`.

## What this PR does

Makes **`hal0-rocmfpx` the universal default** for AMD GPU LLM/embed/rerank lanes, and lets `hal0 update` migrate existing slots onto it.

- **`resolve_default_image(backend, device_class)`** (`config/schema.py`) — rocmfpx for every AMD GPU lane; CUDA → the llama.cpp cuda image; CPU-only → the lean vulkan toolbox (a 7.5 GB ROCm image is wasteful for CPU). Deterministic and probe-free.
- **Not HW-gated.** The rocmfpx image ships `mesa-vulkan-drivers` + a compiled Vulkan/RADV backend (the live Strix slots already run it via `-dev Vulkan0`), so it runs on any AMD GPU — the `CMAKE_HIP_ARCHITECTURES=gfx1151` pin only constrains the HIP kernels, not the portable Vulkan path.
- **Basic seed profiles** (`vulkan`/`rocm`/`rocm-longctx`/`embed`/`rerank`/`vulkan-embed`/`vulkan-rerank`/`cpu-llm`) blank their `image` and defer to `resolve_default_image`; `ProfileConfig` now allows an empty image (= "defer"; whitespace still rejected).
- **`_resolve_image_ref`** honors an explicit slot/profile pin verbatim, else resolves the default.
- **`retag_stale_slot_images`** (the existing `hal0 update` migration) resolves its target through the same function with a no-op guard, and `STALE_ROCMFPX_IMAGE_REFS` gains the old `vulkan-radv-server` / `rocm-7.2.4-rocmfp4-server` refs — so an update rolls stale-pinned GPU slots to rocmfpx (CPU-only pins stay put).

## Verified end-to-end on `hal0-fresh` (0.9.7.3)

- **Before:** `utility`/`agent`/`vision`/`brain`/`embed`/`rerank` → `vulkan-radv-server`.
- **After (this branch overlaid):** all of those → `hal0-rocmfpx:c077206`; `tts`/`img`/`flm` keep their own images. Fresh slots are unpinned (only `device`+`profile`), so they pick up the new image at first `slot load`; existing loaded slots are handled by `rerender_slot_units` + the retag on `hal0 update`.
- 900 tests pass across `tests/{providers,updater,config}`; ruff clean. The 6 non-passing are pre-existing host-env failures that fail identically on `main`.

## Propagation to existing users

On a **release + `hal0 update`**: `ensure_seed_profiles` (prune frozen seeds) → `retag_stale_slot_images` (pinned slots) → `rerender_slot_units` (unpinned slots) — effective on each slot's next start. Not on merge alone; not on editable dev installs.

## Scope / follow-ups (not in this PR)

Ships against the current hand-built `c077206`. Producer side is designed in `docs/design/` (`container-image-overhaul.md`, `toolbox-repo-consolidation.md`): publish a rolling `:rocmfpx-stable` from `Hal0_ROCmFPX`'s inherited CI, flip `DEFAULT_ROCMFPX_IMAGE` to that tag + a manifest digest pin, consolidate `Hal0ai/amd-strix-halo-toolboxes` as the one toolbox factory, detach the kyuz0 fork (keep charlie12345/ciru-ai as ROCmFPX upstream remotes). Those docs still describe the earlier HW-gated approach in places — superseded by the universal default here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
