### PR TITLE
fix(memory): resume list_items cursor at raw offset, not visible count

### DIFF
--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -932,6 +932,17 @@ class HindsightProvider(MemoryProvider):
         * Over-fetch per bank so a heavily-filtered page can still fill, and
           only advertise a ``next_cursor`` when the bank actually reported more
           rows behind the offset we consumed.
+
+        Cursor math (#1667): the resume offset for a bank cut mid-page is
+        derived from the RAW row that produced the last item actually
+        returned, not from ``raw_offset - overflow_count``. The two only
+        agree when the ACL filter drops nothing from the tail of the last
+        fetched chunk — in unified-bank mode the shared bank interleaves
+        other agents' private docs and out-of-scope project docs, so a page
+        routinely filters unevenly, and the visible-count correction
+        under-rewinds and strands unreturned visible rows behind the next
+        cursor forever. Tracking each visible item's raw offset directly
+        keeps the walk exact regardless of what the ACL withheld.
         """
         banks = [namespace_to_bank(ns) for ns in self._allowed_namespaces(dataset, client_id)]
         start_bank, offset = _decode_cursor(cursor, banks)
@@ -952,7 +963,12 @@ class HindsightProvider(MemoryProvider):
         # the first one only — later banks start from the top.
         for bank in banks[banks.index(start_bank) :]:
             bank_offset = offset if bank == start_bank else 0
-            while len(items) < limit:
+            # Every item this bank contributes, paired with the raw offset
+            # immediately after the row that produced it — the exact point a
+            # resumed walk must start from to neither skip nor repeat a row.
+            bank_items: list[dict[str, Any]] = []
+            bank_offsets: list[int] = []
+            while len(items) + len(bank_items) < limit:
                 try:
                     # Over-fetch: the ACL filter below may discard most of a page.
                     fetch = max(limit * 2, 50)
@@ -964,27 +980,38 @@ class HindsightProvider(MemoryProvider):
                 raw = resp.get("items", []) or []
                 if not raw:
                     break
+                row_start = bank_offset
                 bank_offset += len(raw)
                 # Same read ACL as recall: in unified mode the shared bank holds
                 # every agent's private docs AND every project's docs, so list
                 # must not surface other agents' private items or out-of-scope
                 # project items. No-op in pre-unified multi-bank mode. Applied
                 # BEFORE the page cut so the page fills with visible rows.
-                page = self._filter_visible(
-                    [self._list_fact_to_item(fact, bank) for fact in raw], client_id, dataset
-                )
+                candidates = [self._list_fact_to_item(fact, bank) for fact in raw]
+                visible = self._filter_visible(candidates, client_id, dataset)
                 if private_only:
-                    page = [it for it in page if _VISIBILITY_PRIVATE in (it.get("tags") or [])]
-                items.extend(page)
+                    visible = [
+                        it for it in visible if _VISIBILITY_PRIVATE in (it.get("tags") or [])
+                    ]
+                visible_ids = {id(it) for it in visible}
+                for i, cand in enumerate(candidates):
+                    if id(cand) in visible_ids:
+                        bank_items.append(cand)
+                        bank_offsets.append(row_start + i + 1)
                 total = resp.get("total")
                 exhausted = len(raw) < fetch if not isinstance(total, int) else bank_offset >= total
                 if exhausted:
                     break
+            items.extend(bank_items)
             if len(items) >= limit:
-                # More may remain in THIS bank — resume here next call. The
-                # offset counts raw rows consumed, not visible ones, so the
-                # walk stays stable regardless of what the ACL filtered.
-                consumed = bank_offset - max(0, len(items) - limit)
+                # This bank overflowed the page. Resume at the raw offset
+                # right after the last item we're keeping FROM THIS BANK —
+                # not the bank's total raw offset — so any visible row that
+                # sat behind an ACL-withheld one in the same fetched chunk is
+                # still reachable on the next call.
+                overflow = len(items) - limit
+                keep_from_bank = len(bank_items) - overflow
+                consumed = bank_offsets[keep_from_bank - 1] if keep_from_bank > 0 else bank_offset
                 next_cursor = _encode_cursor(bank, consumed)
                 break
         return {"items": items[:limit], "next_cursor": next_cursor}

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -586,6 +586,86 @@ async def test_list_items_last_page_has_no_cursor():
     assert page["next_cursor"] is None
 
 
+# ── #1667: list_items cursor math must not skip ACL-withheld rows ───────────
+#
+# ``consumed = bank_offset - max(0, len(items) - limit)`` corrects the raw
+# offset by the number of *visible* items that overflowed the page. That only
+# equals the number of raw rows to roll back when the ACL filter dropped
+# nothing from the tail of the fetched chunk. In unified-bank mode the shared
+# bank interleaves other agents' private docs, so a real page filters
+# unevenly and the correction under-rewinds — the next cursor starts past raw
+# rows that still held unreturned visible items, and those items become
+# permanently unreachable through pagination.
+
+
+async def _seed_acl_mixed_bank(fake: "FakeHindsightClient", total: int, client_id: str) -> int:
+    """Retain ``total`` shared-bank docs; every raw index with ``i % 5 in (0, 1)``
+    belongs to another agent under ``visibility:private`` (invisible to
+    ``client_id``); the rest are ordinary visible shared docs. Returns the
+    number of visible docs seeded."""
+    visible = 0
+    for i in range(total):
+        if i % 5 in (0, 1):
+            await fake.retain(
+                bank_id="shared",
+                content=f"f{i}",
+                document_id=f"d{i}",
+                tags=["visibility:private", "agent:someone-else"],
+            )
+        else:
+            await fake.retain(bank_id="shared", content=f"f{i}", document_id=f"d{i}", tags=[])
+            visible += 1
+    return visible
+
+
+@pytest.mark.asyncio
+async def test_list_items_cursor_survives_acl_filtering_mid_page():
+    """Every visible item must be reachable across pages — none silently
+    dropped by a mis-rewound cursor — when the ACL filter thins a page
+    unevenly (#1667)."""
+    fake = FakeHindsightClient()
+    visible_total = await _seed_acl_mixed_bank(fake, total=100, client_id="hermes")
+    assert visible_total == 60  # sanity: matches the issue's repro shape
+
+    p = HindsightProvider(client=fake, client_id="hermes", unified_bank=True)
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(20):  # generous bound; the walk must terminate well inside it
+        page = await p.list_items(dataset="shared", limit=50, cursor=cursor, client_id="hermes")
+        seen.extend(item["text"] for item in page["items"])
+        cursor = page["next_cursor"]
+        if not cursor:
+            break
+
+    assert cursor is None, "the walk must terminate"
+    assert len(seen) == len(set(seen)), "no item returned twice"
+    expected = {f"f{i}" for i in range(100) if i % 5 in (2, 3, 4)}
+    assert set(seen) == expected, "every ACL-visible item must be reachable via pagination"
+
+
+@pytest.mark.asyncio
+async def test_list_items_negative_control_still_withholds_foreign_private_docs():
+    """The ACL itself must keep failing closed while the cursor math is
+    fixed — a foreign agent's private doc must never surface, on any page,
+    to a caller who cannot see it."""
+    fake = FakeHindsightClient()
+    await _seed_acl_mixed_bank(fake, total=20, client_id="hermes")
+    p = HindsightProvider(client=fake, client_id="hermes", unified_bank=True)
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(20):
+        page = await p.list_items(dataset="shared", limit=5, cursor=cursor, client_id="hermes")
+        seen.extend(item["text"] for item in page["items"])
+        cursor = page["next_cursor"]
+        if not cursor:
+            break
+
+    withheld = {f"f{i}" for i in range(20) if i % 5 in (0, 1)}
+    assert not (withheld & set(seen)), "another agent's private docs must never be returned"
+
+
 # ── recall modernization: native scores, entities/chunks/source_facts ───────
 
 

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -598,7 +598,7 @@ async def test_list_items_last_page_has_no_cursor():
 # permanently unreachable through pagination.
 
 
-async def _seed_acl_mixed_bank(fake: "FakeHindsightClient", total: int, client_id: str) -> int:
+async def _seed_acl_mixed_bank(fake: FakeHindsightClient, total: int, client_id: str) -> int:
     """Retain ``total`` shared-bank docs; every raw index with ``i % 5 in (0, 1)``
     belongs to another agent under ``visibility:private`` (invisible to
     ``client_id``); the rest are ordinary visible shared docs. Returns the


### PR DESCRIPTION
## Summary
- `list_items`'s cursor-rewind math subtracted the number of *visible* overflow items from the *raw* bank offset (`consumed = bank_offset - max(0, len(items) - limit)`), which only equals the correct raw rewind when the ACL filter drops nothing from the tail of the last fetched chunk.
- In unified-bank mode the shared bank interleaves other agents' `visibility:private` docs and out-of-scope `project:<id>` docs, so a real page filters unevenly — the old correction under-rewound and the next cursor started past raw rows that still held unreturned visible items, making them permanently unreachable via pagination.
- Fix: track each visible item's raw offset directly as it's collected (the raw row index immediately after the row that produced it), and resume the next page at the raw offset right after the last item actually kept from that bank.

## Test plan
- [x] New repro test (`test_list_items_cursor_survives_acl_filtering_mid_page`): 100 raw rows, 40 ACL-withheld unevenly, walks the cursor to completion and asserts every one of the 60 visible items is returned exactly once. Fails on `main` (loses `f84`, `f87`, `f88`, `f89`), passes after the fix.
- [x] Negative control (`test_list_items_negative_control_still_withholds_foreign_private_docs`): asserts another agent's private docs never surface on any page across the same paginated walk — the fail-closed ACL behavior is unchanged by the cursor-math fix.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory tests/security -x -q` → 364 passed.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q -k "memory or hindsight"` → 751 passed.

Closes #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)