### PR TITLE
fix(ui): settings info icons sit inline with their labels

### DIFF
--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2364,8 +2364,12 @@ select.npu-sel {
   border-bottom: 1px solid var(--line-soft);
 }
 .s-row:last-child { border-bottom: none; }
-.s-row .k { font-size: 13px; color: var(--fg); display: flex; flex-direction: column; gap: 3px; }
-.s-row .k .sub { font-family: var(--geist); font-size: 11.5px; color: var(--fg-4); font-weight: 400; }
+/* Row direction so SRow's FieldInfoIcon sits inline beside the label —
+   the same fix .form-lbl got for the model/slot drawers. The column
+   layout predates FieldInfoIcon (sub was a text line under the label);
+   any legacy text .sub still wraps to its own full-width line. */
+.s-row .k { font-size: 13px; color: var(--fg); display: flex; flex-direction: row; flex-wrap: wrap; align-items: center; gap: 3px; }
+.s-row .k .sub { font-family: var(--geist); font-size: 11.5px; color: var(--fg-4); font-weight: 400; flex: 0 0 100%; }
 .s-row .v { font-family: var(--jbm); font-size: 12.5px; color: var(--fg-2); }
 .s-row .v.mono { font-family: var(--jbm); }
 .s-row .ac { display: flex; gap: 6px; }


### PR DESCRIPTION
## What

On every Settings page the field-help info icons rendered *below* their labels instead of beside them — unlike the model/slot edit drawers, where they sit inline.

## Cause

Settings rows (`SRow`) render the icon right next to the label text, but `.s-row .k` still carried `flex-direction: column` from the era when `sub` was a text line under the label. Same defect class the drawers already fixed in `.form-lbl` (row + wrap + center, legacy `.sub` keeps its own full-width line via `flex: 0 0 100%`).

## Verification

Deployed to lxc105 and measured live: `.s-row .k` computes `flex-direction: row` and the icon's vertical center is within 8px of the label's. No text-`.sub` call sites exist inside `.s-row .k` (grepped), so the wrap fallback is purely defensive. UI build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)