### PR TITLE
fix(updater): strip None before TOML-dumping migrated config

### DIFF
--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1128,7 +1128,16 @@ def _maybe_run_config_migrations(
         )
         return (source, source)
 
-    raw = cfg.model_dump(mode="python")
+    # ``exclude_none=True`` matches ``save_hal0_config``: None has no TOML
+    # representation and ``tomli_w`` raises TypeError on it (#1652).
+    # SecurityConfig.require_auth / trust_forwarded_for both default to
+    # None, so every config hit this before exclude_none was added here —
+    # masked only by version arithmetic (the only migration is v2, and the
+    # profile-catalog gate keeps source==target or ceiling==source, so this
+    # writer was never actually reached). Pydantic re-supplies the default
+    # on load, so dropping None on write is safe for any field whose
+    # default is None, same as save_hal0_config.
+    raw = cfg.model_dump(mode="python", exclude_none=True)
     new_raw, new_version = run_migrations(raw, target_version=target)
     write_toml_atomic(toml_path, new_raw)
     log.info(

--- a/tests/updater/test_migration_writer_none.py
+++ b/tests/updater/test_migration_writer_none.py
@@ -1,0 +1,66 @@
+"""#1652: ``_maybe_run_config_migrations`` dumps ``None`` into ``tomli_w``.
+
+``_maybe_run_config_migrations`` (``src/hal0/updater/updater.py``) does
+``cfg.model_dump(mode="python")`` -- unlike ``save_hal0_config``, which uses
+``exclude_none=True`` precisely because ``None`` has no TOML representation
+and ``tomli_w`` raises ``TypeError`` on it. ``SecurityConfig.require_auth``
+and ``trust_forwarded_for`` both default to ``None``, so any config that
+reaches this writer with a migration actually pending raises
+``TypeError: Object of type 'NoneType' is not TOML serializable``.
+
+Today this is masked by arithmetic: the only registered migration is v2,
+and the profile-catalog gate either stamps v2 first (source==target, a
+no-op) or caps the ceiling at 1 (target==source, also a no-op), so the
+real writer is never reached. The moment a v3 migration is registered --
+simulated here by monkeypatching the migrations registry -- this becomes
+a hard failure of every ``hal0 update``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config import migrations as migrations_module
+from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.schema import Hal0Config
+from hal0.updater import updater as updater_module
+
+
+@pytest.fixture
+def _hal0_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real, on-disk v1 hal0.toml, with paths.hal0_toml() redirected to it."""
+    toml_path = tmp_path / "hal0.toml"
+    save_hal0_config(Hal0Config(), toml_path)
+    monkeypatch.setattr(updater_module.paths, "hal0_toml", lambda: toml_path)
+    return toml_path
+
+
+@pytest.fixture
+def _with_v3_migration(monkeypatch: pytest.MonkeyPatch):
+    """Register a throwaway identity v3 migration so a real (non-v2) step
+    is actually walked -- reproducing the world after a v3 migration ships,
+    which today's v2-ceiling arithmetic otherwise masks."""
+
+    def _identity(data: dict) -> dict:
+        return dict(data)
+
+    monkeypatch.setitem(migrations_module.MIGRATIONS, 3, _identity)
+
+
+def test_a_pending_migration_does_not_typeerror_on_none_fields(
+    _hal0_toml: Path, _with_v3_migration
+) -> None:
+    """The regression itself: SecurityConfig's None-default fields must not
+    reach tomli_w unserialized once a real migration step runs."""
+    source, target = updater_module._maybe_run_config_migrations(min_data_version=3)
+    assert (source, target) == (1, 3)
+
+    # And the write actually landed and is re-loadable.
+    reloaded = load_hal0_config(_hal0_toml)
+    assert reloaded.meta.schema_version == 3
+    # The None-default security fields survived the round trip as None, not
+    # some stringified crash artifact.
+    assert reloaded.security.require_auth is None
+    assert reloaded.security.trust_forwarded_for is None


### PR DESCRIPTION
## Summary
- `_maybe_run_config_migrations` (`src/hal0/updater/updater.py`) dumped `cfg.model_dump(mode="python")` straight into `write_toml_atomic`, unlike `save_hal0_config`, which uses `exclude_none=True` because `None` has no TOML representation and `tomli_w` raises `TypeError` on it.
- `SecurityConfig.require_auth` and `trust_forwarded_for` both default to `None`, so any config reaching this writer with a real migration pending raised `TypeError: Object of type 'NoneType' is not TOML serializable` — a plain `TypeError`, not a `Hal0Error`, so it escapes `Updater.commit()`'s exception handler entirely (no staged-tree cleanup).
- Today this is masked by arithmetic, not design: the only registered migration is v2, and the profile-catalog gate keeps `source == target` or `ceiling == source`, so this writer is never actually reached. The moment a v3 migration lands, this becomes a hard failure of every `hal0 update`.

## Fix
Add `exclude_none=True` to match `save_hal0_config`. Pydantic re-supplies the default on load, so dropping `None` on write is safe for any field whose default is `None`.

## Test plan
- [x] Red-first: `test_a_pending_migration_does_not_typeerror_on_none_fields` simulates a v3 migration by monkeypatching the migrations registry (no real v3 exists yet) — fails with the exact `TypeError` from the issue on main, passes after the fix.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/config tests/updater tests/api/test_settings_apply.py -x -q` — 1028 passed, 9 skipped.

Closes #1652

🤖 Generated with [Claude Code](https://claude.com/claude-code)