### PR TITLE
fix(ui): gate board bulk delete behind a type-to-confirm dialog

### DIFF
--- a/ui/src/dash/board/board-view.jsx
+++ b/ui/src/dash/board/board-view.jsx
@@ -178,6 +178,9 @@ function BoardView() {
   const useCreateBoard      = window.__hal0UseCreateBoard;
   const useCreateTask       = window.__hal0UseCreateTask;
   const useBoardEventsStream = window.__hal0UseBoardEventsStream;
+  // primitives.jsx publishes ConfirmDialog on window (this module takes no ES
+  // imports from dash/*). Used for the #1535 bulk-delete guard.
+  const ConfirmDialog       = window.ConfirmDialog;
 
   // ── board scope (declared before the queries that thread it) ──
   // null = the server's current board (omit ?board=, per contract). Set only
@@ -230,6 +233,9 @@ function BoardView() {
   const [byProfile, setByProfile]   = useState(true);
 
   const [sel, setSel]               = useState(() => new Set());
+  // #1535: ids awaiting the bulk-delete confirmation. null = no confirm open.
+  // Delete is the only bulk action gated this way — see the button + dialog.
+  const [delConfirm, setDelConfirm] = useState(null);
   const [openTask, setOpenTask]     = useState(null);
   const [chatOpen, setChatOpen]     = useState(false);
   const [newTaskLane, setNewTaskLane] = useState(null);
@@ -353,11 +359,14 @@ function BoardView() {
     }
   };
 
+  // Terminal. Only ever reached from the confirmation dialog (#1535) — the
+  // toolbar button stages ids into `delConfirm` instead of calling this.
   const delTasks = (ids) => {
     if (deleteTask) {
       ids.forEach(id => deleteTask.mutate(id));
     }
     setSel(new Set());
+    setDelConfirm(null);
   };
 
   const doReassign = () => {
@@ -623,8 +632,13 @@ function BoardView() {
                   onClick={() => { moveTo([...sel], "done"); clearSel(); }}>complete</button>
                 <button className="bb-act" data-testid="board-action-archive"
                   onClick={() => { moveTo([...sel], "archived"); clearSel(); }}>archive</button>
+                {/* #1535: delete is TERMINAL — store.delete_task() is a hard SQL
+                    delete that cascades comments/links/runs/events, and `archive`
+                    (the reversible option) sits one button to the left. A slip
+                    between the two used to destroy N cards and their whole
+                    history on one unacknowledged click. Gate it, and only it. */}
                 <button className="bb-act danger" data-testid="board-action-delete"
-                  onClick={() => delTasks([...sel])}>
+                  onClick={() => setDelConfirm([...sel])}>
                   <BoardIcon name="trash" size={12} />delete
                 </button>
                 <span className="bdiv" />
@@ -778,6 +792,46 @@ function BoardView() {
           }}
         />
         </div>
+      )}
+
+      {/* #1535: bulk-delete confirmation. Terminal action, so it follows the
+          DeleteSlotDialog precedent exactly — `destructive`, type-to-confirm,
+          and an explicit blast radius that names what is destroyed AND what
+          survives. The cascade (comments/links/runs/events) is the part the
+          operator cannot see from the board, so it is spelled out; `archive`
+          is named because a slip onto the adjacent red button is the actual
+          failure mode this guards. */}
+      {delConfirm && ConfirmDialog && (
+        <ConfirmDialog
+          open
+          onCancel={() => setDelConfirm(null)}
+          onConfirm={() => delTasks(delConfirm)}
+          destructive
+          typeToConfirm="delete"
+          confirmLabel={`Delete ${delConfirm.length} card${delConfirm.length === 1 ? "" : "s"}`}
+          title={`Delete ${delConfirm.length} card${delConfirm.length === 1 ? "" : "s"}?`}
+          message={
+            <span data-testid="board-delete-blast">
+              Deleting {delConfirm.length} card{delConfirm.length === 1 ? "" : "s"} will:
+              <span style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 11, fontFamily: "var(--jbm)", fontSize: 11.5, lineHeight: 1.5 }}>
+                <span style={{ display: "flex", gap: 8 }}><span style={{ color: "var(--err)" }}>−</span><span style={{ color: "var(--fg-2)" }}>remove {delConfirm.length === 1 ? "the card" : "the cards"} permanently — this is a hard delete, not an archive</span></span>
+                <span style={{ display: "flex", gap: 8 }}><span style={{ color: "var(--err)" }}>−</span><span style={{ color: "var(--fg-2)" }}>cascade every <span style={{ color: "var(--fg)" }}>comment</span>, <span style={{ color: "var(--fg)" }}>link</span>, <span style={{ color: "var(--fg)" }}>run</span> and <span style={{ color: "var(--fg)" }}>event</span> attached to them</span></span>
+                <span style={{ display: "flex", gap: 8 }}><span style={{ color: "var(--fg-4)" }}>·</span><span style={{ color: "var(--fg-3)" }}>there is no undo — use <b style={{ color: "var(--fg-2)" }}>archive</b> instead if you want them back later</span></span>
+              </span>
+              <span style={{ display: "block", marginTop: 12, maxHeight: 132, overflowY: "auto", fontFamily: "var(--jbm)", fontSize: 11, color: "var(--fg-3)", lineHeight: 1.7 }}>
+                {delConfirm.slice(0, 8).map(id => (
+                  <span key={id} style={{ display: "block", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    <span style={{ color: "var(--fg-5)" }}>{id}</span>{" "}
+                    {(byId[id] && (byId[id].title || byId[id].name)) || ""}
+                  </span>
+                ))}
+                {delConfirm.length > 8 && (
+                  <span style={{ display: "block", color: "var(--fg-5)" }}>+{delConfirm.length - 8} more</span>
+                )}
+              </span>
+            </span>
+          }
+        />
       )}
     </React.Fragment>
   );

--- a/ui/tests/e2e/specs/board-bulk-delete-guard-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-bulk-delete-guard-v3.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * board-bulk-delete-guard-v3 — #1535: bulk delete cannot destroy N cards
+ * (and their cascaded history) on one unacknowledged click.
+ *
+ * The Board's bulk toolbar had a `delete` button wired straight to
+ * `delTasks([...sel])` → `DELETE /api/board/tasks/{id}` per id →
+ * `store.delete_task()`, a hard SQL delete that cascades comments, links, runs
+ * and events. `grep -rn confirm ui/src/dash/board/` returned nothing.
+ *
+ * The failure is a slip, not a mistake: `archive` sits immediately to the left
+ * of the red `delete` in the same button row, and archive is the reversible
+ * option (recoverable via "Show archived"). An operator shift-selecting a
+ * range to archive who lands one button right destroys the lot, with nothing
+ * written anywhere recoverable and no undo affordance.
+ *
+ * This was the only unguarded destructive multi-record action left in the app.
+ * The guard matches the established precedent rather than inventing one —
+ * `ConfirmDialog` with `destructive` + `typeToConfirm` + an explicit
+ * blast-radius list, exactly as `DeleteSlotDialog` does (which states what is
+ * destroyed AND what survives), and in the same family as the secrets removal
+ * (#1450) and the memory bank-wipe echo guard (#1024 / #1457).
+ *
+ * Every assertion below is on the WIRE — zero DELETEs — rather than on the
+ * dialog rendering, because a dialog that renders but doesn't actually gate
+ * the mutation is precisely the bug being fixed.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+import { BOARD_TASKS } from '../fixtures/mock-data'
+
+const FIVE_S = 5_500
+
+/** Capture every per-id DELETE the board can fire. */
+async function captureDeletes(page: any): Promise<string[]> {
+  const urls: string[] = []
+  await page.route(/\/api\/board\/tasks\/[^/]+$/, async (route: any) => {
+    if (route.request().method() === 'DELETE') {
+      urls.push(route.request().url())
+      await json(route, { ok: true })
+    } else {
+      await route.fallback()
+    }
+  })
+  return urls
+}
+
+async function gotoBoardAndWait(page: any) {
+  await page.goto('/#board')
+  await expect(page.locator('[data-testid="board-view"]')).toBeVisible({ timeout: FIVE_S })
+}
+
+async function selectCards(page: any, ids: string[]) {
+  for (const id of ids) {
+    const card = page.locator(`[data-testid="board-task-${id}"]`)
+    await card.scrollIntoViewIfNeeded()
+    await card.locator('.kc-check').click()
+  }
+}
+
+const deleteBtn = (page: any) => page.locator('[data-testid="board-action-delete"]')
+const dialog = (page: any) => page.locator('[data-testid="board-delete-blast"]')
+const confirmBtn = (page: any) =>
+  page.locator('[role="dialog"] button', { hasText: /^Delete \d+ card/ })
+
+/** Two cards that exist in the mock board. */
+const targets = () => BOARD_TASKS.filter((t: any) => t.status === 'done').slice(0, 2)
+
+test.describe('Board bulk delete — confirmation guard (#1535)', () => {
+  test('G1 — clicking delete fires ZERO DELETEs and raises a confirm naming the count', async ({
+    page,
+  }) => {
+    const t = targets()
+    const deletes = await captureDeletes(page)
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await deleteBtn(page).click()
+
+    // The whole point: the click alone must not reach the wire.
+    await page.waitForTimeout(400)
+    expect(deletes).toEqual([])
+
+    await expect(dialog(page)).toBeVisible()
+    await expect(dialog(page)).toContainText(String(t.length))
+  })
+
+  test('G2 — the confirm states the cascade and names archive as the reversible option', async ({
+    page,
+  }) => {
+    const t = targets()
+    await captureDeletes(page)
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await deleteBtn(page).click()
+
+    const blast = dialog(page)
+    await expect(blast).toBeVisible()
+    // What is destroyed — the cascade is the part an operator cannot see.
+    await expect(blast).toContainText(/comment/i)
+    await expect(blast).toContainText(/run/i)
+    await expect(blast).toContainText(/event/i)
+    // …and the recoverable alternative sitting next to the button they hit.
+    await expect(blast).toContainText(/archive/i)
+  })
+
+  test('G3 — Cancel fires nothing and keeps the selection intact', async ({ page }) => {
+    const t = targets()
+    const deletes = await captureDeletes(page)
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await deleteBtn(page).click()
+    await expect(dialog(page)).toBeVisible()
+
+    await page.locator('[role="dialog"] button', { hasText: /^Cancel$/ }).click()
+    await expect(dialog(page)).toHaveCount(0)
+    await page.waitForTimeout(300)
+    expect(deletes).toEqual([])
+
+    // The selection survives, so a mis-click costs nothing — the operator can
+    // still hit archive, which is what they usually meant.
+    await expect(deleteBtn(page)).toBeVisible()
+  })
+
+  test('G4 — Confirm stays disabled until the echo text matches', async ({ page }) => {
+    const t = targets()
+    const deletes = await captureDeletes(page)
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await deleteBtn(page).click()
+    await expect(dialog(page)).toBeVisible()
+
+    await expect(confirmBtn(page)).toBeDisabled()
+    await page.locator('[role="dialog"] input').fill('delet')
+    await expect(confirmBtn(page)).toBeDisabled()
+    // A forced click on the disabled control must still reach nothing.
+    await confirmBtn(page).click({ force: true })
+    await page.waitForTimeout(250)
+    expect(deletes).toEqual([])
+
+    await page.locator('[role="dialog"] input').fill('delete')
+    await expect(confirmBtn(page)).toBeEnabled()
+  })
+
+  test('G5 — confirming fires exactly one DELETE per selected id', async ({ page }) => {
+    const t = targets()
+    const deletes = await captureDeletes(page)
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await deleteBtn(page).click()
+    await page.locator('[role="dialog"] input').fill('delete')
+    await confirmBtn(page).click()
+
+    await expect.poll(() => deletes.length).toBe(t.length)
+    for (const x of t) {
+      expect(deletes.some((u) => u.includes(x.id))).toBe(true)
+    }
+    await expect(dialog(page)).toHaveCount(0)
+  })
+
+  test('G6 (guard) — archive is NOT gated; only the terminal action is', async ({
+    page,
+  }) => {
+    // Over-gating guard. `archive` is the reversible slot and is used
+    // constantly; putting a type-to-confirm in front of it would train
+    // operators to type through the dialog, which is how a guard stops
+    // working.
+    const t = targets()
+    const bulk: any[] = []
+    await page.route(/\/api\/board\/tasks\/bulk/, async (route: any) => {
+      if (route.request().method() === 'POST') {
+        bulk.push(route.request().postDataJSON())
+        await json(route, { updated: t.length })
+      } else {
+        await route.fallback()
+      }
+    })
+
+    await gotoBoardAndWait(page)
+    await selectCards(page, t.map((x: any) => x.id))
+    await page.locator('[data-testid="board-action-archive"]').click()
+
+    await expect.poll(() => bulk.length).toBeGreaterThan(0)
+    expect(bulk.some((b) => b.update?.status === 'archived')).toBe(true)
+    await expect(dialog(page)).toHaveCount(0)
+  })
+})

--- a/ui/tests/e2e/specs/board-bulk-v3.spec.ts
+++ b/ui/tests/e2e/specs/board-bulk-v3.spec.ts
@@ -149,7 +149,14 @@ test.describe('BoardView — bulk actions', () => {
     expect(bulkBodies.some(b => b.update?.status === 'archived')).toBe(true)
   })
 
-  test('bulk → delete: fires DELETE per selected id', async ({ page }) => {
+  // #1535: delete is no longer one-click. The button stages the selection into
+  // a destructive ConfirmDialog (type-to-confirm "delete") and only the
+  // dialog's confirm reaches the wire. The full guard contract — zero DELETEs
+  // before confirming, the cascade blast radius, cancel, and the disabled-until-
+  // matched button — lives in board-bulk-delete-guard-v3.spec.ts. This test
+  // keeps the per-id fan-out contract it always covered, now driven through
+  // the dialog.
+  test('bulk → delete: fires DELETE per selected id (via the confirm)', async ({ page }) => {
     const targets = BOARD_TASKS.filter(t => t.status === 'done').slice(0, 2)
     const deleteUrls: string[] = []
 
@@ -165,9 +172,11 @@ test.describe('BoardView — bulk actions', () => {
     await gotoBoardAndWait(page)
     await selectCards(page, targets.map(t => t.id))
     await page.locator('[data-testid="board-action-delete"]').click()
-    await page.waitForTimeout(300)
+    await expect(page.locator('[data-testid="board-delete-blast"]')).toBeVisible()
+    await page.locator('[role="dialog"] input').fill('delete')
+    await page.locator('[role="dialog"] button', { hasText: /^Delete \d+ card/ }).click()
 
-    expect(deleteUrls.length).toBeGreaterThanOrEqual(2)
+    await expect.poll(() => deleteUrls.length).toBeGreaterThanOrEqual(2)
     for (const t of targets) {
       expect(deleteUrls.some(u => u.includes(t.id))).toBe(true)
     }


### PR DESCRIPTION
## What changed

The board's bulk-toolbar `delete` button was wired straight to a per-id `DELETE /api/board/tasks/{id}`, which `store.delete_task()` executes as a hard SQL delete cascading comments, links, runs and events. The reversible `archive` button sits immediately to its left, so one slip destroyed N cards and their entire history with no acknowledgement and no undo.

- `ui/src/dash/board/board-view.jsx`: the delete button now stages the selection into a destructive `ConfirmDialog` (type-to-confirm `delete`), following the `DeleteSlotDialog` precedent. The dialog spells out the blast radius (permanent delete, cascade of comments/links/runs/events, no undo) and names `archive` as the recoverable alternative, plus a truncated list of the affected card ids/titles. Only the dialog's confirm reaches `delTasks`. Archive stays deliberately ungated.
- `ui/tests/e2e/specs/board-bulk-v3.spec.ts`: existing bulk-delete test now drives through the dialog and keeps its per-id fan-out contract.
- `ui/tests/e2e/specs/board-bulk-delete-guard-v3.spec.ts` (new): full guard contract — zero DELETEs on the wire before confirming (G1), cascade + archive copy (G2), cancel fires nothing and keeps the selection (G3), confirm disabled until the echo matches even under a forced click (G4), exactly one DELETE per selected id on confirm (G5), and archive is NOT gated (G6, over-gating guard).

## Why

This was the only remaining unguarded destructive multi-record action in the app; it now matches the established guard family (DeleteSlotDialog, secrets removal #1450, memory bank-wipe echo #1457).

Closes #1535

## How verified

- `npx playwright test tests/e2e/specs/board-bulk-v3.spec.ts tests/e2e/specs/board-bulk-delete-guard-v3.spec.ts` — 17 passed, 0 failed (mock mode, Vite webServer).
- `npx eslint` on the touched files — 0 errors (spec files are outside the eslint glob).

## Out of scope

No server-side change: the DELETE endpoint remains a hard delete; a soft-delete/undo window would be a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)