### PR TITLE
fix(deps): upgrade MCP SDK security patch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   # ADR-0004 (Phase 8): hal0 ships /mcp/admin + /mcp/memory MCP servers.
   # MIT-licensed Python SDK; consumed by hal0.mcp.* — required at
   # import time, hence core (not optional).
-  "mcp==1.27.0",
+  "mcp==1.28.1",
   # v0.3 Hermes-Agent bootstrap (issue #241): config_write phase
   # renders $HERMES_HOME/config.yaml from a Jinja2 template + deep-merges
   # /etc/hal0/agents/hermes/overrides.yaml. Both libs were already

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "jinja2", specifier = ">=3.1" },
-    { name = "mcp", specifier = "==1.27.0" },
+    { name = "mcp", specifier = "==1.28.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "numpy", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "psutil", specifier = ">=5.9" },
@@ -652,7 +652,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -670,9 +670,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Upgrade the exactly pinned MCP Python SDK from `1.27.0` to the minimal security-fixed `1.28.1` release before the 1.0 Preview candidate is merged.

This closes the dependency ranges for three current high-severity advisories:

- GHSA-vj7q-gjh5-988w — WebSocket server transport Host/Origin validation (`<1.28.1`)
- GHSA-hvrp-rf83-w775 — experimental task handlers cross-client access (`<=1.27.1`)
- GHSA-jpw9-pfvf-9f58 — HTTP session requests not bound to authenticated principal (`<=1.27.1`)

The diff is deliberately limited to:

- `pyproject.toml`: `mcp==1.27.0` → `mcp==1.28.1`
- `uv.lock`: MCP package version and exact distribution hashes

No hal0 source or behavior is changed.

## Compatibility and verification

- installed metadata resolves exactly `mcp==1.28.1`
- FastMCP, ToolAnnotations, TransportSecuritySettings, and `request_ctx` imports remain compatible
- focused MCP/security tests: `200 passed, 1 skipped`
- full isolated locked Python 3.12 suite: `7388 passed, 15 skipped, 1 deselected, 1 xfailed`
- Ruff: passed
- Ruff format check: `968 files already formatted`
- lock churn: `6 insertions, 6 deletions`; no other dependency changed
- independent review: no blocker; all three advisory ranges cleared

The initial focused invocation without isolated `HAL0_HOME` hit the host `/etc/hal0/hal0.toml` permission trap. The corrected hermetic invocation passed and the full suite subsequently passed.

## Release sequencing

PR #1347 is intentionally held until this patch lands. After merge, the `v1.0.0-alpha.2` version-only branch will be updated from `main`, its lock/version coherence regenerated if necessary, and the release rehearsal rerun.

This PR does not tag, publish, deploy, dispatch the release workflow, or advance a channel pointer.
