### PR TITLE
fix(models): lazy_quant checks ROCmFPX resolver before generic regex

### DIFF
--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -237,16 +237,22 @@ def lazy_quant(dumped: dict[str, Any]) -> str | None:
     """Best-effort quant label for a serialised row missing ``quant``.
 
     Filename-token only (cheap enough for the list endpoint's 30s poll):
-    the on-disk basename first, then the HF variant filename. Rows whose
-    quant is only knowable from the GGUF header (hash-named blobs) get it
-    at registration via detect() instead.
+    the on-disk basename first, then the HF variant filename. Checks the
+    ROCmFPX family resolver before the generic quant regex — same order
+    as the eager path in ``detect()`` — so ROCmFPX repacks (hal0's own
+    brain model included) resolve to their family label (``ROCmFP8``)
+    instead of the raw preset token the generic regex would greedily
+    match (``Q8_0_ROCMFPX``). Rows whose quant is only knowable from the
+    GGUF header (hash-named blobs) get it at registration via detect()
+    instead.
     """
-    from hal0.registry.detect import quant_from_filename
+    from hal0.registry.detect import quant_from_filename, quant_from_rocmfpx_filename
 
     for key in ("path", "hf_filename"):
         raw = dumped.get(key)
         if isinstance(raw, str) and raw:
-            quant = quant_from_filename(Path(raw).name)
+            name = Path(raw).name
+            quant = quant_from_rocmfpx_filename(name) or quant_from_filename(name)
             if quant:
                 return quant
     return None

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -25,6 +25,7 @@ from fastapi.testclient import TestClient
 from hal0.api import create_app
 from hal0.api.routes import models as models_route
 from hal0.registry.model import Model, _derive_ns
+from hal0.services.models_service import lazy_quant
 
 # ── _derive_ns ─────────────────────────────────────────────────────────────
 
@@ -56,6 +57,28 @@ def test_derive_ns_empty_path_is_pulled() -> None:
     m = Model(id="ghost", path="/tmp/will-be-cleared")
     object.__setattr__(m, "path", "")
     assert _derive_ns(m) == "pulled"
+
+
+# ── lazy_quant — ROCmFPX family resolver (issue #1659) ──────────────────────
+
+
+def test_lazy_quant_resolves_rocmfpx_family_from_path() -> None:
+    """A pulled ROCmFPX repack must resolve to the family label, not the
+    raw preset token the generic quant regex would greedily match."""
+    dumped = {"path": "/var/lib/hal0/models/hal0-brain/hal0-brain-sft-Q8_0_ROCMFPX.gguf"}
+    assert lazy_quant(dumped) == "ROCmFP8"
+
+
+def test_lazy_quant_resolves_rocmfpx_family_from_hf_filename() -> None:
+    """Same resolver order applies to the HF variant filename fallback."""
+    dumped = {"hf_filename": "hal0-brain-sft-Q4_0_ROCMFP4_FAST.gguf"}
+    assert lazy_quant(dumped) == "ROCmFP4"
+
+
+def test_lazy_quant_still_resolves_generic_quant() -> None:
+    """Non-ROCmFPX filenames keep using the generic quant regex."""
+    dumped = {"path": "/var/lib/hal0/models/qwen3-coder/qwen3-coder-q4_k_m.gguf"}
+    assert lazy_quant(dumped) == "Q4_K_M"
 
 
 def test_derive_ns_blessed_root_with_only_id_segment_is_pulled() -> None:


### PR DESCRIPTION
## Summary
- `lazy_quant()` (`src/hal0/services/models_service.py`) now tries `quant_from_rocmfpx_filename()` before falling back to the generic `quant_from_filename()` regex — same resolver order `detect()` already uses on the eager path.
- Fixes the label mismatch where a pulled/auto-scanned ROCmFPX repack (quant backfilled via `lazy_quant`) showed the raw preset token (`Q8_0_ROCMFPX`) while the identical file registered via `add-from-path` (which goes through `detect()`) showed the family label (`ROCmFP8`).

## Why
`Model.quant` is almost never stored at write time (`registry/pull.py` and `registry/discover.register_candidate` both omit it), so nearly every pulled/scanned row falls through to `lazy_quant` on the `/api/models` hot path. hal0's own bundled brain model (`Hal0ai/hal0-brain-sft-ROCmFPX-GGUF`) is a ROCmFPX repack, so this was hitting the common path, not an edge case.

Closes #1659

## Verification
- Added `test_lazy_quant_resolves_rocmfpx_family_from_path`, `test_lazy_quant_resolves_rocmfpx_family_from_hf_filename`, `test_lazy_quant_still_resolves_generic_quant` to `tests/api/test_models_routes.py`.
- Confirmed red first: reverted the fix, new ROCmFPX tests failed (`Q8_0_ROCMFPX` != `ROCmFP8`, `Q4_0_ROCMFP4_FAST` != `ROCmFP4`), generic-quant test still passed.
- Restored fix: `tests/api/test_models_routes.py` + `tests/registry/test_detect.py` — 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)