### PR TITLE
fix(agents): route agent-unit stop/disable through the privilege seam

### DIFF
--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -12,6 +12,16 @@
 # match a strict identifier regex), no shell is ever evaluated, and no
 # wildcards are accepted.
 #
+# AGENT UNITS (#453 follow-up): the seam was originally slot-only, so
+# HermesDriver._stop_services() had nothing to call and shelled out to a BARE
+# `systemctl stop hal0-agent@hermes.service`. Unprivileged systemctl on a
+# system unit escalates through polkit — i.e. an interactive password dialog
+# in the middle of an uninstall (and, when cancelled, a unit that was never
+# actually stopped). stop-agent/disable-agent close that gap: same posture as
+# the slot verbs — a dedicated validator (validate_agent_id), the unit name is
+# built HERE from a validated id (the caller never supplies a unit string),
+# the systemctl verb is a literal, no shell, no wildcards.
+#
 # NOTE: the iptables FORWARD-chain repair the original P3-perms design doc
 # sketched for this seam is NOT needed — that repair already runs as its own
 # independent root oneshot unit (packaging/systemd/hal0-podman-forward.service,
@@ -22,6 +32,12 @@ set -euo pipefail
 UNIT_PREFIX="hal0-slot@"
 UNIT_DIR="/etc/systemd/system"
 SELF_UNIT="hal0-api.service"
+
+# Bundled-agent template unit (hal0-agent@<id>.service). Separate prefix +
+# separate validator from the slot family on purpose: the two id namespaces are
+# unrelated, and a single shared "id" concept would let a slot verb reach an
+# agent unit (or vice versa) if either regex is ever loosened.
+AGENT_UNIT_PREFIX="hal0-agent@"
 
 # P3-quadlet: per-slot Podman Quadlet source files live here, root-owned by
 # design; podman's systemd generator turns hal0-slot@<id>.container into
@@ -41,6 +57,17 @@ validate_slot_id() {   # arg: slot id (the "<id>" in hal0-slot@<id>.service)
   local id="$1"
   [[ -n "$id" ]] || die "missing slot id"
   [[ "$id" =~ ^[A-Za-z0-9_-]{1,64}$ ]] || die "bad slot id: $id"
+}
+
+validate_agent_id() {  # arg: agent id (the "<id>" in hal0-agent@<id>.service)
+  # Deliberately as strict as validate_slot_id: a bounded identifier charset
+  # with NO '.', '/', '@' or whitespace, so a validated id can never carry a
+  # second unit name, a path traversal, an extra systemd instance spec, or an
+  # option-looking token ('-x' is a legal id but is only ever concatenated into
+  # ${AGENT_UNIT_PREFIX}${id}.service, never passed as a bare argv word).
+  local id="$1"
+  [[ -n "$id" ]] || die "missing agent id"
+  [[ "$id" =~ ^[A-Za-z0-9_-]{1,64}$ ]] || die "bad agent id: $id"
 }
 
 cmd="${1:-help}"; shift || true
@@ -94,13 +121,26 @@ case "$cmd" in
     exec systemctl "$cmd" "${UNIT_PREFIX}${id}.service"
     ;;
 
+  stop-agent)                 # stop-agent <agent-id>   -> systemctl stop hal0-agent@<id>.service
+    # The systemctl verb is a LITERAL here (not "$cmd" as the slot family does)
+    # so the agent-unit surface can never grow a verb by accident: adding one
+    # means adding a new case arm, which is a reviewable diff.
+    id="${1:-}"; validate_agent_id "$id"
+    exec systemctl stop "${AGENT_UNIT_PREFIX}${id}.service"
+    ;;
+
+  disable-agent)              # disable-agent <agent-id> -> systemctl disable hal0-agent@<id>.service
+    id="${1:-}"; validate_agent_id "$id"
+    exec systemctl disable "${AGENT_UNIT_PREFIX}${id}.service"
+    ;;
+
   restart-self)                # literal-only: restart hal0-api.service, never a variable name
     exec systemctl restart "$SELF_UNIT"
     ;;
 
   help|"")
     cat <<EOF
-usage: hal0-systemctl <command> [slot-id]
+usage: hal0-systemctl <command> [slot-id|agent-id]
   write-unit <slot-id>             write ${UNIT_DIR}/${UNIT_PREFIX}<id>.service (body on stdin)
   remove-unit <slot-id>            rm -f ${UNIT_DIR}/${UNIT_PREFIX}<id>.service
   write-quadlet <slot-id>          write ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container (body on stdin)
@@ -110,6 +150,8 @@ usage: hal0-systemctl <command> [slot-id]
   start|stop|restart <slot-id>     systemctl <verb> ${UNIT_PREFIX}<id>.service
   enable|disable <slot-id>         systemctl <verb> ${UNIT_PREFIX}<id>.service
   reset-failed <slot-id>           clear a crash-looped unit's failed sub-state
+  stop-agent <agent-id>            systemctl stop ${AGENT_UNIT_PREFIX}<id>.service
+  disable-agent <agent-id>         systemctl disable ${AGENT_UNIT_PREFIX}<id>.service
   restart-self                     systemctl restart ${SELF_UNIT}
 EOF
     ;;

--- a/packaging/sudoers/hal0-systemctl
+++ b/packaging/sudoers/hal0-systemctl
@@ -4,12 +4,18 @@
 # installer/install.sh). It delegates the genuinely-root slot-lifecycle ops —
 # writing a per-slot unit under /etc/systemd/system, writing the fixed
 # hermes-gateway secrets drop-in, daemon-reload,
-# start/stop/restart/enable/disable/reset-failed of a slot unit, and
-# restarting itself on self-update — to
+# start/stop/restart/enable/disable/reset-failed of a slot unit,
+# stop/disable of a bundled-agent unit (hal0-agent@<id>.service, the #453
+# uninstall teardown), and restarting itself on self-update — to
 # /usr/lib/hal0/bin/hal0-systemctl, which is the entire privileged surface:
-# the helper validates every slot id (strict identifier regex), builds every
-# target path itself (the gateway drop-in path is a literal), never evaluates a
-# shell, and accepts no wildcards.
+# the helper validates every slot id AND every agent id (strict identifier
+# regexes), builds every unit name and target path itself (the gateway drop-in
+# path is a literal), never evaluates a shell, and accepts no wildcards.
+#
+# NOTE: the grant is pinned to the helper BINARY, not to an argv list, so
+# adding stop-agent/disable-agent needs no sudoers change — the helper's own
+# case statement is the allow-list. Widening that allow-list is therefore a
+# reviewable diff in installer/wrappers/hal0-systemctl.
 #
 # Install (as root):
 #   install -m 0755 -o root -g root hal0-systemctl /usr/lib/hal0/bin/hal0-systemctl

--- a/src/hal0/agents/hermes/driver.py
+++ b/src/hal0/agents/hermes/driver.py
@@ -28,7 +28,6 @@ keys off the concrete managed-venv artifacts instead.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import os
 import shutil
@@ -37,11 +36,25 @@ import subprocess  # nosec B404 — required for shim
 from pathlib import Path
 from typing import Any
 
+import structlog
+
 from hal0.agents.manager import (
     AgentDriver,
     HermesUpstreamMissingError,
 )
 from hal0.config import paths as _paths
+
+# The hal0-systemctl privilege seam. `hal0.system.seam` imports nothing from
+# hal0 (stdlib only), so this cannot cycle — which is why the shared sudo
+# helper lives there rather than in `hal0.agents.hermes_provision`, whose
+# `_privileged_systemctl` it was factored out of: that module is a 5k-line
+# provisioner in this driver's own package, so importing it here would invert
+# the driver -> provisioner layering and cost a heavy import on every driver
+# load (the same reason the venv-layout constants above are mirrored, not
+# imported).
+from hal0.system import seam as _seam
+
+log = structlog.get_logger(__name__)
 
 # NOTE: provisioning (venv create + pip install hermes-agent + wrapper
 # shim) moved wholesale into the bootstrap pipeline
@@ -141,6 +154,44 @@ def _probe_systemd_unit_active(unit: str) -> bool:
     except (OSError, subprocess.SubprocessError):
         return False
     return result.returncode == 0
+
+
+# systemd's "no such unit" family. `systemctl stop` on a unit that was never
+# installed exits 5 (EXIT_NOTINSTALLED); `disable` on the same exits 1 with a
+# "does not exist" message. Both mean "nothing to tear down", which the
+# documented best-effort contract says is NOT an error — so they are classified
+# out of the warning path rather than suppressing every failure indiscriminately
+# (the #453 defect). Matched on stderr too, because exit 1 alone is ambiguous:
+# it is also what a DENIED escalation returns, and that one must warn.
+_UNIT_ABSENT_RC = 5
+_UNIT_ABSENT_MARKERS = (
+    "not loaded",
+    "not found",
+    "does not exist",
+    "no such file or directory",
+)
+
+
+def _as_text(raw: object) -> str:
+    """Coerce captured stderr to str.
+
+    ``capture_output=True`` without ``text=True`` yields bytes in production;
+    an injected test fake may yield str or nothing at all. Both are handled
+    here so the classifier below sees one type.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", "replace").strip()
+    return str(raw).strip()
+
+
+def _unit_absent(returncode: int, stderr: str) -> bool:
+    """True when a non-zero systemctl exit only means "there is no such unit"."""
+    if returncode == _UNIT_ABSENT_RC:
+        return True
+    low = stderr.lower()
+    return any(marker in low for marker in _UNIT_ABSENT_MARKERS)
 
 
 def _probe_tcp_port(host: str, port: int, *, timeout: float = 1.0) -> bool:
@@ -265,30 +316,98 @@ class HermesDriver(AgentDriver):
 
     def _stop_services(self) -> None:
         """Stop + disable the hermes-agent systemd service so it doesn't
-        recreate files during uninstall (#453). Best-effort — missing
-        systemctl or a missing unit is not an error; the uninstall proceeds
-        regardless.
+        recreate files during uninstall (#453).
 
-        Goes through ``self._runner`` rather than the module-global
-        ``subprocess``. As a ``@staticmethod`` on the global it bypassed
-        the injection point entirely, so every test that called
-        ``uninstall()`` shelled out to the real system bus — two polkit
-        auth prompts per test, each blocking for its full timeout.
+        Two things this must get right, both of which it previously got wrong.
+
+        **Privilege.** The argv comes from
+        :func:`hal0.system.seam.agent_unit_argv`, not from a literal
+        ``["systemctl", "stop", ...]``. A bare unprivileged ``systemctl stop``
+        on a *system* unit escalates via polkit — an interactive password
+        dialog mid-uninstall, and a unit still running when the operator
+        cancels it. Off root, the seam builds
+        ``sudo -n /usr/lib/hal0/bin/hal0-systemctl stop-agent hermes``
+        (installer/wrappers/hal0-systemctl); ``sudo -n`` can fail but can
+        never prompt. As root it stays a direct ``systemctl``.
+
+        **Silence.** The calls used to sit inside ``contextlib.suppress`` with
+        ``capture_output=True`` and the return code discarded, so a denied
+        escalation was indistinguishable from a clean stop — precisely the
+        condition #453 added this method to prevent (agent still live,
+        recreating the files we are about to delete). Failures are now
+        classified and logged:
+
+        * no systemctl on PATH — return, no log. No systemd, no unit.
+        * unit absent / not loaded — debug. Not an error.
+        * any other non-zero (no sudo grant, seam not installed, stop
+          failed) — **warning**, with exit code, stderr, and a remedy.
+        * ``OSError`` / timeout — warning.
+
+        Still best-effort in the sense that matters: it never raises, and the
+        uninstall always proceeds. Best-effort is not the same as silent.
+
+        Execution goes through ``self._runner`` (upstream #1357): as a
+        ``@staticmethod`` on the module-global ``subprocess`` this bypassed
+        the driver's injection point, so every ``uninstall()`` test shelled
+        out to the real system bus.
         """
-        unit = "hal0-agent@hermes.service"
         if shutil.which("systemctl") is None:
             return
-        for argv, timeout in (
-            (["systemctl", "stop", unit], 10),
-            (["systemctl", "disable", unit], 5),
-        ):
-            with contextlib.suppress(OSError, subprocess.SubprocessError):
-                self._runner.run(  # nosec B603 — known-safe argv
-                    argv,
-                    check=False,
-                    capture_output=True,
-                    timeout=timeout,
-                )
+        # stop before disable: disabling a running unit leaves it running.
+        for verb, timeout in (("stop", 10), ("disable", 5)):
+            self._systemctl_agent_verb(verb, timeout=timeout)
+
+    def _systemctl_agent_verb(self, verb: str, *, timeout: int) -> None:
+        """One seam-routed agent-unit verb + failure classification.
+
+        Split out of :meth:`_stop_services` so the "what counts as a real
+        failure" policy is stated once rather than per-verb.
+        """
+        argv = _seam.agent_unit_argv(verb, self.name)
+        try:
+            proc = self._runner.run(  # nosec B603 — argv built by the seam from a validated id
+                argv,
+                check=False,
+                capture_output=True,
+                timeout=timeout,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            # TimeoutExpired, or sudo/systemctl vanished mid-uninstall.
+            log.warning(
+                "hermes.stop_services_failed",
+                verb=verb,
+                agent=self.name,
+                argv=argv,
+                error=str(exc),
+            )
+            return
+
+        returncode = getattr(proc, "returncode", 0)
+        if returncode == 0:
+            return
+        stderr = _as_text(getattr(proc, "stderr", None))
+        if _unit_absent(returncode, stderr):
+            log.debug(
+                "hermes.stop_services_unit_absent",
+                verb=verb,
+                agent=self.name,
+                returncode=returncode,
+            )
+            return
+        log.warning(
+            "hermes.stop_services_failed",
+            verb=verb,
+            agent=self.name,
+            argv=argv,
+            returncode=returncode,
+            stderr=stderr,
+            hint=(
+                f"could not {verb} {_seam.agent_unit_name(self.name)} — the agent "
+                "may still be running and recreating files during uninstall (#453). "
+                "Re-run as root, or check the /etc/sudoers.d/hal0-systemctl grant "
+                "and that /usr/lib/hal0/bin/hal0-systemctl is installed."
+            ),
+        )
 
     def _data_dir(self) -> Path:
         return _paths.var_lib() / "agents" / self.name

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -55,6 +55,7 @@ from typing import Any
 import structlog
 
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
+from hal0.system import seam as _seam
 
 log = structlog.get_logger(__name__)
 
@@ -4309,16 +4310,17 @@ def cleanup_stale_agent_dropins(
 def _privileged_systemctl(verb: str, body: str | None = None) -> None:
     """Run one hal0-systemctl seam verb as root via ``sudo -n``.
 
+    Thin wrapper over :func:`hal0.system.seam.privileged_systemctl` — the ONE
+    place the ``sudo -n <seam-bin> <verb>`` invocation is spelled, now shared
+    with the agent-unit teardown path (``HermesDriver._stop_services``). Kept as
+    a module-local name so ``_HAL0_SYSTEMCTL`` stays the env-overridable knob
+    this module's tests monkeypatch.
+
     ``body`` (when given) is piped on stdin — used for ``write-gateway-dropin``.
     Raises ``subprocess.CalledProcessError`` on a non-zero seam exit so the
     caller surfaces the failure instead of masquerading a broken gateway as up.
     """
-    subprocess.run(  # nosec B603 — fixed argv; verb is a literal from our own code
-        ["sudo", "-n", _HAL0_SYSTEMCTL, verb],
-        input=body,
-        text=True,
-        check=True,
-    )
+    _seam.privileged_systemctl(verb, body=body, seam_bin=_HAL0_SYSTEMCTL, check=True)
 
 
 def _privileged_env_write(verb: str, body: str) -> None:

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -543,6 +543,25 @@ def _enable_and_start_hermes_unit() -> None:
     No-op when systemd isn't present (containers / dev). A non-zero rc is
     surfaced as a hint rather than failing the install — the agent is
     provisioned either way and can be started manually.
+
+    DELIBERATELY BARE — not routed through the hal0-systemctl privilege seam,
+    unlike ``HermesDriver._stop_services``. Three reasons, judged for this site
+    specifically:
+
+    1. *Interactive by construction.* This runs only from
+       ``hal0 agent install hermes``, a foreground command a human admin runs
+       on the host (it has already shelled out to ``hermes-prereqs.sh`` to
+       install OS packages). A polkit prompt here is legitimate and
+       answerable — someone is at the terminal. The uninstall/daemon path is
+       the opposite: nobody is there to answer, so it must never prompt.
+    2. *Already loud.* A cancelled prompt or a denied escalation returns
+       non-zero and prints a remedy below. The seam fix was about a path that
+       SWALLOWED the failure; this one does not.
+    3. *Keeping the grant asymmetric on purpose.* The seam exposes only
+       ``stop-agent``/``disable-agent``. Adding ``enable``/``start`` would let
+       the unprivileged ``hal0`` service user bring agent units up at boot —
+       a persistence primitive — in exchange for convenience on a path that
+       does not need it. Stop/disable only ever reduces what is running.
     """
     import shutil as _shutil
     import subprocess as _subprocess
@@ -689,6 +708,19 @@ def _install_hermes_gateway() -> None:
             console.print(f"[dim]  {f['detail']}\n  stop: {f['stop_cmd']}[/dim]")
         return
 
+    # Also deliberately bare — same interactive-CLI reasoning as
+    # _enable_and_start_hermes_unit (see its docstring), plus one specific to
+    # this unit: hermes-gateway.service is neither a hal0-agent@ nor a
+    # hal0-slot@ instance, so the seam has no verb that could reach it. The
+    # seam's posture is "build the unit name here from a validated id"; a fixed
+    # foreign unit would need a new literal-only verb (like restart-self),
+    # which this path does not need — it runs from `hal0 agent install hermes`
+    # in the foreground, where a prompt is answerable, and it surfaces a
+    # non-zero rc below instead of swallowing it.
+    #
+    # (The gateway's secrets DROP-IN write does route through the seam —
+    # `write-gateway-dropin` — because that one is reached by the provisioner
+    # running as the unprivileged hal0 user. Different caller, different rule.)
     _subprocess.run(["systemctl", "daemon-reload"], check=False)  # nosec B603 B607
     rc = _subprocess.run(  # nosec B603 B607
         ["systemctl", "enable", "--now", "hermes-gateway.service"], check=False

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -52,6 +52,28 @@ _UNIT_NAME_RE = re.compile(r"^hal0-slot@([A-Za-z0-9_-]{1,64})\.service$")
 #: Root-owned by design; written via ``hal0-systemctl write-quadlet <token>``.
 _QUADLET_NAME_RE = re.compile(r"^hal0-slot@([A-Za-z0-9_-]{1,64})\.container$")
 
+# ── Bundled-agent units (hal0-agent@<id>.service) ────────────────────────────
+#
+# #453 follow-up. The seam started slot-only, so ``HermesDriver._stop_services``
+# had nothing to call and shelled out to a BARE ``systemctl stop
+# hal0-agent@hermes.service``. Unprivileged systemctl on a system unit escalates
+# through polkit — an interactive password dialog in the middle of an uninstall,
+# and a unit that stays up when the operator cancels it. The wrapper grew
+# ``stop-agent``/``disable-agent`` (installer/wrappers/hal0-systemctl); these
+# constants are the Python side of that contract.
+
+#: systemd template unit for a bundled agent.
+AGENT_UNIT_PREFIX = "hal0-agent@"
+
+#: Mirrors ``validate_agent_id`` in installer/wrappers/hal0-systemctl EXACTLY.
+#: Client-side validation is a fail-fast convenience, never the security
+#: boundary — the seam re-validates every id server-side (as root).
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+#: The only agent-unit verbs the seam exposes, mapped bare-systemctl verb ->
+#: seam verb. Anything not in here is a programming error, not a runtime input.
+AGENT_UNIT_VERBS: dict[str, str] = {"stop": "stop-agent", "disable": "disable-agent"}
+
 
 class Hal0SeamMissing(RuntimeError):
     """Raised when the hal0-systemctl seam is required but not installed.
@@ -71,6 +93,93 @@ def is_hal0_service_user() -> bool:
     except KeyError:
         return False
     return os.geteuid() == hal0_uid
+
+
+def agent_unit_name(agent_id: str) -> str:
+    """Build ``hal0-agent@<id>.service`` from a validated ``agent_id``.
+
+    Raises :class:`ValueError` on anything the wrapper's ``validate_agent_id``
+    would reject. Callers never assemble a unit string themselves and never
+    hand one to the seam — the seam takes the bare id and builds the unit name
+    on the root side. This function exists so the unprivileged side fails
+    fast with a readable error instead of burning a sudo round-trip.
+    """
+    if not _AGENT_ID_RE.match(agent_id):
+        raise ValueError(f"bad agent id: {agent_id!r}")
+    return f"{AGENT_UNIT_PREFIX}{agent_id}.service"
+
+
+def privileged_systemctl(
+    verb: str,
+    *args: str,
+    body: str | None = None,
+    seam_bin: str = SEAM_BIN,
+    check: bool = True,
+    capture_output: bool = False,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run one hal0-systemctl seam verb as root via ``sudo -n``.
+
+    THE single sudo helper for this seam:
+    :func:`hal0.agents.hermes_provision._privileged_systemctl` delegates here,
+    and :func:`agent_unit_argv` builds the identical ``sudo -n <bin> <verb>``
+    shape, so there is exactly one spelling of the sudo invocation.
+
+    ``-n`` is load-bearing: it makes sudo non-interactive, so a missing grant
+    fails immediately with a non-zero exit instead of prompting. That is the
+    whole point of routing a daemon/uninstall path through the seam rather
+    than letting bare ``systemctl`` escalate via polkit.
+
+    ``body`` (when given) is piped on stdin — used for ``write-gateway-dropin``.
+    With ``check=True`` a non-zero seam exit raises ``CalledProcessError`` so
+    the caller surfaces the failure instead of masquerading it as success.
+    """
+    return subprocess.run(  # nosec B603 — fixed argv; every arg re-validated by the seam
+        ["sudo", "-n", seam_bin, verb, *args],
+        input=body,
+        text=True,
+        check=check,
+        capture_output=capture_output,
+        timeout=timeout,
+    )
+
+
+def agent_unit_argv(
+    verb: str,
+    agent_id: str,
+    *,
+    seam_bin: str = SEAM_BIN,
+    euid: int | None = None,
+) -> list[str]:
+    """Build the argv for ``systemctl <verb> hal0-agent@<agent_id>.service``.
+
+    A **pure** function — it decides privilege routing and returns argv; it
+    never spawns anything. The caller executes it through its own injected
+    runner (``HermesDriver._runner``), which is what keeps that injection point
+    — and the test fakes hanging off it — intact.
+
+    Gating is on **euid**, deliberately NOT on :func:`is_hal0_service_user`
+    like :class:`SystemCtlSeam`. That gate's "pass through directly when not
+    the hal0 user" default is safe for the slot ops (file writes into a
+    test-owned tmp tree) but is precisely the polkit defect here: a human
+    admin running ``hal0 agent uninstall hermes`` is not the hal0 user
+    either, and a direct ``systemctl stop`` from their unprivileged euid
+    escalates into a password dialog. So:
+
+    * euid 0 — plain ``systemctl <verb> <unit>``. Root needs no seam, and the
+      installer/uninstaller runs before/after the seam binary exists.
+    * anything else — ``sudo -n <seam_bin> <verb>-agent <id>``. ``-n`` makes
+      sudo non-interactive, so this can fail but can never prompt.
+
+    Raises :class:`ValueError` for an invalid ``agent_id`` and :class:`KeyError`
+    for a verb outside :data:`AGENT_UNIT_VERBS` — both caller bugs, surfaced
+    before anything is executed.
+    """
+    seam_verb = AGENT_UNIT_VERBS[verb]
+    unit = agent_unit_name(agent_id)  # validates client-side; seam re-validates
+    if (os.geteuid() if euid is None else euid) == 0:
+        return ["systemctl", verb, unit]
+    return ["sudo", "-n", seam_bin, seam_verb, agent_id]
 
 
 def _slot_id_from_unit(unit_name: str) -> str | None:
@@ -212,4 +321,14 @@ class SystemCtlSeam:
         )
 
 
-__all__ = ["SEAM_BIN", "Hal0SeamMissing", "SystemCtlSeam", "is_hal0_service_user"]
+__all__ = [
+    "AGENT_UNIT_PREFIX",
+    "AGENT_UNIT_VERBS",
+    "SEAM_BIN",
+    "Hal0SeamMissing",
+    "SystemCtlSeam",
+    "agent_unit_argv",
+    "agent_unit_name",
+    "is_hal0_service_user",
+    "privileged_systemctl",
+]

--- a/tests/agents/test_hermes_wrapper.py
+++ b/tests/agents/test_hermes_wrapper.py
@@ -21,6 +21,7 @@ upstream binary, no real wrapper-on-PATH dependency.
 from __future__ import annotations
 
 import json
+import os as _os
 import subprocess as _subprocess
 from pathlib import Path
 from typing import Any
@@ -29,12 +30,19 @@ import pytest
 
 from hal0.agents.hermes import HermesDriver
 from hal0.agents.manager import HermesUpstreamMissingError
+from hal0.system.seam import SEAM_BIN
 
 # ── Fake subprocess ──────────────────────────────────────────────────────────
 
 
 class _FakeCompleted:
-    returncode = 0
+    def __init__(self, returncode: int = 0, stderr: bytes | str = b"") -> None:
+        self.returncode = returncode
+        # Production runs ``capture_output=True`` WITHOUT ``text=True``, so
+        # stderr really is bytes there; default to bytes so the driver's
+        # classifier is exercised on the shape it actually sees.
+        self.stderr = stderr
+        self.stdout = b""
 
 
 class _FakeRunner:
@@ -42,9 +50,22 @@ class _FakeRunner:
     call so tests can assert on argv + env without spawning a real
     shell."""
 
-    def __init__(self, *, fail: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        returncode: int = 0,
+        stderr: bytes | str = b"",
+    ) -> None:
         self.calls: list[dict[str, Any]] = []
         self._fail = fail
+        self._returncode = returncode
+        self._stderr = stderr
+
+    @property
+    def argvs(self) -> list[list[str]]:
+        """Every recorded argv — the assertion surface for the seam tests."""
+        return [c["argv"] for c in self.calls]
 
     def run(
         self,
@@ -62,7 +83,7 @@ class _FakeRunner:
         self.calls.append({"argv": list(argv), "env": dict(env or {}), "check": check})
         if self._fail:
             raise RuntimeError("fake subprocess failure")
-        return _FakeCompleted()
+        return _FakeCompleted(self._returncode, self._stderr)
 
 
 # ── Fake prober ──────────────────────────────────────────────────────────────
@@ -625,3 +646,226 @@ def test_hal0_hermes_wrapper_defaults_home_when_unset(tmp_path: Path) -> None:
     )
     assert "HERMES_HOME=/var/lib/hal0/.hermes" in out.stdout
     assert "HERMES_HOME=/var/lib/hal0/agents/hermes" not in out.stdout
+
+
+# ── uninstall teardown: privilege seam + failure surfacing (#453) ────────────
+#
+# `_stop_services` had two defects beyond the test-isolation one #1357 fixed:
+#
+#   1. It ran a BARE `systemctl stop/disable hal0-agent@hermes.service`. An
+#      unprivileged systemctl on a system unit escalates via polkit — an
+#      interactive password dialog mid-uninstall, and a unit still running if
+#      the operator cancels it.
+#   2. Both calls sat in `contextlib.suppress` with the output captured and the
+#      return code discarded, so a denied escalation was indistinguishable from
+#      a clean stop — exactly the condition #453 added the method to prevent.
+#
+# The driver now builds its argv via `hal0.system.seam.agent_unit_argv` and
+# classifies the result.
+
+
+def _stop_argvs(runner: _FakeRunner) -> list[list[str]]:
+    """Just the teardown argvs (install() records env-file writes too)."""
+    return [a for a in runner.argvs if a and a[0] in {"sudo", "systemctl"}]
+
+
+@pytest.fixture
+def _unprivileged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo tests/agents/conftest.py's suite-wide ``euid == 0`` default.
+
+    That autouse fixture patches the real ``os.geteuid`` (via ``hp.os``) so the
+    whole hermes-provision suite takes the historical root-direct write path.
+    It is also why a euid-gated seam looks like root here — these tests are
+    specifically about the NON-root branch, so pin it explicitly.
+    """
+    monkeypatch.setattr(_os, "geteuid", lambda: 1000)
+
+
+def test_stop_services_routes_through_privilege_seam(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE regression: unprivileged teardown must go through ``sudo -n`` +
+    the hal0-systemctl seam, never a bare ``systemctl``.
+
+    Fails against the pre-fix driver, which emitted
+    ``["systemctl", "stop", "hal0-agent@hermes.service"]`` — the argv that
+    raises a polkit prompt on a developer's desktop.
+    """
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.uninstall()
+
+    assert _stop_argvs(runner) == [
+        ["sudo", "-n", SEAM_BIN, "stop-agent", "hermes"],
+        ["sudo", "-n", SEAM_BIN, "disable-agent", "hermes"],
+    ]
+    # Nothing bare, and no caller-supplied unit string: the seam builds the
+    # unit name itself from the validated id.
+    for argv in _stop_argvs(runner):
+        assert argv[0] != "systemctl"
+        assert "hal0-agent@hermes.service" not in argv
+
+
+def test_stop_services_runs_systemctl_directly_as_root(
+    driver: HermesDriver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root needs no seam — and the uninstaller may run when the seam binary
+    and its sudoers grant are already gone."""
+    monkeypatch.setattr(_os, "geteuid", lambda: 0)
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.uninstall()
+
+    assert _stop_argvs(runner) == [
+        ["systemctl", "stop", "hal0-agent@hermes.service"],
+        ["systemctl", "disable", "hal0-agent@hermes.service"],
+    ]
+
+
+def test_stop_services_stops_before_disabling(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Order matters: disabling a running unit leaves it running, and #453 is
+    about the agent not being live while we delete its files."""
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.uninstall()
+
+    verbs = [a[3] for a in _stop_argvs(runner)]
+    assert verbs == ["stop-agent", "disable-agent"]
+
+
+def test_stop_services_noop_without_systemctl(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Documented best-effort semantics: no systemd on the box (container,
+    dev shell) is not an error and costs no sudo round-trip."""
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: None)
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.uninstall()
+
+    assert _stop_argvs(runner) == []
+
+
+def test_stop_services_warns_when_escalation_is_denied(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE silent-failure regression.
+
+    A missing sudoers grant makes ``sudo -n`` exit 1 with "a password is
+    required". The old code swallowed that inside ``contextlib.suppress`` with
+    ``capture_output=True``, so the uninstall reported success while the agent
+    kept running and recreating the files being deleted. It must be logged.
+    """
+    from structlog.testing import capture_logs
+
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner(returncode=1, stderr=b"sudo: a password is required\n")
+    driver._runner = runner  # type: ignore[assignment]
+
+    with capture_logs() as logs:
+        driver.uninstall()
+
+    warnings = [e for e in logs if e["log_level"] == "warning"]
+    assert len(warnings) == 2, f"expected a warning per verb, got {logs!r}"
+    assert {w["verb"] for w in warnings} == {"stop", "disable"}
+    for w in warnings:
+        assert w["event"] == "hermes.stop_services_failed"
+        assert w["returncode"] == 1
+        assert "password is required" in w["stderr"]
+        assert "sudoers" in w["hint"]
+
+
+def test_stop_services_does_not_warn_when_unit_is_absent(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """...but a MISSING unit stays a non-event. Best-effort must not become
+    alarm fatigue: an agent that was never started has no unit to stop, and
+    ``systemctl stop`` exits 5 for it."""
+    from structlog.testing import capture_logs
+
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner(
+        returncode=5, stderr=b"Failed to stop hal0-agent@hermes.service: Unit not loaded.\n"
+    )
+    driver._runner = runner  # type: ignore[assignment]
+
+    with capture_logs() as logs:
+        driver.uninstall()
+
+    assert [e for e in logs if e["log_level"] == "warning"] == []
+
+
+def test_stop_services_does_not_warn_when_unit_not_found_rc1(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``disable`` on a nonexistent unit exits 1, not 5 — so exit code alone is
+    ambiguous with a denied escalation. Classification falls back to stderr."""
+    from structlog.testing import capture_logs
+
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+    runner = _FakeRunner(
+        returncode=1, stderr=b"Unit file hal0-agent@hermes.service does not exist.\n"
+    )
+    driver._runner = runner  # type: ignore[assignment]
+
+    with capture_logs() as logs:
+        driver.uninstall()
+
+    assert [e for e in logs if e["log_level"] == "warning"] == []
+
+
+def test_stop_services_warns_but_does_not_raise_on_oserror(
+    driver: HermesDriver, _unprivileged: None, tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A timeout or a vanished sudo binary is surfaced, and the uninstall still
+    completes — teardown must never be blocked by systemd bookkeeping."""
+    from structlog.testing import capture_logs
+
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+
+    def _boom(argv: list[str], **_kw: Any) -> Any:
+        raise OSError("sudo vanished")
+
+    runner = _FakeRunner()
+    monkeypatch.setattr(runner, "run", _boom)
+    driver._runner = runner  # type: ignore[assignment]
+    env_file = Path(tmp_hal0_home) / "etc" / "hal0" / "agents" / "hermes.env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text("x=1", encoding="utf-8")
+
+    with capture_logs() as logs:
+        driver.uninstall()  # must not raise
+
+    warnings = [e for e in logs if e["log_level"] == "warning"]
+    assert len(warnings) == 2
+    assert all("sudo vanished" in w["error"] for w in warnings)
+    # Best-effort really is best-effort: the teardown still happened.
+    assert not env_file.exists()
+
+
+def test_stop_services_uses_the_drivers_injected_runner(
+    driver: HermesDriver, _unprivileged: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1357's contract, kept: routing through the seam must not reintroduce a
+    module-global ``subprocess`` call that bypasses the injection point."""
+    monkeypatch.setattr("hal0.agents.hermes.driver.shutil.which", lambda _n: "/usr/bin/systemctl")
+
+    def _explode(*_a: Any, **_kw: Any) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("_stop_services bypassed the injected runner")
+
+    monkeypatch.setattr("hal0.agents.hermes.driver.subprocess.run", _explode)
+    runner = _FakeRunner()
+    driver._runner = runner  # type: ignore[assignment]
+
+    driver.uninstall()
+
+    assert len(_stop_argvs(runner)) == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,30 @@ _SYSTEMCTL_MUTATING_VERBS = frozenset(
 )
 
 
+# The privilege seam (installer/wrappers/hal0-systemctl, reached as
+# `sudo -n /usr/lib/hal0/bin/hal0-systemctl <verb> <id>`) is the SUPPORTED way
+# to reach a mutating verb off root — so the production code the guard below
+# protects against now legitimately spells its argv as `sudo ...` rather than
+# `systemctl ...`. From a test that is still a real escalation attempt against
+# the real host, just one indirection further out, so it must be rejected on
+# exactly the same terms. Unwrap `sudo [-n|-u X|...] <bin> ...` and judge the
+# wrapped command instead of stopping at argv[0].
+_SUDO_NAMES = frozenset({"sudo", "doas", "pkexec"})
+_SEAM_BIN_NAMES = frozenset({"hal0-systemctl"})
+
+
+def _strip_sudo(parts: list[str]) -> list[str]:
+    """Drop a leading ``sudo``/``doas``/``pkexec`` and its option words."""
+    if not parts or Path(parts[0]).name not in _SUDO_NAMES:
+        return parts
+    rest = parts[1:]
+    while rest and rest[0].startswith("-"):
+        # -u/--user take a value; the flags hal0 actually uses (-n) do not.
+        takes_value = rest[0] in {"-u", "--user", "-g", "--group"}
+        rest = rest[2:] if takes_value and len(rest) > 1 else rest[1:]
+    return rest
+
+
 def _reject_privileged_systemctl(argv: object) -> None:
     """Raise if ``argv`` is a systemctl invocation that would need polkit.
 
@@ -71,6 +95,11 @@ def _reject_privileged_systemctl(argv: object) -> None:
     point. Anything that mutates units must go through an injected fake;
     reaching the real system bus from a test is always a bug in the test
     (a missing mock), never intended behavior.
+
+    Covers three shapes, all equivalent in effect:
+      * ``systemctl stop <unit>``                     — bare escalation.
+      * ``sudo -n .../hal0-systemctl stop-agent <id>`` — via the privilege seam.
+      * ``sudo systemctl stop <unit>``                 — sudo'd bare systemctl.
     """
     if isinstance(argv, str):
         parts = argv.split()
@@ -78,9 +107,31 @@ def _reject_privileged_systemctl(argv: object) -> None:
         parts = [str(a) for a in argv]
     else:
         return
-    if not parts or Path(parts[0]).name != "systemctl":
+    if not parts:
         return
-    verbs = [p for p in parts[1:] if not p.startswith("-")]
+
+    inner = _strip_sudo(parts)
+    if not inner:
+        return
+    program = Path(inner[0]).name
+
+    if program in _SEAM_BIN_NAMES:
+        # Seam verbs are `<systemctl-verb>` (slot family) or
+        # `<systemctl-verb>-agent` (agent family); both mutate. The
+        # non-systemctl file verbs (write-unit, write-quadlet, ...) mutate
+        # /etc as root, which a test must never do either.
+        seam_verb = next((p for p in inner[1:] if not p.startswith("-")), "")
+        if seam_verb and seam_verb not in {"help", ""}:
+            raise AssertionError(
+                f"test tried to run the hal0-systemctl privilege seam for real: {parts!r}. "
+                "Inject a fake runner (or patch hal0.system.seam.agent_unit_argv) instead — "
+                "this shells out to sudo on a developer machine."
+            )
+        return
+
+    if program != "systemctl":
+        return
+    verbs = [p for p in inner[1:] if not p.startswith("-")]
     if verbs and verbs[0] in _SYSTEMCTL_MUTATING_VERBS:
         raise AssertionError(
             f"test tried to run privileged systemctl against the real system bus: {parts!r}. "

--- a/tests/system/test_seam_agent_units.py
+++ b/tests/system/test_seam_agent_units.py
@@ -1,0 +1,308 @@
+"""Agent-unit verbs on the hal0-systemctl privilege seam (#453 follow-up).
+
+``HermesDriver._stop_services`` used to run a BARE ``systemctl stop/disable
+hal0-agent@hermes.service``. Unprivileged systemctl on a system unit escalates
+via polkit — an interactive password dialog in the middle of an uninstall, and
+(when cancelled) a unit that is never actually stopped, which is exactly the
+condition #453 added ``_stop_services`` to prevent. The seam was slot-only
+(``UNIT_PREFIX="hal0-slot@"``, every verb calling ``validate_slot_id``), so the
+driver had nothing to call.
+
+Two halves are covered here:
+
+* the **Python** side (:func:`hal0.system.seam.agent_unit_name` /
+  :func:`~hal0.system.seam.agent_unit_argv`) — validation and privilege routing;
+* the **shell** side (``installer/wrappers/hal0-systemctl``) — the actual
+  security boundary, exercised by running the real script with a FAKE
+  ``systemctl`` first on ``PATH``. Nothing here reaches live systemd: the
+  wrapper's happy path execs the fake, and every rejection case dies in the
+  validator before any exec.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hal0.system import seam as seam_mod
+from hal0.system.seam import SEAM_BIN
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER = REPO_ROOT / "installer" / "wrappers" / "hal0-systemctl"
+
+# Inputs the seam must refuse. Each one is a way to smuggle a second unit name,
+# a path, an extra systemd instance spec, or shell metacharacters through what
+# is supposed to be a bare identifier.
+BAD_AGENT_IDS = [
+    "",
+    "hermes evil",
+    "hermes.service",
+    "../etc/passwd",
+    "/etc/passwd",
+    "hal0-slot@x",
+    "hermes;reboot",
+    "hermes\nreboot",
+    "her mes",
+    "hermes@x",
+    "$(id)",
+    "`id`",
+    "*",
+    "hermes.service hal0-api.service",
+    "a" * 65,
+]
+
+
+# ── Python side: validation ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", BAD_AGENT_IDS)
+def test_agent_unit_name_rejects_malformed_id(bad: str) -> None:
+    """A malformed agent id never becomes a unit name."""
+    with pytest.raises(ValueError, match="bad agent id"):
+        seam_mod.agent_unit_name(bad)
+
+
+@pytest.mark.parametrize("bad", BAD_AGENT_IDS)
+def test_agent_unit_argv_rejects_malformed_id(bad: str) -> None:
+    """...and never becomes an argv either — validation happens before routing,
+    so a bad id cannot reach ``sudo`` even to be rejected server-side."""
+    with pytest.raises(ValueError, match="bad agent id"):
+        seam_mod.agent_unit_argv("stop", bad, euid=1000)
+
+
+@pytest.mark.parametrize("good", ["hermes", "a", "my_agent-2", "A" * 64])
+def test_agent_unit_name_builds_expected_unit(good: str) -> None:
+    assert seam_mod.agent_unit_name(good) == f"hal0-agent@{good}.service"
+
+
+def test_agent_unit_argv_rejects_unknown_verb() -> None:
+    """Only stop/disable exist. A typo is a caller bug, caught before exec."""
+    with pytest.raises(KeyError):
+        seam_mod.agent_unit_argv("restart", "hermes", euid=1000)
+
+
+# ── Python side: privilege routing ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("verb", "seam_verb"),
+    [("stop", "stop-agent"), ("disable", "disable-agent")],
+)
+def test_unprivileged_routes_through_sudo_seam(verb: str, seam_verb: str) -> None:
+    """THE regression. Off root the argv must be the ``sudo -n`` seam call —
+    never a bare ``systemctl``, which is what escalates via polkit.
+
+    Note the seam receives the bare id, not a unit string: the wrapper builds
+    ``hal0-agent@<id>.service`` itself on the root side.
+    """
+    argv = seam_mod.agent_unit_argv(verb, "hermes", euid=1000)
+
+    assert argv == ["sudo", "-n", SEAM_BIN, seam_verb, "hermes"]
+    assert argv[0] != "systemctl"
+    assert "hal0-agent@hermes.service" not in argv
+    # -n is load-bearing: it is what makes sudo non-interactive.
+    assert "-n" in argv
+
+
+@pytest.mark.parametrize(
+    ("verb", "seam_verb"),
+    [("stop", "stop-agent"), ("disable", "disable-agent")],
+)
+def test_root_runs_systemctl_directly(verb: str, seam_verb: str) -> None:
+    """Root needs no seam — and the installer/uninstaller runs at moments when
+    the seam binary and its sudoers grant may not exist yet."""
+    argv = seam_mod.agent_unit_argv(verb, "hermes", euid=0)
+
+    assert argv == ["systemctl", verb, "hal0-agent@hermes.service"]
+    assert "sudo" not in argv
+
+
+def test_agent_unit_argv_defaults_to_real_euid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``euid=None`` (the production call) reads the live euid."""
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    assert seam_mod.agent_unit_argv("stop", "hermes")[0] == "sudo"
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    assert seam_mod.agent_unit_argv("stop", "hermes")[0] == "systemctl"
+
+
+def test_seam_bin_is_overridable_but_defaults_to_installed_path() -> None:
+    argv = seam_mod.agent_unit_argv("stop", "hermes", seam_bin="/tmp/x", euid=1000)
+    assert argv[2] == "/tmp/x"
+    assert SEAM_BIN == "/usr/lib/hal0/bin/hal0-systemctl"
+
+
+# ── Shell side: the actual security boundary ─────────────────────────────────
+
+
+@pytest.fixture
+def fake_systemctl(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    """A ``systemctl`` that records its argv instead of talking to systemd.
+
+    Placed FIRST on ``PATH`` so the wrapper's ``exec systemctl ...`` can never
+    reach the real binary from a test run.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "systemctl.log"
+    shim = bindir / "systemctl"
+    shim.write_text(f'#!/bin/sh\nprintf "%s\\n" "$*" >> {log}\nexit 0\n')
+    shim.chmod(0o755)
+    env = {**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"}
+    return env, log
+
+
+def _run_wrapper(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(WRAPPER), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+
+def test_wrapper_is_syntactically_valid() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr
+
+
+@pytest.mark.parametrize("bad", BAD_AGENT_IDS)
+def test_wrapper_rejects_malformed_agent_id(
+    bad: str, fake_systemctl: tuple[dict[str, str], Path]
+) -> None:
+    """The seam re-validates server-side — client-side validation is a
+    convenience, this is the boundary. Rejection must happen BEFORE any exec,
+    so the fake systemctl must record nothing."""
+    env, log = fake_systemctl
+
+    proc = _run_wrapper(env, "stop-agent", bad)
+
+    assert proc.returncode == 64, proc.stderr
+    assert "agent id" in proc.stderr
+    assert not log.exists(), f"wrapper exec'd systemctl for a rejected id: {bad!r}"
+
+
+@pytest.mark.parametrize(
+    ("cmd", "expected"),
+    [
+        ("stop-agent", "stop hal0-agent@hermes.service"),
+        ("disable-agent", "disable hal0-agent@hermes.service"),
+    ],
+)
+def test_wrapper_builds_the_unit_name_itself(
+    cmd: str, expected: str, fake_systemctl: tuple[dict[str, str], Path]
+) -> None:
+    """The caller passes a bare id; the seam concatenates the prefix + suffix."""
+    env, log = fake_systemctl
+
+    proc = _run_wrapper(env, cmd, "hermes")
+
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().strip() == expected
+
+
+def test_wrapper_agent_verbs_cannot_reach_a_slot_unit(
+    fake_systemctl: tuple[dict[str, str], Path],
+) -> None:
+    """The two id namespaces stay separate: an agent verb always produces a
+    ``hal0-agent@`` unit, never a ``hal0-slot@`` one, whatever the id says."""
+    env, log = fake_systemctl
+
+    proc = _run_wrapper(env, "stop-agent", "slot")
+
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().strip() == "stop hal0-agent@slot.service"
+
+
+def test_wrapper_rejects_unknown_agent_verb(
+    fake_systemctl: tuple[dict[str, str], Path],
+) -> None:
+    """The verb allow-list is the case statement; nothing else gets through."""
+    env, log = fake_systemctl
+
+    for verb in ("restart-agent", "enable-agent", "mask-agent", "start-agent"):
+        proc = _run_wrapper(env, verb, "hermes")
+        assert proc.returncode == 64, f"{verb} should not exist: {proc.stderr}"
+        assert "bad cmd" in proc.stderr
+    assert not log.exists()
+
+
+def test_wrapper_usage_documents_the_agent_verbs() -> None:
+    proc = subprocess.run(
+        ["bash", str(WRAPPER), "help"], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "stop-agent <agent-id>" in proc.stdout
+    assert "disable-agent <agent-id>" in proc.stdout
+    assert "hal0-agent@<id>.service" in proc.stdout
+
+
+def test_wrapper_and_python_validators_agree() -> None:
+    """The two validators are copies; keep them provably in sync.
+
+    A drift here is a real hazard: a Python side laxer than the shell side
+    means confusing runtime failures, and a Python side STRICTER than the
+    shell side would hide the fact that the shell is the boundary.
+    """
+    shell_re = None
+    for line in WRAPPER.read_text().splitlines():
+        if "bad agent id" in line and "=~" in line:
+            shell_re = line.split("=~")[1].split("]]")[0].strip()
+            break
+    assert shell_re == "^[A-Za-z0-9_-]{1,64}$", f"wrapper regex changed: {shell_re!r}"
+    assert seam_mod._AGENT_ID_RE.pattern == shell_re
+
+
+# ── The test-isolation guard must cover the seam form too ────────────────────
+#
+# tests/conftest.py's `_no_real_systemctl` (added by #1357) matched on
+# argv[0] == "systemctl". Routing teardown through the seam changes the argv a
+# leaking test would emit to `sudo -n .../hal0-systemctl stop-agent hermes` —
+# still a real escalation against the real host, just one indirection out.
+# Without this coverage the seam fix would have quietly re-opened the hole the
+# guard was built to close.
+
+
+def _reject(argv: object) -> None:
+    from tests.conftest import _reject_privileged_systemctl
+
+    _reject_privileged_systemctl(argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["systemctl", "stop", "hal0-agent@hermes.service"],
+        ["sudo", "-n", SEAM_BIN, "stop-agent", "hermes"],
+        ["sudo", "-n", SEAM_BIN, "disable-agent", "hermes"],
+        ["sudo", "-n", SEAM_BIN, "write-unit", "slot"],
+        ["sudo", "systemctl", "restart", "hal0-api.service"],
+        ["sudo", "-u", "hal0", "systemctl", "stop", "x.service"],
+        "sudo -n /usr/lib/hal0/bin/hal0-systemctl stop-agent hermes",
+    ],
+)
+def test_guard_rejects_every_escalation_shape(argv: object) -> None:
+    with pytest.raises(AssertionError, match=r"privilege seam|real system bus"):
+        _reject(argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["systemctl", "is-active", "hal0-agent@hermes.service"],
+        ["systemctl", "show", "-p", "MainPID", "--value", "hal0-api.service"],
+        ["journalctl", "-u", "hal0-api", "-n", "50"],
+        ["sudo", "-n", SEAM_BIN, "help"],
+        ["bash", "installer/wrappers/hal0-systemctl", "help"],
+        ["echo", "stop"],
+        None,
+    ],
+)
+def test_guard_allows_read_only_and_non_systemd(argv: object) -> None:
+    """Read-only verbs need no authorization and several probes legitimately
+    use them — #1357 deliberately left them alone. Keep it that way."""
+    _reject(argv)


### PR DESCRIPTION
Fixes an interactive polkit password prompt during agent uninstall — **reproduced live today**, repeatedly, on a maintainer desktop.

## The defect

`HermesDriver._stop_services()` ran bare `systemctl stop` / `disable` on `hal0-agent@hermes.service` with no `sudo -n` and no privilege seam. Unprivileged `systemctl` on a system unit escalates via polkit → password dialog.

hal0 *has* a seam for this (`installer/wrappers/hal0-systemctl` via `_privileged_systemctl`), but it was **slot-only**: `UNIT_PREFIX="hal0-slot@"` and every verb calls `validate_slot_id`. No verb could act on a `hal0-agent@<id>` unit, so the driver had nothing to call and went direct.

Both calls also sat inside `contextlib.suppress` with the return code discarded — so a cancelled prompt was swallowed silently and the unit was never stopped, exactly the condition #453 added `_stop_services()` to prevent.

## Relationship to #1357

`610150d7` fixed the **test-side half only**: `_stop_services` became an instance method through `self._runner`, and `tests/conftest.py` gained an autouse `_no_real_systemctl` guard. Production still called bare `systemctl`. This PR closes the production half and is rebased on top of it.

**Gap closed in that guard:** it matched `argv[0] == "systemctl"`. A leaking test now emits `sudo -n …/hal0-systemctl stop-agent hermes` — still a real escalation, one indirection out — which would have slipped through. Extended the *same* function (not a competing guard) to unwrap `sudo`/`doas`/`pkexec` and to reject seam verbs directly.

## Seam verbs

`stop-agent <id>` / `disable-agent <id>` → `hal0-agent@<id>.service`. Dedicated `validate_agent_id` mirroring `validate_slot_id` (`^[A-Za-z0-9_-]{1,64}$`), a separate prefix constant so the two id namespaces cannot cross, and the systemctl verb is a **literal per case arm** (not `"$cmd"` as the slot family does) so the agent surface cannot grow a verb accidentally. Sudoers grant unchanged — it is pinned to the binary, so the case statement is the allow-list.

Rejected by the validator, each `rc=64`, with nothing reaching exec: `hermes evil`, `hermes.service`, `../etc/passwd`, `hermes;reboot`, `$(id)`, `*`, `hal0-slot@x`, 65 chars.

**Asymmetric on purpose:** only stop/disable. Adding `enable`/`start` would hand the unprivileged `hal0` user a persistence primitive; stop/disable only ever reduces what is running.

## Helper placement

`src/hal0/system/seam.py` — already the canonical module for this seam, stdlib-only, no cycle. Importing `hermes_provision` (5k lines, same package as the driver) would invert driver→provisioner layering. `agent_unit_argv()` is a pure argv builder executed via `self._runner`, preserving #1357s injection point. Gating is on **euid**, deliberately not `is_hal0_service_user()` — that gates "pass through when not the hal0 user" default *is* the polkit defect, since a human admin is not the hal0 user either.

Silent-failure fix: rc 5 or a "does not exist" stderr → debug; anything else → warning with rc, stderr, and remedy. Never raises; uninstall always proceeds.

## Which tests were reaching live systemd

Proven with a fake `systemctl` first on PATH plus a plugin tagging each call with its nodeid:

**Mutating (the incident):** 12 tests in `tests/agents/test_hermes_wrapper.py` × 2 calls = **24 real `systemctl stop`/`disable hal0-agent@hermes.service`**, even under `-m "not podman and not systemd and not network"`. After: **zero**.

**Read-only, left alone:** `tests/cli/test_doctor_bundle.py` and one `test_doctor.py` case (`list-units`, `journalctl`, `show -p MainPID`) need no authorization and #1357 deliberately permits them.

**⚠️ Second bug flagged, not changed:** `tests/agents/conftest.py::_euid_root_by_default` patches `hp.os.geteuid` **globally**, telling the entire `tests/agents` suite it is root. Combined with any euid-gated seam that converts every seam into a direct privileged host call. It is deliberate (the provisioners env writers need it), so it is left as-is, but new tests pin euid explicitly and the hazard is documented.

## Task-4 sites, judged individually and NOT converted

`agent_commands.py:553` and `:694` are reachable **only** from `hal0 agent install hermes` (verified: no API/daemon caller) and already surface a non-zero rc. A foreground command a human runs on the host can answer a prompt. `:694`s target is neither a `hal0-agent@` nor `hal0-slot@` instance, so no seam verb reaches it. Reasoning recorded in-code.

## Verification

- Driver reverted to `610150d7` → 4 new tests fail, incl. `At index 0 diff: ["systemctl","stop","hal0-agent@hermes.service"] != ["sudo","-n","/usr/lib/hal0/bin/hal0-systemctl","stop-agent","hermes"]`
- Wrapper reverted → **20 failed** in `tests/system/test_seam_agent_units.py`
- Full suite `-m "not podman and not systemd and not network"` → **7568 passed, 13 skipped, 4 deselected, 1 xfailed**
- `bash -n`, ruff check, ruff format (985 files), sunset (195 ≤ 195), import smoke — all clean

## Not provable off-box

That `sudo -n /usr/lib/hal0/bin/hal0-systemctl stop-agent hermes` succeeds against the real sudoers grant (argv shape asserted, end-to-end escalation not), and the exact rc/stderr real systemd returns for an absent unit (classifier unit-tested against documented shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)