### PR TITLE
chore(ui): remove dead #1632 tag-helper leftovers from Models catalog

### DIFF
--- a/ui/src/dash/__tests__/model-sort.test.mjs
+++ b/ui/src/dash/__tests__/model-sort.test.mjs
@@ -5,8 +5,7 @@
 //
 // These pin the behaviours the UI relies on: unknown sort keys sink to the
 // end (so a "sort by params" doesn't shove registry rows above real values),
-// the sort is stable, tag filtering is AND-narrowing, tag chips are the
-// curated vocab ∩ present tags, and the "added" label stays humane.
+// the sort is stable, and the "added" label stays humane.
 
 import {
   MODEL_SORT_FIELDS,
@@ -14,8 +13,6 @@ import {
   modelSizeBytes,
   modelSortKey,
   sortModels,
-  tagChipsFor,
-  modelMatchesTags,
   fmtAdded,
 } from "../model-sort.js";
 
@@ -94,25 +91,6 @@ eq(modelSizeBytes({}), null, "no size → null");
 eq(modelSortKey({ name: "Foo" }, "name"), "foo", "name key lowercased");
 eq(modelSortKey({ created: 100 }, "added"), 100, "added key = created ts");
 eq(modelSortKey({ created: 0 }, "added"), null, "created 0 → null (unknown)");
-
-// ── tag filtering (AND) ─────────────────────────────────────────────
-ok(modelMatchesTags({ tags: ["coder", "mtp"] }, []), "no selection matches all");
-ok(modelMatchesTags({ tags: ["coder", "mtp"] }, ["coder"]), "single tag match");
-ok(modelMatchesTags({ tags: ["coder", "mtp"] }, ["coder", "mtp"]), "AND match");
-ok(!modelMatchesTags({ tags: ["coder"] }, ["coder", "mtp"]), "AND miss narrows");
-ok(!modelMatchesTags({}, ["coder"]), "no tags → no match when selecting");
-
-// ── tag chips = curated ∩ present, in curated order ─────────────────
-{
-  const rows = [{ tags: ["coder", "user-added"] }, { tags: ["mtp"] }];
-  eq(
-    tagChipsFor(rows, ["mtp", "coder", "vision"]),
-    ["mtp", "coder"],
-    "chips are curated∩present in curated order (vision dropped, no rows)",
-  );
-  eq(tagChipsFor([], ["mtp"]), [], "no rows → no chips");
-  eq(tagChipsFor(rows, []), [], "no curated vocab → no chips");
-}
 
 // ── added label ─────────────────────────────────────────────────────
 {

--- a/ui/src/dash/model-drawer.jsx
+++ b/ui/src/dash/model-drawer.jsx
@@ -414,7 +414,6 @@ function deriveModelChanges(baseline, form) {
 	};
 	c.any =
 		c.name ||
-		c.tags ||
 		c.caps ||
 		c.backends ||
 		c.mmproj ||
@@ -441,10 +440,6 @@ function ModelDrawer({ open, onClose, model }) {
 
 	// Identity + typed fields (preserve the full RecipeEditor save surface).
 	const [name, setName] = useStateMD("");
-	// (Non-curated tags are not editable here; they live on the frozen baseline
-	// as `otherTags` and are re-merged into the write by deriveModelChanges. A
-	// second mutable copy in component state would be exactly the drift this
-	// seam exists to prevent.)
 	const [caps, setCaps] = useStateMD([]);
 	const [backends, setBackends] = useStateMD([]);
 	const [mmproj, setMmproj] = useStateMD("");

--- a/ui/src/dash/model-sort.js
+++ b/ui/src/dash/model-sort.js
@@ -146,38 +146,6 @@ export function sortModels(rows, field, dir = "asc") {
 }
 
 /**
- * Tag chips worth rendering: the curated vocabulary (in its canonical
- * order) intersected with the tags actually present on the given rows, so
- * the toolbar never renders a 35-chip wall of dead filters.
- *
- * @param {any[]} rows
- * @param {string[]} curatedTags meta.curated_model_tags
- * @returns {string[]}
- */
-export function tagChipsFor(rows, curatedTags) {
-  const present = new Set();
-  for (const m of Array.isArray(rows) ? rows : []) {
-    for (const t of Array.isArray(m?.tags) ? m.tags : []) present.add(t);
-  }
-  return (Array.isArray(curatedTags) ? curatedTags : []).filter((t) => present.has(t));
-}
-
-/**
- * True when the model carries EVERY selected tag (AND semantics — chips
- * narrow). No selection matches everything.
- *
- * @param {any} m
- * @param {string[]} selected
- * @returns {boolean}
- */
-export function modelMatchesTags(m, selected) {
-  const sel = Array.isArray(selected) ? selected : [];
-  if (sel.length === 0) return true;
-  const tags = new Set(Array.isArray(m?.tags) ? m.tags : []);
-  return sel.every((t) => tags.has(t));
-}
-
-/**
  * Short human "added" label from a unix-seconds timestamp: relative for
  * the last month ("today", "3d ago"), short date beyond. "—" when unknown.
  *


### PR DESCRIPTION
## Summary
- `deriveModelChanges` (`ui/src/dash/model-drawer.jsx`) still ORed `c.tags` into `c.any`, but `c` no longer carries a `tags` key since #1632 removed Model.tags editing from the drawer — a live dirty-gate expression referencing a permanently-`undefined` field. Removed the dead OR-term and the stale comment claiming non-curated tags "live on the frozen baseline as `otherTags`".
- `ui/src/dash/model-sort.js`'s `tagChipsFor`/`modelMatchesTags` are now dead: `models.jsx` only imports `MODEL_SORT_FIELDS`/`sortModels`/`fmtAdded`, and the only other importer was `model-sort.test.mjs`'s own coverage of them. Removed both helpers and their tests.
- Left `curated_model_tags` (`meta.py`/`deviceMeta.ts`) alone — it's a separate, more invasive backend/API surface with its own pinned test (`test_curated_model_tags.py`), out of scope for this UI-only cleanup.

Removal only, no behavior change.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run build` / `npm run test:unit` — all pass
- [x] `node ui/src/dash/__tests__/model-sort.test.mjs` — all assertions pass

Closes #1660

🤖 Generated with [Claude Code](https://claude.com/claude-code)