### PR TITLE
fix(slots): fold legacy load_asr/load_embed into the lifted [npu] table

### DIFF
--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -377,10 +377,10 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
 
         # [npu] table: expose asr/embed toggles so the dashboard can seed
         # its NPU modality controls. effective_npu_table() also folds in the
-        # legacy [defaults].load_asr/load_embed fallback providers/flm.py
-        # still honors when a pre-1.0 config has no [npu] table at all
-        # (#1670) -- without it the pill renders off even while the
-        # modality is actually running.
+        # pre-[npu]-table [defaults].load_asr/load_embed fallback
+        # providers/flm.py still honors when a pre-1.0 config has no [npu]
+        # table at all (#1670) -- without it the pill renders off even while
+        # the modality is actually running.
         npu_table = effective_npu_table(cfg)
         if npu_table:
             entry["npu"] = {
@@ -596,9 +596,9 @@ async def container_enrichment(
 
         # [npu] table: expose asr/embed toggles so the dashboard can seed
         # its NPU modality controls without a separate /config fetch.
-        # effective_npu_table() also folds in the legacy [defaults].
-        # load_asr/load_embed fallback providers/flm.py still honors when a
-        # pre-1.0 config has no [npu] table at all (#1670).
+        # effective_npu_table() also folds in the pre-[npu]-table
+        # [defaults].load_asr/load_embed fallback providers/flm.py still
+        # honors when a pre-1.0 config has no [npu] table at all (#1670).
         npu_table = effective_npu_table(cfg)
         if npu_table:
             entry["npu"] = {

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -51,7 +51,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from hal0.model_meta import device_to_backend
-from hal0.slots.activation import autoload_enabled, claims_npu_anchor, npu_modality_active
+from hal0.slots.activation import (
+    autoload_enabled,
+    claims_npu_anchor,
+    effective_npu_table,
+    npu_modality_active,
+)
 from hal0.slots.naming import slot_instance_token, slot_unit_name
 from hal0.slots.reaper import eviction_priority
 from hal0.slots.reaper import is_pinned as reaper_is_pinned
@@ -371,11 +376,13 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         entry["llamacpp_args"] = extra_args
 
         # [npu] table: expose asr/embed toggles so the dashboard can seed
-        # its NPU modality controls. Raw TOML dict carries [npu] at the
-        # top level; also check extra["npu"] as a fallback for any
-        # validated-dump shape.
-        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
-        if npu_table and isinstance(npu_table, dict):
+        # its NPU modality controls. effective_npu_table() also folds in the
+        # legacy [defaults].load_asr/load_embed fallback providers/flm.py
+        # still honors when a pre-1.0 config has no [npu] table at all
+        # (#1670) -- without it the pill renders off even while the
+        # modality is actually running.
+        npu_table = effective_npu_table(cfg)
+        if npu_table:
             entry["npu"] = {
                 "asr": bool(npu_table.get("asr")),
                 "embed": bool(npu_table.get("embed")),
@@ -589,10 +596,11 @@ async def container_enrichment(
 
         # [npu] table: expose asr/embed toggles so the dashboard can seed
         # its NPU modality controls without a separate /config fetch.
-        # Raw TOML dict carries [npu] at the top level; also check
-        # extra["npu"] as a fallback for any validated-dump shape.
-        npu_table = cfg.get("npu") or (cfg.get("extra") or {}).get("npu")
-        if npu_table and isinstance(npu_table, dict):
+        # effective_npu_table() also folds in the legacy [defaults].
+        # load_asr/load_embed fallback providers/flm.py still honors when a
+        # pre-1.0 config has no [npu] table at all (#1670).
+        npu_table = effective_npu_table(cfg)
+        if npu_table:
             entry["npu"] = {
                 "asr": bool(npu_table.get("asr")),
                 "embed": bool(npu_table.get("embed")),

--- a/src/hal0/slots/activation.py
+++ b/src/hal0/slots/activation.py
@@ -130,7 +130,8 @@ def npu_anchor_config(configs: list[dict[str, Any]]) -> dict[str, Any] | None:
 
 
 def effective_npu_table(cfg: dict[str, Any] | None) -> dict[str, Any]:
-    """The slot's effective ``[npu]`` modality table, legacy keys included.
+    """The slot's effective ``[npu]`` modality table, pre-``[npu]``-table
+    configs included.
 
     ``providers/flm.py`` still honors the pre-container ``[defaults].load_asr``/
     ``load_embed`` keys at launch when a slot's TOML has no ``[npu]`` table at
@@ -140,11 +141,11 @@ def effective_npu_table(cfg: dict[str, Any] | None) -> dict[str, Any]:
     NPU pill off even while ASR/embed are actually running (#1670).
 
     ``[npu]`` is PRIMARY whenever the table exists at all — an explicit
-    ``asr = false`` must win even if stale legacy defaults say otherwise,
-    same precedence ``flm.py`` itself uses. The legacy fallback is also
-    scoped to ``device == "npu"`` slots only: a chat slot's unrelated
-    ``[defaults]`` table (chat_template, etc.) must never be misread as NPU
-    modality flags.
+    ``asr = false`` must win even if a stale ``[defaults]`` pair says
+    otherwise, same precedence ``flm.py`` itself uses. The pre-``[npu]``
+    fallback is also scoped to ``device == "npu"`` slots only: a chat slot's
+    unrelated ``[defaults]`` table (chat_template, etc.) must never be
+    misread as NPU modality flags.
     """
     if not isinstance(cfg, dict):
         return {}
@@ -167,10 +168,11 @@ def npu_modality_active(configs: list[dict[str, Any]], slot_type: str) -> bool:
     """True when the NPU anchor is live AND ``slot_type``'s modality is on.
 
     The one gate for "should an NPU request of this type route to FLM". Reads
-    the ANCHOR's ``[npu]`` table (falling back to the legacy ``[defaults].
-    load_asr``/``load_embed`` keys, #1670 — see :func:`effective_npu_table`)
-    rather than the child shadow's own config, because a shadow's placeholder
-    model makes it look permanently activated (see :data:`NPU_MODALITY_KEY`).
+    the ANCHOR's ``[npu]`` table (falling back to the pre-``[npu]``-table
+    ``[defaults].load_asr``/``load_embed`` keys, #1670 — see
+    :func:`effective_npu_table`) rather than the child shadow's own config,
+    because a shadow's placeholder model makes it look permanently activated
+    (see :data:`NPU_MODALITY_KEY`).
     ``chat`` defaults ON when the key is absent, matching ``NpuConfig.chat``;
     ``asr``/``embed`` default OFF.
     """

--- a/src/hal0/slots/activation.py
+++ b/src/hal0/slots/activation.py
@@ -32,6 +32,7 @@ __all__ = [
     "NPU_MODALITY_KEY",
     "autoload_enabled",
     "claims_npu_anchor",
+    "effective_npu_table",
     "is_activated",
     "npu_anchor_config",
     "npu_modality_active",
@@ -128,14 +129,50 @@ def npu_anchor_config(configs: list[dict[str, Any]]) -> dict[str, Any] | None:
     return fallback
 
 
+def effective_npu_table(cfg: dict[str, Any] | None) -> dict[str, Any]:
+    """The slot's effective ``[npu]`` modality table, legacy keys included.
+
+    ``providers/flm.py`` still honors the pre-container ``[defaults].load_asr``/
+    ``load_embed`` keys at launch when a slot's TOML has no ``[npu]`` table at
+    all — but nothing folded that fallback forward into the READ paths
+    (``npu_modality_active`` here, and the ``entry["npu"]`` lift in
+    ``slot_view``), so a pre-1.0 config with no ``[npu]`` table renders every
+    NPU pill off even while ASR/embed are actually running (#1670).
+
+    ``[npu]`` is PRIMARY whenever the table exists at all — an explicit
+    ``asr = false`` must win even if stale legacy defaults say otherwise,
+    same precedence ``flm.py`` itself uses. The legacy fallback is also
+    scoped to ``device == "npu"`` slots only: a chat slot's unrelated
+    ``[defaults]`` table (chat_template, etc.) must never be misread as NPU
+    modality flags.
+    """
+    if not isinstance(cfg, dict):
+        return {}
+    table = cfg.get("npu")
+    if not isinstance(table, dict):
+        table = (cfg.get("extra") or {}).get("npu") if isinstance(cfg.get("extra"), dict) else None
+    if isinstance(table, dict):
+        return table
+    if cfg.get("device") != "npu":
+        return {}
+    defaults = cfg.get("defaults")
+    if not isinstance(defaults, dict) or (
+        "load_asr" not in defaults and "load_embed" not in defaults
+    ):
+        return {}
+    return {"asr": bool(defaults.get("load_asr")), "embed": bool(defaults.get("load_embed"))}
+
+
 def npu_modality_active(configs: list[dict[str, Any]], slot_type: str) -> bool:
     """True when the NPU anchor is live AND ``slot_type``'s modality is on.
 
     The one gate for "should an NPU request of this type route to FLM". Reads
-    the ANCHOR's ``[npu]`` table rather than the child shadow's own config,
-    because a shadow's placeholder model makes it look permanently activated
-    (see :data:`NPU_MODALITY_KEY`). ``chat`` defaults ON when the key is
-    absent, matching ``NpuConfig.chat``; ``asr``/``embed`` default OFF.
+    the ANCHOR's ``[npu]`` table (falling back to the legacy ``[defaults].
+    load_asr``/``load_embed`` keys, #1670 — see :func:`effective_npu_table`)
+    rather than the child shadow's own config, because a shadow's placeholder
+    model makes it look permanently activated (see :data:`NPU_MODALITY_KEY`).
+    ``chat`` defaults ON when the key is absent, matching ``NpuConfig.chat``;
+    ``asr``/``embed`` default OFF.
     """
     key = NPU_MODALITY_KEY.get(slot_type)
     if key is None:
@@ -143,15 +180,7 @@ def npu_modality_active(configs: list[dict[str, Any]], slot_type: str) -> bool:
     anchor = npu_anchor_config(configs)
     if anchor is None or not is_activated(anchor):
         return False
-    table = anchor.get("npu")
-    if not isinstance(table, dict):
-        table = (
-            (anchor.get("extra") or {}).get("npu")
-            if isinstance(anchor.get("extra"), dict)
-            else None
-        )
-    if not isinstance(table, dict):
-        table = {}
+    table = effective_npu_table(anchor)
     if key == "chat":
         return table.get("chat", True) is not False
     return bool(table.get(key))

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -355,6 +355,74 @@ class TestConfigEnrichment:
         # The anchor itself is not a shadow — no lifted modality key.
         assert "npu_modality_active" not in out["flm"]
 
+    def test_shadow_modality_falls_back_to_legacy_load_asr_load_embed(self) -> None:
+        """#1670: a pre-1.0 anchor with no [npu] table at all still honors
+        providers/flm.py's legacy [defaults].load_asr/load_embed keys at
+        launch — the lifted pill must agree, not render every NPU pill off."""
+        configs = [
+            _llm_cfg(
+                name="flm",
+                device="npu",
+                defaults={"load_asr": True, "load_embed": False},
+            ),
+            {
+                "name": "flm-stt",
+                "device": "npu",
+                "type": "transcription",
+                "model": {"default": "whisper-v3"},
+            },
+            {
+                "name": "flm-embed",
+                "device": "npu",
+                "type": "embedding",
+                "model": {"default": "embed-gemma"},
+            },
+        ]
+        out = config_enrichment(configs)
+        assert out["flm-stt"]["npu_modality_active"] is True
+        assert out["flm-embed"]["npu_modality_active"] is False
+
+    def test_explicit_npu_table_outranks_stale_legacy_defaults(self) -> None:
+        """[npu] is PRIMARY whenever it exists at all — an explicit
+        asr=false must win even if legacy defaults.load_asr is still True,
+        same precedence providers/flm.py itself uses."""
+        configs = [
+            _llm_cfg(
+                name="flm",
+                device="npu",
+                npu={"asr": False},
+                defaults={"load_asr": True},
+            ),
+            {
+                "name": "flm-stt",
+                "device": "npu",
+                "type": "transcription",
+                "model": {"default": "whisper-v3"},
+            },
+        ]
+        out = config_enrichment(configs)
+        assert out["flm-stt"]["npu_modality_active"] is False
+
+    def test_anchor_npu_entry_folds_in_legacy_defaults(self) -> None:
+        """The anchor's OWN lifted `entry["npu"]` (drawer/card seed) must
+        also see the legacy fallback, not just the shadow's derived
+        npu_modality_active."""
+        configs = [
+            _llm_cfg(name="flm", device="npu", defaults={"load_asr": True, "load_embed": True}),
+        ]
+        out = config_enrichment(configs)
+        assert out["flm"]["npu"] == {"asr": True, "embed": True, "chat": True}
+
+    def test_legacy_defaults_ignored_on_non_npu_slots(self) -> None:
+        """A chat slot's unrelated [defaults] table (chat_template, etc.)
+        must never be misread as NPU modality flags — the fallback is
+        scoped to device=="npu" slots only."""
+        configs = [
+            _llm_cfg(name="chat", defaults={"load_asr": True, "load_embed": True}),
+        ]
+        out = config_enrichment(configs)
+        assert "npu" not in out["chat"]
+
     def test_config_fields_surfaced(self) -> None:
         # spec-hw-slot-ownership §1: enable_thinking/mtp/vision are no longer
         # slot facts (they moved to ModelDefaults) — a stray raw TOML key
@@ -635,6 +703,16 @@ class TestContainerEnrichment:
             provider=FakeContainerProvider(active=False),
         )
         assert out["gpu-chat"]["npu"] == {"asr": True, "embed": True, "chat": True}
+
+    async def test_npu_table_falls_back_to_legacy_defaults(self) -> None:
+        """#1670: same legacy-defaults fallback as config_enrichment, for
+        the /status aggregator's lifted entry."""
+        out = await container_enrichment(
+            [_container_cfg(device="npu", defaults={"load_asr": True, "load_embed": False})],
+            pull_jobs={},
+            provider=FakeContainerProvider(active=False),
+        )
+        assert out["gpu-chat"]["npu"] == {"asr": True, "embed": False, "chat": True}
 
 
 class MapContainerProvider(FakeContainerProvider):


### PR DESCRIPTION
## Summary
- `npuModalityOn()`'s data source — `slot_view`'s `entry["npu"]` lift and `npu_modality_active()` — only read the slot's `[npu]` table. `providers/flm.py` still honors the pre-container `[defaults].load_asr`/`load_embed` keys at launch when a slot's TOML has no `[npu]` table at all, but nothing folded that fallback forward into either read path: a pre-1.0 config with `[defaults].load_asr=true` launches ASR correctly via the legacy fallback, but the NPU occupancy card renders the STT pill off — the toggle disagrees with what's actually running.
- Added `effective_npu_table()` (`hal0.slots.activation`) as the one place that resolves a slot's `[npu]` table with the legacy fallback folded in — `[npu]` stays PRIMARY whenever it exists at all (an explicit `asr=false` still wins over stale legacy defaults, same precedence `flm.py` itself uses), and the fallback is scoped to `device == "npu"` slots only so an unrelated chat slot's `[defaults]` table is never misread.
- Wired it into both `slot_view` enrichment blocks (`config_enrichment` + `container_enrichment`) and `npu_modality_active()`, replacing their three duplicate ad-hoc npu-table lookups.

## Test plan
- [x] `tests/slot_view/test_aggregator.py` — 5 new cases: shadow modality falls back to legacy defaults, explicit `[npu]` outranks stale legacy defaults, anchor's own lifted `entry["npu"]` sees the fallback too, legacy defaults ignored on non-NPU slots, `container_enrichment`'s parallel lift also falls back
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slot_view/ tests/slots/ -x -q` — 824 passed
- [x] `uv run ruff check/format` — clean

Closes #1670

🤖 Generated with [Claude Code](https://claude.com/claude-code)