### PR TITLE
fix(slots): crash-loop backoff for flapping slots; stop slot.state journal flood (#i4)

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1176,6 +1176,9 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
         target=name,
         message=f"load {model_id or 'default'}",
     ) as _rec:
+        # Manual load is operator intent — clear the crash-loop breaker
+        # (issue i4) so an ERROR/parked slot always gets a real attempt.
+        sm.reset_load_failures(name)
         snap = await sm.load(name, model_id=model_id)
         _rec.after = {"model_id": model_id, "state": _state_value(snap)}
     return _slot_to_dict(snap, request)

--- a/src/hal0/dispatcher/router.py
+++ b/src/hal0/dispatcher/router.py
@@ -53,7 +53,7 @@ from hal0.dispatcher._capability_resolve import (
 )
 from hal0.dispatcher.single_flight import SingleFlightGroup
 from hal0.errors import Hal0Error
-from hal0.slots.state import SlotState
+from hal0.slots.state import SlotCrashLooping, SlotState
 from hal0.upstreams.registry import Upstream, UpstreamRegistry
 
 if TYPE_CHECKING:
@@ -824,6 +824,12 @@ class Dispatcher:
         # declared device/profile picks the backend.
         try:
             await self._slot_manager.load(slot_name)
+        except SlotCrashLooping:
+            # Crash-loop breaker (issue i4): already a retryable 503 with
+            # Retry-After — surface it as-is. Must NOT fall through to the
+            # ERROR check below, which would re-wrap it into the
+            # non-retryable SlotLoadFailed 502.
+            raise
         except Exception as exc:
             log.warning(
                 "dispatch.backend_aware_load_failed",

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -99,6 +99,7 @@ from hal0.slots.state import (
     DISPATCHABLE_STATES,
     IllegalSlotTransition,
     SlotConfigError,
+    SlotCrashLooping,
     SlotNotFound,
     SlotPinned,
     SlotState,
@@ -159,6 +160,20 @@ class RegistryUnavailableError(Hal0Error):
 # NOTE: idle-monitor tunables (_IDLE_AFTER_S, _IDLE_MONITOR_INTERVAL_S,
 # _EVICT_AFTER_S) and _PINNED_BY_DEFAULT moved to hal0.slots.reaper
 # (P3-slots §1b) — imported + re-exported below.
+
+# Crash-loop breaker (issue i4): a load() from ERROR is throttled with
+# exponential backoff — min(base * 2**(failures-1), max) — and after
+# _CRASH_LOOP_PARK_AFTER consecutive failures the slot is parked (refuses
+# lazy-load until an operator action resets the breaker).
+_CRASH_LOOP_BASE_S = 5.0
+_CRASH_LOOP_MAX_S = 300.0
+_CRASH_LOOP_PARK_AFTER = 5
+
+# slot.state event coalescing window: identical ERROR-edged transition
+# pairs (error→starting / starting→error) within this window fold into
+# one emitted event carrying the repeat count, so a flap can't flood the
+# EventBus ring + durable activity journal.
+_FLAP_COALESCE_WINDOW_S = 60.0
 
 
 # ── Hook protocols ───────────────────────────────────────────────────────────
@@ -345,6 +360,16 @@ class SlotManager:
         self._cfg_cache: dict[int, tuple[int, int, dict[str, Any]]] = {}
         # In-memory copy of the latest state per slot (mirrors state.json).
         self._states: dict[int, SlotStateRecord] = {}
+        # Crash-loop breaker (issue i4): consecutive load-failure count +
+        # last-failure monotonic timestamp per slot. Incremented in load()'s
+        # except branch, cleared on a healthy transition (READY/IDLE) and by
+        # explicit operator actions (reset_load_failures).
+        self._load_failures: dict[int, tuple[int, float]] = {}
+        # slot.state flap coalescing: (slot key, "from→to") → (last emit
+        # monotonic ts, suppressed count). Tuple-keyed, so deliberately NOT
+        # in _KEY_DICTS_ATTR — a rename orphaning a coalesce record only
+        # costs one extra emitted event.
+        self._flap_emits: dict[tuple[int, str], tuple[float, int]] = {}
         # SSE subscribers: list of queues; one per active state_stream().
         self._subscribers: list[asyncio.Queue[SlotStateRecord]] = []
         # Idle-tracking — last request timestamp per slot.
@@ -705,6 +730,7 @@ class SlotManager:
         "_fail_watchers",
         "_serving_count",
         "_dispatch_tickets",
+        "_load_failures",
     )
 
     def _bind_key(self, name: str, key: int) -> None:
@@ -1160,6 +1186,14 @@ class SlotManager:
         carried_extra: dict[str, Any] = dict(prior.extra) if prior else {}
         if extra:
             carried_extra.update(extra)
+        if to_state in (SlotState.READY, SlotState.IDLE):
+            # Converged healthy — clear the crash-loop breaker and its
+            # carried extras. Covers load() success AND out-of-band
+            # recovery (adoption), so a healthy slot can never stay
+            # refused as "parked".
+            self._load_failures.pop(key, None)
+            carried_extra.pop("parked", None)
+            carried_extra.pop("load_failures", None)
         effective_model_id = (
             model_id if model_id is not None else (prior.model_id if prior else None)
         )
@@ -1237,14 +1271,31 @@ class SlotManager:
                 payload["model_id"] = record.model_id
             if message:
                 payload["error" if severity == "error" else "message"] = message
-            with contextlib.suppress(Exception):
-                await self._event_bus.emit(
-                    "slot.state",
-                    severity,
-                    f"slot:{name}",
-                    f"{name}: {current.value} → {to_state.value}",
-                    data=payload,
-                )
+            # Flap coalescing (issue i4, defense in depth): fold repeats of
+            # an identical ERROR-edged pair within the window into one event
+            # per window, ``repeats`` carrying the fold count so operators
+            # retain evidence. Non-error pairs are never coalesced.
+            emit = True
+            if SlotState.ERROR in (current, to_state):
+                pair = (key, f"{current.value}→{to_state.value}")
+                now = time.monotonic()
+                last_emit, folded = self._flap_emits.get(pair, (0.0, 0))
+                if now - last_emit < _FLAP_COALESCE_WINDOW_S:
+                    self._flap_emits[pair] = (last_emit, folded + 1)
+                    emit = False
+                else:
+                    if folded:
+                        payload["repeats"] = folded
+                    self._flap_emits[pair] = (now, 0)
+            if emit:
+                with contextlib.suppress(Exception):
+                    await self._event_bus.emit(
+                        "slot.state",
+                        severity,
+                        f"slot:{name}",
+                        f"{name}: {current.value} → {to_state.value}",
+                        data=payload,
+                    )
         # TIER1: spawn/cancel the push-driven fail-watcher to match the new
         # state.  Done after broadcast so the SSE frame for the transition
         # itself lands before any watcher-induced follow-up frame.
@@ -1316,6 +1367,55 @@ class SlotManager:
         """See :meth:`hal0.slots.watchdog.SlotWatchdog.readiness_check`."""
         return await self._watchdog.readiness_check(slot_name)
 
+    # ── crash-loop breaker (issue i4) ────────────────────────────────────────
+
+    def _check_crash_loop_gate(self, slot_name: str) -> None:
+        """Raise :class:`SlotCrashLooping` when an ERROR slot must not respawn yet.
+
+        Called from :meth:`load` (inside the slot lock, before any transition)
+        so a throttled retry costs nothing: no STARTING event, no journal row,
+        no systemctl call. ``details.retry_after_s`` rides the same error-
+        middleware promotion to a ``Retry-After`` header as ``SlotLoading``.
+        """
+        failures, last_failure = self._load_failures.get(self._key(slot_name), (0, 0.0))
+        if failures <= 0:
+            return
+        if failures >= _CRASH_LOOP_PARK_AFTER:
+            raise SlotCrashLooping(
+                f"slot {slot_name!r} is parked after {failures} consecutive load "
+                "failures — fix the cause, then load/restart it manually",
+                details={
+                    "slot": slot_name,
+                    "failures": failures,
+                    "parked": True,
+                    "retry_after_s": int(_CRASH_LOOP_MAX_S),
+                },
+            )
+        backoff_s = min(_CRASH_LOOP_BASE_S * (2 ** (failures - 1)), _CRASH_LOOP_MAX_S)
+        remaining = last_failure + backoff_s - time.monotonic()
+        if remaining > 0:
+            raise SlotCrashLooping(
+                f"slot {slot_name!r} failed {failures} consecutive load(s) — "
+                f"backing off {remaining:.0f}s before the next spawn attempt",
+                details={
+                    "slot": slot_name,
+                    "failures": failures,
+                    "retry_after_s": max(1, int(remaining) + 1),
+                },
+            )
+
+    def reset_load_failures(self, slot_name: str) -> None:
+        """Clear the crash-loop breaker for *slot_name* (operator intent).
+
+        Called by the manual API surfaces (POST /{name}/load, /restart) and
+        :meth:`update_config` — the operator presumably fixed the cause, so
+        the next load must run unthrottled. Dispatcher/v1 lazy-load callers
+        never reset; they go through the throttled path unchanged.
+        """
+        key = self._peek_key(self._resolve_alias(slot_name))
+        if key is not None:
+            self._load_failures.pop(key, None)
+
     # ── lifecycle ────────────────────────────────────────────────────────────
 
     async def load(self, slot_name: str, model_id: str | None = None) -> Slot:
@@ -1369,6 +1469,22 @@ class SlotManager:
                 await self._transition(slot_name, SlotState.OFFLINE, force=True)
                 # Fall through into the normal load below, which re-renders
                 # the unit from the current TOML.
+            elif current == SlotState.ERROR:
+                # Crash-loop breaker (issue i4): an ERROR slot is freely
+                # re-loadable per LEGAL_TRANSITIONS, but per-request lazy-
+                # load callers (dispatcher, v1 routes) must not respawn it
+                # at request cadence. Raises SlotCrashLooping (503 +
+                # Retry-After) with NO transition while the backoff window
+                # is open or the slot is parked.
+                self._check_crash_loop_gate(slot_name)
+                # Allowed retry — best-effort terminate + OFFLINE first
+                # (mirrors restart()'s ERROR branch) so the systemd
+                # start-limit state from the previous crash loop is
+                # actually cleared; otherwise backoff just spaces out
+                # guaranteed start-limit failures.
+                with contextlib.suppress(Exception):
+                    await self.terminate(slot_name)
+                await self._transition(slot_name, SlotState.OFFLINE, force=True)
 
             # Configuration check: a slot with no resolvable model is
             # NOT an ERROR (which would render red and flag for operator
@@ -1495,6 +1611,16 @@ class SlotManager:
                             },
                         )
             except Exception as exc:
+                # Crash-loop bookkeeping: consecutive failures drive the
+                # backoff/park gate above. ``parked`` rides ``extra`` (not a
+                # new enum value — wire/state-machine compatible) so the UI
+                # can render "parked — manual restart required".
+                key = self._key(slot_name)
+                failures = self._load_failures.get(key, (0, 0.0))[0] + 1
+                self._load_failures[key] = (failures, time.monotonic())
+                err_extra: dict[str, Any] = {"load_failures": failures}
+                if failures >= _CRASH_LOOP_PARK_AFTER:
+                    err_extra["parked"] = True
                 # TIER1: never swallow — record ERROR with details, re-raise.
                 await self._transition(
                     slot_name,
@@ -1502,6 +1628,7 @@ class SlotManager:
                     model_id=resolved_model,
                     port=_cfg_port(cfg),
                     message=str(exc),
+                    extra=err_extra,
                     force=True,
                 )
                 raise
@@ -1568,6 +1695,9 @@ class SlotManager:
         """
         slot_name = self._resolve_alias(slot_name)
         self._ensure_known(slot_name)
+        # Restart is operator intent — clear the crash-loop breaker so the
+        # reload below is never refused as SlotCrashLooping.
+        self.reset_load_failures(slot_name)
         if self._current_state(slot_name) == SlotState.ERROR:
             async with self._lock(slot_name):
                 # Best-effort cleanup of the wedged unit; never let a stuck
@@ -2305,6 +2435,10 @@ class SlotManager:
                     f"failed to rewrite {cfg_path}: {exc}",
                 ) from exc
             self._invalidate_cfg_cache(slot_name)
+
+        # Config edit is operator intent: the crash cause was presumably
+        # fixed, so the crash-loop breaker must not refuse the next load.
+        self.reset_load_failures(slot_name)
 
         # Issue #359: invalidate stale top-level metadata in state.json
         # whenever the operator's update changes a field that's also

--- a/src/hal0/slots/state.py
+++ b/src/hal0/slots/state.py
@@ -203,6 +203,23 @@ class SlotHealthFailed(SlotError):
     status = 503
 
 
+class SlotCrashLooping(SlotError):
+    """Load refused by the crash-loop breaker (issue i4).
+
+    A slot in ERROR is re-loadable, but not at request cadence: after a
+    load failure, further ``load()`` calls inside the exponential backoff
+    window — or against a slot parked after too many consecutive failures
+    — raise this WITHOUT any state transition (no STARTING event, no
+    journal row, no systemctl call).  ``details`` carries ``retry_after_s``
+    so the error middleware emits a ``Retry-After`` header exactly like
+    ``SlotLoading``; operator actions (manual load/restart, config edit)
+    reset the breaker.
+    """
+
+    code = "slot.crash_looping"
+    status = 503
+
+
 class SlotTerminateTimeout(SlotError):
     """The container stop did not return inside its timeout (#1224).
 
@@ -385,6 +402,7 @@ __all__ = [
     "IllegalSlotTransition",
     "NpuExclusivityViolation",
     "SlotConfigError",
+    "SlotCrashLooping",
     "SlotError",
     "SlotHealthFailed",
     "SlotNotFound",

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -389,6 +389,11 @@ class StackApplyEngine:
                 report.skipped.append(entry.slot)
                 return
             if snap is None or snap.state not in _DISPATCHABLE:
+                # Stack apply is operator intent — clear the crash-loop
+                # breaker (issue i4) so a parked slot gets a real attempt.
+                reset = getattr(self._slot_manager, "reset_load_failures", None)
+                if reset is not None:
+                    reset(entry.slot)
                 await self._slot_manager.load(entry.slot, model_id=entry.model)
                 report.loaded.append(entry.slot)
             elif snap.model_id != entry.model:

--- a/tests/dispatcher/test_router.py
+++ b/tests/dispatcher/test_router.py
@@ -612,6 +612,36 @@ async def test_forward_already_loaded_skips_load_and_forwards(
     assert json.loads(forwarded["body"]) == {"model": "chat"}
 
 
+@pytest.mark.asyncio
+async def test_forward_crash_looping_slot_surfaces_retryable_503() -> None:
+    """Issue i4: SlotCrashLooping from the crash-loop breaker surfaces as-is
+    (503 + retry_after_s) — never re-wrapped into the non-retryable
+    SlotLoadFailed 502 (#987)."""
+    from hal0.slots.state import SlotCrashLooping, SlotState
+
+    class _CrashLoopingSlotManager(_FakeSlotManager):
+        async def load(self, slot_name: str, model_id: str | None = None) -> None:
+            self.load_calls.append(slot_name)
+            raise SlotCrashLooping(
+                f"slot {slot_name!r} failed 3 consecutive load(s)",
+                details={"slot": slot_name, "failures": 3, "retry_after_s": 20},
+            )
+
+    sm = _CrashLoopingSlotManager(state=SlotState.ERROR)
+    dispatcher = Dispatcher(slot_manager=sm)  # type: ignore[arg-type]
+    call = UpstreamCall(
+        upstream_name="utility",
+        target_url="http://127.0.0.1:8085/v1/chat/completions",
+        body=json.dumps({"model": "utility"}).encode(),
+        slot_name="utility",
+    )
+    with pytest.raises(SlotCrashLooping) as exc_info:
+        await dispatcher.forward(call)
+    assert exc_info.value.status == 503
+    assert exc_info.value.details["retry_after_s"] == 20
+    assert sm.load_calls == ["utility"]
+
+
 # ── container-slot preemption over a stale registry binding ────────────────────
 
 

--- a/tests/slots/test_crash_loop_breaker.py
+++ b/tests/slots/test_crash_loop_breaker.py
@@ -1,0 +1,250 @@
+"""Crash-loop breaker: load() from ERROR is throttled, parked, and resettable.
+
+Issue i4: the "utility" slot flapped error→starting→error ~1/s because every
+background inference request re-ran the FULL load from ERROR — no failure
+counter, no backoff, no park state. ``load()`` now gates ERROR retries behind
+an exponential backoff (SlotCrashLooping, 503 + Retry-After, NO transition),
+parks the slot after ``_CRASH_LOOP_PARK_AFTER`` consecutive failures, and the
+breaker resets on operator intent (manual load/restart/config edit) and on
+any healthy convergence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.slots.manager import _CRASH_LOOP_PARK_AFTER, SlotManager
+from hal0.slots.state import SlotCrashLooping, SlotState
+from tests.slots.conftest import FakeContainerProvider
+
+
+async def _fail_load_once(sm: SlotManager, container_stub: FakeContainerProvider) -> None:
+    """One failed spawn → slot stamped ERROR, failure counted."""
+    container_stub.fail_load = RuntimeError("spawn boom")
+    with pytest.raises(RuntimeError):
+        await sm.load("chat")
+    assert sm._current_state("chat") == SlotState.ERROR
+
+
+def _rewind_backoff(sm: SlotManager) -> None:
+    """Move the last-failure timestamp far into the past so the window is open."""
+    key = sm._key("chat")
+    count, ts = sm._load_failures[key]
+    sm._load_failures[key] = (count, ts - 10_000.0)
+
+
+async def test_load_from_error_inside_backoff_raises_without_spawning(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A lazy-load retry inside the backoff window is refused cheaply:
+    no transition, no terminate, no systemctl — just SlotCrashLooping."""
+    sm = SlotManager()
+    await _fail_load_once(sm, container_stub)
+    unloads_before = len(container_stub.unload_calls)
+
+    with pytest.raises(SlotCrashLooping) as exc_info:
+        await sm.load("chat")
+
+    # Retryable 503 with a Retry-After hint for well-behaved clients.
+    assert exc_info.value.status == 503
+    assert exc_info.value.details["retry_after_s"] >= 1
+    # No transition happened — state stayed ERROR, nothing hit the provider.
+    assert sm._current_state("chat") == SlotState.ERROR
+    assert len(container_stub.unload_calls) == unloads_before
+    assert container_stub.load_calls == []
+
+
+async def test_load_from_error_after_backoff_clears_wedge_and_recovers(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """An allowed retry terminates the wedged unit first (clearing systemd's
+    start-limit state) and, with the fault fixed, converges to READY."""
+    sm = SlotManager()
+    await _fail_load_once(sm, container_stub)
+    _rewind_backoff(sm)
+
+    container_stub.fail_load = None
+    await sm.load("chat")
+
+    assert sm._current_state("chat") == SlotState.READY
+    assert container_stub.unload_calls, "retry from ERROR must terminate the wedged unit"
+    # Success clears the breaker and its carried extras.
+    key = sm._key("chat")
+    assert key not in sm._load_failures
+    rec = sm._states[key]
+    assert "parked" not in rec.extra
+    assert "load_failures" not in rec.extra
+
+
+async def test_parks_after_max_consecutive_failures(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """After N consecutive failures the slot parks: load() short-circuits
+    with SlotCrashLooping regardless of elapsed time."""
+    sm = SlotManager()
+    for _ in range(_CRASH_LOOP_PARK_AFTER):
+        await _fail_load_once(sm, container_stub)
+        _rewind_backoff(sm)
+
+    key = sm._key("chat")
+    rec = sm._states[key]
+    assert rec.extra["parked"] is True
+    assert rec.extra["load_failures"] == _CRASH_LOOP_PARK_AFTER
+
+    unloads_before = len(container_stub.unload_calls)
+    with pytest.raises(SlotCrashLooping) as exc_info:
+        await sm.load("chat")
+    assert exc_info.value.details["parked"] is True
+    # Parked refusal is free — no terminate, no spawn.
+    assert len(container_stub.unload_calls) == unloads_before
+    assert container_stub.load_calls == []
+
+
+async def test_manual_reset_unparks_and_load_recovers(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """reset_load_failures (the operator surface) clears the parked breaker;
+    the next load runs for real and a healthy convergence drops the flag."""
+    sm = SlotManager()
+    for _ in range(_CRASH_LOOP_PARK_AFTER):
+        await _fail_load_once(sm, container_stub)
+        _rewind_backoff(sm)
+
+    sm.reset_load_failures("chat")
+    container_stub.fail_load = None
+    await sm.load("chat")
+
+    key = sm._key("chat")
+    assert sm._current_state("chat") == SlotState.READY
+    assert key not in sm._load_failures
+    assert "parked" not in sm._states[key].extra
+
+
+async def test_restart_resets_breaker_and_recovers(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """restart() is operator intent — a parked slot restarts without tripping
+    the gate (#1224 semantics preserved)."""
+    sm = SlotManager()
+    for _ in range(_CRASH_LOOP_PARK_AFTER):
+        await _fail_load_once(sm, container_stub)
+        _rewind_backoff(sm)
+
+    container_stub.fail_load = None
+    await sm.restart("chat")
+
+    assert sm._current_state("chat") == SlotState.READY
+
+
+async def test_update_config_resets_breaker(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A config edit resets the breaker — the operator fixed the cause."""
+    sm = SlotManager()
+    await _fail_load_once(sm, container_stub)
+    assert sm._load_failures
+
+    await sm.update_config("chat", {"port": 8082})
+
+    assert sm._key("chat") not in sm._load_failures
+
+
+# ── slot.state flap coalescing (defense in depth) ────────────────────────────
+
+
+class _BusStub:
+    """Captures EventBus.emit calls (type, severity, source, message, data)."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, str, str, dict[str, Any] | None]] = []
+
+    async def emit(
+        self,
+        type_: str,
+        severity: str,
+        source: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        self.events.append((type_, severity, source, message, data))
+
+
+def _pairs(bus: _BusStub) -> list[tuple[str, str]]:
+    return [(e[4]["from"], e[4]["to"]) for e in bus.events if e[0] == "slot.state" and e[4]]
+
+
+async def test_repeated_flap_pairs_coalesce_within_window(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """Identical ERROR-edged transition pairs inside the window fold into a
+    single emitted event; the next emit after the window carries the count."""
+    bus = _BusStub()
+    sm = SlotManager(event_bus=bus)
+
+    await _fail_load_once(sm, container_stub)
+    _rewind_backoff(sm)
+    await _fail_load_once(sm, container_stub)  # second full flap
+    _rewind_backoff(sm)
+
+    # starting→error emitted exactly once — the repeat was folded.
+    assert _pairs(bus).count(("starting", "error")) == 1
+
+    # Expire the coalescing window: the next flap emits again, carrying the
+    # fold count so operators retain evidence of the suppressed repeats.
+    key = sm._key("chat")
+    last_emit, folded = sm._flap_emits[(key, "starting→error")]
+    assert folded == 1
+    sm._flap_emits[(key, "starting→error")] = (last_emit - 10_000.0, folded)
+
+    await _fail_load_once(sm, container_stub)
+
+    assert _pairs(bus).count(("starting", "error")) == 2
+    repeated = [
+        e[4]
+        for e in bus.events
+        if e[0] == "slot.state" and e[4] and e[4].get("from") == "starting" and "repeats" in e[4]
+    ]
+    assert repeated and repeated[-1]["repeats"] == 1
+
+
+async def test_non_error_transitions_are_never_coalesced(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """Healthy lifecycle pairs (offline→starting, warming→ready, …) always emit."""
+    bus = _BusStub()
+    sm = SlotManager(event_bus=bus)
+
+    await sm.load("chat")
+    await sm.unload("chat")
+    await sm.load("chat")
+
+    assert _pairs(bus).count(("offline", "starting")) == 2
+    assert _pairs(bus).count(("warming", "ready")) == 2
+
+
+async def test_backoff_gate_emits_no_events(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A throttled retry produces zero events — no starting, no error rows."""
+    bus = _BusStub()
+    sm = SlotManager(event_bus=bus)
+    await _fail_load_once(sm, container_stub)
+    n_events = len(bus.events)
+
+    for _ in range(10):
+        with pytest.raises(SlotCrashLooping):
+            await sm.load("chat")
+
+    assert len(bus.events) == n_events


### PR DESCRIPTION
## Problem

The `utility` slot flapped `error → starting → error` roughly once per second,
flooding the activity log and the durable journal. Every page refresh made it
look worse because the log replays history.

## Root cause

`SlotManager` had no failure counter, no backoff and no park state. Every
background request (honcho deriver, memory extraction, hermes) re-ran the full
load from `ERROR`, and `load()` from `ERROR` never cleared the wedged systemd
unit — so each attempt hit `start-limit-hit` and stamped a fresh transition
pair into the EventBus and the activity journal.

## Fix

Crash-loop breaker in `SlotManager`:

- Per-slot consecutive load-failure tracking, id-keyed and registered in
  `_KEY_DICTS_ATTR` so slot renames migrate it.
- `load()` from `ERROR` gates on exponential backoff
  (`min(5s * 2**(n-1), 300s)`). Inside the window it raises the new typed
  `SlotCrashLooping` (503, `slot.crash_looping`, `retry_after_s` surfaced as
  `Retry-After` by the existing error middleware) and emits **no transition** —
  no `STARTING` event, no journal row, no `systemctl` call.
- After 5 consecutive failures the slot parks, carrying
  `parked=true` / `load_failures=N` in `extra`. No new enum value, so the
  change is wire-compatible.

## Validation

- `865 passed` — `pytest tests/slots tests/dispatcher tests/stacks`
- `check_sunset.py` clean (195 <= baseline 195)
- `ruff format --check` clean on all changed files
- New coverage: `tests/slots/test_crash_loop_breaker.py` (250 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)