### PR TITLE
feat(slots): synchronous pre-load eviction + serialized admission (O26)

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1118,6 +1118,8 @@ async def _boot_slot_manager(app: FastAPI, ctx: BootState) -> None:
         upstreams_registry=ctx.upstreams,
         identity_store=ctx.identity_store,
         port_authority=ctx.port_authority,
+        preload_evict_enabled=ctx.hal0_config.slots.preload_evict_enabled,
+        preload_evict_headroom_mb=ctx.hal0_config.slots.preload_evict_headroom_mb,
     )
 
 

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1857,6 +1857,33 @@ class SlotsConfig(BaseModel):
             "back above the floor. 0 disables pressure eviction."
         ),
     )
+    preload_evict_enabled: bool = Field(
+        default=True,
+        description=(
+            "Free memory SYNCHRONOUSLY before a load starts, when the "
+            "incoming model's estimated footprint plus "
+            "preload_evict_headroom_mb would not fit in projected free "
+            "memory. Evicts idle lru-eligible resident slots in "
+            "least-recently-used order — the same eligibility "
+            "evict_pressure_mb uses — until it fits, or fails the load "
+            "with a clear error if it still doesn't fit after evicting "
+            "everything eligible. Set to false to rely solely on the "
+            "reactive pressure sweeper (#903), which only reacts after "
+            "the fact on a timer."
+        ),
+    )
+    preload_evict_headroom_mb: int = Field(
+        default=1024,
+        ge=0,
+        description=(
+            "Extra free-RAM slack (MiB) required on top of a model's "
+            "estimated footprint before pre-load eviction "
+            "(preload_evict_enabled) considers a load safe to start. "
+            "Absorbs error in the coarse file-size + KV-cache footprint "
+            "estimate and runtime/container overhead the estimate doesn't "
+            "capture."
+        ),
+    )
     publish_host: str = Field(
         default="127.0.0.1",
         description=(

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -124,6 +124,22 @@ def _kv_estimate_mb(ctx_tokens: int) -> float:
     return (ctx_tokens / 1000.0) * _KV_MIB_PER_1K_TOKENS
 
 
+def estimate_file_size_kv_mb(model_mb: float, ctx_meta: dict[str, Any] | None) -> float:
+    """Model-file-size + KV-cache footprint estimate, in MiB.
+
+    This is the same baseline/fallback formula :func:`build_per_slot` uses
+    (its path 3, and the floor under path 2's cgroup probe): model file
+    size plus a coarse per-context-token KV estimate (:func:`_kv_estimate_mb`
+    / :func:`_ctx_tokens_for`). Factored out so other callers that must size
+    a model BEFORE it is resident — and therefore have no cgroup/FLM figure
+    to read yet, e.g. pre-load eviction (:mod:`hal0.slots.preload_evict`)
+    deciding whether an incoming load will fit — reuse exactly this
+    estimator instead of a second, divergent one.
+    """
+    kv_mb = _kv_estimate_mb(_ctx_tokens_for(ctx_meta))
+    return round(model_mb + kv_mb, 1)
+
+
 def _ctx_tokens_for(model_meta: dict[str, Any] | None) -> int:
     """Resolve the effective context window (tokens) for a model.
 
@@ -309,8 +325,7 @@ async def build_per_slot(
                 ctx_meta = m.model_dump() if hasattr(m, "model_dump") else None
             except Exception:
                 model_mb = 0.0
-        kv_mb = _kv_estimate_mb(_ctx_tokens_for(ctx_meta))
-        estimate_mb = round(model_mb + kv_mb, 1)
+        estimate_mb = estimate_file_size_kv_mb(model_mb, ctx_meta)
 
         # ── Container cgroup probe (path 2) ────────────────────────────────
         # Probe the live podman/docker cgroup.  Returns 0 when no container
@@ -479,4 +494,5 @@ __all__ = [
     "CapacitySnapshot",
     "_container_cgroup_mem_bytes",
     "build_per_slot",
+    "estimate_file_size_kv_mb",
 ]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -64,6 +64,8 @@ from hal0.slots.drift import compute_config_drift as _compute_config_drift
 from hal0.slots.layout import is_id_stem
 from hal0.slots.npu.trio import is_npu_trio_shadow
 from hal0.slots.npu.trio import reconcile_trio_slots as _npu_reconcile_trio_slots
+from hal0.slots.preload_evict import _DEFAULT_HEADROOM_MB
+from hal0.slots.preload_evict import admit as _preload_admit
 from hal0.slots.profile_adopt import (
     apply_preferred_profile as _profile_adopt_apply_preferred_profile,
 )
@@ -277,6 +279,8 @@ class SlotManager:
         evict_after_s: float = _EVICT_AFTER_S,
         evict_pressure_mb: float = 8192.0,
         evict_pressure_pct: float | None = None,
+        preload_evict_enabled: bool = True,
+        preload_evict_headroom_mb: float = _DEFAULT_HEADROOM_MB,
         idle_monitor_interval_s: float = _IDLE_MONITOR_INTERVAL_S,
         event_bus: Any | None = None,
         upstreams_registry: Any | None = None,
@@ -387,6 +391,22 @@ class SlotManager:
         # GTT pool grows/shrinks). None (default) keeps the absolute
         # ``evict_pressure_mb`` floor above — purely additive.
         self._evict_pressure_pct: float | None = evict_pressure_pct
+        # Pre-load eviction (synchronous, at admission time — see
+        # hal0.slots.preload_evict): before a load starts, free idle
+        # lru-eligible slots until the incoming model's estimated
+        # footprint + headroom fits in projected free memory, instead of
+        # waiting for the next pressure-sweep tick. `_preload_evict_enabled
+        # = False` disables the gate entirely (reactive TTL/pressure
+        # eviction still applies). `_admission_lock` serializes the
+        # fit-decision across concurrently loading slots; each admitted-
+        # but-not-yet-resident load reserves its estimated footprint in
+        # `_preload_reserved_mb` (keyed by slot name) so a second
+        # concurrent admission doesn't also conclude it fits against the
+        # same stale free-memory snapshot.
+        self._preload_evict_enabled: bool = preload_evict_enabled
+        self._preload_evict_headroom_mb: float = float(preload_evict_headroom_mb)
+        self._preload_reserved_mb: dict[str, float] = {}
+        self._admission_lock: asyncio.Lock = asyncio.Lock()
         self._idle_monitor_interval_s: float = idle_monitor_interval_s
         # Idle/eviction background loop (P3-slots §1b) — SlotReaper owns its
         # own task handle; see reaper.py.
@@ -1377,33 +1397,50 @@ class SlotManager:
                     )
                     assert self._pull_runner is not None  # _needs_pull guards
                     await self._pull_runner(resolved_model)
-                await self._transition(
-                    slot_name,
-                    SlotState.STARTING,
-                    model_id=resolved_model,
-                    port=_cfg_port(cfg),
-                )
-                await self._spawn_locked(slot_name, cfg, resolved_model)
-                await self._transition(
-                    slot_name,
-                    SlotState.WARMING,
-                    model_id=resolved_model,
-                    port=_cfg_port(cfg),
-                )
-                # _await_ready returns READY when the upstream has a
-                # model loaded and serves inference, or IDLE when the
-                # process is up but ``/v1/models`` is empty (issue #31:
-                # llama-server --model "" lands here). Either is a
-                # successful load — callers downstream pick READY slots
-                # for routing and IDLE slots for "ready to accept a
-                # model" UX.
-                resolved_state = await self._await_ready(slot_name, _cfg_port(cfg))
-                await self._transition(
-                    slot_name,
-                    resolved_state,
-                    model_id=resolved_model,
-                    port=_cfg_port(cfg),
-                )
+                # Resolved once and threaded through both the pre-load
+                # eviction estimate and _spawn_locked below so a load never
+                # hits the model registry twice for the same model_id.
+                model_info = await self._resolve_model_info(resolved_model)
+                # Pre-load eviction (O26): estimate resolved_model's
+                # footprint and, if projected free memory is short, evict
+                # idle/LRU-eligible resident slots until it fits — BEFORE
+                # starting the container, not after the box is already
+                # tight. Raises PreloadEvictionFailed (caught by the
+                # except below, which stamps ERROR and re-raises) when it
+                # still won't fit after evicting everything eligible; the
+                # reservation this holds is released on any exit from the
+                # `async with`, success or failure. See
+                # hal0.slots.preload_evict for the policy.
+                async with _preload_admit(
+                    self, slot_name=slot_name, model_id=resolved_model, model_info=model_info
+                ):
+                    await self._transition(
+                        slot_name,
+                        SlotState.STARTING,
+                        model_id=resolved_model,
+                        port=_cfg_port(cfg),
+                    )
+                    await self._spawn_locked(slot_name, cfg, resolved_model, model_info=model_info)
+                    await self._transition(
+                        slot_name,
+                        SlotState.WARMING,
+                        model_id=resolved_model,
+                        port=_cfg_port(cfg),
+                    )
+                    # _await_ready returns READY when the upstream has a
+                    # model loaded and serves inference, or IDLE when the
+                    # process is up but ``/v1/models`` is empty (issue #31:
+                    # llama-server --model "" lands here). Either is a
+                    # successful load — callers downstream pick READY slots
+                    # for routing and IDLE slots for "ready to accept a
+                    # model" UX.
+                    resolved_state = await self._await_ready(slot_name, _cfg_port(cfg))
+                    await self._transition(
+                        slot_name,
+                        resolved_state,
+                        model_id=resolved_model,
+                        port=_cfg_port(cfg),
+                    )
                 # Persist explicit model_id to TOML so reconciliation
                 # after an api restart doesn't drift back to "no
                 # model.default" ERROR. Only fires when caller passed
@@ -1833,6 +1870,8 @@ class SlotManager:
         slot_name: str,
         slot_cfg: SlotConfig | dict[str, Any],
         model_id: str | None,
+        *,
+        model_info: dict[str, Any] | None = None,
     ) -> None:
         """Spawn body — caller already holds the per-slot lock.
 
@@ -1842,10 +1881,17 @@ class SlotManager:
         ``model_id`` (when set) overrides the slot config's
         ``model.default`` for swap semantics.
 
+        ``model_info``: pass the already-resolved registry lookup (see
+        :meth:`_resolve_model_info`) when the caller (``load()``) has one,
+        so a single load doesn't hit the model registry twice — once for
+        the pre-load eviction footprint estimate, once here. ``None``
+        (the default, used by every other caller) resolves it fresh.
+
         Any exception is let through as-is; the calling ``load()``
         ``except Exception -> ERROR`` branch records a stable error envelope.
         """
-        model_info = await self._resolve_model_info(model_id)
+        if model_info is None:
+            model_info = await self._resolve_model_info(model_id)
 
         cfg = _cfg_to_dict(slot_cfg)
         if model_id:

--- a/src/hal0/slots/preload_evict.py
+++ b/src/hal0/slots/preload_evict.py
@@ -1,0 +1,471 @@
+"""Pre-load eviction: free memory synchronously BEFORE a load, until it fits.
+
+Today every automatic reclamation path is reactive: TTL eviction and the
+``SlotReaper`` pressure sweep (see :mod:`hal0.slots.reaper`) only run on a
+timer, AFTER the box is already tight. Nothing stood between
+``SlotManager.load()`` and a container spawn that doesn't fit alongside
+what's already resident — the box can OOM before the next sweep tick.
+
+This module adds the missing synchronous gate: before a slot starts, estimate
+the incoming model's footprint and, if projected free memory is short, evict
+idle/LRU-eligible resident slots — in LRU order — until it fits. It
+deliberately REUSES existing machinery rather than inventing a second,
+divergent notion of "fits" or "evictable":
+
+  - Footprint estimate: :func:`hal0.slots.capacity.estimate_file_size_kv_mb`
+    (registry file size + coarse KV-cache estimate) — the same formula
+    :func:`hal0.slots.capacity.build_per_slot` uses as its baseline.
+  - Free-memory probe: :meth:`SlotManager._probe_host_free_mb` (GTT-aware,
+    §21.10) — the same probe the pressure sweeper reads.
+  - Eviction eligibility: :func:`hal0.slots.reaper.is_pinned` + the
+    per-slot ``lru = true`` TOML flag + ``serving_count`` + state — the
+    EXACT rules :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`
+    already applies, just run synchronously at admission time instead of on
+    a timer.
+
+Two layers, so the decision logic is unit-testable without spinning
+containers:
+
+  - :func:`select_eviction_order` is a PURE function: given an LRU-ordered
+    candidate list (with pre-computed footprint estimates) and how much is
+    needed, it decides which candidates to evict and whether the result
+    will fit. No I/O, no SlotManager.
+  - :func:`admit` is the async orchestrator :meth:`SlotManager.load` calls:
+    gathers live candidates, calls :func:`select_eviction_order`, executes
+    the plan against the real manager (real unloads, re-probing real free
+    memory after each — the plan is an ESTIMATE, the probe is ground
+    truth), and raises :class:`PreloadEvictionFailed` with the concrete
+    evidence (what was freed, what was still short) if it still won't fit.
+
+Concurrent admission (field evidence, box OOM postmortem): several loads
+racing independently would each read the same stale free-memory snapshot
+and each conclude "it fits", collectively over-committing. ``admit()``
+serializes the fit decision through :attr:`SlotManager._admission_lock` and
+reserves the incoming model's estimated footprint in
+:attr:`SlotManager._preload_reserved_mb` for the duration of the load —
+released on success AND failure — so a second concurrent ``admit()`` call
+for a DIFFERENT slot sees the first load's reservation subtracted from free
+memory, even though the first slot isn't resident (and thus not visible to
+the host-memory probe) yet.
+
+NOTE — scope: this closes the gate on every path that calls
+``SlotManager.load()`` (interactive load/swap/start, dispatcher
+wake-on-request). It does NOT cover slot containers that systemd starts
+directly at boot via each Quadlet's ``WantedBy=hal0.target`` (see
+``hal0.providers.container``) — those are enabled to auto-start
+independent of hal0-api's Python process, so hal0-api only ever ADOPTS them
+after the fact (:meth:`SlotManager._maybe_adopt_running_slot`) and this
+gate never runs for them. That is a separate, larger change (systemd
+sequencing / hal0-api-owned boot admission) tracked as follow-up, not
+addressed here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from hal0.slots.reaper import is_pinned
+from hal0.slots.state import (
+    IllegalSlotTransition,
+    SlotConfigError,
+    SlotError,
+    SlotNotFound,
+    SlotState,
+)
+
+if TYPE_CHECKING:
+    import asyncio
+
+log = logging.getLogger(__name__)
+
+# Extra free-memory slack (MiB) required on top of a model's estimated
+# footprint before admission considers a load safe. Absorbs error in the
+# coarse file-size + KV-cache estimate and runtime/container overhead the
+# estimate doesn't capture. Mirrors evict_pressure_mb's role as a floor,
+# just applied synchronously at admission instead of on the pressure timer.
+_DEFAULT_HEADROOM_MB: float = 1024.0
+
+__all__ = [
+    "_DEFAULT_HEADROOM_MB",
+    "CandidateSlot",
+    "EvictionStep",
+    "PreloadEvictHost",
+    "PreloadEvictionFailed",
+    "PreloadEvictionPlan",
+    "admit",
+    "select_eviction_order",
+]
+
+
+class PreloadEvictionFailed(SlotError):
+    """The incoming model still doesn't fit after evicting every eligible slot.
+
+    ``details`` carries the concrete evidence an operator needs: which
+    slots were freed, how much that recovered, and the remaining shortfall
+    — never just "out of memory".
+    """
+
+    code = "slot.preload_evict_insufficient"
+    status = 507
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateSlot:
+    """One resident slot considered for pre-load eviction.
+
+    ``eligible=False`` candidates are carried through (rather than
+    filtered out before reaching :func:`select_eviction_order`) so the
+    planner itself is the thing under test for "never evicts protected
+    slots" — a candidate list mixing eligible and ineligible entries is
+    the natural unit-test fixture.
+    """
+
+    name: str
+    last_used: float
+    footprint_mb: float
+    eligible: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class EvictionStep:
+    """One eviction actually executed, for the structured log trail."""
+
+    slot: str
+    freed_mb: float
+
+
+@dataclass(frozen=True, slots=True)
+class PreloadEvictionPlan:
+    """Pure decision output of :func:`select_eviction_order`.
+
+    ``selected`` is the LRU-ordered subset of eligible candidates the
+    caller should evict; ``projected_free_mb`` is the ESTIMATE after
+    evicting all of them (real callers re-probe after each real eviction
+    rather than trusting this cumulative estimate — see :func:`admit`).
+    """
+
+    needed_mb: float
+    headroom_mb: float
+    initial_free_mb: float
+    projected_free_mb: float
+    selected: tuple[CandidateSlot, ...]
+    fits: bool
+
+
+def select_eviction_order(
+    candidates: list[CandidateSlot],
+    *,
+    needed_mb: float,
+    headroom_mb: float,
+    free_mb: float,
+) -> PreloadEvictionPlan:
+    """Decide which candidates to evict, in LRU order, until it fits.
+
+    Pure: no I/O, no SlotManager. Ineligible candidates (``eligible=False``
+    — pinned, non-lru, serving, or in a non-resident state) are NEVER
+    selected regardless of how old or how large they are. Eligible
+    candidates are evicted oldest-``last_used``-first, stopping as soon as
+    the running projected free memory covers ``needed_mb + headroom_mb``,
+    matching :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`'s
+    "stop as soon as relieved" behaviour.
+    """
+    target = needed_mb + headroom_mb
+    if free_mb >= target:
+        return PreloadEvictionPlan(
+            needed_mb=needed_mb,
+            headroom_mb=headroom_mb,
+            initial_free_mb=free_mb,
+            projected_free_mb=free_mb,
+            selected=(),
+            fits=True,
+        )
+
+    eligible = sorted((c for c in candidates if c.eligible), key=lambda c: c.last_used)
+    selected: list[CandidateSlot] = []
+    projected = free_mb
+    for candidate in eligible:
+        if projected >= target:
+            break
+        selected.append(candidate)
+        projected += candidate.footprint_mb
+
+    return PreloadEvictionPlan(
+        needed_mb=needed_mb,
+        headroom_mb=headroom_mb,
+        initial_free_mb=free_mb,
+        projected_free_mb=projected,
+        selected=tuple(selected),
+        fits=projected >= target,
+    )
+
+
+class PreloadEvictHost(Protocol):
+    """Narrow seam :func:`admit` needs from ``SlotManager``.
+
+    Mirrors :class:`hal0.slots.reaper.ReaperHost` — same style, same
+    reasoning: tests monkeypatch these on a real ``SlotManager`` instance
+    (see ``tests/slots/test_pressure_eviction.py``), so every read goes
+    through ``host.X()``, never computed inline here.
+    """
+
+    _serving_count: dict[int, int]
+    _preload_evict_enabled: bool
+    _preload_evict_headroom_mb: float
+    _preload_reserved_mb: dict[str, float]
+    _admission_lock: asyncio.Lock
+
+    def _resolve_alias(self, name: str) -> str: ...
+    def _key(self, name: str) -> int: ...
+    def _current_state(self, name: str) -> SlotState: ...
+    def _sweep_candidates(self) -> dict[str, float]: ...
+    def _probe_host_free_mb(self) -> float: ...
+    async def _load_slot_config(self, name: str) -> dict[str, Any]: ...
+    async def _resolve_model_info(self, model_id: str | None) -> dict[str, Any]: ...
+    async def list(self) -> list[Any]: ...
+    async def unload(self, name: str) -> Any: ...
+
+
+async def _estimate_incoming_footprint_mb(
+    host: PreloadEvictHost,
+    model_id: str,
+    *,
+    model_info: dict[str, Any] | None = None,
+) -> float:
+    """Best-effort footprint (MiB) for a model that is NOT yet resident.
+
+    Reuses :func:`hal0.slots.capacity.estimate_file_size_kv_mb` — registry
+    file size plus the coarse KV-cache estimate — the exact formula
+    :func:`hal0.slots.capacity.build_per_slot` falls back to for a
+    resident slot with no live cgroup/FLM figure yet. There is nothing
+    more precise available synchronously before spawn: FLM's footprint_gb
+    and the container cgroup probe both describe an ALREADY-running
+    process, not one about to start.
+
+    ``model_info``: pass the caller's already-resolved
+    :meth:`SlotManager._resolve_model_info` result (``load()`` does, so it
+    threads through to ``_spawn_locked`` too) to avoid a second registry
+    hit for the same model_id. ``None`` resolves it here.
+
+    WEAK SPOT: when the registry has no size_bytes for ``model_id`` (outage,
+    not-yet-registered catalog id, stub registry) this returns 0.0, and the
+    caller fails OPEN — skips pre-load eviction rather than admitting on a
+    bogus near-zero estimate. This mirrors the pressure probe's existing
+    fail-safe contract (:func:`hal0.slots.reaper.probe_host_free_mb`
+    returns ``inf`` on probe failure so eviction never fires blind) but
+    means a genuinely huge model with an unresolvable registry entry gets
+    NO pre-load protection — only the reactive pressure sweeper still
+    applies. Left as-is rather than guessing a size, per the existing
+    "never swallow into a fabricated number" convention in this module tree
+    (see capacity.py's Tier-1 fixes).
+    """
+    from hal0.slots.capacity import estimate_file_size_kv_mb
+
+    info = model_info if model_info is not None else await host._resolve_model_info(model_id)
+    if not info:
+        return 0.0
+    try:
+        model_mb = float(info.get("size_bytes") or 0) / (1024.0 * 1024.0)
+    except (TypeError, ValueError):
+        model_mb = 0.0
+    if model_mb <= 0:
+        return 0.0
+    return estimate_file_size_kv_mb(model_mb, info)
+
+
+async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[CandidateSlot]:
+    """Build the full candidate list (eligible AND ineligible) for admission.
+
+    Eligibility mirrors :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`
+    exactly: resident state (READY/IDLE), not currently serving, not
+    pinned (:func:`is_pinned`), and ``lru = true`` in the slot's TOML. The
+    slot about to be loaded is always excluded — by construction it can't
+    be READY/IDLE yet (``load()`` short-circuits before this point when it
+    already is), but the exclusion is explicit here too as a hard
+    guarantee, not an accident of state timing.
+    """
+    sweep = host._sweep_candidates()
+    if not sweep:
+        return []
+    exclude_canonical = host._resolve_alias(exclude)
+
+    registry: Any = None
+    with contextlib.suppress(Exception):
+        from hal0.registry.store import ModelRegistry
+
+        registry = ModelRegistry()
+
+    from hal0.slots.capacity import build_per_slot
+
+    slots = await host.list()
+    per_slot = await build_per_slot(slots, registry=registry)
+
+    out: list[CandidateSlot] = []
+    for name, ts in sweep.items():
+        canonical = host._resolve_alias(name)
+        if name == exclude or canonical == exclude_canonical:
+            continue
+
+        reason = ""
+        eligible = True
+        if host._serving_count.get(host._key(name), 0) > 0:
+            eligible, reason = False, "serving"
+        else:
+            state = host._current_state(name)
+            if state not in (SlotState.READY, SlotState.IDLE):
+                eligible, reason = False, "not_resident"
+            else:
+                try:
+                    cfg = await host._load_slot_config(name)
+                except (SlotConfigError, SlotNotFound):
+                    eligible, reason = False, "config_unavailable"
+                else:
+                    if is_pinned(canonical, cfg):
+                        eligible, reason = False, "pinned"
+                    elif not cfg.get("lru", False):
+                        eligible, reason = False, "not_lru"
+
+        footprint_mb = float(per_slot.get(name, {}).get("mem_mb", 0.0) or 0.0)
+        out.append(
+            CandidateSlot(
+                name=name,
+                last_used=ts,
+                footprint_mb=footprint_mb,
+                eligible=eligible,
+                reason=reason,
+            )
+        )
+    return out
+
+
+@contextlib.asynccontextmanager
+async def admit(
+    host: PreloadEvictHost,
+    *,
+    slot_name: str,
+    model_id: str,
+    model_info: dict[str, Any] | None = None,
+) -> AsyncIterator[None]:
+    """Admission gate: free memory (if needed) before ``slot_name`` starts.
+
+    Wrap the spawn section of :meth:`SlotManager.load` in
+    ``async with admit(self, slot_name=slot_name, model_id=resolved_model,
+    model_info=model_info):``. No-op (disabled via config, or the incoming
+    footprint can't be estimated — fail-open) except for the reservation
+    bookkeeping used to serialize concurrent admissions. Raises
+    :class:`PreloadEvictionFailed` — BEFORE the caller's ``yield`` body
+    runs, so nothing is half-loaded — when eviction still leaves it short.
+
+    ``model_info``: pass ``load()``'s already-resolved
+    :meth:`SlotManager._resolve_model_info` result so admission and
+    ``_spawn_locked`` share one registry lookup instead of two.
+    """
+    if not host._preload_evict_enabled:
+        yield
+        return
+
+    needed_mb = await _estimate_incoming_footprint_mb(host, model_id, model_info=model_info)
+    if needed_mb <= 0:
+        log.debug(
+            "slot.preload_evict_unknown_footprint",
+            extra={"slot": slot_name, "model_id": model_id},
+        )
+        yield
+        return
+
+    headroom_mb = host._preload_evict_headroom_mb
+
+    async with host._admission_lock:
+        reserved_by_others = sum(
+            mb for name, mb in host._preload_reserved_mb.items() if name != slot_name
+        )
+        free_mb = host._probe_host_free_mb() - reserved_by_others
+        target = needed_mb + headroom_mb
+
+        executed: list[EvictionStep] = []
+        if free_mb < target:
+            candidates = await _gather_candidates(host, exclude=slot_name)
+            plan = select_eviction_order(
+                candidates, needed_mb=needed_mb, headroom_mb=headroom_mb, free_mb=free_mb
+            )
+            for candidate in plan.selected:
+                try:
+                    await host.unload(candidate.name)
+                except IllegalSlotTransition:
+                    log.warning(
+                        "slot.preload_evict_race",
+                        extra={"slot": slot_name, "candidate": candidate.name},
+                    )
+                    continue
+                except Exception as exc:  # never let one bad eviction sink admission
+                    log.warning(
+                        "slot.preload_evict_failed",
+                        extra={
+                            "slot": slot_name,
+                            "candidate": candidate.name,
+                            "error": str(exc),
+                        },
+                    )
+                    continue
+                free_mb = host._probe_host_free_mb() - reserved_by_others
+                executed.append(EvictionStep(slot=candidate.name, freed_mb=candidate.footprint_mb))
+                log.info(
+                    "slot.preload_evicted",
+                    extra={
+                        "slot": slot_name,
+                        "model_id": model_id,
+                        "candidate": candidate.name,
+                        "freed_mb": round(candidate.footprint_mb, 1),
+                        "free_mb": round(free_mb, 1),
+                        "needed_mb": round(target, 1),
+                    },
+                )
+                if free_mb >= target:
+                    break
+
+        if free_mb < target:
+            shortfall_mb = round(target - free_mb, 1)
+            evicted_names = [step.slot for step in executed]
+            freed_total_mb = round(sum(step.freed_mb for step in executed), 1)
+            log.warning(
+                "slot.preload_evict_insufficient",
+                extra={
+                    "slot": slot_name,
+                    "model_id": model_id,
+                    "evicted": evicted_names,
+                    "freed_mb": freed_total_mb,
+                    "free_mb": round(free_mb, 1),
+                    "needed_mb": round(needed_mb, 1),
+                    "headroom_mb": round(headroom_mb, 1),
+                    "shortfall_mb": shortfall_mb,
+                },
+            )
+            raise PreloadEvictionFailed(
+                f"cannot free enough memory to load {model_id!r} into slot "
+                f"{slot_name!r}: evicted {evicted_names} (freed {freed_total_mb} MiB), "
+                f"still short {shortfall_mb} MiB "
+                f"(need {round(needed_mb, 1)} MiB + {round(headroom_mb, 1)} MiB headroom, "
+                f"have {round(free_mb, 1)} MiB free)",
+                details={
+                    "slot": slot_name,
+                    "model_id": model_id,
+                    "evicted": evicted_names,
+                    "freed_mb": freed_total_mb,
+                    "free_mb": round(free_mb, 1),
+                    "needed_mb": round(needed_mb, 1),
+                    "headroom_mb": round(headroom_mb, 1),
+                    "shortfall_mb": shortfall_mb,
+                },
+            )
+
+        host._preload_reserved_mb[slot_name] = needed_mb
+
+    try:
+        yield
+    finally:
+        async with host._admission_lock:
+            host._preload_reserved_mb.pop(slot_name, None)

--- a/tests/slots/test_npu_trio_shadow.py
+++ b/tests/slots/test_npu_trio_shadow.py
@@ -105,7 +105,17 @@ def patched_spawn(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """
     spawned: list[str] = []
 
-    async def fake_spawn(self: SlotManager, name: str, cfg: object, model: object) -> None:
+    async def fake_spawn(
+        self: SlotManager,
+        name: str,
+        cfg: object,
+        model: object,
+        **kwargs: object,
+    ) -> None:
+        # ``**kwargs`` absorbs the keyword-only ``model_info`` that ``load()``
+        # threads through (O26 pre-load eviction resolves the registry entry
+        # once and hands it to the spawn) without pinning this stub to the
+        # real signature.
         spawned.append(name)
 
     async def fake_await_ready(self: SlotManager, *a: object, **k: object) -> SlotState:

--- a/tests/slots/test_preload_eviction.py
+++ b/tests/slots/test_preload_eviction.py
@@ -1,0 +1,193 @@
+"""Tests for pre-load eviction (§O26): freeing memory synchronously before a
+load, instead of waiting for the reactive pressure sweeper to react.
+
+Two layers, matching hal0.slots.preload_evict's split:
+
+  - ``select_eviction_order()`` — the pure planner. No I/O, no SlotManager;
+    exercises the full policy matrix (fits-without-eviction,
+    fits-after-evicting-N in LRU order, cannot-fit, never-evicts-protected)
+    directly against plain dataclasses.
+  - A couple of ``SlotManager.load()`` integration tests (mirroring
+    tests/slots/test_pressure_eviction.py's fixture style) proving the
+    policy is actually wired into the real load path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+from hal0.slots.preload_evict import (
+    CandidateSlot,
+    PreloadEvictionFailed,
+    select_eviction_order,
+)
+from hal0.slots.state import SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+# ── pure planner: select_eviction_order() ────────────────────────────────────
+
+
+def test_select_no_eviction_when_already_fits() -> None:
+    """Free memory already covers needed + headroom: nothing is selected."""
+    candidates = [
+        CandidateSlot(name="rerank", last_used=100.0, footprint_mb=4000.0, eligible=True),
+    ]
+    plan = select_eviction_order(candidates, needed_mb=2000.0, headroom_mb=500.0, free_mb=4000.0)
+    assert plan.selected == ()
+    assert plan.fits is True
+    assert plan.projected_free_mb == 4000.0
+
+
+def test_select_evicts_in_lru_order_until_it_fits() -> None:
+    """Oldest last_used is evicted first; stops the moment it fits."""
+    candidates = [
+        CandidateSlot(name="rerank", last_used=500.0, footprint_mb=2000.0, eligible=True),
+        CandidateSlot(name="embed", last_used=100.0, footprint_mb=2000.0, eligible=True),  # oldest
+        CandidateSlot(name="stt", last_used=300.0, footprint_mb=2000.0, eligible=True),
+    ]
+    # free=500 vs target=3500 -> one eviction (2500) isn't enough,
+    # two evictions (4500) clears it.
+    plan = select_eviction_order(candidates, needed_mb=3000.0, headroom_mb=500.0, free_mb=500.0)
+    assert [c.name for c in plan.selected] == ["embed", "stt"]
+    assert plan.fits is True
+    assert plan.projected_free_mb == 500.0 + 2000.0 + 2000.0
+
+
+def test_select_cannot_fit_reports_shortfall() -> None:
+    """Evicting every eligible candidate still isn't enough: fits=False."""
+    candidates = [
+        CandidateSlot(name="embed", last_used=100.0, footprint_mb=500.0, eligible=True),
+    ]
+    plan = select_eviction_order(candidates, needed_mb=8000.0, headroom_mb=1000.0, free_mb=100.0)
+    assert [c.name for c in plan.selected] == ["embed"]
+    assert plan.fits is False
+    assert plan.projected_free_mb == 600.0
+
+
+def test_select_never_evicts_ineligible_candidates() -> None:
+    """A pinned/non-lru/serving candidate is never selected — even when it
+    is the oldest AND the largest — because the planner itself enforces
+    eligibility, not just whatever gathered the candidate list."""
+    candidates = [
+        CandidateSlot(
+            name="agent", last_used=1.0, footprint_mb=50_000.0, eligible=False, reason="pinned"
+        ),
+        CandidateSlot(name="embed", last_used=200.0, footprint_mb=1000.0, eligible=True),
+    ]
+    plan = select_eviction_order(candidates, needed_mb=500.0, headroom_mb=100.0, free_mb=0.0)
+    assert [c.name for c in plan.selected] == ["embed"]
+    assert plan.fits is True
+
+
+def test_select_insufficient_when_only_ineligible_candidates_exist() -> None:
+    """No eligible candidates at all -> nothing selected, never fits."""
+    candidates = [
+        CandidateSlot(name="agent", last_used=1.0, footprint_mb=50_000.0, eligible=False),
+    ]
+    plan = select_eviction_order(candidates, needed_mb=500.0, headroom_mb=100.0, free_mb=0.0)
+    assert plan.selected == ()
+    assert plan.fits is False
+
+
+# ── SlotManager.load() integration ───────────────────────────────────────────
+
+
+def _write_slot(root: Path, name: str, *, port: int, lru: bool = False) -> None:
+    lines = [
+        f'name = "{name}"',
+        f"port = {port}",
+        'backend = "vulkan"',
+        'provider = "llama-server"',
+        "enabled = true",
+    ]
+    if lru:
+        lines.append("lru = true")
+    lines += ["[model]", 'default = "qwen3-4b-q4_k_m"', ""]
+    (root / f"{name}.toml").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _stub_model_info(size_mb: float) -> Any:
+    """Fake SlotManager._resolve_model_info returning a fixed file size."""
+
+    async def _info(model_id: str | None) -> dict[str, Any]:
+        return {"size_bytes": int(size_mb * 1024 * 1024)}
+
+    return _info
+
+
+async def test_load_evicts_idle_lru_slot_to_make_room(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A load that wouldn't otherwise fit evicts the idle lru-eligible slot
+    first, then proceeds — no reactive-only wait for the pressure sweeper."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    _write_slot(slot_root, "embed", port=8091, lru=True)
+    sm = SlotManager(preload_evict_headroom_mb=0.0)
+    await sm.load("rerank")
+    sm._last_used[sm._key("rerank")] = 0.0  # idle long enough to be lru-eligible
+
+    monkeypatch.setattr(sm, "_resolve_model_info", _stub_model_info(4000.0))
+    free_readings = [1000.0, 6000.0]  # short before eviction, plenty after
+    monkeypatch.setattr(
+        sm, "_probe_host_free_mb", lambda: free_readings.pop(0) if free_readings else 6000.0
+    )
+
+    await sm.load("embed")
+
+    assert (await sm.status("embed")).state in (SlotState.READY, SlotState.IDLE)
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
+
+
+async def test_load_fails_clearly_when_nothing_fits(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No eligible (non-lru) candidate exists: the load fails with a clear,
+    actionable error — nothing half-loaded, and the resident slot (not
+    lru-eligible, so never a candidate) is left completely untouched."""
+    _write_slot(slot_root, "rerank", port=8090, lru=False)
+    sm = SlotManager(preload_evict_headroom_mb=0.0)
+    await sm.load("rerank")
+
+    monkeypatch.setattr(sm, "_resolve_model_info", _stub_model_info(4000.0))
+    monkeypatch.setattr(sm, "_probe_host_free_mb", lambda: 100.0)
+
+    with pytest.raises(PreloadEvictionFailed) as excinfo:
+        await sm.load("chat")
+
+    assert excinfo.value.details["slot"] == "chat"
+    assert excinfo.value.details["evicted"] == []
+    assert (await sm.status("chat")).state == SlotState.ERROR
+    assert (await sm.status("rerank")).state == SlotState.READY
+    assert not container_stub.unload_calls
+
+
+async def test_load_skips_gate_when_disabled(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """preload_evict_enabled=False: the gate never runs, even when the
+    (stubbed) footprint estimate would otherwise be far short."""
+    _write_slot(slot_root, "rerank", port=8090, lru=True)
+    sm = SlotManager(preload_evict_enabled=False)
+    await sm.load("rerank")
+    sm._last_used[sm._key("rerank")] = 0.0
+
+    monkeypatch.setattr(sm, "_resolve_model_info", _stub_model_info(999_999.0))
+    monkeypatch.setattr(sm, "_probe_host_free_mb", lambda: 1.0)
+
+    await sm.load("chat")
+
+    assert (await sm.status("chat")).state in (SlotState.READY, SlotState.IDLE)
+    # rerank was never touched by pre-load eviction (gate disabled).
+    assert (await sm.status("rerank")).state in (SlotState.READY, SlotState.IDLE)
+    assert not any(c.get("name") == "rerank" for c in container_stub.unload_calls)


### PR DESCRIPTION
## Summary

All memory reclamation was reactive: TTL eviction and a background pressure sweeper. Nothing freed memory **before** a load, so `SlotManager.load()` could start a model that doesn't fit alongside what's already resident and the box would go over before the sweeper reacted.

Adds a synchronous admission gate at `load()`:

- Estimate the incoming model's footprint (`capacity.estimate_file_size_kv_mb` — extracted from `build_per_slot`, same formula, no behavior change).
- If projected free < needed + headroom, evict idle/LRU-eligible slots in LRU order until it fits. Eligibility **mirrors `SlotReaper.pressure_evict_once()` exactly** (`is_pinned()`, per-slot `lru=true`, `serving_count==0`, state in `{READY, IDLE}`); the target slot is excluded by construction. Re-probes actual free memory after each unload rather than trusting the estimate.
- Multi-slot residency is preserved when the model genuinely fits — this is not "unload everything".
- If it still won't fit after evicting everything eligible: `PreloadEvictionFailed` (HTTP 507) raised **before** spawn, with evicted slots / freed MiB / free / needed / headroom / shortfall in `details`. Nothing half-loaded.

**Serialized admission.** `_admission_lock` serializes the fit decision across concurrently loading slots, and each admitted-but-not-yet-resident load reserves its estimated footprint in `_preload_reserved_mb` — so N concurrent loads can't each independently conclude "it fits" against the same stale snapshot. The lock covers the decision and eviction execution only; the load itself runs outside it.

Config: `[slots] preload_evict_enabled = true`, `preload_evict_headroom_mb = 1024`.
Structured events: `slot.preload_evicted`, `slot.preload_evict_race`, `slot.preload_evict_failed`, `slot.preload_evict_insufficient`, `slot.preload_evict_unknown_footprint`.

## Known limitation (documented in-module, not closed here)

**Boot-time systemd concurrent restore is NOT gated.** Field diagnosis on a live box showed the dominant failure is systemd starting every slot Quadlet concurrently via `WantedBy=hal0.target`, independent of hal0-api — which only *adopts* those afterward. This gate covers every path through `SlotManager.load()` (interactive load/swap, dispatcher wake-on-request) but cannot intercept systemd-initiated starts. Closing that needs hal0-api-owned sequencing of boot startup and is deliberately a separate change.

Fail-open case: an unresolvable/unregistered `model_id` yields no `size_bytes`, so the estimate would be ~0. Rather than admit on a bogus number, `admit()` skips the gate and logs `slot.preload_evict_unknown_footprint` — mirroring the pressure probe's existing fail-safe contract.

## Risk grade

- [ ] low
- [x] med — new code path on every load
- [ ] high

## Touched surfaces

- [x] API (`src/hal0/api/`)
- [ ] Auth / sessions
- [x] Slots / dispatch
- [ ] Models / capabilities
- [ ] Installer
- [ ] Updater
- [ ] Board chat / MCP admin
- [x] Config / schema
- [ ] UI
- [ ] Docs
- [ ] CI / release

## §14.1 high-risk surfaces

- [ ] Unauthenticated board routes
- [ ] `AUTONOMOUS_WRITE_TOOLS`
- [ ] Installer / updater RCE-class

## Rollback

_Rollback:_ set `[slots] preload_evict_enabled = false` to disable the gate at runtime (reactive TTL/pressure eviction still applies), or revert the merge.

## Test tiers run

- [x] α unit — `tests/slots/test_preload_eviction.py`, `test_pressure_eviction.py`, `test_manager.py` — 75 passed. New tests cover: fits-without-eviction, fits-after-evicting-N in LRU order, cannot-fit clean failure, protected slots never evicted.
- [x] β — import smoke, ruff, sunset ratchet (200 ≤ 200) green
- [ ] γ — runs as the Playwright check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PuHjo1FhvTL5uGS1VVNdk