### PR TITLE
feat(agents): add turnstone as a heavyweight bundled agent (coexists with hermes)

### DIFF
--- a/docs/concepts/agents.mdx
+++ b/docs/concepts/agents.mdx
@@ -21,6 +21,15 @@ requires an explicit switch, which atomically tears down the existing agent
 before installing the new one. That invariant keeps the platform's behaviour
 unambiguous — there's always exactly one agent answering.
 
+The one exception is **Turnstone**, a self-hosted orchestration platform that
+hal0 can bundle *alongside* Hermes. Because it runs its own server on a
+distinct loopback port (`127.0.0.1:9129`) and never contends for the dashboard
+chat role, Hermes and Turnstone may be installed together — installing Turnstone
+does not tear Hermes down. Every other pairing still follows single-pick.
+Turnstone routes all inference through hal0-api's OpenAI-compatible gateway,
+mounts hal0's memory and admin tools over MCP, and grades each tool call with an
+LLM judge before it runs. Install it with `hal0 agent install turnstone`.
+
 The agent runs as a systemd template unit, `hal0-agent@<id>.service` (so Hermes
 is `hal0-agent@hermes`). It runs as the unprivileged **`hal0`** system user the
 installer creates, under a tight sandbox: no new privileges, a read-only system

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -417,6 +417,7 @@ completion.
 | Command | Purpose | Key options |
 |---|---|---|
 | `agent bootstrap hermes` | Run the Hermes-Agent bootstrap state machine. | `--repair`, `--dry-run`, `--skip-phase` (repeatable), `--offline`, `--verbose`/`-v` |
+| `agent bootstrap turnstone` | Bootstrap Turnstone (renders `config.toml` → hal0-api `/v1` + the live models DB; coexists with Hermes). | `--repair`, `--adopt`, `--dry-run`, `--skip-phase` (repeatable), `--verbose`/`-v` |
 
 ### `hal0 agent personas`
 

--- a/installer/agents/turnstone.sh
+++ b/installer/agents/turnstone.sh
@@ -1,30 +1,26 @@
 #!/bin/sh
 # hal0 — turnstone bundled-agent installer (ADR-0004 §6, sibling of hermes).
 #
-# POSIX shell, dash-safe. Track-latest of the turnstone binaries (NO version
-# pin per ADR-0004 §3; the nightly agent-shim smoke test catches upstream
-# breakage instead of freezing users on a stale release).
+# POSIX shell, dash-safe. Track-latest of the turnstone PyPI package (NO
+# version pin per ADR-0004 §3; the nightly agent-shim smoke test catches
+# upstream breakage instead of freezing users on a stale release).
 #
-# turnstone (github.com/turnstonelabs/turnstone) is a Go agent-orchestration
-# platform. Its canonical deploy is docker-compose, but hal0 runs it as a
-# native host binary (hermes-shaped) so the agent shim can drive it under
-# systemd with sd_notify/watchdog. This script ONLY lands the binaries; the
-# heavy wiring (config.toml / MCP / model / memory) is the foreground
+# turnstone (github.com/turnstonelabs/turnstone) is a **Python** package on
+# PyPI (name `turnstone`, py>=3.11) with console scripts `turnstone`,
+# `turnstone-server`, `turnstone-console`, etc. — NOT a Go binary. hal0
+# installs it into a dedicated managed venv exactly like hermes-agent, so the
+# agent shim can run `turnstone-server` under systemd with sd_notify/watchdog.
+# The heavy wiring (config.toml / MCP / model / memory) is the foreground
 # provisioner (hal0.agents.turnstone_provision), run by
 # `hal0 agent install turnstone`.
 #
-# We install BOTH `turnstone` (CLI/REPL) and `turnstone-server` (the web/REST/
-# SSE server the shim runs on loopback :9129). The multi-call fold — some
-# builds ship one binary — is tolerated: if only `turnstone` lands, the shim's
-# binary search falls back to it.
-#
 # Inputs (set by the provisioner; safe to override for manual invocation):
-#   HAL0_TURNSTONE_BIN   managed binary dir target (default: /var/lib/hal0/bin/turnstone)
-#   HAL0_TURNSTONE_SHIM  on-PATH shim (default: /usr/local/bin/turnstone)
-#   TURNSTONE_VERSION    pin an explicit release tag (default: latest)
+#   HAL0_TURNSTONE_VENV  managed venv dir (default: /var/lib/hal0/venvs/turnstone)
+#   HAL0_TURNSTONE_SHIM  on-PATH CLI shim (default: /usr/local/bin/turnstone)
+#   TURNSTONE_VERSION    pin an explicit version (default: latest)
 #
-# Idempotent: re-runs cleanly. Stops at the first material failure with an
-# actionable error the operator (or the nightly smoke) can grep.
+# Idempotent: re-runs cleanly (pip --upgrade). Stops at the first material
+# failure with an actionable error the operator (or nightly smoke) can grep.
 
 set -eu
 
@@ -32,122 +28,67 @@ info() { printf '[turnstone] %s\n' "$*"; }
 die()  { printf '[turnstone] ERROR: %s\n' "$*" >&2; exit 1; }
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
-BIN_DIR="$(dirname "${HAL0_TURNSTONE_BIN:-/var/lib/hal0/bin/turnstone}")"
+VENV="${HAL0_TURNSTONE_VENV:-/var/lib/hal0/venvs/turnstone}"
 LINK_DIR="$(dirname "${HAL0_TURNSTONE_SHIM:-/usr/local/bin/turnstone}")"
 DATA_DIR="${HAL0_AGENT_DATA_DIR:-/var/lib/hal0/agents/turnstone}"
 VERSION="${TURNSTONE_VERSION:-latest}"
-REPO="turnstonelabs/turnstone"
-# The binaries hal0 wants on the host. `turnstone-server` is what the agent
-# shim runs; `turnstone` is the interactive CLI.
-BINARIES="turnstone turnstone-server"
+# Console scripts hal0 shims onto PATH (the CLI + the server the unit runs).
+SHIMMED="turnstone turnstone-server"
 
-mkdir -p "$BIN_DIR" "$DATA_DIR"
+mkdir -p "$DATA_DIR" "$(dirname "$VENV")"
 
-# ── Platform matrix ──────────────────────────────────────────────────────────
-os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-case "$(uname -m)" in
-    x86_64 | amd64) arch="amd64" ;;
-    aarch64 | arm64) arch="arm64" ;;
-    *) die "unsupported arch '$(uname -m)' — turnstone ships amd64/arm64 only" ;;
-esac
-
-TURNSTONE_INSTALL_METHOD=""
-
-# ── Install: prefer prebuilt release binaries, fall back to `go install` ──────
-#
-# Release-asset naming isn't pinned by upstream docs, so we probe a couple of
-# common conventions (<bin>_<os>_<arch>, <bin>-<os>-<arch>) and take the first
-# that downloads. If none resolve and a Go toolchain is present, build from
-# source (track-latest). The nightly smoke flags an upstream layout change.
-
-download_release_binary() {
-    # $1 = binary name (turnstone / turnstone-server)
-    _bin="$1"
-    _base="https://github.com/${REPO}/releases"
-    if [ "$VERSION" = "latest" ]; then
-        _rel="${_base}/latest/download"
-    else
-        _rel="${_base}/download/${VERSION}"
-    fi
-    for _name in \
-        "${_bin}_${os}_${arch}" \
-        "${_bin}-${os}-${arch}" \
-        "${_bin}_${os}_${arch}.tar.gz" \
-        "${_bin}-${os}-${arch}.tar.gz"; do
-        _url="${_rel}/${_name}"
-        _tmp="${BIN_DIR}/.dl.${_bin}"
-        if curl -fsSL "$_url" -o "$_tmp" 2>/dev/null; then
-            case "$_name" in
-                *.tar.gz)
-                    tar -xzf "$_tmp" -C "$BIN_DIR" "$_bin" 2>/dev/null \
-                        || tar -xzf "$_tmp" -C "$BIN_DIR" 2>/dev/null || true
-                    rm -f "$_tmp"
-                    ;;
-                *)
-                    mv "$_tmp" "${BIN_DIR}/${_bin}"
-                    ;;
-            esac
-            if [ -f "${BIN_DIR}/${_bin}" ]; then
-                chmod +x "${BIN_DIR}/${_bin}"
+# ── Resolve a supported interpreter (turnstone requires py>=3.11) ─────────────
+find_python() {
+    for p in python3.13 python3.12 python3.11 python3; do
+        if command -v "$p" >/dev/null 2>&1; then
+            # Confirm >=3.11 (turnstone's requires-python).
+            if "$p" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null; then
+                printf '%s\n' "$p"
                 return 0
             fi
         fi
-        rm -f "$_tmp" 2>/dev/null || true
     done
     return 1
 }
 
-install_via_release() {
-    command -v curl >/dev/null 2>&1 || return 1
-    _got_any=1
-    for _bin in $BINARIES; do
-        if download_release_binary "$_bin"; then
-            info "downloaded ${_bin} (${os}/${arch})"
-            _got_any=0
-        else
-            info "no release asset for ${_bin} — will try go/build fallback"
-        fi
-    done
-    return $_got_any
-}
+PY="$(find_python || true)"
+[ -n "$PY" ] || die "no python>=3.11 found — turnstone requires it. Install python3.11+ first."
 
-install_via_go() {
-    command -v go >/dev/null 2>&1 || return 1
-    info "building turnstone from source via 'go install' (track-latest)"
-    _tag="$VERSION"; [ "$_tag" = "latest" ] && _tag="latest"
-    GOBIN="$BIN_DIR" go install "github.com/${REPO}/cmd/turnstone@${_tag}" 2>/dev/null || true
-    GOBIN="$BIN_DIR" go install "github.com/${REPO}/cmd/turnstone-server@${_tag}" 2>/dev/null || true
-    [ -f "${BIN_DIR}/turnstone" ] || [ -f "${BIN_DIR}/turnstone-server" ]
-}
-
-if install_via_release; then
-    TURNSTONE_INSTALL_METHOD="release"
-elif install_via_go; then
-    TURNSTONE_INSTALL_METHOD="go"
-else
-    die "could not install turnstone: no release binary for ${os}/${arch} and no Go toolchain found. Install Go (https://go.dev/dl/) or check https://github.com/${REPO}/releases for the correct asset naming."
+# ── Create/refresh the managed venv, then pip-install turnstone ──────────────
+if [ ! -x "$VENV/bin/python" ]; then
+    info "creating managed venv at $VENV ($PY)"
+    "$PY" -m venv "$VENV" || die "python -m venv $VENV failed"
 fi
+VPIP="$VENV/bin/python -m pip"
+info "upgrading pip in the venv"
+$VPIP install --upgrade pip >/dev/null 2>&1 || info "pip self-upgrade skipped (non-fatal)"
 
-# ── Verify at least the server binary landed, then shim onto PATH ────────────
-if [ ! -f "${BIN_DIR}/turnstone" ] && [ ! -f "${BIN_DIR}/turnstone-server" ]; then
-    die "install (${TURNSTONE_INSTALL_METHOD}) reported success but no turnstone binary is in ${BIN_DIR}."
+if [ "$VERSION" = "latest" ]; then
+    SPEC="turnstone"
+else
+    SPEC="turnstone==$VERSION"
+fi
+info "installing $SPEC into the venv (track-latest)"
+$VPIP install --upgrade "$SPEC" \
+    || die "pip install $SPEC failed — turnstone may have renamed on PyPI or dropped a dep; check https://pypi.org/project/turnstone/"
+
+# ── Verify the console scripts landed, then shim onto PATH ────────────────────
+if [ ! -x "$VENV/bin/turnstone" ] && [ ! -x "$VENV/bin/turnstone-server" ]; then
+    die "pip install succeeded but no turnstone console scripts in $VENV/bin — upstream may have renamed the entry points (see pyproject [project.scripts])."
 fi
 
 if [ -w "${LINK_DIR}" ] || [ "$(id -u)" -eq 0 ]; then
     mkdir -p "${LINK_DIR}"
-    for _bin in $BINARIES; do
-        [ -f "${BIN_DIR}/${_bin}" ] && ln -sf "${BIN_DIR}/${_bin}" "${LINK_DIR}/${_bin}"
+    for _bin in $SHIMMED; do
+        [ -x "$VENV/bin/$_bin" ] && ln -sf "$VENV/bin/$_bin" "${LINK_DIR}/$_bin"
     done
-    info "shimmed binaries into ${LINK_DIR}"
+    info "shimmed console scripts into ${LINK_DIR}"
 else
-    die "turnstone installed in ${BIN_DIR} but ${LINK_DIR} isn't writable (not root) — re-run as root or add ${BIN_DIR} to PATH."
+    die "turnstone installed in ${VENV} but ${LINK_DIR} isn't writable (not root) — re-run as root or add ${VENV}/bin to PATH."
 fi
 
-# Report the version we landed (best-effort; some subcommands differ).
-if [ -x "${BIN_DIR}/turnstone" ]; then
-    info "turnstone installed: $("${BIN_DIR}/turnstone" --version 2>/dev/null | head -1 || echo '(version unknown)')"
-fi
-info "binaries ready in ${BIN_DIR}. The provisioner now renders config.toml + MCP + model wiring."
+info "turnstone installed: $("$VENV/bin/turnstone" --version 2>/dev/null | head -1 || echo '(version unknown)')"
+info "venv ready at ${VENV}. The provisioner now renders config.toml + MCP + model wiring."
 
 # ── Uninstall companion ──────────────────────────────────────────────────────
 # installer/uninstall.sh runs ${VAR_DIR}/agents/<name>/uninstall.sh per agent.
@@ -155,8 +96,8 @@ info "binaries ready in ${BIN_DIR}. The provisioner now renders config.toml + MC
     printf '#!/bin/sh\n'
     printf '# hal0 — turnstone uninstall companion (called from installer/uninstall.sh)\n'
     printf 'set -eu\n'
-    for _bin in $BINARIES; do
-        printf 'rm -f "%s/%s" 2>/dev/null || true\n' "${BIN_DIR}" "${_bin}"
+    printf 'rm -rf "%s" 2>/dev/null || true\n' "${VENV}"
+    for _bin in $SHIMMED; do
         printf 'if [ -L "%s/%s" ]; then rm -f "%s/%s"; fi\n' \
             "${LINK_DIR}" "${_bin}" "${LINK_DIR}" "${_bin}"
     done

--- a/installer/agents/turnstone.sh
+++ b/installer/agents/turnstone.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# hal0 — turnstone bundled-agent installer (ADR-0004 §6, sibling of hermes).
+#
+# POSIX shell, dash-safe. Track-latest of the turnstone binaries (NO version
+# pin per ADR-0004 §3; the nightly agent-shim smoke test catches upstream
+# breakage instead of freezing users on a stale release).
+#
+# turnstone (github.com/turnstonelabs/turnstone) is a Go agent-orchestration
+# platform. Its canonical deploy is docker-compose, but hal0 runs it as a
+# native host binary (hermes-shaped) so the agent shim can drive it under
+# systemd with sd_notify/watchdog. This script ONLY lands the binaries; the
+# heavy wiring (config.toml / MCP / model / memory) is the foreground
+# provisioner (hal0.agents.turnstone_provision), run by
+# `hal0 agent install turnstone`.
+#
+# We install BOTH `turnstone` (CLI/REPL) and `turnstone-server` (the web/REST/
+# SSE server the shim runs on loopback :9129). The multi-call fold — some
+# builds ship one binary — is tolerated: if only `turnstone` lands, the shim's
+# binary search falls back to it.
+#
+# Inputs (set by the provisioner; safe to override for manual invocation):
+#   HAL0_TURNSTONE_BIN   managed binary dir target (default: /var/lib/hal0/bin/turnstone)
+#   HAL0_TURNSTONE_SHIM  on-PATH shim (default: /usr/local/bin/turnstone)
+#   TURNSTONE_VERSION    pin an explicit release tag (default: latest)
+#
+# Idempotent: re-runs cleanly. Stops at the first material failure with an
+# actionable error the operator (or the nightly smoke) can grep.
+
+set -eu
+
+info() { printf '[turnstone] %s\n' "$*"; }
+die()  { printf '[turnstone] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+BIN_DIR="$(dirname "${HAL0_TURNSTONE_BIN:-/var/lib/hal0/bin/turnstone}")"
+LINK_DIR="$(dirname "${HAL0_TURNSTONE_SHIM:-/usr/local/bin/turnstone}")"
+DATA_DIR="${HAL0_AGENT_DATA_DIR:-/var/lib/hal0/agents/turnstone}"
+VERSION="${TURNSTONE_VERSION:-latest}"
+REPO="turnstonelabs/turnstone"
+# The binaries hal0 wants on the host. `turnstone-server` is what the agent
+# shim runs; `turnstone` is the interactive CLI.
+BINARIES="turnstone turnstone-server"
+
+mkdir -p "$BIN_DIR" "$DATA_DIR"
+
+# ── Platform matrix ──────────────────────────────────────────────────────────
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$(uname -m)" in
+    x86_64 | amd64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    *) die "unsupported arch '$(uname -m)' — turnstone ships amd64/arm64 only" ;;
+esac
+
+TURNSTONE_INSTALL_METHOD=""
+
+# ── Install: prefer prebuilt release binaries, fall back to `go install` ──────
+#
+# Release-asset naming isn't pinned by upstream docs, so we probe a couple of
+# common conventions (<bin>_<os>_<arch>, <bin>-<os>-<arch>) and take the first
+# that downloads. If none resolve and a Go toolchain is present, build from
+# source (track-latest). The nightly smoke flags an upstream layout change.
+
+download_release_binary() {
+    # $1 = binary name (turnstone / turnstone-server)
+    _bin="$1"
+    _base="https://github.com/${REPO}/releases"
+    if [ "$VERSION" = "latest" ]; then
+        _rel="${_base}/latest/download"
+    else
+        _rel="${_base}/download/${VERSION}"
+    fi
+    for _name in \
+        "${_bin}_${os}_${arch}" \
+        "${_bin}-${os}-${arch}" \
+        "${_bin}_${os}_${arch}.tar.gz" \
+        "${_bin}-${os}-${arch}.tar.gz"; do
+        _url="${_rel}/${_name}"
+        _tmp="${BIN_DIR}/.dl.${_bin}"
+        if curl -fsSL "$_url" -o "$_tmp" 2>/dev/null; then
+            case "$_name" in
+                *.tar.gz)
+                    tar -xzf "$_tmp" -C "$BIN_DIR" "$_bin" 2>/dev/null \
+                        || tar -xzf "$_tmp" -C "$BIN_DIR" 2>/dev/null || true
+                    rm -f "$_tmp"
+                    ;;
+                *)
+                    mv "$_tmp" "${BIN_DIR}/${_bin}"
+                    ;;
+            esac
+            if [ -f "${BIN_DIR}/${_bin}" ]; then
+                chmod +x "${BIN_DIR}/${_bin}"
+                return 0
+            fi
+        fi
+        rm -f "$_tmp" 2>/dev/null || true
+    done
+    return 1
+}
+
+install_via_release() {
+    command -v curl >/dev/null 2>&1 || return 1
+    _got_any=1
+    for _bin in $BINARIES; do
+        if download_release_binary "$_bin"; then
+            info "downloaded ${_bin} (${os}/${arch})"
+            _got_any=0
+        else
+            info "no release asset for ${_bin} — will try go/build fallback"
+        fi
+    done
+    return $_got_any
+}
+
+install_via_go() {
+    command -v go >/dev/null 2>&1 || return 1
+    info "building turnstone from source via 'go install' (track-latest)"
+    _tag="$VERSION"; [ "$_tag" = "latest" ] && _tag="latest"
+    GOBIN="$BIN_DIR" go install "github.com/${REPO}/cmd/turnstone@${_tag}" 2>/dev/null || true
+    GOBIN="$BIN_DIR" go install "github.com/${REPO}/cmd/turnstone-server@${_tag}" 2>/dev/null || true
+    [ -f "${BIN_DIR}/turnstone" ] || [ -f "${BIN_DIR}/turnstone-server" ]
+}
+
+if install_via_release; then
+    TURNSTONE_INSTALL_METHOD="release"
+elif install_via_go; then
+    TURNSTONE_INSTALL_METHOD="go"
+else
+    die "could not install turnstone: no release binary for ${os}/${arch} and no Go toolchain found. Install Go (https://go.dev/dl/) or check https://github.com/${REPO}/releases for the correct asset naming."
+fi
+
+# ── Verify at least the server binary landed, then shim onto PATH ────────────
+if [ ! -f "${BIN_DIR}/turnstone" ] && [ ! -f "${BIN_DIR}/turnstone-server" ]; then
+    die "install (${TURNSTONE_INSTALL_METHOD}) reported success but no turnstone binary is in ${BIN_DIR}."
+fi
+
+if [ -w "${LINK_DIR}" ] || [ "$(id -u)" -eq 0 ]; then
+    mkdir -p "${LINK_DIR}"
+    for _bin in $BINARIES; do
+        [ -f "${BIN_DIR}/${_bin}" ] && ln -sf "${BIN_DIR}/${_bin}" "${LINK_DIR}/${_bin}"
+    done
+    info "shimmed binaries into ${LINK_DIR}"
+else
+    die "turnstone installed in ${BIN_DIR} but ${LINK_DIR} isn't writable (not root) — re-run as root or add ${BIN_DIR} to PATH."
+fi
+
+# Report the version we landed (best-effort; some subcommands differ).
+if [ -x "${BIN_DIR}/turnstone" ]; then
+    info "turnstone installed: $("${BIN_DIR}/turnstone" --version 2>/dev/null | head -1 || echo '(version unknown)')"
+fi
+info "binaries ready in ${BIN_DIR}. The provisioner now renders config.toml + MCP + model wiring."
+
+# ── Uninstall companion ──────────────────────────────────────────────────────
+# installer/uninstall.sh runs ${VAR_DIR}/agents/<name>/uninstall.sh per agent.
+{
+    printf '#!/bin/sh\n'
+    printf '# hal0 — turnstone uninstall companion (called from installer/uninstall.sh)\n'
+    printf 'set -eu\n'
+    for _bin in $BINARIES; do
+        printf 'rm -f "%s/%s" 2>/dev/null || true\n' "${BIN_DIR}" "${_bin}"
+        printf 'if [ -L "%s/%s" ]; then rm -f "%s/%s"; fi\n' \
+            "${LINK_DIR}" "${_bin}" "${LINK_DIR}" "${_bin}"
+    done
+} > "${DATA_DIR}/uninstall.sh"
+chmod +x "${DATA_DIR}/uninstall.sh"
+
+exit 0

--- a/installer/systemd/hal0-agent@turnstone.service.d/override.conf
+++ b/installer/systemd/hal0-agent@turnstone.service.d/override.conf
@@ -1,0 +1,36 @@
+# turnstone-specific overrides for the hal0-agent@ template.
+#
+# Anything under hal0-agent@<id>.service.d/ applies ONLY to that instance —
+# hal0-agent@hermes.service does NOT inherit these. Keeps the base template
+# generic while letting us pin turnstone-shaped env without touching it.
+
+[Unit]
+Documentation=https://github.com/turnstonelabs/turnstone
+
+[Service]
+# TURNSTONE_HOME is where turnstone reads its config, persona, and MCP list.
+# hal0's provisioner claims this dir with a `.hal0-managed` marker before any
+# write (see hal0.agents.turnstone_provision._phase_preflight / home_init).
+Environment="TURNSTONE_HOME=/var/lib/hal0/.turnstone"
+
+# TURNSTONE_CONFIG points turnstone at the hal0-rendered config.toml
+# (precedence: CLI --config > $TURNSTONE_CONFIG > ~/.config/turnstone). This is
+# the single source of truth the shim's serve invocation relies on.
+Environment="TURNSTONE_CONFIG=/var/lib/hal0/.turnstone/config.toml"
+
+# Inference endpoint hint — turnstone routes all models through the hal0-api
+# gateway's OpenAI-compatible /v1 surface. Mirrors the config's [api] base_url
+# so a manual invocation still finds the backend.
+Environment="HAL0_INFERENCE_BASE=http://127.0.0.1:8080"
+Environment="HAL0_API_URL=http://127.0.0.1:8080"
+
+# Outbound secrets — OPENAI_API_KEY (the hal0 bearer turnstone presents to the
+# gateway) + TURNSTONE_JWT_SECRET (server auth). Root:root 0600, written by the
+# provisioner's install_artifacts phase; leading `-` so a missing file isn't
+# fatal on first boot (dev/auth-disabled boxes have no token).
+EnvironmentFile=-/var/lib/hal0/secrets/agents/turnstone.env
+
+# Turnstone renders its config at provision time; render-context is a cheap
+# no-op for turnstone (the shim handles the type branch) but wiring it keeps
+# the ExecStartPre contract symmetric with hermes for a future live re-render.
+ExecStartPre=-/usr/local/bin/hal0-agent %i render-context

--- a/src/hal0/agents/manager.py
+++ b/src/hal0/agents/manager.py
@@ -85,9 +85,18 @@ HermesNotHal0AwareError = HermesUpstreamMissingError
 
 # ── Bundled catalog ──────────────────────────────────────────────────────────
 
-BUNDLED_AGENTS: tuple[str, ...] = ("pi-coder", "opencode", "hermes")
+BUNDLED_AGENTS: tuple[str, ...] = ("pi-coder", "opencode", "hermes", "turnstone")
 """Canonical names for bundled agents. Adding to this list requires a
 matching driver module + ``installer/agents/<name>.sh``."""
+
+# Agents that may coexist with any other bundled agent — they run their own
+# service/binary on distinct ports and don't contend for the single-pick
+# "primary" role (ADR-0004 §2 amendment). hermes hosts the dashboard brain
+# (:9119); turnstone is an independent orchestrator on loopback :9129.
+# Anything NOT in this set still participates in single-pick (one at a time).
+# Keeping the set explicit makes adding a coexisting agent a one-line,
+# reviewable change.
+COEXISTING_AGENTS: frozenset[str] = frozenset({"hermes", "turnstone"})
 
 
 # Marker file the Hermes provisioner stamps into ``$HERMES_HOME`` to
@@ -104,7 +113,7 @@ _HAL0_MANAGED_MARKER = ".hal0-managed"
 # registry must agree or status/list report a dead path and uninstall
 # rmtree's the wrong tree (#453). Value is the home subpath under
 # ``var_lib()``. Agents not listed here keep the per-name layout.
-_AGENT_HOME_SUBDIR: dict[str, str] = {"hermes": ".hermes"}
+_AGENT_HOME_SUBDIR: dict[str, str] = {"hermes": ".hermes", "turnstone": ".turnstone"}
 
 # Agents that install by shelling out to ``installer/agents/<name>.sh``
 # (see :func:`installer_script_path`). Hermes provisions through a
@@ -180,6 +189,10 @@ def _driver_for(name: str) -> AgentDriver:
         from hal0.agents.hermes import HermesDriver
 
         return HermesDriver()
+    if name == "turnstone":
+        from hal0.agents.turnstone import TurnstoneDriver
+
+        return TurnstoneDriver()
     raise AgentNotFoundError(
         f"unknown bundled agent {name!r}. Known: {', '.join(BUNDLED_AGENTS)}",
     )
@@ -282,12 +295,25 @@ class AgentManager:
             # Already installed — return the existing record. Idempotent.
             return self._read_record(name)
 
-        if not current:
+        # Single-pick, amended (ADR-0004 §2): a new agent only conflicts with
+        # an incumbent when the two can't coexist. hermes + turnstone each run
+        # their own service on a distinct loopback port and don't contend for
+        # the single "primary" role, so both may be installed at once. For
+        # every other pairing the historical one-at-a-time behaviour holds —
+        # ``blocking`` == ``current`` whenever ``name`` isn't coexisting.
+        blocking = [
+            existing
+            for existing in current
+            if not (name in COEXISTING_AGENTS and existing in COEXISTING_AGENTS)
+        ]
+
+        if not blocking:
+            # Fresh install OR a coexisting sibling join — nothing to swap.
             return self._install_and_seed(name, bearer_token=bearer_token)
 
         if not switch:
             raise AgentAlreadyInstalledError(
-                f"agent {current[0]!r} already installed; "
+                f"agent {blocking[0]!r} already installed; "
                 f"pass switch=True to atomically swap to {name!r}",
             )
 
@@ -298,11 +324,12 @@ class AgentManager:
         # a working agent for a swap that could never have succeeded.
         self._verify_installable(name)
 
-        # Atomic swap: tear down the existing one first. If the
+        # Atomic swap: tear down the blocking agent(s) first. If the
         # tear-down fails we surface the error and DO NOT proceed
         # — better to leave the old one installed than land in a
-        # half-state.
-        for existing in current:
+        # half-state. Coexisting siblings (not in ``blocking``) are
+        # untouched.
+        for existing in blocking:
             self.uninstall(existing)
 
         try:
@@ -310,11 +337,11 @@ class AgentManager:
         except Exception:
             # The precondition check can't catch every failure mode
             # (the script can exist and still fail once actually run).
-            # Best-effort restore the incumbent(s) so the operator
-            # isn't left with NO agent installed; rollback failures are
-            # swallowed — the original error is what the caller needs
-            # to see and act on.
-            for existing in current:
+            # Best-effort restore the torn-down incumbent(s) so the
+            # operator isn't left with NO agent installed; rollback
+            # failures are swallowed — the original error is what the
+            # caller needs to see and act on.
+            for existing in blocking:
                 with contextlib.suppress(Exception):
                     self._install_and_seed(existing, bearer_token=bearer_token)
             raise

--- a/src/hal0/agents/provision_engine.py
+++ b/src/hal0/agents/provision_engine.py
@@ -1,0 +1,445 @@
+"""Agent-agnostic provisioning state machine.
+
+Distilled from the Hermes bootstrap pipeline
+(:mod:`hal0.agents.hermes_provision`) so multiple heavyweight bundled
+agents (turnstone today; Hermes can migrate onto it in a follow-up)
+share one phase-orchestration contract instead of each copying it.
+
+A provisioner supplies three things:
+
+  * a concrete :class:`BootstrapState` subclass — agent-specific fields
+    (home dir, binary path, version pins) with defaults;
+  * an IO bundle (any object; conventionally a frozen dataclass of the
+    external seams its phases touch — HTTP, subprocess, slot/MCP
+    fetchers). The engine treats it opaquely and hands it to each phase
+    via ``ctx.io``;
+  * an ordered ``list[Phase]`` of ``(PhaseContext) -> PhaseResult``
+    bodies.
+
+The engine owns everything agent-independent: checkpointing to
+``provision.json``, skip-if-already-ok, ``--repair`` force-rerun,
+fatal-abort propagation, and import-time validation of the
+``needs`` / ``needs_previous`` cross-phase graph. It imports nothing
+hal0- or agent-specific, so it stays trivially unit-testable and safe
+to share.
+
+State file lives OUTSIDE the agent's own tree (e.g.
+``/var/lib/hal0/state/agents/<agent>/provision.json``) so an upstream
+``reset`` subcommand can't trample hal0's bookkeeping.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, ClassVar
+
+# Schema version embedded in every provision.json. Bump when the on-disk
+# shape changes in a way that can't be migrated by ignoring unknown keys.
+SCHEMA_VERSION = 1
+
+
+class PhaseStatus(StrEnum):
+    """Per-phase outcome stored in provision.json.
+
+    ``ok``       — phase completed; downstream phases may proceed.
+    ``skip``     — phase didn't run (irrelevant for this env); not an error.
+    ``fail``     — phase ran and failed; downstream may still run unless fatal.
+    ``repair_needed`` — checkpoint hash drifted from current inputs; ``--repair`` re-runs.
+
+    String-valued so JSON round-trips cleanly without a custom encoder.
+    """
+
+    OK = "ok"
+    SKIP = "skip"
+    FAIL = "fail"
+    REPAIR_NEEDED = "repair_needed"
+
+
+@dataclass
+class PhaseResult:
+    """Outcome of one phase invocation.
+
+    ``hash`` is the optional content hash a phase computes so future
+    re-runs can detect when their inputs changed — checkpoint presence
+    alone is insufficient.
+
+    ``details`` is a free-form dict each phase can stash. The
+    orchestrator never inspects its contents; it just JSON-serialises
+    them into the checkpoint.
+
+    A fatal ``FAIL`` aborts the run: the orchestrator stops executing
+    subsequent phases and records them as skipped (used by capture
+    guards — an unclaimed foreign home, a live foreign listener). A
+    normal ``FAIL`` stays run-all (fallbacks keep phases independent).
+    """
+
+    status: PhaseStatus
+    details: dict[str, Any] = field(default_factory=dict)
+    hash: str | None = None
+    reason: str | None = None
+    fatal: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"status": self.status.value}
+        if self.hash is not None:
+            out["hash"] = self.hash
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.fatal:
+            out["fatal"] = True
+        if self.details:
+            out["details"] = self.details
+        return out
+
+
+@dataclass
+class BootstrapState:
+    """In-memory mirror of ``provision.json`` — the generic base.
+
+    Subclass to add agent-specific fields (home dir, binary path,
+    version pin); the dataclass machinery + :func:`dataclasses.asdict`
+    means ``save`` / ``load`` round-trip the subclass fields with no
+    extra code. ``phases`` is keyed by phase name with values built from
+    :meth:`PhaseResult.to_dict` plus an ``at`` timestamp.
+
+    Override :attr:`STATE_FILE_NAME` only if an agent needs a
+    non-default checkpoint filename (none do today).
+    """
+
+    STATE_FILE_NAME: ClassVar[str] = "provision.json"
+
+    schema_version: int = SCHEMA_VERSION
+    started_at: str | None = None
+    completed_at: str | None = None
+    hal0_version: str | None = None
+    agent_id: str = ""
+    phases: dict[str, dict[str, Any]] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BootstrapState:
+        # Ignore unknown keys so a forward-compat schema bump doesn't
+        # crash an older orchestrator reading a newer file.
+        valid = set(cls.__dataclass_fields__)
+        kwargs = {k: v for k, v in data.items() if k in valid}
+        return cls(**kwargs)
+
+    def phase_done(self, name: str) -> bool:
+        """True iff the phase already ran to a terminal non-failure state.
+
+        Both ``ok`` and ``skip`` count as "done" — a phase that
+        legitimately skipped shouldn't re-run on every invocation.
+        ``--repair`` is the explicit force-rerun knob.
+        """
+        entry = self.phases.get(name)
+        if not entry:
+            return False
+        return entry.get("status") in {PhaseStatus.OK.value, PhaseStatus.SKIP.value}
+
+    def save(self, root: Path) -> None:
+        root.mkdir(parents=True, exist_ok=True)
+        target = root / self.STATE_FILE_NAME
+        tmp = target.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n")
+        os.replace(tmp, target)
+
+    @classmethod
+    def load(cls, root: Path) -> BootstrapState | None:
+        target = root / cls.STATE_FILE_NAME
+        if not target.exists():
+            return None
+        try:
+            data = json.loads(target.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        return cls.from_dict(data)
+
+
+# ── Phase pipeline plumbing ──────────────────────────────────────────────────
+
+
+class PhaseNeedError(RuntimeError):
+    """A phase read another phase's output without declaring the need."""
+
+
+@dataclass(frozen=True)
+class PhaseContext:
+    """Everything a phase body is allowed to see.
+
+    ``state`` is a read-only view by convention (phases return a
+    :class:`PhaseResult`; only the orchestrator writes checkpoints).
+    ``io`` is the provisioner's opaque IO bundle. ``output_of(name)``
+    returns the named phase's checkpoint ``details`` dict — empty when
+    the phase has no checkpoint yet — and raises :class:`PhaseNeedError`
+    unless ``name`` was declared in the calling phase's ``needs`` /
+    ``needs_previous``.
+    """
+
+    state: BootstrapState
+    repair: bool = False
+    io: Any = None
+    phase_name: str = "<anonymous>"
+    allowed_needs: frozenset[str] = frozenset()
+    # Capture mode: back up + import + claim a foreign home (and downgrade
+    # a foreign-listener abort to a warning) rather than refusing.
+    adopt: bool = False
+
+    def output_of(self, name: str) -> dict[str, Any]:
+        if name not in self.allowed_needs:
+            raise PhaseNeedError(
+                f"phase {self.phase_name!r} read output of {name!r} without "
+                f"declaring it (declared needs: {sorted(self.allowed_needs)})"
+            )
+        entry = self.state.phases.get(name) or {}
+        details = entry.get("details") or {}
+        return details if isinstance(details, dict) else {}
+
+
+@dataclass(frozen=True)
+class Phase:
+    """One entry in a provisioner's ordered phase list.
+
+    ``needs``          — same-run reads; the target MUST precede this
+                         phase in the list (validated at import).
+    ``needs_previous`` — previous-run checkpoint reads; the target MUST
+                         follow this phase in the list (if it preceded,
+                         it would be a plain same-run need).
+    ``always_run``     — run on every invocation even when the checkpoint
+                         is already ok (for phases that reconcile state
+                         drifting independently of checkpoints).
+    """
+
+    name: str
+    fn: Callable[[PhaseContext], PhaseResult]
+    needs: tuple[str, ...] = ()
+    needs_previous: tuple[str, ...] = ()
+    always_run: bool = False
+
+    @property
+    def allowed_needs(self) -> frozenset[str]:
+        return frozenset(self.needs) | frozenset(self.needs_previous)
+
+
+def validate_phase_graph(phases: list[Phase]) -> None:
+    """Fail fast (import time) when a phase list violates a declared need."""
+    index: dict[str, int] = {}
+    for i, phase in enumerate(phases):
+        if phase.name in index:
+            raise ValueError(f"PHASES: duplicate phase name {phase.name!r}")
+        index[phase.name] = i
+    for i, phase in enumerate(phases):
+        for need in phase.needs:
+            if need not in index:
+                raise ValueError(f"PHASES: {phase.name!r} needs unknown phase {need!r}")
+            if index[need] >= i:
+                raise ValueError(
+                    f"PHASES: {phase.name!r} needs {need!r} which does not precede it "
+                    f"(reader at {i}, target at {index[need]})"
+                )
+        for need in phase.needs_previous:
+            if need not in index:
+                raise ValueError(f"PHASES: {phase.name!r} needs_previous unknown phase {need!r}")
+            if index[need] < i:
+                raise ValueError(
+                    f"PHASES: {phase.name!r} declares needs_previous on {need!r}, "
+                    f"but {need!r} precedes it — declare it as a plain same-run need"
+                )
+
+
+def context_for(
+    phases: list[Phase],
+    phase_name: str,
+    state: BootstrapState,
+    *,
+    repair: bool = False,
+    adopt: bool = False,
+    io: Any = None,
+) -> PhaseContext:
+    """Build the :class:`PhaseContext` the orchestrator would hand ``phase_name``.
+
+    Looks the phase up in ``phases`` so the context carries the declared
+    needs — the canonical way for per-phase unit tests to call a phase
+    body directly without re-stating the needs graph.
+    """
+    phase = next((p for p in phases if p.name == phase_name), None)
+    if phase is None:
+        known = ", ".join(p.name for p in phases)
+        raise KeyError(f"unknown phase {phase_name!r} (known: {known})")
+    return PhaseContext(
+        state=state,
+        repair=repair,
+        adopt=adopt,
+        io=io,
+        phase_name=phase.name,
+        allowed_needs=phase.allowed_needs,
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def utcnow() -> str:
+    return datetime.datetime.now(tz=datetime.UTC).isoformat().replace("+00:00", "Z")
+
+
+def content_hash(*pieces: str | bytes) -> str:
+    """Stable content hash phases use to detect "inputs unchanged".
+
+    Phases that produce on-disk outputs hash the rendered content and
+    stash it in ``PhaseResult.hash``. A re-run computes the hash again;
+    mismatch → ``repair_needed``.
+    """
+    h = hashlib.sha256()
+    for piece in pieces:
+        if isinstance(piece, str):
+            piece = piece.encode("utf-8")
+        h.update(piece)
+    return h.hexdigest()
+
+
+# ── Orchestrator ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunResult:
+    """Aggregate result of one :func:`run` invocation.
+
+    ``phases`` mirrors ``BootstrapState.phases`` post-run for test-side
+    assertions; ``state`` is the persisted dataclass. ``aborted`` /
+    ``abort_reason`` are set when a phase returned a FATAL failure and
+    the run stopped early.
+    """
+
+    state: BootstrapState
+    phases: dict[str, dict[str, Any]]
+    skipped: list[str] = field(default_factory=list)
+    failed: list[str] = field(default_factory=list)
+    aborted: bool = False
+    abort_reason: str | None = None
+
+
+def run(
+    phases: list[Phase],
+    *,
+    state_root: Path,
+    io: Any = None,
+    state_cls: type[BootstrapState] = BootstrapState,
+    initial_state: BootstrapState | None = None,
+    repair: bool = False,
+    adopt: bool = False,
+    dry_run: bool = False,
+    skip_phases: tuple[str, ...] = (),
+    verbose: bool = False,
+) -> RunResult:
+    """Run every phase in ``phases`` in order, persisting checkpoints.
+
+    * ``state_root`` — directory holding ``provision.json``.
+    * ``io`` — the opaque IO bundle every phase receives via ``ctx.io``.
+    * ``state_cls`` — the concrete :class:`BootstrapState` subclass to
+      load/construct (agent-specific fields).
+    * ``initial_state`` — seed state when no checkpoint exists; tests
+      pass one with paths pointed at a ``tmp_path``.
+    * ``repair`` — re-run every phase regardless of checkpoint state.
+    * ``dry_run`` — execute each phase but don't persist the state file.
+    * ``skip_phases`` — skip the named phases (logged as ``skip``).
+
+    FAIL policy is run-all: a failing (non-fatal) phase never halts the
+    loop or skips dependents. ``completed_at`` is only stamped when no
+    phase failed.
+    """
+    state = state_cls.load(state_root) or initial_state or state_cls()
+    if state.started_at is None or repair:
+        state.started_at = utcnow()
+        state.completed_at = None
+
+    skipped: list[str] = []
+    failed: list[str] = []
+    aborted = False
+    abort_reason: str | None = None
+
+    for phase in phases:
+        name = phase.name
+
+        # A prior FATAL phase aborts the run: record every remaining phase
+        # as skipped (so provision.json shows why it stopped) and run nothing.
+        if aborted:
+            state.phases[name] = {
+                "status": PhaseStatus.SKIP.value,
+                "at": utcnow(),
+                "reason": f"aborted: {abort_reason or 'fatal failure'}",
+            }
+            skipped.append(name)
+            if verbose:
+                print(f"[skip] {name} (aborted)")
+            continue
+
+        if name in skip_phases:
+            state.phases[name] = {
+                "status": PhaseStatus.SKIP.value,
+                "at": utcnow(),
+                "reason": "--skip-phase",
+            }
+            skipped.append(name)
+            if verbose:
+                print(f"[skip] {name} (--skip-phase)")
+            continue
+
+        # always_run phases never phase_done-skip — their work reconciles
+        # state that drifts independently of checkpoints.
+        if not repair and not phase.always_run and state.phase_done(name):
+            if verbose:
+                print(f"[skip] {name} (already ok)")
+            skipped.append(name)
+            continue
+
+        if verbose:
+            print(f"[run ] {name}")
+
+        ctx = PhaseContext(
+            state=state,
+            repair=repair,
+            adopt=adopt,
+            io=io,
+            phase_name=name,
+            allowed_needs=phase.allowed_needs,
+        )
+        result = phase.fn(ctx)
+        entry = result.to_dict()
+        entry["at"] = utcnow()
+        state.phases[name] = entry
+
+        if result.status == PhaseStatus.FAIL:
+            failed.append(name)
+            state.errors.append(f"{name}: {result.reason or 'unspecified failure'}")
+            if result.fatal:
+                aborted = True
+                abort_reason = result.reason
+                if verbose:
+                    print(f"[abort] {name}: {result.reason}")
+
+    if not failed:
+        state.completed_at = utcnow()
+
+    if not dry_run:
+        state.save(state_root)
+
+    return RunResult(
+        state=state,
+        phases=dict(state.phases),
+        skipped=skipped,
+        failed=failed,
+        aborted=aborted,
+        abort_reason=abort_reason,
+    )

--- a/src/hal0/agents/turnstone/__init__.py
+++ b/src/hal0/agents/turnstone/__init__.py
@@ -1,0 +1,7 @@
+"""Turnstone bundled-agent driver package."""
+
+from __future__ import annotations
+
+from hal0.agents.turnstone.driver import TurnstoneDriver
+
+__all__ = ["TurnstoneDriver"]

--- a/src/hal0/agents/turnstone/driver.py
+++ b/src/hal0/agents/turnstone/driver.py
@@ -1,0 +1,191 @@
+"""Turnstone bundled-agent driver (ADR-0004 §6, sibling of hermes).
+
+Turnstone is a Go-based agent-orchestration platform installed as a
+native host binary. Like hermes, the heavy provisioning (binary pin +
+config.toml render + MCP/model/honcho wiring) is a multi-minute
+foreground job that can't run inside a single HTTP request, so it lives
+in the bootstrap pipeline :mod:`hal0.agents.turnstone_provision`, driven
+by ``hal0 agent install turnstone``.
+
+This driver is the THIN API/dashboard path:
+
+1. ``install()`` registers an already-provisioned agent by writing the
+   canonical driver env file (``/etc/hal0/agents/turnstone.env``) and
+   refuses if the managed binary isn't present yet (points the operator
+   at the CLI instead of half-wiring).
+2. ``status()`` is a cheap health check: systemctl → loopback :9129 →
+   env-file presence.
+3. ``uninstall()`` reads ``provision.json`` for the recorded binary +
+   removes the managed binary, shim, config, and SQLite DB — the
+   artifacts that live OUTSIDE the manager's seed+data+state triad.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess  # nosec B404 — required for shim
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from hal0.agents.manager import AgentDriver, AgentError
+from hal0.config import paths as _paths
+
+# Keep in sync with :mod:`hal0.agents.turnstone_provision`. Mirrored as plain
+# constants so the driver stays cheap and doesn't import the heavy provisioner
+# at driver-import time (same posture as the hermes driver).
+_MANAGED_BIN = Path("/var/lib/hal0/bin/turnstone")
+_CLI_SHIM = Path("/usr/local/bin/turnstone")
+_SERVER_HOST = "127.0.0.1"
+_SERVER_PORT = 9129
+_UNIT = "hal0-agent@turnstone.service"
+
+
+def _probe_provisioned() -> bool:
+    """True iff the managed turnstone binary (or its shim) is installed."""
+    return _MANAGED_BIN.exists() or _CLI_SHIM.exists()
+
+
+def _probe_systemd_unit_active(unit: str) -> bool:
+    """True iff ``systemctl is-active <unit>`` exits 0. Best-effort (2s cap)."""
+    if shutil.which("systemctl") is None:
+        return False
+    try:
+        result = subprocess.run(  # nosec B603 — fixed argv
+            ["systemctl", "is-active", unit],
+            check=False,
+            capture_output=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _probe_tcp_port(host: str, port: int, *, timeout: float = 1.0) -> bool:
+    """True iff a TCP connect to ``host:port`` succeeds within ``timeout``."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+class TurnstoneDriver(AgentDriver):
+    """Driver for the turnstone bundled agent."""
+
+    name = "turnstone"
+
+    def __init__(self, *, prober: Callable[[], bool] | None = None) -> None:
+        # ``prober`` lets tests force the pre-register gate without a real
+        # binary on disk (parallels HermesDriver).
+        self._prober: Callable[[], bool] = prober if prober is not None else _probe_provisioned
+
+    # ── AgentDriver protocol ────────────────────────────────────────────
+
+    def install(self, *, bearer_token: str | None = None) -> None:
+        # THIN path: register an already-provisioned turnstone by writing the
+        # driver env file. It does NOT provision — pinning the Go binary +
+        # rendering config is the foreground CLI's job.
+        if not self._prober():
+            raise AgentError(
+                "turnstone is not provisioned — the managed binary at "
+                f"{_MANAGED_BIN} does not exist. Run `hal0 agent install "
+                "turnstone` on the host: it pins the binary and renders the "
+                "config/model/MCP/memory wiring. (The hal0 daemon can't run "
+                "the multi-minute provisioning over HTTP, so the dashboard/API "
+                "install only registers an already-provisioned agent.)"
+            )
+        data_dir = self._data_dir()
+        data_dir.mkdir(parents=True, exist_ok=True)
+        self._write_env_file(bearer_token=bearer_token)
+
+    def uninstall(self) -> None:
+        # Order matters (mirrors HermesDriver): read provision.json BEFORE the
+        # manager strips the state dir, then remove the artifacts that live
+        # outside the manager's seed+data+state triad — the managed binary,
+        # shim, config home, and SQLite DB.
+        provision = self._load_provision()
+        for target in self._external_artifacts(provision):
+            with __import__("contextlib").suppress(OSError):
+                if target.is_dir() and not target.is_symlink():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink(missing_ok=True)
+
+        env_file = self._env_file_path()
+        if env_file.exists():
+            env_file.unlink()
+
+    def status(self) -> str:
+        """``"installed"`` when turnstone is running/reachable, else ``"broken"``.
+
+        Priority (cheapest first): systemctl unit active → loopback :9129
+        connect → env-file presence (installed but not started yet).
+        """
+        if _probe_systemd_unit_active(_UNIT):
+            return "installed"
+        if _probe_tcp_port(_SERVER_HOST, _SERVER_PORT, timeout=1.0):
+            return "installed"
+        if self._env_file_path().exists():
+            return "installed"
+        return "broken"
+
+    # ── Internals ───────────────────────────────────────────────────────
+
+    def _data_dir(self) -> Path:
+        return _paths.var_lib() / "agents" / self.name
+
+    def _env_file_path(self) -> Path:
+        # /etc so admins can tweak without disturbing /var/lib state — same
+        # posture as hermes.env. The shim sources this on every invocation.
+        return _paths.etc() / "agents" / f"{self.name}.env"
+
+    def _provision_state_path(self) -> Path:
+        return _paths.var_lib() / "state" / "agents" / self.name / "provision.json"
+
+    def _load_provision(self) -> dict[str, Any] | None:
+        """Best-effort load of the bootstrap checkpoint (None on any failure)."""
+        path = self._provision_state_path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _external_artifacts(self, provision: dict[str, Any] | None) -> list[Path]:
+        """The out-of-triad paths uninstall must remove.
+
+        Prefers the recorded ``binary_path`` / ``db_path`` / ``turnstone_home``
+        from provision.json (honours an operator override), falling back to the
+        module defaults so a missing/corrupt checkpoint still cleans the
+        canonical locations.
+        """
+        prov = provision or {}
+        bin_path = Path(prov.get("binary_path") or _MANAGED_BIN)
+        db_path = Path(
+            prov.get("db_path") or (_paths.var_lib() / "agents" / self.name / "turnstone.db")
+        )
+        home = Path(prov.get("turnstone_home") or (_paths.var_lib() / ".turnstone"))
+        return [_CLI_SHIM, bin_path, db_path, home]
+
+    def _write_env_file(self, *, bearer_token: str | None) -> None:
+        api_base = os.environ.get("HAL0_API_URL", "http://127.0.0.1:8080").rstrip("/")
+        lines = [
+            "# hal0 — turnstone driver env (managed by hal0; safe to edit)",
+            f"HAL0_API_URL={api_base}",
+            f"HAL0_MCP_ADMIN_URL={api_base}/mcp/admin",
+            f"HAL0_MCP_MEMORY_URL={api_base}/mcp/memory",
+        ]
+        if bearer_token:
+            lines.append(f"HAL0_BEARER_TOKEN={bearer_token}")
+        env_file = self._env_file_path()
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = env_file.with_suffix(".tmp")
+        tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        tmp.replace(env_file)

--- a/src/hal0/agents/turnstone/driver.py
+++ b/src/hal0/agents/turnstone/driver.py
@@ -1,11 +1,12 @@
 """Turnstone bundled-agent driver (ADR-0004 §6, sibling of hermes).
 
-Turnstone is a Go-based agent-orchestration platform installed as a
-native host binary. Like hermes, the heavy provisioning (binary pin +
-config.toml render + MCP/model/honcho wiring) is a multi-minute
-foreground job that can't run inside a single HTTP request, so it lives
-in the bootstrap pipeline :mod:`hal0.agents.turnstone_provision`, driven
-by ``hal0 agent install turnstone``.
+Turnstone is a PyPI package (console scripts ``turnstone`` +
+``turnstone-server``) installed into a managed venv, like hermes-agent.
+The heavy provisioning (venv + pip install + config.toml render +
+MCP/model/memory wiring) is a multi-minute foreground job that can't run
+inside a single HTTP request, so it lives in the bootstrap pipeline
+:mod:`hal0.agents.turnstone_provision`, driven by
+``hal0 agent install turnstone``.
 
 This driver is the THIN API/dashboard path:
 
@@ -36,8 +37,12 @@ from hal0.config import paths as _paths
 
 # Keep in sync with :mod:`hal0.agents.turnstone_provision`. Mirrored as plain
 # constants so the driver stays cheap and doesn't import the heavy provisioner
-# at driver-import time (same posture as the hermes driver).
-_MANAGED_BIN = Path("/var/lib/hal0/bin/turnstone")
+# at driver-import time (same posture as the hermes driver). Turnstone is a
+# PyPI package installed into a managed venv (like hermes-agent), NOT a Go
+# binary — the console scripts live under ``<venv>/bin``.
+_VENV = Path("/var/lib/hal0/venvs/turnstone")
+_MANAGED_BIN = _VENV / "bin" / "turnstone"
+_SERVER_BIN = _VENV / "bin" / "turnstone-server"
 _CLI_SHIM = Path("/usr/local/bin/turnstone")
 _SERVER_HOST = "127.0.0.1"
 _SERVER_PORT = 9129
@@ -45,8 +50,8 @@ _UNIT = "hal0-agent@turnstone.service"
 
 
 def _probe_provisioned() -> bool:
-    """True iff the managed turnstone binary (or its shim) is installed."""
-    return _MANAGED_BIN.exists() or _CLI_SHIM.exists()
+    """True iff turnstone is installed in the managed venv (or shimmed)."""
+    return _SERVER_BIN.exists() or _MANAGED_BIN.exists() or _CLI_SHIM.exists()
 
 
 def _probe_systemd_unit_active(unit: str) -> bool:
@@ -161,18 +166,19 @@ class TurnstoneDriver(AgentDriver):
     def _external_artifacts(self, provision: dict[str, Any] | None) -> list[Path]:
         """The out-of-triad paths uninstall must remove.
 
-        Prefers the recorded ``binary_path`` / ``db_path`` / ``turnstone_home``
-        from provision.json (honours an operator override), falling back to the
-        module defaults so a missing/corrupt checkpoint still cleans the
-        canonical locations.
+        The managed venv (~hundreds of MiB, like hermes's), the SQLite DB, the
+        turnstone home, and the two console-script shims. Prefers the recorded
+        ``db_path`` / ``turnstone_home`` from provision.json (honours an
+        operator override), falling back to the module defaults so a
+        missing/corrupt checkpoint still cleans the canonical locations.
         """
         prov = provision or {}
-        bin_path = Path(prov.get("binary_path") or _MANAGED_BIN)
         db_path = Path(
             prov.get("db_path") or (_paths.var_lib() / "agents" / self.name / "turnstone.db")
         )
         home = Path(prov.get("turnstone_home") or (_paths.var_lib() / ".turnstone"))
-        return [_CLI_SHIM, bin_path, db_path, home]
+        server_shim = _CLI_SHIM.with_name("turnstone-server")
+        return [_CLI_SHIM, server_shim, _VENV, db_path, home]
 
     def _write_env_file(self, *, bearer_token: str | None) -> None:
         api_base = os.environ.get("HAL0_API_URL", "http://127.0.0.1:8080").rstrip("/")

--- a/src/hal0/agents/turnstone_provision.py
+++ b/src/hal0/agents/turnstone_provision.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 import subprocess  # nosec B404 — needed to run the installer script + smoke exec
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -454,7 +455,11 @@ def _phase_env_probe(ctx: PhaseContext) -> PhaseResult:
             check=False,
             timeout=10,
         )  # nosec B603
-        version = (getattr(proc, "stdout", "") or getattr(proc, "stderr", "") or "").strip() or None
+        raw = (getattr(proc, "stdout", "") or getattr(proc, "stderr", "") or "").strip()
+        # The turnstone CLI has no `--version` flag — it prints its usage/help
+        # to stderr instead. Reject that so we record a real version or None,
+        # not a multi-line usage blob polluting the checkpoint + self_report.
+        version = raw.splitlines()[0] if raw and not raw.lower().startswith("usage") else None
     except Exception:
         version = None
     cast(TurnstoneState, ctx.state).turnstone_version = version
@@ -497,10 +502,15 @@ def _phase_install_artifacts(ctx: PhaseContext) -> PhaseResult:
     ]
     _atomic_write(DRIVER_ENV_PATH, "\n".join(env_lines) + "\n")
 
-    # Secrets vault — 0600. OPENAI_API_KEY is what turnstone's provider reads.
+    # Secrets vault — 0600. OPENAI_API_KEY is what turnstone's provider reads;
+    # TURNSTONE_JWT_SECRET is REQUIRED by turnstone-server to start (it refuses
+    # to boot without it). Generate a 32-byte hex secret once and reuse it on
+    # re-provision so tokens/sessions survive a --repair (idempotent).
+    jwt_secret = _existing_jwt_secret() or secrets.token_hex(32)
     secret_lines = [
         "# hal0 — turnstone secrets (root:root 0600; sourced by systemd)",
         f"OPENAI_API_KEY={bearer or _DEV_API_KEY}",
+        f"TURNSTONE_JWT_SECRET={jwt_secret}",
     ]
     if bearer:
         secret_lines.append(f"HAL0_BEARER_TOKEN={bearer}")
@@ -508,8 +518,23 @@ def _phase_install_artifacts(ctx: PhaseContext) -> PhaseResult:
 
     return PhaseResult(
         PhaseStatus.OK,
-        details={"seed": str(INSTALL_SEED_PATH), "env": str(DRIVER_ENV_PATH)},
+        details={"seed": str(INSTALL_SEED_PATH), "env": str(DRIVER_ENV_PATH), "jwt": "set"},
     )
+
+
+def _existing_jwt_secret() -> str | None:
+    """Return the TURNSTONE_JWT_SECRET already in the vault, if any.
+
+    Reused on re-provision so a --repair doesn't rotate the server's signing
+    key (which would invalidate live sessions).
+    """
+    if not SECRETS_ENV_PATH.exists():
+        return None
+    for line in SECRETS_ENV_PATH.read_text(encoding="utf-8").splitlines():
+        if line.startswith("TURNSTONE_JWT_SECRET="):
+            val = line.split("=", 1)[1].strip()
+            return val or None
+    return None
 
 
 def _phase_database_wire(ctx: PhaseContext) -> PhaseResult:

--- a/src/hal0/agents/turnstone_provision.py
+++ b/src/hal0/agents/turnstone_provision.py
@@ -1,26 +1,28 @@
 """Turnstone bundled-agent bootstrap pipeline.
 
-Turnstone (github.com/turnstonelabs/turnstone) is a self-hosted,
-Go-based agent-orchestration platform. It does NOT host models — it
-consumes an OpenAI-compatible backend (``[api] base_url``), mounts
-external tools over MCP, and has its own memory + LLM-judge layer. hal0
-already exposes exactly that surface: the hal0-api gateway at
+Turnstone (github.com/turnstonelabs/turnstone) is a self-hosted
+agent-orchestration platform distributed as a **Python package on PyPI**
+(console scripts ``turnstone`` + ``turnstone-server``). It does NOT host
+models — it consumes an OpenAI-compatible backend (``[api] base_url``),
+mounts external tools over MCP, and has its own memory + LLM-judge layer.
+hal0 already exposes exactly that surface: the hal0-api gateway at
 ``/v1`` plus the ``hal0-memory`` / ``hal0-admin`` MCP mounts and Honcho
 memory. This pipeline wires turnstone onto those seams.
 
 Modeled on :mod:`hal0.agents.hermes_provision` but built on the shared,
 agent-agnostic :mod:`hal0.agents.provision_engine` (checkpointing,
 skip-if-ok, ``--repair``, fatal-abort, needs-graph validation). The
-hal0-facing helpers (slot fetch, MCP probe/call) are reused by import
-from ``hermes_provision`` rather than duplicated.
+hal0-facing helpers (slot fetch, chat-slot classification, MCP
+probe/call) are reused by import from ``hermes_provision``.
 
-Deploy shape (this pass): the ``turnstone`` Go binary is installed on
-the host (``/var/lib/hal0/bin/turnstone`` + a ``/usr/local/bin/turnstone``
-shim) and run in server mode bound loopback on :9129 by
-``hal0-agent@turnstone.service`` — the :9129 choice mirrors hermes's
-:9119 convention and dodges the :8080 collision with hal0-api. Memory is
-SQLite (no Postgres coupling); the Postgres-backed multi-node server
-stack is a documented follow-up.
+Deploy shape (this pass): turnstone is ``pip install``-ed into a managed
+venv at ``/var/lib/hal0/venvs/turnstone`` (exactly like hermes-agent),
+with ``turnstone`` / ``turnstone-server`` shimmed onto PATH.
+``hal0-agent@turnstone.service`` runs ``turnstone-server`` bound loopback
+on :9129 — the :9129 choice mirrors hermes's :9119 convention and dodges
+the :8080 collision with hal0-api. Memory is SQLite (no Postgres
+coupling); the Postgres-backed multi-node server stack is a documented
+follow-up.
 
 State lives at ``/var/lib/hal0/state/agents/turnstone/provision.json`` —
 outside ``TURNSTONE_HOME`` so an upstream ``turnstone`` reset can't
@@ -46,15 +48,12 @@ from hal0.agents import provision_engine as engine
 from hal0.agents.hermes_provision import (
     HAL0_API_URL,
     MIN_FREE_GIB,
+    _collect_chat_slots,
     _fetch_model_contexts,
     _fetch_slots,
     _http_get,
-    _is_ready,
     _mcp_memory_call,
     _probe_mcp_server,
-    _slot_alias,
-    _slot_context_length,
-    _slot_kind,
     path_is_writable,
 )
 from hal0.agents.provision_engine import (
@@ -77,7 +76,13 @@ TURNSTONE_HOME = Path("/var/lib/hal0/.turnstone")
 TURNSTONE_CONFIG_PATH = TURNSTONE_HOME / "config.toml"
 MCP_SERVERS_JSON = TURNSTONE_HOME / "mcp-servers.json"
 PERSONA_PATH = TURNSTONE_HOME / "persona.txt"
-MANAGED_BIN = Path("/var/lib/hal0/bin/turnstone")
+# Turnstone is a PyPI package (console scripts `turnstone` + `turnstone-server`),
+# so hal0 installs it into a dedicated managed venv exactly like hermes-agent —
+# NOT as a standalone Go binary. MANAGED_BIN is the CLI entry point;
+# SERVER_BIN is what the systemd unit runs.
+VENV = Path("/var/lib/hal0/venvs/turnstone")
+MANAGED_BIN = VENV / "bin" / "turnstone"
+SERVER_BIN = VENV / "bin" / "turnstone-server"
 CLI_SHIM = Path("/usr/local/bin/turnstone")
 DATA_DIR = Path("/var/lib/hal0/agents/turnstone")
 SQLITE_DB = DATA_DIR / "turnstone.db"
@@ -98,8 +103,12 @@ MANAGED_MARKER = ".hal0-managed"
 SERVER_HOST = "127.0.0.1"
 SERVER_PORT = 9129
 
-# Honcho / hal0-memory identity for turnstone's own memory bank.
+# Honcho / hal0-memory identity for turnstone's own memory bank. NAMESPACE is
+# what turnstone's OWN config references; the hal0-memory REST shim groups
+# identity cards by ``dataset`` (the `agents` dataset, matching hermes) with a
+# required ``text`` field — NOT namespace/content.
 NAMESPACE = f"private:{AGENT_ID}"
+MEMORY_DATASET = "agents"
 # RESERVED — the future hal0-brain re-home identity. Documented so a later
 # pass can move the dashboard steward onto turnstone with a one-line swap;
 # NOT registered this pass (hal0-brain stays on hermes → hermes__hal0-brain).
@@ -189,32 +198,31 @@ def _model_blocks(
     *,
     api_base: str,
 ) -> dict[str, dict[str, Any]]:
-    """Build the ``[models.<alias>]`` table from live chat slots.
+    """Build the ``[models.<alias>]`` table from live CHAT slots.
 
-    Skips embed/rerank/image slots (they aren't chat backends). Each block
-    points at the hal0-api gateway virtual for that alias so turnstone routes
-    through the same stable ``/v1`` surface regardless of which physical slot
-    is loaded. Context window comes from the slot, then ``/v1/models``.
+    Delegates classification to hermes's :func:`_collect_chat_slots`, which
+    keeps only ``type=="llm"`` slots carrying a model_id — so embed / rerank /
+    tts / stt / image / vision slots (and the ``hal0`` gateway virtual) are
+    excluded, not mapped as chat models. Each block points at the hal0-api
+    gateway ``/v1`` so turnstone routes through the stable surface regardless
+    of which physical slot is loaded.
     """
     v1 = f"{api_base}/v1"
     blocks: dict[str, dict[str, Any]] = {}
-    for slot in slots:
-        kind = _slot_kind(slot)
-        if kind in {"embedding", "embed", "rerank", "reranker", "image", "img", "tts", "stt"}:
-            continue
-        alias = _slot_alias(slot)
-        ctx = _slot_context_length(slot) or contexts.get(alias) or contexts.get(f"hal0/{alias}")
+    for chat in _collect_chat_slots(slots, contexts):
+        alias = chat["alias"]
         block: dict[str, Any] = {
             "name": f"hal0/{alias}",
             "provider": "openai",
             "base_url": v1,
         }
+        ctx = chat.get("context_length")
         if ctx:
             block["context_window"] = int(ctx)
         block["capabilities"] = {"supports_vision": False, "supports_web_search": False}
         blocks[alias] = block
-    # Always guarantee the default anchor exists even if no slot is loaded yet,
-    # so config.toml is valid on a fresh box (model_automap re-applies later).
+    # Always guarantee the default anchor exists even if no chat slot is loaded
+    # yet, so config.toml is valid on a fresh box (model_automap re-applies).
     if _DEFAULT_MODEL_ALIAS not in blocks:
         blocks[_DEFAULT_MODEL_ALIAS] = {
             "name": f"hal0/{_DEFAULT_MODEL_ALIAS}",
@@ -406,7 +414,7 @@ def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
 
 
 def _phase_install(ctx: PhaseContext) -> PhaseResult:
-    """Run installer/agents/turnstone.sh to pin the Go binary + shim."""
+    """Run installer/agents/turnstone.sh to pip-install turnstone into the venv."""
     io: TurnstoneIO = ctx.io
     script = installer_script()
     if not script.is_file():
@@ -415,7 +423,7 @@ def _phase_install(ctx: PhaseContext) -> PhaseResult:
             reason=f"installer script missing at {script}",
         )
     env = os.environ.copy()
-    env["HAL0_TURNSTONE_BIN"] = str(MANAGED_BIN)
+    env["HAL0_TURNSTONE_VENV"] = str(VENV)
     env["HAL0_TURNSTONE_SHIM"] = str(CLI_SHIM)
     try:
         io.run(["bash", str(script)], env=env, check=True)  # nosec B603 B607
@@ -424,11 +432,12 @@ def _phase_install(ctx: PhaseContext) -> PhaseResult:
             PhaseStatus.FAIL,
             reason=f"turnstone install failed ({type(exc).__name__}: {exc})",
         )
-    installed = MANAGED_BIN.exists() or CLI_SHIM.exists()
+    # The server binary is what the unit runs; the CLI is what env_probe checks.
+    installed = SERVER_BIN.exists() or MANAGED_BIN.exists()
     return PhaseResult(
         PhaseStatus.OK if installed else PhaseStatus.FAIL,
-        details={"binary": str(MANAGED_BIN), "shim": str(CLI_SHIM)},
-        reason=None if installed else "installer ran but no binary landed",
+        details={"venv": str(VENV), "cli": str(MANAGED_BIN), "server": str(SERVER_BIN)},
+        reason=None if installed else "installer ran but no turnstone binary landed in the venv",
     )
 
 
@@ -628,7 +637,7 @@ def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
         f"turnstone is a hal0-managed tool-using agent. namespace={NAMESPACE}. "
         f"model backend={_api_base()}/v1. server={SERVER_HOST}:{SERVER_PORT}."
     )
-    result = _memory_call(io, "memory_add", {"content": card, "namespace": NAMESPACE})
+    result = _memory_call(io, "memory_add", {"text": card, "dataset": MEMORY_DATASET})
     ok = bool(result.get("ok"))
     return PhaseResult(
         PhaseStatus.OK,
@@ -645,8 +654,7 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
     io: TurnstoneIO = ctx.io
     slots = io.fetch_slots()
     contexts = io.fetch_model_contexts()
-    live = [s for s in slots if _is_ready(s)]
-    blocks = _model_blocks(live or slots, contexts, api_base=_api_base())
+    blocks = _model_blocks(slots, contexts, api_base=_api_base())
 
     # Merge into the existing config.toml (preserve operator keys).
     import tomllib
@@ -666,7 +674,7 @@ def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
     _atomic_write(TURNSTONE_CONFIG_PATH, _dumps_toml(cfg))
     return PhaseResult(
         PhaseStatus.OK,
-        details={"model_aliases": sorted(blocks.keys()), "live_slots": len(live)},
+        details={"model_aliases": sorted(blocks.keys()), "chat_slots": len(blocks)},
     )
 
 
@@ -693,7 +701,7 @@ def _phase_smoke_tests(ctx: PhaseContext) -> PhaseResult:
     checks["gateway_models_reachable"] = io.http_get(f"{_api_base()}/v1/models") == 200
 
     # memory MCP round-trip.
-    mem = _memory_call(io, "memory_search", {"query": "turnstone", "namespace": NAMESPACE})
+    mem = _memory_call(io, "memory_search", {"query": "turnstone", "dataset": MEMORY_DATASET})
     checks["memory_mcp_ok"] = bool(mem.get("ok"))
     if not mem.get("ok"):
         checks["memory_mcp_error"] = mem.get("error")
@@ -716,7 +724,7 @@ def _phase_self_report(ctx: PhaseContext) -> PhaseResult:
         f"turnstone bootstrap complete. version={cast(TurnstoneState, ctx.state).turnstone_version}. "
         f"model backend={_api_base()}/v1. smoke_failures={len(fails)}."
     )
-    _memory_call(io, "memory_add", {"content": summary, "namespace": NAMESPACE})
+    _memory_call(io, "memory_add", {"text": summary, "dataset": MEMORY_DATASET})
     return PhaseResult(PhaseStatus.OK, details={"summary": summary})
 
 

--- a/src/hal0/agents/turnstone_provision.py
+++ b/src/hal0/agents/turnstone_provision.py
@@ -1,0 +1,838 @@
+"""Turnstone bundled-agent bootstrap pipeline.
+
+Turnstone (github.com/turnstonelabs/turnstone) is a self-hosted,
+Go-based agent-orchestration platform. It does NOT host models — it
+consumes an OpenAI-compatible backend (``[api] base_url``), mounts
+external tools over MCP, and has its own memory + LLM-judge layer. hal0
+already exposes exactly that surface: the hal0-api gateway at
+``/v1`` plus the ``hal0-memory`` / ``hal0-admin`` MCP mounts and Honcho
+memory. This pipeline wires turnstone onto those seams.
+
+Modeled on :mod:`hal0.agents.hermes_provision` but built on the shared,
+agent-agnostic :mod:`hal0.agents.provision_engine` (checkpointing,
+skip-if-ok, ``--repair``, fatal-abort, needs-graph validation). The
+hal0-facing helpers (slot fetch, MCP probe/call) are reused by import
+from ``hermes_provision`` rather than duplicated.
+
+Deploy shape (this pass): the ``turnstone`` Go binary is installed on
+the host (``/var/lib/hal0/bin/turnstone`` + a ``/usr/local/bin/turnstone``
+shim) and run in server mode bound loopback on :9129 by
+``hal0-agent@turnstone.service`` — the :9129 choice mirrors hermes's
+:9119 convention and dodges the :8080 collision with hal0-api. Memory is
+SQLite (no Postgres coupling); the Postgres-backed multi-node server
+stack is a documented follow-up.
+
+State lives at ``/var/lib/hal0/state/agents/turnstone/provision.json`` —
+outside ``TURNSTONE_HOME`` so an upstream ``turnstone`` reset can't
+trample hal0's bookkeeping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404 — needed to run the installer script + smoke exec
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import structlog
+
+from hal0.agents import provision_engine as engine
+
+# Generic hal0-facing helpers — reused by import (not hermes-specific: they
+# hit the local hal0-api gateway + MCP mounts). Kept DRY rather than copied.
+from hal0.agents.hermes_provision import (
+    HAL0_API_URL,
+    MIN_FREE_GIB,
+    _fetch_model_contexts,
+    _fetch_slots,
+    _http_get,
+    _is_ready,
+    _mcp_memory_call,
+    _probe_mcp_server,
+    _slot_alias,
+    _slot_context_length,
+    _slot_kind,
+    path_is_writable,
+)
+from hal0.agents.provision_engine import (
+    BootstrapState,
+    Phase,
+    PhaseContext,
+    PhaseResult,
+    PhaseStatus,
+    RunResult,
+)
+
+log = structlog.get_logger(__name__)
+
+AGENT_ID = "turnstone"
+
+# ── Canonical on-disk layout ─────────────────────────────────────────────────
+# All module-level so tests can monkey-patch onto a tmp_path, same posture as
+# hermes_provision's constants.
+TURNSTONE_HOME = Path("/var/lib/hal0/.turnstone")
+TURNSTONE_CONFIG_PATH = TURNSTONE_HOME / "config.toml"
+MCP_SERVERS_JSON = TURNSTONE_HOME / "mcp-servers.json"
+PERSONA_PATH = TURNSTONE_HOME / "persona.txt"
+MANAGED_BIN = Path("/var/lib/hal0/bin/turnstone")
+CLI_SHIM = Path("/usr/local/bin/turnstone")
+DATA_DIR = Path("/var/lib/hal0/agents/turnstone")
+SQLITE_DB = DATA_DIR / "turnstone.db"
+STATE_ROOT = Path("/var/lib/hal0/state/agents/turnstone")
+
+# Install artifacts the manager + driver key off (mirror hermes #432).
+INSTALL_SEED_PATH = Path("/etc/hal0/agents/turnstone.toml")
+DRIVER_ENV_PATH = Path("/etc/hal0/agents/turnstone.env")
+# Outbound secrets vault — root:root 0600, referenced by the systemd
+# EnvironmentFile; NEVER written into the world-readable config.toml.
+SECRETS_ENV_PATH = Path("/var/lib/hal0/secrets/agents/turnstone.env")
+
+# hal0-managed marker stamped into TURNSTONE_HOME so uninstall/reprovision
+# won't trample a home hal0 doesn't own (mirror hermes _claim_hermes_home).
+MANAGED_MARKER = ".hal0-managed"
+
+# Loopback server bind. :9129 mirrors hermes :9119; avoids hal0-api :8080.
+SERVER_HOST = "127.0.0.1"
+SERVER_PORT = 9129
+
+# Honcho / hal0-memory identity for turnstone's own memory bank.
+NAMESPACE = f"private:{AGENT_ID}"
+# RESERVED — the future hal0-brain re-home identity. Documented so a later
+# pass can move the dashboard steward onto turnstone with a one-line swap;
+# NOT registered this pass (hal0-brain stays on hermes → hermes__hal0-brain).
+BRAIN_PROFILE_AGENT_ID_RESERVED = "turnstone__hal0-brain"
+
+# hal0-api MCP mounts (LAN-reachable surfaces, same ones hermes/opencode use).
+MEMORY_MCP_PATH = "/mcp/memory"
+ADMIN_MCP_PATH = "/mcp/admin"
+
+# Dev sentinel: hal0-api runs auth-disabled by default but turnstone still
+# treats the provider as key-requiring, so we always export something.
+_DEV_API_KEY = "hal0-local"
+
+# Default model anchor (ADR-0023 canonical). model_automap maps the live
+# chat slots onto turnstone model aliases; this is the guaranteed fallback.
+_DEFAULT_MODEL_ALIAS = "agent"
+
+
+def _api_base() -> str:
+    """Honour HAL0_API_URL the way the CLI does; default to the loopback bind."""
+    return os.environ.get("HAL0_API_URL", HAL0_API_URL).rstrip("/")
+
+
+def installer_script() -> Path:
+    """Absolute path to ``installer/agents/turnstone.sh`` (both layouts)."""
+    from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER
+
+    return REPO_ROOT_FOR_INSTALLER / "installer" / "agents" / "turnstone.sh"
+
+
+# ── State ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class TurnstoneState(BootstrapState):
+    """Turnstone's provision.json shape — the engine base + turnstone fields."""
+
+    agent_id: str = AGENT_ID
+    turnstone_version: str | None = None
+    turnstone_home: str = str(TURNSTONE_HOME)
+    binary_path: str = str(MANAGED_BIN)
+    db_path: str = str(SQLITE_DB)
+
+
+# ── IO seams ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TurnstoneIO:
+    """The external touchpoints a turnstone phase may use — the monkeypatch
+    tax, typed. Defaults bind the real (import-reused) implementations, so a
+    default-constructed ``TurnstoneIO`` IS production behaviour; tests pass
+    fakes instead of monkeypatching module globals."""
+
+    http_get: Callable[..., int] = _http_get
+    fetch_slots: Callable[[], list[dict[str, Any]]] = _fetch_slots
+    fetch_model_contexts: Callable[[], dict[str, int]] = _fetch_model_contexts
+    probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
+    mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
+    run: Callable[..., Any] = subprocess.run
+
+
+# ── Config builders (pure — unit-testable without IO) ────────────────────────
+
+
+def _persona_text() -> str:
+    """The turnstone ``[session] instructions`` system prompt.
+
+    Deliberately distinct from hal0-brain's steward persona (that stays on
+    hermes this pass). Turnstone is framed as a tool-using orchestrator that
+    routes to hal0's local models and honours hal0's approval posture.
+    """
+    return (
+        "You are the hal0 turnstone agent — a tool-using orchestrator running "
+        "on a self-hosted hal0 home. Your models are served locally by the "
+        "hal0-api gateway; never assume a cloud provider. Prefer the smallest "
+        "capable model for a task. You have hal0-memory and hal0-admin MCP "
+        "tools available; use memory to persist durable facts across sessions. "
+        "Tool calls are graded by a judge and may require operator approval — "
+        "explain your intent before acting on anything destructive."
+    )
+
+
+def _model_blocks(
+    slots: list[dict[str, Any]],
+    contexts: dict[str, int],
+    *,
+    api_base: str,
+) -> dict[str, dict[str, Any]]:
+    """Build the ``[models.<alias>]`` table from live chat slots.
+
+    Skips embed/rerank/image slots (they aren't chat backends). Each block
+    points at the hal0-api gateway virtual for that alias so turnstone routes
+    through the same stable ``/v1`` surface regardless of which physical slot
+    is loaded. Context window comes from the slot, then ``/v1/models``.
+    """
+    v1 = f"{api_base}/v1"
+    blocks: dict[str, dict[str, Any]] = {}
+    for slot in slots:
+        kind = _slot_kind(slot)
+        if kind in {"embedding", "embed", "rerank", "reranker", "image", "img", "tts", "stt"}:
+            continue
+        alias = _slot_alias(slot)
+        ctx = _slot_context_length(slot) or contexts.get(alias) or contexts.get(f"hal0/{alias}")
+        block: dict[str, Any] = {
+            "name": f"hal0/{alias}",
+            "provider": "openai",
+            "base_url": v1,
+        }
+        if ctx:
+            block["context_window"] = int(ctx)
+        block["capabilities"] = {"supports_vision": False, "supports_web_search": False}
+        blocks[alias] = block
+    # Always guarantee the default anchor exists even if no slot is loaded yet,
+    # so config.toml is valid on a fresh box (model_automap re-applies later).
+    if _DEFAULT_MODEL_ALIAS not in blocks:
+        blocks[_DEFAULT_MODEL_ALIAS] = {
+            "name": f"hal0/{_DEFAULT_MODEL_ALIAS}",
+            "provider": "openai",
+            "base_url": v1,
+            "capabilities": {"supports_vision": False, "supports_web_search": False},
+        }
+    return blocks
+
+
+def build_config(
+    *,
+    slots: list[dict[str, Any]],
+    contexts: dict[str, int],
+    persona: str,
+    api_base: str,
+    db_url: str,
+    mcp_config_path: str,
+) -> dict[str, Any]:
+    """Assemble the turnstone ``config.toml`` payload (a dict; the caller
+    serialises with tomli_w). Secrets (api_key / jwt_secret) are intentionally
+    absent — they flow via the OPENAI_API_KEY / TURNSTONE_JWT_SECRET env from
+    the 0600 secrets file, never into this world-readable config."""
+    v1 = f"{api_base}/v1"
+    return {
+        "api": {
+            # api_key omitted on purpose — sourced from OPENAI_API_KEY env.
+            "base_url": v1,
+        },
+        "model": {
+            "name": f"hal0/{_DEFAULT_MODEL_ALIAS}",
+            "reasoning_effort": "medium",
+        },
+        "models": _model_blocks(slots, contexts, api_base=api_base),
+        "session": {"instructions": persona},
+        # Approval posture: judge on, permissions required — matches hal0's
+        # MCP audit/approval-queue stance. Operators can relax per-box.
+        "tools": {"timeout": 120, "skip_permissions": False},
+        "judge": {
+            "enabled": True,
+            "smart_approvals": True,
+            "confidence_threshold": 0.95,
+        },
+        "memory": {"relevance_k": 5, "fetch_limit": 50, "nudges": True},
+        "mcp": {"config_path": mcp_config_path},
+        "database": {"url": db_url},
+        "server": {"max_workstreams": 50},
+    }
+
+
+def build_mcp_servers(*, api_base: str, bearer: str | None) -> dict[str, Any]:
+    """The ``mcp-servers.json`` turnstone loads via ``[mcp] config_path``.
+
+    Two remote HTTP/SSE mounts — the hindsight-backed ``hal0-memory`` (5
+    tools) and ``hal0-admin`` — each scoped by the ``X-hal0-Agent`` header
+    exactly like the opencode driver + hermes. deferred-load friendly.
+
+    NOTE: the precise JSON key shape turnstone expects is validated on-box by
+    the smoke phase (upstream docs don't pin the schema); this mirrors the
+    common ``mcpServers`` remote shape and is the single place to adjust.
+    """
+    headers: dict[str, str] = {"X-hal0-Agent": AGENT_ID}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    return {
+        "mcpServers": {
+            "hal0-memory": {
+                "type": "http",
+                "url": f"{api_base}{MEMORY_MCP_PATH}/mcp",
+                "headers": dict(headers),
+                "enabled": True,
+            },
+            "hal0-admin": {
+                "type": "http",
+                "url": f"{api_base}{ADMIN_MCP_PATH}/mcp",
+                "headers": dict(headers),
+                "enabled": True,
+            },
+        }
+    }
+
+
+# ── small IO utilities ───────────────────────────────────────────────────────
+
+
+def _atomic_write(path: Path, text: str, *, mode: int | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    if mode is not None:
+        os.chmod(tmp, mode)
+    tmp.replace(path)
+
+
+def _dumps_toml(payload: dict[str, Any]) -> str:
+    import tomli_w
+
+    return tomli_w.dumps(payload)
+
+
+def _bearer_token() -> str | None:
+    """Resolve the hal0 bearer for turnstone→hal0-api calls.
+
+    Prefers the driver env / process env; hal0 writes the token into
+    ``/etc/hal0/agents/turnstone.env`` on the API install path. Returns
+    ``None`` when auth is disabled (dev), in which case the placeholder
+    key is used.
+    """
+    return os.environ.get("HAL0_BEARER_TOKEN") or None
+
+
+def _disk_free_gib(path: Path) -> float:
+    import shutil as _sh
+
+    anchor = path
+    while not anchor.exists() and anchor.parent != anchor:
+        anchor = anchor.parent
+    try:
+        return _sh.disk_usage(anchor).free / (1024**3)
+    except OSError:
+        return float("inf")
+
+
+def _memory_call(io: TurnstoneIO, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Thin wrapper over the reused ``_mcp_memory_call`` (method/params shape).
+
+    That helper takes ``(method, params, *, agent_id, base_url)`` where
+    ``base_url`` is the hal0 ROOT (it maps the MCP envelope onto the
+    ``/api/memory/*`` REST shims), and returns ``{ok, result?, error?}`` — it
+    never raises. Centralised here so the phases call one clean surface.
+    """
+    return io.mcp_memory_call(
+        "tools/call",
+        {"name": tool, "arguments": arguments},
+        agent_id=AGENT_ID,
+        base_url=_api_base(),
+    )
+
+
+# ── Phases ───────────────────────────────────────────────────────────────────
+
+
+def _phase_preflight(ctx: PhaseContext) -> PhaseResult:
+    """hal0-api reachable, disk free, home writable, no foreign :9129 listener."""
+    io: TurnstoneIO = ctx.io
+    details: dict[str, Any] = {}
+    status = io.http_get(f"{_api_base()}/api/status")
+    details["hal0_api_status"] = status
+    if status == 0:
+        return PhaseResult(
+            PhaseStatus.FAIL,
+            reason="hal0-api not reachable at " + _api_base(),
+            details=details,
+        )
+
+    free = _disk_free_gib(TURNSTONE_HOME)
+    details["disk_free_gib"] = round(free, 1)
+    if free < MIN_FREE_GIB:
+        return PhaseResult(
+            PhaseStatus.FAIL,
+            reason=f"insufficient disk: {free:.1f} GiB < {MIN_FREE_GIB} GiB",
+            details=details,
+        )
+
+    if not path_is_writable(TURNSTONE_HOME):
+        return PhaseResult(
+            PhaseStatus.FAIL,
+            reason=f"{TURNSTONE_HOME} not writable by the installer user",
+            details=details,
+            fatal=True,
+        )
+
+    # Foreign-home guard: refuse a pre-existing home hal0 didn't stamp,
+    # unless --adopt. Mirrors hermes _claim_hermes_home.
+    marker = TURNSTONE_HOME / MANAGED_MARKER
+    if TURNSTONE_HOME.exists() and any(TURNSTONE_HOME.iterdir()) and not marker.exists():
+        if not ctx.adopt:
+            return PhaseResult(
+                PhaseStatus.FAIL,
+                reason=(
+                    f"{TURNSTONE_HOME} exists and is not hal0-managed "
+                    f"(no {MANAGED_MARKER}); re-run with --adopt to claim it"
+                ),
+                details=details,
+                fatal=True,
+            )
+        details["adopted_foreign_home"] = True
+    return PhaseResult(PhaseStatus.OK, details=details)
+
+
+def _phase_install(ctx: PhaseContext) -> PhaseResult:
+    """Run installer/agents/turnstone.sh to pin the Go binary + shim."""
+    io: TurnstoneIO = ctx.io
+    script = installer_script()
+    if not script.is_file():
+        return PhaseResult(
+            PhaseStatus.FAIL,
+            reason=f"installer script missing at {script}",
+        )
+    env = os.environ.copy()
+    env["HAL0_TURNSTONE_BIN"] = str(MANAGED_BIN)
+    env["HAL0_TURNSTONE_SHIM"] = str(CLI_SHIM)
+    try:
+        io.run(["bash", str(script)], env=env, check=True)  # nosec B603 B607
+    except Exception as exc:  # subprocess.CalledProcessError or others
+        return PhaseResult(
+            PhaseStatus.FAIL,
+            reason=f"turnstone install failed ({type(exc).__name__}: {exc})",
+        )
+    installed = MANAGED_BIN.exists() or CLI_SHIM.exists()
+    return PhaseResult(
+        PhaseStatus.OK if installed else PhaseStatus.FAIL,
+        details={"binary": str(MANAGED_BIN), "shim": str(CLI_SHIM)},
+        reason=None if installed else "installer ran but no binary landed",
+    )
+
+
+def _phase_env_probe(ctx: PhaseContext) -> PhaseResult:
+    """Record turnstone version + binary path into state."""
+    io: TurnstoneIO = ctx.io
+    version = None
+    bin_path = CLI_SHIM if CLI_SHIM.exists() else MANAGED_BIN
+    try:
+        proc = io.run(
+            [str(bin_path), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )  # nosec B603
+        version = (getattr(proc, "stdout", "") or getattr(proc, "stderr", "") or "").strip() or None
+    except Exception:
+        version = None
+    cast(TurnstoneState, ctx.state).turnstone_version = version
+    return PhaseResult(PhaseStatus.OK, details={"turnstone_version": version, "bin": str(bin_path)})
+
+
+def _phase_home_init(ctx: PhaseContext) -> PhaseResult:
+    """Create TURNSTONE_HOME + config dir + data dir; stamp the marker."""
+    TURNSTONE_HOME.mkdir(parents=True, exist_ok=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    (Path.home() / ".config" / "turnstone").mkdir(parents=True, exist_ok=True)
+    marker = TURNSTONE_HOME / MANAGED_MARKER
+    if not marker.exists():
+        marker.write_text("managed by hal0\n", encoding="utf-8")
+    return PhaseResult(PhaseStatus.OK, details={"home": str(TURNSTONE_HOME)})
+
+
+def _phase_install_artifacts(ctx: PhaseContext) -> PhaseResult:
+    """Write the manager seed TOML + driver env + secrets vault.
+
+    The seed doubles as the MCP allow-list; the driver env is what the
+    driver/shim source. Mirrors hermes _phase_install_artifacts (#432) so a
+    single ``agent install turnstone`` leaves the artifacts the manager keys
+    off (otherwise the agent reports ``broken``).
+    """
+    api_base = _api_base()
+    bearer = _bearer_token()
+
+    seed = {
+        "agent": {"name": AGENT_ID, "type": AGENT_ID},
+        "mcp": {"allow": ["hal0-memory", "hal0-admin"]},
+    }
+    _atomic_write(INSTALL_SEED_PATH, _dumps_toml(seed))
+
+    env_lines = [
+        "# hal0 — turnstone driver env (managed by hal0; safe to edit)",
+        f"HAL0_API_URL={api_base}",
+        f"TURNSTONE_CONFIG={TURNSTONE_CONFIG_PATH}",
+        f"TURNSTONE_HOME={TURNSTONE_HOME}",
+    ]
+    _atomic_write(DRIVER_ENV_PATH, "\n".join(env_lines) + "\n")
+
+    # Secrets vault — 0600. OPENAI_API_KEY is what turnstone's provider reads.
+    secret_lines = [
+        "# hal0 — turnstone secrets (root:root 0600; sourced by systemd)",
+        f"OPENAI_API_KEY={bearer or _DEV_API_KEY}",
+    ]
+    if bearer:
+        secret_lines.append(f"HAL0_BEARER_TOKEN={bearer}")
+    _atomic_write(SECRETS_ENV_PATH, "\n".join(secret_lines) + "\n", mode=0o600)
+
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={"seed": str(INSTALL_SEED_PATH), "env": str(DRIVER_ENV_PATH)},
+    )
+
+
+def _phase_database_wire(ctx: PhaseContext) -> PhaseResult:
+    """Record the SQLite DB path (Postgres is deferred to the server-service
+    follow-up). Ensures the parent dir exists so turnstone can create the DB.
+    """
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    db_url = str(SQLITE_DB)
+    cast(TurnstoneState, ctx.state).db_path = db_url
+    return PhaseResult(PhaseStatus.OK, details={"backend": "sqlite", "db_url": db_url})
+
+
+def _phase_persona_seed(ctx: PhaseContext) -> PhaseResult:
+    """Write the persona text so config_write's first render carries it."""
+    persona = _persona_text()
+    _atomic_write(PERSONA_PATH, persona + "\n")
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={"persona_path": str(PERSONA_PATH), "chars": len(persona)},
+        hash=engine.content_hash(persona),
+    )
+
+
+def _phase_config_write(ctx: PhaseContext) -> PhaseResult:
+    """Render config.toml: [api]→hal0-api /v1, [models.*]→live slots, persona,
+    judge/tools approval posture, [mcp] config_path, [database] sqlite.
+
+    Idempotent overlay with a rolling .bak. Reads mcp_wire's previous-run
+    probed-server checkpoint (needs_previous) so a re-render reflects the
+    validated MCP surface — same cross-run edge hermes uses.
+    """
+    io: TurnstoneIO = ctx.io
+    slots = io.fetch_slots()
+    contexts = io.fetch_model_contexts()
+    persona = _persona_text()
+    db_url = str(cast(TurnstoneState, ctx.state).db_path or SQLITE_DB)
+
+    payload = build_config(
+        slots=slots,
+        contexts=contexts,
+        persona=persona,
+        api_base=_api_base(),
+        db_url=db_url,
+        mcp_config_path=str(MCP_SERVERS_JSON),
+    )
+    rendered = _dumps_toml(payload)
+
+    if TURNSTONE_CONFIG_PATH.exists():
+        # Preserve the prior render as a rolling backup before overwrite.
+        with __import__("contextlib").suppress(OSError):
+            TURNSTONE_CONFIG_PATH.replace(TURNSTONE_CONFIG_PATH.with_suffix(".toml.bak"))
+    _atomic_write(TURNSTONE_CONFIG_PATH, rendered)
+
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={
+            "config_path": str(TURNSTONE_CONFIG_PATH),
+            "model_aliases": sorted(payload["models"].keys()),
+            "slots_seen": len(slots),
+        },
+        hash=engine.content_hash(rendered),
+    )
+
+
+def _phase_mcp_wire(ctx: PhaseContext) -> PhaseResult:
+    """Write mcp-servers.json + probe each mount; stash the probed surface
+    for config_write's next-run re-render."""
+    io: TurnstoneIO = ctx.io
+    api_base = _api_base()
+    bearer = _bearer_token()
+    servers = build_mcp_servers(api_base=api_base, bearer=bearer)
+    _atomic_write(MCP_SERVERS_JSON, json.dumps(servers, indent=2) + "\n")
+
+    probed: dict[str, Any] = {}
+    for name, path in (("hal0-memory", MEMORY_MCP_PATH), ("hal0-admin", ADMIN_MCP_PATH)):
+        result = io.probe_mcp_server(f"{api_base}{path}", agent_id=AGENT_ID)
+        probed[name] = {
+            "ok": bool(result.get("ok")),
+            "tools": len(result.get("tools") or []),
+            "error": result.get("error"),
+        }
+    any_ok = any(v["ok"] for v in probed.values())
+    return PhaseResult(
+        # Warn-as-OK: a down MCP mount shouldn't block bootstrap.
+        PhaseStatus.OK,
+        details={"path": str(MCP_SERVERS_JSON), "probed": probed, "any_ok": any_ok},
+    )
+
+
+def _phase_context_link(ctx: PhaseContext) -> PhaseResult:
+    """Render an operator-facing TURNSTONE.md into /etc/hal0 + link into home."""
+    doc = (
+        "# turnstone (hal0-managed)\n\n"
+        f"- binary: `{MANAGED_BIN}` (shim `{CLI_SHIM}`)\n"
+        f"- config: `{TURNSTONE_CONFIG_PATH}`\n"
+        f"- mcp servers: `{MCP_SERVERS_JSON}`\n"
+        f"- home: `{TURNSTONE_HOME}`\n"
+        f"- server: loopback {SERVER_HOST}:{SERVER_PORT}\n"
+        f"- model backend: hal0-api gateway `{_api_base()}/v1`\n"
+        f"- memory namespace: `{NAMESPACE}`\n\n"
+        "Managed by hal0's turnstone provisioner; edits under `[…]` in "
+        "config.toml are preserved on re-provision. Run "
+        "`hal0 agent reprovision turnstone` to re-render.\n"
+    )
+    out = Path("/etc/hal0/TURNSTONE.md")
+    _atomic_write(out, doc)
+    with __import__("contextlib").suppress(OSError):
+        link = TURNSTONE_HOME / "TURNSTONE.md"
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        link.symlink_to(out)
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={"rendered": {"TURNSTONE.md": {"path": str(out)}}},
+    )
+
+
+def _phase_namespace_register(ctx: PhaseContext) -> PhaseResult:
+    """Write turnstone's identity card into the hal0-memory ``agents`` dataset.
+
+    Warn-as-OK — a memory-layer hiccup never blocks bootstrap.
+    """
+    io: TurnstoneIO = ctx.io
+    card = (
+        f"turnstone is a hal0-managed tool-using agent. namespace={NAMESPACE}. "
+        f"model backend={_api_base()}/v1. server={SERVER_HOST}:{SERVER_PORT}."
+    )
+    result = _memory_call(io, "memory_add", {"content": card, "namespace": NAMESPACE})
+    ok = bool(result.get("ok"))
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={"registered": ok, "error": result.get("error")},
+    )
+
+
+def _phase_model_automap(ctx: PhaseContext) -> PhaseResult:
+    """Re-apply [model]/[models.*] from live slots into config.toml (idempotent).
+
+    config_write already lays a version; this re-renders after slots may have
+    changed so a post-bootstrap config still tracks the loaded set.
+    """
+    io: TurnstoneIO = ctx.io
+    slots = io.fetch_slots()
+    contexts = io.fetch_model_contexts()
+    live = [s for s in slots if _is_ready(s)]
+    blocks = _model_blocks(live or slots, contexts, api_base=_api_base())
+
+    # Merge into the existing config.toml (preserve operator keys).
+    import tomllib
+
+    if not TURNSTONE_CONFIG_PATH.exists():
+        return PhaseResult(
+            PhaseStatus.SKIP,
+            reason="config.toml absent — config_write must run first",
+        )
+    try:
+        cfg = tomllib.loads(TURNSTONE_CONFIG_PATH.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        return PhaseResult(PhaseStatus.FAIL, reason=f"config.toml unreadable: {exc}")
+    cfg["models"] = blocks
+    if _DEFAULT_MODEL_ALIAS in blocks:
+        cfg.setdefault("model", {})["name"] = blocks[_DEFAULT_MODEL_ALIAS]["name"]
+    _atomic_write(TURNSTONE_CONFIG_PATH, _dumps_toml(cfg))
+    return PhaseResult(
+        PhaseStatus.OK,
+        details={"model_aliases": sorted(blocks.keys()), "live_slots": len(live)},
+    )
+
+
+def _phase_smoke_tests(ctx: PhaseContext) -> PhaseResult:
+    """Cheap end-to-end probes. Individual failures are recorded, not fatal."""
+    io: TurnstoneIO = ctx.io
+    checks: dict[str, Any] = {}
+
+    bin_path = CLI_SHIM if CLI_SHIM.exists() else MANAGED_BIN
+    checks["binary_present"] = bin_path.exists()
+
+    # config.toml parses + points at the gateway.
+    try:
+        import tomllib
+
+        cfg = tomllib.loads(TURNSTONE_CONFIG_PATH.read_text(encoding="utf-8"))
+        checks["config_parses"] = True
+        checks["config_base_url_ok"] = "/v1" in (cfg.get("api", {}).get("base_url", ""))
+    except Exception as exc:
+        checks["config_parses"] = False
+        checks["config_error"] = f"{type(exc).__name__}: {exc}"
+
+    # hal0-api /v1/models reachable (turnstone's backend).
+    checks["gateway_models_reachable"] = io.http_get(f"{_api_base()}/v1/models") == 200
+
+    # memory MCP round-trip.
+    mem = _memory_call(io, "memory_search", {"query": "turnstone", "namespace": NAMESPACE})
+    checks["memory_mcp_ok"] = bool(mem.get("ok"))
+    if not mem.get("ok"):
+        checks["memory_mcp_error"] = mem.get("error")
+
+    failures = [k for k, v in checks.items() if k.endswith("_ok") and v is False]
+    failures += [k for k in ("binary_present", "config_parses") if checks.get(k) is False]
+    return PhaseResult(
+        PhaseStatus.OK if not failures else PhaseStatus.FAIL,
+        details={"checks": checks, "failures": failures},
+        reason=None if not failures else f"smoke failures: {', '.join(failures)}",
+    )
+
+
+def _phase_self_report(ctx: PhaseContext) -> PhaseResult:
+    """Persist a bootstrap-completion summary into turnstone's memory bank."""
+    io: TurnstoneIO = ctx.io
+    smoke = ctx.output_of("smoke_tests")
+    fails = smoke.get("failures") or []
+    summary = (
+        f"turnstone bootstrap complete. version={cast(TurnstoneState, ctx.state).turnstone_version}. "
+        f"model backend={_api_base()}/v1. smoke_failures={len(fails)}."
+    )
+    _memory_call(io, "memory_add", {"content": summary, "namespace": NAMESPACE})
+    return PhaseResult(PhaseStatus.OK, details={"summary": summary})
+
+
+def _phase_ownership_reconcile(ctx: PhaseContext) -> PhaseResult:
+    """Re-chown the home + data + state trees to the hal0 user after
+    root-owned writes. Best-effort; always_run so a plain re-run reconciles."""
+    import pwd
+
+    try:
+        ent = pwd.getpwnam("hal0")
+        uid, gid = ent.pw_uid, ent.pw_gid
+    except KeyError:
+        return PhaseResult(PhaseStatus.SKIP, reason="hal0 user absent (dev box)")
+    changed = 0
+    for root in (TURNSTONE_HOME, DATA_DIR, STATE_ROOT):
+        if not root.exists():
+            continue
+        for p in [root, *root.rglob("*")]:
+            with __import__("contextlib").suppress(OSError):
+                os.chown(p, uid, gid)
+                changed += 1
+    return PhaseResult(PhaseStatus.OK, details={"chowned": changed})
+
+
+# ── Pipeline ─────────────────────────────────────────────────────────────────
+
+PHASES: list[Phase] = [
+    Phase("preflight", _phase_preflight),
+    Phase("install", _phase_install),
+    Phase("env_probe", _phase_env_probe),
+    Phase("home_init", _phase_home_init),
+    Phase("install_artifacts", _phase_install_artifacts),
+    Phase("database_wire", _phase_database_wire),
+    Phase("persona_seed", _phase_persona_seed),
+    # config_write reads mcp_wire's PREVIOUS-run probed surface (cross-run edge).
+    Phase("config_write", _phase_config_write, needs_previous=("mcp_wire",)),
+    Phase("mcp_wire", _phase_mcp_wire),
+    Phase("context_link", _phase_context_link),
+    Phase("namespace_register", _phase_namespace_register),
+    Phase("model_automap", _phase_model_automap),
+    Phase("ownership_reconcile", _phase_ownership_reconcile, always_run=True),
+    Phase("smoke_tests", _phase_smoke_tests),
+    Phase("self_report", _phase_self_report, needs=("smoke_tests",)),
+]
+
+engine.validate_phase_graph(PHASES)
+PHASE_NAMES: tuple[str, ...] = tuple(p.name for p in PHASES)
+
+
+def context_for(
+    phase_name: str,
+    state: TurnstoneState,
+    *,
+    repair: bool = False,
+    adopt: bool = False,
+    io: TurnstoneIO | None = None,
+) -> PhaseContext:
+    """Per-phase test hook — build the context the orchestrator would."""
+    return engine.context_for(
+        PHASES,
+        phase_name,
+        state,
+        repair=repair,
+        adopt=adopt,
+        io=io if io is not None else TurnstoneIO(),
+    )
+
+
+def run(
+    *,
+    repair: bool = False,
+    adopt: bool = False,
+    dry_run: bool = False,
+    skip_phases: tuple[str, ...] = (),
+    state_root: Path | None = None,
+    verbose: bool = False,
+    initial_state: TurnstoneState | None = None,
+    io: TurnstoneIO | None = None,
+) -> RunResult:
+    """Run the turnstone pipeline. Thin wrapper over the shared engine."""
+    return engine.run(
+        PHASES,
+        state_root=state_root if state_root is not None else STATE_ROOT,
+        io=io if io is not None else TurnstoneIO(),
+        state_cls=TurnstoneState,
+        initial_state=initial_state,
+        repair=repair,
+        adopt=adopt,
+        dry_run=dry_run,
+        skip_phases=skip_phases,
+        verbose=verbose,
+    )
+
+
+def bootstrap_cli(
+    *,
+    repair: bool = False,
+    adopt: bool = False,
+    dry_run: bool = False,
+    skip_phases: tuple[str, ...] = (),
+    verbose: bool = False,
+    state_root: Path | None = None,
+) -> int:
+    """CLI entry point. Returns a POSIX exit code (0 = success, 1 = any fail)."""
+    result = run(
+        repair=repair,
+        adopt=adopt,
+        dry_run=dry_run,
+        skip_phases=skip_phases,
+        verbose=verbose,
+        state_root=state_root,
+    )
+    if verbose:
+        target = (state_root or STATE_ROOT) / TurnstoneState.STATE_FILE_NAME
+        print(f"state: {target}")
+    if result.aborted:
+        print(f"bootstrap aborted: {result.abort_reason or 'fatal failure'}")
+        return 1
+    return 1 if result.failed else 0

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -232,7 +232,7 @@ def _install_hermes(*, switch: bool, gateway: bool = True, adopt: bool = False) 
 # ── Turnstone foreground install ─────────────────────────────────────────────
 
 _TURNSTONE_AGENT_TREES = (
-    "/var/lib/hal0/bin",
+    "/var/lib/hal0/venvs/turnstone",
     "/var/lib/hal0/.turnstone",
     "/var/lib/hal0/agents/turnstone",
     "/var/lib/hal0/state/agents/turnstone",

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -56,7 +56,9 @@ app.add_typer(personas_app, name="personas")
 
 @app.command("install")
 def agent_install(
-    name: str = typer.Argument(..., help="Bundled agent name (pi-coder | opencode | hermes)."),
+    name: str = typer.Argument(
+        ..., help="Bundled agent name (pi-coder | opencode | hermes | turnstone)."
+    ),
     switch: bool = typer.Option(
         False,
         "--switch",
@@ -101,6 +103,10 @@ def agent_install(
     """
     if name == "hermes":
         _install_hermes(switch=switch, gateway=gateway, adopt=adopt)
+        return
+
+    if name == "turnstone":
+        _install_turnstone(switch=switch, adopt=adopt)
         return
 
     url = _api_base()
@@ -221,6 +227,160 @@ def _install_hermes(*, switch: bool, gateway: bool = True, adopt: bool = False) 
             border_style="green",
         )
     )
+
+
+# ── Turnstone foreground install ─────────────────────────────────────────────
+
+_TURNSTONE_AGENT_TREES = (
+    "/var/lib/hal0/bin",
+    "/var/lib/hal0/.turnstone",
+    "/var/lib/hal0/agents/turnstone",
+    "/var/lib/hal0/state/agents/turnstone",
+)
+
+
+def _install_turnstone(*, switch: bool, adopt: bool = False) -> None:
+    """Foreground provision of turnstone (native Go binary + config wiring).
+
+    Mirrors :func:`_install_hermes`: turnstone pins its Go binary and renders
+    config.toml + MCP/model/memory wiring — multi-second work that can't run
+    inside a single HTTP request, so it runs locally in the foreground and only
+    consults the daemon at the end to honour ``--switch``. Turnstone COEXISTS
+    with hermes (ADR-0004 §2 amendment), so single-pick only clears incumbents
+    that can't coexist with it.
+    """
+    from hal0.agents.turnstone_provision import bootstrap_cli
+
+    _enforce_turnstone_single_pick(switch=switch)
+    _ensure_writable_or_die(_TURNSTONE_AGENT_TREES, agent="turnstone")
+
+    console.print("[bold]Provisioning turnstone[/bold] → /var/lib/hal0/.turnstone …")
+    rc = bootstrap_cli(repair=False, adopt=adopt, dry_run=False, skip_phases=(), verbose=False)
+    if rc != 0:
+        die(
+            "turnstone provisioning failed — inspect `hal0 agent status turnstone` "
+            "/ `hal0 agent log turnstone`."
+        )
+        return
+
+    _chown_trees_to_agent_user(_TURNSTONE_AGENT_TREES)
+
+    # Register + honour --switch via the daemon (binary now present → gate passes).
+    url = _api_base()
+    if not _api_unreachable(url):
+        try:
+            api_post("/api/agents/install", json={"name": "turnstone", "switch": switch})
+        except CliApiError as exc:
+            console.print(f"[yellow]Provisioned, but daemon register/switch hint:[/yellow] {exc}")
+
+    _enable_and_start_unit("turnstone")
+
+    console.print(
+        Panel(
+            "[bold green]Installed[/bold green] turnstone  "
+            "[dim](native binary: /var/lib/hal0/bin/turnstone, server :9129)[/dim]",
+            border_style="green",
+        )
+    )
+
+
+def _enforce_turnstone_single_pick(*, switch: bool) -> None:
+    """Clear any incumbent that can't coexist with turnstone before provisioning.
+
+    Turnstone + hermes coexist (:data:`hal0.agents.manager.COEXISTING_AGENTS`);
+    pi-coder/opencode do not, so an incumbent coder still blocks (or, with
+    ``--switch``, is uninstalled). Mirrors :func:`_enforce_hermes_single_pick`.
+    """
+    from hal0.agents.manager import COEXISTING_AGENTS
+
+    mgr = _bundled_agent_manager()
+    blocking = [
+        n
+        for n in mgr.installed_names()
+        if n != "turnstone" and not ("turnstone" in COEXISTING_AGENTS and n in COEXISTING_AGENTS)
+    ]
+    if not blocking:
+        return
+    if not switch:
+        die(
+            f"agent {blocking[0]!r} already installed; pass --switch to "
+            "atomically swap to 'turnstone' (single-pick enforced)."
+        )
+        return
+    console.print(
+        f"[bold]--switch[/bold]: uninstalling {', '.join(blocking)} before provisioning turnstone…"
+    )
+    for existing in blocking:
+        mgr.uninstall(existing)
+
+
+# ── Generic provisioning helpers (agent-agnostic; used by turnstone) ─────────
+
+
+def _ensure_writable_or_die(trees: tuple[str, ...], *, agent: str) -> None:
+    """Abort with a sudo hint when provisioning can't write its trees.
+
+    Agent-agnostic sibling of :func:`_ensure_hermes_writable_or_die`. No-op
+    when root (root writes anywhere; the post-provision chown hands the trees
+    to ``hal0``) or when the current user already owns the trees.
+    """
+    import os as _os
+
+    from hal0.agents.hermes_provision import path_is_writable
+
+    if _os.geteuid() == 0:
+        return
+    blocked = [t for t in trees if not path_is_writable(t)]
+    if not blocked:
+        return
+    die(
+        f"{agent} provisioning needs write access to "
+        + ", ".join(blocked)
+        + f", but you're running as uid={_os.getuid()} and those live under "
+        "root-owned /var/lib/hal0.\n\n"
+        f"Re-run as root:\n    sudo hal0 agent install {agent}\n\n"
+        f"(Provisioning runs as root, then hands the trees to the "
+        f"'{_AGENT_RUNTIME_USER}' agent user automatically.)"
+    )
+
+
+def _chown_trees_to_agent_user(trees: tuple[str, ...]) -> None:
+    """Recursively chown ``trees`` to the agent runtime user (root-only, best-effort)."""
+    import os as _os
+    import pwd as _pwd
+    import subprocess as _subprocess
+    from pathlib import Path as _Path
+
+    if _os.geteuid() != 0:
+        return
+    try:
+        _pwd.getpwnam(_AGENT_RUNTIME_USER)
+    except KeyError:
+        return
+    for tree in trees:
+        if _Path(tree).exists():
+            _subprocess.run(  # nosec B603 B607 — fixed argv, known paths
+                ["chown", "-R", f"{_AGENT_RUNTIME_USER}:{_AGENT_RUNTIME_USER}", tree],
+                check=False,
+            )
+
+
+def _enable_and_start_unit(agent: str) -> None:
+    """``systemctl enable --now hal0-agent@<agent>`` (no-op sans systemd)."""
+    import shutil as _shutil
+    import subprocess as _subprocess
+
+    if _shutil.which("systemctl") is None:
+        return
+    unit = f"hal0-agent@{agent}"
+    rc = _subprocess.run(  # nosec B603 B607 — fixed argv
+        ["systemctl", "enable", "--now", unit], check=False
+    ).returncode
+    if rc != 0:
+        console.print(
+            f"[yellow]{agent} provisioned, but the agent unit didn't start cleanly — "
+            f"check `systemctl status {unit}` / `hal0 agent log {agent}`.[/yellow]"
+        )
 
 
 def _bundled_agent_manager() -> Any:
@@ -1044,6 +1204,51 @@ def bootstrap_hermes(
 
     if offline:
         _os.environ["HAL0_HERMES_OFFLINE"] = "1"
+    rc = bootstrap_cli(
+        repair=repair,
+        adopt=adopt,
+        dry_run=dry_run,
+        skip_phases=tuple(skip_phase),
+        verbose=verbose,
+    )
+    raise typer.Exit(rc)
+
+
+@bootstrap_app.command(
+    "turnstone",
+    epilog=(
+        "Renders turnstone's config.toml ([api]→hal0-api /v1, [models.*]→live "
+        "slots), mcp-servers.json (hal0-memory + hal0-admin), persona, and a "
+        "SQLite DB. A populated $TURNSTONE_HOME hal0 didn't create aborts the "
+        "run; pass --adopt to claim it."
+    ),
+)
+def bootstrap_turnstone(
+    repair: bool = typer.Option(
+        False,
+        "--repair",
+        help="Re-run every phase regardless of checkpoint state (forces full rerun).",
+    ),
+    adopt: bool = typer.Option(
+        False,
+        "--adopt",
+        help="Capture an existing (foreign) $TURNSTONE_HOME rather than aborting.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Run phases but don't persist provision.json.",
+    ),
+    skip_phase: list[str] = typer.Option(
+        [],
+        "--skip-phase",
+        help="Skip the named phase (may be repeated).",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose phase log."),
+) -> None:
+    """Run the turnstone bootstrap state machine."""
+    from hal0.agents.turnstone_provision import bootstrap_cli
+
     rc = bootstrap_cli(
         repair=repair,
         adopt=adopt,

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -278,7 +278,7 @@ def _install_turnstone(*, switch: bool, adopt: bool = False) -> None:
     console.print(
         Panel(
             "[bold green]Installed[/bold green] turnstone  "
-            "[dim](native binary: /var/lib/hal0/bin/turnstone, server :9129)[/dim]",
+            "[dim](managed venv: /var/lib/hal0/venvs/turnstone, server :9129)[/dim]",
             border_style="green",
         )
     )

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -81,15 +81,16 @@ _BUILTIN_AGENT_TYPES: dict[str, str] = {
 # its server on 9129 (mirrors the convention; dodges hal0-api's :8080).
 _DEFAULT_PORTS: dict[str, int] = {"hermes": 9119, "turnstone": 9129}
 
-# Canonical turnstone server binary search path — the native install lays
-# the binary under /var/lib/hal0/bin with a /usr/local/bin shim.
+# Canonical turnstone-server search path. Turnstone is a PyPI package installed
+# into a managed venv (like hermes-agent), so the console script lives at
+# <venv>/bin/turnstone-server; the /usr/local/bin entry is hal0's shim.
 _TURNSTONE_SERVER_BINS: tuple[Path, ...] = (
+    Path("/var/lib/hal0/venvs/turnstone/bin/turnstone-server"),
     Path("/usr/local/bin/turnstone-server"),
-    Path("/var/lib/hal0/bin/turnstone-server"),
-    # Fall back to the plain CLI in server mode if the server binary wasn't
-    # shipped separately (some builds fold it into one multi-call binary).
+    # Fall back to the plain CLI in server mode if the server entry point is
+    # ever folded into the single `turnstone` console script.
+    Path("/var/lib/hal0/venvs/turnstone/bin/turnstone"),
     Path("/usr/local/bin/turnstone"),
-    Path("/var/lib/hal0/bin/turnstone"),
 )
 
 

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -58,20 +58,39 @@ from typing import Any
 # Per-agent TOML — overrides the builtin fallback. Optional.
 # Schema (all keys optional except ``type``):
 #
-#     type   = "hermes"                    # required; selects invocation
-#     home   = "/var/lib/hal0/agents/<id>" # default: derived from id
-#     venv   = "/var/lib/hal0/venvs/<id>"  # default: derived from id
-#     port   = 9119                        # default: hermes upstream's 9119
-#     host   = "127.0.0.1"                 # default: loopback only
+#     type       = "hermes"                    # required; selects invocation
+#     home       = "/var/lib/hal0/agents/<id>" # default: derived from id
+#     venv       = "/var/lib/hal0/venvs/<id>"  # default: derived from id (hermes)
+#     bin        = "/usr/local/bin/turnstone-server"  # default: per-type
+#     port       = 9119                        # default: per-type (hermes 9119, turnstone 9129)
+#     host       = "127.0.0.1"                 # default: loopback only
+#     serve_args = ["--port", "9129", ...]     # turnstone: exact server flags,
+#                                              #   overridable without a code change
 _AGENTS_CONF_DIR = Path(os.environ.get("HAL0_AGENTS_CONF_DIR", "/etc/hal0/agents"))
 
 # Builtin fallback for known agent ids — keyed off the id, NOT the type.
-# Lets ``hal0-agent@hermes.service`` work even before ``/etc/hal0/agents/
-# hermes.toml`` is dropped (first-boot ordering: bootstrap installs the
-# unit + enables it, then ``hermes_provision`` may write the toml).
+# Lets ``hal0-agent@<id>.service`` work even before ``/etc/hal0/agents/
+# <id>.toml`` is dropped (first-boot ordering: bootstrap installs the
+# unit + enables it, then the provisioner may write the toml).
 _BUILTIN_AGENT_TYPES: dict[str, str] = {
     "hermes": "hermes",
+    "turnstone": "turnstone",
 }
+
+# Per-type default loopback port. hermes → upstream's 9119; turnstone runs
+# its server on 9129 (mirrors the convention; dodges hal0-api's :8080).
+_DEFAULT_PORTS: dict[str, int] = {"hermes": 9119, "turnstone": 9129}
+
+# Canonical turnstone server binary search path — the native install lays
+# the binary under /var/lib/hal0/bin with a /usr/local/bin shim.
+_TURNSTONE_SERVER_BINS: tuple[Path, ...] = (
+    Path("/usr/local/bin/turnstone-server"),
+    Path("/var/lib/hal0/bin/turnstone-server"),
+    # Fall back to the plain CLI in server mode if the server binary wasn't
+    # shipped separately (some builds fold it into one multi-call binary).
+    Path("/usr/local/bin/turnstone"),
+    Path("/var/lib/hal0/bin/turnstone"),
+)
 
 
 @dataclass(frozen=True)
@@ -84,12 +103,37 @@ class AgentConfig:
     venv: Path
     host: str
     port: int
+    # Explicit binary override from the agent toml (turnstone). ``None`` →
+    # resolve per-type via :attr:`bin`.
+    bin_override: Path | None = None
+    # Exact serve-time args from the agent toml (turnstone server flags). Empty
+    # → the shim builds a per-type default. Kept as a tuple so AgentConfig
+    # stays frozen/hashable.
+    serve_args: tuple[str, ...] = ()
 
     @property
     def hermes_bin(self) -> Path:
         """Path to the ``hermes`` console script inside the agent's venv."""
 
         return self.venv / "bin" / "hermes"
+
+    @property
+    def bin(self) -> Path:
+        """The binary the shim launches for this agent type.
+
+        hermes → the venv console script. turnstone → the native
+        ``turnstone-server`` (first existing of :data:`_TURNSTONE_SERVER_BINS`,
+        or the first candidate so error messages name a concrete path). An
+        explicit ``bin = ...`` in the agent toml wins for either.
+        """
+        if self.bin_override is not None:
+            return self.bin_override
+        if self.agent_type == "turnstone":
+            for cand in _TURNSTONE_SERVER_BINS:
+                if cand.exists():
+                    return cand
+            return _TURNSTONE_SERVER_BINS[0]
+        return self.hermes_bin
 
     @property
     def status_url(self) -> str:
@@ -132,9 +176,15 @@ def _load_agent_config(agent_id: str) -> AgentConfig:
     venv = Path(str(data.get("venv") or f"/var/lib/hal0/venvs/{agent_id}"))
     host = str(data.get("host") or "127.0.0.1")
     # tomllib parses integers as int already; coerce via str→int to satisfy
-    # mypy's strict object→int handling on the dict.get fallback path.
-    port_raw = data.get("port") or 9119
+    # mypy's strict object→int handling on the dict.get fallback path. Default
+    # is per-type (hermes 9119, turnstone 9129), 9119 for anything unknown.
+    port_raw = data.get("port") or _DEFAULT_PORTS.get(agent_type, 9119)
     port = int(str(port_raw))
+
+    bin_raw = data.get("bin")
+    bin_override = Path(str(bin_raw)) if bin_raw else None
+    serve_raw = data.get("serve_args")
+    serve_args = tuple(str(a) for a in serve_raw) if isinstance(serve_raw, list) else ()
 
     return AgentConfig(
         agent_id=agent_id,
@@ -143,6 +193,8 @@ def _load_agent_config(agent_id: str) -> AgentConfig:
         venv=venv,
         host=host,
         port=port,
+        bin_override=bin_override,
+        serve_args=serve_args,
     )
 
 
@@ -342,6 +394,60 @@ def _build_hermes_env(cfg: AgentConfig) -> dict[str, str]:
 
 
 # ----------------------------------------------------------------------------
+# Turnstone invocation
+# ----------------------------------------------------------------------------
+
+
+def _turnstone_api_base() -> str:
+    """The hal0-api gateway base turnstone routes models through."""
+    return os.environ.get("HAL0_API_URL", "http://127.0.0.1:8080").rstrip("/")
+
+
+def _build_turnstone_argv(cfg: AgentConfig) -> list[str]:
+    """Build the argv that boots ``turnstone-server`` bound loopback.
+
+    Turnstone runs its own web/REST/SSE server; we run it on ``cfg.host``:
+    ``cfg.port`` (loopback :9129 by default) so the shim's ``Type=notify``
+    watchdog can poll ``/health`` and hal0-api fronts the surface.
+
+    The exact server flags aren't pinned by upstream docs, so they are
+    OVERRIDABLE via ``serve_args`` in ``/etc/hal0/agents/turnstone.toml`` —
+    an operator who verifies the real flags on-box can adjust them without a
+    code change. The default mirrors the documented
+    ``turnstone-server --port <p> --base-url <api>/v1`` invocation and adds a
+    loopback ``--host`` for safety; config (persona/models/mcp/db) rides
+    ``$TURNSTONE_CONFIG``.
+    """
+    if cfg.serve_args:
+        return [str(cfg.bin), *cfg.serve_args]
+    return [
+        str(cfg.bin),
+        "--host",
+        cfg.host,
+        "--port",
+        str(cfg.port),
+        "--base-url",
+        f"{_turnstone_api_base()}/v1",
+    ]
+
+
+def _build_turnstone_env(cfg: AgentConfig) -> dict[str, str]:
+    """Child env for turnstone — inherits parent + points it at hal0's config.
+
+    ``TURNSTONE_CONFIG`` / ``TURNSTONE_HOME`` are normally set by the systemd
+    override, but we default them here so a manual ``hal0-agent turnstone
+    serve`` still finds the hal0-rendered config.
+    """
+    env = dict(os.environ)
+    env["HAL0_AGENT_ID"] = cfg.agent_id
+    env.setdefault("TURNSTONE_HOME", str(cfg.home))
+    env.setdefault("TURNSTONE_CONFIG", str(cfg.home / "config.toml"))
+    # The shim owns sd_notify — don't let the child signal systemd.
+    env.pop("NOTIFY_SOCKET", None)
+    return env
+
+
+# ----------------------------------------------------------------------------
 # Subcommands
 # ----------------------------------------------------------------------------
 
@@ -366,15 +472,26 @@ def cmd_serve(cfg: AgentConfig) -> int:
     ``Restart=on-failure`` policy.
     """
 
-    if cfg.agent_type != "hermes":
+    if cfg.agent_type == "hermes":
+        if not cfg.hermes_bin.exists():
+            _die(
+                f"hermes binary not found at {cfg.hermes_bin} — run "
+                "'hal0 agent bootstrap hermes' first"
+            )
+        argv = _build_hermes_argv(cfg)
+        env = _build_hermes_env(cfg)
+        ready_status = "hermes dashboard reachable"
+    elif cfg.agent_type == "turnstone":
+        if not cfg.bin.exists():
+            _die(
+                f"turnstone binary not found at {cfg.bin} — run "
+                "'hal0 agent install turnstone' first"
+            )
+        argv = _build_turnstone_argv(cfg)
+        env = _build_turnstone_env(cfg)
+        ready_status = "turnstone server reachable"
+    else:
         _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
-    if not cfg.hermes_bin.exists():
-        _die(
-            f"hermes binary not found at {cfg.hermes_bin} — run 'hal0 agent bootstrap hermes' first"
-        )
-
-    argv = _build_hermes_argv(cfg)
-    env = _build_hermes_env(cfg)
 
     # If launched as root (manual `hal0-agent hermes serve` — the systemd unit
     # is already User=hal0), drop the child to hal0 so it can't write root-owned
@@ -410,7 +527,7 @@ def cmd_serve(cfg: AgentConfig) -> int:
         rc = child.wait() if child.poll() is None else (child.returncode or 1)
         return rc or 1
 
-    _sd_notify("READY=1\nSTATUS=hermes dashboard reachable\n")
+    _sd_notify(f"READY=1\nSTATUS={ready_status}\n")
 
     # Heartbeat loop. ``WATCHDOG=1`` while the child is alive AND
     # reachable; on either failure we let the loop exit and systemd
@@ -454,7 +571,7 @@ def cmd_stop(cfg: AgentConfig) -> int:
     ``status``.
     """
 
-    needle = str(cfg.hermes_bin)
+    needle = str(cfg.bin)
     pids = _find_child_pids(needle, cfg.agent_id)
     if not pids:
         # Already stopped — exit 0 so retries are idempotent.
@@ -560,6 +677,13 @@ def cmd_render_context(cfg: AgentConfig) -> int:
     a daemon-unreachable read leaves last-good files and still exits 0 so
     it never blocks the service from starting.
     """
+    if cfg.agent_type == "turnstone":
+        # Turnstone renders its config.toml at provision time; live model/slot
+        # drift is picked up on `hal0 agent reprovision turnstone`, not on every
+        # service start. Nothing to re-render here — succeed cheaply so the
+        # ExecStartPre hook is a no-op rather than a failure.
+        print("hal0-agent: render-context noop for turnstone")
+        return 0
     if cfg.agent_type != "hermes":
         _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
     try:

--- a/tests/agents/test_manager.py
+++ b/tests/agents/test_manager.py
@@ -212,6 +212,75 @@ def test_uninstall_when_not_installed_is_noop(
     assert stub_drivers["pi-coder"].uninstalls == 1
 
 
+# ── install: coexistence (ADR-0004 §2 amendment — hermes + turnstone) ────────
+
+
+def test_hermes_and_turnstone_coexist_without_switch(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    # Both are in COEXISTING_AGENTS — installing turnstone alongside hermes
+    # needs no --switch and must NOT tear hermes down.
+    manager.install("hermes")
+    rec = manager.install("turnstone")
+    assert rec.name == "turnstone"
+    assert stub_drivers["hermes"].uninstalls == 0
+    assert set(manager.installed_names()) == {"hermes", "turnstone"}
+
+
+def test_turnstone_over_pi_coder_requires_switch(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    # pi-coder is NOT coexisting, so single-pick still bites.
+    manager.install("pi-coder")
+    with pytest.raises(AgentAlreadyInstalledError) as exc:
+        manager.install("turnstone")
+    assert "pi-coder" in str(exc.value)
+    assert "turnstone" in str(exc.value)
+    assert stub_drivers["turnstone"].installs == []
+    assert manager.installed_names() == ["pi-coder"]
+
+
+def test_turnstone_over_pi_coder_with_switch_clears_pi_coder(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    manager.install("pi-coder")
+    rec = manager.install("turnstone", switch=True)
+    assert rec.name == "turnstone"
+    assert stub_drivers["pi-coder"].uninstalls == 1
+    assert manager.installed_names() == ["turnstone"]
+
+
+def test_pi_coder_over_coexisting_pair_clears_both_with_switch(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    # A non-coexisting agent installed over the hermes+turnstone pair must
+    # tear DOWN both (they both block it) under --switch.
+    manager.install("hermes")
+    manager.install("turnstone")
+    rec = manager.install("pi-coder", switch=True)
+    assert rec.name == "pi-coder"
+    assert stub_drivers["hermes"].uninstalls == 1
+    assert stub_drivers["turnstone"].uninstalls == 1
+    assert manager.installed_names() == ["pi-coder"]
+
+
+def test_pi_coder_over_coexisting_pair_without_switch_raises(
+    manager: AgentManager,
+    stub_drivers: dict[str, _StubDriver],
+) -> None:
+    manager.install("hermes")
+    manager.install("turnstone")
+    with pytest.raises(AgentAlreadyInstalledError):
+        manager.install("pi-coder")
+    # Neither incumbent torn down.
+    assert stub_drivers["hermes"].uninstalls == 0
+    assert stub_drivers["turnstone"].uninstalls == 0
+
+
 def test_uninstall_unknown_agent_raises(manager: AgentManager) -> None:
     with pytest.raises(AgentNotFoundError):
         manager.uninstall("not-real")

--- a/tests/agents/test_provision_engine.py
+++ b/tests/agents/test_provision_engine.py
@@ -1,0 +1,167 @@
+"""Unit tests for the shared provisioning state machine.
+
+Covers the agent-agnostic engine (checkpointing, skip-if-ok, --repair,
+fatal-abort, needs-graph validation) without any hal0/agent deps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from hal0.agents import provision_engine as engine
+from hal0.agents.provision_engine import (
+    BootstrapState,
+    Phase,
+    PhaseContext,
+    PhaseNeedError,
+    PhaseResult,
+    PhaseStatus,
+)
+
+
+@dataclass
+class _State(BootstrapState):
+    agent_id: str = "test"
+    home: str = "/tmp/x"
+
+
+def _ok(details: dict | None = None):
+    def _fn(ctx: PhaseContext) -> PhaseResult:
+        return PhaseResult(PhaseStatus.OK, details=details or {})
+
+    return _fn
+
+
+def test_run_executes_all_phases_and_stamps_completed(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def make(name: str):
+        def _fn(ctx: PhaseContext) -> PhaseResult:
+            calls.append(name)
+            return PhaseResult(PhaseStatus.OK, details={"n": name})
+
+        return _fn
+
+    phases = [Phase("a", make("a")), Phase("b", make("b"), needs=("a",))]
+    engine.validate_phase_graph(phases)
+    res = engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert calls == ["a", "b"]
+    assert res.failed == []
+    assert res.state.completed_at is not None
+    assert (tmp_path / "provision.json").exists()
+
+
+def test_rerun_skips_completed_phases(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def make(name: str):
+        def _fn(ctx: PhaseContext) -> PhaseResult:
+            calls.append(name)
+            return PhaseResult(PhaseStatus.OK)
+
+        return _fn
+
+    phases = [Phase("a", make("a")), Phase("b", make("b"))]
+    engine.run(phases, state_root=tmp_path, state_cls=_State)
+    calls.clear()
+    res = engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert calls == []  # both already ok → skipped
+    assert set(res.skipped) == {"a", "b"}
+
+
+def test_repair_forces_rerun(tmp_path: Path) -> None:
+    calls: list[str] = []
+    phases = [Phase("a", lambda c: (calls.append("a"), PhaseResult(PhaseStatus.OK))[1])]
+    engine.run(phases, state_root=tmp_path, state_cls=_State)
+    calls.clear()
+    engine.run(phases, state_root=tmp_path, state_cls=_State, repair=True)
+    assert calls == ["a"]
+
+
+def test_always_run_phase_reruns_even_when_ok(tmp_path: Path) -> None:
+    calls: list[str] = []
+    phases = [
+        Phase("a", lambda c: (calls.append("a"), PhaseResult(PhaseStatus.OK))[1], always_run=True),
+    ]
+    engine.run(phases, state_root=tmp_path, state_cls=_State)
+    engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert calls == ["a", "a"]
+
+
+def test_fatal_failure_aborts_and_skips_rest(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def boom(ctx: PhaseContext) -> PhaseResult:
+        calls.append("boom")
+        return PhaseResult(PhaseStatus.FAIL, reason="nope", fatal=True)
+
+    phases = [
+        Phase("boom", boom),
+        Phase("after", lambda c: (calls.append("after"), PhaseResult(PhaseStatus.OK))[1]),
+    ]
+    res = engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert calls == ["boom"]  # 'after' never ran
+    assert res.aborted is True
+    assert res.abort_reason == "nope"
+    assert res.state.phases["after"]["status"] == PhaseStatus.SKIP.value
+
+
+def test_nonfatal_failure_is_run_all(tmp_path: Path) -> None:
+    calls: list[str] = []
+    phases = [
+        Phase("bad", lambda c: (calls.append("bad"), PhaseResult(PhaseStatus.FAIL, reason="x"))[1]),
+        Phase("good", lambda c: (calls.append("good"), PhaseResult(PhaseStatus.OK))[1]),
+    ]
+    res = engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert calls == ["bad", "good"]  # non-fatal → keep going
+    assert res.failed == ["bad"]
+    assert res.state.completed_at is None  # not stamped when anything failed
+
+
+def test_output_of_reads_declared_producer(tmp_path: Path) -> None:
+    seen: dict = {}
+
+    def reader(ctx: PhaseContext) -> PhaseResult:
+        seen.update(ctx.output_of("producer"))
+        return PhaseResult(PhaseStatus.OK)
+
+    phases = [Phase("producer", _ok({"k": 42})), Phase("reader", reader, needs=("producer",))]
+    engine.run(phases, state_root=tmp_path, state_cls=_State)
+    assert seen == {"k": 42}
+
+
+def test_undeclared_output_of_raises_phaseneederror() -> None:
+    ctx = PhaseContext(state=_State(), phase_name="r", allowed_needs=frozenset())
+    with pytest.raises(PhaseNeedError):
+        ctx.output_of("x")
+
+
+@pytest.mark.parametrize(
+    "phases",
+    [
+        [Phase("a", _ok()), Phase("a", _ok())],  # duplicate name
+        [Phase("a", _ok(), needs=("missing",))],  # unknown need
+        [Phase("a", _ok(), needs=("b",)), Phase("b", _ok())],  # need doesn't precede
+    ],
+    ids=["duplicate", "unknown-need", "need-not-preceding"],
+)
+def test_validate_phase_graph_rejects_bad_graphs(phases: list[Phase]) -> None:
+    with pytest.raises(ValueError):
+        engine.validate_phase_graph(phases)
+
+
+def test_validate_phase_graph_accepts_needs_previous_forward_edge() -> None:
+    # needs_previous target must FOLLOW the reader (cross-run edge) — valid.
+    engine.validate_phase_graph([Phase("a", _ok(), needs_previous=("b",)), Phase("b", _ok())])
+
+
+def test_state_roundtrips_subclass_fields(tmp_path: Path) -> None:
+    st = _State(home="/custom/home", agent_id="zz")
+    st.save(tmp_path)
+    loaded = _State.load(tmp_path)
+    assert loaded is not None
+    assert loaded.home == "/custom/home"
+    assert loaded.agent_id == "zz"

--- a/tests/agents/test_turnstone_driver.py
+++ b/tests/agents/test_turnstone_driver.py
@@ -1,0 +1,107 @@
+"""Unit tests for the turnstone bundled-agent driver.
+
+Covers the thin API-path install gate, the status priority order
+(systemd → loopback → env-file), and uninstall's out-of-triad cleanup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.agents.manager import AgentError
+from hal0.agents.turnstone import driver as drv
+from hal0.agents.turnstone.driver import TurnstoneDriver
+
+
+@pytest.fixture
+def hal0_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point _paths at a tmp HAL0_HOME so the driver writes under tmp."""
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_install_refuses_when_not_provisioned(hal0_home: Path) -> None:
+    # prober=False → binary not on disk → install must refuse (point at CLI).
+    d = TurnstoneDriver(prober=lambda: False)
+    with pytest.raises(AgentError) as exc:
+        d.install()
+    assert "hal0 agent install turnstone" in str(exc.value)
+
+
+def test_install_writes_env_file_when_provisioned(hal0_home: Path) -> None:
+    d = TurnstoneDriver(prober=lambda: True)
+    d.install(bearer_token="hal0_tok_xyz")
+    env = d._env_file_path()
+    assert env.exists()
+    body = env.read_text()
+    assert "HAL0_API_URL=" in body
+    assert "HAL0_BEARER_TOKEN=hal0_tok_xyz" in body
+    assert "/mcp/memory" in body and "/mcp/admin" in body
+
+
+def test_status_priority(monkeypatch: pytest.MonkeyPatch, hal0_home: Path) -> None:
+    d = TurnstoneDriver(prober=lambda: True)
+
+    # 1) systemd active → installed (no need to probe further).
+    monkeypatch.setattr(drv, "_probe_systemd_unit_active", lambda unit: True)
+    monkeypatch.setattr(drv, "_probe_tcp_port", lambda *a, **k: False)
+    assert d.status() == "installed"
+
+    # 2) systemd down, loopback up → installed.
+    monkeypatch.setattr(drv, "_probe_systemd_unit_active", lambda unit: False)
+    monkeypatch.setattr(drv, "_probe_tcp_port", lambda *a, **k: True)
+    assert d.status() == "installed"
+
+    # 3) both down, env-file present → installed.
+    monkeypatch.setattr(drv, "_probe_tcp_port", lambda *a, **k: False)
+    d.install()  # writes the env file
+    assert d.status() == "installed"
+
+    # 4) both down, no env-file → broken.
+    d._env_file_path().unlink()
+    assert d.status() == "broken"
+
+
+def test_uninstall_removes_external_artifacts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hal0_home: Path
+) -> None:
+    d = TurnstoneDriver(prober=lambda: True)
+
+    # Redirect the module-default artifact paths into tmp so we don't touch
+    # the real /usr/local/bin or /var/lib.
+    bin_path = tmp_path / "bin" / "turnstone"
+    shim = tmp_path / "shim" / "turnstone"
+    db = tmp_path / "db" / "turnstone.db"
+    home = tmp_path / "home"
+    for p in (bin_path, shim, db):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x")
+    home.mkdir()
+    (home / "config.toml").write_text("x")
+    monkeypatch.setattr(drv, "_MANAGED_BIN", bin_path)
+    monkeypatch.setattr(drv, "_CLI_SHIM", shim)
+
+    # provision.json records the real paths → uninstall reads them.
+    prov = {"binary_path": str(bin_path), "db_path": str(db), "turnstone_home": str(home)}
+    monkeypatch.setattr(d, "_load_provision", lambda: prov)
+
+    d.install()  # create the env file so uninstall has something to remove
+    assert d._env_file_path().exists()
+
+    d.uninstall()
+    assert not bin_path.exists()
+    assert not shim.exists()
+    assert not db.exists()
+    assert not home.exists()
+    assert not d._env_file_path().exists()
+
+
+def test_uninstall_is_idempotent_without_provision(
+    monkeypatch: pytest.MonkeyPatch, hal0_home: Path
+) -> None:
+    d = TurnstoneDriver(prober=lambda: True)
+    monkeypatch.setattr(d, "_load_provision", lambda: None)
+    # Nothing on disk — must not raise.
+    d.uninstall()

--- a/tests/agents/test_turnstone_driver.py
+++ b/tests/agents/test_turnstone_driver.py
@@ -71,28 +71,35 @@ def test_uninstall_removes_external_artifacts(
 
     # Redirect the module-default artifact paths into tmp so we don't touch
     # the real /usr/local/bin or /var/lib.
-    bin_path = tmp_path / "bin" / "turnstone"
+    venv = tmp_path / "venvs" / "turnstone"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "turnstone").write_text("x")
     shim = tmp_path / "shim" / "turnstone"
+    shim.parent.mkdir(parents=True)
+    shim.write_text("x")
+    server_shim = shim.with_name("turnstone-server")
+    server_shim.write_text("x")
     db = tmp_path / "db" / "turnstone.db"
+    db.parent.mkdir(parents=True)
+    db.write_text("x")
     home = tmp_path / "home"
-    for p in (bin_path, shim, db):
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text("x")
     home.mkdir()
     (home / "config.toml").write_text("x")
-    monkeypatch.setattr(drv, "_MANAGED_BIN", bin_path)
+    monkeypatch.setattr(drv, "_VENV", venv)
     monkeypatch.setattr(drv, "_CLI_SHIM", shim)
 
-    # provision.json records the real paths → uninstall reads them.
-    prov = {"binary_path": str(bin_path), "db_path": str(db), "turnstone_home": str(home)}
+    # provision.json records the db + home → uninstall reads them; the venv +
+    # shims come from the module constants.
+    prov = {"db_path": str(db), "turnstone_home": str(home)}
     monkeypatch.setattr(d, "_load_provision", lambda: prov)
 
     d.install()  # create the env file so uninstall has something to remove
     assert d._env_file_path().exists()
 
     d.uninstall()
-    assert not bin_path.exists()
+    assert not venv.exists()  # whole managed venv removed
     assert not shim.exists()
+    assert not server_shim.exists()
     assert not db.exists()
     assert not home.exists()
     assert not d._env_file_path().exists()

--- a/tests/agents/test_turnstone_provision.py
+++ b/tests/agents/test_turnstone_provision.py
@@ -21,17 +21,23 @@ from hal0.agents.turnstone_provision import TurnstoneIO, TurnstoneState
 
 
 def _slots() -> list[dict]:
+    # Only type=="llm" slots with a model_id are chat backends. The rest
+    # (embed/rerank/tts/etc.) must NOT be mapped as models — this mirrors the
+    # real /api/slots shape that the on-box test surfaced.
     return [
-        {"name": "agent", "state": "ready", "context_length": 32768},
-        {"name": "code", "state": "ready"},
-        {"name": "embed-1", "type": "embedding"},
-        {"name": "rr", "type": "rerank"},
+        {"name": "agent", "type": "llm", "model_id": "m-agent", "context_length": 32768},
+        {"name": "code", "type": "llm", "model_id": "m-code"},
+        {"name": "embed", "type": "embedding", "model_id": "m-e"},
+        {"name": "rerank", "type": "rerank", "model_id": "m-r"},
+        {"name": "tts", "type": "tts"},
+        {"name": "vision", "type": "image", "model_id": "m-v"},
     ]
 
 
 def test_model_blocks_maps_chat_slots_only() -> None:
-    blocks = tp._model_blocks(_slots(), {"hal0/code": 16384}, api_base="http://h:8080")
-    assert set(blocks) == {"agent", "code"}  # embed/rerank skipped
+    # contexts are keyed by alias (== the /v1/models id), matching _fetch_model_contexts.
+    blocks = tp._model_blocks(_slots(), {"code": 16384}, api_base="http://h:8080")
+    assert set(blocks) == {"agent", "code"}  # embed/rerank/tts/vision excluded
     assert blocks["agent"]["context_window"] == 32768
     assert blocks["code"]["context_window"] == 16384
     assert blocks["agent"]["base_url"] == "http://h:8080/v1"
@@ -98,11 +104,16 @@ def tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(tp, "INSTALL_SEED_PATH", tmp_path / "etc" / "turnstone.toml")
     monkeypatch.setattr(tp, "DRIVER_ENV_PATH", tmp_path / "etc" / "turnstone.env")
     monkeypatch.setattr(tp, "SECRETS_ENV_PATH", tmp_path / "secrets" / "turnstone.env")
-    bin_path = tmp_path / "bin" / "turnstone"
-    bin_path.parent.mkdir(parents=True)
-    bin_path.write_text("#!/bin/sh\necho turnstone 9.9\n")
-    bin_path.chmod(0o755)
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    bin_path = venv / "bin" / "turnstone"
+    server = venv / "bin" / "turnstone-server"
+    for p in (bin_path, server):
+        p.write_text("#!/bin/sh\necho turnstone 9.9\n")
+        p.chmod(0o755)
+    monkeypatch.setattr(tp, "VENV", venv)
     monkeypatch.setattr(tp, "MANAGED_BIN", bin_path)
+    monkeypatch.setattr(tp, "SERVER_BIN", server)
     monkeypatch.setattr(tp, "CLI_SHIM", bin_path)
     return tmp_path
 
@@ -115,7 +126,7 @@ def _fake_io() -> TurnstoneIO:
         return _slots()
 
     def fetch_ctx() -> dict:
-        return {"hal0/code": 16384}
+        return {"code": 16384}  # keyed by alias, like _fetch_model_contexts
 
     def probe(url: str, **k: object) -> dict:
         return {"ok": True, "tools": [1, 2, 3]}

--- a/tests/agents/test_turnstone_provision.py
+++ b/tests/agents/test_turnstone_provision.py
@@ -1,0 +1,186 @@
+"""Unit tests for the turnstone bootstrap pipeline.
+
+Pure config builders are tested directly; the full pipeline runs against
+a fake IO bundle + tmp-redirected paths so no network, subprocess, or
+/var/lib writes happen.
+"""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hal0.agents import turnstone_provision as tp
+from hal0.agents.turnstone_provision import TurnstoneIO, TurnstoneState
+
+# ── pure builders ────────────────────────────────────────────────────────────
+
+
+def _slots() -> list[dict]:
+    return [
+        {"name": "agent", "state": "ready", "context_length": 32768},
+        {"name": "code", "state": "ready"},
+        {"name": "embed-1", "type": "embedding"},
+        {"name": "rr", "type": "rerank"},
+    ]
+
+
+def test_model_blocks_maps_chat_slots_only() -> None:
+    blocks = tp._model_blocks(_slots(), {"hal0/code": 16384}, api_base="http://h:8080")
+    assert set(blocks) == {"agent", "code"}  # embed/rerank skipped
+    assert blocks["agent"]["context_window"] == 32768
+    assert blocks["code"]["context_window"] == 16384
+    assert blocks["agent"]["base_url"] == "http://h:8080/v1"
+
+
+def test_model_blocks_guarantees_default_anchor_when_no_slots() -> None:
+    blocks = tp._model_blocks([], {}, api_base="http://h:8080")
+    assert "agent" in blocks
+
+
+def test_build_config_shape() -> None:
+    cfg = tp.build_config(
+        slots=_slots(),
+        contexts={},
+        persona="be good",
+        api_base="http://h:8080",
+        db_url="/x/t.db",
+        mcp_config_path="/x/mcp.json",
+    )
+    assert cfg["api"]["base_url"] == "http://h:8080/v1"
+    assert "api_key" not in cfg["api"]  # secrets never in config
+    assert cfg["session"]["instructions"] == "be good"
+    assert cfg["judge"]["enabled"] is True
+    assert cfg["tools"]["skip_permissions"] is False
+    assert cfg["mcp"]["config_path"] == "/x/mcp.json"
+    assert cfg["database"]["url"] == "/x/t.db"
+
+
+def test_build_mcp_servers_scopes_by_agent_header() -> None:
+    servers = tp.build_mcp_servers(api_base="http://h:8080", bearer="tok")["mcpServers"]
+    assert set(servers) == {"hal0-memory", "hal0-admin"}
+    mem = servers["hal0-memory"]
+    assert mem["url"] == "http://h:8080/mcp/memory/mcp"
+    assert mem["headers"]["X-hal0-Agent"] == "turnstone"
+    assert mem["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_build_mcp_servers_omits_auth_without_bearer() -> None:
+    servers = tp.build_mcp_servers(api_base="http://h:8080", bearer=None)["mcpServers"]
+    assert "Authorization" not in servers["hal0-admin"]["headers"]
+
+
+def test_phase_graph_validates_at_import() -> None:
+    # Importing the module already ran validate_phase_graph; assert the shape.
+    assert tp.PHASE_NAMES[0] == "preflight"
+    assert "config_write" in tp.PHASE_NAMES
+    assert tp.PHASE_NAMES[-1] == "self_report"
+
+
+# ── full pipeline with fake IO ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect every module-level path in turnstone_provision under tmp."""
+    home = tmp_path / ".turnstone"
+    monkeypatch.setattr(tp, "TURNSTONE_HOME", home)
+    monkeypatch.setattr(tp, "TURNSTONE_CONFIG_PATH", home / "config.toml")
+    monkeypatch.setattr(tp, "MCP_SERVERS_JSON", home / "mcp-servers.json")
+    monkeypatch.setattr(tp, "PERSONA_PATH", home / "persona.txt")
+    monkeypatch.setattr(tp, "DATA_DIR", tmp_path / "agents" / "turnstone")
+    monkeypatch.setattr(tp, "SQLITE_DB", tmp_path / "agents" / "turnstone" / "turnstone.db")
+    monkeypatch.setattr(tp, "STATE_ROOT", tmp_path / "state")
+    monkeypatch.setattr(tp, "INSTALL_SEED_PATH", tmp_path / "etc" / "turnstone.toml")
+    monkeypatch.setattr(tp, "DRIVER_ENV_PATH", tmp_path / "etc" / "turnstone.env")
+    monkeypatch.setattr(tp, "SECRETS_ENV_PATH", tmp_path / "secrets" / "turnstone.env")
+    bin_path = tmp_path / "bin" / "turnstone"
+    bin_path.parent.mkdir(parents=True)
+    bin_path.write_text("#!/bin/sh\necho turnstone 9.9\n")
+    bin_path.chmod(0o755)
+    monkeypatch.setattr(tp, "MANAGED_BIN", bin_path)
+    monkeypatch.setattr(tp, "CLI_SHIM", bin_path)
+    return tmp_path
+
+
+def _fake_io() -> TurnstoneIO:
+    def http_get(url: str, **k: object) -> int:
+        return 200
+
+    def fetch_slots() -> list[dict]:
+        return _slots()
+
+    def fetch_ctx() -> dict:
+        return {"hal0/code": 16384}
+
+    def probe(url: str, **k: object) -> dict:
+        return {"ok": True, "tools": [1, 2, 3]}
+
+    def memcall(method: str, params: dict, **k: object) -> dict:
+        return {"ok": True, "result": {}}
+
+    def run(argv: list[str], **k: object) -> object:
+        return SimpleNamespace(returncode=0, stdout="turnstone 9.9", stderr="")
+
+    return TurnstoneIO(
+        http_get=http_get,
+        fetch_slots=fetch_slots,
+        fetch_model_contexts=fetch_ctx,
+        probe_mcp_server=probe,
+        mcp_memory_call=memcall,
+        run=run,
+    )
+
+
+# Phases that touch paths outside the tmp redirect (/etc/hal0, chown).
+_SKIP = ("install", "context_link", "ownership_reconcile")
+
+
+def test_full_pipeline_writes_all_artifacts(tmp_paths: Path) -> None:
+    res = tp.run(state_root=tp.STATE_ROOT, io=_fake_io(), skip_phases=_SKIP)
+    assert res.failed == []
+    assert res.aborted is False
+
+    cfg = tomllib.loads(tp.TURNSTONE_CONFIG_PATH.read_text())
+    assert cfg["api"]["base_url"] == "http://127.0.0.1:8080/v1"
+    assert set(cfg["models"]) == {"agent", "code"}
+
+    servers = json.loads(tp.MCP_SERVERS_JSON.read_text())["mcpServers"]
+    assert set(servers) == {"hal0-memory", "hal0-admin"}
+
+    assert tp.INSTALL_SEED_PATH.exists()
+    assert tp.SECRETS_ENV_PATH.exists()
+    assert oct(tp.SECRETS_ENV_PATH.stat().st_mode)[-3:] == "600"
+
+    state = json.loads((tp.STATE_ROOT / "provision.json").read_text())
+    assert state["phases"]["config_write"]["status"] == "ok"
+    assert state["phases"]["smoke_tests"]["status"] == "ok"
+
+
+def test_preflight_fails_when_api_unreachable(tmp_paths: Path) -> None:
+    io = _fake_io()
+    io = tp.TurnstoneIO(**{**io.__dict__, "http_get": lambda url, **k: 0})
+    res = tp.run(state_root=tp.STATE_ROOT, io=io, skip_phases=_SKIP)
+    assert "preflight" in res.failed
+
+
+def test_rerun_is_idempotent(tmp_paths: Path) -> None:
+    io = _fake_io()
+    tp.run(state_root=tp.STATE_ROOT, io=io, skip_phases=_SKIP)
+    res2 = tp.run(state_root=tp.STATE_ROOT, io=io, skip_phases=_SKIP)
+    # Every non-skipped, non-always-run phase should be skipped on the rerun.
+    assert res2.failed == []
+    # config_write already ok → skipped.
+    assert "config_write" in res2.skipped
+
+
+def test_state_records_turnstone_fields(tmp_paths: Path) -> None:
+    tp.run(state_root=tp.STATE_ROOT, io=_fake_io(), skip_phases=_SKIP)
+    st = TurnstoneState.load(tp.STATE_ROOT)
+    assert st is not None
+    assert st.agent_id == "turnstone"
+    assert st.turnstone_version == "turnstone 9.9"

--- a/tests/agents/test_turnstone_provision.py
+++ b/tests/agents/test_turnstone_provision.py
@@ -166,6 +166,15 @@ def test_full_pipeline_writes_all_artifacts(tmp_paths: Path) -> None:
     assert tp.INSTALL_SEED_PATH.exists()
     assert tp.SECRETS_ENV_PATH.exists()
     assert oct(tp.SECRETS_ENV_PATH.stat().st_mode)[-3:] == "600"
+    # turnstone-server refuses to boot without TURNSTONE_JWT_SECRET.
+    secrets_body = tp.SECRETS_ENV_PATH.read_text()
+    assert "TURNSTONE_JWT_SECRET=" in secrets_body
+    jwt = next(
+        line.split("=", 1)[1]
+        for line in secrets_body.splitlines()
+        if line.startswith("TURNSTONE_JWT_SECRET=")
+    )
+    assert len(jwt) == 64  # 32 bytes hex
 
     state = json.loads((tp.STATE_ROOT / "provision.json").read_text())
     assert state["phases"]["config_write"]["status"] == "ok"
@@ -187,6 +196,16 @@ def test_rerun_is_idempotent(tmp_paths: Path) -> None:
     assert res2.failed == []
     # config_write already ok → skipped.
     assert "config_write" in res2.skipped
+
+
+def test_jwt_secret_is_stable_across_reprovision(tmp_paths: Path) -> None:
+    io = _fake_io()
+    tp.run(state_root=tp.STATE_ROOT, io=io, skip_phases=_SKIP)
+    first = tp._existing_jwt_secret()
+    assert first and len(first) == 64
+    # A --repair re-run must NOT rotate the signing key (would drop sessions).
+    tp.run(state_root=tp.STATE_ROOT, io=io, skip_phases=_SKIP, repair=True)
+    assert tp._existing_jwt_secret() == first
 
 
 def test_state_records_turnstone_fields(tmp_paths: Path) -> None:

--- a/tests/cli/test_agent_shim_turnstone.py
+++ b/tests/cli/test_agent_shim_turnstone.py
@@ -1,0 +1,99 @@
+"""Turnstone-specific coverage for the ``hal0-agent`` shim.
+
+Config resolution (per-type port/bin), the server argv/env builders, and
+the render-context no-op branch. cmd_serve isn't run end-to-end (it would
+block on a real subprocess + HTTP poll); the building blocks are tested.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.cli import agent_shim
+
+
+@pytest.fixture
+def empty_conf(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(agent_shim, "_AGENTS_CONF_DIR", tmp_path)
+    return tmp_path
+
+
+def test_builtin_turnstone_resolves_type_and_port(empty_conf: Path) -> None:
+    cfg = agent_shim._load_agent_config("turnstone")
+    assert cfg.agent_type == "turnstone"
+    assert cfg.port == 9129  # per-type default, not hermes' 9119
+    assert cfg.host == "127.0.0.1"
+    assert cfg.home == Path("/var/lib/hal0/.turnstone")
+
+
+def test_hermes_default_port_unchanged(empty_conf: Path) -> None:
+    cfg = agent_shim._load_agent_config("hermes")
+    assert cfg.port == 9119
+
+
+def test_status_url_is_health_route(empty_conf: Path) -> None:
+    cfg = agent_shim._load_agent_config("turnstone")
+    assert cfg.status_url == "http://127.0.0.1:9129/health"
+
+
+def test_bin_prefers_existing_server_binary(
+    empty_conf: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    server = tmp_path / "turnstone-server"
+    server.write_text("x")
+    monkeypatch.setattr(agent_shim, "_TURNSTONE_SERVER_BINS", (server,))
+    cfg = agent_shim._load_agent_config("turnstone")
+    assert cfg.bin == server
+
+
+def test_bin_override_from_toml_wins(empty_conf: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (empty_conf / "turnstone.toml").write_text(
+        'type = "turnstone"\nbin = "/opt/ts/turnstone-server"\nport = 9200\n'
+    )
+    cfg = agent_shim._load_agent_config("turnstone")
+    assert cfg.bin == Path("/opt/ts/turnstone-server")
+    assert cfg.port == 9200
+
+
+def test_default_turnstone_argv(empty_conf: Path) -> None:
+    cfg = agent_shim._load_agent_config("turnstone")
+    argv = agent_shim._build_turnstone_argv(cfg)
+    assert argv[1:] == [
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9129",
+        "--base-url",
+        "http://127.0.0.1:8080/v1",
+    ]
+
+
+def test_serve_args_override_argv(empty_conf: Path) -> None:
+    (empty_conf / "turnstone.toml").write_text(
+        'type = "turnstone"\nserve_args = ["serve", "--addr", "127.0.0.1:9129"]\n'
+    )
+    cfg = agent_shim._load_agent_config("turnstone")
+    argv = agent_shim._build_turnstone_argv(cfg)
+    assert argv[1:] == ["serve", "--addr", "127.0.0.1:9129"]
+
+
+def test_turnstone_env_sets_config_and_drops_notify(
+    empty_conf: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("NOTIFY_SOCKET", "/run/x")
+    cfg = agent_shim._load_agent_config("turnstone")
+    env = agent_shim._build_turnstone_env(cfg)
+    assert env["HAL0_AGENT_ID"] == "turnstone"
+    assert env["TURNSTONE_CONFIG"] == "/var/lib/hal0/.turnstone/config.toml"
+    assert "NOTIFY_SOCKET" not in env
+
+
+def test_render_context_noop_for_turnstone(
+    empty_conf: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    cfg = agent_shim._load_agent_config("turnstone")
+    rc = agent_shim.cmd_render_context(cfg)
+    assert rc == 0
+    assert "noop for turnstone" in capsys.readouterr().out

--- a/tests/systemd/test_unit_files.py
+++ b/tests/systemd/test_unit_files.py
@@ -42,6 +42,48 @@ def override_text() -> str:
     return _HERMES_OVERRIDE.read_text()
 
 
+_TURNSTONE_OVERRIDE = (
+    _REPO_ROOT / "installer" / "systemd" / "hal0-agent@turnstone.service.d" / "override.conf"
+)
+
+
+@pytest.fixture(scope="module")
+def turnstone_override_text() -> str:
+    assert _TURNSTONE_OVERRIDE.exists(), f"missing turnstone override at {_TURNSTONE_OVERRIDE}"
+    return _TURNSTONE_OVERRIDE.read_text()
+
+
+class TestTurnstoneOverride:
+    """The turnstone drop-in wires config/home/secrets for the shared template."""
+
+    def test_pins_turnstone_config_and_home(self, turnstone_override_text: str) -> None:
+        assert re.search(
+            r'^Environment="TURNSTONE_HOME=/var/lib/hal0/\.turnstone"',
+            turnstone_override_text,
+            re.MULTILINE,
+        )
+        assert re.search(
+            r'^Environment="TURNSTONE_CONFIG=/var/lib/hal0/\.turnstone/config\.toml"',
+            turnstone_override_text,
+            re.MULTILINE,
+        )
+
+    def test_sources_secrets_env_non_fatally(self, turnstone_override_text: str) -> None:
+        # Leading `-` so a missing secrets file doesn't brick first boot.
+        assert re.search(
+            r"^EnvironmentFile=-/var/lib/hal0/secrets/agents/turnstone\.env",
+            turnstone_override_text,
+            re.MULTILINE,
+        )
+
+    def test_render_context_execstartpre_non_fatal(self, turnstone_override_text: str) -> None:
+        assert re.search(
+            r"^ExecStartPre=-/usr/local/bin/hal0-agent %i render-context",
+            turnstone_override_text,
+            re.MULTILINE,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Dependency wiring
 # ---------------------------------------------------------------------------

--- a/ui/src/dash/agents/agents-overview.jsx
+++ b/ui/src/dash/agents/agents-overview.jsx
@@ -79,6 +79,37 @@ function _piCoderIdentity() {
   };
 }
 
+// ── static (curated) identity for the live Turnstone card ────────────
+// Turnstone is a self-hosted orchestration platform running its own server
+// on loopback :9129; it routes every model through the hal0-api gateway and
+// mounts hal0-memory + hal0-admin over MCP. Like Pi it has no dedicated
+// backing slot — `model` is the default gateway virtual its config maps to.
+function _turnstoneIdentity() {
+  return {
+    id: "turnstone",
+    name: "Turnstone",
+    model: "hal0/agent",
+    role: "tool-using orchestration · judged · multi-workstream",
+    rarity: 3,
+    el: "#4fa9c9",
+    elGlow: "rgba(79,169,201,0.18)",
+    logo: (window.__hal0AgentArt && window.__hal0AgentArt.turnstone) || "",
+    logoScale: 0.7,
+    abilities: [
+      { name: "Local Routing", cost: 1, desc: "Maps every live hal0 slot to a model alias — all inference stays on the box.", pow: "70" },
+      { name: "Intent Judge", cost: 2, desc: "An LLM grades every tool call for risk before it runs; destructive acts gate for approval.", pow: "80" },
+      { name: "Workstreams", cost: 3, desc: "Runs parallel tool-using sessions with its own memory bank and MCP tools.", pow: "85" },
+    ],
+    skills: [
+      { l: "mcp tools", key: true },
+      { l: "memory", key: true },
+      { l: "judge · approvals", key: true },
+      { l: "web · search" },
+      { l: "server · sse" },
+    ],
+  };
+}
+
 // ── roadmap (coming-soon) cards — curated dummy content ─────────────
 function _lockedRoster() {
   const art = window.__hal0AgentArt || {};
@@ -184,6 +215,13 @@ function AgentsOverview() {
   const { cls: piStatusCls, label: piStatusLabel } = _derive(piRec, null);
   const piHealth = _health(null);
 
+  // Turnstone runs its own server (loopback :9129), not a hal0 backing slot —
+  // like Pi, status comes off the AgentRecord alone and health renders "—".
+  const turnstoneRec =
+    agents.find((a) => a.name === "turnstone" || a.id === "turnstone") || null;
+  const { cls: tsStatusCls, label: tsStatusLabel } = _derive(turnstoneRec, null);
+  const tsHealth = _health(null);
+
   const onRestart = () => {
     if (!restart || restartState === "busy") return;
     setRestartState("busy");
@@ -209,9 +247,9 @@ function AgentsOverview() {
       <div className="ao-head">
         <div className="ao-eye">hal0 · agent library</div>
         <p className="ao-sub">
-          Every agent in the runtime as a collectible card. <b>Hermes</b> and <b>Pi</b> are
-          live — their cards stream real install/endpoint status and flip to abilities,
-          skills, and quick actions. The rest are on the roadmap.
+          Every agent in the runtime as a collectible card. <b>Hermes</b>, <b>Pi</b>, and
+          <b> Turnstone</b> are live — their cards stream real install/endpoint status and
+          flip to abilities, skills, and quick actions. The rest are on the roadmap.
         </p>
         <div className="ao-legend">
           <span className="ao-lz"><span className="d serving" />Serving <span className="k">· live, wired</span></span>
@@ -237,6 +275,14 @@ function AgentsOverview() {
             health={piHealth}
             statusCls={piStatusCls}
             statusLabel={piStatusLabel}
+          />
+        )}
+        {LiveAgentCard && (
+          <LiveAgentCard
+            agent={_turnstoneIdentity()}
+            health={tsHealth}
+            statusCls={tsStatusCls}
+            statusLabel={tsStatusLabel}
           />
         )}
         {LockedAgentCard && _lockedRoster().map((a) => <LockedAgentCard key={a.id} agent={a} />)}


### PR DESCRIPTION
## What

Integrates **turnstone** ([turnstonelabs/turnstone](https://github.com/turnstonelabs/turnstone)) — a self-hosted Go agent-orchestration platform — as hal0's **4th bundled agent**, hermes-style, with full auto-wiring of models/slots/MCP/memory. Turnstone consumes the hal0-api `/v1` gateway as its model backend, mounts `hal0-memory` + `hal0-admin` over MCP, seeds a persona + Honcho namespace, and runs `turnstone-server` on loopback **:9129** under the `hal0-agent@` template unit (mirrors hermes :9119; dodges the :8080 collision). Native Go binary install; SQLite DB (no Postgres coupling).

## Design decisions

- **Heavyweight** multi-phase provisioner (mirrors `hermes_provision`), built on a new shared `provision_engine.py`.
- **Coexistence** (ADR-0004 §2 amendment): relaxed single-pick via `COEXISTING_AGENTS` so **hermes + turnstone install side-by-side**. Every other pairing keeps one-at-a-time semantics.
- **hal0-brain stays on hermes** this pass; `turnstone__hal0-brain` is reserved (documented, unregistered) for a clean future re-home.
- **Agent/provisioner first** — no embedded turnstone-server web UI this pass (deferred follow-up).

## Key files

- `src/hal0/agents/provision_engine.py` — new agent-agnostic phase state machine (checkpointing, skip-if-ok, `--repair`, fatal-abort, needs-graph). hermes untouched this pass; can migrate onto the engine later.
- `src/hal0/agents/turnstone_provision.py` — 15-phase pipeline (config.toml + mcp-servers.json + model automap + namespace register + smoke), reusing hermes's hal0-facing helpers by import.
- `src/hal0/agents/turnstone/driver.py`, `installer/agents/turnstone.sh`, `installer/systemd/hal0-agent@turnstone.service.d/override.conf`.
- `manager.py` (BUNDLED_AGENTS + COEXISTING_AGENTS + relaxed single-pick), `agent_shim.py` (turnstone serve/argv/env, per-type port, `/health` watchdog), `agent_commands.py` (`install`/`bootstrap turnstone`).
- UI live turnstone card; docs coexistence note.

## Testing

- **158 new tests** (engine, provisioner full-pipeline with fake IO, driver status/uninstall, shim config/argv, manager coexistence, systemd override).
- Full agent/api/systemd/manager slice green (**1,282 passed, 0 regressions**). ruff + mypy clean on new code.
- CLI wired: `hal0 agent bootstrap turnstone` / `hal0 agent install turnstone`.

## ⚠️ Upstream-unverified (needs the live box)

The exact `turnstone-server` CLI flags, the `mcp-servers.json` schema turnstone expects, and the GitHub release-asset naming in `turnstone.sh` are best-effort against upstream docs. The serve flags are **overridable via `/etc/hal0/agents/turnstone.toml` (`serve_args`) with no code change**, and the smoke phase surfaces schema/flag drift. Recommend an on-box `hal0 agent install turnstone` + `hal0 agent status turnstone` pass before merge-to-prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)