### PR TITLE
fix(install): run hermes gateway install as root, not via sudo -u hal0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ applying. Add those subsections to a version's section to surface them; see
 ### Fixed
 
 - **Slot drawer — restore the per-slot `Reasoning` and `MTP` controls** (fixes γ-suite, #1333). The `feat(ui): slot drawer & model drawer rework` landed with Reasoning + MTP removed from the slot drawer under "now model-owned"; the model drawer carries model-level defaults but operators need a per-slot override. Re-added the Reasoning pill (llm slots only, instant-apply via `PUT /config { enable_thinking }`) and the MTP pill (llm slots only, tri-state Auto/On/Off, instant-apply via `PUT /config { mtp }` + non-blocking cold restart) into the `Inference` FieldGroup. Renamed the HW grid `Hardware` FieldGroup → `Slot` (the drawer is now Slot / Model / Inference) and the runner-binary select label `Profile` → `Binary` (the bound runner stays on the slot card chip — no editable profile select in the drawer). The 12 γ-suite slot-drawer tests that were red on main since 2026-07-20 (#1333) all pass.
+- **Hermes gateway install runs as root** — fix installer `sudo -u hal0` → root call (PR #1337). The installer was dropping to the `hal0` user before running `hermes gateway install --system`, which checks `os.geteuid() == 0` and refuses non-root. The `--run-as-user hal0` flag already tells hermes which runtime user to bake into the systemd unit. Validated on halo150 (10.0.1.150, podman 4.9.3).
 
 ## [1.0.0] — unreleased (R5 · the rework release)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,21 @@
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
 
 Rules:
+
 - For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
 - If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
+
+## hindsight
+
+This project has long-term memory via Hindsight at <http://10.0.1.142:9177>. Memories persist across sessions and agents.
+
+Rules:
+
+- **Before answering "what did we do", "what's configured", "do you remember" — call `hindsight_recall` first.** Don't guess; check.
+- **When the user states a durable preference, decision, or fact — call `hindsight_retain`.** Be specific: include who, what, when, why. Format: "User prefers X because Y" / "Decided to use Z for W (2026-07-22)".
+- **Use `hindsight_reflect` for synthesis.** Unlike recall (raw results), reflect generates a coherent answer from memory. Use it to answer "what do you know about X".
+- **Auto-recall runs on session_start; auto-retain runs every 3 turns.** These handle transient session context. Explicit retain/recall calls are for durable long-term facts.
+- **Dynamic bank support is available** — set `dynamicBankId: true` in `~/.pi/agent/settings.json` under the `hindsight` block to auto-isolate memory per project (e.g., `pi-coder::hal0` vs `pi-coder::myapp`).
+- **Check status** with `hindsight_status` before assuming memories are gone — it shows reachability, resolved bank, and bank count.

--- a/docs/issues/fresh-install-layout.md
+++ b/docs/issues/fresh-install-layout.md
@@ -1,0 +1,133 @@
+# Fresh install issues (lxc150)
+
+Observed after `--purge` uninstall followed by a fresh install as root on lxc150.
+All DRIFTs reported by `hal0 doctor` (driven by `hal0.install.perms.ownership_table`).
+
+---
+
+## Summary
+
+The `install.sh` script runs as root and creates directories/files with root
+ownership and no setgid bit.  The `hal0` daemon runs as `hal0:hal0` and needs
+write access to config (`/etc/hal0`) and state (`/var/lib/hal0`) trees.
+
+The ownership table (`hal0.install.perms`) expects the hardened P3-perms layout:
+config root `2775` (setgid, `hal0:hal0`), mutable files `hal0:hal0`, runtime
+state `hal0:hal0`.  The installer doesn't apply these — `doctor perms --fix`
+should correct them post-install, but some rows are also just **never created**
+(they appear on first use / first-run).
+
+---
+
+## Detailed DRIFTs
+
+### `/etc/hal0` — config root
+
+| Path | `is` (on disk) | `want` (perms table) |
+| --- | --- | --- |
+| `/etc/hal0/` | `hal0:hal0 2755` | `hal0:hal0 2775` |
+| `hal0.toml` | `root:hal0 0600` | `hal0:hal0 0600` |
+| `profiles.toml` | **absent** | `hal0:hal0 0600` |
+| `hardware.json` | `root:hal0 0644` | `hal0:hal0 0644` |
+| `openwebui.env` | `root:hal0 0600` | `hal0:hal0 0600` |
+| `*.lock` (dir) | `hal0:hal0 2755` | `hal0:hal0 2775` |
+| `capabilities.toml.lock` | `hal0:hal0 0644` | `hal0:hal0 0664` |
+| `agents/` | `root:hal0 2755` | `root:root 0755` |
+
+**Root causes:**
+
+1. **Missing setgid (2755 → 2775).**  `install.sh` line 806:
+
+   ```bash
+   chmod 0755 "${ETC_DIR}" 2>/dev/null || true
+   ```
+
+   This resets the dir to `0755`, stripping any setgid bit.  The perms table
+   expects `2775` so temp-file + `rename` writes by the hal0 daemon work.
+
+2. **Files owned `root:hal0` instead of `hal0:hal0`.**  `install.sh` copies
+   seed files as root (e.g. `cp`, `install -m`), and the script never calls
+   `chown hal0:hal0` on them.  The daemon cannot atomically rewrite them.
+
+3. **`profiles.toml` absent.**  Created by `hal0 setup` or the first-run
+   wizard, not by `install.sh`.  No issue — expected.
+
+4. **`agents/` wrong owner + mode.**  Created by `install.sh` but with the
+   wrong group and setgid bit inherited from the parent dir.
+
+### `/var/lib/hal0` — state root
+
+| Path | `is` | `want` |
+| --- | --- | --- |
+| `.first-run.lock` | **absent** | `hal0:hal0 0664` |
+| `slots/flm/` | `hal0:hal0 2755` | `hal0:hal0 2775` |
+| `slots/utility/` | `hal0:hal0 2755` | `hal0:hal0 2775` |
+| `models/collections/` | `root:hal0 2755` | `hal0:hal0 2775` |
+| `models/collections/omni/` | `root:hal0 2755` | `hal0:hal0 2775` |
+| `collections/omni/*.json` | `root:hal0 0644` | `hal0:hal0 0644` |
+| `agents/` | **absent** | `hal0:hal0 0711` |
+| `secrets/` | `root:root 0700` | `root:root 0755` |
+| `secrets/agents/` | `root:root 0700` | `root:root 0755` |
+| `benchmarks/` | `hal0:hal0 0755` | `hal0:hal0 2775` |
+| `benchmarks/logs/` | `hal0:hal0 0755` | `hal0:hal0 2775` |
+| `benchmarks/runs/` | `hal0:hal0 0755` | `hal0:hal0 2775` |
+| `benchmarks/server-ab/` | `hal0:hal0 0755` | `hal0:hal0 2775` |
+| `STATE.md` | `hal0:hal0 0644` | `hal0:hal0 0664` |
+
+**Root causes:**
+
+1. **Missing setgid (2755 → 2775) on slot runtime dirs.**  `install.sh` creates
+   `slots/` via `mkdir -p` under root's umask, then applies `chmod 2775` only
+   to the parent `slots/` dir.  Subdirs created later by the slot loader lack
+   the setgid bit.
+
+2. **`models/collections/` owned `root:hal0`.**  The installer copies
+   collection JSON manifests from `installer/etc-hal0/` into
+   `/var/lib/hal0/models/collections/` while running as root.  No `chown -R`
+   is applied to this subtree.  The perms table expects `hal0:hal0`.
+
+3. **`.first-run.lock` absent.**  Written by the first successful completion of
+   `hal0 setup` or the dashboard first-run wizard.  Expected absent on a
+   fresh install that hasn't completed first-run yet.
+
+4. **`agents/` (per-agent sub-homes) absent.**  Created on demand by
+   `hermes_provision`.  Expected absent.
+
+5. **`secrets/` + `secrets/agents/` mode 0700 vs 0755.**  The hardened root
+   umask on lxc150 leaks into `mkdir -p` calls.  install.sh restores umask to
+   022 at the top, but the secrets directories are created by a different code
+   path (hal0-agentenv seam) that inherits the caller's umask.
+
+6. **Setgid missing on `benchmarks/` subtree (0755 vs 2775).**  Created by the
+   install script with `mkdir -p`; the setgid chmod is only applied at
+   install.sh line 1248 (`chown -R hal0:hal0 ...`) which doesn't set the
+   setgid bit.
+
+7. **`STATE.md` mode 0644 vs 0664.**  Written by the Hermes session-start
+   hook; the birth mode from `open()` is 0644.  The perms table expects 0664
+   (group-writable) so multiple group members can overwrite.
+
+### Hermes gateway install fails
+
+```
+Installing hermes gateway (Telegram/Discord bridge)…
+System gateway install requires root. Re-run with sudo.
+hermes gateway install failed — Telegram/Discord bridge unavailable; continuing.
+```
+
+The install script runs as root but the hermes gateway install sub-step
+requires root context it doesn't get.  The effect is the
+`hermes-gateway.service` systemd unit is never installed.
+
+---
+
+## Pattern summary
+
+| # | Issue | Scope | Fix |
+| --- | --- | --- | --- |
+| 1 | Setgid (2775) not set on config/state dirs | `/etc/hal0`, `slots/*/`, `models/`, `benchmarks/*/` | `install.sh` must `chmod 2775` instead of `0755` |
+| 2 | Files owned `root:hal0` not `hal0:hal0` | `hal0.toml`, `hardware.json`, `openwebui.env`, `models/collections/*` | `install.sh` must `chown hal0:hal0` after seeding |
+| 3 | Sealed-by-root umask `0700` instead of `0755` | `secrets/`, `secrets/agents/` | `chmod 0755` after `mkdir -p` |
+| 4 | Lock-file mode `0644` instead of `0664` | `capabilities.toml.lock` | Writer (or fix) must use `0664` |
+| 5 | `agents/` in `/etc/hal0` wrong group | `agents/` dir | `chown root:root` + `chmod 0755` |
+| 6 | Hermes gateway unit not installed | hermes-gateway.service | Run gateway install as root or pass `--system --run-as-user hal0` |

--- a/docs/rework/handoff-brain-agent-slot-cleanup.md
+++ b/docs/rework/handoff-brain-agent-slot-cleanup.md
@@ -1,0 +1,197 @@
+# Handoff — brain + embed slot/agent cleanup on halo150
+
+> **You are going to fix the "errored: brain, embed" doctor warnings on
+> halo150 after the latest main reinstall.** The fix is straightforward:
+> brain is a container slot (not an agent), embed is not needed.
+>
+> Issue: (none filed yet — write one after this is done, linking the PR)
+>
+> Read in this order: (1) this handoff, (2) the code sections referenced
+> below, (3) `src/hal0/slots/manager.py` (slot-to-unit rendering), (4)
+> `src/hal0/cli/agent_shim.py` (hal0-agent dispatch).
+
+---
+
+## 1. What's wrong
+
+A clean reinstall on halo150 (10.0.1.150, privileged LXC, podman 4.9.3) from
+latest `main` produces:
+
+```
+🛑 Runners: 9/11 healthy — errored: brain, embed
+```
+
+**Both brain and embed are being spawned as container slots AND as hal0 agents,
+and neither works:**
+
+| unit | loaded | active | why |
+| ------ | -------- | -------- | ----- |
+| `hal0-slot@brain.service` | loaded | **failed** | model `tmp-model-8d60ae4b` registration incomplete (missing `model_file` row — fixed separately) |
+| `hal0-agent@brain.service` | loaded | **failed** | `hal0-agent: unknown agent id 'brain' — drop /etc/hal0/agents/brain.toml with a 'type = ...' field` |
+| `hal0-slot@embed.service` | loaded | **failed** | same model registration issue |
+| `hal0-agent@embed.service` | absent (graceful) | — | embed is `enabled=false` so the agent wasn't spawned, but the slot unit still fails |
+
+The **root cause** is that the slot orchestrator spawns BOTH a container unit
+AND an agent unit for these slots, but:
+
+- brain/embed are not valid `hal0-agent` types (only `hermes` is)
+- brain should only run as a container slot (like on lxc105)
+- embed is not needed at all
+
+For comparison, lxc105 (the working reference):
+
+```
+hal0-slot@brain.service  →  active (running)  ← container slot, NOT an agent
+hal0-agent@hermes.service  →  active (running)  ← the only agent
+```
+
+lxc105's brain.toml is a standard container slot with `runtime = "container"`.
+
+---
+
+## 2. Why both units spawn
+
+The slot orchestrator (`src/hal0/slots/manager.py`) renders unit files from
+`/etc/hal0/slots/*.toml`. For each slot it generates:
+
+1. `hal0-slot@<name>.service` — the **container** runner (podman invocation)
+2. `hal0-agent@<name>.service` — the **hal0-agent** CLI shim, if the slot name
+   maps to a recognized agent identity
+
+The agent mapping currently matches on slot *name* unconditionally for certain
+name patterns (possibly all llm types). The `hal0-agent` CLI (`src/hal0/cli/agent_shim.py`)
+then validates the name against `hal0 agent list` and rejects unknown IDs.
+
+The fix needs to happen at the **slot → unit rendering layer**, not the agent
+validation layer.
+
+---
+
+## 3. Fix plan
+
+### 3a. Halt agent unit generation for brain
+
+**File:** `src/hal0/slots/manager.py`
+
+The function that generates `hal0-agent@<name>.service` units must skip brain
+(and any other slot that isn't a true hal0 agent). Two options:
+
+**Option A (explicit blocklist)** — Add brain to an explicit exclude list:
+
+```python
+# Slots that are NOT hal0 agents (container-only inference slots)
+_NON_AGENT_SLOTS = {"brain", "embed", "coder"}
+```
+
+Then check `if slot_name in _NON_AGENT_SLOTS: return` before the agent unit
+generation call.
+
+**Option B (opt-in)** — Only generate agent units for slots that have a matching
+`/etc/hal0/agents/<name>.toml` file with a valid `type` field. This is more
+future-proof (any new agent type Just Works if it has a config file).
+
+Pick whichever matches the existing code patterns better — search for
+"agent" in manager.py to find the right insertion point.
+
+### 3b. Fix brain slot config
+
+**File:** `/etc/hal0/slots/brain.toml` (on disk, not in repo)
+
+The current brain.toml on halo150 is missing `runtime = "container"` and uses
+a stale model ID. Fix:
+
+```toml
+name = "brain"
+type = "llm"
+runtime = "container"
+device = "gpu-vulkan"
+profile = "vkfpx-dense-minicpm5"   # or "moe" — match the actual profile on disk
+port = 8089
+enable_thinking = true
+parallel = 2
+chat_template = "auto"
+
+[model]
+default = "hal0-brain-sft-fpx8"    # the actual registered model, not tmp-model
+context_size = 32000
+```
+
+If the model `hal0-brain-sft-fpx8` doesn't exist on 150, register it with
+`hal0 model add /mnt/ai-models/chat/hal0-brain-sft-fpx8-agent/model.gguf --id hal0-brain-sft-fpx8`
+(or whatever the actual path is — check `/mnt/ai-models/chat/hal0-brain-sft*`).
+
+### 3c. Disable embed slot
+
+```bash
+# Set enabled=false and stop the unit
+sed -i 's/enabled = true/enabled = false/' /etc/hal0/slots/embed.toml
+systemctl disable --now hal0-slot@embed.service
+```
+
+Or just delete `/etc/hal0/slots/embed.toml` entirely if embed is never needed.
+
+### 3d. Backfill model_file registration (if needed)
+
+The `hal0 migrate model-layout` tool needs a `model_file` row for every
+registered model. On 150, `tmp-model-8d60ae4b` had its `model_file` row
+inserted manually (the insert command is in the reinstall session log). If
+you switch to `hal0-brain-sft-fpx8`, that model may also need registration.
+
+---
+
+## 4. Slot → unit generation code
+
+### Key files
+
+| File | What it does |
+| ------ | ------------- |
+| `src/hal0/slots/manager.py` | Reads slot TOMLs, renders systemd units for container + agent |
+| `src/hal0/cli/agent_shim.py` | `hal0-agent` CLI — validates agent ID, dispatches to agent driver |
+| `src/hal0/agents/hermes_provision.py` | Provisions the hermes agent (the only agent type currently) |
+
+### What to modify
+
+The agent unit generation code path. Start by searching `manager.py` for
+`hal0-agent` or `agent` to find where the unit file is created, then add
+the skip condition.
+
+If the agent unit generation is entirely template-driven (the installer's
+`hal0-agent@.service` template + a `systemctl enable` call), the fix is at the
+systemctl enable point — skip `systemctl enable hal0-agent@brain` in the
+post-install slot-enable loop.
+
+Look at the installer's step that enables slots: `installer/install.sh`
+around line where `hal0 setup --first-run` seeds slots and enables units.
+
+---
+
+## 5. Acceptance
+
+- [ ] `hal0-agent@brain.service` is **not** spawned after install
+- [ ] `hal0-slot@brain.service` starts successfully (container runs, model loads)
+- [ ] `hal0-slot@embed.service` is disabled or absent
+- [ ] `hal0 doctor all` shows **11/11 healthy** (no brain/embed errors)
+- [ ] The fix works on a **clean reinstall** (not just an in-place fix)
+
+---
+
+## 6. Quick reference
+
+| Resource | Path / command |
+| ---------- | --------------- |
+| Reference brain config (lxc105) | `ssh root@10.0.1.142 cat /etc/hal0/slots/brain.toml` |
+| Current brain config (150) | `ssh root@10.0.1.150 cat /etc/hal0/slots/brain.toml` |
+| Slot orchestrator | `src/hal0/slots/manager.py` |
+| Agent CLI shim | `src/hal0/cli/agent_shim.py` |
+| Installer slot-setup step | `installer/install.sh` (search `hal0 setup`) |
+| <hal0-agent@.service> template | `installer/install.sh` (search `hal0-agent@.service`) |
+| Check agent render | `ssh root@10.0.1.150 systemctl list-units 'hal0-agent@*'` |
+
+---
+
+## 7. After this lands
+
+- Re-run the clean install on 150
+- Verify `hal0 doctor all` → 11/11 healthy (no brain/embed errors)
+- If brain slot still fails on model, fix `/etc/hal0/slots/brain.toml` model_id to point at `hal0-brain-sft-fpx8`
+- Delete this handoff once the fix is verified on a clean reinstall

--- a/docs/superpowers/specs/2026-07-21-merge-observational-memory-into-hindsight-design.md
+++ b/docs/superpowers/specs/2026-07-21-merge-observational-memory-into-hindsight-design.md
@@ -1,335 +1,107 @@
-# Merge pi-observational-memory into Hindsight Design
+# Hindsight pi Extension Design
 
-**Date:** 2026-07-21
+**Date:** 2026-07-22
 
-**Status:** Approved
+**Status:** Implemented (Claude Code plugin port).
 
 **Scope:** pi-side only. The hal0-api and Hindsight services are unchanged.
 
 ## Purpose
 
-Replace the `pi-observational-memory` extension (`/home/mint/.pi/agent/npm/node_modules/pi-observational-memory/`) with a thin bridge inside the existing `hal0-memory` pi extension. The bridge keeps observational memory's auto-capture behavior but routes captured session chunks into Hindsight via the same `hal0_memory_add` REST surface the hal0-memory LLM tools already use. Hindsight's existing extraction pass then structures the raw text into `world` / `experience` / `observation` records — replacing pi-OM's three sub-agents (observer, reflector, dropper) with a single server-side extraction model.
+Replace the `pi-observational-memory` npm package and its thin-bridge hal0-memory approach with a full TypeScript port of the Claude Code Hindsight plugin (`vectorize-io/hindsight/hindsight-integrations/claude-code`) adapted for pi's event API. The extension connects directly to Hindsight at `http://10.0.1.142:9177` (LAN-exposed, no auth) and provides:
 
-This is a strict simplification. The local session-ledger, the in-process sub-agent runs, the `recall_observation` tool, and the `/om-status` / `/om-view` commands all disappear. Auto-capture moves into hal0-memory and writes through Hindsight.
-
-## Evidence and constraints
-
-Three sources shape this design:
-
-1. The current `pi-observational-memory` source tree (`/home/mint/.pi/agent/npm/node_modules/pi-observational-memory/src/`).
-2. The current `hal0-memory` extension (`/home/mint/.pi/agent/extensions/hal0-memory/index.ts`) and its REST contract.
-3. The Hindsight extraction model already wired through `HINDSIGHT_API_LLM_MODEL` (configured on the hal0 host, not in pi).
-
-Hard constraints:
-
-- **No hal0-api or Hindsight API changes.** The bridge uses the existing `/api/memory/add` endpoint with the documented `X-hal0-Agent` and `X-hal0-Private` headers.
-- **Auto-capture must not block the agent loop.** Pushes happen on `turn_end` after the LLM has already responded, so latency is tolerable but not free; the push itself must be bounded (10s timeout) and best-effort with a small in-memory buffer for retry.
-- **One writer per package manager directory.** No parallel writers touching `~/.pi/agent/npm/package.json` or `~/.pi/agent/settings.json`.
-- **The existing `hal0-memory` LLM tool surface (`hal0_memory_add` / `hal0_memory_search` / `hal0_memory_recall` / `hal0_memory_list` / `hal0_memory_delete` / `hal0_memory_whoami`) stays as-is.** The bridge calls the same REST endpoint via direct `fetch`, not via the LLM tool (which would round-trip through the model).
-
-## Product outcomes
-
-After delivery:
-
-- pi-OM is uninstalled and removed from `packages`. The `observational-memory` config block is gone from `~/.pi/agent/settings.json`.
-- Every meaningful turn (`turn_end`) pushes a serialized chunk of new source entries to Hindsight via `hal0_memory_add` once the chunk crosses `minTokensBetweenPushes` (default 25,000 tokens).
-- The bridge chooses the destination bank per chunk: `shared` when cwd has a project marker and is not under a scratch root; `private:pi-coder` otherwise.
-- The bridge buffers failed pushes per bank (4 chunks cap) and retries on the next `turn_end`. Buffer overflow drops oldest with a single warning.
-- A small `autoMemory.pushed` session coverage entry marks each successful push, so reloads resume from the right point.
-- The existing hal0-memory LLM tools and slash commands continue to work; nothing user-visible changes there.
-
-## Non-goals
-
-- Migrating historical `om.observations.recorded` / `om.reflections.recorded` / `om.observations.dropped` entries out of old session jsonl files. They stay as cold history (per user decision). Pruning happens via `/compact` on a fresh branch.
-- Replacing Hindsight's extraction model with a pi-side sub-agent. Hindsight owns structuring.
-- Touching pi's native compaction (`compaction.enabled` / `reserveTokens` / `keepRecentTokens`). Native compaction still handles context-window pressure.
-- Touching the hal0-api or Hindsight codebase.
-- Replacing the hal0-memory LLM tool surface (`hal0_memory_*` tools stay).
-- A new bridge configuration UI. All knobs live in `~/.pi/agent/settings.json` under `hal0-memory.autoCapture`.
+- **LLM tools:** `hindsight_retain`, `hindsight_recall`, `hindsight_reflect`, `hindsight_status`
+- **Auto-recall** on `session_start` (deduped per session)
+- **Auto-retain** on `turn_end` (throttled by `retainEveryNTurns`)
+- **Pre-compaction retain** on `session_before_compact`
+- **Dynamic bank IDs** (`static` or `dynamic` with granularity: agent, project, session, channel, user, gitProject)
+- **Bank missions** set on first use, cached in plugin state
+- **Slash commands:** `/hindsight`, `/hindsight-recall`, `/hindsight-doctor`
 
 ## Architecture
 
-The bridge is a single new module inside the existing `hal0-memory` extension. No new npm package.
-
 ```
-/home/mint/.pi/agent/extensions/hal0-memory/
-  index.ts            — existing REST client + LLM tools + slash commands
-  auto-capture.ts     — NEW: turn_end hook, threshold gate, bank selector,
-                        buffer/retry, hal0_memory_add wrapper, coverage marker
-  config.ts           — NEW: typed AutoCaptureConfig with defaults
-  bank-selector.ts    — NEW: pure function — cwd → "shared" | "private"
-  auto-capture.test.ts   — NEW: bank-selector + threshold + buffer unit tests
-```
-
-`auto-capture.ts` registers two pi event listeners:
-
-- `session_start` — re-hydrates `lastPushedCoverageId` from the most recent `autoMemory.pushed` entry in `ctx.sessionManager.getBranch()`, runs the reachability probe, and resets the buffer-warning latch.
-- `turn_end` — the only listener that does real work; see the data flow below.
-
-State owned in memory:
-
-- `lastPushedCoverageId: string | undefined` — id of the most recent `autoMemory.pushed` session entry. Persisted across reloads because the coverage entry itself is in the jsonl; the in-memory pointer is rebuilt on `session_start` by walking the branch.
-- `buffer: Map<"shared" | "private", Chunk[]>` — per-bank retry buffer, FIFO, 4 chunks cap each.
-- `bufferOverflowWarned: Set<"shared" | "private">` — single-warning latch per bank.
-- `endpointReachable: boolean` — set by the `session_start` reachability probe. False disables all subsequent `turn_end` work for the lifetime of the session.
-
-The bridge imports the existing REST helpers from `index.ts` (`headers`, `request`) and uses the same `BASE_URL` / `AGENT_ID` constants — single source of truth for the hal0 endpoint.
-
-## Data flow
-
-```
-turn_end fires
-  └─ pi.on("turn_end", (event, ctx) => …)
-       ├─ load AutoCaptureConfig (cwd-aware via ctx.cwd)
-       ├─ if !cfg.enabled → return
-       │
-       ├─ flushBufferIfAny()                       ── (a) retry
-       │     for each bank in buffer:
-       │       while buffer[bank].length > 0:
-       │         chunk = buffer[bank].shift()
-       │         try push; on failure, unshift back, break inner
-       │
-       ├─ compute newSourceTokens since lastPushedCoverageId
-       │     (linear walk of source entries after the marker; tool results
-       │      truncated to 2000 chars before measuring; metric is
-       │      text.length / 4 — heuristic, matches pi-OM's intent)
-       │
-       ├─ if newSourceTokens < cfg.minTokensBetweenPushes → return
-       │
-       ├─ serialize the same entries into a text chunk
-       │     shape (from pi-OM's serializeSourceAddressedBranchEntries):
-       │       [User]: <text>
-       │       [Assistant]: <text>
-       │       [Assistant tool calls]: tool(args); tool(args)
-       │       [Tool result]: <output truncated to 2000 chars>
-       │
-       ├─ prepend a 4-line header:
-       │     ## Auto-captured session chunk
-       │     cwd: <ctx.cwd>
-       │     timestamp: <ISO>
-       │     source entries: <id1> <id2> … <idN>
-       │
-       ├─ bank = selectBank(ctx.cwd, cfg)
-       ├─ tags = [...cfg.tags, "session:<sid>", "project:<git-remote-or-none>"]
-       │
-       ├─ POST /api/memory/add { text, tags }
-       │     headers X-hal0-Agent: pi-coder
-       │             X-hal0-Private: <0 if shared else 1>
-       │     AbortSignal.timeout(10_000)
-       │
-       ├─ on success:
-       │     append custom entry `autoMemory.pushed`
-       │       { pushId: <operation_id>, bank, tokenCount,
-       │         sourceEntryIds, timestamp, firstSourceId, lastSourceId }
-       │     lastPushedCoverageId = new entry id
-       │
-       └─ on failure (network error, !res.ok, timeout):
-             buffer[bank].push({text, tags, sourceEntryIds, attemptedAt: now})
-             if buffer[bank].length > 4:
-               drop oldest
-               if !bufferOverflowWarned.has(bank):
-                 ctx.ui.notify("hal0-memory autoCapture: buffer overflow on <bank>, dropped oldest chunk", "warning")
-                 bufferOverflowWarned.add(bank)
-             return (do NOT append coverage marker)
+~/.pi/agent/extensions/hindsight/
+  index.ts      — entry point, registers tools + hooks
+  client.ts     — HindsightClient (REST wrapper for /v1/default/banks/{id}/...)
+  bank.ts       — deriveBankId (static/dynamic/directoryBankMap + git worktree),
+                  ensureBankMission
+  content.ts    — stripMemoryTags, composeRecallQuery, truncateRecallQuery,
+                  sliceLastTurnsByUserBoundary, prepareRetentionTranscript,
+                  formatMemories, formatCurrentTime
+  config.ts     — typed HindsightConfig + DEFAULT_HINDSIGHT_CONFIG
+  loader.ts     — 4-layer config merge: defaults → ~/.pi/agent/settings.json
+                  hindight block → ~/.hindsight/pi.json → HINDSIGHT_* env vars
+  state.ts      — PluginState (missionsSet, recalledSessions, turn counting)
+  hooks.ts      — session_start (recall), turn_end (retain), session_before_compact
+  *.test.ts     — unit tests (116 passing)
 ```
 
-Order matters: **(a) flush-first then (b) compute-and-push**. This way a transient hal0 outage drains before fresh pushes accumulate, and the next turn never skips a retry that could have succeeded.
+All 116 unit tests pass via `node --experimental-strip-types --test *.test.ts`.
 
-## Bank selector (`bank-selector.ts`)
+## Dynamic Bank IDs
 
-Pure function, zero side effects:
+Supports three modes, ordered by priority:
 
-```ts
-export function selectBank(
-  cwd: string,
-  cfg: AutoCaptureConfig,
-): "shared" | "private" {
-  const home = os.homedir();
-  const expanded = (p: string) => p.replace(/^~/, home);
+1. **directoryBankMap** — explicit directory → bank overrides (highest)
+2. **dynamicBankId** — composed from `dynamicBankGranularity` fields
+3. **static** — single fixed `bankId` or default `"pi-coder"`
 
-  // Rule R3 — scratch roots deny shared
-  for (const r of cfg.scratchRoots) {
-    if (isUnder(cwd, expanded(r))) return "private";
+Dynamic granularity fields: `agent`, `project`, `session`, `channel`, `user`.
+
+Git-worktree-aware project resolution enabled by default (`resolveWorktrees: true`) so linked worktrees share one bank.
+
+Channel and user come from `HINDSIGHT_CHANNEL_ID` / `HINDSIGHT_USER_ID` env vars.
+
+## What was replaced
+
+| Old | New |
+| --- | --- |
+| `npm:pi-observational-memory` | Removed (uninstalled) |
+| `~/.pi/agent/extensions/hal0-memory/` | Deleted (auto-discovery removed) |
+| `observational-memory` settings block | Removed |
+| `hal0_memory_add/search/recall/list/delete/whoami` tools | `hindsight_retain/recall/reflect/status` tools |
+| Thin-bridge auto-capture (auto-capture.ts, bank-selector.ts, etc.) | Claude Code plugin port (hooks.ts, client.ts, bank.ts, content.ts) |
+| hal0-api proxy (<http://10.0.1.142:8080>) | Hindsight direct (<http://10.0.1.142:9177>) |
+
+## Verification
+
+Smoke-tested live against Hindsight 0.8.4 at `http://10.0.1.142:9177`:
+
+- ✅ Retain → server extracts within ~5s
+- ✅ Recall → returns ranked facts with scores
+- ✅ Reflect → synthesizes coherent markdown response
+- ✅ listBanks → 7 banks visible
+- ✅ healthCheck → `/health` returns 200
+
+## Settings (`~/.pi/agent/settings.json`)
+
+```json
+{
+  "hindsight": {
+    "hindsightApiUrl": "http://10.0.1.142:9177",
+    "bankId": null,
+    "dynamicBankId": false,
+    "dynamicBankGranularity": ["agent", "project"],
+    "resolveWorktrees": true,
+    "autoRecall": true,
+    "autoRetain": true,
+    "retainMode": "full-session",
+    "retainEveryNTurns": 3,
+    "retainOverlapTurns": 2,
+    "recallBudget": "mid",
+    "recallMaxTokens": 1024,
+    "recallTypes": ["world", "experience", "observation"],
+    "debug": false
   }
-  // Project markers promote shared
-  for (const m of cfg.projectMarkers) {
-    if (fs.existsSync(path.join(cwd, m))) return "shared";
-  }
-  return cfg.defaultBank;
-}
-
-function isUnder(child: string, parent: string): boolean {
-  const rel = path.relative(parent, child);
-  return !!rel && !rel.startsWith("..") && !path.isAbsolute(rel);
 }
 ```
 
-Defaults:
+## Implementation done
 
-- `scratchRoots: ["~/.pi", "~/scratch", "~/tmp"]`
-- `projectMarkers: ["pyproject.toml", "package.json", "Cargo.toml", "go.mod"]`
-- `defaultBank: "private"`
-
-All three overridable in settings. The `defaultBank` is the third fallback so users who only want "shared in projects, private everywhere else" can leave defaults; users who want "shared everywhere outside `~/.pi`" can set `scratchRoots: ["~/.pi"]`.
-
-## Error handling
-
-Failure modes for `POST /api/memory/add`:
-
-1. **Network error / DNS / TCP reset** → `fetch` rejects with `TypeError`. Caught, treated as transient.
-2. **hal0-api 5xx** → `!res.ok`, body captured for logs.
-3. **hal0-api 4xx** (e.g., malformed payload) → `!res.ok`. Treated as transient too, because we don't have a clean way to distinguish "fixable" from "permanent" without inspecting the body.
-4. **Timeout** (`AbortSignal.timeout(10_000)`) → treated as transient.
-5. **JSON parse failure on success body** → caught, logged, treated as success-but-warning because the `operation_id` could not be parsed (we still append the coverage marker with `pushId: undefined`).
-
-Buffer policy:
-
-- 4 chunks per bank. Each chunk is one `turn_end` push worth of text.
-- The threshold gate (`minTokensBetweenPushes = 25000` by default) is a lower bound — pushes only happen at or above 25k new tokens. There is no upper bound on a single chunk; a dense turn can produce one chunk much larger than 25k tokens.
-- Buffer overflow drops oldest, single `ui.notify` warning per bank per session. The latch is reset on every `session_start`.
-- A `hal0_memory_whoami`-style endpoint reachability check happens once per session in `session_start`; if the endpoint is unreachable, the bridge sets `endpointReachable = false`, fires a single `ui.notify`, and skips all `turn_end` work for the rest of the session. This avoids spamming the buffer on a fully-down hal0-api. Re-enabling requires the user to start a new pi session (no mid-session re-probe).
-
-## Token-threshold coverage tracking
-
-The "new-source tokens since last push" metric is local and cheap:
-
-- Walk source entries after the last `autoMemory.pushed` marker (or since session start if none).
-- For each entry: serialize to text using the same shape as the push payload, but only for measurement. Use `serializeConversation`-style markers. Tool results truncated to 2000 chars before counting.
-- Total `text.length / 4` rounded to integer.
-- If the result is `< cfg.minTokensBetweenPushes`, skip.
-
-This is a heuristic — the pi-OM package used the same shape. We don't need exact token counts; we need a stable, predictable trigger.
-
-On the very first `turn_end` of a session, `lastPushedCoverageId` is undefined, so the walk covers the entire historical session since the start. If that exceeds the threshold, we push. This is intentional — cold-start sessions get caught up.
-
-## Configuration shape
-
-`~/.pi/agent/settings.json` diff:
-
-```diff
-   "packages": [
-     "extensions/hal0-provider",
--    "npm:pi-observational-memory",
-     "npm:@juicesharp/rpiv-todo",
-     "npm:pi-lens",
-     …
-   ],
--  "observational-memory": {
--    "observeAfterTokens": 25000,
--    "reflectAfterTokens": 50000,
--    "compactAfterTokens": 70000,
--    "compactAfterTokensMode": "calibrated",
--    "compactAfterTokensRatio": 0.68,
--    "observationsPoolMaxTokens": 25000,
--    "observationsPoolTargetTokens": 15000,
--    "agentMaxTurns": 16,
--    "model": {
--      "provider": "hal0",
--      "id": "utility",
--      "thinking": "low"
--    },
--    "passive": false,
--    "debugLog": false
--  },
-+  "hal0-memory": {
-+    "autoCapture": {
-+      "enabled": true,
-+      "minTokensBetweenPushes": 25000,
-+      "scratchRoots": ["~/.pi", "~/scratch", "~/tmp"],
-+      "projectMarkers": ["pyproject.toml", "package.json", "Cargo.toml", "go.mod"],
-+      "defaultBank": "private",
-+      "tags": ["obs:auto", "agent:pi-coder"],
-+      "pushTimeoutMs": 10000,
-+      "bufferMaxChunksPerBank": 4
-+    }
-+  },
-```
-
-`~/.pi/agent/npm/package.json` diff:
-
-```diff
-   "dependencies": {
--    "pi-observational-memory": "^3.0.3"
-   }
-```
-
-After applying: `cd ~/.pi/agent/npm && npm uninstall pi-observational-memory` to drop the directory and prune `node_modules`.
-
-The hal0-memory extension is loaded via `extensions/hal0-provider` in `packages`, which already wires the directory into pi. No package list change is needed for the extension itself — only the new module file (`auto-capture.ts`) inside the extension directory.
-
-## Settings migration safety
-
-The old `observational-memory` block has 12 keys. After removal, the only safe removal is the whole block — partial migration could leave dangling keys that nothing reads. So:
-
-1. Backup `~/.pi/agent/settings.json` to `~/.pi/agent/settings.json.bak-pre-om-merge-<timestamp>` before any edit.
-2. Remove the entire `observational-memory` block atomically (one edit).
-3. Add the new `hal0-memory.autoCapture` block atomically (one edit).
-4. Verify with `cat ~/.pi/agent/settings.json | python3 -m json.tool` before saving.
-
-If anything fails partway, restore from the timestamped backup.
-
-## Testing
-
-Unit tests live next to the source (no test runner other than `node --test` to avoid adding dependencies):
-
-- `bank-selector.test.ts`
-  - cwd under `~/.pi/sessions/...` → private
-  - cwd under `~/scratch/...` → private
-  - cwd under `~/hal0/src/foo` (has `pyproject.toml`) → shared
-  - cwd under `~/projects/foo` (has `package.json`) → shared
-  - cwd under an empty dir with no markers and not in scratch → default ("private")
-  - custom `scratchRoots: ["~/.pi"]`, cwd under `~/scratch` → default ("private") confirms scratch list override works
-  - custom `defaultBank: "shared"`, cwd outside projects → "shared"
-  - path-boundary edge case: cwd exactly equal to a scratch root → private (boundary inclusive)
-  - path-boundary edge case: cwd that starts with `~/.pi` as a string prefix but isn't actually under it (e.g., `~/.piXYZ`) → not under
-
-- `auto-capture.test.ts`
-  - threshold gate: 24,999 new tokens → no push; 25,001 → push
-  - first-of-session: no prior marker → push when total exceeds threshold
-  - bank isolation: failed push to shared does not block push to private
-  - buffer cap: 5 failures → 4 buffered, oldest dropped, warning fired
-  - buffer warning latch: second overflow on same bank → no second warning
-  - flush-on-next-turn: after a failure, the next turn_end successfully drains the buffer before computing its own chunk
-  - coverage marker: `autoMemory.pushed` entry is appended on success, not on failure
-  - session_start: `whoami` unreachable → `cfg.enabled = false`, single notify, no subsequent pushes
-  - tool result truncation in measurement (a 10,000-char tool result counts as 2000 chars toward threshold)
-
-Manual smoke test on a real pi session:
-
-1. Apply settings changes; restart pi.
-2. Confirm `/mem-doctor` shows hal0-api reachable.
-3. From `~/hal0/src/foo` (a project marker cwd), run a 3-turn conversation. Verify 1 push lands in `shared` via `hal0_memory_list`.
-4. From `~/.pi/sessions/...` (a scratch cwd), run a 3-turn conversation. Verify 1 push lands in `private:pi-coder` via `hal0_memory_list`.
-5. Inspect `hal0_memory_recall "what did I work on today"` — should surface both pushes' extracted facts.
-
-## Risks
-
-1. **Buffer cap may be too small for long hal0 outages.** If hal0-api is down for a full work session, the bridge drops oldest chunks. Mitigation: the LLM tool `hal0_memory_add` (still callable explicitly) lets the agent catch up at any time. Acceptable for an observability feature.
-
-2. **Cold-start push may be large.** First `turn_end` of a session with no prior marker measures from session start; for a long-resumed session this could push tens of thousands of tokens in one go. Hindsight's extraction handles large inputs (the existing `hal0_memory_add` tool has been used for similar payloads). Acceptable.
-
-3. **Coverage marker never gets pruned.** Each successful push appends a `custom` entry to the jsonl. For a long session with many pushes, this adds a small constant per push to the session file size. Mitigation: markers are tiny (`<200` chars each), and `pi.compact` drops them along with the rest of the source when the session is compacted.
-
-4. **`/om-status` and `/om-view` muscle memory.** Users who learned these commands will get "command not found" until they re-learn `/mem-doctor` / `/mem` / `hal0_memory_recall`. Acceptable; commands are listed by `/help`.
-
-5. **No migration of historical pi-OM entries.** Old session files contain `om.observations.recorded` entries that are now ignored. The next time those sessions are loaded, pi renders them as opaque custom entries. Acceptable per user decision.
-
-## What the user sees after delivery
-
-- `settings.json` is shorter (one block removed, one small block added).
-- `~/.pi/agent/npm/node_modules/pi-observational-memory/` is gone.
-- The LLM tool list in pi is unchanged (`hal0_memory_*` tools still present; `recall_observation` is gone).
-- The slash command list loses `/om-status` and `/om-view`. `pi help` shows `/mem`, `/mem-recall`, `/mem-forget`, `/mem-doctor`.
-- During a session, every heavy `turn_end` produces a status toast: `hal0-memory autoCapture: pushed ~28k tokens → bank=shared`.
-- `hal0_memory_search` and `hal0_memory_recall` return auto-captured session chunks along with anything the agent explicitly added.
-
-## Implementation outline (for the writing-plans handoff)
-
-1. Create `auto-capture.ts`, `config.ts`, `bank-selector.ts` inside `~/.pi/agent/extensions/hal0-memory/`.
-2. Wire `index.ts` to call the auto-capture module from `session_start` and `turn_end`.
-3. Add unit tests in the same directory.
-4. Back up and update `~/.pi/agent/settings.json` (drop `observational-memory` block, add `hal0-memory.autoCapture`).
-5. Update `~/.pi/agent/npm/package.json` (drop `pi-observational-memory` dependency).
-6. Run `npm uninstall pi-observational-memory` in `~/.pi/agent/npm/`.
-7. Smoke test from a project cwd and a scratch cwd.
-8. Verify `/mem-doctor` and `hal0_memory_recall` surface the auto-captured chunks.
+1. Ported Claude Code plugin → TypeScript pi extension
+2. 116 unit tests passing
+3. Settings.json updated (dropped OM block, dropped pi-OM from packages, added hindsight block)
+4. `~/.pi/agent/extensions/hal0-memory/` deleted (auto-discovery would race)
+5. `pi-observational-memory` uninstalled from `~/.pi/agent/npm/`
+6. Live Hindsight smoke tested (retain → recall → reflect)

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2225,22 +2225,17 @@ else
         # "split-brain" root-owned tree `hal0 doctor perms` flags as Hermes
         # ownership drift (check_hermes_ownership's stray_home check; see
         # installer/lib/run-as-hal0.sh's docstring, which names this same
-        # failure mode #843). Drop to hal0 first (same runuser -> setpriv ->
-        # sudo cascade run-as-hal0.sh uses) so this subprocess never runs as
-        # root and never creates /root/.hermes.
-        if command -v runuser >/dev/null 2>&1; then
-            runuser -u hal0 -- env -u HERMES_HOME HOME=/var/lib/hal0 \
-                /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null \
-                || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
-        elif command -v setpriv >/dev/null 2>&1; then
-            setpriv --reuid hal0 --regid hal0 --init-groups -- env -u HERMES_HOME HOME=/var/lib/hal0 \
-                /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null \
-                || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
-        else
-            sudo -H -u hal0 -- env -u HERMES_HOME \
-                /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null \
-                || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
-        fi
+        # `hermes gateway install --system` checks os.geteuid() == 0
+        # internally and refuses when invoked by a non-root user. The
+        # `--run-as-user hal0` flag tells the hermes CLI which runtime
+        # user to write into the systemd unit — we do NOT drop to that
+        # user here. Run the install command AS ROOT directly (the
+        # #843 safeguard for /root/.hermes is satisfied by the
+        # $HOME=/var/lib/hal0 override and the fact that 'pip install'
+        # was already done as hal0 earlier in the provisioning block).
+        env -u HERMES_HOME HOME=/var/lib/hal0 \
+            /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null \
+            || warn "hermes gateway install failed — Telegram/Discord bridge unavailable; continuing"
         # Only enable/start if hermes actually laid down the unit. If the
         # install genuinely failed the file is absent; `systemctl enable` would
         # otherwise emit a scary "Unit file … does not exist" error and trip
@@ -2256,7 +2251,7 @@ else
             fi
         else
             warn "hermes-gateway unit not installed (${GATEWAY_UNIT_DST} missing) — Telegram/Discord bridge unavailable"
-            warn "  retry with 'sudo -u hal0 env -u HERMES_HOME /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null'"
+            warn "  retry with 'HERMES_HOME= /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null'"
         fi
     elif [[ -f "${AGENT_UNIT_DST}" ]]; then
         # No venv after the provision block: it was skipped (HAL0_SKIP_HERMES=1)


### PR DESCRIPTION
## Problem

The installer's hermes gateway provisioning block drops to the `hal0` user (via `runuser` / `setpriv` / `sudo -u hal0`) before calling `hermes gateway install --system --run-as-user hal0`. The `--run-as-user hal0` flag already tells hermes which runtime user to bake into the systemd unit — but `hermes gateway install --system` internally checks `os.geteuid() == 0` and refuses when invoked by a non-root user:

```
System gateway install requires root. Re-run with sudo.
```

Result: hermes gateway never gets installed, Telegram/Discord bridge is unavailable on every clean install. The installer falls through to a soft warning ("Telegram/Discord bridge unavailable; continuing") but the user has to manually repair post-install.

## Root cause

The three-branch `runuser`/`setpriv`/`sudo` cascade was written to prevent the **#843** regression (root running hermes commands would create `/root/.hermes` with root ownership, breaking the hal0 user's subsequent hermes access). But the gateway install step doesn't touch `~/.hermes` at all — it only writes a systemd unit file — so the #843 guard is misapplied here. The `$HOME=/var/lib/hal0` override and the fact that `pip install` already ran as hal0 in the provisioning block above are sufficient to prevent #843.

## Fix

Replace the three-branch cascade with a single direct call:

```bash
env -u HERMES_HOME HOME=/var/lib/hal0 \
    /var/lib/hal0/venvs/hermes/bin/hermes gateway install --system --run-as-user hal0 </dev/null
```

Runs the command as root (satisfying hermes' `os.geteuid() == 0` check) while keeping the `$HOME` redirect and `HERMES_HOME` unset to prevent root-owned state leakage.

Also updates the fallback retry hint at the bottom of the function to match the corrected invocation.

## Validation

On **halo150** (10.0.1.150, privileged LXC, podman 4.9.3, root):
- Full clean reinstall from latest main code
- Hermes gateway unit installed successfully on first attempt
- `hermes-gateway.service` active, enabled
- hal0 doctor: all 13 checks pass (pre-existing brain/embed slot model-missing errors unchanged)