### PR TITLE
fix: correctness fixes on the live release line (watchdog race · comfyui deadlock · bench · doctor json · O25 mount)

### DIFF
--- a/src/hal0/bench/parsers.py
+++ b/src/hal0/bench/parsers.py
@@ -187,7 +187,10 @@ def _sa_run_to_rep(run: dict) -> Rep | None:
         return None
     draft_n = run.get("draft_n")
     accepted = run.get("draft_n_accepted")
-    accept = (accepted / draft_n) if draft_n else None
+    # Only compute acceptance when BOTH counts are present. A run can report
+    # draft_n>0 with draft_n_accepted null/absent (partial or older llama.cpp
+    # timings) — `None / draft_n` would TypeError and drop the whole run.
+    accept = (accepted / draft_n) if (draft_n and accepted is not None) else None
     return Rep(
         t_s=run.get("wall_s"),
         prefill_ts=run.get("prompt_per_second"),

--- a/src/hal0/bench/store.py
+++ b/src/hal0/bench/store.py
@@ -173,18 +173,22 @@ class Store:
                     ),
                 )
                 n += 1
-            # current_cells: newest ok record per cell_key. run_id sorts
-            # lexicographically by its leading UTC stamp, so MAX(run_id) among ok
-            # rows is the newest ok record for the key.
+            # current_cells: newest ok record per cell_key by INSERTION order
+            # (rowid_seq AUTOINCREMENT), matching newest_ok_by_cell()/the planner.
+            # run_id is "<UTC-stamp>-<random hex>", so two ok records in the same
+            # wall-clock second (routine for v1 imports sharing a timestamp, and
+            # fast re-measures) tie-break on the random suffix under MAX(run_id) —
+            # surfacing an OLDER record as current while the planner picks the
+            # newer. rowid_seq is monotonic append order, so both agree.
             conn.executescript(
                 """
                 CREATE VIEW current_cells AS
                 SELECT r.* FROM records r
                 JOIN (
-                    SELECT cell_key, MAX(run_id) AS newest_ok
+                    SELECT cell_key, MAX(rowid_seq) AS newest_ok
                     FROM records WHERE outcome = 'ok'
                     GROUP BY cell_key
-                ) w ON r.cell_key = w.cell_key AND r.run_id = w.newest_ok;
+                ) w ON r.cell_key = w.cell_key AND r.rowid_seq = w.newest_ok;
                 """
             )
             conn.commit()

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -488,7 +488,11 @@ def toolbox_pull(
             rows.append(_probe_one(name, entry, client=client))
 
     if json_output:
-        console.print_json(jsonlib.dumps(rows))
+        # Emit raw, plain JSON — `console.print_json` re-highlights with ANSI
+        # escapes (rich reports is_terminal=True even when stdout is a pipe), so
+        # `toolbox-pull --json | jq` would choke on colour codes. The --json
+        # contract must be deterministic parseable JSON regardless of tty.
+        print(jsonlib.dumps(rows, indent=2))
     else:
         table = Table(title="ghcr.io toolbox-image pull probe (anonymous)")
         table.add_column("Image", style="bold")

--- a/src/hal0/comfyui/fetch.py
+++ b/src/hal0/comfyui/fetch.py
@@ -189,7 +189,11 @@ def _run_sequence(rec: dict, script_path: str, fetch_steps: tuple[tuple[str, ...
             return
 
         cmd = ["bash", script_path, *step_args]
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
+        # Drain child output to /dev/null: it was never read anywhere, and an
+        # unread stdout=PIPE deadlocks proc.wait() once the child fills the
+        # ~64 KB OS pipe buffer (a real `hf` download emits MBs of progress) —
+        # the fetch job then hangs in `running` forever.
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
         rec["_proc"] = proc
 
         rc = proc.wait()

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -58,7 +58,12 @@ from typing import Any
 import httpx
 
 from hal0.config import store as model_store_module
-from hal0.config.paths import DEFAULT_MODEL_STORE, model_mount_roots, model_store_root
+from hal0.config.paths import (
+    DEFAULT_MODEL_STORE,
+    _covers,
+    model_mount_roots,
+    model_store_root,
+)
 from hal0.config.schema import (
     build_mtp_flag_bundle,
     family_flags,
@@ -906,6 +911,24 @@ def _llama_launch_plan(
     # appending ``:z``. `model_mount_roots()` dedups equal/nested roots so
     # store==pull_root renders exactly ONE Volume.
     model_stores = model_mount_roots()
+
+    # Defensive reachability (rework O25 follow-up): a slot's resolved model
+    # file can live OUTSIDE every *configured* model root (store/pull_root) —
+    # e.g. a registry path under /mnt/ai-models after [models].store was moved
+    # to /var/lib/hal0/models. `assert_under_store(severity="warn")` +
+    # `doctor models HAL0-MODEL-STORE-UNMOUNTED` DETECT this but don't heal it,
+    # so the container still can't read the file → llama exits at load → the
+    # slot crashes/flaps warming↔error (live-proven on Strix Halo 150: 6 models
+    # under /mnt/ai-models flagged, store pointed at /var/lib/hal0/models).
+    # Mount the model file's own directory (identical-path, read-only) whenever
+    # no configured root already covers it, so the slot loads regardless of the
+    # store-config drift (the guard still surfaces the misconfig to fix).
+    if model_path:
+        mp = os.path.normpath(model_path)
+        if not any(_covers(root, mp) for root in model_stores):
+            model_dir = os.path.dirname(mp)
+            if model_dir and not any(_covers(root, model_dir) for root in model_stores):
+                model_stores = [*model_stores, model_dir]
 
     return RuntimeLaunchPlan(
         image=image,

--- a/src/hal0/slots/watchdog.py
+++ b/src/hal0/slots/watchdog.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 from hal0.slots._cfg_helpers import _cfg_port
@@ -92,6 +93,7 @@ class WatchdogHost(Protocol):
 
     def _current_state(self, name: str) -> SlotState: ...
     def _key(self, name: str) -> int: ...
+    def _lock(self, name: str) -> asyncio.Lock: ...
     async def _maybe_load_config(self, name: str) -> dict[str, Any] | None: ...
     async def _transition(self, name: str, to_state: SlotState, **kw: Any) -> SlotStateRecord: ...
     async def load(self, name: str) -> Slot: ...
@@ -145,6 +147,66 @@ class SlotWatchdog:
             # Watcher self-cancel via its own transition — let it finish.
             return
         existing.cancel()
+
+    async def _stamp_locked(
+        self,
+        slot_name: str,
+        to_state: SlotState,
+        *,
+        message: str,
+        still_faulted: Callable[[], Awaitable[bool]],
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Flip a confirmed-faulted slot to ``to_state`` under the per-slot lock.
+
+        ``load``/``unload``/``restart`` hold ``host._lock(name)`` for the whole
+        of their run, so taking it here serialises the watchdog against an
+        in-flight load: the watcher can never stamp ERROR/OFFLINE onto a slot
+        whose load is mid-flight — which used to race load's own final
+        ``WARMING → READY`` into an illegal transition (a warming unit that read
+        inactive for a beat during a big model's cold-load got flipped, and the
+        load then failed/409'd). Once we hold the lock the load has settled, so
+        we re-verify BOTH the live state AND the fault itself (``still_faulted``)
+        before stamping — a load that converged healthy while the watcher waited
+        for the lock is left untouched.
+        """
+        host = self._host
+        async with host._lock(slot_name):
+            if host._current_state(slot_name) not in _FAIL_WATCH_LIVE_STATES:
+                return
+            try:
+                faulted = await still_faulted()
+            except Exception as exc:
+                log.warning(
+                    "slot.fail_watch_recheck_failed",
+                    extra={"slot": slot_name, "error": str(exc)},
+                )
+                return
+            if not faulted:
+                # Fault cleared while we waited for the lock (a concurrent
+                # load/restart converged the slot) — leave it alone.
+                return
+            try:
+                await host._transition(
+                    slot_name,
+                    to_state,
+                    message=message,
+                    extra=extra or {},
+                    force=True,
+                )
+            except Exception as exc:
+                log.warning(
+                    "slot.fail_watch_transition_failed",
+                    extra={"slot": slot_name, "error": str(exc)},
+                )
+
+    async def _probe_unhealthy(self, slot_name: str) -> bool:
+        """True when the model server still fails its /health probe."""
+        return not await self.probe_health(slot_name)
+
+    async def _unit_inactive(self, slot_name: str) -> bool:
+        """True when the container unit still reads inactive to systemd."""
+        return not await self.is_active(slot_name)
 
     async def _fail_watch_loop(self, slot_name: str) -> None:
         """Poll the container unit's is-active and flip state when it dies.
@@ -234,27 +296,19 @@ class SlotWatchdog:
                     if health_failures < _HEALTH_FAIL_STRIKES:
                         # Tolerate a transient blip; a real crash fails again.
                         continue
-                    # Re-check state in case load/unload moved us mid-probe.
-                    current = host._current_state(slot_name)
-                    if current not in _FAIL_WATCH_LIVE_STATES:
-                        return
                     # Confirmed unhealthy → ERROR (red dot, operator cue). The
                     # health endpoint (#783 cr1) then reports degraded and
                     # hal0_slot_up reads health_ok=False (#791). Recoverable —
-                    # the dispatcher reloads on the next request.
-                    try:
-                        await host._transition(
-                            slot_name,
-                            SlotState.ERROR,
-                            message="model server failed /health probe",
-                            extra={"health_ok": False},
-                            force=True,
-                        )
-                    except Exception as exc:
-                        log.warning(
-                            "slot.fail_watch_transition_failed",
-                            extra={"slot": slot_name, "error": str(exc)},
-                        )
+                    # the dispatcher reloads on the next request. Stamped under
+                    # the per-slot lock + fault re-verification so it can never
+                    # clobber a concurrent load/reload (see _stamp_locked).
+                    await self._stamp_locked(
+                        slot_name,
+                        SlotState.ERROR,
+                        message="model server failed /health probe",
+                        still_faulted=lambda: self._probe_unhealthy(slot_name),
+                        extra={"health_ok": False},
+                    )
                     return
                 # The container unit went inactive while we believed it
                 # was live. Re-check state once more — load/unload may
@@ -271,19 +325,18 @@ class SlotWatchdog:
                     warming_inactive += 1
                     if warming_inactive < _WARMING_INACTIVE_STRIKES:
                         continue
-                    try:
-                        await host._transition(
-                            slot_name,
-                            SlotState.ERROR,
-                            message="container unit died while warming",
-                            extra={"health_ok": False},
-                            force=True,
-                        )
-                    except Exception as exc:
-                        log.warning(
-                            "slot.fail_watch_transition_failed",
-                            extra={"slot": slot_name, "error": str(exc)},
-                        )
+                    # Under the per-slot lock + re-verification: a big model whose
+                    # unit reads inactive for a beat mid-cold-load must not be
+                    # flipped to ERROR while its load holds the lock (that raced
+                    # load's WARMING→READY into an illegal error→ready). See
+                    # _stamp_locked.
+                    await self._stamp_locked(
+                        slot_name,
+                        SlotState.ERROR,
+                        message="container unit died while warming",
+                        still_faulted=lambda: self._unit_inactive(slot_name),
+                        extra={"health_ok": False},
+                    )
                     return
                 # A stopped unit (GPU arbiter handoff, systemd stop,
                 # OOM-kill with Restart= pending) is a clean not-loaded
@@ -292,18 +345,15 @@ class SlotWatchdog:
                 # (grey dot) rather than ERROR (red dot, operator-
                 # investigation cue), reserving ERROR for the real
                 # failures: spawn/health/load exceptions.
-                try:
-                    await host._transition(
-                        slot_name,
-                        SlotState.OFFLINE,
-                        message="container stopped (auto-reloads on next request)",
-                        force=True,
-                    )
-                except Exception as exc:
-                    log.warning(
-                        "slot.fail_watch_transition_failed",
-                        extra={"slot": slot_name, "error": str(exc)},
-                    )
+                # Under the per-slot lock + re-verification (still inactive): a
+                # concurrent load that just brought the unit up must not be
+                # clobbered to OFFLINE mid-flight (OFFLINE→READY is illegal too).
+                await self._stamp_locked(
+                    slot_name,
+                    SlotState.OFFLINE,
+                    message="container stopped (auto-reloads on next request)",
+                    still_faulted=lambda: self._unit_inactive(slot_name),
+                )
                 return
         except asyncio.CancelledError:
             # Normal shutdown path — slot left live-state cleanly.

--- a/tests/bench/test_parsers.py
+++ b/tests/bench/test_parsers.py
@@ -133,3 +133,32 @@ def test_parse_server_ab_embed():
     assert len(p.reps) == len(doc["results"]["latency_s"])
     assert all(r.t_s is not None and r.decode_ts is None for r in p.reps)
     assert p.summary.decode_ts_med is None  # never guessed for embed
+
+
+def test_parse_server_ab_drafts_without_accepted_does_not_crash():
+    # A speculative run can report a draft count (`draft_n` > 0) without a paired
+    # `draft_n_accepted` (partial/older llama.cpp timings, or a null field). The
+    # acceptance ratio is then unknowable — it must stay null, NOT crash the whole
+    # cell parse with `None / draft_n` (regression: TypeError killed the session).
+    doc = {
+        "mode": "ab",
+        "results": {
+            "spec": {
+                "extra_args": "",
+                "runs": [
+                    {
+                        "predicted_per_second": 40.0,
+                        "prompt_per_second": 300.0,
+                        "draft_n": 12,
+                        "draft_n_accepted": None,
+                        "wall_s": 2.0,
+                    }
+                ],
+            }
+        },
+    }
+    p = parse_server_ab(doc, "chat")
+    assert len(p.reps) == 1  # the run is still a valid throughput measurement
+    assert p.reps[0].decode_ts == 40.0
+    assert p.reps[0].accept_rate is None  # unknowable, never invented, never crash
+    assert p.reps[0].drafted == 12

--- a/tests/bench/test_store.py
+++ b/tests/bench/test_store.py
@@ -1,0 +1,57 @@
+"""test_store.py — the result store's "current value" contract (DESIGN §3.1).
+
+The store defines a cell's *current value* as its newest ok record. Two code
+paths compute this and they MUST agree:
+
+  * ``newest_ok_by_cell`` (the planner's staleness input) reads records.jsonl in
+    append order — "later ok records overwrite earlier ones" — so the newest is
+    the last-appended ok record for a key.
+  * the ``current_cells`` SQL view (what ``results()`` / the dashboard show).
+
+They diverged when two ok records for one cell_key shared a wall-clock second:
+run_id is ``<UTC-stamp>-<random hex>`` and the view picked ``MAX(run_id)``, whose
+tie-break is the RANDOM hex suffix — so the view could surface an OLDER record as
+"current" while the planner (append order) correctly saw the newer one. Same-second
+ties are real for v1 imports (many rows share one source timestamp) and fast
+re-measures.
+"""
+
+from __future__ import annotations
+
+from hal0.bench.store import Store
+
+
+def _ok_rec(run_id: str, decode: float) -> dict:
+    return {
+        "run_id": run_id,
+        "cell_key": "sha256:abc",
+        "suite": "s",
+        "trigger": "t",
+        "identity": {
+            "model": {"id": "m"},
+            "lane": "rocm",
+            "workload": {"kind": "tg", "depth": 0},
+        },
+        "host": {"hal0_version": "1"},
+        "outcome": "ok",
+        "summary": {"decode_ts_med": decode},
+    }
+
+
+def test_current_cells_newest_is_append_order_not_run_id_lexicographic(tmp_path, monkeypatch):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    store = Store()
+
+    # Same wall-clock second. Appended A (older) THEN B (newer), but A's random
+    # run_id suffix sorts AFTER B's — so MAX(run_id) would wrongly pick A.
+    store.append_record(_ok_rec("2026-07-05T00:00:00Z-zzzzzz", 10.0))  # older
+    store.append_record(_ok_rec("2026-07-05T00:00:00Z-aaaaaa", 99.0))  # newest
+
+    store.reindex()
+    rows = store.results()
+    assert len(rows) == 1
+    # The current value must be the newest (last-appended) ok record...
+    assert rows[0]["decode_ts_med"] == 99.0
+    # ...and it must AGREE with the planner's own source-of-truth notion.
+    planner_current = store.newest_ok_by_cell()["sha256:abc"]["summary"]["decode_ts_med"]
+    assert planner_current == 99.0

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -563,3 +563,43 @@ def test_toolbox_pull_invoked_subcommand_skips_preflight(
     result = doctor(ctx=_CtxWithSubcommand(), verify=False, plain=False, ports=None)  # type: ignore[arg-type]
     assert result is None
     assert "should-not-run" not in capfd.readouterr().out
+
+
+def test_toolbox_pull_json_output_is_plain_not_ansi_colorized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--json must emit plain, parseable JSON — no ANSI escapes.
+
+    Regression: rich's ``console.print_json`` re-highlights the payload with
+    ANSI escape sequences whenever its terminal heuristics fire (which they do
+    even when stdout is piped, e.g. ``hal0 doctor toolbox-pull --json | jq``),
+    corrupting the bytes a machine consumer parses.
+    """
+    pinned = "sha256:" + "a" * 64
+    manifest_path = _write_manifest(
+        tmp_path,
+        {
+            "_schema": "hal0.manifest.v1",
+            "toolbox_images": {
+                "vulkan": {
+                    "tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+                    "digest": pinned,
+                },
+            },
+        },
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/token":
+            return httpx.Response(200, json={"token": "anon"})
+        return httpx.Response(200, headers={"Docker-Content-Digest": pinned})
+
+    _install_mock_httpx(monkeypatch, handler)
+
+    with pytest.raises(typer.Exit):
+        toolbox_pull(json_output=True, manifest_path=manifest_path)
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out, "JSON output must not contain ANSI escape sequences"
+    assert jsonlib.loads(out)[0]["ok"] is True

--- a/tests/comfyui/test_fetch_no_deadlock.py
+++ b/tests/comfyui/test_fetch_no_deadlock.py
@@ -1,0 +1,55 @@
+"""Regression: the model-fetch worker must not deadlock on large script output.
+
+``_run_sequence`` used to launch each ``get_*.sh`` step with
+``stdout=subprocess.PIPE`` (``stderr=STDOUT``) and then call ``proc.wait()``
+WITHOUT ever draining the pipe. The Python docs warn this deadlocks once the
+child fills the OS pipe buffer (~64 KB): the child blocks writing, the parent
+blocks in ``wait()``. Real hf-download scripts emit MBs of progress output, so
+every genuine multi-GB pull would hang forever in status ``running`` — the
+worker never advances and the download never lands.
+
+This test exercises the real I/O path (real ``subprocess.Popen``) with a step
+that emits ~1 MB and asserts the job reaches a terminal state promptly.
+"""
+
+from __future__ import annotations
+
+import subprocess as _subprocess
+import time
+
+from hal0.comfyui.capabilities import default_variant
+from hal0.comfyui.fetch import fetch_model, get_job
+
+
+def test_fetch_does_not_deadlock_on_large_script_output(monkeypatch, tmp_path):
+    # A stand-in fetch step that writes ~1 MB to stdout — far past the OS pipe
+    # buffer, like an hf download's progress stream.
+    big = tmp_path / "big_output.sh"
+    big.write_text("head -c 1000000 /dev/zero | tr '\\0' 'x'\n")
+
+    real_popen = _subprocess.Popen
+
+    def _redirect_popen(cmd, **kw):
+        # Ignore the resolved get_*.sh path; run the big-output script with the
+        # EXACT stdio kwargs _run_sequence chose, so the pipe-drain behaviour is
+        # what's under test.
+        return real_popen(["bash", str(big)], **kw)
+
+    monkeypatch.setattr("hal0.comfyui.fetch.subprocess.Popen", _redirect_popen)
+
+    variant = default_variant("image_upscale")  # esrgan: single empty-args step
+    job_id = fetch_model(variant)
+
+    deadline = time.monotonic() + 15.0
+    status = "running"
+    while time.monotonic() < deadline:
+        job = get_job(job_id)
+        if job is not None and job["status"] != "running":
+            status = job["status"]
+            break
+        time.sleep(0.02)
+
+    assert status == "done", (
+        f"fetch worker did not finish (status={status!r}) — the child's stdout "
+        "pipe was not drained, so proc.wait() deadlocked on >64 KB of output"
+    )

--- a/tests/providers/test_container_model_reachability.py
+++ b/tests/providers/test_container_model_reachability.py
@@ -1,0 +1,52 @@
+"""A slot's model file must be bind-mounted even when it lives outside every
+configured model root.
+
+Live regression (Strix Halo box, 150): 42 models under ``/mnt/ai-models`` while
+``[models].store`` and ``[models].pull_root`` both pointed at
+``/var/lib/hal0/models``. ``model_mount_roots()`` then returned only
+``/var/lib/hal0/models``, so a slot whose registry model path was under
+``/mnt/ai-models`` got a container with that file UNREACHABLE — llama-server
+exits at load and the slot's container "crashes" (flaps warming↔error). The
+renderer must mount the model file's own directory whenever no configured root
+covers it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.providers import container as C
+from hal0.providers.container import _llama_launch_plan
+
+
+def _plan(model_path: str):
+    return _llama_launch_plan(
+        image="img",
+        port=8090,
+        model_path=model_path,
+        flags_str="",
+        devices=[],
+        group_ids=[],
+    )
+
+
+def test_model_outside_configured_roots_is_mounted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Configured roots cover only /var/lib/hal0/models (the 150 drift).
+    monkeypatch.setattr(C, "model_mount_roots", lambda: ["/var/lib/hal0/models"])
+    plan = _plan("/mnt/ai-models/qwopus3.5-4b-coder-mtp/model.gguf")
+    sources = {m.source for m in plan.mounts}
+    # The model file's own directory is mounted so the file is reachable...
+    assert "/mnt/ai-models/qwopus3.5-4b-coder-mtp" in sources, sources
+    # ...and the configured root is still mounted too.
+    assert "/var/lib/hal0/models" in sources, sources
+
+
+def test_model_under_configured_root_adds_no_extra_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A model already under a configured root needs no extra mount (no churn
+    # for the common case — e.g. the brain slot on 150).
+    monkeypatch.setattr(C, "model_mount_roots", lambda: ["/var/lib/hal0/models"])
+    plan = _plan("/var/lib/hal0/models/chat/hal0-brain-sft-fpx8/model.gguf")
+    sources = [m.source for m in plan.mounts]
+    assert sources == ["/var/lib/hal0/models"], sources

--- a/tests/slots/test_watchdog_load_race.py
+++ b/tests/slots/test_watchdog_load_race.py
@@ -1,0 +1,73 @@
+"""A fail-watcher must not clobber an in-flight load.
+
+Live regression (105, v1.0.0-alpha.2): a large model's WARMING load holds the
+per-slot lock for the whole cold-load window. The SlotWatchdog stamped ERROR
+(``_transition(..., force=True)``) WITHOUT taking that lock — so while the unit
+read briefly inactive during warmup it flipped the slot to ERROR mid-load. The
+load's own final ``WARMING -> READY`` transition (non-force) then hit
+``current == ERROR`` and raised ``IllegalSlotTransition`` — surfacing as a 409
+on ``/api/slots/{name}/load`` and a slot wedged in ``error``. Small/fast slots
+loaded before the watcher's strike window elapsed, so only big models failed.
+
+The fix: the watchdog acquires the same per-slot lock and RE-VERIFIES the fault
+before stamping, so it can never race a load — and a load that converged
+healthy while the watcher waited for the lock is left READY.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import hal0.slots.watchdog as wd
+from hal0.slots.manager import SlotManager
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def test_load_survives_concurrent_fail_watch(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slot whose unit reads inactive during warmup must still land READY
+    when the model converges — the fail-watcher must not stamp ERROR onto the
+    in-flight load."""
+    # Tighten the watcher so its strike fires inside the test window.
+    monkeypatch.setattr(wd, "_FAIL_WATCH_INTERVAL_S", 0.01)
+    monkeypatch.setattr(wd, "_WARMING_INACTIVE_STRIKES", 1)
+
+    sm = SlotManager()
+
+    # Model is "big": the unit stays inactive through warmup (so the watcher's
+    # is-active probe strikes), and readiness blocks until we release the gate.
+    gate = asyncio.Event()
+
+    def _spawn_no_active(cfg: dict, model_info: dict) -> None:
+        # Record the spawn but DON'T mark the unit active yet — mimics a
+        # container that hasn't converged (reads inactive to the watcher).
+        container_stub.load_calls.append((dict(cfg), dict(model_info)))
+
+    async def _slow_wait_ready(port: int, timeout_s: float | None = None) -> None:
+        await gate.wait()
+
+    monkeypatch.setattr(container_stub, "load_sync", _spawn_no_active)
+    monkeypatch.setattr(container_stub, "wait_ready", _slow_wait_ready)
+    container_stub.healthy = False
+
+    load_task = asyncio.create_task(sm.load("chat"))
+    # Let load reach WARMING and the fail-watcher take several strike ticks
+    # while the unit still reads inactive.
+    await asyncio.sleep(0.1)
+
+    # Model finishes: unit active + serving /health, readiness unblocks.
+    container_stub.active.add("chat")
+    container_stub.healthy = True
+    gate.set()
+
+    slot = await load_task
+
+    assert slot.state == SlotState.READY
+    assert sm._current_state("chat") == SlotState.READY


### PR DESCRIPTION
Six real bugs found during live triage on **main** (1.0.0-alpha.2 — the release line 105/142/150 run) and reproduced against it. The touched files are byte-identical on `main` and `rework/descar`, so these apply to both; landing on `main` because that's where the bugs bite (and where alpha.2 ships).

| Fix | Bug | Regression test |
|---|---|---|
| **slots/watchdog** | `SlotWatchdog` stamped ERROR/OFFLINE (`force=True`) without the per-slot lock `load`/`unload`/`restart` hold → races an in-flight big-model load into an illegal `error→ready` (slot wedged, 409 on `/load`). All 3 stamp sites → `_stamp_locked` (lock + re-verify). **Verified live on Strix Halo 150.** | `tests/slots/test_watchdog_load_race.py` |
| **slots/container (O25)** | model file outside every configured store root (`/mnt/ai-models` after store moved) → never mounted → llama exits at load → slot crashes. descar's `assert_under_store(warn)`+doctor guard **detect but don't heal** (live-proven on 150: 6 flagged). Mount the model's own dir when uncovered. | `tests/providers/test_container_model_reachability.py` |
| **comfyui/fetch** | `stdout=PIPE` never drained → `proc.wait()` deadlocks once a real hf download fills the ~64KB pipe → job hangs forever. → DEVNULL. | `tests/comfyui/test_fetch_no_deadlock.py` |
| **bench/parsers** | `accepted / draft_n` with draft_n>0 but accepted None → TypeError drops the queue item. Guard both counts. | `test_...drafts_without_accepted_does_not_crash` |
| **bench/store** | `current_cells` newest-ok by `MAX(run_id)` (random-suffix tie-break) disagreed with the planner. Use `rowid_seq`. | `tests/bench/test_store.py` |
| **cli/doctor** | `toolbox-pull --json` → `console.print_json` → ANSI on a pipe → unparseable by jq. Plain `json.dumps`. | `test_toolbox_pull_json_output_is_plain_not_ansi_colorized` |

Verification: slots/bench/comfyui/doctor/providers suites pass · ruff clean · check-sunset green (scar neutral) · 150 install-validation confirmed the watchdog + O25 fixes live.

Companion PR against descar: #1350 (same fixes; the branches share these files identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)