### PR TITLE
perf(api): stop /api/slots paying the full probe fan-out on every poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- `GET /api/slots` latency cut sharply on wide boxes (#1507 follow-up):
+  the per-slot probe no longer runs `podman inspect` for stopped slots,
+  `podman image inspect` answers are TTL-cached per image ref, and the
+  whole snapshot is served single-flight with a 2 s TTL (any slot
+  mutation invalidates it immediately) so overlapping dashboard polls
+  stop multiplying the subprocess fan-out.
+
 - Slots page no longer stalls while the activity log backfills: the SSE
   stream replayed the full 1000-row durable backlog one frame at a time on
   every fresh connect, and the pane re-rendered once per frame. The stream

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -327,6 +327,34 @@ def overlay_cached_enrichment(
     return entries
 
 
+#: How long a ``GET /api/slots`` snapshot may be re-served. Well under the
+#: dashboard's 2.5 s poll cadence — bounded staleness, one probe fan-out per
+#: window no matter how many panes/tabs poll concurrently.
+_SLOTS_SNAPSHOT_TTL_S = 2.0
+
+
+def _invalidates_snapshot(fn):
+    """Drop the /api/slots snapshot cache after a slot-mutating handler.
+
+    A mutation (create/rename/delete/config/load/swap/restart) must be
+    visible on the very next poll — TTL alone would let a stale snapshot
+    answer for up to :data:`_SLOTS_SNAPSHOT_TTL_S` after the change (and
+    break every test that mutates then immediately lists).
+    """
+    import functools
+
+    @functools.wraps(fn)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await fn(*args, **kwargs)
+        finally:
+            req = kwargs.get("request") or next((a for a in args if isinstance(a, Request)), None)
+            if req is not None:
+                req.app.state._slots_snapshot_cache = None
+
+    return wrapper
+
+
 # ── list / create ──────────────────────────────────────────────────────────
 
 
@@ -344,20 +372,41 @@ async def list_slots(request: Request) -> list[dict[str, object]]:
     :class:`hal0.slot_view.SlotView` rows.
     """
     import functools
+    import time as _time
 
-    sm = _get_slot_manager(request)
     state = request.app.state
-    aggregator = SlotViewAggregator(
-        sm,
-        registry=getattr(state, "model_registry", None),
-        metrics=functools.partial(slot_metrics, request),
-        model_cache=getattr(state, "model_cache", {}) or {},
-        upstreams=_UpstreamsWithHal0Composite(state.upstreams),
-        last_used_model=getattr(state, "last_used_model", {}),
-        slot_pull_jobs=getattr(state, "slot_pull_jobs", {}),
-    )
-    dicts = [view.to_dict() for view in await aggregator.snapshot()]
-    _cache_slot_enrichment(request, dicts)
+
+    # Single-flight + short-TTL snapshot cache (#1507 follow-up). The probe
+    # fan-out behind snapshot() spawns dozens of systemctl/podman children;
+    # with the dashboard polling every 2.5 s and the probe itself taking
+    # seconds on a wide box, overlapping requests piled up and multiplied
+    # the subprocess load. One probe per TTL window serves every concurrent
+    # caller; staleness is bounded well under the poll cadence.
+    cached = getattr(state, "_slots_snapshot_cache", None)
+    if cached is not None and _time.monotonic() - cached[0] < _SLOTS_SNAPSHOT_TTL_S:
+        return cached[1]
+    lock = getattr(state, "_slots_snapshot_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        state._slots_snapshot_lock = lock
+    async with lock:
+        # A concurrent caller may have refreshed while we waited on the lock.
+        cached = getattr(state, "_slots_snapshot_cache", None)
+        if cached is not None and _time.monotonic() - cached[0] < _SLOTS_SNAPSHOT_TTL_S:
+            return cached[1]
+        sm = _get_slot_manager(request)
+        aggregator = SlotViewAggregator(
+            sm,
+            registry=getattr(state, "model_registry", None),
+            metrics=functools.partial(slot_metrics, request),
+            model_cache=getattr(state, "model_cache", {}) or {},
+            upstreams=_UpstreamsWithHal0Composite(state.upstreams),
+            last_used_model=getattr(state, "last_used_model", {}),
+            slot_pull_jobs=getattr(state, "slot_pull_jobs", {}),
+        )
+        dicts = [view.to_dict() for view in await aggregator.snapshot()]
+        _cache_slot_enrichment(request, dicts)
+        state._slots_snapshot_cache = (_time.monotonic(), dicts)
     return dicts
 
 
@@ -555,6 +604,7 @@ def _normalize_create_body(
 
 
 @router.post("", status_code=201)
+@_invalidates_snapshot
 async def create_slot(request: Request) -> dict[str, object]:
     """Create a new slot. Body: SlotConfig schema.
 
@@ -711,6 +761,7 @@ async def get_slot_by_id(slot_id: int, request: Request) -> dict[str, object]:
 
 
 @router.post("/{name}/rename")
+@_invalidates_snapshot
 async def rename_slot(name: str, request: Request) -> dict[str, object]:
     """Rename a slot's display label. Body: ``{"new_name": "..."}``.
 
@@ -968,6 +1019,7 @@ async def _safe_config(sm: Any, name: str) -> dict[str, Any] | None:
 
 
 @router.delete("/{name}")
+@_invalidates_snapshot
 async def delete_slot(name: str, request: Request, force: bool = False) -> dict[str, object]:
     """Delete a slot. If the slot is running, it is stopped first.
 
@@ -1028,6 +1080,7 @@ async def get_slot_resolved(name: str, request: Request) -> dict[str, object]:
 
 
 @router.put("/{name}/config")
+@_invalidates_snapshot
 async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     """Update a slot's config. Body: partial SlotConfig (shallow merge)."""
     sm = _get_slot_manager(request)
@@ -1082,6 +1135,7 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
 
 
 @router.patch("/{name}/defaults")
+@_invalidates_snapshot
 async def update_slot_defaults(name: str, request: Request) -> dict[str, object]:
     """Update slot defaults (ctx_size / context_size, n_gpu_layers, …).
 
@@ -1127,6 +1181,7 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
 
 
 @router.post("/{name}/load")
+@_invalidates_snapshot
 async def load_slot(name: str, request: Request) -> dict[str, object]:
     """Load a model into a slot. Optional body: {"model_id": "..."}.
 
@@ -1190,6 +1245,7 @@ async def load_slot(name: str, request: Request) -> dict[str, object]:
 
 
 @router.post("/{name}/unload")
+@_invalidates_snapshot
 async def unload_slot(name: str, request: Request, force: bool = False) -> dict[str, object]:
     """Unload a slot. A pinned slot (§21.10) requires ``?force=true``.
 
@@ -1214,6 +1270,7 @@ async def unload_slot(name: str, request: Request, force: bool = False) -> dict[
 
 
 @router.post("/{name}/restart")
+@_invalidates_snapshot
 async def restart_slot(name: str, request: Request) -> dict[str, object]:
     sm = _get_slot_manager(request)
     async with record_action(request, category="slot", action="slot.restart", target=name) as _rec:
@@ -1223,6 +1280,7 @@ async def restart_slot(name: str, request: Request) -> dict[str, object]:
 
 
 @router.post("/{name}/swap")
+@_invalidates_snapshot
 async def swap_slot(name: str, request: Request) -> dict[str, object]:
     """Hot-swap a slot's model. Body: {"model_id": "..."}.
 

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
@@ -437,6 +438,25 @@ _PROBE_TIMEOUT_S = 8.0
 #: deployment finishes in one wave.
 _PROBE_CONCURRENCY = 8
 
+#: ``podman image inspect`` answers ("is this image present on disk?") change
+#: only when an image is pulled or pruned — nowhere near the dashboard's
+#: 2.5 s poll cadence. Cache per image ref so a 20-slot box sharing 3 images
+#: pays 3 inspects per TTL window instead of 20 per poll. Kept short enough
+#: that a just-finished pull flips missing→present within one refresh.
+_IMAGE_PRESENT_TTL_S = 15.0
+_image_present_cache: dict[str, tuple[float, bool]] = {}
+
+
+def _image_present_cached(cp: Any, image: str) -> bool:
+    """TTL-cached ``cp.image_present`` (subprocess-backed, executor-called)."""
+    now = time.monotonic()
+    hit = _image_present_cache.get(image)
+    if hit is not None and now - hit[0] < _IMAGE_PRESENT_TTL_S:
+        return hit[1]
+    present = bool(cp.image_present(image))
+    _image_present_cache[image] = (time.monotonic(), present)
+    return present
+
 
 async def container_enrichment(
     configs: list[dict[str, Any]],
@@ -604,16 +624,22 @@ async def container_enrichment(
         # image_mismatch against the slot's declared profile image. Replaces the
         # fragile /proc actual_backend sniff. Degrades silently - never 500
         # the hot path.
-        try:
-            from hal0.providers.container import _image_mismatch
+        # Only a live container can have a running image — skip the podman
+        # inspect for stopped/crashed slots entirely. On a box where most
+        # slots are offline this was the bulk of the probe's subprocess
+        # spawns, and its answer was always None (#1507 latency follow-up).
+        running_image = None
+        if container_status in ("running", "starting"):
+            try:
+                from hal0.providers.container import _image_mismatch
 
-            cp = _resolve_container_provider(provider)
-            # By CONFIG: the container is named after the instance token
-            # (#1417) — a bare name inspected a container that never exists on
-            # an id-keyed box, leaving the image backend-of-record inert.
-            running_image = await loop.run_in_executor(None, cp.running_image, cfg)
-        except Exception:
-            running_image = None
+                cp = _resolve_container_provider(provider)
+                # By CONFIG: the container is named after the instance token
+                # (#1417) — a bare name inspected a container that never exists on
+                # an id-keyed box, leaving the image backend-of-record inert.
+                running_image = await loop.run_in_executor(None, cp.running_image, cfg)
+            except Exception:
+                running_image = None
         if running_image:
             entry["actual_image"] = running_image
             if image:
@@ -628,7 +654,7 @@ async def container_enrichment(
         elif image:
             try:
                 cp = _resolve_container_provider(provider)
-                present = await loop.run_in_executor(None, cp.image_present, image)
+                present = await loop.run_in_executor(None, _image_present_cached, cp, image)
                 entry["image_status"] = "present" if present else "missing"
             except Exception:
                 entry["image_status"] = "missing"

--- a/tests/api/test_slots_image_pull.py
+++ b/tests/api/test_slots_image_pull.py
@@ -368,3 +368,37 @@ async def test_pull_image_stream_failed_on_nonzero_exit(tmp_path: Path) -> None:
 
     assert chunks, "must yield at least one chunk"
     assert chunks[-1]["state"] == "failed"
+
+
+def test_slots_snapshot_cache_serves_within_ttl_and_invalidates_on_mutation(
+    container_client: TestClient,
+) -> None:
+    """#1507 follow-up: the /api/slots probe fan-out runs once per TTL window,
+    and any slot mutation drops the cached snapshot immediately."""
+    fake_catalog, _ = _fake_profile_catalog()
+    calls = {"n": 0}
+
+    def _counting_is_active(self, slot):
+        calls["n"] += 1
+        return False
+
+    with (
+        patch("hal0.providers.container.ContainerProvider.is_active", _counting_is_active),
+        patch(
+            "hal0.providers.container.ContainerProvider.health",
+            new_callable=AsyncMock,
+            return_value={"ok": False},
+        ),
+        patch("hal0.config.loader.load_profiles_config", return_value=fake_catalog),
+        patch("hal0.providers.container.ContainerProvider.image_present", return_value=True),
+    ):
+        assert container_client.get("/api/slots").status_code == 200
+        probes_first = calls["n"]
+        assert probes_first > 0
+        # Second GET inside the TTL — served from the snapshot cache, no probe.
+        assert container_client.get("/api/slots").status_code == 200
+        assert calls["n"] == probes_first
+        # A mutation invalidates the snapshot, so the next GET re-probes.
+        container_client.put("/api/slots/gpu-chat/config", json={"threads": 3})
+        assert container_client.get("/api/slots").status_code == 200
+        assert calls["n"] > probes_first

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,3 +273,18 @@ def tmp_hal0_home(tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("HAL0_HOME", home)
     monkeypatch.setenv("HAL0_OVERRIDE_DIR", "hal0_home")
     return home
+
+
+@pytest.fixture(autouse=True)
+def _clear_image_present_cache():
+    """Reset slot_view's process-global image-presence TTL cache per test.
+
+    The cache exists so the dashboard's 2.5 s poll doesn't re-run
+    ``podman image inspect`` per slot per poll; across tests it would leak
+    one test's patched ``image_present`` answer into the next.
+    """
+    from hal0 import slot_view
+
+    slot_view._image_present_cache.clear()
+    yield
+    slot_view._image_present_cache.clear()


### PR DESCRIPTION
Measured 4.6-11.3 s on the live 21-slot box, which is what actually
held the slots page's main pane behind the (fast) activity sidebar.
Three cuts, contract unchanged:

- Skip the running-image podman inspect for slots whose unit probe
  already said stopped/crashed — its answer there is always None, and
  on a mostly-offline box it was the bulk of the subprocess spawns.
- TTL-cache podman image-presence per image ref (15 s): a 20-slot box
  sharing 3 images pays 3 inspects per window instead of 20 per poll.
  A process-global cache, so tests get an autouse reset fixture.
- Serve the whole snapshot single-flight with a 2 s TTL: the dashboard
  polls every 2.5 s and overlapping requests each spawned their own
  ~80-child probe fan-out. Every slot-mutating route invalidates the
  snapshot immediately, so a save/swap/restart is still visible on the
  very next poll.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
