### PR TITLE
fix(setup): raise apply-selections HTTP timeout to 300s + env override

### DIFF
--- a/src/hal0/cli/setup_install.py
+++ b/src/hal0/cli/setup_install.py
@@ -23,12 +23,28 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 import os
+import time
 
 import httpx
 import typer
 
 from hal0.cli._shared import _api_base, _auth_headers
+
+log = logging.getLogger(__name__)
+
+# Default HTTP timeout for ``POST /api/install/apply-selections``. The endpoint
+# is heavy on cold-start (Python imports + module load + hermes preflight +
+# pip --no-index cache hit), so 30s was too tight (issue: 150lxc installer
+# timeout — see ``docs/rework/deploy-validation/2026-07-21-installer-150lxc.md``).
+# 300s (5 min) covers the long tail of slow hardware without hanging past the
+# "user has given up and refreshed the page" ceiling. Operators on known-slow
+# or known-fast hardware can override via ``HAL0_SETUP_TIMEOUT_SECS``.
+try:
+    SETUP_HTTP_TIMEOUT_SECS = float(os.environ.get("HAL0_SETUP_TIMEOUT_SECS", "300.0"))
+except ValueError:
+    SETUP_HTTP_TIMEOUT_SECS = 300.0
 
 # Imported as a MODULE ATTRIBUTE (not `from ... import _api_reachable` used at
 # call-site only) so tests can monkeypatch ``hal0.cli.setup_install._api_reachable``.
@@ -231,8 +247,12 @@ async def _apply_via_api(sel) -> None:
     """
     payload = dataclasses.asdict(sel)
     url = f"{_api_base()}/api/install/apply-selections"
-    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), headers=_auth_headers()) as client:
+    timeout = httpx.Timeout(SETUP_HTTP_TIMEOUT_SECS)
+    t0 = time.monotonic()
+    async with httpx.AsyncClient(timeout=timeout, headers=_auth_headers()) as client:
         resp = await client.post(url, json=payload)
+    elapsed = time.monotonic() - t0
+    log.info("hal0 setup apply-selections: %.1fs (status=%s)", elapsed, resp.status_code)
     if resp.status_code in (401, 403):
         typer.echo(
             f"hal0 setup: not authorized ({resp.status_code}) to apply via the live API "

--- a/tests/cli/test_setup_install.py
+++ b/tests/cli/test_setup_install.py
@@ -155,3 +155,75 @@ async def test_apply_via_api_non_conflict_error_still_raises(monkeypatch):
         pass
     else:  # pragma: no cover - defensive
         raise AssertionError("expected HTTPStatusError for a 500 response")
+
+
+# ── _apply_via_api: timeout configuration (issue: 150lxc installer) ───────
+
+
+def test_setup_http_timeout_default_is_300():
+    """Default timeout is 300s (was 30s, too tight for cold-start apply)."""
+    import hal0.cli.setup_install as m
+
+    assert m.SETUP_HTTP_TIMEOUT_SECS == 300.0
+
+
+def test_setup_http_timeout_env_var_override(monkeypatch):
+    """Operators on slow hardware can raise (or lower) the timeout via env."""
+    import importlib
+
+    import hal0.cli.setup_install as m
+
+    monkeypatch.setenv("HAL0_SETUP_TIMEOUT_SECS", "45.5")
+    importlib.reload(m)
+    try:
+        assert m.SETUP_HTTP_TIMEOUT_SECS == 45.5
+    finally:
+        # Restore default for other tests in this module.
+        monkeypatch.delenv("HAL0_SETUP_TIMEOUT_SECS", raising=False)
+        importlib.reload(m)
+
+
+def test_setup_http_timeout_bad_env_falls_back_to_default(monkeypatch):
+    """A non-numeric HAL0_SETUP_TIMEOUT_SECS falls back to 300s, not a crash."""
+    import importlib
+
+    import hal0.cli.setup_install as m
+
+    monkeypatch.setenv("HAL0_SETUP_TIMEOUT_SECS", "not-a-number")
+    importlib.reload(m)
+    try:
+        assert m.SETUP_HTTP_TIMEOUT_SECS == 300.0
+    finally:
+        monkeypatch.delenv("HAL0_SETUP_TIMEOUT_SECS", raising=False)
+        importlib.reload(m)
+
+
+async def test_apply_via_api_uses_configured_timeout(monkeypatch):
+    """The HTTP client must use SETUP_HTTP_TIMEOUT_SECS, not a hardcoded value."""
+    import hal0.cli.setup_install as m
+
+    monkeypatch.setattr(m, "SETUP_HTTP_TIMEOUT_SECS", 123.0)
+
+    captured_timeout: dict = {}
+
+    class _CapturingClient(_FakeAsyncClient):
+        def __init__(self, *args, **kwargs):
+            # ``_dashboard_url`` also instantiates a client; key the capture to
+            # the POST path only by inspecting the caller's stack frame via the
+            # last kwarg passed to ``post`` upstream is fragile, so just take
+            # the FIRST client (the POST) and reuse the same fake for the GET.
+            if "value" not in captured_timeout:
+                captured_timeout["value"] = kwargs.get("timeout")
+
+    resp = httpx.Response(
+        200,
+        json={"model_ids": [], "slots": []},
+        request=httpx.Request("POST", "http://127.0.0.1:8080/api/install/apply-selections"),
+    )
+    _FakeAsyncClient._post_response = resp
+    monkeypatch.setattr("hal0.cli.setup_install.httpx.AsyncClient", _CapturingClient)
+
+    await _apply_via_api(_empty_selections())
+
+    assert captured_timeout["value"] is not None
+    assert captured_timeout["value"].connect == 123.0


### PR DESCRIPTION
## Problem

The installer wizard's guided `hal0 setup` failed with `ReadTimeout` on a fresh install on 150lxc.

The endpoint `POST /api/install/apply-selections` is heavy on cold-start (Python imports + module load + hermes preflight + `pip --no-index` cache hit) and consistently takes 60-110s on first call after hal0-api restart. The hardcoded 30s client timeout was racing the cold start.

Reference: `docs/rework/deploy-validation/2026-07-21-installer-150lxc.md`

## Fix

- Default timeout bumped `30s` → `300s` (5 min ceiling for slow hardware without hanging past the user-refreshes-the-page threshold)
- Module-level constant `SETUP_HTTP_TIMEOUT_SECS` (was inline literal)
- `HAL0_SETUP_TIMEOUT_SECS` env var override for known-slow/fast boxes
- Bad (non-numeric) env value falls back to 300s, not a crash
- Added `log.info` of elapsed wall time + status for telemetry so we can collect real-world numbers from alpha testers

## Verification

On 150lxc:
- `POST /api/install/apply-selections` in steady state: 30ms
- `POST /api/install/apply-selections` cold-start: ~110s (would have failed at 30s, now passes at 120s and 300s)
- `hal0 setup --auto --no-pull`: exits 0, emits `hal0 setup applied via API: 0 model(s), 0 slot(s)`
- All 4 new tests pass; existing `_apply_via_api` tests unaffected (use `_FakeAsyncClient`)
- All hal0 services remain healthy: hal0-api, hal0-openwebui, hal0-agent@hermes, hindsight-api

## Tests added

`tests/cli/test_setup_install.py`:

- `test_setup_http_timeout_default_is_300` — module constant is 300s
- `test_setup_http_timeout_env_var_override` — `HAL0_SETUP_TIMEOUT_SECS` overrides
- `test_setup_http_timeout_bad_env_falls_back_to_default` — non-numeric value falls back
- `test_apply_via_api_uses_configured_timeout` — `_apply_via_api` actually uses `SETUP_HTTP_TIMEOUT_SECS`

## Follow-up

The real fix for slow installs is async-with-job-polling (return `202 Accepted` + job_id, client polls). That's beyond alpha scope but worth filing.