### PR TITLE
feat(slots): explicit autoload setting and eviction priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,25 @@ applying. Add those subsections to a version's section to surface them; see
   implies boot start; existing slots with a bound model migrate as
   `true`, so upgrade changes nothing until toggled.
 - Slots: eviction `priority` (0–100, default 50, drawer field) — memory
-  pressure and pre-load eviction now unload the lowest-priority slot
-  first (least-recently-used within a tier). The `lru = true` opt-in is
-  retired: every non-pinned slot is evictable; the key is ignored with a
-  one-time deprecation warning. `pinned` still exempts entirely.
+  pressure and pre-load eviction unload the lowest-priority slot first
+  (least-recently-used as the tie-break within a tier). `pinned` still
+  exempts a slot entirely.
+
+### Breaking
+
+- The `lru = true` eviction opt-in is retired. Memory-pressure and
+  pre-load eviction used to only ever touch a slot that explicitly set
+  `lru = true`; now every non-pinned resident slot is a candidate,
+  ordered by the new `priority` field. The key is still accepted in slot
+  TOML but ignored, with a one-time deprecation warning — remove it and
+  use `priority`/`pinned` instead. Practically: on a stock box that never
+  set `lru = true` on anything, pressure and pre-load eviction go from
+  inert (nothing was ever eligible) to ACTIVE the moment host memory gets
+  tight. Also note `idle_timeout_s = 0` never exempted a slot from
+  pressure or pre-load eviction — it only ever disabled that one slot's
+  idle-TTL path — and that distinction now matters more than it used to.
+  `pinned` (plus the built-in `agent`/`utility`/`npu` anchors) is the only
+  exemption from pressure and pre-load eviction.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Added
+
+- Slots: explicit `autoload` setting — a slot starts at boot only when
+  `autoload = true` (slot drawer toggle). Binding a model no longer
+  implies boot start; existing slots with a bound model migrate as
+  `true`, so upgrade changes nothing until toggled.
+- Slots: eviction `priority` (0–100, default 50, drawer field) — memory
+  pressure and pre-load eviction now unload the lowest-priority slot
+  first (least-recently-used within a tier). The `lru = true` opt-in is
+  retired: every non-pinned slot is evictable; the key is ignored with a
+  one-time deprecation warning. `pinned` still exempts entirely.
+
 ### Fixed
 
 - `GET /api/slots` latency cut sharply on wide boxes (#1507 follow-up):

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -217,6 +217,8 @@ top-level scalars are accepted on load and normalized.
 | `workers` | int | `1` | — | `>= 1`; deprecated/inert |
 | `idle_timeout_s` | int | `300` | — | `>= 0`; `0` disables the idle transition |
 | `pinned` | bool | `false` | — | exempts the slot from auto-eviction; blocks manual unload without `force` |
+| `autoload` | bool \| null | `null` | — | `true` → the Quadlet unit gets `[Install] WantedBy=hal0.target` and the slot starts at boot; `false` → unit exists, nothing starts it. `null` (key absent) is the migration shim: derived from a non-empty `model.default`. `POST /api/slots` persists an explicit value (`false`) |
+| `priority` | int | `50` | — | `0-100`; eviction order, lowest evicted first, `last_used` breaks ties. `100` is *not* a pin — use `pinned` |
 | `model` | table | — | — | `[model]`, see below |
 | `server` | table | — | — | `[server]`, see below |
 | `npu` | table \| null | `null` | — | `[npu]`, see below |
@@ -224,6 +226,9 @@ top-level scalars are accepted on load and normalized.
 | `extra` | dict | `{}` | — | catch-all |
 
 There is **no `enabled` field** — a non-empty `model.default` is the activation signal.
+Boot start is separate and explicit (`autoload`); a retired `lru` key is still accepted
+but ignored, with a one-time deprecation warning. See
+[Slot lifecycle → Activation](/docs/reference/slot-lifecycle/#activation).
 
 <Aside type="note">
 A legacy `backend` key on a slot is silently promoted to `device` and dropped on load

--- a/docs/reference/config-schema.mdx
+++ b/docs/reference/config-schema.mdx
@@ -215,10 +215,10 @@ top-level scalars are accepted on load and normalized.
 | `default_speed` | float \| null | `null` | — | `0.25-4.0` |
 | `default_response_format` | str \| null | `null` | — | one of `mp3, wav, opus, flac, pcm` |
 | `workers` | int | `1` | — | `>= 1`; deprecated/inert |
-| `idle_timeout_s` | int | `300` | — | `>= 0`; `0` disables the idle transition |
+| `idle_timeout_s` | int | `300` | — | `>= 0`; `0` disables IDLE-TTL eviction for this slot only — pressure and pre-load eviction are separate paths, exempted only by `pinned`. Read via the raw-dict sweep path (not the typed loader), an out-of-range value there is clamped/floored at read time, not errored — the typed `POST`/`PUT` API path still hard-rejects via pydantic's `ge` |
 | `pinned` | bool | `false` | — | exempts the slot from auto-eviction; blocks manual unload without `force` |
 | `autoload` | bool \| null | `null` | — | `true` → the Quadlet unit gets `[Install] WantedBy=hal0.target` and the slot starts at boot; `false` → unit exists, nothing starts it. `null` (key absent) is the migration shim: derived from a non-empty `model.default`. `POST /api/slots` persists an explicit value (`false`) |
-| `priority` | int | `50` | — | `0-100`; eviction order, lowest evicted first, `last_used` breaks ties. `100` is *not* a pin — use `pinned` |
+| `priority` | int | `50` | — | `0-100`; eviction order, lowest evicted first, `last_used` breaks ties. `100` is *not* a pin — use `pinned`. Read via the raw-dict sweep path, an out-of-range TOML value is clamped to `0-100` at read time, not errored — the typed `POST`/`PUT` API path still hard-rejects via pydantic's `ge`/`le` |
 | `model` | table | — | — | `[model]`, see below |
 | `server` | table | — | — | `[server]`, see below |
 | `npu` | table \| null | `null` | — | `[npu]`, see below |

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -105,8 +105,39 @@ with the dashboard's own `SELF_MANAGED_PROVIDERS` constant.
 ## Activation
 
 There is **no `enabled` field** on `SlotConfig`. A non-empty `model.default` is the
-activation signal; boot autostart is gated by the Quadlet unit's
-`WantedBy=hal0.target` plus `SlotManager.load()`'s empty-model guard.
+activation signal — it is what makes a slot routable and loadable.
+
+Boot autostart is a separate, explicit setting: `autoload`. The generated Quadlet unit
+carries `[Install] WantedBy=hal0.target` **only when `autoload = true`**, and that stanza
+is the only thing that starts a slot at boot. With `autoload = false` the unit still
+exists and is start-able (load/swap use `systemctl restart`, which never consults
+`[Install]`) — nothing just pulls it up on reboot. Binding a model no longer implies a
+boot start.
+
+Slots written before the field existed (key absent on disk) migrate to
+`autoload = true` when they have a bound model, and `false` otherwise, so an upgrade
+preserves the old behaviour until you toggle it. Slots created through
+`POST /api/slots` always persist an explicit value, defaulting to `false`.
+
+Editing `autoload` via `PUT /api/slots/{name}/config` re-renders the on-disk unit, so the
+change takes effect from the next boot without a manual reload.
+
+## Eviction priority
+
+Every non-pinned slot is an eviction candidate. `priority` (int, `0–100`, default `50`)
+orders the victims for both memory-pressure eviction (`SlotReaper.pressure_evict_once`)
+and pre-load eviction (`preload_evict`): the **lowest priority is unloaded first**, with
+least-recently-used as the tie-break inside a priority tier. `priority = 100` is not a
+pin — it is merely evicted last; `pinned = true` is what exempts a slot entirely, as do
+the default-pinned anchors (`agent` and friends). A slot with a request in flight is
+never a victim, and only resident slots (`READY`/`IDLE`) are considered at all.
+
+<Aside type="caution">
+The old `lru = true` eviction opt-in is retired. The key is still accepted in slot TOML
+but ignored, with a one-time `slot.lru_flag_deprecated` warning per slot — remove it and
+use `priority`/`pinned` instead. Slots that never set `lru` are now evictable where they
+previously were not.
+</Aside>
 
 ## The v1.0 write-boundary guard
 

--- a/docs/reference/slot-lifecycle.mdx
+++ b/docs/reference/slot-lifecycle.mdx
@@ -134,7 +134,7 @@ never a victim, and only resident slots (`READY`/`IDLE`) are considered at all.
 
 <Aside type="caution">
 The old `lru = true` eviction opt-in is retired. The key is still accepted in slot TOML
-but ignored, with a one-time `slot.lru_flag_deprecated` warning per slot — remove it and
+but ignored, with a one-time `slot.lru_flag_retired` warning per slot — remove it and
 use `priority`/`pinned` instead. Slots that never set `lru` are now evictable where they
 previously were not.
 </Aside>

--- a/docs/superpowers/plans/2026-08-02-slot-autoload-priority.md
+++ b/docs/superpowers/plans/2026-08-02-slot-autoload-priority.md
@@ -1,0 +1,999 @@
+# Slot autoload + eviction priority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every slot an explicit `autoload` (start on boot) setting and an integer `priority` (0–100) that orders eviction victims, replacing the implicit model-bound boot start and the `lru=true` eviction opt-in.
+
+**Architecture:** Two new `SlotConfig` fields persisted in per-slot TOML. `autoload` gates the Quadlet `[Install] WantedBy=hal0.target` stanza (the only thing that boot-starts a slot); a migration shim derives `true` for legacy TOMLs with a bound model. `priority` reorders the two victim-picking paths (`SlotReaper.pressure_evict_once`, `preload_evict`) to `(priority asc, last_used asc)` and retires the `lru=true` gate. Both fields are lifted into the `/api/slots` snapshot and edited from the slot drawer.
+
+**Tech Stack:** Python 3.12 / pydantic v2 / FastAPI / pytest (backend), React + vitest (ui/), Podman Quadlet units.
+
+Spec: `docs/superpowers/specs/2026-08-02-slot-autoload-priority-design.md`
+
+## Global Constraints
+
+- `autoload`: new slots default `false`; TOML missing the key with non-empty `[model].default` → effective `true` (migration shim); explicit value always wins.
+- `priority`: int, 0–100 inclusive, default 50. Lower evicts first; `last_used` ascending breaks ties.
+- `pinned` slots and default anchors (`agent`/`utility`/`npu`) stay never-evicted; `priority=100` is NOT pinned.
+- `lru` TOML key: ignored, deprecation-warned once per slot, never an error.
+- Adoption (`_maybe_adopt_running_slot`) is untouched.
+- Test runs: prefix with `HAL0_HOME=$(mktemp -d)` (kills the ~204 `/etc/hal0-perms` pseudo-errors), e.g. `HAL0_HOME=$(mktemp -d) uv run pytest <path> -x -q`.
+- Commit style: Conventional Commits, lowercase imperative summary, ≤72 chars.
+- Before every commit: `make lint` (ruff) green on touched files.
+
+---
+
+### Task 1: SlotConfig fields + raw-dict helpers
+
+**Files:**
+- Modify: `src/hal0/config/schema.py` (add fields after `pinned`, ~line 565)
+- Modify: `src/hal0/slots/activation.py` (add `autoload_enabled`)
+- Modify: `src/hal0/slots/reaper.py` (add `eviction_priority`, export it)
+- Test: `tests/slots/test_autoload_priority.py` (new file)
+
+**Interfaces:**
+- Produces: `SlotConfig.autoload: bool | None` (post-validation always `bool`), `SlotConfig.priority: int`.
+- Produces: `hal0.slots.activation.autoload_enabled(cfg: dict | None) -> bool` — effective boot-start for a RAW TOML dict.
+- Produces: `hal0.slots.reaper.eviction_priority(cfg: dict | None) -> int` — effective priority for a RAW TOML dict, clamped 0–100 (raw-dict readers clamp defensively — the sweep must never crash on a hand-authored TOML; pydantic paths hard-reject out-of-range instead).
+
+Background: the eviction/render paths consume raw TOML dicts from `_load_slot_config`, not pydantic models — same split as `is_pinned(name, cfg)` (`reaper.py:89`). Both a schema field (validation + API acceptance) and a raw-dict helper are needed.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Slot autoload + eviction-priority field semantics (spec 2026-08-02)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import SlotConfig
+from hal0.slots.activation import autoload_enabled
+from hal0.slots.reaper import eviction_priority
+
+
+def _cfg(**kw) -> SlotConfig:
+    base: dict = {"name": "s1", "port": 8090}
+    base.update(kw)
+    return SlotConfig(**base)
+
+
+class TestSlotConfigAutoload:
+    def test_default_false_without_model(self) -> None:
+        assert _cfg().autoload is False
+
+    def test_derives_true_from_bound_model(self) -> None:
+        # Migration shim: legacy TOML (no autoload key) with a bound model
+        # keeps its implicit boot start.
+        assert _cfg(model={"default": "qwen3"}).autoload is True
+
+    def test_explicit_false_wins_over_bound_model(self) -> None:
+        assert _cfg(model={"default": "qwen3"}, autoload=False).autoload is False
+
+    def test_explicit_true_without_model(self) -> None:
+        assert _cfg(autoload=True).autoload is True
+
+
+class TestSlotConfigPriority:
+    def test_default_50(self) -> None:
+        assert _cfg().priority == 50
+
+    @pytest.mark.parametrize("value", [0, 100])
+    def test_bounds_accepted(self, value: int) -> None:
+        assert _cfg(priority=value).priority == value
+
+    @pytest.mark.parametrize("value", [-1, 101])
+    def test_out_of_range_rejected(self, value: int) -> None:
+        with pytest.raises(ValidationError):
+            _cfg(priority=value)
+
+
+class TestAutoloadEnabledRawDict:
+    def test_none_and_empty(self) -> None:
+        assert autoload_enabled(None) is False
+        assert autoload_enabled({}) is False
+
+    def test_legacy_bound_model_derives_true(self) -> None:
+        assert autoload_enabled({"model": {"default": "qwen3"}}) is True
+
+    def test_explicit_false_wins(self) -> None:
+        assert autoload_enabled({"autoload": False, "model": {"default": "qwen3"}}) is False
+
+    def test_explicit_true_without_model(self) -> None:
+        assert autoload_enabled({"autoload": True}) is True
+
+    def test_model_without_default_is_false(self) -> None:
+        assert autoload_enabled({"model": {}}) is False
+
+
+class TestEvictionPriorityRawDict:
+    def test_default_on_missing(self) -> None:
+        assert eviction_priority(None) == 50
+        assert eviction_priority({}) == 50
+
+    def test_reads_value(self) -> None:
+        assert eviction_priority({"priority": 10}) == 10
+
+    @pytest.mark.parametrize("bad", [True, "10", 3.5, None])
+    def test_non_int_falls_back(self, bad) -> None:
+        assert eviction_priority({"priority": bad}) == 50
+
+    def test_clamps(self) -> None:
+        assert eviction_priority({"priority": -5}) == 0
+        assert eviction_priority({"priority": 999}) == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_autoload_priority.py -x -q`
+Expected: FAIL — `ImportError: cannot import name 'autoload_enabled'` (or `eviction_priority`).
+
+- [ ] **Step 3: Implement**
+
+`src/hal0/config/schema.py` — insert directly after the `pinned` field (~line 565), inside `SlotConfig`:
+
+```python
+    autoload: bool | None = Field(
+        default=None,
+        description=(
+            "Explicit boot-start setting (spec 2026-08-02). True → the "
+            "generated Quadlet unit carries [Install] WantedBy=hal0.target "
+            "and the slot starts at boot; False → the unit exists but "
+            "nothing starts it automatically (manual load/swap only). "
+            "None (key absent on disk) is the migration shim: derived from "
+            "the legacy implicit signal — non-empty [model].default — by "
+            "_derive_autoload below, so pre-field TOMLs keep their boot "
+            "behavior. API-created slots always persist an explicit value "
+            "(create route defaults it to false)."
+        ),
+    )
+    priority: int = Field(
+        default=50,
+        ge=0,
+        le=100,
+        description=(
+            "Eviction priority (spec 2026-08-02): lower evicts first, "
+            "last_used breaks ties. Orders victims in pressure eviction "
+            "(SlotReaper.pressure_evict_once) and pre-load eviction "
+            "(preload_evict). Replaces the deprecated lru=true opt-in — "
+            "every non-pinned slot is now a candidate. 100 is NOT a pin "
+            "(evicted last, still evictable); use `pinned` to exempt."
+        ),
+    )
+```
+
+And a `model_validator(mode="after")` next to the other `SlotConfig` validators (search for `@model_validator` inside the class and add alongside):
+
+```python
+    @model_validator(mode="after")
+    def _derive_autoload(self) -> "SlotConfig":
+        """Resolve the migration shim: absent key → legacy implicit signal.
+
+        A TOML written before the field existed boot-started iff it had a
+        model bound (#1369 activation semantics); deriving here means the
+        next save writes the value back explicitly.
+        """
+        if self.autoload is None:
+            self.autoload = bool(self.model.default)
+        return self
+```
+
+`src/hal0/slots/activation.py` — add after `is_activated` (~line 71):
+
+```python
+def autoload_enabled(cfg: dict[str, Any] | None) -> bool:
+    """Effective boot-start setting for a RAW slot TOML dict (spec 2026-08-02).
+
+    Mirror of ``SlotConfig._derive_autoload`` for the raw-dict readers
+    (unit render, slot_view lift): an explicit ``autoload`` key wins;
+    an absent key falls back to the legacy implicit signal — a bound
+    model (:func:`is_activated`) — so pre-field TOMLs keep their boot
+    behavior. Same raw-dict contract as :func:`hal0.slots.reaper.is_pinned`.
+    """
+    if not isinstance(cfg, dict):
+        return False
+    raw = cfg.get("autoload")
+    if raw is not None:
+        return bool(raw)
+    return is_activated(cfg)
+```
+
+Add `autoload_enabled` to `activation.py`'s `__all__` if one exists (check the file tail).
+
+`src/hal0/slots/reaper.py` — add after `is_pinned` (~line 105):
+
+```python
+_DEFAULT_EVICTION_PRIORITY: int = 50
+
+
+def eviction_priority(cfg: dict[str, Any] | None) -> int:
+    """Effective eviction priority for a RAW slot TOML dict (0-100).
+
+    Lower evicts first; ties fall back to LRU order at the call sites.
+    Defensive by design — the sweep must never crash on a hand-authored
+    TOML: a missing/bool/non-int value falls back to the default and an
+    out-of-range int is clamped. The pydantic paths (SlotConfig ge/le)
+    hard-reject instead; this is the fail-open mirror, same contract as
+    :func:`is_pinned` reading the raw dict.
+    """
+    if not isinstance(cfg, dict):
+        return _DEFAULT_EVICTION_PRIORITY
+    raw = cfg.get("priority")
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return _DEFAULT_EVICTION_PRIORITY
+    return max(0, min(100, raw))
+```
+
+Append `"eviction_priority"` and `"_DEFAULT_EVICTION_PRIORITY"` to `reaper.py`'s `__all__` (keep it sorted).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_autoload_priority.py tests/slots/test_slot_schema.py -q`
+Expected: PASS (schema round-trip suite included to catch field regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/config/schema.py src/hal0/slots/activation.py src/hal0/slots/reaper.py tests/slots/test_autoload_priority.py
+git commit -m "feat(slots): add autoload and eviction-priority slot config fields"
+```
+
+---
+
+### Task 2: Quadlet `[Install]` gated on autoload
+
+**Files:**
+- Modify: `src/hal0/providers/container.py` — `_render_quadlet_from_plan` (~line 622, `[Install]` emit ~line 797) and `_render_quadlet_text` (~line 1733)
+- Test: `tests/providers/test_container.py` (class `TestRenderUnit`, `_render_llama` shim at line 67)
+
+**Interfaces:**
+- Consumes: `hal0.slots.activation.autoload_enabled(cfg)` (Task 1).
+- Produces: `_render_quadlet_from_plan(instance_token, plan, *, publish_host=..., network_mode_default=..., autoload: bool = True) -> str`. With `autoload=False` the rendered unit has NO `[Install]` section (nothing boot-starts it; `systemctl start` / `_write_and_start_unit`'s `restart` still work — they never depended on `[Install]`).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/providers/test_container.py`: add a passthrough kwarg to the `_render_llama` shim — add `autoload=True` to its keyword params and thread it into the shim's final `_render_quadlet_from_plan(...)` call as `autoload=autoload`. Then add to `TestRenderUnit`:
+
+```python
+    def test_install_stanza_present_by_default(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama("test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags)
+        assert "[Install]" in unit
+        assert "WantedBy=hal0.target" in unit.splitlines()
+
+    def test_autoload_false_omits_install_stanza(self) -> None:
+        """autoload=false → no [Install] → nothing boot-starts the slot.
+
+        The unit must remain manually startable: [Service]/Restart survive.
+        """
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama(
+            "test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags,
+            autoload=False,
+        )
+        assert "[Install]" not in unit
+        assert "WantedBy=hal0.target" not in unit
+        assert "[Service]" in unit
+        assert "Restart=always" in unit.splitlines()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/providers/test_container.py::TestRenderUnit -q`
+Expected: FAIL — `TypeError: _render_quadlet_from_plan() got an unexpected keyword argument 'autoload'`.
+
+- [ ] **Step 3: Implement**
+
+`_render_quadlet_from_plan` signature (line ~622) gains the kwarg:
+
+```python
+def _render_quadlet_from_plan(
+    instance_token: str,
+    plan: RuntimeLaunchPlan,
+    *,
+    publish_host: str = "127.0.0.1",
+    network_mode_default: str = "",
+    autoload: bool = True,
+) -> str:
+```
+
+Replace the tail block that appends `[Service]`/`[Install]` (~line 787–801) so `[Install]` is conditional:
+
+```python
+    lines.extend(
+        [
+            "",
+            "[Service]",
+            "Restart=always",
+            "RestartSec=3",
+            f"SyslogIdentifier={container_name}",
+            "StandardOutput=journal",
+            "StandardError=journal",
+        ]
+    )
+    # [Install] WantedBy=hal0.target is the ONLY thing that boot-starts a
+    # slot (Quadlet's generator links the .wants symlink from unit content —
+    # no systemctl enable anywhere). autoload=false omits it wholesale: the
+    # unit stays start-able (load/swap use `systemctl restart`, which never
+    # consulted [Install]) but nothing pulls it up at boot. Spec 2026-08-02.
+    if autoload:
+        lines.extend(["", "[Install]", "WantedBy=hal0.target"])
+    lines.append("")
+    return "\n".join(lines)
+```
+
+`_render_quadlet_text` (~line 1733) threads the slot's effective setting — add the import at the top of the file's import block (`from hal0.slots.activation import autoload_enabled`; check whether `activation` is already imported) and change the return:
+
+```python
+        return _render_quadlet_from_plan(
+            token,
+            plan,
+            publish_host=_slot_publish_host(),
+            network_mode_default=_slot_network_mode(),
+            autoload=autoload_enabled(slot_cfg),
+        )
+```
+
+Also update the docstring line in `_write_and_start_unit` (~line 1704) that claims `[Install] WantedBy=hal0.target` unconditionally handles boot-enable — note it is autoload-gated now.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/providers/test_container.py -q`
+Expected: PASS (whole file — `test_unit_has_expected_sections` must still pass, default is `autoload=True`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/providers/container.py tests/providers/test_container.py
+git commit -m "feat(slots): gate quadlet [Install] boot-start on slot autoload"
+```
+
+---
+
+### Task 3: re-render unit when autoload changes via PUT /config
+
+**Files:**
+- Modify: `src/hal0/api/routes/slots.py` — new helper + call in `update_slot_config` (~line 1082)
+- Test: `tests/api/test_slots_routes.py`
+
+**Interfaces:**
+- Consumes: `ContainerProvider.rerender_unit_sync(cfg, model_info) -> bool`, `ContainerProvider.daemon_reload()`, `hal0.providers.container._best_effort_model_info(cfg, None)` (same trio the updater sweep uses, `src/hal0/updater/updater.py:2390-2418`).
+- Produces: module-level `_rerender_slot_unit_best_effort(cfg: dict[str, Any]) -> None` in `routes/slots.py` (module-level so tests monkeypatch it).
+
+Why: `update_config` only rewrites TOML ("the unit is re-rendered on the next load/restart"). Without this, flipping autoload off then rebooting still starts the slot from the stale unit's `[Install]` — the exact surprise the feature removes.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/api/test_slots_routes.py`, following the file's existing client/monkeypatch fixture pattern (reuse the same fixtures the neighboring `PUT /config` tests use — read two of them first and copy their setup):
+
+```python
+def test_put_config_autoload_triggers_unit_rerender(client, monkeypatch):
+    """PUT {autoload: false} rewrites the on-disk Quadlet unit immediately —
+    otherwise a reboot before the next load still boot-starts the slot."""
+    from hal0.api.routes import slots as slots_routes
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        slots_routes, "_rerender_slot_unit_best_effort", lambda cfg: calls.append(cfg)
+    )
+    resp = client.put("/api/slots/<existing-slot>/config", json={"autoload": False})
+    assert resp.status_code == 200
+    assert len(calls) == 1
+
+
+def test_put_config_priority_skips_unit_rerender(client, monkeypatch):
+    from hal0.api.routes import slots as slots_routes
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        slots_routes, "_rerender_slot_unit_best_effort", lambda cfg: calls.append(cfg)
+    )
+    resp = client.put("/api/slots/<existing-slot>/config", json={"priority": 10})
+    assert resp.status_code == 200
+    assert calls == []
+```
+
+(`<existing-slot>`: use whatever seeded slot name the neighboring PUT-config tests in that file target.) Also assert the priority test round-trips: `resp.json()` or a follow-up GET carries `priority == 10` if the file's pattern makes that cheap.
+
+Value validation: the PUT path merges raw dicts (`reconcile_slot_updates`) — pydantic's `ge/le` never runs there. Add tests:
+
+```python
+@pytest.mark.parametrize("bad", [-1, 101, "high", 3.5, True])
+def test_put_config_priority_out_of_range_rejected(client, bad):
+    resp = client.put("/api/slots/<existing-slot>/config", json={"priority": bad})
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation.invalid_value"
+
+
+def test_put_config_autoload_must_be_bool(client):
+    resp = client.put("/api/slots/<existing-slot>/config", json={"autoload": "yes"})
+    assert resp.status_code == 400
+```
+
+(Match the error-body shape the file's other BadRequest assertions use — the repo's `BadRequest` is HTTP 400 with a `code`; the spec's "422" maps to this house convention.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/api/test_slots_routes.py -q -k autoload`
+Expected: FAIL — `AttributeError: ... has no attribute '_rerender_slot_unit_best_effort'`.
+
+- [ ] **Step 3: Implement**
+
+In `routes/slots.py`, module level (near the other underscore helpers):
+
+```python
+def _rerender_slot_unit_best_effort(cfg: dict[str, Any]) -> None:
+    """Rewrite a slot's on-disk Quadlet unit after an ``autoload`` change.
+
+    The unit's [Install] stanza is baked at render time; without this, a
+    toggle only takes effect on the next load — and a reboot in between
+    boot-starts a slot the operator just opted out. Same provider trio as
+    the updater's post-update unit sweep (updater.py). Never raises past
+    the caller's guard; never starts/stops anything.
+    """
+    from hal0.providers.container import ContainerProvider, _best_effort_model_info
+
+    provider = ContainerProvider()
+    model_info = _best_effort_model_info(cfg, None)
+    if provider.rerender_unit_sync(cfg, model_info):
+        provider.daemon_reload()
+```
+
+In `update_slot_config`, after the `record_action` block (after `_rec.after = body`), before building `out`:
+
+```python
+    if "autoload" in body:
+        try:
+            cfg_after = await _safe_config(sm, name)
+            if cfg_after:
+                await asyncio.to_thread(_rerender_slot_unit_best_effort, cfg_after)
+        except Exception:
+            # Best-effort: the TOML is the source of truth; the updater
+            # sweep / next load converges the unit if this fails.
+            pass
+```
+
+(`asyncio` is already imported in this module. If the module has a `log`, log the swallowed exception at warning level instead of a bare `pass`.)
+
+Value validation helper, module level next to `_reject_unknown_config_keys`:
+
+```python
+def _validate_autoload_priority(body: dict[str, Any]) -> None:
+    """Value-level guard for the two spec-2026-08-02 fields.
+
+    The config write path merges RAW dicts (reconcile_slot_updates), so
+    SlotConfig's ge/le never runs — an out-of-range priority would persist
+    to TOML silently and the eviction helper would clamp it forever.
+    """
+    if "autoload" in body and not isinstance(body["autoload"], bool):
+        raise BadRequest(
+            "autoload must be a boolean",
+            details={"autoload": repr(body["autoload"])},
+            code="validation.invalid_value",
+        )
+    if "priority" in body:
+        prio = body["priority"]
+        if isinstance(prio, bool) or not isinstance(prio, int) or not 0 <= prio <= 100:
+            raise BadRequest(
+                "priority must be an integer between 0 and 100",
+                details={"priority": repr(prio)},
+                code="validation.invalid_value",
+            )
+```
+
+Call it in `update_slot_config` and `create_slot`, right after their existing `_reject_unknown_config_keys(body)` calls:
+
+```python
+    _validate_autoload_priority(body)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/api/test_slots_routes.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/api/routes/slots.py tests/api/test_slots_routes.py
+git commit -m "feat(api): re-render slot unit when autoload changes"
+```
+
+---
+
+### Task 4: priority ordering in pressure eviction, retire lru gate
+
+**Files:**
+- Modify: `src/hal0/slots/reaper.py` — `pressure_evict_once` (~line 381–439), new `_warn_lru_deprecated`
+- Test: `tests/slots/test_pressure_eviction.py`
+
+**Interfaces:**
+- Consumes: `eviction_priority(cfg)` (Task 1).
+- Produces: `pressure_evict_once` victim order `(priority asc, last_used asc)`; `lru` key ignored + warned. `_warn_lru_deprecated(canonical_name: str, cfg: dict | None) -> None` (shared with Task 5 — import it there).
+
+- [ ] **Step 1: Update existing tests + write new failing tests**
+
+First read `tests/slots/test_pressure_eviction.py` fully. Existing expectations that change:
+- Any test asserting a slot WITHOUT `lru = true` is NOT pressure-evicted → now IS evicted (flip the assertion; rename the test to describe the new contract, e.g. `test_non_lru_slot_now_evictable_priority_order`).
+- Tests that set `lru = true` merely to opt in keep passing (key is ignored, slots were already eligible) — leave them, they now also prove the key is harmless.
+
+Add new tests in that file, following its existing manager/monkeypatch harness (reuse the same fixture helpers the surrounding tests use for fake slots, `_last_used`, and the free-mb probe):
+
+```python
+async def test_pressure_evicts_lowest_priority_first(...):
+    """Three resident slots, equal idle age, priorities 10/50/90 →
+    eviction order is the priority order, not LRU."""
+    # setup: three READY slots, same last_used, configs with
+    # priority 90 ("keeper"), 50 ("mid"), 10 ("cheap"); probe returns
+    # below-floor until two evictions have happened.
+    # assert: unload called for "cheap" then "mid"; "keeper" untouched.
+
+
+async def test_pressure_priority_tie_breaks_lru(...):
+    """Equal priority → oldest last_used evicted first (old behavior kept
+    within a priority tier)."""
+
+
+async def test_pressure_skips_pinned_regardless_of_priority(...):
+    """pinned=true + priority=0 is still never evicted."""
+
+
+async def test_lru_key_ignored_and_warned_once(caplog, ...):
+    """A cfg carrying lru=false is evictable anyway; slot.lru_flag_deprecated
+    logged exactly once across two sweeps."""
+```
+
+Flesh these out against the file's real harness — the docstring contracts above are the requirements; the fixture mechanics must match the existing tests in that file (they monkeypatch `sm._probe_host_free_mb` and drive `sm._reaper.pressure_evict_once()` directly).
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_pressure_eviction.py -q`
+Expected: new tests FAIL (non-lru slot still skipped; no priority ordering); flipped legacy tests FAIL too.
+
+- [ ] **Step 3: Implement**
+
+In `reaper.py`, add near `eviction_priority`:
+
+```python
+_lru_flag_warned: set[str] = set()
+
+
+def _warn_lru_deprecated(canonical_name: str, cfg: dict[str, Any] | None) -> None:
+    """One-shot deprecation warning for the retired ``lru`` TOML key.
+
+    The key is IGNORED (never an error): eviction eligibility is now
+    priority-ordered for every non-pinned slot (spec 2026-08-02). Warned
+    once per slot per process so a 30 s sweep doesn't spam the journal.
+    """
+    if not isinstance(cfg, dict) or cfg.get("lru") is None:
+        return
+    if canonical_name in _lru_flag_warned:
+        return
+    _lru_flag_warned.add(canonical_name)
+    log.warning(
+        "slot.lru_flag_deprecated",
+        extra={
+            "slot": canonical_name,
+            "hint": "lru is ignored; eviction order is priority (0-100, "
+            "lower first) — remove the key, use `priority`/`pinned`",
+        },
+    )
+```
+
+In `pressure_evict_once`, replace the candidate build + sort (~lines 419–440):
+
+```python
+        # Build the victim list ordered (priority asc, last_used asc):
+        # lowest priority first, LRU within a tier (spec 2026-08-02).
+        # sweep_candidates() unions _last_used with dispatchable slots known
+        # only via state.json (adopted / restart-surviving), timestamped by
+        # their last observed transition, so pressure eviction can also
+        # reclaim those. The retired ``lru = true`` opt-in no longer gates —
+        # every non-pinned resident slot is a candidate.
+        candidates: list[tuple[int, float, str]] = []
+        for slot_name, ts in self.sweep_candidates().items():
+            if host._serving_count.get(host._key(slot_name), 0) > 0:
+                continue
+            canonical = host._resolve_alias(slot_name)
+            state = host._current_state(slot_name)
+            if state not in (SlotState.READY, SlotState.IDLE):
+                continue
+            try:
+                cfg = await host._load_slot_config(slot_name)
+            except (SlotConfigError, SlotNotFound):
+                continue
+            if is_pinned(canonical, cfg):
+                continue
+            _warn_lru_deprecated(canonical, cfg)
+            candidates.append((eviction_priority(cfg), ts, slot_name))
+
+        candidates.sort(key=lambda item: (item[0], item[1]))
+        for _prio, _ts, slot_name in candidates:
+```
+
+(the loop body below is unchanged.) Update the `pressure_evict_once` docstring: replace the "Only slots with ``lru = true`` …" guard bullet with the priority-order description; same for the module docstring's `lru` mentions. Add `_warn_lru_deprecated` to `__all__` (Task 5 imports it).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_pressure_eviction.py tests/slots/test_adopted_slot_eviction.py tests/slots/test_pin_semantics.py -q`
+Expected: PASS (adjacent eviction/pin suites included — they exercise the same sweep).
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/slots/reaper.py tests/slots/test_pressure_eviction.py
+git commit -m "feat(slots): priority-ordered pressure eviction, retire lru opt-in"
+```
+
+---
+
+### Task 5: priority ordering in pre-load eviction
+
+**Files:**
+- Modify: `src/hal0/slots/preload_evict.py` — `CandidateSlot`, `select_eviction_order` (~line 160), `_gather_candidates` (~line 280), module docstring
+- Test: `tests/slots/test_preload_eviction.py`
+
+**Interfaces:**
+- Consumes: `eviction_priority`, `_warn_lru_deprecated` from `hal0.slots.reaper` (Tasks 1/4).
+- Produces: `CandidateSlot` gains `priority: int = 50` (keyword-position after `reason`); `select_eviction_order` picks eligible candidates sorted `(priority, last_used)`.
+
+- [ ] **Step 1: Update existing tests + write new failing tests**
+
+Read `tests/slots/test_preload_eviction.py` first. Existing changes:
+- Any test constructing `CandidateSlot(..., eligible=False, reason="not_lru")` or asserting the `not_lru` reason → drop/flip (the reason no longer exists; those candidates become eligible).
+- `select_eviction_order` tests keep passing where all candidates default `priority=50` (pure LRU within the tier — unchanged behavior).
+
+New tests (pure-function level — no manager needed):
+
+```python
+def test_select_orders_by_priority_then_lru() -> None:
+    """priority beats recency: an old high-priority slot survives while a
+    newer low-priority one is selected first."""
+    cands = [
+        CandidateSlot(name="hi", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=90),
+        CandidateSlot(name="lo-new", last_used=900.0, footprint_mb=4000.0, eligible=True, priority=10),
+        CandidateSlot(name="lo-old", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=10),
+    ]
+    plan = select_eviction_order(cands, needed_mb=7000.0, headroom_mb=1000.0, free_mb=0.0)
+    assert [c.name for c in plan.selected] == ["lo-old", "lo-new"]
+    assert plan.fits is True
+
+
+def test_select_ineligible_never_selected_regardless_of_priority() -> None:
+    cands = [
+        CandidateSlot(name="pinned", last_used=1.0, footprint_mb=9000.0, eligible=False,
+                      reason="pinned", priority=0),
+        CandidateSlot(name="ok", last_used=2.0, footprint_mb=9000.0, eligible=True, priority=100),
+    ]
+    plan = select_eviction_order(cands, needed_mb=8000.0, headroom_mb=0.0, free_mb=0.0)
+    assert [c.name for c in plan.selected] == ["ok"]
+```
+
+Plus a `_gather_candidates`-level test following the file's existing host-stub pattern: a slot whose cfg has no `lru` key at all is `eligible=True` with `priority` read from cfg (was `eligible=False, reason="not_lru"`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_preload_eviction.py -q`
+Expected: FAIL — `TypeError: CandidateSlot.__init__() got an unexpected keyword argument 'priority'`.
+
+- [ ] **Step 3: Implement**
+
+`CandidateSlot` gains the field (after `reason`):
+
+```python
+    priority: int = 50
+```
+
+`select_eviction_order` — replace the eligible sort line:
+
+```python
+    eligible = sorted(
+        (c for c in candidates if c.eligible), key=lambda c: (c.priority, c.last_used)
+    )
+```
+
+and update its docstring ("oldest-first" → "lowest priority first, oldest within a tier"). `_gather_candidates` — import `_warn_lru_deprecated, eviction_priority` alongside the existing `is_pinned` import from `hal0.slots.reaper`; replace the eligibility tail:
+
+```python
+                else:
+                    if is_pinned(canonical, cfg):
+                        eligible, reason = False, "pinned"
+                    else:
+                        _warn_lru_deprecated(canonical, cfg)
+```
+
+and build the candidate with the priority (cfg may be unbound when the config load failed — hoist a `priority = 50` default before the `try`, set `priority = eviction_priority(cfg)` in the `else` branch):
+
+```python
+        out.append(
+            CandidateSlot(
+                name=name,
+                last_used=ts,
+                footprint_mb=footprint_mb,
+                eligible=eligible,
+                reason=reason,
+                priority=priority,
+            )
+        )
+```
+
+Update the module docstring's two `lru = true` mentions (eligibility bullet ~line 21 and `_gather_candidates` docstring) to the priority contract.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slots/test_preload_eviction.py tests/slots/test_pressure_eviction.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/slots/preload_evict.py tests/slots/test_preload_eviction.py
+git commit -m "feat(slots): priority-ordered pre-load eviction"
+```
+
+---
+
+### Task 6: lift autoload + priority into the /api/slots snapshot
+
+**Files:**
+- Modify: `src/hal0/slot_view/__init__.py` (config enrichment block, ~line 265 next to the `pinned` lift)
+- Test: `tests/slot_view/test_aggregator.py`
+
+**Interfaces:**
+- Consumes: `autoload_enabled`, `eviction_priority` (Task 1).
+- Produces: every real slot entry in `GET /api/slots` carries `"autoload": bool` (effective — shim applied) and `"priority": int`. The drawer reads `slot.autoload` / `slot.priority` (Task 7).
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/slot_view/test_aggregator.py`, next to whatever existing test asserts the `pinned` lift (find it; copy its fixture shape):
+
+```python
+def test_lifts_autoload_and_priority(...):
+    """Effective autoload (shim: bound model + no key → true) and priority
+    are lifted so the drawer renders without a per-slot /config fetch."""
+    # cfg A: {"model": {"default": "m"}} (no autoload key, no priority)
+    #   → entry["autoload"] is True, entry["priority"] == 50
+    # cfg B: {"autoload": False, "priority": 10, "model": {"default": "m"}}
+    #   → entry["autoload"] is False, entry["priority"] == 10
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slot_view/ -q`
+Expected: FAIL — `KeyError: 'autoload'`.
+
+- [ ] **Step 3: Implement**
+
+In `slot_view/__init__.py`, imports: add `autoload_enabled` (the module already imports `is_pinned` as `reaper_is_pinned` at line 56 — add `from hal0.slots.activation import autoload_enabled` and `from hal0.slots.reaper import eviction_priority`; check whether `activation` imports already exist near the top). In the enrichment loop, directly under the `entry["pinned"]` lift (~line 269):
+
+```python
+        # Spec 2026-08-02: lift the EFFECTIVE autoload (migration shim
+        # applied — absent key + bound model reads true) and eviction
+        # priority so the drawer's controls render without a per-slot
+        # /config fetch, same pattern as the pinned lift above.
+        entry["autoload"] = autoload_enabled(cfg)
+        entry["priority"] = eviction_priority(cfg)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `HAL0_HOME=$(mktemp -d) uv run pytest tests/slot_view/ tests/api/test_slots_routes.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+make lint
+git add src/hal0/slot_view/__init__.py tests/slot_view/test_aggregator.py
+git commit -m "feat(api): surface slot autoload and priority in /api/slots"
+```
+
+---
+
+### Task 7: drawer + create-modal controls
+
+**Files:**
+- Modify: `ui/src/dash/slot-modals.jsx` — `EditSlotDrawer` Model group (starts line ~1348), create modal (top of file), instant-apply handlers (pattern: `onTogglePinned`, line ~661)
+- Modify: `src/hal0/api/routes/slots.py` — `create_slot` (~line 606): default `autoload` explicitly
+
+**Interfaces:**
+- Consumes: `slot.autoload` / `slot.priority` from the poll (Task 6); `PUT /api/slots/{name}/config` bodies `{autoload: bool}` / `{priority: int}`; `editMut` mutation already used by `onTogglePinned`.
+- Produces: drawer rows "Auto-load on start" (toggle) and "Eviction priority" (number 0–100); create modal fields; create route persists explicit `autoload` (default `false`).
+
+- [ ] **Step 1: create route default (backend, tiny)**
+
+In `create_slot`, right after `_normalize_create_body(...)` returns (before the `_reject_*` calls):
+
+```python
+    # Spec 2026-08-02: new slots never inherit the legacy implicit boot
+    # start — persist an explicit autoload so the migration shim (absent
+    # key + bound model → true) only ever applies to pre-field TOMLs.
+    body.setdefault("autoload", False)
+```
+
+Add a test next to the existing create tests in `tests/api/test_slots_routes.py`: POST a slot with a model and WITHOUT `autoload` → follow-up config read shows `autoload` False (assert via the same config-fetch pattern neighboring create tests use). Run it (fails before the change, passes after).
+
+- [ ] **Step 2: drawer — instant-apply handlers**
+
+In `EditSlotDrawer`, next to `onTogglePinned` (same shape — instant PUT + toast + poll re-render; reuse `setEnableBusy`-style busy state only if `onTogglePinned` does):
+
+```jsx
+	// Instant-apply autoload toggle + priority commit (spec 2026-08-02).
+	// Same contract as the pinned toggle above: fire the PUT, toast, let the
+	// slots poll re-render from server truth. Excluded from the Save batch.
+	const autoload = slot.autoload === true;
+	const onToggleAutoload = async (next) => {
+		try {
+			await editMut.mutateAsync({ name: slot.name, body: { autoload: next } });
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					`${slot.name} auto-load ${next ? "on" : "off"}`,
+					"ok",
+				);
+		} catch (err) {
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: toggle failed`,
+					"warn",
+				);
+		}
+	};
+	const [prio, setPrio] = React.useState(
+		Number.isInteger(slot.priority) ? slot.priority : 50,
+	);
+	React.useEffect(() => {
+		if (Number.isInteger(slot.priority)) setPrio(slot.priority);
+	}, [slot.priority]);
+	const commitPriority = async () => {
+		const v = Math.max(0, Math.min(100, Number(prio) || 0));
+		setPrio(v);
+		if (v === slot.priority) return;
+		try {
+			await editMut.mutateAsync({ name: slot.name, body: { priority: v } });
+			window.__hal0Toast && window.__hal0Toast(`${slot.name} priority → ${v}`, "ok");
+		} catch (err) {
+			setPrio(Number.isInteger(slot.priority) ? slot.priority : 50);
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: priority save failed`,
+					"warn",
+				);
+		}
+	};
+```
+
+(Match the file's state-hook import style — it may use `useState` bare imports rather than `React.useState`; follow whatever the file does.)
+
+- [ ] **Step 3: drawer — rows in the Model group**
+
+Inside `<FieldGroup label="Model">`, after the model-select row (and after the Profile row if it renders inside this group), add:
+
+```jsx
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Auto-load on start</span>
+								<FieldInfoIcon description="Start this slot automatically at boot. Off: the slot
+									only loads when you load or swap it — binding a model no
+									longer implies boot start." />
+							</div>
+							<div className="form-ctl">
+								<label className="slot-enable-toggle">
+									<input
+										type="checkbox"
+										data-testid="slot-autoload-toggle"
+										checked={autoload}
+										onChange={() => onToggleAutoload(!autoload)}
+										aria-label={autoload ? "Disable auto-load on start" : "Enable auto-load on start"}
+									/>
+									<span className="slot-enable-track" aria-hidden="true" />
+								</label>
+							</div>
+						</div>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Eviction priority</span>
+								<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
+									Ties go to the least recently used. Pin the slot to exempt
+									it entirely." />
+							</div>
+							<div className="form-ctl">
+								<input
+									className="input mono"
+									data-testid="slot-priority-input"
+									type="number"
+									min={0}
+									max={100}
+									step={1}
+									value={prio}
+									onChange={(e) => setPrio(e.target.value)}
+									onBlur={commitPriority}
+									onKeyDown={(e) => {
+										if (e.key === "Enter") e.currentTarget.blur();
+									}}
+									style={{ width: 90 }}
+								/>
+								<div className="hint">lower unloads first</div>
+							</div>
+						</div>
+```
+
+Adapt toggle markup to the exact classes the pinned header toggle uses if `slot-enable-toggle`/`slot-enable-track` don't render standalone in a form row — visual match beats literal copy.
+
+- [ ] **Step 4: create modal**
+
+Find the create modal component at the top of `slot-modals.jsx` (investigator: line ~2). Add the same two controls to its form with local state defaults `autoload=false`, `priority=50`, and include both keys in the POST body it already builds (`autoload: <bool>`, `priority: <number>`). Omit the migration hint copy — new slots have no legacy behavior.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd ui && npm run test:unit && npm run build
+```
+Expected: vitest suite green (no new UI unit tests required — the touched logic is instant-apply wiring; existing suites must not break), build succeeds. Then backend spot-check:
+
+```bash
+HAL0_HOME=$(mktemp -d) uv run pytest tests/api/test_slots_routes.py -q
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+make lint
+git add ui/src/dash/slot-modals.jsx src/hal0/api/routes/slots.py tests/api/test_slots_routes.py
+git commit -m "feat(ui): slot drawer autoload toggle and eviction priority"
+```
+
+---
+
+### Task 8: changelog, docs sweep, full verification
+
+**Files:**
+- Modify: `CHANGELOG.md` (`## [Unreleased]` → `### Added`)
+- Modify: any `docs/` page mentioning `lru = true` or implicit boot start (`grep -rn "lru" docs/ --include="*.md*"`, `grep -rn "WantedBy=hal0.target" docs/`)
+
+- [ ] **Step 1: CHANGELOG entry**
+
+Under `## [Unreleased]`, add (create `### Added` if absent):
+
+```markdown
+### Added
+
+- Slots: explicit `autoload` setting — a slot starts at boot only when
+  `autoload = true` (slot drawer toggle). Binding a model no longer
+  implies boot start; existing slots with a bound model migrate as
+  `true`, so upgrade changes nothing until toggled.
+- Slots: eviction `priority` (0–100, default 50, drawer field) — memory
+  pressure and pre-load eviction now unload the lowest-priority slot
+  first (least-recently-used within a tier). The `lru = true` opt-in is
+  retired: every non-pinned slot is evictable; the key is ignored with a
+  one-time deprecation warning. `pinned` still exempts entirely.
+```
+
+- [ ] **Step 2: docs sweep**
+
+Run the greps above; update any operator-facing doc that documents `lru = true` eligibility or "a slot with a model starts at boot" to the new contract. Skip `docs/superpowers/` and historical specs.
+
+- [ ] **Step 3: full verification**
+
+```bash
+make lint
+make typecheck
+HAL0_HOME=$(mktemp -d) uv run pytest tests/slots tests/providers tests/api/test_slots_routes.py tests/slot_view tests/config -q
+cd ui && npm run test:unit && npm run build
+```
+Expected: all green. If `make typecheck` flags pre-existing unrelated errors, only new errors in touched files block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/
+git commit -m "docs: changelog and docs for slot autoload and eviction priority"
+```

--- a/docs/superpowers/specs/2026-08-02-slot-autoload-priority-design.md
+++ b/docs/superpowers/specs/2026-08-02-slot-autoload-priority-design.md
@@ -1,0 +1,99 @@
+# Slot autoload + eviction priority — design
+
+Date: 2026-08-02
+Branch: `h0/slot-auto-load-priority`
+
+## Problem
+
+Slots start by themselves on host boot and API restart, with no visible setting that
+says so. Today "activation" is implicit: a slot whose TOML has a non-empty
+`[model].default` gets a generated systemd unit with `WantedBy=hal0.target`, so it is
+pulled up at boot, and `_maybe_adopt_running_slot()` re-adopts it on API restart.
+Binding a model to a slot silently opts it into boot start — surprising and sometimes
+undesirable.
+
+Separately, eviction (pressure and pre-load) picks victims in pure LRU order with an
+opt-in `lru=true` gate. There is no way to say "unload this slot before that one".
+
+## Decisions (operator-approved 2026-08-02)
+
+1. `autoload` migrates as `true` for existing slots with a bound model; new slots
+   default `false`.
+2. `priority` is an integer 0–100, default 50; lower evicts first, LRU breaks ties.
+3. Priority replaces the `lru=true` opt-in gate. All non-pinned slots become
+   evictable; `pinned` remains the absolute never-evict override.
+
+## Design
+
+### 1. `autoload` — explicit boot-start setting
+
+- New field `SlotConfig.autoload: bool` (per-slot TOML, `/etc/hal0/slots/*.toml`).
+  Default `false` for newly created slots.
+- **Migration shim:** when loading a slot TOML that has no `autoload` key, derive
+  `autoload = bool(model.default)`. The derived value is written back on the next
+  config save. Upgrading changes no behavior until the operator flips toggles.
+- **Mechanism:** the systemd unit generator emits `WantedBy=hal0.target` only when
+  `autoload=true`. With `autoload=false` the unit still exists (manual load, swap,
+  and API-driven start keep working) but nothing starts it at boot.
+- **Adoption unchanged:** `_maybe_adopt_running_slot()` still adopts a running unit
+  regardless of `autoload`. The flag governs starting; it never stops or kills
+  running work.
+- Net effect: "model bound" and "starts on boot" are decoupled. The only reason a
+  slot starts by itself is an explicit `autoload = true`.
+
+### 2. `priority` — eviction ordering
+
+- New field `SlotConfig.priority: int`, range 0–100 inclusive, default 50.
+  Out-of-range values are rejected at config load and by the API (422).
+- **Victim ordering everywhere victims are picked:** sort candidates by
+  `(priority ascending, last_used ascending)` — lowest priority first, oldest-idle
+  first within equal priority. Applied in:
+  - `SlotReaper.pressure_evict_once()` (free-RAM-floor pressure eviction)
+  - `preload_evict.admit()` (synchronous evict-to-fit before a load)
+- **Hard protections unchanged:** `pinned` slots and the default anchor slots
+  (`agent`, `utility`, `npu`) are never evicted. `priority=100` is *not* pinned —
+  it is merely evicted last.
+- **`lru=true` gate removed:** every non-pinned, non-serving slot is an eviction
+  candidate. The old `lru` key is still accepted in TOML but ignored, with a
+  deprecation warning logged once per slot at config load.
+- **Ordering only, no hard block:** a low-priority load may still evict a
+  higher-priority slot when pressure requires it; only `pinned` and anchor status
+  block eviction.
+- Idle-TTL eviction is untouched — it is time-based and already configurable
+  per slot via `idle_timeout_s`.
+
+### 3. API and UI surface
+
+- `GET /api/slots` includes `autoload` and `priority` per slot.
+- `PUT /api/slots/{name}/config` accepts both fields; `priority` validated 0–100.
+- Slot drawer (`ui/src/dash/slot-modals.jsx`, `EditSlotDrawer`):
+  - "Auto-load on start" toggle in the Model group (next to the model/default
+    fields it modifies the meaning of).
+  - "Eviction priority" number input (0–100) with hint text
+    "lower unloads first".
+  - Create modal: both fields present with defaults (`autoload=false`,
+    `priority=50`).
+
+## Error handling
+
+- `priority` outside 0–100 in TOML → config load error naming the slot and field.
+- `priority` outside 0–100 via API → 422 with field-level message.
+- Deprecated `lru` key → warning log, value ignored, not an error.
+
+## Testing
+
+- Schema: defaults (`autoload=false`, `priority=50`), range validation, TOML
+  round-trip.
+- Migration shim: TOML without `autoload` + bound model → `true`; without model →
+  `false`; explicit value wins; write-back on save.
+- Generator: `WantedBy=hal0.target` present iff `autoload=true`.
+- Reaper: pressure eviction picks lowest priority first, LRU within equal
+  priority, skips pinned/anchors/serving; `lru` flag no longer gates.
+- preload_evict: same ordering; deprecation warning emitted once for `lru`.
+- API: fields round-trip through GET/PUT, 422 on out-of-range priority.
+
+## Out of scope
+
+- Per-slot boot ordering / dependency between autoloaded slots.
+- Priority influence on idle TTL.
+- Any change to adoption semantics on API restart.

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -720,7 +720,7 @@ async def create_slot(request: Request) -> dict[str, object]:
         port_end=(int(slots_cfg.port_range_end) if slots_cfg else None),
         slot_snapshots=runtime_ports,
     )
-    # Spec 2026-08-02: new slots never inherit the legacy implicit boot
+    # Spec 2026-08-02: new slots never inherit the pre-field implicit boot
     # start — persist an explicit autoload so the migration shim (absent
     # key + bound model → true) only ever applies to pre-field TOMLs.
     body.setdefault("autoload", False)

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -720,6 +720,10 @@ async def create_slot(request: Request) -> dict[str, object]:
         port_end=(int(slots_cfg.port_range_end) if slots_cfg else None),
         slot_snapshots=runtime_ports,
     )
+    # Spec 2026-08-02: new slots never inherit the legacy implicit boot
+    # start — persist an explicit autoload so the migration shim (absent
+    # key + bound model → true) only ever applies to pre-field TOMLs.
+    body.setdefault("autoload", False)
     if isinstance(body.get("port"), int):
         _reject_port_conflict(int(body["port"]), name, runtime_ports)
     _reject_model_owned_config_keys(body)

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -30,6 +30,7 @@ import time
 from types import SimpleNamespace
 from typing import Any
 
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ValidationError
@@ -53,6 +54,8 @@ from hal0.slots import metrics_collect as _metrics_collect
 from hal0.slots import port_alloc as _port_alloc
 from hal0.slots import voices as _voices
 from hal0.slots.manager import Slot, SlotManager
+
+log = structlog.get_logger(__name__)
 
 # Auth was removed by design. All routes are open on the local network.
 
@@ -480,6 +483,46 @@ class _SlotSwapBody(BaseModel):
     model_id: str | None = None
 
 
+def _validate_autoload_priority(body: dict[str, Any]) -> None:
+    """Value-level guard for the two spec-2026-08-02 fields.
+
+    The config write path merges RAW dicts (reconcile_slot_updates), so
+    SlotConfig's ge/le never runs — an out-of-range priority would persist
+    to TOML silently and the eviction helper would clamp it forever.
+    """
+    if "autoload" in body and not isinstance(body["autoload"], bool):
+        raise BadRequest(
+            "autoload must be a boolean",
+            details={"autoload": repr(body["autoload"])},
+            code="validation.invalid_value",
+        )
+    if "priority" in body:
+        prio = body["priority"]
+        if isinstance(prio, bool) or not isinstance(prio, int) or not 0 <= prio <= 100:
+            raise BadRequest(
+                "priority must be an integer between 0 and 100",
+                details={"priority": repr(prio)},
+                code="validation.invalid_value",
+            )
+
+
+def _rerender_slot_unit_best_effort(cfg: dict[str, Any]) -> None:
+    """Rewrite a slot's on-disk Quadlet unit after an ``autoload`` change.
+
+    The unit's [Install] stanza is baked at render time; without this, a
+    toggle only takes effect on the next load — and a reboot in between
+    boot-starts a slot the operator just opted out. Same provider trio as
+    the updater's post-update unit sweep (updater.py). Never raises past
+    the caller's guard; never starts/stops anything.
+    """
+    from hal0.providers.container import ContainerProvider, _best_effort_model_info
+
+    provider = ContainerProvider()
+    model_info = _best_effort_model_info(cfg, None)
+    if provider.rerender_unit_sync(cfg, model_info):
+        provider.daemon_reload()
+
+
 def _reject_unknown_config_keys(payload: dict[str, Any]) -> None:
     """400 when a slot-config write body carries keys the schema doesn't know.
 
@@ -681,6 +724,7 @@ async def create_slot(request: Request) -> dict[str, object]:
         _reject_port_conflict(int(body["port"]), name, runtime_ports)
     _reject_model_owned_config_keys(body)
     _reject_unknown_config_keys(body)
+    _validate_autoload_priority(body)
     async with record_action(
         request,
         category="slot",
@@ -1096,6 +1140,7 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
         raise BadRequest("request body must be a JSON object", code="request.not_an_object")
     _reject_model_owned_config_keys(body)
     _reject_unknown_config_keys(body)
+    _validate_autoload_priority(body)
     # Port moves go through the registry so an edit can't land on a port
     # another slot (config or runtime) or listener already owns.
     new_port = body.get("port")
@@ -1115,6 +1160,19 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     ) as _rec:
         snap = await sm.update_config(name, body)
         _rec.after = body
+    if "autoload" in body:
+        try:
+            cfg_after = await _safe_config(sm, name)
+            if cfg_after:
+                await asyncio.to_thread(_rerender_slot_unit_best_effort, cfg_after)
+        except Exception as exc:
+            # Best-effort: the TOML is the source of truth; the updater
+            # sweep / next load converges the unit if this fails.
+            log.warning(
+                "slot.config_autoload_unit_rerender_failed",
+                slot=name,
+                error=str(exc),
+            )
     # NOTE (#1369): this route is a PURE config write — no lifecycle side
     # effect. It used to unload a running slot on an ``enabled: false`` body
     # (so the faded card matched reality); with the field gone, config edits

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -550,7 +550,13 @@ class SlotConfig(BaseModel):
     idle_timeout_s: int = Field(
         default=300,
         ge=0,
-        description="Seconds idle before transitioning to 'idle' state.  0 disables.",
+        description=(
+            "Per-slot idle-TTL override (seconds) for hard eviction "
+            "(SlotReaper.evict_timeout_for). 0 disables IDLE-TTL eviction "
+            "for this slot only — pressure eviction and pre-load eviction "
+            "are separate paths, exempted only by `pinned`, not by this "
+            "value."
+        ),
     )
     pinned: bool = Field(
         default=False,
@@ -789,8 +795,14 @@ class SlotConfig(BaseModel):
         """Resolve the migration shim: absent key → legacy implicit signal.
 
         A TOML written before the field existed boot-started iff it had a
-        model bound (#1369 activation semantics); deriving here means the
-        next save writes the value back explicitly.
+        model bound (#1369 activation semantics); deriving here means every
+        config READ resolves autoload from that signal. This does NOT get
+        written back to disk in production — the config write path merges
+        RAW dicts (reconcile_slot_updates), not this pydantic model, so an
+        absent-key TOML stays absent-key and the shim re-derives on every
+        subsequent read until an explicit `autoload` key is authored (e.g.
+        via the create route's `body.setdefault("autoload", False)`, or an
+        operator toggling the drawer).
         """
         if self.autoload is None:
             self.autoload = bool(self.model.default)
@@ -1930,20 +1942,25 @@ class SlotsConfig(BaseModel):
         default=300,
         ge=0,
         description=(
-            "Default idle-eviction TTL (seconds), applied per slot. "
-            "A slot that has not served a request for this long transitions "
-            "to idle. 0 disables eviction. Per-slot idle_timeout_s in each "
-            "slot's TOML overrides this value."
+            "Default idle-TTL (seconds) for hard eviction, applied per slot "
+            "when the slot's own TOML has no idle_timeout_s override. 0 "
+            "disables IDLE-TTL eviction for slots using this default — "
+            "pressure eviction and pre-load eviction are separate paths, "
+            "exempted only by `pinned`, not by this value."
         ),
     )
     evict_pressure_mb: int = Field(
         default=8192,
         ge=0,
         description=(
-            "Host free-RAM floor (MiB) for pressure-driven LRU eviction (#903). "
-            "When host MemAvailable drops below this value, idle lru-eligible "
-            "slots are evicted in least-recently-used order until free RAM is "
-            "back above the floor. 0 disables pressure eviction."
+            "Host free-RAM floor (MiB) for pressure-driven eviction (#903, "
+            "spec 2026-08-02). When host MemAvailable drops below this "
+            "value, every non-pinned resident slot is a candidate, evicted "
+            "in priority order (lowest `priority` first, "
+            "least-recently-used as the tie-break within a tier) until "
+            "free RAM is back above the floor. 0 disables pressure "
+            "eviction. `pinned` is the only exemption — `idle_timeout_s = "
+            "0` on a slot does not exempt it from this path."
         ),
     )
     preload_evict_enabled: bool = Field(
@@ -1952,8 +1969,9 @@ class SlotsConfig(BaseModel):
             "Free memory SYNCHRONOUSLY before a load starts, when the "
             "incoming model's estimated footprint plus "
             "preload_evict_headroom_mb would not fit in projected free "
-            "memory. Evicts idle lru-eligible resident slots in "
-            "least-recently-used order — the same eligibility "
+            "memory. Evicts non-pinned resident slots in priority order "
+            "(lowest `priority` first, least-recently-used as the "
+            "tie-break within a tier) — the same eligibility "
             "evict_pressure_mb uses — until it fits, or fails the load "
             "with a clear error if it still doesn't fit after evicting "
             "everything eligible. Set to false to rely solely on the "

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -577,7 +577,7 @@ class SlotConfig(BaseModel):
             "and the slot starts at boot; False → the unit exists but "
             "nothing starts it automatically (manual load/swap only). "
             "None (key absent on disk) is the migration shim: derived from "
-            "the legacy implicit signal — non-empty [model].default — by "
+            "the pre-field implicit signal — non-empty [model].default — by "
             "_derive_autoload below, so pre-field TOMLs keep their boot "
             "behavior. API-created slots always persist an explicit value "
             "(create route defaults it to false)."
@@ -591,7 +591,7 @@ class SlotConfig(BaseModel):
             "Eviction priority (spec 2026-08-02): lower evicts first, "
             "last_used breaks ties. Orders victims in pressure eviction "
             "(SlotReaper.pressure_evict_once) and pre-load eviction "
-            "(preload_evict). Replaces the deprecated lru=true opt-in — "
+            "(preload_evict). Replaces the retired lru=true opt-in — "
             "every non-pinned slot is now a candidate. 100 is NOT a pin "
             "(evicted last, still evictable); use `pinned` to exempt."
         ),
@@ -792,7 +792,7 @@ class SlotConfig(BaseModel):
 
     @model_validator(mode="after")
     def _derive_autoload(self) -> SlotConfig:
-        """Resolve the migration shim: absent key → legacy implicit signal.
+        """Resolve the migration shim: absent key → pre-field implicit signal.
 
         A TOML written before the field existed boot-started iff it had a
         model bound (#1369 activation semantics); deriving here means every

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -563,6 +563,33 @@ class SlotConfig(BaseModel):
             "existing behavior for every slot that doesn't set it."
         ),
     )
+    autoload: bool | None = Field(
+        default=None,
+        description=(
+            "Explicit boot-start setting (spec 2026-08-02). True → the "
+            "generated Quadlet unit carries [Install] WantedBy=hal0.target "
+            "and the slot starts at boot; False → the unit exists but "
+            "nothing starts it automatically (manual load/swap only). "
+            "None (key absent on disk) is the migration shim: derived from "
+            "the legacy implicit signal — non-empty [model].default — by "
+            "_derive_autoload below, so pre-field TOMLs keep their boot "
+            "behavior. API-created slots always persist an explicit value "
+            "(create route defaults it to false)."
+        ),
+    )
+    priority: int = Field(
+        default=50,
+        ge=0,
+        le=100,
+        description=(
+            "Eviction priority (spec 2026-08-02): lower evicts first, "
+            "last_used breaks ties. Orders victims in pressure eviction "
+            "(SlotReaper.pressure_evict_once) and pre-load eviction "
+            "(preload_evict). Replaces the deprecated lru=true opt-in — "
+            "every non-pinned slot is now a candidate. 100 is NOT a pin "
+            "(evicted last, still evictable); use `pinned` to exempt."
+        ),
+    )
 
     # Typed [server] subsection.  See ServerConfig + the round-trip
     # validator/serializer below: on load we hoist the [server] table out
@@ -756,6 +783,18 @@ class SlotConfig(BaseModel):
                 )
             new_data["device"] = mapped
         return new_data
+
+    @model_validator(mode="after")
+    def _derive_autoload(self) -> SlotConfig:
+        """Resolve the migration shim: absent key → legacy implicit signal.
+
+        A TOML written before the field existed boot-started iff it had a
+        model bound (#1369 activation semantics); deriving here means the
+        next save writes the value back explicitly.
+        """
+        if self.autoload is None:
+            self.autoload = bool(self.model.default)
+        return self
 
     @model_serializer(mode="wrap")
     def _tuck_server_into_extra(self, handler: Any) -> dict[str, Any]:

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -81,6 +81,7 @@ from hal0.providers._gpu import (
     resolve_gpu_group_ids,
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
+from hal0.slots.activation import autoload_enabled
 from hal0.slots.argv import ResolvedArgv, resolve_argv
 from hal0.slots.naming import (
     slot_container_name,
@@ -625,6 +626,7 @@ def _render_quadlet_from_plan(
     *,
     publish_host: str = "127.0.0.1",
     network_mode_default: str = "",
+    autoload: bool = True,
 ) -> str:
     """Render a Podman Quadlet ``.container`` unit from a launch plan.
 
@@ -793,12 +795,16 @@ def _render_quadlet_from_plan(
             f"SyslogIdentifier={container_name}",
             "StandardOutput=journal",
             "StandardError=journal",
-            "",
-            "[Install]",
-            "WantedBy=hal0.target",
-            "",
         ]
     )
+    # [Install] WantedBy=hal0.target is the ONLY thing that boot-starts a
+    # slot (Quadlet's generator links the .wants symlink from unit content —
+    # no systemctl enable anywhere). autoload=false omits it wholesale: the
+    # unit stays start-able (load/swap use `systemctl restart`, which never
+    # consulted [Install]) but nothing pulls it up at boot. Spec 2026-08-02.
+    if autoload:
+        lines.extend(["", "[Install]", "WantedBy=hal0.target"])
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -1701,8 +1707,10 @@ class ContainerProvider(Provider):
         The Quadlet sequence that replaces the old write→daemon-reload→enable→
         restart triple: the ``.container`` file is the source of truth, podman's
         generator emits ``hal0-slot@<token>.service`` on ``daemon-reload``, and
-        ``[Install] WantedBy=hal0.target`` in the unit handles boot-enable — so
-        no per-load ``systemctl enable``. ``restart`` (not bare ``start``) keeps
+        ``[Install] WantedBy=hal0.target`` in the unit handles boot-enable
+        (autoload-gated: slots with ``autoload = false`` render without an
+        ``[Install]`` section and do not boot-start) — so no per-load
+        ``systemctl enable``. ``restart`` (not bare ``start``) keeps
         this idempotent: it starts a stopped slot and restarts a running one,
         exactly as before. All writes route through the hal0-systemctl seam.
         """
@@ -1766,6 +1774,7 @@ class ContainerProvider(Provider):
             plan,
             publish_host=_slot_publish_host(),
             network_mode_default=_slot_network_mode(),
+            autoload=autoload_enabled(slot_cfg),
         )
 
     def load_sync(

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -205,7 +205,10 @@ def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str
 #:
 #:   - ``type``           — slot kind (llm/embedding/…), read all over manager/routing.
 #:   - ``default``        — SC-4 per-type default flag, read by default_slot_for.
-#:   - ``lru``            — pressure-eviction eligibility (#903).
+#:   - ``lru``            — retired eviction opt-in (#903, spec 2026-08-02).
+#:     Tolerated for back-compat only: the key is ignored (every non-pinned
+#:     slot is now a pressure/pre-load eviction candidate, ordered by
+#:     ``priority``), with a one-time deprecation warning.
 #:   - ``default_voice`` / ``default_language`` — TTS engine extras written by
 #:     the dashboard voice settings (PUT /api/slots/tts/config).
 #:   - ``slot``           — the nested on-disk [slot] table shape (hoisted on load).

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -51,8 +51,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from hal0.model_meta import device_to_backend
-from hal0.slots.activation import claims_npu_anchor, npu_modality_active
+from hal0.slots.activation import autoload_enabled, claims_npu_anchor, npu_modality_active
 from hal0.slots.naming import slot_instance_token, slot_unit_name
+from hal0.slots.reaper import eviction_priority
 from hal0.slots.reaper import is_pinned as reaper_is_pinned
 
 log = logging.getLogger(__name__)
@@ -267,6 +268,13 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         # Pinned/Unpinned toggle and the card badge render without a
         # per-slot /config fetch.
         entry["pinned"] = reaper_is_pinned(name, cfg)
+
+        # Spec 2026-08-02: lift the EFFECTIVE autoload (migration shim
+        # applied — absent key + bound model reads true) and eviction
+        # priority so the drawer's controls render without a per-slot
+        # /config fetch, same pattern as the pinned lift above.
+        entry["autoload"] = autoload_enabled(cfg)
+        entry["priority"] = eviction_priority(cfg)
 
         # SC-4 default marker: exactly one slot per ``type`` may carry
         # ``default = true`` (check_default_uniqueness). Lifted verbatim so the

--- a/src/hal0/slots/activation.py
+++ b/src/hal0/slots/activation.py
@@ -24,6 +24,7 @@ from typing import Any
 
 __all__ = [
     "NPU_MODALITY_KEY",
+    "autoload_enabled",
     "claims_npu_anchor",
     "is_activated",
     "npu_anchor_config",
@@ -69,6 +70,23 @@ def is_activated(cfg: dict[str, Any] | None) -> bool:
     can see and configure it, but nothing routes to it and no unit is written.
     """
     return bool(slot_model_id(cfg))
+
+
+def autoload_enabled(cfg: dict[str, Any] | None) -> bool:
+    """Effective boot-start setting for a RAW slot TOML dict (spec 2026-08-02).
+
+    Mirror of ``SlotConfig._derive_autoload`` for the raw-dict readers
+    (unit render, slot_view lift): an explicit ``autoload`` key wins;
+    an absent key falls back to the legacy implicit signal — a bound
+    model (:func:`is_activated`) — so pre-field TOMLs keep their boot
+    behavior. Same raw-dict contract as :func:`hal0.slots.reaper.is_pinned`.
+    """
+    if not isinstance(cfg, dict):
+        return False
+    raw = cfg.get("autoload")
+    if raw is not None:
+        return bool(raw)
+    return is_activated(cfg)
 
 
 def claims_npu_anchor(cfg: dict[str, Any] | None) -> bool:

--- a/src/hal0/slots/activation.py
+++ b/src/hal0/slots/activation.py
@@ -8,7 +8,7 @@ unit for. Spec 2026-08-02 split the two: boot autostart is now the explicit,
 independently-gated ``autoload`` field — this module owns
 :func:`autoload_enabled`, the raw-dict predicate that mirrors
 ``SlotConfig._derive_autoload`` (explicit key wins; an absent key falls back
-to the legacy implicit signal, a bound model, so pre-field TOMLs keep their
+to the pre-field implicit signal, a bound model, so pre-field TOMLs keep their
 boot behaviour). Activation itself is unchanged: ``[model].default`` is
 still the real routability/loadability signal, and every check that used to
 consult ``enabled`` was immediately followed by a model-presence gate
@@ -83,7 +83,7 @@ def autoload_enabled(cfg: dict[str, Any] | None) -> bool:
 
     Mirror of ``SlotConfig._derive_autoload`` for the raw-dict readers
     (unit render, slot_view lift): an explicit ``autoload`` key wins;
-    an absent key falls back to the legacy implicit signal — a bound
+    an absent key falls back to the pre-field implicit signal — a bound
     model (:func:`is_activated`) — so pre-field TOMLs keep their boot
     behavior. Same raw-dict contract as :func:`hal0.slots.reaper.is_pinned`.
     """

--- a/src/hal0/slots/activation.py
+++ b/src/hal0/slots/activation.py
@@ -1,16 +1,22 @@
 """The slot activation predicate — one owner for "is this slot live config?".
 
 #1369 removed ``SlotConfig.enabled``: a slot is activated by **binding a
-model**, never by a separate boolean. Boot autostart is the Quadlet
-``[Install] WantedBy=hal0.target`` stanza, which only exists because
-:meth:`hal0.slots.manager.SlotManager.load` refuses to write a unit for a
-model-less slot — so ``[model].default`` was always the real signal, and
-every routability check that consulted ``enabled`` was immediately followed
-by a model-presence gate anyway.
+model**, never by a separate boolean. Boot autostart used to ride the same
+signal — the Quadlet ``[Install] WantedBy=hal0.target`` stanza existed
+whenever :meth:`hal0.slots.manager.SlotManager.load` had a model to write a
+unit for. Spec 2026-08-02 split the two: boot autostart is now the explicit,
+independently-gated ``autoload`` field — this module owns
+:func:`autoload_enabled`, the raw-dict predicate that mirrors
+``SlotConfig._derive_autoload`` (explicit key wins; an absent key falls back
+to the legacy implicit signal, a bound model, so pre-field TOMLs keep their
+boot behaviour). Activation itself is unchanged: ``[model].default`` is
+still the real routability/loadability signal, and every check that used to
+consult ``enabled`` was immediately followed by a model-presence gate
+anyway.
 
-Keeping that predicate in one place stops the ~8 call sites (routing, the
-/v1 listing helpers, the slot-view aggregator, the NPU exclusivity guard,
-the dispatcher's NPU swap tracker) from each re-deriving
+Keeping the activation predicate in one place stops the ~8 call sites
+(routing, the /v1 listing helpers, the slot-view aggregator, the NPU
+exclusivity guard, the dispatcher's NPU swap tracker) from each re-deriving
 ``(cfg.get("model") or {}).get("default")`` with subtly different
 None/whitespace handling.
 

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -416,8 +416,9 @@ class SlotManager:
         # idle_timeout_s overrides this global default.
         self._evict_after_s: float = evict_after_s
         # Pressure-eviction floor (#903): when host MemAvailable drops below
-        # this value (MiB), idle lru-eligible slots are evicted in LRU order
-        # until free RAM recovers.  0 disables pressure eviction.
+        # this value (MiB), every non-pinned resident slot is evicted in
+        # priority order (lowest `priority` first, LRU within a tier — spec
+        # 2026-08-02) until free RAM recovers.  0 disables pressure eviction.
         self._evict_pressure_mb: float = float(evict_pressure_mb)
         # §21.10 threshold_pct: when set, the pressure floor is instead
         # ``evict_pressure_pct`` percent of total GTT-aware capacity,
@@ -426,9 +427,10 @@ class SlotManager:
         # ``evict_pressure_mb`` floor above — purely additive.
         self._evict_pressure_pct: float | None = evict_pressure_pct
         # Pre-load eviction (synchronous, at admission time — see
-        # hal0.slots.preload_evict): before a load starts, free idle
-        # lru-eligible slots until the incoming model's estimated
-        # footprint + headroom fits in projected free memory, instead of
+        # hal0.slots.preload_evict): before a load starts, free idle,
+        # non-pinned resident slots (lowest `priority` first, LRU within a
+        # tier) until the incoming model's estimated footprint + headroom
+        # fits in projected free memory, instead of
         # waiting for the next pressure-sweep tick. `_preload_evict_enabled
         # = False` disables the gate entirely (reactive TTL/pressure
         # eviction still applies). `_admission_lock` serializes the
@@ -1557,7 +1559,8 @@ class SlotManager:
                 model_info = await self._resolve_model_info(resolved_model)
                 # Pre-load eviction (O26): estimate resolved_model's
                 # footprint and, if projected free memory is short, evict
-                # idle/LRU-eligible resident slots until it fits — BEFORE
+                # idle, non-pinned resident slots (lowest `priority` first,
+                # LRU within a tier) until it fits — BEFORE
                 # starting the container, not after the box is already
                 # tight. Raises PreloadEvictionFailed (caught by the
                 # except below, which stamps ERROR and re-raises) when it

--- a/src/hal0/slots/preload_evict.py
+++ b/src/hal0/slots/preload_evict.py
@@ -73,7 +73,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from hal0.slots.reaper import (
     _DEFAULT_EVICTION_PRIORITY,
-    _warn_lru_deprecated,
+    _warn_lru_retired,
     eviction_priority,
     is_pinned,
 )
@@ -297,7 +297,7 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
     pinned (:func:`is_pinned`). Every other resident slot is eligible,
     ordered by :func:`hal0.slots.reaper.eviction_priority` (lower evicts
     first); the retired ``lru = true`` TOML key is ignored and warned once
-    per slot (:func:`hal0.slots.reaper._warn_lru_deprecated`). The slot
+    per slot (:func:`hal0.slots.reaper._warn_lru_retired`). The slot
     about to be loaded is always excluded — by construction it can't be
     READY/IDLE yet (``load()`` short-circuits before this point when it
     already is), but the exclusion is explicit here too as a hard
@@ -343,7 +343,7 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
                     if is_pinned(canonical, cfg):
                         eligible, reason = False, "pinned"
                     else:
-                        _warn_lru_deprecated(canonical, cfg)
+                        _warn_lru_retired(canonical, cfg)
                         priority = eviction_priority(cfg)
 
         footprint_mb = float(per_slot.get(name, {}).get("mem_mb", 0.0) or 0.0)

--- a/src/hal0/slots/preload_evict.py
+++ b/src/hal0/slots/preload_evict.py
@@ -8,9 +8,10 @@ what's already resident — the box can OOM before the next sweep tick.
 
 This module adds the missing synchronous gate: before a slot starts, estimate
 the incoming model's footprint and, if projected free memory is short, evict
-idle/LRU-eligible resident slots — in LRU order — until it fits. It
-deliberately REUSES existing machinery rather than inventing a second,
-divergent notion of "fits" or "evictable":
+idle, non-pinned resident slots — lowest eviction ``priority`` first,
+least-recently-used as the tie-break within a tier (spec 2026-08-02) — until
+it fits. It deliberately REUSES existing machinery rather than inventing a
+second, divergent notion of "fits" or "evictable":
 
   - Footprint estimate: :func:`hal0.slots.capacity.estimate_file_size_kv_mb`
     (registry file size + coarse KV-cache estimate) — the same formula
@@ -27,10 +28,11 @@ divergent notion of "fits" or "evictable":
 Two layers, so the decision logic is unit-testable without spinning
 containers:
 
-  - :func:`select_eviction_order` is a PURE function: given an LRU-ordered
-    candidate list (with pre-computed footprint estimates) and how much is
-    needed, it decides which candidates to evict and whether the result
-    will fit. No I/O, no SlotManager.
+  - :func:`select_eviction_order` is a PURE function: given a candidate list
+    (with pre-computed footprint estimates) and how much is needed, it
+    decides which candidates to evict — sorted lowest-priority-first,
+    least-recently-used as the tie-break — and whether the result will fit.
+    No I/O, no SlotManager.
   - :func:`admit` is the async orchestrator :meth:`SlotManager.load` calls:
     gathers live candidates, calls :func:`select_eviction_order`, executes
     the plan against the real manager (real unloads, re-probing real free

--- a/src/hal0/slots/preload_evict.py
+++ b/src/hal0/slots/preload_evict.py
@@ -17,8 +17,9 @@ divergent notion of "fits" or "evictable":
     :func:`hal0.slots.capacity.build_per_slot` uses as its baseline.
   - Free-memory probe: :meth:`SlotManager._probe_host_free_mb` (GTT-aware,
     §21.10) — the same probe the pressure sweeper reads.
-  - Eviction eligibility: :func:`hal0.slots.reaper.is_pinned` + the
-    per-slot ``lru = true`` TOML flag + ``serving_count`` + state — the
+  - Eviction eligibility: :func:`hal0.slots.reaper.is_pinned` +
+    ``serving_count`` + state, ordered by
+    :func:`hal0.slots.reaper.eviction_priority` (lower evicts first) — the
     EXACT rules :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`
     already applies, just run synchronously at admission time instead of on
     a timer.
@@ -68,7 +69,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from hal0.slots.reaper import is_pinned
+from hal0.slots.reaper import _warn_lru_deprecated, eviction_priority, is_pinned
 from hal0.slots.state import (
     IllegalSlotTransition,
     SlotConfigError,
@@ -129,6 +130,7 @@ class CandidateSlot:
     footprint_mb: float
     eligible: bool
     reason: str = ""
+    priority: int = 50
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,7 +145,7 @@ class EvictionStep:
 class PreloadEvictionPlan:
     """Pure decision output of :func:`select_eviction_order`.
 
-    ``selected`` is the LRU-ordered subset of eligible candidates the
+    ``selected`` is the priority-ordered subset of eligible candidates the
     caller should evict; ``projected_free_mb`` is the ESTIMATE after
     evicting all of them (real callers re-probe after each real eviction
     rather than trusting this cumulative estimate — see :func:`admit`).
@@ -164,15 +166,16 @@ def select_eviction_order(
     headroom_mb: float,
     free_mb: float,
 ) -> PreloadEvictionPlan:
-    """Decide which candidates to evict, in LRU order, until it fits.
+    """Decide which candidates to evict, lowest priority first, until it fits.
 
     Pure: no I/O, no SlotManager. Ineligible candidates (``eligible=False``
-    — pinned, non-lru, serving, or in a non-resident state) are NEVER
-    selected regardless of how old or how large they are. Eligible
-    candidates are evicted oldest-``last_used``-first, stopping as soon as
-    the running projected free memory covers ``needed_mb + headroom_mb``,
-    matching :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`'s
-    "stop as soon as relieved" behaviour.
+    — pinned, serving, not resident, or config unavailable) are NEVER
+    selected regardless of priority. Eligible candidates are evicted
+    lowest-``priority``-first, oldest-``last_used``-first within a tier,
+    stopping as soon as the running projected free memory covers
+    ``needed_mb + headroom_mb``, matching
+    :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`'s "stop as
+    soon as relieved" behaviour.
     """
     target = needed_mb + headroom_mb
     if free_mb >= target:
@@ -185,7 +188,9 @@ def select_eviction_order(
             fits=True,
         )
 
-    eligible = sorted((c for c in candidates if c.eligible), key=lambda c: c.last_used)
+    eligible = sorted(
+        (c for c in candidates if c.eligible), key=lambda c: (c.priority, c.last_used)
+    )
     selected: list[CandidateSlot] = []
     projected = free_mb
     for candidate in eligible:
@@ -282,9 +287,12 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
 
     Eligibility mirrors :meth:`hal0.slots.reaper.SlotReaper.pressure_evict_once`
     exactly: resident state (READY/IDLE), not currently serving, not
-    pinned (:func:`is_pinned`), and ``lru = true`` in the slot's TOML. The
-    slot about to be loaded is always excluded — by construction it can't
-    be READY/IDLE yet (``load()`` short-circuits before this point when it
+    pinned (:func:`is_pinned`). Every other resident slot is eligible,
+    ordered by :func:`hal0.slots.reaper.eviction_priority` (lower evicts
+    first); the retired ``lru = true`` TOML key is ignored and warned once
+    per slot (:func:`hal0.slots.reaper._warn_lru_deprecated`). The slot
+    about to be loaded is always excluded — by construction it can't be
+    READY/IDLE yet (``load()`` short-circuits before this point when it
     already is), but the exclusion is explicit here too as a hard
     guarantee, not an accident of state timing.
     """
@@ -312,6 +320,7 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
 
         reason = ""
         eligible = True
+        priority = 50
         if host._serving_count.get(host._key(name), 0) > 0:
             eligible, reason = False, "serving"
         else:
@@ -326,8 +335,9 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
                 else:
                     if is_pinned(canonical, cfg):
                         eligible, reason = False, "pinned"
-                    elif not cfg.get("lru", False):
-                        eligible, reason = False, "not_lru"
+                    else:
+                        _warn_lru_deprecated(canonical, cfg)
+                        priority = eviction_priority(cfg)
 
         footprint_mb = float(per_slot.get(name, {}).get("mem_mb", 0.0) or 0.0)
         out.append(
@@ -337,6 +347,7 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
                 footprint_mb=footprint_mb,
                 eligible=eligible,
                 reason=reason,
+                priority=priority,
             )
         )
     return out

--- a/src/hal0/slots/preload_evict.py
+++ b/src/hal0/slots/preload_evict.py
@@ -69,7 +69,12 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from hal0.slots.reaper import _warn_lru_deprecated, eviction_priority, is_pinned
+from hal0.slots.reaper import (
+    _DEFAULT_EVICTION_PRIORITY,
+    _warn_lru_deprecated,
+    eviction_priority,
+    is_pinned,
+)
 from hal0.slots.state import (
     IllegalSlotTransition,
     SlotConfigError,
@@ -130,7 +135,7 @@ class CandidateSlot:
     footprint_mb: float
     eligible: bool
     reason: str = ""
-    priority: int = 50
+    priority: int = _DEFAULT_EVICTION_PRIORITY
 
 
 @dataclass(frozen=True, slots=True)
@@ -320,7 +325,7 @@ async def _gather_candidates(host: PreloadEvictHost, *, exclude: str) -> list[Ca
 
         reason = ""
         eligible = True
-        priority = 50
+        priority = _DEFAULT_EVICTION_PRIORITY
         if host._serving_count.get(host._key(name), 0) > 0:
             eligible, reason = False, "serving"
         else:

--- a/src/hal0/slots/reaper.py
+++ b/src/hal0/slots/reaper.py
@@ -128,7 +128,7 @@ def eviction_priority(cfg: dict[str, Any] | None) -> int:
 _lru_flag_warned: set[str] = set()
 
 
-def _warn_lru_deprecated(canonical_name: str, cfg: dict[str, Any] | None) -> None:
+def _warn_lru_retired(canonical_name: str, cfg: dict[str, Any] | None) -> None:
     """One-shot deprecation warning for the retired ``lru`` TOML key.
 
     The key is IGNORED (never an error): eviction eligibility is now
@@ -141,7 +141,7 @@ def _warn_lru_deprecated(canonical_name: str, cfg: dict[str, Any] | None) -> Non
         return
     _lru_flag_warned.add(canonical_name)
     log.warning(
-        "slot.lru_flag_deprecated",
+        "slot.lru_flag_retired",
         extra={
             "slot": canonical_name,
             "hint": "lru is ignored; eviction order is priority (0-100, "
@@ -447,7 +447,7 @@ class SlotReaper:
             regardless of its priority.
           - Every other resident slot is a candidate. The retired ``lru =
             true`` opt-in no longer gates eligibility — the key is
-            ignored (:func:`_warn_lru_deprecated` logs it once per slot).
+            ignored (:func:`_warn_lru_retired` logs it once per slot).
         """
         host = self._host
         floor = host._evict_pressure_mb
@@ -483,7 +483,7 @@ class SlotReaper:
                 continue
             if is_pinned(canonical, cfg):
                 continue
-            _warn_lru_deprecated(canonical, cfg)
+            _warn_lru_retired(canonical, cfg)
             candidates.append((eviction_priority(cfg), ts, slot_name))
 
         candidates.sort(key=lambda item: (item[0], item[1]))
@@ -529,7 +529,7 @@ __all__ = [
     "_PINNED_BY_DEFAULT",
     "ReaperHost",
     "SlotReaper",
-    "_warn_lru_deprecated",
+    "_warn_lru_retired",
     "eviction_priority",
     "is_pinned",
     "probe_host_free_mb",

--- a/src/hal0/slots/reaper.py
+++ b/src/hal0/slots/reaper.py
@@ -125,6 +125,31 @@ def eviction_priority(cfg: dict[str, Any] | None) -> int:
     return max(0, min(100, raw))
 
 
+_lru_flag_warned: set[str] = set()
+
+
+def _warn_lru_deprecated(canonical_name: str, cfg: dict[str, Any] | None) -> None:
+    """One-shot deprecation warning for the retired ``lru`` TOML key.
+
+    The key is IGNORED (never an error): eviction eligibility is now
+    priority-ordered for every non-pinned slot (spec 2026-08-02). Warned
+    once per slot per process so a 30 s sweep doesn't spam the journal.
+    """
+    if not isinstance(cfg, dict) or cfg.get("lru") is None:
+        return
+    if canonical_name in _lru_flag_warned:
+        return
+    _lru_flag_warned.add(canonical_name)
+    log.warning(
+        "slot.lru_flag_deprecated",
+        extra={
+            "slot": canonical_name,
+            "hint": "lru is ignored; eviction order is priority (0-100, "
+            "lower first) — remove the key, use `priority`/`pinned`",
+        },
+    )
+
+
 def probe_host_free_mb() -> float:
     """Return free host memory in MiB, GTT-aware where possible (§21.10).
 
@@ -406,10 +431,11 @@ class SlotReaper:
         ``host._probe_host_free_mb()``). The floor is either the absolute
         ``_evict_pressure_mb`` (default) or, when ``_evict_pressure_pct``
         is set, that percentage of total capacity (``threshold_pct``,
-        §21.10). When free RAM is below the floor, evicts idle,
-        ``lru``-eligible, unpinned slots one at a time in
-        least-recently-used order (oldest ``last_used`` first) until free
-        RAM is back above the floor or no more eligible slots remain.
+        §21.10). When free RAM is below the floor, evicts idle, unpinned
+        slots one at a time in priority order — lowest ``eviction_priority``
+        first, oldest ``last_used`` as the tie-break within a priority tier
+        (spec 2026-08-02) — until free RAM is back above the floor or no
+        more eligible slots remain.
 
         Guards:
           - floor <= 0 → pressure eviction is disabled.
@@ -417,8 +443,11 @@ class SlotReaper:
             evicted.
           - A pinned slot (:func:`is_pinned`: the canonical ``agent``
             anchor and other default-pinned names, or any slot with
-            ``SlotConfig.pinned = true``) is never evicted by pressure.
-          - Only slots with ``lru = true`` in their TOML are eligible.
+            ``SlotConfig.pinned = true``) is never evicted by pressure,
+            regardless of its priority.
+          - Every other resident slot is a candidate. The retired ``lru =
+            true`` opt-in no longer gates eligibility — the key is
+            ignored (:func:`_warn_lru_deprecated` logs it once per slot).
         """
         host = self._host
         floor = host._evict_pressure_mb
@@ -433,11 +462,14 @@ class SlotReaper:
         if free_mb >= floor:
             return
 
-        # Build the LRU-ordered candidate list. sweep_candidates() unions
-        # _last_used with dispatchable slots known only via state.json
-        # (adopted / restart-surviving), timestamped by their last observed
-        # transition, so pressure eviction can also reclaim those.
-        candidates: list[tuple[float, str]] = []
+        # Build the victim list ordered (priority asc, last_used asc):
+        # lowest priority first, LRU within a tier (spec 2026-08-02).
+        # sweep_candidates() unions _last_used with dispatchable slots known
+        # only via state.json (adopted / restart-surviving), timestamped by
+        # their last observed transition, so pressure eviction can also
+        # reclaim those. The retired ``lru = true`` opt-in no longer gates —
+        # every non-pinned resident slot is a candidate.
+        candidates: list[tuple[int, float, str]] = []
         for slot_name, ts in self.sweep_candidates().items():
             if host._serving_count.get(host._key(slot_name), 0) > 0:
                 continue
@@ -445,20 +477,17 @@ class SlotReaper:
             state = host._current_state(slot_name)
             if state not in (SlotState.READY, SlotState.IDLE):
                 continue
-            # Read cfg once — used for both the pin check and the lru flag.
             try:
                 cfg = await host._load_slot_config(slot_name)
             except (SlotConfigError, SlotNotFound):
                 continue
             if is_pinned(canonical, cfg):
                 continue
-            if not cfg.get("lru", False):
-                continue
-            candidates.append((ts, slot_name))
+            _warn_lru_deprecated(canonical, cfg)
+            candidates.append((eviction_priority(cfg), ts, slot_name))
 
-        # Evict oldest-first until pressure is relieved or list is exhausted.
-        candidates.sort(key=lambda pair: pair[0])
-        for _ts, slot_name in candidates:
+        candidates.sort(key=lambda item: (item[0], item[1]))
+        for _prio, _ts, slot_name in candidates:
             # Re-check serving guard and state — may have changed since
             # the list was built (another coroutine may have started a
             # request or the TTL sweep may have evicted it already).
@@ -500,6 +529,7 @@ __all__ = [
     "_PINNED_BY_DEFAULT",
     "ReaperHost",
     "SlotReaper",
+    "_warn_lru_deprecated",
     "eviction_priority",
     "is_pinned",
     "probe_host_free_mb",

--- a/src/hal0/slots/reaper.py
+++ b/src/hal0/slots/reaper.py
@@ -104,6 +104,27 @@ def is_pinned(canonical_name: str, cfg: dict[str, Any] | None) -> bool:
     return canonical_name in _PINNED_BY_DEFAULT
 
 
+_DEFAULT_EVICTION_PRIORITY: int = 50
+
+
+def eviction_priority(cfg: dict[str, Any] | None) -> int:
+    """Effective eviction priority for a RAW slot TOML dict (0-100).
+
+    Lower evicts first; ties fall back to LRU order at the call sites.
+    Defensive by design — the sweep must never crash on a hand-authored
+    TOML: a missing/bool/non-int value falls back to the default and an
+    out-of-range int is clamped. The pydantic paths (SlotConfig ge/le)
+    hard-reject instead; this is the fail-open mirror, same contract as
+    :func:`is_pinned` reading the raw dict.
+    """
+    if not isinstance(cfg, dict):
+        return _DEFAULT_EVICTION_PRIORITY
+    raw = cfg.get("priority")
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        return _DEFAULT_EVICTION_PRIORITY
+    return max(0, min(100, raw))
+
+
 def probe_host_free_mb() -> float:
     """Return free host memory in MiB, GTT-aware where possible (§21.10).
 
@@ -472,12 +493,14 @@ class SlotReaper:
 
 
 __all__ = [
+    "_DEFAULT_EVICTION_PRIORITY",
     "_EVICT_AFTER_S",
     "_IDLE_AFTER_S",
     "_IDLE_MONITOR_INTERVAL_S",
     "_PINNED_BY_DEFAULT",
     "ReaperHost",
     "SlotReaper",
+    "eviction_priority",
     "is_pinned",
     "probe_host_free_mb",
     "probe_host_total_mb",

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -535,6 +535,30 @@ def test_create_slot_rejects_model_owned_keys(
     assert not (slot_root / "owned.toml").exists()
 
 
+def test_create_slot_without_autoload_persists_explicit_false(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """POST /api/slots with no ``autoload`` key persists an explicit False.
+
+    Spec 2026-08-02: new slots never inherit the legacy implicit boot start
+    — the absent-key migration shim (bound model → true) is for pre-field
+    TOMLs only. A freshly created slot must not silently boot-start just
+    because it has a model bound.
+    """
+    body = {
+        "name": "fresh",
+        "model": "qwen3-4b-q4_k_m",
+        "device": "gpu-vulkan",
+        "profile": "vulkan-radv",
+    }
+    r = isolated_client.post("/api/slots", json=body)
+    assert r.status_code == 201, r.text
+    cfg = isolated_client.get("/api/slots/fresh/config").json()
+    assert cfg.get("autoload") is False
+
+
 @pytest.mark.parametrize("key", ["mtp", "enable_thinking", "vision"])
 def test_patch_defaults_rejects_model_owned_keys_with_the_right_message(
     key: str,

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -815,6 +815,29 @@ def test_put_config_priority_out_of_range_rejected(
     assert resp.json()["error"]["code"] == "validation.invalid_value"
 
 
+def test_create_slot_priority_out_of_range_rejected(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    """POST /api/slots refuses an out-of-range priority the same way PUT
+    /config does (test_put_config_priority_out_of_range_rejected above) —
+    the create path runs the same `_validate_autoload_priority` guard, so a
+    bad value must 400 before the slot TOML is ever written, not persist and
+    get silently clamped forever by the eviction helper."""
+    body = {
+        "name": "badprio",
+        "model": "qwen3-4b-q4_k_m",
+        "device": "gpu-vulkan",
+        "profile": "vulkan-radv",
+        "priority": 101,
+    }
+    r = isolated_client.post("/api/slots", json=body)
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "validation.invalid_value"
+    assert not (slot_root / "badprio.toml").exists()
+
+
 def test_put_config_autoload_must_be_bool(
     slot_root: Path,
     container_stub: dict[str, Any],

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -738,6 +738,69 @@ def test_put_config_pinned_round_trips(
     assert cfg.get("pinned") is False
 
 
+# ── autoload/priority (spec-2026-08-02): unit rerender + value validation ───
+
+
+def test_put_config_autoload_triggers_unit_rerender(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PUT {autoload: false} rewrites the on-disk Quadlet unit immediately —
+    otherwise a reboot before the next load still boot-starts the slot."""
+    from hal0.api.routes import slots as slots_routes
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        slots_routes, "_rerender_slot_unit_best_effort", lambda cfg: calls.append(cfg)
+    )
+    resp = isolated_client.put("/api/slots/chat/config", json={"autoload": False})
+    assert resp.status_code == 200, resp.text
+    assert len(calls) == 1
+
+
+def test_put_config_priority_skips_unit_rerender(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hal0.api.routes import slots as slots_routes
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        slots_routes, "_rerender_slot_unit_best_effort", lambda cfg: calls.append(cfg)
+    )
+    resp = isolated_client.put("/api/slots/chat/config", json={"priority": 10})
+    assert resp.status_code == 200, resp.text
+    assert calls == []
+    cfg = isolated_client.get("/api/slots/chat/config").json()
+    assert cfg.get("priority") == 10
+
+
+@pytest.mark.parametrize("bad", [-1, 101, "high", 3.5, True])
+def test_put_config_priority_out_of_range_rejected(
+    bad: object,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    resp = isolated_client.put("/api/slots/chat/config", json={"priority": bad})
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "validation.invalid_value"
+
+
+def test_put_config_autoload_must_be_bool(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+) -> None:
+    resp = isolated_client.put("/api/slots/chat/config", json={"autoload": "yes"})
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"]["code"] == "validation.invalid_value"
+
+
 def test_binding_a_second_npu_model_surfaces_conflict(
     tmp_hal0_home: str,
     container_stub: dict[str, Any],

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -77,6 +77,7 @@ def _render_llama(
     extra_args=None,
     model_alias=None,
     publish_host="127.0.0.1",
+    autoload=True,
 ):
     """Test shim mirroring the deleted ``_render_unit`` scalar shim, producing
     Quadlet text: build the llama launch plan, then render it.
@@ -107,7 +108,7 @@ def _render_llama(
         model_alias=model_alias,
         model_defaults={"extra_args": merged_tune} if merged_tune else None,
     )
-    return _render_quadlet_from_plan(token, plan, publish_host=publish_host)
+    return _render_quadlet_from_plan(token, plan, publish_host=publish_host, autoload=autoload)
 
 
 def _exec_line(unit_text: str) -> str:
@@ -525,6 +526,33 @@ class TestRenderUnit:
         assert "[Service]" in unit
         assert "[Install]" in unit
         # Quadlet owns crash recovery now (was the hand-rendered Restart=no).
+        assert "Restart=always" in unit.splitlines()
+
+    def test_install_stanza_present_by_default(self) -> None:
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama("test-slot", _TEST_IMAGE, 8095, "/mnt/ai-models/model.gguf", flags)
+        assert "[Install]" in unit
+        assert "WantedBy=hal0.target" in unit.splitlines()
+
+    def test_autoload_false_omits_install_stanza(self) -> None:
+        """autoload=false → no [Install] → nothing boot-starts the slot.
+
+        The unit must remain manually startable: [Service]/Restart survive.
+        """
+        profile = _moe_profile()
+        flags = resolve_profile_flags(profile)
+        unit = _render_llama(
+            "test-slot",
+            _TEST_IMAGE,
+            8095,
+            "/mnt/ai-models/model.gguf",
+            flags,
+            autoload=False,
+        )
+        assert "[Install]" not in unit
+        assert "WantedBy=hal0.target" not in unit
+        assert "[Service]" in unit
         assert "Restart=always" in unit.splitlines()
 
     def test_startlimit_keys_land_in_unit_section_not_service(self) -> None:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -270,6 +270,22 @@ class TestConfigEnrichment:
         out = config_enrichment([_llm_cfg(device="gpu-vulkan")])
         assert out["chat"]["declared_backend"] == "vulkan"
 
+    def test_lifts_autoload_and_priority(self) -> None:
+        """Effective autoload (shim: bound model + no key → true) and priority
+        are lifted so the drawer renders without a per-slot /config fetch."""
+        out = config_enrichment(
+            [
+                # cfg A: bound model, no autoload/priority keys → shim defaults.
+                _llm_cfg(),
+                # cfg B: explicit keys win.
+                _llm_cfg(name="b", autoload=False, priority=10),
+            ],
+        )
+        assert out["chat"]["autoload"] is True
+        assert out["chat"]["priority"] == 50
+        assert out["b"]["autoload"] is False
+        assert out["b"]["priority"] == 10
+
     def test_coresident_group_for_npu_trio(self) -> None:
         configs = [
             _llm_cfg(name="agent", device="npu"),

--- a/tests/slots/test_adopted_slot_eviction.py
+++ b/tests/slots/test_adopted_slot_eviction.py
@@ -100,7 +100,9 @@ async def test_pressure_sweep_sees_slot_missing_from_last_used(
     container_stub: FakeContainerProvider,
     monkeypatch,
 ) -> None:
-    """Pressure eviction reclaims an lru slot known only via state.json."""
+    """Pressure eviction reclaims a non-pinned slot known only via
+    state.json. `lru = true` in the TOML confirms the retired key is
+    tolerated (and ignored) rather than required for eligibility."""
     (slot_root / "chat.toml").write_text(
         "\n".join(
             [

--- a/tests/slots/test_autoload_priority.py
+++ b/tests/slots/test_autoload_priority.py
@@ -1,0 +1,81 @@
+"""Slot autoload + eviction-priority field semantics (spec 2026-08-02)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hal0.config.schema import SlotConfig
+from hal0.slots.activation import autoload_enabled
+from hal0.slots.reaper import eviction_priority
+
+
+def _cfg(**kw) -> SlotConfig:
+    base: dict = {"name": "s1", "port": 8090}
+    base.update(kw)
+    return SlotConfig(**base)
+
+
+class TestSlotConfigAutoload:
+    def test_default_false_without_model(self) -> None:
+        assert _cfg().autoload is False
+
+    def test_derives_true_from_bound_model(self) -> None:
+        # Migration shim: legacy TOML (no autoload key) with a bound model
+        # keeps its implicit boot start.
+        assert _cfg(model={"default": "qwen3"}).autoload is True
+
+    def test_explicit_false_wins_over_bound_model(self) -> None:
+        assert _cfg(model={"default": "qwen3"}, autoload=False).autoload is False
+
+    def test_explicit_true_without_model(self) -> None:
+        assert _cfg(autoload=True).autoload is True
+
+
+class TestSlotConfigPriority:
+    def test_default_50(self) -> None:
+        assert _cfg().priority == 50
+
+    @pytest.mark.parametrize("value", [0, 100])
+    def test_bounds_accepted(self, value: int) -> None:
+        assert _cfg(priority=value).priority == value
+
+    @pytest.mark.parametrize("value", [-1, 101])
+    def test_out_of_range_rejected(self, value: int) -> None:
+        with pytest.raises(ValidationError):
+            _cfg(priority=value)
+
+
+class TestAutoloadEnabledRawDict:
+    def test_none_and_empty(self) -> None:
+        assert autoload_enabled(None) is False
+        assert autoload_enabled({}) is False
+
+    def test_legacy_bound_model_derives_true(self) -> None:
+        assert autoload_enabled({"model": {"default": "qwen3"}}) is True
+
+    def test_explicit_false_wins(self) -> None:
+        assert autoload_enabled({"autoload": False, "model": {"default": "qwen3"}}) is False
+
+    def test_explicit_true_without_model(self) -> None:
+        assert autoload_enabled({"autoload": True}) is True
+
+    def test_model_without_default_is_false(self) -> None:
+        assert autoload_enabled({"model": {}}) is False
+
+
+class TestEvictionPriorityRawDict:
+    def test_default_on_missing(self) -> None:
+        assert eviction_priority(None) == 50
+        assert eviction_priority({}) == 50
+
+    def test_reads_value(self) -> None:
+        assert eviction_priority({"priority": 10}) == 10
+
+    @pytest.mark.parametrize("bad", [True, "10", 3.5, None])
+    def test_non_int_falls_back(self, bad) -> None:
+        assert eviction_priority({"priority": bad}) == 50
+
+    def test_clamps(self) -> None:
+        assert eviction_priority({"priority": -5}) == 0
+        assert eviction_priority({"priority": 999}) == 100

--- a/tests/slots/test_preload_eviction.py
+++ b/tests/slots/test_preload_eviction.py
@@ -19,14 +19,33 @@ from typing import Any
 
 import pytest
 
+from hal0.slots import reaper
 from hal0.slots.manager import SlotManager
 from hal0.slots.preload_evict import (
     CandidateSlot,
     PreloadEvictionFailed,
+    _gather_candidates,
     select_eviction_order,
 )
 from hal0.slots.state import SlotState
 from tests.slots.conftest import FakeContainerProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_lru_deprecation_state() -> None:
+    """``reaper._lru_flag_warned`` is module-level, one-shot-per-process.
+
+    Shared with ``hal0.slots.reaper`` (see
+    ``tests/slots/test_pressure_eviction.py``'s identical fixture) — this
+    file writes slots with a bare/omitted ``lru`` key too, so without a
+    reset whichever test runs first (in this file OR the reaper test file,
+    same pytest process) would "use up" the one-shot warning for everyone
+    after it.
+    """
+    reaper._lru_flag_warned.clear()
+    yield
+    reaper._lru_flag_warned.clear()
+
 
 # ── pure planner: select_eviction_order() ────────────────────────────────────
 
@@ -93,18 +112,84 @@ def test_select_insufficient_when_only_ineligible_candidates_exist() -> None:
     assert plan.fits is False
 
 
+def test_select_orders_by_priority_then_lru() -> None:
+    """priority beats recency: an old high-priority slot survives while a
+    newer low-priority one is selected first."""
+    cands = [
+        CandidateSlot(name="hi", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=90),
+        CandidateSlot(name="lo-new", last_used=900.0, footprint_mb=4000.0, eligible=True, priority=10),
+        CandidateSlot(name="lo-old", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=10),
+    ]
+    plan = select_eviction_order(cands, needed_mb=7000.0, headroom_mb=1000.0, free_mb=0.0)
+    assert [c.name for c in plan.selected] == ["lo-old", "lo-new"]
+    assert plan.fits is True
+
+
+def test_select_ineligible_never_selected_regardless_of_priority() -> None:
+    cands = [
+        CandidateSlot(name="pinned", last_used=1.0, footprint_mb=9000.0, eligible=False,
+                      reason="pinned", priority=0),
+        CandidateSlot(name="ok", last_used=2.0, footprint_mb=9000.0, eligible=True, priority=100),
+    ]
+    plan = select_eviction_order(cands, needed_mb=8000.0, headroom_mb=0.0, free_mb=0.0)
+    assert [c.name for c in plan.selected] == ["ok"]
+
+
+# ── _gather_candidates() ──────────────────────────────────────────────────────
+
+
+async def test_gather_candidates_no_lru_key_is_eligible_with_priority(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+) -> None:
+    """A slot with no ``lru`` key at all is eligible, priority read from
+    cfg (was ``eligible=False, reason="not_lru"`` before the priority
+    rework — the retired key no longer gates eligibility)."""
+    _write_slot(slot_root, "rerank", port=8090, priority=30)
+    sm = SlotManager()
+    await sm.load("rerank")
+
+    candidates = await _gather_candidates(sm, exclude="chat")
+
+    assert len(candidates) == 1
+    cand = candidates[0]
+    assert cand.name == "rerank"
+    assert cand.eligible is True
+    assert cand.reason == ""
+    assert cand.priority == 30
+
+
 # ── SlotManager.load() integration ───────────────────────────────────────────
 
 
-def _write_slot(root: Path, name: str, *, port: int, lru: bool = False) -> None:
+def _write_slot(
+    root: Path,
+    name: str,
+    *,
+    port: int,
+    lru: bool | None = None,
+    priority: int | None = None,
+    pinned: bool | None = None,
+) -> None:
+    """Write a minimal slot TOML.
+
+    ``lru`` is the retired opt-in key — pass it to prove it's
+    read-but-ignored; omit it (default) to match a freshly authored TOML
+    that never had it. ``priority``/``pinned`` map directly to the current
+    eviction-order fields (mirrors ``test_pressure_eviction.py``'s helper).
+    """
     lines = [
         f'name = "{name}"',
         f"port = {port}",
         'backend = "vulkan"',
         'provider = "llama-server"',
     ]
-    if lru:
-        lines.append("lru = true")
+    if lru is not None:
+        lines.append(f"lru = {'true' if lru else 'false'}")
+    if priority is not None:
+        lines.append(f"priority = {priority}")
+    if pinned is not None:
+        lines.append(f"pinned = {'true' if pinned else 'false'}")
     lines += ["[model]", 'default = "qwen3-4b-q4_k_m"', ""]
     (root / f"{name}.toml").write_text("\n".join(lines), encoding="utf-8")
 
@@ -149,10 +234,10 @@ async def test_load_fails_clearly_when_nothing_fits(
     container_stub: FakeContainerProvider,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No eligible (non-lru) candidate exists: the load fails with a clear,
-    actionable error — nothing half-loaded, and the resident slot (not
-    lru-eligible, so never a candidate) is left completely untouched."""
-    _write_slot(slot_root, "rerank", port=8090, lru=False)
+    """No eligible candidate exists: the load fails with a clear,
+    actionable error — nothing half-loaded, and the resident slot (pinned,
+    so never a candidate) is left completely untouched."""
+    _write_slot(slot_root, "rerank", port=8090, pinned=True)
     sm = SlotManager(preload_evict_headroom_mb=0.0)
     await sm.load("rerank")
 

--- a/tests/slots/test_preload_eviction.py
+++ b/tests/slots/test_preload_eviction.py
@@ -88,8 +88,8 @@ def test_select_cannot_fit_reports_shortfall() -> None:
 
 
 def test_select_never_evicts_ineligible_candidates() -> None:
-    """A pinned/non-lru/serving candidate is never selected — even when it
-    is the oldest AND the largest — because the planner itself enforces
+    """A pinned/serving/not-resident candidate is never selected — even when
+    it is the oldest AND the largest — because the planner itself enforces
     eligibility, not just whatever gathered the candidate list."""
     candidates = [
         CandidateSlot(
@@ -208,13 +208,15 @@ async def test_load_evicts_idle_lru_slot_to_make_room(
     container_stub: FakeContainerProvider,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A load that wouldn't otherwise fit evicts the idle lru-eligible slot
-    first, then proceeds — no reactive-only wait for the pressure sweeper."""
+    """A load that wouldn't otherwise fit evicts the idle, non-pinned
+    resident slot first, then proceeds — no reactive-only wait for the
+    pressure sweeper. `lru=True` is set on both slots to confirm the
+    retired key is tolerated (and ignored) rather than required."""
     _write_slot(slot_root, "rerank", port=8090, lru=True)
     _write_slot(slot_root, "embed", port=8091, lru=True)
     sm = SlotManager(preload_evict_headroom_mb=0.0)
     await sm.load("rerank")
-    sm._last_used[sm._key("rerank")] = 0.0  # idle long enough to be lru-eligible
+    sm._last_used[sm._key("rerank")] = 0.0  # idle long enough to be evicted
 
     monkeypatch.setattr(sm, "_resolve_model_info", _stub_model_info(4000.0))
     free_readings = [1000.0, 6000.0]  # short before eviction, plenty after

--- a/tests/slots/test_preload_eviction.py
+++ b/tests/slots/test_preload_eviction.py
@@ -117,8 +117,12 @@ def test_select_orders_by_priority_then_lru() -> None:
     newer low-priority one is selected first."""
     cands = [
         CandidateSlot(name="hi", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=90),
-        CandidateSlot(name="lo-new", last_used=900.0, footprint_mb=4000.0, eligible=True, priority=10),
-        CandidateSlot(name="lo-old", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=10),
+        CandidateSlot(
+            name="lo-new", last_used=900.0, footprint_mb=4000.0, eligible=True, priority=10
+        ),
+        CandidateSlot(
+            name="lo-old", last_used=100.0, footprint_mb=4000.0, eligible=True, priority=10
+        ),
     ]
     plan = select_eviction_order(cands, needed_mb=7000.0, headroom_mb=1000.0, free_mb=0.0)
     assert [c.name for c in plan.selected] == ["lo-old", "lo-new"]
@@ -127,8 +131,14 @@ def test_select_orders_by_priority_then_lru() -> None:
 
 def test_select_ineligible_never_selected_regardless_of_priority() -> None:
     cands = [
-        CandidateSlot(name="pinned", last_used=1.0, footprint_mb=9000.0, eligible=False,
-                      reason="pinned", priority=0),
+        CandidateSlot(
+            name="pinned",
+            last_used=1.0,
+            footprint_mb=9000.0,
+            eligible=False,
+            reason="pinned",
+            priority=0,
+        ),
         CandidateSlot(name="ok", last_used=2.0, footprint_mb=9000.0, eligible=True, priority=100),
     ]
     plan = select_eviction_order(cands, needed_mb=8000.0, headroom_mb=0.0, free_mb=0.0)

--- a/tests/slots/test_pressure_eviction.py
+++ b/tests/slots/test_pressure_eviction.py
@@ -1,14 +1,17 @@
-"""Tests for host-memory-pressure LRU eviction (#903).
+"""Tests for host-memory-pressure eviction (#903, priority-order spec 2026-08-02).
 
 Covers _pressure_evict_once() and its integration with the idle monitor:
 
-  - Under-floor free RAM triggers LRU-ordered eviction until RAM ≥ floor.
-  - Non-lru slots are skipped (allow-list gate).
-  - The canonical ``agent`` slot is never evicted even under pressure.
+  - Under-floor free RAM triggers priority-ordered eviction (lowest
+    ``priority`` first, LRU tie-break within a tier) until RAM ≥ floor.
+  - Every non-pinned resident slot is a candidate — the retired ``lru =
+    true`` opt-in gate no longer restricts eligibility; the key is
+    ignored (deprecation-warned once per slot per process).
+  - The canonical ``agent`` slot, and any ``pinned = true`` slot
+    regardless of priority, are never evicted even under pressure.
   - A slot serving a request is never evicted even under pressure.
   - Above-floor free RAM is a no-op (no eviction).
   - evict_pressure_mb = 0 disables pressure eviction entirely.
-  - The LRU ordering evicts oldest last_used first.
 
 The host-free-RAM probe (_probe_host_free_mb) is monkeypatched in every
 test — no real /proc/meminfo reads occur.
@@ -16,10 +19,12 @@ test — no real /proc/meminfo reads occur.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
+from hal0.slots import reaper
 from hal0.slots.manager import SlotManager
 from hal0.slots.state import SlotState
 from tests.slots.conftest import FakeContainerProvider
@@ -32,17 +37,29 @@ def _write_slot(
     name: str,
     *,
     port: int,
-    lru: bool = False,
+    lru: bool | None = None,
+    priority: int | None = None,
+    pinned: bool | None = None,
 ) -> None:
-    """Write a minimal slot TOML, optionally marking it lru-eligible."""
+    """Write a minimal slot TOML.
+
+    ``lru`` is the retired opt-in key — pass it (True or False) to prove
+    it's read-but-ignored; leave it ``None`` to omit it entirely, matching
+    a freshly authored TOML that never had it. ``priority``/``pinned`` map
+    directly to the current eviction-order fields.
+    """
     lines = [
         f'name = "{name}"',
         f"port = {port}",
         'backend = "vulkan"',
         'provider = "llama-server"',
     ]
-    if lru:
-        lines.append("lru = true")
+    if lru is not None:
+        lines.append(f"lru = {'true' if lru else 'false'}")
+    if priority is not None:
+        lines.append(f"priority = {priority}")
+    if pinned is not None:
+        lines.append(f"pinned = {'true' if pinned else 'false'}")
     lines += ["[model]", 'default = "qwen3-4b-q4_k_m"', ""]
     (root / f"{name}.toml").write_text("\n".join(lines), encoding="utf-8")
 
@@ -50,6 +67,20 @@ def _write_slot(
 def _patch_free_mb(monkeypatch: pytest.MonkeyPatch, sm: SlotManager, value: float) -> None:
     """Monkeypatch _probe_host_free_mb to return a fixed value."""
     monkeypatch.setattr(sm, "_probe_host_free_mb", lambda: value)
+
+
+@pytest.fixture(autouse=True)
+def _reset_lru_deprecation_state() -> None:
+    """``reaper._lru_flag_warned`` is module-level, one-shot-per-process.
+
+    Several tests in this file reuse slot names (``rerank``, etc.) and
+    assert on the deprecation warning's fire-once behavior — without a
+    reset, whichever test runs first would "use up" the warning for every
+    test after it in the same pytest process.
+    """
+    reaper._lru_flag_warned.clear()
+    yield
+    reaper._lru_flag_warned.clear()
 
 
 # ── above-floor: no-op ────────────────────────────────────────────────────────
@@ -96,26 +127,27 @@ async def test_pressure_evict_disabled_when_floor_is_zero(
     assert not container_stub.unload_calls
 
 
-# ── allow-list: non-lru slots skipped ────────────────────────────────────────
+# ── lru gate retired: every non-pinned slot is now evictable ────────────────
 
 
-async def test_pressure_evict_skips_non_lru_slot(
+async def test_non_lru_slot_now_evictable_priority_order(
     slot_root: Path,
     container_stub: FakeContainerProvider,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A slot without lru=true in its TOML is never evicted under pressure."""
-    _write_slot(slot_root, "rerank", port=8090, lru=False)  # NOT lru-eligible
+    """A slot with no ``lru`` key at all is evictable under pressure (spec
+    2026-08-02): eligibility is priority-ordered, not lru-opt-in gated."""
+    _write_slot(slot_root, "rerank", port=8090)  # no lru key, no priority override
     sm = SlotManager(evict_pressure_mb=8192.0)
     await sm.load("rerank")
     sm._last_used[sm._key("rerank")] = 0.0
 
-    # Free RAM well below floor → pressure fires, but rerank lacks lru=true.
+    # Free RAM well below floor → pressure fires and rerank is now eligible.
     _patch_free_mb(monkeypatch, sm, 512.0)
     await sm._pressure_evict_once()
 
-    assert (await sm.status("rerank")).state in (SlotState.READY, SlotState.IDLE)
-    assert not container_stub.unload_calls
+    assert (await sm.status("rerank")).state == SlotState.OFFLINE
+    assert any(c.get("name") == "rerank" for c in container_stub.unload_calls)
 
 
 # ── agent never evicted ───────────────────────────────────────────────────────
@@ -299,3 +331,130 @@ async def test_pressure_evict_stops_when_floor_met(
     assert states["stt"] == SlotState.OFFLINE
     assert states["embed"] in (SlotState.READY, SlotState.IDLE)
     assert states["rerank"] in (SlotState.READY, SlotState.IDLE)
+
+
+# ── priority ordering (spec 2026-08-02) ──────────────────────────────────────
+
+
+async def test_pressure_evicts_lowest_priority_first(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three resident slots, equal idle age, priorities 10/50/90 → eviction
+    order is the priority order, not LRU."""
+    _write_slot(slot_root, "cheap", port=8090, priority=10)
+    _write_slot(slot_root, "mid", port=8091, priority=50)
+    _write_slot(slot_root, "keeper", port=8092, priority=90)
+    sm = SlotManager(evict_pressure_mb=4096.0)
+    for name in ("cheap", "mid", "keeper"):
+        await sm.load(name)
+        sm._last_used[sm._key(name)] = 1000.0  # identical idle age
+
+    evicted: list[str] = []
+    original_unload = sm.unload
+
+    async def _tracking_unload(name: str) -> object:
+        evicted.append(name)
+        return await original_unload(name)
+
+    call_count = 0
+
+    def _probe() -> float:
+        nonlocal call_count
+        call_count += 1
+        # Under floor until two evictions have happened, then relieved.
+        return 512.0 if call_count <= 2 else 8192.0
+
+    monkeypatch.setattr(sm, "_probe_host_free_mb", _probe)
+    monkeypatch.setattr(sm, "unload", _tracking_unload)
+
+    await sm._pressure_evict_once()
+
+    assert evicted == ["cheap", "mid"], f"expected priority order cheap,mid; got {evicted}"
+    assert (await sm.status("keeper")).state == SlotState.READY
+    assert not any(c.get("name") == "keeper" for c in container_stub.unload_calls)
+
+
+async def test_pressure_priority_tie_breaks_lru(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equal priority → oldest last_used evicted first (LRU tie-break kept
+    within a priority tier)."""
+    _write_slot(slot_root, "rerank", port=8090, priority=50)
+    _write_slot(slot_root, "embed", port=8091, priority=50)
+    sm = SlotManager(evict_pressure_mb=4096.0)
+    await sm.load("rerank")
+    await sm.load("embed")
+    sm._last_used[sm._key("rerank")] = 1000.0  # newer
+    sm._last_used[sm._key("embed")] = 100.0  # older → evicted first
+
+    evicted: list[str] = []
+    original_unload = sm.unload
+
+    async def _tracking_unload(name: str) -> object:
+        evicted.append(name)
+        return await original_unload(name)
+
+    call_count = 0
+
+    def _probe() -> float:
+        nonlocal call_count
+        call_count += 1
+        return 512.0 if call_count == 1 else 8192.0
+
+    monkeypatch.setattr(sm, "_probe_host_free_mb", _probe)
+    monkeypatch.setattr(sm, "unload", _tracking_unload)
+
+    await sm._pressure_evict_once()
+
+    assert evicted == ["embed"], f"oldest within the tied priority tier evicts first; got {evicted}"
+
+
+async def test_pressure_skips_pinned_regardless_of_priority(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pinned=true + priority=0 is still never evicted."""
+    _write_slot(slot_root, "rerank", port=8090, priority=0, pinned=True)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+    sm._last_used[sm._key("rerank")] = 0.0  # ancient AND lowest priority
+
+    _patch_free_mb(monkeypatch, sm, 512.0)  # well below floor
+    await sm._pressure_evict_once()
+
+    assert (await sm.status("rerank")).state in (SlotState.READY, SlotState.IDLE)
+    assert not container_stub.unload_calls
+
+
+async def test_lru_key_ignored_and_warned_once(
+    slot_root: Path,
+    container_stub: FakeContainerProvider,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A cfg carrying lru=false is evictable anyway; slot.lru_flag_deprecated
+    is logged exactly once across two sweeps (one-shot per slot per process)."""
+    _write_slot(slot_root, "rerank", port=8090, lru=False)
+    sm = SlotManager(evict_pressure_mb=8192.0)
+    await sm.load("rerank")
+    sm._last_used[sm._key("rerank")] = 0.0
+
+    _patch_free_mb(monkeypatch, sm, 512.0)
+    with caplog.at_level(logging.WARNING, logger="hal0.slots.reaper"):
+        await sm._pressure_evict_once()
+        assert (await sm.status("rerank")).state == SlotState.OFFLINE
+
+        # Reload and sweep again — the warning must not fire a second time.
+        await sm.load("rerank")
+        sm._last_used[sm._key("rerank")] = 0.0
+        await sm._pressure_evict_once()
+        assert (await sm.status("rerank")).state == SlotState.OFFLINE
+
+    warnings = [r for r in caplog.records if r.message == "slot.lru_flag_deprecated"]
+    assert len(warnings) == 1, f"expected exactly one deprecation warning; got {len(warnings)}"
+    assert len(container_stub.unload_calls) == 2  # evicted both sweeps despite lru=false

--- a/tests/slots/test_pressure_eviction.py
+++ b/tests/slots/test_pressure_eviction.py
@@ -437,7 +437,7 @@ async def test_lru_key_ignored_and_warned_once(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A cfg carrying lru=false is evictable anyway; slot.lru_flag_deprecated
+    """A cfg carrying lru=false is evictable anyway; slot.lru_flag_retired
     is logged exactly once across two sweeps (one-shot per slot per process)."""
     _write_slot(slot_root, "rerank", port=8090, lru=False)
     sm = SlotManager(evict_pressure_mb=8192.0)
@@ -455,6 +455,6 @@ async def test_lru_key_ignored_and_warned_once(
         await sm._pressure_evict_once()
         assert (await sm.status("rerank")).state == SlotState.OFFLINE
 
-    warnings = [r for r in caplog.records if r.message == "slot.lru_flag_deprecated"]
+    warnings = [r for r in caplog.records if r.message == "slot.lru_flag_retired"]
     assert len(warnings) == 1, f"expected exactly one deprecation warning; got {len(warnings)}"
     assert len(container_stub.unload_calls) == 2  # evicted both sweeps despite lru=false

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -50,6 +50,8 @@ const CONFIG_ENRICHMENT_KEYS = [
   'model_default',
   'labels',
   'pinned',
+  'autoload',
+  'priority',
   'ctx_max',
   'chat_template',
   'n_gpu_layers',

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -261,6 +261,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// drawer). Rides Save (PUT /config {profile}), restart-required; the
 	// backend's _reconcile_device_profile keeps device/profile coherent.
 	const [profileSel, setProfileSel] = useStateSM(slot?.profile || "");
+	// Eviction priority (spec 2026-08-02) — instant-apply on blur/Enter, NOT
+	// part of the Save batch (see the pinned-toggle-shaped handler below).
+	// Hooks must execute every render (see the note atop this component), so
+	// this is declared here rather than next to its handler.
+	const [prio, setPrio] = useStateSM(
+		Number.isInteger(slot?.priority) ? slot.priority : 50,
+	);
 	// (#1379: `parallel` and `extra_args` state removed with their controls —
 	// both are INERT at launch, so editing them here only wrote TOML nothing
 	// reads. See configBaseline above.)
@@ -498,6 +505,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	useEffectSM(() => {
 		if (!open || !curModelRow) setModelEditOpen(false);
 	}, [open, curModelRow]);
+	// Re-seed `prio` from server truth whenever the slot's persisted priority
+	// changes (poll refresh, or this drawer's own commitPriority resolving) —
+	// same shape as the config-baseline effect above, but for an instant-apply
+	// field that never enters `baseline`. Must run every render (see above).
+	useEffectSM(() => {
+		if (Number.isInteger(slot?.priority)) setPrio(slot.priority);
+	}, [slot?.priority]);
 
 	if (!slot) return null;
 
@@ -680,6 +694,44 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		}
 	};
 
+	// Instant-apply autoload toggle + priority commit (spec 2026-08-02).
+	// Same contract as the pinned toggle above: fire the PUT, toast, let the
+	// slots poll re-render from server truth. Excluded from the Save batch —
+	// see the `dirty` comment below.
+	const autoload = slot.autoload === true;
+	const onToggleAutoload = async (next) => {
+		try {
+			await editMut.mutateAsync({ name: slot.name, body: { autoload: next } });
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					`${slot.name} auto-load ${next ? "on" : "off"}`,
+					"ok",
+				);
+		} catch (err) {
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: toggle failed`,
+					"warn",
+				);
+		}
+	};
+	const commitPriority = async () => {
+		const v = Math.max(0, Math.min(100, Number(prio) || 0));
+		setPrio(v);
+		if (v === slot.priority) return;
+		try {
+			await editMut.mutateAsync({ name: slot.name, body: { priority: v } });
+			window.__hal0Toast && window.__hal0Toast(`${slot.name} priority → ${v}`, "ok");
+		} catch (err) {
+			setPrio(Number.isInteger(slot.priority) ? slot.priority : 50);
+			window.__hal0Toast &&
+				window.__hal0Toast(
+					err?.message ? `${slot.name}: ${err.message}` : `${slot.name}: priority save failed`,
+					"warn",
+				);
+		}
+	};
+
 	// THE dirty comparison — derived once, against the FROZEN baseline, and read
 	// by every consumer (the unsaved-changes guard, the Save body, the stale-
 	// command overlay). No predicate is re-derived anywhere else, and none of
@@ -704,9 +756,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// UI-1: unsaved-changes guard. Aggregate ONLY the Save-batched fields — the
 	// HW grid and ctx. The instant-apply ``pinned`` toggle fires its own PUT
 	// outside Save and is intentionally excluded: a flipped toggle is already
-	// persisted. (Reasoning/MTP/Vision were also instant-apply toggles here;
-	// they moved to the model drawer — spec-hw-slot-ownership §1. Template /
-	// Parallel / Extra Args left with #1379 — see configBaseline.)
+	// persisted. ``autoload``/``priority`` (spec 2026-08-02) are the same
+	// shape — their own PUT fires on toggle/blur above and neither is passed
+	// into deriveChanges, so they never enter this dirty aggregate. (Reasoning/
+	// MTP/Vision were also instant-apply toggles here; they moved to the model
+	// drawer — spec-hw-slot-ownership §1. Template / Parallel / Extra Args
+	// left with #1379 — see configBaseline.)
 	const dirty =
 		!!changes &&
 		(changes.ctx ||
@@ -1439,6 +1494,53 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						})()}
 
 						{profileRow}
+
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Auto-load on start</span>
+								<FieldInfoIcon description="Start this slot automatically at boot. Off: the slot
+									only loads when you load or swap it — binding a model no
+									longer implies boot start." />
+							</div>
+							<div className="form-ctl">
+								<label className="slot-enable-toggle">
+									<input
+										type="checkbox"
+										data-testid="slot-autoload-toggle"
+										checked={autoload}
+										onChange={() => onToggleAutoload(!autoload)}
+										aria-label={autoload ? "Disable auto-load on start" : "Enable auto-load on start"}
+									/>
+									<span className="slot-enable-track" aria-hidden="true" />
+								</label>
+							</div>
+						</div>
+						<div className="form-row">
+							<div className="form-lbl">
+								<span>Eviction priority</span>
+								<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
+									Ties go to the least recently used. Pin the slot to exempt
+									it entirely." />
+							</div>
+							<div className="form-ctl">
+								<input
+									className="input mono"
+									data-testid="slot-priority-input"
+									type="number"
+									min={0}
+									max={100}
+									step={1}
+									value={prio}
+									onChange={(e) => setPrio(e.target.value)}
+									onBlur={commitPriority}
+									onKeyDown={(e) => {
+										if (e.key === "Enter") e.currentTarget.blur();
+									}}
+									style={{ width: 90 }}
+								/>
+								<div className="hint">lower unloads first</div>
+							</div>
+						</div>
 
 						<div className="form-row">
 							<div className="form-lbl">

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -716,7 +716,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		}
 	};
 	const commitPriority = async () => {
-		const v = Math.max(0, Math.min(100, Number(prio) || 0));
+		// An emptied/garbage input must never commit as 0 — that's the most
+		// aggressive evict-first priority, not "no input yet". Revert to the
+		// last known-good value (server truth, or the 50 default) and bail
+		// without a PUT rather than guessing.
+		const raw = String(prio).trim();
+		if (raw === "" || !Number.isFinite(Number(raw))) {
+			setPrio(Number.isInteger(slot.priority) ? slot.priority : 50);
+			return;
+		}
+		const v = Math.max(0, Math.min(100, Math.round(Number(raw))));
 		setPrio(v);
 		if (v === slot.priority) return;
 		try {

--- a/ui/src/dash/slots/CreateSlotModal.jsx
+++ b/ui/src/dash/slots/CreateSlotModal.jsx
@@ -26,6 +26,11 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
 
   const [name, setName] = useStateC("");
   const [modelId, setModelId] = useStateC("");
+  // Spec 2026-08-02: new slots start with no boot-start and mid-priority —
+  // no legacy behavior to migrate, so these default cold rather than
+  // inheriting anything from an existing slot.
+  const [autoload, setAutoload] = useStateC(false);
+  const [priority, setPriority] = useStateC(50);
   const [submitErr, setSubmitErr] = useStateC(null);
 
   const models = useMemoC(() => localModels(modelsQuery.data), [modelsQuery.data]);
@@ -34,6 +39,8 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
     if (open) {
       setName(defaults.name || "");
       setModelId(defaults.model || "");
+      setAutoload(false);
+      setPriority(50);
       setSubmitErr(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -82,6 +89,8 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
       // FIRST slot of a type, and re-pointing the default afterwards is the
       // explicit "Set as default" row action on the slot list.
       device: device || "gpu-rocm",
+      autoload,
+      priority,
     };
     try {
       await createMut.mutateAsync(body);
@@ -156,6 +165,49 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
             assigned on create
             <span className="tag" style={{ color: "var(--fg-4)", fontFamily: "var(--jbm)", fontSize: 9, letterSpacing: ".05em", textTransform: "uppercase", padding: "2px 6px", borderRadius: 3, border: "1px solid var(--line)", background: "var(--bg-2)" }}>by PortAuthority</span>
           </span>
+        </div>
+      </div>
+
+      {/* Auto-load on start — off by default; a new slot has no legacy boot
+          behavior to inherit. */}
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>auto-load on start</span>
+          <FieldInfoIcon description="start this slot automatically at boot — off means it only loads when you load or swap it" />
+        </div>
+        <div className="form-ctl">
+          <label className="slot-enable-toggle">
+            <input
+              type="checkbox"
+              data-testid="create-slot-autoload"
+              checked={autoload}
+              onChange={() => setAutoload(!autoload)}
+              aria-label={autoload ? "Disable auto-load on start" : "Enable auto-load on start"}
+            />
+            <span className="slot-enable-track" aria-hidden="true" />
+          </label>
+        </div>
+      </div>
+
+      {/* Eviction priority — 0-100, defaults to the mid-point */}
+      <div className="form-row">
+        <div className="form-lbl">
+          <span>eviction priority</span>
+          <FieldInfoIcon description="0-100 — lower unloads first when memory is needed; ties go to the least recently used" />
+        </div>
+        <div className="form-ctl">
+          <input
+            className="input mono"
+            data-testid="create-slot-priority"
+            type="number"
+            min={0}
+            max={100}
+            step={1}
+            value={priority}
+            onChange={(e) => setPriority(Math.max(0, Math.min(100, Number(e.target.value) || 0)))}
+            style={{ width: 90 }}
+          />
+          <div className="hint">lower unloads first</div>
         </div>
       </div>
 

--- a/ui/src/dash/slots/CreateSlotModal.jsx
+++ b/ui/src/dash/slots/CreateSlotModal.jsx
@@ -204,7 +204,18 @@ function CreateSlotModal({ open, onClose, defaults = {}, existingSlots = [] }) {
             max={100}
             step={1}
             value={priority}
-            onChange={(e) => setPriority(Math.max(0, Math.min(100, Number(e.target.value) || 0)))}
+            onChange={(e) => {
+              // Same numeric hardening as the edit drawer's commitPriority:
+              // a blank/garbage value must not silently become 0 (the most
+              // aggressive evict-first priority) or a float the backend 400s
+              // on — fall back to the 50 default and otherwise round+clamp.
+              const raw = e.target.value.trim();
+              if (raw === "" || !Number.isFinite(Number(raw))) {
+                setPriority(50);
+                return;
+              }
+              setPriority(Math.max(0, Math.min(100, Math.round(Number(raw)))));
+            }}
             style={{ width: 90 }}
           />
           <div className="hint">lower unloads first</div>


### PR DESCRIPTION
## What

Two new per-slot settings, surfaced in the slot drawer and create modal:

- **`autoload`** — explicit boot-start control. The generated Quadlet unit carries `[Install] WantedBy=hal0.target` only when `autoload = true`, so binding a model no longer implicitly opts a slot into starting at boot. Migration shim: existing TOMLs without the key keep their current behavior (bound model → effective true); new slots persist an explicit `false`. Flipping the toggle re-renders the on-disk unit immediately so the change survives a reboot without an intervening load.
- **`priority`** (0–100, default 50) — eviction ordering. Pressure eviction and the pre-load admission gate now pick victims by `(priority asc, last_used asc)`: lowest priority first, LRU within a tier. The `lru = true` opt-in is retired — every non-pinned resident slot is a candidate; the stale key is ignored with a one-shot deprecation warning. `pinned` and the default anchors remain the only absolute exemptions.

Also: both fields lifted into `GET /api/slots`, value validation on the raw-dict config write path (it bypasses pydantic), CHANGELOG with a **Breaking** callout (pressure/pre-load eviction becomes active on stock boxes that never set `lru=true`), and reference-doc updates.

## Why

Slots were starting by themselves with no visible setting saying so — activation was implicit in `[model].default` plus the unconditional `WantedBy` stanza. And eviction had no way to say "unload this one before that one".

## How verified

- Full backend sweep: 2034 passed (slots/providers/api-routes/slot_view/config), plus targeted TDD suites per commit
- UI: vitest 66/66, `npm run build` and `npm run lint` clean
- `make lint` clean; `make typecheck` introduces zero new errors (verified against a base-commit worktree)
- Subagent-driven build with per-task spec+quality review and a final whole-branch review; all findings fixed and re-reviewed

## Out of scope / follow-ups

- `_unflatten_slot_toml` is a lossy round-trip (drops `pinned`/`profile`/`autoload`/`priority`) — no production caller today, noted for whoever wires `save_slot_config`
- Re-render trigger is `autoload in body`; a model bind/unbind that flips *effective* autoload on a keyless TOML doesn't re-render (benign today)
- Spec/plan docs live in `docs/superpowers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)