### PR TITLE
fix(brain): send brain rounds tools-less — llama.cpp peg-format 500

### DIFF
--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1229,12 +1229,14 @@ def _unrouteable_model_error(tried_model: str) -> str:
 # use of `run_tool_loop` is therefore untouched by construction.
 
 #: The remnant llama.cpp's jinja tool parser leaves in `content` when it eats a
-#: `<function name="X">` opener it then fails to parse: `name="X"`.
-_ARTEFACT_NAME_RE = re.compile(r"""name\s*=\s*["']?\s*([A-Za-z0-9_.\-]+)""")
+#: `<function name="X">` opener it then fails to parse: `name="X"`. `/` is in
+#: the name class because the brain reaches for slash-qualified names too —
+#: measured live: ` name="hal0/slot_list">` (virtual-model spelling).
+_ARTEFACT_NAME_RE = re.compile(r"""name\s*=\s*["']?\s*([A-Za-z0-9_./\-]+)""")
 
 #: An unterminated `<function=X` opener — the terminated form is already handled
 #: by the shared text-call fallback (`parse_text_tool_calls`).
-_ARTEFACT_FN_RE = re.compile(r"<\s*function\s*=\s*([A-Za-z0-9_.\-]+)", re.IGNORECASE)
+_ARTEFACT_FN_RE = re.compile(r"<\s*function\s*=\s*([A-Za-z0-9_./\-]+)", re.IGNORECASE)
 
 #: Call-tag syntax of any shape. Reaching this module at all means neither
 #: extractor could make a call out of it, so a surviving `<function` /

--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1165,6 +1165,14 @@ def _unrouteable_model_error(tried_model: str) -> str:
 #     prompt: `content` came back EMPTY with `reasoning_content` ending
 #     "I'll call the slot_list() function to retrieve the information." — it
 #     stated intent and stopped. That is signal (b) below.
+#   * WITH `--jinja` + `--chat-template-file hal0-brain-sft.jinja` (the bundled
+#     template, post-#1434) + native `tools`: HTTP 500 "The model produced
+#     output that does not match the expected peg-native format" on EVERY
+#     tools-attached completion, tool-related prompt or not. llama.cpp builds
+#     a tool-format parser from the template and rejects the whole request
+#     when the output doesn't match. This is why `_routed` strips `tools`
+#     from the brain round below — no response ever arrives to run signal
+#     detection on otherwise.
 #
 # So the 1B genuinely cannot drive tools on this runtime. `[brain_chat]
 # tool_model` (default "hal0/agent") is the documented mitigation, and this is
@@ -1402,7 +1410,25 @@ def _tool_routing_llm(
             return await _degrade(await llm(body))
 
         body["model"] = chat_model
-        response = await llm(body)
+        # The brain round goes out WITHOUT native `tools`. The runtime builds
+        # a tool-format parser from the chat template and hard-fails the WHOLE
+        # completion when the model's output doesn't match it — measured on
+        # lxc105 (image c077206, bundled hal0-brain-sft.jinja): every
+        # tools-attached request, even "just say hello", returns HTTP 500
+        # "The model produced output that does not match the expected
+        # peg-native format". The 1B cannot match that format by design (the
+        # reason this reroute exists), so attaching `tools` buys nothing and
+        # costs the entire turn. Detection is unaffected: the text fallback
+        # and _tool_intent_artefact read the reply, not the request, and the
+        # steward knows its tool surface from the system prompt. Popped per
+        # round and restored — the engine owns `body` and the tool-model
+        # rounds need the schemas back.
+        native_tools = body.pop("tools", None)
+        try:
+            response = await llm(body)
+        finally:
+            if native_tools is not None:
+                body["tools"] = native_tools
         if not isinstance(response, dict) or response.get("error"):
             # A BRAIN-side failure keeps its documented contract exactly — the
             # loop core turns it into the error+done frames tests already pin.

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -356,6 +356,67 @@ def test_replayed_tool_history_does_not_pin_a_turn_to_the_tool_model() -> None:
     assert _tokens(events) == "Nothing else pending."
 
 
+# ── native `tools` never ride a brain round (the peg-format 500) ────────────
+#
+# Third measured failure shape (lxc105, image c077206, bundled
+# hal0-brain-sft.jinja via --chat-template-file): EVERY tools-attached
+# completion against the brain slot — even "just say hello" — fails with
+#
+#   HTTP 500 {"error":{"message":"The model produced output that does not
+#   match the expected peg-native format","type":"server_error"}}
+#
+# llama.cpp builds a tool-format parser from the chat template and hard-fails
+# the whole request when the model's output doesn't match it. The 1B cannot
+# match it by design (that is why the reroute exists), so attaching native
+# `tools` to a brain round buys nothing and now costs the entire turn.
+
+
+def test_brain_rounds_do_not_carry_native_tools() -> None:
+    """With the reroute armed, the brain round goes out WITHOUT `tools`.
+
+    The tool-capable rounds keep them — the 35B parses native calls fine.
+    """
+    stub = _StubLLM(
+        [
+            _leaked("", reasoning=STATED_INTENT),  # round 0, brain (tools-less)
+            _tool_call("list_slots", {}, "c1"),  # round 0 re-run, tool model
+            _final("Three slots."),  # round 1, tool model
+        ]
+    )
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    _run(_collect(request))
+
+    assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
+    assert "tools" not in stub.calls[0], "native tools rode the brain round"
+    assert stub.calls[1].get("tools"), "the tool-model re-run lost the tools"
+    assert stub.calls[2].get("tools"), "the continuation round lost the tools"
+
+
+def test_tools_are_restored_when_the_brain_round_answers_plain() -> None:
+    """Stripping is per-round, not destructive: the engine-owned body gets its
+    `tools` back after the brain answers, so a later turn or reroute path
+    always finds them in place."""
+    stub = _StubLLM([_final("Hey — what can I help with?")])
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
+
+    _run(_collect(request, {"messages": [{"role": "user", "content": "hi"}]}))
+
+    assert "tools" not in stub.calls[0]
+
+
+def test_no_reroute_keeps_tools_on_the_chat_model() -> None:
+    """With the reroute off (tool_model == chat model) the operator has said
+    their chat model handles tools natively — the pass-through must not strip
+    them."""
+    stub = _StubLLM([_tool_call("list_slots", {}, "c1"), _final("done")])
+    request = _fake_request(stub, model="hal0/agent", tool_model="hal0/agent")
+
+    _run(_collect(request))
+
+    assert stub.calls[0].get("tools"), "pass-through path must keep native tools"
+
+
 # ── the tool_model vocabulary (Stream A's contract) ─────────────────────────
 
 

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -599,6 +599,11 @@ def test_tool_intent_artefact_signals() -> None:
     # catch, so it does not.
     assert art(_leaked(JINJA_LEAK), known) == "slot_list"
     assert art(_leaked('<function name="get_board">'), known) == "get_board"
+    # Slash-qualified names — measured live on lxc105 after the tools-less
+    # round landed: the brain reached for `hal0/slot_list` and the remnant
+    # ` name="hal0/slot_list">` sailed past a `/`-less name char class.
+    assert art(_leaked(' name="hal0/slot_list">'), known) == "hal0/slot_list"
+    assert art(_leaked('<function name="hal0/list_slots">'), known) == "hal0/list_slots"
     # An unterminated `<function=NAME` opener (the terminated form is already
     # handled by the shared text-call fallback).
     assert art(_leaked("<function=list_slots"), known) == "list_slots"


### PR DESCRIPTION
## What

Brain chat on lxc105 was fully broken whenever tools were surfaced: every tools-attached completion against the brain slot returned

```
HTTP 500 {"error":{"message":"The model produced output that does not match the expected peg-native format","type":"server_error"}}
```

— even "just say hello". llama.cpp builds a tool-format parser from the bundled `hal0-brain-sft.jinja` chat template (`--jinja --chat-template-file`, post-#1434) and hard-fails the whole request when the model's output doesn't match. The 1B cannot match that format by design — that is exactly why the ADR-0023 tool-round reroute exists — so attaching native `tools` to a brain round buys nothing and costs the entire turn. `hal0 chat --brain` surfaced the raw 500 (`primary slot HTTP 500: ...`).

## Fix

`_tool_routing_llm`'s brain round now pops `tools` from the engine-owned body before the completion and restores it afterwards, so native schemas only ride tool-model rounds. Detection is unaffected: the text fallback and `_tool_intent_artefact` read the reply, not the request, and the steward knows its tool surface from the system prompt. The no-reroute pass-through path keeps tools, so an operator pointing brain chat at a tool-capable model keeps native calling.

This is the third measured failure shape for the brain-on-this-runtime family (#1419 → #1434 parsed the attribute-XML leak; this one never yields a response to parse). Module comment and test-file preamble document it.

## Verification

- New tests pin: tools-less brain round, tools-carrying tool-model rounds, tools kept on the pass-through path (red before the fix, green after).
- `tests/brain` (139 passed) and toolloop/board_chat/omni selection (226 passed).
- `ruff check`/`format` clean; mypy error count on `brain/chat.py` unchanged vs main (8 pre-existing).
- Live repro on lxc105 (image `c077206`) confirmed the failure mode before the fix.

## Out of scope

- Deploying to lxc105 (needs the pip `--force-reinstall --no-deps` recipe).
- Whether the registry should also flag `hal0-brain-sft-*` `tool_calling: false` explicitly — the omni-router gate already derives it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)