### PR TITLE
feat(ui): slot drawer runner image picks from the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Changed
+
+- Slot drawer: the Runner Image field is a dropdown of the runner-image
+  catalog (the same registry the Runtimes page shows) instead of a free-text
+  input; a "Custom image ref…" option keeps the debug/A-B/rollback escape
+  hatch. Picking an image repopulates the Runner Binary dropdown with the
+  binaries that image ships — dual-binary images (e.g. the shared
+  ROCm/Vulkan image) offer both, single-binary images hop the selection to
+  their sole binary.
+
 ## [1.0.0-rc.1] — 2026-08-01 (R5 · the rework release)
 
 The R5 rework puts the platform back together as a genuine 1.0: memory and

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -250,6 +250,11 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// image_pin — optional escape hatch. Empty = release default
 	// (RUNNER_IMAGES[binary]). A non-default pin is shown on the slot card.
 	const [imagePin, setImagePin] = useStateSM(slot?.image_pin || "");
+	// Runner Image is a catalog dropdown (the RUNNER_IMAGES refs system-info
+	// reports — same source as the Runtimes page). `pinCustom` flips the
+	// control to a free-text input for the debug-build/A-B/rollback escape
+	// hatch the field originally existed for.
+	const [pinCustom, setPinCustom] = useStateSM(false);
 	// Runtime profile (SlotConfig.profile) — picks the runtime family,
 	// device-class gating and MTP draft backend. NOT a flags source at launch:
 	// profile flags are copy-on-stamp into model.defaults.extra_args (model
@@ -459,6 +464,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		setThreads(slot.threads != null ? String(slot.threads) : "0");
 		setBinary(slot.binary || "");
 		setImagePin(slot.image_pin || "");
+		setPinCustom(false);
 		setProfileSel(slot.profile || "");
 		setSubmitErr(null);
 		setDiscardOpen(false);
@@ -983,6 +989,19 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						// and `vulkanfpx · vulkan`). With no image named yet there is
 						// nothing to match against, so fall back to the device fit set.
 						const pinnedImage = (imagePin || "").trim();
+						// Runner Image catalog — the distinct image refs RUNNER_IMAGES
+						// resolves to (same system-info source the Runtimes page renders).
+						// One image can ship several binaries (rocmfpx/vulkanfpx share
+						// one Vulkan-portable image); the map records which, so picking
+						// an image repopulates the Runner Binary dropdown below.
+						const imageKeysByRef = new Map();
+						for (const k of binaryKeys) {
+							const img = backends[k]?.image;
+							if (!img) continue;
+							if (!imageKeysByRef.has(img)) imageKeysByRef.set(img, []);
+							imageKeysByRef.get(img).push(k);
+						}
+						const catalogImages = [...imageKeysByRef.keys()];
 						const imageFitKeys = pinnedImage
 							? binaryKeys.filter((k) => backends[k]?.image === pinnedImage)
 							: [];
@@ -1012,27 +1031,95 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								<div className="form-row">
 									<div className="form-lbl">
 										<span>Runner Image</span>
-										<FieldInfoIcon description="Optional container image override for a debug build, A/B test, or rollback. Empty uses the release default." />
+										<FieldInfoIcon description="Pin the container image the slot launches. The list is the
+											runner-image catalog (the same registry the Runtimes page
+											shows); ‘Custom image ref…’ keeps the free-text escape
+											hatch for a debug build, A/B test, or rollback. Empty
+											uses the release default resolved from Runner Binary." />
 									</div>
 									<div className="form-ctl">
-										<input
-											className={
-												"input mono" + (fieldErrs.imagePin ? " input-err" : "")
-											}
-											data-testid="slot-hw-image-pin"
-											value={imagePin}
-											onChange={(e) => {
-												setImagePin(e.target.value);
-												setFieldErrs((p) => ({ ...p, imagePin: undefined }));
-											}}
-											placeholder={
-												binary && backends[binary]?.image
-													? backends[binary].image
-													: "will resolve from runner (binary)"
-											}
-											spellCheck={false}
-											style={imagePin ? {} : { color: "var(--fg-4)" }}
-										/>
+										{pinCustom ? (
+											<div
+												style={{ display: "flex", gap: 8, alignItems: "center" }}
+											>
+												<input
+													className={
+														"input mono" +
+														(fieldErrs.imagePin ? " input-err" : "")
+													}
+													data-testid="slot-hw-image-pin"
+													value={imagePin}
+													onChange={(e) => {
+														setImagePin(e.target.value);
+														setFieldErrs((p) => ({
+															...p,
+															imagePin: undefined,
+														}));
+													}}
+													placeholder={
+														binary && backends[binary]?.image
+															? backends[binary].image
+															: "will resolve from runner (binary)"
+													}
+													spellCheck={false}
+													style={{ flex: 1 }}
+													autoFocus
+												/>
+												<button
+													className="btn ghost sm"
+													data-testid="slot-hw-image-pin-catalog"
+													title="Back to the runner-image catalog"
+													onClick={() => setPinCustom(false)}
+												>
+													Catalog
+												</button>
+											</div>
+										) : (
+											<select
+												className={
+													"input mono" +
+													(fieldErrs.imagePin ? " input-err" : "")
+												}
+												data-testid="slot-hw-image-pin"
+												value={imagePin}
+												onChange={(e) => {
+													const v = e.target.value;
+													if (v === "__custom__") {
+														setPinCustom(true);
+														return;
+													}
+													setImagePin(v);
+													setFieldErrs((p) => ({ ...p, imagePin: undefined }));
+													// Keep BINARY coherent with the picked image: if the
+													// current binary doesn't ship in it, hop to the
+													// image's sole binary, or clear so the operator picks
+													// from the repopulated list.
+													const keys = imageKeysByRef.get(v) || [];
+													if (v && binary && !keys.includes(binary)) {
+														setBinary(keys.length === 1 ? keys[0] : "");
+													}
+												}}
+												style={imagePin ? {} : { color: "var(--fg-4)" }}
+											>
+												<option value="">
+													— default · resolved from Runner Binary —
+												</option>
+												{/* A persisted pin outside the catalog (older release,
+												    hand-edited TOML) keeps its own option so opening the
+												    drawer never silently rewrites it. */}
+												{pinnedImage && !catalogImages.includes(pinnedImage) && (
+													<option value={pinnedImage}>
+														{pinnedImage} · custom
+													</option>
+												)}
+												{catalogImages.map((img) => (
+													<option key={img} value={img} title={img}>
+														{(imageKeysByRef.get(img) || []).join(" / ")} · {img}
+													</option>
+												))}
+												<option value="__custom__">Custom image ref…</option>
+											</select>
+										)}
 										{fieldErrs.imagePin ? (
 											<div className="hint" style={{ color: "var(--err)" }}>
 												{fieldErrs.imagePin}

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -225,6 +225,9 @@ test.describe('Slot edit controls (/slots)', () => {
     await page.getByTestId('slot-hw-binary').selectOption('rocmfpx')
     await page.getByTestId('slot-hw-ngl').fill('0')
     await page.getByTestId('slot-hw-threads').fill('8')
+    // Runner Image is a catalog dropdown now; the free-text escape hatch
+    // lives behind the "Custom image ref…" option.
+    await page.getByTestId('slot-hw-image-pin').selectOption('__custom__')
     await page.getByTestId('slot-hw-image-pin').fill('ghcr.io/example/runner:test')
     await page.locator('.drawer button:has-text("Save")').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
@@ -234,6 +237,73 @@ test.describe('Slot edit controls (/slots)', () => {
       image_pin: 'ghcr.io/example/runner:test',
     })
     expect(puts[0].binary).toBeTruthy()
+  })
+
+  test('HW grid — Runner Image is a catalog dropdown; picking one repopulates BINARY', async ({ page }) => {
+    // rocmfpx + vulkanfpx share one dual-binary image; cuda ships its own.
+    // The Runner Image select lists the two distinct refs; choosing the
+    // shared one offers both binaries, choosing cuda's hops BINARY to its
+    // sole key.
+    await page.route('**/api/system-info', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          hardware: {},
+          features: {},
+          podman_context: 'rootless',
+          backends: {
+            rocmfpx: {
+              image: 'ghcr.io/hal0ai/tb:dual',
+              runtime_family: 'llamacpp',
+              device_class: 'gpu',
+              backend: 'rocm',
+              supported_backends: ['rocm', 'vulkan'],
+              format_arch: 'gguf',
+              state: 'installed',
+            },
+            vulkanfpx: {
+              image: 'ghcr.io/hal0ai/tb:dual',
+              runtime_family: 'llamacpp',
+              device_class: 'gpu',
+              backend: 'vulkan',
+              supported_backends: ['rocm', 'vulkan'],
+              format_arch: 'gguf',
+              state: 'installed',
+            },
+            cuda: {
+              image: 'ghcr.io/hal0ai/tb:cuda',
+              runtime_family: 'llamacpp',
+              device_class: 'gpu',
+              backend: 'cuda',
+              supported_backends: ['cuda'],
+              format_arch: 'gguf',
+              state: 'installed',
+            },
+          },
+        }),
+      }),
+    )
+    await seedSlots(page, [{ ...PRIMARY, binary: 'rocmfpx', image_pin: null }, EMBED])
+    await page.goto('/#slots/primary')
+
+    const imageSel = page.getByTestId('slot-hw-image-pin')
+    await expect(imageSel).toBeVisible()
+    // Catalog: default + 2 distinct images + the custom escape hatch.
+    await expect(imageSel.locator('option')).toHaveCount(4)
+
+    // Pick the shared dual-binary image → BINARY offers both its binaries
+    // and the current rocmfpx selection survives (it ships in the image).
+    await imageSel.selectOption('ghcr.io/hal0ai/tb:dual')
+    const binarySel = page.getByTestId('slot-hw-binary')
+    await expect(binarySel.locator('option')).toHaveCount(2)
+    await expect(binarySel).toHaveValue('rocmfpx')
+
+    // Hop to the cuda image → rocmfpx doesn't ship in it, so BINARY moves
+    // to the image's sole binary.
+    await imageSel.selectOption('ghcr.io/hal0ai/tb:cuda')
+    await expect(binarySel).toHaveValue('cuda')
+    await expect(binarySel.locator('option')).toHaveCount(1)
   })
 
   test('HW grid — fit-check warns when device backend ∉ BINARY supported_backends (§4)', async ({ page }) => {


### PR DESCRIPTION
The Runner Image field in the slot drawer was a bare text input — the
operator had to paste an image ref by hand even though the runner-image
catalog (RUNNER_IMAGES, surfaced by /api/system-info and rendered on the
Runtimes page) already knows every ref hal0 ships. The field is now a
dropdown over the distinct catalog images, labelled with the binaries
each image provides; a "Custom image ref…" option keeps the free-text
escape hatch for debug builds, A/B tests, and rollbacks, and an
out-of-catalog persisted pin keeps its own option so opening the drawer
never rewrites it.

Choosing an image drives the Runner Binary dropdown, which already
listed only the binaries built into the pinned image: dual-binary
images (the shared ROCm/Vulkan fpx image) offer both keys, and picking
a single-binary image hops the selection to its sole binary instead of
leaving an incoherent pair behind.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
