### PR TITLE
fix(memory): use the read resolver on GET /api/memory/list, fail closed

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -709,15 +709,30 @@ async def memory_list(
 ) -> dict[str, Any]:
     """Paginated list. Returns ``{items: [...], next_cursor: str | null}``.
 
-    Identity rules mirror ``/search``: ``X-hal0-Private: 1`` with no
-    explicit ``?dataset=`` resolves to the caller's own private bucket
-    so the ``hal0 agent memory list`` CLI subcommand can enumerate
-    per-agent items without the operator passing the namespace by hand.
+    Identity rules mirror ``/search``: this is a READ route, so it resolves
+    through :func:`resolve_read_datasets` like ``/search``/``/recall`` do —
+    ``X-hal0-Private: 1`` with no explicit ``?dataset=`` expands to
+    ``[shared, private:<client_id>]`` (not just the caller's own bucket) so
+    the ``hal0 agent memory list`` CLI subcommand sees the same scope a
+    search would. (#1669 fixed this route using the WRITE resolver instead,
+    which — being write-shaped — also narrowed the no-``?dataset=``
+    private-mode case to the private bucket alone, unlike ``/search``.)
 
     ``?bank=`` is a convenience alias for the dashboard's Hindsight bank
     browser: a bank id (``private__hermes``) is translated to the matching
     dataset namespace (``private:hermes``) when no explicit ``?dataset=`` is
     given. If both are supplied and conflict, the explicit ``dataset`` wins.
+
+    Like every namespace resolution in this module, the alias is still
+    bound by the closed-set rule (module docstring in
+    ``hal0.memory.namespace``): a caller may only ever address their OWN
+    ``private:<client_id>`` bucket. ``bank=private__hermes`` resolves to
+    hermes's bucket only when the caller's own identity IS hermes
+    (``X-hal0-Agent: hermes`` + ``X-hal0-Private: 1``); any other caller's
+    private-mode request still resolves to their OWN bucket, and a
+    non-private caller naming ``private__<anything>`` still 400s — the
+    alias is sugar for spelling your own bank id, never a door into another
+    agent's.
     """
     if bank is not None:
         bank_dataset = bank_to_namespace(bank)
@@ -734,7 +749,7 @@ async def memory_list(
     agent_id = _agent_id(request)
     private = _is_private(request)
     try:
-        resolved = resolve_write_dataset(
+        resolved = resolve_read_datasets(
             dataset,
             private=private,
             client_id=agent_id if agent_id != "anonymous" else None,

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -909,7 +909,7 @@ class HindsightProvider(MemoryProvider):
 
     async def list_items(
         self,
-        dataset: str = _SHARED,
+        dataset: str | list[str] = _SHARED,
         cursor: str | None = None,
         limit: int = 50,
         client_id: str | None = None,

--- a/src/hal0/memory/namespace.py
+++ b/src/hal0/memory/namespace.py
@@ -152,7 +152,17 @@ def resolve_read_datasets(
         :func:`resolve_write_dataset` (same rule applies; e.g. an explicit
         ``shared`` from a private-mode client still gets promoted —
         consistent with the write side).
+      - ``private=True`` with no authenticated ``client_id`` → always
+        ``MemoryNamespaceError``, regardless of ``requested`` shape — same
+        guard :func:`resolve_write_dataset` applies. Without this, an
+        unauthenticated private-mode caller with no explicit ``requested``
+        fell through the empty/``None`` branch's ``private and client_id``
+        check straight to the "not private at all" default (``shared``),
+        silently degrading a claimed-private read into an unscoped shared
+        one instead of refusing it (#1669).
     """
+    if private and (not client_id or client_id == ANONYMOUS_CLIENT_ID):
+        raise MemoryNamespaceError("private namespace requires an authenticated client_id")
     if isinstance(requested, list) and requested:
         names = [str(d) for d in requested]
         kept = [d for d in names if is_known_namespace(d, client_id=client_id)]
@@ -164,7 +174,7 @@ def resolve_read_datasets(
             )
         return kept
     if requested is None or isinstance(requested, list) or not requested.strip():
-        if private and client_id:
+        if private:
             return [DEFAULT_DATASET, f"{PRIVATE_PREFIX}{client_id}"]
         return DEFAULT_DATASET
     return resolve_write_dataset(requested, private=private, client_id=client_id)

--- a/src/hal0/memory/provider.py
+++ b/src/hal0/memory/provider.py
@@ -201,7 +201,7 @@ class MemoryProvider(ABC):
     @abstractmethod
     async def list_items(
         self,
-        dataset: str = "shared",
+        dataset: str | list[str] = "shared",
         cursor: str | None = None,
         limit: int = 50,
         client_id: str | None = None,

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -264,19 +264,21 @@ def test_search_default_no_headers_is_shared(client: TestClient, stub_wrapper: S
 # ── /api/memory/list ───────────────────────────────────────────────────────
 
 
-def test_list_private_mode_targets_own_namespace(
+def test_list_private_mode_expands_to_both_namespaces(
     client: TestClient, stub_wrapper: StubWrapper
 ) -> None:
-    """List with ``X-hal0-Private: 1`` resolves to the caller's own
-    private bucket — required for the ``hal0 agent`` CLI ``memory list``
-    subcommand to enumerate per-agent items."""
+    """List with ``X-hal0-Private: 1`` and no ``?dataset=``/``?bank=``
+    expands to ``[shared, private:<agent>]`` — the SAME read-side
+    expansion ``/search`` uses (#1669: ``/list`` used to resolve through
+    the WRITE resolver, which forced the private bucket alone and broke
+    the "Identity rules mirror /search" contract this route documents)."""
     r = client.get(
         "/api/memory/list",
         headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
     )
     assert r.status_code == 200, r.text
     call = stub_wrapper.list_calls[0]
-    assert call["dataset"] == "private:hermes-agent"
+    assert call["dataset"] == ["shared", "private:hermes-agent"]
 
 
 def test_list_explicit_dataset_query_param(client: TestClient, stub_wrapper: StubWrapper) -> None:
@@ -285,6 +287,55 @@ def test_list_explicit_dataset_query_param(client: TestClient, stub_wrapper: Stu
     assert r.status_code == 200, r.text
     call = stub_wrapper.list_calls[0]
     assert call["dataset"] == "agents"
+
+
+# ── /api/memory/list?bank= (#1669) ───────────────────────────────────────────
+
+
+def test_list_bank_alias_resolves_own_private_bucket(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """``?bank=private__<own-agent>`` — the dashboard bank browser's own
+    worked example — resolves once the caller's identity actually IS that
+    agent (``X-hal0-Agent`` + ``X-hal0-Private: 1``)."""
+    r = client.get(
+        "/api/memory/list?bank=private__hermes-agent",
+        headers={"X-hal0-Agent": "hermes-agent", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.list_calls[0]
+    assert call["dataset"] == "private:hermes-agent"
+
+
+def test_list_bank_alias_private_prefix_rejected_without_private_header(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Negative control (#1669, fail-closed): naming a ``private__`` bank
+    without ``X-hal0-Private: 1`` still 400s — the alias is sugar for
+    spelling a namespace, not a bypass of the private-mode toggle that is
+    "the only path in" to the private namespace (namespace.py)."""
+    r = client.get("/api/memory/list?bank=private__hermes-agent")
+    assert r.status_code >= 400
+    assert stub_wrapper.list_calls == []
+
+
+def test_list_bank_alias_cannot_address_another_agents_private_bank(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    """Negative control (#1669, fail-closed): a private-mode caller naming
+    a DIFFERENT agent's bank via ``?bank=`` still resolves to THEIR OWN
+    bucket, never the named one — the closed-set namespace rule (module
+    docstring, ``hal0.memory.namespace``) has no escape hatch for naming
+    another agent's private bucket, by alias or otherwise. This is the
+    repro from #1669: alice requesting ``bank=private__hermes-agent``
+    must never see hermes's bucket."""
+    r = client.get(
+        "/api/memory/list?bank=private__hermes-agent",
+        headers={"X-hal0-Agent": "alice", "X-hal0-Private": "1"},
+    )
+    assert r.status_code == 200, r.text
+    call = stub_wrapper.list_calls[0]
+    assert call["dataset"] == "private:alice"
 
 
 # ── /api/memory/delete ─────────────────────────────────────────────────────

--- a/tests/memory/test_namespace_policy.py
+++ b/tests/memory/test_namespace_policy.py
@@ -95,3 +95,19 @@ def test_read_default_expansion_unchanged() -> None:
 def test_read_string_resolves_via_write_rules() -> None:
     with pytest.raises(MemoryNamespaceError, match="unknown namespace"):
         resolve_read_datasets("junk-bank", private=False, client_id="me")
+
+
+def test_read_private_rejects_missing_or_anonymous_client_id() -> None:
+    """#1669: private=True with no authenticated client_id must ALWAYS
+    raise, regardless of ``requested`` shape (None/list/string) — the
+    None-branch used to only guard with ``if private and client_id``,
+    which fell through to the "not private at all" default (shared) for
+    an unauthenticated private-mode caller instead of refusing the read.
+    Mirrors resolve_write_dataset's same guard (test above)."""
+    for cid in (None, "", "anonymous"):
+        with pytest.raises(MemoryNamespaceError, match="authenticated client_id"):
+            resolve_read_datasets(None, private=True, client_id=cid)
+        with pytest.raises(MemoryNamespaceError, match="authenticated client_id"):
+            resolve_read_datasets("shared", private=True, client_id=cid)
+        with pytest.raises(MemoryNamespaceError, match="authenticated client_id"):
+            resolve_read_datasets(["shared"], private=True, client_id=cid)


### PR DESCRIPTION
## Summary
- `memory_list` resolved its dataset through `resolve_write_dataset` instead of `resolve_read_datasets`, unlike `/search` and `/recall` — a READ route running through the WRITE-shaped resolver. Concretely this broke the documented "Identity rules mirror /search" contract: a private-mode caller with no explicit `?dataset=`/`?bank=` narrowed to their own private bucket alone instead of the `[shared, private:<agent>]` expansion `/search` gives.
- The `?bank=` alias's own worked example (`private__hermes`) was never reachable for any caller other than hermes itself — by design: the closed-set namespace policy (`hal0.memory.namespace`) only ever lets a caller address `shared`/`agents`/`project:<id>`/their OWN `private:<client_id>`, alias or not. Corrected the docstring instead of loosening that rule — loosening it would reopen exactly the "any caller can read/write arbitrary engine banks" hole the closed-set policy was built to close.
- While fixing this, found and closed a real fail-open gap in `resolve_read_datasets` itself: its empty/None-requested branch only guarded the private expansion with `if private and client_id`, so a private-mode caller with NO agent header (`client_id=None`) fell through to the same branch as "not private at all" and got the unscoped `shared` default instead of an error — the same class of silent-widening #1451 closed for the list-requested case. `resolve_write_dataset` already guarded this explicitly; `resolve_read_datasets` now does too, since `/search`/`/recall` go through it and had this gap already (unexercised until this PR's negative-control test).

## Test plan
- [x] `tests/api/test_memory_rest_routes.py` — updated `/list` private-mode-no-dataset expectation to the `[shared, private:<agent>]` expansion; 3 new cases for the `?bank=` alias (own-agent success, non-private 400, cross-agent negative control proving no privilege escalation)
- [x] `tests/memory/test_namespace_policy.py` — new case pinning `resolve_read_datasets`'s private+unauthenticated-client_id guard across all three `requested` shapes (None/list/string)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory/ tests/mcp/ tests/api/test_memory_rest_routes.py tests/security/ -x -q` — 729 passed
- [x] `uv run ruff check/format` — clean

Closes #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)