### PR TITLE
release: v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,34 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [0.9.8] — 2026-07-13
+
+Turnstone lands as a second heavyweight bundled agent alongside Hermes and
+becomes a first-class companion service; the unified **hal0-rocmfpx** runner
+becomes the default image for AMD GPUs (with an automatic slot migration on
+update); and a memory security fix stops one agent deleting another's private
+memories.
+
+### Highlights
+- **Turnstone — a second heavyweight bundled agent** joins Hermes: a native `turnstone-server` on loopback :9129, installed into its own managed PyPI venv, coexisting with Hermes via relaxed single-pick (#1299).
+- **Turnstone is a first-class companion service** — it shows in the Services pane and the Overview health card with start/stop/restart controls, next to Hermes/Hindsight/OpenWebUI.
+- **hal0-rocmfpx is now the universal default runner for AMD GPUs** — one unified image (Vulkan/RADV + HIP) replaces the per-lane toolboxes; CUDA and CPU-only lanes keep their lean images (#1297).
+- **Memory: private-visibility is now enforced on delete** — in unified-bank mode one agent could delete another agent's `visibility:private` memory by id; `delete` now applies the same fail-closed ACL as read/search/list.
+
+### Migrations
+- `hal0 update` automatically re-pins existing AMD-GPU slots from the old `amd-strix-halo-toolboxes` images to the unified `hal0-rocmfpx` runner (no-op on CUDA/CPU lanes) (#1297).
+
+### Added
+- **Turnstone bundled agent** — provisioning pipeline (managed PyPI venv, JWT-secret generation, model automap) plus hal0 provider/memory wiring, coexisting with Hermes (#1299).
+- **Turnstone companion-service registration** — a `ServiceDef` + systemd health probe, so turnstone appears in `/api/services` (Services pane, full lifecycle actions) and `/api/services/health` (Overview card + sidebar status).
+
+### Changed
+- **hal0-rocmfpx as the default AMD-GPU image** — basic seed profiles defer to a manifest-driven resolver that returns the unified runner for AMD lanes, the CUDA image for NVIDIA, and the lean toolbox for CPU-only (#1297).
+- PyPI distribution is published under the name **`hal0ai`** (the import package and `hal0`/`hal0-agent` console scripts are unchanged) (#1298).
+
+### Fixed
+- **Memory delete ACL** — `delete` enforces the `visibility:private` owner check in unified-bank mode, so an agent can no longer delete another agent's private memory by (guessable) document id; unresolved ids are withheld fail-closed (#1302).
+
 ## [0.9.7.3] — 2026-07-12
 
 A robustness release. Fresh installs now adapt to the host — provisioning their

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "0.9.7.3"
+version = "0.9.8"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/hal0/api/routes/services_health.py
+++ b/src/hal0/api/routes/services_health.py
@@ -1,12 +1,12 @@
 """GET /api/services/health — dashboard services health aggregator.
 
-Returns a stable list of four well-known services (comfyui, hermes,
-openwebui, n8n) with honest up/down state.  Every source degrades
+Returns a stable list of five well-known services (comfyui, hermes,
+turnstone, openwebui, n8n) with honest up/down state.  Every source degrades
 gracefully — a probe failure yields up=false, never a 500.
 
-Real probes: comfyui (in-process /system_stats+/queue), hermes (systemd
-unit state), openwebui (loopback GET /health — SpikeB §5.4).  n8n has no
-reachable probe from the API process (not deployed on this host) and
+Real probes: comfyui (in-process /system_stats+/queue), hermes + turnstone
+(systemd unit state), openwebui (loopback GET /health — SpikeB §5.4).  n8n
+has no reachable probe from the API process (not deployed on this host) and
 reports up=false, detail="unmonitored".
 
 HARD RULE: up=true requires a real signal.  Services with no wired probe
@@ -37,6 +37,11 @@ from hal0.api.routes.comfyui import (
 log = structlog.get_logger(__name__)
 
 router = APIRouter()
+
+# Turnstone's systemd unit (bundled agent, loopback :9129) — probed the same
+# way as hermes. _HERMES_UNIT is imported from comfyui; turnstone has no such
+# shared constant, so name it locally.
+_TURNSTONE_UNIT = "hal0-agent@turnstone.service"
 
 # OpenWebUI binds 0.0.0.0:3001 in hal0-openwebui.service (the port is fixed
 # in the unit — see config.py _OPENWEBUI_PORT). We probe it over loopback,
@@ -113,6 +118,18 @@ async def _probe_hermes() -> tuple[bool, str]:
     return False, "systemd unit inactive or absent"
 
 
+async def _probe_turnstone() -> tuple[bool, str]:
+    """Probe Turnstone via systemd unit state — same mechanism as hermes.
+
+    Turnstone is a bundled agent running ``hal0-agent@turnstone.service``
+    (loopback :9129). Real signal: the unit's active state.
+    """
+    active = await _systemd_active(_TURNSTONE_UNIT)
+    if active:
+        return True, "systemd unit active"
+    return False, "systemd unit inactive or absent"
+
+
 async def _probe_openwebui() -> tuple[bool, str]:
     """Real reachability probe — GET <loopback>/health on OpenWebUI.
 
@@ -141,14 +158,14 @@ async def _probe_n8n() -> tuple[bool, str]:
 
 @router.get("/health")
 async def services_health() -> dict[str, Any]:
-    """Aggregate health of the four known hal0 companion services.
+    """Aggregate health of the five known hal0 companion services.
 
     Response shape::
 
         {
           "services": [
             {
-              "id":     "comfyui"|"hermes"|"openwebui"|"n8n",
+              "id":     "comfyui"|"hermes"|"turnstone"|"openwebui"|"n8n",
               "name":   str,
               "up":     bool,
               "detail": str,
@@ -194,6 +211,24 @@ async def services_health() -> dict[str, Any]:
             "name": "Hermes",
             "up": h_up,
             "detail": h_detail,
+            "url": None,  # loopback-only, no browser-reachable URL
+            "stat": None,
+        }
+    )
+
+    # ── turnstone ────────────────────────────────────────────────────────────
+    try:
+        t_up, t_detail = await _probe_turnstone()
+    except Exception as exc:
+        log.warning("services_health.turnstone_probe_error", exc=repr(exc))
+        t_up, t_detail = False, type(exc).__name__
+
+    services.append(
+        {
+            "id": "turnstone",
+            "name": "Turnstone",
+            "up": t_up,
+            "detail": t_detail,
             "url": None,  # loopback-only, no browser-reachable URL
             "stat": None,
         }

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -45,6 +45,11 @@ _AGENT_TAG_PREFIX = "agent:"
 _ANONYMOUS = "anonymous"
 _UNKNOWN_AGENT = "unknown"
 
+# Page size for the pre-delete visibility scan (unified mode). delete() lists
+# the caller's banks to resolve each target doc's owner before removing it; a
+# page big enough that a normal delete resolves in one round-trip.
+_DELETE_SCAN_PAGE = 500
+
 
 def _agent_of(tags: list[str] | tuple[str, ...] | None) -> str | None:
     """Return the ``<id>`` of the first ``agent:<id>`` tag, else None."""
@@ -383,6 +388,47 @@ class HindsightProvider(MemoryProvider):
             "type": fact.get("fact_type"),
         }
 
+    async def _deletable_ids(
+        self, ids: set[str], banks: list[str], client_id: str | None
+    ) -> set[str]:
+        """Return the subset of ``ids`` the caller is allowed to delete under
+        unified-bank visibility.
+
+        In unified mode the single ``shared`` bank holds every agent's
+        ``visibility:private`` docs, so a blind delete-by-id would let any
+        caller remove another agent's private memory (read/search/list all
+        enforce visibility; delete must too). A doc is deletable when it is
+        non-private, or private and owned by the caller — the exact predicate
+        the read paths use (:meth:`_is_visible_to`). An id we cannot resolve to
+        a doc in the caller's banks is **withheld** (fail-closed), matching the
+        fail-closed posture of the read filter.
+        """
+        if not ids:
+            return set()
+        caller = self._caller_agent(client_id)
+        wanted = set(ids)
+        out: set[str] = set()
+        for bank in banks:
+            if not wanted - out:
+                break
+            offset = 0
+            while wanted - out:
+                try:
+                    resp = await self._client.list_memories(
+                        bank_id=bank, limit=_DELETE_SCAN_PAGE, offset=offset
+                    )
+                except Exception:
+                    break  # fail-soft per bank; unresolved ids stay withheld
+                items = resp.get("items", [])
+                for fact in items:
+                    fid = fact.get("id") or fact.get("document_id")
+                    if fid in wanted and fid not in out and self._is_visible_to(fact, caller):
+                        out.add(fid)
+                if len(items) < _DELETE_SCAN_PAGE:
+                    break  # last page
+                offset += _DELETE_SCAN_PAGE
+        return out
+
     async def delete(
         self,
         ids: list[str],
@@ -400,7 +446,16 @@ class HindsightProvider(MemoryProvider):
         banks = [
             namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset or _SHARED, client_id)
         ]
+        # Unified mode: gate deletes on the same visibility:private ACL the read
+        # paths enforce, so one agent can't delete another's private doc by id.
+        # Legacy multi-bank mode needs no gate — _allowed_namespaces never
+        # yields a foreign private bank, so bank isolation already protects it.
+        deletable = (
+            await self._deletable_ids(set(ids), banks, client_id) if self._unified_bank else None
+        )
         for document_id in ids:
+            if deletable is not None and document_id not in deletable:
+                continue  # withheld: not visible to this caller (fail-closed)
             for bank in banks:
                 try:
                     res = await self._client.delete_document(bank_id=bank, document_id=document_id)

--- a/src/hal0/services/registry.py
+++ b/src/hal0/services/registry.py
@@ -102,6 +102,16 @@ SERVICES: tuple[ServiceDef, ...] = (
         loopback_port=9119,
     ),
     ServiceDef(
+        id="turnstone",
+        name="Turnstone",
+        description="Bundled agent (turnstone-server, loopback :9129).",
+        unit="hal0-agent@turnstone.service",
+        public_url_env="HAL0_TURNSTONE_PUBLIC_URL",
+        probe="systemd",
+        actions=_FULL,
+        loopback_port=9129,
+    ),
+    ServiceDef(
         id="hindsight",
         name="Hindsight",
         description="Memory engine (native daemon, loopback :9177).",

--- a/tests/api/test_services_health.py
+++ b/tests/api/test_services_health.py
@@ -6,7 +6,7 @@ minimal FastAPI app with the router mounted under the canonical prefix
 so the endpoint is reachable without touching the real app factory.
 
 Covers:
-  1. Endpoint returns 200 with all 4 service ids present.
+  1. Endpoint returns 200 with all 5 service ids present.
   2. n8n is up=false, detail="unmonitored" (no real probe).
   3. With comfyui probe mocked reachable -> up=true, stat populated.
   4. comfyui probe raising -> comfyui up=false, endpoint still 200.
@@ -27,7 +27,7 @@ from fastapi.testclient import TestClient
 from hal0.api.routes.services_health import router as services_router
 
 _BASE = "hal0.api.routes.services_health"
-_EXPECTED_IDS = {"comfyui", "hermes", "openwebui", "n8n"}
+_EXPECTED_IDS = {"comfyui", "hermes", "turnstone", "openwebui", "n8n"}
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def _services_by_id(body: dict) -> dict:
 
 
 def _stub_other_probes() -> list:
-    """Patch comfyui/hermes/openwebui to neutral down states so a test can
+    """Patch comfyui/hermes/turnstone/openwebui to neutral down states so a test can
     isolate ONE service without real network/systemd calls. Returns a list
     of started patchers the caller closes via an ExitStack, OR use as a
     context-manager group. Default: everything down/unmonitored.
@@ -60,6 +60,11 @@ def _stub_other_probes() -> list:
             return_value=(False, "systemd unit inactive or absent"),
         ),
         patch(
+            f"{_BASE}._probe_turnstone",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
             f"{_BASE}._probe_openwebui",
             new_callable=AsyncMock,
             return_value=(False, "unreachable (ConnectError)"),
@@ -67,7 +72,7 @@ def _stub_other_probes() -> list:
     ]
 
 
-# ── 1. shape: 200 + all 4 ids ─────────────────────────────────────────────────
+# ── 1. shape: 200 + all 5 ids ─────────────────────────────────────────────────
 
 
 def test_services_health_200_all_ids(svc_client: TestClient) -> None:
@@ -79,7 +84,7 @@ def test_services_health_200_all_ids(svc_client: TestClient) -> None:
     assert r.status_code == 200, r.text
     body = r.json()
     assert "services" in body
-    assert len(body["services"]) == 4
+    assert len(body["services"]) == 5
     ids = {s["id"] for s in body["services"]}
     assert ids == _EXPECTED_IDS
 
@@ -117,6 +122,11 @@ def test_comfyui_reachable_up_true_stat_populated(svc_client: TestClient) -> Non
             return_value=(False, "systemd unit inactive or absent"),
         ),
         patch(
+            f"{_BASE}._probe_turnstone",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
             f"{_BASE}._probe_openwebui",
             new_callable=AsyncMock,
             return_value=(False, "unreachable (ConnectError)"),
@@ -145,6 +155,11 @@ def test_comfyui_probe_raises_degrades_gracefully(svc_client: TestClient) -> Non
         ),
         patch(
             f"{_BASE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
+            f"{_BASE}._probe_turnstone",
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),
@@ -182,6 +197,11 @@ def test_openwebui_health_2xx_up_true(svc_client: TestClient) -> None:
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),
+        patch(
+            f"{_BASE}._probe_turnstone",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
         patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=ok_resp),
     ):
         r = svc_client.get("/api/services/health")
@@ -205,6 +225,11 @@ def test_openwebui_unreachable_up_false(svc_client: TestClient) -> None:
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),
+        patch(
+            f"{_BASE}._probe_turnstone",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
         patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=conn_err),
     ):
         r = svc_client.get("/api/services/health")
@@ -225,6 +250,11 @@ def test_openwebui_non_2xx_up_false(svc_client: TestClient) -> None:
         ),
         patch(
             f"{_BASE}._probe_hermes",
+            new_callable=AsyncMock,
+            return_value=(False, "systemd unit inactive or absent"),
+        ),
+        patch(
+            f"{_BASE}._probe_turnstone",
             new_callable=AsyncMock,
             return_value=(False, "systemd unit inactive or absent"),
         ),

--- a/tests/api/test_services_page.py
+++ b/tests/api/test_services_page.py
@@ -30,7 +30,7 @@ from hal0.services import systemd as svc_systemd
 from hal0.services.registry import SERVICES, service_by_id
 
 _ROUTE = "hal0.api.routes.services"
-_EXPECTED_IDS = {"openwebui", "comfyui", "hermes", "hindsight", "honcho", "n8n"}
+_EXPECTED_IDS = {"openwebui", "comfyui", "hermes", "turnstone", "hindsight", "honcho", "n8n"}
 
 _DOWN_STATE = {
     "active_state": "inactive",

--- a/tests/memory/test_unified_bank.py
+++ b/tests/memory/test_unified_bank.py
@@ -55,10 +55,17 @@ class RecordingClient:
         return {"results": list(self._facts_by_bank.get(bank_id, []))}
 
     async def list_memories(self, *, bank_id, limit=50, offset=0, types=None, query=None):
-        raw = self._facts_by_bank.get(bank_id, [])
+        raw = self._facts_by_bank.get(bank_id, [])[offset : offset + limit]
         return {
             "items": [{"id": f["document_id"], "text": f["text"], "tags": f["tags"]} for f in raw]
         }
+
+    async def delete_document(self, *, bank_id, document_id):
+        facts = self._facts_by_bank.get(bank_id, [])
+        kept = [f for f in facts if f["document_id"] != document_id]
+        removed = len(facts) - len(kept)
+        self._facts_by_bank[bank_id] = kept
+        return {"memory_units_deleted": removed}
 
 
 def _unified(client_id: str = "hermes") -> HindsightProvider:
@@ -339,6 +346,82 @@ async def test_legacy_multibank_private_recall_not_over_filtered():
     await p.add("secret", dataset="private:hermes", client_id="hermes", tags=["agent:override"])
     out = await p.recall("secret", dataset="private:hermes", client_id="hermes")
     assert any(i["text"] == "secret" for i in out)
+
+
+# ── Delete-side enforcement of visibility:private (unified mode) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_unified_delete_refuses_foreign_private():
+    """A caller must NOT be able to delete another agent's visibility:private
+    doc by id — even knowing/guessing the id — because in unified mode it lives
+    in the same ``shared`` bank as their own. Delete enforces the same ACL as
+    read (regression: previously delete swept by id with no owner check)."""
+    p = _unified(client_id="hermes")
+    r = await p.add("hermes secret", dataset="private:hermes", client_id="hermes")
+    doc_id = r["id"]
+
+    res = await p.delete([doc_id], client_id="scribe")
+    assert res["deleted"] == 0
+    # Still there for the owner.
+    owner = await p.recall("secret", dataset="shared", client_id="hermes")
+    assert any(i["text"] == "hermes secret" for i in owner)
+
+
+@pytest.mark.asyncio
+async def test_unified_delete_anonymous_refused_foreign_private():
+    """A caller with no resolved identity (provider default ``anonymous`` →
+    ``unknown``) cannot delete a real agent's private doc. Mirrors the read-side
+    ``test_unified_anonymous_provider_denied_foreign_private``."""
+    p = HindsightProvider(client=RecordingClient(), unified_bank=True)
+    r = await p.add("hermes secret", dataset="private:hermes", client_id="hermes")
+    res = await p.delete([r["id"]])  # no client_id → unknown
+    assert res["deleted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_unified_delete_allows_owner_private():
+    """The owning agent can still delete its own private doc."""
+    p = _unified(client_id="hermes")
+    r = await p.add("hermes secret", dataset="private:hermes", client_id="hermes")
+    res = await p.delete([r["id"]], client_id="hermes")
+    assert res["deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unified_delete_allows_shared_for_any_caller():
+    """Non-private (shared) docs stay communally deletable — the gate must not
+    over-restrict, mirroring shared being readable by everyone."""
+    p = _unified(client_id="hermes")
+    r = await p.add("public", dataset="shared", client_id="hermes")
+    res = await p.delete([r["id"]], client_id="scribe")
+    assert res["deleted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unified_delete_mixed_ids_only_removes_visible():
+    """A batch delete removes the caller's own + shared docs but withholds a
+    foreign private one."""
+    p = _unified(client_id="hermes")
+    own = await p.add("hermes note", dataset="private:hermes", client_id="hermes")
+    shared = await p.add("public", dataset="shared", client_id="hermes")
+    foreign = await p.add("scribe secret", dataset="private:scribe", client_id="scribe")
+
+    res = await p.delete([own["id"], shared["id"], foreign["id"]], client_id="hermes")
+    assert res["deleted"] == 2
+    # The foreign private doc survives and is still visible to its owner.
+    s = await p.recall("secret", dataset="shared", client_id="scribe")
+    assert any(i["text"] == "scribe secret" for i in s)
+
+
+@pytest.mark.asyncio
+async def test_legacy_multibank_delete_unaffected():
+    """Legacy mode keeps deleting by bank ACL (no visibility scan) — the owner
+    deletes its own private doc as before."""
+    p = HindsightProvider(client=RecordingClient(), client_id="hermes", unified_bank=False)
+    r = await p.add("secret", dataset="private:hermes", client_id="hermes")
+    res = await p.delete([r["id"]], dataset="private:hermes", client_id="hermes")
+    assert res["deleted"] == 1
 
 
 # ── Config default ────────────────────────────────────────────────────────────

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -812,6 +812,12 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       title: serviceById.hermes?.detail || (serviceHealth.pending ? 'service health pending' : 'hermes down'),
     },
     {
+      id: 'turnstone',
+      label: 'turnstone',
+      tone: serviceHealth.pending ? 'warn' : serviceById.turnstone?.up ? 'up' : 'err',
+      title: serviceById.turnstone?.detail || (serviceHealth.pending ? 'service health pending' : 'turnstone down'),
+    },
+    {
       id: 'openwebui',
       label: 'openwebui',
       tone: serviceHealth.pending ? 'warn' : serviceById.openwebui?.up ? 'up' : 'err',

--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -816,7 +816,7 @@ function RDActivityCard({ swap }) {
 
 // ─── band C · services ───────────────────────────────────────────────────────
 
-const SERVICE_ORDER = ['openwebui', 'comfyui', 'hermes', 'n8n']
+const SERVICE_ORDER = ['openwebui', 'comfyui', 'hermes', 'turnstone', 'n8n']
 
 function RDServicesCard({ swap, onGo }) {
   const svc = useServices()


### PR DESCRIPTION
Cuts **v0.9.8**. Based on current `main` (turnstone #1299, rocmfpx #1297, pypi #1298) plus two cherry-picked additions.

## What this adds on top of main
- **`fix(memory)`: enforce `visibility:private` ACL on delete** — in unified-bank mode an agent could delete another agent's private memory by (guessable) document id; `delete` now applies the same fail-closed ACL as read/search/list. Regression tests in `tests/memory/test_unified_bank.py`. (finding #1302)
- **`feat(services)`: register turnstone as a companion service** — a `ServiceDef` + systemd health probe so turnstone appears in `/api/services` (Services pane, full lifecycle) and `/api/services/health` (Overview card + sidebar), matching Hermes.

## Release commit
- Bump `pyproject` → `0.9.8`
- `CHANGELOG.md` `[0.9.8]` covering everything since 0.9.7.3: turnstone agent (#1299), turnstone-as-service, rocmfpx universal default + slot migration (#1297, with a `### Migrations` callout), pypi `hal0ai` rename (#1298), and the memory delete-ACL fix.

## Validation
- Full install tested end-to-end on a fresh box (Ubuntu 24.04): install completes, services up, turnstone appears in `/api/services` + health.
- Local pre-flight: ruff clean; targeted suites (memory delete-ACL, services page/health, CLI docs-parity) green on the main base.

Once the required checks are green, merge and tag `v0.9.8` to trigger `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)