### PR TITLE
fix(ui): mirror backend defaults.mtp rule in isMtpEligibleModel

### DIFF
--- a/ui/src/lib/normalizeApiModel.test.ts
+++ b/ui/src/lib/normalizeApiModel.test.ts
@@ -16,6 +16,14 @@ describe('isMtpEligibleModel', () => {
     expect(isMtpEligibleModel({ id: 'some-model', tags: ['chat', 'mtp'] })).toBe(true)
   })
 
+  it('honors an explicit defaults.mtp=false over the legacy mtp tag (either direction wins)', () => {
+    // A row can carry BOTH an explicit opt-out and a stale/un-retired tag
+    // (older backend, or before a tag-retirement sweep ran). The backend's
+    // model_is_mtp_eligible treats explicit=false as authoritative — it
+    // does NOT fall back to the tag in that case.
+    expect(isMtpEligibleModel({ id: 'some-model', tags: ['chat', 'mtp'], defaults: { mtp: false } })).toBe(false)
+  })
+
   it('is NOT eligible for a name-only "mtp" marker with no tag and no defaults.mtp (removed sniff)', () => {
     // The old MTP_NAME_RE fallback used to false-positive on this; the
     // backend's sniff was removed, so the UI must not diverge.

--- a/ui/src/lib/normalizeApiModel.test.ts
+++ b/ui/src/lib/normalizeApiModel.test.ts
@@ -1,0 +1,35 @@
+// isMtpEligibleModel — pins the #1642 migration fix: the helper must mirror
+// the backend's model_meta.model_is_mtp_eligible (defaults.mtp wins, else
+// the registry `mtp` tag) instead of the retired tag+filename-sniff rule.
+import { describe, expect, it } from 'vitest'
+
+import { isMtpEligibleModel } from './normalizeApiModel'
+
+describe('isMtpEligibleModel', () => {
+  it('is eligible when defaults.mtp is explicitly true, even with no mtp tag and no name marker', () => {
+    // The #1632 boot sweep (tag_retirement) folds the legacy `mtp` tag into
+    // defaults.mtp=true and STRIPS the tag — this is the migrated shape.
+    expect(isMtpEligibleModel({ id: 'gemma-4-12b-it-ud-q4-k-xl', tags: ['chat'], defaults: { mtp: true } })).toBe(true)
+  })
+
+  it('is eligible when the legacy mtp tag is present and defaults.mtp is unset', () => {
+    expect(isMtpEligibleModel({ id: 'some-model', tags: ['chat', 'mtp'] })).toBe(true)
+  })
+
+  it('is NOT eligible for a name-only "mtp" marker with no tag and no defaults.mtp (removed sniff)', () => {
+    // The old MTP_NAME_RE fallback used to false-positive on this; the
+    // backend's sniff was removed, so the UI must not diverge.
+    expect(isMtpEligibleModel({ id: 'foo-mtp-q4_k_m.gguf', tags: [] })).toBe(false)
+    expect(isMtpEligibleModel({ id: 'foo', path: '/models/foo-mtp-q4_k_m.gguf', tags: [] })).toBe(false)
+  })
+
+  it('is not eligible with neither signal', () => {
+    expect(isMtpEligibleModel({ id: 'plain-model', tags: ['chat'] })).toBe(false)
+    expect(isMtpEligibleModel({ id: 'plain-model' })).toBe(false)
+  })
+
+  it('handles null/undefined models', () => {
+    expect(isMtpEligibleModel(null)).toBe(false)
+    expect(isMtpEligibleModel(undefined)).toBe(false)
+  })
+})

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -34,6 +34,10 @@ export interface ApiModelRaw {
   quant?: string | null
   /** Freeform registry tags ("mtp", "coder", "user-added", …). */
   tags?: string[]
+  /** Per-model launch-default overrides (`ModelDefaults` on the backend).
+   * `defaults.mtp === true` is an explicit opt-in that wins over the legacy
+   * `mtp` tag — see `isMtpEligibleModel`. */
+  defaults?: { mtp?: boolean | null; [k: string]: unknown } | null
   /** Unix seconds the row was registered / first seen. */
   created?: number
   /** True when the last HF update check (GET /api/models/updates/check)
@@ -100,20 +104,17 @@ export function formatSize(b: number): string {
 // present. Fallback (older backends / legacy fixtures): infer from
 // installed+upstream. FLM/NPU rows also carry `upstream` ("npu") but are
 // installed host-side, so the `installed` check keeps them local.
-/** Delimited "MTP" marker in a model id / filename — mirrors the backend's
- * `model_meta._MTP_NAME_RE` so the UI's eligibility gate never disagrees with
- * the server's `_effective_mtp` auto decision. */
-const MTP_NAME_RE = /(?:^|[-_. ])mtp(?:[-_. ]|$)/i
-
 /** True when a model ships MTP speculative-decoding heads, per the SAME rule
- * the server uses (`model_meta.model_is_mtp_eligible`): the registry `mtp`
- * tag, or — for uncurated local pulls that carry no tags — a delimited MTP
- * marker in the id/path. Keep in sync with the backend; a divergence here
- * hides the MTP control exactly when the override matters. */
+ * the server uses (`model_meta.model_is_mtp_eligible`): an explicit
+ * `defaults.mtp === true` opt-in wins, else fall back to the registry `mtp`
+ * tag. The old filename/GGUF-name `MTP` marker sniff (`_MTP_NAME_RE`) was
+ * REMOVED server-side — an uncurated local pull with no tag and no explicit
+ * `defaults.mtp` is simply not eligible. Mirrors `isMtpModel` in
+ * `dash/models.jsx`; keep the two in sync. */
 export function isMtpEligibleModel(m: ApiModelRaw | null | undefined): boolean {
   if (!m) return false
-  if (Array.isArray(m.tags) && m.tags.some(t => String(t).trim().toLowerCase() === 'mtp')) return true
-  return MTP_NAME_RE.test(String(m.id || '')) || MTP_NAME_RE.test(String(m.path || ''))
+  if (m.defaults?.mtp === true) return true
+  return Array.isArray(m.tags) && m.tags.some(t => String(t).trim().toLowerCase() === 'mtp')
 }
 
 export function isUpstreamModel(m: ApiModelRaw): boolean {

--- a/ui/src/lib/normalizeApiModel.ts
+++ b/ui/src/lib/normalizeApiModel.ts
@@ -106,14 +106,15 @@ export function formatSize(b: number): string {
 // installed host-side, so the `installed` check keeps them local.
 /** True when a model ships MTP speculative-decoding heads, per the SAME rule
  * the server uses (`model_meta.model_is_mtp_eligible`): an explicit
- * `defaults.mtp === true` opt-in wins, else fall back to the registry `mtp`
- * tag. The old filename/GGUF-name `MTP` marker sniff (`_MTP_NAME_RE`) was
- * REMOVED server-side — an uncurated local pull with no tag and no explicit
- * `defaults.mtp` is simply not eligible. Mirrors `isMtpModel` in
- * `dash/models.jsx`; keep the two in sync. */
+ * `defaults.mtp` — EITHER direction, true or false — wins over the registry
+ * `mtp` tag; only an unset/null `defaults.mtp` falls back to the tag. The
+ * old filename/GGUF-name `MTP` marker sniff (`_MTP_NAME_RE`) was REMOVED
+ * server-side — an uncurated local pull with no tag and no explicit
+ * `defaults.mtp` is simply not eligible. */
 export function isMtpEligibleModel(m: ApiModelRaw | null | undefined): boolean {
   if (!m) return false
-  if (m.defaults?.mtp === true) return true
+  const explicit = m.defaults?.mtp
+  if (explicit != null) return Boolean(explicit)
   return Array.isArray(m.tags) && m.tags.some(t => String(t).trim().toLowerCase() === 'mtp')
 }
 


### PR DESCRIPTION
## Summary
- `isMtpEligibleModel()` (`ui/src/lib/normalizeApiModel.ts`) still implemented the pre-#1632 rule: `mtp` tag, else a name-regex sniff (`MTP_NAME_RE`) on `id`/`path`.
- Backend's `model_is_mtp_eligible` now prefers `defaults.mtp` and the filename sniff was removed server-side; `registry/tag_retirement` folds the legacy `mtp` tag into `defaults.mtp=true` and strips the tag on boot.
- Net effect: models migrated by the boot sweep silently lost the Stacks per-slot MTP override control (false negative — `defaults.mtp` never read), while local pulls named e.g. `foo-mtp-q4_k_m.gguf` with no tag/defaults still tripped a false positive.
- Fix mirrors the already-correct sibling `isMtpModel` in `dash/models.jsx`: prefer `defaults.mtp === true`, fall back to the `mtp` tag, drop `MTP_NAME_RE` entirely.

## Test plan
- [x] Added `ui/src/lib/normalizeApiModel.test.ts` (vitest, wired into `npm run test:unit` via `vitest.config.ts`'s `src/**/*.test.ts` include). Red-first: confirmed the new cases fail against the pre-fix implementation (`defaults.mtp` ignored; name-marker false positive), then pass after the fix.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` — 9 files / 85 tests passing

Closes #1642