### PR TITLE
ci(installer): mirror bootstrap.sh to the served install.sh

### DIFF
--- a/.github/workflows/mirror-bootstrap.yml
+++ b/.github/workflows/mirror-bootstrap.yml
@@ -1,0 +1,108 @@
+# Mirror hal0:installer/bootstrap.sh → Hal0ai/hal0-web:public/install.sh, the
+# file served at https://hal0.dev/install.sh. bootstrap.sh is the canonical
+# copy; its own header asks the author to "sync the other in the same PR", and
+# that hand-sync has drifted before (the served copy sat 5 hardening commits
+# behind, with warn-only cosign and a different manifest URL). This closes it.
+#
+# Setup: reuses `HALO_WEB_MIRROR_TOKEN` (see mirror-docs.yml).
+#
+# Publish gate — why this does not just push on every main commit:
+#   The canonical bootstrap is fail-closed. It authenticates the channel
+#   manifest against a sibling Sigstore bundle (`<channel>.json.bundle`) before
+#   parsing it. Releases at or after v1.0.0-rc.1 publish that bundle; v0.9.8 —
+#   the manifest `stable` still points at — does not. Publishing the canonical
+#   script while `stable` lacks a bundle would break every one-line install.
+#
+#   So the job refuses to publish until the live stable manifest has its
+#   sibling bundle. The gate opens by itself the moment a signed stable release
+#   (v1.0.0) is published, and `release: published` re-runs it at that instant.
+#   Override with the `force` input only if you know the gate is stale.
+
+name: mirror-bootstrap
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "installer/bootstrap.sh"
+      - ".github/workflows/mirror-bootstrap.yml"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Publish even if the stable manifest has no sibling Sigstore bundle"
+        type: boolean
+        default: false
+
+concurrency:
+  group: mirror-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout hal0 (source)
+        uses: actions/checkout@v4
+        with:
+          path: hal0
+
+      - name: Gate on a signed stable manifest
+        id: gate
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          bundle_url="https://releases.hal0.dev/stable.json.bundle"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' -L --retry 3 --retry-delay 2 "${bundle_url}" || echo 000)"
+
+          if [ "${code}" = "200" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "Stable manifest is signed (${bundle_url} → 200). Publishing."
+            exit 0
+          fi
+
+          if [ "${FORCE}" = "true" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::${bundle_url} → ${code}, but force=true. Publishing anyway."
+            exit 0
+          fi
+
+          echo "publish=false" >> "$GITHUB_OUTPUT"
+          printf '::warning::%s\n' "${bundle_url} -> ${code}. The stable channel is not signed yet, so publishing the canonical fail-closed bootstrap would break the one-line install. Skipping. This gate opens by itself once a signed stable release is published."
+
+      - name: Checkout Hal0ai/hal0-web (target)
+        if: steps.gate.outputs.publish == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: Hal0ai/hal0-web
+          token: ${{ secrets.HALO_WEB_MIRROR_TOKEN }}
+          path: hal0-web
+
+      - name: Sync bootstrap.sh → public/install.sh
+        if: steps.gate.outputs.publish == 'true'
+        run: |
+          install -m 0644 hal0/installer/bootstrap.sh hal0-web/public/install.sh
+          # A syntax error here is served to every new user's shell.
+          bash -n hal0-web/public/install.sh
+
+      - name: Commit + push
+        if: steps.gate.outputs.publish == 'true'
+        working-directory: hal0-web
+        run: |
+          git config user.name  "hal0-docs-mirror[bot]"
+          git config user.email "hal0-docs-mirror@users.noreply.github.com"
+
+          if [ -z "$(git status --porcelain public/install.sh)" ]; then
+            echo "public/install.sh already matches bootstrap.sh. Nothing to push."
+            exit 0
+          fi
+
+          source_sha="${{ github.sha }}"
+          git add public/install.sh
+          git commit -m "chore: mirror install.sh from hal0@${source_sha:0:7}
+
+          Auto-synced from Hal0ai/hal0:installer/bootstrap.sh at ${source_sha}.
+          See .github/workflows/mirror-bootstrap.yml in hal0."
+
+          git push origin HEAD:master

--- a/installer/bootstrap.sh
+++ b/installer/bootstrap.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 #
 # ⚠️  This file is MIRRORED between two locations and must stay identical:
-#       - Hal0ai/hal0:installer/bootstrap.sh   (canonical)
+#       - Hal0ai/hal0:installer/bootstrap.sh   (canonical — edit here)
 #       - Hal0ai/hal0-web:public/install.sh    (served at https://hal0.dev/install.sh)
-#     When you edit one, sync the other in the same PR.
+#     .github/workflows/mirror-bootstrap.yml publishes this file to the web copy
+#     on every main push, gated on the stable channel manifest being signed.
+#     Never hand-edit the web copy; it is overwritten.
 #
 # hal0 one-line installer — fetch, verify, unpack, hand off to install.sh.
 #


### PR DESCRIPTION
## Problem

`installer/bootstrap.sh` and `hal0-web:public/install.sh` (served at `https://hal0.dev/install.sh`) must stay byte-identical — the file header says so. The hand-sync drifted: the **served copy is behind canonical by ~5 hardening commits** (513-line diff).

Concretely, what the public one-liner runs today vs. what hal0 ships:

| | served (`hal0.dev/install.sh`) | canonical (`installer/bootstrap.sh`) |
|---|---|---|
| cosign | optional, warn-only unless `HAL0_INSTALL_REQUIRE_COSIGN=1` | required; digest-pinned build fetched when the host has none (#1363, #1384) |
| manifest source | `github.com/.../releases/latest/download/<channel>.json` | `https://releases.hal0.dev/<channel>.json` |
| manifest authentication | — | Sigstore bundle + client-pinned release-workflow identity, verified *before* the JSON is parsed |

For a public v1.0 launch, launch-day installs would run the weaker trust boundary.

## Why this can't just push today

Canonical is fail-closed: it authenticates `<channel>.json` against a sibling `<channel>.json.bundle`. Current state:

- `releases.hal0.dev/stable.json` → **200** (v0.9.8)
- `releases.hal0.dev/stable.json.bundle` → **404** (v0.9.8 predates manifest signing)
- `v1.0.0-rc.1` assets → `preview.json` + `preview.json.bundle` ✅
- nightly assets → `nightly.json` + `nightly.json.bundle` ✅

Publishing canonical while `stable` has no bundle would break **every** one-line install.

## What this does

New `mirror-bootstrap.yml` publishes canonical → the web copy on main pushes touching `bootstrap.sh`, plus `release: published` and manual dispatch, **gated** on `stable.json.bundle` returning 200. The gate is closed right now on purpose and opens by itself the moment a signed v1.0.0 stable is published — the `release: published` trigger runs it at that instant, so the served script flips in the same window as the release. `bash -n` runs on the result before it is pushed (a syntax error here goes straight into new users' shells). Header comment updated: canonical is the edit point, the web copy is generated.

Reuses `HALO_WEB_MIRROR_TOKEN` from #1622 — **blocked until that secret exists.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)