### PR TITLE
fix(install): stamp context window + tool_calling at pull — fresh brain slot wiring

### DIFF
--- a/installer/etc-hal0/slots/brain.toml
+++ b/installer/etc-hal0/slots/brain.toml
@@ -47,16 +47,16 @@
 #
 # Port 8089: 8088 belongs to the flm seed.
 #
-# If you point this slot at a small (~1B) model, note the tool-calling
-# caveat: on the FPX brain runtime a 1B can't emit tool calls the native
-# parser accepts (it leaks/500s). There is no per-turn reroute for this —
-# the steward's own model handles tool calls internally on whatever
-# `[brain_chat] model` resolves to. If that matters on your box, point the
-# whole steward chat at a tool-capable model instead, e.g.
-# `[brain_chat] model = "hal0/agent"` (the always-on anchor every fallback
-# chain ends in, ADR-0023). The chadrock family are confirmed clean native
-# tool-callers on this runtime: `hal0/code` (27B coder, lighter) and
-# `hal0/agent` (35B anchor).
+# Tool calling: as of runner ade07ba (DEFAULT_ROCMFPX_IMAGE) the brain
+# models are NATIVE tool-callers — llama.cpp's MiniCPM5 specialized parser
+# preserves the vocab's tool-syntax control tokens and grammar-locks the
+# call shape, so the steward executes its own calls on this slot (verified
+# live on both the SFT quants and the MiniCPM5 base). The `[brain_chat]
+# tool_model` reroute (default `hal0/agent`, ADR-0023) remains as the
+# FALLBACK: it catches artefact rounds and covers older runner images or
+# off-dialect models, and the tool-capable model still owns a chain's
+# continuation rounds. Point `[brain_chat] model` elsewhere only if you
+# deliberately want a bigger steward voice.
 name = "brain"
 type = "llm"
 device = "gpu-vulkan"

--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -107,12 +107,14 @@ intent = "ComfyUI"
 quant = ""
 
 [profile.brain]
-# Brain steward workload + MiniCPM5-1B-Agentic-Tooluse quirks (per
+# Brain steward workload + MiniCPM5-family quirks (per
 # spec-p3-brain.final.md §5a). Brain is 1:1 with its model (the only
 # 1B model the steward runs), so a single combined profile is cleaner
-# than overlay. Small batch (1B model), reasoning off; the steward
-# handles its own tool-call turns on this model — there is no separate
-# per-turn model reroute.
+# than overlay. Small batch (1B model), reasoning off — the 1B rambles
+# past any completion budget with thinking on, so the profile suppresses
+# it at launch. On runner ade07ba the model emits NATIVE tool calls on
+# this slot; artefact rounds still reroute per turn to `[brain_chat]
+# tool_model` (ADR-0023 fallback).
 flags = "--jinja -fa on -b 512 -ub 256 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.9 --top-k 20 --no-mmproj"
 mtp = false
 intent = "Brain steward (1B MiniCPM5 + persona + tool-call routing) · 64K ctx"

--- a/src/hal0/registry/curated.py
+++ b/src/hal0/registry/curated.py
@@ -132,6 +132,18 @@ class CuratedModel(BaseModel):
             "lacks). Empty = use the embedded template ('auto')."
         ),
     )
+    tool_calling: bool | None = Field(
+        default=None,
+        description=(
+            "Curated ``capability_flags.tool_calling`` stamp. True marks a "
+            "catalogue model as a NATIVE tool-caller on the shipped runner "
+            "(verified, not aspirational — the omni-router's master gate and "
+            "the dashboard's capability pill both read the derived flag). "
+            "Stamped at pull like ``chat_template``: absent-only, never over "
+            "an operator's own setting. None = no curated opinion (derives "
+            "False downstream)."
+        ),
+    )
     recommended_slot: str = Field(
         default="chat",
         description="Default slot to assign the model to. 'chat' for chat, 'img' for image-gen.",
@@ -348,9 +360,16 @@ CURATED_MODELS: list[CuratedModel] = [
     # ``hal0.install.brain_model`` picks between them from hardware.json;
     # don't hardcode a variant in a slot seed.
     #
-    # Tool calling is `hal0-function-xml`, and a 1B leaks on native tool-call
-    # parsing on this runtime — the steward routes TOOL turns to a capable
-    # model via ``[brain_chat] tool_model`` (default ``hal0/agent``). See
+    # Tool calling is the attribute-XML dialect (`<function name="..">
+    # <param name="..">..</param></function>`). As of runner ade07ba
+    # (DEFAULT_ROCMFPX_IMAGE) that dialect parses NATIVELY: llama.cpp's
+    # MiniCPM5 specialized parser preserves the vocab's tool-syntax control
+    # tokens and grammar-locks the call shape, so the ROCmFPX variants are
+    # verified native tool-callers (tool_calling=True below). The steward's
+    # ``[brain_chat] tool_model`` reroute (default ``hal0/agent``) remains as
+    # the fallback for older runners / artefact rounds. The F16 variant runs
+    # on stock llama.cpp images whose parser vintage we don't pin, so it
+    # carries no curated tool_calling opinion. See
     # installer/etc-hal0/slots/brain.toml.
     CuratedModel(
         id="hal0-brain-sft-q8-rocmfpx",
@@ -365,6 +384,7 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
         context_length=131072,
         chat_template="hal0-brain-sft",
+        tool_calling=True,
         recommended_slot="chat",
         tags=["chat", "brain", "steward", "tool-use", "tiny", "rocmfpx"],
         notes=(
@@ -388,6 +408,7 @@ CURATED_MODELS: list[CuratedModel] = [
         hf_file="hal0-brain-sft-Q4_0_ROCMFP4_COHERENT.gguf",
         context_length=131072,
         chat_template="hal0-brain-sft",
+        tool_calling=True,
         recommended_slot="chat",
         tags=["chat", "brain", "steward", "tool-use", "tiny", "rocmfp4"],
         notes=(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -40,7 +40,7 @@ from hal0.db import repository
 from hal0.db.connection import connect, tx
 from hal0.errors import Hal0Error
 from hal0.registry.fileset import FileSetEntry, FileSetPlan
-from hal0.registry.model import Model, ModelDefaults
+from hal0.registry.model import Model, ModelCapabilities, ModelDefaults
 from hal0.registry.store import ModelNotFound, ModelRegistry, _fsync_dir
 
 log = logging.getLogger(__name__)
@@ -1208,6 +1208,25 @@ def _register_pulled(
 
     curated = get_curated(model_id)
     curated_template = curated.chat_template if curated is not None else ""
+    curated_tool_calling = curated.tool_calling if curated is not None else None
+    # Context window — the pull path is the ONLY registration these bytes get
+    # on a fresh install (nothing re-runs detection on them), and a row with
+    # no window sends the 1.0 launch resolver to the 8192 safe fallback. For
+    # the brain slot that is fatal: the steward's system prompt alone is
+    # ~7.3k tokens, so the second turn 400s with exceed_context. The
+    # artifact's own GGUF header is authoritative; the curated catalogue
+    # window backfills an unreadable header.
+    from hal0.registry.detect import detect
+
+    ctx_len: int | None = None
+    try:
+        ctx_len = detect(Path(path)).context_length
+    except Exception:  # header parse must never fail a completed pull
+        ctx_len = None
+    if not ctx_len and curated is not None and curated.context_length:
+        ctx_len = int(curated.context_length)
+    if ctx_len:
+        fresh_meta["context_length"] = int(ctx_len)
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
@@ -1239,6 +1258,9 @@ def _register_pulled(
                 defaults=ModelDefaults(chat_template=curated_template)
                 if curated_template
                 else None,
+                capability_flags=ModelCapabilities(tool_calling=curated_tool_calling)
+                if curated_tool_calling is not None
+                else ModelCapabilities(),
             )
         )
         return
@@ -1247,6 +1269,11 @@ def _register_pulled(
     # before kicking off the pull).
     merged_meta = dict(existing.metadata)
     merged_meta.update(fresh_meta)
+    # An operator/scan-provided window outranks this pull's read: only fill
+    # the key when the existing row has none (same absent-only contract as
+    # chat_template below).
+    if existing.metadata.get("context_length") and "context_length" in fresh_meta:
+        merged_meta["context_length"] = existing.metadata["context_length"]
     updates["metadata"] = merged_meta
     if curated_template and not (existing.defaults is not None and existing.defaults.chat_template):
         merged_defaults = (
@@ -1255,6 +1282,10 @@ def _register_pulled(
             else ModelDefaults(chat_template=curated_template)
         )
         updates["defaults"] = merged_defaults
+    if curated_tool_calling is not None and (
+        existing.capability_flags is None or existing.capability_flags.tool_calling is None
+    ):
+        updates["capability_flags"] = ModelCapabilities(tool_calling=curated_tool_calling)
     registry.update(model_id, updates)
 
 

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -215,6 +215,140 @@ async def test_run_pull_uncurated_model_gets_no_template_default(
     assert registry.get("some-random-gguf").defaults is None
 
 
+# ── context-length + capability stamping at pull time ────────────────────────
+#
+# The fresh-install path registers pulled models HERE — nothing else runs
+# detection on them. Without a context_length the 1.0 launch resolver falls to
+# the 8192 safe fallback, which is fatal for the brain steward (its system
+# prompt alone is ~7.3k tokens): the measured live shape was every second turn
+# 400ing with exceed_context. Same story for capability_flags.tool_calling:
+# null derives False, so the omni-router ships a natively tool-capable brain
+# model no tools at all.
+
+
+def _gguf_payload(context_length: int = 131072) -> bytes:
+    """A minimal REAL GGUF header (llama arch + context_length), as a pull body."""
+    import struct
+
+    def enc_str(s: str) -> bytes:
+        raw = s.encode("utf-8")
+        return struct.pack("<Q", len(raw)) + raw
+
+    kvs = [
+        ("general.architecture", 8, enc_str("llama")),  # 8 = GGUF string type
+        ("llama.context_length", 4, struct.pack("<I", context_length)),  # 4 = uint32
+    ]
+    out = bytearray(b"GGUF")
+    out += struct.pack("<I", 3)  # version
+    out += struct.pack("<Q", 0)  # tensor_count
+    out += struct.pack("<Q", len(kvs))
+    for key, vtype, vbytes in kvs:
+        out += enc_str(key) + struct.pack("<I", vtype) + vbytes
+    return bytes(out)
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_gguf_context_length(tmp_hal0_home: str) -> None:
+    """The pulled artifact's own GGUF window lands in metadata.context_length."""
+    body = _gguf_payload(context_length=131072)
+    job = make_job("some-random-gguf")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job, hf_repo="org/random-GGUF", hf_file="random.gguf", registry=registry, client=client
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("some-random-gguf").metadata.get("context_length") == 131072
+
+
+@pytest.mark.asyncio
+async def test_run_pull_curated_context_length_backfills_unreadable_gguf(
+    tmp_hal0_home: str,
+) -> None:
+    """When the header can't be read, the curated catalogue window is stamped.
+
+    The FPX brain artifacts carry custom tensor types; if a future layout ever
+    defeats the header parser, the curated context_length (the same value the
+    wizard card shows) must still reach the registry row — 8192-fallback on
+    the steward's slot is the failure this exists to prevent.
+    """
+    body = _payload(4096)  # not a GGUF — detection yields nothing
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("hal0-brain-sft-q8-rocmfpx").metadata.get("context_length") == 131072
+
+
+@pytest.mark.asyncio
+async def test_run_pull_stamps_curated_tool_calling(tmp_hal0_home: str) -> None:
+    """A curated native tool-caller lands with capability_flags.tool_calling=True."""
+    body = _payload(4096)
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    registry = ModelRegistry()
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("hal0-brain-sft-q8-rocmfpx").capability_flags.tool_calling is True
+
+
+@pytest.mark.asyncio
+async def test_run_pull_keeps_operator_tool_calling(tmp_hal0_home: str) -> None:
+    """An operator's explicit tool_calling=False survives a re-pull."""
+    from hal0.registry.model import Model, ModelCapabilities
+
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="hal0-brain-sft-q8-rocmfpx",
+            name="hal0-brain-sft-q8-rocmfpx",
+            path="/nonexistent/pre-pull.gguf",
+            capability_flags=ModelCapabilities(tool_calling=False),
+        )
+    )
+    body = _payload(4096)
+    job = make_job("hal0-brain-sft-q8-rocmfpx")
+    client = httpx.AsyncClient(transport=_ok_handler(body))
+    try:
+        await run_pull(
+            job,
+            hf_repo="Hal0ai/hal0-brain-sft-ROCmFPX-GGUF",
+            hf_file="hal0-brain-sft-Q8_0_ROCMFPX_AGENT.gguf",
+            registry=registry,
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("hal0-brain-sft-q8-rocmfpx").capability_flags.tool_calling is False
+
+
 # ── MR-1: run_pull persists a durable snapshot for ALL callers ────────────────
 
 


### PR DESCRIPTION
## What

Closes the last gaps in the fresh-install brain pipeline found by an end-to-end audit (slot seed → model pull → registry row → launch resolution → brain chat).

**The bug:** the install-time pull path (`_register_pulled_model`) is the only registration a fresh box's models ever get, and it stamped no context window — the 1.0 launch resolver (`defaults.context_size` → `metadata.context_length` → 8192 safe fallback) then launched the brain slot at **8192**. The steward's system prompt alone is ~7.3k tokens, so the second turn dies with `exceed_context`. This is the same failure family as the live agent-slot 8192 clamp found on lxc105 (chadrock had no registry window either).

**Fix:**
- Pull now reads the pulled artifact's GGUF header (`registry.detect`) and stamps `metadata.context_length`; the curated catalogue window backfills an unreadable header. Absent-only — an operator/scan value is never overwritten.
- `CuratedModel` gains a `tool_calling` tri-state, stamped into `capability_flags.tool_calling` under the same absent-only contract as `chat_template`. The two ROCmFPX brain variants declare `True` (verified native tool-callers on runner `ade07ba`); the F16 variant stays neutral (stock-llama.cpp image vintage unpinned). The omni-router's master gate stops deriving `False` for the steward's own model on a fresh box.
- Stale pre-`ade07ba` guidance refreshed in `installer/etc-hal0/slots/brain.toml` and `[profile.brain]` ("a 1B can't emit tool calls on this runtime" → native calls, reroute is the fallback).

## Audit results (no change needed)

- Slot seed (`brain.toml`): port 8089, profile `brain`, gpu-vulkan, 65536 ctx ceiling — correct as a HW ceiling under model-owned ctx.
- `[profile.brain]` flags (`--jinja -fa on -b 512 --reasoning off …`): correct for the 1B (reasoning suppressed — it rambles past any budget with thinking on).
- Model pull: `install.sh` → `hal0.install.brain_model` HW-gated variant pick, `[model].default` stamped only after bytes land — intact.
- Chat template: `seed_chat_templates` copies bundled `hal0-brain-sft.jinja` into the model store at API startup; pull stamps `defaults.chat_template` — intact.
- Brain chat wiring: `hal0/brain` → agent resolver chain, `[brain_chat] tool_model` fallback — intact.

## Verification

registry/install/config/brain suites: 1495 passed. New tests pin: GGUF-header stamping, curated backfill on unreadable header, curated `tool_calling` stamping, operator-value preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)