### PR TITLE
fix(models): let a re-pull's context_length win over its own prior stamp

### DIFF
--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -273,7 +273,11 @@ class Model(BaseModel):
         description=(
             "Provider-specific or user-defined extra metadata. "
             "Reserved keys: 'context_length' (int, GGUF arch max), "
-            "'upstream_url' (str, dispatcher route hint)."
+            "'context_length_detected' (bool, set by the pull path when it "
+            "auto-stamped 'context_length' from the GGUF header/curated "
+            "catalogue — absent means an operator set it explicitly, which "
+            "outranks a later re-pull's own detection; see registry/pull.py "
+            "_register_pulled), 'upstream_url' (str, dispatcher route hint)."
         ),
     )
 

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1227,6 +1227,10 @@ def _register_pulled(
         ctx_len = int(curated.context_length)
     if ctx_len:
         fresh_meta["context_length"] = int(ctx_len)
+        # #1657: mark this value as auto-detected (GGUF header or curated
+        # backfill) so a LATER re-pull can tell it apart from an operator's
+        # explicit metadata edit — see the merge below.
+        fresh_meta["context_length_detected"] = True
     updates: dict[str, Any] = {
         "path": path,
         "size_bytes": size_bytes,
@@ -1269,11 +1273,21 @@ def _register_pulled(
     # before kicking off the pull).
     merged_meta = dict(existing.metadata)
     merged_meta.update(fresh_meta)
-    # An operator/scan-provided window outranks this pull's read: only fill
-    # the key when the existing row has none (same absent-only contract as
-    # chat_template below).
-    if existing.metadata.get("context_length") and "context_length" in fresh_meta:
+    # An operator-provided window outranks this pull's read — but a value
+    # THIS SAME PATH auto-stamped on a prior pull (context_length_detected)
+    # must NOT outrank a fresh re-pull's own detection, or an in-place
+    # model update (replaced bytes, different GGUF header) can never pick
+    # up the new window: it stays stuck at whatever the first pull happened
+    # to read (#1657). Only a value with no detected-marker — i.e. one an
+    # operator set explicitly through the metadata edit surface — wins over
+    # the fresh read.
+    if (
+        existing.metadata.get("context_length")
+        and not existing.metadata.get("context_length_detected")
+        and "context_length" in fresh_meta
+    ):
         merged_meta["context_length"] = existing.metadata["context_length"]
+        merged_meta.pop("context_length_detected", None)
     updates["metadata"] = merged_meta
     if curated_template and not (existing.defaults is not None and existing.defaults.chat_template):
         merged_defaults = (

--- a/tests/registry/test_pull.py
+++ b/tests/registry/test_pull.py
@@ -297,6 +297,71 @@ async def test_run_pull_curated_context_length_backfills_unreadable_gguf(
 
 
 @pytest.mark.asyncio
+async def test_run_pull_refreshes_context_length_on_repull(tmp_hal0_home: str) -> None:
+    """#1657: an in-place update (replaced bytes, different GGUF header)
+    must pick up the fresh context_length, not stay stuck at whatever the
+    first pull happened to read. Repro: run_pull twice on the same
+    model_id with different GGUF context_length headers."""
+    job = make_job("some-random-gguf")
+    registry = ModelRegistry()
+
+    client = httpx.AsyncClient(transport=_ok_handler(_gguf_payload(context_length=4096)))
+    try:
+        await run_pull(
+            job, hf_repo="org/random-GGUF", hf_file="random.gguf", registry=registry, client=client
+        )
+    finally:
+        await client.aclose()
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("some-random-gguf").metadata.get("context_length") == 4096
+
+    job2 = make_job("some-random-gguf")
+    client2 = httpx.AsyncClient(transport=_ok_handler(_gguf_payload(context_length=131072)))
+    try:
+        await run_pull(
+            job2,
+            hf_repo="org/random-GGUF",
+            hf_file="random.gguf",
+            registry=registry,
+            client=client2,
+        )
+    finally:
+        await client2.aclose()
+    assert job2.state == "completed", f"got {job2.state}: {job2.error}"
+    assert registry.get("some-random-gguf").metadata.get("context_length") == 131072
+
+
+@pytest.mark.asyncio
+async def test_run_pull_keeps_operator_context_length(tmp_hal0_home: str) -> None:
+    """A context_length the operator set explicitly (no context_length_detected
+    marker — never stamped by this pull path) outranks a re-pull's fresh
+    GGUF read, same absent-only contract as chat_template."""
+    from hal0.registry.model import Model
+
+    registry = ModelRegistry()
+    registry.add(
+        Model(
+            id="some-random-gguf",
+            name="some-random-gguf",
+            path="/nonexistent/model.gguf",
+            size_bytes=1,
+            metadata={"context_length": 99999},
+        )
+    )
+    job = make_job("some-random-gguf")
+    client = httpx.AsyncClient(transport=_ok_handler(_gguf_payload(context_length=131072)))
+    try:
+        await run_pull(
+            job, hf_repo="org/random-GGUF", hf_file="random.gguf", registry=registry, client=client
+        )
+    finally:
+        await client.aclose()
+
+    assert job.state == "completed", f"got {job.state}: {job.error}"
+    assert registry.get("some-random-gguf").metadata.get("context_length") == 99999
+
+
+@pytest.mark.asyncio
 async def test_run_pull_stamps_curated_tool_calling(tmp_hal0_home: str) -> None:
     """A curated native tool-caller lands with capability_flags.tool_calling=True."""
     body = _payload(4096)


### PR DESCRIPTION
## Summary
- `_register_pulled`'s merge (`src/hal0/registry/pull.py:1272-1276`) unconditionally kept the existing row's `context_length` whenever both it and the fresh GGUF read had a value — with no way to distinguish an operator's explicit override from a value the SAME pull path had itself stamped on a prior pull.
- Consequence: an in-place model update (`POST /api/models/{id}/update`, replaced bytes with a different GGUF header) could never pick up the new window. It stayed stuck at whatever the first pull happened to read — a shrunk native window could launch unsupported, or a genuinely larger window stayed artificially capped.
- Fix: mark auto-stamped values with `metadata.context_length_detected = True` at pull time. On merge, only a `context_length` WITHOUT that marker (an operator's explicit metadata edit, never touched by this path) outranks the fresh read; a pull-stamped value always yields to the current pull's own detection.

## Test plan
- [x] `test_run_pull_refreshes_context_length_on_repull` (new) — the issue's repro: `run_pull` twice on the same `model_id` with GGUF headers 4096 then 131072 → final value is 131072
- [x] `test_run_pull_keeps_operator_context_length` (new) — a row seeded with `metadata={"context_length": 99999}` (no detected-marker, i.e. operator-set) survives a re-pull with a different GGUF header
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/registry/ -x -q` — 393 passed
- [x] `uv run ruff check/format` — clean

Closes #1657

🤖 Generated with [Claude Code](https://claude.com/claude-code)