### PR TITLE
fix(ui): NPU slot Save no longer vetoed by the unmounted extra_args error (#1389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- **Slot drawer Save is no longer silently dead on an NPU slot with a malformed persisted `extra_args`** (#1389). The freeform extra_args field and its error surface live in the Model group, which is unmounted for `device === "npu"` — but the Save validator still computed `extraArgsErr` from the persisted `llamacpp_args`. A slot whose stored override carried an unbalanced quote blocked every Save on the slot with zero feedback: no request fired, no error rendered, the drawer just did nothing. The validator now only vetoes Save when the field is actually mounted; an operator who flips the device off `npu` still sees (and must fix) the error before the field's value can ride a write.
+
 ### Added
 
 - **`hal0 slot migrate-flags` — the flags-fold migrator finally has an operator entry point** (#1396). `hal0.config.migrations.slot_flags_fold` has existed since the flags-ownership lane, but nothing ever exposed it: no CLI, no installer hook, no boot wiring — only tests referenced it. Its sibling folds both had commands (`slot migrate-hw`, `slot migrate-caps`). Meanwhile the launch-side readers were already deleted (`providers.container` drops `profile_flags`/`slot_parallel`/`extra_args`; `resolve_chat_template` no longer consults the slot), so an upgraded box with a bench-tuned slot silently launched **without** that tune and had no supported way to recover it — the exact ordering hazard spec-flags-ownership §5.4 flagged ("readers become expired shims with a sunset"). The new command mirrors `migrate-hw`: dry-run by default, `--apply` takes a timestamped backup and passes the `deploy_window=True` ack, refuses to run while any hal0 unit is live (`--stop-services` to stop them), and is never wired into an automatic path. Divergent-share conflicts (two slots folding different tunes onto one model) are surfaced as a clean non-zero exit listing every conflict — on the dry-run path too, which previously would have raised an unhandled `RuntimeError` at an operator merely *previewing* a conflicted box.

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -427,7 +427,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		}
 		// Block Save on malformed extra_args (unbalanced quotes) the same way
 		// numeric fields block — the resolved command can't be built from it.
-		if (extraArgsErr) {
+		// Only when the field is actually mounted (`device !== "npu"` gates the
+		// Model group): a malformed PERSISTED value on an NPU slot must not
+		// veto unrelated saves with the error surface unmounted (#1389).
+		if (extraArgsErr && device !== "npu") {
 			errs.extraArgs = extraArgsErr;
 		}
 		if (Object.keys(errs).length > 0) {

--- a/ui/tests/e2e/specs/slot-npu-dead-save-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-npu-dead-save-v3.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * slot-npu-dead-save-v3 — #1389: Save must not be silently dead on an NPU
+ * slot whose PERSISTED extra_args is malformed.
+ *
+ * The freeform extra_args field (and its error surface) lives in the Model
+ * group, which is unmounted for `device === "npu"`. The Save validator still
+ * seeded `extraArgsErr` from the persisted `llamacpp_args`, so a malformed
+ * persisted value blocked every Save on the slot with zero feedback — the
+ * error rendered into an unmounted subtree and no request ever fired.
+ *
+ * Contract: a validation error on a field the operator cannot see or edit
+ * must not veto the batched Save of unrelated, visible fields.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const NPU = {
+  name: 'agent', type: 'llm', device: 'npu', profile: '',
+  model: 'qwen3:8b', model_id: 'qwen3:8b', modelLong: 'qwen3:8b',
+  modelDefault: 'qwen3:8b', model_default: 'qwen3:8b',
+  group: 'chat', state: 'ready', port: 8083, isDefault: false,
+  n_gpu_layers: -1, threads: 0,
+  // Persisted malformed override (unbalanced quote) — the repro's trigger.
+  llamacpp_args: '--flash-attn "oops',
+  npu: { chat: true, asr: false, embed: false },
+  metrics: {},
+}
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+test.describe('NPU slot Save with malformed persisted extra_args (#1389)', () => {
+  test('N1 — Save of a visible field is not vetoed by the unmounted extra_args error', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/agent/config', async (route) => {
+      if (route.request().method() === 'PUT')
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/agent/restart', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await seedSlots(page, [NPU])
+    await page.goto('/#slots/agent')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    await page.getByTestId('slot-hw-threads').fill('4')
+    await page.locator('.drawer button:has-text("Save")').click()
+
+    await expect.poll(() => puts.length, { timeout: 5000 }).toBeGreaterThan(0)
+    expect(puts[0]).toMatchObject({ threads: 4 })
+    // The phantom error must not ride the write either.
+    expect(puts[0]).not.toHaveProperty('server')
+  })
+})


### PR DESCRIPTION
Closes #1389.

The freeform extra_args field + error surface are in the Model group, unmounted for `device === "npu"`, but `onSaveClick` still seeded `errs.extraArgs` from the persisted `llamacpp_args`. A stored unbalanced quote made every Save on the slot silently dead — no request, no visible error (it rendered into the unmounted subtree).

Fix: the veto now applies only while the field is mounted. Off-NPU behavior unchanged — a mounted malformed field still blocks Save with its visible error.

TDD: `slot-npu-dead-save-v3.spec.ts` N1 red first (poll on captured PUTs timed out at zero), green after; asserts the write carries `{threads: 4}` and never a phantom `server` key. Regression: 84 drawer specs passed, eslint clean, isolated e2e port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)