### PR TITLE
fix(memory): reconcile drop-in drift, survive cancellation, share the toml lock

### DIFF
--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -494,36 +494,44 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
         slot_changed = new_cfg.extraction_slot != cfg.memory.graph.extraction_slot
         timeout_changed = new_cfg.llm_timeout_s != cfg.memory.graph.llm_timeout_s
 
-        # Whether this PUT needs to propagate to hindsight-api: an explicit
-        # slot/timeout change, or (#1682 review) the on-disk drop-in has
-        # drifted from what hal0.toml already claims to be running — a host
-        # stuck in the pre-seam-bug broken state (toml already says slot A,
-        # drop-in never written) must still reconcile on the next PUT of its
-        # unchanged slot, not no-op on config equality. Computed here (a pure
-        # read, no side effects) so the validation below can cover it too.
-        needs_propagation = slot_changed or timeout_changed
-        if not needs_propagation:
-            from hal0.memory.extraction_env import drop_in_matches
-
-            needs_propagation = not drop_in_matches(new_cfg.extraction_slot, new_cfg.llm_timeout_s)
-
-        # Validate extraction_slot against the live slot set whenever it is
-        # about to be applied to hindsight-api — reject an unknown / non-llm
-        # slot with the valid options so the gate never flips onto (or, via
-        # reconciliation, restarts hindsight-api onto) a target that can't
-        # serve extraction. Covers BOTH an explicit change AND a
-        # reconciliation propagation (#1717 review): an unrelated PUT like
-        # {"enabled": true} with slot_changed=False must not silently
-        # restart hindsight-api onto a slot that's since been
-        # deleted/disabled just because the on-disk drop-in also happened
-        # to be stale.
-        if slot_changed or needs_propagation:
+        # Validate an EXPLICIT slot change against the live slot set —
+        # reject an unknown / non-llm slot with the valid options so the
+        # gate never flips onto a target that can't serve extraction.
+        if slot_changed:
             available = await _enabled_llm_slots(request)
             if available and new_cfg.extraction_slot not in available:
                 raise MemoryGraphSlotInvalid(
                     f"extraction_slot {new_cfg.extraction_slot!r} is not an enabled llm slot",
                     details={"available_slots": ", ".join(available)},
                 )
+
+        # Whether this PUT needs to propagate to hindsight-api: an explicit
+        # slot/timeout change, or (#1682 review) the on-disk drop-in has
+        # drifted from what hal0.toml already claims to be running — a host
+        # stuck in the pre-seam-bug broken state (toml already says slot A,
+        # drop-in never written) must still reconcile on the next PUT of its
+        # unchanged slot, not no-op on config equality.
+        #
+        # Reconciliation only runs while the gate is meant to be enabled
+        # (#1717 review): a bare {"enabled": false} must always be able to
+        # disable, even with a stale/deleted configured slot — disabling
+        # doesn't need the (unchanged) slot to be valid.
+        needs_propagation = slot_changed or timeout_changed
+        if not needs_propagation and new_cfg.enabled:
+            from hal0.memory.extraction_env import drop_in_matches
+
+            if not drop_in_matches(new_cfg.extraction_slot, new_cfg.llm_timeout_s):
+                # Reconciliation is inferred work we chose to do ourselves,
+                # not an explicit operator action — only do it when we can
+                # POSITIVELY confirm the unchanged slot is still valid
+                # (#1717 review). An empty/unknown available set (no slots
+                # enabled, or enumeration failed) means we can't tell, and
+                # forcing a restart onto an unverifiable slot could replace
+                # a possibly-still-working drop-in with a broken one; skip
+                # reconciliation instead of erroring this — often
+                # unrelated — request.
+                available = await _enabled_llm_slots(request)
+                needs_propagation = new_cfg.extraction_slot in available
 
         # Flip the live wrapper's reported state BEFORE persisting.
         try:

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -19,6 +19,7 @@ veneer that:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 from typing import Any
@@ -432,6 +433,12 @@ async def _propagate_shielded(slot: str, timeout_s: int) -> dict[str, Any]:
     the *caller's* await is cancelled anyway, wait out the (already-running,
     un-cancellable) worker before re-raising — so the lock is held for the
     worker's true lifetime, not just until the first cancellation.
+
+    That cleanup wait is ALSO shielded, in a loop (#1717 review): a second
+    cancellation arriving while we're waiting out the first one (e.g. a
+    request timeout followed by server shutdown) must not re-propagate
+    early either — an unshielded ``await task`` there would exit and
+    release the lock exactly like the bug this function exists to close.
     """
     from hal0.memory.extraction_env import apply_extraction_slot
 
@@ -441,7 +448,9 @@ async def _propagate_shielded(slot: str, timeout_s: int) -> dict[str, Any]:
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        await task
+        while not task.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.shield(task)
         raise
 
 
@@ -482,12 +491,33 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
                 details=_validation_error_details(exc),
             ) from exc
 
-        # Validate extraction_slot against the live slot set when it is being
-        # changed — reject an unknown / non-llm slot with the valid options so
-        # the gate never flips onto a target that can't serve extraction.
         slot_changed = new_cfg.extraction_slot != cfg.memory.graph.extraction_slot
         timeout_changed = new_cfg.llm_timeout_s != cfg.memory.graph.llm_timeout_s
-        if slot_changed:
+
+        # Whether this PUT needs to propagate to hindsight-api: an explicit
+        # slot/timeout change, or (#1682 review) the on-disk drop-in has
+        # drifted from what hal0.toml already claims to be running — a host
+        # stuck in the pre-seam-bug broken state (toml already says slot A,
+        # drop-in never written) must still reconcile on the next PUT of its
+        # unchanged slot, not no-op on config equality. Computed here (a pure
+        # read, no side effects) so the validation below can cover it too.
+        needs_propagation = slot_changed or timeout_changed
+        if not needs_propagation:
+            from hal0.memory.extraction_env import drop_in_matches
+
+            needs_propagation = not drop_in_matches(new_cfg.extraction_slot, new_cfg.llm_timeout_s)
+
+        # Validate extraction_slot against the live slot set whenever it is
+        # about to be applied to hindsight-api — reject an unknown / non-llm
+        # slot with the valid options so the gate never flips onto (or, via
+        # reconciliation, restarts hindsight-api onto) a target that can't
+        # serve extraction. Covers BOTH an explicit change AND a
+        # reconciliation propagation (#1717 review): an unrelated PUT like
+        # {"enabled": true} with slot_changed=False must not silently
+        # restart hindsight-api onto a slot that's since been
+        # deleted/disabled just because the on-disk drop-in also happened
+        # to be stale.
+        if slot_changed or needs_propagation:
             available = await _enabled_llm_slots(request)
             if available and new_cfg.extraction_slot not in available:
                 raise MemoryGraphSlotInvalid(
@@ -520,20 +550,7 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
         # Propagate the extraction slot + LLM timeout to hindsight-api (drop-in
         # + restart) so the engine's native extraction LLM follows the choice.
-        needs_propagation = slot_changed or timeout_changed
-        if not needs_propagation:
-            from hal0.memory.extraction_env import drop_in_matches
-
-            # #1682 review: hal0.toml equality alone is not enough to skip
-            # propagation. A host hit by the pre-seam write bug (or any other
-            # silent failure) can already have hal0.toml recording this exact
-            # slot while hindsight-api's drop-in was never actually written
-            # or still names a different target — re-requesting the
-            # unchanged value must still reconcile instead of no-op'ing on
-            # config equality. The drop-in is 0644 root:root (#1641), so this
-            # is a plain unprivileged read, not a seam round trip.
-            needs_propagation = not drop_in_matches(new_cfg.extraction_slot, new_cfg.llm_timeout_s)
-
+        # ``needs_propagation`` was already computed (and validated) above.
         propagation: dict[str, Any] | None = None
         if needs_propagation:
             # Thread hop (#1641): the propagation shells out to the privileged

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -28,7 +28,7 @@ from pydantic import ValidationError
 
 from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
-from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.loader import HAL0_TOML_LOCK, load_hal0_config, save_hal0_config
 from hal0.config.schema import MemoryGraphConfig
 from hal0.memory.hindsight_provider import bank_to_namespace
 from hal0.memory.namespace import (
@@ -414,13 +414,35 @@ async def retry_failed_extractions(request: Request) -> dict[str, Any]:
 
 # ── PUT /api/memory/graph ──────────────────────────────────────────────────
 
-#: Serializes the graph-config read-modify-write. The propagation awaits a
-#: ~60s hindsight-api restart (#1641), so without this two concurrent PUTs
-#: could interleave — one writing slot A's drop-in, the other overwriting it
-#: with B, and the first still persisting A into ``hal0.toml`` afterwards,
-#: leaving the recorded config and the running daemon on different slots.
-#: hal0-api is the only writer of either, so one in-process lock is enough.
-_GRAPH_CONFIG_LOCK = asyncio.Lock()
+
+async def _propagate_shielded(slot: str, timeout_s: int) -> dict[str, Any]:
+    """Propagate an extraction-slot/timeout change, safe against cancellation.
+
+    ``asyncio.to_thread`` submits :func:`~hal0.memory.extraction_env.apply_extraction_slot`
+    to a real OS thread; cancelling the awaiting coroutine (client disconnect,
+    shutdown, request timeout) does NOT stop that thread — it just makes the
+    ``await`` raise early while the write/restart keeps running in the
+    background. This is called from inside :data:`HAL0_TOML_LOCK`'s critical
+    section (#1682 review): an early return there would release the lock
+    while the orphaned worker could still clobber the drop-in, letting a
+    second PUT's propagation interleave with it — one write wins the drop-in,
+    the other wins ``hal0.toml``, and they can disagree.
+
+    Shield the wait so the underlying task is never itself cancelled, and if
+    the *caller's* await is cancelled anyway, wait out the (already-running,
+    un-cancellable) worker before re-raising — so the lock is held for the
+    worker's true lifetime, not just until the first cancellation.
+    """
+    from hal0.memory.extraction_env import apply_extraction_slot
+
+    task = asyncio.ensure_future(
+        asyncio.to_thread(apply_extraction_slot, slot, timeout_s=timeout_s)
+    )
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
 
 
 @router.put("/graph")
@@ -447,7 +469,7 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
     wrapper = _wrapper(request)
 
-    async with _GRAPH_CONFIG_LOCK:
+    async with HAL0_TOML_LOCK:
         cfg = load_hal0_config()
         current_raw = cfg.memory.graph.model_dump(mode="python")
         merged_raw = {**current_raw, **body}
@@ -498,19 +520,29 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
         # Propagate the extraction slot + LLM timeout to hindsight-api (drop-in
         # + restart) so the engine's native extraction LLM follows the choice.
-        propagation: dict[str, Any] | None = None
-        if slot_changed or timeout_changed:
-            from hal0.memory.extraction_env import apply_extraction_slot
+        needs_propagation = slot_changed or timeout_changed
+        if not needs_propagation:
+            from hal0.memory.extraction_env import drop_in_matches
 
+            # #1682 review: hal0.toml equality alone is not enough to skip
+            # propagation. A host hit by the pre-seam write bug (or any other
+            # silent failure) can already have hal0.toml recording this exact
+            # slot while hindsight-api's drop-in was never actually written
+            # or still names a different target — re-requesting the
+            # unchanged value must still reconcile instead of no-op'ing on
+            # config equality. The drop-in is 0644 root:root (#1641), so this
+            # is a plain unprivileged read, not a seam round trip.
+            needs_propagation = not drop_in_matches(new_cfg.extraction_slot, new_cfg.llm_timeout_s)
+
+        propagation: dict[str, Any] | None = None
+        if needs_propagation:
             # Thread hop (#1641): the propagation shells out to the privileged
             # seam and then waits on a hindsight-api restart — a bounded but
             # multi-second blocking call that would otherwise stall the whole
-            # event loop for the engine's cold start.
-            propagation = await asyncio.to_thread(
-                apply_extraction_slot,
-                new_cfg.extraction_slot,
-                timeout_s=new_cfg.llm_timeout_s,
-            )
+            # event loop for the engine's cold start. Shielded against
+            # cancellation (see _propagate_shielded) so this lock's critical
+            # section can't be exited early while the worker is still live.
+            propagation = await _propagate_shielded(new_cfg.extraction_slot, new_cfg.llm_timeout_s)
 
         out = new_cfg.model_dump(mode="json")
         # Echo the live status so the dashboard's optimistic-update path

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -41,7 +41,7 @@ from pydantic import ValidationError
 from hal0.api._redact import redact_config
 from hal0.api._settings_apply import APPLY_CLASSES, REGISTRY, apply_plan, get_registry
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
-from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.loader import HAL0_TOML_LOCK, load_hal0_config, save_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.registry.model_store import (
     MigrationPlan,
@@ -137,30 +137,36 @@ async def update_settings(request: Request) -> dict[str, Any]:
     if not isinstance(body, dict):
         raise Hal0Error("request body must be a JSON object")
 
-    current = getattr(request.app.state, "hal0_config", None)
-    if current is None:
-        current = load_hal0_config()
+    # Shared with routes/memory.py's PUT /graph (#1682 review): that route
+    # can hold its own critical section across a ~60s extraction-slot
+    # propagation, and without a lock SHARED across both routes this save
+    # could land mid-flight, persisting a config snapshot taken before the
+    # propagation started and clobbering the graph section it just wrote.
+    async with HAL0_TOML_LOCK:
+        current = getattr(request.app.state, "hal0_config", None)
+        if current is None:
+            current = load_hal0_config()
 
-    merged_raw = _deep_merge(current.model_dump(mode="python"), body)
+        merged_raw = _deep_merge(current.model_dump(mode="python"), body)
 
-    try:
-        merged = Hal0Config.model_validate(merged_raw)
-    except ValidationError as exc:
-        raise ConfigInvalidError(
-            "hal0 config failed schema validation",
-            details=_validation_error_details(exc),
-        ) from exc
+        try:
+            merged = Hal0Config.model_validate(merged_raw)
+        except ValidationError as exc:
+            raise ConfigInvalidError(
+                "hal0 config failed schema validation",
+                details=_validation_error_details(exc),
+            ) from exc
 
-    # Atomic write via the loader's write_toml_atomic-backed helper.
-    try:
-        save_hal0_config(merged)
-    except OSError as exc:
-        raise Hal0Error(
-            f"could not persist hal0 config: {exc}",
-            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
-        ) from exc
+        # Atomic write via the loader's write_toml_atomic-backed helper.
+        try:
+            save_hal0_config(merged)
+        except OSError as exc:
+            raise Hal0Error(
+                f"could not persist hal0 config: {exc}",
+                details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+            ) from exc
 
-    request.app.state.hal0_config = merged
+        request.app.state.hal0_config = merged
     event_bus = getattr(request.app.state, "events", None)
     if event_bus is not None:
         # Surface a footer chip when the operator saves the config. The

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -143,9 +143,15 @@ async def update_settings(request: Request) -> dict[str, Any]:
     # could land mid-flight, persisting a config snapshot taken before the
     # propagation started and clobbering the graph section it just wrote.
     async with HAL0_TOML_LOCK:
-        current = getattr(request.app.state, "hal0_config", None)
-        if current is None:
-            current = load_hal0_config()
+        # Always reload from disk here (#1717 review), never trust
+        # ``app.state.hal0_config`` — the graph route saves its section
+        # straight to disk without updating that cache, so a settings PUT
+        # that waited behind a graph PUT would otherwise resume on the
+        # STALE cached snapshot, merge its own (unrelated) patch into it,
+        # and overwrite the graph section the preceding request just wrote.
+        # One extra read under an already-held lock is cheap; a lost write
+        # is not.
+        current = load_hal0_config()
 
         merged_raw = _deep_merge(current.model_dump(mode="python"), body)
 

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -15,6 +15,7 @@ See PLAN.md §3 and §5 Tier 1.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -204,6 +205,18 @@ def load_hal0_config(path: Path | None = None) -> Hal0Config:
             f"failed to validate hal0 config at {target}: {exc}",
             details={"path": str(target), "reason": str(exc)},
         ) from exc
+
+
+#: Serializes concurrent hal0.toml read-modify-write across API routes
+#: (routes/settings.py's ``PUT /api/settings``, routes/memory.py's
+#: ``PUT /api/memory/graph``). One in-process lock is sufficient — hal0-api
+#: is the only writer process. A per-route lock is not enough on its own
+#: (#1682 review): the memory/graph route holds its critical section across
+#: a multi-second-to-~60s extraction-slot propagation, and without a SHARED
+#: lock an unrelated settings save can land mid-flight, persisting a config
+#: snapshot taken before the propagation started and clobbering the section
+#: it just wrote.
+HAL0_TOML_LOCK: asyncio.Lock = asyncio.Lock()
 
 
 def save_hal0_config(cfg: Hal0Config, path: Path | None = None) -> None:

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -118,6 +118,27 @@ def render_drop_in(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> str:
     return _DROP_IN_TEMPLATE.format(slot=slot, timeout_s=int(timeout_s))
 
 
+def drop_in_matches(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> bool:
+    """True when the on-disk drop-in already reflects ``(slot, timeout_s)``.
+
+    #1682 review: comparing only against ``hal0.toml`` is not enough to
+    decide propagation is unnecessary. A host hit by the pre-seam write bug
+    (or any other silent failure) can have ``hal0.toml`` already recording
+    this exact slot while the drop-in was never actually written or still
+    names something else — re-requesting the *same* slot would then never
+    reconcile.
+
+    The drop-in is 0644 root:root (world-readable, #1641), so this is a
+    plain, unprivileged read — no seam round trip. Any read failure (missing
+    file on a fresh install or a host that never propagated, a permission
+    oddity) counts as "does not match": propagate.
+    """
+    try:
+        return DROP_IN_PATH.read_text() == render_drop_in(slot, timeout_s)
+    except OSError:
+        return False
+
+
 def apply_extraction_slot(
     slot: str,
     *,
@@ -191,4 +212,4 @@ def apply_extraction_slot(
     return result
 
 
-__all__ = ["DROP_IN_PATH", "apply_extraction_slot", "render_drop_in"]
+__all__ = ["DROP_IN_PATH", "apply_extraction_slot", "drop_in_matches", "render_drop_in"]

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -131,11 +131,15 @@ def drop_in_matches(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> bool:
     The drop-in is 0644 root:root (world-readable, #1641), so this is a
     plain, unprivileged read — no seam round trip. Any read failure (missing
     file on a fresh install or a host that never propagated, a permission
-    oddity) counts as "does not match": propagate.
+    oddity, or — #1717 review — undecodable bytes from manual tampering or a
+    locale mismatch, which ``Path.read_text()`` raises as a
+    ``UnicodeDecodeError`` rather than an ``OSError``) counts as "does not
+    match": propagate and let the atomic rewrite repair it, instead of an
+    otherwise-idempotent PUT 500ing.
     """
     try:
         return DROP_IN_PATH.read_text() == render_drop_in(slot, timeout_s)
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return False
 
 

--- a/src/hal0/memory/extraction_env.py
+++ b/src/hal0/memory/extraction_env.py
@@ -129,16 +129,20 @@ def drop_in_matches(slot: str, timeout_s: int = DEFAULT_LLM_TIMEOUT_S) -> bool:
     reconcile.
 
     The drop-in is 0644 root:root (world-readable, #1641), so this is a
-    plain, unprivileged read — no seam round trip. Any read failure (missing
-    file on a fresh install or a host that never propagated, a permission
-    oddity, or — #1717 review — undecodable bytes from manual tampering or a
-    locale mismatch, which ``Path.read_text()`` raises as a
-    ``UnicodeDecodeError`` rather than an ``OSError``) counts as "does not
-    match": propagate and let the atomic rewrite repair it, instead of an
-    otherwise-idempotent PUT 500ing.
+    plain, unprivileged read — no seam round trip. Read as explicit UTF-8
+    (#1717 review): the file is always written UTF-8 by
+    :class:`~hal0.system.seam.SystemCtlSeam`, and the template's em dash
+    would otherwise be locale-dependent — under e.g. ``LC_ALL=C`` a bare
+    ``Path.read_text()`` can fail to decode a byte-for-byte correct file,
+    misreporting a healthy drop-in as drift on every enabled graph PUT.
+    Any read failure (missing file on a fresh install or a host that never
+    propagated, a permission oddity, or genuinely undecodable content —
+    ``Path.read_text()`` raises ``UnicodeDecodeError``, not ``OSError``)
+    counts as "does not match": propagate and let the atomic rewrite
+    repair it, instead of an otherwise-idempotent PUT 500ing.
     """
     try:
-        return DROP_IN_PATH.read_text() == render_drop_in(slot, timeout_s)
+        return DROP_IN_PATH.read_text(encoding="utf-8") == render_drop_in(slot, timeout_s)
     except (OSError, UnicodeDecodeError):
         return False
 

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -14,6 +14,8 @@ hal0 lifespan or a real memory engine. Pins the contract the
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -169,6 +171,44 @@ def test_put_persists_hal0_toml_before_propagating(
     assert r.json()["propagation"]["written"] is True
 
 
+async def test_propagate_shielded_does_not_resolve_until_worker_finishes() -> None:
+    """#1682 review: cancelling the request that's awaiting propagation must
+    not let this coroutine (and therefore the caller's HAL0_TOML_LOCK
+    critical section) resolve while apply_extraction_slot's worker thread —
+    which asyncio cannot actually stop once it's running — is still live.
+    Otherwise a second PUT can persist + propagate a different slot while
+    the orphaned worker later clobbers the drop-in back to the first one."""
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    order: list[str] = []
+
+    def _slow_apply(slot: str, *, timeout_s: int) -> dict[str, Any]:
+        worker_started.set()
+        assert release_worker.wait(timeout=5), "test bug: never released"
+        order.append("worker_done")
+        return {"slot": slot, "written": True, "error": None}
+
+    with patch("hal0.memory.extraction_env.apply_extraction_slot", side_effect=_slow_apply):
+        task = asyncio.ensure_future(memory_routes._propagate_shielded("agent", 300))
+        await asyncio.get_running_loop().run_in_executor(None, worker_started.wait, 5)
+        task.cancel()
+
+        # Cancellation was requested a while ago, but the worker is still
+        # blocked — a naive `await asyncio.to_thread(...)` would already have
+        # raised CancelledError by now regardless of the worker's state.
+        # The shielded helper must NOT have resolved yet.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.2)
+        assert order == []
+
+        release_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The helper only raised CancelledError AFTER the worker actually
+        # finished — the lock-holding caller never sees an early release.
+        assert order == ["worker_done"]
+
+
 def test_put_enable_with_unknown_slot_rejected(
     client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:
@@ -188,14 +228,40 @@ def test_put_enable_without_slot_change_keeps_default(
     client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:
     # Flipping enabled with no extraction_slot keeps the default (utility) and
-    # does NOT trigger propagation (slot unchanged).
-    r = client.put("/api/memory/graph", json={"enabled": True})
+    # does NOT trigger propagation when the on-disk drop-in already matches
+    # (nothing to reconcile).
+    with patch("hal0.memory.extraction_env.drop_in_matches", return_value=True):
+        r = client.put("/api/memory/graph", json={"enabled": True})
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["enabled"] is True
     assert body["extraction_slot"] == "utility"
     assert "propagation" not in body
     assert stub_wrapper.set_calls == [(True, "utility")]
+
+
+def test_put_reconciles_when_toml_matches_but_drop_in_does_not(
+    client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    """#1682 review: a host bitten by the pre-seam write bug (or any other
+    silent failure) can already have hal0.toml recording this exact slot
+    while hindsight-api's drop-in was never actually written. Re-requesting
+    the SAME (unchanged) slot must still propagate instead of no-op'ing on
+    config equality."""
+    with (
+        patch("hal0.memory.extraction_env.drop_in_matches", return_value=False),
+        patch("hal0.memory.extraction_env.apply_extraction_slot") as apply_mock,
+    ):
+        apply_mock.return_value = {"slot": "utility", "written": True, "error": None}
+        # No extraction_slot in the body — merges to the existing default
+        # (utility), so hal0.toml's value does not change.
+        r = client.put("/api/memory/graph", json={"enabled": True})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["extraction_slot"] == "utility"
+    assert body["propagation"]["written"] is True
+    apply_mock.assert_called_once_with("utility", timeout_s=300)
 
 
 def test_put_disable_idempotent(client: TestClient, stub_wrapper: StubWrapper) -> None:

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -209,6 +209,42 @@ async def test_propagate_shielded_does_not_resolve_until_worker_finishes() -> No
         assert order == ["worker_done"]
 
 
+async def test_propagate_shielded_survives_a_second_cancellation() -> None:
+    """#1717 review: a second cancellation arriving while we're already
+    waiting out the first (request timeout, then server shutdown) must not
+    re-propagate early either — an unshielded ``await task`` in the cleanup
+    path would exit (and release HAL0_TOML_LOCK) exactly like the bug this
+    helper exists to close, just one cancellation later."""
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    order: list[str] = []
+
+    def _slow_apply(slot: str, *, timeout_s: int) -> dict[str, Any]:
+        worker_started.set()
+        assert release_worker.wait(timeout=5), "test bug: never released"
+        order.append("worker_done")
+        return {"slot": slot, "written": True, "error": None}
+
+    with patch("hal0.memory.extraction_env.apply_extraction_slot", side_effect=_slow_apply):
+        task = asyncio.ensure_future(memory_routes._propagate_shielded("agent", 300))
+        await asyncio.get_running_loop().run_in_executor(None, worker_started.wait, 5)
+
+        task.cancel()
+        await asyncio.sleep(0)  # let the first cancellation reach the shield
+        task.cancel()  # a second cancellation, while still cleaning up from the first
+
+        # Worker is still blocked — even with two cancellations queued, the
+        # helper must not have resolved.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.2)
+        assert order == []
+
+        release_worker.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert order == ["worker_done"]
+
+
 def test_put_enable_with_unknown_slot_rejected(
     client: TestClient, stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:
@@ -262,6 +298,32 @@ def test_put_reconciles_when_toml_matches_but_drop_in_does_not(
     assert body["extraction_slot"] == "utility"
     assert body["propagation"]["written"] is True
     apply_mock.assert_called_once_with("utility", timeout_s=300)
+
+
+def test_put_reconciliation_still_validates_the_unchanged_slot(
+    stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    """#1717 review: an unrelated PUT (e.g. just {"enabled": true}) with
+    slot_changed=False must not silently restart hindsight-api onto a slot
+    that's since been deleted/disabled just because the on-disk drop-in also
+    happened to be stale. Reconciliation must go through the same
+    live-slot-set validation as an explicit slot change, not bypass it."""
+    # "utility" (the config default / stub_wrapper's default extraction_slot)
+    # is deliberately NOT in the enabled llm slot set here.
+    app = _build_app(stub_wrapper, "agent")
+    with (
+        TestClient(app) as client,
+        patch("hal0.memory.extraction_env.drop_in_matches", return_value=False),
+        patch("hal0.memory.extraction_env.apply_extraction_slot") as apply_mock,
+    ):
+        r = client.put("/api/memory/graph", json={"enabled": True})
+
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "config.memory_graph_slot_invalid"
+    apply_mock.assert_not_called()
+    # Rejected before any wrapper flip / persist, same as an explicit
+    # unknown-slot request.
+    assert stub_wrapper.set_calls == []
 
 
 def test_put_disable_idempotent(client: TestClient, stub_wrapper: StubWrapper) -> None:

--- a/tests/api/test_memory_graph_route.py
+++ b/tests/api/test_memory_graph_route.py
@@ -300,14 +300,16 @@ def test_put_reconciles_when_toml_matches_but_drop_in_does_not(
     apply_mock.assert_called_once_with("utility", timeout_s=300)
 
 
-def test_put_reconciliation_still_validates_the_unchanged_slot(
+def test_put_reconciliation_skipped_when_unchanged_slot_is_unavailable(
     stub_wrapper: StubWrapper, hal0_home: Path
 ) -> None:
     """#1717 review: an unrelated PUT (e.g. just {"enabled": true}) with
     slot_changed=False must not silently restart hindsight-api onto a slot
     that's since been deleted/disabled just because the on-disk drop-in also
-    happened to be stale. Reconciliation must go through the same
-    live-slot-set validation as an explicit slot change, not bypass it."""
+    happened to be stale. Unlike an explicit slot change, reconciliation is
+    inferred work — when we can't positively confirm the (unchanged) slot is
+    still valid, skip the reconciliation attempt rather than erroring this
+    otherwise-unrelated request."""
     # "utility" (the config default / stub_wrapper's default extraction_slot)
     # is deliberately NOT in the enabled llm slot set here.
     app = _build_app(stub_wrapper, "agent")
@@ -318,12 +320,57 @@ def test_put_reconciliation_still_validates_the_unchanged_slot(
     ):
         r = client.put("/api/memory/graph", json={"enabled": True})
 
-    assert r.status_code == 422, r.text
-    assert r.json()["error"]["code"] == "config.memory_graph_slot_invalid"
+    assert r.status_code == 200, r.text
+    assert "propagation" not in r.json()
     apply_mock.assert_not_called()
-    # Rejected before any wrapper flip / persist, same as an explicit
-    # unknown-slot request.
-    assert stub_wrapper.set_calls == []
+    # The gate itself still flips — reconciliation just declined to touch
+    # hindsight-api, it didn't block the (unrelated) enable request.
+    assert stub_wrapper.set_calls == [(True, "utility")]
+
+
+def test_put_reconciliation_skipped_when_no_slots_are_known(
+    stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    """#1717 review: an empty/unknown available set (slot_manager unwired,
+    or enumeration failed) must not be treated as "anything goes" for
+    reconciliation the way it is for an explicit operator-driven slot
+    change — we can't verify the slot, so we must not force a restart onto
+    it just because the drop-in happens to be stale too."""
+    app = _build_app(stub_wrapper)  # no slot_manager at all
+    with (
+        TestClient(app) as client,
+        patch("hal0.memory.extraction_env.drop_in_matches", return_value=False),
+        patch("hal0.memory.extraction_env.apply_extraction_slot") as apply_mock,
+    ):
+        r = client.put("/api/memory/graph", json={"enabled": True})
+
+    assert r.status_code == 200, r.text
+    assert "propagation" not in r.json()
+    apply_mock.assert_not_called()
+
+
+def test_put_disable_succeeds_despite_a_stale_unavailable_configured_slot(
+    stub_wrapper: StubWrapper, hal0_home: Path
+) -> None:
+    """#1717 review: `hal0 memory graph disable` sends only
+    {"enabled": false}. Disabling must always succeed — including when the
+    configured extraction slot has since been deleted/disabled and the
+    drop-in is also stale — because disabling doesn't need the (unchanged,
+    now-irrelevant) slot to be valid. Reconciliation must not even be
+    attempted while enabled=False."""
+    app = _build_app(stub_wrapper, "agent")  # "utility" not available
+    with (
+        TestClient(app) as client,
+        patch("hal0.memory.extraction_env.drop_in_matches") as matches_mock,
+        patch("hal0.memory.extraction_env.apply_extraction_slot") as apply_mock,
+    ):
+        r = client.put("/api/memory/graph", json={"enabled": False})
+
+    assert r.status_code == 200, r.text
+    assert "propagation" not in r.json()
+    matches_mock.assert_not_called()
+    apply_mock.assert_not_called()
+    assert stub_wrapper.set_calls == [(False, "utility")]
 
 
 def test_put_disable_idempotent(client: TestClient, stub_wrapper: StubWrapper) -> None:

--- a/tests/api/test_settings_routes.py
+++ b/tests/api/test_settings_routes.py
@@ -5,14 +5,18 @@ Uses ``tmp_hal0_home`` so writes land in a tmp dir, not /etc.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hal0.api import create_app
+from hal0.api.routes import settings as settings_routes
+from hal0.config.loader import HAL0_TOML_LOCK
 
 
 @pytest.fixture
@@ -132,3 +136,48 @@ def test_reload_after_bad_toml_returns_parse_error_envelope(
     assert r.status_code in (400, 500)
     body = r.json()
     assert body["error"]["code"].startswith("config."), body
+
+
+class _FakeAppState:
+    pass
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.state = _FakeAppState()
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette ``Request`` — just enough surface for
+    ``update_settings`` (``.json()`` + ``.app.state``) without a real ASGI
+    app or TestClient, so the lock-sharing test can drive the coroutine
+    directly instead of going through HTTP transport plumbing."""
+
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+        self.app = _FakeApp()
+
+    async def json(self) -> dict[str, Any]:
+        return self._body
+
+
+async def test_update_settings_waits_for_shared_hal0_toml_lock(tmp_hal0_home: str) -> None:
+    """#1682 review: routes/memory.py's ``PUT /graph`` can hold ``HAL0_TOML_LOCK``
+    across a multi-second extraction-slot propagation. Without a lock SHARED
+    across both routes, an unrelated settings save landing mid-flight would
+    persist a config snapshot taken before that propagation started,
+    clobbering the graph section it just wrote. Simulate the graph route
+    holding the lock and assert the settings route genuinely waits rather
+    than racing straight past it."""
+    await HAL0_TOML_LOCK.acquire()
+    try:
+        task = asyncio.ensure_future(
+            settings_routes.update_settings(_FakeRequest({"telemetry": {"enabled": True}}))
+        )
+        await asyncio.sleep(0.05)
+        assert not task.done(), "update_settings must block on the shared lock"
+    finally:
+        HAL0_TOML_LOCK.release()
+
+    result = await task
+    assert result["telemetry"]["enabled"] is True

--- a/tests/api/test_settings_routes.py
+++ b/tests/api/test_settings_routes.py
@@ -48,6 +48,42 @@ def test_get_settings_returns_default_config_when_no_toml(isolated_client: TestC
     assert body["telemetry"]["channel"] == "stable"
 
 
+def test_put_settings_reloads_disk_instead_of_a_stale_cache(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """#1717 review: routes/memory.py's PUT /graph writes its section
+    straight to disk without touching ``app.state.hal0_config``. A settings
+    PUT that resumes after waiting on the shared HAL0_TOML_LOCK must reload
+    from disk rather than trusting that (now stale) cache — otherwise it
+    merges its own unrelated patch into the pre-graph-write snapshot and
+    overwrites the section the other route just saved."""
+    # Simulate exactly that: hal0.toml on disk now has a graph section the
+    # app's in-memory ``hal0_config`` (still whatever create_app()'s
+    # lifespan loaded at startup) knows nothing about.
+    cfg_dir = Path(tmp_hal0_home) / "etc" / "hal0"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "hal0.toml").write_text(
+        '[memory.graph]\nenabled = true\nextraction_slot = "agent"\n',
+        encoding="utf-8",
+    )
+
+    # An unrelated PUT — must not clobber the graph section above.
+    r = isolated_client.put("/api/settings", json={"telemetry": {"enabled": True}})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["telemetry"]["enabled"] is True
+    assert body["memory"]["graph"]["enabled"] is True
+    assert body["memory"]["graph"]["extraction_slot"] == "agent"
+
+    # And the on-disk file reflects both, not just the settings PUT's patch.
+    toml_path = cfg_dir / "hal0.toml"
+    import tomllib
+
+    parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    assert parsed["telemetry"]["enabled"] is True
+    assert parsed["memory"]["graph"]["extraction_slot"] == "agent"
+
+
 def test_put_settings_partial_update_persists_to_disk(
     isolated_client: TestClient, tmp_hal0_home: str
 ) -> None:

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from hal0.memory.extraction_env import (
     DROP_IN_PATH,
     apply_extraction_slot,
+    drop_in_matches,
     render_drop_in,
 )
 from hal0.system.seam import SEAM_BIN, SystemCtlSeam
@@ -222,6 +223,40 @@ def test_apply_does_not_blame_the_wrapper_for_other_failures(monkeypatch, tmp_pa
     seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
 
     assert "install.sh" not in (apply_extraction_slot("utility", seam=seam)["error"] or "")
+
+
+def test_drop_in_matches_true_when_content_is_identical(monkeypatch, tmp_path: Path):
+    import hal0.memory.extraction_env as ee
+
+    path = tmp_path / "extraction-model.conf"
+    path.write_text(render_drop_in("agent", 300))
+    monkeypatch.setattr(ee, "DROP_IN_PATH", path)
+
+    assert drop_in_matches("agent", 300) is True
+
+
+def test_drop_in_matches_false_on_stale_content(monkeypatch, tmp_path: Path):
+    """The recorded slot changed but the drop-in still names the old one —
+    exactly the divergence a broken host can be stuck in."""
+    import hal0.memory.extraction_env as ee
+
+    path = tmp_path / "extraction-model.conf"
+    path.write_text(render_drop_in("utility", 300))
+    monkeypatch.setattr(ee, "DROP_IN_PATH", path)
+
+    assert drop_in_matches("agent", 300) is False
+
+
+def test_drop_in_matches_false_when_missing(monkeypatch, tmp_path: Path):
+    """#1682 review: a host where the privileged write previously failed
+    silently (pre-seam bug) has hal0.toml recording a slot that was NEVER
+    actually applied — no drop-in file at all. That must read as "does not
+    match", not error out, so the caller knows to (re)propagate."""
+    import hal0.memory.extraction_env as ee
+
+    monkeypatch.setattr(ee, "DROP_IN_PATH", tmp_path / "never-written.conf")
+
+    assert drop_in_matches("agent", 300) is False
 
 
 def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Path):

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -259,6 +259,20 @@ def test_drop_in_matches_false_when_missing(monkeypatch, tmp_path: Path):
     assert drop_in_matches("agent", 300) is False
 
 
+def test_drop_in_matches_false_on_undecodable_bytes(monkeypatch, tmp_path: Path):
+    """#1717 review: ``Path.read_text()`` raises ``UnicodeDecodeError`` (NOT
+    an ``OSError``) on malformed/tampered content. That must still read as
+    "does not match" so the caller reconciles by rewriting the file, instead
+    of an otherwise-idempotent graph PUT 500ing on a decode failure."""
+    import hal0.memory.extraction_env as ee
+
+    path = tmp_path / "extraction-model.conf"
+    path.write_bytes(b"\xff\xfe not valid utf-8 \x80\x81")
+    monkeypatch.setattr(ee, "DROP_IN_PATH", path)
+
+    assert drop_in_matches("agent", 300) is False
+
+
 def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Path):
     """Root / dev / CI keeps the pre-seam behaviour: a direct atomic write."""
     import hal0.memory.extraction_env as ee

--- a/tests/memory/test_extraction_env.py
+++ b/tests/memory/test_extraction_env.py
@@ -273,6 +273,36 @@ def test_drop_in_matches_false_on_undecodable_bytes(monkeypatch, tmp_path: Path)
     assert drop_in_matches("agent", 300) is False
 
 
+def test_drop_in_matches_reads_utf8_regardless_of_locale(monkeypatch, tmp_path: Path):
+    """#1717 review: the drop-in (and the em dash in its header comment) is
+    always written UTF-8 by SystemCtlSeam — the comparison must decode it as
+    UTF-8 explicitly rather than via ``Path.read_text()``'s locale-dependent
+    default, or a byte-for-byte correct file can misread as drift under
+    e.g. ``LC_ALL=C`` and trigger a needless rewrite + restart on every
+    enabled graph PUT."""
+    import hal0.memory.extraction_env as ee
+
+    path = tmp_path / "extraction-model.conf"
+    # The rendered template contains a real em dash (U+2014) in its header.
+    content = render_drop_in("agent", 300)
+    assert "—" in content
+    path.write_text(content, encoding="utf-8")
+    monkeypatch.setattr(ee, "DROP_IN_PATH", path)
+
+    real_read_text = Path.read_text
+
+    def _locale_sensitive_read_text(self, *args, **kwargs):
+        # Fail unless the caller passed an explicit encoding — the same
+        # failure mode as a real ASCII-locale default.
+        if kwargs.get("encoding") != "utf-8" and (len(args) < 1 or args[0] != "utf-8"):
+            raise UnicodeDecodeError("ascii", b"\xe2\x80\x94", 0, 1, "ordinal not in range(128)")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _locale_sensitive_read_text)
+
+    assert drop_in_matches("agent", 300) is True
+
+
 def test_apply_writes_directly_when_not_the_hal0_user(monkeypatch, tmp_path: Path):
     """Root / dev / CI keeps the pre-seam behaviour: a direct atomic write."""
     import hal0.memory.extraction_env as ee


### PR DESCRIPTION
Follow-up to #1682 (merged as f648408e), addressing the remaining Codex findings on that PR's final revision (c3d7c79c) that landed after merge.

## What
- **Reconcile against actual on-disk state, not just hal0.toml equality.** A host already hit by the pre-seam write bug can have `hal0.toml` recording a slot that was never actually applied to the drop-in. New `extraction_env.drop_in_matches()` (plain unprivileged read — the drop-in is 0644 root:root) lets the route detect that drift and propagate on the next PUT even when the requested slot/timeout match the recorded config.
- **`_propagate_shielded()`** — shields the `asyncio.to_thread` propagation call; if the awaiting request is cancelled (client disconnect, shutdown), it waits out the already-running, un-cancellable worker before re-raising, so the config lock is held for the worker's true lifetime instead of releasing early and letting a second PUT interleave a clobber.
- **`HAL0_TOML_LOCK` moved to `hal0.config.loader`** and is now shared between `routes/memory.py`'s `PUT /graph` and `routes/settings.py`'s `PUT /api/settings`, closing the race where an unrelated settings save could land mid-propagation and persist a stale snapshot over the graph section that was just written.

## Not in scope (filed separately)
#1716 — the write-hindsight-dropin/write-gateway-dropin wrapper verbs accept an unvalidated systemd fragment as root. Root-trust-boundary hardening, not concurrency semantics; pre-existing posture (write-gateway-dropin predates #1682), not a regression from this line of work.

## Test plan
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/test_memory_graph_route.py tests/api/test_settings_routes.py tests/memory tests/system -q` — 378 passed
- [x] `ruff check` / `ruff format --check` on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)