### PR TITLE
fix(memory): route the hindsight extraction drop-in through the systemctl seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ applying. Add those subsections to a version's section to surface them; see
   starts, Pin = whether it may be stopped), and Eviction priority moved into
   the Advanced disclosure. Two fewer always-visible rows in the drawer body,
   and NPU slots — which have no Model section — gain the Auto-Load toggle.
+- Memory extraction-slot / LLM-timeout changes now actually reach the
+  hindsight-api daemon (#1641). The propagation wrote
+  `/etc/systemd/system/hindsight-api.service.d/extraction-model.conf`
+  directly and called bare `systemctl`, but hal0-api runs as the
+  unprivileged `hal0` user — the write was `EPERM` and the restart would
+  have hit polkit, so on every standard install the drop-in was never
+  created while `hal0.toml` (and the dashboard) reported the new slot as
+  applied. The write, `daemon-reload` and restart all route through the
+  existing `hal0-systemctl` seam now (new `write-hindsight-dropin` verb —
+  fixed literal path, body on stdin, no sudoers change: the grant is
+  pinned to the wrapper binary). The propagation also runs off the event
+  loop, so a hindsight-api cold start no longer blocks the API for the
+  length of the restart; `hal0.toml` is persisted *before* it, and the
+  whole read-modify-write is serialised, so a disconnect or a concurrent
+  save can no longer leave the recorded slot and the running daemon
+  disagreeing. Upgrading in place refreshes the wrapper only on
+  an `install.sh` re-run; until then the failure is loud
+  (`propagation.error`) instead of silent.
 
 ## [1.0.0-rc.2] — 2026-08-08
 
@@ -100,6 +118,23 @@ re-installing the previous tag (`v1.0.0-rc.1`) from its GitHub release.
 Note the `enabled`-sweep caveat from the R5 set: pre-R5 code reads a
 missing `enabled` as true, so a rollback past R5 needs the config backup
 taken before upgrading.
+=======
+- Memory extraction-slot / LLM-timeout changes now actually reach the
+  hindsight-api daemon (#1641). The propagation wrote
+  `/etc/systemd/system/hindsight-api.service.d/extraction-model.conf`
+  directly and called bare `systemctl`, but hal0-api runs as the
+  unprivileged `hal0` user — the write was `EPERM` and the restart would
+  have hit polkit, so on every standard install the drop-in was never
+  created while `hal0.toml` (and the dashboard) reported the new slot as
+  applied. The write, `daemon-reload` and restart all route through the
+  existing `hal0-systemctl` seam now (new `write-hindsight-dropin` verb —
+  fixed literal path, body on stdin, no sudoers change: the grant is
+  pinned to the wrapper binary). The propagation also runs off the event
+  loop, so a hindsight-api cold start no longer blocks the API for the
+  length of the restart. Upgrading in place refreshes the wrapper only on
+  an `install.sh` re-run; until then the failure is loud
+  (`propagation.error`) instead of silent.
+>>>>>>> 038a7541 (fix(memory): route the hindsight extraction drop-in through the systemctl seam)
 
 ## [1.0.0] — 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,26 +118,6 @@ re-installing the previous tag (`v1.0.0-rc.1`) from its GitHub release.
 Note the `enabled`-sweep caveat from the R5 set: pre-R5 code reads a
 missing `enabled` as true, so a rollback past R5 needs the config backup
 taken before upgrading.
-=======
-- Memory extraction-slot / LLM-timeout changes now actually reach the
-  hindsight-api daemon (#1641). The propagation wrote
-  `/etc/systemd/system/hindsight-api.service.d/extraction-model.conf`
-  directly and called bare `systemctl`, but hal0-api runs as the
-  unprivileged `hal0` user — the write was `EPERM` and the restart would
-  have hit polkit, so on every standard install the drop-in was never
-  created while `hal0.toml` (and the dashboard) reported the new slot as
-  applied. The write, `daemon-reload` and restart all route through the
-  existing `hal0-systemctl` seam now (new `write-hindsight-dropin` verb —
-  fixed literal path, body on stdin, no sudoers change: the grant is
-  pinned to the wrapper binary). The propagation also runs off the event
-  loop, so a hindsight-api cold start no longer blocks the API for the
-  length of the restart; `hal0.toml` is persisted *before* it, and the
-  whole read-modify-write is serialised, so a disconnect or a concurrent
-  save can no longer leave the recorded slot and the running daemon
-  disagreeing. Upgrading in place refreshes the wrapper only on
-  an `install.sh` re-run; until then the failure is loud
-  (`propagation.error`) instead of silent.
->>>>>>> 038a7541 (fix(memory): route the hindsight extraction drop-in through the systemctl seam)
 
 ## [1.0.0] — 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,10 @@ taken before upgrading.
   fixed literal path, body on stdin, no sudoers change: the grant is
   pinned to the wrapper binary). The propagation also runs off the event
   loop, so a hindsight-api cold start no longer blocks the API for the
-  length of the restart. Upgrading in place refreshes the wrapper only on
+  length of the restart; `hal0.toml` is persisted *before* it, and the
+  whole read-modify-write is serialised, so a disconnect or a concurrent
+  save can no longer leave the recorded slot and the running daemon
+  disagreeing. Upgrading in place refreshes the wrapper only on
   an `install.sh` re-run; until then the failure is loud
   (`propagation.error`) instead of silent.
 >>>>>>> 038a7541 (fix(memory): route the hindsight extraction drop-in through the systemctl seam)

--- a/docs/operate/services.mdx
+++ b/docs/operate/services.mdx
@@ -132,8 +132,15 @@ WantedBy=multi-user.target
 - **No TOML config** — every setting is an inline `Environment=` line in the
   unit itself. An optional operator drop-in,
   `hindsight-api.service.d/extraction-model.conf`, overrides
-  `HINDSIGHT_API_LLM_MODEL` without editing the installer-owned unit (written
-  by `hal0 memory graph enable --slot <name>` or the Memory dashboard page).
+  `HINDSIGHT_API_LLM_MODEL` and `HINDSIGHT_API_LLM_TIMEOUT` without editing the
+  installer-owned unit (written by `hal0 memory graph enable --slot <name>` or
+  the Memory dashboard page). That drop-in lives under `/etc/systemd/system`
+  and hal0-api runs unprivileged, so the write and the follow-up restart both
+  route through the `hal0-systemctl` wrapper
+  (`write-hindsight-dropin` + `svc-restart hindsight`). If the wrapper or its
+  sudoers grant is missing, the API's response carries a non-null
+  `propagation.error` and the engine keeps its previous extraction target —
+  check `hal0 doctor` for the seam rows.
 - **Data root** — embedded Postgres at `/var/lib/hal0/memory/hindsight/.pg0`,
   pinned via the unit's `HOME=` env (Hindsight has no dedicated data-dir
   variable of its own).

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -51,6 +51,15 @@ QUADLET_DIR="/etc/containers/systemd"
 GATEWAY_DROPIN_DIR="/etc/systemd/system/hermes-gateway.service.d"
 GATEWAY_DROPIN_FILE="${GATEWAY_DROPIN_DIR}/10-hal0-secrets.conf"
 
+# Fixed, literal drop-in path for the hindsight-api extraction override (#1641 /
+# ADR-0023): HINDSIGHT_API_LLM_MODEL + HINDSIGHT_API_LLM_TIMEOUT, repointed by
+# `hal0 memory graph enable --slot <name>` and the Memory dashboard. Same posture
+# and same reason as the gateway drop-in above: hal0-api runs as the
+# unprivileged hal0 user and cannot write /etc/systemd/system itself. LITERAL —
+# the caller supplies only the body on stdin, never the path.
+HINDSIGHT_DROPIN_DIR="/etc/systemd/system/hindsight-api.service.d"
+HINDSIGHT_DROPIN_FILE="${HINDSIGHT_DROPIN_DIR}/extraction-model.conf"
+
 die() { echo "hal0-systemctl: $1" >&2; exit 64; }
 
 validate_slot_id() {   # arg: slot id (the "<id>" in hal0-slot@<id>.service)
@@ -109,6 +118,21 @@ case "$cmd" in
     chown root:root "$tmp"
     chmod 0644 "$tmp"
     mv -f "$tmp" "$GATEWAY_DROPIN_FILE"
+    trap - EXIT
+    ;;
+
+  write-hindsight-dropin)     # write the hindsight-api extraction drop-in (body on stdin)
+    # Literal fixed path — the caller never supplies it, so this verb can only
+    # ever reach that one file. 0644 root:root so systemd can read the fragment.
+    # Atomic (tmp + mv), same shape as write-gateway-dropin.
+    install -d -m 0755 -o root -g root "$HINDSIGHT_DROPIN_DIR"
+    umask 022
+    tmp="$(mktemp "${HINDSIGHT_DROPIN_FILE}.XXXXXX")"
+    trap 'rm -f "$tmp"' EXIT
+    cat > "$tmp"
+    chown root:root "$tmp"
+    chmod 0644 "$tmp"
+    mv -f "$tmp" "$HINDSIGHT_DROPIN_FILE"
     trap - EXIT
     ;;
 
@@ -185,6 +209,7 @@ usage: hal0-systemctl <command> [slot-id|agent-id]
   write-quadlet <slot-id>          write ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container (body on stdin)
   remove-quadlet <slot-id>         rm -f ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container
   write-gateway-dropin             write ${GATEWAY_DROPIN_FILE} (body on stdin)
+  write-hindsight-dropin           write ${HINDSIGHT_DROPIN_FILE} (body on stdin)
   daemon-reload                    systemctl daemon-reload
   start|stop|restart <slot-id>     systemctl <verb> ${UNIT_PREFIX}<id>.service
   enable|disable <slot-id>         systemctl <verb> ${UNIT_PREFIX}<id>.service

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -414,6 +414,14 @@ async def retry_failed_extractions(request: Request) -> dict[str, Any]:
 
 # ── PUT /api/memory/graph ──────────────────────────────────────────────────
 
+#: Serializes the graph-config read-modify-write. The propagation awaits a
+#: ~60s hindsight-api restart (#1641), so without this two concurrent PUTs
+#: could interleave — one writing slot A's drop-in, the other overwriting it
+#: with B, and the first still persisting A into ``hal0.toml`` afterwards,
+#: leaving the recorded config and the running daemon on different slots.
+#: hal0-api is the only writer of either, so one in-process lock is enough.
+_GRAPH_CONFIG_LOCK = asyncio.Lock()
+
 
 @router.put("/graph")
 async def update_graph_config(request: Request) -> dict[str, Any]:
@@ -438,71 +446,79 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
         raise Hal0Error("request body must be a JSON object")
 
     wrapper = _wrapper(request)
-    cfg = load_hal0_config()
-    current_raw = cfg.memory.graph.model_dump(mode="python")
-    merged_raw = {**current_raw, **body}
 
-    try:
-        new_cfg = MemoryGraphConfig.model_validate(merged_raw)
-    except ValidationError as exc:
-        raise MemoryGraphConfigInvalid(
-            "memory.graph config failed schema validation",
-            details=_validation_error_details(exc),
-        ) from exc
+    async with _GRAPH_CONFIG_LOCK:
+        cfg = load_hal0_config()
+        current_raw = cfg.memory.graph.model_dump(mode="python")
+        merged_raw = {**current_raw, **body}
 
-    # Validate extraction_slot against the live slot set when it is being
-    # changed — reject an unknown / non-llm slot with the valid options so the
-    # gate never flips onto a target that can't serve extraction.
-    slot_changed = new_cfg.extraction_slot != cfg.memory.graph.extraction_slot
-    if slot_changed:
-        available = await _enabled_llm_slots(request)
-        if available and new_cfg.extraction_slot not in available:
-            raise MemoryGraphSlotInvalid(
-                f"extraction_slot {new_cfg.extraction_slot!r} is not an enabled llm slot",
-                details={"available_slots": ", ".join(available)},
+        try:
+            new_cfg = MemoryGraphConfig.model_validate(merged_raw)
+        except ValidationError as exc:
+            raise MemoryGraphConfigInvalid(
+                "memory.graph config failed schema validation",
+                details=_validation_error_details(exc),
+            ) from exc
+
+        # Validate extraction_slot against the live slot set when it is being
+        # changed — reject an unknown / non-llm slot with the valid options so
+        # the gate never flips onto a target that can't serve extraction.
+        slot_changed = new_cfg.extraction_slot != cfg.memory.graph.extraction_slot
+        timeout_changed = new_cfg.llm_timeout_s != cfg.memory.graph.llm_timeout_s
+        if slot_changed:
+            available = await _enabled_llm_slots(request)
+            if available and new_cfg.extraction_slot not in available:
+                raise MemoryGraphSlotInvalid(
+                    f"extraction_slot {new_cfg.extraction_slot!r} is not an enabled llm slot",
+                    details={"available_slots": ", ".join(available)},
+                )
+
+        # Flip the live wrapper's reported state BEFORE persisting.
+        try:
+            wrapper.set_graph_enabled(new_cfg.enabled, extraction_slot=new_cfg.extraction_slot)
+        except ValueError as exc:
+            raise MemoryGraphConfigInvalid(str(exc)) from exc
+
+        # Persist BEFORE propagating (#1641). The propagation awaits a ~60s
+        # restart, and cancelling that await (client disconnect, shutdown,
+        # request timeout) does NOT stop the worker thread — with the save
+        # afterwards the daemon could end up on the new slot while hal0.toml
+        # still held the old one. Config is the source of truth and the
+        # propagation is documented best-effort in the other direction (a
+        # restart failure is surfaced, never rolled back), so saving first is
+        # the ordering that cannot produce a silent divergence.
+        cfg.memory.graph = new_cfg
+        try:
+            save_hal0_config(cfg)
+        except OSError as exc:
+            raise Hal0Error(
+                f"could not persist hal0 config: {exc}",
+                details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+            ) from exc
+
+        # Propagate the extraction slot + LLM timeout to hindsight-api (drop-in
+        # + restart) so the engine's native extraction LLM follows the choice.
+        propagation: dict[str, Any] | None = None
+        if slot_changed or timeout_changed:
+            from hal0.memory.extraction_env import apply_extraction_slot
+
+            # Thread hop (#1641): the propagation shells out to the privileged
+            # seam and then waits on a hindsight-api restart — a bounded but
+            # multi-second blocking call that would otherwise stall the whole
+            # event loop for the engine's cold start.
+            propagation = await asyncio.to_thread(
+                apply_extraction_slot,
+                new_cfg.extraction_slot,
+                timeout_s=new_cfg.llm_timeout_s,
             )
 
-    # Flip the live wrapper's reported state BEFORE persisting.
-    try:
-        wrapper.set_graph_enabled(new_cfg.enabled, extraction_slot=new_cfg.extraction_slot)
-    except ValueError as exc:
-        raise MemoryGraphConfigInvalid(str(exc)) from exc
-
-    # Propagate the extraction slot + LLM timeout to hindsight-api (drop-in +
-    # restart) so the engine's native extraction LLM follows the choice.
-    # Best-effort: a restart failure is surfaced in the response but does not
-    # roll back the config.
-    timeout_changed = new_cfg.llm_timeout_s != cfg.memory.graph.llm_timeout_s
-    propagation: dict[str, Any] | None = None
-    if slot_changed or timeout_changed:
-        from hal0.memory.extraction_env import apply_extraction_slot
-
-        # Thread hop (#1641): the propagation shells out to the privileged seam
-        # and then waits on a hindsight-api restart — a ~60s-bounded blocking
-        # call that would otherwise stall the whole event loop for the engine's
-        # cold start.
-        propagation = await asyncio.to_thread(
-            apply_extraction_slot,
-            new_cfg.extraction_slot,
-            timeout_s=new_cfg.llm_timeout_s,
-        )
-
-    cfg.memory.graph = new_cfg
-    try:
-        save_hal0_config(cfg)
-    except OSError as exc:
-        raise Hal0Error(
-            f"could not persist hal0 config: {exc}",
-            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
-        ) from exc
-
-    out = new_cfg.model_dump(mode="json")
-    # Echo the live status so the dashboard's optimistic-update path
-    # gets the counters in the same round trip without a second fetch.
-    out["status"] = wrapper.graph_status()
-    if propagation is not None:
-        out["propagation"] = propagation
-    return out
+        out = new_cfg.model_dump(mode="json")
+        # Echo the live status so the dashboard's optimistic-update path
+        # gets the counters in the same round trip without a second fetch.
+        out["status"] = wrapper.graph_status()
+        if propagation is not None:
+            out["propagation"] = propagation
+        return out
 
 
 # ── REST shims for /api/memory/{add,search,list,delete} (#302) ─────────────

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -18,6 +18,7 @@ veneer that:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from typing import Any
@@ -476,8 +477,14 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
     if slot_changed or timeout_changed:
         from hal0.memory.extraction_env import apply_extraction_slot
 
-        propagation = apply_extraction_slot(
-            new_cfg.extraction_slot, timeout_s=new_cfg.llm_timeout_s
+        # Thread hop (#1641): the propagation shells out to the privileged seam
+        # and then waits on a hindsight-api restart — a ~60s-bounded blocking
+        # call that would otherwise stall the whole event loop for the engine's
+        # cold start.
+        propagation = await asyncio.to_thread(
+            apply_extraction_slot,
+            new_cfg.extraction_slot,
+            timeout_s=new_cfg.llm_timeout_s,
         )
 
     cfg.memory.graph = new_cfg

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -89,6 +89,30 @@ def _detail(exc: BaseException) -> str:
     return f"{exc}{(' — ' + stderr) if stderr else ''}"
 
 
+#: The wrapper's own ``die()`` exit code (installer/wrappers/hal0-systemctl).
+_SEAM_USAGE_RC = 64
+
+_STALE_WRAPPER_HINT = (
+    " — the installed /usr/lib/hal0/bin/hal0-systemctl predates this verb; "
+    "re-run the installer (`sudo bash install.sh`) to refresh the seam wrapper"
+)
+
+
+def _stale_wrapper_hint(exc: BaseException) -> str:
+    """Remediation text when the seam rejected the verb outright.
+
+    ``hal0 update`` swaps the release tree and re-pips the venv but does not
+    reinstall ``${LIB_DIR}/bin/*`` — only ``install.sh`` does. So new Python can
+    meet an old wrapper, which answers a verb it doesn't know with
+    ``hal0-systemctl: bad cmd: ...`` and exit 64. That is a fixable operator
+    condition, not a bug report, so say how to fix it.
+    """
+    rc = getattr(exc, "returncode", None)
+    if rc == _SEAM_USAGE_RC or "bad cmd" in _detail(exc):
+        return _STALE_WRAPPER_HINT
+    return ""
+
+
 def render_drop_in(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> str:
     """Return the drop-in contents pinning extraction to ``hal0/<slot>`` + timeout."""
     return _DROP_IN_TEMPLATE.format(slot=slot, timeout_s=int(timeout_s))
@@ -130,10 +154,16 @@ def apply_extraction_slot(
     }
 
     try:
-        seam.write_hindsight_dropin(render_drop_in(slot, timeout_s), path=DROP_IN_PATH)
+        seam.write_hindsight_dropin(
+            render_drop_in(slot, timeout_s),
+            path=DROP_IN_PATH,
+            timeout=_SYSTEMCTL_TIMEOUT_S,
+        )
         result["written"] = True
     except (OSError, subprocess.SubprocessError) as exc:
-        result["error"] = f"could not write {DROP_IN_PATH}: {_detail(exc)}"
+        result["error"] = (
+            f"could not write {DROP_IN_PATH}: {_detail(exc)}{_stale_wrapper_hint(exc)}"
+        )
         log.warning("hal0.memory.extraction_dropin_write_failed", slot=slot, error=str(exc))
         return result
 

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -14,10 +14,27 @@ engine picks up the new target. The slot is addressed as the ``hal0/<slot>`` vir
 (resolved by the dispatcher to that slot's model — ADR-0023 §2), so the value tracks
 the slot, never a hardcoded model id.
 
-Privileged operation: writing under ``/etc/systemd/system`` + restarting a unit needs
-root. When hal0-api runs unprivileged the write/restart will fail; this module is
-best-effort and returns a status dict describing what happened rather than raising, so
-the API can surface a partial result instead of 500ing.
+Privileged operation, routed through the seam (#1641): both the drop-in write and
+the restart are genuinely-root, and hal0-api runs as the unprivileged ``hal0``
+service user (``User=hal0``). The original implementation wrote
+``/etc/systemd/system`` directly and shelled out to a bare ``systemctl``, so on
+every standard install the write died with ``EPERM`` (the ``.d`` dir is
+``root:root``) and the restart, had it been reached, would have hit polkit's
+"Interactive authentication required" — while ``hal0.toml`` recorded the new slot
+regardless, so the dashboard reported an override that was never applied. Every
+step now goes through :class:`hal0.system.SystemCtlSeam`:
+
+* the drop-in write -> ``hal0-systemctl write-hindsight-dropin`` (body on stdin,
+  the path is a root-side literal — the ``write-gateway-dropin`` posture);
+* ``daemon-reload`` -> the seam's own verb;
+* the restart -> ``svc-restart hindsight`` (the wrapper's closed companion-unit
+  map), which is why the unit is spelled ``hindsight-api.service`` here.
+
+Off the ``hal0`` service account (root, a dev shell, CI, the unit tests) the seam
+is a passthrough and everything runs directly, exactly as before.
+
+Still best-effort: this returns a status dict describing what happened rather than
+raising, so the API can surface a partial result instead of 500ing.
 """
 
 from __future__ import annotations
@@ -28,12 +45,20 @@ from typing import Any
 
 import structlog
 
+from hal0.system.seam import SystemCtlSeam
+
 log = structlog.get_logger(__name__)
 
 #: systemd drop-in directory + file for the hindsight-api extraction model override.
 DROP_IN_DIR = Path("/etc/systemd/system/hindsight-api.service.d")
 DROP_IN_PATH = DROP_IN_DIR / "extraction-model.conf"
-SERVICE = "hindsight-api"
+#: Full unit name — ``COMPANION_SERVICE_UNITS`` keys on it to reach the wrapper's
+#: ``svc-restart hindsight`` arm. A bare ``hindsight-api`` would miss that map and
+#: fall through to an unprivileged (polkit-blocked) systemctl.
+SERVICE = "hindsight-api.service"
+
+#: Bound on each seam call so a wedged unit can never pin an event-loop thread.
+_SYSTEMCTL_TIMEOUT_S = 60.0
 
 #: Default daemon LLM timeout (seconds) — mirrors MemoryGraphConfig.llm_timeout_s.
 DEFAULT_LLM_TIMEOUT_S = 300
@@ -50,6 +75,20 @@ _DROP_IN_TEMPLATE = (
 )
 
 
+def _detail(exc: BaseException) -> str:
+    """``str(exc)`` plus the child's stderr when there is one.
+
+    A seam failure's *cause* almost always lives in stderr — ``sudo: a password
+    is required`` (no grant), ``hal0-systemctl: bad cmd`` (stale wrapper) — while
+    ``str(exc)`` is just the exit code. Both go to the operator.
+    """
+    stderr = getattr(exc, "stderr", "") or ""
+    if isinstance(stderr, bytes):  # TimeoutExpired can carry raw bytes
+        stderr = stderr.decode("utf-8", "replace")
+    stderr = stderr.strip()
+    return f"{exc}{(' — ' + stderr) if stderr else ''}"
+
+
 def render_drop_in(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> str:
     """Return the drop-in contents pinning extraction to ``hal0/<slot>`` + timeout."""
     return _DROP_IN_TEMPLATE.format(slot=slot, timeout_s=int(timeout_s))
@@ -60,6 +99,7 @@ def apply_extraction_slot(
     *,
     timeout_s: int = DEFAULT_LLM_TIMEOUT_S,
     restart: bool = True,
+    seam: SystemCtlSeam | None = None,
 ) -> dict[str, Any]:
     """Write the drop-in for ``slot`` and (best-effort) restart hindsight-api.
 
@@ -70,7 +110,13 @@ def apply_extraction_slot(
 
     ``error`` is ``None`` on full success. The write is atomic (temp + rename) so a
     crash mid-write never leaves a half-written override that would wedge the unit.
+
+    ``seam`` is an injection point (default-constructed = production behaviour), so
+    the privileged routing is unit-testable without sudo, a real ``hal0`` user, or
+    a writable ``/etc``. Blocking: callers on the event loop must hop a thread
+    (``asyncio.to_thread``) — the restart waits on a hindsight-api cold start.
     """
+    seam = seam if seam is not None else SystemCtlSeam()
     model = f"hal0/{slot}"
     result: dict[str, Any] = {
         "slot": slot,
@@ -84,13 +130,10 @@ def apply_extraction_slot(
     }
 
     try:
-        DROP_IN_DIR.mkdir(parents=True, exist_ok=True)
-        tmp = DROP_IN_PATH.with_suffix(".conf.tmp")
-        tmp.write_text(render_drop_in(slot, timeout_s), encoding="utf-8")
-        tmp.replace(DROP_IN_PATH)
+        seam.write_hindsight_dropin(render_drop_in(slot, timeout_s), path=DROP_IN_PATH)
         result["written"] = True
-    except OSError as exc:
-        result["error"] = f"could not write {DROP_IN_PATH}: {exc}"
+    except (OSError, subprocess.SubprocessError) as exc:
+        result["error"] = f"could not write {DROP_IN_PATH}: {_detail(exc)}"
         log.warning("hal0.memory.extraction_dropin_write_failed", slot=slot, error=str(exc))
         return result
 
@@ -98,17 +141,14 @@ def apply_extraction_slot(
         return result
 
     for step, args in (
-        ("daemon_reloaded", ["systemctl", "daemon-reload"]),
-        ("restarted", ["systemctl", "restart", SERVICE]),
+        ("daemon_reloaded", ("systemctl", "daemon-reload")),
+        ("restarted", ("systemctl", "restart", SERVICE)),
     ):
         try:
-            subprocess.run(args, check=True, capture_output=True, text=True, timeout=60)
+            seam.systemctl(*args, check=True, timeout=_SYSTEMCTL_TIMEOUT_S)
             result[step] = True
         except (OSError, subprocess.SubprocessError) as exc:
-            stderr = getattr(exc, "stderr", "") or ""
-            result["error"] = (
-                f"{' '.join(args)} failed: {exc}{(' — ' + stderr.strip()) if stderr else ''}"
-            )
+            result["error"] = f"{' '.join(args)} failed: {_detail(exc)}"
             log.warning(
                 "hal0.memory.extraction_restart_failed",
                 slot=slot,

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -92,6 +92,14 @@ COMPANION_SERVICE_UNITS: dict[str, str] = {
     "hindsight-api.service": "hindsight",
 }
 
+#: Fixed, literal drop-in the memory extraction slot / LLM timeout ride on
+#: (#1641, ADR-0023). Root-owned like every other ``/etc/systemd/system``
+#: fragment, so an unprivileged hal0-api writes it through the wrapper's
+#: ``write-hindsight-dropin`` verb (body on stdin, path is a root-side literal)
+#: — exactly the ``write-gateway-dropin`` shape.
+HINDSIGHT_DROPIN_DIR = Path("/etc/systemd/system/hindsight-api.service.d")
+HINDSIGHT_DROPIN_PATH = HINDSIGHT_DROPIN_DIR / "extraction-model.conf"
+
 
 class Hal0SeamMissing(RuntimeError):
     """Raised when the hal0-systemctl seam is required but not installed.
@@ -307,6 +315,34 @@ class SystemCtlSeam:
             raise ValueError(f"not a hal0-slot@ quadlet file: {quadlet_path.name!r}")
         self._run(self._seam_argv("remove-quadlet", token), check=False)
 
+    def write_hindsight_dropin(self, body: str, *, path: Path = HINDSIGHT_DROPIN_PATH) -> None:
+        """Write the hindsight-api extraction drop-in (#1641).
+
+        Unlike :meth:`write_unit` / :meth:`write_quadlet` there is no id to
+        validate: the target is a single fixed file, so the seam verb takes only
+        the body on stdin and the root side owns the path outright (the
+        ``write-gateway-dropin`` posture). ``path`` is therefore used **only** on
+        the direct (root / dev / CI) branch — it exists so tests and callers that
+        redirect the drop-in to a tmp tree keep working; the seam branch can only
+        ever reach :data:`HINDSIGHT_DROPIN_PATH`.
+
+        The direct write is atomic (temp + rename) so a crash mid-write can never
+        leave a half-written override that would wedge hindsight-api.
+        """
+        if not self._is_hal0_user():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".conf.tmp")
+            tmp.write_text(body, encoding="utf-8")
+            tmp.replace(path)
+            return
+        self._run(
+            self._seam_argv("write-hindsight-dropin"),
+            input=body,
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+
     def systemctl(
         self,
         *args: str,
@@ -398,6 +434,8 @@ __all__ = [
     "AGENT_UNIT_PREFIX",
     "AGENT_UNIT_VERBS",
     "COMPANION_SERVICE_UNITS",
+    "HINDSIGHT_DROPIN_DIR",
+    "HINDSIGHT_DROPIN_PATH",
     "SEAM_BIN",
     "Hal0SeamMissing",
     "SystemCtlSeam",

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -315,7 +315,13 @@ class SystemCtlSeam:
             raise ValueError(f"not a hal0-slot@ quadlet file: {quadlet_path.name!r}")
         self._run(self._seam_argv("remove-quadlet", token), check=False)
 
-    def write_hindsight_dropin(self, body: str, *, path: Path = HINDSIGHT_DROPIN_PATH) -> None:
+    def write_hindsight_dropin(
+        self,
+        body: str,
+        *,
+        path: Path = HINDSIGHT_DROPIN_PATH,
+        timeout: float | None = None,
+    ) -> None:
         """Write the hindsight-api extraction drop-in (#1641).
 
         Unlike :meth:`write_unit` / :meth:`write_quadlet` there is no id to
@@ -328,6 +334,12 @@ class SystemCtlSeam:
 
         The direct write is atomic (temp + rename) so a crash mid-write can never
         leave a half-written override that would wedge hindsight-api.
+
+        ``timeout`` (seconds, ``None`` = unbounded) bounds the seam child, like
+        :meth:`systemctl`'s. A caller on an API worker thread must pass one: a
+        stalled ``sudo`` (NSS lookup, a wedged root-side filesystem op) would
+        otherwise park that thread forever, and enough retries would drain the
+        pool.
         """
         if not self._is_hal0_user():
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -341,6 +353,7 @@ class SystemCtlSeam:
             text=True,
             check=True,
             capture_output=True,
+            timeout=timeout,
         )
 
     def systemctl(

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -148,6 +148,27 @@ def test_put_enable_with_valid_slot(
     assert body["propagation"]["slot"] == "agent"
 
 
+def test_put_persists_hal0_toml_before_propagating(
+    client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    """#1641 review: the propagation awaits a ~60s restart, and cancelling that
+    await (client disconnect) does NOT stop the worker thread. If the save ran
+    afterwards, the daemon could end up on the new slot while hal0.toml still
+    held the old one. Persist first — the propagation is the best-effort half."""
+    from hal0.config import paths as config_paths
+
+    def _record(*_a: object, **_k: object) -> dict[str, object]:
+        # Called from the thread hop: hal0.toml must ALREADY name the new slot.
+        assert 'extraction_slot = "agent"' in config_paths.hal0_toml().read_text()
+        return {"slot": "agent", "written": True, "error": None}
+
+    with patch("hal0.memory.extraction_env.apply_extraction_slot", side_effect=_record):
+        r = client.put("/api/memory/graph", json={"enabled": True, "extraction_slot": "agent"})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["propagation"]["written"] is True
+
+
 def test_put_enable_with_unknown_slot_rejected(
     client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -9,6 +9,7 @@ best-effort (returns a status dict rather than raising) so an unprivileged hal0
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from hal0.memory.extraction_env import (
@@ -16,6 +17,25 @@ from hal0.memory.extraction_env import (
     apply_extraction_slot,
     render_drop_in,
 )
+from hal0.system.seam import SEAM_BIN, SystemCtlSeam
+
+
+def _seam_recorder(rc: int = 0, stderr: str = ""):
+    """Record ``(argv, stdin-body)`` for every seam invocation."""
+    calls: list[tuple[list[str], str | None]] = []
+
+    def _run(argv, **kwargs):
+        calls.append((list(argv), kwargs.get("input")))
+        done = subprocess.CompletedProcess(list(argv), rc, "", stderr)
+        if rc and kwargs.get("check", False):
+            raise subprocess.CalledProcessError(rc, list(argv), "", stderr)
+        return done
+
+    return calls, _run
+
+
+def _forbidden(*_a, **_k):  # pragma: no cover — a call here is the bug
+    raise AssertionError("privileged work must route through the seam, not bare subprocess")
 
 
 def test_render_drop_in_pins_hal0_virtual():
@@ -37,7 +57,7 @@ def test_drop_in_path_is_a_systemd_override():
 
 
 def test_apply_writes_drop_in_and_reports_status(monkeypatch, tmp_path: Path):
-    # Redirect the drop-in to a tmp dir + stub systemctl so the test never
+    # Redirect the drop-in to a tmp dir + inject a fake runner so the test never
     # touches /etc or the real service.
     import hal0.memory.extraction_env as ee
 
@@ -45,19 +65,11 @@ def test_apply_writes_drop_in_and_reports_status(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
     monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
 
-    ran: list[list[str]] = []
+    calls, run = _seam_recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: False)
 
-    def fake_run(args, **_kw):
-        ran.append(list(args))
-
-        class _Done:
-            returncode = 0
-
-        return _Done()
-
-    monkeypatch.setattr(ee.subprocess, "run", fake_run)
-
-    result = apply_extraction_slot("utility")
+    result = apply_extraction_slot("utility", seam=seam)
+    ran = [c[0] for c in calls]
 
     assert result["error"] is None
     assert result["written"] is True
@@ -65,9 +77,10 @@ def test_apply_writes_drop_in_and_reports_status(monkeypatch, tmp_path: Path):
     assert result["restarted"] is True
     assert result["model"] == "hal0/utility"
     assert drop_in.read_text().count("HINDSIGHT_API_LLM_MODEL=hal0/utility") == 1
-    # daemon-reload then restart, in order.
+    # daemon-reload then restart, in order. Off the hal0 service account the
+    # seam is a passthrough, so these are the bare argv.
     assert ran[0][:2] == ["systemctl", "daemon-reload"]
-    assert ran[1] == ["systemctl", "restart", "hindsight-api"]
+    assert ran[1] == ["systemctl", "restart", "hindsight-api.service"]
 
 
 def test_apply_no_restart_skips_systemctl(monkeypatch, tmp_path: Path):
@@ -77,12 +90,9 @@ def test_apply_no_restart_skips_systemctl(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
     monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
 
-    def boom(*_a, **_k):  # pragma: no cover — must not be called
-        raise AssertionError("systemctl should not run when restart=False")
+    seam = SystemCtlSeam(run=_forbidden, is_hal0_user=lambda: False)
 
-    monkeypatch.setattr(ee.subprocess, "run", boom)
-
-    result = apply_extraction_slot("agent", restart=False)
+    result = apply_extraction_slot("agent", restart=False, seam=seam)
     assert result["written"] is True
     assert result["restarted"] is False
     assert result["error"] is None
@@ -108,3 +118,81 @@ def test_apply_threads_timeout_into_drop_in_and_status(monkeypatch, tmp_path: Pa
     text = drop_in.read_text()
     assert "HINDSIGHT_API_LLM_MODEL=hal0/agent" in text
     assert "HINDSIGHT_API_LLM_TIMEOUT=900" in text
+
+
+# ── #1641: the unprivileged hal0-api path ────────────────────────────────────
+#
+# hal0-api runs as the unprivileged ``hal0`` service user (User=hal0), and
+# /etc/systemd/system/hindsight-api.service.d is root:root. Writing the drop-in
+# directly is EPERM and a bare ``systemctl restart`` escalates through polkit
+# ("Interactive authentication required"), so on every standard install the
+# propagation silently no-opped while hal0.toml recorded the new slot. Every
+# privileged step must route through the hal0-systemctl seam instead.
+
+
+def test_apply_routes_every_step_through_the_seam_as_the_hal0_user(monkeypatch, tmp_path: Path):
+    import hal0.memory.extraction_env as ee
+
+    drop_in = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+    monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
+    monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
+    monkeypatch.setattr(ee.subprocess, "run", _forbidden)
+
+    calls, run = _seam_recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+
+    result = apply_extraction_slot("utility", timeout_s=420, seam=seam)
+
+    assert result["error"] is None
+    assert result["written"] is True
+    assert result["daemon_reloaded"] is True
+    assert result["restarted"] is True
+    # Never written directly — the root side owns the literal path.
+    assert not drop_in.exists()
+    assert [c[0] for c in calls] == [
+        ["sudo", "-n", SEAM_BIN, "write-hindsight-dropin"],
+        ["sudo", "-n", SEAM_BIN, "daemon-reload"],
+        ["sudo", "-n", SEAM_BIN, "svc-restart", "hindsight"],
+    ]
+    body = calls[0][1]
+    assert "HINDSIGHT_API_LLM_MODEL=hal0/utility" in body
+    assert "HINDSIGHT_API_LLM_TIMEOUT=420" in body
+
+
+def test_apply_surfaces_a_seam_write_failure(monkeypatch, tmp_path: Path):
+    import hal0.memory.extraction_env as ee
+
+    drop_in = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+    monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
+    monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
+    monkeypatch.setattr(ee.subprocess, "run", _forbidden)
+
+    _calls, run = _seam_recorder(rc=1, stderr="sudo: a password is required")
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+
+    result = apply_extraction_slot("utility", seam=seam)
+
+    assert result["written"] is False
+    assert result["restarted"] is False
+    assert result["error"] and "sudo" in result["error"]
+
+
+def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Path):
+    """Root / dev / CI keeps the pre-seam behaviour: a direct atomic write."""
+    import hal0.memory.extraction_env as ee
+
+    drop_in = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+    monkeypatch.setattr(ee, "DROP_IN_DIR", drop_in.parent)
+    monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
+
+    calls, run = _seam_recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: False)
+
+    result = apply_extraction_slot("agent", seam=seam)
+
+    assert result["error"] is None
+    assert drop_in.read_text().count("HINDSIGHT_API_LLM_MODEL=hal0/agent") == 1
+    assert [c[0] for c in calls] == [
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "restart", "hindsight-api.service"],
+    ]

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -177,6 +177,53 @@ def test_apply_surfaces_a_seam_write_failure(monkeypatch, tmp_path: Path):
     assert result["error"] and "sudo" in result["error"]
 
 
+def test_apply_bounds_the_privileged_write(monkeypatch, tmp_path: Path):
+    """A stalled sudo must not park an API worker thread forever."""
+    import hal0.memory.extraction_env as ee
+
+    drop_in = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+    monkeypatch.setattr(ee, "DROP_IN_PATH", drop_in)
+
+    seen: list[object] = []
+
+    def _run(argv, **kwargs):
+        seen.append(kwargs.get("timeout"))
+        return subprocess.CompletedProcess(list(argv), 0, "", "")
+
+    seam = SystemCtlSeam(run=_run, is_hal0_user=lambda: True)
+    apply_extraction_slot("utility", seam=seam)
+
+    # write, daemon-reload, restart — every one bounded.
+    assert seen == [ee._SYSTEMCTL_TIMEOUT_S] * 3
+
+
+def test_apply_names_the_stale_wrapper_as_the_cause(monkeypatch, tmp_path: Path):
+    """`hal0 update` never refreshes ${LIB_DIR}/bin, so new Python can meet an
+    old wrapper. Exit 64 / `bad cmd` is a fixable operator condition — say so."""
+    import hal0.memory.extraction_env as ee
+
+    monkeypatch.setattr(ee, "DROP_IN_PATH", tmp_path / "extraction-model.conf")
+
+    _calls, run = _seam_recorder(rc=64, stderr="hal0-systemctl: bad cmd: write-hindsight-dropin")
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+
+    result = apply_extraction_slot("utility", seam=seam)
+
+    assert result["written"] is False
+    assert "install.sh" in result["error"]
+
+
+def test_apply_does_not_blame_the_wrapper_for_other_failures(monkeypatch, tmp_path: Path):
+    import hal0.memory.extraction_env as ee
+
+    monkeypatch.setattr(ee, "DROP_IN_PATH", tmp_path / "extraction-model.conf")
+
+    _calls, run = _seam_recorder(rc=1, stderr="sudo: a password is required")
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+
+    assert "install.sh" not in (apply_extraction_slot("utility", seam=seam)["error"] or "")
+
+
 def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Path):
     """Root / dev / CI keeps the pre-seam behaviour: a direct atomic write."""
     import hal0.memory.extraction_env as ee

--- a/tests/system/test_seam.py
+++ b/tests/system/test_seam.py
@@ -100,6 +100,62 @@ def test_write_quadlet_routes_through_seam_when_hal0_user(tmp_path: Path) -> Non
     assert calls == [["sudo", "-n", SEAM_BIN, "write-quadlet", "chat"]]
 
 
+# ── write_hindsight_dropin (#1641) ─────────────────────────────────────────
+
+
+def test_write_hindsight_dropin_direct_when_not_hal0_user(tmp_path: Path) -> None:
+    calls, run = _recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: False)
+    dropin = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+
+    seam.write_hindsight_dropin("[Service]\n", path=dropin)
+
+    assert dropin.read_text() == "[Service]\n"  # parent dir auto-created
+    assert calls == []
+    # Atomic write: the temp file is renamed, never left behind.
+    assert sorted(p.name for p in dropin.parent.iterdir()) == ["extraction-model.conf"]
+
+
+def test_write_hindsight_dropin_routes_through_seam_when_hal0_user(tmp_path: Path) -> None:
+    calls, run = _recorder()
+    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
+    dropin = tmp_path / "hindsight-api.service.d" / "extraction-model.conf"
+
+    seam.write_hindsight_dropin("[Service]\n", path=dropin)
+
+    assert not dropin.exists()  # never written directly — root owns the path
+    assert calls == [["sudo", "-n", SEAM_BIN, "write-hindsight-dropin"]]
+
+
+def test_write_hindsight_dropin_pipes_the_body_on_stdin() -> None:
+    """No id to validate: the body is the ENTIRE payload, so it must ride
+    stdin rather than argv (the write-gateway-dropin contract)."""
+    seen: dict[str, object] = {}
+
+    def _run(argv: object, **kwargs: object) -> MagicMock:
+        seen["argv"] = list(argv)  # type: ignore[arg-type]
+        seen.update(kwargs)
+        return _completed()
+
+    SystemCtlSeam(run=_run, is_hal0_user=lambda: True).write_hindsight_dropin("BODY")
+
+    assert seen["input"] == "BODY"
+    assert seen["check"] is True
+    # No path token anywhere in argv — the root side owns the literal.
+    assert not any("/" in a for a in seen["argv"][3:])  # type: ignore[index]
+
+
+def test_hindsight_dropin_verb_exists_in_the_wrapper() -> None:
+    """The sudoers grant is pinned to the BINARY, so the wrapper's case
+    statement is the allow-list. A Python-side verb the wrapper doesn't have
+    fails at runtime with `bad cmd` — pin the two spellings together."""
+    wrapper = Path(__file__).resolve().parents[2] / "installer" / "wrappers" / "hal0-systemctl"
+    text = wrapper.read_text()
+    assert "write-hindsight-dropin)" in text
+    assert str(seam_mod.HINDSIGHT_DROPIN_PATH.parent) in text
+    assert seam_mod.HINDSIGHT_DROPIN_PATH.name in text
+
+
 def test_write_quadlet_rejects_non_slot_name(tmp_path: Path) -> None:
     _, run = _recorder()
     seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)


### PR DESCRIPTION
Closes #1641 (P0).

## What was broken

`apply_extraction_slot()` wrote `/etc/systemd/system/hindsight-api.service.d/extraction-model.conf` with a raw `Path.mkdir()` + file write, then shelled out to a bare `systemctl restart hindsight-api`.

`hal0-api` runs as the unprivileged `hal0` service user (`User=hal0`), and that drop-in dir is `root:root`. So on **every standard install**:

- the write died with `EPERM` at the first `except OSError` → `written=False`
- the restart was therefore never even attempted
- the daemon kept extracting against the base unit's `HINDSIGHT_API_LLM_MODEL=hal0/utility`
- …while `hal0.toml` persisted the new slot unconditionally and `graph_status()` reports it from hal0's *own* config, so the dashboard showed an override that had never been applied

Same for `llm_timeout_s`. Verified live on CT105 in the issue.

## Approach

hal0 already has the exact mechanism for this: the `hal0-systemctl` sudo seam, whose `write-gateway-dropin` verb writes a fixed literal root-owned drop-in from this same unprivileged caller. This adds its sibling rather than inventing anything:

- **`installer/wrappers/hal0-systemctl`** — new `write-hindsight-dropin` verb. Literal fixed path (the caller supplies only the body on stdin, never a path), `install -d` the `.d` dir, atomic tmp+`mv`, `0644 root:root`. Byte-for-byte the `write-gateway-dropin` shape.
- **`SystemCtlSeam.write_hindsight_dropin()`** — the Python side, euid-gated exactly like `write_unit`/`write_quadlet`.
- **`extraction_env.apply_extraction_slot()`** — all three privileged steps now go through the seam: the write, `daemon-reload`, and the restart. The restart rides the wrapper's **existing** closed companion-unit map (`svc-restart hindsight`, added in #1590), which is why `SERVICE` is now spelled `hindsight-api.service` — the bare `hindsight-api` missed `COMPANION_SERVICE_UNITS` and fell through to a polkit-blocked unprivileged systemctl.

**No new privilege surface beyond one wrapper verb, and no sudoers change**: the grant is pinned to the wrapper *binary*, so the wrapper's `case` statement is the allow-list (`packaging/sudoers/hal0-systemctl` says so explicitly). Widening it stays a reviewable diff — this is that diff.

Least-privilege alternative considered and rejected: give the base unit an `EnvironmentFile=` under a hal0-owned path. It would need the base unit edited *and* correct ordering relative to the existing `Environment=` lines, and it fails the same way on a box whose unit hasn't been refreshed — while costing a divergence from the established drop-in pattern the docs, ADR-0023 and `doctor` all already describe.

Off the `hal0` service account (root, dev shells, CI, the unit tests) the seam is a passthrough and everything runs directly, exactly as before.

## Secondary (also in the issue)

The propagation is a blocking call that waits on a hindsight-api cold start, and it ran inline in an `async` route. It now hops `asyncio.to_thread`, so a ~60s restart no longer stalls the event loop. Each seam call is bounded at 60s.

Error reporting also improved: seam stderr (`sudo: a password is required`, `hal0-systemctl: bad cmd`) is now folded into `propagation.error` alongside the exit code, so a misconfigured box says *why*. The CLI (`hal0 memory graph enable`) and the dashboard panel both already render `propagation.error`.

## Verification

Red-first: `test_apply_routes_every_step_through_the_seam_as_the_hal0_user` fails on `main` (`TypeError: apply_extraction_slot() got an unexpected keyword argument 'seam'`), and with a naive port it fails on the argv assertion.

New tests:
- `tests/memory/test_extraction_env.py` — seam routing as the hal0 user (asserts the exact argv trio + that the drop-in is *never* written directly), seam-failure surfacing, and the unchanged direct path off the service account.
- `tests/system/test_seam.py` — `write_hindsight_dropin` direct/seam branches, body-on-stdin contract (no path token in argv), and a parity test pinning the Python verb name + literal path against the wrapper's `case` statement, so the two spellings can't drift.

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory tests/installer tests/system tests/api tests/cli tests/agents -q
3527 passed, 2 skipped, 1 xfailed in 915.96s
```

`ruff check src tests` clean, `ruff format --check` clean, `scripts/check_sunset.py` clean (193 <= 193). `mypy` on the touched files reports the same 4 pre-existing `no-any-return` errors in `routes/memory.py` as `main` — no new ones. `bash -n` clean on the wrapper.

## Deployment note

Wrappers under `${LIB_DIR}/bin/` are installed by `install.sh` only — `hal0 update` swaps the release tree and re-pips the venv but does not refresh them. So an in-place update from rc.1 will have new Python calling an old wrapper until `install.sh` is re-run. That's pre-existing for every wrapper verb (`stop-agent` #453, the `svc-*` family #1590), and the failure is now **loud** rather than silent: `hal0-systemctl: bad cmd: write-hindsight-dropin` lands in `propagation.error`. Flagging it rather than fixing wrapper-refresh-on-update here, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)