### PR TITLE
feat(registry): prune stale rows on scan; protect slot/stack-referenced models

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -180,7 +180,15 @@ async def scan_preview(request: Request) -> dict[str, Any]:
     extensions = {e.lower() for e in cfg.models.file_extensions}
 
     preview = _svc.preview_scan_rows(raw_paths, recursive, extensions)
-    return {"preview": preview, "count": len(preview)}
+
+    # Drift view: existing registry rows whose backing file is now absent.
+    # Surfaced so the operator/UI can see what a `{"prune": true}` scan would
+    # remove BEFORE committing. ``referenced`` flags rows a slot/stack still
+    # points at — those are protected from prune (repair, don't delete).
+    registry = request.app.state.model_registry
+    missing = _svc.missing_registry_rows(registry)
+
+    return {"preview": preview, "count": len(preview), "missing": missing}
 
 
 @router.post("/scan")
@@ -193,7 +201,11 @@ async def scan_models(request: Request) -> dict[str, Any]:
     * **Legacy / empty body** — walk the configured ``[models].roots`` and
       auto-register every new candidate via the discover module. Each
       added model fires a ``model.registered`` event with
-      ``source='scan'``.
+      ``source='scan'``. Pass ``{"prune": true}`` to also reconcile the
+      registry: rows whose backing file is missing on disk are removed
+      (each firing a ``model.pruned`` event) UNLESS the id is referenced by
+      a slot or stack, in which case it is reported under
+      ``missing_referenced`` for repair rather than deleted.
 
     * **``{"rows": [...]}``** — commit pre-vetted preview rows. Each row
       may carry user-edited ``backends`` / ``capabilities`` / ``defaults``
@@ -201,7 +213,8 @@ async def scan_models(request: Request) -> dict[str, Any]:
       detection output for that path. User overrides always win — that's
       the whole point of the preview round-trip.
 
-    Returns ``{added, skipped, scanned_roots}`` in both modes so the UI's
+    Returns ``{added, skipped, scanned_roots}`` in both modes (plus
+    ``pruned`` / ``missing_referenced`` on the auto-scan path) so the UI's
     toast-render path is unchanged.
     """
     registry = request.app.state.model_registry
@@ -215,8 +228,9 @@ async def scan_models(request: Request) -> dict[str, Any]:
     if isinstance(rows, list) and rows:
         return await _svc.commit_scan_rows(rows, registry, event_bus)
 
+    prune = bool(body.get("prune", False)) if isinstance(body, dict) else False
     cfg = load_hal0_config()
-    return await _svc.auto_scan_and_register(registry, cfg.models, event_bus)
+    return await _svc.auto_scan_and_register(registry, cfg.models, event_bus, prune=prune)
 
 
 @router.post("/add-from-path", status_code=201)

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -332,9 +332,12 @@ AUTONOMOUS_READ_TOOLS: frozenset[str] = frozenset(
 # (reversible, scoped, low blast radius).
 AUTONOMOUS_WRITE_TOOLS: frozenset[str] = frozenset(
     {
-        # Model. model_scan only ADDS registry entries for files already
-        # on disk (reversible via model_delete); model_pull_cancel stops
-        # an in-flight download the agent (or operator) started.
+        # Model. model_scan ADDS registry entries for files on disk
+        # (reversible via model_delete); with prune=true it also removes
+        # rows whose file is missing on disk — but slot/stack-referenced
+        # rows are protected and only reported, never auto-deleted, so the
+        # blast radius stays low. model_pull_cancel stops an in-flight
+        # download the agent (or operator) started.
         "model_swap",
         "model_assign",
         "model_edit",
@@ -648,6 +651,18 @@ TOOL_PARAM_HINTS: dict[str, dict[str, Any]] = {
                 "description": "Exact .gguf filename in the repo (from model_inspect)",
             },
             "mmproj_filename": {"type": "string", "description": "Optional vision sidecar"},
+        },
+    },
+    "model_scan": {
+        "properties": {
+            "prune": {
+                "type": "boolean",
+                "description": (
+                    "Also remove registry rows whose file is missing on disk; "
+                    "slot/stack-referenced rows are protected and only reported "
+                    "(missing_referenced), never deleted. Default false = add-only."
+                ),
+            },
         },
     },
     "model_swap": {
@@ -1608,7 +1623,11 @@ TOOL_DESCRIPTIONS: dict[str, str] = {
         "Args: name=SLOT name (not the model!), model=registered model id."
     ),
     "model_edit": "Update a model's metadata (name, capabilities, tags, mmproj, defaults).",
-    "model_scan": "Walk the configured model roots + store and register newly-found files.",
+    "model_scan": (
+        "Walk the configured model roots + store and register newly-found files. "
+        "Pass prune=true to also remove registry rows whose file is missing on disk "
+        "(slot/stack-referenced rows are protected and only reported)."
+    ),
     "model_pull_cancel": "Cancel an in-flight model pull job.",
     "model_pull_delete": (
         "Clear a TERMINAL pull job's record from memory + disk (409s if still queued/running)."

--- a/src/hal0/registry/discover.py
+++ b/src/hal0/registry/discover.py
@@ -495,11 +495,128 @@ def backfill_coordless(registry: ModelRegistry) -> list[str]:
     return repaired
 
 
-def scan_and_register(registry: ModelRegistry, cfg: ModelsConfig) -> dict:
+def prune_missing(
+    registry: ModelRegistry,
+    *,
+    protected_ids: set[str],
+    dry_run: bool = False,
+) -> dict:
+    """Remove registry rows whose backing path no longer exists on disk.
+
+    A row is pruned only if BOTH: its resolved path is missing AND its id is
+    not in ``protected_ids`` (slot/stack-referenced ids). Protected-but-missing
+    rows are returned under ``missing_referenced`` so callers can surface them
+    as drift needing repair rather than silently deleting a referenced model.
+    Returns {"pruned": [...ids...], "missing_referenced": [...ids...], "kept": int}.
+    """
+    pruned: list[str] = []
+    missing_referenced: list[str] = []
+    kept = 0
+    for m in registry.list():
+        # ``p.exists()`` is authoritative: do NOT special-case size_bytes==0
+        # (that's stale metadata — the weights may well still be on disk).
+        try:
+            present = Path(m.path).exists()
+        except OSError:
+            present = False
+        if present:
+            kept += 1
+            continue
+        # Path is missing on disk.
+        if m.id in protected_ids:
+            # Referenced by a live slot or a stack — this is functional drift
+            # that needs a repair, not a deletion. Report, never remove.
+            missing_referenced.append(m.id)
+            continue
+        pruned.append(m.id)
+        if not dry_run:
+            try:
+                registry.remove(m.id)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("discover.prune_remove_failed id=%s err=%s", m.id, exc)
+    return {"pruned": pruned, "missing_referenced": missing_referenced, "kept": kept}
+
+
+def referenced_model_ids() -> set[str]:
+    """Model ids referenced by any configured slot or any stack.
+
+    Union of: each slot's default model (plus its capability child models from
+    the live capabilities config) and every model id referenced by a stack
+    (slot primaries + capability rows). Best-effort — each per-slot / per-stack /
+    per-config load is wrapped so a single malformed config can't blow up the
+    whole scan. Missing subsystems are simply skipped.
+    """
+    ids: set[str] = set()
+
+    # ── Slots (+ live capability child selections) ────────────────────────
+    try:
+        from hal0.config.loader import list_slots, load_slot_config
+
+        for slot_name in list_slots():
+            try:
+                slot = load_slot_config(slot_name)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("discover.ref_slot_load_failed slot=%s err=%s", slot_name, exc)
+                continue
+            model_id = getattr(getattr(slot, "model", None), "default", "") or ""
+            if model_id:
+                ids.add(model_id)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("discover.ref_slots_failed err=%s", exc)
+
+    # Capability child selections (live [selections.<slot>.<child>] rows).
+    try:
+        from hal0.capabilities.config import load_capabilities_config
+
+        cap_cfg = load_capabilities_config()
+        for children in getattr(cap_cfg, "selections", {}).values():
+            for sel in children.values():
+                child_model = getattr(sel, "model", "") or ""
+                if child_model:
+                    ids.add(child_model)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("discover.ref_capabilities_failed err=%s", exc)
+
+    # ── Stacks (slot primaries + capability rows) ─────────────────────────
+    try:
+        from hal0.stacks import StacksCatalog
+        from hal0.stacks.portable import _referenced_model_ids
+
+        for stack in StacksCatalog().list():
+            try:
+                # ResolvedStack duck-types StackConfig for _referenced_model_ids
+                # (both expose ``.slots`` of StackSlotEntry).
+                ids |= _referenced_model_ids(stack)
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning(
+                    "discover.ref_stack_failed stack=%s err=%s",
+                    getattr(stack, "slug", "?"),
+                    exc,
+                )
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("discover.ref_stacks_failed err=%s", exc)
+
+    return ids
+
+
+def scan_and_register(
+    registry: ModelRegistry,
+    cfg: ModelsConfig,
+    *,
+    prune: bool = False,
+    protected_ids: set[str] | None = None,
+) -> dict:
     """Discover candidates under ``cfg.roots`` and register the new ones.
 
     Returns a result dict shaped for both the API surface and the
     startup log line.
+
+    When ``prune`` is True, also run :func:`prune_missing` after the add pass
+    to drop registry rows whose backing file no longer exists — except rows in
+    ``protected_ids`` (slot/stack-referenced), which are reported under
+    ``missing_referenced`` for repair. The ``pruned`` / ``missing_referenced``
+    keys are always present (both ``[]`` when ``prune`` is False) so the return
+    shape is stable.
     """
     known_paths: set[str] = set()
     for existing in registry.list():
@@ -549,11 +666,24 @@ def scan_and_register(registry: ModelRegistry, cfg: ModelsConfig) -> dict:
             log.warning("discover.register_failed path=%s err=%s", cand.path, exc)
             skipped.append({"path": str(cand.path), "reason": f"register_failed:{exc}"})
 
+    pruned: list[str] = []
+    missing_referenced: list[str] = []
+    if prune:
+        prune_result = prune_missing(
+            registry,
+            protected_ids=protected_ids or set(),
+            dry_run=False,
+        )
+        pruned = prune_result["pruned"]
+        missing_referenced = prune_result["missing_referenced"]
+
     return {
         "added": added,
         "backfilled": backfilled,
         "skipped": skipped,
         "scanned_roots": [str(r) for r in roots],
+        "pruned": pruned,
+        "missing_referenced": missing_referenced,
     }
 
 
@@ -569,6 +699,8 @@ __all__ = [
     "backfill_coordless",
     "find_candidates",
     "is_skippable",
+    "prune_missing",
+    "referenced_model_ids",
     "register_candidate",
     "scan_and_register",
 ]

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -19,6 +19,7 @@ that land first.
 from __future__ import annotations
 
 import contextlib
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,8 @@ from hal0.model_meta import classify
 from hal0.registry.detect import DetectionResult, detect
 from hal0.registry.model import _derive_ns
 from hal0.upstreams.filters import apply_filters
+
+log = logging.getLogger(__name__)
 
 # ── model-id classification (pure) ────────────────────────────────────────────
 
@@ -430,15 +433,26 @@ async def auto_scan_and_register(
     registry: Any,
     models_cfg: Any,
     event_bus: Any | None,
+    *,
+    prune: bool = False,
 ) -> dict[str, Any]:
     """Walk the configured ``[models].roots`` and auto-register new candidates.
 
     The empty-body branch of ``POST /api/models/scan``: every newly discovered
     file fires a ``model.registered`` event with ``source='scan'``.
-    """
-    from hal0.registry.discover import scan_and_register
 
-    result = scan_and_register(registry, models_cfg)
+    ``prune=True`` also reconciles the registry (:func:`hal0.registry.discover
+    .prune_missing`): rows whose backing file is missing on disk are removed
+    — each firing a ``model.pruned`` event — UNLESS the id is referenced by a
+    slot or stack (:func:`hal0.registry.discover.referenced_model_ids`), in
+    which case it is reported under ``missing_referenced`` for repair rather
+    than deleted. The ``pruned``/``missing_referenced`` result keys are always
+    present (both ``[]`` when ``prune`` is False).
+    """
+    from hal0.registry.discover import referenced_model_ids, scan_and_register
+
+    protected_ids = referenced_model_ids() if prune else set()
+    result = scan_and_register(registry, models_cfg, prune=prune, protected_ids=protected_ids)
     if event_bus is not None:
         for mid in result.get("added", []):
             try:
@@ -457,7 +471,45 @@ async def auto_scan_and_register(
                     "source": "scan",
                 },
             )
+        # Best-effort: surface pruned rows as a distinct event so the UI /
+        # audit trail records the reconcile (mirrors model.registered).
+        for mid in result.get("pruned", []):
+            with contextlib.suppress(Exception):
+                await event_bus.emit(
+                    "model.pruned",
+                    "info",
+                    f"model:{mid}",
+                    f"{mid}: pruned (scan — backing file missing)",
+                    data={"id": mid, "source": "scan"},
+                )
     return result
+
+
+def missing_registry_rows(registry: Any) -> list[dict[str, Any]]:
+    """Registry rows whose backing file is now absent on disk — drift preview.
+
+    Surfaced by ``POST /api/models/scan/preview`` so the operator/UI can see
+    what a ``{"prune": true}`` scan would remove BEFORE committing.
+    ``referenced`` flags rows a slot/stack still points at — those are
+    protected from prune (repair, don't delete); see
+    :func:`hal0.registry.discover.referenced_model_ids`.
+    """
+    from hal0.registry.discover import referenced_model_ids
+
+    missing: list[dict[str, Any]] = []
+    try:
+        referenced = referenced_model_ids()
+        for m in registry.list():
+            try:
+                present = Path(m.path).exists()
+            except OSError:
+                present = False
+            if present:
+                continue
+            missing.append({"id": m.id, "path": m.path, "referenced": m.id in referenced})
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("models.scan_preview_missing_failed err=%s", exc)
+    return missing
 
 
 def preview_scan_rows(

--- a/tests/registry/test_discover.py
+++ b/tests/registry/test_discover.py
@@ -10,6 +10,7 @@ from hal0.config.schema import ModelsConfig
 from hal0.registry.discover import (
     backfill_coordless,
     find_candidates,
+    prune_missing,
     register_candidate,
     scan_and_register,
 )
@@ -448,3 +449,110 @@ def test_scan_and_register_backfills_existing_coordless_row(
     row = registry.get(mid)
     assert row.hf_repo == "Jackrong/Qwopus3.6-27B-Coder-MTP-GGUF"
     assert row.hf_filename == fname
+
+
+# ── prune_missing / reconcile ──────────────────────────────────────────────
+
+
+def test_prune_missing_removes_unprotected_missing_row(
+    tmp_path: Path, registry: ModelRegistry
+) -> None:
+    """A row whose backing file no longer exists and is NOT referenced by any
+    slot/stack is removed from the registry and reported under 'pruned'."""
+    gone = tmp_path / "deleted-model-q4.gguf"
+    gone.write_bytes(b"x" * 64)
+    registry.add(Model(id="gone", path=str(gone.resolve()), capabilities=["chat"]))
+    gone.unlink()  # weights deleted from disk → row is now stale
+
+    result = prune_missing(registry, protected_ids=set())
+    assert result["pruned"] == ["gone"]
+    assert result["missing_referenced"] == []
+    assert result["kept"] == 0
+    assert not registry.has("gone")
+
+
+def test_prune_missing_protects_referenced_missing_row(
+    tmp_path: Path, registry: ModelRegistry
+) -> None:
+    """A row whose file is missing but whose id is in protected_ids is NOT
+    removed — it is reported under 'missing_referenced' for repair instead."""
+    gone = tmp_path / "slot-model-q4.gguf"
+    gone.write_bytes(b"x" * 64)
+    registry.add(Model(id="slot-model", path=str(gone.resolve()), capabilities=["chat"]))
+    gone.unlink()
+
+    result = prune_missing(registry, protected_ids={"slot-model"})
+    assert result["pruned"] == []
+    assert result["missing_referenced"] == ["slot-model"]
+    assert result["kept"] == 0
+    # Still present — functional drift the operator must repair, not delete.
+    assert registry.has("slot-model")
+
+
+def test_prune_missing_leaves_present_rows(tmp_path: Path, registry: ModelRegistry) -> None:
+    """A row whose backing file still exists is untouched and counts as kept —
+    even when its size_bytes metadata is 0 (stale meta is not authoritative)."""
+    live = tmp_path / "live-model-q4.gguf"
+    live.write_bytes(b"x" * 64)
+    # size_bytes intentionally 0 (stale metadata) — must NOT trigger a prune.
+    registry.add(Model(id="live", path=str(live.resolve()), size_bytes=0, capabilities=["chat"]))
+
+    result = prune_missing(registry, protected_ids=set())
+    assert result["pruned"] == []
+    assert result["missing_referenced"] == []
+    assert result["kept"] == 1
+    assert registry.has("live")
+
+
+def test_prune_missing_dry_run_does_not_remove(tmp_path: Path, registry: ModelRegistry) -> None:
+    """dry_run reports what would be pruned without mutating the registry."""
+    gone = tmp_path / "dry-model-q4.gguf"
+    gone.write_bytes(b"x" * 64)
+    registry.add(Model(id="dry", path=str(gone.resolve()), capabilities=["chat"]))
+    gone.unlink()
+
+    result = prune_missing(registry, protected_ids=set(), dry_run=True)
+    assert result["pruned"] == ["dry"]
+    assert registry.has("dry")  # unchanged
+
+
+def test_scan_and_register_prune_true_prunes_and_returns_new_keys(
+    tmp_path: Path, registry: ModelRegistry
+) -> None:
+    """scan_and_register(prune=True) folds prune results into its return under
+    'pruned'/'missing_referenced' and removes the unprotected stale row."""
+    root = tmp_path / "models"
+    root.mkdir()
+    # A live model that stays registered on-disk.
+    live = root / "qwen3-4b-instruct-q4_k_m.gguf"
+    live.write_bytes(b"y" * 128)
+    # A stale row whose file was deleted.
+    gone = root / "old-model-q4.gguf"
+    gone.write_bytes(b"z" * 64)
+    registry.add(Model(id="stale", path=str(gone.resolve()), capabilities=["chat"]))
+    gone.unlink()
+
+    cfg = ModelsConfig(roots=[str(root)])
+    result = scan_and_register(registry, cfg, prune=True, protected_ids=set())
+    assert "pruned" in result and "missing_referenced" in result
+    assert result["pruned"] == ["stale"]
+    assert result["missing_referenced"] == []
+    assert not registry.has("stale")
+
+
+def test_scan_and_register_default_does_not_prune(tmp_path: Path, registry: ModelRegistry) -> None:
+    """Default (prune=False) never removes stale rows and returns empty
+    'pruned'/'missing_referenced' so the return shape stays stable."""
+    root = tmp_path / "models"
+    root.mkdir()
+    gone = root / "old-model-q4.gguf"
+    gone.write_bytes(b"z" * 64)
+    registry.add(Model(id="stale", path=str(gone.resolve()), capabilities=["chat"]))
+    gone.unlink()
+
+    cfg = ModelsConfig(roots=[str(root)])
+    result = scan_and_register(registry, cfg)
+    assert result["pruned"] == []
+    assert result["missing_referenced"] == []
+    # Stale row is left alone — add-only behavior preserved by default.
+    assert registry.has("stale")


### PR DESCRIPTION
## Root cause — registry ↔ disk drift

`scan_and_register()` in `src/hal0/registry/discover.py` was **add-only**: it built a `known_paths` set from existing registry rows and only registered *new* candidate files. It never checked whether existing rows still pointed at files that exist. So when model weights were deleted from disk, their rows in `registry.toml` became permanently stale — the model list drifted from reality, with no reconcile/prune path. (This is the "0-byte / dead-file" audit pain seen in the catalogue cleanup notes.)

## What this adds — opt-in prune/reconcile

- **`prune_missing(registry, *, protected_ids, dry_run=False)`** — removes rows whose backing `Path(m.path)` no longer exists. `p.exists()` is authoritative; `size_bytes==0` is *not* treated as missing (stale metadata, weights may still be on disk). Returns `{"pruned": [...], "missing_referenced": [...], "kept": int}`.
- **Slot/stack protection** — a missing row whose id is in `protected_ids` is **never deleted**; it is reported under `missing_referenced` as functional drift that needs a *repair*, not a deletion.
- **`referenced_model_ids()`** — unions the ids referenced by any configured **slot** (`SlotConfig.model.default`), any live **capability** child selection (`[selections.<slot>.<child>].model`), and any **stack** (reuses `stacks.portable._referenced_model_ids` over `StacksCatalog().list()` — slot primaries + capability rows). Every per-slot / per-stack / per-config load is wrapped defensively so one malformed config can't break the scan.
- **`scan_and_register(..., prune=False, protected_ids=None)`** — after the add loop, optionally runs `prune_missing` and folds results into the return under `pruned` / `missing_referenced`. Both keys are always present (`[]` when `prune=False`) so the return shape is stable; existing `added`/`backfilled`/`skipped`/`scanned_roots` keys are unchanged.

## Wiring

- **`POST /api/models/scan`** — legacy/auto branch reads `bool(body.get("prune", False))`, computes `protected_ids = referenced_model_ids()` when pruning, passes them through, and emits a best-effort `model.pruned` event per pruned id (mirrors `model.registered`).
- **`POST /api/models/scan/preview`** — now also returns a `"missing"` list (`{id, path, referenced}`) so the UI/operator can see drift *before* committing a prune. Existing `preview`/`count` keys intact.
- **MCP `model_scan`** — generic passthrough already forwards the JSON body, so `{"prune": true}` reaches the route. Added an optional `prune` boolean to `TOOL_PARAM_HINTS` + updated the tool description and the `AUTONOMOUS_WRITE_TOOLS` comment that claimed it "only ADDS".

## Tests

Added 6 tests in `tests/registry/test_discover.py`: prune removes an unprotected missing row; protects a referenced missing row (reports it in `missing_referenced`); leaves present rows (incl. `size_bytes==0`) untouched; `dry_run` doesn't mutate; `scan_and_register(prune=True)` prunes and returns the new keys; default (`prune=False`) does not prune and returns empty keys.

`tests/registry/` + `tests/mcp/` (372 passed, 1 skipped), `tests/api/test_models_scan.py` + `test_models_routes.py` (27 passed), `tests/stacks/` + `tests/capabilities/` (150 passed), and `ruff check` on changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)