### PR TITLE
chore(release): v1 release prep — PyPI preview guard, ui typecheck gate, test-CT preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,12 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      # Runs BEFORE build: `vite build` transpiles per-file and never
+      # type-checks across module boundaries, so a field renamed in one file
+      # and still read in another builds green forever. That is exactly how
+      # useRuntime.ts came to filter on a property the normaliser had already
+      # renamed — a dead condition nothing could have caught here.
+      - name: Typecheck
+        run: npm run typecheck
       - name: Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -802,6 +802,7 @@ jobs:
           EXPECTED_PRERELEASE: ${{ needs.resolve.outputs.github_prerelease }}
           EXPECTED_LATEST: ${{ needs.resolve.outputs.github_latest }}
           PUBLISH_PYPI: ${{ needs.resolve.outputs.publish_pypi }}
+          POLICY_KIND: ${{ needs.resolve.outputs.kind }}
           SIGNER_IDENTITY: ${{ needs.resolve.outputs.signer_identity }}
           EXPECTED_DIGEST: ${{ needs.release.outputs.tarball_digest }}
         run: |
@@ -1077,7 +1078,7 @@ jobs:
           PY
             echo "pypi_evidence=PyPI publication | hal0ai==${PYPI_VERSION} verified" >> "$GITHUB_OUTPUT"
           else
-            echo "pypi_evidence=PyPI publication | not required (nightly policy)" >> "$GITHUB_OUTPUT"
+            echo "pypi_evidence=PyPI publication | not required (${POLICY_KIND} policy)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Record non-mutating authorization evidence

--- a/packaging/proxmox/hal0-test-template/README.md
+++ b/packaging/proxmox/hal0-test-template/README.md
@@ -18,8 +18,11 @@ A vanilla **Ubuntu 24.04** LXC (VMID **200**, `hal0-test-template`) with:
   otherwise (see memory `dreamserver_ct108_eval`)
 - `hal0-test-ready.service` — a per-boot oneshot that writes
   `/tmp/hal0-test-ready` so the harness knows a clone is up
-- LAN nameserver (`192.0.2.1 192.0.2.2`) — the pve host's resolv.conf points at
-  a Tailscale resolver (`100.100.100.100`) that does **not** work inside the CT
+- an explicit LAN nameserver — the pve host's resolv.conf points at a Tailscale
+  resolver (`100.100.100.100`) that does **not** work inside the CT, so the
+  clone must be given a reachable resolver or every `apt-get` and model pull
+  fails with a DNS error. Copy the real value off a live hal0 CT rather than
+  guessing: `pct config 105 | grep -E 'nameserver|searchdomain'`
 
 No `mp0` model mount: bind mounts can't be templated, and the install/uninstall
 smoke doesn't warm models. `fresh-test-ct.sh --with-models` adds it per-clone.
@@ -35,7 +38,9 @@ pct create 200 local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst \
   --unprivileged 0 --onboot 0
 # append the passthrough block (dev0-3 + cgroup allows + memlock + apparmor)
 # — copy the lines from /etc/pve/lxc/105.conf (minus the mp* mounts)
-pct set 200 --nameserver "192.0.2.1 192.0.2.2" --searchdomain thinmint.dev
+# DNS: copy the working values off a live hal0 CT — do NOT invent them.
+#   pct config 105 | grep -E 'nameserver|searchdomain'
+pct set 200 --nameserver "<lan-resolver> 1.1.1.1" --searchdomain "<your-domain>"
 pct start 200
 # provision (this dir): pct push provision.sh + hal0-test-ready.service + a
 # pubkey file, then `pct exec 200 -- bash /root/provision.sh`

--- a/scripts/fresh-test-ct.sh
+++ b/scripts/fresh-test-ct.sh
@@ -43,6 +43,32 @@ done
 PVE() { ssh -i "$KEY" -o BatchMode=yes -o ConnectTimeout=10 "$PVE_HOST" "$@"; }
 log() { echo "[fresh-test-ct] $*" >&2; }
 
+# ── preflight: fail loudly BEFORE allocating a vmid ─────────────────────────
+# `pct clone` against a missing template produced a bare "install_ok:false"
+# JSON row with no reason, which reads as "the installer broke" when in fact
+# the harness was pointed at a template that does not exist. Both defaults
+# (HAL0_PVE=pve, HAL0_TEST_TEMPLATE=200) go stale as soon as the lab is
+# rebuilt, so check them explicitly and say what IS available.
+PVE "true" >/dev/null 2>&1 || {
+  echo "cannot reach Proxmox host via ssh alias '${PVE_HOST}'" >&2
+  echo "  set HAL0_PVE to the right ssh alias (check: grep -i '^Host ' ~/.ssh/config)" >&2
+  exit 2
+}
+if ! PVE "pct config ${TEMPLATE}" >/dev/null 2>&1; then
+  echo "template CT ${TEMPLATE} does not exist on ${PVE_HOST}" >&2
+  echo "  set HAL0_TEST_TEMPLATE to a real template vmid. Templates present:" >&2
+  PVE "pct list | tail -n +2 | awk '{print \$1}' | while read -r v; do
+        pct config \"\$v\" 2>/dev/null | grep -q '^template: 1' && echo \"    \$v \$(pct config \"\$v\" | sed -n 's/^hostname: //p')\"
+      done" >&2 || true
+  exit 2
+fi
+PVE "pct config ${TEMPLATE} | grep -q '^template: 1'" 2>/dev/null || {
+  echo "CT ${TEMPLATE} exists but is NOT a template — refusing to clone a live container" >&2
+  echo "  convert it first: pct stop ${TEMPLATE} && pct template ${TEMPLATE}" >&2
+  exit 2
+}
+[[ -r "$KEY" ]] || { echo "ssh key not readable: ${KEY} (set HAL0_TEST_KEY)" >&2; exit 2; }
+
 # Pick a free ephemeral vmid (990-999) if none given.
 if [[ -z "$VMID" ]]; then
   for c in $(seq 990 999); do
@@ -60,6 +86,7 @@ emit() {
     "$VMID" "$INSTALL_OK" "$SMOKE_OK" "$UNINSTALL_OK" "$RESIDUE" "$IP" "$elapsed"
 }
 cleanup() {
+  [[ -n "${KNOWN_HOSTS:-}" ]] && rm -f "${KNOWN_HOSTS}"
   if [[ "$KEEP" == "1" ]]; then log "--keep: clone $VMID left running at ${IP:-?}"; return; fi
   # A privileged LXC holding /dev/kfd (after install warms ROCm) hangs on
   # `lxc-stop --kill`. SIGKILL the lxc-start monitor first — that tears the
@@ -95,7 +122,17 @@ IP="$(PVE "pct exec $VMID -- hostname -I" 2>/dev/null | awk '{print $1}')"
 [[ -n "$IP" ]] || { log "no IP"; emit; exit 1; }
 log "clone IP $IP"
 
-SSH() { ssh -i "$KEY" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 "halo@$IP" "$@"; }
+# Throwaway known_hosts. Ephemeral clones recycle both vmids AND DHCP leases,
+# so a previous run's host key sits in ~/.ssh/known_hosts under the same IP and
+# the next run dies on REMOTE HOST IDENTIFICATION HAS CHANGED. accept-new does
+# NOT cover a *changed* key — only an unknown one — so isolate the file instead
+# of polluting (or having to hand-prune) the operator's real known_hosts.
+# (Removed by cleanup() — do NOT add a second `trap ... EXIT` here, it would
+# override `trap cleanup EXIT` above and orphan every clone.)
+KNOWN_HOSTS="$(mktemp)"
+SSH() { ssh -i "$KEY" -o BatchMode=yes -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile="$KNOWN_HOSTS" -o GlobalKnownHostsFile=/dev/null \
+  -o ConnectTimeout=10 "halo@$IP" "$@"; }
 for _ in $(seq 1 30); do SSH true 2>/dev/null && break; sleep 2; done
 
 # ── install ──────────────────────────────────────────────────────────────────

--- a/src/hal0/release/policy.py
+++ b/src/hal0/release/policy.py
@@ -71,7 +71,13 @@ class ReleasePolicy:
                 manifest_targets=("preview",),
                 github_prerelease=True,
                 github_latest=False,
-                publish_pypi=True,
+                # Previews do NOT go to PyPI. A PyPI upload is permanent and
+                # undeletable, so burning `1.0.0rcN` on a developer preview
+                # spends a version string we can never reclaim — and anyone
+                # running `pip install hal0ai --pre` would be served it. A
+                # preview's distribution channel is the GitHub prerelease and
+                # the `preview` release manifest; PyPI is reserved for stable.
+                publish_pypi=False,
                 retain=True,
             )
         if match := _FINAL.fullmatch(tag):

--- a/tests/release/test_policy.py
+++ b/tests/release/test_policy.py
@@ -13,9 +13,9 @@ from hal0.release.policy import ReleasePolicy, ReleaseTagError
 @pytest.mark.parametrize(
     ("tag", "kind", "stage", "targets", "prerelease", "latest", "pypi", "python_version"),
     [
-        ("v1.0.0-alpha.0", "preview", "alpha", ("preview",), True, False, True, "1.0.0a0"),
-        ("v1.0.0-beta.2", "preview", "beta", ("preview",), True, False, True, "1.0.0b2"),
-        ("v1.0.0-rc.1", "preview", "rc", ("preview",), True, False, True, "1.0.0rc1"),
+        ("v1.0.0-alpha.0", "preview", "alpha", ("preview",), True, False, False, "1.0.0a0"),
+        ("v1.0.0-beta.2", "preview", "beta", ("preview",), True, False, False, "1.0.0b2"),
+        ("v1.0.0-rc.1", "preview", "rc", ("preview",), True, False, False, "1.0.0rc1"),
         ("v1.0.0", "stable", None, ("stable", "preview"), False, True, True, "1.0.0"),
         (
             "v1.0.1-nightly.20260721060000",
@@ -78,6 +78,6 @@ def test_github_outputs_are_strings() -> None:
         "manifest_targets": "preview",
         "github_prerelease": "true",
         "github_latest": "false",
-        "publish_pypi": "true",
+        "publish_pypi": "false",
         "retain": "true",
     }

--- a/tests/release/test_workflow_contract.py
+++ b/tests/release/test_workflow_contract.py
@@ -376,7 +376,10 @@ def test_authorizer_conditionally_checks_exact_pypi_version_with_bounded_retries
     assert "--max-time 20" in run
     assert 'payload["info"]["name"] != "hal0ai"' in run
     assert 'payload["info"]["version"] != expected' in run
-    assert "PyPI publication | not required (nightly policy)" in run
+    # The skip branch names the actual policy kind — both nightly and preview
+    # skip PyPI now, so hardcoding "nightly" would misreport a preview release.
+    assert "PyPI publication | not required (${POLICY_KIND} policy)" in run
+    assert "POLICY_KIND: ${{ needs.resolve.outputs.kind }}" in _workflow_text()
 
 
 def test_evidence_is_appended_only_after_all_remote_checks() -> None:


### PR DESCRIPTION
**Human review required before merge**

## What

Three v1 release-prep hardening changes:

1. **Keep developer previews off PyPI** (`src/hal0/release/policy.py`, `.github/workflows/release.yml`): the release policy now refuses to publish developer-preview versions to PyPI, with tests (`tests/release/test_policy.py`) and a workflow-contract evidence string (`tests/release/test_workflow_contract.py`) pinning the workflow to the policy.
2. **CI ui typecheck gate** (`.github/workflows/ci.yml`): `npm run typecheck` now runs before build in the ui job. `vite build` transpiles per-file and never type-checks across module boundaries, so renamed-field dead reads (like the one #1494 fixed in `useRuntime.ts`) built green forever.
3. **fresh-test-ct.sh preflight / host-key isolation** (`scripts/fresh-test-ct.sh`, `packaging/proxmox/hal0-test-template/README.md`): fail loudly on a stale template, isolate clone host keys, and document the template DNS guidance.

## Why

Release hygiene ahead of v1.0.0: prevent accidental preview publishes, close the UI type-gate gap CI was silently missing, and make the Proxmox test-clone harness fail fast instead of confusingly.

## Verification

- Rebased onto `main` (was ~62 commits behind). Conflict in `ui/src/api/hooks/useRuntime.ts` resolved in favor of main's #1494 shape (`modelDefault` camelCase read; boolean `ok` health checks untouched); the typecheck-gate commit now carries only the CI change and its message was reworded accordingly.
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/release/test_policy.py tests/release/test_workflow_contract.py -x -q` — 31 passed.
- `uv run ruff check` on touched Python files — clean.
- `npm run typecheck` from `ui/` (the exact command the new CI step runs) — exit 0.

## Out of scope

CI watch-to-green and merge are left for human review (release/CI policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
