### PR TITLE
feat(services): make dashboard lifecycle verbs work under User=hal0, add ComfyUI Start

### DIFF
--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -134,6 +134,40 @@ case "$cmd" in
     exec systemctl disable "${AGENT_UNIT_PREFIX}${id}.service"
     ;;
 
+  # Dashboard Services page lifecycle (#1590): the /api/services surface
+  # advertises start/restart/enable for the bundled-agent card too, and until
+  # these arms existed the API fell through to a bare unprivileged systemctl —
+  # polkit's "Interactive authentication required" — for every one of them.
+  # Same posture as stop-agent: literal verb per arm, validated id, unit name
+  # built here.
+  start-agent)                # start-agent <agent-id>  -> systemctl start hal0-agent@<id>.service
+    id="${1:-}"; validate_agent_id "$id"
+    exec systemctl start "${AGENT_UNIT_PREFIX}${id}.service"
+    ;;
+
+  restart-agent)              # restart-agent <agent-id> -> systemctl restart hal0-agent@<id>.service
+    id="${1:-}"; validate_agent_id "$id"
+    exec systemctl restart "${AGENT_UNIT_PREFIX}${id}.service"
+    ;;
+
+  enable-agent)               # enable-agent <agent-id> -> systemctl enable hal0-agent@<id>.service
+    id="${1:-}"; validate_agent_id "$id"
+    exec systemctl enable "${AGENT_UNIT_PREFIX}${id}.service"
+    ;;
+
+  # Companion-service units (#1590). A CLOSED name->unit map — the caller
+  # supplies a service key, never a unit string, so this family can only ever
+  # reach the units enumerated here. Growing the map is a reviewable diff.
+  svc-start|svc-stop|svc-restart|svc-enable|svc-disable)
+    key="${1:-}"
+    case "$key" in
+      openwebui)  unit="hal0-openwebui.service" ;;
+      hindsight)  unit="hindsight-api.service" ;;
+      *) die "bad service key: ${key:-<missing>}" ;;
+    esac
+    exec systemctl "${cmd#svc-}" "$unit"
+    ;;
+
   restart-self)                # literal-only: restart hal0-api.service, never a variable name
     # --no-block: this is invoked BY hal0-api, from inside hal0-api.service's
     # own cgroup. A blocking `systemctl restart` waits for the unit to stop —
@@ -157,6 +191,10 @@ usage: hal0-systemctl <command> [slot-id|agent-id]
   reset-failed <slot-id>           clear a crash-looped unit's failed sub-state
   stop-agent <agent-id>            systemctl stop ${AGENT_UNIT_PREFIX}<id>.service
   disable-agent <agent-id>         systemctl disable ${AGENT_UNIT_PREFIX}<id>.service
+  start-agent <agent-id>           systemctl start ${AGENT_UNIT_PREFIX}<id>.service
+  restart-agent <agent-id>         systemctl restart ${AGENT_UNIT_PREFIX}<id>.service
+  enable-agent <agent-id>          systemctl enable ${AGENT_UNIT_PREFIX}<id>.service
+  svc-<verb> <openwebui|hindsight> systemctl <verb> on the mapped companion unit
   restart-self                     systemctl restart ${SELF_UNIT}
 EOF
     ;;

--- a/src/hal0/api/routes/services.py
+++ b/src/hal0/api/routes/services.py
@@ -28,10 +28,9 @@ verb subset lives in ``hal0.services.registry`` (e.g. ComfyUI only exposes
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
-
-import json
 
 import httpx
 import structlog

--- a/src/hal0/api/routes/services.py
+++ b/src/hal0/api/routes/services.py
@@ -31,9 +31,11 @@ from __future__ import annotations
 import os
 from typing import Any
 
+import json
+
 import httpx
 import structlog
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, BackgroundTasks, Request
 
 from hal0.api._audit import record_action
 from hal0.api.routes.config import _behind_proxy, _host_without_port, _resolve_host
@@ -183,14 +185,41 @@ async def list_services(request: Request) -> dict[str, Any]:
     return {"services": services, "mdns": disco}
 
 
+async def _comfyui_start(request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
+    """ComfyUI "start" = the GPU-arbiter switchover to generation mode.
+
+    A raw ``systemctl start hal0-slot@img`` would boot ComfyUI *under* the
+    resident LLM stack — the arbiter exists precisely to drain and hand the
+    iGPU over first. Delegates to the comfyui router's own switchover handler
+    so the guards (switch-in-flight 409, already-there noop, arbiter-missing
+    503) stay in one place.
+    """
+    from hal0.api.routes.comfyui import SwitchoverBody, comfyui_switchover
+
+    resp = await comfyui_switchover(request, background_tasks, SwitchoverBody(mode="generation"))
+    try:
+        payload = json.loads(bytes(resp.body))
+    except Exception:  # pragma: no cover — defensive
+        payload = {}
+    if resp.status_code == 202:
+        return {"ok": True, "message": "GPU switchover to generation started — track via status"}
+    if resp.status_code == 200 and payload.get("status") == "noop":
+        return {"ok": True, "message": "already in generation mode"}
+    detail = (payload.get("error") or {}).get("message") or f"HTTP {resp.status_code}"
+    return {"ok": False, "message": f"start comfyui failed: {detail}"}
+
+
 @router.post("/{service_id}/action")
-async def service_action(service_id: str, request: Request) -> dict[str, Any]:
+async def service_action(
+    service_id: str, request: Request, background_tasks: BackgroundTasks
+) -> dict[str, Any]:
     """Run one lifecycle verb against a registered service's unit.
 
     Body: ``{"action": "start"|"stop"|"restart"|"enable"|"disable"}``.
-    The verb must be in the service's registry allow-list — e.g. ComfyUI
-    accepts only ``restart`` (its start/stop belongs to the GPU arbiter).
-    Audit-logged with a truthful outcome.
+    The verb must be in the service's registry allow-list. ComfyUI's
+    ``start`` is special-cased into the GPU-arbiter switchover (#1590);
+    its ``restart`` stays a plain unit bounce. Audit-logged with a
+    truthful outcome.
     """
     sdef = service_by_id(service_id)
     if sdef is None:
@@ -220,7 +249,10 @@ async def service_action(service_id: str, request: Request) -> dict[str, Any]:
         action=f"services.{action}",
         target=sdef.unit,
     ) as rec:
-        result = await svc_systemd.unit_action(sdef.unit, action)
+        if sdef.id == "comfyui" and action == "start":
+            result = await _comfyui_start(request, background_tasks)
+        else:
+            result = await svc_systemd.unit_action(sdef.unit, action)
         active = await svc_systemd.unit_is_active(sdef.unit)
         rec.after = {"ok": result["ok"], "active": active}
         rec.message = str(result["message"])

--- a/src/hal0/services/registry.py
+++ b/src/hal0/services/registry.py
@@ -84,9 +84,13 @@ SERVICES: tuple[ServiceDef, ...] = (
         port=8188,
         public_url_env="HAL0_COMFYUI_PUBLIC_URL",
         probe="comfyui",
-        actions=("restart",),
+        # "start" here does NOT run `systemctl start` — the route special-cases
+        # it into the GPU-arbiter switchover (drain LLM slots, hand the iGPU
+        # over), the only honest way to bring ComfyUI up (#1590). "restart"
+        # stays the raw unit bounce the FirstRun repair button uses.
+        actions=("start", "restart"),
         mdns=True,
-        hints=("start/stop is GPU-arbiter managed — use the Image-Gen pane switchover",),
+        hints=("stop is GPU-arbiter managed — switch back to inference in the Image-Gen pane",),
     ),
     ServiceDef(
         id="hermes",

--- a/src/hal0/services/systemd.py
+++ b/src/hal0/services/systemd.py
@@ -10,9 +10,18 @@ This module is the single implementation the services surface uses:
 * :func:`unit_action` — run one allow-listed lifecycle verb.
 
 Everything is fail-soft: a host without systemd (CI, dev laptop) yields
-"unknown" states and honest error strings, never an exception. hal0-api
-runs as root, so systemctl is invoked directly — same assumption as
-``installer._privileged_systemctl_argv`` (the sudoers seam was removed).
+"unknown" states and honest error strings, never an exception.
+
+Privilege (#1590): hal0-api runs as ``User=hal0`` post-P3-perms, so the
+MUTATING verbs (:func:`unit_action`) route through
+:class:`hal0.system.seam.SystemCtlSeam` — which forwards hal0-managed units
+(``hal0-slot@*``, ``hal0-agent@*``, and the companion units in
+``COMPANION_SERVICE_UNITS``) through the ``hal0-systemctl`` sudo wrapper and
+passes everything else straight through. The original "hal0-api runs as
+root, so systemctl is invoked directly" assumption here predated that flip:
+every Services-page verb died on polkit's "Interactive authentication
+required". Read-only queries (``show``, ``is-active``) stay direct — they
+never need root.
 
 The verb allow-list is enforced HERE, at the execution boundary, in
 addition to the per-service ``ServiceDef.actions`` check in the route —
@@ -24,10 +33,18 @@ from __future__ import annotations
 import asyncio
 import re
 import shutil
+import subprocess
 
 import structlog
 
+from hal0.system.seam import SystemCtlSeam
+
 log = structlog.get_logger(__name__)
+
+#: Shared seam instance for the mutating verbs. Default construction =
+#: production gating (seam engages only for the real hal0 service account;
+#: dev/CI/tests pass straight through, exactly as before #1590).
+_SEAM = SystemCtlSeam()
 
 #: Verbs :func:`unit_action` will ever execute.
 ALLOWED_VERBS = frozenset({"start", "stop", "restart", "enable", "disable"})
@@ -194,10 +211,31 @@ async def unit_action(unit: str, verb: str) -> dict[str, object]:
         raise ValueError(f"verb {verb!r} is not an allowed systemctl verb")
     if not valid_unit(unit):
         raise ValueError(f"invalid unit name {unit!r}")
-    rc, _stdout, stderr = await _run(verb, unit, timeout=_VERB_TIMEOUT[verb])
-    if rc == 0:
+    if shutil.which("systemctl") is None:
+        return {"ok": False, "message": f"{verb} {unit} failed: systemctl not available"}
+    # Through the seam (#1590): as the hal0 service user this becomes
+    # `sudo -n hal0-systemctl …` for hal0-managed units; everywhere else it is
+    # the plain systemctl call this module always made. Sync subprocess —
+    # off-loop so a slow verb can't stall the event loop.
+    try:
+        proc = await asyncio.to_thread(
+            _SEAM.systemctl,
+            "systemctl",
+            verb,
+            unit,
+            check=False,
+            timeout=_VERB_TIMEOUT[verb],
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "message": f"{verb} {unit} failed: timed out after {_VERB_TIMEOUT[verb]:.0f}s",
+        }
+    except OSError as exc:  # pragma: no cover — spawn failure
+        return {"ok": False, "message": f"{verb} {unit} failed: {exc}"}
+    if proc.returncode == 0:
         return {"ok": True, "message": f"{verb} {unit}: ok"}
-    detail = stderr.strip() or f"exit code {rc}"
+    detail = (proc.stderr or "").strip() or f"exit code {proc.returncode}"
     log.warning("services.unit_action_failed", unit=unit, verb=verb, detail=detail)
     return {"ok": False, "message": f"{verb} {unit} failed: {detail}"}
 

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -72,7 +72,25 @@ _AGENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 #: The only agent-unit verbs the seam exposes, mapped bare-systemctl verb ->
 #: seam verb. Anything not in here is a programming error, not a runtime input.
-AGENT_UNIT_VERBS: dict[str, str] = {"stop": "stop-agent", "disable": "disable-agent"}
+#: start/restart/enable joined stop/disable for the dashboard Services page
+#: (#1590) — before that every mutating verb on the hermes card fell through
+#: to bare systemctl and died on polkit.
+AGENT_UNIT_VERBS: dict[str, str] = {
+    "stop": "stop-agent",
+    "disable": "disable-agent",
+    "start": "start-agent",
+    "restart": "restart-agent",
+    "enable": "enable-agent",
+}
+
+#: Companion-service units the seam's ``svc-<verb>`` family may reach (#1590),
+#: mapped unit name -> the service key the wrapper's own CLOSED map accepts.
+#: Mirrors the ``svc-start|...`` case arm in installer/wrappers/hal0-systemctl
+#: exactly — the wrapper is the boundary, this is the client-side spelling.
+COMPANION_SERVICE_UNITS: dict[str, str] = {
+    "hal0-openwebui.service": "openwebui",
+    "hindsight-api.service": "hindsight",
+}
 
 
 class Hal0SeamMissing(RuntimeError):
@@ -186,6 +204,15 @@ def _slot_id_from_unit(unit_name: str) -> str | None:
     """Extract ``<id>`` from ``hal0-slot@<id>.service``, or ``None`` if the
     unit name isn't one (e.g. ``hal0-api.service`` — never routed here)."""
     m = _UNIT_NAME_RE.match(unit_name)
+    return m.group(1) if m else None
+
+
+_AGENT_UNIT_NAME_RE = re.compile(r"^hal0-agent@([A-Za-z0-9_-]{1,64})\.service$")
+
+
+def _agent_id_from_unit(unit_name: str) -> str | None:
+    """Extract ``<id>`` from ``hal0-agent@<id>.service``, or ``None``."""
+    m = _AGENT_UNIT_NAME_RE.match(unit_name)
     return m.group(1) if m else None
 
 
@@ -324,7 +351,32 @@ class SystemCtlSeam:
                     check=check,
                     timeout=timeout,
                 )
-        # Not a routable hal0-slot@ op (e.g. is-active, or a non-slot unit) —
+            # Bundled-agent unit (hal0-agent@<id>.service) — route through the
+            # wrapper's <verb>-agent arms (#1590). Same shape as the slot
+            # family: the seam takes the bare id and rebuilds the unit name
+            # root-side.
+            agent_id = _agent_id_from_unit(args[2])
+            if agent_id is not None and verb in AGENT_UNIT_VERBS:
+                return self._run(
+                    self._seam_argv(AGENT_UNIT_VERBS[verb], agent_id),
+                    capture_output=True,
+                    text=True,
+                    check=check,
+                    timeout=timeout,
+                )
+            # Companion-service unit (openwebui / hindsight) — the wrapper's
+            # svc-<verb> family takes a service KEY from a closed map, never a
+            # unit string (#1590).
+            svc_key = COMPANION_SERVICE_UNITS.get(args[2])
+            if svc_key is not None and verb != "reset-failed":
+                return self._run(
+                    self._seam_argv(f"svc-{verb}", svc_key),
+                    capture_output=True,
+                    text=True,
+                    check=check,
+                    timeout=timeout,
+                )
+        # Not a routable hal0-managed op (e.g. is-active, or a foreign unit) —
         # pass through unprivileged; systemctl read-only queries never need root.
         return self._run(list(args), capture_output=True, text=True, check=check, timeout=timeout)
 
@@ -345,6 +397,7 @@ class SystemCtlSeam:
 __all__ = [
     "AGENT_UNIT_PREFIX",
     "AGENT_UNIT_VERBS",
+    "COMPANION_SERVICE_UNITS",
     "SEAM_BIN",
     "Hal0SeamMissing",
     "SystemCtlSeam",

--- a/tests/api/test_services_page.py
+++ b/tests/api/test_services_page.py
@@ -139,10 +139,12 @@ def test_list_services_200_all_ids(svc_client: TestClient) -> None:
 # ── 2. registry invariants ────────────────────────────────────────────────────
 
 
-def test_registry_comfyui_restart_only() -> None:
+def test_registry_comfyui_start_and_restart_only() -> None:
+    # start is arbiter-delegated (#1590), restart is the raw unit bounce;
+    # stop stays arbiter-owned (Image-Gen pane switchover), never a raw verb.
     comfy = service_by_id("comfyui")
     assert comfy is not None
-    assert comfy.actions == ("restart",)
+    assert comfy.actions == ("start", "restart")
     assert comfy.unit == "hal0-slot@img.service"
 
 
@@ -168,19 +170,38 @@ def test_action_missing_action_400(svc_client: TestClient) -> None:
 
 
 def test_action_disallowed_verb_400(svc_client: TestClient) -> None:
-    # ComfyUI: stop is arbiter-owned, registry only allows restart.
+    # ComfyUI: stop is arbiter-owned, registry allows only start + restart.
     r = svc_client.post("/api/services/comfyui/action", json={"action": "stop"})
     assert r.status_code == 400
     body = r.json()["error"]
     assert body["code"] == "services.action_not_allowed"
-    assert body["details"]["allowed"] == ["restart"]
+    assert body["details"]["allowed"] == ["start", "restart"]
 
 
 def test_action_disallowed_action_400(svc_client: TestClient) -> None:
-    # comfyui only exposes "restart"; any other verb → action_not_allowed.
-    r = svc_client.post("/api/services/comfyui/action", json={"action": "start"})
+    # comfyui exposes start/restart; any other verb → action_not_allowed.
+    r = svc_client.post("/api/services/comfyui/action", json={"action": "disable"})
     assert r.status_code == 400
     assert r.json()["error"]["code"] == "services.action_not_allowed"
+
+
+def test_action_comfyui_start_delegates_to_switchover_not_systemctl(
+    svc_client: TestClient,
+) -> None:
+    # #1590: comfyui "start" must never run `systemctl start` — it drives the
+    # GPU-arbiter switchover. With no arbiter wired on the test app the
+    # switchover answers 503 arbiter_unavailable, which the services route
+    # reports as an honest ok=False — and unit_action is never called.
+    with patch(
+        f"{_ROUTE}.svc_systemd.unit_action",
+        new_callable=AsyncMock,
+    ) as action_mock:
+        r = svc_client.post("/api/services/comfyui/action", json={"action": "start"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "arbiter" in body["message"]
+    action_mock.assert_not_awaited()
 
 
 # ── 4. action happy path ──────────────────────────────────────────────────────

--- a/tests/system/test_seam.py
+++ b/tests/system/test_seam.py
@@ -249,15 +249,51 @@ def test_systemctl_read_only_query_never_routed_even_as_hal0_user() -> None:
     assert calls == [["systemctl", "is-active", "hal0-slot@chat.service"]]
 
 
-def test_systemctl_non_slot_unit_passes_through_even_as_hal0_user() -> None:
-    """A non-hal0-slot@ unit (e.g. hindsight-api.service) isn't covered by the
-    seam's whitelist — passes straight through unprivileged."""
+def test_systemctl_foreign_unit_passes_through_even_as_hal0_user() -> None:
+    """A unit hal0 doesn't manage at all isn't covered by any seam family —
+    passes straight through unprivileged. (hindsight-api used to be the
+    example here; #1590 made it seam-routed, which was exactly the point.)"""
     calls, run = _recorder()
     seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
 
-    seam.systemctl("systemctl", "restart", "hindsight-api.service")
+    seam.systemctl("systemctl", "restart", "nginx.service")
 
-    assert calls == [["systemctl", "restart", "hindsight-api.service"]]
+    assert calls == [["systemctl", "restart", "nginx.service"]]
+
+
+@pytest.mark.parametrize(
+    ("unit", "verb", "seam_argv_tail"),
+    [
+        ("hal0-agent@hermes.service", "start", ["start-agent", "hermes"]),
+        ("hal0-agent@hermes.service", "restart", ["restart-agent", "hermes"]),
+        ("hal0-openwebui.service", "restart", ["svc-restart", "openwebui"]),
+        ("hal0-openwebui.service", "start", ["svc-start", "openwebui"]),
+        ("hindsight-api.service", "stop", ["svc-stop", "hindsight"]),
+        ("hindsight-api.service", "enable", ["svc-enable", "hindsight"]),
+    ],
+)
+def test_systemctl_routes_agent_and_companion_units_through_seam(
+    unit: str, verb: str, seam_argv_tail: list[str]
+) -> None:
+    """#1590: as the hal0 user, agent + companion units route through the
+    wrapper instead of falling through to bare systemctl (= polkit)."""
+    calls, run = _recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+
+    seam.systemctl("systemctl", verb, unit)
+
+    assert calls == [["sudo", "-n", seam._seam_bin, *seam_argv_tail]]
+
+
+def test_systemctl_companion_units_pass_through_off_the_service_account() -> None:
+    """Dev/CI/tests (not the hal0 user) keep the direct call — no sudo grant
+    exists there, and root needs none."""
+    calls, run = _recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: False)
+
+    seam.systemctl("systemctl", "restart", "hal0-openwebui.service")
+
+    assert calls == [["systemctl", "restart", "hal0-openwebui.service"]]
 
 
 def test_systemctl_non_systemctl_argv_always_passes_through() -> None:

--- a/tests/system/test_seam_agent_units.py
+++ b/tests/system/test_seam_agent_units.py
@@ -79,9 +79,10 @@ def test_agent_unit_name_builds_expected_unit(good: str) -> None:
 
 
 def test_agent_unit_argv_rejects_unknown_verb() -> None:
-    """Only stop/disable exist. A typo is a caller bug, caught before exec."""
+    """Only the AGENT_UNIT_VERBS map exists (start/stop/restart/enable/disable
+    since #1590). A verb outside it is a caller bug, caught before exec."""
     with pytest.raises(KeyError):
-        seam_mod.agent_unit_argv("restart", "hermes", euid=1000)
+        seam_mod.agent_unit_argv("mask", "hermes", euid=1000)
 
 
 # ── Python side: privilege routing ───────────────────────────────────────────
@@ -89,7 +90,13 @@ def test_agent_unit_argv_rejects_unknown_verb() -> None:
 
 @pytest.mark.parametrize(
     ("verb", "seam_verb"),
-    [("stop", "stop-agent"), ("disable", "disable-agent")],
+    [
+        ("stop", "stop-agent"),
+        ("disable", "disable-agent"),
+        ("start", "start-agent"),
+        ("restart", "restart-agent"),
+        ("enable", "enable-agent"),
+    ],
 )
 def test_unprivileged_routes_through_sudo_seam(verb: str, seam_verb: str) -> None:
     """THE regression. Off root the argv must be the ``sudo -n`` seam call —
@@ -109,7 +116,13 @@ def test_unprivileged_routes_through_sudo_seam(verb: str, seam_verb: str) -> Non
 
 @pytest.mark.parametrize(
     ("verb", "seam_verb"),
-    [("stop", "stop-agent"), ("disable", "disable-agent")],
+    [
+        ("stop", "stop-agent"),
+        ("disable", "disable-agent"),
+        ("start", "start-agent"),
+        ("restart", "restart-agent"),
+        ("enable", "enable-agent"),
+    ],
 )
 def test_root_runs_systemctl_directly(verb: str, seam_verb: str) -> None:
     """Root needs no seam — and the installer/uninstaller runs at moments when
@@ -191,6 +204,9 @@ def test_wrapper_rejects_malformed_agent_id(
     [
         ("stop-agent", "stop hal0-agent@hermes.service"),
         ("disable-agent", "disable hal0-agent@hermes.service"),
+        ("start-agent", "start hal0-agent@hermes.service"),
+        ("restart-agent", "restart hal0-agent@hermes.service"),
+        ("enable-agent", "enable hal0-agent@hermes.service"),
     ],
 )
 def test_wrapper_builds_the_unit_name_itself(
@@ -224,10 +240,50 @@ def test_wrapper_rejects_unknown_agent_verb(
     """The verb allow-list is the case statement; nothing else gets through."""
     env, log = fake_systemctl
 
-    for verb in ("restart-agent", "enable-agent", "mask-agent", "start-agent"):
+    for verb in ("mask-agent", "kill-agent", "isolate-agent"):
         proc = _run_wrapper(env, verb, "hermes")
         assert proc.returncode == 64, f"{verb} should not exist: {proc.stderr}"
         assert "bad cmd" in proc.stderr
+    assert not log.exists()
+
+
+# ── Companion-service family (svc-<verb>, #1590) ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("cmd", "key", "expected"),
+    [
+        ("svc-start", "openwebui", "start hal0-openwebui.service"),
+        ("svc-stop", "openwebui", "stop hal0-openwebui.service"),
+        ("svc-restart", "hindsight", "restart hindsight-api.service"),
+        ("svc-enable", "hindsight", "enable hindsight-api.service"),
+        ("svc-disable", "openwebui", "disable hal0-openwebui.service"),
+    ],
+)
+def test_wrapper_companion_family_maps_key_to_unit(
+    cmd: str, key: str, expected: str, fake_systemctl: tuple[dict[str, str], Path]
+) -> None:
+    """The caller passes a service KEY from a closed map, never a unit string."""
+    env, log = fake_systemctl
+
+    proc = _run_wrapper(env, cmd, key)
+
+    assert proc.returncode == 0, proc.stderr
+    assert log.read_text().strip() == expected
+
+
+@pytest.mark.parametrize("bad", ["hal0-api", "comfyui", "../etc", "hal0-openwebui.service", ""])
+def test_wrapper_companion_family_rejects_unknown_keys(
+    bad: str, fake_systemctl: tuple[dict[str, str], Path]
+) -> None:
+    """Anything outside the enumerated map dies before exec — including a raw
+    unit string, so the family can never be widened from the caller side."""
+    env, log = fake_systemctl
+
+    proc = _run_wrapper(env, "svc-restart", bad)
+
+    assert proc.returncode == 64, proc.stderr
+    assert "bad service key" in proc.stderr
     assert not log.exists()
 
 

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -18,6 +18,7 @@ import {
   useComfyui,
   useComfyuiRenderCancel,
   useComfyuiRestart,
+  useComfyuiSwitchover,
   useComfyuiWorkflows,
   transformComfyuiStatus,
   COMFYUI_FALLBACK,
@@ -400,7 +401,7 @@ export const COMFYUI_V2_MOCK = {
 // is worse than none, so it's removed rather than wired to a speculative
 // endpoint; switching away from generation mode already has a real path via
 // the arbiter switchover (mode=inference).
-function CardHead({ run, pct, onRestart, onLogs }) {
+function CardHead({ run, pct, onRestart, onLogs, onStart, engineStopped, startBusy }) {
   const hasRun = run != null
   return (
     <div className="engine-h wcard-h">
@@ -414,7 +415,7 @@ function CardHead({ run, pct, onRestart, onLogs }) {
       </span>
       <span className={'epill' + (hasRun ? ' generating' : '')}>
         <span className="dot" />
-        {hasRun ? `generating · ${Math.round(pct)}%` : 'idle'}
+        {hasRun ? `generating · ${Math.round(pct)}%` : (engineStopped ? 'stopped' : 'idle')}
       </span>
       <span className="grow" />
       <span className="eh-right">
@@ -422,8 +423,18 @@ function CardHead({ run, pct, onRestart, onLogs }) {
           <span className="d" />
           iGPU · exclusive
         </span>
-        {/* Container controls — moved up from the footer to the header far right. */}
+        {/* Container controls — moved up from the footer to the header far right.
+            Start (#1590) drives the GPU-arbiter switchover to generation mode —
+            the honest way to bring ComfyUI up (drain LLM slots, hand the iGPU
+            over) — and renders only while the engine is down. Slot-card button
+            style per the operator's ask. */}
         <span className="foot-ctrls">
+          {engineStopped && onStart && (
+            <button className="btn ghost sm" data-testid="comfy-start"
+              disabled={startBusy} onClick={onStart}>
+              {startBusy ? 'starting…' : 'Start'}
+            </button>
+          )}
           <button className="sctrl restart" title="Restart" onClick={onRestart}><Ci name="refresh" size={12} /></button>
           <button className="sctrl" title="Logs" onClick={onLogs}><Ci name="logs" size={12} /></button>
         </span>
@@ -478,6 +489,9 @@ export function ImageGenCard({
   onCancel,
   onRestart,
   onLogs,
+  onStart,
+  engineStopped,
+  startBusy,
   comfyBaseUrl,
 }) {
   const { engine, run, queue, gtt, ram, stats, inventory } = mock
@@ -517,7 +531,8 @@ export function ImageGenCard({
 
   return (
     <div className="engine wcard active">
-      <CardHead run={run} pct={pct} onRestart={onRestart} onLogs={onLogs} />
+      <CardHead run={run} pct={pct} onRestart={onRestart} onLogs={onLogs}
+        onStart={onStart} engineStopped={engineStopped} startBusy={startBusy} />
       <div className="wcard-b">
 
         {/* Render-active notice — moved out of the card header so it sits
@@ -765,6 +780,16 @@ export function ComfyuiPane() {
   // Control mutations
   const cancelMutation = useComfyuiRenderCancel()
   const restartMutation = useComfyuiRestart()
+  // Start = GPU-arbiter switchover to generation mode (#1590). Gated on the
+  // LIVE status (never the mock override), so the button can only appear when
+  // the real engine reports stopped/error; the switchover block on /status
+  // then drives the pill through starting → running on the next polls.
+  const switchoverMutation = useComfyuiSwitchover()
+  const engineStopped =
+    !override && liveStatus != null &&
+    (liveStatus.engine === 'stopped' || liveStatus.engine === 'error') &&
+    !liveStatus.switchover?.active
+  const startBusy = switchoverMutation.isPending || !!liveStatus?.switchover?.active
 
   // Resolve the browser-reachable ComfyUI base URL. The authoritative source
   // is /api/config/urls → `comfyui` (HAL0_COMFYUI_PUBLIC_URL, or
@@ -788,6 +813,9 @@ export function ComfyuiPane() {
         mock={paneData}
         onCancel={() => cancelMutation.mutate()}
         onRestart={() => restartMutation.mutate()}
+        onStart={() => switchoverMutation.mutate({ mode: 'generation' })}
+        engineStopped={engineStopped}
+        startBusy={startBusy}
         onLogs={() => {
           // Fetch logs and open in a basic alert for now; a logs drawer is a
           // future enhancement (the endpoint is wired, UI depth TBD).

--- a/ui/src/dash/services.css
+++ b/ui/src/dash/services.css
@@ -1,7 +1,10 @@
 /* hal0 dashboard — Services page (#services)
    Page-scoped styles (svcp- prefix). Reuses the global service atoms from
-   overhaul.css: .sdot, .svc-pill, .svc-icon-tile, .svc-btn, .svc-pending,
-   .svc-comfy-drawer (queue drawer shared with services-card.jsx). */
+   overhaul.css (.sdot, .svc-pill, .svc-icon-tile, .svc-btn, .svc-pending,
+   .svc-comfy-drawer) and matches the slot-card design system: same card
+   container (bg-1 / line / rad-lg), same JetBrains Mono label rhythm, same
+   ok/warn/err token vocabulary — no generic rgba fallbacks, no opacity
+   dimming where a foreground tier token exists. */
 
 .svcp-view .dcard { margin-bottom: 14px; }
 
@@ -11,16 +14,19 @@
   gap: 14px;
 }
 
+/* Card container — mirrors .slot (dashboard.css). */
 .svcp-card {
-  border: 1px solid var(--line, rgba(127, 127, 127, 0.25));
-  border-radius: 10px;
-  padding: 14px 16px;
-  background: var(--card-bg, rgba(127, 127, 127, 0.04));
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--rad-lg);
+  padding: 16px 16px 14px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   min-width: 0;
+  transition: border-color 0.12s ease;
 }
+.svcp-card:hover { border-color: var(--line-strong); }
 
 .svcp-card-head {
   display: flex;
@@ -36,39 +42,51 @@
   flex: 1;
 }
 
-.svcp-name { font-weight: 600; }
+/* Name — mirrors .slot-name typography. */
+.svcp-name {
+  font-family: var(--jbm);
+  font-size: 14.5px;
+  font-weight: 500;
+  color: var(--fg);
+  letter-spacing: -0.01em;
+}
 
 .svcp-uptime {
+  font-family: var(--jbm);
   font-size: 11px;
-  opacity: 0.65;
+  color: var(--fg-4);
 }
 
 .svcp-desc {
   font-size: 12px;
-  opacity: 0.8;
+  color: var(--fg-3);
+  line-height: 1.5;
 }
 
 .svcp-detail {
-  font-size: 12px;
-  opacity: 0.6;
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-3);
 }
 
+/* Meta rows — the slot-met label register: mono, small, tiered fg. */
 .svcp-meta {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
   font-size: 11px;
-  opacity: 0.7;
+  color: var(--fg-4);
   overflow-wrap: anywhere;
 }
 
-.svcp-meta-row b { font-weight: 600; }
+.svcp-meta-row b { font-weight: 500; color: var(--fg-2); }
 
-.svcp-unmanaged { opacity: 0.55; font-style: italic; }
+.svcp-unmanaged { color: var(--fg-4); font-style: italic; }
 
 .svcp-hints {
   font-size: 11px;
-  opacity: 0.65;
+  color: var(--fg-4);
+  line-height: 1.5;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -82,37 +100,54 @@
   margin-top: auto;
 }
 
+/* Buttons are .btn.ghost.sm (the slot-card family) — this only keeps the
+   icon+label gap; size/colors come from the shared .btn rules. */
 .svcp-act {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
 }
 
-.svcp-act-danger { color: var(--danger, #d05050); }
+/* Danger verb (Stop) — the .btn.danger vocabulary. */
+.svcp-act-danger { color: var(--err); border-color: var(--err-line); }
+.svcp-act-danger:hover { background: var(--err-soft); border-color: var(--err-line); }
 
-.svcp-busy { font-size: 11px; opacity: 0.6; }
+.svcp-busy {
+  font-family: var(--jbm);
+  font-size: 11px;
+  color: var(--fg-4);
+}
 
+/* Action outcome line — ok/err soft tokens, chip-adjacent. */
 .svcp-result {
+  font-family: var(--jbm);
   font-size: 11px;
   padding: 6px 8px;
-  border-radius: 6px;
-  background: rgba(80, 180, 110, 0.1);
+  border-radius: var(--rad-sm);
+  background: var(--ok-soft);
+  color: var(--ok);
+  border: 1px solid var(--ok-line);
 }
 
-.svcp-result.err { background: rgba(210, 80, 80, 0.12); }
+.svcp-result.err {
+  background: var(--err-soft);
+  color: var(--err);
+  border-color: var(--err-line);
+}
 
 /* ── logs drawer ── */
 .svcp-logs {
-  border-top: 1px solid var(--line, rgba(127, 127, 127, 0.2));
+  border-top: 1px solid var(--line-soft);
   padding-top: 8px;
   max-height: 260px;
   overflow: auto;
 }
 
 .svcp-logs-pre {
+  font-family: var(--jbm);
   font-size: 10.5px;
   line-height: 1.5;
+  color: var(--fg-2);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   margin: 0;
@@ -120,7 +155,7 @@
 
 .svcp-logs-empty {
   font-size: 11px;
-  opacity: 0.55;
+  color: var(--fg-4);
   padding: 6px 0;
 }
 
@@ -136,12 +171,17 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
+  color: var(--fg);
 }
 
-.svcp-mdns-host { opacity: 0.7; font-size: 12px; }
+.svcp-mdns-host {
+  font-family: var(--jbm);
+  font-size: 12px;
+  color: var(--fg-4);
+}
 
 .svcp-mdns-sub {
   font-size: 12px;
-  opacity: 0.7;
+  color: var(--fg-3);
   line-height: 1.55;
 }

--- a/ui/src/dash/services.jsx
+++ b/ui/src/dash/services.jsx
@@ -98,21 +98,21 @@ function ActionButtons({ svc, onAction, busy }) {
   return (
     <>
       {has('restart') && (
-        <button className="btn ghost svcp-act" disabled={busy}
+        <button className="btn ghost sm svcp-act" disabled={busy}
           data-testid={`svcp-restart-${svc.id}`}
           onClick={() => onAction(svc.id, 'restart')}>
           {SIcons.restart} Restart
         </button>
       )}
       {has('start') && !running && (
-        <button className="btn ghost svcp-act" disabled={busy}
+        <button className="btn ghost sm svcp-act" disabled={busy}
           data-testid={`svcp-start-${svc.id}`}
           onClick={() => onAction(svc.id, 'start')}>
           {SIcons.play} Start
         </button>
       )}
       {has('stop') && running && (
-        <button className="btn ghost svcp-act svcp-act-danger" disabled={busy}
+        <button className="btn ghost sm svcp-act svcp-act-danger" disabled={busy}
           data-testid={`svcp-stop-${svc.id}`}
           onClick={() => {
             if (window.confirm(`Stop ${svc.name}? Clients using it will lose access until it is started again.`)) {
@@ -171,14 +171,14 @@ function ServiceCard({ svc, onAction, busyId, actionMsg, comfyReachable }) {
       <div className="svcp-actions">
         <ActionButtons svc={svc} onAction={onAction} busy={busy} />
         {svc.unit && (
-          <button className={'btn ghost svcp-act' + (logsOpen ? ' on' : '')}
+          <button className={'btn ghost sm svcp-act' + (logsOpen ? ' on' : '')}
             data-testid={`svcp-logbtn-${svc.id}`}
             onClick={() => setLogsOpen(v => !v)}>
             {SIcons.logs} Logs {logsOpen ? SIcons.chevUp : SIcons.chev}
           </button>
         )}
         {isComfy && CJQ && (
-          <button className={'btn ghost svcp-act' + (queueOpen ? ' on' : '')}
+          <button className={'btn ghost sm svcp-act' + (queueOpen ? ' on' : '')}
             data-testid="svcp-queue-comfyui"
             onClick={() => setQueueOpen(v => !v)}>
             Queue {queueOpen ? SIcons.chevUp : SIcons.chev}
@@ -211,7 +211,7 @@ function DiscoveryCard({ mdns, services }) {
           <span>avahi {mdns.available ? 'active' : 'inactive'}</span>
           <span className="svcp-mdns-host mono">{mdns.hostname}</span>
           <span className="vh-spacer" style={{ flex: 1 }} />
-          <button className={'btn ghost svcp-act' + (on ? ' on' : '')}
+          <button className={'btn ghost sm svcp-act' + (on ? ' on' : '')}
             data-testid="svcp-mdns-toggle"
             disabled={advertiseMut.isPending || !mdns.available}
             onClick={() => advertiseMut.mutate(!on)}>


### PR DESCRIPTION
Closes #1590. Reported live on lxc105 (v1.0.0-rc.1): Services-page Restart on ComfyUI died with `Interactive authentication required`.

## Root cause

`hal0.services.systemd` ran `systemctl` directly under a stale "hal0-api runs as root" assumption (its own docstring said so). P3-perms made the API `User=hal0`; slot ops got the `hal0-systemctl` seam, the updater got it in #1464 — the companion-services layer never did. Every mutating verb on all four service cards escalated through polkit and failed.

## Changes

**Wrapper** (`installer/wrappers/hal0-systemctl`): `start-agent`/`restart-agent`/`enable-agent` arms (same posture as stop-agent: literal verb, validated id, unit built root-side) + a `svc-start|stop|restart|enable|disable` family over a **closed** key→unit map (openwebui, hindsight). The sudoers grant is binary-pinned — no sudoers change; the case statement is the allow-list.

**Seam** (`hal0.system.seam`): `AGENT_UNIT_VERBS` grows start/restart/enable; `SystemCtlSeam.systemctl()` routes `hal0-agent@*` + companion units through the wrapper. Foreign units and non-hal0-user processes pass through exactly as before.

**Services layer**: `unit_action` executes through the seam (off-loop, per-verb timeouts kept). ComfyUI gains `start`, special-cased in the route to `POST /api/comfyui/switchover {mode: generation}` — the GPU-arbiter drain-and-handoff — because a raw `systemctl start` would boot ComfyUI under the resident LLM stack. `restart` stays the raw unit bounce the FirstRun repair uses; `stop` stays arbiter-only.

**UI**: Image-Gen card header gains Start (gated on the LIVE engine status reporting stopped/error, disabled while a switch is in flight); Services-page buttons adopt the slot-card style (`btn ghost sm`) per operator request.

## Verification

- Targeted backend: 173 passed (seam routing for agent+companion units, wrapper key→unit map + unknown-key/verb rejection, comfyui-start delegation with `unit_action` never called, registry/allow-list updates)
- UI: vitest 66, tsc, build — clean
- **Live on lxc105**: deployed the wrapper + modules; `POST /api/services/hindsight/action {restart}` now returns `ok: true` through `sudo -n hal0-systemctl svc-restart hindsight` (was the polkit error); Start renders on the ComfyUI service card and the Image-Gen header

## Review note

Touches the privileged wrapper (installer/systemd surface) — **no automerge** per workspace policy; requesting human review. lxc105 is already running this diff for live evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)