### PR TITLE
fix(ci): re-arm mirror-bootstrap on GITHUB_TOKEN-created releases

### DIFF
--- a/.github/workflows/mirror-bootstrap.yml
+++ b/.github/workflows/mirror-bootstrap.yml
@@ -17,6 +17,13 @@
 #   sibling bundle. The gate opens by itself the moment a signed stable release
 #   (v1.0.0) is published, and `release: published` re-runs it at that instant.
 #   Override with the `force` input only if you know the gate is stale.
+#
+# `release: published` never actually fires for a release hal0 cuts itself:
+# release.yml creates the release via `gh release create` running under the
+# default GITHUB_TOKEN, and GitHub suppresses workflow-triggering events
+# created by that token (anti-recursion). So release.yml calls this workflow
+# directly via `workflow_call` right after its release is verified — the same
+# pattern nightly.yml uses to invoke release.yml.
 
 name: mirror-bootstrap
 
@@ -29,6 +36,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Publish even if the stable manifest has no sibling Sigstore bundle"
+        type: boolean
+        default: false
+  workflow_call:
     inputs:
       force:
         description: "Publish even if the stable manifest has no sibling Sigstore bundle"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -134,6 +134,11 @@ jobs:
       id-token: write
       packages: read
     uses: ./.github/workflows/release.yml
+    # secrets: inherit — required for release.yml's own trigger-mirror-bootstrap
+    # job to reach HALO_WEB_MIRROR_TOKEN. Nested workflow_call hops don't pass
+    # secrets by default; without this, a nightly-triggered release would call
+    # mirror-bootstrap.yml with an empty mirror token instead of skipping it.
+    secrets: inherit
     with:
       tag: ${{ needs.tag.outputs.tag }}
       channel: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1124,3 +1124,18 @@ jobs:
             echo "**No external channel pointer was mutated.** This job performed read-only authorization only."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+  # ── 10. Re-arm the GA→mirror handoff ────────────────────────────────────
+  # `gh release create` in the release job above runs under the default
+  # GITHUB_TOKEN, and GitHub suppresses workflow-triggering events created by
+  # the default token (anti-recursion) — so mirror-bootstrap.yml's own
+  # `release: published` trigger never fires for a release this workflow just
+  # cut. Call it directly instead, the same way nightly.yml invokes this
+  # workflow via workflow_call. Gated on authorize-pointer (not just release)
+  # so the mirror only fires once the cut release has been independently
+  # re-verified from the remote, not merely reported as published.
+  trigger-mirror-bootstrap:
+    name: Re-arm mirror-bootstrap
+    needs: [release, authorize-pointer]
+    uses: ./.github/workflows/mirror-bootstrap.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary
- `gh release create` in `release.yml` publishes under the default `GITHUB_TOKEN`. GitHub suppresses workflow-triggering events created by that token (anti-recursion), so `mirror-bootstrap.yml`'s `release: published` trigger silently never fired for any release hal0 cuts itself — the hardened installer never auto-mirrored to hal0.dev/install.sh.
- Gave `mirror-bootstrap.yml` a `workflow_call` trigger (mirrors the existing `workflow_dispatch` inputs) and added a `trigger-mirror-bootstrap` job to `release.yml` that calls it directly via `uses: ./.github/workflows/mirror-bootstrap.yml` — the same pattern `nightly.yml` already uses to invoke `release.yml`.
- Gated on `authorize-pointer` (not just `release`) succeeding, so the mirror only fires once the cut release has been independently re-verified against the remote, not merely reported as published.
- No new secrets added — reuses `secrets: inherit` so `mirror-bootstrap.yml`'s existing `HALO_WEB_MIRROR_TOKEN` reference keeps working when called from `release.yml`.

Closes #1646

**CI/CD change — operator review required, automerge deliberately not enabled.**

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on `release.yml` / `mirror-bootstrap.yml` / `nightly.yml` — all parse.
- [x] `actionlint` (via `rhysd/actionlint` docker image) on the three workflows — no new findings (2 pre-existing shellcheck style/warning notes elsewhere in `release.yml`, unrelated to this diff).
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/release -x -q` — 92 passed.
- [ ] First real release cut (post-merge) to confirm `mirror-bootstrap` actually fires and syncs — static contracts can't prove remote behavior (documented limitation already called out at the top of `tests/release/test_workflow_contract.py`).