### PR TITLE
fix(agents): scope per-agent memory stats by client_id

### DIFF
--- a/src/hal0/api/agents/memory_stats.py
+++ b/src/hal0/api/agents/memory_stats.py
@@ -170,6 +170,7 @@ async def get_agent_memory_stats(agent_id: str, request: Request) -> dict[str, A
             dataset=namespace,
             cursor=None,
             limit=_LIST_PAGE_LIMIT,
+            client_id=agent_id,
         )
     except Exception as exc:
         # Wrapper failures shouldn't 500 the sidebar chip — surface as

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -635,6 +635,25 @@ class HindsightProvider(MemoryProvider):
         return projects, len(projects) < len([r for r in reqs if r])
 
     @staticmethod
+    def _wants_private_only(requested: str | list[str] | None) -> bool:
+        """True when every requested namespace is ``private:<id>`` (#1654).
+
+        ``_is_visible_to`` only enforces OWNERSHIP of private docs — a
+        non-private doc always passes it, unconditionally, regardless of
+        what was requested. So a read for ``private:<agent>`` alone (no
+        ``shared``) currently returns identically to a ``shared`` read: the
+        caller's own private docs AND every ordinary public doc in the bank.
+        Callers that explicitly ask for the private namespace ONLY (e.g. the
+        per-agent memory-stats chip) want private docs alone; this is the
+        signal :meth:`list_items` uses to apply that extra filter. A mixed
+        request (``["shared", "private:x"]``) is NOT private-only — it wants
+        the ordinary union — so this returns ``False`` unless every entry is
+        a private namespace.
+        """
+        reqs = HindsightProvider._requested_list(requested)
+        return bool(reqs) and all(isinstance(ds, str) and ds.startswith(_PRIVATE) for ds in reqs)
+
+    @staticmethod
     def _is_in_scope(item: dict[str, Any], projects: set[str], wants_unscoped: bool) -> bool:
         """Read-side enforcement of the ``project:<id>`` tag (#1300).
 
@@ -911,6 +930,14 @@ class HindsightProvider(MemoryProvider):
         if start_bank is None:
             return {"items": [], "next_cursor": None}
 
+        # #1654: in unified mode, ``_filter_visible`` only enforces private
+        # OWNERSHIP — a non-private doc passes it unconditionally regardless
+        # of what was requested, so a ``private:<agent>``-only request would
+        # otherwise return identically to a ``shared`` request (own private
+        # docs AND every public doc). A caller that asked for the private
+        # namespace(s) alone gets exactly that: private docs only.
+        private_only = self._unified_bank and self._wants_private_only(dataset)
+
         items: list[dict[str, Any]] = []
         next_cursor: str | None = None
         # Walk banks from the cursor's bank onward, carrying its offset into
@@ -938,6 +965,8 @@ class HindsightProvider(MemoryProvider):
                 page = self._filter_visible(
                     [self._list_fact_to_item(fact, bank) for fact in raw], client_id, dataset
                 )
+                if private_only:
+                    page = [it for it in page if _VISIBILITY_PRIVATE in (it.get("tags") or [])]
                 items.extend(page)
                 total = resp.get("total")
                 exhausted = len(raw) < fetch if not isinstance(total, int) else bank_offset >= total

--- a/tests/agents/test_agent_memory_stats_endpoint.py
+++ b/tests/agents/test_agent_memory_stats_endpoint.py
@@ -41,8 +41,11 @@ class _FakeWrapper:
         dataset: str = "shared",
         cursor: str | None = None,
         limit: int = 50,
+        client_id: str | None = None,
     ) -> dict[str, Any]:
-        self.calls.append({"dataset": dataset, "cursor": cursor, "limit": limit})
+        self.calls.append(
+            {"dataset": dataset, "cursor": cursor, "limit": limit, "client_id": client_id}
+        )
         if self.exc is not None:
             raise self.exc
         return self.payload
@@ -170,6 +173,22 @@ def test_memory_stats_namespace_is_per_agent_private(client: TestClient) -> None
 
     client.get("/api/agents/hermes/memory/stats")
     assert fake.calls[0]["dataset"] == "private:hermes"
+
+
+def test_memory_stats_passes_client_id_for_unified_bank_scoping(client: TestClient) -> None:
+    """#1654: without ``client_id``, unified-bank mode collapses
+    ``private:<agent>`` to ``shared`` and resolves the caller as
+    "unknown" — every private doc gets filtered OUT (owner mismatch)
+    while every ordinary shared doc passes straight through, so the
+    chip reports the whole shared bank instead of this agent's writes.
+    Every other caller (routes/memory.py, mcp/memory.py) passes
+    ``client_id`` — this endpoint must too.
+    """
+    fake = _FakeWrapper()
+    client.app.state.memory_provider = fake
+
+    client.get("/api/agents/hermes/memory/stats")
+    assert fake.calls[0]["client_id"] == "hermes"
 
 
 def test_memory_stats_handles_malformed_payload_gracefully(client: TestClient) -> None:

--- a/tests/memory/test_unified_bank.py
+++ b/tests/memory/test_unified_bank.py
@@ -338,6 +338,37 @@ async def test_unified_private_list_returns_to_owner_only():
 
 
 @pytest.mark.asyncio
+async def test_unified_private_only_list_excludes_public_shared_docs():
+    """#1654: a read that asks for ``private:<agent>`` ALONE (no ``shared``)
+    must return only that agent's private docs — NOT every public shared
+    doc too. ``_is_visible_to`` only enforces private OWNERSHIP and passes
+    every non-private doc unconditionally, so without this private-only
+    scoping a ``private:<agent>``-only request silently degrades to the
+    same result as a ``shared`` request (this is what the per-agent
+    memory-stats chip hits — codex review on #1654's fix PR)."""
+    p = _unified(client_id="hermes")
+    await p.add("hermes secret", dataset="private:hermes", client_id="hermes")
+    await p.add("public from hermes", dataset="shared", client_id="hermes")
+    await p.add("public from scribe", dataset="shared", client_id="scribe")
+
+    private_only = {
+        i["text"]
+        for i in (await p.list_items(dataset="private:hermes", client_id="hermes"))["items"]
+    }
+    assert private_only == {"hermes secret"}
+
+    # A mixed request (private + shared) is NOT private-only — it still
+    # wants the ordinary union.
+    mixed = {
+        i["text"]
+        for i in (await p.list_items(dataset=["private:hermes", "shared"], client_id="hermes"))[
+            "items"
+        ]
+    }
+    assert mixed == {"hermes secret", "public from hermes", "public from scribe"}
+
+
+@pytest.mark.asyncio
 async def test_legacy_multibank_private_recall_not_over_filtered():
     """Legacy multi-bank mode relies on per-bank ACL, not the tag, so a private
     doc carrying a custom (non-matching) agent tag must still come back to its


### PR DESCRIPTION
## Summary
- `get_agent_memory_stats` (`memory_stats.py:169`) called `wrapper.list_items(dataset="private:<agent>", cursor=None, limit=500)` with no `client_id` — every other caller (`routes/memory.py`, `mcp/memory.py`) passes it.
- In unified-bank mode (the shipped default), `HindsightProvider._allowed_namespaces` collapses `private:<agent>` → `[shared]`, and `_filter_visible` resolves the caller via `_caller_agent(None)` → `"unknown"`. Every doc actually tagged `visibility:private` + `agent:<agent>` is filtered OUT (owner mismatch), while every ordinary shared doc passes straight through unscoped. The per-agent chip ends up reporting the whole shared-bank page count (capped at 500) instead of that agent's own writes — the exact inverse of the module's documented contract.
- Fix: pass `client_id=agent_id`, matching every other read path.
- The existing test double's `list_items()` didn't declare a `client_id` parameter at all, so the fix would `TypeError` against it — updated the fake to accept and record `client_id`, and added a regression test asserting it's threaded through on every call.

Closes #1654

## Test plan
- [x] Confirmed red: reverted the source fix (kept the updated fake) → new `test_memory_stats_passes_client_id_for_unified_bank_scoping` fails (`client_id` was `None`).
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory tests/agents/test_agent_memory_stats_endpoint.py -q` — 197 passed