### PR TITLE
fix(release): honour digest-pinned refs in update-toolbox-digests.sh

### DIFF
--- a/scripts/update-toolbox-digests.sh
+++ b/scripts/update-toolbox-digests.sh
@@ -11,17 +11,29 @@
 # informational `version` field from pyproject.toml so it can't rot.
 #
 # For each entry under `toolbox_images`, the script:
-#   1. parses `ghcr.io/hal0ai/<image>:<tag>` out of the `.tag` field,
-#   2. resolves the published content digest from ghcr.io anonymously
-#      (registry v2 manifest API; falls back to `docker buildx imagetools
-#      inspect` if the curl/token flow is unavailable),
+#   1. parses the `.tag` field (usually `ghcr.io/hal0ai/<image>:<tag>`, but a
+#      few entries — e.g. comfyui — pin a non-ghcr, digest-referenced image
+#      like `docker.io/<owner>/<repo>@sha256:...`),
+#   2. resolves the published content digest:
+#        - a digest-pinned ref (`@sha256:...`) is authoritative BY
+#          CONSTRUCTION — the digest is read straight out of the ref, no
+#          registry round-trip;
+#        - otherwise resolves from ghcr.io anonymously (registry v2 manifest
+#          API), falling back to `docker buildx imagetools inspect` (works
+#          against any registry, ghcr.io included) if the curl/token flow is
+#          unavailable,
 #   3. patches manifest.json in place via python3 so JSON formatting stays
 #      stable.
 #
-# A missing/unpublished image leaves its digest as null and emits a warning —
-# matching the runtime contract (null digest => pull-by-tag + warn). The
-# script never hard-fails on a single unpublished image; it exits non-zero
-# only on a usage / environment error.
+# A ghcr.io image that fails resolution leaves its digest null and emits a
+# warning — matching the runtime contract (null digest => pull-by-tag +
+# warn); that image really is unpublished/unreachable. A NON-ghcr image that
+# fails resolution (no authoritative path here beyond the two above) instead
+# KEEPS whatever digest is already recorded and warns — a transient/offline
+# lookup must never regress a previously-valid pin to null, which used to
+# fail release.yml's null-digest gate on the very manifest this script
+# prepares (#1676). The script never hard-fails on a single unresolved
+# image; it exits non-zero only on a usage / environment error.
 #
 # Usage:
 #   scripts/update-toolbox-digests.sh [path/to/manifest.json]
@@ -67,6 +79,18 @@ PY
 resolve_digest() {
     local image_ref="$1"
     local registry repo_ref repo reference token digest
+
+    # A digest-pinned ref ("registry/repo@sha256:...") is authoritative by
+    # construction — the digest IS the reference, no registry round-trip
+    # needed (and none is possible for a non-ghcr registry anyway). This
+    # also fixes the comfyui entry (a docker.io@sha256 pin): the split below
+    # only understands a ":tag" suffix, so an "@sha256:..." ref used to mis-
+    # parse into a bogus repo/reference pair, fail both the ghcr curl path
+    # and the registry mismatch, and null out a perfectly valid pin (#1676).
+    if [[ "${image_ref}" == *@sha256:* ]]; then
+        printf 'sha256:%s\n' "${image_ref##*@sha256:}"
+        return 0
+    fi
 
     # Split "ghcr.io/owner/name:tag" into registry / repo / reference.
     registry="${image_ref%%/*}"
@@ -118,6 +142,21 @@ resolve_digest() {
     fi
 
     return 1
+}
+
+# Read the currently-recorded toolbox_images.<name>.digest, or "" if unset.
+current_digest() {
+    local name="$1"
+    python3 - "${MANIFEST}" "${name}" <<'PY'
+import json
+import sys
+
+path, name = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    manifest = json.load(fh)
+entry = (manifest.get("toolbox_images") or {}).get(name) or {}
+print(entry.get("digest") or "")
+PY
 }
 
 # Patch a single toolbox_images.<name>.digest in place via python3.
@@ -180,8 +219,22 @@ while IFS=$'\t' read -r name tag; do
         echo "    -> ${digest}"
         updated=$((updated + 1))
     else
-        echo "warn: ${name}: ${tag} is unpublished or unreachable — leaving digest null (runtime pulls by tag)" >&2
-        patch_digest "${name}" ""
+        # Never regress a valid pin to null. A ghcr.io image that fails
+        # resolution really is unpublished/unreachable — null is correct,
+        # the runtime falls back to pull-by-tag. A non-ghcr registry (no
+        # authoritative resolution path here beyond the digest-pinned-ref
+        # shortcut and the docker buildx fallback above) that fails is far
+        # more likely a transient/offline lookup than an actual unpublish —
+        # keep whatever digest is already recorded and warn instead (#1676).
+        registry="${tag%%/*}"
+        existing="$(current_digest "${name}")"
+        if [[ "${registry}" != "ghcr.io" && -n "${existing}" ]]; then
+            echo "warn: ${name}: ${tag} could not be resolved on ${registry} — keeping existing digest ${existing} (never regress a valid pin to null)" >&2
+            patch_digest "${name}" "${existing}"
+        else
+            echo "warn: ${name}: ${tag} is unpublished or unreachable — leaving digest null (runtime pulls by tag)" >&2
+            patch_digest "${name}" ""
+        fi
         warned=$((warned + 1))
     fi
 done < <(list_images)

--- a/tests/scripts/test_update_toolbox_digests.py
+++ b/tests/scripts/test_update_toolbox_digests.py
@@ -160,7 +160,5 @@ def test_missing_tag_still_nulls(tmp_path: Path, offline_path: str) -> None:
 
 
 def test_bash_syntax_check() -> None:
-    proc = subprocess.run(
-        ["bash", "-n", str(_SCRIPT)], capture_output=True, text=True, check=False
-    )
+    proc = subprocess.run(["bash", "-n", str(_SCRIPT)], capture_output=True, text=True, check=False)
     assert proc.returncode == 0, proc.stderr

--- a/tests/scripts/test_update_toolbox_digests.py
+++ b/tests/scripts/test_update_toolbox_digests.py
@@ -1,0 +1,166 @@
+"""scripts/update-toolbox-digests.sh must never null a valid digest pin (#1676).
+
+The script only resolved digests via the ghcr.io registry v2 curl path. The
+comfyui entry pins a docker.io, digest-referenced tag
+(``docker.io/kyuz0/amd-strix-halo-comfyui@sha256:...``): the ghcr-only path
+mis-parsed it, reported it "unpublished", and overwrote a valid digest with
+null — which then failed ``release.yml``'s null-digest gate on the very
+manifest this script prepares.
+
+These tests drive the REAL script against a throwaway copy of the manifest,
+under a hermetic PATH where ``curl`` and ``docker`` are stubbed to always
+fail (simulating an offline / token-less run) so the tests are deterministic
+regardless of the sandbox's real network access. A digest-pinned ref must
+resolve without ever touching either stub; a non-ghcr tag-only ref that
+cannot be resolved must keep its previously-recorded digest instead of going
+null; a ghcr ref that cannot be resolved keeps the documented null contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "update-toolbox-digests.sh"
+_MANIFEST = _REPO_ROOT / "manifest.json"
+
+_COMFYUI_TAG = (
+    "docker.io/kyuz0/amd-strix-halo-comfyui"
+    "@sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+)
+_COMFYUI_DIGEST = "sha256:0066678ae9043f69a1c8c7699e70626ceffd35c1a8ca03227a05640ad0241ed2"
+
+
+def _write_always_failing(path: Path) -> None:
+    path.write_text("#!/usr/bin/env bash\nexit 22\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def offline_path(tmp_path: Path) -> str:
+    """PATH with curl/docker stubbed to always fail — hermetic, no real network."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_always_failing(bin_dir / "curl")
+    _write_always_failing(bin_dir / "docker")
+    return f"{bin_dir}:{os.environ['PATH']}"
+
+
+def _run(manifest: Path, path: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PATH"] = path
+    return subprocess.run(
+        ["bash", str(_SCRIPT), str(manifest)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+
+def _load(manifest: Path) -> dict:
+    return json.loads(manifest.read_text(encoding="utf-8"))
+
+
+# ── the regression, against the real manifest ──────────────────────────────
+
+
+def test_comfyui_digest_survives_a_full_offline_run(tmp_path: Path, offline_path: str) -> None:
+    """THE bug: a copy of the real manifest, network fully stubbed off."""
+    manifest = tmp_path / "manifest.json"
+    shutil.copy2(_MANIFEST, manifest)
+    before = _load(manifest)["toolbox_images"]["comfyui"]["digest"]
+    assert before == _COMFYUI_DIGEST  # sanity: fixture assumption still holds
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
+    after = _load(manifest)["toolbox_images"]["comfyui"]
+    assert after["digest"] == _COMFYUI_DIGEST
+    assert after["tag"] == _COMFYUI_TAG
+
+
+# ── isolated behaviour, minimal fixture manifests ──────────────────────────
+
+
+def _fixture_manifest(tmp_path: Path, toolbox_images: dict) -> Path:
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"version": "0.0.0", "toolbox_images": toolbox_images}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_digest_pinned_non_ghcr_ref_resolves_without_touching_curl_or_docker(
+    tmp_path: Path, offline_path: str
+) -> None:
+    manifest = _fixture_manifest(
+        tmp_path, {"comfyui": {"tag": _COMFYUI_TAG, "digest": "sha256:" + "0" * 64}}
+    )
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["comfyui"]["digest"] == _COMFYUI_DIGEST
+    assert "unpublished" not in proc.stderr
+    assert "1 digest(s) updated, 0 left null" in proc.stdout
+
+
+def test_unresolvable_non_ghcr_tag_keeps_its_existing_digest(
+    tmp_path: Path, offline_path: str
+) -> None:
+    # No digest pin in the ref itself, registry isn't ghcr.io, and both
+    # resolution paths are stubbed offline — must NOT regress to null.
+    existing = "sha256:" + "a" * 64
+    manifest = _fixture_manifest(
+        tmp_path, {"widget": {"tag": "docker.io/example/widget:v1", "digest": existing}}
+    )
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["widget"]["digest"] == existing
+    assert "keeping existing digest" in proc.stderr
+
+
+def test_unresolvable_ghcr_tag_still_nulls_per_the_documented_contract(
+    tmp_path: Path, offline_path: str
+) -> None:
+    # Regression guard the other way: ghcr.io failures must still null out
+    # (the runtime's documented pull-by-tag + warn contract), not silently
+    # keep a possibly-stale digest.
+    existing = "sha256:" + "b" * 64
+    manifest = _fixture_manifest(
+        tmp_path, {"vulkan": {"tag": "ghcr.io/hal0ai/hal0-toolbox-vulkan:v1", "digest": existing}}
+    )
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["vulkan"]["digest"] is None
+    assert "unpublished or unreachable" in proc.stderr
+
+
+def test_missing_tag_still_nulls(tmp_path: Path, offline_path: str) -> None:
+    manifest = _fixture_manifest(tmp_path, {"empty": {"tag": "", "digest": "sha256:" + "c" * 64}})
+
+    proc = _run(manifest, offline_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert _load(manifest)["toolbox_images"]["empty"]["digest"] is None
+
+
+def test_bash_syntax_check() -> None:
+    proc = subprocess.run(
+        ["bash", "-n", str(_SCRIPT)], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Summary
- `scripts/update-toolbox-digests.sh` only resolved digests via the ghcr.io registry v2 curl path. The `comfyui` entry pins a `docker.io`, digest-referenced tag (`docker.io/kyuz0/amd-strix-halo-comfyui@sha256:...`); the ghcr-only split logic mis-parsed the `@sha256:` ref, reported it unpublished, and overwrote a valid digest with `null` — which then fails `release.yml`'s null-digest gate on the very manifest this script is supposed to prepare.
- A digest-pinned ref (`@sha256:...`) is now read directly out of the ref — authoritative by construction, no registry round-trip.
- For a non-ghcr ref *without* a digest pin that still fails resolution (both the ghcr curl path and the `docker buildx imagetools inspect` fallback), the script now keeps the previously-recorded digest and warns, instead of nulling it. A ghcr.io failure still nulls, matching the documented pull-by-tag runtime contract.

## Test plan
- [x] New `tests/scripts/test_update_toolbox_digests.py` drives the real script under a hermetic PATH (`curl`/`docker` stubbed to always fail, so it's deterministic with no real network): comfyui's digest survives a full offline run against a copy of the actual `manifest.json`; a digest-pinned ref resolves without touching either stub; an unresolvable non-ghcr tag keeps its existing digest; an unresolvable ghcr tag still nulls (regression guard the other direction); a missing tag still nulls; `bash -n` syntax check.
- [x] `uvx --from shellcheck-py shellcheck scripts/update-toolbox-digests.sh` — clean.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/scripts -q` — 67 passed.

Closes #1676

🤖 Generated with [Claude Code](https://claude.com/claude-code)