### PR TITLE
fix(installer): escape backticks in hal0-api.service heredoc (fresh install blocker)

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -988,7 +988,7 @@ Group=hal0
 # group-writable kludge needed, the setgid dirs already cover group access.
 WorkingDirectory=${API_WORKDIR}
 EnvironmentFile=${API_ENV}
-# Shared Hermes interpreter policy, persisted by `hal0 agent install hermes`.
+# Shared Hermes interpreter policy, persisted by \`hal0 agent install hermes\`.
 # Optional so core hal0 services remain installable when Hermes is skipped/degraded.
 EnvironmentFile=-${ETC_DIR}/hermes-python.env
 # Optional (leading \`-\`): the HF_TOKEN secrets file (WS-D, #1106) — absent


### PR DESCRIPTION
## Real fresh-install blocker

The `hal0-api.service` unit heredoc (`installer/install.sh` ~L972, `cat > "$API_UNIT" <<EOF` — **unquoted**) had a comment with literal backticks:

```
# Shared Hermes interpreter policy, persisted by `hal0 agent install hermes`.
```

Bash **command-substitutes** those backticks — it *runs a full `hal0 agent install hermes`* at unit-render time and bakes its multi-line stdout (`[hermes-prereqs]…`, `Provisioning Hermes…`, gateway logs) **into the unit file**. systemd then reads `[hermes-prereqs] …` as an invalid section header:

```
hal0-api.service:20: Invalid section header '[hermes-prereqs] toolchain already present …'
Failed to enable unit: File hal0-api.service: Bad message
XX install failed at line 1969 during: Service start   (INSTALL_EXIT=1)
```

Fix: escape the two backticks (sibling lines 986/994/999 already were). One line.

**Found + verified** during a full RC1.0 reinstall test on lxc105 **and** lxc150: pre-fix `INSTALL_EXIT=1`, post-fix `INSTALL_EXIT=0` on both boxes, unit `systemd-analyze verify` clean, services start, slots load, `/v1/chat/completions` serves.

`bash -n installer/install.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)