### PR TITLE
fix(ui): read the real hindsight-api operations envelope

### DIFF
--- a/ui/src/api/hooks/useHindsight.ts
+++ b/ui/src/api/hooks/useHindsight.ts
@@ -59,17 +59,23 @@ export interface BankTimeseries {
 }
 
 export interface BankOperation {
-  operation_id: string
-  operation_type: string
+  id: string
+  task_type: string
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled' | string
   created_at: string
   error_message: string | null
   retry_count: number
 }
 
+// Real hindsight-api 0.8.4 envelope — verified live against
+// GET /v1/default/banks/{bank}/operations. NOT the `{items, total}` shape
+// every other Hindsight list endpoint uses (#1645).
 export interface BankOperations {
-  items: BankOperation[]
+  bank_id?: string
   total: number
+  limit?: number
+  offset?: number
+  operations: BankOperation[]
 }
 
 // ── engine card ──────────────────────────────────────────────────────────────
@@ -176,7 +182,7 @@ export interface BankActivity {
   cancelled: number
   /** pending + processing — "work in flight" drives the spinner/pulse. */
   inFlight: number
-  /** operation_type of each failed op, for the failed-ops affordance. */
+  /** task_type of each failed op, for the failed-ops affordance. */
   failedTypes: string[]
   total: number
 }
@@ -185,10 +191,10 @@ export interface BankActivity {
 export function summarizeBankOperations(ops?: BankOperations | null): BankActivity {
   const counts = { pending: 0, processing: 0, completed: 0, failed: 0, cancelled: 0 }
   const failedTypes: string[] = []
-  const items = ops?.items ?? []
+  const items = ops?.operations ?? []
   for (const op of items) {
     if (op.status in counts) counts[op.status as keyof typeof counts] += 1
-    if (op.status === 'failed') failedTypes.push(op.operation_type)
+    if (op.status === 'failed') failedTypes.push(op.task_type)
   }
   return {
     ...counts,
@@ -214,7 +220,7 @@ export function useBankOperations(
     enabled: !!bank && opts?.enabled !== false,
     staleTime: 3_000,
     refetchInterval: (query) => {
-      const items = query.state.data?.items ?? []
+      const items = query.state.data?.operations ?? []
       const inFlight = items.some((o) => IN_FLIGHT_STATUSES.has(o.status))
       return inFlight ? 3_000 : 20_000
     },

--- a/ui/src/api/mockFixtures.ts
+++ b/ui/src/api/mockFixtures.ts
@@ -1084,23 +1084,26 @@ function buildDirectives() {
   return { items, total: items.length }
 }
 
+// Real hindsight-api 0.8.4 envelope: {bank_id, total, limit, offset,
+// operations: [{id, task_type, status, ...}]} — NOT {items, operation_id,
+// operation_type} (#1645).
 function buildBankOperations(_url: string, match: RegExpMatchArray) {
   const bank = bankFrom(match)
   if (bank === 'ingest') {
-    const items = [
-      { operation_id: 'op-ing-9012', operation_type: 'document_ingest', status: 'processing', created_at: '2026-06-12T22:14:00.000Z', error_message: null, retry_count: 0 },
-      { operation_id: 'op-ing-9011', operation_type: 'document_ingest', status: 'pending', created_at: '2026-06-12T22:13:30.000Z', error_message: null, retry_count: 0 },
-      { operation_id: 'op-ing-8990', operation_type: 'consolidation', status: 'failed', created_at: '2026-06-12T19:02:00.000Z', error_message: 'embedding backend timed out after 30s', retry_count: 2 },
-      { operation_id: 'op-ing-8975', operation_type: 'document_ingest', status: 'completed', created_at: '2026-06-12T18:40:00.000Z', error_message: null, retry_count: 0 },
+    const operations = [
+      { id: 'op-ing-9012', task_type: 'document_ingest', status: 'processing', created_at: '2026-06-12T22:14:00.000Z', error_message: null, retry_count: 0 },
+      { id: 'op-ing-9011', task_type: 'document_ingest', status: 'pending', created_at: '2026-06-12T22:13:30.000Z', error_message: null, retry_count: 0 },
+      { id: 'op-ing-8990', task_type: 'consolidation', status: 'failed', created_at: '2026-06-12T19:02:00.000Z', error_message: 'embedding backend timed out after 30s', retry_count: 2 },
+      { id: 'op-ing-8975', task_type: 'document_ingest', status: 'completed', created_at: '2026-06-12T18:40:00.000Z', error_message: null, retry_count: 0 },
     ]
-    return { items, total: items.length }
+    return { bank_id: bank, total: operations.length, limit: 50, offset: 0, operations }
   }
-  const items = [
-    { operation_id: 'op-7741', operation_type: 'consolidation', status: 'completed', created_at: '2026-06-12T04:30:00.000Z', error_message: null, retry_count: 0 },
-    { operation_id: 'op-7742', operation_type: 'observation_extract', status: 'pending', created_at: '2026-06-12T22:06:00.000Z', error_message: null, retry_count: 0 },
-    { operation_id: 'op-7710', operation_type: 'document_ingest', status: 'completed', created_at: '2026-06-05T11:21:00.000Z', error_message: null, retry_count: 0 },
+  const operations = [
+    { id: 'op-7741', task_type: 'consolidation', status: 'completed', created_at: '2026-06-12T04:30:00.000Z', error_message: null, retry_count: 0 },
+    { id: 'op-7742', task_type: 'observation_extract', status: 'pending', created_at: '2026-06-12T22:06:00.000Z', error_message: null, retry_count: 0 },
+    { id: 'op-7710', task_type: 'document_ingest', status: 'completed', created_at: '2026-06-05T11:21:00.000Z', error_message: null, retry_count: 0 },
   ]
-  return { items, total: items.length }
+  return { bank_id: bank, total: operations.length, limit: 50, offset: 0, operations }
 }
 
 // Route wrappers: the allowlist passes the query-stripped path as the first

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -458,7 +458,7 @@ function MemOperations({ bank }) {
   const query = useBankOperations ? useBankOperations(bank) : { data: null };
   const retry = useOperationRetry ? useOperationRetry() : null;
   const cancel = useOperationCancel ? useOperationCancel() : null;
-  const items = query.data?.items || [];
+  const items = query.data?.operations || [];
 
   async function doRetry(id) {
     try {
@@ -488,21 +488,21 @@ function MemOperations({ bank }) {
   return (
     <div className="mem-ops">
       {items.map(op => (
-        <div className="mem-op-row" key={op.operation_id} data-testid={`mem-op-${op.operation_id}`}>
+        <div className="mem-op-row" key={op.id} data-testid={`mem-op-${op.id}`}>
           <span className={'chip ' + (op.status === 'failed' ? 'err' : op.status === 'completed' ? 'ok' : 'warn')}>
             {op.status}
           </span>
-          <span className="mono mem-op-type">{op.operation_type}</span>
+          <span className="mono mem-op-type">{op.task_type}</span>
           <span className="mono mem-op-when">{fmtWhen(op.created_at)}</span>
           {op.error_message && <span className="mem-op-err mono" title={op.error_message}>{op.error_message}</span>}
           <span className="mem-op-actions">
             {op.status === 'failed' && (
-              <button className="btn ghost xs" data-testid="mem-op-retry" onClick={() => doRetry(op.operation_id)}>
+              <button className="btn ghost xs" data-testid="mem-op-retry" onClick={() => doRetry(op.id)}>
                 Retry
               </button>
             )}
             {op.status === 'pending' && (
-              <button className="btn ghost xs danger" data-testid="mem-op-cancel" onClick={() => doCancel(op.operation_id)}>
+              <button className="btn ghost xs danger" data-testid="mem-op-cancel" onClick={() => doCancel(op.id)}>
                 Cancel
               </button>
             )}

--- a/ui/tests/e2e/specs/memory-view-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-view-v3.spec.ts
@@ -94,26 +94,32 @@ const TIMESERIES = {
   ],
 }
 
+// Real hindsight-api 0.8.4 envelope: {bank_id, total, limit, offset,
+// operations: [{id, task_type, ...}]} — NOT {items, operation_id,
+// operation_type} (#1645).
 const OPERATIONS = {
-  items: [
+  bank_id: 'shared',
+  total: 2,
+  limit: 50,
+  offset: 0,
+  operations: [
     {
-      operation_id: 'op-fail-1',
-      operation_type: 'consolidation',
+      id: 'op-fail-1',
+      task_type: 'consolidation',
       status: 'failed',
       created_at: '2026-06-07T09:00:00Z',
       error_message: 'LLM timeout',
       retry_count: 3,
     },
     {
-      operation_id: 'op-pend-1',
-      operation_type: 'retain',
+      id: 'op-pend-1',
+      task_type: 'retain',
       status: 'pending',
       created_at: '2026-06-07T09:10:00Z',
       error_message: null,
       retry_count: 0,
     },
   ],
-  total: 2,
 }
 
 async function installMemoryMocks(page: any) {


### PR DESCRIPTION
## Summary
- `GET /v1/default/banks/{bank}/operations` returns `{operations: [{id, task_type, ...}]}` (verified against hindsight-api 0.8.4, the version `installer/install.sh` pins) — not `{items: [{operation_id, operation_type, ...}]}`, the shape every other Hindsight list endpoint uses.
- The UI hardcoded the wrong shape, so the Operations panel's items list was always empty (card never rendered → no Retry/Cancel affordance) and `MemBankActivity`'s per-bank working/pending/failed badges always read `total: 0`. Adaptive polling never sped up either, since it inspected the same always-empty list.
- The Python side was already correct (`routes/memory.py`, `cli/memory_ops_commands.py` both read `operations`) — only the UI disagreed with the wire format.
- Not caught by tests because both e2e fixtures (`memory-view-v3.spec.ts`, `mockFixtures.ts`) mocked the same wrong `{items, operation_id, operation_type}` shape as the buggy code. Fixed both fakes to the verified real contract.

Closes #1645

## Test plan
- [x] Confirmed red: reverted the source fix (kept fixed fakes) → `bank cards show fact-type counts and live activity` and `failed operation exposes Retry...` e2e specs fail against the old code.
- [x] `cd ui && npx tsc --noEmit` — clean
- [x] `cd ui && npm run build` — succeeds
- [x] `cd ui && npx vitest run` — 80/80 pass
- [x] `cd ui && npx playwright test tests/e2e/specs/memory-view-v3.spec.ts tests/e2e/specs/memory-tools-v3.spec.ts` — 12/12 pass
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory -x -q` — 187 passed