### PR TITLE
feat(models): UI-API-1 — close the managed-arg gap (launch + create + /validate)

### DIFF
--- a/src/hal0/api/routes/models.py
+++ b/src/hal0/api/routes/models.py
@@ -300,6 +300,11 @@ async def create_model(request: Request) -> dict[str, Any]:
     # Pop ``source`` before validation — it's an event-only tag, not a
     # Model field. Default to "manual" for hand-registered single files.
     source = body.pop("source", "manual")
+    # Screen launch-affecting fields at CREATE time too (UI-API-1 item 1): PUT
+    # already screened, but create wrote straight to the registry, so a row
+    # born with an extra_args that smuggles --port/--model/… would only fail at
+    # launch (or silently rebind the slot). Same helper the PUT/validate paths use.
+    _svc.screen_model_write(body, runner_images=_RUNNER_IMAGES)
     try:
         model = Model(**body)
     except (TypeError, ValueError) as exc:
@@ -321,6 +326,29 @@ async def create_model(request: Request) -> dict[str, Any]:
             },
         )
     return _model_to_dict(model)
+
+
+@router.post("/validate")
+async def validate_model_write(request: Request) -> dict[str, Any]:
+    """Dry-run screen of a model create/edit body — no registry write (UI-API-1).
+
+    The dashboard's Model drawer POSTs a candidate ``{defaults, preferred_runner}``
+    here before saving, so a managed-arg smuggle (e.g. ``--port`` in
+    ``defaults.extra_args``) or an unknown ``preferred_runner`` is surfaced inline
+    instead of only at the eventual save (or, worse, at launch). Returns
+    ``{"ok": true}`` on a clean body; a violation raises the SAME typed envelope
+    (``slot.managed_arg_denied`` / ``model.extra_args_unparseable`` /
+    ``model.extra_args_json_quoting`` / ``model.unknown_runner``) the create and
+    PUT paths raise, so the drawer renders one error path.
+    """
+    try:
+        body = await request.json()
+    except Exception as exc:
+        raise BadRequest("body must be valid JSON", details={"error": str(exc)}) from exc
+    if not isinstance(body, dict):
+        raise BadRequest("body must be a JSON object")
+    _svc.screen_model_write(body, runner_images=_RUNNER_IMAGES)
+    return {"ok": True}
 
 
 @router.get("/pulls")
@@ -549,42 +577,12 @@ async def update_model(model_id: str, request: Request) -> dict[str, Any]:
     if not isinstance(body, dict):
         raise BadRequest("body must be a JSON object")
 
-    # Validate a writable ``preferred_runner`` (UI-API-1 item 2): the field is
-    # a key into hal0.runners.RUNNER_IMAGES. Reject an unknown key at SAVE time
-    # so the drawer's runner-override dropdown can never persist a value the
-    # launcher would silently skip. ``None``/"" clears the preference (valid).
-    if "preferred_runner" in body:
-        pr = body["preferred_runner"]
-        if pr is not None and (not isinstance(pr, str) or pr not in _RUNNER_IMAGES):
-            raise BadRequest(
-                f"preferred_runner {pr!r} is not a known runner key",
-                code="model.unknown_runner",
-                details={"preferred_runner": pr, "available": sorted(_RUNNER_IMAGES)},
-            )
-
-    # Screen defaults.extra_args against the managed-arg denylist at SAVE
-    # time. Launch already rejects loudly (slot.managed_arg_denied), so this
-    # is defense-in-depth/UX for non-dashboard clients: fail the write with
-    # the same envelope instead of persisting a tune that can never load.
-    defaults = body.get("defaults")
-    if isinstance(defaults, dict) and isinstance(defaults.get("extra_args"), str):
-        import shlex
-
-        from hal0.slots.argv import _deny_managed_flags
-
-        # O10 guard (spec §3 JSON-token integrity): catch a bare double-quoted
-        # JSON value the shell would eat BEFORE the denylist/parse checks so
-        # the operator gets the actionable "single-quote it" message.
-        _svc.screen_extra_args_json(defaults["extra_args"], segment="model defaults.extra_args")
-
-        try:
-            tokens = shlex.split(defaults["extra_args"])
-        except ValueError as exc:
-            raise BadRequest(
-                f"defaults.extra_args is not parseable as a flag string: {exc}",
-                code="model.extra_args_unparseable",
-            ) from exc
-        _deny_managed_flags(tokens, segment="model defaults.extra_args")
+    # Validate the launch-affecting fields (preferred_runner + defaults.extra_args)
+    # at SAVE time (UI-API-1 items 1/2). Shared with create + /validate so the
+    # three paths never drift; screens preferred_runner against RUNNER_IMAGES and
+    # defaults.extra_args against the managed-arg denylist (fails the write with
+    # the same envelope the launch path raises).
+    _svc.screen_model_write(body, runner_images=_RUNNER_IMAGES)
 
     # Snapshot the pre-update model so we can diff the field set the
     # client actually changed (vs the wire-format keys, which may include

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -817,14 +817,23 @@ def _llama_argv_segments(
     # Model-registry defaults: shlex-split extra_args + `-ngl <n>` from
     # defaults.n_gpu_layers. rope_freq_base is intentionally NOT emitted
     # (reachable via extra_args only — see ModelDefaults deprecation note).
-    md_tokens: list[str] = []
+    #
+    # The free-form ``defaults.extra_args`` is caller-supplied, so it rides its
+    # own ``model_extra_args`` segment which ``resolve_argv`` screens against
+    # the managed-arg denylist (argv.UNTRUSTED_SEGMENT_LABELS) — a model whose
+    # extra_args smuggles ``--port``/``--model``/… fails loudly at launch, not
+    # silently redirected. The ``-ngl`` derived from the schema field
+    # ``defaults.n_gpu_layers`` is hal0-computed and legitimately sets a managed
+    # flag, so it stays in the TRUSTED ``model_defaults`` segment.
+    md_extra_tokens: list[str] = []
+    md_ngl_tokens: list[str] = []
     if model_defaults:
         md_extra = model_defaults.get("extra_args")
         if md_extra and str(md_extra).strip():
-            md_tokens += shlex.split(str(md_extra))
+            md_extra_tokens += shlex.split(str(md_extra))
         md_ngl = model_defaults.get("n_gpu_layers")
         if md_ngl is not None:
-            md_tokens += ["-ngl", str(int(md_ngl))]
+            md_ngl_tokens += ["-ngl", str(int(md_ngl))]
 
     chat_tokens = ["--chat-template-file", chat_template_path] if chat_template_path else []
     mmproj_tokens = ["--mmproj", mmproj] if mmproj else []
@@ -850,7 +859,8 @@ def _llama_argv_segments(
     return [
         ("base", base),
         ("profile", profile_tokens),
-        ("model_defaults", md_tokens),
+        ("model_extra_args", md_extra_tokens),
+        ("model_defaults", md_ngl_tokens),
         ("chat_template", chat_tokens),
         ("mmproj", mmproj_tokens),
         ("slot_overrides", slot_override_tokens),

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1128,6 +1128,54 @@ def screen_extra_args_json(raw: str, *, segment: str = "extra_args") -> None:
             ) from None
 
 
+def screen_model_write(body: dict[str, Any], *, runner_images: Any = None) -> None:
+    """Validate the launch-affecting fields of a model create/update/validate body.
+
+    Raises :class:`~hal0.errors.BadRequest` on the first violation, with the same
+    envelope the launch path and the dashboard key on. Shared by
+    ``POST /api/models``, ``PUT /api/models/{id}`` and ``POST /api/models/validate``
+    so the three can never drift (UI-API-1 item 1). Screens:
+
+    * ``preferred_runner`` — must be a known ``RUNNER_IMAGES`` key, or ``None``/""
+      to clear the preference. Only checked when ``runner_images`` is supplied.
+    * ``defaults.extra_args`` — shell-quoting integrity (O10) then the managed-arg
+      denylist (§21.7), so a smuggled ``--model``/``--host``/``--port``/
+      ``--ctx-size``/``-ngl``/``--alias`` fails at SAVE with the same
+      ``slot.managed_arg_denied`` code the launcher raises, instead of persisting
+      a row that can never load (or silently rebinds a slot).
+    """
+    from hal0.errors import BadRequest
+
+    if runner_images is not None and "preferred_runner" in body:
+        pr = body["preferred_runner"]
+        if pr is not None and (not isinstance(pr, str) or pr not in runner_images):
+            raise BadRequest(
+                f"preferred_runner {pr!r} is not a known runner key",
+                code="model.unknown_runner",
+                details={"preferred_runner": pr, "available": sorted(runner_images)},
+            )
+
+    defaults = body.get("defaults")
+    if isinstance(defaults, dict) and isinstance(defaults.get("extra_args"), str):
+        import shlex
+
+        from hal0.slots.argv import _deny_managed_flags
+
+        seg = "model defaults.extra_args"
+        # O10 guard (spec §3): catch a bare double-quoted JSON value the shell
+        # would eat BEFORE the denylist/parse checks so the operator gets the
+        # actionable "single-quote it" message.
+        screen_extra_args_json(defaults["extra_args"], segment=seg)
+        try:
+            tokens = shlex.split(defaults["extra_args"])
+        except ValueError as exc:
+            raise BadRequest(
+                f"defaults.extra_args is not parseable as a flag string: {exc}",
+                code="model.extra_args_unparseable",
+            ) from exc
+        _deny_managed_flags(tokens, segment=seg)
+
+
 # ── duplicate a model row (UI-API-1 item 3) ───────────────────────────────────
 #
 # Study note (spec deliverable): a model's *weights* live on disk at

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -100,11 +100,15 @@ MANAGED_ARGS_DENYLIST: frozenset[str] = frozenset(
 
 # Segment labels whose tokens are free-form / caller-supplied rather than
 # hal0-computed, and therefore must be screened against
-# ``MANAGED_ARGS_DENYLIST`` before they're merged in. Currently just
-# ``[server].extra_args`` (``container._llama_argv_segments``' last segment);
-# a future request-level ``llamacpp_args`` segment (§7.1a 5-tier precedence
+# ``MANAGED_ARGS_DENYLIST`` before they're merged in:
+#   * ``extra_args``       — a slot's ``[server].extra_args``.
+#   * ``model_extra_args`` — a model's ``defaults.extra_args`` (the registry
+#     row's free-form launcher flags; NOT the schema-computed ``-ngl`` from
+#     ``defaults.n_gpu_layers``, which rides the trusted ``model_defaults``
+#     segment — see ``container._llama_argv_segments``).
+# A future request-level ``llamacpp_args`` segment (§7.1a 5-tier precedence
 # rewrite) adds its own label here so it rides the same guard.
-UNTRUSTED_SEGMENT_LABELS: frozenset[str] = frozenset({"extra_args"})
+UNTRUSTED_SEGMENT_LABELS: frozenset[str] = frozenset({"extra_args", "model_extra_args"})
 
 
 @dataclass(frozen=True)

--- a/tests/api/test_models_crud.py
+++ b/tests/api/test_models_crud.py
@@ -414,6 +414,67 @@ def test_put_single_quoted_json_extra_args_accepted(
     assert r.json()["defaults"]["extra_args"] == good
 
 
+# ── Deliverable 1: create screens too, + dry-run /validate ────────────────────
+
+
+def test_create_screens_managed_extra_args(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    """POST create screens defaults.extra_args like PUT does — a smuggled
+    managed flag fails the write instead of persisting a row that rebinds a
+    slot at launch."""
+    fpath = crud_models_root / "cs1.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post(
+        "/api/models",
+        json={
+            "id": "cs1",
+            "path": str(fpath),
+            "defaults": {"extra_args": "--flash-attn on --port 9"},
+        },
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+    # And nothing was written.
+    assert crud_client.get("/api/models/cs1").status_code == 404
+
+
+def test_create_screens_unknown_preferred_runner(
+    crud_client: TestClient,
+    crud_models_root: Path,
+) -> None:
+    fpath = crud_models_root / "cs2.gguf"
+    fpath.write_bytes(b"\x00" * 16)
+    r = crud_client.post(
+        "/api/models",
+        json={"id": "cs2", "path": str(fpath), "preferred_runner": "does-not-exist"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "model.unknown_runner"
+
+
+def test_validate_accepts_clean_body(crud_client: TestClient) -> None:
+    r = crud_client.post(
+        "/api/models/validate",
+        json={"defaults": {"extra_args": "-b 8192 --flash-attn on"}, "preferred_runner": "cpu"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ok"] is True
+
+
+def test_validate_rejects_managed_extra_args_without_writing(crud_client: TestClient) -> None:
+    """/validate is a dry run: it screens with the same envelope as create/PUT
+    and never touches the registry (no id required, nothing persisted)."""
+    r = crud_client.post(
+        "/api/models/validate",
+        json={"id": "should-not-persist", "defaults": {"extra_args": "--model /etc/passwd"}},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+    assert crud_client.get("/api/models/should-not-persist").status_code == 404
+
+
 # ── Deliverable 3: duplicate-model endpoint ────────────────────────────────────
 
 

--- a/tests/golden_paths/test_gp05_stamped_launch_layering.py
+++ b/tests/golden_paths/test_gp05_stamped_launch_layering.py
@@ -6,9 +6,9 @@ post-stamp, because the model's materialized flags text is the whole tune.
 
 The CURRENT launch path does NOT yet satisfy that: by the ML-5 design the
 llama-server argv still layers a live ``profile`` segment (from a live profile
-resolve) UNDER the model's ``model_defaults`` segment — see
+resolve) UNDER the model's stamped ``model_extra_args`` segment — see
 ``hal0.providers.container._llama_argv_segments``' documented precedence
-``base < profile < model_defaults < … < extra_args``. This increment is the
+``base < profile < model_extra_args < model_defaults < … < extra_args``. This increment is the
 ADDITIVE backend (increment 1); ripping out the profile layer is increment-2
 migration-window work.
 
@@ -23,7 +23,7 @@ Increment-2 work items (delta from the §7 target):
      container load path (image resolution stays; flag layering goes).
   3. Delete the slot ``slot_overrides``/``extra_args`` flag segments per §2.
   4. Flip THIS test to assert the ``profile`` segment is absent / empty and the
-     stamped ``model_defaults`` text is the sole tune source.
+     stamped ``model_extra_args`` text is the sole tune source.
 """
 
 from __future__ import annotations
@@ -68,12 +68,16 @@ def test_stamped_model_still_layers_a_live_profile_segment_at_launch() -> None:
     # profile participated at launch, not just the stamp).
     prov = {p.flag: p.source for p in resolved.provenance}
     assert prov.get("-fa") == "profile"
-    assert prov.get("-b") == "model_defaults"
+    # The stamped tune's -b comes from the model's free-form extra_args, which
+    # now rides its own screened ``model_extra_args`` segment (split out from
+    # ``model_defaults`` — see slots.argv.UNTRUSTED_SEGMENT_LABELS). -b is not a
+    # managed flag, so it passes screening; precedence is unchanged.
+    assert prov.get("-b") == "model_extra_args"
 
 
 def test_stamped_model_defaults_win_over_profile_on_flag_collision() -> None:
     """When the stamp and the live profile set the SAME flag, the model tune
-    wins (``model_defaults`` sits above ``profile`` in the precedence chain) —
+    wins (``model_extra_args`` sits above ``profile`` in the precedence chain) —
     the closest current behaviour gets to 'the model owns its tune'."""
     segments = _llama_argv_segments(
         port=8081,
@@ -86,4 +90,4 @@ def test_stamped_model_defaults_win_over_profile_on_flag_collision() -> None:
     idx = resolved.argv.index("-b")
     assert resolved.argv[idx + 1] == "2048"
     prov = {p.flag: p.source for p in resolved.provenance}
-    assert prov.get("-b") == "model_defaults"
+    assert prov.get("-b") == "model_extra_args"

--- a/tests/providers/test_capability_injection.py
+++ b/tests/providers/test_capability_injection.py
@@ -126,12 +126,17 @@ def test_slot_mtp_true_forces_bundle_even_on_cuda():
 
 
 def test_precedence_chain_ngl_slot_beats_everything():
-    """-ngl set at profile, model_defaults (via family + extra_args), and
+    """-ngl set at profile, model_defaults (via the n_gpu_layers field), and
     slot [model].n_gpu_layers all disagree -- the slot override must win in
-    the final resolved argv (normalize_argv/resolve_argv last-wins)."""
+    the final resolved argv (normalize_argv/resolve_argv last-wins).
+
+    The model tier sets -ngl via the schema field ``n_gpu_layers`` (trusted
+    ``model_defaults`` segment), NOT via ``extra_args``: ``-ngl`` is a managed
+    flag, so a model ``extra_args`` carrying it is now rejected at launch just
+    like a slot's ``[server].extra_args`` (see test_argv.py)."""
     profile = _rocm_profile(flags="-ngl 10 -fa on")
     model = _plain_model(
-        defaults={"extra_args": "-ngl 20", "n_gpu_layers": None},
+        defaults={"extra_args": "", "n_gpu_layers": 20},
         architecture="gemma3",  # exercises the family-defaults tier too
     )
     slot_cfg = {"name": "s", "model": {"n_gpu_layers": 30}}

--- a/tests/providers/test_container_resolved_detail.py
+++ b/tests/providers/test_container_resolved_detail.py
@@ -40,8 +40,11 @@ def test_detail_dedups_and_attributes_provenance() -> None:
     assert prov["-b"]["source"] == "extra_args"
     assert prov["-b"]["value"] == "8192"
     # --jinja is the default-on runner capability injection (§7.1a / ML-5) —
-    # it lands in the model_defaults segment now, not the profile segment.
-    assert prov["--jinja"]["source"] == "model_defaults"
+    # it's folded into the model-defaults extra_args string, which now rides
+    # its own ``model_extra_args`` segment (split out from ``model_defaults`` so
+    # a user's free-form model extra_args is screened against the managed-arg
+    # denylist at launch; --jinja is not managed, so it passes through).
+    assert prov["--jinja"]["source"] == "model_extra_args"
     assert prov["--jinja"]["value"] is None
     # base-segment structural flags are credited to "base"
     assert prov["--model"]["source"] == "base"

--- a/tests/slots/test_argv.py
+++ b/tests/slots/test_argv.py
@@ -356,6 +356,27 @@ def test_resolve_argv_only_screens_untrusted_labels() -> None:
     assert "-ngl" in res.argv
 
 
+def test_resolve_argv_screens_model_extra_args_segment() -> None:
+    """A model's free-form ``defaults.extra_args`` (the ``model_extra_args``
+    segment) is caller-supplied, so a managed flag smuggled through it must be
+    rejected at launch — the gap where an ``extra_args`` with ``--port`` reached
+    the container only because the model-defaults segment wasn't screened."""
+    segments = [*_BASE_SEGMENTS, ("model_extra_args", ["--flash-attn", "on", "--port", "9999"])]
+    with pytest.raises(BadRequest) as exc_info:
+        resolve_argv(segments)
+    assert exc_info.value.code == "slot.managed_arg_denied"
+    assert "--port" in exc_info.value.message
+
+
+def test_resolve_argv_does_not_screen_trusted_model_defaults_ngl() -> None:
+    """The ``-ngl`` hal0 computes from the schema field ``defaults.n_gpu_layers``
+    rides the trusted ``model_defaults`` segment and must NOT be rejected, even
+    though ``--n-gpu-layers`` is a managed flag."""
+    segments = [*_BASE_SEGMENTS, ("model_defaults", ["-ngl", "20"])]
+    res = resolve_argv(segments)  # must not raise
+    assert "-ngl" in res.argv
+
+
 def test_managed_args_denylist_covers_expected_flags() -> None:
     expected = frozenset({"--model", "--ctx-size", "--host", "--port", "--n-gpu-layers", "--alias"})
     assert expected == MANAGED_ARGS_DENYLIST


### PR DESCRIPTION
## What & why

R5 lane **UI-API-1 item 1** — the backend affordance the UI-D1-D3 Model drawer flagged: managed-arg validation. The board suspected a live gap; I confirmed one **worse than the note** (an `extra_args` that smuggles `--port` bypassed *both* save and launch), and closed it end-to-end. Items 2 (`preferred_runner`) and 3 (`/duplicate`) were already on `main`, so this is scoped to what remained.

## The gap (confirmed on current main)

- `create_model` (POST) wrote straight to the registry with **zero** screening (PUT already screened).
- At launch, a model's free-form `defaults.extra_args` rode the `model_defaults` argv segment, which `resolve_argv` did **not** screen — only the slot's `[server].extra_args` was in `UNTRUSTED_SEGMENT_LABELS`. So a `--port`/`--model`/`--host`/`--alias`/`--ctx-size` in a model's extra_args reached the container and could silently rebind/redirect a slot.

## Changes

**A — launch-path (`slots/argv.py`, `providers/container.py`)**
Split the argv segment: the free-form model extra_args now rides its own `model_extra_args` segment (screened against the managed-arg denylist at launch, matching slot extra_args), while the hal0-computed `-ngl` from the `defaults.n_gpu_layers` schema field stays in the trusted `model_defaults` segment (it legitimately sets a managed flag). Family/`--jinja` capability flags fold into the model extra_args string and pass screening (not managed). Closes the bypass for **all** rows regardless of write path (create, HF-pull seeding, hand-edited TOML) — launch is the backstop.

**B — create (`api/routes/models.py`, `services/models_service.py`)**
`create_model` now screens at save like PUT. Extracted the create/PUT screening into `models_service.screen_model_write` so the paths can't drift; PUT rewired onto it (envelopes/codes byte-preserved).

**C — dry-run (`POST /api/models/validate`)**
Screens a candidate `{defaults, preferred_runner}` body and returns `{"ok": true}` or the **same** typed envelope (`slot.managed_arg_denied` / `model.unknown_runner` / `model.extra_args_json_quoting` / `model.extra_args_unparseable`) that create/PUT raise — one error path for the drawer. Never writes the registry.

## Tests
- `test_argv`: `model_extra_args` segment screened (`--port` rejected); trusted `model_defaults` `-ngl` not screened.
- `test_capability_injection` / `test_container_resolved_detail`: precedence test now sets the model-tier `-ngl` via the `n_gpu_layers` field; `--jinja` provenance relabeled to `model_extra_args` (it folds into that string).
- `test_models_crud`: create rejects managed extra_args (nothing persisted) + unknown `preferred_runner`; `/validate` accepts clean, rejects a managed flag without writing.
- Local: providers+slots+models suites green (817 + 30), `ruff`/`ruff format`/`sunset`/route-collision clean. (Two `test_moonshine_server` ffmpeg failures are pre-existing on `main`, unrelated.)

## Behaviour change to flag
`-ngl` in a model's `defaults.extra_args` is now **rejected** at launch (it's a managed flag; set GPU layers via the `n_gpu_layers` field). This matches how the slot's `[server].extra_args` already behaves — the model tier was the inconsistent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JUyAmsZs6eFRJNij7UBZx

---
_Generated by [Claude Code](https://claude.ai/code/session_018JUyAmsZs6eFRJNij7UBZx)_