### PR TITLE
fix(config): persist activity.max_rows = null (unlimited) through save/load

### DIFF
--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -2783,7 +2783,45 @@ class ActivityConfig(BaseModel):
     enabled: bool = True
     retention_days: int = Field(default=30, ge=1)
     # None disables the row cap (retention_days still applies).
+    #
+    # PERSISTENCE (#1665): ``save_hal0_config``/``_maybe_run_config_migrations``
+    # both dump with ``exclude_none=True`` — None has no TOML representation
+    # and ``tomli_w`` raises TypeError on it. Dumping None for "unlimited"
+    # therefore drops the key outright, and the next load restores this
+    # 50_000 default: the documented unlimited mode was unreachable through
+    # any persisted config. ``0`` is already unreachable as a genuine row cap
+    # (below the ``ge=100`` floor), so it is reserved as the on-disk spelling
+    # of "unlimited" — see ``_normalise_max_rows`` (load) and
+    # ``_serialize_max_rows`` (save) below. Same fix shape as
+    # ``BrainChatConfig.tool_model`` / ``BRAIN_TOOL_MODEL_DISABLED`` (#1644):
+    # give the unrepresentable sentinel a real word/value on disk instead of
+    # relying on ``exclude_none`` to round-trip it.
     max_rows: int | None = Field(default=50_000, ge=100)
+
+    @field_validator("max_rows", mode="before")
+    @classmethod
+    def _normalise_max_rows(cls, v: Any) -> Any:
+        """``0`` on disk (or via the API) means "unlimited" — see above."""
+        if v == 0:
+            return None
+        return v
+
+    @model_serializer(mode="wrap")
+    def _serialize_max_rows(self, handler: Any) -> dict[str, Any]:
+        """Persist ``None`` ("unlimited") as ``0``, not absent (#1665).
+
+        ``exclude_none=True`` drops a None-valued field before any
+        field-level serializer would run, so the disabled-cap intent is
+        lost silently on write. A wrapping model serializer runs after
+        ``handler`` has already applied that exclusion, so it can add the
+        sentinel back in only when the key was actually dropped — an
+        ``exclude_none=False`` dump (e.g. the API echo) already has
+        ``max_rows: None`` in ``data`` and is left untouched.
+        """
+        data = handler(self)
+        if self.max_rows is None and "max_rows" not in data:
+            data["max_rows"] = 0
+        return data
 
 
 #: Where the steward sends TOOL turns when nothing else says otherwise. ADR-0023's

--- a/tests/config/test_activity_max_rows_null.py
+++ b/tests/config/test_activity_max_rows_null.py
@@ -1,0 +1,74 @@
+"""#1665: ``[activity] max_rows = null`` ("disables the row cap") cannot persist.
+
+``max_rows: int | None = Field(default=50_000, ge=100)`` carries the comment
+"None disables the row cap". ``save_hal0_config`` uses ``exclude_none=True``
+(TOML has no null), so writing ``None`` drops the key entirely and the next
+load restores the ``50_000`` default -- the documented unlimited mode was
+unreachable through any persisted config. ``PUT /api/settings`` accepted
+``{"activity": {"max_rows": null}}``, returned 200 with ``max_rows=null`` in
+the echoed config, and silently reverted on the next reload/restart.
+
+Same save/load re-default class as #1644 (``[brain_chat] tool_model``): the
+internal "unlimited" value (``None``) has no lossless TOML spelling, so it
+must be given one at the serialization boundary rather than relying on
+``exclude_none`` to round-trip it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.schema import ActivityConfig, Hal0Config
+
+
+def test_the_default_is_still_the_anchor() -> None:
+    assert ActivityConfig().max_rows == 50_000
+
+
+def test_none_means_unlimited_in_memory() -> None:
+    assert ActivityConfig(max_rows=None).max_rows is None
+
+
+def test_a_real_value_is_kept() -> None:
+    assert ActivityConfig(max_rows=1000).max_rows == 1000
+
+
+def test_below_the_floor_is_still_rejected() -> None:
+    with pytest.raises(Exception):
+        ActivityConfig(max_rows=50)
+
+
+def test_max_rows_null_survives_a_save_load_round_trip(tmp_path: Path) -> None:
+    """The regression itself (#1665)."""
+    toml_path = tmp_path / "hal0.toml"
+    save_hal0_config(Hal0Config(activity={"max_rows": None}), toml_path)
+    reloaded = load_hal0_config(toml_path)
+    assert reloaded.activity.max_rows is None, (
+        "max_rows=None did not survive a save/load round trip: "
+        f"got {reloaded.activity.max_rows!r}"
+    )
+
+
+def test_zero_is_accepted_on_disk_as_the_unlimited_spelling(tmp_path: Path) -> None:
+    """0 is below the ge=100 floor, so it was never a valid persisted row
+    cap -- free to repurpose as the on-disk "unlimited" sentinel, the same
+    way "off"/"none"/"disabled" are reserved spellings for tool_model."""
+    toml_path = tmp_path / "hal0.toml"
+    toml_path.write_text("[activity]\nmax_rows = 0\n", encoding="utf-8")
+    assert load_hal0_config(toml_path).activity.max_rows is None
+
+
+def test_a_real_value_still_round_trips(tmp_path: Path) -> None:
+    toml_path = tmp_path / "hal0.toml"
+    save_hal0_config(Hal0Config(activity={"max_rows": 1234}), toml_path)
+    assert load_hal0_config(toml_path).activity.max_rows == 1234
+
+
+def test_the_api_echo_still_shows_null_not_the_disk_sentinel() -> None:
+    """The dump used for API responses (no exclude_none) must keep showing
+    the real None, not leak the 0 on-disk encoding into the client."""
+    cfg = ActivityConfig(max_rows=None)
+    assert cfg.model_dump()["max_rows"] is None

--- a/tests/config/test_activity_max_rows_null.py
+++ b/tests/config/test_activity_max_rows_null.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import ActivityConfig, Hal0Config
@@ -37,7 +38,7 @@ def test_a_real_value_is_kept() -> None:
 
 
 def test_below_the_floor_is_still_rejected() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         ActivityConfig(max_rows=50)
 
 

--- a/tests/config/test_activity_max_rows_null.py
+++ b/tests/config/test_activity_max_rows_null.py
@@ -48,8 +48,7 @@ def test_max_rows_null_survives_a_save_load_round_trip(tmp_path: Path) -> None:
     save_hal0_config(Hal0Config(activity={"max_rows": None}), toml_path)
     reloaded = load_hal0_config(toml_path)
     assert reloaded.activity.max_rows is None, (
-        "max_rows=None did not survive a save/load round trip: "
-        f"got {reloaded.activity.max_rows!r}"
+        f"max_rows=None did not survive a save/load round trip: got {reloaded.activity.max_rows!r}"
     )
 
 


### PR DESCRIPTION
## Summary
- `save_hal0_config` dumps with `exclude_none=True`, so writing `activity.max_rows = null` ("unlimited row cap") silently dropped the key and the next load restored the `50_000` default. `PUT /api/settings` echoed 200 with `max_rows=null` but it reverted on reload/restart.
- Reserves `0` (already unreachable as a real cap — floor is `ge=100`) as the on-disk spelling of "unlimited", same shape as `BrainChatConfig.tool_model`'s `BRAIN_TOOL_MODEL_DISABLED` sentinel from #1644/#1672: a before-validator maps `0 -> None` on load, and a wrapping `model_serializer` re-adds `max_rows=0` only when `exclude_none` actually dropped it. The no-exclude API echo dump is untouched, so clients still see the real `None`.

## Test plan
- [x] New regression tests in `tests/config/test_activity_max_rows_null.py` (save/load round trip, on-disk `0` sentinel, API echo still shows `null`, floor/default still enforced)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/config/ -x -q` — 755 passed, 9 skipped

Closes #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)