### PR TITLE
fix(updater): resolve HAL0_RELEASES_URL for the root stage seam

### DIFF
--- a/installer/wrappers/hal0-update
+++ b/installer/wrappers/hal0-update
@@ -78,6 +78,61 @@ validate_dir_name() {
   [[ "${d}" =~ ^hal0-[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$ ]] || die "bad release directory name: ${d}"
 }
 
+# ── operator releases-URL override (#1690) ──────────────────────────────────
+#
+# hal0-api (unprivileged) resolves its manifest URL via
+# hal0.updater.updater.releases_url(), which honours HAL0_RELEASES_URL from
+# its systemd EnvironmentFile= (/etc/hal0/api.env) — the documented interim
+# mechanism while releases.hal0.dev does not exist (see
+# scripts/release-prototype/RELEASE_PIPELINE_NOTES.md). `sudo` resets the
+# environment for this grant (no env_keep in packaging/sudoers/hal0-update),
+# so root never inherited that value: `stage` silently re-resolved the
+# production default instead, so a custom-URL box passed
+# /api/updates/check and then always failed stage against a host
+# (releases.hal0.dev) that does not exist yet.
+#
+# Root does NOT accept the URL via sudo argv or the caller's environment —
+# both are an injection surface into a root process. Instead it reads the
+# SAME root-owned trusted config the daemon reads, itself, as root. No
+# `source`/`eval` of the file (it also carries provider tokens and
+# HAL0_ADMIN_KEY/HAL0_CLIENT_KEY): exactly the ``HAL0_RELEASES_URL=`` line is
+# grep+cut out, and it must look like an http(s)/file URL before it is
+# exported into the Python re-entry's environment. A present-but-malformed
+# value dies loudly here rather than silently falling back to the default —
+# that silent fallback is the exact bug being fixed.
+resolve_releases_url() {
+  local etc_root="/etc/hal0"
+  # HAL0_HOME sandboxes the whole config root for dev installs + integration
+  # tests (src/hal0/config/paths.py: etc()/api_env()) — mirrored here so a
+  # sandboxed run resolves the exact api.env the Python side resolves,
+  # never a real box's /etc/hal0/api.env.
+  if [[ -n "${HAL0_HOME:-}" ]]; then
+    etc_root="${HAL0_HOME}/etc/hal0"
+  fi
+  local env_file="${etc_root}/api.env"
+  [[ -r "${env_file}" ]] || return 0
+
+  local raw
+  # `|| true`: grep exits 1 on no match (the common case — most boxes never
+  # set this override), and with `pipefail` that would otherwise trip
+  # `set -e` and kill the whole seam with an opaque rc=1 before `stage` ever
+  # runs. No match is not an error here, just "no override configured".
+  raw="$(grep -E '^HAL0_RELEASES_URL=' -- "${env_file}" 2>/dev/null | tail -n1 | cut -d'=' -f2-)" || true
+  raw="${raw%$'\r'}"
+  # api.env is a plain KEY=VALUE file; strip one layer of matching quotes if
+  # the operator added them (systemd's EnvironmentFile= parser does the same).
+  case "${raw}" in
+    \"*\") raw="${raw#\"}"; raw="${raw%\"}" ;;
+    \'*\') raw="${raw#\'}"; raw="${raw%\'}" ;;
+  esac
+
+  [[ -n "${raw}" ]] || return 0
+  case "${raw}" in
+    https://*|file://*) export HAL0_RELEASES_URL="${raw}" ;;
+    *) die "bad HAL0_RELEASES_URL in ${env_file} (must be https:// or file://): ${raw}" ;;
+  esac
+}
+
 cmd="${1:-help}"; shift || true
 
 case "${cmd}" in
@@ -88,6 +143,7 @@ case "${cmd}" in
   stage)                      # stage <channel> [version]
     channel="${1:-}"; validate_channel "${channel}"
     version="${2:-}"
+    resolve_releases_url      # #1690 — same-origin HAL0_RELEASES_URL as the daemon
     if [[ -n "${version}" ]]; then
       validate_version "${version}"
       exec "${PY}" -I -m hal0.updater.privileged stage "${channel}" "${version}"

--- a/tests/installer/test_hal0_update_wrapper.py
+++ b/tests/installer/test_hal0_update_wrapper.py
@@ -23,6 +23,11 @@ WRAPPER = Path(__file__).resolve().parents[2] / "installer" / "wrappers" / "hal0
 _STUB_PY = """#!/bin/bash
 # Records argv so the test can assert exactly what the wrapper forwarded.
 printf '%s\\n' "$@" > "${HAL0_TEST_ARGV_SINK}"
+# Records the resolved HAL0_RELEASES_URL (if any) so #1690 tests can assert
+# on it without needing a real network fetch.
+if [[ -n "${HAL0_TEST_ENV_SINK:-}" ]]; then
+  printf '%s' "${HAL0_RELEASES_URL:-}" > "${HAL0_TEST_ENV_SINK}"
+fi
 """
 
 
@@ -40,17 +45,41 @@ def installed(tmp_path: Path) -> Path:
     return lib
 
 
-def _run(installed: Path, *args: str) -> tuple[int, list[str], str]:
+def _run(
+    installed: Path, *args: str, env: dict[str, str] | None = None
+) -> tuple[int, list[str], str]:
     sink = installed / "argv.txt"
+    env_sink = installed / "env.txt"
+    base_env = {
+        "PATH": "/usr/bin:/bin",
+        "HAL0_TEST_ARGV_SINK": str(sink),
+        "HAL0_TEST_ENV_SINK": str(env_sink),
+    }
+    if env:
+        base_env.update(env)
     proc = subprocess.run(
         [str(installed / "bin" / "hal0-update"), *args],
         capture_output=True,
         text=True,
-        env={"PATH": "/usr/bin:/bin", "HAL0_TEST_ARGV_SINK": str(sink)},
+        env=base_env,
         check=False,
     )
     forwarded = sink.read_text().splitlines() if sink.exists() else []
     return proc.returncode, forwarded, proc.stderr
+
+
+def _released_url(installed: Path) -> str | None:
+    """The HAL0_RELEASES_URL the stub interpreter observed, or None if unset."""
+    env_sink = installed / "env.txt"
+    return env_sink.read_text() if env_sink.exists() and env_sink.stat().st_size else None
+
+
+def _write_api_env(hal0_home: Path, body: str) -> None:
+    """Lay out $HAL0_HOME/etc/hal0/api.env exactly where paths.py's api_env() and
+    this wrapper's resolve_releases_url() both look for it."""
+    etc = hal0_home / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "api.env").write_text(body)
 
 
 # ── accepted verbs ─────────────────────────────────────────────────────────────
@@ -103,6 +132,160 @@ def test_help_lists_exactly_the_granted_verbs(installed: Path) -> None:
     assert proc.returncode == 0
     for verb in ("check", "stage", "activate", "discard"):
         assert verb in proc.stdout
+
+
+# ── operator releases-URL override (#1690) ──────────────────────────────────
+
+
+def test_stage_reads_releases_url_from_hal0_home_api_env(
+    installed: Path, tmp_path: Path
+) -> None:
+    """The documented interim mechanism (custom HAL0_RELEASES_URL while
+    releases.hal0.dev does not exist) must reach root, or every custom-URL box
+    passes /api/updates/check and then always fails stage (#1690)."""
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, "HAL0_RELEASES_URL=https://mirror.example/preview.json\n")
+
+    rc, argv, _ = _run(installed, "stage", "preview", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert argv == ["-I", "-m", "hal0.updater.privileged", "stage", "preview"]
+    assert _released_url(installed) == "https://mirror.example/preview.json"
+
+
+def test_stage_accepts_a_file_url(installed: Path, tmp_path: Path) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, "HAL0_RELEASES_URL=file:///srv/hal0-releases/stable.json\n")
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "file:///srv/hal0-releases/stable.json"
+
+
+def test_stage_strips_matching_quotes_around_releases_url(
+    installed: Path, tmp_path: Path
+) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, 'HAL0_RELEASES_URL="https://mirror.example/stable.json"\n')
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "https://mirror.example/stable.json"
+
+
+def test_stage_uses_the_last_releases_url_line_when_duplicated(
+    installed: Path, tmp_path: Path
+) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(
+        hal0_home,
+        "HAL0_RELEASES_URL=https://stale.example/stable.json\n"
+        "HAL0_RELEASES_URL=https://current.example/stable.json\n",
+    )
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "https://current.example/stable.json"
+
+
+def test_stage_ignores_a_missing_api_env(installed: Path, tmp_path: Path) -> None:
+    """No override configured -> unset, falls through to the production default
+    (releases.hal0.dev) exactly like before this fix."""
+    hal0_home = tmp_path / "sandbox"  # created, but no etc/hal0/api.env inside it
+    hal0_home.mkdir()
+
+    rc, argv, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert argv == ["-I", "-m", "hal0.updater.privileged", "stage", "stable"]
+    assert _released_url(installed) is None
+
+
+def test_stage_ignores_an_api_env_with_no_releases_url_line(
+    installed: Path, tmp_path: Path
+) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, "HF_TOKEN=super-secret\nHAL0_PORT=8000\n")
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) is None
+
+
+def test_stage_never_forwards_unrelated_api_env_secrets(
+    installed: Path, tmp_path: Path
+) -> None:
+    """Only HAL0_RELEASES_URL is parsed out — never a `source`/`eval` of the
+    whole file, which also carries provider tokens and HAL0_ADMIN_KEY /
+    HAL0_CLIENT_KEY."""
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(
+        hal0_home,
+        "HF_TOKEN=super-secret\n"
+        "HAL0_ADMIN_KEY=do-not-leak\n"
+        "HAL0_RELEASES_URL=https://mirror.example/stable.json\n",
+    )
+
+    proc = subprocess.run(
+        [str(installed / "bin" / "hal0-update"), "stage", "stable"],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HAL0_TEST_ARGV_SINK": str(installed / "argv.txt"),
+            "HAL0_TEST_ENV_SINK": str(installed / "env.txt"),
+            "HAL0_HOME": str(hal0_home),
+        },
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "super-secret" not in proc.stdout
+    assert "super-secret" not in proc.stderr
+    assert "do-not-leak" not in proc.stdout
+    assert "do-not-leak" not in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "javascript:alert(1)",
+        "ftp://mirror.example/stable.json",
+        "not-a-url",
+        "http://mirror.example/stable.json",  # https:// or file:// only, per #1690
+    ],
+)
+def test_stage_refuses_a_releases_url_with_a_disallowed_scheme(
+    installed: Path, tmp_path: Path, bad_url: str
+) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, f"HAL0_RELEASES_URL={bad_url}\n")
+
+    rc, argv, stderr = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 64
+    assert argv == [], "malformed operator URL must never reach the interpreter"
+    assert "hal0-update:" in stderr
+
+
+def test_check_activate_discard_do_not_resolve_releases_url(
+    installed: Path, tmp_path: Path
+) -> None:
+    """Only `stage` fetches a manifest; keep the blast radius of #1690 narrow."""
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, "HAL0_RELEASES_URL=https://mirror.example/stable.json\n")
+
+    rc, _, _ = _run(installed, "check", env={"HAL0_HOME": str(hal0_home)})
+    assert rc == 0
+    assert _released_url(installed) is None
+
+    rc, _, _ = _run(installed, "activate", "hal0-1.0.0", env={"HAL0_HOME": str(hal0_home)})
+    assert rc == 0
+    assert _released_url(installed) is None
 
 
 # ── rejected input (never reaches the interpreter) ─────────────────────────────

--- a/tests/installer/test_hal0_update_wrapper.py
+++ b/tests/installer/test_hal0_update_wrapper.py
@@ -137,9 +137,7 @@ def test_help_lists_exactly_the_granted_verbs(installed: Path) -> None:
 # ── operator releases-URL override (#1690) ──────────────────────────────────
 
 
-def test_stage_reads_releases_url_from_hal0_home_api_env(
-    installed: Path, tmp_path: Path
-) -> None:
+def test_stage_reads_releases_url_from_hal0_home_api_env(installed: Path, tmp_path: Path) -> None:
     """The documented interim mechanism (custom HAL0_RELEASES_URL while
     releases.hal0.dev does not exist) must reach root, or every custom-URL box
     passes /api/updates/check and then always fails stage (#1690)."""
@@ -163,9 +161,7 @@ def test_stage_accepts_a_file_url(installed: Path, tmp_path: Path) -> None:
     assert _released_url(installed) == "file:///srv/hal0-releases/stable.json"
 
 
-def test_stage_strips_matching_quotes_around_releases_url(
-    installed: Path, tmp_path: Path
-) -> None:
+def test_stage_strips_matching_quotes_around_releases_url(installed: Path, tmp_path: Path) -> None:
     hal0_home = tmp_path / "sandbox"
     _write_api_env(hal0_home, 'HAL0_RELEASES_URL="https://mirror.example/stable.json"\n')
 
@@ -216,9 +212,7 @@ def test_stage_ignores_an_api_env_with_no_releases_url_line(
     assert _released_url(installed) is None
 
 
-def test_stage_never_forwards_unrelated_api_env_secrets(
-    installed: Path, tmp_path: Path
-) -> None:
+def test_stage_never_forwards_unrelated_api_env_secrets(installed: Path, tmp_path: Path) -> None:
     """Only HAL0_RELEASES_URL is parsed out — never a `source`/`eval` of the
     whole file, which also carries provider tokens and HAL0_ADMIN_KEY /
     HAL0_CLIENT_KEY."""


### PR DESCRIPTION
## Summary

Closes #1690.

- `installer/wrappers/hal0-update`'s `stage` verb runs as root via `sudo`, which resets the environment for this grant (no `env_keep` in `packaging/sudoers/hal0-update`). So it always re-resolved the production default (`https://releases.hal0.dev/...`, which does not exist yet) instead of the operator's `HAL0_RELEASES_URL` — the documented interim mechanism while `releases.hal0.dev` isn't stood up. Every custom-URL box passed `/api/updates/check` (unprivileged daemon, which does honor the env var) and then always failed `stage` (root, which didn't). Reproduced live on CT150 during the rc.1 -> rc.2 update test.
- Fix: the wrapper's new `resolve_releases_url()` reads the *same* root-owned `/etc/hal0/api.env` the daemon reads, itself, as root — not via sudo argv, not via the caller's environment (both are an injection surface into a root process). It never `source`s/`eval`s the whole file (which also carries provider tokens and `HAL0_ADMIN_KEY`/`HAL0_CLIENT_KEY`): only the single `HAL0_RELEASES_URL=` line is grep+cut out, quote-stripped, and validated to look like an `https://` or `file://` URL before being exported for the Python re-entry. A present-but-malformed value dies loudly instead of silently falling back — that silent fallback is the exact bug being fixed. `HAL0_HOME`-aware, mirroring `src/hal0/config/paths.py`, so sandboxed/test runs resolve the same `api.env` the Python side does.
- `hal0.updater.updater.releases_url()` already reads `HAL0_RELEASES_URL` from `os.environ` for both the unprivileged and privileged code paths, so no Python change was needed there — verified directly (`releases_url()` returns the override URL once the wrapper exports it).

**Privileged-surface change — operator review required.** This touches the root-side seam for self-update (`installer/wrappers/hal0-update`, granted via `packaging/sudoers/hal0-update`). Automerge is deliberately **not** enabled on this PR.

## Design constraint honored

Per the issue: root does not accept the manifest URL via sudo argv or caller env (injection surface). It re-reads root-owned trusted config itself, defensively (no whole-file `source`/`eval`, single-key grep+cut, scheme allow-list before export).

## Test plan

- [x] Red-first: added failing tests to `tests/installer/test_hal0_update_wrapper.py` pinning the new behavior, watched them fail against the unmodified wrapper.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/installer/test_hal0_update_wrapper.py -q` — 39 passed.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/installer tests/install -q` — 716 passed, 1 pre-existing unrelated skip (shellcheck not on PATH for that one test).
- [x] `shellcheck installer/wrappers/hal0-update` — clean.
- [x] Manually verified `hal0.updater.updater.releases_url()` honors the env var identically once set (no Python change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)