### PR TITLE
fix(slots): don't re-check default uniqueness on unrelated field edits

### DIFF
--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -309,7 +309,9 @@ def reconcile_and_guard_slot_config(
     """
     merged = reconcile_slot_updates(base, updates)
     check_npu_exclusivity(slot_name, merged, slots_dir=slots_dir)
-    check_default_uniqueness(slot_name, merged, slots_dir=slots_dir, changed_keys=set(updates.keys()))
+    check_default_uniqueness(
+        slot_name, merged, slots_dir=slots_dir, changed_keys=set(updates.keys())
+    )
     return merged
 
 

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -236,13 +236,26 @@ def check_default_uniqueness(
     cfg_dict: dict[str, Any],
     *,
     slots_dir: Path | None = None,
+    changed_keys: set[str] | None = None,
 ) -> None:
     """Reject a write that would land a second ``default=true`` per type.
 
     Sync core of :meth:`SlotManager._check_default_uniqueness` (see its
     docstring for the full contract), shared with the stacks apply engine.
+
+    ``changed_keys`` is the set of keys the caller's *update* actually
+    touched (``None`` at create time, where every field is new so the
+    merged ``cfg_dict`` is checked unconditionally). A partial update that
+    carries a pre-existing ``default=true`` forward without changing it
+    must not re-trigger this guard just because a stale duplicate already
+    sits on disk — that would permanently brick edits to any field on a
+    slot that already has (possibly duplicate) ``default=true`` state.
+    Retroactive cleanup of stale duplicates is ``default_slot_for``'s job
+    at routing time, not this write-time guard's.
     """
     if cfg_dict.get("default") is not True:
+        return
+    if changed_keys is not None and "default" not in changed_keys:
         return
     type_ = cfg_dict.get("type")
     if not type_:
@@ -296,7 +309,7 @@ def reconcile_and_guard_slot_config(
     """
     merged = reconcile_slot_updates(base, updates)
     check_npu_exclusivity(slot_name, merged, slots_dir=slots_dir)
-    check_default_uniqueness(slot_name, merged, slots_dir=slots_dir)
+    check_default_uniqueness(slot_name, merged, slots_dir=slots_dir, changed_keys=set(updates.keys()))
     return merged
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2427,8 +2427,11 @@ class SlotManager:
             # only on the pre-existing config) is checked against the merged
             # cfg_dict — the authoritative post-merge state, same as the NPU
             # guard. The peer walk excludes slot_name, so re-persisting the
-            # sole default never self-conflicts.
-            await self._check_default_uniqueness(slot_name, cfg_dict)
+            # sole default never self-conflicts. Gated on changed_keys so an
+            # edit to an unrelated field (e.g. context size) on a slot that
+            # already carries default=true doesn't get blocked by some other
+            # stale duplicate default already sitting on disk (#1500).
+            await self._check_default_uniqueness(slot_name, cfg_dict, changed_keys=set(updates.keys()))
 
             try:
                 write_slot_toml(cfg_path, cfg_dict)
@@ -2676,6 +2679,8 @@ class SlotManager:
         self,
         slot_name: str,
         cfg_dict: dict[str, Any],
+        *,
+        changed_keys: set[str] | None = None,
     ) -> None:
         """Reject a write that would land a second ``default=true`` per type.
 
@@ -2704,9 +2709,13 @@ class SlotManager:
         Thin async wrapper (kept for the public method surface and test
         monkeypatchability) over the module-level sync
         :func:`check_default_uniqueness`, which the stacks apply engine
-        shares so its writes obey the same guard.
+        shares so its writes obey the same guard. ``changed_keys`` is
+        threaded through so an ``update_config()`` PATCH that never
+        touches ``default`` doesn't get blocked by a pre-existing stale
+        duplicate elsewhere on disk (that write-time collision check only
+        fires when this write is the one setting ``default=true``).
         """
-        check_default_uniqueness(slot_name, cfg_dict)
+        check_default_uniqueness(slot_name, cfg_dict, changed_keys=changed_keys)
 
     # ── idle / wake-on-request ───────────────────────────────────────────────
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2431,7 +2431,9 @@ class SlotManager:
             # edit to an unrelated field (e.g. context size) on a slot that
             # already carries default=true doesn't get blocked by some other
             # stale duplicate default already sitting on disk (#1500).
-            await self._check_default_uniqueness(slot_name, cfg_dict, changed_keys=set(updates.keys()))
+            await self._check_default_uniqueness(
+                slot_name, cfg_dict, changed_keys=set(updates.keys())
+            )
 
             try:
                 write_slot_toml(cfg_path, cfg_dict)

--- a/tests/slots/test_default_uniqueness.py
+++ b/tests/slots/test_default_uniqueness.py
@@ -169,3 +169,21 @@ async def test_update_config_sole_default_does_not_self_conflict(slot_root: Path
     _write_slot(slot_root, "a", slot_type="llm", default=True)
     sm = SlotManager()
     await sm.update_config("a", {"model": {"context_size": 4096}})
+
+
+@pytest.mark.asyncio
+async def test_update_config_unrelated_field_not_blocked_by_stale_peer_default(
+    slot_root: Path,
+) -> None:
+    """A pre-existing stale duplicate default must not brick unrelated edits.
+
+    Two ``default=true`` slots of the same type can already be sitting on
+    disk (e.g. seeded outside SlotManager, or left over from before this
+    guard existed). Editing an unrelated field on either one must still
+    succeed — cleanup of the stale duplicate is ``default_slot_for``'s job
+    at routing time, not this write-time guard's (#1500).
+    """
+    _write_slot(slot_root, "a", slot_type="llm", default=True)
+    _write_slot(slot_root, "b", slot_type="llm", default=True)
+    sm = SlotManager()
+    await sm.update_config("a", {"model": {"context_size": 4096}})


### PR DESCRIPTION
## Summary
- `check_default_uniqueness()` fired on every `update_config()` write whose merged config carried `default=true`, even when the caller's PATCH never touched `default`. A slot that already legitimately carries `default=true` (or has a pre-existing stale duplicate default from before this guard existed) could never have any other field edited — e.g. bumping `context_size` on the dashboard's slot edit drawer failed with `slot type 'llm' already has a default=true slot`.
- Gated the check on `changed_keys`: it now only fires when the write is the one actually setting `default=true`. Retroactive cleanup of a stale duplicate stays `default_slot_for`'s job at routing time (matches what the guard's own docstring already claimed but didn't implement).

## Test plan
- [x] `tests/slots/test_default_uniqueness.py` — added `test_update_config_unrelated_field_not_blocked_by_stale_peer_default`, all 8 tests pass
- [x] `tests/slots/` full suite — 658 passed