### PR TITLE
fix(ui): Clear override actually removes a persisted chat_template (#1372)

### DIFF
--- a/tests/api/test_slot_config_validation.py
+++ b/tests/api/test_slot_config_validation.py
@@ -83,6 +83,38 @@ def test_put_config_valid_keys_and_dynamic_server_fields_pass(
     assert on_disk["server"]["env"] == {"HSA_XNACK": "1"}
 
 
+def test_put_config_null_deletes_chat_template(slot_toml: Path, client: TestClient) -> None:
+    """``chat_template: null`` REMOVES a persisted per-slot override (#1372).
+
+    The drawer's "Clear override" needs a wire value that actually unsets the
+    key. ``reconcile_slot_updates`` implements None-means-delete, so ``null``
+    drops it from the TOML entirely — whereas ``""`` (see the companion test
+    below) persists an empty-string override, which is a different thing and
+    would still emit ``--chat-template ''`` on the launch line.
+    """
+    r = client.put("/api/slots/chat/config", json={"chat_template": "chatml"})
+    assert r.status_code == 200, r.text
+    assert _read(slot_toml)["chat_template"] == "chatml"
+
+    r = client.put("/api/slots/chat/config", json={"chat_template": None})
+    assert r.status_code == 200, r.text
+    on_disk = _read(slot_toml)
+    assert "chat_template" not in on_disk
+    # Siblings survive the removal — it is a targeted delete, not a rewrite.
+    assert on_disk["model"]["default"] == "qwen3-4b"
+    assert on_disk["port"] == 8081
+
+
+def test_put_config_empty_string_chat_template_is_not_a_removal(
+    slot_toml: Path, client: TestClient
+) -> None:
+    """``""`` persists an empty override — the reason #1372 clears with null."""
+    client.put("/api/slots/chat/config", json={"chat_template": "chatml"})
+    r = client.put("/api/slots/chat/config", json={"chat_template": ""})
+    assert r.status_code == 200, r.text
+    assert _read(slot_toml)["chat_template"] == ""
+
+
 def test_put_config_tolerated_extras_pass(slot_toml: Path, client: TestClient) -> None:
     """default_voice (voice settings) and string image override keep working."""
     r = client.put("/api/slots/chat/config", json={"default_voice": "Ryan"})

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -399,9 +399,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 			return;
 		}
 		setFieldErrs({});
-		// Task 5: include chat_template only when the user has set/changed an override.
-		const chatTemplateChanged =
-			overrideOpen && chatTemplate !== (slot.chat_template || "");
+		// Task 5 / #1372: include chat_template whenever the effective override
+		// changed — a SET, a CHANGE, or a REMOVAL. Shares `chatTemplateDirty`
+		// with the unsaved-changes guard so the two can never disagree again.
+		const chatTemplateChanged = chatTemplateDirty;
 		// Per-slot extra_args override — ship only when changed, nested under
 		// [server] so the backend one-level merge preserves sibling server keys.
 		const extraArgsChanged = extraArgs !== extraArgsBaseline;
@@ -438,7 +439,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
 			if (binaryChanged) slotBody.binary = binary;
 			if (imagePinChanged) slotBody.image_pin = pinValue;
 			if (chatTemplateChanged) {
-				slotBody.chat_template = chatTemplate;
+				// null clears the override outright; a string pins it.
+				slotBody.chat_template = effectiveChatTemplate;
 			}
 			if (extraArgsChanged) {
 				slotBody.server = { extra_args: extraArgs };
@@ -593,6 +595,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	const parRawNow = String(parallel).trim();
 	const parValueNow = parRawNow === "" ? null : Number(parRawNow);
 	const parallelDirty = parValueNow !== (slot.parallel ?? null);
+	// #1372: the EFFECTIVE per-slot chat-template override. Collapsed to a
+	// single source of truth because the dirty check and the save body used to
+	// carry their own copy of this predicate, and both gated on `overrideOpen`
+	// — which "Clear override" itself sets to false before either one runs, so
+	// removing a persisted override silently wrote nothing.
+	//
+	// null (never "") is the removal value: `reconcile_slot_updates` implements
+	// None-means-delete, so null drops the key from the slot TOML, whereas ""
+	// would persist an empty-string override (a different, still-wrong state).
+	// Covered by tests/api/test_slot_config_validation.py.
+	const effectiveChatTemplate = overrideOpen ? chatTemplate || null : null;
+	const chatTemplateDirty =
+		effectiveChatTemplate !== (slot.chat_template || null);
 	const dirty =
 		extraArgsDirty ||
 		ctxDirty ||
@@ -602,7 +617,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		binaryDirty ||
 		imagePinDirty ||
 		parallelDirty ||
-		(overrideOpen && chatTemplate !== (slot.chat_template || ""));
+		chatTemplateDirty;
 	const requestClose = () => {
 		if (dirty) {
 			setDiscardOpen(true);

--- a/ui/tests/e2e/specs/slot-drawer-field-wiring-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-field-wiring-v3.spec.ts
@@ -233,15 +233,16 @@ test.describe('Slot drawer — parallel wiring', () => {
 
 test.describe('Slot drawer — chat-template override wiring', () => {
   // Setting/changing an override is covered by slot-drawer-profile-v3 C7k.
-  // REMOVING one is not — and today it silently does nothing (#1372): the
-  // drawer gates both the dirty check and the save body on `overrideOpen`,
-  // which "Clear override" has just flipped to false, so the persisted
-  // template survives while the UI claims the model default is in effect.
+  // REMOVING one used to silently do nothing (#1372): both the dirty check and
+  // the save body were gated on `overrideOpen`, which "Clear override" has
+  // itself just flipped to false, so the persisted template survived while the
+  // UI claimed the model default was back in effect.
   //
-  // Annotated test.fail() so the suite stays green on the known bug and trips
-  // (unexpected pass) the moment #1372 lands — drop the annotation then.
-  test.fail(true, 'known bug — see #1372')
-  test('W7 — Clear override writes the removal to /config', async ({ page }) => {
+  // The removal must ride as `null`, NOT `""`: `reconcile_slot_updates`
+  // implements None-means-delete, so `null` drops the key from the slot TOML
+  // while `""` would persist an empty-string override (asserted backend-side in
+  // tests/api/test_slot_config_validation.py).
+  test('W7 — Clear override writes chat_template: null to /config', async ({ page }) => {
     const puts = await captureConfig(page, 'primary')
     await page.route('**/api/chat-templates', (route) =>
       route.fulfill({
@@ -264,9 +265,36 @@ test.describe('Slot drawer — chat-template override wiring', () => {
     await page.locator('.drawer button:has-text("Save")').click()
 
     await expect.poll(() => puts.length).toBe(1)
-    // Empty-string vs null is the open contract question in #1372; either is a
-    // removal, both beat sending nothing at all.
-    expect(puts[0].chat_template ?? '').toBe('')
+    expect(puts[0]).toHaveProperty('chat_template', null)
+  })
+
+  test('W7 — Clear override then reopening the override is not a phantom write', async ({ page }) => {
+    // Guard the inverse: clearing and re-picking the SAME template the slot
+    // already had must collapse back to "nothing changed".
+    const puts = await captureConfig(page, 'primary')
+    await page.route('**/api/chat-templates', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 'auto', label: 'Auto (GGUF embedded)' },
+          { id: 'chatml', label: 'ChatML' },
+        ]),
+      }),
+    )
+    await seedSlots(page, [{ ...PRIMARY, chat_template: 'chatml' }, EMBED])
+
+    await page.goto('/#slots/primary')
+    const row = page
+      .locator('.drawer .form-row')
+      .filter({ has: page.locator('.form-lbl > span', { hasText: /^Template$/ }) })
+    await row.getByRole('button', { name: 'Clear override' }).click()
+    await row.getByRole('button', { name: 'Override' }).click()
+    await row.locator('select').selectOption('chatml')
+    await page.locator('.drawer button:has-text("Save")').click()
+
+    await expect(page.locator('.drawer')).toHaveCount(0)
+    expect(puts).toEqual([])
   })
 })
 


### PR DESCRIPTION
Closes #1372.

> **Stacked on #1373** (`test/field-wiring-specs`) — W7 in that PR is this one's RED. Based against `test/field-wiring-specs` so the diff stays clean; GitHub retargets to `main` when #1373 merges. Review the 3-file diff, not the base.

## The bug

The slot drawer's Template row offers **[Override]** to pin a per-slot `chat_template` and **[Clear override]** to drop it. Clearing did nothing: Save issued **no request at all**, the override stayed on disk and kept feeding `llama-server`, and the drawer went on rendering the model default as though the removal had taken. It wasn't counted as an unsaved change either, so the discard guard stayed silent. There was no other way to remove a per-slot override from the dashboard.

Both the save body and the dirty aggregate gated on `overrideOpen`:

```js
const chatTemplateChanged =
  overrideOpen && chatTemplate !== (slot.chat_template || "");
```

**Clear override** sets `overrideOpen = false` *before* either predicate runs, so both evaluate false and the clear is unobservable.

## The fix

Collapse the two duplicated predicates into one `chatTemplateDirty`, derived from a single `effectiveChatTemplate` (`null` when the override is closed, otherwise the picked template). Save and the dirty guard now read the same value and cannot drift apart again — duplication is exactly how they diverged.

## Wire value: `null`, not `""`

`reconcile_slot_updates` implements None-means-delete. Probed at the route level:

| body | result on disk |
|---|---|
| `{"chat_template": null}` | **key removed** ✅ |
| `{"chat_template": ""}` | `chat_template = ""` ❌ empty-string override |

`""` would swap one bug for a subtler one — the slot would still emit an empty `--chat-template`. No test covered None-deletion of *any* slot key before, so `tests/api/test_slot_config_validation.py` gains two:

- `null` removes the key **and leaves siblings intact** (`[model].default`, `port`) — it's a targeted delete, not a rewrite
- `""` is explicitly **not** a removal, pinning the reason `null` is the wire value

## Red-first evidence

W7 dropped its `test.fail()` annotation and tightened from "either `null` or empty" to `null` exactly. With the fix not yet applied:

```
W7 CAPTURED PUTS: []
  1 failed
    W7 — Clear override writes chat_template: null to /config
```

Zero PUTs against an expected one. After the fix:

```
  2 passed
```

A second W7 case guards the inverse — clear, re-open, re-pick the *same* template ⇒ collapse back to no write at all — so the fix can't overshoot into phantom writes.

## Verification

```
npx playwright test slot-drawer-field-wiring-v3 slot-drawer-profile-v3 slot-edit-controls-v3 \
  model-drawer model-recipe-template-v3 model-edit-identity-v3 slots-v3 slots-wireup-v3 slot-pin-toggle-v3
  63 passed (32.6s)

pytest tests/api/test_slot_config_validation.py
  13 passed

npm run lint
  clean
```

The regression set includes `slot-drawer-profile-v3` C7k (the *set* path for the same field) and `slot-pin-toggle-v3` (#1368, which touches this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)