### PR TITLE
polish: chat-page leftovers, bench cli version, stale docs sweep slice

### DIFF
--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -769,15 +769,22 @@ async def list_models(
 
     Two classes of entries are emitted:
 
-    * **Per-slot alias entries** (``hermes-role-slots``). Every enabled
-      chat slot (``type == "llm"``) that is currently being served
-      surfaces as one model object whose ``id`` is the slot **alias =
-      slot name** (``primary``, ``agent-hermes``, ``utility``), carrying a
-      human ``name`` (``"<slot> · <model display name>"``) and the slot's
+    * **Per-slot alias entries** (``hermes-role-slots``). Every chat slot
+      (``type == "llm"``) **with a bound model** surfaces as one model
+      object whose ``id`` is the slot **alias = slot name** (``primary``,
+      ``agent-hermes``, ``utility``), carrying a human ``name``
+      (``"<slot> · <model display name>"``) and the slot's
       ``context_length``/``max_context_window``. Built by
-      :func:`hal0.api.hal0_slot_alias_models`. Unloaded / disabled slots
-      are omitted. The alias is stable across model swaps so callers can
-      pin a co-resident slot.
+      :func:`hal0.api.hal0_slot_alias_models`. **Both warm and cold slots
+      are advertised** — dispatch cold-loads on demand when a request
+      addresses a cold slot by alias, so restricting discovery to warm
+      slots would hide slots the gateway will happily serve. The alias is
+      stable across model swaps so callers can pin a co-resident slot.
+
+      (This paragraph previously claimed only slots "currently being
+      served" appear and that "unloaded / disabled slots are omitted".
+      Neither was true of the builder, and post-#1369/#1408 there is no
+      ``enabled`` field at all — model-presence is the activation signal.)
     * **Upstream catalog entries** (incl. the direct-read composite
       catalogue below) — the raw model ids each ``advertise_models``
       upstream reports, so non-chat models (embed / rerank / image / …)

--- a/src/hal0/bench/__init__.py
+++ b/src/hal0/bench/__init__.py
@@ -17,4 +17,9 @@ $BENCHLAB_STATE). Surfaces: `hal0 bench <verb>` (cli.py) and
 `/api/benchmarks/*` (hal0.api.routes.benchmarks).
 """
 
-__version__ = "0.1.0"
+# No module-local __version__ (#1477). This carried "0.1.0" — inherited from
+# the out-of-tree benchlab repo and never bumped again — and its ONLY consumer
+# was `hal0 bench --version`, which therefore announced 0.1.0 on a hal0
+# 1.0.0-rc.1 box. bench ships inside hal0 and has no independent release
+# cadence, so the CLI reports hal0's version instead of maintaining a second
+# number that can only ever drift.

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -1,4 +1,4 @@
-"""cli.py — the single operator/agent surface: ``benchlab <verb>`` (DESIGN §5).
+"""The single operator/agent surface for the bench system: ``hal0 bench <verb>``.
 
 argparse (not typer) so the CLI is stdlib-only like the rest of the critical
 path (server_ab.py precedent). Every verb is a thin wrapper over the library
@@ -26,7 +26,8 @@ import urllib.error
 from datetime import UTC, datetime
 from pathlib import Path
 
-from . import __version__
+import hal0
+
 from .planner import fetch_registry_models, plan
 from .publish import build_roster, emit_site_ts, write_roster
 from .regress import check as regress_check
@@ -959,8 +960,23 @@ def _stamp_to_run_id(ts: str) -> str:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    ap = argparse.ArgumentParser(prog="hal0 bench", description=__doc__.split("\n")[0])
-    ap.add_argument("--version", action="version", version=f"hal0 bench {__version__}")
+    # Operator-facing copy, not the module docstring's first line (#1477):
+    # that read "cli.py — the single operator/agent surface: ``benchlab
+    # <verb>`` (DESIGN §5)", so `hal0 bench --help` led with a filename, an
+    # internal design-doc section, and a command name (`benchlab`) that is not
+    # how anyone invokes this.
+    ap = argparse.ArgumentParser(
+        prog="hal0 bench",
+        description=(
+            "Keep hal0's throughput/latency benchmark dataset current: plan what is "
+            "stale, run those cells, and query or publish the results."
+        ),
+    )
+    ap.add_argument(
+        "--version",
+        action="version",
+        version=f"hal0 bench (hal0 {hal0.__version__})",
+    )
     ap.add_argument("--api", default=DEFAULT_API, help=f"hal0-api base (default {DEFAULT_API})")
     ap.add_argument(
         "--no-registry",

--- a/ui/src/dash/board/agent-chat.jsx
+++ b/ui/src/dash/board/agent-chat.jsx
@@ -189,6 +189,29 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
   const displayMsgs = chatHook ? chatHook.messages : [];
   const isTyping    = chatHook ? chatHook.streaming : false;
 
+  // Steward status dot. The header used to hard-code a green pulsing `live`
+  // dot regardless of backend state, so during a brain-lane outage (#1418) or
+  // while the slot warms, the drawer still signalled a healthy agent — the
+  // only degraded state it ever surfaced was a missing hook bridge.
+  //
+  // There is no cheap dedicated liveness probe for the steward, so this is
+  // derived from the evidence the drawer already holds: the outcome of the
+  // last turn. It defaults to UNKNOWN (neutral, no pulse) rather than green —
+  // "we have not talked to it yet" must not render as "healthy", which is the
+  // same rule the agent-liveness work landed for `unit_active: null` (#1459).
+  const lastAssistant = [...displayMsgs].reverse().find(m => m.role === "assistant");
+  const stewardState = !chatHook          ? "unknown"
+    : isTyping                            ? "busy"
+    : lastAssistant?.error                ? "down"
+    : lastAssistant                       ? "ok"
+    : "unknown";
+  const STEWARD_DOT = {
+    ok:      { cls: "kdot live", st: "var(--ok)",   title: "last turn completed" },
+    busy:    { cls: "kdot live", st: "var(--warn)", title: "responding…" },
+    down:    { cls: "kdot",      st: "var(--bad)",  title: "last turn failed" },
+    unknown: { cls: "kdot",      st: "var(--fg-4)", title: "no turn taken yet — status unknown" },
+  }[stewardState];
+
   const [draft, setDraft] = useState("");
   const threadRef = useRef(null);
 
@@ -219,7 +242,13 @@ function AgentChat({ chat, byId, onClose, onOpenTask }) {
       >
         <div className="b-drawer-h">
           <span className="dh-title">
-            <span className="kdot live" style={{ "--st": "var(--ok)" }} />
+            <span
+              className={STEWARD_DOT.cls}
+              style={{ "--st": STEWARD_DOT.st }}
+              title={STEWARD_DOT.title}
+              data-testid="board-chat-steward-dot"
+              data-state={stewardState}
+            />
             hal0-brain · platform steward
           </span>
           <span className="spacer" />

--- a/ui/src/dash/extras.jsx
+++ b/ui/src/dash/extras.jsx
@@ -2,9 +2,13 @@
 //
 // Phase B1: Logs reads from real hooks. v0.3 PR-8 split the
 // AgentView monolith out of this file into ui/src/dash/agents/* — see
-// agent-view.jsx, hermes-chat-tab.jsx, personas-tab.jsx, skills-tab.jsx,
-// memory-tab.jsx, plugins-tab.jsx. v0.4: BackendsView removed (the page
+// agent-view.jsx and memory-tab.jsx. v0.4: BackendsView removed (the page
 // duplicated Settings → Runtime + config.json).
+//
+// (#1477) This map used to also name hermes-chat-tab.jsx, personas-tab.jsx,
+// skills-tab.jsx and plugins-tab.jsx. None of those exist any more, so the
+// only thing the comment did was send a reader looking for files that were
+// deleted with the chat page in #439.
 
 import { useLogsHistorical, useLogsStream, useSlotLogsStream } from '@/api/hooks/useLogs'
 import { useSlots } from '@/api/hooks/useSlots'

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -41,8 +41,7 @@ function fmtApprovalTs(v) {
 
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
   "slotVariant": "instrument",
-  "showHero": true,
-  "personaPlacement": "composer-left"
+  "showHero": true
 }/*EDITMODE-END*/;
 
 // ─── hash routing — supports #slots or #slots/<name> ───
@@ -154,7 +153,6 @@ function App() {
   const [{ route, param }, setRouteState] = useStateA(parseRoute());
   const [approvalsOpen, setApprovalsOpen] = useStateA(false);
   const [heroDismissed, setHeroDismissed] = useStateA(false);
-  const [composerState, setComposerState] = useStateA("idle");
   const [footerOpen, setFooterOpen] = useStateA(false);
   const [paletteOpen, setPaletteOpen] = useStateA(false);
   const [navOpen, setNavOpen] = useStateA(false);
@@ -476,28 +474,11 @@ function App() {
             value={tweaks.showHero}
             onChange={v => setTweak("showHero", v)}
           />
-          <TweakRadio
-            label="Persona placement"
-            value={tweaks.personaPlacement}
-            onChange={v => setTweak("personaPlacement", v)}
-            options={[
-              { value: "composer-left", label: "In composer" },
-              { value: "above",         label: "Above input" },
-            ]}
-          />
-          <TweakSelect
-            label="Composer state"
-            value={composerState}
-            onChange={v => setComposerState(v)}
-            options={[
-              { value: "idle",      label: "Idle (default)" },
-              { value: "sending",   label: "Sending" },
-              { value: "streaming", label: "Streaming" },
-              { value: "swap",      label: "NPU swap in progress" },
-              { value: "no-tools",  label: "No tool-calling LLM" },
-              { value: "offline",   label: "runtime offline" },
-            ]}
-          />
+          {/* "Persona placement" and "Composer state" lived here until #1477.
+              Both drove the chat page deleted in #439 — nothing has read
+              tweaks.personaPlacement or composerState since, so the controls
+              moved state no surface consumed. A knob that visibly does
+              nothing teaches an operator the whole panel is decorative. */}
         </TweakSection>
 
         <TweakSection title="Banners" label="Banners">

--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -542,9 +542,13 @@ const BANNER_CATALOG = [
     id: "post-install", scope: "dashboard", kind: "info",
     eyebrow: "FirstRun · just installed",
     heading: "Welcome to hal0 — {bundleName} is loaded",
-    body: <span>Try a message below. <span className="mono" style={{color: "var(--fg)"}}>primary</span> is your default chat persona. The persona dropdown lets you swap to <span className="mono">coder</span> or the NPU <span className="mono">agent</span>.</span>,
+    // Copy rewritten in #1477. It used to say "Try a message below … the
+    // persona dropdown lets you swap to coder or the NPU agent" — describing
+    // the chat page and its persona dropdown, both deleted in #439. It points
+    // at the surfaces that actually exist now. "Take the tour" is gone too: it
+    // dispatched `hal0:tour-start`, for which no listener has ever existed.
+    body: <span>Ask the steward anything from the <span className="mono" style={{color: "var(--fg)"}}>Quick chat</span> card, or open the platform steward from the Board. Your slots and models live under <span className="mono">Slots</span>.</span>,
     actions: [
-      { label: "Take the tour", primary: true, onClick: () => window.dispatchEvent(new CustomEvent("hal0:tour-start")) },
       { label: "Dismiss" },
     ],
   },

--- a/ui/src/stores/useBannerStore.ts
+++ b/ui/src/stores/useBannerStore.ts
@@ -190,9 +190,11 @@ export const BANNER_CATALOG: ReadonlyArray<BannerEntry> = Object.freeze([
     kind: 'info',
     eyebrow: 'FirstRun · just installed',
     heading: 'Welcome to hal0 — {bundleName} is loaded',
-    body: 'Try a message below. primary is your default chat persona. The persona dropdown lets you swap to coder or the NPU agent.',
+    // Kept in lockstep with the primitives.jsx catalog entry (#1477): the old
+    // copy described the chat page + persona dropdown deleted in #439, and
+    // "Take the tour" fired an event with no listener.
+    body: 'Ask the steward anything from the Quick chat card, or open the platform steward from the Board. Your slots and models live under Slots.',
     actions: [
-      { label: 'Take the tour', primary: true },
       { label: 'Dismiss' },
     ],
   },

--- a/ui/src/stores/useTweaksStore.ts
+++ b/ui/src/stores/useTweaksStore.ts
@@ -15,9 +15,7 @@ const IS_DEV = !!(import.meta.env && (import.meta.env as any).DEV)
 export interface TweaksState {
   slotCardVariant: 'a' | 'b' | 'c' | 'instrument' | 'list' | 'spec'
   heroStrip: 'sparkline' | 'metrics' | 'minimal'
-  composerState: 'idle' | 'sending' | 'streaming' | 'swap' | 'no-tools' | 'offline'
   firstrunLayout: 'tiers' | 'wizard' | 'grid' | 'table'
-  personaPlacement: 'topbar' | 'inline' | 'drawer' | 'composer-left' | 'above'
   chatVariant: 'active' | 'empty'
   heroVariant: 'returning' | 'post-install' | 'skip-path-empty'
   // User-facing (persist in prod too)
@@ -28,9 +26,7 @@ export interface TweaksState {
 const DEFAULTS: TweaksState = {
   slotCardVariant: 'instrument',
   heroStrip: 'sparkline',
-  composerState: 'idle',
   firstrunLayout: 'grid',
-  personaPlacement: 'composer-left',
   chatVariant: 'active',
   heroVariant: 'returning',
   theme: 'dark',


### PR DESCRIPTION
Partial slice of the open polish sweep #1477 (the sweep stays open — each touched item here is self-complete).

## What changed

- **`hal0 bench --version` / `--help`** — the CLI reported a frozen module-local `0.1.0` inherited from the out-of-tree benchlab repo; it now reports hal0's real version (`hal0 bench (hal0 1.0.0rc1)`). `--help` led with a filename, an internal design-doc section, and the obsolete `benchlab` command name; it now leads with operator-facing copy. The module-local `__version__` is removed — bench has no independent release cadence, so a second number can only drift.
- **`list_models` docstring** (`src/hal0/api/routes/v1.py`) — corrected two false claims: both warm and cold slots are advertised (dispatch cold-loads on demand), and post-#1369 there is no `enabled` flag — model presence is the activation signal. (A matching `openai-compat.mdx` fix was dropped during rebase: main's doc rewrite in the meantime already removed the stale paragraph.)
- **Dead chat-page tweaks removed** — `personaPlacement` and `composerState` controls and store fields drove the chat page deleted in #439; nothing has read them since. Rebase note: main independently removed the local `toast` state in the same declaration block; the resolution keeps both removals.
- **Post-install banner copy rewritten** (both `primitives.jsx` and `useBannerStore.ts` catalogs) — the old copy described the deleted chat page and persona dropdown, and "Take the tour" dispatched `hal0:tour-start`, an event with no listener anywhere. It now points at surfaces that exist (Quick chat card, Board steward drawer, Slots).
- **Agent-chat steward status dot made honest** — the drawer header hard-coded a green pulsing dot regardless of backend state. It is now derived from the last turn's outcome (ok / busy / down), defaulting to a neutral "unknown" state before any turn is taken — matching the `unit_active: null` rule from the agent-liveness work (#1459).
- **`extras.jsx` header comment** — no longer names four tab files deleted with the chat page.

## Verification

- `HAL0_HOME=$(mktemp -d) uv run pytest tests/bench tests/cli -x -q` — 764 passed
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/api -x -q` — 1606 passed, 1 skipped (journalctl-follow skip, pre-existing)
- `uv run ruff check` on the three touched Python files — clean
- `hal0 bench --version` / `--help` smoke-tested by hand
- UI: `npm run typecheck`, `npm run lint`, `npm run test:unit` (60 passed) — all clean

## Out of scope

- The remaining items of sweep #1477 (31-item list) — this PR uses `Refs`, not `Closes`.
- Main's rewritten `openai-compat.mdx` still says "any enabled LLM slot name" in the chat-completions deviations section; strictly there is no enabled flag post-#1369, but that sentence is new wording from main's rewrite and is left for the sweep.

Refs #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)