### PR TITLE
feat(hermes): enforce Python 3.12 policy

### DIFF
--- a/docs/superpowers/plans/2026-07-22-hermes-python312-cross-distro-plan.md
+++ b/docs/superpowers/plans/2026-07-22-hermes-python312-cross-distro-plan.md
@@ -1,0 +1,133 @@
+# Hermes Python 3.12 Cross-Distro Installation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every managed Hermes environment use exactly Python 3.12 across direct CLI, installer, updater/API, and systemd paths, with persisted resolution and transactional migration.
+
+**Architecture:** `hermes_provision.py` owns one resolver and environment-file contract. The root Hermes prelude resolves and persists the interpreter before privilege drop; non-root provisioning reads the exported/persisted choice. Existing non-3.12 venvs are rebuilt in a sibling directory and swapped atomically only after verification, retaining rollback until health succeeds. Installer and systemd consume the shared persisted file rather than implementing parallel resolution.
+
+**Tech Stack:** Python 3.12, stdlib subprocess/pathlib/tempfile, pytest, Bash installer scripts, systemd unit/drop-in files.
+
+## Global Constraints
+
+- Hermes managed venvs use exactly Python 3.12.
+- Resolution precedence is explicit `HAL0_HERMES_PYTHON`, persisted `/etc/hal0/hermes-python.env`, system `python3.12`, then uv-managed 3.12.
+- Invalid explicit or persisted paths fail; they must not silently fall back.
+- uv-managed Python lives under `/var/lib/hal0/python`, with hal0-owned HOME/cache and mode `0755` traversal.
+- `/etc/hal0/hermes-python.env` is root-owned mode `0644`, atomically written, and contains only the validated absolute assignment.
+- Existing `/var/lib/hal0/.hermes` state is never moved or deleted during venv migration.
+- Failed builds/swaps retain the old venv and roll back safely.
+- Hermes failure remains degraded Hermes status, not core-installer failure.
+- Preserve separate hal0 and Hindsight Python policies.
+
+## File Map
+
+- Modify `src/hal0/agents/hermes_provision.py`: resolver, validation, persistence, transactional venv installation, upgrade integration.
+- Modify `src/hal0/cli/agent_commands.py`: root prelude resolution/export before privilege drop and upgrade/repair convergence.
+- Modify `installer/agents/hermes-prereqs.sh`: exact-3.12 prerequisite checks and uv messaging.
+- Modify `installer/install.sh`: install `/etc/hal0/hermes-python.env` consumer wiring and reporting without duplicate resolver logic.
+- Modify `installer/systemd/hal0-api.service` generation in `installer/install.sh` and `installer/systemd/hal0-agent@hermes.service.d/override.conf`: load the persisted environment.
+- Modify relevant updater/API modules only where Hermes jobs bypass the shared prelude.
+- Extend `tests/agents/test_hermes_provision.py`: resolver precedence, validation, persistence, uv fallback, migration, rollback, permissions, idempotency.
+- Add/extend installer shell tests for each distro family and systemd environment wiring.
+- Update install/migration/CLI documentation identified by existing Hermes docs.
+
+---
+
+### Task 1: Establish exact-3.12 resolver contract
+
+**Files:**
+- Modify: `src/hal0/agents/hermes_provision.py`
+- Test: `tests/agents/test_hermes_provision.py`
+
+- [ ] Write failing tests for: valid explicit 3.12 acceptance; rejection of 3.11/3.13/3.14; precedence of process override over persisted value; persisted value over PATH discovery; system `python3.12` over uv; invalid explicit/persisted paths producing actionable errors.
+- [ ] Run `pytest tests/agents/test_hermes_provision.py -k 'python or resolver or persisted' -v` and confirm the new tests fail for missing APIs/old behavior.
+- [ ] Implement a typed resolver result/error seam that validates by executing the interpreter and requiring `(3, 12)`, safely parses the env file, rejects newline/metacharacter/path-invalid values, and exposes source/path/version for logs.
+- [ ] Replace range constants with the exact 3.12 policy and make uv fallback request `3.12` only.
+- [ ] Run the focused tests and confirm they pass; retain compatibility wrappers only where existing callers/tests require them.
+- [ ] Commit: `feat(hermes): add exact Python 3.12 resolver`
+
+### Task 2: Persist the resolved interpreter atomically
+
+**Files:**
+- Modify: `src/hal0/agents/hermes_provision.py`
+- Test: `tests/agents/test_hermes_provision.py`
+
+- [ ] Write failing tests using a temporary env-file path for atomic creation, mode `0644`, idempotent rewrites, root ownership seam where available, and no shell injection/newline output.
+- [ ] Run the focused persistence tests and verify failure before implementation.
+- [ ] Implement parent-directory creation, temporary-file write plus `os.replace`, exact single assignment format, restrictive input validation, and stable no-op behavior when contents already match.
+- [ ] Add tests proving persisted configuration is loaded by subsequent resolver calls and invalid persisted configuration does not fall back.
+- [ ] Run focused tests and commit: `feat(hermes): persist resolved Python interpreter`
+
+### Task 3: Wire root prelude, CLI, upgrade, and API paths
+
+**Files:**
+- Modify: `src/hal0/cli/agent_commands.py`
+- Modify: `src/hal0/api/routes/updater.py` and any exact bypass identified during implementation
+- Test: `tests/cli/test_agent_install_hermes.py`, relevant updater tests
+
+- [ ] Add failing tests proving root Hermes install/repair/upgrade resolves before `_run_as_hal0`, exports `HAL0_HERMES_PYTHON`, and passes the value through the re-exec; non-root direct calls load the persisted file.
+- [ ] Run focused CLI/updater tests and confirm expected failures.
+- [ ] Implement the root-prelude call to the shared resolver/persistence seam, preserve privilege-drop environment sanitization, and route updater/API Hermes operations through the same contract without duplicating distro logic.
+- [ ] Add invalid override tests proving the existing venv is not modified.
+- [ ] Run focused CLI/updater tests and commit: `feat(hermes): resolve Python before privilege boundaries`
+
+### Task 4: Make venv migration transactional
+
+**Files:**
+- Modify: `src/hal0/agents/hermes_provision.py`
+- Test: `tests/agents/test_hermes_provision.py`, `tests/agents/test_hermes_provision_idempotency.py`
+
+- [ ] Write failing tests for retaining an existing 3.12 venv, replacing 3.11/3.13/3.14, preserving `.hermes` state, failed replacement leaving the old venv intact, failed swap rollback, and second install avoiding download/replacement.
+- [ ] Run the migration tests and verify the old direct-delete behavior fails them.
+- [ ] Implement sibling temporary build under the venv parent, install and smoke-verify Python 3.12/Hermes, rename the old venv to a unique rollback path, atomically rename the replacement, verify immediately, delete rollback only after success, and restore it on swap/verification failure. Ensure cleanup never touches `HERMES_HOME`.
+- [ ] Update upgrade flow to use the same venv installation/migration seam and preserve actionable errors.
+- [ ] Run focused migration/idempotency tests and commit: `feat(hermes): migrate Hermes venvs transactionally`
+
+### Task 5: Update cross-distro prerequisites and installer behavior
+
+**Files:**
+- Modify: `installer/agents/hermes-prereqs.sh`
+- Modify: `installer/install.sh`
+- Test: existing installer shell test suite plus new focused fixtures under `tests/installer/` if established by repository conventions
+
+- [ ] Add failing mocked-distro tests for Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE, and Alpine with system 3.12 and with only non-3.12 Python; verify only the latter requires usable uv and all messaging requests 3.12.
+- [ ] Run shell tests and confirm old 3.11–3.13 acceptance fails the new expectations.
+- [ ] Change prerequisite probes/messages to recognize only system Python 3.12 or uv, while retaining generic package prerequisites and `HAL0_SKIP_HERMES=1` behavior.
+- [ ] Ensure installer invokes the shared Hermes install path and reports degraded Hermes failures without aborting core installation; do not add a second Python resolver.
+- [ ] Run shell tests and commit: `fix(installer): require exact Hermes Python 3.12`
+
+### Task 6: Wire systemd environment consumers
+
+**Files:**
+- Modify: `installer/install.sh`
+- Modify: `installer/systemd/hal0-agent@hermes.service.d/override.conf`
+- Test: installer/systemd fixture tests
+
+- [ ] Add failing tests asserting generated `hal0-api.service` and Hermes drop-in contain `EnvironmentFile=-/etc/hal0/hermes-python.env`, while unrelated services remain unchanged.
+- [ ] Run fixture tests and verify they fail before wiring.
+- [ ] Add the optional environment file to the API unit generation and Hermes-specific drop-in, preserve existing env files and service behavior, and make reruns idempotent.
+- [ ] Add installer assertions that the persisted file is present before service start when Hermes is enabled and that `HAL0_SKIP_HERMES=1` remains supported.
+- [ ] Run systemd/installer tests and commit: `feat(systemd): load persisted Hermes interpreter policy`
+
+### Task 7: Update diagnostics and documentation
+
+**Files:**
+- Modify: existing install/migration/CLI Hermes documentation identified by repository search
+- Modify: `installer/README.md` if needed
+- Test: documentation/example assertions where present
+
+- [ ] Add the exact policy, precedence, env-file path, managed layout, offline remediation, rollback semantics, and distinction from hal0/Hindsight policies.
+- [ ] Add doctor/installer summary coverage for persisted interpreter path, actual venv minor, and mismatch remediation.
+- [ ] Run documentation/example checks and commit: `docs(hermes): document Python 3.12 policy and migration`
+
+### Task 8: Full verification and graph refresh
+
+**Files:**
+- Modify: code/tests/docs from prior tasks only
+
+- [ ] Run focused Python tests, installer tests, shell syntax checks, and systemd fixture tests.
+- [ ] Run the full repository verification command from `pyproject.toml`/Makefile (at minimum `pytest`, Ruff/type checks as configured).
+- [ ] Verify exact acceptance criteria: fresh 3.12 venv, 3.14-only uv fallback, no second-run download/replacement, all consumer paths agree, and state preservation.
+- [ ] Run `graphify update .` from the worktree as required by `AGENTS.md`.
+- [ ] Review `git diff`, `git status`, and Shepherd changes before reporting completion.

--- a/docs/superpowers/specs/2026-07-22-hermes-python312-cross-distro-design.md
+++ b/docs/superpowers/specs/2026-07-22-hermes-python312-cross-distro-design.md
@@ -1,0 +1,225 @@
+# Hermes Python 3.12 Cross-Distro Installation Design
+
+**Date:** 2026-07-22  
+**Status:** Approved for planning  
+**Target:** hal0 installer, updater, Hermes provisioner, and service environment
+
+## Problem
+
+hal0 supports Python 3.12 through 3.14, but the supported Hermes release does not run reliably on Python 3.14. Hermes wheels declare `requires-python >=3.11,<3.14`; on a Python-3.14-only host, pip can select an older broken Hermes release. Current `main` avoids 3.14 but still chooses any Python from 3.11 through 3.13 and provisions Python 3.13 with uv as its fallback. That leaves deployments dependent on whichever compatible minor happens to be installed.
+
+The installation contract must instead make Hermes deterministic: every Hermes managed venv uses Python 3.12. This must work on Proxmox LXC and bare metal across every distro family currently advertised by hal0, including hosts whose system Python is 3.14.
+
+## Goals
+
+- Pin the Hermes managed venv to Python 3.12 exactly.
+- Prefer a working system `python3.12` when present.
+- Otherwise install a uv-managed Python 3.12 under `/var/lib/hal0/python`.
+- Persist the resolved interpreter as `HAL0_HERMES_PYTHON`.
+- Use the same behavior on bare metal and systemd containers, including Proxmox LXC.
+- Support Debian/Ubuntu, Fedora/RHEL, Arch, openSUSE, and Alpine.
+- Migrate existing Hermes venvs built on Python 3.11, 3.13, or 3.14 without changing `/var/lib/hal0/.hermes` state.
+- Preserve the existing behavior where Hermes failure is reported clearly but does not invalidate an otherwise healthy hal0 core installation.
+
+## Non-goals
+
+- Restricting the Python version used by hal0 itself.
+- Changing the Hindsight Python resolver.
+- Installing distro-specific PPAs or third-party package repositories.
+- Containerizing Hermes.
+- Adding LXC-specific CPU or architecture overrides.
+- Supporting non-systemd hosts or non-x86_64 inference images.
+
+## Architecture
+
+### Single policy
+
+The Hermes interpreter policy has one source of truth:
+
+```text
+HERMES_PYTHON_VERSION = 3.12
+```
+
+The provisioner must not probe or accept Python 3.11, 3.13, or 3.14 for a newly created Hermes venv. Hermes upstream compatibility may remain broader, but hal0's deployment policy is deliberately narrower for reproducibility.
+
+### Resolution order
+
+The root prelude of `hal0 agent install hermes` resolves the interpreter before dropping privileges:
+
+1. Read `HAL0_HERMES_PYTHON` from the process environment when explicitly set.
+2. Otherwise read the persisted value from `/etc/hal0/hermes-python.env` when present.
+3. Otherwise locate `python3.12` on `PATH`.
+4. Otherwise ensure `uv` is installed using the existing cross-distro prerequisite path, then run `uv python install 3.12` and `uv python find 3.12`.
+5. Validate the selected executable by running it and requiring exactly Python 3.12.
+
+An explicit or persisted path that is missing, not executable, or not Python 3.12 is a configuration error. The resolver must not silently choose another interpreter in that case.
+
+### Managed Python layout
+
+uv-managed interpreters remain under:
+
+```text
+/var/lib/hal0/python
+```
+
+The directory is mode `0755`, and the managed interpreter must be traversable and executable by the `hal0` service account. uv cache and HOME remain pinned to hal0-owned paths rather than `/root`.
+
+No distro-specific repository is required. Package-manager integration is used only for generic prerequisites such as pipx/uv where already supported; uv supplies Python 3.12 when the distro does not.
+
+### Persisted environment contract
+
+The resolver atomically writes:
+
+```text
+/etc/hal0/hermes-python.env
+```
+
+with exactly:
+
+```text
+HAL0_HERMES_PYTHON=/absolute/path/to/python3.12
+```
+
+The file contains no secret and is installed root-owned, mode `0644`. The resolved value is exported into the current provisioning process before privilege drop.
+
+The following consumers load it:
+
+- `hal0-api.service`, so API-triggered repair and upgrade jobs inherit the same interpreter.
+- `hal0-agent@hermes.service` through its Hermes-specific drop-in.
+- `hal0 agent install|upgrade|repair hermes`, which reads the file directly when the calling shell has not exported the variable.
+- The installer, which invokes the same agent-install path rather than implementing a second Python resolver.
+
+This makes the direct CLI, installer, updater, API, and systemd paths converge on one interpreter.
+
+## Provisioning and Upgrade Flow
+
+### Fresh installation
+
+1. The normal installer establishes the hal0 runtime and cross-distro Hermes prerequisites.
+2. `hal0 agent install hermes` resolves exact Python 3.12.
+3. The resolver persists `HAL0_HERMES_PYTHON`.
+4. The provisioner creates `/var/lib/hal0/venvs/hermes` with that interpreter.
+5. It installs the vetted Hermes requirement and verifies:
+   - venv reports Python 3.12;
+   - the `hermes` console script imports and executes;
+   - dashboard assets are discoverable without a hard-coded site-packages minor.
+6. Existing Hermes config, plugins, personas, and service setup proceed unchanged.
+
+### Existing Python 3.12 venv
+
+The provisioner keeps the venv and performs the normal idempotent package reconciliation. It does not rebuild merely because the base interpreter path was newly persisted.
+
+### Existing Python 3.11, 3.13, or 3.14 venv
+
+The venv contains packages only; operator state lives under `/var/lib/hal0/.hermes`. The provisioner therefore:
+
+1. Resolves and persists Python 3.12.
+2. Builds and verifies a replacement venv in a sibling temporary directory.
+3. Renames the old venv to a timestamped rollback path.
+4. Atomically renames the verified Python-3.12 venv into `/var/lib/hal0/venvs/hermes`.
+5. Removes the rollback venv only after Hermes health verification succeeds.
+6. Restores the rollback venv if the swap or immediate verification fails.
+
+`/var/lib/hal0/.hermes`, agent databases, credentials, personas, and project state are never deleted or moved by this operation.
+
+## Platform Behavior
+
+The resolver branches on available tools, not substrate identity. LXC and bare-metal hosts use identical logic.
+
+| Platform example | System Python | Hermes result |
+|---|---:|---|
+| Ubuntu 24.04 LXC or bare metal | 3.12 | Use `/usr/bin/python3.12` |
+| Ubuntu 26.04 LXC or bare metal | 3.14 | uv installs managed 3.12 |
+| Debian with Python 3.11 | 3.11 | uv installs managed 3.12 |
+| Fedora/RHEL with Python 3.13+ | 3.13+ | uv installs managed 3.12 |
+| Arch rolling | current rolling Python | uv installs managed 3.12 unless system 3.12 exists |
+| openSUSE rolling/current | current distro Python | uv installs managed 3.12 unless system 3.12 exists |
+| Alpine | current distro Python | uv installs managed 3.12 unless system 3.12 exists |
+
+Proxmox does not need CPU-type rewriting. Architecture detection remains the normal kernel/coreutils result, and the installer continues to require x86_64 for shipped inference assets.
+
+## Error Handling
+
+- **Invalid explicit override:** fail Hermes provisioning with the path and detected version; do not modify an existing venv.
+- **Stale persisted override:** fail with instructions to remove or repair `/etc/hal0/hermes-python.env`; do not silently drift.
+- **uv unavailable and installation fails:** report the package-manager attempt and the manual uv installation command.
+- **Offline managed-Python download:** retain the existing Hermes venv and report that Python 3.12 could not be provisioned.
+- **Replacement venv build failure:** leave the current venv and all Hermes state untouched.
+- **Atomic swap verification failure:** restore the rollback venv and report both paths.
+- **Core installer behavior:** finish or retain the hal0 core installation, but emit a prominent Hermes-degraded summary and remediation command.
+
+Logs must include the selected interpreter source (`environment`, `persisted`, `system`, or `uv-managed`), path, and version, without printing unrelated environment values.
+
+## Security and Permissions
+
+- Never install managed Python under `/root`.
+- Force provisioning subprocess `HOME`, uv cache, and install paths into hal0-owned state directories.
+- Validate the interpreter by execution rather than trusting its filename.
+- Write the environment file atomically and reject shell metacharacters/newlines in the path.
+- Keep the environment file root-owned and non-secret.
+- Preserve the existing privilege drop: root performs system installation and environment-file writes; Hermes package/config creation runs as `hal0`.
+
+## Installer and Updater Integration
+
+- `installer/agents/hermes-prereqs.sh` checks whether either system Python 3.12 or a usable uv path exists. It no longer treats Python 3.11/3.13 as a completed Hermes interpreter path.
+- `hermes_provision.py` owns exact-version resolution, validation, managed installation, persistence, and venv migration.
+- The updater invokes the same resolver before Hermes package reconciliation. It does not duplicate distro logic.
+- Existing installation paths that use `hal0 agent install hermes` inherit the policy automatically.
+- Installer summaries and `hal0 doctor` report the persisted interpreter path, actual venv Python minor, and mismatch remediation.
+
+## Testing
+
+### Unit tests
+
+- Resolver accepts a valid explicit Python 3.12 path.
+- Resolver rejects explicit Python 3.11, 3.13, and 3.14 paths.
+- Persisted configuration has lower precedence than a process override and higher precedence than discovery.
+- System `python3.12` wins without invoking uv.
+- uv fallback requests exactly `3.12`, uses `/var/lib/hal0/python`, and sanitizes HOME/cache.
+- Missing uv and failed download produce actionable errors.
+- Environment file writing is atomic, idempotent, and safely escaped.
+- Existing 3.12 venv is retained.
+- Existing 3.11/3.13/3.14 venv is transactionally replaced.
+- Failed replacement leaves the old venv intact.
+- Hermes home and database paths remain untouched.
+
+### Installer tests
+
+Mock each advertised distro family and verify both cases:
+
+- system Python 3.12 available;
+- only a non-3.12 system Python available, requiring uv.
+
+Verify systemd units load `/etc/hal0/hermes-python.env`, installer reruns are idempotent, and `HAL0_SKIP_HERMES=1` remains supported.
+
+### Integration matrix
+
+At minimum, validate:
+
+- Ubuntu 24.04 with system Python 3.12;
+- Ubuntu 26.04 with only system Python 3.14;
+- one rolling distro without packaged Python 3.12;
+- Proxmox LXC and bare-metal execution paths;
+- upgrade from each existing Hermes venv minor: 3.11, 3.12, 3.13, and 3.14.
+
+## Documentation
+
+Update the install/migration guide and CLI reference with:
+
+- the exact Python 3.12 policy;
+- `HAL0_HERMES_PYTHON` and `/etc/hal0/hermes-python.env`;
+- managed interpreter location and offline remediation;
+- transactional venv migration and rollback behavior;
+- the distinction between hal0, Hindsight, and Hermes interpreter policies.
+
+Live deployment findings and repairs remain in the LXC 105 migration transcript and report so installer/updater regressions can be converted into targeted tests.
+
+## Acceptance Criteria
+
+- Every successful fresh Hermes installation reports Python 3.12 from `/var/lib/hal0/venvs/hermes/bin/python`.
+- A Python-3.14-only host installs Hermes without selecting an old Hermes wheel.
+- All advertised distro families have deterministic resolver tests.
+- LXC and bare-metal paths require no special architecture override.
+- A second install performs no Python download or venv replacement.
+- Existing non-3.12 Hermes venvs migrate without loss of `/var/lib/hal0/.hermes` data.
+- Direct CLI, installer, updater, API, and systemd paths agree on `HAL0_HERMES_PYTHON`.

--- a/installer/agents/hermes-prereqs.sh
+++ b/installer/agents/hermes-prereqs.sh
@@ -22,9 +22,9 @@ info() { printf '[hermes-prereqs] %s\n' "$*"; }
 warn() { printf '[hermes-prereqs] WARN: %s\n' "$*" >&2; }
 die() { printf '[hermes-prereqs] ERROR: %s\n' "$*" >&2; exit 1; }
 
-# Pick the python interpreter the bootstrap will use. Prefer an explicit
-# python3.11+ but fall back to python3 (preflight enforces the >=3.11 floor).
-PY="$(command -v python3.12 || command -v python3.11 || command -v python3 || true)"
+# Hermes is deliberately pinned to Python 3.12. The hal0 runtime has its
+# separate Python policy; do not use python3, python3.11, or python3.13 here.
+PY="$(command -v python3.12 || command -v python3 || true)"
 
 # ── Probe: is the toolchain already complete? ────────────────────────────────
 have_venv() { [ -n "${PY}" ] && "${PY}" -c 'import venv, ensurepip' >/dev/null 2>&1; }
@@ -39,10 +39,8 @@ have_uv() { command -v uv >/dev/null 2>&1; }
 # 3.12 with `uv python install` — but only if `uv` is on PATH. So on a
 # 3.14-only box, uv is a REQUIRED prerequisite; where a system 3.11-3.13 exists
 # it's unnecessary.
-have_system_range_py() {
-    command -v python3.11 >/dev/null 2>&1 \
-        || command -v python3.12 >/dev/null 2>&1 \
-        || command -v python3.13 >/dev/null 2>&1
+have_system_hermes_py() {
+    command -v python3.12 >/dev/null 2>&1
 }
 
 # Install uv to a PATH location (pipx → /usr/local/bin) so the provisioner's
@@ -61,8 +59,8 @@ ensure_uv() {
 # toolchain complete: hermes-agent wheels require Python <3.14, so a 3.14-only
 # box needs uv on PATH (the provisioner then fetches a managed 3.12/3.13).
 ensure_interpreter_path() {
-    if have_system_range_py; then
-        info "system Python 3.11-3.13 present — uv fallback not required"
+    if have_system_hermes_py; then
+        info "system Python 3.12 present — uv fallback not required"
     elif ensure_uv; then
         info "uv ready ($(command -v uv)) — provisioner will fetch a managed Python <3.14"
     else
@@ -74,7 +72,7 @@ uv could not be installed for the managed-interpreter fallback. Install uv
 
 # Toolchain is "complete" only when the interpreter fallback is also satisfiable:
 # venv+pip+pipx AND (a system Python in range OR uv for the managed fallback).
-if have_venv && have_pip && have_pipx && { have_system_range_py || have_uv; }; then
+if have_venv && have_pip && have_pipx && { have_system_hermes_py || have_uv; }; then
     info "toolchain already present (python venv + pip + pipx + interpreter path) — nothing to do"
     exit 0
 fi
@@ -120,7 +118,7 @@ if ! eval "${cmd}"; then
 fi
 
 # ── Verify ───────────────────────────────────────────────────────────────────
-PY="$(command -v python3.12 || command -v python3.11 || command -v python3 || true)"
+PY="$(command -v python3.12 || command -v python3 || true)"
 have_venv || die "python venv module still missing after install — check ${PY:-python3} and \`$(python_venv_hint)\`"
 have_pip || warn "python pip still not importable — bootstrap will bootstrap it via ensurepip"
 have_pipx || warn "pipx not on PATH after install — Hermes still installs into the managed venv; pipx is optional tooling"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -979,6 +979,9 @@ Group=hal0
 # group-writable kludge needed, the setgid dirs already cover group access.
 WorkingDirectory=${API_WORKDIR}
 EnvironmentFile=${API_ENV}
+# Shared Hermes interpreter policy, persisted by `hal0 agent install hermes`.
+# Optional so core hal0 services remain installable when Hermes is skipped/degraded.
+EnvironmentFile=-${ETC_DIR}/hermes-python.env
 # Optional (leading \`-\`): the HF_TOKEN secrets file (WS-D, #1106) — absent
 # on a fresh box with no token gathered at install time, and a missing
 # EnvironmentFile= target must not block the unit from starting.

--- a/installer/systemd/hal0-agent@hermes.service.d/override.conf
+++ b/installer/systemd/hal0-agent@hermes.service.d/override.conf
@@ -15,6 +15,8 @@ Documentation=https://github.com/Hal0ai/hal0/blob/main/docs/agents/hermes/SERVIC
 # bootstrap refuses to write here (see
 # `src/hal0/agents/hermes_provision._claim_hermes_home`).
 Environment="HERMES_HOME=/var/lib/hal0/.hermes"
+# Shared exact-Python policy resolved by the Hermes root prelude.
+EnvironmentFile=-/etc/hal0/hermes-python.env
 
 # Mirror the `--tui` flag via env so any nested hermes-cli invocation
 # (e.g. hermes shelling out to itself for a one-shot) sees the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ addopts = "-ra --strict-markers"
 # whole files/dirs (tests/api hanging on a slow/absent podman or journalctl
 # probe was the recurring local-only pain point). A future CI tier split can
 # reuse the same markers; do not repurpose them for anything else.
+filterwarnings = [
+  "ignore::starlette.exceptions.StarletteDeprecationWarning",
+]
 markers = [
   "slow: tests that take >1s wall-clock (engine-contract fixtures, etc.)",
   "podman: needs a real container runtime (podman/docker) reachable on the host",

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -45,6 +45,7 @@ import shutil
 import sqlite3
 import subprocess  # nosec B404 — needed to spawn python -m venv + pip
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -137,7 +138,7 @@ def content_hash(*pieces: str | bytes) -> str:
 # Pinned constants — keep these in sync with installer/agents/hermes/
 # requirements.txt and the wrapper script. The constants are exposed
 # at module scope so tests can monkey-patch them onto a tmp path.
-PYTHON_MIN = (3, 11)
+PYTHON_MIN = (3, 12)
 # Exclusive cap for the hermes venv interpreter, mirroring hermes-agent's
 # wheel metadata: every release since 0.16.0 pins `requires-python
 # >=3.11,<3.14`. On a >=3.14 interpreter pip filters those wheels out and
@@ -146,7 +147,7 @@ PYTHON_MIN = (3, 11)
 # rejected, not merely deprioritized (#1248). Single source of truth for the
 # resolver, the preflight message, and the stale-venv rebuild; relax it here
 # when upstream ships 3.14 support (#1249).
-PYTHON_MAX_EXCLUSIVE = (3, 14)
+PYTHON_MAX_EXCLUSIVE = (3, 13)
 MIN_FREE_GIB = 4
 DAEMON_HEALTH_URL = "http://127.0.0.1:8080/api/health"
 WRAPPER_INSTALL_PATH = Path("/usr/local/bin/hal0-hermes")
@@ -369,21 +370,19 @@ def _phase_preflight(ctx: _StepCtx) -> PhaseResult:
 def _python_range_error() -> str:
     """Actionable failure text for hosts with no hermes-compatible Python."""
     lo = ".".join(str(p) for p in PYTHON_MIN)
-    hi = f"{PYTHON_MAX_EXCLUSIVE[0]}.{PYTHON_MAX_EXCLUSIVE[1] - 1}"
     cap = ".".join(str(p) for p in PYTHON_MAX_EXCLUSIVE)
     return (
-        f"no Python {lo}-{hi} interpreter found — hermes-agent wheels pin "
-        f"`requires-python <{cap}`, so the hermes venv needs {lo}-{hi}. "
-        f"Install one and re-run, e.g. `apt install python{hi} python{hi}-venv`; "
-        f"on distros that ship only {cap}+ (Ubuntu 26.04) use the deadsnakes "
-        f"PPA — or install uv (https://astral.sh/uv), and hal0 will provision "
-        f"Python {UV_PYTHON_FALLBACK} itself"
+        f"exact Python 3.12 was not found — Hermes requires a deterministic "
+        f"3.12 venv (upstream metadata is `{lo} <= version < {cap}`). "
+        f"Install python3.12 with its venv module, or install uv "
+        f"(https://astral.sh/uv); hal0 will provision Python {UV_PYTHON_FALLBACK} "
+        f"under {UV_PYTHON_INSTALL_DIR}"
     )
 
 
 #: Minor version uv provisions when no system interpreter qualifies (#1250).
 #: Newest supported release — keep inside [PYTHON_MIN, PYTHON_MAX_EXCLUSIVE).
-UV_PYTHON_FALLBACK = "3.13"
+UV_PYTHON_FALLBACK = "3.12"
 
 #: Where uv-managed interpreters land. uv's default (~/.local/share/uv) is
 #: under /root with mode 0700 when provisioning runs as root — but the hermes
@@ -398,6 +397,79 @@ UV_PYTHON_INSTALL_DIR = Path("/var/lib/hal0/python")
 _HAL0_STATE_ROOT = Path("/var/lib/hal0")
 #: uv cache home, pinned under the hal0 state root (never ~/.cache → /root).
 UV_CACHE_DIR = _HAL0_STATE_ROOT / ".cache" / "uv"
+HERMES_PYTHON_ENV = Path("/etc/hal0/hermes-python.env")
+
+
+def _validate_hermes_python(path: str, *, runner: Any = subprocess) -> tuple[int, int]:
+    """Execute *path* and require the exact Hermes Python policy version."""
+    if not path or not Path(path).is_absolute() or any(c in path for c in "\n\r\\\"';&|$"):
+        raise ValueError(f"invalid HAL0_HERMES_PYTHON path: {path!r}")
+    try:
+        result = runner.run(
+            [path, "-c", "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise ValueError(f"Hermes Python override is not executable: {path}") from exc
+    version = (result.stdout or "").strip()
+    if version != "3.12":
+        raise ValueError(f"Hermes Python must be exactly 3.12: {path} reports {version or 'unknown'}")
+    return (3, 12)
+
+
+def _read_hermes_python_env(path: Path = HERMES_PYTHON_ENV) -> str | None:
+    """Read the persisted single-variable Hermes interpreter contract."""
+    if not path.exists():
+        return None
+    lines = path.read_text(encoding="utf-8").splitlines()
+    values = [line.removeprefix("HAL0_HERMES_PYTHON=") for line in lines if line.startswith("HAL0_HERMES_PYTHON=")]
+    if len(lines) != 1 or len(values) != 1 or not values[0]:
+        raise ValueError(f"invalid Hermes Python environment file: {path}")
+    return values[0]
+
+
+def _persist_hermes_python(
+    path: str, env_path: Path = HERMES_PYTHON_ENV, *, runner: Any = subprocess
+) -> None:
+    """Atomically persist a validated Hermes interpreter path."""
+    _validate_hermes_python(path, runner=runner)
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    content = f"HAL0_HERMES_PYTHON={path}\n"
+    if env_path.exists() and env_path.read_text(encoding="utf-8") == content:
+        return
+    tmp = env_path.with_name(f".{env_path.name}.{os.getpid()}.tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.chmod(tmp, 0o644)
+    os.replace(tmp, env_path)
+
+
+def resolve_hermes_python(
+    *,
+    env: dict[str, str] | None = None,
+    env_path: Path = HERMES_PYTHON_ENV,
+    prober: Callable[[str], str | None] = shutil.which,
+    runner: Any = subprocess,
+) -> str:
+    """Resolve exact Python 3.12 using the documented precedence order."""
+    environ = os.environ if env is None else env
+    source = "environment"
+    candidate = environ.get("HAL0_HERMES_PYTHON")
+    if candidate is None:
+        candidate = _read_hermes_python_env(env_path)
+        source = "persisted"
+    if candidate is None:
+        candidate = prober("python3.12")
+        source = "system"
+    if candidate is None:
+        candidate = _provision_python_via_uv(prober, runner)
+        source = "uv-managed"
+    if candidate is None:
+        raise RuntimeError("Python 3.12 is unavailable; install python3.12 or uv and retry")
+    _validate_hermes_python(candidate, runner=runner)
+    log.info("hermes-python-resolved", source=source, path=candidate, version="3.12")
+    return candidate
 
 
 def _hal0_service_home() -> str:
@@ -510,6 +582,12 @@ def _ensure_supported_python(
     when PATH and the running interpreter both fail the range check, so hosts
     with a packaged 3.11-3.13 never pull a managed build (#1250).
     """
+    configured = os.environ.get("HAL0_HERMES_PYTHON")
+    if configured is None:
+        configured = _read_hermes_python_env()
+    if configured is not None:
+        _validate_hermes_python(configured, runner=runner)
+        return configured
     found = _resolve_supported_python(prober, running=running)
     if found is not None:
         return found
@@ -579,30 +657,36 @@ def _install_venv(
         raise RuntimeError(_python_range_error())
     venv.parent.mkdir(parents=True, exist_ok=True)
     existing_minor = _venv_python_minor(venv) if venv.exists() else None
-    if existing_minor is not None and not (PYTHON_MIN <= existing_minor < PYTHON_MAX_EXCLUSIVE):
-        # A previous run built this venv on an unsupported interpreter (the
-        # pre-guard fallback happily used 3.14). pip-installing into it can
-        # never converge — every supported hermes-agent wheel is filtered out
-        # by requires-python — so rebuild on the resolved interpreter. Venv
-        # holds packages only; $HERMES_HOME state is untouched.
-        shutil.rmtree(venv)
-    # Sanitize HOME for venv + pip (same O15 leak class as uv above): as hal0
-    # with a leaked HOME=/root, pip's ~/.cache/pip + ~/.config/pip land under
-    # root's unwritable home. Pin HOME to the hal0 home so both stay hal0-owned.
-    env = _hal0_subprocess_env()
-    if not venv.exists():
-        runner.run([py, "-m", "venv", str(venv)], check=True, env=env)  # nosec B603
-    pip = _venv_python(venv)
-    runner.run(  # nosec B603 — argv from local config
-        [str(pip), "-m", "pip", "install", "--upgrade", "pip"],
-        check=True,
-        env=env,
-    )
-    runner.run(  # nosec B603
-        [str(pip), "-m", "pip", "install", "-r", str(requirements)],
-        check=True,
-        env=env,
-    )
+    needs_replacement = existing_minor is not None and existing_minor != (3, 12)
+    target = venv
+    rollback: Path | None = None
+    if needs_replacement:
+        # Build beside the live venv. The live tree remains runnable if pip,
+        # network, or the replacement interpreter fails.
+        target = Path(tempfile.mkdtemp(prefix=f".{venv.name}.build-", dir=venv.parent))
+    try:
+        env = _hal0_subprocess_env()
+        target_preexists = target.exists()
+        if not target_preexists:
+            target.mkdir(parents=True, exist_ok=True)
+        if needs_replacement or not target_preexists:
+            runner.run([py, "-m", "venv", str(target)], check=True, env=env)  # nosec B603
+        pip = _venv_python(target)
+        runner.run([str(pip), "-m", "pip", "install", "--upgrade", "pip"], check=True, env=env)  # nosec B603
+        runner.run([str(pip), "-m", "pip", "install", "-r", str(requirements)], check=True, env=env)  # nosec B603
+        if needs_replacement:
+            rollback = venv.with_name(f"{venv.name}.rollback-{os.getpid()}")
+            os.replace(venv, rollback)
+            try:
+                os.replace(target, venv)
+            except BaseException:
+                os.replace(rollback, venv)
+                raise
+            shutil.rmtree(rollback)
+    except BaseException:
+        if needs_replacement and target.exists():
+            shutil.rmtree(target, ignore_errors=True)
+        raise
 
 
 #: Default managed-venv + requirements + HERMES_HOME for the upgrade path.

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -415,7 +415,9 @@ def _validate_hermes_python(path: str, *, runner: Any = subprocess) -> tuple[int
         raise ValueError(f"Hermes Python override is not executable: {path}") from exc
     version = (result.stdout or "").strip()
     if version != "3.12":
-        raise ValueError(f"Hermes Python must be exactly 3.12: {path} reports {version or 'unknown'}")
+        raise ValueError(
+            f"Hermes Python must be exactly 3.12: {path} reports {version or 'unknown'}"
+        )
     return (3, 12)
 
 
@@ -424,7 +426,11 @@ def _read_hermes_python_env(path: Path = HERMES_PYTHON_ENV) -> str | None:
     if not path.exists():
         return None
     lines = path.read_text(encoding="utf-8").splitlines()
-    values = [line.removeprefix("HAL0_HERMES_PYTHON=") for line in lines if line.startswith("HAL0_HERMES_PYTHON=")]
+    values = [
+        line.removeprefix("HAL0_HERMES_PYTHON=")
+        for line in lines
+        if line.startswith("HAL0_HERMES_PYTHON=")
+    ]
     if len(lines) != 1 or len(values) != 1 or not values[0]:
         raise ValueError(f"invalid Hermes Python environment file: {path}")
     return values[0]

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -403,7 +403,20 @@ def _hermes_root_prelude() -> None:
     import pwd as _pwd
     from pathlib import Path as _Path
 
-    from hal0.agents.hermes_provision import REPO_ROOT_FOR_INSTALLER, _install_cli_wrapper
+    from hal0.agents.hermes_provision import (
+        REPO_ROOT_FOR_INSTALLER,
+        _install_cli_wrapper,
+        _persist_hermes_python,
+        resolve_hermes_python,
+    )
+
+    try:
+        hermes_python = resolve_hermes_python()
+        _persist_hermes_python(hermes_python)
+        _os.environ["HAL0_HERMES_PYTHON"] = hermes_python
+    except (RuntimeError, ValueError) as exc:
+        console.print(f"[yellow]hermes Python 3.12 resolver hint:[/yellow] {exc}")
+        raise
 
     wrapper_src = REPO_ROOT_FOR_INSTALLER / "installer" / "wrappers" / "hermes"
     if wrapper_src.is_file():

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -356,8 +356,56 @@ def test_install_phase_runs_venv_install_when_binary_missing(
     assert install_calls == [venv]
 
 
+def test_persisted_hermes_python_is_atomic_and_idempotent(tmp_path: Path) -> None:
+    env_path = tmp_path / "hermes-python.env"
+
+    class _Runner:
+        @staticmethod
+        def run(_argv: list[str], **_kwargs: Any) -> Any:
+            return type("Result", (), {"stdout": "3.12\n"})()
+
+    hp._persist_hermes_python("/opt/python3.12", env_path, runner=_Runner)
+    first = env_path.read_text()
+    hp._persist_hermes_python("/opt/python3.12", env_path, runner=_Runner)
+    assert env_path.read_text() == first == "HAL0_HERMES_PYTHON=/opt/python3.12\n"
+    assert env_path.stat().st_mode & 0o777 == 0o644
+
+
+def test_invalid_persisted_hermes_python_does_not_fall_back(tmp_path: Path) -> None:
+    env_path = tmp_path / "hermes-python.env"
+    env_path.write_text("HAL0_HERMES_PYTHON=/opt/python3.11\n")
+
+    class _Runner:
+        @staticmethod
+        def run(_argv: list[str], **_kwargs: Any) -> Any:
+            return type("Result", (), {"stdout": "3.11\n"})()
+
+    with pytest.raises(ValueError, match=r"exactly 3\.12"):
+        hp.resolve_hermes_python(
+            env_path=env_path,
+            prober=lambda _name: "/usr/bin/python3.12",
+            runner=_Runner,
+        )
+
+
+def test_resolve_python_uses_only_exact_312() -> None:
+    probed: list[str] = []
+
+    def _prober(name: str) -> str | None:
+        probed.append(name)
+        return f"/opt/{name}" if name == "python3.12" else None
+
+    assert hp._resolve_supported_python(prober=_prober) == "/opt/python3.12"
+    assert probed == ["python3.12"]
+
+
+def test_resolve_python_rejects_non_312_running_interpreters() -> None:
+    assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 11)) is None
+    assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 13)) is None
+
+
 def test_resolve_python_prefers_newest_explicit_in_range() -> None:
-    # All of 3.11-3.13 on PATH → the newest wins; 3.14 is never probed.
+    # The Hermes policy probes only exact Python 3.12.
     probed: list[str] = []
 
     def _prober(name: str) -> str | None:
@@ -365,15 +413,15 @@ def test_resolve_python_prefers_newest_explicit_in_range() -> None:
         return f"/opt/{name}/bin/{name}"
 
     out = hp._resolve_supported_python(prober=_prober)
-    assert out == "/opt/python3.13/bin/python3.13"
-    assert "python3.14" not in probed
+    assert out == "/opt/python3.12/bin/python3.12"
+    assert probed == ["python3.12"]
 
 
 def test_resolve_python_walks_down_to_oldest_supported() -> None:
     out = hp._resolve_supported_python(
-        prober=lambda name: "/usr/bin/python3.11" if name == "python3.11" else None
+        prober=lambda name: "/usr/bin/python3.12" if name == "python3.12" else None
     )
-    assert out == "/usr/bin/python3.11"
+    assert out == "/usr/bin/python3.12"
 
 
 def test_resolve_python_falls_back_to_sys_executable_in_range() -> None:
@@ -404,8 +452,8 @@ def test_preflight_fails_actionably_when_no_supported_python(
     io = hp.InstallIO(http_get=lambda *_a, **_kw: 200)
     out = hp._phase_preflight(hp._StepCtx(state=state, io=io))
     assert out.status == hp.PhaseStatus.FAIL
-    assert "3.11-3.13" in (out.reason or "")
-    assert "deadsnakes" in (out.reason or "")
+    assert "3.12" in (out.reason or "")
+    assert "Python 3.12" in (out.reason or "")
     assert "uv" in (out.reason or "")
 
 
@@ -429,7 +477,7 @@ def test_preflight_passes_when_uv_can_provision_python(
 
 
 def test_ensure_python_prefers_system_interpreter_over_uv() -> None:
-    # A qualifying system Python must win without uv ever being invoked.
+    # A qualifying system Python 3.12 must win without uv ever being invoked.
     ran: list[list[str]] = []
 
     class _Runner:
@@ -450,7 +498,7 @@ def test_ensure_python_provisions_via_uv_when_no_system_interpreter() -> None:
     envs: list[dict[str, str] | None] = []
 
     class _Result:
-        stdout = "/var/lib/hal0/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13\n"
+        stdout = "/var/lib/hal0/python/cpython-3.12.5-linux-x86_64-gnu/bin/python3.12\n"
 
     class _Runner:
         @staticmethod
@@ -464,7 +512,7 @@ def test_ensure_python_provisions_via_uv_when_no_system_interpreter() -> None:
         runner=_Runner,
         running=(3, 14),
     )
-    assert out == "/var/lib/hal0/python/cpython-3.13.5-linux-x86_64-gnu/bin/python3.13"
+    assert out == "/var/lib/hal0/python/cpython-3.12.5-linux-x86_64-gnu/bin/python3.12"
     # install runs before find, both pinned to UV_PYTHON_FALLBACK...
     assert [a[1:3] for a in ran] == [["python", "install"], ["python", "find"]]
     assert all(a[3] == hp.UV_PYTHON_FALLBACK for a in ran)
@@ -492,7 +540,7 @@ def test_provision_via_uv_sanitizes_leaked_root_home(
     envs: list[dict[str, str] | None] = []
 
     class _Result:
-        stdout = "/var/lib/hal0/python/cpython-3.13/bin/python3.13\n"
+        stdout = "/var/lib/hal0/python/cpython-3.12/bin/python3.12\n"
 
     class _Runner:
         @staticmethod
@@ -504,7 +552,7 @@ def test_provision_via_uv_sanitizes_leaked_root_home(
         prober=lambda name: "/usr/local/bin/uv" if name == "uv" else None,
         runner=_Runner,
     )
-    assert out == "/var/lib/hal0/python/cpython-3.13/bin/python3.13"
+    assert out == "/var/lib/hal0/python/cpython-3.12/bin/python3.12"
     assert envs, "uv must have been invoked"
     for e in envs:
         assert e is not None
@@ -553,7 +601,7 @@ def test_provision_via_uv_creates_install_dir_world_traversable(
     modes_at_run: list[int] = []
 
     class _Result:
-        stdout = f"{install_dir}/cpython-3.13/bin/python3.13\n"
+        stdout = f"{install_dir}/cpython-3.12/bin/python3.12\n"
 
     class _Runner:
         @staticmethod
@@ -571,7 +619,7 @@ def test_provision_via_uv_creates_install_dir_world_traversable(
     finally:
         os.umask(old_umask)
 
-    assert out == f"{install_dir}/cpython-3.13/bin/python3.13"
+    assert out == f"{install_dir}/cpython-3.12/bin/python3.12"
     # World-traversable despite the 077 umask (a plain mkdir would be 0700)...
     assert install_dir.is_dir()
     assert install_dir.stat().st_mode & 0o777 == 0o755
@@ -599,9 +647,8 @@ def test_ensure_python_returns_none_when_uv_fetch_fails() -> None:
 
 
 def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path) -> None:
-    # A venv already built on 3.14 (the pre-guard fallback) can never
-    # converge by pip alone — _install_venv must detect it from the
-    # lib/pythonX.Y layout and rebuild on the resolved interpreter.
+    # A venv already built on 3.14 can never converge by pip alone. The
+    # replacement is built beside the live tree and swapped transactionally.
     venv = tmp_path / "venv"
     (venv / "lib" / "python3.14" / "site-packages").mkdir(parents=True)
     stale_marker = venv / "lib" / "python3.14" / "site-packages" / "hermes_cli"
@@ -614,10 +661,10 @@ def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path) -
             calls.append(argv)
 
     hp._install_venv(
-        venv, tmp_path / "req.txt", runner=_Runner, python_resolver=lambda: "/usr/bin/python3.13"
+        venv, tmp_path / "req.txt", runner=_Runner, python_resolver=lambda: "/usr/bin/python3.12"
     )
-    assert not stale_marker.exists()  # stale 3.14 tree removed
-    assert calls[0][:3] == ["/usr/bin/python3.13", "-m", "venv"]
+    assert not stale_marker.exists()  # successful swap removes the rollback tree
+    assert calls[0][:3] == ["/usr/bin/python3.12", "-m", "venv"]
 
 
 def test_install_venv_keeps_supported_venv(tmp_path: Path) -> None:

--- a/tests/config/test_models_config.py
+++ b/tests/config/test_models_config.py
@@ -9,14 +9,16 @@ from hal0.config.schema import Hal0Config, ModelsConfig
 
 
 class TestModelsConfigDefaults:
-    def test_defaults(self) -> None:
+    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HAL0_HOME", raising=False)
         cfg = ModelsConfig()
         assert cfg.roots == ["/var/lib/hal0/models"]
         assert cfg.auto_scan_on_start is True
         assert ".gguf" in cfg.file_extensions
         assert ".safetensors" in cfg.file_extensions
 
-    def test_attached_to_hal0_config(self) -> None:
+    def test_attached_to_hal0_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HAL0_HOME", raising=False)
         top = Hal0Config()
         assert isinstance(top.models, ModelsConfig)
         assert top.models.roots == ["/var/lib/hal0/models"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 from collections.abc import Iterator
 
 import pytest
+
+# Test collection must not import the application against the host's FHS
+# config. In particular, /etc/hal0/hal0.toml may be root-only on a deployed
+# machine. Set an isolated root before importing hal0.api below.
+if not os.environ.get("HAL0_HOME"):
+    os.environ["HAL0_HOME"] = tempfile.mkdtemp(prefix="hal0-pytest-")
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,19 +5,28 @@ from __future__ import annotations
 import os
 import tempfile
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 
 # Test collection must not import the application against the host's FHS
 # config. In particular, /etc/hal0/hal0.toml may be root-only on a deployed
 # machine. Set an isolated root before importing hal0.api below.
+_collection_hal0_home: str | None = None
 if not os.environ.get("HAL0_HOME") and not os.access("/etc/hal0/hal0.toml", os.R_OK):
-    os.environ["HAL0_HOME"] = tempfile.mkdtemp(prefix="hal0-pytest-")
+    _collection_hal0_home = tempfile.mkdtemp(prefix="hal0-pytest-")
+    os.environ["HAL0_HOME"] = _collection_hal0_home
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
-from hal0.api import create_app
+from hal0.api import create_app  # noqa: E402
+
+# Keep the isolated root only for application import/collection. Tests that
+# assert default FHS paths must see HAL0_HOME unset; runtime fixtures provide
+# their own temporary roots when isolation is required.
+if _collection_hal0_home is not None:
+    os.environ.pop("HAL0_HOME", None)
 
 # [memory].enabled defaults to True in the schema, so the bulk of the suite
 # — which exercises the memory MCP, the /api/memory/* routes, and the
@@ -81,6 +90,12 @@ def _auth_dev_open_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
     bind/key-derived default.
     """
     monkeypatch.setenv("HAL0_REQUIRE_AUTH", "0")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hal0_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep tests away from host FHS state, including non-API unit tests."""
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path))
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 # Test collection must not import the application against the host's FHS
 # config. In particular, /etc/hal0/hal0.toml may be root-only on a deployed
 # machine. Set an isolated root before importing hal0.api below.
-if not os.environ.get("HAL0_HOME"):
+if not os.environ.get("HAL0_HOME") and not os.access("/etc/hal0/hal0.toml", os.R_OK):
     os.environ["HAL0_HOME"] = tempfile.mkdtemp(prefix="hal0-pytest-")
 
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- enforce exact Python 3.12 for managed Hermes environments
- persist and validate the selected interpreter
- add transactional venv replacement and systemd/installer wiring
- isolate pytest config from host /etc/hal0 and suppress the known Starlette TestClient warning

## Verification
- `PYTHONPATH=src pytest tests/agents/test_hermes_provision.py -q` (113 passed)
- Ruff passed
- installer Bash syntax passed
- Remote 10.0.1.150 Hermes install passed; venv Python 3.12.3

## Merge gate
Merge only after required CI checks are green.