### PR TITLE
fix(update): refresh the privileged sudo wrappers on every activate

### DIFF
--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -2649,6 +2649,148 @@ def _restore_service_ownership(root: Path, *, job_id: str | None = None) -> None
         log.warning("updater.cache_chown_failed", job_id=job_id, path=str(root), error=str(exc))
 
 
+def refresh_privileged_wrappers(target: Path, *, job_id: str | None = None) -> dict[str, Any]:
+    """Re-install the privileged sudo wrappers from the just-activated release (#1689).
+
+    ``install.sh`` was the ONLY installer of ``${LIB_DIR}/bin/hal0-*`` — self-
+    update never touched them, so a box upgraded through ``hal0 update`` kept
+    running every NEW hal0 release against the OLD wrapper. Any seam verb
+    added after the box's last ``install.sh`` run (``stop-agent``/#453, the
+    ``svc-<verb>`` companion-service family/#1590, ``write-hindsight-
+    dropin``/#1641) was rejected by the stale wrapper with
+    ``hal0-systemctl: bad cmd: <verb>`` / exit 64 on any box that only ever
+    updated, never re-ran the installer.
+
+    Privileged-side ONLY: a no-op unless ``os.geteuid() == 0`` — the same
+    guard :func:`_restore_service_ownership` uses just above. The
+    unprivileged daemon (``hal0-api`` running ``User=hal0``) must never write
+    ``${LIB_DIR}/bin`` or ``/etc/sudoers.d`` itself; it only ever reaches this
+    function by way of the root-side seam
+    (:func:`hal0.updater.privileged.main`'s ``activate`` verb, run under
+    ``sudo -n hal0-update activate``), which is what makes the euid-0 check
+    sufficient rather than a bare "are we routed" flag — an operator's direct
+    ``sudo hal0 update`` and a root dev/CI run reach the SAME euid-0 branch,
+    with no seam in between, and refresh correctly too.
+
+    Trust: by the time :func:`activate_release` calls this, ``target`` has
+    already passed ``assert_trusted_release_dir`` (root-owned) and cosign
+    verification, and ``pip install`` has already executed that tree's build
+    backend as root — copying its ``installer/wrappers/*`` here is strictly
+    LESS privileged than that, so this adds no new trust assumption.
+
+    Best-effort, per seam: :data:`hal0.system.seam_check.SEAMS` is the
+    canonical wrapper inventory (kept in lock-step with ``install.sh``'s
+    per-seam blocks — #1465's lesson). A release tree missing an optional
+    wrapper source is skipped, not fatal: a stale wrapper is a correctness
+    gap the seam already surfaces loudly (#1682's remediation line) or that
+    ``hal0 doctor`` catches, never a reason to fail an otherwise-successful
+    activate.
+
+    The matching ``/etc/sudoers.d/<seam>`` drop-in is reinstalled ONLY when
+    its content actually changed, and ONLY after an independent
+    ``visudo -cf`` pass on the release tree's copy — a malformed drop-in must
+    never reach ``/etc/sudoers.d``, corrupted release tree or not.
+    """
+    if os.geteuid() != 0:
+        return {"refreshed": [], "sudoers_refreshed": [], "errors": {}}
+
+    from hal0.system.seam_check import SEAM_BIN_DIR, SEAMS, SUDOERS_DIR
+
+    refreshed: list[str] = []
+    sudoers_refreshed: list[str] = []
+    errors: dict[str, str] = {}
+
+    for seam in SEAMS:
+        src = target / "installer" / "wrappers" / seam.name
+        if src.is_file():
+            dest = SEAM_BIN_DIR / seam.name
+            try:
+                SEAM_BIN_DIR.mkdir(parents=True, exist_ok=True)
+                subprocess.run(  # nosec B603 — fixed argv, no caller input
+                    ["install", "-m", "0755", "-o", "root", "-g", "root", str(src), str(dest)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                refreshed.append(seam.name)
+            except subprocess.CalledProcessError as exc:
+                msg = (exc.stderr or str(exc)).strip()[:300]
+                errors[seam.name] = msg
+                log.warning(
+                    "updater.wrapper_refresh_failed", job_id=job_id, seam=seam.name, error=msg
+                )
+            except (OSError, subprocess.SubprocessError) as exc:
+                errors[seam.name] = str(exc)
+                log.warning(
+                    "updater.wrapper_refresh_failed",
+                    job_id=job_id,
+                    seam=seam.name,
+                    error=str(exc),
+                )
+
+        sudoers_src = target / "packaging" / "sudoers" / seam.name
+        if not sudoers_src.is_file():
+            continue
+        sudoers_dest = SUDOERS_DIR / seam.name
+        try:
+            new_content = sudoers_src.read_text(encoding="utf-8")
+            old_content = (
+                sudoers_dest.read_text(encoding="utf-8") if sudoers_dest.exists() else None
+            )
+            if new_content == old_content:
+                continue
+            check = subprocess.run(  # nosec B603 — fixed argv, no caller input
+                ["visudo", "-cf", str(sudoers_src)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if check.returncode != 0:
+                log.warning(
+                    "updater.sudoers_refresh_rejected",
+                    job_id=job_id,
+                    seam=seam.name,
+                    stderr=(check.stderr or "").strip()[:300],
+                )
+                continue
+            SUDOERS_DIR.mkdir(parents=True, exist_ok=True)
+            subprocess.run(  # nosec B603 — fixed argv, no caller input
+                [
+                    "install",
+                    "-m",
+                    "0440",
+                    "-o",
+                    "root",
+                    "-g",
+                    "root",
+                    str(sudoers_src),
+                    str(sudoers_dest),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            sudoers_refreshed.append(seam.name)
+        except (OSError, subprocess.SubprocessError) as exc:
+            msg = (
+                (exc.stderr or str(exc)).strip()[:300]
+                if isinstance(exc, subprocess.CalledProcessError)
+                else str(exc)
+            )
+            log.warning("updater.sudoers_refresh_failed", job_id=job_id, seam=seam.name, error=msg)
+
+    log.info(
+        "updater.wrappers_refreshed",
+        job_id=job_id,
+        refreshed=refreshed,
+        sudoers_refreshed=sudoers_refreshed,
+        errors=errors or None,
+    )
+    return {"refreshed": refreshed, "sudoers_refreshed": sudoers_refreshed, "errors": errors}
+
+
 def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, Any]:
     """§9 step 8 + 8b: swap ``current`` to ``<usr_lib>/<dir_name>`` and re-pip it.
 
@@ -2703,13 +2845,23 @@ def activate_release(dir_name: str, *, job_id: str | None = None) -> dict[str, A
                     _atomic_symlink_swap(prior, link)
             raise
 
+    # #1689: re-install the privileged sudo wrappers from the tree we just
+    # activated — best-effort, never fatal to an otherwise-successful
+    # activate (a wrapper that fails to refresh keeps the OLD one in place,
+    # same class of degradation as before this fix, not a new failure mode).
+    wrappers = refresh_privileged_wrappers(target, job_id=job_id)
+
     log.info(
         "updater.activate_ok",
         job_id=job_id,
         target=str(target),
         previous=str(prior) if prior else None,
     )
-    return {"previous": str(prior) if prior else None, "target": str(target)}
+    return {
+        "previous": str(prior) if prior else None,
+        "target": str(target),
+        "wrappers_refreshed": wrappers["refreshed"],
+    }
 
 
 def discard_release(dir_name: str, *, job_id: str | None = None) -> None:
@@ -3272,6 +3424,7 @@ __all__ = [
     "ensure_seed_profiles",
     "fetch_release_manifest",
     "profile_reset_status",
+    "refresh_privileged_wrappers",
     "release_dir_name",
     "releases_url",
     "reset_profile_catalog",

--- a/tests/updater/test_wrapper_refresh.py
+++ b/tests/updater/test_wrapper_refresh.py
@@ -1,0 +1,240 @@
+"""#1689 — self-update never refreshed the privileged sudo wrappers.
+
+``install.sh`` was the ONLY installer of ``${LIB_DIR}/bin/hal0-*``. Self-update
+swapped the ``current`` symlink and re-pipped the venv but never touched the
+wrappers, so a box upgraded exclusively through ``hal0 update`` kept running
+every new hal0 release against whatever wrapper its last ``install.sh`` run
+left behind — any seam verb added since (``stop-agent``/#453, the
+``svc-<verb>`` family/#1590, ``write-hindsight-dropin``/#1641) was rejected
+with ``hal0-systemctl: bad cmd: <verb>`` on such a box.
+
+These tests pin :func:`hal0.updater.updater.refresh_privileged_wrappers`:
+privileged-side only (a no-op unless euid 0), best-effort per seam, and the
+sudoers drop-in reinstalled only on genuine content change and only after an
+independent ``visudo -cf`` pass.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.updater.updater import refresh_privileged_wrappers
+
+
+class FakeRun:
+    """Recording stand-in for ``subprocess.run`` — never touches the real OS."""
+
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        if kwargs.get("check") and self.returncode != 0:
+            raise subprocess.CalledProcessError(self.returncode, argv, stderr=self.stderr)
+        return subprocess.CompletedProcess(argv, self.returncode, self.stdout, self.stderr)
+
+
+def _release_tree(tmp_path: Path, *, seams: tuple[str, ...], with_sudoers: bool = False) -> Path:
+    target = tmp_path / "hal0-1.0.0"
+    wrappers = target / "installer" / "wrappers"
+    wrappers.mkdir(parents=True)
+    for name in seams:
+        (wrappers / name).write_text(f"#!/bin/sh\n# {name} v2\n", encoding="utf-8")
+    if with_sudoers:
+        sudoers = target / "packaging" / "sudoers"
+        sudoers.mkdir(parents=True)
+        for name in seams:
+            (sudoers / name).write_text(
+                f"hal0 ALL=(root) NOPASSWD: /usr/lib/hal0/bin/{name}\n", encoding="utf-8"
+            )
+    return target
+
+
+@pytest.fixture
+def seam_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Redirect the wrapper/sudoers destinations to a throwaway tree.
+
+    ``refresh_privileged_wrappers`` locally imports ``SEAM_BIN_DIR`` /
+    ``SUDOERS_DIR`` on every call, so patching the module attributes here is
+    picked up fresh each time — no need to patch a cached binding.
+    """
+    bin_dir = tmp_path / "usr-lib-hal0-bin"
+    sudoers_dir = tmp_path / "etc-sudoers.d"
+    monkeypatch.setattr("hal0.system.seam_check.SEAM_BIN_DIR", bin_dir)
+    monkeypatch.setattr("hal0.system.seam_check.SUDOERS_DIR", sudoers_dir)
+    return bin_dir, sudoers_dir
+
+
+def test_noop_when_not_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    """The unprivileged daemon must never write the wrapper tree itself."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 1000)
+    fake_run = FakeRun()
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",))
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result == {"refreshed": [], "sudoers_refreshed": [], "errors": {}}
+    assert fake_run.calls == []
+
+
+def test_root_refreshes_every_wrapper_present_in_the_release_tree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    fake_run = FakeRun()
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(
+        tmp_path,
+        seams=("hal0-systemctl", "hal0-update", "hal0-agentenv", "hal0-benchctl", "hal0-podman-ro"),
+    )
+
+    result = refresh_privileged_wrappers(target, job_id="job-1")
+
+    assert set(result["refreshed"]) == {
+        "hal0-systemctl",
+        "hal0-update",
+        "hal0-agentenv",
+        "hal0-benchctl",
+        "hal0-podman-ro",
+    }
+    assert result["errors"] == {}
+    install_calls = [c for c in fake_run.calls if c[0] == "install"]
+    assert len(install_calls) == 5
+    for call in install_calls:
+        assert call[:3] == ["install", "-m", "0755"]
+        assert "-o" in call and "root" in call
+        assert "-g" in call and "root" in call
+
+
+def test_skips_a_seam_missing_from_the_release_tree_without_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    """A release tree that only ships some wrapper sources (or none at all,
+    e.g. a stripped-down channel) must not fail the activate over it."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    fake_run = FakeRun()
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",))
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result["refreshed"] == ["hal0-systemctl"]
+    assert result["errors"] == {}
+
+
+def test_install_failure_is_recorded_not_raised(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    """A wrapper refresh failure must be fail-soft — the OLD wrapper stays in
+    place, same degradation class as before this fix, never a new one; it
+    must not tear down an otherwise-successful activate."""
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    fake_run = FakeRun(returncode=1, stderr="install: permission denied")
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",))
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result["refreshed"] == []
+    assert "hal0-systemctl" in result["errors"]
+    assert "permission denied" in result["errors"]["hal0-systemctl"]
+
+
+def test_sudoers_dropin_reinstalled_only_on_content_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    _bin_dir, sudoers_dir = seam_dirs
+    sudoers_dir.mkdir(parents=True)
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    fake_run = FakeRun()  # visudo -cf and install both "succeed"
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",), with_sudoers=True)
+
+    # Already-identical on-disk drop-in — visudo/install must not run for it.
+    (sudoers_dir / "hal0-systemctl").write_text(
+        (target / "packaging" / "sudoers" / "hal0-systemctl").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result["sudoers_refreshed"] == []
+    assert not any(c[0] == "visudo" for c in fake_run.calls)
+
+
+def test_sudoers_dropin_reinstalled_when_content_differs_and_validates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    _bin_dir, sudoers_dir = seam_dirs
+    sudoers_dir.mkdir(parents=True)
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+    fake_run = FakeRun()
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", fake_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",), with_sudoers=True)
+    (sudoers_dir / "hal0-systemctl").write_text("stale old grant\n", encoding="utf-8")
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result["sudoers_refreshed"] == ["hal0-systemctl"]
+    assert any(c[0] == "visudo" and c[1] == "-cf" for c in fake_run.calls)
+    install_sudoers_calls = [c for c in fake_run.calls if c[0] == "install" and c[2] == "0440"]
+    assert len(install_sudoers_calls) == 1
+
+
+def test_sudoers_dropin_never_installed_when_visudo_rejects_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    """A malformed drop-in must never reach /etc/sudoers.d, corrupted
+    release tree or not — visudo -cf is checked BEFORE install runs."""
+    _bin_dir, sudoers_dir = seam_dirs
+    sudoers_dir.mkdir(parents=True)
+    monkeypatch.setattr("hal0.updater.updater.os.geteuid", lambda: 0)
+
+    def selective_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if argv[0] == "visudo":
+            return subprocess.CompletedProcess(argv, 1, "", "syntax error near line 1")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    calls: list[list[str]] = []
+
+    def recording_run(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(list(argv))
+        return selective_run(argv, **kwargs)
+
+    monkeypatch.setattr("hal0.updater.updater.subprocess.run", recording_run)
+    target = _release_tree(tmp_path, seams=("hal0-systemctl",), with_sudoers=True)
+    (sudoers_dir / "hal0-systemctl").write_text("stale old grant\n", encoding="utf-8")
+
+    result = refresh_privileged_wrappers(target)
+
+    assert result["sudoers_refreshed"] == []
+    assert any(c[0] == "visudo" for c in calls)
+    assert not any(c[0] == "install" and "0440" in c for c in calls)
+
+
+def test_activate_release_includes_wrappers_refreshed_key(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch, seam_dirs: tuple[Path, Path]
+) -> None:
+    """Integration: activate_release surfaces the refresh result. Under test
+    (non-root) it must be an empty list, not a missing key or a crash."""
+    from hal0.updater.updater import _usr_lib_root, activate_release
+
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: True)
+    root = _usr_lib_root()
+    root.mkdir(parents=True, exist_ok=True)
+    new = root / "hal0-1.0.0"
+    new.mkdir()
+
+    result = activate_release("hal0-1.0.0")
+
+    assert result["wrappers_refreshed"] == []


### PR DESCRIPTION
## Summary

The privileged wrappers under `${LIB_DIR}/bin` (`hal0-systemctl`, `hal0-update`, `hal0-agentenv`, `hal0-benchctl`, `hal0-podman-ro`) were installed ONLY by `install.sh`. Self-update swapped the `current` symlink and re-pipped the venv but never touched them, so a box upgraded exclusively through `hal0 update` kept running every new hal0 release against whatever wrapper its last `install.sh` run left behind. Any seam verb added since (`stop-agent`/#453, the `svc-<verb>` companion-service family/#1590, `write-hindsight-dropin`/#1641) was rejected by the stale wrapper with `hal0-systemctl: bad cmd: <verb>` / exit 64 — structurally reachable on any box that only ever updated. Systemic, not specific to one feature.

## Design (privileged side only)

Added `refresh_privileged_wrappers()`, called from `activate_release` right after the venv re-pip. **Privileged-side only** — a no-op unless `os.geteuid() == 0`, the same guard `_restore_service_ownership` already uses just above it. The unprivileged `hal0-api` daemon only ever reaches this by way of the root seam (`hal0.updater.privileged.main`'s `activate` verb, invoked under `sudo -n hal0-update activate`); an operator's direct `sudo hal0 update` or a root dev/CI run share the same euid-0 branch and refresh correctly too.

**Trust**: by the time this runs, the caller has already proven the release tree is root-owned (`assert_trusted_release_dir`) and cosign-verified, and `pip install` has already executed that tree's build backend as root — copying its `installer/wrappers/*` is strictly LESS privileged than that, so this adds no new trust assumption.

`seam_check.SEAMS` is the canonical wrapper inventory (#1465's keep-in-lock-step lesson) — best-effort per seam, a release tree missing an optional wrapper source is skipped, never fatal to an otherwise-successful activate. The matching `/etc/sudoers.d/<seam>` drop-in is reinstalled only when its content actually changed, and only after an independent `visudo -cf` pass on the release tree's copy, so a malformed drop-in can never reach `/etc/sudoers.d`.

**Deferred (open question in the issue, not required for this fix)**: whether `hal0 doctor` should also diff the installed wrapper against the release-tree copy to catch a stale seam before an operator trips over it. Left for a follow-up — this PR closes the actual data-loss/silent-staleness path.

## Operator pre-approval

Per team-lead: the operator has pre-approved merging the seam PRs, including this one, so automerge is enabled here despite touching the privileged surface.

## Test plan
- [x] `tests/updater/test_wrapper_refresh.py` (new) — 8 cases: no-op when not root, refreshes every wrapper present in the release tree, skips a wrapper missing from the tree without erroring, install failure recorded fail-soft (never raised), sudoers drop-in skipped when content is identical, reinstalled when content differs and `visudo -cf` passes, never installed when `visudo -cf` rejects it, and an `activate_release` integration check
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater/ tests/api/test_updater_routes.py tests/system/ -x -q` — 305 + 152 passed
- [x] `uv run ruff check/format`, `scripts/check_sunset.py` — clean

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)