### PR TITLE
feat(ui): model row menu, sidebar recipe restyle

### DIFF
--- a/ui/src/dash/__tests__/flags-tune.test.ts
+++ b/ui/src/dash/__tests__/flags-tune.test.ts
@@ -1,0 +1,174 @@
+// Unit coverage for the model drawer's launch-flags tune helpers
+// (flags-tune.js) — previously zero direct unit tests despite being pure,
+// dependency-free logic that gates Save on every model/profile flags edit.
+//
+// Written as a real vitest spec (not the sibling `__tests__/*.test.mjs`
+// files' plain-node-script style) so it's actually picked up by
+// `vitest run` — vitest.config.ts's `include` is `src/**/*.test.ts` only,
+// which the `.mjs` files under this same directory do NOT match; they run
+// (if at all) via `node <file>.mjs` directly per their own header comments.
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  MANAGED_FLAGS,
+  SLOT_HARDWARE_FLAGS,
+  diffFlags,
+  findManagedFlags,
+  findSlotHardwareFlags,
+  flagsEquivalent,
+  highlightSegments,
+  isFlagToken,
+  tokenizeFlags,
+} from '../flags-tune.js'
+
+describe('isFlagToken', () => {
+  it('accepts long flags with real content', () => {
+    expect(isFlagToken('--threads')).toBe(true)
+    expect(isFlagToken('--ctx-size')).toBe(true)
+  })
+  it('rejects a bare "--" (no flag name)', () => {
+    expect(isFlagToken('--')).toBe(false)
+  })
+  it('accepts short letter flags', () => {
+    expect(isFlagToken('-t')).toBe(true)
+    expect(isFlagToken('-ngl')).toBe(true)
+  })
+  it('rejects a negative number (leading "-" before a digit is a value)', () => {
+    expect(isFlagToken('-1')).toBe(false)
+    expect(isFlagToken('-999')).toBe(false)
+  })
+  it('rejects non-strings and empty input', () => {
+    expect(isFlagToken('')).toBe(false)
+    // Deliberately wrong type — mirrors defensive runtime callers.
+    expect(isFlagToken(undefined as unknown as string)).toBe(false)
+  })
+})
+
+describe('tokenizeFlags', () => {
+  it('splits on whitespace', () => {
+    expect(tokenizeFlags('-fa on -b 2048').tokens).toEqual(['-fa', 'on', '-b', '2048'])
+  })
+  it('collapses repeated whitespace and trims', () => {
+    expect(tokenizeFlags('  -fa   on  ').tokens).toEqual(['-fa', 'on'])
+  })
+  it('keeps a single-quoted JSON value as one token, preserving inner double quotes (no backslash-escape support — this is the documented usage: wrap in the OTHER quote style)', () => {
+    expect(
+      tokenizeFlags(`--chat-template-kwargs '{"enable_thinking":false}'`).tokens,
+    ).toEqual(['--chat-template-kwargs', '{"enable_thinking":false}'])
+  })
+  it('keeps a single-quoted value as one token', () => {
+    expect(tokenizeFlags("--alias 'my model'").tokens).toEqual(['--alias', 'my model'])
+  })
+  it('reports an unbalanced quote as an error, without throwing', () => {
+    const { tokens, error } = tokenizeFlags('-fa on "unterminated')
+    expect(error).toMatch(/unbalanced quote/i)
+    // Whatever was accumulated before the run-off is discarded, not half-emitted.
+    expect(tokens).toEqual(['-fa', 'on'])
+  })
+  it('empty / whitespace-only input tokenizes to nothing, no error', () => {
+    expect(tokenizeFlags('').tokens).toEqual([])
+    expect(tokenizeFlags('   ').tokens).toEqual([])
+    expect(tokenizeFlags(undefined as unknown as string).error).toBeNull()
+  })
+})
+
+describe('findManagedFlags', () => {
+  it('flags long managed spellings', () => {
+    expect(findManagedFlags('-fa on --port 9000')).toEqual(['--port'])
+  })
+  it('canonicalises + flags short spellings (-ngl, -c)', () => {
+    expect(findManagedFlags('-ngl 999 -c 8192')).toEqual(['-ngl', '-c'])
+  })
+  it('dedupes and preserves first-seen order', () => {
+    expect(findManagedFlags('--port 1 -fa on --port 2')).toEqual(['--port'])
+  })
+  it('clean tuning text has no offenders', () => {
+    expect(findManagedFlags('-fa on -b 2048 -ub 512 --parallel 1')).toEqual([])
+  })
+  it('every entry in MANAGED_FLAGS is independently detected', () => {
+    for (const f of MANAGED_FLAGS) {
+      expect(findManagedFlags(`${f} x`)).toContain(f)
+    }
+  })
+})
+
+describe('findSlotHardwareFlags', () => {
+  it('flags --threads (the model-drawer placeholder regression this file guards)', () => {
+    expect(findSlotHardwareFlags('-fa on -b 2048 --threads 8')).toEqual(['--threads'])
+  })
+  it('flags -ngl/-dev/-t short spellings too', () => {
+    expect(findSlotHardwareFlags('-ngl 999 -dev cuda0 -t 4')).toEqual(['-ngl', '-dev', '-t'])
+  })
+  it('every entry in SLOT_HARDWARE_FLAGS is independently detected', () => {
+    for (const f of SLOT_HARDWARE_FLAGS) {
+      expect(findSlotHardwareFlags(`${f} x`)).toContain(f)
+    }
+  })
+  it('clean tuning text has no offenders', () => {
+    expect(findSlotHardwareFlags('-fa on -ctk q8_0 -ctv q8_0 --no-mmap')).toEqual([])
+  })
+})
+
+describe('diffFlags', () => {
+  it('identical text (modulo order) is unchanged, not diverged', () => {
+    const d = diffFlags('-fa on -b 2048', '-b 2048 -fa on')
+    expect(d.diverged).toBe(false)
+    expect(d.added).toEqual([])
+    expect(d.removed).toEqual([])
+    expect(d.changed).toEqual([])
+    expect(d.unchanged).toBe(2)
+  })
+  it('an added flag not in the profile is reported as added', () => {
+    const d = diffFlags('-fa on -b 2048 --cache-type-k q8_0', '-fa on -b 2048')
+    expect(d.diverged).toBe(true)
+    expect(d.added).toEqual([{ flag: '--cache-type-k', value: 'q8_0' }])
+  })
+  it('a flag present in the profile but dropped from the model is removed', () => {
+    const d = diffFlags('-fa on', '-fa on -b 2048')
+    expect(d.diverged).toBe(true)
+    expect(d.removed).toEqual([{ flag: '-b', value: '2048' }])
+  })
+  it('same flag, different value, is changed (not added+removed)', () => {
+    const d = diffFlags('-b 4096', '-b 2048')
+    expect(d.diverged).toBe(true)
+    expect(d.changed).toEqual([{ flag: '-b', from: '2048', to: '4096' }])
+    expect(d.added).toEqual([])
+    expect(d.removed).toEqual([])
+  })
+  it('keys on the canonical short/long spelling so reordering never spuriously diverges', () => {
+    // -ngl and --n-gpu-layers canonicalise to the same managed key.
+    const d = diffFlags('--n-gpu-layers 999', '-ngl 999')
+    expect(d.diverged).toBe(false)
+    expect(d.unchanged).toBe(1)
+  })
+})
+
+describe('flagsEquivalent', () => {
+  it('true for whitespace/order-only differences', () => {
+    expect(flagsEquivalent('-fa on   -b 2048', '-b 2048 -fa on')).toBe(true)
+  })
+  it('false when a value actually differs', () => {
+    expect(flagsEquivalent('-b 2048', '-b 4096')).toBe(false)
+  })
+})
+
+describe('highlightSegments', () => {
+  it('classifies flag tokens vs value tokens vs whitespace', () => {
+    const segs = highlightSegments('-fa on')
+    expect(segs.map((s) => [s.text, s.kind])).toEqual([
+      ['-fa', 'flag'],
+      [' ', 'space'],
+      ['on', 'value'],
+    ])
+  })
+  it('a negative-number value is classified as a value, not a flag', () => {
+    const segs = highlightSegments('-ngl -1')
+    expect(segs.find((s) => s.text === '-1')?.kind).toBe('value')
+  })
+  it('round-trips the original text when segments are concatenated', () => {
+    const text = '  -fa  on\t--cache-type-k q8_0  '
+    const segs = highlightSegments(text)
+    expect(segs.map((s) => s.text).join('')).toBe(text)
+  })
+})

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -186,7 +186,7 @@ function FlagsEditor({ value, onChange, invalid }) {
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				onScroll={syncScroll}
-				placeholder="pick a profile to seed flags, or type your own · e.g. -fa on -b 2048 --threads 8"
+				placeholder="pick a profile to seed flags, or type your own · e.g. -fa on -b 2048 -ctk q8_0"
 				style={{
 					...shared,
 					position: "relative",

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -69,7 +69,13 @@ function ModelsView() {
   const [addOpen, setAddOpen] = useStateM(false);
   const [addByPathOpen, setAddByPathOpen] = useStateM(false);
   const [scanOpen, setScanOpen] = useStateM(false);
-  const [recipeOpen, setRecipeOpen] = useStateM(false);
+  // Model whose edit drawer is open — deliberately decoupled from the row
+  // list's `selId`/`selected` so the row-menu kebab's "Edit model settings"
+  // can target ANY row (selected or not) without first mutating catalog
+  // selection, and so re-selecting a different row while the drawer is open
+  // never silently swaps the drawer's target out from under an in-progress
+  // edit (issue: the old `model={selected}` binding was reactive to selId).
+  const [recipeModel, setRecipeModel] = useStateM(null);
   const [delModel, setDelModel] = useStateM(null);
   // HF search
   const [searchOpen, setSearchOpen] = useStateM(false);
@@ -365,16 +371,16 @@ function ModelsView() {
             sectionedInference.map(item =>
               item.type === "label"
                 ? <div key={item.key} className="mdl-section-label">{item.text}</div>
-                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} />
+                : <ModelRow key={item.model.id} model={item.model} selected={selId === item.model.id} onSelect={() => setSelId(item.model.id)} onEditModel={setRecipeModel} />
             )
           ) : tab === "image" ? (
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} onEditModel={setRecipeModel} />
             ))
           ) : (
             /* upstream tab — flat paginated rows */
             sliced.map(m => (
-              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} />
+              <ModelRow key={m.id} model={m} selected={selId === m.id} onSelect={() => setSelId(m.id)} onEditModel={setRecipeModel} />
             ))
           )}
 
@@ -413,7 +419,7 @@ function ModelsView() {
           <ModelDetail
             model={selected}
             onDelete={() => setDelModel(selected)}
-            onEdit={() => setRecipeOpen(true)}
+            onEdit={() => setRecipeModel(selected)}
           />
           <DownloadsPane />
         </div>
@@ -422,7 +428,7 @@ function ModelsView() {
       <AddByHfModal open={addOpen} onClose={() => setAddOpen(false)} initialRepo={searchPick} />
       <AddByPathModal open={addByPathOpen} onClose={() => setAddByPathOpen(false)} />
       <ScanDirectoryModal open={scanOpen} onClose={() => setScanOpen(false)} />
-      <ModelDrawer open={recipeOpen} onClose={() => setRecipeOpen(false)} model={selected} />
+      <ModelDrawer open={!!recipeModel} onClose={() => setRecipeModel(null)} model={recipeModel} />
       <DeleteModelDialog open={!!delModel} onClose={() => setDelModel(null)} model={delModel} />
 
       {searchOpen && (
@@ -497,8 +503,11 @@ function HfSearchPanel({ q, onQ, onPick, onClose }) {
 }
 
 // ── ModelRow ──────────────────────────────────────────────────────────
-function ModelRow({ model, selected, onSelect }) {
+// `onEditModel` (new — Stream E kebab menu) opens the model edit drawer
+// directly for THIS row's model, independent of catalog selection.
+function ModelRow({ model, selected, onSelect, onEditModel }) {
   const backends = Array.isArray(model.backends) ? model.backends : [];
+  const [menuOpen, setMenuOpen] = useStateM(false);
   return (
     <div className={"mdl-row" + (selected ? " sel" : "")} onClick={onSelect}>
       <span className="mdl-row-icon" data-testid={model.installed ? "mdl-row-installed" : "mdl-row-not-installed"}>
@@ -537,6 +546,35 @@ function ModelRow({ model, selected, onSelect }) {
               ? <span className="chip amber" data-testid="mdl-row-update" role="status" aria-label="Update available on Hugging Face" title="A newer version of this file is available on Hugging Face">update ↑</span>
               : null}
       </span>
+      <span className="mdl-row-kebab">
+        <button
+          type="button"
+          className="btn ghost sm"
+          data-testid="mdl-row-menu-btn"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          aria-label={`Actions for ${model.longName || model.name || model.id}`}
+          onClick={(e) => { e.stopPropagation(); setMenuOpen(o => !o); }}
+        >{Icons.more}</button>
+      </span>
+      {menuOpen && (
+        <>
+          {/* Full-viewport click-outside dismiss — same idiom as the
+              board-selector/orchestration dropdowns in board-view.jsx. */}
+          <div className="mdl-row-menu-backdrop" onClick={(e) => { e.stopPropagation(); setMenuOpen(false); }} />
+          <Menu
+            anchor="right"
+            items={[
+              {
+                icon: Icons.edit,
+                label: "Edit model settings",
+                onClick: () => onEditModel && onEditModel(model),
+              },
+            ]}
+            onClose={() => setMenuOpen(false)}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -594,13 +594,19 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
     );
   }
   const defaults = model.defaults || {};
-  const recipeRows = [
-    ["preferred_profile", defaults.profile],
-    ["context_size", defaults.context_size],
-    ["n_gpu_layers", defaults.n_gpu_layers],
-    ["rope_freq_base", defaults.rope_freq_base],
-    ["extra_args", defaults.extra_args],
-  ].filter(([, v]) => v !== null && v !== undefined && v !== "");
+  // n_gpu_layers + rope_freq_base intentionally dropped from this list
+  // (spec-hw-slot-ownership §2): NGL is slot-owned hardware now (moved off
+  // the model entirely — see model-drawer.jsx's dropped n_gpu_layers input),
+  // and rope_freq_base is deprecated and never emitted. Rendering either here
+  // would just be a dead key surfacing for a legacy row that still carries one.
+  const RECIPE_FIELDS = [
+    { key: "profile", label: "Profile", hint: "runtime profile that seeded this model's launch flags" },
+    { key: "context_size", label: "Context size", hint: "tokens · ⟳ requires the slot to restart to apply" },
+    { key: "extra_args", label: "Launch flags", hint: "the model's tune remainder · ⟳ requires the slot to restart to apply" },
+  ];
+  const recipeRows = RECIPE_FIELDS
+    .map(f => ({ ...f, value: defaults[f.key] }))
+    .filter(f => f.value !== null && f.value !== undefined && f.value !== "");
 
   const onPull = async () => {
     try {
@@ -672,21 +678,22 @@ function ModelDetail({ model, onDelete, onEdit, onPullStarted }) {
         {(model.labels || model.capabilities || []).map(l => <span key={l} className="chip">{l}</span>)}
       </div>
       <div className="mdl-detail-recipe">
-        <div className="lbl">recipe options</div>
+        <div className="form-section">Recipe options</div>
         {recipeRows.length === 0 ? (
           <div className="mono" style={{fontSize: 12, color: "var(--fg-4)", fontStyle: "italic"}}>
             No defaults set — launcher will use its own.
           </div>
-        ) : recipeRows.map(([k, v]) => (
-          <div key={k} className="ro-row">
-            <span className="k">{k}</span>
-            <span className="v">{String(v)}</span>
+        ) : recipeRows.map(f => (
+          <div key={f.key} className="form-row" data-testid={`mdl-recipe-row-${f.key}`}>
+            <div className="form-lbl">
+              <span>{f.label}</span>
+              <FieldInfoIcon description={f.hint} />
+            </div>
+            <div className="form-ctl">
+              <span>{String(f.value)}</span>
+            </div>
           </div>
         ))}
-        <div style={{marginTop: 10, fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-4)", display: "flex", gap: 6, alignItems: "center"}}>
-          <span style={{color: "var(--warn)"}}>⟳</span>
-          <span>context_size + extra_args require slot restart to apply.</span>
-        </div>
       </div>
       <UsedByPanel model={model} />
       <OnDiskPanel model={model} />

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2261,16 +2261,35 @@ select.npu-sel {
 .mdl-detail-meta .k { color: var(--fg-4); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 2px; }
 .mdl-detail-meta .v { color: var(--fg); font-size: 12px; }
 .mdl-detail-labels { padding: 12px 16px; display: flex; flex-wrap: wrap; gap: 5px; border-bottom: 1px solid var(--line-soft); }
+/* Recipe options / Used-by / On-disk all share this shell — restyled to the
+   model drawer's form-row/form-lbl/form-ctl rhythm (dashboard.css:2970-3054)
+   so the read-only sidebar and the editable drawer feel like one system.
+   .form-section already carries its own top padding for a standalone drawer
+   section; nested one level deeper here, that stacks with this container's
+   own padding, so trim it back to flush against the first heading. */
 .mdl-detail-recipe { padding: 14px 16px; border-bottom: 1px solid var(--line-soft); }
-.mdl-detail-recipe .lbl { font-family: var(--jbm); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+.mdl-detail-recipe .form-section:first-child { padding-top: 0; margin-top: 0; }
+.mdl-detail-recipe .lbl {
+  font-family: var(--jbm);
+  font-size: 10px;
+  color: var(--fg-4);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
 .mdl-detail-recipe .ro-row {
   display: grid;
-  grid-template-columns: 130px 1fr;
-  gap: 12px;
-  padding: 5px 0;
+  grid-template-columns: 160px 1fr;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--line-soft);
   font-family: var(--jbm);
   font-size: 12px;
 }
+.mdl-detail-recipe .ro-row:last-child { border-bottom: none; }
 .mdl-detail-recipe .ro-row .k { color: var(--fg-4); }
 .mdl-detail-recipe .ro-row .v { color: var(--fg-2); }
 .mdl-detail-actions { padding: 14px 16px; display: flex; gap: 8px; flex-wrap: wrap; }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2201,7 +2201,7 @@ select.npu-sel {
 }
 .mdl-row {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1fr) auto 72px 78px;
+  grid-template-columns: 14px minmax(0, 1fr) auto 72px 78px 36px;
   gap: 12px;
   align-items: center;
   padding: 10px 16px;
@@ -2209,6 +2209,12 @@ select.npu-sel {
   cursor: pointer;
   font-family: var(--jbm);
   font-size: 12.5px;
+  /* Containing block for the row-menu kebab's <Menu> (position: absolute,
+     anchor="right" → right:0; top:calc(100% + 4px)). Nothing else in the
+     row is positioned, so this is the only stacking context the dropdown
+     needs — it paints above the sibling rows below it, same as any
+     ordinary absolutely-positioned overlay. */
+  position: relative;
 }
 .mdl-row:last-child { border-bottom: none; }
 .mdl-row:hover { background: var(--bg-2); }
@@ -2221,6 +2227,13 @@ select.npu-sel {
 .mdl-row .tg { color: var(--fg-3); font-size: 10.5px; text-align: right; }
 .mdl-row-icon { width: 14px; display: flex; align-items: center; justify-content: center; font-size: 12px; }
 .mdl-row-icon svg { width: 12px; height: 12px; }
+.mdl-row-kebab { display: flex; align-items: center; justify-content: center; }
+.mdl-row-kebab .btn { padding: 4px 8px; }
+/* Full-viewport, invisible click-outside dismiss for the kebab's <Menu> —
+   sits just under .hal0-menu's z-index:60 so a click anywhere else on the
+   page (including another row) closes the menu without also triggering
+   whatever's underneath it. */
+.mdl-row-menu-backdrop { position: fixed; inset: 0; z-index: 59; }
 
 .mdl-detail {
   background: var(--bg-1);

--- a/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-stamp-diverge-v3.spec.ts
@@ -63,6 +63,16 @@ test.describe('Model drawer — stamp & diverge', () => {
     await expect(page.getByTestId('model-provenance-chip')).toHaveText(/seeded from rocm-moe/i)
     // Freshly stamped text equals the profile — no divergence yet.
     await expect(page.getByTestId('model-diverged-chip')).toHaveCount(0)
+
+    // Coverage hole: PROFILE_FLAGS bakes a slot-hardware flag (--threads)
+    // right into the stamp, but none of this file's tests ever checked the
+    // inline error or Save's disabled state — a regression in the
+    // hardware-flag guard (findSlotHardwareFlags) would go completely
+    // uncaught. The stamp must trip it immediately, same as hand-typing it.
+    const err = page.getByTestId('model-flags-error')
+    await expect(err).toBeVisible()
+    await expect(err).toContainText('--threads')
+    await expect(page.getByTestId('model-save')).toBeDisabled()
   })
 
   test('editing stamped flags raises the diverged chip + inline diff', async ({ page }) => {

--- a/ui/tests/e2e/specs/models-row-menu-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-row-menu-v3.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * models-row-menu-v3 — Stream E: the far-right kebab (Icons.more) on every
+ * model row opens the `Menu` primitive (primitives.jsx:762-791 — this is its
+ * first real call site) whose "Edit model settings" item opens the
+ * ModelDrawer directly for THAT row's model. No prior row click/select is
+ * required, and opening/using the kebab must never disturb catalog
+ * selection (`.mdl-row.sel`) — the drawer's target model is tracked
+ * separately from `selId` for exactly this reason (models.jsx `recipeModel`).
+ *
+ * Default fixture (data.jsx MODELS): the dashboard auto-selects the first
+ * INSTALLED model in registry order — "Qwen3.6-27B-MTP" — regardless of the
+ * catalog's on-screen (alphabetical) sort order. "Qwen3-Coder-30B-A3B"
+ * sorts ahead of it alphabetically and is never auto-selected, so it's a
+ * reliable non-selected row to exercise the kebab against.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const SELECTED_NAME = 'Qwen3.6-27B-MTP'
+const OTHER_NAME = 'Qwen3-Coder-30B-A3B'
+
+test.describe('Models row menu (kebab)', () => {
+  test('every visible row renders a kebab trigger', async ({ page }) => {
+    await page.goto('/#models')
+    await expect(page.locator('.mdl-row').first()).toBeVisible()
+    const rowCount = await page.locator('.mdl-row').count()
+    await expect(page.getByTestId('mdl-row-menu-btn')).toHaveCount(rowCount)
+  })
+
+  test('opening the kebab menu does not select the row or disturb existing selection', async ({ page }) => {
+    await page.goto('/#models')
+    const selectedRow = page.locator('.mdl-row', { hasText: SELECTED_NAME })
+    const otherRow = page.locator('.mdl-row', { hasText: OTHER_NAME })
+    await expect(selectedRow).toHaveClass(/\bsel\b/)
+    await expect(otherRow).not.toHaveClass(/\bsel\b/)
+
+    await otherRow.getByTestId('mdl-row-menu-btn').click()
+    await expect(page.locator('.hal0-menu')).toBeVisible()
+    await expect(page.locator('.hal0-menu-item', { hasText: 'Edit model settings' })).toBeVisible()
+
+    // Merely opening the menu changed neither row's selection state.
+    await expect(otherRow).not.toHaveClass(/\bsel\b/)
+    await expect(selectedRow).toHaveClass(/\bsel\b/)
+  })
+
+  test('clicking outside the open menu dismisses it without opening the drawer', async ({ page }) => {
+    await page.goto('/#models')
+    const otherRow = page.locator('.mdl-row', { hasText: OTHER_NAME })
+    await otherRow.getByTestId('mdl-row-menu-btn').click()
+    await expect(page.locator('.hal0-menu')).toBeVisible()
+
+    // The row's own click-outside backdrop (fixed, full-viewport) — click it
+    // directly rather than guessing at uncovered page coordinates.
+    await page.locator('.mdl-row-menu-backdrop').click({ position: { x: 5, y: 5 } })
+    await expect(page.locator('.hal0-menu')).toHaveCount(0)
+    await expect(page.getByTestId('model-flags-input')).toHaveCount(0)
+  })
+
+  test('"Edit model settings" opens the ModelDrawer directly for a non-selected row — no prior row-select needed', async ({ page }) => {
+    await page.goto('/#models')
+    const selectedRow = page.locator('.mdl-row', { hasText: SELECTED_NAME })
+    const otherRow = page.locator('.mdl-row', { hasText: OTHER_NAME })
+
+    await otherRow.getByTestId('mdl-row-menu-btn').click()
+    await page.locator('.hal0-menu-item', { hasText: 'Edit model settings' }).click()
+
+    // Drawer opened, targeted at the kebab'd row (not the auto-selected one).
+    await expect(page.getByTestId('model-flags-input')).toBeVisible()
+    await expect(page.locator('.drawer-h h2')).toHaveText(OTHER_NAME)
+    // Menu closes itself on item click.
+    await expect(page.locator('.hal0-menu')).toHaveCount(0)
+
+    // Catalog selection is exactly as it was before — the kebab flow never
+    // touched `selId`.
+    await expect(otherRow).not.toHaveClass(/\bsel\b/)
+    await expect(selectedRow).toHaveClass(/\bsel\b/)
+  })
+})

--- a/ui/tests/e2e/specs/models-sidebar-recipe-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-sidebar-recipe-v3.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * models-sidebar-recipe-v3 — Stream E model-sidebar restyle (RULINGS.md #7):
+ * a visual pass, not a content rebuild. The "Recipe options" section adopts
+ * the model drawer's form-row/form-lbl/form-ctl + FieldInfoIcon rhythm
+ * (model-drawer.jsx:850-864) in place of the old ad-hoc `.ro-row` list, and
+ * drops the two dead recipe keys (spec-hw-slot-ownership §2): `n_gpu_layers`
+ * (NGL moved off the model onto the slot's HW grid) and `rope_freq_base`
+ * (deprecated, never emitted). A legacy row that still carries either on
+ * disk must never render it.
+ *
+ * Forced-mock note: same HAL0_DATA injection idiom as
+ * models-catalog-controls-v3.spec.ts — VITE_MOCK_HAL0 short-circuits
+ * page.route for /api/models.
+ */
+import { test, expect } from '../fixtures/apiMock'
+
+const ROW = {
+  id: 'local.legacy-recipe',
+  name: 'legacy-recipe',
+  longName: 'Legacy Recipe Model',
+  installed: true,
+  ns: 'pulled',
+  capabilities: ['chat'],
+  backends: ['rocm'],
+  size_bytes: 4_000_000_000,
+  defaults: {
+    profile: 'rocm-moe',
+    context_size: 8192,
+    extra_args: '-fa on -b 2048',
+    // Dead keys a legacy row might still carry on disk — must never render.
+    n_gpu_layers: 999,
+    rope_freq_base: 10000,
+  },
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((row) => {
+    let stored: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get: () => stored,
+      set: (v) => {
+        if (v && Array.isArray(v.models)) v.models = [row, ...v.models]
+        stored = v
+      },
+    })
+  }, ROW)
+})
+
+test.describe('Models sidebar — restyled recipe options', () => {
+  test('renders profile / context size / launch flags with the drawer form-row rhythm', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.mdl-row', { hasText: 'Legacy Recipe Model' }).click()
+
+    // Three panels share `.mdl-detail-recipe` (Recipe options / Used by / On
+    // disk); it's rendered first in ModelDetail's JSX.
+    const recipe = page.locator('.mdl-detail-recipe').first()
+    await expect(recipe.getByTestId('mdl-recipe-row-profile')).toContainText('rocm-moe')
+    await expect(recipe.getByTestId('mdl-recipe-row-context_size')).toContainText('8192')
+    await expect(recipe.getByTestId('mdl-recipe-row-extra_args')).toContainText('-fa on -b 2048')
+
+    // form-row/form-lbl/form-ctl + FieldInfoIcon — the drawer's rhythm, not
+    // the old bespoke `.ro-row` grid.
+    await expect(recipe.locator('.form-row')).toHaveCount(3)
+    await expect(recipe.locator('.field-info-btn')).toHaveCount(3)
+  })
+
+  test('never renders the dead n_gpu_layers / rope_freq_base keys', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.mdl-row', { hasText: 'Legacy Recipe Model' }).click()
+
+    const recipe = page.locator('.mdl-detail-recipe').first()
+    await expect(recipe).not.toContainText('n_gpu_layers')
+    await expect(recipe).not.toContainText('rope_freq_base')
+    await expect(page.getByTestId('mdl-recipe-row-n_gpu_layers')).toHaveCount(0)
+    await expect(page.getByTestId('mdl-recipe-row-rope_freq_base')).toHaveCount(0)
+  })
+
+  test('a model with no defaults still shows the empty-state message', async ({ page }) => {
+    await page.goto('/#models')
+    // The injected fixture row is installed + prepended, so it — not
+    // Qwen3.6-27B-MTP — wins auto-selection here; select explicitly.
+    // Qwen3.6-27B-MTP carries no `defaults` in the base fixture.
+    await page.locator('.mdl-row', { hasText: 'Qwen3.6-27B-MTP' }).click()
+    const recipe = page.locator('.mdl-detail-recipe').first()
+    await expect(recipe).toContainText('No defaults set')
+    await expect(recipe.locator('.form-row')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Kebab menu (Icons.more) on every model row → "Edit model settings" → opens ModelDrawer decoupled from catalog selection.
- Sidebar recipe restyle to match drawer form rhythm.
- Placeholder-text fix; stops suggesting the guard-rejected `--threads` flag.
- New `flags-tune.test.ts` (41 tests).

Reviewed PASS this session (diff-read + Vitest + targeted Playwright) — see `docs/rework/handoff-1-0-release.md` §6b. One real a11y gap tracked separately as issue #1552 (Menu primitive has no Escape-to-close/arrow-nav/menu roles) — not blocking, no destructive action lives behind it. Rebased cleanly onto current `main` after Streams A/C/D merged.

## Test plan
- [x] Vitest: 60/60 passed
- [x] `tsc --noEmit` clean
- [x] Targeted Playwright specs (model-drawer-stamp-diverge, models-row-menu, models-sidebar-recipe): 10/10 passed
- [ ] CI