### PR TITLE
fix(profiles): strip authority-owned flags from default profiles and sanitize persisted ones

### DIFF
--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -127,21 +127,24 @@ def list_profiles() -> list[dict[str, Any]]:
 
 
 def _screen_profile_flags(flags: str | None) -> None:
-    """Reject grid-owned hardware flags in a profile's freeform ``flags`` text.
+    """Reject hal0-owned flags in a profile's freeform ``flags`` text.
 
     spec-hw-slot-ownership §5: a profile is a device-agnostic tune template, so
     its ``flags`` must not carry the slot-hardware flags (``-ngl``/``--device``/
-    ``--threads``). Symmetric to the model ``defaults.extra_args`` guard in
+    ``--threads``). §21.7: nor the managed args hal0 computes per-slot
+    (``--model``/``--host``/``--port``/``--ctx-size``/``--alias``) — a profile
+    that persists ``-c``/``--port`` only explodes later when stamped onto a
+    model. Symmetric to the model ``defaults.extra_args`` guard in
     :func:`hal0.services.models_service.screen_model_write`; raises the same
-    ``slot.hardware_flag_denied`` BadRequest so both surfaces render one path.
-    Empty / unset flags are a no-op; an unparseable flag string is left to the
-    ProfileConfig schema to reject.
+    ``slot.hardware_flag_denied`` / ``slot.managed_arg_denied`` BadRequests so
+    both surfaces render one path. Empty / unset flags are a no-op; an
+    unparseable flag string is left to the ProfileConfig schema to reject.
     """
     if not flags or not flags.strip():
         return
     import shlex
 
-    from hal0.slots.argv import _deny_slot_hardware_flags
+    from hal0.slots.argv import _deny_managed_flags, _deny_slot_hardware_flags
 
     try:
         tokens = shlex.split(flags)
@@ -149,7 +152,10 @@ def _screen_profile_flags(flags: str | None) -> None:
         # Malformed quoting — defer to the pydantic/config layer's own error
         # rather than masking it with a partition message.
         return
+    # Hardware first so -ngl (in both sets) gets the "belongs on the slot"
+    # message — mirrors screen_model_write's ordering.
     _deny_slot_hardware_flags(tokens, segment="profile flags")
+    _deny_managed_flags(tokens, segment="profile flags")
 
 
 @router.post("", status_code=201)
@@ -162,8 +168,10 @@ async def create_profile(body: ProfileBody, request: Request) -> dict[str, Any]:
         409 profiles.exists: name already exists (seed or custom).
         422: pydantic validation failure (bad name, …).
         400 slot.hardware_flag_denied: flags carry a slot-owned hardware flag.
+        400 slot.managed_arg_denied: flags carry a hal0-managed flag.
     """
-    # spec-hw-slot-ownership §5: reject slot-hardware flags before persisting.
+    # spec-hw-slot-ownership §5 + §21.7: reject slot-hardware and managed
+    # flags before persisting.
     _screen_profile_flags(body.flags)
     async with record_action(
         request, category="profile", action="profile.create", target=body.name
@@ -294,8 +302,10 @@ async def update_profile(name: str, body: ProfileUpdateBody, request: Request) -
         404 profiles.not_found: custom profile not found.
         422: pydantic validation failure.
         400 slot.hardware_flag_denied: flags carry a slot-owned hardware flag.
+        400 slot.managed_arg_denied: flags carry a hal0-managed flag.
     """
-    # spec-hw-slot-ownership §5: reject slot-hardware flags before persisting.
+    # spec-hw-slot-ownership §5 + §21.7: reject slot-hardware and managed
+    # flags before persisting.
     _screen_profile_flags(body.flags)
     catalog = ProfileCatalog()
     before = None

--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -7,6 +7,9 @@
 # --parallel, --metrics, --no-webui, --no-mmap, --poll, --slot-prompt-
 # similarity, --main-gpu, --tensor-split, --split-mode, --ngld) live on
 # the slot. Images and runners live on the slot (via binary / image_pin).
+# Context is slot-owned too (context_size → the launch prefix's --ctx-size):
+# `-c`/`--ctx-size` is on the managed-args denylist (§21.7) and must never
+# appear in a profile's flags — record the intended window in `intent`.
 #
 # `mtp` remains informational for 1.0 (per spec-hw-slot-ownership.md §10)
 # — launch reads MTP from model capability plus the selected slot runner.
@@ -26,25 +29,25 @@ quant = ""
 
 [profile.chat-long-context]
 # Long-context chat variant (model-family defaults may override KV policy).
-flags = "-fa on -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 -c 131072 --no-context-shift"
+flags = "-fa on -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 --no-context-shift"
 mtp = false
-intent = "Long-context chat"
+intent = "Long-context chat · tuned for 128K ctx"
 quant = ""
 
 [profile.dense]
 # Generic dense workload — model-agnostic. Family-specific kv-cache / sampler
 # overrides go in profile.<family>-dense (e.g. profile.chadrock-dense).
-flags = "--jinja -fa on -b 2048 -ub 512 -c 131072 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
 mtp = false
-intent = "Generic dense workload"
+intent = "Generic dense workload · tuned for 128K ctx"
 quant = ""
 
 [profile.moe]
 # Generic MoE workload — model-agnostic. Family-specific overrides in
 # profile.<family>-moe (e.g. profile.chadrock-moe).
-flags = "--jinja -fa on -b 2048 -ub 512 -c 32768 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
 mtp = false
-intent = "Generic MoE workload"
+intent = "Generic MoE workload · tuned for 32K ctx"
 quant = ""
 
 [profile.embedding]
@@ -98,9 +101,9 @@ quant = ""
 # 1B model the steward runs), so a single combined profile is cleaner
 # than overlay. Small batch (1B model), reasoning off, no native
 # toolcalls on FPX — tool turns route via [brain_chat] tool_model.
-flags = "--jinja -fa on -b 512 -ub 256 -c 65536 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.9 --top-k 20 --no-mmproj"
+flags = "--jinja -fa on -b 512 -ub 256 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.9 --top-k 20 --no-mmproj"
 mtp = false
-intent = "Brain steward (1B MiniCPM5 + persona + tool-call routing)"
+intent = "Brain steward (1B MiniCPM5 + persona + tool-call routing) · 64K ctx"
 quant = ""
 
 [profile.chadrock-dense]
@@ -108,9 +111,9 @@ quant = ""
 # jcbtc/chadrock3.6-27b-pi-agent-rocmfp4-mtp model card — the chadrock
 # launch card that the legacy profile.dense was distilled from). 27B
 # dense + ROCmFP4 + MTP-capable + mmproj (vision).
-flags = "--jinja -fa on -b 2048 -ub 512 -c 131072 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift -ctk q8_0 -ctv q8_0 --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift -ctk q8_0 -ctv q8_0 --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
 mtp = true
-intent = "Chadrock 27B dense coder (ROCmFP4 + MTP-capable + mmproj)"
+intent = "Chadrock 27B dense coder (ROCmFP4 + MTP + mmproj) · 128K ctx"
 quant = "ROCmFP4"
 
 [profile.chadrock-moe]
@@ -118,9 +121,9 @@ quant = "ROCmFP4"
 # jcbtc/chadrock-35b-ace-saber-rocmfp4-mtp model card — the Saber launch
 # card that the legacy profile.moe was distilled from). 35B MoE A3B +
 # ROCmFPX MoEQuality + MTP draft heads.
-flags = "--jinja -fa on -b 2048 -ub 512 -c 32768 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift -ctk f16 -ctv f16 --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift -ctk f16 -ctv f16 --temp 0 --top-p 0.95 --top-k 20 --seed 123 --no-mmproj"
 mtp = true
-intent = "Chadrock 35B MoE Saber (ROCmFPX MoEQuality + MTP)"
+intent = "Chadrock 35B MoE Saber (ROCmFPX MoEQuality + MTP) · 32K ctx"
 quant = "ROCmFP4"
 
 [profile.thinking]
@@ -128,16 +131,16 @@ quant = "ROCmFP4"
 # (qwen3-5-9b-deepseek, qwen3-6-35b-a3b-halostrix-dyn-mtp, chadrock-
 # uncensored-thinking). Family-specific reasoning-format / MTP bits fold
 # into the materialized model text at edit time.
-flags = "--jinja -fa on -b 2048 -ub 512 -c 32768 --reasoning on --reasoning-format deepseek --reasoning-budget -1 --no-context-shift --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0 --presence-penalty 0 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning on --reasoning-format deepseek --reasoning-budget -1 --no-context-shift --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0 --presence-penalty 0 --no-mmproj"
 mtp = false
-intent = "Reasoning-ON workload (qwen3-deepseek, ace-saber thinking, etc.)"
+intent = "Reasoning-ON workload (qwen3-deepseek, ace-saber thinking) · 32K ctx"
 quant = ""
 
 [profile.coding]
 # Workload-level code-gen tuned profile. Use for the coder slot (port
 # 8082), qwen3-coder, qwopus-coder, Qwen3-Coder-30B-A3B. Higher temp
 # for code-gen creativity; no reasoning (coders are non-reasoning).
-flags = "--jinja -fa on -b 2048 -ub 512 -c 32768 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.95 --top-k 40 --seed 123 --no-mmproj"
+flags = "--jinja -fa on -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.95 --top-k 40 --seed 123 --no-mmproj"
 mtp = false
-intent = "Code-gen workload (coder slot, qwen3-coder, qwopus-coder)"
+intent = "Code-gen workload (coder slot, qwen3-coder, qwopus-coder) · 32K ctx"
 quant = ""

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -16,6 +16,7 @@ See PLAN.md §3 and §5 Tier 1.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import tempfile
 import tomllib
@@ -40,6 +41,8 @@ from hal0.config.schema import (
     UpstreamsConfig,
 )
 from hal0.errors import Hal0Error
+
+log = logging.getLogger(__name__)
 
 # ── Typed errors ──────────────────────────────────────────────────────────────
 
@@ -556,7 +559,53 @@ def load_profiles_config(path: Path | None = None) -> ProfilesConfig:
     # loses nothing.  Non-seed (operator) profiles are left exactly as written.
     for key, seed_raw in SEED_PROFILES.items():
         cfg.profile[key] = ProfileConfig.model_validate(seed_raw)
+    _sanitize_custom_profile_flags(cfg, Path(target))
     return cfg
+
+
+def _sanitize_custom_profile_flags(cfg: ProfilesConfig, target: Path) -> None:
+    """Strip hal0-managed flags (§21.7) from non-seed profiles, healing disk.
+
+    Older releases let custom profiles persist managed flags — clones of the
+    ``-c``-carrying seeds, hand-edited TOML, pre-guard POST/PUT bodies. Such a
+    profile only explodes later, when its flags are stamped onto a model
+    (``slot.managed_arg_denied`` at save and launch). Strip exactly the
+    denylisted tokens (+ their values) from every non-seed profile so the
+    catalog never serves an unstampable template, and best-effort persist the
+    cleaned text so the on-disk TOML self-heals too (a read-only /etc still
+    gets the sanitized in-memory catalog). Seed keys are code-owned (overlaid
+    above) and never touched.
+    """
+    import shlex
+
+    # Lazy import: hal0.slots pulls in the manager stack, which imports config.
+    from hal0.slots.argv import strip_managed_flags
+
+    sanitized: dict[str, list[str]] = {}
+    for key, profile in cfg.profile.items():
+        if key in SEED_PROFILES or not profile.flags.strip():
+            continue
+        try:
+            tokens = shlex.split(profile.flags)
+        except ValueError:
+            continue  # malformed quoting — leave for the write-path screens
+        clean, removed = strip_managed_flags(tokens)
+        if removed:
+            profile.flags = " ".join(shlex.quote(tok) for tok in clean)
+            sanitized[key] = removed
+    if not sanitized:
+        return
+    log.warning(
+        "custom profile flags carried hal0-managed flag(s); stripped",
+        extra={"event": "profile.flags_sanitized", "profiles": sanitized},
+    )
+    try:
+        save_profiles_config(cfg, path=target)
+    except OSError as exc:
+        log.warning(
+            "could not persist sanitized profiles.toml; serving cleaned catalog in-memory",
+            extra={"event": "profile.flags_sanitize_write_failed", "error": str(exc)},
+        )
 
 
 def save_profiles_config(cfg: ProfilesConfig, path: Path | None = None) -> None:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -998,7 +998,7 @@ def resolve_default_image(backend: str | None, device_class: str | None = None) 
 
 
 #: Seed profile catalog — externalized to shipped TOML (P3-schema, spec
-#: Part A). See ``hal0/config/data/seed_profiles.toml`` for the 20 seed
+#: Part A). See ``hal0/config/data/seed_profiles.toml`` for the 16 seed
 #: entries (with their per-profile rationale comments) and
 #: ``hal0.config.seeds.seed_profiles()`` for the loader. ``SEED_PROFILES``
 #: is (re)assigned at the bottom of this module, once every model above

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -326,12 +326,12 @@ __all__ = [
 
 
 def _screen_hardware_flags(flags: str) -> None:
-    """Reject physical slot flags before a profile is persisted.
+    """Reject physical slot flags and hal0-managed flags before a profile is persisted.
 
     The HTTP route performs the same check for an early, route-specific error,
     but the catalog is also used by import/CLI paths and is the actual write
     seam. Keeping the guard here prevents those paths from bypassing the
-    model/profile ownership partition.
+    model/profile ownership partition (§5 hardware + §21.7 managed args).
     """
     if not flags.strip():
         return
@@ -339,6 +339,9 @@ def _screen_hardware_flags(flags: str) -> None:
         tokens = shlex.split(flags)
     except ValueError:
         return  # schema/parser owns malformed quoting diagnostics
-    from hal0.slots.argv import _deny_slot_hardware_flags
+    from hal0.slots.argv import _deny_managed_flags, _deny_slot_hardware_flags
 
+    # Hardware first so -ngl (in both sets) gets the "belongs on the slot"
+    # message — mirrors the route/screen_model_write ordering.
     _deny_slot_hardware_flags(tokens, segment="profile flags")
+    _deny_managed_flags(tokens, segment="profile flags")

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1288,6 +1288,42 @@ def _copy_model_files_refcounted(db_path: Any, *, source_id: str, new_id: str) -
     return copied
 
 
+def _strip_denied_flags(flags: str) -> str:
+    """Drop hal0-managed + slot-hardware flags from a profile stamp text.
+
+    The duplicate path persists a profile's flags straight into the new row's
+    ``defaults.extra_args`` without going through :func:`screen_model_write`,
+    so a legacy profile still carrying ``-c``/``-ngl`` would mint a row that
+    hard-fails every launch with ``slot.managed_arg_denied``. Silently strip
+    the denied tokens (+ values) instead — the duplicate is a fresh row, not
+    an operator edit, so there is nothing to reject interactively.
+    """
+    import shlex
+
+    from hal0.slots.argv import (
+        MANAGED_ARGS_DENYLIST,
+        SLOT_HARDWARE_FLAGS,
+        strip_managed_flags,
+    )
+
+    if not flags or not flags.strip():
+        return flags
+    try:
+        tokens = shlex.split(flags)
+    except ValueError:
+        return flags  # malformed quoting — leave verbatim for the edit screens
+    clean, removed = strip_managed_flags(
+        tokens, denylist=MANAGED_ARGS_DENYLIST | SLOT_HARDWARE_FLAGS
+    )
+    if not removed:
+        return flags
+    log.warning(
+        "profile stamp carried hal0-owned flag(s); stripped from duplicate",
+        extra={"event": "model.duplicate_flags_sanitized", "flags": removed},
+    )
+    return " ".join(shlex.quote(tok) for tok in clean)
+
+
 def duplicate_model(
     registry: Any,
     *,
@@ -1344,7 +1380,7 @@ def duplicate_model(
             existing_defaults = {}
         existing_defaults = dict(existing_defaults)
         existing_defaults["profile"] = profile
-        existing_defaults["extra_args"] = resolved.flags
+        existing_defaults["extra_args"] = _strip_denied_flags(resolved.flags)
         dumped["defaults"] = existing_defaults
 
     new_model = Model.model_validate(dumped)

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1293,7 +1293,7 @@ def _strip_denied_flags(flags: str) -> str:
 
     The duplicate path persists a profile's flags straight into the new row's
     ``defaults.extra_args`` without going through :func:`screen_model_write`,
-    so a legacy profile still carrying ``-c``/``-ngl`` would mint a row that
+    so a stale profile still carrying ``-c``/``-ngl`` would mint a row that
     hard-fails every launch with ``slot.managed_arg_denied``. Silently strip
     the denied tokens (+ values) instead — the duplicate is a fresh row, not
     an operator edit, so there is nothing to reject interactively.

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -228,6 +228,37 @@ def _deny_managed_flags(tokens: list[str], *, segment: str) -> None:
         )
 
 
+def strip_managed_flags(
+    tokens: list[str], *, denylist: frozenset[str] = MANAGED_ARGS_DENYLIST
+) -> tuple[list[str], list[str]]:
+    """Drop every denylisted flag (and its value) from ``tokens``.
+
+    The healing counterpart of :func:`_deny_managed_flags`: instead of
+    rejecting, it removes each offending flag together with its value so
+    already-persisted state (custom profiles / model ``defaults.extra_args``
+    stamped before the guards existed) can be sanitized in place. Matching is
+    token-exact via ``_canon()`` — ``-c`` maps onto ``--ctx-size`` but
+    ``--threads-batch``/``--model_path`` never collide with ``--threads``/
+    ``--model``. Pass ``denylist`` to screen a different flag set (e.g.
+    ``MANAGED_ARGS_DENYLIST | SLOT_HARDWARE_FLAGS``).
+
+    Returns:
+        ``(clean_tokens, removed_flags)`` — the surviving tokens in order, and
+        the offending flags by their original spelling (empty = already clean).
+    """
+    clean: list[str] = []
+    removed: list[str] = []
+    for pair in _split_pairs(tokens):
+        if pair.canon is not None and pair.canon in denylist:
+            assert pair.flag is not None
+            removed.append(pair.flag)
+            continue
+        if pair.flag is not None:
+            clean.append(pair.flag)
+        clean.extend(pair.values)
+    return clean, removed
+
+
 def _deny_slot_hardware_flags(tokens: list[str], *, segment: str) -> None:
     """Raise :class:`~hal0.errors.BadRequest` if ``tokens`` set a slot-hardware flag.
 
@@ -446,4 +477,5 @@ __all__ = [
     "merge_flags",
     "normalize_argv",
     "resolve_argv",
+    "strip_managed_flags",
 ]

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1470,6 +1470,79 @@ def clear_stale_mtp_overrides(*, job_id: str | None = None, registry: Any = None
     return cleared
 
 
+def sanitize_model_extra_args(*, job_id: str | None = None, registry: Any = None) -> int:
+    """Strip hal0-managed flags from model ``defaults.extra_args`` (upgrade migration).
+
+    ``defaults.extra_args`` rides the untrusted ``model_extra_args`` argv
+    segment, which hard-rejects the §21.7 managed flags at every launch
+    (``slot.managed_arg_denied``). Rows stamped before the screens existed —
+    notably via the unscreened ``POST /api/models/{id}/duplicate`` profile
+    stamp, back when 8 seed profiles carried ``-c <N>`` — are therefore
+    bricked: they can never load until the flag is hand-removed. Strip exactly
+    the denylisted tokens (+ values) from every model's ``extra_args`` and log
+    loudly per row. Matching is token-exact via the argv alias table, so
+    ``--model_path``/``--threads-batch`` are never touched; slot-hardware
+    flags (``--threads``/``-dev``) are left alone too — they are functional at
+    launch, so stripping them would change working rows.
+
+    Args:
+        job_id: Optional breadcrumb for structured-log tracing.
+        registry: Model-registry override for tests (anything with ``list()``
+            and ``update(model_id, updates)``). ``None`` uses the real
+            :class:`~hal0.registry.store.ModelRegistry`.
+
+    Returns:
+        Number of model rows sanitized.
+    """
+    import shlex
+
+    from hal0.slots.argv import strip_managed_flags
+
+    if registry is None:
+        from hal0.registry.store import ModelRegistry
+
+        registry = ModelRegistry()
+
+    sanitized = 0
+    for model in registry.list():
+        defaults = getattr(model, "defaults", None)
+        extra = getattr(defaults, "extra_args", None) if defaults is not None else None
+        if not extra or not extra.strip():
+            continue
+        try:
+            tokens = shlex.split(extra)
+        except ValueError:
+            continue  # malformed quoting — leave for the edit-path screens
+        clean, removed = strip_managed_flags(tokens)
+        if not removed:
+            continue
+        defaults_dict = defaults.model_dump(mode="python")
+        defaults_dict["extra_args"] = " ".join(shlex.quote(tok) for tok in clean)
+        try:
+            registry.update(model.id, {"defaults": defaults_dict})
+        except Exception as exc:
+            log.warning(
+                "updater.extra_args_sanitize_write_failed",
+                job_id=job_id,
+                model=model.id,
+                error=str(exc),
+            )
+            continue
+        sanitized += 1
+        log.warning(
+            "updater.model_extra_args_sanitized",
+            job_id=job_id,
+            model=model.id,
+            removed=removed,
+            note=(
+                "defaults.extra_args carried hal0-managed flag(s) the launcher "
+                "hard-rejects (slot.managed_arg_denied); stripped so the model "
+                "can load again. Context/port/host come from the slot config."
+            ),
+        )
+    return sanitized
+
+
 def retag_stale_slot_images(*, job_id: str | None = None) -> int:
     """Retag slot ``image`` pins that are stale FORMER DEFAULTS (upgrade migration).
 
@@ -1981,6 +2054,20 @@ class Updater:
             )
             # Non-fatal: a stale pin just keeps the previous runner image.
 
+        # Step 7e: strip hal0-managed flags (§21.7) from model
+        # defaults.extra_args — rows stamped via the pre-screen duplicate path
+        # carry -c/--port debris that hard-fails every launch. Loud per-row log.
+        try:
+            await asyncio.to_thread(sanitize_model_extra_args, job_id=self.job_id)
+        except Exception as exc:
+            log.warning(
+                "updater.extra_args_sanitize_failed",
+                job_id=self.job_id,
+                error=str(exc),
+            )
+            # Non-fatal: an affected model keeps failing to launch until the
+            # operator removes the managed flag in the model drawer.
+
         # Step 8 + 9: atomic symlink swap + record previous.
         link = _current_symlink()
         try:
@@ -2220,5 +2307,6 @@ __all__ = [
     "ensure_seed_profiles",
     "fetch_release_manifest",
     "releases_url",
+    "sanitize_model_extra_args",
     "validate_manifest_for_channel",
 ]

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -127,6 +127,36 @@ def test_update_profile_rejects_slot_hardware_flag(client: TestClient) -> None:
     assert r.json()["error"]["code"] == "slot.hardware_flag_denied"
 
 
+def test_create_profile_rejects_managed_flag(client: TestClient) -> None:
+    """§21.7: -c/--ctx-size (like --port/--model/--host/--alias) is hal0-managed
+    — a profile that persists it only explodes later when stamped onto a model.
+    The create hard-rejects with slot.managed_arg_denied and persists nothing."""
+    r = client.post(
+        "/api/profiles",
+        json={
+            "name": "ctx-profile",
+            "flags": "-fa on -c 131072",
+        },
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+    listed = client.get("/api/profiles").json()
+    assert not any(p["name"] == "ctx-profile" for p in listed)
+
+
+def test_update_profile_rejects_managed_flag(client: TestClient) -> None:
+    """PUT screens the managed denylist too — a clean profile edited to carry
+    --port is rejected."""
+    created = client.post(
+        "/api/profiles",
+        json={"name": "edit-ctx", "flags": "-fa on"},
+    )
+    assert created.status_code == 201, created.text
+    r = client.put("/api/profiles/edit-ctx", json={"flags": "-b 2048 --port 9999"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+
+
 def test_create_profile_accepts_device_agnostic_tune(client: TestClient) -> None:
     """A real tune template (batch/flash-attn/KV-quant, no hardware) is accepted."""
     r = client.post(

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -323,6 +323,42 @@ class TestLoadProfilesConfig:
         # Seeds are also present.
         assert set(SEED_PROFILES.keys()) <= set(cfg.profile.keys())
 
+    # ── managed-flag sanitization of persisted custom profiles (§21.7) ────────
+
+    def test_custom_profile_managed_flags_stripped_and_persisted(self, tmp_path: Path) -> None:
+        """A custom profile carrying managed flags (a pre-guard clone of a
+        -c-carrying seed, or a hand-edit) is healed at load: the denylisted
+        tokens (+ values) are stripped in-memory AND written back to disk."""
+        toml_content = (
+            "[profile.old-clone]\n"
+            'flags = "--jinja -fa on -b 2048 -c 131072 --no-context-shift"\n'
+            "mtp = false\n"
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+
+        cfg = load_profiles_config(path=p)
+
+        assert cfg.profile["old-clone"].flags == "--jinja -fa on -b 2048 --no-context-shift"
+        # Disk self-healed: a re-load finds nothing left to strip.
+        raw = tomllib.loads(p.read_text(encoding="utf-8"))
+        assert raw["profile"]["old-clone"]["flags"] == "--jinja -fa on -b 2048 --no-context-shift"
+
+    def test_custom_profile_lookalike_flags_survive_sanitize(self, tmp_path: Path) -> None:
+        """Token-exact stripping: --model_path / --threads-batch are NOT the
+        managed --model / slot --threads — they must survive untouched."""
+        toml_content = (
+            "[profile.tts-clone]\n"
+            'flags = "--model_path /models/kokoro --threads-batch 8"\n'
+            "mtp = false\n"
+        )
+        p = tmp_path / "profiles.toml"
+        p.write_bytes(toml_content.encode())
+
+        cfg = load_profiles_config(path=p)
+
+        assert cfg.profile["tts-clone"].flags == "--model_path /models/kokoro --threads-batch 8"
+
     def test_complete_seed_file_no_extras_added(self, tmp_path: Path) -> None:
         """A file that already contains all seeds gets no duplicates."""
         import tomli_w

--- a/tests/config/test_seeds_parity.py
+++ b/tests/config/test_seeds_parity.py
@@ -27,7 +27,10 @@ def test_seed_catalog_is_canonical_and_complete() -> None:
 
 
 def test_seed_profiles_are_device_agnostic_and_partition_safe() -> None:
+    # Slot-hardware flags (§5) + hal0-managed args (§21.7) — token-exact, so
+    # --model_path / --threads-batch in the TTS / cpu-chat seeds never trip.
     forbidden = {"-ngl", "--n-gpu-layers", "-dev", "--device", "--threads", "-t"}
+    forbidden |= {"-c", "--ctx-size", "--host", "--port", "--model", "--alias"}
     for name, profile in seeds.seed_profiles().items():
         assert "image" not in profile, name
         assert profile.get("backend") is None, name

--- a/tests/config/test_seeds_parity.py
+++ b/tests/config/test_seeds_parity.py
@@ -39,10 +39,11 @@ def test_fpx_profiles_keep_logical_tune_and_drop_physical_mtp_flags() -> None:
     dense = seeds.seed_profiles()["dense"]["flags"]
     # Generic moe/dense are model-agnostic and carry no family-specific
     # kv-cache (chadrock-specific -ctk/-ctv moved to chadrock-moe/dense
-    # per spec §4.2). Both still carry batch + context defaults.
+    # per spec §4.2). Both still carry batch defaults; context is slot-owned
+    # (context_size → --ctx-size, §21.7), so -c must never appear.
     assert "-b 2048" in moe
-    assert "-c 32768" in moe
-    assert "-c 131072" in dense
+    assert "-c" not in moe.split()
+    assert "-c" not in dense.split()
     # Chadrock family profiles own the family-specific KV quirks
     chadrock_moe = seeds.seed_profiles()["chadrock-moe"]["flags"]
     chadrock_dense = seeds.seed_profiles()["chadrock-dense"]["flags"]

--- a/tests/profiles/test_portable.py
+++ b/tests/profiles/test_portable.py
@@ -185,17 +185,13 @@ class TestImportProfile:
         """§21.7: import routes through the catalog write seam, so an envelope
         carrying a hal0-managed flag (-c/--port/…) is rejected — the import
         path must not bypass the screens the create/update routes enforce."""
-        env = export_envelope(
-            "orig", ProfileConfig(flags="-fa on -c 131072"), exported_at="t"
-        )
+        env = export_envelope("orig", ProfileConfig(flags="-fa on -c 131072"), exported_at="t")
         with pytest.raises(BadRequest) as exc:
             import_profile(env, "copied", _catalog(tmp_hal0_home))
         assert exc.value.code == "slot.managed_arg_denied"
 
     def test_slot_hardware_flag_rejected(self, tmp_hal0_home: str) -> None:
-        env = export_envelope(
-            "orig", ProfileConfig(flags="-fa on -ngl 999"), exported_at="t"
-        )
+        env = export_envelope("orig", ProfileConfig(flags="-fa on -ngl 999"), exported_at="t")
         with pytest.raises(BadRequest) as exc:
             import_profile(env, "copied", _catalog(tmp_hal0_home))
         assert exc.value.code == "slot.hardware_flag_denied"

--- a/tests/profiles/test_portable.py
+++ b/tests/profiles/test_portable.py
@@ -180,3 +180,22 @@ class TestImportProfile:
         with pytest.raises(Conflict) as exc:
             import_profile(env, "taken", catalog)
         assert exc.value.code == "profiles.exists"
+
+    def test_managed_flag_rejected(self, tmp_hal0_home: str) -> None:
+        """§21.7: import routes through the catalog write seam, so an envelope
+        carrying a hal0-managed flag (-c/--port/…) is rejected — the import
+        path must not bypass the screens the create/update routes enforce."""
+        env = export_envelope(
+            "orig", ProfileConfig(flags="-fa on -c 131072"), exported_at="t"
+        )
+        with pytest.raises(BadRequest) as exc:
+            import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "slot.managed_arg_denied"
+
+    def test_slot_hardware_flag_rejected(self, tmp_hal0_home: str) -> None:
+        env = export_envelope(
+            "orig", ProfileConfig(flags="-fa on -ngl 999"), exported_at="t"
+        )
+        with pytest.raises(BadRequest) as exc:
+            import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "slot.hardware_flag_denied"

--- a/tests/registry/test_duplicate_refcount.py
+++ b/tests/registry/test_duplicate_refcount.py
@@ -111,6 +111,29 @@ def test_duplicate_with_profile_stamps_flags(registry: SqliteModelRegistry, tmp_
     assert registry.get("p").defaults is None
 
 
+def test_duplicate_profile_stamp_strips_denied_flags(
+    registry: SqliteModelRegistry, tmp_path: Path, tmp_hal0_home: str
+) -> None:
+    """A legacy profile still carrying hal0-owned flags must not mint a row
+    that hard-fails every launch (slot.managed_arg_denied) — the stamp strips
+    the managed + slot-hardware tokens before persisting. Written straight to
+    disk: the catalog screens create/update, but pre-guard TOML still exists
+    (and load-time sanitization strips only the MANAGED set, not --threads)."""
+    from hal0.config.paths import profiles_toml
+
+    target = profiles_toml()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        '[profile.legacy-tune]\nflags = "--jinja -fa on --threads 8 -b 2048"\nmtp = false\n',
+        encoding="utf-8",
+    )
+    f = tmp_path / "d.gguf"
+    f.write_bytes(b"\x00")
+    registry.add(Model(id="d", path=str(f)))
+    out = duplicate_model(registry, source_id="d", new_id="d-copy", profile="legacy-tune")
+    assert out["defaults"]["extra_args"] == "--jinja -fa on -b 2048"
+
+
 def test_duplicate_unknown_source_raises(registry: SqliteModelRegistry) -> None:
     with pytest.raises(ModelNotFound):
         duplicate_model(registry, source_id="nope", new_id="x")

--- a/tests/slots/test_argv.py
+++ b/tests/slots/test_argv.py
@@ -18,6 +18,7 @@ from hal0.slots.argv import (
     _deny_slot_hardware_flags,
     normalize_argv,
     resolve_argv,
+    strip_managed_flags,
 )
 
 # The flag portion of the live `agent` slot resolved_command (post `--port`).
@@ -433,3 +434,46 @@ def test_deny_slot_hardware_flags_allows_clean_tune() -> None:
     hardware flags, so the guard is a no-op."""
     tokens = ["-b", "2048", "-ub", "512", "-fa", "on", "-ctk", "q8_0", "--no-mmap"]
     _deny_slot_hardware_flags(tokens, segment="model defaults.extra_args")  # must not raise
+
+
+# ── strip_managed_flags: the healing counterpart of the deny guards ───────────
+
+
+def test_strip_managed_flags_drops_flag_and_value() -> None:
+    clean, removed = strip_managed_flags(["-fa", "on", "-c", "131072", "--jinja"])
+    assert clean == ["-fa", "on", "--jinja"]
+    assert removed == ["-c"]
+
+
+def test_strip_managed_flags_catches_both_spellings() -> None:
+    clean, removed = strip_managed_flags(
+        ["--ctx-size", "8192", "-ngl", "99", "--port", "9999", "-b", "2048"]
+    )
+    assert clean == ["-b", "2048"]
+    assert removed == ["--ctx-size", "-ngl", "--port"]
+
+
+def test_strip_managed_flags_clean_input_untouched() -> None:
+    tokens = ["-fa", "on", "-b", "2048", "-ub", "512", "-ctk", "q8_0"]
+    clean, removed = strip_managed_flags(tokens)
+    assert clean == tokens
+    assert removed == []
+
+
+def test_strip_managed_flags_never_touches_lookalike_tokens() -> None:
+    """Token-exact matching: --model_path / --threads-batch are NOT --model /
+    --threads (the kokoro / cpu-chat seed flags depend on this)."""
+    tokens = ["--model_path", "/models/kokoro", "--threads-batch", "8"]
+    clean, removed = strip_managed_flags(
+        tokens, denylist=MANAGED_ARGS_DENYLIST | SLOT_HARDWARE_FLAGS
+    )
+    assert clean == tokens
+    assert removed == []
+
+
+def test_strip_managed_flags_custom_denylist_covers_hardware() -> None:
+    clean, removed = strip_managed_flags(
+        ["--threads", "8", "-fa", "on"], denylist=MANAGED_ARGS_DENYLIST | SLOT_HARDWARE_FLAGS
+    )
+    assert clean == ["-fa", "on"]
+    assert removed == ["--threads"]

--- a/tests/slots/test_seed_profiles.py
+++ b/tests/slots/test_seed_profiles.py
@@ -116,6 +116,25 @@ def test_all_profiles_have_no_operational_flags(profile_name: str) -> None:
 
 
 @pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+def test_all_profiles_have_no_managed_or_hardware_flags(profile_name: str) -> None:
+    """§21.7 regression tripwire: a seed's flags must never carry a flag hal0
+    owns (managed denylist: --model/--ctx-size/-c/--host/--port/-ngl/--alias)
+    or a slot-hardware flag. Token-exact via the argv alias table, so
+    --model_path / --threads-batch never false-positive.
+    """
+    import shlex
+
+    from hal0.slots.argv import MANAGED_ARGS_DENYLIST, SLOT_HARDWARE_FLAGS, strip_managed_flags
+
+    profiles = _load_seed_profiles()
+    flags = str(profiles[profile_name].get("flags", ""))
+    _, removed = strip_managed_flags(
+        shlex.split(flags), denylist=MANAGED_ARGS_DENYLIST | SLOT_HARDWARE_FLAGS
+    )
+    assert not removed, f"{profile_name} flags carry hal0-owned flag(s) {removed}: {flags}"
+
+
+@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
 def test_all_profiles_have_intent(profile_name: str) -> None:
     profiles = _load_seed_profiles()
     assert "intent" in profiles[profile_name], f"{profile_name} missing intent"

--- a/tests/updater/test_extra_args_sanitize.py
+++ b/tests/updater/test_extra_args_sanitize.py
@@ -1,0 +1,59 @@
+"""sanitize_model_extra_args — the managed-flag registry-heal migration.
+
+``defaults.extra_args`` rides the untrusted ``model_extra_args`` argv segment,
+so a row carrying a §21.7 managed flag (``-c``/``--port``/…) hard-fails every
+launch with ``slot.managed_arg_denied``. Such rows were minted by the
+pre-screen ``POST /api/models/{id}/duplicate`` profile stamp back when 8 seed
+profiles carried ``-c <N>``. The migration's contract under test:
+
+  - managed flags (+ values) are stripped, either spelling, and persisted,
+  - clean rows / rows without defaults are untouched,
+  - token-exact matching: lookalikes (``--model_path``/``--threads-batch``)
+    and functional slot-hardware flags (``--threads``) survive.
+"""
+
+from __future__ import annotations
+
+from hal0.registry.model import Model, ModelDefaults
+from hal0.registry.store import ModelRegistry
+from hal0.updater.updater import sanitize_model_extra_args
+
+
+def _register(model_id: str, extra_args: str | None) -> None:
+    ModelRegistry().add(
+        Model(
+            id=model_id,
+            path=f"/tmp/{model_id}.gguf",
+            capabilities=["chat"],
+            defaults=ModelDefaults(extra_args=extra_args) if extra_args is not None else None,
+        )
+    )
+
+
+def test_strips_managed_flags_and_persists(tmp_hal0_home: str) -> None:
+    _register("bricked", "--jinja -fa on -c 131072 --port 9999 -b 2048")
+    _register("clean", "-fa on -b 2048")
+    _register("no-defaults", None)
+
+    assert sanitize_model_extra_args() == 1
+
+    reg = ModelRegistry()
+    assert reg.get("bricked").defaults.extra_args == "--jinja -fa on -b 2048"
+    assert reg.get("clean").defaults.extra_args == "-fa on -b 2048"
+    assert reg.get("no-defaults").defaults is None
+
+
+def test_leaves_lookalike_and_hardware_flags_alone(tmp_hal0_home: str) -> None:
+    """--model_path/--threads-batch are not --model/--threads; --threads itself
+    is slot-hardware, functional at launch, and NOT stripped by this migration."""
+    _register("tts", "--model_path /models/kokoro --threads-batch 8 --threads 4")
+
+    assert sanitize_model_extra_args() == 0
+    assert (
+        ModelRegistry().get("tts").defaults.extra_args
+        == "--model_path /models/kokoro --threads-batch 8 --threads 4"
+    )
+
+
+def test_empty_registry_is_noop(tmp_hal0_home: str) -> None:
+    assert sanitize_model_extra_args() == 0

--- a/ui/src/dash/profiles.jsx
+++ b/ui/src/dash/profiles.jsx
@@ -24,6 +24,12 @@ import {
 } from '@/api/hooks/useProfiles'
 import { useMetaEnums } from '@/api/hooks/useMeta'
 import { prettyProfile } from './profile-names'
+import {
+  findManagedFlags,
+  findSlotHardwareFlags,
+  tokenizeFlags,
+  MANAGED_FLAG_SOURCE,
+} from './flags-tune.js'
 
 // Backend runtime hue map — built from meta.devices (GET /api/meta/enums via
 // useMetaEnums, static fallback when absent) instead of the old hardcoded
@@ -204,6 +210,21 @@ function Section({ title, count, hint, children }) {
 // FormRow is a shared primitive (primitives.jsx) — the superset variant this
 // view seeded (error/warn/ok/counter + real <label htmlFor>).
 
+// Managed / slot-hardware rejection copy — mirrors the model drawer's inline
+// messages (model-drawer.jsx) so both flag editors speak with one voice.
+function managedFlagError(offenders) {
+  const first = offenders[0];
+  const canon = first === '-ngl' ? '--n-gpu-layers' : first === '-c' ? '--ctx-size' : first;
+  const where = MANAGED_FLAG_SOURCE[first] || MANAGED_FLAG_SOURCE[canon] || 'the slot/model configuration';
+  const rest = offenders.length > 1 ? ` (also managed: ${offenders.slice(1).join(', ')})` : '';
+  return `${first} is computed by hal0 and can't be set here — it comes from ${where}. Remove it.${rest}`;
+}
+function hardwareFlagError(offenders) {
+  const first = offenders[0];
+  const rest = offenders.length > 1 ? ` (also: ${offenders.slice(1).join(', ')})` : '';
+  return `${first} is hardware — it belongs on the slot (device · NGL · THREADS grid), not the profile. Remove it.${rest}`;
+}
+
 function validateForm(form, existing) {
   const errs = {};
   const name = (form.name || '').trim();
@@ -212,6 +233,16 @@ function validateForm(form, existing) {
   else if (existing.includes(name)) errs.name = `“${name}” already exists`;
   // spec-hw-slot-ownership §3: profiles no longer carry an image — only a name
   // + device-agnostic tune. Image lives on the runner (RUNNER_IMAGES[binary]).
+  // Flag-ownership screens (§21.7 managed + §5 slot-hardware) — mirror the
+  // server hard-reject inline so the save never surfaces the 400. Hardware
+  // first so -ngl (in both sets) gets the "belongs on the slot" message.
+  const flagsText = form.flags || '';
+  const quoteErr = tokenizeFlags(flagsText).error;
+  const hw = quoteErr ? [] : findSlotHardwareFlags(flagsText);
+  const managed = quoteErr ? [] : findManagedFlags(flagsText);
+  if (quoteErr) errs.flags = quoteErr;
+  else if (hw.length) errs.flags = hardwareFlagError(hw);
+  else if (managed.length) errs.flags = managedFlagError(managed);
   return errs;
 }
 
@@ -363,10 +394,13 @@ function ProfileDrawer({ mode, source, existing = [], onClose, onSaved }) {
             placeholder="FP4 · Q4_K_M …" data-testid="pf-input-quant" />
         </FormRow>
 
-        <FormRow label="Flags" sub="appended to the run command">
-          <textarea className="pf-input mono pf-textarea" value={form.flags || ''}
-            onChange={e => set('flags', e.target.value)} rows={3} placeholder="--flash-attn on -ngl 999"
-            data-testid="pf-input-flags" />
+        <FormRow label="Flags" sub="appended to the run command"
+          error={show('flags') ? errs.flags : null}>
+          <textarea className={'pf-input mono pf-textarea' + (show('flags') && errs.flags ? ' err' : '')}
+            value={form.flags || ''}
+            onChange={e => set('flags', e.target.value)} onBlur={() => touch('flags')}
+            rows={3} placeholder="-fa on --jinja -b 2048 -ub 512"
+            aria-invalid={!!(show('flags') && errs.flags)} data-testid="pf-input-flags" />
         </FormRow>
 
         <FormRow label="MTP" sub="Multi-Token Prediction speculative decode">

--- a/ui/tests/e2e/fixtures/mock-data.ts
+++ b/ui/tests/e2e/fixtures/mock-data.ts
@@ -246,11 +246,14 @@ export const MOCK_DATA = {
 
   approvals: [] as any[],
 
+  // Seed profiles carry no slot-hardware flags (-ngl belongs on the slot's
+  // NGL field) — resolved_flags still shows it, since the slot contributes it
+  // at resolve time. Keeps the fixture honest about flag ownership.
   profiles: [
     {
       name: 'rocm',
       image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server',
-      flags: '--flash-attn on -ngl 999',
+      flags: '--flash-attn on',
       mtp: false,
       resolved_flags: '--flash-attn on -ngl 999',
       device_class: 'gpu',
@@ -265,7 +268,7 @@ export const MOCK_DATA = {
     {
       name: 'rocm-mtp',
       image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocm-7.2.4-rocmfp4-server',
-      flags: '--flash-attn on -ngl 999',
+      flags: '--flash-attn on',
       mtp: true,
       resolved_flags: '--flash-attn on -ngl 999 --draft-model /mnt/ai-models/mtp/llama-3b.gguf',
       device_class: 'gpu',
@@ -280,7 +283,7 @@ export const MOCK_DATA = {
     {
       name: 'vulkan',
       image: 'ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server',
-      flags: '--flash-attn on -ngl 999',
+      flags: '--flash-attn on',
       mtp: false,
       resolved_flags: '--flash-attn on -ngl 999',
       device_class: 'gpu',


### PR DESCRIPTION
## Summary

Strips authority-owned (managed) flags from default profiles and sanitizes persisted ones, so profile `extra_args` can never fight the slot/authority for flags like `-c`, `--host`, `--port`, `--model`, or `--alias`.

1. **Root cause** — removed `-c <N>` from the 8 seed profiles in `seed_profiles.toml` (chat-long-context, dense, moe, brain, chadrock-dense, chadrock-moe, thinking, coding), preserving the intended window in each intent string ("· 128K ctx" etc.) and adding a header note that ctx is slot-owned. Seeds are virtual, so this heals every install on upgrade. Also fixed the stale "20 seed entries" comment in `schema.py`.
2. **Regression guards** — new `strip_managed_flags(tokens, denylist=...)` helper in `slots/argv.py` (token-exact via `_canon`, drops flag+value); POST/PUT `/api/profiles` now also deny `MANAGED_ARGS_DENYLIST` (hardware-first ordering matches `screen_model_write`); §21.7 seed tripwire test parametrized over all 16 profiles.
3. **Healing** — `load_profiles_config` strips managed flags from non-seed profiles, logs `profile.flags_sanitized`, and best-effort persists (OSError-safe for read-only `/etc`); new updater migration `sanitize_model_extra_args` (Step 7e, exported, non-fatal) un-bricks registry rows whose `defaults.extra_args` carry managed flags — managed set only, slot-hardware flags deliberately left (functional at launch).
4. **Closed the unscreened stamp hole** — `duplicate_model` passes profile flags through the managed+hardware strip before persisting.
5. **UI** — profile drawer now mirrors the model drawer's inline validation (tokenize → slot-hardware → managed with `MANAGED_FLAG_SOURCE` copy) wired into the Flags FormRow, and the placeholder no longer suggests the server-rejected `-ngl 999`.

Tests updated/added across 8 files, including a new `tests/updater/test_extra_args_sanitize.py`. Branch rebased cleanly onto `main` (no conflicts) with targeted suites re-run green post-rebase.

## Validation

- **Backend**: PASS — full suite (`.venv/bin/pytest tests/ -q`) run twice: 7503→7504 passed, 16 skipped, 1 xfailed, 0 real failures. 204 errors are pre-existing environment noise (every one is `tests/mcp/*` erroring with PermissionError reading the real root-owned `/etc/hal0/hal0.toml`; reproduced identically at baseline via `git stash`). One order-dependent flake in run 1 only (`tests/cli/test_registry_import.py::test_import_cleans_tempdir_on_success` scans the shared system tempdir while ~10 other pytest processes run on this box; passed standalone and in run 2). Targeted profile-related subset (tests/profiles, slots/test_argv, slots/test_seed_profiles, config/test_profiles, config/test_seeds_parity, api/test_profiles_crud, registry/test_duplicate_refcount, updater/test_extra_args_sanitize): 238 passed — re-verified after rebase onto main, plus tests/updater + tests/config (840 passed, 9 skipped).
- **Typecheck**: PRE-EXISTING FAIL (not introduced) — `npm run typecheck` reports 2 errors: TS2307 "Cannot find module vitest" in `src/api/mock.test.ts` and `src/dash/settings/pages/diagnostics/UpdatesPage.test.ts`. Byte-identical failure on the untouched main checkout (vitest is absent from the shared node_modules). No new errors from these changes; `npm run build` (vite) passes clean in the worktree, verifying the profiles.jsx edit compiles and its imports resolve.
- **Lint**: PASS — `npm run lint` (eslint .) clean in the worktree.
- **UI unit**: COULD NOT RUN (pre-existing env gap) — `npm run test:unit` fails with "vitest: command not found", identical on the untouched main repo's ui/ (vitest binary not installed in the shared node_modules; deps deliberately not reinstalled). No existing UI unit tests cover profiles.jsx; backend pytest covers all server-side changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
