### PR TITLE
feat(brain): route tool rounds to [brain_chat] tool_model

### DIFF
--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
@@ -1102,6 +1103,261 @@ def _unrouteable_model_error(tried_model: str) -> str:
     )
 
 
+# ── tool-round rerouting (ADR-0023 / spec-p3-brain.final.md §5a) ────────────
+#
+# WHY THIS EXISTS. The shipped brain model is a ~1.1B SFT that CANNOT emit tool
+# calls the local runtime parses. Measured on a GPU box against the published
+# `hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf` in the pinned ROCmFPX runner:
+#
+#   * WITH `--jinja` + native OpenAI `tools`: HTTP 200, `finish_reason: stop`,
+#     `tool_calls: null`, and `content` came back as the literal string
+#     ' name="slot_list">'. The model emitted `<function name="slot_list">`;
+#     llama.cpp's jinja tool parser ate the `<function` prefix as a tool-call
+#     start marker, failed to parse the rest, and dumped the REMNANT into
+#     content. That remnant is signal (a) below.
+#   * WITHOUT `--jinja`, using the `hal0-function-xml` contract in the system
+#     prompt: `content` came back EMPTY with `reasoning_content` ending
+#     "I'll call the slot_list() function to retrieve the information." — it
+#     stated intent and stopped. That is signal (b) below.
+#
+# So the 1B genuinely cannot drive tools on this runtime. `[brain_chat]
+# tool_model` (default "hal0/agent") is the documented mitigation, and this is
+# its implementation.
+#
+# ROUTING SEMANTICS — per ROUND, not per conversation.
+#
+#   The brain's own 1B is the steward's VOICE. Keeping plain chat on it is the
+#   entire point of running a 1B, so every turn starts there and a turn that
+#   never needs a tool never touches `tool_model` at all — no extra latency, no
+#   35B wake-up for "hi".
+#
+#   A round becomes a TOOL round in exactly two ways:
+#     1. the brain produced a usable tool call (native `tool_calls`, or a
+#        text-embedded one the shared fallback parses). Nothing is re-run —
+#        that call is dispatched as-is;
+#     2. the brain produced a tool-call ARTEFACT it could not express
+#        (:func:`_tool_intent_artefact`). Its output is DISCARDED and the round
+#        is re-run against `tool_model`, whose reply is what reaches the user.
+#        The user must never see ' name="slot_list">'.
+#
+#   Once a turn has entered a tool chain by either route, every SUBSEQUENT
+#   round of that turn runs on `tool_model` — the tool-capable model continues;
+#   the 1B does NOT summarise tool results back. Four reasons, in order:
+#     * the `role: tool` payloads are raw JSON from an 82-tool admin catalogue.
+#       Reading them is precisely the reasoning the 1B already failed at;
+#     * a chain usually needs a SECOND call (read the slot, then load it).
+#       Handing back to the 1B mid-chain breaks it at the first continuation;
+#     * OpenAI wire semantics: the assistant message carrying `tool_calls` and
+#       its matching `role: tool` replies belong to ONE assistant turn-owner.
+#       Swapping models mid-chain produces shapes strict chat templates reject
+#       (the qwen3.5 `multi_step_tool` guard already bit this module — see
+#       `_frame_messages` / O18);
+#     * consistency: one model owns a tool chain end to end.
+#
+#   The chain is scoped to ONE turn. The next user message re-enters
+#   `_chat_stream` with fresh state and lands back on the 1B, so the steward's
+#   voice returns as soon as the tool work is done. State is tracked LOCALLY
+#   per turn and deliberately NOT inferred from the inbound `messages` — the
+#   dashboard replays prior `role: tool` turns as history (ui/src/api/hooks/
+#   useBoard.ts), so scanning them would pin every later turn to `tool_model`.
+#
+# NOTE ON `model` PRECEDENCE. An explicit per-request `model` sets the turn's
+# CHAT model; it does NOT suppress the reroute. It cannot: the dashboard sends
+# `model: "hal0/brain"` on EVERY send (useBoard.ts BOARD_CHAT_MODEL), so
+# treating a per-request model as "pin the whole turn" would make this feature
+# dead in the only UI that uses it.
+#
+# NOTE ON THE ENGINE. None of this touches `hal0.toolloop.engine`. The engine
+# owns `body` and mutates it in place between rounds; the per-round model hook
+# is just this wrapper writing `body["model"]` before delegating. OmniRouter's
+# use of `run_tool_loop` is therefore untouched by construction.
+
+#: The remnant llama.cpp's jinja tool parser leaves in `content` when it eats a
+#: `<function name="X">` opener it then fails to parse: `name="X"`.
+_ARTEFACT_NAME_RE = re.compile(r"""name\s*=\s*["']?\s*([A-Za-z0-9_.\-]+)""")
+
+#: An unterminated `<function=X` opener — the terminated form is already handled
+#: by the shared text-call fallback (`parse_text_tool_calls`).
+_ARTEFACT_FN_RE = re.compile(r"<\s*function\s*=\s*([A-Za-z0-9_.\-]+)")
+
+#: A stated call in prose: `slot_list(` / `slot_list()`. Requiring the paren
+#: form (and a known tool name) is what keeps ordinary prose from misfiring.
+_CALL_FORM_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_.\-]*)\s*\(")
+
+
+def _tool_intent_artefact(response: dict[str, Any], known_tool_names: frozenset[str]) -> str | None:
+    """The tool the brain *tried* to call but could not express, or ``None``.
+
+    Called ONLY after both the native and the text-embedded extractors came up
+    empty — this is the "the model wanted a tool and produced garbage instead"
+    detector, not a third parser. Returns the tool name so it can be logged.
+
+    Two signals, both requiring the name to be a tool actually surfaced this
+    turn (``known_tool_names``), which is what makes a false positive
+    essentially impossible — an unknown identifier is never a reroute trigger:
+
+    (a) a mangled call tag in the VISIBLE text — ``name="slot_list"`` or a bare
+        ``<function=slot_list``. No steward reply contains tag syntax naming one
+        of its own tools; this only ever appears when the tool parser chewed on
+        the completion.
+
+    (b) a stated call in the reasoning with NOTHING to show for it — the
+        no-``--jinja`` shape, where ``content`` is empty and
+        ``reasoning_content`` says "I'll call the slot_list() function". Gated
+        on the visible text being empty: a real reply is never empty, so this
+        can only fire on a turn that already produced nothing usable.
+    """
+    if not known_tool_names:
+        return None
+
+    inline_thinking, visible = _split_thinking(_assistant_text(response))
+
+    # (a) a mangled call tag in the visible text.
+    for pattern in (_ARTEFACT_NAME_RE, _ARTEFACT_FN_RE):
+        for m in pattern.finditer(visible):
+            if m.group(1) in known_tool_names:
+                return m.group(1)
+
+    # (b) stated intent, nothing to show for it. A non-empty reply is a reply.
+    if visible.strip():
+        return None
+    reasoning = "\n".join(t for t in (_assistant_thinking(response), inline_thinking) if t)
+    for m in _CALL_FORM_RE.finditer(reasoning):
+        if m.group(1) in known_tool_names:
+            return m.group(1)
+    return None
+
+
+def _tool_reroute_unavailable_message(tool_model: str, error: str) -> str:
+    """What the steward SAYS when the reroute target has no model behind it.
+
+    The single most likely real-world path, not an error branch: per the v1.0
+    ruling the agent anchor is an opt-in that DEFAULTS TO SKIP at install time,
+    so on a fresh box ``hal0/agent`` has no model bound and this fires on the
+    operator's first "list my slots". It must read as the steward explaining a
+    gap it can see, with the exact fix — never a stack trace, never a raw
+    dispatch envelope, and above all never an empty reply.
+    """
+    slot = tool_model.split("/", 1)[1] if tool_model.startswith("hal0/") else tool_model
+    return (
+        "I can't run tools right now. I answer chat on the brain model, but it can't "
+        f"emit tool calls on this runtime, so tool turns route to {tool_model!r} — and "
+        "that has no model behind it yet.\n\n"
+        f"To fix it: open the Models page, pull a tool-capable model, bind it to the "
+        f"`{slot}` slot, and load the slot. Alternatively point `[brain_chat] tool_model` "
+        'in hal0.toml at a slot that IS loaded, or set it to "off" if you\'d rather I '
+        "never offer tools.\n\n"
+        f"Plain chat keeps working meanwhile. (Underlying error: {error})"
+    )
+
+
+def _synthetic_reply(text: str) -> dict[str, Any]:
+    """An OpenAI-shaped completion carrying ``text`` as the assistant reply.
+
+    Used to turn a failed reroute into a normal, terminating steward turn: the
+    loop core sees an assistant message with no ``tool_calls``, emits one
+    ``token`` frame and ``done``. No crash, no 500, no empty message.
+    """
+    return {
+        "choices": [{"message": {"role": "assistant", "content": text}, "finish_reason": "stop"}]
+    }
+
+
+def _tool_routing_llm(
+    llm: LlmFn,
+    *,
+    chat_model: str,
+    tool_model: str,
+    known_tool_names: frozenset[str],
+) -> LlmFn:
+    """Wrap ``llm`` so TOOL rounds run on ``tool_model`` and chat stays on the brain.
+
+    The per-round model hook, implemented entirely on this side of the seam:
+    ``body`` is the engine-owned request dict, so setting ``body["model"]``
+    before delegating is all a "route this round elsewhere" hook needs. The
+    shared :func:`hal0.toolloop.engine.run_tool_loop` — and therefore
+    OmniRouter — is not modified.
+
+    An empty ``tool_model`` (the explicit ``"off"``/``"none"``/``"disabled"``
+    spellings, normalised by :meth:`BrainChatConfig._normalise_tool_model`) or a
+    ``tool_model`` equal to the chat model returns ``llm`` behaviourally
+    unchanged: exactly the pre-reroute code path, one call per round.
+
+    See the module comment above this function for the full routing semantics
+    and why the tool-capable model — not the 1B — finishes a tool chain.
+    """
+    # Nothing to reroute TO, or nowhere to reroute FROM. Note this branch is
+    # also what "no reroute" costs: a plain pass-through, not a wrapper that
+    # inspects every response.
+    if not tool_model or tool_model == chat_model:
+
+        async def _plain(body: dict[str, Any]) -> dict[str, Any]:
+            body["model"] = chat_model
+            return await llm(body)
+
+        return _plain
+
+    # Per-TURN, not per-round: once this turn is in a tool chain it stays on
+    # tool_model for the rest of the turn. A new turn builds a new wrapper.
+    in_tool_chain = False
+
+    async def _degrade(response: dict[str, Any]) -> dict[str, Any]:
+        """A tool-model round that failed becomes an honest steward sentence."""
+        if isinstance(response, dict) and response.get("error"):
+            log.warning(
+                "hal0.brain_chat.tool_model_unavailable",
+                tool_model=tool_model,
+                error=str(response["error"]),
+            )
+            return _synthetic_reply(
+                _tool_reroute_unavailable_message(tool_model, str(response["error"]))
+            )
+        return response
+
+    async def _routed(body: dict[str, Any]) -> dict[str, Any]:
+        nonlocal in_tool_chain
+
+        if in_tool_chain:
+            body["model"] = tool_model
+            return await _degrade(await llm(body))
+
+        body["model"] = chat_model
+        response = await llm(body)
+        if not isinstance(response, dict) or response.get("error"):
+            # A BRAIN-side failure keeps its documented contract exactly — the
+            # loop core turns it into the error+done frames tests already pin.
+            return response
+
+        # Usable call? Dispatch it as-is and hand the CONTINUATION to the tool
+        # model. Re-running a round the brain got right would only burn a
+        # second completion for the same answer.
+        calls = _extract_tool_calls(response)
+        if not calls:
+            calls, _cleaned = _parse_text_tool_calls(_assistant_text(response), known_tool_names)
+        if calls:
+            in_tool_chain = True
+            return response
+
+        wanted = _tool_intent_artefact(response, known_tool_names)
+        if wanted is None:
+            return response  # plain chat — the steward's own reply stands.
+
+        # The brain tried and produced garbage. Discard it and re-run THIS
+        # round on the tool-capable model. This is one extra completion inside
+        # one engine round, so `[brain_chat] max_rounds` still bounds the turn.
+        log.info(
+            "hal0.brain_chat.tool_round_rerouted",
+            tool=wanted,
+            chat_model=chat_model,
+            tool_model=tool_model,
+        )
+        in_tool_chain = True
+        body["model"] = tool_model
+        return await _degrade(await llm(body))
+
+    return _routed
+
+
 # ── SSE framing helpers ─────────────────────────────────────────────────────
 
 
@@ -1245,12 +1501,30 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     messages = _frame_messages(payload, system_prompt)
 
     tools = _surfaced_tool_schemas(request)
-    # Model precedence: an explicit per-request model wins; then the
-    # [brain_chat] model override (e.g. hal0/npu); then the persona's
-    # preferred_model / default. Tool turns are NOT rerouted to a second
-    # model — the steward's own model handles them internally, on whatever
-    # it resolves to here.
+    known_tool_names = _surfaced_tool_names(request)
+
+    # CHAT model precedence: an explicit per-request model wins, then the
+    # [brain_chat] model override (e.g. hal0/npu), then the persona's
+    # preferred_model / BRAIN_SLOT_MODEL. This is the model the steward SPEAKS
+    # with, and it is what every plain-chat round runs on.
     model = payload.get("model") or cfg.model or default_model
+
+    # TOOL model: the round that needs a tool reroutes here, because the ~1.1B
+    # brain cannot emit tool calls this runtime parses. Default "hal0/agent"
+    # (ADR-0023's always-on anchor, resolved through the normal virtual-model
+    # chain in hal0.normalize.resolver — no slot lookup is hardcoded here).
+    # Already normalised by BrainChatConfig: "" / whitespace fell back to the
+    # default with a warning, and "off"/"none"/"disabled" arrive here as "",
+    # which _tool_routing_llm treats as no reroute. See the routing-semantics
+    # comment above _tool_intent_artefact.
+    tool_model = (cfg.tool_model or "").strip()
+    llm = _tool_routing_llm(
+        llm,
+        chat_model=model,
+        tool_model=tool_model,
+        known_tool_names=known_tool_names,
+    )
+
     body: dict[str, Any] = {
         "model": model,
         "messages": messages,
@@ -1279,7 +1553,7 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
             dispatch_fn,
             body=body,
             max_rounds=cfg.max_rounds,
-            known_tool_names=_surfaced_tool_names(request),
+            known_tool_names=known_tool_names,
         ):
             if event.get("type") == "response":
                 continue  # internal marker — never part of the documented SSE contract
@@ -1435,7 +1709,12 @@ __all__ = [
     "_resolve_read_tool",
     "_resolve_tool",
     "_split_thinking",
+    "_surfaced_tool_names",
     "_surfaced_tool_schemas",
+    "_synthetic_reply",
+    "_tool_intent_artefact",
+    "_tool_reroute_unavailable_message",
+    "_tool_routing_llm",
     "_tool_schemas",
     "_unrouteable_model_error",
     "run_board_chat",

--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1178,11 +1178,19 @@ _ARTEFACT_NAME_RE = re.compile(r"""name\s*=\s*["']?\s*([A-Za-z0-9_.\-]+)""")
 
 #: An unterminated `<function=X` opener — the terminated form is already handled
 #: by the shared text-call fallback (`parse_text_tool_calls`).
-_ARTEFACT_FN_RE = re.compile(r"<\s*function\s*=\s*([A-Za-z0-9_.\-]+)")
+_ARTEFACT_FN_RE = re.compile(r"<\s*function\s*=\s*([A-Za-z0-9_.\-]+)", re.IGNORECASE)
 
-#: A stated call in prose: `slot_list(` / `slot_list()`. Requiring the paren
-#: form (and a known tool name) is what keeps ordinary prose from misfiring.
+#: Call-tag syntax of any shape. Reaching this module at all means neither
+#: extractor could make a call out of it, so a surviving `<function` /
+#: `<tool_call` opener is by definition a FAILED call attempt.
+_ARTEFACT_TAG_RE = re.compile(r"<\s*/?\s*(?:function|tool_call)\b", re.IGNORECASE)
+
+#: A stated call in prose: `slot_list(` / `slot_list()`. The paren form is what
+#: separates "I will call X()" from a reply that merely mentions X.
 _CALL_FORM_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_.\-]*)\s*\(")
+
+#: Debris left over once a `name="X"` fragment is lifted out of a mangled tag.
+_TAG_DEBRIS = " \t\r\n<>/\"'="
 
 
 def _tool_intent_artefact(response: dict[str, Any], known_tool_names: frozenset[str]) -> str | None:
@@ -1190,16 +1198,26 @@ def _tool_intent_artefact(response: dict[str, Any], known_tool_names: frozenset[
 
     Called ONLY after both the native and the text-embedded extractors came up
     empty — this is the "the model wanted a tool and produced garbage instead"
-    detector, not a third parser. Returns the tool name so it can be logged.
+    detector, not a third parser. Returns the name it was reaching for (for the
+    log line); ``"(unnamed)"`` when the artefact carries no readable name.
 
-    Two signals, both requiring the name to be a tool actually surfaced this
-    turn (``known_tool_names``), which is what makes a false positive
-    essentially impossible — an unknown identifier is never a reroute trigger:
+    DELIBERATELY NOT GATED ON THE NAME BEING A REAL TOOL. The measured leak was
+    ``<function name="slot_list">`` and there is no ``slot_list`` in the
+    catalogue — the real names are ``list_slots`` / ``slot_state`` — so a
+    membership check would have missed the exact failure this exists to catch.
+    A 1B reaching for a tool it half-remembers is *more* reason to hand the
+    round to the capable model, not less: that model then picks the right tool.
+    ``known_tool_names`` is therefore only the "are any tools surfaced at all"
+    guard (with none, there is nothing to reroute for) and a preference for
+    which name to report.
 
-    (a) a mangled call tag in the VISIBLE text — ``name="slot_list"`` or a bare
-        ``<function=slot_list``. No steward reply contains tag syntax naming one
-        of its own tools; this only ever appears when the tool parser chewed on
-        the completion.
+    Two signals, both narrow enough that ordinary prose cannot trip them:
+
+    (a) call-tag syntax surviving in the VISIBLE text. Either a whole
+        ``<function`` / ``<tool_call`` opener, or the bare ``name="X">``
+        REMNANT the jinja parser leaves after eating the opener — recognised
+        only when the fragment is essentially the entire reply, so a sentence
+        that happens to contain ``name="ops"`` is not an artefact.
 
     (b) a stated call in the reasoning with NOTHING to show for it — the
         no-``--jinja`` shape, where ``content`` is empty and
@@ -1212,20 +1230,34 @@ def _tool_intent_artefact(response: dict[str, Any], known_tool_names: frozenset[
 
     inline_thinking, visible = _split_thinking(_assistant_text(response))
 
-    # (a) a mangled call tag in the visible text.
-    for pattern in (_ARTEFACT_NAME_RE, _ARTEFACT_FN_RE):
-        for m in pattern.finditer(visible):
-            if m.group(1) in known_tool_names:
-                return m.group(1)
+    def _name_in(text: str) -> str | None:
+        """Prefer a real tool name; otherwise report whatever was written."""
+        found = [m.group(1) for p in (_ARTEFACT_FN_RE, _ARTEFACT_NAME_RE) for m in p.finditer(text)]
+        for name in found:
+            if name in known_tool_names:
+                return name
+        return found[0] if found else None
+
+    # (a1) a surviving call-tag opener — unambiguous failed-call syntax.
+    if _ARTEFACT_TAG_RE.search(visible):
+        return _name_in(visible) or "(unnamed)"
+
+    # (a2) the measured remnant: content IS a `name="X">` fragment and little
+    # else. Removing the fragment must leave nothing but tag punctuation.
+    if _ARTEFACT_NAME_RE.search(visible) and not _ARTEFACT_NAME_RE.sub("", visible).strip(
+        _TAG_DEBRIS
+    ):
+        return _name_in(visible) or "(unnamed)"
 
     # (b) stated intent, nothing to show for it. A non-empty reply is a reply.
     if visible.strip():
         return None
     reasoning = "\n".join(t for t in (_assistant_thinking(response), inline_thinking) if t)
-    for m in _CALL_FORM_RE.finditer(reasoning):
-        if m.group(1) in known_tool_names:
-            return m.group(1)
-    return None
+    matches = [m.group(1) for m in _CALL_FORM_RE.finditer(reasoning)]
+    for name in matches:
+        if name in known_tool_names:
+            return name
+    return matches[0] if matches else None
 
 
 def _tool_reroute_unavailable_message(tool_model: str, error: str) -> str:

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2741,15 +2741,24 @@ class BrainChatConfig(BaseModel):
     # the steward system prompt alone is ~7.3k tokens — and must actually be
     # LOADED, or the chat 404s (see BrainChatConfig docstring above).
     model: str = ""
-    # Route tool-calling turns to a capable, tool-format-compatible model. The
-    # steward always offers tools, so when set this is the model its tool loop
-    # runs on — the escape hatch for boxes whose ``model`` (e.g. a small 1B
-    # brain slot) can't emit tool calls the local runtime parses natively (it
-    # leaks/500s). Point it at a model that tool-calls cleanly on this runtime
-    # (a capable local slot like ``hal0/agent``, or the fallback provider).
-    # Default "hal0/agent" per spec-p3-brain.final.md §5a + ADR-0023
-    # (always-on anchor every fallback chain ends in). An explicit per-request
-    # ``model`` wins over it.
+    # Route tool-calling ROUNDS to a capable, tool-format-compatible model —
+    # the escape hatch for boxes whose ``model`` (the shipped ~1.1B brain slot)
+    # can't emit tool calls the local runtime parses natively (it leaks/500s).
+    # Point it at a model that tool-calls cleanly on this runtime (a capable
+    # local slot like ``hal0/agent``, or the fallback provider). Default
+    # "hal0/agent" per spec-p3-brain.final.md §5a + ADR-0023 (always-on anchor
+    # every fallback chain ends in), resolved through the normal virtual-model
+    # chain (:mod:`hal0.normalize.resolver`).
+    #
+    # PER ROUND, NOT PER CONVERSATION. Plain-chat rounds stay on ``model`` —
+    # that is the whole point of a fast 1B steward — and only a round that
+    # needs a tool reroutes here; once a turn is in a tool chain the tool model
+    # finishes it (it, not the 1B, reads the ``role: tool`` payloads). An
+    # explicit per-request ``model`` sets the CHAT model and does NOT suppress
+    # the reroute: the dashboard sends one on every message, so treating it as
+    # a whole-turn pin would disable this feature in the only UI that uses it.
+    # Implementation + measured failure modes: :func:`hal0.brain.chat
+    # ._tool_routing_llm`.
     #
     # EMPTY STRING IS NOT "DISABLED" — see _normalise_tool_model below. A live
     # box was found with `[brain_chat] tool_model = ""`, which silently

--- a/tests/board/test_board_chat.py
+++ b/tests/board/test_board_chat.py
@@ -1025,17 +1025,57 @@ def test_explicit_request_model_wins_over_config_override(tmp_path) -> None:
     assert stub.calls[0]["model"] == "hal0/utility"
 
 
-def test_brain_model_keeps_tool_turns_internal_when_tool_model_configured(tmp_path) -> None:
-    # Brain routes board/memory tool turns internally now; a configured tool_model
-    # is still available for lower-level fallback, but it should not override the
-    # steward's own chat model.
+class _ModelTracingLLM(_StubLLM):
+    """_StubLLM that records the model of EVERY round.
+
+    ``_StubLLM`` appends the live ``body`` dict, which the tool loop mutates in
+    place across rounds — so all its entries alias the last round. Fine for the
+    single-round tests above; useless for asserting per-round routing.
+    """
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__(responses)
+        self.models: list[str] = []
+
+    async def __call__(self, body: dict[str, Any]) -> dict[str, Any]:
+        self.models.append(body["model"])
+        return await super().__call__(body)
+
+
+def test_plain_chat_stays_on_the_brain_model(tmp_path) -> None:
+    # Half of the tool_model contract: a turn that never needs a tool never
+    # leaves the fast 1B. (This assertion is what the old
+    # "brain routes tool turns internally now" test actually pinned — it used a
+    # plain-chat response, so it never exercised the tool path at all.)
     rec = _Recorder()
-    stub = _StubLLM([_final_response("hi")])
+    stub = _ModelTracingLLM([_final_response("hi")])
     app, client = _make_app(rec, stub, tmp_path)
-    _set_brain_chat_config(app, model="hal0/brain", tool_model="hal0/agent")
+    _set_brain_chat_config(app, read_only=False, model="hal0/brain", tool_model="hal0/agent")
 
     client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
-    assert stub.calls[0]["model"] == "hal0/brain"
+    assert stub.models == ["hal0/brain"]
+
+
+def test_a_tool_round_routes_to_the_tool_model(tmp_path) -> None:
+    # The other half, and the contract the old test asserted the INVERSE of:
+    # the brain no longer "handles tool calls internally" — it can't (the ~1.1B
+    # emits no parseable call on this runtime), so the tool round and every
+    # continuation of it run on [brain_chat] tool_model.
+    rec = _Recorder()
+    rec.respond("GET", "/board", {"columns": []})
+    stub = _ModelTracingLLM(
+        [_tool_call_response("get_board", {}, "c1"), _final_response("all clear")]
+    )
+    app, client = _make_app(rec, stub, tmp_path)
+    _set_brain_chat_config(app, read_only=False, model="hal0/brain", tool_model="hal0/agent")
+
+    resp = client.post("/api/board/chat", json={"messages": [{"role": "user", "content": "x"}]})
+    assert resp.status_code == 200
+    # Round 0 decides on the brain; the round that READS the tool result runs
+    # on the tool model.
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+    events = _sse_events(resp.text)
+    assert next(e for e in events if e["type"] == "tool_call")["name"] == "get_board"
 
 
 def test_explicit_request_model_wins_over_tool_model(tmp_path) -> None:

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -1,0 +1,571 @@
+"""Tool-round rerouting — ``[brain_chat] tool_model`` (ADR-0023 / §5a).
+
+The shipped ~1.1B brain model cannot emit tool calls the local runtime parses.
+Measured on a GPU box against the published
+``hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf`` in the pinned ROCmFPX runner:
+
+  * WITH ``--jinja`` + native OpenAI ``tools``: HTTP 200, ``finish_reason:
+    stop``, ``tool_calls: null``, and ``content`` came back as the literal
+    string ``' name="slot_list">'`` — llama.cpp's jinja tool parser ate the
+    ``<function`` opener and dumped the remnant into content;
+  * WITHOUT ``--jinja`` (the ``hal0-function-xml`` prompt contract):
+    ``content`` came back EMPTY with ``reasoning_content`` ending "I'll call
+    the slot_list() function to retrieve the information."
+
+Both literal shapes are pinned below as the reroute triggers, so a regression
+in the detector shows up as *these exact strings* reaching the operator.
+
+What this file locks down:
+
+  * a plain-chat round stays on the brain; a tool round goes to ``tool_model``;
+  * once a turn is in a tool chain the TOOL model finishes it — the 1B never
+    reads a ``role: tool`` payload;
+  * the chain is scoped to ONE turn (a fresh turn is back on the brain), and is
+    NOT inferred from replayed inbound ``role: tool`` history;
+  * ``off``/``none``/``disabled`` disable the reroute; ``""``/whitespace falls
+    back to the default with a warning (Stream A's contract, extended here to
+    the routing behaviour that contract now drives);
+  * the reroute target having NO model bound — the default fresh-box state —
+    produces a clear, actionable steward message: no crash, no empty reply;
+  * ``hal0.toolloop.engine.run_tool_loop`` is untouched, so OmniRouter's use of
+    it is unchanged.
+
+Scripted stub LLM, no network.
+
+Run targeted:
+    uv run pytest tests/brain/test_brain_tool_reroute.py -q
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from hal0.api.routes import board_chat as bc
+from hal0.config.schema import (
+    BRAIN_TOOL_MODEL_DEFAULT,
+    BRAIN_TOOL_MODEL_DISABLED,
+    BrainChatConfig,
+    Hal0Config,
+)
+from hal0.mcp.approval_queue import ApprovalQueue
+
+# ── the two measured failure shapes ─────────────────────────────────────────
+
+#: What `--jinja` leaves in `content` after its tool parser eats the opener.
+JINJA_LEAK = ' name="slot_list">'
+
+#: What the no-`--jinja` run put in `reasoning_content`, with `content` EMPTY.
+STATED_INTENT = (
+    "The operator wants the slot inventory. I'll call the slot_list() function "
+    "to retrieve the information."
+)
+
+
+# ── harness ─────────────────────────────────────────────────────────────────
+
+
+class _StubLLM:
+    """Pops a canned response per call, recording the model of EACH call.
+
+    Records a deep-ish copy: the tool loop mutates one ``body`` dict in place
+    across rounds, so appending the object itself would make every recorded
+    call alias the last one — which is exactly the per-round routing this file
+    is asserting.
+    """
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def models(self) -> list[str]:
+        return [c["model"] for c in self.calls]
+
+    async def __call__(self, body: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(json.loads(json.dumps(body, default=str)))
+        return self._responses.pop(0) if self._responses else _final("done")
+
+
+def _tool_call(name: str, args: dict[str, Any], call_id: str) -> dict[str, Any]:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": name, "arguments": json.dumps(args)},
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _final(text: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": text}}]}
+
+
+def _leaked(content: str, reasoning: str = "") -> dict[str, Any]:
+    """A 200 OK completion with NO tool_calls — the brain's real failure shape."""
+    msg: dict[str, Any] = {"role": "assistant", "content": content, "tool_calls": None}
+    if reasoning:
+        msg["reasoning_content"] = reasoning
+    return {"choices": [{"message": msg, "finish_reason": "stop"}]}
+
+
+class _FakeKanban:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def request_json(self, method: str, path: str, **kw: Any) -> Any:
+        self.calls.append((method, path))
+        return {"columns": []} if path == "/board" else {"ok": True}
+
+
+def _fake_request(stub: _StubLLM, **brain_chat: Any) -> Any:
+    cfg = BrainChatConfig(read_only=False, **brain_chat)
+    state = SimpleNamespace(
+        board_chat_llm=stub,
+        hermes_kanban=_FakeKanban(),
+        approval_queue=ApprovalQueue(),
+        self_api_base_url="http://testserver",
+        brain_persona_root=Path("/nonexistent-personas-root"),
+        memory_dispatcher=None,
+        hal0_config=Hal0Config(brain_chat=cfg),
+        audit=None,
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state), headers={})
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+async def _collect(request: Any, payload: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    payload = payload or {"messages": [{"role": "user", "content": "list my slots"}]}
+    out = []
+    async for frame in bc._chat_stream(request, payload):
+        assert frame.startswith("data: ")
+        out.append(json.loads(frame[len("data: ") :].strip()))
+    return out
+
+
+def _tokens(events: list[dict[str, Any]]) -> str:
+    return "\n".join(e["text"] for e in events if e["type"] == "token")
+
+
+# ── the headline contract ───────────────────────────────────────────────────
+
+
+def test_plain_chat_round_stays_on_the_brain() -> None:
+    """No tool wanted -> the 1B answers and `tool_model` is never touched.
+
+    This is the reason routing is per-round: a fast 1B steward that woke a 35B
+    for "hi" would be pointless.
+    """
+    stub = _StubLLM([_final("Hey — what can I help with?")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request, {"messages": [{"role": "user", "content": "hi"}]}))
+
+    assert stub.models == ["hal0/brain"]
+    assert _tokens(events) == "Hey — what can I help with?"
+    assert events[-1] == {"type": "done"}
+
+
+def test_jinja_leak_reroutes_that_round_to_the_tool_model() -> None:
+    """The measured `--jinja` shape: the round re-runs on `tool_model`.
+
+    The brain's output is DISCARDED — ' name="slot_list">' must never reach the
+    operator — and the tool model's tool call is what drives the turn.
+    """
+    stub = _StubLLM(
+        [
+            _leaked(JINJA_LEAK),  # round 0, brain: garbage
+            _tool_call("list_slots", {}, "c1"),  # round 0 re-run, tool model
+            _final("You have three slots loaded."),  # round 1, tool model
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    # Round 0 on the brain, re-run on the tool model, continuation on the tool
+    # model. The 1B was asked once and never again this turn.
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    # The leak never surfaced.
+    assert JINJA_LEAK not in _tokens(events)
+    assert "slot_list" not in _tokens(events)
+    # The tool actually ran.
+    call = next(e for e in events if e["type"] == "tool_call")
+    assert call["name"] == "list_slots"
+    assert _tokens(events) == "You have three slots loaded."
+
+
+def test_stated_intent_with_empty_content_reroutes() -> None:
+    """The measured no-`--jinja` shape: intent in reasoning, content empty.
+
+    Left alone this is a blank steward reply — a 200 OK that reads as broken.
+    """
+    stub = _StubLLM(
+        [
+            _leaked("", reasoning=STATED_INTENT),
+            _tool_call("list_slots", {}, "c1"),
+            _final("Three slots."),
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    assert _tokens(events) == "Three slots."
+    assert events[-1] == {"type": "done"}
+
+
+def test_a_reply_that_merely_mentions_a_tool_is_not_rerouted() -> None:
+    """The detector must not fire on prose. A real reply is a real reply.
+
+    Names a surfaced tool, in call form, in the reasoning — but `content` is
+    non-empty, so the turn produced an actual answer and there is nothing to
+    recover.
+    """
+    stub = _StubLLM(
+        [
+            _leaked(
+                "You can see them on the Slots page.",
+                reasoning="I could call list_slots() but the operator only asked where.",
+            )
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    assert stub.models == ["hal0/brain"]
+    assert _tokens(events) == "You can see them on the Slots page."
+
+
+def test_a_usable_brain_tool_call_is_not_re_run() -> None:
+    """When the brain gets it right, dispatch it — don't burn a second round.
+
+    The reroute exists because the 1B *fails*; a box whose `[brain_chat] model`
+    points at a capable model must not pay double for every tool turn.
+    """
+    stub = _StubLLM([_tool_call("list_slots", {}, "c1"), _final("done")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    _run(_collect(request))
+
+    # Exactly two completions — round 0 on the brain (its call is used as-is),
+    # round 1 on the tool model. No re-run of round 0.
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+
+
+# ── who finishes a tool chain ───────────────────────────────────────────────
+
+
+def test_the_tool_model_reads_the_tool_results_not_the_brain() -> None:
+    """The settled semantics for point 1: the tool-capable model continues.
+
+    The `role: tool` payload is raw JSON from an 82-tool admin catalogue and a
+    chain usually needs a second call. The round that SEES a tool result is
+    always a tool-model round.
+    """
+    stub = _StubLLM(
+        [
+            _tool_call("get_board", {}, "c1"),
+            _tool_call("get_board", {}, "c2"),  # chains a second call
+            _final("summary"),
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    _run(_collect(request))
+
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    # Every round that carried a tool result ran on the tool model.
+    for body in stub.calls:
+        if any(m.get("role") == "tool" for m in body["messages"]):
+            assert body["model"] == "hal0/agent"
+
+
+def test_the_chain_is_scoped_to_one_turn() -> None:
+    """A fresh turn starts back on the brain — the 1B stays the steward's voice."""
+    stub = _StubLLM([_tool_call("get_board", {}, "c1"), _final("done")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+    _run(_collect(request))
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+
+    # Second turn, same app state, same config.
+    stub._responses = [_final("sure")]
+    stub.calls.clear()
+    _run(_collect(request, {"messages": [{"role": "user", "content": "thanks"}]}))
+    assert stub.models == ["hal0/brain"]
+
+
+def test_replayed_tool_history_does_not_pin_a_turn_to_the_tool_model() -> None:
+    """Chain state is LOCAL, not inferred from the inbound messages.
+
+    The dashboard replays prior tool turns as history
+    (ui/src/api/hooks/useBoard.ts) — scanning `messages` for `role: tool` would
+    pin every subsequent turn to the tool model and silently retire the 1B.
+    """
+    stub = _StubLLM([_final("Nothing else pending.")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(
+        _collect(
+            request,
+            {
+                "messages": [
+                    {"role": "user", "content": "what's on the board?"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "old",
+                                "type": "function",
+                                "function": {"name": "get_board", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "old",
+                        "name": "get_board",
+                        "content": "{}",
+                    },
+                    {"role": "user", "content": "anything else?"},
+                ]
+            },
+        )
+    )
+
+    assert stub.models == ["hal0/brain"]
+    assert _tokens(events) == "Nothing else pending."
+
+
+# ── the tool_model vocabulary (Stream A's contract) ─────────────────────────
+
+
+def test_explicit_off_spellings_disable_the_reroute() -> None:
+    """ "off"/"none"/"disabled" -> no reroute, ever. One completion per round."""
+    for spelling in sorted(BRAIN_TOOL_MODEL_DISABLED):
+        stub = _StubLLM([_leaked(JINJA_LEAK), _final("x")])
+        request = _fake_request(stub, model="hal0/brain", tool_model=spelling)
+
+        events = _run(_collect(request))
+
+        # The garbage round was NOT re-run — with the reroute off there is
+        # nowhere to send it, so the turn ends on the brain's own output.
+        assert stub.models == ["hal0/brain"], spelling
+        assert events[-1] == {"type": "done"}, spelling
+
+
+def test_empty_tool_model_falls_back_to_the_default_and_still_reroutes() -> None:
+    """Stream A: "" normalises to the default. It must ROUTE there too.
+
+    Ruling 12: a live box was found with `tool_model = ""`, which overrode the
+    default and silently killed tool routing. Normalising the value is only
+    half the fix — the routing has to follow it.
+    """
+    for spelling in ("", "   ", "\t\n"):
+        stub = _StubLLM([_leaked(JINJA_LEAK), _tool_call("list_slots", {}, "c1"), _final("ok")])
+        request = _fake_request(stub, model="hal0/brain", tool_model=spelling)
+
+        _run(_collect(request))
+
+        assert stub.models == [
+            "hal0/brain",
+            BRAIN_TOOL_MODEL_DEFAULT,
+            BRAIN_TOOL_MODEL_DEFAULT,
+        ], repr(spelling)
+
+
+def test_empty_tool_model_warns(caplog) -> None:
+    """The fallback is loud — a config that looks unset must not be silent."""
+    with caplog.at_level("WARNING", logger="hal0.config.schema"):
+        cfg = BrainChatConfig(tool_model="")
+    assert cfg.tool_model == BRAIN_TOOL_MODEL_DEFAULT
+    assert any("tool_model is empty" in r.getMessage() for r in caplog.records)
+
+
+def test_tool_model_equal_to_the_chat_model_is_a_no_op() -> None:
+    """Nothing to reroute to — re-running the same model would only cost a round."""
+    stub = _StubLLM([_leaked(JINJA_LEAK), _final("x")])
+    request = _fake_request(stub, model="hal0/agent", tool_model="hal0/agent")
+
+    _run(_collect(request))
+
+    assert stub.models == ["hal0/agent"]
+
+
+def test_per_request_model_sets_the_chat_model_but_does_not_pin_the_turn() -> None:
+    """The dashboard sends `model` on EVERY message (useBoard.ts:1219).
+
+    Treating a per-request model as a whole-turn pin would make the reroute
+    dead in the only UI that uses it. It sets the CHAT model; tool rounds still
+    go to `tool_model`.
+    """
+    stub = _StubLLM([_leaked(JINJA_LEAK), _tool_call("list_slots", {}, "c1"), _final("ok")])
+    request = _fake_request(stub, model="hal0/npu", tool_model="hal0/agent")
+
+    _run(
+        _collect(
+            request,
+            {"model": "hal0/utility", "messages": [{"role": "user", "content": "slots?"}]},
+        )
+    )
+
+    assert stub.models == ["hal0/utility", "hal0/agent", "hal0/agent"]
+
+
+# ── degrading honestly when the target has no model (the fresh-box path) ────
+
+
+def test_no_model_on_the_reroute_target_explains_itself() -> None:
+    """Per ruling 10 the agent anchor is a skip-by-default install opt-in, so on
+    most fresh boxes `hal0/agent` has NO model bound. That is the single most
+    likely real-world path, not an error branch: the operator must get a
+    sentence they can act on, not a crash, not a 500, and not silence.
+    """
+    stub = _StubLLM(
+        [
+            _leaked(JINJA_LEAK),
+            # The re-run hits the resolver's dead end — what the real
+            # _primary_completion returns on a 404 dispatch.no_route.
+            {"error": bc._unrouteable_model_error("hal0/agent")},
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    # No crash, and the turn terminated normally.
+    assert events[-1] == {"type": "done"}
+    assert not [e for e in events if e["type"] == "error"]
+
+    # Not an empty reply — and it names the target, the surface to fix it on,
+    # and the opt-out.
+    said = _tokens(events)
+    assert said.strip(), "the steward said nothing at all"
+    assert "hal0/agent" in said
+    assert "Models page" in said
+    assert "`agent` slot" in said
+    assert "tool_model" in said
+    assert "Plain chat keeps working" in said
+    # The raw leak is still not shown.
+    assert JINJA_LEAK not in said
+
+
+def test_a_transport_failure_on_the_tool_model_also_degrades_to_a_sentence() -> None:
+    """Same first-class handling for the other reroute failure, with the
+    underlying error kept visible so it stays diagnosable."""
+    stub = _StubLLM(
+        [
+            _leaked(JINJA_LEAK),
+            {"error": "primary slot transport failure: connection refused"},
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    said = _tokens(events)
+    assert "connection refused" in said
+    assert "Models page" in said
+    assert events[-1] == {"type": "done"}
+
+
+def test_a_tool_model_failure_mid_chain_still_explains_itself() -> None:
+    """The tools ran; the model that must READ their results is missing.
+
+    Without this the turn would end on a bare error frame right after a
+    successful mutation — the worst moment to go quiet.
+    """
+    stub = _StubLLM(
+        [
+            _tool_call("get_board", {}, "c1"),  # brain got it right
+            {"error": bc._unrouteable_model_error("hal0/agent")},  # continuation dies
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    assert next(e for e in events if e["type"] == "tool_result")["result"] == {"tasks": []}
+    said = _tokens(events)
+    assert "Models page" in said
+    assert events[-1] == {"type": "done"}
+
+
+def test_a_brain_side_failure_keeps_its_documented_error_frame() -> None:
+    """The degrade path is for TOOL-model rounds only — a brain transport
+    failure still surfaces as the documented error+done frames."""
+    stub = _StubLLM([{"error": "primary slot transport failure: connection refused"}])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    events = _run(_collect(request))
+
+    err = next(e for e in events if e["type"] == "error")
+    assert "transport failure" in err["message"]
+    assert events[-1] == {"type": "done"}
+
+
+# ── the detector, unit level ────────────────────────────────────────────────
+
+
+def test_tool_intent_artefact_signals() -> None:
+    known = frozenset({"list_slots", "get_board"})
+    art = bc._tool_intent_artefact
+
+    # (a) the measured jinja remnant, and the whole tag it came from.
+    #
+    # NOTE the name in the real measured leak is `slot_list`, which is NOT a
+    # tool — the catalogue has `list_slots` / `slot_state`. Gating the detector
+    # on the name being real would have missed the exact failure it exists to
+    # catch, so it does not.
+    assert art(_leaked(JINJA_LEAK), known) == "slot_list"
+    assert art(_leaked('<function name="get_board">'), known) == "get_board"
+    # An unterminated `<function=NAME` opener (the terminated form is already
+    # handled by the shared text-call fallback).
+    assert art(_leaked("<function=list_slots"), known) == "list_slots"
+    # A tag with nothing readable in it is still a failed call.
+    assert art(_leaked("<tool_call>"), known) == "(unnamed)"
+
+    # (b) stated intent with nothing to show for it.
+    assert art(_leaked("", reasoning=STATED_INTENT), known) == "slot_list"
+    # ...but only when there is genuinely nothing to show.
+    assert art(_leaked("Here you go.", reasoning=STATED_INTENT), known) is None
+    # A real tool name in the reasoning is preferred over an earlier one.
+    assert (
+        art(_leaked("", reasoning="maybe frobnicate(), no — list_slots()"), known) == "list_slots"
+    )
+
+    # Never fires on ordinary prose, or on a genuinely blank turn.
+    assert art(_leaked("Three slots are loaded."), known) is None
+    assert art(_leaked('I made a slot with name="ops" for you.'), known) is None
+    assert art(_leaked("", reasoning="Thinking about the answer."), known) is None
+    # No tools surfaced -> no reroute is possible, so no signal.
+    assert art(_leaked(JINJA_LEAK), frozenset()) is None
+
+
+def test_unavailable_message_is_actionable() -> None:
+    msg = bc._tool_reroute_unavailable_message("hal0/agent", "dispatch.no_route")
+    assert "hal0/agent" in msg
+    assert "`agent` slot" in msg  # the slot name is extracted from hal0/<slot>
+    assert "Models page" in msg
+    assert "dispatch.no_route" in msg
+    # A non-virtual target degrades without mangling the name.
+    assert "some-model" in bc._tool_reroute_unavailable_message("some-model", "x")

--- a/tests/omni_router/test_router_loop.py
+++ b/tests/omni_router/test_router_loop.py
@@ -553,3 +553,113 @@ async def test_loop_handles_malformed_arguments_gracefully() -> None:
         body={"model": "agent", "messages": [{"role": "user", "content": "x"}]},
     )
     assert result["choices"][0]["message"]["content"] == "sorry"
+
+
+# ── the shared loop core is not brain-specific (Stream G guard) ─────────────
+#
+# `hal0.toolloop.engine.run_tool_loop` is shared with the hal0-brain steward
+# chat, which gained per-round model rerouting (`[brain_chat] tool_model`) so a
+# tool round can leave the ~1.1B brain for a tool-capable model. That reroute
+# is implemented ENTIRELY on the brain's side of the seam, as a wrapper around
+# the `llm_fn` it hands the engine. These tests fail if it ever leaks in here.
+
+
+@pytest.mark.asyncio
+async def test_router_loop_never_rewrites_the_model_between_rounds() -> None:
+    """Every round of an OmniRouter loop uses the caller's model, verbatim.
+
+    The brain rewrites `body["model"]` per round. OmniRouter must not: its
+    `model` is the caller's slot resolution and rewriting it would silently
+    re-route someone else's `/v1/chat/completions` request mid-loop.
+    """
+    rounds: list[dict[str, Any]] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        # Only the LOOP's own completions — not the image dispatch a tool call
+        # fans out to, which legitimately carries the image slot's model.
+        if req.url.path != "/v1/chat/completions":
+            return httpx.Response(200, json={"data": [{"url": "http://img/1.png"}]})
+        body = json.loads(req.read())
+        rounds.append(body)
+        if len(rounds) == 1:
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "generate_image",
+                                            "arguments": json.dumps({"prompt": "a cat"}),
+                                        },
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(200, json={"choices": [{"message": {"content": "done"}}]})
+
+    router = _make_router(handler, [_caller(), _img_slot()])
+    await router.run_loop(
+        caller_slot_name="primary",
+        body={"model": "agent", "messages": [{"role": "user", "content": "draw"}]},
+    )
+
+    assert len(rounds) >= 2, "the loop did not run a continuation round"
+    assert [r["model"] for r in rounds] == ["agent"] * len(rounds)
+
+
+@pytest.mark.asyncio
+async def test_router_loop_signature_takes_no_model_hook() -> None:
+    """`run_tool_loop` grew no per-round model parameter.
+
+    The brain's reroute needed one; adding it to the shared core would have
+    changed this caller's contract. It was implemented as an `llm_fn` wrapper
+    instead, so the engine's signature is exactly what it was.
+    """
+    import inspect
+
+    from hal0.toolloop.engine import run_tool_loop
+
+    params = inspect.signature(run_tool_loop).parameters
+    assert list(params) == [
+        "llm_fn",
+        "tools",
+        "dispatch_fn",
+        "body",
+        "max_rounds",
+        "known_tool_names",
+        "on_event",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_router_loop_never_synthesises_a_reply_for_an_error_round() -> None:
+    """An upstream error stays an error for OmniRouter.
+
+    The brain turns a failed TOOL-model round into a synthetic assistant
+    message ("tool calls need a model on the agent slot..."). That degrade is
+    brain-local: OmniRouter must keep returning the raw error envelope its
+    callers forward verbatim.
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream is down")
+
+    router = _make_router(handler, [_caller(), _img_slot()])
+    result = await router.run_loop(
+        caller_slot_name="primary",
+        body={"model": "agent", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert "error" in result
+    assert "503" in result["error"]
+    assert "choices" not in result


### PR DESCRIPTION
## Summary
- The mitigation `[brain_chat] tool_model` (ADR-0023 / spec-p3-brain.final.md §5a) was documented but never implemented — the brain's own ~1.1B model cannot emit tool calls the local runtime parses reliably, and no code path ever rerouted a tool round to a capable model.
- Routes per ROUND, not per conversation: plain chat stays on the fast brain model; a round only leaves it when it actually needs a tool (a usable call, or an unparseable artefact it produced instead). Once a turn enters a tool chain, every subsequent round of that turn runs on `tool_model` — reading raw tool-result JSON and continuing a chain is a reasoning task the small model isn't asked to do, independent of whatever native/text tool-call parsing succeeds.
- Fresh-box degrade path: when the reroute target has no model behind it (the default state — the agent anchor is a skip-by-default install opt-in), the turn terminates as a normal steward message naming the target and the fix, not a crash/500/blank.

This branch was originally stacked on Stream A's uncommitted history and picked up this session as real, substantive in-progress work (11 uncommitted files) with no author context available. Investigation found the uncommitted portion (a `hal0.toolloop.contract`/`dialects` module implementing a native-tools-avoidance strategy for the brain's tool-call syntax) was solving a problem **already closed on `main`** via a different, already-shipped, twice-refined fix (`f8b3d950`/#1434 closes #1419, `ec14fb62`/#1542 refines it) that lets llama.cpp's parser mangle the output and parses the mangled remnant back out — a proven, hardware-tested approach. Kept only this stream's own two original committed commits (routing to `tool_model`), which add real, non-duplicated value: main has zero tool_model reroute wiring in `chat.py`. Rebased cleanly onto current `main` (which now includes that #1419/#1509 parser work) with one conflict (a stale "not rerouted" comment/docstring, resolved in this branch's favor since implementing that routing is the whole point).

## Test plan
- [x] Targeted tests (`test_brain_tool_reroute.py`, `test_board_chat.py`, `tests/omni_router/`, `test_schema.py`, `test_brain_tool_model_empty.py`): 288 passed
- [x] `ruff format --check` / `ruff check` clean
- [x] Full local backend suite green post-rebase: 8509 passed, 0 failed
- [ ] CI