### PR TITLE
fix(profiles): make the hardware hints inert by default and keep legacy profiles editable

### DIFF
--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -273,7 +273,10 @@ async def import_profile_route(request: Request, response: Response) -> dict[str
     # for those, and reporting a checksum mismatch for `{"kind": "nope"}` would
     # point the operator at the wrong problem.
     env = parse_envelope(envelope)
-    if isinstance(envelope, dict) and not force and not verify_checksum(envelope):
+    # A missing/empty checksum is not corruption (hand-authored envelopes
+    # legitimately omit it) — only a checksum that is PRESENT and WRONG is
+    # rejected. Mirrors import_profile()'s own check in profiles/portable.py.
+    if isinstance(envelope, dict) and not force and env.checksum and not verify_checksum(envelope):
         raise BadRequest(
             "envelope checksum does not match its profile body — the file was "
             "hand-edited or corrupted in transit. Re-export it, or pass "
@@ -290,7 +293,7 @@ async def import_profile_route(request: Request, response: Response) -> dict[str
     async with record_action(
         request, category="profile", action="profile.import", target=name
     ) as rec:
-        resolved = import_profile(envelope, name, ProfileCatalog())
+        resolved = import_profile(envelope, name, ProfileCatalog(), force=force)
         rec.after = {"name": name}
     response.status_code = 201
     return {"dry_run": False, "profile": resolved.to_dict()}

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -58,13 +58,21 @@ class ProfileBody(BaseModel):
     )
     flags: str = Field(default="", description="Bench-tuned llama-server CLI flags.")
     mtp: bool = Field(default=False, description="Append MTP bundle to flags when True.")
-    device_class: Literal["gpu", "cpu", "npu", "img"] = Field(
-        default="gpu",
-        description="Device class this profile targets.",
-    )
-    backend: Literal["rocm", "vulkan"] | None = Field(
+    device_class: Literal["gpu", "cpu", "npu", "img"] | None = Field(
         default=None,
-        description="GPU runtime (rocm|vulkan); None for non-GPU profiles.",
+        description=(
+            "INERT match-only fit hint — selects no hardware. None (the default) "
+            "means device-agnostic, which is what every shipped seed is and what "
+            "a tuning-only profile should be. Was `'gpu'`, which silently "
+            "stamped a hardware claim onto every profile created without one."
+        ),
+    )
+    backend: Literal["rocm", "vulkan", "cuda"] | None = Field(
+        default=None,
+        description=(
+            "INERT match-only fit hint (rocm|vulkan|cuda); None for non-GPU "
+            "profiles. Selects no runtime — the slot's `device` does."
+        ),
     )
     cloned_from: str | None = Field(
         default=None,
@@ -90,11 +98,15 @@ class ProfileUpdateBody(BaseModel):
     mtp: bool | None = Field(default=None, description="MTP toggle.")
     device_class: Literal["gpu", "cpu", "npu", "img"] | None = Field(
         default=None,
-        description="Device class this profile targets.",
+        description="INERT match-only fit hint; None leaves the stored value unchanged.",
     )
-    backend: Literal["rocm", "vulkan"] | None = Field(
+    backend: Literal["rocm", "vulkan", "cuda"] | None = Field(
         default=None,
-        description="GPU runtime (rocm|vulkan); None for non-GPU profiles.",
+        description=(
+            "INERT match-only fit hint (rocm|vulkan|cuda); None leaves the "
+            "stored value unchanged. `cuda` was missing here while ProfileConfig "
+            "accepted it, so a CUDA profile 422'd on every PUT — un-editable."
+        ),
     )
     intent: str | None = Field(default=None, description="Human label for the card headline.")
     quant: str | None = Field(default=None, description="Weight quant shown as a card chip.")

--- a/src/hal0/api/routes/profiles.py
+++ b/src/hal0/api/routes/profiles.py
@@ -219,6 +219,10 @@ async def import_profile_route(request: Request, response: Response) -> dict[str
     applies (``ProfileCatalog.create``), so an envelope can never back-door a
     hardware or managed flag past the guards ``POST``/``PUT`` enforce.
 
+    A commit verifies the envelope checksum as well (#1416) — ``dry_run`` used
+    to be the only place it was checked, so a tampered file that failed the
+    dry-run report still imported cleanly on the next call.
+
     Raises:
         400 profiles.bad_envelope: not a valid hal0.profile envelope.
         400 profiles.checksum_mismatch: checksum does not cover the body (#1416).

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -128,10 +128,18 @@ class ModelConfig(BaseModel):
         default=None,
         ge=128,
         description=(
-            "Context window size in tokens. Unset (None) is NOT 4096: the "
-            "load path derives the model's native window (dense-capped) or a "
-            "safe 8192 floor, so a slot never silently inherits llama-server's "
-            "4096 default (chat@4096 incident, 2026-06-15)."
+            "HARDWARE CEILING ONLY — no longer an override. v1.0 ownership "
+            "split: the MODEL owns context size (its "
+            "``defaults.context_size``, else the GGUF-derived native window "
+            "dense-capped, else a safe 8192 floor — never llama-server's "
+            "silent 4096, chat@4096 incident 2026-06-15). This slot-level "
+            "value is honored only as a cap on that resolved window "
+            "(``effective = min(model_window, this)``) because a slot owns "
+            "hardware and the installer writes a VRAM-budget clamp here "
+            "(hal0.hardware.recommend / hal0.install.orchestrate, #1108). It "
+            "can never RAISE the effective window. Unset (None) — the default, "
+            "and what a new slot gets — means 'follow the model'. See "
+            "hal0.providers.container._resolve_context_size."
         ),
     )
     # HAL0-SUNSET: v1.0.0 — flags own by models (spec-flags-ownership §2/§4).

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1116,22 +1116,39 @@ class ProfileConfig(BaseModel):
     device_class: Literal["gpu", "cpu", "npu", "img"] | None = Field(
         default=None,
         description=(
-            "Device class this profile targets.  None (default, per "
-            "spec-hw-slot-ownership.md §4.1 / seeded-profile-rework §4.1) "
-            "means the profile is device-agnostic — the slot owns device "
-            "and the profile supplies the logical tune only.  ``'gpu'``, "
-            "``'cpu'``, ``'npu'``, ``'img'`` are explicit-fit values; "
-            "``profile_fits_slot`` skips the device-class gate when this is "
-            "None."
+            "INERT MATCH-ONLY FIT HINT — selects no hardware (v1.0, "
+            "spec-hw-slot-ownership §2/§4.1). A profile is a bundle of "
+            "model-tuning flags and carries no hardware placement; the SLOT's "
+            "``device`` enum is the single authoritative hardware fact. This "
+            "field is read ONLY by ``hal0.model_fit.profile_fits_slot`` (does "
+            "this profile suit this slot?), by the display/runtime-family "
+            "classification in ``hal0.profiles._runtime_family``, and as a "
+            "last-resort fallback in "
+            "``providers.container._effective_backend_and_device_class`` for a "
+            "hand-built slot dict that declares no ``device`` at all. It no "
+            "longer gates real ``/dev/kfd`` + ``/dev/dri`` passthrough — it "
+            "did until 1.0, which let a ``cpu-chat`` profile request GPU device "
+            "nodes on a ``device='cpu'`` slot. None (the default, and what "
+            "every shipped seed uses) means device-agnostic: "
+            "``profile_fits_slot`` skips the device-class gate entirely. "
+            "RETAINED on this class rather than removed because published "
+            "``.hal0profile.json`` artifacts carry it and their checksums cover "
+            "it — dropping it would break import round-trip."
         ),
     )
     backend: Literal["rocm", "vulkan", "cuda"] | None = Field(
         default=None,
         description=(
-            "GPU runtime this profile targets — the authoritative source for the "
-            "ROCm-vs-Vulkan-vs-CUDA choice (replaces sniffing the image tag).  "
-            "``None`` for non-GPU profiles (npu/cpu/img), where ``device_class`` "
-            "drives display and slot-card colour."
+            "INERT MATCH-ONLY FIT HINT — selects no runtime (v1.0, "
+            "spec-hw-slot-ownership §2). NOT the source of the "
+            "ROCm-vs-Vulkan-vs-CUDA choice: that is derived from the SLOT's "
+            "``device`` enum by ``hal0.model_meta.device_to_backend`` via "
+            "``providers.container._effective_backend_and_device_class``, which "
+            "feeds BOTH the image/capability resolution and the device-node "
+            "passthrough gate so the two can never drift. Read here only as the "
+            "last-resort fallback for a slot dict with no ``device``. ``None`` "
+            "for non-GPU profiles (npu/cpu/img). RETAINED for on-disk and "
+            "envelope-checksum back-compat (see ``device_class``)."
         ),
     )
     cloned_from: str | None = Field(

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -96,7 +96,9 @@ class ProfilePatch:
     flags: str | None = None
     mtp: bool | None = None
     device_class: Literal["gpu", "cpu", "npu", "img"] | None = None
-    backend: Literal["rocm", "vulkan"] | None = None
+    #: Mirrors ProfileConfig.backend, which accepts "cuda" too. Omitting it here
+    #: made a CUDA profile un-patchable through this seam.
+    backend: Literal["rocm", "vulkan", "cuda"] | None = None
     intent: str | None = None
     quant: str | None = None
 

--- a/src/hal0/profiles/portable.py
+++ b/src/hal0/profiles/portable.py
@@ -100,6 +100,7 @@ def import_profile(
     catalog: Any,
     *,
     profile_path: Path | None = None,
+    force: bool = False,
 ) -> Any:
     """Validate the envelope and create the profile under ``name``.
 
@@ -126,8 +127,11 @@ def import_profile(
     # A MISSING/empty checksum is still accepted: ``ProfileEnvelope.checksum``
     # defaults to ``""`` and hand-authored envelopes legitimately omit it.
     # Only a checksum that is PRESENT and WRONG is rejected — that is
-    # unambiguously corruption, never an authoring style.
-    if env.checksum and isinstance(data, dict) and not verify_checksum(data):
+    # unambiguously corruption, never an authoring style. ``force`` is the
+    # documented escape hatch for a deliberately hand-edited envelope; it
+    # waives this check ONLY — the flag screen below (via ``catalog.create``)
+    # still applies unconditionally.
+    if not force and env.checksum and isinstance(data, dict) and not verify_checksum(data):
         raise BadRequest(
             "profile envelope checksum does not match its body — the file is "
             "corrupt or was modified after export",

--- a/src/hal0/profiles/portable.py
+++ b/src/hal0/profiles/portable.py
@@ -104,8 +104,9 @@ def import_profile(
     """Validate the envelope and create the profile under ``name``.
 
     ``catalog`` is a ProfileCatalog (duck-typed: needs ``create(name, ProfileConfig)``).
-    Raises BadRequest for a bad/too-new envelope; the catalog raises Conflict
-    (``profiles.exists``) on a duplicate name. Returns the created ResolvedProfile.
+    Raises BadRequest for a bad/too-new envelope or a checksum that does not
+    match the body; the catalog raises Conflict (``profiles.exists``) on a
+    duplicate name. Returns the created ResolvedProfile.
     """
     env = parse_envelope(data)
     if env.schema_version > PROFILE_SCHEMA_VERSION_CURRENT:
@@ -114,6 +115,27 @@ def import_profile(
             f"v{PROFILE_SCHEMA_VERSION_CURRENT}",
             code="profiles.envelope_too_new",
             details={"got": env.schema_version, "supported": PROFILE_SCHEMA_VERSION_CURRENT},
+        )
+    # #1416 — the commit path verifies the checksum, not just ``dry_run``.
+    #
+    # ``POST /api/profiles/import`` reported ``checksum_ok`` on a dry run and
+    # then imported without ever checking it again, so a tampered or truncated
+    # envelope committed silently and the dry-run report was advisory theatre.
+    # The checksum is the only integrity signal a portable profile carries.
+    #
+    # A MISSING/empty checksum is still accepted: ``ProfileEnvelope.checksum``
+    # defaults to ``""`` and hand-authored envelopes legitimately omit it.
+    # Only a checksum that is PRESENT and WRONG is rejected — that is
+    # unambiguously corruption, never an authoring style.
+    if env.checksum and isinstance(data, dict) and not verify_checksum(data):
+        raise BadRequest(
+            "profile envelope checksum does not match its body — the file is "
+            "corrupt or was modified after export",
+            code="profiles.checksum_mismatch",
+            details={
+                "expected": env.checksum,
+                "actual": _checksum(data.get("profile") or {}),
+            },
         )
     # (forward-compat seam: older schema_version would migrate here; only v1 exists.)
     return catalog.create(name, env.profile)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -195,7 +195,7 @@ def _effective_backend_and_device_class(
             device_class = "npu" if recipe == "flm" else ("cpu" if device == "cpu" else "gpu")
             return backend, device_class
         # No ``device`` at all: a pre-pivot TOML or a hand-built dict. Retain the
-        # legacy slot-level ``backend`` mirror, then the profile's inert hint.
+        # pre-pivot slot-level ``backend`` mirror, then the profile's inert hint.
         sb = slot_cfg.get("backend")
         if isinstance(sb, str) and sb:
             return sb, getattr(profile, "device_class", None)
@@ -1440,7 +1440,7 @@ def _resolve_llama_scalars(
         # still fell through ``or "gpu"`` and requested /dev/kfd + /dev/dri on a
         # ``device="cpu"`` slot. The ``or "gpu"`` floor is retained ONLY for a
         # slot_cfg that declares no device at all (hand-built dict / pre-pivot
-        # TOML) so a legacy GPU slot is never stranded on CPU.
+        # TOML) so an old GPU slot is never stranded on CPU.
         "device_class": str(effective_device_class or "gpu"),
         "backend": effective_backend,
         # Back-compat mirror of ``backend`` under its former name; some callers

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1062,6 +1062,21 @@ def _profile_runtime_family(slot_cfg: dict[str, Any]) -> str | None:
 _CTX_SAFE_FALLBACK = 8192
 _CTX_DENSE_CAP = 32768
 
+#: Plausibility bounds for an EXPLICIT ``defaults.context_size`` on the launch
+#: path (#1414). Mirrors the write-boundary range check so the two agree; kept
+#: as a separate launch-side guard on purpose, because the write boundary can
+#: only screen NEW writes — rows persisted before that screen existed (0, -1,
+#: 99999999 all returned HTTP 200) are deliberately left readable so they stay
+#: fixable, which means they are still on disk and still reach this function.
+#:
+#: Before the v1.0 ownership flip the damage was masked: the slot's
+#: ``[model].context_size`` won outright, so a slot with a sane value covered
+#: for a garbage model row. Now the MODEL is authoritative and a bad value goes
+#: straight to ``--ctx-size``, where -1 or 99999999 is a slot that never warms.
+#: Making the model the owner without this guard would have ENTRENCHED #1414.
+_CTX_MIN_PLAUSIBLE = 128
+_CTX_MAX_PLAUSIBLE = 2**24
+
 
 def _model_declared_ctx(model_info: dict[str, Any]) -> int | None:
     """The MODEL's own explicit context window (``defaults.context_size``).
@@ -1069,14 +1084,45 @@ def _model_declared_ctx(model_info: dict[str, Any]) -> int | None:
     This is the authoritative value under the v1.0 ownership split — an
     operator's deliberate, model-scoped choice made in the model drawer. It is
     NOT dense-capped: an explicit number means what it says.
+
+    An unparseable or implausible value (outside
+    ``[_CTX_MIN_PLAUSIBLE, _CTX_MAX_PLAUSIBLE]``) is treated as ABSENT, not
+    clamped — a half-applied garbage number is harder to diagnose than falling
+    through to the native window or the safe floor, and the operator's stated
+    intent is unrecoverable either way. Logged at warning so the bad row is
+    visible in ``journalctl -u hal0-api`` instead of surfacing as a slot that
+    silently never warms.
     """
     defaults = model_info.get("defaults")
-    if isinstance(defaults, dict) and defaults.get("context_size"):
-        try:
-            return int(defaults["context_size"])
-        except (TypeError, ValueError):
-            pass
-    return None
+    if not isinstance(defaults, dict) or not defaults.get("context_size"):
+        return None
+    raw = defaults["context_size"]
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        log.warning(
+            "slot.context_size_unparseable",
+            extra={
+                "raw": repr(raw),
+                "hint": "model defaults.context_size is not a number; ignoring it and "
+                "falling back to the model's native window. Fix it in the model drawer.",
+            },
+        )
+        return None
+    if not (_CTX_MIN_PLAUSIBLE <= value <= _CTX_MAX_PLAUSIBLE):
+        log.warning(
+            "slot.context_size_implausible",
+            extra={
+                "value": value,
+                "min": _CTX_MIN_PLAUSIBLE,
+                "max": _CTX_MAX_PLAUSIBLE,
+                "hint": "model defaults.context_size is outside the plausible range; "
+                "ignoring it and falling back to the model's native window. Fix it in "
+                "the model drawer.",
+            },
+        )
+        return None
+    return value
 
 
 def _native_ctx(model_info: dict[str, Any]) -> int | None:
@@ -1109,7 +1155,9 @@ def _resolve_context_size(
     the slot silently overrode the model. Precedence is now, highest first:
 
     1. ``model_info["defaults"]["context_size"]`` — the model's own explicit
-       window (:func:`_model_declared_ctx`). Authoritative, NOT dense-capped.
+       window (:func:`_model_declared_ctx`). Authoritative, NOT dense-capped —
+       but an unparseable or implausible value is ignored rather than launched
+       (#1414; see :data:`_CTX_MIN_PLAUSIBLE`).
     2. ``model_info["metadata"]["context_length"]`` — the GGUF-derived native
        window (:func:`_native_ctx`), dense-capped at :data:`_CTX_DENSE_CAP`.
        Still a model fact, but a *derived* one, so an explicit choice outranks

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -166,24 +166,40 @@ def _resolve_profile_or_base(profile_name: str, slot_cfg: dict[str, Any]) -> Any
 def _effective_backend_and_device_class(
     slot_cfg: Mapping[str, Any] | None, profile: Any
 ) -> tuple[str | None, str | None]:
-    """``(backend, device_class)`` for this lane — slot override beats profile."""
-    backend = getattr(profile, "backend", None)
-    device_class = getattr(profile, "device_class", None)
+    """``(backend, device_class)`` for this lane — the SLOT's device decides.
+
+    SINGLE SOURCE for "what hardware class is this launch" (spec-hw-slot-ownership
+    §2/§4.1). Consumed by :func:`_effective_runner` (image/capability resolution)
+    AND by :func:`_resolve_llama_scalars` → :meth:`ContainerProvider.container_spec`
+    (the real ``/dev/kfd`` + ``/dev/dri`` / NVIDIA-CDI passthrough gate), so the
+    image that launches, the capabilities that gate its flags, and the device
+    nodes mounted into it can never disagree.
+
+    A PROFILE carries no hardware placement in 1.0. ``profile.device_class`` /
+    ``profile.backend`` survive on :class:`~hal0.config.schema.ProfileConfig` only
+    as INERT match-only fit hints for :func:`hal0.model_fit.profile_fits_slot`
+    (and for the shipped ``.hal0profile.json`` artifacts whose checksums cover
+    them). They are read here ONLY as the last-resort fallback for a hand-built
+    / pre-pivot ``slot_cfg`` dict that declares no ``device`` at all — every
+    real ``SlotConfig`` has one (``device`` defaults to
+    :data:`~hal0.model_meta.DEFAULT_DEVICE`), so on a real box the profile never
+    contributes.
+    """
     if isinstance(slot_cfg, Mapping):
-        # 1.0 profiles do not select hardware. Derive the runtime backend
-        # from the slot's authoritative device; retain the legacy backend
-        # mirror only for pre-pivot TOMLs that have no device.
+        # 1.0: the slot's ``device`` enum is the authoritative hardware fact.
         device = slot_cfg.get("device")
         if isinstance(device, str) and device:
             from hal0.model_meta import device_to_backend
 
-            _recipe, backend = device_to_backend(device)
-            device_class = "npu" if _recipe == "flm" else ("cpu" if device == "cpu" else "gpu")
-        else:
-            sb = slot_cfg.get("backend")
-            if isinstance(sb, str) and sb:
-                backend = sb
-    return backend, device_class
+            recipe, backend = device_to_backend(device)
+            device_class = "npu" if recipe == "flm" else ("cpu" if device == "cpu" else "gpu")
+            return backend, device_class
+        # No ``device`` at all: a pre-pivot TOML or a hand-built dict. Retain the
+        # legacy slot-level ``backend`` mirror, then the profile's inert hint.
+        sb = slot_cfg.get("backend")
+        if isinstance(sb, str) and sb:
+            return sb, getattr(profile, "device_class", None)
+    return getattr(profile, "backend", None), getattr(profile, "device_class", None)
 
 
 def _binary_runner(slot_cfg: Mapping[str, Any] | None) -> Any | None:
@@ -1110,6 +1126,13 @@ def _resolve_llama_scalars(
     # the mtp/jinja capability gates below, so they can never drift onto two
     # different runners (§7.1a / ML-5).
     runner = _effective_runner(slot_cfg, profile, model_info)
+    # SINGLE SOURCE for "what hardware class is this launch" — the same helper
+    # ``_effective_runner`` uses, so the image and the device-node passthrough
+    # gate in ``container_spec`` can never drift onto two different hardware
+    # classes. Slot-derived; the profile contributes nothing on a real box.
+    effective_backend, effective_device_class = _effective_backend_and_device_class(
+        slot_cfg, profile
+    )
     effective_mtp = _effective_mtp(model_info, runner, log_ineligible=for_launch)
     # FLAGS-own (spec-flags-ownership §2, golden #5): resolve the image WITHOUT
     # resolving the profile's flags — the profile flag resolver
@@ -1271,10 +1294,19 @@ def _resolve_llama_scalars(
         "slot_threads": slot_threads,
         # slot_parallel stays inert (spec-flags-ownership §2 — sunset).
         "slot_parallel": None,
-        "device_class": str(getattr(profile, "device_class", "gpu") or "gpu"),
-        # GPU vendor discriminator: the profile's declared backend (rocm /
-        # vulkan / cuda / None) — configuration, not host probing.
-        "profile_backend": getattr(profile, "backend", None),
+        # HARDWARE CLASS + GPU-vendor discriminator (spec-hw-slot-ownership §2):
+        # derived from the SLOT's ``device`` enum via the one shared helper, NOT
+        # read off the profile. A profile is a model-tuning bundle and selects no
+        # hardware; before this, a ``cpu-chat`` profile with device_class unset
+        # still fell through ``or "gpu"`` and requested /dev/kfd + /dev/dri on a
+        # ``device="cpu"`` slot. The ``or "gpu"`` floor is retained ONLY for a
+        # slot_cfg that declares no device at all (hand-built dict / pre-pivot
+        # TOML) so a legacy GPU slot is never stranded on CPU.
+        "device_class": str(effective_device_class or "gpu"),
+        "backend": effective_backend,
+        # Back-compat mirror of ``backend`` under its former name; some callers
+        # (and the ``is_nvidia_gpu_device`` parameter) still say "profile".
+        "profile_backend": effective_backend,
         "device": str(slot_cfg.get("device") or ""),
         "gpu_index": gpu_index,
     }
@@ -1330,14 +1362,17 @@ class ContainerProvider(Provider):
         the health-check override are all included, so what loads matches what
         the plan describes (no GPU-special argv assembly elsewhere).
 
-        GPU passthrough branches by VENDOR, decided from the slot's declared
-        device/profile (never by probing at spec-build time):
+        GPU passthrough branches by VENDOR, decided from the SLOT's declared
+        ``device`` enum (never by probing at spec-build time, and never from the
+        profile — spec-hw-slot-ownership §2: a profile is a model-tuning bundle
+        and selects no hardware):
 
-        * AMD/other (default): device nodes + group GIDs are included ONLY
-          for gpu/img profiles and are existence-filtered — a cpu (or npu)
-          ``device_class`` profile gets no ``/dev/kfd`` / ``/dev/dri``
-          passthrough or ``--group-add``.
-        * NVIDIA (``device=gpu-cuda`` or profile ``backend="cuda"``): CDI —
+        * AMD/other (default): device nodes + group GIDs are included ONLY when
+          the slot's device resolves to a gpu/img class, and are
+          existence-filtered — a ``device="cpu"`` (or ``"npu"``) slot gets no
+          ``/dev/kfd`` / ``/dev/dri`` passthrough and no ``--group-add``,
+          whatever its profile says.
+        * NVIDIA (``device=gpu-cuda``): CDI —
           ``--device nvidia.com/gpu=all`` (per-index ``nvidia.com/gpu=<n>``
           when ``gpu_index`` is set). CDI names are not paths, so no
           existence filter and no GID ``--group-add`` (the CDI spec injects
@@ -1352,12 +1387,16 @@ class ContainerProvider(Provider):
         model_path = _resolve_model_path(model_info)
         port = int(slot_cfg.get("port", 0))
 
-        # GPU plumbing gate (#674/CPU-profile fix): only gpu/img profiles get
-        # GPU passthrough. On the AMD path only device paths that actually
-        # exist on this host are passed (podman errors on a non-existent
-        # --device); CDI entries are names, not paths — passed verbatim.
+        # GPU plumbing gate (#674/CPU-profile fix): only a gpu/img-class SLOT
+        # gets GPU passthrough. ``scalars["device_class"]`` is derived from the
+        # slot's ``device`` enum by ``_effective_backend_and_device_class`` — a
+        # profile's inert ``device_class``/``backend`` hint can no longer mount
+        # /dev/kfd + /dev/dri into a ``device="cpu"`` slot's container. On the
+        # AMD path only device paths that actually exist on this host are passed
+        # (podman errors on a non-existent --device); CDI entries are names, not
+        # paths — passed verbatim.
         if scalars["device_class"] in ("gpu", "img"):
-            if is_nvidia_gpu_device(scalars["device"], scalars["profile_backend"]):
+            if is_nvidia_gpu_device(scalars["device"], scalars["backend"]):
                 devices = nvidia_cdi_devices(scalars["gpu_index"])
                 group_ids = []
             else:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1052,29 +1052,24 @@ def _profile_runtime_family(slot_cfg: dict[str, Any]) -> str | None:
         return None
 
 
-# Native context-window resolution (chat@4096 incident, 2026-06-15).
+# Context-window resolution (chat@4096 incident, 2026-06-15).
 #
-# A slot whose [model].context_size is unset must NEVER fall through to
-# llama-server's silent 4096 default. We derive the model's native window
-# from the registry (GGUF arch max), cap dense models so an unconfigured
-# slot can't request an impractically large KV cache, and otherwise use a
-# safe floor. Mirrors hal0.hardware.recommend's installer-side policy.
+# A slot must NEVER fall through to llama-server's silent 4096 default. When
+# the model declares no window of its own we derive it from the registry's
+# GGUF arch max, cap dense models so an unconfigured slot can't request an
+# impractically large KV cache, and otherwise use a safe floor. Mirrors
+# hal0.hardware.recommend's installer-side policy.
 _CTX_SAFE_FALLBACK = 8192
 _CTX_DENSE_CAP = 32768
 
 
-def _native_ctx(model_info: dict[str, Any]) -> int | None:
-    """Best-effort native context window for a model, or None if unknown.
+def _model_declared_ctx(model_info: dict[str, Any]) -> int | None:
+    """The MODEL's own explicit context window (``defaults.context_size``).
 
-    GGUF arch max (registry metadata.context_length) is authoritative;
-    a model's own defaults.context_size is the secondary source.
+    This is the authoritative value under the v1.0 ownership split — an
+    operator's deliberate, model-scoped choice made in the model drawer. It is
+    NOT dense-capped: an explicit number means what it says.
     """
-    md = model_info.get("metadata")
-    if isinstance(md, dict) and md.get("context_length"):
-        try:
-            return int(md["context_length"])
-        except (TypeError, ValueError):
-            pass
     defaults = model_info.get("defaults")
     if isinstance(defaults, dict) and defaults.get("context_size"):
         try:
@@ -1084,20 +1079,110 @@ def _native_ctx(model_info: dict[str, Any]) -> int | None:
     return None
 
 
-def _resolve_context_size(explicit: int | None, model_info: dict[str, Any]) -> int:
-    """The slot's effective context window.
+def _native_ctx(model_info: dict[str, Any]) -> int | None:
+    """The model's INTRINSIC native window (registry ``metadata.context_length``).
 
-    The explicit slot value wins when set; otherwise derive the model's
-    native window (dense-capped); otherwise a safe _CTX_SAFE_FALLBACK.
-    Guarantees a non-None int so the slot never silently inherits
-    llama-server's 4096 default.
+    Read straight off the GGUF arch max at import time — still a MODEL fact, but
+    a derived one, so it only applies when nobody made an explicit choice, and it
+    is dense-capped by the caller.
     """
-    if explicit is not None:
-        return int(explicit)
-    native = _native_ctx(model_info)
-    if native:
-        return min(native, _CTX_DENSE_CAP)
-    return _CTX_SAFE_FALLBACK
+    md = model_info.get("metadata")
+    if isinstance(md, dict) and md.get("context_length"):
+        try:
+            return int(md["context_length"])
+        except (TypeError, ValueError):
+            pass
+    return None
+
+
+def _resolve_context_size(
+    slot_ceiling: int | None,
+    model_info: dict[str, Any],
+    *,
+    slot_name: str = "",
+) -> int:
+    """The slot's effective context window — the MODEL is authoritative.
+
+    v1.0 ownership split: **the MODEL owns context size.** Before this, a slot's
+    ``[model].context_size`` won OUTRIGHT over everything, so two drawers
+    (model + slot) each exposed a "Context size" control with no indication that
+    the slot silently overrode the model. Precedence is now, highest first:
+
+    1. ``model_info["defaults"]["context_size"]`` — the model's own explicit
+       window (:func:`_model_declared_ctx`). Authoritative, NOT dense-capped.
+    2. ``model_info["metadata"]["context_length"]`` — the GGUF-derived native
+       window (:func:`_native_ctx`), dense-capped at :data:`_CTX_DENSE_CAP`.
+       Still a model fact, but a *derived* one, so an explicit choice outranks
+       it — the reverse of the pre-1.0 order, which let a 262144-token arch max
+       shadow a deliberate ``defaults.context_size``.
+    3. :data:`_CTX_SAFE_FALLBACK` (8192) — never llama-server's silent 4096.
+
+    ``slot_ceiling`` (the on-disk ``[model].context_size``) is NO LONGER an
+    override. It is honored only as a **hardware CEILING**: the slot owns
+    hardware, and a slot-level window written by
+    :func:`hal0.hardware.recommend.recommend_primary_slot` /
+    :mod:`hal0.install.orchestrate` is a VRAM-budget clamp computed for this
+    box's memory (#1108). Dropping it outright would let a model's own larger
+    window reopen the first-warm OOM those clamps exist to prevent. So the
+    resolved value is capped at the slot ceiling but can never be RAISED by it:
+
+        effective = min(model_authoritative, slot_ceiling)
+
+    Net effect on a box that already has a slot-level ``context_size`` on disk:
+    where the clamp was below the model's window (the installer's case) the
+    effective context is UNCHANGED; where the slot was silently inflating the
+    model's window (the dual-ownership bug) it drops to what the model asked
+    for. The effective context can therefore only stay the same or shrink —
+    never grow — so no box gains a KV cache it cannot hold. Every case where
+    the ceiling actually changes the answer is logged, so the change is visible
+    in ``journalctl -u hal0-api`` rather than silent.
+
+    Guarantees a non-None int.
+    """
+    declared = _model_declared_ctx(model_info)
+    if declared is not None:
+        resolved, source = declared, "model.defaults.context_size"
+    else:
+        native = _native_ctx(model_info)
+        if native:
+            resolved, source = min(native, _CTX_DENSE_CAP), "model.metadata.context_length"
+        else:
+            resolved, source = _CTX_SAFE_FALLBACK, "safe_fallback"
+
+    if slot_ceiling is None:
+        return resolved
+
+    ceiling = int(slot_ceiling)
+    if ceiling < resolved:
+        log.info(
+            "slot.context_size_clamped_by_slot",
+            extra={
+                "slot": slot_name,
+                "model_ctx": resolved,
+                "model_ctx_source": source,
+                "slot_ceiling": ceiling,
+                "effective": ceiling,
+                "hint": "the slot's [model].context_size is a hardware ceiling now, "
+                "not an override; raise it (or lower the model's context size) to change "
+                "the effective window",
+            },
+        )
+        return ceiling
+    if ceiling > resolved:
+        log.warning(
+            "slot.context_size_no_longer_overrides",
+            extra={
+                "slot": slot_name,
+                "model_ctx": resolved,
+                "model_ctx_source": source,
+                "slot_context_size": ceiling,
+                "effective": resolved,
+                "hint": "the MODEL owns context size in 1.0; this slot's larger "
+                "[model].context_size no longer wins. Set the window on the model to "
+                "restore it.",
+            },
+        )
+    return resolved
 
 
 def _resolve_llama_scalars(
@@ -1160,7 +1245,13 @@ def _resolve_llama_scalars(
     model_table = slot_cfg.get("model") or {}
     if not isinstance(model_table, dict):
         model_table = {}
-    context_size = _resolve_context_size(model_table.get("context_size"), model_info)
+    # MODEL-authoritative context window; the slot's on-disk [model].context_size
+    # is a hardware ceiling only, never an override (see _resolve_context_size).
+    context_size = _resolve_context_size(
+        model_table.get("context_size"),
+        model_info,
+        slot_name=str(slot_cfg.get("name") or ""),
+    )
 
     server_table = slot_cfg.get("server") or {}
     if not isinstance(server_table, dict):

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2182,16 +2182,16 @@ class SlotManager:
         # same single fold (:func:`hal0.slot_config.fold_ctx_size_alias`)
         # the merge/update path uses.
         fold_ctx_size_alias(cfg_dict)
-        # Persist a concrete context window when the operator left it unset, so
-        # the TOML, the dashboard, and the running container all agree. The
-        # provider's load-path derive is the belt-and-suspenders fallback; this
-        # makes the chosen window visible at create time (chat@4096 incident).
+        # v1.0: do NOT backfill [model].context_size here. The MODEL owns the
+        # context window (providers.container._resolve_context_size) and a
+        # slot-level value is now only a hardware CEILING. Stamping the model's
+        # current window onto the new slot would freeze that ceiling at
+        # create-time: raising the model's context size later would be silently
+        # clamped back down by a number the operator never chose. Leaving it
+        # unset means the slot follows the model, which is the whole point of the
+        # partition — and the launch path still guarantees a concrete window
+        # (never llama-server's silent 4096, chat@4096 incident).
         model_tbl = cfg_dict.get("model")
-        if isinstance(model_tbl, dict) and model_tbl.get("context_size") is None:
-            from hal0.providers.container import _resolve_context_size
-
-            model_info = await self._resolve_model_info(model_tbl.get("default"))
-            model_tbl["context_size"] = _resolve_context_size(None, model_info)
         # Q1 (model profiles): a new slot bound to a model but with NO explicit
         # profile adopts the model's preferred profile when it fits the slot's
         # device/type. An operator's explicit create-time profile is left

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -567,3 +567,158 @@ def test_create_with_cloned_from_201_and_listed(client: TestClient) -> None:
 def test_seed_profiles_have_null_cloned_from(client: TestClient) -> None:
     listed = client.get("/api/profiles").json()
     assert listed and all(p["cloned_from"] is None for p in listed)
+
+
+# ── 1c: the inert fit hints are not stamped with a hardware claim ─────────────
+
+
+def test_create_without_device_class_leaves_it_unset(client: TestClient) -> None:
+    """`ProfileBody.device_class` defaulted to `"gpu"`, so every profile created
+    without one silently acquired a hardware claim it never asked for — on a
+    field that (before 81e1e206) gated real /dev/kfd passthrough. A tuning-only
+    profile is device-AGNOSTIC; the default is now None, matching ProfileConfig
+    and all 16 seeds."""
+    r = client.post("/api/profiles", json={"name": "agnostic", "flags": "-fa on"})
+    assert r.status_code == 201, r.text
+    assert r.json()["device_class"] is None
+    # and it survives the round-trip through the on-disk catalog
+    listed = client.get("/api/profiles").json()
+    entry = next(p for p in listed if p["name"] == "agnostic")
+    assert entry["device_class"] is None
+
+
+def test_create_with_explicit_device_class_still_honored(client: TestClient) -> None:
+    """The hint is inert, not forbidden — an operator may still declare a fit
+    hint, and the published chat-long-context artifact carries one."""
+    r = client.post(
+        "/api/profiles",
+        json={"name": "gpu-hinted", "flags": "-fa on", "device_class": "gpu"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["device_class"] == "gpu"
+
+
+def test_cuda_backend_accepted_on_create_and_update(client: TestClient) -> None:
+    """`ProfileConfig.backend` accepts rocm|vulkan|cuda but the route DTOs only
+    accepted rocm|vulkan, so a CUDA profile could be imported yet 422'd on every
+    subsequent PUT — un-editable through the API that created it."""
+    r = client.post(
+        "/api/profiles",
+        json={"name": "cuda-tune", "flags": "-fa on", "device_class": "gpu", "backend": "cuda"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["backend"] == "cuda"
+    r2 = client.put("/api/profiles/cuda-tune", json={"backend": "cuda", "intent": "NVIDIA"})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["backend"] == "cuda"
+    assert r2.json()["intent"] == "NVIDIA"
+
+
+# ── #1411: a pre-1.0 custom profile must stay editable ────────────────────────
+
+
+def _seed_legacy_profiles_toml(home: str, name: str, flags: str) -> Path:
+    """Write a custom profile carrying flags that today's §5 screen rejects.
+
+    This is what a 0.9.8 box has on disk: `-dev`/`--threads` were legal on a
+    profile before spec-hw-slot-ownership §5. It must be written directly —
+    the API (correctly) refuses to create one.
+    """
+    root = Path(home) / "etc" / "hal0"
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / "profiles.toml"
+    path.write_text(
+        f'[profile.{name}]\nflags = "{flags}"\nmtp = false\n'
+        'intent = "Legacy"\nquant = ""\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.fixture
+def legacy_client(tmp_hal0_home: str) -> Iterator[TestClient]:
+    """Client over a box that already has a pre-1.0 custom profile on disk."""
+    _seed_legacy_profiles_toml(tmp_hal0_home, "old-custom", "-fa on -dev Vulkan0 --threads 8")
+    with TestClient(create_app()) as c:
+        yield c
+
+
+def test_legacy_profile_is_visible(legacy_client: TestClient) -> None:
+    listed = legacy_client.get("/api/profiles").json()
+    entry = next(p for p in listed if p["name"] == "old-custom")
+    assert "-dev Vulkan0" in entry["flags"]
+
+
+def test_legacy_profile_metadata_edit_is_not_blocked_by_its_stored_flags(
+    legacy_client: TestClient,
+) -> None:
+    """#1411 — THE HEADLINE CASE. The dashboard round-trips the whole profile on
+    save, so editing `intent` resubmits the stored `-dev`/`--threads` flags
+    verbatim. Screening an UNCHANGED value rejected a write that changes
+    nothing, making every pre-existing custom profile permanently un-editable
+    after upgrade, with no in-product way to fix it."""
+    r = legacy_client.put(
+        "/api/profiles/old-custom",
+        json={"flags": "-fa on -dev Vulkan0 --threads 8", "intent": "Renamed"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["intent"] == "Renamed"
+    assert r.json()["flags"] == "-fa on -dev Vulkan0 --threads 8"
+
+
+def test_legacy_profile_edit_omitting_flags_also_works(legacy_client: TestClient) -> None:
+    """A client that PATCHes only the field it changed was never broken; pinned
+    so the delta rule does not regress it."""
+    r = legacy_client.put("/api/profiles/old-custom", json={"intent": "Renamed"})
+    assert r.status_code == 200, r.text
+    assert r.json()["intent"] == "Renamed"
+
+
+def test_legacy_profile_cleaning_its_flags_is_allowed(legacy_client: TestClient) -> None:
+    """The migration path: an operator CAN fix the offending flags."""
+    r = legacy_client.put("/api/profiles/old-custom", json={"flags": "-fa on -b 512"})
+    assert r.status_code == 200, r.text
+    assert r.json()["flags"] == "-fa on -b 512"
+
+
+def test_legacy_profile_cannot_gain_a_new_hardware_flag(legacy_client: TestClient) -> None:
+    """The partition is still fully enforced on any ACTUAL change — the
+    exemption is for byte-identical resubmission only, not a general amnesty."""
+    r = legacy_client.put(
+        "/api/profiles/old-custom",
+        json={"flags": "-fa on -dev Vulkan0 --threads 8 -ngl 999"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.hardware_flag_denied"
+
+
+def test_legacy_profile_cannot_gain_a_managed_flag(legacy_client: TestClient) -> None:
+    """Cleaning the legacy hardware flags but smuggling in a managed arg is
+    still rejected — and by the MANAGED screen, since no hardware flag remains
+    to trip the hardware screen that runs first."""
+    r = legacy_client.put("/api/profiles/old-custom", json={"flags": "-fa on --ctx-size 4096"})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.managed_arg_denied"
+
+
+def test_legacy_profile_edit_keeping_hardware_flags_reports_the_hardware_denial(
+    legacy_client: TestClient,
+) -> None:
+    """Ordering guarantee: when a changed flag string still carries a hardware
+    flag, the operator is told about the hardware flag (the thing that belongs
+    on the slot), not whatever else is wrong."""
+    r = legacy_client.put(
+        "/api/profiles/old-custom",
+        json={"flags": "-fa on -dev Vulkan0 --threads 8 --ctx-size 4096"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.hardware_flag_denied"
+
+
+def test_create_is_still_fully_screened(legacy_client: TestClient) -> None:
+    """A NEW profile gets no exemption — there is no legacy value to preserve."""
+    r = legacy_client.post(
+        "/api/profiles", json={"name": "brand-new", "flags": "-fa on --threads 8"}
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "slot.hardware_flag_denied"

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -703,12 +703,15 @@ def test_legacy_profile_cannot_gain_a_managed_flag(legacy_client: TestClient) ->
 def test_legacy_profile_edit_keeping_hardware_flags_reports_the_hardware_denial(
     legacy_client: TestClient,
 ) -> None:
-    """Ordering guarantee: when a changed flag string still carries a hardware
-    flag, the operator is told about the hardware flag (the thing that belongs
-    on the slot), not whatever else is wrong."""
+    """Ordering guarantee: when a changed flag string introduces BOTH a new
+    hardware flag and a new managed flag, the operator is told about the
+    hardware flag (the thing that belongs on the slot), not whatever else is
+    wrong. ``-dev`` is already inherited from the legacy value (#1411
+    grandfathering), so this uses ``-ngl`` — a hardware flag with no prior
+    value to inherit — to keep the hardware screen live in this update."""
     r = legacy_client.put(
         "/api/profiles/old-custom",
-        json={"flags": "-fa on -dev Vulkan0 --threads 8 --ctx-size 4096"},
+        json={"flags": "-fa on -dev Vulkan0 --threads 8 -ngl 999 --ctx-size 4096"},
     )
     assert r.status_code == 400, r.text
     assert r.json()["error"]["code"] == "slot.hardware_flag_denied"

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -628,8 +628,7 @@ def _seed_legacy_profiles_toml(home: str, name: str, flags: str) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     path = root / "profiles.toml"
     path.write_text(
-        f'[profile.{name}]\nflags = "{flags}"\nmtp = false\n'
-        'intent = "Legacy"\nquant = ""\n',
+        f'[profile.{name}]\nflags = "{flags}"\nmtp = false\nintent = "Legacy"\nquant = ""\n',
         encoding="utf-8",
     )
     return path

--- a/tests/api/test_profiles_portable_routes.py
+++ b/tests/api/test_profiles_portable_routes.py
@@ -184,7 +184,7 @@ class TestImportCommit:
         env = client.post(f"/api/profiles/{_seed_name()}/export").json()
         env.pop("checksum")
         r = client.post("/api/profiles/import", json={"envelope": env, "name": "no-sum"})
-        assert r.status_code == 200, r.text
+        assert r.status_code == 201, r.text
 
 
 # ── #1416: commit verifies the checksum + screens the flags ──────────────────

--- a/tests/api/test_profiles_portable_routes.py
+++ b/tests/api/test_profiles_portable_routes.py
@@ -163,6 +163,29 @@ class TestImportCommit:
         assert r.status_code == 400
         assert r.json()["error"]["code"] == "profiles.envelope_too_new"
 
+    def test_commit_tampered_checksum_400(self, client: TestClient) -> None:
+        """#1416 — the exact envelope ``dry_run`` reports ``checksum_ok: false``
+        for used to commit anyway. Same input, both calls, asserted together so
+        the two paths can never disagree again."""
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        env["profile"]["flags"] = "-fa off TAMPERED"
+
+        dry = client.post("/api/profiles/import", json={"envelope": env, "dry_run": True})
+        assert dry.json()["checksum_ok"] is False
+
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "tampered"})
+        assert r.status_code == 400, r.text
+        assert r.json()["error"]["code"] == "profiles.checksum_mismatch"
+        # …and nothing was written.
+        assert client.get("/api/profiles/tampered").status_code == 404
+
+    def test_commit_checksumless_envelope_still_imports(self, client: TestClient) -> None:
+        """A hand-authored envelope omitting ``checksum`` is not corruption."""
+        env = client.post(f"/api/profiles/{_seed_name()}/export").json()
+        env.pop("checksum")
+        r = client.post("/api/profiles/import", json={"envelope": env, "name": "no-sum"})
+        assert r.status_code == 200, r.text
+
 
 # ── #1416: commit verifies the checksum + screens the flags ──────────────────
 #

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -6,6 +6,7 @@ Targeted file run:
 
 from __future__ import annotations
 
+import shlex
 import tomllib
 from pathlib import Path
 
@@ -453,3 +454,52 @@ def test_cpu_default_profile_supports_llm(tmp_path: Path) -> None:
         DEVICE_DEFAULT_PROFILES["cpu"]
     )
     assert "llm" in resolved.supported_slot_types
+
+
+# ── seeds must survive the screens the API enforces on custom profiles ───────
+
+
+def test_every_seed_profile_passes_the_hardware_and_managed_flag_screens() -> None:
+    """Deliverable 3 — the seeds stay tuning-only, enforced not asserted.
+
+    ``test_seed_device_classes`` / ``test_seed_backends`` pin the typed hardware
+    fields, but nothing pinned the freeform ``flags`` string. Seeds are VIRTUAL:
+    ``load_profiles_config`` overlays ``SEED_PROFILES`` over whatever is on disk,
+    so a seed never passes through ``ProfileCatalog.create`` and never meets
+    ``screen_profile_flags``. A seed could therefore acquire ``-ngl`` or
+    ``--ctx-size`` and ship, while a user typing the same flag into the profile
+    editor gets a 400 — the exact inconsistency spec-hw-slot-ownership §5 and
+    §21.7 exist to prevent.
+
+    This runs the real screen (the one the create/update/import seam calls) over
+    every seed, so the seeds are held to the identical standard as user input.
+    """
+    from hal0.config.schema import SEED_PROFILES
+    from hal0.profiles import screen_profile_flags
+
+    for name, profile in SEED_PROFILES.items():
+        flags = profile.get("flags", "")
+        try:
+            screen_profile_flags(flags)
+        except Exception as exc:  # pragma: no cover - only on a regression
+            raise AssertionError(
+                f"seed profile {name!r} carries a slot-hardware or hal0-managed "
+                f"flag and would be rejected by the API: {flags!r} → {exc}"
+            ) from exc
+
+
+def test_no_seed_profile_carries_a_context_or_layer_flag() -> None:
+    """Belt-and-braces on the two that actually corrupt a launch.
+
+    ``-c``/``--ctx-size`` on a profile would fight the model-owned context
+    window (``_resolve_context_size``); ``-ngl``/``--n-gpu-layers`` would fight
+    the slot-owned hardware grid. Spelled out literally so the intent survives a
+    future refactor of the screen internals.
+    """
+    from hal0.config.schema import SEED_PROFILES
+
+    banned = ("-c", "--ctx-size", "-ngl", "--n-gpu-layers", "--device", "-dev", "--threads")
+    for name, profile in SEED_PROFILES.items():
+        tokens = shlex.split(profile.get("flags", ""))
+        for bad in banned:
+            assert bad not in tokens, f"seed {name!r} carries {bad!r}: {profile.get('flags')!r}"

--- a/tests/profiles/test_portable.py
+++ b/tests/profiles/test_portable.py
@@ -195,3 +195,122 @@ class TestImportProfile:
         with pytest.raises(BadRequest) as exc:
             import_profile(env, "copied", _catalog(tmp_hal0_home))
         assert exc.value.code == "slot.hardware_flag_denied"
+
+
+# ── the SHIPPED artifact: exact-checksum round-trip guarantee ────────────────
+
+#: The published brain profile, byte-for-byte as it ships in
+#: ``Hal0ai/hal0-brain-sft-ROCmFPX-GGUF/chat-long-context.hal0profile.json``.
+#: Its ``device_class: "gpu"`` is exactly the field the v1.0 tuning-only rule
+#: neutralised, so this artifact is the canary for that change.
+_PUBLISHED_CHAT_LONG_CONTEXT: dict = {
+    "kind": "hal0.profile",
+    "schema_version": 1,
+    "hal0_version": "1.0.0a1",
+    "name": "chat-long-context",
+    "checksum": "sha256:241af4cd2636ac1da32a8a7ca0d856724445242cfcde88a208b702b155bdee47",
+    "profile": {
+        "flags": (
+            "-fa on -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 --parallel 1 --no-mmap "
+            "--no-context-shift --poll 100 --poll-batch 1 --metrics --no-webui"
+        ),
+        "mtp": False,
+        "device_class": "gpu",
+        "intent": "Long-context chat",
+        "quant": "",
+    },
+}
+
+
+class TestPublishedBrainProfileRoundTrip:
+    """The shipped ``chat-long-context`` artifact must import and round-trip
+    with a STABLE checksum (SHARED-BRIEF §"The shipped brain profile").
+
+    This is the hard constraint on the v1.0 tuning-only rule. ``device_class``
+    and ``backend`` were neutralised to inert match-only hints, but they could
+    NOT be removed from :class:`ProfileConfig`: ``export_envelope`` checksums
+    ``model_dump(exclude_none=True)``, so deleting a field the artifact carries
+    — or changing which fields serialize — silently changes the checksum and
+    breaks every published profile in the wild. These tests fail loudly if
+    anyone later "cleans up" those fields.
+    """
+
+    def test_published_checksum_verifies(self) -> None:
+        assert verify_checksum(_PUBLISHED_CHAT_LONG_CONTEXT) is True
+
+    def test_reexport_reproduces_the_published_checksum_exactly(self) -> None:
+        """Parse → re-export must land on the same sha256. ``exported_at`` is
+        excluded from the checksum, so a different clock cannot move it."""
+        env = parse_envelope(_PUBLISHED_CHAT_LONG_CONTEXT)
+        again = export_envelope(env.name, env.profile, exported_at="2099-01-01T00:00:00Z")
+        assert again["checksum"] == _PUBLISHED_CHAT_LONG_CONTEXT["checksum"]
+        assert again["profile"] == _PUBLISHED_CHAT_LONG_CONTEXT["profile"]
+
+    def test_device_class_gpu_survives_the_round_trip(self) -> None:
+        """The inert hint is PRESERVED, not stripped — stripping it would change
+        the checksum."""
+        env = parse_envelope(_PUBLISHED_CHAT_LONG_CONTEXT)
+        assert env.profile.device_class == "gpu"
+        body = export_envelope(env.name, env.profile, exported_at="t")["profile"]
+        assert body["device_class"] == "gpu"
+
+    def test_published_artifact_imports_and_is_resolvable(self, tmp_hal0_home: str) -> None:
+        """A real commit-path import: its flags are all genuine model-tuning
+        flags, so it passes the §5 hardware / §21.7 managed screens.
+
+        Imported under a NON-seed name — see
+        ``test_cannot_import_under_its_own_name_because_a_seed_owns_it``."""
+        catalog = _catalog(tmp_hal0_home)
+        resolved = import_profile(_PUBLISHED_CHAT_LONG_CONTEXT, "brain-long-ctx", catalog)
+        assert resolved.name == "brain-long-ctx"
+        assert resolved.device_class == "gpu"
+        assert "--no-webui" in resolved.flags
+
+    def test_cannot_import_under_its_own_name_because_a_seed_owns_it(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """KNOWN LIMITATION, pinned so it is not mistaken for a regression.
+
+        A SEED profile is also named ``chat-long-context``, and it is a
+        DIFFERENT profile — the seed's flags are the short
+        ``-fa on -ctk q8_0 -ctv q8_0 -b 2048 -ub 512 --no-context-shift`` with
+        ``device_class`` unset, so it checksums to a different sha256 than the
+        published artifact. Importing the published file under its own name
+        therefore 409s, and even if it did not, ``save_profiles_config`` strips
+        seed-named keys before writing, so it could never persist there. An
+        operator must import it under a different name.
+        """
+        catalog = _catalog(tmp_hal0_home)
+        with pytest.raises(Conflict) as exc:
+            import_profile(_PUBLISHED_CHAT_LONG_CONTEXT, "chat-long-context", catalog)
+        assert exc.value.code == "profiles.exists"
+
+    def test_imported_then_exported_still_matches_published(self, tmp_hal0_home: str) -> None:
+        """Full loop through the on-disk catalog: import → persist → resolve →
+        export reproduces the published checksum. Catches a catalog write that
+        drops or coerces a field."""
+        catalog = _catalog(tmp_hal0_home)
+        import_profile(_PUBLISHED_CHAT_LONG_CONTEXT, "brain-long-ctx", catalog)
+        r = catalog.resolve("brain-long-ctx")
+        again = export_envelope(
+            "brain-long-ctx",
+            ProfileConfig(
+                flags=r.flags,
+                mtp=r.mtp,
+                device_class=r.device_class,
+                backend=r.backend,
+                cloned_from=r.cloned_from,
+                intent=r.intent,
+                quant=r.quant,
+            ),
+            exported_at="t",
+        )
+        assert again["checksum"] == _PUBLISHED_CHAT_LONG_CONTEXT["checksum"]
+
+    def test_published_flags_carry_no_hardware_or_managed_flag(self) -> None:
+        """Why the artifact survives the tuning-only rule at all: every entry in
+        its ``flags`` is a model-tuning flag. Guards against a future seed/screen
+        widening that would strand the shipped profile."""
+        flags = _PUBLISHED_CHAT_LONG_CONTEXT["profile"]["flags"]
+        for banned in ("-ngl", "--device", "--threads", "-dev", "-c ", "--ctx-size", "--port"):
+            assert banned not in flags

--- a/tests/profiles/test_portable.py
+++ b/tests/profiles/test_portable.py
@@ -197,6 +197,76 @@ class TestImportProfile:
         assert exc.value.code == "slot.hardware_flag_denied"
 
 
+# ── #1416: the COMMIT path verifies the checksum, not just dry_run ───────────
+
+
+class TestImportVerifiesChecksum:
+    """``POST /api/profiles/import`` computed ``checksum_ok`` on a dry run and
+    then committed without ever checking it — the integrity signal was advisory
+    only. A tampered envelope imported silently."""
+
+    def test_tampered_body_is_rejected_on_commit(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["profile"]["intent"] = "SOMETHING ELSE"  # checksum now stale
+        assert verify_checksum(env) is False
+        with pytest.raises(BadRequest) as exc:
+            import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "profiles.checksum_mismatch"
+
+    def test_tampered_flags_are_rejected_before_anything_is_written(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """The rejection must happen BEFORE ``catalog.create`` — otherwise the
+        corrupt profile is already on disk when the error surfaces."""
+        catalog = _catalog(tmp_hal0_home)
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["profile"]["flags"] = "-fa off"
+        with pytest.raises(BadRequest):
+            import_profile(env, "copied", catalog)
+        assert not any(p.name == "copied" for p in catalog.list())
+
+    def test_wrong_checksum_string_is_rejected(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["checksum"] = "sha256:" + "0" * 64
+        with pytest.raises(BadRequest) as exc:
+            import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert exc.value.code == "profiles.checksum_mismatch"
+        assert exc.value.details["expected"] == env["checksum"]
+        assert exc.value.details["actual"] != env["checksum"]
+
+    def test_absent_checksum_is_still_accepted(self, tmp_hal0_home: str) -> None:
+        """A hand-authored envelope legitimately omits the checksum;
+        ``ProfileEnvelope.checksum`` defaults to ``""``. Only a checksum that is
+        PRESENT and WRONG means corruption."""
+        env = export_envelope("orig", _profile(), exported_at="t")
+        del env["checksum"]
+        resolved = import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert resolved.name == "copied"
+
+    def test_empty_checksum_is_still_accepted(self, tmp_hal0_home: str) -> None:
+        env = export_envelope("orig", _profile(), exported_at="t")
+        env["checksum"] = ""
+        resolved = import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert resolved.name == "copied"
+
+    def test_intact_envelope_still_imports(self, tmp_hal0_home: str) -> None:
+        """Guard against the check being too strict — an untouched export must
+        still import."""
+        env = export_envelope("orig", _profile(), exported_at="t")
+        resolved = import_profile(env, "copied", _catalog(tmp_hal0_home))
+        assert resolved.name == "copied"
+
+    def test_published_artifact_still_imports_with_its_real_checksum(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """The whole point of 1a: the shipped brain profile carries a real
+        checksum, so tightening import must NOT reject it."""
+        resolved = import_profile(
+            _PUBLISHED_CHAT_LONG_CONTEXT, "brain-long-ctx", _catalog(tmp_hal0_home)
+        )
+        assert resolved.name == "brain-long-ctx"
+
+
 # ── the SHIPPED artifact: exact-checksum round-trip guarantee ────────────────
 
 #: The published brain profile, byte-for-byte as it ships in

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import shlex
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 from hal0.config.schema import (
@@ -1014,6 +1014,103 @@ def test_resolve_model_path_registry_miss_falls_back_to_bare_id() -> None:
     GGUF path — the C8 deploy precheck enforces this on CT105.
     """
     assert _resolve_model_path({"_model_key": "gemma-4-12b-it"}) == "gemma-4-12b-it"
+
+
+class TestGpuPassthroughGate:
+    """spec-hw-slot-ownership §2 — the /dev/kfd + /dev/dri passthrough gate is
+    decided by the SLOT's ``device`` enum, NEVER by the profile.
+
+    Before the 1.0 fix, ``_resolve_llama_scalars`` read ``profile.device_class``
+    and defaulted it to ``"gpu"`` when unset, so a ``cpu-chat`` profile (all 16
+    seeds leave ``device_class`` unset) on a ``device="cpu"`` slot still
+    requested real GPU device nodes. Both directions are asserted: a cpu/npu
+    slot must get NOTHING, and a gpu slot must NOT be stranded on CPU.
+    """
+
+    _NODES: ClassVar[list[str]] = ["/dev/kfd", "/dev/dri/renderD128"]
+
+    def _spec(self, cfg: dict[str, Any], profile: ProfileConfig):
+        provider = ContainerProvider()
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=list(self._NODES),
+            ),
+            # Existence-filtered at the call site; force present so a CI host
+            # with no /dev/kfd still exercises the gate rather than the filter.
+            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
+        ):
+            return provider.container_spec(cfg, _model_info())
+
+    # ── the headline bug: cpu-chat on a device="cpu" slot ────────────────────
+
+    def test_cpu_slot_with_device_agnostic_profile_gets_no_gpu_nodes(self) -> None:
+        """The exact shipped shape: the ``cpu-chat`` seed leaves ``device_class``
+        unset, so the old ``or "gpu"`` floor mounted /dev/kfd + /dev/dri into a
+        CPU slot's container."""
+        cpu_chat = ProfileConfig(flags="--threads-batch 8 --jinja -b 256 -ub 256")
+        assert cpu_chat.device_class is None, "the cpu-chat seed is device-agnostic"
+        spec = self._spec(_slot_cfg(device="cpu", profile="cpu-chat"), cpu_chat)
+        assert spec.devices == []
+        assert spec.group_add == []
+
+    def test_cpu_slot_ignores_a_profile_that_claims_gpu(self) -> None:
+        """A legacy/imported profile carrying ``device_class="gpu"`` (e.g. the
+        published ``chat-long-context`` artifact) must NOT drag GPU nodes onto a
+        ``device="cpu"`` slot — the hint is inert."""
+        spec = self._spec(
+            _slot_cfg(device="cpu"), ProfileConfig(flags="-fa on", device_class="gpu")
+        )
+        assert spec.devices == []
+        assert spec.group_add == []
+
+    def test_npu_slot_gets_no_gpu_nodes(self) -> None:
+        spec = self._spec(_slot_cfg(device="npu"), ProfileConfig(flags="", device_class="gpu"))
+        assert spec.devices == []
+        assert spec.group_add == []
+
+    # ── the other direction: never strand a real GPU slot on CPU ────────────
+
+    def test_gpu_slot_with_device_agnostic_profile_still_gets_nodes(self) -> None:
+        """All 16 seeds leave ``device_class`` unset — a gpu-rocm slot bound to
+        one must still get real passthrough."""
+        spec = self._spec(_slot_cfg(device="gpu-rocm"), _moe_profile())
+        assert spec.devices == self._NODES
+        assert spec.group_add == ["993", "44"]
+
+    def test_gpu_slot_ignores_a_profile_that_claims_cpu(self) -> None:
+        spec = self._spec(
+            _slot_cfg(device="gpu-vulkan"), ProfileConfig(flags="-fa on", device_class="cpu")
+        )
+        assert spec.devices == self._NODES
+
+    def test_cuda_slot_uses_cdi_from_the_slot_device_not_profile_backend(self) -> None:
+        """NVIDIA is selected by ``device="gpu-cuda"``. CDI names are not paths,
+        so no existence filter and no --group-add."""
+        spec = self._spec(_slot_cfg(device="gpu-cuda"), _moe_profile())
+        assert spec.devices == ["nvidia.com/gpu=all"]
+        assert spec.group_add == []
+
+    def test_rocm_slot_does_not_take_cdi_from_a_profile_backend_cuda(self) -> None:
+        """A profile claiming ``backend="cuda"`` must not flip a gpu-rocm slot
+        onto the CDI path — the vendor comes from the slot's device."""
+        spec = self._spec(
+            _slot_cfg(device="gpu-rocm"), ProfileConfig(flags="-fa on", backend="cuda")
+        )
+        assert spec.devices == self._NODES
+        assert not any("nvidia.com" in d for d in spec.devices)
+
+    # ── back-compat: a hand-built / pre-pivot dict with no device at all ────
+
+    def test_deviceless_slot_cfg_falls_back_to_gpu_not_cpu(self) -> None:
+        """A pre-pivot slot dict with no ``device`` key keeps the historical
+        gpu default rather than silently losing its GPU."""
+        cfg = _slot_cfg()
+        cfg.pop("device")
+        spec = self._spec(cfg, _moe_profile())
+        assert spec.devices == self._NODES
 
 
 class TestContextSizeDerive:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -42,6 +42,7 @@ from hal0.providers.container import (
     _llama_launch_plan,
     _loopback_fence_command,
     _render_quadlet_from_plan,
+    _resolve_context_size,
     _resolve_model_path,
     resolved_command_for_slot,
 )
@@ -719,10 +720,15 @@ class TestLoadSync:
         assert (tmp_path / "test.service").exists()
 
     def test_load_sync_threads_ctx_size_and_model_tune(self, tmp_path: Path) -> None:
-        """load_sync bakes the slot ``context_size`` (base --ctx-size, still
-        slot-resolved) AND the MODEL's materialized ``defaults.extra_args`` into
-        the rendered unit. FLAGS-own: a slot ``[server].extra_args`` is inert —
-        the model owns the tune, so the override-kv rides ``model_info.defaults``."""
+        """load_sync bakes the resolved context window (base --ctx-size) AND the
+        MODEL's materialized ``defaults.extra_args`` into the rendered unit.
+        FLAGS-own: a slot ``[server].extra_args`` is inert — the model owns the
+        tune, so the override-kv rides ``model_info.defaults``.
+
+        CTX-own (v1.0): the window comes from the MODEL's
+        ``defaults.context_size``. The slot's ``[model].context_size`` is a
+        ceiling only, and here it sits ABOVE the model's window, so it does not
+        move the answer."""
         profile = _moe_profile()
         provider = ContainerProvider()
         unit_file = tmp_path / "test.service"
@@ -752,12 +758,15 @@ class TestLoadSync:
                 {
                     "path": "/mnt/ai-models/model.gguf",
                     "_model_key": "model",
-                    "defaults": {"extra_args": "--override-kv k=bool:false"},
+                    "defaults": {
+                        "extra_args": "--override-kv k=bool:false",
+                        "context_size": 131072,
+                    },
                 },
             )
 
         unit = unit_file.read_text()
-        assert "--ctx-size 131072" in unit  # slot context_size still reaches base
+        assert "--ctx-size 131072" in unit  # the MODEL's window reaches base
         assert "--override-kv k=bool:false" in unit  # model tune reaches launch
         assert "IGNORED=bool:true" not in unit  # slot extra_args inert
 
@@ -862,7 +871,13 @@ class TestLoadSync:
 
     def test_resolved_command_includes_ctx_size(self) -> None:
         """The displayed resolved_command must show --ctx-size so it matches
-        what actually launches."""
+        what actually launches — including the v1.0 ownership rule.
+
+        ``m`` is a registry miss, so the model declares no window and the
+        resolver lands on the 8192 safe floor. The slot's ``context_size``
+        131072 is a CEILING above that floor, so it cannot raise it. Preview and
+        launch share ``_resolve_context_size``, so what an operator sees here is
+        exactly what the unit gets."""
         profile = _moe_profile()
         cfg = {
             "profile": "rocm",
@@ -873,7 +888,8 @@ class TestLoadSync:
             argv = resolved_command_for_slot(cfg, model_path="/mnt/ai-models/m.gguf")
         assert argv is not None
         assert "--ctx-size" in argv
-        assert argv[argv.index("--ctx-size") + 1] == "131072"
+        assert argv[argv.index("--ctx-size") + 1] == "8192"
+        assert argv[argv.index("--ctx-size") + 1] != "4096"  # chat@4096 incident
 
     def test_resolved_command_includes_model_alias(self) -> None:
         """resolved_command shows --alias <model id> so it matches the unit."""
@@ -1148,10 +1164,89 @@ class TestContextSizeDerive:
         mi = _model_info(defaults={"context_size": 16384})
         assert self._ctx(self._spec(cfg, mi).command) == "16384"
 
-    def test_explicit_ctx_always_wins_over_native(self) -> None:
-        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 131072})
-        mi = _model_info(metadata={"context_length": 262144})
+
+class TestContextSizeOwnership:
+    """v1.0 ownership split — the MODEL owns the context window; the slot's
+    ``[model].context_size`` is a hardware CEILING, never an override.
+
+    Before this, ``_resolve_context_size`` returned the slot value OUTRIGHT
+    whenever it was set, so the model drawer's "Context size" and the slot
+    drawer's "Context size" both claimed the same field and the slot silently
+    won. The invariant now: the effective window can only STAY THE SAME or
+    SHRINK relative to what the model asks for — never grow.
+    """
+
+    def _spec(self, cfg: dict[str, Any], model_info: dict[str, Any]):
+        provider = ContainerProvider()
+        with patch(
+            "hal0.providers.container._resolve_profile",
+            return_value=_moe_profile(),
+        ):
+            return provider.container_spec(cfg, model_info)
+
+    @staticmethod
+    def _ctx(command: list[str]) -> str | None:
+        return command[command.index("--ctx-size") + 1] if "--ctx-size" in command else None
+
+    # ── the model is authoritative ───────────────────────────────────────────
+
+    def test_model_declared_ctx_outranks_gguf_native(self) -> None:
+        """An explicit ``defaults.context_size`` is a deliberate operator choice
+        and is NOT dense-capped — the reverse of the pre-1.0 order, which let a
+        262144 arch max shadow it."""
+        cfg = _slot_cfg()
+        mi = _model_info(metadata={"context_length": 262144}, defaults={"context_size": 131072})
         assert self._ctx(self._spec(cfg, mi).command) == "131072"
+
+    def test_slot_ctx_no_longer_raises_the_model_window(self) -> None:
+        """THE HEADLINE FIX. Slot asks for 131072, model says 16384 → the model
+        wins. Pre-1.0 this returned 131072."""
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 131072})
+        mi = _model_info(defaults={"context_size": 16384})
+        assert self._ctx(self._spec(cfg, mi).command) == "16384"
+
+    def test_slot_ctx_cannot_inflate_the_safe_fallback(self) -> None:
+        """A slot ceiling above a model with NO declared window resolves to the
+        8192 floor, not the slot's number."""
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 131072})
+        mi = _model_info()
+        assert self._ctx(self._spec(cfg, mi).command) == "8192"
+
+    # ── but the slot ceiling still clamps (the installer's VRAM budget) ──────
+
+    def test_slot_ceiling_below_model_window_still_clamps(self) -> None:
+        """#1108: ``hardware.recommend`` writes a VRAM-budget clamp into the
+        slot. Dropping it outright would reopen the first-warm OOM it exists to
+        prevent, so a ceiling BELOW the model's window is still honored."""
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 8192})
+        mi = _model_info(defaults={"context_size": 131072})
+        assert self._ctx(self._spec(cfg, mi).command) == "8192"
+
+    def test_slot_ceiling_clamps_the_gguf_native_window_too(self) -> None:
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 4096})
+        mi = _model_info(metadata={"context_length": 131072})
+        assert self._ctx(self._spec(cfg, mi).command) == "4096"
+
+    def test_equal_ceiling_and_model_window_is_a_no_op(self) -> None:
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 16384})
+        mi = _model_info(defaults={"context_size": 16384})
+        assert self._ctx(self._spec(cfg, mi).command) == "16384"
+
+    # ── the monotonic guarantee, stated directly on the resolver ────────────
+
+    def test_effective_window_never_exceeds_the_model_window(self) -> None:
+        """Property: for any slot ceiling, effective <= what the model asked
+        for. This is what makes the change safe to ship onto existing boxes —
+        no box can gain a KV cache it could not previously hold."""
+        mi = _model_info(defaults={"context_size": 16384})
+        model_window = _resolve_context_size(None, mi)
+        assert model_window == 16384
+        for ceiling in (None, 1024, 8192, 16384, 32768, 131072):
+            assert _resolve_context_size(ceiling, mi) <= model_window
+
+    def test_unset_ceiling_means_follow_the_model(self) -> None:
+        mi = _model_info(defaults={"context_size": 16384})
+        assert _resolve_context_size(None, mi) == 16384
 
 
 class TestFamilyDefaults:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hal0.config.schema import (
     FAMILY_DEFAULTS,
     MTP_FLAG_BUNDLE,
@@ -33,6 +35,8 @@ from hal0.providers import container as _container_mod
 from hal0.providers._gpu import resolve_gpu_group_ids
 from hal0.providers.base import RuntimeLaunchPlan
 from hal0.providers.container import (
+    _CTX_DENSE_CAP,
+    _CTX_SAFE_FALLBACK,
     _MODEL_STORE_MOUNT,
     _UNIT_STOP_TIMEOUT_S,
     ContainerProvider,
@@ -1247,6 +1251,60 @@ class TestContextSizeOwnership:
     def test_unset_ceiling_means_follow_the_model(self) -> None:
         mi = _model_info(defaults={"context_size": 16384})
         assert _resolve_context_size(None, mi) == 16384
+
+    # ── #1414: making the model authoritative must not entrench a bad row ────
+    #
+    # `PUT /api/models/{id}` accepted 0 / -1 / 99999999 with a 200 and 500'd on
+    # an unparseable value. The write boundary is being tightened separately
+    # (#1432) — but deliberately only for NEW writes, so rows already persisted
+    # stay readable and therefore fixable. Those rows are still on disk and
+    # still reach this resolver.
+    #
+    # Before the ownership flip the damage was masked: the slot's
+    # `[model].context_size` won outright, so a sane slot covered for a garbage
+    # model row. Now the model is authoritative and the value goes straight to
+    # `--ctx-size`. Making the model the owner WITHOUT this guard would have
+    # turned a bad-but-survivable row into a slot that never warms.
+
+    @pytest.mark.parametrize("bad", ["abc", "8k", "", [1], {}, 1.5])
+    def test_unparseable_model_ctx_falls_back_instead_of_launching(self, bad: Any) -> None:
+        """An int() failure yields the native window / safe floor, never a
+        crash and never a garbage `--ctx-size`."""
+        mi = _model_info(defaults={"context_size": bad})
+        assert _resolve_context_size(None, mi) == _CTX_SAFE_FALLBACK
+
+    @pytest.mark.parametrize("bad", [-1, -8192, 1, 127, 2**24 + 1, 99999999])
+    def test_implausible_model_ctx_falls_back_instead_of_launching(self, bad: int) -> None:
+        """Outside [128, 2**24] is ignored, NOT clamped — a half-applied garbage
+        number is harder to diagnose than falling through, and the operator's
+        intent is unrecoverable either way."""
+        mi = _model_info(defaults={"context_size": bad})
+        assert _resolve_context_size(None, mi) == _CTX_SAFE_FALLBACK
+
+    def test_implausible_model_ctx_still_defers_to_the_native_window(self) -> None:
+        """Falling back means falling through the NORMAL chain, so a model with
+        a real GGUF window still gets it rather than the bare floor."""
+        mi = _model_info(metadata={"context_length": 131072}, defaults={"context_size": -1})
+        assert _resolve_context_size(None, mi) == _CTX_DENSE_CAP
+
+    def test_zero_model_ctx_is_treated_as_unset(self) -> None:
+        """0 was already falsy-skipped; pinned so the new range check does not
+        change that path's answer."""
+        mi = _model_info(metadata={"context_length": 16384}, defaults={"context_size": 0})
+        assert _resolve_context_size(None, mi) == 16384
+
+    @pytest.mark.parametrize("ok", [128, 4096, 131072, 2**24])
+    def test_plausible_boundary_values_are_honored(self, ok: int) -> None:
+        """The guard must not reject legitimate windows, including both bounds."""
+        mi = _model_info(defaults={"context_size": ok})
+        assert _resolve_context_size(None, mi) == ok
+
+    def test_bad_model_ctx_reaches_the_launch_command_as_the_fallback(self) -> None:
+        """End-to-end through `container_spec`: the emitted `--ctx-size` is a
+        usable number, not `-1`."""
+        cfg = _slot_cfg()
+        mi = _model_info(defaults={"context_size": -1})
+        assert self._ctx(self._spec(cfg, mi).command) == str(_CTX_SAFE_FALLBACK)
 
 
 class TestFamilyDefaults:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1120,7 +1120,7 @@ class TestGpuPassthroughGate:
             _slot_cfg(device="gpu-rocm"), ProfileConfig(flags="-fa on", backend="cuda")
         )
         assert spec.devices == self._NODES
-        assert not any("nvidia.com" in d for d in spec.devices)
+        assert "nvidia.com/gpu=all" not in spec.devices
 
     # ── back-compat: a hand-built / pre-pivot dict with no device at all ────
 

--- a/tests/providers/test_container_assembler.py
+++ b/tests/providers/test_container_assembler.py
@@ -19,10 +19,12 @@ from hal0.config.schema import ProfileConfig
 from hal0.errors import BadRequest
 from hal0.providers.container import (
     ContainerProvider,
+    _llama_argv_segments,
     _llama_launch_plan,
     _render_quadlet_from_plan,
     resolved_command_for_slot,
 )
+from hal0.slots.argv import resolve_argv
 
 
 def _render_from_plan(token, plan, *, runtime_bin=None, publish_host="127.0.0.1"):
@@ -304,3 +306,179 @@ def test_env_empty_when_no_server_env() -> None:
         image="i:1", port=8095, model_path="/m.gguf", flags_str="", devices=[], group_ids=[]
     )
     assert plan.env == {}
+
+
+# ── 6. GOLDEN: the full ordered launch argv, pinned literally ────────────────
+#
+# Everything above (and every other argv test in the tree) asserts SEGMENT
+# MEMBERSHIP — `"-ngl" in command`, `command[command.index("--threads") + 1]`,
+# `set(labels) == {...}`. Membership and index-relative lookups are invariant
+# under a REORDER of `_llama_argv_segments`' return list, so today the entire
+# suite passes if someone swaps `chat_template` and `mmproj`, or hoists
+# `slot_hardware` above `model_extra_args`. That last one silently inverts the
+# documented precedence chain
+#
+#     base < model_extra_args < slot_hardware < chat_template < mmproj
+#
+# and hands a model's `defaults.extra_args` the power to override the slot's
+# typed hardware grid — the exact ownership inversion spec-hw-slot-ownership §2
+# exists to prevent.
+#
+# These tests pin the literal, fully-ordered argv. Any reorder, insertion,
+# removal, or renaming of a segment fails them with a readable diff.
+
+
+#: Every segment populated, with a deliberate cross-segment `--threads`
+#: collision (model says 3, slot says 16). Update this literal ONLY together
+#: with a deliberate, documented change to the launch shape.
+GOLDEN_MAXIMAL_ARGV: list[str] = [
+    # base
+    "--host", "0.0.0.0",
+    "--port", "8081",
+    "--model", "/var/lib/hal0/models/qwen3-4b/model.gguf",
+    "--alias", "hal0/qwen3-4b",
+    "--ctx-size", "32768",
+    # model_extra_args (the model's logical tune; its --threads 3 lost)
+    "-fa", "on",
+    "-b", "2048",
+    "-ub", "512",
+    "--jinja",
+    # slot_hardware (the slot's typed physical grid — wins the collision)
+    "-ngl", "99",
+    "--threads", "16",
+    # chat_template
+    "--chat-template-file", "/etc/hal0/templates/qwen3.jinja",
+    # mmproj
+    "--mmproj", "/var/lib/hal0/models/qwen3-4b/mmproj.gguf",
+]  # fmt: skip
+
+
+def _maximal_segments() -> list[tuple[str, list[str]]]:
+    """Every segment populated. `profile_flags`, `slot_parallel` and
+    `extra_args` are threaded in deliberately: they are inert (deleted at the
+    top of the builder) and must contribute NOTHING to the golden argv."""
+    return _llama_argv_segments(
+        port=8081,
+        model_path="/var/lib/hal0/models/qwen3-4b/model.gguf",
+        model_alias="hal0/qwen3-4b",
+        context_size=32768,
+        model_defaults={"extra_args": "-fa on -b 2048 -ub 512 --threads 3 --jinja"},
+        slot_n_gpu_layers=99,
+        slot_threads=16,
+        chat_template_path="/etc/hal0/templates/qwen3.jinja",
+        mmproj="/var/lib/hal0/models/qwen3-4b/mmproj.gguf",
+        # inert — must not appear anywhere in GOLDEN_MAXIMAL_ARGV
+        profile_flags="-ctk q8_0 -ctv q8_0",
+        slot_parallel=4,
+        extra_args="--no-webui",
+    )
+
+
+def test_golden_full_ordered_launch_argv() -> None:
+    """LITERAL equality on the whole argv — the reorder tripwire."""
+    assert resolve_argv(_maximal_segments()).argv == GOLDEN_MAXIMAL_ARGV
+
+
+def test_golden_segment_order_is_the_documented_precedence_chain() -> None:
+    """The labels, in order. `set()` comparisons elsewhere cannot catch a swap;
+    this is a list comparison."""
+    labels = [label for label, _tokens in _maximal_segments()]
+    assert labels == [
+        "base",
+        "model_extra_args",
+        "slot_hardware",
+        "chat_template",
+        "mmproj",
+    ]
+
+
+def test_golden_provenance_pins_which_segment_won_each_flag() -> None:
+    """The other half of the pin: not just the token order, but WHICH source
+    won every surviving flag. A reorder that happened to preserve token order
+    would still move a winner."""
+    resolved = resolve_argv(_maximal_segments())
+    assert [(p.flag, p.value, p.source) for p in resolved.provenance] == [
+        ("--host", "0.0.0.0", "base"),
+        ("--port", "8081", "base"),
+        ("--model", "/var/lib/hal0/models/qwen3-4b/model.gguf", "base"),
+        ("--alias", "hal0/qwen3-4b", "base"),
+        ("--ctx-size", "32768", "base"),
+        ("-fa", "on", "model_extra_args"),
+        ("-b", "2048", "model_extra_args"),
+        ("-ub", "512", "model_extra_args"),
+        ("--jinja", None, "model_extra_args"),
+        ("-ngl", "99", "slot_hardware"),
+        ("--threads", "16", "slot_hardware"),
+        ("--chat-template-file", "/etc/hal0/templates/qwen3.jinja", "chat_template"),
+        ("--mmproj", "/var/lib/hal0/models/qwen3-4b/mmproj.gguf", "mmproj"),
+    ]
+    # exactly one token pair was dropped: the model's losing `--threads 3`
+    assert resolved.removed == 1
+
+
+def test_golden_launch_plan_command_equals_the_golden_argv() -> None:
+    """The plan the load path actually renders — `_llama_launch_plan` collapses
+    the same segments — carries the identical argv. Pins the plan level too, so
+    a change to how the plan assembles the command cannot drift from the
+    builder."""
+    plan = _llama_launch_plan(
+        image="ghcr.io/hal0ai/hal0-rocmfpx:test",
+        port=8081,
+        model_path="/var/lib/hal0/models/qwen3-4b/model.gguf",
+        flags_str="-ctk q8_0 -ctv q8_0",
+        devices=[],
+        group_ids=[],
+        context_size=32768,
+        extra_args="--no-webui",
+        model_alias="hal0/qwen3-4b",
+        chat_template_path="/etc/hal0/templates/qwen3.jinja",
+        mmproj="/var/lib/hal0/models/qwen3-4b/mmproj.gguf",
+        model_defaults={"extra_args": "-fa on -b 2048 -ub 512 --threads 3 --jinja"},
+        slot_n_gpu_layers=99,
+        slot_threads=16,
+        slot_parallel=4,
+    )
+    assert plan.command == GOLDEN_MAXIMAL_ARGV
+
+
+def test_golden_minimal_argv() -> None:
+    """The floor: nothing but a port and a model path. Pins that no segment
+    leaks a default token in when its input is absent."""
+    argv = resolve_argv(_llama_argv_segments(port=8081, model_path="/m.gguf")).argv
+    assert argv == ["--host", "0.0.0.0", "--port", "8081", "--model", "/m.gguf"]
+
+
+def test_golden_later_segments_beat_a_model_tune_claiming_their_flags() -> None:
+    """Adversarial ordering proof. `--chat-template-file` and `--mmproj` are NOT
+    in `MANAGED_ARGS_DENYLIST`, so a model's `defaults.extra_args` can smuggle
+    them through the screen. They must still lose to the real `chat_template` /
+    `mmproj` segments — which is true only because those segments come LAST.
+    Hoist `model_extra_args` and hal0 loads the wrong projector."""
+    argv = resolve_argv(
+        _llama_argv_segments(
+            port=8081,
+            model_path="/m.gguf",
+            context_size=4096,
+            model_defaults={
+                "extra_args": (
+                    "--chat-template-file /tmp/evil.jinja --mmproj /tmp/evil.gguf --threads 1"
+                )
+            },
+            slot_threads=16,
+            slot_n_gpu_layers=0,
+            chat_template_path="/etc/hal0/templates/real.jinja",
+            mmproj="/models/real-mmproj.gguf",
+        )
+    ).argv
+    assert argv == [
+        "--host", "0.0.0.0",
+        "--port", "8081",
+        "--model", "/m.gguf",
+        "--ctx-size", "4096",
+        "-ngl", "0",
+        "--threads", "16",
+        "--chat-template-file", "/etc/hal0/templates/real.jinja",
+        "--mmproj", "/models/real-mmproj.gguf",
+    ]  # fmt: skip
+    assert "/tmp/evil.jinja" not in argv
+    assert "/tmp/evil.gguf" not in argv


### PR DESCRIPTION
## Summary
- Reject/screen slot-hardware and hal0-managed flags on profile create/update (#1411), grandfathering flags a legacy profile already carried so a byte-identical resave doesn't 400 on its own data.
- `providers/container.py`: GPU device-node passthrough now decided from `slot.device`, not `profile.device_class`/`.backend` — closes a bug where a `cpu-chat` profile on a `device="cpu"` slot still requested real GPU device nodes.
- `_resolve_context_size` is model-first; a slot's context value is a ceiling, not an override.
- Verify the envelope checksum on profile import **commit**, not only `dry_run` (#1416); `force: true` waives the checksum only, never the flag screen.

Reviewed PASS this session (diff-read + full local suite, 0 failures) — see `docs/rework/handoff-1-0-release.md` §6b. Rebased onto current `main` after Stream A merged; that rebase surfaced two real conflicts against main's own independent takes on #1411 and #1416 (per-flag grandfathering vs whole-string, and a route-level checksum check with no `force` bypass) — fixed in a follow-up commit on this branch, full local suite re-verified green after.

## Test plan
- [x] Targeted tests (`tests/config/test_profiles.py`, `tests/api/test_profiles_crud.py`, `tests/api/test_profiles_portable_routes.py`) pass
- [x] `ruff format --check` / `ruff check` clean
- [x] Full local backend suite green post-rebase (8229+ passed, 0 failed)
- [ ] CI