### PR TITLE
fix(slots): merge_slot_config projects onto [slot], not the root, on nested-shape configs

### DIFF
--- a/src/hal0/slot_config/__init__.py
+++ b/src/hal0/slot_config/__init__.py
@@ -140,6 +140,33 @@ def fold_ctx_size_alias(cfg_dict: dict[str, Any]) -> None:
 # ── the shared slot-projection merge primitive (SC-11) ───────────────────────
 
 
+def slot_scalar_table(raw: dict[str, Any]) -> dict[str, Any]:
+    """The table a slot's SCALAR fields actually live in (#1685).
+
+    Two on-disk shapes are supported (:func:`hal0.config.loader._flatten_slot_toml`
+    is the read-side twin of this rule):
+
+      - **flat** — scalars (``device``, ``provider``, ``profile``, ``port``, …)
+        at the root, alongside sibling TABLES (``[model]``, ``[server]``,
+        ``[npu]``, …). What ``SlotManager.create`` / ``write_slot_toml`` write.
+      - **nested** (haloai-compatible) — the same scalars live under
+        ``[slot]``; sibling tables are still root-level siblings of
+        ``[slot]``, never nested inside it. What hand-edited files,
+        ``loader.save_slot_config``, and ``migrate_slot_id_keying`` produce.
+
+    ``_flatten_slot_toml`` treats ``[slot]`` as AUTHORITATIVE whenever it
+    exists on load: only its keys become the loaded ``SlotConfig``'s scalar
+    fields, and every top-level scalar sibling is stashed into ``extra`` and
+    ignored. A writer that always projects onto the root therefore silently
+    no-ops on a nested file — the write "succeeds", lands on a key nobody
+    reads, and the duplicated root scalar even makes the next drift-check
+    look converged. Every scalar read/write in the shared write pipeline
+    goes through this one accessor instead of assuming a shape.
+    """
+    table = raw.get("slot")
+    return table if isinstance(table, dict) else raw
+
+
 def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
     """Project ``updates`` onto a slot-config ``base`` dict, copy-safe.
 
@@ -150,12 +177,19 @@ def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str
     (the store's selection→updates mapping and the manager's device/profile
     coherence stay with their respective callers):
 
-      - shallow-copies ``base`` so the caller's dict is never mutated,
+      - shallow-copies ``base`` (and, when nested, its ``[slot]`` sub-dict —
+        see below) so the caller's dict is never mutated,
       - runs a ONE-level-deep merge: for a key present as a dict on both
         sides the sub-tables are merged key-by-key (``{**existing, **value}``,
         so sibling ``[model]`` keys like ``default``/``context_size``
         survive); every other key (scalars, lists, dict-vs-scalar) replaces
-        wholesale — value wins,
+        wholesale — value wins. A DICT-valued update (a sibling table like
+        ``model``/``server``/``npu``) always lands at the ROOT; a
+        SCALAR-valued update lands in :func:`slot_scalar_table` — ``[slot]``
+        when ``base`` uses the nested shape, else the root itself (#1685:
+        merge_slot_config used to always project onto the root, which is a
+        silent no-op for a scalar update on a nested-shape file — see
+        :func:`slot_scalar_table`'s docstring),
       - treats an explicit ``None`` value in ``updates`` as **delete the key**
         (top level and one level deep). TOML has no null — ``tomli_w`` raises
         ``TypeError`` on a ``None`` value, so "set to null" could never be
@@ -169,23 +203,38 @@ def merge_slot_config(base: dict[str, Any], updates: dict[str, Any]) -> dict[str
 
     Copy-safety is load-bearing: the store diffs ``before`` against ``after``
     and rolls back to ``before`` on a failed commit, so the returned dict must
-    never share the ``[model]`` sub-dict with ``base``. Both the merge path
-    (which builds a fresh ``{**existing, **value}``) and the fold path (which
-    copies the sub-dict before ``pop``) honour that.
+    never share the ``[model]`` sub-dict (or, on a nested-shape base, the
+    ``[slot]`` sub-dict) with ``base``. The merge path (which builds a fresh
+    ``{**existing, **value}``) and the fold path (which copies the sub-dict
+    before ``pop``) both honour that.
     """
     after = dict(base)
+    nested = isinstance(base.get("slot"), dict)
+    if nested:
+        # Copy-safety for the [slot] sub-dict too: it is about to be mutated
+        # (scalar updates land in it), so `base["slot"]` must never be that
+        # same object.
+        after["slot"] = dict(base["slot"])
+    scalars = after["slot"] if nested else after
+
     for key, value in updates.items():
-        existing = after.get(key)
+        # A dict-VALUED update is a sibling TABLE ([model], [server], [npu],
+        # …) — those live at the root in BOTH on-disk shapes, never nested
+        # inside [slot]. Everything else is a slot scalar, which targets
+        # `scalars` ([slot] when nested, else the root — the same object as
+        # `after` in the flat case).
+        target = after if isinstance(value, dict) else scalars
+        existing = target.get(key)
         if value is None:
             # None = delete: remove the key so the TOML writer never sees a
             # null (tomli_w TypeError). Deleting a missing key is a no-op.
-            after.pop(key, None)
+            target.pop(key, None)
         elif isinstance(existing, dict) and isinstance(value, dict):
             sub = {**existing, **value}
             # Same None-deletes rule one level deep ({"server": {"extra_args": null}}).
-            after[key] = {k: v for k, v in sub.items() if v is not None}
+            target[key] = {k: v for k, v in sub.items() if v is not None}
         else:
-            after[key] = value
+            target[key] = value
 
     # #585: fold the legacy [model].ctx_size alias into the canonical
     # context_size via the ONE shared fold (:func:`fold_ctx_size_alias`).
@@ -763,6 +812,7 @@ __all__ = [
     "merge_slot_config",
     "reject_model_owned_slot_keys",
     "reject_removed_slot_keys",
+    "slot_scalar_table",
     "slot_write_lock",
     "unknown_slot_config_keys",
     "write_slot_toml",

--- a/src/hal0/slots/config_write.py
+++ b/src/hal0/slots/config_write.py
@@ -100,9 +100,15 @@ def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> No
 
     No-ops for slots without a GPU profile (npu/cpu/img profiles declare
     ``backend=None``) and for ``auto`` device (empty) unless the profile
-    itself changed. Mutates ``cfg_dict`` in place.
+    itself changed. Mutates ``cfg_dict`` in place — through
+    :func:`hal0.slot_config.slot_scalar_table` (#1685), since ``device``/
+    ``profile`` are scalar fields that live under ``[slot]`` on a
+    nested-shape config, not at ``cfg_dict``'s root.
     """
-    profile_name = cfg_dict.get("profile")
+    from hal0.slot_config import slot_scalar_table
+
+    scalars = slot_scalar_table(cfg_dict)
+    profile_name = scalars.get("profile")
     if not isinstance(profile_name, str) or not profile_name:
         return
 
@@ -117,7 +123,7 @@ def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> No
     from hal0.config.schema import map_backend_to_device
     from hal0.model_meta import device_to_backend
 
-    device = cfg_dict.get("device")
+    device = scalars.get("device")
     dev_backend = device_to_backend(str(device))[1] if device else None
     if dev_backend == prof_backend:
         return  # already coherent
@@ -129,14 +135,14 @@ def _reconcile_device_profile(cfg_dict: dict[str, Any], changed: set[str]) -> No
         # ``auto``/unset device: only adopt the profile's backend when the
         # operator explicitly (re)selected the profile; otherwise leave auto.
         if prof_changed:
-            cfg_dict["device"] = map_backend_to_device(prof_backend)
+            scalars["device"] = map_backend_to_device(prof_backend)
         return
 
     if prof_changed and not dev_changed:
-        cfg_dict["device"] = map_backend_to_device(prof_backend)
+        scalars["device"] = map_backend_to_device(prof_backend)
     elif dev_changed and not prof_changed and dev_backend is not None:
         catalog = load_profiles_config()
-        cfg_dict["profile"] = _base_profile_for_backend(catalog, dev_backend)
+        scalars["profile"] = _base_profile_for_backend(catalog, dev_backend)
     elif prof_changed and dev_changed:
         raise SlotConfigError(
             f"slot device {device!r} (backend {dev_backend!r}) conflicts with "

--- a/src/hal0/slots/npu/trio.py
+++ b/src/hal0/slots/npu/trio.py
@@ -26,7 +26,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
-from hal0.slot_config import write_slot_toml
+from hal0.slot_config import slot_scalar_table, write_slot_toml
 from hal0.slots._cfg_helpers import _cfg_to_dict
 from hal0.slots.layout import is_id_stem, resolve_slot_stem
 
@@ -55,21 +55,6 @@ def _log_renamed(old: str, canon: str) -> None:
     log.info("slot.trio_shadow_renamed", extra={"from": old, "to": canon})
 
 
-def _slot_table(raw: dict[str, Any]) -> dict[str, Any]:
-    """The table a slot's SCALAR fields actually live in.
-
-    Two on-disk shapes are supported: flat (scalars at the root, what the
-    runtime writes) and nested (scalars under ``[slot]``, the haloai shape the
-    id-keying migration preserves verbatim). ``_flatten_slot_toml`` treats
-    ``[slot]`` as authoritative and drops root scalars into ``extra`` when it
-    exists, so a writer that normalizes at the root of a nested file produces a
-    change the runtime never sees — and, worse, one that looks converged on the
-    next pass. Every field write here goes through this accessor instead.
-    """
-    table = raw.get("slot")
-    return table if isinstance(table, dict) else raw
-
-
 async def _relabel_shadow_in_place(mgr: NpuTrioHost, path: Path, old: str, canon: str) -> None:
     """Relabel an id-keyed shadow: TOML body + identity row, no file moves.
 
@@ -89,7 +74,7 @@ async def _relabel_shadow_in_place(mgr: NpuTrioHost, path: Path, old: str, canon
     import tomllib
 
     raw = tomllib.loads(path.read_text(encoding="utf-8"))
-    _slot_table(raw)["name"] = canon
+    slot_scalar_table(raw)["name"] = canon
     write_slot_toml(path, raw)
     identity = getattr(mgr, "_identity", None)
     if identity is not None and is_id_stem(path.stem):
@@ -232,7 +217,7 @@ async def reconcile_trio_slots(mgr: NpuTrioHost) -> int:
                     _log_renamed(prior, canon)
                 else:
                     raw_before = tomllib.loads(prior_path.read_text(encoding="utf-8"))
-                    _slot_table(raw_before)["name"] = canon
+                    slot_scalar_table(raw_before)["name"] = canon
                     canon_path = slots_dir / f"{canon}.toml"
                     write_slot_toml(canon_path, raw_before)
                     with contextlib.suppress(FileNotFoundError):
@@ -249,7 +234,7 @@ async def reconcile_trio_slots(mgr: NpuTrioHost) -> int:
                 # in: normalizing at the root of a ``[slot]``-nested file is
                 # invisible to the loader, and the duplicated root values then
                 # make the next pass look converged and suppress the repair.
-                table = _slot_table(raw)
+                table = slot_scalar_table(raw)
                 desired = {
                     "device": "npu",
                     "profile": "flm",

--- a/tests/config/test_profile_derivation_parity.py
+++ b/tests/config/test_profile_derivation_parity.py
@@ -191,3 +191,34 @@ def test_reconcile_device_flip_stays_non_mtp(tmp_hal0_home: str) -> None:
     cfg_dict2: dict[str, object] = {"device": "gpu-vulkan", "profile": "chat"}
     _reconcile_device_profile(cfg_dict2, changed={"device"})
     assert cfg_dict2["profile"] == "chat"
+
+
+def test_reconcile_device_profile_writes_into_nested_slot_table(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1685: _reconcile_device_profile must read/write device+profile
+    through slot_scalar_table, not the dict root — on a nested-shape
+    cfg_dict (scalars under [slot]) it used to always no-op (profile_name
+    read from the root came back None) and, worse, a write would have
+    landed on a root key _flatten_slot_toml discards."""
+    from hal0.config.schema import ProfileConfig, ProfilesConfig
+    from hal0.slots.config_write import _reconcile_device_profile
+
+    # Deliberately NOT named "chat" -- _base_profile_for_backend prefers a
+    # literal "chat" profile over any backend match, which would mask the
+    # thing this test is pinning.
+    catalog = ProfilesConfig(
+        profile={
+            "gpu-rocm-base": ProfileConfig(backend="rocm"),
+            "gpu-vulkan-base": ProfileConfig(backend="vulkan"),
+        }
+    )
+    monkeypatch.setattr("hal0.config.loader.load_profiles_config", lambda: catalog)
+
+    # A conflicting-backend flip (device -> vulkan, profile stayed the
+    # rocm-backed profile) must derive a coherent vulkan profile -- and land
+    # it in [slot], not the root, on a nested-shape cfg_dict.
+    cfg_dict: dict[str, object] = {"slot": {"device": "gpu-vulkan", "profile": "gpu-rocm-base"}}
+    _reconcile_device_profile(cfg_dict, changed={"device"})
+    assert cfg_dict["slot"]["profile"] == "gpu-vulkan-base"
+    assert "profile" not in cfg_dict

--- a/tests/slot_config/test_merge_slot_config.py
+++ b/tests/slot_config/test_merge_slot_config.py
@@ -19,10 +19,12 @@ import tomllib
 from pathlib import Path
 
 from hal0.capabilities.config import CapabilitySelection
+from hal0.config.loader import _flatten_slot_toml
 from hal0.slot_config import (
     SlotConfigStore,
     SlotSelection,
     merge_slot_config,
+    slot_scalar_table,
 )
 
 # ── merge_slot_config unit behaviour ─────────────────────────────────────────
@@ -115,6 +117,82 @@ def test_merge_does_not_alias_base_model_on_merge_path() -> None:
     after = merge_slot_config(base, {"model": {"context_size": 8192}})
     after["model"]["default"] = "mutated"
     assert base["model"]["default"] == "m"
+
+
+# ── nested ([slot]) shape projection (#1685) ─────────────────────────────────
+#
+# _flatten_slot_toml treats [slot] as AUTHORITATIVE when it exists: only its
+# keys become the loaded SlotConfig's scalars, and every top-level scalar
+# sibling is stashed into `extra` and ignored. merge_slot_config used to
+# always project scalar updates onto the ROOT regardless of shape, so a
+# scalar write on a nested-shape file landed on a key nobody reads.
+
+
+def test_merge_scalar_update_targets_nested_slot_table() -> None:
+    """A scalar update on a nested-shape base lands in [slot], not the root."""
+    base = {"slot": {"name": "embed", "device": "gpu-vulkan", "port": 8082}}
+    after = merge_slot_config(base, {"device": "gpu-rocm"})
+    assert after["slot"]["device"] == "gpu-rocm"
+    assert "device" not in after  # never duplicated at the root
+
+
+def test_merge_scalar_update_still_targets_root_on_flat_base() -> None:
+    """Flat-shape bases are unaffected — scalars still merge at the root."""
+    base = {"device": "gpu-vulkan", "port": 8082}
+    after = merge_slot_config(base, {"device": "gpu-rocm"})
+    assert after["device"] == "gpu-rocm"
+    assert "slot" not in after
+
+
+def test_merge_table_update_stays_at_root_on_nested_base() -> None:
+    """A sibling TABLE update ([model]/[server]/[npu]) always lands at the
+    root — it is never nested inside [slot] in either on-disk shape."""
+    base = {
+        "slot": {"name": "embed", "device": "gpu-vulkan"},
+        "model": {"default": "old-model"},
+    }
+    after = merge_slot_config(base, {"model": {"default": "new-model"}})
+    assert after["model"] == {"default": "new-model"}
+    assert "model" not in after["slot"]
+
+
+def test_merge_scalar_delete_on_nested_base_targets_slot_table() -> None:
+    base = {"slot": {"name": "embed", "mtp": True}}
+    after = merge_slot_config(base, {"mtp": None})
+    assert "mtp" not in after["slot"]
+
+
+def test_merge_nested_base_slot_subdict_is_copy_safe() -> None:
+    """The [slot] sub-dict is copied before mutation, like [model]."""
+    base = {"slot": {"name": "embed", "device": "gpu-vulkan"}}
+    after = merge_slot_config(base, {"device": "gpu-rocm"})
+    assert base["slot"]["device"] == "gpu-vulkan"
+    assert after["slot"]["device"] == "gpu-rocm"
+
+
+def test_merge_nested_shape_round_trips_through_flatten() -> None:
+    """End-to-end: a scalar write survives the SAME read path the runtime
+    uses (_flatten_slot_toml) — the actual regression from #1685. Before the
+    fix, `_flatten_slot_toml("embed").device` would still read "gpu-vulkan"
+    after this merge, because the write landed on a root key `_flatten_slot_toml`
+    discards into `extra` whenever `[slot]` exists."""
+    base = {
+        "slot": {"name": "embed", "device": "gpu-vulkan", "port": 8082},
+        "model": {"default": "nomic-embed:v1"},
+    }
+    after = merge_slot_config(base, {"device": "gpu-rocm"})
+    flat = _flatten_slot_toml(after, "embed")
+    assert flat["device"] == "gpu-rocm"
+
+
+def test_slot_scalar_table_returns_slot_subdict_when_nested() -> None:
+    raw = {"slot": {"name": "embed"}, "model": {"default": "m"}}
+    assert slot_scalar_table(raw) is raw["slot"]
+
+
+def test_slot_scalar_table_returns_root_when_flat() -> None:
+    raw = {"name": "embed", "device": "gpu-vulkan"}
+    assert slot_scalar_table(raw) is raw
 
 
 # ── store integration: copy-safety survives commit ───────────────────────────


### PR DESCRIPTION
## Summary
- `_flatten_slot_toml` treats `[slot]` as AUTHORITATIVE whenever it exists on load: only its keys become the loaded `SlotConfig`'s scalar fields, and every top-level scalar sibling is stashed into `extra` and ignored. `merge_slot_config` always projected scalar updates onto the ROOT regardless of on-disk shape, so a write of `device`/`provider`/`profile`/`port`/`type`/`served_by` on a nested-shape file (hand-edited, `loader.save_slot_config`, `migrate_slot_id_keying`'s preserved output) landed on a key nobody reads — reports success, the runtime keeps the old value, and the duplicated root scalar makes the next drift comparison look converged, suppressing repair.
- Every writer through the shared pipeline was affected: `SlotConfigStore._reconciled_slot` (capability enable / tts+stt engine switch), `SlotManager.update_config` (slot edit drawer), and `hal0.stacks.apply`. `[model]` is a sibling TABLE in both shapes, so model binds/unbinds were unaffected — the silent field was the scalar set only.
- Added `slot_scalar_table()` — the shape-aware accessor (`[slot]` when it exists, else the root — the read-side twin of `_flatten_slot_toml`'s own rule) — and made `merge_slot_config` route scalar updates through it while dict-valued (sibling table) updates keep landing at the root in both shapes.
- `_reconcile_device_profile` (`config_write.py`) gets the same treatment: it read/wrote `device`/`profile` at `cfg_dict`'s root directly, which would have undone the merge fix for exactly the two fields the issue's repro names.
- `hal0.slots.npu.trio`'s local `_slot_table` (added in PR #1681 for the same reason) collapses into the shared helper.

## Test plan
- [x] `tests/slot_config/test_merge_slot_config.py` — 7 new cases: scalar update targets `[slot]` on nested base, flat base unaffected, sibling table always at root, scalar delete on nested base, `[slot]` copy-safety, an end-to-end round trip through the actual `_flatten_slot_toml` read path (the literal regression), plus direct `slot_scalar_table` coverage
- [x] `tests/config/test_profile_derivation_parity.py` — new case pinning `_reconcile_device_profile` writing into `[slot]` on a nested-shape `cfg_dict`
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slot_config/ tests/slots/ tests/config/ tests/api/test_slot_config_validation.py tests/api/test_stacks_routes.py tests/cli/test_slot_metrics_capacity.py -q` — 988 passed
- [x] `uv run ruff check/format`, `scripts/check_sunset.py` — clean

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)