### PR TITLE
fix(models): keep the legacy <tag>-FLM id resolvable after dedupe

### DIFF
--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -916,6 +916,20 @@ async def list_all(
                 if row is not None and probe_caps and row.get("capabilities") != probe_caps:
                     row["capabilities"] = probe_caps
                     row["type"] = dispatch_type(row.get("id", ""), capabilities=probe_caps)
+                # #1656: this dedupe skip fires BEFORE the legacy ``<tag>-FLM``
+                # id below is ever computed, so a slot whose persisted model
+                # default is still that pre-#1629 generated id (created
+                # before the dedupe change) no longer finds a matching row
+                # via the UI's exact `m.id === id` lookup — dispatch still
+                # routes it correctly server-side, only the model-editor
+                # reference goes dangling. Stamp the legacy id onto the
+                # surviving row's `aliases` so the UI lookup can fall back to
+                # it (see `slotModelRow` in slot-shared.js).
+                if row is not None:
+                    legacy_id = fm["tag"].replace(":", "-") + "-FLM"
+                    aliases = row.setdefault("aliases", [])
+                    if legacy_id not in aliases:
+                        aliases.append(legacy_id)
                 continue
             mid = fm["tag"].replace(":", "-") + "-FLM"
             if mid in seen:

--- a/tests/api/test_models_routes.py
+++ b/tests/api/test_models_routes.py
@@ -713,6 +713,40 @@ def test_list_models_dedupe_merges_flm_probe_capabilities_into_registry_row(
     assert row["type"] == "embedding"
 
 
+def test_list_models_dedupe_keeps_legacy_flm_id_as_an_alias(
+    inspect_client: TestClient,
+    tmp_hal0_home: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1656: a slot created before the #1629 dedupe change can still
+    persist the legacy generated ``<tag>-FLM`` id as its model default.
+    The dedupe skip fires before that id is ever computed, so the surviving
+    registry row must carry it in ``aliases`` — otherwise the UI's exact
+    `m.id === id` lookup (slotModelRow) goes dangling for that slot even
+    though dispatch still routes the model correctly server-side."""
+    fpath = Path(tmp_hal0_home) / "gemma4-e4b.gguf"
+    fpath.write_bytes(b"\x00" * 8)
+    inspect_client.post(
+        "/api/models",
+        json={"id": "gemma4-it:e4b", "path": str(fpath)},
+    )
+    fake = [
+        {
+            "tag": "gemma4-it:e4b",
+            "capabilities": ["chat"],
+            "installed": True,
+            "size_bytes": 1,
+            "footprint_gb": 0.0,
+            "family": "gemma4",
+        },
+    ]
+    monkeypatch.setattr("hal0.providers.flm.flm_served_models", lambda: fake)
+
+    rows = {m["id"]: m for m in inspect_client.get("/api/models").json()["models"]}
+    assert "gemma4-it-e4b-FLM" not in rows
+    assert rows["gemma4-it:e4b"]["aliases"] == ["gemma4-it-e4b-FLM"]
+
+
 # ── upstream provenance in /api/models ─────────────────────────────────────
 
 

--- a/ui/src/dash/slots/slot-shared.js
+++ b/ui/src/dash/slots/slot-shared.js
@@ -46,10 +46,18 @@ export function slotModelId(slot) {
 // One copy on purpose: the slot edit drawer (slot-modals.jsx) and the slot
 // card (slots.jsx / inference-pane.jsx) both need this exact lookup, and the
 // `model_id || model` precedence is easy to get subtly wrong twice.
+//
+// Falls back to `m.aliases` (#1656): pre-#1629 slots can still be bound to
+// the legacy generated `<tag>-FLM` id, which the catalog's dedupe skip no
+// longer emits as its own row — the surviving registry row carries that id
+// in `aliases` instead so the lookup doesn't go dangling.
 export function slotModelRow(slot, models) {
   const id = slotModelId(slot);
   if (!id) return null;
-  return (models ?? []).find((m) => m?.id === id) || null;
+  const rows = models ?? [];
+  const exact = rows.find((m) => m?.id === id);
+  if (exact) return exact;
+  return rows.find((m) => Array.isArray(m?.aliases) && m.aliases.includes(id)) || null;
 }
 
 // The short device label + hue token for a device string (chip / teach copy).

--- a/ui/src/dash/slots/slot-shared.test.ts
+++ b/ui/src/dash/slots/slot-shared.test.ts
@@ -61,4 +61,20 @@ describe('slotModelRow', () => {
   it('skips null entries in the list instead of throwing', () => {
     expect(slotModelRow({ model_id: 'qwen3.6-27b' }, [null, ...ROWS])).toBe(ROWS[0])
   })
+
+  it('falls back to a row carrying the id in `aliases` (#1656 legacy FLM id)', () => {
+    const rows = [{ id: 'gemma4-it:e4b', aliases: ['gemma4-it-e4b-FLM'] }, ...ROWS]
+    expect(slotModelRow({ model_id: 'gemma4-it-e4b-FLM' }, rows)).toBe(rows[0])
+  })
+
+  it('prefers an exact id match over an alias match', () => {
+    const exact = { id: 'gemma4-it-e4b-FLM' }
+    const aliased = { id: 'gemma4-it:e4b', aliases: ['gemma4-it-e4b-FLM'] }
+    expect(slotModelRow({ model_id: 'gemma4-it-e4b-FLM' }, [aliased, exact])).toBe(exact)
+  })
+
+  it('tolerates rows with a non-array `aliases`', () => {
+    const rows = [{ id: 'x', aliases: 'not-an-array' }]
+    expect(slotModelRow({ model_id: 'gone' }, rows)).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary
- `list_all()`'s dedupe skip (`src/hal0/services/models_service.py`, `if fm["tag"] in seen: continue`) fires before the legacy `<tag>-FLM` id is ever computed, so a slot whose persisted model default is that pre-#1629 generated id (e.g. `gemma4-it-e4b-FLM`) no longer finds a matching row via `slot-shared.js`'s exact `m.id === id` lookup (`slotModelRow`).
- Server-side dispatch (`is_installed_flm_id`/`flm_id_to_tag`) still routes the slot correctly — only the UI reference goes dangling, so an otherwise-working slot reads as broken in the model editor.
- Fix: stamp the legacy id onto the surviving registry row's `aliases` when the dedupe skip fires (same spot #1647/#1695 already merges the probe's capabilities into that row), and teach `slotModelRow` to fall back to an `aliases` match when the exact id lookup misses.

## Test plan
- [x] `tests/api/test_models_routes.py::test_list_models_dedupe_keeps_legacy_flm_id_as_an_alias` (new)
- [x] `ui/src/dash/slots/slot-shared.test.ts` — 3 new cases (alias fallback, exact-match precedence, non-array `aliases` tolerance)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/test_models_routes.py -x -q` — 36 passed
- [x] `uv run ruff check/format` — clean
- [x] `npm run lint` / `npm run typecheck` / `npm run build` / `npm run test:unit` — all pass (105 tests)

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)