### PR TITLE
fix(ui): key the MOE filter chip on a real signal, not architecture

### DIFF
--- a/ui/src/dash/__tests__/model-filters.test.ts
+++ b/ui/src/dash/__tests__/model-filters.test.ts
@@ -1,0 +1,78 @@
+// isMtpModel / isMoeModel — pins the #1649 fix: the MOE filter chip must key
+// on the same signal the backend uses (hardware.recommend._resolve_primary_ctx
+// / profiles.generate._looks_moe), not on Model.architecture (never persisted
+// on a registry row) or the retired "moe" curated tag.
+//
+// Named `.test.ts` deliberately: vitest.config.ts's `include` is
+// ['src/**/*.test.ts', 'tests/e2e/*.test.ts'], so a `.test.mjs` file added
+// alongside model-sort.test.mjs would silently never execute under
+// `npm run test:unit`.
+import { describe, expect, it } from 'vitest'
+
+// model-sort.js is untyped JS; tsconfig has allowJs with checkJs:false, so
+// the import resolves and the exports come through as `any`.
+import { isMoeModel, isMtpModel } from '../model-sort.js'
+
+describe('isMtpModel', () => {
+  it('is true when defaults.mtp is explicitly true', () => {
+    expect(isMtpModel({ id: 'm', defaults: { mtp: true } })).toBe(true)
+  })
+
+  it('is true when the legacy mtp tag is present', () => {
+    expect(isMtpModel({ id: 'm', tags: ['chat', 'mtp'] })).toBe(true)
+  })
+
+  it('is false with neither signal', () => {
+    expect(isMtpModel({ id: 'm', tags: ['chat'] })).toBe(false)
+    expect(isMtpModel({ id: 'm' })).toBe(false)
+  })
+})
+
+describe('isMoeModel', () => {
+  it('is FALSE for a fresh install with no architecture, no tag, no id marker (the #1649 repro shape before the fix)', () => {
+    expect(isMoeModel({ id: 'plain-chat-model', tags: ['chat'] })).toBe(false)
+  })
+
+  it('is true for a known MoE architecture id, once Model.architecture is ever backfilled', () => {
+    expect(isMoeModel({ id: 'whatever', architecture: 'qwen3next' })).toBe(true)
+    expect(isMoeModel({ id: 'whatever', architecture: 'Mixtral' })).toBe(true)
+  })
+
+  it('a known dense architecture id is NOT flagged moe even with an "a3b"-shaped id', () => {
+    // architecture, when present, is authoritative and short-circuits the
+    // id/tag fallback — mirrors the backend's precedence exactly.
+    expect(isMoeModel({ id: 'some-a3b-named-thing', architecture: 'llama' })).toBe(false)
+  })
+
+  it('is true for the curated qwen3.6-35b-a3b MTP repro model (id substring + mtp tag, no architecture)', () => {
+    expect(
+      isMoeModel({ id: 'qwen3-6-35b-a3b-halostrix-dyn-mtp-v7', tags: ['chat', 'mtp', 'rocmfp4'] }),
+    ).toBe(true)
+  })
+
+  it('is true for an A3B MoE coder with no mtp tag at all (id substring alone is enough)', () => {
+    expect(isMoeModel({ id: 'Qwen3-Coder-30B-A3B-Instruct-GGUF', tags: ['chat', 'coder'] })).toBe(true)
+  })
+
+  it('is true when the legacy "moe" or "a3b" tag is present even with a plain id', () => {
+    expect(isMoeModel({ id: 'plain-id', tags: ['moe'] })).toBe(true)
+    expect(isMoeModel({ id: 'plain-id', tags: ['a3b'] })).toBe(true)
+  })
+
+  it('is false for a plain dense model with none of the signals', () => {
+    expect(isMoeModel({ id: 'gemma-4-12b-it-ud-q4-k-xl', tags: ['chat'] })).toBe(false)
+    expect(isMoeModel({})).toBe(false)
+  })
+})
+
+describe('DENSE bucket (neither mtp nor moe)', () => {
+  it('an A3B MoE model with no mtp tag is excluded from dense (was previously mis-bucketed as dense)', () => {
+    const m = { id: 'Qwen3-Coder-30B-A3B-Instruct-GGUF', tags: ['chat', 'coder'] }
+    expect(!isMtpModel(m) && !isMoeModel(m)).toBe(false)
+  })
+
+  it('a plain dense model with no signals stays in dense', () => {
+    const m = { id: 'gemma-4-12b-it-ud-q4-k-xl', tags: ['chat'] }
+    expect(!isMtpModel(m) && !isMoeModel(m)).toBe(true)
+  })
+})

--- a/ui/src/dash/model-sort.js
+++ b/ui/src/dash/model-sort.js
@@ -15,6 +15,48 @@ export const MODEL_SORT_FIELDS = [
 ];
 
 /**
+ * True when a model carries an explicit MTP opt-in (`defaults.mtp === true`)
+ * or the legacy registry `mtp` tag. Mirrors
+ * `hal0.model_meta.model_is_mtp_eligible`'s tag fallback — see
+ * `lib/normalizeApiModel.isMtpEligibleModel` for the full tri-state version
+ * (this simplified OR is what the Models-page MTP filter chip has always
+ * used; keep the two in sync).
+ *
+ * @param {any} m
+ * @returns {boolean}
+ */
+export function isMtpModel(m) {
+  return m?.defaults?.mtp === true || (m?.tags || []).some((t) => String(t).toLowerCase() === "mtp");
+}
+
+//: Architecture ids the backend already knows are MoE — mirrors
+//: `hal0.hardware.recommend._MOE_ARCHITECTURES`. Keep in sync.
+const MOE_ARCHITECTURES = new Set(["qwen3next", "mixtral", "deepseek-moe"]);
+
+/**
+ * True when a model is MoE, per the SAME precedence the backend uses
+ * (`hal0.hardware.recommend._resolve_primary_ctx` /
+ * `hal0.profiles.generate._looks_moe`): a backfilled `Model.architecture`
+ * wins when present; otherwise fall back to the `moe`/`a3b`/`mtp` tag-or-id
+ * heuristic every row relies on today.
+ *
+ * `Model.architecture` is not persisted on any registry row yet (#1649) —
+ * no writer sets it — so in practice this always takes the fallback path.
+ * It's still checked first so a future architecture backfill picks it up
+ * for free, same as the backend.
+ *
+ * @param {any} m
+ * @returns {boolean}
+ */
+export function isMoeModel(m) {
+  const arch = String(m?.architecture || "").trim().toLowerCase();
+  if (arch) return MOE_ARCHITECTURES.has(arch);
+  const tags = (m?.tags || []).map((t) => String(t).trim().toLowerCase());
+  if (tags.includes("moe") || tags.includes("a3b") || tags.includes("mtp")) return true;
+  return /a3b/i.test(String(m?.id || ""));
+}
+
+/**
  * Parse a human param-count ("27B", "350M", "1.5B", "74K") — or a raw
  * number — into a comparable count. Returns null when unparseable.
  *

--- a/ui/src/dash/models.jsx
+++ b/ui/src/dash/models.jsx
@@ -13,7 +13,7 @@ import { ENDPOINTS } from '@/api/endpoints'
 import { useSlots, useSlotSwap } from '@/api/hooks/useSlots'
 import { useMetaEnums } from '@/api/hooks/useMeta'
 import { isUpstreamModel } from '@/lib/normalizeApiModel'
-import { MODEL_SORT_FIELDS, sortModels, fmtAdded } from '@/dash/model-sort.js'
+import { MODEL_SORT_FIELDS, sortModels, fmtAdded, isMtpModel, isMoeModel } from '@/dash/model-sort.js'
 import { RunnerImagesView, RunnerImagesSyncButton } from '@/dash/runner-images.jsx'
 
 const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
@@ -21,14 +21,10 @@ const { useState: useStateM, useMemo: useMemoM, useEffect: useEffectM } = React;
 // ── Simplified filter chips ────────────────────────────────────────────
 // Each chip is a multi-select toggle with OR semantics (empty = show all).
 // "DENSE" means neither MTP nor MOE; checked by absence of those tags.
-// mtp/moe read typed facts first (defaults.mtp, architecture) and fall back
-// to legacy tags for rows an older release stamped — the curated type-tag
-// editor is retired and the boot migration strips behaviour tags.
-const isMtpModel = m =>
-  m?.defaults?.mtp === true || (m.tags || []).some(t => String(t).toLowerCase() === "mtp");
-const isMoeModel = m =>
-  String(m.architecture || "").toLowerCase().includes("moe") ||
-  (m.tags || []).some(t => String(t).toLowerCase() === "moe");
+// isMtpModel/isMoeModel live in model-sort.js (dependency-free, unit
+// tested) — they mirror the backend's own MTP/MoE detection so the chips
+// key on the same signal the server acts on, not on `Model.architecture`
+// (never persisted on a registry row — #1649) or the retired `moe` tag.
 const FILTER_CHIPS = [
   { id: "mtp",    label: "MTP",   check: isMtpModel },
   { id: "moe",    label: "MOE",   check: isMoeModel },


### PR DESCRIPTION
## Summary
- #1632 rewrote the Models page MOE/DENSE filter chips to key on `Model.architecture` with a legacy-tag fallback. Neither branch is live: `Model.architecture` is never persisted on any registry row (no writer — `services/models_service.add_from_path`, `registry/discover.register_candidate`, and the pull path all omit it), and the `"moe"` curated tag was removed in §7.1d. Net effect: the MOE chip matched 0 rows, and DENSE (`!mtp && !moe`) bucketed every MoE model as dense.
- Moved `isMtpModel`/`isMoeModel` out of `models.jsx` into the dependency-free, already-unit-tested `model-sort.js`, and rewrote `isMoeModel` to key on the same signal the backend already acts on: `hal0.hardware.recommend._resolve_primary_ctx` / `hal0.profiles.generate._looks_moe` — a backfilled `architecture` against the known-MoE set (`qwen3next`, `mixtral`, `deepseek-moe`) wins when present, else the `moe`/`a3b`/`mtp` tag-or-id-substring heuristic every curated row relies on today (e.g. `Qwen3-Coder-30B-A3B-Instruct-GGUF`, `qwen3-6-35b-a3b-halostrix-dyn-mtp-v7`).

## Test plan
- [x] Added `ui/src/dash/__tests__/model-filters.test.ts` (vitest, wired into `npm run test:unit`). Red-first: confirmed all 12 cases fail against the pre-fix module (`isMoeModel`/`isMtpModel` not even exported yet), then pass after the fix — including the two repro models from the issue and a DENSE-bucket regression case.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test:unit` — 10 files / 98 tests passing
- [x] `node src/dash/__tests__/model-sort.test.mjs` (legacy dependency-free regression script) — still passes

Closes #1649