### PR TITLE
chore(release): prepare v1.0.0-alpha.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See PLAN.md \u00a712 (toolbox images) and \u00a717 (Risks).",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0a1"
+version = "1.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Prepare the non-publishing `v1.0.0-alpha.2` integration candidate from the reviewed Preview hardening and MCP security baseline (`main` at `d9c2e1e8`).

This changes exactly the five canonical version files:

- `manifest.json`: `1.0.0-alpha.2`
- `pyproject.toml`: `1.0.0-alpha.2`
- `ui/package.json`: `1.0.0-alpha.2`
- `ui/package-lock.json`: `1.0.0-alpha.2`
- `uv.lock`: PEP 440 `1.0.0a2`

No runtime, workflow, release-policy, installer, updater, or documentation source is changed.

## Verification

- `python scripts/set-version.py --check 1.0.0-alpha.2`: valid; no files modified
- `bash scripts/release-check.sh --local --channel preview --tag v1.0.0-alpha.2`: passed
- Python: `7388 passed, 15 skipped, 1 deselected, 1 xfailed`
- UI typecheck: passed
- UI unit: `4 passed`
- UI production build: passed
- Chromium: `470 passed, 17 skipped`
- Ruff: passed
- all seven toolbox images are digest-pinned
- base includes `mcp==1.28.1`, clearing the three high-severity MCP SDK advisories found during candidate review
- no remote `v1.0.0-alpha.2` tag, GitHub Release, or PyPI `hal0ai==1.0.0a2` collision
- candidate tree is byte-identical to the independently reviewed pre-merge candidate tree apart from Git history

## Deliberately not performed

This PR does **not** create or push a tag, dispatch the release workflow, publish GitHub/PyPI assets, deploy `hal0-web`, or advance a channel pointer.

The candidate remains **not release-authorized** until:

1. a fresh coherent non-local tier-γ report passes
2. production `hal0-web` serves authenticated paired Preview manifest bytes
3. an explicitly authorized real OIDC/Cosign publication run completes and `authorize-pointer` evidence is reviewed
4. the Preview pointer is separately authorized and live install/update/rollback/stable-isolation gates pass
