### PR TITLE
feat(runner): default to the ade07ba rocmfpx runner — native brain tool calls

### DIFF
--- a/installer/bench/config.sh
+++ b/installer/bench/config.sh
@@ -201,8 +201,8 @@ COMMON_RUN_FLAGS=(
 # device flags at all, so the container is handed neither /dev/kfd nor a
 # /dev/dri node and there is physically no backend device to select.
 declare -A BACKENDS=(
-  [rocm]="ghcr.io/hal0ai/hal0-rocmfpx:c077206|/opt/rocmfpx/bin/llama-bench|2048|GGML_HIP_ENABLE_UNIFIED_MEMORY=1|-ngl 99 -dev ROCm0"
-  [vulkan_radv]="ghcr.io/hal0ai/hal0-rocmfpx:c077206|/opt/rocmfpx/bin/llama-bench|512||-ngl 99 -dev Vulkan0"
+  [rocm]="ghcr.io/hal0ai/hal0-rocmfpx:ade07ba|/opt/rocmfpx/bin/llama-bench|2048|GGML_HIP_ENABLE_UNIFIED_MEMORY=1|-ngl 99 -dev ROCm0"
+  [vulkan_radv]="ghcr.io/hal0ai/hal0-rocmfpx:ade07ba|/opt/rocmfpx/bin/llama-bench|512||-ngl 99 -dev Vulkan0"
   [cpu]="ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server|/usr/local/bin/llama-bench|512||-ngl 0"
 )
 

--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1170,11 +1170,18 @@ def _unrouteable_model_error(tried_model: str) -> str:
 #     output that does not match the expected peg-native format" on EVERY
 #     tools-attached completion, tool-related prompt or not. llama.cpp builds
 #     a tool-format parser from the template and rejects the whole request
-#     when the output doesn't match. This is why `_routed` strips `tools`
-#     from the brain round below — no response ever arrives to run signal
-#     detection on otherwise.
+#     when the output doesn't match. #1626 briefly stripped `tools` from the
+#     brain round because of this.
 #
-# So the 1B genuinely cannot drive tools on this runtime. `[brain_chat]
+# ROOT CAUSE, RESOLVED BY RUNNER ade07ba (DEFAULT_ROCMFPX_IMAGE): all three
+# shapes were ONE bug — the MiniCPM5-family vocab carries the tool syntax as
+# CONTROL tokens (`<function`=18, `</function>`=19, `<param`=20,
+# `</param>`=21) and llama-server strips control pieces at decode, so the
+# parser never saw the openers the model actually emitted. The ade07ba
+# runner's MiniCPM5 specialized parser preserves those tokens and
+# grammar-locks the call shape, so the 1B DOES drive native tool calls now;
+# brain rounds carry `tools` again and everything below is the FALLBACK for
+# older runners and off-dialect models. `[brain_chat]
 # tool_model` (default "hal0/agent") is the documented mitigation, and this is
 # its implementation.
 #
@@ -1412,25 +1419,16 @@ def _tool_routing_llm(
             return await _degrade(await llm(body))
 
         body["model"] = chat_model
-        # The brain round goes out WITHOUT native `tools`. The runtime builds
-        # a tool-format parser from the chat template and hard-fails the WHOLE
-        # completion when the model's output doesn't match it — measured on
-        # lxc105 (image c077206, bundled hal0-brain-sft.jinja): every
-        # tools-attached request, even "just say hello", returns HTTP 500
-        # "The model produced output that does not match the expected
-        # peg-native format". The 1B cannot match that format by design (the
-        # reason this reroute exists), so attaching `tools` buys nothing and
-        # costs the entire turn. Detection is unaffected: the text fallback
-        # and _tool_intent_artefact read the reply, not the request, and the
-        # steward knows its tool surface from the system prompt. Popped per
-        # round and restored — the engine owns `body` and the tool-model
-        # rounds need the schemas back.
-        native_tools = body.pop("tools", None)
-        try:
-            response = await llm(body)
-        finally:
-            if native_tools is not None:
-                body["tools"] = native_tools
+        # Brain rounds carry native `tools` again as of runner ade07ba
+        # (DEFAULT_ROCMFPX_IMAGE): llama.cpp's MiniCPM5 specialized parser
+        # preserves the vocab's tool-syntax control tokens and grammar-locks
+        # the call shape, so the 1B's attribute-XML dialect parses into real
+        # `tool_calls` — measured live (clean JSON args, no peg-format 500).
+        # On the PRIOR runner (c077206) a tools-attached request against the
+        # brain slot always 500'd, which is why #1626 briefly stripped tools
+        # from this round; the reroute below is now the fallback it was
+        # designed to be, not the only path.
+        response = await llm(body)
         if not isinstance(response, dict) or response.get("error"):
             # A BRAIN-side failure keeps its documented contract exactly — the
             # loop core turns it into the error+done frames tests already pin.

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -989,7 +989,7 @@ MTP_FLAG_BUNDLE = build_mtp_flag_bundle("rocm")
 #: (debug builds, A/B tests, etc.).  See #__hal0_image_control__ for the
 #: phasing: 0.9.5 wires slot.image + DEFAULT_ROCMFPX_IMAGE; 0.9.6 will
 #: drop ``image`` from SEED_PROFILES entirely.
-DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-rocmfpx:c077206"
+DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba"
 
 #: Historical DEFAULT_ROCMFPX_IMAGE values (and their pre-consolidation
 #: equivalents). A slot-level ``image`` pin equal to one of these is a STALE
@@ -998,13 +998,28 @@ DEFAULT_ROCMFPX_IMAGE = "ghcr.io/hal0ai/hal0-rocmfpx:c077206"
 #: default (:func:`hal0.updater.updater.retag_stale_slot_images`). A pin to
 #: any ref NOT in this set is treated as intentional and never touched.
 #:
+#: ade07ba lineage (2026-08-08, alias ``b10297-hal0.1``): llama.cpp upstream
+#: b10297 via ciru/main's FPX-preserving sync (native MiniCPM5 tool-call
+#: parser with preserved control tokens + lazy grammar, vulkan submission
+#: batching fix, gfx1151 fixes, MTP-layer alloc fix, spec-decode /metrics)
+#: + two hal0 patches: multi-token preserved-marker control tokens
+#: (server-schema) and the restored vulkan ROCmFPX dmmv registrations the
+#: sync dropped. Source: Hal0ai/Hal0_ROCmFPX branch hal0/build-20260808.
+#: This runner is what makes the brain model's attribute-XML tool dialect
+#: parse NATIVELY — brain rounds carry OpenAI ``tools`` again from this
+#: release (see hal0.brain.chat).
+#:
 #: c077206 lineage (2026-07-10): charlie ROCmFPX main @5b39566 (FP6 CPU
 #: decode fix, MTP partial-draft-state fix, vecdotq pack window) + the
 #: minicpm5 pre-tokenizer vocab mapping (ac0137d) + TurboQuant turbo3/turbo4
 #: KV-cache types; image assembly drops the base toolbox's stale
 #: /usr/local llama.cpp (the old mixed install ABI-segfaulted llama-bench).
+#: Superseded by ade07ba — every tools-attached completion against a
+#: MiniCPM5-vocab model on c077206 500s with "peg-native format" (the
+#: control-token pieces are stripped before the parser sees them).
 STALE_ROCMFPX_IMAGE_REFS = frozenset(
     {
+        "ghcr.io/hal0ai/hal0-rocmfpx:c077206",
         "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5",
         "localhost/hal0-rocmfpx:vulkan-minicpm5",
         "ghcr.io/hal0ai/hal0-rocmfpx:server",

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1156,7 +1156,7 @@ TOOL_PARAM_HINTS: dict[str, dict[str, Any]] = {
                 "type": "string",
                 "description": (
                     "Container image override — FPX/FP4 quants need "
-                    "ghcr.io/hal0ai/hal0-rocmfpx:c077206 with runtime='container'"
+                    "ghcr.io/hal0ai/hal0-rocmfpx:ade07ba with runtime='container'"
                 ),
             },
             "runtime": {"type": "string", "description": "Set 'container' when image is set"},

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -356,29 +356,25 @@ def test_replayed_tool_history_does_not_pin_a_turn_to_the_tool_model() -> None:
     assert _tokens(events) == "Nothing else pending."
 
 
-# ── native `tools` never ride a brain round (the peg-format 500) ────────────
+# ── native `tools` ride every round again (runner ade07ba) ──────────────────
 #
-# Third measured failure shape (lxc105, image c077206, bundled
-# hal0-brain-sft.jinja via --chat-template-file): EVERY tools-attached
-# completion against the brain slot — even "just say hello" — fails with
-#
-#   HTTP 500 {"error":{"message":"The model produced output that does not
-#   match the expected peg-native format","type":"server_error"}}
-#
-# llama.cpp builds a tool-format parser from the chat template and hard-fails
-# the whole request when the model's output doesn't match it. The 1B cannot
-# match it by design (that is why the reroute exists), so attaching native
-# `tools` to a brain round buys nothing and now costs the entire turn.
+# #1626 stripped `tools` from brain rounds because the c077206 runner 500'd
+# every tools-attached completion ("peg-native format"). The real bug was the
+# runtime stripping the vocab's tool-syntax CONTROL tokens at decode; the
+# ade07ba runner preserves them and parses the 1B's attribute-XML natively,
+# so the brain round must get the schemas back — a native `tool_calls` round
+# from the brain is now the EXPECTED fast path, with the reroute as fallback.
 
 
-def test_brain_rounds_do_not_carry_native_tools() -> None:
-    """With the reroute armed, the brain round goes out WITHOUT `tools`.
+def test_brain_rounds_carry_native_tools() -> None:
+    """Every round — brain and tool-model alike — goes out with `tools`.
 
-    The tool-capable rounds keep them — the 35B parses native calls fine.
+    The ade07ba runner parses the brain's dialect natively; stripping the
+    schemas would forfeit the native fast path this runner exists for.
     """
     stub = _StubLLM(
         [
-            _leaked("", reasoning=STATED_INTENT),  # round 0, brain (tools-less)
+            _leaked("", reasoning=STATED_INTENT),  # round 0, brain (reroute fallback)
             _tool_call("list_slots", {}, "c1"),  # round 0 re-run, tool model
             _final("Three slots."),  # round 1, tool model
         ]
@@ -388,33 +384,21 @@ def test_brain_rounds_do_not_carry_native_tools() -> None:
     _run(_collect(request))
 
     assert stub.models == ["hal0/brain", "hal0/agent", "hal0/agent"]
-    assert "tools" not in stub.calls[0], "native tools rode the brain round"
-    assert stub.calls[1].get("tools"), "the tool-model re-run lost the tools"
-    assert stub.calls[2].get("tools"), "the continuation round lost the tools"
+    for n, call in enumerate(stub.calls):
+        assert call.get("tools"), f"round {n} lost the native tools"
 
 
-def test_tools_are_restored_when_the_brain_round_answers_plain() -> None:
-    """Stripping is per-round, not destructive: the engine-owned body gets its
-    `tools` back after the brain answers, so a later turn or reroute path
-    always finds them in place."""
-    stub = _StubLLM([_final("Hey — what can I help with?")])
-    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
-
-    _run(_collect(request, {"messages": [{"role": "user", "content": "hi"}]}))
-
-    assert "tools" not in stub.calls[0]
-
-
-def test_no_reroute_keeps_tools_on_the_chat_model() -> None:
-    """With the reroute off (tool_model == chat model) the operator has said
-    their chat model handles tools natively — the pass-through must not strip
-    them."""
+def test_a_native_brain_tool_call_stays_on_the_fast_path() -> None:
+    """The brain returning real `tool_calls` is dispatched as-is — no re-run,
+    no reroute of the round that produced it (the continuation still goes to
+    the tool model per the chain semantics)."""
     stub = _StubLLM([_tool_call("list_slots", {}, "c1"), _final("done")])
-    request = _fake_request(stub, model="hal0/agent", tool_model="hal0/agent")
+    request = _fake_request(stub, model="hal0/brain", tool_model="hal0/agent")
 
     _run(_collect(request))
 
-    assert stub.calls[0].get("tools"), "pass-through path must keep native tools"
+    assert stub.models == ["hal0/brain", "hal0/agent"]
+    assert stub.calls[0].get("tools"), "brain round lost the native tools"
 
 
 # ── the tool_model vocabulary (Stream A's contract) ─────────────────────────


### PR DESCRIPTION
## What

Rolls the default ROCmFPX runner to **`ghcr.io/hal0ai/hal0-rocmfpx:ade07ba`** (alias `b10297-hal0.1`, public) and reverts #1626's brain-round tools-stripping now that the root cause is fixed in the runtime.

## The runner

Built from `ciru/main` (llama.cpp upstream **b10297** with ROCmFPX features preserved) plus two hal0 patches, source at `Hal0ai/Hal0_ROCmFPX` branch `hal0/build-20260808`:

1. **server: preserve control tokens inside multi-token preserved markers** — the true root cause of the "peg-native format" 500s: MiniCPM5-family vocabs carry `<function`/`</function>`/`<param`/`</param>` as control tokens (ids 18–21) that llama-server strips at decode, so no parser ever saw the openers the model emitted.
2. **vulkan: restore ROCmFPX dmmv pipeline registrations lost in the b10297 sync** — without them a ROCmFP4 MoE model (chadrock 35B.A3B) aborted at token-gen on Vulkan (`GGML_ASSERT(dmmv != nullptr)`).

Also riding in from b10297: the native MiniCPM5 tool-call parser (preserved tokens + lazy grammar + CDATA), vulkan submission-batching/DeviceLost fix, gfx1151 fixes, MTP-layer alloc fix, spec-decode /metrics counters, BailingMoeV3/Ling-3.0-flash arch, DFlash drafters.

## Verification

- Fork test suites green incl. new cases pinning that `hal0-brain-sft.jinja` and `hal0-minicpm5-1b.jinja` route to the MiniCPM5 specialized parser (CDATA, reasoning split, the `|min` filter minja rejected).
- Live gates on lxc105, both backends: native `tool_calls` with clean JSON args from MiniCPM5-1B-Agentic-Tooluse **and** hal0-brain-sft-fpx8 (custom tensor type 103); plain chat with tools attached no longer 500s; chadrock 35B loads and runs on ROCm **and** Vulkan.
- Bench (chadrock 35B, r=2): ROCm pp512 614→1223 t/s, tg64 32→52 t/s. Vulkan pp512 770→683, tg64 62→57 (known ~8–11% vulkan regression vs c077206, tracked for a tuning pass — ROCm gains dominate).
- hal0 suites: tests/brain 138 passed; schema/config/updater/bench selection 1607 passed; ruff clean.

## Rollout

`c077206` added to `STALE_ROCMFPX_IMAGE_REFS`, so the updater retags slots pinned to the old default automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)