### PR TITLE
fix(activity): redact secrets in event messages and audit rows

### DIFF
--- a/src/hal0/activity/__init__.py
+++ b/src/hal0/activity/__init__.py
@@ -37,6 +37,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
+from hal0.redaction import redact_log_line, redact_text_tree
+
 __all__ = ["ActionRecorder", "AuditStore", "audit_action"]
 
 Kind = Literal["action", "event"]
@@ -117,7 +119,12 @@ def _now_iso() -> str:
 
 
 def _redact(value: Any) -> Any:
-    """Recursively replace secret-looking values so they never hit disk."""
+    """Recursively replace secret-looking values so they never hit disk.
+
+    Key-NAME strategy: a value is masked because of what its key is called.
+    Blind to a secret hiding in free text under an innocent key — see
+    :func:`_redact_text` for the complementary pass (#1523).
+    """
     if isinstance(value, dict):
         return {
             k: (_REDACTED if k.lower() in _SECRET_KEYS else _redact(v)) for k, v in value.items()
@@ -127,11 +134,21 @@ def _redact(value: Any) -> Any:
     return value
 
 
+def _redact_text(value: str | None) -> str | None:
+    """Scrub a free-text column, passing ``None`` through unchanged."""
+    return None if value is None else redact_log_line(value)
+
+
 def _dump(value: Any) -> str | None:
-    """JSON-encode a before/after blob (after redaction), or None."""
+    """JSON-encode a before/after blob (after redaction), or None.
+
+    Both strategies run: key-name masking first, then a text scan over what
+    survives. ``{"stderr": "curl -H 'Authorization: Bearer tok…'"}`` has no
+    sensitive KEY, so only the text pass catches it (#1523).
+    """
     if value is None:
         return None
-    return json.dumps(_redact(value), separators=(",", ":"), default=str)
+    return json.dumps(redact_text_tree(_redact(value)), separators=(",", ":"), default=str)
 
 
 @dataclass
@@ -214,10 +231,15 @@ class AuditStore:
                     actor,
                     severity,
                     outcome,
-                    message,
+                    # #1523: scrub free-text at the last moment before it is
+                    # durable. ``record_action`` writes here directly without
+                    # crossing the EventBus, so make_event's seam never sees
+                    # these two columns — and ``error`` is exactly where
+                    # audit_action parks a stringified exception.
+                    _redact_text(message),
                     _dump(before),
                     _dump(after),
-                    error,
+                    _redact_text(error),
                     duration_ms,
                     request_id,
                 ),

--- a/src/hal0/api/_redact.py
+++ b/src/hal0/api/_redact.py
@@ -22,16 +22,26 @@ Wired into every config-echoing endpoint (``/api/settings``,
 ``/api/config/models``, ``/api/upstreams``, …). See
 ``tests/api/test_redact.py`` for the contract.
 
-Also home to :func:`redact_log_line` — the TEXT-scanning counterpart
-used on free-text journald lines (``/api/logs``, ``/api/logs/stream``,
-the MCP ``logs_tail``/``slot_logs`` tools) where there's no key/value
-structure to walk. See that function's docstring for details.
+The TEXT-scanning counterpart — :func:`redact_log_line`, used on free-text
+journald lines (``/api/logs``, ``/api/logs/stream``, the MCP
+``logs_tail``/``slot_logs`` tools), event messages, and durable audit rows —
+now lives in the dependency-free :mod:`hal0.redaction` so layers *below* the
+API package (``hal0.events``, ``hal0.activity``) can reach it without an
+import cycle (#1523). It is re-exported here unchanged, so every existing
+``from hal0.api._redact import redact_log_line`` keeps working.
 """
 
 from __future__ import annotations
 
 import re
 from typing import Any, Final
+
+from hal0.redaction import (
+    LOG_SECRET_RE,
+    MASK,
+    redact_log_line,
+    redact_text_tree,
+)
 
 # Match by key NAME. Case-insensitive. ``(?:...)`` non-capturing group;
 # alternation ordered longest-token-first so e.g. ``PRIVATE_KEY`` wins
@@ -50,9 +60,9 @@ _SENSITIVE_RE: Final[re.Pattern[str]] = re.compile(
     r"(?i)(?:SECRET|TOKEN|PASSWORD|PASS|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|SALT|_KEY$|^KEY$)"
 )
 
-# Plain sentinel for masked values. Exposed via __all__ so a future
-# caller can grep logs / fixtures for the exact token.
-MASK: Final[str] = "***REDACTED***"
+# ``MASK`` is defined once in hal0.redaction and re-exported above — both
+# strategies must mask to the SAME sentinel or a caller grepping for it
+# would find only half the redactions.
 
 
 def is_sensitive_key(key: str) -> bool:
@@ -92,55 +102,6 @@ def redact_value(value: Any) -> dict[str, Any]:
 # ``redact_log_line`` from here so logs_tail and /api/logs share one
 # behaviour (api-logs-redact, surfaced by the SEC-mcp-clientid lane).
 #
-# Compiled once at import time. Each alternative ends with a
-# ``(?P<...>...)`` capture of just the secret token; ``redact_log_line``
-# rewrites that token to :data:`MASK` while leaving the surrounding
-# ``Authorization:``, ``Bearer``, ``HAL0_BEARER_TOKEN=``, ``client_id=``,
-# or ``<NAME>_KEY=``/``KEY=`` prefix in place so an operator reading a
-# redacted log still sees a secret WAS present. Case-insensitive; the
-# explicit alternatives are ordered most-to-least specific so the
-# precise header form wins over the bare ``Bearer`` fallback (Python's
-# ``re`` alternation is leftmost-wins inside a single match).
-#
-# The ``client_id=`` alternative is length-gated (16+ chars) so it
-# doesn't mask the short, non-secret labels client_id legitimately takes
-# (``anonymous``, the 12-hex-char hash). The ``<NAME>_KEY=``/``KEY=``
-# alternative mirrors is_sensitive_key's ``_KEY$``/``^KEY$`` suffix rule
-# so hal0's own admin/client keys (HAL0_ADMIN_KEY, HAL0_CLIENT_KEY, ...)
-# are caught if one is ever stamped into a log line verbatim, not just
-# in structured config — same conservative "over-redact" posture as
-# is_sensitive_key.
-LOG_SECRET_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?P<prefix_auth>Authorization:\s*Bearer\s+)(?P<auth_token>\S+)"
-    r"|(?P<prefix_env>HAL0_BEARER_TOKEN=)(?P<env_token>\S+)"
-    r"|(?P<prefix_bearer>Bearer\s+)(?P<bearer_token>[A-Za-z0-9_\-\.]+)"
-    r"|(?P<prefix_client_id>client_id=)(?P<client_id_token>[A-Za-z0-9_\-\.]{16,})"
-    r"|(?P<prefix_key>\b(?:[A-Za-z][A-Za-z0-9_]*_KEY|KEY)=)(?P<key_token>\S+)",
-    re.IGNORECASE,
-)
-
-
-def redact_log_line(line: str) -> str:
-    """Replace Bearer / HAL0_BEARER_TOKEN / long client_id / ``*_KEY=``
-    secrets in ``line`` with :data:`MASK`.
-
-    The prefix is preserved so an operator reading a redacted log still
-    sees that an Authorization header (or client_id / ``*_KEY`` field)
-    was present — only the token body is destroyed. For free-text log
-    lines; contrast with :func:`redact_config`, which walks structured
-    dict/list trees by key name.
-    """
-
-    def _sub(match: re.Match[str]) -> str:
-        groups = match.groupdict()
-        for prefix_group in ("prefix_auth", "prefix_env", "prefix_client_id", "prefix_key"):
-            if groups[prefix_group] is not None:
-                return f"{groups[prefix_group]}{MASK}"
-        return f"{groups['prefix_bearer']}{MASK}"
-
-    return LOG_SECRET_RE.sub(_sub, line)
-
-
 def redact_config(config: Any) -> Any:
     """Recursively scrub sensitive-keyed values from a config tree.
 
@@ -176,5 +137,6 @@ __all__ = [
     "is_sensitive_key",
     "redact_config",
     "redact_log_line",
+    "redact_text_tree",
     "redact_value",
 ]

--- a/src/hal0/events/__init__.py
+++ b/src/hal0/events/__init__.py
@@ -52,6 +52,8 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 
+from hal0.redaction import redact_log_line, redact_text_tree
+
 __all__ = ["EventBus", "Severity", "make_event"]
 
 _log = logging.getLogger("hal0.events")
@@ -81,15 +83,34 @@ def make_event(
     message: str,
     data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Build the canonical event dict. Exposed for tests + manual injection."""
+    """Build the canonical event dict. Exposed for tests + manual injection.
+
+    Secret redaction happens HERE (#1523) because this is the single choke
+    point every event crosses before it reaches the ring, the subscriber
+    queues, ``/api/events``, ``/api/journal``, or the durable AuditStore
+    sink. Redacting downstream instead would mean four filters that can
+    each drift; redacting here means a producer physically cannot put a
+    bearer token on any of those surfaces.
+
+    The concrete leak this closes: ``hal0.registry.pull`` builds its
+    failure message with ``f"{type(exc).__name__}: {exc}"``, so an httpx
+    error carrying an ``Authorization: Bearer …`` header or an
+    ``HF_TOKEN=…`` query string rode verbatim into ``pull.failed`` and
+    from there into ``activity.db`` — at rest, on an endpoint that is
+    unauthenticated in the shipped LAN posture.
+
+    Only string CONTENT is touched: :func:`redact_text_tree` preserves
+    every key, type, and shape, so consumers routing on ``data["slot"]``
+    or ``data["model"]`` are unaffected.
+    """
     return {
         "id": event_id,
         "ts": _now_iso(),
         "type": type,
         "severity": severity,
         "source": source,
-        "message": message,
-        "data": dict(data) if data else {},
+        "message": redact_log_line(message),
+        "data": redact_text_tree(dict(data)) if data else {},
     }
 
 

--- a/src/hal0/redaction.py
+++ b/src/hal0/redaction.py
@@ -1,0 +1,124 @@
+"""Dependency-free secret redaction primitives (issues #553, #1523).
+
+This module is the *bottom* of the redaction stack: it imports nothing from
+hal0 and may therefore be used from any layer, including ``hal0.events`` and
+``hal0.activity``, which sit below the API package and cannot import
+:mod:`hal0.api._redact` without a cycle.
+
+Two complementary strategies live here:
+
+``redact_log_line``
+    TEXT scanning. For free-text where there is no key/value structure to
+    walk — journald lines, exception strings, event messages. Matches on
+    the *shape* of the secret (``Authorization: Bearer …``,
+    ``HAL0_BEARER_TOKEN=…``, a long ``client_id=…``, ``<NAME>_KEY=…``) and
+    destroys only the token body, leaving the prefix so an operator reading
+    a redacted log still sees a secret WAS present.
+
+``redact_text_tree``
+    The same text scan applied recursively to every string in a structured
+    value, without touching keys, types, or shape. Structured ``data``
+    blobs are half text: ``{"error": "HTTPStatusError: Bearer tok…"}`` hides
+    a secret under an entirely innocent key name, so key-name redaction
+    alone (:func:`hal0.api._redact.redact_config`) cannot see it.
+
+Key-NAME redaction (``is_sensitive_key`` / ``redact_config`` /
+``redact_value``) stays in :mod:`hal0.api._redact`, which re-exports
+everything here so existing importers keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Final
+
+# Plain sentinel for masked values. Exposed so a caller can grep logs /
+# fixtures for the exact token.
+MASK: Final[str] = "***REDACTED***"
+
+# Compiled once at import time. Each alternative ends with a
+# ``(?P<...>...)`` capture of just the secret token; ``redact_log_line``
+# rewrites that token to :data:`MASK` while leaving the surrounding
+# ``Authorization:``, ``Bearer``, ``HAL0_BEARER_TOKEN=``, ``client_id=``,
+# or ``<NAME>_KEY=``/``KEY=`` prefix in place so an operator reading a
+# redacted log still sees a secret WAS present. Case-insensitive; the
+# explicit alternatives are ordered most-to-least specific so the
+# precise header form wins over the bare ``Bearer`` fallback (Python's
+# ``re`` alternation is leftmost-wins inside a single match).
+#
+# The ``client_id=`` alternative is length-gated (16+ chars) so it
+# doesn't mask the short, non-secret labels client_id legitimately takes
+# (``anonymous``, the 12-hex-char hash). The ``<NAME>_KEY=``/``KEY=``
+# alternative mirrors is_sensitive_key's ``_KEY$``/``^KEY$`` suffix rule
+# so hal0's own admin/client keys (HAL0_ADMIN_KEY, HAL0_CLIENT_KEY, ...)
+# are caught if one is ever stamped into a log line verbatim, not just
+# in structured config — same conservative "over-redact" posture as
+# is_sensitive_key.
+LOG_SECRET_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?P<prefix_auth>Authorization:\s*Bearer\s+)(?P<auth_token>\S+)"
+    r"|(?P<prefix_env>HAL0_BEARER_TOKEN=)(?P<env_token>\S+)"
+    r"|(?P<prefix_bearer>Bearer\s+)(?P<bearer_token>[A-Za-z0-9_\-\.]+)"
+    r"|(?P<prefix_client_id>client_id=)(?P<client_id_token>[A-Za-z0-9_\-\.]{16,})"
+    r"|(?P<prefix_key>\b(?:[A-Za-z][A-Za-z0-9_]*_KEY|KEY)=)(?P<key_token>\S+)",
+    re.IGNORECASE,
+)
+
+
+def redact_log_line(line: str) -> str:
+    """Replace Bearer / HAL0_BEARER_TOKEN / long client_id / ``*_KEY=``
+    secrets in ``line`` with :data:`MASK`.
+
+    The prefix is preserved so an operator reading a redacted log still
+    sees that an Authorization header (or client_id / ``*_KEY`` field)
+    was present — only the token body is destroyed. For free-text log
+    lines; contrast with ``redact_config``, which walks structured
+    dict/list trees by key name.
+
+    Idempotent: :data:`MASK` contains no character that any alternative
+    matches, so re-running over already-redacted text is a no-op. That
+    matters because the same string can cross more than one seam
+    (emit-time redaction, then again at the durable write).
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        groups = match.groupdict()
+        for prefix_group in ("prefix_auth", "prefix_env", "prefix_client_id", "prefix_key"):
+            if groups[prefix_group] is not None:
+                return f"{groups[prefix_group]}{MASK}"
+        return f"{groups['prefix_bearer']}{MASK}"
+
+    return LOG_SECRET_RE.sub(_sub, line)
+
+
+def redact_text_tree(value: Any) -> Any:
+    """Apply :func:`redact_log_line` to every string inside ``value``.
+
+    Walks dicts (values only — keys are structural and never carry the
+    secret body), lists, and tuples; returns scalars untouched. Shape,
+    types, key names, and ordering are preserved exactly, because
+    consumers route on structured fields: ``data["slot"]`` picks the slot
+    a journal entry belongs to, ``data["model"]`` the activity target.
+    A redaction that reshaped those would break routing rather than
+    protect it.
+
+    Pure — does not mutate the input. Complements key-name redaction
+    rather than replacing it: this catches a secret hiding in the VALUE
+    under an innocent key, that one catches a secret whose KEY names it.
+    """
+    if isinstance(value, str):
+        return redact_log_line(value)
+    if isinstance(value, dict):
+        return {k: redact_text_tree(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_text_tree(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(redact_text_tree(v) for v in value)
+    return value
+
+
+__all__ = [
+    "LOG_SECRET_RE",
+    "MASK",
+    "redact_log_line",
+    "redact_text_tree",
+]

--- a/tests/activity/test_journal_activity_redaction.py
+++ b/tests/activity/test_journal_activity_redaction.py
@@ -1,0 +1,199 @@
+"""Secret redaction on the journal / events / activity pipes (issue #1523).
+
+``/api/logs`` has scrubbed free-text journald lines through
+:func:`hal0.redaction.redact_log_line` since the SEC-mcp-clientid review.
+The sibling pipes never got the same treatment: ``EventBus`` messages flow
+verbatim into ``/api/events``, ``/api/journal``, and — via the AuditStore
+sink — the durable ``activity.db``. Producers that stringify an exception
+(``f"{type(exc).__name__}: {exc}"`` in ``hal0.registry.pull``) can therefore
+put a bearer token or ``*_KEY=`` value at rest in a database served over an
+unauthenticated LAN endpoint.
+
+These tests pin the seam at the two write boundaries:
+
+  * :func:`hal0.events.make_event` — the single choke point every event
+    passes through before it reaches the ring, subscribers, or the sink.
+  * :meth:`hal0.activity.AuditStore.record` — the direct-write path used by
+    ``record_action`` for API mutations, which never goes through the bus.
+
+The existing key-name redaction on ``before``/``after`` blobs is orthogonal
+and must keep working; text redaction is additive.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hal0.activity import AuditStore
+from hal0.events import make_event
+from hal0.redaction import MASK
+
+# A representative secret of each shape LOG_SECRET_RE knows about, paired
+# with the fragment that must NOT survive redaction.
+SECRET_LINES: list[tuple[str, str]] = [
+    ("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9-supersecret", "eyJhbGciOiJIUzI1NiJ9-supersecret"),
+    ("pull failed: HAL0_BEARER_TOKEN=tok_live_abcdefghijklmnop", "tok_live_abcdefghijklmnop"),
+    ("GET /v1/models?client_id=abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"),
+    ("env HF_TOKEN_KEY=hf_QQQQwwwweeeerrrrtttt rejected", "hf_QQQQwwwweeeerrrrtttt"),
+]
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> AuditStore:
+    s = AuditStore(tmp_path / "activity.db", retention_days=30, max_rows=None)
+    s.init_schema()
+    return s
+
+
+# ── make_event: the shared emit-boundary seam ────────────────────────────────
+
+
+@pytest.mark.parametrize(("line", "secret"), SECRET_LINES)
+def test_make_event_redacts_secrets_in_message(line: str, secret: str) -> None:
+    """A secret in an event message never reaches the ring, /api/events, or the sink."""
+    event = make_event(1, type="pull.failed", severity="error", source="registry", message=line)
+    assert secret not in event["message"]
+    assert MASK in event["message"]
+
+
+@pytest.mark.parametrize(("line", "secret"), SECRET_LINES)
+def test_make_event_redacts_secrets_in_data_strings(line: str, secret: str) -> None:
+    """Structured ``data`` string values are scrubbed too — /api/journal spreads
+    the whole ``data`` dict into the served entry."""
+    event = make_event(
+        1,
+        type="pull.failed",
+        severity="error",
+        source="registry",
+        message="pull failed",
+        data={"error": line, "nested": {"detail": line}, "items": [line]},
+    )
+    assert secret not in str(event["data"])
+    assert MASK in event["data"]["error"]
+    assert MASK in event["data"]["nested"]["detail"]
+    assert MASK in event["data"]["items"][0]
+
+
+def test_make_event_preserves_non_secret_data_shape() -> None:
+    """Redaction must not change types, keys, or ordering — consumers read
+    ``data.slot`` / ``data.model`` for routing."""
+    event = make_event(
+        7,
+        type="slot.state",
+        severity="info",
+        source="slot:agent",
+        message="slot agent is ready",
+        data={"slot": "agent", "port": 8082, "ready": True, "tps": 41.5, "tags": ["a", "b"]},
+    )
+    assert event["message"] == "slot agent is ready"
+    assert event["data"] == {
+        "slot": "agent",
+        "port": 8082,
+        "ready": True,
+        "tps": 41.5,
+        "tags": ["a", "b"],
+    }
+    assert event["id"] == 7
+    assert event["type"] == "slot.state"
+
+
+def test_make_event_redaction_is_idempotent() -> None:
+    """Re-redacting an already-masked message is a no-op (defence in depth
+    means the same text may pass more than one seam)."""
+    once = make_event(1, type="t", severity="info", source="s", message="Bearer abcdef123456")
+    twice = make_event(2, type="t", severity="info", source="s", message=once["message"])
+    assert once["message"] == twice["message"]
+
+
+# ── AuditStore: the durable direct-write path ────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("line", "secret"), SECRET_LINES)
+async def test_record_redacts_message_at_rest(store: AuditStore, line: str, secret: str) -> None:
+    """``record_action``'s free-text message is scrubbed before it hits sqlite."""
+    await store.record(kind="action", category="model", action="model.pull", message=line)
+    rows = store.query(limit=10)
+    assert secret not in rows[0]["message"]
+    assert MASK in rows[0]["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("line", "secret"), SECRET_LINES)
+async def test_record_redacts_error_at_rest(store: AuditStore, line: str, secret: str) -> None:
+    """``audit_action`` stores the stringified exception in ``error`` — the
+    exact field ``hal0.registry.pull`` fills with ``f"{type(exc).__name__}: {exc}"``."""
+    await store.record(
+        kind="action", category="model", action="model.pull", outcome="error", error=line
+    )
+    rows = store.query(limit=10)
+    assert secret not in (rows[0]["error"] or "")
+    assert MASK in (rows[0]["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_record_redacts_secret_text_inside_after_blob(store: AuditStore) -> None:
+    """Key-name redaction misses a secret embedded in a free-text VALUE under a
+    harmless key — text redaction must cover it."""
+    await store.record(
+        kind="action",
+        category="model",
+        action="model.pull",
+        after={"stderr": "curl -H 'Authorization: Bearer tok_abcdef123456' failed"},
+    )
+    rows = store.query(limit=10)
+    assert "tok_abcdef123456" not in str(rows[0]["after"])
+
+
+@pytest.mark.asyncio
+async def test_record_keeps_key_name_redaction(store: AuditStore) -> None:
+    """The pre-existing key-name masking on before/after must not regress."""
+    await store.record(
+        kind="action",
+        category="provider",
+        action="upstream.create",
+        after={"name": "openrouter", "api_key": "sk-or-v1-plaintext"},
+    )
+    rows = store.query(limit=10)
+    assert "sk-or-v1-plaintext" not in str(rows[0]["after"])
+    assert json.loads(rows[0]["after"])["name"] == "openrouter"
+
+
+@pytest.mark.asyncio
+async def test_secret_never_reaches_the_sqlite_file(store: AuditStore, tmp_path: Path) -> None:
+    """End-to-end: grep the raw database file — nothing readable survives."""
+    secret = "tok_live_never_at_rest_0001"
+    await store.record(
+        kind="action",
+        category="model",
+        action="model.pull",
+        message=f"pull failed: HAL0_BEARER_TOKEN={secret}",
+        error=f"HTTPStatusError: Bearer {secret}",
+        after={"stderr": f"HAL0_BEARER_TOKEN={secret}"},
+    )
+    conn = sqlite3.connect(store.db_path)
+    try:
+        blob = "".join(str(r) for r in conn.execute("SELECT * FROM audit").fetchall())
+    finally:
+        conn.close()
+    assert secret not in blob
+
+
+@pytest.mark.asyncio
+async def test_record_event_redacts_via_the_shared_seam(store: AuditStore) -> None:
+    """An event mirrored into the durable store carries no secret either."""
+    event = make_event(
+        1,
+        type="pull.failed",
+        severity="error",
+        source="registry",
+        message="HTTPStatusError: Bearer tok_abcdef123456",
+        data={"error": "HAL0_BEARER_TOKEN=tok_abcdef123456"},
+    )
+    await store.record_event(event)
+    rows = store.query(limit=10)
+    assert "tok_abcdef123456" not in str(rows[0])


### PR DESCRIPTION
**Security-relevant — human review required before merge.**

## What changed

Closes the redaction gap tracked in #1523: free-text event messages and AuditStore rows reached `activity.db` unredacted, unlike `/api/logs`, which has scrubbed journald lines since the SEC-mcp-clientid review. A producer that stringifies an exception (`hal0.registry.pull` builds its failure message with `f"{type(exc).__name__}: {exc}"`) could put a bearer token or `*_KEY=` value at rest in a database served over an unauthenticated LAN endpoint.

- New dependency-free `hal0.redaction` module holding `redact_log_line`, `LOG_SECRET_RE`, `MASK`, and a new `redact_text_tree` (the same text scan applied recursively to every string in a structured value, preserving keys, types, and shape). The module sits below the API package so `hal0.events` and `hal0.activity` can import it without a cycle.
- `hal0.api._redact` re-exports everything unchanged, so every existing `from hal0.api._redact import redact_log_line` keeps working; key-name redaction (`is_sensitive_key` / `redact_config` / `redact_value`) stays where it was.
- Both write boundaries are wired:
  - `hal0.events.make_event` — the single choke point every event crosses before the ring, subscriber queues, `/api/events`, `/api/journal`, and the AuditStore sink — now scrubs `message` and all string values inside `data`.
  - `hal0.activity.AuditStore.record` — the direct-write path used by `record_action`, which never crosses the bus — now scrubs `message`, `error`, and applies `redact_text_tree` to the `before`/`after` blobs on top of the existing key-name masking.

Redaction is idempotent, so text crossing both seams is not double-mangled.

## Why

Refs #1523. Secrets at rest in `activity.db` outlive log rotation and are served over an endpoint that is unauthenticated in the shipped LAN posture.

## How verified

- New `tests/activity/test_journal_activity_redaction.py`: parametrized over every secret shape `LOG_SECRET_RE` knows, covering `make_event` message/data redaction, shape preservation, idempotence, `AuditStore.record` message/error/blob redaction, key-name regression, and an end-to-end grep of the raw sqlite file.
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/activity/ tests/api/test_redact.py tests/api/test_slot_logs_stream_redact.py tests/api/test_logs_routes.py tests/mcp/test_logs_tail_redaction.py -x -q` — 117 passed, 1 skipped (journalctl-follow skip, pre-existing).
- `ruff check` clean on all touched files.

## Out of scope

- Redaction of other producers' payloads beyond string content (binary blobs are untouched).
- Retroactive scrubbing of existing `activity.db` rows written before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)