### PR TITLE
fix(ui): align NPU card modality pills + model label with the edit drawer

### DIFF
--- a/ui/src/dash/__tests__/npu-modality.test.ts
+++ b/ui/src/dash/__tests__/npu-modality.test.ts
@@ -1,0 +1,35 @@
+// Pins the FLM [npu] modality defaults to the backend contract
+// (config/schema.py NpuConfig + providers/flm.py build_env): chat defaults ON
+// when the key is absent; asr/embed default OFF unless explicitly true.
+//
+// Regression: the NPU occupancy card rendered its STT/Embed pills with
+// `npu.asr !== false` (absent ⇒ On) while the edit drawer seeded its toggles
+// with `npu.asr === true` (absent ⇒ Off) — the two surfaces showed opposite
+// states for the same slot. Both now read through npuModalityOn.
+
+import { describe, expect, it } from 'vitest'
+
+import { npuModalityOn } from '../npu-modality.js'
+
+describe('npuModalityOn', () => {
+  it('defaults chat ON, asr/embed OFF when the [npu] table is absent', () => {
+    for (const npu of [undefined, null, {}]) {
+      expect(npuModalityOn(npu, 'chat')).toBe(true)
+      expect(npuModalityOn(npu, 'asr')).toBe(false)
+      expect(npuModalityOn(npu, 'embed')).toBe(false)
+    }
+  })
+
+  it('honours explicit values', () => {
+    const npu = { chat: false, asr: true, embed: true }
+    expect(npuModalityOn(npu, 'chat')).toBe(false)
+    expect(npuModalityOn(npu, 'asr')).toBe(true)
+    expect(npuModalityOn(npu, 'embed')).toBe(true)
+  })
+
+  it('treats a bare [npu] section with partial keys per-key', () => {
+    expect(npuModalityOn({ asr: true }, 'asr')).toBe(true)
+    expect(npuModalityOn({ asr: true }, 'embed')).toBe(false)
+    expect(npuModalityOn({ asr: true }, 'chat')).toBe(true)
+  })
+})

--- a/ui/src/dash/npu-modality.js
+++ b/ui/src/dash/npu-modality.js
@@ -1,0 +1,11 @@
+// Single source of truth for the FLM [npu] modality defaults.
+//
+// Backend contract (config/schema.py NpuConfig + providers/flm.py build_env):
+// chat defaults ON when the key is absent; asr/embed default OFF unless
+// explicitly true. The slot-drawer toggle seeds and the NPU occupancy card's
+// pills both read through here so the two surfaces can never disagree on an
+// absent key.
+export const npuModalityOn = (npu, role) => {
+  const t = npu || {}
+  return role === 'chat' ? t.chat !== false : t[role] === true
+}

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -27,6 +27,7 @@ import { slotIndicatorFromPhase } from './slot-status.js'
 // the shared helper folds them through backend_to_device → npu).
 import { devKind } from '@/lib/deviceMeta'
 import { PillToggle } from './primitives.jsx'
+import { npuModalityOn } from './npu-modality.js'
 
 // ─── icons (16×16, hal0 thin-line family — ported from the design) ─────────
 const NI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -298,7 +299,12 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
   const tps = typeof m.toks === 'number' && m.toks > 0 ? Math.round(m.toks) : null
   const ttft = typeof m.ttft === 'number' && m.ttft > 0 ? Math.round(m.ttft) : null
   const gb = occ && typeof occ.gb === 'number' ? round1(occ.gb) : typeof m.mem === 'number' ? round1(m.mem) : null
-  const model = String(slot.model_id || slot.model || occ?.model || '').replace(/-FLM$/, '')
+  // #1388 ordering, same as the drawer's chat-model seed: the CONFIGURED
+  // [model].default first, live id as fallback. model_id is documented stale
+  // for this slot class (trio slots never load as their own process; the
+  // anchor's id lags while stopped), so leading with it made this card
+  // disagree with the edit drawer about which model the slot runs.
+  const model = String(slot.modelDefault || slot.model_id || slot.model || occ?.model || '').replace(/-FLM$/, '')
   return (
     <div className={'cslot' + (running ? ' running' : ' dim')} style={{ '--slot-hue': hue.hue, '--slot-fg': hue.fg }}>
       <div className="cslot-top">
@@ -328,7 +334,7 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
               {slot.name === 'flm-stt' ? 'STT' : 'Embed'}
             </span>
             <PillToggle
-              on={slot.name === 'flm-stt' ? mainFlmNpu.asr !== false : mainFlmNpu.embed !== false}
+              on={npuModalityOn(mainFlmNpu, slot.name === 'flm-stt' ? 'asr' : 'embed')}
               label={slot.name === 'flm-stt' ? 'STT' : 'Embed'}
               className="npu-card-toggle"
               onToggle={() => handlers.onEdit(slot)}
@@ -338,7 +344,7 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
           <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
             <span style={{color: 'var(--fg-2)'}}>Chat</span>
             <PillToggle
-              on={mainFlmNpu?.chat !== false}
+              on={npuModalityOn(mainFlmNpu, 'chat')}
               label="Chat"
               className="npu-card-toggle"
               onToggle={() => handlers.onEdit(slot)}

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -21,6 +21,7 @@ import { useSlotLogsStream } from "@/api/hooks/useLogs";
 import { ENDPOINTS } from "@/api/endpoints";
 import { normalizeApiModel, isUpstreamModel } from "@/lib/normalizeApiModel";
 import { stateChipClassForSlot, slotButtonPhase } from "./slot-status.js";
+import { npuModalityOn } from "./npu-modality.js";
 import { slotModelRow } from "./slots/slot-shared.js";
 
 // The slot edit drawer's own width, and therefore the offset the stacked model
@@ -316,9 +317,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// Task 3 (NPU modality toggles): asr/embed instant-apply + cold restart for
 	// device=npu slots. Seeded from slot.npu ({asr,embed}); optimistic with
 	// revert-on-error.
-	const [npuAsr, setNpuAsr] = useStateSM(slot?.npu?.asr === true);
-	const [npuEmbed, setNpuEmbed] = useStateSM(slot?.npu?.embed === true);
-	const [npuChat, setNpuChat] = useStateSM(slot?.npu?.chat !== false);
+	const [npuAsr, setNpuAsr] = useStateSM(npuModalityOn(slot?.npu, "asr"));
+	const [npuEmbed, setNpuEmbed] = useStateSM(npuModalityOn(slot?.npu, "embed"));
+	const [npuChat, setNpuChat] = useStateSM(npuModalityOn(slot?.npu, "chat"));
 	// #1388: seed from the CONFIGURED tag ([model].default, lifted by
 	// config_enrichment and normalised to `modelDefault`), not the live
 	// `model_id`. useSlots documents model_id as stale for exactly this slot
@@ -478,12 +479,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		setPendingSwap(null);
 		setModelEditOpen(false);
 		setFieldErrs({});
-		setNpuAsr(slot.npu?.asr === true);
-		setNpuEmbed(slot.npu?.embed === true);
+		setNpuAsr(npuModalityOn(slot.npu, "asr"));
+		setNpuEmbed(npuModalityOn(slot.npu, "embed"));
 		// Re-seed the chat pill + all three model selects too, so a save +
 		// refetch keeps the drawer in sync with server truth instead of
 		// drifting until the drawer is remounted.
-		setNpuChat(slot.npu?.chat !== false);
+		setNpuChat(npuModalityOn(slot.npu, "chat"));
 		setNpuChatModel(
 			slot.modelDefault || slot.model_id || slot.model || "qwen3:4b",
 		);


### PR DESCRIPTION
## What changed

The NPU occupancy card and the FLM slot edit drawer disagreed about the same slot (screenshot in the originating report):

- **Toggle polarity.** The card rendered its STT/Embed pills with `npu.asr !== false` (absent key ⇒ **On**) while the drawer seeded the same toggles with `npu.asr === true` (absent key ⇒ **Off**). The backend contract (`NpuConfig` in `config/schema.py` and `FLMProvider.build_env`) defaults `asr`/`embed` **off** and `chat` **on** — the drawer was right, the card was wrong.
- **Model label.** The card led with the live `model_id` (documented stale for this slot class in `useSlots.ts`) while the drawer seeds from the configured `[model].default` (#1388), so the two could name different models.

## How

Extracted the contract into a single pure predicate, `npuModalityOn(npu, role)` (`ui/src/dash/npu-modality.js`), and routed both the card pills and every drawer seed/re-seed through it so the two surfaces can no longer diverge. The card's model label now uses the drawer's preference order (`modelDefault → model_id → model → occ.model`).

## Verification

- New unit test `ui/src/dash/__tests__/npu-modality.test.ts` pins the default polarity (written red-first against the old behaviour).
- `vitest run`: 78 passed. `npm run build`: clean. `npm run lint`: clean.
- No e2e spec pinned the old card polarity (checked `npu-card-toggle` usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)