### PR TITLE
fix(security): allow-list drop-in content in the privileged systemctl seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ applying. Add those subsections to a version's section to surface them; see
 
 ## [Unreleased]
 
+### Security
+
+- The privileged `hal0-systemctl` wrapper now allow-lists the *content* of the
+  two systemd drop-ins it writes as root (`write-gateway-dropin`,
+  `write-hindsight-dropin`). Both verbs take their whole payload on stdin, and
+  the sudoers grant lets the unprivileged `hal0` service account run the
+  wrapper as root — so a process compromised as `hal0` could previously supply
+  a `[Service]` fragment with `User=root` and a replaced `ExecStart=`, then use
+  the wrapper's own `daemon-reload` + `svc-restart` verbs to run it as root.
+  Validation is parsed on the root side of that boundary: only `#` comments,
+  blank lines, a single `[Service]` header and a closed set of directives per
+  verb (`Environment=HINDSIGHT_API_LLM_MODEL` / `…_TIMEOUT`; an
+  `EnvironmentFile=` confined to the hal0 secrets vault) are accepted, each
+  with a pinned value charset. Anything else — any other section or directive,
+  a line continuation, a control byte, leading whitespace — is rejected with a
+  loud error and nothing is written. The wrapper persists the validated
+  reconstruction rather than raw stdin, and a new side-effect-free
+  `check-dropin <gateway|hindsight>` verb dry-runs the allow-list.
+
 ## [1.0.0-rc.3] — 2026-08-09
 
 The hardening candidate: rc.2 plus the full yield of the pre-1.0 review —

--- a/docs/operate/services.mdx
+++ b/docs/operate/services.mdx
@@ -140,7 +140,13 @@ WantedBy=multi-user.target
   (`write-hindsight-dropin` + `svc-restart hindsight`). If the wrapper or its
   sudoers grant is missing, the API's response carries a non-null
   `propagation.error` and the engine keeps its previous extraction target —
-  check `hal0 doctor` for the seam rows.
+  check `hal0 doctor` for the seam rows. The wrapper allow-lists the drop-in
+  body on the root side: only `#` comments, a single `[Service]` header and the
+  two `Environment=HINDSIGHT_API_LLM_*` assignments are accepted, so a
+  hand-crafted fragment (`ExecStart=`, `User=`, any other directive) is
+  rejected rather than written. Run
+  `hal0-systemctl check-dropin hindsight < body` to see why a body was refused;
+  it validates and echoes without writing anything.
 - **Data root** — embedded Postgres at `/var/lib/hal0/memory/hindsight/.pg0`,
   pinned via the unit's `HOME=` env (Hindsight has no dedicated data-dir
   variable of its own).

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -22,6 +22,18 @@
 # built HERE from a validated id (the caller never supplies a unit string),
 # the systemctl verb is a literal, no shell, no wildcards.
 #
+# DROP-IN CONTENT (#1716): the two drop-in verbs take their whole payload on
+# stdin, and stdin is attacker-controlled at this privilege boundary — the
+# sudoers grant lets the unprivileged `hal0` account run this script as root.
+# Copying that payload verbatim into a root-owned systemd fragment is a direct
+# path to root: a `[Service]` body with `User=root` + a replaced `ExecStart=`,
+# followed by this same wrapper's `daemon-reload` and `svc-restart` verbs, runs
+# an arbitrary command as root. Pinning the destination path (already true for
+# both verbs) does not constrain the directives written there. So the body is
+# ALLOW-LISTED here, on the root side of the boundary — see
+# validate_dropin_body below. The unprivileged caller's own templating is a
+# convenience, never a control.
+#
 # NOTE: the iptables FORWARD-chain repair the original P3-perms design doc
 # sketched for this seam is NOT needed — that repair already runs as its own
 # independent root oneshot unit (packaging/systemd/hal0-podman-forward.service,
@@ -79,6 +91,128 @@ validate_agent_id() {  # arg: agent id (the "<id>" in hal0-agent@<id>.service)
   [[ "$id" =~ ^[A-Za-z0-9_-]{1,64}$ ]] || die "bad agent id: $id"
 }
 
+# ── drop-in content allow-list (#1716) ─────────────────────────────────────
+#
+# Root-side validation for the `write-*-dropin` verbs. Deliberately in the same
+# style as the id validators above: strict regexes, a closed set of accepted
+# tokens, no shell evaluation of anything read from stdin, and a loud `die` on
+# the first thing that is not explicitly permitted.
+#
+# The grammar accepted is a small subset of systemd unit syntax:
+#   * `#` comment lines and blank lines,
+#   * exactly one `[Service]` section header, before any directive,
+#   * `Key=Value` directives whose Key is in the per-verb allow-list below and
+#     whose Value matches that key's regex.
+# Everything else — any other section, any other directive (`ExecStart`,
+# `ExecStartPre`, `User`, `Group`, …), leading whitespace, tabs, `;` comments,
+# CR, a trailing backslash (systemd line continuation, which would let a second
+# logical directive hide on a "value" line), any control byte — is rejected.
+#
+# On success DROPIN_BODY holds the RECONSTRUCTION of the validated lines, and
+# that — not the raw stdin — is what the write arms persist. What was checked
+# is therefore byte-for-byte what lands in /etc.
+
+DROPIN_BODY=""
+
+_DROPIN_MAX_LINES=200
+_DROPIN_MAX_LINE=512
+
+validate_dropin_directive() {  # args: kind, "Key=Value" line
+  local kind="$1" line="$2" key value ename evalue
+  [[ "$line" == *=* ]] || die "drop-in rejected: not a Key=Value directive: $line"
+  key="${line%%=*}"
+  value="${line#*=}"
+  # No spaces, no tabs, no quoting around the key — a systemd-legal `Key = v`
+  # or ` Key=v` is rejected rather than normalised, so there is exactly one
+  # accepted spelling per directive.
+  [[ "$key" =~ ^[A-Za-z]+$ ]] || die "drop-in rejected: bad directive key: $key"
+
+  case "$kind" in
+    hindsight)
+      # ADR-0023: the extraction drop-in sets two Environment= assignments and
+      # nothing else. `Environment=` takes `NAME=VALUE`, so the NAME is checked
+      # against its own closed list; the value charsets exclude whitespace, so
+      # a second `NAME=VALUE` pair cannot ride along on one line.
+      [[ "$key" == "Environment" ]] || die "drop-in rejected: directive not allowed here: $key"
+      [[ "$value" == *=* ]] || die "drop-in rejected: Environment= needs NAME=VALUE: $value"
+      ename="${value%%=*}"
+      evalue="${value#*=}"
+      case "$ename" in
+        HINDSIGHT_API_LLM_MODEL)
+          # Always the `hal0/<slot>` virtual (never a raw model id), and a slot
+          # id is the same bounded identifier the slot verbs accept.
+          [[ "$evalue" =~ ^hal0/[A-Za-z0-9_.-]{1,64}$ ]] \
+            || die "drop-in rejected: bad HINDSIGHT_API_LLM_MODEL value: $evalue"
+          ;;
+        HINDSIGHT_API_LLM_TIMEOUT)
+          [[ "$evalue" =~ ^[0-9]{1,9}$ ]] \
+            || die "drop-in rejected: bad HINDSIGHT_API_LLM_TIMEOUT value: $evalue"
+          ;;
+        *) die "drop-in rejected: environment name not allowed here: $ename" ;;
+      esac
+      ;;
+    gateway)
+      # #437: the gateway drop-in only points systemd at the hal0 secrets
+      # vault. The value is confined to that directory (an EnvironmentFile
+      # anywhere else would let a compromised caller inject env — LD_PRELOAD —
+      # into a root unit); a leading `-` (optional-file marker) is allowed.
+      [[ "$key" == "EnvironmentFile" ]] || die "drop-in rejected: directive not allowed here: $key"
+      [[ "$value" =~ ^-?/var/lib/hal0/secrets/[A-Za-z0-9_./-]{1,128}$ ]] \
+        || die "drop-in rejected: EnvironmentFile outside the hal0 secrets vault: $value"
+      [[ "$value" != *".."* ]] || die "drop-in rejected: EnvironmentFile traversal: $value"
+      ;;
+    *) die "unknown drop-in kind: $kind" ;;
+  esac
+}
+
+validate_dropin_body() {  # arg: kind (gateway|hindsight); body on stdin
+  local kind="$1"
+  local LC_ALL=C
+  local line out="" seen_service=0 directives=0
+  local -a lines=()
+
+  case "$kind" in
+    gateway|hindsight) ;;
+    *) die "unknown drop-in kind: $kind" ;;
+  esac
+
+  mapfile -t lines
+  (( ${#lines[@]} <= _DROPIN_MAX_LINES )) \
+    || die "drop-in rejected: too many lines (${#lines[@]} > ${_DROPIN_MAX_LINES})"
+
+  for line in "${lines[@]}"; do
+    (( ${#line} <= _DROPIN_MAX_LINE )) || die "drop-in rejected: line too long (${#line} bytes)"
+    # No control bytes: rejects CR, tab, NUL and the rest of C0/DEL in one
+    # check, so nothing can smuggle a second logical line or an invisible
+    # directive. High bytes are allowed — the managed headers are UTF-8 prose
+    # ("—") and comments are inert; every *directive* is separately pinned by
+    # its own regex below.
+    [[ ! "$line" =~ [[:cntrl:]] ]] || die "drop-in rejected: control byte in line: $line"
+    # A trailing backslash continues the directive onto the next line in
+    # systemd's parser, which would defeat the per-line checks below.
+    [[ "$line" != *\\ ]] || die "drop-in rejected: line continuation: $line"
+
+    case "$line" in
+      "")   ;;                                            # blank line
+      "#"*) ;;                                            # comment (control-byte-free, checked above)
+      "["*)
+        [[ "$line" == "[Service]" ]] || die "drop-in rejected: section not allowed: $line"
+        (( seen_service == 0 )) || die "drop-in rejected: duplicate [Service] section"
+        seen_service=1
+        ;;
+      *)
+        (( seen_service == 1 )) || die "drop-in rejected: directive before [Service]: $line"
+        validate_dropin_directive "$kind" "$line"
+        directives=$(( directives + 1 ))
+        ;;
+    esac
+    out+="${line}"$'\n'
+  done
+
+  (( directives > 0 )) || die "drop-in rejected: no allowed directives in body"
+  DROPIN_BODY="$out"
+}
+
 cmd="${1:-help}"; shift || true
 
 case "$cmd" in
@@ -110,11 +244,15 @@ case "$cmd" in
     # 0600 vault, not here. Atomic (tmp + mv), mirroring hal0-agentenv's
     # write-driver-env — `install /dev/stdin` misbehaves overwriting an
     # existing target when the source is a pipe.
+    #
+    # #1716: the body is allow-listed BEFORE anything is created, and what gets
+    # written is the validated reconstruction ($DROPIN_BODY), never raw stdin.
+    validate_dropin_body gateway
     install -d -m 0755 -o root -g root "$GATEWAY_DROPIN_DIR"
     umask 022
     tmp="$(mktemp "${GATEWAY_DROPIN_FILE}.XXXXXX")"
     trap 'rm -f "$tmp"' EXIT
-    cat > "$tmp"
+    printf '%s' "$DROPIN_BODY" > "$tmp"
     chown root:root "$tmp"
     chmod 0644 "$tmp"
     mv -f "$tmp" "$GATEWAY_DROPIN_FILE"
@@ -125,15 +263,30 @@ case "$cmd" in
     # Literal fixed path — the caller never supplies it, so this verb can only
     # ever reach that one file. 0644 root:root so systemd can read the fragment.
     # Atomic (tmp + mv), same shape as write-gateway-dropin.
+    #
+    # #1716: allow-listed body (only the two ADR-0023 Environment= keys), and
+    # the validated reconstruction is what is written — never raw stdin.
+    validate_dropin_body hindsight
     install -d -m 0755 -o root -g root "$HINDSIGHT_DROPIN_DIR"
     umask 022
     tmp="$(mktemp "${HINDSIGHT_DROPIN_FILE}.XXXXXX")"
     trap 'rm -f "$tmp"' EXIT
-    cat > "$tmp"
+    printf '%s' "$DROPIN_BODY" > "$tmp"
     chown root:root "$tmp"
     chmod 0644 "$tmp"
     mv -f "$tmp" "$HINDSIGHT_DROPIN_FILE"
     trap - EXIT
+    ;;
+
+  check-dropin)               # check-dropin <gateway|hindsight>   (body on stdin)
+    # Side-effect-free dry run of the #1716 allow-list: validates the body and
+    # echoes back exactly what a write would persist, or dies 64 with the
+    # reason. Writes nothing, touches no unit, reloads nothing — it exists so
+    # the allow-list can be exercised (by the test suite, and by an operator
+    # debugging a rejected body) without a privileged write.
+    kind="${1:-}"
+    validate_dropin_body "$kind"
+    printf '%s' "$DROPIN_BODY"
     ;;
 
   daemon-reload)
@@ -210,6 +363,7 @@ usage: hal0-systemctl <command> [slot-id|agent-id]
   remove-quadlet <slot-id>         rm -f ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container
   write-gateway-dropin             write ${GATEWAY_DROPIN_FILE} (body on stdin)
   write-hindsight-dropin           write ${HINDSIGHT_DROPIN_FILE} (body on stdin)
+  check-dropin <gateway|hindsight> validate a drop-in body (stdin) without writing it
   daemon-reload                    systemctl daemon-reload
   start|stop|restart <slot-id>     systemctl <verb> ${UNIT_PREFIX}<id>.service
   enable|disable <slot-id>         systemctl <verb> ${UNIT_PREFIX}<id>.service

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,8 +130,14 @@ def _reject_privileged_systemctl(argv: object) -> None:
         # `<systemctl-verb>-agent` (agent family); both mutate. The
         # non-systemctl file verbs (write-unit, write-quadlet, ...) mutate
         # /etc as root, which a test must never do either.
+        #
+        # `help` and `check-dropin` are the exceptions: both are pure — they
+        # read stdin/argv, write nothing, and never touch systemd. Running the
+        # real script IS the point for those (tests/installer's #1716 suite
+        # exercises the root-side drop-in allow-list against the shipped bash),
+        # and neither needs sudo or root.
         seam_verb = next((p for p in inner[1:] if not p.startswith("-")), "")
-        if seam_verb and seam_verb not in {"help", ""}:
+        if seam_verb and seam_verb not in {"help", "", "check-dropin"}:
             raise AssertionError(
                 f"test tried to run the hal0-systemctl privilege seam for real: {parts!r}. "
                 "Inject a fake runner (or patch hal0.system.seam.agent_unit_argv) instead — "

--- a/tests/installer/test_systemctl_dropin_validation.py
+++ b/tests/installer/test_systemctl_dropin_validation.py
@@ -1,0 +1,182 @@
+"""#1716 — root-side content allow-list for the two drop-in verbs.
+
+``installer/wrappers/hal0-systemctl`` is reachable as root by the unprivileged
+``hal0`` service account (packaging/sudoers/hal0-systemctl), so *stdin* is
+attacker-controlled at a privilege boundary. Both ``write-gateway-dropin`` and
+``write-hindsight-dropin`` used to copy that stdin verbatim into a root-owned
+systemd fragment; combined with the wrapper's own ``daemon-reload`` +
+``svc-restart`` verbs that is a direct path to root (``ExecStart=`` / ``User=``
+override) from an ``hal0``-level compromise.
+
+The fix is an allow-list parsed on the ROOT side of the boundary. These tests
+exercise the *real* bash wrapper through its side-effect-free ``check-dropin``
+verb (the same validator the write arms call), so they need no root, no sudo
+and no provisioned box — the ``hal0-update`` wrapper suite's posture.
+
+The legitimate bodies are imported from the actual call sites rather than
+retyped, so a template change that the allow-list would reject fails here
+instead of on a production host.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hal0.agents.hermes_provision import _gateway_dropin_body
+from hal0.memory.extraction_env import render_drop_in
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-systemctl"
+
+
+def _check(kind: str, body: str) -> subprocess.CompletedProcess[str]:
+    """Run the real wrapper's validator over ``body``. rc 0 = accepted."""
+    return subprocess.run(
+        [str(WRAPPER), "check-dropin", kind],
+        input=body,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+
+def _accepts(kind: str, body: str) -> None:
+    proc = _check(kind, body)
+    assert proc.returncode == 0, f"rejected: {proc.stderr}"
+    # The write arms persist the VALIDATED reconstruction, not the raw stdin,
+    # so what is echoed here is byte-for-byte what lands in /etc.
+    assert proc.stdout == body
+
+
+def _rejects(kind: str, body: str) -> str:
+    proc = _check(kind, body)
+    assert proc.returncode == 64, f"accepted (rc={proc.returncode}): {body!r}"
+    assert "drop-in rejected" in proc.stderr
+    return proc.stderr
+
+
+# ── the wrapper still parses ───────────────────────────────────────────────
+
+
+def test_wrapper_is_syntactically_valid() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_both_write_arms_validate_before_writing() -> None:
+    """The validator must be on the write path, not merely available: a
+    ``check-dropin`` verb nothing calls would be security theatre."""
+    text = WRAPPER.read_text()
+    for verb in ("write-gateway-dropin", "write-hindsight-dropin"):
+        arm = text.split(f"  {verb})", 1)[1].split("\n    ;;", 1)[0]
+        assert "validate_dropin_body" in arm, f"{verb} does not validate its body"
+        # …and it writes the validated reconstruction, never raw stdin.
+        assert "DROPIN_BODY" in arm
+        assert "cat > " not in arm
+
+
+# ── the real payloads both call sites produce ──────────────────────────────
+
+
+def test_live_hindsight_body_is_accepted_byte_for_byte() -> None:
+    _accepts("hindsight", render_drop_in("chat"))
+
+
+@pytest.mark.parametrize("slot", ["chat", "graph-extract", "slot_1", "Mixed-Case"])
+@pytest.mark.parametrize("timeout_s", [300, 60, 1800])
+def test_live_hindsight_body_variants_are_accepted(slot: str, timeout_s: int) -> None:
+    _accepts("hindsight", render_drop_in(slot, timeout_s))
+
+
+def test_live_gateway_body_is_accepted_byte_for_byte() -> None:
+    _accepts("gateway", _gateway_dropin_body())
+
+
+# ── the escalation payloads ────────────────────────────────────────────────
+
+_MODEL = "Environment=HINDSIGHT_API_LLM_MODEL=hal0/chat\n"
+
+ESCALATIONS = {
+    "execstart-override": "[Service]\nExecStart=\nExecStart=/bin/sh -c 'id>/tmp/pwn'\n",
+    "execstartpre": f"[Service]\n{_MODEL}ExecStartPre=/bin/sh -c 'id>/tmp/pwn'\n",
+    "user-root": f"[Service]\n{_MODEL}User=root\n",
+    "group-root": f"[Service]\n{_MODEL}Group=root\n",
+    "extra-section": f"[Unit]\nDescription=x\n[Service]\n{_MODEL}",
+    "second-service-section": f"[Service]\n{_MODEL}[Service]\nExecStart=/bin/sh\n",
+    "install-section": f"[Service]\n{_MODEL}[Install]\nWantedBy=multi-user.target\n",
+    "line-continuation": "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=hal0/chat \\\nExecStart=/bin/sh\n",
+    "carriage-return-smuggling": "[Service]\r\nExecStart=/bin/sh\n",
+    "cr-inside-directive": "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=hal0/chat\rUser=root\n",
+    "environment-key-smuggling": "[Service]\nEnvironment=LD_PRELOAD=/tmp/evil.so\n",
+    "environment-multi-assignment": (
+        "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=hal0/chat LD_PRELOAD=/tmp/e.so\n"
+    ),
+    "environment-quoted-value": '[Service]\nEnvironment="HINDSIGHT_API_LLM_MODEL=hal0/chat"\n',
+    "environment-file-injection": "[Service]\nEnvironmentFile=/tmp/attacker.env\n",
+    "leading-whitespace-directive": f"[Service]\n{_MODEL}  User=root\n",
+    "spaced-key": f"[Service]\n{_MODEL}User = root\n",
+    "directive-before-section": f"{_MODEL}[Service]\n",
+    "no-section": "ExecStart=/bin/sh\n",
+    "semicolon-comment-then-directive": f"[Service]\n{_MODEL}; note\nUser=root\n",
+    "tab-indented-directive": f"[Service]\n{_MODEL}\tUser=root\n",
+    "empty-body": "",
+    "section-only": "[Service]\n",
+    "timeout-not-a-number": "[Service]\nEnvironment=HINDSIGHT_API_LLM_TIMEOUT=$(id)\n",
+    "model-not-a-hal0-slot": "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=/bin/sh\n",
+    "model-path-traversal": "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=hal0/../../etc\n",
+}
+
+
+@pytest.mark.parametrize("name", sorted(ESCALATIONS))
+def test_hindsight_rejects_escalation_payloads(name: str) -> None:
+    _rejects("hindsight", ESCALATIONS[name])
+
+
+def test_gateway_rejects_arbitrary_environment_file() -> None:
+    _rejects("gateway", "[Service]\nEnvironmentFile=/etc/shadow\n")
+
+
+def test_gateway_rejects_traversal_out_of_the_vault() -> None:
+    _rejects("gateway", "[Service]\nEnvironmentFile=-/var/lib/hal0/secrets/../../../tmp/evil\n")
+
+
+def test_gateway_rejects_execstart() -> None:
+    _rejects("gateway", "[Service]\nExecStart=/bin/sh -c 'id>/tmp/pwn'\n")
+
+
+# ── the two kinds are separate allow-lists ─────────────────────────────────
+
+
+def test_gateway_body_is_not_accepted_as_a_hindsight_dropin() -> None:
+    _rejects("hindsight", _gateway_dropin_body())
+
+
+def test_hindsight_body_is_not_accepted_as_a_gateway_dropin() -> None:
+    _rejects("gateway", render_drop_in("chat"))
+
+
+def test_unknown_kind_is_refused() -> None:
+    proc = _check("nope", "[Service]\n")
+    assert proc.returncode == 64
+    assert "unknown drop-in kind" in proc.stderr
+
+
+# ── bounds ─────────────────────────────────────────────────────────────────
+
+
+def test_absurdly_long_line_is_rejected() -> None:
+    _rejects(
+        "hindsight", "[Service]\nEnvironment=HINDSIGHT_API_LLM_MODEL=hal0/" + "a" * 4096 + "\n"
+    )
+
+
+def test_absurdly_many_lines_are_rejected() -> None:
+    _rejects("hindsight", "[Service]\n" + "# pad\n" * 5000 + _MODEL)
+
+
+def test_comments_and_blank_lines_are_allowed() -> None:
+    _accepts("hindsight", f"# managed by hal0\n#\n\n[Service]\n{_MODEL}")


### PR DESCRIPTION
**Privileged-surface security change — operator review required. Automerge is deliberately NOT enabled on this PR.**

Closes #1716 (P1, pre-GA).

## The trust boundary

`installer/wrappers/hal0-systemctl` is the entire privileged surface for hal0-api's systemd operations, and `packaging/sudoers/hal0-systemctl` lets the unprivileged `hal0` service account run it as root. Its two drop-in verbs — `write-gateway-dropin` and `write-hindsight-dropin` — take their whole payload on stdin, so **stdin is attacker-controlled at that boundary**. Both copied it verbatim into a root-owned systemd fragment.

From an `hal0`-level compromise (an RCE in hal0-api, say) that is a direct path to root: supply a `[Service]` fragment setting `User=root` with a reset-and-replaced `ExecStart=`, then invoke the wrapper's own `daemon-reload` + `svc-restart hindsight` / `svc-restart openwebui` verbs. Pinning the destination path — already true for both verbs — does not constrain the directives written there.

This is a pre-existing design posture, not a regression from #1682 (which only added `write-hindsight-dropin`, following the `write-gateway-dropin` shape already there).

## The allow-list

Validation now lives on the **root side** of the boundary, in the wrapper itself, in the same style as the existing id validators: strict regexes, a closed token set, no shell evaluation of anything read from stdin, a loud `die` (rc 64) on the first thing not explicitly permitted.

Accepted grammar — a small subset of systemd unit syntax:

- `#` comment lines and blank lines
- exactly one `[Service]` header, before any directive
- `Key=Value` directives from a per-verb allow-list:
  - **hindsight** — `Environment=HINDSIGHT_API_LLM_MODEL=hal0/<slot>` and `Environment=HINDSIGHT_API_LLM_TIMEOUT=<digits>` (ADR-0023). Value charsets exclude whitespace, so a second `NAME=VALUE` pair cannot ride along on one line.
  - **gateway** — a single `EnvironmentFile=` confined to the hal0 secrets vault (#437). An `EnvironmentFile` anywhere else would let a compromised caller inject env — `LD_PRELOAD` included — into a root unit.

Rejected: every other section, every other directive (`ExecStart`, `ExecStartPre`, `User`, `Group`, …), leading whitespace, tabs, `;` comments, a trailing backslash (systemd line continuation, which would hide a second logical directive on a "value" line), any control byte, and bodies over 200 lines / 512 bytes per line.

The write arms persist the **validated reconstruction**, not raw stdin, so what was checked is byte-for-byte what lands in `/etc`. The Python callers' templating is unchanged — it is a convenience, never a control.

New `check-dropin <gateway|hindsight>` verb: side-effect-free dry run of the same validator. Reads stdin, writes nothing, touches no unit, echoes back what a write would persist or dies 64 with the reason. It exists so the allow-list can be exercised against the real shipped bash (no root, no sudo — the `hal0-update` wrapper suite's posture) and so an operator can debug a rejected body.

Out of scope: `write-unit` / `write-quadlet` legitimately write full slot units including `ExecStart=`, and are constrained by their validated slot id plus a fixed path instead.

## Verification

Red-first: the new suite failed against the old wrapper, then passed.

- `tests/installer/test_systemctl_dropin_validation.py` — 50 tests driving the **real bash wrapper** as a subprocess.
  - ~25 escalation payloads REJECTED: `ExecStart=` reset+override, `ExecStartPre`, `User=root`, `Group=root`, extra `[Unit]`/`[Install]` sections, a second `[Service]`, line-continuation smuggling, CR smuggling (both as a line terminator and mid-directive), `Environment=LD_PRELOAD=…`, multi-assignment on one `Environment=` line, quoted-key form, `EnvironmentFile=/etc/shadow`, vault traversal (`…/secrets/../../../tmp/evil`), leading-whitespace and tab-indented directives, `Key = Value` spacing, directive-before-`[Service]`, no section at all, `;`-comment then directive, non-numeric timeout, non-`hal0/` model value, model-value traversal, empty body, section-only body, over-long line, 5000-line body.
  - Legitimate bodies ACCEPTED byte-for-byte, imported from the actual call sites (`hal0.memory.extraction_env.render_drop_in`, `hal0.agents.hermes_provision._gateway_dropin_body`) rather than retyped — a template change the allow-list would reject fails here instead of on a production host. Includes slot/timeout variants.
  - Cross-kind bodies rejected (the gateway body is not a valid hindsight drop-in and vice versa); unknown kind refused; `bash -n` clean; structural assertion that both write arms actually call the validator and write `$DROPIN_BODY` rather than `cat > "$tmp"` — a validator nothing calls would be security theatre.
- `tests/conftest.py`'s privileged-seam guard now permits `check-dropin` alongside `help`; both are pure.
- Targeted: `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/system tests/memory tests/install tests/installer tests/agents/test_hermes_provision.py -q` → **999 passed, 1 skipped** (shellcheck not installed locally).
- Full suite: **9175 passed, 15 skipped, 1 xfailed** in 16m12s.
- `make lint` clean; `make check-sunset` clean (scar markers 191 ≤ 193).

Docs: CHANGELOG `### Security` entry; `docs/operate/services.mdx` notes the allow-list and the `check-dropin` debugging path.

## Review focus

- Are the two per-verb allow-lists correct and complete for what the call sites legitimately produce today, including anything #1717 will send? (#1717 does not change either template.)
- The gateway `EnvironmentFile=` value is confined to `/var/lib/hal0/secrets/…` rather than pinned to the single literal `-/var/lib/hal0/secrets/agents/hermes.env`. Pinning it exactly would be tighter but would make a future path change fail on a host running a stale wrapper.
- The validator is versioned with the wrapper, so an install that ships a stale `hal0-systemctl` alongside a newer template fails closed (loud rc 64), not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)