### PR TITLE
feat(stt): reinstate Moonshine as the CPU STT engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Added
 
+- Moonshine reinstated as hal0's CPU STT engine, packaged as its own
+  toolbox image (`hal0-toolbox-moonshine:v1`). `voice.stt` is now a
+  device-keyed engine switch exactly like `voice.tts`: `cpu` runs
+  Moonshine, `npu` runs whisper-v3:turbo via the FLM trio, and GPU
+  devices resolve to no STT engine (previously a fall-through bug handed
+  the `stt` slot the wrong llama chat profile). Moonshine's weights are
+  operator-staged under the model store and preflighted at slot spawn,
+  failing loudly by name (`slot.weights_missing`) instead of 500ing on
+  first request. This supersedes the `[v0.2.0]` "Moonshine STT retired in
+  favour of `whisper.cpp`" entry below — that justification never held,
+  since `whisper.cpp` never shipped as a standalone CPU service. See
+  [`docs/adr/0001-moonshine-cpu-stt-reinstatement.md`](docs/adr/0001-moonshine-cpu-stt-reinstatement.md).
+
+### Added
+
 - Image Gen pane: proper engine lifecycle controls and running indicators.
   The header pill is state-typed off the live engine (stopped / starting /
   running / generating·% / error) with matching colors, and a Stop button

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -fsSL https://hal0.dev/install.sh | bash
 > virtual (code-defined, self-healing on upgrade) with dedicated
 > embed/rerank lanes and a model×profile×slot MTP decision; models carry
 > a preferred runtime profile, interrupted pulls resume, and voice runs
-> end-to-end (NPU STT + Kokoro or GPU Qwen3-TTS). The one-liner creates
+> end-to-end (NPU or CPU/Moonshine STT + Kokoro or GPU Qwen3-TTS). The one-liner creates
 > every capability slot and pulls the `brain` steward model; the rest of
 > the slots land model-less, so you assign models from the dashboard (or
 > `hal0 model pull` + `hal0 slot load`) with no surprise downloads. See
@@ -276,7 +276,7 @@ pins the container image and flag bundle for each backend.
 |--------------------------|----------------------------------|---------------------|--------------------------------------------------------------|
 | chat + embed + rerank    | `rocm` / `rocm-dnse` / `rocm-moe` / `vulkan` / `cuda` (experimental) | ROCm / Vulkan / CUDA / CPU | ROCm FP4 fork baked into the image; MTP via `--spec-type draft-mtp` on the `rocm-dnse`/`rocm-moe` profiles |
 | chat + STT + embed (NPU) | `flm` (`hal0-toolbox-flm`)  | AMD XDNA (opt-in)   | FLM trio: one container, `[npu] asr/embed` toggles, ~2 GB NPU mem |
-| transcription            | whisper.cpp in toolbox image     | Vulkan / CPU        | `stt` slot                                                   |
+| transcription            | `stt` (`hal0-toolbox-moonshine`) / FLM trio above | CPU / AMD XDNA | `voice.stt` switches Moonshine (CPU) ⇄ FLM's whisper-v3:turbo (NPU) without reconfiguring the slot; no GPU STT engine |
 | TTS                      | `tts` (`hal0-toolbox-kokoro`) / `tts-qwen3` (`hal0-toolbox-qwen3tts`) | CPU / ROCm | `voice.tts` switches Kokoro (CPU) ⇄ Qwen3-TTS (GPU) without reconfiguring the slot |
 | image                    | `comfyui` (`docker.io/kyuz0/amd-strix-halo-comfyui`) | ROCm | Exclusive GPU via arbiter; SD Turbo / Flux-2-Klein-9B        |
 

--- a/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
+++ b/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
@@ -1,0 +1,105 @@
+# ADR-0001: Reinstate Moonshine as the CPU STT engine
+
+## Status
+
+Accepted.
+
+## Context
+
+`v0.2.0` (the Lemonade migration cut) retired Moonshine STT "in favour of
+`whisper.cpp`" (CHANGELOG `[v0.2.0]`, Breaking: "Moonshine STT retired in
+favour of `whisper.cpp` via Lemonade"). That justification never held past
+the Lemonade rollback: `whisper.cpp` was never shipped as a standalone CPU
+toolbox service. The only Whisper hal0 actually runs is `whisper-v3:turbo`
+inside the FastFlowLM (FLM) NPU trio — chat + transcription + embedding
+coresident in one `flm serve` process on AMD XDNA hardware. `whisper.cpp` as
+a general-purpose CPU service is on the PLAN.md strip list (§"Strip (gone
+for good unless re-justified)", `PLAN.md:333-339`) alongside Vibevoice and
+Infinity, and was never re-justified.
+
+The practical result: any host without the XDNA NPU — CPU-only x86_64, or
+Strix Halo with FastFlowLM not installed — had **zero** speech-to-text.
+`voice.stt` could only ever be enabled via `backend=npu`, and the docs said
+so explicitly ("there is no CPU-only STT backend in hal0").
+
+Meanwhile TTS already solved the equivalent problem: `voice.tts` is a
+single canonical `tts` slot that runs one of two engines depending on the
+selected device — Kokoro-82M ONNX on CPU, or Qwen3-TTS on GPU (ROCm). No
+second slot, no `provider` selection — the device alone picks the engine.
+
+## Decision
+
+1. **Reinstate Moonshine as hal0's CPU STT engine**, packaged as its own
+   toolbox image (`ghcr.io/hal0ai/hal0-toolbox-moonshine:v1`, digest pinned
+   in `manifest.json`,
+   `sha256:bf07e3d5640fc1d009298be0600b62ec24185f80d7c8bed47321742fce17aa31`,
+   verified anonymously pullable 2026-08-03) and a new `MoonshineProvider`.
+
+2. **`voice.stt` becomes device-keyed, exactly like `voice.tts`**: `cpu` →
+   Moonshine, `npu` → the FLM trio's Whisper. This is deliberately sound at
+   exactly two engines on two devices — the device alone disambiguates
+   which engine a slot runs, with no separate `provider` field needed on
+   the capability selection. GPU devices resolve to **no STT engine**: hal0
+   ships no GPU STT engine, and the previous behavior — falling through to
+   the generic GPU branch and silently handing the `stt` slot a llama chat
+   profile — was a live bug (wrong runtime family; the slot could never
+   actually start the STT image). That fall-through is fixed: `(stt,
+   gpu-*)` now resolves to `None` and surfaces a typed error instead of a
+   wrong profile.
+
+   **Future-work trigger:** this device-keyed rule holds only because
+   exactly one engine exists per device. If a **second** CPU STT engine
+   ever lands, `device` stops being enough to disambiguate, and `provider`
+   must become a first-class selector in capability selection (mirroring
+   how `voice.tts` would need the same treatment if a second CPU or GPU TTS
+   engine appeared). Don't extend the device-keyed rule past two engines
+   without making that change first.
+
+3. **Weights are operator-staged, not registry-pulled.** Moonshine ships a
+   multi-file ONNX bundle (encoder/decoder `.ort`/`.onnx` + tokenizer JSON)
+   that the curated catalogue's single-file GGUF/safetensors/checkpoint
+   schema can't express — the same documented open item covering Kokoro and
+   Vibevoice (see the three resolution paths noted in
+   `docs/reference/model-roster-benchmark.mdx`). Rather than block on a
+   schema redesign, Moonshine's resolution ships now: the operator stages
+   the bundle under the model store (default
+   `/mnt/ai-models/local/moonshine`, leaf layout `quantized/<variant>/`,
+   e.g. `quantized/small-streaming-en/`), and
+   both slot spawn and `hal0 doctor` preflight the path — a missing or
+   empty bundle fails loudly, by name (`slot.weights_missing`), instead of
+   starting a container that 500s on the first real request.
+
+4. **This supersedes the `[v0.2.0]` retirement claim.** "Moonshine STT
+   retired in favour of `whisper.cpp`" is no longer accurate on either
+   half: `whisper.cpp` never shipped as the CPU service that justified the
+   retirement, and Moonshine is back as the CPU engine. The CHANGELOG entry
+   is left as a historical record; this ADR is the record of record for why
+   the decision reversed.
+
+hal0 binds 0.0.0.0:8080 with no built-in auth by design (LAN-trust
+posture); voice endpoints accept file uploads on that unauthenticated bind.
+The Moonshine server also exposes a `WS /v1/audio/stream` endpoint for live
+PCM16 streaming — this is **in-container only**, not routed by the hal0
+dispatcher, and is not part of the public API surface.
+
+## Consequences
+
+- CPU-only and NPU-less hosts get real STT again, with no NPU/FastFlowLM
+  dependency.
+- `voice.stt` and `voice.tts` are now symmetric device-keyed switches,
+  which keeps the capability-selection mental model (and its
+  `profile_name_for_fit` implementation) consistent across both children
+  of `voice`.
+- Operators on CPU-only STT take on a manual staging step (and a doctor
+  preflight to catch it) rather than a registry pull — an explicit,
+  documented trade-off, not an oversight, until the curated-catalogue
+  multi-file-bundle schema work lands.
+- The device-keyed `stt` rule is a two-engine special case, not a general
+  pattern — see the future-work trigger above. Anyone adding a third STT
+  engine (a second CPU engine, or any GPU engine) must revisit
+  `profile_name_for_fit` and the capability-selection schema together, not
+  patch around the device switch.
+- What would retire Moonshine again: a GPU or NPU STT engine that
+  outperforms it on every host Moonshine currently serves, or a curated
+  multi-file-bundle resolution path landing that makes the operator-staging
+  step unnecessary — neither has happened yet.

--- a/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
+++ b/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
@@ -119,3 +119,21 @@ dispatcher, and is not part of the public API surface.
   outperforms it on every host Moonshine currently serves, or a curated
   multi-file-bundle resolution path landing that makes the operator-staging
   step unnecessary — neither has happened yet.
+
+## Open item, surfaced but not settled here
+
+The capability picker still offers `Whisper-Large-v3-Turbo` for `voice.stt`
+under provider `whispercpp`. Two parts of the tree disagree about whether it
+should: `tests/capabilities/test_stt_curation.py` (#514) asserts the row must
+be visible and must fan out to a real host backend, while
+`registry/curated.py`'s own TODO records that no whisper.cpp runtime exists —
+no toolbox image, no provider, no runtime family — so the pick cannot serve a
+request on any host.
+
+This ADR does not resolve that. It only removes the way the STT engine switch
+made it *worse*: a device-keyed profile rule handed those `cpu` rows
+Moonshine's profile, which would have started `MoonshineProvider` against a
+Whisper GGUF. `profile_name_for_fit` now resolves no profile for an STT
+provider hal0 has no runtime for, so the row is inert rather than actively
+mis-wired. Deciding whether to ship a whisper.cpp toolbox image or drop the
+curated surfacing belongs to whoever revisits #514.

--- a/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
+++ b/docs/adr/0001-moonshine-cpu-stt-reinstatement.md
@@ -62,12 +62,28 @@ second slot, no `provider` selection — the device alone picks the engine.
    Vibevoice (see the three resolution paths noted in
    `docs/reference/model-roster-benchmark.mdx`). Rather than block on a
    schema redesign, Moonshine's resolution ships now: the operator stages
-   the bundle under the model store (default
-   `/mnt/ai-models/local/moonshine`, leaf layout `quantized/<variant>/`,
-   e.g. `quantized/small-streaming-en/`), and
-   both slot spawn and `hal0 doctor` preflight the path — a missing or
-   empty bundle fails loudly, by name (`slot.weights_missing`), instead of
-   starting a container that 500s on the first real request.
+   the bundle (default `/mnt/ai-models/local/moonshine`; hal0 walks the tree
+   for the directory holding `encoder_model.{ort,onnx}`, so both the root
+   and a `quantized/<variant>/` leaf work), and both slot spawn and
+   `hal0 doctor` preflight the path — a missing or unusable bundle fails
+   loudly, by name (`slot.weights_missing`), instead of starting a container
+   that 500s on the first real request.
+
+   Live validation on lxc105 (2026-08-03) sharpened three points of this
+   decision, each now covered by a regression test:
+   - **Only non-streaming variants are usable.** The streaming bundles ship
+     the Moonshine streaming SDK's file set (`encoder.ort`, `frontend.ort`),
+     which this image cannot load. The preflight names that case rather than
+     accepting any `*.ort` file.
+   - **Staged weights may sit outside the model store root.** A box whose
+     `[models].roots` is `/var/lib/hal0/models` can legitimately stage under
+     `/mnt/ai-models`; the slot mounts the resolved path (and its realpath)
+     identical-path read-only so the container can read it.
+   - **A registry path only wins when it is a Moonshine bundle.** Because
+     the provider is self-managed, the manager's model lookup for a
+     transcription slot may return an unrelated ASR artifact (it returned a
+     VibeVoice `.gguf`); such a path is ignored in favour of the staged
+     bundle.
 
 4. **This supersedes the `[v0.2.0]` retirement claim.** "Moonshine STT
    retired in favour of `whisper.cpp`" is no longer accurate on either

--- a/docs/concepts/capabilities-and-profiles.mdx
+++ b/docs/concepts/capabilities-and-profiles.mdx
@@ -74,6 +74,7 @@ works regardless of which device a slot targets:
 | `flm` | FLM inference on the NPU (chat/embed/STT) |
 | `kokoro` | Text-to-speech (Kokoro), CPU |
 | `qwen3-tts` | Text-to-speech (Qwen3-TTS), GPU |
+| `moonshine` | Speech-to-text (Moonshine), CPU |
 | `comfyui` | Image generation (ComfyUI) |
 | `brain` | The hal0-brain steward workload (small tool-routing model) |
 | `chadrock-dense` / `chadrock-moe` | Family-tuned recipes for specific dense/MoE model cards (ROCmFP4, MTP, mmproj) |
@@ -125,7 +126,7 @@ A `ProfileConfig` still carries two optional fields, `device_class` and
 `backend`, for back-compat — but as of v1.0 they are **inert match-only fit
 hints**, not a source of runtime configuration:
 
-- None of the 16 shipped seed profiles set either field — they're
+- None of the 17 shipped seed profiles set either field — they're
   device-agnostic by construction.
 - When set (on a hand-authored or pre-1.0 profile), `device_class` is
   consulted only as a **fit-check** signal (surfacing a

--- a/docs/guides/voice-stt-tts.mdx
+++ b/docs/guides/voice-stt-tts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Speech to text and text to speech
-description: "Enable hal0's voice capability with hal0 capabilities set: transcription via whisper-class models on the XDNA NPU (FLM), synthesis via Kokoro (CPU) or Qwen3-TTS (GPU), then call /v1/audio/transcriptions and /v1/audio/speech."
+description: "Enable hal0's voice capability with hal0 capabilities set: transcription via Moonshine (CPU) or whisper-class models on the XDNA NPU (FLM), synthesis via Kokoro (CPU) or Qwen3-TTS (GPU), then call /v1/audio/transcriptions and /v1/audio/speech."
 sidebar:
   order: 80
 ---
@@ -9,9 +9,12 @@ import { Steps, Aside, Tabs, TabItem, Code } from '@astrojs/starlight/components
 
 hal0 exposes two voice directions through OpenAI-compatible endpoints:
 
-- **Speech-to-text** (`POST /v1/audio/transcriptions`) — served by
-  FastFlowLM (FLM) on the XDNA NPU, co-loaded with the chat model in one
-  FLM process (the "NPU trio": chat + STT + embed).
+- **Speech-to-text** (`POST /v1/audio/transcriptions`) — served from the
+  single canonical `stt` slot, which can run **either** engine: Moonshine
+  (ONNX) on CPU, or whisper-v3:turbo on the XDNA NPU, co-loaded with the
+  chat model in one FLM process (the "NPU trio": chat + STT + embed).
+  Choosing a device swaps which engine the `stt` slot runs — there's no
+  separate slot to configure.
 - **Text-to-speech** (`POST /v1/audio/speech`) — served from the single
   canonical `tts` slot, which can run **either** engine: Kokoro-82M ONNX
   on CPU, or Qwen3-TTS on GPU (ROCm, native gfx1151). Choosing a device
@@ -19,7 +22,10 @@ hal0 exposes two voice directions through OpenAI-compatible endpoints:
   configure.
 
 Both are children of the **`voice`** capability: `voice.stt` maps to the
-`stt` slot and `voice.tts` maps to the `tts` slot.
+`stt` slot and `voice.tts` maps to the `tts` slot. Both children are
+now device-keyed engine switches with the same shape — see
+[ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/) for why `stt`
+was redesigned to match `tts` here.
 
 ## Enable the voice capability
 
@@ -32,12 +38,21 @@ Or over the API, which accepts any subset of `{ backend, provider, model,
 enabled }`:
 
 <Tabs>
+<TabItem label="Speech-to-text (CPU, Moonshine)">
+
+```sh
+curl -X POST http://localhost:8080/api/capabilities/voice/stt \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true, "backend": "cpu", "provider": "moonshine"}'
+```
+
+</TabItem>
 <TabItem label="Speech-to-text (NPU, FLM)">
 
 ```sh
 curl -X POST http://localhost:8080/api/capabilities/voice/stt \
   -H 'Content-Type: application/json' \
-  -d '{"enabled": true, "backend": "npu"}'
+  -d '{"enabled": true, "backend": "npu", "provider": "flm"}'
 ```
 
 </TabItem>
@@ -62,12 +77,28 @@ curl -X POST http://localhost:8080/api/capabilities/voice/tts \
 </Tabs>
 
 <Aside type="note">
-STT runs on the XDNA NPU via the FLM container — there is no CPU-only STT
-backend in hal0. TTS runs from the single `tts` slot on either engine:
-Kokoro (CPU, ONNX) or Qwen3-TTS (GPU, ROCm) — picking a device in the
-`voice.tts` picker swaps the engine in place, it does not add a second
-slot.
+STT runs from the single `stt` slot on either engine: Moonshine (CPU,
+ONNX) or whisper-v3:turbo via the XDNA NPU's FLM trio — picking a device in
+the `voice.stt` picker swaps the engine in place, it does not add a second
+slot. GPU devices carry **no** STT engine: hal0 ships no GPU STT backend,
+so selecting a GPU device for `voice.stt` returns a typed error instead of
+silently loading the wrong profile. TTS runs from the single `tts` slot on
+either engine: Kokoro (CPU, ONNX) or Qwen3-TTS (GPU, ROCm) — picking a
+device in the `voice.tts` picker swaps the engine in place the same way.
 </Aside>
+
+### The `voice.stt` engine switch
+
+| Device | Provider | Runs on |
+| --- | --- | --- |
+| `cpu` | `moonshine` | CPU (ONNX) |
+| `npu` | `flm` | XDNA NPU, coresident with chat + embed in the FLM trio |
+
+There is deliberately no GPU row — hal0 ships no GPU STT engine. This is a
+two-engine, two-device special case, not a general `provider` selector: if
+a second CPU (or GPU) STT engine ever lands, `device` alone stops being
+enough to disambiguate and `provider` must become a first-class part of
+capability selection (see [ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/)).
 
 ### The `voice.tts` engine switch
 
@@ -76,10 +107,29 @@ slot.
 | `cpu` | `kokoro` | CPU (ONNX) |
 | `gpu-rocm` | `qwen3tts` | Strix Halo iGPU (ROCm, native gfx1151) |
 
-Selecting a device rewrites which provider the `tts` slot loads — the
-slot itself doesn't move. Both engines' weights are operator-staged (not
-pulled through the hal0 registry); the slot mounts a writable cache
-directory for kernel/tokenizer caches.
+Selecting a device rewrites which provider the `tts` (or `stt`) slot
+loads — the slot itself doesn't move. Kokoro, Qwen3-TTS, and Moonshine
+weights are all operator-staged (not pulled through the hal0 registry;
+whisper-v3:turbo on the FLM/NPU path resolves through FastFlowLM's own
+model handling instead). Moonshine's weights preflight at slot spawn — a
+missing or empty bundle fails loudly, by name (`slot.weights_missing`),
+rather than starting a container that 500s on the first request. The
+`tts` slot additionally mounts a writable cache directory for
+kernel/tokenizer caches.
+
+### How the CPU STT path works (Moonshine)
+
+Enabling `voice.stt` with `backend=cpu` spawns the `stt` slot's own
+container from the `hal0-toolbox-moonshine` image (`MoonshineProvider`),
+distinct from the NPU path below — it's a standalone process, not a
+co-loaded FLM role. The container wraps an OpenAI-compatible FastAPI
+server (`POST /v1/audio/transcriptions`, `GET /v1/models`, `GET /health`).
+It also exposes `WS /v1/audio/stream` for live PCM16 (16 kHz mono)
+streaming transcription — this endpoint is **in-container only** and is
+**not** routed by the hal0 dispatcher; it isn't part of the public `/v1/*`
+surface. hal0 binds `0.0.0.0:8080` with no built-in auth by design
+(LAN-trust posture); voice endpoints accept file uploads on that
+unauthenticated bind.
 
 ### How the NPU STT path works
 

--- a/docs/guides/voice-stt-tts.mdx
+++ b/docs/guides/voice-stt-tts.mdx
@@ -117,6 +117,32 @@ rather than starting a container that 500s on the first request. The
 `tts` slot additionally mounts a writable cache directory for
 kernel/tokenizer caches.
 
+### Staging the Moonshine weights
+
+The bundle is a directory the loader reads directly — it resolves
+`encoder_model.ort` (or `.onnx`) plus `decoder_model_merged.*` and the
+tokenizer inside whatever directory it is handed. Two consequences:
+
+- **Stage a non-streaming variant.** The `base-en` bundle has the file
+  names the loader wants. The *streaming* bundles (`small-streaming-en`,
+  `medium-streaming-en`) ship a different file set (`encoder.ort`,
+  `frontend.ort`, `adapter.ort`) belonging to the Moonshine streaming SDK,
+  which this image does not consume. Pointing the slot at one is rejected
+  at spawn with `slot.weights_missing` naming the streaming case.
+- **Point `--model_path` anywhere sensible.** hal0 walks the tree to find
+  the directory holding the encoder, so both `…/base-en` and
+  `…/base-en/quantized/base-en` work. If the resolved path is outside the
+  model store root, the slot mounts it read-only at the same absolute path
+  (plus the symlink target, if any) so the container can read it.
+
+Verify staging before enabling the capability:
+
+```sh
+hal0 doctor all --json | jq '.[] | select(.key == "stt-weights")'
+```
+
+A `pass` names the staged path; a `fail` names exactly what is missing.
+
 ### How the CPU STT path works (Moonshine)
 
 Enabling `voice.stt` with `backend=cpu` spawns the `stt` slot's own

--- a/docs/reference/model-roster-benchmark.mdx
+++ b/docs/reference/model-roster-benchmark.mdx
@@ -59,11 +59,17 @@ the first-run wizard's model cards render via `GET /api/install/curated-models`.
 | `tags`, `notes` | — |
 
 <Aside type="caution">
-STT/TTS curated picks are not implemented as of this writing — moonshine, kokoro, and
-vibevoice can't be expressed in the current single-file GGUF/safetensors/checkpoint
-curated schema (they ship as multi-file ONNX/PyTorch bundles). This is a documented
-open item in source with three possible resolution paths, none landed. Don't document
-a curated STT/TTS pick flow as existing.
+STT/TTS curated picks are not implemented as of this writing — kokoro and vibevoice
+can't be expressed in the current single-file GGUF/safetensors/checkpoint curated
+schema (they ship as multi-file ONNX/PyTorch bundles). This is a documented open item
+in source with three possible resolution paths, none landed for those two. Don't
+document a curated STT/TTS pick flow as existing for kokoro or vibevoice.
+
+Moonshine's resolution is decided (it doesn't wait on the curated-schema redesign):
+weights are operator-staged under the model store rather than registry-pulled, and
+both slot spawn and `hal0 doctor` preflight the staged path, failing loudly and by
+name (`slot.weights_missing`) instead of starting a container that 500s on first
+request. See [ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/).
 </Aside>
 
 ## Hardware-driven recommendation

--- a/docs/reference/providers-profiles-devices.mdx
+++ b/docs/reference/providers-profiles-devices.mdx
@@ -24,6 +24,7 @@ process. Concrete implementations:
 | `ComfyUIProvider` | `providers/comfyui.py` | Image generation. |
 | `KokoroProvider` | `providers/kokoro.py` | TTS. |
 | `Qwen3TTSProvider` | `providers/qwen3tts.py` | TTS. |
+| `MoonshineProvider` | `providers/moonshine.py` | STT (CPU, ONNX). |
 
 Every `Provider` is stateless — no per-slot mutable state lives on the instance.
 Abstract methods: `build_env()`, `start_cmd()`, `health()`, `infer()`,
@@ -112,11 +113,19 @@ still referenced by a slot or by a model's `defaults.profile`). Seed profiles ar
 only cloned.
 
 A resolved profile (`ResolvedProfile`) adds derived fields: `runtime_family`
-(`llama-server, flm, kokoro, qwen3tts, comfyui` — classified structurally off name and
-`device_class`, not by sniffing an image string), `supported_slot_types` (e.g. `flm` →
-`llm, embedding, transcription`; `kokoro`/`qwen3tts` → `tts`; `comfyui` → `image`;
-everything else → `llm, embedding, reranking`), `used_by` (slot names referencing the
-profile), and static `tps`/`rtf` numbers from the bench table.
+(`llama-server, flm, kokoro, qwen3tts, moonshine, comfyui` — classified structurally off
+name and `device_class`, not by sniffing an image string), `supported_slot_types` (e.g.
+`flm` → `llm, embedding, transcription`; `kokoro`/`qwen3tts` → `tts`; `moonshine` →
+`transcription`; `comfyui` → `image`; everything else → `llm, embedding, reranking`),
+`used_by` (slot names referencing the profile), and static `tps`/`rtf` numbers from the
+bench table.
+
+The seeded `moonshine` profile (device `cpu`) is the STT sibling of the seeded `kokoro`
+profile: `runtime_family = "moonshine"`, `supported_slot_types = ("transcription",)`,
+image `ghcr.io/hal0ai/hal0-toolbox-moonshine:v1` (resolved via `RUNNER_IMAGES["moonshine"]`,
+digest pinned in `manifest.json`), and self-managed (operator-staged) weights — see
+[Voice: STT and TTS](/docs/guides/voice-stt-tts/) and
+[ADR-0001](/docs/adr/0001-moonshine-cpu-stt-reinstatement/).
 
 ## Device taxonomy
 

--- a/scripts/release-test.sh
+++ b/scripts/release-test.sh
@@ -233,8 +233,16 @@ with wave.open(\"$TMP/t.wav\",\"wb\") as w:
     w.setnchannels(1); w.setsampwidth(2); w.setframerate(16000)
     w.writeframes(b\"\".join(struct.pack(\"<h\", int(32000*math.sin(2*math.pi*440*i/16000))) for i in range(16000)))
 "
+        # The served id is moonshine-<arch>-en (moonshine_server /v1/models),
+        # NOT moonshine-<arch> — a bare "moonshine-base" falls through the
+        # router to an upstream that answers 501 "does not support audio
+        # input", so this row could never pass as written. Auth header is
+        # required on any box with HAL0_ADMIN_KEY set (unauthenticated is
+        # 401); it is sourced from api.env the same way an operator would.
+        set +u; [ -r /etc/hal0/api.env ] && . /etc/hal0/api.env; set -u
         curl -fsS -m 30 '"${REMOTE_HAL0_API}"'/v1/audio/transcriptions \
-            -F file=@$TMP/t.wav -F model=moonshine-base \
+            ${HAL0_ADMIN_KEY:+-H "Authorization: Bearer $HAL0_ADMIN_KEY"} \
+            -F file=@$TMP/t.wav -F model=moonshine-base-en \
             -o $TMP/out.json
         rm -rf $TMP
     '; then

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -750,16 +750,18 @@ def _registry_downloaded(model_id: str, *, registry: ModelRegistry | None) -> bo
         return False
 
 
-#: The one CPU STT engine surfaced directly (mirrors ``_TTS_ENGINES``). The
-#: seeded id matches ``moonshine-small-streaming-en`` in
-#: ``seeds/haloai_models.json`` exactly — that HaloaiModel entry is
-#: otherwise skipped from the flat fan-out (see ``_flat_rows_for_capability``
-#: docstring: HaloaiModel rows surface no download path / working route on a
-#: standalone install), so this injects the picker row directly instead,
-#: the same way :func:`_tts_rows_for_capability` injects its two engines.
+#: The one CPU STT engine surfaced directly (mirrors ``_TTS_ENGINES``).
+#:
+#: The id is what ``moonshine_server`` actually advertises on ``/v1/models``
+#: for the bundle hal0 can load: ``moonshine-<arch>-en`` with the default
+#: ``base`` arch. It deliberately does NOT reuse the
+#: ``moonshine-small-streaming-en`` HaloaiModel seed row — that id names a
+#: STREAMING bundle, whose file set this toolbox image cannot load at all
+#: (see ``providers.moonshine._ENCODER_STEMS``), so advertising it would
+#: hand the operator a pick that can never serve a request.
 #: NPU stt is NOT here — it fans out through :func:`_flm_rows_for_capability`
 #: (the FLM trio), same split as embed.
-_STT_ENGINE_ID = "moonshine-small-streaming-en"
+_STT_ENGINE_ID = "moonshine-base-en"
 
 
 def _stt_rows_for_capability(

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -669,6 +669,13 @@ def _flat_rows_for_capability(
         seen.add(key)
         rows.append(tts_row)
 
+    for stt_row in _stt_rows_for_capability(capability, registry=registry):
+        key = (stt_row["id"], stt_row["backend"])
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(stt_row)
+
     return rows
 
 
@@ -741,6 +748,50 @@ def _registry_downloaded(model_id: str, *, registry: ModelRegistry | None) -> bo
         return Path(reg_path).exists()
     except OSError:
         return False
+
+
+#: The one CPU STT engine surfaced directly (mirrors ``_TTS_ENGINES``). The
+#: seeded id matches ``moonshine-small-streaming-en`` in
+#: ``seeds/haloai_models.json`` exactly — that HaloaiModel entry is
+#: otherwise skipped from the flat fan-out (see ``_flat_rows_for_capability``
+#: docstring: HaloaiModel rows surface no download path / working route on a
+#: standalone install), so this injects the picker row directly instead,
+#: the same way :func:`_tts_rows_for_capability` injects its two engines.
+#: NPU stt is NOT here — it fans out through :func:`_flm_rows_for_capability`
+#: (the FLM trio), same split as embed.
+_STT_ENGINE_ID = "moonshine-small-streaming-en"
+
+
+def _stt_rows_for_capability(
+    capability: str,
+    *,
+    registry: ModelRegistry | None = None,
+) -> list[dict[str, Any]]:
+    """Enumerate the CPU Moonshine engine for the voice.stt picker.
+
+    Device-keyed STT engine switch (mirrors TTS): CPU runs the standalone
+    Moonshine engine (this row); NPU is served coresident by the FLM trio
+    (:func:`_flm_rows_for_capability`) — there is no GPU STT engine.
+    Moonshine's weights are operator-staged (multi-file ONNX bundle, not
+    registry-pulled), so ``downloaded`` comes from a registry lookup like
+    :func:`_registry_downloaded` handles for ``qwen3-tts`` and ``pullable``
+    is always False — mirrors how :func:`_tts_rows_for_capability` treats
+    the self-managed Qwen3-TTS engine.
+    """
+    if capability != "stt":
+        return []
+
+    return [
+        {
+            "id": _STT_ENGINE_ID,
+            "backend": "cpu",
+            "provider": "moonshine",
+            "size_gb": 0.0,
+            "capabilities": ["stt"],
+            "downloaded": _registry_downloaded(_STT_ENGINE_ID, registry=registry),
+            "pullable": False,
+        }
+    ]
 
 
 def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -796,7 +796,7 @@ def _stt_rows_for_capability(
     ]
 
 
-def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:
+def _profile_for_fit(capability: str, device: str, provider: str = "") -> ResolvedProfile | None:
     """Infer the profile implied by a picker backend.
 
     Mirrors CapabilityOrchestrator's conservative inference so picker and
@@ -808,7 +808,7 @@ def _profile_for_fit(capability: str, device: str) -> ResolvedProfile | None:
     # module, so a top-level import here would be circular.
     from hal0.capabilities.profile_fit import profile_name_for_fit
 
-    profile_name = profile_name_for_fit(capability, device)
+    profile_name = profile_name_for_fit(capability, device, provider)
     if not profile_name:
         return None
     try:
@@ -833,7 +833,7 @@ def _row_with_model_fit(
     if slot_type is None:
         return row
     backend_id = str(row.get("backend") or "")
-    profile = _profile_for_fit(capability, backend_id)
+    profile = _profile_for_fit(capability, backend_id, str(row.get("provider") or ""))
     registry_for_fit = None
     if registry is not None:
         try:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -724,7 +724,7 @@ class CapabilityOrchestrator:
         # it); ``profile_name_for_fit`` returns ``None`` for any device this
         # branch could see beyond cpu, so the stamp only ever fires there.
         elif child == "stt":
-            stt_profile = profile_name_for_fit("stt", selection.device)
+            stt_profile = profile_name_for_fit("stt", selection.device, selection.provider or "")
             if stt_profile is not None:
                 cfg_dict["profile"] = stt_profile
         try:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -413,6 +413,19 @@ class CapabilityOrchestrator:
                 details={"slot": slot, "child": child, "partial": partial},
             ) from exc
 
+        # voice.stt is a device-keyed engine switch with engines on cpu
+        # (moonshine) and npu (FLM whisper) ONLY — hal0 ships no GPU STT
+        # engine. Reject a GPU device with a typed error here; the historical
+        # behaviour (falling through profile inference) handed the stt slot a
+        # llama chat profile, which could never start an STT image.
+        if child == "stt" and merged.device.startswith("gpu"):
+            raise BadRequest(
+                f"no STT engine exists for device {merged.device!r} — "
+                "voice.stt runs on 'cpu' (moonshine) or 'npu' (FLM whisper)",
+                code="capability.no_engine_for_device",
+                details={"slot": slot, "child": child, "device": merged.device},
+            )
+
         # Validate the model against the catalog when one is set + the
         # caller didn't explicitly clear it. We don't fail when the model
         # is empty — that's the "unset" state.
@@ -701,6 +714,19 @@ class CapabilityOrchestrator:
             cfg_dict["type"] = "tts"
             cfg_dict["runtime"] = "container"
             cfg_dict["profile"] = tts_profile_for_device(selection.device)
+        # voice.stt engine switch (moonshine reinstatement): a (re)created cpu
+        # stt slot carries the Moonshine profile explicitly, mirroring the tts
+        # mechanism above, rather than relying on MoonshineProvider's own
+        # profile-less default (belt-and-suspenders — the slot's on-disk shape
+        # then already matches what a reconciled EXISTING slot would carry via
+        # SlotConfigStore._engine_profile_for). The npu case never reaches
+        # here (`_apply_npu_trio_modality` / `_ensure_slot_exists_npu` handle
+        # it); ``profile_name_for_fit`` returns ``None`` for any device this
+        # branch could see beyond cpu, so the stamp only ever fires there.
+        elif child == "stt":
+            stt_profile = profile_name_for_fit("stt", selection.device)
+            if stt_profile is not None:
+                cfg_dict["profile"] = stt_profile
         try:
             await self._slot_manager.create(slot_name, cfg_dict)
         except Exception as exc:

--- a/src/hal0/capabilities/profile_fit.py
+++ b/src/hal0/capabilities/profile_fit.py
@@ -33,6 +33,19 @@ def profile_name_for_fit(capability: str, device: str) -> str | None:
     if capability == "tts":
         # Engine switch within the tts slot — GPU resolves Qwen3, CPU Kokoro.
         return tts_profile_for_device(device)
+    if capability == "stt":
+        # Device-keyed STT engine switch (mirrors tts): NPU → the FLM trio,
+        # CPU → Moonshine. There is deliberately NO GPU branch — hal0 ships
+        # no GPU STT engine, and falling through to the generic GPU branch
+        # below would hand the stt slot a llama chat profile (wrong runtime
+        # family; the slot would never start the STT image). If a second CPU
+        # STT engine ever lands, this device-keyed rule stops discriminating
+        # and `provider` must become part of the selection (see the ADR).
+        if device == "npu":
+            return DEVICE_DEFAULT_PROFILES.get("npu")
+        if device == "cpu":
+            return "moonshine"
+        return None
     if device == "npu":
         return DEVICE_DEFAULT_PROFILES.get("npu")
     if capability == "embed" and device in {"gpu-rocm", "gpu-vulkan"}:

--- a/src/hal0/capabilities/profile_fit.py
+++ b/src/hal0/capabilities/profile_fit.py
@@ -17,8 +17,13 @@ from __future__ import annotations
 from hal0.capabilities.catalog import tts_profile_for_device
 from hal0.config.schema import DEVICE_DEFAULT_PROFILES
 
+#: STT providers hal0 actually has a runtime profile for. A selection naming
+#: anything else resolves NO profile rather than inheriting the CPU engine's
+#: (see the ``stt`` branch below).
+_STT_PROVIDERS_WITH_PROFILES: frozenset[str] = frozenset({"moonshine", "flm"})
 
-def profile_name_for_fit(capability: str, device: str) -> str | None:
+
+def profile_name_for_fit(capability: str, device: str, provider: str = "") -> str | None:
     """Infer the runtime profile name implied by a picker/apply selection.
 
     Keeps inference conservative: use profiles where the device/capability
@@ -41,6 +46,16 @@ def profile_name_for_fit(capability: str, device: str) -> str | None:
         # family; the slot would never start the STT image). If a second CPU
         # STT engine ever lands, this device-keyed rule stops discriminating
         # and `provider` must become part of the selection (see the ADR).
+        #
+        # ``provider`` is honoured NARROWLY here: a caller that names an
+        # engine hal0 has no profile for gets ``None`` instead of the CPU
+        # engine's profile. Live case (lxc105): the picker offers
+        # Whisper-Large-v3-Turbo under provider ``whispercpp`` (a curated
+        # surfacing decision from #514, with no runtime behind it), and the
+        # device-only rule handed that row Moonshine's profile — a slot that
+        # would point MoonshineProvider at a Whisper GGUF it cannot load.
+        if provider and provider not in _STT_PROVIDERS_WITH_PROFILES:
+            return None
         if device == "npu":
             return DEVICE_DEFAULT_PROFILES.get("npu")
         if device == "cpu":

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -119,6 +119,57 @@ def check_secret_file_modes() -> Check:
     return Check("secret-modes", "Secret file modes", _PASS, "secret files are owner-only")
 
 
+def check_voice_stt_weights() -> Check:
+    """Moonshine STT weights preflight — the same rule slot spawn enforces.
+
+    The moonshine ONNX bundle is operator-staged (multi-file, not registry-
+    pulled), so a fresh box can configure the stt slot and only find out the
+    weights are missing when the container 500s. This row runs
+    :func:`hal0.providers.moonshine.check_moonshine_weights` against the
+    profile-baked ``--model_path`` so the gap is named here first. An empty
+    ``--model_path`` is the in-container HuggingFace auto-download path —
+    legitimate but slow on first start, so it warns rather than fails.
+    """
+    import shlex
+
+    from hal0.errors import Hal0Error
+    from hal0.profiles import ProfileCatalog
+    from hal0.providers.moonshine import check_moonshine_weights
+
+    try:
+        profile = ProfileCatalog().resolve("moonshine")
+    except Exception:
+        return Check(
+            "stt-weights",
+            "Moonshine weights",
+            _PASS,
+            "moonshine profile absent — nothing to preflight",
+        )
+    tokens = shlex.split(profile.resolved_flags or "")
+    model_path = ""
+    for i, tok in enumerate(tokens[:-1]):
+        if tok == "--model_path":
+            model_path = tokens[i + 1]
+    if not model_path:
+        return Check(
+            "stt-weights",
+            "Moonshine weights",
+            _WARN,
+            "no --model_path in the moonshine profile — first slot start will "
+            "auto-download from HuggingFace inside the container (slow, needs egress)",
+        )
+    try:
+        check_moonshine_weights(model_path)
+    except Hal0Error as exc:
+        return Check("stt-weights", "Moonshine weights", _FAIL, str(exc))
+    return Check(
+        "stt-weights",
+        "Moonshine weights",
+        _PASS,
+        f"staged bundle present at {model_path}",
+    )
+
+
 def check_model_store(
     models: Any,
     *,
@@ -387,6 +438,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_ports(_get_any("/api/slots", base, timeout=SLOTS_PROBE_TIMEOUT_S)),
         check_hal0_target(),
         check_secret_file_modes(),
+        check_voice_stt_weights(),
         check_seams(),
     ]
     return verify_rows + extra_rows

--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -1,4 +1,4 @@
-# hal0 1.0 seeded profile catalog (16 profiles total).
+# hal0 1.0 seeded profile catalog (17 profiles total).
 #
 # Per docs/superpowers/specs/2026-07-20-seeded-profile-rework-design.md §4:
 # Profiles are device-agnostic logical-tune TEMPLATES — they carry only
@@ -81,6 +81,17 @@ quant = "W4ABF16"
 flags = "--model_path /mnt/ai-models/local/kokoro-v1/kokoro-onnx"
 mtp = false
 intent = "Kokoro TTS"
+quant = ""
+
+[profile.moonshine]
+# Moonshine STT (CPU ONNX). Weights are operator-staged under the model
+# store (SELF_MANAGED_PROVIDERS — multi-file ONNX bundle, not registry-
+# pulled). --model_arch picks the checkpoint family the server loads;
+# --model_path points at the staged bundle root (the server resolves the
+# quantized/<variant> leaf itself).
+flags = "--model_path /mnt/ai-models/local/moonshine --model_arch small_streaming"
+mtp = false
+intent = "Moonshine STT (CPU)"
 quant = ""
 
 [profile.qwen3-tts]

--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -89,7 +89,7 @@ quant = ""
 # pulled). --model_arch picks the checkpoint family the server loads;
 # --model_path points at the staged bundle root (the server resolves the
 # quantized/<variant> leaf itself).
-flags = "--model_path /mnt/ai-models/local/moonshine --model_arch small_streaming"
+flags = "--model_path /mnt/ai-models/local/moonshine --model_arch base"
 mtp = false
 intent = "Moonshine STT (CPU)"
 quant = ""

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1060,7 +1060,7 @@ def resolve_default_image(backend: str | None, device_class: str | None = None) 
 
 
 #: Seed profile catalog — externalized to shipped TOML (P3-schema, spec
-#: Part A). See ``hal0/config/data/seed_profiles.toml`` for the 16 seed
+#: Part A). See ``hal0/config/data/seed_profiles.toml`` for the 17 seed
 #: entries (with their per-profile rationale comments) and
 #: ``hal0.config.seeds.seed_profiles()`` for the loader. ``SEED_PROFILES``
 #: is (re)assigned at the bottom of this module, once every model above

--- a/src/hal0/model_meta/__init__.py
+++ b/src/hal0/model_meta/__init__.py
@@ -183,7 +183,14 @@ DEVICE_CLASSES: tuple[str, ...] = ("gpu", "cpu", "npu", "img")
 #: Profile runtime families. MUST stay in sync with the
 #: ``hal0.profiles.RuntimeFamily`` Literal (a Literal can't be built from a
 #: runtime tuple; tests/model_meta assert the two match).
-RUNTIME_FAMILIES: tuple[str, ...] = ("llama-server", "flm", "kokoro", "qwen3tts", "comfyui")
+RUNTIME_FAMILIES: tuple[str, ...] = (
+    "llama-server",
+    "flm",
+    "kokoro",
+    "qwen3tts",
+    "moonshine",
+    "comfyui",
+)
 
 #: Legacy ``backend`` token → canonical ``device``. Used by the SlotConfig
 #: and CapabilitySelection promote-then-drop shims (auto-promote a legacy

--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -40,7 +40,7 @@ from hal0.errors import Conflict, NotFound
 
 log = logging.getLogger(__name__)
 
-RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "comfyui"]
+RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "moonshine", "comfyui"]
 SlotType = Literal["llm", "embedding", "reranking", "transcription", "tts", "image"]
 
 _PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
@@ -110,8 +110,9 @@ def _runtime_family(name: str, profile: ProfileConfig) -> RuntimeFamily:
     spec-hw-slot-ownership §3: profiles carry no ``image`` anymore, so the old
     exact-image→``RUNNER_IMAGES`` lookup and the image-substring sniffs are gone.
     The runtime family is a structural fact: ``device_class`` pins the
-    single-purpose runtimes (``img`` → comfyui, ``npu`` → flm), and the two TTS
-    engines (kokoro / qwen3tts) — which share a ``cpu`` device_class with a plain
+    single-purpose runtimes (``img`` → comfyui, ``npu`` → flm), and the
+    name-keyed CPU engines — the two TTS engines (kokoro / qwen3tts) plus the
+    moonshine STT engine, which share a ``cpu`` device_class with a plain
     llama-server CPU profile and so can only be told apart by name — key off
     their seed slug. Mirrors the model-side backends-driven classification in
     :func:`hal0.model_meta.modality.derive_modalities` (a structural signal, not
@@ -124,6 +125,8 @@ def _runtime_family(name: str, profile: ProfileConfig) -> RuntimeFamily:
         return "qwen3tts"
     if name == "kokoro":
         return "kokoro"
+    if name == "moonshine":
+        return "moonshine"
     if name == "comfyui" or profile.device_class == "img":
         return "comfyui"
     return "llama-server"
@@ -134,6 +137,8 @@ def _supported_slot_types(runtime_family: RuntimeFamily) -> tuple[SlotType, ...]
         return ("llm", "embedding", "transcription")
     if runtime_family in ("kokoro", "qwen3tts"):
         return ("tts",)
+    if runtime_family == "moonshine":
+        return ("transcription",)
     if runtime_family == "comfyui":
         return ("image",)
     return ("llm", "embedding", "reranking")

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -70,6 +70,7 @@ from hal0.config.schema import (
     resolve_chat_template,
     resolve_profile_flags,
 )
+from hal0.errors import Hal0Error
 from hal0.http_client import async_client
 from hal0.model_meta import model_is_mtp_eligible
 from hal0.profiles import ProfileCatalog
@@ -94,6 +95,17 @@ from hal0.system.seam import SystemCtlSeam
 # ``ContainerSpec`` is the back-compat alias for ``RuntimeLaunchPlan``; some
 # callers/tests still import the old name from this module.
 ContainerSpec = RuntimeLaunchPlan
+
+
+class UnknownRuntimeFamilyError(Hal0Error):
+    """A slot profile resolved to a runtime family with no dispatch branch.
+
+    Raised by :func:`_spec_provider_for` instead of silently falling through
+    to the llama-server default (which would spawn the wrong binary).
+    """
+
+    code = "slot.unknown_runtime_family"
+    status = 500
 
 
 def _artefact_token(slot: Mapping[str, Any] | str) -> str:
@@ -1036,10 +1048,29 @@ def _spec_provider_for(slot_cfg: dict[str, Any]) -> Any | None:
         from hal0.providers.kokoro import KokoroProvider
 
         return KokoroProvider()
+    # Moonshine (CPU STT). NPU transcription never reaches here — the FLM
+    # branch above matches on family/device first, so this generic
+    # ``slot_type == "transcription"`` fallback (for profile-less stt slots)
+    # can only mean the CPU engine, mirroring the tts → Kokoro fallback.
+    if family == "moonshine" or slot_type == "transcription":
+        from hal0.providers.moonshine import MoonshineProvider
+
+        return MoonshineProvider()
     if family == "comfyui" or provider == "comfyui" or slot_type == "image":
         from hal0.providers.comfyui import ComfyUIProvider
 
         return ComfyUIProvider()
+    if family not in (None, "llama-server"):
+        # A runtime family with no dispatch branch above. This can only
+        # happen when someone extends the RuntimeFamily literal without
+        # teaching this resolver about it — silently falling through to the
+        # llama-server default would spawn the wrong binary, so fail loudly
+        # instead (the F3 fragility, made explicit).
+        raise UnknownRuntimeFamilyError(
+            f"no provider is registered for runtime family {family!r} — "
+            "extend _spec_provider_for alongside the RuntimeFamily literal",
+            details={"runtime_family": family, "slot_type": slot_type},
+        )
     return None
 
 

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -35,6 +35,7 @@ No devices / group_add:
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
 from pathlib import Path
@@ -51,6 +52,8 @@ from hal0.runners import RUNNER_IMAGES
 # Sourced from the runner-image registry (§7.1b / ML-4) so the literal tag
 # lives in exactly one place (hal0.runners.RUNNER_IMAGES["moonshine"].image).
 # Kept as a module attribute for back-compat imports.
+log = logging.getLogger(__name__)
+
 _DEFAULT_MOONSHINE_IMAGE = RUNNER_IMAGES["moonshine"].image
 
 # Default profile name if the slot TOML omits one.
@@ -332,11 +335,24 @@ class MoonshineProvider(Provider):
         profile = ProfileCatalog().resolve(profile_name)
         flag_tokens = shlex.split(profile.resolved_flags) if profile.resolved_flags.strip() else []
 
-        # Registry-bound model path (self-managed slots usually have none)
-        # beats the profile-baked --model_path.
+        # A registry-bound model path beats the profile-baked --model_path,
+        # but ONLY when it resolves to a bundle this engine can actually
+        # load. Moonshine is a SELF_MANAGED_PROVIDER: the slot needs no
+        # model_id, so whatever the manager resolved for a transcription
+        # slot may be an unrelated ASR artifact. Live case (lxc105): the
+        # lookup handed back a VibeVoice `.gguf`, which would have replaced
+        # a perfectly good staged ONNX bundle with a path this server can
+        # never load. Falling back to the profile keeps the engine's own
+        # operator-staged weights authoritative.
         metadata = model_info.get("metadata") or {}
         variant = str(metadata.get("variant", ""))
         registry_path = str(model_info.get("path") or "")
+        if registry_path and _find_loadable_bundle(Path(registry_path)) is None:
+            log.info(
+                "moonshine.registry_path_ignored path=%s reason=not_a_loadable_bundle",
+                registry_path,
+            )
+            registry_path = ""
         if registry_path:
             model_path = _resolve_model_leaf(registry_path, variant)
             arch = (

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -109,26 +109,67 @@ def _derive_arch_from_variant(variant: str) -> str:
     return norm if norm in _VALID_ARCHS else ""
 
 
+#: The encoder file the in-container loader resolves. ``moonshine_server``'s
+#: ``_detect_local_format`` looks for exactly ``encoder_model.{ort,onnx}`` in
+#: the directory it is handed (MoonshineOnnxModel builds
+#: ``f"{models_dir}/encoder_model.{fmt}"``), so THIS is the marker that makes
+#: a directory a usable bundle — not "contains some .ort file".
+#:
+#: Live gotcha (lxc105, 2026-08-03): the operator-staged tree carries both
+#: layouts. ``base-en/quantized/base-en/`` holds ``encoder_model.ort`` and is
+#: loadable; the *streaming* variants hold ``encoder.ort`` / ``frontend.ort``
+#: — a different, streaming-SDK file set this server cannot consume. Matching
+#: on any ``*.ort`` accepted those and produced a container that started and
+#: then failed every transcription.
+_ENCODER_STEMS: tuple[str, ...] = ("encoder_model.ort", "encoder_model.onnx")
+
+
+def _is_loadable_bundle(directory: Path) -> bool:
+    """True iff ``directory`` holds the encoder file the loader resolves."""
+    return any((directory / name).is_file() for name in _ENCODER_STEMS)
+
+
+def _find_loadable_bundle(root: Path) -> Path | None:
+    """Search ``root`` for the directory holding ``encoder_model.{ort,onnx}``.
+
+    Returns the first match, preferring the shallowest (``root`` itself, then
+    its ``quantized`` layouts). ``None`` when the tree holds no bundle this
+    server can load.
+    """
+    if _is_loadable_bundle(root):
+        return root
+    for name in _ENCODER_STEMS:
+        matches = sorted(root.rglob(name), key=lambda p: len(p.parts))
+        if matches:
+            return matches[0].parent
+    return None
+
+
 def _resolve_model_leaf(model_path: str, variant: str) -> str:
     """Pick the directory the moonshine ONNX loader actually wants.
 
-    The staged layout keeps weights under ``<root>/quantized/<variant>/``
-    (decoder/encoder/tokenizer files). A --model_path pointing at ``<root>``
-    would make the in-container loader fall back to downloading from HF.
-    Prefer the leaf when it exists; otherwise return the input unchanged.
+    Staged trees nest the weights under ``<root>/quantized/…`` — sometimes
+    ``quantized/<variant>/``, sometimes ``quantized/`` directly. A
+    ``--model_path`` pointing at ``<root>`` makes the in-container loader
+    fall back to downloading from HuggingFace, so resolve to the leaf that
+    actually holds ``encoder_model.{ort,onnx}``. The ``variant`` hint is
+    tried first (cheap, exact); otherwise we search the tree. Returns the
+    input unchanged when nothing loadable is found — the preflight below is
+    what turns that into a named error.
     """
     if not model_path:
         return ""
     candidate = Path(model_path)
     if not candidate.is_dir():
         return model_path
-    if any(candidate.glob("*.ort")) or any(candidate.glob("*.onnx")):
+    if _is_loadable_bundle(candidate):
         return str(candidate)
     if variant:
-        leaf = candidate / "quantized" / variant
-        if leaf.is_dir() and (any(leaf.glob("*.ort")) or any(leaf.glob("*.onnx"))):
-            return str(leaf)
-    return model_path
+        hinted = candidate / "quantized" / variant
+        if hinted.is_dir() and _is_loadable_bundle(hinted):
+            return str(hinted)
+    found = _find_loadable_bundle(candidate)
+    return str(found) if found is not None else model_path
 
 
 def check_moonshine_weights(model_path: str) -> None:
@@ -150,12 +191,13 @@ def check_moonshine_weights(model_path: str) -> None:
             "in-container HuggingFace fallback",
             details={"model_path": model_path},
         )
-    has_weights = any(root.rglob("*.ort")) or any(root.rglob("*.onnx"))
-    if not has_weights:
+    if _find_loadable_bundle(root) is None:
         raise MoonshineWeightsMissingError(
-            f"moonshine weights directory {model_path} contains no .ort/.onnx "
-            "files — expected the staged bundle at <root>/quantized/<variant>/ "
-            "(e.g. quantized/small-streaming-en/)",
+            f"moonshine weights directory {model_path} holds no loadable bundle "
+            "— the server resolves encoder_model.ort / encoder_model.onnx, and "
+            "no directory under this root has one. A streaming-SDK bundle "
+            "(encoder.ort / frontend.ort) is NOT loadable by this image; stage "
+            "a non-streaming variant such as base-en/quantized/base-en/",
             details={"model_path": model_path},
         )
 

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -1,0 +1,377 @@
+"""MoonshineProvider — CPU STT inference backend (moonshine-onnx).
+
+The STT sibling of :class:`~hal0.providers.kokoro.KokoroProvider`: a
+``type=transcription`` slot on ``device=cpu`` runs this engine, while the
+same slot on ``device=npu`` runs whisper through the FLM trio — the
+device-keyed engine switch, same shape as the tts kokoro⇄qwen3tts pair.
+
+Image API surface (ghcr.io/hal0ai/hal0-toolbox-moonshine:v1; server source
+packaging/toolbox/moonshine/moonshine_server.py):
+  ENTRYPOINT: the FastAPI server — ``container_spec.command`` carries flags
+  only (no binary path or subcommand prefix).
+  Flags: ``--model_path <dir> --model_arch <arch> --port N --host H``.
+  Endpoints:
+    GET  /health                  -> {status, model_loaded, model_arch, model_id}
+    GET  /v1/models               -> {data: [{id: "moonshine-<arch>-en"}]}
+    POST /v1/audio/transcriptions -> OpenAI-compat multipart upload
+    WS   /v1/audio/stream         -> live PCM16 @ 16kHz mono (in-container
+                                     only — NOT routed by the dispatcher)
+
+Weights:
+  Moonshine ships a multi-file ONNX bundle (encoder/decoder ``.ort``/``.onnx``
+  + tokenizer JSON) that the single-file curated pull schema can't express,
+  so the weights are operator-staged under the model store and the provider
+  is in ``SELF_MANAGED_PROVIDERS``. The store is bind-mounted identical-path
+  read-only so the profile-baked ``--model_path`` resolves in-container.
+  :meth:`MoonshineProvider.container_spec` preflights that path and raises a
+  typed error NAMING the missing directory — a container that starts and
+  500s on first request is not an acceptable failure mode.
+
+No devices / group_add:
+  The upstream moonshine wheel ships only the ONNX CPU execution provider
+  (see ``_RUNTIME_TO_HOST_BACKENDS`` in capabilities/catalog.py), so no GPU
+  passthrough is emitted.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from hal0.config import store as model_store_module
+from hal0.config.paths import model_store_root
+from hal0.errors import Hal0Error
+from hal0.providers.base import ContainerSpec, Provider
+from hal0.runners import RUNNER_IMAGES
+
+# Sourced from the runner-image registry (§7.1b / ML-4) so the literal tag
+# lives in exactly one place (hal0.runners.RUNNER_IMAGES["moonshine"].image).
+# Kept as a module attribute for back-compat imports.
+_DEFAULT_MOONSHINE_IMAGE = RUNNER_IMAGES["moonshine"].image
+
+# Default profile name if the slot TOML omits one.
+_DEFAULT_PROFILE = "moonshine"
+
+# Default slot port (slot TOML normally pins this; matches the server's own
+# argparse default so a profile-less dev run lands on the same port).
+_DEFAULT_PORT = 8089
+
+# moonshine_server.py only accepts these arch tokens.
+_VALID_ARCHS = {"tiny", "tiny_streaming", "base", "small", "small_streaming"}
+
+_DEFAULT_MODEL_ARCH = "small_streaming"
+
+# Health/infer timeouts. Transcription of a long upload is slow on CPU —
+# give the read leg headroom.
+_HEALTH_TIMEOUT = httpx.Timeout(5.0)
+_INFER_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
+
+
+class MoonshineHealthError(Hal0Error):
+    """Moonshine health probe failed."""
+
+    code = "slot.not_ready"
+    status = 503
+
+
+class MoonshineInferError(Hal0Error):
+    """Moonshine inference call failed."""
+
+    code = "dispatch.upstream_failed"
+    status = 502
+
+
+class MoonshineWeightsMissingError(Hal0Error):
+    """The operator-staged Moonshine ONNX bundle is absent.
+
+    Raised at container-spec time (spawn preflight) so the failure names the
+    artifact instead of surfacing as a container that starts and 500s.
+    """
+
+    code = "slot.weights_missing"
+    status = 409
+
+
+def _derive_arch_from_variant(variant: str) -> str:
+    """Map a registry ``metadata.variant`` to a moonshine_server arch.
+
+    Variants look like ``base-en`` / ``small-streaming-en``. The arch enum
+    drops the ``-en`` suffix and uses underscores for the streaming flag
+    (``small-streaming-en`` → ``small_streaming``). Returns "" when the
+    variant doesn't map cleanly so callers fall back to the default.
+    """
+    if not variant:
+        return ""
+    norm = variant.strip().lower().removesuffix("-en").replace("-", "_")
+    return norm if norm in _VALID_ARCHS else ""
+
+
+def _resolve_model_leaf(model_path: str, variant: str) -> str:
+    """Pick the directory the moonshine ONNX loader actually wants.
+
+    The staged layout keeps weights under ``<root>/quantized/<variant>/``
+    (decoder/encoder/tokenizer files). A --model_path pointing at ``<root>``
+    would make the in-container loader fall back to downloading from HF.
+    Prefer the leaf when it exists; otherwise return the input unchanged.
+    """
+    if not model_path:
+        return ""
+    candidate = Path(model_path)
+    if not candidate.is_dir():
+        return model_path
+    if any(candidate.glob("*.ort")) or any(candidate.glob("*.onnx")):
+        return str(candidate)
+    if variant:
+        leaf = candidate / "quantized" / variant
+        if leaf.is_dir() and (any(leaf.glob("*.ort")) or any(leaf.glob("*.onnx"))):
+            return str(leaf)
+    return model_path
+
+
+def check_moonshine_weights(model_path: str) -> None:
+    """Preflight the operator-staged bundle; raise a typed, named error.
+
+    Shared by :meth:`MoonshineProvider.container_spec` (spawn preflight) and
+    the ``hal0 doctor`` voice check so both fail with the same message. An
+    EMPTY path is allowed — the server then auto-downloads from HuggingFace,
+    which is a legitimate (if slow) first-run path.
+    """
+    if not model_path:
+        return
+    root = Path(model_path)
+    if not root.is_dir():
+        raise MoonshineWeightsMissingError(
+            f"moonshine weights directory not found: {model_path} — stage the "
+            "multi-file ONNX bundle (encoder/decoder + tokenizer) there, or "
+            "clear --model_path from the moonshine profile to allow the "
+            "in-container HuggingFace fallback",
+            details={"model_path": model_path},
+        )
+    has_weights = any(root.rglob("*.ort")) or any(root.rglob("*.onnx"))
+    if not has_weights:
+        raise MoonshineWeightsMissingError(
+            f"moonshine weights directory {model_path} contains no .ort/.onnx "
+            "files — expected the staged bundle at <root>/quantized/<variant>/ "
+            "(e.g. quantized/small-streaming-en/)",
+            details={"model_path": model_path},
+        )
+
+
+def _flag_value(tokens: list[str], flag: str) -> str:
+    """Return the value following ``flag`` in an argv token list, or ""."""
+    for i, tok in enumerate(tokens[:-1]):
+        if tok == flag:
+            return tokens[i + 1]
+    return ""
+
+
+class MoonshineProvider(Provider):
+    """Provider for the Moonshine ONNX STT backend.
+
+    CPU-only: no GPU devices, no group_add. Weights are operator-staged
+    under the model store (``SELF_MANAGED_PROVIDERS``). The container image
+    wraps ``moonshine_server.py`` which implements OpenAI-compat
+    ``POST /v1/audio/transcriptions``, ``GET /v1/models``, and ``GET /health``.
+
+    Primary deployment path is ``container_spec`` → ``_render_quadlet_from_plan``
+    (same pattern as KokoroProvider / Qwen3TTSProvider). ``build_env`` /
+    ``start_cmd`` are informational stubs kept for ABC compliance.
+    """
+
+    name = "moonshine"
+
+    # ── Provider ABC stubs ─────────────────────────────────────────────────────
+
+    def build_env(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> dict[str, str]:
+        """Informational env block (container is self-contained)."""
+        return {
+            "HAL0_SLOT": str(slot_cfg.get("name", "")),
+            "HAL0_RUNTIME": "container",
+            "HAL0_PROFILE": str(slot_cfg.get("profile") or _DEFAULT_PROFILE),
+        }
+
+    def start_cmd(self, env: dict[str, str]) -> list[str]:
+        """Not applicable — systemd starts the container."""
+        raise NotImplementedError("MoonshineProvider uses systemd; start_cmd() is unused")
+
+    # ── Image / container spec ─────────────────────────────────────────────────
+
+    def image_ref(self, slot_cfg: dict[str, Any]) -> str:
+        """Return the Moonshine toolbox image reference.
+
+        Resolution (§7.1b / ML-4): ``slot_cfg["image_pin"]`` (top-level or
+        ``[slot]``-nested string override) → the runner registry
+        (``HAL0_TOOLBOX_IMAGE_MOONSHINE`` env override → the manifest digest
+        pin → the bundled default) — see
+        :func:`hal0.runners.resolve_runner_image`.
+        """
+        override: Any = None
+        if isinstance(slot_cfg, dict):
+            override = slot_cfg.get("image_pin")
+            if not (isinstance(override, str) and override):
+                nested = slot_cfg.get("slot")
+                override = nested.get("image_pin") if isinstance(nested, dict) else None
+        if isinstance(override, str) and override:
+            return override
+
+        from hal0.runners import get_runner, resolve_runner_image
+
+        return resolve_runner_image(get_runner("moonshine"))
+
+    def container_spec(
+        self,
+        slot_cfg: dict[str, Any],
+        model_info: dict[str, Any],
+    ) -> ContainerSpec:
+        """Build a ContainerSpec for the Moonshine STT slot.
+
+        The toolbox image ENTRYPOINT is the FastAPI server, so ``command``
+        carries only flags. Flags come from the resolved profile
+        (``moonshine`` by default), which bakes ``--model_path`` +
+        ``--model_arch``. ``--host`` and ``--port`` are always appended
+        (argparse last-wins, so the slot's --port beats any --port baked
+        into profile flags).
+
+        A registry-bound model (``model_info["path"]``) beats the
+        profile-baked --model_path, with the ``quantized/<variant>`` leaf
+        resolved so the in-container loader doesn't fall back to a network
+        download. The effective path is preflighted via
+        :func:`check_moonshine_weights` — missing weights fail HERE, loudly
+        and by name, not as a 500 on first request.
+
+        No devices or group_add are emitted — Moonshine is CPU-only.
+        Security opts (apparmor/seccomp=unconfined) are required for
+        Proxmox LXC deployments (same rationale as the other providers).
+        """
+        from hal0.profiles import ProfileCatalog
+
+        port = int(slot_cfg.get("port") or _DEFAULT_PORT)
+        profile_name: str = str(slot_cfg.get("profile") or _DEFAULT_PROFILE)
+        profile = ProfileCatalog().resolve(profile_name)
+        flag_tokens = shlex.split(profile.resolved_flags) if profile.resolved_flags.strip() else []
+
+        # Registry-bound model path (self-managed slots usually have none)
+        # beats the profile-baked --model_path.
+        metadata = model_info.get("metadata") or {}
+        variant = str(metadata.get("variant", ""))
+        registry_path = str(model_info.get("path") or "")
+        if registry_path:
+            model_path = _resolve_model_leaf(registry_path, variant)
+            arch = (
+                str(model_info.get("model_arch") or "")
+                or _derive_arch_from_variant(variant)
+                or _flag_value(flag_tokens, "--model_arch")
+                or _DEFAULT_MODEL_ARCH
+            )
+            # Strip the profile's --model_path/--model_arch pair; the
+            # registry-resolved values are appended below (argparse
+            # last-wins would also work, but a single occurrence keeps the
+            # rendered Quadlet legible).
+            cleaned: list[str] = []
+            skip = False
+            for tok in flag_tokens:
+                if skip:
+                    skip = False
+                    continue
+                if tok in ("--model_path", "--model_arch"):
+                    skip = True
+                    continue
+                cleaned.append(tok)
+            flag_tokens = [*cleaned, "--model_path", model_path, "--model_arch", arch]
+        else:
+            model_path = _flag_value(flag_tokens, "--model_path")
+
+        # Spawn preflight: fail by artifact name, not by first-request 500.
+        check_moonshine_weights(model_path)
+
+        command: list[str] = [
+            *flag_tokens,
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+        ]
+
+        store_root = model_store_root()
+
+        return ContainerSpec(
+            image=self.image_ref(slot_cfg),
+            command=command,
+            env={},
+            # Model store mounted read-only via the shared `mount_for`
+            # factory (ML-3) — identical-path so --model_path resolves
+            # in-container without translation.
+            mounts=[model_store_module.mount_for(store_root, read_only=True)],
+            # CPU-only: no GPU devices or supplementary groups required.
+            devices=[],
+            cap_add=[],
+            # Required for Proxmox LXC container deployments.
+            security_opt=["apparmor=unconfined", "seccomp=unconfined"],
+            group_add=[],
+            port=port,
+            # Port-mapped (not host networking) so it can coexist with the
+            # other CPU slots; the Quadlet renderer derives
+            # --publish=127.0.0.1:<port>:<port> from spec.port.
+            network_mode="",
+            extra_args=[],
+        )
+
+    # ── Health / infer ─────────────────────────────────────────────────────────
+
+    async def health(self, port: int) -> dict[str, Any]:
+        """Probe GET /health on the moonshine-server port.
+
+        NOTE: dead code in the container deployment path — slot health
+        checks go through :meth:`ContainerProvider.health`, whose generic
+        ``model_loaded`` gating already covers this server's body shape.
+        Kept because ``health`` is abstract on the Provider ABC.
+        """
+        url = f"http://127.0.0.1:{port}/health"
+        try:
+            async with httpx.AsyncClient(timeout=_HEALTH_TIMEOUT) as client:
+                resp = await client.get(url)
+                if resp.status_code == 200:
+                    body = resp.json()
+                    loaded = bool(body.get("model_loaded"))
+                    return {
+                        "ok": loaded,
+                        "status": "ready" if loaded else "loading",
+                    }
+                return {"ok": False, "status": f"http_{resp.status_code}"}
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            return {"ok": False, "status": str(exc)}
+        except Exception as exc:
+            return {"ok": False, "status": "exception", "detail": str(exc)}
+
+    async def infer(self, port: int, body: dict[str, Any]) -> dict[str, Any]:
+        """Unary transcription passthrough for smoke tests.
+
+        ``body`` carries ``{"file": (filename, bytes, content_type), ...}``
+        pre-shaped for a multipart POST; the dispatcher's streaming WS path
+        does NOT go through here (in-container only, unrouted).
+        """
+        url = f"http://127.0.0.1:{port}/v1/audio/transcriptions"
+        file_part = body.get("file")
+        data = {k: v for k, v in body.items() if k != "file" and v is not None}
+        try:
+            async with httpx.AsyncClient(timeout=_INFER_TIMEOUT) as client:
+                resp = await client.post(url, files={"file": file_part}, data=data)
+                resp.raise_for_status()
+                return resp.json()  # type: ignore[no-any-return]
+        except httpx.HTTPStatusError as exc:
+            raise MoonshineInferError(
+                f"Moonshine returned HTTP {exc.response.status_code}",
+                details={"port": port, "status_code": exc.response.status_code},
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise MoonshineInferError(
+                f"Moonshine transport error: {exc}",
+                details={"port": port},
+            ) from exc

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -359,6 +359,11 @@ class MoonshineProvider(Provider):
         """
         url = f"http://127.0.0.1:{port}/v1/audio/transcriptions"
         file_part = body.get("file")
+        if file_part is None:
+            raise MoonshineInferError(
+                "transcription body carries no 'file' part",
+                details={"port": port},
+            )
         data = {k: v for k, v in body.items() if k != "file" and v is not None}
         try:
             async with httpx.AsyncClient(timeout=_INFER_TIMEOUT) as client:

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -328,7 +328,19 @@ class MoonshineProvider(Provider):
                 cleaned.append(tok)
             flag_tokens = [*cleaned, "--model_path", model_path, "--model_arch", arch]
         else:
-            model_path = _flag_value(flag_tokens, "--model_path")
+            # The profile-baked path needs the SAME leaf resolution as a
+            # registry-bound one: operators stage the tree root (the natural
+            # thing to write in a profile), while the loader wants the
+            # directory that actually holds encoder_model.{ort,onnx}. Without
+            # this the container silently falls back to a HuggingFace
+            # download despite the weights sitting right there on disk.
+            raw_path = _flag_value(flag_tokens, "--model_path")
+            model_path = _resolve_model_leaf(raw_path, _flag_value(flag_tokens, "--model_arch"))
+            if model_path != raw_path:
+                flag_tokens = [
+                    model_path if (i and flag_tokens[i - 1] == "--model_path") else tok
+                    for i, tok in enumerate(flag_tokens)
+                ]
 
         # Spawn preflight: fail by artifact name, not by first-request 500.
         check_moonshine_weights(model_path)

--- a/src/hal0/providers/moonshine.py
+++ b/src/hal0/providers/moonshine.py
@@ -35,6 +35,7 @@ No devices / group_add:
 
 from __future__ import annotations
 
+import os
 import shlex
 from pathlib import Path
 from typing import Any
@@ -44,7 +45,7 @@ import httpx
 from hal0.config import store as model_store_module
 from hal0.config.paths import model_store_root
 from hal0.errors import Hal0Error
-from hal0.providers.base import ContainerSpec, Provider
+from hal0.providers.base import ContainerSpec, Mount, Provider
 from hal0.runners import RUNNER_IMAGES
 
 # Sourced from the runner-image registry (§7.1b / ML-4) so the literal tag
@@ -202,6 +203,38 @@ def check_moonshine_weights(model_path: str) -> None:
         )
 
 
+def _extra_weight_mounts(model_path: str, store_root: str | Path) -> list[Mount]:
+    """Identical-path read-only mounts for weights staged outside the store.
+
+    The slot mounts ``model_store_root()``, but an operator-staged bundle can
+    legitimately live elsewhere — and does: on a box whose ``[models].roots``
+    is ``/var/lib/hal0/models``, a bundle under ``/mnt/ai-models`` is simply
+    not inside the mount, so the container sees nothing and the loader
+    silently falls back to a HuggingFace download.
+
+    Mount the resolved path (and its realpath, so a symlink into a separate
+    tree resolves in-container too) at the same absolute path, skipping
+    anything already covered by the store mount. This restores the behaviour
+    of the pre-#620 provider, which mounted the model dir plus its realpath
+    parent for exactly this reason.
+    """
+    if not model_path:
+        return []
+    root = str(store_root).rstrip("/")
+
+    def _covered(path: str) -> bool:
+        return path == root or path.startswith(root + "/")
+
+    out: list[Mount] = []
+    seen: set[str] = set()
+    for candidate in (model_path, os.path.realpath(model_path)):
+        if not candidate.startswith("/") or _covered(candidate) or candidate in seen:
+            continue
+        seen.add(candidate)
+        out.append(Mount(candidate, candidate, read_only=True, selinux="z"))
+    return out
+
+
 def _flag_value(tokens: list[str], flag: str) -> str:
     """Return the value following ``flag`` in an argv token list, or ""."""
     for i, tok in enumerate(tokens[:-1]):
@@ -354,6 +387,8 @@ class MoonshineProvider(Provider):
         ]
 
         store_root = model_store_root()
+        mounts = [model_store_module.mount_for(store_root, read_only=True)]
+        mounts.extend(_extra_weight_mounts(model_path, store_root))
 
         return ContainerSpec(
             image=self.image_ref(slot_cfg),
@@ -361,8 +396,10 @@ class MoonshineProvider(Provider):
             env={},
             # Model store mounted read-only via the shared `mount_for`
             # factory (ML-3) — identical-path so --model_path resolves
-            # in-container without translation.
-            mounts=[model_store_module.mount_for(store_root, read_only=True)],
+            # in-container without translation. Weights staged OUTSIDE the
+            # store root get their own identical-path mount (see
+            # :func:`_extra_weight_mounts`).
+            mounts=mounts,
             # CPU-only: no GPU devices or supplementary groups required.
             devices=[],
             cap_add=[],

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -62,7 +62,7 @@ from hal0.errors import NotFound
 #: a runner's family), and a module-level import the other way would risk
 #: a cycle the first time either side changes its import shape. The value
 #: set is the same vocabulary as ``hal0.profiles.RuntimeFamily``.
-RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "comfyui"]
+RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "moonshine", "comfyui"]
 
 #: Bundled default image tags for the single-purpose runtimes. Literal
 #: constants live HERE (not duplicated in each provider module) — a
@@ -70,6 +70,7 @@ RuntimeFamily = Literal["llama-server", "flm", "kokoro", "qwen3tts", "comfyui"]
 #: imports it from :data:`RUNNER_IMAGES` instead of redefining the string.
 _FLM_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44"
 _KOKORO_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-kokoro:v1"
+_MOONSHINE_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1"
 _QWEN3TTS_IMAGE = "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1"
 _COMFYUI_IMAGE = "docker.io/kyuz0/amd-strix-halo-comfyui:latest"
 
@@ -181,6 +182,17 @@ RUNNER_IMAGES: dict[str, Runner] = {
         "kokoro",
         supported_backends=("cpu",),
         format_arch="kokoro",
+    ),
+    "moonshine": Runner(
+        "moonshine",
+        _MOONSHINE_IMAGE,
+        "moonshine",
+        RunnerSupports(),
+        "cpu",
+        None,
+        "moonshine",
+        supported_backends=("cpu",),
+        format_arch="onnx",
     ),
     "qwen3tts": Runner(
         "qwen3tts",

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -635,13 +635,15 @@ class SlotConfigStore:
         ``before`` snapshot) or a disable-only reconcile could break the
         commit diff / rollback.
 
-        voice.tts engine switch (follow-up to #972): the two TTS engines
-        (Kokoro CPU / Qwen3-TTS GPU) live in the SAME ``tts`` slot, selected
-        by device. The device alone is not enough to start the right engine —
-        the slot's ``profile`` is what ``container._spec_provider_for`` resolves
-        to a runtime family. So for the ``tts`` child we also derive and write
-        the engine's ``profile`` (cpu → ``kokoro``, gpu → ``qwen3-tts``); without
-        this the slot would keep Kokoro's profile and never spawn Qwen3.
+        voice.tts / voice.stt engine switches (tts: follow-up to #972; stt:
+        moonshine reinstatement): both are device-keyed engine selections
+        living in a SINGLE slot (``tts`` / ``stt``) — the device alone is not
+        enough to start the right engine, since the slot's ``profile`` is
+        what ``container._spec_provider_for`` resolves to a runtime family.
+        So for those two children we also derive and write the engine's
+        ``profile`` (tts: cpu → ``kokoro``, gpu → ``qwen3-tts``; stt: cpu →
+        ``moonshine``, npu → the FLM profile) — without this the slot would
+        keep its previous engine's profile and never spawn the new one.
         """
         selection = slot_selection.selection
         if raw_before is None:
@@ -669,34 +671,42 @@ class SlotConfigStore:
             if selection.model:
                 updates["model"] = {"default": selection.model}
 
-            # TTS engine switch: derive the slot profile from the picked device
-            # so the GPU/CPU choice actually swaps the provider inside the one
-            # tts slot.
-            tts_profile = self._tts_profile_for(slot_selection)
-            if tts_profile is not None:
-                updates["profile"] = tts_profile
+            # tts/stt engine switch: derive the slot profile from the picked
+            # device so the GPU/CPU (tts) or CPU/NPU (stt) choice actually
+            # swaps the provider inside the one tts/stt slot.
+            engine_profile = self._engine_profile_for(slot_selection)
+            if engine_profile is not None:
+                updates["profile"] = engine_profile
 
         # The one-level [model] merge + #585 ctx_size fold is the shared,
         # copy-safe primitive (SC-11) — ``raw_before`` (the ChangeSet's
         # ``before`` snapshot) is never mutated.
         return merge_slot_config(raw_before, updates)
 
-    @staticmethod
-    def _tts_profile_for(slot_selection: SlotSelection) -> str | None:
-        """Engine profile a voice.tts selection implies, or ``None``.
+    #: Children whose device selection is an engine switch WITHIN one slot
+    #: (as opposed to a device that just changes which GPU backend the same
+    #: engine runs on). Every other capability leaves the slot's profile
+    #: untouched (most have none).
+    _ENGINE_SWITCH_CHILDREN: frozenset[str] = frozenset({"tts", "stt"})
 
-        Only the ``tts`` child carries an engine switch — every other
-        capability leaves the slot's profile untouched (most have none). The
-        canonical (device → profile) mapping lives in
-        :func:`hal0.capabilities.catalog.tts_profile_for_device`; imported
+    @classmethod
+    def _engine_profile_for(cls, slot_selection: SlotSelection) -> str | None:
+        """Engine profile a voice.tts/voice.stt selection implies, or ``None``.
+
+        Both children pick their runtime engine via the selected device
+        (tts: cpu → Kokoro, gpu → Qwen3-TTS; stt: cpu → Moonshine, npu → the
+        FLM trio). The canonical ``(capability, device) → profile`` mapping
+        is the ONE rule shared with the picker/apply-time fit inference —
+        :func:`hal0.capabilities.profile_fit.profile_name_for_fit` — imported
         lazily here to keep this module import-light (the cycle the module
-        docstring guards against).
+        docstring guards against). ``child`` names line up 1:1 with the
+        capability strings that function expects for both tts and stt.
         """
-        if slot_selection.child != "tts":
+        if slot_selection.child not in cls._ENGINE_SWITCH_CHILDREN:
             return None
-        from hal0.capabilities.catalog import tts_profile_for_device
+        from hal0.capabilities.profile_fit import profile_name_for_fit
 
-        return tts_profile_for_device(slot_selection.selection.device)
+        return profile_name_for_fit(slot_selection.child, slot_selection.selection.device)
 
 
 # ── file-state IO ────────────────────────────────────────────────────────────

--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -706,7 +706,11 @@ class SlotConfigStore:
             return None
         from hal0.capabilities.profile_fit import profile_name_for_fit
 
-        return profile_name_for_fit(slot_selection.child, slot_selection.selection.device)
+        return profile_name_for_fit(
+            slot_selection.child,
+            slot_selection.selection.device,
+            slot_selection.selection.provider or "",
+        )
 
 
 # ── file-state IO ────────────────────────────────────────────────────────────

--- a/tests/capabilities/test_stt_capability_switch.py
+++ b/tests/capabilities/test_stt_capability_switch.py
@@ -49,7 +49,7 @@ def _no_flm_probe(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_voice_stt_catalog_includes_moonshine_engine(tmp_hal0_home: str) -> None:
     rows = models_for_capability("stt", registry=None)
-    moonshine = next((r for r in rows if r["id"] == "moonshine-small-streaming-en"), None)
+    moonshine = next((r for r in rows if r["id"] == "moonshine-base-en"), None)
     assert moonshine is not None, f"moonshine engine missing from voice.stt catalog: {rows!r}"
     backends = {b["id"]: b for b in moonshine["backends"]}
     assert "cpu" in backends, f"moonshine row carries no cpu backend: {moonshine!r}"
@@ -64,7 +64,7 @@ def test_voice_stt_catalog_includes_moonshine_engine(tmp_hal0_home: str) -> None
 def test_voice_stt_catalog_moonshine_not_offered_on_gpu(tmp_hal0_home: str) -> None:
     """Regression: hal0 ships no GPU STT engine — moonshine must not fan out there."""
     rows = models_for_capability("stt", registry=None)
-    moonshine = next((r for r in rows if r["id"] == "moonshine-small-streaming-en"), None)
+    moonshine = next((r for r in rows if r["id"] == "moonshine-base-en"), None)
     assert moonshine is not None
     backends = {b["id"] for b in moonshine["backends"]}
     assert "gpu-vulkan" not in backends
@@ -94,7 +94,7 @@ def _write_stt_slot(home: str, *, device: str, profile: str, provider: str = "mo
                 f'provider = "{provider}"',
                 "port = 8084",
                 "[model]",
-                'default = "moonshine-small-streaming-en"',
+                'default = "moonshine-base-en"',
                 "",
             ]
         ),
@@ -117,7 +117,7 @@ def test_apply_selecting_cpu_moonshine_writes_profile_and_provider(
         {
             "device": "cpu",
             "provider": "moonshine",
-            "model": "moonshine-small-streaming-en",
+            "model": "moonshine-base-en",
             "enabled": True,
         }
     )
@@ -128,7 +128,7 @@ def test_apply_selecting_cpu_moonshine_writes_profile_and_provider(
     assert on_disk["profile"] == "moonshine", f"engine profile not stamped: {on_disk!r}"
     assert on_disk["provider"] == "moonshine", on_disk
     assert on_disk["device"] == "cpu", on_disk
-    assert on_disk["model"]["default"] == "moonshine-small-streaming-en", on_disk
+    assert on_disk["model"]["default"] == "moonshine-base-en", on_disk
     assert on_disk["name"] == "stt", "slot must not move/rename"
     # Only one slot file exists — the selection reconciled in place.
     slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
@@ -147,7 +147,7 @@ def test_apply_disabled_stt_selection_does_not_rewrite_engine(tmp_hal0_home: str
         {
             "device": "cpu",
             "provider": "moonshine",
-            "model": "moonshine-small-streaming-en",
+            "model": "moonshine-base-en",
             "enabled": False,
         }
     )
@@ -319,7 +319,7 @@ async def test_apply_npu_stt_drives_flm_trio_without_slot_spawn(
                 "[selections.voice.stt]",
                 'device = "cpu"',
                 'provider = "moonshine"',
-                'model = "moonshine-small-streaming-en"',
+                'model = "moonshine-base-en"',
                 "enabled = true",
                 "",
             ]
@@ -416,3 +416,17 @@ async def test_apply_gpu_device_for_stt_is_a_typed_error(
     on_disk = _read_stt_slot(tmp_hal0_home)
     assert on_disk["profile"] == "moonshine"
     assert on_disk["device"] == "cpu"
+
+
+def test_stt_engine_id_is_the_served_non_streaming_id(tmp_hal0_home: str) -> None:
+    """The picker must advertise the id the server actually serves.
+
+    ``moonshine-small-streaming-en`` (the HaloaiModel seed id) names a
+    streaming bundle the toolbox image cannot load — offering it would be a
+    pick that never serves a request. The server advertises
+    ``moonshine-<arch>-en`` for the loadable non-streaming bundle.
+    """
+    rows = models_for_capability("stt", registry=None)
+    ids = {r["id"] for r in rows}
+    assert "moonshine-base-en" in ids
+    assert "moonshine-small-streaming-en" not in ids

--- a/tests/capabilities/test_stt_capability_switch.py
+++ b/tests/capabilities/test_stt_capability_switch.py
@@ -394,6 +394,7 @@ async def test_apply_npu_stt_drives_flm_trio_without_slot_spawn(
     # 6. Still exactly one stt slot file — no new/renamed file appeared.
     assert [p.name for p in slots_dir.glob("*.toml")] == ["stt.toml"]
 
+
 async def test_apply_gpu_device_for_stt_is_a_typed_error(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/capabilities/test_stt_capability_switch.py
+++ b/tests/capabilities/test_stt_capability_switch.py
@@ -1,0 +1,418 @@
+"""voice.stt capability switch — Moonshine (CPU) vs the FLM trio (NPU).
+
+Mirrors ``tests/capabilities/test_tts_capability_switch.py``: STT is a
+device-keyed engine switch WITHIN the single ``stt`` slot, exactly like
+voice.tts (cpu -> kokoro / gpu -> qwen3-tts). Three surfaces are exercised
+here:
+
+  - the catalog enumerates the CPU Moonshine engine for voice.stt
+    (``_stt_rows_for_capability``, wired into ``_flat_rows_for_capability``
+    the same way ``_tts_rows_for_capability`` is),
+  - the apply path (``SlotConfigStore._reconciled_slot`` /
+    ``_engine_profile_for``) rewrites the single ``stt`` slot's ``profile``
+    + ``provider`` to match the picked engine — the SAME mechanism the tts
+    engine switch uses, generalised off ``child in {"tts", "stt"}``,
+  - selecting ``npu`` drives the FLM trio (no standalone slot spawn) exactly
+    like voice.embed's NPU Phase 2 path — see
+    ``tests/capabilities/test_npu_phase2_integration.py`` and
+    ``tests/capabilities/test_catalog_npu_stt.py`` for the pre-existing NPU
+    fan-out/apply contracts this must not contradict.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.catalog import models_for_capability
+from hal0.capabilities.config import load_capabilities_config
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+
+# ── catalog enumeration ──────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _no_flm_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the stt catalog's NPU fan-out deterministic (empty) in these tests.
+
+    ``stt`` is in ``_NPU_FANOUT_CAPS`` so ``models_for_capability("stt")``
+    always calls ``flm_served_models()``, which shells a container runtime
+    probe absent a mock. Real NPU/FLM fan-out behaviour is covered by
+    ``test_catalog_npu_stt.py``; here we only care about the Moonshine
+    CPU row, so pin the FLM side to empty for isolation and speed.
+    """
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: [])
+
+
+def test_voice_stt_catalog_includes_moonshine_engine(tmp_hal0_home: str) -> None:
+    rows = models_for_capability("stt", registry=None)
+    moonshine = next((r for r in rows if r["id"] == "moonshine-small-streaming-en"), None)
+    assert moonshine is not None, f"moonshine engine missing from voice.stt catalog: {rows!r}"
+    backends = {b["id"]: b for b in moonshine["backends"]}
+    assert "cpu" in backends, f"moonshine row carries no cpu backend: {moonshine!r}"
+    cpu = backends["cpu"]
+    assert cpu["provider"] == "moonshine"
+    # The CPU engine resolves the Moonshine profile, not a llama profile.
+    assert cpu["runtime_family"] == "moonshine"
+    assert cpu["profile"] == "moonshine"
+    assert cpu["pullable"] is False, "moonshine weights are operator-staged, not pullable"
+
+
+def test_voice_stt_catalog_moonshine_not_offered_on_gpu(tmp_hal0_home: str) -> None:
+    """Regression: hal0 ships no GPU STT engine — moonshine must not fan out there."""
+    rows = models_for_capability("stt", registry=None)
+    moonshine = next((r for r in rows if r["id"] == "moonshine-small-streaming-en"), None)
+    assert moonshine is not None
+    backends = {b["id"] for b in moonshine["backends"]}
+    assert "gpu-vulkan" not in backends
+    assert "gpu-rocm" not in backends
+
+
+# ── apply path: the engine swap lands in the single ``stt`` slot ─────────────
+
+
+def _read_stt_slot(home: str) -> dict[str, Any]:
+    with open(Path(home) / "etc" / "hal0" / "slots" / "stt.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+def _write_stt_slot(home: str, *, device: str, profile: str, provider: str = "moonshine") -> None:
+    """Write the canonical single ``stt`` slot in a known engine state."""
+    slots_dir = Path(home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "stt.toml").write_text(
+        "\n".join(
+            [
+                'name = "stt"',
+                'type = "transcription"',
+                f'device = "{device}"',
+                'runtime = "container"',
+                f'profile = "{profile}"',
+                f'provider = "{provider}"',
+                "port = 8084",
+                "[model]",
+                'default = "moonshine-small-streaming-en"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_apply_selecting_cpu_moonshine_writes_profile_and_provider(
+    tmp_hal0_home: str,
+) -> None:
+    """Picking cpu/moonshine writes profile=moonshine + provider=moonshine
+    into the SAME ``stt`` slot TOML — no move, no new slot file.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    _write_stt_slot(tmp_hal0_home, device="cpu", profile="", provider="")
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {
+            "device": "cpu",
+            "provider": "moonshine",
+            "model": "moonshine-small-streaming-en",
+            "enabled": True,
+        }
+    )
+    cs = store.apply(SlotSelection(slot="voice", child="stt", slot_name="stt", selection=selection))
+    store.commit(cs)
+
+    on_disk = _read_stt_slot(tmp_hal0_home)
+    assert on_disk["profile"] == "moonshine", f"engine profile not stamped: {on_disk!r}"
+    assert on_disk["provider"] == "moonshine", on_disk
+    assert on_disk["device"] == "cpu", on_disk
+    assert on_disk["model"]["default"] == "moonshine-small-streaming-en", on_disk
+    assert on_disk["name"] == "stt", "slot must not move/rename"
+    # Only one slot file exists — the selection reconciled in place.
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    assert [p.name for p in slots_dir.glob("*.toml")] == ["stt.toml"]
+
+
+def test_apply_disabled_stt_selection_does_not_rewrite_engine(tmp_hal0_home: str) -> None:
+    """A disabled selection clears the model but never rewrites profile/device/provider."""
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    _write_stt_slot(tmp_hal0_home, device="cpu", profile="moonshine")
+    before = _read_stt_slot(tmp_hal0_home)
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {
+            "device": "cpu",
+            "provider": "moonshine",
+            "model": "moonshine-small-streaming-en",
+            "enabled": False,
+        }
+    )
+    cs = store.apply(SlotSelection(slot="voice", child="stt", slot_name="stt", selection=selection))
+    store.commit(cs)
+    after = _read_stt_slot(tmp_hal0_home)
+    assert after["model"]["default"] == "", "disable must clear [model].default"
+    assert {k: v for k, v in after.items() if k != "model"} == {
+        k: v for k, v in before.items() if k != "model"
+    }, "disabled selection rewrote an engine field"
+
+
+def test_apply_non_stt_child_never_gets_moonshine_profile(tmp_hal0_home: str) -> None:
+    """Regression: the stt engine-profile derivation must be gated on the stt
+    child only — an embed apply must never pick up the moonshine profile,
+    and a tts apply must keep resolving its own (kokoro/qwen3-tts) engine,
+    not moonshine.
+    """
+    from hal0.capabilities.config import CapabilitySelection
+    from hal0.slot_config import SlotConfigStore, SlotSelection
+
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "embed.toml").write_text(
+        "\n".join(
+            [
+                'name = "embed"',
+                "port = 8082",
+                'device = "gpu-vulkan"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "nomic-embed-text-v1.5-q8_0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    store = SlotConfigStore()
+    selection = CapabilitySelection.model_validate(
+        {
+            "device": "cpu",
+            "provider": "llama-server",
+            "model": "nomic-embed-text-v1.5-q8_0",
+            "enabled": True,
+        }
+    )
+    cs = store.apply(
+        SlotSelection(slot="embed", child="embed", slot_name="embed", selection=selection)
+    )
+    store.commit(cs)
+    with open(slots_dir / "embed.toml", "rb") as f:
+        on_disk = tomllib.load(f)
+    assert "profile" not in on_disk, f"embed slot must not gain a profile: {on_disk!r}"
+    assert on_disk.get("provider") != "moonshine"
+
+    # tts must still resolve its OWN engine, never moonshine leaking across
+    # capabilities.
+    (slots_dir / "tts.toml").write_text(
+        "\n".join(
+            [
+                'name = "tts"',
+                'type = "tts"',
+                'device = "cpu"',
+                'runtime = "container"',
+                'profile = "kokoro"',
+                "port = 8085",
+                "[model]",
+                'default = "kokoro-v1"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    tts_selection = CapabilitySelection.model_validate(
+        {"device": "cpu", "provider": "kokoro", "model": "kokoro-v1", "enabled": True}
+    )
+    cs = store.apply(
+        SlotSelection(slot="voice", child="tts", slot_name="tts", selection=tts_selection)
+    )
+    store.commit(cs)
+    with open(slots_dir / "tts.toml", "rb") as f:
+        tts_on_disk = tomllib.load(f)
+    assert tts_on_disk["profile"] == "kokoro", tts_on_disk
+    assert tts_on_disk["provider"] != "moonshine"
+
+
+# ── NPU trio (NPU Phase 2): device=npu never spawns the shadow stt slot ──────
+
+
+class _StubSlot:
+    def __init__(self, state: str = "ready") -> None:
+        class _S:
+            value = state
+
+        self.state = _S()
+
+
+class FakeSlotManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        self._configs: list[dict[str, Any]] = []
+
+    def set_configs(self, configs: list[dict[str, Any]]) -> None:
+        self._configs = list(configs)
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        self.calls.append(("iter_configs", "", {}))
+        return list(self._configs)
+
+    async def status(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("status", slot_name, {}))
+        return _StubSlot("ready")
+
+    async def load(self, slot_name: str, model_id: str | None = None) -> _StubSlot:
+        self.calls.append(("load", slot_name, {"model_id": model_id}))
+        return _StubSlot("ready")
+
+    async def unload(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("unload", slot_name, {}))
+        return _StubSlot("offline")
+
+    async def swap(self, slot_name: str, new_model_id: str) -> _StubSlot:
+        self.calls.append(("swap", slot_name, {"model_id": new_model_id}))
+        return _StubSlot("ready")
+
+    async def restart(self, slot_name: str) -> _StubSlot:
+        self.calls.append(("restart", slot_name, {}))
+        return _StubSlot("ready")
+
+    async def create(self, slot_name: str, cfg: dict[str, Any]) -> _StubSlot:
+        self.calls.append(("create", slot_name, {"cfg": cfg}))
+        return _StubSlot("offline")
+
+    async def update_config(self, slot_name: str, updates: dict[str, Any]) -> _StubSlot:
+        self.calls.append(("update_config", slot_name, {"updates": updates}))
+        return _StubSlot("ready")
+
+
+@pytest.fixture(autouse=True)
+def _no_spawn_context_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.agents.hermes_refresh as _hr
+
+    monkeypatch.setattr(_hr, "spawn_context_refresh", lambda *a, **k: None)
+
+
+async def test_apply_npu_stt_drives_flm_trio_without_slot_spawn(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Selecting npu for voice.stt rewrites to the FLM trio behaviour: an
+    anchor [npu] asr=True toggle, a device=npu/type=transcription slot
+    RECORD, ZERO load/swap/unload of the stt slot, and pending_reload=True —
+    mirrors the embed NPU Phase 2 contract in
+    ``test_npu_phase2_integration.py`` adapted for voice.stt.
+    """
+    monkeypatch.setattr(
+        CapabilityOrchestrator,
+        "_validate_model_in_catalog",
+        lambda self, slot, child, model_id, backend_id: None,
+    )
+    home = Path(tmp_hal0_home)
+    slots_dir = home / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    # Prior state: CPU Moonshine engine already selected and running.
+    _write_stt_slot(str(home), device="cpu", profile="moonshine")
+    caps_path = home / "etc" / "hal0" / "capabilities.toml"
+    caps_path.write_text(
+        "\n".join(
+            [
+                "[selections.voice.stt]",
+                'device = "cpu"',
+                'provider = "moonshine"',
+                'model = "moonshine-small-streaming-en"',
+                "enabled = true",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    fake = FakeSlotManager()
+    fake.set_configs(
+        [
+            {
+                "name": "npu",
+                "type": "llm",
+                "device": "npu",
+                "profile": "flm",
+                "model": {"default": "gemma3:1b"},
+            }
+        ]
+    )
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    result = await orch.apply(
+        "voice",
+        "stt",
+        {
+            "enabled": True,
+            "device": "npu",
+            "provider": "flm",
+            "model": "whisper-large-v3",
+        },
+    )
+
+    # 1. Anchor's [npu] asr toggle written.
+    npu_writes = [
+        c
+        for c in fake.calls
+        if c[0] == "update_config" and c[1] == "npu" and c[2]["updates"] == {"npu": {"asr": True}}
+    ]
+    assert npu_writes, f"anchor [npu] asr toggle was never written: {fake.calls}"
+
+    # 2. The stt slot RECORD is stamped type=transcription (no nested model).
+    type_writes = [
+        c
+        for c in fake.calls
+        if c[0] == "update_config"
+        and c[1] == "stt"
+        and c[2]["updates"].get("type") == "transcription"
+    ]
+    assert type_writes, f"no type write on stt slot: {fake.calls}"
+    assert type_writes[-1][2]["updates"] == {"type": "transcription"}, type_writes[-1]
+
+    # 3. ZERO standalone spawn on the stt slot — same slot, no move/recreate
+    #    via the lifecycle path.
+    assert not [c for c in fake.calls if c[0] in ("load", "swap", "unload")], (
+        f"NPU stt path must not bounce the modality slot: {fake.calls}"
+    )
+    assert not [c for c in fake.calls if c[0] == "create"], (
+        f"stt.toml already existed — must reconcile in place, not recreate: {fake.calls}"
+    )
+
+    # 4. Anchor never eagerly restarted; pending_reload surfaced.
+    assert not [c for c in fake.calls if c[0] == "restart"], fake.calls
+    assert result.get("pending_reload") is True
+
+    # 5. Persisted selection reflects device=npu + enabled; slot name unchanged.
+    assert result["slot"] == "stt"
+    persisted = load_capabilities_config(caps_path)
+    sel = persisted.selections["voice"]["stt"]
+    assert sel.device == "npu"
+    assert sel.enabled is True
+
+    # 6. Still exactly one stt slot file — no new/renamed file appeared.
+    assert [p.name for p in slots_dir.glob("*.toml")] == ["stt.toml"]
+
+async def test_apply_gpu_device_for_stt_is_a_typed_error(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """hal0 ships no GPU STT engine — a gpu device selection for voice.stt
+    must fail with a typed BadRequest (capability.no_engine_for_device), not
+    fall through to writing a llama profile into the stt slot."""
+    from hal0.errors import BadRequest
+
+    _write_stt_slot(tmp_hal0_home, device="cpu", profile="moonshine")
+    fake = FakeSlotManager()
+    orch = CapabilityOrchestrator(slot_manager=fake)
+
+    for device in ("gpu-vulkan", "gpu-rocm"):
+        with pytest.raises(BadRequest) as exc_info:
+            await orch.apply("voice", "stt", {"device": device, "enabled": True})
+        assert exc_info.value.code == "capability.no_engine_for_device"
+        assert device in str(exc_info.value)
+
+    # The slot on disk is untouched — the reject happened before any write.
+    on_disk = _read_stt_slot(tmp_hal0_home)
+    assert on_disk["profile"] == "moonshine"
+    assert on_disk["device"] == "cpu"

--- a/tests/capabilities/test_stt_profile_fit.py
+++ b/tests/capabilities/test_stt_profile_fit.py
@@ -1,0 +1,56 @@
+"""STT branch of the shared picker/apply profile-fit rule.
+
+The stt capability is device-keyed exactly like tts (two engines on two
+different devices): ``npu`` resolves the FLM trio profile, ``cpu`` resolves
+the Moonshine profile. GPU devices resolve NOTHING — hal0 ships no GPU STT
+engine, and the historical behaviour (falling through to the generic GPU
+branch) handed the stt slot a llama chat profile: wrong runtime family, the
+slot could never start the STT image. That fall-through is the regression
+pinned here.
+"""
+
+from __future__ import annotations
+
+from hal0.capabilities.profile_fit import profile_name_for_fit
+from hal0.config.schema import DEVICE_DEFAULT_PROFILES
+
+
+def test_stt_npu_resolves_flm_profile() -> None:
+    assert profile_name_for_fit("stt", "npu") == DEVICE_DEFAULT_PROFILES["npu"]
+
+
+def test_stt_cpu_resolves_moonshine() -> None:
+    assert profile_name_for_fit("stt", "cpu") == "moonshine"
+
+
+def test_stt_gpu_devices_resolve_nothing() -> None:
+    """Regression: gpu-vulkan STT used to resolve the llama chat profile.
+
+    ``None`` (not a llama profile) is the contract — the apply path treats
+    it as "no engine for this device" instead of silently writing a chat
+    profile into the stt slot.
+    """
+    for device in ("gpu-vulkan", "gpu-rocm", "gpu-cuda"):
+        assert profile_name_for_fit("stt", device) is None
+
+
+def test_stt_unknown_device_resolves_nothing() -> None:
+    assert profile_name_for_fit("stt", "") is None
+    assert profile_name_for_fit("stt", "bogus") is None
+
+
+def test_moonshine_profile_serves_transcription_only() -> None:
+    """The seeded moonshine profile classifies to the moonshine runtime
+    family and supports exactly the transcription slot type."""
+    from hal0.profiles import ProfileCatalog
+
+    resolved = ProfileCatalog().resolve("moonshine")
+    assert resolved.runtime_family == "moonshine"
+    assert resolved.supported_slot_types == ("transcription",)
+
+
+def test_tts_rule_unchanged() -> None:
+    """The tts engine switch must stay byte-identical while stt lands."""
+    assert profile_name_for_fit("tts", "cpu") == "kokoro"
+    assert profile_name_for_fit("tts", "gpu-rocm") == "qwen3-tts"
+    assert profile_name_for_fit("tts", "gpu-vulkan") == "qwen3-tts"

--- a/tests/capabilities/test_stt_profile_fit.py
+++ b/tests/capabilities/test_stt_profile_fit.py
@@ -54,3 +54,25 @@ def test_tts_rule_unchanged() -> None:
     assert profile_name_for_fit("tts", "cpu") == "kokoro"
     assert profile_name_for_fit("tts", "gpu-rocm") == "qwen3-tts"
     assert profile_name_for_fit("tts", "gpu-vulkan") == "qwen3-tts"
+
+
+def test_stt_provider_without_a_runtime_resolves_no_profile() -> None:
+    """A provider hal0 has no runtime profile for must not inherit the CPU
+    engine's profile.
+
+    Live defect (lxc105): the picker offers Whisper-Large-v3-Turbo under
+    provider ``whispercpp`` (a curated surfacing decision from #514 with no
+    runtime behind it). The device-only rule handed that cpu row Moonshine's
+    profile, which would have pointed MoonshineProvider at a Whisper GGUF it
+    cannot load.
+    """
+    assert profile_name_for_fit("stt", "cpu", "whispercpp") is None
+    assert profile_name_for_fit("stt", "gpu-vulkan", "whispercpp") is None
+
+
+def test_stt_known_providers_still_resolve() -> None:
+    assert profile_name_for_fit("stt", "cpu", "moonshine") == "moonshine"
+    assert profile_name_for_fit("stt", "npu", "flm") == DEVICE_DEFAULT_PROFILES["npu"]
+    # No provider named (the common partial-selection case) keeps the
+    # device-keyed default.
+    assert profile_name_for_fit("stt", "cpu") == "moonshine"

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -244,6 +244,59 @@ def test_exit_code_mapping() -> None:
     assert da._exit_code([_c("fail", critical=True)]) == 2
 
 
+# ── check_voice_stt_weights ───────────────────────────────────────────────────
+
+
+class _StubProfile:
+    def __init__(self, flags: str) -> None:
+        self.resolved_flags = flags
+
+
+class _StubCatalog:
+    def __init__(self, flags: str | None) -> None:
+        self._flags = flags
+
+    def resolve(self, name: str):
+        if self._flags is None:
+            raise KeyError(name)
+        return _StubProfile(self._flags)
+
+
+def _stt_weights_with(monkeypatch: pytest.MonkeyPatch, flags: str | None) -> Check:
+    import hal0.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "ProfileCatalog", lambda: _StubCatalog(flags))
+    return da.check_voice_stt_weights()
+
+
+def test_stt_weights_missing_bundle_fails_by_name(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    missing = tmp_path / "moonshine"
+    c = _stt_weights_with(monkeypatch, f"--model_path {missing} --model_arch small_streaming")
+    assert c.status == "fail"
+    assert str(missing) in c.detail
+
+
+def test_stt_weights_empty_path_warns_hf_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _stt_weights_with(monkeypatch, "--model_arch small_streaming")
+    assert c.status == "warn"
+    assert "HuggingFace" in c.detail
+
+
+def test_stt_weights_staged_bundle_passes(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    leaf = tmp_path / "moonshine" / "quantized" / "small-streaming-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encode_model.ort").write_bytes(b"\0")
+    c = _stt_weights_with(monkeypatch, f"--model_path {tmp_path / 'moonshine'}")
+    assert c.status == "pass"
+
+
+def test_stt_weights_profile_absent_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _stt_weights_with(monkeypatch, None)
+    assert c.status == "pass"
+
+
 # ── build_all_checks orchestration ────────────────────────────────────────────
 
 
@@ -282,17 +335,22 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
     # Privileged seams (#1465): probed against the real filesystem otherwise,
     # which is neither present nor relevant in CI — pretend all installed.
     monkeypatch.setattr(da, "probe_seams", lambda: [])
+    # Moonshine weights row (stt-weights) preflights a real filesystem path
+    # via the provider helper; neutralise it so this composition test asserts
+    # the row list, not the host's staged-weights state.
+    monkeypatch.setattr("hal0.providers.moonshine.check_moonshine_weights", lambda _p: None)
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 7 extras.
-    assert keys[-7:] == [
+    # 7 verify rows + 8 extras.
+    assert keys[-8:] == [
         "auth",
         "models",
         "migrations",
         "ports",
         "hal0_target",
         "secret-modes",
+        "stt-weights",
         "seams",
     ]
     assert "api" in keys and "runners" in keys

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -287,7 +287,7 @@ def test_stt_weights_empty_path_warns_hf_fallback(monkeypatch: pytest.MonkeyPatc
 def test_stt_weights_staged_bundle_passes(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     leaf = tmp_path / "moonshine" / "quantized" / "small-streaming-en"
     leaf.mkdir(parents=True)
-    (leaf / "encode_model.ort").write_bytes(b"\0")
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
     c = _stt_weights_with(monkeypatch, f"--model_path {tmp_path / 'moonshine'}")
     assert c.status == "pass"
 

--- a/tests/config/test_seeds_data.py
+++ b/tests/config/test_seeds_data.py
@@ -22,7 +22,7 @@ from hal0.config.schema import (
 )
 
 # The 1.0 catalog is intentionally small: workload/runtime-family seeds only.
-_EXPECTED_PROFILE_COUNT = 16
+_EXPECTED_PROFILE_COUNT = 17
 _EXPECTED_STACK_SLUGS = {"saber", "forge", "pi"}
 
 

--- a/tests/config/test_seeds_parity.py
+++ b/tests/config/test_seeds_parity.py
@@ -19,6 +19,7 @@ CANONICAL_PROFILES = {
     "chadrock-moe",
     "thinking",
     "coding",
+    "moonshine",
 }
 
 

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -92,10 +92,13 @@ def test_unknown_runtime_family_fails_loudly() -> None:
 
     from hal0.providers.container import UnknownRuntimeFamilyError
 
-    with _patch(
-        "hal0.providers.container._profile_runtime_family",
-        return_value="quantumfoo",
-    ), _pytest.raises(UnknownRuntimeFamilyError) as exc_info:
+    with (
+        _patch(
+            "hal0.providers.container._profile_runtime_family",
+            return_value="quantumfoo",
+        ),
+        _pytest.raises(UnknownRuntimeFamilyError) as exc_info,
+    ):
         _spec_provider_for({"device": "cpu", "profile": "whatever"})
     assert "quantumfoo" in str(exc_info.value)
 

--- a/tests/providers/test_container_spec_dispatch.py
+++ b/tests/providers/test_container_spec_dispatch.py
@@ -61,6 +61,45 @@ def test_spec_provider_comfyui_returns_comfyui() -> None:
         assert isinstance(_spec_provider_for(cfg), ComfyUIProvider), cfg
 
 
+def test_spec_provider_transcription_type_returns_moonshine() -> None:
+    from hal0.providers.moonshine import MoonshineProvider
+
+    result = _spec_provider_for({"device": "cpu", "type": "transcription"})
+    assert isinstance(result, MoonshineProvider)
+
+
+def test_spec_provider_moonshine_profile_returns_moonshine() -> None:
+    from hal0.providers.moonshine import MoonshineProvider
+
+    result = _spec_provider_for({"device": "cpu", "profile": "moonshine"})
+    assert isinstance(result, MoonshineProvider)
+
+
+def test_npu_transcription_wins_over_moonshine() -> None:
+    """device=npu transcription is the FLM trio, never the CPU engine."""
+    from hal0.providers.flm import FLMProvider
+
+    result = _spec_provider_for({"device": "npu", "type": "transcription"})
+    assert isinstance(result, FLMProvider)
+
+
+def test_unknown_runtime_family_fails_loudly() -> None:
+    """A RuntimeFamily extension without a dispatch branch must not silently
+    fall through to the llama-server default (the F3 fragility)."""
+    from unittest.mock import patch as _patch
+
+    import pytest as _pytest
+
+    from hal0.providers.container import UnknownRuntimeFamilyError
+
+    with _patch(
+        "hal0.providers.container._profile_runtime_family",
+        return_value="quantumfoo",
+    ), _pytest.raises(UnknownRuntimeFamilyError) as exc_info:
+        _spec_provider_for({"device": "cpu", "profile": "whatever"})
+    assert "quantumfoo" in str(exc_info.value)
+
+
 def test_spec_provider_gpu_returns_none() -> None:
     result = _spec_provider_for({"device": "gpu-rocm", "profile": "chat"})
     assert result is None

--- a/tests/providers/test_moonshine_container_spec.py
+++ b/tests/providers/test_moonshine_container_spec.py
@@ -171,3 +171,35 @@ def test_preflight_allows_empty_path_hf_fallback() -> None:
 
 def test_preflight_accepts_staged_bundle(bundle) -> None:
     check_moonshine_weights(str(bundle))  # must not raise
+
+
+def test_profile_baked_path_is_leaf_resolved(tmp_path, monkeypatch) -> None:
+    """A self-managed slot (no registry path) must still get the loadable leaf.
+
+    Live gotcha (lxc105): operators stage the tree ROOT in the profile — the
+    natural thing to write — while the loader wants the directory holding
+    encoder_model.{ort,onnx}. Without resolution the container silently
+    downloads from HuggingFace despite the weights being on disk.
+    """
+    import shlex
+
+    from hal0.providers import moonshine as ms
+
+    root = tmp_path / "moonshine"
+    leaf = root / "quantized" / "base-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+
+    class _Profile:
+        resolved_flags = f"--model_path {root} --model_arch base"
+
+    class _Catalog:
+        def resolve(self, _name):
+            return _Profile()
+
+    monkeypatch.setattr("hal0.profiles.ProfileCatalog", lambda: _Catalog())
+
+    spec = ms.MoonshineProvider().container_spec(_slot_cfg(), {})
+    c = spec.command
+    assert c[c.index("--model_path") + 1] == str(leaf)
+    assert shlex.join(c).count("--model_path") == 1

--- a/tests/providers/test_moonshine_container_spec.py
+++ b/tests/providers/test_moonshine_container_spec.py
@@ -203,3 +203,54 @@ def test_profile_baked_path_is_leaf_resolved(tmp_path, monkeypatch) -> None:
     c = spec.command
     assert c[c.index("--model_path") + 1] == str(leaf)
     assert shlex.join(c).count("--model_path") == 1
+
+
+def test_weights_outside_store_root_get_their_own_mount(tmp_path, monkeypatch) -> None:
+    """Live gotcha (lxc105): the box's model store is /var/lib/hal0/models
+    while the staged bundle sits under /mnt/ai-models — outside the mount,
+    so the container saw nothing and fell back to a network download.
+    Weights outside the store root get an identical-path read-only mount.
+    """
+    from hal0.providers import moonshine as ms
+
+    store = tmp_path / "store"
+    store.mkdir()
+    leaf = tmp_path / "elsewhere" / "moonshine" / "quantized" / "base-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+
+    class _Profile:
+        resolved_flags = f"--model_path {tmp_path / 'elsewhere' / 'moonshine'} --model_arch base"
+
+    monkeypatch.setattr(
+        "hal0.profiles.ProfileCatalog",
+        lambda: type("C", (), {"resolve": lambda s, n: _Profile()})(),
+    )
+    monkeypatch.setattr(ms, "model_store_root", lambda: str(store))
+
+    spec = ms.MoonshineProvider().container_spec(_slot_cfg(), {})
+    sources = {m.source for m in spec.mounts}
+    assert str(store) in sources
+    assert str(leaf) in sources, f"weights outside the store root were not mounted: {sources}"
+    assert all(m.read_only for m in spec.mounts)
+
+
+def test_weights_inside_store_root_add_no_extra_mount(tmp_path, monkeypatch) -> None:
+    from hal0.providers import moonshine as ms
+
+    store = tmp_path / "store"
+    leaf = store / "asr" / "moonshine" / "quantized" / "base-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+
+    class _Profile:
+        resolved_flags = f"--model_path {store / 'asr' / 'moonshine'} --model_arch base"
+
+    monkeypatch.setattr(
+        "hal0.profiles.ProfileCatalog",
+        lambda: type("C", (), {"resolve": lambda s, n: _Profile()})(),
+    )
+    monkeypatch.setattr(ms, "model_store_root", lambda: str(store))
+
+    spec = ms.MoonshineProvider().container_spec(_slot_cfg(), {})
+    assert [m.source for m in spec.mounts] == [str(store)]

--- a/tests/providers/test_moonshine_container_spec.py
+++ b/tests/providers/test_moonshine_container_spec.py
@@ -122,10 +122,28 @@ def test_slot_port_override_wins(bundle) -> None:
 # ── Weight preflight (spawn fails by artifact name, not first-request 500) ─────
 
 
-def test_spec_preflight_names_missing_bundle(tmp_path) -> None:
+def test_spec_preflight_names_missing_bundle(tmp_path, monkeypatch) -> None:
+    """Spawn fails by artifact name when the staged bundle is absent.
+
+    The path preflighted is the profile's — a registry path that holds no
+    loadable bundle is ignored (see
+    ``test_non_bundle_registry_path_falls_back_to_profile``), so the error
+    must name the operator-facing path, not the stray registry one.
+    """
+    from hal0.providers import moonshine as ms
+
     missing = tmp_path / "nope" / "moonshine"
+
+    class _Profile:
+        resolved_flags = f"--model_path {missing} --model_arch base"
+
+    monkeypatch.setattr(
+        "hal0.profiles.ProfileCatalog",
+        lambda: type("C", (), {"resolve": lambda s, n: _Profile()})(),
+    )
+
     with pytest.raises(MoonshineWeightsMissingError) as exc_info:
-        MoonshineProvider().container_spec(_slot_cfg(), {"path": str(missing)})
+        ms.MoonshineProvider().container_spec(_slot_cfg(), {})
     assert str(missing) in str(exc_info.value)
     assert exc_info.value.code == "slot.weights_missing"
 
@@ -254,3 +272,30 @@ def test_weights_inside_store_root_add_no_extra_mount(tmp_path, monkeypatch) -> 
 
     spec = ms.MoonshineProvider().container_spec(_slot_cfg(), {})
     assert [m.source for m in spec.mounts] == [str(store)]
+
+
+def test_non_bundle_registry_path_falls_back_to_profile(tmp_path, monkeypatch) -> None:
+    """Live gotcha (lxc105): a self-managed transcription slot's registry
+    lookup returned an unrelated VibeVoice .gguf. A non-loadable registry
+    path must not displace the operator-staged bundle in the profile."""
+    from hal0.providers import moonshine as ms
+
+    staged = tmp_path / "moonshine"
+    leaf = staged / "quantized" / "base-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+    stray = tmp_path / "asr" / "VibeVoice-ASR-BitNet"
+    stray.mkdir(parents=True)
+    (stray / "model.gguf").write_bytes(b"\0")
+
+    class _Profile:
+        resolved_flags = f"--model_path {staged} --model_arch base"
+
+    monkeypatch.setattr(
+        "hal0.profiles.ProfileCatalog",
+        lambda: type("C", (), {"resolve": lambda s, n: _Profile()})(),
+    )
+
+    spec = ms.MoonshineProvider().container_spec(_slot_cfg(), {"path": str(stray / "model.gguf")})
+    c = spec.command
+    assert c[c.index("--model_path") + 1] == str(leaf)

--- a/tests/providers/test_moonshine_container_spec.py
+++ b/tests/providers/test_moonshine_container_spec.py
@@ -35,8 +35,8 @@ def bundle(tmp_path) -> Any:
     """A staged-looking moonshine bundle: root/quantized/<variant>/ with weights."""
     leaf = tmp_path / "moonshine" / "quantized" / "small-streaming-en"
     leaf.mkdir(parents=True)
-    (leaf / "encode_model.ort").write_bytes(b"\0")
-    (leaf / "decode_model.ort").write_bytes(b"\0")
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+    (leaf / "decoder_model_merged.ort").write_bytes(b"\0")
     return tmp_path / "moonshine"
 
 
@@ -136,6 +136,32 @@ def test_preflight_rejects_dir_without_weights(tmp_path) -> None:
     with pytest.raises(MoonshineWeightsMissingError) as exc_info:
         check_moonshine_weights(str(empty))
     assert str(empty) in str(exc_info.value)
+
+
+def test_preflight_rejects_streaming_only_bundle(tmp_path) -> None:
+    """Live gotcha (lxc105): the streaming-SDK file set (encoder.ort /
+    frontend.ort) is NOT loadable by this image — the server resolves
+    encoder_model.{ort,onnx}. Accepting it produced a container that started
+    and then failed every transcription."""
+    streaming = tmp_path / "moonshine" / "quantized"
+    streaming.mkdir(parents=True)
+    for name in ("encoder.ort", "frontend.ort", "cross_kv.ort", "tokenizer.bin"):
+        (streaming / name).write_bytes(b"\0")
+    with pytest.raises(MoonshineWeightsMissingError) as exc_info:
+        check_moonshine_weights(str(tmp_path / "moonshine"))
+    assert "streaming" in str(exc_info.value).lower()
+
+
+def test_leaf_resolves_bundle_nested_without_variant_dir(tmp_path) -> None:
+    """The staged tree also uses <root>/quantized/ directly (no <variant>
+    subdir) — the resolver must find the encoder there too."""
+    from hal0.providers.moonshine import _resolve_model_leaf
+
+    leaf = tmp_path / "base-en" / "quantized"
+    leaf.mkdir(parents=True)
+    (leaf / "encoder_model.ort").write_bytes(b"\0")
+    resolved = _resolve_model_leaf(str(tmp_path / "base-en"), "base-en")
+    assert resolved == str(leaf)
 
 
 def test_preflight_allows_empty_path_hf_fallback() -> None:

--- a/tests/providers/test_moonshine_container_spec.py
+++ b/tests/providers/test_moonshine_container_spec.py
@@ -1,0 +1,147 @@
+"""Moonshine STT container spec (CPU-only, mirrors the kokoro spec contract)."""
+
+from typing import Any
+
+import pytest
+
+from hal0.providers.container import _render_quadlet_from_plan
+from hal0.providers.moonshine import (
+    MoonshineProvider,
+    MoonshineWeightsMissingError,
+    check_moonshine_weights,
+)
+
+
+def _render_from_spec(token, spec, *, publish_host="127.0.0.1"):
+    return _render_quadlet_from_plan(token, spec, publish_host=publish_host)
+
+
+def _exec(unit):
+    for line in unit.splitlines():
+        if line.startswith("Exec="):
+            return line[len("Exec=") :]
+    raise AssertionError("Exec not found")
+
+
+@pytest.fixture(autouse=True)
+def _pin_model_store(monkeypatch) -> None:
+    """Pin the store resolver to the literal /mnt/ai-models mount source
+    (same rationale as the kokoro spec module)."""
+    monkeypatch.setenv("HAL0_MODEL_STORE", "/mnt/ai-models")
+
+
+@pytest.fixture()
+def bundle(tmp_path) -> Any:
+    """A staged-looking moonshine bundle: root/quantized/<variant>/ with weights."""
+    leaf = tmp_path / "moonshine" / "quantized" / "small-streaming-en"
+    leaf.mkdir(parents=True)
+    (leaf / "encode_model.ort").write_bytes(b"\0")
+    (leaf / "decode_model.ort").write_bytes(b"\0")
+    return tmp_path / "moonshine"
+
+
+def _slot_cfg(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "stt",
+        "port": 8089,
+        "device": "cpu",
+        "type": "transcription",
+        "runtime": "container",
+        "profile": "moonshine",
+    }
+    base.update(overrides)
+    return base
+
+
+def _model_info(bundle) -> dict[str, Any]:
+    return {
+        "path": str(bundle),
+        "metadata": {"variant": "small-streaming-en"},
+    }
+
+
+def test_spec_has_no_gpu_devices_or_groups(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(), _model_info(bundle))
+    assert spec.devices == []
+    assert spec.group_add == []
+
+
+def test_spec_command_carries_port_host_model_path_and_arch(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(), _model_info(bundle))
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8089"
+    assert c[c.index("--host") + 1] == "0.0.0.0"
+    # Registry path beats the profile-baked default AND resolves the
+    # quantized/<variant> leaf so the in-container loader can't fall back
+    # to a network download.
+    assert c[c.index("--model_path") + 1] == str(bundle / "quantized" / "small-streaming-en")
+    assert c[c.index("--model_arch") + 1] == "small_streaming"
+
+
+def test_spec_mounts_model_store_ro_and_publishes_loopback(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(), _model_info(bundle))
+    ai_mount = next(m for m in spec.mounts if m.source == "/mnt/ai-models")
+    assert ai_mount.read_only is True
+    assert ai_mount.target == "/mnt/ai-models"
+    assert spec.port == 8089
+    assert spec.network_mode == ""
+
+
+def test_spec_security_opts_for_lxc(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(), _model_info(bundle))
+    assert "apparmor=unconfined" in spec.security_opt
+    assert "seccomp=unconfined" in spec.security_opt
+
+
+def test_renderer_no_device_args_publish_volume_command(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(), _model_info(bundle))
+    unit = _render_from_spec("stt", spec)
+    lines = unit.splitlines()
+
+    assert not any(line.startswith("AddDevice=") for line in lines), (
+        "CPU slot must not pass any device nodes"
+    )
+    assert "PublishPort=127.0.0.1:8089:8089" in lines
+    assert "Volume=/mnt/ai-models:/mnt/ai-models:ro" in unit
+    exec_argv = _exec(unit)
+    assert "--model_path" in exec_argv
+    assert "--model_arch" in exec_argv
+    assert "8089" in exec_argv
+
+
+def test_slot_port_override_wins(bundle) -> None:
+    spec = MoonshineProvider().container_spec(_slot_cfg(port=8098), _model_info(bundle))
+    c = spec.command
+    assert c[c.index("--port") + 1] == "8098"
+    assert spec.port == 8098
+
+    unit = _render_from_spec("stt", spec)
+    assert "PublishPort=127.0.0.1:8098:8098" in unit.splitlines()
+
+
+# ── Weight preflight (spawn fails by artifact name, not first-request 500) ─────
+
+
+def test_spec_preflight_names_missing_bundle(tmp_path) -> None:
+    missing = tmp_path / "nope" / "moonshine"
+    with pytest.raises(MoonshineWeightsMissingError) as exc_info:
+        MoonshineProvider().container_spec(_slot_cfg(), {"path": str(missing)})
+    assert str(missing) in str(exc_info.value)
+    assert exc_info.value.code == "slot.weights_missing"
+
+
+def test_preflight_rejects_dir_without_weights(tmp_path) -> None:
+    empty = tmp_path / "moonshine"
+    empty.mkdir()
+    with pytest.raises(MoonshineWeightsMissingError) as exc_info:
+        check_moonshine_weights(str(empty))
+    assert str(empty) in str(exc_info.value)
+
+
+def test_preflight_allows_empty_path_hf_fallback() -> None:
+    """No --model_path → the in-container HuggingFace fallback is legal."""
+    check_moonshine_weights("")  # must not raise
+
+
+def test_preflight_accepts_staged_bundle(bundle) -> None:
+    check_moonshine_weights(str(bundle))  # must not raise

--- a/tests/runners/test_registry.py
+++ b/tests/runners/test_registry.py
@@ -26,7 +26,7 @@ from hal0.runners import (
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-_REAL_FAMILIES = {"llama-server", "flm", "kokoro", "qwen3tts", "comfyui"}
+_REAL_FAMILIES = {"llama-server", "flm", "kokoro", "qwen3tts", "moonshine", "comfyui"}
 _REAL_DEVICE_CLASSES = {"gpu", "cpu", "npu", "img"}
 
 
@@ -38,6 +38,7 @@ def test_registry_has_every_expected_key() -> None:
         "cpu",
         "flm",
         "kokoro",
+        "moonshine",
         "qwen3tts",
         "comfyui",
     }

--- a/tests/slots/test_seed_profiles.py
+++ b/tests/slots/test_seed_profiles.py
@@ -4,7 +4,8 @@ Per docs/superpowers/specs/2026-07-20-seeded-profile-rework-design.md:
 - Every profile must have: name (implicit via [profile.<name>]), flags, intent.
 - `device_class` field is REMOVED (slot owns device).
 - `flags` must NOT contain SLOT_HARDWARE_FLAGS or operational flags.
-- Profile names match the 1.0 catalog (16 total — 11 kept + 5 new for 1.0).
+- Profile names match the 1.0 catalog (17 total — 11 kept + 5 new for 1.0
+  + moonshine, reinstated post-1.0-freeze; see docs/adr/0001).
 """
 
 from __future__ import annotations
@@ -42,7 +43,7 @@ OPERATIONAL_FLAG_FRAGMENTS = (
     "--no-mmap",
 )
 
-ALL_16_PROFILES = [
+ALL_17_PROFILES = [
     "profile.chat",
     "profile.chat-long-context",
     "profile.dense",
@@ -53,6 +54,7 @@ ALL_16_PROFILES = [
     "profile.flm",
     "profile.kokoro",
     "profile.qwen3-tts",
+    "profile.moonshine",
     "profile.comfyui",
     # New for 1.0 (per spec §4.2):
     "profile.brain",
@@ -78,14 +80,14 @@ def test_seed_profiles_loads() -> None:
     assert len(profiles) >= 11, f"expected ≥11 profiles, got {len(profiles)}: {list(profiles)}"
 
 
-def test_catalog_has_exactly_16_profiles() -> None:
-    """1.0 catalog is exactly 16 profiles (11 kept + 5 new)."""
+def test_catalog_has_exactly_17_profiles() -> None:
+    """1.0 catalog is exactly 17 profiles (11 kept + 5 new + moonshine)."""
     profiles = _load_seed_profiles()
     names = sorted(profiles)
-    assert names == sorted(ALL_16_PROFILES), f"catalog profiles out of order or missing: {names}"
+    assert names == sorted(ALL_17_PROFILES), f"catalog profiles out of order or missing: {names}"
 
 
-@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+@pytest.mark.parametrize("profile_name", ALL_17_PROFILES)
 def test_every_seed_profile_is_device_agnostic(profile_name: str) -> None:
     profiles = _load_seed_profiles()
     assert profile_name in profiles, f"missing {profile_name}"
@@ -95,7 +97,7 @@ def test_every_seed_profile_is_device_agnostic(profile_name: str) -> None:
     )
 
 
-@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+@pytest.mark.parametrize("profile_name", ALL_17_PROFILES)
 def test_all_profiles_have_no_hardware_flags(profile_name: str) -> None:
     profiles = _load_seed_profiles()
     flags = profiles[profile_name].get("flags", "")
@@ -105,7 +107,7 @@ def test_all_profiles_have_no_hardware_flags(profile_name: str) -> None:
         )
 
 
-@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+@pytest.mark.parametrize("profile_name", ALL_17_PROFILES)
 def test_all_profiles_have_no_operational_flags(profile_name: str) -> None:
     profiles = _load_seed_profiles()
     flags = profiles[profile_name].get("flags", "")
@@ -115,7 +117,7 @@ def test_all_profiles_have_no_operational_flags(profile_name: str) -> None:
         )
 
 
-@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+@pytest.mark.parametrize("profile_name", ALL_17_PROFILES)
 def test_all_profiles_have_no_managed_or_hardware_flags(profile_name: str) -> None:
     """§21.7 regression tripwire: a seed's flags must never carry a flag hal0
     owns (managed denylist: --model/--ctx-size/-c/--host/--port/-ngl/--alias)
@@ -134,7 +136,7 @@ def test_all_profiles_have_no_managed_or_hardware_flags(profile_name: str) -> No
     assert not removed, f"{profile_name} flags carry hal0-owned flag(s) {removed}: {flags}"
 
 
-@pytest.mark.parametrize("profile_name", ALL_16_PROFILES)
+@pytest.mark.parametrize("profile_name", ALL_17_PROFILES)
 def test_all_profiles_have_intent(profile_name: str) -> None:
     profiles = _load_seed_profiles()
     assert "intent" in profiles[profile_name], f"{profile_name} missing intent"


### PR DESCRIPTION
Reinstates Moonshine as hal0's CPU speech-to-text engine, making `voice.stt` a
device-keyed engine switch with the same shape as the existing `voice.tts` one:
`cpu` runs Moonshine, `npu` runs whisper-v3:turbo through the FLM trio.

## Why

`v0.2.0` retired Moonshine "in favour of whisper.cpp via Lemonade". That
justification never survived the Lemonade rollback — whisper.cpp was never
shipped as a CPU service and sits on PLAN.md's strip list. The only Whisper
hal0 runs is inside the NPU trio, so **every host without XDNA had zero STT**,
and the docs said so outright ("there is no CPU-only STT backend in hal0").

Moonshine was a reinstatement, not new work: the toolbox image was still
published and digest-pinned in `manifest.json`, the in-container server and its
tests were still in the tree, and `scripts/release-test.sh` still carried a
moonshine STT row. Only the provider and the wiring had been deleted.

## What changed

- **Runtime family + registries** — `moonshine` added to both `RuntimeFamily`
  literals and `model_meta.RUNTIME_FAMILIES`; `RUNNER_IMAGES["moonshine"]`
  (cpu, manifest-pinned, onnx); seeded `[profile.moonshine]`; the profile
  catalog grants it the `transcription` slot type.
- **`MoonshineProvider`** — CPU-only container spec modelled on the qwen3tts
  runtime-family pattern (no GPU devices, read-only identical-path model-store
  mount, loopback publish, LXC `security_opt`), plus a dispatch branch that now
  fails loudly on any runtime family with no branch instead of silently
  spawning llama-server.
- **Engine switch** — `profile_name_for_fit` grows an `stt` branch, the catalog
  injects the CPU engine row, and `SlotConfigStore` generalises the tts profile
  stamp so both children share one rule. GPU devices for `voice.stt` return a
  typed `capability.no_engine_for_device` instead of the previous fall-through,
  which handed the slot a **llama chat profile** — a live bug fixed here.
- **Weight preflight** — slot spawn and a new `hal0 doctor` row run the same
  check; a missing or unusable bundle fails with `slot.weights_missing` naming
  the path, rather than a container that starts and 500s on first request.
- **Docs** — ADR-0001 (the repo's first ADR), voice guide rewritten around the
  switch, README backends row corrected (it claimed a whisper.cpp toolbox path
  that does not exist), plus reference/CHANGELOG updates.

## Verification

**α:** full unit suite `8819 passed, 14 skipped, 1 xfailed, 0 failed`. Ruff
clean. Mypy unchanged from baseline `94fc296c` (463 pre-existing errors, zero
introduced).

**Live on LXC 105** — deployed, staged the bundle, and exercised it:

| Check | Result |
|---|---|
| Round-trip transcription | `{"text":"How zero voice check 1 2 3"}`, 0.63 s warm / 7.55 s cold |
| Error matrix (direct + API) | empty→400, 1-byte→415, text-as-wav→415 |
| ffmpeg argv redaction | clean — no path or argv in any error body |
| Missing `model` | 400 `request.missing_model` |
| GPU device for `voice.stt` | 400 `capability.no_engine_for_device` |
| Weights removed | 409 naming the path, doctor FAIL, zero orphan containers |
| load / unload / restart | clean, no orphans |
| Concurrent chat + STT | STT 0.57 s alongside a 4.34 s chat |
| γ moonshine row | passes (200 + JSON body) |

The live run found seven defects that passing unit tests had confirmed as
correct — each fixed with a regression test:

1. Streaming bundles aren't loadable (the server resolves
   `encoder_model.{ort,onnx}`; streaming ships `encoder.ort`/`frontend.ort`).
2. Leaf resolution missed the `quantized/` layout.
3. The profile-baked path was never leaf-resolved, so self-managed slots
   silently fell back to a HuggingFace download.
4. Weights staged outside the model store root weren't mounted at all.
5. A stray registry path (a VibeVoice `.gguf`) hijacked the slot.
6. The γ row posted `model=moonshine-base`, an id the server never serves, and
   sent no auth header — it could not pass on any box.
7. The device-only fit rule lent Moonshine's profile to `whispercpp` picker
   rows, which would have pointed `MoonshineProvider` at a Whisper GGUF.

## Deliberately out of scope

- **whisper.cpp stays stripped.** NPU whisper via FLM is untouched.
- **The whispercpp surfacing contradiction is surfaced, not settled.**
  `test_stt_curation.py` (#514) asserts `Whisper-Large-v3-Turbo` must be
  visible with a real backend; `registry/curated.py`'s TODO records that no
  such runtime exists. This PR removes the harm (the row is inert, not
  mis-wired) and documents the conflict in ADR-0001 for whoever revisits #514.
- **`provider` as a first-class selector.** Unnecessary at two engines on two
  devices; ADR-0001 records the trigger (a second CPU STT engine).
- **WebSocket streaming** stays in-container and unrouted, documented as such.

## Pre-existing issues found, not fixed

- The NPU leg of the switch trips `slot.npu_exclusivity_violation` on LXC 105
  (guard from #163, present at baseline; that box has an id-vs-name keying
  mismatch between slot `flm` and slot `8`).
- A port collision returns a generic 500 rather than a typed error — affects
  every provider, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
