### PR TITLE
feat(observability): optional Sentry error reporting

### DIFF
--- a/docs/operate/sentry.mdx
+++ b/docs/operate/sentry.mdx
@@ -1,0 +1,148 @@
+---
+title: Report errors to Sentry
+description: Optional, off-by-default Sentry error reporting for the hal0 API, CLI, agent shim and dashboard, with the scrubbing rules that keep prompts and credentials off the wire.
+sidebar:
+  order: 140
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+
+hal0 can report crashes to [Sentry](https://sentry.io). It is **off unless you
+turn it on**, and turning it on takes two deliberate steps — installing an
+optional package and setting a DSN. A stock install has no Sentry package, no
+DSN, and sends nothing.
+
+<Aside type="caution" title="This sends data off your LAN">
+hal0 is otherwise a local-first appliance. Enabling Sentry means crash reports
+leave the box for a third-party service. Read [What gets sent](#what-gets-sent)
+before you enable it on anything holding real data.
+</Aside>
+
+## Enable it on the backend
+
+<Steps>
+
+1. Install the extra into the same environment hal0 runs from:
+
+   ```sh
+   /usr/lib/hal0/venv/bin/pip install 'hal0ai[sentry]'
+   ```
+
+2. Put the DSN somewhere the units read. A separate file keeps it out of
+   `api.env` and makes "turn it off" a single `rm`:
+
+   ```sh
+   sudo tee /etc/hal0/sentry.env >/dev/null <<'EOF'
+   HAL0_SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project>
+   HAL0_SENTRY_ENVIRONMENT=my-box
+   HAL0_SENTRY_TRACES_SAMPLE_RATE=0.1
+   EOF
+   sudo chmod 0640 /etc/hal0/sentry.env
+   sudo chgrp hal0 /etc/hal0/sentry.env
+   ```
+
+3. Point the units at it with drop-ins, then reload:
+
+   ```sh
+   for unit in hal0-api.service hal0-bench-worker.service hal0-agent@hermes.service; do
+     sudo mkdir -p "/etc/systemd/system/$unit.d"
+     printf '[Service]\nEnvironmentFile=-/etc/hal0/sentry.env\n' \
+       | sudo tee "/etc/systemd/system/$unit.d/sentry.conf" >/dev/null
+   done
+   sudo systemctl daemon-reload
+   sudo systemctl restart hal0-api.service
+   ```
+
+4. Confirm it took:
+
+   ```sh
+   /usr/lib/hal0/venv/bin/python -c \
+     'from hal0.observability import sentry; print(sentry.init_sentry("api"))'
+   ```
+
+   `True` means a DSN is configured and the SDK initialised.
+
+</Steps>
+
+### Settings
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `HAL0_SENTRY_DSN` | *(unset)* | The DSN. Unset or empty means Sentry is off. Falls back to `SENTRY_DSN`. |
+| `HAL0_SENTRY_ENVIRONMENT` | `development` | Sentry environment tag. |
+| `HAL0_SENTRY_SERVER_NAME` | hostname | Overrides the reported host. |
+| `HAL0_SENTRY_TRACES_SAMPLE_RATE` | `0` | Transaction sampling, `0`–`1`. |
+| `HAL0_SENTRY_PROFILES_SAMPLE_RATE` | `0` | Profile sampling, `0`–`1`. |
+| `HAL0_SENTRY_DEBUG` | off | Print the SDK's own transport logging. |
+
+Tracing defaults to `0` on purpose: hal0 serves long-lived streaming requests,
+and sampling every one of them on an inference box is expensive.
+
+## Enable it on the dashboard
+
+The dashboard reads its DSN at **build time**, so a dashboard you did not build
+with a DSN cannot start reporting later:
+
+```sh
+cd ui
+VITE_SENTRY_DSN='https://<key>@<org>.ingest.sentry.io/<project>' \
+VITE_SENTRY_ENVIRONMENT=my-box \
+npm run build
+```
+
+Then deploy `ui/dist` as usual. Without `VITE_SENTRY_DSN` the SDK lands in an
+unreferenced chunk that the browser never fetches.
+
+## What gets covered
+
+| Surface | How |
+| --- | --- |
+| `hal0-api.service` | `create_app()` initialises the SDK; the catch-all exception handler reports every 500 explicitly (a registered handler makes the exception "handled", so the Starlette integration would otherwise never see it). |
+| `hal0` CLI and `hal0-bench-worker.service` | The Typer root callback initialises before any subcommand; unhandled exceptions arrive via the SDK's excepthook. |
+| `hal0-agent@<id>.service` | The shim initialises inside `main()`, wrapped so a broken SDK can never stop an agent from starting. |
+| Dashboard | Global browser errors, plus an explicit capture in the view-level error boundary (it swallows render throws to keep the chrome alive). |
+
+4xx responses are not reported — those are the API contract working as
+designed. Only 5xx and genuinely unhandled exceptions become events.
+
+## What gets sent
+
+Every event passes a scrubber before it leaves the process
+(`hal0.observability.sentry.scrub_event`, mirrored in `ui/src/sentry.ts`):
+
+- the `user` block is dropped — no id, IP or email from hal0 itself;
+- request bodies, cookies, query strings and the WSGI environ are dropped, and
+  URLs are truncated at `?` (hal0 accepts `?api_key=` on WebSocket and SSE
+  upgrades, where browsers cannot set headers);
+- `Authorization` and friends are masked;
+- everything remaining is walked with hal0's own redaction helpers
+  (`hal0.api._redact`) — sensitive key names are masked by name, and free text
+  is scanned for `Bearer` / `*_KEY=` / `client_id=` tokens. That last rule is
+  what catches a credential echoed inside an upstream error message.
+
+If the scrubber itself fails, the event is dropped rather than sent raw.
+
+<Aside type="note" title="Two things the scrubber cannot do">
+**Geo-IP.** Sentry derives a coarse location from the IP that delivers the
+event. That happens on their side, after scrubbing. Turn on *Prevent Storing of
+IP Addresses* in the Sentry project's security & privacy settings if you do not
+want it.
+
+**Prompt text inside exception messages.** Prompts are never attached
+deliberately, but an exception whose message quotes user input will carry it.
+Do not add `extra={...}` payloads containing user text at capture sites.
+</Aside>
+
+## Turn it off
+
+Delete the DSN and restart — the code no-ops without one:
+
+```sh
+sudo rm /etc/hal0/sentry.env
+sudo rm -rf /etc/systemd/system/hal0-*.service.d/sentry.conf
+sudo systemctl daemon-reload
+sudo systemctl restart hal0-api.service
+```
+
+To remove it entirely, also `pip uninstall sentry-sdk` and rebuild the
+dashboard without `VITE_SENTRY_DSN`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,15 @@ dev = [
   "python-multipart>=0.0.9",
 ]
 
+# Optional error reporting. Deliberately NOT in `dependencies`: hal0 is a
+# self-hosted appliance that phones home to nobody by default, and the
+# absence of the package is a second, physical guarantee of that on top of
+# the "no DSN ⇒ no-op" logic in hal0.observability.sentry. Install with
+# `pip install 'hal0ai[sentry]'` only on boxes you want reporting from.
+sentry = [
+  "sentry-sdk>=2.20",
+]
+
 [project.scripts]
 hal0 = "hal0.cli.main:app"
 # hal0-agent is the small subprocess wrapper invoked by the systemd

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -135,6 +135,7 @@ from hal0.config.paths import activity_db
 from hal0.dispatcher.router import Dispatcher
 from hal0.events import EventBus
 from hal0.hardware.probe import HardwareProbe
+from hal0.observability import sentry
 from hal0.registry.discover import scan_and_register
 from hal0.registry.model import _BLESSED_PREFIX
 from hal0.registry.store import ModelRegistry
@@ -1906,6 +1907,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 def create_app() -> FastAPI:
+    # First statement in the factory, so an exception raised while BUILDING
+    # the app (router import, middleware construction) is already
+    # reportable. Inert unless HAL0_SENTRY_DSN is set — see
+    # hal0.observability.sentry.
+    sentry.init_sentry("api")
+
     app = FastAPI(
         title="hal0",
         version=__version__,

--- a/src/hal0/api/middleware/error_codes.py
+++ b/src/hal0/api/middleware/error_codes.py
@@ -37,6 +37,7 @@ from hal0.errors import (
     Unauthorized,
     UnprocessableEntity,
 )
+from hal0.observability import sentry
 
 log = structlog.get_logger(__name__)
 
@@ -74,6 +75,11 @@ def install(app: FastAPI) -> None:
     @app.exception_handler(Hal0Error)
     async def _hal0_handler(_: Request, exc: Hal0Error) -> JSONResponse:
         log.warning("hal0.error", code=exc.code, message=exc.message, **exc.details)
+        # 4xx Hal0Errors are the contract working as designed (bad request,
+        # not found, ...) and would be pure noise in Sentry. 5xx means hal0
+        # itself failed to hold up its end, which is worth an event.
+        if exc.status >= 500:
+            sentry.capture_exception(exc, component="api")
         # Honor a ``retry_after_s`` hint in details by promoting it to the
         # ``Retry-After`` HTTP header so OpenAI-compatible SDKs back off
         # correctly.  Only applied on 503 responses (RFC 7231 §7.1.3).
@@ -124,6 +130,11 @@ def install(app: FastAPI) -> None:
     @app.exception_handler(Exception)
     async def _unhandled_handler(_: Request, exc: Exception) -> JSONResponse:
         log.exception("hal0.unhandled", error=str(exc))
+        # This handler is why hal0 needs an EXPLICIT capture: registering
+        # `@app.exception_handler(Exception)` marks the exception handled,
+        # so Sentry's Starlette integration never sees it. Without this
+        # line every 500 would be invisible in Sentry.
+        sentry.capture_exception(exc, component="api")
         return JSONResponse(
             status_code=500,
             content=_envelope("system.internal", "internal server error"),

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -654,7 +654,28 @@ _DISPATCH: dict[str, Callable[[AgentConfig], int]] = {
 }
 
 
+def _init_sentry() -> None:
+    """Best-effort Sentry init for the shim process.
+
+    Imported HERE rather than at module scope on purpose: this module's
+    contract (see the module docstring) is that importing it pulls in
+    nothing but stdlib, so a hal0 wheel/import drift can never stop
+    ``hal0-agent@<id>.service`` from starting. The whole call is wrapped
+    so a missing package, a broken ``hal0.observability`` or a bad DSN
+    degrades to "no telemetry", never to "agent won't start".
+
+    No-op unless ``HAL0_SENTRY_DSN`` is set.
+    """
+    try:
+        from hal0.observability.sentry import init_sentry
+
+        init_sentry("agent")
+    except Exception:
+        return
+
+
 def main(argv: Sequence[str] | None = None) -> int:
+    _init_sentry()
     parser = _build_parser()
     args = parser.parse_args(argv)
     cfg = _load_agent_config(args.agent_id)

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -46,6 +46,7 @@ from hal0.cli.setup_command import app as setup_app
 from hal0.cli.slot_commands import app as slot_app
 from hal0.cli.update_commands import update_app
 from hal0.cli.upstream_commands import app as upstream_app
+from hal0.observability import sentry
 
 console = Console()
 
@@ -137,6 +138,11 @@ def main_callback(
     ),
 ) -> None:
     """hal0 — open-source home AI inference platform."""
+    # Runs before any subcommand, so `hal0 bench worker` (the long-lived
+    # hal0-bench-worker.service process) and every one-shot CLI call are
+    # both covered by one hook. Unhandled CLI exceptions are then picked up
+    # by the SDK's own excepthook integration. Inert without a DSN.
+    sentry.init_sentry("cli")
 
 
 # ---------------------------------------------------------------------------

--- a/src/hal0/observability/__init__.py
+++ b/src/hal0/observability/__init__.py
@@ -1,0 +1,15 @@
+"""Observability side-car wiring for hal0.
+
+Everything in this package is OPTIONAL and fails soft: hal0 must start,
+serve, and shut down identically whether or not the observability extras
+are installed or configured. Nothing here may become an import-time
+dependency of a hot path.
+
+Currently one member:
+
+    sentry.py  — optional Sentry error reporting (``pip install 'hal0ai[sentry]'``)
+"""
+
+from __future__ import annotations
+
+__all__ = ["sentry"]

--- a/src/hal0/observability/sentry.py
+++ b/src/hal0/observability/sentry.py
@@ -1,0 +1,327 @@
+"""Optional Sentry error reporting.
+
+hal0 is a self-hosted appliance: by default it phones home to nobody, and
+that default does not change here. Sentry is **inert unless a DSN is
+configured** — no DSN, no SDK import, no network egress, no behaviour
+change. That makes this module safe to call unconditionally from every
+entry point (API, CLI, agent shim) without gating each call site on an
+"is telemetry on" check.
+
+Enabling it
+-----------
+1. ``pip install 'hal0ai[sentry]'`` (or ``uv pip install sentry-sdk``)
+2. Set ``HAL0_SENTRY_DSN`` in the unit's environment file
+   (``/etc/hal0/api.env`` for ``hal0-api.service``).
+
+Environment
+-----------
+``HAL0_SENTRY_DSN``
+    The DSN. Falls back to the SDK-conventional ``SENTRY_DSN``. Empty or
+    unset ⇒ hard off. This is the ONLY switch; there is no separate
+    enable flag to drift out of sync with it.
+``HAL0_SENTRY_ENVIRONMENT``
+    Sentry "environment" tag. Default ``development`` — deliberately not
+    ``production``, so an operator who copies a DSN around without
+    thinking does not pollute a production stream.
+``HAL0_SENTRY_TRACES_SAMPLE_RATE`` / ``HAL0_SENTRY_PROFILES_SAMPLE_RATE``
+    Floats in ``[0, 1]``. Both default to ``0.0`` (errors only). hal0
+    serves long-lived streaming requests; sampling every transaction on
+    an inference box is expensive, so tracing is opt-in per install.
+``HAL0_SENTRY_SERVER_NAME``
+    Overrides the reported hostname. Defaults to ``socket.gethostname()``.
+``HAL0_SENTRY_DEBUG``
+    ``1``/``true``/``yes`` prints the SDK's own transport logging. For
+    diagnosing "why did my event not arrive".
+
+Privacy posture (strict scrub)
+------------------------------
+``send_default_pii=False`` and ``max_request_body_size="never"`` are the
+SDK-level floor; on top of that :func:`scrub_event` runs on every event
+and transaction and:
+
+* drops the ``user`` block entirely (no id / ip / email leaves the box),
+* drops request ``data`` / ``cookies`` / ``query_string`` / ``env``, and
+  truncates the request URL at ``?`` — hal0 accepts ``?api_key=`` on WS
+  and SSE upgrades (browsers cannot set headers there), so a query string
+  is assumed to be credential-bearing,
+* masks headers in :data:`SENSITIVE_HEADERS`,
+* walks the whole remaining event and applies hal0's OWN redaction
+  helpers — :func:`hal0.api._redact.is_sensitive_key` by key name and
+  :func:`hal0.api._redact.redact_log_line` on every string — so the
+  Sentry surface inherits exactly the scrubbing rules already proven on
+  ``/api/logs`` and the config-echo endpoints rather than inventing a
+  second, weaker pattern list that would drift.
+
+If scrubbing itself raises, the event is **dropped**, not sent raw.
+
+The dashboard has a twin of this policy in ``ui/src/sentry.ts``, including a
+hand-port of ``LOG_SECRET_RE``. Changing the pattern list here means changing
+it there too — a browser-side leak is just as bad as a server-side one.
+
+Prompt/completion content never reaches Sentry unless it appears inside an
+exception message; that residue is what ``redact_log_line`` is for. Do not
+add ``extra={...}`` payloads carrying user text at capture sites.
+
+Failure posture
+---------------
+Every public function swallows exceptions and returns a bool/None. A
+broken or unreachable Sentry must never take down an inference box.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Any, Final
+
+# Env var names, in resolution order. HAL0_-prefixed first so hal0's own
+# config surface wins over anything ambient in the unit environment.
+DSN_ENV_VARS: Final[tuple[str, ...]] = ("HAL0_SENTRY_DSN", "SENTRY_DSN")
+
+# Request headers masked wholesale. Compared lower-cased. Anything NOT in
+# this list still passes through the key-name scrubber below, which
+# catches ``X-Foo-Token``-shaped names generically; this set exists for
+# the names that carry a credential without a matching key-name token.
+SENSITIVE_HEADERS: Final[frozenset[str]] = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
+        "api-key",
+        "x-auth-token",
+        "x-hal0-admin-key",
+        "x-hal0-client-key",
+    }
+)
+
+# Request sub-keys dropped outright. ``env`` is Sentry's copy of the WSGI
+# environ; ``data`` is the parsed body (prompts live there).
+DROPPED_REQUEST_KEYS: Final[tuple[str, ...]] = ("data", "cookies", "query_string", "env")
+
+# Recursion guard for the event walker. Sentry events nest a handful of
+# levels; anything deeper is pathological and not worth the stack.
+_MAX_SCRUB_DEPTH: Final[int] = 12
+
+# Component name of the entry point that won the init race, or None when
+# Sentry is off / not yet initialised. Module-global because sentry_sdk's
+# own client is global too — a second init() would silently replace the
+# first one's config.
+_initialised_component: str | None = None
+
+
+def dsn_from_env() -> str:
+    """Return the configured DSN, or ``""`` when Sentry is off.
+
+    Whitespace-only values count as unset — an env file with
+    ``HAL0_SENTRY_DSN=`` (the shape a commented-out line degrades into)
+    must mean "off", not "misconfigured".
+    """
+    for name in DSN_ENV_VARS:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _float_env(name: str, default: float) -> float:
+    """Parse a ``[0, 1]`` sample rate from the environment.
+
+    Anything unparseable or out of range falls back to ``default`` rather
+    than raising — a typo in a sample rate must not stop a service from
+    starting.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if not 0.0 <= value <= 1.0:
+        return default
+    return value
+
+
+def _bool_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _scrub(value: Any, depth: int = 0) -> Any:
+    """Recursively redact a decoded-JSON-shaped structure.
+
+    Two independent rules, both borrowed from ``hal0.api._redact`` so this
+    module never becomes a second source of truth for "what is a secret":
+
+    * key name matches :func:`is_sensitive_key` ⇒ value replaced by
+      ``MASK``, without ever inspecting the value;
+    * any surviving ``str`` ⇒ passed through :func:`redact_log_line`,
+      which strips ``Bearer``/``*_KEY=``/``client_id=`` token bodies while
+      preserving the prefix.
+
+    Imported lazily: ``hal0.api._redact`` is pure-stdlib, but keeping the
+    import inside the call preserves this module's "importable from the
+    stdlib-only agent shim" property no matter what that module grows.
+    """
+    from hal0.api._redact import MASK, is_sensitive_key, redact_log_line
+
+    if depth > _MAX_SCRUB_DEPTH:
+        return MASK
+    if isinstance(value, dict):
+        out: dict[Any, Any] = {}
+        for key, item in value.items():
+            if isinstance(key, str) and is_sensitive_key(key):
+                out[key] = MASK
+            else:
+                out[key] = _scrub(item, depth + 1)
+        return out
+    if isinstance(value, (list, tuple)):
+        scrubbed = [_scrub(item, depth + 1) for item in value]
+        return type(value)(scrubbed) if isinstance(value, tuple) else scrubbed
+    if isinstance(value, str):
+        return redact_log_line(value)
+    return value
+
+
+def scrub_event(event: dict[str, Any], hint: Any = None) -> dict[str, Any] | None:
+    """``before_send`` / ``before_send_transaction`` hook.
+
+    Returns the scrubbed event, or ``None`` to drop it. See the module
+    docstring for the full policy. ``hint`` is accepted (and ignored) to
+    match the SDK's callback signature.
+    """
+    del hint  # SDK signature parity; hal0 does not branch on the hint
+    try:
+        from hal0.api._redact import MASK
+
+        event.pop("user", None)
+
+        request = event.get("request")
+        if isinstance(request, dict):
+            for key in DROPPED_REQUEST_KEYS:
+                request.pop(key, None)
+            url = request.get("url")
+            if isinstance(url, str) and "?" in url:
+                request["url"] = url.split("?", 1)[0]
+            headers = request.get("headers")
+            if isinstance(headers, dict):
+                request["headers"] = {
+                    name: (MASK if str(name).lower() in SENSITIVE_HEADERS else value)
+                    for name, value in headers.items()
+                }
+
+        scrubbed = _scrub(event)
+        return scrubbed if isinstance(scrubbed, dict) else None
+    except Exception:
+        # Fail CLOSED. An event we could not scrub is an event we do not
+        # send — the opposite choice would ship raw prompts on any future
+        # shape change in the SDK's event schema.
+        return None
+
+
+def init_sentry(component: str) -> bool:
+    """Initialise the SDK for ``component`` (``api`` / ``cli`` / ``agent``).
+
+    Returns True when Sentry is live afterwards, False when it is off for
+    any reason (no DSN, SDK not installed, init raised). Idempotent: the
+    first caller in a process wins and later calls are no-ops, so an
+    in-process CLI that also builds the FastAPI app does not re-init and
+    clobber the first client's config.
+    """
+    global _initialised_component
+
+    if _initialised_component is not None:
+        return True
+
+    dsn = dsn_from_env()
+    if not dsn:
+        return False
+
+    try:
+        import sentry_sdk
+    except ImportError:
+        # Extra not installed. Silent: a DSN in the environment of a box
+        # without the extra is a config leftover, not an error worth
+        # printing on every CLI invocation.
+        return False
+
+    try:
+        from hal0 import __version__
+
+        sentry_sdk.init(
+            dsn=dsn,
+            release=f"hal0@{__version__}",
+            environment=os.environ.get("HAL0_SENTRY_ENVIRONMENT", "").strip() or "development",
+            server_name=os.environ.get("HAL0_SENTRY_SERVER_NAME", "").strip()
+            or socket.gethostname(),
+            # Privacy floor — see module docstring. These three are the
+            # SDK-level guarantees; scrub_event is the hal0-level one.
+            send_default_pii=False,
+            max_request_body_size="never",
+            attach_stacktrace=True,
+            traces_sample_rate=_float_env("HAL0_SENTRY_TRACES_SAMPLE_RATE", 0.0),
+            profiles_sample_rate=_float_env("HAL0_SENTRY_PROFILES_SAMPLE_RATE", 0.0),
+            before_send=scrub_event,
+            before_send_transaction=scrub_event,
+            debug=_bool_env("HAL0_SENTRY_DEBUG"),
+        )
+        sentry_sdk.set_tag("hal0.component", component)
+        _initialised_component = component
+        return True
+    except Exception:
+        return False
+
+
+def capture_exception(exc: BaseException, *, component: str | None = None) -> None:
+    """Report ``exc`` to Sentry if it is live; otherwise do nothing.
+
+    Needed because hal0 installs a catch-all ``@app.exception_handler(Exception)``
+    (``hal0.api.middleware.error_codes``). A handled exception is invisible
+    to Sentry's Starlette integration, so unhandled-in-spirit 500s have to
+    be reported explicitly at that handler.
+
+    ``component`` tags the event when the caller knows a narrower scope
+    than the process-wide tag set at init.
+    """
+    if _initialised_component is None:
+        return
+    try:
+        import sentry_sdk
+
+        if component:
+            with sentry_sdk.new_scope() as scope:
+                scope.set_tag("hal0.component", component)
+                sentry_sdk.capture_exception(exc)
+        else:
+            sentry_sdk.capture_exception(exc)
+    except Exception:
+        return
+
+
+def active_component() -> str | None:
+    """Return the component name Sentry was initialised for, else None.
+
+    Read-only view of module state for tests and ``hal0 doctor``-style
+    reporting; never use it to gate behaviour that must work with Sentry
+    off.
+    """
+    return _initialised_component
+
+
+def _reset_for_tests() -> None:
+    """Clear the init latch. Tests only — not part of the public surface."""
+    global _initialised_component
+    _initialised_component = None
+
+
+__all__ = [
+    "DROPPED_REQUEST_KEYS",
+    "DSN_ENV_VARS",
+    "SENSITIVE_HEADERS",
+    "active_component",
+    "capture_exception",
+    "dsn_from_env",
+    "init_sentry",
+    "scrub_event",
+]

--- a/tests/observability/test_sentry.py
+++ b/tests/observability/test_sentry.py
@@ -1,0 +1,192 @@
+"""Contract tests for hal0.observability.sentry.
+
+Two things are being pinned here, and they are the two things that would
+actually hurt if they regressed:
+
+1. **Off by default.** No DSN ⇒ no init, no SDK import, no behaviour change.
+   hal0 ships as a self-hosted appliance; silently acquiring telemetry would
+   be a defect, not a feature.
+2. **The scrubber holds.** Every event passes through ``scrub_event``; if it
+   ever lets a bearer token, an api key or a request body through, secrets
+   leave the operator's LAN.
+
+The tests never call the real ``sentry_sdk`` (the extra is optional and is
+not in the ``dev`` group) — ``scrub_event`` is a pure function over the
+event dict, which is exactly the part worth testing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.api._redact import MASK
+from hal0.observability import sentry
+
+
+@pytest.fixture(autouse=True)
+def _clean_sentry_env(monkeypatch: pytest.MonkeyPatch):
+    """Neutralise ambient config and the module-level init latch.
+
+    A developer box with HAL0_SENTRY_DSN exported (or a previous test that
+    initialised the module) must not change what these tests assert.
+    """
+    for name in sentry.DSN_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    sentry._reset_for_tests()
+    yield
+    sentry._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Off by default
+# ---------------------------------------------------------------------------
+
+
+def test_no_dsn_means_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert sentry.dsn_from_env() == ""
+    assert sentry.init_sentry("api") is False
+    assert sentry.active_component() is None
+
+
+def test_blank_dsn_counts_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `HAL0_SENTRY_DSN=` in an env file is the shape a commented-out line
+    # degrades into. It must mean "off", not "misconfigured".
+    monkeypatch.setenv("HAL0_SENTRY_DSN", "   ")
+    assert sentry.dsn_from_env() == ""
+    assert sentry.init_sentry("api") is False
+
+
+def test_hal0_prefix_wins_over_bare_sentry_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "https://ambient@example.invalid/1")
+    monkeypatch.setenv("HAL0_SENTRY_DSN", "https://hal0@example.invalid/2")
+    assert sentry.dsn_from_env() == "https://hal0@example.invalid/2"
+
+
+def test_capture_exception_is_a_noop_when_off() -> None:
+    # No exception, no import of sentry_sdk, no output.
+    sentry.capture_exception(RuntimeError("boom"))
+
+
+def test_bad_sample_rate_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A typo in a sample rate must never stop a service from starting, so
+    # the parser clamps to the default instead of raising.
+    monkeypatch.setenv("RATE", "not-a-float")
+    assert sentry._float_env("RATE", 0.25) == 0.25
+    monkeypatch.setenv("RATE", "7")
+    assert sentry._float_env("RATE", 0.25) == 0.25
+    monkeypatch.setenv("RATE", "0.5")
+    assert sentry._float_env("RATE", 0.25) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Scrubbing
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_drops_user_block() -> None:
+    event = {"user": {"id": "alexander", "ip_address": "10.0.1.42"}, "message": "hi"}
+    scrubbed = sentry.scrub_event(dict(event))
+    assert scrubbed is not None
+    assert "user" not in scrubbed
+
+
+def test_scrub_drops_request_body_cookies_and_query() -> None:
+    event = {
+        "request": {
+            "url": "http://halo:8080/v1/chat/completions?api_key=sk-live-abcdef0123456789",
+            "query_string": "api_key=sk-live-abcdef0123456789",
+            "cookies": {"hal0_session": "deadbeef"},
+            "data": {"messages": [{"role": "user", "content": "my private prompt"}]},
+            "env": {"REMOTE_ADDR": "10.0.1.42"},
+            "headers": {
+                "Authorization": "Bearer sk-live-abcdef0123456789",
+                "User-Agent": "curl/8.5.0",
+            },
+        }
+    }
+    scrubbed = sentry.scrub_event(event)
+    assert scrubbed is not None
+    request = scrubbed["request"]
+
+    for dropped in sentry.DROPPED_REQUEST_KEYS:
+        assert dropped not in request
+    # The URL keeps its shape (useful for grouping) but loses the query.
+    assert request["url"] == "http://halo:8080/v1/chat/completions"
+    assert request["headers"]["Authorization"] == MASK
+    # Non-sensitive headers survive — the scrubber must stay useful.
+    assert request["headers"]["User-Agent"] == "curl/8.5.0"
+
+    # And the prompt text is gone with the body.
+    assert "my private prompt" not in repr(scrubbed)
+
+
+def test_scrub_masks_sensitive_keys_anywhere_in_the_event() -> None:
+    event = {
+        "extra": {
+            "HAL0_ADMIN_KEY": "hal0-admin-abc123",
+            "hf_token": "hf_abcdefghijklmno",
+            "slot_name": "flm",
+            "nested": [{"password": "hunter2"}],
+        }
+    }
+    scrubbed = sentry.scrub_event(event)
+    assert scrubbed is not None
+    extra = scrubbed["extra"]
+    assert extra["HAL0_ADMIN_KEY"] == MASK
+    assert extra["hf_token"] == MASK
+    assert extra["nested"][0]["password"] == MASK
+    # Non-sensitive keys are untouched.
+    assert extra["slot_name"] == "flm"
+
+
+def test_scrub_redacts_secrets_inside_free_text() -> None:
+    # The case the key-name rule cannot catch: a credential embedded in an
+    # exception message. redact_log_line keeps the prefix, kills the token.
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "type": "HTTPStatusError",
+                    "value": "401 from upstream (Authorization: Bearer sk-live-abcdef0123456789)",
+                }
+            ]
+        }
+    }
+    scrubbed = sentry.scrub_event(event)
+    assert scrubbed is not None
+    value = scrubbed["exception"]["values"][0]["value"]
+    assert "sk-live-abcdef0123456789" not in value
+    assert MASK in value
+    # Prefix preserved so an operator can still tell what kind of secret it was.
+    assert "Authorization: Bearer" in value
+
+
+def test_scrub_fails_closed_on_a_broken_event() -> None:
+    class Exploding(dict):
+        def get(self, *_args, **_kwargs):  # type: ignore[override]
+            raise RuntimeError("unexpected event shape")
+
+    # An event we cannot scrub is an event we do not send.
+    assert sentry.scrub_event(Exploding()) is None
+
+
+def test_scrub_bounds_recursion() -> None:
+    # A self-referential-by-depth structure must terminate rather than blow
+    # the stack inside the SDK's before_send hook.
+    event: dict = {}
+    node = event
+    for _ in range(40):
+        child: dict = {}
+        node["child"] = child
+        node = child
+    node["done"] = True
+
+    scrubbed = sentry.scrub_event(event)
+    assert scrubbed is not None
+
+    depth = 0
+    cursor = scrubbed
+    while isinstance(cursor, dict) and "child" in cursor:
+        cursor = cursor["child"]
+        depth += 1
+    assert depth <= sentry._MAX_SCRUB_DEPTH + 1

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
+        "@sentry/react": "^10.69.0",
         "@tanstack/react-query": "^5.59.0",
         "d3-force": "^3.0.0",
         "react": "^18.3.1",
@@ -1418,6 +1419,112 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+      "integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0",
+        "@sentry/feedback": "10.69.0",
+        "@sentry/replay": "10.69.0",
+        "@sentry/replay-canvas": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+      "integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+      "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+      "integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+      "integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.69.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+      "integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.69.0",
+        "@sentry/core": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.69.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+      "integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.69.0",
+        "@sentry/replay": "10.69.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource/jetbrains-mono": "^5.2.8",
+    "@sentry/react": "^10.69.0",
     "@tanstack/react-query": "^5.59.0",
     "d3-force": "^3.0.0",
     "react": "^18.3.1",

--- a/ui/src/dash/main.jsx
+++ b/ui/src/dash/main.jsx
@@ -21,6 +21,10 @@ import { AuthGate } from './auth/AuthGate.jsx'
 // index.html), so a box that's live-updated without a UI rebuild still
 // shows its true version.
 import { useUpdateState } from '@/api/hooks/useUpdates'
+// Optional error reporting (src/sentry.ts). Import is always safe: with no
+// VITE_SENTRY_DSN baked in, captureUiException is a no-op and the SDK chunk is
+// never fetched.
+import { captureUiException } from '@/sentry'
 
 const { useState: useStateA, useEffect: useEffectA } = React;
 
@@ -122,6 +126,11 @@ class ViewErrorBoundary extends React.Component {
   componentDidCatch(err, info) {
     // Surface in the console for diagnosis; never re-throw.
     console.error("view crashed:", err, info && info.componentStack);
+    // This boundary swallows the throw to keep the chrome alive, so the
+    // browser's global error handler never sees it — a black-screened view
+    // would be invisible in Sentry without an explicit capture. No-op when
+    // Sentry is off (the shipped default).
+    captureUiException(err, info && info.componentStack);
   }
   render() {
     if (this.state.err) {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -22,6 +22,13 @@
 //    evaluation depth-first means imports run fully before the importer's
 //    own statements, so an inline `globalThis.React = React` further down
 //    in this file would execute AFTER the dash imports.
+// 0) Optional error reporting, kicked off before anything else so the SDK is
+//    installing while the dash modules evaluate. No-op unless VITE_SENTRY_DSN
+//    was set at build time — see src/sentry.ts. Fire-and-forget: nothing below
+//    may wait on the network.
+import { initSentry } from './sentry'
+void initSentry()
+
 import './globals-install'
 
 // Self-hosted fonts (package.json shipped these but nothing imported them,

--- a/ui/src/sentry.test.ts
+++ b/ui/src/sentry.test.ts
@@ -1,0 +1,57 @@
+// Pins the browser-side secret scrubber in src/sentry.ts.
+//
+// `redactSecrets` is a hand-port of `LOG_SECRET_RE` in
+// `src/hal0/api/_redact.py`. A port with no test is a leak waiting for the
+// next pattern change, and this one is not theoretical: the first live test of
+// the Sentry wiring shipped a bearer token from the browser that the Python
+// side had already masked, because the browser hook only scrubbed URLs and
+// bodies. These cases mirror `tests/observability/test_sentry.py`.
+
+import { describe, expect, it } from 'vitest'
+
+import { redactSecrets } from './sentry'
+
+const MASK = '***REDACTED***'
+
+describe('redactSecrets', () => {
+  it('masks an Authorization: Bearer header, keeping the prefix', () => {
+    const out = redactSecrets(
+      '401 from upstream (Authorization: Bearer sk-live-abcdef0123456789)',
+    ) as string
+    expect(out).not.toContain('sk-live-abcdef0123456789')
+    expect(out).toContain(MASK)
+    // The prefix survives so an operator can tell what kind of secret it was.
+    expect(out).toContain('Authorization: Bearer')
+  })
+
+  it('masks a bare Bearer token', () => {
+    const out = redactSecrets('sent Bearer sk-live-abcdef0123456789 upstream') as string
+    expect(out).toBe(`sent Bearer ${MASK} upstream`)
+  })
+
+  it('masks HAL0_BEARER_TOKEN= and *_KEY= assignments', () => {
+    expect(redactSecrets('HAL0_BEARER_TOKEN=abc123')).toBe(`HAL0_BEARER_TOKEN=${MASK}`)
+    expect(redactSecrets('HAL0_ADMIN_KEY=hal0-admin-abc123')).toBe(`HAL0_ADMIN_KEY=${MASK}`)
+    expect(redactSecrets('KEY=abc123')).toBe(`KEY=${MASK}`)
+  })
+
+  it('masks a long client_id but leaves short non-secret labels alone', () => {
+    expect(redactSecrets('client_id=abcdefghijklmnopqrst')).toBe(`client_id=${MASK}`)
+    // The Python original length-gates this at 16+ chars so the legitimate
+    // short labels (`anonymous`, the 12-hex-char hash) are not masked.
+    expect(redactSecrets('client_id=anonymous')).toBe('client_id=anonymous')
+  })
+
+  it('masks every occurrence in one string, not just the first', () => {
+    const out = redactSecrets('Bearer aaaaaaaaaaaa and HAL0_ADMIN_KEY=bbbbbbbbbbbb') as string
+    expect(out).toBe(`Bearer ${MASK} and HAL0_ADMIN_KEY=${MASK}`)
+  })
+
+  it('leaves ordinary text and non-strings untouched', () => {
+    expect(redactSecrets('slot flm failed to start on port 8081')).toBe(
+      'slot flm failed to start on port 8081',
+    )
+    expect(redactSecrets(undefined)).toBeUndefined()
+    expect(redactSecrets(42)).toBe(42)
+  })
+})

--- a/ui/src/sentry.ts
+++ b/ui/src/sentry.ts
@@ -1,0 +1,183 @@
+// Optional browser-side Sentry for the hal0 dashboard.
+//
+// Mirrors the backend posture in `src/hal0/observability/sentry.py`: hal0 is a
+// self-hosted appliance, so this is INERT unless a DSN is configured at build
+// time. The SDK sits behind a dynamic `import()`, so it lands in its own
+// rollup chunk that `index.html` does not reference: with no DSN the chunk is
+// emitted to dist/ but never fetched, no listener is installed, and no request
+// leaves the browser. (Verify after a build: the entry chunk named in
+// dist/index.html must contain no `sentry-trace` string.)
+//
+// Configuration (Vite env, baked in at `npm run build`):
+//
+//   VITE_SENTRY_DSN                 the DSN. Unset/empty ⇒ hard off.
+//   VITE_SENTRY_ENVIRONMENT         environment tag. Default 'development'.
+//   VITE_SENTRY_TRACES_SAMPLE_RATE  float in [0,1]. Default 0 (errors only).
+//
+// Because these are build-time values, a dashboard already deployed to
+// `/usr/lib/hal0/current/ui/dist` cannot be switched on without a rebuild —
+// which is the point: an artifact built without a DSN has no endpoint to
+// report to, and grepping it for the ingest host proves it.
+//
+// Privacy posture (strict scrub), matching the backend:
+//   * `sendDefaultPii: false`, and the `user` block is dropped outright.
+//   * every URL is truncated at `?` before it is sent. hal0 accepts
+//     `?api_key=` on SSE/WS URLs (browsers cannot set headers on those), so a
+//     query string is assumed to be credential-bearing.
+//   * no Session Replay, no `attachStacktrace` of DOM content — a replay of a
+//     chat pane would ship prompt text off the box.
+
+// Injected by vite.config.ts `define`.
+declare const __HAL0_UI_VERSION__: string
+
+type SentryModule = typeof import('@sentry/react')
+
+// Populated once the dynamic import resolves. Null while Sentry is off, or
+// during the window between page load and the chunk arriving.
+let sentry: SentryModule | null = null
+
+function readSampleRate(raw: unknown, fallback: number): number {
+  const value = Number.parseFloat(String(raw ?? ''))
+  if (!Number.isFinite(value) || value < 0 || value > 1) return fallback
+  return value
+}
+
+// Truncate at the first '?'. Applied to every URL-shaped field we know Sentry
+// populates. Non-strings pass through untouched.
+function stripQuery(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  const cut = value.indexOf('?')
+  return cut === -1 ? value : value.slice(0, cut)
+}
+
+// Same sentinel the Python side uses, so a masked value looks identical
+// whichever process produced the event.
+const MASK = '***REDACTED***'
+
+// Free-text secret scanner. This is a deliberate port of `LOG_SECRET_RE` in
+// `src/hal0/api/_redact.py` — KEEP THE TWO IN SYNC. Dropping URL query strings
+// and request bodies is not enough on its own: a credential also travels
+// inside exception *text* (an upstream 401 that echoes the header it was sent),
+// and that path is how a real token reached Sentry the first time this wiring
+// was tested. Each alternative captures the prefix and the token separately so
+// the prefix survives and only the token body is destroyed — an operator
+// reading a redacted event can still see what kind of secret was present.
+const SECRET_RE =
+  /(Authorization:\s*Bearer\s+)(\S+)|(HAL0_BEARER_TOKEN=)(\S+)|(Bearer\s+)([A-Za-z0-9_\-.]+)|(client_id=)([A-Za-z0-9_\-.]{16,})|(\b(?:[A-Za-z][A-Za-z0-9_]*_KEY|KEY)=)(\S+)/gi
+
+// Exported for `sentry.test.ts` — the port is only trustworthy if it is
+// pinned against the same cases as the Python original.
+export function redactSecrets(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  return value.replace(SECRET_RE, (match, ...groups: (string | undefined)[]) => {
+    // Alternatives are (prefix, token) pairs; the first defined prefix wins.
+    for (let i = 0; i < 10; i += 2) {
+      if (groups[i] !== undefined) return `${groups[i]}${MASK}`
+    }
+    return match
+  })
+}
+
+/**
+ * Initialise browser Sentry. Safe to call unconditionally and more than once;
+ * the second call is a no-op. Resolves to true when Sentry ends up live.
+ *
+ * Deliberately async + dynamically imported so that a build WITHOUT a DSN
+ * never pulls the SDK into the bundle. The trade-off is a short window at
+ * startup where an error is not yet captured; a synchronous static import
+ * would close that window at the cost of shipping the SDK to every install.
+ */
+export async function initSentry(): Promise<boolean> {
+  if (sentry) return true
+
+  const dsn = String(import.meta.env.VITE_SENTRY_DSN ?? '').trim()
+  if (!dsn) return false
+
+  try {
+    const mod = await import('@sentry/react')
+    const tracesSampleRate = readSampleRate(import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE, 0)
+
+    mod.init({
+      dsn,
+      release: `hal0-ui@${__HAL0_UI_VERSION__}`,
+      environment: String(import.meta.env.VITE_SENTRY_ENVIRONMENT ?? '').trim() || 'development',
+      sendDefaultPii: false,
+      tracesSampleRate,
+      // Only add the tracing integration when it will actually sample —
+      // otherwise it instruments every fetch/XHR on the dashboard's polling
+      // loops for events that are immediately discarded.
+      integrations: tracesSampleRate > 0 ? [mod.browserTracingIntegration()] : [],
+      beforeSend(event) {
+        try {
+          delete event.user
+          if (event.request) {
+            event.request.url = stripQuery(event.request.url) as string | undefined
+            delete event.request.query_string
+            delete event.request.cookies
+            delete event.request.data
+          }
+          if (Array.isArray(event.breadcrumbs)) {
+            for (const crumb of event.breadcrumbs) {
+              if (typeof crumb?.message === 'string') {
+                crumb.message = redactSecrets(crumb.message) as string
+              }
+              if (crumb?.data && typeof crumb.data === 'object') {
+                const data = crumb.data as Record<string, unknown>
+                if ('url' in data) data.url = stripQuery(data.url)
+                for (const [key, item] of Object.entries(data)) {
+                  if (typeof item === 'string') data[key] = redactSecrets(item) as string
+                }
+              }
+            }
+          }
+
+          // The text surfaces. `message` is the top-level string form,
+          // `logentry` its structured twin, and `exception.values[].value` is
+          // what actually carries an upstream 401's echoed header.
+          if (typeof event.message === 'string') {
+            event.message = redactSecrets(event.message) as string
+          }
+          if (event.logentry && typeof event.logentry.message === 'string') {
+            event.logentry.message = redactSecrets(event.logentry.message) as string
+          }
+          for (const value of event.exception?.values ?? []) {
+            if (typeof value.value === 'string') {
+              value.value = redactSecrets(value.value) as string
+            }
+          }
+
+          return event
+        } catch {
+          // Fail closed, same as the backend: an event we could not scrub is
+          // an event we do not send.
+          return null
+        }
+      },
+    })
+    mod.setTag('hal0.component', 'ui')
+    sentry = mod
+    return true
+  } catch {
+    // A blocked chunk fetch or a DSN typo must never break the dashboard.
+    return false
+  }
+}
+
+/**
+ * Report a React render-time crash. No-op while Sentry is off.
+ *
+ * Called from `ViewErrorBoundary.componentDidCatch` in `dash/main.jsx`: that
+ * boundary swallows the throw to keep the chrome alive, so without an explicit
+ * capture here a black-screened view would be invisible in Sentry.
+ */
+export function captureUiException(err: unknown, componentStack?: string): void {
+  if (!sentry) return
+  try {
+    sentry.withScope((scope) => {
+      if (componentStack) scope.setContext('react', { componentStack })
+      sentry!.captureException(err)
+    })
+  } catch {
+    return
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -61,6 +61,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  // Same single source of truth the <title> stamp uses (appVersion, read from
+  // package.json above), exposed to app code so src/sentry.ts can tag events
+  // with the exact UI build that produced them instead of carrying a second
+  // version constant that would drift.
+  define: {
+    __HAL0_UI_VERSION__: JSON.stringify(appVersion),
+  },
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## What

Adds an optional, opt-in Sentry error-reporting integration across the backend and UI. All changes are additive (+1107 lines, 17 files):

- `src/hal0/observability/` — new module wrapping sentry-sdk init, DSN/config resolution, and scrubbing
- API wiring in `src/hal0/api/__init__.py` plus an error-code hook in `src/hal0/api/middleware/error_codes.py`
- CLI wiring in `src/hal0/cli/main.py` and `src/hal0/cli/agent_shim.py`
- UI: `ui/src/sentry.ts` with integration in `ui/src/main.tsx`, `ui/src/dash/main.jsx`, and `ui/vite.config.ts`
- Tests on both sides: `tests/observability/test_sentry.py` and `ui/src/sentry.test.ts`
- Docs: `docs/operate/sentry.mdx`

## Why

Operators need optional crash/error telemetry for hal0 deployments without making Sentry a hard dependency. The feature is disabled unless a DSN is configured.

## Verification

- `HAL0_HOME=$(mktemp -d) uv run pytest tests/observability/test_sentry.py -x -q` — 11 passed
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/api/test_middleware.py tests/api/test_smoke.py tests/api/test_typed_errors.py -x -q` — 33 passed (middleware seam smoke)
- `uv run ruff check` on all touched Python files — clean
- `ui/`: `npm run typecheck` clean, `npm run lint` clean, `npx vitest run src/sentry.test.ts` — 6 passed
- Rebased cleanly onto `github/main` (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)