### PR TITLE
fix(test-infra): bound pytest's tmp_path retention so /tmp stops filling (#1490)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,18 @@ quote-style = "double"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 addopts = "-ra --strict-markers"
+# #1490: the HAL0_HOME/model-registry fixtures that ride pytest's `tmp_path`
+# write multi-GB payloads per run (measured: one generation at 6.3G), and
+# pytest's own default keeps the last 3 generations under
+# <tmpdir>/pytest-of-<user>/. On this project's dev boxes /tmp is routinely a
+# small tmpfs, so three concurrent/recent runs is enough to fill it and
+# ENOSPC every other tool on the host (including test-runner output capture
+# itself). Retain ONLY failed-test tmp_path dirs, and only the latest
+# generation of those — a passed test's fixture tree is disposable the
+# moment it passes; a failed one is exactly what you want left behind to
+# inspect. (pytest >=7.3; this repo pins >=8.3.)
+tmp_path_retention_count = 1
+tmp_path_retention_policy = "failed"
 # Environment-dependent markers (P4-tests, pulled forward from R5): tag tests
 # that shell out to a real host facility the *default* pytest run never
 # guarantees (a container runtime, a live systemd/journald, outbound

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import atexit
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -12,10 +14,18 @@ import pytest
 # Test collection must not import the application against the host's FHS
 # config. In particular, /etc/hal0/hal0.toml may be root-only on a deployed
 # machine. Set an isolated root before importing hal0.api below.
+#
+# #1490: unlike every other test's isolation root, this one is NOT a
+# `tmp_path`-family fixture dir, so pytest's own `tmp_path_retention_*`
+# settings never see it — it was leaking one directory per collection
+# forever. It's cheap (import-time scaffolding only, not a fixture that
+# writes model/registry payloads), but a leak is a leak; clean it up
+# ourselves at interpreter exit.
 _collection_hal0_home: str | None = None
 if not os.environ.get("HAL0_HOME") and not os.access("/etc/hal0/hal0.toml", os.R_OK):
     _collection_hal0_home = tempfile.mkdtemp(prefix="hal0-pytest-")
     os.environ["HAL0_HOME"] = _collection_hal0_home
+    atexit.register(shutil.rmtree, _collection_hal0_home, ignore_errors=True)
 
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402

--- a/tests/scripts/test_pytest_tmp_retention.py
+++ b/tests/scripts/test_pytest_tmp_retention.py
@@ -1,0 +1,47 @@
+"""#1490: pin the tmp_path retention settings that keep /tmp bounded.
+
+pytest's default policy keeps the last 3 generations of every `tmp_path`-family
+fixture dir under `<tmpdir>/pytest-of-<user>/`, and this suite's HAL0_HOME /
+model-registry fixtures write multi-GB payloads into them. On this project's
+dev boxes `/tmp` is routinely a small tmpfs, so a handful of runs is enough to
+ENOSPC the whole host — including, ironically, the test runner's own output
+capture. `tmp_path_retention_count = 1` + `tmp_path_retention_policy = "failed"`
+(pytest >=7.3) means a passed test's fixture tree is gone the moment the run
+that produced it ends; only genuinely-failed runs' trees survive, which is
+also the only case anyone actually wants to inspect one.
+
+This test only pins the config values are present and correctly typed in
+pyproject.toml — it does not exercise pytest's own retention machinery
+(that's pytest's problem, not this repo's), matching how
+tests/installer/test_preflight_python_floor.py pins the `requires-python`
+floor rather than re-testing CPython's own version parsing.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+
+def _pytest_ini_options() -> dict[str, object]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return data["tool"]["pytest"]["ini_options"]
+
+
+def test_tmp_path_retention_count_bounds_generations() -> None:
+    opts = _pytest_ini_options()
+    assert opts.get("tmp_path_retention_count") == 1, (
+        "tmp_path_retention_count must stay at 1 (or lower) — see #1490. "
+        "pytest's default of 3 is what let /tmp fill up in the first place."
+    )
+
+
+def test_tmp_path_retention_policy_keeps_only_failed() -> None:
+    opts = _pytest_ini_options()
+    assert opts.get("tmp_path_retention_policy") == "failed", (
+        "tmp_path_retention_policy must stay 'failed' — see #1490. A passed "
+        "test's fixture tree is disposable the instant the run ends; only a "
+        "failure is worth the disk to go inspect."
+    )


### PR DESCRIPTION
## Summary
- Sets `tmp_path_retention_count = 1` + `tmp_path_retention_policy = "failed"` in `pyproject.toml` — a passed test's fixture tree is gone the moment its run ends; only a genuine failure's tree survives.
- Cleans up the collection-time `HAL0_HOME` scratch dir in `tests/conftest.py` at interpreter exit — it's created via a raw `tempfile.mkdtemp` rather than a `tmp_path` fixture, so it was invisible to the retention setting above and leaked one directory per collection, forever.

Root cause per #1490: concurrent pytest runs' `HAL0_HOME`/model-registry fixtures write multi-GB payloads (one generation measured at 6.3G), and pytest's default keep-last-3-generations policy multiplied across runs filled the 16G dev-box tmpfs twice in one day, ENOSPC'ing every other tool on the host — including the test runner's own output capture.

## Test plan
- [x] `tests/scripts/test_pytest_tmp_retention.py` pins both new config values (matches the `test_preflight_python_floor.py` convention of pinning config rather than re-testing the underlying mechanism)
- [x] `tests/scripts/` full dir: 80 passed
- [x] `tests/config/` smoke run: 719 passed, 9 skipped, verified basetemp dirs are emptied (0 bytes) for every passed test rather than accumulating

Closes #1490.