### PR TITLE
perf(slots): cache httpx SSL context for local probe clients

### DIFF
--- a/src/hal0/http_client.py
+++ b/src/hal0/http_client.py
@@ -1,0 +1,64 @@
+"""Shared httpx client construction — one cached SSL context per process (#1507).
+
+``httpx`` builds a fresh :class:`ssl.SSLContext` on **every**
+``AsyncClient`` construction, and building one loads the system CA
+bundle off disk. Measured on a v1.0 box (httpx 0.28.1, Python 3.12):
+
+    httpx.AsyncClient(timeout=1.0)                 89.2  ms
+    httpx.AsyncClient(timeout=1.0, verify=ctx)      0.121 ms   <- 737x cheaper
+
+That is 89 ms of *event-loop CPU*, not I/O — it cannot be hidden behind
+an ``await``. hal0 constructs a throwaway client per probe, so the
+metrics sampler, the slot fail-watcher and the ``/api/slots`` container
+probe each paid it every tick, all on the same event loop. Profiling
+``GET /api/slots`` on a 16-slot box (py-spy, 22 s window) attributed
+**8.45 s** to ``ssl.create_default_context`` alone — the single largest
+consumer of loop time, and the reason a ~7 s request took 12-15 s.
+
+Every one of those URLs is ``http://127.0.0.1:<port>/...``, which never
+negotiates TLS at all.
+
+Caching keeps TLS behaviour byte-identical: the context still comes from
+``httpx.create_ssl_context()``, it is just built once per process
+instead of once per request. An ``ssl.SSLContext`` is explicitly
+designed to be shared across many connections and threads.
+
+Use :func:`async_client` as a drop-in for ``httpx.AsyncClient(...)``.
+Callers that pass their own ``verify`` or a client ``cert`` keep full
+control — the shared context is only injected when neither is given.
+"""
+
+from __future__ import annotations
+
+import ssl
+from functools import cache
+from typing import Any
+
+import httpx
+
+__all__ = ["async_client", "shared_ssl_context"]
+
+
+@cache
+def shared_ssl_context(trust_env: bool = True) -> ssl.SSLContext:
+    """The process-wide SSL context, built once per ``trust_env`` value.
+
+    Keyed on ``trust_env`` because that flag changes which CA material
+    httpx loads (``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` honoured or not);
+    sharing one context across both settings would silently ignore the
+    caller's choice.
+    """
+    return httpx.create_ssl_context(trust_env=trust_env)
+
+
+def async_client(**kwargs: Any) -> httpx.AsyncClient:
+    """``httpx.AsyncClient`` with the cached SSL context pre-injected.
+
+    Behaviourally identical to constructing the client directly, minus
+    the per-call CA-bundle load. Falls back to plain construction when
+    the caller supplies ``verify`` or ``cert`` explicitly, so a call site
+    that needs bespoke TLS material is never quietly overridden.
+    """
+    if "verify" not in kwargs and "cert" not in kwargs:
+        kwargs["verify"] = shared_ssl_context(bool(kwargs.get("trust_env", True)))
+    return httpx.AsyncClient(**kwargs)

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -70,6 +70,7 @@ from hal0.config.schema import (
     resolve_chat_template,
     resolve_profile_flags,
 )
+from hal0.http_client import async_client
 from hal0.model_meta import model_is_mtp_eligible
 from hal0.profiles import ProfileCatalog
 from hal0.providers._gpu import (
@@ -1483,7 +1484,7 @@ class ContainerProvider(Provider):
 
     async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
         """Direct inference passthrough (used by tests; dispatcher is primary path)."""
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with async_client(timeout=30.0) as client:
             resp = await client.post(f"http://127.0.0.1:{port}/v1/chat/completions", json=body)
             resp.raise_for_status()
             return resp.json()  # type: ignore[no-any-return]
@@ -1654,7 +1655,7 @@ class ContainerProvider(Provider):
         health_url = f"http://127.0.0.1:{port}/health"
         models_url = f"http://127.0.0.1:{port}/v1/models"
         try:
-            async with httpx.AsyncClient(timeout=_HEALTH_REQUEST_TIMEOUT_S) as client:
+            async with async_client(timeout=_HEALTH_REQUEST_TIMEOUT_S) as client:
                 resp = await client.get(health_url)
                 if resp.status_code == 200:
                     try:

--- a/src/hal0/providers/flm.py
+++ b/src/hal0/providers/flm.py
@@ -39,6 +39,7 @@ from typing import Any
 import httpx
 
 from hal0.errors import Hal0Error
+from hal0.http_client import async_client
 from hal0.providers.base import ContainerSpec, Provider
 from hal0.runners import RUNNER_IMAGES
 
@@ -588,7 +589,7 @@ class FLMProvider(Provider):
         """
         models_url = f"http://127.0.0.1:{port}/v1/models"
         try:
-            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+            async with async_client(timeout=_HEALTH_TIMEOUT) as client:
                 models_resp = await client.get(models_url)
                 models_resp.raise_for_status()
                 data = models_resp.json()
@@ -641,7 +642,7 @@ class FLMProvider(Provider):
         models_url = f"http://127.0.0.1:{port}/v1/models"
         chat_url = f"http://127.0.0.1:{port}/v1/chat/completions"
         try:
-            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+            async with async_client(timeout=_HEALTH_TIMEOUT) as client:
                 models_resp = await client.get(models_url)
                 models_resp.raise_for_status()
                 data = models_resp.json()
@@ -655,7 +656,7 @@ class FLMProvider(Provider):
                 ids = [m.get("id") for m in models]
                 model_id = expected_model if expected_model in ids else models[0].get("id")
 
-            async with httpx.AsyncClient(timeout=_HEALTH_INFER_TIMEOUT) as client:
+            async with async_client(timeout=_HEALTH_INFER_TIMEOUT) as client:
                 probe_body = {
                     "model": model_id,
                     "messages": [{"role": "user", "content": "ping"}],
@@ -709,7 +710,7 @@ class FLMProvider(Provider):
         models_url = f"http://127.0.0.1:{port}/v1/models"
         embed_url = f"http://127.0.0.1:{port}/v1/embeddings"
         try:
-            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+            async with async_client(timeout=_HEALTH_TIMEOUT) as client:
                 models_resp = await client.get(models_url)
                 models_resp.raise_for_status()
                 data = models_resp.json()
@@ -722,7 +723,7 @@ class FLMProvider(Provider):
                     }
                 model_id = models[0].get("id")
 
-            async with httpx.AsyncClient(timeout=_HEALTH_INFER_TIMEOUT) as client:
+            async with async_client(timeout=_HEALTH_INFER_TIMEOUT) as client:
                 probe_body = {"model": model_id, "input": "ping"}
                 resp = await asyncio.shield(client.post(embed_url, json=probe_body))
                 if resp.status_code != 200:
@@ -748,7 +749,7 @@ class FLMProvider(Provider):
         """Passthrough /v1/chat/completions to FLM."""
         url = f"http://127.0.0.1:{port}/v1/chat/completions"
         try:
-            async with httpx.AsyncClient(timeout=_INFER_TIMEOUT) as client:
+            async with async_client(timeout=_INFER_TIMEOUT) as client:
                 resp = await client.post(url, json=body)
                 resp.raise_for_status()
                 return resp.json()

--- a/src/hal0/slots/metrics_collect.py
+++ b/src/hal0/slots/metrics_collect.py
@@ -164,6 +164,8 @@ async def llama_metrics(port: int) -> dict[str, Any]:
         return {}
     import httpx
 
+    from hal0.http_client import async_client
+
     metrics_url = f"http://127.0.0.1:{port}/metrics"
     slots_url = f"http://127.0.0.1:{port}/slots"
     timeout = httpx.Timeout(0.5)
@@ -171,7 +173,7 @@ async def llama_metrics(port: int) -> dict[str, Any]:
 
     # Fan the two scrapes out in parallel; either may 404 (older builds,
     # --no-slots, --no-metrics) and we degrade silently per-endpoint.
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with async_client(timeout=timeout) as client:
         try:
             metrics_resp, slots_resp = await asyncio.gather(
                 client.get(metrics_url),


### PR DESCRIPTION
## What changed

- New module `src/hal0/http_client.py` exposing `async_client(**kwargs)`, a drop-in for `httpx.AsyncClient(...)` that injects a process-wide cached SSL context (built once via `httpx.create_ssl_context`, keyed on `trust_env`). Callers that pass `verify` or `cert` explicitly are left untouched.
- Swapped local-probe call sites to `async_client`: `providers/container.py` (infer passthrough, health probe), `providers/flm.py` (models/chat/embeddings probes, infer passthrough), `slots/metrics_collect.py` (llama metrics/slots scrape).

## Why

`httpx` builds a fresh `ssl.SSLContext` on every `AsyncClient` construction, loading the system CA bundle off disk (~89 ms of event-loop CPU per client on a v1.0 box). hal0 constructs a throwaway client per probe, so the metrics sampler, slot fail-watcher, and `/api/slots` container probes each paid that cost every tick on the same event loop. py-spy attributed 8.45 s of a 22 s window to `ssl.create_default_context` — the main reason `GET /api/slots` took 11-15 s on a 16-slot box. All these URLs are `http://127.0.0.1` and never negotiate TLS. Refs #1507.

## How verified

Ran with `HAL0_HOME=$(mktemp -d) uv run pytest ... -q`:

- `tests/slot_view` + `tests/test_import.py`: 75 passed
- `tests/providers/test_flm.py` + `tests/providers/test_container_health_gating.py`: 44 passed
- `tests/metrics` + `tests/slots/test_fail_watcher.py`: 65 passed
- `ruff check` + `ruff format --check` on all four touched files: clean

`tests/providers/test_container.py` could not be completed locally: the TrueNAS host backing the `/mnt/ai-models` automount is down on the dev box, and several tests stat hardcoded `/mnt/ai-models/...` model paths, wedging in `autofs_wait`. Control run of the same file against unmodified `github/main` code hangs identically, confirming the hang is a pre-existing environment outage, not this diff (which only touches `infer()` and health-probe client construction). CI should exercise it normally.

## Out of scope

- The concurrent slot-probe rewrite of `slot_view/__init__.py` from the original #1507 work was dropped — main already has probe-concurrency coverage (`tests/slot_view/test_probe_concurrency.py`) and the rewrite carried no unique value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)