### PR TITLE
chore(release): v1.0.0-rc.2 — version bump, rc.2 notes, refreshed digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,24 +28,63 @@ applying. Add those subsections to a version's section to surface them; see
 
 Second — and intended final — release candidate on the road to 1.0.0. This
 tag is the preview-channel snapshot of everything documented in the
-[1.0.0](#100--2026-08-07) section below; a box on `1.0.0-rc.1` picks up all
-of it via `hal0 update`.
+[1.0.0 section of the changelog](https://github.com/Hal0ai/hal0/blob/v1.0.0-rc.2/CHANGELOG.md#100--2026-08-07);
+a box on `1.0.0-rc.1` picks up all of it via `hal0 update`.
 
 ### Highlights
 
-- **Preview snapshot of the full 1.0.0 content:** 180-tool admin MCP catalog, memory MCP parity with Hindsight 0.8.4, Moonshine CPU STT reinstated, slot `autoload` + eviction `priority`, on-demand capability slots, per-slot profiles, and the hardened OpenWebUI/secrets posture. Full detail in the [1.0.0](#100--2026-08-07) section.
+- **Preview snapshot of the full 1.0.0 content:** 180-tool admin MCP catalog, memory MCP parity with Hindsight 0.8.4, Moonshine CPU STT reinstated, slot `autoload` + eviction `priority`, on-demand capability slots, per-slot profiles, and the hardened OpenWebUI/secrets posture. Full detail in the [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/v1.0.0-rc.2/CHANGELOG.md#100--2026-08-07).
 
 ### Breaking
 
 New since `1.0.0-rc.1` (a box upgrading from 0.9.8 also gets the R5 set —
-see the [1.0.0](#100--2026-08-07) section):
+see the [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/v1.0.0-rc.2/CHANGELOG.md#100--2026-08-07)):
 
-- **The experimental standalone browser MCP server is removed.** (`hal0.mcp.browser_server`, port 9178, `HAL0_BROWSER_*` env; detail under [1.0.0].)
-- **The `lru = true` eviction opt-in is retired — every non-pinned resident slot is now an eviction candidate, ordered by the new `priority` field.** On a box that never set `lru = true`, pressure and pre-load eviction go from inert to active; `pinned` is the only exemption. (Detail under [1.0.0].)
+- **The experimental standalone browser MCP server is removed.** (`hal0.mcp.browser_server`, port 9178, `HAL0_BROWSER_*` env; detail in the 1.0.0 changelog section linked above.)
+- **The `lru = true` eviction opt-in is retired — every non-pinned resident slot is now an eviction candidate, ordered by the new `priority` field.** On a box that never set `lru = true`, pressure and pre-load eviction go from inert to active; `pinned` is the only exemption. (Detail in the 1.0.0 changelog section linked above.)
 
 ### Migrations
 
-- **Nothing new for a box already on `1.0.0-rc.1`** — slots with a bound model migrate to `autoload = true` automatically, so boot behaviour is unchanged until toggled. Boxes coming from 0.9.8 follow the [1.0.0](#100--2026-08-07) migration set (one-shot `enabled` sweep at first boot; operator-run slot-flag fold and id-keying migrators).
+- **Nothing new for a box already on `1.0.0-rc.1`** — slots with a bound model migrate to `autoload = true` automatically, so boot behaviour is unchanged until toggled. Boxes coming from 0.9.8 follow the [1.0.0 migration set](https://github.com/Hal0ai/hal0/blob/v1.0.0-rc.2/CHANGELOG.md#100--2026-08-07) (one-shot `enabled` sweep at first boot; operator-run slot-flag fold and id-keying migrators).
+
+### Audience
+
+Preview-channel operators validating the 1.0 line ahead of GA, and fresh
+installs that want the current build. Boxes that track the stable channel
+are not offered this tag.
+
+### Supported upgrades
+
+- `1.0.0-rc.1` → `1.0.0-rc.2` via `hal0 update` (preview channel).
+- `0.9.8` → `1.0.0-rc.2` in place — re-run the installer or `hal0 update`
+  after switching to the preview channel; the R5 migration set applies
+  (see Migrations above).
+- Older than 0.9.8: step through 0.9.8 first.
+
+### Known issues
+
+The three known issues carry forward from `1.0.0-rc.1` unchanged: the
+profile-catalog reset defers to the next v1.0-applied update when coming
+from 0.9.8 (#1585); the 0.9.8 CLI reports a spurious error at the end of
+a successful 0.9.8 → 1.0 update (verify with `hal0 --version` and
+`curl http://127.0.0.1:8080/api/health`); and first-boot installs can
+lose the dpkg lock race to `unattended-upgrades` (#1584, degrades with a
+remediation line). Detail in the 1.0.0 changelog section linked above.
+
+### Operator migrations
+
+None for a box already on `1.0.0-rc.1`. Coming from 0.9.8, the one-shot
+`enabled` sweep runs automatically at first boot; the slot-flag fold and
+slot id-keying migrators remain operator-run and unchanged from rc.1
+(dry-run by default — back up `hal0.db` and the slot dirs first).
+
+### Rollback
+
+Release tarballs are immutable and cosign-signed; roll back by
+re-installing the previous tag (`v1.0.0-rc.1`) from its GitHub release.
+Note the `enabled`-sweep caveat from the R5 set: pre-R5 code reads a
+missing `enabled` as true, so a rollback past R5 needs the config backup
+taken before upgrading.
 
 ## [1.0.0] — 2026-08-07
 
@@ -82,7 +121,8 @@ see the [1.0.0](#100--2026-08-07) section):
 
 The R5 breaking changes below shipped in `1.0.0-rc.1` and apply equally to a
 box coming straight from 0.9.8 — the expected upgrade path into 1.0. Full
-rationale and code-path detail under [1.0.0-rc.1](#100-rc1--2026-08-01-r5--the-rework-release).
+rationale and code-path detail in the
+[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
 
 - **Launch flags, device, and chat-template moved off slots onto models.**
   A slot is just `(id, name, model, port, state)`; `model.defaults` carries
@@ -114,7 +154,8 @@ rationale and code-path detail under [1.0.0-rc.1](#100-rc1--2026-08-01-r5--the-r
 ### Migrations
 
 These carry forward from `1.0.0-rc.1` for every box upgrading from 0.9.8;
-full detail under [1.0.0-rc.1](#100-rc1--2026-08-01-r5--the-rework-release).
+full detail in the
+[1.0.0-rc.1 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc1--2026-08-01-r5--the-rework-release).
 
 - **Upgrade in place — re-run the installer (or `hal0 update`); idempotent, non-destructive, never clobbers existing config. No reinstall.**
 - **Slot-flag fold (operator-run): the fold migrator moves slot tunes into model defaults — dry-run by default; back up `hal0.db` + slot dirs before applying.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,34 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+## [1.0.0-rc.2] — 2026-08-08
+
+Second — and intended final — release candidate on the road to 1.0.0. This
+tag is the preview-channel snapshot of everything documented in the
+[1.0.0](#100--2026-08-07) section below; a box on `1.0.0-rc.1` picks up all
+of it via `hal0 update`.
+
+### Highlights
+
+- **Preview snapshot of the full 1.0.0 content:** 180-tool admin MCP catalog, memory MCP parity with Hindsight 0.8.4, Moonshine CPU STT reinstated, slot `autoload` + eviction `priority`, on-demand capability slots, per-slot profiles, and the hardened OpenWebUI/secrets posture. Full detail in the [1.0.0](#100--2026-08-07) section.
+
+### Breaking
+
+New since `1.0.0-rc.1` (a box upgrading from 0.9.8 also gets the R5 set —
+see the [1.0.0](#100--2026-08-07) section):
+
+- **The experimental standalone browser MCP server is removed.** (`hal0.mcp.browser_server`, port 9178, `HAL0_BROWSER_*` env; detail under [1.0.0].)
+- **The `lru = true` eviction opt-in is retired — every non-pinned resident slot is now an eviction candidate, ordered by the new `priority` field.** On a box that never set `lru = true`, pressure and pre-load eviction go from inert to active; `pinned` is the only exemption. (Detail under [1.0.0].)
+
+### Migrations
+
+- **Nothing new for a box already on `1.0.0-rc.1`** — slots with a bound model migrate to `autoload = true` automatically, so boot behaviour is unchanged until toggled. Boxes coming from 0.9.8 follow the [1.0.0](#100--2026-08-07) migration set (one-shot `enabled` sweep at first boot; operator-run slot-flag fold and id-keying migrators).
+
 ## [1.0.0] — 2026-08-07
 
 ### Highlights
 
-- **The whole platform is agent-reachable.** The admin MCP catalog went from 92 to 181 tools — services, ComfyUI, updater/doctor/health, hardware and request telemetry, slots and models long-tail, bench, activity, approvals, runner images, NPU load/unload — plus the full 26-tool memory surface (was 5) at feature parity with Hindsight 0.8.4.
+- **The whole platform is agent-reachable.** The admin MCP catalog went from 92 to 180 tools — services, ComfyUI, updater/doctor/health, hardware and request telemetry, slots and models long-tail, bench, activity, approvals, runner images, NPU load/unload — plus the full 26-tool memory surface (was 5) at feature parity with Hindsight 0.8.4.
 - **Slots start when you say so.** New `autoload` setting: binding a model no longer implies boot start. New eviction `priority` (0-100) replaces the inert `lru = true` opt-in, so memory-pressure eviction actually works on a stock box.
 - **Voice is a device-keyed switch.** Moonshine is back as the CPU STT engine in its own toolbox image; `cpu` runs Moonshine, `npu` runs whisper-v3:turbo, GPU resolves to no STT engine instead of silently taking a llama chat profile.
 - **Image Gen and Slots panes got their lifecycle right** — state-typed engine indicators, a Stop that drives the GPU arbiter back to inference mode, dropdown-driven runner image/binary selection, and a `GET /api/slots` path that no longer multiplies `podman inspect` fan-out on wide boxes.
@@ -114,7 +137,7 @@ full detail under [1.0.0-rc.1](#100-rc1--2026-08-01-r5--the-rework-release).
 
 ### Added
 
-- Admin MCP catalog expanded from 92 to 181 tools — the full platform
+- Admin MCP catalog expanded from 92 to 180 tools — the full platform
   management surface is now agent-reachable: services lifecycle
   (`service_list`/`service_health` + gated `service_action`), ComfyUI
   (status/workflows reads, gated switchover/pin/launch/cancel/restart),

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 
 > **Status:** **release candidate — v1.0.0 stable is the target of the current cut.** Container-runtime era,
 > declarative config. Each slot (`agent`, `utility`, `embed`, `rerank`,
-> `stt`, `tts`, `img`, `vision`, NPU trio) runs as a dedicated podman
+> `stt`, `tts`, `img`, NPU trio) runs as a dedicated podman
 > container (`hal0-slot@<name>.service`). Slot definitions live in
 > `/etc/hal0/slots/<name>.toml`; backend profiles in
 > `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
@@ -152,7 +152,7 @@ be evicted out from under a streaming request.
   `/etc/hal0/slots/<name>.toml` during install (each gates on its own
   runtime validation at load time — the `flm` NPU slot simply stays
   grey without FastFlowLM hardware); the installer scaffolds the
-  additional capability slots (chat/`agent`, coder, embed, stt, vision)
+  additional capability slots (chat/`agent`, coder, embed, stt)
   with empty model picks for the operator to fill.
   User-added slots via `hal0 slot create NAME --type TYPE --model MODEL`.
   Slots refer to a **profile** in `/etc/hal0/profiles.toml` that pins
@@ -256,7 +256,7 @@ header bell + inbox modal in the dashboard, with CLI parity via
 
 The **hal0-brain steward** is a third, built-in persona wired to the
 dashboard's top-bar agent chat — no install step. It drives the platform
-through the full **181-tool `hal0-admin` catalog** (models, slots, stacks,
+through the full **180-tool `hal0-admin` catalog** (models, slots, stacks,
 profiles, settings, upstreams, benchmarks) under a **per-persona tool
 policy**: `tools_allowed` hides tools, `require_approval` tightens them,
 and a `POLICY_NO_LOOSEN` floor keeps destructive/secret-bearing tools
@@ -402,7 +402,7 @@ running on your box. Full version at [hal0.dev/#roadmap](https://hal0.dev/#roadm
 ### Shipped (v1.0)
 
 - **hal0-brain steward** — the top-bar agent chat drives the whole
-  platform through the 181-tool `hal0-admin` catalog under a per-persona
+  platform through the 180-tool `hal0-admin` catalog under a per-persona
   tool policy, pausing turns on gated tools for inline approve/deny
 - **Upstream model controls** — manage external providers (OpenRouter,
   Anthropic, OpenAI, Google AI Studio, Ollama, custom) with reactive

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
-  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.1",
+  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md \u00a712 and \u00a717 (maintainer-local).",
+  "version": "1.0.0-rc.2",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {
@@ -38,7 +38,7 @@
     },
     "qwen3tts": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-qwen3tts:v1",
-      "digest": "sha256:c3a4606de1488ef594c3552057985186bc01f4af7e79a23bbd2c9cf275e70838",
+      "digest": "sha256:748774babc8bd9b83da4c437d09311bbcbd279f0328d1a9f5b419e70ca2a036c",
       "_notes": "Qwen3-TTS-12Hz-1.7B-CustomVoice multilingual GPU TTS (ROCm); OpenAI-compat /v1/audio/speech. Digest pinned from the CI push via .github/workflows/toolbox.yml; refresh with scripts/update-toolbox-digests.sh."
     }
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -18,7 +18,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "hal0 contributors" }]
 keywords = ["ai", "llm", "inference", "openai-compatible", "homeai"]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: End Users/Desktop",
   "Intended Audience :: System Administrators",
   "Operating System :: POSIX :: Linux",

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -98,7 +99,9 @@ def main() -> int:
         markdown = _git_changelog(args.tag, nightly=(args.channel == "nightly"))
         source = "git-log"
 
-    # Preview notes: add required headings when absent.
+    # Preview notes: add required headings when absent. A changelog section
+    # can only carry them as ### subsections (a ## heading would terminate
+    # extract_changelog_section), so accept either level, case-insensitively.
     if args.channel == "preview":
         required_headings = [
             "Audience",
@@ -108,7 +111,11 @@ def main() -> int:
             "Rollback",
         ]
         for heading in required_headings:
-            if f"## {heading}" not in markdown:
+            pattern = re.compile(
+                rf"^#{{2,3}} {re.escape(heading)}\s*$",
+                re.IGNORECASE | re.MULTILINE,
+            )
+            if not pattern.search(markdown):
                 markdown += f"\n## {heading}\n\nTBD\n"
 
     (out / "RELEASE_NOTES.md").write_text(markdown, encoding="utf-8")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Prepares the v1.0.0-rc.2 preview cut.

## What changed
- `scripts/set-version.py 1.0.0-rc.2`: pyproject.toml, ui/package.json + package-lock.json, manifest.json, uv.lock.
- `scripts/update-toolbox-digests.sh`: 6 digests refreshed against ghcr.io. The comfyui digest was hand-restored after the script nulled it (docker.io digest-pinned ref unsupported by the ghcr curl path) — filed as #1676; a null digest would fail release.yml's manifest gate.
- New `[1.0.0-rc.2]` CHANGELOG section: preview snapshot of the 1.0.0 content, with the two breaking items new since rc.1 (browser MCP server removal, lru retirement) as complete first-line headlines for the structured extractor, and a nothing-new migration note for rc.1 boxes.
- Admin MCP catalog count corrected to the validated 180 (#1635 removed `model_duplicate` after 181 was measured).
- Retired `vision` slot dropped from README slot lists (#1631).
- PyPI classifier Alpha → Production/Stable.

## Verification
- `gen_release_notes.py --tag v1.0.0-rc.2 --channel preview`: extracts highlights=1 breaking=2 migrations=1, no truncated first lines.
- `python -m hal0.release.policy v1.0.0-rc.2`: kind=preview, prerelease_stage=rc, github_prerelease=true, publish_pypi=false.
- `manifest.json` has zero null digests.
- Live count of `TOOL_DESCRIPTIONS` on this tree: 180.

After merge: tag `v1.0.0-rc.2` on the squash commit (together with the #1640 updater dependency fix, which should be in the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)