### PR TITLE
chore(hermes): clean up Python 3.12 resolver tests

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -582,11 +582,10 @@ def _ensure_supported_python(
     runner: Any = subprocess,
     running: tuple[int, int] | None = None,
 ) -> str | None:
-    """Resolve a venv interpreter: system Python first, uv-managed as fallback.
+    """Resolve the exact Python 3.12 interpreter for the Hermes venv.
 
-    A qualifying system interpreter always wins — the uv download only fires
-    when PATH and the running interpreter both fail the range check, so hosts
-    with a packaged 3.11-3.13 never pull a managed build (#1250).
+    A qualifying system ``python3.12`` wins before uv downloads a managed 3.12;
+    explicit and persisted overrides are validated before either fallback.
     """
     configured = os.environ.get("HAL0_HERMES_PYTHON")
     if configured is None:
@@ -605,15 +604,10 @@ def _resolve_supported_python(
     *,
     running: tuple[int, int] | None = None,
 ) -> str | None:
-    """Find an interpreter in hermes-agent's supported range, newest first.
+    """Find an exact Python 3.12 interpreter for Hermes venv creation.
 
-    Probes explicit ``python3.13`` → ``python3.11`` binaries on PATH so the
-    venv pins its minor version regardless of what ``sys.executable`` is.
-    Falls back to the running interpreter only when it is itself inside the
-    range — NOT merely ``>= 3.11``: on a Python-3.14-only host (Ubuntu 26.04)
-    the old fallback built the venv on 3.14, where pip filters out every
-    hermes-agent 0.16+ wheel (``requires-python <3.14``) and resolution
-    lands on the broken 0.15.2 build (#1248).
+    Probes explicit ``python3.12`` on PATH so the venv minor is deterministic.
+    The running interpreter is accepted only when it is itself Python 3.12.
     """
     for minor in range(PYTHON_MAX_EXCLUSIVE[1] - 1, PYTHON_MIN[1] - 1, -1):
         explicit = prober(f"python3.{minor}")
@@ -654,9 +648,9 @@ def _install_venv(
 ) -> None:
     """Create the venv at ``venv`` and install ``requirements`` into it.
 
-    Two-step: ``python3.x -m venv`` then ``pip install -r``. The venv itself
+    Two-step: ``python3.12 -m venv`` then ``pip install -r``. The venv itself
     is stdlib-built — uv enters only inside the resolver, as the last-resort
-    interpreter fetch on hosts with no packaged 3.11-3.13 (#1250).
+    interpreter fetch on hosts with no packaged Python 3.12.
     """
     py = python_resolver()
     if py is None:
@@ -673,8 +667,6 @@ def _install_venv(
     try:
         env = _hal0_subprocess_env()
         target_preexists = target.exists()
-        if not target_preexists:
-            target.mkdir(parents=True, exist_ok=True)
         if needs_replacement or not target_preexists:
             runner.run([py, "-m", "venv", str(target)], check=True, env=env)  # nosec B603
         pip = _venv_python(target)

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -404,20 +404,7 @@ def test_resolve_python_rejects_non_312_running_interpreters() -> None:
     assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 13)) is None
 
 
-def test_resolve_python_prefers_newest_explicit_in_range() -> None:
-    # The Hermes policy probes only exact Python 3.12.
-    probed: list[str] = []
-
-    def _prober(name: str) -> str | None:
-        probed.append(name)
-        return f"/opt/{name}/bin/{name}"
-
-    out = hp._resolve_supported_python(prober=_prober)
-    assert out == "/opt/python3.12/bin/python3.12"
-    assert probed == ["python3.12"]
-
-
-def test_resolve_python_walks_down_to_oldest_supported() -> None:
+def test_resolve_python_finds_exact_python3_12() -> None:
     out = hp._resolve_supported_python(
         prober=lambda name: "/usr/bin/python3.12" if name == "python3.12" else None
     )
@@ -430,10 +417,7 @@ def test_resolve_python_falls_back_to_sys_executable_in_range() -> None:
 
 
 def test_resolve_python_rejects_unsupported_running_interpreter() -> None:
-    # The Ubuntu 26.04 case (#1248): only a 3.14 interpreter exists. The old
-    # ">= 3.11" fallback accepted it and pip resolved the broken
-    # hermes-agent 0.15.2; now the resolver must return None so the
-    # preflight fails with the actionable range message.
+    # Only Python 3.12 may be used for the managed Hermes venv.
     assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 14)) is None
     assert hp._resolve_supported_python(prober=lambda _name: None, running=(3, 10)) is None
 
@@ -646,12 +630,13 @@ def test_ensure_python_returns_none_when_uv_fetch_fails() -> None:
     assert out is None
 
 
-def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path) -> None:
-    # A venv already built on 3.14 can never converge by pip alone. The
-    # replacement is built beside the live tree and swapped transactionally.
+@pytest.mark.parametrize("minor", ["3.11", "3.13", "3.14"])
+def test_install_venv_rebuilds_venv_on_unsupported_interpreter(tmp_path: Path, minor: str) -> None:
+    # A non-3.12 venv can never converge by pip alone. The replacement is
+    # built beside the live tree and swapped transactionally.
     venv = tmp_path / "venv"
-    (venv / "lib" / "python3.14" / "site-packages").mkdir(parents=True)
-    stale_marker = venv / "lib" / "python3.14" / "site-packages" / "hermes_cli"
+    (venv / "lib" / f"python{minor}" / "site-packages").mkdir(parents=True)
+    stale_marker = venv / "lib" / f"python{minor}" / "site-packages" / "hermes_cli"
     stale_marker.mkdir()
     calls: list[list[str]] = []
 


### PR DESCRIPTION
## Summary
- refresh stale Hermes Python 3.12 resolver docstrings
- remove duplicate/misleading resolver tests
- parametrize non-3.12 venv migration coverage for 3.11, 3.13, and 3.14
- remove redundant venv target mkdir scaffolding

## Verification
- `ruff format src/hal0/agents/hermes_provision.py tests/agents/test_hermes_provision.py`
- `ruff check src/hal0/agents/hermes_provision.py tests/agents/test_hermes_provision.py`
- `PYTHONPATH=src pytest tests/agents/test_hermes_provision.py -k "resolve_python or install_venv" -q`
- `PYTHONPATH=src pytest tests/agents/test_hermes_provision.py -q`