### PR TITLE
ci(release): cap the GitHub release body under the 125k limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,6 +588,25 @@ jobs:
             echo "See CHANGELOG.md for release notes." > "${NOTES_FILE}"
           fi
 
+          # GitHub rejects a release body over 125,000 characters (observed
+          # live on v1.0.0-rc.1: the folded milestone section is ~150 KB and
+          # the publish step died with HTTP 422 "body is too long"). The full
+          # notes still ship *inside* the signed tarball as RELEASE_NOTES.md
+          # (step 2b) — the release page body is a rendering, not the record —
+          # so truncate at a line boundary under the cap and point at the
+          # canonical copy rather than failing the whole publication.
+          BODY_CAP=120000
+          if [[ "$(wc -c < "${NOTES_FILE}")" -gt "${BODY_CAP}" ]]; then
+            TRAILER="
+
+*Truncated — full notes in [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md) and as RELEASE_NOTES.md inside the release tarball.*"
+            head -c $(( BODY_CAP - ${#TRAILER} )) "${NOTES_FILE}" \
+              | sed '$ d' > "${NOTES_FILE}.capped"
+            printf '%s' "${TRAILER}" >> "${NOTES_FILE}.capped"
+            mv "${NOTES_FILE}.capped" "${NOTES_FILE}"
+            echo "::warning::release notes body exceeded ${BODY_CAP} chars; truncated for the release page (full copy remains in the tarball)"
+          fi
+
           echo "path=${NOTES_FILE}" >> "$GITHUB_OUTPUT"
 
       # ── 7. Publish one immutable GitHub Release ────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -597,9 +597,11 @@ jobs:
           # canonical copy rather than failing the whole publication.
           BODY_CAP=120000
           if [[ "$(wc -c < "${NOTES_FILE}")" -gt "${BODY_CAP}" ]]; then
-            TRAILER="
-
-*Truncated — full notes in [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/${TAG}/CHANGELOG.md) and as RELEASE_NOTES.md inside the release tarball.*"
+            # $'…' single-line form on purpose: a multi-line string literal
+            # whose continuation lines start at column 0 would terminate this
+            # YAML literal block (tests/release/test_workflow_contract.py
+            # parses this file and would fail on it).
+            TRAILER=$'\n\n*Truncated — full notes in [CHANGELOG.md](https://github.com/'"${GITHUB_REPOSITORY}"$'/blob/'"${TAG}"$'/CHANGELOG.md) and as RELEASE_NOTES.md inside the release tarball.*'
             head -c $(( BODY_CAP - ${#TRAILER} )) "${NOTES_FILE}" \
               | sed '$ d' > "${NOTES_FILE}.capped"
             printf '%s' "${TRAILER}" >> "${NOTES_FILE}.capped"


### PR DESCRIPTION
## What

The `v1.0.0-rc.1` release run (30723133336) failed at **Publish GitHub Release** with `HTTP 422: body is too long (maximum is 125000 characters)` — the folded milestone CHANGELOG section is ~150 KB. No release was created, so the run can be repeated cleanly after this merges (`workflow_dispatch` with the tag).

## Fix

Truncate the notes body at 120k characters on a line boundary, append a pointer to CHANGELOG.md at the tag + the in-tarball `RELEASE_NOTES.md` (which always carries the full text and is the cosign-verified record), and emit a workflow warning when truncation fires. Normal-sized releases are unchanged.

## Review note

CI workflow change — per workspace policy, held for human review; no automerge. After merge: re-run the release for `v1.0.0-rc.1` via `gh workflow run release.yml -f tag=v1.0.0-rc.1` (the tag is already pushed and immutable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)