### PR TITLE
fix(updater): treat a signal-killed self-restart as ambiguous, not failed

### DIFF
--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -261,7 +261,7 @@ def _load_persisted_job(job_id: str) -> dict[str, Any] | None:
     return loaded if isinstance(loaded, dict) else None
 
 
-def _try_restart_hal0_api() -> tuple[bool, str | None]:
+def _try_restart_hal0_api() -> tuple[bool | None, str | None]:
     """``systemctl try-restart hal0-api.service`` - fail-soft.
 
     Returns ``(restarted, error)``. No-ops cleanly when ``systemctl`` is
@@ -274,6 +274,19 @@ def _try_restart_hal0_api() -> tuple[bool, str | None]:
     (installer/wrappers/hal0-systemctl) instead of a direct
     ``systemctl try-restart`` (dev/tests/a pre-flip install keep the direct
     call, unchanged). See :mod:`hal0.system.seam`.
+
+    #1691, same incident class as #1548: the restart-self wrapper already
+    passes ``--no-block`` so ``systemctl`` itself returns as soon as the
+    restart is QUEUED, without waiting for the old unit to stop. But that
+    ``sudo``/``systemctl`` call is still a CHILD of this process, hence
+    still inside hal0-api.service's own cgroup — systemd can start tearing
+    the old unit down (SIGTERMing the whole cgroup, this child included)
+    before the queued call finishes exiting cleanly. A signal-killed
+    ``returncode`` (negative) here is therefore ambiguous, not a definite
+    failure: it can BE the restart succeeding, reaping its own caller mid
+    flight. Report ``restarted=None`` for it — the same "terminal, bounce
+    still in flight" state #1548 introduced for the job level — rather than
+    ``False``, which the CLI treats as a real failure and warns on.
     """
     systemctl = shutil.which("systemctl")
     if not systemctl:
@@ -297,6 +310,10 @@ def _try_restart_hal0_api() -> tuple[bool, str | None]:
     except (OSError, subprocess.SubprocessError) as exc:
         log.warning("updater.restart_errored", error=str(exc))
         return (False, str(exc))
+    if proc.returncode < 0:
+        err = (proc.stderr or "").strip()[:300] or f"systemctl exited {proc.returncode}"
+        log.info("updater.restart_signalled", returncode=proc.returncode, stderr=err)
+        return (None, err)
     if proc.returncode != 0:
         err = (proc.stderr or "").strip()[:300] or f"systemctl exited {proc.returncode}"
         log.warning("updater.restart_nonzero", returncode=proc.returncode, stderr=err)

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -670,6 +670,54 @@ def test_apply_success_restart_failure_is_fail_soft(
     assert final.get("restart_error")
 
 
+def test_apply_restart_sigterm_is_ambiguous_not_failed(
+    isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1691: a signal-killed restart call reports restarted=None, not False.
+
+    --no-block (#1540) makes systemctl return as soon as the restart is
+    QUEUED, but that systemctl call is still a child of hal0-api's own
+    process -- still inside hal0-api.service's cgroup -- so systemd tearing
+    the old unit down can SIGTERM it before it exits cleanly. That negative
+    returncode can BE the restart succeeding (it killed its own caller mid
+    flight), so it must land as the same 'terminal, bounce still in flight'
+    None the job level already uses, not a definite restarted=False -- the
+    CLI only warns on False, and a successful update reporting
+    'systemctl exited -15' as a failure is the exact bug this closes.
+    """
+    from hal0.api.routes import updater as u_mod
+
+    async def fake_apply(self: object, version: str | None = None) -> dict:
+        return {"version": "0.0.9"}
+
+    monkeypatch.setattr(u_mod.Updater, "apply", fake_apply)
+
+    def signalled_run(cmd: list[str], *a: object, **k: object) -> object:
+        class _R:
+            returncode = -15  # SIGTERM
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(u_mod.subprocess, "run", signalled_run)
+
+    r = isolated_client.post("/api/updates/apply", json={})
+    job_id = r.json()["id"]
+
+    deadline = time.monotonic() + 6.0
+    final: dict = {}
+    while time.monotonic() < deadline:
+        final = isolated_client.get(f"/api/updates/status/{job_id}").json()
+        if final["state"] == "failed" or final.get("restart_error"):
+            break
+        time.sleep(0.05)
+
+    assert final.get("state") == "applied", final
+    assert final.get("restarted") is None
+    assert final.get("restart_error")
+
+
 def test_apply_target_strips_leading_v(
     isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `_try_restart_hal0_api`'s self-restart path (`sudo -n hal0-systemctl restart-self`) already passes `--no-block` (#1548/#1540), so `systemctl` returns as soon as the restart is QUEUED, without waiting for the old unit to stop. But that `sudo`/`systemctl` call is still a CHILD of this process, hence still inside `hal0-api.service`'s own cgroup — systemd can start tearing the old unit down (SIGTERMing the whole cgroup, this child included) before the queued call finishes exiting cleanly.
- A negative returncode here is therefore ambiguous, not a definite failure: it can BE the restart succeeding, reaping its own caller mid-flight. Same incident class as #1548, one layer deeper.
- Report `restarted=None` for a signal-killed restart call — the same "terminal, bounce still in flight" state #1548 introduced at the job level — instead of `False`, which the CLI treats as a real failure and warns on. A successful rc.1 → rc.2 update on CT150 printed `hal0-api restart did not complete: systemctl exited -15` despite the update (and the restart) actually succeeding.

## Test plan
- [x] `test_apply_restart_sigterm_is_ambiguous_not_failed` (new) — a `returncode=-15` restart call resolves to `restarted=None`, not `False`
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/test_updater_routes.py tests/cli/ -x -q` — 722 passed
- [x] `uv run ruff check/format`, `scripts/check_sunset.py` — clean

Closes #1691

🤖 Generated with [Claude Code](https://claude.com/claude-code)