### PR TITLE
fix(metrics): gate hal0-internal metrics/hardware fan-out to real hal0 peers

### DIFF
--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -288,9 +288,7 @@ async def _proxy_upstream_endpoint(
             except Exception:
                 return u.name, None
 
-        for item in await asyncio.gather(
-            *(_one(u) for u in peers), return_exceptions=True
-        ):
+        for item in await asyncio.gather(*(_one(u) for u in peers), return_exceptions=True):
             if isinstance(item, BaseException):
                 continue
             name, payload = item

--- a/src/hal0/api/routes/hardware.py
+++ b/src/hal0/api/routes/hardware.py
@@ -242,47 +242,59 @@ async def reprobe_hardware(request: Request) -> dict[str, Any]:
 async def _proxy_upstream_endpoint(
     request: Request, suffix: str, timeout_s: float = 3.0
 ) -> dict[str, dict[str, Any]]:
-    """Fan out ``suffix`` (e.g. ``/api/stats/hardware``) to every *remote*
+    """Fan out ``suffix`` (e.g. ``/api/stats/hardware``) to every hal0 **peer**
     upstream's base host and return ``{upstream_name: payload}``.
 
-    Upstream base URLs end in ``/v1`` by convention; we strip that to hit
-    the upstream's internal API surface (haloai exposes its dashboard
-    endpoints at the bare ``/api/...`` path on the same host:port).
-    Failures are recorded as ``None`` so callers can render "offline" tiles.
+    ``suffix`` is a hal0-internal API path, so the only upstream that can
+    answer it is another hal0 (the haloai-style fanout this feature exists
+    for). Eligibility is decided by :func:`hal0.upstreams.peers.is_hal0_peer`
+    and the URL by :func:`hal0.upstreams.peers.peer_api_url` — see that
+    module for the full rationale. Two classes of upstream are excluded:
 
-    Only ``kind == "remote"`` upstreams are proxied. ``kind == "slot"``
-    upstreams are local slots whose base URL points back at *this*
-    hal0-api host:port. Stripping ``/v1`` and appending ``suffix`` would
-    make the endpoint call itself — under the single-worker async server
-    this recurses until every request in the chain hits its timeout,
-    hanging ``/api/stats/hardware`` and ``/api/slots/metrics`` for tens of
-    seconds and returning an empty body. Slot upstreams have no separate
-    dashboard API anyway — the local probe + ``_local_slot_metrics``
-    already cover them — so we
-    skip them outright.
+      * **Third-party OpenAI-compatible providers** (openrouter.ai,
+        api.minimax.io, api.openai.com, …). They have no ``/api/...``
+        surface; asking them is guaranteed-404 traffic that leaks hal0's
+        internal path structure to a third party and burns provider rate
+        limit (issue #1425 measured ~20 such requests/minute).
+      * **``kind == "slot"`` upstreams**, whose base URL points back at
+        *this* hal0-api host:port. Proxying ``suffix`` to them is a
+        self-call that, under the single-worker async server, recurses
+        until every request in the chain hits its timeout — hanging
+        ``/api/stats/hardware`` and ``/api/slots/metrics`` for tens of
+        seconds and returning an empty body. Slot upstreams have no
+        separate dashboard API anyway; the local probe +
+        ``_local_slot_metrics`` already cover them.
+
+    Peers are probed **concurrently**: this runs inside the ``GET
+    /api/slots`` aggregation, where a serial walk made every unreachable
+    peer add a full ``timeout_s`` to the page (issue #1427). Failures are
+    recorded as ``None`` so callers can render "offline" tiles.
     """
     import httpx
 
-    upstreams = request.app.state.upstreams
+    from hal0.upstreams.peers import hal0_peer_upstreams, peer_api_url
+
+    peers = hal0_peer_upstreams(request.app.state.upstreams)
+    if not peers:
+        return {}
+
     out: dict[str, dict[str, Any]] = {}
     async with httpx.AsyncClient(timeout=timeout_s) as client:
-        for u in upstreams.list():
-            # Skip slot-kind upstreams — they resolve to this same
-            # hal0-api host:port; proxying ``suffix`` to them is a
-            # self-call that deadlocks the worker (see docstring).
-            if getattr(u, "kind", "remote") == "slot":
-                continue
-            base = u.url.rstrip("/")
-            if base.endswith("/v1"):
-                base = base[: -len("/v1")]
+
+        async def _one(u: Any) -> tuple[str, Any]:
             try:
-                resp = await client.get(base + suffix)
-                if resp.status_code == 200:
-                    out[u.name] = resp.json()
-                else:
-                    out[u.name] = None  # type: ignore[assignment]
+                resp = await client.get(peer_api_url(u.url, suffix))
+                return u.name, resp.json() if resp.status_code == 200 else None
             except Exception:
-                out[u.name] = None  # type: ignore[assignment]
+                return u.name, None
+
+        for item in await asyncio.gather(
+            *(_one(u) for u in peers), return_exceptions=True
+        ):
+            if isinstance(item, BaseException):
+                continue
+            name, payload = item
+            out[name] = payload
     return out
 
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -799,7 +799,9 @@ async def slot_metrics(request: Request) -> dict[str, Any]:
 
     Drives the dashboard's per-slot tok/s row + sparkline. Three layers:
 
-    1. Remote upstreams' /api/slots/metrics (for haloai-style fanouts).
+    1. hal0 *peer* upstreams' /api/slots/metrics (haloai-style fanouts).
+       Third-party OpenAI-compatible providers are NOT asked — see
+       ``hal0.upstreams.peers`` / issue #1425.
     2. Local per-slot tok/s measured on the dispatcher's streaming path.
     3. Local per-slot MEM/UP scraped from systemd + /proc for the
        hal0-slot@<name>.service template instance.

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1523,6 +1523,17 @@ class UpstreamEntry(BaseModel):
         description="When false the upstream is skipped by routing and /v1/models.",
     )
     model_filters: UpstreamModelFilters | None = Field(default=None)
+    hal0_peer: bool | None = Field(
+        default=None,
+        description=(
+            "Is this upstream another hal0 whose internal dashboard API "
+            "(/api/stats/hardware, /api/slots/metrics) may be polled? "
+            "Unset (null) auto-derives from the URL host: private/loopback "
+            "hosts are treated as peers, public hosts never are, so "
+            "hal0-internal paths are never sent to a third-party provider "
+            "(issue #1425). Set true to opt a public-hostname hal0 peer in."
+        ),
+    )
 
     @field_validator("name")
     @classmethod

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -418,6 +418,26 @@ def _resolve_container_provider(provider: Any) -> Any:
     return container_provider()
 
 
+#: Wall-clock bound on ONE slot's container probe (issue #1427).
+#:
+#: The probe is four independent IO waits (``systemctl is-active``, GET
+#: /health on the slot port, ``podman inspect`` on the container, ``podman
+#: image inspect`` on the declared image). Each has its own inner timeout,
+#: but nothing bounded their SUM, and the whole thing ran serially across
+#: every slot — which is where ``GET /api/slots`` got its measured 17–41 s.
+#: A slot that blows this budget degrades to ``stopped`` / unhealthy for
+#: that poll, exactly as a probe exception already did; the next poll
+#: (2.5 s later) re-probes it.
+_PROBE_TIMEOUT_S = 8.0
+
+#: How many slot probes may be in flight at once. The probes are dominated
+#: by subprocess waits that land in the default thread-pool executor, so an
+#: unbounded fan-out over ~30 slots would just queue there while spawning
+#: ~90 podman/systemctl children at once. Wide enough that a typical
+#: deployment finishes in one wave.
+_PROBE_CONCURRENCY = 8
+
+
 async def container_enrichment(
     configs: list[dict[str, Any]],
     *,
@@ -441,60 +461,87 @@ async def container_enrichment(
     ContainerProvider lazily so route-level patches on the class keep
     working. Never raises — probe failures degrade to ``stopped`` /
     ``False`` rather than surfacing as a 500.
+
+    Slots are probed **concurrently** (bounded by
+    :data:`_PROBE_CONCURRENCY`) and each slot's probe is bounded by
+    :data:`_PROBE_TIMEOUT_S`. Issue #1427: this loop used to run serially,
+    so ``GET /api/slots`` paid the sum of every slot's connect timeouts —
+    17–41 s measured on a 19–29 slot box. Concurrency turns that sum into a
+    max, and the per-slot deadline bounds the max.
     """
     from hal0.slots.manager import _cfg_port  # type: ignore[attr-defined]
 
     jobs = pull_jobs or {}
-    out: dict[str, dict[str, Any]] = {}
-    for cfg in configs:
-        name = str(cfg.get("name", ""))
-        if not name:
-            continue
+    named = [(str(cfg.get("name", "")), cfg) for cfg in configs]
+    named = [(name, cfg) for name, cfg in named if name]
+    if not named:
+        return {}
 
-        entry: dict[str, Any] = {}
+    # The profile catalogue is process-global config, not per-slot state —
+    # load it ONCE instead of re-reading and re-parsing profiles.toml inside
+    # every slot's probe.
+    try:
+        from hal0.config.loader import load_profiles_config
 
+        profiles: dict[str, Any] | None = load_profiles_config().profile
+    except Exception:
+        # ``None`` (not ``{}``) so an unreadable catalogue degrades exactly as
+        # the old per-slot ``except`` did: image + resolved_command are nulled
+        # rather than half-resolved.
+        profiles = None
+
+    loop = asyncio.get_event_loop()
+    sem = asyncio.Semaphore(_PROBE_CONCURRENCY)
+
+    async def _probe_status(name: str, cfg: dict[str, Any]) -> tuple[str, bool]:
+        """(container_status, container_health) for one slot."""
         try:
             cp = _resolve_container_provider(provider)
-            # 1) systemctl is-active (synchronous — run in executor). The CONFIG
+            # 1) systemctl is-active (synchronous — run in executor, #1427: on
+            # the event loop it would serialise every slot's check). The CONFIG
             # goes down, not the name: the unit is keyed by the slot's instance
             # token, which is the durable id on a post-migration box (#1417).
-            active = await asyncio.get_event_loop().run_in_executor(None, cp.is_active, cfg)
+            active = await loop.run_in_executor(None, cp.is_active, cfg)
             if active:
                 # 2) /health probe on the slot port to distinguish running vs starting
                 port = _cfg_port(cfg)
                 if port:
                     health = await cp.health(port)
                     container_health = bool(health.get("ok"))
-                    container_status = "running" if container_health else "starting"
-                else:
-                    container_health = False
-                    container_status = "running"
-            else:
-                container_health = False
-                # Distinguish crashed (failed) from clean stop by checking unit state
-                # via is-active exit codes: 0=active, 3=inactive, other=failed
-                container_status = "stopped"
-                try:
-                    import subprocess
+                    return ("running" if container_health else "starting", container_health)
+                return "running", False
+            # Distinguish crashed (failed) from clean stop by checking unit state
+            # via is-active exit codes: 0=active, 3=inactive, other=failed
+            try:
+                import subprocess
 
-                    result = subprocess.run(
-                        # Through the naming seam, not an f-string on the name:
-                        # this discriminator was the last place that hardcoded
-                        # a name-keyed unit (#1417), so on an id-keyed box it
-                        # reported every slot "stopped" and never "crashed".
+                # In an executor: subprocess.run blocks, and on the event loop
+                # it would serialise every stopped slot's 5 s worst case into
+                # the request (#1427). Through the naming seam, not an
+                # f-string on the name: this discriminator was the last place
+                # that hardcoded a name-keyed unit (#1417), so on an
+                # id-keyed box it reported every slot "stopped" and never
+                # "crashed".
+                result = await loop.run_in_executor(
+                    None,
+                    lambda: subprocess.run(
                         ["systemctl", "is-active", slot_unit_name(slot_instance_token(cfg))],
                         capture_output=True,
                         timeout=5,
-                    )
-                    stdout = result.stdout.decode().strip()
-                    if stdout == "failed":
-                        container_status = "crashed"
-                except Exception:
-                    pass
+                    ),
+                )
+                if result.stdout.decode().strip() == "failed":
+                    return "crashed", False
+            except Exception:
+                pass
+            return "stopped", False
         except Exception:
-            container_health = False
-            container_status = "stopped"
+            return "stopped", False
 
+    async def _one(name: str, cfg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        entry: dict[str, Any] = {}
+
+        container_status, container_health = await _probe_status(name, cfg)
         entry["container_status"] = container_status
         entry["container_health"] = container_health
 
@@ -521,10 +568,9 @@ async def container_enrichment(
         image: str | None = None
         if profile_name:
             try:
-                from hal0.config.loader import load_profiles_config
-
-                catalog = load_profiles_config()
-                prof = catalog.profile.get(profile_name)
+                if profiles is None:
+                    raise RuntimeError("profiles catalogue unreadable")
+                prof = profiles.get(profile_name)
                 if prof is not None:
                     from hal0.providers.container import _resolve_image_ref
 
@@ -538,10 +584,14 @@ async def container_enrichment(
                 if prof is not None:
                     entry["device_class"] = prof.device_class
                     entry["backend"] = prof.backend
-                # resolved_command = llama-server argv starting from the image
+                # resolved_command = llama-server argv starting from the image.
+                # Off the event loop: it re-reads config + resolves the runner
+                # image, which is filesystem work, not a pure function.
                 from hal0.providers.container import resolved_command_for_slot
 
-                entry["resolved_command"] = resolved_command_for_slot(cfg)
+                entry["resolved_command"] = await loop.run_in_executor(
+                    None, resolved_command_for_slot, cfg
+                )
             except Exception:
                 entry["image"] = None
                 entry["resolved_command"] = None
@@ -561,9 +611,7 @@ async def container_enrichment(
             # By CONFIG: the container is named after the instance token
             # (#1417) — a bare name inspected a container that never exists on
             # an id-keyed box, leaving the image backend-of-record inert.
-            running_image = await asyncio.get_event_loop().run_in_executor(
-                None, cp.running_image, cfg
-            )
+            running_image = await loop.run_in_executor(None, cp.running_image, cfg)
         except Exception:
             running_image = None
         if running_image:
@@ -580,9 +628,7 @@ async def container_enrichment(
         elif image:
             try:
                 cp = _resolve_container_provider(provider)
-                present = await asyncio.get_event_loop().run_in_executor(
-                    None, cp.image_present, image
-                )
+                present = await loop.run_in_executor(None, cp.image_present, image)
                 entry["image_status"] = "present" if present else "missing"
             except Exception:
                 entry["image_status"] = "missing"
@@ -593,6 +639,33 @@ async def container_enrichment(
             # learn to ignore a real "missing" every 30s.
             entry["image_status"] = "not-configured"
 
+        return name, entry
+
+    async def _bounded(name: str, cfg: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        # Acquire FIRST, then start the clock — a slot queued behind the
+        # semaphore must not spend its deadline waiting for a turn.
+        async with sem:
+            try:
+                return await asyncio.wait_for(_one(name, cfg), timeout=_PROBE_TIMEOUT_S)
+            except (TimeoutError, asyncio.TimeoutError):
+                log.warning("slot_view.container_probe_timeout slot=%s", name)
+                return name, {
+                    "container_status": "stopped",
+                    "container_health": False,
+                    "runtime": "container",
+                    "profile": str(cfg.get("profile") or ""),
+                    "image": None,
+                    "resolved_command": None,
+                    "image_status": "not-configured",
+                }
+
+    out: dict[str, dict[str, Any]] = {}
+    for item in await asyncio.gather(
+        *(_bounded(name, cfg) for name, cfg in named), return_exceptions=True
+    ):
+        if isinstance(item, BaseException):
+            continue
+        name, entry = item
         out[name] = entry
 
     # #733: trio shadow slots (embed/stt — device=npu, non-llm) never run a
@@ -764,10 +837,19 @@ class SlotViewAggregator:
         configs = await self._safe_configs()
 
         enrichment = config_enrichment(configs)
-        c_enrichment = await container_enrichment(
-            configs,
-            pull_jobs=self._slot_pull_jobs,
-            provider=self._container_provider,
+        # #1427: the container probe, the capacity probe and the metrics
+        # fan-out are three independent IO waits over the same slot set —
+        # there is no data dependency between them, so awaiting them one
+        # after another just added their latencies together on every
+        # dashboard poll. Run them concurrently.
+        c_enrichment, per_slot_mem, raw_metrics = await asyncio.gather(
+            container_enrichment(
+                configs,
+                pull_jobs=self._slot_pull_jobs,
+                provider=self._container_provider,
+            ),
+            self._safe_per_slot_mem(real_slots),
+            self._safe_metrics(),
         )
         for payload in payloads:
             slot_name = str(payload["name"])
@@ -783,8 +865,8 @@ class SlotViewAggregator:
         # Per-slot resident memory (model weights + KV-cache estimate) so the
         # dashboard memory map (W4) attributes a real footprint per slot. Only
         # resident slots get a non-zero row; everything else reads 0. Never let
-        # a memory-probe failure break the slots list.
-        per_slot_mem = await self._safe_per_slot_mem(real_slots)
+        # a memory-probe failure break the slots list. (Probed above, in the
+        # concurrent gather.)
         mem_by_name: dict[str, float | int] = {}
         for payload in payloads:
             slot_name = str(payload["name"])
@@ -799,8 +881,6 @@ class SlotViewAggregator:
                 self._last_used_model,
                 loaded_models=loaded_model_names_from_slots(real_slots),
             )
-
-        raw_metrics = await self._safe_metrics()
 
         views: list[SlotView] = []
         for payload in payloads:

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -424,7 +424,7 @@ def _resolve_container_provider(provider: Any) -> Any:
 #: /health on the slot port, ``podman inspect`` on the container, ``podman
 #: image inspect`` on the declared image). Each has its own inner timeout,
 #: but nothing bounded their SUM, and the whole thing ran serially across
-#: every slot — which is where ``GET /api/slots`` got its measured 17–41 s.
+#: every slot — which is where ``GET /api/slots`` got its measured 17-41 s.
 #: A slot that blows this budget degrades to ``stopped`` / unhealthy for
 #: that poll, exactly as a probe exception already did; the next poll
 #: (2.5 s later) re-probes it.
@@ -466,7 +466,7 @@ async def container_enrichment(
     :data:`_PROBE_CONCURRENCY`) and each slot's probe is bounded by
     :data:`_PROBE_TIMEOUT_S`. Issue #1427: this loop used to run serially,
     so ``GET /api/slots`` paid the sum of every slot's connect timeouts —
-    17–41 s measured on a 19–29 slot box. Concurrency turns that sum into a
+    17-41 s measured on a 19-29 slot box. Concurrency turns that sum into a
     max, and the per-slot deadline bounds the max.
     """
     from hal0.slots.manager import _cfg_port  # type: ignore[attr-defined]
@@ -647,7 +647,7 @@ async def container_enrichment(
         async with sem:
             try:
                 return await asyncio.wait_for(_one(name, cfg), timeout=_PROBE_TIMEOUT_S)
-            except (TimeoutError, asyncio.TimeoutError):
+            except TimeoutError:
                 log.warning("slot_view.container_probe_timeout slot=%s", name)
                 return name, {
                     "container_status": "stopped",

--- a/src/hal0/upstreams/peers.py
+++ b/src/hal0/upstreams/peers.py
@@ -1,0 +1,155 @@
+"""hal0-peer classification + hal0-internal URL joining (issue #1425).
+
+``/api/stats/hardware`` and ``/api/slots/metrics`` are **hal0's own** API
+paths. The stats/metrics aggregators fan them out across upstreams so a
+remote hal0 box ("haloai-style fanout") can contribute its slot metrics to
+this dashboard. That fan-out was gated on ``kind != "slot"``, which is not
+the same question: every third-party OpenAI-compatible provider is also
+``kind == "remote"``, so openrouter.ai and api.minimax.io were being asked
+for hal0-internal paths ~20 times a minute — guaranteed 404s that leak
+hal0's internal path structure to third parties and burn provider rate
+limit.
+
+This module owns the two things that fix were missing:
+
+  * :func:`is_hal0_peer` — is this upstream *another hal0*, as opposed to a
+    third-party provider that merely speaks the same chat protocol?
+  * :func:`peer_api_url` — join a peer's base URL with a hal0-internal path
+    **without** producing the doubled ``/api/api/...`` seen in the issue.
+
+Both are pure functions so the outbound-URL contract can be asserted
+directly in tests rather than inferred from a log line.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+__all__ = [
+    "hal0_peer_upstreams",
+    "is_hal0_peer",
+    "is_private_host",
+    "peer_api_url",
+]
+
+
+# Single-label hostnames and these suffixes never resolve on the public
+# internet — they are LAN / split-horizon names, i.e. a plausible home for a
+# peer hal0. Matching is lexical on purpose: no DNS lookup happens on the
+# dashboard's hot path, and a resolver answer is not a security boundary.
+_PRIVATE_HOST_SUFFIXES = (
+    ".localhost",
+    ".local",
+    ".lan",
+    ".internal",
+    ".intranet",
+    ".home.arpa",
+)
+
+
+def is_private_host(host: str) -> bool:
+    """True when ``host`` cannot address the public internet.
+
+    Literal addresses are classified with :mod:`ipaddress` (loopback,
+    RFC1918, link-local, CGNAT-free unique-local v6, …). Names are matched
+    lexically against :data:`_PRIVATE_HOST_SUFFIXES` plus the bare
+    single-label case. Empty / unparseable input is treated as **public**
+    — the conservative answer, since the whole point is to not egress.
+    """
+    host = (host or "").strip().lower()
+    if not host:
+        return False
+    # Strip an IPv6 literal's brackets before parsing.
+    if host.startswith("[") and host.endswith("]"):
+        host = host[1:-1]
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        return bool(
+            addr.is_loopback or addr.is_private or addr.is_link_local or addr.is_unspecified
+        )
+    if host == "localhost":
+        return True
+    if host.endswith(_PRIVATE_HOST_SUFFIXES):
+        return True
+    # Bare single-label name ("hal0", "halo") — only resolvable through a
+    # local search domain.
+    return "." not in host
+
+
+def is_hal0_peer(upstream: Any) -> bool:
+    """True when ``upstream`` is another hal0 whose internal API we may poll.
+
+    Decision order:
+
+      1. ``kind == "slot"`` → **False**. Slot upstreams point back at *this*
+         hal0-api host:port; proxying a hal0-internal path to them is a
+         self-call that deadlocks the single-worker async server (this is
+         the pre-existing carve-out documented on
+         ``_proxy_upstream_endpoint``, kept intact).
+      2. ``enabled is False`` → **False**. A kill-switched upstream must not
+         be touched by any poller.
+      3. An explicit ``hal0_peer`` flag in ``upstreams.toml`` wins outright,
+         in both directions.
+      4. Otherwise auto-derive: a peer hal0 lives on the operator's own
+         network, so only a private/loopback host qualifies. Every
+         third-party provider (openrouter.ai, api.minimax.io, api.openai.com
+         …) is a public host and is therefore never probed.
+
+    Rule 4 is what makes the default *safe*: no configuration change can
+    accidentally re-enable egress of hal0-internal paths to a public API,
+    while the haloai-style LAN fanout the feature exists for keeps working
+    with no operator action.
+    """
+    if getattr(upstream, "kind", "remote") == "slot":
+        return False
+    if getattr(upstream, "enabled", True) is False:
+        return False
+    explicit = getattr(upstream, "hal0_peer", None)
+    if explicit is not None:
+        return bool(explicit)
+    host = urlsplit(str(getattr(upstream, "url", "") or "")).hostname or ""
+    return is_private_host(host)
+
+
+def hal0_peer_upstreams(upstreams: Any) -> list[Any]:
+    """Filter a registry's ``list()`` down to the hal0 peers."""
+    try:
+        entries = list(upstreams.list())
+    except Exception:
+        return []
+    return [u for u in entries if is_hal0_peer(u)]
+
+
+def peer_api_url(base_url: str, suffix: str) -> str:
+    """Join a peer's OpenAI-compat base URL with a hal0-internal API path.
+
+    Upstream base URLs end in ``/v1`` by convention; hal0's dashboard API is
+    a *sibling* of ``/v1`` on the same host:port, so the ``/v1`` segment is
+    dropped before ``suffix`` is appended.
+
+    The doubled-path bug in #1427 (``https://openrouter.ai/api/v1`` +
+    ``/api/slots/metrics`` → ``https://openrouter.ai/api/api/slots/metrics``)
+    came from doing that concatenation blind: stripping ``/v1`` off
+    ``/api/v1`` leaves ``/api``, and ``suffix`` starts with ``/api/`` too.
+    This helper collapses that overlap, so no caller can construct an
+    ``/api/api/`` path regardless of how the base URL was written.
+
+    Query strings and fragments on the base URL are dropped — they have no
+    meaning for a dashboard GET and would otherwise be silently smuggled
+    onto an unrelated path.
+    """
+    suffix = "/" + suffix.lstrip("/")
+    parts = urlsplit(base_url.strip())
+    path = parts.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[: -len("/v1")]
+    # Collapse a repeated leading segment: ".../api" + "/api/slots/metrics".
+    head = "/" + suffix.lstrip("/").split("/", 1)[0]
+    if head != "/" and path.endswith(head):
+        path = path[: -len(head)]
+    return urlunsplit((parts.scheme, parts.netloc, path + suffix, "", ""))

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -150,6 +150,16 @@ class Upstream:
     model_filters: ModelFilters | None = None
     """Optional /v1/models advertising filters.  Dispatch is unfiltered."""
 
+    hal0_peer: bool | None = None
+    """Is this upstream another hal0 (issue #1425)?
+
+    ``True``/``False`` are an explicit operator declaration; ``None`` (the
+    default) auto-derives from the URL host — see
+    :func:`hal0.upstreams.peers.is_hal0_peer`. Only peers are asked for
+    hal0-internal API paths; a third-party OpenAI-compatible provider never
+    is.
+    """
+
 
 # ── Config-layer ↔ runtime conversion ─────────────────────────────────────────
 
@@ -211,6 +221,7 @@ def upstream_from_entry(entry: UpstreamEntry) -> Upstream:
         advertise_models=entry.advertise_models,
         enabled=entry.enabled,
         model_filters=_filters_to_runtime(entry.model_filters),
+        hal0_peer=entry.hal0_peer,
     )
 
 

--- a/tests/api/test_metrics_egress.py
+++ b/tests/api/test_metrics_egress.py
@@ -42,7 +42,9 @@ class _RecordingClient:
 
 
 def _request_with(upstreams: UpstreamRegistry) -> object:
-    return types.SimpleNamespace(app=types.SimpleNamespace(state=types.SimpleNamespace(upstreams=upstreams)))
+    return types.SimpleNamespace(
+        app=types.SimpleNamespace(state=types.SimpleNamespace(upstreams=upstreams))
+    )
 
 
 def _registry(*upstreams: Upstream) -> UpstreamRegistry:
@@ -60,7 +62,9 @@ SLOT = Upstream(name="agent", kind="slot", url="http://127.0.0.1:8087/v1", slot_
 
 def _patch_client(monkeypatch: pytest.MonkeyPatch, calls: list[str], **kw: object) -> None:
     monkeypatch.setattr(
-        httpx, "AsyncClient", lambda *a, **k: _RecordingClient(calls, {"ok": {}}, **kw)  # type: ignore[arg-type]
+        httpx,
+        "AsyncClient",
+        lambda *a, **k: _RecordingClient(calls, {"ok": {}}, **kw),  # type: ignore[arg-type]
     )
 
 
@@ -119,9 +123,7 @@ async def test_no_outbound_url_contains_a_doubled_api_segment(
     _patch_client(monkeypatch, calls)
     weird = Upstream(name="weird", kind="remote", url="https://peer.example/api/v1", hal0_peer=True)
 
-    await hw_mod._proxy_upstream_endpoint(
-        _request_with(_registry(weird)), "/api/slots/metrics"
-    )
+    await hw_mod._proxy_upstream_endpoint(_request_with(_registry(weird)), "/api/slots/metrics")
 
     assert calls == ["https://peer.example/api/slots/metrics"]
     assert not any("/api/api/" in c for c in calls)
@@ -155,9 +157,7 @@ async def test_unreachable_peer_does_not_serialise_the_fanout(
         client = _Client(calls, {"ok": {}}, delay_hosts={"10.0.1.151", "10.0.1.152", "10.0.1.153"})
 
         async def _get(url: str, **kw: object) -> object:
-            return await asyncio.wait_for(
-                _RecordingClient.get(client, url, **kw), timeout=timeout
-            )
+            return await asyncio.wait_for(_RecordingClient.get(client, url, **kw), timeout=timeout)
 
         client.get = _get  # type: ignore[method-assign]
         return client

--- a/tests/api/test_metrics_egress.py
+++ b/tests/api/test_metrics_egress.py
@@ -1,0 +1,183 @@
+"""No hal0-internal API path ever leaves for a third-party upstream (#1425).
+
+Every assertion here is on the **actual outbound URL set** the aggregator
+produces, captured at the httpx seam — not on a log message. Issue #1425 was
+found by grepping the journal; a test that also greps a log would not catch a
+regression that egresses silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import httpx
+import pytest
+
+import hal0.api.routes.hardware as hw_mod
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+
+class _RecordingClient:
+    """httpx.AsyncClient stand-in that records every GET and answers 200."""
+
+    def __init__(self, calls: list[str], payload: object, delay_hosts: set[str] | None = None):
+        self._calls = calls
+        self._payload = payload
+        self._delay_hosts = delay_hosts or set()
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def get(self, url: str, **_kw: object) -> object:
+        self._calls.append(url)
+        if httpx.URL(url).host in self._delay_hosts:
+            # Simulate an unreachable peer: hang until the caller's own
+            # timeout budget gives up on us.
+            await asyncio.sleep(3600)
+        return types.SimpleNamespace(status_code=200, json=lambda: self._payload)
+
+
+def _request_with(upstreams: UpstreamRegistry) -> object:
+    return types.SimpleNamespace(app=types.SimpleNamespace(state=types.SimpleNamespace(upstreams=upstreams)))
+
+
+def _registry(*upstreams: Upstream) -> UpstreamRegistry:
+    reg = UpstreamRegistry()
+    for u in upstreams:
+        reg.add(u)
+    return reg
+
+
+OPENROUTER = Upstream(name="openrouter", kind="remote", url="https://openrouter.ai/api/v1")
+MINIMAX = Upstream(name="minimax", kind="remote", url="https://api.minimax.io/v1")
+PEER = Upstream(name="peer", kind="remote", url="http://10.0.1.150:8080/v1")
+SLOT = Upstream(name="agent", kind="slot", url="http://127.0.0.1:8087/v1", slot_name="agent")
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, calls: list[str], **kw: object) -> None:
+    monkeypatch.setattr(
+        httpx, "AsyncClient", lambda *a, **k: _RecordingClient(calls, {"ok": {}}, **kw)  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.parametrize("suffix", ["/api/slots/metrics", "/api/stats/hardware"])
+async def test_third_party_upstreams_get_zero_requests(
+    monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    calls: list[str] = []
+    _patch_client(monkeypatch, calls)
+
+    out = await hw_mod._proxy_upstream_endpoint(
+        _request_with(_registry(OPENROUTER, MINIMAX, SLOT)), suffix
+    )
+
+    assert calls == []
+    assert out == {}
+
+
+@pytest.mark.parametrize("suffix", ["/api/slots/metrics", "/api/stats/hardware"])
+async def test_a_genuine_hal0_peer_still_receives_the_fanout(
+    monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    """The feature is gated, not disabled."""
+    calls: list[str] = []
+    _patch_client(monkeypatch, calls)
+
+    out = await hw_mod._proxy_upstream_endpoint(
+        _request_with(_registry(OPENROUTER, MINIMAX, PEER, SLOT)), suffix
+    )
+
+    assert calls == [f"http://10.0.1.150:8080{suffix}"]
+    assert out == {"peer": {"ok": {}}}
+
+
+async def test_public_hostname_peer_opts_in_explicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _patch_client(monkeypatch, calls)
+    peer = Upstream(name="wan", kind="remote", url="https://hal0.example.com/v1", hal0_peer=True)
+
+    await hw_mod._proxy_upstream_endpoint(
+        _request_with(_registry(OPENROUTER, peer)), "/api/slots/metrics"
+    )
+
+    assert calls == ["https://hal0.example.com/api/slots/metrics"]
+
+
+async def test_no_outbound_url_contains_a_doubled_api_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even an operator who declares openrouter's URL shape as a peer.
+
+    ``hal0_peer = true`` on a ``/api/v1`` base is the exact input that
+    produced ``https://openrouter.ai/api/api/slots/metrics`` in the wild.
+    """
+    calls: list[str] = []
+    _patch_client(monkeypatch, calls)
+    weird = Upstream(name="weird", kind="remote", url="https://peer.example/api/v1", hal0_peer=True)
+
+    await hw_mod._proxy_upstream_endpoint(
+        _request_with(_registry(weird)), "/api/slots/metrics"
+    )
+
+    assert calls == ["https://peer.example/api/slots/metrics"]
+    assert not any("/api/api/" in c for c in calls)
+
+
+async def test_disabled_peer_is_not_probed(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    _patch_client(monkeypatch, calls)
+    off = Upstream(name="peer", kind="remote", url="http://10.0.1.150:8080/v1", enabled=False)
+
+    await hw_mod._proxy_upstream_endpoint(_request_with(_registry(off)), "/api/slots/metrics")
+
+    assert calls == []
+
+
+async def test_unreachable_peer_does_not_serialise_the_fanout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Peers are probed concurrently and bounded by the httpx timeout.
+
+    The fake client hangs forever on ``10.0.1.151``; the caller passes a
+    0.2 s timeout, so the whole fan-out must finish in roughly one timeout,
+    not N of them, and the reachable peer must still report.
+    """
+    calls: list[str] = []
+
+    class _Client(_RecordingClient):
+        pass
+
+    def _factory(*_a: object, timeout: float = 0.0, **_k: object) -> object:
+        client = _Client(calls, {"ok": {}}, delay_hosts={"10.0.1.151", "10.0.1.152", "10.0.1.153"})
+
+        async def _get(url: str, **kw: object) -> object:
+            return await asyncio.wait_for(
+                _RecordingClient.get(client, url, **kw), timeout=timeout
+            )
+
+        client.get = _get  # type: ignore[method-assign]
+        return client
+
+    monkeypatch.setattr(httpx, "AsyncClient", _factory)
+
+    dead = [
+        Upstream(name=f"dead{i}", kind="remote", url=f"http://10.0.1.15{i}:8080/v1")
+        for i in (1, 2, 3)
+    ]
+    reg = _registry(PEER, *dead)
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    out = await hw_mod._proxy_upstream_endpoint(
+        _request_with(reg), "/api/slots/metrics", timeout_s=0.2
+    )
+    elapsed = loop.time() - started
+
+    assert out["peer"] == {"ok": {}}
+    assert out["dead1"] is None and out["dead2"] is None and out["dead3"] is None
+    # Serial would be >= 3 * 0.2 s; concurrent is ~1 * 0.2 s.
+    assert elapsed < 0.5, f"fan-out serialised: {elapsed:.2f}s"

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -1,0 +1,180 @@
+"""``GET /api/slots`` stays bounded with N slots and a slow upstream (#1427).
+
+Measured on lxc105: 17–41 s for 19–29 slots, ~1 s per slot, because
+``container_enrichment`` walked the slot set serially and each slot paid a
+full connect timeout against a port with nothing listening. These tests pin
+the two properties that fix rests on:
+
+  * the per-slot probes overlap (wall-clock ≈ the slowest slot, not the sum);
+  * one wedged slot cannot hold the whole list past ``_PROBE_TIMEOUT_S``.
+
+Timings are asserted with generous headroom — the failure they guard against
+is an order of magnitude, not a few ms.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import hal0.slot_view as sv_mod
+from hal0.slot_view import SlotViewAggregator, container_enrichment
+from hal0.slots.manager import Slot
+from hal0.slots.state import SlotState
+
+PROBE_S = 0.25
+
+
+class SlowProvider:
+    """Every probe sleeps ``delay`` — the "port with nothing listening" shape."""
+
+    def __init__(self, delay: float = PROBE_S, wedged: set[str] | None = None) -> None:
+        self.delay = delay
+        self.wedged = wedged or set()
+        self.max_in_flight = 0
+        self._in_flight = 0
+
+    def _enter(self) -> None:
+        self._in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self._in_flight)
+
+    def is_active(self, slot_name: str) -> bool:
+        # Synchronous, exactly like the real provider — the aggregator is
+        # responsible for pushing it off the event loop.
+        import time
+
+        time.sleep(self.delay)
+        return True
+
+    async def health(self, port: int) -> dict[str, Any]:
+        self._enter()
+        try:
+            await asyncio.sleep(self.delay)
+            return {"ok": True}
+        finally:
+            self._in_flight -= 1
+
+    def running_image(self, slot_name: str) -> str | None:
+        if slot_name in self.wedged:
+            import time
+
+            # Long relative to the probe deadline, short enough that the
+            # abandoned executor thread doesn't stall the test session.
+            time.sleep(3)
+        return None
+
+    def image_present(self, image: str) -> bool:
+        return True
+
+
+def _configs(n: int, prefix: str = "s") -> list[dict[str, Any]]:
+    return [{"name": f"{prefix}{i}", "port": 8100 + i, "profile": ""} for i in range(n)]
+
+
+async def test_probes_overlap_instead_of_summing() -> None:
+    n = 10
+    provider = SlowProvider(delay=PROBE_S)
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    out = await container_enrichment(_configs(n), provider=provider)
+    elapsed = loop.time() - started
+
+    assert len(out) == n
+    assert all(e["container_status"] == "running" for e in out.values())
+    # Serial would be >= n * 2 * PROBE_S (is_active + health per slot) = 5 s.
+    assert elapsed < n * PROBE_S, f"probes serialised: {elapsed:.2f}s for {n} slots"
+    assert provider.max_in_flight > 1, "no probe overlap at all"
+
+
+async def test_probe_fanout_is_bounded() -> None:
+    """Concurrency is capped so 40 slots don't spawn 120 podman children."""
+    provider = SlowProvider(delay=0.05)
+    await container_enrichment(_configs(40), provider=provider)
+    assert provider.max_in_flight <= sv_mod._PROBE_CONCURRENCY
+
+
+async def test_one_wedged_slot_cannot_hold_the_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unreachable-upstream case: a probe that never returns is dropped.
+
+    This is where the tens-of-seconds behaviour came from — nothing bounded
+    the SUM of a slot's four independent IO waits.
+    """
+    monkeypatch.setattr(sv_mod, "_PROBE_TIMEOUT_S", 0.4)
+    provider = SlowProvider(delay=0.01, wedged={"s3"})
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    out = await container_enrichment(_configs(6), provider=provider)
+    elapsed = loop.time() - started
+
+    assert elapsed < 3.0, f"a wedged slot held the list for {elapsed:.2f}s"
+    assert set(out) == {f"s{i}" for i in range(6)}
+    # The wedged slot degrades rather than disappearing or 500ing.
+    assert out["s3"]["container_status"] == "stopped"
+    assert out["s3"]["container_health"] is False
+    assert out["s2"]["container_status"] == "running"
+
+
+# ── the whole GET /api/slots path ────────────────────────────────────────────
+
+
+class _SM:
+    def __init__(self, configs: list[dict[str, Any]]) -> None:
+        self._configs = configs
+
+    async def list(self) -> list[Slot]:
+        return [
+            Slot(c["name"], state=SlotState.READY, port=c["port"], model_id="m")
+            for c in self._configs
+        ]
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        return self._configs
+
+
+async def test_slot_list_snapshot_bounded_with_a_slow_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N slots + an upstream metrics fetch that never returns.
+
+    ``_safe_metrics`` is the leg that reaches upstreams; it used to be
+    awaited *after* the container probe and the capacity probe, so its
+    latency added to theirs. It now overlaps them, and the aggregator still
+    returns a full row set.
+    """
+    monkeypatch.setattr(sv_mod, "_PROBE_TIMEOUT_S", 1.0)
+
+    async def fake_build(slots: Any, registry: Any = None, **kw: Any) -> dict[str, Any]:
+        await asyncio.sleep(PROBE_S)
+        return {}
+
+    monkeypatch.setattr("hal0.slots.capacity.build_per_slot", fake_build)
+
+    async def slow_metrics() -> dict[str, Any]:
+        # Stands in for a remote fan-out that times out.
+        await asyncio.sleep(PROBE_S)
+        raise TimeoutError("upstream unreachable")
+
+    configs = _configs(8)
+    agg = SlotViewAggregator(
+        _SM(configs),
+        metrics=slow_metrics,
+        container_provider=SlowProvider(delay=PROBE_S / 2),
+        model_cache={},
+        upstreams=SimpleNamespace(list=lambda: []),
+        last_used_model={},
+        slot_pull_jobs={},
+    )
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    views = await agg.snapshot()
+    elapsed = loop.time() - started
+
+    assert len(views) == 8
+    assert elapsed < 2.0, f"GET /api/slots aggregation took {elapsed:.2f}s"

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -1,6 +1,6 @@
 """``GET /api/slots`` stays bounded with N slots and a slow upstream (#1427).
 
-Measured on lxc105: 17–41 s for 19–29 slots, ~1 s per slot, because
+Measured on lxc105: 17-41 s for 19-29 slots, ~1 s per slot, because
 ``container_enrichment`` walked the slot set serially and each slot paid a
 full connect timeout against a port with nothing listening. These tests pin
 the two properties that fix rests on:

--- a/tests/slot_view/test_probe_concurrency.py
+++ b/tests/slot_view/test_probe_concurrency.py
@@ -41,7 +41,7 @@ class SlowProvider:
         self._in_flight += 1
         self.max_in_flight = max(self.max_in_flight, self._in_flight)
 
-    def is_active(self, slot_name: str) -> bool:
+    def is_active(self, slot: dict[str, Any] | str) -> bool:
         # Synchronous, exactly like the real provider — the aggregator is
         # responsible for pushing it off the event loop.
         import time
@@ -57,8 +57,11 @@ class SlowProvider:
         finally:
             self._in_flight -= 1
 
-    def running_image(self, slot_name: str) -> str | None:
-        if slot_name in self.wedged:
+    def running_image(self, slot: dict[str, Any] | str) -> str | None:
+        # #1417: the aggregator passes the slot CONFIG, not a bare name — mirror
+        # the real provider's `Mapping[str, Any] | str` contract.
+        name = slot["name"] if isinstance(slot, dict) else slot
+        if name in self.wedged:
             import time
 
             # Long relative to the probe deadline, short enough that the

--- a/tests/upstreams/test_peers.py
+++ b/tests/upstreams/test_peers.py
@@ -1,0 +1,168 @@
+"""hal0-peer classification + hal0-internal URL joining (issues #1425, #1427).
+
+These are the *contract* tests for the egress fix: they assert on the URL
+string a peer probe would produce, not on a log line, so a regression that
+re-enables third-party egress fails here rather than in a journal grep.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.upstreams.peers import (
+    hal0_peer_upstreams,
+    is_hal0_peer,
+    is_private_host,
+    peer_api_url,
+)
+from hal0.upstreams.registry import Upstream, UpstreamRegistry
+
+# ── the URL join ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("base", "suffix", "expected"),
+    [
+        # The canonical hal0 peer shape: /v1 is a sibling of /api.
+        ("http://10.0.1.150:8080/v1", "/api/slots/metrics", "http://10.0.1.150:8080/api/slots/metrics"),
+        ("http://10.0.1.150:8080/v1/", "/api/stats/hardware", "http://10.0.1.150:8080/api/stats/hardware"),
+        # No /v1 at all.
+        ("http://peer.lan:8080", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+        # THE #1427 BUG: base path already ends in /api, suffix starts with
+        # /api/ → the naive concat produced /api/api/slots/metrics.
+        ("https://openrouter.ai/api/v1", "/api/slots/metrics", "https://openrouter.ai/api/slots/metrics"),
+        ("https://openrouter.ai/api", "/api/stats/hardware", "https://openrouter.ai/api/stats/hardware"),
+        # Suffix without a leading slash is still joined correctly.
+        ("http://peer.lan:8080/v1", "api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+        # Query/fragment on the base URL never leak onto the joined path.
+        ("http://peer.lan:8080/v1?x=1#frag", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+        # Surrounding whitespace in hand-authored TOML.
+        ("  http://peer.lan:8080/v1  ", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+    ],
+)
+def test_peer_api_url_join(base: str, suffix: str, expected: str) -> None:
+    assert peer_api_url(base, suffix) == expected
+
+
+@pytest.mark.parametrize(
+    "base",
+    [
+        "https://openrouter.ai/api/v1",
+        "https://openrouter.ai/api",
+        "https://openrouter.ai/api/",
+        "https://api.minimax.io/v1",
+        "http://10.0.1.150:8080/v1",
+        "http://10.0.1.150:8080/api/v1",
+        "http://peer.lan/",
+        "http://peer.lan",
+    ],
+)
+@pytest.mark.parametrize("suffix", ["/api/slots/metrics", "/api/stats/hardware"])
+def test_no_doubled_api_segment_is_constructible(base: str, suffix: str) -> None:
+    """No base URL shape may yield ``/api/api/`` — that was its own bug."""
+    assert "/api/api/" not in peer_api_url(base, suffix)
+
+
+# ── host classification ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1",
+        "0.0.0.0",
+        "10.0.1.150",
+        "192.168.1.20",
+        "172.16.4.9",
+        "169.254.10.1",
+        "::1",
+        "[::1]",
+        "fd00::1",
+        "localhost",
+        "hal0.localhost",
+        "peer.local",
+        "peer.lan",
+        "peer.internal",
+        "peer.home.arpa",
+        "halo",
+    ],
+)
+def test_private_hosts(host: str) -> None:
+    assert is_private_host(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "openrouter.ai",
+        "api.minimax.io",
+        "api.openai.com",
+        "api.anthropic.com",
+        "generativelanguage.googleapis.com",
+        "8.8.8.8",
+        "2606:4700::1111",
+        "",
+    ],
+)
+def test_public_hosts(host: str) -> None:
+    assert is_private_host(host) is False
+
+
+# ── peer eligibility ─────────────────────────────────────────────────────────
+
+
+def _u(name: str, url: str, **kw: object) -> Upstream:
+    return Upstream(name=name, kind=kw.pop("kind", "remote"), url=url, **kw)  # type: ignore[arg-type]
+
+
+def test_third_party_providers_are_never_peers() -> None:
+    for name, url in [
+        ("openrouter", "https://openrouter.ai/api/v1"),
+        ("minimax", "https://api.minimax.io/v1"),
+        ("openai", "https://api.openai.com/v1"),
+    ]:
+        assert is_hal0_peer(_u(name, url)) is False, name
+
+
+def test_private_remote_is_a_peer_by_default() -> None:
+    """The haloai-style LAN fanout keeps working with no operator action."""
+    assert is_hal0_peer(_u("peer", "http://10.0.1.150:8080/v1")) is True
+
+
+def test_slot_kind_is_never_a_peer() -> None:
+    """Pre-existing self-call carve-out: a slot upstream is THIS hal0."""
+    u = _u("agent", "http://127.0.0.1:8087/v1", kind="slot", slot_name="agent")
+    assert is_hal0_peer(u) is False
+
+
+def test_disabled_upstream_is_never_a_peer() -> None:
+    assert is_hal0_peer(_u("peer", "http://10.0.1.150:8080/v1", enabled=False)) is False
+
+
+def test_explicit_flag_wins_both_ways() -> None:
+    # Opt a public-hostname hal0 peer IN.
+    assert is_hal0_peer(_u("peer", "https://hal0.example.com/v1", hal0_peer=True)) is True
+    # Opt a private host OUT.
+    assert is_hal0_peer(_u("nope", "http://10.0.1.150:8080/v1", hal0_peer=False)) is False
+    # ...but an explicit flag never overrides the slot-kind self-call guard.
+    u = _u("agent", "http://127.0.0.1:8087/v1", kind="slot", slot_name="agent", hal0_peer=True)
+    assert is_hal0_peer(u) is False
+
+
+def test_hal0_peer_upstreams_filters_a_real_registry() -> None:
+    reg = UpstreamRegistry()
+    reg.add(_u("openrouter", "https://openrouter.ai/api/v1"))
+    reg.add(_u("minimax", "https://api.minimax.io/v1"))
+    reg.add(_u("peer", "http://10.0.1.150:8080/v1"))
+    reg.add(_u("agent", "http://127.0.0.1:8087/v1", kind="slot", slot_name="agent"))
+    assert [u.name for u in hal0_peer_upstreams(reg)] == ["peer"]
+
+
+def test_hal0_peer_survives_the_config_round_trip() -> None:
+    from hal0.config.schema import UpstreamEntry
+    from hal0.upstreams.registry import upstream_from_entry
+
+    entry = UpstreamEntry(name="peer", url="https://hal0.example.com/v1", hal0_peer=True)
+    assert upstream_from_entry(entry).hal0_peer is True
+    # Unset stays tri-state None so the auto-derivation runs.
+    assert upstream_from_entry(UpstreamEntry(name="x", url="https://openrouter.ai/api/v1")).hal0_peer is None

--- a/tests/upstreams/test_peers.py
+++ b/tests/upstreams/test_peers.py
@@ -24,20 +24,44 @@ from hal0.upstreams.registry import Upstream, UpstreamRegistry
     ("base", "suffix", "expected"),
     [
         # The canonical hal0 peer shape: /v1 is a sibling of /api.
-        ("http://10.0.1.150:8080/v1", "/api/slots/metrics", "http://10.0.1.150:8080/api/slots/metrics"),
-        ("http://10.0.1.150:8080/v1/", "/api/stats/hardware", "http://10.0.1.150:8080/api/stats/hardware"),
+        (
+            "http://10.0.1.150:8080/v1",
+            "/api/slots/metrics",
+            "http://10.0.1.150:8080/api/slots/metrics",
+        ),
+        (
+            "http://10.0.1.150:8080/v1/",
+            "/api/stats/hardware",
+            "http://10.0.1.150:8080/api/stats/hardware",
+        ),
         # No /v1 at all.
         ("http://peer.lan:8080", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
         # THE #1427 BUG: base path already ends in /api, suffix starts with
         # /api/ → the naive concat produced /api/api/slots/metrics.
-        ("https://openrouter.ai/api/v1", "/api/slots/metrics", "https://openrouter.ai/api/slots/metrics"),
-        ("https://openrouter.ai/api", "/api/stats/hardware", "https://openrouter.ai/api/stats/hardware"),
+        (
+            "https://openrouter.ai/api/v1",
+            "/api/slots/metrics",
+            "https://openrouter.ai/api/slots/metrics",
+        ),
+        (
+            "https://openrouter.ai/api",
+            "/api/stats/hardware",
+            "https://openrouter.ai/api/stats/hardware",
+        ),
         # Suffix without a leading slash is still joined correctly.
         ("http://peer.lan:8080/v1", "api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
         # Query/fragment on the base URL never leak onto the joined path.
-        ("http://peer.lan:8080/v1?x=1#frag", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+        (
+            "http://peer.lan:8080/v1?x=1#frag",
+            "/api/slots/metrics",
+            "http://peer.lan:8080/api/slots/metrics",
+        ),
         # Surrounding whitespace in hand-authored TOML.
-        ("  http://peer.lan:8080/v1  ", "/api/slots/metrics", "http://peer.lan:8080/api/slots/metrics"),
+        (
+            "  http://peer.lan:8080/v1  ",
+            "/api/slots/metrics",
+            "http://peer.lan:8080/api/slots/metrics",
+        ),
     ],
 )
 def test_peer_api_url_join(base: str, suffix: str, expected: str) -> None:
@@ -165,4 +189,7 @@ def test_hal0_peer_survives_the_config_round_trip() -> None:
     entry = UpstreamEntry(name="peer", url="https://hal0.example.com/v1", hal0_peer=True)
     assert upstream_from_entry(entry).hal0_peer is True
     # Unset stays tri-state None so the auto-derivation runs.
-    assert upstream_from_entry(UpstreamEntry(name="x", url="https://openrouter.ai/api/v1")).hal0_peer is None
+    assert (
+        upstream_from_entry(UpstreamEntry(name="x", url="https://openrouter.ai/api/v1")).hal0_peer
+        is None
+    )


### PR DESCRIPTION
## Summary
- Gates hal0-internal metrics/hardware fan-out to actual hal0 peers (excludes third-party OpenAI-compatible providers, disabled upstreams, local slot upstreams); adds explicit tri-state `hal0_peer` config.
- URL-level egress tests for the peer fan-out.
- Concurrent-probe work (#1427): bounded slot-probe concurrency, per-slot deadline, concurrent container/capacity/metrics aggregation — `GET /api/slots` no longer pays the SUM of every slot's connect timeout, only the max.

Reviewed PASS this session (diff-read + targeted tests) — see `docs/rework/handoff-1-0-release.md` §6b. Rebased onto current `main` after Streams A/C/D/E/F merged; that rebase collided with main's own independently-landed #1417 fix (id-keyed container/unit naming) at the exact same call sites this stream's #1427 concurrency fix touches — combined both (executor-wrapped calls now pass the slot config, not a bare name), and fixed a test fake (`SlowProvider` in `test_probe_concurrency.py`) that still keyed its wedged-slot check off a bare name string.

## Test plan
- [x] Targeted tests (`test_metrics_egress.py`, `test_probe_concurrency.py`, `test_peers.py`, `tests/slot_view/`): 126 passed
- [x] `ruff format --check` / `ruff check` clean
- [x] scar-marker ratchet clean (193 <= 194)
- [ ] CI