### PR TITLE
fix(comfyui): make the img slot lifecycle survive its own health model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- ComfyUI img slot reliability: the provider now creates its bind-mount
+  data dirs before spawn (a missing tree crash-looped the container with
+  podman exit 125), slot readiness waits on ComfyUI's real health probe
+  (`GET /system_stats`) instead of 404-polling the llama-style `/health`
+  for the full 180 s deadline and wedging the slot in WARMING, and the
+  fail-watcher's health probe delegates to the ComfyUI provider so a
+  READY img slot is no longer struck to ERROR seconds after coming up.
+
 - `GET /api/slots` latency cut sharply on wide boxes (#1507 follow-up):
   the per-slot probe no longer runs `podman inspect` for stopped slots,
   `podman image inspect` answers are TTL-cached per image ref, and the

--- a/src/hal0/providers/comfyui.py
+++ b/src/hal0/providers/comfyui.py
@@ -251,6 +251,22 @@ class ComfyUIProvider(Provider):
             os.environ.get("HAL0_COMFYUI_DATA_ROOT", "").strip()
             or f"{model_store_root()}/{_COMFYUI_DATA_SUBDIR}"
         )
+        # Podman refuses a bind mount whose host path is absent (statfs →
+        # exit 125), which crash-looped the img slot on any box where the
+        # comfyui tree hadn't been provisioned (fresh install, or a store
+        # root that moved after install). Ensure every mounted dir exists,
+        # and the extra_model_paths.yaml file too — an empty one is a valid
+        # ComfyUI config. Best-effort: a read-only store degrades to the old
+        # behaviour (podman reports the missing path).
+        try:
+            for sub in ("models", "output", "input", "user", "custom_nodes"):
+                os.makedirs(f"{data_root}/{sub}", exist_ok=True)
+            yaml_path = f"{data_root}/extra_model_paths.yaml"
+            if not os.path.exists(yaml_path):
+                with open(yaml_path, "w", encoding="utf-8"):
+                    pass
+        except OSError as exc:
+            log.warning("comfyui.data_root_provision_failed root=%s err=%s", data_root, exc)
         # read_only is a first-class Mount flag; extra_model_paths.yaml is the
         # only read-only mount (the renderer appends ":ro").
         mounts: list[Mount] = [
@@ -285,6 +301,25 @@ class ComfyUIProvider(Provider):
         )
 
     # ── Health ─────────────────────────────────────────────────────────────────
+
+    async def wait_ready(self, port: int) -> None:
+        """Poll ``/system_stats`` until healthy or the container deadline passes.
+
+        Mirrors :meth:`ContainerProvider.wait_ready`'s loop but through THIS
+        provider's health probe: ComfyUI ships no llama-style ``/health``, so
+        the generic container waiter 404-polled for the full 180 s and the
+        slot wedged in WARMING with a perfectly healthy server behind it
+        (every ``/v1/images/generations`` then 409'd on warming → starting).
+        """
+        from hal0.providers.container import _HEALTH_POLL_INTERVAL_S, _HEALTH_TIMEOUT_S
+
+        deadline = asyncio.get_event_loop().time() + _HEALTH_TIMEOUT_S
+        while asyncio.get_event_loop().time() < deadline:
+            h = await self.health(port)
+            if h.get("ok"):
+                return
+            await asyncio.sleep(_HEALTH_POLL_INTERVAL_S)
+        raise TimeoutError(f"comfyui slot port {port} did not become healthy")
 
     async def health(self, port: int) -> dict[str, Any]:
         """Health probe: GET /system_stats returns 200 with python_version.

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1647,9 +1647,14 @@ class ContainerProvider(Provider):
                 provider = _spec_provider_for(slot_cfg)
             except Exception:
                 provider = None
+            from hal0.providers.comfyui import ComfyUIProvider
             from hal0.providers.flm import FLMProvider
 
-            if isinstance(provider, FLMProvider):
+            # ComfyUI serves neither /health nor /v1/models (its liveness
+            # probe is GET /system_stats), so the generic path below read a
+            # healthy ComfyUI as http_404 — the fail-watcher then struck a
+            # READY img slot to ERROR within seconds of it coming up.
+            if isinstance(provider, (FLMProvider, ComfyUIProvider)):
                 return await provider.health(port)
 
         health_url = f"http://127.0.0.1:{port}/health"

--- a/src/hal0/registry/pull_jobs.py
+++ b/src/hal0/registry/pull_jobs.py
@@ -201,26 +201,35 @@ def resolve_pull_capability(
 
     Priority for capability: explicit ``body.capability`` → the registry row's
     first capability → the curated entry's capability. ``comfyui_subdir`` comes
-    from the curated entry only. Returns ``(None, None)`` for an unknown ad-hoc
-    model so :func:`run_pull` falls back to the legacy flat layout.
+    from the curated entry in EVERY branch — it used to be consulted only for
+    an unknown model, so RE-pulling an already-registered image model (the
+    repair path for deleted checkpoint bytes) dropped the subdir and landed
+    the safetensors under ``<store>/image/<id>/model.gguf``, where ComfyUI
+    never finds it. Returns ``(None, None)`` for an unknown ad-hoc model so
+    :func:`run_pull` falls back to the legacy flat layout.
     """
+    curated = get_curated(model_id)
+    curated_subdir = (
+        ((getattr(curated, "comfyui_subdir", "") or "").strip() or None)
+        if curated is not None
+        else None
+    )
+
     if isinstance(body, dict):
         cap_raw = body.get("capability")
         if isinstance(cap_raw, str) and cap_raw.strip():
-            return cap_raw.strip(), None
+            return cap_raw.strip(), curated_subdir
 
     try:
         existing = request.app.state.model_registry.get(model_id)
         caps = getattr(existing, "capabilities", None) or []
         if caps:
-            return str(caps[0]), None
+            return str(caps[0]), curated_subdir
     except Exception:
         pass
 
-    curated = get_curated(model_id)
     if curated is not None:
-        subdir = (getattr(curated, "comfyui_subdir", "") or "").strip() or None
-        return (curated.capability or None), subdir
+        return (curated.capability or None), curated_subdir
     return None, None
 
 

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -523,10 +523,24 @@ async def container_enrichment(
             # token, which is the durable id on a post-migration box (#1417).
             active = await loop.run_in_executor(None, cp.is_active, cfg)
             if active:
-                # 2) /health probe on the slot port to distinguish running vs starting
+                # 2) /health probe on the slot port to distinguish running vs starting.
+                # ComfyUI ships no llama-style /health — its readiness probe is
+                # GET /system_stats (ComfyUIProvider.health). Probing the
+                # generic path 404'd forever, so a healthy img slot rendered
+                # "starting"/unhealthy in the dashboard indefinitely. Only when
+                # no provider was injected (tests inject fakes and expect them
+                # to answer): production resolves the real family provider.
                 port = _cfg_port(cfg)
                 if port:
-                    health = await cp.health(port)
+                    health_probe = cp.health
+                    if provider is None:
+                        from hal0.providers.comfyui import ComfyUIProvider
+                        from hal0.providers.container import _spec_provider_for
+
+                        sp = _spec_provider_for(cfg)
+                        if isinstance(sp, ComfyUIProvider):
+                            health_probe = sp.health
+                    health = await health_probe(port)
                     container_health = bool(health.get("ok"))
                     return ("running" if container_health else "starting", container_health)
                 return "running", False

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -3302,12 +3302,18 @@ class SlotManager:
         if not cfg:
             return SlotState.READY  # nothing more to verify
 
-        # Wait for /health 200 on the container port.
+        # Wait for /health 200 on the container port. A runtime family whose
+        # provider ships its OWN wait_ready (ComfyUI — no llama-style /health,
+        # readiness is GET /system_stats) waits through that instead: the
+        # generic waiter 404-polled ComfyUI for the full deadline and wedged
+        # the slot in WARMING behind a healthy server.
         slot_port = port or int(_cfg_to_dict(cfg).get("port", 0))
         from hal0.providers.container import _spec_provider_for, container_provider
 
+        spec_provider = _spec_provider_for(cfg)
+        wait_ready = getattr(spec_provider, "wait_ready", None) or container_provider().wait_ready
         try:
-            await container_provider().wait_ready(slot_port)
+            await wait_ready(slot_port)
         except TimeoutError as exc:
             log.warning(
                 "slot.container_await_ready_timeout",

--- a/tests/api/test_models_pull_capability.py
+++ b/tests/api/test_models_pull_capability.py
@@ -56,3 +56,32 @@ def test_unknown_model_returns_none(monkeypatch):
     cap, subdir = _resolve_pull_capability(_req(), "ad-hoc", None)
     assert cap is None
     assert subdir is None
+
+
+def test_registered_curated_image_model_keeps_comfyui_subdir(monkeypatch):
+    """RE-pulling an already-registered curated image model keeps the subdir.
+
+    The repair path for deleted checkpoint bytes: the registry row survives,
+    so resolution took the registry branch — which used to return
+    ``subdir=None`` and landed the safetensors at ``image/<id>/model.gguf``
+    where ComfyUI never finds it.
+    """
+    import hal0.registry.pull_jobs as m
+
+    curated = SimpleNamespace(capability="image", comfyui_subdir="checkpoints")
+    monkeypatch.setattr(m, "get_curated", lambda _mid: curated)
+    entry = SimpleNamespace(capabilities=["image"], hf_repo="r", hf_filename="f")
+    cap, subdir = _resolve_pull_capability(_req(entry), "sdxl-turbo", None)
+    assert cap == "image"
+    assert subdir == "checkpoints"
+
+
+def test_body_capability_keeps_curated_subdir(monkeypatch):
+    """An explicit body capability doesn't discard the curated subdir."""
+    import hal0.registry.pull_jobs as m
+
+    curated = SimpleNamespace(capability="image", comfyui_subdir="checkpoints")
+    monkeypatch.setattr(m, "get_curated", lambda _mid: curated)
+    cap, subdir = _resolve_pull_capability(_req(), "sdxl-turbo", {"capability": "image"})
+    assert cap == "image"
+    assert subdir == "checkpoints"

--- a/tests/providers/test_comfyui_container_spec.py
+++ b/tests/providers/test_comfyui_container_spec.py
@@ -10,6 +10,7 @@ and label=disable alongside the usual LXC security opts.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -193,3 +194,48 @@ def test_image_section_dict_is_not_an_image_override(monkeypatch) -> None:
     assert isinstance(ref, str)
     assert "idle_restore_minutes" not in ref
     assert "kyuz0/amd-strix-halo-comfyui" in ref  # manifest pin or fallback tag
+
+
+def test_comfyui_container_spec_provisions_data_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing data dirs are created before the mounts are rendered.
+
+    Podman refuses a bind mount whose host path is absent (statfs → exit
+    125), which crash-looped the img slot on any box where the comfyui tree
+    wasn't provisioned.
+    """
+    root = tmp_path / "comfy-data"
+    monkeypatch.setenv("HAL0_COMFYUI_DATA_ROOT", str(root))
+    ComfyUIProvider().container_spec(_img_cfg(), {})
+    for sub in ("models", "output", "input", "user", "custom_nodes"):
+        assert (root / sub).is_dir(), sub
+    assert (root / "extra_model_paths.yaml").is_file()
+
+
+@pytest.mark.asyncio
+async def test_comfyui_wait_ready_uses_system_stats_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """wait_ready resolves through the provider's own /system_stats health.
+
+    The generic container waiter polls llama-style /health, which ComfyUI
+    never serves — the slot wedged in WARMING behind a healthy server.
+    """
+    provider = ComfyUIProvider()
+    answers = iter([{"ok": False, "status": "http_404"}, {"ok": True}])
+
+    async def _fake_health(port: int) -> dict:
+        return next(answers)
+
+    monkeypatch.setattr(provider, "health", _fake_health)
+    monkeypatch.setattr("hal0.providers.container._HEALTH_POLL_INTERVAL_S", 0.01)
+    await provider.wait_ready(8188)  # returns without raising
+
+    async def _never_ok(port: int) -> dict:
+        return {"ok": False, "status": "http_404"}
+
+    monkeypatch.setattr(provider, "health", _never_ok)
+    monkeypatch.setattr("hal0.providers.container._HEALTH_TIMEOUT_S", 0.05)
+    with pytest.raises(TimeoutError):
+        await provider.wait_ready(8188)

--- a/tests/providers/test_container_npu.py
+++ b/tests/providers/test_container_npu.py
@@ -394,3 +394,34 @@ async def test_health_v1_models_also_fails_unhealthy() -> None:
         result = await provider.health(8088)
 
     assert result["ok"] is False
+
+
+@pytest.mark.anyio
+async def test_health_delegates_to_comfyui_system_stats() -> None:
+    """A comfyui-family slot_cfg delegates to ComfyUIProvider.health.
+
+    ComfyUI serves neither /health nor /v1/models (liveness is GET
+    /system_stats) — the generic fallback read a healthy server as http_404
+    and the fail-watcher struck a READY img slot to ERROR within seconds.
+    """
+    from hal0.providers.comfyui import ComfyUIProvider
+
+    sentinel = {"ok": True, "status": "healthy"}
+
+    async def fake_comfy_health(self: Any, port: int) -> dict[str, Any]:
+        assert port == 8188
+        return sentinel
+
+    provider = ContainerProvider()
+    with (
+        patch.object(ComfyUIProvider, "health", fake_comfy_health),
+        patch(
+            "hal0.providers.container.httpx.AsyncClient",
+            side_effect=AssertionError("must not open an httpx client when delegating"),
+        ),
+    ):
+        result = await provider.health(
+            8188, slot_cfg={"provider": "comfyui", "type": "image", "name": "img"}
+        )
+
+    assert result is sentinel


### PR DESCRIPTION
Three independent faults left the img slot permanently unreliable:

- The container crash-looped with podman exit 125 whenever the comfyui
  data tree was absent (fresh install, or a store root that moved after
  install): podman refuses a bind mount whose host path is missing.
  container_spec now provisions the mounted dirs (and an empty
  extra_model_paths.yaml) before rendering the mounts, best-effort.
- A slot that did spawn wedged in WARMING for the full 180 s deadline:
  readiness polled the llama-style /health, which ComfyUI never serves.
  ComfyUIProvider now ships its own wait_ready over GET /system_stats,
  and the manager's readiness wait prefers a provider-supplied waiter.
- A slot that did reach READY was struck to ERROR seconds later: the
  fail-watcher's health probe fell back from /health 404 to /v1/models
  404. ContainerProvider.health now delegates to the ComfyUI provider
  for comfyui-family slots, same as the existing FLM delegation, and
  the slots-view container probe does the same so the dashboard stops
  rendering a healthy img slot as perpetually starting.

Verified live on lxc105: img reaches READY ~15 s after restart and
holds it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
