### PR TITLE
fix(ci): pin mirror-docs workflow_dispatch to main

### DIFF
--- a/.github/workflows/mirror-docs.yml
+++ b/.github/workflows/mirror-docs.yml
@@ -14,6 +14,11 @@
 #   - .mdx/.md copied verbatim (Starlight component imports preserved).
 #   - A section missing in hal0 is skipped, never deleted on the web side.
 #   - Nothing else in hal0-web is touched (blog/, marketing, alpha-docs/).
+#
+# workflow_dispatch has no branch input, so a manual run is pinned to `main`
+# below (the "Checkout hal0 (source)" step) rather than defaulting to
+# whatever ref it was invoked from — a manual test run off a feature branch
+# must never mirror unmerged docs to the live site.
 
 name: mirror-docs
 
@@ -40,6 +45,7 @@ jobs:
       - name: Checkout hal0 (source)
         uses: actions/checkout@v4
         with:
+          ref: main
           path: hal0
 
       - name: Checkout Hal0ai/hal0-web (target)
@@ -72,7 +78,10 @@ jobs:
             exit 0
           fi
 
-          source_sha="${{ github.sha }}"
+          # Read the actual synced commit off the pinned hal0 checkout rather
+          # than github.sha, which under workflow_dispatch reflects whatever
+          # ref triggered the run, not the main commit that was mirrored.
+          source_sha="$(git -C ../hal0 rev-parse HEAD)"
           source_short="${source_sha:0:7}"
           git add src/content/docs/docs/
           git commit -m "docs: mirror from hal0@${source_short}


### PR DESCRIPTION
## Summary
- `mirror-docs.yml`'s `workflow_dispatch` trigger had no branch-input restriction, and its "Checkout hal0 (source)" step specified no `ref:` — so a manual run defaulted to whatever branch it was invoked from, and `rsync`'d that (possibly unmerged) `docs/` tree straight to `hal0-web`'s live `master`, bypassing the workflow's stated "syncs on main" contract.
- Pinned the `Checkout hal0 (source)` step to `ref: main`, consistent with how other workflows in this repo pin refs explicitly (e.g. `nightly.yml`'s `ref: main`, `release.yml`'s `ref: refs/tags/${{ needs.resolve.outputs.tag }}` on `pypi-publish`/`authorize-pointer`) rather than trusting the invoking context's ref.
- Also fixed the commit-message provenance: it previously used `github.sha`, which under `workflow_dispatch` reflects the invoking ref (not necessarily `main`). Now reads the actual mirrored commit off the pinned `hal0` checkout (`git -C ../hal0 rev-parse HEAD`), so the mirror commit always cites the content it actually shipped.
- No new secrets, no behavior change on the existing `push` trigger (there `github.sha` already equals `main` HEAD).

Closes #1658

**CI/CD change — operator review required, automerge deliberately not enabled.**

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on `mirror-docs.yml` — parses.
- [x] `actionlint` (via `rhysd/actionlint` docker image) — no findings.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/release -x -q` — 92 passed (no test targets this workflow directly; ran the full release suite for regression safety).