### PR TITLE
fix(upstreams): retire unimplemented google_query auth style

### DIFF
--- a/src/hal0/cli/upstream_commands.py
+++ b/src/hal0/cli/upstream_commands.py
@@ -220,7 +220,7 @@ def create_upstream(
     auth_style: str = typer.Option(
         None,
         "--auth-style",
-        help="Auth style: bearer | anthropic | google_query | header | none.",
+        help="Auth style: bearer | anthropic | header | none.",
     ),
     auth_header: str = typer.Option(
         None,
@@ -315,7 +315,7 @@ def update_upstream(
     auth_style: str = typer.Option(
         None,
         "--auth-style",
-        help="Auth style: bearer | anthropic | google_query | header | none.",
+        help="Auth style: bearer | anthropic | header | none.",
     ),
     auth_header: str = typer.Option(
         None, "--auth-header", help="Header NAME when auth-style is 'header'."

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1466,8 +1466,24 @@ def resolve_chat_template(slot_cfg: dict, model_info: dict) -> str | None:
 
 
 _VALID_UPSTREAM_KINDS = frozenset({"slot", "remote"})
-# The full set implemented by UpstreamRegistry.auth_headers().
-_VALID_AUTH_STYLES = frozenset({"bearer", "anthropic", "google_query", "header", "none"})
+# The full set implemented by UpstreamRegistry.auth_headers() — and this
+# comment is now enforced (tests/security/test_upstream_auth_contract.py).
+# "google_query" sat here for releases with no implementation behind it, so
+# Google AI Studio dispatched unauthenticated while the UI showed "key set"
+# (#1513).
+_VALID_AUTH_STYLES = frozenset({"bearer", "anthropic", "header", "none"})
+
+#: Retired auth styles → the style that replaces them on read. Dropping
+#: "google_query" from the enum outright would hard-fail config load on any
+#: box that already has a Google upstream configured; coercing it to "bearer"
+#: both keeps that box booting AND starts authenticating its Gemini calls,
+#: because bearer is what the endpoint it points at actually accepts.
+_AUTH_STYLE_ALIASES: dict[str, str] = {"google_query": "bearer"}
+
+
+def coerce_auth_style(style: str) -> str:
+    """Map a retired auth style onto its replacement; pass others through."""
+    return _AUTH_STYLE_ALIASES.get((style or "").strip().lower(), style)
 # Canonical vocabulary matches the Upstream dataclass; "lazy"/"eager" were the
 # original schema-only spellings and are still accepted as aliases on read.
 _VALID_WARMUP = frozenset({"none", "ondemand", "always"})
@@ -1561,11 +1577,25 @@ class UpstreamEntry(BaseModel):
     @field_validator("auth_style")
     @classmethod
     def auth_style_valid(cls, v: str) -> str:
-        if v not in _VALID_AUTH_STYLES:
+        # Coerce retired styles before validating (#1513) — an existing box
+        # carrying auth_style = "google_query" must keep booting, and must
+        # start authenticating rather than continue dispatching naked.
+        coerced = coerce_auth_style(v)
+        if coerced != v:
+            # stdlib logging here (this module predates the structlog sweep),
+            # so %-style rather than kwargs.
+            log.warning(
+                "upstream.auth_style_retired: auth_style %r was never "
+                "implemented and dispatched unauthenticated; reading it as "
+                "%r. Update /etc/hal0/upstreams.toml to silence this.",
+                v,
+                coerced,
+            )
+        if coerced not in _VALID_AUTH_STYLES:
             raise ValueError(
                 f"auth_style {v!r} is not valid; choose from {sorted(_VALID_AUTH_STYLES)}"
             )
-        return v
+        return coerced
 
     @field_validator("warmup_strategy")
     @classmethod

--- a/src/hal0/upstreams/integrations.py
+++ b/src/hal0/upstreams/integrations.py
@@ -6,9 +6,12 @@ at runtime; user configuration lives in /etc/hal0/upstreams.toml.
 Auth styles:
     "bearer"          → Authorization: Bearer <key>              (most providers)
     "anthropic"       → x-api-key: <key>  +  anthropic-version  (Anthropic only)
-    "google_query"    → ?key=<key> on the URL                    (Google AI Studio)
     "header"          → custom header_name: <key>                ("custom" only)
     "none"            → no auth header                           ("custom" only)
+
+Every style listed here has a branch in UpstreamRegistry.auth_headers();
+"google_query" was listed here for releases without one (#1513). Keep the
+two in lock-step — tests/security/test_upstream_auth_contract.py asserts it.
 
 API keys are NEVER written to TOML.  They live in the slot env file managed
 by hal0.config.env.write_env_atomic; the key's env var name is stored in
@@ -100,8 +103,15 @@ _CATALOG: dict[str, dict[str, Any]] = {
         "id": "google_ai_studio",
         "name": "Google AI Studio",
         "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
-        "auth": "google_query",
-        "auth_header_name": "",
+        # bearer, not the retired "google_query" (#1513). ?key= belongs to
+        # Google's NATIVE generativelanguage API; the OpenAI-compatible
+        # surface pinned above authenticates with a plain bearer header —
+        # Google's own REST example is
+        # `-H "Authorization: Bearer $GEMINI_API_KEY"`. The old style was
+        # declared, validated and offered but implemented nowhere, so every
+        # Gemini call dispatched unauthenticated behind a "key set" chip.
+        "auth": "bearer",
+        "auth_header_name": "Authorization",
         "models_path": "/models",
         "default_models": ["gemini-2.0-flash", "gemini-1.5-pro"],
         "default_model": "gemini-2.0-flash",
@@ -217,7 +227,7 @@ def validate_catalog() -> list[str]:
         if category != "custom" and not entry.get("base_url"):
             problems.append(f"{cid}: missing base_url")
         auth = entry.get("auth", "")
-        if auth not in {"bearer", "anthropic", "google_query", "header", "none"}:
+        if auth not in {"bearer", "anthropic", "header", "none"}:
             problems.append(f"{cid}: invalid auth style {auth!r}")
         caps = entry.get("capabilities", [])
         if not isinstance(caps, list):

--- a/src/hal0/upstreams/registry.py
+++ b/src/hal0/upstreams/registry.py
@@ -83,6 +83,25 @@ class UpstreamProtected(UpstreamError):
     status = 400
 
 
+class UpstreamAuthUnconfigured(UpstreamError):
+    """An upstream declares an auth style that needs a credential it lacks.
+
+    Before #1513 this was silent: :meth:`UpstreamRegistry.auth_headers`
+    returned ``{}`` when the env var behind ``auth_value_env`` was unset, so
+    the request went out unauthenticated and the *remote* reported the
+    problem — as a 401 the operator had to go and read — while the dashboard
+    showed a green "key set" chip (``auth_key_present`` is env-var presence,
+    not presentability). Failing here names the upstream and the variable, at
+    the point the credential was supposed to be attached.
+
+    502 rather than 500: the call never left hal0, and the fault is
+    configuration of a remote dependency, not an internal error.
+    """
+
+    code = "system.upstream_auth_unconfigured"
+    status = 502
+
+
 # "hal0" is reserved from the reactive CRUD surface (POST/DELETE
 # /api/upstreams) — it's the cache key the /v1/models aggregator and the
 # dashboard's synthetic slot tile use for the direct-read model catalogue
@@ -114,7 +133,7 @@ class Upstream:
     """Base URL, e.g. "http://127.0.0.1:8081/v1" or "https://openrouter.ai/api/v1"."""
 
     auth_style: str = "bearer"
-    """How to present the API key: "bearer" | "anthropic" | "google_query" | "header" | "none"."""
+    """How to present the API key: "bearer" | "anthropic" | "header" | "none"."""
 
     auth_header: str = ""
     """Custom header name when auth_style == "header"."""
@@ -557,13 +576,38 @@ class UpstreamRegistry:
 
     # ── Auth headers ──────────────────────────────────────────────────────────
 
+    #: Auth styles that cannot do their job without a credential. A missing
+    #: key for one of these is a configuration error, not "no header today"
+    #: (#1513).
+    _CREDENTIALED_STYLES = frozenset({"bearer", "anthropic", "header"})
+
     def auth_headers(self, u: Upstream) -> dict[str, str]:
-        """Build outbound auth headers honouring `u.auth_style`."""
+        """Build outbound auth headers honouring `u.auth_style`.
+
+        Raises :class:`UpstreamAuthUnconfigured` when the style needs a
+        credential and ``$auth_value_env`` is unset or blank. It used to
+        return ``{}`` and let the request go out naked (#1513) — a silent
+        downgrade from "authenticated" to "not", which is the failure mode the
+        dashboard's "key set" chip was actively contradicting. A blank value
+        counts as missing: ``KEY=`` is the shape left behind by clearing a
+        secret, not a credential.
+
+        ``none`` — and any upstream that declares no ``auth_value_env`` at
+        all, which is every local slot upstream — is unaffected.
+        """
         style = (u.auth_style or "bearer").lower()
-        key = os.environ.get(u.auth_value_env, "") if u.auth_value_env else ""
+        key = os.environ.get(u.auth_value_env, "").strip() if u.auth_value_env else ""
 
         if style == "none":
             return {}
+        if style in self._CREDENTIALED_STYLES and u.auth_value_env and not key:
+            raise UpstreamAuthUnconfigured(
+                f"upstream {u.name!r} uses auth_style {style!r} but "
+                f"${u.auth_value_env} is unset — the request would be sent "
+                "unauthenticated. Set it via Settings ▸ Secrets or in "
+                "/etc/hal0/api.env, then restart hal0-api.",
+                details={"name": u.name, "auth_style": style, "env": u.auth_value_env},
+            )
         if style == "bearer":
             if not key:
                 return {}
@@ -576,9 +620,6 @@ class UpstreamRegistry:
             if key:
                 out["x-api-key"] = key
             return out
-        if style == "google_query":
-            # Google keys ride as ?key=… on the URL — emit no header here.
-            return {}
         if style == "header":
             if u.auth_header and key:
                 return {u.auth_header: key}
@@ -823,10 +864,19 @@ class UpstreamRegistry:
             return []
         target = u.url.rstrip("/") + "/models"
         try:
+            # #1513: auth_headers now raises on an unconfigured credential
+            # rather than silently probing naked. Model prefetch is
+            # best-effort — an upstream that cannot authenticate drops out of
+            # the advertised list instead of taking the whole fan-out down.
+            headers = self.auth_headers(u)
+        except UpstreamAuthUnconfigured as exc:
+            log.warning("upstream.fetch_models_auth_unconfigured", name=name, detail=str(exc))
+            return []
+        try:
             c = self._get_client()
             resp = await c.get(
                 target,
-                headers=self.auth_headers(u),
+                headers=headers,
                 timeout=httpx.Timeout(connect=3.0, read=5.0, write=3.0, pool=3.0),
             )
             if resp.status_code != 200:

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -340,12 +340,16 @@ class TestUpstreamEntry:
             UpstreamEntry(name="x", url="http://x", timeout_seconds=-1.0)
 
     def test_anthropic_and_google_auth_styles_accepted(self) -> None:
-        # These were rejected pre-fix even though the runtime implements them.
+        # "anthropic" is implemented by the runtime and passes through.
+        # "google_query" was retired in #1513 (declared but implemented
+        # nowhere, so Google calls dispatched unauthenticated); an existing
+        # config carrying it is coerced to "bearer" so the box keeps booting
+        # and starts authenticating.
         assert UpstreamEntry(name="a", url="http://x", auth_style="anthropic").auth_style == (
             "anthropic"
         )
         assert UpstreamEntry(name="g", url="http://x", auth_style="google_query").auth_style == (
-            "google_query"
+            "bearer"
         )
 
     def test_warmup_canonical_vocabulary_accepted(self) -> None:

--- a/tests/security/test_upstream_auth_contract.py
+++ b/tests/security/test_upstream_auth_contract.py
@@ -1,0 +1,275 @@
+"""Issue #1513: an upstream cannot advertise auth it does not perform.
+
+`google_query` was declared in the schema enum, accepted by the validator,
+shipped in the provider catalog as Google AI Studio's auth style, offered as
+an MCP/CLI prefill — and implemented nowhere. `auth_headers` returned `{}`
+for it with the comment *"Google keys ride as ?key=… on the URL — emit no
+header here"*, and no code anywhere appends that query parameter. The
+dispatcher builds its outbound URL by plain concatenation and injects only
+the header map, so every Google AI Studio call left hal0 with no
+`Authorization`, no `x-api-key` and no `?key=` — while the dashboard showed
+a green "key set" chip, because `auth_key_present` is backed by env-var
+presence rather than by whether the key can be presented.
+
+That is the worst shape a security bug takes: the UI asserts a protection
+that does not exist, so nobody investigates.
+
+**The fix is not to implement `?key=`.** Google's OpenAI-compatible endpoint
+— the one in the catalog, `/v1beta/openai` — authenticates with a normal
+bearer header; Google's own REST example is
+`-H "Authorization: Bearer $GEMINI_API_KEY"`. `google_query` was modelled on
+the *native* `generativelanguage` API, which is a different surface. So the
+catalog entry becomes `bearer` (a style that is implemented, tested, and
+shared with every other cloud provider) and `google_query` is retired
+outright. Threading a secret into a URL would have been strictly worse:
+query strings land in access logs, `Referer` headers and error envelopes,
+so it would have traded a broken provider for a credential-leak surface.
+
+The second half is the invariant behind the lying chip: a style that
+*requires* a credential must fail loudly when it does not have one, instead
+of dispatching unauthenticated and letting the remote answer 401.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import _VALID_AUTH_STYLES
+from hal0.upstreams.integrations import _CATALOG, validate_catalog
+from hal0.upstreams.registry import Upstream, UpstreamAuthUnconfigured, UpstreamRegistry
+
+
+def _upstream(**kw) -> Upstream:
+    base = {
+        "name": "probe",
+        "kind": "remote",
+        "url": "https://example.invalid/v1",
+        "auth_style": "bearer",
+        "auth_value_env": "PROBE_KEY",
+    }
+    base.update(kw)
+    return Upstream(**base)  # type: ignore[arg-type]
+
+
+@pytest.fixture
+def registry() -> UpstreamRegistry:
+    return UpstreamRegistry()
+
+
+# ── 1. google_query is retired everywhere it was declared ───────────────────
+
+
+def test_google_query_is_not_a_valid_auth_style() -> None:
+    """The schema comment claimed "the full set implemented by
+    UpstreamRegistry.auth_headers()" while listing one that wasn't."""
+    assert "google_query" not in _VALID_AUTH_STYLES
+
+
+def test_every_declared_auth_style_is_actually_implemented() -> None:
+    """The assertion the schema comment was making. Stated as a check so the
+    next style added to the enum has to come with a branch."""
+    registry_styles = {"bearer", "anthropic", "header", "none"}
+    assert registry_styles == _VALID_AUTH_STYLES
+
+
+def test_no_catalog_entry_uses_an_unimplemented_style() -> None:
+    for cid, entry in _CATALOG.items():
+        assert entry["auth"] in _VALID_AUTH_STYLES, f"{cid} → {entry['auth']!r}"
+
+
+def test_catalog_still_validates() -> None:
+    assert validate_catalog() == []
+
+
+def test_google_query_is_no_longer_offered_as_a_choice() -> None:
+    """The CLI help advertised it in two places. A style the validator now
+    rejects must not still be printed as a selectable option — the retirement
+    comments and the alias map that keeps old configs booting are expected to
+    keep naming it."""
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    cli = (root / "src/hal0/cli/upstream_commands.py").read_text(encoding="utf-8")
+    assert "google_query" not in cli
+
+
+def test_google_query_is_not_a_selectable_value_anywhere() -> None:
+    """The three places that enumerate valid styles agree."""
+    from hal0.upstreams import integrations
+
+    assert "google_query" not in _VALID_AUTH_STYLES
+    assert all(e["auth"] != "google_query" for e in integrations._CATALOG.values())
+    assert "google_query" not in (integrations.__doc__ or "").split("Auth styles:")[1].split(
+        "Every style"
+    )[0]
+
+
+# ── 2. Google AI Studio authenticates ───────────────────────────────────────
+
+
+def test_google_ai_studio_uses_bearer() -> None:
+    entry = _CATALOG["google_ai_studio"]
+    assert entry["auth"] == "bearer"
+    assert entry["auth_header_name"] == "Authorization"
+
+
+def test_google_ai_studio_still_points_at_the_openai_compat_surface() -> None:
+    """The bearer choice is only correct for `/v1beta/openai`; the native
+    API is a different surface with different auth."""
+    assert _CATALOG["google_ai_studio"]["base_url"].endswith("/v1beta/openai")
+
+
+def test_google_ai_studio_emits_a_bearer_header(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #1513 repro: this returned `{}` and the call went out naked."""
+    monkeypatch.setenv("GEMINI_KEY", "secret-key")
+    entry = _CATALOG["google_ai_studio"]
+    u = _upstream(
+        name="gemini",
+        url=entry["base_url"],
+        auth_style=entry["auth"],
+        auth_value_env="GEMINI_KEY",
+    )
+    assert registry.auth_headers(u) == {"Authorization": "Bearer secret-key"}
+
+
+# ── 3. a configured google_query survives the upgrade, authenticating ───────
+
+
+def test_existing_google_query_config_is_coerced_to_bearer(tmp_path) -> None:
+    """A box already carrying `auth_style = "google_query"` must not hard-fail
+    config load on upgrade — and must stop dispatching unauthenticated. It is
+    coerced to the style that actually works against that base_url."""
+    from hal0.config.schema import coerce_auth_style
+
+    assert coerce_auth_style("google_query") == "bearer"
+    assert coerce_auth_style("bearer") == "bearer"
+    assert coerce_auth_style("none") == "none"
+
+
+def test_a_google_query_entry_still_validates_and_becomes_bearer() -> None:
+    """The upgrade path: dropping the value from the enum without an alias
+    would turn every existing Gemini upstream into a config-load failure."""
+    from hal0.config.schema import UpstreamEntry
+
+    entry = UpstreamEntry(
+        name="gemini",
+        kind="remote",
+        url="https://generativelanguage.googleapis.com/v1beta/openai",
+        auth_style="google_query",
+        auth_value_env="GEMINI_KEY",
+    )
+    assert entry.auth_style == "bearer"
+
+
+def test_a_genuinely_unknown_auth_style_is_still_rejected() -> None:
+    """The alias map must not become a way to smuggle anything through."""
+    import pydantic
+
+    from hal0.config.schema import UpstreamEntry
+
+    with pytest.raises(pydantic.ValidationError):
+        UpstreamEntry(name="x", kind="remote", url="https://x.invalid", auth_style="magic")
+
+
+def test_a_coerced_entry_authenticates_end_to_end(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Coercion is only worth anything if the resulting upstream presents a
+    credential — the whole defect was one that dispatched naked."""
+    from hal0.config.schema import UpstreamEntry
+
+    monkeypatch.setenv("GEMINI_KEY", "k")
+    entry = UpstreamEntry(
+        name="gemini",
+        kind="remote",
+        url="https://generativelanguage.googleapis.com/v1beta/openai",
+        auth_style="google_query",
+        auth_value_env="GEMINI_KEY",
+    )
+    u = _upstream(
+        name=entry.name,
+        url=entry.url,
+        auth_style=entry.auth_style,
+        auth_value_env=entry.auth_value_env,
+    )
+    assert registry.auth_headers(u) == {"Authorization": "Bearer k"}
+
+
+# ── 4. a credential-requiring style fails loudly without a credential ───────
+
+
+@pytest.mark.parametrize("style", ["bearer", "anthropic", "header"])
+def test_missing_credential_raises_instead_of_dispatching_naked(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch, style: str
+) -> None:
+    """The invariant the "key set" chip was asserting. `auth_headers` used to
+    return `{}` (or bare `anthropic-version`) for a missing key, so the call
+    went out unauthenticated and the remote — not hal0 — reported the
+    problem, as a 401 the operator had to go read."""
+    monkeypatch.delenv("PROBE_KEY", raising=False)
+    u = _upstream(auth_style=style, auth_header="X-Api-Key" if style == "header" else None)
+    with pytest.raises(UpstreamAuthUnconfigured) as exc:
+        registry.auth_headers(u)
+    assert "PROBE_KEY" in str(exc.value)
+    assert "probe" in str(exc.value)
+
+
+def test_the_error_never_carries_the_key_itself(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PROBE_KEY", "   ")
+    with pytest.raises(UpstreamAuthUnconfigured) as exc:
+        registry.auth_headers(_upstream())
+    assert "   " not in str(exc.value).replace("PROBE_KEY", "")
+
+
+def test_blank_credential_counts_as_missing(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`KEY=` in api.env is the shape an operator leaves behind after
+    clearing a secret; it must not read as configured."""
+    monkeypatch.setenv("PROBE_KEY", "")
+    with pytest.raises(UpstreamAuthUnconfigured):
+        registry.auth_headers(_upstream())
+
+
+def test_style_none_needs_no_credential(registry: UpstreamRegistry) -> None:
+    assert registry.auth_headers(_upstream(auth_style="none", auth_value_env=None)) == {}
+
+
+def test_an_upstream_with_no_env_declared_needs_no_credential(
+    registry: UpstreamRegistry,
+) -> None:
+    """Local slot upstreams declare no auth_value_env; they must not start
+    raising."""
+    assert registry.auth_headers(_upstream(auth_style="none", auth_value_env=None)) == {}
+    assert registry.auth_headers(_upstream(kind="slot", auth_value_env=None, auth_style="none")) == {}
+
+
+# ── 5. the failure surfaces cleanly, not as a 500 ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cold_prefetch_degrades_instead_of_exploding(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prefetch is best-effort; an unconfigured upstream must drop out of the
+    model list, not take the whole fan-out down."""
+    monkeypatch.delenv("PROBE_KEY", raising=False)
+    registry._upstreams["probe"] = _upstream()
+    assert await registry.fetch_models("probe") == []
+
+
+@pytest.mark.asyncio
+async def test_test_reports_the_missing_env_var_without_raising(
+    registry: UpstreamRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`test()` already pre-checked the env var and returned a clean message;
+    that path must keep working rather than becoming an exception."""
+    monkeypatch.delenv("PROBE_KEY", raising=False)
+    registry._upstreams["probe"] = _upstream()
+    result = await registry.test("probe")
+    assert result["ok"] is False
+    assert "PROBE_KEY" in result["error"]

--- a/tests/upstreams/test_registry.py
+++ b/tests/upstreams/test_registry.py
@@ -26,6 +26,7 @@ from hal0.upstreams.registry import (
     TIER1_TOTAL_GRACE_S,
     Upstream,
     UpstreamAlreadyExists,
+    UpstreamAuthUnconfigured,
     UpstreamNotFound,
     UpstreamRegistry,
 )
@@ -134,10 +135,13 @@ def test_auth_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_auth_bearer_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A credentialed style with an unset env var raises instead of
+    dispatching unauthenticated (#1513)."""
     monkeypatch.delenv("MY_KEY", raising=False)
     r = UpstreamRegistry()
     u = _remote(auth_style="bearer", auth_value_env="MY_KEY")
-    assert r.auth_headers(u) == {}
+    with pytest.raises(UpstreamAuthUnconfigured):
+        r.auth_headers(u)
 
 
 def test_auth_anthropic(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,10 +164,14 @@ def test_auth_none() -> None:
     assert r.auth_headers(u) == {}
 
 
-def test_auth_google_query_emits_no_header(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_auth_unknown_style_emits_no_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """"google_query" was retired in #1513 (it emitted no header, so calls
+    dispatched unauthenticated); an unknown style with a key present still
+    falls through to no headers rather than raising here — the schema
+    validator is the gate for unknown styles."""
     monkeypatch.setenv("G_KEY", "foo")
     r = UpstreamRegistry()
-    u = _remote(auth_style="google_query", auth_value_env="G_KEY")
+    u = _remote(auth_style="mystery", auth_value_env="G_KEY")
     assert r.auth_headers(u) == {}
 
 


### PR DESCRIPTION
**Security-relevant — human review required before merge.**

## What changed

Closes #1513. The `google_query` auth style was declared in the schema enum, offered in the CLI help, and set as Google AI Studio's auth style in the provider catalog — but implemented nowhere. `UpstreamRegistry.auth_headers()` returned `{}` for it and no code appended `?key=` to the URL, so every Google AI Studio call left hal0 with no credential at all while the dashboard showed a green "key set" chip (`auth_key_present` reflects env-var presence, not whether the key is actually presented).

- **`src/hal0/upstreams/integrations.py`** — Google AI Studio catalog entry switched to `bearer`. The catalog points at Google's OpenAI-compatible surface (`/v1beta/openai`), which authenticates with a plain `Authorization: Bearer` header; `?key=` belongs to the native generativelanguage API, and implementing it would put secrets in query strings (access logs, Referer, error envelopes).
- **`src/hal0/config/schema.py`** — `google_query` removed from `_VALID_AUTH_STYLES`; new `coerce_auth_style()` maps it to `bearer` on read (with a warning) so existing configs keep booting and start authenticating instead of hard-failing config load.
- **`src/hal0/upstreams/registry.py`** — new `UpstreamAuthUnconfigured` (502) raised when a credentialed style (`bearer`/`anthropic`/`header`) has an unset or blank `auth_value_env`, instead of silently dispatching unauthenticated. Blank values count as missing. Model prefetch catches it and degrades to an empty list. `none` and upstreams with no `auth_value_env` (local slots) are unaffected.
- **`src/hal0/cli/upstream_commands.py`** — help text no longer offers `google_query`.
- **`tests/security/test_upstream_auth_contract.py`** — new contract test: every declared auth style has an implementation, the catalog validates, coercion works end-to-end, missing credentials raise without leaking the key.
- **`tests/upstreams/test_registry.py`, `tests/config/test_schema.py`** — legacy tests that asserted the old naked-dispatch behavior updated to the new contract.

## How verified

`HAL0_HOME=$(mktemp -d) uv run pytest tests/security/test_upstream_auth_contract.py tests/upstreams tests/config tests/cli` — full targeted run: 1522 passed before the two legacy-test updates (1 expected failure), 216 passed / 9 skipped on the targeted re-run after; the new contract file is 22/22. `ruff check` clean on all touched files.

## Out of scope

- The dashboard "key set" chip still reports env-var presence; with this change a present-but-blank key now fails loudly at dispatch, but the chip semantics themselves were not touched.
- No implementation of native generativelanguage `?key=` auth — deliberately rejected as a credential-leak surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)