### PR TITLE
fix(memory): dedupe both sides of the project-scope width check

### DIFF
--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -629,10 +629,18 @@ class HindsightProvider(MemoryProvider):
         An empty request scopes to nothing at all, so neither is True
         (#1451: ``[]`` used to read back as ``[shared]`` here too, which is
         what let the unified-mode delete gate wave shared docs through).
+
+        Both sides of the comparison must be deduplicated (#1668): a caller
+        repeating the same project entry (e.g. a client-side retry building
+        ``["project:apollo", "project:apollo"]``) must not make ``projects``
+        (a set) look smaller than the raw request count and flip
+        ``wants_unscoped`` True — that silently admitted unscoped shared docs
+        into a call that only ever named one project.
         """
         reqs = HindsightProvider._requested_list(requested)
         projects = {ds for ds in reqs if isinstance(ds, str) and ds.startswith(_PROJECT)}
-        return projects, len(projects) < len([r for r in reqs if r])
+        non_empty = {r for r in reqs if r}
+        return projects, len(projects) < len(non_empty)
 
     @staticmethod
     def _is_in_scope(item: dict[str, Any], projects: set[str], wants_unscoped: bool) -> bool:

--- a/tests/memory/test_unified_project_scope.py
+++ b/tests/memory/test_unified_project_scope.py
@@ -130,6 +130,71 @@ async def test_multi_project_read_unions_the_requested_scopes() -> None:
     assert _texts(out) == {"apollo secret", "zeus secret"}
 
 
+# ── #1668: a duplicate project entry must not widen the scope ────────────────
+#
+# ``_requested_scope`` computed ``wants_unscoped`` by comparing the size of a
+# *set* of project namespaces against the size of the *list* of non-empty
+# requests. A repeated project entry shrinks the set relative to the list even
+# though every entry named the same project, flipping ``wants_unscoped`` True
+# and admitting unscoped shared docs into a call that only ever asked for one
+# project.
+
+
+@pytest.mark.asyncio
+async def test_duplicate_project_entry_does_not_widen_recall_to_unscoped() -> None:
+    p = _unified()
+    await p.add("apollo secret", dataset="project:apollo", client_id="hermes")
+    await p.add("everyone knows", dataset="shared", client_id="hermes")
+
+    out = await p.recall(
+        "x", dataset=["project:apollo", "project:apollo"], client_id="hermes"
+    )
+    assert _texts(out) == {"apollo secret"}, "duplicate entry must not leak unscoped shared docs"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_project_entry_does_not_widen_list_to_unscoped() -> None:
+    p = _unified()
+    await p.add("apollo secret", dataset="project:apollo", client_id="hermes")
+    await p.add("everyone knows", dataset="shared", client_id="hermes")
+
+    page = await p.list_items(dataset=["project:apollo", "project:apollo"], client_id="hermes")
+    assert _texts(page["items"]) == {"apollo secret"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_project_entry_does_not_widen_delete_to_unscoped() -> None:
+    """Negative control: a delete scoped (with a duplicate) to one project
+    must not be able to reach an unscoped shared doc (fail-closed, #1451
+    lineage) — mirrors test_delete_scoped_to_a_project_cannot_reach_another."""
+    p = _unified()
+    await p.add("apollo secret", dataset="project:apollo", client_id="hermes")
+    await p.add("everyone knows", dataset="shared", client_id="hermes")
+    shared_id = p._client.retained[1]["document_id"]
+
+    res = await p.delete(
+        [shared_id], client_id="hermes", dataset=["project:apollo", "project:apollo"]
+    )
+    assert res["deleted"] == 0
+
+    remaining = await p.recall("knows", dataset="shared", client_id="hermes")
+    assert _texts(remaining) == {"everyone knows"}
+
+
+@pytest.mark.asyncio
+async def test_distinct_multi_project_entries_do_not_widen_to_unscoped() -> None:
+    """A caller who legitimately named several distinct projects (no
+    duplicates, no non-project entry) must still see ONLY those projects —
+    covers the case the naive set-size fix could get backwards."""
+    p = _unified()
+    await p.add("apollo secret", dataset="project:apollo", client_id="hermes")
+    await p.add("zeus secret", dataset="project:zeus", client_id="hermes")
+    await p.add("everyone knows", dataset="shared", client_id="hermes")
+
+    out = await p.recall("x", dataset=["project:apollo", "project:zeus"], client_id="hermes")
+    assert _texts(out) == {"apollo secret", "zeus secret"}
+
+
 # ── Read path: list ──────────────────────────────────────────────────────────
 
 

--- a/tests/memory/test_unified_project_scope.py
+++ b/tests/memory/test_unified_project_scope.py
@@ -146,9 +146,7 @@ async def test_duplicate_project_entry_does_not_widen_recall_to_unscoped() -> No
     await p.add("apollo secret", dataset="project:apollo", client_id="hermes")
     await p.add("everyone knows", dataset="shared", client_id="hermes")
 
-    out = await p.recall(
-        "x", dataset=["project:apollo", "project:apollo"], client_id="hermes"
-    )
+    out = await p.recall("x", dataset=["project:apollo", "project:apollo"], client_id="hermes")
     assert _texts(out) == {"apollo secret"}, "duplicate entry must not leak unscoped shared docs"
 
 


### PR DESCRIPTION
## Summary
- `_requested_scope` (`hindsight_provider.py:635`) computed `wants_unscoped` as `len(projects) < len([r for r in reqs if r])` — comparing a **set** of project namespaces against a **list** of requests that can carry duplicates.
- A repeated project entry (e.g. `dataset=["project:apollo", "project:apollo"]`) shrinks the set relative to the list even though every entry names the same project, flipping `wants_unscoped` True and admitting unscoped shared docs into a read/delete that only ever asked for one project.
- Fix: dedupe both sides before comparing (`len(projects) < len({r for r in reqs if r})`). Affects `search`/`recall`/`list` and, via `_deletable_ids`, `delete` — a delete scoped to one project with a duplicate could otherwise reach an unscoped shared doc.

## Test plan
- [x] `test_duplicate_project_entry_does_not_widen_recall_to_unscoped` — fails on `main` (leaks `"everyone knows"`), passes after the fix.
- [x] `test_duplicate_project_entry_does_not_widen_list_to_unscoped` — same shape for `list_items`.
- [x] `test_duplicate_project_entry_does_not_widen_delete_to_unscoped` — negative control: a duplicate-carrying project-scoped delete must not reach an unscoped shared doc (fail-closed, #1451 lineage); asserts `deleted == 0` and the shared doc survives.
- [x] `test_distinct_multi_project_entries_do_not_widen_to_unscoped` — guards against a naive "just dedupe the list" fix that could flip the comparison the other way for legitimate multi-project reads with no duplicates.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory tests/security -x -q` → 366 passed.

Closes #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)