### PR TITLE
test(ui): cover Kokoro info popover

### DIFF
--- a/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
+++ b/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
@@ -110,7 +110,7 @@ test.describe('ImageGen section — deferred row hidden', () => {
 })
 
 test.describe('Voice section — Kokoro label', () => {
-  test.skip('Sub-text says "bundled voices (Kokoro v1)"', async ({ page }) => {
+  test('Sub-text says "bundled voices (Kokoro v1)"', async ({ page }) => {
     await page.goto('/#settings')
     await page.locator('.nav-item', { hasText: 'Voice' }).click()
     const defaultVoiceRow = page.locator('.settings-content .s-row').filter({


### PR DESCRIPTION
## Summary
- enable the existing Kokoro Voice settings popover regression
- keep the production SRow binding from #1330 unchanged

## Verification
- `CI=true npx playwright test tests/e2e/specs/ui-sweep-a-v3.spec.ts --project=chromium` — 13 passed
- `npm run typecheck`
- independent Codex review: spec PASS, quality PASS