### PR TITLE
feat(ui): comfyui pane engine controls + state-typed running indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Added
 
+- Image Gen pane: proper engine lifecycle controls and running indicators.
+  The header pill is state-typed off the live engine (stopped / starting /
+  running / generating·% / error) with matching colors, and a Stop button
+  appears while the engine is up — it drives the GPU-arbiter switchover
+  back to inference mode (restoring the LLM slots) and then unloads the img
+  slot so the container actually goes down. Start/Restart/Logs unchanged.
+
+### Added
+
 - Slots: explicit `autoload` setting — a slot starts at boot only when
   `autoload = true` (slot drawer toggle). Binding a model no longer
   implies boot start; existing slots with a bound model migrate as

--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -465,6 +465,9 @@
 .comfy-page .sctrl:hover { border-color: var(--line-strong); background: var(--bg-3); color: var(--fg-2); }
 .comfy-page .sctrl.stop    { color: var(--err);  border-color: var(--err-line); }
 .comfy-page .sctrl.stop:hover    { background: var(--err-soft); }
+.comfy-page .sctrl.start   { color: var(--ok, #4caf7d); border-color: var(--ok-line, rgba(76,175,125,.4)); }
+.comfy-page .sctrl.start:hover   { background: var(--ok-soft, rgba(76,175,125,.12)); }
+.comfy-page .sctrl:disabled { opacity: .5; cursor: default; }
 .comfy-page .sctrl.restart { color: var(--info); border-color: var(--info-line); }
 .comfy-page .sctrl.restart:hover { background: var(--info-soft); }
 .comfy-page .sctrl.acc { color: var(--comfy); border-color: var(--comfy-line); }

--- a/ui/src/dash/comfyui-pane.css
+++ b/ui/src/dash/comfyui-pane.css
@@ -98,6 +98,15 @@
   box-shadow: 0 0 8px var(--comfy);
   animation: pulse 1.4s ease-in-out infinite;
 }
+/* Engine-state variants (data-state set by CardHead): running = healthy
+   resident engine (green), starting = transitional (amber), error = red.
+   "stopped" keeps the neutral base style. */
+.comfy-page .epill[data-state="running"] { color: var(--ok, #4caf7d); border-color: var(--ok-line, rgba(76,175,125,.4)); }
+.comfy-page .epill[data-state="running"] .dot { background: var(--ok, #4caf7d); }
+.comfy-page .epill[data-state="starting"] { color: var(--warn, #d9a441); border-color: var(--warn-line, rgba(217,164,65,.4)); }
+.comfy-page .epill[data-state="starting"] .dot { background: var(--warn, #d9a441); animation: pulse 1.4s ease-in-out infinite; }
+.comfy-page .epill[data-state="error"] { color: var(--err, #d9534f); border-color: var(--err-line, rgba(217,83,79,.4)); }
+.comfy-page .epill[data-state="error"] .dot { background: var(--err, #d9534f); }
 
 /* ── Device pill ────────────────────────────────────────────────────────────── */
 .comfy-page .cf-pill {

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -101,6 +101,7 @@ const CIcons = {
       <rect x="4" y="4" width="8" height="8" rx="1" />
     </CI>
   ),
+  start: <CI d="M5 3.5l7 4.5-7 4.5V3.5z" fill="currentColor" sw="0" />,
   refresh: (
     <CI>
       <path d="M14 8a6 6 0 1 1-2-4.5" />
@@ -457,9 +458,10 @@ function CardHead({
             style per the operator's ask. */}
         <span className="foot-ctrls">
           {engineStopped && onStart && (
-            <button className="btn ghost sm" data-testid="comfy-start"
+            <button className="sctrl start" data-testid="comfy-start"
+              title={startBusy ? 'Starting…' : 'Start engine'}
               disabled={startBusy} onClick={onStart}>
-              {startBusy ? 'starting…' : 'Start'}
+              <Ci name="start" size={12} />
             </button>
           )}
           {/* Stop = arbiter switchover to inference mode: frees ComfyUI's
@@ -468,9 +470,10 @@ function CardHead({
               backend refuses to drop a busy render queue, so a stop during
               a render surfaces its error instead of killing the job. */}
           {engineUp && onStop && (
-            <button className="btn ghost sm" data-testid="comfy-stop"
+            <button className="sctrl stop" data-testid="comfy-stop"
+              title={stopBusy ? 'Stopping…' : 'Stop engine — restores LLM slots'}
               disabled={stopBusy} onClick={onStop}>
-              {stopBusy ? 'stopping…' : 'Stop'}
+              <Ci name="stop" size={12} />
             </button>
           )}
           <button className="sctrl restart" title="Restart" onClick={onRestart}><Ci name="refresh" size={12} /></button>

--- a/ui/src/dash/comfyui-pane.jsx
+++ b/ui/src/dash/comfyui-pane.jsx
@@ -24,6 +24,7 @@ import {
   COMFYUI_FALLBACK,
 } from '@/api/hooks/useComfyui'
 import { useConfigUrls } from '@/api/hooks/useConfigUrls'
+import { useSlotUnload } from '@/api/hooks/useSlots'
 import { ENDPOINTS } from '@/api/endpoints'
 
 const { useState, useEffect, useRef } = React
@@ -394,15 +395,37 @@ export const COMFYUI_V2_MOCK = {
 }
 
 // ── Card header ───────────────────────────────────────────────────────────────
-// #1470: the header used to also render a "Stop container" button, but
-// nothing wired an onStop handler (the sole call site below never passed
-// one) and no stop mutation exists in useComfyui.ts (only cancel/restart/
-// switchover/pin). A control that silently no-ops on a GPU-exclusive engine
-// is worse than none, so it's removed rather than wired to a speculative
-// endpoint; switching away from generation mode already has a real path via
-// the arbiter switchover (mode=inference).
-function CardHead({ run, pct, onRestart, onLogs, onStart, engineStopped, startBusy }) {
+// #1470 removed a dead "Stop container" button (nothing wired onStop). The
+// control is back with a REAL path behind it: Stop drives the GPU-arbiter
+// switchover to inference mode (free ComfyUI's models, reload the saved LLM
+// set) — the exact inverse of Start's mode=generation. The status pill is
+// state-typed off the live engine field (stopped/starting/running/
+// generating/error) instead of collapsing everything non-generating to
+// "idle", so the operator can actually see the engine running.
+function CardHead({
+  run,
+  pct,
+  onRestart,
+  onLogs,
+  onStart,
+  onStop,
+  engineStopped,
+  engineState,
+  startBusy,
+  stopBusy,
+}) {
   const hasRun = run != null
+  const pillState = hasRun ? 'generating' : engineState || 'stopped'
+  const pillLabel = hasRun
+    ? `generating · ${Math.round(pct)}%`
+    : pillState === 'running'
+      ? 'running'
+      : pillState === 'starting'
+        ? 'starting…'
+        : pillState === 'error'
+          ? 'error'
+          : 'stopped'
+  const engineUp = !engineStopped && (engineState === 'running' || engineState === 'generating' || hasRun)
   return (
     <div className="engine-h wcard-h">
       <span className="engine-glyph"><Ci name="comfy" size={16} /></span>
@@ -413,9 +436,13 @@ function CardHead({ run, pct, onRestart, onLogs, onStart, engineStopped, startBu
         <span className="dim">·</span>
         <span className="meta">docker</span>
       </span>
-      <span className={'epill' + (hasRun ? ' generating' : '')}>
+      <span
+        className={'epill' + (hasRun ? ' generating' : '')}
+        data-state={pillState}
+        data-testid="comfy-engine-pill"
+      >
         <span className="dot" />
-        {hasRun ? `generating · ${Math.round(pct)}%` : (engineStopped ? 'stopped' : 'idle')}
+        {pillLabel}
       </span>
       <span className="grow" />
       <span className="eh-right">
@@ -433,6 +460,17 @@ function CardHead({ run, pct, onRestart, onLogs, onStart, engineStopped, startBu
             <button className="btn ghost sm" data-testid="comfy-start"
               disabled={startBusy} onClick={onStart}>
               {startBusy ? 'starting…' : 'Start'}
+            </button>
+          )}
+          {/* Stop = arbiter switchover to inference mode: frees ComfyUI's
+              models and reloads the saved LLM set — the honest inverse of
+              Start. Only rendered while the engine is actually up; the
+              backend refuses to drop a busy render queue, so a stop during
+              a render surfaces its error instead of killing the job. */}
+          {engineUp && onStop && (
+            <button className="btn ghost sm" data-testid="comfy-stop"
+              disabled={stopBusy} onClick={onStop}>
+              {stopBusy ? 'stopping…' : 'Stop'}
             </button>
           )}
           <button className="sctrl restart" title="Restart" onClick={onRestart}><Ci name="refresh" size={12} /></button>
@@ -490,8 +528,11 @@ export function ImageGenCard({
   onRestart,
   onLogs,
   onStart,
+  onStop,
   engineStopped,
+  engineState,
   startBusy,
+  stopBusy,
   comfyBaseUrl,
 }) {
   const { engine, run, queue, gtt, ram, stats, inventory } = mock
@@ -532,7 +573,8 @@ export function ImageGenCard({
   return (
     <div className="engine wcard active">
       <CardHead run={run} pct={pct} onRestart={onRestart} onLogs={onLogs}
-        onStart={onStart} engineStopped={engineStopped} startBusy={startBusy} />
+        onStart={onStart} onStop={onStop} engineStopped={engineStopped}
+        engineState={engineState} startBusy={startBusy} stopBusy={stopBusy} />
       <div className="wcard-b">
 
         {/* Render-active notice — moved out of the card header so it sits
@@ -789,7 +831,49 @@ export function ComfyuiPane() {
     !override && liveStatus != null &&
     (liveStatus.engine === 'stopped' || liveStatus.engine === 'error') &&
     !liveStatus.switchover?.active
+  // Live engine state for the header pill + Stop gating. A switchover in
+  // flight reads as "starting" (either direction — the pill's job is "the
+  // engine is mid-transition, hands off"). The e2e mock override derives
+  // from its own run field so deterministic tests stay self-contained.
+  const engineState = override
+    ? (override.run ? 'generating' : 'running')
+    : liveStatus?.switchover?.active
+      ? 'starting'
+      : (liveStatus?.engine ?? 'stopped')
   const startBusy = switchoverMutation.isPending || !!liveStatus?.switchover?.active
+  const unloadMutation = useSlotUnload()
+  const stopBusy = startBusy || unloadMutation.isPending
+  const toast = (msg, kind) =>
+    typeof window !== 'undefined' && window.__hal0Toast && window.__hal0Toast(msg, kind)
+  const startEngine = () =>
+    switchoverMutation.mutate(
+      { mode: 'generation' },
+      {
+        onError: (err) => toast(`Start failed: ${err?.message || 'switchover error'}`, 'error'),
+        onSuccess: () =>
+          toast('Bringing ComfyUI up — handing the iGPU to generation mode', 'info'),
+      },
+    )
+  // Stop = two honest steps. The arbiter switchover to inference frees
+  // ComfyUI's VRAM and restores the saved LLM set but DELIBERATELY leaves
+  // the container up (fast switch-back) — so a Stop that only switched
+  // modes would leave the pill green and the operator confused. Follow it
+  // with a real slot unload so the img container actually goes down. The
+  // switchover refuses to drop a busy render queue, so an active render
+  // surfaces an error instead of being killed.
+  const stopEngine = () =>
+    switchoverMutation.mutate(
+      { mode: 'inference' },
+      {
+        onError: (err) => toast(`Stop failed: ${err?.message || 'switchover error'}`, 'error'),
+        onSuccess: () =>
+          unloadMutation.mutate('img', {
+            onError: (err) =>
+              toast(`Stop failed: ${err?.message || 'img slot unload error'}`, 'error'),
+            onSuccess: () => toast('ComfyUI stopped — LLM slots restored', 'info'),
+          }),
+      },
+    )
 
   // Resolve the browser-reachable ComfyUI base URL. The authoritative source
   // is /api/config/urls → `comfyui` (HAL0_COMFYUI_PUBLIC_URL, or
@@ -813,9 +897,12 @@ export function ComfyuiPane() {
         mock={paneData}
         onCancel={() => cancelMutation.mutate()}
         onRestart={() => restartMutation.mutate()}
-        onStart={() => switchoverMutation.mutate({ mode: 'generation' })}
+        onStart={startEngine}
+        onStop={stopEngine}
         engineStopped={engineStopped}
+        engineState={engineState}
         startBusy={startBusy}
+        stopBusy={stopBusy}
         onLogs={() => {
           // Fetch logs and open in a basic alert for now; a logs drawer is a
           // future enhancement (the endpoint is wired, UI depth TBD).

--- a/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
+++ b/ui/tests/e2e/specs/comfyui-arbiter-v3.spec.ts
@@ -212,6 +212,60 @@ test.describe('ComfyUI V2 live-wired pane (Task 5.2)', () => {
     expect(posts[0]).toBe('POST')
   })
 
+  test('running engine shows the Stop control + a state-typed pill; Stop drives switchover then img unload', async ({ page }) => {
+    const switches: any[] = []
+    const unloads: string[] = []
+    await page.route('**/api/comfyui/status', (route: any) => json(route, comfyV2Idle()))
+    await page.route('**/api/comfyui/switchover', async (route: any) => {
+      switches.push(JSON.parse(route.request().postData() || '{}'))
+      return json(route, { status: 'accepted' }, 202)
+    })
+    await page.route('**/api/slots/img/unload', (route: any) => {
+      unloads.push(route.request().method())
+      return json(route, {})
+    })
+
+    await gotoImageTab(page)
+
+    // Running indicator: pill carries the live engine state.
+    const pill = page.getByTestId('comfy-engine-pill')
+    await expect(pill).toBeVisible()
+    await expect(pill).toHaveAttribute('data-state', 'running')
+    await expect(pill).toContainText('running')
+
+    // Stop is offered while the engine is up; Start is not.
+    const stopBtn = page.getByTestId('comfy-stop')
+    await expect(stopBtn).toBeVisible()
+    await expect(page.getByTestId('comfy-start')).toHaveCount(0)
+
+    await stopBtn.click()
+    await expect.poll(() => switches.length, { timeout: 5_000 }).toBeGreaterThan(0)
+    expect(switches[0]).toMatchObject({ mode: 'inference' })
+    // The switchover leaves the container up by design — Stop follows with a
+    // real img slot unload so the engine actually goes down.
+    await expect.poll(() => unloads.length, { timeout: 5_000 }).toBeGreaterThan(0)
+    expect(unloads[0]).toBe('POST')
+  })
+
+  test('stopped engine shows Start (no Stop) and a neutral stopped pill', async ({ page }) => {
+    await page.route('**/api/comfyui/status', (route: any) =>
+      json(route, {
+        ...comfyV2Idle(),
+        mode: 'inference',
+        reachable: false,
+        engine: 'stopped',
+        arbiter: { mode: 'llm', pinned: false, saved_llm_slots: [], idle_restore_at: null },
+      }),
+    )
+    await gotoImageTab(page)
+
+    const pill = page.getByTestId('comfy-engine-pill')
+    await expect(pill).toHaveAttribute('data-state', 'stopped')
+    await expect(pill).toContainText('stopped')
+    await expect(page.getByTestId('comfy-start')).toBeVisible()
+    await expect(page.getByTestId('comfy-stop')).toHaveCount(0)
+  })
+
   // ── 7. Idle state: empty queue renders in-flow (no overlay lockup) ────────
 
   test('idle: empty-queue state renders in-flow, no click-blocking overlay', async ({ page }) => {

--- a/ui/tests/e2e/specs/imagegen-v2.spec.ts
+++ b/ui/tests/e2e/specs/imagegen-v2.spec.ts
@@ -189,7 +189,7 @@ test.describe('ImageGen V2 render-hero pane', () => {
   // backing mutation (only restart/logs are wired) — removed as a dead
   // control rather than left silently doing nothing on a GPU-exclusive
   // engine. Pin its absence so it doesn't come back un-wired.
-  test('footer identity + header controls render (no dead Stop button)', async ({ page }) => {
+  test('footer identity + header controls render (Stop is wired, icon-style)', async ({ page }) => {
     await gotoImageTab(page)
     const pane = page.locator('.comfy-v2-pane')
 
@@ -200,8 +200,10 @@ test.describe('ImageGen V2 render-hero pane', () => {
     // restart control — still in the header far right
     const head = pane.locator('.wcard-h')
     await expect(head.locator('.sctrl.restart')).toBeVisible()
-    // the un-wired "Stop container" button must not be rendered (#1470)
-    await expect(head.locator('.sctrl.stop')).toHaveCount(0)
+    // #1470 removed a DEAD Stop button; it is back as a wired icon control
+    // (arbiter switchover + img unload behind it — comfyui-arbiter-v3 spec
+    // covers the wiring). The engine is up in this mock, so it renders.
+    await expect(head.getByTestId('comfy-stop')).toBeVisible()
   })
 
   // ── 7. Empty-queue state: NO click-blocking overlay ─────────────────────


### PR DESCRIPTION
The img slot is excluded from the InferencePane on purpose (image is its
own pane), but that pane offered no way to stop a running engine — #1470
removed the Stop button because nothing was wired behind it — and the
status pill collapsed every non-generating state to 'idle', so a running
engine was neither visible nor controllable.

The header pill now carries the live engine state (stopped / starting /
running / generating·% / error) with state-typed colors, and Stop is
back with a real path behind it: arbiter switchover to inference mode
(frees ComfyUI's VRAM, restores the saved LLM set) followed by an img
slot unload — the switchover alone deliberately leaves the container up,
which would have left the pill green and the operator confused. Failures
surface as toasts; the backend still refuses to drop a busy render
queue, so Stop during a render errors instead of killing the job.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
