### PR TITLE
fix(dash): slot edit drawer cleanup — layout, activity-log spam, default picker

### DIFF
--- a/.handoff-slot-edit-drawer-cleanup-2026-07-31.md
+++ b/.handoff-slot-edit-drawer-cleanup-2026-07-31.md
@@ -1,0 +1,93 @@
+# Slot Edit Drawer Cleanup — Handoff (Branch 1 of 2)
+
+**Date**: 2026-07-31
+**Repo**: `/mnt/mintdev/repos/hal0` (canonical) — this branch runs in a Superset workspace/worktree
+**Branch**: `fix/slot-edit-drawer-cleanup`
+**Base**: `origin/main`
+**Sibling branch**: `feat/runner-image-catalogue` (see `.handoff-runner-image-catalogue-2026-07-31.md`) — read the "Shared context" section below, it's identical in both docs so either branch can be picked up standalone.
+
+---
+
+## Shared context (same in both handoff docs)
+
+Two related but independently-shippable pieces of work came out of a single design session (operator: thinMint, on `hal0.thinmint.dev` / LXC105, `10.0.1.142`):
+
+1. **Slot edit drawer cleanup** (this doc) — a UI polish + wiring pass on the existing slot create/edit flow: field layout, a stale/misleading default-slot picker, an activity-log spam bug, and splitting `device` (create-time only) from the runner binary/image fields (edit-time).
+2. **Runner Image catalogue** (sibling doc) — a new "Runner Images" subpage under Models, backed by a sync job that discovers container images the operator publishes to `ghcr.io/Hal0ai/hal0-runner-images` and displays them with a Model-Card-style detail view, a download job, and (once downloaded) makes them selectable from this drawer's Runner Image field.
+
+**Why split into two branches**: the drawer cleanup is same-day UI/wiring work with low risk. The catalogue is a multi-day net-new feature with its own architecture (sync mechanism, job system, card schema) that would otherwise block the drawer fixes on unrelated design decisions. They're sequenced so branch 1 ships a Runner Binary dropdown sourced from the existing static `RUNNER_IMAGES` registry (`src/hal0/runners/__init__.py`) — branch 2 later swaps that source to the live catalogue without changing branch 1's UI contract.
+
+**Existing device→model coupling** (do not relitigate — it's already correct and predates this work): at slot **creation**, device is inferred from the selected model's stamped tune, per the tooltip already in the create modal ("Looking for a device? It rides the model. Pick a model — its stamped tune sets the device. To run on another device, duplicate the model for that device."). What's being fixed here is that the **edit drawer** independently exposes a full manual device dropdown post-creation (image 5 in the design session) that is redundant with and inconsistent with that create-time inference — it needs to go away, not be replicated.
+
+**Design session artifacts**: 7 annotated screenshots were reviewed live (not attached to this repo) showing: the activity-log spam, the create-modal default checkbox, info-icon placement, the Profile/Hardware/Model section order, the current Device dropdown in the edit drawer, the Runner dropdown's "default (from device)" entry, and a target end-state sketch of the edit drawer shape. Where a screenshot is referenced below (e.g. "image #2"), it means the corresponding screenshot from that session — recreate the intent from the text description if the image isn't available; ask the operator (thinMint) if genuinely ambiguous.
+
+---
+
+## Branch 1 scope: `fix/slot-edit-drawer-cleanup`
+
+Primary files (confirmed via `graphify query` against this repo's knowledge graph — re-run `graphify query "slot edit drawer"` if these have moved):
+
+- `ui/src/dash/slot-modals.jsx` — slot create modal + edit drawer (main target)
+- `ui/src/dash/slots.jsx` — slots list page, imports `ActivityLog` from `activity-log.jsx`; will need a new "Set as default" action here (item 4 below)
+- `ui/src/dash/activity-log.jsx` — `ActivityLog()` component (item 2 below)
+- `ui/src/dash/inference-pane.jsx`, `ui/src/dash/npu-pane.jsx` — the two containers the activity panel needs to size against (item 2)
+- `src/hal0/runners/__init__.py` — `RUNNER_IMAGES: dict[str, Runner]` registry, already has everything needed for item 7's binary dropdown (see below)
+- `src/hal0/slots/manager.py`, `src/hal0/slots/config_write.py` — slot create/update backend, already has the SC-4 default-uniqueness guard (see item 4)
+- `src/hal0/slot_config/__init__.py` — `TOLERATED_SLOT_CONFIG_KEYS` frozenset (~line 212); check any newly-required/removed field lands here if the backend rejects it with "unknown slot config key(s)"
+
+A prior, unrelated, **rolled-back** attempt at some of this lives at `.handoff-slot-drawer-cleanup.md` (dated 2026-07-20, targeted a different host/LXC-143, pre-`rework/p3-brain` merge). It is stale — different image/label conventions, some renames it made were reverted — but skim it for one useful fact: it independently arrived at reordering the hardware grid and moving NGL/Parallel/extra_args into the Model section, which overlaps with item 6 below. Don't blindly reapply its diff.
+
+### 1. Type field relocation
+
+Move the slot `type` field into the top grid area, positioned between **Runner Binary** and **Image Status**. Make it **read-only** — it must auto-update based on the operator's model/slot-type choice elsewhere in the form (mirrors how `device` already rides the model at create time — same pattern, different field). Confirm in `slot-modals.jsx` where `type` is currently rendered/edited and where the model-selection state lives so the derivation is wired to the same source of truth, not duplicated state.
+
+### 2. Activity log spam + height
+
+Two related but separate bugs/tasks in `activity-log.jsx`:
+
+- **Spam bug**: on slot page load, the activity log floods with `[Image #1]`-style duplicate entries before settling. This smells like a duplicate SSE subscription or a state update firing on every render during initial hydration — use `superpowers:systematic-debugging` to find the actual duplicate-emit source (check for an effect with a missing/wrong dependency array, or a subscription set up twice in dev-mode StrictMode vs prod). Don't guess-fix; reproduce first (load the slots page against a live or mocked backend, watch the log stream).
+- **Height**: extend the activity panel to the full combined height of the Inference container (`inference-pane.jsx`) + NPU container (`npu-pane.jsx`) — i.e. it should visually span the same vertical extent as those two panes stacked, not its own fixed/short height. Check `slots.jsx` for how these three components are laid out relative to each other (likely a CSS grid or flex column) and adjust the layout, not just the component's own height rule, if the panels are siblings under a shared grid.
+
+### 3. Info icon alignment
+
+Across **all** slot edit drawers (and check the model drawer / other drawers sharing the same primitive if there is one — see `primitives.jsx`), the small `(i)` info icons currently render beneath the field title. Move them inline with the field label (same row, not a line below). This is almost certainly one shared label/field primitive component — find it (likely in `primitives.jsx` or inline in `slot-modals.jsx`) and fix it once rather than patching every field individually.
+
+### 4. Remove default-slot picker from creation
+
+The create-slot modal currently shows a "default for type?" checkbox + "Set as default" label + explanatory tooltip (design-session image #2). Remove this from the creation flow entirely.
+
+**Decided replacement behavior** (confirmed with operator):
+- The **first slot created of a given `type`** silently becomes that type's default — no checkbox, nothing to conflict with yet.
+- Changing which slot is the default afterward becomes a separate, explicit action — a **"Set as default" action on each slot's row/card in the slots list** (`slots.jsx`), not part of create or the edit drawer.
+- Backend already enforces "exactly one `default=true` per type" via `check_default_uniqueness()` in `src/hal0/slots/config_write.py` (SC-4) — this guard was just fixed (2026-07-31, same session) so a PATCH that doesn't touch `default` on a slot with a pre-existing stale duplicate default no longer gets incorrectly blocked. See `changed_keys` param on `check_default_uniqueness()` / `SlotManager._check_default_uniqueness()`. The new "Set as default" action should call `update_config(slot_name, {"default": True})` — that path is already correctly guarded.
+
+### 5. Profile section reorder
+
+Move the **Profile** section below the **Model** selection section (design-session image #4 shows Profile currently above Hardware/Device/Model, with an arrow indicating it should move down past Model). Confirm the exact target order against the sibling doc's end-state sketch (item 8 below) rather than guessing.
+
+### 6. Device split: create-only, removed from edit drawer
+
+- The `Device` dropdown currently in the edit drawer (design-session image 5: GPU ROCm/Vulkan/CUDA/CPU/NPU choices with a starred default) must be **removed from the edit drawer entirely**.
+- Device selection belongs **only** in the slot **creation** modal, consistent with the existing create-time "device rides the model" tooltip — this isn't introducing manual device choice where none existed, it's removing the redundant/conflicting copy that lets an operator change device post-creation without recreating the slot.
+- After a slot exists, device is fixed for that slot's lifetime; changing device means duplicating the model for the new device and creating a new slot (already the documented pattern).
+
+### 7. Rename + rework Image pin / Runner fields
+
+- `Image pin` → **`Runner Image`** (label + any internal var/prop names worth renaming for clarity — don't rename the backend field `image_pin` itself unless the sibling branch's catalogue work requires it; check `TOLERATED_SLOT_CONFIG_KEYS` and `SlotConfig` in `src/hal0/config/schema.py` before touching the wire format).
+  - This pass: **stays a text field**, not yet a dropdown. Becoming a dropdown (sourced from the Runner Image catalogue) is explicitly deferred to the sibling branch (`feat/runner-image-catalogue`) — don't build a half-catalogue here.
+- `Runner` → **`Runner Binary`**.
+  - Remove the `"— default (from device) —"` dropdown entry (design-session image 6 annotation: "Shows Available Binary's Built Into the Image (No Default)").
+  - Populate the dropdown from `RUNNER_IMAGES` in `src/hal0/runners/__init__.py`, filtered to entries whose `.image` matches the slot's current `image_pin`/Runner Image value. This data already exists today — e.g. for `ghcr.io/hal0ai/hal0-rocmfpx:...` both `rocmfpx` and `vulkanfpx` keys match (they share one Vulkan-portable image, see the `Runner` dataclass's `supported_backends` field and its docstring in that file), giving exactly the "rocmfpx · rocm" / "vulkanfpx · vulkan" choices shown in image 6 — no default entry, only what's actually available for that image.
+  - You'll likely need a new small backend endpoint or extend an existing one to expose "runner keys matching image X" if this filtering isn't already done client-side against a `RUNNER_IMAGES` export — check whether `RUNNER_IMAGES` (or an equivalent) is already surfaced over the API (search `ui/src/api/endpoints.ts` and `useModels.ts`/a possible `useRunners.ts`) before adding a new one.
+
+### 8. Target end-state shape
+
+Design-session image #7 is a sketch of the resulting edit-drawer shape once all of the above lands: `Type` (top grid, read-only) between Runner Binary and Image Status → Hardware section without Device → Runner Image (text, this branch) / Runner Binary (dropdown) → Profile (moved below Model) → Model section. Cross-check your final layout against this before calling the branch done; ask the operator to eyeball a screenshot if unsure.
+
+---
+
+## Verification
+
+- `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/ -q` should stay green — the SC-4 default-uniqueness fix already has regression coverage in `tests/slots/test_default_uniqueness.py`; add coverage for the "first slot of a type auto-defaults" behavior (item 4) if that logic moves server-side, or a frontend test if it's purely a UI-side POST-then-set-default sequence.
+- No automated UI test suite was confirmed in this session — check `ui/tests/e2e/` (`apiMock.ts` exists) for Playwright coverage of the slot drawer and extend it for the info-icon/layout changes if such coverage exists; otherwise manually verify against a running dashboard (`superpowers:run` skill / project's own run instructions) before calling this done, per this repo's UI-change verification rule (start the dev server, click through the golden path).
+- Follow this workspace's GitOps rules: Conventional Commits, one logical change per commit (these 8 items can reasonably be 3-5 commits — e.g. layout/relabel, activity-log bugfix, default-picker removal, device split — don't bundle all 8 into one commit), PR against `main`, watch CI green, `gh pr merge --squash --auto --delete-branch`.

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -267,6 +267,13 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         # per-slot /config fetch.
         entry["pinned"] = reaper_is_pinned(name, cfg)
 
+        # SC-4 default marker: exactly one slot per ``type`` may carry
+        # ``default = true`` (check_default_uniqueness). Lifted verbatim so the
+        # slot list can render a "Set as default" action only on the slots that
+        # are NOT already their type's default — the create modal no longer
+        # asks, so this is the one place the operator re-points it.
+        entry["default"] = cfg.get("default") is True
+
         # ctx_max: the configured context window. The canonical TOML key is
         # ``[model].context_size`` (the dashboard's ``ctx_size`` alias is
         # folded to it on write — see slots.manager). Surfaced so the

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -236,12 +236,26 @@ def check_default_uniqueness(
     cfg_dict: dict[str, Any],
     *,
     slots_dir: Path | None = None,
+    changed_keys: set[str] | None = None,
 ) -> None:
     """Reject a write that would land a second ``default=true`` per type.
 
     Sync core of :meth:`SlotManager._check_default_uniqueness` (see its
     docstring for the full contract), shared with the stacks apply engine.
+
+    ``changed_keys`` is the set of keys this write actually touches. When it is
+    supplied and does NOT contain ``"default"``, the check is skipped outright:
+    the write isn't moving the invariant, so a pre-existing pair of stale
+    ``default=true`` peers on disk is not this write's problem to fix — and
+    must not veto it. (Without this, a plain ``update_config("b",
+    {"n_gpu_layers": 40})`` on a slot that merely *happens* to carry
+    ``default=true`` in an already-violated state gets rejected for a conflict
+    it did not create.) ``None`` — the default — keeps the historical behaviour
+    of validating the full merged dict, which is what ``create()`` wants: there
+    every key is new.
     """
+    if changed_keys is not None and "default" not in changed_keys:
+        return
     if cfg_dict.get("default") is not True:
         return
     type_ = cfg_dict.get("type")
@@ -296,7 +310,15 @@ def reconcile_and_guard_slot_config(
     """
     merged = reconcile_slot_updates(base, updates)
     check_npu_exclusivity(slot_name, merged, slots_dir=slots_dir)
-    check_default_uniqueness(slot_name, merged, slots_dir=slots_dir)
+    # Only the keys this apply actually carries drive the SC-4 guard — an
+    # unrelated stack field must not be blocked by a stale duplicate-default
+    # state it neither created nor touches.
+    check_default_uniqueness(
+        slot_name,
+        merged,
+        slots_dir=slots_dir,
+        changed_keys=set(updates.keys()),
+    )
     return merged
 
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -53,6 +53,7 @@ from hal0.slots._cfg_helpers import (
 from hal0.slots.config_write import (
     _base_profile_for_backend,
     _cfg_effective_backend,
+    _iter_peer_configs,
     _reconcile_device_profile,
     check_default_uniqueness,
     check_npu_exclusivity,
@@ -2215,6 +2216,20 @@ class SlotManager:
         # operator error and raises.
         _reconcile_device_profile(cfg_dict, set(cfg_dict.keys()))
         await self._check_npu_exclusivity(slot_name, cfg_dict)
+        # SC-4, first-of-type: the create modal no longer asks "make this the
+        # default?" — the FIRST slot of a type silently becomes that type's
+        # default (there is nothing yet to conflict with), and re-pointing it
+        # afterwards is the explicit "Set as default" row action on the slot
+        # list. Only fills an absent/false marker: an explicit
+        # ``default=true`` from the caller is left alone and still goes
+        # through the uniqueness guard below.
+        if cfg_dict.get("default") is not True:
+            type_ = cfg_dict.get("type")
+            if type_ and not any(
+                peer.get("type") == type_
+                for _peer_name, peer in _iter_peer_configs(slot_name, None)
+            ):
+                cfg_dict["default"] = True
         # SC-4: refuse a second default=true slot of the same type before
         # the TOML lands on disk (belt to default_slot_for's routing-time
         # suspenders). Fast fast path when this write isn't a new default.
@@ -2428,7 +2443,15 @@ class SlotManager:
             # cfg_dict — the authoritative post-merge state, same as the NPU
             # guard. The peer walk excludes slot_name, so re-persisting the
             # sole default never self-conflicts.
-            await self._check_default_uniqueness(slot_name, cfg_dict)
+            #
+            # ``changed_keys`` is the update's own key set: a PATCH that does
+            # not carry ``default`` skips the check entirely, so an unrelated
+            # edit to a slot caught in a pre-existing two-defaults-on-disk
+            # state is no longer wrongly rejected for a conflict it did not
+            # create. A PATCH that DOES set ``default`` is still fully guarded.
+            await self._check_default_uniqueness(
+                slot_name, cfg_dict, changed_keys=set(updates.keys())
+            )
 
             try:
                 write_slot_toml(cfg_path, cfg_dict)
@@ -2676,6 +2699,8 @@ class SlotManager:
         self,
         slot_name: str,
         cfg_dict: dict[str, Any],
+        *,
+        changed_keys: set[str] | None = None,
     ) -> None:
         """Reject a write that would land a second ``default=true`` per type.
 
@@ -2705,8 +2730,13 @@ class SlotManager:
         monkeypatchability) over the module-level sync
         :func:`check_default_uniqueness`, which the stacks apply engine
         shares so its writes obey the same guard.
+
+        ``changed_keys`` narrows the guard to writes that actually touch
+        ``default`` — see :func:`check_default_uniqueness`. ``None`` (the
+        default) validates the full merged dict, which is what ``create()``
+        wants.
         """
-        check_default_uniqueness(slot_name, cfg_dict)
+        check_default_uniqueness(slot_name, cfg_dict, changed_keys=changed_keys)
 
     # ── idle / wake-on-request ───────────────────────────────────────────────
 

--- a/tests/api/test_models_default.py
+++ b/tests/api/test_models_default.py
@@ -201,9 +201,18 @@ def test_create_slot_with_default_promotes_model(client: TestClient, tmp_hal0_ho
     assert promo["type"] == "llm"
     # The MODEL is now its type's default.
     assert client.get("/api/models/slot-model").json()["default"] is True
-    # And `default` did NOT leak into the slot TOML (it's the model marker).
-    cfg = client.get("/api/slots/myslot/config").json()
-    assert "default" not in cfg
+    # The POST body's `default` is the MODEL marker and never lands on the slot
+    # as such. `myslot` IS the type's default here, but only because it is the
+    # FIRST llm slot on disk (SlotManager.create's first-of-type auto-default),
+    # not because the body said so. A SECOND slot of the type proves it: it gets
+    # the same body flag and still carries no slot-level default marker.
+    r2 = client.post(
+        "/api/slots",
+        json={"name": "myslot2", "type": "llm", "model": "slot-model", "default": True},
+    )
+    assert r2.status_code == 201, r2.text
+    cfg2 = client.get("/api/slots/myslot2/config").json()
+    assert "default" not in cfg2
 
 
 def test_create_slot_default_false_does_not_promote(client: TestClient, tmp_hal0_home: str) -> None:

--- a/tests/slots/test_default_uniqueness.py
+++ b/tests/slots/test_default_uniqueness.py
@@ -169,3 +169,103 @@ async def test_update_config_sole_default_does_not_self_conflict(slot_root: Path
     _write_slot(slot_root, "a", slot_type="llm", default=True)
     sm = SlotManager()
     await sm.update_config("a", {"model": {"context_size": 4096}})
+
+
+# ── First-of-type auto-default (create modal no longer asks) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_create_first_slot_of_type_auto_defaults(slot_root: Path) -> None:
+    """The FIRST slot of a type becomes that type's default with no ask.
+
+    The create modal dropped its "default for <type>?" checkbox, so a create
+    body carries no ``default`` key at all. With no peer of the same type on
+    disk there is nothing to conflict with — the slot silently becomes the
+    type's default so routing has something to resolve.
+    """
+    sm = SlotManager()
+    await sm.create(
+        "a",
+        {
+            "name": "a",
+            "port": 8083,
+            "device": "gpu-rocm",
+            "type": "llm",
+            "model": {"default": "qwen3-1b"},
+        },
+    )
+    assert "default = true" in (slot_root / "a.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_create_second_slot_of_type_is_not_auto_defaulted(slot_root: Path) -> None:
+    """A second slot of a type stays undefaulted — a peer already exists.
+
+    True regardless of whether the existing peer is itself the default: the
+    auto-default only fires when the type has no slot at all.
+    """
+    _write_slot(slot_root, "a", slot_type="llm", default=False)
+    sm = SlotManager()
+    await sm.create(
+        "b",
+        {
+            "name": "b",
+            "port": 8083,
+            "device": "gpu-rocm",
+            "type": "llm",
+            "model": {"default": "qwen3-1b"},
+        },
+    )
+    assert "default = true" not in (slot_root / "b.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_create_second_slot_of_type_with_default_peer_is_not_auto_defaulted(
+    slot_root: Path,
+) -> None:
+    """Same, with the existing peer holding the default marker."""
+    _write_slot(slot_root, "a", slot_type="llm", default=True)
+    sm = SlotManager()
+    await sm.create(
+        "b",
+        {
+            "name": "b",
+            "port": 8083,
+            "device": "gpu-rocm",
+            "type": "llm",
+            "model": {"default": "qwen3-1b"},
+        },
+    )
+    assert "default = true" not in (slot_root / "b.toml").read_text(encoding="utf-8")
+
+
+# ── changed_keys: an unrelated PATCH is not blocked by stale disk state ────
+
+
+@pytest.mark.asyncio
+async def test_update_config_unrelated_patch_survives_stale_duplicate_defaults(
+    slot_root: Path,
+) -> None:
+    """A PATCH that doesn't touch ``default`` is never blocked by SC-4.
+
+    Two ``default=true`` peers of the same type on disk is an invariant
+    violation that predates (or raced) this guard. Re-litigating it on an
+    unrelated write bricks legitimate edits: the write is not moving the
+    invariant, so it is not this write's problem to fix or be blocked by.
+    """
+    _write_slot(slot_root, "a", slot_type="llm", default=True)
+    _write_slot(slot_root, "b", slot_type="llm", default=True)
+    sm = SlotManager()
+    await sm.update_config("b", {"n_gpu_layers": 40})
+    assert "n_gpu_layers = 40" in (slot_root / "b.toml").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_update_config_explicit_default_still_guarded(slot_root: Path) -> None:
+    """A PATCH that DOES set ``default=true`` is still refused on a conflict."""
+    _write_slot(slot_root, "a", slot_type="llm", default=True)
+    _write_slot(slot_root, "b", slot_type="llm", default=False)
+    sm = SlotManager()
+    with pytest.raises(SlotConfigError) as exc:
+        await sm.update_config("b", {"default": True})
+    assert "a" in exc.value.details["conflicting_slots"]

--- a/ui/src/api/hooks/useActivity.ts
+++ b/ui/src/api/hooks/useActivity.ts
@@ -211,8 +211,29 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
   const esRef = useRef<EventSource | null>(null)
   const epochRef = useRef<string | null>(_epochCache.get(filterKey) ?? null)
   const errorCountRef = useRef(0)
+  // Resume cursor — the highest activity id this filter set has already seen.
+  //
+  // Without it EVERY connect() asked the backend for `since=0`, i.e. a full
+  // durable backfill (up to the server's 1000-row cap) streamed one SSE frame
+  // at a time. ActivityLog is mounted in several mutually-exclusive branches
+  // of SlotsView (loading skeleton / empty / populated), so a normal page load
+  // unmounts and remounts it as soon as /api/slots resolves — two full
+  // replays back-to-back, which is exactly the "activity log floods on load
+  // then settles" symptom. The id-dedup below made the second replay a no-op
+  // *semantically*, but only after every one of its frames had been pushed
+  // through setRecords. Resuming from the cursor means a reconnect asks only
+  // for what it has not already got.
+  const sinceRef = useRef<number>(0)
+  // Re-seed whenever the filter set changes: each filter set has its own ring.
+  const seededForRef = useRef<string | null>(null)
+  if (seededForRef.current !== filterKey) {
+    seededForRef.current = filterKey
+    const cached = _ringCache.get(filterKey) ?? []
+    sinceRef.current = cached.reduce((mx, r) => (r.id != null && r.id > mx ? r.id : mx), 0)
+  }
 
   const push = (record: ActivityRecord) => {
+    if (record.id != null && record.id > sinceRef.current) sinceRef.current = record.id
     setRecords((prev) => {
       // Dedup by id (durable backfill can overlap a reconnect replay, and a
       // remount rehydrates from the cache before the SSE replays).
@@ -239,7 +260,13 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
     const connect = () => {
       if (cancelled) return
       try {
-        const url = `${ENDPOINTS.activityStream}${buildActivityQuery(filters)}`
+        // Resume from the cursor unless the caller pinned its own `since`
+        // (then that value IS the contract and must not be overridden).
+        const query =
+          filters.since != null || sinceRef.current <= 0
+            ? buildActivityQuery(filters)
+            : buildActivityQuery({ ...filters, since: sinceRef.current })
+        const url = `${ENDPOINTS.activityStream}${query}`
         esRef.current = new EventSource(url)
       } catch {
         setDisconnected(true)
@@ -257,6 +284,8 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
             if (epochRef.current != null) {
               setRecords([])
               _ringCache.delete(filterKey)
+              // Ids restart with the new epoch — the old cursor is meaningless.
+              sinceRef.current = 0
             }
             epochRef.current = ep
             _epochCache.set(filterKey, ep)

--- a/ui/src/api/hooks/useSlots.ts
+++ b/ui/src/api/hooks/useSlots.ts
@@ -91,6 +91,11 @@ export interface Slot {
    *  null/absent = release default. A non-default pin is shown on the card so
    *  drift is never hidden. Canonical TOML key `image_pin`. */
   image_pin?: string | null
+  /** SC-4 default marker — true iff this slot is its `type`'s default. Exactly
+   *  one slot per type may carry it (check_default_uniqueness). Lifted by
+   *  slot_view so the slot list can offer "Set as default" on the slots that
+   *  are NOT already the default. */
+  default?: boolean
   /** Configured context window ([model].context_size). Surfaced by
    *  config_enrichment so the Inference engine pane can render "ctx
    *  used / max". Absent when the slot configures no context window —
@@ -337,6 +342,9 @@ function normalizeSlot(s: any): Slot {
     threads: s?.threads,
     binary: s?.binary ?? '',
     image_pin: s?.image_pin ?? null,
+    // SC-4 default marker — strict boolean so an absent key reads as "not the
+    // default" rather than undefined (the row action gates on `!== true`).
+    default: s?.default === true,
   }
 }
 

--- a/ui/src/dash/activity-log.css
+++ b/ui/src/dash/activity-log.css
@@ -9,8 +9,11 @@
 .act-card {
   display: flex;
   flex-direction: column;
-  /* The card never grows unbounded — the body owns the scroll. */
-  max-height: 760px;
+  /* Fill the (stretched) side column rather than self-capping, so the pane
+     lines up with the bottom of the stacked main-column panes. The body
+     still owns the scroll — see `.act-body`. */
+  height: 100%;
+  min-height: 0;
 }
 
 /* ── header ─────────────────────────────────────────────────────── */
@@ -116,7 +119,9 @@
 .act-body {
   flex: 1 1 auto;
   min-height: 200px;
-  max-height: 620px;
+  /* No self-cap: the card is height:100% of the stretched side column, so the
+     body takes whatever is left after the header/filter bar. */
+  max-height: none;
   overflow-y: auto;
   overflow-x: hidden;
   font-family: var(--jbm);

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -31,6 +31,7 @@ import {
   useSlotUnload,
   useSlotLoad,
   useSlotSwap,
+  useSlotEdit,
 } from '@/api/hooks/useSlots'
 import { useModels } from '@/api/hooks/useModels'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
@@ -91,6 +92,7 @@ const IIcons = {
   ),
   play: <II d="M5 3.4l8 4.6-8 4.6V3.4z" />,
   edit: <II d="M3 13l3-1 7-7-2-2-7 7-1 3z" />,
+  star: <II d="M8 2.2l1.8 3.7 4 .6-2.9 2.8.7 4-3.6-1.9-3.6 1.9.7-4L2.2 6.5l4-.6z" />,
   ext: <II d="M6 3H3v10h10v-3M9 3h4v4M9 9l4-4" />,
 }
 const Ic = ({ name, size = 16 }) =>
@@ -257,7 +259,20 @@ export function ModelPicker({ s, models, disabled, onSwap }) {
 
 // per-slot controls — Start/Stop are mutually exclusive by running state;
 // compact (collapsed) cards get the minimal set (no Logs/Edit).
-export function SlotControls({ phase, busy, compact, onStart, onStop, onRestart, onLogs, onEdit }) {
+export function SlotControls({
+  phase,
+  busy,
+  compact,
+  onStart,
+  onStop,
+  onRestart,
+  onLogs,
+  onEdit,
+  // SC-4: promote this slot to its type's default. Rendered only when
+  // `onSetDefault` is supplied AND the slot isn't already the default — a slot
+  // that already holds the marker has nothing to promote.
+  onSetDefault,
+}) {
   const running = phase !== 'off'
   return (
     <span className="slot-ctrls" onClick={(e) => e.stopPropagation()}>
@@ -285,6 +300,16 @@ export function SlotControls({ phase, busy, compact, onStart, onStop, onRestart,
       {!compact && (
         <button className="sctrl" title="Logs" onClick={onLogs}>
           <Ic name="logs" size={13} />
+        </button>
+      )}
+      {onSetDefault && (
+        <button
+          className="sctrl"
+          title="Set as default for this slot type"
+          disabled={busy}
+          onClick={onSetDefault}
+        >
+          <Ic name="star" size={13} />
         </button>
       )}
       {!compact && (
@@ -444,6 +469,9 @@ function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows 
             onRestart={() => handlers.onRestart(s)}
             onLogs={() => handlers.onLogs(s)}
             onEdit={() => handlers.onEdit(s)}
+            onSetDefault={
+              s.default === true ? undefined : () => handlers.onSetDefault(s)
+            }
           />
         )
         // The bound registry row, resolved through the shared helper the slot
@@ -495,6 +523,9 @@ function MiniCard({ s, ind, busy, handlers }) {
           onRestart={() => handlers.onRestart(s)}
           onLogs={() => handlers.onLogs(s)}
           onEdit={() => handlers.onEdit(s)}
+          onSetDefault={
+            s.default === true ? undefined : () => handlers.onSetDefault(s)
+          }
         />
       </div>
     </div>
@@ -530,6 +561,11 @@ export function InferencePane() {
   const unloadMut = useSlotUnload()
   const loadMut = useSlotLoad()
   const swapMut = useSlotSwap()
+  // SC-4 "Set as default" row action — the same PUT /config the drawer's
+  // Pinned toggle uses. check_default_uniqueness REFUSES a second
+  // default=true rather than demoting the incumbent, so `handlers.onSetDefault`
+  // below does the demote-then-promote itself (two PUTs).
+  const editMut = useSlotEdit()
   const [busyName, setBusyName] = useStateI(null)
   // Inline model edit — the ModelDrawer is mounted ONCE here (the pane owns the
   // cards) and driven by the picked registry row, matching how models.jsx
@@ -593,6 +629,35 @@ export function InferencePane() {
       run(s.name, swapMut, { name: s.name, model_id }, `Swapping ${s.name}…`),
     onEdit: (s) => {
       window.location.hash = '#slots/' + s.name
+    },
+    // SC-4 allows exactly one default=true slot per type and REFUSES a write
+    // that would land a second one — it does not silently demote. There is no
+    // atomic promote endpoint, so re-pointing the default is demote-then-
+    // promote. If the promote fails we restore the incumbent rather than
+    // leaving the type with no default at all.
+    onSetDefault: async (s) => {
+      const prev = (allSlots || []).find(
+        (p) => p?.name && p.name !== s.name && p?.type === s.type && p?.default === true,
+      )
+      try {
+        if (prev) await editMut.mutateAsync({ name: prev.name, body: { default: false } })
+        try {
+          await editMut.mutateAsync({ name: s.name, body: { default: true } })
+        } catch (err) {
+          if (prev) {
+            await editMut
+              .mutateAsync({ name: prev.name, body: { default: true } })
+              .catch(() => {})
+          }
+          throw err
+        }
+        toast(`${s.name} is now the default ${s.type || 'slot'}`, 'ok')
+      } catch (err) {
+        toast(
+          err?.message ? `${s.name}: ${err.message}` : `${s.name}: could not set default`,
+          'warn',
+        )
+      }
     },
     onLogs: (s) => {
       window.dispatchEvent(new CustomEvent('hal0:slot-logs', { detail: { name: s.name } }))

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -17,7 +17,6 @@ import { useHardware } from "@/api/hooks/useHardware";
 import { useModels, usePullJob } from "@/api/hooks/useModels";
 import { useProfiles } from "@/api/hooks/useProfiles";
 import { useSystemInfo, deviceBackend } from "@/api/hooks/useRuntimes";
-import { useMetaEnums } from "@/api/hooks/useMeta";
 import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
@@ -216,9 +215,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	const swapMut = useSlotSwap();
 	const profilesQuery = useProfiles();
 	const modelsQuery = useModels();
-	// HW grid (spec-hw-slot-ownership §2): device enum from meta, BINARY options +
-	// fit-check metadata from system-info (RUNNER_IMAGES).
-	const metaEnums = useMetaEnums();
+	// HW grid (spec-hw-slot-ownership §2): BINARY options + fit-check metadata
+	// from system-info (RUNNER_IMAGES). The device ENUM is no longer read here —
+	// device rides the model at creation and is not editable post-create, so the
+	// drawer only ever *displays* the slot's persisted device.
 	const systemInfoQuery = useSystemInfo();
 
 	// Seed from the PERSISTED context window (slot.ctx_max, from
@@ -867,13 +867,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					/>
 				</div>
 
-				{/* Runner + image status strip — read-only. Runner (BINARY) resolves the
-          launch image (RUNNER_IMAGES[binary]); image_pin overrides it (§3).
+				{/* Runner + type + image status strip — read-only. Runner (BINARY)
+          resolves the launch image (RUNNER_IMAGES[binary]); image_pin overrides
+          it (§3). `type` sits between the two: it is fixed at creation (it rides
+          the model, exactly like device), so it belongs in the read-only strip
+          rather than as a disabled form control down in the Slot group.
           image status keyed to slot_id so the operator knows which slot owns it. */}
 				<div
 					style={{
 						display: "grid",
-						gridTemplateColumns: "1fr 1fr",
+						gridTemplateColumns: "1fr 1fr 1fr",
 						gap: 0,
 						border: "1px solid var(--line-soft)",
 						borderRadius: "var(--rad-sm)",
@@ -884,6 +887,17 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					<ReadOnlyStrip
 						k="runner · binary"
 						v={slot.binary || `auto · ${deviceBackend(device) || device}`}
+					/>
+					<ReadOnlyStrip
+						k="type"
+						v={
+							<span
+								data-testid="slot-type-readonly"
+								title="Type is fixed once created — make a new slot for a different kind."
+							>
+								{slot.type || "—"}
+							</span>
+						}
 					/>
 					<ReadOnlyStrip
 						k="image status"
@@ -932,114 +946,15 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							</button>
 						</div>
 					</div>
-
-					<div className="form-row">
-						<div className="form-lbl">
-							<span>Type</span>
-						</div>
-						<div className="form-ctl">
-							<select className="input mono" defaultValue={slot.type} disabled>
-								<option>{slot.type}</option>
-							</select>
-							<FieldInfoIcon description="Type is fixed once created. Make a new slot for a different kind." />
-						</div>
-					</div>
+					{/* Type moved to the read-only strip above — it is fixed at
+					    creation, so a disabled select here was a control that could
+					    never do anything. */}
 				</FieldGroup>
 
-				{/* Runtime profile — the slot's SlotConfig.profile. Controls the
-	          runtime family, device-class gating and MTP draft backend; profile
-	          FLAGS are copy-on-stamp into the model tune (model drawer), never
-	          read at launch. */}
-				<FieldGroup label="Profile">
-					{(() => {
-						const all = Array.isArray(profilesQuery.data)
-							? profilesQuery.data
-							: [];
-						const devBackend = deviceBackend(device);
-						// Mirror backend profile_fits_slot: slot type supported +
-						// device_class match + backend match (when both declared).
-						const fit = all.filter(
-							(p) =>
-								(!Array.isArray(p.supported_slot_types) ||
-									p.supported_slot_types.includes(slot.type)) &&
-								(!p.device_class || p.device_class === deviceClass) &&
-								(!p.backend || !devBackend || p.backend === devBackend),
-						);
-						const fitNames = fit.map((p) => p.name);
-						const adoptedFromModel =
-							!!profileSel &&
-							profileSel === (curModelRow?.defaults?.profile || "");
-						// The options are filtered against the CURRENT device, but the
-						// device select sits below and can flip afterwards. Saving a
-						// profile+device pair with conflicting backends is a hard
-						// SlotConfigError (_reconcile_device_profile), so warn instead of
-						// silently PUTting the conflict.
-						const profileFitWarn =
-							profileSel && all.length > 0 && !fitNames.includes(profileSel)
-								? `Profile "${profileSel}" does not fit device "${device}" — saving both together is rejected. Pick a listed profile or revert the device.`
-								: null;
-						return (
-							<div className="form-row">
-								<div className="form-lbl">
-									<span>Profile</span>
-									<FieldInfoIcon description="⟳ Runtime profile — picks the runtime family, device-class
-										gating and the MTP draft backend. Flags are NOT read from here
-										at launch; they are stamped into the model's launch flags on
-										the model drawer." />
-								</div>
-								<div className="form-ctl">
-									<select
-										className="input mono"
-										data-testid="slot-profile"
-										value={profileSel}
-										onChange={(e) => setProfileSel(e.target.value)}
-									>
-										{/* keep a none/out-of-vocab persisted profile selectable */}
-										{!slot.profile && <option value="">— none —</option>}
-										{profileSel && !fitNames.includes(profileSel) && (
-											<option value={profileSel}>{profileSel}</option>
-										)}
-										{fit.map((p) => (
-											<option key={p.name} value={p.name} title={p.intent}>
-												{p.name}
-												{p.intent ? ` · ${p.intent}` : ""}
-											</option>
-										))}
-									</select>
-									{adoptedFromModel && (
-										<div className="hint">
-											Adopted from the bound model's preference — swapping the
-											model may change it.
-										</div>
-									)}
-									{profileFitWarn && (
-										<div
-											className="hint"
-											data-testid="slot-profile-fit-warning"
-											style={{
-												marginTop: 6,
-												padding: "6px 10px",
-												borderRadius: "var(--rad-sm)",
-												color: "var(--warn)",
-												border: "1px solid var(--warn-line)",
-												background: "var(--warn-soft)",
-											}}
-										>
-											⚠ {profileFitWarn}
-										</div>
-									)}
-								</div>
-							</div>
-						);
-					})()}
-				</FieldGroup>
 
 				{/* Hardware ownership — changes apply on Save and require a restart. */}
 				<FieldGroup label="Hardware">
 					{(() => {
-						const devices = Array.isArray(metaEnums?.devices)
-							? metaEnums.devices
-							: [];
 						const backends = systemInfoQuery.data?.backends ?? {};
 						const binaryKeys = Object.keys(backends);
 						const devBackend = deviceBackend(device);
@@ -1049,7 +964,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						// qwen3tts/comfyui) and the SAME supported_backends list the
 						// fit-check below warns on. An out-of-vocab persisted value stays
 						// selectable underneath.
-						const fitBinaryKeys = binaryKeys.filter((k) => {
+						const deviceFitBinaryKeys = binaryKeys.filter((k) => {
 							const r = backends[k] || {};
 							if (r.device_class && r.device_class !== deviceClass)
 								return false;
@@ -1059,6 +974,18 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							const sup = runnerBackends(r);
 							return !(sup.length > 0 && devBackend && !sup.includes(devBackend));
 						});
+						// The Runner Binary dropdown offers the binaries BUILT INTO the
+						// currently-named Runner Image — one image can ship several
+						// (e.g. the shared rocmfpx image serves both `rocmfpx · rocm`
+						// and `vulkanfpx · vulkan`). With no image named yet there is
+						// nothing to match against, so fall back to the device fit set.
+						const pinnedImage = (imagePin || "").trim();
+						const imageFitKeys = pinnedImage
+							? binaryKeys.filter((k) => backends[k]?.image === pinnedImage)
+							: [];
+						const fitBinaryKeys = pinnedImage
+							? imageFitKeys
+							: deviceFitBinaryKeys;
 						// Fit-check (§4): the selected device's backend must be in the chosen
 						// BINARY's supported_backends. WARN at assignment, never block. Only
 						// when a BINARY is explicitly picked (empty = HW-gated default).
@@ -1074,35 +1001,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								: null;
 						return (
 							<>
+								{/* Device has no control here on purpose: it rides the model
+								    at creation (see the create modal's device-redirect note),
+								    and changing it afterwards means duplicating the model for
+								    the other device and making a new slot. The drawer still
+								    READS slot.device for the fit filters below. */}
 								<div className="form-row">
 									<div className="form-lbl">
-										<span>Device</span>
-										<FieldInfoIcon description="Changing device changes the hardware class/backend and requires a restart." />
-									</div>
-									<div className="form-ctl">
-										<select
-											className="input mono"
-											data-testid="slot-hw-device"
-											value={device}
-											onChange={(e) => setDevice(e.target.value)}
-										>
-											{/* keep an out-of-vocab persisted device selectable */}
-											{device && !devices.some((d) => d.id === device) && (
-												<option value={device}>{device}</option>
-											)}
-											{devices.map((d) => (
-												<option key={d.id} value={d.id} title={d.description}>
-													{d.label}
-													{d.recommended ? " ★" : ""}
-												</option>
-											))}
-										</select>
-									</div>
-								</div>
-
-								<div className="form-row">
-									<div className="form-lbl">
-										<span>Image pin</span>
+										<span>Runner Image</span>
 										<FieldInfoIcon description="Optional container image override for a debug build, A/B test, or rollback. Empty uses the release default." />
 									</div>
 									<div className="form-ctl">
@@ -1134,10 +1040,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 								<div className="form-row">
 									<div className="form-lbl">
-										<span>Runner</span>
-										<FieldInfoIcon description="⟳ Which runner build/image executes on the selected
-											device (a RUNNER_IMAGES key, not a profile). Empty = auto
-											from device." />
+										<span>Runner Binary</span>
+										<FieldInfoIcon description="⟳ Which binary inside the Runner Image executes (a
+											RUNNER_IMAGES key, not a profile). One image can ship
+											several — the list shows exactly what the named Runner
+											Image provides." />
 									</div>
 									<div className="form-ctl">
 										<select
@@ -1146,8 +1053,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 											value={binary}
 											onChange={(e) => setBinary(e.target.value)}
 										>
-											<option value="">— default (from device) —</option>
-											{/* keep an out-of-vocab persisted binary selectable */}
+											{/* No "— default (from device) —" entry: the dropdown lists
+											    the binaries actually built into the Runner Image, and
+											    nothing else. An out-of-vocab persisted value keeps its
+											    own option so the drawer never silently rewrites it. */}
 											{binary && !fitBinaryKeys.includes(binary) && (
 												<option value={binary}>{binary}</option>
 											)}
@@ -1160,6 +1069,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												</option>
 											))}
 										</select>
+										{!binary && fitBinaryKeys.length > 0 && (
+											<div className="hint">
+												No binary pinned — the launcher resolves one from the
+												device. Pick one to fix it.
+											</div>
+										)}
+										{pinnedImage && fitBinaryKeys.length === 0 && (
+											<div className="hint" data-testid="slot-hw-binary-none">
+												No known runner binary ships in{" "}
+												<span className="mono">{pinnedImage}</span>. Clear the
+												Runner Image to see the binaries that fit this device.
+											</div>
+										)}
 										{fitWarn && (
 											<div
 												className="hint"
@@ -1235,6 +1157,95 @@ function EditSlotDrawer({ open, slot, onClose }) {
 									</div>
 								</div>
 							</>
+						);
+					})()}
+				</FieldGroup>
+
+				{/* Runtime profile — the slot's SlotConfig.profile. Controls the
+	          runtime family, device-class gating and MTP draft backend; profile
+	          FLAGS are copy-on-stamp into the model tune (model drawer), never
+	          read at launch. */}
+				<FieldGroup label="Profile">
+					{(() => {
+						const all = Array.isArray(profilesQuery.data)
+							? profilesQuery.data
+							: [];
+						const devBackend = deviceBackend(device);
+						// Mirror backend profile_fits_slot: slot type supported +
+						// device_class match + backend match (when both declared).
+						const fit = all.filter(
+							(p) =>
+								(!Array.isArray(p.supported_slot_types) ||
+									p.supported_slot_types.includes(slot.type)) &&
+								(!p.device_class || p.device_class === deviceClass) &&
+								(!p.backend || !devBackend || p.backend === devBackend),
+						);
+						const fitNames = fit.map((p) => p.name);
+						const adoptedFromModel =
+							!!profileSel &&
+							profileSel === (curModelRow?.defaults?.profile || "");
+						// The options are filtered against the slot's device, which is no
+						// longer editable here — a profile persisted on disk can still be
+						// out-of-vocab for it. Saving a
+						// profile+device pair with conflicting backends is a hard
+						// SlotConfigError (_reconcile_device_profile), so warn instead of
+						// silently PUTting the conflict.
+						const profileFitWarn =
+							profileSel && all.length > 0 && !fitNames.includes(profileSel)
+								? `Profile "${profileSel}" does not fit device "${device}" — saving both together is rejected. Pick a listed profile or revert the device.`
+								: null;
+						return (
+							<div className="form-row">
+								<div className="form-lbl">
+									<span>Profile</span>
+									<FieldInfoIcon description="⟳ Runtime profile — picks the runtime family, device-class
+										gating and the MTP draft backend. Flags are NOT read from here
+										at launch; they are stamped into the model's launch flags on
+										the model drawer." />
+								</div>
+								<div className="form-ctl">
+									<select
+										className="input mono"
+										data-testid="slot-profile"
+										value={profileSel}
+										onChange={(e) => setProfileSel(e.target.value)}
+									>
+										{/* keep a none/out-of-vocab persisted profile selectable */}
+										{!slot.profile && <option value="">— none —</option>}
+										{profileSel && !fitNames.includes(profileSel) && (
+											<option value={profileSel}>{profileSel}</option>
+										)}
+										{fit.map((p) => (
+											<option key={p.name} value={p.name} title={p.intent}>
+												{p.name}
+												{p.intent ? ` · ${p.intent}` : ""}
+											</option>
+										))}
+									</select>
+									{adoptedFromModel && (
+										<div className="hint">
+											Adopted from the bound model's preference — swapping the
+											model may change it.
+										</div>
+									)}
+									{profileFitWarn && (
+										<div
+											className="hint"
+											data-testid="slot-profile-fit-warning"
+											style={{
+												marginTop: 6,
+												padding: "6px 10px",
+												borderRadius: "var(--rad-sm)",
+												color: "var(--warn)",
+												border: "1px solid var(--warn-line)",
+												background: "var(--warn-soft)",
+											}}
+										>
+											⚠ {profileFitWarn}
+										</div>
+									)}
+								</div>
+							</div>
 						);
 					})()}
 				</FieldGroup>

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -827,7 +827,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
               );
             })}
           </div>
-          <div className="dash-side">
+          <div className="dash-side dash-side-fill">
             <ActivityLog />
           </div>
         </div>
@@ -868,7 +868,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
               ))}
             </div>
           </div>
-          <div className="dash-side">
+          <div className="dash-side dash-side-fill">
             <ActivityLog />
           </div>
         </div>
@@ -897,7 +897,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
               </div>
             </div>
           </div>
-          <div className="dash-side">
+          <div className="dash-side dash-side-fill">
             <ActivityLog />
           </div>
         </div>
@@ -1063,7 +1063,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
             </>
           )}
         </div>
-        <div className="dash-side">
+        <div className="dash-side dash-side-fill">
           <ActivityLog />
         </div>
       </div>

--- a/ui/src/dash/slots/CreateSlotModal.jsx
+++ b/ui/src/dash/slots/CreateSlotModal.jsx
@@ -26,7 +26,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
 
   const [name, setName] = useStateC("");
   const [modelId, setModelId] = useStateC("");
-  const [makeDefault, setMakeDefault] = useStateC(false);
   const [submitErr, setSubmitErr] = useStateC(null);
 
   const models = useMemoC(() => localModels(modelsQuery.data), [modelsQuery.data]);
@@ -35,7 +34,6 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
     if (open) {
       setName(defaults.name || "");
       setModelId(defaults.model || "");
-      setMakeDefault(false);
       setSubmitErr(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -69,7 +67,7 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
   const nameInvalid = name && !NAME_RE.test(name);
   const nameError = nameCollision ? "name already in use" : nameInvalid ? "lowercase + dashes only" : null;
 
-  const dirty = !!name || !!modelId || makeDefault;
+  const dirty = !!name || !!modelId;
   const canSave = !!name && !nameError && !!modelId && !createMut.isPending;
 
   async function onCreate() {
@@ -80,8 +78,10 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
       runtime: "container",
       model: modelId,
       // Device rides the model — derived, not a slot choice.
+      // `default` is deliberately NOT sent: the backend silently defaults the
+      // FIRST slot of a type, and re-pointing the default afterwards is the
+      // explicit "Set as default" row action on the slot list.
       device: device || "gpu-rocm",
-      ...(makeDefault ? { default: true } : {}),
     };
     try {
       await createMut.mutateAsync(body);
@@ -173,19 +173,9 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
         </div>
       </div>
 
-      {/* Default for type — promotes the picked MODEL as its type's default */}
-      <div className="form-row" style={{ marginTop: 8 }}>
-        <div className="form-lbl">
-          <span>default for {selModel?.type || "type"}?</span>
-          <FieldInfoIcon description="makes this model the {selModel?.type || &quot;type&quot;} default; demotes the current one" />
-        </div>
-        <div className="form-ctl">
-          <label className="checkbox-row">
-            <input type="checkbox" data-testid="create-slot-default" checked={makeDefault} onChange={(e) => setMakeDefault(e.target.checked)} />
-            <span>Set as default</span>
-          </label>
-        </div>
-      </div>
+      {/* (The "default for <type>?" checkbox is gone. The first slot of a type
+          becomes that type's default on the backend; changing it afterwards is
+          the explicit "Set as default" action on the slot's row.) */}
     </Modal>
   );
 }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -1203,6 +1203,16 @@ a { color: inherit; text-decoration: none; }
 }
 .dash-main { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
 .dash-side { display: flex; flex-direction: column; gap: 16px; position: sticky; top: 12px; }
+/* Full-bleed side column (slots page): the ActivityLog spans the same
+   vertical extent as the stacked main-column panes (InferencePane +
+   NpuOccupancyCard) instead of capping itself short. `align-self: stretch`
+   fills the grid track; `position: static` because a stretched, track-height
+   box has nothing left to stick against — sticky and stretch fight. */
+.dash-side.dash-side-fill {
+  align-self: stretch;
+  position: static;
+  min-height: 0;
+}
 
 /* Slots-page tabs — underline style, matching the Agent page's tab bar
    (Inference · Image Gen · Endpoints · Profiles). Borderless buttons with an
@@ -3031,15 +3041,26 @@ select.npu-sel {
   border-bottom: 1px solid var(--line-soft);
 }
 .form-row:last-child { border-bottom: none; }
+/* Row-flow so the (i) info affordance sits INLINE with the field title
+   instead of stacking beneath it. `.sub` keeps its own line via a
+   full-width flex-basis, so the multi-line label fields (model drawer,
+   create-model modal) look exactly as they did before. */
 .form-row .form-lbl {
   font-size: 12.5px;
   color: var(--fg);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 3px;
 }
 .form-row .form-lbl .req { color: var(--accent); font-family: var(--jbm); font-size: 10px; }
-.form-row .form-lbl .sub { font-size: 11px; color: var(--fg-4); font-weight: 400; }
+.form-row .form-lbl .sub {
+  font-size: 11px;
+  color: var(--fg-4);
+  font-weight: 400;
+  flex: 0 0 100%;
+}
 
 /* Field descriptions are available only through the adjacent info affordance. */
 .field-info-wrap {

--- a/ui/tests/e2e/specs/activity-log.spec.ts
+++ b/ui/tests/e2e/specs/activity-log.spec.ts
@@ -181,9 +181,16 @@ test.describe('ActivityLog sidebar pane (#slots)', () => {
     // `''`). `toHaveCSS` re-resolves the locator on every retry, so it
     // settles once the pane stops remounting instead of racing it.
     await expect(body).toHaveCSS('overflow-y', /^(auto|scroll)$/)
-    // A real px cap (not "none") proves the pane is bounded.
-    await expect(body).not.toHaveCSS('max-height', 'none')
-    const maxH = await body.evaluate((el) => getComputedStyle(el).maxHeight)
-    expect(parseFloat(maxH)).toBeGreaterThan(0)
+    // Boundedness is now structural, not a `max-height` px cap: the card is
+    // `height: 100%` of the stretched `.dash-side` grid track and the body is
+    // the `flex: 1 1 auto` child, so the body can never be taller than the
+    // card it lives in — the content scrolls inside instead of growing the
+    // page. (The old 620px cap made the pane stop short of the main column.)
+    const box = await body.evaluate((el) => {
+      const card = el.closest('.act-card') as HTMLElement
+      return { body: el.clientHeight, card: card.clientHeight }
+    })
+    expect(box.body).toBeGreaterThan(0)
+    expect(box.body).toBeLessThanOrEqual(box.card)
   })
 })

--- a/ui/tests/e2e/specs/slot-create-default-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-create-default-v3.spec.ts
@@ -1,10 +1,11 @@
 /**
- * slot-create-default-v3 — the create-slot "Set as default" checkbox now works.
+ * slot-create-default-v3 — the create-slot flow no longer picks a default.
  *
- * Checking "Set as default" sends `default: true` in the POST /api/slots body;
- * the backend promotes the slot's MODEL as its type's default (verified in
- * tests/api/test_models_default.py). Here we assert the wire contract: the
- * checkbox drives the payload flag, and leaving it unchecked omits it.
+ * The "Set as default" checkbox was removed: the backend silently defaults the
+ * FIRST slot of a given type (SlotManager.create), and re-pointing it later is
+ * the explicit "Set as default" action on the slot's row in the slot list.
+ * Here we assert the wire contract: the modal has no picker and the POST
+ * /api/slots body never carries `default`.
  */
 import { test, expect, type Page } from '../fixtures/apiMock'
 
@@ -53,32 +54,8 @@ async function openCreateModalWithDefaults(page: import('@playwright/test').Page
   await expect(page.getByTestId('create-slot-model')).toBeVisible()
 }
 
-test.describe('Create slot — set-as-default checkbox', () => {
-  test('checking the box sends default:true in the create payload', async ({ page }) => {
-    let posted: any = null
-    await page.route('**/api/slots', (route) => {
-      if (route.request().method() === 'POST') {
-        posted = route.request().postDataJSON?.() ?? {}
-        return route.fulfill({
-          status: 201,
-          contentType: 'application/json',
-          body: JSON.stringify({ name: posted.name, state: 'offline', default_promotion: { promoted: true } }),
-        })
-      }
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ slots: [] }) })
-    })
-
-    await openCreateModal(page)
-    await page.getByTestId('create-slot-model').selectOption({ index: 1 })
-    await page.getByTestId('create-slot-name').fill('coder')
-    await page.getByTestId('create-slot-default').check()
-    await page.getByTestId('create-slot-submit').click()
-
-    await expect.poll(() => posted?.default).toBe(true)
-    expect(posted.name).toBe('coder')
-  })
-
-  test('leaving the box unchecked omits default from the payload', async ({ page }) => {
+test.describe('Create slot — no set-as-default picker', () => {
+  test('the modal offers no default checkbox and never sends `default` in the payload', async ({ page }) => {
     let posted: any = null
     await page.route('**/api/slots', (route) => {
       if (route.request().method() === 'POST') {
@@ -93,6 +70,10 @@ test.describe('Create slot — set-as-default checkbox', () => {
     })
 
     await openCreateModal(page)
+    // The picker is gone: the FIRST slot of a type is defaulted server-side,
+    // and re-pointing it afterwards is the slot list's "Set as default" action.
+    await expect(page.getByTestId('create-slot-default')).toHaveCount(0)
+
     await page.getByTestId('create-slot-model').selectOption({ index: 1 })
     await page.getByTestId('create-slot-name').fill('coder')
     await page.getByTestId('create-slot-submit').click()

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -41,7 +41,9 @@ test.describe('C7 — slot-owned hardware grid; no drawer profile selector', () 
     await page.goto('/#slots/chat')
     await expect(page.locator('.drawer')).toBeVisible()
 
-    await expect(page.getByTestId('slot-hw-device')).toBeVisible()
+    // Device has no control in the drawer any more — it rides the model at
+    // creation and is fixed for the slot's lifetime.
+    await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
     await expect(page.getByTestId('slot-hw-ngl')).toBeVisible()
     await expect(page.getByTestId('slot-hw-threads')).toBeVisible()
     await expect(page.getByTestId('slot-hw-binary')).toBeVisible()
@@ -166,7 +168,7 @@ test.describe('C7 — slot-owned hardware grid; no drawer profile selector', () 
     await page.goto('/#slots/npu')
     await expect(page.locator('.drawer')).toBeVisible()
 
-    await expect(page.getByTestId('slot-hw-device')).toBeVisible()
+    await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
     await expect(page.locator('.drawer .form-row', { hasText: 'Profile' }).locator('select')).toHaveCount(0)
   })
 

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -180,10 +180,12 @@ test.describe('Slot edit controls (/slots)', () => {
     expect(puts[0]).toHaveProperty('n_gpu_layers', -1)
   })
 
-  test('HW grid — the 4 typed fields + image_pin render (§2)', async ({ page }) => {
+  test('HW grid — the typed fields + Runner Image render; Device does not (§2)', async ({ page }) => {
     await seedSlots(page, [PRIMARY, EMBED])
     await page.goto('/#slots/primary')
-    await expect(page.getByTestId('slot-hw-device')).toBeVisible()
+    // Device is create-time only now: it rides the model and is fixed for the
+    // slot's lifetime, so the drawer displays it but offers no control.
+    await expect(page.getByTestId('slot-hw-device')).toHaveCount(0)
     await expect(page.getByTestId('slot-hw-ngl')).toBeVisible()
     await expect(page.getByTestId('slot-hw-threads')).toBeVisible()
     await expect(page.getByTestId('slot-hw-binary')).toBeVisible()
@@ -217,19 +219,16 @@ test.describe('Slot edit controls (/slots)', () => {
     await seedSlots(page, [{ ...PRIMARY, device: 'gpu-rocm', threads: 0, binary: '', image_pin: null }, EMBED])
 
     await page.goto('/#slots/primary')
-    // Pick the runner while the gpu-rocm device still fits it — the Runner
-    // options are filtered by the device lane (runner_matches predicate);
-    // after the device flips to cpu the pick survives as an out-of-vocab
-    // persisted option.
-    await page.getByTestId('slot-hw-binary').selectOption({ index: 1 })
-    await page.getByTestId('slot-hw-device').selectOption('cpu')
+    // Pick the runner binary — the options are the ones that fit this slot's
+    // (fixed) device lane. There is no "— default (from device) —" entry any
+    // more, so the first real option is index 0.
+    await page.getByTestId('slot-hw-binary').selectOption('rocmfpx')
     await page.getByTestId('slot-hw-ngl').fill('0')
     await page.getByTestId('slot-hw-threads').fill('8')
     await page.getByTestId('slot-hw-image-pin').fill('ghcr.io/example/runner:test')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
     expect(puts[0]).toMatchObject({
-      device: 'cpu',
       n_gpu_layers: 0,
       threads: 8,
       image_pin: 'ghcr.io/example/runner:test',


### PR DESCRIPTION
## Summary
- Type field moves into the top read-only strip (between Runner Binary and Image Status) — it's fixed at creation, so the old disabled `<select>` in the Slot group could never do anything.
- Device dropdown removed from the edit drawer entirely — device rides the model at creation (already the case for create-time), so a manual post-creation change was redundant and inconsistent with that flow. The drawer still reads/displays the slot's device, it just no longer offers a control.
- Profile section moved below Hardware/Model, per the target drawer shape.
- "Image pin" → "Runner Image" (stays a text field), "Runner" → "Runner Binary" (now a dropdown filtered to the binaries the named Runner Image actually ships, no more "— default (from device) —" entry). No new backend endpoint — `useSystemInfo()`'s existing `backends` payload already carries the image association.
- Fixed the info-icon (i) rendering below the field label instead of inline: `.form-lbl` was `flex-direction: column`, switched to row-flow (`.sub` keeps its own line via a flex-basis override).
- Fixed the activity-log flood on load: `useActivityStream` never sent `since`, so every SSE connect requested a full durable backfill from 0 — and `ActivityLog` remounts across SlotsView's loading/empty/populated branches, so a normal page load did two full backfills back-to-back. Added a resume cursor.
- Activity-log pane now spans the full height of the stacked Inference/NPU panes instead of self-capping at a fixed 760px/620px.
- Removed the create-slot "default for type?" checkbox (its tooltip text was also broken — a raw JSX expression leaking into the label). Replacement: the first slot created of a type silently becomes that type's default; re-pointing it later is an explicit "Set as default" (★) row action on each slot card.
- Fixed a latent SC-4 gap: `update_config` re-validated default-uniqueness against the full merged config on every write, even when the write didn't touch `default` — an unrelated PATCH to a slot carrying a stale duplicate default (an invariant violation predating this guard) was wrongly rejected. Added a `changed_keys` param so the check is skipped when the write doesn't touch `default`.

Branch 1 of 2 — see the sibling `feat/runner-image-catalogue` work (not part of this PR) for turning Runner Image into a dropdown sourced from a live catalogue; this PR ships it as a filtered-but-still-typed text field per the agreed split.

## Test plan
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slots/ tests/api -q` — 2248 passed, 1 skipped (post-rebase)
- [x] `npx tsc --noEmit` clean
- [x] Playwright specs touching this work (slot-create-default-v3, slot-edit-controls-v3, slot-drawer-profile-v3, activity-log) pass
- [x] Manual check via mock dev server: drawer field order, info-icon alignment, activity-log bottom-edge alignment with the main column, "Set as default" star on slot cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)