### PR TITLE
fix(ui): harden NPU card pills — structural anchor, type-keyed roles, partial [npu] writes

### DIFF
--- a/ui/src/dash/__tests__/npu-modality.test.ts
+++ b/ui/src/dash/__tests__/npu-modality.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { npuModalityOn } from '../npu-modality.js'
+import { npuModalityOn, npuRoleForSlot } from '../npu-modality.js'
 
 describe('npuModalityOn', () => {
   it('defaults chat ON, asr/embed OFF when the [npu] table is absent', () => {
@@ -31,5 +31,23 @@ describe('npuModalityOn', () => {
     expect(npuModalityOn({ asr: true }, 'asr')).toBe(true)
     expect(npuModalityOn({ asr: true }, 'embed')).toBe(false)
     expect(npuModalityOn({ asr: true }, 'chat')).toBe(true)
+  })
+})
+
+describe('npuRoleForSlot', () => {
+  it('derives the role from the slot TYPE, never the display name', () => {
+    // Shadow semantics everywhere else key off type — a shadow with a
+    // non-canonical name (legacy `stt-npu`, operator rename) must not fall
+    // into the chat branch and flip the anchor's chat modality.
+    expect(npuRoleForSlot({ name: 'weird-name', type: 'transcription' })).toBe('asr')
+    expect(npuRoleForSlot({ name: 'weird-name', type: 'embedding' })).toBe('embed')
+    expect(npuRoleForSlot({ name: 'flm-stt', type: 'transcription' })).toBe('asr')
+    expect(npuRoleForSlot({ name: 'flm-embed', type: 'embedding' })).toBe('embed')
+  })
+
+  it('treats the anchor (type=llm) and unknowns as chat', () => {
+    expect(npuRoleForSlot({ name: 'flm', type: 'llm' })).toBe('chat')
+    expect(npuRoleForSlot({ name: 'npu', type: 'llm' })).toBe('chat')
+    expect(npuRoleForSlot(undefined)).toBe('chat')
   })
 })

--- a/ui/src/dash/npu-modality.js
+++ b/ui/src/dash/npu-modality.js
@@ -9,3 +9,15 @@ export const npuModalityOn = (npu, role) => {
   const t = npu || {}
   return role === 'chat' ? t.chat !== false : t[role] === true
 }
+
+// Which [npu] role a slot card stands for. Keyed on slot TYPE — the same
+// discriminator the backend trio uses (device=npu + type=transcription|
+// embedding marks a shadow) — never on the display name: a shadow with a
+// non-canonical name must not fall into the chat branch and toggle the
+// anchor's chat modality.
+export const npuRoleForSlot = (slot) =>
+  slot?.type === 'transcription' ? 'asr' : slot?.type === 'embedding' ? 'embed' : 'chat'
+
+// True for the trio shadow records (stt/embed) riding the anchor's process.
+export const isNpuShadowSlot = (slot) =>
+  slot?.type === 'transcription' || slot?.type === 'embedding'

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -27,7 +27,7 @@ import { slotIndicatorFromPhase } from './slot-status.js'
 // the shared helper folds them through backend_to_device → npu).
 import { devKind } from '@/lib/deviceMeta'
 import { PillToggle } from './primitives.jsx'
-import { npuModalityOn } from './npu-modality.js'
+import { npuModalityOn, npuRoleForSlot, isNpuShadowSlot } from './npu-modality.js'
 
 // ─── icons (16×16, hal0 thin-line family — ported from the design) ─────────
 const NI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -272,7 +272,7 @@ export function TileStrip({ owners, ownerName, act = 0, w = 10, h = 10 }) {
 }
 
 // ═══ per-slot card (right rail) ════════════════════════════════════════
-function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
+function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, anchorNpu }) {
   const ind = slotIndicatorFromPhase(slot)
   // Signal from BOTH the slot's own phase and the NPU occupancy's synthesised
   // state. The slot phase is authoritative for the anchor (esp. actively
@@ -330,30 +330,24 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, mainFlmNpu }) {
         <span className="grow" />
         {/* The pills APPLY the modality directly (PUT [npu] on the anchor +
             cold restart, same contract as the drawer's applyNpu) — they used
-            to merely open the edit drawer, which read as a broken toggle. */}
-        {(slot.name === 'flm-stt' || slot.name === 'flm-embed') ? (
-          <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
-            <span style={{color: 'var(--fg-2)'}}>
-              {slot.name === 'flm-stt' ? 'STT' : 'Embed'}
+            to merely open the edit drawer, which read as a broken toggle.
+            Role comes from the slot TYPE (npuRoleForSlot), not the display
+            name — a non-canonically-named shadow must not flip chat. */}
+        {(() => {
+          const role = npuRoleForSlot(slot)
+          const roleLabel = role === 'asr' ? 'STT' : role === 'embed' ? 'Embed' : 'Chat'
+          return (
+            <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
+              <span style={{color: 'var(--fg-2)'}}>{roleLabel}</span>
+              <PillToggle
+                on={npuModalityOn(anchorNpu, role)}
+                label={roleLabel}
+                disabled={handlers.modalityBusy}
+                onToggle={(next) => handlers.onModality(role, next)}
+              />
             </span>
-            <PillToggle
-              on={npuModalityOn(mainFlmNpu, slot.name === 'flm-stt' ? 'asr' : 'embed')}
-              label={slot.name === 'flm-stt' ? 'STT' : 'Embed'}
-              disabled={handlers.modalityBusy}
-              onToggle={(next) => handlers.onModality(slot.name === 'flm-stt' ? 'asr' : 'embed', next)}
-            />
-          </span>
-        ) : (
-          <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
-            <span style={{color: 'var(--fg-2)'}}>Chat</span>
-            <PillToggle
-              on={npuModalityOn(mainFlmNpu, 'chat')}
-              label="Chat"
-              disabled={handlers.modalityBusy}
-              onToggle={(next) => handlers.onModality('chat', next)}
-            />
-          </span>
-        )}
+          )
+        })()}
       </div>
     </div>
   )
@@ -367,16 +361,22 @@ export function NpuOccupancyCard({ slots }) {
   const unloadMut = useSlotUnload()
   const loadMut = useSlotLoad()
   const editMut = useSlotEdit()
-  // Full npu dict (chat/asr/embed) via react-query so the drawer's edit
-  // (which invalidates ['slot-config','flm']) refreshes the card toggles in
-  // lockstep — the old one-shot fetch went stale after every drawer change.
-  const flmCfgQuery = useSlotConfig('flm')
 
+  // The ANCHOR is resolved structurally — the non-shadow NPU LLM slot — not
+  // by the canonical 'flm' display name. A renamed or legacy anchor ('npu')
+  // must still own the pills, the config query and the header controls;
+  // keyed on the name, every pill click silently no-op'd on such boxes.
   const npuSlots = (slots || []).filter(isNpuSlot)
+  const anchorSlot =
+    npuSlots.find((s) => !isNpuShadowSlot(s) && s.type === 'llm') ||
+    npuSlots.find((s) => !isNpuShadowSlot(s))
+  // Full npu dict (chat/asr/embed) via react-query so the drawer's edit
+  // (which invalidates ['slot-config',anchor]) refreshes the card toggles in
+  // lockstep — the old one-shot fetch went stale after every drawer change.
+  const anchorCfgQuery = useSlotConfig(anchorSlot?.name)
   if (npuSlots.length === 0) return null
 
-  const flmSlot = npuSlots.find(s => s.name === 'flm')
-  const mainFlmNpu = flmCfgQuery.data?.npu || flmSlot?.npu || {}
+  const anchorNpu = anchorCfgQuery.data?.npu || anchorSlot?.npu || {}
 
   const occ = occQuery.data || {}
   const occSlots = occ.slots || []
@@ -408,10 +408,9 @@ export function NpuOccupancyCard({ slots }) {
   // overwrite the anchor's colour (grid turns green + labels "flm-stt"). Only
   // non-shadow slots own grid columns, so the grid always reads as the primary
   // FLM slot. Shadow cards keep their own accent via ComboSlot's `hue` prop.
-  const isNpuShadow = (s) => s.type === 'transcription' || s.type === 'embedding'
   const owners = Array(NPU_COLS).fill(null)
   npuSlots.forEach((s, idx) => {
-    if (isNpuShadow(s)) return
+    if (isNpuShadowSlot(s)) return
     const o = occByName[s.name]
     const cols = o?.cols || []
     const ind = slotIndicatorFromPhase(s)
@@ -455,19 +454,24 @@ export function NpuOccupancyCard({ slots }) {
   // process owns all three capabilities; the shadow slots have no config of
   // their own) and cold-restarts it, mirroring the drawer's applyNpu.
   const applyModality = (role, next) => {
-    if (!flmSlot || editMut.isPending || restartMut.isPending) return
-    const npu = {
-      chat: npuModalityOn(mainFlmNpu, 'chat'),
-      asr: npuModalityOn(mainFlmNpu, 'asr'),
-      embed: npuModalityOn(mainFlmNpu, 'embed'),
-      [role]: next,
+    if (!anchorSlot || editMut.isPending || restartMut.isPending) return
+    // Enabling chat needs a bound model — model presence IS the activation
+    // signal, so a bare chat=true write would show the pill on while the
+    // slot stays unroutable. The model picker lives in the drawer.
+    if (role === 'chat' && next && !(anchorSlot.modelDefault || anchorSlot.model_id || anchorSlot.model)) {
+      toast('Pick a chat model first — opening the slot editor', 'info')
+      window.location.hash = '#slots/' + anchorSlot.name
+      return
     }
+    // Partial write on purpose: the backend one-level-deep-merges [npu]
+    // (merge_slot_config), so sending only the flipped key can never clobber
+    // sibling modalities off a stale or still-loading client snapshot.
     editMut.mutate(
-      { name: flmSlot.name, body: { npu } },
+      { name: anchorSlot.name, body: { npu: { [role]: next } } },
       {
         onSuccess: () => {
-          toast(`${flmSlot.name} NPU ${role} ${next ? 'on' : 'off'} — restarting`, 'info')
-          restartMut.mutate(flmSlot.name, {
+          toast(`${anchorSlot.name} NPU ${role} ${next ? 'on' : 'off'} — restarting`, 'info')
+          restartMut.mutate(anchorSlot.name, {
             onError: (err) =>
               toast(`NPU restart failed — ${err?.message || 'see logs'}`, 'warn'),
           })
@@ -513,22 +517,22 @@ export function NpuOccupancyCard({ slots }) {
           </span>
           <span className="grow" />
           <button className="btn ghost sm ctl-start" title="Start"
-            onClick={() => handlers.onStart(flmSlot)} disabled={!flmSlot}>
+            onClick={() => handlers.onStart(anchorSlot)} disabled={!anchorSlot}>
             ▶
           </button>
           <button className="btn ghost sm ctl-stop" title="Stop"
-            onClick={() => handlers.onStop(flmSlot)} disabled={!flmSlot}>
+            onClick={() => handlers.onStop(anchorSlot)} disabled={!anchorSlot}>
             ■
           </button>
           <button className="btn ghost sm ctl-restart" title="Restart"
-            onClick={() => handlers.onRestart(flmSlot)} disabled={!flmSlot}>
+            onClick={() => handlers.onRestart(anchorSlot)} disabled={!anchorSlot}>
             ↻
           </button>
           <button className="btn ghost sm ctl-logs" title="Logs"
-            onClick={() => handlers.onLogs(flmSlot)} disabled={!flmSlot}>
+            onClick={() => handlers.onLogs(anchorSlot)} disabled={!anchorSlot}>
             📋
           </button>
-          <button className="btn ghost sm" title="Configure FLM slot" onClick={() => window.location.hash = '#slots/flm'} style={{fontSize: 13}}>✎ Configure</button>
+          <button className="btn ghost sm" title="Configure FLM slot" onClick={() => anchorSlot && (window.location.hash = '#slots/' + anchorSlot.name)} disabled={!anchorSlot} style={{fontSize: 13}}>✎ Configure</button>
         </div>
         <div className="wcard-b">
           <div className="combo">
@@ -565,7 +569,7 @@ export function NpuOccupancyCard({ slots }) {
                   hue={HUES[idx % HUES.length]}
                   handlers={handlers}
                   act={act}
-                  mainFlmNpu={mainFlmNpu}
+                  anchorNpu={anchorNpu}
                 />
               ))}
             </div>

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -296,6 +296,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// replacing the raw window.confirm. Every dismiss path (Cancel, ✕, Esc,
 	// backdrop) funnels through requestClose below.
 	const [discardOpen, setDiscardOpen] = useStateSM(false);
+	// In-drawer navigation target (anchor link on trio shadows) held while the
+	// discard dialog confirms — hash assignment must not bypass the dirty
+	// guard, or the re-seed effect silently drops pending Save-batched edits.
+	const [pendingNav, setPendingNav] = useStateSM(null);
 	// UI-5 (state-driven): swapping the model on a LIVE container slot
 	// cold-restarts it — stash the picked {id, label} here and confirm through
 	// ConfirmDialog before firing the swap. null = no confirm pending.
@@ -478,6 +482,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		setProfileSel(slot.profile || "");
 		setSubmitErr(null);
 		setDiscardOpen(false);
+		setPendingNav(null);
 		setPendingSwap(null);
 		setModelEditOpen(false);
 		setFieldErrs({});
@@ -1620,7 +1625,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												href={"#slots/" + anchor}
 												onClick={(e) => {
 													e.preventDefault();
-													window.location.hash = "#slots/" + anchor;
+													const target = "#slots/" + anchor;
+													// Route through the dirty guard — a direct hash
+													// assignment would re-seed the drawer for the anchor
+													// and silently drop pending Save-batched edits.
+													if (dirty) {
+														setPendingNav(target);
+														setDiscardOpen(true);
+													} else {
+														window.location.hash = target;
+													}
 												}}
 											>
 												Open {anchor}
@@ -2003,9 +2017,20 @@ function EditSlotDrawer({ open, slot, onClose }) {
 			</DrawerDock>
 			<ConfirmDialog
 				open={discardOpen}
-				onCancel={() => setDiscardOpen(false)}
+				onCancel={() => {
+					setDiscardOpen(false);
+					setPendingNav(null);
+				}}
 				onConfirm={() => {
 					setDiscardOpen(false);
+					if (pendingNav) {
+						// Discard confirmed for an in-drawer navigation (shadow ->
+						// anchor): switch slots instead of closing.
+						const target = pendingNav;
+						setPendingNav(null);
+						window.location.hash = target;
+						return;
+					}
 					onClose();
 				}}
 				title="Discard unsaved changes?"


### PR DESCRIPTION
## What changed

Follow-up addressing all five Codex review findings on #1633 (none bite the canonical install today, but three were genuine robustness bugs):

1. **Structural anchor resolution.** The occupancy card found its anchor with `name === 'flm'`; on a renamed or legacy-named anchor (`npu`) every pill click silently no-op'd — worse than the pre-#1633 behavior. The anchor is now the non-shadow `type === 'llm'` NPU slot, and the config query + header Start/Stop/Restart/Logs/Configure controls follow the same resolution.
2. **Type-keyed roles.** Card roles were keyed on the `flm-stt`/`flm-embed` display names, so a non-canonically-named shadow fell into the Chat branch and its pill would have flipped the anchor's *chat* modality. Roles now derive from slot type via `npuRoleForSlot` (transcription → asr, embedding → embed), matching how shadow semantics are determined everywhere else.
3. **Partial `[npu]` writes.** The pill sent a fully reconstructed `{chat, asr, embed}` table synthesized from client state — an empty/stale snapshot (config query still loading) could silently disable a configured sibling. Verified `merge_slot_config` one-level-deep-merges `[npu]`, so the pill now sends only `{ npu: { [role]: next } }`.
4. **Chat-enable guard on a model-less anchor.** Model presence is the activation signal; a bare `chat=true` write showed the pill on while the slot stayed unroutable. Enabling chat with no bound model now opens the drawer's model picker instead (with a toast).
5. **Dirty-guard on the shadow drawer's anchor link.** Direct hash assignment bypassed `requestClose`; pending Save-batched edits were silently dropped by the re-seed effect. The link now routes through the discard dialog (`pendingNav`), which navigates on confirm instead of closing.

## Verification

- New `npuRoleForSlot` unit tests (non-canonical shadow names must not map to chat); vitest 80 passed.
- Playwright: npu-chat-model-seed, slot-drawer-field-wiring, slot-edit-controls, drawer-save-errors, warm-color-tones — 42 passed.
- Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)