### PR TITLE
feat(ui): drag slot cards to arrange the Inference pane

### DIFF
--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -997,6 +997,55 @@
 :is(.infer-pane, .npu-pane) .scard.dim {
   opacity: 0.55;
 }
+/* ─── Drag-to-reorder grip ───────────────────────────────────────────────
+   A dotted tab hanging from the top-centre edge of a slot card, in the card's
+   own border + --bg-2 chrome. Faint at rest so a grid of cards stays quiet;
+   full strength on card hover, grip hover, and keyboard focus. Only rendered
+   on the reorderable Inference-pane cards (see slots/card-order.js). */
+.infer-pane .card-grip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 13px;
+  padding: 0;
+  border: 1px solid var(--line-soft);
+  border-top: 0;
+  border-radius: 0 0 var(--rad-sm) var(--rad-sm);
+  background: var(--bg-2);
+  color: var(--fg-5);
+  cursor: grab;
+  opacity: 0.4;
+  transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.infer-pane :is(.scard, .mcard):hover .card-grip {
+  opacity: 1;
+}
+.infer-pane .card-grip:hover,
+.infer-pane .card-grip:focus-visible {
+  opacity: 1;
+  color: var(--fg-2);
+  border-color: var(--line-strong);
+}
+.infer-pane .card-grip:active {
+  cursor: grabbing;
+}
+/* The card being dragged — its live position in the grid already previews the
+   drop, so the source only needs to read as "in flight". */
+.infer-pane :is(.scard, .mcard).dragging {
+  opacity: 0.4;
+  border-style: dashed;
+}
+.infer-pane :is(.scard, .mcard).dragging:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 :is(.infer-pane, .npu-pane) .scard-h {
   display: flex;
   align-items: center;

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -38,6 +38,7 @@ import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { useMemoryMapModel } from './memory-map'
 import { slotIndicatorFromPhase, isSlotLive } from './slot-status.js'
 import { slotModelRow } from './slots/slot-shared.js'
+import { useCardReorder } from './slots/card-order.js'
 // devKind — one shared, meta-aware helper (src/lib/deviceMeta.ts); replaces
 // the copy this file used to carry (and the verbatim clones in slot-list.jsx
 // and npu-pane.jsx).
@@ -154,6 +155,34 @@ function SubLabel({ icon, note, children }) {
         </>
       )}
     </div>
+  )
+}
+
+// ── card grip ───────────────────────────────────────────────────────────
+// Drag handle for reordering the slot cards — a small dotted tab hanging from
+// the top-centre edge of the card, in the same border/`--bg-2` chrome as the
+// rest of the card. Rest state is faint; it comes up on card hover and on
+// keyboard focus. Arrow keys move the card one place (the accessible path, and
+// the only one on touch — native HTML5 DnD is pointer-only).
+function CardGrip({ name, grip }) {
+  return (
+    <button
+      type="button"
+      className="card-grip"
+      title="Drag to reorder — or use the arrow keys"
+      aria-label={`Reorder ${name} — drag, or use the arrow keys`}
+      data-testid={`infer-grip-${name}`}
+      {...grip}
+    >
+      <svg width="16" height="8" viewBox="0 0 16 8" fill="currentColor" aria-hidden="true">
+        {[3, 8, 13].map((cx) => (
+          <React.Fragment key={cx}>
+            <circle cx={cx} cy="3" r="1" />
+            <circle cx={cx} cy="6" r="1" />
+          </React.Fragment>
+        ))}
+      </svg>
+    </button>
   )
 }
 
@@ -348,7 +377,13 @@ export function slotCtrlPhase(slot) {
 //               from their modality toggle, not the slot's own state).
 //   onEditModel / modelName — inline model-edit affordance. Omit both and the
 //               model row renders exactly as before (the NPU stack does).
-export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName }) {
+//   grip / dragging / dropProps — drag-to-reorder wiring (see slots/card-order).
+//               Omit `grip` and the card carries no handle at all, which is how
+//               every non-reorderable caller renders it.
+export function SlotScard({
+  s, ind, full, modelNode, controls, phase, onEdit, onEditModel, modelName,
+  grip, dragging, dropProps,
+}) {
   const dot = dotCls(ind)
   const ph = phase || slotCtrlPhase(s)
   // A live-ish card whose /api/slots enrichment hasn't landed yet (bare
@@ -362,9 +397,14 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit, on
   const ttft = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
   return (
     <div
-      className={'scard ' + dot + (ph === 'off' ? ' dim' : '') + (pending ? ' pending' : '')}
+      className={
+        'scard ' + dot + (ph === 'off' ? ' dim' : '') + (pending ? ' pending' : '') +
+        (dragging ? ' dragging' : '')
+      }
       data-testid={`infer-slot-${s.name}`}
+      {...(dropProps || {})}
     >
+      {grip}
       <div className="scard-h">
         <span className={'sdot ' + dot} title={ind.tooltip} />
         <span className="snm">{s.name}</span>
@@ -432,6 +472,9 @@ export function SlotScard({ s, ind, full, modelNode, controls, phase, onEdit, on
 }
 
 function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows }) {
+  // Operator-arranged order + drag wiring. Called before the early returns so
+  // the hook order is stable across the loading/empty/populated renders.
+  const reorder = useCardReorder('inference.chat', rows)
   if (!rows.length) {
     if (loading)
       return (
@@ -445,7 +488,7 @@ function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows 
   }
   return (
     <div className={'scards ' + (full ? 'full' : 'compact')}>
-      {rows.map(({ s, ind }) => {
+      {reorder.rows.map(({ s, ind }) => {
         const busy = busyName === s.name
         const modelNode = full ? (
           <ModelPicker
@@ -491,6 +534,9 @@ function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows 
               handlers.onEditModel ? () => handlers.onEditModel(s) : undefined
             }
             modelName={modelRow ? modelRow.longName || modelRow.name || modelRow.id : ''}
+            grip={<CardGrip name={s.name} grip={reorder.gripProps(s.name)} />}
+            dragging={reorder.dragName === s.name}
+            dropProps={reorder.dropProps(s.name)}
           />
         )
       })}
@@ -501,11 +547,16 @@ function SlotCards({ rows, full, models, busyName, handlers, loading, modelRows 
 // Utility tier — compact mini cards for the support slots (embed / rerank /
 // voice). No meta row, no model picker: just the dot + name + port header and
 // a minimal model + Start/Stop/Restart control cluster (SlotControls compact).
-function MiniCard({ s, ind, busy, handlers }) {
+function MiniCard({ s, ind, busy, handlers, grip, dragging, dropProps }) {
   const dot = dotCls(ind)
   const ph = slotCtrlPhase(s)
   return (
-    <div className={'mcard ' + dot} data-testid={`infer-slot-${s.name}`}>
+    <div
+      className={'mcard ' + dot + (dragging ? ' dragging' : '')}
+      data-testid={`infer-slot-${s.name}`}
+      {...(dropProps || {})}
+    >
+      {grip}
       <div className="mcard-h">
         <span className={'sdot ' + dot} title={ind.tooltip} />
         <span className="snm">{s.name}</span>
@@ -533,16 +584,22 @@ function MiniCard({ s, ind, busy, handlers }) {
 }
 
 function MiniCards({ rows, busyName, handlers }) {
+  // Utility tier arranges independently of the headline tier — its own scope
+  // key. Hook first: `rows` can be empty on the very first render.
+  const reorder = useCardReorder('inference.util', rows)
   if (!rows.length) return null
   return (
     <div className="util-mini">
-      {rows.map(({ s, ind }) => (
+      {reorder.rows.map(({ s, ind }) => (
         <MiniCard
           key={s.name}
           s={s}
           ind={ind}
           busy={busyName === s.name}
           handlers={handlers}
+          grip={<CardGrip name={s.name} grip={reorder.gripProps(s.name)} />}
+          dragging={reorder.dragName === s.name}
+          dropProps={reorder.dropProps(s.name)}
         />
       ))}
     </div>

--- a/ui/src/dash/slots/card-order.js
+++ b/ui/src/dash/slots/card-order.js
@@ -1,0 +1,192 @@
+// hal0 dashboard — operator-arranged slot-card order (drag to reorder).
+//
+// The Inference pane's slot cards can be rearranged by grabbing the grip at the
+// top of a card and dropping it where you want it. This is a per-browser VIEW
+// preference: it never touches slot config, so it needs no Save step and no
+// backend round-trip — the new order is written to localStorage as it happens
+// and applied on the next render.
+//
+// Ordering is stored as a list of slot NAMES, not indices, so adding, renaming,
+// or deleting a slot can't scramble the arrangement:
+//   - a name in the saved list keeps its saved position
+//   - a name that isn't (a slot created since) falls to the end, in its natural
+//     /api/slots order
+//   - a saved name whose slot is gone is simply ignored
+//
+// The pure helpers below carry the logic (unit-tested in card-order.test.ts);
+// useCardReorder is the hook the pane consumes. React is read off the global at
+// call time (the dash modules' house pattern) so this file stays importable in
+// the Node-environment unit suite.
+
+const LS_PREFIX = 'hal0.slots.order.'
+
+// Default key extractor — the pane's rows are `{ s, ind }` pairs.
+const defaultKey = (r) => r?.s?.name
+
+// ─── pure helpers ───────────────────────────────────────────────────────────
+
+// Reorder `rows` to match `order` (a list of names). Rows named in `order` come
+// first, in that order; everything else keeps its natural relative order and
+// follows. Never mutates the input.
+export function applyOrder(rows, order, keyOf = defaultKey) {
+  const list = Array.isArray(rows) ? rows.slice() : []
+  if (!Array.isArray(order) || order.length === 0) return list
+  const rank = new Map()
+  order.forEach((n, i) => { if (!rank.has(n)) rank.set(n, i) })
+  const known = []
+  const rest = []
+  for (const r of list) (rank.has(keyOf(r)) ? known : rest).push(r)
+  known.sort((a, b) => rank.get(keyOf(a)) - rank.get(keyOf(b)))
+  return known.concat(rest)
+}
+
+// Move `name` to sit at `toIndex` in `names`. The index is read against the
+// list BEFORE the removal, which is what makes a drag read naturally: dropping
+// onto a card to your right lands you after it, onto one to your left, before
+// it. Out-of-range indices clamp; an unknown name is a no-op copy.
+export function moveName(names, name, toIndex) {
+  const next = Array.isArray(names) ? names.slice() : []
+  const from = next.indexOf(name)
+  if (from < 0) return next
+  next.splice(from, 1)
+  const to = Math.max(0, Math.min(next.length, toIndex))
+  next.splice(to, 0, name)
+  return next
+}
+
+// ─── localStorage ───────────────────────────────────────────────────────────
+// Fail-soft both ways: a corrupt/absent entry reads as "no saved order" (the
+// natural /api/slots order), and a failed write (private mode, quota) leaves
+// the in-memory order working for the session rather than breaking the drag.
+
+export function readOrder(scope) {
+  try {
+    const raw = localStorage.getItem(LS_PREFIX + scope)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((n) => typeof n === 'string')
+  } catch {
+    return []
+  }
+}
+
+export function writeOrder(scope, order) {
+  try {
+    localStorage.setItem(LS_PREFIX + scope, JSON.stringify(order))
+  } catch {
+    /* ignore — the session keeps the order in memory */
+  }
+}
+
+// ─── useCardReorder ─────────────────────────────────────────────────────────
+//
+// Owns the saved order, the in-flight drag, and the DOM props the card + grip
+// need. `scope` is the localStorage sub-key (one per card list, so the chat
+// tier and the utility tier arrange independently).
+//
+// Returns:
+//   rows      — `rows` in the operator's order
+//   dragName  — the name currently being dragged (null when idle)
+//   gripProps(name)  — spread onto the grip button
+//   dropProps(name)  — spread onto the card element
+//
+// Reordering happens live on dragenter (not on drop), so the grid shows the
+// result while you're still holding the card; the drop just ends the gesture.
+// dragenter rather than dragover keeps that to one reorder per card crossed.
+//
+// Native HTML5 drag-and-drop has no touch support; the grip's arrow-key
+// handling is the accessible (and touch-device) path.
+export function useCardReorder(scope, rows, keyOf = defaultKey) {
+  const [order, setOrder] = React.useState(() => readOrder(scope))
+  // The dragged name lives in a REF as well as state. State drives the
+  // `.dragging` styling; the ref is what the drop handlers read, because
+  // dragstart and the first dragenter can land in the same task — a handler
+  // closed over the pre-dragstart render would still see `dragName === null`
+  // and swallow the reorder.
+  const dragRef = React.useRef(null)
+  const [dragName, setDragName] = React.useState(null)
+  const beginDrag = (name) => {
+    dragRef.current = name
+    setDragName(name)
+  }
+  const endDrag = () => {
+    dragRef.current = null
+    setDragName(null)
+  }
+
+  // Mirrored in refs for the same reason as `dragRef`: a burst of drag events
+  // can outrun React's re-render, and a reorder computed against a stale name
+  // list would undo the one before it.
+  const orderRef = React.useRef(order)
+  const rowsRef = React.useRef(rows)
+  orderRef.current = order
+  rowsRef.current = rows
+
+  const ordered = applyOrder(rows, order, keyOf)
+  const currentNames = () => applyOrder(rowsRef.current, orderRef.current, keyOf).map(keyOf)
+
+  const moveTo = (name, toIndex) => {
+    const names = currentNames()
+    const next = moveName(names, name, toIndex)
+    if (next.length === names.length && next.every((n, i) => n === names[i])) return
+    orderRef.current = next
+    setOrder(next)
+    writeOrder(scope, next)
+  }
+
+  const gripProps = (name) => ({
+    draggable: true,
+    onDragStart: (e) => {
+      beginDrag(name)
+      e.dataTransfer.effectAllowed = 'move'
+      try {
+        e.dataTransfer.setData('text/plain', name)
+      } catch {
+        /* Safari can refuse setData on a non-text drag — the name lives in state anyway */
+      }
+      // Drag the whole card, not the little grip button.
+      const card = e.currentTarget.closest('.scard, .mcard')
+      if (card && e.dataTransfer.setDragImage) {
+        e.dataTransfer.setDragImage(card, card.offsetWidth / 2, 14)
+      }
+    },
+    onDragEnd: endDrag,
+    // The grip sits on a card whose header/body carry their own click targets.
+    onClick: (e) => e.stopPropagation(),
+    onKeyDown: (e) => {
+      const step =
+        e.key === 'ArrowLeft' || e.key === 'ArrowUp' ? -1
+        : e.key === 'ArrowRight' || e.key === 'ArrowDown' ? 1
+        : 0
+      if (!step) return
+      e.preventDefault()
+      const i = currentNames().indexOf(name)
+      if (i < 0) return
+      // Keyed reorder moves the existing DOM node, so focus rides along with
+      // the grip and the arrow keys keep working from the new position.
+      moveTo(name, i + step)
+    },
+  })
+
+  const dropProps = (name) => ({
+    onDragOver: (e) => {
+      if (!dragRef.current) return
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+    },
+    onDragEnter: (e) => {
+      const dragged = dragRef.current
+      if (!dragged || dragged === name) return
+      e.preventDefault()
+      moveTo(dragged, currentNames().indexOf(name))
+    },
+    onDrop: (e) => {
+      if (!dragRef.current) return
+      e.preventDefault()
+      endDrag()
+    },
+  })
+
+  return { rows: ordered, dragName, gripProps, dropProps }
+}

--- a/ui/src/dash/slots/card-order.test.ts
+++ b/ui/src/dash/slots/card-order.test.ts
@@ -1,0 +1,64 @@
+// card-order — pure-logic coverage for slot-card drag reordering.
+//
+// Named `.test.ts` deliberately (see slot-shared.test.ts): vitest.config.ts
+// only collects src/**/*.test.ts. The environment is `node`, so this file
+// exercises the pure helpers only — readOrder/writeOrder/useCardReorder need
+// localStorage and React and are covered by the e2e spec instead.
+import { describe, expect, it } from 'vitest'
+
+// card-order.js is untyped JS; tsconfig has allowJs with checkJs:false.
+import { applyOrder, moveName } from './card-order.js'
+
+const rows = (...names: string[]) => names.map((n) => ({ s: { name: n } }))
+const names = (list: { s: { name: string } }[]) => list.map((r) => r.s.name)
+
+describe('applyOrder', () => {
+  it('leaves the natural order alone when nothing is saved', () => {
+    const input = rows('a', 'b', 'c')
+    expect(names(applyOrder(input, []))).toEqual(['a', 'b', 'c'])
+    expect(names(applyOrder(input, null))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('sorts saved names into their saved positions', () => {
+    expect(names(applyOrder(rows('a', 'b', 'c'), ['c', 'a', 'b']))).toEqual(['c', 'a', 'b'])
+  })
+
+  it('sends slots created since the save to the end, in natural order', () => {
+    // `d` and `e` are new; `c` was saved first.
+    expect(names(applyOrder(rows('a', 'd', 'b', 'e', 'c'), ['c', 'b', 'a'])))
+      .toEqual(['c', 'b', 'a', 'd', 'e'])
+  })
+
+  it('ignores saved names whose slot is gone', () => {
+    expect(names(applyOrder(rows('a', 'b'), ['deleted', 'b', 'a']))).toEqual(['b', 'a'])
+  })
+
+  it('never mutates the input list', () => {
+    const input = rows('a', 'b', 'c')
+    applyOrder(input, ['c', 'b', 'a'])
+    expect(names(input)).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('moveName', () => {
+  it('drops a card after the one it was dragged rightwards onto', () => {
+    // dragging `a` onto `c` (index 2) lands it past `c`
+    expect(moveName(['a', 'b', 'c'], 'a', 2)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('drops a card before the one it was dragged leftwards onto', () => {
+    expect(moveName(['a', 'b', 'c'], 'c', 0)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('clamps an out-of-range index instead of losing the card', () => {
+    expect(moveName(['a', 'b', 'c'], 'b', -5)).toEqual(['b', 'a', 'c'])
+    expect(moveName(['a', 'b', 'c'], 'b', 99)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('is a no-op copy for an unknown name', () => {
+    const input = ['a', 'b']
+    const out = moveName(input, 'zzz', 0)
+    expect(out).toEqual(['a', 'b'])
+    expect(out).not.toBe(input)
+  })
+})

--- a/ui/tests/e2e/specs/slot-card-reorder-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-card-reorder-v3.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * slot-card-reorder-v3 — drag-to-reorder the Inference-pane slot cards.
+ *
+ * The cards are `SlotScard` / `MiniCard` in dash/inference-pane.jsx, ordered by
+ * dash/slots/card-order.js. Arrangement is a per-browser VIEW preference: it
+ * persists to localStorage as it happens, with no Save step and no request to
+ * the backend.
+ *
+ *   R1. the grip renders on every reorderable card, top-centre.
+ *   R2. dragging a card by its grip onto another reorders the grid live and
+ *       lands the arrangement in localStorage — no Save step, no slot config.
+ *   R3. the new order survives a reload.
+ *   R4. arrow keys on a focused grip move the card one place (the accessible
+ *       path, and the only one on touch — HTML5 DnD is pointer-only).
+ *   R5. the utility (mini-card) tier arranges independently of the chat tier.
+ *   R6. a slot created after the save lands at the end, and the saved cards
+ *       keep their positions.
+ */
+import { test, expect, type Page } from '../fixtures/apiMock'
+
+const CHAT_KEY = 'hal0.slots.order.inference.chat'
+const UTIL_KEY = 'hal0.slots.order.inference.util'
+
+const llm = (name: string, port: number) => ({
+  name, type: 'llm', device: 'gpu-rocm', profile: 'rocm',
+  runtime: 'container', container_status: 'running', container_health: true,
+  model: 'qwen3.6-27b-mtp', model_id: 'qwen3.6-27b-mtp',
+  group: 'chat', state: 'serving', port,
+  n_gpu_layers: -1,
+  metrics: { ctx: 8192, toks: 42, ttft: 180, kv: 35 },
+})
+const util = (name: string, type: string, port: number) => ({
+  name, type, device: 'cpu', profile: 'cpu',
+  model: 'nomic-v1.5', model_id: 'nomic-v1.5',
+  state: 'ready', port, metrics: {},
+})
+
+const ALPHA = llm('alpha', 8092)
+const BRAVO = llm('bravo', 8093)
+const CHARLIE = llm('charlie', 8094)
+
+// The dev-server suite is forced-mock: `src/api/mock.ts` answers the allowlisted
+// GETs straight from `window.HAL0_DATA`, so slot seeding goes through that
+// global rather than the apiMock page.route stubs (same shim the slot-card
+// model-edit spec uses).
+async function seedSlots(page: Page, slots: unknown[]) {
+  await page.addInitScript((slots) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+const pane = (page: Page) => page.locator('.infer-pane:not(.infer-hero-top)').first()
+const card = (page: Page, name: string) => pane(page).getByTestId(`infer-slot-${name}`)
+const grip = (page: Page, name: string) => page.getByTestId(`infer-grip-${name}`)
+
+const namesOf = (sel: string) => async (page: Page) => {
+  const ids = await pane(page)
+    .locator(sel)
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid') || ''))
+  return ids.map((id) => id.replace('infer-slot-', ''))
+}
+/** Slot names in DOM order within the headline (chat/agent) card grid. */
+const chatOrder = namesOf('.scards.full > .scard')
+/** Slot names in DOM order within the utility mini-card row. */
+const utilOrder = namesOf('.util-mini > .mcard')
+
+test.describe('Slot card — drag to reorder', () => {
+  test('R1 — every reorderable card carries a grip, top-centre', async ({ page }) => {
+    await seedSlots(page, [ALPHA, BRAVO])
+    await page.goto('/#slots')
+    await expect(card(page, 'alpha')).toBeVisible()
+
+    for (const name of ['alpha', 'bravo']) {
+      const g = grip(page, name)
+      await expect(g).toHaveCount(1)
+      await expect(g).toHaveAttribute('draggable', 'true')
+      await expect(g).toHaveAttribute('aria-label', new RegExp(`Reorder ${name}`))
+    }
+    const cardBox = (await card(page, 'alpha').boundingBox())!
+    const gripBox = (await grip(page, 'alpha').boundingBox())!
+    expect(cardBox).toBeTruthy()
+    expect(gripBox).toBeTruthy()
+    const cardMid = cardBox.x + cardBox.width / 2
+    const gripMid = gripBox.x + gripBox.width / 2
+    expect(Math.abs(cardMid - gripMid)).toBeLessThan(2)
+    expect(gripBox.y - cardBox.y).toBeLessThan(4)
+  })
+
+  test('R2/R3 — a drag reorders the grid and the order survives a reload', async ({ page }) => {
+    await seedSlots(page, [ALPHA, BRAVO, CHARLIE])
+    await page.goto('/#slots')
+    await expect(card(page, 'charlie')).toBeVisible()
+    expect(await chatOrder(page)).toEqual(['alpha', 'bravo', 'charlie'])
+
+    // The cards sit below the telemetry header; a native drag needs both ends
+    // of the gesture inside the viewport, so bring the row up first.
+    await card(page, 'charlie').scrollIntoViewIfNeeded()
+
+    // Drag alpha rightwards onto charlie — it lands past charlie.
+    await grip(page, 'alpha').dragTo(card(page, 'charlie'))
+    await expect.poll(() => chatOrder(page)).toEqual(['bravo', 'charlie', 'alpha'])
+
+    // No Save step: the arrangement is already persisted, client-side only.
+    expect(await page.evaluate((k) => localStorage.getItem(k), CHAT_KEY)).toBe(
+      JSON.stringify(['bravo', 'charlie', 'alpha']),
+    )
+    await page.reload()
+    await expect(card(page, 'charlie')).toBeVisible()
+    expect(await chatOrder(page)).toEqual(['bravo', 'charlie', 'alpha'])
+  })
+
+  test('R4 — arrow keys on a focused grip move the card one place', async ({ page }) => {
+    await seedSlots(page, [ALPHA, BRAVO, CHARLIE])
+    await page.goto('/#slots')
+    await expect(card(page, 'charlie')).toBeVisible()
+
+    await grip(page, 'charlie').focus()
+    await page.keyboard.press('ArrowLeft')
+    await expect.poll(() => chatOrder(page)).toEqual(['alpha', 'charlie', 'bravo'])
+
+    // Focus rides along with the moved card, so the next press continues.
+    await page.keyboard.press('ArrowLeft')
+    await expect.poll(() => chatOrder(page)).toEqual(['charlie', 'alpha', 'bravo'])
+
+    // Already first — a further press is a no-op, never a wrap-around.
+    await page.keyboard.press('ArrowLeft')
+    await expect.poll(() => chatOrder(page)).toEqual(['charlie', 'alpha', 'bravo'])
+  })
+
+  test('R5 — the utility tier arranges independently of the chat tier', async ({ page }) => {
+    await seedSlots(page, [
+      ALPHA,
+      BRAVO,
+      util('embed', 'embedding', 8100),
+      util('rerank', 'reranking', 8101),
+    ])
+    await page.goto('/#slots')
+    await expect(card(page, 'rerank')).toBeVisible()
+    expect(await utilOrder(page)).toEqual(['embed', 'rerank'])
+
+    await grip(page, 'rerank').focus()
+    await page.keyboard.press('ArrowLeft')
+    await expect.poll(() => utilOrder(page)).toEqual(['rerank', 'embed'])
+
+    // Its own storage scope — the chat grid is untouched.
+    expect(await chatOrder(page)).toEqual(['alpha', 'bravo'])
+    expect(await page.evaluate((k) => localStorage.getItem(k), UTIL_KEY)).toBe(
+      JSON.stringify(['rerank', 'embed']),
+    )
+    expect(await page.evaluate((k) => localStorage.getItem(k), CHAT_KEY)).toBeNull()
+  })
+
+  test('R6 — a slot created after the save lands at the end', async ({ page }) => {
+    await seedSlots(page, [ALPHA, BRAVO, CHARLIE])
+    await page.addInitScript(
+      ([key, order]) => localStorage.setItem(key as string, JSON.stringify(order)),
+      [CHAT_KEY, ['charlie', 'alpha']] as const,
+    )
+    await page.goto('/#slots')
+    await expect(card(page, 'bravo')).toBeVisible()
+
+    // `bravo` was never arranged — it follows the arranged pair rather than
+    // scrambling their saved positions.
+    expect(await chatOrder(page)).toEqual(['charlie', 'alpha', 'bravo'])
+  })
+})


### PR DESCRIPTION
## What

Slot cards on the Slots page can be rearranged by dragging. A dotted grip hangs from the top-centre edge of each card, in the card's own border/`--bg-2` chrome — faint at rest, full strength on card hover and keyboard focus.

The chat/agent grid (`.scard`) and the utility mini-card row (`.mcard`) arrange independently, each with its own storage scope. The NPU pane is untouched (`SlotScard`'s new `grip` prop is optional; omit it and the card renders exactly as before).

## Why this shape

Arrangement is a per-browser **view** preference, not slot config, so:

- **No Save step.** The order is written to `localStorage` (`hal0.slots.order.inference.chat` / `.util`) as the drag happens and applied on the next render. Nothing reaches the backend.
- **Stored as slot names, not indices,** so creating/renaming/deleting a slot can't scramble it. A name that isn't in the saved list (a slot created since) falls to the end in its natural `/api/slots` order; a saved name whose slot is gone is ignored.
- **Reorder happens live on `dragenter`,** not on drop — the grid shows the result while you're still holding the card.

Native HTML5 drag-and-drop, no new dependency. That is pointer-only, so the grip is a real `<button>` and arrow keys move a card one place — the accessible path, and the only one on touch.

## Files

- `ui/src/dash/slots/card-order.js` — `applyOrder` / `moveName` pure helpers + the `useCardReorder` hook (localStorage read/write is fail-soft both ways).
- `ui/src/dash/inference-pane.jsx` — `CardGrip`, plus `grip` / `dragging` / `dropProps` on `SlotScard` and `MiniCard`.
- `ui/src/dash/engine-panes.css` — `.card-grip` and the `.dragging` source treatment.

## Verified

- `npm run lint`, `npm run typecheck` — clean.
- `npm run test:unit` — 75 passed, including the new `card-order.test.ts` (ordering/move semantics, new-slot-lands-at-end, stale-name tolerance, no input mutation).
- `npx playwright test` — full e2e suite, 608 passed / 0 failed, including the new `slot-card-reorder-v3.spec.ts`: grip presence + top-centre placement, a real drag reordering the grid, localStorage persistence across a reload, arrow-key moves with focus following the card, per-tier independence, and a post-save slot landing at the end.

## Out of scope

Cross-device sync (would need a backend `order` field + endpoint) and touch drag. The NPU/FLM stack cards are not reorderable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)