### PR TITLE
fix(ui): Runner Images tab renames the catalog heading instead of stacking one

### DIFF
--- a/ui/src/api/mock.ts
+++ b/ui/src/api/mock.ts
@@ -98,6 +98,11 @@ export const MOCK_ALLOWLIST: ReadonlyArray<AllowRow> = Object.freeze([
   { re: /^\/api\/profiles$/, key: 'profiles', networkFirst: true },
   { re: /^\/api\/stacks$/, key: 'stacks', networkFirst: true },
   { re: /^\/api\/chat-templates$/, key: 'chatTemplates', networkFirst: true },
+  // ── Runner Images (Models → Runner Images tab) — ORDER MATTERS: the
+  // more-specific sub-paths sit before the bare collection route.
+  { re: /^\/api\/runner-images\/pulls\/list$/, key: 'runnerImagesPulls' },
+  { re: /^\/api\/runner-images\/downloaded$/, key: 'runnerImagesDownloaded' },
+  { re: /^\/api\/runner-images$/, key: 'runnerImages' },
   // ── Memory (Hindsight) — engine + bank-scoped surface ────────────
   // Forced-mock + 404-fallback story for the Memory graph overhaul. The
   // bank id is captured as group 1. ORDER MATTERS: the more-specific

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -1197,6 +1197,43 @@ function buildMemoryGraphStatus() {
   }
 }
 
+// ─── Runner Images (Models → Runner Images tab) ───────────────────────────
+// Shape mirrors /api/runner-images (registry rows synced from
+// hal0-runner-images images.json + GHCR). One row is enough for the
+// catalog list + card to render; the pulls list must be an ARRAY — the
+// downloads pane calls `.filter` on it directly.
+function buildRunnerImages() {
+  return {
+    images: [
+      {
+        id: 'rocmfpx',
+        image: 'ghcr.io/hal0ai/hal0-rocmfpx',
+        tag: 'ade07ba',
+        digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
+        size_bytes: 7_340_032_000,
+        manifest_key: null,
+        ownership: 'referenced',
+        publish: 'manual',
+        notes: 'ROCmFPX runner — HIP+Vulkan single build (mock fixture).',
+        build: null,
+        local_path: null,
+        downloaded_at: null,
+        discovered_at: '2026-08-08T00:00:00Z',
+        updated_at: '2026-08-08T00:00:00Z',
+        extra: {},
+      },
+    ],
+  }
+}
+
+function buildRunnerImagesDownloaded() {
+  return { images: [] }
+}
+
+function buildRunnerImagesPulls() {
+  return []
+}
+
 // ─── Builder lookup — keyed by the AllowRow.key in `./mock.ts`'s
 // `MOCK_ALLOWLIST`. The route table there only carries `{re, key,
 // networkFirst}` (no function refs), so it stays cheap to construct eagerly;
@@ -1221,6 +1258,9 @@ export const MOCK_BUILDERS: Record<string, Builder> = {
   stacks: buildStacksList,
   chatTemplates: buildChatTemplates,
   memoryGraphStatus: buildMemoryGraphStatus,
+  runnerImages: buildRunnerImages,
+  runnerImagesDownloaded: buildRunnerImagesDownloaded,
+  runnerImagesPulls: buildRunnerImagesPulls,
   memoryEngine: buildMemoryEngine,
   memoryBanks: buildMemoryBanks,
   bankTimeseries: buildBankTimeseries,

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -14,7 +14,7 @@ import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 import { useMetaEnums } from '@/api/hooks/useMeta'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
 import { MODEL_SORT_FIELDS, sortModels, fmtAdded } from '@/dash/model-sort.js'
-import { RunnerImagesView } from '@/dash/runner-images.jsx'
+import { RunnerImagesView, RunnerImagesSyncButton } from '@/dash/runner-images.jsx'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 
@@ -238,32 +238,41 @@ function ModelsView() {
     <div className="view">
       <div className="vh">
         <span className="vh-eye mono">Catalog</span>
-        <h1>Models</h1>
+        {/* One heading for the whole catalog — the active tab names it. The
+            Runner Images tab swaps the title and header actions in place
+            rather than stacking a second vh below the tab bar. */}
+        <h1>{tab === "runner-images" ? "Runner Images" : "Models"}</h1>
         <span className="vh-spacer" />
-        {updatable.length > 0 ? (
-          <button
-            className="btn"
-            data-testid="mdl-update-all"
-            disabled={updateAll.isPending}
-            title="Re-pull every installed model whose HuggingFace file has changed"
-            onClick={onUpdateAll}
-          >{Icons.download} {updateAll.isPending ? "Starting…" : `Update all (${updatable.length})`}</button>
+        {tab === "runner-images" ? (
+          <RunnerImagesSyncButton />
         ) : (
-          /* Everything current → the update surface would otherwise be
-             invisible. Keep an explicit check affordance so the feature is
-             discoverable and the TTL cache can be bypassed on demand. */
-          <button
-            className="btn ghost"
-            data-testid="mdl-check-updates"
-            disabled={forceCheck.isPending}
-            title="Compare every installed model against its HuggingFace repo now"
-            onClick={onCheckUpdates}
-          >{Icons.download} {forceCheck.isPending ? "Checking…" : "Check updates"}</button>
+          <>
+            {updatable.length > 0 ? (
+              <button
+                className="btn"
+                data-testid="mdl-update-all"
+                disabled={updateAll.isPending}
+                title="Re-pull every installed model whose HuggingFace file has changed"
+                onClick={onUpdateAll}
+              >{Icons.download} {updateAll.isPending ? "Starting…" : `Update all (${updatable.length})`}</button>
+            ) : (
+              /* Everything current → the update surface would otherwise be
+                 invisible. Keep an explicit check affordance so the feature is
+                 discoverable and the TTL cache can be bypassed on demand. */
+              <button
+                className="btn ghost"
+                data-testid="mdl-check-updates"
+                disabled={forceCheck.isPending}
+                title="Compare every installed model against its HuggingFace repo now"
+                onClick={onCheckUpdates}
+              >{Icons.download} {forceCheck.isPending ? "Checking…" : "Check updates"}</button>
+            )}
+            <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
+            <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
+            <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
+            <button className="btn" onClick={() => setAddOpen(true)}>{Icons.plus} Add by HF coords</button>
+          </>
         )}
-        <button className="btn ghost" onClick={() => setSearchOpen(v => !v)}>{Icons.search} Search HF</button>
-        <button className="btn ghost" onClick={() => setScanOpen(true)}>{Icons.search} Scan directory</button>
-        <button className="btn ghost" onClick={() => setAddByPathOpen(true)}>{Icons.plus} Add by path</button>
-        <button className="btn" onClick={() => setAddOpen(true)}>{Icons.plus} Add by HF coords</button>
       </div>
 
       {/* ── Tab bar (matches slot-tabs pattern) ── */}

--- a/ui/src/dash/runner-images.jsx
+++ b/ui/src/dash/runner-images.jsx
@@ -23,6 +23,31 @@ function fmtBytesRI(b) {
   return `${(b / 1024 ** 3).toFixed(2)} GB`;
 }
 
+// ── RunnerImagesSyncButton ──────────────────────────────────────────────
+// Rendered by models.jsx inside the Models page header (vh) when the
+// Runner Images tab is active — the view below carries no header of its
+// own, so the page keeps a single "Catalog / Runner Images" heading.
+export function RunnerImagesSyncButton() {
+  const sync = useRunnerImageSync();
+
+  const onSync = async () => {
+    try {
+      const res = await sync.mutateAsync();
+      const n = res.images?.length ?? 0;
+      const warn = res.images_json_ok === false ? " (images.json unreachable — GHCR data only)" : "";
+      window.__hal0Toast && window.__hal0Toast(`Runner image sync complete — ${n} image${n === 1 ? "" : "s"}${warn}`, res.images_json_ok === false ? "warn" : "info");
+    } catch (e) {
+      window.__hal0Toast && window.__hal0Toast(`Sync failed — ${e?.message || "see logs"}`, "err");
+    }
+  };
+
+  return (
+    <button className="btn" data-testid="ri-sync" disabled={sync.isPending} onClick={onSync}>
+      {Icons.restart} {sync.isPending ? "Syncing…" : "Sync now"}
+    </button>
+  );
+}
+
 // ── RunnerImagesView ────────────────────────────────────────────────────
 export function RunnerImagesView() {
   const [selId, setSelId] = useStateRI(null);
@@ -30,7 +55,6 @@ export function RunnerImagesView() {
 
   const imagesQuery = useRunnerImages();
   const images = imagesQuery.data ?? [];
-  const sync = useRunnerImageSync();
 
   useEffectRI(() => {
     if (!selId && images.length) setSelId(images[0].id);
@@ -45,29 +69,8 @@ export function RunnerImagesView() {
 
   const selected = images.find(i => i.id === selId) || images[0];
 
-  const onSync = async () => {
-    try {
-      const res = await sync.mutateAsync();
-      const n = res.images?.length ?? 0;
-      const warn = res.images_json_ok === false ? " (images.json unreachable — GHCR data only)" : "";
-      window.__hal0Toast && window.__hal0Toast(`Runner image sync complete — ${n} image${n === 1 ? "" : "s"}${warn}`, res.images_json_ok === false ? "warn" : "info");
-    } catch (e) {
-      window.__hal0Toast && window.__hal0Toast(`Sync failed — ${e?.message || "see logs"}`, "err");
-    }
-  };
-
   return (
-    <div className="view">
-      <div className="vh">
-        <span className="vh-eye mono">Catalog</span>
-        <h1>Runner Images</h1>
-        <span className="vh-spacer" />
-        <button className="btn" data-testid="ri-sync" disabled={sync.isPending} onClick={onSync}>
-          {Icons.restart} {sync.isPending ? "Syncing…" : "Sync now"}
-        </button>
-      </div>
-
-      <div className="models-layout" style={{marginTop: 18}}>
+    <div className="models-layout" style={{marginTop: 18}}>
         <div className="mdl-list">
           <div className="mdl-toolbar">
             <input
@@ -108,7 +111,6 @@ export function RunnerImagesView() {
           <RunnerCard image={selected} />
           <RunnerDownloadsPane />
         </div>
-      </div>
     </div>
   );
 }
@@ -259,7 +261,8 @@ function RunnerDownloadRow({ job }) {
 
 function RunnerDownloadsPane() {
   const pullsList = useRunnerImagePullsList();
-  const jobs = pullsList.data ?? [];
+  // An error envelope (or proxy 5xx body) must not crash the whole tab.
+  const jobs = Array.isArray(pullsList.data) ? pullsList.data : [];
   const active = jobs.filter(j => j.state === "queued" || j.state === "running");
   if (active.length === 0) return null;
   return (

--- a/ui/tests/e2e/specs/models-v3.spec.ts
+++ b/ui/tests/e2e/specs/models-v3.spec.ts
@@ -39,6 +39,21 @@ test.describe('Models v3 (/models)', () => {
     await expect(page.locator('.view .vh button:has-text("Search HF")')).toBeVisible()
   })
 
+  test('Runner Images tab swaps the page heading in place — no second vh', async ({ page }) => {
+    await page.goto('/#models')
+    await page.locator('.slot-tab:has-text("Runner Images")').click()
+    // The single catalog heading renames; the view must not stack a second one.
+    await expect(page.locator('.view .vh h1')).toHaveCount(1)
+    await expect(page.locator('.view .vh h1')).toHaveText('Runner Images')
+    // Header actions swap to the sync CTA; the Models CTAs leave.
+    await expect(page.getByTestId('ri-sync')).toBeVisible()
+    await expect(page.locator('.view .vh button:has-text("Add by HF coords")')).toHaveCount(0)
+    // Switching back restores the Models heading + CTAs.
+    await page.locator('.slot-tab:has-text("Inference Models")').click()
+    await expect(page.locator('.view .vh h1')).toHaveText('Models')
+    await expect(page.locator('.view .vh button:has-text("Add by HF coords")')).toBeVisible()
+  })
+
   test('simplified filter chips toggle OR semantics', async ({ page }) => {
     await page.goto('/#models')
     // All 7 filter chips render


### PR DESCRIPTION
## What

The Runner Images tab rendered its own full `view`/`vh` header below the Models page header — two stacked "Catalog" headings (screenshot in report). The tab now swaps the single page heading to **Runner Images** in place and moves the **Sync now** CTA into the header actions slot; `RunnerImagesView` renders only the catalog layout.

## Also

Opening the tab in forced-mock/dev crashed the whole view ("This view hit an error — jobs.filter is not a function"): the runner-images endpoints weren't in the mock allowlist, so the pulls list resolved to a non-array. Added the three GET fixtures (`runnerImages`, `runnerImagesDownloaded`, `runnerImagesPulls`) and an `Array.isArray` guard in `RunnerDownloadsPane`.

## Verification

- new e2e: heading swaps in place, single `h1`, CTAs swap, restores on tab switch — `models-v3.spec.ts` 14/14 pass
- vitest 78/78, vite build clean, eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)