### PR TITLE
fix(stacks): stop stack-created slots carrying model-owned vision/mtp

### DIFF
--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -181,16 +181,23 @@ async def _create_missing_slots(
             continue
         device = entry.device or "gpu-vulkan"
         profile = entry.profile or DEVICE_TO_DEFAULT_PROFILE.get(device, "")
+        # spec-hw-slot-ownership §1: vision/mtp are model-owned typed
+        # capabilities, so a stack-created slot must not be born carrying
+        # them. `reject_model_owned_slot_keys` guards the HTTP surface
+        # (create_slot / update_slot_config in api/routes/slots.py), but this
+        # path calls `SlotManager.create()` directly in-process and never
+        # reaches that handler — so dropping them here is what keeps
+        # stack-created slots on the right side of the partition.
+        # `entry.vision`/`entry.mtp` stay on the stack schema for back-compat
+        # but no longer project onto the slot, matching what
+        # `stacks.apply._reconciled_stack_slot` already does.
         body: dict[str, Any] = {
             "name": entry.slot,
             "type": "llm",
             "model": entry.model,
             "device": device,
             "profile": profile,
-            "vision": bool(entry.vision),
         }
-        if entry.mtp is not None:
-            body["mtp"] = bool(entry.mtp)
         if entry.server_extra_args:
             body["server"] = {"extra_args": entry.server_extra_args}
         try:


### PR DESCRIPTION
## Summary

Salvaged from #1354 (closed as superseded by #1353) — this is the one piece #1353 doesn't cover.

#1353 made `mtp`/`enable_thinking`/`vision` model-owned and added `reject_model_owned_slot_keys`, but wired the guard **only** into the HTTP surface (`create_slot` / `update_slot_config` in `api/routes/slots.py`). `_create_missing_slots` in `api/routes/stacks.py` calls `SlotManager.create()` **directly in-process**, so it never reaches that handler — it still wrote `vision` unconditionally (and `mtp` when set) into the create body.

Net effect on main today: applying a stack births every created slot carrying model-owned keys, re-opening the two-writer split §1 exists to close, on the one path the guard can't see.

Fix drops both from the create body, matching what `stacks.apply._reconciled_stack_slot` already does. `entry.vision`/`entry.mtp` stay on the stack schema for back-compat; they simply no longer project onto the slot.

## Risk grade

- [x] low — behaviour-preserving alignment with §1; removes dead/harmful keys from one write path
- [ ] med
- [ ] high

## Touched surfaces

- [x] API (`src/hal0/api/`)
- [ ] Auth / sessions
- [x] Slots / dispatch
- [ ] Models / capabilities
- [ ] Installer
- [ ] Updater
- [ ] Board chat / MCP admin
- [ ] Config / schema
- [ ] UI
- [ ] Docs
- [ ] CI / release

## §14.1 high-risk surfaces

- [ ] Unauthenticated board routes
- [ ] `AUTONOMOUS_WRITE_TOOLS`
- [ ] Installer / updater RCE-class

## Rollback

_Rollback:_ revert the commit — single-file, no schema or migration involved.

## Test tiers run

- [x] α unit — `tests/stacks/`, `tests/slot_config/` — 137 passed
- [x] β — ruff check/format, import smoke, sunset ratchet (200 ≤ 200) green
- [ ] γ — runs as the Playwright check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PuHjo1FhvTL5uGS1VVNdk