### PR TITLE
fix(ui): slot drawer — widen info popups, consolidate lifecycle controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Fixed
+
+- Field-info popups (the `(i)` descriptions in the slot/model drawers and
+  settings pages) no longer collapse to one word per line — the popup was
+  shrink-to-fit against its tiny icon wrapper; it now sizes to its text up
+  to the 280px wrap width. The slot drawer's Auto-load and Pin descriptions
+  now also spell out the difference: Auto-load only controls boot start,
+  Pin only controls residency (eviction exemption + guarded unload/delete).
+- Slot drawer lifecycle controls consolidated: Auto-Load moved from the Model
+  section up into the drawer header next to the Pinned toggle (same
+  instant-apply style — the pair now reads as one story: Auto-Load = when it
+  starts, Pin = whether it may be stopped), and Eviction priority moved into
+  the Advanced disclosure. Two fewer always-visible rows in the drawer body,
+  and NPU slots — which have no Model section — gain the Auto-Load toggle.
+
 ## [1.0.0-rc.2] — 2026-08-08
 
 Second — and intended final — release candidate on the road to 1.0.0. This

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -931,8 +931,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						className="slot-enable-toggle drawer-enable"
 						title={
 							pinned
-								? "Unpin slot"
-								: "Pin slot — exempt from idle/pressure eviction; unload/delete require ?force=true"
+								? "Unpin slot — idle/pressure eviction applies again (order set by Eviction priority)"
+								: "Pin slot — once loaded it stays resident: exempt from idle/pressure eviction, and unload/delete require ?force=true. Pinning never starts a slot — boot start is the Auto-load toggle."
 						}
 					>
 						<span className="drawer-enable-label mono">
@@ -1517,7 +1517,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								<span>Auto-load on start</span>
 								<FieldInfoIcon description="Start this slot automatically at boot. Off: the slot
 									only loads when you load or swap it — binding a model no
-									longer implies boot start." />
+									longer implies boot start. Auto-load only controls startup;
+									it does not protect a running slot from eviction — that is
+									the Pin toggle in the drawer header." />
 							</div>
 							<div className="form-ctl">
 								<label className="slot-enable-toggle">

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -521,6 +521,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		if (Number.isInteger(slot?.priority)) setPrio(slot.priority);
 	}, [slot?.priority]);
 
+	// Screen-reader descriptions for the header toggles — the hover `title`
+	// alone is unreachable for keyboard/touch/SR users (Codex review, #1638).
+	// Hooks: must sit ABOVE the `!slot` early return (positional counting).
+	const autoloadDescId = React.useId();
+	const pinDescId = React.useId();
+
 	if (!slot) return null;
 
 	async function onSaveClick() {
@@ -706,6 +712,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// Same contract as the pinned toggle above: fire the PUT, toast, let the
 	// slots poll re-render from server truth. Excluded from the Save batch —
 	// see the `dirty` comment below.
+	// NPU trio shadows (flm-stt / flm-embed) never run as their own process,
+	// so the process-lifecycle controls (Auto-Load, Eviction priority) are
+	// hidden for them — the anchor slot owns the FLM process.
+	const isNpuShadow = device === "npu" && slot.type !== "llm";
 	const autoload = slot.autoload === true;
 	const onToggleAutoload = async (next) => {
 		try {
@@ -930,25 +940,36 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					<>
 						{/* Lifecycle pair (spec 2026-08-02 consolidation): Auto-Load =
 						    boot start only, Pin = residency only. Side by side so they
-						    read as one story instead of competing features. */}
-						<label
-							className="slot-enable-toggle drawer-enable"
-							data-testid="slot-autoload-toggle"
-							title="Auto-Load — start this slot automatically at boot. Only controls startup; eviction protection is the Pin toggle."
-						>
-							<span className="drawer-enable-label mono">Auto-Load</span>
-							<input
-								type="checkbox"
-								checked={autoload}
-								onChange={() => onToggleAutoload(!autoload)}
-								aria-label={
-									autoload
-										? "Disable auto-load on start"
-										: "Enable auto-load on start"
-								}
-							/>
-							<span className="slot-enable-track" aria-hidden="true" />
-						</label>
+						    read as one story instead of competing features. NPU trio
+						    shadows (flm-stt / flm-embed) have no unit or container of
+						    their own — the anchor's FLM process serves them — so
+						    Auto-Load is hidden there: writing { autoload } to a shadow
+						    TOML configures a boot start that can never happen. */}
+						{!isNpuShadow && (
+							<label
+								className="slot-enable-toggle drawer-enable"
+								data-testid="slot-autoload-toggle"
+								title="Auto-Load — start this slot automatically at boot. Only controls startup; eviction protection is the Pin toggle."
+							>
+								<span className="drawer-enable-label mono">Auto-Load</span>
+								<input
+									type="checkbox"
+									checked={autoload}
+									onChange={() => onToggleAutoload(!autoload)}
+									aria-label={
+										autoload
+											? "Disable auto-load on start"
+											: "Enable auto-load on start"
+									}
+									aria-describedby={autoloadDescId}
+								/>
+								<span className="slot-enable-track" aria-hidden="true" />
+								<span id={autoloadDescId} className="sr-only">
+									Start this slot automatically at boot. Only controls
+									startup; eviction protection is the Pin toggle.
+								</span>
+							</label>
+						)}
 						<label
 							className="slot-enable-toggle drawer-enable"
 							data-testid="slot-pin-toggle"
@@ -967,8 +988,14 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								disabled={enableBusy}
 								onChange={() => onTogglePinned(!pinned)}
 								aria-label={pinned ? "Unpin slot" : "Pin slot"}
+								aria-describedby={pinDescId}
 							/>
 							<span className="slot-enable-track" aria-hidden="true" />
+							<span id={pinDescId} className="sr-only">
+								A pinned slot stays resident once loaded: exempt from idle
+								and pressure eviction, and unload or delete require force.
+								Pinning never starts a slot — boot start is Auto-Load.
+							</span>
 						</label>
 					</>
 				}
@@ -1765,7 +1792,9 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 					{/* Eviction priority (spec 2026-08-02) lives under Advanced: its
 					    lifecycle siblings (Auto-Load / Pin) are header toggles, and it
-					    only matters for unpinned slots under memory pressure. */}
+					    only matters for unpinned slots under memory pressure. Hidden
+					    for NPU trio shadows — no process of their own to evict. */}
+					{!isNpuShadow && (
 					<div className="form-row">
 						<div className="form-lbl">
 							<span>Eviction priority</span>
@@ -1792,6 +1821,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							<div className="hint">lower unloads first</div>
 						</div>
 					</div>
+					)}
 
 					{/* Flags preview — backend-provided resolved_command (real podman argv),
           computed SERVER-SIDE (profile + MTP + image resolution). #1379 removed

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -927,26 +927,50 @@ function EditSlotDrawer({ open, slot, onClose }) {
 				title={`Edit ${slot.name}`}
 				width={SLOT_DRAWER_WIDTH}
 				headRight={
-					<label
-						className="slot-enable-toggle drawer-enable"
-						title={
-							pinned
-								? "Unpin slot — idle/pressure eviction applies again (order set by Eviction priority)"
-								: "Pin slot — once loaded it stays resident: exempt from idle/pressure eviction, and unload/delete require ?force=true. Pinning never starts a slot — boot start is the Auto-load toggle."
-						}
-					>
-						<span className="drawer-enable-label mono">
-							{pinned ? "Pinned" : "Unpinned"}
-						</span>
-						<input
-							type="checkbox"
-							checked={pinned}
-							disabled={enableBusy}
-							onChange={() => onTogglePinned(!pinned)}
-							aria-label={pinned ? "Unpin slot" : "Pin slot"}
-						/>
-						<span className="slot-enable-track" aria-hidden="true" />
-					</label>
+					<>
+						{/* Lifecycle pair (spec 2026-08-02 consolidation): Auto-Load =
+						    boot start only, Pin = residency only. Side by side so they
+						    read as one story instead of competing features. */}
+						<label
+							className="slot-enable-toggle drawer-enable"
+							data-testid="slot-autoload-toggle"
+							title="Auto-Load — start this slot automatically at boot. Only controls startup; eviction protection is the Pin toggle."
+						>
+							<span className="drawer-enable-label mono">Auto-Load</span>
+							<input
+								type="checkbox"
+								checked={autoload}
+								onChange={() => onToggleAutoload(!autoload)}
+								aria-label={
+									autoload
+										? "Disable auto-load on start"
+										: "Enable auto-load on start"
+								}
+							/>
+							<span className="slot-enable-track" aria-hidden="true" />
+						</label>
+						<label
+							className="slot-enable-toggle drawer-enable"
+							data-testid="slot-pin-toggle"
+							title={
+								pinned
+									? "Unpin slot — idle/pressure eviction applies again (order set by Eviction priority under Advanced)"
+									: "Pin slot — once loaded it stays resident: exempt from idle/pressure eviction, and unload/delete require ?force=true. Pinning never starts a slot — boot start is the Auto-Load toggle."
+							}
+						>
+							<span className="drawer-enable-label mono">
+								{pinned ? "Pinned" : "Unpinned"}
+							</span>
+							<input
+								type="checkbox"
+								checked={pinned}
+								disabled={enableBusy}
+								onChange={() => onTogglePinned(!pinned)}
+								aria-label={pinned ? "Unpin slot" : "Pin slot"}
+							/>
+							<span className="slot-enable-track" aria-hidden="true" />
+						</label>
+					</>
 				}
 				foot={
 					<>
@@ -1514,55 +1538,6 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 						<div className="form-row">
 							<div className="form-lbl">
-								<span>Auto-load on start</span>
-								<FieldInfoIcon description="Start this slot automatically at boot. Off: the slot
-									only loads when you load or swap it — binding a model no
-									longer implies boot start. Auto-load only controls startup;
-									it does not protect a running slot from eviction — that is
-									the Pin toggle in the drawer header." />
-							</div>
-							<div className="form-ctl">
-								<label className="slot-enable-toggle">
-									<input
-										type="checkbox"
-										data-testid="slot-autoload-toggle"
-										checked={autoload}
-										onChange={() => onToggleAutoload(!autoload)}
-										aria-label={autoload ? "Disable auto-load on start" : "Enable auto-load on start"}
-									/>
-									<span className="slot-enable-track" aria-hidden="true" />
-								</label>
-							</div>
-						</div>
-						<div className="form-row">
-							<div className="form-lbl">
-								<span>Eviction priority</span>
-								<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
-									Ties go to the least recently used. Pin the slot to exempt
-									it entirely." />
-							</div>
-							<div className="form-ctl">
-								<input
-									className="input mono"
-									data-testid="slot-priority-input"
-									type="number"
-									min={0}
-									max={100}
-									step={1}
-									value={prio}
-									onChange={(e) => setPrio(e.target.value)}
-									onBlur={commitPriority}
-									onKeyDown={(e) => {
-										if (e.key === "Enter") e.currentTarget.blur();
-									}}
-									style={{ width: 90 }}
-								/>
-								<div className="hint">lower unloads first</div>
-							</div>
-						</div>
-
-						<div className="form-row">
-							<div className="form-lbl">
 								<span>Context (ceiling)</span>
 								<FieldInfoIcon description="⟳ ctx_size — a hardware CEILING in tokens, not an
 									override: the bound model's own default context_size (set on the
@@ -1787,6 +1762,36 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					>
 						Advanced
 					</summary>
+
+					{/* Eviction priority (spec 2026-08-02) lives under Advanced: its
+					    lifecycle siblings (Auto-Load / Pin) are header toggles, and it
+					    only matters for unpinned slots under memory pressure. */}
+					<div className="form-row">
+						<div className="form-lbl">
+							<span>Eviction priority</span>
+							<FieldInfoIcon description="0-100 — lower unloads first when memory is needed.
+								Ties go to the least recently used. Pin the slot to exempt
+								it entirely." />
+						</div>
+						<div className="form-ctl">
+							<input
+								className="input mono"
+								data-testid="slot-priority-input"
+								type="number"
+								min={0}
+								max={100}
+								step={1}
+								value={prio}
+								onChange={(e) => setPrio(e.target.value)}
+								onBlur={commitPriority}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") e.currentTarget.blur();
+								}}
+								style={{ width: 90 }}
+							/>
+							<div className="hint">lower unloads first</div>
+						</div>
+					</div>
 
 					{/* Flags preview — backend-provided resolved_command (real podman argv),
           computed SERVER-SIDE (profile + MTP + image resolution). #1379 removed

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2910,6 +2910,17 @@ select.npu-sel {
   align-items: center;
   gap: 18px; /* room between the Auto-Load and Pinned header toggles */
 }
+/* headRight is absolutely positioned, so the header reserves no space for it —
+   a long title (e.g. "Edit <slot-name>") or the eyebrow would run underneath.
+   Reserve the width of the widest headRight (the slot drawer's two lifecycle
+   toggles, ~215px, plus their 56px close-button offset) and ellipsize. */
+.drawer-h:has(.drawer-h-right) h2,
+.drawer-h:has(.drawer-h-right) .modal-h-eye {
+  margin-right: 270px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 .drawer-enable { gap: 8px; }
 .drawer-enable-label {
   font-size: 11px;
@@ -3171,6 +3182,29 @@ select.npu-sel {
 .field-info-wrap:hover .field-info-pop,
 .field-info-wrap:focus-within .field-info-pop {
   display: block;
+}
+/* On narrow screens the to-the-right placement runs the (now content-width)
+   popup past the right edge of overflow-clipped panels (.s-panel). Drop it
+   below the icon, centred, with a viewport-derived cap instead. */
+@media (max-width: 720px) {
+  .field-info-pop {
+    left: 50%;
+    top: 20px;
+    transform: translateX(-50%);
+    max-width: min(260px, calc(100vw - 48px));
+  }
+}
+/* Visually hidden but exposed to assistive tech (toggle descriptions etc.). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 .form-row .form-lbl .warn { font-size: 10px; color: var(--warn); font-family: var(--jbm); }
 .form-row .form-ctl { font-family: var(--jbm); }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3151,6 +3151,11 @@ select.npu-sel {
   top: -4px;
   z-index: 60;
   display: none;
+  /* Shrink-to-fit for an absolutely-positioned box resolves against the
+     containing block — the ~19px icon wrapper — which collapsed the popup
+     to one word per line. max-content sizes it to the text instead, with
+     max-width as the wrap point. */
+  width: max-content;
   max-width: 280px;
   padding: 6px 10px;
   color: var(--fg-2);

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -2908,6 +2908,7 @@ select.npu-sel {
   right: 56px;
   display: flex;
   align-items: center;
+  gap: 18px; /* room between the Auto-Load and Pinned header toggles */
 }
 .drawer-enable { gap: 8px; }
 .drawer-enable-label {

--- a/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-pin-toggle-v3.spec.ts
@@ -1,11 +1,18 @@
 /**
- * slot-pin-toggle-v3 — the drawer header toggle is Pinned/Unpinned (#1367).
+ * slot-pin-toggle-v3 — the drawer header lifecycle toggles (#1367 + spec
+ * 2026-08-02 consolidation).
  *
- * §21.10 operator pin replaces the old Enabled/Disabled header toggle:
- *   P1. header toggle renders "Pinned"/"Unpinned" from `slot.pinned`;
- *       the old Enabled/Disabled copy is gone from the drawer.
- *   P2. flipping the toggle fires PUT /config { pinned } — never { enabled }.
+ * §21.10 operator pin replaced the old Enabled/Disabled header toggle; the
+ * lifecycle consolidation then moved Auto-Load up next to it and re-homed
+ * Eviction priority under the Advanced disclosure:
+ *   P1. header renders BOTH toggles — "Auto-Load" and "Pinned"/"Unpinned"
+ *       (from `slot.pinned`); the old Enabled/Disabled copy is gone.
+ *   P2. flipping the pin toggle fires PUT /config { pinned } — never
+ *       { enabled }.
  *   P3. a pinned slot (fresh-install utility anchor) seeds the toggle on.
+ *   P4. flipping the header Auto-Load toggle fires PUT /config { autoload }.
+ *   P5. Eviction priority lives under the Advanced disclosure (not in the
+ *       Model section) and commits PUT /config { priority } on blur.
  *
  * List seeding mirrors slot-edit-controls-v3.spec.ts (in-bundle HAL0_DATA,
  * mutations fall through to page.route).
@@ -44,15 +51,20 @@ async function seedSlots(page: Page, slots: any[]) {
 }
 
 test.describe('Slot pin toggle (/slots drawer header)', () => {
-  test('P1 — header toggle reads Pinned/Unpinned, Enabled/Disabled copy is gone', async ({ page }) => {
+  test('P1 — header shows Auto-Load + Pinned/Unpinned, Enabled/Disabled copy is gone', async ({ page }) => {
     await seedSlots(page, [PRIMARY, UTILITY])
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
-    await expect(page.locator('.drawer-enable-label')).toHaveText('Unpinned')
+    await expect(
+      page.locator('[data-testid="slot-pin-toggle"] .drawer-enable-label'),
+    ).toHaveText('Unpinned')
+    await expect(
+      page.locator('[data-testid="slot-autoload-toggle"] .drawer-enable-label'),
+    ).toHaveText('Auto-Load')
     await expect(page.locator('.drawer', { hasText: /Enabled|Disabled/ })).toHaveCount(0)
   })
 
-  test('P2 — flipping the toggle PUTs { pinned }, never { enabled }', async ({ page }) => {
+  test('P2 — flipping the pin toggle PUTs { pinned }, never { enabled }', async ({ page }) => {
     const puts: any[] = []
     await page.route('**/api/slots/primary/config', async (route) => {
       if (route.request().method() === 'PUT')
@@ -63,7 +75,7 @@ test.describe('Slot pin toggle (/slots drawer header)', () => {
     await page.goto('/#slots/primary')
     await expect(page.locator('.drawer')).toBeVisible()
     // The input is visually hidden behind the styled track — click the label.
-    await page.locator('label.drawer-enable').click()
+    await page.locator('label[data-testid="slot-pin-toggle"]').click()
     await expect.poll(() => puts.length).toBeGreaterThan(0)
     expect(puts[0]).toEqual({ pinned: true })
     expect(puts[0]).not.toHaveProperty('enabled')
@@ -73,7 +85,47 @@ test.describe('Slot pin toggle (/slots drawer header)', () => {
     await seedSlots(page, [PRIMARY, UTILITY])
     await page.goto('/#slots/utility')
     await expect(page.locator('.drawer')).toBeVisible()
-    await expect(page.locator('.drawer-enable-label')).toHaveText('Pinned')
-    await expect(page.locator('.drawer-enable input[type="checkbox"]')).toBeChecked()
+    await expect(
+      page.locator('[data-testid="slot-pin-toggle"] .drawer-enable-label'),
+    ).toHaveText('Pinned')
+    await expect(
+      page.locator('[data-testid="slot-pin-toggle"] input[type="checkbox"]'),
+    ).toBeChecked()
+  })
+
+  test('P4 — flipping the header Auto-Load toggle PUTs { autoload }', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT')
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, UTILITY])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await page.locator('label[data-testid="slot-autoload-toggle"]').click()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0]).toEqual({ autoload: true })
+  })
+
+  test('P5 — Eviction priority lives under Advanced and PUTs { priority } on blur', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/primary/config', async (route) => {
+      if (route.request().method() === 'PUT')
+        puts.push(JSON.parse(route.request().postData() || '{}'))
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedSlots(page, [PRIMARY, UTILITY])
+    await page.goto('/#slots/primary')
+    await expect(page.locator('.drawer')).toBeVisible()
+    const prio = page.locator('[data-testid="slot-priority-input"]')
+    // Collapsed by default — the row sits inside the Advanced disclosure.
+    await expect(prio).toBeHidden()
+    await page.locator('details.adv-disclosure > summary').click()
+    await expect(prio).toBeVisible()
+    await prio.fill('10')
+    await prio.blur()
+    await expect.poll(() => puts.length).toBeGreaterThan(0)
+    expect(puts[0]).toEqual({ priority: 10 })
   })
 })


### PR DESCRIPTION
## What changed

- **Field-info popups no longer collapse to one word per line.** `.field-info-pop` is absolutely positioned inside its ~19px icon wrapper, so shrink-to-fit resolved against that tiny containing block. `width: max-content` (capped at the existing 280px) sizes it to the text instead. Fixes every `(i)` popup app-wide (slot/model drawers, settings pages).
- **Slot drawer lifecycle controls consolidated.** Auto-Load moved from the Model section into the drawer header next to the Pinned toggle, same instant-apply style — the pair now reads as one story: Auto-Load = when the slot starts (boot), Pin = whether it may be stopped (eviction exemption + force-guarded unload/delete). Eviction priority moved into the Advanced disclosure. Net: two fewer always-visible rows; NPU slots (no Model section) gain the Auto-Load toggle.
- **Copy clarified.** Auto-Load and Pin tooltips now define each control against the other.

## Why

The drawer was getting tall, and Pinned vs Auto-load read as competing features when they're orthogonal (startup vs residency).

## Verification

- `slot-pin-toggle-v3` spec updated for the two-toggle header (testid selectors) and extended: P4 header Auto-Load fires `PUT /config { autoload }`; P5 priority hidden until Advanced opens, `PUT /config { priority }` on blur.
- 20/20 e2e green (`slot-pin-toggle-v3` + `slot-edit-controls-v3`), eslint clean, CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)