### PR TITLE
fix(ui): stop the activity backfill from janking the slots page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- Slots page no longer stalls while the activity log backfills: the SSE
+  stream replayed the full 1000-row durable backlog one frame at a time on
+  every fresh connect, and the pane re-rendered once per frame. The stream
+  now takes a `limit` (the pane asks for its 200-row ring cap) and the
+  client coalesces frame bursts into one render per 50ms window.
+
 - hal0-brain tool-bearing requests no longer 500 with "Unknown (built-in)
   filter 'min'": the GGUF-embedded chat template uses the `|min` filter,
   which llama-server's jinja engine (minja) lacks. A corrected template

--- a/src/hal0/api/routes/activity.py
+++ b/src/hal0/api/routes/activity.py
@@ -166,6 +166,7 @@ async def stream_activity(
     actor: str | None = None,
     kind: str | None = None,
     search: str | None = None,
+    limit: int = Query(_LIMIT_MAX, ge=1, le=_LIMIT_MAX),
 ) -> StreamingResponse:
     _validate(severity, kind, outcome)
     store = _store(request)
@@ -183,10 +184,13 @@ async def stream_activity(
 
     async def gen():
         # Durable backfill first (id > since), oldest→newest for replay.
+        # ``limit`` caps ONLY this replay (the newest N matching rows): the
+        # dashboard pane keeps a 200-row ring, so streaming the full
+        # 1000-row durable backlog one SSE frame at a time just made the
+        # slots page churn through hundreds of frames it would immediately
+        # discard. The live tail below is unaffected.
         backfill = list(
-            reversed(
-                [_row_to_dict(r) for r in store.query(since=since, limit=_LIMIT_MAX, **filters)]
-            )
+            reversed([_row_to_dict(r) for r in store.query(since=since, limit=limit, **filters)])
         )
         cursor = since
         for rec in backfill:

--- a/tests/api/test_activity.py
+++ b/tests/api/test_activity.py
@@ -121,3 +121,62 @@ def test_activity_epoch_is_stable_within_process(client: TestClient) -> None:
     a = client.get("/api/activity").json()["epoch"]
     b = client.get("/api/activity").json()["epoch"]
     assert a == b
+
+
+def test_activity_stream_backfill_respects_limit(client: TestClient) -> None:
+    """`limit` caps the SSE connect backfill to the newest N matching rows.
+
+    The dashboard pane keeps a 200-row ring; without the cap the stream
+    replayed the full 1000-row durable backlog one frame at a time and the
+    slots page churned through hundreds of frames it immediately discarded.
+
+    Called directly (not through TestClient streaming — the live tail is an
+    infinite generator) with a fake already-disconnected request, so the
+    generator drains the backfill and exits at the first tail poll.
+    """
+    import json as _json
+
+    from hal0.api.routes.activity import stream_activity
+
+    for i in range(30):
+        _seed(
+            client,
+            kind="event",
+            category="slot",
+            action="slot.state",
+            message=f"seed {i}",
+        )
+
+    class _DisconnectedRequest:
+        def __init__(self, app) -> None:
+            self.app = app
+
+        async def is_disconnected(self) -> bool:
+            return True
+
+    async def _drain() -> list[dict]:
+        resp = await stream_activity(
+            _DisconnectedRequest(client.app),  # type: ignore[arg-type]
+            since=0,
+            category=None,
+            action=None,
+            severity=None,
+            outcome=None,
+            actor=None,
+            kind=None,
+            search=None,
+            limit=10,
+        )
+        frames: list[dict] = []
+        async for chunk in resp.body_iterator:
+            text = chunk.decode() if isinstance(chunk, bytes) else chunk
+            for line in text.splitlines():
+                if line.startswith("data: "):
+                    frames.append(_json.loads(line[len("data: ") :]))
+        return frames
+
+    frames = asyncio.run(_drain())
+    assert len(frames) == 10
+    # The newest 10 seeds, replayed oldest→newest.
+    messages = [f["record"]["message"] for f in frames]
+    assert messages == [f"seed {i}" for i in range(20, 30)]

--- a/ui/src/api/hooks/useActivity.ts
+++ b/ui/src/api/hooks/useActivity.ts
@@ -49,6 +49,8 @@ export type ActivitySeverity = 'info' | 'warn' | 'error' | 'ok'
 export const ACTIVITY_RING_MAX = 200
 /** Debounce SSE reconnect on rapid filter chip toggling. */
 const SSE_RECONNECT_DEBOUNCE_MS = 200
+/** Coalesce a burst of SSE frames (the connect backfill) into one render. */
+const FRAME_FLUSH_MS = 50
 
 // Module-level ring cache keyed by filter set. The ActivityLog sidebar is
 // mounted inside several early-return branches of SlotsView (loading / empty
@@ -232,17 +234,56 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
     sinceRef.current = cached.reduce((mx, r) => (r.id != null && r.id > mx ? r.id : mx), 0)
   }
 
+  // Frame batching: the connect backfill arrives as one SSE frame per record
+  // (up to the ring cap), and a setState per frame re-rendered the whole
+  // slots page once per record — the "activity log blocks the page load"
+  // jank. Frames buffer here and flush through ONE setRecords per
+  // FRAME_FLUSH_MS window instead.
+  const pendingRef = useRef<ActivityRecord[]>([])
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Merge a frame batch into a newest-first ring: dedup by id (durable
+  // backfill can overlap a reconnect replay, and a remount rehydrates from
+  // the cache before the SSE replays), clamp to the cap. Null = no change.
+  const mergeBatch = (
+    prev: ActivityRecord[],
+    batch: ActivityRecord[],
+  ): ActivityRecord[] | null => {
+    const seen = new Set(prev.map((r) => r.id))
+    const add: ActivityRecord[] = []
+    for (const r of batch) {
+      if (r.id != null) {
+        if (seen.has(r.id)) continue
+        seen.add(r.id)
+      }
+      add.push(r)
+    }
+    if (!add.length) return null
+    // Frames arrive oldest→newest; the ring is newest-first.
+    add.reverse()
+    const next = [...add, ...prev]
+    return next.length > ACTIVITY_RING_MAX ? next.slice(0, ACTIVITY_RING_MAX) : next
+  }
+
+  const flush = () => {
+    flushTimerRef.current = null
+    const batch = pendingRef.current
+    pendingRef.current = []
+    if (!batch.length) return
+    setRecords((prev) => {
+      const merged = mergeBatch(prev, batch)
+      if (merged == null) return prev
+      _ringCache.set(filterKey, merged)
+      return merged
+    })
+  }
+
   const push = (record: ActivityRecord) => {
     if (record.id != null && record.id > sinceRef.current) sinceRef.current = record.id
-    setRecords((prev) => {
-      // Dedup by id (durable backfill can overlap a reconnect replay, and a
-      // remount rehydrates from the cache before the SSE replays).
-      if (record.id != null && prev.some((r) => r.id === record.id)) return prev
-      const next = [record, ...prev]
-      const clamped = next.length > ACTIVITY_RING_MAX ? next.slice(0, ACTIVITY_RING_MAX) : next
-      _ringCache.set(filterKey, clamped)
-      return clamped
-    })
+    pendingRef.current.push(record)
+    if (flushTimerRef.current == null) {
+      flushTimerRef.current = setTimeout(flush, FRAME_FLUSH_MS)
+    }
   }
 
   useEffect(() => {
@@ -262,10 +303,16 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
       try {
         // Resume from the cursor unless the caller pinned its own `since`
         // (then that value IS the contract and must not be overridden).
+        // Always cap the connect backfill at the ring size (unless the
+        // caller pinned a limit): the server would otherwise replay its
+        // full 1000-row durable backlog one frame at a time, most of which
+        // the ring immediately discards.
+        const effective =
+          filters.limit != null ? filters : { ...filters, limit: ACTIVITY_RING_MAX }
         const query =
           filters.since != null || sinceRef.current <= 0
-            ? buildActivityQuery(filters)
-            : buildActivityQuery({ ...filters, since: sinceRef.current })
+            ? buildActivityQuery(effective)
+            : buildActivityQuery({ ...effective, since: sinceRef.current })
         const url = `${ENDPOINTS.activityStream}${query}`
         esRef.current = new EventSource(url)
       } catch {
@@ -283,6 +330,7 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
             // persistent cache, else a stale ring would rehydrate on remount).
             if (epochRef.current != null) {
               setRecords([])
+              pendingRef.current = []
               _ringCache.delete(filterKey)
               // Ids restart with the new epoch — the old cursor is meaningless.
               sinceRef.current = 0
@@ -319,6 +367,20 @@ export function useActivityStream(opts: UseActivityStreamOptions = {}): Activity
       cancelled = true
       clearTimeout(debounceTimer)
       if (backoffTimer) clearTimeout(backoffTimer)
+      if (flushTimerRef.current != null) {
+        clearTimeout(flushTimerRef.current)
+        flushTimerRef.current = null
+      }
+      // Don't drop buffered frames on teardown — a setState here wouldn't
+      // run its updater (unmounting), so merge straight into the persistent
+      // cache: the remounted pane (SlotsView swaps panes on /api/slots
+      // resolve) rehydrates complete and the cursor stays truthful.
+      const batch = pendingRef.current
+      pendingRef.current = []
+      if (batch.length) {
+        const merged = mergeBatch(_ringCache.get(filterKey) ?? [], batch)
+        if (merged != null) _ringCache.set(filterKey, merged)
+      }
       if (esRef.current) {
         esRef.current.close()
         esRef.current = null

--- a/uv.lock
+++ b/uv.lock
@@ -364,6 +364,9 @@ dev = [
     { name = "ruff" },
     { name = "soundfile" },
 ]
+sentry = [
+    { name = "sentry-sdk" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -384,13 +387,14 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.9" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
+    { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = ">=2.20" },
     { name = "soundfile", marker = "extra == 'dev'", specifier = ">=0.12" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.15" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "sentry"]
 
 [[package]]
 name = "httpcore"
@@ -1246,6 +1250,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.66.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/6f/d59cad0889d15fde85254cf58e701484de3f3f0406003b3197746910b19b/sentry_sdk-2.66.1.tar.gz", hash = "sha256:f882fb08710c5f8bfc603aafa3e901b384009a19cc3f76a572b863392ee81cdc", size = 940543, upload-time = "2026-07-22T12:26:54.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/d3/726bd88f0eece09ddf431bea4c9191c18e7a8d070b854eb0014d447712ee/sentry_sdk-2.66.1-py3-none-any.whl", hash = "sha256:86002793161d9a95ef04bdd8d442e9bfece5d989b755f05d6360215094a7aff6", size = 505555, upload-time = "2026-07-22T12:26:52.71Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1351,6 +1368,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two compounding costs on every fresh mount of the slots page:

The SSE stream's connect backfill replayed the durable backlog up to the
server's 1000-row cap, one SSE frame per record, while the pane's ring
keeps only the newest 200 — hundreds of frames streamed just to be
discarded. The stream endpoint now takes a `limit` (capping only the
connect replay, never the live tail) and the client asks for its ring
cap unless the caller pinned a limit of its own.

Each frame also went through its own setState, re-rendering the whole
slots view once per record. Frames now buffer and flush through one
setState per 50ms window; buffered frames surviving an unmount are
merged into the persistent ring cache directly (a setState in teardown
never runs its updater), so the remounted pane rehydrates complete and
the resume cursor stays truthful.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
