### PR TITLE
feat(slots): on-demand capability slots — retire the vision lane, fix seed delete/recreate

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1177,13 +1177,13 @@ async def _boot_slot_reconcile(app: FastAPI, ctx: BootState) -> None:
         log.warning("registry.type_tags_retirement_failed", error=str(exc))
 
     # Retire the pre-1.0 ``vision`` scaffold slot (untouched scaffolds only —
-    # vision is a model property now, served by any llm slot; see
-    # hal0.config.migrations.vision_slot_retirement).
+    # vision is a model property now, served by any llm slot). Routed through
+    # SlotManager.delete so identity row, port claim, and state go with the
+    # TOML on id-keyed boxes; see hal0.config.migrations.vision_slot_retirement.
     try:
-        from hal0.config import paths as _vision_paths
-        from hal0.config.migrations.vision_slot_retirement import migrate_vision_slot
+        from hal0.config.migrations.vision_slot_retirement import retire_vision_scaffold
 
-        if migrate_vision_slot(_vision_paths.slots_config_dir()):
+        if await retire_vision_scaffold(ctx.slot_manager):
             log.info("slot.vision_scaffold_retired")
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("slot.vision_retirement_failed", error=str(exc))

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -1176,6 +1176,18 @@ async def _boot_slot_reconcile(app: FastAPI, ctx: BootState) -> None:
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("registry.type_tags_retirement_failed", error=str(exc))
 
+    # Retire the pre-1.0 ``vision`` scaffold slot (untouched scaffolds only —
+    # vision is a model property now, served by any llm slot; see
+    # hal0.config.migrations.vision_slot_retirement).
+    try:
+        from hal0.config import paths as _vision_paths
+        from hal0.config.migrations.vision_slot_retirement import migrate_vision_slot
+
+        if migrate_vision_slot(_vision_paths.slots_config_dir()):
+            log.info("slot.vision_scaffold_retired")
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("slot.vision_retirement_failed", error=str(exc))
+
     # One-shot reconciliation: clear pre-fix stuck ERROR on slots whose
     # only problem was an empty model.default. After fix(slots): empty
     # default is OFFLINE+CTA, not ERROR; this pass migrates existing

--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -114,6 +114,11 @@ def _model_caps(m: dict[str, Any]) -> set[str]:
         caps.update(m.get(field_name) or [])
     if m.get("type"):
         caps.add(m["type"])
+    # The type-tag retirement folds the pre-1.0 "mtp" tag into the typed
+    # defaults.mtp field — surface it back into the match set so rosters
+    # keyed on "mtp" keep selecting migrated rows.
+    if (m.get("defaults") or {}).get("mtp") is True:
+        caps.add("mtp")
     return caps
 
 

--- a/src/hal0/capabilities/catalog.py
+++ b/src/hal0/capabilities/catalog.py
@@ -1018,9 +1018,6 @@ def catalogs_by_slot(
         "img": {
             "img": models_for_capability("image", registry=registry),
         },
-        "vision": {
-            "vision": models_for_capability("vision", registry=registry),
-        },
         "chat": {
             "chat": models_for_capability("chat", registry=registry),
         },

--- a/src/hal0/capabilities/config.py
+++ b/src/hal0/capabilities/config.py
@@ -338,6 +338,14 @@ def load_capabilities_config(path: Path | None = None) -> CapabilityConfig:
         return CapabilityConfig()
     with open(target, "rb") as f:
         raw = tomllib.load(f)
+    # Retired capability lanes are dropped on read (tolerant load — the next
+    # write converges the file). ``vision`` stopped being a slot-backed
+    # capability: vision is a MODEL property (mmproj presence, the registry's
+    # ``capabilities``/``defaults.vision``) served by any llm slot, so a
+    # stray ``[selections.vision]`` table from an older install is inert.
+    sels = raw.get("selections")
+    if isinstance(sels, dict):
+        sels.pop("vision", None)
     return CapabilityConfig.model_validate(raw)
 
 

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -25,7 +25,7 @@ serving chat coresident with embed/asr — by writing the anchor's
 (``v1._is_npu_trio_request``). The modality slot is never
 load/swap/unloaded; the anchor is never eagerly restarted — the change
 returns ``pending_reload`` and the operator applies it via the dashboard
-NPU section's reload affordance. Non-trio children (rerank/tts/img/vision)
+NPU section's reload affordance. Non-trio children (rerank/tts/img)
 and non-NPU devices keep spawning their own slot via the regular
 ``load()`` path.
 """
@@ -71,7 +71,6 @@ _CHILD_TO_SLOT: dict[tuple[str, str], str] = {
     ("voice", "stt"): "stt",
     ("voice", "tts"): "tts",
     ("img", "img"): "img",
-    ("vision", "vision"): "vision",
 }
 
 # Inverse for status surfacing ("which child is this slot serving").
@@ -82,7 +81,7 @@ _SLOT_TO_CHILD: dict[str, tuple[str, str]] = {
 # ── Trio dispatch discriminator: capability child → slot ``type`` ─────────────
 # The FLM trio (one ``flm serve`` process serving chat + embed + asr) is gated
 # in v1._is_npu_trio_request on the slot record's ``type`` field. Only the two
-# trio modalities carry a type; rerank/tts/img/vision are NOT trio members and
+# trio modalities carry a type; rerank/tts/img are NOT trio members and
 # get no ``type`` key (their auto-created slots are plain llama-server/dedicated
 # providers). Mirrors providers/flm._classify_flm_model emitting "embed"/"stt".
 _CHILD_TO_SLOT_TYPE: dict[str, str] = {
@@ -91,7 +90,7 @@ _CHILD_TO_SLOT_TYPE: dict[str, str] = {
 }
 
 # The legal capability/child surface — used by HTTP validation.
-LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img", "vision")
+LEGAL_SLOTS: tuple[str, ...] = ("embed", "voice", "img")
 
 
 # child → the ``[npu]`` TOML boolean field that controls it on container slots.
@@ -130,7 +129,6 @@ _CHILD_TO_CAPABILITY: dict[tuple[str, str], str] = {
     ("voice", "stt"): "stt",
     ("voice", "tts"): "tts",
     ("img", "img"): "image",
-    ("vision", "vision"): "vision",
 }
 
 _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
@@ -140,7 +138,6 @@ _CAPABILITY_TO_SLOT_TYPE: dict[str, str] = {
     "stt": "transcription",
     "tts": "tts",
     "image": "image",
-    "vision": "llm",
 }
 
 
@@ -701,7 +698,7 @@ class CapabilityOrchestrator:
         }
         # Stamp the trio dispatch discriminator for embed/stt children so
         # v1._is_npu_trio_request can gate on it. Non-trio children
-        # (rerank/tts/img/vision) get no ``type`` key.
+        # (rerank/tts/img) get no ``type`` key.
         _, child = _SLOT_TO_CHILD.get(slot_name, (None, None))
         slot_type = _CHILD_TO_SLOT_TYPE.get(child) if child else None
         if slot_type:

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -106,6 +106,41 @@ def legal_children(slot: str) -> list[str]:
     return [child for (s, child) in _CHILD_TO_SLOT if s == slot]
 
 
+def disable_selections_for_slot(slot_name: str) -> list[tuple[str, str]]:
+    """Mark every capabilities.toml selection served by ``slot_name`` disabled.
+
+    Called from ``SlotManager.delete`` (lazily, to keep the import edge thin):
+    deleting a capability slot without releasing its selection leaves the file
+    claiming an enabled capability with nothing behind it, and the converged-
+    file fast path never recreates the slot. Returns the (group, child) pairs
+    it disabled; empty when the slot serves no capability child or the file
+    doesn't exist.
+    """
+    from hal0.capabilities.config import (
+        capabilities_toml_path,
+        load_capabilities_config,
+        save_capabilities_config,
+    )
+
+    key = _SLOT_TO_CHILD.get(slot_name)
+    if key is None or not capabilities_toml_path().exists():
+        return []
+    group, child = key
+    cfg = load_capabilities_config()
+    selection = (cfg.selections.get(group) or {}).get(child)
+    if selection is None or not selection.enabled:
+        return []
+    selection.enabled = False
+    save_capabilities_config(cfg)
+    log.info(
+        "capability.selection_disabled_on_slot_delete slot=%s group=%s child=%s",
+        slot_name,
+        group,
+        child,
+    )
+    return [(group, child)]
+
+
 def child_to_slot(slot: str, child: str) -> str:
     """Resolve a (slot, child) tuple to its underlying slot name.
 

--- a/src/hal0/cli/setup_command.py
+++ b/src/hal0/cli/setup_command.py
@@ -41,7 +41,7 @@ from hal0.registry.model_store import describe_store_state
 
 #: capability → (slot_name, port) for the slots first-run provisions. Mirrors
 #: installer.py:_SLOT_META for the shared capabilities (chat/coder/embed/stt/
-#: tts) and adds rerank/vision on free ports in the 8081-8099 pool. ``img`` is
+#: tts) and adds rerank on a free port in the 8081-8099 pool. ``img`` is
 #: handled via the ComfyUI ``comfyui_defaults`` sidecar, not this table.
 #: The chat capability's slot is NAMED ``agent`` per ADR-0023: `agent` is the
 #: default LLM anchor every ``hal0/<slot>`` fallback chain ends in, so first
@@ -53,7 +53,6 @@ _SETUP_SLOTS = {
     "stt": ("stt", 8084),
     "tts": ("tts", 8085),
     "rerank": ("rerank", 8086),
-    "vision": ("vision", 8087),
 }
 
 #: The dashboard steward's dedicated slot, scaffolded (empty, chat-capability
@@ -68,7 +67,7 @@ _BRAIN_SLOT = ("brain", 8089)
 #: separately, gated on an agent extension. ``apply_setup`` derives each slot's
 #: device and skips any that don't apply to the hardware (e.g. NPU-only ``stt``
 #: without ``npu_opt_in``).
-_SCAFFOLD_CAPS = ("chat", "embed", "rerank", "stt", "tts", "vision")
+_SCAFFOLD_CAPS = ("chat", "embed", "rerank", "stt", "tts")
 
 
 def _api_reachable(timeout: float = 0.5) -> bool:

--- a/src/hal0/config/migrations/vision_slot_retirement.py
+++ b/src/hal0/config/migrations/vision_slot_retirement.py
@@ -7,20 +7,23 @@ llm slot whose bound model carries it. The capability orchestrator no longer
 maps a ``vision.vision`` child to a slot, and ``capabilities.toml`` drops a
 stray ``[selections.vision]`` table on load.
 
-This sweep removes the on-disk scaffold slot older installs carry — but ONLY
-the untouched scaffold: a ``vision`` slot with no model bound. A vision slot
-the operator pointed at a model is left alone (it keeps working as a plain
-llm slot under that name; the name is no longer reserved either way).
+This sweep removes the slot older installs carry — but ONLY the untouched
+scaffold: a ``vision`` slot with no model bound. A vision slot the operator
+pointed at a model is left alone (it keeps working as a plain llm slot under
+that name; the name is no longer reserved either way).
+
+Retirement goes through ``SlotManager.delete`` so the WHOLE lifecycle is
+cleaned: on an id-keyed box a prior ``fold_identity()`` pass gave the
+scaffold a persistent identity row, a port claim, and state under
+``slot_data_dir`` — unlinking just the name-keyed TOML would leak all three.
 
 Idempotent and best-effort: after the first sweep there is nothing left to
-find, and a config-dir problem must not block startup.
+find, and a failure must not block startup.
 """
 
 from __future__ import annotations
 
-import contextlib
-import tomllib
-from pathlib import Path
+from typing import Any
 
 import structlog
 
@@ -29,20 +32,13 @@ log = structlog.get_logger(__name__)
 _RETIRED_SLOT = "vision"
 
 
-def migrate_vision_slot(slots_dir: Path) -> bool:
-    """Remove an untouched ``vision`` scaffold slot TOML. Returns True if removed.
+async def retire_vision_scaffold(slot_manager: Any) -> bool:
+    """Delete an untouched ``vision`` scaffold slot. Returns True if removed."""
+    from hal0.slots.state import SlotNotFound
 
-    Only the name-keyed file is considered: an id-keyed slot went through the
-    identity migration, which means it was live enough to matter — that is
-    operator territory, not scaffold debris.
-    """
-    cfg_path = slots_dir / f"{_RETIRED_SLOT}.toml"
-    if not cfg_path.is_file():
-        return False
     try:
-        with open(cfg_path, "rb") as f:
-            cfg = tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError):
+        cfg = await slot_manager.get_config(_RETIRED_SLOT)
+    except SlotNotFound:
         return False
     model_default = str(((cfg.get("model") or {}).get("default")) or "").strip()
     if model_default:
@@ -53,14 +49,12 @@ def migrate_vision_slot(slots_dir: Path) -> bool:
             model=model_default,
         )
         return False
-    with contextlib.suppress(OSError):
-        cfg_path.unlink()
-        state = slots_dir / _RETIRED_SLOT / "state.json"
-        with contextlib.suppress(OSError):
-            state.unlink()
-        log.info("migrate.vision_slot_retired", slot=_RETIRED_SLOT, path=str(cfg_path))
-        return True
-    return False
+    # force=True: the scaffold can carry a pin on some boxes; the retirement
+    # decision is release-level, not per-box. delete() releases the port
+    # claim, drops the identity row, and removes both keyed artefact forms.
+    await slot_manager.delete(_RETIRED_SLOT, force=True)
+    log.info("migrate.vision_slot_retired", slot=_RETIRED_SLOT)
+    return True
 
 
-__all__ = ["migrate_vision_slot"]
+__all__ = ["retire_vision_scaffold"]

--- a/src/hal0/config/migrations/vision_slot_retirement.py
+++ b/src/hal0/config/migrations/vision_slot_retirement.py
@@ -1,4 +1,4 @@
-"""One-shot boot sweep: retire the legacy ``vision`` scaffold slot.
+"""One-shot boot sweep: retire the pre-1.0 ``vision`` scaffold slot.
 
 The dedicated ``vision`` slot lane is gone — vision is a MODEL property
 (mmproj sidecar, the registry's ``capabilities`` list and ``defaults.vision``

--- a/src/hal0/config/migrations/vision_slot_retirement.py
+++ b/src/hal0/config/migrations/vision_slot_retirement.py
@@ -1,0 +1,66 @@
+"""One-shot boot sweep: retire the legacy ``vision`` scaffold slot.
+
+The dedicated ``vision`` slot lane is gone — vision is a MODEL property
+(mmproj sidecar, the registry's ``capabilities`` list and ``defaults.vision``
+tri-state, surfaced per-slot via ``LoadedSlot.modalities``), served by any
+llm slot whose bound model carries it. The capability orchestrator no longer
+maps a ``vision.vision`` child to a slot, and ``capabilities.toml`` drops a
+stray ``[selections.vision]`` table on load.
+
+This sweep removes the on-disk scaffold slot older installs carry — but ONLY
+the untouched scaffold: a ``vision`` slot with no model bound. A vision slot
+the operator pointed at a model is left alone (it keeps working as a plain
+llm slot under that name; the name is no longer reserved either way).
+
+Idempotent and best-effort: after the first sweep there is nothing left to
+find, and a config-dir problem must not block startup.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import tomllib
+from pathlib import Path
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+_RETIRED_SLOT = "vision"
+
+
+def migrate_vision_slot(slots_dir: Path) -> bool:
+    """Remove an untouched ``vision`` scaffold slot TOML. Returns True if removed.
+
+    Only the name-keyed file is considered: an id-keyed slot went through the
+    identity migration, which means it was live enough to matter — that is
+    operator territory, not scaffold debris.
+    """
+    cfg_path = slots_dir / f"{_RETIRED_SLOT}.toml"
+    if not cfg_path.is_file():
+        return False
+    try:
+        with open(cfg_path, "rb") as f:
+            cfg = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+    model_default = str(((cfg.get("model") or {}).get("default")) or "").strip()
+    if model_default:
+        log.info(
+            "migrate.vision_slot_kept",
+            slot=_RETIRED_SLOT,
+            reason="model bound — operator-owned, retiring only the scaffold",
+            model=model_default,
+        )
+        return False
+    with contextlib.suppress(OSError):
+        cfg_path.unlink()
+        state = slots_dir / _RETIRED_SLOT / "state.json"
+        with contextlib.suppress(OSError):
+            state.unlink()
+        log.info("migrate.vision_slot_retired", slot=_RETIRED_SLOT, path=str(cfg_path))
+        return True
+    return False
+
+
+__all__ = ["migrate_vision_slot"]

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -83,12 +83,16 @@ def seed_static_slots(
     src_dir = installer_root / "installer" / "etc-hal0" / "slots"
     known = set(existing_names)
 
+    tombstoned = read_seed_tombstones(slots_dir=dest_dir)
     seeded: list[str] = []
     for name in STATIC_SEED_SLOTS:
         dest = dest_dir / f"{name}.toml"
         # "Already known" = the identity store tracks it (id-keyed, no
         # <name>.toml) OR a name-keyed file still exists (pre-migration box).
-        if name in known or dest.exists():
+        # A tombstoned name is an operator DELETION — honour it instead of
+        # resurrecting the slot on every boot (the pre-tombstone behaviour
+        # that made seeded slots effectively undeletable).
+        if name in known or name in tombstoned or dest.exists():
             continue
         src = src_dir / f"{name}.toml"
         if not src.is_file():
@@ -102,4 +106,66 @@ def seed_static_slots(
     return seeded
 
 
-__all__ = ["STATIC_SEED_SLOTS", "seed_static_slots"]
+# ── Seed tombstones — "the operator deleted this seed on purpose" ────────────
+#
+# Deleting a slot removes its TOML and identity row, which made a static seed
+# indistinguishable from "new seed this release" on the next boot — the seeding
+# pass re-created it, so a seeded slot could never actually be removed (the
+# delete guard papered over that with a hard refusal). A tombstone records the
+# deletion; creating a slot under the name again (operator create, or the
+# capability orchestrator materialising it on re-enable) clears it.
+
+_TOMBSTONE_FILE = ".seed-tombstones"
+
+
+def _tombstone_path(slots_dir: Path | None = None) -> Path:
+    base = slots_dir if slots_dir is not None else paths.slots_config_dir()
+    return base / _TOMBSTONE_FILE
+
+
+def read_seed_tombstones(*, slots_dir: Path | None = None) -> frozenset[str]:
+    """Names the operator deleted and that seeding must not resurrect."""
+    try:
+        raw = _tombstone_path(slots_dir).read_text()
+    except OSError:
+        return frozenset()
+    return frozenset(line.strip() for line in raw.splitlines() if line.strip())
+
+
+def add_seed_tombstone(name: str, *, slots_dir: Path | None = None) -> None:
+    """Record that seed ``name`` was deliberately deleted (idempotent)."""
+    current = set(read_seed_tombstones(slots_dir=slots_dir))
+    if name in current:
+        return
+    current.add(name)
+    path = _tombstone_path(slots_dir)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(f"{n}\n" for n in sorted(current)))
+    except OSError as exc:  # read-only config dir — deletion still proceeds
+        log.warning("install.seed_tombstone_write_failed", slot=name, error=str(exc))
+
+
+def clear_seed_tombstone(name: str, *, slots_dir: Path | None = None) -> None:
+    """Forget a deletion — the slot exists again under this name (idempotent)."""
+    current = set(read_seed_tombstones(slots_dir=slots_dir))
+    if name not in current:
+        return
+    current.discard(name)
+    path = _tombstone_path(slots_dir)
+    try:
+        if current:
+            path.write_text("".join(f"{n}\n" for n in sorted(current)))
+        else:
+            path.unlink(missing_ok=True)
+    except OSError as exc:  # pragma: no cover — defensive
+        log.warning("install.seed_tombstone_clear_failed", slot=name, error=str(exc))
+
+
+__all__ = [
+    "STATIC_SEED_SLOTS",
+    "add_seed_tombstone",
+    "clear_seed_tombstone",
+    "read_seed_tombstones",
+    "seed_static_slots",
+]

--- a/src/hal0/install/static_seeds.py
+++ b/src/hal0/install/static_seeds.py
@@ -133,33 +133,44 @@ def read_seed_tombstones(*, slots_dir: Path | None = None) -> frozenset[str]:
 
 
 def add_seed_tombstone(name: str, *, slots_dir: Path | None = None) -> None:
-    """Record that seed ``name`` was deliberately deleted (idempotent)."""
-    current = set(read_seed_tombstones(slots_dir=slots_dir))
-    if name in current:
-        return
-    current.add(name)
-    path = _tombstone_path(slots_dir)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("".join(f"{n}\n" for n in sorted(current)))
-    except OSError as exc:  # read-only config dir — deletion still proceeds
-        log.warning("install.seed_tombstone_write_failed", slot=name, error=str(exc))
+    """Record that seed ``name`` was deliberately deleted (idempotent).
+
+    Read-modify-write under the cross-process slot-TOML lock: two concurrent
+    deletes (CLI + API) each rewriting the whole file would otherwise lose one
+    entry and the lost deletion resurrects on the next seeding pass.
+    """
+    from hal0.slot_config import slot_write_lock
+
+    with slot_write_lock():
+        current = set(read_seed_tombstones(slots_dir=slots_dir))
+        if name in current:
+            return
+        current.add(name)
+        path = _tombstone_path(slots_dir)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("".join(f"{n}\n" for n in sorted(current)))
+        except OSError as exc:  # read-only config dir — deletion still proceeds
+            log.warning("install.seed_tombstone_write_failed", slot=name, error=str(exc))
 
 
 def clear_seed_tombstone(name: str, *, slots_dir: Path | None = None) -> None:
     """Forget a deletion — the slot exists again under this name (idempotent)."""
-    current = set(read_seed_tombstones(slots_dir=slots_dir))
-    if name not in current:
-        return
-    current.discard(name)
-    path = _tombstone_path(slots_dir)
-    try:
-        if current:
-            path.write_text("".join(f"{n}\n" for n in sorted(current)))
-        else:
-            path.unlink(missing_ok=True)
-    except OSError as exc:  # pragma: no cover — defensive
-        log.warning("install.seed_tombstone_clear_failed", slot=name, error=str(exc))
+    from hal0.slot_config import slot_write_lock
+
+    with slot_write_lock():
+        current = set(read_seed_tombstones(slots_dir=slots_dir))
+        if name not in current:
+            return
+        current.discard(name)
+        path = _tombstone_path(slots_dir)
+        try:
+            if current:
+                path.write_text("".join(f"{n}\n" for n in sorted(current)))
+            else:
+                path.unlink(missing_ok=True)
+        except OSError as exc:  # pragma: no cover — defensive
+            log.warning("install.seed_tombstone_clear_failed", slot=name, error=str(exc))
 
 
 __all__ = [

--- a/src/hal0/registry/tag_retirement.py
+++ b/src/hal0/registry/tag_retirement.py
@@ -8,12 +8,17 @@ drove behaviour into their typed homes and strips all six:
 
 * ``mtp`` → ``defaults.mtp = True`` (absent-only — an explicit operator
   False stays False; ``model_is_mtp_eligible`` prefers the typed field).
-* ``vision`` → ensure ``"vision"`` is in the ``capabilities`` list (the
-  fact-derived surface model pickers and ``LoadedSlot.modalities`` read).
-* ``moe``/``tool-calling``/``reasoning``/``coder`` → dropped; their typed
-  owners (``Model.architecture``, ``capability_flags.tool_calling``,
-  ``defaults.enable_thinking``, the capabilities list) are populated by
-  detection/curation, not by tags.
+* ``vision`` → folded into the ``capabilities`` list ONLY when the row
+  carries an mmproj sidecar — a vision capability with no projector is a
+  lie the modality derivation would immediately contradict; a projector-
+  less ``vision`` tag is dropped (the tag never made the model multimodal).
+* ``moe`` → stripped only when ``Model.architecture`` is set (the typed
+  MoE signal); with no architecture the tag is the row's only MoE marker,
+  so it stays until a scan/detect fills the typed field.
+* ``coder`` → KEPT — the bench roster selector matches it as a descriptive
+  label (tags are inert for routing either way).
+* ``tool-calling``/``reasoning`` → dropped; ``capability_flags.
+  tool_calling`` and ``defaults.enable_thinking`` own those behaviours.
 
 Curated CATALOGUE entries (registry/curated.py) keep their descriptive tags —
 this sweep touches only registry rows. Idempotent and best-effort: a store
@@ -28,10 +33,13 @@ import structlog
 
 log = structlog.get_logger(__name__)
 
-#: The retired behaviour tags, lowercase.
-RETIRED_TYPE_TAGS: frozenset[str] = frozenset(
-    {"mtp", "moe", "tool-calling", "reasoning", "coder", "vision"}
-)
+#: Tags stripped unconditionally once folded, lowercase. ``moe`` and
+#: ``vision`` strip conditionally (see module docstring); ``coder`` is kept
+#: as a descriptive label the bench roster selector matches.
+RETIRED_TYPE_TAGS: frozenset[str] = frozenset({"mtp", "tool-calling", "reasoning"})
+
+#: Conditionally-stripped tags — see the per-tag rules in the sweep body.
+CONDITIONAL_TYPE_TAGS: frozenset[str] = frozenset({"moe", "vision"})
 
 
 def retire_model_type_tags(registry: Any) -> list[str]:
@@ -48,12 +56,22 @@ def retire_model_type_tags(registry: Any) -> list[str]:
         try:
             tags = list(getattr(row, "tags", None) or [])
             lowered = {str(t).lower() for t in tags}
-            hit = lowered & RETIRED_TYPE_TAGS
+            hit = lowered & (RETIRED_TYPE_TAGS | CONDITIONAL_TYPE_TAGS)
             if not hit:
                 continue
-            updates: dict[str, Any] = {
-                "tags": [t for t in tags if str(t).lower() not in RETIRED_TYPE_TAGS]
-            }
+            strip = set(RETIRED_TYPE_TAGS)
+            # ``moe`` strips only when the typed MoE signal exists.
+            if "moe" in hit and str(getattr(row, "architecture", "") or "").strip():
+                strip.add("moe")
+            # ``vision`` folds into capabilities only alongside an mmproj
+            # sidecar; either way the tag itself strips (it drove nothing).
+            has_mmproj = bool(str(getattr(row, "mmproj", "") or "").strip())
+            if "vision" in hit:
+                strip.add("vision")
+            new_tags = [t for t in tags if str(t).lower() not in strip]
+            if new_tags == tags and not (hit & strip):
+                continue  # nothing strippable this pass (e.g. lone un-typed moe)
+            updates: dict[str, Any] = {"tags": new_tags}
             defaults = getattr(row, "defaults", None)
             if "mtp" in hit and (defaults is None or defaults.mtp is None):
                 updates["defaults"] = (
@@ -61,13 +79,13 @@ def retire_model_type_tags(registry: Any) -> list[str]:
                     if defaults is not None
                     else ModelDefaults(mtp=True)
                 )
-            if "vision" in hit:
+            if "vision" in hit and has_mmproj:
                 caps = list(getattr(row, "capabilities", None) or [])
                 if "vision" not in {str(c).lower() for c in caps}:
                     updates["capabilities"] = [*caps, "vision"]
             registry.update(row.id, updates)
             changed.append(row.id)
-            log.info("registry.type_tags_retired", model=row.id, folded=sorted(hit))
+            log.info("registry.type_tags_retired", model=row.id, folded=sorted(hit & strip))
         except Exception as exc:  # pragma: no cover — best-effort per row
             log.warning(
                 "registry.tag_retirement_row_failed",
@@ -77,4 +95,4 @@ def retire_model_type_tags(registry: Any) -> list[str]:
     return changed
 
 
-__all__ = ["RETIRED_TYPE_TAGS", "retire_model_type_tags"]
+__all__ = ["CONDITIONAL_TYPE_TAGS", "RETIRED_TYPE_TAGS", "retire_model_type_tags"]

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2396,10 +2396,28 @@ class SlotManager:
         # Deleting a static seed leaves a tombstone so the boot-time seeding
         # pass honours the deletion (it would otherwise re-copy the seed TOML
         # on the next start — the old "undeletable seeded slot" behaviour).
-        if slot_name in self.seeded_slots():
-            from hal0.install.static_seeds import add_seed_tombstone
+        # STATIC seeds only: the NPU trio (flm-stt/flm-embed) is reconciled
+        # from the anchor by reconcile_trio_slots, which does not consult
+        # tombstones — a trio deletion is ephemeral by contract.
+        from hal0.install.static_seeds import STATIC_SEED_SLOTS, add_seed_tombstone
 
+        if slot_name in STATIC_SEED_SLOTS:
             add_seed_tombstone(slot_name)
+
+        # Reconcile capability intent: a deleted capability slot must not
+        # leave its capabilities.toml selection enabled — the orchestrator
+        # would treat the file as converged and never recreate the slot,
+        # while the dashboard shows the capability "on" with nothing behind
+        # it. Best-effort; re-enabling in settings recreates the slot.
+        try:
+            from hal0.capabilities.orchestrator import disable_selections_for_slot
+
+            disable_selections_for_slot(slot_name)
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(
+                "slot.capability_selection_release_failed",
+                extra={"slot": slot_name, "error": str(exc)},
+            )
 
     async def update_config(
         self,

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2321,36 +2321,38 @@ class SlotManager:
                 },
                 force=True,
             )
+        # The name exists again — a deleted-seed tombstone (if any) is now
+        # stale; forget it so future seeding decisions see current intent.
+        from hal0.install.static_seeds import clear_seed_tombstone
+
+        clear_seed_tombstone(slot_name)
         return await self.status(slot_name)
 
     async def delete(self, slot_name: str, *, force: bool = False) -> None:
-        """Delete a slot. Seeded + pinned slots are protected unless ``force=True``.
+        """Delete a slot. Only a pinned slot is protected (without ``force``).
 
-        A seeded slot (``primary`` / ``embed`` / … + the NPU trio) is normally
-        undeletable — disable it via ``capabilities.toml`` instead. ``force``
-        overrides that guard so an operator can remove a seeded slot outright;
-        note an install/update reconcile may re-seed it later, and the name stays
-        reserved (``create`` still rejects it) until then.
+        Seeded slots are deletable like any other: capability slots are
+        recreated on demand when their capability is re-enabled in settings
+        (the orchestrator's ``_ensure_slot_exists``), and deleting a static
+        seed writes a tombstone (:mod:`hal0.install.static_seeds`) so the
+        boot-time seeding pass honours the deletion instead of resurrecting
+        the slot. Recreating the name clears the tombstone.
 
         §21.10 operator-pin hardening: a pinned slot (default-pinned anchor
-        or ``SlotConfig.pinned = true``) is likewise refused without
-        ``force=True`` — HTTP 409 ``slot.pinned`` — so an accidental delete
-        can't take down an always-warm anchor.
+        or ``SlotConfig.pinned = true``) is refused without ``force=True`` —
+        HTTP 409 ``slot.pinned`` — so an accidental delete can't take down
+        an always-warm anchor.
         """
         slot_name = self._resolve_alias(slot_name)
-        if not force:
-            if slot_name in self.seeded_slots():
-                raise SlotConfigError(
-                    f"cannot delete seeded slot {slot_name!r} — disable it via "
-                    "capabilities.toml, or pass force to delete it anyway",
-                    details={"slot": slot_name, "seeded": True},
-                )
-            if await self.is_pinned(slot_name):
-                raise SlotPinned(
-                    f"slot {slot_name!r} is pinned — pass force=true to delete it anyway",
-                    details={"slot": slot_name, "pinned": True},
-                )
+        # Existence first: deleting an unknown slot is a 404, not a pinned
+        # 409 (the default-pinned anchor names would otherwise 409 even when
+        # no such slot exists on disk).
         self._ensure_known(slot_name)
+        if not force and await self.is_pinned(slot_name):
+            raise SlotPinned(
+                f"slot {slot_name!r} is pinned — pass force=true to delete it anyway",
+                details={"slot": slot_name, "pinned": True},
+            )
         # Make sure it's stopped first.
         current = self._current_state(slot_name)
         if current != SlotState.OFFLINE:
@@ -2390,6 +2392,14 @@ class SlotManager:
             self._last_used.pop(key, None)
             self._cfg_cache.pop(key, None)
         self._forget_key(slot_name)
+
+        # Deleting a static seed leaves a tombstone so the boot-time seeding
+        # pass honours the deletion (it would otherwise re-copy the seed TOML
+        # on the next start — the old "undeletable seeded slot" behaviour).
+        if slot_name in self.seeded_slots():
+            from hal0.install.static_seeds import add_seed_tombstone
+
+            add_seed_tombstone(slot_name)
 
     async def update_config(
         self,

--- a/src/hal0/slots/routing.py
+++ b/src/hal0/slots/routing.py
@@ -35,25 +35,25 @@ log = logging.getLogger(__name__)
 
 # ── Seeded slot catalogue (PR-10, plan §4.2 + §10.2) ────────────────────────
 
-#: Slots that exist on every hal0 install regardless of hardware. The
-#: dashboard creates these as empty cards at first run; the bundle
-#: picker (Phase 5) populates their ``model.default`` fields. ``agent``
-#: is the GPU MoE chat-role sibling of ``chat`` (moved here from the NPU
-#: set in #679 — it is a GPU slot, not the NPU FLM anchor).
+#: Slots with a static install seed — SINGLE-SOURCED from
+#: :data:`hal0.install.static_seeds.STATIC_SEED_SLOTS` (which itself mirrors
+#: install.sh's seed loop). This list previously hand-duplicated the seed set
+#: and drifted badly: it still carried the retired ``stt``/``vision`` scaffold
+#: names (protected-but-never-seeded — the un-deletable ghost-slot bug) while
+#: missing ``brain``/``coder``/``flm``/``qwen3tts`` (seeded-but-unprotected).
+#:
+#: Membership no longer implies delete-protection or name reservation:
+#: capability slots are created ON DEMAND when their capability is enabled in
+#: settings (:meth:`hal0.capabilities.orchestrator.CapabilityOrchestrator.
+#: _ensure_slot_exists`), any slot is deletable (``pinned`` is the protection
+#: lever, §21.10), and a deleted seed leaves a tombstone so boot-time seeding
+#: doesn't resurrect it (:mod:`hal0.install.static_seeds`). The list now only
+#: feeds identity metadata (``is_seed``) and the seeding pass itself.
 # ADR-0023: `utility` (cheap helper) + `agent` (capable/default anchor) are the two
 # canonical llm seeds. `chat` is retired as a slot/role name (the `chat` *capability*
 # is unaffected; any llm slot serves it). `utility` is seeded so the memory
 # extraction target is always present on a fresh box.
-SEEDED_SLOTS: tuple[str, ...] = (
-    "utility",
-    "embed",
-    "rerank",
-    "stt",
-    "tts",
-    "img",
-    "vision",
-    "agent",
-)
+from hal0.install.static_seeds import STATIC_SEED_SLOTS as SEEDED_SLOTS  # noqa: E402
 
 #: NPU FLM shadow slots seeded only when the FastFlowLM ``.deb`` is
 #: installed (``shutil.which('flm')`` truthy): the ASR + embed tags that
@@ -432,13 +432,16 @@ async def add_slot(
             f"start with alphanumeric; max 32 chars",
             details={"slot": name},
         )
-    # Reject collisions with ALL seeded slots (include the NPU trio
-    # regardless of FLM presence — the names are reserved).
-    reserved = set(SEEDED_SLOTS) | set(NPU_SEEDED_SLOTS)
-    if name in reserved:
+    # Only the NPU trio names stay reserved: the occupancy pane SYNTHESISES
+    # ``flm-stt``/``flm-embed`` virtual sub-cards from the anchor slot, so a
+    # real slot under either name would collide with the synthesis. Seed
+    # names are NOT reserved any more — a deleted seed is recreatable (the
+    # collision-with-an-existing-slot case is host.create's own check), and
+    # recreation clears its seed tombstone in SlotManager.create.
+    if name in NPU_SEEDED_SLOTS:
         raise SlotConfigError(
-            f"slot {name!r} collides with a seeded slot; pick a different name",
-            details={"slot": name, "reserved": sorted(reserved)},
+            f"slot {name!r} collides with a synthesised NPU sub-card name; pick a different name",
+            details={"slot": name, "reserved": sorted(NPU_SEEDED_SLOTS)},
         )
     if type not in _VALID_SLOT_TYPES:
         raise SlotConfigError(
@@ -476,18 +479,13 @@ async def add_slot(
 async def remove_slot(host: RoutingHost, name: str) -> None:
     """Programmatic ``hal0 slot remove`` (plan §4.3).
 
-    Rejects seeded-slot names (use :meth:`SlotManager.unload` or
-    ``capabilities.toml`` to disable a seeded slot, not delete it).
-    No side effect on the underlying model files — they stay in
-    the registry.
+    Any slot is removable — capability slots are recreated on demand when
+    their capability is re-enabled in settings, and a removed static seed
+    leaves a tombstone so boot-time seeding honours the deletion. A pinned
+    slot still refuses without force (SlotManager.delete, §21.10). No side
+    effect on the underlying model files — they stay in the registry.
     """
     name = host._resolve_alias(name)
-    reserved = set(SEEDED_SLOTS) | set(NPU_SEEDED_SLOTS)
-    if name in reserved:
-        raise SlotConfigError(
-            f"slot {name!r} is seeded; cannot remove (disable it via capabilities.toml)",
-            details={"slot": name, "reserved": sorted(reserved)},
-        )
     await host.delete(name)
 
 

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -100,6 +100,10 @@ _CHILD_TO_GROUP: dict[str, str] = {
     "tts": "voice",
     "img": "img",
 }
+#: Capability children retired from the slot-lane surface entirely — rows in
+#: saved stacks that predate the retirement are skipped, not errored.
+_RETIRED_CHILDREN: frozenset[str] = frozenset({"vision"})
+
 _CHILD_TO_SLOT_NAME: dict[str, str] = {
     "embed": "embed",
     "rerank": "embed-rerank",
@@ -477,6 +481,12 @@ class StackApplyEngine:
                 group = _CHILD_TO_GROUP.get(row.child)
                 slot_name = _CHILD_TO_SLOT_NAME.get(row.child)
                 if group is None or slot_name is None:
+                    if row.child in _RETIRED_CHILDREN:
+                        # A stack saved before the lane was retired — skip
+                        # quietly rather than failing the whole convergence
+                        # (vision is a model property now, not a slot lane).
+                        log.info("stack.retired_capability_child_skipped child=%s", row.child)
+                        continue
                     report.errors.append((f"capability:{row.child}", "unknown capability child"))
                     continue
                 touched.add(slot_name)

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -7,7 +7,7 @@ spanning every touched file, then commit it through the verified
 backs the dashboard's dry-run diff preview.
 
 Out of scope here (PR-2b): slot lifecycle convergence (load/swap/unload) and
-capability-child (embed/stt/tts/rerank/vision) routing through the
+capability-child (embed/stt/tts/rerank) routing through the
 CapabilityOrchestrator.
 """
 
@@ -99,7 +99,6 @@ _CHILD_TO_GROUP: dict[str, str] = {
     "stt": "voice",
     "tts": "voice",
     "img": "img",
-    "vision": "vision",
 }
 _CHILD_TO_SLOT_NAME: dict[str, str] = {
     "embed": "embed",
@@ -107,7 +106,6 @@ _CHILD_TO_SLOT_NAME: dict[str, str] = {
     "stt": "stt",
     "tts": "tts",
     "img": "img",
-    "vision": "vision",
 }
 
 

--- a/tests/capabilities/test_vision_curation.py
+++ b/tests/capabilities/test_vision_curation.py
@@ -1,44 +1,71 @@
-"""Vision capability surfacing (#515).
+"""Vision is a MODEL property, not a slot lane (vision-slot retirement).
 
-hal0 gains a first-class ``vision`` capability. Rather than introducing a
-brand-new model download, the vision slot REUSES the curated multimodal
-MoE primaries that PR #500 already reconciled into ``curated.py``:
-``Qwen3.6-35B-A3B-MTP-GGUF`` and ``Qwen3.6-27B-MTP-GGUF`` both carry the
-``vision`` tag and ship a stock mmproj sidecar, so a vision slot
-can load them straight from the bundled catalogue.
-
-These tests pin three things:
-  - the ``vision`` capability/child is a recognized slot + child, and
-  - ``models_for_capability("vision")`` surfaces a multimodal model even
-    though those entries are otherwise ``bundle_only``.
+The dedicated ``vision`` slot lane (#515) is retired: vision is served by any
+llm slot whose bound model carries it (mmproj sidecar, the registry's
+``capabilities`` list / ``defaults.vision`` tri-state, surfaced per-slot via
+``LoadedSlot.modalities``). These tests pin the retirement — no seeded vision
+slot, no ``vision.vision`` capability child — while the MODEL-side vision
+surfacing (``models_for_capability("vision")``, curated tags) stays intact
+for model pickers.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from hal0.capabilities import orchestrator as orch
 from hal0.capabilities.catalog import models_for_capability
 from hal0.registry.curated import CURATED_BY_ID
 from hal0.slots.manager import SEEDED_SLOTS
 
-# The curated multimodal MoE primaries the vision slot reuses.
+# The curated multimodal MoE primaries that carry the vision tag.
 _VISION_MODELS = ("Qwen3.6-35B-A3B-MTP-GGUF", "Qwen3.6-27B-MTP-GGUF")
 
 
-def test_vision_slot_is_seeded() -> None:
-    assert "vision" in SEEDED_SLOTS
+def test_vision_slot_is_not_seeded() -> None:
+    assert "vision" not in SEEDED_SLOTS
 
 
-def test_vision_child_is_recognized() -> None:
-    # The (slot, child) tuple resolves to an underlying slot name.
-    assert ("vision", "vision") in orch._CHILD_TO_SLOT
-    assert orch.child_to_slot("vision", "vision") == "vision"
-    # And the capability slot is legal for HTTP validation.
-    assert "vision" in orch.LEGAL_SLOTS
-    assert orch.legal_children("vision") == ["vision"]
+def test_vision_child_is_retired() -> None:
+    assert ("vision", "vision") not in orch._CHILD_TO_SLOT
+    assert "vision" not in orch.LEGAL_SLOTS
+    assert ("vision", "vision") not in orch._CHILD_TO_CAPABILITY
+    with pytest.raises(Exception, match="unknown capability child"):
+        orch.child_to_slot("vision", "vision")
 
 
-def test_vision_child_maps_to_vision_capability() -> None:
-    assert orch._CHILD_TO_CAPABILITY[("vision", "vision")] == "vision"
+def test_capabilities_toml_drops_stray_vision_selection(tmp_path) -> None:
+    # An older install's [selections.vision] table is dropped on load — the
+    # retired lane must not resurrect through a stale file.
+    from hal0.capabilities.config import load_capabilities_config
+
+    p = tmp_path / "capabilities.toml"
+    p.write_text(
+        "schema_version = 2\n"
+        '[selections.vision.vision]\nmodel = "some-mm-model"\ndevice = "gpu-vulkan"\n'
+        '[selections.img.img]\nmodel = ""\ndevice = "gpu-rocm"\n'
+    )
+    cfg = load_capabilities_config(p)
+    assert "vision" not in cfg.selections
+    assert "img" in cfg.selections
+
+
+def test_vision_scaffold_slot_migration(tmp_path) -> None:
+    from hal0.config.migrations.vision_slot_retirement import migrate_vision_slot
+
+    # Untouched scaffold (no model bound) → removed.
+    (tmp_path / "vision.toml").write_text('name = "vision"\nport = 8093\n[model]\ndefault = ""\n')
+    assert migrate_vision_slot(tmp_path) is True
+    assert not (tmp_path / "vision.toml").exists()
+    # Idempotent.
+    assert migrate_vision_slot(tmp_path) is False
+    # Operator-owned (model bound) → kept.
+    (tmp_path / "vision.toml").write_text('name = "vision"\nport = 8093\n[model]\ndefault = "mm"\n')
+    assert migrate_vision_slot(tmp_path) is False
+    assert (tmp_path / "vision.toml").exists()
+
+
+# ── Model-side vision surfacing stays intact ────────────────────────────────
 
 
 def test_curated_vision_models_carry_vision_tag() -> None:

--- a/tests/capabilities/test_vision_curation.py
+++ b/tests/capabilities/test_vision_curation.py
@@ -50,19 +50,40 @@ def test_capabilities_toml_drops_stray_vision_selection(tmp_path) -> None:
     assert "img" in cfg.selections
 
 
-def test_vision_scaffold_slot_migration(tmp_path) -> None:
-    from hal0.config.migrations.vision_slot_retirement import migrate_vision_slot
+def test_vision_scaffold_retirement_goes_through_the_manager() -> None:
+    """The scaffold retires via SlotManager.delete (identity/port/state go
+    with the TOML); a model-bound vision slot is operator-owned and kept."""
+    import asyncio
 
-    # Untouched scaffold (no model bound) → removed.
-    (tmp_path / "vision.toml").write_text('name = "vision"\nport = 8093\n[model]\ndefault = ""\n')
-    assert migrate_vision_slot(tmp_path) is True
-    assert not (tmp_path / "vision.toml").exists()
-    # Idempotent.
-    assert migrate_vision_slot(tmp_path) is False
-    # Operator-owned (model bound) → kept.
-    (tmp_path / "vision.toml").write_text('name = "vision"\nport = 8093\n[model]\ndefault = "mm"\n')
-    assert migrate_vision_slot(tmp_path) is False
-    assert (tmp_path / "vision.toml").exists()
+    from hal0.config.migrations.vision_slot_retirement import retire_vision_scaffold
+    from hal0.slots.state import SlotNotFound
+
+    class _FakeManager:
+        def __init__(self, cfg):
+            self._cfg = cfg
+            self.deleted: list[tuple[str, bool]] = []
+
+        async def get_config(self, name):
+            if self._cfg is None:
+                raise SlotNotFound(name)
+            return self._cfg
+
+        async def delete(self, name, *, force=False):
+            self.deleted.append((name, force))
+
+    # Untouched scaffold → deleted with force (pin-proof).
+    mgr = _FakeManager({"name": "vision", "model": {"default": ""}})
+    assert asyncio.run(retire_vision_scaffold(mgr)) is True
+    assert mgr.deleted == [("vision", True)]
+
+    # Model bound → operator-owned, kept.
+    mgr = _FakeManager({"name": "vision", "model": {"default": "mm"}})
+    assert asyncio.run(retire_vision_scaffold(mgr)) is False
+    assert mgr.deleted == []
+
+    # No slot at all → idempotent no-op.
+    mgr = _FakeManager(None)
+    assert asyncio.run(retire_vision_scaffold(mgr)) is False
 
 
 # ── Model-side vision surfacing stays intact ────────────────────────────────

--- a/tests/cli/test_setup_command.py
+++ b/tests/cli/test_setup_command.py
@@ -46,7 +46,10 @@ def test_auto_selections_scaffolds_capability_slots_empty():
     # model is chosen — pick-free: slots yes, models no. The chat capability's
     # slot is NAMED `agent` (ADR-0023 LLM anchor) and the steward's `brain`
     # scaffold rides along.
-    assert {"agent", "brain", "embed", "rerank", "stt", "tts", "vision"} <= names
+    # vision is retired — a model property served by any llm slot, no
+    # dedicated scaffold.
+    assert {"agent", "brain", "embed", "rerank", "stt", "tts"} <= names
+    assert "vision" not in names
     assert all(s.model_id is None for s in sel.slots)  # every slot empty
     assert sel.extensions["openwebui"] is True
     assert sel.extensions["hermes"] is True

--- a/tests/install/test_curated_seed_wins.py
+++ b/tests/install/test_curated_seed_wins.py
@@ -143,15 +143,18 @@ def test_scaffolding_first_destroys_the_curated_config(hal0_home: Path, slot_nam
 def test_scaffold_still_creates_slots_that_have_no_static_seed(hal0_home: Path) -> None:
     """Seeding first must not disable the scaffold pass.
 
-    ``vision`` has no file in ``installer/etc-hal0/slots/``, so the scaffold is
-    the only thing that can create it. If the ordering fix accidentally short-
-    circuited the whole pass, this is what would silently go missing.
+    ``vision`` used to be the unconditional seed-less scaffold this test
+    pinned; its lane is retired (vision is a model property served by any
+    llm slot) and the one other seed-less capability, ``stt``, is hardware-
+    gated. So the pin inverts: the scaffold pass must complete WITHOUT
+    creating the retired lane, while the curated seeds all still land.
     """
     _copy_curated_seeds(hal0_home)
     _run_scaffold_pass(hal0_home)
-    assert not (_SEEDS_DIR / "vision.toml").exists(), (
-        "vision now has a static seed — pick a different scaffold-only slot here"
+    # The retired vision lane must NOT come back through setup.
+    assert not (hal0_home / "etc" / "hal0" / "slots" / "vision.toml").exists(), (
+        "setup recreated the retired vision scaffold slot"
     )
-    assert (hal0_home / "etc" / "hal0" / "slots" / "vision.toml").exists(), (
-        "the scaffold pass no longer creates seed-less capability slots"
-    )
+    # And the pass as a whole still ran — every curated seed is present.
+    for name in _CURATED_EXPECTATIONS:
+        assert (hal0_home / "etc" / "hal0" / "slots" / f"{name}.toml").exists()

--- a/tests/registry/test_tag_retirement.py
+++ b/tests/registry/test_tag_retirement.py
@@ -1,8 +1,10 @@
 """The retired "type" tags fold into typed fields and strip from registry rows.
 
 Pins hal0.registry.tag_retirement: ``mtp`` folds to ``defaults.mtp`` (absent-
-only), ``vision`` folds into the capabilities list, all six behaviour tags
-strip, descriptive tags survive, and the sweep is idempotent.
+only), ``vision`` folds into the capabilities list only alongside an mmproj
+sidecar, ``moe`` strips only once ``architecture`` carries the typed signal,
+``coder`` is kept as a descriptive label (bench roster matcher), and the
+sweep is idempotent.
 """
 
 from __future__ import annotations
@@ -39,9 +41,15 @@ def test_operator_mtp_false_survives_the_fold(tmp_hal0_home: str) -> None:
     assert row.tags == []
 
 
-def test_vision_tag_folds_into_capabilities(tmp_hal0_home: str) -> None:
+def test_vision_tag_folds_into_capabilities_with_mmproj(tmp_hal0_home: str) -> None:
     registry = ModelRegistry()
-    _add(registry, "m1", tags=["vision", "frontier"], capabilities=["chat"])
+    _add(
+        registry,
+        "m1",
+        tags=["vision", "frontier"],
+        capabilities=["chat"],
+        mmproj="/m/mmproj.gguf",
+    )
 
     retire_model_type_tags(registry)
 
@@ -50,13 +58,45 @@ def test_vision_tag_folds_into_capabilities(tmp_hal0_home: str) -> None:
     assert row.tags == ["frontier"]
 
 
-def test_all_six_behaviour_tags_strip(tmp_hal0_home: str) -> None:
+def test_vision_tag_without_mmproj_strips_without_folding(tmp_hal0_home: str) -> None:
+    # A projector-less "vision" tag never made the model multimodal — folding
+    # it into capabilities would advertise vision the modality derivation
+    # immediately contradicts. Strip only.
     registry = ModelRegistry()
-    _add(
-        registry,
-        "m1",
-        tags=["mtp", "moe", "tool-calling", "reasoning", "coder", "vision", "user-added"],
-    )
+    _add(registry, "m1", tags=["vision"], capabilities=["chat"])
+
+    retire_model_type_tags(registry)
+
+    row = registry.get("m1")
+    assert "vision" not in row.capabilities
+    assert row.tags == []
+
+
+def test_moe_tag_kept_until_architecture_is_typed(tmp_hal0_home: str) -> None:
+    registry = ModelRegistry()
+    _add(registry, "untyped", tags=["moe"])
+    _add(registry, "typed", tags=["moe"], architecture="qwen35moe")
+
+    retire_model_type_tags(registry)
+
+    # No architecture → the tag is the only MoE marker; it stays.
+    assert registry.get("untyped").tags == ["moe"]
+    # Typed signal present → the tag is redundant; it strips.
+    assert registry.get("typed").tags == []
+
+
+def test_coder_tag_is_kept_as_descriptive(tmp_hal0_home: str) -> None:
+    registry = ModelRegistry()
+    _add(registry, "m1", tags=["coder", "reasoning"])
+
+    retire_model_type_tags(registry)
+
+    assert registry.get("m1").tags == ["coder"]
+
+
+def test_unconditional_tags_strip(tmp_hal0_home: str) -> None:
+    registry = ModelRegistry()
+    _add(registry, "m1", tags=["mtp", "tool-calling", "reasoning", "user-added"])
 
     retire_model_type_tags(registry)
 

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -53,11 +53,17 @@ def _no_spawn_context_refresh(monkeypatch):
 # ── SEEDED_SLOTS + NPU_SEEDED_SLOTS (PR-10 §10.2) ───────────────────────────
 
 
-def test_seeded_slots_matches_plan_section_10_2() -> None:
-    # ``vision`` added in #515 (first-class vision capability, reusing the
-    # curated multimodal MoE primaries + their mmproj sidecar).
-    # ADR-0023: ``chat`` retired as a seed; ``utility`` (cheap helper) added.
-    assert SEEDED_SLOTS == ("utility", "embed", "rerank", "stt", "tts", "img", "vision", "agent")
+def test_seeded_slots_is_single_sourced_from_static_seeds() -> None:
+    # SEEDED_SLOTS previously hand-duplicated the install seed set and drifted
+    # (it carried the retired ``stt``/``vision`` scaffolds while missing
+    # ``brain``/``coder``/``flm``/``qwen3tts``). It is now a re-export of
+    # STATIC_SEED_SLOTS — one source of truth, no drift possible.
+    from hal0.install.static_seeds import STATIC_SEED_SLOTS
+
+    assert SEEDED_SLOTS is STATIC_SEED_SLOTS
+    assert "vision" not in SEEDED_SLOTS
+    assert "stt" not in SEEDED_SLOTS
+    assert "brain" in SEEDED_SLOTS
 
 
 def test_npu_seeded_slots_matches_plan_section_10_2() -> None:
@@ -220,37 +226,54 @@ async def test_add_slot_writes_toml(
     assert 'default = "whisper-base"' in text
 
 
-async def test_add_slot_rejects_seeded_collision(tmp_hal0_home: str) -> None:
+async def test_add_slot_allows_recreating_a_seed_name(tmp_hal0_home: str) -> None:
+    # Seed names are no longer reserved — a deleted seed must be recreatable
+    # (capability slots materialise on demand when re-enabled in settings).
     sm = SlotManager()
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.add_slot("utility", type="llm", model="x", port=8090)
+    slot = await sm.add_slot("utility", type="llm", model="x", port=8090)
+    assert slot.name == "utility"
 
 
 async def test_add_slot_rejects_npu_seeded_collision(tmp_hal0_home: str) -> None:
-    # Reserved even when FLM isn't installed.
+    # The NPU trio names stay reserved even when FLM isn't installed — the
+    # occupancy pane synthesises flm-stt/flm-embed virtual sub-cards, so a
+    # real slot under either name would collide with the synthesis.
     sm = SlotManager()
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.add_slot("agent", type="llm", model="x", port=8090)
+    with pytest.raises(SlotConfigError, match="NPU"):
+        await sm.add_slot("flm-stt", type="transcription", model="x", port=8090)
 
 
-async def test_agent_slot_non_deletable_without_flm(
+async def test_seeded_slot_deletable_without_force(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # #679: agent is a GPU seed slot, so it is non-deletable regardless of FLM.
-    # Regression guard — while agent was NPU-seeded, delete protection vanished
-    # on non-FLM boxes (seeded_slots() excludes the NPU trio without flm).
+    # Seeded slots are deletable like any other (pinned is the protection
+    # lever) — and the deletion writes a tombstone so the boot-time seeding
+    # pass doesn't resurrect the slot. ``tts`` is a seed but not a
+    # default-pinned anchor.
     monkeypatch.setattr("hal0.slots.routing.shutil.which", lambda name: None)
     sm = SlotManager()
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.delete("agent")
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "tts.toml").write_text(
+        'name = "tts"\nport = 8084\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
+    )
+    await sm.delete("tts")
+    assert not (slots_dir / "tts.toml").exists()
+
+    from hal0.install.static_seeds import read_seed_tombstones, seed_static_slots
+
+    assert "tts" in read_seed_tombstones()
+    # The seeding pass honours the tombstone instead of re-copying the seed.
+    seeded = seed_static_slots()
+    assert "tts" not in seeded
+    assert not (slots_dir / "tts.toml").exists()
 
 
-async def test_seeded_slot_deletable_with_force(
+async def test_default_pinned_anchor_still_refuses_without_force(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # force=True overrides the seeded-slot guard so an operator can remove one
-    # outright. Seed the config on disk, confirm the guard still refuses without
-    # force, then force-delete it.
+    # The anchor protection moved wholly onto the pinned lever (§21.10):
+    # agent is default-pinned, so a bare delete 409s and force succeeds.
     monkeypatch.setattr("hal0.slots.routing.shutil.which", lambda name: None)
     sm = SlotManager()
     slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
@@ -258,10 +281,31 @@ async def test_seeded_slot_deletable_with_force(
     (slots_dir / "agent.toml").write_text(
         'name = "agent"\nport = 8081\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
     )
-    with pytest.raises(SlotConfigError, match="seeded"):
+    from hal0.slots.manager import SlotPinned
+
+    with pytest.raises(SlotPinned):
         await sm.delete("agent")
     await sm.delete("agent", force=True)
     assert not (slots_dir / "agent.toml").exists()
+
+
+async def test_recreating_a_deleted_seed_clears_its_tombstone(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hal0.slots.routing.shutil.which", lambda name: None)
+    sm = SlotManager()
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "rerank.toml").write_text(
+        'name = "rerank"\nport = 8083\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
+    )
+    await sm.delete("rerank")
+
+    from hal0.install.static_seeds import read_seed_tombstones
+
+    assert "rerank" in read_seed_tombstones()
+    await sm.add_slot("rerank", type="reranking", model="x", port=8090)
+    assert "rerank" not in read_seed_tombstones()
 
 
 async def test_add_slot_rejects_invalid_type(tmp_hal0_home: str) -> None:
@@ -278,14 +322,17 @@ async def test_add_slot_rejects_invalid_name(tmp_hal0_home: str) -> None:
         await sm.add_slot("-leading-hyphen", type="llm", model="x", port=8090)
 
 
-async def test_remove_slot_refuses_seeded(tmp_hal0_home: str) -> None:
+async def test_remove_slot_deletes_seeded(tmp_hal0_home: str) -> None:
+    # remove_slot no longer refuses seed names — deletion works and resolves
+    # back-compat aliases first (agent-hermes → agent).
     sm = SlotManager()
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.remove_slot("utility")  # canonical name
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.remove_slot("agent-hermes")  # back-compat alias → agent (still seeded)
-    with pytest.raises(SlotConfigError, match="seeded"):
-        await sm.remove_slot("agent")
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "img.toml").write_text(
+        'name = "img"\nport = 8188\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
+    )
+    await sm.remove_slot("img")
+    assert not (slots_dir / "img.toml").exists()
 
 
 async def test_remove_slot_deletes_user_slot(
@@ -720,7 +767,9 @@ async def test_delete_removes_files_and_protects_seeded(
     await sm.create("extra", cfg)
     await sm.delete("extra")
     assert not (Path(tmp_hal0_home) / "etc" / "hal0" / "slots" / "extra.toml").exists()
-    with pytest.raises(SlotConfigError):
+    # Seed names are no longer delete-protected; an unknown slot (no TOML on
+    # disk) surfaces as not-found rather than "seeded".
+    with pytest.raises(SlotNotFound):
         await sm.delete("utility")
 
 

--- a/tests/slots/test_manager.py
+++ b/tests/slots/test_manager.py
@@ -269,6 +269,54 @@ async def test_seeded_slot_deletable_without_force(
     assert not (slots_dir / "tts.toml").exists()
 
 
+async def test_npu_trio_delete_writes_no_tombstone(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The trio shadow slots are reconciled from the FLM anchor every boot and
+    # reconcile_trio_slots does not consult tombstones — writing one would be
+    # a dead promise. Deleting a trio slot is ephemeral by contract.
+    monkeypatch.setattr("hal0.slots.routing.shutil.which", lambda name: "/usr/bin/flm")
+    sm = SlotManager()
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "flm-stt.toml").write_text(
+        'name = "flm-stt"\nport = 8088\nprovider = "llama-server"\n[model]\ndefault = "x"\n'
+    )
+    await sm.delete("flm-stt")
+
+    from hal0.install.static_seeds import read_seed_tombstones
+
+    assert "flm-stt" not in read_seed_tombstones()
+
+
+async def test_deleting_a_capability_slot_disables_its_selection(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # capabilities.toml must not keep claiming an enabled capability whose
+    # slot is gone — the converged-file fast path would never recreate it.
+    monkeypatch.setattr("hal0.slots.routing.shutil.which", lambda name: None)
+    sm = SlotManager()
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "img.toml").write_text(
+        'name = "img"\nport = 8188\nprovider = "llama-server"\n[model]\ndefault = "sdxl"\n'
+    )
+    from hal0.capabilities.config import capabilities_toml_path
+
+    capabilities_toml_path().parent.mkdir(parents=True, exist_ok=True)
+    capabilities_toml_path().write_text(
+        "schema_version = 2\n"
+        "[selections.img.img]\n"
+        'model = "sdxl"\ndevice = "gpu-rocm"\nenabled = true\n'
+    )
+    await sm.delete("img")
+
+    from hal0.capabilities.config import load_capabilities_config
+
+    cfg = load_capabilities_config()
+    assert cfg.selections["img"]["img"].enabled is False
+
+
 async def test_default_pinned_anchor_still_refuses_without_force(
     tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/stacks/test_converge_capabilities.py
+++ b/tests/stacks/test_converge_capabilities.py
@@ -101,3 +101,14 @@ def test_child_maps_mirror_orchestrator_source_of_truth() -> None:
     expected_slot = {child: slot for (group, child), slot in _CHILD_TO_SLOT.items()}
     assert expected_group == _CHILD_TO_GROUP
     assert expected_slot == _CHILD_TO_SLOT_NAME
+
+
+def test_retired_vision_child_is_skipped_not_errored() -> None:
+    """A stack saved before the vision-lane retirement carries a
+    StackCapabilityRow(child="vision"); applying it must skip the row
+    quietly instead of failing convergence."""
+    from hal0.stacks.apply import _CHILD_TO_GROUP, _CHILD_TO_SLOT_NAME, _RETIRED_CHILDREN
+
+    assert "vision" in _RETIRED_CHILDREN
+    assert "vision" not in _CHILD_TO_GROUP
+    assert "vision" not in _CHILD_TO_SLOT_NAME


### PR DESCRIPTION
## What

Per operator direction: capability slots are created **on demand** when their capability is enabled in settings — being a seed no longer grants special delete/create rules — and the dedicated `vision` slot lane is retired outright (vision is a model property, served by any llm slot whose model carries it).

## Changes

- **Delete guard**: the `cannot delete seeded slot` refusal is gone. Protection is the `pinned` lever alone (§21.10) — the default-pinned anchors (`agent`/`utility`/`npu`) still 409 without `force`, everything else deletes cleanly. Existence is now checked before pinned, so unknown names 404 instead of 409.
- **Seed tombstones**: deleting a static seed writes a tombstone; the boot-time seeding pass honours it instead of resurrecting the slot every start (the mechanism that made seeds effectively undeletable). Recreating the name clears the tombstone.
- **Recreate**: seed names are no longer reserved in `add_slot` — only the NPU trio names stay reserved (they collide with the occupancy pane's synthesised sub-cards).
- **Drift fix**: `SEEDED_SLOTS` is now a re-export of `STATIC_SEED_SLOTS`. The hand-copied list had drifted badly: `stt`/`vision` were protected-but-never-seeded ghosts; `brain`/`coder`/`flm`/`qwen3tts` were seeded-but-unprotected.
- **Vision lane retirement**: `vision.vision` capability child, catalog panel row, and orchestrator mappings removed; `capabilities.toml` drops a stray `[selections.vision]` on load; a boot migration deletes the untouched vision scaffold slot (a vision slot with a model bound is operator-owned and left alone — it keeps working as a plain llm slot). Model-side vision (`models_for_capability("vision")`, curated tags, `LoadedSlot.modalities`) is untouched.

## Verification

slots/capabilities/config/install suites: 1790 passed. New tests pin: seed deletable without force + tombstone honoured by seeding, recreate clears tombstone, anchor pin still enforced, NPU names still reserved, vision child retired, stray selections dropped, scaffold migration (remove/keep/idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)