### PR TITLE
fix(brain): replace the |min chat-template filter minja can't execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- hal0-brain tool-bearing requests no longer 500 with "Unknown (built-in)
+  filter 'min'": the GGUF-embedded chat template uses the `|min` filter,
+  which llama-server's jinja engine (minja) lacks. A corrected template
+  (`hal0-brain-sft.jinja`) now ships bundled, and the curated catalogue
+  stamps it into the model's `defaults.chat_template` at pull time so
+  fresh installs launch with `--chat-template-file` instead of the broken
+  embedded template.
+
 ### Changed
 
 - Slot drawer: the Runner Image field is a dropdown of the runner-image

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -119,6 +119,19 @@ class CuratedModel(BaseModel):
         default=0,
         description=("Native context window in tokens. Zero/omitted for image-gen entries."),
     )
+    chat_template: str = Field(
+        default="",
+        description=(
+            "Optional bundled chat-template id (a ``<id>.jinja`` under the "
+            "model-store ``chat-templates/`` dir, seeded from "
+            "``hal0.templates``). When set, the pull layer stamps it into the "
+            "registry row's ``defaults.chat_template`` so launches use the "
+            "curated template instead of the GGUF-embedded one — the escape "
+            "hatch for artifacts whose embedded template trips the runner's "
+            "jinja engine (e.g. hal0-brain-sft's ``|min`` filter, which minja "
+            "lacks). Empty = use the embedded template ('auto')."
+        ),
+    )
     recommended_slot: str = Field(
         default="chat",
         description="Default slot to assign the model to. 'chat' for chat, 'img' for image-gen.",
@@ -351,6 +364,7 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
         hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
         context_length=131072,
+        chat_template="hal0-brain-sft",
         recommended_slot="chat",
         tags=["chat", "brain", "steward", "tool-use", "tiny", "rocmfpx"],
         notes=(
@@ -373,6 +387,7 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
         hf_file="hal0-brain-sft-Q4_0_ROCMFP4_COHERENT.gguf",
         context_length=131072,
+        chat_template="hal0-brain-sft",
         recommended_slot="chat",
         tags=["chat", "brain", "steward", "tool-use", "tiny", "rocmfp4"],
         notes=(
@@ -395,6 +410,7 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
         hf_file="hal0-brain-sft-F16.gguf",
         context_length=131072,
+        chat_template="hal0-brain-sft",
         recommended_slot="chat",
         tags=["chat", "brain", "steward", "tool-use", "tiny", "portable"],
         notes=(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1248,9 +1248,7 @@ def _register_pulled(
     merged_meta = dict(existing.metadata)
     merged_meta.update(fresh_meta)
     updates["metadata"] = merged_meta
-    if curated_template and not (
-        existing.defaults is not None and existing.defaults.chat_template
-    ):
+    if curated_template and not (existing.defaults is not None and existing.defaults.chat_template):
         merged_defaults = (
             existing.defaults.model_copy(update={"chat_template": curated_template})
             if existing.defaults is not None

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -40,7 +40,7 @@ from hal0.db import repository
 from hal0.db.connection import connect, tx
 from hal0.errors import Hal0Error
 from hal0.registry.fileset import FileSetEntry, FileSetPlan
-from hal0.registry.model import Model
+from hal0.registry.model import Model, ModelDefaults
 from hal0.registry.store import ModelNotFound, ModelRegistry, _fsync_dir
 
 log = logging.getLogger(__name__)
@@ -1200,6 +1200,14 @@ def _register_pulled(
     # bytes were fetched — and thereby how stale they are vs an available
     # HF update (registry/update_check.py compares the shas).
     fresh_meta = {"sha256": sha256, "pulled_at": int(time.time())}
+    # Curated template override: some artifacts ship an embedded chat template
+    # the runner's jinja engine can't execute (hal0-brain-sft's ``|min``), so
+    # their catalogue entry names a bundled replacement. Stamped as a defaults
+    # value, never over an operator's own setting.
+    from hal0.registry.curated import get_curated
+
+    curated = get_curated(model_id)
+    curated_template = curated.chat_template if curated is not None else ""
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
@@ -1228,6 +1236,9 @@ def _register_pulled(
                 backends=backends,
                 mmproj=mmproj,
                 metadata=dict(fresh_meta),
+                defaults=ModelDefaults(chat_template=curated_template)
+                if curated_template
+                else None,
             )
         )
         return
@@ -1237,6 +1248,15 @@ def _register_pulled(
     merged_meta = dict(existing.metadata)
     merged_meta.update(fresh_meta)
     updates["metadata"] = merged_meta
+    if curated_template and not (
+        existing.defaults is not None and existing.defaults.chat_template
+    ):
+        merged_defaults = (
+            existing.defaults.model_copy(update={"chat_template": curated_template})
+            if existing.defaults is not None
+            else ModelDefaults(chat_template=curated_template)
+        )
+        updates["defaults"] = merged_defaults
     registry.update(model_id, updates)
 
 

--- a/src/hal0/templates/chat/hal0-brain-sft.jinja
+++ b/src/hal0/templates/chat/hal0-brain-sft.jinja
@@ -1,0 +1,179 @@
+{{- bos_token }}{%- if tools %}
+    {%- set tool_definitions %}
+        {{- "# Tools\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+        {%- for tool in tools %}
+            {{- "\n" }}
+            {{- tool | tojson(ensure_ascii=False) }}
+        {%- endfor %}
+        {{- '\n</tools>\n\nTool usage guidelines:\n- You may call zero or more functions. If no function calls are needed, just answer normally and do not include any <function ... </function>.\n- When calling a function, return an XML object within <function ... </function> using:\n<function name="function-name"><param name="param-name">param-value</param></function>\n- param-value may be multi-line. If it contains <, & or newline characters, wrap it in a CDATA block: <param name="param-name"><![CDATA[...multi-line value...]]></param>' }}
+    {%- endset %}
+    
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {%- if '<tool_def_sep>' in messages[0].content %}
+            {{- messages[0].content.replace('<tool_def_sep>', tool_definitions) }}
+        {%- else %}
+            {{- messages[0].content + '\n\n' + tool_definitions }}
+        {%- endif %}
+    {%- else %}
+        {{- tool_definitions.lstrip() }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        
+        {%- if message.tool_calls %}
+            {%- set content_parts = content.split('<tool_sep>') %}
+            {%- set processed_content = content_parts[0] %}
+            {%- set tool_calls_count = message.tool_calls|length %}
+            {%- set tool_sep_count = content_parts|length - 1 %}
+            {%- set min_count = tool_calls_count %}{%- if tool_sep_count < tool_calls_count %}{%- set min_count = tool_sep_count %}{%- endif %}
+            
+            {%- for i in range(1, content_parts|length) %}
+                {%- set tool_index = i - 1 %}
+                {%- if tool_index < tool_calls_count %}
+                    {%- set tool_call = message.tool_calls[tool_index] %}
+                    {%- if tool_call.function %}
+                        {%- set tool_call = tool_call.function %}
+                    {%- endif %}
+                    {%- set single_tool_xml %}
+                        {{- '<function name="' ~ tool_call.name ~ '">' }}
+                        {%- if tool_call.arguments %}
+                            {%- set args_dict = tool_call.arguments %}
+                            {%- for param_name, param_value in args_dict.items() %}
+                                {{- '<param name="' ~ param_name ~ '">' }}
+                                {%- if param_value is string and ('<' in param_value or '&' in param_value or '\n' in param_value) %}
+                                    {{- '<![CDATA[' + param_value + ']]>' }}
+                                {%- else %}
+                                    {{- param_value }}
+                                {%- endif %}
+                                {{- '</param>' }}
+                            {%- endfor %}
+                        {%- endif %}
+                        {{- '</function>' }}
+                    {%- endset %}
+                    {%- set processed_content = processed_content + single_tool_xml + content_parts[i] %}
+                {%- else %}
+                    {%- set processed_content = processed_content + content_parts[i] %}
+                {%- endif %}
+            {%- endfor %}
+            
+            {%- if tool_calls_count > tool_sep_count %}
+                {%- for remaining_index in range(tool_sep_count, tool_calls_count) %}
+                    {%- set tool_call = message.tool_calls[remaining_index] %}
+                    {%- if tool_call.function %}
+                        {%- set tool_call = tool_call.function %}
+                    {%- endif %}
+                    {%- set remaining_tool_xml %}
+                        {{- '<function name="' ~ tool_call.name ~ '">' }}
+                        {%- if tool_call.arguments %}
+                            {%- set args_dict = tool_call.arguments %}
+                            {%- for param_name, param_value in args_dict.items() %}
+                                {{- '<param name="' ~ param_name ~ '">' }}
+                                {%- if param_value is string and ('<' in param_value or '&' in param_value or '\n' in param_value) %}
+                                    {{- '<![CDATA[' + param_value + ']]>' }}
+                                {%- else %}
+                                    {{- param_value }}
+                                {%- endif %}
+                                {{- '</param>' }}
+                            {%- endfor %}
+                        {%- endif %}
+                        {{- '</function>' }}
+                    {%- endset %}
+                    {%- set processed_content = processed_content + remaining_tool_xml %}
+                {%- endfor %}
+            {%- endif %}
+            
+            {%- set content = processed_content %}
+        {%- endif %}
+        
+        {%- if loop.index0 > ns.last_query_index %}
+            {%- if reasoning_content %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        
+        {%- if message.tool_calls and not has_tool_sep %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<function name="' ~ tool_call.name ~ '">' }}
+                {%- if tool_call.arguments %}
+                    {%- set args_dict = tool_call.arguments %}
+                    {%- for param_name, param_value in args_dict.items() %}
+                        {{- '<param name="' ~ param_name ~ '">' }}
+                        {%- if param_value is string and ('<' in param_value or '&' in param_value or '\n' in param_value) %}
+                            {{- '<![CDATA[' + param_value + ']]>' }}
+                        {%- else %}
+                            {{- param_value }}
+                        {%- endif %}
+                        {{- '</param>' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {%- if message.content is string %}
+            {{- content }}
+        {%- else %}
+            {{- message.content | tojson(ensure_ascii=False) }}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined %}
+        {%- if enable_thinking is false %}
+            {{- '<think>\n\n</think>\n\n' }}
+        {%- elif enable_thinking is true %}
+            {{- '<think>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endif %}

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -122,6 +122,99 @@ async def test_run_pull_happy_path_writes_file_and_registers(
     assert entry.metadata.get("sha256") == digest
 
 
+# ── curated chat-template stamping ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_curated_chat_template(tmp_hal0_home: str) -> None:
+    """A curated entry naming a bundled template lands in defaults.chat_template.
+
+    hal0-brain-sft's GGUF-embedded template uses the ``|min`` filter, which
+    llama-server's minja lacks — every tool-bearing request 500s. The curated
+    row therefore names the bundled ``hal0-brain-sft`` template, and the pull
+    layer must stamp it so launches pass ``--chat-template-file`` instead of
+    trusting the embedded one.
+    """
+    body = _payload(4096)
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("hal0-brain-sft-q8-rocmfpx")
+    assert entry.defaults is not None
+    assert entry.defaults.chat_template == "hal0-brain-sft"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_keeps_operator_chat_template(tmp_hal0_home: str) -> None:
+    """A re-pull never clobbers a chat_template the operator already set."""
+    from hal0.registry.model import Model, ModelDefaults
+
+    body = _payload(4096)
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="hal0-brain-sft-q8-rocmfpx",
+            name="hal0-brain-sft-q8-rocmfpx",
+            path="/nonexistent/model.gguf",
+            size_bytes=1,
+            defaults=ModelDefaults(chat_template="operator-own"),
+        )
+    )
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    entry = registry.get("hal0-brain-sft-q8-rocmfpx")
+    assert entry.defaults is not None
+    assert entry.defaults.chat_template == "operator-own"
+
+
+@pytest.mark.asyncio
+async def test_run_pull_uncurated_model_gets_no_template_default(
+    tmp_hal0_home: str,
+) -> None:
+    """A non-curated pull (custom HF coords) leaves defaults untouched."""
+    body = _payload(4096)
+    job = make_job("some-random-gguf")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="org/random-GGUF",
+            hf_file="random.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("some-random-gguf").defaults is None
+
+
 # ── MR-1: run_pull persists a durable snapshot for ALL callers ────────────────
 
 


### PR DESCRIPTION
The hal0-brain-sft GGUFs embed a chat template that computes
min(tool_calls_count, tool_sep_count) as `[a, b]|min` — a filter
llama-server's jinja engine (minja) doesn't implement. Any request whose
history carries assistant tool_calls hit that branch and the slot
answered HTTP 500 'Unknown (built-in) filter min', which surfaced from
the steward as intermittent 'primary slot HTTP 500' errors.

Ship a corrected copy of the embedded template (the min expressed as a
plain if, nothing else changed) as a bundled chat template, and teach
the curated catalogue to name a bundled template per entry: the pull
layer stamps it into the registry row's defaults.chat_template — never
over an operator's own setting — so launches pass --chat-template-file
instead of trusting the broken embedded template. All three brain
variants carry the stamp.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
