### PR TITLE
fix(ui): stop the slot drawer crashing when a save's refetch drops the slot

### DIFF
--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -274,7 +274,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// Name the current baseline belongs to. Guards the re-seed effect so a poll
 	// that merely RECOVERS from a degraded interval doesn't wipe the operator's
 	// in-flight edits (the enrichment flag flipping false→true re-runs it).
-	const baselineFor = useRefSM(baseline ? slot.name : null);
+	// `slot` can be undefined here while `baseline` is still set: a save's
+	// invalidation can drop the slot from one poll before the cleanup effect
+	// below runs, and this initializer argument is evaluated on that render.
+	const baselineFor = useRefSM(baseline && slot ? slot.name : null);
 	const [submitErr, setSubmitErr] = useStateSM(null);
 	// Dirty-close confirms through the shared ConfirmDialog (state-driven),
 	// replacing the raw window.confirm. Every dismiss path (Cancel, ✕, Esc,


### PR DESCRIPTION
## What

Saving slot settings crashed the Slots view to the error boundary with `Cannot read properties of undefined (reading 'name')` — reported live on lxc105 running v1.0.0-rc.1, reproduced 2/2, and traced to `ui/src/dash/slot-modals.jsx:277`:

```js
const baselineFor = useRefSM(baseline ? slot.name : null);
```

The save invalidates the slots query; on a box with a slow `GET /api/slots` (11–15s on lxc105, #1507) the next poll can briefly return a list without the edited slot. The parent's `find()` then passes `slot=undefined` while `baseline` state is still set, and this initializer argument is evaluated on that render — before the cleanup effect that clears the baseline can run. Regression from the #1447 frozen-baseline rework. Cancel/close never hits it because the slot stays in the list; only a save's invalidation window exposes it.

## Fix

Guard on `slot` too: `baseline && slot ? slot.name : null`. One line; the rest of the pre-guard hook region was audited — every other `slot.` read is inside a handler or an effect already guarded on `!slot`.

## Verification

- Reproduced on lxc105 (rerank slot, Context save): crash 2/2 on the rc1 bundle
- Same repro on the fixed bundle: save completes, no error boundary, zero console errors (2/2, both directions of the value change)
- `vitest`: 66 passed · `tsc --noEmit`: clean · `npm run build`: clean

Release note: worth cherry-picking into the rc — it makes every slot-settings save on a slow box a coin-flip crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)