### PR TITLE
feat(slots): per-slot divergence path — profile flag overlay + cross-device picker

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -70,7 +70,7 @@ from hal0.config.schema import (
     resolve_chat_template,
     resolve_profile_flags,
 )
-from hal0.errors import Hal0Error
+from hal0.errors import Hal0Error, UnprocessableEntity
 from hal0.http_client import async_client
 from hal0.model_meta import model_is_mtp_eligible
 from hal0.profiles import ProfileCatalog
@@ -935,7 +935,30 @@ def _llama_argv_segments(
         ("model_extra_args", md_extra_tokens),
     ]
     if slot_profile_flags.strip():
-        segments.append(("slot_profile", shlex.split(slot_profile_flags)))
+        try:
+            _profile_tokens = shlex.split(slot_profile_flags)
+        except ValueError as exc:
+            # A profile's flags string is free text (operator-editable on
+            # disk) and the create/edit path has no quoting validator —
+            # unmatched quotes only surface here, where an unhandled
+            # ValueError would otherwise 500 the launch/preview. Fail with a
+            # controlled config error instead.
+            raise UnprocessableEntity(
+                f"divergent slot profile flags are not valid shell text: {exc}",
+                code="slot.profile_flags_malformed",
+                details={"flags": slot_profile_flags},
+            ) from exc
+        # jinja is a runner+model CAPABILITY, resolved once as
+        # ``effective_jinja`` and injected/suppressed through
+        # ``model_defaults.extra_args`` above — never through a raw profile
+        # flag. llama-server has no ``--no-jinja`` negation, so a legacy or
+        # hand-authored profile's own ``--jinja`` token would otherwise
+        # permanently defeat an explicit ``defaults.jinja=false`` once it
+        # rides the (higher-precedence) slot_profile segment. Strip it so
+        # the overlay can never outrank the already-computed capability.
+        _profile_tokens = [t for t in _profile_tokens if t != "--jinja"]
+        if _profile_tokens:
+            segments.append(("slot_profile", _profile_tokens))
     segments += [
         ("slot_hardware", slot_hw_tokens),
         ("chat_template", chat_tokens),
@@ -1351,7 +1374,14 @@ def _resolve_llama_scalars(
     #   * the names differ;
     #   * the resolved profile IS the slot's named one — a missing-profile
     #     fallback to the backend base (``_resolve_profile_or_base``) must not
-    #     inject flags the operator never picked.
+    #     inject flags the operator never picked;
+    #   * the profile actually FITS the slot (``profile_fits_slot`` — same
+    #     supported_slot_types + device_class/backend predicate the drawer's
+    #     cross-device picker and Q1 adoption already gate on). A profile
+    #     assigned out-of-band (API, hand-edited TOML) that names a wrong-type
+    #     profile (e.g. ``embedding``/``kokoro`` on an LLM slot) must not
+    #     inject mode-changing flags (``--embedding``, ``--model_path``) that
+    #     were inert before this overlay existed.
     # No MTP expansion here (``resolve_profile_flags`` with no override): the
     # ``--spec-draft-*`` bundle stays model-driven (see _effective_mtp).
     slot_profile_flags = ""
@@ -1366,7 +1396,10 @@ def _resolve_llama_scalars(
         and _cfg_profile != _provenance
         and (_resolved_name is None or _resolved_name == _cfg_profile)
     ):
-        slot_profile_flags = str(resolve_profile_flags(profile) or "").strip()
+        from hal0.slots.profile_adopt import profile_fits_slot
+
+        if profile_fits_slot(_cfg_profile, slot_cfg):
+            slot_profile_flags = str(resolve_profile_flags(profile) or "").strip()
         if slot_profile_flags and for_launch:
             log.info(
                 "slot.profile_divergence_applied",

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -834,6 +834,7 @@ def _llama_argv_segments(
     slot_threads: int | None = None,
     slot_parallel: int | None = None,
     extra_args: str | None = None,
+    slot_profile_flags: str = "",
 ) -> list[tuple[str, list[str]]]:
     """Build the ordered, labelled llama-server argv segments (SINGLE SOURCE).
 
@@ -848,19 +849,29 @@ def _llama_argv_segments(
     fields, emitted in a TRUSTED ``slot_hardware`` segment. The MODEL still owns
     the logical, device-agnostic tune — free-form ``defaults.extra_args``
     (``model_extra_args`` segment, still screened against the §21.7 managed-arg
-    denylist by :func:`~hal0.slots.argv.resolve_argv`). The ``profile`` segment
-    stays removed — a profile is a copy-on-stamp template, read at stamp time,
-    never at launch.
+    denylist by :func:`~hal0.slots.argv.resolve_argv`). The old ``profile``
+    segment stays removed — a profile is a copy-on-stamp template, read at
+    stamp time, not at launch, whenever the slot's profile matches the model's
+    stamped provenance (``defaults.profile``).
+
+    Divergence overlay (#1636): when the slot's profile DIFFERS from the
+    model's provenance, ``slot_profile_flags`` carries that profile's resolved
+    flag text and is emitted as an UNTRUSTED ``slot_profile`` segment layered
+    over the model tune — the per-slot flag-divergence path that replaced the
+    retired duplicate-for-device model flow (PR #1635). The caller
+    (:func:`_resolve_llama_scalars`) computes it divergence-gated; aligned and
+    provenance-less slots pass ``""`` and launch byte-identical to the stamped
+    tune.
 
     Precedence (lowest → highest; ``resolve_argv``/``normalize_argv`` keeps the
     LAST occurrence of each canonical flag)::
 
-        base < model_extra_args < slot_hardware < chat_template < mmproj
+        base < model_extra_args < slot_profile < slot_hardware < chat_template < mmproj
 
-    The slot hardware segment sits AFTER ``model_extra_args`` so the slot's
-    typed ``-ngl``/``--threads`` win over any collision a model tune smuggled in
-    (defense in depth — the model/profile flag save also hard-rejects
-    hardware flags, spec §5).
+    The slot hardware segment sits AFTER ``model_extra_args`` and
+    ``slot_profile`` so the slot's typed ``-ngl``/``--threads`` win over any
+    collision a model tune or divergent profile smuggled in (defense in depth
+    — the model/profile flag save also hard-rejects hardware flags, spec §5).
 
     ``profile_flags`` / ``slot_parallel`` / ``extra_args`` are accepted-and-
     ignored (kept for call-site compat until the sunset ratchet drops the
@@ -913,13 +924,24 @@ def _llama_argv_segments(
     chat_tokens = ["--chat-template-file", chat_template_path] if chat_template_path else []
     mmproj_tokens = ["--mmproj", mmproj] if mmproj else []
 
-    return [
+    # Divergent slot-profile overlay (#1636): free-form/operator-editable, so it
+    # rides an UNTRUSTED label (managed-arg screen in resolve_argv). Sits above
+    # the model tune (the divergence wins collisions) but below slot_hardware
+    # (typed slot fields stay authoritative). The segment appears ONLY when a
+    # divergence produced flags — the aligned case keeps the exact golden #5
+    # segment shape (tests/golden_paths/test_gp05_stamped_launch_layering.py).
+    segments: list[tuple[str, list[str]]] = [
         ("base", base),
         ("model_extra_args", md_extra_tokens),
+    ]
+    if slot_profile_flags.strip():
+        segments.append(("slot_profile", shlex.split(slot_profile_flags)))
+    segments += [
         ("slot_hardware", slot_hw_tokens),
         ("chat_template", chat_tokens),
         ("mmproj", mmproj_tokens),
     ]
+    return segments
 
 
 def _llama_launch_plan(
@@ -940,6 +962,7 @@ def _llama_launch_plan(
     slot_threads: int | None = None,
     slot_parallel: int | None = None,
     env: dict[str, str] | None = None,
+    slot_profile_flags: str = "",
 ) -> RuntimeLaunchPlan:
     """Build the GPU/llama-server :class:`RuntimeLaunchPlan`.
 
@@ -964,6 +987,7 @@ def _llama_launch_plan(
         slot_threads=slot_threads,
         slot_parallel=slot_parallel,
         extra_args=extra_args,
+        slot_profile_flags=slot_profile_flags,
     )
     # resolve_argv over the labelled segments is argv-equivalent to
     # normalize_argv over the flat concatenation (pinned by tests/slots/
@@ -1315,6 +1339,44 @@ def _resolve_llama_scalars(
     # no longer enter the argv chain (see _llama_argv_segments).
     flags_str = ""
 
+    # Divergent slot-profile overlay (#1636): a slot whose ``profile`` differs
+    # from the model's stamped provenance (``defaults.profile``) launches with
+    # that profile's flags layered over the model tune (the ``slot_profile``
+    # segment) — the per-slot flag-divergence path replacing the retired
+    # duplicate-for-device model flow. Gated three ways so the common case
+    # stays byte-identical to golden #5:
+    #   * the slot names a profile AND the model records a provenance — a
+    #     provenance-less (hand-authored) tune has made no profile choice, so
+    #     there is nothing to diverge from;
+    #   * the names differ;
+    #   * the resolved profile IS the slot's named one — a missing-profile
+    #     fallback to the backend base (``_resolve_profile_or_base``) must not
+    #     inject flags the operator never picked.
+    # No MTP expansion here (``resolve_profile_flags`` with no override): the
+    # ``--spec-draft-*`` bundle stays model-driven (see _effective_mtp).
+    slot_profile_flags = ""
+    _cfg_profile = str(slot_cfg.get("profile") or "")
+    _mi_defaults = model_info.get("defaults")
+    _provenance = _mi_defaults.get("profile") if isinstance(_mi_defaults, Mapping) else None
+    _resolved_name = getattr(profile, "name", None)
+    if (
+        _cfg_profile
+        and isinstance(_provenance, str)
+        and _provenance
+        and _cfg_profile != _provenance
+        and (_resolved_name is None or _resolved_name == _cfg_profile)
+    ):
+        slot_profile_flags = str(resolve_profile_flags(profile) or "").strip()
+        if slot_profile_flags and for_launch:
+            log.info(
+                "slot.profile_divergence_applied",
+                extra={
+                    "slot": str(slot_cfg.get("name") or ""),
+                    "profile": _cfg_profile,
+                    "model_profile": _provenance,
+                },
+            )
+
     if for_launch:
         workers = slot_cfg.get("workers")
         if workers is not None and int(workers or 1) != 1:
@@ -1458,6 +1520,7 @@ def _resolve_llama_scalars(
     return {
         "image": str(image),
         "flags_str": str(flags_str),
+        "slot_profile_flags": str(slot_profile_flags),
         "context_size": context_size,
         "extra_args": extra_args,
         "server_env": server_env,
@@ -1606,6 +1669,7 @@ class ContainerProvider(Provider):
             slot_threads=scalars["slot_threads"],
             slot_parallel=scalars["slot_parallel"],
             env=merged_env or None,
+            slot_profile_flags=scalars["slot_profile_flags"],
         )
 
     # ── ContainerProvider-specific control plane ──────────────────────────────
@@ -2240,6 +2304,7 @@ def _resolve_slot_argv(
         slot_threads=scalars["slot_threads"],
         slot_parallel=scalars["slot_parallel"],
         extra_args=scalars["extra_args"],
+        slot_profile_flags=scalars["slot_profile_flags"],
     )
     return str(scalars["image"]), resolve_argv(segments)
 

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -130,9 +130,16 @@ SLOT_HARDWARE_FLAGS: frozenset[str] = frozenset(
 #     row's free-form launcher flags; NOT the schema-computed ``-ngl`` from
 #     ``defaults.n_gpu_layers``, which rides the trusted ``model_defaults``
 #     segment — see ``container._llama_argv_segments``).
+#   * ``slot_profile``     — a DIVERGENT slot profile's flag text (#1636):
+#     emitted only when ``slot.profile`` differs from the model's stamped
+#     provenance (``defaults.profile``). Profile saves already screen these
+#     flags, but the profile file is operator-editable on disk, so the launch
+#     merge re-screens them like any other free-form source.
 # A future request-level ``llamacpp_args`` segment (§7.1a 5-tier precedence
 # rewrite) adds its own label here so it rides the same guard.
-UNTRUSTED_SEGMENT_LABELS: frozenset[str] = frozenset({"extra_args", "model_extra_args"})
+UNTRUSTED_SEGMENT_LABELS: frozenset[str] = frozenset(
+    {"extra_args", "model_extra_args", "slot_profile"}
+)
 
 
 @dataclass(frozen=True)

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -384,12 +384,26 @@ def resolve_argv(segments: list[tuple[str, list[str]]]) -> ResolvedArgv:
 
     Raises:
         hal0.errors.BadRequest: an untrusted segment sets a managed flag.
+
+    ``slot_profile`` (#1636) additionally gets its hardware flags
+    (``SLOT_HARDWARE_FLAGS``) silently stripped rather than hard-rejected: the
+    profile save path only started enforcing the §5 partition guard after
+    grandfathered/hand-edited profiles could already carry ``-dev``/
+    ``--threads``. Before the divergence overlay existed, those flags were
+    never read at launch at all (live profile flags were inert); stripping
+    here preserves that "ignored" behaviour instead of failing the launch,
+    while still guaranteeing the slot's typed hardware fields are the only
+    source for those flags — even when the typed field is unset and would
+    otherwise leave nothing to out-rank the profile's stale value in the
+    last-wins dedup.
     """
     tokens: list[str] = []
     sources: list[str] = []
     for label, seg in segments:
         if label in UNTRUSTED_SEGMENT_LABELS:
             _deny_managed_flags(seg, segment=label)
+        if label == "slot_profile":
+            seg, _stripped = strip_managed_flags(seg, denylist=SLOT_HARDWARE_FLAGS)
         for tok in seg:
             tokens.append(tok)
             sources.append(label)

--- a/tests/providers/test_slot_profile_divergence.py
+++ b/tests/providers/test_slot_profile_divergence.py
@@ -1,0 +1,155 @@
+"""Divergent slot-profile overlay (#1636) — per-slot flag divergence.
+
+PR #1635 removed the duplicate-for-device model flow; the divergence path is
+now: a slot whose ``profile`` differs from the model's stamped provenance
+(``defaults.profile``) launches with that profile's flags layered over the
+model tune in an UNTRUSTED ``slot_profile`` segment:
+
+    base < model_extra_args < slot_profile < slot_hardware < chat_template < mmproj
+
+The ALIGNED case (slot profile == provenance, or no provenance at all) stays
+byte-identical to golden #5 (tests/golden_paths/
+test_gp05_stamped_launch_layering.py) — no ``slot_profile`` segment, no live
+profile-flag read.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import ProfileConfig
+from hal0.errors import BadRequest
+from hal0.providers.container import _llama_argv_segments, _resolve_llama_scalars
+from hal0.slots.argv import resolve_argv
+
+
+class _NamedProfile(ProfileConfig):
+    """ProfileConfig plus the ``name`` a ResolvedProfile carries."""
+
+    name: str = ""
+
+
+def _profile(name: str, flags: str) -> _NamedProfile:
+    return _NamedProfile(name=name, flags=flags, mtp=False)
+
+
+def _model(provenance: str | None, extra_args: str = "-b 2048") -> dict:
+    defaults: dict = {"extra_args": extra_args}
+    if provenance is not None:
+        defaults["profile"] = provenance
+    return {
+        "_model_key": "qwen3-4b",
+        "path": "/m/qwen3-4b.gguf",
+        "tags": ["chat"],
+        "defaults": defaults,
+    }
+
+
+def _slot(profile: str) -> dict:
+    return {"name": "coder", "profile": profile, "port": 8082}
+
+
+# ── divergence gate (_resolve_llama_scalars) ─────────────────────────────────
+
+
+def test_divergent_profile_produces_flags():
+    scalars = _resolve_llama_scalars(
+        _slot("coding"), _model("chat"), _profile("coding", "--temp 0.7 --top-k 40")
+    )
+    assert scalars["slot_profile_flags"] == "--temp 0.7 --top-k 40"
+
+
+def test_aligned_profile_produces_no_flags():
+    scalars = _resolve_llama_scalars(
+        _slot("chat"), _model("chat"), _profile("chat", "--temp 0.7")
+    )
+    assert scalars["slot_profile_flags"] == ""
+
+
+def test_provenance_less_model_produces_no_flags():
+    # A hand-authored tune records no profile choice — nothing to diverge from.
+    scalars = _resolve_llama_scalars(
+        _slot("coding"), _model(None), _profile("coding", "--temp 0.7")
+    )
+    assert scalars["slot_profile_flags"] == ""
+
+
+def test_base_fallback_profile_produces_no_flags():
+    # The slot names a profile that no longer resolves; the caller fell back to
+    # the backend base profile. Its flags must NOT be injected — the operator
+    # never picked them.
+    scalars = _resolve_llama_scalars(
+        _slot("retired-profile"), _model("chat"), _profile("rocm", "-fa on")
+    )
+    assert scalars["slot_profile_flags"] == ""
+
+
+def test_legacy_flags_str_stays_empty():
+    scalars = _resolve_llama_scalars(
+        _slot("coding"), _model("chat"), _profile("coding", "--temp 0.7")
+    )
+    assert scalars["flags_str"] == ""
+
+
+# ── segment emission + precedence (_llama_argv_segments) ─────────────────────
+
+
+def _segments(slot_profile_flags: str = "", **kw):
+    return _llama_argv_segments(
+        port=8082,
+        model_path="/m/qwen3-4b.gguf",
+        model_defaults={"extra_args": "-b 2048 --temp 0"},
+        slot_profile_flags=slot_profile_flags,
+        **kw,
+    )
+
+
+def test_segment_emitted_between_model_tune_and_slot_hardware():
+    labels = [label for label, _ in _segments("--temp 0.7", slot_n_gpu_layers=30)]
+    assert labels.index("model_extra_args") < labels.index("slot_profile")
+    assert labels.index("slot_profile") < labels.index("slot_hardware")
+
+
+def test_no_segment_when_empty():
+    labels = {label for label, _ in _segments("")}
+    assert "slot_profile" not in labels
+
+
+def test_divergent_profile_wins_collisions_with_model_tune():
+    resolved = resolve_argv(_segments("--temp 0.7 --top-k 40"))
+    prov = {p.flag: p.source for p in resolved.provenance}
+    assert resolved.argv[resolved.argv.index("--temp") + 1] == "0.7"
+    assert prov["--temp"] == "slot_profile"
+    # Model-tune flags the profile does not mention survive underneath.
+    assert "-b" in resolved.argv
+    assert prov["-b"] == "model_extra_args"
+
+
+def test_slot_hardware_still_wins_over_divergent_profile():
+    # Defense in depth: profile saves reject hardware flags, but a hand-edited
+    # profiles.toml can smuggle one — the typed slot field must win.
+    resolved = resolve_argv(_segments("--threads 4", slot_threads=16))
+    assert resolved.argv[resolved.argv.index("--threads") + 1] == "16"
+
+
+def test_managed_flag_in_divergent_profile_fails_loudly():
+    with pytest.raises(BadRequest):
+        resolve_argv(_segments("--port 9999"))
+
+
+# ── end-to-end scalars → segments parity ─────────────────────────────────────
+
+
+def test_scalars_thread_into_segments():
+    scalars = _resolve_llama_scalars(
+        _slot("coding"), _model("chat"), _profile("coding", "--temp 0.7")
+    )
+    segments = _llama_argv_segments(
+        port=8082,
+        model_path="/m/qwen3-4b.gguf",
+        model_defaults=scalars["model_defaults"],
+        slot_profile_flags=scalars["slot_profile_flags"],
+    )
+    resolved = resolve_argv(segments)
+    prov = {p.flag: p.source for p in resolved.provenance}
+    assert prov["--temp"] == "slot_profile"

--- a/tests/providers/test_slot_profile_divergence.py
+++ b/tests/providers/test_slot_profile_divergence.py
@@ -60,9 +60,7 @@ def test_divergent_profile_produces_flags():
 
 
 def test_aligned_profile_produces_no_flags():
-    scalars = _resolve_llama_scalars(
-        _slot("chat"), _model("chat"), _profile("chat", "--temp 0.7")
-    )
+    scalars = _resolve_llama_scalars(_slot("chat"), _model("chat"), _profile("chat", "--temp 0.7"))
     assert scalars["slot_profile_flags"] == ""
 
 

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -87,6 +87,50 @@ function compatibleModels(models, { type, backend }) {
 		);
 }
 
+// Device-class token for profile/runner fit filters — mirrors the backend
+// derivation in profile_adopt (gpu-* → gpu; npu/cpu/img as-is). ONE helper so
+// the drawer's baseline deviceClass and the cross-profile target-device class
+// (below) can't drift apart.
+function deviceClassOf(device) {
+	return device.startsWith("gpu")
+		? "gpu"
+		: ["npu", "cpu", "img"].includes(device)
+			? device
+			: "cpu";
+}
+
+// A GPU/CPU backend a profile can declare → the device it drives
+// (map_backend_to_device's FE mirror). Module-level so the cross-device
+// picker (#1636) and its Codex-flagged fixes share one source of truth
+// instead of three independently-drifting inline copies.
+const BACKEND_DEVICE = {
+	rocm: "gpu-rocm",
+	vulkan: "gpu-vulkan",
+	cuda: "gpu-cuda",
+	cpu: "cpu",
+};
+
+// Cross-device target for a candidate profile (#1636 + Codex P2 fixes):
+// - must declare a recognized backend that ACTUALLY differs from the slot's
+//   current backend (same-backend device_class mismatches are not a "switch"
+//   — _reconcile_device_profile leaves `device` alone when backends already
+//   agree, so admitting them here would silently persist a profile the
+//   normal `fit` predicate rejects, e.g. device_class:"cpu"/backend:"rocm" on
+//   a gpu-rocm slot).
+// - its device_class (if declared) must be compatible with the CLASS OF THE
+//   TARGET device, not the slot's current class.
+// Returns the target device string, or null when the profile doesn't
+// resolve to a genuine cross-backend switch.
+function crossDeviceTarget(profile, devBackend) {
+	if (!profile?.backend || !BACKEND_DEVICE[profile.backend]) return null;
+	if (profile.backend === devBackend) return null;
+	const targetDevice = BACKEND_DEVICE[profile.backend];
+	const targetClass = deviceClassOf(targetDevice);
+	if (profile.device_class && profile.device_class !== targetClass)
+		return null;
+	return targetDevice;
+}
+
 // ─── Create-slot modal ──────────────────────────────────────────
 // Decomposed (D2) into dash/slots/CreateSlotModal.jsx — the create flow is now
 // a pure instance: pick a model (it carries tune/device/runner) + name it. The
@@ -679,11 +723,36 @@ function EditSlotDrawer({ open, slot, onClose }) {
 
 	// Device-class token for profile/runner fit filters — mirrors the
 	// backend derivation in profile_adopt (gpu-* → gpu; npu/cpu/img as-is).
-	const deviceClass = device.startsWith("gpu")
-		? "gpu"
-		: ["npu", "cpu", "img"].includes(device)
-			? device
-			: "cpu";
+	const deviceClass = deviceClassOf(device);
+
+	// Pending cross-device target (#1636 Codex fix): when the selected
+	// profile is a genuine cross-backend switch (see crossDeviceTarget), the
+	// device this slot will actually launch on AFTER Save is the profile's
+	// backend device, not the still-persisted `device` state — the drawer
+	// has no direct device control, so `device` never moves on its own.
+	// Every dependent filter below (Runner Image/Binary fit, the Model
+	// swap picker's rocmfp4 gate) reads `pendingDevice`/`pendingDeviceClass`
+	// instead of `device` so they preview the POST-save world rather than
+	// hiding the very runner/model the operator is being told to pick.
+	const pendingDevice = (() => {
+		// Only a live in-drawer edit counts as "pending" — a persisted slot
+		// whose device and profile already disagree (a pre-existing
+		// misconfiguration the HW fit-check warning exists to surface) must
+		// keep reading its REAL device here, not a profile-implied one the
+		// operator never picked.
+		if (profileSel === (slot.profile || "")) return device;
+		const all = Array.isArray(profilesQuery.data) ? profilesQuery.data : [];
+		const typeFit = all.filter(
+			(p) =>
+				!Array.isArray(p.supported_slot_types) ||
+				p.supported_slot_types.includes(slot.type),
+		);
+		const p = typeFit.find((x) => x.name === profileSel);
+		if (!p) return device;
+		const target = crossDeviceTarget(p, deviceBackend(device));
+		return target || device;
+	})();
+	const pendingDeviceClass = deviceClassOf(pendingDevice);
 
 	// Instant-apply pin/unpin for the drawer header toggle (§21.10, #1367).
 	// Fires the PUT, toasts the result, and lets the slots poll re-render from
@@ -875,33 +944,40 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		// _reconcile_device_profile flips the slot's device to match (profile
 		// changed alone → device rederived). Only gpu/cpu-class slots
 		// transition (npu/img route to different runtime families —
-		// hard-blocked in model_fit), and only a backend-declaring profile can
-		// drive the flip; a bare device_class hint cannot.
-		const BACKEND_DEVICE = {
-			rocm: "gpu-rocm",
-			vulkan: "gpu-vulkan",
-			cuda: "gpu-cuda",
-			cpu: "cpu",
-		};
+		// hard-blocked in model_fit), and only a GENUINE backend switch can
+		// drive the flip — crossDeviceTarget excludes same-backend
+		// device_class mismatches (those aren't a switch;
+		// _reconcile_device_profile leaves `device` alone when the backend
+		// already agrees, so admitting them here would silently persist a
+		// profile the normal `fit` predicate rejects, e.g.
+		// device_class:"cpu"/backend:"rocm" on a gpu-rocm slot) and requires
+		// the profile's device_class (if any) to match the TARGET class.
 		const crossFit = ["gpu", "cpu"].includes(deviceClass)
 			? typeFit.filter(
-					(p) =>
-						!fit.includes(p) &&
-						p.backend &&
-						BACKEND_DEVICE[p.backend] &&
-						!["npu", "img"].includes(p.device_class || ""),
+					(p) => !fit.includes(p) && !!crossDeviceTarget(p, devBackend),
 				)
 			: [];
 		const fitNames = fit.map((p) => p.name);
 		const listedNames = [...fitNames, ...crossFit.map((p) => p.name)];
 		const adoptedFromModel = !!profileSel && profileSel === modelProfile;
+		// Does the selected profile even resolve? A deleted/renamed profile
+		// stays selectable (out-of-vocab option below) but
+		// _resolve_profile_or_base falls back to the backend's base profile
+		// and _resolve_llama_scalars suppresses the overlay when the
+		// resolved name doesn't match the configured one — so an
+		// unresolvable profile never injects flags. Gate the divergence hint
+		// on actually resolving, or it tells the operator about an overlay
+		// that will not launch.
+		const profileResolves = all.some((p) => p.name === profileSel);
 		// Divergence overlay (#1636): a slot profile that differs from the
 		// model's stamped provenance layers its flags over the model tune at
 		// launch (the slot_profile argv segment).
 		const diverges =
-			!!profileSel && !!modelProfile && profileSel !== modelProfile;
+			profileResolves && !!modelProfile && profileSel !== modelProfile;
 		const selCross = crossFit.find((p) => p.name === profileSel) || null;
-		const targetDevice = selCross ? BACKEND_DEVICE[selCross.backend] : null;
+		const targetDevice = selCross
+			? crossDeviceTarget(selCross, devBackend)
+			: null;
 		// Cross-device cautions: an explicit BINARY or a pinned image may not
 		// serve the target backend — warn before Save, never block (§4).
 		const crossCautions = [];
@@ -1271,7 +1347,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					{(() => {
 						const backends = systemInfoQuery.data?.backends ?? {};
 						const binaryKeys = Object.keys(backends);
-						const devBackend = deviceBackend(device);
+						// A pending cross-backend profile switch (#1636 Codex fix) moves
+						// this slot's device on Save even though `device` itself never
+						// changes in this drawer — read the pending device/class here so
+						// Runner Image/Binary options preview the POST-save fit instead
+						// of hiding the very runner the divergence hint tells the
+						// operator to pick.
+						const devBackend = deviceBackend(pendingDevice);
 						// Runner options filtered down to the ones that fit this slot:
 						// device_class exact (runner_matches), the family's slot types
 						// (_supported_slot_types — so a gpu llm slot is not offered
@@ -1280,7 +1362,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						// selectable underneath.
 						const deviceFitBinaryKeys = binaryKeys.filter((k) => {
 							const r = backends[k] || {};
-							if (r.device_class && r.device_class !== deviceClass)
+							if (r.device_class && r.device_class !== pendingDeviceClass)
 								return false;
 							const types = FAMILY_SLOT_TYPES[r.runtime_family];
 							if (types && slot.type && !types.includes(slot.type))
@@ -1575,8 +1657,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							// Derive the backend from the SELECTED device (reactive) so the rocmfp4
 							// filter re-evaluates immediately when the operator switches the HW-grid
 							// device — before Save is clicked. (Device is the single owner of the
-							// rocm/vulkan axis now — spec-hw-slot-ownership §2.)
-							const selBackend = deviceBackend(device) || slot.backend;
+							// rocm/vulkan axis now — spec-hw-slot-ownership §2.) A pending
+							// cross-backend profile switch (#1636 Codex fix) also moves this
+							// slot's eventual device, so read pendingDevice rather than the
+							// still-unchanged `device` state — otherwise this list keeps
+							// offering rocmfp4-only models a ROCm→Vulkan switch will no
+							// longer fit.
+							const selBackend = deviceBackend(pendingDevice) || slot.backend;
 							const compatible = compatibleModels(modelsQuery.data, {
 								type: slot.type,
 								backend: selBackend,

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -262,10 +262,12 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	// hatch the field originally existed for.
 	const [pinCustom, setPinCustom] = useStateSM(false);
 	// Runtime profile (SlotConfig.profile) — picks the runtime family,
-	// device-class gating and MTP draft backend. NOT a flags source at launch:
-	// profile flags are copy-on-stamp into model.defaults.extra_args (model
-	// drawer). Rides Save (PUT /config {profile}), restart-required; the
-	// backend's _reconcile_device_profile keeps device/profile coherent.
+	// device-class gating and MTP draft backend. Flags: copy-on-stamp into
+	// model.defaults.extra_args (model drawer) when aligned with the model's
+	// provenance; a DIVERGENT slot profile overlays its flags on the model
+	// tune at launch (#1636). Rides Save (PUT /config {profile}),
+	// restart-required; the backend's _reconcile_device_profile keeps
+	// device/profile coherent (a cross-backend profile flips the device).
 	const [profileSel, setProfileSel] = useStateSM(slot?.profile || "");
 	// Eviction priority (spec 2026-08-02) — instant-apply on blur/Enter, NOT
 	// part of the Save batch (see the pinned-toggle-shaped handler below).
@@ -843,44 +845,96 @@ function EditSlotDrawer({ open, slot, onClose }) {
 	};
 
 	// Runtime profile row — the slot's SlotConfig.profile. Controls the runtime
-	// family, device-class gating and MTP draft backend; profile FLAGS are
-	// copy-on-stamp into the model tune (model drawer), never read at launch.
+	// family, device-class gating and MTP draft backend. Flags: aligned with
+	// the model's stamped provenance (defaults.profile) they are copy-on-stamp
+	// only (model drawer); a DIVERGENT slot profile overlays its flags on the
+	// model tune at launch (#1636, the slot_profile argv segment). A profile
+	// declaring another backend switches the slot's device on save (the
+	// backend's _reconcile_device_profile rederives it).
 	// Rendered inside the Model group right under the model select (it rides
 	// the model choice), or under its own group on an NPU slot where the Model
 	// group is replaced by the NPU capability matrix.
 	const profileRow = (() => {
 		const all = Array.isArray(profilesQuery.data) ? profilesQuery.data : [];
 		const devBackend = deviceBackend(device);
-		// Mirror backend profile_fits_slot: slot type supported +
+		const modelProfile = curModelRow?.defaults?.profile || "";
+		// Mirror backend profile_fits_slot: slot type supported first, then
 		// device_class match + backend match (when both declared).
-		const fit = all.filter(
+		const typeFit = all.filter(
 			(p) =>
-				(!Array.isArray(p.supported_slot_types) ||
-					p.supported_slot_types.includes(slot.type)) &&
+				!Array.isArray(p.supported_slot_types) ||
+				p.supported_slot_types.includes(slot.type),
+		);
+		const fit = typeFit.filter(
+			(p) =>
 				(!p.device_class || p.device_class === deviceClass) &&
 				(!p.backend || !devBackend || p.backend === devBackend),
 		);
+		// Cross-device candidates (#1636): a profile declaring ANOTHER llama
+		// backend is selectable — on save the backend's
+		// _reconcile_device_profile flips the slot's device to match (profile
+		// changed alone → device rederived). Only gpu/cpu-class slots
+		// transition (npu/img route to different runtime families —
+		// hard-blocked in model_fit), and only a backend-declaring profile can
+		// drive the flip; a bare device_class hint cannot.
+		const BACKEND_DEVICE = {
+			rocm: "gpu-rocm",
+			vulkan: "gpu-vulkan",
+			cuda: "gpu-cuda",
+			cpu: "cpu",
+		};
+		const crossFit = ["gpu", "cpu"].includes(deviceClass)
+			? typeFit.filter(
+					(p) =>
+						!fit.includes(p) &&
+						p.backend &&
+						BACKEND_DEVICE[p.backend] &&
+						!["npu", "img"].includes(p.device_class || ""),
+				)
+			: [];
 		const fitNames = fit.map((p) => p.name);
-		const adoptedFromModel =
-			!!profileSel && profileSel === (curModelRow?.defaults?.profile || "");
-		// The options are filtered against the slot's device, which is no
-		// longer editable here — a profile persisted on disk can still be
-		// out-of-vocab for it. Saving a
-		// profile+device pair with conflicting backends is a hard
-		// SlotConfigError (_reconcile_device_profile), so warn instead of
-		// silently PUTting the conflict.
+		const listedNames = [...fitNames, ...crossFit.map((p) => p.name)];
+		const adoptedFromModel = !!profileSel && profileSel === modelProfile;
+		// Divergence overlay (#1636): a slot profile that differs from the
+		// model's stamped provenance layers its flags over the model tune at
+		// launch (the slot_profile argv segment).
+		const diverges =
+			!!profileSel && !!modelProfile && profileSel !== modelProfile;
+		const selCross = crossFit.find((p) => p.name === profileSel) || null;
+		const targetDevice = selCross ? BACKEND_DEVICE[selCross.backend] : null;
+		// Cross-device cautions: an explicit BINARY or a pinned image may not
+		// serve the target backend — warn before Save, never block (§4).
+		const crossCautions = [];
+		if (selCross) {
+			const backendsCat = systemInfoQuery.data?.backends ?? {};
+			const selRunner = binary ? backendsCat[binary] : null;
+			const sup = selRunner ? runnerBackends(selRunner) : [];
+			if (binary && sup.length > 0 && !sup.includes(selCross.backend))
+				crossCautions.push(
+					`Runner binary "${binary}" does not list backend "${selCross.backend}" — clear it or pick a matching binary.`,
+				);
+			if ((imagePin || "").trim())
+				crossCautions.push(
+					"The pinned runner image may not serve the new backend — check or clear the pin.",
+				);
+		}
+		// A persisted profile that is neither same-device nor a viable
+		// transition target (bare device_class hint, npu/img class, unknown):
+		// stays selectable, but the device cannot follow it — warn.
 		const profileFitWarn =
-			profileSel && all.length > 0 && !fitNames.includes(profileSel)
-				? `Profile "${profileSel}" does not fit device "${device}" — saving both together is rejected. Pick a listed profile or revert the device.`
+			profileSel && all.length > 0 && !listedNames.includes(profileSel)
+				? `Profile "${profileSel}" does not fit device "${device}" and declares no backend the device could follow — the slot may misbehave at launch. Pick a listed profile.`
 				: null;
 		return (
 			<div className="form-row">
 				<div className="form-lbl">
 					<span>Profile</span>
-					<FieldInfoIcon description="⟳ Runtime profile — picks the runtime family, device-class
-						gating and the MTP draft backend. Flags are NOT read from here
-						at launch; they are stamped into the model's launch flags on
-						the model drawer." />
+					<FieldInfoIcon description="⟳ Runtime profile — picks the runtime family and the MTP
+						draft backend. Matching the model's profile: flags come solely
+						from the model's stamped tune. Diverging from it: this
+						profile's flags overlay the model tune for this slot at
+						launch. A profile declaring another backend also switches the
+						slot's device on save." />
 				</div>
 				<div className="form-ctl">
 					<select
@@ -891,7 +945,7 @@ function EditSlotDrawer({ open, slot, onClose }) {
 					>
 						{/* keep a none/out-of-vocab persisted profile selectable */}
 						{!slot.profile && <option value="">— none —</option>}
-						{profileSel && !fitNames.includes(profileSel) && (
+						{profileSel && !listedNames.includes(profileSel) && (
 							<option value={profileSel}>{profileSel}</option>
 						)}
 						{fit.map((p) => (
@@ -900,11 +954,48 @@ function EditSlotDrawer({ open, slot, onClose }) {
 								{p.intent ? ` · ${p.intent}` : ""}
 							</option>
 						))}
+						{crossFit.length > 0 && (
+							<optgroup label="Other backend — switches slot device">
+								{crossFit.map((p) => (
+									<option key={p.name} value={p.name} title={p.intent}>
+										{p.name} · → {BACKEND_DEVICE[p.backend]}
+										{p.intent ? ` · ${p.intent}` : ""}
+									</option>
+								))}
+							</optgroup>
+						)}
 					</select>
 					{adoptedFromModel && (
 						<div className="hint">
 							Adopted from the bound model's preference — swapping the model
 							may change it.
+						</div>
+					)}
+					{diverges && (
+						<div className="hint" data-testid="slot-profile-diverges">
+							Diverges from the model's profile ("{modelProfile}") — this
+							profile's flags overlay the model tune for this slot at
+							launch.
+						</div>
+					)}
+					{selCross && (
+						<div
+							className="hint"
+							data-testid="slot-profile-device-switch"
+							style={{
+								marginTop: 6,
+								padding: "6px 10px",
+								borderRadius: "var(--rad-sm)",
+								border: "1px solid var(--line)",
+							}}
+						>
+							Saving switches this slot's device to "{targetDevice}"
+							(profile backend "{selCross.backend}") and restarts it.
+							{crossCautions.map((c) => (
+								<div key={c} style={{ marginTop: 4, color: "var(--warn)" }}>
+									⚠ {c}
+								</div>
+							))}
 						</div>
 					)}
 					{profileFitWarn && (

--- a/ui/src/dash/slot-modals.jsx
+++ b/ui/src/dash/slot-modals.jsx
@@ -623,6 +623,13 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		// guarded a value the launch path ignores, and #1389 was that gate vetoing
 		// unrelated saves from an unmounted subtree — a whole failure mode that
 		// removing the control makes unrepresentable.)
+		// Codex P1 (#1636 fallout): a pending cross-backend profile switch that
+		// would strand the currently-bound model — block Save until the
+		// operator swaps to a compatible model or reverts the profile pick.
+		if (strandsBoundModel) {
+			errs.profile =
+				"This profile switches the slot to a device that can't run the bound model — swap to a compatible model first, or pick a same-backend profile.";
+		}
 		if (Object.keys(errs).length > 0) {
 			setFieldErrs(errs);
 			return;
@@ -753,6 +760,28 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		return target || device;
 	})();
 	const pendingDeviceClass = deviceClassOf(pendingDevice);
+	// A live (uncommitted) cross-backend profile pick, or null — the single
+	// signal both the Save-time strand check and the Model-swap gate below
+	// key off. Split out from `pendingDevice` itself (which returns `device`
+	// as a harmless no-op fallback) so callers don't have to re-derive
+	// "is this actually pending" from an equality check on every read.
+	const pendingCrossDevice =
+		pendingDevice !== device ? pendingDevice : null;
+	// Codex P1: a Save that switches the slot to `pendingCrossDevice` also
+	// re-derives its device server-side (_reconcile_device_profile) — but the
+	// currently BOUND model rides along untouched. If that model doesn't fit
+	// the new backend (e.g. a rocmfp4 model on a ROCm→Vulkan switch), Save
+	// would strand it: a live container restarts onto a runner that can't
+	// load its own bound model. Block Save in that case (see onSaveClick)
+	// rather than let the restart fail after the fact.
+	const boundModelId = slot.model_id || slot.model || "";
+	const strandsBoundModel =
+		!!pendingCrossDevice &&
+		!!boundModelId &&
+		!compatibleModels(modelsQuery.data, {
+			type: slot.type,
+			backend: deviceBackend(pendingCrossDevice),
+		}).some((m) => m.id === boundModelId);
 
 	// Instant-apply pin/unpin for the drawer header toggle (§21.10, #1367).
 	// Fires the PUT, toasts the result, and lets the slots poll re-render from
@@ -974,7 +1003,18 @@ function EditSlotDrawer({ open, slot, onClose }) {
 		// launch (the slot_profile argv segment).
 		const diverges =
 			profileResolves && !!modelProfile && profileSel !== modelProfile;
-		const selCross = crossFit.find((p) => p.name === profileSel) || null;
+		// Only a LIVE selection change counts as "picking" a cross-device
+		// profile — a persisted slot whose profile already sits in crossFit
+		// (backend drift predating this drawer, or edited out-of-band) has
+		// not had anything picked; treating it as `selCross` would suppress
+		// the fit warning and promise a Save-time switch that `changes.profile`
+		// (false — nothing changed) never arms, while `_reconcile_device_profile`
+		// deliberately leaves that drift untouched.
+		const profileIsLiveSelection = profileSel !== (slot.profile || "");
+		const selCross =
+			(profileIsLiveSelection &&
+				crossFit.find((p) => p.name === profileSel)) ||
+			null;
 		const targetDevice = selCross
 			? crossDeviceTarget(selCross, devBackend)
 			: null;
@@ -1017,7 +1057,10 @@ function EditSlotDrawer({ open, slot, onClose }) {
 						className="input mono"
 						data-testid="slot-profile"
 						value={profileSel}
-						onChange={(e) => setProfileSel(e.target.value)}
+						onChange={(e) => {
+							setProfileSel(e.target.value);
+							setFieldErrs((p) => ({ ...p, profile: undefined }));
+						}}
 					>
 						{/* keep a none/out-of-vocab persisted profile selectable */}
 						{!slot.profile && <option value="">— none —</option>}
@@ -1088,6 +1131,22 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							}}
 						>
 							⚠ {profileFitWarn}
+						</div>
+					)}
+					{fieldErrs.profile && (
+						<div
+							className="hint"
+							data-testid="slot-profile-strands-model"
+							style={{
+								marginTop: 6,
+								padding: "6px 10px",
+								borderRadius: "var(--rad-sm)",
+								color: "var(--warn)",
+								border: "1px solid var(--warn-line)",
+								background: "var(--warn-soft)",
+							}}
+						>
+							⚠ {fieldErrs.profile}
 						</div>
 					)}
 				</div>
@@ -1657,13 +1716,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
 							// Derive the backend from the SELECTED device (reactive) so the rocmfp4
 							// filter re-evaluates immediately when the operator switches the HW-grid
 							// device — before Save is clicked. (Device is the single owner of the
-							// rocm/vulkan axis now — spec-hw-slot-ownership §2.) A pending
-							// cross-backend profile switch (#1636 Codex fix) also moves this
-							// slot's eventual device, so read pendingDevice rather than the
-							// still-unchanged `device` state — otherwise this list keeps
-							// offering rocmfp4-only models a ROCm→Vulkan switch will no
-							// longer fit.
-							const selBackend = deviceBackend(pendingDevice) || slot.backend;
+							// rocm/vulkan axis now — spec-hw-slot-ownership §2.)
+							//
+							// Codex P1: deliberately `device` here, NOT `pendingDevice`. Swap fires
+							// its own immediate POST /slots/{name}/swap, independent of the batched
+							// Save — a pending cross-backend profile pick hasn't reached the server
+							// yet, so previewing the post-Save backend here would offer a model the
+							// CURRENTLY persisted runner can't load (the live swap has no idea a
+							// device switch is staged). Gate the whole control instead (below) while
+							// a switch is pending, and keep this list honest about the real device.
+							const selBackend = deviceBackend(device) || slot.backend;
 							const compatible = compatibleModels(modelsQuery.data, {
 								type: slot.type,
 								backend: selBackend,
@@ -1687,7 +1749,8 @@ function EditSlotDrawer({ open, slot, onClose }) {
 												className="input mono"
 												style={{ flex: 1 }}
 												value={cur}
-												disabled={saving}
+												disabled={saving || !!pendingCrossDevice}
+												data-testid="slot-model-swap"
 												aria-label={`Model for ${slot.name}`}
 												onChange={(e) => {
 													const id = e.target.value;
@@ -1739,6 +1802,16 @@ function EditSlotDrawer({ open, slot, onClose }) {
 											</button>
 										</div>
 										{swapping && <div className="hint">Swapping…</div>}
+										{!swapping && pendingCrossDevice && (
+											<div
+												className="hint"
+												data-testid="slot-model-swap-blocked"
+											>
+												Model swap is unavailable while the profile pick
+												above is staged to switch this slot's device — Save
+												that change (or revert the profile) before swapping.
+											</div>
+										)}
 									</div>
 								</div>
 							);

--- a/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-drawer-profile-v3.spec.ts
@@ -280,3 +280,86 @@ test.describe('C7 — slot-owned hardware grid; no drawer profile selector', () 
     await expect(modelSel.locator('option[value="qwen-plain"]')).toHaveCount(1)
   })
 })
+
+// ─── #1636 — per-slot divergence: flag overlay + cross-device transition ────
+//
+// Option (a): a slot profile that DIFFERS from the model's stamped provenance
+// (defaults.profile) overlays its flags on the model tune at launch — the
+// drawer surfaces that divergence. Option (b): the picker offers profiles
+// declaring ANOTHER backend; selecting one flips the slot's device on save
+// (server-side _reconcile_device_profile).
+test.describe('slot profile divergence (#1636)', () => {
+  const CHAT = MOCK_DATA.slots.find(s => s.name === 'chat')!  // gpu-rocm · rocm-mtp
+
+  async function seedSlotsAndModels(page: Page, slots: any[], models: any[]) {
+    await page.addInitScript(({ slots, models }: { slots: any[]; models: any[] }) => {
+      let real: any
+      Object.defineProperty(window, 'HAL0_DATA', {
+        configurable: true, get() { return real },
+        set(v) { real = v; if (v && typeof v === 'object') { v.slots = slots; v.models = models } },
+      })
+    }, { slots, models })
+  }
+
+  const CHAT_MODEL = (profile: string) => [{
+    id: 'qwen3.6-35b-a3b', name: 'qwen3.6-35b-a3b', capabilities: ['chat'],
+    defaults: { profile, extra_args: '-b 2048' },
+  }]
+
+  test('divergent slot profile surfaces the flag-overlay hint', async ({ page }) => {
+    // Model provenance says "rocm"; the slot pins "rocm-mtp" → divergence.
+    await seedSlotsAndModels(page, [CHAT], CHAT_MODEL('rocm'))
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await expect(page.getByTestId('slot-profile-diverges')).toBeVisible()
+  })
+
+  test('aligned slot profile shows no divergence hint', async ({ page }) => {
+    await seedSlotsAndModels(page, [CHAT], CHAT_MODEL('rocm-mtp'))
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await expect(page.getByTestId('slot-profile-diverges')).toHaveCount(0)
+  })
+
+  test('cross-backend profile is offered and saving it PUTs the profile', async ({ page }) => {
+    const configPuts: any[] = []
+    await page.route('**/api/slots/chat/config', async (route) => {
+      if (route.request().method() === 'PUT') {
+        configPuts.push(JSON.parse(route.request().postData() || '{}'))
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await page.route('**/api/slots/chat/defaults', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+    await page.route('**/api/slots/chat/restart', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{}' }),
+    )
+
+    await seedSlotsAndModels(page, [CHAT], CHAT_MODEL('rocm-mtp'))
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+
+    // The gpu-rocm slot is offered the vulkan-backend profile (was filtered
+    // out pre-#1636) under the "Other backend" group…
+    const sel = page.getByTestId('slot-profile')
+    await expect(sel.locator('optgroup option[value="vulkan"]')).toHaveCount(1)
+    await sel.selectOption('vulkan')
+
+    // …and selecting it announces the device switch.
+    await expect(page.getByTestId('slot-profile-device-switch')).toBeVisible()
+    await expect(page.getByTestId('slot-profile-device-switch')).toContainText('gpu-vulkan')
+
+    await page.locator('.drawer button:has-text("Save")').click()
+    await expect.poll(() => configPuts.length).toBeGreaterThan(0)
+    expect(configPuts[0].profile).toBe('vulkan')
+  })
+
+  test('same-backend profiles carry no device-switch hint', async ({ page }) => {
+    await seedSlotsAndModels(page, [CHAT], CHAT_MODEL('rocm-mtp'))
+    await page.goto('/#slots/chat')
+    await expect(page.locator('.drawer')).toBeVisible()
+    await page.getByTestId('slot-profile').selectOption('rocm')
+    await expect(page.getByTestId('slot-profile-device-switch')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Closes #1636 — the two gaps PR #1635's duplicate-model removal left behind.

## What changed

**Gap 1 — per-slot launch-flag divergence (option a, divergence-gated).**
A slot whose `profile` differs from the model's stamped provenance (`defaults.profile`) now launches with that profile's flags layered over the model tune, in a new **untrusted `slot_profile` argv segment**:

```
base < model_extra_args < slot_profile < slot_hardware < chat_template < mmproj
```

- Aligned (`slot.profile == defaults.profile`) and provenance-less slots emit **no** segment — launch stays byte-identical, and golden #5 (`test_gp05_stamped_launch_layering`) passes verbatim. This is the surgical read of "reverses part of spec-flags-ownership": the copy-on-stamp model stays authoritative unless the operator deliberately diverges a slot.
- A missing-profile fallback to the backend base profile never injects flags.
- The segment rides the managed-arg denylist screen (`UNTRUSTED_SEGMENT_LABELS`), and typed slot hardware fields (`-ngl`/`--threads`) still win collisions.
- No MTP expansion in the overlay — the `--spec-draft-*` bundle stays model-driven.
- Launch/preview parity holds: both paths thread `scalars["slot_profile_flags"]` through the same segment builder, so `GET /api/slots` provenance shows the overlay.

**Gap 2 — cross-device path (option b).**
The slot drawer's profile picker no longer hides profiles declaring another llama backend. They appear under an *"Other backend — switches slot device"* group; saving one lets the existing `_reconcile_device_profile` flip the slot's device (profile changed alone → device rederived — already implemented server-side, no backend change needed). The drawer announces the switch and warns when an explicit runner BINARY or pinned image may not serve the target backend. `npu`/`img` classes stay excluded (different runtime families — hard-blocked in `model_fit`). Seed profiles are device-agnostic, so this only affects profiles carrying a backend hint (generated/imported/operator-created).

**Polish.** Drawer copy now states the real semantics (aligned = stamped tune only; divergent = overlay at launch), a divergence hint appears when slot profile ≠ model provenance, and the stale "saving both together is rejected" warning is reworded (the drawer has no device control, so that conflict can't be produced anymore).

## Semantics notes

- Adoption (Q1) is untouched: a **model swap** still adopts the new model's preferred profile when it fits, which replaces a divergent pick — new model, new tune context. Restarts/reloads never touch it.
- Collision rule inside the overlay is last-wins per canonical flag: the divergent profile wins flags it mentions; model-tune-only flags survive underneath.

## Verification

- Full pytest: **9043 passed** (11 new unit tests: gate, precedence, screening, fallback, legacy-param inertness)
- Full Playwright: **607 passed** (4 new specs: divergence hint on/off, cross-backend offer + PUT, no hint same-backend)
- ruff clean · scar ratchet at baseline (193) · UI lint + `vite build` clean
- mypy: 535 pre-existing errors, none on touched lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)