### PR TITLE
fix(ui): portal-render field-info popup to escape clipped panels

### DIFF
--- a/ui/src/dash/primitives.jsx
+++ b/ui/src/dash/primitives.jsx
@@ -715,11 +715,78 @@ function FieldGroup({ label, hint, children }) {
 // Generalized from slots.jsx NpuSwitch.
 // Fixed label; the on/off STATE is shown by the pill, never by a changing label.
 // ─── FieldInfoIcon — hover/focus-only help for drawer field descriptions ───
+// The popup renders through a portal at document.body so no overflow:hidden
+// ancestor (e.g. .s-panel on narrow viewports, issue #1683) can clip it. Its
+// position is computed from the trigger icon's getBoundingClientRect() and
+// re-clamped to the viewport — flip above the icon when there isn't room
+// below, and clamp the left edge so the box never runs off either side.
 function FieldInfoIcon({ description }) {
   const descriptionId = React.useId();
+  const triggerRef = useRefP(null);
+  const popRef = useRefP(null);
+  const [open, setOpen] = useStateP(false);
+  const [pos, setPos] = useStateP(null);
+  // Popup stays open while either the icon or the popup itself has
+  // hover/focus — tracked in refs (not state) so mouseleave on one doesn't
+  // race a mouseenter on the other.
+  const hoverRef = useRefP(false);
+  const focusRef = useRefP(false);
+
+  const updatePosition = React.useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const popEl = popRef.current;
+    const popWidth = popEl ? popEl.offsetWidth : 260;
+    const popHeight = popEl ? popEl.offsetHeight : 40;
+    const margin = 8;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    let left = rect.left;
+    left = Math.min(left, vw - popWidth - margin);
+    left = Math.max(left, margin);
+
+    let top = rect.bottom + 6;
+    let placement = "below";
+    if (top + popHeight + margin > vh && rect.top - popHeight - 6 > margin) {
+      top = rect.top - popHeight - 6;
+      placement = "above";
+    }
+    setPos({ top, left, placement });
+  }, []);
+
+  const show = React.useCallback(() => setOpen(true), []);
+  const maybeHide = React.useCallback(() => {
+    if (!hoverRef.current && !focusRef.current) setOpen(false);
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!open) return undefined;
+    updatePosition();
+    const onReflow = () => updatePosition();
+    window.addEventListener("scroll", onReflow, true);
+    window.addEventListener("resize", onReflow);
+    return () => {
+      window.removeEventListener("scroll", onReflow, true);
+      window.removeEventListener("resize", onReflow);
+    };
+  }, [open, updatePosition]);
+
+  // Always portal-mounted (never conditionally rendered) so `[data-open]` on
+  // its own element owns visibility — mirrors the old CSS-only
+  // display:none/block toggle and keeps a stable node for aria-describedby
+  // and for measuring offsetWidth/offsetHeight before the first open.
   return (
-    <span className="field-info-wrap">
+    <span
+      className="field-info-wrap"
+      onMouseEnter={() => { hoverRef.current = true; show(); }}
+      onMouseLeave={() => { hoverRef.current = false; maybeHide(); }}
+      onFocus={() => { focusRef.current = true; show(); }}
+      onBlur={() => { focusRef.current = false; maybeHide(); }}
+    >
       <button
+        ref={triggerRef}
         type="button"
         className="field-info-btn"
         aria-label="Info"
@@ -728,9 +795,21 @@ function FieldInfoIcon({ description }) {
       >
         i
       </button>
-      <span id={descriptionId} role="tooltip" className="field-info-pop">
-        {description}
-      </span>
+      {ReactDOM.createPortal(
+        <span
+          ref={popRef}
+          id={descriptionId}
+          role="tooltip"
+          className={`field-info-pop field-info-pop--${pos ? pos.placement : "below"}`}
+          data-open={open ? "1" : undefined}
+          style={pos ? { top: `${pos.top}px`, left: `${pos.left}px` } : { top: "-9999px", left: "-9999px" }}
+          onMouseEnter={() => { hoverRef.current = true; show(); }}
+          onMouseLeave={() => { hoverRef.current = false; maybeHide(); }}
+        >
+          {description}
+        </span>,
+        document.body,
+      )}
     </span>
   );
 }

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -3157,18 +3157,18 @@ select.npu-sel {
   outline: 1px solid var(--accent);
   outline-offset: 2px;
 }
+/* Rendered through a portal at document.body (#1683) so no overflow:hidden
+   ancestor — .s-panel, .drawer, etc. — can clip it. FieldInfoIcon computes
+   `top`/`left` from the trigger's getBoundingClientRect() and writes them as
+   inline styles; this rule only owns paint/visibility, never placement. */
 .field-info-pop {
-  position: absolute;
-  left: 22px;
-  top: -4px;
-  z-index: 60;
+  position: fixed;
+  z-index: 250;
   display: none;
-  /* Shrink-to-fit for an absolutely-positioned box resolves against the
-     containing block — the ~19px icon wrapper — which collapsed the popup
-     to one word per line. max-content sizes it to the text instead, with
-     max-width as the wrap point. */
+  /* Shrink-to-fit sized to the text; max-width caps it and leaves room for
+     the JS-computed horizontal clamp to keep it fully on-screen. */
   width: max-content;
-  max-width: 280px;
+  max-width: min(280px, calc(100vw - 16px));
   padding: 6px 10px;
   color: var(--fg-2);
   background: var(--bg-2);
@@ -3179,20 +3179,8 @@ select.npu-sel {
   line-height: 1.5;
   white-space: normal;
 }
-.field-info-wrap:hover .field-info-pop,
-.field-info-wrap:focus-within .field-info-pop {
+.field-info-pop[data-open="1"] {
   display: block;
-}
-/* On narrow screens the to-the-right placement runs the (now content-width)
-   popup past the right edge of overflow-clipped panels (.s-panel). Drop it
-   below the icon, centred, with a viewport-derived cap instead. */
-@media (max-width: 720px) {
-  .field-info-pop {
-    left: 50%;
-    top: 20px;
-    transform: translateX(-50%);
-    max-width: min(260px, calc(100vw - 48px));
-  }
 }
 /* Visually hidden but exposed to assistive tech (toggle descriptions etc.). */
 .sr-only {

--- a/ui/src/globals-install.ts
+++ b/ui/src/globals-install.ts
@@ -19,10 +19,17 @@
 //     keeps calling `window.__hal0Toast(...)`.
 
 import React from 'react'
-import * as ReactDOM from 'react-dom/client'
+import * as ReactDOMClient from 'react-dom/client'
+import { createPortal } from 'react-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { queryClient } from './lib/queryClient'
 import { installToastGlobal, installToastQueueHook } from './stores/useToastStore'
+
+// react-dom/client only exports createRoot/hydrateRoot; createPortal lives on
+// the main 'react-dom' entry. Dash prototype code (e.g. FieldInfoIcon) needs
+// createPortal to escape overflow:hidden ancestors, so merge it onto the same
+// global object rather than installing a second global.
+const ReactDOM = { ...ReactDOMClient, createPortal }
 
 ;(globalThis as any).React = React
 ;(globalThis as any).ReactDOM = ReactDOM

--- a/ui/src/types/globals.d.ts
+++ b/ui/src/types/globals.d.ts
@@ -9,7 +9,7 @@
 declare global {
   interface Window {
     React: typeof import('react')
-    ReactDOM: typeof import('react-dom/client')
+    ReactDOM: typeof import('react-dom/client') & { createPortal: typeof import('react-dom').createPortal }
 
     // dash/data.jsx
     HAL0_DATA: any
@@ -24,7 +24,7 @@ declare global {
   // dash/*.jsx side-effect module runs. The .jsx files reference `React`
   // directly (e.g. `const { useState } = React`).
   var React: typeof import('react')
-  var ReactDOM: typeof import('react-dom/client')
+  var ReactDOM: typeof import('react-dom/client') & { createPortal: typeof import('react-dom').createPortal }
 }
 
 export {}

--- a/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
+++ b/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
@@ -16,6 +16,17 @@
  * being absent.
  */
 import { test, expect, json } from '../fixtures/apiMock'
+import type { Locator } from '@playwright/test'
+
+// #1683: FieldInfoIcon's description now portals to document.body (so
+// overflow:hidden panels can't clip it), so it's no longer a DOM descendant
+// of its row — `row.textContent` (what `toContainText` reads) doesn't see it
+// anymore. Look the popup up via the Info button's aria-describedby instead.
+async function fieldInfoPopup(row: Locator) {
+  const btn = row.getByRole('button', { name: 'Info' })
+  const id = await btn.getAttribute('aria-describedby')
+  return row.page().locator(`[id="${id}"]`)
+}
 
 function capabilityRow(device: string, provider: string, model: string | null, slot: string, status: string) {
   return { device, backend: device, provider, model, enabled: !!model, slot, status }
@@ -109,8 +120,8 @@ test.describe('Capability catalog pickers (#1454)', () => {
     await expect(page.locator('.settings-content h2').first()).toHaveText('Voice')
 
     const modelRows = page.locator('.s-row').filter({ has: page.locator('.k span', { hasText: /^Model$/ }) })
-    await expect(modelRows.nth(0)).toContainText('no installed STT models')
-    await expect(modelRows.nth(1)).toContainText('no installed TTS models')
+    await expect(await fieldInfoPopup(modelRows.nth(0))).toContainText('no installed STT models')
+    await expect(await fieldInfoPopup(modelRows.nth(1))).toContainText('no installed TTS models')
     // Genuinely-empty catalog falls back to the free-text input, not a <select>.
     await expect(modelRows.nth(0).locator('select')).toHaveCount(0)
   })

--- a/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
+++ b/ui/tests/e2e/specs/model-drawer-save-info-v3.spec.ts
@@ -157,7 +157,13 @@ test.describe('Model drawer — complete save and compact field help', () => {
 
     const displayNameLabel = labels.filter({ hasText: 'Display name' })
     const info = displayNameLabel.getByRole('button', { name: 'Info' })
-    const popover = displayNameLabel.locator('.field-info-pop')
+    // #1683: the popup portals to document.body (so overflow:hidden panels
+    // can't clip it), so it's no longer a DOM descendant of the label — find
+    // it via the button's aria-describedby instead of a row-scoped locator.
+    const popupId = await info.getAttribute('aria-describedby')
+    // useId() ids contain colons (e.g. ":r0:"), invalid in a raw #id CSS
+    // selector — use an attribute selector, which doesn't need escaping.
+    const popover = page.locator(`[id="${popupId}"]`)
     await expect(popover).toHaveCount(1)
     await expect(popover).toBeHidden()
 

--- a/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
+++ b/ui/tests/e2e/specs/slot-edit-controls-v3.spec.ts
@@ -127,10 +127,17 @@ test.describe('Slot edit controls (/slots)', () => {
     await expect(input).toHaveValue('-1')
     const row = page.locator('.drawer .form-row', { hasText: 'NGL' })
     const info = row.getByRole('button', { name: 'Info' })
+    // #1683: the popup portals to document.body (so overflow:hidden panels
+    // can't clip it), so it's no longer a DOM descendant of `row` — find it
+    // via the button's aria-describedby instead of a row-scoped locator.
+    const popupId = await info.getAttribute('aria-describedby')
+    // useId() ids contain colons (e.g. ":r0:"), invalid in a raw #id CSS
+    // selector — use an attribute selector, which doesn't need escaping.
+    const popup = page.locator(`[id="${popupId}"]`)
     await info.hover()
-    await expect(row.locator('.field-info-pop')).toContainText('emits -ngl')
+    await expect(popup).toContainText('emits -ngl')
     await page.mouse.move(0, 0)
-    await expect(row.locator('.field-info-pop')).toBeHidden()
+    await expect(popup).toBeHidden()
   })
 
   test('C5 — editing NGL Save PUTs /config { n_gpu_layers } (top-level)', async ({ page }) => {

--- a/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
+++ b/ui/tests/e2e/specs/ui-sweep-a-v3.spec.ts
@@ -117,10 +117,61 @@ test.describe('Voice section — Kokoro label', () => {
       has: page.locator('.k > span', { hasText: /^Default voice$/ }),
     })
     await expect(defaultVoiceRow).toBeVisible()
-    await defaultVoiceRow.getByRole('button', { name: 'Info' }).click()
-    await expect(defaultVoiceRow.locator('.field-info-pop')).toContainText(
+    const info = defaultVoiceRow.getByRole('button', { name: 'Info' })
+    await info.click()
+    // #1683: the popup portals to document.body (so overflow:hidden panels
+    // can't clip it), so it's no longer a DOM descendant of the row — find
+    // it via the button's aria-describedby instead of a row-scoped locator.
+    const popupId = await info.getAttribute('aria-describedby')
+    // useId() ids contain colons (e.g. ":r0:"), invalid in a raw #id CSS
+    // selector — use an attribute selector, which doesn't need escaping.
+    await expect(page.locator(`[id="${popupId}"]`)).toContainText(
       'bundled voices (Kokoro v1)',
     )
+  })
+
+  // #1683: `.s-panel` sets `overflow: hidden`. The popup used to render as a
+  // DOM descendant of the row inside that panel, so on narrow viewports an
+  // icon near the panel's edge could have its popup clipped even though it
+  // fit the viewport. The fix portals the popup to document.body — assert
+  // that ancestry directly (proves it can no longer be clipped by any
+  // ancestor's overflow) and that it still lands fully on-screen.
+  test('#1683 — popup escapes the overflow:hidden .s-panel via a body-level portal', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 700 })
+    await page.goto('/#settings')
+    await page.locator('.nav-item', { hasText: 'Voice' }).click()
+    const defaultVoiceRow = page.locator('.settings-content .s-row').filter({
+      has: page.locator('.k > span', { hasText: /^Default voice$/ }),
+    })
+    await expect(defaultVoiceRow).toBeVisible()
+    const panel = page.locator('.s-panel', {
+      has: page.locator('.k > span', { hasText: /^Default voice$/ }),
+    })
+    await expect(panel).toHaveCSS('overflow', 'hidden')
+
+    const info = defaultVoiceRow.getByRole('button', { name: 'Info' })
+    await info.click()
+    const popupId = await info.getAttribute('aria-describedby')
+    // useId() ids contain colons (e.g. ":r0:"), invalid in a raw #id CSS
+    // selector — use an attribute selector, which doesn't need escaping.
+    const popup = page.locator(`[id="${popupId}"]`)
+    await expect(popup).toBeVisible()
+
+    // Structural proof: the popup is a direct child of <body>, not nested
+    // inside the clipped .s-panel — an overflow:hidden ancestor can only
+    // clip its own DOM descendants.
+    const isBodyChild = await popup.evaluate((el) => el.parentElement === document.body)
+    expect(isBodyChild).toBe(true)
+
+    // And it still fully fits on-screen at this narrow width (the
+    // viewport-aware clamp/flip logic).
+    const viewport = page.viewportSize()
+    const box = await popup.boundingBox()
+    expect(box).toBeTruthy()
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.y).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1)
+    expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1)
   })
 })
 

--- a/ui/tests/e2e/specs/voice-page-provider-copy-v3.spec.ts
+++ b/ui/tests/e2e/specs/voice-page-provider-copy-v3.spec.ts
@@ -16,6 +16,17 @@
  * facts as a regression guard.
  */
 import { test, expect, json } from '../fixtures/apiMock'
+import type { Locator } from '@playwright/test'
+
+// #1683: FieldInfoIcon's description now portals to document.body (so
+// overflow:hidden panels can't clip it), so it's no longer a DOM descendant
+// of its row — `row.textContent` (what `toContainText` reads) doesn't see it
+// anymore. Look the popup up via the Info button's aria-describedby instead.
+async function fieldInfoPopup(row: Locator) {
+  const btn = row.getByRole('button', { name: 'Info' })
+  const id = await btn.getAttribute('aria-describedby')
+  return row.page().locator(`[id="${id}"]`)
+}
 
 function capabilityRow(device: string, provider: string, model: string | null, slot: string, status: string) {
   return { device, backend: device, provider, model, enabled: !!model, slot, status }
@@ -91,7 +102,7 @@ test.describe('Voice page copy keyed on provider (#1470)', () => {
 
     const sampleRateRow = ttsPanel.locator('.s-row').filter({ hasText: 'Sample rate' })
     await expect(sampleRateRow).toContainText('24 kHz')
-    await expect(sampleRateRow).toContainText('Kokoro')
+    await expect(await fieldInfoPopup(sampleRateRow)).toContainText('Kokoro')
   })
 
   test('moonshine STT selection keeps the English-only language copy, other providers do not claim it', async ({ page }) => {
@@ -102,6 +113,6 @@ test.describe('Voice page copy keyed on provider (#1470)', () => {
 
     const languageRow = page.locator('.s-row').filter({ hasText: 'Language' })
     await expect(languageRow).toContainText('English')
-    await expect(languageRow).toContainText('moonshine is English-only')
+    await expect(await fieldInfoPopup(languageRow)).toContainText('moonshine is English-only')
   })
 })


### PR DESCRIPTION
## Summary
- `FieldInfoIcon`'s `.field-info-pop` now renders through a React portal at `document.body` instead of as a DOM descendant of the trigger icon, so no `overflow: hidden` ancestor (`.s-panel`, worse ≤720px after #1638) can clip it
- Position is computed from the trigger's `getBoundingClientRect()`: flips above the icon when there's no room below, clamps horizontally to stay on-screen
- `aria-describedby` wiring is unchanged — same stable id, just relocated in the DOM
- `react-dom/client` doesn't export `createPortal` (only `createRoot`/`hydrateRoot`), so `globals-install.ts` now merges it in from the main `react-dom` entry, with the `window.ReactDOM` type updated to match

## Why
Scoped out of #1638 per Codex review — the proper fix needed the popup to escape its clipped ancestor via a portal, bigger scope than that copy/layout PR.

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (102 passed)
- [x] `npm run test:e2e` full suite (608 passed, 16 pre-existing skips, 0 failures)
- [x] Updated `capability-catalog-pickers-v3`, `model-drawer-save-info-v3`, `slot-edit-controls-v3`, `voice-page-provider-copy-v3` specs — they located popup text via `row.locator('.field-info-pop')` or relied on hidden-but-DOM-nested `textContent`, both of which break once the popup moves to `document.body`; switched to looking it up via the trigger's `aria-describedby`
- [x] Added a dedicated regression test in `ui-sweep-a-v3.spec.ts` (`#1683 — popup escapes the overflow:hidden .s-panel via a body-level portal`) asserting the popup is a direct child of `<body>` (structurally un-clippable) and stays fully within the viewport at a narrow width

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)