### PR TITLE
chore(deps): bump js-yaml to 4.3.1

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2914,9 +2914,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,5 +40,8 @@
   },
   "allowScripts": {
     "esbuild@0.25.12": true
+  },
+  "overrides": {
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `js-yaml` from 4.3.0 to 4.3.1 in `ui/` (dev-only, transitive via `eslint` -> `@eslint/eslintrc`).
- Fixes Dependabot high-severity alert: quadratic CPU consumption in `!!omap` resolution, [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (CVE-2026-59870 fix not backported to 4.3.0).

## Why
`eslint@9.39.5`'s `@eslint/eslintrc` still pins `js-yaml@4.3.0`, so a plain `npm update` doesn't reach 4.3.1. Added a scoped `overrides` entry in `ui/package.json` pinning `js-yaml` to `^4.3.1` to force the patched version without waiting on an eslint release.

## Verification
- `npm install` — resolves `js-yaml@4.3.1` (confirmed via `npm ls js-yaml`)
- `npm run build` — succeeds
- `npm run test:unit` — 80/80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)