### PR TITLE
feat(models): HF update-check basename fallback + a11y + e2e coverage

### DIFF
--- a/src/hal0/registry/update_check.py
+++ b/src/hal0/registry/update_check.py
@@ -140,7 +140,7 @@ def evaluate_model_update(
     if remote_sha is None:
         # Exact repo-relative path missed — fall back to a UNIQUE basename
         # match. A row whose stored hf_filename dropped the upstream subdir
-        # prefix (hand-registered rows, legacy imports) would otherwise
+        # prefix (hand-registered or path-added rows) would otherwise
         # silently never flag even though the file is right there under
         # ``<quant>/<file>``. Guarded on a single distinct sha so an
         # ambiguous basename (the same filename under two quant dirs) is

--- a/src/hal0/registry/update_check.py
+++ b/src/hal0/registry/update_check.py
@@ -138,6 +138,18 @@ def evaluate_model_update(
         return verdict
     remote_sha = files.get(filename)
     if remote_sha is None:
+        # Exact repo-relative path missed — fall back to a UNIQUE basename
+        # match. A row whose stored hf_filename dropped the upstream subdir
+        # prefix (hand-registered rows, legacy imports) would otherwise
+        # silently never flag even though the file is right there under
+        # ``<quant>/<file>``. Guarded on a single distinct sha so an
+        # ambiguous basename (the same filename under two quant dirs) is
+        # left unresolved rather than compared against the wrong variant.
+        base = filename.rsplit("/", 1)[-1]
+        candidates = {sha for path, sha in files.items() if path.rsplit("/", 1)[-1] == base}
+        if len(candidates) == 1:
+            remote_sha = next(iter(candidates))
+    if remote_sha is None:
         # File renamed/removed upstream, or a non-LFS object (no sha256).
         verdict["reason"] = "file_missing_or_not_lfs"
         return verdict

--- a/tests/registry/test_update_check.py
+++ b/tests/registry/test_update_check.py
@@ -110,6 +110,31 @@ def test_evaluate_no_local_sha_never_flags_update() -> None:
     assert verdict["remote_sha256"] == SHA_B
 
 
+def test_evaluate_basename_fallback_resolves_subdir_hosted_file() -> None:
+    """A row whose stored hf_filename dropped the upstream subdir prefix
+    still resolves via a unique basename match, so it isn't a false negative."""
+    verdict = evaluate_model_update(
+        _model(),  # hf_filename="qwen3-4b.gguf" (bare)
+        {"Qwen/Qwen3-4B-GGUF": {"UD-Q4_K_XL/qwen3-4b.gguf": SHA_B}},
+    )
+    assert verdict is not None
+    assert verdict["update_available"] is True
+    assert verdict["remote_sha256"] == SHA_B
+
+
+def test_evaluate_basename_fallback_skips_ambiguous_match() -> None:
+    """When two tree files share the basename with DIFFERENT shas, the
+    fallback must not guess — leave it unresolved rather than compare
+    against the wrong quant."""
+    verdict = evaluate_model_update(
+        _model(),
+        {"Qwen/Qwen3-4B-GGUF": {"a/qwen3-4b.gguf": SHA_A, "b/qwen3-4b.gguf": SHA_B}},
+    )
+    assert verdict is not None
+    assert verdict["update_available"] is False
+    assert verdict["reason"] == "file_missing_or_not_lfs"
+
+
 # ── fetch_remote_lfs_shas ────────────────────────────────────────────────────
 
 

--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -53,7 +53,20 @@ function buildSlots() {
 }
 
 function buildModels() {
-  return { models: data().models ?? [] }
+  // Forced mock can't be page.route-overridden for /api/models, so a spec
+  // opts into HF-update badges via `window.__hal0MockModelUpdates.availableIds`
+  // (mirrors the __hal0MockMemoryEnabled pattern). Absent → no badges, exactly
+  // as before, so unrelated specs are unaffected.
+  const ov =
+    typeof window !== 'undefined'
+      ? (window as unknown as { __hal0MockModelUpdates?: { availableIds?: string[] } })
+          .__hal0MockModelUpdates
+      : undefined
+  const availableIds = new Set(ov?.availableIds ?? [])
+  const models = (data().models ?? []).map((m: any) =>
+    availableIds.has(m.id) ? { ...m, update_available: true } : m,
+  )
+  return { models }
 }
 
 function buildBackends() {
@@ -339,7 +352,34 @@ function buildUpdateState() {
 // renders without hammering the (absent) backend with 500-retries. A live
 // backend or a page.route override stays authoritative via networkFirst.
 function buildModelUpdatesCheck() {
-  return { checked_at: 0, checked: 0, updates_available: 0, models: {} }
+  // Mirrors buildModels' opt-in: a spec sets availableIds (+ optional
+  // checked_at) to exercise the "last checked / N available" surface.
+  const ov =
+    typeof window !== 'undefined'
+      ? (
+          window as unknown as {
+            __hal0MockModelUpdates?: { availableIds?: string[]; checked_at?: number }
+          }
+        ).__hal0MockModelUpdates
+      : undefined
+  const ids = ov?.availableIds ?? []
+  const models: Record<string, unknown> = {}
+  for (const id of ids) {
+    models[id] = {
+      hf_repo: 'org/repo',
+      hf_filename: `${id}.gguf`,
+      local_sha256: 'a'.repeat(64),
+      remote_sha256: 'b'.repeat(64),
+      update_available: true,
+      reason: null,
+    }
+  }
+  return {
+    checked_at: ov?.checked_at ?? 0,
+    checked: ids.length,
+    updates_available: ids.length,
+    models,
+  }
 }
 
 function buildAuthToken() {

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -524,7 +524,7 @@ function ModelRow({ model, selected, onSelect }) {
           : !model.installed
             ? <span className="chip" style={{color: model.ns === "blessed" ? "var(--accent)" : "var(--fg-3)", borderColor: model.ns === "blessed" ? "var(--accent-line)" : "var(--line)", background: model.ns === "blessed" ? "var(--accent-soft)" : "transparent"}}>{model.ns}</span>
             : model.update_available
-              ? <span className="chip amber" data-testid="mdl-row-update" title="A newer version of this file is available on Hugging Face">update ↑</span>
+              ? <span className="chip amber" data-testid="mdl-row-update" role="status" aria-label="Update available on Hugging Face" title="A newer version of this file is available on Hugging Face">update ↑</span>
               : null}
       </span>
     </div>
@@ -598,7 +598,7 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
           <div className="nm mono">{model.longName || model.name || model.id}</div>
           <span style={{marginLeft: "auto", display: "inline-flex", gap: 6}}>
             {model.installed && model.update_available && (
-              <span className="chip amber" title="A newer version of this file is available on Hugging Face">update available</span>
+              <span className="chip amber" data-testid="mdl-detail-update-badge" role="status" aria-label="Update available on Hugging Face" title="A newer version of this file is available on Hugging Face">update available</span>
             )}
             {model.installed
               ? <span className="chip ok">installed</span>

--- a/ui/tests/e2e/specs/model-updates-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-updates-v3.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * model-updates-v3 — HF model-update surface on the `#models` catalog.
+ *
+ * Covers the merged feature (per-row badge, Update-all, per-model detail
+ * Update) plus the follow-up "Check updates" control (last-checked +
+ * manual re-check + in-flight state).
+ *
+ * Forced-mock (VITE_MOCK_HAL0) short-circuits page.route for /api/models,
+ * so update badges are driven via `window.__hal0MockModelUpdates` — the
+ * mock's buildModels + buildModelUpdatesCheck honour it (mirrors the
+ * __hal0MockMemoryEnabled pattern). `/api/models/{id}/update` is a POST and
+ * is NOT allowlisted, so it reaches page.route normally.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+// An installed model id from the forced-mock HAL0_DATA catalog (dash/data.jsx).
+const STALE_ID = 'qwen3.6-27b-mtp'
+
+test.describe('Model updates (/models)', () => {
+  test('no badge or Update-all button when everything is fresh', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-list')).toBeVisible()
+    await expect(page.locator('[data-testid="mdl-update-all"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="mdl-row-update"]')).toHaveCount(0)
+    // The "Check updates" control is always present, regardless of staleness.
+    await expect(page.locator('[data-testid="mdl-check-updates"]')).toBeVisible()
+  })
+
+  test.describe('with one stale model', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.addInitScript((id) => {
+        ;(window as unknown as { __hal0MockModelUpdates?: unknown }).__hal0MockModelUpdates = {
+          availableIds: [id],
+          checked_at: Math.floor(Date.now() / 1000) - 120, // 2 min ago
+        }
+      }, STALE_ID)
+    })
+
+    test('stale model shows a row badge and the Update-all button', async ({ page }) => {
+      await page.goto('/#models')
+      await expect(page.locator('.mdl-list')).toBeVisible()
+      const btn = page.locator('[data-testid="mdl-update-all"]')
+      await expect(btn).toBeVisible()
+      await expect(btn).toContainText('Update all (1)')
+      await expect(page.locator('[data-testid="mdl-row-update"]')).toHaveCount(1)
+    })
+
+    test('Update-all POSTs /api/models/{id}/update for the stale model', async ({ page }) => {
+      const posted: string[] = []
+      await page.route('**/api/models/*/update', (route) => {
+        posted.push(new URL(route.request().url()).pathname)
+        return route.fulfill({ status: 202, contentType: 'application/json', body: '{}' })
+      })
+      await page.goto('/#models')
+      await page.locator('[data-testid="mdl-update-all"]').click()
+      await expect.poll(() => posted).toContain(`/api/models/${STALE_ID}/update`)
+    })
+
+    test('detail pane exposes a per-model Update action', async ({ page }) => {
+      await page.goto('/#models')
+      // Select the stale row so the detail pane targets it.
+      await page.locator('[data-testid="mdl-row-update"]').first().click()
+      await expect(page.locator('[data-testid="mdl-detail-update"]')).toBeVisible()
+    })
+  })
+
+  test('Check-updates button re-probes with ?refresh=1 and shows a pending state', async ({ page }) => {
+    let refreshed = false
+    // Gate the refresh so the "Checking…" pending state is observable.
+    let release: () => void = () => {}
+    const gate = new Promise<void>((r) => (release = r))
+    await page.route('**/api/models/updates/check?refresh=1', async (route) => {
+      refreshed = true
+      await gate
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ checked_at: Math.floor(Date.now() / 1000), checked: 3, updates_available: 0, models: {} }),
+      })
+    })
+    await page.goto('/#models')
+    const btn = page.locator('[data-testid="mdl-check-updates"]')
+    await expect(btn).toBeVisible()
+    await btn.click()
+    await expect(btn).toContainText('Checking…')
+    await expect(btn).toBeDisabled()
+    release()
+    await expect.poll(() => refreshed).toBe(true)
+    await expect(btn).toContainText('Check updates')
+  })
+})


### PR DESCRIPTION
## What & why

Follow-up hardening on top of the merged HF model-update feature. Originally this PR also added a "Check updates" force-recheck button — but a parallel PR landed that on `main` first (`useModelUpdatesForceCheck`), so this has been **rebased onto main and reduced to only what main still lacks**.

## Changes

**Backend — basename fallback (`registry/update_check.py`)**
- `evaluate_model_update` matched the stored `hf_filename` against tree paths by exact repo-relative path only. A row whose coordinate dropped the upstream subdir prefix (`model.gguf` vs the real `UD-Q4_K_XL/model.gguf`) — common for hand-registered/legacy rows — silently reported `file_missing_or_not_lfs` and never flagged.
- Now falls back to a **unique basename match**, guarded on a single distinct sha so an ambiguous basename (same filename under two quant dirs) is left unresolved rather than compared against the wrong variant.

**Frontend a11y (`dash/models.jsx`)**
- `role="status"` + `aria-label` on the row and detail update badges (a bare `title` isn't reliably announced by screen readers); added a `data-testid` to the detail badge.

**Test harness (`api/mock.ts`)**
- `buildModels` + `buildModelUpdatesCheck` honour `window.__hal0MockModelUpdates` so specs can drive update badges under forced-mock (mirrors the existing `__hal0MockMemoryEnabled` pattern). Absent → behaviour unchanged, so unrelated specs are unaffected.

## Tests
- **registry:** unique basename fallback resolves; ambiguous basename does not.
- **e2e `model-updates-v3`:** badge + Update-all gating, per-model detail Update, Update-all POSTs `/{id}/update`, and the existing Check-updates refresh + pending state. Fills the feature's previously **zero** frontend coverage.
- Local: backend `pytest`/`ruff`/`ruff format` green; UI `tsc` + the new e2e spec (5) green.

## Deliberately out of scope (candidate follow-ups)
Non-`main` default-branch repos, HF tree pagination for very large repos, 429 backoff, and refreshing an `mmproj` vision companion on update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JUyAmsZs6eFRJNij7UBZx