### PR TITLE
fix(config): persist [brain_chat] tool_model=off across save/load

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -27,7 +27,14 @@ import re
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from hal0.config import paths
 from hal0.model_meta import (
@@ -2909,6 +2916,26 @@ class BrainChatConfig(BaseModel):
         if text.lower() in BRAIN_TOOL_MODEL_DISABLED:
             return ""
         return text
+
+    @field_serializer("tool_model")
+    def _serialize_tool_model(self, value: str) -> str:
+        """Persist "disabled" as a word, not the empty string (#1644).
+
+        In-memory/runtime, "no tool routing" is represented as ``""`` — every
+        consumer (:func:`hal0.brain.chat._tool_routing_llm` et al.) treats a
+        falsy ``tool_model`` as "don't reroute". But :meth:`_normalise_tool_model`
+        treats an on-disk ``tool_model = ""`` as "nobody set this" and coerces
+        it back to :data:`BRAIN_TOOL_MODEL_DEFAULT`. Dumping ``""`` straight to
+        ``hal0.toml`` for the disabled state collided with that rule: save
+        wrote ``""``, the next load saw an "unset" empty string and silently
+        re-enabled routing.
+
+        Route around the collision by giving the disabled state a word on
+        disk. ``"off"`` round-trips cleanly back through
+        ``_normalise_tool_model`` to ``""`` on the next load, same as any
+        other spelling in :data:`BRAIN_TOOL_MODEL_DISABLED`.
+        """
+        return "off" if value == "" else value
 
 
 class SecurityConfig(BaseModel):

--- a/tests/config/test_brain_tool_model_empty.py
+++ b/tests/config/test_brain_tool_model_empty.py
@@ -12,9 +12,11 @@ The fix keeps "no tool routing" reachable, but only if you say so out loud.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 
+from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import (
     BRAIN_TOOL_MODEL_DEFAULT,
     BRAIN_TOOL_MODEL_DISABLED,
@@ -84,6 +86,26 @@ def test_the_normalised_value_round_trips_through_a_dump() -> None:
     cfg = BrainChatConfig(tool_model="")
     assert cfg.model_dump()["tool_model"] == BRAIN_TOOL_MODEL_DEFAULT
     assert BrainChatConfig(**cfg.model_dump()).tool_model == BRAIN_TOOL_MODEL_DEFAULT
+
+
+@pytest.mark.parametrize("word", sorted(BRAIN_TOOL_MODEL_DISABLED))
+def test_an_explicit_off_survives_a_save_load_round_trip(word: str, tmp_path: Path) -> None:
+    """#1644: the save→load composition, not just each rule in isolation.
+
+    ``save_hal0_config`` used to dump the in-memory disabled value ("") to
+    disk verbatim; ``load_hal0_config`` then re-ran ``_normalise_tool_model``
+    on that on-disk "" and coerced it straight back to the default, because
+    an on-disk empty string is defined to mean "never set". An operator who
+    deliberately disabled tool routing got it silently re-enabled on the
+    next `hal0-api` restart.
+    """
+    toml_path = tmp_path / "hal0.toml"
+    save_hal0_config(Hal0Config(brain_chat={"tool_model": word}), toml_path)
+    reloaded = load_hal0_config(toml_path)
+    assert reloaded.brain_chat.tool_model == "", (
+        f"tool_model={word!r} did not survive a save/load round trip: "
+        f"got {reloaded.brain_chat.tool_model!r}"
+    )
 
 
 def test_tool_model_is_a_known_settings_key() -> None:


### PR DESCRIPTION
## Summary
- `save_hal0_config` dumped the disabled `tool_model` sentinel (`""`) verbatim to `hal0.toml`.
- `load_hal0_config`'s own `_normalise_tool_model` treats an on-disk `""` as "never set" and coerces it back to the `hal0/agent` default.
- Net effect: an operator who explicitly sets `tool_model = "off"` gets it silently re-enabled on the next `hal0-api` restart, plus a spurious "tool_model is empty" warning.

## Fix
Add a `field_serializer("tool_model")` on `BrainChatConfig` that persists the disabled state as the word `"off"` instead of `""`. `"off"` round-trips cleanly back through the existing `_normalise_tool_model` to `""` on the next load — no collision with the "unset" rule. Runtime/in-memory representation is unchanged (still `""`), so every `if not tool_model` consumer (`hal0.brain.chat`) is untouched.

## Test plan
- [x] Red-first: `test_an_explicit_off_survives_a_save_load_round_trip` (parametrized over `off`/`none`/`disabled`) fails on main, passes after the fix.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/config tests/updater tests/api/test_settings_apply.py -x -q` — 1030 passed, 9 skipped.

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)