### PR TITLE
fix(ui): NPU STT/Embed pills reflect npu_modality_active, not raw config

### DIFF
--- a/ui/src/dash/__tests__/npu-modality.test.ts
+++ b/ui/src/dash/__tests__/npu-modality.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { npuModalityOn, npuRoleForSlot } from '../npu-modality.js'
+import { npuModalityOn, npuPillOn, npuRoleForSlot } from '../npu-modality.js'
 
 describe('npuModalityOn', () => {
   it('defaults chat ON, asr/embed OFF when the [npu] table is absent', () => {
@@ -31,6 +31,33 @@ describe('npuModalityOn', () => {
     expect(npuModalityOn({ asr: true }, 'asr')).toBe(true)
     expect(npuModalityOn({ asr: true }, 'embed')).toBe(false)
     expect(npuModalityOn({ asr: true }, 'chat')).toBe(true)
+  })
+})
+
+describe('npuPillOn (#1661)', () => {
+  it('asr/embed resolve off npu_modality_active, not the raw [npu] table', () => {
+    // Model-less anchor: the write already landed npu.asr=true on disk (or
+    // is still in flight), but the backend's npu_modality_active gate is
+    // False whenever the anchor has no model bound — the pill must agree.
+    const shadow = { type: 'transcription', npu_modality_active: false }
+    expect(npuPillOn(shadow, { asr: true }, 'asr')).toBe(false)
+  })
+
+  it('reflects npu_modality_active true once the anchor is actually activated', () => {
+    const shadow = { type: 'embedding', npu_modality_active: true }
+    expect(npuPillOn(shadow, { embed: true }, 'embed')).toBe(true)
+  })
+
+  it('treats a missing npu_modality_active field as off', () => {
+    const shadow = { type: 'transcription' }
+    expect(npuPillOn(shadow, { asr: true }, 'asr')).toBe(false)
+  })
+
+  it('chat still reads the raw [npu] table (the anchor carries no npu_modality_active field)', () => {
+    const anchor = { type: 'llm' }
+    expect(npuPillOn(anchor, { chat: true }, 'chat')).toBe(true)
+    expect(npuPillOn(anchor, { chat: false }, 'chat')).toBe(false)
+    expect(npuPillOn(anchor, undefined, 'chat')).toBe(true)
   })
 })
 

--- a/ui/src/dash/npu-modality.js
+++ b/ui/src/dash/npu-modality.js
@@ -21,3 +21,18 @@ export const npuRoleForSlot = (slot) =>
 // True for the trio shadow records (stt/embed) riding the anchor's process.
 export const isNpuShadowSlot = (slot) =>
   slot?.type === 'transcription' || slot?.type === 'embedding'
+
+// Resolved pill state — what the card should actually render as ON/OFF.
+//
+// #1637 guarded the CHAT toggle write against a model-less anchor ("model
+// presence IS the activation signal") but left the asr/embed pills reading
+// the raw [npu] table via npuModalityOn: a model-less anchor that already
+// has (or later gets) `npu.asr=true` on disk renders the STT/Embed pill ON
+// even though `hal0.slots.activation.npu_modality_active` — the one gate
+// for "does an NPU request of this type actually route" — is False whenever
+// `is_activated(anchor)` is False (#1661). The backend already lifts that
+// resolved answer onto each trio SHADOW's `npu_modality_active` field
+// (slot_view config_enrichment); the anchor's own chat entry has no such
+// field (only shadows get it), so chat keeps reading the raw table.
+export const npuPillOn = (slot, anchorNpu, role) =>
+  role === 'chat' ? npuModalityOn(anchorNpu, role) : !!slot?.npu_modality_active

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -27,7 +27,7 @@ import { slotIndicatorFromPhase } from './slot-status.js'
 // the shared helper folds them through backend_to_device → npu).
 import { devKind } from '@/lib/deviceMeta'
 import { PillToggle } from './primitives.jsx'
-import { npuModalityOn, npuRoleForSlot, isNpuShadowSlot } from './npu-modality.js'
+import { npuPillOn, npuRoleForSlot, isNpuShadowSlot } from './npu-modality.js'
 
 // ─── icons (16×16, hal0 thin-line family — ported from the design) ─────────
 const NI = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -332,7 +332,12 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, anchorNpu }) {
             cold restart, same contract as the drawer's applyNpu) — they used
             to merely open the edit drawer, which read as a broken toggle.
             Role comes from the slot TYPE (npuRoleForSlot), not the display
-            name — a non-canonically-named shadow must not flip chat. */}
+            name — a non-canonically-named shadow must not flip chat.
+            "on" reads through npuPillOn: asr/embed resolve off the anchor's
+            server-computed npu_modality_active (False whenever the anchor
+            has no model bound), not the raw [npu] table — else a model-less
+            anchor's stale/pending `npu.asr=true` renders the pill ON while
+            nothing actually routes (#1661). */}
         {(() => {
           const role = npuRoleForSlot(slot)
           const roleLabel = role === 'asr' ? 'STT' : role === 'embed' ? 'Embed' : 'Chat'
@@ -340,7 +345,7 @@ function ComboSlot({ slot, occ, owners, hue, handlers, act = 0, anchorNpu }) {
             <span style={{display: 'flex', alignItems: 'center', gap: 8, fontSize: 11}}>
               <span style={{color: 'var(--fg-2)'}}>{roleLabel}</span>
               <PillToggle
-                on={npuModalityOn(anchorNpu, role)}
+                on={npuPillOn(slot, anchorNpu, role)}
                 label={roleLabel}
                 disabled={handlers.modalityBusy}
                 onToggle={(next) => handlers.onModality(role, next)}
@@ -455,10 +460,14 @@ export function NpuOccupancyCard({ slots }) {
   // their own) and cold-restarts it, mirroring the drawer's applyNpu.
   const applyModality = (role, next) => {
     if (!anchorSlot || editMut.isPending || restartMut.isPending) return
-    // Enabling chat needs a bound model — model presence IS the activation
-    // signal, so a bare chat=true write would show the pill on while the
-    // slot stays unroutable. The model picker lives in the drawer.
-    if (role === 'chat' && next && !(anchorSlot.modelDefault || anchorSlot.model_id || anchorSlot.model)) {
+    // Every NPU modality (chat/asr/embed) rides the one anchor FLM process
+    // and needs a bound model to be routable — model presence IS the
+    // activation signal (hal0.slots.activation.is_activated /
+    // npu_modality_active), so a bare `<role>=true` write on a model-less
+    // anchor would cold-restart the container and leave the pill on while
+    // nothing routes. #1637 guarded chat; asr/embed share the identical
+    // dependency (#1661). The model picker lives in the drawer.
+    if (next && !(anchorSlot.modelDefault || anchorSlot.model_id || anchorSlot.model)) {
       toast('Pick a chat model first — opening the slot editor', 'info')
       window.location.hash = '#slots/' + anchorSlot.name
       return

--- a/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
+++ b/ui/tests/e2e/specs/npu-occupancy-v3.spec.ts
@@ -137,3 +137,103 @@ test.describe('NPU occupancy card', () => {
     await expect(card.locator('.gauge .sub')).toContainText('column probe unavailable')
   })
 })
+
+// ─── #1661: STT/Embed pills must reflect npu_modality_active, not the raw
+// [npu] table, on a model-less anchor ──────────────────────────────────────
+//
+// #1637 guarded the CHAT pill's write against a model-less anchor but left
+// the STT/Embed pills reading `npu.asr`/`npu.embed` off the raw config —
+// which happily renders ON right after a write lands (or on any pre-seeded
+// TOML), even though `hal0.slots.activation.npu_modality_active` — the one
+// gate the backend actually dispatches on — is False whenever the anchor
+// has no `[model].default`. The trio shadows carry the server-resolved
+// answer as `npu_modality_active`; this suite pins the card to read that,
+// not the raw table, and confirms a click on a model-less anchor never PUTs.
+async function seedTrio(page: any, slots: any[]) {
+  await page.addInitScript((slots: any[]) => {
+    let real: any
+    Object.defineProperty(window, 'HAL0_DATA', {
+      configurable: true,
+      get() {
+        return real
+      },
+      set(v) {
+        real = v
+        if (v && typeof v === 'object') v.slots = slots
+      },
+    })
+  }, slots)
+}
+
+const MODELLESS_ANCHOR = {
+  name: 'flm',
+  type: 'llm',
+  device: 'npu',
+  device_class: 'npu',
+  group: 'chat',
+  state: 'offline',
+  port: 8098,
+  // No model bound anywhere — the fresh-install, out-of-the-box state.
+  model: null,
+  model_id: null,
+  modelDefault: null,
+  // The write already landed on disk (or is still in flight) — this is
+  // exactly the stale-looking-ON config the raw-table read used to trust.
+  npu: { chat: true, asr: true, embed: false },
+  metrics: {},
+}
+
+const STT_SHADOW = {
+  name: 'flm-stt',
+  type: 'transcription',
+  device: 'npu',
+  device_class: 'npu',
+  group: 'chat',
+  state: 'offline',
+  port: 8098,
+  model: 'flm-stt-placeholder',
+  model_id: 'flm-stt-placeholder',
+  // Server-resolved: the anchor has no model, so nothing routes — even
+  // though the anchor's raw npu.asr above reads true.
+  npu_modality_active: false,
+  metrics: {},
+}
+
+const EMBED_SHADOW = {
+  ...STT_SHADOW,
+  name: 'flm-embed',
+  type: 'embedding',
+  npu_modality_active: false,
+}
+
+test.describe('NPU pills on a model-less anchor (#1661)', () => {
+  test('STT/Embed pills render OFF even though the raw [npu] table says on', async ({ page }) => {
+    await seedTrio(page, [MODELLESS_ANCHOR, STT_SHADOW, EMBED_SHADOW])
+    await page.goto('/#slots')
+
+    const card = page.locator('.npu-card')
+    await expect(card).toBeVisible()
+
+    const sttSwitch = card.locator('.cslot', { hasText: 'flm-stt' }).getByRole('switch', { name: 'STT' })
+    const embedSwitch = card.locator('.cslot', { hasText: 'flm-embed' }).getByRole('switch', { name: 'Embed' })
+    await expect(sttSwitch).toHaveAttribute('aria-checked', 'false')
+    await expect(embedSwitch).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('clicking the STT pill on a model-less anchor never PUTs — it routes to the drawer instead', async ({ page }) => {
+    const puts: any[] = []
+    await page.route('**/api/slots/flm/config', async (route) => {
+      if (route.request().method() === 'PUT') puts.push(route.request().postDataJSON())
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+    })
+    await seedTrio(page, [MODELLESS_ANCHOR, STT_SHADOW, EMBED_SHADOW])
+    await page.goto('/#slots')
+
+    const card = page.locator('.npu-card')
+    await card.locator('.cslot', { hasText: 'flm-stt' }).getByRole('switch', { name: 'STT' }).click()
+
+    // No write ever fires — the guard redirects to the drawer to pick a model.
+    await expect(page).toHaveURL(/#slots\/flm$/)
+    expect(puts.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- The occupancy card's STT/Embed pills read `npu.asr`/`npu.embed` straight off the anchor's raw `[npu]` table. On a model-less anchor (the fresh-install default with no `[model].default`), this renders the pills ON as soon as a write lands, even though `hal0.slots.activation.npu_modality_active` — the actual dispatch gate — is `False` whenever the anchor has no model bound.
- `#1637` already guarded the chat pill's write against exactly this case ("model presence IS the activation signal"). This extends the same write guard to asr/embed (they share the identical dependency) and switches the read side to the server-resolved `npu_modality_active` field the trio shadows already carry (`slot_view` config enrichment), instead of the raw table.
- Added a shared `npuPillOn(slot, anchorNpu, role)` helper in `npu-modality.js` so the resolution logic is one pure, tested function.

## Test plan
- [x] `npm run test:unit` — 84 passed, incl. 4 new `npuPillOn` cases in `npu-modality.test.ts`
- [x] `npx playwright test npu-occupancy-v3` — new `#1661` describe block: pills render OFF on a model-less anchor despite a stale `npu.asr=true`; clicking never PUTs and redirects to the drawer instead
- [x] Verified red-first: reverted the source fix, confirmed all 6 new assertions fail with the exact symptom described in the issue, then restored
- [x] `npm run build` — clean

Closes #1661

🤖 Generated with [Claude Code](https://claude.com/claude-code)