### PR TITLE
fix(models): dedupe FLM probe rows against registered colon tags

### DIFF
--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -888,6 +888,12 @@ async def list_all(
         for fm in flm_served_models():
             if not fm.get("installed"):
                 continue
+            # A registry row already covers this installed model under FLM's
+            # native colon tag (the FLM pull flow registers ``gemma4-it:e4b``
+            # with backends=["npu"]) — emitting the probe row too listed every
+            # pulled FLM model twice, once undeletable (#duplicate-FLM-rows).
+            if fm["tag"] in seen:
+                continue
             mid = fm["tag"].replace(":", "-") + "-FLM"
             if mid in seen:
                 continue

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -615,6 +615,48 @@ def test_list_models_surfaces_installed_flm_models(
     assert "qwen3-0.6b-FLM" not in rows
 
 
+def test_list_models_dedups_flm_probe_against_registry_rows(
+    inspect_client: TestClient,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installed FLM tag that already has a registry row (the FLM pull
+    flow registers the native colon tag, e.g. ``gemma4-it:e4b``) must not
+    ALSO surface as a probe-sourced ``<tag>-FLM`` row — that listed every
+    pulled FLM model twice, and the duplicate could not be deleted because
+    it exists in no registry."""
+    fpath = Path(tmp_hal0_home) / "gemma4-e4b.gguf"
+    fpath.write_bytes(b"\x00" * 8)
+    inspect_client.post(
+        "/api/models",
+        json={"id": "gemma4-it:e4b", "path": str(fpath)},
+    )
+    fake = [
+        {
+            "tag": "gemma4-it:e4b",
+            "capabilities": ["chat", "stt"],
+            "installed": True,
+            "size_bytes": 1,
+            "footprint_gb": 0.0,
+            "family": "gemma4",
+        },
+        {
+            "tag": "llama3.2:1b",  # no registry row — probe row must remain
+            "capabilities": ["chat"],
+            "installed": True,
+            "size_bytes": 1,
+            "footprint_gb": 0.0,
+            "family": "llama3.2",
+        },
+    ]
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: fake)
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    assert "gemma4-it:e4b" in rows
+    assert "gemma4-it-e4b-FLM" not in rows
+    assert rows["llama3.2-1b-FLM"]["backend"] == "flm"
+
+
 # ── upstream provenance in /api/models ─────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Installed FLM models rendered twice in the Models list: once as the registry row the FLM pull flow creates under the native colon tag (`gemma4-it:e4b`), and once as the host-flm probe's `<tag>-FLM` row (`gemma4-it-e4b-FLM`). The probe dedupe only checked its own `-FLM` id against `seen`, which holds colon-form registry ids — never a match. The probe duplicate is also undeletable (`hal0 model rm` → "not in registry") because it exists only in the composed listing.

## Fix

Skip the probe row when the native tag already has a registry row. Registry rows carry `backends=["npu"]`, which `modelDeviceClasses()` maps to the npu device class, so the NPU slot pickers keep offering registered models; unregistered installed FLM tags still surface as probe rows (covered by the new test).

## Verification

- `tests/api` + `tests/registry`: 2033 passed, 1 skipped
- new regression test `test_list_models_dedups_flm_probe_against_registry_rows`
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)