### PR TITLE
fix(release): harden preview prerelease pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ name: Release
 # Also reusable via workflow_call from nightly.yml (a GITHUB_TOKEN tag push
 # can't trigger this workflow's `push` event, so nightly invokes it directly).
 #
-# Updater clients consume https://releases.hal0.dev/<channel>.json. Advancing
-# those external channel pointers is deliberately a separate, final gate after
-# this workflow's immutable assets have been verified and uploaded.
+# Updater clients consume https://releases.hal0.dev/<channel>.json. This workflow
+# only authorizes the immutable remote publication; it never advances an external
+# channel pointer. Static contract tests cannot prove remote behavior, so the
+# first real release run is required before relying on this authorization gate.
 #
 # What this workflow does NOT do (deliberate, see "Blockers" in
 # scripts/release-prototype/RELEASE_PIPELINE_NOTES.md):
@@ -171,6 +172,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: resolve
+    outputs:
+      tarball_digest: ${{ steps.tarball.outputs.digest }}
 
     steps:
       - name: Checkout exact release tag
@@ -635,16 +638,6 @@ jobs:
           done
           gh release upload "${TAG}" "${ASSETS[@]}"
 
-      # External channel pointer advancement is intentionally NOT performed in
-      # this immutable release step. It is the final, separately verified gate
-      # after every exact manifest and sibling bundle asset has been uploaded.
-      - name: Record separately verified channel pointer gate
-        env:
-          TAG: ${{ needs.resolve.outputs.tag }}
-          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
-        run: |
-          echo "Channel pointer advancement remains external for ${TAG}: ${MANIFEST_TARGETS}"
-
       - name: Summary
         env:
           TAG: ${{ needs.resolve.outputs.tag }}
@@ -732,3 +725,301 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ── 9. Read-only authorization of the exact remote publication ─────────────
+  # This is deliberately an evidence gate, not a pointer publisher. It starts
+  # from a clean checkout and re-downloads every byte from the release API.
+  authorize-pointer:
+    name: Authorize verified remote publication
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [resolve, release, pypi-publish]
+    if: >-
+      ${{ always()
+          && needs.resolve.result == 'success'
+          && needs.release.result == 'success'
+          && ((needs.resolve.outputs.publish_pypi == 'true'
+               && needs.pypi-publish.result == 'success')
+              || (needs.resolve.outputs.publish_pypi == 'false'
+                  && needs.pypi-publish.result == 'skipped')) }}
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.evidence.outputs.authorized }}
+
+    steps:
+      - name: Checkout exact release tag
+        uses: actions/checkout@v6
+        with:
+          repository: Hal0ai/hal0
+          ref: refs/tags/${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify exact release commit
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::checked-out tag ${TAG} resolved to ${HEAD_SHA}, expected ${EXPECTED_SHA}"
+            exit 1
+          fi
+
+      - name: Install release validation dependencies
+        run: python3 -m pip install -e ".[dev]" >/dev/null
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Download and verify exact remote publication
+        id: remote
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          PYPI_VERSION: ${{ needs.resolve.outputs.python_version }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+          EXPECTED_PRERELEASE: ${{ needs.resolve.outputs.github_prerelease }}
+          EXPECTED_LATEST: ${{ needs.resolve.outputs.github_latest }}
+          PUBLISH_PYPI: ${{ needs.resolve.outputs.publish_pypi }}
+          SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}
+          EXPECTED_DIGEST: ${{ needs.release.outputs.tarball_digest }}
+        run: |
+          set -euo pipefail
+          VERIFY_DIR="$(mktemp -d)"
+          trap 'rm -rf "${VERIFY_DIR}"' EXIT
+          RELEASE_JSON="${VERIFY_DIR}/release.json"
+          LATEST_JSON="${VERIFY_DIR}/latest.json"
+          ASSET_INDEX="${VERIFY_DIR}/assets.tsv"
+          DOWNLOAD_DIR="${VERIFY_DIR}/downloaded"
+          mkdir "${DOWNLOAD_DIR}"
+
+          # Query one exact release. The latest endpoint is consulted only to
+          # observe GitHub's computed flag; it is never used to choose assets.
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" > "${RELEASE_JSON}"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > "${LATEST_JSON}"
+
+          python3 - "${RELEASE_JSON}" "${LATEST_JSON}" "${ASSET_INDEX}" <<'PY'
+          import json
+          import os
+          import sys
+          from collections import Counter
+          from pathlib import Path
+
+          release_path, latest_path, index_path = map(Path, sys.argv[1:])
+          release = json.loads(release_path.read_bytes())
+          latest = json.loads(latest_path.read_bytes())
+          tag = os.environ["TAG"]
+          version = os.environ["VERSION"]
+          targets = os.environ["MANIFEST_TARGETS"].split(",")
+          expected_prerelease = os.environ["EXPECTED_PRERELEASE"] == "true"
+          expected_latest = os.environ["EXPECTED_LATEST"] == "true"
+
+          if release.get("tag_name") != tag:
+              raise SystemExit("exact release API returned a tag mismatch")
+          if release.get("draft") is not False:
+              raise SystemExit("exact release is still a draft")
+          if release.get("prerelease") is not expected_prerelease:
+              raise SystemExit("exact release prerelease flag differs from policy")
+          observed_latest = latest.get("tag_name") == tag
+          if observed_latest is not expected_latest:
+              raise SystemExit("GitHub latest release differs from policy")
+
+          tarball = f"hal0-{version}.tar.gz"
+          expected_assets = {
+              tarball,
+              f"{tarball}.bundle",
+              f"{tarball}.sig",
+              f"{tarball}.crt",
+          }
+          for channel in targets:
+              expected_assets.update({f"{channel}.json", f"{channel}.json.bundle"})
+          print("EXPECTED_ASSETS=" + ",".join(sorted(expected_assets)))
+
+          assets = release.get("assets")
+          if not isinstance(assets, list):
+              raise SystemExit("exact release has no asset list")
+          names = [asset.get("name") for asset in assets]
+          duplicates = sorted(name for name, count in Counter(names).items() if count != 1)
+          if duplicates:
+              raise SystemExit(f"duplicate remote asset names: {duplicates}")
+          observed_assets = set(names)
+          if observed_assets != expected_assets:
+              missing = sorted(expected_assets - observed_assets)
+              extra = sorted(observed_assets - expected_assets)
+              raise SystemExit(f"remote asset set mismatch; missing={missing}, extra={extra}")
+
+          rows = []
+          for asset in assets:
+              name = asset["name"]
+              if asset.get("state") != "uploaded":
+                  raise SystemExit(f"non-uploaded remote asset: {name}")
+              if not isinstance(asset.get("size"), int) or asset["size"] <= 0:
+                  raise SystemExit(f"empty remote asset: {name}")
+              asset_id = asset.get("id")
+              if not isinstance(asset_id, int) or asset_id <= 0:
+                  raise SystemExit(f"invalid numeric asset ID: {name}")
+              rows.append((name, asset_id))
+          index_path.write_text("".join(f"{name}\t{asset_id}\n" for name, asset_id in rows))
+          PY
+
+          while IFS=$'\t' read -r ASSET_NAME ASSET_ID; do
+            DESTINATION="${DOWNLOAD_DIR}/${ASSET_NAME}"
+            if [[ -e "${DESTINATION}" ]]; then
+              echo "::error::refusing duplicate asset destination ${ASSET_NAME}"
+              exit 1
+            fi
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" > "${DESTINATION}"
+            if [[ ! -s "${DESTINATION}" ]]; then
+              echo "::error::downloaded empty asset ${ASSET_NAME}"
+              exit 1
+            fi
+          done < "${ASSET_INDEX}"
+
+          TARBALL="${DOWNLOAD_DIR}/hal0-${VERSION}.tar.gz"
+          OBSERVED_DIGEST="$(sha256sum "${TARBALL}" | awk '{print $1}')"
+          if [[ "${OBSERVED_DIGEST}" != "${EXPECTED_DIGEST}" ]]; then
+            echo "::error::remote tarball digest ${OBSERVED_DIGEST} differs from build ${EXPECTED_DIGEST}"
+            exit 1
+          fi
+
+          ISSUER="https://token.actions.githubusercontent.com"
+          cosign verify-blob --bundle "${TARBALL}.bundle" \
+            --certificate-identity-regexp "${SIGNER_IDENTITY}" \
+            --certificate-oidc-issuer "${ISSUER}" \
+            "${TARBALL}"
+          cosign verify-blob \
+            --signature "${TARBALL}.sig" \
+            --certificate "${TARBALL}.crt" \
+            --certificate-identity-regexp "${SIGNER_IDENTITY}" \
+            --certificate-oidc-issuer "${ISSUER}" \
+            "${TARBALL}"
+
+          IFS=',' read -ra TARGETS <<< "${MANIFEST_TARGETS}"
+          for CHANNEL in "${TARGETS[@]}"; do
+            MANIFEST="${DOWNLOAD_DIR}/${CHANNEL}.json"
+            # Verify the exact downloaded bytes before parsing any field.
+            cosign verify-blob --bundle "${MANIFEST}.bundle" \
+              --certificate-identity-regexp "${SIGNER_IDENTITY}" \
+              --certificate-oidc-issuer "${ISSUER}" \
+              "${MANIFEST}"
+          done
+
+          PYTHONPATH=src python3 - "${RELEASE_JSON}" "${LATEST_JSON}" "${DOWNLOAD_DIR}" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          from hal0.release.policy import ReleasePolicy
+          from hal0.updater.updater import ReleaseManifest
+
+          release_path, latest_path, download_dir = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3])
+          release = json.loads(release_path.read_bytes())
+          latest = json.loads(latest_path.read_bytes())
+          tag = os.environ["TAG"]
+          policy = ReleasePolicy.from_tag(tag)
+          expected_digest = os.environ["EXPECTED_DIGEST"]
+          expected_identity = os.environ["SIGNER_IDENTITY"]
+          expected_issuer = "https://token.actions.githubusercontent.com"
+          expected_base = f"https://github.com/Hal0ai/hal0/releases/download/{tag}"
+          expected_targets = tuple(os.environ["MANIFEST_TARGETS"].split(","))
+
+          if policy.manifest_targets != expected_targets:
+              raise SystemExit("resolved manifest targets differ from ReleasePolicy")
+          if policy.github_prerelease != (os.environ["EXPECTED_PRERELEASE"] == "true"):
+              raise SystemExit("resolved prerelease flag differs from ReleasePolicy")
+          if policy.github_latest != (os.environ["EXPECTED_LATEST"] == "true"):
+              raise SystemExit("resolved latest flag differs from ReleasePolicy")
+          if release["prerelease"] != policy.github_prerelease:
+              raise SystemExit("remote prerelease flag differs from ReleasePolicy")
+          if (latest.get("tag_name") == tag) != policy.github_latest:
+              raise SystemExit("remote latest observation differs from ReleasePolicy")
+
+          identities = {}
+          for channel in policy.manifest_targets:
+              manifest_path = download_dir / f"{channel}.json"
+              payload = json.loads(manifest_path.read_bytes())
+              manifest = ReleaseManifest.model_validate(payload)
+              expected_urls = {
+                  "url": f"{expected_base}/hal0-{policy.version}.tar.gz",
+                  "bundle_url": f"{expected_base}/hal0-{policy.version}.tar.gz.bundle",
+                  "sig_url": f"{expected_base}/hal0-{policy.version}.tar.gz.sig",
+                  "cert_url": f"{expected_base}/hal0-{policy.version}.tar.gz.crt",
+                  "manifest_url": f"{expected_base}/{channel}.json",
+                  "notes_url": f"https://github.com/Hal0ai/hal0/releases/tag/{tag}",
+              }
+              if manifest.channel != channel:
+                  raise SystemExit(f"manifest channel mismatch: {channel}")
+              if manifest.version != policy.version:
+                  raise SystemExit(f"manifest version mismatch: {channel}")
+              if manifest.release_kind != policy.kind:
+                  raise SystemExit(f"manifest release policy mismatch: {channel}")
+              if manifest.prerelease_stage != policy.prerelease_stage:
+                  raise SystemExit(f"manifest prerelease policy mismatch: {channel}")
+              if manifest.digest_sha256 != expected_digest:
+                  raise SystemExit(f"manifest digest_sha256 differs from tarball: {channel}")
+              if manifest.signer_identity != expected_identity:
+                  raise SystemExit(f"manifest signer_identity mismatch: {channel}")
+              if manifest.signer_issuer != expected_issuer:
+                  raise SystemExit(f"manifest signer_issuer mismatch: {channel}")
+              for field, expected in expected_urls.items():
+                  if payload.get(field) != expected:
+                      raise SystemExit(f"manifest {field} mismatch: {channel}")
+              identities[channel] = tuple(payload[field] for field in (
+                  "version", "release_kind", "url", "bundle_url", "sig_url",
+                  "cert_url", "digest_sha256", "signer_identity", "signer_issuer",
+              ))
+
+          if policy.kind == "stable" and identities["stable"] != identities["preview"]:
+              raise SystemExit("stable and preview manifests differ in artifact identity")
+          PY
+
+          if [[ "${PUBLISH_PYPI}" == "true" ]]; then
+            PYPI_JSON="${VERIFY_DIR}/pypi.json"
+            curl --fail --silent --show-error --location \
+              --retry 5 --retry-delay 2 --retry-all-errors \
+              --connect-timeout 5 --max-time 20 \
+              "https://pypi.org/pypi/hal0ai/${PYPI_VERSION}/json" \
+              --output "${PYPI_JSON}"
+            python3 - "${PYPI_JSON}" "${PYPI_VERSION}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_bytes())
+          expected = sys.argv[2]
+          if payload["info"]["name"] != "hal0ai":
+              raise SystemExit("PyPI project name differs from hal0ai")
+          if payload["info"]["version"] != expected:
+              raise SystemExit("PyPI exact version differs from release policy")
+          PY
+            echo "pypi_evidence=PyPI publication | hal0ai==${PYPI_VERSION} verified" >> "$GITHUB_OUTPUT"
+          else
+            echo "pypi_evidence=PyPI publication | not required (nightly policy)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Record non-mutating authorization evidence
+        id: evidence
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+          EXPECTED_DIGEST: ${{ needs.release.outputs.tarball_digest }}
+          PYPI_EVIDENCE: ${{ steps.remote.outputs.pypi_evidence }}
+        run: |
+          {
+            echo "## Remote publication authorized: ${TAG}"
+            echo ""
+            echo "| evidence | observed result |"
+            echo "|---|---|"
+            echo "| Exact GitHub release | tag, draft, prerelease, and latest policy verified |"
+            echo "| Exact remote asset set | IDs, uploaded state, non-empty bytes, and signatures verified |"
+            echo "| Tarball SHA-256 | \`${EXPECTED_DIGEST}\` (release output and every manifest) |"
+            echo "| Manifest targets | ${MANIFEST_TARGETS} (exact bytes and sibling bundles verified) |"
+            echo "| ${PYPI_EVIDENCE} |"
+            echo ""
+            echo "**No external channel pointer was mutated.** This job performed read-only authorization only."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "authorized=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,16 @@ jobs:
       github_prerelease: ${{ steps.policy.outputs.github_prerelease }}
       github_latest: ${{ steps.policy.outputs.github_latest }}
       publish_pypi: ${{ steps.policy.outputs.publish_pypi }}
+      target_sha: ${{ steps.policy.outputs.target_sha }}
 
     steps:
+      - name: Reject noncanonical repository
+        run: |
+          if [[ "${GITHUB_REPOSITORY,,}" != "hal0ai/hal0" ]]; then
+            echo "::error::refusing noncanonical repository ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+
       - name: Resolve requested tag
         id: requested
         env:
@@ -101,7 +109,8 @@ jobs:
       - name: Checkout requested tag for policy resolution
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.requested.outputs.tag }}
+          repository: Hal0ai/hal0
+          ref: refs/tags/${{ steps.requested.outputs.tag }}
           fetch-depth: 0
 
       - name: Verify requested tag and export policy
@@ -110,12 +119,17 @@ jobs:
           TAG: ${{ steps.requested.outputs.tag }}
           INPUT_CHANNEL: ${{ inputs.channel }}
         run: |
-          HEAD_SHA="$(git rev-parse HEAD)"
-          TAG_SHA="$(git rev-list -n1 "${TAG}")"
-          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
-            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
+          if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
+            echo "::error::requested ref is not a tag: refs/tags/${TAG}"
             exit 1
           fi
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TARGET_SHA="$(git rev-parse "refs/tags/${TAG}^{commit}")"
+          if [[ "${HEAD_SHA}" != "${TARGET_SHA}" ]]; then
+            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TARGET_SHA})"
+            exit 1
+          fi
+          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
           PYTHONPATH=src python3 -m hal0.release.policy "${TAG}" --format github >> "$GITHUB_OUTPUT"
           KIND="$(sed -n 's/^kind=//p' "$GITHUB_OUTPUT" | tail -n1)"
           if [[ -n "${INPUT_CHANNEL}" && "${INPUT_CHANNEL}" != "${KIND}" ]]; then
@@ -133,17 +147,18 @@ jobs:
       - name: Checkout exact release tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          repository: Hal0ai/hal0
+          ref: refs/tags/${{ needs.resolve.outputs.tag }}
           fetch-depth: 0
 
       - name: Verify exact release commit
         env:
           TAG: ${{ needs.resolve.outputs.tag }}
+          EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
-          TAG_SHA="$(git rev-list -n1 "${TAG}")"
-          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
-            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
+          if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::checked-out tag ${TAG} resolved to ${HEAD_SHA}, expected ${EXPECTED_SHA}"
             exit 1
           fi
 
@@ -621,17 +636,18 @@ jobs:
       - name: Checkout exact release tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.resolve.outputs.tag }}
+          repository: Hal0ai/hal0
+          ref: refs/tags/${{ needs.resolve.outputs.tag }}
           fetch-depth: 0
 
       - name: Verify exact release commit
         env:
           TAG: ${{ needs.resolve.outputs.tag }}
+          EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}
         run: |
           HEAD_SHA="$(git rev-parse HEAD)"
-          TAG_SHA="$(git rev-list -n1 "${TAG}")"
-          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
-            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
+          if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]; then
+            echo "::error::checked-out tag ${TAG} resolved to ${HEAD_SHA}, expected ${EXPECTED_SHA}"
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,16 @@ name: Release
 # Cut a hal0 release on a `v*` tag push:
 #   1. build the source + UI tarball with the layout the updater expects
 #   2. cosign keyless-sign the tarball against the workflow's OIDC subject
-#   3. write a hal0.releases.v1 manifest pointing at the GH-release assets
-#   4. publish tarball + .sig + manifest as a GitHub Release
+#   3. write, validate, and sign every policy-targeted channel manifest
+#   4. immutably publish tarball signatures, manifests, and sibling bundles
 #
 # Triggered by: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 # Also reusable via workflow_call from nightly.yml (a GITHUB_TOKEN tag push
 # can't trigger this workflow's `push` event, so nightly invokes it directly).
 #
-# The manifest is automatically served at https://releases.hal0.dev/<channel>.json
-# (e.g. /stable.json) by the Cloudflare Pages middleware in hal0-web
-# (functions/_middleware.ts). On a successful upload here, the next request
-# to releases.hal0.dev picks it up within ~60s (CF cache TTL) — no hal0-web
-# deploy needed. Updater clients should point at
-# HAL0_RELEASES_URL=https://releases.hal0.dev/stable.json.
+# Updater clients consume https://releases.hal0.dev/<channel>.json. Advancing
+# those external channel pointers is deliberately a separate, final gate after
+# this workflow's immutable assets have been verified and uploaded.
 #
 # What this workflow does NOT do (deliberate, see "Blockers" in
 # scripts/release-prototype/RELEASE_PIPELINE_NOTES.md):
@@ -35,7 +32,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to (re)build a release for, e.g. v0.1.0-rc1"
+        description: "Exact new release tag, e.g. v1.0.0-rc.1"
         required: true
         default: ""
       channel:
@@ -64,67 +61,112 @@ concurrency:
   cancel-in-progress: false # never cancel a half-published release
 
 jobs:
+  resolve:
+    name: Resolve immutable release policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.policy.outputs.tag }}
+      base_version: ${{ steps.policy.outputs.base_version }}
+      version: ${{ steps.policy.outputs.version }}
+      python_version: ${{ steps.policy.outputs.python_version }}
+      kind: ${{ steps.policy.outputs.kind }}
+      prerelease_stage: ${{ steps.policy.outputs.prerelease_stage }}
+      manifest_targets: ${{ steps.policy.outputs.manifest_targets }}
+      github_prerelease: ${{ steps.policy.outputs.github_prerelease }}
+      github_latest: ${{ steps.policy.outputs.github_latest }}
+      publish_pypi: ${{ steps.policy.outputs.publish_pypi }}
+
+    steps:
+      - name: Resolve requested tag
+        id: requested
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG="${INPUT_TAG}"
+            if [[ -z "${TAG}" ]]; then
+              echo "::error::workflow_dispatch/workflow_call requires a tag"
+              exit 1
+            fi
+          fi
+          if [[ -z "${TAG}" || "${TAG}" == "${GITHUB_REF}" ]]; then
+            echo "::error::could not resolve a tag from event ${GITHUB_EVENT_NAME}"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout requested tag for policy resolution
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.requested.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify requested tag and export policy
+        id: policy
+        env:
+          TAG: ${{ steps.requested.outputs.tag }}
+          INPUT_CHANNEL: ${{ inputs.channel }}
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-list -n1 "${TAG}")"
+          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
+            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
+            exit 1
+          fi
+          PYTHONPATH=src python3 -m hal0.release.policy "${TAG}" --format github >> "$GITHUB_OUTPUT"
+          KIND="$(sed -n 's/^kind=//p' "$GITHUB_OUTPUT" | tail -n1)"
+          if [[ -n "${INPUT_CHANNEL}" && "${INPUT_CHANNEL}" != "${KIND}" ]]; then
+            echo "::error::input channel ${INPUT_CHANNEL} conflicts with tag policy ${KIND}"
+            exit 1
+          fi
+
   release:
     name: Build, sign, publish
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: resolve
 
     steps:
-      # ── 0. Resolve tag + version ────────────────────────────────────────────
-      - name: Checkout
+      - name: Checkout exact release tag
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.resolve.outputs.tag }}
           fetch-depth: 0
 
-      - name: Resolve tag + version
-        id: ver
+      - name: Verify exact release commit
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
         run: |
-          TAG="${{ inputs.tag }}"
-          if [[ -z "${TAG}" ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          # Strip leading "v"; updater compares dotted versions without it.
-          VERSION="${TAG#v}"
-          if [[ -z "${VERSION}" ]]; then
-            echo "::error::could not resolve version from tag '${TAG}'"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-list -n1 "${TAG}")"
+          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
+            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
             exit 1
           fi
-          # Channel: an explicit input wins; otherwise derive from the tag
-          # (a `-nightly.<date>` segment ⇒ nightly, else stable).
-          # On a plain tag-push event `inputs` is undefined and ${{ inputs.channel }}
-          # renders empty, so the -z branch (Python derivation) is the push path.
-          # TAG goes through the environment, not string-interpolated into the
-          # one-liner, so an odd tag can't break/inject into the Python literal.
-          CHANNEL="${{ inputs.channel }}"
-          if [[ -z "${CHANNEL}" ]]; then
-            CHANNEL="$(TAG="${TAG}" PYTHONPATH=src python3 -c "import os; from hal0.release.channel import channel_for_tag; print(channel_for_tag(os.environ['TAG']))")"
-          fi
-          echo "tag=${TAG}"           >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}"   >> "$GITHUB_OUTPUT"
-          echo "channel=${CHANNEL}"   >> "$GITHUB_OUTPUT"
 
-      - name: Confirm pyproject.toml version matches the tag
+      - name: Confirm pyproject.toml version matches release policy
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          BASE_VERSION: ${{ needs.resolve.outputs.base_version }}
+          KIND: ${{ needs.resolve.outputs.kind }}
         run: |
           PYV="$(python3 -c '
           import tomllib
           print(tomllib.loads(open("pyproject.toml","rb").read().decode())["project"]["version"])
           ')"
           echo "pyproject.toml version: ${PYV}"
-          echo "tag-derived version:    ${{ steps.ver.outputs.version }}"
-          CHANNEL="${{ steps.ver.outputs.channel }}"
-          if [[ "${CHANNEL}" == "nightly" ]]; then
-            # Nightly: pyproject stays on its dev version (e.g. 0.5.0-alpha.1)
-            # while the tag is v<base>-nightly.<date>; require only the base
-            # X.Y.Z to match so we never ship a tarball off the wrong line.
-            # PYV/TAG via env (not interpolated into the literal) so an odd
-            # version/tag string can't break or inject into the Python.
-            if ! PYV="${PYV}" TAG="${{ steps.ver.outputs.tag }}" PYTHONPATH=src python3 -c "import os, sys; from hal0.release.channel import base_matches; sys.exit(0 if base_matches(os.environ['PYV'], os.environ['TAG']) else 1)"; then
-              echo "::error::nightly tag base ≠ pyproject base version (${PYV})"
+          echo "policy version:          ${VERSION}"
+          if [[ "${KIND}" == "nightly" ]]; then
+            if ! PYV="${PYV}" TAG="${TAG}" PYTHONPATH=src python3 -c "import os, sys; from hal0.release.channel import base_matches; sys.exit(0 if base_matches(os.environ['PYV'], os.environ['TAG']) else 1)"; then
+              echo "::error::nightly tag base differs from pyproject.toml (${PYV})"
               exit 1
             fi
-          elif [[ "${PYV}" != "${{ steps.ver.outputs.version }}" ]]; then
-            echo "::error::pyproject.toml version (${PYV}) ≠ tag (${{ steps.ver.outputs.version }})"
-            echo "::error::bump pyproject.toml + retag, or use scripts/release-check.sh --tag ${{ steps.ver.outputs.tag }} first"
+          elif [[ "${PYV}" != "${VERSION}" ]]; then
+            echo "::error::pyproject.toml version (${PYV}) differs from policy (${VERSION})"
             exit 1
           fi
 
@@ -146,7 +188,7 @@ jobs:
       - name: Stage release tree
         id: stage
         run: |
-          VERSION="${{ steps.ver.outputs.version }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
           STAGE="${RUNNER_TEMP}/hal0-${VERSION}"
           mkdir -p "${STAGE}"
 
@@ -186,14 +228,14 @@ jobs:
       - name: Stage release notes
         run: |
           python3 scripts/gen_release_notes.py \
-            --tag "${{ steps.ver.outputs.tag }}" \
-            --channel "${{ steps.ver.outputs.channel }}" \
+            --tag "${{ needs.resolve.outputs.tag }}" \
+            --channel "${{ needs.resolve.outputs.kind }}" \
             --out-dir "${{ steps.stage.outputs.stage }}"
 
       - name: Build tarball
         id: tarball
         run: |
-          VERSION="${{ steps.ver.outputs.version }}"
+          VERSION="${{ needs.resolve.outputs.version }}"
           OUT="${RUNNER_TEMP}/hal0-${VERSION}.tar.gz"
           # Use --owner/--group to make the archive reproducible-ish across
           # runners. The updater doesn't care, but it makes diffs sane.
@@ -274,18 +316,9 @@ jobs:
         run: |
           TARBALL="${{ steps.tarball.outputs.path }}"
           BUNDLE="${{ steps.sign.outputs.bundle }}"
-          # The identity regex must match what we'll write into the
-          # manifest below — keep these two strings in lock-step.
-          # github.repository preserves case (Hal0ai/hal0); use (?i) to
-          # absorb the lowercase `hal0ai` redirect form too.
-          # The Fulcio cert SAN is the workflow that OWNS the signing job
-          # (release.yml — the job_workflow_ref) at the CALLER's ref:
-          # release.yml@refs/tags/vX on a direct tag push, or
-          # release.yml@refs/heads/main when invoked via workflow_call from
-          # nightly.yml. github.ref is the caller's ref in BOTH cases — NOT
-          # github.workflow_ref, which is the entry-point (nightly.yml) and
-          # does NOT match the cert SAN under workflow_call.
-          IDENT="^(?i)https://github\\.com/${{ github.repository }}/\\.github/workflows/release\\.yml@${{ github.ref }}$"
+          # This is the same release.yml tag-or-main trust root pinned by
+          # updater.py for authenticating channel-manifest bundles.
+          IDENT="^https://github\\.com/(Hal0ai|hal0ai)/hal0/\\.github/workflows/release\\.yml@(refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.(0|[1-9][0-9]*)|-nightly\\.[0-9]{14})?|refs/heads/main)$"
           ISSUER="https://token.actions.githubusercontent.com"
           # Verify exactly as the client will (bootstrap.sh + updater.py):
           # the bundle supplies the cert + signature + Rekor SET, so this
@@ -312,90 +345,96 @@ jobs:
               --certificate-oidc-issuer    "${ISSUER}" \
               "${TARBALL}"
 
-      # ── 5. Generate the hal0.releases.v1 manifest ───────────────────────────
-      - name: Generate release manifest
+      # ── 5. Generate, validate, sign, and verify every policy target ────────
+      - name: Generate and validate target manifests
         id: manifest
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          RELEASE_KIND: ${{ needs.resolve.outputs.kind }}
+          PRERELEASE_STAGE: ${{ needs.resolve.outputs.prerelease_stage }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+          DIGEST: ${{ steps.tarball.outputs.digest }}
         run: |
-          VERSION="${{ steps.ver.outputs.version }}"
-          TAG="${{ steps.ver.outputs.tag }}"
-          CHANNEL="${{ steps.ver.outputs.channel }}"
-          DIGEST="${{ steps.tarball.outputs.digest }}"
-          OUT="${RUNNER_TEMP}/${CHANNEL}.json"
-
-          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
-          MANIFEST_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${CHANNEL}.json"
-
-          # Must match the Self-verify identity above (and the cert SAN) so the
-          # updater's cosign verify-blob succeeds. release.yml@<caller-ref> via
-          # github.ref — correct for both tag-push and workflow_call (nightly).
-          IDENT="^(?i)https://github\\.com/${{ github.repository }}/\\.github/workflows/release\\.yml@${{ github.ref }}$"
-
-          PYTHONPATH=src python3 - "${OUT}" "${VERSION}" "${TAG}" "${CHANNEL}" "${DIGEST}" \
-                   "${BASE_URL}" "${MANIFEST_URL}" "${IDENT}" <<'PY'
-          import json, sys, datetime as dt
-          from hal0.release.policy import ReleasePolicy
-          out, version, tag, channel, digest, base, self_url, ident = sys.argv[1:]
-          # Derive release_kind + prerelease_stage from the tag so the
-          # ReleaseManifest pydantic schema's cross-field validator sees
-          # consistent values (release_kind must match channel, and preview
-          # requires a non-None prerelease_stage).
-          policy = ReleasePolicy.from_tag(tag)
-          # Mirror the toolbox_images block from manifest.json into the
-          # release manifest so an updater can pull the matching image
-          # set (see docs/internal/release-manifest.md §"What the release pipeline
-          # must guarantee", item 6).
-          repo_manifest = json.loads(open("manifest.json").read())
-          payload = {
-              "_schema":         "hal0.releases.v1",
-              "version":         version,
-              "channel":         channel,
-              "release_kind":    policy.kind,
-              "prerelease_stage": policy.prerelease_stage,
-              "url":             f"{base}/hal0-{version}.tar.gz",
-              "bundle_url":      f"{base}/hal0-{version}.tar.gz.bundle",
-              # Transition-window fields (see the sign step above) — dropped
-              # once the fleet has moved past sig_url-only clients (#1159).
-              "sig_url":         f"{base}/hal0-{version}.tar.gz.sig",
-              "cert_url":        f"{base}/hal0-{version}.tar.gz.crt",
-              "digest_sha256":   digest,
-              "signer_identity": ident,
-              "signer_issuer":   "https://token.actions.githubusercontent.com",
-              "min_data_version": int(repo_manifest.get("min_data_version", 1)),
-              "released_at":     dt.datetime.now(dt.UTC).isoformat(timespec="seconds"),
-              "notes_url":       f"https://github.com/{__import__('os').environ['GITHUB_REPOSITORY']}/releases/tag/{tag}",
-              "manifest_url":    self_url,
-              "toolbox_images":  repo_manifest.get("toolbox_images", {}),
-          }
-          # Refuse to publish if any toolbox digest is null/missing — the
-          # release would advertise images we never actually pinned.
-          missing = [n for n, e in payload["toolbox_images"].items() if not e.get("digest")]
-          if missing:
-              sys.exit(f"toolbox_images digests missing for: {missing} - run scripts/update-toolbox-digests.sh on main first")
-          open(out, "w").write(json.dumps(payload, indent=2) + "\n")
-          print(f"wrote {out}")
-          PY
-          echo "path=${OUT}" >> "$GITHUB_OUTPUT"
-
-      - name: Self-validate manifest against ReleaseManifest schema
-        run: |
-          # Catch shape regressions before publish. Uses the runtime's
-          # own pydantic schema so the manifest can never drift from
-          # what hal0.updater can actually parse.
           python3 -m pip install -e ".[dev]" >/dev/null
-          python3 - "${{ steps.manifest.outputs.path }}" <<'PY'
-          import json, sys
-          from hal0.updater.updater import _parse_manifest
-          raw = json.loads(open(sys.argv[1]).read())
-          mf = _parse_manifest(raw)
-          print(f"manifest OK: version={mf.version} digest_sha256={mf.digest_sha256[:12]}…")
+          OUT_DIR="${RUNNER_TEMP}/manifests"
+          mkdir -p "${OUT_DIR}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+          IDENT="^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.(0|[1-9][0-9]*)|-nightly\.[0-9]{14})?|refs/heads/main)$"
+
+          python3 - "${OUT_DIR}" "${VERSION}" "${TAG}" "${RELEASE_KIND}" \
+                   "${PRERELEASE_STAGE}" "${MANIFEST_TARGETS}" "${DIGEST}" \
+                   "${BASE_URL}" "${IDENT}" <<'PY'
+          import datetime as dt
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          from hal0.updater.updater import ReleaseManifest
+
+          out_dir, version, tag, kind, stage, targets, digest, base, ident = sys.argv[1:]
+          repo_manifest = json.loads(Path("manifest.json").read_text())
+          toolbox_images = repo_manifest.get("toolbox_images", {})
+          missing = [name for name, entry in toolbox_images.items() if not entry.get("digest")]
+          if missing:
+              sys.exit(f"toolbox_images digests missing for: {missing}")
+
+          released_at = dt.datetime.now(dt.UTC).isoformat(timespec="seconds")
+          common = {
+              "_schema": "hal0.releases.v1",
+              "version": version,
+              "release_kind": kind,
+              "prerelease_stage": stage or None,
+              "url": f"{base}/hal0-{version}.tar.gz",
+              "bundle_url": f"{base}/hal0-{version}.tar.gz.bundle",
+              "sig_url": f"{base}/hal0-{version}.tar.gz.sig",
+              "cert_url": f"{base}/hal0-{version}.tar.gz.crt",
+              "digest_sha256": digest,
+              "signer_identity": ident,
+              "signer_issuer": "https://token.actions.githubusercontent.com",
+              "min_data_version": int(repo_manifest.get("min_data_version", 1)),
+              "released_at": released_at,
+              "notes_url": f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/tag/{tag}",
+              "toolbox_images": toolbox_images,
+          }
+          for channel in targets.split(","):
+              payload = {
+                  **common,
+                  "channel": channel,
+                  "manifest_url": f"{base}/{channel}.json",
+              }
+              ReleaseManifest.model_validate(payload)
+              path = Path(out_dir, f"{channel}.json")
+              path.write_text(json.dumps(payload, indent=2) + "\n")
+              print(f"manifest OK: {path}")
           PY
+          echo "dir=${OUT_DIR}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign and self-verify every manifest bundle
+        env:
+          MANIFEST_DIR: ${{ steps.manifest.outputs.dir }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+        run: |
+          IDENT="^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.(0|[1-9][0-9]*)|-nightly\.[0-9]{14})?|refs/heads/main)$"
+          ISSUER="https://token.actions.githubusercontent.com"
+          IFS=',' read -ra TARGETS <<< "${MANIFEST_TARGETS}"
+          for CHANNEL in "${TARGETS[@]}"; do
+            MANIFEST="${MANIFEST_DIR}/${CHANNEL}.json"
+            cosign sign-blob --yes --bundle "${MANIFEST}.bundle" "${MANIFEST}"
+            cosign verify-blob \
+              --bundle "${MANIFEST}.bundle" \
+              --certificate-identity-regexp "${IDENT}" \
+              --certificate-oidc-issuer "${ISSUER}" \
+              "${MANIFEST}"
+          done
 
       # ── 6. Generate release notes ────────────────────────────────────────────
       - name: Generate release notes
         id: notes
         run: |
-          TAG="${{ steps.ver.outputs.tag }}"
-          CHANNEL="${{ steps.ver.outputs.channel }}"
+          TAG="${{ needs.resolve.outputs.tag }}"
+          CHANNEL="${{ needs.resolve.outputs.kind }}"
           NOTES_FILE="${RUNNER_TEMP}/RELEASE_NOTES.md"
 
           # Non-fatal wrapper: if anything goes wrong we still publish.
@@ -464,69 +503,96 @@ jobs:
 
           echo "path=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
-      # ── 7. Publish GitHub Release with all three assets ─────────────────────
-      - name: Publish GitHub Release
+      # ── 7. Publish one immutable GitHub Release ────────────────────────────
+      - name: Preflight immutable publication
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          PUBLISH_PYPI: ${{ needs.resolve.outputs.publish_pypi }}
+          PYPI_VERSION: ${{ needs.resolve.outputs.python_version }}
         run: |
-          TAG="${{ steps.ver.outputs.tag }}"
-          TARBALL="${{ steps.tarball.outputs.path }}"
-          BUNDLE="${{ steps.sign.outputs.bundle }}"
-          SIG="${{ steps.sign.outputs.sig }}"
-          CRT="${{ steps.sign.outputs.cert }}"
-          MANIFEST="${{ steps.manifest.outputs.path }}"
-          NOTES_FILE="${{ steps.notes.outputs.path }}"
-
-          # Create the release if it doesn't already exist (workflow_dispatch
-          # rebuild path) — otherwise just upload the assets, replacing
-          # any prior copies with --clobber.
-          if ! gh release view "${TAG}" >/dev/null 2>&1; then
-            if [[ "${{ steps.ver.outputs.channel }}" == "nightly" ]]; then
-              # Nightly: a real prerelease, and deliberately NOT --latest —
-              # /releases/latest and the "Latest" badge must keep pointing at
-              # the newest STABLE release that install.sh + stable `hal0 update`
-              # depend on. The nightly channel is followed via releases.hal0.dev
-              # /nightly.json, not /releases/latest.
-              gh release create "${TAG}" \
-                --title "hal0 ${TAG}" \
-                --notes-file "${NOTES_FILE}" \
-                --draft=false \
-                --prerelease=true
-            else
-              # Stable: see hal0_v0.1.0-alpha-launch + hal0_release_prerelease_flag
-              # memories. Pre-v1.0 tags are published --prerelease=false --latest
-              # on purpose so /releases/latest works while we're pre-stable.
-              gh release create "${TAG}" \
-                --title "hal0 ${TAG}" \
-                --notes-file "${NOTES_FILE}" \
-                --draft=false \
-                --prerelease=false \
-                --latest
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::error::GitHub Release ${TAG} already exists"
+            exit 1
+          fi
+          if [[ "${PUBLISH_PYPI}" == "true" ]]; then
+            STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/hal0ai/${PYPI_VERSION}/json")"
+            if [[ "${STATUS}" == "200" ]]; then
+              echo "::error::PyPI already has hal0ai==${PYPI_VERSION}"
+              exit 1
+            elif [[ "${STATUS}" != "404" ]]; then
+              echo "::error::PyPI collision preflight returned HTTP ${STATUS}"
+              exit 1
             fi
           fi
 
-          gh release upload "${TAG}" "${TARBALL}" "${BUNDLE}" "${SIG}" "${CRT}" "${MANIFEST}" --clobber
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve.outputs.tag }}
+          GITHUB_PRERELEASE: ${{ needs.resolve.outputs.github_prerelease }}
+          GITHUB_LATEST: ${{ needs.resolve.outputs.github_latest }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+          MANIFEST_DIR: ${{ steps.manifest.outputs.dir }}
+          TARBALL: ${{ steps.tarball.outputs.path }}
+          BUNDLE: ${{ steps.sign.outputs.bundle }}
+          SIG: ${{ steps.sign.outputs.sig }}
+          CRT: ${{ steps.sign.outputs.cert }}
+          NOTES_FILE: ${{ steps.notes.outputs.path }}
+        run: |
+          gh release create "${TAG}" --verify-tag --title "hal0 ${TAG}" --notes-file "${NOTES_FILE}" \
+            --draft=false --prerelease="${GITHUB_PRERELEASE}" --latest="${GITHUB_LATEST}"
+
+          ACTUAL_PRERELEASE="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.prerelease')"
+          LATEST_TAG="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"
+          ACTUAL_LATEST=false
+          [[ "${LATEST_TAG}" == "${TAG}" ]] && ACTUAL_LATEST=true
+          if [[ "${ACTUAL_PRERELEASE}" != "${GITHUB_PRERELEASE}" || \
+                "${ACTUAL_LATEST}" != "${GITHUB_LATEST}" ]]; then
+            echo "::error::release flags differ from policy: prerelease=${ACTUAL_PRERELEASE}, latest=${ACTUAL_LATEST}"
+            exit 1
+          fi
+
+          ASSETS=("${TARBALL}" "${BUNDLE}" "${SIG}" "${CRT}")
+          IFS=',' read -ra TARGETS <<< "${MANIFEST_TARGETS}"
+          for CHANNEL in "${TARGETS[@]}"; do
+            MANIFEST="${MANIFEST_DIR}/${CHANNEL}.json"
+            ASSETS+=("${MANIFEST}" "${MANIFEST}.bundle")
+          done
+
+          EXISTING_ASSETS="$(gh release view "${TAG}" --json assets --jq '.assets[].name')"
+          for ASSET in "${ASSETS[@]}"; do
+            NAME="$(basename "${ASSET}")"
+            if grep -Fxq "${NAME}" <<< "${EXISTING_ASSETS}"; then
+              echo "::error::asset collision: ${NAME} already exists on ${TAG}"
+              exit 1
+            fi
+          done
+          gh release upload "${TAG}" "${ASSETS[@]}"
+
+      # External channel pointer advancement is intentionally NOT performed in
+      # this immutable release step. It is the final, separately verified gate
+      # after every exact manifest and sibling bundle asset has been uploaded.
+      - name: Record separately verified channel pointer gate
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+        run: |
+          echo "Channel pointer advancement remains external for ${TAG}: ${MANIFEST_TARGETS}"
 
       - name: Summary
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+          MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
         run: |
-          TAG="${{ steps.ver.outputs.tag }}"
           {
             echo "## hal0 ${TAG} published"
             echo ""
             echo "| asset | sha256 |"
             echo "|---|---|"
-            echo "| hal0-${{ steps.ver.outputs.version }}.tar.gz | \`${{ steps.tarball.outputs.digest }}\` |"
+            echo "| hal0-${{ needs.resolve.outputs.version }}.tar.gz | \`${{ steps.tarball.outputs.digest }}\` |"
             echo ""
-            echo "Manifest URL (until releases.hal0.dev exists): "
-            echo ""
-            echo "    https://github.com/${{ github.repository }}/releases/download/${TAG}/${{ steps.ver.outputs.channel }}.json"
-            echo ""
-            echo "Verify locally:"
-            echo ""
-            echo '```'
-            echo "HAL0_RELEASES_URL='https://github.com/${{ github.repository }}/releases/download/${TAG}/${{ steps.ver.outputs.channel }}.json' \\"
-            echo "  hal0 update --check"
-            echo '```'
+            echo "Immutable manifests (each uploaded with a sibling .bundle): ${MANIFEST_TARGETS}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ── 8. PyPI wheel — convenience install, not the production path ────────────
@@ -544,47 +610,54 @@ jobs:
     name: PyPI wheel
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    needs: release # never ship a wheel for a release the tarball job couldn't verify
+    if: needs.resolve.outputs.publish_pypi == 'true'
+    needs: [resolve, release]
     environment: pypi
     permissions:
       contents: read
       id-token: write # required for PyPI OIDC
 
     steps:
-      - name: Resolve tag
-        id: tag
-        run: |
-          TAG="${{ inputs.tag }}"
-          if [[ -z "${TAG}" ]]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          if [[ -z "${TAG}" ]]; then
-            echo "::error::could not resolve tag"
-            exit 1
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout
+      - name: Checkout exact release tag
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.tag.outputs.tag }}
+          ref: ${{ needs.resolve.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Verify exact release commit
+        env:
+          TAG: ${{ needs.resolve.outputs.tag }}
+        run: |
+          HEAD_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-list -n1 "${TAG}")"
+          if [[ "${HEAD_SHA}" != "${TAG_SHA}" ]]; then
+            echo "::error::checked-out ref ${HEAD_SHA} does not match ${TAG} (${TAG_SHA})"
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Verify pyproject version matches tag
+      - name: Verify source and PyPI version remain available
+        env:
+          EXPECTED_SOURCE_VERSION: ${{ needs.resolve.outputs.version }}
+          PYPI_VERSION: ${{ needs.resolve.outputs.python_version }}
         run: |
-          EXPECT="${TAG#v}"
           ACTUAL="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          if [[ "${ACTUAL}" != "${EXPECT}" ]]; then
-            echo "::error::pyproject.toml version (${ACTUAL}) does not match tag (${TAG})"
+          if [[ "${ACTUAL}" != "${EXPECTED_SOURCE_VERSION}" ]]; then
+            echo "::error::pyproject.toml version (${ACTUAL}) differs from policy (${EXPECTED_SOURCE_VERSION})"
             exit 1
           fi
-        env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/hal0ai/${PYPI_VERSION}/json")"
+          if [[ "${STATUS}" == "200" ]]; then
+            echo "::error::PyPI already has hal0ai==${PYPI_VERSION}"
+            exit 1
+          elif [[ "${STATUS}" != "404" ]]; then
+            echo "::error::PyPI collision preflight returned HTTP ${STATUS}"
+            exit 1
+          fi
 
       - name: Build wheel + sdist
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
       github_prerelease: ${{ steps.policy.outputs.github_prerelease }}
       github_latest: ${{ steps.policy.outputs.github_latest }}
       publish_pypi: ${{ steps.policy.outputs.publish_pypi }}
+      signer_identity: ${{ steps.policy.outputs.signer_identity }}
       target_sha: ${{ steps.policy.outputs.target_sha }}
 
     steps:
@@ -136,6 +137,34 @@ jobs:
             echo "::error::input channel ${INPUT_CHANNEL} conflicts with tag policy ${KIND}"
             exit 1
           fi
+
+          # GitHub's keyless certificate binds the reusable workflow to the ref
+          # from which release.yml itself executes. Nightly is called from main;
+          # stable/preview execute directly at their immutable tag ref.
+          IDENT_PREFIX='^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@'
+          if [[ "${KIND}" == "nightly" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" != "workflow_call" ]]; then
+              echo "::error::nightly releases require workflow_call"
+              exit 1
+            fi
+            if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+              echo "::error::nightly release workflow must execute from refs/heads/main"
+              exit 1
+            fi
+            signer_identity=${IDENT_PREFIX}refs/heads/main$
+          else
+            if [[ "${GITHUB_EVENT_NAME}" != "push" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
+              echo "::error::${KIND} releases require push or workflow_dispatch"
+              exit 1
+            fi
+            if [[ "${GITHUB_REF}" != "refs/tags/${TAG}" ]]; then
+              echo "::error::${KIND} release workflow ref ${GITHUB_REF} must equal refs/tags/${TAG}"
+              exit 1
+            fi
+            ESCAPED_TAG="${TAG//./\\.}"
+            signer_identity=${IDENT_PREFIX}refs/tags/${ESCAPED_TAG}$
+          fi
+          echo "signer_identity=${signer_identity}" >> "$GITHUB_OUTPUT"
 
   release:
     name: Build, sign, publish
@@ -350,12 +379,11 @@ jobs:
       # ── 4. Self-verify before publishing — never ship a release we can't
       #       verify with our own production code path. ────────────────────────
       - name: Self-verify (cosign verify-blob with workflow OIDC identity)
+        env:
+          SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}
         run: |
           TARBALL="${{ steps.tarball.outputs.path }}"
           BUNDLE="${{ steps.sign.outputs.bundle }}"
-          # This is the same release.yml tag-or-main trust root pinned by
-          # updater.py for authenticating channel-manifest bundles.
-          IDENT="^https://github\\.com/(Hal0ai|hal0ai)/hal0/\\.github/workflows/release\\.yml@(refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.(0|[1-9][0-9]*)|-nightly\\.[0-9]{14})?|refs/heads/main)$"
           ISSUER="https://token.actions.githubusercontent.com"
           # Verify exactly as the client will (bootstrap.sh + updater.py):
           # the bundle supplies the cert + signature + Rekor SET, so this
@@ -363,7 +391,7 @@ jobs:
           # meaningful mirror of the real install path.
           cosign verify-blob \
               --bundle "${BUNDLE}" \
-              --certificate-identity-regexp "${IDENT}" \
+              --certificate-identity-regexp "${SIGNER_IDENTITY}" \
               --certificate-oidc-issuer    "${ISSUER}" \
               "${TARBALL}"
 
@@ -378,7 +406,7 @@ jobs:
           cosign verify-blob \
               --signature "${SIG}" \
               --certificate "${CRT}" \
-              --certificate-identity-regexp "${IDENT}" \
+              --certificate-identity-regexp "${SIGNER_IDENTITY}" \
               --certificate-oidc-issuer    "${ISSUER}" \
               "${TARBALL}"
 
@@ -392,16 +420,16 @@ jobs:
           PRERELEASE_STAGE: ${{ needs.resolve.outputs.prerelease_stage }}
           MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
           DIGEST: ${{ steps.tarball.outputs.digest }}
+          SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}
         run: |
           python3 -m pip install -e ".[dev]" >/dev/null
           OUT_DIR="${RUNNER_TEMP}/manifests"
           mkdir -p "${OUT_DIR}"
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
-          IDENT="^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.(0|[1-9][0-9]*)|-nightly\.[0-9]{14})?|refs/heads/main)$"
 
           python3 - "${OUT_DIR}" "${VERSION}" "${TAG}" "${RELEASE_KIND}" \
                    "${PRERELEASE_STAGE}" "${MANIFEST_TARGETS}" "${DIGEST}" \
-                   "${BASE_URL}" "${IDENT}" <<'PY'
+                   "${BASE_URL}" "${SIGNER_IDENTITY}" <<'PY'
           import datetime as dt
           import json
           import os
@@ -452,8 +480,8 @@ jobs:
         env:
           MANIFEST_DIR: ${{ steps.manifest.outputs.dir }}
           MANIFEST_TARGETS: ${{ needs.resolve.outputs.manifest_targets }}
+          SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}
         run: |
-          IDENT="^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.(0|[1-9][0-9]*)|-nightly\.[0-9]{14})?|refs/heads/main)$"
           ISSUER="https://token.actions.githubusercontent.com"
           IFS=',' read -ra TARGETS <<< "${MANIFEST_TARGETS}"
           for CHANNEL in "${TARGETS[@]}"; do
@@ -461,7 +489,7 @@ jobs:
             cosign sign-blob --yes --bundle "${MANIFEST}.bundle" "${MANIFEST}"
             cosign verify-blob \
               --bundle "${MANIFEST}.bundle" \
-              --certificate-identity-regexp "${IDENT}" \
+              --certificate-identity-regexp "${SIGNER_IDENTITY}" \
               --certificate-oidc-issuer "${ISSUER}" \
               "${MANIFEST}"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -792,13 +792,74 @@ jobs:
           RELEASE_JSON="${VERIFY_DIR}/release.json"
           LATEST_JSON="${VERIFY_DIR}/latest.json"
           ASSET_INDEX="${VERIFY_DIR}/assets.tsv"
+          ATTEMPT_DIR="${VERIFY_DIR}/attempts"
           DOWNLOAD_DIR="${VERIFY_DIR}/downloaded"
-          mkdir "${DOWNLOAD_DIR}"
+          mkdir "${ATTEMPT_DIR}" "${DOWNLOAD_DIR}"
+          GH_API_MAX_ATTEMPTS=5
+          GH_API_BACKOFF_SECONDS=2
+
+          github_api_read() {
+            local ENDPOINT="$1"
+            local DESTINATION="$2"
+            local LABEL="$3"
+            local ATTEMPT ATTEMPT_PATH
+            for ((ATTEMPT = 1; ATTEMPT <= GH_API_MAX_ATTEMPTS; ATTEMPT++)); do
+              ATTEMPT_PATH="${ATTEMPT_DIR}/${LABEL}.attempt-${ATTEMPT}"
+              rm -f -- "${ATTEMPT_PATH}"
+              if gh api "${ENDPOINT}" > "${ATTEMPT_PATH}"; then
+                mv -- "${ATTEMPT_PATH}" "${DESTINATION}"
+                return 0
+              fi
+              rm -f -- "${ATTEMPT_PATH}"
+              if ((ATTEMPT < GH_API_MAX_ATTEMPTS)); then
+                echo "::warning::GitHub API read failed for ${LABEL} (attempt ${ATTEMPT}/${GH_API_MAX_ATTEMPTS}); retrying"
+                sleep "$((GH_API_BACKOFF_SECONDS * ATTEMPT))"
+              fi
+            done
+            echo "::error::GitHub API read failed for ${LABEL} after ${GH_API_MAX_ATTEMPTS} attempts"
+            return 1
+          }
+
+          download_asset() {
+            local ASSET_NAME="$1"
+            local ASSET_ID="$2"
+            local DECLARED_SIZE="$3"
+            local DESTINATION="$4"
+            local ATTEMPT ATTEMPT_PATH OBSERVED_SIZE
+            for ((ATTEMPT = 1; ATTEMPT <= GH_API_MAX_ATTEMPTS; ATTEMPT++)); do
+              ATTEMPT_PATH="${ATTEMPT_DIR}/asset-${ASSET_ID}.attempt-${ATTEMPT}"
+              rm -f -- "${ATTEMPT_PATH}"
+              if gh api -H "Accept: application/octet-stream" \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" \
+                > "${ATTEMPT_PATH}"; then
+                OBSERVED_SIZE="$(wc -c < "${ATTEMPT_PATH}")"
+                if [[ "${OBSERVED_SIZE}" == "${DECLARED_SIZE}" ]]; then
+                  mv -- "${ATTEMPT_PATH}" "${DESTINATION}"
+                  return 0
+                fi
+                echo "::warning::remote asset size mismatch for ${ASSET_NAME}: declared=${DECLARED_SIZE}, downloaded=${OBSERVED_SIZE} (attempt ${ATTEMPT}/${GH_API_MAX_ATTEMPTS})"
+              else
+                echo "::warning::GitHub API download failed for ${ASSET_NAME} (attempt ${ATTEMPT}/${GH_API_MAX_ATTEMPTS})"
+              fi
+              rm -f -- "${ATTEMPT_PATH}"
+              if ((ATTEMPT < GH_API_MAX_ATTEMPTS)); then
+                sleep "$((GH_API_BACKOFF_SECONDS * ATTEMPT))"
+              fi
+            done
+            echo "::error::failed to download exact declared bytes for ${ASSET_NAME} after ${GH_API_MAX_ATTEMPTS} attempts"
+            return 1
+          }
 
           # Query one exact release. The latest endpoint is consulted only to
           # observe GitHub's computed flag; it is never used to choose assets.
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" > "${RELEASE_JSON}"
-          gh api "repos/${GITHUB_REPOSITORY}/releases/latest" > "${LATEST_JSON}"
+          # Each successful response is atomically promoted from an attempt file;
+          # exhausted API failures stop authorization rather than changing policy.
+          github_api_read \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            "${RELEASE_JSON}" "release-metadata"
+          github_api_read \
+            "repos/${GITHUB_REPOSITORY}/releases/latest" \
+            "${LATEST_JSON}" "latest-release"
 
           python3 - "${RELEASE_JSON}" "${LATEST_JSON}" "${ASSET_INDEX}" <<'PY'
           import json
@@ -860,22 +921,21 @@ jobs:
               asset_id = asset.get("id")
               if not isinstance(asset_id, int) or asset_id <= 0:
                   raise SystemExit(f"invalid numeric asset ID: {name}")
-              rows.append((name, asset_id))
-          index_path.write_text("".join(f"{name}\t{asset_id}\n" for name, asset_id in rows))
+              rows.append((name, asset_id, asset["size"]))
+          index_path.write_text(
+              "".join(
+                  f"{name}\t{asset_id}\t{size}\n" for name, asset_id, size in rows
+              )
+          )
           PY
 
-          while IFS=$'\t' read -r ASSET_NAME ASSET_ID; do
+          while IFS=$'\t' read -r ASSET_NAME ASSET_ID DECLARED_SIZE; do
             DESTINATION="${DOWNLOAD_DIR}/${ASSET_NAME}"
             if [[ -e "${DESTINATION}" ]]; then
               echo "::error::refusing duplicate asset destination ${ASSET_NAME}"
               exit 1
             fi
-            gh api -H "Accept: application/octet-stream" \
-              "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" > "${DESTINATION}"
-            if [[ ! -s "${DESTINATION}" ]]; then
-              echo "::error::downloaded empty asset ${ASSET_NAME}"
-              exit 1
-            fi
+            download_asset "${ASSET_NAME}" "${ASSET_ID}" "${DECLARED_SIZE}" "${DESTINATION}"
           done < "${ASSET_INDEX}"
 
           TARBALL="${DOWNLOAD_DIR}/hal0-${VERSION}.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
             exit 1
           fi
 
-      # ── 1. Build the UI bundle so the tarball includes ui-dist/ ─────────────
+      # ── 1. Build the UI bundle so the tarball includes ui/dist/ ─────────────
       - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
@@ -217,20 +217,42 @@ jobs:
           cp -a packaging            "${STAGE}/"
           cp -a docs                 "${STAGE}/"
 
-          # Prebuilt UI bundle — staged at ui/dist/ so install.sh's
-          # "ui/dist already built — left alone" branch fires (the npm
-          # fallback would `cd ui && npm install` which we don't ship)
-          # and so the FastAPI mount_dashboard resolution path
-          # (`<repo>/ui/dist`) finds it without a HAL0_UI_DIST override.
-          if [[ -d ui/dist ]]; then
+          # Prebuilt UI bundle — release trees intentionally contain ui/dist
+          # but no ui/package.json or other rebuild inputs. install.sh therefore
+          # treats this signed payload as distribution-only and never invokes
+          # npm; FastAPI resolves the same bundle at <repo>/ui/dist.
+          if [[ -s ui/dist/index.html ]]; then
             mkdir -p                 "${STAGE}/ui"
             cp -a ui/dist            "${STAGE}/ui/dist"
           else
-            echo "::error::ui/dist missing after npm run build"
+            echo "::error::ui/dist/index.html missing or empty after npm run build"
             exit 1
           fi
 
           echo "${VERSION}" > "${STAGE}/VERSION"
+
+          # Composition contract: these paths are consumed by install.sh or by
+          # updater extraction/apply. Keep the release tree installable while
+          # preserving its prebuilt-only UI shape (never stage node_modules).
+          for required in \
+            "${STAGE}/src/hal0/updater/updater.py" \
+            "${STAGE}/manifest.json" \
+            "${STAGE}/pyproject.toml" \
+            "${STAGE}/installer/install.sh" \
+            "${STAGE}/installer/lib/ui.sh" \
+            "${STAGE}/packaging/systemd/hal0-openwebui.service" \
+            "${STAGE}/ui/dist/index.html" \
+            "${STAGE}/VERSION"; do
+            if [[ ! -e "${required}" ]]; then
+              echo "::error::release tree missing required path ${required}"
+              exit 1
+            fi
+          done
+          if [[ -e "${STAGE}/ui/package.json" || -e "${STAGE}/ui/node_modules" ]]; then
+            echo "::error::release tree must contain prebuilt ui/dist only, not npm build inputs"
+            exit 1
+          fi
+
           echo "stage=${STAGE}"      >> "$GITHUB_OUTPUT"
 
       # ── 2b. Stage release notes INTO the tarball ────────────────────────────

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,69 @@
+# Task 4 report — immutable prerelease publication
+
+## Status
+
+Complete. The release workflow now resolves one tag-derived policy before any build, checks out that exact tag in release and PyPI jobs, publishes policy-targeted manifests with sibling Sigstore bundles, and refuses mutable GitHub/PyPI publication. The local preflight accepts and validates the preview channel. No installer, UI, updater, Graphify, or Shepherd source was intentionally changed.
+
+## Commits
+
+- `5dd93fdd` — `fix(release): publish preview artifacts immutably`
+- Follow-up documentation commit — this report only.
+
+## Changed files
+
+- `.github/workflows/release.yml`
+  - Added the prerequisite `resolve` job and exposed `ReleasePolicy.to_github_outputs()` values.
+  - Made release and PyPI jobs depend on the resolved exact tag and verify tag/HEAD equality.
+  - Generated and schema-validated every `manifest_targets` manifest.
+  - Signed and self-verified each exact JSON file with its sibling `.bundle` using the client-pinned release-workflow identity and issuer.
+  - Added release, asset, and normalized PyPI collision preflights; removed overwrite publication.
+  - Drove GitHub prerelease/latest flags and PyPI eligibility from policy outputs and verified release flags after creation.
+  - Kept channel-pointer advancement external as the final separately verified gate.
+- `scripts/release-check.sh`
+  - Added `stable|preview|nightly` usage/help and channel validation.
+  - Enforced preview tag grammar, channel-policy agreement, base/source version agreement, and normalized PyPI collision checks.
+  - Kept dry-run preflight operations read-only.
+- `tests/release/test_workflow_contract.py`
+  - Added static contracts for resolve outputs, exact-ref checkout, immutable upload, policy flags, manifest validation/signing/verification/upload, and separate pointer advancement.
+
+## TDD evidence
+
+### RED
+
+1. Initial literal command:
+   - `uv run pytest -q tests/release/test_workflow_contract.py tests/release/test_policy.py`
+   - Collection blocked with exit 4 because the host `/etc/hal0/hal0.toml` was present but unreadable. This was an environment issue, not the intended contract RED.
+2. Isolated command:
+   - `HAL0_HOME=/tmp/hal0-task4-test uv run pytest -q tests/release/test_workflow_contract.py tests/release/test_policy.py`
+   - **6 failed, 13 passed**. All six new workflow-contract tests failed against the pre-change workflow.
+
+### GREEN
+
+- `HAL0_HOME=/tmp/hal0-task4-test uv run pytest -q tests/release/test_workflow_contract.py tests/release/test_policy.py tests/release/test_channel.py`
+  - **34 passed**, 1 unrelated Starlette deprecation warning.
+- `bash -n scripts/release-check.sh`
+  - Passed.
+- `bash scripts/release-check.sh --help`
+  - Passed and printed `stable|preview|nightly` usage without running release gates.
+- Extracted workflow manifest generator, run locally with dummy digest and stable policy targets.
+  - Both manifests passed `ReleaseManifest.model_validate`; comparison confirmed stable/preview outputs differ only by `channel` and `manifest_url`.
+- Parsed `.github/workflows/release.yml` with PyYAML.
+  - Passed; jobs were `resolve`, `release`, and `pypi-publish`.
+- `git diff --check`
+  - Passed.
+
+## Self-review
+
+### Findings
+
+- **No blocker/high findings.** Exact tag checkout and tag-to-HEAD verification are present in both publishing jobs.
+- **No blocker/high findings.** Every generated channel JSON is validated, signed as exact bytes, self-verified with the updater-pinned trust root, collision-checked, and uploaded with its sibling bundle.
+- **No blocker/high findings.** `--clobber` is absent; existing releases, assets, and policy-normalized PyPI versions fail closed.
+- **No blocker/high findings.** Preview prerelease/latest values and PyPI eligibility are policy outputs rather than inferred from an input channel.
+
+### Concerns / residual risks
+
+- No live GitHub Release, Sigstore OIDC signing, or PyPI publication was executed locally; safety/security wiring is covered by static contracts plus local manifest validation.
+- An external channel-pointer advancement implementation remains outside this workflow by explicit requirement; this workflow only records that separately verified final gate.
+- If GitHub release creation succeeds but a later verification or upload fails, the intentionally immutable retry policy requires an operator to inspect and clean up the incomplete release rather than overwrite it.
+- Pre-existing/generated `.pi/shepherd/index.json` and `graphify-out/*` changes remain unstaged and were not included in the Task 4 implementation commit.

--- a/README.md
+++ b/README.md
@@ -219,16 +219,17 @@ be evicted out from under a streaming request.
   ComfyUI in the `img` slot container (ROCm). `hal0 setup` lets you
   select image-gen as part of the initial configuration.
 - **Atomic self-update with rollback** — `hal0 update --channel
-  stable|nightly`. Cosign-verified tarballs swap a
+  stable|preview|nightly`. Cosign-verified tarballs swap a
   `/usr/lib/hal0/current` symlink; `--rollback` reverts.
 - **One-line install** — `curl -fsSL https://hal0.dev/install.sh | bash`
   writes the first-run sentinel and wiring automatically — no model picks,
   no download, no interaction needed. Run `hal0 setup` afterward to choose
   models and configure apps and agents.
   (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects model pulls
-  off `/var/lib/hal0/models`). The bootstrap fetches the release
-  manifest, sha256-verifies the tarball, cosign-verifies the signature
-  against the workflow OIDC identity, then hands off to
+  off `/var/lib/hal0/models`). The bootstrap requires `jq` and `cosign`,
+  authenticates the exact channel manifest before strict schema/channel
+  parsing, then sha256- and Sigstore-bundle-verifies the tarball before
+  handing off to
   [`installer/install.sh`](./installer/install.sh).
   Rerun `hal0 setup` at any time to add slots, change storage, or
   install extensions — the provisioning endpoints are idempotent.

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -21,8 +21,11 @@ To install from the opt-in preview channel instead:
 curl -fsSL https://hal0.dev/install.sh | HAL0_CHANNEL=preview bash
 ```
 
-Only `stable`, `preview`, and `nightly` are accepted. The channel is validated
-before any download, and stable clients never consume preview artifacts.
+Only `stable`, `preview`, and `nightly` are accepted. The requested channel is
+validated before any download, and stable clients never consume preview
+artifacts. These URLs describe the client contract; installation also depends
+on the external release service publishing the selected pointer and sibling
+bundle, which this repository does not operate.
 
 <Aside type="note">
 The installer needs root to write to `/etc`, `/usr/lib`, and the systemd
@@ -42,6 +45,8 @@ itself under `sudo` automatically. You can also run it explicitly:
 - **cosign** — required to authenticate the channel manifest and release
   artifact against hal0's pinned GitHub Actions workflow identity. The
   bootstrap fails closed when `cosign` or a signature bundle is missing.
+- **jq 1.6 or newer** — required for the authenticated manifest's strict,
+  fail-closed schema and channel-policy validation.
 - **A container runtime** — every inference slot runs in a container. The
   installer auto-installs **podman** if no runtime is found.
 - **~20 GB free disk** under the data directory, plus free ports `8080`
@@ -92,16 +97,21 @@ For a full production deployment, use the bootstrap script above.
    `HAL0_CHANNEL`. The bootstrap downloads the exact sibling
    `<channel>.json.bundle` and verifies the manifest bytes with cosign against
    the client-pinned release-workflow identity and issuer before parsing JSON
-   or trusting artifact URLs. Missing cosign, a missing bundle, or failed
-   verification aborts the install. `HAL0_RELEASES_URL` still overrides the
-   full manifest URL; its sibling `.bundle` must satisfy the same contract.
+   or trusting artifact URLs. Then one jq-compatible policy pass requires the
+   exact `hal0.releases.v1` schema, required strings and digest shape, and the
+   canonical requested-channel/kind/stage matrix. Missing jq or cosign, a
+   missing bundle, or failed validation/verification aborts the install.
+   `HAL0_RELEASES_URL` still overrides the full manifest URL; its sibling
+   `.bundle` must satisfy the same contract.
 
 2. **Download and SHA-256-verify the tarball** against the authenticated
    manifest digest. A mismatch aborts the install.
 
-3. **Cosign keyless verify the tarball** — the artifact's Sigstore bundle is
-   checked against the workflow OIDC identity declared in the now-trusted
-   manifest. This second signature check is defense-in-depth.
+3. **Cosign keyless verify the tarball** — the mandatory artifact Sigstore
+   bundle from `bundle_url` is checked against the workflow OIDC identity
+   declared in the now-trusted manifest. Detached signature/certificate
+   fallback is not accepted by the bootstrap. This second signature check is
+   defense-in-depth.
 
 4. **Unpack and hand off** to `installer/install.sh`, which runs
    pre-flight checks, installs podman + the Python venv, builds the

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install hal0
-description: Install hal0 with one command — the bootstrap verifies the release with SHA-256 (and cosign, when available), installs podman, scaffolds empty capability slots, and starts the API.
+description: Install hal0 with one command — the bootstrap verifies the signed channel manifest and release artifact, installs podman, scaffolds empty capability slots, and starts the API.
 sidebar:
   order: 10
 ---
@@ -14,6 +14,15 @@ it, and hands off to the real installer.
 ```sh
 curl -fsSL https://hal0.dev/install.sh | bash
 ```
+
+To install from the opt-in preview channel instead:
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | HAL0_CHANNEL=preview bash
+```
+
+Only `stable`, `preview`, and `nightly` are accepted. The channel is validated
+before any download, and stable clients never consume preview artifacts.
 
 <Aside type="note">
 The installer needs root to write to `/etc`, `/usr/lib`, and the systemd
@@ -30,6 +39,9 @@ itself under `sudo` automatically. You can also run it explicitly:
 - **systemd** — `systemctl` must be on `PATH` (outside `--dev` mode).
 - **Python ≥ 3.12** — the package requires 3.12+; the installer is tested
   on 3.11–3.14 and builds a dedicated virtualenv.
+- **cosign** — required to authenticate the channel manifest and release
+  artifact against hal0's pinned GitHub Actions workflow identity. The
+  bootstrap fails closed when `cosign` or a signature bundle is missing.
 - **A container runtime** — every inference slot runs in a container. The
   installer auto-installs **podman** if no runtime is found.
 - **~20 GB free disk** under the data directory, plus free ports `8080`
@@ -75,21 +87,21 @@ For a full production deployment, use the bootstrap script above.
 
 <Steps>
 
-1. **Fetch the release manifest** — by default the latest `stable.json`
-   from GitHub Releases. Override with `HAL0_RELEASES_URL` or pick a
-   channel with `HAL0_CHANNEL`.
+1. **Fetch and authenticate the channel manifest** — by default from
+   `https://releases.hal0.dev/stable.json`, or the selected
+   `HAL0_CHANNEL`. The bootstrap downloads the exact sibling
+   `<channel>.json.bundle` and verifies the manifest bytes with cosign against
+   the client-pinned release-workflow identity and issuer before parsing JSON
+   or trusting artifact URLs. Missing cosign, a missing bundle, or failed
+   verification aborts the install. `HAL0_RELEASES_URL` still overrides the
+   full manifest URL; its sibling `.bundle` must satisfy the same contract.
 
-2. **Download and SHA-256-verify the tarball** against the digest in the
-   manifest. A mismatch aborts the install.
+2. **Download and SHA-256-verify the tarball** against the authenticated
+   manifest digest. A mismatch aborts the install.
 
-3. **Cosign keyless verify, when available** — if `cosign` is on `PATH`,
-   the Fulcio-issued certificate and signature are checked against the
-   workflow OIDC identity declared in the manifest; a failed check aborts
-   the install. If `cosign` is **not** installed, the bootstrap proceeds
-   on the SHA-256 check alone with a loud warning — cosign is no longer a
-   hard requirement for the one-line install. Set
-   `HAL0_INSTALL_REQUIRE_COSIGN=1` to restore the old strict behavior
-   (fail instead of warn when cosign is missing).
+3. **Cosign keyless verify the tarball** — the artifact's Sigstore bundle is
+   checked against the workflow OIDC identity declared in the now-trusted
+   manifest. This second signature check is defense-in-depth.
 
 4. **Unpack and hand off** to `installer/install.sh`, which runs
    pre-flight checks, installs podman + the Python venv, builds the
@@ -113,7 +125,8 @@ flags:
 | `HAL0_MODELS_DIR` | `/var/lib/hal0/models` (or `$PWD/.hal0ai/var/lib/hal0/models` under `--dev`) | Where Hugging Face pulls land |
 | `HAL0_PYTHON` | `python3` | Python interpreter to build the venv from |
 | `HAL0_NO_PROBE` | _(unset)_ | Set to `1` to skip first-run automatic setup (empty capability-slot scaffolding) |
-| `HAL0_INSTALL_REQUIRE_COSIGN` | _(unset)_ | Set to `1` to make the bootstrap refuse the install outright when `cosign` isn't present, instead of warning and proceeding on the SHA-256 check alone |
+| `HAL0_CHANNEL` | `stable` | Bootstrap channel: `stable`, `preview`, or `nightly` |
+| `HAL0_RELEASES_URL` | `https://releases.hal0.dev/<channel>.json` | Full manifest URL override; the exact sibling `.bundle` remains mandatory |
 
 | Flag | Effect |
 |---|---|

--- a/docs/guides/update-and-rollback.mdx
+++ b/docs/guides/update-and-rollback.mdx
@@ -67,15 +67,27 @@ hal0 update --target v0.8.4b1
 
 ## Channels
 
-Two release channels are available: **`stable`** and **`nightly`**. Set
-your channel (it persists in `hal0.toml`), which also runs a check:
+Three release channels are available: **`stable`**, **`preview`**, and
+**`nightly`**. Set your updater channel (it persists in `hal0.toml`), which
+also runs a check:
 
 ```sh
+hal0 update --channel preview
+# or
 hal0 update --channel nightly
 ```
 
+For a new preview-channel bootstrap, pass the channel to the receiving shell:
+
+```sh
+curl -fsSL https://hal0.dev/install.sh | HAL0_CHANNEL=preview bash
+```
+
 The manifest is fetched from `https://releases.hal0.dev/<channel>.json`
-(overridable via `HAL0_RELEASES_URL` for dev / air-gapped installs).
+(overridable via `HAL0_RELEASES_URL` for dev / air-gapped installs). Preview is
+strictly opt-in: stable clients accept only stable pointer contents and never
+consume preview artifacts. A stable artifact may be promoted through the
+preview pointer without changing its `release_kind`.
 
 ![The Settings → Updates panel showing current version, available update, and channel selector](/screenshots/settings-page.png)
 *Settings → Updates: current version, available release, and channel selector.*
@@ -112,16 +124,20 @@ testing, not production.
 
 <Steps>
 
-1. **Fetch** the release manifest for the channel.
+1. **Fetch and authenticate** the exact release-manifest bytes and sibling
+   `<channel>.json.bundle` with `cosign verify-blob`, using the updater's
+   client-pinned release-workflow identity and issuer. No artifact URL is
+   trusted before authentication succeeds. A missing `cosign`, missing bundle,
+   or failed verification aborts closed.
 
-2. **Download** the release tarball plus its detached cosign signature and
-   Fulcio certificate into a per-version cache under `/var/lib/hal0`.
+2. **Download** the release tarball plus its Sigstore bundle into a per-version
+   cache under `/var/lib/hal0`.
 
-3. **Verify** the SHA-256 digest against the manifest, then the signature
-   with `cosign verify-blob` against the GitHub Actions OIDC identity
-   declared in the manifest (`signer_identity` / `signer_issuer`). A missing
-   `cosign` binary or a failed verification aborts the update — nothing is
-   swapped.
+3. **Verify** the SHA-256 digest against the authenticated manifest, then
+   verify the tarball signature against the GitHub Actions OIDC identity
+   declared in the trusted manifest (`signer_identity` / `signer_issuer`).
+   This artifact verification remains defense-in-depth; failure aborts the
+   update and nothing is swapped.
 
 4. **Extract** the tarball and run any forward config migrations the
    release needs, plus three self-healing passes over on-disk state:
@@ -172,13 +188,10 @@ that skip hatch is active.
 </Aside>
 
 <Aside type="note">
-This mandatory check is for the ongoing `hal0 update` path above. The
-**initial one-line installer** is more lenient: it does not
-hard-requires the `cosign` binary to be present — a missing `cosign` logs a
-warning and the install proceeds without publisher-signature verification
-(the tarball's checksum is still checked). Set
-`HAL0_INSTALL_REQUIRE_COSIGN=1` before running the installer to restore the
-old hard-require behavior.
+The **initial one-line installer** uses the same signed-manifest trust
+contract. It requires cosign, verifies the sibling channel-manifest bundle
+against the same pinned release-workflow identity and issuer before parsing,
+and then verifies the tarball digest and signature as defense-in-depth.
 </Aside>
 
 ## Roll back

--- a/docs/guides/update-and-rollback.mdx
+++ b/docs/guides/update-and-rollback.mdx
@@ -1,6 +1,6 @@
 ---
 title: Update and roll back
-description: Cosign-verified, atomic self-update for hal0 — check the stable or nightly channel, apply or pin a specific version, and roll back to the previous tree.
+description: Cosign-verified, atomic self-update for hal0 — check the stable, preview, or nightly channel, apply or pin a specific version, and roll back to the previous tree.
 sidebar:
   order: 110
 ---
@@ -83,11 +83,14 @@ For a new preview-channel bootstrap, pass the channel to the receiving shell:
 curl -fsSL https://hal0.dev/install.sh | HAL0_CHANNEL=preview bash
 ```
 
-The manifest is fetched from `https://releases.hal0.dev/<channel>.json`
-(overridable via `HAL0_RELEASES_URL` for dev / air-gapped installs). Preview is
-strictly opt-in: stable clients accept only stable pointer contents and never
-consume preview artifacts. A stable artifact may be promoted through the
-preview pointer without changing its `release_kind`.
+The manifest URL contract is `https://releases.hal0.dev/<channel>.json`
+(overridable via `HAL0_RELEASES_URL` for dev / air-gapped installs). Availability
+still depends on the separately operated external release service publishing
+that exact pointer and sibling bundle; this repository does not make those
+external pointers operational. Preview is strictly opt-in: stable clients
+accept only stable pointer contents and never consume preview artifacts. A
+stable artifact may be promoted through the preview pointer without changing
+its `release_kind`.
 
 ![The Settings → Updates panel showing current version, available update, and channel selector](/screenshots/settings-page.png)
 *Settings → Updates: current version, available release, and channel selector.*
@@ -189,9 +192,11 @@ that skip hatch is active.
 
 <Aside type="note">
 The **initial one-line installer** uses the same signed-manifest trust
-contract. It requires cosign, verifies the sibling channel-manifest bundle
-against the same pinned release-workflow identity and issuer before parsing,
-and then verifies the tarball digest and signature as defense-in-depth.
+contract. It requires jq and cosign, verifies the sibling channel-manifest
+bundle against the same pinned release-workflow identity and issuer before
+parsing, then applies a strict `hal0.releases.v1` channel policy. It requires
+the artifact `bundle_url`; detached signature/certificate fallback is not
+accepted. Digest and bundle verification remain defense-in-depth.
 </Aside>
 
 ## Roll back

--- a/docs/internal/release-manifest.md
+++ b/docs/internal/release-manifest.md
@@ -11,30 +11,32 @@ self-updater (``installer/bootstrap.sh`` and
 "_schema": "hal0.releases.v1"
 ```
 
-All manifests carry this field so consumers can reject an unexpected schema
-shape. Future schema iterations (v2, v3…) will use a distinct identifier.
+This field is mandatory and must be the string literal shown above. Missing,
+unknown, null, or non-string schema identities are rejected. Future schema
+iterations (v2, v3…) will use a distinct identifier.
 
-## Required fields
+## Fields required by the strict bootstrap policy
 
 | Field              | Type     | Description                                              |
 |--------------------|----------|----------------------------------------------------------|
-| `version`          | `str`    | Release version, e.g. `"0.1.1"`.                        |
-| `url`              | `str`    | Tarball download URL (https or file).                    |
-| `bundle_url`       | `str`    | Sigstore bundle URL (cosign keyless OIDC).               |
-| `digest_sha256`    | `str`    | Hex sha256 of the tarball bytes (64 hex chars).          |
-| `signer_identity`  | `str`    | GitHub Actions OIDC subject regex for cosign verify.     |
+| `_schema`          | literal  | Exactly `"hal0.releases.v1"`.                           |
+| `version`          | `str`    | Nonempty release version, e.g. `"0.1.1"`.               |
+| `channel`          | `str`    | Canonical pointer: `stable`, `preview`, or `nightly`.    |
+| `release_kind`     | `str`    | Canonical artifact kind: stable, preview, or nightly.    |
+| `url`              | `str`    | Nonempty tarball download URL (https or file).           |
+| `bundle_url`       | `str`    | Nonempty, mandatory Sigstore artifact-bundle URL.        |
+| `digest_sha256`    | `str`    | 64 hex chars, optionally prefixed with `sha256:`.        |
+| `signer_identity`  | `str`    | Nonempty GitHub Actions OIDC subject regex for cosign.   |
+| `signer_issuer`    | `str`    | Nonempty OIDC issuer used for artifact verification.     |
 
 ## Optional fields
 
 | Field                | Type                 | Default                            | Description                                              |
 |----------------------|----------------------|------------------------------------|----------------------------------------------------------|
-| `channel`            | `str`                | `"stable"`                         | Channel pointer targeted by this manifest.                |
-| `release_kind`       | `str`                | `"stable"`                         | Artifact kind: `"stable"`, `"nightly"`, or `"preview"`.  |
 | `prerelease_stage`   | `str` or `null`      | `null`                             | Preview stage: `"alpha"`, `"beta"`, or `"rc"`.           |
 | `rollback_policy`    | `str`                | `"safe"`                           | Rollback policy: `"safe"`, `"backup-required"`, `"blocked"`. |
 | `upgrade_from`       | `str`                | `""`                               | Version constraint for supported upgrade paths, e.g. `">=0.9.8"`. |
 | `operator_migrations`| `list[str]`          | `[]`                               | Operator-visible migration steps for this release.        |
-| `signer_issuer`      | `str`                | `"https://token.actions.githubusercontent.com"` | OIDC issuer URL.                         |
 | `min_data_version`   | `int`                | `1`                                | Minimum config schema version.                            |
 | `revoked`            | `bool`               | `false`                            | True if the release is yanked/withdrawn.                  |
 | `revoked_reason`     | `str`                | `""`                               | Reason shown when `revoked` is true.                      |
@@ -42,6 +44,11 @@ shape. Future schema iterations (v2, v3…) will use a distinct identifier.
 | `notes_url`          | `str` or `null`      | `null`                             | URL to release notes.                                     |
 | `manifest_url`       | `str` or `null`      | `null`                             | Self-reference URL.                                       |
 | `toolbox_images`     | `dict`               | `{}`                               | Mirror of manifest.json's toolbox_images block.           |
+
+For updater compatibility, the Python model still defaults omitted `channel`
+and `release_kind` to `stable`, and `signer_issuer` to the GitHub Actions OIDC
+issuer. The bootstrap intentionally does not apply those defaults: all three
+must be explicit nonempty strings in an authenticated pointer.
 
 ## Cross-field validation
 
@@ -76,12 +83,17 @@ Each pointer has an exact sibling Sigstore bundle, for example
 and sibling bundle, then run `cosign verify-blob` with their client-pinned
 `.github/workflows/release.yml` identity and
 `https://token.actions.githubusercontent.com` issuer before trusting artifact
-URLs. The bootstrap performs this check before parsing the JSON; the updater
+URLs. The bootstrap performs this check before parsing the JSON; no manifest
+field can influence manifest verification. After authentication, one jq
+1.6-compatible fail-closed pass requires the exact schema, nonempty bootstrap
+strings, normalized digest, requested-channel equality, the stable/preview/
+nightly kind matrix, and preview-only alpha/beta/rc stage rules. The updater
 may decode for schema/channel rejection first but does not return or act on the
 manifest until authentication succeeds. The manifest's own `signer_identity`
 and `signer_issuer` fields become trusted only after that check. A missing
-bundle, missing `cosign`, or failed verification aborts closed. Tarball digest
-and bundle verification then remain defense-in-depth.
+`jq`, bundle, or `cosign`, or failed validation/verification aborts closed.
+The artifact `bundle_url` is mandatory; bootstrap has no detached `.sig`/`.crt`
+fallback. Tarball digest and bundle verification then remain defense-in-depth.
 
 The release workflow produces each pointer and bundle together as release
 assets. Serving or advancing those external `releases.hal0.dev` pointers is a

--- a/docs/internal/release-manifest.md
+++ b/docs/internal/release-manifest.md
@@ -26,7 +26,7 @@ iterations (v2, v3…) will use a distinct identifier.
 | `url`              | `str`    | Nonempty tarball download URL (https or file).           |
 | `bundle_url`       | `str`    | Nonempty, mandatory Sigstore artifact-bundle URL.        |
 | `digest_sha256`    | `str`    | 64 hex chars, optionally prefixed with `sha256:`.        |
-| `signer_identity`  | `str`    | Nonempty GitHub Actions OIDC subject regex for cosign.   |
+| `signer_identity`  | `str`    | Exact generated GitHub Actions OIDC subject regex.       |
 | `signer_issuer`    | `str`    | Nonempty OIDC issuer used for artifact verification.     |
 
 ## Optional fields
@@ -52,7 +52,7 @@ must be explicit nonempty strings in an authenticated pointer.
 
 ## Cross-field validation
 
-The pydantic model enforces these rules at parse time:
+Client schema and authenticated admission validation enforce these rules:
 
 1. **Preview coherence** — When `release_kind` is `"preview"`:
    - `prerelease_stage` must be one of `"alpha"`, `"beta"`, or `"rc"`.
@@ -64,6 +64,10 @@ The pydantic model enforces these rules at parse time:
      of an already-built stable artifact to preview before advancing stable.
    - Nightly artifacts have `release_kind: "nightly"`, no `prerelease_stage`,
      and target only the `nightly` pointer.
+   - Versions match their artifact kind: `X.Y.Z` for stable,
+     `X.Y.Z-(alpha|beta|rc).N` for preview, and
+     `X.Y.Z-nightly.YYYYMMDDHHMMSS` for current nightlies. Clients retain
+     read compatibility for legacy `X.Y.Z-nightly.YYYYMMDD` manifests.
 
 3. **Operator-migration safety** — When `operator_migrations` is non-empty:
    - `rollback_policy` must be `"backup-required"` or `"blocked"`.
@@ -79,19 +83,22 @@ artifact during promotion, but `stable.json` accepts only stable artifacts.
 Consequently, stable clients never consume preview artifacts.
 
 Each pointer has an exact sibling Sigstore bundle, for example
-`preview.json.bundle`. The bootstrap and updater download the manifest bytes
-and sibling bundle, then run `cosign verify-blob` with their client-pinned
-`.github/workflows/release.yml` identity and
-`https://token.actions.githubusercontent.com` issuer before trusting artifact
-URLs. The bootstrap performs this check before parsing the JSON; no manifest
-field can influence manifest verification. After authentication, one jq
-1.6-compatible fail-closed pass requires the exact schema, nonempty bootstrap
-strings, normalized digest, requested-channel equality, the stable/preview/
-nightly kind matrix, and preview-only alpha/beta/rc stage rules. The updater
-may decode for schema/channel rejection first but does not return or act on the
-manifest until authentication succeeds. The manifest's own `signer_identity`
-and `signer_issuer` fields become trusted only after that check. A missing
-`jq`, bundle, or `cosign`, or failed validation/verification aborts closed.
+`preview.json.bundle`. The bootstrap and updater download the exact manifest
+bytes and sibling bundle, then verify before parsing any JSON. The first
+identity is selected only from the locally requested channel: stable admits
+final `vX.Y.Z` tag identities, preview admits final or
+`vX.Y.Z-(alpha|beta|rc).N` tag identities, and nightly admits only
+`.github/workflows/release.yml@refs/heads/main`. Tag identities never admit a
+nightly manifest, and the main identity never admits stable or preview.
+
+After admission, schema/channel/version policy is validated, including the
+legacy 8-digit nightly read form. Clients derive the one exact expected
+identity from authenticated `release_kind` + `version`, require
+`signer_identity` to equal that generated contract, and reverify broader tag
+admissions with the exact escaped tag identity. Artifact verification uses
+that derived exact identity rather than a manifest-selected regex. Manifest
+verification pins `https://token.actions.githubusercontent.com`. A missing
+`jq`, bundle, or `cosign`, or failed validation or verification aborts closed.
 The artifact `bundle_url` is mandatory; bootstrap has no detached `.sig`/`.crt`
 fallback. Tarball digest and bundle verification then remain defense-in-depth.
 
@@ -137,7 +144,7 @@ update is offered.
   "url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz",
   "bundle_url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz.bundle",
   "digest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-  "signer_identity": "^https://github\\.example/haloai/hal0/.*"
+  "signer_identity": "^https://github\\.com/(Hal0ai|hal0ai)/hal0/\\.github/workflows/release\\.yml@refs/tags/v1\\.0\\.0$"
 }
 ```
 
@@ -157,7 +164,7 @@ stable classification:
   "url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz",
   "bundle_url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz.bundle",
   "digest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-  "signer_identity": "^https://github\\.example/haloai/hal0/.*"
+  "signer_identity": "^https://github\\.com/(Hal0ai|hal0ai)/hal0/\\.github/workflows/release\\.yml@refs/tags/v1\\.0\\.0$"
 }
 ```
 
@@ -176,6 +183,6 @@ stable classification:
   "url": "https://releases.hal0.dev/v1.0.0-alpha.1/hal0.tar.gz",
   "bundle_url": "https://releases.hal0.dev/v1.0.0-alpha.1/hal0.tar.gz.bundle",
   "digest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-  "signer_identity": "^https://github\\.example/haloai/hal0/.*"
+  "signer_identity": "^https://github\\.com/(Hal0ai|hal0ai)/hal0/\\.github/workflows/release\\.yml@refs/tags/v1\\.0\\.0-alpha\\.1$"
 }
 ```

--- a/docs/internal/release-manifest.md
+++ b/docs/internal/release-manifest.md
@@ -1,8 +1,9 @@
 # Release manifest
 
 The release manifest is the JSON schema used to describe a hal0 release on the
-`releases.hal0.dev` endpoint and consumed by the self-updater
-(``src/hal0/updater/updater.py``).
+`releases.hal0.dev` endpoint and consumed by the bootstrap installer and
+self-updater (``installer/bootstrap.sh`` and
+``src/hal0/updater/updater.py``).
 
 ## Schema identity
 
@@ -27,8 +28,8 @@ shape. Future schema iterations (v2, v3…) will use a distinct identifier.
 
 | Field                | Type                 | Default                            | Description                                              |
 |----------------------|----------------------|------------------------------------|----------------------------------------------------------|
-| `channel`            | `str`                | `"stable"`                         | Release channel.                                         |
-| `release_kind`       | `str`                | `"stable"`                         | Kind: `"stable"`, `"nightly"`, or `"preview"`.           |
+| `channel`            | `str`                | `"stable"`                         | Channel pointer targeted by this manifest.                |
+| `release_kind`       | `str`                | `"stable"`                         | Artifact kind: `"stable"`, `"nightly"`, or `"preview"`.  |
 | `prerelease_stage`   | `str` or `null`      | `null`                             | Preview stage: `"alpha"`, `"beta"`, or `"rc"`.           |
 | `rollback_policy`    | `str`                | `"safe"`                           | Rollback policy: `"safe"`, `"backup-required"`, `"blocked"`. |
 | `upgrade_from`       | `str`                | `""`                               | Version constraint for supported upgrade paths, e.g. `">=0.9.8"`. |
@@ -50,12 +51,44 @@ The pydantic model enforces these rules at parse time:
    - `prerelease_stage` must be one of `"alpha"`, `"beta"`, or `"rc"`.
    - `channel` must be `"preview"`.
 
-2. **Stable / nightly coherence** — When `release_kind` is `"stable"` or `"nightly"`:
-   - `prerelease_stage` must be `null`.
-   - `channel` must match `release_kind`.
+2. **Stable / nightly coherence**:
+   - Stable artifacts have `release_kind: "stable"`, no `prerelease_stage`,
+     and may target the `stable` or `preview` pointer. This permits promotion
+     of an already-built stable artifact to preview before advancing stable.
+   - Nightly artifacts have `release_kind: "nightly"`, no `prerelease_stage`,
+     and target only the `nightly` pointer.
 
 3. **Operator-migration safety** — When `operator_migrations` is non-empty:
    - `rollback_policy` must be `"backup-required"` or `"blocked"`.
+
+## Channel pointers and artifact kinds
+
+Clients select one of the canonical pointers at
+`https://releases.hal0.dev/<channel>.json`, where `<channel>` is `stable`,
+`preview`, or `nightly`. The `channel` field identifies the pointer being
+advanced; `release_kind` classifies the immutable artifact it references.
+They are intentionally not synonyms: `preview.json` may point to a stable
+artifact during promotion, but `stable.json` accepts only stable artifacts.
+Consequently, stable clients never consume preview artifacts.
+
+Each pointer has an exact sibling Sigstore bundle, for example
+`preview.json.bundle`. The bootstrap and updater download the manifest bytes
+and sibling bundle, then run `cosign verify-blob` with their client-pinned
+`.github/workflows/release.yml` identity and
+`https://token.actions.githubusercontent.com` issuer before trusting artifact
+URLs. The bootstrap performs this check before parsing the JSON; the updater
+may decode for schema/channel rejection first but does not return or act on the
+manifest until authentication succeeds. The manifest's own `signer_identity`
+and `signer_issuer` fields become trusted only after that check. A missing
+bundle, missing `cosign`, or failed verification aborts closed. Tarball digest
+and bundle verification then remain defense-in-depth.
+
+The release workflow produces each pointer and bundle together as release
+assets. Serving or advancing those external `releases.hal0.dev` pointers is a
+separate **hal0-web release gate**: hal0-web must publish the exact manifest
+bytes and matching sibling `.bundle`, and must not expose a new pointer when
+either asset is absent. This repository does not make that external serving
+step optional.
 
 ## Backward compatibility
 
@@ -88,6 +121,26 @@ update is offered.
   "version": "1.0.0",
   "channel": "stable",
   "release_kind": "stable",
+  "rollback_policy": "safe",
+  "url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz",
+  "bundle_url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz.bundle",
+  "digest_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "signer_identity": "^https://github\\.example/haloai/hal0/.*"
+}
+```
+
+## Example: stable artifact promoted to preview
+
+The pointer target remains `preview`, while the immutable artifact keeps its
+stable classification:
+
+```json
+{
+  "_schema": "hal0.releases.v1",
+  "version": "1.0.0",
+  "channel": "preview",
+  "release_kind": "stable",
+  "prerelease_stage": null,
   "rollback_policy": "safe",
   "url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz",
   "bundle_url": "https://releases.hal0.dev/v1.0.0/hal0.tar.gz.bundle",

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -35,7 +35,7 @@ directly so they work without a running daemon.
 | `hal0 probe` | **[Deprecated]** hidden alias for `hal0 config hardware --refresh` — re-runs hardware detection (`POST /api/hardware/probe`) and updates `hardware.json`. | — |
 | `hal0 setup` | First-run (or re-run) provisioning: seed slots, pull starter models, wire extensions. See the section below. | `--auto`, `--storage-dir`, `--no-pull`, `--no-extensions` |
 | `hal0 serve` | Start the hal0 API server (used by `hal0-api.service`). | `--host` (default `127.0.0.1`), `--port` (default `8080`), `--reload` |
-| `hal0 update` | Check, apply, or roll back an update (thin client over `/api/updates/*`). | `--check`, `--rollback`, `--channel {stable\|nightly}`, `--target VER`, `--yes`/`-y`, `--restart-slots`, `--source {release\|git}` |
+| `hal0 update` | Check, apply, or roll back an update (thin client over `/api/updates/*`). | `--check`, `--rollback`, `--channel {stable\|preview\|nightly}`, `--target VER`, `--yes`/`-y`, `--restart-slots`, `--source {release\|git}` |
 | `hal0 update owui` | Repin the OpenWebUI companion image to the latest (or an explicit) digest, pull, and restart. | `--check`, `--tag TAG`, `--target DIGEST`, `--yes`/`-y`, `--force` |
 | `hal0 uninstall` | Uninstall hal0 (wraps `installer/uninstall.sh`). Conservative by default. | `--purge`/`--clean-slate`, `--keep-data`, `--force`/`-f`, `--dev` |
 | `hal0 chat` | Terminal chat REPL over `/v1/chat/completions` (or the hal0-brain steward with `--brain`) — handy for SSH/headless boxes. In-REPL: `/think on\|off\|default`, `/clear`, `/quit` (or Ctrl-D). | `--model` (default `agent`), `--base-url` (default `http://127.0.0.1:8080/v1`), `--no-stream`, `--brain` |

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -92,7 +92,7 @@ defaults (an empty file is valid).
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `enabled` | bool | `false` | Opt-in anonymous telemetry. |
-| `channel` | `"stable"` \| `"nightly"` | `"stable"` | Update channel. |
+| `channel` | `"stable"` \| `"preview"` \| `"nightly"` | `"stable"` | Update channel; preview is opt-in. |
 
 ### `[models]` — discovery
 

--- a/docs/reference/env-vars.mdx
+++ b/docs/reference/env-vars.mdx
@@ -108,12 +108,17 @@ These are honoured by the installer / bootstrap scripts.
 | Variable                    | What it does                                                       | Default  |
 |-----------------------------|-------------------------------------------------------------------|----------|
 | `HAL0_PREFIX`               | Installation root.                                                 | `/usr/lib/hal0` (system) / `$PWD/.hal0ai` (no-sudo) |
-| `HAL0_CHANNEL`              | Release channel for the default download URL.                     | `stable` |
+| `HAL0_CHANNEL`              | Bootstrap channel (`stable`, `preview`, or `nightly`) for the default manifest URL. | `stable` |
+| `HAL0_RELEASES_URL`         | Full channel-manifest URL override; its exact sibling `.bundle` and the artifact `bundle_url` remain mandatory. | `https://releases.hal0.dev/<channel>.json` |
 | `HAL0_INSTALL_SKIP_VERIFY`  | Install from an unverified source (skip the cosign check). Not recommended. | `0`      |
 | `HAL0_UPDATE_SKIP_COSIGN`   | Skip cosign signature verify on updates. Only honoured on pre-release/dev builds — silently ignored on stable v1+. Not recommended. | `0`      |
 | `HAL0_NO_PROBE`             | Skip the hardware probe during install.                           | unset    |
 | `HAL0_INSTALL_HONCHO`       | Install the optional self-hosted Honcho v3 memory stack (docker compose: clone, build, `hal0-honcho.service`). See [Honcho memory](/docs/guides/honcho-memory). | `0` (skipped) |
 | `HONCHO_REF`                | Git ref of `plastic-labs/honcho` the installer clones when `HAL0_INSTALL_HONCHO=1`. | `v3.0.9` |
+
+The bootstrap requires `jq` and `cosign`. It authenticates the exact manifest
+bytes before jq applies the strict `hal0.releases.v1` channel/kind/stage policy;
+no manifest field influences that first signature verification.
 
 <Aside type="caution">
 `HAL0_INSTALL_SKIP_VERIFY=1` and `HAL0_UPDATE_SKIP_COSIGN=1` disable the

--- a/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
+++ b/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
@@ -18,6 +18,9 @@
 - Stable clients must never consume preview artifacts; preview may consume preview or a promoted stable artifact.
 - Preserve existing Python, UI, Chromium/Gamma, updater, rollback, and release safety coverage.
 - External `hal0-web` preview-pointer deployment is a required release gate, not an implicit mutation from this repository.
+- Channel selection persists only after the requested channel's current manifest is reachable, signature/schema-valid, and channel-coherent; failures leave the prior channel unchanged.
+- This repository implements the local manifest-bundle contract and verification seams; external hal0-web serving/verification remains a hard prerelease gate.
+- Release tag resolution occurs in a prerequisite `resolve` job; build/publish jobs depend on it and checkout the resolved exact tag.
 
 ---
 
@@ -263,11 +266,13 @@ Expected: the endpoint assertion fails against the current GitHub `/latest` defa
 
 Set the script default to the canonical per-channel endpoint, preserve explicit
 `HAL0_RELEASES_URL` overrides, validate the channel before constructing the URL, and
-keep the current digest/signature verification path. Update the manifest docs to
-state that `channel` is the pointer target and `release_kind` is the artifact kind,
-including the stable artifact promoted to preview case and the external hal0-web
-pointer gate. Update install/update/rollback docs with `HAL0_CHANNEL=preview` and
-explicitly state that stable clients never consume preview.
+keep the current digest/signature verification path. Add the local manifest-bundle
+verification seam used by the updater/bootstrap while leaving external bundle
+serving as a hal0-web release gate. Update the manifest docs to state that `channel`
+is the pointer target and `release_kind` is the artifact kind, including the stable
+artifact promoted to preview case and the external hal0-web pointer gate. Update
+install/update/rollback docs with `HAL0_CHANNEL=preview` and explicitly state that
+stable clients never consume preview.
 
 - [ ] **Step 4: Run tests and shell syntax validation.**
 
@@ -343,9 +348,7 @@ Expected: the current workflow fails the no-`--clobber` and policy-output assert
 
 - [ ] **Step 3: Implement exact ref checkout and policy outputs.**
 
-In the release job, resolve the tag before checkout or add a dedicated exact-ref
-checkout step after tag resolution with `ref: ${{ steps.ver.outputs.tag }}`. Assert
-that `git rev-parse HEAD` equals `git rev-list -n1 "${TAG}"`.
+Add a dedicated `resolve` job before the build job. It resolves the push/dispatch/call tag, runs `ReleasePolicy.to_github_outputs()`, and exposes the outputs. Make the build and PyPI jobs depend on `resolve`; both use `ref: ${{ needs.resolve.outputs.tag }}` in `actions/checkout`. Assert that `git rev-parse HEAD` equals `git rev-list -n1 "${TAG}"`.
 
 Export policy outputs from a single `PYTHONPATH=src python3 -m hal0.release.policy
 "${TAG}" --format github` step. Use those outputs for version checks, manifest

--- a/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
+++ b/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
@@ -328,6 +328,12 @@ def test_release_policy_controls_manifest_targets() -> None:
     text = Path(".github/workflows/release.yml").read_text()
     assert "manifest_targets" in text
     assert "publish_pypi" in text
+
+
+def test_release_signs_and_uploads_every_manifest_bundle() -> None:
+    text = Path(".github/workflows/release.yml").read_text()
+    assert 'cosign sign-blob --yes --bundle "${MANIFEST}.bundle" "${MANIFEST}"' in text
+    assert '"${MANIFEST}.bundle"' in text
 ```
 
 Add policy matrix tests that assert:
@@ -358,7 +364,12 @@ preview/stable behavior from a string comparison such as `channel == nightly`.
 Generate one manifest per `manifest_targets` target. For a stable final, the stable
 and preview manifests must differ only in target `channel` and self-reference URL;
 artifact version, digest, signer, and release kind remain identical. Run
-`ReleaseManifest` validation on every generated manifest.
+`ReleaseManifest` validation on every generated manifest. For each exact generated
+manifest file, run `cosign sign-blob --bundle "${MANIFEST}.bundle" "${MANIFEST}"`,
+self-verify the bundle using the client-pinned release-workflow identity and issuer,
+and upload both `${channel}.json` and `${channel}.json.bundle`. The updater's
+manifest verification intentionally derives the latter sibling URL, so missing or
+unsigned bundles must make the workflow contract test fail.
 
 - [ ] **Step 4: Implement collision-safe publication.**
 

--- a/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
+++ b/docs/superpowers/plans/2026-07-22-prerelease-preview-pipeline-hardening-plan.md
@@ -1,0 +1,494 @@
+# Prerelease Preview Pipeline Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the official `vX.Y.Z-alpha.N`/beta/RC release action and `hal0 update --channel preview` safe, channel-isolated, immutable, and verifiable without publishing anything during implementation.
+
+**Architecture:** Keep `src/hal0/release/policy.py` as the tag-policy source of truth. Add a shared accepted-channel/manifest acceptance layer used by schema, API, CLI, updater, and UI; make the updater validate requested channel against the fetched manifest before persisting or applying. Harden `.github/workflows/release.yml` to checkout the exact tag, consume policy outputs, reject collisions/overwrites, set explicit GitHub flags, and verify artifacts before the external channel pointer gate.
+
+**Tech Stack:** Python 3.12, Pydantic, FastAPI, Typer, pytest, React/TypeScript, Bash, GitHub Actions, Cosign/Sigstore, PyPI Trusted Publishing.
+
+## Global Constraints
+
+- The canonical official prerelease channel is `preview`.
+- Every official cut uses a fresh short-lived branch such as `release/v1.0.0-alpha.1`; never reuse `prerelease-channel`.
+- Do not publish tags, GitHub Releases, PyPI distributions, or channel pointers during implementation or tests.
+- Preview releases must be GitHub prereleases and must never be GitHub latest.
+- Published tags, releases, assets, and PyPI versions are immutable; no `--clobber` or replacement path.
+- Stable clients must never consume preview artifacts; preview may consume preview or a promoted stable artifact.
+- Preserve existing Python, UI, Chromium/Gamma, updater, rollback, and release safety coverage.
+- External `hal0-web` preview-pointer deployment is a required release gate, not an implicit mutation from this repository.
+
+---
+
+## File Map
+
+- `src/hal0/updater/updater.py` — manifest channel semantics, accepted-channel validation, fetch/check/prepare channel binding.
+- `src/hal0/config/schema.py` — persisted `telemetry.channel` validation.
+- `src/hal0/api/routes/updater.py` — channel API validation and validated persistence.
+- `src/hal0/cli/update_commands.py` — `UpdateChannel` enum and `--channel preview` help/flow.
+- `ui/src/api/hooks/useUpdates.ts` — frontend channel union and mutation type.
+- `ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx` — preview selector and display copy.
+- `installer/bootstrap.sh` — canonical release endpoint and channel validation.
+- `.github/workflows/release.yml` — exact-ref checkout, policy outputs, collision gates, manifest targets, explicit release flags, non-overwriting publication.
+- `scripts/release-check.sh` — preview channel/tag preflight and collision policy.
+- `tests/updater/test_updater.py` — manifest semantics, URL, channel binding, persistence/update behavior.
+- `tests/api/test_updater_routes.py` — API preview acceptance and failure-preserves-channel behavior.
+- `tests/cli/test_update_commands.py` — CLI preview option and API interaction.
+- `tests/config/test_schema.py` — persisted preview channel validation.
+- `tests/release/test_policy.py` and `tests/release/test_channel.py` — policy matrix and channel helpers.
+- `tests/release/test_workflow_contract.py` — new static workflow safety contract tests.
+- `tests/installer/test_bootstrap_contract.py` — new shell contract tests for canonical channel endpoint.
+- `docs/internal/release-manifest.md` — stable-to-preview promotion and signed channel-pointer contract.
+- `docs/guides/update-and-rollback.mdx` and `docs/getting-started/install.mdx` — preview install/update/rollback behavior and external hal0-web gate.
+
+---
+
+### Task 1: Add shared preview channel and manifest acceptance semantics
+
+**Files:**
+- Modify: `src/hal0/updater/updater.py:143-280,305-375,1450-1590`
+- Modify: `src/hal0/config/schema.py:1985-2005`
+- Test: `tests/updater/test_updater.py`
+- Test: `tests/config/test_schema.py`
+
+**Interfaces:**
+- Produce `UpdateChannelName = Literal["stable", "preview", "nightly"]` or the repository-equivalent shared type.
+- Produce a manifest acceptance helper with a stable signature, for example:
+  `validate_manifest_for_channel(manifest: ReleaseManifest, requested_channel: str) -> ReleaseManifest`.
+- Preserve `releases_url(channel)` as the canonical URL helper and make preview use `https://releases.hal0.dev/preview.json`.
+
+- [ ] **Step 1: Write failing manifest/channel tests.**
+
+Add tests to `tests/updater/test_updater.py` covering:
+
+```python
+def test_preview_manifest_accepts_preview_channel() -> None:
+    manifest = _parse_manifest({**VALID_MANIFEST, "channel": "preview", "release_kind": "preview", "prerelease_stage": "alpha"})
+    assert validate_manifest_for_channel(manifest, "preview") is manifest
+
+
+def test_promoted_stable_manifest_is_accepted_by_preview_channel() -> None:
+    manifest = _parse_manifest({**VALID_MANIFEST, "channel": "preview", "release_kind": "stable", "prerelease_stage": None})
+    assert validate_manifest_for_channel(manifest, "preview") is manifest
+
+
+def test_stable_channel_rejects_preview_manifest() -> None:
+    manifest = _parse_manifest({**VALID_MANIFEST, "channel": "preview", "release_kind": "preview", "prerelease_stage": "alpha"})
+    with pytest.raises(ValueError, match="requested channel.*stable"):
+        validate_manifest_for_channel(manifest, "stable")
+
+
+def test_requested_channel_must_match_manifest_channel() -> None:
+    manifest = _parse_manifest({**VALID_MANIFEST, "channel": "nightly", "release_kind": "nightly"})
+    with pytest.raises(ValueError, match="manifest channel.*nightly"):
+        validate_manifest_for_channel(manifest, "preview")
+```
+
+Add `preview` to the URL table and add a schema test in `tests/config/test_schema.py` that `TelemetryConfig(channel="preview")` validates while an unknown channel still fails.
+
+- [ ] **Step 2: Run the focused tests and confirm RED.**
+
+Run:
+
+```bash
+HAL0_HOME="$(mktemp -d)" uv run pytest -q \
+  tests/updater/test_updater.py \
+  tests/config/test_schema.py
+```
+
+Expected: failures for preview channel validation, stable-to-preview promotion, and the new helper.
+
+- [ ] **Step 3: Implement the minimum shared semantics.**
+
+In `ReleaseManifest._validate_release_policy`, keep `preview` release kinds requiring `prerelease_stage`, but allow a stable release kind to target either `stable` or `preview`; keep nightly restricted to nightly. Add the requested-channel helper with this exact acceptance matrix:
+
+```python
+_ACCEPTED_RELEASE_KINDS = {
+    "stable": {"stable"},
+    "preview": {"preview", "stable"},
+    "nightly": {"nightly"},
+}
+```
+
+Reject an unknown requested channel, a manifest whose `channel` differs from the requested channel, or a release kind outside the matrix. Change `TelemetryConfig.channel` to accept exactly `stable | preview | nightly`, preserving the existing default.
+
+- [ ] **Step 4: Run the focused tests and confirm GREEN.**
+
+Run the same pytest command. Expected: all targeted updater/schema tests pass.
+
+- [ ] **Step 5: Commit the independently testable model change.**
+
+```bash
+git add src/hal0/updater/updater.py src/hal0/config/schema.py \
+  tests/updater/test_updater.py tests/config/test_schema.py
+git commit -m "fix(updater): support preview channel manifest policy"
+```
+
+---
+
+### Task 2: Make updater, API, CLI, and dashboard persist preview safely
+
+**Files:**
+- Modify: `src/hal0/updater/updater.py:330-375,1460-1590`
+- Modify: `src/hal0/api/routes/updater.py:20-60,450-575,776-840`
+- Modify: `src/hal0/cli/update_commands.py:50-70,236-305`
+- Modify: `ui/src/api/hooks/useUpdates.ts:86-100`
+- Modify: `ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx:1-180`
+- Test: `tests/api/test_updater_routes.py`
+- Test: `tests/cli/test_update_commands.py`
+
+**Interfaces:**
+- API `PUT /api/updates/channel` accepts `{"channel": "preview"}` and returns it only after validated persistence.
+- CLI `hal0 update --channel preview` sends the same API payload.
+- `Updater.check()` and `Updater.prepare()` call `validate_manifest_for_channel` before returning/applying data.
+
+- [ ] **Step 1: Write failing API/CLI/updater tests.**
+
+Add to `tests/api/test_updater_routes.py`:
+
+```python
+def test_channel_put_accepts_preview(isolated_client: TestClient, tmp_hal0_home: str) -> None:
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+    assert response.status_code == 200
+    assert response.json() == {"channel": "preview"}
+
+
+def test_channel_put_keeps_previous_channel_when_validation_fails(isolated_client: TestClient) -> None:
+    # Use the route's manifest-fetch seam to force validation failure.
+    isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+    assert response.status_code in {400, 502}
+    assert isolated_client.get("/api/updates/channel").json() == {"channel": "stable"}
+```
+
+Add CLI coverage asserting `UpdateChannel.preview.value == "preview"` and `update(channel=UpdateChannel.preview)` posts `{"channel": "preview"}`. Add updater tests that `check()` and `prepare()` reject a wrong-channel manifest before download/apply state changes.
+
+- [ ] **Step 2: Run the focused tests and confirm RED.**
+
+```bash
+HAL0_HOME="$(mktemp -d)" uv run pytest -q \
+  tests/api/test_updater_routes.py \
+  tests/cli/test_update_commands.py \
+  tests/updater/test_updater.py -k 'channel or preview'
+```
+
+Expected: preview is rejected or not present, and wrong-channel manifests are not rejected at the requested boundary.
+
+- [ ] **Step 3: Implement channel validation and delayed persistence.**
+
+Use the shared accepted-channel set in `src/hal0/api/routes/updater.py` instead of a second literal set. In the channel PUT route:
+
+1. reject unknown channel;
+2. construct/validate the merged config;
+3. if switching to a release channel, fetch and parse the channel manifest through the same updater validation seam;
+4. only then atomically persist `telemetry.channel`;
+5. leave the prior file unchanged when validation fails.
+
+Update `Updater.check()` to parse the manifest and call `validate_manifest_for_channel` before constructing `ReleaseInfo`. Update `prepare()` to perform the same check before any download, cache write, or state transition. Keep explicit `HAL0_RELEASES_URL` test overrides intact.
+
+Add `preview` to `UpdateChannel`, its help text, frontend `UpdateChannelName`, and the dashboard selector. Use an explicit option branch:
+
+```jsx
+onChange={e => {
+  const next = e.target.value;
+  if (next === 'stable' || next === 'preview' || next === 'nightly') {
+    setChannel(next);
+  }
+}}
+```
+
+- [ ] **Step 4: Run the focused tests and confirm GREEN.**
+
+```bash
+HAL0_HOME="$(mktemp -d)" uv run pytest -q \
+  tests/api/test_updater_routes.py \
+  tests/cli/test_update_commands.py \
+  tests/updater/test_updater.py -k 'channel or preview'
+cd ui && npm run typecheck && npx eslint src/api/hooks/useUpdates.ts src/dash/settings/pages/diagnostics/UpdatesPage.jsx
+```
+
+- [ ] **Step 5: Commit the updater/client change.**
+
+```bash
+git add src/hal0/updater/updater.py src/hal0/api/routes/updater.py \
+  src/hal0/cli/update_commands.py src/hal0/config/schema.py \
+  ui/src/api/hooks/useUpdates.ts \
+  ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx \
+  tests/api/test_updater_routes.py tests/cli/test_update_commands.py
+ git commit -m "feat(update): make preview channel selectable and safe"
+```
+
+---
+
+### Task 3: Align bootstrap and release-manifest documentation contracts
+
+**Files:**
+- Modify: `installer/bootstrap.sh:1-100`
+- Modify: `docs/internal/release-manifest.md`
+- Modify: `docs/guides/update-and-rollback.mdx`
+- Modify: `docs/getting-started/install.mdx`
+- Create: `tests/installer/test_bootstrap_contract.py`
+
+**Interfaces:**
+- Default bootstrap endpoint: `https://releases.hal0.dev/${HAL0_CHANNEL}.json`.
+- `HAL0_CHANNEL` accepts `stable`, `preview`, or `nightly`; invalid values fail before download.
+- The installer uses the same manifest signature/bundle trust contract as the updater.
+
+- [ ] **Step 1: Write failing shell contract tests.**
+
+Create `tests/installer/test_bootstrap_contract.py` that reads the script text and asserts:
+
+```python
+def test_bootstrap_uses_canonical_channel_endpoint() -> None:
+    script = Path("installer/bootstrap.sh").read_text()
+    assert "https://releases.hal0.dev/${HAL0_CHANNEL}.json" in script
+    assert "/releases/latest/download" not in script
+
+
+def test_bootstrap_validates_preview_channel() -> None:
+    script = Path("installer/bootstrap.sh").read_text()
+    assert 'stable|preview|nightly' in script or 'preview' in script
+```
+
+- [ ] **Step 2: Run tests and confirm RED.**
+
+```bash
+uv run pytest -q tests/installer/test_bootstrap_contract.py
+```
+
+Expected: the endpoint assertion fails against the current GitHub `/latest` default.
+
+- [ ] **Step 3: Implement the canonical endpoint and validation.**
+
+Set the script default to the canonical per-channel endpoint, preserve explicit
+`HAL0_RELEASES_URL` overrides, validate the channel before constructing the URL, and
+keep the current digest/signature verification path. Update the manifest docs to
+state that `channel` is the pointer target and `release_kind` is the artifact kind,
+including the stable artifact promoted to preview case and the external hal0-web
+pointer gate. Update install/update/rollback docs with `HAL0_CHANNEL=preview` and
+explicitly state that stable clients never consume preview.
+
+- [ ] **Step 4: Run tests and shell syntax validation.**
+
+```bash
+uv run pytest -q tests/installer/test_bootstrap_contract.py
+bash -n installer/bootstrap.sh
+```
+
+- [ ] **Step 5: Commit the installer/docs contract.**
+
+```bash
+git add installer/bootstrap.sh tests/installer/test_bootstrap_contract.py \
+  docs/internal/release-manifest.md docs/guides/update-and-rollback.mdx \
+  docs/getting-started/install.mdx
+git commit -m "fix(update): align bootstrap with preview channel manifests"
+```
+
+---
+
+### Task 4: Harden the release workflow for exact refs and immutable publication
+
+**Files:**
+- Modify: `.github/workflows/release.yml:35-70,80-120,450-510,532-600`
+- Modify: `scripts/release-check.sh:1-80,250-335`
+- Create: `tests/release/test_workflow_contract.py`
+
+**Interfaces:**
+- Workflow outputs must consume `ReleasePolicy.to_github_outputs()` for `kind`,
+`prerelease_stage`, `manifest_targets`, `github_prerelease`, `github_latest`, and
+`publish_pypi`.
+- `workflow_dispatch` and `workflow_call` checkout the exact supplied tag.
+- Official upload fails when release/tag/asset/PyPI version already exists.
+
+- [ ] **Step 1: Write failing workflow contract tests.**
+
+Create `tests/release/test_workflow_contract.py` using `Path.read_text()` and
+assertions on the workflow text. Cover:
+
+```python
+def test_release_checks_out_dispatch_tag() -> None:
+    text = Path(".github/workflows/release.yml").read_text()
+    assert "ref: ${{ steps.ver.outputs.tag }}" in text
+
+
+def test_preview_release_is_not_latest() -> None:
+    text = Path(".github/workflows/release.yml").read_text()
+    assert "github_prerelease" in text
+    assert "github_latest" in text
+    assert "--clobber" not in text
+
+
+def test_release_policy_controls_manifest_targets() -> None:
+    text = Path(".github/workflows/release.yml").read_text()
+    assert "manifest_targets" in text
+    assert "publish_pypi" in text
+```
+
+Add policy matrix tests that assert:
+
+```python
+assert ReleasePolicy.from_tag("v1.0.0-alpha.1").github_prerelease is True
+assert ReleasePolicy.from_tag("v1.0.0-alpha.1").github_latest is False
+assert ReleasePolicy.from_tag("v1.0.0").manifest_targets == ("stable", "preview")
+```
+
+- [ ] **Step 2: Run tests and confirm RED.**
+
+```bash
+uv run pytest -q tests/release/test_workflow_contract.py tests/release/test_policy.py
+```
+
+Expected: the current workflow fails the no-`--clobber` and policy-output assertions.
+
+- [ ] **Step 3: Implement exact ref checkout and policy outputs.**
+
+In the release job, resolve the tag before checkout or add a dedicated exact-ref
+checkout step after tag resolution with `ref: ${{ steps.ver.outputs.tag }}`. Assert
+that `git rev-parse HEAD` equals `git rev-list -n1 "${TAG}"`.
+
+Export policy outputs from a single `PYTHONPATH=src python3 -m hal0.release.policy
+"${TAG}" --format github` step. Use those outputs for version checks, manifest
+creation, release flags, target manifests, and the PyPI job condition. Do not infer
+preview/stable behavior from a string comparison such as `channel == nightly`.
+
+Generate one manifest per `manifest_targets` target. For a stable final, the stable
+and preview manifests must differ only in target `channel` and self-reference URL;
+artifact version, digest, signer, and release kind remain identical. Run
+`ReleaseManifest` validation on every generated manifest.
+
+- [ ] **Step 4: Implement collision-safe publication.**
+
+Before creating a release, fail if `gh release view "$TAG"` succeeds. Before upload,
+fail if any target asset already exists. Replace the current `gh release upload "$TAG" "$TARBALL" "$BUNDLE" "$SIG" "$CRT" "$MANIFEST" --clobber` command with the same explicit asset list and no overwrite option. Verify the created release's
+`isPrerelease` and `isLatest` values against policy after creation.
+
+Add explicit preflight for the PyPI normalized version when `publish_pypi=true`; the
+PyPI job must not run for nightly and must checkout the exact tag. Refuse a dispatch
+or reusable invocation when the supplied tag is absent or its commit does not equal
+the checked-out ref.
+
+Keep external channel-pointer advancement outside the immutable release creation
+step and document it as the final, separately verified gate. Do not add a live
+pointer mutation to tests or local runs.
+
+- [ ] **Step 5: Extend `scripts/release-check.sh`.**
+
+Accept `--channel preview`, require preview tags to match `^vX.Y.Z-(alpha|beta|rc).N$`,
+check that the tag's base version is consistent with `pyproject.toml`, and reject a
+release/tag/version that already exists. Keep dry-run behavior read-only. Update the
+usage text to `stable|preview|nightly`.
+
+- [ ] **Step 6: Run contract and shell checks.**
+
+```bash
+uv run pytest -q tests/release/test_workflow_contract.py tests/release/test_policy.py tests/release/test_channel.py
+bash -n scripts/release-check.sh
+bash scripts/release-check.sh --help
+```
+
+- [ ] **Step 7: Commit the workflow hardening.**
+
+```bash
+git add .github/workflows/release.yml scripts/release-check.sh \
+  tests/release/test_workflow_contract.py tests/release/test_policy.py
+ git commit -m "fix(release): publish preview artifacts immutably"
+```
+
+---
+
+### Task 5: Add non-publishing release rehearsal and full verification
+
+**Files:**
+- Modify: `tests/release/test_workflow_contract.py`
+- Modify: `tests/updater/test_updater.py`
+- Modify: `docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md` only if verification reveals a contract correction.
+
+- [ ] **Step 1: Add non-publishing policy rehearsal tests.**
+
+Test generated policy metadata for:
+
+```python
+@pytest.mark.parametrize("tag, kind, targets, prerelease, latest", [
+    ("v1.0.0-alpha.1", "preview", ("preview",), True, False),
+    ("v1.0.0-beta.2", "preview", ("preview",), True, False),
+    ("v1.0.0-rc.1", "preview", ("preview",), True, False),
+    ("v1.0.0", "stable", ("stable", "preview"), False, True),
+])
+def test_policy_matrix(tag, kind, targets, prerelease, latest):
+    policy = ReleasePolicy.from_tag(tag)
+    assert policy.kind == kind
+    assert policy.manifest_targets == targets
+    assert policy.github_prerelease is prerelease
+    assert policy.github_latest is latest
+```
+
+Use local temporary manifests and `HAL0_RELEASES_URL=file:///tmp/preview-manifest.json` to exercise
+`Updater(channel="preview").check()` and `prepare()` without network, tag push,
+GitHub, PyPI, or external pointer access.
+
+- [ ] **Step 2: Run the complete focused release/update suite.**
+
+```bash
+HAL0_HOME="$(mktemp -d)" uv run pytest -q \
+  tests/release \
+  tests/updater \
+  tests/api/test_updater_routes.py \
+  tests/cli/test_update_commands.py \
+  tests/config/test_schema.py \
+  tests/installer/test_bootstrap_contract.py
+```
+
+Expected: zero failures and no test-created publication/network side effects.
+
+- [ ] **Step 3: Run repository validation.**
+
+```bash
+git diff --check
+uv run ruff check src/hal0/release src/hal0/updater/updater.py src/hal0/api/routes/updater.py src/hal0/cli/update_commands.py tests/release tests/updater tests/api/test_updater_routes.py tests/cli/test_update_commands.py tests/config/test_schema.py tests/installer/test_bootstrap_contract.py
+uv run pytest -q
+cd ui && npm run typecheck && npm run build && npm run test:unit
+cd ui && CI=true npx playwright test --project=chromium
+```
+
+- [ ] **Step 4: Update the graph and inspect the final diff.**
+
+```bash
+cd /home/mint/hal0/.worktrees/prerelease-preview-pipeline
+graphify update .
+git status --short
+git diff --check
+git log --oneline --decorate -12
+```
+
+Generated Graphify/Shepherd files remain excluded from commits unless explicitly
+required by the repository release policy.
+
+- [ ] **Step 5: Commit verification-only documentation corrections, if any.**
+
+```bash
+git add docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md
+git commit -m "docs: record preview pipeline verification corrections"
+```
+
+Do not mark the release pipeline ready for publication unless all focused and full
+checks are green and the external hal0-web preview-pointer contract is separately
+verified.
+
+---
+
+## Final handoff gates
+
+Before any release tag or publication:
+
+1. PR #1330 has landed and the final incoming session is included.
+2. A fresh `release/vX.Y.Z-alpha.N` branch exists from the intended merged commit.
+3. `scripts/release-check.sh --channel preview --tag vX.Y.Z-alpha.N` passes in read-only mode.
+4. Full Python, UI, Chromium/Gamma, updater, and release contract suites pass.
+5. External hal0-web serves a signed, channel-correct `preview.json` contract.
+6. The release action's workflow run is reviewed for exact tag checkout, explicit
+GitHub prerelease/not-latest flags, immutable assets, PyPI verification, and no
+premature pointer advancement.
+7. Live preview install, update, rollback, and stable-channel isolation checks pass.
+8. Any failed publication is replaced by a new immutable version; no existing
+published prerelease is overwritten.

--- a/docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md
@@ -1,0 +1,201 @@
+# Prerelease Preview Pipeline Hardening
+
+## Status
+
+Approved direction: use the existing canonical `preview` channel for official alpha,
+beta, and release-candidate builds. This design covers the local hal0 updater,
+installer contract, release workflow, and verification tests. It does not silently
+deploy or mutate the external hal0-web channel service.
+
+## Problem
+
+The repository has tag policy for `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, and
+`vX.Y.Z-rc.N`, but the release action and updater do not consistently implement
+that policy. Current gaps include:
+
+- preview tags can be published as GitHub latest/stable releases;
+- `hal0 update --channel preview` is rejected by CLI/API/config validation;
+- manual and reusable release invocations can build a ref other than the supplied
+tag;
+- release reruns can overwrite existing release assets;
+- the updater does not bind the requested channel to the fetched manifest before
+persisting or applying it;
+- final-release promotion to both `stable` and `preview` is not represented by the
+manifest validator and workflow;
+- bootstrap and updater endpoint defaults are inconsistent.
+
+The first official preview must be immutable, signed, channel-isolated, and
+verifiable before the rolling `preview` pointer advances.
+
+## Goals
+
+1. Make `preview` a first-class channel across CLI, API, schema, updater, UI, and
+installer validation.
+2. Make release workflow behavior derive from the shared release policy rather than
+branching on ad hoc tag strings.
+3. Build the exact requested tag for push, dispatch, and reusable workflow events.
+4. Refuse tag/release/version/asset reuse and never use `--clobber` for official
+artifacts.
+5. Publish preview releases as GitHub prereleases, never latest, and publish the
+corresponding PyPI prerelease only after artifact verification.
+6. Validate requested-channel/manifest-channel coherence and persist a channel only
+after successful manifest validation.
+7. Define final-release promotion so the same stable artifact can be addressed by
+both `stable` and `preview` channel manifests.
+8. Add deterministic tests for policy, workflow contracts, updater behavior, and
+CLI/API/config validation.
+
+## Non-goals and boundaries
+
+- Do not publish a tag, GitHub Release, PyPI distribution, or channel pointer during
+implementation or test runs.
+- Do not reuse the long-lived `prerelease-channel` branch. Each cut uses a fresh
+short-lived preparation branch such as `release/v1.0.0-alpha.1`.
+- Do not change the `nightly` channel semantics except where shared validation or
+workflow policy requires an explicit matrix case.
+- Do not implement or deploy the external hal0-web service in this repository. Its
+preview-pointer and signed-manifest serving contract is a release gate and must be
+validated separately before the first publication.
+- Do not weaken existing Gamma, Python, UI, or release safety coverage.
+
+## Canonical channel and manifest model
+
+`preview` is the rolling client channel for alpha, beta, and RC releases. The
+manifest `channel` field identifies the channel pointer being served; the
+`release_kind` field identifies the artifact's release class. These are distinct:
+
+| Requested channel | Accepted release kind | Meaning |
+|---|---|---|
+| `stable` | `stable` | Stable users never consume previews. |
+| `preview` | `preview` or `stable` | Preview users receive the newest official preview, or the promoted final artifact after GA. |
+| `nightly` | `nightly` | Nightly remains separate from official previews. |
+
+A preview manifest must still carry a non-null `prerelease_stage` when its
+`release_kind` is `preview`. A promoted stable artifact has `release_kind =
+"stable"`, `prerelease_stage = null`, and may be serialized once for `stable` and
+once for `preview` with the target channel field changed. Artifact identity,
+digest, signature, and version must remain identical between those two manifests.
+
+The updater's canonical endpoint is:
+
+`https://releases.hal0.dev/<channel>.json`
+
+The bootstrap installer must use the same endpoint contract rather than GitHub's
+mutable `/releases/latest` endpoint. Both clients must verify the channel manifest
+signature/bundle according to the existing release-manifest trust design before
+trusting artifact URLs or digests.
+
+## Release workflow design
+
+### Input and ref resolution
+
+- For a tag push, derive the tag from `GITHUB_REF`.
+- For `workflow_dispatch` and `workflow_call`, require the tag input and checkout
+that exact tag/ref explicitly.
+- Resolve `ReleasePolicy` once and export `tag`, `version`, `channel`, release kind,
+prerelease stage, GitHub flags, manifest targets, and PyPI publication policy as
+workflow outputs.
+- Refuse a tag whose checked-out commit does not equal the tag target.
+- Require a fresh release-preparation branch policy before a tag is created; the
+workflow validates the immutable tag, while the branch naming rule is enforced by
+the cut checklist/preflight.
+
+### Collision and publication gates
+
+Before any upload:
+
+1. Confirm the tag exists and is not moved or reused.
+2. Confirm the GitHub Release for the version/tag does not already exist.
+3. Confirm required assets do not already exist.
+4. Confirm the PyPI version is not already published when policy enables PyPI.
+5. Build the runtime tarball and UI from the checked-out tag.
+6. Generate the channel manifest(s), sign them, and self-verify signatures and
+artifact digests.
+
+Creation uses explicit policy-derived GitHub fields:
+
+- alpha/beta/RC: `prerelease=true`, `latest=false`;
+- nightly: `prerelease=true`, `latest=false`;
+- final: `prerelease=false`, `latest=true`.
+
+Uploads must fail if an asset already exists. No `--clobber` or equivalent overwrite
+path is permitted. A rerun after any publication failure must use a new immutable
+version/tag, not replace the prior release.
+
+For preview publication, the workflow verifies the GitHub assets and PyPI result
+before the external `preview.json` pointer is advanced. Pointer advancement is the
+last publication step. If the pointer update or external verification fails, the
+immutable release remains published and the next operator action is repair/new
+pointer publication, never asset replacement.
+
+For a final release, generate equivalent stable and preview target manifests for the
+same artifact identity and advance both pointers only after all artifact/signature
+and PyPI checks pass.
+
+## Updater and API design
+
+- Define one shared channel type containing `stable`, `preview`, and `nightly`.
+- Accept `preview` in CLI `update --channel`, API update/check routes, persisted
+configuration, and dashboard update controls.
+- Fetch and parse the manifest before persisting a requested channel change.
+- Reject a manifest whose `channel` is not the requested channel.
+- Apply the acceptance matrix above: stable rejects preview artifacts; preview
+accepts preview or promoted stable; nightly accepts nightly only.
+- Keep channel state unchanged when fetch, signature, schema, or channel-coherence
+validation fails.
+- Ensure `check`, `prepare`, `commit`, rollback, and editable-install read-only
+paths use the same channel validation.
+- Preserve rollback behavior: an applied preview update records the previous tree
+and manifest, and rollback does not silently switch channels or downgrade outside
+the requested policy.
+
+## Error handling and observability
+
+Errors must identify the rejected tag/channel/version and the failed gate without
+printing credentials or signer secrets. Publication failures must distinguish:
+
+- pre-publication validation failure;
+- immutable GitHub artifact publication failure;
+- PyPI publication/verification failure;
+- external channel-pointer advancement failure.
+
+The workflow must leave enough logs and artifact metadata to prove which gate
+completed. It must never report a channel as advanced before remote verification.
+
+## Verification plan
+
+### Unit and integration tests
+
+- Release policy matrix for alpha, beta, RC, nightly, and final tags.
+- Workflow contract tests for exact-tag checkout, prerelease/latest flags, no
+`--clobber`, collision checks, manifest targets, and PyPI gating.
+- Manifest tests for preview coherence, stable-to-preview promotion, and signature
+metadata.
+- Updater tests for preview URL selection, requested-channel mismatch, acceptance
+matrix, failed-persistence behavior, update, and rollback.
+- CLI/API/config tests for accepting preview and preserving the old channel after
+validation failure.
+- Installer tests for stable/preview canonical endpoint selection and channel
+isolation.
+- Existing full Python, UI, Chromium/Gamma, and release test suites.
+
+### Release rehearsal (non-publishing)
+
+Use a disposable local/tag fixture and workflow-contract checks to exercise the
+policy and generated metadata without pushing a tag, uploading an asset, publishing
+to PyPI, or advancing an external pointer. The rehearsal must verify the exact
+release branch/tag naming and artifact identity checks.
+
+## Release cut sequence after merge
+
+1. Wait for the final incoming session and merge PR #1330 only after fresh required
+checks are green.
+2. Create a new short-lived branch `release/v1.0.0-alpha.N` from the merged commit.
+3. Run release preflight, full tests, UI/Gamma coverage, manifest/signature rehearsal,
+and external hal0-web preview contract verification.
+4. Create and push the immutable signed tag `v1.0.0-alpha.N` only after all gates pass.
+5. Let the guarded action build, sign, publish, and verify GitHub/PyPI artifacts.
+6. Advance `preview.json` last, then run live preview install/update/rollback
+validation.
+7. Stop on any unresolved gate; cut a new version rather than replacing a failed
+published prerelease.

--- a/docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-22-prerelease-preview-pipeline-hardening-design.md
@@ -7,6 +7,20 @@ beta, and release-candidate builds. This design covers the local hal0 updater,
 installer contract, release workflow, and verification tests. It does not silently
 deploy or mutate the external hal0-web channel service.
 
+### Verified blockers
+
+- `v1.0.0-alpha.1` is already a manually published, empty GitHub prerelease. Its
+empty state does not make it reusable; it remains immutable and must never be
+reused. The first viable candidate is `v1.0.0-alpha.2`, or the next unused tag, on
+a matching fresh `release/v1.0.0-alpha.N` branch.
+- External verification found that `releases.hal0.dev` serves `stable.json` and
+`nightly.json`, while `stable.json.bundle`, `nightly.json.bundle`, `preview.json`,
+and `preview.json.bundle` return 404. No external pointer is therefore operational
+for hardened clients, which require both the manifest and its bundle.
+- Local static and full-suite gates do not replace the first real OIDC signing and
+remote authorization run. The non-publishing implementation and rehearsal boundary
+remains in force, and these verification results do not establish release readiness.
+
 ## Problem
 
 The repository has tag policy for `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, and
@@ -50,7 +64,7 @@ CLI/API/config validation.
 - Do not publish a tag, GitHub Release, PyPI distribution, or channel pointer during
 implementation or test runs.
 - Do not reuse the long-lived `prerelease-channel` branch. Each cut uses a fresh
-short-lived preparation branch such as `release/v1.0.0-alpha.1`.
+short-lived preparation branch such as `release/v1.0.0-alpha.N`.
 - Do not change the `nightly` channel semantics except where shared validation or
 workflow policy requires an explicit matrix case.
 - Do not implement or deploy the external hal0-web service in this repository. Its

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -80,6 +80,7 @@ preflight() {
     need curl
     need tar
     need sha256sum
+    need jq
     need python3
 }
 
@@ -134,56 +135,50 @@ verify_release_manifest() {
 }
 
 validate_manifest_for_channel() {
-    python3 - "$1" "$2" <<'PY'
-import json
-import sys
+    local manifest="$1" requested_channel="$2" normalized="$3"
 
-with open(sys.argv[1], encoding="utf-8") as manifest_file:
-    manifest = json.load(manifest_file)
-requested_channel = sys.argv[2]
-manifest_channel = manifest.get("channel", "stable")
-release_kind = manifest.get("release_kind", "stable")
-accepted_kinds = {
-    "stable": {"stable"},
-    "preview": {"preview", "stable"},
-    "nightly": {"nightly"},
-}
-if manifest_channel != requested_channel:
-    sys.exit(
-        f"manifest channel {manifest_channel} does not match requested channel "
-        f"{requested_channel}"
-    )
-if release_kind not in accepted_kinds[requested_channel]:
-    sys.exit(
-        f"release kind {release_kind} is not accepted for channel {requested_channel}"
-    )
-PY
+    # This is deliberately one fail-closed jq policy pass over the exact bytes
+    # authenticated above. It emits a normalized manifest only when every
+    # bootstrap-required field and channel/kind/stage relationship is valid.
+    if ! jq -e --arg requested "${requested_channel}" '
+        def nonempty_string: type == "string" and length > 0;
+        select(
+            type == "object"
+            and ._schema == "hal0.releases.v1"
+            and (.version | nonempty_string)
+            and (.url | nonempty_string)
+            and (.bundle_url | nonempty_string)
+            and (.signer_identity | nonempty_string)
+            and (.signer_issuer | nonempty_string)
+            and (try (.digest_sha256 | test("^(sha256:)?[0-9A-Fa-f]{64}$")) catch false)
+            and (.channel == "stable" or .channel == "preview" or .channel == "nightly")
+            and (.release_kind == "stable" or .release_kind == "preview" or .release_kind == "nightly")
+            and .channel == $requested
+            and (
+                ($requested == "stable" and .release_kind == "stable")
+                or ($requested == "preview" and (.release_kind == "preview" or .release_kind == "stable"))
+                or ($requested == "nightly" and .release_kind == "nightly")
+            )
+            and (
+                (.release_kind == "preview" and (
+                    .prerelease_stage == "alpha"
+                    or .prerelease_stage == "beta"
+                    or .prerelease_stage == "rc"
+                ))
+                or ((.release_kind == "stable" or .release_kind == "nightly") and .prerelease_stage == null)
+            )
+        )
+        | .digest_sha256 |= (ascii_downcase | sub("^sha256:"; ""))
+    ' "${manifest}" >"${normalized}"; then
+        rm -f -- "${normalized}"
+        die "authenticated release manifest failed strict policy validation"
+    fi
 }
 
 parse_manifest_field() {
     local file="$1" field="$2"
-    python3 -c "
-import json, sys
-try:
-    v = json.load(open('${file}')).get('${field}')
-    if v is None:
-        sys.exit('manifest missing required field: ${field}')
-    print(v)
-except json.JSONDecodeError as e:
-    sys.exit(f'manifest is not valid JSON: {e}')
-"
-}
-
-# Like parse_manifest_field but prints nothing (rather than dying) when the
-# field is absent — used for the transition-window bundle_url/sig_url/
-# cert_url fields, which are mutually optional (see cosign_verify below).
-parse_manifest_field_optional() {
-    local file="$1" field="$2"
-    python3 -c "
-import json
-v = json.load(open('${file}')).get('${field}')
-print(v if v is not None else '')
-"
+    jq -er --arg field "${field}" '.[$field] | select(type == "string")' "${file}" \
+        || die "validated release manifest field extraction failed: ${field}"
 }
 
 # ── tarball fetch + sha256 verify ─────────────────────────────────────────
@@ -213,9 +208,7 @@ fetch_sidecar() {
 }
 
 cosign_verify() {
-    # bundle may be empty — in that case sig and cert must both be set (the
-    # transition-window fallback for manifests without bundle_url). See main().
-    local tarball="$1" bundle="$2" sig="$3" cert="$4" identity="$5" issuer="$6"
+    local tarball="$1" bundle="$2" identity="$3" issuer="$4"
 
     command -v cosign >/dev/null 2>&1 \
         || die "cosign disappeared after release manifest verification — refusing to install"
@@ -224,25 +217,9 @@ cosign_verify() {
     info "  identity-regex: ${_C_DIM}${identity}${_C_RST}"
     info "  issuer:         ${_C_DIM}${issuer}${_C_RST}"
 
-    local -a verify_args
-    if [[ -n "${bundle}" ]]; then
-        # Keyless verification uses a Sigstore bundle. The bundle carries the
-        # Fulcio cert, the signature, AND the Rekor Signed Entry Timestamp
-        # (SET) — the trusted timestamp that lets verify-blob succeed after
-        # the short-lived (~10 min) signing cert has expired, which is
-        # always the case by the time a user runs the installer.
-        # --certificate-identity-regexp is matched against the cert SAN
-        # carried in the bundle. (A detached .sig + .crt had no SET and
-        # failed on every client — #1159.)
-        verify_args=(--bundle "${bundle}")
-    else
-        # Transition-window fallback: manifest had no bundle_url (older
-        # release, or a manifest generated before #1159 shipped). This path
-        # inherits the known post-expiry failure the bundle fixes — kept
-        # only so manifests without bundle_url still attempt verification
-        # instead of erroring outright.
-        verify_args=(--signature "${sig}" --certificate "${cert}")
-    fi
+    # The authenticated manifest must provide a Sigstore bundle. Detached
+    # signature/certificate sidecars are not an accepted bootstrap scheme.
+    local -a verify_args=(--bundle "${bundle}")
     if ! cosign verify-blob \
             "${verify_args[@]}" \
             --certificate-identity-regexp "${identity}" \
@@ -277,44 +254,32 @@ main() {
         "$(release_manifest_bundle_url "${HAL0_RELEASES_URL}")" \
         "${manifest_bundle}"
     verify_release_manifest "${manifest}" "${manifest_bundle}"
-    validate_manifest_for_channel "${manifest}" "${HAL0_CHANNEL}"
 
-    local version url bundle_url sig_url cert_url digest identity issuer
-    version="$(parse_manifest_field "${manifest}" version)"
-    url="$(parse_manifest_field "${manifest}" url)"
-    bundle_url="$(parse_manifest_field_optional "${manifest}" bundle_url)"
-    sig_url="$(parse_manifest_field_optional "${manifest}" sig_url)"
-    cert_url="$(parse_manifest_field_optional "${manifest}" cert_url)"
-    digest="$(parse_manifest_field "${manifest}" digest_sha256)"
-    identity="$(parse_manifest_field "${manifest}" signer_identity)"
-    issuer="$(parse_manifest_field "${manifest}" signer_issuer)"
+    local validated_manifest="${work}/manifest.validated.json"
+    validate_manifest_for_channel "${manifest}" "${HAL0_CHANNEL}" "${validated_manifest}"
 
-    if [[ -z "${bundle_url}" && ( -z "${sig_url}" || -z "${cert_url}" ) ]]; then
-        die "manifest has no usable signing scheme (need bundle_url, or both sig_url and cert_url)"
-    fi
+    local version url bundle_url digest identity issuer
+    version="$(parse_manifest_field "${validated_manifest}" version)"
+    url="$(parse_manifest_field "${validated_manifest}" url)"
+    bundle_url="$(parse_manifest_field "${validated_manifest}" bundle_url)"
+    digest="$(parse_manifest_field "${validated_manifest}" digest_sha256)"
+    identity="$(parse_manifest_field "${validated_manifest}" signer_identity)"
+    issuer="$(parse_manifest_field "${validated_manifest}" signer_issuer)"
 
     info "release: ${_C_BLD}hal0 v${version}${_C_RST} (${HAL0_CHANNEL})"
 
-    local tarball="${work}/hal0-${version}.tar.gz"
+    # Manifest strings never become shell syntax or path components.
+    local tarball="${work}/artifact.tar.gz"
     fetch_and_hash_check "${url}" "${digest}" "${tarball}"
 
-    # Prefer the Sigstore bundle (survives cert expiry, #1159); fall back to
-    # the transition-window sig_url/cert_url pair when bundle_url is absent.
-    local bundle="" sig="" cert=""
-    if [[ -n "${bundle_url}" ]]; then
-        bundle="${tarball}.bundle"
-        fetch_sidecar "signature bundle" "${bundle_url}" "${bundle}"
-    else
-        sig="${tarball}.sig"
-        cert="${tarball}.crt"
-        fetch_sidecar "signature" "${sig_url}" "${sig}"
-        fetch_sidecar "certificate" "${cert_url}" "${cert}"
-    fi
-    cosign_verify "${tarball}" "${bundle}" "${sig}" "${cert}" "${identity}" "${issuer}"
+    local bundle="${tarball}.bundle"
+    fetch_sidecar "signature bundle" "${bundle_url}" "${bundle}"
+    cosign_verify "${tarball}" "${bundle}" "${identity}" "${issuer}"
 
     info "extracting tarball"
-    tar -xzf "${tarball}" -C "${work}"
-    local unpacked="${work}/hal0-${version}"
+    local unpacked="${work}/unpacked"
+    mkdir "${unpacked}"
+    tar -xzf "${tarball}" --strip-components=1 -C "${unpacked}"
     [[ -x "${unpacked}/installer/install.sh" ]] \
         || die "extracted tree is missing installer/install.sh — corrupt tarball?"
 

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -58,6 +58,13 @@ warn() { printf '%s! %s%s\n'   "${_C_YEL}" "$*" "${_C_RST}" >&2; }
 err()  { printf '%s✗ %s%s\n'   "${_C_RED}" "$*" "${_C_RST}" >&2; }
 die()  { err "$*"; exit 1; }
 
+_BOOTSTRAP_WORK=""
+cleanup_workdir() {
+    if [[ -n "${_BOOTSTRAP_WORK}" ]]; then
+        rm -rf -- "${_BOOTSTRAP_WORK}"
+    fi
+}
+
 banner() {
     printf '\n%shal0%s — open-source home AI inference platform\n' "${_C_BLD}" "${_C_RST}"
     printf '%s%s%s\n\n' "${_C_DIM}" "https://hal0.dev" "${_C_RST}"
@@ -256,7 +263,8 @@ main() {
     local work
     work="$(mktemp -d -t hal0-install-XXXXXX)"
     if [[ "${HAL0_BOOTSTRAP_KEEP_TMP:-0}" != "1" ]]; then
-        trap "rm -rf '${work}'" EXIT
+        _BOOTSTRAP_WORK="${work}"
+        trap cleanup_workdir EXIT
     else
         warn "HAL0_BOOTSTRAP_KEEP_TMP=1 — leaving work dir ${work}"
     fi

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -19,22 +19,17 @@
 #
 # Env overrides:
 #   HAL0_RELEASES_URL           full URL to a hal0.releases.v1 manifest
-#                               (default: GitHub Releases /latest/download/stable.json)
-#   HAL0_CHANNEL                channel name when using the default URL (default: stable)
-#   HAL0_INSTALL_REQUIRE_COSIGN=1
-#                               fail the install if cosign is not present
-#                               (restores the old hard requirement for
-#                               security-conscious / enterprise installs)
+#                               (default: https://releases.hal0.dev/<channel>.json)
+#   HAL0_CHANNEL                stable, preview, or nightly (default: stable)
 #   HAL0_BOOTSTRAP_KEEP_TMP=1   don't delete the work directory on exit
 #                               (debugging the unpacked tree)
 #
-# This script is the trust boundary for the one-line install. The tarball's
-# sha256 is ALWAYS checked against the manifest digest (fatal on mismatch)
-# before anything is executed. cosign then verifies the publisher signature
-# against the workflow OIDC identity — but cosign is no longer a hard
-# install-time dependency: if the binary is absent, the install proceeds on
-# the sha256 check alone with a loud warning (opt back into strict mode with
-# HAL0_INSTALL_REQUIRE_COSIGN=1). See docs/internal/release-manifest.md.
+# This script is the trust boundary for the one-line install. It first verifies
+# the exact channel-manifest bytes with their sibling Sigstore bundle and a
+# client-pinned release-workflow identity. Only then does it parse artifact
+# URLs. The tarball's sha256 and publisher signature are both checked again as
+# defense-in-depth before anything is executed. cosign is therefore a required
+# bootstrap dependency. See docs/internal/release-manifest.md.
 #
 # Schema reference: docs/internal/release-manifest.md (hal0.releases.v1).
 
@@ -42,7 +37,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 HAL0_CHANNEL="${HAL0_CHANNEL:-stable}"
-HAL0_RELEASES_URL="${HAL0_RELEASES_URL:-https://github.com/Hal0ai/hal0/releases/latest/download/${HAL0_CHANNEL}.json}"
+HAL0_RELEASES_URL="${HAL0_RELEASES_URL:-}"
+
+# Keep this trust root in lockstep with src/hal0/updater/updater.py. These
+# values authenticate the channel pointer itself; signer claims inside that
+# unauthenticated JSON are trusted only after this verification succeeds.
+_MANIFEST_SIGNER_IDENTITY_REGEXP='^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v\d+\.\d+\.\d+(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?|refs/heads/main)$'
+_MANIFEST_SIGNER_ISSUER='https://token.actions.githubusercontent.com'
 
 # ── tiny output helpers ────────────────────────────────────────────────────
 if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
@@ -75,7 +76,30 @@ preflight() {
     need python3
 }
 
-# ── manifest fetch + parse ────────────────────────────────────────────────
+validate_channel() {
+    case "${HAL0_CHANNEL}" in
+        stable|preview|nightly) ;;
+        *) die "HAL0_CHANNEL must be one of: stable, preview, nightly (got ${HAL0_CHANNEL})" ;;
+    esac
+}
+
+resolve_release_manifest_url() {
+    if [[ -z "${HAL0_RELEASES_URL}" ]]; then
+        HAL0_RELEASES_URL="https://releases.hal0.dev/${HAL0_CHANNEL}.json"
+    fi
+}
+
+release_manifest_bundle_url() {
+    python3 - "$1" <<'PY'
+import sys
+from urllib.parse import urlsplit, urlunsplit
+
+scheme, netloc, path, query, fragment = urlsplit(sys.argv[1])
+print(urlunsplit((scheme, netloc, f"{path}.bundle", query, fragment)))
+PY
+}
+
+# ── manifest fetch + authenticate + parse ─────────────────────────────────
 fetch_manifest() {
     local out="$1"
     info "fetching release manifest"
@@ -83,6 +107,50 @@ fetch_manifest() {
     if ! curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${HAL0_RELEASES_URL}"; then
         die "could not download release manifest from ${HAL0_RELEASES_URL}"
     fi
+}
+
+verify_release_manifest() {
+    local manifest="$1" bundle="$2"
+    command -v cosign >/dev/null 2>&1 \
+        || die "cosign is required to verify the release manifest but is not installed.
+   install it from https://docs.sigstore.dev/cosign/installation/"
+
+    info "verifying release manifest with pinned workflow identity"
+    if ! cosign verify-blob \
+            --bundle "${bundle}" \
+            --certificate-identity-regexp "${_MANIFEST_SIGNER_IDENTITY_REGEXP}" \
+            --certificate-oidc-issuer "${_MANIFEST_SIGNER_ISSUER}" \
+            "${manifest}" >/dev/null 2>&1; then
+        die "release manifest signature verification FAILED — refusing to trust artifact URLs"
+    fi
+    ok "release manifest signature OK"
+}
+
+validate_manifest_for_channel() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as manifest_file:
+    manifest = json.load(manifest_file)
+requested_channel = sys.argv[2]
+manifest_channel = manifest.get("channel", "stable")
+release_kind = manifest.get("release_kind", "stable")
+accepted_kinds = {
+    "stable": {"stable"},
+    "preview": {"preview", "stable"},
+    "nightly": {"nightly"},
+}
+if manifest_channel != requested_channel:
+    sys.exit(
+        f"manifest channel {manifest_channel} does not match requested channel "
+        f"{requested_channel}"
+    )
+if release_kind not in accepted_kinds[requested_channel]:
+    sys.exit(
+        f"release kind {release_kind} is not accepted for channel {requested_channel}"
+    )
+PY
 }
 
 parse_manifest_field() {
@@ -128,7 +196,7 @@ fetch_and_hash_check() {
     ok "sha256 OK (${actual:0:12}…)"
 }
 
-# ── cosign verify (or documented skip) ────────────────────────────────────
+# ── tarball cosign verify (defense-in-depth) ───────────────────────────────
 fetch_sidecar() {
     local label="$1" url="$2" out="$3"
     info "downloading ${label}"
@@ -142,25 +210,8 @@ cosign_verify() {
     # transition-window fallback for manifests without bundle_url). See main().
     local tarball="$1" bundle="$2" sig="$3" cert="$4" identity="$5" issuer="$6"
 
-    if ! command -v cosign >/dev/null 2>&1; then
-        if [[ "${HAL0_INSTALL_REQUIRE_COSIGN:-0}" == "1" ]]; then
-            die "cosign is required (HAL0_INSTALL_REQUIRE_COSIGN=1) but not installed.
-   install it from https://docs.sigstore.dev/cosign/installation/"
-        fi
-        # cosign is not a hard dependency: the tarball's sha256 was already
-        # verified against the manifest digest (fetch_and_hash_check, fatal on
-        # mismatch), so integrity relative to the manifest holds. What we lose
-        # by skipping is proof that the tarball was built by hal0's signing
-        # workflow rather than substituted upstream of the manifest — hence the
-        # loud warning. Install cosign, or set HAL0_INSTALL_REQUIRE_COSIGN=1, to
-        # keep that guarantee.
-        warn "cosign not installed — skipping publisher signature verification"
-        warn "  the tarball sha256 was verified against the manifest, but its"
-        warn "  cosign/OIDC signature was NOT checked."
-        warn "  for full supply-chain verification install cosign:"
-        warn "    ${_C_DIM}https://docs.sigstore.dev/cosign/installation/${_C_RST}"
-        return 0
-    fi
+    command -v cosign >/dev/null 2>&1 \
+        || die "cosign disappeared after release manifest verification — refusing to install"
 
     info "verifying signature with cosign keyless OIDC"
     info "  identity-regex: ${_C_DIM}${identity}${_C_RST}"
@@ -197,19 +248,28 @@ cosign_verify() {
 
 # ── main ──────────────────────────────────────────────────────────────────
 main() {
+    validate_channel
     banner
     preflight
+    resolve_release_manifest_url
 
     local work
     work="$(mktemp -d -t hal0-install-XXXXXX)"
     if [[ "${HAL0_BOOTSTRAP_KEEP_TMP:-0}" != "1" ]]; then
-        trap 'rm -rf "${work}"' EXIT
+        trap "rm -rf '${work}'" EXIT
     else
         warn "HAL0_BOOTSTRAP_KEEP_TMP=1 — leaving work dir ${work}"
     fi
 
     local manifest="${work}/manifest.json"
+    local manifest_bundle="${work}/manifest.json.bundle"
     fetch_manifest "${manifest}"
+    fetch_sidecar \
+        "release manifest signature bundle" \
+        "$(release_manifest_bundle_url "${HAL0_RELEASES_URL}")" \
+        "${manifest_bundle}"
+    verify_release_manifest "${manifest}" "${manifest_bundle}"
+    validate_manifest_for_channel "${manifest}" "${HAL0_CHANNEL}"
 
     local version url bundle_url sig_url cert_url digest identity issuer
     version="$(parse_manifest_field "${manifest}" version)"

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -112,7 +112,7 @@ fetch_manifest() {
     local out="$1"
     info "fetching release manifest"
     info "  ${_C_DIM}${HAL0_RELEASES_URL}${_C_RST}"
-    if ! curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${HAL0_RELEASES_URL}"; then
+    if ! curl -fsSL --retry 3 --retry-delay 2 -o "${out}" --url "${HAL0_RELEASES_URL}"; then
         die "could not download release manifest from ${HAL0_RELEASES_URL}"
     fi
 }
@@ -140,9 +140,11 @@ validate_manifest_for_channel() {
     # This is deliberately one fail-closed jq policy pass over the exact bytes
     # authenticated above. It emits a normalized manifest only when every
     # bootstrap-required field and channel/kind/stage relationship is valid.
-    if ! jq -e --arg requested "${requested_channel}" '
+    if ! jq -e -s --arg requested "${requested_channel}" '
         def nonempty_string: type == "string" and length > 0;
-        select(
+        select(length == 1)
+        | .[0]
+        | select(
             type == "object"
             and ._schema == "hal0.releases.v1"
             and (.version | nonempty_string)
@@ -186,7 +188,7 @@ fetch_and_hash_check() {
     local url="$1" expected_digest="$2" out="$3"
     info "downloading tarball"
     info "  ${_C_DIM}${url}${_C_RST}"
-    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${url}" \
+    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" --url "${url}" \
         || die "could not download tarball"
 
     info "verifying sha256"
@@ -203,7 +205,7 @@ fetch_sidecar() {
     local label="$1" url="$2" out="$3"
     info "downloading ${label}"
     info "  ${_C_DIM}${url}${_C_RST}"
-    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" "${url}" \
+    curl -fsSL --retry 3 --retry-delay 2 -o "${out}" --url "${url}" \
         || die "could not download ${label}"
 }
 

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -39,10 +39,12 @@ IFS=$'\n\t'
 HAL0_CHANNEL="${HAL0_CHANNEL:-stable}"
 HAL0_RELEASES_URL="${HAL0_RELEASES_URL:-}"
 
-# Keep this trust root in lockstep with src/hal0/updater/updater.py. These
-# values authenticate the channel pointer itself; signer claims inside that
-# unauthenticated JSON are trusted only after this verification succeeds.
-_MANIFEST_SIGNER_IDENTITY_REGEXP='^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@(refs/tags/v\d+\.\d+\.\d+(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?|refs/heads/main)$'
+# Keep these trust roots in lockstep with src/hal0/updater/updater.py. The
+# requested channel selects admission before any manifest JSON is parsed.
+_MANIFEST_IDENTITY_PREFIX='^https://github\.com/(Hal0ai|hal0ai)/hal0/\.github/workflows/release\.yml@'
+_STABLE_MANIFEST_ADMISSION_IDENTITY="${_MANIFEST_IDENTITY_PREFIX}refs/tags/v\\d+\\.\\d+\\.\\d+$"
+_PREVIEW_MANIFEST_ADMISSION_IDENTITY="${_MANIFEST_IDENTITY_PREFIX}refs/tags/v\\d+\\.\\d+\\.\\d+(-(alpha|beta|rc)\\.(0|[1-9]\\d*))?$"
+_NIGHTLY_MANIFEST_IDENTITY="${_MANIFEST_IDENTITY_PREFIX}refs/heads/main$"
 _MANIFEST_SIGNER_ISSUER='https://token.actions.githubusercontent.com'
 
 # ── tiny output helpers ────────────────────────────────────────────────────
@@ -91,6 +93,37 @@ validate_channel() {
     esac
 }
 
+manifest_admission_identity() {
+    case "$1" in
+        stable) printf '%s\n' "${_STABLE_MANIFEST_ADMISSION_IDENTITY}" ;;
+        preview) printf '%s\n' "${_PREVIEW_MANIFEST_ADMISSION_IDENTITY}" ;;
+        nightly) printf '%s\n' "${_NIGHTLY_MANIFEST_IDENTITY}" ;;
+        *) return 1 ;;
+    esac
+}
+
+exact_manifest_identity() {
+    local release_kind="$1" version="$2" escaped_version
+    case "${release_kind}" in
+        stable)
+            [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || return 1
+            ;;
+        preview)
+            [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.(0|[1-9][0-9]*)$ ]] \
+                || return 1
+            ;;
+        nightly)
+            [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-nightly\.([0-9]{8}|[0-9]{14})$ ]] \
+                || return 1
+            printf '%s\n' "${_NIGHTLY_MANIFEST_IDENTITY}"
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+    escaped_version="${version//./\\.}"
+    printf '%srefs/tags/v%s$\n' "${_MANIFEST_IDENTITY_PREFIX}" "${escaped_version}"
+}
+
 resolve_release_manifest_url() {
     if [[ -z "${HAL0_RELEASES_URL}" ]]; then
         HAL0_RELEASES_URL="https://releases.hal0.dev/${HAL0_CHANNEL}.json"
@@ -118,7 +151,7 @@ fetch_manifest() {
 }
 
 verify_release_manifest() {
-    local manifest="$1" bundle="$2"
+    local manifest="$1" bundle="$2" identity="$3"
     command -v cosign >/dev/null 2>&1 \
         || die "cosign is required to verify the release manifest but is not installed.
    install it from https://docs.sigstore.dev/cosign/installation/"
@@ -126,7 +159,7 @@ verify_release_manifest() {
     info "verifying release manifest with pinned workflow identity"
     if ! cosign verify-blob \
             --bundle "${bundle}" \
-            --certificate-identity-regexp "${_MANIFEST_SIGNER_IDENTITY_REGEXP}" \
+            --certificate-identity-regexp "${identity}" \
             --certificate-oidc-issuer "${_MANIFEST_SIGNER_ISSUER}" \
             "${manifest}" >/dev/null 2>&1; then
         die "release manifest signature verification FAILED — refusing to trust artifact URLs"
@@ -168,6 +201,20 @@ validate_manifest_for_channel() {
                     or .prerelease_stage == "rc"
                 ))
                 or ((.release_kind == "stable" or .release_kind == "nightly") and .prerelease_stage == null)
+            )
+            and (
+                (.release_kind == "stable"
+                    and (try (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) catch false))
+                or (.release_kind == "preview" and (
+                    (.prerelease_stage == "alpha" and
+                        (try (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+-alpha\\.(0|[1-9][0-9]*)$")) catch false))
+                    or (.prerelease_stage == "beta" and
+                        (try (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.(0|[1-9][0-9]*)$")) catch false))
+                    or (.prerelease_stage == "rc" and
+                        (try (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+-rc\\.(0|[1-9][0-9]*)$")) catch false))
+                ))
+                or (.release_kind == "nightly" and
+                    (try (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\.([0-9]{8}|[0-9]{14})$")) catch false))
             )
         )
         | .digest_sha256 |= (ascii_downcase | sub("^sha256:"; ""))
@@ -235,6 +282,9 @@ cosign_verify() {
 # ── main ──────────────────────────────────────────────────────────────────
 main() {
     validate_channel
+    local admission_identity
+    admission_identity="$(manifest_admission_identity "${HAL0_CHANNEL}")" \
+        || die "could not derive manifest admission identity"
     banner
     preflight
     resolve_release_manifest_url
@@ -255,18 +305,27 @@ main() {
         "release manifest signature bundle" \
         "$(release_manifest_bundle_url "${HAL0_RELEASES_URL}")" \
         "${manifest_bundle}"
-    verify_release_manifest "${manifest}" "${manifest_bundle}"
+    verify_release_manifest "${manifest}" "${manifest_bundle}" "${admission_identity}"
 
     local validated_manifest="${work}/manifest.validated.json"
     validate_manifest_for_channel "${manifest}" "${HAL0_CHANNEL}" "${validated_manifest}"
 
-    local version url bundle_url digest identity issuer
+    local version release_kind url bundle_url digest manifest_identity expected_identity issuer
     version="$(parse_manifest_field "${validated_manifest}" version)"
+    release_kind="$(parse_manifest_field "${validated_manifest}" release_kind)"
     url="$(parse_manifest_field "${validated_manifest}" url)"
     bundle_url="$(parse_manifest_field "${validated_manifest}" bundle_url)"
     digest="$(parse_manifest_field "${validated_manifest}" digest_sha256)"
-    identity="$(parse_manifest_field "${validated_manifest}" signer_identity)"
+    manifest_identity="$(parse_manifest_field "${validated_manifest}" signer_identity)"
     issuer="$(parse_manifest_field "${validated_manifest}" signer_issuer)"
+    expected_identity="$(exact_manifest_identity "${release_kind}" "${version}")" \
+        || die "validated release manifest has unsupported release identity policy"
+    if [[ "${manifest_identity}" != "${expected_identity}" ]]; then
+        die "authenticated release manifest signer_identity does not match exact release identity"
+    fi
+    if [[ "${admission_identity}" != "${expected_identity}" ]]; then
+        verify_release_manifest "${manifest}" "${manifest_bundle}" "${expected_identity}"
+    fi
 
     info "release: ${_C_BLD}hal0 v${version}${_C_RST} (${HAL0_CHANNEL})"
 
@@ -276,7 +335,7 @@ main() {
 
     local bundle="${tarball}.bundle"
     fetch_sidecar "signature bundle" "${bundle_url}" "${bundle}"
-    cosign_verify "${tarball}" "${bundle}" "${identity}" "${issuer}"
+    cosign_verify "${tarball}" "${bundle}" "${expected_identity}" "${issuer}"
 
     info "extracting tarball"
     local unpacked="${work}/unpacked"

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -173,7 +173,9 @@ validate_manifest_for_channel() {
     # This is deliberately one fail-closed jq policy pass over the exact bytes
     # authenticated above. It emits a normalized manifest only when every
     # bootstrap-required field and channel/kind/stage relationship is valid.
-    if ! jq -e -s --arg requested "${requested_channel}" '
+    if ! jq -e -s \
+            --arg requested "${requested_channel}" \
+            --arg trusted_issuer "${_MANIFEST_SIGNER_ISSUER}" '
         def nonempty_string: type == "string" and length > 0;
         select(length == 1)
         | .[0]
@@ -184,7 +186,7 @@ validate_manifest_for_channel() {
             and (.url | nonempty_string)
             and (.bundle_url | nonempty_string)
             and (.signer_identity | nonempty_string)
-            and (.signer_issuer | nonempty_string)
+            and .signer_issuer == $trusted_issuer
             and (try (.digest_sha256 | test("^(sha256:)?[0-9A-Fa-f]{64}$")) catch false)
             and (.channel == "stable" or .channel == "preview" or .channel == "nightly")
             and (.release_kind == "stable" or .release_kind == "preview" or .release_kind == "nightly")
@@ -257,14 +259,14 @@ fetch_sidecar() {
 }
 
 cosign_verify() {
-    local tarball="$1" bundle="$2" identity="$3" issuer="$4"
+    local tarball="$1" bundle="$2" identity="$3"
 
     command -v cosign >/dev/null 2>&1 \
         || die "cosign disappeared after release manifest verification — refusing to install"
 
     info "verifying signature with cosign keyless OIDC"
     info "  identity-regex: ${_C_DIM}${identity}${_C_RST}"
-    info "  issuer:         ${_C_DIM}${issuer}${_C_RST}"
+    info "  issuer:         ${_C_DIM}${_MANIFEST_SIGNER_ISSUER}${_C_RST}"
 
     # The authenticated manifest must provide a Sigstore bundle. Detached
     # signature/certificate sidecars are not an accepted bootstrap scheme.
@@ -272,7 +274,7 @@ cosign_verify() {
     if ! cosign verify-blob \
             "${verify_args[@]}" \
             --certificate-identity-regexp "${identity}" \
-            --certificate-oidc-issuer "${issuer}" \
+            --certificate-oidc-issuer "${_MANIFEST_SIGNER_ISSUER}" \
             "${tarball}" >/dev/null 2>&1; then
         die "cosign signature verification FAILED — refusing to install"
     fi
@@ -310,14 +312,13 @@ main() {
     local validated_manifest="${work}/manifest.validated.json"
     validate_manifest_for_channel "${manifest}" "${HAL0_CHANNEL}" "${validated_manifest}"
 
-    local version release_kind url bundle_url digest manifest_identity expected_identity issuer
+    local version release_kind url bundle_url digest manifest_identity expected_identity
     version="$(parse_manifest_field "${validated_manifest}" version)"
     release_kind="$(parse_manifest_field "${validated_manifest}" release_kind)"
     url="$(parse_manifest_field "${validated_manifest}" url)"
     bundle_url="$(parse_manifest_field "${validated_manifest}" bundle_url)"
     digest="$(parse_manifest_field "${validated_manifest}" digest_sha256)"
     manifest_identity="$(parse_manifest_field "${validated_manifest}" signer_identity)"
-    issuer="$(parse_manifest_field "${validated_manifest}" signer_issuer)"
     expected_identity="$(exact_manifest_identity "${release_kind}" "${version}")" \
         || die "validated release manifest has unsupported release identity policy"
     if [[ "${manifest_identity}" != "${expected_identity}" ]]; then
@@ -335,7 +336,7 @@ main() {
 
     local bundle="${tarball}.bundle"
     fetch_sidecar "signature bundle" "${bundle_url}" "${bundle}"
-    cosign_verify "${tarball}" "${bundle}" "${expected_identity}" "${issuer}"
+    cosign_verify "${tarball}" "${bundle}" "${expected_identity}"
 
     info "extracting tarball"
     local unpacked="${work}/unpacked"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -685,18 +685,22 @@ fi
 
 ui_step "Node.js toolchain"
 
-# Node/npm is a hard dependency for the dashboard UI build right below
-# (the pi-coder + opencode bundled agents used to need it too — both shelled
-# out to npm — but those speculative drivers were deleted; hal0 v0.3 only
-# ever ships hermes, which doesn't need Node). Provisioning it here, once,
-# up front covers the dashboard build instead of only warning in the
-# Dashboard UI step below. Best-effort: resolve_node tries an
-# already-present Node >=20 first, then auto-installs via the detected
-# package manager (NodeSource setup script on Debian/Ubuntu, since their
-# base repos ship an ancient Node; direct package install elsewhere); never
-# fatal — a Node-less box still installs, just without the dashboard build
-# until Node is added later.
-if [[ "${DEV_MODE}" -eq 1 ]]; then
+UI_DIR="${REPO_ROOT}/ui"
+UI_DIST="${UI_DIR}/dist"
+_ui_has_build_inputs=0
+[[ -f "${UI_DIR}/package.json" ]] && _ui_has_build_inputs=1
+_ui_prebuilt_release=0
+if [[ "${_ui_has_build_inputs}" -eq 0 && -s "${UI_DIST}/index.html" ]]; then
+    _ui_prebuilt_release=1
+fi
+
+# Node/npm is a dependency only when this tree contains the dashboard npm
+# project. Signed release trees intentionally ship a verified ui/dist without
+# ui/package.json; provisioning Node there cannot rebuild anything and would be
+# misleading work. Source/git installs retain the existing best-effort setup.
+if [[ "${_ui_has_build_inputs}" -eq 0 ]]; then
+    info "dashboard npm project not shipped — Node.js toolchain not required"
+elif [[ "${DEV_MODE}" -eq 1 ]]; then
     info "dev mode — skipping Node.js auto-provisioning (install manually if exercising the dashboard build)"
 elif HAL0_NODE_AUTOINSTALL=1 resolve_node; then
     info "node: $(node -v 2>/dev/null || echo present) (>= ${NODE_MIN_MAJOR} LTS)"
@@ -707,15 +711,11 @@ fi
 
 ui_step "Dashboard UI"
 
-UI_DIR="${REPO_ROOT}/ui"
-UI_DIST="${UI_DIR}/dist"
-# Staleness gate (same class as the venv same-version trap): "dist exists"
-# is NOT "dist is current" — a bare index.html check kept the FIRST build a
-# box ever produced alive through every later redeploy, silently serving an
-# old dashboard. Stamp the built dist with the ui/ tree hash and skip only
-# on an exact match; no git / no stamp → rebuild (safe default).
+# Staleness gate for source trees (same class as the venv same-version trap):
+# "dist exists" is NOT "dist is current". Stamp a local build with the ui/
+# tree hash and skip only on an exact match; no git / no stamp → rebuild.
 _ui_tree_hash=""
-if command -v git >/dev/null 2>&1; then
+if [[ "${_ui_has_build_inputs}" -eq 1 ]] && command -v git >/dev/null 2>&1; then
     _ui_tree_hash="$(git -C "${REPO_ROOT}" rev-parse HEAD:ui 2>/dev/null || true)"
 fi
 _ui_dist_current=0
@@ -724,7 +724,16 @@ if [[ -f "${UI_DIST}/index.html" && -n "${_ui_tree_hash}" \
       && "$(cat "${UI_DIST}/.hal0-build-stamp" 2>/dev/null)" == "${_ui_tree_hash}" ]]; then
     _ui_dist_current=1
 fi
-if [[ "${_ui_dist_current}" -eq 1 ]]; then
+
+# A distribution-only tree has no source freshness signal or npm project by
+# design. Its prebuilt bundle is part of the already-verified release artifact,
+# so reuse a non-empty index explicitly and never attempt an impossible rebuild.
+if [[ "${_ui_prebuilt_release}" -eq 1 ]]; then
+    info "using release's prebuilt ui/dist — npm rebuild not required"
+elif [[ "${_ui_has_build_inputs}" -eq 0 ]]; then
+    warn "no valid prebuilt ui/dist/index.html; dashboard cannot rebuild without ui/package.json"
+    warn "dashboard at :${HAL0_PORT}/ will return 404 until a complete release tree is installed"
+elif [[ "${_ui_dist_current}" -eq 1 ]]; then
     info "ui/dist already built for this ui/ tree (${_ui_tree_hash:0:12}) — left alone"
 elif command -v npm >/dev/null 2>&1; then
     # ui/package.json pins vite ^6.0.3 + @tailwindcss/vite ^4.2.2, both of

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -304,20 +304,24 @@ cd "${REPO_ROOT}"
 TRACKED_DIRT="$(
 	{
 		git diff --name-only -- . \
-			':(exclude).pi/shepherd/index.json' \
+			':(exclude).pi/shepherd/**' \
 			':(exclude)graphify-out/**'
 		git diff --cached --name-only -- . \
-			':(exclude).pi/shepherd/index.json' \
+			':(exclude).pi/shepherd/**' \
 			':(exclude)graphify-out/**'
 	}
 )"
 UNTRACKED_DIRT="$(
 	{
 		git ls-files --others --exclude-standard -- . \
+			':(exclude).pi/shepherd/**' \
+			':(exclude).pi-subagents/**' \
+			':(exclude)graphify-out/**'
+		# `.pi/` is ignored globally, so explicitly surface any ignored
+		# untracked entry outside the two generated runtime subtrees.
+		git ls-files --others -- .pi \
+			':(exclude).pi/shepherd/**' \
 			':(exclude).pi-subagents/**'
-		# Shepherd is ignored globally, but only its tracked index is allowed
-		# to change. Any additional Shepherd file remains release-blocking.
-		git ls-files --others -- .pi/shepherd
 	}
 )"
 if [[ -z "${TRACKED_DIRT}" && -z "${UNTRACKED_DIRT}" ]]; then

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -5,7 +5,10 @@
 # safety net between "main looks good" and `git tag`.
 #
 # Usage:
-#   bash scripts/release-check.sh [--channel stable|preview|nightly] [--tag vX.Y.Z]
+#   bash scripts/release-check.sh [--local] [--channel stable|preview|nightly] [--tag vX.Y.Z]
+#
+# --local is a non-publishing, read-only rehearsal. It skips the remote tier-γ
+# report gate, so a local pass never authorizes a release.
 #
 # Gates (in order):
 #   1.  Backend tests green (pytest)
@@ -50,6 +53,7 @@ Options:
   --channel stable|preview|nightly  Release channel (default: stable)
   --tag vX.Y.Z                     Proposed immutable release tag
   --dry-run                        Run read-only preflight; never publish or tag
+  --local                          Non-publishing local rehearsal (implies --dry-run)
   -h, --help                       Show this help
 EOF
 }
@@ -58,6 +62,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHANNEL="${HAL0_CHANNEL:-stable}"
 PROPOSED_TAG=""
 DRY_RUN=false
+LOCAL=false
 FAILURES=0
 
 while [[ $# -gt 0 ]]; do
@@ -84,6 +89,11 @@ while [[ $# -gt 0 ]]; do
 		DRY_RUN=true
 		shift
 		;;
+	--local)
+		LOCAL=true
+		DRY_RUN=true
+		shift
+		;;
 	-h | --help)
 		usage
 		exit 0
@@ -105,19 +115,38 @@ stable | preview | nightly) ;;
 	;;
 esac
 
+# Every Python gate runs from the locked repository environment with an
+# isolated application home. This prevents a global pytest/ruff or an editable
+# checkout elsewhere on the machine from affecting release results.
+CHECK_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/hal0-release-check.XXXXXX")"
+HAL0_CHECK_HOME="${CHECK_TMPDIR}/hal0-home"
+mkdir -p "${HAL0_CHECK_HOME}"
+cleanup() {
+	rm -rf "${CHECK_TMPDIR}"
+}
+trap cleanup EXIT
+
+run_repo_python() {
+	PYTHONPATH="${REPO_ROOT}/src" HAL0_HOME="${HAL0_CHECK_HOME}" uv run "$@"
+}
+
+if [[ "${LOCAL}" == true ]]; then
+	warn "LOCAL rehearsal mode is read-only and non-publishing (--dry-run implied)"
+fi
+
 # ── 1. Backend tests ──────────────────────────────────────────────────────────
 step "1. Backend tests"
 
-if command -v pytest &>/dev/null; then
+if command -v uv &>/dev/null; then
 	# Unit tier only — tier β + γ run elsewhere (the integration workflow
 	# and `make release-test` respectively).
-	if pytest "${REPO_ROOT}/tests/" -q -m "not integration" 2>&1; then
-		info "pytest (-m 'not integration'): green"
+	if run_repo_python pytest "${REPO_ROOT}/tests/" -q -m "not integration" 2>&1; then
+		info "uv run pytest (-m 'not integration'): green"
 	else
 		fail "pytest: test failures — fix before release"
 	fi
 else
-	fail "pytest not installed — required for release-check"
+	fail "uv not installed — repository environment is required for release-check"
 fi
 
 # ── 2. UI build ───────────────────────────────────────────────────────────────
@@ -138,14 +167,14 @@ fi
 # ── 3. Lint ───────────────────────────────────────────────────────────────────
 step "3. Lint"
 
-if command -v ruff &>/dev/null; then
-	if ruff check "${REPO_ROOT}/src/" "${REPO_ROOT}/tests/" 2>&1; then
-		info "ruff: clean"
+if command -v uv &>/dev/null; then
+	if run_repo_python ruff check "${REPO_ROOT}/src/" "${REPO_ROOT}/tests/" 2>&1; then
+		info "uv run ruff: clean"
 	else
 		fail "ruff found lint errors"
 	fi
 else
-	warn "ruff not installed — skipping Python lint (pip install ruff)"
+	fail "uv not installed — cannot run repository ruff"
 fi
 
 if command -v shellcheck &>/dev/null; then
@@ -204,7 +233,10 @@ fi
 step "5. Release-gate report (tier γ)"
 
 REPORT="${REPO_ROOT}/tests/release-gate-report.json"
-if [[ -f "${REPORT}" ]]; then
+if [[ "${LOCAL}" == true ]]; then
+	warn "LOCAL rehearsal: skipping remote tier-γ release-gate report"
+	warn "Local success is insufficient for release authorization; a fresh non-local all-pass report is required"
+elif [[ -f "${REPORT}" ]]; then
 	if python3 - "${REPORT}" <<'PY'; then
 import json, sys, time
 report = json.loads(open(sys.argv[1]).read())
@@ -230,10 +262,16 @@ fi
 step "6. Git state"
 
 cd "${REPO_ROOT}"
-if [[ -z "$(git status --porcelain)" ]]; then
-	info "working tree clean"
+GIT_DIRT="$(
+	git status --porcelain=v1 --untracked-files=all -- . \
+		':(exclude).pi/shepherd/**' \
+		':(exclude).pi-subagents/**' \
+		':(exclude)graphify-out/**'
+)"
+if [[ -z "${GIT_DIRT}" ]]; then
+	info "working tree clean (excluding generated state)"
 else
-	fail "working tree is dirty — commit or stash before tagging"
+	fail "working tree is dirty — commit or stash source changes before tagging"
 fi
 
 if [[ -n "${PROPOSED_TAG}" ]]; then
@@ -382,7 +420,12 @@ fi
 # ── Summary ───────────────────────────────────────────────────────────────────
 printf "\n"
 if [[ "${FAILURES}" -eq 0 ]]; then
-	printf "${GREEN}${BOLD}Release check passed${RESET} (channel: %s)\n\n" "${CHANNEL}"
+	if [[ "${LOCAL}" == true ]]; then
+		warn "Local success is insufficient for release authorization; run the non-local check with a fresh all-pass report"
+		printf "${GREEN}${BOLD}Local release rehearsal passed${RESET} (channel: %s)\n\n" "${CHANNEL}"
+	else
+		printf "${GREEN}${BOLD}Release check passed${RESET} (channel: %s)\n\n" "${CHANNEL}"
+	fi
 	exit 0
 else
 	printf "${RED}${BOLD}Release check FAILED${RESET} — %d gate(s) failed.\n\n" "${FAILURES}"

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -7,8 +7,9 @@
 # Usage:
 #   bash scripts/release-check.sh [--local] [--channel stable|preview|nightly] [--tag vX.Y.Z]
 #
-# --local is a non-publishing, read-only rehearsal. It skips the remote tier-γ
-# report gate, so a local pass never authorizes a release.
+# --local is a publication-read-only rehearsal: it never creates or mutates a
+# tag, release, or published artifact, though dependency/build caches may change.
+# It skips the remote tier-γ report gate, so a local pass never authorizes a release.
 #
 # Gates (in order):
 #   1.  Backend tests green (pytest)
@@ -53,7 +54,7 @@ Options:
   --channel stable|preview|nightly  Release channel (default: stable)
   --tag vX.Y.Z                     Proposed immutable release tag
   --dry-run                        Run read-only preflight; never publish or tag
-  --local                          Non-publishing local rehearsal (implies --dry-run)
+  --local                          Publication-read-only rehearsal; dependency/build caches may change
   -h, --help                       Show this help
 EOF
 }
@@ -131,7 +132,7 @@ run_repo_python() {
 }
 
 if [[ "${LOCAL}" == true ]]; then
-	warn "LOCAL rehearsal mode is read-only and non-publishing (--dry-run implied)"
+	warn "LOCAL rehearsal is publication-read-only (--dry-run implied); dependency/build caches may change"
 fi
 
 # ── 1. Backend tests ──────────────────────────────────────────────────────────
@@ -240,6 +241,10 @@ elif [[ -f "${REPORT}" ]]; then
 	if python3 - "${REPORT}" <<'PY'; then
 import json, sys, time
 report = json.loads(open(sys.argv[1]).read())
+if not isinstance(report, dict):
+    sys.exit("release-test report must be an object")
+if report.get("_schema") != "hal0.release-gate-report.v1":
+    sys.exit("release-test report _schema must equal 'hal0.release-gate-report.v1'")
 generated = report.get("generated", 0)
 age_s = time.time() - generated
 if generated <= 0 or age_s > 24 * 3600:
@@ -258,23 +263,24 @@ if counts["total"] <= 0:
     sys.exit("release-test report has no rows")
 if counts["total"] != sum(counts[key] for key in keys[1:]):
     sys.exit("release-test summary total does not equal status counts")
+rows = report.get("rows")
+if not isinstance(rows, list):
+    sys.exit("release-test rows must be present and must be an array")
+if not rows:
+    sys.exit("release-test rows must not be empty")
+row_counts = {key: 0 for key in keys[1:]}
+for index, row in enumerate(rows):
+    if not isinstance(row, dict) or row.get("status") not in row_counts:
+        sys.exit(f"release-test row {index} has an invalid status")
+    row_counts[row["status"]] += 1
+if len(rows) != counts["total"]:
+    sys.exit("release-test rows length does not match summary total")
+if any(row_counts[key] != counts[key] for key in row_counts):
+    sys.exit("release-test row statuses do not match summary counts")
 if counts["pass"] <= 0:
     sys.exit("release-test report must contain at least one passed row")
 if counts["fail"] != 0:
     sys.exit(f"release-test has {counts['fail']} failed row(s)")
-if "rows" in report:
-    rows = report["rows"]
-    if not isinstance(rows, list):
-        sys.exit("release-test rows must be an array")
-    row_counts = {key: 0 for key in keys[1:]}
-    for index, row in enumerate(rows):
-        if not isinstance(row, dict) or row.get("status") not in row_counts:
-            sys.exit(f"release-test row {index} has an invalid status")
-        row_counts[row["status"]] += 1
-    if len(rows) != counts["total"]:
-        sys.exit("release-test rows length does not match summary total")
-    if any(row_counts[key] != counts[key] for key in row_counts):
-        sys.exit("release-test row statuses do not match summary counts")
 print(f"release-test fresh (age={age_s/3600:.1f}h): {counts['pass']} pass, "
       f"{counts['skip']} skip, {counts['deferred']} deferred; no failed rows")
 PY
@@ -290,13 +296,26 @@ fi
 step "6. Git state"
 
 cd "${REPO_ROOT}"
-GIT_DIRT="$(
-	git status --porcelain=v1 --untracked-files=all -- . \
-		':(exclude).pi/shepherd/**' \
-		':(exclude).pi-subagents/**' \
-		':(exclude)graphify-out/**'
+TRACKED_DIRT="$(
+	{
+		git diff --name-only -- . \
+			':(exclude).pi/shepherd/index.json' \
+			':(exclude)graphify-out/**'
+		git diff --cached --name-only -- . \
+			':(exclude).pi/shepherd/index.json' \
+			':(exclude)graphify-out/**'
+	}
 )"
-if [[ -z "${GIT_DIRT}" ]]; then
+UNTRACKED_DIRT="$(
+	{
+		git ls-files --others --exclude-standard -- . \
+			':(exclude).pi-subagents/**'
+		# These generated roots are ignored globally, but policy permits only
+		# their already-tracked outputs to change during rehearsal.
+		git ls-files --others -- .pi/shepherd graphify-out
+	}
+)"
+if [[ -z "${TRACKED_DIRT}" && -z "${UNTRACKED_DIRT}" ]]; then
 	info "working tree clean (excluding generated state)"
 else
 	fail "working tree is dirty — commit or stash source changes before tagging"

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -5,7 +5,7 @@
 # safety net between "main looks good" and `git tag`.
 #
 # Usage:
-#   bash scripts/release-check.sh [--channel stable|nightly] [--tag vX.Y.Z]
+#   bash scripts/release-check.sh [--channel stable|preview|nightly] [--tag vX.Y.Z]
 #
 # Gates (in order):
 #   1.  Backend tests green (pytest)
@@ -42,6 +42,17 @@ fail() {
 	FAILURES=$((FAILURES + 1))
 }
 step() { printf "\n${BOLD}── %s${RESET}\n" "$*"; }
+usage() {
+	cat <<'EOF'
+Usage: bash scripts/release-check.sh [options]
+
+Options:
+  --channel stable|preview|nightly  Release channel (default: stable)
+  --tag vX.Y.Z                     Proposed immutable release tag
+  --dry-run                        Run read-only preflight; never publish or tag
+  -h, --help                       Show this help
+EOF
+}
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHANNEL="${HAL0_CHANNEL:-stable}"
@@ -73,12 +84,26 @@ while [[ $# -gt 0 ]]; do
 		DRY_RUN=true
 		shift
 		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
 	*)
-		warn "unknown arg: $1 (ignored)"
-		shift
+		usage >&2
+		printf "Unknown argument: %s\n" "$1" >&2
+		exit 2
 		;;
 	esac
 done
+
+case "${CHANNEL}" in
+stable | preview | nightly) ;;
+*)
+	usage >&2
+	printf "Invalid channel: %s (expected stable|preview|nightly)\n" "${CHANNEL}" >&2
+	exit 2
+	;;
+esac
 
 # ── 1. Backend tests ──────────────────────────────────────────────────────────
 step "1. Backend tests"
@@ -237,9 +262,28 @@ PY
 info "pyproject.toml version: ${PYPROJ_VERSION:-<unknown>}"
 
 if [[ -n "${PROPOSED_TAG}" ]]; then
-	# Strip leading "v" if present so `v0.1.0` and `0.1.0` both match.
-	NORMALISED_TAG="${PROPOSED_TAG#v}"
-	if [[ "${PYPROJ_VERSION}" == "${NORMALISED_TAG}" ]]; then
+	case "${CHANNEL}" in
+	stable)
+		[[ "${PROPOSED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+			fail "stable tag must match vX.Y.Z"
+		;;
+	preview)
+		[[ "${PROPOSED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.(0|[1-9][0-9]*)$ ]] ||
+			fail "preview tag must match vX.Y.Z-(alpha|beta|rc).N"
+		;;
+	nightly)
+		[[ "${PROPOSED_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{14}$ ]] ||
+			fail "nightly tag must match vX.Y.Z-nightly.YYYYMMDDhhmmss"
+		;;
+	esac
+
+	TAG_BASE="$(PYTHONPATH=src python3 -c 'import sys; from hal0.release.channel import base_version; print(base_version(sys.argv[1]))' "${PROPOSED_TAG}")"
+	PYPROJECT_BASE="$(PYTHONPATH=src python3 -c 'import sys; from hal0.release.channel import base_version; print(base_version(sys.argv[1]))' "${PYPROJ_VERSION}")"
+	if [[ "${TAG_BASE}" != "${PYPROJECT_BASE}" ]]; then
+		fail "tag base '${TAG_BASE}' does not match pyproject.toml base '${PYPROJECT_BASE}'"
+	elif [[ "${CHANNEL}" == "nightly" ]]; then
+		info "nightly tag base matches pyproject.toml"
+	elif [[ "${PYPROJ_VERSION}" == "${PROPOSED_TAG#v}" ]]; then
 		info "version matches proposed tag"
 	else
 		fail "pyproject.toml version '${PYPROJ_VERSION}' does not match tag '${PROPOSED_TAG}'"
@@ -254,34 +298,40 @@ cd "${REPO_ROOT}"
 if [[ -z "${PROPOSED_TAG}" ]]; then
 	warn "no --tag provided — skipping preflight"
 else
-	# Derive policy from the proposed tag
+	# Derive every publication decision from the shared release policy.
 	POLICY_JSON="$(PYTHONPATH=src python3 -m hal0.release.policy "${PROPOSED_TAG}" --format json 2>/dev/null || true)"
 	if [[ -z "${POLICY_JSON}" ]]; then
 		fail "release.policy failed for tag '${PROPOSED_TAG}'"
 	else
 		POLICY_VERSION="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])' <<<"${POLICY_JSON}")"
 		POLICY_KIND="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["kind"])' <<<"${POLICY_JSON}")"
+		POLICY_PYTHON_VERSION="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["python_version"] or "")' <<<"${POLICY_JSON}")"
+		POLICY_PUBLISH_PYPI="$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["publish_pypi"]).lower())' <<<"${POLICY_JSON}")"
 		info "policy: ${POLICY_VERSION} (${POLICY_KIND})"
 
-		# Compare normalised source versions
-		NORMALISED_TAG_VERSION="${PROPOSED_TAG#v}"
-		if [[ "${POLICY_VERSION}" != "${NORMALISED_TAG_VERSION}" ]]; then
+		if [[ "${POLICY_KIND}" != "${CHANNEL}" ]]; then
+			fail "channel '${CHANNEL}' conflicts with tag policy '${POLICY_KIND}'"
+		else
+			info "channel agrees with tag policy"
+		fi
+
+		if [[ "${POLICY_VERSION}" != "${PROPOSED_TAG#v}" ]]; then
 			fail "policy version '${POLICY_VERSION}' does not match tag '${PROPOSED_TAG}'"
 		else
 			info "policy version agrees with tag"
 		fi
 
-		if [[ "${POLICY_KIND}" != "nightly" ]] && [[ "${DRY_RUN}" == false ]]; then
-			# Check tag target = origin/main
-			TAG_SHA="$(git rev-parse "${PROPOSED_TAG}" 2>/dev/null || true)"
+		# Official stable/preview tags must be cut from origin/main. All checks
+		# here are reads, including --dry-run mode.
+		if [[ "${POLICY_KIND}" != "nightly" ]]; then
+			TAG_SHA="$(git rev-list -n1 "${PROPOSED_TAG}" 2>/dev/null || true)"
 			MAIN_SHA="$(git rev-parse origin/main 2>/dev/null || true)"
 			if [[ -z "${MAIN_SHA}" ]]; then
 				warn "cannot resolve origin/main — skipping target check"
-			elif [[ -n "${TAG_SHA}" ]] && [[ "${TAG_SHA}" != "${MAIN_SHA}" ]]; then
+			elif [[ -n "${TAG_SHA}" && "${TAG_SHA}" != "${MAIN_SHA}" ]]; then
 				fail "tag '${PROPOSED_TAG}' points to ${TAG_SHA}, not origin/main (${MAIN_SHA})"
 			fi
 
-			# Query GitHub checks for the target SHA (requires gh CLI)
 			if command -v gh &>/dev/null && [[ -n "${MAIN_SHA}" ]]; then
 				GH_CHECKS="$(gh api "repos/:owner/:repo/commits/${MAIN_SHA}/check-runs" --jq '.check_runs[].conclusion' 2>/dev/null || true)"
 				if echo "${GH_CHECKS}" | grep -q -v "success" 2>/dev/null; then
@@ -292,35 +342,39 @@ else
 			else
 				warn "gh CLI not available or no main SHA — skipping GitHub check query"
 			fi
+		fi
 
-			# Reject existing local/remote tags
-			if git rev-parse "${PROPOSED_TAG}" >/dev/null 2>&1; then
-				fail "tag '${PROPOSED_TAG}' already exists locally"
-			fi
-			if git ls-remote --tags origin "${PROPOSED_TAG}" 2>/dev/null | grep -q "${PROPOSED_TAG}"; then
-				fail "tag '${PROPOSED_TAG}' already exists on origin"
-			fi
+		if git ls-remote --tags origin "${PROPOSED_TAG}" 2>/dev/null | grep -q "refs/tags/${PROPOSED_TAG}"; then
+			fail "tag '${PROPOSED_TAG}' already exists on origin"
+		else
+			info "remote tag '${PROPOSED_TAG}' is available"
+		fi
 
-			# Reject existing GitHub Release (requires gh CLI)
-			if command -v gh &>/dev/null; then
-				if gh release view "${PROPOSED_TAG}" 2>/dev/null | head -1 | grep -q .; then
-					fail "GitHub Release '${PROPOSED_TAG}' already exists"
-				fi
-			fi
-
-			# Reject existing PyPI version
-			NORMALISED_TAG_VERSION="${PROPOSED_TAG#v}"
-			if curl -sf "https://pypi.org/pypi/hal0ai/${NORMALISED_TAG_VERSION}/json" >/dev/null 2>&1; then
-				fail "PyPI already has hal0ai==${NORMALISED_TAG_VERSION}"
+		if command -v gh &>/dev/null; then
+			if gh release view "${PROPOSED_TAG}" >/dev/null 2>&1; then
+				fail "GitHub Release '${PROPOSED_TAG}' already exists"
 			else
-				info "PyPI does not have hal0ai==${NORMALISED_TAG_VERSION}"
+				info "GitHub Release '${PROPOSED_TAG}' is available"
 			fi
-		elif [[ "${POLICY_KIND}" == "nightly"* ]]; then
-			info "nightly tag — keeping existing base-match and collision behavior (gate 6)"
+		else
+			warn "gh CLI not available — skipping GitHub Release collision check"
+		fi
+
+		if [[ "${POLICY_PUBLISH_PYPI}" == "true" ]]; then
+			STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "https://pypi.org/pypi/hal0ai/${POLICY_PYTHON_VERSION}/json" || true)"
+			if [[ "${STATUS}" == "200" ]]; then
+				fail "PyPI already has hal0ai==${POLICY_PYTHON_VERSION}"
+			elif [[ "${STATUS}" == "404" ]]; then
+				info "PyPI does not have hal0ai==${POLICY_PYTHON_VERSION}"
+			else
+				fail "PyPI collision preflight returned HTTP ${STATUS:-<none>}"
+			fi
+		else
+			info "policy disables PyPI publication"
 		fi
 
 		if [[ "${DRY_RUN}" == true ]]; then
-			info "DRY-RUN: policy printed above; no tag or release mutation performed"
+			info "DRY-RUN: all preflight operations were read-only; no tag or release mutation performed"
 		fi
 	fi
 fi

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -15,7 +15,7 @@
 #   2.  UI build clean (npm run build)
 #   3.  Lint clean (ruff + shellcheck if present)
 #   4.  Toolbox image manifest pinned (manifest.json digests non-empty)
-#   5.  Release-gate report present, fresh (≤24h), all-pass
+#   5.  Release-gate report present, fresh (≤24h), coherent, no failures
 #   6.  Working tree clean, proposed tag doesn't exist
 #   7.  pyproject.toml version matches the proposed tag
 #   8.  Release preflight — policy, tag/release collisions, PyPI
@@ -127,7 +127,7 @@ cleanup() {
 trap cleanup EXIT
 
 run_repo_python() {
-	PYTHONPATH="${REPO_ROOT}/src" HAL0_HOME="${HAL0_CHECK_HOME}" uv run "$@"
+	PYTHONPATH="${REPO_ROOT}/src" HAL0_HOME="${HAL0_CHECK_HOME}" uv run --locked "$@"
 }
 
 if [[ "${LOCAL}" == true ]]; then
@@ -141,7 +141,7 @@ if command -v uv &>/dev/null; then
 	# Unit tier only — tier β + γ run elsewhere (the integration workflow
 	# and `make release-test` respectively).
 	if run_repo_python pytest "${REPO_ROOT}/tests/" -q -m "not integration" 2>&1; then
-		info "uv run pytest (-m 'not integration'): green"
+		info "uv run --locked pytest (-m 'not integration'): green"
 	else
 		fail "pytest: test failures — fix before release"
 	fi
@@ -169,7 +169,7 @@ step "3. Lint"
 
 if command -v uv &>/dev/null; then
 	if run_repo_python ruff check "${REPO_ROOT}/src/" "${REPO_ROOT}/tests/" 2>&1; then
-		info "uv run ruff: clean"
+		info "uv run --locked ruff: clean"
 	else
 		fail "ruff found lint errors"
 	fi
@@ -235,7 +235,7 @@ step "5. Release-gate report (tier γ)"
 REPORT="${REPO_ROOT}/tests/release-gate-report.json"
 if [[ "${LOCAL}" == true ]]; then
 	warn "LOCAL rehearsal: skipping remote tier-γ release-gate report"
-	warn "Local success is insufficient for release authorization; a fresh non-local all-pass report is required"
+	warn "Local success is insufficient for release authorization; a fresh coherent non-local report is required"
 elif [[ -f "${REPORT}" ]]; then
 	if python3 - "${REPORT}" <<'PY'; then
 import json, sys, time
@@ -244,15 +244,43 @@ generated = report.get("generated", 0)
 age_s = time.time() - generated
 if generated <= 0 or age_s > 24 * 3600:
     sys.exit(f"report is stale (age={age_s/3600:.1f}h) — re-run `make release-test`")
-summary = report.get("summary", {})
-if summary.get("fail", 0):
-    sys.exit(f"release-test has {summary['fail']} failed row(s)")
-print(f"release-test fresh (age={age_s/3600:.1f}h), {summary.get('pass', 0)} pass, "
-      f"{summary.get('skip', 0)} skip, {summary.get('deferred', 0)} deferred")
+summary = report.get("summary")
+if not isinstance(summary, dict):
+    sys.exit("report summary must be an object")
+keys = ("total", "pass", "fail", "skip", "deferred")
+counts = {}
+for key in keys:
+    value = summary.get(key)
+    if type(value) is not int or value < 0:
+        sys.exit(f"report summary {key!r} must be a nonnegative integer")
+    counts[key] = value
+if counts["total"] <= 0:
+    sys.exit("release-test report has no rows")
+if counts["total"] != sum(counts[key] for key in keys[1:]):
+    sys.exit("release-test summary total does not equal status counts")
+if counts["pass"] <= 0:
+    sys.exit("release-test report must contain at least one passed row")
+if counts["fail"] != 0:
+    sys.exit(f"release-test has {counts['fail']} failed row(s)")
+if "rows" in report:
+    rows = report["rows"]
+    if not isinstance(rows, list):
+        sys.exit("release-test rows must be an array")
+    row_counts = {key: 0 for key in keys[1:]}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict) or row.get("status") not in row_counts:
+            sys.exit(f"release-test row {index} has an invalid status")
+        row_counts[row["status"]] += 1
+    if len(rows) != counts["total"]:
+        sys.exit("release-test rows length does not match summary total")
+    if any(row_counts[key] != counts[key] for key in row_counts):
+        sys.exit("release-test row statuses do not match summary counts")
+print(f"release-test fresh (age={age_s/3600:.1f}h): {counts['pass']} pass, "
+      f"{counts['skip']} skip, {counts['deferred']} deferred; no failed rows")
 PY
-		info "release-gate report fresh and clean"
+		info "release-gate report accepted"
 	else
-		fail "release-gate report is stale or has failures — run 'make release-test'"
+		fail "release-gate report is invalid, stale, or has failures — run 'make release-test'"
 	fi
 else
 	fail "tests/release-gate-report.json not found — run 'make release-test'"
@@ -421,7 +449,7 @@ fi
 printf "\n"
 if [[ "${FAILURES}" -eq 0 ]]; then
 	if [[ "${LOCAL}" == true ]]; then
-		warn "Local success is insufficient for release authorization; run the non-local check with a fresh all-pass report"
+		warn "Local success is insufficient for release authorization; run the non-local check with a fresh coherent report"
 		printf "${GREEN}${BOLD}Local release rehearsal passed${RESET} (channel: %s)\n\n" "${CHANNEL}"
 	else
 		printf "${GREEN}${BOLD}Release check passed${RESET} (channel: %s)\n\n" "${CHANNEL}"

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -128,7 +128,8 @@ cleanup() {
 trap cleanup EXIT
 
 run_repo_python() {
-	PYTHONPATH="${REPO_ROOT}/src" HAL0_HOME="${HAL0_CHECK_HOME}" uv run --locked "$@"
+	PYTHONPATH="${REPO_ROOT}/src" HAL0_HOME="${HAL0_CHECK_HOME}" \
+		uv run --isolated --locked --python 3.12 --extra dev "$@"
 }
 
 if [[ "${LOCAL}" == true ]]; then
@@ -142,7 +143,7 @@ if command -v uv &>/dev/null; then
 	# Unit tier only — tier β + γ run elsewhere (the integration workflow
 	# and `make release-test` respectively).
 	if run_repo_python pytest "${REPO_ROOT}/tests/" -q -m "not integration" 2>&1; then
-		info "uv run --locked pytest (-m 'not integration'): green"
+		info "isolated locked Python 3.12 pytest (-m 'not integration'): green"
 	else
 		fail "pytest: test failures — fix before release"
 	fi
@@ -170,7 +171,7 @@ step "3. Lint"
 
 if command -v uv &>/dev/null; then
 	if run_repo_python ruff check "${REPO_ROOT}/src/" "${REPO_ROOT}/tests/" 2>&1; then
-		info "uv run --locked ruff: clean"
+		info "isolated locked Python 3.12 ruff: clean"
 	else
 		fail "ruff found lint errors"
 	fi
@@ -314,9 +315,9 @@ UNTRACKED_DIRT="$(
 	{
 		git ls-files --others --exclude-standard -- . \
 			':(exclude).pi-subagents/**'
-		# These generated roots are ignored globally, but policy permits only
-		# their already-tracked outputs to change during rehearsal.
-		git ls-files --others -- .pi/shepherd graphify-out
+		# Shepherd is ignored globally, but only its tracked index is allowed
+		# to change. Any additional Shepherd file remains release-blocking.
+		git ls-files --others -- .pi/shepherd
 	}
 )"
 if [[ -z "${TRACKED_DIRT}" && -z "${UNTRACKED_DIRT}" ]]; then

--- a/scripts/release-check.sh
+++ b/scripts/release-check.sh
@@ -246,8 +246,12 @@ if not isinstance(report, dict):
 if report.get("_schema") != "hal0.release-gate-report.v1":
     sys.exit("release-test report _schema must equal 'hal0.release-gate-report.v1'")
 generated = report.get("generated", 0)
+if type(generated) is not int or generated <= 0:
+    sys.exit("release-test report generated must be a positive integer timestamp")
 age_s = time.time() - generated
-if generated <= 0 or age_s > 24 * 3600:
+if age_s < -5 * 60:
+    sys.exit(f"report timestamp is in the future (skew={-age_s:.0f}s) — check clocks and re-run `make release-test`")
+if age_s > 24 * 3600:
     sys.exit(f"report is stale (age={age_s/3600:.1f}h) — re-run `make release-test`")
 summary = report.get("summary")
 if not isinstance(summary, dict):

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -246,8 +246,10 @@ def set_version(root: Path, version: str) -> None:
             )
     candidates.append((lock_path, lock_text_new))
 
-    # 3. Write every candidate to a temporary file in a shared tmpdir
-    tmpdir = Path(tempfile.mkdtemp(prefix=".set-version."))
+    # 3. Write every candidate to a shared transaction directory under the
+    # repository root.  Keeping candidates beside their destinations guarantees
+    # os.replace() stays on one filesystem (and cannot fail with EXDEV).
+    tmpdir = Path(tempfile.mkdtemp(prefix=".set-version.", dir=root))
     try:
         temp_paths: list[tuple[Path, Path]] = []
         for dst, content in candidates:

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 
 
@@ -249,6 +250,7 @@ def set_version(root: Path, version: str) -> None:
     # repository root.  Keeping candidates beside their destinations guarantees
     # os.replace() stays on one filesystem (and cannot fail with EXDEV).
     tmpdir = Path(tempfile.mkdtemp(prefix=".set-version.", dir=root))
+    preserve_transaction = False
     try:
         temp_paths: list[tuple[Path, Path]] = []
         for dst, content in candidates:
@@ -328,20 +330,32 @@ def set_version(root: Path, version: str) -> None:
                     f"{hal0ai_final!r} != expected {pep440!r}"
                 )
         except Exception as update_error:
-            rollback_errors: list[str] = []
+            rollback_errors: list[tuple[Path, Path, Exception]] = []
             for backup_path, dst_path in backups:
                 try:
                     os.replace(str(backup_path), str(dst_path))
                 except Exception as rollback_error:  # continue restoring every file
-                    rollback_errors.append(f"{dst_path}: {rollback_error!r}")
+                    rollback_errors.append((backup_path, dst_path, rollback_error))
             if rollback_errors:
-                details = "; ".join(rollback_errors)
+                preserve_transaction = True
+                # Updated candidates cannot recover original data, so remove any
+                # that were not consumed when it is safe to do so. Cleanup must
+                # never endanger the retained original backups.
+                for candidate_path, _ in temp_paths:
+                    with suppress(OSError):
+                        candidate_path.unlink(missing_ok=True)
+                details = "; ".join(
+                    f"restore {backup_path} -> {dst_path} ({rollback_error!r})"
+                    for backup_path, dst_path, rollback_error in rollback_errors
+                )
                 raise RuntimeError(
-                    f"version update failed ({update_error!r}); ROLLBACK FAILED: {details}"
+                    f"version update failed ({update_error!r}); ROLLBACK FAILED; "
+                    f"recovery required: {details}"
                 ) from update_error
             raise
     finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        if not preserve_transaction:
+            shutil.rmtree(tmpdir)
 
 
 def _main() -> None:

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
-"""Atomic version synchronisation across hal0 release artifacts.
+"""Rollback-capable version synchronisation across hal0 release artifacts.
 
 Updates all top-level version fields (pyproject.toml, ui/package.json,
 ui/package-lock.json, manifest.json) and the PEP 440 version of the
-editable ``hal0ai`` package in uv.lock in a single atomic transaction:
-every candidate is written to a temporary file first, all candidates are
-validated, and only then are originals replaced via ``os.replace``.
-
-After a successful replacement ``uv lock`` is re-run and the resulting
-lock version is re-validated.
+editable ``hal0ai`` package in uv.lock. Every candidate is validated before
+per-file atomic replacement via ``os.replace``. Originals are retained in a
+repository-local transaction directory. Replacement, ``uv lock``, and
+postvalidation failures trigger per-file atomic restoration; the five-file
+update is not globally atomic.
 
 Usage::
 
@@ -157,7 +156,7 @@ def _update_file_atomic(dst: Path, content: str, tmpdir: Path) -> Path:
 
 
 def set_version(root: Path, version: str) -> None:
-    """Atomically update all version fields to *version*.
+    """Update all version fields with per-file atomic replacement and rollback.
 
     Args:
         root: Repository root directory.
@@ -166,7 +165,7 @@ def set_version(root: Path, version: str) -> None:
     Raises:
         ValueError: If the version is nightly or a required file is
             malformed.
-        RuntimeError: If ``uv lock`` fails or re-validation fails.
+        RuntimeError: If postvalidation or rollback fails.
     """
     # 1. Resolve channel and PEP 440 form; reject nightly
     channel = _resolve_channel(version)
@@ -290,39 +289,64 @@ def set_version(root: Path, version: str) -> None:
                         f"{hal0ai_ver!r} != expected {pep440!r}"
                     )
 
-        # 4. All good — atomically replace originals
-        for tmp_path, dst_path in temp_paths:
-            os.replace(str(tmp_path), str(dst_path))
+        # 4. Preserve every original before replacing any destination.
+        backups: list[tuple[Path, Path]] = []
+        for index, (_, dst_path) in enumerate(temp_paths):
+            backup_path = tmpdir / f".original.{index}"
+            shutil.copy2(dst_path, backup_path)
+            backups.append((backup_path, dst_path))
 
+        try:
+            # Each destination replacement is atomic, but the group is guarded
+            # by rollback rather than claiming impossible global atomicity.
+            for tmp_path, dst_path in temp_paths:
+                os.replace(str(tmp_path), str(dst_path))
+
+            # 5. Re-run uv lock while originals remain available for rollback.
+            subprocess.run(
+                ["uv", "lock"],
+                cwd=str(root),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            # 6. Re-validate lock version before committing the transaction.
+            lock_text_final = lock_path.read_text(encoding="utf-8")
+            lock_data_final = tomllib.loads(lock_text_final)
+            hal0ai_final = next(
+                (
+                    p["version"]
+                    for p in lock_data_final.get("package", [])
+                    if p.get("name") == "hal0ai"
+                ),
+                None,
+            )
+            if hal0ai_final != pep440:
+                raise RuntimeError(
+                    f"post-lock re-validation: uv.lock hal0ai version "
+                    f"{hal0ai_final!r} != expected {pep440!r}"
+                )
+        except Exception as update_error:
+            rollback_errors: list[str] = []
+            for backup_path, dst_path in backups:
+                try:
+                    os.replace(str(backup_path), str(dst_path))
+                except Exception as rollback_error:  # continue restoring every file
+                    rollback_errors.append(f"{dst_path}: {rollback_error!r}")
+            if rollback_errors:
+                details = "; ".join(rollback_errors)
+                raise RuntimeError(
+                    f"version update failed ({update_error!r}); ROLLBACK FAILED: {details}"
+                ) from update_error
+            raise
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
-
-    # 5. Re-run uv lock and re-validate
-    subprocess.run(
-        ["uv", "lock"],
-        cwd=str(root),
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-    # 6. Re-validate lock version
-    lock_text_final = lock_path.read_text(encoding="utf-8")
-    lock_data_final = tomllib.loads(lock_text_final)
-    hal0ai_final = next(
-        (p["version"] for p in lock_data_final.get("package", []) if p.get("name") == "hal0ai"),
-        None,
-    )
-    if hal0ai_final != pep440:
-        raise RuntimeError(
-            f"post-lock re-validation: uv.lock hal0ai version "
-            f"{hal0ai_final!r} != expected {pep440!r}"
-        )
 
 
 def _main() -> None:
     parser = argparse.ArgumentParser(
-        description="Atomically synchronize version across hal0 release artifacts."
+        description=("Synchronize version artifacts with per-file atomic replacement and rollback.")
     )
     parser.add_argument(
         "version",

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -828,10 +828,10 @@ async def set_channel(request: Request) -> dict[str, str]:
             code="channel.invalid",
         ) from exc
 
-    # Validate before touching either the file or the app-state cache. A failed
-    # fetch/schema/channel check must leave the previous channel fully intact.
-    if channel != current.telemetry.channel:
-        await Updater(channel=channel).check()
+    # Validate before touching either the file or the app-state cache. This is
+    # required even for an idempotent PUT: success authenticates the channel's
+    # current manifest, not merely the requested config value.
+    await Updater(channel=channel).check()
 
     try:
         save_hal0_config(merged)

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -47,7 +47,7 @@ from hal0.config import paths
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.release.policy import ReleaseKind
-from hal0.updater import Updater, fetch_release_manifest, releases_url
+from hal0.updater import Updater, fetch_release_manifest, releases_url, validate_release_version
 
 log = structlog.get_logger(__name__)
 
@@ -593,14 +593,7 @@ async def apply_update(request: Request) -> dict[str, Any]:
         body = await request.json()
     except Exception:
         body = {}
-    version: str | None = None
-    if isinstance(body, dict):
-        v = body.get("version")
-        if isinstance(v, str) and v.strip():
-            # Strip a leading "v" so {"version": "v0.1.1"} and "0.1.1"
-            # drive the same target - matches the CLI's --target handling
-            # (#510). lstrip is fine here: versions never start with "v".
-            version = v.strip().lstrip("v") or None
+    version = _body_version(body)
 
     channel = _current_channel(request)
     jobs = _update_jobs(request)
@@ -643,11 +636,11 @@ def _spawn_update_task(request: Request, coro: Any) -> None:
 
 
 def _body_version(body: Any) -> str | None:
-    """Extract a normalised ``version`` from a request body (strip a leading v)."""
+    """Extract ``version``, normalising one compatible leading ``v`` only."""
     if isinstance(body, dict):
-        v = body.get("version")
-        if isinstance(v, str) and v.strip():
-            return v.strip().lstrip("v") or None
+        version = body.get("version")
+        if isinstance(version, str) and version:
+            return version[1:] if version.startswith("v") else version
     return None
 
 
@@ -706,6 +699,13 @@ async def commit_update(request: Request) -> dict[str, Any]:
             "commit requires a 'version' — the resolved_version from /prepare",
             details={"hint": "POST /api/updates/prepare first, then commit its resolved_version"},
         )
+    try:
+        version = validate_release_version(version)
+    except ValueError as exc:
+        raise BadRequest(
+            "commit version must be an exact supported release version",
+            details={"version": version, "error": str(exc)},
+        ) from exc
     channel = _current_channel(request)
     jobs = _update_jobs(request)
     job_id = uuid.uuid4().hex[:12]

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -36,7 +36,7 @@ import tempfile
 import time
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import structlog
 from fastapi import APIRouter, Request
@@ -46,6 +46,7 @@ from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config import paths
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
+from hal0.release.policy import ReleaseKind
 from hal0.updater import Updater, fetch_release_manifest, releases_url
 
 log = structlog.get_logger(__name__)
@@ -55,7 +56,7 @@ log = structlog.get_logger(__name__)
 router = APIRouter()
 
 
-_VALID_CHANNELS = frozenset({"stable", "nightly"})
+_VALID_CHANNELS = frozenset(get_args(ReleaseKind))
 
 
 class UpdateError(Hal0Error):
@@ -778,7 +779,7 @@ async def rollback_update(request: Request) -> dict[str, Any]:
 
 @router.get("/channel")
 async def get_channel(request: Request) -> dict[str, str]:
-    """Return the configured update channel (stable | nightly)."""
+    """Return the configured update channel (stable | preview | nightly)."""
     return {"channel": _current_channel(request)}
 
 
@@ -788,11 +789,12 @@ async def set_channel(request: Request) -> dict[str, str]:
 
     Body::
 
-        {"channel": "stable"}   # or "nightly"
+        {"channel": "stable"}   # or "preview" / "nightly"
 
-    Persists to ``/etc/hal0/hal0.toml`` (telemetry.channel) via the same
-    atomic write path as ``/api/settings``. The new channel takes effect
-    immediately for subsequent ``/check`` calls.
+    Before switching, validates the target channel's manifest through
+    :meth:`Updater.check`. Only a reachable, schema-valid, channel-coherent
+    manifest is persisted to ``/etc/hal0/hal0.toml`` (telemetry.channel), via
+    the same atomic write path as ``/api/settings``.
     """
     try:
         body = await request.json()
@@ -825,6 +827,12 @@ async def set_channel(request: Request) -> dict[str, str]:
             details={"error": str(exc)},
             code="channel.invalid",
         ) from exc
+
+    # Validate before touching either the file or the app-state cache. A failed
+    # fetch/schema/channel check must leave the previous channel fully intact.
+    if channel != current.telemetry.channel:
+        await Updater(channel=channel).check()
+
     try:
         save_hal0_config(merged)
     except OSError as exc:

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -254,7 +254,7 @@ def update(
     target: str | None = typer.Option(
         None,
         "--target",
-        help="Pin a specific version (e.g. v0.1.1). Overrides the latest manifest version.",
+        help="Require the authenticated channel manifest to exactly match this version.",
     ),
     yes: bool = typer.Option(
         False,

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -53,6 +53,7 @@ update_app = typer.Typer(
 
 class UpdateChannel(StrEnum):
     stable = "stable"
+    preview = "preview"
 
 
 def _print_check(body: dict) -> None:
@@ -238,7 +239,7 @@ def update(
     channel: UpdateChannel | None = typer.Option(
         None,
         "--channel",
-        help="Persist the update channel (stable), then check.",
+        help="Persist the update channel (stable or preview), then check.",
     ),
     check: bool = typer.Option(
         False,

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -54,6 +54,7 @@ update_app = typer.Typer(
 class UpdateChannel(StrEnum):
     stable = "stable"
     preview = "preview"
+    nightly = "nightly"
 
 
 def _print_check(body: dict) -> None:
@@ -239,7 +240,7 @@ def update(
     channel: UpdateChannel | None = typer.Option(
         None,
         "--channel",
-        help="Persist the update channel (stable or preview), then check.",
+        help="Persist the update channel (stable, preview, or nightly), then check.",
     ),
     check: bool = typer.Option(
         False,

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -39,6 +39,7 @@ from hal0.model_meta import (
 from hal0.model_meta import (
     VALID_DEVICES as _VALID_DEVICES,
 )
+from hal0.release.policy import ReleaseKind
 
 log = logging.getLogger(__name__)
 
@@ -1992,17 +1993,10 @@ class TelemetryConfig(BaseModel):
         default=False,
         description="Opt-in anonymous telemetry.  Off by default.  See PLAN.md §14.",
     )
-    channel: str = Field(
+    channel: ReleaseKind = Field(
         default="stable",
-        description="Update channel: 'stable' | 'nightly'.",
+        description="Update channel: 'stable' | 'preview' | 'nightly'.",
     )
-
-    @field_validator("channel")
-    @classmethod
-    def channel_valid(cls, v: str) -> str:
-        if v not in ("stable", "nightly"):
-            raise ValueError(f"channel {v!r} must be 'stable' or 'nightly'")
-        return v
 
 
 # ── MemoryGraphConfig (ADR-0023) ──────────────────────────────────────────────

--- a/src/hal0/updater/__init__.py
+++ b/src/hal0/updater/__init__.py
@@ -38,6 +38,7 @@ from hal0.updater.updater import (
     fetch_release_manifest,
     releases_url,
     validate_manifest_for_channel,
+    validate_release_version,
 )
 
 __all__ = [
@@ -56,4 +57,5 @@ __all__ = [
     "fetch_release_manifest",
     "releases_url",
     "validate_manifest_for_channel",
+    "validate_release_version",
 ]

--- a/src/hal0/updater/__init__.py
+++ b/src/hal0/updater/__init__.py
@@ -37,6 +37,7 @@ from hal0.updater.updater import (
     UpdateVerifyError,
     fetch_release_manifest,
     releases_url,
+    validate_manifest_for_channel,
 )
 
 __all__ = [
@@ -54,4 +55,5 @@ __all__ = [
     "Updater",
     "fetch_release_manifest",
     "releases_url",
+    "validate_manifest_for_channel",
 ]

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -157,17 +157,30 @@ class UpdateRollbackUnavailable(UpdateError):
 # ── Release-manifest schema (pydantic) ─────────────────────────────────────────
 
 
-def validate_release_version(version: str) -> str:
-    """Return an exact supported release version or raise ``ValueError``.
+# Read/install compatibility for nightly manifests published before the current
+# 14-digit timestamp policy. This is deliberately anchored and ASCII-only so the
+# updater can safely reuse the value in cache/install paths without making legacy
+# 8-digit tags valid for new publication through ReleasePolicy.
+_LEGACY_NIGHTLY_VERSION_RE = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}$"
+)
 
-    ReleasePolicy is the stdlib source of truth shared with release publishing;
-    updater paths only accept its canonical, leading-``v``-free version form.
+
+def validate_release_version(version: str) -> str:
+    """Return an exact supported updater version or raise ``ValueError``.
+
+    ReleasePolicy remains the source of truth for every currently publishable
+    version. The updater additionally accepts the documented, path-safe legacy
+    nightly read/install form ``X.Y.Z-nightly.YYYYMMDD`` for compatibility with
+    existing manifests and staged releases.
     """
     if not isinstance(version, str):
         raise ValueError(f"release version must be a string, got {type(version).__name__}")
     try:
         policy = ReleasePolicy.from_tag(f"v{version}")
     except ReleaseTagError as exc:
+        if _LEGACY_NIGHTLY_VERSION_RE.fullmatch(version):
+            return version
         raise ValueError(f"unsupported release version: {version!r}") from exc
     if policy.version != version:
         raise ValueError(f"noncanonical release version: {version!r}")

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -69,8 +69,8 @@ log = structlog.get_logger(__name__)
 
 
 # Read/install compatibility for nightly manifests published before the current
-# 14-digit timestamp policy. This does not make legacy tags publishable through
-# ReleasePolicy; it only preserves existing manifest and staged-release reads.
+# 14-digit timestamp policy. This does not make older date-only tags publishable
+# through ReleasePolicy; it only preserves existing manifest and staged-release reads.
 _LEGACY_NIGHTLY_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}$")
 
 
@@ -201,9 +201,9 @@ def validate_release_version(version: str) -> str:
     """Return an exact supported updater version or raise ``ValueError``.
 
     ReleasePolicy remains the source of truth for every currently publishable
-    version. The updater additionally accepts the documented, path-safe legacy
-    nightly read/install form ``X.Y.Z-nightly.YYYYMMDD`` for compatibility with
-    existing manifests and staged releases.
+    version. The updater additionally accepts the documented, path-safe date-only
+    nightly read/install form ``X.Y.Z-nightly.YYYYMMDD`` for already-issued
+    manifests and staged releases.
     """
     if not isinstance(version, str):
         raise ValueError(f"release version must be a string, got {type(version).__name__}")

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -170,7 +170,7 @@ class ReleaseManifest(BaseModel):
 
     model_config = {"populate_by_name": True, "extra": "allow"}
 
-    schema_id: str = Field(default="hal0.releases.v1", alias="_schema")
+    schema_id: Literal["hal0.releases.v1"] = Field(alias="_schema")
     version: str = Field(..., description="Release version, e.g. '0.1.1'.")
     channel: ReleaseKind = Field(default="stable", description="Release channel.")
     release_kind: ReleaseKind = Field(

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -830,6 +830,15 @@ async def _fetch_verified_release_manifest(
                     "manifest_signer_identity": manifest.signer_identity,
                 },
             )
+        if manifest.signer_issuer != _MANIFEST_SIGNER_ISSUER:
+            raise UpdateManifestInvalid(
+                "release manifest signer_issuer does not match the pinned issuer",
+                details={
+                    "channel": channel,
+                    "expected_signer_issuer": _MANIFEST_SIGNER_ISSUER,
+                    "manifest_signer_issuer": manifest.signer_issuer,
+                },
+            )
 
         if exact_identity != admission_identity:
             await asyncio.to_thread(
@@ -1836,7 +1845,7 @@ class Updater:
             tarball_path,
             bundle_path,
             identity_regexp=expected_identity,
-            issuer=manifest.signer_issuer,
+            issuer=_MANIFEST_SIGNER_ISSUER,
             job_id=self.job_id,
         )
 
@@ -1895,6 +1904,13 @@ class Updater:
                     "manifest_version": manifest.version,
                 },
             )
+        try:
+            validate_manifest_for_channel(manifest, self.channel)
+        except ValueError as exc:
+            raise UpdateManifestInvalid(
+                f"cached manifest is not accepted for channel {self.channel!r}: {exc}",
+                details={"channel": self.channel, "error": str(exc)},
+            ) from exc
         log.info("updater.commit_start", job_id=self.job_id, version=target_version)
 
         # Step 7: config migrations.

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1666,19 +1666,24 @@ class Updater:
         log.info("updater.prepare_start", job_id=self.job_id, channel=self.channel, pinned=version)
         raw, manifest, _ = await _fetch_verified_release_manifest(self.channel, job_id=self.job_id)
 
-        # Step 2: confirm target version.
-        target_version = (version or "").strip() or manifest.version
-        if not target_version:
+        # Step 2: treat the optional version as an optimistic exact pin. It is
+        # never a historical resolver or a caller-controlled staging label:
+        # authenticated manifest.version remains the sole target authority.
+        requested_version = (version or "").strip() or None
+        if requested_version is not None and requested_version != manifest.version:
+            raise UpdateManifestInvalid(
+                "requested version does not match authenticated channel manifest",
+                details={
+                    "channel": self.channel,
+                    "requested_version": requested_version,
+                    "manifest_version": manifest.version,
+                },
+            )
+        target_version = manifest.version
+        if not target_version.strip():
             raise UpdateManifestInvalid(
                 "release manifest has no usable version",
                 details={"channel": self.channel},
-            )
-        if version and version != manifest.version:
-            log.info(
-                "updater.version_pinned_mismatch",
-                job_id=self.job_id,
-                pinned=version,
-                manifest=manifest.version,
             )
 
         # Step 3: download tarball + Sigstore bundle (survives cert expiry, #1159).
@@ -1772,8 +1777,18 @@ class Updater:
                 f"nothing staged for {target_version} — call prepare() before commit()",
                 details={"version": target_version, "install_dir": str(install_dir)},
             )
-        # Manifest cached by prepare(); needed for min_data_version below.
+        # Manifest cached by prepare(); needed for min_data_version below. Recheck
+        # its authenticated target binding before any migration or activation.
         manifest = _parse_manifest(_load_cached_manifest(target_version))
+        if manifest.version != target_version:
+            raise UpdateManifestInvalid(
+                "cached manifest version does not match prepared target",
+                details={
+                    "channel": self.channel,
+                    "target_version": target_version,
+                    "manifest_version": manifest.version,
+                },
+            )
         log.info("updater.commit_start", job_id=self.job_id, version=target_version)
 
         # Step 7: config migrations.

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -68,6 +68,22 @@ from hal0.release.policy import ReleaseKind
 log = structlog.get_logger(__name__)
 
 
+# Client-pinned trust root for authenticating release manifests. Direct release
+# jobs sign at their immutable v... tag ref. The current nightly workflow calls
+# release.yml from main, so GitHub records the reusable job identity at
+# refs/heads/main (see release.yml's signing comments). Keep this independent of
+# signer_identity/signer_issuer in the unauthenticated manifest; those fields are
+# trusted only after this verification and are then used for the release tarball.
+_MANIFEST_SIGNER_IDENTITY_REGEXP = (
+    r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+    r"\.github/workflows/release\.yml@"
+    r"(refs/tags/v\d+\.\d+\.\d+"
+    r"(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?"
+    r"|refs/heads/main)$"
+)
+_MANIFEST_SIGNER_ISSUER = "https://token.actions.githubusercontent.com"
+
+
 # ── Typed errors (system.update_*) ─────────────────────────────────────────────
 
 
@@ -675,9 +691,11 @@ async def _fetch_verified_release_manifest(
 ) -> tuple[dict[str, Any], ReleaseManifest, str]:
     """Fetch, validate, and authenticate a channel manifest and sibling bundle.
 
-    Verification uses the exact fetched JSON bytes and the existing mandatory
-    Cosign/OIDC primitive. Temporary files live outside the updater cache, so a
-    failed channel validation cannot leave staged update state behind.
+    Verification uses the exact fetched JSON bytes, a client-pinned workflow
+    identity and OIDC issuer, and the existing mandatory Cosign primitive. The
+    manifest's own signer claims remain untrusted until this succeeds. Temporary
+    files live outside the updater cache, so failed validation cannot leave
+    staged update state behind.
     """
     url = releases_url(channel)
     try:
@@ -713,8 +731,8 @@ async def _fetch_verified_release_manifest(
             _verify_cosign,
             manifest_path,
             bundle_path,
-            identity_regexp=manifest.signer_identity,
-            issuer=manifest.signer_issuer,
+            identity_regexp=_MANIFEST_SIGNER_IDENTITY_REGEXP,
+            issuer=_MANIFEST_SIGNER_ISSUER,
             job_id=job_id,
         )
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -63,6 +63,7 @@ from hal0.config.loader import (
 )
 from hal0.config.migrations import latest_version, run_migrations
 from hal0.errors import Hal0Error
+from hal0.release.policy import ReleaseKind
 
 log = structlog.get_logger(__name__)
 
@@ -155,8 +156,8 @@ class ReleaseManifest(BaseModel):
 
     schema_id: str = Field(default="hal0.releases.v1", alias="_schema")
     version: str = Field(..., description="Release version, e.g. '0.1.1'.")
-    channel: str = Field(default="stable", description="Release channel.")
-    release_kind: Literal["stable", "nightly", "preview"] = Field(
+    channel: ReleaseKind = Field(default="stable", description="Release channel.")
+    release_kind: ReleaseKind = Field(
         default="stable",
         description="Kind of release: stable, nightly, or preview.",
     )
@@ -241,7 +242,8 @@ class ReleaseManifest(BaseModel):
 
         Rules:
         - preview requires prerelease_stage in (alpha, beta, rc) and channel="preview".
-        - stable/nightly require no prerelease_stage and channel matches release_kind.
+        - stable requires no prerelease_stage and may target stable or preview.
+        - nightly requires no prerelease_stage and channel="nightly".
         - non-empty operator_migrations require rollback_policy in
           ("backup-required", "blocked").
         """
@@ -254,16 +256,26 @@ class ReleaseManifest(BaseModel):
                 raise ValueError(
                     f"preview release_kind requires channel='preview', got {self.channel!r}"
                 )
-        if self.release_kind in ("stable", "nightly"):
+        if self.release_kind == "stable":
             if self.prerelease_stage is not None:
                 raise ValueError(
-                    f"{self.release_kind} release_kind must not have a "
+                    "stable release_kind must not have a "
                     f"prerelease_stage, got {self.prerelease_stage!r}"
                 )
-            if self.channel != self.release_kind:
+            if self.channel not in ("stable", "preview"):
                 raise ValueError(
-                    f"{self.release_kind} release_kind requires "
-                    f"channel={self.release_kind!r}, got {self.channel!r}"
+                    "stable release_kind requires channel='stable' or 'preview', "
+                    f"got {self.channel!r}"
+                )
+        if self.release_kind == "nightly":
+            if self.prerelease_stage is not None:
+                raise ValueError(
+                    "nightly release_kind must not have a "
+                    f"prerelease_stage, got {self.prerelease_stage!r}"
+                )
+            if self.channel != "nightly":
+                raise ValueError(
+                    f"nightly release_kind requires channel='nightly', got {self.channel!r}"
                 )
         if self.operator_migrations and self.rollback_policy not in (
             "backup-required",
@@ -275,6 +287,33 @@ class ReleaseManifest(BaseModel):
                 f"got {self.rollback_policy!r}"
             )
         return self
+
+
+_ACCEPTED_RELEASE_KINDS: dict[str, frozenset[ReleaseKind]] = {
+    "stable": frozenset({"stable"}),
+    "preview": frozenset({"preview", "stable"}),
+    "nightly": frozenset({"nightly"}),
+}
+
+
+def validate_manifest_for_channel(
+    manifest: ReleaseManifest, requested_channel: str
+) -> ReleaseManifest:
+    """Return ``manifest`` when it is safe to consume for the requested channel."""
+    if requested_channel not in _ACCEPTED_RELEASE_KINDS:
+        raise ValueError(f"unknown requested channel {requested_channel!r}")
+    if manifest.channel != requested_channel:
+        raise ValueError(
+            f"manifest channel {manifest.channel!r} does not match "
+            f"requested channel {requested_channel!r}"
+        )
+    accepted_kinds = _ACCEPTED_RELEASE_KINDS[requested_channel]
+    if manifest.release_kind not in accepted_kinds:
+        raise ValueError(
+            f"release kind {manifest.release_kind!r} is not accepted for "
+            f"requested channel {requested_channel!r}"
+        )
+    return manifest
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1565,6 +1604,13 @@ class Updater:
                 details={"channel": self.channel, "error": str(exc)},
             ) from exc
         manifest = _parse_manifest(raw)
+        try:
+            validate_manifest_for_channel(manifest, self.channel)
+        except ValueError as exc:
+            raise UpdateManifestInvalid(
+                f"release manifest is not accepted for channel {self.channel!r}: {exc}",
+                details={"channel": self.channel, "error": str(exc)},
+            ) from exc
 
         # Step 2: confirm target version.
         target_version = (version or "").strip() or manifest.version

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -63,7 +63,7 @@ from hal0.config.loader import (
 )
 from hal0.config.migrations import latest_version, run_migrations
 from hal0.errors import Hal0Error
-from hal0.release.policy import ReleaseKind
+from hal0.release.policy import ReleaseKind, ReleasePolicy, ReleaseTagError
 
 log = structlog.get_logger(__name__)
 
@@ -157,6 +157,34 @@ class UpdateRollbackUnavailable(UpdateError):
 # ── Release-manifest schema (pydantic) ─────────────────────────────────────────
 
 
+def validate_release_version(version: str) -> str:
+    """Return an exact supported release version or raise ``ValueError``.
+
+    ReleasePolicy is the stdlib source of truth shared with release publishing;
+    updater paths only accept its canonical, leading-``v``-free version form.
+    """
+    if not isinstance(version, str):
+        raise ValueError(f"release version must be a string, got {type(version).__name__}")
+    try:
+        policy = ReleasePolicy.from_tag(f"v{version}")
+    except ReleaseTagError as exc:
+        raise ValueError(f"unsupported release version: {version!r}") from exc
+    if policy.version != version:
+        raise ValueError(f"noncanonical release version: {version!r}")
+    return policy.version
+
+
+def _require_release_version(version: str, *, field: str) -> str:
+    """Translate release-policy rejection into the updater's typed 400 error."""
+    try:
+        return validate_release_version(version)
+    except ValueError as exc:
+        raise UpdateManifestInvalid(
+            f"{field} must be an exact supported release version",
+            details={field: version, "error": str(exc)},
+        ) from exc
+
+
 class ReleaseManifest(BaseModel):
     """Schema-validated release-manifest payload.
 
@@ -241,6 +269,11 @@ class ReleaseManifest(BaseModel):
         default_factory=dict,
         description="Mirror of manifest.json's toolbox_images block.",
     )
+
+    @field_validator("version")
+    @classmethod
+    def _version_is_supported(cls, v: str) -> str:
+        return validate_release_version(v)
 
     @field_validator("digest_sha256")
     @classmethod
@@ -1669,22 +1702,26 @@ class Updater:
         # Step 2: treat the optional version as an optimistic exact pin. It is
         # never a historical resolver or a caller-controlled staging label:
         # authenticated manifest.version remains the sole target authority.
-        requested_version = (version or "").strip() or None
-        if requested_version is not None and requested_version != manifest.version:
+        requested_version = (
+            _require_release_version(version, field="requested_version")
+            if version is not None
+            else None
+        )
+        target_version = _require_release_version(manifest.version, field="manifest_version")
+        if requested_version is not None and requested_version != target_version:
             raise UpdateManifestInvalid(
                 "requested version does not match authenticated channel manifest",
                 details={
                     "channel": self.channel,
                     "requested_version": requested_version,
-                    "manifest_version": manifest.version,
+                    "manifest_version": target_version,
                 },
             )
-        target_version = manifest.version
-        if not target_version.strip():
-            raise UpdateManifestInvalid(
-                "release manifest has no usable version",
-                details={"channel": self.channel},
-            )
+
+        # Residual: concurrent prepares for the same version share cache/install
+        # paths and are not serialized. A lock redesign is intentionally out of
+        # scope; signed immutable same-version assets limit current release risk
+        # because both prepares authenticate the same publisher-pinned bytes.
 
         # Step 3: download tarball + Sigstore bundle (survives cert expiry, #1159).
         cache = _cache_dir(target_version)
@@ -1764,12 +1801,7 @@ class Updater:
         shape as the old single-step apply.
         """
         _raise_if_editable_install()
-        target_version = (version or "").strip()
-        if not target_version:
-            raise UpdateManifestInvalid(
-                "commit requires an explicit prepared version",
-                details={"channel": self.channel},
-            )
+        target_version = _require_release_version(version, field="commit_version")
         install_dir = _versioned_install_dir(target_version)
         cache = _cache_dir(target_version)
         if not install_dir.exists():

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1524,16 +1524,18 @@ class Updater:
                 details={"channel": ch, "url": url, "error": str(exc)},
             ) from exc
 
-        # Soft-validate: some routes (test fixture) ship a minimal manifest
-        # with just {"version": "9.9.9"} — surface it without forcing a
-        # full schema match. Strict validation happens inside ``apply()``.
-        latest = ""
-        revoked = False
-        revoked_reason = ""
-        if isinstance(raw, dict):
-            latest = str(raw.get("version") or raw.get("latest_version") or "")
-            revoked = bool(raw.get("revoked", False))
-            revoked_reason = str(raw.get("revoked_reason") or "")
+        manifest = _parse_manifest(raw)
+        try:
+            validate_manifest_for_channel(manifest, ch)
+        except ValueError as exc:
+            raise UpdateManifestInvalid(
+                f"release manifest is not accepted for channel {ch!r}: {exc}",
+                details={"channel": ch, "error": str(exc)},
+            ) from exc
+
+        latest = manifest.version
+        revoked = manifest.revoked
+        revoked_reason = manifest.revoked_reason
         # A revoked (yanked/withdrawn) latest is never recommended — the
         # operator should not be nudged toward a release we've pulled. The
         # version is still surfaced (revoked + reason) so the dashboard can
@@ -1552,13 +1554,13 @@ class Updater:
             channel=ch,
             update_available=update_available,
             manifest_url=url,
-            digest_sha256=raw.get("digest_sha256") if isinstance(raw, dict) else None,
-            signer_identity=raw.get("signer_identity") if isinstance(raw, dict) else None,
-            min_data_version=raw.get("min_data_version") if isinstance(raw, dict) else None,
-            notes_url=raw.get("notes_url") if isinstance(raw, dict) else None,
+            digest_sha256=manifest.digest_sha256,
+            signer_identity=manifest.signer_identity,
+            min_data_version=manifest.min_data_version,
+            notes_url=manifest.notes_url,
             revoked=revoked,
             revoked_reason=revoked_reason,
-            raw_manifest=raw if isinstance(raw, dict) else {},
+            raw_manifest=raw,
         )
 
     # ── apply ──────────────────────────────────────────────────────────────────
@@ -2028,4 +2030,5 @@ __all__ = [
     "ensure_seed_profiles",
     "fetch_release_manifest",
     "releases_url",
+    "validate_manifest_for_channel",
 ]

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -5,8 +5,8 @@ Updater handles the full update lifecycle:
      for a newer version.
   2. Download tarball + cosign signature to ``/var/lib/hal0/cache/<version>/``.
   3. Verify the SHA-256 digest against the release manifest.
-  4. ``cosign verify-blob`` against the GitHub Actions OIDC identity
-     declared in the manifest (``signer_identity`` / ``signer_issuer``).
+  4. ``cosign verify-blob`` against the exact GitHub Actions OIDC identity
+     derived from the authenticated release kind and version.
   5. Extract to ``/usr/lib/hal0-<version>/`` (refuses non-empty paths).
   6. Run pending config migrations (``hal0.config.migrations.run_migrations``)
      when ``min_data_version`` advances the schema.
@@ -68,20 +68,60 @@ from hal0.release.policy import ReleaseKind, ReleasePolicy, ReleaseTagError
 log = structlog.get_logger(__name__)
 
 
-# Client-pinned trust root for authenticating release manifests. Direct release
-# jobs sign at their immutable v... tag ref. The current nightly workflow calls
-# release.yml from main, so GitHub records the reusable job identity at
-# refs/heads/main (see release.yml's signing comments). Keep this independent of
-# signer_identity/signer_issuer in the unauthenticated manifest; those fields are
-# trusted only after this verification and are then used for the release tarball.
-_MANIFEST_SIGNER_IDENTITY_REGEXP = (
+# Read/install compatibility for nightly manifests published before the current
+# 14-digit timestamp policy. This does not make legacy tags publishable through
+# ReleasePolicy; it only preserves existing manifest and staged-release reads.
+_LEGACY_NIGHTLY_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}$")
+
+
+# Client-pinned trust roots for authenticating release manifests. Admission is
+# selected only from the locally requested channel, before any JSON is decoded.
+# Stable and preview admit only their respective immutable tag grammars. Nightly
+# is signed by the reusable release workflow as invoked from main, so its sole
+# admitted identity is release.yml@refs/heads/main. After authenticated parsing,
+# every manifest is bound to one exact release identity before artifact fields
+# are consumed.
+_MANIFEST_IDENTITY_PREFIX = (
     r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
     r"\.github/workflows/release\.yml@"
-    r"(refs/tags/v\d+\.\d+\.\d+"
-    r"(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?"
-    r"|refs/heads/main)$"
 )
 _MANIFEST_SIGNER_ISSUER = "https://token.actions.githubusercontent.com"
+_STABLE_MANIFEST_ADMISSION_IDENTITY = _MANIFEST_IDENTITY_PREFIX + r"refs/tags/v\d+\.\d+\.\d+$"
+_PREVIEW_MANIFEST_ADMISSION_IDENTITY = (
+    _MANIFEST_IDENTITY_PREFIX + r"refs/tags/v\d+\.\d+\.\d+(-(alpha|beta|rc)\.(0|[1-9]\d*))?$"
+)
+_NIGHTLY_MANIFEST_IDENTITY = _MANIFEST_IDENTITY_PREFIX + r"refs/heads/main$"
+
+
+def manifest_admission_identity(channel: str) -> str:
+    """Return the first-verification identity for a trusted requested channel."""
+    identities = {
+        "stable": _STABLE_MANIFEST_ADMISSION_IDENTITY,
+        "preview": _PREVIEW_MANIFEST_ADMISSION_IDENTITY,
+        "nightly": _NIGHTLY_MANIFEST_IDENTITY,
+    }
+    try:
+        return identities[channel]
+    except KeyError as exc:
+        raise ValueError(f"unknown requested channel {channel!r}") from exc
+
+
+def exact_manifest_identity(release_kind: str, version: str) -> str:
+    """Derive the sole accepted signer identity from authenticated release policy."""
+    if release_kind == "nightly" and _LEGACY_NIGHTLY_VERSION_RE.fullmatch(version):
+        return _NIGHTLY_MANIFEST_IDENTITY
+    try:
+        policy = ReleasePolicy.from_tag(f"v{version}")
+    except ReleaseTagError as exc:
+        raise ValueError(f"unsupported release version: {version!r}") from exc
+    if policy.version != version or policy.kind != release_kind:
+        raise ValueError(
+            f"release kind {release_kind!r} does not match version policy {policy.kind!r}"
+        )
+    if policy.kind == "nightly":
+        return _NIGHTLY_MANIFEST_IDENTITY
+    escaped_tag = f"v{version}".replace(".", r"\.")
+    return _MANIFEST_IDENTITY_PREFIX + f"refs/tags/{escaped_tag}$"
 
 
 # ── Typed errors (system.update_*) ─────────────────────────────────────────────
@@ -155,15 +195,6 @@ class UpdateRollbackUnavailable(UpdateError):
 
 
 # ── Release-manifest schema (pydantic) ─────────────────────────────────────────
-
-
-# Read/install compatibility for nightly manifests published before the current
-# 14-digit timestamp policy. This is deliberately anchored and ASCII-only so the
-# updater can safely reuse the value in cache/install paths without making legacy
-# 8-digit tags valid for new publication through ReleasePolicy.
-_LEGACY_NIGHTLY_VERSION_RE = re.compile(
-    r"^[0-9]+\.[0-9]+\.[0-9]+-nightly\.[0-9]{8}$"
-)
 
 
 def validate_release_version(version: str) -> str:
@@ -249,8 +280,8 @@ class ReleaseManifest(BaseModel):
     signer_identity: str = Field(
         ...,
         description=(
-            "GitHub Actions OIDC subject. Used as a regex for "
-            "``cosign verify-blob --certificate-identity-regexp``."
+            "Exact generated GitHub Actions OIDC subject regex for this release. "
+            "Clients derive and enforce the same value from release_kind + version."
         ),
     )
     signer_issuer: str = Field(
@@ -735,36 +766,28 @@ def _verify_cosign(
 async def _fetch_verified_release_manifest(
     channel: str, *, job_id: str | None = None
 ) -> tuple[dict[str, Any], ReleaseManifest, str]:
-    """Fetch, validate, and authenticate a channel manifest and sibling bundle.
+    """Fetch and authenticate exact manifest bytes before parsing any JSON.
 
-    Verification uses the exact fetched JSON bytes, a client-pinned workflow
-    identity and OIDC issuer, and the existing mandatory Cosign primitive. The
-    manifest's own signer claims remain untrusted until this succeeds. Temporary
-    files live outside the updater cache, so failed validation cannot leave
-    staged update state behind.
+    The first identity depends only on the trusted requested channel. Once the
+    admitted bytes pass schema and channel policy, they are rebound to the exact
+    identity derived from authenticated ``release_kind`` + ``version``. Temporary
+    files live outside the updater cache, so rejection cannot stage update state.
     """
+    try:
+        admission_identity = manifest_admission_identity(channel)
+    except ValueError as exc:
+        raise UpdateManifestInvalid(
+            f"release manifest channel is invalid: {exc}",
+            details={"channel": channel, "error": str(exc)},
+        ) from exc
+
     url = releases_url(channel)
     try:
         raw_bytes = await _fetch_release_manifest_bytes(channel)
-        raw = _decode_release_manifest(raw_bytes, url)
     except OSError as exc:
         raise UpdateError(
             f"could not fetch release manifest: {exc}",
             details={"channel": channel, "url": url, "error": str(exc)},
-        ) from exc
-    except ValueError as exc:
-        raise UpdateError(
-            f"release manifest is not valid JSON: {exc}",
-            details={"channel": channel, "url": url, "error": str(exc)},
-        ) from exc
-
-    manifest = _parse_manifest(raw)
-    try:
-        validate_manifest_for_channel(manifest, channel)
-    except ValueError as exc:
-        raise UpdateManifestInvalid(
-            f"release manifest is not accepted for channel {channel!r}: {exc}",
-            details={"channel": channel, "error": str(exc)},
         ) from exc
 
     bundle_url = _release_manifest_bundle_url(url)
@@ -777,10 +800,46 @@ async def _fetch_verified_release_manifest(
             _verify_cosign,
             manifest_path,
             bundle_path,
-            identity_regexp=_MANIFEST_SIGNER_IDENTITY_REGEXP,
+            identity_regexp=admission_identity,
             issuer=_MANIFEST_SIGNER_ISSUER,
             job_id=job_id,
         )
+
+        try:
+            raw = _decode_release_manifest(raw_bytes, url)
+        except ValueError as exc:
+            raise UpdateError(
+                f"release manifest is not valid JSON: {exc}",
+                details={"channel": channel, "url": url, "error": str(exc)},
+            ) from exc
+        manifest = _parse_manifest(raw)
+        try:
+            validate_manifest_for_channel(manifest, channel)
+            exact_identity = exact_manifest_identity(manifest.release_kind, manifest.version)
+        except ValueError as exc:
+            raise UpdateManifestInvalid(
+                f"release manifest is not accepted for channel {channel!r}: {exc}",
+                details={"channel": channel, "error": str(exc)},
+            ) from exc
+        if manifest.signer_identity != exact_identity:
+            raise UpdateManifestInvalid(
+                "release manifest signer_identity does not match exact release identity",
+                details={
+                    "channel": channel,
+                    "expected_signer_identity": exact_identity,
+                    "manifest_signer_identity": manifest.signer_identity,
+                },
+            )
+
+        if exact_identity != admission_identity:
+            await asyncio.to_thread(
+                _verify_cosign,
+                manifest_path,
+                bundle_path,
+                identity_regexp=exact_identity,
+                issuer=_MANIFEST_SIGNER_ISSUER,
+                job_id=job_id,
+            )
 
     return raw, manifest, url
 
@@ -1769,12 +1828,14 @@ class Updater:
             )
         log.info("updater.sha256_ok", job_id=self.job_id, digest=got_digest)
 
-        # Step 5: cosign verify-blob.
+        # Step 5: verify against the identity derived from authenticated release
+        # policy, never a manifest-selected broader expression.
+        expected_identity = exact_manifest_identity(manifest.release_kind, manifest.version)
         await asyncio.to_thread(
             _verify_cosign,
             tarball_path,
             bundle_path,
-            identity_regexp=manifest.signer_identity,
+            identity_regexp=expected_identity,
             issuer=manifest.signer_issuer,
             job_id=self.job_id,
         )

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -366,26 +366,24 @@ def releases_url(channel: str = "stable") -> str:
     return f"https://releases.hal0.dev/{channel}.json"
 
 
-async def fetch_release_manifest(channel: str = "stable") -> dict[str, Any]:
-    """Fetch and parse the release manifest for ``channel``.
+def _release_manifest_bundle_url(manifest_url: str) -> str:
+    """Return the sibling Sigstore bundle URL for a channel manifest."""
+    parsed = urlparse(manifest_url)
+    if parsed.scheme in ("http", "https", "file"):
+        return parsed._replace(path=f"{parsed.path}.bundle").geturl()
+    return f"{manifest_url}.bundle"
 
-    Returns the parsed JSON dict. Supports both ``http(s)://`` URLs (via
-    httpx) and ``file://`` URLs / bare paths (for tests). Raises
-    ``OSError`` on transport failures and ``ValueError`` on bad JSON so
-    callers can produce typed envelopes.
-    """
+
+async def _fetch_release_manifest_bytes(channel: str = "stable") -> bytes:
+    """Fetch the exact manifest bytes so their sibling bundle can verify them."""
     url = releases_url(channel)
     parsed = urlparse(url)
     if parsed.scheme in ("", "file"):
         path = parsed.path if parsed.scheme == "file" else url
         try:
-            raw = Path(path).read_text(encoding="utf-8")
+            return Path(path).read_bytes()
         except OSError as exc:
             raise OSError(f"could not read release manifest at {path}: {exc}") from exc
-        try:
-            return json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"release manifest at {path} is not valid JSON: {exc}") from exc
 
     import httpx
 
@@ -396,10 +394,30 @@ async def fetch_release_manifest(channel: str = "stable") -> dict[str, Any]:
         raise OSError(f"release manifest fetch failed for {url}: {exc}") from exc
     if resp.status_code != 200:
         raise OSError(f"release manifest fetch returned HTTP {resp.status_code} from {url}")
+    return resp.content
+
+
+def _decode_release_manifest(raw_bytes: bytes, url: str) -> dict[str, Any]:
+    """Decode exact fetched bytes as a JSON object."""
     try:
-        return resp.json()
-    except ValueError as exc:
+        raw = json.loads(raw_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError(f"release manifest at {url} is not valid JSON: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"release manifest at {url} must be a JSON object")
+    return raw
+
+
+async def fetch_release_manifest(channel: str = "stable") -> dict[str, Any]:
+    """Fetch and parse the release manifest for ``channel``.
+
+    Returns the parsed JSON dict. Supports both ``http(s)://`` URLs (via
+    httpx) and ``file://`` URLs / bare paths (for tests). Raises
+    ``OSError`` on transport failures and ``ValueError`` on bad JSON so
+    callers can produce typed envelopes.
+    """
+    url = releases_url(channel)
+    return _decode_release_manifest(await _fetch_release_manifest_bytes(channel), url)
 
 
 def _parse_manifest(raw: dict[str, Any]) -> ReleaseManifest:
@@ -650,6 +668,57 @@ def _verify_cosign(
             },
         )
     log.info("updater.cosign_verify_ok", job_id=job_id)
+
+
+async def _fetch_verified_release_manifest(
+    channel: str, *, job_id: str | None = None
+) -> tuple[dict[str, Any], ReleaseManifest, str]:
+    """Fetch, validate, and authenticate a channel manifest and sibling bundle.
+
+    Verification uses the exact fetched JSON bytes and the existing mandatory
+    Cosign/OIDC primitive. Temporary files live outside the updater cache, so a
+    failed channel validation cannot leave staged update state behind.
+    """
+    url = releases_url(channel)
+    try:
+        raw_bytes = await _fetch_release_manifest_bytes(channel)
+        raw = _decode_release_manifest(raw_bytes, url)
+    except OSError as exc:
+        raise UpdateError(
+            f"could not fetch release manifest: {exc}",
+            details={"channel": channel, "url": url, "error": str(exc)},
+        ) from exc
+    except ValueError as exc:
+        raise UpdateError(
+            f"release manifest is not valid JSON: {exc}",
+            details={"channel": channel, "url": url, "error": str(exc)},
+        ) from exc
+
+    manifest = _parse_manifest(raw)
+    try:
+        validate_manifest_for_channel(manifest, channel)
+    except ValueError as exc:
+        raise UpdateManifestInvalid(
+            f"release manifest is not accepted for channel {channel!r}: {exc}",
+            details={"channel": channel, "error": str(exc)},
+        ) from exc
+
+    bundle_url = _release_manifest_bundle_url(url)
+    with tempfile.TemporaryDirectory(prefix="hal0-manifest-") as work:
+        manifest_path = Path(work) / "manifest.json"
+        bundle_path = Path(work) / "manifest.json.bundle"
+        manifest_path.write_bytes(raw_bytes)
+        await _download(bundle_url, bundle_path)
+        await asyncio.to_thread(
+            _verify_cosign,
+            manifest_path,
+            bundle_path,
+            identity_regexp=manifest.signer_identity,
+            issuer=manifest.signer_issuer,
+            job_id=job_id,
+        )
+
+    return raw, manifest, url
 
 
 # ── Extraction + migration helpers ─────────────────────────────────────────────
@@ -1510,28 +1579,7 @@ class Updater:
             UpdateManifestInvalid: Manifest is missing required fields.
         """
         ch = channel or self.channel
-        url = releases_url(ch)
-        try:
-            raw = await fetch_release_manifest(ch)
-        except OSError as exc:
-            raise UpdateError(
-                f"could not fetch release manifest: {exc}",
-                details={"channel": ch, "url": url, "error": str(exc)},
-            ) from exc
-        except ValueError as exc:
-            raise UpdateError(
-                f"release manifest is not valid JSON: {exc}",
-                details={"channel": ch, "url": url, "error": str(exc)},
-            ) from exc
-
-        manifest = _parse_manifest(raw)
-        try:
-            validate_manifest_for_channel(manifest, ch)
-        except ValueError as exc:
-            raise UpdateManifestInvalid(
-                f"release manifest is not accepted for channel {ch!r}: {exc}",
-                details={"channel": ch, "error": str(exc)},
-            ) from exc
+        raw, manifest, url = await _fetch_verified_release_manifest(ch, job_id=self.job_id)
 
         latest = manifest.version
         revoked = manifest.revoked
@@ -1596,23 +1644,9 @@ class Updater:
         # silently extract a tarball that is never actually loaded.
         _raise_if_editable_install()
 
-        # Step 1: fetch + validate manifest.
+        # Step 1: fetch, validate, and authenticate the manifest itself.
         log.info("updater.prepare_start", job_id=self.job_id, channel=self.channel, pinned=version)
-        try:
-            raw = await fetch_release_manifest(self.channel)
-        except (OSError, ValueError) as exc:
-            raise UpdateError(
-                f"could not fetch release manifest: {exc}",
-                details={"channel": self.channel, "error": str(exc)},
-            ) from exc
-        manifest = _parse_manifest(raw)
-        try:
-            validate_manifest_for_channel(manifest, self.channel)
-        except ValueError as exc:
-            raise UpdateManifestInvalid(
-                f"release manifest is not accepted for channel {self.channel!r}: {exc}",
-                details={"channel": self.channel, "error": str(exc)},
-            ) from exc
+        raw, manifest, _ = await _fetch_verified_release_manifest(self.channel, job_id=self.job_id)
 
         # Step 2: confirm target version.
         target_version = (version or "").strip() or manifest.version

--- a/tests/api/test_typed_errors.py
+++ b/tests/api/test_typed_errors.py
@@ -440,22 +440,32 @@ def test_route_validation_returns_typed_4xx(
     assert isinstance(envelope["error"]["details"], dict)
 
 
-def test_updater_channel_invalid_after_validation(slot_client: TestClient) -> None:
-    """updater.py:331 — Hal0Config rejecting a merged channel value surfaces
-    as ``channel.invalid`` (400), not as a 500.
+def test_updater_channel_invalid_after_validation(
+    slot_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The valid nightly channel is checked and persisted without network I/O.
 
-    This path is hard to trigger via the public PUT because the prior
-    allowlist check (line 318 → ``channel.unknown``) catches every bad
-    value first. We exercise it by stuffing a synthetic config into
-    app.state where ``model_dump`` produces a payload that re-validates
-    cleanly, then making sure the route doesn't 500 on the happy path —
-    a regression here would mean the secondary validation try/except
-    swallowed the wrong exception class.
+    The real HTTP route, allowlist, config merge, pydantic validation, and
+    atomic persistence path all run. Only the updater's remote manifest check
+    is replaced with a recording async seam so this happy path is hermetic.
     """
-    # The happy-path call must still 200 — covers the "no exception" branch.
+    checked_channels: list[str] = []
+
+    async def record_check(updater: Any) -> None:
+        checked_channels.append(updater.channel)
+
+    monkeypatch.setattr("hal0.api.routes.updater.Updater.check", record_check)
+
     r = slot_client.put("/api/updates/channel", json={"channel": "nightly"})
+
     assert r.status_code == 200, r.text
     assert r.json() == {"channel": "nightly"}
+    assert checked_channels == ["nightly"]
+    assert slot_client.app.state.hal0_config.telemetry.channel == "nightly"
+
+    from hal0.config.loader import load_hal0_config
+
+    assert load_hal0_config().telemetry.channel == "nightly"
 
 
 def test_models_unknown_id_returns_404_not_found(slot_client: TestClient) -> None:

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -42,7 +42,16 @@ def isolated_client(
     """TestClient with HAL0_RELEASES_URL pointing at a tmp file."""
     manifest = _write_manifest(
         tmp_path / "latest.json",
-        {"version": "9.9.9", "url": "https://example.test/hal0-9.9.9.tar.gz"},
+        {
+            "_schema": "hal0.releases.v1",
+            "version": "9.9.9",
+            "channel": "stable",
+            "release_kind": "stable",
+            "url": "https://example.test/hal0-9.9.9.tar.gz",
+            "bundle_url": "https://example.test/hal0-9.9.9.tar.gz.bundle",
+            "digest_sha256": "0" * 64,
+            "signer_identity": "^https://github\\.com/hal0ai/hal0/.*",
+        },
     )
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest))
 
@@ -345,6 +354,11 @@ def test_channel_get_returns_stable_default(isolated_client: TestClient) -> None
 
 def test_channel_put_persists_to_hal0_toml(isolated_client: TestClient, tmp_hal0_home: str) -> None:
     """PUT /api/updates/channel writes telemetry.channel into hal0.toml."""
+    manifest_path = isolated_client.__dict__["_manifest_path"]
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.update(channel="nightly", release_kind="nightly")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
     r = isolated_client.put("/api/updates/channel", json={"channel": "nightly"})
     assert r.status_code == 200, r.text
     assert r.json() == {"channel": "nightly"}
@@ -360,6 +374,39 @@ def test_channel_put_persists_to_hal0_toml(isolated_client: TestClient, tmp_hal0
     # GET reflects the change.
     r2 = isolated_client.get("/api/updates/channel")
     assert r2.json() == {"channel": "nightly"}
+
+
+def test_channel_put_accepts_preview(isolated_client: TestClient, tmp_hal0_home: str) -> None:
+    manifest_path = isolated_client.__dict__["_manifest_path"]
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.update(
+        version="9.9.9-alpha.1",
+        channel="preview",
+        release_kind="preview",
+        prerelease_stage="alpha",
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"channel": "preview"}
+
+
+def test_channel_put_keeps_previous_channel_when_validation_fails(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    config_path = Path(tmp_hal0_home) / "etc" / "hal0" / "hal0.toml"
+    initial = isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+    assert initial.status_code == 200, initial.text
+    previous_contents = config_path.read_bytes()
+
+    # The preview URL resolves, but serves a stable-channel manifest.
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+
+    assert response.status_code in {400, 502}
+    assert config_path.read_bytes() == previous_contents
+    assert isolated_client.get("/api/updates/channel").json() == {"channel": "stable"}
 
 
 def test_channel_put_invalid_value_returns_envelope(isolated_client: TestClient) -> None:

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -789,15 +789,16 @@ def test_commit_route_requires_version(isolated_client: TestClient) -> None:
         ("v1.2.3", "1.2.3"),
         ("1.2.3-rc.1", "1.2.3-rc.1"),
         ("1.2.3-nightly.20260721060000", "1.2.3-nightly.20260721060000"),
+        ("1.2.3-nightly.20260721", "1.2.3-nightly.20260721"),
     ],
 )
-def test_commit_route_accepts_canonical_version_before_queueing(
+def test_commit_route_accepts_supported_version_before_queueing(
     supplied: str,
     normalized: str,
     isolated_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Canonical versions queue, including compatible single-leading-v input."""
+    """Current and legacy-compatible versions queue after leading-v normalization."""
     from hal0.api.routes import updater as u_mod
 
     def discard_task(request: object, coro: Any) -> None:
@@ -821,6 +822,9 @@ def test_commit_route_accepts_canonical_version_before_queueing(
         "/tmp/outside",
         " 1.2.3 ",
         "1.2.3-preview.1",
+        "1.2.3-nightly.2026072",
+        "1.2.3-nightly.202607210",
+        "1.2.3-nightly.2026072106",
     ],
 )
 def test_commit_route_rejects_invalid_version_before_queueing(

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -53,7 +53,9 @@ def isolated_client(
             "signer_identity": "^https://github\\.com/hal0ai/hal0/.*",
         },
     )
+    Path(f"{manifest}.bundle").write_bytes(b"manifest-bundle-placeholder\n")
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest))
+    monkeypatch.setattr("hal0.updater.updater._verify_cosign", lambda *args, **kwargs: None)
 
     app: FastAPI = create_app()
     with TestClient(app) as c:
@@ -407,6 +409,92 @@ def test_channel_put_keeps_previous_channel_when_validation_fails(
     assert response.status_code in {400, 502}
     assert config_path.read_bytes() == previous_contents
     assert isolated_client.get("/api/updates/channel").json() == {"channel": "stable"}
+
+
+def test_same_channel_put_rejects_invalid_manifest_without_mutation(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """An idempotent PUT must still authenticate the current channel manifest."""
+    config_path = Path(tmp_hal0_home) / "etc" / "hal0" / "hal0.toml"
+    initial = isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+    assert initial.status_code == 200, initial.text
+    previous_contents = config_path.read_bytes()
+    previous_config = isolated_client.app.state.hal0_config
+    cache_path = Path(tmp_hal0_home) / "var-lib" / "hal0" / "cache"
+    assert not cache_path.exists()
+
+    manifest_path = isolated_client.__dict__["_manifest_path"]
+    manifest_path.write_text("{not json", encoding="utf-8")
+
+    response = isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "system.update_error"
+    assert config_path.read_bytes() == previous_contents
+    assert isolated_client.app.state.hal0_config is previous_config
+    assert not cache_path.exists()
+
+
+def test_channel_put_rejects_malformed_target_manifest_without_mutation(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """Schema-invalid signing metadata cannot authorize a channel switch."""
+    config_path = Path(tmp_hal0_home) / "etc" / "hal0" / "hal0.toml"
+    initial = isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+    assert initial.status_code == 200, initial.text
+    previous_contents = config_path.read_bytes()
+    previous_config = isolated_client.app.state.hal0_config
+
+    manifest_path = isolated_client.__dict__["_manifest_path"]
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.update(channel="preview", release_kind="preview", prerelease_stage="beta")
+    manifest.pop("bundle_url")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "system.update_manifest_invalid"
+    assert config_path.read_bytes() == previous_contents
+    assert isolated_client.app.state.hal0_config is previous_config
+
+
+def test_channel_put_rejects_signature_invalid_manifest_without_mutation(
+    isolated_client: TestClient, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A reachable coherent manifest must not persist unless its bundle verifies."""
+    from hal0.updater import UpdateCosignFailed
+
+    config_path = Path(tmp_hal0_home) / "etc" / "hal0" / "hal0.toml"
+    initial = isolated_client.put("/api/updates/channel", json={"channel": "stable"})
+    assert initial.status_code == 200, initial.text
+    previous_contents = config_path.read_bytes()
+    previous_config = isolated_client.app.state.hal0_config
+    cache_path = Path(tmp_hal0_home) / "var-lib" / "hal0" / "cache"
+    assert not cache_path.exists()
+
+    manifest_path = isolated_client.__dict__["_manifest_path"]
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.update(
+        version="9.9.9-rc.1",
+        channel="preview",
+        release_kind="preview",
+        prerelease_stage="rc",
+    )
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    def reject_signature(*args: object, **kwargs: object) -> None:
+        raise UpdateCosignFailed("test signature rejected")
+
+    monkeypatch.setattr("hal0.updater.updater._verify_cosign", reject_signature)
+
+    response = isolated_client.put("/api/updates/channel", json={"channel": "preview"})
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "system.update_cosign_failed"
+    assert config_path.read_bytes() == previous_contents
+    assert isolated_client.app.state.hal0_config is previous_config
+    assert not cache_path.exists()
 
 
 def test_channel_put_invalid_value_returns_envelope(isolated_client: TestClient) -> None:

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -681,6 +681,44 @@ def test_apply_target_strips_leading_v(
 # ── prepare / commit split ─────────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize("endpoint", ["prepare", "apply"])
+def test_version_pin_mismatch_fails_update_job(
+    endpoint: str,
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API prepare/apply jobs preserve the updater's typed pin-mismatch failure."""
+    from hal0.api.routes import updater as u_mod
+    from hal0.updater import UpdateManifestInvalid
+
+    async def reject_pin(self: object, version: str | None = None) -> dict:
+        raise UpdateManifestInvalid(
+            "requested version does not match authenticated channel manifest",
+            details={
+                "channel": "stable",
+                "requested_version": version,
+                "manifest_version": "9.9.9",
+            },
+        )
+
+    monkeypatch.setattr(u_mod.Updater, endpoint, reject_pin)
+    response = isolated_client.post(f"/api/updates/{endpoint}", json={"version": "0.0.1"})
+    assert response.status_code == 202, response.text
+    job_id = response.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] in ("prepared", "applied", "failed"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") == "failed", final
+    assert final.get("error_code") == "UpdateManifestInvalid"
+    assert "authenticated channel manifest" in final.get("error", "")
+
+
 def test_prepare_route_returns_queued_prepare_job(isolated_client: TestClient) -> None:
     """POST /api/updates/prepare returns a queued job tagged phase=prepare."""
     r = isolated_client.post("/api/updates/prepare", json={})

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -51,7 +51,10 @@ def isolated_client(
             "url": "https://example.test/hal0-9.9.9.tar.gz",
             "bundle_url": "https://example.test/hal0-9.9.9.tar.gz.bundle",
             "digest_sha256": "0" * 64,
-            "signer_identity": "^https://github\\.com/hal0ai/hal0/.*",
+            "signer_identity": (
+                r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+                r"\.github/workflows/release\.yml@refs/tags/v9\.9\.9$"
+            ),
         },
     )
     Path(f"{manifest}.bundle").write_bytes(b"manifest-bundle-placeholder\n")
@@ -359,7 +362,15 @@ def test_channel_put_persists_to_hal0_toml(isolated_client: TestClient, tmp_hal0
     """PUT /api/updates/channel writes telemetry.channel into hal0.toml."""
     manifest_path = isolated_client.__dict__["_manifest_path"]
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    manifest.update(channel="nightly", release_kind="nightly")
+    manifest.update(
+        version="9.9.9-nightly.20260722123000",
+        channel="nightly",
+        release_kind="nightly",
+        signer_identity=(
+            r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+            r"\.github/workflows/release\.yml@refs/heads/main$"
+        ),
+    )
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
     r = isolated_client.put("/api/updates/channel", json={"channel": "nightly"})
@@ -387,6 +398,10 @@ def test_channel_put_accepts_preview(isolated_client: TestClient, tmp_hal0_home:
         channel="preview",
         release_kind="preview",
         prerelease_stage="alpha",
+        signer_identity=(
+            r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+            r"\.github/workflows/release\.yml@refs/tags/v9\.9\.9-alpha\.1$"
+        ),
     )
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
@@ -481,6 +496,10 @@ def test_channel_put_rejects_signature_invalid_manifest_without_mutation(
         channel="preview",
         release_kind="preview",
         prerelease_stage="rc",
+        signer_identity=(
+            r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+            r"\.github/workflows/release\.yml@refs/tags/v9\.9\.9-rc\.1$"
+        ),
     )
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -10,6 +10,7 @@ import json
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -781,11 +782,62 @@ def test_commit_route_requires_version(isolated_client: TestClient) -> None:
     assert "error" in body
 
 
-def test_commit_route_accepts_version(isolated_client: TestClient) -> None:
-    """POST /api/updates/commit with a version queues a phase=commit job (202)."""
-    r = isolated_client.post("/api/updates/commit", json={"version": "0.0.1"})
+@pytest.mark.parametrize(
+    ("supplied", "normalized"),
+    [
+        ("1.2.3", "1.2.3"),
+        ("v1.2.3", "1.2.3"),
+        ("1.2.3-rc.1", "1.2.3-rc.1"),
+        ("1.2.3-nightly.20260721060000", "1.2.3-nightly.20260721060000"),
+    ],
+)
+def test_commit_route_accepts_canonical_version_before_queueing(
+    supplied: str,
+    normalized: str,
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canonical versions queue, including compatible single-leading-v input."""
+    from hal0.api.routes import updater as u_mod
+
+    def discard_task(request: object, coro: Any) -> None:
+        coro.close()
+
+    monkeypatch.setattr(u_mod, "_spawn_update_task", discard_task)
+    r = isolated_client.post("/api/updates/commit", json={"version": supplied})
     assert r.status_code == 202, r.text
     body = r.json()
     assert body["phase"] == "commit"
     assert body["state"] == "queued"
-    assert body["version"] == "0.0.1"
+    assert body["version"] == normalized
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "../../outside",
+        "1.2.3/../../outside",
+        r"1.2.3\..\outside",
+        "/tmp/outside",
+        " 1.2.3 ",
+        "1.2.3-preview.1",
+    ],
+)
+def test_commit_route_rejects_invalid_version_before_queueing(
+    version: str,
+    isolated_client: TestClient,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hostile commit labels return a typed 400 without touching job storage."""
+    from hal0.api.routes import updater as u_mod
+
+    def unexpected_jobs(request: object) -> dict:
+        raise AssertionError("invalid commit version reached the update queue")
+
+    monkeypatch.setattr(u_mod, "_update_jobs", unexpected_jobs)
+    response = isolated_client.post("/api/updates/commit", json={"version": version})
+
+    assert response.status_code == 400, response.text
+    assert response.json()["error"]["code"] == "validation.invalid"
+    assert not (Path(tmp_hal0_home) / "var-lib" / "hal0" / "update-jobs").exists()

--- a/tests/cli/test_doctor_bundle.py
+++ b/tests/cli/test_doctor_bundle.py
@@ -1,8 +1,8 @@
 """Tests for ``hal0 doctor bundle`` (§21.4 §3).
 
-Runs the real ``build_bundle`` orchestration against ``tmp_hal0_home`` (no
-live API, no real podman/systemd — this dev sandbox has neither, which is
-exactly the "graceful degrade" path §21.4 HARD REQUIREMENT #5 calls for).
+Runs the real ``build_bundle`` orchestration against ``tmp_hal0_home`` with
+no live API. Tests that assert missing-tool degradation force that condition
+explicitly instead of depending on binaries installed in the test sandbox.
 Asserts: the layout lands, the manifest is well-formed, ``commands.tsv`` has
 one row per probe, and a sensitive-keyed ``hal0.toml`` value gets redacted
 rather than echoed.
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+from hal0.cli import doctor_bundle
 from hal0.cli.doctor_bundle import build_bundle
 
 
@@ -29,7 +30,22 @@ def _no_live_api(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_shared, "api_get", _boom)
 
 
-def test_bundle_layout_matches_spec(tmp_hal0_home: str, tmp_path: Path) -> None:
+def _force_rocminfo_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make only rocminfo unavailable while preserving every other real probe."""
+    original_run = doctor_bundle.subprocess.run
+
+    def run_without_rocminfo(argv, *args, **kwargs):
+        if argv[0] == "rocminfo":
+            raise FileNotFoundError("forced missing rocminfo")
+        return original_run(argv, *args, **kwargs)
+
+    monkeypatch.setattr(doctor_bundle.subprocess, "run", run_without_rocminfo)
+
+
+def test_bundle_layout_matches_spec(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _force_rocminfo_missing(monkeypatch)
     out = tmp_path / "bundle"
     written, _failed = build_bundle(out)
 
@@ -41,8 +57,7 @@ def test_bundle_layout_matches_spec(tmp_hal0_home: str, tmp_path: Path) -> None:
     assert (out / "doctor-summary.txt").is_file()
     # Every _CORE_PROBES command produced SOME file (present or a stub).
     assert (out / "system" / "uname.txt").is_file()
-    # Missing binaries (rocminfo etc, absent on this sandbox) degrade to a
-    # stub, not a crash.
+    # The deterministically missing rocminfo binary degrades to a stub.
     assert "not found" in (out / "system" / "rocminfo.txt").read_text()
 
 
@@ -146,9 +161,10 @@ def test_bundle_no_logs_flag_skips_logs_dir(tmp_hal0_home: str, tmp_path: Path) 
 
 
 def test_bundle_returns_nonzero_failed_count_when_probes_missing(
-    tmp_hal0_home: str, tmp_path: Path
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _force_rocminfo_missing(monkeypatch)
     out = tmp_path / "bundle"
     _, failed = build_bundle(out, include_rocm_smi=True)
-    # rocminfo/rocm-smi/podman/ss are all absent on this dev sandbox.
+    # The forced rocminfo failure guarantees at least one failed probe.
     assert failed > 0

--- a/tests/cli/test_slot_migrate_hw.py
+++ b/tests/cli/test_slot_migrate_hw.py
@@ -57,8 +57,9 @@ def test_apply_folds_slot_image_to_image_pin_and_backs_up(
         'name = "chat"\nport = 8081\nimage = "ghcr.io/test/custom:v1"\n',
     )
 
-    # No live systemd in the test env — _active_hal0_units reports nothing, so
-    # the safety gate passes; --apply performs the real (filesystem) fold.
+    # Exercise the filesystem fold independently of host systemd state. The
+    # safety gate itself retains dedicated coverage in the id-keying tests.
+    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
     slot_migrate_hw(apply=True, yes=True, stop_services=False)
 
     raw = tomllib.loads(slot.read_text(encoding="utf-8"))

--- a/tests/cli/test_slot_migrate_id_keying.py
+++ b/tests/cli/test_slot_migrate_id_keying.py
@@ -178,8 +178,9 @@ def test_command_migrates_tree_and_writes_backup(
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / "chat.toml").write_text('[slot]\nname = "chat"\nport = 8081\n')
 
-    # No live systemd in the test env — _active_hal0_units naturally reports
-    # nothing running (FileNotFoundError path), so the safety gate passes.
+    # Exercise the filesystem migration independently of host systemd state.
+    # The safety gate keeps its dedicated coverage above.
+    monkeypatch.setattr("hal0.cli.slot_commands._active_hal0_units", lambda: [])
     slot_migrate_id_keying(yes=True, stop_services=False, dry_run=False)
 
     remaining = sorted(p.name for p in config_dir.glob("*.toml"))

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -211,6 +211,31 @@ def test_target_without_v_is_unchanged(stub_api: dict, monkeypatch: pytest.Monke
     assert stub_api["prepare_json"] == {"version": "0.1.1"}
 
 
+def test_prepare_pin_mismatch_never_posts_commit(
+    stub_api: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed prepare job stops the CLI before the activation request."""
+
+    def failed_poll(
+        job_id: str, *, terminal: tuple = ("applied", "failed"), **kwargs: object
+    ) -> dict:
+        return {
+            "id": job_id,
+            "state": "failed",
+            "error": "requested version does not match authenticated channel manifest",
+        }
+
+    monkeypatch.setattr(uc, "_poll_job", failed_poll)
+
+    result = runner.invoke(app, ["update", "--target", "0.1.1"])
+
+    assert result.exit_code != 0
+    assert "authenticated channel" in result.output
+    assert "manifest" in result.output
+    assert stub_api["prepare_json"] == {"version": "0.1.1"}
+    assert stub_api["commit_json"] is None
+
+
 def test_prepare_then_commit_flow(stub_api: dict, monkeypatch: pytest.MonkeyPatch) -> None:
     """The CLI stages via /prepare, then activates via /commit with the resolved version."""
     result = runner.invoke(app, ["update", "--target", "0.1.1"])

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -10,12 +10,14 @@ running daemon.
 from __future__ import annotations
 
 import inspect
+from typing import get_args
 
 import pytest
 from typer.testing import CliRunner
 
 from hal0.cli import update_commands as uc
 from hal0.cli.main import app
+from hal0.release.policy import ReleaseKind
 
 runner = CliRunner()
 
@@ -83,13 +85,24 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     return captured
 
 
-def test_preview_channel_posts_preview_payload(stub_api: dict) -> None:
-    assert uc.UpdateChannel.preview.value == "preview"
+def test_update_channel_values_match_shared_release_kinds() -> None:
+    assert {channel.value for channel in uc.UpdateChannel} == set(get_args(ReleaseKind))
 
-    result = runner.invoke(app, ["update", "--channel", "preview", "--check"])
+
+@pytest.mark.parametrize("channel", get_args(ReleaseKind))
+def test_channel_posts_shared_release_kind_payload(channel: str, stub_api: dict) -> None:
+    result = runner.invoke(app, ["update", "--channel", channel, "--check"])
 
     assert result.exit_code == 0, result.output
-    assert stub_api["put_json"] == {"channel": "preview"}
+    assert stub_api["put_json"] == {"channel": channel}
+
+
+def test_channel_help_lists_all_shared_release_kinds() -> None:
+    result = runner.invoke(app, ["update", "--help"])
+
+    assert result.exit_code == 0, result.output
+    for channel in get_args(ReleaseKind):
+        assert channel in result.output
 
 
 def test_restart_slots_flag_present_and_drift_aware() -> None:

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -83,6 +83,15 @@ def stub_api(monkeypatch: pytest.MonkeyPatch) -> dict:
     return captured
 
 
+def test_preview_channel_posts_preview_payload(stub_api: dict) -> None:
+    assert uc.UpdateChannel.preview.value == "preview"
+
+    result = runner.invoke(app, ["update", "--channel", "preview", "--check"])
+
+    assert result.exit_code == 0, result.output
+    assert stub_api["put_json"] == {"channel": "preview"}
+
+
 def test_restart_slots_flag_present_and_drift_aware() -> None:
     """``--restart-slots`` is back — but drift-aware, via the API (WS-J, #1111).
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -416,6 +416,9 @@ class TestHal0Config:
         assert c.telemetry.enabled is False
         assert c.telemetry.channel == "stable"
 
+    def test_preview_channel_is_valid(self) -> None:
+        assert TelemetryConfig(channel="preview").channel == "preview"
+
     def test_invalid_channel_raises(self) -> None:
         with pytest.raises(ValidationError) as ei:
             TelemetryConfig(channel="beta")

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -48,6 +48,7 @@ def _bootstrap_env(
     for tool in (
         "awk",
         "bash",
+        "cat",
         "gzip",
         "uname",
         "mktemp",
@@ -82,6 +83,11 @@ while (($#)); do
     case "$1" in
         -o) out="$2"; shift 2 ;;
         --retry|--retry-delay) shift 2 ;;
+        --url) url="$2"; shift 2 ;;
+        --config=*)
+            cat "${{1#*=}}" > "$CONFIG_READ_LOG"
+            shift
+            ;;
         -*) shift ;;
         *) url="$1"; shift ;;
     esac
@@ -114,6 +120,8 @@ exit "$COSIGN_RC"
         "ARTIFACT_FIXTURE": str(artifact_fixture or ""),
         "ARTIFACT_URL": artifact_url,
         "ARTIFACT_BUNDLE_URL": artifact_bundle_url,
+        "CONFIG_READ_LOG": str(tmp_path / "config-read.log"),
+        "TMPDIR": str(tmp_path),
     }
     return env, curl_log, cosign_log
 
@@ -337,6 +345,94 @@ def test_authenticated_malformed_manifest_rejected_before_artifact_io(
         f"https://releases.hal0.dev/{requested_channel}.json.bundle",
     ]
     assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
+
+
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        pytest.param(
+            json.dumps({"not": "a release manifest"}).encode()
+            + b"\n"
+            + json.dumps(_valid_manifest()).encode(),
+            id="invalid-then-valid",
+        ),
+        pytest.param(
+            json.dumps(_valid_manifest()).encode()
+            + b"\n"
+            + json.dumps(_valid_manifest()).encode(),
+            id="valid-then-valid",
+        ),
+        pytest.param(
+            json.dumps(_valid_manifest()).encode() + b"\ntrue",
+            id="valid-then-trailing-value",
+        ),
+    ],
+)
+def test_authenticated_manifest_must_contain_exactly_one_json_value(
+    tmp_path: Path,
+    manifest: bytes,
+) -> None:
+    env, curl_log, cosign_log = _bootstrap_env(tmp_path, manifest, cosign_rc=0)
+    env["HAL0_BOOTSTRAP_KEEP_TMP"] = "1"
+    install_log = tmp_path / "install.log"
+    env["INSTALL_LOG"] = str(install_log)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "authenticated release manifest failed strict policy validation" in proc.stderr
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://releases.hal0.dev/stable.json",
+        "https://releases.hal0.dev/stable.json.bundle",
+    ]
+    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
+    assert not install_log.exists()
+    assert not list(tmp_path.glob("hal0-install-*/artifact.tar.gz"))
+
+
+@pytest.mark.parametrize("hostile_field", ["url", "bundle_url"])
+def test_authenticated_option_like_artifact_urls_are_explicit_curl_urls(
+    tmp_path: Path,
+    hostile_field: str,
+) -> None:
+    artifact = tmp_path / "artifact.fixture"
+    artifact.write_bytes(b"authenticated artifact fixture")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    curl_config = tmp_path / "hostile.curlrc"
+    curl_config.write_text("url = file:///etc/passwd\n", encoding="utf-8")
+    hostile_url = f"--config={curl_config}"
+    artifact_url = "https://fixtures.example/hal0.tar.gz"
+    artifact_bundle_url = "https://fixtures.example/hal0.tar.gz.bundle"
+    manifest = _valid_manifest()
+    manifest.update(
+        {
+            "url": hostile_url if hostile_field == "url" else artifact_url,
+            "bundle_url": hostile_url if hostile_field == "bundle_url" else artifact_bundle_url,
+            "digest_sha256": digest,
+        }
+    )
+    env, curl_log, cosign_log = _bootstrap_env(
+        tmp_path,
+        json.dumps(manifest).encode(),
+        cosign_rc=0,
+        artifact_fixture=artifact,
+        artifact_url=artifact_url,
+        artifact_bundle_url=artifact_bundle_url,
+    )
+    env["HAL0_BOOTSTRAP_KEEP_TMP"] = "1"
+    install_log = tmp_path / "install.log"
+    env["INSTALL_LOG"] = str(install_log)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert curl_log.read_text(encoding="utf-8").splitlines()[-1] == hostile_url
+    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
+    assert not Path(env["CONFIG_READ_LOG"]).exists()
+    assert not install_log.exists()
+    assert not list(tmp_path.glob("hal0-install-*/artifact.tar.gz.bundle"))
+    if hostile_field == "url":
+        assert not list(tmp_path.glob("hal0-install-*/artifact.tar.gz"))
 
 
 def test_bootstrap_missing_cosign_fails_closed_for_channel_manifest(

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -1,0 +1,215 @@
+"""Behavioral contracts for the release-manifest bootstrap trust boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
+_CANONICAL_IDENTITY = (
+    r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+    r"\.github/workflows/release\.yml@"
+    r"(refs/tags/v\d+\.\d+\.\d+"
+    r"(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?"
+    r"|refs/heads/main)$"
+)
+_CANONICAL_ISSUER = "https://token.actions.githubusercontent.com"
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _bootstrap_env(
+    tmp_path: Path,
+    manifest: bytes,
+    *,
+    with_cosign: bool = True,
+    cosign_rc: int = 1,
+) -> tuple[dict[str, str], Path, Path]:
+    """Build a hermetic PATH that records network and cosign behavior."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for tool in ("bash", "uname", "mktemp", "rm", "tar", "sha256sum", "python3"):
+        target = shutil.which(tool)
+        assert target is not None
+        os.symlink(target, bin_dir / tool)
+
+    manifest_fixture = tmp_path / "manifest.fixture"
+    manifest_fixture.write_bytes(manifest)
+    curl_log = tmp_path / "curl.log"
+    cosign_log = tmp_path / "cosign.log"
+
+    cp = shutil.which("cp")
+    assert cp is not None
+    _write_executable(
+        bin_dir / "curl",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+out=""
+url=""
+while (($#)); do
+    case "$1" in
+        -o) out="$2"; shift 2 ;;
+        --retry|--retry-delay) shift 2 ;;
+        -*) shift ;;
+        *) url="$1"; shift ;;
+    esac
+done
+printf '%s\\n' "$url" >> "$CURL_LOG"
+case "$url" in
+    *.json|*.json\\?*) {cp} "$MANIFEST_FIXTURE" "$out" ;;
+    *.json.bundle|*.json.bundle\\?*) printf 'fixture bundle\\n' > "$out" ;;
+    *) exit 22 ;;
+esac
+""",
+    )
+    if with_cosign:
+        _write_executable(
+            bin_dir / "cosign",
+            """#!/usr/bin/env bash
+printf '%s\\n' "$@" > "$COSIGN_LOG"
+exit "$COSIGN_RC"
+""",
+        )
+
+    env = {
+        "PATH": str(bin_dir),
+        "CURL_LOG": str(curl_log),
+        "COSIGN_LOG": str(cosign_log),
+        "COSIGN_RC": str(cosign_rc),
+        "MANIFEST_FIXTURE": str(manifest_fixture),
+    }
+    return env, curl_log, cosign_log
+
+
+def _run_bootstrap(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["/bin/bash", str(_BOOTSTRAP)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_bootstrap_uses_canonical_channel_endpoint() -> None:
+    script = _BOOTSTRAP.read_text(encoding="utf-8")
+    assert "https://releases.hal0.dev/${HAL0_CHANNEL}.json" in script
+    assert "/releases/latest/download" not in script
+
+
+@pytest.mark.parametrize("channel", ["stable", "preview", "nightly"])
+def test_bootstrap_accepts_supported_channels_and_fetches_exact_sibling_bundle(
+    tmp_path: Path, channel: str
+) -> None:
+    env, curl_log, _ = _bootstrap_env(tmp_path, b"{not trusted yet")
+    env["HAL0_CHANNEL"] = channel
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        f"https://releases.hal0.dev/{channel}.json",
+        f"https://releases.hal0.dev/{channel}.json.bundle",
+    ]
+
+
+@pytest.mark.parametrize("channel", ["beta", "PREVIEW", "stable/../../owned"])
+def test_bootstrap_rejects_invalid_channel_before_network(
+    tmp_path: Path, channel: str
+) -> None:
+    env, curl_log, _ = _bootstrap_env(tmp_path, b"{}")
+    env["HAL0_CHANNEL"] = channel
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "HAL0_CHANNEL must be one of: stable, preview, nightly" in proc.stderr
+    assert not curl_log.exists()
+
+
+def test_bootstrap_preserves_override_and_places_bundle_before_query(
+    tmp_path: Path,
+) -> None:
+    env, curl_log, _ = _bootstrap_env(tmp_path, b"{not trusted yet")
+    env["HAL0_CHANNEL"] = "preview"
+    env["HAL0_RELEASES_URL"] = "https://mirror.example/pointers/custom.json?token=test"
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://mirror.example/pointers/custom.json?token=test",
+        "https://mirror.example/pointers/custom.json.bundle?token=test",
+    ]
+
+
+def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
+    tmp_path: Path,
+) -> None:
+    manifest = b'{"url":"https://attacker.example/untrusted.tar.gz"}'
+    env, curl_log, cosign_log = _bootstrap_env(tmp_path, manifest, cosign_rc=1)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "release manifest signature verification FAILED" in proc.stderr
+    assert "attacker.example" not in curl_log.read_text(encoding="utf-8")
+    args = cosign_log.read_text(encoding="utf-8").splitlines()
+    assert args[0] == "verify-blob"
+    assert args[1] == "--bundle"
+    assert args[2].endswith("/manifest.json.bundle")
+    assert args[3:5] == ["--certificate-identity-regexp", _CANONICAL_IDENTITY]
+    assert args[5:7] == ["--certificate-oidc-issuer", _CANONICAL_ISSUER]
+    assert args[-1].endswith("/manifest.json")
+
+
+def test_stable_bootstrap_rejects_authenticated_preview_artifact(
+    tmp_path: Path,
+) -> None:
+    manifest = json.dumps(
+        {
+            "version": "1.0.0-rc.1",
+            "channel": "stable",
+            "release_kind": "preview",
+            "prerelease_stage": "rc",
+            "url": "https://attacker.example/preview.tar.gz",
+            "bundle_url": "https://attacker.example/preview.tar.gz.bundle",
+            "digest_sha256": "0" * 64,
+            "signer_identity": "untrusted-until-manifest-verification",
+        }
+    ).encode()
+    env, curl_log, _ = _bootstrap_env(tmp_path, manifest, cosign_rc=0)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "release kind preview is not accepted for channel stable" in proc.stderr
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://releases.hal0.dev/stable.json",
+        "https://releases.hal0.dev/stable.json.bundle",
+    ]
+
+
+def test_bootstrap_missing_cosign_fails_closed_for_channel_manifest(
+    tmp_path: Path,
+) -> None:
+    env, curl_log, _ = _bootstrap_env(tmp_path, b"{}", with_cosign=False)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "cosign is required to verify the release manifest" in proc.stderr
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://releases.hal0.dev/stable.json",
+        "https://releases.hal0.dev/stable.json.bundle",
+    ]

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import os
@@ -39,6 +40,7 @@ def _bootstrap_env(
     artifact_fixture: Path | None = None,
     artifact_url: str = "",
     artifact_bundle_url: str = "",
+    with_jq: bool = True,
 ) -> tuple[dict[str, str], Path, Path]:
     """Build a hermetic PATH that records network and cosign behavior."""
     bin_dir = tmp_path / "bin"
@@ -49,6 +51,7 @@ def _bootstrap_env(
         "gzip",
         "uname",
         "mktemp",
+        "mkdir",
         "rm",
         "tar",
         "sha256sum",
@@ -57,6 +60,10 @@ def _bootstrap_env(
         target = shutil.which(tool)
         assert target is not None
         os.symlink(target, bin_dir / tool)
+    if with_jq:
+        jq = shutil.which("jq")
+        assert jq is not None
+        os.symlink(jq, bin_dir / "jq")
 
     manifest_fixture = tmp_path / "manifest.fixture"
     manifest_fixture.write_bytes(manifest)
@@ -126,10 +133,39 @@ def _run_bootstrap(
     )
 
 
+def _valid_manifest(
+    *,
+    channel: str = "stable",
+    release_kind: str = "stable",
+    prerelease_stage: str | None = None,
+) -> dict[str, object]:
+    return {
+        "_schema": "hal0.releases.v1",
+        "version": "1.2.3",
+        "channel": channel,
+        "release_kind": release_kind,
+        "prerelease_stage": prerelease_stage,
+        "url": "https://fixtures.example/hal0.tar.gz",
+        "bundle_url": "https://fixtures.example/hal0.tar.gz.bundle",
+        "digest_sha256": "A" * 64,
+        "signer_identity": _CANONICAL_IDENTITY,
+        "signer_issuer": _CANONICAL_ISSUER,
+    }
+
+
 def test_bootstrap_uses_canonical_channel_endpoint() -> None:
     script = _BOOTSTRAP.read_text(encoding="utf-8")
     assert "https://releases.hal0.dev/${HAL0_CHANNEL}.json" in script
     assert "/releases/latest/download" not in script
+
+
+def test_bootstrap_requires_jq_and_artifact_bundle_without_detached_fallback() -> None:
+    script = _BOOTSTRAP.read_text(encoding="utf-8")
+    assert "need jq" in script
+    assert 'verify_args=(--bundle "${bundle}")' in script
+    assert "--signature" not in script
+    assert "sig_url" not in script
+    assert "cert_url" not in script
 
 
 @pytest.mark.parametrize("channel", ["stable", "preview", "nightly"])
@@ -149,9 +185,7 @@ def test_bootstrap_accepts_supported_channels_and_fetches_exact_sibling_bundle(
 
 
 @pytest.mark.parametrize("channel", ["beta", "PREVIEW", "stable/../../owned"])
-def test_bootstrap_rejects_invalid_channel_before_network(
-    tmp_path: Path, channel: str
-) -> None:
+def test_bootstrap_rejects_invalid_channel_before_network(tmp_path: Path, channel: str) -> None:
     env, curl_log, _ = _bootstrap_env(tmp_path, b"{}")
     env["HAL0_CHANNEL"] = channel
 
@@ -159,6 +193,16 @@ def test_bootstrap_rejects_invalid_channel_before_network(
 
     assert proc.returncode != 0
     assert "HAL0_CHANNEL must be one of: stable, preview, nightly" in proc.stderr
+    assert not curl_log.exists()
+
+
+def test_bootstrap_missing_jq_fails_preflight_before_network(tmp_path: Path) -> None:
+    env, curl_log, _ = _bootstrap_env(tmp_path, b"{}", with_jq=False)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "missing dependency: jq" in proc.stderr
     assert not curl_log.exists()
 
 
@@ -181,14 +225,22 @@ def test_bootstrap_preserves_override_and_places_bundle_before_query(
 def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
     tmp_path: Path,
 ) -> None:
-    manifest = b'{"url":"https://attacker.example/untrusted.tar.gz"}'
+    manifest = b'{"url":"https://attacker.example/untrusted.tar.gz", "x": "$(touch owned)"}'
     env, curl_log, cosign_log = _bootstrap_env(tmp_path, manifest, cosign_rc=1)
+    jq_log = tmp_path / "jq.log"
+    (tmp_path / "bin" / "jq").unlink()
+    _write_executable(
+        tmp_path / "bin" / "jq",
+        f"#!/usr/bin/env bash\nprintf invoked > {jq_log}\nexit 99\n",
+    )
 
     proc = _run_bootstrap(env)
 
     assert proc.returncode != 0
     assert "release manifest signature verification FAILED" in proc.stderr
     assert "attacker.example" not in curl_log.read_text(encoding="utf-8")
+    assert not jq_log.exists()
+    assert not (tmp_path / "owned").exists()
     args = cosign_log.read_text(encoding="utf-8").splitlines()
     assert args[0] == "verify-blob"
     assert args[1] == "--bundle"
@@ -198,31 +250,93 @@ def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
     assert args[-1].endswith("/manifest.json")
 
 
-def test_stable_bootstrap_rejects_authenticated_preview_artifact(
+@pytest.mark.parametrize(
+    ("updates", "removals", "requested_channel"),
+    [
+        pytest.param({}, {"_schema"}, "stable", id="schema-missing"),
+        pytest.param({"_schema": "hal0.releases.v2"}, set(), "stable", id="schema-unknown"),
+        pytest.param({"_schema": 1}, set(), "stable", id="schema-non-string"),
+        pytest.param({}, {"version"}, "stable", id="version-missing"),
+        pytest.param({"version": ""}, set(), "stable", id="version-empty"),
+        pytest.param({"version": 1}, set(), "stable", id="version-non-string"),
+        pytest.param({}, {"url"}, "stable", id="url-missing"),
+        pytest.param({"url": ""}, set(), "stable", id="url-empty"),
+        pytest.param({"url": []}, set(), "stable", id="url-non-string"),
+        pytest.param({}, {"bundle_url"}, "stable", id="bundle-url-missing"),
+        pytest.param({"bundle_url": ""}, set(), "stable", id="bundle-url-empty"),
+        pytest.param({"bundle_url": 1}, set(), "stable", id="bundle-url-non-string"),
+        pytest.param({}, {"signer_identity"}, "stable", id="identity-missing"),
+        pytest.param({"signer_identity": ""}, set(), "stable", id="identity-empty"),
+        pytest.param({"signer_identity": False}, set(), "stable", id="identity-non-string"),
+        pytest.param({}, {"signer_issuer"}, "stable", id="issuer-missing"),
+        pytest.param({"signer_issuer": ""}, set(), "stable", id="issuer-empty"),
+        pytest.param({"signer_issuer": {}}, set(), "stable", id="issuer-non-string"),
+        pytest.param({}, {"digest_sha256"}, "stable", id="digest-missing"),
+        pytest.param({"digest_sha256": 1}, set(), "stable", id="digest-non-string"),
+        pytest.param({"digest_sha256": "0" * 63}, set(), "stable", id="digest-short"),
+        pytest.param({"digest_sha256": "md5:" + "0" * 64}, set(), "stable", id="digest-prefix"),
+        pytest.param({}, {"channel"}, "stable", id="channel-missing"),
+        pytest.param({"channel": 1}, set(), "stable", id="channel-non-string"),
+        pytest.param({"channel": "beta"}, set(), "stable", id="channel-noncanonical"),
+        pytest.param({}, {"release_kind"}, "stable", id="kind-missing"),
+        pytest.param({"release_kind": []}, set(), "stable", id="kind-non-string"),
+        pytest.param({"release_kind": "beta"}, set(), "stable", id="kind-noncanonical"),
+        pytest.param({}, set(), "preview", id="requested-channel-mismatch"),
+        pytest.param(
+            {"release_kind": "preview", "prerelease_stage": "rc"},
+            set(),
+            "stable",
+            id="stable-rejects-preview-kind",
+        ),
+        pytest.param(
+            {"channel": "preview", "release_kind": "preview", "prerelease_stage": None},
+            set(),
+            "preview",
+            id="preview-stage-missing",
+        ),
+        pytest.param(
+            {"channel": "preview", "release_kind": "preview", "prerelease_stage": "dev"},
+            set(),
+            "preview",
+            id="preview-stage-unknown",
+        ),
+        pytest.param({"prerelease_stage": "rc"}, set(), "stable", id="stable-has-stage"),
+        pytest.param(
+            {"channel": "nightly", "release_kind": "nightly", "prerelease_stage": "alpha"},
+            set(),
+            "nightly",
+            id="nightly-has-stage",
+        ),
+        pytest.param(
+            {"channel": "preview", "prerelease_stage": "rc"},
+            set(),
+            "preview",
+            id="promoted-stable-has-stage",
+        ),
+    ],
+)
+def test_authenticated_malformed_manifest_rejected_before_artifact_io(
     tmp_path: Path,
+    updates: dict[str, object],
+    removals: set[str],
+    requested_channel: str,
 ) -> None:
-    manifest = json.dumps(
-        {
-            "version": "1.0.0-rc.1",
-            "channel": "stable",
-            "release_kind": "preview",
-            "prerelease_stage": "rc",
-            "url": "https://attacker.example/preview.tar.gz",
-            "bundle_url": "https://attacker.example/preview.tar.gz.bundle",
-            "digest_sha256": "0" * 64,
-            "signer_identity": "untrusted-until-manifest-verification",
-        }
-    ).encode()
-    env, curl_log, _ = _bootstrap_env(tmp_path, manifest, cosign_rc=0)
+    payload = copy.deepcopy(_valid_manifest())
+    payload.update(updates)
+    for field in removals:
+        payload.pop(field)
+    env, curl_log, cosign_log = _bootstrap_env(tmp_path, json.dumps(payload).encode(), cosign_rc=0)
+    env["HAL0_CHANNEL"] = requested_channel
 
     proc = _run_bootstrap(env)
 
     assert proc.returncode != 0
-    assert "release kind preview is not accepted for channel stable" in proc.stderr
+    assert "authenticated release manifest failed strict policy validation" in proc.stderr
     assert curl_log.read_text(encoding="utf-8").splitlines() == [
-        "https://releases.hal0.dev/stable.json",
-        "https://releases.hal0.dev/stable.json.bundle",
+        f"https://releases.hal0.dev/{requested_channel}.json",
+        f"https://releases.hal0.dev/{requested_channel}.json.bundle",
     ]
+    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
 
 
 def test_bootstrap_missing_cosign_fails_closed_for_channel_manifest(
@@ -257,10 +371,28 @@ def test_bootstrap_cleanup_does_not_evaluate_hostile_tmpdir(
     assert list(hostile_tmpdir.iterdir()) == []
 
 
+@pytest.mark.parametrize(
+    ("channel", "release_kind", "prerelease_stage", "version"),
+    [
+        pytest.param("stable", "stable", None, "1.2.3", id="stable"),
+        pytest.param("preview", "preview", "rc", "1.2.3-rc.1", id="preview"),
+        pytest.param(
+            "nightly",
+            "nightly",
+            None,
+            "1.2.3-nightly.202607221230",
+            id="nightly",
+        ),
+        pytest.param("preview", "stable", None, "1.2.3", id="promoted-stable"),
+    ],
+)
 def test_bootstrap_successfully_verifies_extracts_and_hands_off_fixture(
     tmp_path: Path,
+    channel: str,
+    release_kind: str,
+    prerelease_stage: str | None,
+    version: str,
 ) -> None:
-    version = "1.2.3-rc.1"
     artifact_url = f"https://fixtures.example/hal0-{version}.tar.gz"
     artifact_bundle_url = f"{artifact_url}.bundle"
     artifact = tmp_path / f"hal0-{version}.tar.gz"
@@ -281,13 +413,14 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
     digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
     manifest = json.dumps(
         {
+            "_schema": "hal0.releases.v1",
             "version": version,
-            "channel": "preview",
-            "release_kind": "preview",
-            "prerelease_stage": "rc",
+            "channel": channel,
+            "release_kind": release_kind,
+            "prerelease_stage": prerelease_stage,
             "url": artifact_url,
             "bundle_url": artifact_bundle_url,
-            "digest_sha256": digest,
+            "digest_sha256": f"sha256:{digest.upper()}",
             "signer_identity": _CANONICAL_IDENTITY,
             "signer_issuer": _CANONICAL_ISSUER,
         }
@@ -302,7 +435,7 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
     )
     env.update(
         {
-            "HAL0_CHANNEL": "preview",
+            "HAL0_CHANNEL": channel,
             "INSTALL_LOG": str(install_log),
         }
     )
@@ -312,8 +445,8 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
     assert proc.returncode == 0, proc.stderr
     assert f"sha256 OK ({digest[:12]}…)" in proc.stdout
     assert curl_log.read_text(encoding="utf-8").splitlines() == [
-        "https://releases.hal0.dev/preview.json",
-        "https://releases.hal0.dev/preview.json.bundle",
+        f"https://releases.hal0.dev/{channel}.json",
+        f"https://releases.hal0.dev/{channel}.json.bundle",
         artifact_url,
         artifact_bundle_url,
     ]
@@ -326,7 +459,7 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
     assert cosign_args[7].endswith("/manifest.json")
     artifact_verify = cosign_args.index("verify-blob", 1)
     assert cosign_args[artifact_verify + 1] == "--bundle"
-    assert cosign_args[artifact_verify + 2].endswith(f"hal0-{version}.tar.gz.bundle")
+    assert cosign_args[artifact_verify + 2].endswith("/artifact.tar.gz.bundle")
     assert cosign_args[artifact_verify + 3 : artifact_verify + 5] == [
         "--certificate-identity-regexp",
         _CANONICAL_IDENTITY,
@@ -335,7 +468,7 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
         "--certificate-oidc-issuer",
         _CANONICAL_ISSUER,
     ]
-    assert cosign_args[artifact_verify + 7].endswith(f"hal0-{version}.tar.gz")
+    assert cosign_args[artifact_verify + 7].endswith("/artifact.tar.gz")
     assert install_log.read_text(encoding="utf-8").splitlines() == [
         "verified=1",
         "arg=--no-tls",

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -16,14 +16,30 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _BOOTSTRAP = _REPO_ROOT / "installer" / "bootstrap.sh"
-_CANONICAL_IDENTITY = (
+_IDENTITY_PREFIX = (
     r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
     r"\.github/workflows/release\.yml@"
-    r"(refs/tags/v\d+\.\d+\.\d+"
-    r"(-(alpha|beta|rc)\.(0|[1-9]\d*)|-nightly\.\d{14})?"
-    r"|refs/heads/main)$"
 )
+_STABLE_ADMISSION = _IDENTITY_PREFIX + r"refs/tags/v\d+\.\d+\.\d+$"
+_PREVIEW_ADMISSION = (
+    _IDENTITY_PREFIX + r"refs/tags/v\d+\.\d+\.\d+(-(alpha|beta|rc)\.(0|[1-9]\d*))?$"
+)
+_MAIN_IDENTITY = _IDENTITY_PREFIX + r"refs/heads/main$"
 _CANONICAL_ISSUER = "https://token.actions.githubusercontent.com"
+
+
+def _admission_identity(channel: str) -> str:
+    return {
+        "stable": _STABLE_ADMISSION,
+        "preview": _PREVIEW_ADMISSION,
+        "nightly": _MAIN_IDENTITY,
+    }[channel]
+
+
+def _exact_identity(release_kind: str, version: str) -> str:
+    if release_kind == "nightly":
+        return _MAIN_IDENTITY
+    return _IDENTITY_PREFIX + "refs/tags/v" + version.replace(".", r"\.") + "$"
 
 
 def _write_executable(path: Path, body: str) -> None:
@@ -146,17 +162,18 @@ def _valid_manifest(
     channel: str = "stable",
     release_kind: str = "stable",
     prerelease_stage: str | None = None,
+    version: str = "1.2.3",
 ) -> dict[str, object]:
     return {
         "_schema": "hal0.releases.v1",
-        "version": "1.2.3",
+        "version": version,
         "channel": channel,
         "release_kind": release_kind,
         "prerelease_stage": prerelease_stage,
         "url": "https://fixtures.example/hal0.tar.gz",
         "bundle_url": "https://fixtures.example/hal0.tar.gz.bundle",
         "digest_sha256": "A" * 64,
-        "signer_identity": _CANONICAL_IDENTITY,
+        "signer_identity": _exact_identity(release_kind, version),
         "signer_issuer": _CANONICAL_ISSUER,
     }
 
@@ -230,6 +247,25 @@ def test_bootstrap_preserves_override_and_places_bundle_before_query(
     ]
 
 
+@pytest.mark.parametrize("channel", ["stable", "preview", "nightly"])
+def test_bootstrap_first_verification_identity_depends_only_on_requested_channel(
+    tmp_path: Path, channel: str
+) -> None:
+    forged = _valid_manifest(
+        channel="nightly",
+        release_kind="nightly",
+        version="1.2.3-nightly.20260722123000",
+    )
+    env, _, cosign_log = _bootstrap_env(tmp_path, json.dumps(forged).encode(), cosign_rc=1)
+    env["HAL0_CHANNEL"] = channel
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    args = cosign_log.read_text(encoding="utf-8").splitlines()
+    assert args[3:5] == ["--certificate-identity-regexp", _admission_identity(channel)]
+
+
 def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -253,7 +289,7 @@ def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
     assert args[0] == "verify-blob"
     assert args[1] == "--bundle"
     assert args[2].endswith("/manifest.json.bundle")
-    assert args[3:5] == ["--certificate-identity-regexp", _CANONICAL_IDENTITY]
+    assert args[3:5] == ["--certificate-identity-regexp", _STABLE_ADMISSION]
     assert args[5:7] == ["--certificate-oidc-issuer", _CANONICAL_ISSUER]
     assert args[-1].endswith("/manifest.json")
 
@@ -267,6 +303,28 @@ def test_bootstrap_verifies_manifest_before_parsing_or_fetching_artifacts(
         pytest.param({}, {"version"}, "stable", id="version-missing"),
         pytest.param({"version": ""}, set(), "stable", id="version-empty"),
         pytest.param({"version": 1}, set(), "stable", id="version-non-string"),
+        pytest.param({"version": "1.2.3-rc.1"}, set(), "stable", id="stable-version-preview"),
+        pytest.param(
+            {
+                "version": "1.2.3",
+                "channel": "preview",
+                "release_kind": "preview",
+                "prerelease_stage": "rc",
+            },
+            set(),
+            "preview",
+            id="preview-version-final",
+        ),
+        pytest.param(
+            {
+                "version": "1.2.3-nightly.20260722123",
+                "channel": "nightly",
+                "release_kind": "nightly",
+            },
+            set(),
+            "nightly",
+            id="nightly-version-wrong-width",
+        ),
         pytest.param({}, {"url"}, "stable", id="url-missing"),
         pytest.param({"url": ""}, set(), "stable", id="url-empty"),
         pytest.param({"url": []}, set(), "stable", id="url-non-string"),
@@ -347,6 +405,21 @@ def test_authenticated_malformed_manifest_rejected_before_artifact_io(
     assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
 
 
+def test_authenticated_manifest_signer_must_match_exact_release_identity(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_manifest()
+    payload["signer_identity"] = _PREVIEW_ADMISSION
+    env, curl_log, cosign_log = _bootstrap_env(tmp_path, json.dumps(payload).encode(), cosign_rc=0)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "signer_identity does not match exact release identity" in proc.stderr
+    assert len(curl_log.read_text(encoding="utf-8").splitlines()) == 2
+    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
+
+
 @pytest.mark.parametrize(
     "manifest",
     [
@@ -357,9 +430,7 @@ def test_authenticated_malformed_manifest_rejected_before_artifact_io(
             id="invalid-then-valid",
         ),
         pytest.param(
-            json.dumps(_valid_manifest()).encode()
-            + b"\n"
-            + json.dumps(_valid_manifest()).encode(),
+            json.dumps(_valid_manifest()).encode() + b"\n" + json.dumps(_valid_manifest()).encode(),
             id="valid-then-valid",
         ),
         pytest.param(
@@ -427,7 +498,7 @@ def test_authenticated_option_like_artifact_urls_are_explicit_curl_urls(
 
     assert proc.returncode != 0
     assert curl_log.read_text(encoding="utf-8").splitlines()[-1] == hostile_url
-    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
+    assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 2
     assert not Path(env["CONFIG_READ_LOG"]).exists()
     assert not install_log.exists()
     assert not list(tmp_path.glob("hal0-install-*/artifact.tar.gz.bundle"))
@@ -476,8 +547,15 @@ def test_bootstrap_cleanup_does_not_evaluate_hostile_tmpdir(
             "nightly",
             "nightly",
             None,
-            "1.2.3-nightly.202607221230",
+            "1.2.3-nightly.20260722123000",
             id="nightly",
+        ),
+        pytest.param(
+            "nightly",
+            "nightly",
+            None,
+            "1.2.3-nightly.20260722",
+            id="legacy-nightly",
         ),
         pytest.param("preview", "stable", None, "1.2.3", id="promoted-stable"),
     ],
@@ -517,7 +595,7 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
             "url": artifact_url,
             "bundle_url": artifact_bundle_url,
             "digest_sha256": f"sha256:{digest.upper()}",
-            "signer_identity": _CANONICAL_IDENTITY,
+            "signer_identity": _exact_identity(release_kind, version),
             "signer_issuer": _CANONICAL_ISSUER,
         }
     ).encode()
@@ -547,18 +625,31 @@ printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
         artifact_bundle_url,
     ]
     cosign_args = cosign_log.read_text(encoding="utf-8").splitlines()
-    assert cosign_args.count("verify-blob") == 2
+    expected_identity = _exact_identity(release_kind, version)
+    expected_verify_count = 2 if channel == "nightly" else 3
+    assert cosign_args.count("verify-blob") == expected_verify_count
     assert cosign_args[1] == "--bundle"
     assert cosign_args[2].endswith("/manifest.json.bundle")
-    assert cosign_args[3:5] == ["--certificate-identity-regexp", _CANONICAL_IDENTITY]
+    assert cosign_args[3:5] == [
+        "--certificate-identity-regexp",
+        _admission_identity(channel),
+    ]
     assert cosign_args[5:7] == ["--certificate-oidc-issuer", _CANONICAL_ISSUER]
     assert cosign_args[7].endswith("/manifest.json")
-    artifact_verify = cosign_args.index("verify-blob", 1)
+    if channel == "nightly":
+        artifact_verify = cosign_args.index("verify-blob", 1)
+    else:
+        exact_verify = cosign_args.index("verify-blob", 1)
+        assert cosign_args[exact_verify + 3 : exact_verify + 5] == [
+            "--certificate-identity-regexp",
+            expected_identity,
+        ]
+        artifact_verify = cosign_args.index("verify-blob", exact_verify + 1)
     assert cosign_args[artifact_verify + 1] == "--bundle"
     assert cosign_args[artifact_verify + 2].endswith("/artifact.tar.gz.bundle")
     assert cosign_args[artifact_verify + 3 : artifact_verify + 5] == [
         "--certificate-identity-regexp",
-        _CANONICAL_IDENTITY,
+        expected_identity,
     ]
     assert cosign_args[artifact_verify + 5 : artifact_verify + 7] == [
         "--certificate-oidc-issuer",

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
 import stat
 import subprocess
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -34,11 +36,24 @@ def _bootstrap_env(
     *,
     with_cosign: bool = True,
     cosign_rc: int = 1,
+    artifact_fixture: Path | None = None,
+    artifact_url: str = "",
+    artifact_bundle_url: str = "",
 ) -> tuple[dict[str, str], Path, Path]:
     """Build a hermetic PATH that records network and cosign behavior."""
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    for tool in ("bash", "uname", "mktemp", "rm", "tar", "sha256sum", "python3"):
+    for tool in (
+        "awk",
+        "bash",
+        "gzip",
+        "uname",
+        "mktemp",
+        "rm",
+        "tar",
+        "sha256sum",
+        "python3",
+    ):
         target = shutil.which(tool)
         assert target is not None
         os.symlink(target, bin_dir / tool)
@@ -68,6 +83,8 @@ printf '%s\\n' "$url" >> "$CURL_LOG"
 case "$url" in
     *.json|*.json\\?*) {cp} "$MANIFEST_FIXTURE" "$out" ;;
     *.json.bundle|*.json.bundle\\?*) printf 'fixture bundle\\n' > "$out" ;;
+    "$ARTIFACT_URL") {cp} "$ARTIFACT_FIXTURE" "$out" ;;
+    "$ARTIFACT_BUNDLE_URL") printf 'artifact fixture bundle\\n' > "$out" ;;
     *) exit 22 ;;
 esac
 """,
@@ -76,7 +93,7 @@ esac
         _write_executable(
             bin_dir / "cosign",
             """#!/usr/bin/env bash
-printf '%s\\n' "$@" > "$COSIGN_LOG"
+printf '%s\\n' "$@" >> "$COSIGN_LOG"
 exit "$COSIGN_RC"
 """,
         )
@@ -87,14 +104,22 @@ exit "$COSIGN_RC"
         "COSIGN_LOG": str(cosign_log),
         "COSIGN_RC": str(cosign_rc),
         "MANIFEST_FIXTURE": str(manifest_fixture),
+        "ARTIFACT_FIXTURE": str(artifact_fixture or ""),
+        "ARTIFACT_URL": artifact_url,
+        "ARTIFACT_BUNDLE_URL": artifact_bundle_url,
     }
     return env, curl_log, cosign_log
 
 
-def _run_bootstrap(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_bootstrap(
+    env: dict[str, str],
+    *args: str,
+    cwd: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["/bin/bash", str(_BOOTSTRAP)],
+        ["/bin/bash", str(_BOOTSTRAP), *args],
         env=env,
+        cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
@@ -212,4 +237,107 @@ def test_bootstrap_missing_cosign_fails_closed_for_channel_manifest(
     assert curl_log.read_text(encoding="utf-8").splitlines() == [
         "https://releases.hal0.dev/stable.json",
         "https://releases.hal0.dev/stable.json.bundle",
+    ]
+
+
+def test_bootstrap_cleanup_does_not_evaluate_hostile_tmpdir(
+    tmp_path: Path,
+) -> None:
+    env, _, _ = _bootstrap_env(tmp_path, b"{}", cosign_rc=1)
+    marker = tmp_path / "trap-injected"
+    marker.touch()
+    hostile_tmpdir = tmp_path / "hostile'; rm -f trap-injected; : '"
+    hostile_tmpdir.mkdir()
+    env["TMPDIR"] = str(hostile_tmpdir)
+
+    proc = _run_bootstrap(env, cwd=tmp_path)
+
+    assert proc.returncode != 0
+    assert marker.exists()
+    assert list(hostile_tmpdir.iterdir()) == []
+
+
+def test_bootstrap_successfully_verifies_extracts_and_hands_off_fixture(
+    tmp_path: Path,
+) -> None:
+    version = "1.2.3-rc.1"
+    artifact_url = f"https://fixtures.example/hal0-{version}.tar.gz"
+    artifact_bundle_url = f"{artifact_url}.bundle"
+    artifact = tmp_path / f"hal0-{version}.tar.gz"
+    install_log = tmp_path / "install.log"
+
+    install_script = tmp_path / "tree" / f"hal0-{version}" / "installer" / "install.sh"
+    install_script.parent.mkdir(parents=True)
+    _write_executable(
+        install_script,
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'verified=%s\\n' "${HAL0_BOOTSTRAP_VERIFIED:-}" > "$INSTALL_LOG"
+printf 'arg=%s\\n' "$@" >> "$INSTALL_LOG"
+""",
+    )
+    with tarfile.open(artifact, "w:gz") as archive:
+        archive.add(install_script.parents[1], arcname=f"hal0-{version}")
+    digest = hashlib.sha256(artifact.read_bytes()).hexdigest()
+    manifest = json.dumps(
+        {
+            "version": version,
+            "channel": "preview",
+            "release_kind": "preview",
+            "prerelease_stage": "rc",
+            "url": artifact_url,
+            "bundle_url": artifact_bundle_url,
+            "digest_sha256": digest,
+            "signer_identity": _CANONICAL_IDENTITY,
+            "signer_issuer": _CANONICAL_ISSUER,
+        }
+    ).encode()
+    env, curl_log, cosign_log = _bootstrap_env(
+        tmp_path,
+        manifest,
+        cosign_rc=0,
+        artifact_fixture=artifact,
+        artifact_url=artifact_url,
+        artifact_bundle_url=artifact_bundle_url,
+    )
+    env.update(
+        {
+            "HAL0_CHANNEL": "preview",
+            "INSTALL_LOG": str(install_log),
+        }
+    )
+
+    proc = _run_bootstrap(env, "--no-tls", "--models-dir=/fixture")
+
+    assert proc.returncode == 0, proc.stderr
+    assert f"sha256 OK ({digest[:12]}…)" in proc.stdout
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://releases.hal0.dev/preview.json",
+        "https://releases.hal0.dev/preview.json.bundle",
+        artifact_url,
+        artifact_bundle_url,
+    ]
+    cosign_args = cosign_log.read_text(encoding="utf-8").splitlines()
+    assert cosign_args.count("verify-blob") == 2
+    assert cosign_args[1] == "--bundle"
+    assert cosign_args[2].endswith("/manifest.json.bundle")
+    assert cosign_args[3:5] == ["--certificate-identity-regexp", _CANONICAL_IDENTITY]
+    assert cosign_args[5:7] == ["--certificate-oidc-issuer", _CANONICAL_ISSUER]
+    assert cosign_args[7].endswith("/manifest.json")
+    artifact_verify = cosign_args.index("verify-blob", 1)
+    assert cosign_args[artifact_verify + 1] == "--bundle"
+    assert cosign_args[artifact_verify + 2].endswith(f"hal0-{version}.tar.gz.bundle")
+    assert cosign_args[artifact_verify + 3 : artifact_verify + 5] == [
+        "--certificate-identity-regexp",
+        _CANONICAL_IDENTITY,
+    ]
+    assert cosign_args[artifact_verify + 5 : artifact_verify + 7] == [
+        "--certificate-oidc-issuer",
+        _CANONICAL_ISSUER,
+    ]
+    assert cosign_args[artifact_verify + 7].endswith(f"hal0-{version}.tar.gz")
+    assert install_log.read_text(encoding="utf-8").splitlines() == [
+        "verified=1",
+        "arg=--no-tls",
+        "arg=--models-dir=/fixture",
     ]

--- a/tests/installer/test_bootstrap_contract.py
+++ b/tests/installer/test_bootstrap_contract.py
@@ -420,6 +420,26 @@ def test_authenticated_manifest_signer_must_match_exact_release_identity(
     assert cosign_log.read_text(encoding="utf-8").splitlines().count("verify-blob") == 1
 
 
+def test_authenticated_manifest_rejects_forged_issuer_before_artifact_io(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_manifest()
+    payload["signer_issuer"] = "https://issuer.attacker.example"
+    env, curl_log, cosign_log = _bootstrap_env(tmp_path, json.dumps(payload).encode(), cosign_rc=0)
+
+    proc = _run_bootstrap(env)
+
+    assert proc.returncode != 0
+    assert "authenticated release manifest failed strict policy validation" in proc.stderr
+    assert curl_log.read_text(encoding="utf-8").splitlines() == [
+        "https://releases.hal0.dev/stable.json",
+        "https://releases.hal0.dev/stable.json.bundle",
+    ]
+    cosign_args = cosign_log.read_text(encoding="utf-8").splitlines()
+    assert cosign_args.count("verify-blob") == 1
+    assert cosign_args[5:7] == ["--certificate-oidc-issuer", _CANONICAL_ISSUER]
+
+
 @pytest.mark.parametrize(
     "manifest",
     [

--- a/tests/installer/test_prebuilt_ui_install.py
+++ b/tests/installer/test_prebuilt_ui_install.py
@@ -1,0 +1,162 @@
+"""Behavioral tests for the installer's dashboard build decision.
+
+Release artifacts intentionally contain ``ui/dist`` but not the npm project used
+to build it.  Exercise the real Node/UI shell block with fake toolchain commands
+so a distribution-only tree can never regress into an impossible npm rebuild.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+
+def _node_and_ui_block() -> str:
+    text = _INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(
+        r'ui_step "Node\.js toolchain"\n(.*?)\nui_step "Configuration"',
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "Node.js/Dashboard UI block not found in install.sh"
+    return match.group(1)
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_ui_block(
+    tmp_path: Path,
+    *,
+    package_json: bool,
+    index_html: str | None,
+    current_git_dist: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
+    tree = tmp_path / "tree"
+    ui = tree / "ui"
+    dist = ui / "dist"
+    dist.mkdir(parents=True)
+    if package_json:
+        (ui / "package.json").write_text('{"scripts":{"build":"vite build"}}\n', encoding="utf-8")
+    if index_html is not None:
+        (dist / "index.html").write_text(index_html, encoding="utf-8")
+    if current_git_dist:
+        subprocess.run(["git", "init", "-q"], cwd=tree, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.test"], cwd=tree, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tree, check=True)
+        subprocess.run(["git", "add", "ui"], cwd=tree, check=True)
+        subprocess.run(["git", "commit", "-qm", "ui"], cwd=tree, check=True)
+        tree_hash = subprocess.check_output(
+            ["git", "rev-parse", "HEAD:ui"], cwd=tree, text=True
+        ).strip()
+        (dist / ".hal0-build-stamp").write_text(f"{tree_hash}\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    npm_log = tmp_path / "npm.log"
+    resolve_log = tmp_path / "resolve-node.log"
+    _write_executable(
+        fake_bin / "npm",
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${NPM_LOG}"
+if [[ "${1:-}" == "run" && "${2:-}" == "build" ]]; then
+    mkdir -p "${REPO_ROOT}/ui/dist"
+    printf '<!doctype html>built\n' > "${REPO_ROOT}/ui/dist/index.html"
+fi
+""",
+    )
+    _write_executable(fake_bin / "node", "#!/usr/bin/env bash\nprintf 'v22.0.0\\n'\n")
+
+    harness = f"""set -euo pipefail
+info() {{ printf 'INFO: %s\\n' "$*"; }}
+warn() {{ printf 'WARN: %s\\n' "$*"; }}
+ui_step() {{ :; }}
+ui_spinner_run() {{ shift; "$@"; }}
+resolve_node() {{ printf 'called\\n' >> "${{RESOLVE_LOG}}"; return 0; }}
+export REPO_ROOT={tree!s}
+export NPM_LOG={npm_log!s}
+export RESOLVE_LOG={resolve_log!s}
+DEV_MODE=0
+HAL0_PORT=8080
+NODE_MIN_MAJOR=20
+{_node_and_ui_block()}
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        cwd=tree,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    npm_calls = npm_log.read_text(encoding="utf-8").splitlines() if npm_log.exists() else []
+    resolve_calls = (
+        resolve_log.read_text(encoding="utf-8").splitlines() if resolve_log.exists() else []
+    )
+    return proc, npm_calls, resolve_calls
+
+
+def test_release_tree_reuses_valid_prebuilt_dist_without_node_or_npm(tmp_path: Path) -> None:
+    proc, npm_calls, resolve_calls = _run_ui_block(
+        tmp_path,
+        package_json=False,
+        index_html="<!doctype html><html>signed release</html>\n",
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert npm_calls == []
+    assert resolve_calls == []
+    assert "using release's prebuilt ui/dist" in proc.stdout
+    assert "will return 404" not in proc.stdout
+
+
+def test_source_tree_retains_dashboard_build_behavior(tmp_path: Path) -> None:
+    proc, npm_calls, resolve_calls = _run_ui_block(
+        tmp_path,
+        package_json=True,
+        index_html=None,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert resolve_calls == ["called"]
+    assert npm_calls == ["install --no-audit --no-fund", "run build"]
+    assert (tmp_path / "tree" / "ui" / "dist" / "index.html").is_file()
+
+
+def test_current_git_dist_retains_freshness_skip(tmp_path: Path) -> None:
+    proc, npm_calls, resolve_calls = _run_ui_block(
+        tmp_path,
+        package_json=True,
+        index_html="<!doctype html><html>current source build</html>\n",
+        current_git_dist=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert resolve_calls == ["called"]
+    assert npm_calls == []
+    assert "already built for this ui/ tree" in proc.stdout
+
+
+def test_distribution_tree_with_invalid_dist_does_not_attempt_impossible_rebuild(
+    tmp_path: Path,
+) -> None:
+    proc, npm_calls, _ = _run_ui_block(
+        tmp_path,
+        package_json=False,
+        index_html="",
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert npm_calls == []
+    assert "no valid prebuilt ui/dist/index.html" in proc.stdout
+    assert "cannot rebuild without ui/package.json" in proc.stdout

--- a/tests/memory/test_honcho_env.py
+++ b/tests/memory/test_honcho_env.py
@@ -197,6 +197,7 @@ class TestApplyHonchoEnv:
 def test_deriver_flush_enabled_by_default(monkeypatch):
     from hal0.memory import honcho_env as he
 
+    monkeypatch.setattr(he, "SECRETS_PATH", _NO_SECRETS)
     out = he.render_env(_honcho_cfg())
     assert "DERIVER_FLUSH_ENABLED=true" in out
 
@@ -204,6 +205,7 @@ def test_deriver_flush_enabled_by_default(monkeypatch):
 def test_deriver_json_object_mode_local_only(monkeypatch):
     from hal0.memory import honcho_env as he
 
+    monkeypatch.setattr(he, "SECRETS_PATH", _NO_SECRETS)
     out = he.render_env(_honcho_cfg())
     assert "DERIVER_MODEL_CONFIG__STRUCTURED_OUTPUT_MODE=json_object" in out
 

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -1,0 +1,177 @@
+"""Functional contracts for the non-publishing release preflight."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release-check.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_tree(
+    tmp_path: Path, report: dict[str, object] | None = None
+) -> tuple[Path, dict[str, str]]:
+    root = tmp_path / "repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "src").mkdir()
+    (root / "tests").mkdir()
+    shutil.copy2(SCRIPT, root / "scripts" / "release-check.sh")
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "hal0ai"\nversion = "1.0.0-alpha.1"\n', encoding="utf-8"
+    )
+    (root / "manifest.json").write_text(
+        json.dumps({"toolbox_images": {"test": {"digest": "sha256:abc"}}}),
+        encoding="utf-8",
+    )
+    if report is not None:
+        (root / "tests" / "release-gate-report.json").write_text(
+            json.dumps(report), encoding="utf-8"
+        )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv_log = tmp_path / "uv.log"
+    _write_executable(
+        fake_bin / "uv",
+        '#!/usr/bin/env bash\nprintf "%s|%s|%s\\n" "$PYTHONPATH" "$HAL0_HOME" "$*" >> "$UV_LOG"\n',
+    )
+    _write_executable(fake_bin / "shellcheck", "#!/usr/bin/env bash\nexit 0\n")
+
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "-c",
+            "user.name=Release Test",
+            "-c",
+            "user.email=release-test@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["UV_LOG"] = str(uv_log)
+    env["HAL0_HOME"] = str(tmp_path / "must-not-be-used")
+    return root, env
+
+
+def _run(root: Path, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(root / "scripts" / "release-check.sh"), *args],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _fresh_report(**summary_overrides: int) -> dict[str, object]:
+    summary = {"total": 1, "pass": 1, "fail": 0, "skip": 0, "deferred": 0}
+    summary.update(summary_overrides)
+    return {"generated": int(time.time()), "summary": summary}
+
+
+def test_help_and_unknown_argument_contract(tmp_path: Path) -> None:
+    root, env = _make_tree(tmp_path)
+
+    help_result = _run(root, env, "--help")
+    bad_result = _run(root, env, "--unknown")
+
+    assert help_result.returncode == 0
+    assert "--local" in help_result.stdout
+    assert "non-publishing" in help_result.stdout.lower()
+    assert bad_result.returncode == 2
+    assert "Unknown argument" in bad_result.stderr
+
+
+def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Path) -> None:
+    root, env = _make_tree(tmp_path)
+
+    result = _run(root, env, "--local")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    assert "LOCAL rehearsal" in output
+    assert "skipping remote tier-" in output
+    assert "release-gate report" in output
+    assert "insufficient for release authorization" in output
+    uv_calls = Path(env["UV_LOG"]).read_text(encoding="utf-8").splitlines()
+    assert len(uv_calls) == 2
+    homes = set()
+    for call in uv_calls:
+        pythonpath, hal0_home, command = call.split("|", 2)
+        assert pythonpath == str(root / "src")
+        assert hal0_home != env["HAL0_HOME"]
+        assert "hal0-release-check." in hal0_home
+        homes.add(hal0_home)
+        assert command.startswith("run ")
+    assert len(homes) == 1
+    assert not Path(next(iter(homes))).exists()
+    assert any("run pytest" in call for call in uv_calls)
+    assert any("run ruff check" in call for call in uv_calls)
+
+
+@pytest.mark.parametrize(
+    ("report", "expected_success"),
+    [
+        (None, False),
+        ({**_fresh_report(), "generated": int(time.time()) - 25 * 3600}, False),
+        (_fresh_report(**{"fail": 1, "pass": 0}), False),
+        (_fresh_report(), True),
+    ],
+)
+def test_nonlocal_requires_fresh_all_pass_report(
+    tmp_path: Path, report: dict[str, object] | None, expected_success: bool
+) -> None:
+    root, env = _make_tree(tmp_path, report)
+
+    result = _run(root, env, "--dry-run")
+
+    assert (result.returncode == 0) is expected_success
+    output = result.stdout + result.stderr
+    if expected_success:
+        assert "release-gate report fresh and clean" in output
+    else:
+        assert "release-gate report" in output.lower()
+        assert "FAILED" in output
+
+
+def test_git_cleanliness_ignores_only_generated_paths(tmp_path: Path) -> None:
+    root, env = _make_tree(tmp_path)
+    generated = [
+        root / ".pi" / "shepherd" / "index.json",
+        root / ".pi-subagents" / "worker.log",
+        root / "graphify-out" / "graph.json",
+    ]
+    for path in generated:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("generated\n", encoding="utf-8")
+
+    generated_result = _run(root, env, "--local")
+    assert generated_result.returncode == 0, generated_result.stdout + generated_result.stderr
+    assert "working tree clean (excluding generated state)" in generated_result.stdout
+
+    source_dirt = root / "src" / "unexpected.py"
+    source_dirt.write_text("dirty = True\n", encoding="utf-8")
+    source_result = _run(root, env, "--local")
+
+    assert source_result.returncode == 1
+    assert "working tree is dirty" in source_result.stderr

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -56,7 +56,7 @@ def _make_tree(
         fake_bin / "uv",
         """#!/usr/bin/env bash
 printf "%s|%s|%s\\n" "$PYTHONPATH" "$HAL0_HOME" "$*" >> "$UV_LOG"
-if [[ "$*" != "run --locked "* ]]; then
+if [[ "$*" != "run --isolated --locked --python 3.12 --extra dev "* ]]; then
     printf 'unexpected lock rewrite\\n' > uv.lock
 fi
 """,
@@ -164,11 +164,11 @@ def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Pat
         assert hal0_home != env["HAL0_HOME"]
         assert "hal0-release-check." in hal0_home
         homes.add(hal0_home)
-        assert command.startswith("run --locked ")
+        assert command.startswith("run --isolated --locked --python 3.12 --extra dev ")
     assert len(homes) == 1
     assert not Path(next(iter(homes))).exists()
-    assert any("run --locked pytest" in call for call in uv_calls)
-    assert any("run --locked ruff check" in call for call in uv_calls)
+    assert any("--extra dev pytest" in call for call in uv_calls)
+    assert any("--extra dev ruff check" in call for call in uv_calls)
 
 
 @pytest.mark.parametrize(
@@ -176,7 +176,7 @@ def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Pat
     [
         (None, False),
         ({**_fresh_report(), "generated": int(time.time()) - 25 * 3600}, False),
-        ({**_fresh_report(), "generated": int(time.time()) + 10 * 60}, False),
+        ({**_fresh_report(), "generated": int(time.time()) + 24 * 3600}, False),
         ({**_fresh_report(), "generated": "not-a-timestamp"}, False),
         (_fresh_report(**{"fail": 1, "pass": 0}), False),
         (_fresh_report(), True),
@@ -300,6 +300,9 @@ def test_git_cleanliness_allows_exact_generated_dirt(tmp_path: Path) -> None:
     subagent_log = root / ".pi-subagents" / "worker.log"
     subagent_log.parent.mkdir(parents=True)
     subagent_log.write_text("untracked generated log\n", encoding="utf-8")
+    (root / "graphify-out" / "untracked.json").write_text(
+        "untracked generated graph data\n", encoding="utf-8"
+    )
 
     result = _run(root, env, "--local")
 
@@ -312,13 +315,11 @@ def test_git_cleanliness_allows_exact_generated_dirt(tmp_path: Path) -> None:
     [
         (Path(".pi/shepherd/nearby.json"), True),
         (Path(".pi/shepherd/untracked.json"), False),
-        (Path("graphify-out/untracked.json"), False),
         (Path("src/unexpected.py"), False),
     ],
     ids=[
         "nearby-tracked-shepherd-file",
         "nearby-untracked-shepherd-file",
-        "untracked-graphify-file",
         "source-file",
     ],
 )

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -35,6 +35,17 @@ def _make_tree(
         encoding="utf-8",
     )
     (root / "uv.lock").write_bytes(b"fixture lock bytes\n")
+    (root / ".gitignore").write_text(
+        ".pi/\ngraphify-out/*\n", encoding="utf-8"
+    )
+    tracked_generated = {
+        root / ".pi" / "shepherd" / "index.json": "generated index\n",
+        root / ".pi" / "shepherd" / "nearby.json": "tracked source state\n",
+        root / "graphify-out" / "graph.json": "generated graph\n",
+    }
+    for path, content in tracked_generated.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
     if report is not None:
         (root / "tests" / "release-gate-report.json").write_text(
             json.dumps(report), encoding="utf-8"
@@ -56,6 +67,19 @@ fi
 
     subprocess.run(["git", "init", "-q", str(root)], check=True)
     subprocess.run(["git", "-C", str(root), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "add",
+            "-f",
+            ".pi/shepherd/index.json",
+            ".pi/shepherd/nearby.json",
+            "graphify-out/graph.json",
+        ],
+        check=True,
+    )
     subprocess.run(
         [
             "git",
@@ -92,7 +116,17 @@ def _run(root: Path, env: dict[str, str], *args: str) -> subprocess.CompletedPro
 def _fresh_report(**summary_overrides: int) -> dict[str, object]:
     summary = {"total": 1, "pass": 1, "fail": 0, "skip": 0, "deferred": 0}
     summary.update(summary_overrides)
-    return {"generated": int(time.time()), "summary": summary}
+    rows = [
+        {"status": status}
+        for status in ("pass", "fail", "skip", "deferred")
+        for _ in range(summary[status])
+    ]
+    return {
+        "_schema": "hal0.release-gate-report.v1",
+        "generated": int(time.time()),
+        "summary": summary,
+        "rows": rows,
+    }
 
 
 def test_help_and_unknown_argument_contract(tmp_path: Path) -> None:
@@ -103,7 +137,8 @@ def test_help_and_unknown_argument_contract(tmp_path: Path) -> None:
 
     assert help_result.returncode == 0
     assert "--local" in help_result.stdout
-    assert "non-publishing" in help_result.stdout.lower()
+    assert "publication-read-only" in help_result.stdout.lower()
+    assert "dependency/build caches may change" in help_result.stdout.lower()
     assert bad_result.returncode == 2
     assert "Unknown argument" in bad_result.stderr
 
@@ -164,6 +199,36 @@ def test_nonlocal_requires_fresh_coherent_report(
 
 
 @pytest.mark.parametrize(
+    "mutation",
+    [
+        "missing-schema",
+        "wrong-schema",
+        "missing-rows",
+        "rows-not-list",
+        "invalid-row-status",
+    ],
+)
+def test_tier_gamma_requires_schema_and_valid_rows(tmp_path: Path, mutation: str) -> None:
+    report = _fresh_report()
+    if mutation == "missing-schema":
+        report.pop("_schema")
+    elif mutation == "wrong-schema":
+        report["_schema"] = "hal0.release-gate-report.v2"
+    elif mutation == "missing-rows":
+        report.pop("rows")
+    elif mutation == "rows-not-list":
+        report["rows"] = {"status": "pass"}
+    else:
+        report["rows"] = [{"status": "unknown"}]
+    root, env = _make_tree(tmp_path, report)
+
+    result = _run(root, env, "--dry-run")
+
+    assert result.returncode == 1
+    assert "Release check FAILED" in result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
     ("summary", "rows", "expected_success"),
     [
         ({"total": 0, "pass": 0, "fail": 0, "skip": 0, "deferred": 0}, None, False),
@@ -204,7 +269,11 @@ def test_tier_gamma_report_policy(
     rows: list[dict[str, str]] | None,
     expected_success: bool,
 ) -> None:
-    report: dict[str, object] = {"generated": int(time.time()), "summary": summary}
+    report: dict[str, object] = {
+        "_schema": "hal0.release-gate-report.v1",
+        "generated": int(time.time()),
+        "summary": summary,
+    }
     if rows is not None:
         report["rows"] = rows
     root, env = _make_tree(tmp_path, report)
@@ -220,24 +289,50 @@ def test_tier_gamma_report_policy(
         assert "Release check FAILED" in output
 
 
-def test_git_cleanliness_ignores_only_generated_paths(tmp_path: Path) -> None:
+def test_git_cleanliness_allows_exact_generated_dirt(tmp_path: Path) -> None:
     root, env = _make_tree(tmp_path)
-    generated = [
-        root / ".pi" / "shepherd" / "index.json",
-        root / ".pi-subagents" / "worker.log",
-        root / "graphify-out" / "graph.json",
-    ]
-    for path in generated:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("generated\n", encoding="utf-8")
+    (root / ".pi" / "shepherd" / "index.json").write_text(
+        "modified generated index\n", encoding="utf-8"
+    )
+    (root / "graphify-out" / "graph.json").write_text(
+        "modified generated graph\n", encoding="utf-8"
+    )
+    subagent_log = root / ".pi-subagents" / "worker.log"
+    subagent_log.parent.mkdir(parents=True)
+    subagent_log.write_text("untracked generated log\n", encoding="utf-8")
 
-    generated_result = _run(root, env, "--local")
-    assert generated_result.returncode == 0, generated_result.stdout + generated_result.stderr
-    assert "working tree clean (excluding generated state)" in generated_result.stdout
+    result = _run(root, env, "--local")
 
-    source_dirt = root / "src" / "unexpected.py"
-    source_dirt.write_text("dirty = True\n", encoding="utf-8")
-    source_result = _run(root, env, "--local")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "working tree clean (excluding generated state)" in result.stdout
 
-    assert source_result.returncode == 1
-    assert "working tree is dirty" in source_result.stderr
+
+@pytest.mark.parametrize(
+    ("relative_path", "tracked"),
+    [
+        (Path(".pi/shepherd/nearby.json"), True),
+        (Path(".pi/shepherd/untracked.json"), False),
+        (Path("graphify-out/untracked.json"), False),
+        (Path("src/unexpected.py"), False),
+    ],
+    ids=[
+        "nearby-tracked-shepherd-file",
+        "nearby-untracked-shepherd-file",
+        "untracked-graphify-file",
+        "source-file",
+    ],
+)
+def test_git_cleanliness_rejects_all_other_dirt(
+    tmp_path: Path, relative_path: Path, tracked: bool
+) -> None:
+    root, env = _make_tree(tmp_path)
+    dirty_path = root / relative_path
+    dirty_path.parent.mkdir(parents=True, exist_ok=True)
+    if tracked:
+        assert dirty_path.exists()
+    dirty_path.write_text("unexpected dirt\n", encoding="utf-8")
+
+    result = _run(root, env, "--local")
+
+    assert result.returncode == 1
+    assert "working tree is dirty" in result.stderr

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -294,6 +294,12 @@ def test_git_cleanliness_allows_exact_generated_dirt(tmp_path: Path) -> None:
     (root / ".pi" / "shepherd" / "index.json").write_text(
         "modified generated index\n", encoding="utf-8"
     )
+    (root / ".pi" / "shepherd" / "nearby.json").write_text(
+        "modified tracked run state\n", encoding="utf-8"
+    )
+    shepherd_run = root / ".pi" / "shepherd" / "runs" / "run.json"
+    shepherd_run.parent.mkdir(parents=True)
+    shepherd_run.write_text("untracked run receipt\n", encoding="utf-8")
     (root / "graphify-out" / "graph.json").write_text(
         "modified generated graph\n", encoding="utf-8"
     )
@@ -313,13 +319,11 @@ def test_git_cleanliness_allows_exact_generated_dirt(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("relative_path", "tracked"),
     [
-        (Path(".pi/shepherd/nearby.json"), True),
-        (Path(".pi/shepherd/untracked.json"), False),
+        (Path(".pi/unexpected.json"), False),
         (Path("src/unexpected.py"), False),
     ],
     ids=[
-        "nearby-tracked-shepherd-file",
-        "nearby-untracked-shepherd-file",
+        "unrelated-pi-file",
         "source-file",
     ],
 )

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -34,6 +34,7 @@ def _make_tree(
         json.dumps({"toolbox_images": {"test": {"digest": "sha256:abc"}}}),
         encoding="utf-8",
     )
+    (root / "uv.lock").write_bytes(b"fixture lock bytes\n")
     if report is not None:
         (root / "tests" / "release-gate-report.json").write_text(
             json.dumps(report), encoding="utf-8"
@@ -44,7 +45,12 @@ def _make_tree(
     uv_log = tmp_path / "uv.log"
     _write_executable(
         fake_bin / "uv",
-        '#!/usr/bin/env bash\nprintf "%s|%s|%s\\n" "$PYTHONPATH" "$HAL0_HOME" "$*" >> "$UV_LOG"\n',
+        """#!/usr/bin/env bash
+printf "%s|%s|%s\\n" "$PYTHONPATH" "$HAL0_HOME" "$*" >> "$UV_LOG"
+if [[ "$*" != "run --locked "* ]]; then
+    printf 'unexpected lock rewrite\\n' > uv.lock
+fi
+""",
     )
     _write_executable(fake_bin / "shellcheck", "#!/usr/bin/env bash\nexit 0\n")
 
@@ -105,9 +111,12 @@ def test_help_and_unknown_argument_contract(tmp_path: Path) -> None:
 def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Path) -> None:
     root, env = _make_tree(tmp_path)
 
+    original_lock = (root / "uv.lock").read_bytes()
+
     result = _run(root, env, "--local")
 
     assert result.returncode == 0, result.stdout + result.stderr
+    assert (root / "uv.lock").read_bytes() == original_lock
     output = result.stdout + result.stderr
     assert "LOCAL rehearsal" in output
     assert "skipping remote tier-" in output
@@ -122,11 +131,11 @@ def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Pat
         assert hal0_home != env["HAL0_HOME"]
         assert "hal0-release-check." in hal0_home
         homes.add(hal0_home)
-        assert command.startswith("run ")
+        assert command.startswith("run --locked ")
     assert len(homes) == 1
     assert not Path(next(iter(homes))).exists()
-    assert any("run pytest" in call for call in uv_calls)
-    assert any("run ruff check" in call for call in uv_calls)
+    assert any("run --locked pytest" in call for call in uv_calls)
+    assert any("run --locked ruff check" in call for call in uv_calls)
 
 
 @pytest.mark.parametrize(
@@ -138,7 +147,7 @@ def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Pat
         (_fresh_report(), True),
     ],
 )
-def test_nonlocal_requires_fresh_all_pass_report(
+def test_nonlocal_requires_fresh_coherent_report(
     tmp_path: Path, report: dict[str, object] | None, expected_success: bool
 ) -> None:
     root, env = _make_tree(tmp_path, report)
@@ -148,10 +157,67 @@ def test_nonlocal_requires_fresh_all_pass_report(
     assert (result.returncode == 0) is expected_success
     output = result.stdout + result.stderr
     if expected_success:
-        assert "release-gate report fresh and clean" in output
+        assert "release-gate report accepted" in output
     else:
         assert "release-gate report" in output.lower()
         assert "FAILED" in output
+
+
+@pytest.mark.parametrize(
+    ("summary", "rows", "expected_success"),
+    [
+        ({"total": 0, "pass": 0, "fail": 0, "skip": 0, "deferred": 0}, None, False),
+        ({"total": 1, "pass": 0, "fail": 0, "skip": 1, "deferred": 0}, None, False),
+        ({"total": 1, "pass": 0, "fail": 0, "skip": 0, "deferred": 1}, None, False),
+        ({"total": 2, "pass": 1, "fail": 0, "skip": 0, "deferred": 0}, None, False),
+        ({"total": 1, "pass": "1", "fail": 0, "skip": 0, "deferred": 0}, None, False),
+        (
+            {"total": 2, "pass": 1, "fail": 0, "skip": 1, "deferred": 0},
+            [{"status": "pass"}, {"status": "skip"}],
+            True,
+        ),
+        (
+            {"total": 2, "pass": 1, "fail": 1, "skip": 0, "deferred": 0},
+            [{"status": "pass"}, {"status": "fail"}],
+            False,
+        ),
+        (
+            {"total": 2, "pass": 1, "fail": 0, "skip": 1, "deferred": 0},
+            [{"status": "pass"}, {"status": "deferred"}],
+            False,
+        ),
+    ],
+    ids=[
+        "empty-report",
+        "all-skipped",
+        "all-deferred",
+        "inconsistent-counts",
+        "malformed-count",
+        "pass-with-skip",
+        "failed-row",
+        "rows-summary-mismatch",
+    ],
+)
+def test_tier_gamma_report_policy(
+    tmp_path: Path,
+    summary: dict[str, object],
+    rows: list[dict[str, str]] | None,
+    expected_success: bool,
+) -> None:
+    report: dict[str, object] = {"generated": int(time.time()), "summary": summary}
+    if rows is not None:
+        report["rows"] = rows
+    root, env = _make_tree(tmp_path, report)
+
+    result = _run(root, env, "--dry-run")
+    output = result.stdout + result.stderr
+
+    assert (result.returncode == 0) is expected_success, output
+    if expected_success:
+        assert "1 pass, 1 skip, 0 deferred; no failed rows" in output
+        assert "all-pass" not in output.lower()
+    else:
+        assert "Release check FAILED" in output
 
 
 def test_git_cleanliness_ignores_only_generated_paths(tmp_path: Path) -> None:

--- a/tests/release/test_release_check.py
+++ b/tests/release/test_release_check.py
@@ -35,9 +35,7 @@ def _make_tree(
         encoding="utf-8",
     )
     (root / "uv.lock").write_bytes(b"fixture lock bytes\n")
-    (root / ".gitignore").write_text(
-        ".pi/\ngraphify-out/*\n", encoding="utf-8"
-    )
+    (root / ".gitignore").write_text(".pi/\ngraphify-out/*\n", encoding="utf-8")
     tracked_generated = {
         root / ".pi" / "shepherd" / "index.json": "generated index\n",
         root / ".pi" / "shepherd" / "nearby.json": "tracked source state\n",
@@ -178,6 +176,8 @@ def test_local_uses_isolated_repository_uv_and_skips_remote_report(tmp_path: Pat
     [
         (None, False),
         ({**_fresh_report(), "generated": int(time.time()) - 25 * 3600}, False),
+        ({**_fresh_report(), "generated": int(time.time()) + 10 * 60}, False),
+        ({**_fresh_report(), "generated": "not-a-timestamp"}, False),
         (_fresh_report(**{"fail": 1, "pass": 0}), False),
         (_fresh_report(), True),
     ],

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -4,6 +4,7 @@ These tests deliberately inspect the workflow text: they protect security-critic
 GitHub Actions wiring without publishing a release during the test suite.
 """
 
+import re
 from pathlib import Path
 
 
@@ -29,11 +30,44 @@ def test_release_resolves_policy_before_building() -> None:
         assert f"{output}: ${{{{ steps.policy.outputs.{output} }}}}" in text
 
 
-def test_release_checks_out_resolved_tag_in_build_and_pypi_jobs() -> None:
+def test_resolve_first_rejects_every_noncanonical_repository() -> None:
     text = _workflow_text()
-    assert text.count("ref: ${{ needs.resolve.outputs.tag }}") >= 2
-    assert 'git rev-parse HEAD' in text
-    assert 'git rev-list -n1 "${TAG}"' in text
+    resolve_steps = text.split("  resolve:", 1)[1].split("    steps:\n", 1)[1]
+    first_step = resolve_steps.split("\n      - name:", 1)[0]
+
+    assert '"${GITHUB_REPOSITORY,,}" != "hal0ai/hal0"' in first_step
+    assert "GITHUB_EVENT_NAME" not in first_step
+    assert "workflow_call" not in first_step
+    assert "refusing noncanonical repository" in first_step
+
+
+def test_resolve_uses_only_the_tag_namespace_and_exports_target_sha() -> None:
+    text = _workflow_text()
+    assert "target_sha: ${{ steps.policy.outputs.target_sha }}" in text
+    assert "ref: refs/tags/${{ steps.requested.outputs.tag }}" in text
+    assert 'git show-ref --verify --quiet "refs/tags/${TAG}"' in text
+    assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in text
+    assert 'echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"' in text
+
+
+def test_release_checkouts_pin_canonical_repository_and_immutable_tag() -> None:
+    text = _workflow_text()
+    checkout_with_blocks = re.findall(
+        r"(?m)^        uses: actions/checkout@[^\n]+\n"
+        r"        with:\n((?:          [^\n]+\n)+)",
+        text,
+    )
+
+    assert text.count("uses: actions/checkout@") == 3
+    assert len(checkout_with_blocks) == 3
+    assert all(
+        block.count("repository: Hal0ai/hal0") == 1
+        for block in checkout_with_blocks
+    )
+    assert sum(block.count("repository: Hal0ai/hal0") for block in checkout_with_blocks) == 3
+    assert text.count("ref: refs/tags/${{ needs.resolve.outputs.tag }}") == 2
+    assert text.count("EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}") == 2
+    assert text.count('if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]') == 2
 
 
 def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -43,6 +43,12 @@ def _step(job_id: str, name: str) -> dict[str, Any]:
     return next(step for step in _job(job_id)["steps"] if step.get("name") == name)
 
 
+def _shell_function(script: str, name: str) -> str:
+    match = re.search(rf"(?ms)^\s*{re.escape(name)}\(\) \{{\n(?P<body>.*?)^\s*\}}$", script)
+    assert match is not None, f"missing shell function: {name}"
+    return match.group("body")
+
+
 def test_executable_scalar_traversal_covers_every_yaml_run_form_and_uses() -> None:
     fixture = """
 name: traversal-regression
@@ -220,9 +226,83 @@ def test_release_exposes_digest_and_authorizer_redownloads_exact_remote_asset_se
     assert "gh release download" not in run
     assert "--pattern" not in run
     assert "--clobber" not in run
-    assert "releases/latest" not in re.sub(
-        r'gh api "repos/\$\{GITHUB_REPOSITORY\}/releases/latest"[^\n]*', "", run
+    assert run.count("repos/${GITHUB_REPOSITORY}/releases/latest") == 1
+
+
+def test_authorizer_retries_every_github_api_read_and_fails_closed() -> None:
+    run = _step("authorize-pointer", "Download and verify exact remote publication")["run"]
+    api_read = _shell_function(run, "github_api_read").replace("\\\n", " ")
+    asset_download = _shell_function(run, "download_asset").replace("\\\n", " ")
+    run_without_continuations = run.replace("\\\n", " ")
+
+    assert re.search(r"(?m)^GH_API_MAX_ATTEMPTS=5$", run)
+    assert re.search(r"(?m)^GH_API_BACKOFF_SECONDS=2$", run)
+    retry_loop = r"for \(\(ATTEMPT = 1; ATTEMPT <= GH_API_MAX_ATTEMPTS; ATTEMPT\+\+\)\); do"
+    for body in (api_read, asset_download):
+        assert re.search(retry_loop, body)
+        assert re.search(
+            r"if \(\(ATTEMPT < GH_API_MAX_ATTEMPTS\)\); then\s+"
+            r'(?:echo "::warning::[^\n]+"\s+)?'
+            r'sleep "\$\(\(GH_API_BACKOFF_SECONDS \* ATTEMPT\)\)"',
+            body,
+        )
+        assert re.search(r'done\s+echo "::error::[^\n]+"\s+return 1\s*$', body)
+
+    assert re.search(
+        r'if gh api "\$\{ENDPOINT\}" > "\$\{ATTEMPT_PATH\}"; then\s+'
+        r'mv -- "\$\{ATTEMPT_PATH\}" "\$\{DESTINATION\}"\s+'
+        r"return 0",
+        api_read,
     )
+    assert 'rm -f -- "${ATTEMPT_PATH}"' in api_read
+    assert re.search(
+        r"github_api_read\s+"
+        r'"repos/\$\{GITHUB_REPOSITORY\}/releases/tags/\$\{TAG\}"\s+'
+        r'"\$\{RELEASE_JSON\}"',
+        run_without_continuations,
+    )
+    assert re.search(
+        r"github_api_read\s+"
+        r'"repos/\$\{GITHUB_REPOSITORY\}/releases/latest"\s+'
+        r'"\$\{LATEST_JSON\}"',
+        run_without_continuations,
+    )
+    assert "|| true" not in "\n".join(
+        line for line in run.splitlines() if "github_api_read" in line
+    )
+    # The only gh invocations are inside the two retry functions, so no
+    # evidence endpoint or octet-stream download can bypass bounded retries.
+    assert run.count("gh api ") == 2
+
+
+def test_authorizer_retries_size_mismatches_and_atomically_accepts_assets() -> None:
+    run = _step("authorize-pointer", "Download and verify exact remote publication")["run"]
+    download = _shell_function(run, "download_asset").replace("\\\n", " ")
+
+    assert 'rows.append((name, asset_id, asset["size"]))' in run
+    assert 'f"{name}\\t{asset_id}\\t{size}\\n"' in run
+    assert "while IFS=$'\\t' read -r ASSET_NAME ASSET_ID DECLARED_SIZE; do" in run
+    assert re.search(
+        r'download_asset "\$\{ASSET_NAME\}" "\$\{ASSET_ID\}" '
+        r'"\$\{DECLARED_SIZE\}" "\$\{DESTINATION\}"',
+        run,
+    )
+    assert re.search(
+        r'if gh api -H "Accept: application/octet-stream"\s+'
+        r'"repos/\$\{GITHUB_REPOSITORY\}/releases/assets/\$\{ASSET_ID\}"\s+'
+        r'> "\$\{ATTEMPT_PATH\}"; then\s+'
+        r'OBSERVED_SIZE="\$\(wc -c < "\$\{ATTEMPT_PATH\}"\)"\s+'
+        r'if \[\[ "\$\{OBSERVED_SIZE\}" == "\$\{DECLARED_SIZE\}" \]\]; then\s+'
+        r'mv -- "\$\{ATTEMPT_PATH\}" "\$\{DESTINATION\}"\s+'
+        r"return 0",
+        download,
+    )
+    assert "remote asset size mismatch for ${ASSET_NAME}" in download
+    assert 'rm -f -- "${ATTEMPT_PATH}"' in download
+    assert 'ATTEMPT_PATH="${ATTEMPT_DIR}/asset-${ASSET_ID}.attempt-${ATTEMPT}"' in download
+    assert 'DESTINATION="${DOWNLOAD_DIR}/${ASSET_NAME}"' in run
+    assert 'mv -- "${ATTEMPT_PATH}" "${DESTINATION}"' in download
+    assert "gh release download" not in run
 
 
 def test_authorizer_verifies_flags_digests_policy_and_all_signatures() -> None:

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -101,3 +101,45 @@ def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:
     text = _workflow_text()
     assert "channel pointer" in text.lower()
     assert "separately verified" in text.lower()
+
+
+def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
+    text = _workflow_text()
+    stage = text.split("      - name: Stage release tree", 1)[1].split(
+        "      - name: Stage release notes", 1
+    )[0]
+
+    for copy in (
+        "src",
+        "manifest.json",
+        "pyproject.toml",
+        "installer",
+        "packaging",
+    ):
+        assert re.search(rf"cp -a {re.escape(copy)}\s+\"\$\{{STAGE\}}/\"", stage)
+
+    for required in (
+        "src/hal0/updater/updater.py",
+        "manifest.json",
+        "pyproject.toml",
+        "installer/install.sh",
+        "installer/lib/ui.sh",
+        "packaging/systemd/hal0-openwebui.service",
+        "ui/dist/index.html",
+        "VERSION",
+    ):
+        assert f'"${{STAGE}}/{required}"' in stage
+
+
+def test_release_tree_is_explicitly_prebuilt_ui_only() -> None:
+    text = _workflow_text()
+    stage = text.split("      - name: Stage release tree", 1)[1].split(
+        "      - name: Stage release notes", 1
+    )[0]
+
+    assert "if [[ -s ui/dist/index.html ]]" in stage
+    assert 'cp -a ui/dist            "${STAGE}/ui/dist"' in stage
+    assert '"${STAGE}/ui/package.json"' in stage
+    assert '"${STAGE}/ui/node_modules"' in stage
+    assert "ui-dist/" not in stage
+    assert "npm fallback" not in stage

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -7,7 +7,6 @@ GitHub Actions wiring without publishing a release during the test suite.
 import re
 from pathlib import Path
 
-
 WORKFLOW = Path(".github/workflows/release.yml")
 
 
@@ -72,8 +71,19 @@ def test_release_checkouts_pin_canonical_repository_and_immutable_tag() -> None:
 
 def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:
     text = _workflow_text()
-    assert "needs.resolve.outputs.github_prerelease" in text
-    assert "needs.resolve.outputs.github_latest" in text
+    publish = text.split("      - name: Publish GitHub Release", 1)[1].split(
+        "      - name: Record separately verified channel pointer gate", 1
+    )[0]
+    normalized = " ".join(publish.replace("\\\n", " ").split())
+
+    assert "GITHUB_PRERELEASE: ${{ needs.resolve.outputs.github_prerelease }}" in publish
+    assert "GITHUB_LATEST: ${{ needs.resolve.outputs.github_latest }}" in publish
+    assert (
+        'gh release create "${TAG}" --verify-tag --title "hal0 ${TAG}" '
+        '--notes-file "${NOTES_FILE}" --draft=false '
+        '--prerelease="${GITHUB_PRERELEASE}" --latest="${GITHUB_LATEST}"'
+    ) in normalized
+    assert 'gh release upload "${TAG}" "${ASSETS[@]}"' in publish
     assert "--clobber" not in text
     assert 'gh release view "${TAG}"' in text
     assert 'asset collision:' in text
@@ -99,8 +109,15 @@ def test_release_signs_verifies_and_uploads_every_manifest_bundle() -> None:
 
 def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:
     text = _workflow_text()
+    gate = text.split(
+        "      - name: Record separately verified channel pointer gate", 1
+    )[1].split("      - name: Summary", 1)[0]
+
     assert "channel pointer" in text.lower()
     assert "separately verified" in text.lower()
+    assert 'echo "Channel pointer advancement remains external' in gate
+    for publishing_command in ("curl ", "gh ", "git push", "upload", "release create"):
+        assert publishing_command not in gate
 
 
 def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
@@ -109,14 +126,19 @@ def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
         "      - name: Stage release notes", 1
     )[0]
 
-    for copy in (
+    staged_roots = re.findall(
+        r'(?m)^\s*cp -a\s+(\S+)\s+"\$\{STAGE\}/"\s*$', stage
+    )
+    assert staged_roots == [
         "src",
         "manifest.json",
+        "LICENSE",
+        "README.md",
         "pyproject.toml",
         "installer",
         "packaging",
-    ):
-        assert re.search(rf"cp -a {re.escape(copy)}\s+\"\$\{{STAGE\}}/\"", stage)
+        "docs",
+    ]
 
     for required in (
         "src/hal0/updater/updater.py",

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -1,0 +1,69 @@
+"""Static contracts for immutable release publication.
+
+These tests deliberately inspect the workflow text: they protect security-critical
+GitHub Actions wiring without publishing a release during the test suite.
+"""
+
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_release_resolves_policy_before_building() -> None:
+    text = _workflow_text()
+    assert "resolve:" in text
+    assert 'PYTHONPATH=src python3 -m hal0.release.policy "${TAG}" --format github' in text
+    for output in (
+        "kind",
+        "prerelease_stage",
+        "manifest_targets",
+        "github_prerelease",
+        "github_latest",
+        "publish_pypi",
+    ):
+        assert f"{output}: ${{{{ steps.policy.outputs.{output} }}}}" in text
+
+
+def test_release_checks_out_resolved_tag_in_build_and_pypi_jobs() -> None:
+    text = _workflow_text()
+    assert text.count("ref: ${{ needs.resolve.outputs.tag }}") >= 2
+    assert 'git rev-parse HEAD' in text
+    assert 'git rev-list -n1 "${TAG}"' in text
+
+
+def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:
+    text = _workflow_text()
+    assert "needs.resolve.outputs.github_prerelease" in text
+    assert "needs.resolve.outputs.github_latest" in text
+    assert "--clobber" not in text
+    assert 'gh release view "${TAG}"' in text
+    assert 'asset collision:' in text
+
+
+def test_release_policy_controls_manifests_and_pypi() -> None:
+    text = _workflow_text()
+    assert "needs.resolve.outputs.manifest_targets" in text
+    assert "needs.resolve.outputs.publish_pypi == 'true'" in text
+    assert "pypi.org/pypi/hal0ai/${PYPI_VERSION}/json" in text
+
+
+def test_release_signs_verifies_and_uploads_every_manifest_bundle() -> None:
+    text = _workflow_text()
+    assert 'cosign sign-blob --yes --bundle "${MANIFEST}.bundle" "${MANIFEST}"' in text
+    assert 'cosign verify-blob \\\n              --bundle "${MANIFEST}.bundle"' in text
+    assert 'ASSETS+=("${MANIFEST}" "${MANIFEST}.bundle")' in text
+    assert "ReleaseManifest.model_validate(payload)" in text
+    assert "refs/heads/main" in text
+    assert "refs/tags/v" in text
+    assert text.count("https://token.actions.githubusercontent.com") >= 3
+
+
+def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:
+    text = _workflow_text()
+    assert "channel pointer" in text.lower()
+    assert "separately verified" in text.lower()

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -1,11 +1,16 @@
 """Static contracts for immutable release publication.
 
-These tests deliberately inspect the workflow text: they protect security-critical
-GitHub Actions wiring without publishing a release during the test suite.
+These tests inspect every executable YAML scalar without publishing anything.
+They cannot establish that GitHub, Sigstore, or PyPI behave as expected remotely;
+the first real release run remains required before relying on authorization.
 """
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 WORKFLOW = Path(".github/workflows/release.yml")
 
@@ -14,31 +19,76 @@ def _workflow_text() -> str:
     return WORKFLOW.read_text()
 
 
-def _workflow_command_lines(text: str) -> list[str]:
-    """Return action invocations and non-comment shell lines from every run block."""
-    command_lines: list[str] = []
-    run_indent: int | None = None
-    for line in text.splitlines():
-        stripped = line.strip()
-        indent = len(line) - len(line.lstrip())
-        if run_indent is not None:
-            if stripped and indent <= run_indent:
-                run_indent = None
-            elif stripped and not stripped.startswith("#"):
-                command_lines.append(stripped)
-                continue
-            else:
-                continue
-        if re.match(r"^\s*run:\s*\|\s*$", line):
-            run_indent = indent
-        elif re.match(r"^\s*uses:\s*", line):
-            command_lines.append(stripped)
-    return command_lines
+def _yaml(text: str | None = None) -> Any:
+    return yaml.safe_load(_workflow_text() if text is None else text)
+
+
+def _executable_scalars(node: Any) -> Iterator[tuple[str, str]]:
+    """Yield every ``run`` and ``uses`` string via recursive YAML traversal."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in {"run", "uses"} and isinstance(value, str):
+                yield key, value
+            yield from _executable_scalars(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _executable_scalars(value)
+
+
+def _job(job_id: str) -> dict[str, Any]:
+    return _yaml()["jobs"][job_id]
+
+
+def _step(job_id: str, name: str) -> dict[str, Any]:
+    return next(step for step in _job(job_id)["steps"] if step.get("name") == name)
+
+
+def test_executable_scalar_traversal_covers_every_yaml_run_form_and_uses() -> None:
+    fixture = """
+name: traversal-regression
+jobs:
+  synthetic:
+    steps:
+      - run: echo plain
+      - run: "echo quoted"
+      - run: |
+          echo literal
+      - run: |-
+          echo literal-strip
+      - run: |+
+          echo literal-keep
+      - run: >
+          echo folded
+      - run: >-
+          echo folded-strip
+      - run: >+
+          echo folded-keep
+      - uses: owner/action@sha
+"""
+    surface = list(_executable_scalars(_yaml(fixture)))
+    assert len(surface) == 9
+    assert {value.strip() for _, value in surface} == {
+        "echo plain",
+        "echo quoted",
+        "echo literal",
+        "echo literal-strip",
+        "echo literal-keep",
+        "echo folded",
+        "echo folded-strip",
+        "echo folded-keep",
+        "owner/action@sha",
+    }
+
+
+def test_workflow_yaml_parses_and_declares_live_run_limit() -> None:
+    assert isinstance(_yaml(), dict)
+    text = _workflow_text().lower()
+    assert "static contract" in text
+    assert "first real release run" in text
 
 
 def test_release_resolves_policy_before_building() -> None:
     text = _workflow_text()
-    assert "resolve:" in text
     assert 'PYTHONPATH=src python3 -m hal0.release.policy "${TAG}" --format github' in text
     for output in (
         "kind",
@@ -48,74 +98,50 @@ def test_release_resolves_policy_before_building() -> None:
         "github_latest",
         "publish_pypi",
         "signer_identity",
+        "target_sha",
     ):
-        assert f"{output}: ${{{{ steps.policy.outputs.{output} }}}}" in text
+        assert output in _job("resolve")["outputs"]
 
 
 def test_resolve_first_rejects_every_noncanonical_repository() -> None:
+    first_step = _job("resolve")["steps"][0]
+    run = first_step["run"]
+    assert '"${GITHUB_REPOSITORY,,}" != "hal0ai/hal0"' in run
+    assert "GITHUB_EVENT_NAME" not in run
+    assert "refusing noncanonical repository" in run
+
+
+def test_resolve_uses_only_tag_namespace_and_exports_target_sha() -> None:
     text = _workflow_text()
-    resolve_steps = text.split("  resolve:", 1)[1].split("    steps:\n", 1)[1]
-    first_step = resolve_steps.split("\n      - name:", 1)[0]
-
-    assert '"${GITHUB_REPOSITORY,,}" != "hal0ai/hal0"' in first_step
-    assert "GITHUB_EVENT_NAME" not in first_step
-    assert "workflow_call" not in first_step
-    assert "refusing noncanonical repository" in first_step
-
-
-def test_resolve_uses_only_the_tag_namespace_and_exports_target_sha() -> None:
-    text = _workflow_text()
-    assert "target_sha: ${{ steps.policy.outputs.target_sha }}" in text
     assert "ref: refs/tags/${{ steps.requested.outputs.tag }}" in text
     assert 'git show-ref --verify --quiet "refs/tags/${TAG}"' in text
     assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in text
     assert 'echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"' in text
 
 
-def test_resolve_enforces_event_and_ref_authority_for_each_release_kind() -> None:
-    text = _workflow_text()
-    policy = text.split("      - name: Verify requested tag and export policy", 1)[1].split(
-        "\n  release:", 1
-    )[0]
-
-    assert 'if [[ "${KIND}" == "nightly" ]]' in policy
-    assert '"${GITHUB_EVENT_NAME}" != "workflow_call"' in policy
-    assert '"${GITHUB_REF}" != "refs/heads/main"' in policy
-    assert (
-        '"${GITHUB_EVENT_NAME}" != "push" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch"'
-        in policy
+def test_release_checkouts_pin_canonical_repository_tag_and_sha() -> None:
+    checkouts = [
+        step
+        for job in _yaml()["jobs"].values()
+        for step in job.get("steps", [])
+        if step.get("uses", "").startswith("actions/checkout@")
+    ]
+    assert len(checkouts) == 4
+    assert all(step["with"]["repository"] == "Hal0ai/hal0" for step in checkouts)
+    assert checkouts[0]["with"]["ref"] == "refs/tags/${{ steps.requested.outputs.tag }}"
+    assert all(
+        step["with"]["ref"] == "refs/tags/${{ needs.resolve.outputs.tag }}"
+        for step in checkouts[1:]
     )
-    assert '"${GITHUB_REF}" != "refs/tags/${TAG}"' in policy
-    assert "signer_identity=${IDENT_PREFIX}refs/heads/main$" in policy
-    assert "signer_identity=${IDENT_PREFIX}refs/tags/${ESCAPED_TAG}$" in policy
-
-
-def test_release_checkouts_pin_canonical_repository_and_immutable_tag() -> None:
     text = _workflow_text()
-    checkout_with_blocks = re.findall(
-        r"(?m)^        uses: actions/checkout@[^\n]+\n"
-        r"        with:\n((?:          [^\n]+\n)+)",
-        text,
-    )
-
-    assert text.count("uses: actions/checkout@") == 3
-    assert len(checkout_with_blocks) == 3
-    assert all(block.count("repository: Hal0ai/hal0") == 1 for block in checkout_with_blocks)
-    assert sum(block.count("repository: Hal0ai/hal0") for block in checkout_with_blocks) == 3
-    assert text.count("ref: refs/tags/${{ needs.resolve.outputs.tag }}") == 2
-    assert text.count("EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}") == 2
-    assert text.count('if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]') == 2
+    assert text.count("EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}") == 3
+    assert text.count('if [[ "${HEAD_SHA}" != "${EXPECTED_SHA}" ]]') == 3
 
 
-def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:
+def test_release_publication_remains_immutable_and_intended_publishers_allowed() -> None:
     text = _workflow_text()
-    publish = text.split("      - name: Publish GitHub Release", 1)[1].split(
-        "      - name: Record separately verified channel pointer gate", 1
-    )[0]
+    publish = _step("release", "Publish GitHub Release")["run"]
     normalized = " ".join(publish.replace("\\\n", " ").split())
-
-    assert "GITHUB_PRERELEASE: ${{ needs.resolve.outputs.github_prerelease }}" in publish
-    assert "GITHUB_LATEST: ${{ needs.resolve.outputs.github_latest }}" in publish
     assert (
         'gh release create "${TAG}" --verify-tag --title "hal0 ${TAG}" '
         '--notes-file "${NOTES_FILE}" --draft=false '
@@ -123,82 +149,131 @@ def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:
     ) in normalized
     assert 'gh release upload "${TAG}" "${ASSETS[@]}"' in publish
     assert "--clobber" not in text
-    assert 'gh release view "${TAG}"' in text
-    assert "asset collision:" in text
+    assert _step("pypi-publish", "Publish to PyPI")["uses"] == (
+        "pypa/gh-action-pypi-publish@release/v1"
+    )
+    assert "Record separately verified channel pointer gate" not in text
 
 
-def test_release_policy_controls_manifests_and_pypi() -> None:
-    text = _workflow_text()
-    assert "needs.resolve.outputs.manifest_targets" in text
-    assert "needs.resolve.outputs.publish_pypi == 'true'" in text
-    assert "pypi.org/pypi/hal0ai/${PYPI_VERSION}/json" in text
-
-
-def test_release_signs_verifies_and_uploads_every_manifest_bundle() -> None:
-    text = _workflow_text()
-    assert 'cosign sign-blob --yes --bundle "${MANIFEST}.bundle" "${MANIFEST}"' in text
-    assert 'cosign verify-blob \\\n              --bundle "${MANIFEST}.bundle"' in text
-    assert 'ASSETS+=("${MANIFEST}" "${MANIFEST}.bundle")' in text
-    assert "ReleaseManifest.model_validate(payload)" in text
-    assert "refs/heads/main" in text
-    assert "refs/tags/${ESCAPED_TAG}" in text
-    assert text.count("https://token.actions.githubusercontent.com") >= 3
-
-
-def test_generated_and_self_verified_identities_are_exact_policy_output() -> None:
-    text = _workflow_text()
-    assert "signer_identity: ${{ steps.policy.outputs.signer_identity }}" in text
-    assert text.count("SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}") >= 3
-    assert '"signer_identity": ident' in text
-    assert '--certificate-identity-regexp "${SIGNER_IDENTITY}"' in text
-    assert "tag-or-main" not in text
-    assert "|refs/heads/main" not in text
-    assert "refs/heads/main)$" not in text
-    assert "refs/tags/v[0-9]" not in text
-
-
-def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:
-    text = _workflow_text()
-    gate = text.split("      - name: Record separately verified channel pointer gate", 1)[1].split(
-        "      - name: Summary", 1
-    )[0]
-
-    assert "channel pointer" in text.lower()
-    assert "separately verified" in text.lower()
-    assert 'echo "Channel pointer advancement remains external' in gate
-    for publishing_command in ("curl ", "gh ", "git push", "upload", "release create"):
-        assert publishing_command not in gate
-
-    # The external pointer endpoint may be documented, but never executed by
-    # this workflow. This scans every job rather than trusting the named gate.
-    pointer_endpoint_mentions = [
-        line for line in text.splitlines() if "releases.hal0.dev" in line.lower()
-    ]
-    assert pointer_endpoint_mentions
-    assert all(line.lstrip().startswith("#") for line in pointer_endpoint_mentions)
-
-    command_surface = "\n".join(_workflow_command_lines(text)).lower()
-    external_pointer_markers = (
+def test_global_executable_surface_has_no_external_pointer_or_mutation_markers() -> None:
+    # YAML parsing discards comments, so documentation may name forbidden systems.
+    surface = "\n".join(value for _, value in _executable_scalars(_yaml())).lower()
+    markers = (
         r"releases\.hal0\.dev",
         r"\bhal0-web\b",
         r"\bcloudflare\b",
         r"\bwrangler\b",
         r"\bapi\.cloudflare\.com\b",
         r"\b(?:aws\s+s3|gsutil|rclone)\b",
-        r"\br2(?:://|\s+(?:bucket|object|put|copy))\b",
-        r"\b(?:advance|update|publish|promote|write|sync)[-_ ](?:channel[-_ ]?)?pointer\b",
-        r"\bchannel[-_ ]pointer[-_ ](?:advance|update|publish|promote|write|sync)\b",
+        r"\bkv\b",
+        r"\br2\b",
+        r"\bpointer[-_ ]service\b",
+        r"\b(?:advance|update|publish|promote|write|sync|mutate)[-_ ](?:channel[-_ ]?)?pointer\b",
+        r"\bchannel[-_ ]pointer[-_ ](?:advance|update|publish|promote|write|sync|mutate)\b",
     )
-    for marker in external_pointer_markers:
-        assert re.search(marker, command_surface) is None, marker
+    for marker in markers:
+        assert re.search(marker, surface) is None, marker
+
+
+def test_authorize_job_truth_table_permissions_and_dependencies() -> None:
+    job = _job("authorize-pointer")
+    assert job["needs"] == ["resolve", "release", "pypi-publish"]
+    condition = job["if"]
+    assert "always()" in condition
+    assert "needs.resolve.result == 'success'" in condition
+    assert "needs.release.result == 'success'" in condition
+    assert "needs.resolve.outputs.publish_pypi == 'true'" in condition
+    assert "needs.pypi-publish.result == 'success'" in condition
+    assert "needs.resolve.outputs.publish_pypi == 'false'" in condition
+    assert "needs.pypi-publish.result == 'skipped'" in condition
+    assert job["permissions"] == {"contents": "read"}
+    serialized = yaml.safe_dump(job).lower()
+    for forbidden in (
+        "id-token",
+        "environment:",
+        "secrets.",
+        "password",
+        "cloudflare_api",
+        "wrangler",
+        "pointer_token",
+    ):
+        assert forbidden not in serialized
+    assert job["outputs"]["authorized"] == "${{ steps.evidence.outputs.authorized }}"
+
+
+def test_release_exposes_digest_and_authorizer_redownloads_exact_remote_asset_set() -> None:
+    release = _job("release")
+    assert release["outputs"]["tarball_digest"] == "${{ steps.tarball.outputs.digest }}"
+    run = _step("authorize-pointer", "Download and verify exact remote publication")["run"]
+    assert "EXPECTED_DIGEST: ${{ needs.release.outputs.tarball_digest }}" in yaml.safe_dump(
+        _step("authorize-pointer", "Download and verify exact remote publication")
+    )
+    assert "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" in run
+    assert "repos/${GITHUB_REPOSITORY}/releases/latest" in run
+    assert "repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}" in run
+    assert "Accept: application/octet-stream" in run
+    assert "mktemp -d" in run
+    assert "EXPECTED_ASSETS" in run
+    assert "duplicate" in run.lower()
+    assert "uploaded" in run
+    assert "empty" in run.lower()
+    assert "gh release download" not in run
+    assert "--pattern" not in run
+    assert "--clobber" not in run
+    assert "releases/latest" not in re.sub(
+        r'gh api "repos/\$\{GITHUB_REPOSITORY\}/releases/latest"[^\n]*', "", run
+    )
+
+
+def test_authorizer_verifies_flags_digests_policy_and_all_signatures() -> None:
+    run = _step("authorize-pointer", "Download and verify exact remote publication")["run"]
+    assert "ReleaseManifest.model_validate" in run
+    assert "ReleasePolicy.from_tag" in run
+    assert "github_prerelease" in run
+    assert "github_latest" in run
+    assert "digest_sha256" in run
+    assert "EXPECTED_DIGEST" in run
+    assert "signer_identity" in run
+    assert "signer_issuer" in run
+    assert "stable and preview manifests differ in artifact identity" in run
+    assert 'cosign verify-blob --bundle "${TARBALL}.bundle"' in run
+    normalized = " ".join(run.replace("\\\n", " ").split())
+    assert (
+        'cosign verify-blob --signature "${TARBALL}.sig" --certificate "${TARBALL}.crt"'
+    ) in normalized
+    assert 'cosign verify-blob --bundle "${MANIFEST}.bundle"' in run
+    installers = [
+        step["uses"]
+        for job in ("release", "authorize-pointer")
+        for step in _job(job)["steps"]
+        if step.get("name") == "Install cosign"
+    ]
+    assert installers == ["sigstore/cosign-installer@v3"] * 2
+
+
+def test_authorizer_conditionally_checks_exact_pypi_version_with_bounded_retries() -> None:
+    run = _step("authorize-pointer", "Download and verify exact remote publication")["run"]
+    assert 'if [[ "${PUBLISH_PYPI}" == "true" ]]' in run
+    assert "pypi/hal0ai/${PYPI_VERSION}/json" in run
+    assert "--retry 5" in run
+    assert "--max-time 20" in run
+    assert 'payload["info"]["name"] != "hal0ai"' in run
+    assert 'payload["info"]["version"] != expected' in run
+    assert "PyPI publication | not required (nightly policy)" in run
+
+
+def test_evidence_is_appended_only_after_all_remote_checks() -> None:
+    steps = _job("authorize-pointer")["steps"]
+    assert steps[-1]["name"] == "Record non-mutating authorization evidence"
+    evidence = steps[-1]["run"]
+    assert 'echo "authorized=true" >> "$GITHUB_OUTPUT"' in evidence
+    assert "No external channel pointer was mutated" in evidence
+    assert "$GITHUB_STEP_SUMMARY" in evidence
+    assert "Download and verify exact remote publication" in steps[-2]["name"]
 
 
 def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
-    text = _workflow_text()
-    stage = text.split("      - name: Stage release tree", 1)[1].split(
-        "      - name: Stage release notes", 1
-    )[0]
-
+    stage = _step("release", "Stage release tree")["run"]
     staged_roots = re.findall(r'(?m)^\s*cp -a\s+(\S+)\s+"\$\{STAGE\}/"\s*$', stage)
     assert staged_roots == [
         "src",
@@ -210,29 +285,7 @@ def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
         "packaging",
         "docs",
     ]
-
-    for required in (
-        "src/hal0/updater/updater.py",
-        "manifest.json",
-        "pyproject.toml",
-        "installer/install.sh",
-        "installer/lib/ui.sh",
-        "packaging/systemd/hal0-openwebui.service",
-        "ui/dist/index.html",
-        "VERSION",
-    ):
-        assert f'"${{STAGE}}/{required}"' in stage
-
-
-def test_release_tree_is_explicitly_prebuilt_ui_only() -> None:
-    text = _workflow_text()
-    stage = text.split("      - name: Stage release tree", 1)[1].split(
-        "      - name: Stage release notes", 1
-    )[0]
-
     assert "if [[ -s ui/dist/index.html ]]" in stage
     assert 'cp -a ui/dist            "${STAGE}/ui/dist"' in stage
     assert '"${STAGE}/ui/package.json"' in stage
     assert '"${STAGE}/ui/node_modules"' in stage
-    assert "ui-dist/" not in stage
-    assert "npm fallback" not in stage

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -47,6 +47,7 @@ def test_release_resolves_policy_before_building() -> None:
         "github_prerelease",
         "github_latest",
         "publish_pypi",
+        "signer_identity",
     ):
         assert f"{output}: ${{{{ steps.policy.outputs.{output} }}}}" in text
 
@@ -69,6 +70,24 @@ def test_resolve_uses_only_the_tag_namespace_and_exports_target_sha() -> None:
     assert 'git show-ref --verify --quiet "refs/tags/${TAG}"' in text
     assert 'git rev-parse "refs/tags/${TAG}^{commit}"' in text
     assert 'echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"' in text
+
+
+def test_resolve_enforces_event_and_ref_authority_for_each_release_kind() -> None:
+    text = _workflow_text()
+    policy = text.split("      - name: Verify requested tag and export policy", 1)[1].split(
+        "\n  release:", 1
+    )[0]
+
+    assert 'if [[ "${KIND}" == "nightly" ]]' in policy
+    assert '"${GITHUB_EVENT_NAME}" != "workflow_call"' in policy
+    assert '"${GITHUB_REF}" != "refs/heads/main"' in policy
+    assert (
+        '"${GITHUB_EVENT_NAME}" != "push" && "${GITHUB_EVENT_NAME}" != "workflow_dispatch"'
+        in policy
+    )
+    assert '"${GITHUB_REF}" != "refs/tags/${TAG}"' in policy
+    assert "signer_identity=${IDENT_PREFIX}refs/heads/main$" in policy
+    assert "signer_identity=${IDENT_PREFIX}refs/tags/${ESCAPED_TAG}$" in policy
 
 
 def test_release_checkouts_pin_canonical_repository_and_immutable_tag() -> None:
@@ -122,8 +141,20 @@ def test_release_signs_verifies_and_uploads_every_manifest_bundle() -> None:
     assert 'ASSETS+=("${MANIFEST}" "${MANIFEST}.bundle")' in text
     assert "ReleaseManifest.model_validate(payload)" in text
     assert "refs/heads/main" in text
-    assert "refs/tags/v" in text
+    assert "refs/tags/${ESCAPED_TAG}" in text
     assert text.count("https://token.actions.githubusercontent.com") >= 3
+
+
+def test_generated_and_self_verified_identities_are_exact_policy_output() -> None:
+    text = _workflow_text()
+    assert "signer_identity: ${{ steps.policy.outputs.signer_identity }}" in text
+    assert text.count("SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}") >= 3
+    assert '"signer_identity": ident' in text
+    assert '--certificate-identity-regexp "${SIGNER_IDENTITY}"' in text
+    assert "tag-or-main" not in text
+    assert "|refs/heads/main" not in text
+    assert "refs/heads/main)$" not in text
+    assert "refs/tags/v[0-9]" not in text
 
 
 def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -14,6 +14,28 @@ def _workflow_text() -> str:
     return WORKFLOW.read_text()
 
 
+def _workflow_command_lines(text: str) -> list[str]:
+    """Return action invocations and non-comment shell lines from every run block."""
+    command_lines: list[str] = []
+    run_indent: int | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip())
+        if run_indent is not None:
+            if stripped and indent <= run_indent:
+                run_indent = None
+            elif stripped and not stripped.startswith("#"):
+                command_lines.append(stripped)
+                continue
+            else:
+                continue
+        if re.match(r"^\s*run:\s*\|\s*$", line):
+            run_indent = indent
+        elif re.match(r"^\s*uses:\s*", line):
+            command_lines.append(stripped)
+    return command_lines
+
+
 def test_release_resolves_policy_before_building() -> None:
     text = _workflow_text()
     assert "resolve:" in text
@@ -59,10 +81,7 @@ def test_release_checkouts_pin_canonical_repository_and_immutable_tag() -> None:
 
     assert text.count("uses: actions/checkout@") == 3
     assert len(checkout_with_blocks) == 3
-    assert all(
-        block.count("repository: Hal0ai/hal0") == 1
-        for block in checkout_with_blocks
-    )
+    assert all(block.count("repository: Hal0ai/hal0") == 1 for block in checkout_with_blocks)
     assert sum(block.count("repository: Hal0ai/hal0") for block in checkout_with_blocks) == 3
     assert text.count("ref: refs/tags/${{ needs.resolve.outputs.tag }}") == 2
     assert text.count("EXPECTED_SHA: ${{ needs.resolve.outputs.target_sha }}") == 2
@@ -86,7 +105,7 @@ def test_preview_release_is_not_latest_and_upload_is_immutable() -> None:
     assert 'gh release upload "${TAG}" "${ASSETS[@]}"' in publish
     assert "--clobber" not in text
     assert 'gh release view "${TAG}"' in text
-    assert 'asset collision:' in text
+    assert "asset collision:" in text
 
 
 def test_release_policy_controls_manifests_and_pypi() -> None:
@@ -109,15 +128,38 @@ def test_release_signs_verifies_and_uploads_every_manifest_bundle() -> None:
 
 def test_channel_pointer_advancement_is_a_separate_final_gate() -> None:
     text = _workflow_text()
-    gate = text.split(
-        "      - name: Record separately verified channel pointer gate", 1
-    )[1].split("      - name: Summary", 1)[0]
+    gate = text.split("      - name: Record separately verified channel pointer gate", 1)[1].split(
+        "      - name: Summary", 1
+    )[0]
 
     assert "channel pointer" in text.lower()
     assert "separately verified" in text.lower()
     assert 'echo "Channel pointer advancement remains external' in gate
     for publishing_command in ("curl ", "gh ", "git push", "upload", "release create"):
         assert publishing_command not in gate
+
+    # The external pointer endpoint may be documented, but never executed by
+    # this workflow. This scans every job rather than trusting the named gate.
+    pointer_endpoint_mentions = [
+        line for line in text.splitlines() if "releases.hal0.dev" in line.lower()
+    ]
+    assert pointer_endpoint_mentions
+    assert all(line.lstrip().startswith("#") for line in pointer_endpoint_mentions)
+
+    command_surface = "\n".join(_workflow_command_lines(text)).lower()
+    external_pointer_markers = (
+        r"releases\.hal0\.dev",
+        r"\bhal0-web\b",
+        r"\bcloudflare\b",
+        r"\bwrangler\b",
+        r"\bapi\.cloudflare\.com\b",
+        r"\b(?:aws\s+s3|gsutil|rclone)\b",
+        r"\br2(?:://|\s+(?:bucket|object|put|copy))\b",
+        r"\b(?:advance|update|publish|promote|write|sync)[-_ ](?:channel[-_ ]?)?pointer\b",
+        r"\bchannel[-_ ]pointer[-_ ](?:advance|update|publish|promote|write|sync)\b",
+    )
+    for marker in external_pointer_markers:
+        assert re.search(marker, command_surface) is None, marker
 
 
 def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
@@ -126,9 +168,7 @@ def test_release_tree_pins_installer_and_updater_runtime_inputs() -> None:
         "      - name: Stage release notes", 1
     )[0]
 
-    staged_roots = re.findall(
-        r'(?m)^\s*cp -a\s+(\S+)\s+"\$\{STAGE\}/"\s*$', stage
-    )
+    staged_roots = re.findall(r'(?m)^\s*cp -a\s+(\S+)\s+"\$\{STAGE\}/"\s*$', stage)
     assert staged_roots == [
         "src",
         "manifest.json",

--- a/tests/scripts/test_set_version.py
+++ b/tests/scripts/test_set_version.py
@@ -256,11 +256,12 @@ class TestSetVersion:
 
         _assert_original_bytes(paths, originals)
 
-    def test_rollback_failure_is_reported_loudly(
+    def test_rollback_failure_preserves_original_backup_and_reports_recovery_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A restore error is not hidden behind the original update error."""
-        _populate_project(tmp_path, "1.0.0-alpha.0")
+        """A failed restore retains the original bytes and recovery instructions."""
+        paths = _populate_project(tmp_path, "1.0.0-alpha.0")
+        originals = _original_bytes(paths)
         mod = _load_set_version()
         real_replace = mod.os.replace
         calls = 0
@@ -275,10 +276,17 @@ class TestSetVersion:
         monkeypatch.setattr(mod.os, "replace", fail_update_and_restore)
         monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: None)
 
-        with pytest.raises(RuntimeError, match="ROLLBACK FAILED"):
+        with pytest.raises(RuntimeError, match="ROLLBACK FAILED") as exc_info:
             mod.set_version(tmp_path, "1.0.0-alpha.2")
 
-        assert not list(tmp_path.glob(".set-version.*"))
+        transaction_dirs = list(tmp_path.glob(".set-version.*"))
+        assert len(transaction_dirs) == 1
+        failed_backup = transaction_dirs[0] / ".original.0"
+        assert failed_backup.read_bytes() == originals["pyproject.toml"]
+        error = str(exc_info.value)
+        assert str(failed_backup) in error
+        assert str(paths["pyproject.toml"]) in error
+        assert sorted(path.name for path in transaction_dirs[0].iterdir()) == [".original.0"]
 
     def test_uv_lock_failure_rolls_back_every_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -294,6 +302,28 @@ class TestSetVersion:
         monkeypatch.setattr(mod.subprocess, "run", fail_uv_lock)
 
         with pytest.raises(mod.subprocess.CalledProcessError):
+            mod.set_version(tmp_path, "1.0.0-alpha.2")
+
+        _assert_original_bytes(paths, originals)
+
+    def test_post_lock_revalidation_failure_restores_every_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A post-lock mismatch restores all originals and removes transaction state."""
+        paths = _populate_project(tmp_path, "1.0.0-alpha.0")
+        originals = _original_bytes(paths)
+        mod = _load_set_version()
+
+        def corrupt_regenerated_lock(*args: object, **kwargs: object) -> None:
+            lock_path = tmp_path / "uv.lock"
+            lock_path.write_text(
+                _replace_lock_version(lock_path.read_text(encoding="utf-8"), "9.9.9"),
+                encoding="utf-8",
+            )
+
+        monkeypatch.setattr(mod.subprocess, "run", corrupt_regenerated_lock)
+
+        with pytest.raises(RuntimeError, match="post-lock re-validation"):
             mod.set_version(tmp_path, "1.0.0-alpha.2")
 
         _assert_original_bytes(paths, originals)

--- a/tests/scripts/test_set_version.py
+++ b/tests/scripts/test_set_version.py
@@ -9,6 +9,7 @@ a hyphen.
 from __future__ import annotations
 
 import json
+import os
 import sys
 import textwrap
 from pathlib import Path
@@ -186,6 +187,37 @@ class TestSetVersion:
         lock_data = tomllib.loads(lock_text)
         hal0ai = next(p for p in lock_data["package"] if p["name"] == "hal0ai")
         assert hal0ai["version"] == "1.0.0a2"
+
+    def test_transaction_temps_share_repository_filesystem(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Replacement candidates live under root, independent of TMPDIR."""
+        _populate_project(tmp_path, "1.0.0-alpha.0")
+        mod = _load_set_version()
+        real_mkdtemp = mod.tempfile.mkdtemp
+        real_replace = mod.os.replace
+        temp_parents: list[Path] = []
+        replacement_devices: list[tuple[int, int]] = []
+
+        def recording_mkdtemp(*args: object, **kwargs: object) -> str:
+            temp_dir = Path(real_mkdtemp(*args, **kwargs))
+            temp_parents.append(temp_dir.parent)
+            return str(temp_dir)
+
+        def same_filesystem_replace(src: str, dst: str) -> None:
+            replacement_devices.append((os.stat(src).st_dev, os.stat(Path(dst).parent).st_dev))
+            real_replace(src, dst)
+
+        monkeypatch.setattr(mod.tempfile, "mkdtemp", recording_mkdtemp)
+        monkeypatch.setattr(mod.os, "replace", same_filesystem_replace)
+        monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: None)
+
+        mod.set_version(tmp_path, "1.0.0-alpha.2")
+
+        assert temp_parents == [tmp_path]
+        assert replacement_devices
+        assert all(src_device == dst_device for src_device, dst_device in replacement_devices)
+        assert not list(tmp_path.glob(".set-version.*"))
 
     def test_nightly_is_rejected(self, tmp_path: Path) -> None:
         """Nightly versions are rejected because they don't rewrite source."""

--- a/tests/scripts/test_set_version.py
+++ b/tests/scripts/test_set_version.py
@@ -118,6 +118,18 @@ def _populate_project(tmp_path: Path, version: str) -> dict[str, Path]:
     return paths
 
 
+def _original_bytes(paths: dict[str, Path]) -> dict[str, bytes]:
+    """Snapshot every versioned artifact for rollback assertions."""
+    return {name: path.read_bytes() for name, path in paths.items()}
+
+
+def _assert_original_bytes(paths: dict[str, Path], originals: dict[str, bytes]) -> None:
+    """Assert every versioned artifact and transaction cleanup were restored."""
+    assert {name: path.read_bytes() for name, path in paths.items()} == originals
+    root = paths["pyproject.toml"].parent
+    assert not list(root.glob(".set-version.*"))
+
+
 def _replace_lock_version(lock_text: str, new_version: str) -> str:
     """Replace the PEP 440 version line for ``name = "hal0ai"``."""
     import tomllib
@@ -218,6 +230,73 @@ class TestSetVersion:
         assert replacement_devices
         assert all(src_device == dst_device for src_device, dst_device in replacement_devices)
         assert not list(tmp_path.glob(".set-version.*"))
+
+    def test_mid_replacement_failure_rolls_back_every_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A one-time replacement failure restores all five original files."""
+        paths = _populate_project(tmp_path, "1.0.0-alpha.0")
+        originals = _original_bytes(paths)
+        mod = _load_set_version()
+        real_replace = mod.os.replace
+        calls = 0
+
+        def fail_once_mid_replacement(src: str, dst: str) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                raise OSError("injected mid-replacement failure")
+            real_replace(src, dst)
+
+        monkeypatch.setattr(mod.os, "replace", fail_once_mid_replacement)
+        monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: None)
+
+        with pytest.raises(OSError, match="injected mid-replacement failure"):
+            mod.set_version(tmp_path, "1.0.0-alpha.2")
+
+        _assert_original_bytes(paths, originals)
+
+    def test_rollback_failure_is_reported_loudly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A restore error is not hidden behind the original update error."""
+        _populate_project(tmp_path, "1.0.0-alpha.0")
+        mod = _load_set_version()
+        real_replace = mod.os.replace
+        calls = 0
+
+        def fail_update_and_restore(src: str, dst: str) -> None:
+            nonlocal calls
+            calls += 1
+            if calls in {3, 4}:
+                raise OSError(f"injected replacement failure {calls}")
+            real_replace(src, dst)
+
+        monkeypatch.setattr(mod.os, "replace", fail_update_and_restore)
+        monkeypatch.setattr(mod.subprocess, "run", lambda *args, **kwargs: None)
+
+        with pytest.raises(RuntimeError, match="ROLLBACK FAILED"):
+            mod.set_version(tmp_path, "1.0.0-alpha.2")
+
+        assert not list(tmp_path.glob(".set-version.*"))
+
+    def test_uv_lock_failure_rolls_back_every_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed uv lock restores all five original files and cleans up."""
+        paths = _populate_project(tmp_path, "1.0.0-alpha.0")
+        originals = _original_bytes(paths)
+        mod = _load_set_version()
+
+        def fail_uv_lock(*args: object, **kwargs: object) -> None:
+            raise mod.subprocess.CalledProcessError(1, ["uv", "lock"])
+
+        monkeypatch.setattr(mod.subprocess, "run", fail_uv_lock)
+
+        with pytest.raises(mod.subprocess.CalledProcessError):
+            mod.set_version(tmp_path, "1.0.0-alpha.2")
+
+        _assert_original_bytes(paths, originals)
 
     def test_nightly_is_rejected(self, tmp_path: Path) -> None:
         """Nightly versions are rejected because they don't rewrite source."""

--- a/tests/security/test_exposure.py
+++ b/tests/security/test_exposure.py
@@ -21,12 +21,13 @@ plus ``tests/api/test_auth_core.py``.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from starlette.routing import BaseRoute, Mount
 
-from hal0.api import create_app
+from hal0.api import _mount_dashboard, create_app
 from hal0.security.exposure import OPEN_ALLOWLIST, AuthClass, classify, match_rule
 
 
@@ -111,8 +112,13 @@ def _classify_method(method: str) -> str:
 
 
 @pytest.fixture(scope="module")
-def app_routes() -> set[tuple[str, str]]:
-    app = create_app()
+def app_routes(tmp_path_factory: pytest.TempPathFactory) -> set[tuple[str, str]]:
+    hal0_home = tmp_path_factory.mktemp("exposure-hal0-home")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("HAL0_HOME", str(hal0_home))
+        monkeypatch.setattr("hal0.api._mount_dashboard", lambda _app: None)
+        app = create_app()
+
     routes = _enumerate_routes(app)
     assert len(routes) > 100, (
         f"only found {len(routes)} routes -- the route walker probably isn't "
@@ -163,6 +169,30 @@ def test_open_allowlist_is_exact(app_routes: set[tuple[str, str]]) -> None:
         f"Newly OPEN (not expected): {sorted(actual_open - OPEN_ALLOWLIST)}\n"
         f"Missing (expected but not OPEN): {sorted(OPEN_ALLOWLIST - actual_open)}"
     )
+
+
+def test_dashboard_route_templates_are_open_when_mounted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "brand").mkdir()
+    (dist / "index.html").write_text("<html></html>", encoding="utf-8")
+    (dist / "favicon.svg").write_text("<svg></svg>", encoding="utf-8")
+    monkeypatch.setenv("HAL0_UI_DIST", str(dist))
+
+    app = FastAPI()
+    _mount_dashboard(app)
+    mounted = _enumerate_routes(app)
+    expected = {
+        ("GET", "/assets"),
+        ("GET", "/brand"),
+        ("GET", "/favicon.svg"),
+        ("GET", "/{full_path:path}"),
+    }
+
+    assert expected <= mounted
+    assert all(classify(method, path) is AuthClass.OPEN for method, path in expected)
 
 
 def test_bootstrap_class_covers_installer(app_routes: set[tuple[str, str]]) -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pytest
 
+import hal0.updater as updater_package
 import hal0.updater.updater as updater_module
 from hal0.updater import (
     ReleaseInfo,
@@ -494,6 +495,38 @@ def test_check_handles_missing_manifest(
     monkeypatch.setenv("HAL0_RELEASES_URL", str(tmp_path / "nope.json"))
     with pytest.raises(UpdateError):
         asyncio.run(Updater().check())
+
+
+def test_check_rejects_wrong_channel_manifest(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """check() rejects a manifest that prepare() would reject for the channel."""
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    tarball = _build_release_tarball(tmp=artifacts, version="99.0.0")
+    manifest_path = artifacts / "latest.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version="99.0.0",
+        overrides={"channel": "nightly", "release_kind": "nightly"},
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater(channel="stable").check())
+
+    assert exc_info.value.code == "system.update_manifest_invalid"
+    assert exc_info.value.details["channel"] == "stable"
+
+
+def test_validate_manifest_for_channel_is_public_export() -> None:
+    """The shared channel validator is available from the updater package."""
+    assert "validate_manifest_for_channel" in updater_package.__all__
+    assert (
+        updater_package.validate_manifest_for_channel
+        is updater_module.validate_manifest_for_channel
+    )
 
 
 def test_check_does_not_recommend_revoked_latest(
@@ -1079,23 +1112,21 @@ def test_rollback_repip_failure_re_swaps_symlink_forward(
 def test_check_uses_per_channel_url(
     tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The check() method honours the channel argument when looking up the URL.
-
-    With HAL0_RELEASES_URL set to a file:// path, the channel parameter
-    doesn't rewrite the URL but the returned ReleaseInfo.channel reflects
-    the requested channel — exactly the contract the route layer needs.
-    """
+    """The check() method honours its channel argument when looking up the URL."""
     artifacts = tmp_path / "artifacts"
     artifacts.mkdir()
     tarball = _build_release_tarball(tmp=artifacts, version="0.0.1")
     manifest_path = artifacts / "latest.json"
-    _write_release_manifest(manifest_path=manifest_path, tarball=tarball, version="0.0.1")
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version="0.0.1",
+        overrides={"channel": "nightly", "release_kind": "nightly"},
+    )
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
 
-    info_stable = asyncio.run(Updater(channel="stable").check())
-    info_nightly = asyncio.run(Updater(channel="nightly").check())
-    assert info_stable.channel == "stable"
-    assert info_nightly.channel == "nightly"
+    info = asyncio.run(Updater(channel="stable").check(channel="nightly"))
+    assert info.channel == "nightly"
 
 
 # ── #510: dead-code sweep ──────────────────────────────────────────────────────

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1,11 +1,11 @@
 """Tests for hal0.updater.Updater — apply, rollback, check semantics.
 
 These tests run entirely against ``HAL0_HOME`` tmp dirs and ``file://``
-release manifests; no network, no real cosign. The ``cosign_skip`` fixture
-stubs :func:`hal0.updater.updater._verify_cosign` to a no-op for the
-happy-path tests so the swap orchestration can be exercised without a real
-signed artifact — cosign verification itself is mandatory in production and
-has no runtime bypass.
+release manifests; no network and no cryptographic claims. Most happy-path
+swap tests use the ``cosign_skip`` verification seam. Preview rehearsal tests
+instead execute the real :func:`hal0.updater.updater._verify_cosign` subprocess
+path against a hermetic fake ``cosign`` executable that validates and records
+its bundle/blob arguments; cosign remains mandatory in production.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -108,9 +109,9 @@ def _write_release_manifest(
 ) -> dict[str, Any]:
     """Write a full hal0.releases.v1 manifest pointing at file:// URLs.
 
-    The manifest carries a ``bundle_url`` (a Sigstore bundle that embeds the
-    cert + signature + Rekor SET, #1159) — the only signing scheme the
-    updater accepts.
+    The synthetic manifest has the production ``bundle_url`` shape, but its
+    placeholder bundle bytes are only for exercising test verification seams;
+    they are not cryptographic signatures.
     """
     bundle = bundle if bundle is not None else Path(f"{tarball}.bundle")
     if not bundle.exists():
@@ -137,6 +138,73 @@ def _write_release_manifest(
     manifest_path.write_text(json.dumps(payload), encoding="utf-8")
     Path(f"{manifest_path}.bundle").write_bytes(b"manifest-bundle-placeholder\n")
     return payload
+
+
+def _install_fake_cosign(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, reject: bool = False
+) -> Path:
+    """Install a hermetic cosign verifier that validates pairs and logs argv.
+
+    This exercises the updater's real subprocess wrapper, not cryptography.
+    The executable requires the exact production ``verify-blob`` argument
+    shape, existing files, and a sibling ``<blob>.bundle`` path.
+    """
+    fake_bin = tmp_path / "fake-cosign-bin"
+    fake_bin.mkdir(exist_ok=True)
+    log_path = tmp_path / "fake-cosign-invocations.jsonl"
+    fake = fake_bin / "cosign"
+    fake.write_text(
+        f"#!{sys.executable}\n"
+        + """import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if len(args) != 8 or args[0] != "verify-blob":
+    print(f"unexpected cosign argv: {args!r}", file=sys.stderr)
+    raise SystemExit(64)
+if args[1] != "--bundle" or args[3] != "--certificate-identity-regexp":
+    print(f"unexpected cosign flags: {args!r}", file=sys.stderr)
+    raise SystemExit(64)
+if args[5] != "--certificate-oidc-issuer":
+    print(f"unexpected cosign flags: {args!r}", file=sys.stderr)
+    raise SystemExit(64)
+
+bundle = Path(args[2])
+blob = Path(args[7])
+if bundle != Path(f"{blob}.bundle"):
+    print(f"bundle/blob mismatch: {bundle} != {blob}.bundle", file=sys.stderr)
+    raise SystemExit(65)
+if not blob.is_file() or not bundle.is_file():
+    print(f"missing verification input: blob={blob} bundle={bundle}", file=sys.stderr)
+    raise SystemExit(66)
+
+entry = {
+    "args": args,
+    "blob": str(blob),
+    "bundle": str(bundle),
+    "blob_sha256": hashlib.sha256(blob.read_bytes()).hexdigest(),
+    "bundle_sha256": hashlib.sha256(bundle.read_bytes()).hexdigest(),
+}
+with Path(os.environ["HAL0_FAKE_COSIGN_LOG"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(entry) + "\\n")
+if os.environ.get("HAL0_FAKE_COSIGN_MODE") == "reject":
+    print("synthetic signature rejection", file=sys.stderr)
+    raise SystemExit(1)
+""",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("HAL0_FAKE_COSIGN_LOG", str(log_path))
+    monkeypatch.setenv("HAL0_FAKE_COSIGN_MODE", "reject" if reject else "accept")
+    return log_path
+
+
+def _fake_cosign_calls(log_path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
 
 
 @pytest.fixture
@@ -193,7 +261,11 @@ def synthetic_release(
 def synthetic_preview_release(
     tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> dict[str, Any]:
-    """Build an entirely local alpha release and signed-manifest fixture."""
+    """Build local alpha bytes for the updater's synthetic verification seam.
+
+    The bundle files are placeholders accepted by the fake cosign executable;
+    this fixture does not represent or claim real cryptographic verification.
+    """
     artifacts = tmp_path / "preview-artifacts"
     artifacts.mkdir()
     version = "99.0.0-alpha.1"
@@ -526,11 +598,13 @@ def test_check_returns_typed_release_info(
     assert info.update_available is True or info.update_available is False  # type sanity
 
 
-def test_preview_check_and_prepare_verify_local_signed_manifest_without_activation(
-    synthetic_preview_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+def test_preview_check_and_prepare_exercise_cosign_subprocess_without_activation(
+    synthetic_preview_release: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    """Rehearse preview check + prepare using file:// artifacts only."""
-    verification_calls: list[tuple[str, bytes, bytes, str, str]] = []
+    """Rehearse preview verification plumbing with synthetic file:// inputs."""
+    cosign_log = _install_fake_cosign(tmp_path, monkeypatch)
     download_urls: list[str] = []
     original_download = updater_module._download
 
@@ -538,26 +612,7 @@ def test_preview_check_and_prepare_verify_local_signed_manifest_without_activati
         download_urls.append(url)
         await original_download(url, destination)
 
-    def record_verification(
-        blob: Path,
-        bundle: Path,
-        *,
-        identity_regexp: str,
-        issuer: str,
-        job_id: str | None = None,
-    ) -> None:
-        verification_calls.append(
-            (
-                blob.name,
-                blob.read_bytes(),
-                bundle.read_bytes(),
-                identity_regexp,
-                issuer,
-            )
-        )
-
     monkeypatch.setattr(updater_module, "_download", record_local_download)
-    monkeypatch.setattr(updater_module, "_verify_cosign", record_verification)
 
     updater = Updater(channel="preview")
     info = asyncio.run(updater.check())
@@ -583,22 +638,46 @@ def test_preview_check_and_prepare_verify_local_signed_manifest_without_activati
         payload["bundle_url"],
     ]
     assert all(url.startswith("file://") for url in download_urls)
-    assert [call[0] for call in verification_calls] == [
+
+    verification_calls = _fake_cosign_calls(cosign_log)
+    assert [Path(call["blob"]).name for call in verification_calls] == [
         "manifest.json",
         "manifest.json",
         synthetic_preview_release["tarball"].name,
     ]
+    manifest_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    manifest_bundle_digest = hashlib.sha256(
+        Path(f"{manifest_path}.bundle").read_bytes()
+    ).hexdigest()
     for call in verification_calls[:2]:
-        assert call[1] == manifest_path.read_bytes()
-        assert call[2] == Path(f"{manifest_path}.bundle").read_bytes()
-        assert call[3:] == (
+        assert call["blob_sha256"] == manifest_digest
+        assert call["bundle_sha256"] == manifest_bundle_digest
+        assert call["args"] == [
+            "verify-blob",
+            "--bundle",
+            call["bundle"],
+            "--certificate-identity-regexp",
             updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP,
+            "--certificate-oidc-issuer",
             updater_module._MANIFEST_SIGNER_ISSUER,
-        )
-    assert verification_calls[2][3:] == (
+            call["blob"],
+        ]
+
+    artifact_call = verification_calls[2]
+    cached_tarball = updater_module._cache_dir(version) / f"hal0-{version}.tar.gz"
+    assert artifact_call["blob"] == str(cached_tarball)
+    assert artifact_call["bundle"] == f"{cached_tarball}.bundle"
+    assert artifact_call["blob_sha256"] == _sha256_of(synthetic_preview_release["tarball"])
+    assert artifact_call["args"] == [
+        "verify-blob",
+        "--bundle",
+        str(Path(f"{cached_tarball}.bundle")),
+        "--certificate-identity-regexp",
         payload["signer_identity"],
+        "--certificate-oidc-issuer",
         payload["signer_issuer"],
-    )
+        str(cached_tarball),
+    ]
 
 
 @pytest.mark.parametrize("operation", ["check", "prepare"])
@@ -606,8 +685,10 @@ def test_preview_manifest_verification_failure_leaves_no_staged_state(
     operation: str,
     synthetic_preview_release: dict[str, Any],
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
-    """A rejected channel-manifest bundle cannot reach artifact staging."""
+    """A fake-cosign rejection cannot reach artifact staging or activation."""
+    cosign_log = _install_fake_cosign(tmp_path, monkeypatch, reject=True)
     download_urls: list[str] = []
     original_download = updater_module._download
 
@@ -615,11 +696,7 @@ def test_preview_manifest_verification_failure_leaves_no_staged_state(
         download_urls.append(url)
         await original_download(url, destination)
 
-    def reject_manifest(*args: Any, **kwargs: Any) -> None:
-        raise UpdateCosignFailed("local rehearsal rejected manifest signature")
-
     monkeypatch.setattr(updater_module, "_download", record_local_download)
-    monkeypatch.setattr(updater_module, "_verify_cosign", reject_manifest)
 
     updater = Updater(channel="preview")
     with pytest.raises(UpdateCosignFailed):
@@ -628,7 +705,9 @@ def test_preview_manifest_verification_failure_leaves_no_staged_state(
     version = synthetic_preview_release["version"]
     manifest_path = synthetic_preview_release["manifest_path"]
     assert download_urls == [f"{manifest_path.as_uri()}.bundle"]
+    assert len(_fake_cosign_calls(cosign_log)) == 1
     assert not updater_module._cache_dir(version).exists()
+    assert not updater_module._manifest_cache_path(version).exists()
     assert not _versioned_install_dir(version).exists()
     assert not _current_symlink().is_symlink()
 

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -328,9 +328,7 @@ def test_stable_channel_rejects_preview_manifest() -> None:
 
 
 def test_requested_channel_must_match_manifest_channel() -> None:
-    manifest = _parse_manifest(
-        {**VALID_MANIFEST, "channel": "nightly", "release_kind": "nightly"}
-    )
+    manifest = _parse_manifest({**VALID_MANIFEST, "channel": "nightly", "release_kind": "nightly"})
     with pytest.raises(ValueError, match=r"manifest channel.*nightly"):
         updater_module.validate_manifest_for_channel(manifest, "preview")
 
@@ -518,6 +516,36 @@ def test_check_rejects_wrong_channel_manifest(
 
     assert exc_info.value.code == "system.update_manifest_invalid"
     assert exc_info.value.details["channel"] == "stable"
+
+
+def test_prepare_rejects_wrong_channel_before_download_or_cache_write(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """prepare() validates channel coherence before creating staged state."""
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    tarball = _build_release_tarball(tmp=artifacts, version="99.0.0")
+    manifest_path = artifacts / "latest.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version="99.0.0",
+        overrides={"channel": "nightly", "release_kind": "nightly"},
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    downloads: list[str] = []
+
+    async def record_download(url: str, destination: Path) -> None:
+        downloads.append(url)
+
+    monkeypatch.setattr(updater_module, "_download", record_download)
+
+    with pytest.raises(UpdateManifestInvalid):
+        asyncio.run(Updater(channel="stable").prepare())
+
+    assert downloads == []
+    assert not updater_module._cache_dir("99.0.0").exists()
 
 
 def test_validate_manifest_for_channel_is_public_export() -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -337,6 +337,38 @@ def test_manifest_schema_accepts_full_payload(tmp_path: Path) -> None:
     assert len(m.digest_sha256) == 64
 
 
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.2.3",
+        "1.2.3-alpha.0",
+        "1.2.3-beta.2",
+        "1.2.3-rc.1",
+        "1.2.3-nightly.20260721060000",
+    ],
+)
+def test_manifest_schema_accepts_canonical_release_versions(version: str) -> None:
+    manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": version})
+    assert manifest.version == version
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "../../outside",
+        "1.2.3/../../outside",
+        r"1.2.3\..\outside",
+        "/tmp/outside",
+        " 1.2.3 ",
+        "1.2.3-preview.1",
+        "1.2.3-alpha1",
+    ],
+)
+def test_manifest_schema_rejects_hostile_or_noncanonical_versions(version: str) -> None:
+    with pytest.raises(UpdateManifestInvalid):
+        _parse_manifest({**VALID_MANIFEST, "version": version})
+
+
 def test_manifest_schema_rejects_missing_required_fields() -> None:
     """The pydantic schema rejects manifests without bundle_url / digest_sha256."""
     with pytest.raises(UpdateManifestInvalid):
@@ -1097,13 +1129,12 @@ def test_apply_repip_failure_rolls_back_symlink(
 # ── prepare / commit split ─────────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize("requested_version", ["0.0.2", "../../outside"])
 def test_prepare_rejects_mismatched_pin_before_staging_paths(
-    requested_version: str,
     tmp_hal0_home: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An authenticated channel manifest cannot be staged under a caller label."""
+    requested_version = "0.0.2"
     manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": "0.0.1"})
 
     async def fake_fetch(
@@ -1133,14 +1164,80 @@ def test_prepare_rejects_mismatched_pin_before_staging_paths(
     }
 
 
-@pytest.mark.parametrize("requested_version", ["0.0.1", " 0.0.1 "])
-def test_prepare_matching_pin_stages_authenticated_manifest_version(
+@pytest.mark.parametrize(
+    "requested_version",
+    [
+        "../../outside",
+        "1.2.3/../../outside",
+        r"1.2.3\..\outside",
+        "/tmp/outside",
+        " 0.0.1 ",
+        "1.2.3-preview.1",
+    ],
+)
+def test_prepare_rejects_invalid_pin_before_staging_paths(
     requested_version: str,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": "0.0.1"})
+
+    async def fake_fetch(
+        channel: str, *, job_id: str | None = None
+    ) -> tuple[dict[str, Any], ReleaseManifest, str]:
+        return manifest.model_dump(by_alias=True), manifest, "https://example.test/stable.json"
+
+    def unexpected_path(version: str) -> Path:
+        raise AssertionError(f"staging path constructed for invalid pin: {version}")
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(updater_module, "_fetch_verified_release_manifest", fake_fetch)
+    monkeypatch.setattr(updater_module, "_cache_dir", unexpected_path)
+    monkeypatch.setattr(updater_module, "_manifest_cache_path", unexpected_path)
+    monkeypatch.setattr(updater_module, "_versioned_install_dir", unexpected_path)
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater(channel="stable").prepare(requested_version))
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.details["requested_version"] == requested_version
+
+
+@pytest.mark.parametrize("manifest_version", ["../../outside", "/tmp/outside", r"1.2.3\x"])
+def test_prepare_revalidates_manifest_version_before_staging_paths(
+    manifest_version: str,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense in depth holds even if a caller bypasses pydantic construction."""
+    manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": "0.0.1"}).model_copy(
+        update={"version": manifest_version}
+    )
+
+    async def fake_fetch(
+        channel: str, *, job_id: str | None = None
+    ) -> tuple[dict[str, Any], ReleaseManifest, str]:
+        return {**VALID_MANIFEST, "version": manifest_version}, manifest, "https://example.test/x"
+
+    def unexpected_path(version: str) -> Path:
+        raise AssertionError(f"staging path constructed for invalid manifest: {version}")
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(updater_module, "_fetch_verified_release_manifest", fake_fetch)
+    monkeypatch.setattr(updater_module, "_cache_dir", unexpected_path)
+    monkeypatch.setattr(updater_module, "_manifest_cache_path", unexpected_path)
+    monkeypatch.setattr(updater_module, "_versioned_install_dir", unexpected_path)
+
+    with pytest.raises(UpdateManifestInvalid):
+        asyncio.run(Updater(channel="stable").prepare())
+
+
+def test_prepare_matching_pin_stages_authenticated_manifest_version(
     synthetic_release: dict[str, Any],
     cosign_skip: None,
 ) -> None:
-    """An exact optimistic pin preserves the normal prepare flow after trimming."""
-    res = asyncio.run(Updater().prepare(requested_version))
+    """An exact optimistic pin preserves the normal prepare flow."""
+    res = asyncio.run(Updater().prepare("0.0.1"))
 
     assert res["version"] == "0.0.1"
     assert _versioned_install_dir("0.0.1").is_dir()
@@ -1209,6 +1306,40 @@ def test_commit_without_prepare_raises(tmp_hal0_home: str, monkeypatch: pytest.M
     monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
     with pytest.raises(UpdateError):
         asyncio.run(Updater().commit("0.0.1"))
+
+
+@pytest.mark.parametrize(
+    "commit_version",
+    [
+        "../../outside",
+        "1.2.3/../../outside",
+        r"1.2.3\..\outside",
+        "/tmp/outside",
+        " 1.2.3 ",
+        "1.2.3-preview.1",
+    ],
+)
+def test_commit_rejects_invalid_version_before_any_staging_path(
+    commit_version: str,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_path(version: str) -> Path:
+        raise AssertionError(f"staging path constructed for invalid commit: {version}")
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(updater_module, "_cache_dir", unexpected_path)
+    monkeypatch.setattr(updater_module, "_manifest_cache_path", unexpected_path)
+    monkeypatch.setattr(updater_module, "_versioned_install_dir", unexpected_path)
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater().commit(commit_version))
+
+    assert exc_info.value.status == 400
+    assert exc_info.value.details["commit_version"] == commit_version
+    home = Path(tmp_hal0_home)
+    assert not (home / "var-lib" / "hal0" / "cache").exists()
+    assert not (home / "usr-lib" / "hal0").exists()
 
 
 def test_commit_rejects_cached_manifest_for_different_version(

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -189,6 +189,36 @@ def synthetic_release(
     }
 
 
+@pytest.fixture
+def synthetic_preview_release(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Any]:
+    """Build an entirely local alpha release and signed-manifest fixture."""
+    artifacts = tmp_path / "preview-artifacts"
+    artifacts.mkdir()
+    version = "99.0.0-alpha.1"
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
+    manifest_path = artifacts / "preview-manifest.json"
+    payload = _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version=version,
+        overrides={
+            "channel": "preview",
+            "release_kind": "preview",
+            "prerelease_stage": "alpha",
+        },
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", manifest_path.as_uri())
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+    return {
+        "version": version,
+        "tarball": tarball,
+        "manifest_path": manifest_path,
+        "payload": payload,
+    }
+
+
 # ── releases_url ───────────────────────────────────────────────────────────────
 
 
@@ -494,6 +524,113 @@ def test_check_returns_typed_release_info(
     assert info.digest_sha256 == synthetic_release["payload"]["digest_sha256"]
     assert info.signer_identity == synthetic_release["payload"]["signer_identity"]
     assert info.update_available is True or info.update_available is False  # type sanity
+
+
+def test_preview_check_and_prepare_verify_local_signed_manifest_without_activation(
+    synthetic_preview_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rehearse preview check + prepare using file:// artifacts only."""
+    verification_calls: list[tuple[str, bytes, bytes, str, str]] = []
+    download_urls: list[str] = []
+    original_download = updater_module._download
+
+    async def record_local_download(url: str, destination: Path) -> None:
+        download_urls.append(url)
+        await original_download(url, destination)
+
+    def record_verification(
+        blob: Path,
+        bundle: Path,
+        *,
+        identity_regexp: str,
+        issuer: str,
+        job_id: str | None = None,
+    ) -> None:
+        verification_calls.append(
+            (
+                blob.name,
+                blob.read_bytes(),
+                bundle.read_bytes(),
+                identity_regexp,
+                issuer,
+            )
+        )
+
+    monkeypatch.setattr(updater_module, "_download", record_local_download)
+    monkeypatch.setattr(updater_module, "_verify_cosign", record_verification)
+
+    updater = Updater(channel="preview")
+    info = asyncio.run(updater.check())
+
+    version = synthetic_preview_release["version"]
+    manifest_path = synthetic_preview_release["manifest_path"]
+    payload = synthetic_preview_release["payload"]
+    assert info.latest == version
+    assert info.channel == "preview"
+    assert info.raw_manifest["release_kind"] == "preview"
+    assert not updater_module._cache_dir(version).exists()
+
+    prepared = asyncio.run(updater.prepare())
+
+    assert prepared["version"] == version
+    assert Path(prepared["install_dir"]).is_dir()
+    assert updater_module._manifest_cache_path(version).is_file()
+    assert not _current_symlink().is_symlink()
+    assert download_urls == [
+        f"{manifest_path.as_uri()}.bundle",
+        f"{manifest_path.as_uri()}.bundle",
+        payload["url"],
+        payload["bundle_url"],
+    ]
+    assert all(url.startswith("file://") for url in download_urls)
+    assert [call[0] for call in verification_calls] == [
+        "manifest.json",
+        "manifest.json",
+        synthetic_preview_release["tarball"].name,
+    ]
+    for call in verification_calls[:2]:
+        assert call[1] == manifest_path.read_bytes()
+        assert call[2] == Path(f"{manifest_path}.bundle").read_bytes()
+        assert call[3:] == (
+            updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP,
+            updater_module._MANIFEST_SIGNER_ISSUER,
+        )
+    assert verification_calls[2][3:] == (
+        payload["signer_identity"],
+        payload["signer_issuer"],
+    )
+
+
+@pytest.mark.parametrize("operation", ["check", "prepare"])
+def test_preview_manifest_verification_failure_leaves_no_staged_state(
+    operation: str,
+    synthetic_preview_release: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected channel-manifest bundle cannot reach artifact staging."""
+    download_urls: list[str] = []
+    original_download = updater_module._download
+
+    async def record_local_download(url: str, destination: Path) -> None:
+        download_urls.append(url)
+        await original_download(url, destination)
+
+    def reject_manifest(*args: Any, **kwargs: Any) -> None:
+        raise UpdateCosignFailed("local rehearsal rejected manifest signature")
+
+    monkeypatch.setattr(updater_module, "_download", record_local_download)
+    monkeypatch.setattr(updater_module, "_verify_cosign", reject_manifest)
+
+    updater = Updater(channel="preview")
+    with pytest.raises(UpdateCosignFailed):
+        asyncio.run(getattr(updater, operation)())
+
+    version = synthetic_preview_release["version"]
+    manifest_path = synthetic_preview_release["manifest_path"]
+    assert download_urls == [f"{manifest_path.as_uri()}.bundle"]
+    assert not updater_module._cache_dir(version).exists()
+    assert not _versioned_install_dir(version).exists()
+    assert not _current_symlink().is_symlink()
 
 
 def test_check_uses_pinned_trust_root_for_unauthenticated_manifest(

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -868,6 +868,46 @@ def test_authenticated_manifest_rejects_broad_signer_before_exact_reverify(
     assert identities == [updater_module.manifest_admission_identity("stable")]
 
 
+@pytest.mark.parametrize("operation", ["check", "prepare"])
+def test_authenticated_manifest_rejects_forged_issuer_before_artifact_download(
+    operation: str,
+    synthetic_release: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = synthetic_release["payload"]
+    payload["signer_issuer"] = "https://issuer.attacker.example"
+    synthetic_release["manifest_path"].write_text(json.dumps(payload), encoding="utf-8")
+    verified_issuers: list[str] = []
+    downloads: list[str] = []
+    original_download = updater_module._download
+
+    def record_verify(
+        blob: Path,
+        bundle: Path,
+        *,
+        identity_regexp: str,
+        issuer: str,
+        job_id: str | None = None,
+    ) -> None:
+        verified_issuers.append(issuer)
+
+    async def record_download(url: str, destination: Path) -> None:
+        downloads.append(url)
+        await original_download(url, destination)
+
+    monkeypatch.setattr(updater_module, "_verify_cosign", record_verify)
+    monkeypatch.setattr(updater_module, "_download", record_download)
+
+    with pytest.raises(UpdateManifestInvalid, match="signer_issuer"):
+        asyncio.run(getattr(Updater(channel="stable"), operation)())
+
+    manifest_path = synthetic_release["manifest_path"]
+    assert verified_issuers == [updater_module._MANIFEST_SIGNER_ISSUER]
+    assert downloads == [f"{manifest_path}.bundle"]
+    assert not updater_module._cache_dir(synthetic_release["version"]).exists()
+    assert not _current_symlink().exists()
+
+
 @pytest.mark.parametrize(
     ("channel", "accepted", "rejected"),
     [
@@ -1501,6 +1541,67 @@ def test_commit_rejects_cached_manifest_for_different_version(
         "manifest_version": "0.0.2",
     }
     assert not _current_symlink().exists()
+
+
+def test_commit_revalidates_cached_manifest_channel_before_activation(
+    synthetic_preview_release: dict[str, Any],
+    cosign_skip: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    version = synthetic_preview_release["version"]
+    asyncio.run(Updater(channel="preview").prepare())
+    side_effects: list[str] = []
+
+    def unexpected_migration(*args: Any, **kwargs: Any) -> tuple[int, int]:
+        side_effects.append("migration")
+        return (1, 1)
+
+    def unexpected_swap(*args: Any, **kwargs: Any) -> None:
+        side_effects.append("symlink")
+
+    monkeypatch.setattr(updater_module, "_maybe_run_config_migrations", unexpected_migration)
+    monkeypatch.setattr(updater_module, "_atomic_symlink_swap", unexpected_swap)
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater(channel="stable").commit(version))
+
+    assert exc_info.value.details["channel"] == "stable"
+    assert side_effects == []
+    assert not _current_symlink().exists()
+    assert _versioned_install_dir(version).is_dir()
+
+
+def test_preview_commit_accepts_promoted_stable_manifest(
+    tmp_hal0_home: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cosign_skip: None,
+) -> None:
+    version = "99.0.0"
+    artifacts = tmp_path / "promoted-stable-artifacts"
+    artifacts.mkdir()
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
+    manifest_path = artifacts / "preview.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version=version,
+        overrides={"channel": "preview", "release_kind": "stable"},
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(
+        updater_module,
+        "_reinstall_into_venv",
+        lambda install_dir, *, job_id=None: None,
+    )
+
+    updater = Updater(channel="preview")
+    asyncio.run(updater.prepare())
+    committed = asyncio.run(updater.commit(version))
+
+    assert committed["version"] == version
+    assert Path(os.readlink(_current_symlink())).name == f"hal0-{version}"
 
 
 def test_prepare_then_commit_swaps(synthetic_release: dict[str, Any], cosign_skip: None) -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -128,6 +128,7 @@ def _write_release_manifest(
     if overrides:
         payload.update(overrides)
     manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    Path(f"{manifest_path}.bundle").write_bytes(b"manifest-bundle-placeholder\n")
     return payload
 
 
@@ -475,7 +476,9 @@ def test_manifest_schema_defaults_for_old_stable() -> None:
 # ── check ──────────────────────────────────────────────────────────────────────
 
 
-def test_check_returns_typed_release_info(synthetic_release: dict[str, Any]) -> None:
+def test_check_returns_typed_release_info(
+    synthetic_release: dict[str, Any], cosign_skip: None
+) -> None:
     """Updater.check() returns a ReleaseInfo dataclass with the manifest fields."""
     info = asyncio.run(Updater().check())
     assert isinstance(info, ReleaseInfo)
@@ -484,6 +487,36 @@ def test_check_returns_typed_release_info(synthetic_release: dict[str, Any]) -> 
     assert info.digest_sha256 == synthetic_release["payload"]["digest_sha256"]
     assert info.signer_identity == synthetic_release["payload"]["signer_identity"]
     assert info.update_available is True or info.update_available is False  # type sanity
+
+
+def test_check_verifies_exact_manifest_bytes_with_sibling_bundle(
+    synthetic_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """check() authenticates the fetched manifest itself before returning policy."""
+    calls: list[tuple[bytes, bytes, str, str]] = []
+
+    def record_verify(
+        blob: Path,
+        bundle: Path,
+        *,
+        identity_regexp: str,
+        issuer: str,
+        job_id: str | None = None,
+    ) -> None:
+        calls.append((blob.read_bytes(), bundle.read_bytes(), identity_regexp, issuer))
+
+    monkeypatch.setattr(updater_module, "_verify_cosign", record_verify)
+
+    asyncio.run(Updater().check())
+
+    assert calls == [
+        (
+            synthetic_release["manifest_path"].read_bytes(),
+            b"manifest-bundle-placeholder\n",
+            synthetic_release["payload"]["signer_identity"],
+            synthetic_release["payload"]["signer_issuer"],
+        )
+    ]
 
 
 def test_check_handles_missing_manifest(
@@ -558,7 +591,10 @@ def test_validate_manifest_for_channel_is_public_export() -> None:
 
 
 def test_check_does_not_recommend_revoked_latest(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cosign_skip: None,
 ) -> None:
     """A revoked latest manifest is NOT reported as an available update."""
     artifacts = tmp_path / "artifacts"
@@ -582,7 +618,10 @@ def test_check_does_not_recommend_revoked_latest(
 
 
 def test_check_recommends_non_revoked_newer_latest(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cosign_skip: None,
 ) -> None:
     """A non-revoked newer manifest IS reported as an available update."""
     artifacts = tmp_path / "artifacts"
@@ -1138,7 +1177,10 @@ def test_rollback_repip_failure_re_swaps_symlink_forward(
 
 
 def test_check_uses_per_channel_url(
-    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_hal0_home: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cosign_skip: None,
 ) -> None:
     """The check() method honours its channel argument when looking up the URL."""
     artifacts = tmp_path / "artifacts"

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import pytest
 
+import hal0.updater.updater as updater_module
 from hal0.updater import (
     ReleaseInfo,
     ReleaseManifest,
@@ -47,6 +48,18 @@ from hal0.updater.updater import (
 )
 
 # ── helpers ────────────────────────────────────────────────────────────────────
+
+
+VALID_MANIFEST: dict[str, Any] = {
+    "_schema": "hal0.releases.v1",
+    "version": "1.0.0",
+    "channel": "stable",
+    "release_kind": "stable",
+    "url": "https://example.test/hal0.tar.gz",
+    "bundle_url": "https://example.test/hal0.tar.gz.bundle",
+    "digest_sha256": "0" * 64,
+    "signer_identity": "release-workflow",
+}
 
 
 def _build_release_tarball(
@@ -174,6 +187,7 @@ def test_releases_url_defaults_per_channel(monkeypatch: pytest.MonkeyPatch) -> N
     """Without the override env var the URL is per-channel under releases.hal0.dev."""
     monkeypatch.delenv("HAL0_RELEASES_URL", raising=False)
     assert releases_url("stable") == "https://releases.hal0.dev/stable.json"
+    assert releases_url("preview") == "https://releases.hal0.dev/preview.json"
     assert releases_url("nightly") == "https://releases.hal0.dev/nightly.json"
 
 
@@ -273,6 +287,57 @@ def test_manifest_schema_accepts_revoked(tmp_path: Path) -> None:
 
 
 # ── preview / release-kind manifest validation ────────────────────────────────
+
+
+def test_preview_manifest_accepts_preview_channel() -> None:
+    manifest = _parse_manifest(
+        {
+            **VALID_MANIFEST,
+            "channel": "preview",
+            "release_kind": "preview",
+            "prerelease_stage": "alpha",
+        }
+    )
+    assert updater_module.validate_manifest_for_channel(manifest, "preview") is manifest
+
+
+def test_promoted_stable_manifest_is_accepted_by_preview_channel() -> None:
+    manifest = _parse_manifest(
+        {
+            **VALID_MANIFEST,
+            "channel": "preview",
+            "release_kind": "stable",
+            "prerelease_stage": None,
+        }
+    )
+    assert updater_module.validate_manifest_for_channel(manifest, "preview") is manifest
+
+
+def test_stable_channel_rejects_preview_manifest() -> None:
+    manifest = _parse_manifest(
+        {
+            **VALID_MANIFEST,
+            "channel": "preview",
+            "release_kind": "preview",
+            "prerelease_stage": "alpha",
+        }
+    )
+    with pytest.raises(ValueError, match=r"requested channel.*stable"):
+        updater_module.validate_manifest_for_channel(manifest, "stable")
+
+
+def test_requested_channel_must_match_manifest_channel() -> None:
+    manifest = _parse_manifest(
+        {**VALID_MANIFEST, "channel": "nightly", "release_kind": "nightly"}
+    )
+    with pytest.raises(ValueError, match=r"manifest channel.*nightly"):
+        updater_module.validate_manifest_for_channel(manifest, "preview")
+
+
+def test_unknown_requested_channel_is_rejected() -> None:
+    manifest = _parse_manifest(VALID_MANIFEST)
+    with pytest.raises(ValueError, match="unknown requested channel"):
+        updater_module.validate_manifest_for_channel(manifest, "beta")
 
 
 def test_manifest_schema_accepts_alpha_preview() -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -343,6 +343,26 @@ def test_manifest_schema_rejects_missing_required_fields() -> None:
         _parse_manifest({"version": "9.9.9", "url": "https://x/y.tar.gz"})
 
 
+@pytest.mark.parametrize(
+    ("schema_value", "missing"),
+    [
+        pytest.param(None, True, id="missing"),
+        pytest.param("hal0.releases.v2", False, id="unknown"),
+        pytest.param(1, False, id="number"),
+        pytest.param(None, False, id="null"),
+    ],
+)
+def test_manifest_schema_requires_exact_v1_schema(schema_value: object, missing: bool) -> None:
+    payload = dict(VALID_MANIFEST)
+    if missing:
+        payload.pop("_schema")
+    else:
+        payload["_schema"] = schema_value
+
+    with pytest.raises(UpdateManifestInvalid):
+        _parse_manifest(payload)
+
+
 def test_manifest_schema_rejects_malformed_digest() -> None:
     """digest_sha256 must be hex; garbage strings fail validation."""
     payload = {

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -53,6 +53,19 @@ from hal0.updater.updater import (
 # ── helpers ────────────────────────────────────────────────────────────────────
 
 
+_IDENTITY_PREFIX = (
+    r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+    r"\.github/workflows/release\.yml@"
+)
+_MAIN_IDENTITY = _IDENTITY_PREFIX + r"refs/heads/main$"
+
+
+def _test_exact_identity(release_kind: str, version: str) -> str:
+    if release_kind == "nightly":
+        return _MAIN_IDENTITY
+    return _IDENTITY_PREFIX + "refs/tags/v" + version.replace(".", r"\.") + "$"
+
+
 VALID_MANIFEST: dict[str, Any] = {
     "_schema": "hal0.releases.v1",
     "version": "1.0.0",
@@ -123,10 +136,6 @@ def _write_release_manifest(
         "url": f"file://{tarball}",
         "bundle_url": f"file://{bundle}",
         "digest_sha256": _sha256_of(tarball),
-        "signer_identity": (
-            r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
-            rf"\.github/workflows/release\.yml@refs/tags/v{re.escape(version)}$"
-        ),
         "signer_issuer": "https://token.actions.githubusercontent.com",
         "min_data_version": 1,
         "released_at": "2026-05-15T12:00:00Z",
@@ -135,6 +144,10 @@ def _write_release_manifest(
     }
     if overrides:
         payload.update(overrides)
+    payload.setdefault(
+        "signer_identity",
+        _test_exact_identity(str(payload.get("release_kind", "stable")), version),
+    )
     manifest_path.write_text(json.dumps(payload), encoding="utf-8")
     Path(f"{manifest_path}.bundle").write_bytes(b"manifest-bundle-placeholder\n")
     return payload
@@ -713,27 +726,34 @@ def test_preview_check_and_prepare_exercise_cosign_subprocess_without_activation
     assert [Path(call["blob"]).name for call in verification_calls] == [
         "manifest.json",
         "manifest.json",
+        "manifest.json",
+        "manifest.json",
         synthetic_preview_release["tarball"].name,
     ]
     manifest_digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
     manifest_bundle_digest = hashlib.sha256(
         Path(f"{manifest_path}.bundle").read_bytes()
     ).hexdigest()
-    for call in verification_calls[:2]:
+    for index, call in enumerate(verification_calls[:4]):
         assert call["blob_sha256"] == manifest_digest
         assert call["bundle_sha256"] == manifest_bundle_digest
+        expected_identity = (
+            updater_module.manifest_admission_identity("preview")
+            if index % 2 == 0
+            else payload["signer_identity"]
+        )
         assert call["args"] == [
             "verify-blob",
             "--bundle",
             call["bundle"],
             "--certificate-identity-regexp",
-            updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP,
+            expected_identity,
             "--certificate-oidc-issuer",
             updater_module._MANIFEST_SIGNER_ISSUER,
             call["blob"],
         ]
 
-    artifact_call = verification_calls[2]
+    artifact_call = verification_calls[4]
     cached_tarball = updater_module._cache_dir(version) / f"hal0-{version}.tar.gz"
     assert artifact_call["blob"] == str(cached_tarball)
     assert artifact_call["bundle"] == f"{cached_tarball}.bundle"
@@ -782,17 +802,18 @@ def test_preview_manifest_verification_failure_leaves_no_staged_state(
     assert not _current_symlink().is_symlink()
 
 
-def test_check_uses_pinned_trust_root_for_unauthenticated_manifest(
+def test_check_uses_channel_admission_before_parsing_untrusted_manifest(
     synthetic_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Manifest-provided signer claims cannot select the manifest trust root."""
-    forged_identity = r"^https://github\.com/attacker/forged/.*$"
-    forged_issuer = "https://attacker.example/oidc"
+    """Untrusted JSON fields cannot influence the first verification identity."""
     payload = synthetic_release["payload"]
-    payload["signer_identity"] = forged_identity
-    payload["signer_issuer"] = forged_issuer
+    payload.update(
+        release_kind="nightly",
+        signer_identity=_MAIN_IDENTITY,
+    )
     synthetic_release["manifest_path"].write_text(json.dumps(payload), encoding="utf-8")
-    calls: list[tuple[bytes, bytes, str, str]] = []
+    events: list[tuple[str, str]] = []
+    original_decode = updater_module._decode_release_manifest
 
     def record_verify(
         blob: Path,
@@ -802,47 +823,96 @@ def test_check_uses_pinned_trust_root_for_unauthenticated_manifest(
         issuer: str,
         job_id: str | None = None,
     ) -> None:
-        calls.append((blob.read_bytes(), bundle.read_bytes(), identity_regexp, issuer))
+        events.append(("verify", identity_regexp))
+
+    def record_decode(raw_bytes: bytes, url: str) -> dict[str, Any]:
+        events.append(("decode", ""))
+        return original_decode(raw_bytes, url)
+
+    monkeypatch.setattr(updater_module, "_verify_cosign", record_verify)
+    monkeypatch.setattr(updater_module, "_decode_release_manifest", record_decode)
+
+    with pytest.raises(UpdateManifestInvalid):
+        asyncio.run(Updater(channel="stable").check())
+
+    assert events == [
+        ("verify", updater_module.manifest_admission_identity("stable")),
+        ("decode", ""),
+    ]
+    assert _MAIN_IDENTITY not in [value for event, value in events if event == "verify"]
+
+
+def test_authenticated_manifest_rejects_broad_signer_before_exact_reverify(
+    synthetic_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = synthetic_release["payload"]
+    payload["signer_identity"] = updater_module.manifest_admission_identity("preview")
+    synthetic_release["manifest_path"].write_text(json.dumps(payload), encoding="utf-8")
+    identities: list[str] = []
+
+    def record_verify(
+        blob: Path,
+        bundle: Path,
+        *,
+        identity_regexp: str,
+        issuer: str,
+        job_id: str | None = None,
+    ) -> None:
+        identities.append(identity_regexp)
 
     monkeypatch.setattr(updater_module, "_verify_cosign", record_verify)
 
-    info = asyncio.run(Updater().check())
+    with pytest.raises(UpdateManifestInvalid, match="signer_identity"):
+        asyncio.run(Updater(channel="stable").check())
 
-    assert calls == [
+    assert identities == [updater_module.manifest_admission_identity("stable")]
+
+
+@pytest.mark.parametrize(
+    ("channel", "accepted", "rejected"),
+    [
         (
-            synthetic_release["manifest_path"].read_bytes(),
-            b"manifest-bundle-placeholder\n",
-            updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP,
-            updater_module._MANIFEST_SIGNER_ISSUER,
-        )
-    ]
-    assert info.signer_identity == forged_identity
+            "stable",
+            "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3",
+            "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main",
+        ),
+        (
+            "preview",
+            "https://github.com/hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3-rc.1",
+            "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main",
+        ),
+        (
+            "nightly",
+            "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main",
+            "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3-nightly.20260722123000",
+        ),
+    ],
+)
+def test_manifest_admission_identity_is_channel_scoped(
+    channel: str, accepted: str, rejected: str
+) -> None:
+    identity = updater_module.manifest_admission_identity(channel)
+    assert re.fullmatch(identity, accepted)
+    assert re.fullmatch(identity, rejected) is None
+
+
+def test_preview_admission_accepts_promoted_stable_tag() -> None:
+    identity = updater_module.manifest_admission_identity("preview")
+    subject = "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3"
+    assert re.fullmatch(identity, subject)
 
 
 @pytest.mark.parametrize(
-    "identity",
+    ("release_kind", "version", "expected"),
     [
-        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3",
-        "https://github.com/hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3-rc.1",
-        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main",
+        ("stable", "1.2.3", _test_exact_identity("stable", "1.2.3")),
+        ("preview", "1.2.3-beta.4", _test_exact_identity("preview", "1.2.3-beta.4")),
+        ("nightly", "1.2.3-nightly.20260722123000", _MAIN_IDENTITY),
+        ("nightly", "1.2.3-nightly.20260722", _MAIN_IDENTITY),
     ],
 )
-def test_manifest_pinned_identity_accepts_supported_release_refs(identity: str) -> None:
-    """The trust root covers direct release tags and nightly's reusable caller ref."""
-    assert re.fullmatch(updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP, identity)
-
-
-@pytest.mark.parametrize(
-    "identity",
-    [
-        "https://github.com/attacker/hal0/.github/workflows/release.yml@refs/tags/v1.2.3",
-        "https://github.com/Hal0ai/hal0/.github/workflows/other.yml@refs/tags/v1.2.3",
-        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/feature",
-        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/not-v1.2.3",
-    ],
-)
-def test_manifest_pinned_identity_rejects_unofficial_subjects(identity: str) -> None:
-    assert re.fullmatch(updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP, identity) is None
+def test_exact_manifest_identity_matrix(release_kind: str, version: str, expected: str) -> None:
+    assert updater_module.exact_manifest_identity(release_kind, version) == expected
 
 
 def test_check_handles_missing_manifest(
@@ -855,7 +925,10 @@ def test_check_handles_missing_manifest(
 
 
 def test_check_rejects_wrong_channel_manifest(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cosign_skip: None,
 ) -> None:
     """check() rejects a manifest that prepare() would reject for the channel."""
     artifacts = tmp_path / "artifacts"
@@ -878,7 +951,10 @@ def test_check_rejects_wrong_channel_manifest(
 
 
 def test_prepare_rejects_wrong_channel_before_download_or_cache_write(
-    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    cosign_skip: None,
 ) -> None:
     """prepare() validates channel coherence before creating staged state."""
     artifacts = tmp_path / "artifacts"
@@ -903,7 +979,7 @@ def test_prepare_rejects_wrong_channel_before_download_or_cache_write(
     with pytest.raises(UpdateManifestInvalid):
         asyncio.run(Updater(channel="stable").prepare())
 
-    assert downloads == []
+    assert downloads == [f"{manifest_path}.bundle"]
     assert not updater_module._cache_dir("99.0.0").exists()
 
 
@@ -1757,12 +1833,13 @@ def test_check_uses_per_channel_url(
     """The check() method honours its channel argument when looking up the URL."""
     artifacts = tmp_path / "artifacts"
     artifacts.mkdir()
-    tarball = _build_release_tarball(tmp=artifacts, version="0.0.1")
+    version = "0.0.1-nightly.20260722123000"
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
     manifest_path = artifacts / "latest.json"
     _write_release_manifest(
         manifest_path=manifest_path,
         tarball=tarball,
-        version="0.0.1",
+        version=version,
         overrides={"channel": "nightly", "release_kind": "nightly"},
     )
     monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -1077,6 +1077,86 @@ def test_apply_repip_failure_rolls_back_symlink(
 # ── prepare / commit split ─────────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize("requested_version", ["0.0.2", "../../outside"])
+def test_prepare_rejects_mismatched_pin_before_staging_paths(
+    requested_version: str,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An authenticated channel manifest cannot be staged under a caller label."""
+    manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": "0.0.1"})
+
+    async def fake_fetch(
+        channel: str, *, job_id: str | None = None
+    ) -> tuple[dict[str, Any], ReleaseManifest, str]:
+        return manifest.model_dump(by_alias=True), manifest, "https://example.test/stable.json"
+
+    async def unexpected_download(url: str, dest: Path) -> None:
+        raise AssertionError(f"artifact download reached for mismatched pin: {url} -> {dest}")
+
+    def unexpected_path(version: str) -> Path:
+        raise AssertionError(f"staging path constructed for mismatched pin: {version}")
+
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(updater_module, "_fetch_verified_release_manifest", fake_fetch)
+    monkeypatch.setattr(updater_module, "_download", unexpected_download)
+    monkeypatch.setattr(updater_module, "_cache_dir", unexpected_path)
+    monkeypatch.setattr(updater_module, "_versioned_install_dir", unexpected_path)
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater(channel="stable").prepare(requested_version))
+
+    assert exc_info.value.details == {
+        "channel": "stable",
+        "requested_version": requested_version,
+        "manifest_version": "0.0.1",
+    }
+
+
+@pytest.mark.parametrize("requested_version", ["0.0.1", " 0.0.1 "])
+def test_prepare_matching_pin_stages_authenticated_manifest_version(
+    requested_version: str,
+    synthetic_release: dict[str, Any],
+    cosign_skip: None,
+) -> None:
+    """An exact optimistic pin preserves the normal prepare flow after trimming."""
+    res = asyncio.run(Updater().prepare(requested_version))
+
+    assert res["version"] == "0.0.1"
+    assert _versioned_install_dir("0.0.1").is_dir()
+    assert updater_module._manifest_cache_path("0.0.1").is_file()
+
+
+def test_apply_mismatched_pin_never_commits(
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single-step apply propagates pin mismatch without activation."""
+    manifest = ReleaseManifest.model_validate({**VALID_MANIFEST, "version": "0.0.1"})
+    committed = False
+
+    async def fake_fetch(
+        channel: str, *, job_id: str | None = None
+    ) -> tuple[dict[str, Any], ReleaseManifest, str]:
+        return manifest.model_dump(by_alias=True), manifest, "https://example.test/stable.json"
+
+    async def fake_commit(version: str) -> dict[str, Any]:
+        nonlocal committed
+        committed = True
+        return {}
+
+    updater = Updater(channel="stable")
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(updater_module, "_fetch_verified_release_manifest", fake_fetch)
+    monkeypatch.setattr(updater, "commit", fake_commit)
+
+    with pytest.raises(UpdateManifestInvalid):
+        asyncio.run(updater.apply("0.0.2"))
+
+    assert committed is False
+    assert not _current_symlink().exists()
+
+
 def test_prepare_stages_without_swap(synthetic_release: dict[str, Any], cosign_skip: None) -> None:
     """prepare() downloads + verifies + extracts but activates nothing.
 
@@ -1109,6 +1189,32 @@ def test_commit_without_prepare_raises(tmp_hal0_home: str, monkeypatch: pytest.M
     monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
     with pytest.raises(UpdateError):
         asyncio.run(Updater().commit("0.0.1"))
+
+
+def test_commit_rejects_cached_manifest_for_different_version(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """commit() never activates a staged tree whose cached manifest names another version."""
+    target_version = "0.0.1"
+    install_dir = _versioned_install_dir(target_version)
+    install_dir.mkdir(parents=True)
+    manifest_path = updater_module._manifest_cache_path(target_version)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps({**VALID_MANIFEST, "version": "0.0.2"}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+
+    with pytest.raises(UpdateManifestInvalid) as exc_info:
+        asyncio.run(Updater(channel="stable").commit(target_version))
+
+    assert exc_info.value.details == {
+        "channel": "stable",
+        "target_version": target_version,
+        "manifest_version": "0.0.2",
+    }
+    assert not _current_symlink().exists()
 
 
 def test_prepare_then_commit_swaps(synthetic_release: dict[str, Any], cosign_skip: None) -> None:

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -352,6 +352,19 @@ def test_manifest_schema_accepts_canonical_release_versions(version: str) -> Non
     assert manifest.version == version
 
 
+def test_manifest_schema_accepts_legacy_date_only_nightly_version() -> None:
+    version = "1.2.3-nightly.20260721"
+    manifest = _parse_manifest(
+        {
+            **VALID_MANIFEST,
+            "version": version,
+            "channel": "nightly",
+            "release_kind": "nightly",
+        }
+    )
+    assert manifest.version == version
+
+
 @pytest.mark.parametrize(
     "version",
     [
@@ -362,6 +375,11 @@ def test_manifest_schema_accepts_canonical_release_versions(version: str) -> Non
         " 1.2.3 ",
         "1.2.3-preview.1",
         "1.2.3-alpha1",
+        "1.2.3-nightly.2026072",
+        "1.2.3-nightly.202607210",
+        "1.2.3-nightly.2026072106",
+        "1.2.3-nightly.2026072106000",
+        "1.2.3-nightly.202607210600000",
     ],
 )
 def test_manifest_schema_rejects_hostile_or_noncanonical_versions(version: str) -> None:
@@ -1173,6 +1191,9 @@ def test_prepare_rejects_mismatched_pin_before_staging_paths(
         "/tmp/outside",
         " 0.0.1 ",
         "1.2.3-preview.1",
+        "1.2.3-nightly.2026072",
+        "1.2.3-nightly.202607210",
+        "1.2.3-nightly.2026072106",
     ],
 )
 def test_prepare_rejects_invalid_pin_before_staging_paths(
@@ -1242,6 +1263,41 @@ def test_prepare_matching_pin_stages_authenticated_manifest_version(
     assert res["version"] == "0.0.1"
     assert _versioned_install_dir("0.0.1").is_dir()
     assert updater_module._manifest_cache_path("0.0.1").is_file()
+
+
+def test_legacy_nightly_exact_prepare_pin_and_commit_are_accepted(
+    tmp_hal0_home: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    cosign_skip: None,
+) -> None:
+    """Legacy date-only nightlies remain readable, stageable, and installable."""
+    version = "1.2.3-nightly.20260721"
+    artifacts = tmp_path / "legacy-nightly-artifacts"
+    artifacts.mkdir()
+    tarball = _build_release_tarball(tmp=artifacts, version=version)
+    manifest_path = artifacts / "nightly.json"
+    _write_release_manifest(
+        manifest_path=manifest_path,
+        tarball=tarball,
+        version=version,
+        overrides={"channel": "nightly", "release_kind": "nightly"},
+    )
+    monkeypatch.setenv("HAL0_RELEASES_URL", str(manifest_path))
+    monkeypatch.setattr(updater_module, "_is_editable_install", lambda: False)
+    monkeypatch.setattr(
+        updater_module,
+        "_reinstall_into_venv",
+        lambda install_dir, *, job_id=None: None,
+    )
+
+    updater = Updater(channel="nightly")
+    prepared = asyncio.run(updater.prepare(version))
+    committed = asyncio.run(updater.commit(version))
+
+    assert prepared["version"] == version
+    assert committed["version"] == version
+    assert Path(os.readlink(_current_symlink())).name == f"hal0-{version}"
 
 
 def test_apply_mismatched_pin_never_commits(
@@ -1317,6 +1373,9 @@ def test_commit_without_prepare_raises(tmp_hal0_home: str, monkeypatch: pytest.M
         "/tmp/outside",
         " 1.2.3 ",
         "1.2.3-preview.1",
+        "1.2.3-nightly.2026072",
+        "1.2.3-nightly.202607210",
+        "1.2.3-nightly.2026072106",
     ],
 )
 def test_commit_rejects_invalid_version_before_any_staging_path(

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -14,6 +14,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import shutil
 import tarfile
 from pathlib import Path
@@ -59,7 +60,10 @@ VALID_MANIFEST: dict[str, Any] = {
     "url": "https://example.test/hal0.tar.gz",
     "bundle_url": "https://example.test/hal0.tar.gz.bundle",
     "digest_sha256": "0" * 64,
-    "signer_identity": "release-workflow",
+    "signer_identity": (
+        r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+        r"\.github/workflows/release\.yml@refs/tags/v1\.0\.0$"
+    ),
 }
 
 
@@ -118,7 +122,10 @@ def _write_release_manifest(
         "url": f"file://{tarball}",
         "bundle_url": f"file://{bundle}",
         "digest_sha256": _sha256_of(tarball),
-        "signer_identity": "^https://github\\.com/hal0ai/hal0/.*",
+        "signer_identity": (
+            r"^https://github\.com/(Hal0ai|hal0ai)/hal0/"
+            rf"\.github/workflows/release\.yml@refs/tags/v{re.escape(version)}$"
+        ),
         "signer_issuer": "https://token.actions.githubusercontent.com",
         "min_data_version": 1,
         "released_at": "2026-05-15T12:00:00Z",
@@ -489,10 +496,16 @@ def test_check_returns_typed_release_info(
     assert info.update_available is True or info.update_available is False  # type sanity
 
 
-def test_check_verifies_exact_manifest_bytes_with_sibling_bundle(
+def test_check_uses_pinned_trust_root_for_unauthenticated_manifest(
     synthetic_release: dict[str, Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """check() authenticates the fetched manifest itself before returning policy."""
+    """Manifest-provided signer claims cannot select the manifest trust root."""
+    forged_identity = r"^https://github\.com/attacker/forged/.*$"
+    forged_issuer = "https://attacker.example/oidc"
+    payload = synthetic_release["payload"]
+    payload["signer_identity"] = forged_identity
+    payload["signer_issuer"] = forged_issuer
+    synthetic_release["manifest_path"].write_text(json.dumps(payload), encoding="utf-8")
     calls: list[tuple[bytes, bytes, str, str]] = []
 
     def record_verify(
@@ -507,16 +520,43 @@ def test_check_verifies_exact_manifest_bytes_with_sibling_bundle(
 
     monkeypatch.setattr(updater_module, "_verify_cosign", record_verify)
 
-    asyncio.run(Updater().check())
+    info = asyncio.run(Updater().check())
 
     assert calls == [
         (
             synthetic_release["manifest_path"].read_bytes(),
             b"manifest-bundle-placeholder\n",
-            synthetic_release["payload"]["signer_identity"],
-            synthetic_release["payload"]["signer_issuer"],
+            updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP,
+            updater_module._MANIFEST_SIGNER_ISSUER,
         )
     ]
+    assert info.signer_identity == forged_identity
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3",
+        "https://github.com/hal0ai/hal0/.github/workflows/release.yml@refs/tags/v1.2.3-rc.1",
+        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/main",
+    ],
+)
+def test_manifest_pinned_identity_accepts_supported_release_refs(identity: str) -> None:
+    """The trust root covers direct release tags and nightly's reusable caller ref."""
+    assert re.fullmatch(updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP, identity)
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        "https://github.com/attacker/hal0/.github/workflows/release.yml@refs/tags/v1.2.3",
+        "https://github.com/Hal0ai/hal0/.github/workflows/other.yml@refs/tags/v1.2.3",
+        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/heads/feature",
+        "https://github.com/Hal0ai/hal0/.github/workflows/release.yml@refs/tags/not-v1.2.3",
+    ],
+)
+def test_manifest_pinned_identity_rejects_unofficial_subjects(identity: str) -> None:
+    assert re.fullmatch(updater_module._MANIFEST_SIGNER_IDENTITY_REGEXP, identity) is None
 
 
 def test_check_handles_missing_manifest(

--- a/ui/src/api/hooks/useUpdates.ts
+++ b/ui/src/api/hooks/useUpdates.ts
@@ -84,11 +84,12 @@ export function useUpdateRollback() {
 }
 
 // Channel switch (issue #546). PUT /api/updates/channel with {channel:
-// "stable" | "nightly"} persists to hal0.toml; on success the updates/
-// state query is invalidated so the per-component channel fields (which
-// the UI binds to for the current value) refetch the persisted channel
+// "stable" | "preview" | "nightly"} persists to hal0.toml; on success the
+// updates/state query is invalidated so the per-component channel fields
+// (which the UI binds to for the current value) refetch the persisted channel
 // before the next render.
-export type UpdateChannelName = 'stable' | 'nightly'
+export const UPDATE_CHANNEL_NAMES = ['stable', 'preview', 'nightly'] as const
+export type UpdateChannelName = (typeof UPDATE_CHANNEL_NAMES)[number]
 
 export function useSetUpdateChannel() {
   const qc = useQueryClient()

--- a/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
+++ b/ui/src/dash/settings/pages/diagnostics/UpdatesPage.jsx
@@ -12,7 +12,7 @@ export function UpdatesPage() {
   // Phase B1: live state + check + apply mutations. While the query is
   // in flight or 5xx'd we render an empty envelope and let the SRow
   // fallbacks show '—' rather than fabricated versions.
-  // Issue #546: channel switch (stable | nightly) is wired to
+  // Issue #546: channel switch (stable | preview | nightly) is wired to
   // useSetUpdateChannel → PUT /api/updates/channel; reads the current
   // value from useUpdateState().hal0.channel on load.
   const stateQuery = useUpdateState();
@@ -147,21 +147,24 @@ export function UpdatesPage() {
               value={currentChannel}
               disabled={setChannelM.isPending}
               onChange={(e) => {
-                const next = e.target.value === 'nightly' ? 'nightly' : 'stable';
-                if (next === currentChannel) return;
-                setChannelM.mutate(next, {
-                  onSuccess: () => {
-                    window.__hal0Toast && window.__hal0Toast(`Channel set to ${next}`, "ok");
-                  },
-                  onError: (err) => {
-                    const msg = (err && err.message) || "could not set channel";
-                    window.__hal0Toast && window.__hal0Toast(`Channel change failed: ${msg}`, "err");
-                  },
-                });
+                const next = e.target.value;
+                if (next === 'stable' || next === 'preview' || next === 'nightly') {
+                  if (next === currentChannel) return;
+                  setChannelM.mutate(next, {
+                    onSuccess: () => {
+                      window.__hal0Toast && window.__hal0Toast(`Channel set to ${next}`, "ok");
+                    },
+                    onError: (err) => {
+                      const msg = (err && err.message) || "could not set channel";
+                      window.__hal0Toast && window.__hal0Toast(`Channel change failed: ${msg}`, "err");
+                    },
+                  });
+                }
               }}
               style={{maxWidth: 160}}
             >
               <option value="stable">stable</option>
+              <option value="preview">preview</option>
               <option value="nightly">nightly</option>
             </select>
           }

--- a/ui/src/dash/settings/pages/diagnostics/UpdatesPage.test.ts
+++ b/ui/src/dash/settings/pages/diagnostics/UpdatesPage.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { UPDATE_CHANNEL_NAMES } from '../../../../api/hooks/useUpdates'
+
+describe('UpdatesPage channel selector', () => {
+  it('has preview in the accepted UI channel vocabulary', () => {
+    expect(UPDATE_CHANNEL_NAMES).toEqual(['stable', 'preview', 'nightly'])
+  })
+})


### PR DESCRIPTION
## Summary

- make `preview` a first-class alpha/beta/RC channel across config, API, CLI, UI, updater, installer, policy, and docs
- authenticate channel manifests and sibling Sigstore bundles before trusting artifact metadata
- scope stable/preview manifests to exact immutable tag identities and nightly to the reusable `main` workflow identity
- bind release checkout and publication to the canonical repository, exact tag, and peeled commit SHA
- publish immutable assets without clobbering and verify remote GitHub/PyPI state in a final read-only `authorize-pointer` job
- install verified prebuilt UI trees without attempting an npm rebuild from distribution-only release trees
- add a rollback-safe repository-local version transaction and hermetic `release-check.sh --local` rehearsal
- harden tier-γ report schema/coherence/freshness checks and preserve recovery evidence on failed version updates

## Verification

Hardening branch:

- full Python: `7359 passed, 16 skipped, 1 xfailed`
- focused release/updater/installer: `431 passed, 9 skipped`
- UI typecheck/build passed; UI unit: `4 passed`
- Chromium/Gamma: `470 passed, 17 skipped`
- release/set-version tooling: `33 passed`
- Ruff, Bash syntax, workflow YAML/embedded shell, sunset ratchet, and `git diff --check`: passed
- independent Codex whole-branch review: no in-repository blocker
- PR head `49228819`: GitHub Python, UI, sunset, and Chromium/Gamma checks all passed

Local non-publishing `v1.0.0-alpha.2` integration candidate (`d949cb74`):

- version synchronization changes exactly the five canonical version files
- `release-check.sh --local --channel preview --tag v1.0.0-alpha.2`: passed
- candidate Python: `7388 passed, 15 skipped, 1 deselected, 1 xfailed`
- candidate UI unit: `4 passed`; Chromium: `470 passed, 17 skipped`
- no local/origin tag, GitHub Release, or PyPI `1.0.0a2` collision
- independent review verdict: **candidate-ready, not release-ready**

## Deliberately not performed

This PR does **not** push a tag, publish a GitHub Release or PyPI distribution, deploy `hal0-web`, or advance any channel pointer.

Release remains blocked on:

1. production `hal0-web` provisioning and deployment of explicit KV pointers for byte-exact signed `<channel>.json` and sibling `.json.bundle` assets; the local resolver patch is prepared and reviewed but intentionally unpushed
2. a real GitHub OIDC/Cosign release run and review of emitted `authorize-pointer` evidence
3. a fresh coherent non-local tier-γ report plus live preview install/update/rollback and stable-channel isolation checks

`v1.0.0-alpha.1` is already a published empty/manual prerelease and is immutable; the prepared candidate is `v1.0.0-alpha.2`.
