### PR TITLE
fix(stacks): resolve slot stems by display name on id-keyed boxes

### DIFF
--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -39,6 +39,7 @@ from hal0.config.schema import StackConfig
 from hal0.errors import BadRequest
 from hal0.model_meta import DEVICE_TO_DEFAULT_PROFILE
 from hal0.profiles import ProfileCatalog
+from hal0.slots.layout import resolve_slot_stem
 from hal0.stacks import ResolvedStack, StacksCatalog
 from hal0.stacks.apply import StackApplyEngine
 from hal0.stacks.portable import (
@@ -154,7 +155,16 @@ def _registry(request: Request) -> Any:
 
 
 def _slot_toml_exists(slot: str) -> bool:
-    return (paths.slots_config_dir() / f"{slot}.toml").exists()
+    """Does this box already have the slot a stack entry names? (#1510)
+
+    Resolved through the bilingual layout seam, not ``f"{slot}.toml"``: a
+    stack addresses slots by display name, and on an id-keyed box that name
+    lives under a digit stem (``agent`` → ``1.toml``). The raw f-string
+    reported every live slot missing, which made ``_create_missing_slots``
+    clone all sixteen of them alongside the originals — the duplicate-slot
+    state #1422 reports.
+    """
+    return resolve_slot_stem(paths.slots_config_dir(), slot) is not None
 
 
 def _missing_slot_names(cfg: StackConfig) -> list[str]:
@@ -244,14 +254,22 @@ def _known_model_ids(request: Request) -> set[str]:
 
 
 def _diff_rows(plan: Any) -> list[dict[str, Any]]:
-    """Per-slot before→after model summary for the dry-run preview UI."""
+    """Per-slot before→after model summary for the dry-run preview UI.
+
+    ``slot`` is the DISPLAY name from ``plan.slot_names`` (#1510) — labelling
+    rows with ``after.path.stem`` listed an id-keyed box's slots to the
+    operator as ``1`` / ``13`` instead of ``agent`` / ``rerank``.
+    """
     rows: list[dict[str, Any]] = []
-    for before, after in zip(plan.change_set.before, plan.change_set.after, strict=True):
+    names = getattr(plan, "slot_names", ()) or ()
+    for i, (before, after) in enumerate(
+        zip(plan.change_set.before, plan.change_set.after, strict=True)
+    ):
         b_model = (before.data or {}).get("model", {}).get("default") if before.data else None
         a_model = (after.data or {}).get("model", {}).get("default") if after.data else None
         rows.append(
             {
-                "slot": after.path.stem,
+                "slot": names[i] if i < len(names) else after.path.stem,
                 "before_model": b_model,
                 "after_model": a_model,
                 "changed": before.data != after.data,

--- a/src/hal0/slots/layout.py
+++ b/src/hal0/slots/layout.py
@@ -10,16 +10,25 @@ Historically the stem was always the slot's mutable ``name``. The M5 id-flip
 artefacts to the stable opaque ``id`` — so a converged box carries a mix while
 a migration rolls forward, and every reader must accept BOTH shapes.
 
-These are pure functions (no I/O beyond ``Path`` composition and a directory
-glob) so the loader, the manager, and their tests share one classification
-rule. The HARD INVARIANT they encode: a *digit-only* stem is an id key; every
-other stem is a name key. An id key never collides with a name because slot
-ids are SQLite ``AUTOINCREMENT`` integers (>= 1) and slot names are never
-all-digit.
+These are pure functions (no I/O beyond ``Path`` composition, a directory
+glob, and — for the name→stem resolver — reading the slot TOMLs themselves) so
+the loader, the manager, and their tests share one classification rule. The
+HARD INVARIANT they encode: a *digit-only* stem is an id key; every other stem
+is a name key. An id key never collides with a name because slot ids are
+SQLite ``AUTOINCREMENT`` integers (>= 1) and slot names are never all-digit.
+
+:func:`resolve_slot_stem` closes the other half of the seam: callers that hold
+a slot's *display name* (a stack entry, a capability selection, an operator
+request) and need the on-disk stem. It works from the file's own embedded
+``name`` — ``loader.save_slot_config`` guarantees every bilingual writer emits
+it precisely so a reader can recover the display name WITHOUT the identity DB,
+which is what lets the stacks dry-run path resolve slots with no SlotManager
+wired.
 """
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 
@@ -61,9 +70,84 @@ def classify_layout(config_dir: Path | str) -> dict[str, str]:
     return out
 
 
+def read_slot_display_name(path: Path) -> str | None:
+    """The display name embedded in one slot TOML, or ``None``.
+
+    Accepts BOTH on-disk shapes: the flat body the runtime writes (top-level
+    ``name``) and the legacy nested one (``[slot] name``). An unreadable or
+    unparseable file yields ``None`` rather than raising — a single corrupt
+    TOML must never break enumeration for the rest.
+
+    A digit ``name`` is rejected (``None``): a slot name is never all-digit, so
+    a digit there means the file was written by something that confused the id
+    for the name, and honouring it would let an id-keyed stem masquerade as a
+    display name.
+    """
+    try:
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    name = raw.get("name")
+    if not isinstance(name, str):
+        section = raw.get("slot")
+        name = section.get("name") if isinstance(section, dict) else None
+    if not isinstance(name, str) or not name or is_id_stem(name):
+        return None
+    return name
+
+
+def slot_stems_by_name(config_dir: Path | str) -> dict[str, str]:
+    """Map each slot's display name to its on-disk stem.
+
+    On a name-keyed box this is the identity map. On an id-keyed box it is
+    ``{"agent": "1", "rerank": "13", ...}``. Dotfiles (atomic-write
+    temporaries) are skipped. A file whose display name cannot be recovered is
+    omitted — it is still reachable by stem.
+
+    First writer wins on a duplicate display name (stems are visited sorted),
+    which keeps the mapping deterministic while a rename is half-applied.
+    """
+    d = Path(config_dir)
+    if not d.exists():
+        return {}
+    out: dict[str, str] = {}
+    for p in sorted(d.glob("*.toml")):
+        if p.name.startswith("."):
+            continue
+        name = read_slot_display_name(p)
+        if name is not None and name not in out:
+            out[name] = p.stem
+    return out
+
+
+def resolve_slot_stem(config_dir: Path | str, key: str) -> str | None:
+    """The on-disk stem for a slot addressed by display name OR stem.
+
+    ``None`` when no such slot exists — callers distinguish "this slot lives
+    under a different stem" from "this slot must be created".
+
+    Stem-first: a file literally named ``<key>.toml`` wins, so a name-keyed box
+    (and every caller that already holds a stem) resolves with a single
+    ``exists()`` and never reads a TOML. Only when that misses do we fall back
+    to the display-name index — which is the id-keyed case.
+    """
+    if not key:
+        return None
+    d = Path(config_dir)
+    if (d / f"{key}.toml").exists():
+        return key
+    return slot_stems_by_name(d).get(key)
+
+
 __all__ = [
     "classify_layout",
     "is_id_stem",
+    "read_slot_display_name",
+    "resolve_slot_stem",
     "slot_state_path",
+    "slot_stems_by_name",
     "slot_toml_path",
 ]

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -24,6 +24,7 @@ from hal0.config.schema import StackConfig, StackSlotEntry
 from hal0.errors import BadRequest
 from hal0.model_meta import canonical_device
 from hal0.slot_config import ChangeSet, FileState, SlotConfigStore
+from hal0.slots.layout import resolve_slot_stem
 from hal0.slots.manager import reconcile_and_guard_slot_config
 from hal0.slots.state import (
     DISPATCHABLE_STATES,
@@ -72,6 +73,12 @@ class StackChangePlan:
     change_set: ChangeSet
     summary: list[str]
     errors: list[tuple[str, str]] = field(default_factory=list)
+    # Display names, positionally parallel to ``change_set.before/after``
+    # (#1510). The ChangeSet addresses files by STEM, which on an id-keyed box
+    # is a digit ("1"), not the slot's name ("agent"). Anything that labels a
+    # row for a human, or keys a projection a StackConfig will later be
+    # compared against, must use THIS list — never ``FileState.path.stem``.
+    slot_names: tuple[str, ...] = ()
 
 
 # Slot states by convergence intent.
@@ -136,9 +143,27 @@ class StackApplyEngine:
         self._slot_manager = slot_manager
         self._orchestrator = orchestrator
 
+    def _slots_base(self) -> Path:
+        return self._slots_dir or paths.slots_config_dir()
+
+    def _slot_stem(self, slot_name: str) -> str:
+        """The on-disk stem for a stack entry's slot (#1510).
+
+        A stack entry addresses a slot by its *display name* — that is the
+        portable identity, and it is what ``SlotManager.load/swap/unload`` and
+        ``capabilities.toml`` already speak. The on-disk stem is this box's
+        storage detail: the same name on an id-keyed box lives at ``1.toml``.
+        Resolving through the layout seam is what makes snapshot→apply
+        round-trip instead of manufacturing a duplicate slot.
+
+        Falls back to the name itself when nothing resolves, so a slot the
+        stack names but the box doesn't have yet still gets the name-keyed
+        creation path the create-on-apply flow expects.
+        """
+        return resolve_slot_stem(self._slots_base(), slot_name) or slot_name
+
     def _slot_path(self, slot_name: str) -> Path:
-        base = self._slots_dir or paths.slots_config_dir()
-        return base / f"{slot_name}.toml"
+        return self._slots_base() / f"{self._slot_stem(slot_name)}.toml"
 
     # ── plan (compute-only) ──────────────────────────────────────────────────
 
@@ -161,22 +186,25 @@ class StackApplyEngine:
         """
         befores: list[FileState] = []
         afters: list[FileState] = []
+        slot_names: list[str] = []
         summary: list[str] = []
         errors: list[tuple[str, str]] = []
 
         for entry in stack.slots:
             if not entry.model:
                 continue
-            path = self._slot_path(entry.slot)
+            stem = self._slot_stem(entry.slot)
+            path = self._slots_base() / f"{stem}.toml"
             before = _read_toml_or_none(path)
             try:
-                after = self._reconciled_stack_slot(before, entry)
+                after = self._reconciled_stack_slot(before, entry, stem)
             except (SlotConfigError, NpuExclusivityViolation, BadRequest) as exc:
                 errors.append((entry.slot, str(exc)))
                 summary.append(f"{entry.slot}: rejected — {exc}")
                 after = before
             befores.append(FileState(path=path, data=before))
             afters.append(FileState(path=path, data=after))
+            slot_names.append(entry.slot)
             if before != after:
                 summary.append(self._summarize(entry.slot, before, after))
 
@@ -185,6 +213,7 @@ class StackApplyEngine:
             change_set=ChangeSet(before=tuple(befores), after=tuple(afters)),
             summary=summary,
             errors=errors,
+            slot_names=tuple(slot_names),
         )
 
     def validate(
@@ -212,7 +241,7 @@ class StackApplyEngine:
         return warnings
 
     def _reconciled_stack_slot(
-        self, before: dict[str, Any] | None, entry: StackSlotEntry
+        self, before: dict[str, Any] | None, entry: StackSlotEntry, stem: str | None = None
     ) -> dict[str, Any] | None:
         """Project a stack slot entry onto the existing slot TOML dict.
 
@@ -231,6 +260,13 @@ class StackApplyEngine:
         violations raise and :meth:`plan` records them per-slot. Returns
         ``before`` unchanged when the slot file is absent (creation is out
         of 2a scope).
+
+        ``stem`` is the slot's ON-DISK stem (#1510). The cross-slot guards
+        exclude the slot's own file from its peer set by comparing against
+        ``path.stem``, so passing the display name on an id-keyed box made a
+        slot conflict with ITSELF (its ``1.toml`` never matched ``"agent"``)
+        and rejected its own plan. Defaults to ``entry.slot`` for the
+        name-keyed case, where the two are the same string.
         """
         if before is None:
             return None
@@ -259,7 +295,7 @@ class StackApplyEngine:
             updates["server"] = {"extra_args": entry.server_extra_args}
 
         return reconcile_and_guard_slot_config(
-            entry.slot, before, updates, slots_dir=self._slots_dir
+            stem or entry.slot, before, updates, slots_dir=self._slots_dir
         )
 
     @staticmethod
@@ -291,8 +327,25 @@ class StackApplyEngine:
     # ── drift / active pointer ───────────────────────────────────────────────
 
     def _projection_from_plan(self, plan: StackChangePlan) -> dict[str, Any]:
-        """The slot→after-dict projection a plan would write (keyed by slot name)."""
-        return {fs.path.stem: fs.data for fs in plan.change_set.after}
+        """The slot→after-dict projection a plan would write, keyed by DISPLAY NAME.
+
+        Must use ``plan.slot_names`` and not ``fs.path.stem`` (#1510): the
+        counterpart :meth:`_projection_live` keys by ``entry.slot``, so on an
+        id-keyed box a stem-keyed fingerprint (``{"1": ...}``) could never
+        match the name-keyed projection it is compared against (``{"agent":
+        ...}``) and every applied stack reported ``modified`` immediately.
+
+        No migration is needed for already-recorded fingerprints: on a
+        name-keyed box the stem IS the display name, so the key space is
+        byte-identical; on an id-keyed box the old fingerprint never matched
+        anything anyway.
+        """
+        after = plan.change_set.after
+        if len(plan.slot_names) == len(after):
+            return dict(zip(plan.slot_names, (fs.data for fs in after), strict=True))
+        # Defensive: a hand-built plan with no slot_names (older callers/tests)
+        # keeps the legacy stem keying rather than silently mis-pairing.
+        return {fs.path.stem: fs.data for fs in after}
 
     def _projection_live(self, stack: StackConfig) -> dict[str, Any]:
         """The slot→current-disk-dict projection for a stack's primary slots."""

--- a/tests/slots/test_layout.py
+++ b/tests/slots/test_layout.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from hal0.slots.layout import (
     classify_layout,
     is_id_stem,
+    read_slot_display_name,
+    resolve_slot_stem,
     slot_state_path,
+    slot_stems_by_name,
     slot_toml_path,
 )
 
@@ -55,3 +58,53 @@ def test_classify_layout_mixed_tree(tmp_path: Path) -> None:
 
 def test_classify_layout_absent_dir(tmp_path: Path) -> None:
     assert classify_layout(tmp_path / "nope") == {}
+
+
+# ── name→stem resolution (#1510) ─────────────────────────────────────────────
+
+
+def test_read_slot_display_name_flat_and_nested(tmp_path: Path) -> None:
+    (tmp_path / "1.toml").write_text('name = "agent"\nport = 8087\n', encoding="utf-8")
+    (tmp_path / "2.toml").write_text('[slot]\nname = "code"\n', encoding="utf-8")
+    assert read_slot_display_name(tmp_path / "1.toml") == "agent"
+    assert read_slot_display_name(tmp_path / "2.toml") == "code"
+
+
+def test_read_slot_display_name_tolerates_junk(tmp_path: Path) -> None:
+    (tmp_path / "bad.toml").write_text("this is not = = toml\n", encoding="utf-8")
+    (tmp_path / "nameless.toml").write_text("port = 1\n", encoding="utf-8")
+    # A digit name is refused: a slot name is never all-digit, and honouring one
+    # would let an id stem masquerade as a display name.
+    (tmp_path / "digit.toml").write_text('name = "143"\n', encoding="utf-8")
+    assert read_slot_display_name(tmp_path / "bad.toml") is None
+    assert read_slot_display_name(tmp_path / "nameless.toml") is None
+    assert read_slot_display_name(tmp_path / "digit.toml") is None
+    assert read_slot_display_name(tmp_path / "absent.toml") is None
+
+
+def test_slot_stems_by_name_id_keyed_box(tmp_path: Path) -> None:
+    (tmp_path / "1.toml").write_text('name = "agent"\n', encoding="utf-8")
+    (tmp_path / "13.toml").write_text('name = "rerank"\n', encoding="utf-8")
+    (tmp_path / ".1.toml.tmp").write_text('name = "half"\n', encoding="utf-8")
+    assert slot_stems_by_name(tmp_path) == {"agent": "1", "rerank": "13"}
+
+
+def test_resolve_slot_stem_prefers_a_literal_stem(tmp_path: Path) -> None:
+    # A name-keyed box, and any caller that already holds a stem, resolve
+    # without reading a single TOML.
+    (tmp_path / "brain.toml").write_text('name = "brain"\n', encoding="utf-8")
+    (tmp_path / "1.toml").write_text('name = "agent"\n', encoding="utf-8")
+    assert resolve_slot_stem(tmp_path, "brain") == "brain"
+    assert resolve_slot_stem(tmp_path, "1") == "1"
+
+
+def test_resolve_slot_stem_finds_an_id_keyed_slot_by_display_name(tmp_path: Path) -> None:
+    (tmp_path / "1.toml").write_text('name = "agent"\n', encoding="utf-8")
+    assert resolve_slot_stem(tmp_path, "agent") == "1"
+
+
+def test_resolve_slot_stem_absent_is_none(tmp_path: Path) -> None:
+    (tmp_path / "1.toml").write_text('name = "agent"\n', encoding="utf-8")
+    assert resolve_slot_stem(tmp_path, "quick") is None
+    assert resolve_slot_stem(tmp_path, "") is None
+    assert resolve_slot_stem(tmp_path / "nope", "agent") is None

--- a/tests/stacks/test_id_keyed_roundtrip.py
+++ b/tests/stacks/test_id_keyed_roundtrip.py
@@ -115,7 +115,10 @@ class TestSnapshotApplyRoundTrip:
         touched = {fs.path for fs in plan.change_set.after}
         assert touched == {path}, f"apply must address the id-keyed file, got {touched}"
         assert plan.errors == []
-        assert any(fs.data != b.data for b, fs in zip(plan.change_set.before, plan.change_set.after))
+        assert any(
+            fs.data != b.data
+            for b, fs in zip(plan.change_set.before, plan.change_set.after, strict=True)
+        )
 
     def test_apply_commits_onto_the_id_keyed_file_and_creates_no_duplicate(
         self, reg: ModelRegistry, tmp_hal0_home: str
@@ -170,10 +173,15 @@ class TestGuardsExcludeTheSlotItself:
         plan = StackApplyEngine().plan("live", _stack())
         assert plan.errors == [], f"the slot conflicted with itself: {plan.errors}"
 
-    def test_default_uniqueness_still_fires_against_a_real_peer(self, tmp_hal0_home: str) -> None:
-        """The guard must keep its teeth — a genuine second default=true peer is
-        still rejected when both slots are id-keyed. ``default`` is not a stack
-        field, so it reaches the merged config from the slot's own TOML."""
+    def test_stale_duplicate_default_state_does_not_veto_the_apply(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """SC-4 ``changed_keys`` semantics: ``default`` is not a stack field,
+        so a stack apply never moves the default-uniqueness invariant — and a
+        pre-existing two-defaults-on-disk state it neither created nor touches
+        must not veto it (``check_default_uniqueness`` skips when the write
+        carries no ``default`` key). This holds identically on an id-keyed
+        box: the plan reconciles, and the model change lands."""
         write_id_keyed_slot(
             tmp_hal0_home, stem="1", name="agent", model="ace-saber", extra=["default = true"]
         )
@@ -181,7 +189,10 @@ class TestGuardsExcludeTheSlotItself:
             tmp_hal0_home, stem="2", name="code", model="other", extra=["default = true"]
         )
         plan = StackApplyEngine().plan("live", _stack())
-        assert plan.errors, "a real second default=true must still be rejected"
+        assert plan.errors == [], (
+            f"a stack apply that never touches default was vetoed: {plan.errors}"
+        )
+        assert plan.slot_names == ("agent",)
 
 
 # ── 3. drift ─────────────────────────────────────────────────────────────────

--- a/tests/stacks/test_id_keyed_roundtrip.py
+++ b/tests/stacks/test_id_keyed_roundtrip.py
@@ -1,0 +1,238 @@
+"""Stacks on an ID-KEYED box — the snapshot→apply round-trip (#1510).
+
+Every other test in ``tests/stacks/`` writes a NAME-keyed fixture
+(``agent.toml`` whose embedded ``name`` is ``"agent"``), where the on-disk
+stem and the display name are the same string. That is why the id-keying
+seam shipped broken: on the live box ``/etc/hal0/slots/`` is fully id-keyed
+(``1.toml`` … ``16.toml``, each with ``name = "agent"`` inside), so stem and
+display name DIVERGE and every ``f"{entry.slot}.toml"`` in the apply path
+addresses a file that does not exist.
+
+These tests use an id-keyed fixture exclusively. They pin the three distinct
+failures that divergence produced:
+
+  1. ``_slot_toml_exists`` reported every live slot missing, so apply's
+     create-on-apply path cloned it as a second, name-keyed TOML (#1510, the
+     first-party producer of the duplicate-slot state in #1422);
+  2. the cross-slot write guards excluded the slot's peer set by *stem*, so a
+     slot passed by display name saw ITSELF as a peer and rejected its own
+     plan; and
+  3. the drift fingerprint was keyed by stem at record time and by display
+     name at compare time, so an applied stack read as ``modified`` forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config.schema import StackConfig, StackSlotEntry
+from hal0.registry.store import ModelRegistry
+from hal0.stacks.apply import StackApplyEngine
+from hal0.stacks.portable import snapshot_live_stack
+
+# ── fixtures — the live box's layout, not the tests' historical one ──────────
+
+
+def _slots_dir(home: str) -> Path:
+    d = Path(home) / "etc" / "hal0" / "slots"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def write_id_keyed_slot(
+    home: str,
+    *,
+    stem: str,
+    name: str,
+    model: str | None = "old-model",
+    device: str = "gpu-vulkan",
+    extra: list[str] | None = None,
+) -> Path:
+    """Write ``<stem>.toml`` whose embedded display name is ``name``.
+
+    Mirrors the live shape read off lxc105: a digit stem, the flat (no
+    ``[slot]`` section) body the runtime writes, and a self-describing
+    ``name`` key.
+    """
+    lines = [
+        f'name = "{name}"',
+        'type = "llm"',
+        f'device = "{device}"',
+        'provider = "llama-server"',
+        "port = 8087",
+        "vision = false",
+        *(extra or []),
+    ]
+    if model is not None:
+        lines += ["[model]", f'default = "{model}"', "context_size = 8192"]
+    path = _slots_dir(home) / f"{stem}.toml"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def reg(tmp_path: Path) -> ModelRegistry:
+    return ModelRegistry(registry_dir=tmp_path / "registry")
+
+
+def _stack(slot: str = "agent", model: str = "new-model") -> StackConfig:
+    return StackConfig(
+        name="Live", slots=[StackSlotEntry(slot=slot, model=model, device="gpu-vulkan")]
+    )
+
+
+# ── 1. the round-trip itself ─────────────────────────────────────────────────
+
+
+class TestSnapshotApplyRoundTrip:
+    def test_snapshot_records_the_display_name_not_the_digit_stem(
+        self, reg: ModelRegistry, tmp_hal0_home: str
+    ) -> None:
+        """A stack is a PORTABLE artefact — its slot identity is the display
+        name, never this box's storage stem. This half already worked; it is
+        pinned so a future "fix" doesn't make snapshot emit ``"1"``."""
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        stack = snapshot_live_stack(registry=reg, name="Live")
+        assert [e.slot for e in stack.slots] == ["agent"]
+
+    def test_apply_resolves_a_snapshotted_slot_to_its_id_keyed_file(
+        self, reg: ModelRegistry, tmp_hal0_home: str
+    ) -> None:
+        """RED before #1510: ``_slot_path`` built ``agent.toml`` and the plan
+        found nothing to change, so snapshot→apply was a silent no-op."""
+        path = write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        stack = snapshot_live_stack(registry=reg, name="Live")
+        # Re-point the snapshot at a different model so a working apply MUST
+        # produce a diff on the id-keyed file.
+        stack = stack.model_copy(
+            update={"slots": [stack.slots[0].model_copy(update={"model": "new-model"})]}
+        )
+
+        plan = StackApplyEngine().plan("live", stack)
+
+        touched = {fs.path for fs in plan.change_set.after}
+        assert touched == {path}, f"apply must address the id-keyed file, got {touched}"
+        assert plan.errors == []
+        assert any(fs.data != b.data for b, fs in zip(plan.change_set.before, plan.change_set.after))
+
+    def test_apply_commits_onto_the_id_keyed_file_and_creates_no_duplicate(
+        self, reg: ModelRegistry, tmp_hal0_home: str
+    ) -> None:
+        """RED before #1510: apply wrote a brand-new ``agent.toml`` beside the
+        live ``1.toml`` — exactly the duplicate-slot state #1422 reports."""
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        engine = StackApplyEngine()
+        plan = engine.plan("live", _stack())
+        engine.apply_config(plan)
+
+        stems = sorted(p.stem for p in _slots_dir(tmp_hal0_home).glob("*.toml"))
+        assert stems == ["1"], f"apply must not clone the slot, found {stems}"
+
+        import tomllib
+
+        with open(_slots_dir(tmp_hal0_home) / "1.toml", "rb") as f:
+            assert tomllib.load(f)["model"]["default"] == "new-model"
+
+
+class TestMissingSlotDetection:
+    def test_an_existing_id_keyed_slot_is_not_reported_missing(self, tmp_hal0_home: str) -> None:
+        """RED before #1510: this is the exact call that made
+        ``_create_missing_slots`` clone all 16 live slots."""
+        from hal0.api.routes.stacks import _missing_slot_names
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent")
+        assert _missing_slot_names(_stack("agent")) == []
+
+    def test_a_genuinely_absent_slot_is_still_reported_missing(self, tmp_hal0_home: str) -> None:
+        """The create-on-apply path must keep working — resolving by name must
+        not swallow a slot that really doesn't exist."""
+        from hal0.api.routes.stacks import _missing_slot_names
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent")
+        assert _missing_slot_names(_stack("quick")) == ["quick"]
+
+
+# ── 2. the cross-slot write guards ───────────────────────────────────────────
+
+
+class TestGuardsExcludeTheSlotItself:
+    def test_default_uniqueness_does_not_fire_against_the_slot_itself(
+        self, tmp_hal0_home: str
+    ) -> None:
+        """RED before #1510: ``_iter_peer_configs`` excludes by STEM, so a slot
+        addressed as ``"agent"`` never excluded ``1.toml`` — its own file — and
+        the default-uniqueness guard rejected the slot's own plan."""
+        write_id_keyed_slot(
+            tmp_hal0_home, stem="1", name="agent", model="ace-saber", extra=["default = true"]
+        )
+        plan = StackApplyEngine().plan("live", _stack())
+        assert plan.errors == [], f"the slot conflicted with itself: {plan.errors}"
+
+    def test_default_uniqueness_still_fires_against_a_real_peer(self, tmp_hal0_home: str) -> None:
+        """The guard must keep its teeth — a genuine second default=true peer is
+        still rejected when both slots are id-keyed. ``default`` is not a stack
+        field, so it reaches the merged config from the slot's own TOML."""
+        write_id_keyed_slot(
+            tmp_hal0_home, stem="1", name="agent", model="ace-saber", extra=["default = true"]
+        )
+        write_id_keyed_slot(
+            tmp_hal0_home, stem="2", name="code", model="other", extra=["default = true"]
+        )
+        plan = StackApplyEngine().plan("live", _stack())
+        assert plan.errors, "a real second default=true must still be rejected"
+
+
+# ── 3. drift ─────────────────────────────────────────────────────────────────
+
+
+class TestDriftOnAnIdKeyedBox:
+    def test_a_fresh_apply_reads_clean(self, tmp_hal0_home: str) -> None:
+        """RED before #1510: ``record_active`` fingerprinted a STEM-keyed
+        projection (``{"1": ...}``) while ``drift_status`` compared a
+        NAME-keyed one (``{"agent": ...}``), so an id-keyed box reported
+        ``modified`` the instant it applied anything."""
+
+        class _Catalog:
+            def resolve(self, slug: str) -> StackConfig:
+                return _stack()
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        engine = StackApplyEngine()
+        plan = engine.plan("live", _stack())
+        engine.apply_config(plan)
+        engine.record_active(plan, applied_at=1.0)
+
+        assert engine.drift_status(_Catalog()) == {"active": "live", "status": "clean"}
+
+    def test_a_hand_edit_still_reads_modified(self, tmp_hal0_home: str) -> None:
+        """Drift must keep its teeth on an id-keyed box too."""
+
+        class _Catalog:
+            def resolve(self, slug: str) -> StackConfig:
+                return _stack()
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        engine = StackApplyEngine()
+        plan = engine.plan("live", _stack())
+        engine.apply_config(plan)
+        engine.record_active(plan, applied_at=1.0)
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="hand-edited")
+        assert engine.drift_status(_Catalog())["status"] == "modified"
+
+
+# ── 4. the diff rows the UI renders ──────────────────────────────────────────
+
+
+class TestDiffRowsSpeakDisplayNames:
+    def test_diff_row_slot_is_the_display_name_not_the_digit(self, tmp_hal0_home: str) -> None:
+        """RED before #1510: ``_diff_rows`` labelled rows ``after.path.stem``,
+        so the dry-run preview on an id-keyed box listed ``1`` / ``13`` instead
+        of ``agent`` / ``rerank``."""
+        from hal0.api.routes.stacks import _diff_rows
+
+        write_id_keyed_slot(tmp_hal0_home, stem="1", name="agent", model="ace-saber")
+        plan = StackApplyEngine().plan("live", _stack())
+        assert [r["slot"] for r in _diff_rows(plan)] == ["agent"]


### PR DESCRIPTION
## What changed

Fixes #1510 (and the first-party producer of the duplicate-slot state in #1422): the stacks snapshot-then-apply path addressed slot TOMLs by display name (`f"{entry.slot}.toml"`) while an id-keyed box stores them under digit stems (`agent` -> `1.toml`). That divergence produced three distinct failures:

1. `_slot_toml_exists` reported every live slot missing, so `_create_missing_slots` cloned all of them as duplicate name-keyed TOMLs.
2. The cross-slot write guards excluded a slot's peer set by stem, so a slot addressed by display name saw itself as a peer and rejected its own plan.
3. The drift fingerprint was keyed by stem at record time but compared against a name-keyed live projection, so every applied stack read as `modified` forever.

Changes:
- `src/hal0/slots/layout.py`: bilingual name/stem resolver — `read_slot_display_name`, `slot_stems_by_name`, `resolve_slot_stem` (stem-first, display-name fallback).
- `src/hal0/stacks/apply.py`: `StackApplyEngine` resolves paths and guard identity through the layout seam; `StackChangePlan` carries `slot_names` positionally parallel to the change set; drift projection keys by display name.
- `src/hal0/api/routes/stacks.py`: `_slot_toml_exists` resolves through the seam; dry-run diff rows label slots by display name instead of digit stems.
- `tests/stacks/test_id_keyed_roundtrip.py`: 250-line regression suite using an id-keyed fixture exclusively, pinning all three failures.
- `tests/slots/test_layout.py`: unit coverage for the new resolver functions.

## Why

On the live box `/etc/hal0/slots/` is fully id-keyed, while every existing test fixture was name-keyed (stem == display name), which is why the seam shipped broken.

## How verified

`HAL0_HOME=$(mktemp -d) uv run pytest tests/stacks/ tests/slots/test_layout.py -q` — 107 passed. `ruff check` and `ruff format --check` clean on all touched files.

## Notes

Rebased onto main during salvage: main's SC-4 `changed_keys` semantics (skip `check_default_uniqueness` when the write does not touch `default`) intentionally supersede the old "stale duplicate default vetoes the apply" behaviour, so one guard test was reworked to pin the new contract. Slot creation on apply remains out of scope; a slot the stack names but the box lacks still takes the name-keyed creation path.

Closes #1510
Refs #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)