### PR TITLE
fix(models): stop dropping FLM probe capabilities on dedupe

### DIFF
--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1831,6 +1831,17 @@ async def run_flm_pull(
             job.bytes_downloaded = size_bytes
         job.path = str(final_path)
 
+        # Read the freshly-reset probe's classification for this tag so the
+        # registry row records the model's real modality (embed/stt/chat)
+        # instead of assuming chat (#1647).
+        pulled_capabilities: list[str] | None = None
+        for entry in flm_served_models():
+            if entry["tag"] == tag:
+                caps = entry.get("capabilities")
+                if caps:
+                    pulled_capabilities = list(caps)
+                break
+
         # Register an FLM tag so the registry surfaces it for downstream
         # consumers (catalog, slot model resolution). hf_repo/filename
         # stay empty — FLM tags route through the toolbox, not HF directly.
@@ -1839,6 +1850,7 @@ async def run_flm_pull(
             tag=tag,
             path=str(final_path),
             size_bytes=size_bytes,
+            capabilities=pulled_capabilities,
         )
 
         job.state = "completed"
@@ -1930,6 +1942,7 @@ def _register_flm_pulled(
     tag: str,
     path: str,
     size_bytes: int,
+    capabilities: list[str] | None = None,
 ) -> None:
     """Upsert a registry entry for an FLM-pulled model.
 
@@ -1938,10 +1951,20 @@ def _register_flm_pulled(
     ``hf_filename`` stay empty. ``metadata.runtime = "flm"`` flags the
     entry so other code (slot pick, model resolution) can route it to
     the FLM provider without re-deriving from the id.
+
+    ``capabilities`` should come from the live ``flm_served_models()``
+    classification (embed/stt/chat) rather than being assumed — a hardcoded
+    ``["chat"]`` here mistyped every embed/STT tag pulled through FLM as
+    chat-only, and ``models_service.list_all()``'s dedupe skip had no way to
+    recover the real value afterward (#1647). Falls back to ``["chat"]``
+    only when the caller couldn't resolve a classification (e.g. the probe
+    was transiently empty right after the pull).
     """
+    caps = list(capabilities) if capabilities else ["chat"]
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
+        "capabilities": caps,
         "metadata": {"runtime": "flm"},
     }
     try:
@@ -1953,7 +1976,7 @@ def _register_flm_pulled(
                 name=tag,
                 path=path,
                 size_bytes=size_bytes,
-                capabilities=["chat"],
+                capabilities=caps,
                 backends=["npu"],
                 metadata={"runtime": "flm"},
             )

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -752,6 +752,10 @@ async def list_all(
     now = int(time.time())
     data: list[dict[str, Any]] = []
     seen: set[str] = set()
+    # Registry-sourced rows keyed by id, so the FLM-probe dedupe below can
+    # patch a surviving row in place instead of only being able to skip it
+    # (see the ``fm["tag"] in seen`` branch — #1647).
+    by_id: dict[str, dict[str, Any]] = {}
     filtered = 0
     # Last HF update-check snapshot (populated by /api/models/updates/check;
     # never fetched on this hot path). The flag is recomputed against the
@@ -799,6 +803,7 @@ async def list_all(
                 dumped["comfyui_category"] = _cat
         data.append(dumped)
         seen.add(entry.id)
+        by_id[entry.id] = dumped
     # "Don't surface invisible models": the composite ``hal0``/npu upstream
     # advertises FLM slot-default tags via /v1/models even when the weights are
     # not on disk, so they used to leak into the catalog as available-but-
@@ -893,6 +898,18 @@ async def list_all(
             # with backends=["npu"]) — emitting the probe row too listed every
             # pulled FLM model twice, once undeletable (#duplicate-FLM-rows).
             if fm["tag"] in seen:
+                # The registry row can be mistyped (#1647: the FLM pull path
+                # used to hardcode capabilities=["chat"] regardless of the
+                # model's real modality). The live probe knows better — merge
+                # its classification into the surviving row instead of
+                # silently discarding it, so an embed/stt model pulled via
+                # FLM doesn't masquerade as chat-only forever with no
+                # migration path.
+                row = by_id.get(fm["tag"])
+                probe_caps = list(fm.get("capabilities") or [])
+                if row is not None and probe_caps and row.get("capabilities") != probe_caps:
+                    row["capabilities"] = probe_caps
+                    row["type"] = dispatch_type(row.get("id", ""), capabilities=probe_caps)
                 continue
             mid = fm["tag"].replace(":", "-") + "-FLM"
             if mid in seen:

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -657,6 +657,39 @@ def test_list_models_dedups_flm_probe_against_registry_rows(
     assert rows["llama3.2-1b-FLM"]["backend"] == "flm"
 
 
+def test_list_models_dedupe_merges_flm_probe_capabilities_into_registry_row(
+    inspect_client: TestClient,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registry row born from the FLM-pull hardcoded-chat bug (#1647) must
+    have its capabilities/type corrected from the live probe on every list —
+    the dedupe skip must not silently discard the probe's correct embed/stt
+    classification just because the tag is already ``seen``."""
+    fpath = Path(tmp_hal0_home) / "embed-gemma-300m.gguf"
+    fpath.write_bytes(b"\x00" * 8)
+    inspect_client.post(
+        "/api/models",
+        json={"id": "embed-gemma:300m", "path": str(fpath), "capabilities": ["chat"]},
+    )
+    fake = [
+        {
+            "tag": "embed-gemma:300m",
+            "capabilities": ["embed"],
+            "installed": True,
+            "size_bytes": 1,
+            "footprint_gb": 0.0,
+            "family": "embed-gemma",
+        },
+    ]
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: fake)
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    row = rows["embed-gemma:300m"]
+    assert row["capabilities"] == ["embed"]
+    assert row["type"] == "embedding"
+
+
 # ── upstream provenance in /api/models ─────────────────────────────────────
 
 

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -22,6 +22,7 @@ import pytest
 from hal0.registry.pull import (
     _CHUNK_BYTES,
     _pull_root,
+    _register_flm_pulled,
     _sanitise_id,
     _tmp_dir,
     hf_download_url,
@@ -1524,3 +1525,65 @@ async def test_run_pull_expected_hash_captured_from_redirect_hop(
     assert job.state == "failed"
     assert job.error_code == "pull.checksum_mismatch"
     assert job.files[0].expected_sha256 == wrong
+
+
+# ── _register_flm_pulled: capability classification (#1647) ──────────────────
+
+
+def test_register_flm_pulled_uses_probe_capabilities_not_hardcoded_chat(
+    tmp_hal0_home: str,
+) -> None:
+    """A fresh FLM registration must record the caller-supplied (probe-
+    classified) capabilities — an embed/STT tag must not be mistyped as
+    chat-only just because the registry row is new."""
+    registry = ModelRegistry()
+    _register_flm_pulled(
+        registry,
+        tag="embed-gemma:300m",
+        path="/models/embed-gemma",
+        size_bytes=123,
+        capabilities=["embed"],
+    )
+    model = registry.get("embed-gemma:300m")
+    assert model.capabilities == ["embed"]
+    assert model.metadata.get("runtime") == "flm"
+
+
+def test_register_flm_pulled_falls_back_to_chat_when_probe_has_no_classification(
+    tmp_hal0_home: str,
+) -> None:
+    """When the probe couldn't classify the tag (transiently empty right
+    after a pull), keep the old chat-default rather than writing an empty
+    capabilities list."""
+    registry = ModelRegistry()
+    _register_flm_pulled(
+        registry,
+        tag="mystery:tag",
+        path="/models/mystery",
+        size_bytes=123,
+        capabilities=None,
+    )
+    assert registry.get("mystery:tag").capabilities == ["chat"]
+
+
+def test_register_flm_pulled_re_pull_corrects_stale_capabilities(
+    tmp_hal0_home: str,
+) -> None:
+    """A re-pull (e.g. after upgrading the FLM toolbox) must self-heal a row
+    that was mistyped by a prior buggy pull, not just leave it alone."""
+    registry = ModelRegistry()
+    _register_flm_pulled(
+        registry,
+        tag="embed-gemma:300m",
+        path="/models/embed-gemma",
+        size_bytes=100,
+        capabilities=["chat"],  # simulates the pre-#1647 hardcoded write
+    )
+    _register_flm_pulled(
+        registry,
+        tag="embed-gemma:300m",
+        path="/models/embed-gemma",
+        size_bytes=200,
+        capabilities=["embed"],
+    )
+    assert registry.get("embed-gemma:300m").capabilities == ["embed"]


### PR DESCRIPTION
## Summary
- `_register_flm_pulled` hardcoded `capabilities=["chat"]` on every FLM pull, mistyping embed/STT tags (e.g. `embed-gemma:300m`, `whisper-v3:turbo`) as chat-only.
- `list_all()`'s dedupe skip (`fm["tag"] in seen`) then discarded the live probe's correct classification every time, with no merge path — the model stayed mistyped forever with no migration.
- Fix: `run_flm_pull` now reads the freshly-reset probe's classification and passes it through to `_register_flm_pulled` (which also self-heals a stale row on re-pull); `list_all()`'s dedupe skip now merges the probe's `capabilities`/`type` into the surviving row instead of silently dropping them.

Closes #1647

## Test plan
- [x] Added a red-first regression test reproducing the dedupe capability drop (`tests/api/test_models_routes.py::test_list_models_dedupe_merges_flm_probe_capabilities_into_registry_row`)
- [x] Added unit tests for `_register_flm_pulled` covering fresh-register, no-classification fallback, and re-pull self-heal (`tests/registry/test_pull.py`)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/registry tests/api/test_models_routes.py tests/providers/test_flm.py tests/capabilities -q` → 545 passed
- [x] `ruff check` clean on touched files; `mypy` shows only pre-existing unrelated errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)