### PR TITLE
fix(slots): tombstone the vacated name when renaming a static seed slot

### DIFF
--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -994,6 +994,12 @@ class SlotManager:
         also moves those two artefacts and re-keys the in-memory caches. To
         avoid orphaning a live ``hal0-slot@<oldname>`` unit, rename is refused
         unless the slot is OFFLINE.
+
+        If ``slot_name`` is a static seed (:data:`hal0.install.static_seeds.
+        STATIC_SEED_SLOTS`), the vacated name is tombstoned so the boot-time
+        seeding pass does not resurrect a duplicate under the old label
+        (#1651); renaming into a tombstoned ``new_name`` clears it, mirroring
+        :meth:`create`.
         """
         if self._identity is None:
             raise SlotConfigError(
@@ -1088,6 +1094,26 @@ class SlotManager:
                 self._name_to_key.pop(canonical, None)
                 self._bind_key(new_name, key)
                 self._cfg_cache.pop(key, None)
+                # 5. Seed-tombstone bookkeeping (#1651). Renaming a static seed
+                #    vacates `canonical` — without a tombstone the boot-time
+                #    seeding pass (hal0.install.static_seeds.seed_static_slots)
+                #    sees that name as neither known (identity now carries
+                #    `new_name`) nor on disk (id-keyed slots carry no
+                #    <name>.toml) and re-materialises a fresh seed under the
+                #    OLD name, duplicating the slot. Mirror delete()'s
+                #    tombstone write. Renaming INTO a tombstoned name must
+                #    also clear it — mirrors create() — or the stale
+                #    tombstone blocks that name from ever being seeded again
+                #    even though a live slot now legitimately owns it.
+                from hal0.install.static_seeds import (
+                    STATIC_SEED_SLOTS,
+                    add_seed_tombstone,
+                    clear_seed_tombstone,
+                )
+
+                if canonical in STATIC_SEED_SLOTS:
+                    add_seed_tombstone(canonical)
+                clear_seed_tombstone(new_name)
         return await self.status(new_name)
 
     def _ensure_known(self, name: str) -> None:

--- a/tests/slots/test_id_keying.py
+++ b/tests/slots/test_id_keying.py
@@ -111,6 +111,46 @@ async def test_rename_rejects_name_collision(hal0_home: Path) -> None:
         await sm.rename("chat", "agent")
 
 
+async def test_renaming_a_static_seed_tombstones_the_old_name(hal0_home: Path) -> None:
+    # #1651: rename() relabelled the identity row and moved/rewrote the TOML
+    # but wrote no tombstone for the vacated name. The boot-time seeding pass
+    # (hal0.install.static_seeds.seed_static_slots) then sees `brain` as
+    # neither known (identity now carries `steward`) nor on disk (id-keyed
+    # slots carry no <name>.toml) and re-materialises a fresh seed under the
+    # OLD name — the operator ends up with both `steward` and a duplicate
+    # `brain` after a plain restart. Mirror delete()'s tombstone write.
+    sm = _manager(hal0_home)
+    await _create(sm, "brain", port=8085)
+    await sm.rename("brain", "steward")
+
+    from hal0.install.static_seeds import read_seed_tombstones, seed_static_slots
+
+    assert "brain" in read_seed_tombstones()
+    # The seeding pass must honour that tombstone, not resurrect a duplicate.
+    seeded = seed_static_slots(existing_names=sm.identity_names())
+    assert "brain" not in seeded
+    assert sm._identity.get_by_name("brain") is None
+    assert sm._identity.get_by_name("steward") is not None
+
+
+async def test_renaming_into_a_tombstoned_seed_name_clears_it(hal0_home: Path) -> None:
+    # Mirror hazard called out in #1651: renaming INTO a previously-deleted
+    # seed name must clear that name's tombstone the same way create() does,
+    # or the stale tombstone silently blocks that name from ever being
+    # seeded again even though a live slot now legitimately owns it.
+    sm = _manager(hal0_home)
+    await _create(sm, "rerank", port=8083)
+    await sm.delete("rerank", force=True)
+
+    from hal0.install.static_seeds import read_seed_tombstones
+
+    assert "rerank" in read_seed_tombstones()
+
+    await _create(sm, "utility", port=8091)
+    await sm.rename("utility", "rerank")
+    assert "rerank" not in read_seed_tombstones()
+
+
 async def test_slot_id_to_name_roundtrip(hal0_home: Path) -> None:
     sm = _manager(hal0_home)
     snap = await _create(sm, "chat", port=8081)


### PR DESCRIPTION
## Summary
- `SlotManager.rename()` (`src/hal0/slots/manager.py:988`) relabelled the identity row and moved/rewrote the TOML but wrote no seed tombstone for the vacated name, and never consulted/cleared one for the new name.
- The startup seeding pass skips a name only when it's in `identity_names()`, tombstoned, or `<name>.toml` exists. After renaming a `STATIC_SEED_SLOTS` member, all three were false for the old name, so `seed_static_slots` copied the curated seed back on the next boot — duplicating the slot.
- Fix: on rename, tombstone the vacated name if it's a static seed (mirrors `delete()`), and clear any tombstone on the new name (mirrors `create()`) so renaming *into* a previously-deleted seed name doesn't leave a stale tombstone blocking it.

## Test plan
- [x] Red-first: added `test_renaming_a_static_seed_tombstones_the_old_name` and `test_renaming_into_a_tombstoned_seed_name_clears_it` to `tests/slots/test_id_keying.py` (the suite that wires a real `SlotIdentityStore`/`PortAuthority` through `rename()`) — both failed against pre-fix `manager.py`, confirmed the repro.
- [x] Implemented the fix, tests now pass.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slots tests/install tests/api/test_startup_slot_seed.py -q` — 744 + 325 passed (full slots suite + install/seed suites), no regressions.

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)