### PR TITLE
fix(memory): colon bank ids + self-healing boot fallback + seam-routed repair restarts

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1150,8 +1150,12 @@ cat > "${API_UNIT}" <<EOF
 [Unit]
 Description=hal0 API daemon
 Documentation=https://github.com/hal0ai/hal0
-After=network-online.target
-Wants=network-online.target
+# hindsight-api ordering (#1613): a cold engine start outlasts hal0-api's
+# boot probe, degrading memory to the pgvector fallback. After= narrows the
+# boot-time window (the runtime self-heal re-probe covers the rest); both
+# directives are no-ops on a box without the engine unit.
+After=network-online.target hindsight-api.service
+Wants=network-online.target hindsight-api.service
 
 [Service]
 Type=simple

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -965,6 +965,8 @@ class BootState:
     refresh_task: asyncio.Task[None] | None = None
     stop_refresh_task: Any = None
     stop_gpu_arbiter_idle_loop: Any = None
+    memory_reprobe_task: asyncio.Task[None] | None = None
+    stop_memory_reprobe_task: Any = None
     omni_router_client: httpx.AsyncClient | None = None
     boot_report: BootReport = field(default_factory=BootReport)
 
@@ -1611,6 +1613,35 @@ async def _boot_background_tasks(app: FastAPI, ctx: BootState) -> None:
 
     ctx.stop_gpu_arbiter_idle_loop = _stop_gpu_arbiter_idle_loop
 
+    # Memory provider self-heal loop (#1613). Armed only when create_app
+    # wrapped a boot-degraded provider in SelfHealingMemoryProvider; polls
+    # until the hindsight engine answers a probe, then the shell swaps its
+    # delegate in place and the loop exits. The probe is sync + bounded
+    # (HAL0_HINDSIGHT_PROBE_TIMEOUT_S), run off-loop via to_thread.
+    ctx.memory_reprobe_task = None
+    _mem_provider = getattr(app.state, "memory_provider", None)
+    if hasattr(_mem_provider, "try_heal"):
+        _reprobe_interval = float(
+            os.environ.get("HAL0_MEMORY_REPROBE_INTERVAL_S", "30") or "30"
+        )
+
+        async def _memory_reprobe_loop(provider: Any = _mem_provider) -> None:
+            while True:
+                await asyncio.sleep(_reprobe_interval)
+                if await asyncio.to_thread(provider.try_heal):
+                    return
+
+        ctx.memory_reprobe_task = asyncio.create_task(_memory_reprobe_loop())
+        log.info("hal0.memory.reprobe_loop_started", interval_s=_reprobe_interval)
+
+    async def _stop_memory_reprobe_task() -> None:
+        if ctx.memory_reprobe_task is not None:
+            ctx.memory_reprobe_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ctx.memory_reprobe_task
+
+    ctx.stop_memory_reprobe_task = _stop_memory_reprobe_task
+
     # OmniRouter (PR-16). Client-side OpenAI
     # tool-calling loop. Wired here so the /v1/chat/completions route
     # can pick it up via ``request.app.state.omni_router`` when a
@@ -1901,6 +1932,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 await stack.enter_async_context(mgr.run())
             stack.push_async_callback(ctx.stop_refresh_task)
             stack.push_async_callback(ctx.stop_gpu_arbiter_idle_loop)
+            stack.push_async_callback(ctx.stop_memory_reprobe_task)
             ctx.metrics_service.start()
             stack.push_async_callback(ctx.metrics_service.stop)
             yield
@@ -2320,9 +2352,25 @@ def create_app() -> FastAPI:
         log.info("hal0.memory.disabled", reason="memory.enabled=false")
     else:
         try:
-            from hal0.memory import provider_from_config
+            from hal0.memory import SelfHealingMemoryProvider, provider_from_config
 
             memory_provider = provider_from_config(create_app_cfg)
+            # #1613: a degraded boot result (hindsight lost the boot race,
+            # pgvector fallback) used to be permanent because every consumer
+            # below captures this object. Wrap ONLY the degraded case in the
+            # self-healing shell; the lifespan polls try_heal() until the
+            # durable engine answers. Deliberate pgvector config is not a
+            # degradation — no shell, no re-probe loop.
+            engine_cfg = str(
+                getattr(create_app_cfg.memory, "engine", "hindsight") or "hindsight"
+            ).lower()
+            if engine_cfg != "pgvector" and getattr(memory_provider, "degraded", False):
+                memory_provider = SelfHealingMemoryProvider(memory_provider, create_app_cfg)
+                log.warning(
+                    "hal0.memory.boot_degraded",
+                    detail="hindsight unreachable at boot — pgvector fallback active, "
+                    "self-heal re-probe armed",
+                )
         except Exception as exc:  # pragma: no cover — defensive
             log.warning("hal0.memory.init_failed", error=str(exc))
     app.state.memory_provider = memory_provider

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1621,9 +1621,7 @@ async def _boot_background_tasks(app: FastAPI, ctx: BootState) -> None:
     ctx.memory_reprobe_task = None
     _mem_provider = getattr(app.state, "memory_provider", None)
     if hasattr(_mem_provider, "try_heal"):
-        _reprobe_interval = float(
-            os.environ.get("HAL0_MEMORY_REPROBE_INTERVAL_S", "30") or "30"
-        )
+        _reprobe_interval = float(os.environ.get("HAL0_MEMORY_REPROBE_INTERVAL_S", "30") or "30")
 
         async def _memory_reprobe_loop(provider: Any = _mem_provider) -> None:
             while True:

--- a/src/hal0/api/routes/installer.py
+++ b/src/hal0/api/routes/installer.py
@@ -556,13 +556,22 @@ _REPAIRABLE_UNITS = {
     "hal0-slot@img.service",
 }
 _COMFYUI_SLOT_UNIT = "hal0-slot@img.service"
-_SYSTEMCTL = "/usr/bin/systemctl"
 
 
-def _privileged_systemctl_argv(*args: str) -> list[str]:
-    # hal0-api runs as root, so systemctl is invoked directly. The former
-    # euid != 0 `sudo -n` fallback was part of the removed hardened-perms seam.
-    return [_SYSTEMCTL, *args]
+def _seam_restart(unit: str) -> subprocess.CompletedProcess[str]:
+    """Restart a unit through the hal0-systemctl seam.
+
+    hal0-api runs as ``User=hal0`` (P3-perms), so a bare ``systemctl restart``
+    dies on polkit's "Interactive authentication required" — which the
+    dashboard surfaces as a permission-denied toast on every repair/restart
+    button. :meth:`SystemCtlSeam.systemctl` routes hal0-managed units
+    (``hal0-slot@*``, ``hal0-agent@*``, and the companion map that covers
+    hindsight + openwebui) through the sudo wrapper, and still passes straight
+    through for root/dev/CI where the wrapper isn't needed.
+    """
+    from hal0.system.seam import SystemCtlSeam
+
+    return SystemCtlSeam().systemctl("systemctl", "restart", unit, timeout=60)
 
 
 def _unit_active(unit: str) -> bool:
@@ -652,11 +661,7 @@ async def service_repair(unit: str) -> dict[str, Any]:
     # Special case: public service id maps to the slot unit that owns :8188.
     if unit == "comfyui":
         try:
-            subprocess.run(
-                _privileged_systemctl_argv("restart", _COMFYUI_SLOT_UNIT),
-                check=True,
-                timeout=60,
-            )
+            await asyncio.to_thread(_seam_restart, _COMFYUI_SLOT_UNIT)
         except (OSError, subprocess.SubprocessError) as exc:
             raise PickDefaultError(
                 f"comfyui restart failed: {exc}", details={"unit": unit}
@@ -675,22 +680,20 @@ async def service_repair(unit: str) -> dict[str, Any]:
         # subprocess call holds the event loop, so neither the restart nor
         # the HTTP response can complete until a timeout kills one of them.
         # Mirror the updater's pattern instead (updater._try_restart_hal0_api):
-        # flush the response first, then fail-soft try-restart off-loop.
+        # flush the response first, then fail-soft restart off-loop via the
+        # seam's ``restart-self`` arm (queued with --no-block, #1540).
         # Callers should poll /api/health for recovery.
         async def _bounce_self() -> None:
             await asyncio.sleep(0.5)  # let the response flush
             with contextlib.suppress(OSError, subprocess.SubprocessError):
-                await asyncio.to_thread(
-                    subprocess.run,
-                    ["systemctl", "try-restart", unit],
-                    check=False,
-                    timeout=60,
-                )
+                from hal0.system.seam import SystemCtlSeam
+
+                await asyncio.to_thread(SystemCtlSeam().restart_self)
 
         asyncio.get_running_loop().create_task(_bounce_self())
         return {"unit": unit, "active": True, "deferred": True}
     try:
-        subprocess.run(["systemctl", "restart", unit], check=True, timeout=30)
+        await asyncio.to_thread(_seam_restart, unit)
     except (OSError, subprocess.SubprocessError) as exc:
         raise PickDefaultError(f"restart failed: {exc}", details={"unit": unit}) from exc
     return {"unit": unit, "active": _unit_active(unit)}

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -44,9 +44,13 @@ router = APIRouter()
 
 log = logging.getLogger(__name__)
 
-#: Bank ids come from namespace_to_bank() (``private__<agent>``) or operator
-#: input — kebab/snake alphanumerics only, no dots (blocks path tricks).
-_BANK_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$")
+#: Bank ids come from namespace_to_bank() (``private__<agent>``), operator
+#: input, or foreign agents writing to the shared engine directly — e.g. the
+#: hindsight plugin's ``dynamicBankId`` mints ``claude::<project>`` and other
+#: stacks use ``global:hal0`` / ``private:claude``. Colons are legal in a URL
+#: path segment and carry no traversal risk, so they are allowed (after the
+#: first char); dots stay blocked (path tricks).
+_BANK_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_:-]{0,127}$")
 
 #: Sub-resource ids (documents, operations, entities, …) — UUIDs and slugs;
 #: dots allowed but never as a whole traversal segment.

--- a/src/hal0/health_report.py
+++ b/src/hal0/health_report.py
@@ -157,6 +157,20 @@ def check_memory(memory: dict[str, Any] | None) -> Check:
     if memory is None:
         return Check("memory", "Hindsight / banks", _WARN, "memory admin unreachable")
     if not isinstance(memory, dict) or memory.get("engine") is None:
+        # engine=None covers two very different states (#1543/#1613): memory
+        # deliberately disabled (enabled=False → an honest PASS) vs. memory
+        # ENABLED but running on the degraded in-memory fallback because
+        # hindsight lost the boot race. The latter used to render as
+        # "✔ PASS  disabled (no memory engine)" while hindsight-api was
+        # active — the checkmark operators read as "done".
+        if isinstance(memory, dict) and memory.get("enabled"):
+            return Check(
+                "memory",
+                "Hindsight / banks",
+                _WARN,
+                "memory enabled but engine degraded (pgvector fallback) — "
+                "waits for the self-heal re-probe, or restart hal0-api",
+            )
         return Check("memory", "Hindsight / banks", _PASS, "disabled (no memory engine)")
     if not memory.get("reachable"):
         return Check("memory", "Hindsight / banks", _WARN, "engine enabled but :9177 unreachable")

--- a/src/hal0/memory/__init__.py
+++ b/src/hal0/memory/__init__.py
@@ -37,9 +37,66 @@ __all__ = [
     "MemoryRecord",
     "Mode",
     "PgVectorProvider",
+    "SelfHealingMemoryProvider",
     "_build_hindsight_client",
     "provider_from_config",
 ]
+
+
+class SelfHealingMemoryProvider:
+    """Delegating shell around a boot-degraded memory provider (#1613).
+
+    ``provider_from_config`` hands back the in-memory ``PgVectorProvider``
+    when the Hindsight daemon loses the boot race (a cold engine start —
+    embedded postgres init + model load — outlasts the 2s boot probe).
+    Every consumer captures the provider object at ``create_app`` time: the
+    REST routes read it off ``app.state``, but both MCP mounts and the
+    in-process dispatcher close over it. That made the fallback PERMANENT
+    until an operator restarted hal0-api — which is also the default end
+    state of a fresh install (#1543), because the installer starts both
+    units in the same pass.
+
+    ``create_app`` wraps a *degraded* boot result in this shell (a healthy
+    boot keeps today's exact object graph — no shell), and the lifespan
+    polls :meth:`try_heal` until the durable engine answers. The swap is a
+    single attribute rebind, so every captured reference — closures
+    included — recovers at once.
+    """
+
+    def __init__(self, provider: MemoryProvider, cfg: Any) -> None:
+        self._target = provider
+        self._cfg = cfg
+
+    @property
+    def target(self) -> Any:
+        """The current delegate (tests introspect which side is live)."""
+        return self._target
+
+    def try_heal(self) -> bool:
+        """One re-probe attempt; True once the durable engine is live.
+
+        Runs the same construction path as boot (probe included, so it is
+        bounded by ``HAL0_HINDSIGHT_PROBE_TIMEOUT_S``). Call off-loop —
+        the probe is synchronous I/O.
+        """
+        if not getattr(self._target, "degraded", False):
+            return True
+        try:
+            candidate = provider_from_config(self._cfg)
+        except Exception as exc:  # pragma: no cover — defensive
+            log.debug("hal0.memory.reprobe_failed", error=str(exc))
+            return False
+        if getattr(candidate, "degraded", False):
+            return False
+        self._target = candidate
+        log.warning(
+            "hal0.memory.provider_healed",
+            detail="hindsight engine recovered — swapped out the degraded pgvector fallback",
+        )
+        return True
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(object.__getattribute__(self, "_target"), name)
 
 
 def _build_hindsight_client(cfg: Any) -> Any:

--- a/tests/api/test_install_services.py
+++ b/tests/api/test_install_services.py
@@ -23,24 +23,12 @@ def test_repair_unknown_unit_400(isolated_client):
 def test_repair_known_unit_restarts(isolated_client, monkeypatch):
     import hal0.api.routes.installer as inst
 
-    # Record EVERY call: monkeypatching inst.subprocess.run patches the
-    # shared subprocess module process-wide, and in-app background samplers
-    # (GPU probe: nvidia-smi --query-gpu=name) can fire during the request
-    # window — a last-call-only record races (CI flake on a18b9b05).
-    calls = []
-
-    def _fake_run(cmd, **kw):
-        calls.append(list(cmd))
-
-        class _R:
-            returncode = 0
-            stdout = "active"
-
-        return _R()
-
-    monkeypatch.setattr(inst.subprocess, "run", _fake_run)
+    # Repairs route through the hal0-systemctl seam (P3-perms: hal0-api runs
+    # as User=hal0, a bare systemctl dies on polkit) — assert at that boundary.
+    restarted = []
+    monkeypatch.setattr(inst, "_seam_restart", lambda unit: restarted.append(unit))
     monkeypatch.setattr(inst, "_unit_active", lambda u: True)
     r = isolated_client.post("/api/install/services/hal0-openwebui.service/repair")
     assert r.status_code == 200, r.text
     assert r.json()["active"] is True
-    assert any(c[:2] == ["systemctl", "restart"] for c in calls), calls
+    assert restarted == ["hal0-openwebui.service"]

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -114,6 +114,26 @@ def test_bank_id_with_invalid_chars_400(client: TestClient) -> None:
     assert r.json()["error"]["code"] == "memory.invalid_bank"
 
 
+def test_colon_namespaced_bank_id_forwards(client: TestClient, recorder: _Recorder) -> None:
+    """Foreign agents mint colon-namespaced banks (``claude::mint``,
+    ``global:hal0``) directly on the shared engine; the admin surface must
+    browse them instead of 400ing (the "stats unavailable" bug)."""
+    for bank in ("claude::mint", "global:hal0", "private:claude"):
+        recorder.respond(
+            "GET", f"/v1/default/banks/{bank}/stats", 200, {"bank_id": bank, "total_nodes": 1}
+        )
+        r = client.get(f"/api/memory/banks/{bank}/stats")
+        assert r.status_code == 200, (bank, r.json())
+        assert r.json()["bank_id"] == bank
+        assert recorder.requests[-1]["path"] == f"/v1/default/banks/{bank}/stats"
+
+
+def test_leading_colon_bank_id_still_400(client: TestClient) -> None:
+    r = client.get("/api/memory/banks/:sneaky/stats")
+    assert r.status_code == 400
+    assert r.json()["error"]["code"] == "memory.invalid_bank"
+
+
 # ── forwarding: reads ──────────────────────────────────────────────────────────
 
 

--- a/tests/api/test_services_comfyui.py
+++ b/tests/api/test_services_comfyui.py
@@ -25,46 +25,23 @@ def test_comfyui_repair_restarts_img_slot_unit(isolated_client, monkeypatch):
     import hal0.api.routes.installer as inst
 
     calls = []
-
-    def _fake_run(cmd, **kw):
-        calls.append(list(cmd))
-
-        class _R:
-            returncode = 0
-            stdout = ""
-
-        return _R()
-
-    monkeypatch.setattr(inst.subprocess, "run", _fake_run)
+    monkeypatch.setattr(inst, "_seam_restart", lambda unit: calls.append(unit))
     monkeypatch.setattr(inst.os, "geteuid", lambda: 0)
     monkeypatch.setattr(inst, "_unit_active", lambda u: False)
     monkeypatch.setattr(inst, "_container_active", lambda: True)
 
     r = isolated_client.post("/api/install/services/comfyui/repair")
     assert r.status_code == 200, r.text
-    assert calls, "repair made no subprocess calls"
-    # The background GPU sampler thread also routes through the module-level
-    # subprocess.run this test monkeypatches, so assert the restart is AMONG
-    # the calls rather than positionally first (position is race-dependent).
-    assert [inst._SYSTEMCTL, "restart", inst._COMFYUI_SLOT_UNIT] in calls
+    # comfyui maps to the seeded img slot unit, restarted through the seam
+    # (P3-perms: bare systemctl under User=hal0 dies on polkit).
+    assert calls == [inst._COMFYUI_SLOT_UNIT]
 
 
 def test_comfyui_repair_not_blocked_by_unknown_unit_check(isolated_client, monkeypatch):
     """Ensure comfyui repair returns 200, not 400 'unit not repairable'."""
     import hal0.api.routes.installer as inst
 
-    calls = []
-
-    def _fake_run(cmd, **kw):
-        calls.append(list(cmd))
-
-        class _R:
-            returncode = 0
-            stdout = ""
-
-        return _R()
-
-    monkeypatch.setattr(inst.subprocess, "run", _fake_run)
+    monkeypatch.setattr(inst, "_seam_restart", lambda unit: None)
     monkeypatch.setattr(inst.os, "geteuid", lambda: 0)
     monkeypatch.setattr(inst, "_unit_active", lambda u: False)
     monkeypatch.setattr(inst, "_container_active", lambda: True)

--- a/tests/cli/test_doctor_verify.py
+++ b/tests/cli/test_doctor_verify.py
@@ -86,6 +86,16 @@ def test_check_memory_states() -> None:
     assert ok.status == "pass" and "3 bank" in ok.detail
 
 
+def test_check_memory_enabled_but_degraded_is_not_a_pass() -> None:
+    """#1543: memory ENABLED with no engine client = the pgvector fallback
+    after a lost boot race — must not render as a green 'disabled' PASS."""
+    degraded = dv.check_memory({"enabled": True, "engine": None})
+    assert degraded.status == "warn"
+    assert "degraded" in degraded.detail
+    # deliberate disabled config stays an honest pass
+    assert dv.check_memory({"enabled": False, "engine": None}).status == "pass"
+
+
 def test_service_checks_up_and_down() -> None:
     services = {
         "services": [

--- a/tests/memory/test_degrade_live.py
+++ b/tests/memory/test_degrade_live.py
@@ -218,3 +218,73 @@ def test_boot_ladder_engages_against_a_real_closed_port(
 
     assert isinstance(provider, PgVectorProvider)
     assert provider.degraded is True
+
+
+# ── #1613: the boot-degraded fallback must self-heal, closures included ──────
+
+
+class _FakeDegraded:
+    degraded = True
+
+    def marker(self) -> str:
+        return "degraded"
+
+
+class _FakeHealthy:
+    degraded = False
+
+    def marker(self) -> str:
+        return "healthy"
+
+
+def test_self_heal_swaps_delegate_for_every_captured_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hal0.memory as mem
+
+    shell = mem.SelfHealingMemoryProvider(_FakeDegraded(), _cfg("hindsight"))
+
+    # A consumer closing over the provider at create_app time — the shape of
+    # both MCP mounts and the in-process dispatcher. Must heal WITHOUT rebind.
+    captured = (lambda p: (lambda: p.marker()))(shell)
+
+    # Engine still down: heal fails, delegate unchanged.
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeDegraded())
+    assert shell.try_heal() is False
+    assert captured() == "degraded"
+
+    # Engine back: one probe swaps the delegate; the closure sees it too.
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+    assert shell.try_heal() is True
+    assert shell.degraded is False
+    assert captured() == "healthy"
+    assert isinstance(shell.target, _FakeHealthy)
+
+
+def test_self_heal_is_a_noop_once_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.memory as mem
+
+    shell = mem.SelfHealingMemoryProvider(_FakeHealthy(), _cfg("hindsight"))
+
+    def _boom(cfg: object) -> None:
+        raise AssertionError("re-probe must not run for a healthy delegate")
+
+    monkeypatch.setattr(mem, "provider_from_config", _boom)
+    assert shell.try_heal() is True
+
+
+def test_boot_degraded_result_wraps_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real ladder against a closed port, then heal via a patched factory —
+    proves the shell composes with the actual provider_from_config output."""
+    import hal0.memory as mem
+
+    monkeypatch.setenv("HAL0_HINDSIGHT_URL", _closed_port_url())
+    provider = provider_from_config(_cfg("hindsight"))
+    assert provider.degraded is True
+
+    shell = mem.SelfHealingMemoryProvider(provider, _cfg("hindsight"))
+    assert shell.degraded is True  # delegation before heal
+
+    monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeHealthy())
+    assert shell.try_heal() is True
+    assert shell.degraded is False

--- a/tests/memory/test_degrade_live.py
+++ b/tests/memory/test_degrade_live.py
@@ -246,7 +246,7 @@ def test_self_heal_swaps_delegate_for_every_captured_reference(
 
     # A consumer closing over the provider at create_app time — the shape of
     # both MCP mounts and the in-process dispatcher. Must heal WITHOUT rebind.
-    captured = (lambda p: (lambda: p.marker()))(shell)
+    captured = (lambda p: lambda: p.marker())(shell)
 
     # Engine still down: heal fails, delegate unchanged.
     monkeypatch.setattr(mem, "provider_from_config", lambda cfg: _FakeDegraded())


### PR DESCRIPTION
## What changed

Three fixes found while debugging the CT105 memory-bank outage today:

1. **Colon-namespaced bank ids** (`claude::mint`, `global:hal0`, `private:claude`, …) were rejected by `_BANK_RE` on the memory admin surface, so every such bank showed *stats unavailable* in the dashboard while the engine served them fine. Colons are now allowed (never leading); dots stay blocked.

2. **#1613 / #1543 — the boot-race pgvector fallback is now self-healing.** A cold hindsight start outlasts the 2s boot probe, and the degraded provider was captured by closures (MCP mounts, dispatcher) at `create_app` time, making the fallback permanent until a manual restart — also the default end state of a fresh install. A degraded boot result is now wrapped in `SelfHealingMemoryProvider`; a lifespan task re-probes and swaps the delegate in place. Doctor renders the degraded state as WARN instead of `✔ PASS disabled (no memory engine)`, and the installer orders `hal0-api` after `hindsight-api`. Closes #1613.

3. **Settings-page 'Restart hal0-api' / repair buttons died on polkit** ("permission denied") — the repair endpoint still ran bare `systemctl` from the pre-P3-perms root era. Restarts now route through the `hal0-systemctl` sudo seam (`restart-self` for hal0-api, slot/agent/companion arms for the rest).

## Verification

- `tests/api` + `tests/memory` full run: **1835 passed, 1 skipped** (environmental journalctl skip)
- New regression tests: colon-bank passthrough, leading-colon rejection, self-heal swap (incl. closure capture), doctor WARN on enabled-but-degraded, seam-boundary repair assertions
- Live on CT105: engine serves colon banks (raw + percent-encoded); degraded-provider state reproduced and recovered

## Out of scope / follow-ups

- Doctor row asserting the ACTIVE provider matches `[memory].engine` (suggested in #1613) — the WARN added here covers the observed failure class
- CT105 thermal instability (Proxmox host thermal trips) — separate host-level issue, tracked outside this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)