### PR TITLE
fix(ui): normalize memory graph slot selector

### DIFF
--- a/ui/src/dash/agents/memory-tab.jsx
+++ b/ui/src/dash/agents/memory-tab.jsx
@@ -83,6 +83,15 @@ function MemoryTab({ subsection } = {}) { // eslint-disable-line no-unused-vars
 
 // ── ADR-0023 Graph extraction panel ──────────────────────────────────
 // Extraction is routed to a single local enabled-llm slot (extraction_slot).
+function normalizeMemoryGraphSlot(value, availableSlots = []) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  const prefix = "hal0/";
+  if (!raw.startsWith(prefix)) return raw;
+  const slotName = raw.slice(prefix.length);
+  return availableSlots.includes(slotName) ? slotName : raw;
+}
+
 function MemoryGraphPanel() {
   const useStatus = window.__hal0UseMemoryGraphStatus;
   const useUpdate = window.__hal0UseUpdateMemoryGraph;
@@ -92,12 +101,18 @@ function MemoryGraphPanel() {
   const enabled = !!(data && data.enabled);
   // ADR-0023: prefer extraction_slot; fall back to the deprecated `route`
   // mirror only if the new field is absent.
-  const extractionSlot = (data && (data.extraction_slot || data.route)) || "utility";
   const slotResolves = !!(data && data.slot_resolves);
   const availableSlots = (data && data.available_slots) || [];
+  const configuredSlot = (data && (data.extraction_slot || data.route)) || "utility";
+  const extractionSlot = normalizeMemoryGraphSlot(configuredSlot, availableSlots);
 
   const [showSlotPicker, setShowSlotPicker] = useStateMT(false);
   const [draftSlot, setDraftSlot] = useStateMT(extractionSlot);
+  const canonicalDraftSlot = normalizeMemoryGraphSlot(draftSlot, availableSlots);
+  const slotOptions =
+    canonicalDraftSlot && !availableSlots.includes(canonicalDraftSlot)
+      ? [canonicalDraftSlot, ...availableSlots]
+      : availableSlots;
 
   const openPanel = () => {
     setDraftSlot(extractionSlot);
@@ -105,7 +120,7 @@ function MemoryGraphPanel() {
   };
 
   const submit = () => {
-    const payload = { enabled: true, extraction_slot: draftSlot };
+    const payload = { enabled: true, extraction_slot: canonicalDraftSlot };
     update.mutate(payload, {
       onSuccess: (resp) => {
         setShowSlotPicker(false);
@@ -218,15 +233,15 @@ function MemoryGraphPanel() {
         <div style={{display: "flex", flexDirection: "column", gap: 14}}>
           <div>
             <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 6}}>Extraction slot</div>
-            {availableSlots.length > 0 ? (
+            {slotOptions.length > 0 ? (
               <select
                 data-testid="graph-slot-select"
-                value={draftSlot}
+                value={canonicalDraftSlot}
                 onChange={e => setDraftSlot(e.target.value)}
                 style={{width: "100%", padding: "6px 8px", background: "var(--bg-2)", border: "1px solid var(--line)", color: "var(--fg)", fontFamily: "var(--jbm)", fontSize: 12}}
               >
-                {availableSlots.map(s => (
-                  <option key={s} value={s}>{s}</option>
+                {slotOptions.map(s => (
+                  <option key={s} value={s}>{s}{availableSlots.includes(s) ? "" : " (not running)"}</option>
                 ))}
               </select>
             ) : (
@@ -246,7 +261,7 @@ function MemoryGraphPanel() {
             <div className="mono" style={{fontSize: 10, color: "var(--fg-4)", textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 4}}>Routing</div>
             <p style={{fontSize: 12, color: "var(--fg-2)", margin: 0, lineHeight: 1.5}}>
               Graph extraction sends ingested memory text to the&nbsp;
-              <span className="mono" style={{color: "var(--fg)"}}>{draftSlot}</span> slot
+              <span className="mono" style={{color: "var(--fg)"}}>{canonicalDraftSlot}</span> slot
               {" "}for entity + relation extraction. Everything stays on-box — pick a
               cheap local slot (e.g. <span className="mono" style={{color: "var(--fg)"}}>utility</span>)
               to keep extraction light. Quality may vary on small models.

--- a/ui/src/dash/settings/pages/data/MemoryPage.jsx
+++ b/ui/src/dash/settings/pages/data/MemoryPage.jsx
@@ -9,6 +9,7 @@ import { useMemoryGraphStatus, useRetryFailedExtractions, useUpdateMemoryGraph }
 import { ApplyBadge } from '../../shared/ApplyBadge.jsx'
 import { SRow } from '../../shared/SRow.jsx'
 import { AdvRow, _schemaField, _getIn, _deepMergePatch, _advCoerce, _advInputStyle } from '../../shared/SchemaRow.jsx'
+import { normalizeMemoryGraphSlot } from './memoryGraphSlot.js'
 
 export function MemoryPage() {
   // R5 data seam: one typed client supplies the merged reload-class registry.
@@ -350,29 +351,31 @@ function MemoryGraphPanel() {
   const [enabled, setEnabled] = useState(false);
   const [slot, setSlot] = useState("");
   const [timeoutS, setTimeoutS] = useState("300");
+  const slots = st?.available_slots || [];
+  const currentSlot = normalizeMemoryGraphSlot(st?.extraction_slot || "", slots);
   useEffect(() => {
     if (!st) return;
     setEnabled(!!st.enabled);
-    setSlot(st.extraction_slot || "");
+    setSlot(normalizeMemoryGraphSlot(st.extraction_slot || "", st.available_slots || []));
     if (st.llm_timeout_s != null) setTimeoutS(String(st.llm_timeout_s));
-  }, [st?.enabled, st?.extraction_slot, st?.llm_timeout_s]);
+  }, [st?.enabled, st?.extraction_slot, st?.llm_timeout_s, st?.available_slots]);
 
   const timeoutNum = parseInt(timeoutS, 10);
   const timeoutValid = /^\d+$/.test(timeoutS.trim()) && timeoutNum >= 30 && timeoutNum <= 3600;
+  const canonicalSlot = normalizeMemoryGraphSlot(slot, slots);
   const dirty = !!st && (
     enabled !== !!st.enabled
-    || slot !== (st.extraction_slot || "")
+    || canonicalSlot !== currentSlot
     || (st.llm_timeout_s != null && timeoutS !== String(st.llm_timeout_s))
   );
-  const slots = st?.available_slots || [];
   // Keep the currently-configured slot pickable even when it no longer
   // resolves, so the operator can see (and move off) a stale value.
-  const slotOptions = slot && !slots.includes(slot) ? [slot, ...slots] : slots;
+  const slotOptions = canonicalSlot && !slots.includes(canonicalSlot) ? [canonicalSlot, ...slots] : slots;
 
   const doSave = async () => {
     try {
       const body = { enabled };
-      if (slot) body.extraction_slot = slot;
+      if (canonicalSlot) body.extraction_slot = canonicalSlot;
       if (timeoutValid) body.llm_timeout_s = timeoutNum;
       const resp = await updateGraph.mutateAsync(body);
       const perr = resp?.propagation?.error;
@@ -421,7 +424,13 @@ function MemoryGraphPanel() {
           : "Local LLM slot that runs the extraction prompts"}
         v={
           slotOptions.length > 0 ? (
-            <select value={slot} disabled={!st} onChange={e => setSlot(e.target.value)} style={_advInputStyle}>
+            <select
+              value={canonicalSlot}
+              disabled={!st}
+              onChange={e => setSlot(e.target.value)}
+              style={_advInputStyle}
+              data-testid="graph-slot-select"
+            >
               {slotOptions.map(s => (
                 <option key={s} value={s}>{s}{slots.includes(s) ? "" : " (not running)"}</option>
               ))}
@@ -474,7 +483,7 @@ function MemoryGraphPanel() {
         {dirty && (
           <button className="btn ghost sm" onClick={() => {
             setEnabled(!!st?.enabled);
-            setSlot(st?.extraction_slot || "");
+            setSlot(currentSlot);
             setTimeoutS(st?.llm_timeout_s != null ? String(st.llm_timeout_s) : "300");
           }}>Reset</button>
         )}

--- a/ui/src/dash/settings/pages/data/memoryGraphSlot.js
+++ b/ui/src/dash/settings/pages/data/memoryGraphSlot.js
@@ -1,0 +1,10 @@
+export function normalizeMemoryGraphSlot(value, availableSlots = []) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+
+  const prefix = "hal0/";
+  if (!raw.startsWith(prefix)) return raw;
+
+  const slotName = raw.slice(prefix.length);
+  return availableSlots.includes(slotName) ? slotName : raw;
+}

--- a/ui/src/dash/settings/pages/data/memoryGraphSlot.test.ts
+++ b/ui/src/dash/settings/pages/data/memoryGraphSlot.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeMemoryGraphSlot } from './memoryGraphSlot'
+
+describe('normalizeMemoryGraphSlot', () => {
+  it('submits canonical slot names instead of hal0 route aliases', () => {
+    expect(normalizeMemoryGraphSlot('hal0/utility', ['agent', 'utility'])).toBe('utility')
+  })
+
+  it('keeps plain slot names unchanged', () => {
+    expect(normalizeMemoryGraphSlot('utility', ['agent', 'utility'])).toBe('utility')
+  })
+
+  it('does not strip arbitrary routed model ids when no matching slot exists', () => {
+    expect(normalizeMemoryGraphSlot('hal0/unknown', ['agent', 'utility'])).toBe('hal0/unknown')
+  })
+
+  it('trims operator input', () => {
+    expect(normalizeMemoryGraphSlot('  hal0/agent  ', ['agent', 'utility'])).toBe('agent')
+  })
+})


### PR DESCRIPTION
## Summary
- normalize Hindsight memory graph slot aliases like hal0/utility to canonical available slots like utility
- submit the canonical slot value from the memory page selector/save path
- add focused unit coverage for alias normalization and unknown alias preservation

## Verification
- cd ui && npm run test:unit
- cd ui && npm run typecheck
- cd ui && npm run build

Note: build emits existing Vite chunk-size and Node DEP0205 warnings.