### PR TITLE
refactor(ui): remove the last turnstone stragglers

### DIFF
--- a/src/hal0/api/routes/agents.py
+++ b/src/hal0/api/routes/agents.py
@@ -56,9 +56,9 @@ async def _unit_active(name: str) -> bool | None:
     Delegates to the single systemctl seam in :mod:`hal0.api.agents.restart`
     (module attribute, not a from-import, so the probe stays patchable in
     tests). Agents outside that module's registry have no ``hal0-agent@``
-    template unit — Pi is a CLI tool, Turnstone runs its own server — so
-    probing them would answer "inactive" about a unit that was never meant to
-    exist. They report ``None`` (unknown) instead.
+    template unit — Pi, for instance, is a CLI tool — so probing them would
+    answer "inactive" about a unit that was never meant to exist. They report
+    ``None`` (unknown) instead.
     """
     if name not in agent_restart.KNOWN_AGENT_IDS:
         return None

--- a/tests/security/test_api_env_mode.py
+++ b/tests/security/test_api_env_mode.py
@@ -2,8 +2,7 @@
 
 The live box carried ``644 hal0:hal0`` on ``/etc/hal0/api.env`` while that
 file held ``HF_TOKEN``, ``MINIMAX_API_KEY``, ``OPENROUTER_API_KEY``,
-``HERMES_SESSION_TOKEN`` and ``HAL0_TURNSTONE_TOKEN`` — every local account
-could read them.
+and ``HERMES_SESSION_TOKEN`` — every local account could read them.
 
 FOUR writers disagreed:
 

--- a/tests/security/test_secrets_protected_keys.py
+++ b/tests/security/test_secrets_protected_keys.py
@@ -138,10 +138,10 @@ def test_set_of_a_protected_key_is_refused(
 def test_protected_refusal_names_the_key_but_never_its_value(
     client: TestClient, tmp_hal0_home: str
 ) -> None:
-    _seed(tmp_hal0_home, "HAL0_TURNSTONE_TOKEN")
-    r = client.delete("/api/secrets/HAL0_TURNSTONE_TOKEN")
+    _seed(tmp_hal0_home, "HAL0_SESSION_TOKEN")
+    r = client.delete("/api/secrets/HAL0_SESSION_TOKEN")
     assert r.status_code == 403
-    assert "HAL0_TURNSTONE_TOKEN" in r.text
+    assert "HAL0_SESSION_TOKEN" in r.text
     assert "value-for-" not in r.text
 
 

--- a/ui/src/dash/agents/agents-overview.jsx
+++ b/ui/src/dash/agents/agents-overview.jsx
@@ -79,37 +79,6 @@ function _piCoderIdentity() {
   };
 }
 
-// ── static (curated) identity for the live Turnstone card ────────────
-// Turnstone is a self-hosted orchestration platform running its own server
-// on loopback :9129; it routes every model through the hal0-api gateway and
-// mounts hal0-memory + hal0-admin over MCP. Like Pi it has no dedicated
-// backing slot — `model` is the default gateway virtual its config maps to.
-function _turnstoneIdentity() {
-  return {
-    id: "turnstone",
-    name: "Turnstone",
-    model: "hal0/agent",
-    role: "tool-using orchestration · judged · multi-workstream",
-    rarity: 3,
-    el: "#4fa9c9",
-    elGlow: "rgba(79,169,201,0.18)",
-    logo: (window.__hal0AgentArt && window.__hal0AgentArt.turnstone) || "",
-    logoScale: 0.7,
-    abilities: [
-      { name: "Local Routing", cost: 1, desc: "Maps every live hal0 slot to a model alias — all inference stays on the box.", pow: "70" },
-      { name: "Intent Judge", cost: 2, desc: "An LLM grades every tool call for risk before it runs; destructive acts gate for approval.", pow: "80" },
-      { name: "Workstreams", cost: 3, desc: "Runs parallel tool-using sessions with its own memory bank and MCP tools.", pow: "85" },
-    ],
-    skills: [
-      { l: "mcp tools", key: true },
-      { l: "memory", key: true },
-      { l: "judge · approvals", key: true },
-      { l: "web · search" },
-      { l: "server · sse" },
-    ],
-  };
-}
-
 // ── roadmap (coming-soon) cards — curated dummy content ─────────────
 function _lockedRoster() {
   const art = window.__hal0AgentArt || {};
@@ -164,7 +133,7 @@ function _primarySlot(slots) {
 //   false → down (red), and the card's Restart action is the way out
 //   null / absent → unknown (grey). Unobservable is NOT healthy: an older
 //           backend, a host without systemd, or an agent with no template unit
-//           (Pi is a CLI tool, Turnstone runs its own server) all land here.
+//           (Pi is a CLI tool) all land here.
 function _derive(agentRec, slot) {
   if (!agentRec) return { cls: "offline", label: "not installed" };
   const status = String(agentRec.status || "").toLowerCase();
@@ -224,21 +193,18 @@ function AgentsOverview() {
   // throughput/ctx from (_derive/_health both tolerate a null slot: status
   // falls back to "ready"/"not installed"/"down" off the AgentRecord alone,
   // health renders "—" placeholders).
-  // #1472: Pi and Turnstone used to look themselves up in GET /api/agents and
-  // run the result through _derive. That lookup can never hit: BUNDLED_AGENTS
-  // is ("hermes",) (src/hal0/agents/manager.py) and POST /api/agents/install
-  // 404s any other name, so no AgentRecord for pi-coder or turnstone is
-  // constructible. _derive(null, null) answers "not installed", which reads as
-  // "installable, just not installed yet" — the one thing that is not true.
-  // Both are roadmap entries; label them the way the legend already labels
-  // roadmap cards, and drop the dead lookup rather than leave wiring that
-  // implies a signal exists. Restore the probe when either is genuinely
-  // installable (Turnstone: loopback :9129 health; Pi: pi-coder driver config).
+  // #1472: Pi used to look itself up in GET /api/agents and run the result
+  // through _derive. That lookup can never hit: BUNDLED_AGENTS is ("hermes",)
+  // (src/hal0/agents/manager.py) and POST /api/agents/install 404s any other
+  // name, so no AgentRecord for pi-coder is constructible. _derive(null, null)
+  // answers "not installed", which reads as "installable, just not installed
+  // yet" — the one thing that is not true. Pi is a roadmap entry; label it the
+  // way the legend already labels roadmap cards, and drop the dead lookup
+  // rather than leave wiring that implies a signal exists. Restore the probe
+  // when it is genuinely installable (pi-coder driver config).
   const ROADMAP_STATUS = { cls: "soon", label: "on the roadmap" };
   const { cls: piStatusCls, label: piStatusLabel } = ROADMAP_STATUS;
   const piHealth = _health(null);
-  const { cls: tsStatusCls, label: tsStatusLabel } = ROADMAP_STATUS;
-  const tsHealth = _health(null);
 
   const onRestart = () => {
     if (!restart || restartState === "busy") return;
@@ -264,18 +230,18 @@ function AgentsOverview() {
     <div className="agents-overview" data-testid="agents-overview">
       <div className="ao-head">
         <div className="ao-eye">hal0 · agent library</div>
-        {/* #1472: this claimed Hermes, Pi and Turnstone were all "live —
-            their cards stream real install/endpoint status". Only Hermes can
-            be: BUNDLED_AGENTS is ("hermes",) and POST /api/agents/install
-            404s any other name, so no AgentRecord for pi-coder or turnstone
-            can exist and both cards were permanently "not installed" — which
-            reads as "installable, just not installed yet". They are on the
-            roadmap like the rest; say that instead of contradicting the
-            page's own legend. */}
+        {/* #1472: this claimed Hermes and Pi were both "live — their cards
+            stream real install/endpoint status". Only Hermes can be:
+            BUNDLED_AGENTS is ("hermes",) and POST /api/agents/install 404s
+            any other name, so no AgentRecord for pi-coder can exist and the
+            card was permanently "not installed" — which reads as
+            "installable, just not installed yet". It is on the roadmap like
+            the rest; say that instead of contradicting the page's own
+            legend. */}
         <p className="ao-sub">
           Every agent in the runtime as a collectible card. <b>Hermes</b> is live — its card
           streams real install/endpoint status and flips to abilities, skills, and quick
-          actions. <b>Pi</b> and <b>Turnstone</b> are on the roadmap alongside the rest.
+          actions. <b>Pi</b> is on the roadmap alongside the rest.
         </p>
         <div className="ao-legend">
           <span className="ao-lz"><span className="d serving" />Serving <span className="k">· live, wired</span></span>
@@ -301,14 +267,6 @@ function AgentsOverview() {
             health={piHealth}
             statusCls={piStatusCls}
             statusLabel={piStatusLabel}
-          />
-        )}
-        {LiveAgentCard && (
-          <LiveAgentCard
-            agent={_turnstoneIdentity()}
-            health={tsHealth}
-            statusCls={tsStatusCls}
-            statusLabel={tsStatusLabel}
           />
         )}
         {LockedAgentCard && _lockedRoster().map((a) => <LockedAgentCard key={a.id} agent={a} />)}

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -815,12 +815,6 @@ function Footer({ updateAvailable, expanded = false, onToggle }) {
       title: serviceById.hermes?.detail || (serviceHealth.pending ? 'service health pending' : 'hermes down'),
     },
     {
-      id: 'turnstone',
-      label: 'turnstone',
-      tone: serviceHealth.pending ? 'warn' : serviceById.turnstone?.up ? 'up' : 'err',
-      title: serviceById.turnstone?.detail || (serviceHealth.pending ? 'service health pending' : 'turnstone down'),
-    },
-    {
       id: 'openwebui',
       label: 'openwebui',
       tone: serviceHealth.pending ? 'warn' : serviceById.openwebui?.up ? 'up' : 'err',

--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -828,7 +828,7 @@ function RDActivityCard({ swap }) {
 
 // ─── band C · services ───────────────────────────────────────────────────────
 
-const SERVICE_ORDER = ['openwebui', 'comfyui', 'hermes', 'turnstone', 'n8n']
+const SERVICE_ORDER = ['openwebui', 'comfyui', 'hermes', 'n8n']
 
 function RDServicesCard({ swap, onGo }) {
   const svc = useServices()


### PR DESCRIPTION
## What

Turnstone was retired from the installer, service registry, and user-facing docs in `93df008b` / `be9f1cef`, but the dashboard still carried it. This removes what was left:

- `ui/src/dash/agents/agents-overview.jsx` — the `_turnstoneIdentity()` card definition, the rendered `<LiveAgentCard>`, its `tsStatusCls` / `tsHealth` wiring, and the header copy
- `ui/src/dash/chrome.jsx` — the turnstone footer status indicator
- `ui/src/dash/dashboard-redesign.jsx` — the `SERVICE_ORDER` entry
- `src/hal0/api/routes/agents.py` — a prose mention in the `_unit_active` docstring
- `tests/security/test_api_env_mode.py`, `tests/security/test_secrets_protected_keys.py` — docstring mentions, and the protected-key fixture name

## Why

Nothing behind these existed anymore. The footer indicator read `serviceById.turnstone`, which no backend registers, so it could only ever render "turnstone down". The agent card was already labelled "on the roadmap" (#1472) for something no longer on it. The `SERVICE_ORDER` entry was inert.

The protected-key fixture switched from `HAL0_TURNSTONE_TOKEN` to `HAL0_SESSION_TOKEN`: the test only needs *some* `HAL0_`-prefixed name to prove the prefix gate refuses it, so behaviour is unchanged.

## Out of scope

`CHANGELOG.md` keeps its 7 historical mentions — those describe what shipped in past releases and are not a claim about the current runtime. `graphify-out/` is generated and refreshes on `graphify update .`.

## Verification

- `pytest tests/security` — 174 passed
- `pytest -k "agent or service"` — 1131 passed, 2 skipped, 1 xfail (pre-existing Hermes terminal-backend deviation, unrelated)
- `npm run test:unit` — 75 passed
- `npm run lint`, `npm run typecheck`, `npm run build` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)