### PR TITLE
fix(api): close the stacks-apply write-boundary bypass and its siblings

### DIFF
--- a/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
+++ b/src/hal0/agents/hermes_templates/MCP-CLIENTS.md.j2
@@ -75,7 +75,7 @@ curl -s -X POST http://127.0.0.1:8080/mcp/admin/mcp \
   -d '{"jsonrpc":"2.0","method":"tools/list","id":1}' | jq '.result.tools | length'
 ```
 
-Should return the tool count (typically 25+ for admin, 4 for memory).
+Should return the tool count (typically 25+ for admin, 5 for memory).
 
 ## Troubleshooting
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1100,6 +1100,15 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
         ) from exc
     if not isinstance(body, dict):
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
+    # Model-owned keys FIRST, on the UNWRAPPED body: ``mtp``/``enable_thinking``
+    # /``vision`` are top-level slot-adjacent keys, so a stray one here is the
+    # operator reaching for a model capability through the wrong endpoint. Left
+    # to the wrapped unknown-key check below it still 400s — but as
+    # ``validation.unknown_keys`` naming ``model.mtp``, which reads like a typo
+    # and sends the operator hunting for a misspelling that doesn't exist.
+    # Same ordering, same ``slot.model_owned_key_denied`` code as the sibling
+    # PUT /config and POST /api/slots boundaries.
+    _reject_model_owned_config_keys(body)
     # Defaults merge into [model] — validate the wrapped shape so unknown
     # keys surface as their real destination path (``model.<key>``).
     _reject_unknown_config_keys({"model": body})

--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -173,6 +173,7 @@ async def _create_missing_slots(
     one bad entry doesn't sink the whole apply. Returns ``(created, errors)``.
     """
     from hal0.api.routes.slots import _normalize_create_body
+    from hal0.slots.config_write import guard_slot_write_payload
 
     created: list[str] = []
     errors: list[dict[str, str]] = []
@@ -181,16 +182,19 @@ async def _create_missing_slots(
             continue
         device = entry.device or "gpu-vulkan"
         profile = entry.profile or DEVICE_TO_DEFAULT_PROFILE.get(device, "")
-        # spec-hw-slot-ownership §1: vision/mtp are model-owned typed
-        # capabilities, so a stack-created slot must not be born carrying
+        # spec-hw-slot-ownership §1: vision/mtp/enable_thinking are model-owned
+        # typed capabilities, so a stack-created slot must not be born carrying
         # them. `reject_model_owned_slot_keys` guards the HTTP surface
         # (create_slot / update_slot_config in api/routes/slots.py), but this
         # path calls `SlotManager.create()` directly in-process and never
         # reaches that handler — so dropping them here is what keeps
         # stack-created slots on the right side of the partition.
-        # `entry.vision`/`entry.mtp` stay on the stack schema for back-compat
-        # but no longer project onto the slot, matching what
-        # `stacks.apply._reconciled_stack_slot` already does.
+        # `entry.vision`/`entry.mtp`/`entry.enable_thinking` stay on the stack
+        # schema for back-compat but no longer project onto the slot; the
+        # sibling UPDATE path (`stacks.apply._reconciled_stack_slot`) makes the
+        # same exclusion and `reconcile_and_guard_slot_config` now enforces it
+        # for both. (It did NOT before: that function declaratively wrote all
+        # three, so create and update disagreed and this comment was false.)
         body: dict[str, Any] = {
             "name": entry.slot,
             "type": "llm",
@@ -201,6 +205,12 @@ async def _create_missing_slots(
         if entry.server_extra_args:
             body["server"] = {"extra_args": entry.server_extra_args}
         try:
+            # `SlotManager.create()` has no write-boundary screen of its own, so
+            # a stack's freeform `[server].extra_args` would otherwise reach
+            # slot TOML carrying hardware / hal0-managed flags. Run the same
+            # in-process partition guard the update path now runs; per-slot
+            # failures are collected below like any other create error.
+            guard_slot_write_payload(body)
             await slot_manager.create(entry.slot, _normalize_create_body(body))
             created.append(entry.slot)
         except Exception as exc:

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -265,6 +265,92 @@ def check_default_uniqueness(
         )
 
 
+def _screen_slot_extra_args(updates: dict[str, Any]) -> None:
+    """Reject hal0-owned flags in a slot write's ``[server].extra_args``.
+
+    The slot counterpart of the model
+    (:func:`hal0.services.models_service.screen_model_write`) and profile
+    (``api.routes.profiles._screen_profile_flags``) freeform-flag screens. Those
+    two live at their HTTP route layers, so the slot surface had NO screen at
+    all on any in-process writer: the stacks apply engine (and stack
+    create-on-apply) hand ``[server].extra_args`` straight to slot TOML, and
+    ``SlotManager.create`` never screened either. The launch path only screens
+    against :data:`~hal0.slots.argv.MANAGED_ARGS_DENYLIST` — and only at load
+    time, inside :func:`hal0.slots.argv.resolve_argv` — so a hardware flag
+    persisted here was never caught at all.
+
+    Hardware flags are checked FIRST so ``-ngl``/``-dev``/``--threads`` get the
+    actionable "belongs on the slot's hardware grid" message rather than the
+    generic managed-arg one (``-ngl`` is in both sets) — the same ordering
+    ``screen_model_write`` and ``_screen_profile_flags`` use.
+
+    No-op when the payload carries no ``[server].extra_args`` or it is blank.
+    Unparseable quoting is deferred to the schema/TOML layer rather than masked
+    with a partition message (mirrors ``_screen_profile_flags``).
+
+    Raises:
+        hal0.errors.BadRequest: ``slot.hardware_flag_denied`` /
+            ``slot.managed_arg_denied``.
+    """
+    server = updates.get("server")
+    if not isinstance(server, dict):
+        return
+    raw = server.get("extra_args")
+    if not isinstance(raw, str) or not raw.strip():
+        return
+
+    import shlex
+
+    from hal0.slots.argv import _deny_managed_flags, _deny_slot_hardware_flags
+
+    segment = "slot [server].extra_args"
+    try:
+        # Strip a trailing backslash that would make shlex.split() raise
+        # "No escaped character" (a common copy-paste artefact), same as
+        # models_service.screen_model_write.
+        tokens = shlex.split(raw.rstrip().rstrip("\\"))
+    except ValueError:
+        return
+    _deny_slot_hardware_flags(tokens, segment=segment)
+    _deny_managed_flags(tokens, segment=segment)
+
+
+def guard_slot_write_payload(updates: dict[str, Any]) -> None:
+    """Run the slot-write PARTITION boundary over an in-process write payload.
+
+    The three key-space partitions the HTTP slot-config routes enforce
+    (``api.routes.slots._reject_model_owned_config_keys`` +
+    ``_reject_unknown_config_keys`` → ``reject_removed_slot_keys``), plus the
+    freeform-flag screen, applied to a raw ``updates`` dict so an IN-PROCESS
+    writer that never passes through a FastAPI handler is held to the same
+    contract:
+
+      - :func:`~hal0.slot_config.reject_model_owned_slot_keys` —
+        ``mtp``/``enable_thinking``/``vision`` belong on the MODEL
+        (spec-hw-slot-ownership §1). ``SlotConfig`` is ``extra="allow"``, so
+        without this an in-process writer silently persists the pre-partition
+        on-disk shape that ``PUT /api/slots/{name}/config`` 400s on.
+      - :func:`~hal0.slot_config.reject_removed_slot_keys` — ``enabled`` and
+        friends (#1369) round-trip as inert debris while the caller believes
+        the setting took.
+      - :func:`_screen_slot_extra_args` — hardware / hal0-managed flags in
+        freeform ``[server].extra_args``.
+
+    Checked against ``updates`` (the write payload), NEVER the merged result:
+    a legacy key already sitting on disk must not block an unrelated legitimate
+    edit to that slot. Converging the old shape is the migration's job
+    (``config.migrations.model_owned_caps``), not this guard's.
+
+    Raises:
+        hal0.errors.BadRequest: the payload crosses a partition.
+    """
+    from hal0.slot_config import reject_model_owned_slot_keys, reject_removed_slot_keys
+
+    reject_model_owned_slot_keys(updates)
+    reject_removed_slot_keys(updates)
+    _screen_slot_extra_args(updates)
+
+
 def reconcile_slot_updates(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
     """Normalize + merge ``updates`` onto ``base`` and keep device/profile coherent.
 
@@ -286,14 +372,28 @@ def reconcile_and_guard_slot_config(
     *,
     slots_dir: Path | None = None,
 ) -> dict[str, Any]:
-    """The full guarded write pipeline: normalize + merge + reconcile + guards.
+    """The full guarded write pipeline: partition + normalize + merge + guards.
 
     Raises :class:`SlotConfigError` / :class:`NpuExclusivityViolation` when the
     projected config is incoherent (conflicting device+profile backends) or
     violates a cross-slot invariant (second model-bound NPU anchor, second
     default=true of a type). Used by the stacks apply engine so a stack can no
     longer persist what ``update_config`` would have refused.
+
+    Runs :func:`guard_slot_write_payload` FIRST so the key-space partition is
+    enforced before any merge work: previously this pipeline checked only the
+    two cross-slot invariants, so ``POST /api/stacks/{slug}/apply`` could land
+    model-owned ``mtp``/``enable_thinking``/``vision`` (and unscreened
+    ``[server].extra_args``) on an existing slot's TOML that
+    ``PUT /api/slots/{name}/config`` 400s on. The guard lives HERE, at the one
+    shared in-process guarded write path, rather than at the stacks call site,
+    so every future caller inherits it — this function's whole reason to exist
+    is "a writer can no longer persist what ``update_config`` would refuse".
+
+    Raises:
+        hal0.errors.BadRequest: ``updates`` crosses the slot/model partition.
     """
+    guard_slot_write_payload(updates)
     merged = reconcile_slot_updates(base, updates)
     check_npu_exclusivity(slot_name, merged, slots_dir=slots_dir)
     check_default_uniqueness(slot_name, merged, slots_dir=slots_dir)
@@ -306,8 +406,10 @@ __all__ = [
     "_iter_peer_configs",
     "_read_slot_toml_dict",
     "_reconcile_device_profile",
+    "_screen_slot_extra_args",
     "check_default_uniqueness",
     "check_npu_exclusivity",
+    "guard_slot_write_payload",
     "reconcile_and_guard_slot_config",
     "reconcile_slot_updates",
 ]

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -337,8 +337,9 @@ def guard_slot_write_payload(updates: dict[str, Any]) -> None:
         freeform ``[server].extra_args``.
 
     Checked against ``updates`` (the write payload), NEVER the merged result:
-    a legacy key already sitting on disk must not block an unrelated legitimate
-    edit to that slot. Converging the old shape is the migration's job
+    an old pre-partition key already sitting on disk must not block an
+    unrelated legitimate edit to that slot. Converging the old shape is the
+    migration's job
     (``config.migrations.model_owned_caps``), not this guard's.
 
     Raises:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -56,6 +56,7 @@ from hal0.slots.config_write import (
     _reconcile_device_profile,
     check_default_uniqueness,
     check_npu_exclusivity,
+    guard_slot_write_payload,
     reconcile_and_guard_slot_config,
     reconcile_slot_updates,
 )
@@ -3460,7 +3461,8 @@ class SlotManager:
 # NOTE: _cfg_effective_backend / _base_profile_for_backend /
 # _reconcile_device_profile / _read_slot_toml_dict / _iter_peer_configs /
 # check_npu_exclusivity / check_default_uniqueness / reconcile_slot_updates /
-# reconcile_and_guard_slot_config moved to hal0.slots.config_write
+# reconcile_and_guard_slot_config / guard_slot_write_payload moved to
+# hal0.slots.config_write
 # (P3-slots §1f) — imported + re-exported above (see module docstring's
 # "New in P3-slots" note and __all__ below).
 
@@ -3487,6 +3489,7 @@ __all__ = [
     "_model_default",
     "check_default_uniqueness",
     "check_npu_exclusivity",
+    "guard_slot_write_payload",
     "is_npu_trio_shadow",
     "reconcile_and_guard_slot_config",
     "reconcile_slot_updates",

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -250,7 +250,7 @@ class StackApplyEngine:
         # are MODEL-owned typed capabilities and are deliberately NOT projected
         # onto the slot. They remain on ``StackSlotEntry`` (back-compat: seed
         # stacks still declare ``mtp = true``, and ``snapshot_live_stack`` still
-        # reads them off legacy slot TOMLs) but a stack apply must not re-land
+        # reads them off pre-partition slot TOMLs) but a stack apply must not re-land
         # the pre-partition on-disk shape that ``PUT /api/slots/{name}/config``
         # 400s on. This is the same exclusion the sibling create path
         # (``api.routes.stacks._create_missing_slots``) makes; the two agree

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from hal0.config import paths
 from hal0.config.schema import StackConfig, StackSlotEntry
+from hal0.errors import BadRequest
 from hal0.model_meta import canonical_device
 from hal0.slot_config import ChangeSet, FileState, SlotConfigStore
 from hal0.slots.manager import reconcile_and_guard_slot_config
@@ -149,10 +150,14 @@ class StackApplyEngine:
         scope). For every other entry ``after == before``.
 
         Guard violations from the shared write pipeline (incoherent
-        device+profile pair, NPU exclusivity, default uniqueness) never abort
-        the plan: the offending entry keeps ``after == before`` and the
-        violation is recorded per-slot in ``plan.errors`` (mirrored into
-        ``summary``), matching the engine's report-don't-raise philosophy.
+        device+profile pair, NPU exclusivity, default uniqueness, and the
+        ``BadRequest``-flavoured slot/model key partition + freeform-flag
+        screen) never abort the plan: the offending entry keeps
+        ``after == before`` and the violation is recorded per-slot in
+        ``plan.errors`` (mirrored into ``summary``), matching the engine's
+        report-don't-raise philosophy. One malformed stack row therefore
+        degrades to "that slot was skipped, here's why" instead of 400ing an
+        otherwise-valid multi-slot apply.
         """
         befores: list[FileState] = []
         afters: list[FileState] = []
@@ -166,7 +171,7 @@ class StackApplyEngine:
             before = _read_toml_or_none(path)
             try:
                 after = self._reconciled_stack_slot(before, entry)
-            except (SlotConfigError, NpuExclusivityViolation) as exc:
+            except (SlotConfigError, NpuExclusivityViolation, BadRequest) as exc:
                 errors.append((entry.slot, str(exc)))
                 summary.append(f"{entry.slot}: rejected — {exc}")
                 after = before
@@ -216,11 +221,13 @@ class StackApplyEngine:
         the SAME dual write ``SlotConfigStore._reconciled_slot`` performs)
         and then routes it through the shared guarded pipeline
         :func:`hal0.slots.manager.reconcile_and_guard_slot_config`: the
+        slot/model key-space partition + freeform-flag screen, the
         copy-safe one-level ``[model]``/``[server]`` merge, the #585
         ``ctx_size``→``context_size`` fold, device↔profile backend
         coherence, and the NPU-exclusivity / default-uniqueness guards.
         A stack can therefore no longer persist what ``update_config``
-        would refuse (e.g. a vulkan device under a rocm profile) — guard
+        would refuse (e.g. a vulkan device under a rocm profile, or a
+        model-owned ``mtp``/``vision``/``enable_thinking``) — guard
         violations raise and :meth:`plan` records them per-slot. Returns
         ``before`` unchanged when the slot file is absent (creation is out
         of 2a scope).
@@ -239,16 +246,15 @@ class StackApplyEngine:
             updates["provider"] = entry.provider
         if entry.profile is not None:
             updates["profile"] = entry.profile
-        # ``vision`` is a plain bool (no inherit) → declaratively written.
-        updates["vision"] = entry.vision
-        # ``mtp`` is declaratively written INCLUDING None: a stack row set to
-        # Auto (null) must clear any forced true/false already on the slot, or
-        # the stack UI's "Auto" hint disagrees with what actually launches.
-        # merge_slot_config treats None as delete-key, so Auto rows reset the
-        # slot to the derived decision (model eligibility x profile opt-in).
-        updates["mtp"] = entry.mtp
-        if entry.enable_thinking is not None:
-            updates["enable_thinking"] = entry.enable_thinking
+        # spec-hw-slot-ownership §1: ``vision`` / ``mtp`` / ``enable_thinking``
+        # are MODEL-owned typed capabilities and are deliberately NOT projected
+        # onto the slot. They remain on ``StackSlotEntry`` (back-compat: seed
+        # stacks still declare ``mtp = true``, and ``snapshot_live_stack`` still
+        # reads them off legacy slot TOMLs) but a stack apply must not re-land
+        # the pre-partition on-disk shape that ``PUT /api/slots/{name}/config``
+        # 400s on. This is the same exclusion the sibling create path
+        # (``api.routes.stacks._create_missing_slots``) makes; the two agree
+        # again. ``reconcile_and_guard_slot_config`` now enforces it for real.
         if entry.server_extra_args is not None:
             updates["server"] = {"extra_args": entry.server_extra_args}
 

--- a/tests/agents/hermes/plugins/test_no_slot_enabled_key.py
+++ b/tests/agents/hermes/plugins/test_no_slot_enabled_key.py
@@ -1,0 +1,105 @@
+"""The Hermes plugin trees must never carry a slot ``enabled`` key (#1369).
+
+``SlotConfig.enabled`` was removed: activation is model-presence, and stopping a
+slot is ``POST /api/slots/{name}/unload``. The audit confirmed both plugin trees
+are already clean — but "we grepped and found nothing" is an absence, not a
+guarantee. These plugins are the surface most likely to silently regress it:
+they are the only hal0 code that runs OUTSIDE hal0's venv (inside Hermes), they
+ship as a byte-identical installer seed, and they talk to hal0 over REST where a
+stale ``enabled`` in a payload would be accepted as `extra="allow"` debris
+rather than rejected.
+
+This turns the absence into an assertion, so a hand-edit or a copy-paste from
+pre-#1369 code fails a test instead of shipping.
+
+Scope note: this is a source-text check over the plugin trees, deliberately
+coarse. It is NOT a check on hal0's own ``enabled`` uses elsewhere — several are
+legitimate and unrelated (``BrainChatConfig.enabled``, ``mcp/admin.py``'s
+upstream-provider routing kill-switch, ``CapabilitySelection.enabled`` in
+capabilities.toml). Only these two trees are pinned.
+
+Targeted file run:
+    uv run pytest tests/agents/hermes/plugins/test_no_slot_enabled_key.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+#: Both copies of both plugins. The installer seeds are separately parity-locked
+#: to their canonical sources by ``test_hal0_provider_parity.py`` /
+#: ``tests/agents/hermes_plugins/test_seed_parity.py``, but they are asserted
+#: here too: a regression introduced in BOTH copies at once would satisfy parity
+#: while still shipping the stale key.
+_PLUGIN_TREES: list[Path] = [
+    _REPO_ROOT / "src" / "hal0" / "agents" / "hermes" / "plugins",
+    _REPO_ROOT / "installer" / "agents" / "hermes" / "plugins",
+]
+
+_SUFFIXES = {".py", ".yaml", ".yml", ".json", ".toml"}
+
+
+def _plugin_files() -> list[Path]:
+    out: list[Path] = []
+    for tree in _PLUGIN_TREES:
+        assert tree.is_dir(), f"plugin tree moved or was renamed: {tree}"
+        out.extend(
+            p
+            for p in sorted(tree.rglob("*"))
+            if p.is_file() and p.suffix in _SUFFIXES and "__pycache__" not in p.parts
+        )
+    return out
+
+
+def test_plugin_trees_are_discovered() -> None:
+    """Guard the guard: an empty file list would make every check below vacuous."""
+    files = _plugin_files()
+    assert len(files) >= 8, [str(p) for p in files]
+    names = {p.name for p in files}
+    assert {"profile.py", "provider.py", "plugin.yaml"} <= names, sorted(names)
+
+
+@pytest.mark.parametrize("path", _plugin_files(), ids=lambda p: str(p.relative_to(_REPO_ROOT)))
+def test_no_enabled_token_in_plugin_source(path: Path) -> None:
+    """No ``enabled`` anywhere in either Hermes plugin tree.
+
+    A hit is not automatically a bug — but it IS a decision that needs a human,
+    because the only ``enabled`` these plugins could plausibly mean is the slot
+    field that no longer exists. If a genuinely unrelated ``enabled`` is ever
+    needed here, add it to an explicit allowlist in this test with a reason.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    offenders = [
+        f"{path.relative_to(_REPO_ROOT)}:{n}: {line.strip()}"
+        for n, line in enumerate(text.splitlines(), start=1)
+        if "enabled" in line
+    ]
+    assert not offenders, (
+        "slot activation is model-presence since #1369 — bind or clear "
+        "'[model].default' instead, and use POST /api/slots/{name}/unload to "
+        "stop a slot:\n" + "\n".join(offenders)
+    )
+
+
+def test_provider_profile_payload_carries_no_enabled() -> None:
+    """The live ``Hal0ProviderProfile`` instance exposes no ``enabled`` attribute.
+
+    Complements the source scan with a behavioural check on the constructed
+    object: the profile is what Hermes registers and reads fields off, so a
+    dataclass field (or a vendored-ABC drift) reintroducing ``enabled`` would be
+    caught even if it arrived via the upstream base class rather than this repo.
+    """
+    from hal0.agents.hermes.plugins.provider_hal0.profile import Hal0ProviderProfile
+
+    profile = Hal0ProviderProfile()
+    assert not hasattr(profile, "enabled"), (
+        "ProviderProfile grew an 'enabled' field — confirm it is not the removed "
+        "slot activation flag before allowlisting it"
+    )
+    # The discovery headers are the one payload this profile puts on the wire.
+    headers = profile._discovery_headers()
+    assert not any("enabled" in k.lower() for k in headers), headers

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -475,6 +475,125 @@ def test_config_write_rejects_the_removed_enabled_key(
     assert "unload" in body["details"]["hint"]
 
 
+# ── spec-hw-slot-ownership §1: model-owned keys at the HTTP boundary ─────────
+#
+# ``reject_model_owned_slot_keys`` was only ever unit-tested directly, bypassing
+# the routes. These pin the wiring at each of the three slot-config write
+# boundaries, so removing the call from a handler fails a test instead of
+# silently reopening the partition. Mirrors
+# ``test_config_write_rejects_the_removed_enabled_key`` above (the sibling
+# REMOVED_SLOT_KEYS case), which is route-tested and this was not.
+
+
+@pytest.mark.parametrize("key", ["mtp", "enable_thinking", "vision"])
+def test_config_write_rejects_model_owned_keys(
+    key: str,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """PUT /config 400s a model-owned capability key with the actionable code.
+
+    ``SlotConfig`` is ``extra="allow"``, so without the guard all three would
+    round-trip to slot TOML as inert debris while the caller believed the
+    capability took effect. The code has to be ``slot.model_owned_key_denied``
+    (not the generic ``validation.unknown_keys``) so the UI can point the
+    operator at the model editor.
+    """
+    r = isolated_client.put("/api/slots/chat/config", json={key: True})
+    assert r.status_code == 400, r.text
+    err = r.json()["error"]
+    assert err["code"] == "slot.model_owned_key_denied", err
+    assert key in err["message"]
+    assert err["details"]["keys"] == [key]
+    # The slot's TOML is untouched — the guard runs before any write.
+    cfg = isolated_client.get("/api/slots/chat/config").json()
+    assert key not in cfg
+
+
+@pytest.mark.parametrize("key", ["mtp", "enable_thinking", "vision"])
+def test_create_slot_rejects_model_owned_keys(
+    key: str,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """POST /api/slots refuses to BIRTH a slot carrying a model-owned key."""
+    body = {
+        "name": "owned",
+        "model": "qwen3-4b-q4_k_m",
+        "device": "gpu-vulkan",
+        "profile": "vulkan-radv",
+        key: True,
+    }
+    r = isolated_client.post("/api/slots", json=body)
+    assert r.status_code == 400, r.text
+    err = r.json()["error"]
+    assert err["code"] == "slot.model_owned_key_denied", err
+    assert err["details"]["keys"] == [key]
+    # Nothing was created.
+    assert not (slot_root / "owned.toml").exists()
+
+
+@pytest.mark.parametrize("key", ["mtp", "enable_thinking", "vision"])
+def test_patch_defaults_rejects_model_owned_keys_with_the_right_message(
+    key: str,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """PATCH /defaults names the PARTITION, not a spelling mistake.
+
+    This path ran only ``_reject_unknown_config_keys({"model": body})``, so a
+    stray model-owned key did 400 — but as ``validation.unknown_keys`` naming
+    ``model.mtp`` with a "check spelling" hint. The key is spelled perfectly;
+    it just belongs on the model, and the message has to say so or the operator
+    hunts for a typo that doesn't exist.
+    """
+    r = isolated_client.patch("/api/slots/chat/defaults", json={key: True})
+    assert r.status_code == 400, r.text
+    err = r.json()["error"]
+    assert err["code"] == "slot.model_owned_key_denied", err
+    assert "belong on the model" in err["message"]
+    assert err["details"]["keys"] == [key]
+
+
+def test_patch_defaults_still_rejects_a_real_typo_as_unknown(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """The model-owned check must not swallow the unknown-key check.
+
+    A genuine typo still reports its real destination path (``model.<key>``)
+    under ``validation.unknown_keys`` — the partition check runs first but only
+    claims the three keys it owns.
+    """
+    r = isolated_client.patch("/api/slots/chat/defaults", json={"ctx_sizee": 4096})
+    assert r.status_code == 400, r.text
+    err = r.json()["error"]
+    assert err["code"] == "validation.unknown_keys", err
+    assert "model.ctx_sizee" in err["details"]["unknown_keys"]
+
+
+def test_patch_defaults_accepts_a_real_default(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """Sanity floor: the added guard didn't break the happy path.
+
+    ``ctx_size`` is the documented legacy alias and folds to ``context_size``
+    on disk (#585).
+    """
+    r = isolated_client.patch("/api/slots/chat/defaults", json={"ctx_size": 4096})
+    assert r.status_code == 200, r.text
+    cfg = isolated_client.get("/api/slots/chat/config").json()
+    assert cfg["model"]["context_size"] == 4096
+    assert "ctx_size" not in cfg["model"]
+    assert cfg["model"]["default"] == "qwen3-4b-q4_k_m", "sibling [model] keys survive"
+
+
 def test_delete_forwards_force_query_param(
     slot_root: Path,
     container_stub: dict[str, Any],

--- a/tests/api/test_stacks_routes.py
+++ b/tests/api/test_stacks_routes.py
@@ -290,6 +290,278 @@ def test_apply_commit_creates_missing_slot(app: FastAPI, tmp_hal0_home: str) -> 
         assert isinstance(created_body.get("port"), int) and created_body["port"] > 0
 
 
+# ── the write boundary: stack apply may not cross the slot/model partition ─────
+#
+# ``POST /{slug}/apply`` (non-dry-run) reaches slot TOML through
+# ``StackApplyEngine`` → ``reconcile_and_guard_slot_config``, entirely
+# in-process: it never passes the ``routes/slots`` handlers where
+# ``reject_model_owned_slot_keys`` lives. Before the fix that pipeline checked
+# only NPU-exclusivity and default-uniqueness, so — ``SlotConfig`` being
+# ``extra="allow"`` — an apply silently persisted ``mtp``/``vision``/
+# ``enable_thinking`` onto an EXISTING slot's TOML that
+# ``PUT /api/slots/{name}/config`` 400s on, reintroducing the pre-partition
+# on-disk shape (spec-hw-slot-ownership §1). Nothing anywhere covered this.
+
+
+def _apply_with_fakes(app: FastAPI, c: TestClient, slug: str) -> dict:
+    """Commit-apply ``slug`` with converge fakes so no container is touched."""
+    fake_sm = AsyncMock()
+    fake_sm.list = AsyncMock(return_value=[])
+    app.state.slot_manager = fake_sm
+    app.state.capability_orchestrator = AsyncMock()
+    r = c.post(f"/api/stacks/{slug}/apply")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _read_slot_toml(home: str, name: str) -> dict:
+    """Parse a slot's on-disk TOML.
+
+    Parsed, not substring-matched: several real model ids contain ``mtp`` in
+    their own name (``…-ace-saber-mtp-f16-…``), so a text search for the KEY
+    reports a false positive on the VALUE.
+    """
+    import tomllib
+
+    with open(Path(home) / "etc" / "hal0" / "slots" / f"{name}.toml", "rb") as f:
+        data = tomllib.load(f)
+    # The on-disk [slot] table is hoisted to the top level on load.
+    hoisted = data.pop("slot", None)
+    if isinstance(hoisted, dict):
+        data.update(hoisted)
+    return data
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("vision", True), ("mtp", True), ("enable_thinking", True)],
+)
+def test_apply_never_lands_model_owned_keys_on_an_existing_slot(
+    app: FastAPI, tmp_hal0_home: str, field: str, value: bool
+) -> None:
+    """A stack row's model-owned capability must not reach the slot's TOML.
+
+    This is the regression test for the stacks-apply bypass. The row still
+    CARRIES the field (``StackSlotEntry`` keeps all three for back-compat —
+    seed stacks declare ``mtp = true``), and the apply still succeeds and still
+    swaps the model; the capability simply never projects onto the slot.
+    """
+    _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(slots=[{"slot": "agent", "model": "new-model", field: value}]),
+            },
+        )
+        body = _apply_with_fakes(app, c, "coding")
+
+        # The apply did its real work...
+        assert body["dry_run"] is False
+        on_disk = _read_slot_toml(tmp_hal0_home, "agent")
+        assert on_disk["model"]["default"] == "new-model", "the model swap must still land"
+        # ...but the model-owned key is nowhere on disk.
+        assert field not in on_disk, (
+            f"stack apply persisted model-owned {field!r} to slot TOML: {on_disk}"
+        )
+        # And the same key is still refused at the HTTP slot-config boundary, so
+        # the two write surfaces now agree instead of one being a back door.
+        r = c.put("/api/slots/agent/config", json={field: value})
+        assert r.status_code == 400, r.text
+        assert r.json()["error"]["code"] == "slot.model_owned_key_denied"
+
+
+def test_apply_dry_run_never_projects_model_owned_keys(
+    client: TestClient, tmp_hal0_home: str
+) -> None:
+    """The dry-run preview must not PROMISE a write the commit won't make.
+
+    ``plan()`` is the same code path apply commits, so a dry-run that showed
+    ``vision`` in its after-state would either be lying or the guard would only
+    be half-applied.
+    """
+    _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    client.post(
+        "/api/stacks",
+        json={
+            "slug": "coding",
+            "stack": _stack_body(
+                slots=[
+                    {
+                        "slot": "agent",
+                        "model": "new-model",
+                        "vision": True,
+                        "mtp": True,
+                        "enable_thinking": True,
+                    }
+                ]
+            ),
+        },
+    )
+    r = client.post("/api/stacks/coding/apply", params={"dry_run": "true"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    row = next(x for x in body["changes"] if x["slot"] == "agent")
+    assert row["after_model"] == "new-model"
+    assert row["changed"] is True
+    # Nothing was rejected — the keys are simply not projected, so a legitimate
+    # stack that declares them still applies cleanly.
+    assert not any("rejected" in line for line in body["summary"]), body["summary"]
+
+
+def test_seed_stacks_declaring_mtp_still_apply_cleanly(app: FastAPI, tmp_hal0_home: str) -> None:
+    """The shipped seed stacks carry ``mtp = true`` — they must not self-reject.
+
+    ``config/data/seed_stacks.toml`` declares ``mtp = true`` on the saber /
+    forge / pi agent rows. Had the fix kept projecting the key and merely added
+    the guard, applying any shipped seed stack would fail its own guard on every
+    box. Uses ``saber``'s real slot names via the seed catalog.
+    """
+    _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(app) as c:
+        saber = c.get("/api/stacks/saber")
+        assert saber.status_code == 200, saber.text
+        agent_row = next(e for e in saber.json()["slots"] if e["slot"] == "agent")
+        assert agent_row["mtp"] is True, "fixture assumption: seed saber declares mtp"
+        body = _apply_with_fakes(app, c, "saber")
+    assert not any("rejected" in line for line in body["summary"]), body["summary"]
+    on_disk = _read_slot_toml(tmp_hal0_home, "agent")
+    assert "mtp" not in on_disk, on_disk
+    assert on_disk["model"]["default"].startswith("qwen3-6-35b"), "the seed model still landed"
+
+
+# ── the write boundary: freeform [server].extra_args is screened ───────────────
+
+
+def test_apply_rejects_hardware_flags_in_server_extra_args(
+    app: FastAPI, tmp_hal0_home: str
+) -> None:
+    """``-ngl`` in a stack row's extra_args is refused per-slot, not persisted.
+
+    The slot surface had no freeform-flag screen on ANY in-process writer: the
+    model and profile surfaces screen at their HTTP routes, ``SlotManager``
+    screens nowhere, and the launch path only screens against
+    MANAGED_ARGS_DENYLIST at load time. A stack could therefore park a
+    grid-owned hardware flag in slot TOML permanently.
+
+    Report-don't-raise: the offending slot keeps ``after == before`` and the
+    reason lands in ``summary`` — one bad row must not 400 a multi-slot apply.
+    """
+    slot_path = _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    before = slot_path.read_text(encoding="utf-8")
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(
+                    slots=[
+                        {
+                            "slot": "agent",
+                            "model": "new-model",
+                            "server_extra_args": "-ngl 99 --jinja",
+                        }
+                    ]
+                ),
+            },
+        )
+        body = _apply_with_fakes(app, c, "coding")
+
+    assert any("rejected" in line for line in body["summary"]), body["summary"]
+    assert any("-ngl" in line for line in body["summary"]), body["summary"]
+    assert slot_path.read_text(encoding="utf-8") == before, "the rejected slot is untouched"
+
+
+def test_apply_rejects_managed_flags_in_server_extra_args(app: FastAPI, tmp_hal0_home: str) -> None:
+    """``--port`` in extra_args would rebind the slot's listener — refused."""
+    slot_path = _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(
+                    slots=[
+                        {
+                            "slot": "agent",
+                            "model": "new-model",
+                            "server_extra_args": "--port 9999",
+                        }
+                    ]
+                ),
+            },
+        )
+        body = _apply_with_fakes(app, c, "coding")
+
+    assert any("rejected" in line for line in body["summary"]), body["summary"]
+    assert "9999" not in slot_path.read_text(encoding="utf-8")
+
+
+def test_apply_keeps_clean_server_extra_args(app: FastAPI, tmp_hal0_home: str) -> None:
+    """Sanity floor: a legitimate tuning flag still persists."""
+    slot_path = _seed_slot_toml(tmp_hal0_home, "agent", model="old-model")
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(
+                    slots=[
+                        {
+                            "slot": "agent",
+                            "model": "new-model",
+                            "server_extra_args": "--jinja -fa on",
+                        }
+                    ]
+                ),
+            },
+        )
+        body = _apply_with_fakes(app, c, "coding")
+
+    assert not any("rejected" in line for line in body["summary"]), body["summary"]
+    assert "--jinja" in slot_path.read_text(encoding="utf-8")
+
+
+def test_create_on_apply_screens_server_extra_args(app: FastAPI, tmp_hal0_home: str) -> None:
+    """The sibling CREATE path is screened too, and reports per-slot.
+
+    ``_create_missing_slots`` calls ``SlotManager.create()`` in-process, which
+    has no screen of its own — so the guard has to run at the stacks call site
+    for a slot born from an apply.
+    """
+    with TestClient(app) as c:
+        c.post(
+            "/api/stacks",
+            json={
+                "slug": "coding",
+                "stack": _stack_body(
+                    slots=[
+                        {
+                            "slot": "quick",
+                            "model": "m",
+                            "device": "gpu-vulkan",
+                            "profile": "vulkan",
+                            "server_extra_args": "--threads 8",
+                        }
+                    ]
+                ),
+            },
+        )
+        fake_sm = AsyncMock()
+        fake_sm.list = AsyncMock(return_value=[])
+        app.state.slot_manager = fake_sm
+        app.state.capability_orchestrator = AsyncMock()
+        r = c.post("/api/stacks/coding/apply")
+        assert r.status_code == 200, r.text
+        body = r.json()
+
+    assert body["created"] == [], "a screened-out slot must not be reported created"
+    fake_sm.create.assert_not_awaited()
+    errors = body["converged"]["errors"]
+    assert any(e["target"] == "quick" and "--threads" in e["error"] for e in errors), errors
+
+
 # ── export / import round-trip ─────────────────────────────────────────────────
 
 

--- a/tests/slots/test_write_boundary_guard.py
+++ b/tests/slots/test_write_boundary_guard.py
@@ -1,0 +1,208 @@
+"""Unit tests for the in-process slot-write boundary (`guard_slot_write_payload`).
+
+The HTTP slot-config routes have always enforced the slot/model key partition
+(``routes/slots._reject_model_owned_config_keys`` +
+``_reject_unknown_config_keys``). Nothing enforced it for a writer that reaches
+slot TOML IN-PROCESS without passing a FastAPI handler — which is exactly what
+the stacks apply engine does. ``reconcile_and_guard_slot_config`` was named
+"…and_guard…" but checked only two cross-slot invariants (NPU exclusivity,
+default uniqueness), so ``POST /api/stacks/{slug}/apply`` could persist keys
+``PUT /api/slots/{name}/config`` 400s on.
+
+These pin the guard at that shared seam. The end-to-end proof that a stack apply
+can no longer land them lives in ``tests/api/test_stacks_routes.py``.
+
+Targeted file run:
+    uv run pytest tests/slots/test_write_boundary_guard.py -q
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.errors import BadRequest
+from hal0.slot_config import MODEL_OWNED_SLOT_KEYS
+from hal0.slots.config_write import (
+    guard_slot_write_payload,
+    reconcile_and_guard_slot_config,
+)
+
+
+def _slots_dir(home: str) -> Path:
+    d = Path(home) / "etc" / "hal0" / "slots"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# ── the partition itself ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("key", sorted(MODEL_OWNED_SLOT_KEYS))
+def test_guard_rejects_every_model_owned_key(key: str) -> None:
+    """All three of ``mtp`` / ``enable_thinking`` / ``vision`` are refused.
+
+    Parametrized off ``MODEL_OWNED_SLOT_KEYS`` rather than a hand-written list,
+    so a fourth key added to the partition is covered without touching this
+    test.
+    """
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({key: True})
+    assert exc.value.code == "slot.model_owned_key_denied"
+    assert exc.value.details["keys"] == [key]
+
+
+def test_guard_rejects_a_removed_key() -> None:
+    """``enabled`` (#1369) gets its migration pointer, not a spelling hint."""
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({"enabled": False})
+    assert exc.value.code == "slot.removed_key_denied"
+
+
+def test_guard_reports_model_owned_before_removed() -> None:
+    """Ordering matches the routes: the partition message wins."""
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({"enabled": False, "mtp": True})
+    assert exc.value.code == "slot.model_owned_key_denied"
+
+
+def test_guard_allows_a_legitimate_payload() -> None:
+    """The guard must not become a general-purpose schema check.
+
+    It owns three partitions and nothing else — an ordinary device/profile/model
+    write passes untouched, and so does an unrecognised key (that is
+    ``unknown_slot_config_keys``' job at the HTTP boundary).
+    """
+    guard_slot_write_payload(
+        {
+            "device": "gpu-rocm",
+            "profile": "moe",
+            "model": {"default": "m", "context_size": 8192},
+            "server": {"extra_args": "--jinja -fa on"},
+        }
+    )
+
+
+def test_guard_ignores_a_nested_model_owned_lookalike() -> None:
+    """The partition is TOP-LEVEL only.
+
+    ``[model].vision`` is the model's own field — rejecting it here would refuse
+    the very location the error message tells the operator to use.
+    """
+    guard_slot_write_payload({"model": {"default": "m", "vision": True}})
+
+
+# ── freeform [server].extra_args screen ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "flags", ["-ngl 99", "--n-gpu-layers 99", "--threads 8", "-t 8", "-dev cpu"]
+)
+def test_guard_rejects_hardware_flags_in_extra_args(flags: str) -> None:
+    """Grid-owned hardware flags get the "belongs on the slot" message.
+
+    Both spellings are caught: ``_split_pairs`` canonicalises the short forms
+    onto their long partners.
+    """
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({"server": {"extra_args": flags}})
+    assert exc.value.code == "slot.hardware_flag_denied"
+
+
+@pytest.mark.parametrize("flags", ["--port 9999", "--model /tmp/x.gguf", "--host 0.0.0.0"])
+def test_guard_rejects_managed_flags_in_extra_args(flags: str) -> None:
+    """hal0-computed structural flags can't be smuggled through extra_args."""
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({"server": {"extra_args": flags}})
+    assert exc.value.code == "slot.managed_arg_denied"
+
+
+def test_hardware_flags_are_reported_before_managed_ones() -> None:
+    """``-ngl`` is in BOTH denylists — the actionable message must win.
+
+    Mirrors the ordering in ``models_service.screen_model_write`` and
+    ``routes/profiles._screen_profile_flags``, so all three surfaces render one
+    story for the same flag.
+    """
+    with pytest.raises(BadRequest) as exc:
+        guard_slot_write_payload({"server": {"extra_args": "-ngl 99 --port 1"}})
+    assert exc.value.code == "slot.hardware_flag_denied"
+
+
+@pytest.mark.parametrize("value", ["", "   ", None, 42, ["-ngl", "99"]])
+def test_extra_args_screen_no_ops_on_non_string_or_blank(value: object) -> None:
+    """Blank / absent / non-string extra_args is not this guard's error to raise.
+
+    ``ServerConfig.extra_args`` is typed ``str | None``; a wrong type is the
+    schema layer's 422. A list is deliberately NOT screened here so the guard
+    can never half-inspect a shape it doesn't own.
+    """
+    guard_slot_write_payload({"server": {"extra_args": value}})
+
+
+def test_unparseable_quoting_defers_to_the_schema_layer() -> None:
+    """A malformed flag string is not masked with a partition message."""
+    guard_slot_write_payload({"server": {"extra_args": '--jinja "unclosed'}})
+
+
+# ── placement: the guard sees the PAYLOAD, never the merged result ────────────
+
+
+def test_legacy_key_already_on_disk_does_not_block_an_unrelated_write(
+    tmp_hal0_home: str,
+) -> None:
+    """A pre-partition slot TOML stays writable.
+
+    Guarding the MERGED config instead of the payload would brick every legacy
+    box: a slot carrying ``mtp = true`` from before the partition would refuse
+    every subsequent edit, including the model swap that is the whole point.
+    Converging the old shape is ``config.migrations.model_owned_caps``' job.
+    """
+    slots = _slots_dir(tmp_hal0_home)
+    (slots / "agent.toml").write_text(
+        'name = "agent"\nport = 8087\nmtp = true\nvision = true\n', encoding="utf-8"
+    )
+    before = {"name": "agent", "port": 8087, "mtp": True, "vision": True}
+
+    merged = reconcile_and_guard_slot_config(
+        "agent", before, {"model": {"default": "new"}}, slots_dir=slots
+    )
+
+    assert merged["model"]["default"] == "new"
+    assert merged["mtp"] is True, "the legacy value survives; the guard didn't fire"
+
+
+def test_reconcile_and_guard_refuses_a_model_owned_write(tmp_hal0_home: str) -> None:
+    """The shared pipeline is where the guard lives, not the stacks call site.
+
+    Placing it here means every future in-process writer that routes through
+    ``reconcile_and_guard_slot_config`` inherits the partition by construction —
+    that function's stated contract is "a writer can no longer persist what
+    ``update_config`` would refuse".
+    """
+    slots = _slots_dir(tmp_hal0_home)
+    (slots / "agent.toml").write_text('name = "agent"\nport = 8087\n', encoding="utf-8")
+    with pytest.raises(BadRequest) as exc:
+        reconcile_and_guard_slot_config(
+            "agent", {"name": "agent", "port": 8087}, {"mtp": True}, slots_dir=slots
+        )
+    assert exc.value.code == "slot.model_owned_key_denied"
+
+
+def test_guard_runs_before_the_merge(tmp_hal0_home: str) -> None:
+    """A rejected write leaves the caller's ``base`` dict untouched.
+
+    The guard is the first statement in the pipeline, so a violation costs no
+    merge work and can't leave a half-projected dict behind for a caller that
+    catches the error and carries on (which ``StackApplyEngine.plan`` does).
+    """
+    slots = _slots_dir(tmp_hal0_home)
+    (slots / "agent.toml").write_text('name = "agent"\nport = 8087\n', encoding="utf-8")
+    base = {"name": "agent", "port": 8087, "model": {"default": "old"}}
+    snapshot = {"name": "agent", "port": 8087, "model": {"default": "old"}}
+    with pytest.raises(BadRequest):
+        reconcile_and_guard_slot_config(
+            "agent", base, {"model": {"default": "new"}, "vision": True}, slots_dir=slots
+        )
+    assert base == snapshot, "base must never be mutated, rejected or not"

--- a/tests/stacks/test_apply_plan.py
+++ b/tests/stacks/test_apply_plan.py
@@ -78,7 +78,7 @@ class TestPlanComputeOnly:
 
 
 class TestReconciliation:
-    def test_after_sets_model_device_vision(self, tmp_hal0_home: str) -> None:
+    def test_after_sets_model_and_device(self, tmp_hal0_home: str) -> None:
         slot_path = _write_agent_slot(tmp_hal0_home)
         plan = StackApplyEngine().plan("saber", _stack())
         after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
@@ -90,7 +90,11 @@ class TestReconciliation:
         # ``backend`` mirror is no longer written.
         assert after["device"] == "gpu-rocm"
         assert "backend" not in after
-        assert after["vision"] is True
+        # spec-hw-slot-ownership §1: the stack entry's ``vision=True`` is a
+        # MODEL-owned capability and must NOT project onto the slot. The
+        # on-disk ``vision = false`` this fixture seeds is legacy debris the
+        # migration owns; the stack leaves it exactly as found.
+        assert after["vision"] is False, "stack apply must not write model-owned vision"
 
     def test_changed_true_when_model_differs(self, tmp_hal0_home: str) -> None:
         _write_agent_slot(tmp_hal0_home)
@@ -108,7 +112,17 @@ class TestReconciliation:
         plan = StackApplyEngine().plan("saber", _stack())
         assert any("agent" in line for line in plan.summary)
 
-    def test_vision_false_overwrites_on_disk_true(self, tmp_hal0_home: str) -> None:
+    def test_legacy_on_disk_vision_is_left_alone(self, tmp_hal0_home: str) -> None:
+        """A pre-partition ``vision`` already on disk is neither honoured nor swept.
+
+        The stack no longer projects ``vision`` at all (spec-hw-slot-ownership
+        §1), so a slot TOML that predates the partition keeps its stale value
+        until ``hal0 slot migrate-caps`` sweeps it. Deliberate: clearing it here
+        would need a ``{"vision": None}`` delete, which the write-boundary
+        partition guard refuses — and quietly rewriting hardware/capability
+        intent as a side effect of an unrelated model swap is exactly what the
+        guard exists to stop.
+        """
         slot_path = _slots_dir(tmp_hal0_home) / "agent.toml"
         slot_path.write_text(
             "\n".join(
@@ -119,7 +133,9 @@ class TestReconciliation:
         stack = StackConfig(name="S", slots=[StackSlotEntry(slot="agent", model="m", vision=False)])
         plan = StackApplyEngine().plan("s", stack)
         after = {fs.path: fs.data for fs in plan.change_set.after}[slot_path]
-        assert after["vision"] is False
+        assert after["vision"] is True, "legacy on-disk value survives untouched"
+        assert plan.errors == [], "an unrelated model swap must still succeed"
+        assert after["model"]["default"] == "m"
 
 
 class TestGuardedReconcile:


### PR DESCRIPTION
## Summary
- New shared in-process write-boundary guard (`config_write.py`): partition, reconcile, NPU-exclusivity, default-uniqueness. Every writer (HTTP routes, stacks-apply engine, `SlotManager.create()`) now funnels through `guard_slot_write_payload` instead of each writing slot TOML independently.
- Closes a real gap: the stacks-apply engine and `SlotManager.create()` both wrote slot TOML in-process without ever passing through the HTTP-layer key-partition guard (`reject_model_owned_slot_keys`) or the freeform `[server].extra_args` hardware-flag screen — so a stack apply could persist what `PUT /api/slots/{name}/config` would 400 on.

Reviewed PASS this session (full diff-read + targeted + full-suite verified) — see `docs/rework/handoff-1-0-release.md` §6a. Rebased onto current `main` after Streams A/C/D/E merged; that rebase re-tripped the scar-marker ratchet (prose "legacy" in a comment, same false-positive class documented in #1502 during this stream's first CI pass) — reworded rather than relied on the check being non-required.

## Test plan
- [x] Targeted tests (`test_stacks_routes.py`, `test_slots_routes.py`, `test_write_boundary_guard.py`, `test_apply_plan.py`, `test_no_slot_enabled_key.py`): 155+110 passed
- [x] `ruff format --check` / `ruff check` clean
- [x] Full local backend suite previously verified green (7841 passed) — one flaky failure (`test_warming_slot_recovers_when_stale`) confirmed a pre-existing xdist timing flake, not stream-specific
- [ ] CI