### PR TITLE
feat(ui): inline model-edit pencil, docked slot/model drawers

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -1159,6 +1159,25 @@
   cursor: default;
 }
 
+/* model row + inline model-edit pencil (slot card).
+   The pencil is a SIBLING of the model control, never nested inside it: the
+   LLM row is a <select> whose own click gesture must stay uncontested. The
+   picker keeps flexing to fill; the button is a fixed square. */
+:is(.infer-pane, .npu-pane) .smodel-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+:is(.infer-pane, .npu-pane) .smodel-row > .model-picker,
+:is(.infer-pane, .npu-pane) .smodel-row > .smodel {
+  flex: 1;
+  min-width: 0;
+}
+:is(.infer-pane, .npu-pane) .sctrl.scard-model-edit {
+  flex: 0 0 auto;
+}
+
 /* expanded-body status line — right-aligned mono */
 :is(.infer-pane, .npu-pane) .body-status {
   display: flex;

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -36,6 +36,7 @@ import { useModels } from '@/api/hooks/useModels'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
+import { slotModelRow } from './slots/slot-shared.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
 // the copy this file used to carry (and the verbatim clones in slot-list.jsx
 // and npu-pane.jsx).
@@ -320,7 +321,9 @@ export function slotCtrlPhase(slot) {
 //               for the NPU trio these map to stack-load / modality-toggle).
 //   phase     — overrides the lifecycle phase (NPU coresident roles derive it
 //               from their modality toggle, not the slot's own state).
-export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) {
+//   onEditModel / modelName — inline model-edit affordance. Omit both and the
+//               model row renders exactly as before (the NPU stack does).
+export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName }) {
   const dot = dotCls(ind)
   const ph = phase || slotCtrlPhase(s)
   // A live-ish card whose /api/slots enrichment hasn't landed yet (bare
@@ -343,7 +346,36 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) 
         <span className="sport">{s.port ? ':' + s.port : ''}</span>
       </div>
       <div className="scard-b">
-        {modelNode}
+        {/* Inline model edit sits OUTSIDE the model control, never nested in it:
+            the LLM model row is a <select> and the pencil must not compete with
+            that picker's own click/keyboard gesture. `stopPropagation` is
+            belt-and-braces on top of the separate hit area. Disabled when the
+            bound model isn't resolvable to a registry row — ModelDrawer needs
+            the row, not an id, and renders nothing for null. */}
+        {onEditModel ? (
+          <div className="smodel-row">
+            {modelNode}
+            <button
+              className="sctrl scard-model-edit"
+              data-testid={`infer-model-edit-${s.name}`}
+              disabled={!modelName}
+              title={
+                modelName
+                  ? `Edit model ${modelName} — launch flags, chat template, caps`
+                  : 'No model bound — nothing to edit'
+              }
+              aria-label={modelName ? `Edit model ${modelName}` : 'Edit model'}
+              onClick={(e) => {
+                e.stopPropagation()
+                onEditModel()
+              }}
+            >
+              <Ic name="edit" size={13} />
+            </button>
+          </div>
+        ) : (
+          modelNode
+        )}
         {full && (
           <div className="scard-meta">
             <div className="m">
@@ -374,7 +406,7 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit }) 
   )
 }
 
-function SlotCards({ rows, full, models, busyName, handlers, loading }) {
+function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows }) {
   if (!rows.length) {
     if (loading)
       return (
@@ -414,6 +446,10 @@ function SlotCards({ rows, full, models, busyName, handlers, loading }) {
             onEdit={() => handlers.onEdit(s)}
           />
         )
+        // The bound registry row, resolved through the shared helper the slot
+        // drawer uses. null = unbound or not in the list yet → the pencil is
+        // disabled rather than opening an empty editor.
+        const modelRow = modelRows ? modelRows(s) : null
         return (
           <SlotScard
             key={s.name}
@@ -423,6 +459,10 @@ function SlotCards({ rows, full, models, busyName, handlers, loading }) {
             modelNode={modelNode}
             controls={controls}
             onEdit={() => handlers.onEdit(s)}
+            onEditModel={
+              handlers.onEditModel ? () => handlers.onEditModel(s) : undefined
+            }
+            modelName={modelRow ? modelRow.longName || modelRow.name || modelRow.id : ''}
           />
         )
       })}
@@ -491,6 +531,12 @@ export function InferencePane() {
   const loadMut = useSlotLoad()
   const swapMut = useSlotSwap()
   const [busyName, setBusyName] = useStateI(null)
+  // Inline model edit — the ModelDrawer is mounted ONCE here (the pane owns the
+  // cards) and driven by the picked registry row, matching how models.jsx
+  // drives it. Row, not id: ModelDrawer renders nothing for a null model.
+  // There is no UI/overlay store in this app; drawer open-state is local
+  // useState in the nearest view owner.
+  const [modelEditRow, setModelEditRow] = useStateI(null)
 
   // The Inference rollup is the iGPU/CPU slot stack. Image generation is its
   // own pane (ComfyuiPane); NPU/FLM slots are cordoned off to the NPU · FLM
@@ -551,7 +597,17 @@ export function InferencePane() {
     onLogs: (s) => {
       window.dispatchEvent(new CustomEvent('hal0:slot-logs', { detail: { name: s.name } }))
     },
+    // Open the model editor for this slot's bound model — no close → Models
+    // page → find the row → reopen round-trip.
+    onEditModel: (s) => {
+      const row = slotModelRow(s, modelsQuery.data)
+      if (row) setModelEditRow(row)
+    },
   }
+
+  // Per-slot bound-row lookup handed to the cards so the pencil can be disabled
+  // (and labelled) without every card re-scanning the list itself.
+  const modelRowFor = (s) => slotModelRow(s, modelsQuery.data)
 
   const newSlot = () => window.dispatchEvent(new CustomEvent('hal0:create-slot'))
   const openLogs = () => {
@@ -559,6 +615,7 @@ export function InferencePane() {
   }
 
   return (
+    <>
     <div className="infer-pane">
       <div className="proto">
         {/* Single NPU-card-style header row — the old two-row stack (sec-label
@@ -612,6 +669,7 @@ export function InferencePane() {
                 full
                 loading={loading}
                 models={modelsQuery.data}
+                modelRows={modelRowFor}
                 busyName={busyName}
                 handlers={handlers}
               />
@@ -656,6 +714,18 @@ export function InferencePane() {
         </div>
       </div>
     </div>
+    {/* Inline model editor for the card pencil — ONE instance for the whole
+        pane, driven by the picked row. Not docked: nothing is stacked beneath
+        it here, so it takes the normal flush-right position and its own dim
+        scrim (contrast the slot edit drawer, which docks it — slot-modals.jsx).
+        Rendered as a sibling of .infer-pane so its `position: fixed` can't be
+        captured by a transformed ancestor. */}
+    <ModelDrawer
+      open={!!modelEditRow}
+      onClose={() => setModelEditRow(null)}
+      model={modelEditRow}
+    />
+    </>
   )
 }
 

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -5,7 +5,7 @@ import { useUpdateState, useUpdateApply, useUpdateJob } from '@/api/hooks/useUpd
 import { useInstallState, bundleNameOr } from '@/api/hooks/useInstallState'
 import { useComfyui } from '@/api/hooks/useComfyui'
 
-const { useState: useStateP, useEffect: useEffectP, useRef: useRefP, createContext: createContextP, useContext: useContextP } = React;
+const { useState: useStateP, useEffect: useEffectP, useRef: useRefP, useMemo: useMemoP, createContext: createContextP, useContext: useContextP } = React;
 
 // ─── Shared leaf utilities (single source of truth for the dash editors) ───
 // Slug/name rule — mirrors the API regex ^[a-z0-9][a-z0-9_-]{0,31}$. Consumed
@@ -145,12 +145,51 @@ function Modal({ open, onClose, title, eyebrow, children, foot, width = 640, dis
   );
 }
 
+// ─── DrawerDock — side-by-side drawer stacking ─────────────────────────────
+// This app has no portals: every overlay is an in-place `position: fixed` +
+// z-index element. `.drawer` (dashboard.css) hardcodes `right: 0; z-index: 95`,
+// so two drawers open at once dock flush-right at EQUAL z-index and the
+// later-rendered one fully COVERS the first instead of sitting beside it.
+//
+// Two knobs fix that, both readable as direct Drawer props:
+//   rightOf  — px to move the drawer's right edge inboard, so it lands flush
+//              against the left edge of the drawer it stacks on. Pass the
+//              other drawer's width. Degrades to the overlay stack below
+//              1200px (see `.drawer--docked` in dashboard.css) rather than
+//              pushing the panel off-canvas to the left.
+//   backdrop — "dim" (default, the normal scrim) | "clear" (a click target
+//              with no paint) | "none". Each Drawer renders its OWN
+//              full-screen `.drawer-backdrop`, and two dimmed scrims
+//              double-darken the page, so a stacked drawer wants "clear":
+//              exactly one dim layer, and click-outside still dismisses the
+//              TOP drawer.
+//
+// DrawerDock exists because the drawer being docked usually isn't the one you
+// own. EditSlotDrawer stacks <ModelDrawer>, which owns its own <Drawer> and
+// takes no drawer props — wrapping it in <DrawerDock> reaches that nested
+// Drawer through context instead of threading a prop through every component
+// in between. Explicit props always beat the ambient dock.
+const DrawerDockContext = createContextP(null);
+
+export function DrawerDock({ rightOf = 0, backdrop = "clear", children }) {
+  const value = useMemoP(() => ({ rightOf, backdrop }), [rightOf, backdrop]);
+  return <DrawerDockContext.Provider value={value}>{children}</DrawerDockContext.Provider>;
+}
+
 // ─── Right-side Drawer ────────────────────────────────────────────────────
 // Captures + restores focus and traps Tab within the drawer (honours
 // role="dialog" aria-modal). Pass `dirty` (+ optional `confirmDiscard`) to
 // guard Esc/backdrop/close against unsaved changes; `dismissable={false}`
-// disables backdrop dismissal.
-function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, headRight, dirty = false, dismissable = true, confirmDiscard = "Discard unsaved changes?" }) {
+// disables backdrop dismissal. `rightOf` / `backdrop` dock this drawer beside
+// another one — see DrawerDock above.
+function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, headRight, dirty = false, dismissable = true, confirmDiscard = "Discard unsaved changes?", rightOf, backdrop }) {
+  const dock = useContextP(DrawerDockContext);
+  // A non-finite / negative offset is treated as "not docked" rather than
+  // emitting `right: NaNpx`, which would collapse the panel to the viewport
+  // edge with no visible cause.
+  const dockRaw = Number(rightOf ?? dock?.rightOf ?? 0);
+  const dockOffset = Number.isFinite(dockRaw) && dockRaw > 0 ? dockRaw : 0;
+  const scrim = backdrop ?? dock?.backdrop ?? "dim";
   const shellRef = useRefP(null);
   const [discardOpen, setDiscardOpen] = useStateP(false);
   useEffectP(() => { if (!open) setDiscardOpen(false); }, [open]);
@@ -168,10 +207,16 @@ function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, he
   useFocusTrap(shellRef, open);
   return (
     <>
-      <div
-        className={"drawer-backdrop" + (open ? " open" : "")}
-        onClick={() => { if (dismissable) requestClose(); }}
-      />
+      {scrim !== "none" && (
+        <div
+          className={
+            "drawer-backdrop" +
+            (open ? " open" : "") +
+            (scrim === "clear" ? " drawer-backdrop--clear" : "")
+          }
+          onClick={() => { if (dismissable) requestClose(); }}
+        />
+      )}
       {dirty && (
         <DiscardGuardDialog
           open={discardOpen}
@@ -183,10 +228,17 @@ function Drawer({ open, onClose, title, eyebrow, children, foot, width = 520, he
       <aside
         ref={shellRef}
         tabIndex={-1}
-        className={"drawer" + (open ? " open" : "")}
-        style={{ width }}
+        className={"drawer" + (open ? " open" : "") + (dockOffset ? " drawer--docked" : "")}
+        // The dock offset rides a CSS custom property, not `right` directly:
+        // inline styles win over stylesheet rules only for the properties they
+        // actually set, so `.drawer--docked`'s narrow-viewport media query can
+        // still reset `right` back to 0.
+        style={dockOffset ? { width, "--drawer-dock": `${dockOffset}px` } : { width }}
+        data-drawer-dock={dockOffset || undefined}
+        // aria-modal is a lie while two drawers are docked side by side — both
+        // are genuinely reachable — so the stacked one drops the claim.
         role="dialog"
-        aria-modal="true"
+        aria-modal={dockOffset ? undefined : "true"}
         aria-hidden={!open}
       >
         <div className="drawer-h">
@@ -1057,4 +1109,4 @@ function ImportDialog({
   );
 }
 
-Object.assign(window, { Modal, Drawer, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FirstRunBanner, FieldGroup, FieldInfoIcon, PillToggle, MtpControl, NAME_RE, toast, useFocusTrap, FormRow, useForm, FormDrawer, ImportDialog });
+Object.assign(window, { Modal, Drawer, DrawerDock, ConfirmDialog, Banner, BannerStack, BannerProvider, useBanners, BANNER_CATALOG, Menu, UpdateBanner, GpuImageModeBanner, FirstRunBanner, FieldGroup, FieldInfoIcon, PillToggle, MtpControl, NAME_RE, toast, useFocusTrap, FormRow, useForm, FormDrawer, ImportDialog });

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -1335,12 +1335,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 						<div className="form-row">
 							<div className="form-lbl">
-								<span>Context (override)</span>
-								<FieldInfoIcon description="⟳ ctx_size — context window in tokens, an OVERRIDE of the
-									bound model's own default context_size (set on the model drawer).
-									Slot-owned so the same model can run a bigger/smaller window on
-									different hardware. PATCHes /defaults; takes effect on next
-									request. (~model-load seconds)" />
+								<span>Context (ceiling)</span>
+								<FieldInfoIcon description="⟳ ctx_size — a hardware CEILING in tokens, not an
+									override: the bound model's own default context_size (set on the
+									model drawer) is authoritative, and this only clamps it down for
+									hardware that can't fit the model's full window. Slot-owned so the
+									same model can run capped on lighter hardware elsewhere. PATCHes
+									/defaults; takes effect on next request. (~model-load seconds)" />
 							</div>
 							<div className="form-ctl">
 								<input

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -22,6 +22,13 @@ import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
 import { stateChipClassForSlot, slotButtonPhase } from "./slot-status.js";
+import { slotModelRow } from "./slots/slot-shared.js";
+
+// The slot edit drawer's own width, and therefore the offset the stacked model
+// drawer docks at so its right edge lands flush against this drawer's left one.
+// ONE constant: a width that drifted from the dock offset would leave a gap or
+// an overlap with no obvious cause.
+const SLOT_DRAWER_WIDTH = 560;
 
 const {
 	useState: useStateSM,
@@ -471,10 +478,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 	// Bound model row, resolved BEFORE the `!slot` guard below: the effect
 	// that follows must run on every render, and anything after an early
-	// return does not (React counts hooks positionally).
-	const curModelId = slot?.model_id || slot?.model || "";
-	const curModelRow =
-		(modelsQuery.data ?? []).find((m) => m.id === curModelId) || null;
+	// return does not (React counts hooks positionally). slotModelRow is the
+	// shared resolver (dash/slots/slot-shared.js) the slot card uses too.
+	const curModelRow = slotModelRow(slot, modelsQuery.data);
 	// ModelDrawer renders nothing for a null model and never calls onClose in
 	// that path, so a models refetch that drops the bound row would otherwise
 	// leave modelEditOpen stuck true (dead ✕/Esc, and a surprise re-stack when
@@ -624,7 +630,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// drawer in a blocked "Saving…" state for the whole model-load.
 	const saving = editMut.isPending || defaultsMut.isPending;
 
-	// (curModelId / curModelRow are resolved above the `!slot` guard, so the
+	// (curModelRow is resolved above the `!slot` guard, so the
 	// modelEditOpen effect can run on every render.)
 
 	// Device-class token for profile/runner fit filters — mirrors the
@@ -752,7 +758,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 				onClose={requestClose}
 				eyebrow={`Slots · /slots/${slot.name}`}
 				title={`Edit ${slot.name}`}
-				width={560}
+				width={SLOT_DRAWER_WIDTH}
 				headRight={
 					<label
 						className="slot-enable-toggle drawer-enable"
@@ -1302,14 +1308,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
 													</option>
 												))}
 											</select>
+											{/* Inline model edit — the app-wide pencil affordance
+											    (Icons.edit), same bare `btn ghost sm` icon-button
+											    convention as the slot card. Opens the model drawer
+											    DOCKED to the left of this one, so the slot's unsaved
+											    edits stay visible and editable underneath. */}
 											<button
 												className="btn ghost sm"
 												data-testid="slot-model-edit-open"
 												disabled={!curModelRow}
 												title="Edit the bound model's tune (flags, template, caps) in place"
-												onClick={() => setModelEditOpen(true)}
+												aria-label={`Edit model ${curModelRow?.longName || curModelRow?.name || ""}`.trim()}
+												onClick={(e) => {
+													e.stopPropagation();
+													setModelEditOpen(true);
+												}}
 											>
-												Edit model…
+												{Icons.edit}
 											</button>
 										</div>
 										{swapping && <div className="hint">Swapping…</div>}
@@ -1710,14 +1725,23 @@ function EditSlotDrawer({ open, slot, onClose }) {
 				onClose={() => setRenameOpen(false)}
 			/>
 			{/* Stacked model editor — the reusable ModelDrawer (window-global,
-	        same instance contract as models.jsx). Rendered later in the DOM at
-	        equal z-index so it fully overlays this drawer; its own save path
-	        closes it and returns here with every slot edit intact. */}
-			<ModelDrawer
-				open={modelEditOpen && !!curModelRow}
-				onClose={() => setModelEditOpen(false)}
-				model={curModelRow}
-			/>
+	        same instance contract as models.jsx). DrawerDock reaches the
+	        <Drawer> nested inside ModelDrawer through context, docking it
+	        SLOT_DRAWER_WIDTH px inboard so it lands flush against this drawer's
+	        left edge: two panels side by side, both fully visible and
+	        interactive, instead of the model drawer covering this one at equal
+	        z-index. `backdrop="clear"` keeps exactly one dim scrim on the page
+	        (this drawer's) while leaving click-outside dismissing the TOP layer.
+	        Below 1200px there is no room for both, and the CSS falls back to the
+	        overlay stack (see .drawer--docked in dashboard.css). Its own save
+	        path closes it and returns here with every slot edit intact. */}
+			<DrawerDock rightOf={SLOT_DRAWER_WIDTH} backdrop="clear">
+				<ModelDrawer
+					open={modelEditOpen && !!curModelRow}
+					onClose={() => setModelEditOpen(false)}
+					model={curModelRow}
+				/>
+			</DrawerDock>
 			<ConfirmDialog
 				open={discardOpen}
 				onCancel={() => setDiscardOpen(false)}

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -30,6 +30,7 @@ import {
 import { TelemetryHeader } from './telemetry-header.jsx'
 import { slotIndicatorFromPhase, slotButtonPhase, isSlotLive } from './slot-status.js'
 import { prettyProfile } from './profile-names.js'
+import { slotModelRow } from './slots/slot-shared.js'
 
 const { useState: useStateS, useRef, useEffect } = React;
 
@@ -133,6 +134,17 @@ function SlotImagePullBar({ slot }) {
 }
 
 // ─── SlotCard (instrument variant) ───
+//
+// NOTE (2026-07): this grid is currently UNMOUNTED. `renderGroup`/`slotWithState`
+// below have no call site — the standalone Chat + Capabilities SlotCard grids
+// were retired and `InferencePane` (inference-pane.jsx `SlotScard`) is the live
+// per-slot card surface, which is where the inline model-edit pencil actually
+// ships. It is wired here too so the two cards can't diverge if the grid is
+// revived; see slots-v3.spec.ts, which asserts `.slots-grid` has count 0.
+//
+//   modelRow / onEditModel — inline model edit. `modelRow` is the slot's bound
+//   registry row (resolved by SlotsView through slotModelRow); the pencil is
+//   disabled without one because ModelDrawer needs the row, not an id.
 function SlotCard({
   slot,
   onSwap,
@@ -142,6 +154,8 @@ function SlotCard({
   onStart,
   onSwapPick,
   onViewLogs,
+  onEditModel,
+  modelRow,
   swapOpen,
   onCloseSwap,
   errorMsg,
@@ -230,16 +244,37 @@ function SlotCard({
               headRight) now, not on the card. */}
         </div>
       </div>
-      <div className="slot-model mono" onClick={onSwap} style={{position: "relative"}}>
-        <span className="mid">{model}</span>
-        <span className="chev">{Icons.chev}</span>
-        {swapOpen && (
-          <InlineSwapPopover
-            slot={slot}
-            open={swapOpen}
-            onClose={onCloseSwap}
-            onPick={onSwapPick}
-          />
+      {/* The model dropdown and the model-edit pencil are SIBLINGS. The pencil
+          is deliberately NOT nested inside .slot-model: that div is itself the
+          click target that opens InlineSwapPopover, so a nested button would be
+          fighting the swap gesture. stopPropagation is belt-and-braces on top
+          of the separate hit area. */}
+      <div className="slot-model-row">
+        <div className="slot-model mono" onClick={onSwap} style={{position: "relative"}}>
+          <span className="mid">{model}</span>
+          <span className="chev">{Icons.chev}</span>
+          {swapOpen && (
+            <InlineSwapPopover
+              slot={slot}
+              open={swapOpen}
+              onClose={onCloseSwap}
+              onPick={onSwapPick}
+            />
+          )}
+        </div>
+        {onEditModel && (
+          <button
+            className="btn ghost sm slot-model-edit"
+            data-testid={`slot-card-model-edit-${slot.name}`}
+            disabled={!modelRow}
+            title={modelRow
+              ? `Edit model ${modelRow.longName || modelRow.name || modelRow.id} — launch flags, chat template, caps`
+              : "No model bound — nothing to edit"}
+            aria-label={modelRow
+              ? `Edit model ${modelRow.longName || modelRow.name || modelRow.id}`
+              : "Edit model"}
+            onClick={(e) => { e.stopPropagation(); onEditModel(); }}
+          >{Icons.edit}</button>
         )}
       </div>
       <div className="slot-chips">
@@ -537,6 +572,10 @@ function SlotListRow({ slot, onEdit }) {
 // ─── Slots view ───
 function SlotsView({ slotVariant, slotParam, onGo }) {
   const slotsQuery = useSlots();
+  // Model registry, for the slot card's inline model-edit pencil. useModels()
+  // shares the react-query cache key ['models'] with InferencePane's own call,
+  // so this extra consumer costs nothing.
+  const modelsQuery = useModels();
   // Single source of truth: the hook. The Playwright apiMock fixture
   // fulfils /api/slots so mock-mode coverage is symmetric with live runs;
   // we no longer fall back to HAL0_DATA.slots (per slots-wireup brief).
@@ -559,6 +598,10 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   const [swapName, setSwapName] = useStateS(null);
   const [logsForSlot, setLogsForSlot] = useStateS(null);
   const [busyName, setBusyName] = useStateS(null);
+  // ONE ModelDrawer instance for the whole card grid, driven by the picked
+  // registry ROW (ModelDrawer renders nothing for a null model, and needs the
+  // row rather than an id). Local useState — there is no UI/overlay store.
+  const [modelEditRow, setModelEditRow] = useStateS(null);
   // Slots-page tabs: "inference" (chat/embed/voice/npu) vs "image" (the ComfyUI
   // generation engine pane). ComfyUI is one container engine, not per-model
   // slots, and is mutually exclusive with the LLM stack — so it gets its own
@@ -704,12 +747,16 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   ];
   const openCreatePrefilled = (def) => { setCreateDefaults(def); setCreateOpen(true); };
 
-  const slotWithState = (s, errorMsg) => (
+  const slotWithState = (s, errorMsg) => {
+    const modelRow = slotModelRow(s, modelsQuery.data);
+    return (
     <SlotCard
       key={s.name}
       slot={s}
       errorMsg={errorMsg}
       busy={busyName === s.name}
+      modelRow={modelRow}
+      onEditModel={() => { if (modelRow) setModelEditRow(modelRow); }}
       swapOpen={swapName === s.name}
       onSwap={(e) => { e.stopPropagation(); setSwapName(swapName === s.name ? null : s.name); }}
       onCloseSwap={() => setSwapName(null)}
@@ -733,7 +780,8 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
       }
       onViewLogs={() => { setLogsForSlot(s.name); }}
     />
-  );
+    );
+  };
 
   // Skip-path layout: render six seeded empty cards under their default groups.
   if (skipPath) {
@@ -1036,6 +1084,14 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
         open={!!logsSlot}
         slot={logsSlot}
         onClose={() => setLogsForSlot(null)}
+      />
+      {/* Inline model editor for the card-grid pencil. Not docked — nothing is
+          stacked beneath it from this surface (the slot EDIT drawer docks it
+          instead, see slot-modals.jsx). */}
+      <ModelDrawer
+        open={!!modelEditRow}
+        onClose={() => setModelEditRow(null)}
+        model={modelEditRow}
       />
     </div>
   );

--- a/ui/src/dash/slots/slot-shared.js
+++ b/ui/src/dash/slots/slot-shared.js
@@ -29,6 +29,29 @@ export function deviceFromModel(model) {
   return "cpu";
 }
 
+// ─── slot → bound model row ────────────────────────────────────────────────
+// The id a slot is bound to. `model_id` is the live-reconciled id from
+// /api/slots; `model` is the display/label fallback carried by the bare
+// /api/status union entry (and by HAL0_DATA seeds). Empty string = unbound.
+export function slotModelId(slot) {
+  return slot?.model_id || slot?.model || "";
+}
+
+// The FULL normalized model row a slot is bound to, resolved out of a
+// useModels() list (which already maps through normalizeApiModel). Returns
+// null when the slot is unbound or the row isn't in the list yet — callers
+// must treat null as "no model editor available", because ModelDrawer needs
+// the row, not an id, and renders nothing for a null model.
+//
+// One copy on purpose: the slot edit drawer (slot-modals.jsx) and the slot
+// card (slots.jsx / inference-pane.jsx) both need this exact lookup, and the
+// `model_id || model` precedence is easy to get subtly wrong twice.
+export function slotModelRow(slot, models) {
+  const id = slotModelId(slot);
+  if (!id) return null;
+  return (models ?? []).find((m) => m?.id === id) || null;
+}
+
 // The short device label + hue token for a device string (chip / teach copy).
 export function deviceHue(deviceToken) {
   const t = String(deviceToken || "").toLowerCase();

--- a/ui/src/dash/slots/slot-shared.test.ts
+++ b/ui/src/dash/slots/slot-shared.test.ts
@@ -1,0 +1,63 @@
+// slot-shared — pure-logic unit coverage for the slot→model resolution helpers.
+//
+// Named `.test.ts` deliberately: vitest.config.ts's `include` is
+// ['src/**/*.test.ts', 'tests/e2e/*.test.ts'], so the older
+// src/dash/__tests__/*.test.mjs files are NOT collected by `vitest run`. A
+// `.test.mjs` file added here would silently never execute.
+import { describe, expect, it } from 'vitest'
+
+// @ts-expect-error — slot-shared.js is untyped JS (tsconfig allowJs/checkJs:false)
+import { slotModelId, slotModelRow } from './slot-shared.js'
+
+const ROWS = [
+  { id: 'qwen3.6-27b', name: 'Qwen3.6 27B', type: 'llm' },
+  { id: 'nomic-v1.5', name: 'nomic-embed-text-v1.5', type: 'embedding' },
+]
+
+describe('slotModelId', () => {
+  it('prefers model_id over the display-label fallback', () => {
+    expect(slotModelId({ model_id: 'a', model: 'b' })).toBe('a')
+  })
+
+  it('falls back to `model` when model_id is absent (bare /api/status entry)', () => {
+    expect(slotModelId({ model: 'b' })).toBe('b')
+  })
+
+  it('returns "" for an unbound slot', () => {
+    expect(slotModelId({})).toBe('')
+    expect(slotModelId({ model_id: null, model: '' })).toBe('')
+  })
+
+  it('returns "" rather than throwing for null/undefined', () => {
+    expect(slotModelId(null)).toBe('')
+    expect(slotModelId(undefined)).toBe('')
+  })
+})
+
+describe('slotModelRow', () => {
+  it('resolves the full row for a bound slot', () => {
+    expect(slotModelRow({ model_id: 'qwen3.6-27b' }, ROWS)).toBe(ROWS[0])
+  })
+
+  it('resolves through the `model` fallback too', () => {
+    expect(slotModelRow({ model: 'nomic-v1.5' }, ROWS)).toBe(ROWS[1])
+  })
+
+  it('returns null for an unbound slot without scanning the list', () => {
+    expect(slotModelRow({}, ROWS)).toBeNull()
+    expect(slotModelRow(null, ROWS)).toBeNull()
+  })
+
+  it('returns null when the bound id is not in the list (mid-refetch / deleted)', () => {
+    expect(slotModelRow({ model_id: 'gone' }, ROWS)).toBeNull()
+  })
+
+  it('tolerates a missing/undefined model list', () => {
+    expect(slotModelRow({ model_id: 'qwen3.6-27b' }, undefined)).toBeNull()
+    expect(slotModelRow({ model_id: 'qwen3.6-27b' }, null)).toBeNull()
+  })
+
+  it('skips null entries in the list instead of throwing', () => {
+    expect(slotModelRow({ model_id: 'qwen3.6-27b' }, [null, ...ROWS])).toBe(ROWS[0])
+  })
+})

--- a/ui/src/dash/slots/slot-shared.test.ts
+++ b/ui/src/dash/slots/slot-shared.test.ts
@@ -6,7 +6,8 @@
 // `.test.mjs` file added here would silently never execute.
 import { describe, expect, it } from 'vitest'
 
-// @ts-expect-error — slot-shared.js is untyped JS (tsconfig allowJs/checkJs:false)
+// slot-shared.js is untyped JS; tsconfig has allowJs with checkJs:false, so the
+// import resolves and the exports come through as `any`.
 import { slotModelId, slotModelRow } from './slot-shared.js'
 
 const ROWS = [

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1898,6 +1898,11 @@ a { color: inherit; text-decoration: none; }
 .slot-model:hover { border-color: var(--line-strong); }
 .slot-model .mid { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .slot-model .chev { color: var(--fg-4); }
+/* Slot-card model row: the swap dropdown plus the inline model-edit pencil as
+   a SIBLING (never nested — .slot-model is itself the popover click target). */
+.slot-model-row { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.slot-model-row > .slot-model { flex: 1; min-width: 0; }
+.slot-model-row > .slot-model-edit { flex: 0 0 auto; }
 
 .slot-chips { display: flex; flex-wrap: wrap; gap: 5px; }
 
@@ -2859,6 +2864,45 @@ select.npu-sel {
   color: var(--fg-4);
   gap: 12px;
 }
+
+/* ─── Docked drawer (side-by-side stack) ────────────────────────────
+   Consumed by the slot edit drawer, which stacks the model drawer beside
+   itself (see DrawerDock in dash/primitives.jsx). There are no portals here:
+   `.drawer` is `position: fixed; right: 0; z-index: 95`, so a second drawer
+   would otherwise land flush-right at equal z-index and fully cover the first.
+
+   `right` is driven by the --drawer-dock custom property, set inline by the
+   primitive, NOT by an inline `right`. Inline styles beat stylesheet rules only
+   for the properties they actually set, so keeping `right` in the stylesheet is
+   what lets the narrow-viewport fallback below reclaim it. */
+.drawer.drawer--docked {
+  right: var(--drawer-dock, 0px);
+  /* Never push the panel off-canvas to the left: shrink first. */
+  max-width: calc(100vw - var(--drawer-dock, 0px));
+  /* Flush against the drawer it stacks on — a lighter shadow so the seam
+     between the two panels reads as one continuous surface. */
+  box-shadow: -14px 0 40px -18px rgba(0, 0, 0, 0.55);
+}
+/* Closed, a docked drawer must slide fully off-canvas. The base
+   `translateX(100%)` only clears its own width, which would park the panel
+   directly on top of the drawer it is docked beside. */
+.drawer.drawer--docked:not(.open) {
+  transform: translateX(calc(100% + var(--drawer-dock, 0px)));
+}
+/* Below ~1200px there is no room for both panels (the slot drawer is 560 and
+   the model drawer 600 = 1160 plus breathing room), so drop back to the
+   overlay stack instead of squeezing the docked panel into a useless column. */
+@media (max-width: 1199px) {
+  .drawer.drawer--docked {
+    right: 0;
+    max-width: 100vw;
+  }
+  .drawer.drawer--docked:not(.open) { transform: translateX(100%); }
+}
+/* A stacked drawer's own scrim must not double-darken the page — the drawer
+   underneath already painted one. Kept as a click target with no paint so
+   click-outside still dismisses the TOP drawer. */
+.drawer-backdrop.drawer-backdrop--clear { background: transparent; }
 
 /* ─── Banner ───────────────────────────────────────────────────── */
 .view-banners { padding: 20px 28px 0; max-width: 1600px; margin: 0 auto; }

--- a/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
+++ b/ui/tests/e2e/specs/drawer-save-errors-v3.spec.ts
@@ -108,7 +108,7 @@ test.describe('Slot drawer — rejected writes', () => {
     })
     await modelGroup
       .locator('.form-row')
-      .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(override\)$/ }) })
+      .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }) })
       .locator('input')
       .fill('16384')
     await page.getByTestId('slot-hw-ngl').fill('24')

--- a/ui/tests/e2e/specs/slot-card-model-edit-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-model-edit-v3.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * slot-card-model-edit-v3 — the inline model-edit pencil on the SLOT CARD.
+ *
+ * The card is `SlotScard` in dash/inference-pane.jsx: the standalone Chat +
+ * Capabilities `slots.jsx` SlotCard grids were retired (slots-v3.spec.ts
+ * asserts `.slots-grid` has count 0), so the InferencePane card is the live
+ * per-slot surface and the only one a spec can drive.
+ *
+ *   K1. the pencil renders beside the model picker and opens the model drawer
+ *       on the slot's BOUND registry row.
+ *   K2. it does NOT fight the model picker: clicking it fires no /swap and
+ *       leaves the select's value untouched. (The pencil is a SIBLING of the
+ *       picker, never nested in it — same rule as slots.jsx SlotCard, where
+ *       the model div is itself the InlineSwapPopover click target.)
+ *   K3. it does NOT open the slot edit drawer — that is the card's own Edit
+ *       control, on a different route (#slots/:name).
+ *   K4. disabled when the bound model has no registry row: ModelDrawer needs
+ *       the ROW, not an id, and renders nothing for null.
+ *
+ * The stacked/docked variant of this drawer (opened from INSIDE the slot edit
+ * drawer) is covered by slot-drawer-model-stack-v3.spec.ts.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+// model_id must be a real HAL0_DATA.models id for the row lookup to resolve.
+const PRIMARY = {
+  name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
+  runtime: 'container', container_status: 'running', container_health: true,
+  model: 'qwen3.6-27b-mtp', model_id: 'qwen3.6-27b-mtp',
+  modelLong: 'Qwen3.6-27B-MTP',
+  group: 'chat', state: 'serving', port: 8092, isDefault: true,
+  n_gpu_layers: -1,
+  metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
+}
+// Bound to an id absent from the registry.
+const ORPHAN = {
+  ...PRIMARY,
+  name: 'orphan',
+  model: 'ghost-7b',
+  model_id: 'ghost-7b',
+  port: 8093,
+}
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').first()
+const card = (page: Page, name: string) => pane(page).getByTestId(`infer-slot-${name}`)
+const pencil = (page: Page, name: string) => page.getByTestId(`infer-model-edit-${name}`)
+// The pane's own ModelDrawer is NOT docked (nothing is stacked beneath it here).
+const drawer = (page: Page) => page.locator('.drawer')
+
+test.describe('Slot card — inline model edit', () => {
+  test('K1 — the pencil sits beside the model picker and opens the bound model', async ({ page }) => {
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots')
+    await expect(card(page, 'primary')).toBeVisible()
+
+    // Sibling of the picker inside the model row, not nested inside it.
+    const row = card(page, 'primary').locator('.smodel-row')
+    await expect(row.locator('> select.model-picker')).toHaveCount(1)
+    await expect(row.locator('> button')).toHaveCount(1)
+    await expect(pencil(page, 'primary')).toBeEnabled()
+    await expect(pencil(page, 'primary').locator('svg')).toHaveCount(1)
+    // Nothing stacked yet.
+    await expect(drawer(page)).toHaveCount(0)
+
+    await pencil(page, 'primary').click()
+    await expect(drawer(page)).toBeVisible()
+    await expect(drawer(page).locator('.modal-h-eye')).toContainText('Edit model')
+    await expect(drawer(page).locator('.drawer-h h2')).toHaveText('Qwen3.6-27B-MTP')
+  })
+
+  test('K2 — the pencil never fires a model swap and leaves the picker alone', async ({ page }) => {
+    const swaps: any[] = []
+    await page.route('**/api/slots/primary/swap', async (route) => {
+      swaps.push(route.request().postDataJSON())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots')
+
+    const select = card(page, 'primary').locator('select.model-picker')
+    await expect(select).toHaveValue('qwen3.6-27b-mtp')
+
+    await pencil(page, 'primary').click()
+    await expect(drawer(page)).toBeVisible()
+
+    // No swap fired, and the bound model is unchanged. `primary` is a LIVE
+    // container here, so an accidental swap would also cold-restart it.
+    await page.waitForTimeout(250)
+    expect(swaps).toEqual([])
+    await expect(select).toHaveValue('qwen3.6-27b-mtp')
+  })
+
+  test('K3 — the pencil does not open the slot edit drawer', async ({ page }) => {
+    await seedSlots(page, [PRIMARY])
+    await page.goto('/#slots')
+    await pencil(page, 'primary').click()
+    await expect(drawer(page)).toBeVisible()
+
+    // The MODEL editor opened, not the slot editor — the route never moved to
+    // #slots/primary (which is what the card's own Edit control does).
+    expect(page.url()).toContain('#slots')
+    expect(page.url()).not.toContain('#slots/primary')
+    await expect(drawer(page)).toHaveCount(1)
+    await expect(page.locator('.drawer', { hasText: 'Edit primary' })).toHaveCount(0)
+  })
+
+  test('K4 — the pencil is disabled when the bound model has no registry row', async ({ page }) => {
+    await seedSlots(page, [ORPHAN])
+    await page.goto('/#slots')
+    await expect(card(page, 'orphan')).toBeVisible()
+    await expect(pencil(page, 'orphan')).toBeDisabled()
+    await expect(pencil(page, 'orphan')).toHaveAttribute('title', /No model bound/)
+  })
+})

--- a/ui/tests/e2e/specs/slot-drawer-dirty-baseline-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-dirty-baseline-v3.spec.ts
@@ -118,7 +118,7 @@ function ctxInput(page: Page) {
   })
   return modelGroup
     .locator('.form-row')
-    .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(override\)$/ }) })
+    .filter({ has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }) })
     .locator('input')
 }
 

--- a/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * slot-drawer-model-stack-v3 — the slot edit drawer stacks the model drawer
+ * SIDE BY SIDE, not on top of it.
+ *
+ * Nothing covered `data-testid="slot-model-edit-open"` or the stacked
+ * ModelDrawer before this file. The geometry is the whole point: there are no
+ * portals in this app, `.drawer` is `position: fixed; right: 0; z-index: 95`,
+ * and both drawers used to dock flush-right at equal z-index — so the
+ * later-rendered ModelDrawer fully COVERED the slot drawer and the "in place"
+ * edit was a lie.
+ *
+ *   S1. the model field's pencil opens the model drawer for the BOUND model.
+ *   S2. both drawers are simultaneously visible AND interactive — a slot
+ *       hardware control and a model-drawer control are usable at once.
+ *   S3. the docked drawer's right edge lands exactly on the slot drawer's left
+ *       edge (dock offset === the slot drawer's 560px width).
+ *   S4. exactly ONE dim scrim — the docked drawer's own backdrop paints
+ *       nothing (no double-darkening) but is still a click target.
+ *   S5. one Esc closes only the TOP drawer; the slot drawer and its unsaved
+ *       edits survive.
+ *   S6. below the 1200px breakpoint the dock degrades to the overlay stack
+ *       rather than pushing 1160px of panels off-canvas to the left.
+ *
+ * List seeding mirrors slot-drawer-field-wiring-v3.spec.ts (in-bundle
+ * HAL0_DATA; VITE_MOCK_HAL0=1 short-circuits GET /api/slots before page.route
+ * sees it).
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+/** The slot drawer's width — and therefore the expected dock offset. */
+const SLOT_DRAWER_WIDTH = 560
+
+// `model_id` must be a real HAL0_DATA.models id: the pencil resolves the slot
+// to a registry ROW (ModelDrawer renders nothing for a null model) and is
+// disabled when that lookup fails.
+const PRIMARY = {
+  name: 'primary', type: 'llm', device: 'gpu-rocm', profile: 'rocm',
+  model: 'qwen3.6-27b-mtp', model_id: 'qwen3.6-27b-mtp',
+  modelLong: 'Qwen3.6-27B-MTP',
+  group: 'chat', state: 'serving', port: 8092, isDefault: true,
+  n_gpu_layers: -1,
+  metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
+}
+// Bound to an id that is NOT in the registry — the pencil must be disabled
+// rather than opening an empty editor.
+const ORPHAN = {
+  ...PRIMARY,
+  name: 'orphan',
+  model: 'ghost-7b',
+  model_id: 'ghost-7b',
+  port: 8093,
+}
+
+async function seedSlots(page: Page, slots: any[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+/** Stub the sibling writes so nothing leaks to the vite proxy. */
+async function stubWrites(page: Page, name: string) {
+  await page.route(`**/api/slots/${name}/config`, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+  await page.route(`**/api/slots/${name}/defaults`, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+  )
+}
+
+const slotDrawer = (page: Page) => page.locator('.drawer:not(.drawer--docked)')
+const modelDrawer = (page: Page) => page.locator('.drawer.drawer--docked')
+
+/** Open the slot drawer, then the stacked model drawer. */
+async function openStack(page: Page, name = 'primary') {
+  await page.goto(`/#slots/${name}`)
+  await expect(slotDrawer(page)).toBeVisible()
+  await page.getByTestId('slot-model-edit-open').click()
+  await expect(modelDrawer(page)).toBeVisible()
+}
+
+test.describe('Slot drawer — stacked model editor', () => {
+  test('S1 — the model field pencil opens the model drawer for the BOUND model', async ({ page }) => {
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+
+    await page.goto('/#slots/primary')
+    // Icon button, not the old "Edit model…" text button.
+    const pencil = page.getByTestId('slot-model-edit-open')
+    await expect(pencil).toBeVisible()
+    await expect(pencil).toBeEnabled()
+    await expect(pencil.locator('svg')).toHaveCount(1)
+    await expect(page.locator('.drawer', { hasText: 'Edit model…' })).toHaveCount(0)
+    // Nothing is stacked yet.
+    await expect(modelDrawer(page)).toHaveCount(0)
+
+    await pencil.click()
+    await expect(modelDrawer(page)).toBeVisible()
+    // It is the model editor, opened on the slot's BOUND row — the drawer title
+    // is `longName || name || id`, and the Display-name placeholder is the id.
+    await expect(modelDrawer(page).locator('.modal-h-eye')).toContainText('Edit model')
+    await expect(modelDrawer(page).locator('.drawer-h h2')).toHaveText('Qwen3.6-27B-MTP')
+    await expect(modelDrawer(page).getByTestId('model-name-input')).toHaveAttribute(
+      'placeholder',
+      'qwen3.6-27b-mtp',
+    )
+  })
+
+  test('S1 — the pencil is disabled when the bound model has no registry row', async ({ page }) => {
+    await stubWrites(page, 'orphan')
+    await seedSlots(page, [ORPHAN])
+
+    await page.goto('/#slots/orphan')
+    await expect(slotDrawer(page)).toBeVisible()
+    // ModelDrawer needs the ROW, not an id, so with no row there is nothing to
+    // open — the control says so instead of flashing an empty editor.
+    await expect(page.getByTestId('slot-model-edit-open')).toBeDisabled()
+  })
+
+  test('S2 — both drawers are visible and interactive at the same time', async ({ page }) => {
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await openStack(page)
+
+    // Two live drawers, not one covering the other.
+    await expect(page.locator('.drawer')).toHaveCount(2)
+    await expect(slotDrawer(page)).toBeVisible()
+    await expect(modelDrawer(page)).toBeVisible()
+
+    // A slot HARDWARE control and a MODEL control are both visible together —
+    // the old behaviour hid the slot drawer entirely behind the model drawer.
+    const ngl = page.getByTestId('slot-hw-ngl')
+    const flags = modelDrawer(page).getByTestId('model-flags-input')
+    await expect(ngl).toBeVisible()
+    await expect(flags).toBeVisible()
+
+    // …and both accept input while the other stays put (visible ⇒ hit-testable,
+    // which is what the covering stack broke).
+    await flags.fill('-fa on -b 2048')
+    await expect(flags).toHaveValue('-fa on -b 2048')
+    await ngl.fill('24')
+    await expect(ngl).toHaveValue('24')
+    await expect(flags).toHaveValue('-fa on -b 2048')
+  })
+
+  test('S3 — the docked drawer sits flush against the slot drawer, offset by its width', async ({ page }) => {
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await openStack(page)
+
+    // The dock offset is declared on the element, so a drift between the slot
+    // drawer's width and the offset is caught here rather than by eyeball.
+    await expect(modelDrawer(page)).toHaveAttribute(
+      'data-drawer-dock',
+      String(SLOT_DRAWER_WIDTH),
+    )
+    await expect(slotDrawer(page)).not.toHaveAttribute('data-drawer-dock', /.*/)
+
+    const slotBox = (await slotDrawer(page).boundingBox())!
+    const modelBox = (await modelDrawer(page).boundingBox())!
+    expect(slotBox).toBeTruthy()
+    expect(modelBox).toBeTruthy()
+
+    // Slot drawer still flush right; docked drawer's right edge == the slot
+    // drawer's left edge (flush seam, no gap, no overlap).
+    const viewport = page.viewportSize()!
+    expect(Math.round(slotBox.x + slotBox.width)).toBe(viewport.width)
+    expect(Math.round(slotBox.width)).toBe(SLOT_DRAWER_WIDTH)
+    expect(Math.abs(modelBox.x + modelBox.width - slotBox.x)).toBeLessThanOrEqual(1)
+    // …and neither is pushed off-canvas to the left.
+    expect(modelBox.x).toBeGreaterThanOrEqual(0)
+  })
+
+  test('S4 — the stacked drawer paints no second scrim (no double-darkening)', async ({ page }) => {
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await openStack(page)
+
+    // Two backdrops exist (each Drawer renders its own) but exactly ONE paints.
+    const backdrops = page.locator('.drawer-backdrop')
+    await expect(backdrops).toHaveCount(2)
+    await expect(page.locator('.drawer-backdrop--clear')).toHaveCount(1)
+
+    const painted = await backdrops.evaluateAll((els) =>
+      els.map((el) => getComputedStyle(el).backgroundColor),
+    )
+    const opaqueish = painted.filter((c) => c !== 'rgba(0, 0, 0, 0)' && c !== 'transparent')
+    expect(opaqueish).toHaveLength(1)
+
+    // The clear one is still a click target — click-outside dismisses the TOP
+    // drawer and leaves the slot drawer alone.
+    await page.mouse.click(40, 400)
+    await expect(modelDrawer(page)).toHaveCount(0)
+    await expect(slotDrawer(page)).toBeVisible()
+  })
+
+  test('S5 — one Esc closes only the model drawer; the slot drawer keeps its edits', async ({ page }) => {
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await openStack(page)
+
+    // Dirty the slot drawer first — a single Esc used to fire BOTH drawers'
+    // document-level keydown handlers.
+    await page.getByTestId('slot-hw-threads').fill('12')
+
+    await page.keyboard.press('Escape')
+    await expect(modelDrawer(page)).toHaveCount(0)
+    await expect(slotDrawer(page)).toBeVisible()
+    // No discard dialog popped underneath, and the edit is intact.
+    await expect(page.locator('.modal-shell', { hasText: 'Discard' })).toHaveCount(0)
+    await expect(page.getByTestId('slot-hw-threads')).toHaveValue('12')
+  })
+
+  test('S6 — below 1200px the dock degrades to the overlay stack, never off-canvas', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 800 })
+    await stubWrites(page, 'primary')
+    await seedSlots(page, [PRIMARY])
+    await openStack(page)
+
+    const modelBox = (await modelDrawer(page).boundingBox())!
+    // 560 + 600 does not fit in 1024: the media query resets `right` to 0 so
+    // the panel overlays instead of hanging 136px off the left edge.
+    expect(modelBox.x).toBeGreaterThanOrEqual(0)
+    expect(Math.round(modelBox.x + modelBox.width)).toBe(1024)
+    // Still fully usable at the narrow size.
+    await expect(modelDrawer(page).getByTestId('model-flags-input')).toBeVisible()
+  })
+})

--- a/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-model-stack-v3.spec.ts
@@ -94,12 +94,15 @@ test.describe('Slot drawer — stacked model editor', () => {
     await seedSlots(page, [PRIMARY])
 
     await page.goto('/#slots/primary')
-    // Icon button, not the old "Edit model…" text button.
+    // Icon button, not the old "Edit model…" text button. Scoped to `button`
+    // rather than the whole `.drawer` — the slot drawer's own launch-tune
+    // hint prose ("edit them with "Edit model…" above", #1508) legitimately
+    // contains this phrase now, so a drawer-wide text filter false-positives.
     const pencil = page.getByTestId('slot-model-edit-open')
     await expect(pencil).toBeVisible()
     await expect(pencil).toBeEnabled()
     await expect(pencil.locator('svg')).toHaveCount(1)
-    await expect(page.locator('.drawer', { hasText: 'Edit model…' })).toHaveCount(0)
+    await expect(page.locator('.drawer button', { hasText: 'Edit model…' })).toHaveCount(0)
     // Nothing is stacked yet.
     await expect(modelDrawer(page)).toHaveCount(0)
 

--- a/ui/tests/e2e/specs/slot-drawer-sunset-removal-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-sunset-removal-v3.spec.ts
@@ -181,7 +181,7 @@ test.describe('Slot drawer — sunset launch controls are gone (#1379)', () => {
     await page.goto('/#slots/primary')
     await expect(drawer(page)).toBeVisible()
 
-    const ctxRow = rowByLabel(page, /^Context \(override\)$/)
+    const ctxRow = rowByLabel(page, /^Context \(ceiling\)$/)
     await ctxRow.locator('input').fill('16384')
     await page.locator('.drawer button:has-text("Save")').click()
 

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -316,13 +316,14 @@ test.describe('Slot edit controls (/slots)', () => {
 
     await page.goto('/#slots/primary')
     // Context is directly visible in the Model group (not inside Advanced).
-    // Label reads "Context (override)" — spec-hw-slot-ownership §1: it is an
-    // explicit override of the bound model's own default context_size.
+    // Label reads "Context (ceiling)": the bound model's own default
+    // context_size is authoritative; this slot value only clamps it down for
+    // lighter hardware, it never overrides it upward.
     const modelGroup = page.locator('.drawer .field-group').filter({
       has: page.locator('.field-group-label', { hasText: /^Model$/ }),
     })
     const contextRow = modelGroup.locator('.form-row').filter({
-      has: page.locator('.form-lbl > span', { hasText: /^Context \(override\)$/ }),
+      has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }),
     })
     await expect(contextRow).toBeVisible()
     await contextRow.locator('input').fill('16384')

--- a/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
+++ b/ui/tests/e2e/specs/slots-wireup-v3.spec.ts
@@ -97,10 +97,11 @@ test.describe('Slots v3 wire-up (/slots)', () => {
     const modelGroup = page.locator('.drawer .field-group').filter({
       has: page.locator('.field-group-label', { hasText: /^Model$/ }),
     })
-    // Label reads "Context (override)" — spec-hw-slot-ownership §1: it is an
-    // explicit override of the bound model's own default context_size.
+    // Label reads "Context (ceiling)": the bound model's own default
+    // context_size is authoritative; this slot value only clamps it down for
+    // lighter hardware, it never overrides it upward.
     const contextRow = modelGroup.locator('.form-row').filter({
-      has: page.locator('.form-lbl > span', { hasText: /^Context \(override\)$/ }),
+      has: page.locator('.form-lbl > span', { hasText: /^Context \(ceiling\)$/ }),
     })
     const ctxInput = contextRow.locator('input')
     await expect(ctxInput).toBeVisible()

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig } from 'vitest/config'
 
 // hal0 v3 dashboard — unit test config (vitest), separate from the app's
@@ -5,6 +7,15 @@ import { defineConfig } from 'vitest/config'
 // doesn't need). Node environment is enough for src/api/* logic — nothing
 // under test touches the DOM.
 export default defineConfig({
+  // `@/…` is the app's own source alias (tsconfig paths + vite.config.ts). It
+  // was missing here, so any unit test whose import graph reached a module
+  // using `@/…` failed to resolve — which silently ruled out unit-testing
+  // anything under src/dash/. Mirrors vite.config.ts.
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
     // tests/e2e/port.test.ts covers the Playwright port derivation (#1399) —


### PR DESCRIPTION
## Summary
- Inline model-edit pencil on every slot card (InferencePane + SlotsView) opens `ModelDrawer` side-by-side via a new `DrawerDock` context, so tuning the bound model doesn't force a close → Models page → reopen round-trip.
- Shared `slotModelRow` resolver (`dash/slots/slot-shared.js`) so the slot card, InferencePane card, and slot drawer can't drift in model-row precedence.
- Drops dead `chat_template`/`extra_args`/`parallel` fields from the slot drawer — same removal `main` had already landed independently (#1508); this branch also proposed dropping `ctx_size`, which turned out to still be a live hardware ceiling post-Stream-C's context-size redesign, so it's kept (relabeled from "override" to "ceiling" to match).

Reviewed PASS this session (diff-read + Vitest + typecheck) — see `docs/rework/handoff-1-0-release.md` §6b. Rebased onto current `main` after Streams A and C merged; that rebase collided with main's own already-merged #1508 (same UI cleanup, landed independently) — skipped this branch's duplicate commit and hand-applied only its unique delta (the ctx_size relabel) on top of main's version.

## Test plan
- [x] Vitest: 30/30 passed
- [x] `tsc --noEmit` clean (the pre-existing `useRuntime.ts` error is already fixed on `main`)
- [x] Targeted Playwright specs (slot-edit-controls, slots-wireup, drawer-save-errors, slot-drawer-sunset-removal, slot-drawer-dirty-baseline, slot-drawer-field-wiring, slot-drawer-profile): 48/48 passed serially (3 failed under parallel workers, confirmed contention flakes — pass individually and pass serially)
- [ ] CI