### PR TITLE
fix(slots+ui): NPU trio toggles — id-keyed guard self-conflict, real card pills, shadow drawer pointer

### DIFF
--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -182,7 +182,15 @@ def _read_slot_toml_dict(path: Path) -> dict[str, Any] | None:
 def _iter_peer_configs(
     slot_name: str, slots_dir: Path | None = None
 ) -> list[tuple[str, dict[str, Any]]]:
-    """(name, cfg) for every readable configured slot other than ``slot_name``."""
+    """(name, cfg) for every readable configured slot other than ``slot_name``.
+
+    ``slot_name`` is the DISPLAY name. On an id-keyed box (#1569) the file
+    stem is the slot's numeric id and the display name lives in the body, so
+    exclusion must also match the embedded name — keyed on stems alone, the
+    slot's own file (``flm`` stored as ``8.toml``) counted as a peer and the
+    cross-slot guards vetoed every write against the slot itself. Peers are
+    likewise reported by their embedded display name when one exists.
+    """
     base = Path(slots_dir) if slots_dir is not None else paths.slots_config_dir()
     if not base.is_dir():
         return []
@@ -191,8 +199,13 @@ def _iter_peer_configs(
         if path.stem == slot_name:
             continue
         peer = _read_slot_toml_dict(path)
-        if peer is not None:
-            peers.append((path.stem, peer))
+        if peer is None:
+            continue
+        display = peer.get("name")
+        if display == slot_name:
+            continue
+        label = display if isinstance(display, str) and display and not display.isdigit() else path.stem
+        peers.append((label, peer))
     return peers
 
 

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -204,7 +204,9 @@ def _iter_peer_configs(
         display = peer.get("name")
         if display == slot_name:
             continue
-        label = display if isinstance(display, str) and display and not display.isdigit() else path.stem
+        label = (
+            display if isinstance(display, str) and display and not display.isdigit() else path.stem
+        )
         peers.append((label, peer))
     return peers
 

--- a/tests/slots/test_npu_exclusivity.py
+++ b/tests/slots/test_npu_exclusivity.py
@@ -275,3 +275,68 @@ async def test_create_allows_first_npu_llm_in_clean_home(tmp_hal0_home: str) -> 
         },
     )
     assert snap is not None
+
+
+# ── Id-keyed boxes (#1569): stems are numeric ids, names live in the body ──
+
+
+def test_id_keyed_own_file_is_not_a_peer(tmp_hal0_home: str) -> None:
+    """A slot must not conflict with its OWN file stored under an id stem.
+
+    On an id-keyed box ``flm``'s config lives at ``8.toml`` (stem = numeric
+    id, display name in the body). The peer walk excluded only ``flm.toml``,
+    so the slot's own file counted as an offender and EVERY config write on
+    the anchor 409'd against itself ("slot 'flm' would conflict with '8'").
+    """
+    from hal0.slots.config_write import check_npu_exclusivity
+
+    cfg = {
+        "name": "flm",
+        "device": "npu",
+        "type": "llm",
+        "model": {"default": "gemma4-it:e4b"},
+    }
+    path = _write_slot_toml(
+        tmp_hal0_home,
+        "8",
+        [
+            'name = "flm"',
+            "port = 8088",
+            'device = "npu"',
+            'type = "llm"',
+            "id = 8",
+            "[model]",
+            'default = "gemma4-it:e4b"',
+        ],
+    )
+    # Must not raise: 8.toml IS slot "flm".
+    check_npu_exclusivity("flm", cfg, slots_dir=path.parent)
+
+
+def test_id_keyed_real_peer_still_conflicts_and_is_named(tmp_hal0_home: str) -> None:
+    """A genuine second anchor under an id stem still 409s, reported by name."""
+    from hal0.slots.config_write import check_npu_exclusivity
+
+    path = _write_slot_toml(
+        tmp_hal0_home,
+        "9",
+        [
+            'name = "npu-b"',
+            "port = 8089",
+            'device = "npu"',
+            'type = "llm"',
+            "id = 9",
+            "[model]",
+            'default = "qwen3-1b"',
+        ],
+    )
+    cfg = {
+        "name": "flm",
+        "device": "npu",
+        "type": "llm",
+        "model": {"default": "gemma4-it:e4b"},
+    }
+    with pytest.raises(NpuExclusivityViolation) as exc:
+        check_npu_exclusivity("flm", cfg, slots_dir=path.parent)
+    # The offender is reported by its display name, not its opaque id stem.
+    assert exc.value.details["conflicting_slots"] == ["npu-b"]

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -328,6 +328,9 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
       </div>
       <div className="cslot-foot">
         <span className="grow" />
+        {/* The pills APPLY the modality directly (PUT [npu] on the anchor +
+            cold restart, same contract as the drawer's applyNpu) — they used
+            to merely open the edit drawer, which read as a broken toggle. */}
         {(slot.name === 'flm-stt' || slot.name === 'flm-embed') ? (
           <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
             <span style={{color: 'var(--fg-2)'}}>
@@ -336,8 +339,8 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
             <PillToggle
               on={npuModalityOn(mainFlmNpu, slot.name === 'flm-stt' ? 'asr' : 'embed')}
               label={slot.name === 'flm-stt' ? 'STT' : 'Embed'}
-              className="npu-card-toggle"
-              onToggle={() => handlers.onEdit(slot)}
+              disabled={handlers.modalityBusy}
+              onToggle={(next) => handlers.onModality(slot.name === 'flm-stt' ? 'asr' : 'embed', next)}
             />
           </span>
         ) : (
@@ -346,8 +349,8 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
             <PillToggle
               on={npuModalityOn(mainFlmNpu, 'chat')}
               label="Chat"
-              className="npu-card-toggle"
-              onToggle={() => handlers.onEdit(slot)}
+              disabled={handlers.modalityBusy}
+              onToggle={(next) => handlers.onModality('chat', next)}
             />
           </span>
         )}
@@ -448,6 +451,32 @@ export function NpuOccupancyCard({ slots }) {
     })
     toast(okMsg, 'info')
   }
+  // Direct modality apply — writes the ANCHOR's [npu] table (the single FLM
+  // process owns all three capabilities; the shadow slots have no config of
+  // their own) and cold-restarts it, mirroring the drawer's applyNpu.
+  const applyModality = (role, next) => {
+    if (!flmSlot || editMut.isPending || restartMut.isPending) return
+    const npu = {
+      chat: npuModalityOn(mainFlmNpu, 'chat'),
+      asr: npuModalityOn(mainFlmNpu, 'asr'),
+      embed: npuModalityOn(mainFlmNpu, 'embed'),
+      [role]: next,
+    }
+    editMut.mutate(
+      { name: flmSlot.name, body: { npu } },
+      {
+        onSuccess: () => {
+          toast(`${flmSlot.name} NPU ${role} ${next ? 'on' : 'off'} — restarting`, 'info')
+          restartMut.mutate(flmSlot.name, {
+            onError: (err) =>
+              toast(`NPU restart failed — ${err?.message || 'see logs'}`, 'warn'),
+          })
+        },
+        onError: (err) => toast(err?.message || `NPU ${role} toggle failed`, 'warn'),
+      }
+    )
+  }
+
   const handlers = {
     onStart: (s) => run(s.name, loadMut, s.name, `Starting ${s.name}…`),
     onStop: (s) => run(s.name, unloadMut, s.name, `Stopping ${s.name}…`),
@@ -458,10 +487,8 @@ export function NpuOccupancyCard({ slots }) {
     onLogs: (s) => {
       window.dispatchEvent(new CustomEvent('hal0:slot-logs', { detail: { name: s.name } }))
     },
-    onToggleShadow: (s) => {
-      // Open the FLM edit drawer — capability toggles are configured there
-      window.location.hash = '#slots/flm'
-    },
+    onModality: applyModality,
+    modalityBusy: editMut.isPending || restartMut.isPending,
   }
 
   const dutySub = colsAvailable

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -360,7 +360,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 			.catch(() => {});
 	}, []);
 	React.useEffect(() => {
-		if (device !== "npu") return;
+		// Anchor only — the trio shadows render no model pickers (their [npu]
+		// section is a pointer at the anchor), so skip the catalogue fetch.
+		if (device !== "npu" || slot?.type !== "llm") return;
 		refreshFlmModels();
 	}, [slot?.name, device]);
 
@@ -1596,8 +1598,45 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						</div>
 					</FieldGroup>
 				)}
-				{/* NPU capability matrix — replaces Model+Template for NPU slots */}
+				{/* NPU trio SHADOW (flm-stt / flm-embed): its own [npu] table is
+				    inert — the anchor's FLM process owns all three modalities, so
+				    editing toggles here wrote config the launcher never reads and
+				    nothing outside the drawer reflected it. Point at the anchor
+				    instead of rendering write-only controls. */}
+				{device === "npu" && slot && slot.type !== "llm" && (
+					<div className="form-row">
+						<div className="form-lbl">
+							<span>NPU modalities</span>
+						</div>
+						<div className="form-ctl">
+							<div className="hint">
+								{(() => {
+									const anchor = slot.name.replace(/-(stt|embed)$/, "") || "flm";
+									return (
+										<>
+											This capability is served by the anchor FLM slot — STT and
+											Embed are toggled there.{" "}
+											<a
+												href={"#slots/" + anchor}
+												onClick={(e) => {
+													e.preventDefault();
+													window.location.hash = "#slots/" + anchor;
+												}}
+											>
+												Open {anchor}
+											</a>
+										</>
+									);
+								})()}
+							</div>
+						</div>
+					</div>
+				)}
+				{/* NPU capability matrix — replaces Model+Template for NPU slots.
+				    Anchor only (type=llm): the trio shadows have no config of
+				    their own (see the block above). */}
 				{device === "npu" &&
+					slot?.type === "llm" &&
 					(() => {
 						// Full catalogue per lane (installed + downloadable) — NOT filtered by
 						// `installed`, so any tag can be picked and pulled on demand. Lane


### PR DESCRIPTION
## What changed

Follow-up to #1630 — the NPU trio toggle path was broken in three places (operator report):

1. **Backend: every config write on the FLM anchor 409'd against itself on id-keyed boxes.** `_iter_peer_configs` excluded peers by file stem only; on an id-keyed box (#1569) `flm` lives at `8.toml`, so the slot's own file counted as a peer and `check_npu_exclusivity` refused every write: *"only one NPU LLM slot may have a model configured at a time (slot 'flm' would conflict with '8')"*. `check_default_uniqueness` shared the same walk. Peers whose embedded display name matches the written slot are now excluded, and genuine offenders are reported by display name instead of the id stem.
2. **UI: the occupancy-card pills only opened the edit drawer.** They now apply the modality directly — `PUT { npu }` on the anchor + cold restart, the same contract as the drawer's `applyNpu` — and disable while the mutation/restart is in flight.
3. **UI: the drawer rendered write-only NPU controls for the trio shadows** (`flm-stt` / `flm-embed`). A shadow's own `[npu]` table is inert (the anchor's FLM process owns all three modalities), so toggling there saved config the launcher never reads. Shadow drawers now point at the anchor slot instead.

## Verification

- New pytest `test_id_keyed_own_file_is_not_a_peer` (red-first against the live failure) + `test_id_keyed_real_peer_still_conflicts_and_is_named`.
- `tests/slots` + `tests/stacks`: 834 passed. `ruff`: clean.
- UI: vitest 78 passed; Playwright NPU-related specs (npu-chat-model-seed, slot-drawer-field-wiring, slot-edit-controls, drawer-save-errors): 35 passed; build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)