### PR TITLE
fix(memory): engine LLM credential under auth + reflect client timeout

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2629,7 +2629,7 @@ else
             # /health poll below is the real gate on whether the engine came up.
             hs_installed=0
             if [[ "${hs_fallback}" -ne 1 ]]; then
-                if "${hs_pip}" install "hindsight-api==0.7.2" -q; then
+                if "${hs_pip}" install "hindsight-api==0.8.4" -q; then
                     hs_installed=1
                 else
                     hs_pyver="$("${HS_DIR}/.venv/bin/python" -c 'import sys;print("%d.%d"%sys.version_info[:2])' 2>/dev/null || echo '?')"
@@ -2639,7 +2639,7 @@ else
             if [[ "${hs_installed}" -ne 1 ]]; then
                 [[ "${hs_fallback}" -eq 1 ]] && \
                     info "installing hindsight-api with --ignore-requires-python (no Python 3.11-3.13 available; litellm's 3.14 gate is metadata-only)"
-                if "${hs_pip}" install --ignore-requires-python "hindsight-api==0.7.2" -q; then
+                if "${hs_pip}" install --ignore-requires-python "hindsight-api==0.8.4" -q; then
                     hs_installed=1
                 else
                     warn "hindsight-api install failed — memory engine will be unavailable"
@@ -2653,6 +2653,22 @@ else
         chown -R hal0:hal0 "${VAR_DIR}/memory" 2>/dev/null || true
         if [[ -x "${HS_DIR}/.venv/bin/hindsight-api" ]]; then
             install -m644 "${HINDSIGHT_UNIT_SRC}" /etc/systemd/system/hindsight-api.service
+            # The unit ships HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth — fine
+            # while the box has no keys, but once KB-1 auth is on, every
+            # extraction/reflect call to /v1 401s and retains fail silently
+            # (#1543's engine-side sibling). Hand the engine a real client-tier
+            # key via the unit's EnvironmentFile whenever one exists;
+            # `hal0 auth rotate` keeps the file fresh afterward.
+            hs_key=""
+            if [[ -f /etc/hal0/api.env ]]; then
+                hs_key="$(grep -oP '(?<=^HAL0_CLIENT_KEY=).*' /etc/hal0/api.env 2>/dev/null | head -1)"
+                [[ -z "${hs_key}" ]] && hs_key="$(grep -oP '(?<=^HAL0_ADMIN_KEY=).*' /etc/hal0/api.env 2>/dev/null | head -1)"
+            fi
+            if [[ -n "${hs_key}" ]]; then
+                ( umask 027 && printf 'HINDSIGHT_API_LLM_API_KEY=%s\n' "${hs_key}" \
+                    > /etc/hal0/hindsight-llm.env )
+                chown root:hal0 /etc/hal0/hindsight-llm.env 2>/dev/null || true
+            fi
             systemctl daemon-reload
             systemctl enable --now hindsight-api
             # First boot: embedded pg0 init + local embed/rerank model load can

--- a/installer/systemd/hindsight-api.service
+++ b/installer/systemd/hindsight-api.service
@@ -55,7 +55,14 @@ Environment=HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:8080/v1
 # overrides this value, so the operator can repoint extraction without editing this
 # installer-owned unit.
 Environment=HINDSIGHT_API_LLM_MODEL=hal0/utility
+# Placeholder credential for the auth-off posture only. Once KB-1 auth is on,
+# /v1 requires a CLIENT-tier bearer and this placeholder 401s every
+# extraction/reflect call (silent retain failure). The real key lives in
+# /etc/hal0/hindsight-llm.env — written by install.sh when a box key exists
+# and kept fresh by `hal0 auth rotate` — and, being an EnvironmentFile,
+# overrides the placeholder below at unit start.
 Environment=HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth
+EnvironmentFile=-/etc/hal0/hindsight-llm.env
 # Generous timeout retained: covers utility-slot cold starts + long reflects.
 Environment=HINDSIGHT_API_LLM_TIMEOUT=300
 # Skip the blocking startup LLM verification. On a fresh box no model is loaded

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1328,7 +1328,12 @@ def _default_mcp_servers() -> list[dict[str, Any]]:
             "url": "http://127.0.0.1:8080/mcp/memory/mcp",
             "type": "http",
             "private": True,
-            "timeout": 30,
+            # memory_reflect is an agentic LLM loop on the engine side — on the
+            # reference box a single reflect legitimately runs 5-9 minutes, so a
+            # short per-server timeout guarantees a spurious client-side failure
+            # while the engine finishes the job anyway (matches the client-side
+            # HAL0_MEMORY_REFLECT_TIMEOUT_S=900 default in memory/hindsight_client).
+            "timeout": 900,
             "usage_hint": (
                 "read/write persistent context across sessions. Use when the operator "
                 "references prior conversations or asks you to remember a fact."

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -247,6 +247,12 @@ async def rotate_key(body: RotateKeyRequest, request: Request) -> dict[str, obje
         # A client-key rotation never touches the operator's admin session.
         session_preserved = True
 
+    if status_only.get("hindsight_llm_env_refreshed"):
+        note += (
+            " The memory engine's LLM credential (/etc/hal0/hindsight-llm.env) was "
+            "refreshed too — restart hindsight-api to apply it."
+        )
+
     return {
         **status_only,
         "rotated_at": rotated_at,

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -539,6 +539,65 @@ def check_hermes_mcp_config_auth(
     )
 
 
+#: The placeholder credential the hindsight-api unit ships for the auth-off
+#: posture — see installer/systemd/hindsight-api.service.
+_HINDSIGHT_LLM_PLACEHOLDER = "hal0-local-noauth"
+
+
+def check_hindsight_llm_auth(
+    *,
+    auth: dict[str, Any] | None,
+    unit_path: Path | None = None,
+    env_path: Path | None = None,
+) -> Check:
+    """The memory engine's LLM credential must be a real key when auth is on.
+
+    hindsight-api calls back into hal0's ``/v1`` (CLIENT tier) for every
+    extraction and reflect. Its unit ships the ``hal0-local-noauth``
+    placeholder, overridden by ``/etc/hal0/hindsight-llm.env``. On an
+    auth-required box a missing/placeholder/stale key means every retain
+    fails extraction with a 401 — silently, because retain is async
+    (#1543's engine-side sibling).
+    """
+    unit = unit_path if unit_path is not None else Path("/etc/systemd/system/hindsight-api.service")
+    env_file = env_path if env_path is not None else Path("/etc/hal0/hindsight-llm.env")
+    name, title = "hindsight_llm_auth", "Memory engine LLM auth"
+    if not unit.exists():
+        return Check(name, title, _PASS, "memory engine not installed — nothing to check")
+    if not bool((auth or {}).get("auth_required")):
+        return Check(name, title, _PASS, "auth not required — placeholder credential is fine")
+
+    key = ""
+    try:
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("HINDSIGHT_API_LLM_API_KEY="):
+                key = line.split("=", 1)[1].strip()
+    except OSError:
+        key = ""
+    if not key or key == _HINDSIGHT_LLM_PLACEHOLDER:
+        return Check(
+            name,
+            title,
+            _FAIL,
+            f"auth is required but {env_file} carries no real LLM key — every retain/reflect "
+            "401s against /v1. Write a client-tier key there (`hal0 auth rotate` refreshes it "
+            "automatically from now on) and restart hindsight-api",
+        )
+
+    from hal0.service_identity import keys_from_api_env
+
+    live = set(keys_from_api_env().values())
+    if live and key not in live:
+        return Check(
+            name,
+            title,
+            _FAIL,
+            f"{env_file} carries a key that matches neither current box key (stale after a "
+            "rotation?) — refresh it and restart hindsight-api",
+        )
+    return Check(name, title, _PASS, "memory engine carries a current client-tier LLM key")
+
+
 # ── orchestration ──────────────────────────────────────────────────────────────
 
 # GET /api/slots is the slowest read-only route hal0 serves: the aggregator
@@ -595,6 +654,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_seams(),
         check_mcp_mounts(),
         check_hermes_mcp_config_auth(auth=auth_payload),
+        check_hindsight_llm_auth(auth=auth_payload),
     ]
     return verify_rows + extra_rows
 
@@ -679,6 +739,7 @@ __all__ = [
     "check_auth_posture",
     "check_hal0_target",
     "check_hermes_mcp_config_auth",
+    "check_hindsight_llm_auth",
     "check_mcp_mounts",
     "check_migrations",
     "check_model_store",

--- a/src/hal0/memory/hindsight_client.py
+++ b/src/hal0/memory/hindsight_client.py
@@ -25,6 +25,13 @@ DEFAULT_API_KEY = "hal0-local-noauth"
 DEFAULT_PROBE_TIMEOUT_S = 2.0
 PROBE_TIMEOUT_ENV = "HAL0_HINDSIGHT_PROBE_TIMEOUT_S"
 
+#: Read budget for ``/reflect`` only. Reflect is an agentic LLM loop on the
+#: engine side — on the reference box (4B utility model, 33-65k-token
+#: prompts) a single reflect legitimately runs 5-9 minutes, so the
+#: client-wide 120s read timeout guarantees a spurious failure while the
+#: engine goes on to finish the job. Overridable for slower boxes.
+REFLECT_TIMEOUT_S = float(os.environ.get("HAL0_MEMORY_REFLECT_TIMEOUT_S", "900") or "900")
+
 
 class HindsightUnreachable(RuntimeError):
     """The Hindsight daemon did not answer a health probe.
@@ -245,7 +252,10 @@ class HindsightRestClient:
         if exclude_mental_model_ids is not None:
             body["exclude_mental_model_ids"] = list(exclude_mental_model_ids)
         return await self.request_json(
-            "POST", f"/v1/default/banks/{bank_id}/reflect", json_body=body
+            "POST",
+            f"/v1/default/banks/{bank_id}/reflect",
+            json_body=body,
+            timeout_s=REFLECT_TIMEOUT_S,
         )
 
     async def list_memories(self, *, bank_id, limit=50, offset=0, types=None, query=None):
@@ -542,12 +552,15 @@ class HindsightRestClient:
         *,
         params: dict[str, Any] | None = None,
         json_body: Any | None = None,
+        timeout_s: float | None = None,
     ) -> Any:
         """Generic authenticated forward to any Hindsight REST path.
 
         The admin surface (/api/memory/banks/*) funnels its allowlisted
         passthrough through here so auth + base-url live in one place.
         Raises ``httpx.HTTPStatusError`` on non-2xx (callers map status).
+        ``timeout_s`` overrides the client-wide 120s read budget for the
+        few endpoints whose latency is dominated by an agentic LLM loop.
         """
         resp = await self._http.request(
             method,
@@ -555,6 +568,13 @@ class HindsightRestClient:
             headers=self._headers(),
             params=params,
             json=json_body,
+            timeout=(
+                httpx.Timeout(timeout_s, connect=3.0)
+                if timeout_s is not None
+                # httpx treats an explicit ``timeout=None`` as "no timeout at
+                # all"; the sentinel keeps the client-wide default instead.
+                else httpx.USE_CLIENT_DEFAULT
+            ),
         )
         resp.raise_for_status()
         if not resp.content:

--- a/src/hal0/service_identity.py
+++ b/src/hal0/service_identity.py
@@ -216,17 +216,91 @@ def rotate_api_env_key(tier: str) -> dict[str, object]:
     # key is honoured on the very next request without a restart.
     os.environ[env_name] = new_key
 
+    # Keep the memory engine's LLM credential in step: hindsight-api calls
+    # back into /v1 (CLIENT tier) for extraction/reflect, and its unit reads
+    # the key from hindsight-llm.env. A rotation that skipped this file would
+    # 401 every retain from the next hindsight restart onward (#1543's
+    # engine-side sibling). Best-effort — a box without the engine installed
+    # simply has no file to refresh.
+    hindsight_refreshed = False
+    with contextlib.suppress(OSError):
+        hindsight_refreshed = refresh_hindsight_llm_env()
+
     return {
         "tier": tier,
         "key_len": len(new_key),
         "fingerprint": key_fingerprint(new_key),
+        "hindsight_llm_env_refreshed": hindsight_refreshed,
     }
+
+
+#: The env file the hindsight-api unit reads (``EnvironmentFile=-``) for its
+#: extraction/reflect LLM credential. Written by install.sh at setup and by
+#: :func:`refresh_hindsight_llm_env` on rotation; 0640, same owner handling
+#: as api.env. The unit must be restarted to pick up a refresh (systemd reads
+#: EnvironmentFile at start) — surfaced in the rotate route's response note.
+_HINDSIGHT_LLM_ENV_NAME = "hindsight-llm.env"
+
+
+def refresh_hindsight_llm_env() -> bool:
+    """Sync ``/etc/hal0/hindsight-llm.env`` to the current box keys.
+
+    Writes ``HINDSIGHT_API_LLM_API_KEY=<client-or-admin key>`` using the same
+    atomic tmpfile + ``os.replace`` discipline as :func:`rotate_api_env_key`.
+    Returns True when the file was (re)written, False when the box has no
+    keys or the file does not exist yet and there is nothing to refresh —
+    creation on a keyless box is pointless (the placeholder default works
+    while auth is off) and creating it here would surprise operators who
+    never installed the memory engine.
+    """
+    from hal0.config import paths as cfg_paths
+
+    target = cfg_paths.etc() / _HINDSIGHT_LLM_ENV_NAME
+    key = service_key(prefer="client")
+    if not key:
+        return False
+    if not target.exists():
+        return False
+
+    content = f"HINDSIGHT_API_LLM_API_KEY={key}\n"
+
+    prev_uid = prev_gid = -1
+    with contextlib.suppress(OSError):
+        st = target.stat()
+        prev_uid, prev_gid = st.st_uid, st.st_gid
+
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=f".{_HINDSIGHT_LLM_ENV_NAME}.", suffix=".tmp", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+                fh.flush()
+                os.fsync(fh.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.chmod(tmp_path, _API_ENV_MODE)
+        if prev_uid != -1:
+            with contextlib.suppress(OSError):
+                os.chown(tmp_path, prev_uid, prev_gid)
+        os.replace(tmp_path, str(target))
+        tmp_path = None
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+    return True
 
 
 __all__ = [
     "generate_service_key",
     "key_fingerprint",
     "keys_from_api_env",
+    "refresh_hindsight_llm_env",
     "rotate_api_env_key",
     "service_auth_headers",
     "service_key",

--- a/tests/api/test_auth_rotate.py
+++ b/tests/api/test_auth_rotate.py
@@ -247,3 +247,36 @@ def test_rotate_is_rate_limited(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
         resp = client.post("/api/auth/rotate", json={"tier": "admin"})
         assert resp.status_code == 429
         assert resp.json()["error"]["code"] == "auth.rate_limited"
+
+
+def test_rotate_refreshes_hindsight_llm_env_when_present(
+    rotate_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rotation must re-sync the memory engine's LLM credential file —
+    otherwise every retain/reflect 401s from the engine's next restart on."""
+    monkeypatch.setenv("HAL0_CLIENT_KEY", "old-client-key")
+    env_file = paths.etc() / "hindsight-llm.env"
+    env_file.write_text("HINDSIGHT_API_LLM_API_KEY=old-client-key\n")
+
+    resp = rotate_client.post("/api/auth/rotate", json={"tier": "client"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["hindsight_llm_env_refreshed"] is True
+    assert "restart hindsight-api" in body["note"]
+
+    new_key = keys_from_api_env().get("HAL0_CLIENT_KEY")
+    content = env_file.read_text()
+    assert new_key and f"HINDSIGHT_API_LLM_API_KEY={new_key}" in content
+    assert "old-client-key" not in content
+
+
+def test_rotate_skips_hindsight_llm_env_when_absent(
+    rotate_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HAL0_CLIENT_KEY", "old-client-key")
+    resp = rotate_client.post("/api/auth/rotate", json={"tier": "client"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["hindsight_llm_env_refreshed"] is False
+    assert "restart hindsight-api" not in body["note"]

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -496,11 +496,16 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "check_hermes_mcp_config_auth",
         lambda **_kw: Check("hermes_mcp_auth", "Hermes MCP config auth", "pass", "stubbed"),
     )
+    monkeypatch.setattr(
+        da,
+        "check_hindsight_llm_auth",
+        lambda **_kw: Check("hindsight_llm_auth", "Memory engine LLM auth", "pass", "stubbed"),
+    )
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 10 extras.
-    assert keys[-10:] == [
+    # 7 verify rows + 11 extras.
+    assert keys[-11:] == [
         "auth",
         "models",
         "migrations",
@@ -511,9 +516,66 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "seams",
         "mcp_mounts",
         "hermes_mcp_auth",
+        "hindsight_llm_auth",
     ]
     assert "api" in keys and "runners" in keys
     assert da.overall_verdict(checks) == "ok"
+
+
+# ── hindsight LLM auth (engine-side silent-401 guard) ────────────────────────
+
+
+def test_hindsight_llm_auth_passes_when_engine_not_installed(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    check = da.check_hindsight_llm_auth(
+        auth={"auth_required": True},
+        unit_path=tmp_path / "missing.service",
+        env_path=tmp_path / "hindsight-llm.env",
+    )
+    assert check.status == "pass"
+
+
+def test_hindsight_llm_auth_passes_when_auth_off(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    unit = tmp_path / "hindsight-api.service"
+    unit.write_text("[Service]\n")
+    check = da.check_hindsight_llm_auth(
+        auth={"auth_required": False}, unit_path=unit, env_path=tmp_path / "hindsight-llm.env"
+    )
+    assert check.status == "pass"
+
+
+def test_hindsight_llm_auth_fails_on_missing_or_placeholder_key(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    unit = tmp_path / "hindsight-api.service"
+    unit.write_text("[Service]\n")
+    env = tmp_path / "hindsight-llm.env"
+    # Missing file.
+    check = da.check_hindsight_llm_auth(auth={"auth_required": True}, unit_path=unit, env_path=env)
+    assert check.status == "fail"
+    assert "restart hindsight-api" in check.detail
+    # Placeholder value.
+    env.write_text("HINDSIGHT_API_LLM_API_KEY=hal0-local-noauth\n")
+    check = da.check_hindsight_llm_auth(auth={"auth_required": True}, unit_path=unit, env_path=env)
+    assert check.status == "fail"
+
+
+def test_hindsight_llm_auth_passes_on_current_key_fails_on_stale(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:  # type: ignore[no-untyped-def]
+    unit = tmp_path / "hindsight-api.service"
+    unit.write_text("[Service]\n")
+    env = tmp_path / "hindsight-llm.env"
+    env.write_text("HINDSIGHT_API_LLM_API_KEY=live-key-123\n")
+    monkeypatch.setattr(
+        "hal0.service_identity.keys_from_api_env", lambda: {"HAL0_CLIENT_KEY": "live-key-123"}
+    )
+    check = da.check_hindsight_llm_auth(auth={"auth_required": True}, unit_path=unit, env_path=env)
+    assert check.status == "pass"
+
+    monkeypatch.setattr(
+        "hal0.service_identity.keys_from_api_env", lambda: {"HAL0_CLIENT_KEY": "rotated-away"}
+    )
+    check = da.check_hindsight_llm_auth(auth={"auth_required": True}, unit_path=unit, env_path=env)
+    assert check.status == "fail"
+    assert "stale" in check.detail
 
 
 # ── command ───────────────────────────────────────────────────────────────────

--- a/tests/memory/test_hindsight_client.py
+++ b/tests/memory/test_hindsight_client.py
@@ -252,6 +252,27 @@ async def test_reflect_posts_to_reflect_endpoint():
     assert out == {"text": "an answer"}
 
 
+@pytest.mark.asyncio
+async def test_reflect_carries_long_read_timeout():
+    """Reflect is an engine-side agentic LLM loop that legitimately runs for
+    minutes; the client-wide 120s read budget must not apply to it."""
+    from hal0.memory.hindsight_client import REFLECT_TIMEOUT_S
+
+    seen: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(200, json={"text": "ok"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="http://127.0.0.1:9177") as http:
+        client = HindsightRestClient(http_client=http, api_key="hal0-local-noauth")
+        await client.reflect(bank_id="shared", query="q")
+
+    assert seen["timeout"]["read"] == REFLECT_TIMEOUT_S
+    assert REFLECT_TIMEOUT_S >= 600
+
+
 # ── single-memory curation ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Two fixes that raced past #1612's automerge (the branch auto-deleted and the late push re-created it unmerged — caught during live verification on CT105):

- **Engine LLM credential**: with KB-1 auth on, hindsight-api's extraction/reflect calls into `/v1` carried the shipped `hal0-local-noauth` placeholder and 401ed — every retain failed extraction silently (208 failed operations on the reference box). The unit now reads `/etc/hal0/hindsight-llm.env` (EnvironmentFile override), install.sh renders it when a box key exists, `hal0 auth rotate` re-syncs it (response notes the needed engine restart), and a new `hal0 doctor all` row (`hindsight_llm_auth`) fails on a missing/placeholder/stale key. install.sh also moves the hindsight-api pin 0.7.2 → 0.8.4, the version the #1612 memory MCP surface targets.
- **Reflect client timeout**: reflect is an engine-side agentic LLM loop (5-9 min legitimate on the reference box); the client's blanket 120s read budget and hermes' 30s server timeout guaranteed spurious client-side failure while the engine finished anyway. The client now sends a reflect-specific read timeout (`HAL0_MEMORY_REFLECT_TIMEOUT_S`, default 900s) and hermes provisioning renders the memory server timeout to match.

Verified live on CT105 (reflect completed end-to-end after the fixes; doctor row exercised both FAIL and PASS paths). Refs #1543, #1613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)