### PR TITLE
docs(readme): flip docs/README.md to match the reversed hal0->hal0-web mirror

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,18 @@ This directory has two halves:
 
 ## Top-level `docs/*.mdx` — user docs
 
-A **mirror** of the documentation published at <https://hal0.dev/docs/>.
-The canonical source is `Hal0ai/hal0-web` (Starlight, Astro) and a GitHub
-Action there auto-pushes updates into this folder whenever
-`src/content/docs/docs/**` changes on `hal0-web/main`.
+The **canonical source** of the documentation published at
+<https://hal0.dev/docs/>. `.github/workflows/mirror-docs.yml` pushes the
+published sections (`getting-started/`, `concepts/`, `guides/`,
+`operate/`, `reference/`) from here into `Hal0ai/hal0-web`
+(`src/content/docs/docs/**`, Starlight/Astro) on every push to `main` —
+the direction was reversed by #1622; `hal0-web` used to be the source and
+mirror into this repo, but is now the generated copy.
 
-**Do not hand-edit these files in `Hal0ai/hal0`.** Any commit landing
-here will be overwritten on the next upstream sync. Edit the source in
-`hal0-web` instead.
+**Edit these files here, in `Hal0ai/hal0`.** Hand-editing the mirrored
+copy in `hal0-web` is pointless: the next push to `hal0/main` touching a
+published section `rsync --delete`s that section on the web side and
+silently discards the change.
 
 The `.mdx` extension is preserved verbatim — the files import Starlight
 components (`Card`, `Tabs`, `Steps`, …) that only render inside the


### PR DESCRIPTION
## Summary
- #1622 reversed `mirror-docs.yml` to push `hal0/docs/**` → `hal0-web`, making `hal0` the source of truth for the published docs sections. `docs/README.md` was never updated and still said the opposite: `hal0-web` canonical, `hal0/docs/*.mdx` a generated mirror not to be hand-edited.
- A contributor following those stale instructions edits `hal0-web` instead of `hal0/docs`, and the next `mirror-docs` run `rsync --delete`s the section from `hal0-web`'s live docs, silently discarding their change.
- Corrected the top-level user-docs section to describe the current direction and named the actual synced sections/workflow.

## Test plan
- [x] Read-only doc fix — no code paths affected. Verified `mirror-docs.yml`'s direction and section list match the new wording.

Closes #1648

🤖 Generated with [Claude Code](https://claude.com/claude-code)