### PR TITLE
feat(runner-images): tag-aware short ids + real image sizes in catalogue sync

### DIFF
--- a/src/hal0/registry/runner_image_store.py
+++ b/src/hal0/registry/runner_image_store.py
@@ -192,6 +192,33 @@ class RunnerImageStore:
         self._notify_change()
         return self.get(image_id)
 
+    def prune_absent(self, keep_ids: set[str]) -> int:
+        """Delete rows whose id is not in ``keep_ids`` and has no local pull.
+
+        Called by the sync job after a *successful* images.json fetch so
+        removed/renamed manifest entries (e.g. the repo-path ids used
+        before images.json carried per-entry ``id`` short names) don't
+        linger as stale duplicates. Rows with ``local_path`` set are kept —
+        a downloaded image stays visible even if delisted upstream.
+        Returns the number of rows deleted.
+        """
+        with self._connect() as conn:
+            self._ensure_migrated(conn)
+            with tx(conn):
+                if keep_ids:
+                    placeholders = ", ".join("?" for _ in keep_ids)
+                    cur = conn.execute(
+                        f"DELETE FROM runner_image WHERE local_path IS NULL "
+                        f"AND id NOT IN ({placeholders})",
+                        tuple(keep_ids),
+                    )
+                else:
+                    cur = conn.execute("DELETE FROM runner_image WHERE local_path IS NULL")
+                removed = int(cur.rowcount)
+        if removed:
+            self._notify_change()
+        return removed
+
     def reload(self) -> None:
         """No-op — kept for interface symmetry with SqliteModelRegistry."""
         return None

--- a/src/hal0/registry/runner_image_sync.py
+++ b/src/hal0/registry/runner_image_sync.py
@@ -1,7 +1,9 @@
 """Runner-image discovery — GHCR anonymous probe + ``images.json`` merge.
 
-Two independent fetches, merged by GHCR repo path (feat/runner-image-catalogue,
-corrected against the original handoff doc — see PR description):
+Two independent fetches, merged per ``images.json`` entry — row id is the
+entry's ``id`` short name, falling back to the GHCR repo path
+(feat/runner-image-catalogue, corrected against the original handoff doc —
+see PR description):
 
 1. **GHCR discovery.** Anonymous-token tag/digest resolution against known
    packages (the same flow already proven out by
@@ -132,12 +134,64 @@ async def _ghcr_list_tags(repo: str, *, token: str, client: httpx.AsyncClient) -
     return [t for t in tags if isinstance(t, str)] if isinstance(tags, list) else []
 
 
-async def _ghcr_manifest_head(
+def _manifest_content_size(payload: Any) -> int | None:
+    """Sum ``config.size`` + every ``layers[].size`` of one image manifest."""
+    if not isinstance(payload, dict):
+        return None
+    layers = payload.get("layers")
+    if not isinstance(layers, list):
+        return None
+    total = 0
+    config = payload.get("config")
+    if isinstance(config, dict) and isinstance(config.get("size"), int):
+        total += config["size"]
+    for layer in layers:
+        if isinstance(layer, dict) and isinstance(layer.get("size"), int):
+            total += layer["size"]
+    return total or None
+
+
+def _pick_index_manifest(payload: dict[str, Any]) -> str | None:
+    """Pick the linux/amd64 image-manifest digest out of an OCI index.
+
+    Attestation manifests (buildkit provenance, platform ``unknown``) are
+    skipped; falls back to the first non-attestation entry when no
+    linux/amd64 platform is declared.
+    """
+    manifests = payload.get("manifests")
+    if not isinstance(manifests, list):
+        return None
+    fallback: str | None = None
+    for entry in manifests:
+        if not isinstance(entry, dict):
+            continue
+        digest = entry.get("digest")
+        if not isinstance(digest, str):
+            continue
+        platform_raw = entry.get("platform")
+        platform: dict[str, Any] = platform_raw if isinstance(platform_raw, dict) else {}
+        if platform.get("os") == "unknown" or platform.get("architecture") == "unknown":
+            continue  # buildkit attestation, not a runnable image
+        if fallback is None:
+            fallback = digest
+        if platform.get("os") == "linux" and platform.get("architecture") == "amd64":
+            return digest
+    return fallback
+
+
+async def _ghcr_manifest_info(
     repo: str, ref: str, *, token: str, client: httpx.AsyncClient
 ) -> tuple[str | None, int | None]:
-    """Return ``(digest, size_bytes)`` for one tag; either may be None."""
-    resp = await client.request(
-        "HEAD",
+    """Return ``(digest, size_bytes)`` for one tag; either may be None.
+
+    Unlike a bare HEAD (whose ``content-length`` is the size of the manifest
+    *document*, a couple of KB), this GETs the manifest body and sums the
+    config + layer blob sizes — the actual compressed image size, matching
+    what GHCR's package UI reports. Multi-arch indexes are followed one
+    level down to the linux/amd64 image manifest. The digest reported is
+    the top-level one (what ``podman pull repo@digest`` would resolve).
+    """
+    resp = await client.get(
         f"https://ghcr.io/v2/{repo}/manifests/{ref}",
         headers={"Authorization": f"Bearer {token}", "Accept": _OCI_MANIFEST_ACCEPT},
         timeout=_HTTP_TIMEOUT_S,
@@ -145,28 +199,54 @@ async def _ghcr_manifest_head(
     if resp.status_code >= 400:
         raise RuntimeError(f"HTTP {resp.status_code} probing {repo}:{ref}")
     digest = resp.headers.get("docker-content-digest")
-    length = resp.headers.get("content-length")
-    size = int(length) if length and length.isdigit() else None
+    try:
+        payload = resp.json()
+    except ValueError:
+        payload = None
+
+    size = _manifest_content_size(payload)
+    if size is None and isinstance(payload, dict):
+        child_digest = _pick_index_manifest(payload)
+        if child_digest:
+            child = await client.get(
+                f"https://ghcr.io/v2/{repo}/manifests/{child_digest}",
+                headers={"Authorization": f"Bearer {token}", "Accept": _OCI_MANIFEST_ACCEPT},
+                timeout=_HTTP_TIMEOUT_S,
+            )
+            if child.status_code < 400:
+                try:
+                    size = _manifest_content_size(child.json())
+                except ValueError:
+                    size = None
+    if size is None:
+        length = resp.headers.get("content-length")
+        size = int(length) if length and length.isdigit() else None
     return digest, size
 
 
 async def probe_ghcr_package(
-    repo: str, *, client: httpx.AsyncClient, tag: str | None = None
+    repo: str,
+    *,
+    client: httpx.AsyncClient,
+    tag: str | None = None,
+    image_id: str | None = None,
 ) -> RunnerImage:
     """Anonymously resolve one GHCR package's latest tag + digest + size.
 
     ``tag`` pins a specific tag (from an ``images.json`` entry); when
     omitted, the newest-looking tag from ``tags/list`` is used, falling
-    back to ``latest``.
+    back to ``latest``. ``image_id`` sets the catalogue row id (the
+    ``images.json`` short name, e.g. ``cpu``); defaults to the repo path
+    for rows with no manifest entry.
     """
     token = await _ghcr_anon_token(repo, client=client)
     resolved_tag = tag
     if resolved_tag is None:
         tags = await _ghcr_list_tags(repo, token=token, client=client)
         resolved_tag = "latest" if "latest" in tags else (tags[-1] if tags else "latest")
-    digest, size = await _ghcr_manifest_head(repo, resolved_tag, token=token, client=client)
+    digest, size = await _ghcr_manifest_info(repo, resolved_tag, token=token, client=client)
     return RunnerImage(
-        id=repo,
+        id=image_id or repo,
         image=f"ghcr.io/{repo}",
         tag=resolved_tag,
         digest=digest,
@@ -208,10 +288,15 @@ async def sync_runner_images(
 
     Source of which GHCR packages to probe: ``images.json``'s entries
     (see module docstring — anonymous org-wide GHCR listing isn't
-    available). A malformed/unreachable ``images.json`` still lets
-    already-catalogued packages keep their existing rows (nothing is
-    deleted on a failed manifest fetch); packages present only via a
-    prior sync are left untouched this run.
+    available). Row id is the entry's ``id`` short name (``cpu``,
+    ``rocmfpx-hy3``, …) so two entries sharing one GHCR repo path under
+    different tags stay distinct rows; entries with no ``id`` fall back
+    to the repo path. A malformed/unreachable ``images.json`` still lets
+    already-catalogued packages keep their existing rows; on a *successful*
+    manifest fetch, catalogue rows whose id no longer appears in
+    ``images.json`` are pruned (unless locally downloaded) so removed or
+    renamed entries don't linger as stale duplicates. A failed per-package
+    probe never deletes anything.
     """
     owns_client = client is None
     client = client or httpx.AsyncClient(follow_redirects=True)
@@ -221,22 +306,32 @@ async def sync_runner_images(
         result.images_json_ok = err is None
         result.images_json_error = err
 
-        by_repo: dict[str, dict[str, Any]] = {}
+        by_id: dict[str, tuple[str, dict[str, Any]]] = {}
         for entry in entries:
-            key = _match_key(entry)
-            if key:
-                by_repo[key] = entry
+            repo = _match_key(entry)
+            if not repo:
+                continue
+            entry_id = entry.get("id")
+            image_id = entry_id.strip() if isinstance(entry_id, str) and entry_id.strip() else repo
+            by_id[image_id] = (repo, entry)
 
-        for repo, entry in by_repo.items():
+        for image_id, (repo, entry) in by_id.items():
             tag = entry.get("tag") if isinstance(entry.get("tag"), str) else None
             try:
-                image = await probe_ghcr_package(repo, client=client, tag=tag)
+                image = await probe_ghcr_package(repo, client=client, tag=tag, image_id=image_id)
             except (httpx.HTTPError, RuntimeError, ValueError) as exc:
-                result.probe_errors[repo] = str(exc)
-                log.warning("runner_images.probe_failed repo=%s error=%s", repo, exc)
+                result.probe_errors[image_id] = str(exc)
+                log.warning(
+                    "runner_images.probe_failed id=%s repo=%s error=%s", image_id, repo, exc
+                )
                 continue
             image = _apply_manifest_metadata(image, entry)
             result.images.append(store.upsert(image))
+
+        if result.images_json_ok:
+            pruned = store.prune_absent(set(by_id))
+            if pruned:
+                log.info("runner_images.pruned_stale_rows count=%d", pruned)
     finally:
         if owns_client:
             await client.aclose()

--- a/tests/registry/test_runner_image_sync.py
+++ b/tests/registry/test_runner_image_sync.py
@@ -23,6 +23,7 @@ _IMAGES_JSON = {
     "schema": "hal0.runner-images.v1",
     "images": [
         {
+            "id": "cpu",
             "image": "ghcr.io/hal0ai/hal0-toolbox-cpu",
             "tag": "latest",
             "manifest_key": "toolbox-cpu",
@@ -32,6 +33,7 @@ _IMAGES_JSON = {
             "notes": "CPU-only toolbox image.",
         },
         {
+            # no "id" — exercises the repo-path fallback
             "image": "ghcr.io/hal0ai/hal0-toolbox-flm",
             "tag": "v2",
             "manifest_key": "toolbox-flm",
@@ -42,9 +44,29 @@ _IMAGES_JSON = {
     ],
 }
 
+#: config 345 + layers 6000 + 6000 — what a size probe should sum to.
+_MANIFEST_BODY = {
+    "schemaVersion": 2,
+    "config": {"size": 345},
+    "layers": [{"size": 6000}, {"size": 6000}],
+}
+_MANIFEST_SIZE = 12345
 
-def _route_handler(*, images_json: dict | None, ghcr_fail: set[str] | None = None):
+
+def _route_handler(
+    *,
+    images_json: dict | None,
+    ghcr_fail: set[str] | None = None,
+    manifest_body: dict | None = None,
+    child_manifests: dict[str, dict] | None = None,
+):
+    """MockTransport handler for raw.githubusercontent.com + ghcr.io.
+
+    ``manifest_body`` overrides the manifest returned for tag refs;
+    ``child_manifests`` maps digest refs to bodies (multi-arch children).
+    """
     ghcr_fail = ghcr_fail or set()
+    child_manifests = child_manifests or {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         url = str(request.url)
@@ -59,15 +81,15 @@ def _route_handler(*, images_json: dict | None, ghcr_fail: set[str] | None = Non
                 return httpx.Response(500, content=b"nope")
             return httpx.Response(200, json={"token": f"tok-{repo}"})
         if "/manifests/" in url:
-            repo = url.split("https://ghcr.io/v2/")[1].split("/manifests/")[0]
+            repo, _, ref = url.split("https://ghcr.io/v2/")[1].partition("/manifests/")
             if repo in ghcr_fail:
                 return httpx.Response(500, content=b"nope")
+            if ref in child_manifests:
+                return httpx.Response(200, json=child_manifests[ref])
             return httpx.Response(
                 200,
-                headers={
-                    "docker-content-digest": f"sha256:{repo.replace('/', '-')}",
-                    "content-length": "12345",
-                },
+                headers={"docker-content-digest": f"sha256:{repo.replace('/', '-')}-{ref}"},
+                json=manifest_body if manifest_body is not None else _MANIFEST_BODY,
             )
         if "/tags/list" in url:
             return httpx.Response(200, json={"tags": ["latest"]})
@@ -130,16 +152,17 @@ async def test_sync_merges_ghcr_and_images_json(tmp_path: Path) -> None:
     assert result.probe_errors == {}
     assert len(result.images) == 2
 
-    cpu = store.get("hal0ai/hal0-toolbox-cpu")
+    cpu = store.get("cpu")  # images.json "id" short name wins as row id
     assert cpu is not None
-    assert cpu.digest == "sha256:hal0ai-hal0-toolbox-cpu"
-    assert cpu.size_bytes == 12345
+    assert cpu.image == "ghcr.io/hal0ai/hal0-toolbox-cpu"
+    assert cpu.digest == "sha256:hal0ai-hal0-toolbox-cpu-latest"
+    assert cpu.size_bytes == _MANIFEST_SIZE  # config + layer blob sizes, not doc length
     assert cpu.ownership == "owned"
     assert cpu.publish == "ci"
     assert cpu.notes == "CPU-only toolbox image."
     assert cpu.build == {"context": ".", "dockerfile": "Dockerfile.cpu"}
 
-    flm = store.get("hal0ai/hal0-toolbox-flm")
+    flm = store.get("hal0ai/hal0-toolbox-flm")  # no "id" — repo-path fallback
     assert flm is not None
     assert flm.tag == "v2"
     assert flm.ownership == "referenced"
@@ -175,5 +198,111 @@ async def test_sync_one_bad_package_does_not_abort_the_rest(tmp_path: Path) -> N
         await client.aclose()
 
     assert "hal0ai/hal0-toolbox-flm" in result.probe_errors
-    assert store.get("hal0ai/hal0-toolbox-cpu") is not None
+    assert store.get("cpu") is not None
     assert store.get("hal0ai/hal0-toolbox-flm") is None
+
+
+@pytest.mark.asyncio
+async def test_sync_multiarch_index_size_summed_from_child(tmp_path: Path) -> None:
+    """An OCI index resolves size via its linux/amd64 child manifest."""
+    index = {
+        "schemaVersion": 2,
+        "manifests": [
+            {"digest": "sha256:attest", "platform": {"os": "unknown", "architecture": "unknown"}},
+            {"digest": "sha256:amd64child", "platform": {"os": "linux", "architecture": "amd64"}},
+        ],
+    }
+    child = {"schemaVersion": 2, "config": {"size": 100}, "layers": [{"size": 900}]}
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    handler = _route_handler(
+        images_json=_IMAGES_JSON,
+        manifest_body=index,
+        child_manifests={"sha256:amd64child": child},
+    )
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    cpu = store.get("cpu")
+    assert cpu is not None
+    assert cpu.size_bytes == 1000
+    # digest stays the top-level (index) one — what a pull-by-digest resolves
+    assert cpu.digest == "sha256:hal0ai-hal0-toolbox-cpu-latest"
+
+
+@pytest.mark.asyncio
+async def test_sync_two_entries_sharing_one_repo_stay_distinct(tmp_path: Path) -> None:
+    """rocmfpx/rocmfpx-hy3 pattern: one GHCR repo, two tags, two rows."""
+    images_json = {
+        "schema": "hal0.runner-images.v1",
+        "images": [
+            {"id": "rocmfpx", "image": "ghcr.io/hal0ai/hal0-rocmfpx", "tag": "c077206"},
+            {"id": "rocmfpx-hy3", "image": "ghcr.io/hal0ai/hal0-rocmfpx", "tag": "ifp2-hyv3"},
+        ],
+    }
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_route_handler(images_json=images_json))
+    )
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.probe_errors == {}
+    assert len(result.images) == 2
+    base = store.get("rocmfpx")
+    hy3 = store.get("rocmfpx-hy3")
+    assert base is not None and base.tag == "c077206"
+    assert hy3 is not None and hy3.tag == "ifp2-hyv3"
+    assert base.image == hy3.image == "ghcr.io/hal0ai/hal0-rocmfpx"
+
+
+@pytest.mark.asyncio
+async def test_sync_prunes_stale_rows_but_keeps_downloaded(tmp_path: Path) -> None:
+    """Rows delisted from images.json vanish on the next good sync — unless
+    a local pull landed, in which case the row survives."""
+    from hal0.registry.runner_image import RunnerImage
+
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    # Stale pre-rename row (old repo-path id for what is now id "cpu"):
+    store.upsert(RunnerImage(id="hal0ai/hal0-toolbox-cpu", image="ghcr.io/hal0ai/hal0-toolbox-cpu"))
+    # Delisted but locally downloaded — must survive the prune:
+    store.upsert(
+        RunnerImage(
+            id="hal0ai/old-downloaded",
+            image="ghcr.io/hal0ai/old-downloaded",
+            local_path="/var/lib/hal0/runner-images/old-downloaded.json",
+        )
+    )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_route_handler(images_json=_IMAGES_JSON))
+    )
+    try:
+        await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    ids = {i.id for i in store.list()}
+    assert ids == {"cpu", "hal0ai/hal0-toolbox-flm", "hal0ai/old-downloaded"}
+
+
+@pytest.mark.asyncio
+async def test_failed_images_json_never_prunes(tmp_path: Path) -> None:
+    from hal0.registry.runner_image import RunnerImage
+
+    store = RunnerImageStore(db_path=tmp_path / "hal0.db")
+    store.upsert(RunnerImage(id="cpu", image="ghcr.io/hal0ai/hal0-toolbox-cpu"))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_route_handler(images_json=None)))
+    try:
+        result = await sync_runner_images(store, client=client)
+    finally:
+        await client.aclose()
+
+    assert result.images_json_ok is False
+    assert store.get("cpu") is not None

--- a/ui/src/api/endpoints.ts
+++ b/ui/src/api/endpoints.ts
@@ -91,11 +91,13 @@ export const ENDPOINTS = {
   // Mirrors the model-pull surface above: /api/runner-images (list) +
   // /downloaded (locally-pulled only, for the slot edit drawer's Runner
   // Image field — owned by fix/slot-edit-drawer-cleanup) + per-id
-  // pull/status/stream/cancel. Catalogue ids are GHCR repo paths
-  // ("hal0ai/hal0-toolbox-cpu") so they're NOT re-encoded per-segment —
-  // encodeURIComponent would turn the id's "/" into "%2F", which the
-  // backend's :path route converter expects decoded, matching how the
-  // browser's fetch/EventSource already send it.
+  // pull/status/stream/cancel. Catalogue ids are images.json short names
+  // ("cpu", "rocmfpx-hy3"), falling back to GHCR repo paths
+  // ("hal0ai/hal0-toolbox-cpu") for unmatched rows, so they're NOT
+  // re-encoded per-segment — encodeURIComponent would turn a fallback
+  // id's "/" into "%2F", which the backend's :path route converter
+  // expects decoded, matching how the browser's fetch/EventSource
+  // already send it.
   runnerImages: '/api/runner-images',
   runnerImagesDownloaded: '/api/runner-images/downloaded',
   runnerImagesSync: '/api/runner-images/sync',


### PR DESCRIPTION
## What

Follow-up to [Hal0ai/hal0-runner-images#1](https://github.com/Hal0ai/hal0-runner-images/pull/1) (images.json now serves the app's `hal0.runner-images.v1` array shape). Two catalogue-sync fixes plus a stale-row prune:

**Tag-aware short ids.** Catalogue row id is now the images.json entry's `id` short name (`cpu`, `comfyui`, `rocmfpx-hy3`, …) instead of the GHCR repo path. Previously `rocmfpx` and `rocmfpx-hy3` — one repo path, two tags — collapsed into a single row (last entry won). Entries without an `id` keep the repo-path fallback; the UI passes ids through untouched (`:path` route converter still handles fallback ids containing `/`).

**Real image sizes.** `size_bytes` was the HEAD `content-length` — the manifest *document* size, a few KB, rendered as nonsense on the page. The probe now GETs the manifest and sums config + layer blob sizes, following multi-arch indexes one level down to the linux/amd64 child and skipping buildkit attestation manifests. Reported digest stays the top-level one (what pull-by-digest resolves).

**Prune on good sync.** After a successful images.json fetch, rows whose id is no longer manifested are pruned (`RunnerImageStore.prune_absent`) so the pre-rename repo-path rows and future delisted entries don't linger. Locally-downloaded rows are never pruned; a failed images.json fetch never prunes anything; a failed per-package probe never deletes.

## Verified

- 30 registry/api runner-image tests pass, incl. 4 new: multi-arch index size summing, shared-repo entries staying distinct, prune keeping downloaded rows, failed fetch never pruning
- Live sync against ghcr + the merged images.json: all 10 entries, zero probe errors, real sizes (comfyui 3.7 GB, qwen3tts 10.6 GB, cpu 40 MB)
- ruff check/format clean; no new mypy errors in touched files

## Out of scope

- GHCR package renames (`hal0-toolbox-*` vs `hal0-comfyui` vs `hal0-rocmfpx` inconsistency) — renaming published packages breaks existing pulls and manifest pins; display names are now the clean short ids, which covers the UX without the breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)