### PR TITLE
fix(settings): classify the 20 registry-gap keys, stop dropping unknown

### DIFF
--- a/src/hal0/api/_settings_apply.py
+++ b/src/hal0/api/_settings_apply.py
@@ -98,6 +98,41 @@ SERVICE_HAL0_API: str = "hal0-api"
 #   * ``[meta].schema_version``             → manual-restart (migrations
 #                                            run on next hal0-api boot
 #                                            after the value is bumped).
+#   * ``[security].{require_auth,          → immediate (api/auth.py reads
+#     trust_forwarded_for}``                  both live off hal0.toml, cached
+#                                            on (path, mtime) — a Settings
+#                                            save bumps the mtime so the very
+#                                            next request picks it up, no
+#                                            restart needed).
+#   * ``[slots].network_mode``              → service-restart[slots] (same
+#                                            "baked into the rendered
+#                                            quadlet unit" pattern as
+#                                            publish_host — existing slot
+#                                            units must be restarted to
+#                                            observe a new podman network
+#                                            mode).
+#   * ``[slots].{preload_evict_enabled,    → service-restart[hal0-api]
+#     preload_evict_headroom_mb}``           (constructor args to
+#                                            SlotManager, built once at
+#                                            create_app time).
+#   * ``[dispatcher].direct_read_timeout_s`` → service-restart[hal0-api]
+#                                            (threaded into the dispatcher
+#                                            Router at create_app time,
+#                                            same as the other two
+#                                            dispatcher knobs above).
+#   * ``[memory].unified_bank``             → service-restart[hal0-api]
+#                                            (constructor arg to
+#                                            HindsightProvider, built once
+#                                            at create_app time — same
+#                                            pattern as memory.enabled /
+#                                            memory.engine above).
+#   * ``[realtime].*``                      → immediate (routes/realtime.py
+#                                            reads ``app.state.hal0_config
+#                                            .realtime`` fresh on every WS
+#                                            connect; the settings PUT
+#                                            refreshes app.state.hal0_config
+#                                            in place, same as brain_chat.*
+#                                            above — no restart needed).
 #
 # Nested field names are written dot-notation (``slots.max_slots``)
 # because the registry is keyed off the path the PUT body uses. The
@@ -188,6 +223,46 @@ _HAL0_REGISTRY: dict[str, ApplyPlanEntry] = {
     "brain_chat.completion_timeout_s": {"apply_class": "immediate", "services": []},
     # [meta]
     "meta.schema_version": {"apply_class": "manual-restart", "services": []},
+    # [security] — both toggles are read live off hal0.toml with an
+    # (path, mtime) cache in api/auth.py; a Settings save rewrites the
+    # file (bumping mtime), so the very next request observes the change.
+    "security.require_auth": {"apply_class": "immediate", "services": []},
+    "security.trust_forwarded_for": {"apply_class": "immediate", "services": []},
+    # [slots] — network_mode is baked into each slot's rendered quadlet
+    # unit the same way publish_host is; preload_evict_* are SlotManager
+    # constructor args fixed at create_app time.
+    "slots.network_mode": {"apply_class": "service-restart", "services": [SERVICE_SLOTS]},
+    "slots.preload_evict_enabled": {
+        "apply_class": "service-restart",
+        "services": [SERVICE_HAL0_API],
+    },
+    "slots.preload_evict_headroom_mb": {
+        "apply_class": "service-restart",
+        "services": [SERVICE_HAL0_API],
+    },
+    # [dispatcher] — same create_app-time wiring as the other two entries.
+    "dispatcher.direct_read_timeout_s": {
+        "apply_class": "service-restart",
+        "services": [SERVICE_HAL0_API],
+    },
+    # [memory] — HindsightProvider constructor arg, built once at boot.
+    "memory.unified_bank": {"apply_class": "service-restart", "services": [SERVICE_HAL0_API]},
+    # [realtime] — every key is read live off app.state.hal0_config.realtime
+    # on each WS connect (routes/realtime.py), which the settings PUT
+    # refreshes in place, so all of them apply immediately.
+    "realtime.enabled": {"apply_class": "immediate", "services": []},
+    "realtime.sample_rate": {"apply_class": "immediate", "services": []},
+    "realtime.default_model": {"apply_class": "immediate", "services": []},
+    "realtime.stt_model": {"apply_class": "immediate", "services": []},
+    "realtime.tts_model": {"apply_class": "immediate", "services": []},
+    "realtime.tts_voice": {"apply_class": "immediate", "services": []},
+    "realtime.vad_energy_threshold": {"apply_class": "immediate", "services": []},
+    "realtime.vad_silence_ms": {"apply_class": "immediate", "services": []},
+    "realtime.vad_min_speech_ms": {"apply_class": "immediate", "services": []},
+    "realtime.vad_window_ms": {"apply_class": "immediate", "services": []},
+    "realtime.frame_ms": {"apply_class": "immediate", "services": []},
+    "realtime.approval_wait_s": {"apply_class": "immediate", "services": []},
+    "realtime.max_buffer_seconds": {"apply_class": "immediate", "services": []},
 }
 
 

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -39,7 +39,7 @@ from fastapi import APIRouter, Request
 from pydantic import ValidationError
 
 from hal0.api._redact import redact_config
-from hal0.api._settings_apply import APPLY_CLASSES, REGISTRY, apply_plan, get_registry
+from hal0.api._settings_apply import APPLY_CLASSES, apply_plan, get_registry
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config.loader import load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
@@ -186,9 +186,15 @@ async def update_settings(request: Request) -> dict[str, Any]:
     # normal nested PUT ({"slots": {"max_slots": 4}}) previously produced
     # an all-empty plan because only top-level body keys were matched
     # against the registry, so the UI's restart hint never fired for
-    # generic-endpoint edits. Keys the registry doesn't know stay out of
-    # the list (they'd land in "unknown"; section names and forward-compat
-    # extras aren't actionable).
+    # generic-endpoint edits.
+    #
+    # Every touched leaf goes to apply_plan() unfiltered — a key the
+    # registry doesn't know about lands in ApplyPlanResult.unknown rather
+    # than being silently dropped here. Pre-filtering with `if k in
+    # REGISTRY` made `unknown` structurally always `[]` on this route,
+    # contradicting the documented contract on ApplyPlanResult (the UI is
+    # supposed to render an informational chip for a gap key instead of
+    # guessing at its class).
     def _dotted_leaf_keys(node: dict[str, Any], prefix: str = "") -> list[str]:
         out: list[str] = []
         for k, v in node.items():
@@ -199,9 +205,9 @@ async def update_settings(request: Request) -> dict[str, Any]:
                 out.append(path)
         return out
 
-    touched_registry_keys = [k for k in _dotted_leaf_keys(body) if k in REGISTRY]
+    touched_keys = _dotted_leaf_keys(body)
     config_view = _config_to_dict(merged)
-    config_view["_hal0"] = {"apply_plan": apply_plan(touched_registry_keys)}
+    config_view["_hal0"] = {"apply_plan": apply_plan(touched_keys)}
     return config_view
 
 

--- a/tests/api/test_settings_apply.py
+++ b/tests/api/test_settings_apply.py
@@ -101,6 +101,36 @@ def test_registry_declares_three_apply_classes() -> None:
         ("activity.max_rows", "service-restart", [SERVICE_HAL0_API]),
         # [meta]
         ("meta.schema_version", "manual-restart", []),
+        # [security] — both read live off hal0.toml, (path, mtime)-cached
+        # in api/auth.py; a Settings save bumps mtime so the next request
+        # picks it up.
+        ("security.require_auth", "immediate", []),
+        ("security.trust_forwarded_for", "immediate", []),
+        # [slots] — network_mode is baked into the rendered quadlet unit
+        # like publish_host; preload_evict_* are SlotManager constructor
+        # args fixed at create_app time.
+        ("slots.network_mode", "service-restart", [SERVICE_SLOTS]),
+        ("slots.preload_evict_enabled", "service-restart", [SERVICE_HAL0_API]),
+        ("slots.preload_evict_headroom_mb", "service-restart", [SERVICE_HAL0_API]),
+        # [dispatcher] — same create_app-time wiring as the other two knobs.
+        ("dispatcher.direct_read_timeout_s", "service-restart", [SERVICE_HAL0_API]),
+        # [memory] — HindsightProvider constructor arg, built once at boot.
+        ("memory.unified_bank", "service-restart", [SERVICE_HAL0_API]),
+        # [realtime] — read live off app.state.hal0_config.realtime on
+        # every WS connect; the settings PUT refreshes app.state in place.
+        ("realtime.enabled", "immediate", []),
+        ("realtime.sample_rate", "immediate", []),
+        ("realtime.default_model", "immediate", []),
+        ("realtime.stt_model", "immediate", []),
+        ("realtime.tts_model", "immediate", []),
+        ("realtime.tts_voice", "immediate", []),
+        ("realtime.vad_energy_threshold", "immediate", []),
+        ("realtime.vad_silence_ms", "immediate", []),
+        ("realtime.vad_min_speech_ms", "immediate", []),
+        ("realtime.vad_window_ms", "immediate", []),
+        ("realtime.frame_ms", "immediate", []),
+        ("realtime.approval_wait_s", "immediate", []),
+        ("realtime.max_buffer_seconds", "immediate", []),
     ],
 )
 def test_registry_hal0_keys_have_expected_class(
@@ -350,6 +380,27 @@ def test_put_settings_apply_plan_flattens_nested_keys(
     assert plan["service_restart"] == {"hal0-api": ["slots.idle_timeout_s"]}
     assert plan["manual_restart"] == []
     assert plan["unknown"] == []
+
+
+def test_put_settings_surfaces_unknown_keys(isolated_client: TestClient) -> None:
+    """A touched key the registry has no class for must land in the PUT
+    response's ``unknown`` bucket, not be silently dropped (issue #1666).
+
+    ``update_settings`` used to pre-filter the touched-key list with
+    ``if k in REGISTRY`` before calling ``apply_plan``, so
+    ``ApplyPlanResult.unknown`` was structurally always ``[]`` on this
+    route -- contradicting the documented contract that the route
+    "surfaces the list verbatim" for the UI's informational chip.
+    ``Hal0Config`` has ``extra="allow"`` at the top level, so a
+    forward-compat key validates fine but has no registry row."""
+    r = isolated_client.put(
+        "/api/settings",
+        json={"telemetry": {"enabled": True}, "totally_new_field": {"foo": "bar"}},
+    )
+    assert r.status_code == 200, r.text
+    plan = r.json()["_hal0"]["apply_plan"]
+    assert plan["immediate"] == ["telemetry.enabled"]
+    assert plan["unknown"] == ["totally_new_field.foo"]
 
 
 def test_put_settings_response_preserves_existing_top_level_shape(


### PR DESCRIPTION
## Summary
- `security.require_auth`, `security.trust_forwarded_for`, `slots.network_mode`, `slots.preload_evict_{enabled,headroom_mb}`, `dispatcher.direct_read_timeout_s`, `memory.unified_bank`, and all 12 `realtime.*` keys had no `ApplyPlanEntry`, so a settings write touching any of them rendered no reload-class badge. Classified each against how it's actually consumed:
  - `security.*` / `realtime.*` → `immediate` (both read live off `app.state.hal0_config` / an mtime-cached `hal0.toml` read — verified in `api/auth.py` and `api/routes/realtime.py`, no restart needed).
  - `slots.network_mode` → `service-restart[slots]` (baked into the rendered quadlet unit at slot-render time, same pattern as `publish_host` — verified in `providers/container.py`).
  - `slots.preload_evict_*`, `dispatcher.direct_read_timeout_s`, `memory.unified_bank` → `service-restart[hal0-api]` (constructor args fixed at `create_app` time — verified in `api/__init__.py`).
- Separately, `update_settings` pre-filtered the touched-key list with `if k in REGISTRY` before calling `apply_plan()`, so `ApplyPlanResult.unknown` was structurally always `[]` on the PUT route — contradicting the documented contract that the route "surfaces the list verbatim" so the UI can render an informational chip for a gap key. Removed the pre-filter; `apply_plan()` now sees every touched leaf and classifies or reports it.

## Test plan
- [x] `tests/api/test_settings_apply.py` — 20 new registry-classification cases + `test_put_settings_surfaces_unknown_keys` (a forward-compat top-level key now lands in `unknown` instead of being silently dropped)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/ -k settings -x -q` — 87 passed
- [x] `uv run ruff check/format`, `scripts/check_sunset.py` — clean

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)