### PR TITLE
fix(memory): read the real stats keys in the bank-delete preview

### DIFF
--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -281,7 +281,10 @@ async def bank_subgraph(request: Request, bank_id: str) -> dict[str, Any]:
 
 #: #1024 dry-run preview: bank-stats keys carrying stored-item counts. Best
 #: effort — Hindsight versions differ, so absent keys are simply omitted.
-_PREVIEW_COUNT_KEYS = ("memory_count", "document_count", "entity_count")
+#: These are the real hindsight-api 0.8.4 ``/v1/default/banks/{bank}/stats``
+#: keys (verified live) — NOT the ``memory_count``/``document_count``/
+#: ``entity_count`` keys that endpoint has never returned (#1653).
+_PREVIEW_COUNT_KEYS = ("total_nodes", "total_documents", "total_observations")
 
 
 async def _delete_preview(client: Any, bank_id: str) -> dict[str, Any]:
@@ -303,7 +306,7 @@ async def _delete_preview(client: Any, bank_id: str) -> dict[str, Any]:
     counts = {k: stats[k] for k in _PREVIEW_COUNT_KEYS if isinstance(stats.get(k), int)}
     preview["stats_available"] = True
     preview["counts"] = counts
-    preview["item_count"] = counts.get("memory_count")
+    preview["item_count"] = counts.get("total_nodes")
     return preview
 
 

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -273,14 +273,18 @@ def test_unconfirmed_bank_delete_returns_stats_preview(
         "GET",
         "/v1/default/banks/scratch/stats",
         200,
-        {"memory_count": 42, "document_count": 7, "entity_count": 3, "unrelated": "x"},
+        {"total_nodes": 42, "total_documents": 7, "total_observations": 3, "unrelated": "x"},
     )
     r = client.delete("/api/memory/banks/scratch")
     assert r.status_code == 400
     preview = r.json()["error"]["details"]["preview"]
     assert preview["stats_available"] is True
     assert preview["item_count"] == 42
-    assert preview["counts"] == {"memory_count": 42, "document_count": 7, "entity_count": 3}
+    assert preview["counts"] == {
+        "total_nodes": 42,
+        "total_documents": 7,
+        "total_observations": 3,
+    }
     # The rejection still forwarded no DELETE upstream.
     assert not any(rq["method"] == "DELETE" for rq in recorder.requests)
 

--- a/tests/security/test_memory_bank_wipe_guard.py
+++ b/tests/security/test_memory_bank_wipe_guard.py
@@ -86,12 +86,12 @@ def test_bank_memories_wipe_rejection_carries_the_blast_radius_preview(
         "GET",
         "/v1/default/banks/scratch/stats",
         200,
-        {"memory_count": 1629, "document_count": 315, "entity_count": 12},
+        {"total_nodes": 1629, "total_documents": 315, "total_observations": 12},
     )
     preview = client.delete(WIPE).json()["error"]["details"]["preview"]
     assert preview["stats_available"] is True
     assert preview["item_count"] == 1629
-    assert preview["counts"]["document_count"] == 315
+    assert preview["counts"]["total_documents"] == 315
 
 
 def test_bank_memories_wipe_preview_failsoft_still_rejects(


### PR DESCRIPTION
## Summary
- `_delete_preview` (`memory_admin.py:284`) read `memory_count`/`document_count`/`entity_count` off `GET /v1/default/banks/{bank}/stats` — hindsight-api 0.8.4 has never returned those keys (verified live: `total_nodes, total_links, total_documents, total_observations, ...`).
- Result: `counts = {}` every time, but `stats_available` was still set `True`, so the #1024 confirm-gate's dry-run preview claimed it read stats and then showed **zero** blast radius for both `DELETE /banks/{bank}` and `DELETE /banks/{bank}/memories` — even when the bank held 1600+ facts and hundreds of documents. The operator got no real signal before an irreversible wipe.
- Point `_PREVIEW_COUNT_KEYS` at `total_nodes` / `total_documents` / `total_observations`; headline `item_count` now comes from `total_nodes`.
- Both existing tests (`test_memory_admin_routes.py`, `test_memory_bank_wipe_guard.py`) encoded the same wrong keys as the bug — that's how it shipped unnoticed. Fixed both fakes to the real shape.

Closes #1653

## Test plan
- [x] Confirmed red: reverted the source fix (kept fixed test fakes) → both preview tests fail with `item_count == None` instead of the expected count.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory tests/api/test_memory_admin_routes.py tests/security/test_memory_bank_wipe_guard.py -q` — 229 passed