### PR TITLE
build(pypi): publish under distribution name "hal0ai"

### DIFF
--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -52,10 +52,12 @@ manually from the dashboard after install.
 ## pip install (convenience only — not the full install)
 
 hal0 is also published to PyPI as a convenience for scripting, tool
-discovery, and Python-level imports:
+discovery, and Python-level imports. The distribution is named `hal0ai`
+(PyPI's name-similarity guard rejects `hal0`), but it still installs the
+`hal0` command and the `hal0` import package:
 
 ```sh
-pip install hal0
+pip install hal0ai
 ```
 
 This installs the `hal0` and `hal0-agent` console scripts and the
@@ -63,7 +65,7 @@ This installs the `hal0` and `hal0-agent` console scripts and the
 `hal0.*` in your own Python code, or invoke the CLI from a virtualenv.
 
 <Aside type="danger" title="Not the supported production path">
-`pip install hal0` does **not** set up systemd units, podman containers,
+`pip install hal0ai` does **not** set up systemd units, podman containers,
 the dashboard UI, OpenWebUI, model registry, or the FHS `/usr/lib/hal0`
 layout. It is a lightweight complement for scripting and development.
 For a full production deployment, use the bootstrap script above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,14 @@
 requires = ["hatchling>=1.21"]
 build-backend = "hatchling.build"
 
+# NOTE: the DISTRIBUTION name is "hal0ai" (what `pip install` fetches).
+# PyPI rejects "hal0" under its name-similarity guard (too close to the
+# existing "halo" project). The import package stays `hal0` (see
+# [tool.hatch.build.targets.wheel] below) and the console scripts stay
+# `hal0` / `hal0-agent`, so only the pip-install name differs. Anything
+# that resolves this project by distribution name must use "hal0ai".
 [project]
-name = "hal0"
+name = "hal0ai"
 version = "0.9.7.3"
 description = "Open-source home AI inference platform"
 readme = "README.md"

--- a/src/hal0/__init__.py
+++ b/src/hal0/__init__.py
@@ -4,7 +4,13 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 try:
-    __version__ = _pkg_version("hal0")
+    # Distribution name is "hal0ai" (PyPI rejects "hal0"); the fallback to
+    # "hal0" covers a transitional editable install whose .dist-info still
+    # carries the old name until it's re-`pip install`-ed.
+    try:
+        __version__ = _pkg_version("hal0ai")
+    except PackageNotFoundError:
+        __version__ = _pkg_version("hal0")
 except PackageNotFoundError:
     # Importing the source tree without `pip install`-ing it (e.g. a
     # `python -c "import hal0"` from a repo clone) bypasses metadata.

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -62,10 +62,11 @@ def _editable_source_version() -> str | None:
     """Return the version in the source-tree pyproject.toml, if this is an
     editable/source checkout; otherwise None.
 
-    In an editable install ``importlib.metadata.version("hal0")`` is frozen
+    In an editable install ``importlib.metadata.version("hal0ai")`` is frozen
     at ``pip install -e`` time and goes stale after a ``git pull``. We detect
     the source tree by walking up from ``hal0.__file__`` for a pyproject.toml
-    whose project name is ``hal0`` and reading its declared version.
+    whose project name is ``hal0ai`` (the distribution name; "hal0" is the
+    legacy pre-rename name) and reading its declared version.
     """
     mod_file = getattr(hal0, "__file__", None)
     if not mod_file:
@@ -79,7 +80,7 @@ def _editable_source_version() -> str | None:
         except (OSError, tomllib.TOMLDecodeError):
             return None
         project = data.get("project", {})
-        if project.get("name") == "hal0":
+        if project.get("name") in ("hal0ai", "hal0"):
             ver = project.get("version")
             return str(ver) if ver else None
         # A pyproject that isn't hal0's - stop walking (we left the tree).

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -650,8 +650,9 @@ def _looks_like_hal0_install(path: Path) -> bool:
     """Heuristic: does ``path`` look like a prior hal0 tarball extraction?
 
     A safe quarantine candidate has either a top-level ``VERSION`` file
-    or a ``pyproject.toml`` whose ``name`` is ``hal0``. We deliberately
-    refuse to touch unrelated non-empty directories.
+    or a ``pyproject.toml`` whose ``name`` is ``hal0ai`` (or the legacy
+    pre-rename ``hal0``). We deliberately refuse to touch unrelated
+    non-empty directories.
     """
     if (path / "VERSION").is_file():
         return True
@@ -661,7 +662,10 @@ def _looks_like_hal0_install(path: Path) -> bool:
             head = pp.read_text(encoding="utf-8", errors="replace")[:512]
         except OSError:
             return False
-        return 'name = "hal0"' in head or "name = 'hal0'" in head
+        return any(
+            marker in head
+            for marker in ('name = "hal0ai"', "name = 'hal0ai'", 'name = "hal0"', "name = 'hal0'")
+        )
     return False
 
 


### PR DESCRIPTION
## Why

`pip install hal0` **cannot** be enabled: PyPI's name-similarity guard (PEP 541) rejects `hal0` as too close to the existing [`halo`](https://pypi.org/project/halo/) package (o-vs-0 confusable). The `pypi-publish` job in `release.yml` was therefore failing on every tagged release with nothing ever uploaded (`pypi.org/pypi/hal0/json` → 404).

## What

Publish the wheel under distribution name **`hal0ai`** instead. The **import package stays `hal0`** and the **console scripts stay `hal0` / `hal0-agent`** — only the pip-install name changes:

```sh
pip install hal0ai   # then, unchanged:  import hal0  /  hal0 --version
```

`hal0ai` is unclaimed on PyPI and already passes the similarity guard (a pending Trusted Publisher for it was accepted).

## Changes

- `pyproject.toml` — `name = "hal0"` → `"hal0ai"` (+ explainer comment)
- Three internal spots resolve the project by **distribution name**; each updated with a `hal0` fallback for transitional editable installs:
  - `src/hal0/__init__.py` — `__version__` looks up `hal0ai` then `hal0`
  - `src/hal0/cli/update_commands.py` — editable-drift detector accepts `hal0ai`/`hal0`
  - `src/hal0/updater/updater.py` — tarball-recognition marker accepts `name = "hal0ai"` (the old `'name = "hal0"'` substring check does **not** match `name = "hal0ai"`)
- `docs/getting-started/install.mdx` — `pip install hal0ai`, noting the command stays `hal0`

Runtime `name="hal0"` (API/CLI/service identity) is intentionally left unchanged.

## Verification

Built + installed into a fresh venv:

```
pip show hal0ai  → Name: hal0ai, Version: 0.9.7.3
hal0 --version   → hal0 0.9.7.3
python -c "import hal0; print(hal0.__version__)"  → 0.9.7.3   (resolves from metadata, not the source sentinel)
```

## Out-of-band steps still required to go live (not in this PR)

1. Keep the **`hal0ai`** pending Trusted Publisher on PyPI (project `hal0ai`, owner `hal0ai`, repo `hal0`, workflow `release.yml`, environment `pypi`).
2. Create the **`pypi` GitHub environment** in repo settings (the `pypi-publish` job declares `environment: pypi`).
3. After merge, cut a new tag — `pypi-publish` fires on the tag push and claims `hal0ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)