### PR TITLE
fix(dashboard): stop slot cards flickering bare→enriched on poll

### DIFF
--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -97,6 +97,7 @@ async def get_status(request: Request) -> dict[str, Any]:
         _loaded_models,
         _slot_to_dict,
         _synthesize_slots_from_upstreams,
+        overlay_cached_enrichment,
     )
 
     try:
@@ -108,6 +109,11 @@ async def get_status(request: Request) -> dict[str, Any]:
         # bootstrap window), fall back to synthetic-only so /api/status
         # still serves something useful instead of 500-ing the dashboard.
         real_entries = []
+    # These entries are bare (no container probe — /api/status must stay cheap).
+    # Overlay list_slots' last-good container state so the dashboard union sees
+    # a coherent dot + metrics instead of flickering back to the FSM-only view
+    # whenever this poll beats the slower /api/slots one. Pure dict overlay.
+    real_entries = overlay_cached_enrichment(request, real_entries)
     real_names = {entry["name"] for entry in real_entries}
 
     slot_list: list[dict[str, Any]] = list(real_entries)

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -268,6 +269,63 @@ def _synthesize_slots_from_upstreams(
     )
 
 
+# ── /api/status enrichment mirror ────────────────────────────────────────────
+# The fast /api/status poll serialises slots via _slot_to_dict only — it must
+# NOT run the heavy per-slot container probe (systemctl is-active + /health)
+# that list_slots' aggregator does, or it loses its cheap-liveness role. But the
+# dashboard unions /api/status with /api/slots, and a status-only entry arrives
+# bare (container_status null → a downgraded dot + zeroed metrics), so it
+# flickers whenever it wins a poll that the slow /api/slots lost. As a cheap
+# bridge, list_slots caches the enrichment it already computed and get_status
+# overlays the last-good values (no extra syscalls) onto its bare entries within
+# a short TTL. Mirrors the client-side reconcileEnrichment carry-forward.
+_STATUS_ENRICH_TTL_S = 30.0
+
+
+def _cache_slot_enrichment(request: Request, dicts: list[dict[str, Any]]) -> None:
+    """Stash list_slots' freshly-probed container state for /api/status reuse."""
+    store = getattr(request.app.state, "slot_enrich_cache", None)
+    if store is None:
+        store = {}
+        request.app.state.slot_enrich_cache = store
+    now = time.monotonic()
+    for d in dicts:
+        name = d.get("name")
+        if not name or d.get("_synthetic") or d.get("container_status") is None:
+            continue
+        store[name] = {
+            "container_status": d.get("container_status"),
+            "container_health": d.get("container_health"),
+            "metrics": d.get("metrics"),
+            "ts": now,
+        }
+
+
+def overlay_cached_enrichment(
+    request: Request, entries: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Fill bare /api/status entries with list_slots' last-good enrichment.
+
+    Only touches entries that lack their own ``container_status`` and only when
+    the cached probe is within :data:`_STATUS_ENRICH_TTL_S`. Never runs a
+    syscall — a pure dict overlay — so /api/status keeps its cheap-poll
+    contract while its slot cards stop flickering in the dashboard union.
+    """
+    store = getattr(request.app.state, "slot_enrich_cache", {}) or {}
+    now = time.monotonic()
+    for e in entries:
+        if e.get("container_status") is not None:
+            continue
+        cached = store.get(e.get("name"))
+        if not cached or now - cached["ts"] > _STATUS_ENRICH_TTL_S:
+            continue
+        e["container_status"] = cached["container_status"]
+        e["container_health"] = cached["container_health"]
+        if cached.get("metrics") is not None and not e.get("metrics"):
+            e["metrics"] = cached["metrics"]
+    return entries
+
+
 # ── list / create ──────────────────────────────────────────────────────────
 
 
@@ -297,7 +355,9 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
         last_used_model=getattr(state, "last_used_model", {}),
         slot_pull_jobs=getattr(state, "slot_pull_jobs", {}),
     )
-    return [view.to_dict() for view in await aggregator.snapshot()]
+    dicts = [view.to_dict() for view in await aggregator.snapshot()]
+    _cache_slot_enrichment(request, dicts)
+    return dicts
 
 
 # The slot port allocator (pool resolution, claim collection, next-free,

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -151,6 +151,12 @@ export interface Slot {
   // that fronts every chat model. These are NOT loadable/unloadable/
   // deletable slots, so `useSlots()` filters them out of the slot grid
   // and `useEndpoints()` surfaces them in the sidebar instead.
+  /** True once the heavy /api/slots aggregator has stamped live container
+   *  state onto this entry — or once reconcileEnrichment carried the last-good
+   *  enrichment forward across a dropped poll. Bare /api/status union entries
+   *  read false; the InferencePane gates a "pending" style off this so a card
+   *  doesn't flash zeroed metrics while a slow /api/slots poll is in flight. */
+  _enriched?: boolean
   /** True for synthetic upstream-backed entries (composite endpoints). */
   _synthetic?: boolean
   /** Operator-facing explanation of why this entry isn't a real slot. */
@@ -331,30 +337,54 @@ async function fetchSlotsUnion(): Promise<Slot[]> {
 const ENRICH_TTL_MS = 30_000
 const lastGoodEnrichment = new Map<
   string,
-  { container_status: unknown; container_health: unknown; ts: number }
+  {
+    container_status: unknown
+    container_health: unknown
+    model: unknown
+    metrics: unknown
+    ts: number
+  }
 >()
+
+// A slot is "enriched" once the /api/slots aggregator has stamped its live
+// container probe onto it. /api/status union entries arrive bare (FSM state
+// only, container_status null).
+function isEnriched(s: Slot): boolean {
+  return s.container_status != null
+}
 
 function reconcileEnrichment(slots: Slot[]): Slot[] {
   const now = Date.now()
   return slots.map((s) => {
     if (s._synthetic) return s
-    if (s.container_status != null) {
+    if (isEnriched(s)) {
+      // Fresh authoritative data — snapshot it (including model + metrics, so a
+      // subsequent dropped poll can carry the whole card forward, not just the
+      // container dot) and trust it verbatim even when it reads offline/idle.
       lastGoodEnrichment.set(s.name, {
         container_status: s.container_status,
         container_health: (s as { container_health?: unknown }).container_health,
+        model: s.model,
+        metrics: s.metrics,
         ts: now,
       })
-      return s
+      return { ...s, _enriched: true }
     }
     const lg = lastGoodEnrichment.get(s.name)
     if (lg && now - lg.ts <= ENRICH_TTL_MS) {
+      // Bare entry won a poll that /api/slots lost — carry the last-good
+      // enrichment forward so the card holds its dot + model + metrics instead
+      // of degrading to a downgraded state and zeroed tok/s for one interval.
       return {
         ...s,
         container_status: lg.container_status,
         container_health: lg.container_health,
+        model: s.model || (lg.model as string | undefined) || s.model,
+        metrics: lg.metrics ?? s.metrics,
+        _enriched: true,
       } as Slot
     }
-    return s
+    return { ...s, _enriched: false }
   })
 }
 

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -323,12 +323,18 @@ export function slotCtrlPhase(slot) {
 export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) {
   const dot = dotCls(ind)
   const ph = phase || slotCtrlPhase(s)
+  // A live-ish card whose /api/slots enrichment hasn't landed yet (bare
+  // /api/status union entry) — pulse the metrics area so the values reading
+  // as "—" are legible as loading, not as a real zero. `_enriched === false`
+  // is only ever set by reconcileEnrichment; undefined (e.g. NPU/stack cards
+  // that never union with /api/status) never trips this.
+  const pending = s._enriched === false && ph !== 'off'
   const memGb = typeof s.mem_mb === 'number' && s.mem_mb > 0 ? round1(s.mem_mb / 1024) : null
   const tps = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
   const ttft = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
   return (
     <div
-      className={'scard ' + dot + (ph === 'off' ? ' dim' : '')}
+      className={'scard ' + dot + (ph === 'off' ? ' dim' : '') + (pending ? ' pending' : '')}
       data-testid={`infer-slot-${s.name}`}
     >
       <div className="scard-h">
@@ -368,9 +374,18 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) 
   )
 }
 
-function SlotCards({ rows, full, models, busyName, handlers }) {
-  if (!rows.length)
+function SlotCards({ rows, full, models, busyName, handlers, loading }) {
+  if (!rows.length) {
+    if (loading)
+      return (
+        <div className={'scards ' + (full ? 'full' : 'compact')}>
+          {[0, 1].map((i) => (
+            <div key={i} className="slot-skeleton" />
+          ))}
+        </div>
+      )
     return <div className="scards-empty">no inference slots — create one to start</div>
+  }
   return (
     <div className={'scards ' + (full ? 'full' : 'compact')}>
       {rows.map(({ s, ind }) => {
@@ -481,6 +496,10 @@ export function InferencePane() {
   // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
   // stack pane below — they appear here only as the sec-label FLM count.
   const allSlots = slotsQuery.data || []
+  // Cold start: no cached data yet. Render neutral skeletons instead of the
+  // "no inference slots — create one" empty state, which would otherwise flash
+  // in for one poll before the first payload lands and get replaced.
+  const loading = slotsQuery.isLoading && !slotsQuery.data
   const nonImg = allSlots.filter((s) => String(s?.type) !== 'image')
   const slots = nonImg.filter((s) => devKind(s.device) !== 'npu')
   const npuN = nonImg.length - slots.length
@@ -591,6 +610,7 @@ export function InferencePane() {
               <SlotCards
                 rows={headlineRows}
                 full
+                loading={loading}
                 models={modelsQuery.data}
                 busyName={busyName}
                 handlers={handlers}

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1501,6 +1501,11 @@ a { color: inherit; text-decoration: none; }
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
+/* A slot card present but not yet enriched by the /api/slots poll (its bare
+   /api/status union twin won the interval) — pulse the metrics row so the
+   "—" placeholders read as loading rather than a real reading. Reuses the
+   `pulse` opacity keyframe. */
+.scard.pending .scard-meta { animation: pulse 1.4s ease-in-out infinite; }
 
 /* throughput sparkline */
 .spark { display: flex; align-items: flex-end; gap: 1px; height: 36px; padding: 4px 0; }


### PR DESCRIPTION
## Problem

The Inference pane unions `/api/status` (cheap, FSM-only) over `/api/slots` (heavy container probe + live metrics) in one React Query poll. When a slow `/api/slots` poll soft-fails or lags, the bare `/api/status` entry wins the interval and the card **flickers**: dot downgrades, tok/s drops to zero, then re-enriches on the next poll. Cold start also flashed a false "no inference slots — create one" empty state for one poll.

That's the "show briefly then replaced by the actual running/recent/seeded ones" behavior from the screenshot.

## Fix — three complementary layers

**1. Client carry-forward** — `ui/src/api/hooks/useSlots.ts`
`reconcileEnrichment` now snapshots + carries `model` + `metrics` forward (not just the container dot) across a dropped `/api/slots` poll, within the existing 30s TTL. Slots are tagged `_enriched` so consumers can distinguish a live-probed card from a bare status twin.

**2. Skeleton + pending gate** — `inference-pane.jsx` + `dashboard.css`
Cold start renders neutral `.slot-skeleton` shimmer instead of the false empty state. A bare-but-live card gets `.scard.pending` so its `—` metrics pulse as loading rather than reading as a real zero.

**3. Server enrichment mirror** — `slots.py` + `health.py`
`list_slots` caches the container state it already probed; `get_status` overlays the last-good values onto its bare entries — **pure dict copy, no extra syscalls**, so `/api/status` keeps its cheap-poll contract. Warm after the first `/api/slots` poll; benefits every `/api/status` consumer, not just the union.

Layers are complementary: #2 covers first paint, #1 transient client drops, #3 makes the endpoint itself richer at the source.

## Verification
- Backend: `pytest -k "status or enrich or serialize_slot or list_slots"` → 206 passed
- Frontend: `tsc --noEmit` clean · `vitest run` 3 passed · `vite build` ok · ruff format/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)