### PR TITLE
fix(config): route every hal0.toml writer through one serialized RMW path

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -687,42 +687,56 @@ fi
 HAL0_TOML="${ETC_DIR}/hal0.toml"
 if [[ "${MODELS_DIR}" != "/var/lib/hal0/models" ]]; then
     if ! grep -qE "^\\s*store\\s*=\\s*\"${MODELS_DIR//\//\\/}\"" "${HAL0_TOML}" 2>/dev/null; then
-        if [[ -f "${HAL0_TOML}" ]] && grep -q "^\\[models\\]" "${HAL0_TOML}"; then
-            # [models] table exists — patch store + pull_root in place (or
-            # append under the existing table). Cheap regex pass; no toml
-            # parser so we accept the limitation that nested tables under
-            # [models.xxx] aren't supported (the schema has none).
-            python3 - "${HAL0_TOML}" "${MODELS_DIR}" <<'PYEOF'
-import sys, re, pathlib
+        # ONE locked read-modify-write for every case (existing [models] table,
+        # table-less file, no file at all). This step runs BEFORE hal0-api is
+        # restarted below, i.e. against a possibly-live daemon that may be
+        # serving a settings PUT, so it takes the same `hal0.toml.lock` advisory
+        # lock every in-process writer holds (hal0.config.locking / #1721) —
+        # otherwise the installer and the API can erase each other's section.
+        # Plain fcntl on purpose: this is system python3, which cannot import
+        # hal0 (the venv does not exist yet at this point).
+        mkdir -p "${ETC_DIR}"
+        python3 - "${HAL0_TOML}" "${MODELS_DIR}" <<'PYEOF'
+import fcntl, os, pathlib, re, stat, sys
 path = pathlib.Path(sys.argv[1])
 new_root = sys.argv[2]
-text = path.read_text(encoding="utf-8")
-# Replace existing store/pull_root inside [models], else append before the
-# next [section]. The section body is "every following line that does not
-# START with '['" — NOT `[^\[]*`, which the old patcher used and which
-# stopped at the first '[' of a list value like roots = ["/x"], splicing
-# the table in half and corrupting the TOML.
-m = re.search(r"^\[models\][ \t]*\n(?:(?!\[).*\n?)*", text, flags=re.MULTILINE)
-if m:
-    block = m.group(0)
-    for key in ("store", "pull_root"):
-        if re.search(rf"^\s*{key}\s*=", block, flags=re.MULTILINE):
-            block = re.sub(rf"^\s*{key}\s*=.*$",
-                           f'{key} = "{new_root}"',
-                           block, count=1, flags=re.MULTILINE)
-        else:
-            block = block.rstrip() + f'\n{key} = "{new_root}"\n'
-    if not block.endswith("\n"):
-        block += "\n"
-    text = text[:m.start()] + block + text[m.end():]
-else:
-    text = text.rstrip() + f'\n\n[models]\nstore = "{new_root}"\npull_root = "{new_root}"\n'
-path.write_text(text, encoding="utf-8")
+
+# Same lock file, same O_NOFOLLOW discipline as hal0.config.locking.file_lock:
+# /etc/hal0 is service-writable under the ownership flip while this script runs
+# as root, so following a symlink here would be a privilege hole.
+lock_path = pathlib.Path(f"{path}.lock")
+fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o664)
+try:
+    if not stat.S_ISREG(os.fstat(fd).st_mode):
+        raise SystemExit(f"lock path is not a regular file: {lock_path}")
+    fcntl.flock(fd, fcntl.LOCK_EX)
+
+    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    # Replace existing store/pull_root inside [models], else append before the
+    # next [section]. The section body is "every following line that does not
+    # START with '['" — NOT `[^\[]*`, which the old patcher used and which
+    # stopped at the first '[' of a list value like roots = ["/x"], splicing
+    # the table in half and corrupting the TOML.
+    m = re.search(r"^\[models\][ \t]*\n(?:(?!\[).*\n?)*", text, flags=re.MULTILINE)
+    if m:
+        block = m.group(0)
+        for key in ("store", "pull_root"):
+            if re.search(rf"^\s*{key}\s*=", block, flags=re.MULTILINE):
+                block = re.sub(rf"^\s*{key}\s*=.*$",
+                               f'{key} = "{new_root}"',
+                               block, count=1, flags=re.MULTILINE)
+            else:
+                block = block.rstrip() + f'\n{key} = "{new_root}"\n'
+        if not block.endswith("\n"):
+            block += "\n"
+        text = text[:m.start()] + block + text[m.end():]
+    else:
+        text = text.rstrip() + f'\n\n[models]\nstore = "{new_root}"\npull_root = "{new_root}"\n'
+        text = text.lstrip("\n")
+    path.write_text(text, encoding="utf-8")
+finally:
+    os.close(fd)
 PYEOF
-        else
-            mkdir -p "${ETC_DIR}"
-            printf '\n[models]\nstore = "%s"\npull_root = "%s"\n' "${MODELS_DIR}" "${MODELS_DIR}" >> "${HAL0_TOML}"
-        fi
         info "wrote [models].store (+pull_root) → ${HAL0_TOML}"
     fi
 fi

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -697,7 +697,7 @@ if [[ "${MODELS_DIR}" != "/var/lib/hal0/models" ]]; then
         # hal0 (the venv does not exist yet at this point).
         mkdir -p "${ETC_DIR}"
         python3 - "${HAL0_TOML}" "${MODELS_DIR}" <<'PYEOF'
-import fcntl, os, pathlib, re, stat, sys
+import fcntl, os, pathlib, re, stat, sys, tempfile
 path = pathlib.Path(sys.argv[1])
 new_root = sys.argv[2]
 
@@ -733,7 +733,36 @@ try:
     else:
         text = text.rstrip() + f'\n\n[models]\nstore = "{new_root}"\npull_root = "{new_root}"\n'
         text = text.lstrip("\n")
-    path.write_text(text, encoding="utf-8")
+
+    # Same-dir tempfile + fsync + os.replace, exactly like
+    # hal0.config.loader.write_toml_atomic. The advisory lock binds only
+    # COOPERATING writers; every API read path calls load_hal0_config()
+    # unlocked, so a truncate-then-write here is observable by a live daemon as
+    # an empty file (= silently all-defaults) or as half-written TOML that
+    # fails to parse. The rename is atomic, so a reader sees either the old
+    # file or the new one and never a torn one.
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp:
+            tmp.write(text)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        if path.exists():
+            # Preserve the config's existing mode/ownership across the replace
+            # (0600 root:root, or hal0-owned under the service-user flip).
+            st = path.stat()
+            os.chmod(tmp_name, stat.S_IMODE(st.st_mode))
+            try:
+                os.chown(tmp_name, st.st_uid, st.st_gid)
+            except PermissionError:
+                pass
+        else:
+            os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        if tmp_name is not None and os.path.exists(tmp_name):
+            os.unlink(tmp_name)
 finally:
     os.close(fd)
 PYEOF

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -730,7 +730,29 @@ try:
             pass
     fcntl.flock(fd, fcntl.LOCK_EX)
 
-    text = path.read_text(encoding="utf-8") if path.exists() else ""
+    # Read the TARGET through O_NOFOLLOW too, not just the lock file. This runs
+    # as root while /etc/hal0 is writable by the hal0 service account, so a
+    # symlinked hal0.toml would otherwise be followed: the read would slurp a
+    # root-only file and the replace below would copy its contents into
+    # /etc/hal0/hal0.toml, which the installer's later `doctor perms --fix`
+    # step then hands to the hal0 account. Refuse the symlink instead.
+    if path.is_symlink():
+        raise SystemExit(f"refusing to write through a symlinked config: {path}")
+    text = ""
+    if path.exists():
+        try:
+            tfd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            raise SystemExit(f"refusing to read config {path}: {exc}") from None
+        try:
+            if not stat.S_ISREG(os.fstat(tfd).st_mode):
+                raise SystemExit(f"config is not a regular file: {path}")
+            with os.fdopen(tfd, "r", encoding="utf-8") as fh_target:
+                tfd = -1
+                text = fh_target.read()
+        finally:
+            if tfd >= 0:
+                os.close(tfd)
     # Replace existing store/pull_root inside [models], else append before the
     # next [section]. The section body is "every following line that does not
     # START with '['" — NOT `[^\[]*`, which the old patcher used and which

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -705,10 +705,29 @@ new_root = sys.argv[2]
 # /etc/hal0 is service-writable under the ownership flip while this script runs
 # as root, so following a symlink here would be a privilege hole.
 lock_path = pathlib.Path(f"{path}.lock")
-fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o664)
+created = False
+try:
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o664)
+    created = True
+except FileExistsError:
+    fd = os.open(lock_path, os.O_RDWR | os.O_NOFOLLOW)
 try:
     if not stat.S_ISREG(os.fstat(fd).st_mode):
         raise SystemExit(f"lock path is not a regular file: {lock_path}")
+    if created:
+        # This script runs as root under `umask 022`, so the creation mode
+        # would land 0644 root:root and the hal0 daemon — which opens the lock
+        # O_RDWR — could then never take it, failing EVERY config write until a
+        # doctor perms --fix. Set the mode explicitly and adopt the guarded
+        # file's owner so the lock follows the service-user ownership flip.
+        os.fchmod(fd, 0o664)
+        src = path if path.exists() else path.parent
+        try:
+            st_src = src.stat()
+            if (st_src.st_uid, st_src.st_gid) != (0, 0):
+                os.fchown(fd, st_src.st_uid, st_src.st_gid)
+        except OSError:
+            pass
     fcntl.flock(fd, fcntl.LOCK_EX)
 
     text = path.read_text(encoding="utf-8") if path.exists() else ""

--- a/src/hal0/api/routes/auth.py
+++ b/src/hal0/api/routes/auth.py
@@ -24,7 +24,7 @@ from hal0.api.auth import (
     trust_forwarded_for_enabled,
     verify_admin_key,
 )
-from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.loader import hal0_config_txn
 from hal0.errors import BadRequest, TooManyRequests, Unauthorized
 from hal0.security.exposure import OPEN_ALLOWLIST, RULES, AuthClass
 from hal0.service_identity import rotate_api_env_key
@@ -167,12 +167,15 @@ async def set_require_auth(body: RequireAuthRequest, request: Request) -> dict[s
             code="auth.no_admin_key",
         )
 
-    cfg = load_hal0_config()
-    cfg.security.require_auth = body.require_auth
-    save_hal0_config(cfg)
-    # Keep the in-process settings view (app.state.hal0_config) coherent with
-    # what other settings surfaces read, matching routes/settings.py.
-    request.app.state.hal0_config = cfg
+    # Serialized read-modify-write (#1721): unlocked, this toggle could
+    # persist its own pre-read snapshot over a concurrent settings /
+    # memory-graph / models / channel write. ``txn.save`` also keeps the
+    # in-process settings view (app.state.hal0_config) coherent with what the
+    # other settings surfaces read.
+    async with hal0_config_txn(request) as txn:
+        cfg = txn.config
+        cfg.security.require_auth = body.require_auth
+        txn.save(cfg)
     log.info("hal0.auth.require_toggled", require_auth=body.require_auth)
     return {"require_auth": body.require_auth, "applies_live": True}
 

--- a/src/hal0/api/routes/config.py
+++ b/src/hal0/api/routes/config.py
@@ -23,7 +23,7 @@ from pydantic import ValidationError
 
 from hal0.api._redact import redact_config
 from hal0.api.middleware.error_codes import Hal0Error
-from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import ModelsConfig
 from hal0.registry.discover import scan_and_register
 
@@ -284,32 +284,37 @@ async def update_models_config(request: Request) -> dict[str, Any]:
     if not isinstance(body, dict):
         raise Hal0Error("request body must be a JSON object")
 
-    cfg = load_hal0_config()
-    merged_raw = {**cfg.models.model_dump(mode="python"), **body}
-    try:
-        new_models = ModelsConfig.model_validate(merged_raw)
-    except ValidationError as exc:
-        raise ConfigInvalidError(
-            "models config failed schema validation",
-            details=_validation_error_details(exc),
-        ) from exc
+    # Serialized read-modify-write (#1721): this route used to load, merge and
+    # save hal0.toml with no lock at all, so it could persist its own
+    # pre-read snapshot over a concurrent settings / memory-graph / auth /
+    # channel write and erase that section.
+    async with hal0_config_txn(request) as txn:
+        cfg = txn.config
+        merged_raw = {**cfg.models.model_dump(mode="python"), **body}
+        try:
+            new_models = ModelsConfig.model_validate(merged_raw)
+        except ValidationError as exc:
+            raise ConfigInvalidError(
+                "models config failed schema validation",
+                details=_validation_error_details(exc),
+            ) from exc
 
-    # pull_root is always implicitly scanned — otherwise a user who only
-    # ever pulls (never points roots at an external dir) gets an empty
-    # registry after a save.
-    if new_models.pull_root not in new_models.roots:
-        new_models = new_models.model_copy(
-            update={"roots": [*new_models.roots, new_models.pull_root]},
-        )
+        # pull_root is always implicitly scanned — otherwise a user who only
+        # ever pulls (never points roots at an external dir) gets an empty
+        # registry after a save.
+        if new_models.pull_root not in new_models.roots:
+            new_models = new_models.model_copy(
+                update={"roots": [*new_models.roots, new_models.pull_root]},
+            )
 
-    cfg.models = new_models
-    try:
-        save_hal0_config(cfg)
-    except OSError as exc:
-        raise Hal0Error(
-            f"could not persist hal0 config: {exc}",
-            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
-        ) from exc
+        cfg.models = new_models
+        try:
+            txn.save(cfg)
+        except OSError as exc:
+            raise Hal0Error(
+                f"could not persist hal0 config: {exc}",
+                details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+            ) from exc
 
     # Run a discovery scan so newly-added roots produce results immediately.
     # The scan walks the filesystem synchronously (potentially seconds on

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -4,7 +4,7 @@ Mounted under ``/api/memory/*``. The dashboard's Memory tab + the
 ``hal0 memory graph {enable,disable,status}`` CLI both read + write
 through this surface; there is no other writer for ``[memory.graph]``
 so a swap-flip from either client lands atomically through the same
-``save_hal0_config`` pipeline.
+``hal0_config_txn`` pipeline.
 
 The actual graph-extraction dispatch lives in the active memory provider
 (:class:`hal0.memory.MemoryProvider`); this module is the thin HTTP
@@ -29,7 +29,7 @@ from pydantic import ValidationError
 
 from hal0.api._audit import record_action
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
-from hal0.config.loader import HAL0_TOML_LOCK, load_hal0_config, save_hal0_config
+from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import MemoryGraphConfig
 from hal0.memory.hindsight_provider import bank_to_namespace
 from hal0.memory.namespace import (
@@ -423,7 +423,7 @@ async def _propagate_shielded(slot: str, timeout_s: int) -> dict[str, Any]:
     to a real OS thread; cancelling the awaiting coroutine (client disconnect,
     shutdown, request timeout) does NOT stop that thread — it just makes the
     ``await`` raise early while the write/restart keeps running in the
-    background. This is called from inside :data:`HAL0_TOML_LOCK`'s critical
+    background. This is called from inside :func:`hal0_config_txn`'s critical
     section (#1682 review): an early return there would release the lock
     while the orphaned worker could still clobber the drop-in, letting a
     second PUT's propagation interleave with it — one write wins the drop-in,
@@ -478,8 +478,14 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
 
     wrapper = _wrapper(request)
 
-    async with HAL0_TOML_LOCK:
-        cfg = load_hal0_config()
+    # One serialized RMW path for every hal0.toml writer (#1721): the txn takes
+    # the shared in-process lock plus the cross-process advisory lock and loads
+    # the config from disk inside both. The whole critical section — including
+    # the propagation below — stays inside it, deliberately: an unrelated writer
+    # persisting a pre-propagation snapshot mid-flight is exactly the lost
+    # update #1682 found.
+    async with hal0_config_txn(request) as txn:
+        cfg = txn.config
         current_raw = cfg.memory.graph.model_dump(mode="python")
         merged_raw = {**current_raw, **body}
 
@@ -549,7 +555,10 @@ async def update_graph_config(request: Request) -> dict[str, Any]:
         # the ordering that cannot produce a silent divergence.
         cfg.memory.graph = new_cfg
         try:
-            save_hal0_config(cfg)
+            # ``txn.save`` also refreshes ``app.state.hal0_config`` — this route
+            # writing straight to disk and leaving that cache stale is what let
+            # a later settings PUT clobber the graph section (#1717 review).
+            txn.save(cfg)
         except OSError as exc:
             raise Hal0Error(
                 f"could not persist hal0 config: {exc}",

--- a/src/hal0/api/routes/settings.py
+++ b/src/hal0/api/routes/settings.py
@@ -1,7 +1,7 @@
 """Settings (config) endpoints (mounted under /api/settings).
 
 Typed read/write of ``/etc/hal0/hal0.toml`` (or the HAL0_HOME-rooted
-override). All writes go through ``hal0.config.loader.save_hal0_config``
+override). All writes go through ``hal0.config.loader.hal0_config_txn``
 which uses the same tempfile+fsync+os.replace pattern as
 ``write_env_atomic`` — never a partial-write.
 
@@ -41,7 +41,7 @@ from pydantic import ValidationError
 from hal0.api._redact import redact_config
 from hal0.api._settings_apply import APPLY_CLASSES, apply_plan, get_registry
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
-from hal0.config.loader import HAL0_TOML_LOCK, load_hal0_config, save_hal0_config
+from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.registry.model_store import (
     MigrationPlan,
@@ -137,23 +137,15 @@ async def update_settings(request: Request) -> dict[str, Any]:
     if not isinstance(body, dict):
         raise Hal0Error("request body must be a JSON object")
 
-    # Shared with routes/memory.py's PUT /graph (#1682 review): that route
-    # can hold its own critical section across a ~60s extraction-slot
-    # propagation, and without a lock SHARED across both routes this save
-    # could land mid-flight, persisting a config snapshot taken before the
-    # propagation started and clobbering the graph section it just wrote.
-    async with HAL0_TOML_LOCK:
-        # Always reload from disk here (#1717 review), never trust
-        # ``app.state.hal0_config`` — the graph route saves its section
-        # straight to disk without updating that cache, so a settings PUT
-        # that waited behind a graph PUT would otherwise resume on the
-        # STALE cached snapshot, merge its own (unrelated) patch into it,
-        # and overwrite the graph section the preceding request just wrote.
-        # One extra read under an already-held lock is cheap; a lost write
-        # is not.
-        current = load_hal0_config()
-
-        merged_raw = _deep_merge(current.model_dump(mode="python"), body)
+    # One serialized RMW path for every hal0.toml writer (#1721). The txn
+    # holds the shared in-process lock AND the cross-process advisory lock,
+    # and hands back a config read from DISK inside both — never
+    # ``app.state.hal0_config``, which any other writer may have invalidated
+    # (#1717 review: a settings PUT waiting behind a ~60s graph PUT used to
+    # resume on the stale cached snapshot, merge its own unrelated patch into
+    # it, and overwrite the graph section the graph route had just written).
+    async with hal0_config_txn(request) as txn:
+        merged_raw = _deep_merge(txn.config.model_dump(mode="python"), body)
 
         try:
             merged = Hal0Config.model_validate(merged_raw)
@@ -163,16 +155,16 @@ async def update_settings(request: Request) -> dict[str, Any]:
                 details=_validation_error_details(exc),
             ) from exc
 
-        # Atomic write via the loader's write_toml_atomic-backed helper.
+        # Atomic write via the txn — which also refreshes
+        # ``app.state.hal0_config`` so no writer can leave that cache stale.
         try:
-            save_hal0_config(merged)
+            txn.save(merged)
         except OSError as exc:
             raise Hal0Error(
                 f"could not persist hal0 config: {exc}",
                 details={"error": str(exc), "errno": getattr(exc, "errno", None)},
             ) from exc
 
-        request.app.state.hal0_config = merged
     event_bus = getattr(request.app.state, "events", None)
     if event_bus is not None:
         # Surface a footer chip when the operator saves the config. The
@@ -489,6 +481,19 @@ async def _apply_store_change(
 
     Slot containers mount the store path; they observe the new value on
     their next restart (the apply-plan badge tells the operator).
+
+    Lock scope (#1721). The file move is deliberately kept OUTSIDE the config
+    lock and only the read-modify-write is serialized: a real multi-file store
+    migration can run for minutes, and holding the one hal0.toml lock across it
+    would stall every other config writer — including the API's own settings
+    and memory/graph routes — for the whole move. Nothing in the move reads or
+    writes hal0.toml, so it needs no protection; what needed fixing was the
+    save, which used to persist ``current`` — a snapshot taken BEFORE the move,
+    possibly minutes stale and possibly the startup ``app.state`` cache — and
+    could therefore erase a concurrent writer's section. The txn below re-reads
+    from disk under the lock and applies only ``[models].store`` to that fresh
+    config, so a concurrent settings/graph/auth/channel write survives and the
+    critical section stays as short as every other writer's.
     """
     migration_result_dict: dict[str, Any] | None = None
     if plan.needed:
@@ -521,25 +526,27 @@ async def _apply_store_change(
             "failed": list(mig.failed),
         }
 
-    # Persist hal0.toml.
-    new_models_raw = dict(current.models.model_dump(mode="python"))
-    new_models_raw["store"] = path
-    try:
-        merged_models = current.models.__class__.model_validate(new_models_raw)
-    except ValidationError as exc:
-        raise ConfigInvalidError(
-            "models config failed schema validation",
-            details=_validation_error_details(exc),
-        ) from exc
-    merged = current.model_copy(update={"models": merged_models})
-    try:
-        save_hal0_config(merged)
-    except OSError as exc:
-        raise Hal0Error(
-            f"could not persist hal0 config: {exc}",
-            details={"error": str(exc), "errno": getattr(exc, "errno", None)},
-        ) from exc
-    request.app.state.hal0_config = merged
+    # Persist hal0.toml — short critical section, fresh read (see the
+    # lock-scope note in this function's docstring).
+    async with hal0_config_txn(request) as txn:
+        fresh = txn.config
+        new_models_raw = dict(fresh.models.model_dump(mode="python"))
+        new_models_raw["store"] = path
+        try:
+            merged_models = fresh.models.__class__.model_validate(new_models_raw)
+        except ValidationError as exc:
+            raise ConfigInvalidError(
+                "models config failed schema validation",
+                details=_validation_error_details(exc),
+            ) from exc
+        merged = fresh.model_copy(update={"models": merged_models})
+        try:
+            txn.save(merged)
+        except OSError as exc:
+            raise Hal0Error(
+                f"could not persist hal0 config: {exc}",
+                details={"error": str(exc), "errno": getattr(exc, "errno", None)},
+            ) from exc
 
     # A store change usually means model files already live at the new path
     # (that's why the operator pointed hal0 there). Register them NOW —

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -45,7 +45,7 @@ from fastapi import APIRouter, Request
 from hal0 import __version__
 from hal0.api.middleware.error_codes import BadRequest, Hal0Error
 from hal0.config import paths
-from hal0.config.loader import load_hal0_config, save_hal0_config
+from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.release.policy import ReleaseKind
 from hal0.updater import Updater, fetch_release_manifest, releases_url, validate_release_version
@@ -936,33 +936,37 @@ async def set_channel(request: Request) -> dict[str, str]:
             code="channel.unknown",
         )
 
-    current = getattr(request.app.state, "hal0_config", None)
-    if current is None:
-        current = load_hal0_config()
-    merged_raw = current.model_dump(mode="python")
-    merged_raw.setdefault("telemetry", {})["channel"] = channel
-    try:
-        merged = Hal0Config.model_validate(merged_raw)
-    except Exception as exc:
-        raise BadRequest(
-            f"could not validate channel update: {exc}",
-            details={"error": str(exc)},
-            code="channel.invalid",
-        ) from exc
-
-    # Validate before touching either the file or the app-state cache. This is
-    # required even for an idempotent PUT: success authenticates the channel's
-    # current manifest, not merely the requested config value.
+    # Validate BEFORE taking the config lock and before touching either the
+    # file or the app-state cache. This is required even for an idempotent
+    # PUT: success authenticates the channel's current manifest, not merely
+    # the requested config value. It is also a network round-trip, so it stays
+    # outside the critical section — no other config writer should queue
+    # behind a manifest fetch (#1721).
     await Updater(channel=channel).check()
 
-    try:
-        save_hal0_config(merged)
-    except OSError as exc:
-        raise UpdateError(
-            f"could not persist channel to hal0.toml: {exc}",
-            details={"error": str(exc)},
-        ) from exc
-    request.app.state.hal0_config = merged
+    # Serialized read-modify-write (#1721). Unlocked, and starting from the
+    # possibly-stale ``app.state.hal0_config`` startup snapshot, this route
+    # could persist a whole pre-read config over a concurrent settings /
+    # memory-graph / models / auth write and erase that section.
+    async with hal0_config_txn(request) as txn:
+        merged_raw = txn.config.model_dump(mode="python")
+        merged_raw.setdefault("telemetry", {})["channel"] = channel
+        try:
+            merged = Hal0Config.model_validate(merged_raw)
+        except Exception as exc:
+            raise BadRequest(
+                f"could not validate channel update: {exc}",
+                details={"error": str(exc)},
+                code="channel.invalid",
+            ) from exc
+
+        try:
+            txn.save(merged)
+        except OSError as exc:
+            raise UpdateError(
+                f"could not persist channel to hal0.toml: {exc}",
+                details={"error": str(exc)},
+            ) from exc
     return {"channel": channel}
 
 

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -131,15 +131,28 @@ def config_migrate() -> None:
     version actually advanced. If the config is already current (or
     absent), nothing is written and that is reported honestly.
     """
-    import tomllib
-
-    from hal0.config.loader import write_toml_atomic
+    from hal0.config.loader import hal0_config_file_lock
     from hal0.config.migrations import MigrationError, latest_version, run_migrations
 
     path = _hal0_toml_path()
     if not path.exists():
         console.print(f"[dim]No config at {path} - nothing to migrate.[/dim]")
         raise typer.Exit(0)
+
+    # Cross-process serialization (#1721): the CLI can migrate hal0.toml while
+    # hal0-api is live and serving a settings PUT, and this read → migrate →
+    # write is precisely the shape that loses the other writer's section. Same
+    # advisory lock the API's ``hal0_config_txn`` holds, taken across the whole
+    # round-trip rather than only the write.
+    with hal0_config_file_lock(path):
+        _run_config_migration(path, latest_version(), run_migrations, MigrationError)
+
+
+def _run_config_migration(path, target, run_migrations, MigrationError) -> None:  # type: ignore[no-untyped-def]
+    """Body of ``hal0 config migrate``, run under the hal0.toml advisory lock."""
+    import tomllib
+
+    from hal0.config.loader import write_toml_atomic
 
     try:
         with open(path, "rb") as f:
@@ -149,7 +162,6 @@ def config_migrate() -> None:
         return
 
     current = int((data.get("meta") or {}).get("schema_version", 1) or 1)
-    target = latest_version()
 
     if current >= target:
         console.print(

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -15,18 +15,19 @@ See PLAN.md §3 and §5 Tier 1.
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 import os
 import tempfile
 import tomllib
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
 
 import tomli_w
 
 from hal0.config import paths
+from hal0.config.locking import PerLoopLock, async_file_lock, file_lock
 from hal0.config.schema import (
     CURRENT_SCHEMA_VERSION,
     SEED_PROFILES,
@@ -207,20 +208,36 @@ def load_hal0_config(path: Path | None = None) -> Hal0Config:
         ) from exc
 
 
-#: Serializes concurrent hal0.toml read-modify-write across API routes
-#: (routes/settings.py's ``PUT /api/settings``, routes/memory.py's
-#: ``PUT /api/memory/graph``). One in-process lock is sufficient — hal0-api
-#: is the only writer process. A per-route lock is not enough on its own
-#: (#1682 review): the memory/graph route holds its critical section across
-#: a multi-second-to-~60s extraction-slot propagation, and without a SHARED
-#: lock an unrelated settings save can land mid-flight, persisting a config
-#: snapshot taken before the propagation started and clobbering the section
-#: it just wrote.
-HAL0_TOML_LOCK: asyncio.Lock = asyncio.Lock()
+#: Serializes concurrent hal0.toml read-modify-write between coroutines in the
+#: API process. Held by :func:`hal0_config_txn`, which is the ONLY supported way
+#: to run a read-modify-write on hal0.toml from the event loop — do not acquire
+#: this by hand at a call site (#1721: four routes each hand-rolled the RMW and
+#: three of them forgot the lock entirely).
+#:
+#: A per-route lock is not enough on its own (#1682 review): the memory/graph
+#: route holds its critical section across a multi-second-to-~60s
+#: extraction-slot propagation, and without a SHARED lock an unrelated settings
+#: save can land mid-flight, persisting a config snapshot taken before the
+#: propagation started and clobbering the section it just wrote.
+HAL0_TOML_LOCK: PerLoopLock = PerLoopLock()
+
+
+class ConfigLockBusy(ConfigError):
+    """Another writer held hal0.toml's advisory lock past the wait timeout."""
+
+    code = "config.lock_busy"
+    status = 503
 
 
 def save_hal0_config(cfg: Hal0Config, path: Path | None = None) -> None:
     """Atomically write hal0.toml.
+
+    Low-level writer: it takes NO lock. Any read-modify-write (load → mutate →
+    save) must run inside :func:`hal0_config_txn` (async) or
+    :func:`hal0_config_file_lock` (sync/threaded) instead of calling this
+    directly, or it can clobber a concurrent writer's section. Calling it bare
+    is correct only when the whole config is being written from nothing (tests,
+    first-run seeding).
 
     Args:
         cfg: Validated Hal0Config to persist.
@@ -233,6 +250,132 @@ def save_hal0_config(cfg: Hal0Config, path: Path | None = None) -> None:
     # safe for any field whose default is None.
     data = cfg.model_dump(mode="python", exclude_none=True)
     write_toml_atomic(target, data)
+
+
+# ── the one serialized hal0.toml read-modify-write path (#1721) ───────────────
+#
+# Every writer that reads hal0.toml, changes part of it and writes it back is a
+# lost-update hazard against every other writer. #1717 fixed one PAIR of them
+# by sharing an asyncio lock between two routes; #1721 is the same bug arriving
+# from the four routes that were never taught about it. A lock every future
+# caller has to remember is the failure mode, so the lock now lives INSIDE the
+# accessor and the accessor is the API:
+#
+#   async with hal0_config_txn(request) as txn:      # loads fresh under lock
+#       txn.config.security.require_auth = True
+#       txn.save()                                   # writes + refreshes cache
+#
+# Three properties fall out of putting it here rather than at each call site:
+#
+#   * **Fresh read.** The config handed to the body is loaded from DISK inside
+#     the critical section, never ``app.state.hal0_config`` — the cache is a
+#     startup snapshot that any other writer may have invalidated (#1717
+#     review found exactly this: a settings PUT waiting behind a graph PUT
+#     merged into the pre-graph snapshot and erased the graph section).
+#   * **Cache coherence.** ``txn.save()`` refreshes ``app.state.hal0_config``
+#     when a request was passed, so the "writer forgot to update the cache"
+#     variant of the same bug cannot come back either.
+#   * **Cross-process exclusion.** The in-process ``asyncio.Lock`` cannot see
+#     the CLI, the installer, or ``installer/install.sh``'s post-activation
+#     migration step — and that step deliberately runs BEFORE it restarts
+#     hal0-api, i.e. against a live daemon that may be serving a settings PUT.
+#     So the txn also takes the same ``fcntl`` advisory lock
+#     (``hal0.toml.lock``) that the sync writers in the updater and installer
+#     now take, which is what actually serializes those two processes.
+#     ``/etc/hal0/*.lock`` already has a perms row, so no new install surface.
+
+
+class Hal0ConfigTxn:
+    """Handle yielded by :func:`hal0_config_txn` — a locked RMW on hal0.toml."""
+
+    def __init__(self, config: Hal0Config, path: Path, request: Any | None = None) -> None:
+        #: Config loaded from disk inside the lock. Mutate it (or build a
+        #: replacement) and hand the result to :meth:`save`.
+        self.config = config
+        self.path = path
+        self._request = request
+
+    def save(self, cfg: Hal0Config | None = None) -> Hal0Config:
+        """Persist ``cfg`` (default: :attr:`config`) and refresh the app cache.
+
+        Returns the config that was written, so callers can echo it back.
+        """
+        new = self.config if cfg is None else cfg
+        save_hal0_config(new, self.path)
+        self.config = new
+        request = self._request
+        if request is not None:
+            with contextlib.suppress(AttributeError):
+                request.app.state.hal0_config = new
+        return new
+
+
+@contextlib.asynccontextmanager
+async def hal0_config_txn(
+    request: Any | None = None,
+    *,
+    path: Path | None = None,
+    timeout: float | None = 60.0,
+) -> AsyncIterator[Hal0ConfigTxn]:
+    """Serialized read-modify-write of hal0.toml, for the event loop.
+
+    Holds :data:`HAL0_TOML_LOCK` (in-process) and the ``hal0.toml.lock``
+    advisory file lock (cross-process) for the whole body, and yields a
+    :class:`Hal0ConfigTxn` whose ``config`` was loaded from disk under both.
+
+    The body may await: the memory/graph route deliberately keeps its
+    hindsight-api propagation inside the critical section so no other writer
+    can persist a pre-propagation snapshot over it. A cross-process writer
+    blocking behind that is the intended outcome — waiting is strictly better
+    than the lost update it would otherwise commit.
+
+    Args:
+        request: Optional Starlette request; when given, ``txn.save()`` also
+            refreshes ``request.app.state.hal0_config``.
+        path: Override hal0.toml path (tests).
+        timeout: Seconds to wait for the cross-process lock before failing the
+            request with :class:`ConfigLockBusy`.
+
+    Raises:
+        ConfigLockBusy: Another process held the advisory lock too long.
+    """
+    target = Path(path) if path is not None else paths.hal0_toml()
+    async with HAL0_TOML_LOCK:
+        # ``acquired`` narrows the except to the ACQUIRE. A body that raises its
+        # own TimeoutError (the memory route awaits a bounded hindsight-api
+        # restart in here) must surface as itself, not be relabelled "another
+        # process is writing hal0.toml".
+        acquired = False
+        try:
+            async with async_file_lock(target, timeout=timeout):
+                acquired = True
+                yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+        except TimeoutError as exc:
+            if acquired:
+                raise
+            raise ConfigLockBusy(
+                f"another process is writing {target} — try again",
+                details={"path": str(target)},
+            ) from exc
+
+
+@contextlib.contextmanager
+def hal0_config_file_lock(path: Path | None = None) -> Iterator[Path]:
+    """Serialized read-modify-write of hal0.toml, for sync/threaded writers.
+
+    The blocking counterpart of :func:`hal0_config_txn` for code that is not on
+    the event loop — the updater's schema-migration passes (``asyncio.to_thread``
+    inside the API process, or a bare ``hal0`` process from ``install.sh``) and
+    the installer's storage-choice writer. Takes the same ``hal0.toml.lock``, so
+    those writers serialize against the API's routes and each other; it
+    deliberately does NOT touch :data:`HAL0_TOML_LOCK`, which is an
+    ``asyncio.Lock`` and cannot be acquired off-loop.
+
+    Yields the locked hal0.toml path so callers can read it inside the body.
+    """
+    target = Path(path) if path is not None else paths.hal0_toml()
+    with file_lock(target):
+        yield target
 
 
 # ── slots/<name>.toml ─────────────────────────────────────────────────────────
@@ -1001,9 +1144,14 @@ def manifest_image_ref(
 
 __all__ = [
     "CURRENT_SCHEMA_VERSION",
+    "HAL0_TOML_LOCK",
     "ConfigError",
+    "ConfigLockBusy",
     "ConfigNotFound",
     "ConfigParseError",
+    "Hal0ConfigTxn",
+    "hal0_config_file_lock",
+    "hal0_config_txn",
     "list_agent_configs",
     "list_slot_layout",
     "list_slots",

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -22,6 +22,7 @@ import os
 import tempfile
 import tomllib
 from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -286,12 +287,6 @@ def save_hal0_config(cfg: Hal0Config, path: Path | None = None) -> None:
 #     ``/etc/hal0/*.lock`` already has a perms row, so no new install surface.
 
 
-#: Task holding an open :func:`hal0_config_txn` per hal0.toml path. Only ever
-#: read/written from the loop thread while the locks are held, so a plain dict
-#: is sufficient.
-_TXN_OWNERS: dict[str, Any] = {}
-
-
 class Hal0ConfigTxn:
     """Handle yielded by :func:`hal0_config_txn` — a locked RMW on hal0.toml."""
 
@@ -315,6 +310,20 @@ class Hal0ConfigTxn:
             with contextlib.suppress(AttributeError):
                 request.app.state.hal0_config = new
         return new
+
+
+@dataclass
+class _ActiveTxn:
+    """The open transaction for one hal0.toml path, and the task that owns it."""
+
+    task: Any
+    txn: Hal0ConfigTxn
+    depth: int = 1
+
+
+#: Open :func:`hal0_config_txn` per hal0.toml path. Only ever read/written from
+#: the loop thread while the locks are held, so a plain dict is sufficient.
+_TXN_OWNERS: dict[str, _ActiveTxn] = {}
 
 
 @contextlib.asynccontextmanager
@@ -350,12 +359,24 @@ async def hal0_config_txn(
 
     # Re-entrancy (#1721 review): ``HAL0_TOML_LOCK`` is reached BEFORE the file
     # lock's own owner check, so a writer that opened a txn and then called a
-    # helper which opens another would hang here forever rather than fail. The
-    # holding task passes straight through — it already owns both locks, and
-    # re-reading from disk under them yields the same consistent view.
+    # helper which opens another would hang here forever rather than fail.
+    #
+    # The nested caller gets the SAME handle, not a fresh load (#1721 review
+    # round 2). Re-reading would fork the working state: an outer caller that
+    # mutated ``txn.config`` and then reached a helper would hand that helper a
+    # model without its edits, and the outer ``save()`` would later write its
+    # own stale object back over whatever the inner one committed — a lost
+    # update inside a single request, which is the exact bug class this
+    # accessor exists to remove.
+    key = str(target)
     current_task = asyncio.current_task()
-    if current_task is not None and _TXN_OWNERS.get(str(target)) is current_task:
-        yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+    active = _TXN_OWNERS.get(key)
+    if current_task is not None and active is not None and active.task is current_task:
+        active.depth += 1
+        try:
+            yield active.txn
+        finally:
+            active.depth -= 1
         return
 
     async with HAL0_TOML_LOCK:
@@ -367,13 +388,14 @@ async def hal0_config_txn(
         try:
             async with async_file_lock(target, timeout=timeout):
                 acquired = True
+                txn = Hal0ConfigTxn(load_hal0_config(target), target, request)
                 if current_task is not None:
-                    _TXN_OWNERS[str(target)] = current_task
+                    _TXN_OWNERS[key] = _ActiveTxn(task=current_task, txn=txn)
                 try:
-                    yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+                    yield txn
                 finally:
                     if current_task is not None:
-                        _TXN_OWNERS.pop(str(target), None)
+                        _TXN_OWNERS.pop(key, None)
         except TimeoutError as exc:
             if acquired:
                 raise

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -15,6 +15,7 @@ See PLAN.md §3 and §5 Tier 1.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -285,6 +286,12 @@ def save_hal0_config(cfg: Hal0Config, path: Path | None = None) -> None:
 #     ``/etc/hal0/*.lock`` already has a perms row, so no new install surface.
 
 
+#: Task holding an open :func:`hal0_config_txn` per hal0.toml path. Only ever
+#: read/written from the loop thread while the locks are held, so a plain dict
+#: is sufficient.
+_TXN_OWNERS: dict[str, Any] = {}
+
+
 class Hal0ConfigTxn:
     """Handle yielded by :func:`hal0_config_txn` — a locked RMW on hal0.toml."""
 
@@ -340,6 +347,17 @@ async def hal0_config_txn(
         ConfigLockBusy: Another process held the advisory lock too long.
     """
     target = Path(path) if path is not None else paths.hal0_toml()
+
+    # Re-entrancy (#1721 review): ``HAL0_TOML_LOCK`` is reached BEFORE the file
+    # lock's own owner check, so a writer that opened a txn and then called a
+    # helper which opens another would hang here forever rather than fail. The
+    # holding task passes straight through — it already owns both locks, and
+    # re-reading from disk under them yields the same consistent view.
+    current_task = asyncio.current_task()
+    if current_task is not None and _TXN_OWNERS.get(str(target)) is current_task:
+        yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+        return
+
     async with HAL0_TOML_LOCK:
         # ``acquired`` narrows the except to the ACQUIRE. A body that raises its
         # own TimeoutError (the memory route awaits a bounded hindsight-api
@@ -349,7 +367,13 @@ async def hal0_config_txn(
         try:
             async with async_file_lock(target, timeout=timeout):
                 acquired = True
-                yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+                if current_task is not None:
+                    _TXN_OWNERS[str(target)] = current_task
+                try:
+                    yield Hal0ConfigTxn(load_hal0_config(target), target, request)
+                finally:
+                    if current_task is not None:
+                        _TXN_OWNERS.pop(str(target), None)
         except TimeoutError as exc:
             if acquired:
                 raise

--- a/src/hal0/config/locking.py
+++ b/src/hal0/config/locking.py
@@ -35,11 +35,15 @@ advisory nature of the primitive.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import os
 import threading
-from collections.abc import Iterator
+import time
+import weakref
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
+from typing import Any
 
 try:
     import fcntl
@@ -108,4 +112,182 @@ def file_lock(target: Path | str) -> Iterator[None]:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
 
-__all__ = ["file_lock", "lock_path_for"]
+# ── async variant ─────────────────────────────────────────────────────────────
+#
+# ``file_lock`` blocks the calling thread. On the API's event loop that is a
+# whole-process stall: while an ``install.sh`` migration or a CLI writer holds
+# the lock, EVERY request would freeze, not just the config writer. The async
+# variant therefore polls ``LOCK_EX | LOCK_NB`` and awaits between attempts, so
+# only the waiting coroutine is parked.
+#
+# Re-entrancy needs a second guard here that the sync path does not: the
+# thread-local depth map is shared by every task on the loop thread, so a
+# second TASK arriving while the first holds the lock would read depth > 0 and
+# sail straight through with no lock at all. Coroutines are therefore
+# serialized first by a per-loop, per-path ``asyncio.Lock`` — held for the same
+# span as the OS lock — and only then does the depth map get set (which keeps a
+# nested SYNC ``file_lock`` on the same target inside the body a no-op instead
+# of a self-deadlock).
+
+_async_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+class PerLoopLock:
+    """An ``asyncio.Lock`` that survives being declared at module scope.
+
+    A bare module-level ``asyncio.Lock()`` binds to the FIRST event loop that
+    awaits it and raises ``RuntimeError: bound to a different event loop`` on
+    every later loop. In the daemon that never shows (one loop for the process
+    lifetime), but it makes a module-scope lock unusable from any second loop —
+    a test suite, a CLI that spins its own ``asyncio.run``, or a future worker
+    loop — and the failure mode is a raised writer, not a queued one.
+
+    Keying one real lock per running loop keeps the single-loop semantics
+    identical while making the object safe to hold as a module constant.
+    Supports the ``asyncio.Lock`` surface its callers use: ``async with``,
+    ``acquire``, ``release``, ``locked``.
+    """
+
+    __slots__ = ("_locks",)
+
+    def __init__(self) -> None:
+        self._locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def _lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def acquire(self) -> bool:
+        return await self._lock().acquire()
+
+    def release(self) -> None:
+        self._lock().release()
+
+    def locked(self) -> bool:
+        return self._lock().locked()
+
+    async def __aenter__(self) -> None:
+        await self.acquire()
+
+    async def __aexit__(self, *exc: object) -> None:
+        self.release()
+
+
+#: Task currently holding each key's async lock, per loop. Needed for
+#: re-entrancy: the thread-local depth map cannot tell "this task already holds
+#: it" (safe to pass through) from "a sibling task holds it" (must wait), and
+#: an ``asyncio.Lock`` is not recursive — a nested acquire by the holder would
+#: hang forever rather than time out.
+_async_owners: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, dict[str, asyncio.Task[Any] | None]
+] = weakref.WeakKeyDictionary()
+
+
+def _async_lock_for(key: str) -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    per_loop = _async_locks.get(loop)
+    if per_loop is None:
+        per_loop = {}
+        _async_locks[loop] = per_loop
+    lock = per_loop.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        per_loop[key] = lock
+    return lock
+
+
+def _async_owner_map() -> dict[str, asyncio.Task[Any] | None]:
+    loop = asyncio.get_running_loop()
+    owners = _async_owners.get(loop)
+    if owners is None:
+        owners = {}
+        _async_owners[loop] = owners
+    return owners
+
+
+@contextlib.asynccontextmanager
+async def async_file_lock(
+    target: Path | str,
+    *,
+    timeout: float | None = 60.0,
+    poll_interval: float = 0.02,
+) -> AsyncIterator[None]:
+    """:func:`file_lock` for the event loop — never blocks the loop thread.
+
+    Same exclusion contract as :func:`file_lock` (same ``<target>.lock`` file,
+    so the two serialize against each other across processes and threads), but
+    the wait is an ``await`` rather than a blocking ``flock``.
+
+    Args:
+        target: File whose read-modify-write is being serialized.
+        timeout: Seconds to wait for the OS lock before raising
+            ``TimeoutError``. ``None`` waits forever. A timeout is preferred
+            over an unbounded wait: a stuck peer should fail one request, not
+            wedge the writer surface permanently.
+        poll_interval: Delay between non-blocking acquire attempts.
+
+    Raises:
+        TimeoutError: The lock was still held after ``timeout`` seconds.
+    """
+    lock_path = lock_path_for(target)
+    key = str(lock_path)
+    owners = _async_owner_map()
+    current = asyncio.current_task()
+
+    if current is not None and owners.get(key) is current:
+        # Re-entrant acquire by the task that already holds it. Passing through
+        # is the only non-hanging option: ``asyncio.Lock`` is not recursive, so
+        # waiting here would block on ourselves until the process ends.
+        yield
+        return
+
+    async with _async_lock_for(key):
+        depths = _depths()
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if fcntl is None:  # pragma: no cover - non-POSIX platforms
+            depths[key] = depths.get(key, 0) + 1
+            owners[key] = current
+            try:
+                yield
+            finally:
+                owners.pop(key, None)
+                depths[key] -= 1
+                if depths[key] <= 0:
+                    depths.pop(key, None)
+            return
+
+        with open(lock_path, "w") as fh:
+            deadline = None if timeout is None else time.monotonic() + timeout
+            while True:
+                try:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"timed out after {timeout}s waiting for advisory lock {lock_path}"
+                        ) from None
+                    await asyncio.sleep(poll_interval)
+            depths[key] = depths.get(key, 0) + 1
+            owners[key] = current
+            try:
+                yield
+            finally:
+                owners.pop(key, None)
+                depths[key] -= 1
+                if depths[key] <= 0:
+                    depths.pop(key, None)
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+__all__ = ["PerLoopLock", "async_file_lock", "file_lock", "lock_path_for"]

--- a/src/hal0/config/locking.py
+++ b/src/hal0/config/locking.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import stat
 import threading
 import time
 import weakref
@@ -61,6 +62,30 @@ def _depths() -> dict[str, int]:
         depths = {}
         _reentry.depths = depths
     return depths
+
+
+def _open_lock_file(lock_path: Path):  # type: ignore[no-untyped-def]
+    """Open ``lock_path`` for locking, refusing symlinks and non-regular files.
+
+    These locks straddle a privilege boundary: ``/etc/hal0`` is writable by the
+    ``hal0`` service account under the ownership flip, while ``install.sh`` and
+    ``hal0 update`` acquire the same lock as **root**. A plain
+    ``open(path, "w")`` there follows a symlink and truncates whatever it points
+    at, so a compromised service account could aim ``hal0.toml.lock`` at any
+    root-writable file and have the next upgrade clobber it. ``O_NOFOLLOW``
+    plus an ``S_ISREG`` check on the descriptor (not the path — no TOCTOU
+    window) closes that. No ``O_TRUNC``: the lock file's contents are never
+    read or written, only its inode is locked.
+    """
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o664)
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise OSError(f"lock path is not a regular file: {lock_path}")
+    except BaseException:
+        os.close(fd)
+        raise
+    return os.fdopen(fd, "r+b")
 
 
 def lock_path_for(target: Path | str) -> Path:
@@ -101,7 +126,7 @@ def file_lock(target: Path | str) -> Iterator[None]:
             depths.pop(key, None)
         return
 
-    with open(lock_path, "w") as fh:
+    with _open_lock_file(lock_path) as fh:
         fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
         depths[key] = 1
         try:
@@ -120,14 +145,19 @@ def file_lock(target: Path | str) -> Iterator[None]:
 # variant therefore polls ``LOCK_EX | LOCK_NB`` and awaits between attempts, so
 # only the waiting coroutine is parked.
 #
-# Re-entrancy needs a second guard here that the sync path does not: the
-# thread-local depth map is shared by every task on the loop thread, so a
-# second TASK arriving while the first holds the lock would read depth > 0 and
-# sail straight through with no lock at all. Coroutines are therefore
-# serialized first by a per-loop, per-path ``asyncio.Lock`` — held for the same
-# span as the OS lock — and only then does the depth map get set (which keeps a
-# nested SYNC ``file_lock`` on the same target inside the body a no-op instead
-# of a self-deadlock).
+# Re-entrancy is tracked by TASK, not by thread. The sync path's thread-local
+# depth map is deliberately NOT touched here: every task on the loop shares one
+# thread, so marking depth > 0 while an async holder runs would make a sibling
+# task's sync ``file_lock`` believe it already held the lock and write with no
+# lock at all — a silent lost update, worse than the contention it avoids.
+# Coroutines serialize on a per-loop, per-path ``asyncio.Lock`` and the holding
+# task is recorded so its own nested acquire passes through instead of hanging
+# on the non-recursive lock.
+#
+# Corollary: never call the blocking :func:`file_lock` from the event-loop
+# thread for a target an async writer also locks — it would block the loop, and
+# if a txn on that same loop holds it, forever. Off-loop writers must run in a
+# worker thread (``asyncio.to_thread``) or use this async variant.
 
 _async_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = (
     weakref.WeakKeyDictionary()
@@ -250,22 +280,17 @@ async def async_file_lock(
         return
 
     async with _async_lock_for(key):
-        depths = _depths()
         lock_path.parent.mkdir(parents=True, exist_ok=True)
 
         if fcntl is None:  # pragma: no cover - non-POSIX platforms
-            depths[key] = depths.get(key, 0) + 1
             owners[key] = current
             try:
                 yield
             finally:
                 owners.pop(key, None)
-                depths[key] -= 1
-                if depths[key] <= 0:
-                    depths.pop(key, None)
             return
 
-        with open(lock_path, "w") as fh:
+        with _open_lock_file(lock_path) as fh:
             deadline = None if timeout is None else time.monotonic() + timeout
             while True:
                 try:
@@ -277,15 +302,11 @@ async def async_file_lock(
                             f"timed out after {timeout}s waiting for advisory lock {lock_path}"
                         ) from None
                     await asyncio.sleep(poll_interval)
-            depths[key] = depths.get(key, 0) + 1
             owners[key] = current
             try:
                 yield
             finally:
                 owners.pop(key, None)
-                depths[key] -= 1
-                if depths[key] <= 0:
-                    depths.pop(key, None)
                 with contextlib.suppress(OSError):
                     fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 

--- a/src/hal0/config/locking.py
+++ b/src/hal0/config/locking.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import errno
 import os
 import stat
 import threading
@@ -64,7 +65,44 @@ def _depths() -> dict[str, int]:
     return depths
 
 
-def _open_lock_file(lock_path: Path):  # type: ignore[no-untyped-def]
+#: Mode for a freshly created lock file. Owner+group writable, matching the
+#: ``/etc/hal0 *.lock`` and ``/var/lib/hal0 *.lock`` perms rows: root and the
+#: service account both have to be able to take these locks.
+LOCK_FILE_MODE = 0o664
+
+
+def _adopt_target_ownership(fd: int, target: Path) -> None:
+    """Give a just-created lock file the guarded file's owner, when running as root.
+
+    A root-run writer that creates the lock first (``sudo hal0 config migrate``,
+    the installer, ``hal0 update``) would otherwise leave it ``root:root`` and
+    ``umask``-filtered — install.sh sets ``umask 022``, so ``0644`` — and the
+    ``hal0`` daemon, which opens the lock ``O_RDWR``, then fails EVERY config
+    write with ``PermissionError`` until someone runs ``doctor perms --fix``.
+    The same hazard already bit ``slots.lock`` on halo150 (see the ``*.lock``
+    rows in ``hal0.install.perms``); a standalone privileged CLI run has no
+    later repair step at all, so the fix belongs at creation time.
+
+    The lock inherits the guarded file's uid/gid (falling back to its directory)
+    rather than a hard-coded account, so it tracks whichever side of the
+    service-user ownership flip the box is on. Best-effort: a non-root process
+    cannot chown, and it does not need to — it created the file as itself.
+    """
+    os.fchmod(fd, LOCK_FILE_MODE)  # explicit: os.open's mode is umask-filtered
+    if os.geteuid() != 0:
+        return
+    source = target if target.exists() else target.parent
+    try:
+        st = source.stat()
+    except OSError:
+        return
+    if st.st_uid == 0 and st.st_gid == 0:
+        return  # unflipped, root-owned box — root:root is already correct
+    with contextlib.suppress(OSError):
+        os.fchown(fd, st.st_uid, st.st_gid)
+
+
+def _open_lock_file(lock_path: Path, target: Path):  # type: ignore[no-untyped-def]
     """Open ``lock_path`` for locking, refusing symlinks and non-regular files.
 
     These locks straddle a privilege boundary: ``/etc/hal0`` is writable by the
@@ -76,12 +114,23 @@ def _open_lock_file(lock_path: Path):  # type: ignore[no-untyped-def]
     plus an ``S_ISREG`` check on the descriptor (not the path — no TOCTOU
     window) closes that. No ``O_TRUNC``: the lock file's contents are never
     read or written, only its inode is locked.
+
+    Creation is a separate ``O_EXCL`` attempt so the mode/ownership fix-up in
+    :func:`_adopt_target_ownership` runs on the creating process only, and never
+    re-chmods a lock another process is already holding.
     """
-    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o664)
+    created = False
+    try:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, LOCK_FILE_MODE)
+        created = True
+    except FileExistsError:
+        fd = os.open(lock_path, os.O_RDWR | os.O_NOFOLLOW)
     try:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             raise OSError(f"lock path is not a regular file: {lock_path}")
+        if created:
+            _adopt_target_ownership(fd, target)
     except BaseException:
         os.close(fd)
         raise
@@ -126,7 +175,7 @@ def file_lock(target: Path | str) -> Iterator[None]:
             depths.pop(key, None)
         return
 
-    with _open_lock_file(lock_path) as fh:
+    with _open_lock_file(lock_path, Path(target)) as fh:
         fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
         depths[key] = 1
         try:
@@ -158,6 +207,11 @@ def file_lock(target: Path | str) -> Iterator[None]:
 # thread for a target an async writer also locks — it would block the loop, and
 # if a txn on that same loop holds it, forever. Off-loop writers must run in a
 # worker thread (``asyncio.to_thread``) or use this async variant.
+
+#: ``flock(LOCK_NB)`` errnos that mean "held by someone else, try again".
+#: Anything else (ENOSYS/EOPNOTSUPP on a filesystem without advisory locks, EBADF)
+#: is permanent and must surface immediately rather than be polled.
+_CONTENTION_ERRNOS = frozenset({errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK, errno.EINTR})
 
 _async_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = (
     weakref.WeakKeyDictionary()
@@ -290,13 +344,20 @@ async def async_file_lock(
                 owners.pop(key, None)
             return
 
-        with _open_lock_file(lock_path) as fh:
+        with _open_lock_file(lock_path, Path(target)) as fh:
             deadline = None if timeout is None else time.monotonic() + timeout
             while True:
                 try:
                     fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     break
-                except OSError:
+                except OSError as exc:
+                    # Only genuine contention is worth retrying. A filesystem
+                    # with no advisory-lock support (ENOSYS / EOPNOTSUPP) fails
+                    # identically on every attempt, so polling it would burn the
+                    # whole timeout and then report a misleading "another
+                    # process is writing" — or spin forever when timeout=None.
+                    if exc.errno not in _CONTENTION_ERRNOS:
+                        raise
                     if deadline is not None and time.monotonic() >= deadline:
                         raise TimeoutError(
                             f"timed out after {timeout}s waiting for advisory lock {lock_path}"

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -444,16 +444,26 @@ def _persist_store_dir(storage_dir: str) -> None:
     flm_target = _colocated_flm_store(s)
 
     try:
-        from hal0.config.loader import load_hal0_config, save_hal0_config
+        from hal0.config.loader import (
+            hal0_config_file_lock,
+            load_hal0_config,
+            save_hal0_config,
+        )
 
-        cfg = load_hal0_config()
-        store_ok = (cfg.models.store or "").strip() == s
-        flm_ok = (cfg.models.flm_store or "").strip() == flm_target
-        if store_ok and flm_ok:
-            return
-        cfg.models.store = s
-        cfg.models.flm_store = flm_target
-        save_hal0_config(cfg)
+        # Cross-process serialization (#1721): the installer is a separate
+        # process from hal0-api and can run against a live daemon, so this
+        # read-modify-write takes the same ``hal0.toml.lock`` the API's
+        # ``hal0_config_txn`` holds — otherwise it can persist its pre-read
+        # snapshot over a concurrent settings write.
+        with hal0_config_file_lock() as toml_path:
+            cfg = load_hal0_config(toml_path)
+            store_ok = (cfg.models.store or "").strip() == s
+            flm_ok = (cfg.models.flm_store or "").strip() == flm_target
+            if store_ok and flm_ok:
+                return
+            cfg.models.store = s
+            cfg.models.flm_store = flm_target
+            save_hal0_config(cfg, toml_path)
     except Exception:
         # Config persistence is best-effort: pulls fall back to the default
         # store and the rest of setup must proceed regardless.

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -7,6 +7,7 @@ post-install. Deps are injected so there is no hidden ``app.state`` coupling.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
@@ -519,7 +520,12 @@ async def apply_setup(
     # Honour the operator's chosen store BEFORE planning pulls: the pull engine
     # reads ``[models].store`` lazily at pull time, so persisting it here is
     # what threads ``storage_dir`` all the way to the pull destination (#1095).
-    _persist_store_dir(selections.storage_dir)
+    # Off-loop (#1721 review): ``apply_setup`` is awaited by
+    # ``POST /api/installer/apply*`` on the API event loop, and
+    # ``_persist_store_dir`` takes the BLOCKING hal0.toml advisory lock. Run on
+    # the loop it would freeze the whole daemon while any peer holds that lock
+    # (and deadlock outright behind a txn on the same loop).
+    await asyncio.to_thread(_persist_store_dir, selections.storage_dir)
 
     for s in selections.slots:
         rec = SlotOutcome(slot=s.slot_name, model_id=s.model_id or "")

--- a/src/hal0/install/orchestrate.py
+++ b/src/hal0/install/orchestrate.py
@@ -471,6 +471,30 @@ def _persist_store_dir(storage_dir: str) -> None:
         pass
 
 
+async def _persist_store_dir_shielded(storage_dir: str) -> None:
+    """Run :func:`_persist_store_dir` off-loop, safe against cancellation.
+
+    ``asyncio.to_thread`` cancels only the awaiter, never the worker. If the
+    installer request is cancelled (shutdown, request-timeout middleware) while
+    that worker is blocked on ``hal0.toml.lock``, the orphan can acquire the
+    lock afterwards and persist the CANCELLED request's storage choice — over a
+    newer setup request, and without provisioning the slots that were supposed
+    to accompany it (#1721 review round 4).
+
+    Same shape as ``routes/memory.py``'s ``_propagate_shielded``: shield the
+    wait, and if the caller is cancelled anyway, wait the worker out in a
+    shielded loop so a second cancellation cannot exit early either.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(_persist_store_dir, storage_dir))
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        while not task.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.shield(task)
+        raise
+
+
 def install_extension(ext_id: str) -> ExtensionOutcome:
     """Install + wire one extension. Delegates to extensions.install_extension
     (Task 1.2); imported lazily to avoid a cycle."""
@@ -525,7 +549,7 @@ async def apply_setup(
     # ``_persist_store_dir`` takes the BLOCKING hal0.toml advisory lock. Run on
     # the loop it would freeze the whole daemon while any peer holds that lock
     # (and deadlock outright behind a txn on the same loop).
-    await asyncio.to_thread(_persist_store_dir, selections.storage_dir)
+    await _persist_store_dir_shielded(selections.storage_dir)
 
     for s in selections.slots:
         rec = SlotOutcome(slot=s.slot_name, model_id=s.model_id or "")

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1892,19 +1892,27 @@ def _stamp_profile_catalog_version(*, job_id: str | None = None) -> bool:
     # Same cross-process lock as every other hal0.toml read-modify-write
     # (#1721) — the raw round-trip below is exactly the read → modify → write
     # shape that loses a concurrent API writer's section.
-    with hal0_config_file_lock():
-        raw = _raw_hal0_toml()
-        if raw is None:
-            log.warning(
-                "updater.profile_reset_stamp_skipped", job_id=job_id, reason="hal0.toml absent"
-            )
-            return False
-        try:
+    #
+    # The lock ACQUIRE is inside the failure handler on purpose (#1721 review):
+    # this runs after ``reset_profile_catalog`` has already backed up and
+    # deleted profiles.toml, so an un-contained OSError here (an unwritable
+    # lock file left by an earlier root-run install, say) would escape as a
+    # generic reset error and leave the catalog deleted with no stamp and no
+    # honest report. A lock we cannot take is reported exactly like a write we
+    # cannot make: unstamped, logged, False.
+    try:
+        with hal0_config_file_lock():
+            raw = _raw_hal0_toml()
+            if raw is None:
+                log.warning(
+                    "updater.profile_reset_stamp_skipped", job_id=job_id, reason="hal0.toml absent"
+                )
+                return False
             new_raw, version = run_migrations(raw, target_version=PROFILE_CATALOG_SCHEMA_VERSION)
             write_toml_atomic(paths.hal0_toml(), new_raw)
-        except Exception as exc:
-            log.warning("updater.profile_reset_stamp_failed", job_id=job_id, error=str(exc))
-            return False
+    except Exception as exc:
+        log.warning("updater.profile_reset_stamp_failed", job_id=job_id, error=str(exc))
+        return False
     log.info("updater.profile_reset_stamped", job_id=job_id, schema_version=version)
     return True
 

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -57,6 +57,7 @@ import hal0
 from hal0.config import paths
 from hal0.config.loader import (
     ConfigParseError,
+    hal0_config_file_lock,
     load_hal0_config,
     save_profiles_config,
     write_toml_atomic,
@@ -1166,6 +1167,23 @@ def _maybe_run_config_migrations(
         )
         return (target, target)
 
+    # Cross-process serialization (#1721). This runs either on an
+    # ``asyncio.to_thread`` inside the live API process (Updater.commit) or as
+    # a bare ``hal0`` process from ``install.sh`` — and install.sh runs this
+    # step BEFORE it restarts hal0-api, i.e. against a daemon that may be
+    # serving a settings PUT right now. Same ``hal0.toml.lock`` the API's
+    # ``hal0_config_txn`` takes, held across this read-modify-write.
+    with hal0_config_file_lock(toml_path):
+        return _run_config_migrations_locked(toml_path, target, job_id=job_id)
+
+
+def _run_config_migrations_locked(
+    toml_path: Path,
+    target: int,
+    *,
+    job_id: str | None = None,
+) -> tuple[int, int]:
+    """Body of :func:`_maybe_run_config_migrations`, run under the config lock."""
     cfg = load_hal0_config(toml_path)
     source = int(getattr(cfg.meta, "schema_version", 1) or 1)
     if source >= target:
@@ -1871,16 +1889,22 @@ def _stamp_profile_catalog_version(*, job_id: str | None = None) -> bool:
     """
     from hal0.config.migrations.v2 import PROFILE_CATALOG_SCHEMA_VERSION
 
-    raw = _raw_hal0_toml()
-    if raw is None:
-        log.warning("updater.profile_reset_stamp_skipped", job_id=job_id, reason="hal0.toml absent")
-        return False
-    try:
-        new_raw, version = run_migrations(raw, target_version=PROFILE_CATALOG_SCHEMA_VERSION)
-        write_toml_atomic(paths.hal0_toml(), new_raw)
-    except Exception as exc:
-        log.warning("updater.profile_reset_stamp_failed", job_id=job_id, error=str(exc))
-        return False
+    # Same cross-process lock as every other hal0.toml read-modify-write
+    # (#1721) — the raw round-trip below is exactly the read → modify → write
+    # shape that loses a concurrent API writer's section.
+    with hal0_config_file_lock():
+        raw = _raw_hal0_toml()
+        if raw is None:
+            log.warning(
+                "updater.profile_reset_stamp_skipped", job_id=job_id, reason="hal0.toml absent"
+            )
+            return False
+        try:
+            new_raw, version = run_migrations(raw, target_version=PROFILE_CATALOG_SCHEMA_VERSION)
+            write_toml_atomic(paths.hal0_toml(), new_raw)
+        except Exception as exc:
+            log.warning("updater.profile_reset_stamp_failed", job_id=job_id, error=str(exc))
+            return False
     log.info("updater.profile_reset_stamped", job_id=job_id, schema_version=version)
     return True
 

--- a/tests/api/test_hal0_toml_lock_scope.py
+++ b/tests/api/test_hal0_toml_lock_scope.py
@@ -20,7 +20,10 @@ These tests pin the fix at three levels:
 from __future__ import annotations
 
 import asyncio
+import errno
+import os
 import re
+import stat
 import subprocess
 import sys
 import threading
@@ -607,6 +610,85 @@ def test_lock_file_open_refuses_a_symlink(tmp_path: Path) -> None:
     with pytest.raises(OSError), file_lock(target):
         pass  # pragma: no cover — the open must fail first
     assert victim.read_text(encoding="utf-8") == "precious"
+
+
+def test_new_lock_file_is_group_writable_regardless_of_umask(tmp_path: Path) -> None:
+    """A privileged writer must not leave a lock the service account can't open.
+
+    ``sudo hal0 config migrate`` / the root-run installer can create
+    ``hal0.toml.lock`` first, under ``umask 022``. Relying on ``os.open``'s
+    creation mode would land 0644 and the daemon — which opens the lock O_RDWR
+    — would then fail EVERY config write with PermissionError until a
+    ``doctor perms --fix``. Same hazard that bit ``slots.lock`` on halo150
+    (#1721 review round 3), so the mode is set explicitly at creation.
+    """
+    target = tmp_path / "hal0.toml"
+    target.write_text("", encoding="utf-8")
+    lock_path = tmp_path / "hal0.toml.lock"
+
+    old_umask = os.umask(0o022)  # exactly what install.sh sets
+    try:
+        with file_lock(target):
+            pass
+    finally:
+        os.umask(old_umask)
+
+    assert lock_path.exists()
+    mode = stat.S_IMODE(lock_path.stat().st_mode)
+    assert mode == 0o664, f"lock created 0o{mode:o}; the service account needs group write"
+
+
+def test_installer_lock_open_sets_mode_explicitly() -> None:
+    """install.sh's inline lock needs the same creation-mode fix.
+
+    It runs as root under ``umask 022`` by construction, so it is the most
+    likely creator of the lock file on a fresh box.
+    """
+    install_sh = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+    match = re.search(
+        r"python3 - \"\$\{HAL0_TOML\}\" \"\$\{MODELS_DIR\}\" <<'PYEOF'\n(.*?)\nPYEOF",
+        install_sh.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert match
+    writer = match.group(1)
+    assert "fchmod" in writer, "the installer must set the lock mode explicitly, not via umask"
+    assert "fchown" in writer, "a root-created lock must adopt the guarded file's owner"
+
+
+async def test_permanent_flock_failure_is_not_polled(tmp_hal0_home: str) -> None:
+    """A filesystem without advisory locks must fail fast, not burn the timeout.
+
+    ``ENOSYS``/``EOPNOTSUPP`` fail identically on every attempt, so retrying
+    them spends the whole timeout and then reports a misleading
+    ``config.lock_busy`` — or spins forever when ``timeout=None``
+    (#1721 review round 3).
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    import fcntl as fcntl_mod
+
+    from hal0.config import locking as locking_mod
+
+    calls = 0
+
+    def _boom(fd: int, op: int) -> None:
+        nonlocal calls
+        calls += 1
+        raise OSError(errno.ENOSYS, "function not implemented")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(locking_mod.fcntl, "flock", _boom)
+        with pytest.raises(OSError) as caught:
+            async with hal0_config_txn(path=target, timeout=30):
+                pass  # pragma: no cover — the acquire must fail first
+
+    assert caught.value.errno == errno.ENOSYS
+    assert not isinstance(caught.value, ConfigLockBusy)
+    assert calls == 1, f"a permanent error was retried {calls} times"
+    assert fcntl_mod.flock is not _boom  # monkeypatch cleaned up
 
 
 async def test_async_lock_does_not_fake_reentrancy_for_a_sibling_task(

--- a/tests/api/test_hal0_toml_lock_scope.py
+++ b/tests/api/test_hal0_toml_lock_scope.py
@@ -415,6 +415,50 @@ async def test_nested_txn_shares_the_outer_working_state(tmp_hal0_home: str) -> 
     assert final.telemetry.channel == "preview"
 
 
+def _installer_writer_source() -> str:
+    """The ``[models].store`` writer, extracted straight out of install.sh.
+
+    Tests execute the real script body rather than a copy, so they cannot drift
+    from what an operator actually runs.
+    """
+    install_sh = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+    match = re.search(
+        r"python3 - \"\$\{HAL0_TOML\}\" \"\$\{MODELS_DIR\}\" <<'PYEOF'\n(.*?)\nPYEOF",
+        install_sh.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert match, "could not locate install.sh's [models].store writer"
+    return match.group(1)
+
+
+def test_installer_writer_refuses_a_symlinked_config(tmp_path: Path) -> None:
+    """A symlinked hal0.toml must be refused, not followed.
+
+    install.sh runs as root while ``/etc/hal0`` is service-writable, so
+    following a symlinked target would let the read slurp a root-only file and
+    the atomic replace copy it into ``hal0.toml`` — which the installer's later
+    ``doctor perms --fix`` step then hands to the ``hal0`` account
+    (#1721 review round 4). Hardening only the lock file is not enough.
+    """
+    script = tmp_path / "writer.py"
+    script.write_text(_installer_writer_source(), encoding="utf-8")
+
+    secret = tmp_path / "root-only.txt"
+    secret.write_text("SUPERSECRET", encoding="utf-8")
+    link = tmp_path / "hal0.toml"
+    link.symlink_to(secret)
+
+    proc = subprocess.run(
+        [sys.executable, str(script), str(link), "/new/models"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode != 0, "the writer must refuse a symlinked config"
+    assert secret.read_text(encoding="utf-8") == "SUPERSECRET", "the victim was modified"
+    assert link.is_symlink(), "the symlink was replaced by a real file"
+
+
 def test_installer_shell_writer_replaces_hal0_toml_atomically(tmp_path: Path) -> None:
     """Run install.sh's embedded writer for real and prove the swap is atomic.
 
@@ -514,6 +558,44 @@ def _reenter_file_lock(target: Path) -> Any:
     from hal0.config.locking import async_file_lock
 
     return async_file_lock(target, timeout=2)
+
+
+async def test_installer_store_write_is_shielded_from_cancellation(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancelling the installer request must not orphan its config write.
+
+    ``asyncio.to_thread`` cancels only the awaiter. If the worker is blocked on
+    ``hal0.toml.lock`` when the request is cancelled (shutdown, request-timeout
+    middleware), the orphan can acquire the lock afterwards and persist the
+    CANCELLED request's storage choice — over a newer setup request, and with
+    no slots provisioned to match (#1721 review round 4).
+    """
+    from hal0.install import orchestrate
+
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _slow_persist(storage_dir: str) -> None:
+        started.set()
+        release.wait(timeout=10)
+        finished.set()
+
+    monkeypatch.setattr(orchestrate, "_persist_store_dir", _slow_persist)
+
+    task = asyncio.ensure_future(orchestrate._persist_store_dir_shielded(str(tmp_path)))
+    await asyncio.to_thread(started.wait, 5)
+    task.cancel()
+    await asyncio.sleep(0.05)
+
+    assert not task.done(), "cancellation must not abandon the in-flight worker"
+    assert not finished.is_set()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert finished.is_set(), "the worker must have run to completion before we gave up"
 
 
 # ── the ratchet ───────────────────────────────────────────────────────────────

--- a/tests/api/test_hal0_toml_lock_scope.py
+++ b/tests/api/test_hal0_toml_lock_scope.py
@@ -20,6 +20,9 @@ These tests pin the fix at three levels:
 from __future__ import annotations
 
 import asyncio
+import re
+import subprocess
+import sys
 import threading
 import tomllib
 from collections.abc import Awaitable, Callable
@@ -376,6 +379,113 @@ async def test_nested_txn_in_one_task_does_not_deadlock(tmp_hal0_home: str) -> N
                 return "ok"
 
     assert await asyncio.wait_for(_nested(), timeout=10) == "ok"
+
+
+async def test_nested_txn_shares_the_outer_working_state(tmp_hal0_home: str) -> None:
+    """A nested txn must see the outer's UNSAVED edits and share its handle.
+
+    #1721 review round 2: yielding a freshly loaded model to the nested caller
+    forks the working state — the helper never sees the outer's in-flight
+    changes, and the outer's later ``save()`` writes its own stale object back
+    over whatever the helper committed. That is a lost update inside a single
+    request, the exact bug class this accessor exists to remove.
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    async def _helper() -> None:
+        async with hal0_config_txn(path=target, timeout=5) as inner:
+            # The outer's unsaved edit is visible here.
+            assert inner.config.telemetry.enabled is True
+            inner.config.telemetry.channel = "preview"
+
+    async with hal0_config_txn(path=target, timeout=5) as outer:
+        outer.config.telemetry.enabled = True  # NOT saved yet
+        await _helper()
+        # The helper's edit landed on the same object, not a forked copy.
+        assert outer.config.telemetry.channel == "preview"
+        outer.save()
+
+    final = load_hal0_config(target)
+    assert final.telemetry.enabled is True
+    assert final.telemetry.channel == "preview"
+
+
+def test_installer_shell_writer_replaces_hal0_toml_atomically(tmp_path: Path) -> None:
+    """Run install.sh's embedded writer for real and prove the swap is atomic.
+
+    The advisory lock binds cooperating writers only — every API read path calls
+    ``load_hal0_config()`` unlocked — so a truncate-then-write is observable by
+    a live daemon as an empty file (silently all-defaults) or as half-written
+    TOML (#1721 review round 2).
+    """
+    install_sh = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+    text = install_sh.read_text(encoding="utf-8")
+    match = re.search(
+        r"python3 - \"\$\{HAL0_TOML\}\" \"\$\{MODELS_DIR\}\" <<'PYEOF'\n(.*?)\nPYEOF",
+        text,
+        re.S,
+    )
+    assert match, "could not locate install.sh's [models].store writer"
+    writer = match.group(1)
+    assert "os.replace" in writer and "fsync" in writer, "the installer write must be atomic"
+
+    toml_path = tmp_path / "hal0.toml"
+    toml_path.write_text(
+        '[telemetry]\nenabled = true\n\n[models]\nstore = "/old"\nroots = ["/a"]\n',
+        encoding="utf-8",
+    )
+    script = tmp_path / "writer.py"
+    script.write_text(writer, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(script), str(toml_path), "/new/models"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    assert parsed["models"]["store"] == "/new/models"
+    assert parsed["models"]["pull_root"] == "/new/models"
+    assert parsed["models"]["roots"] == ["/a"]  # untouched
+    assert parsed["telemetry"]["enabled"] is True  # other sections survive
+    # No tempfile left behind, and the lock file is a plain sibling.
+    assert not list(tmp_path.glob(".hal0.toml.*.tmp"))
+
+
+def test_installer_shell_writer_seeds_a_config_without_a_models_table(tmp_path: Path) -> None:
+    """The old ``printf >>`` append branch folded into the locked writer.
+
+    That branch is the one a table-less (or absent) hal0.toml took, and it was
+    the least protected of the two: a bare shell append with no lock at all.
+    """
+    install_sh = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+    match = re.search(
+        r"python3 - \"\$\{HAL0_TOML\}\" \"\$\{MODELS_DIR\}\" <<'PYEOF'\n(.*?)\nPYEOF",
+        install_sh.read_text(encoding="utf-8"),
+        re.S,
+    )
+    assert match
+    script = tmp_path / "writer.py"
+    script.write_text(match.group(1), encoding="utf-8")
+
+    for label, seed in (("table-less", "[telemetry]\nenabled = true\n"), ("absent", None)):
+        toml_path = tmp_path / f"hal0-{label}.toml"
+        if seed is not None:
+            toml_path.write_text(seed, encoding="utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, str(script), str(toml_path), "/new/models"],
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, f"{label}: {proc.stderr}"
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        assert parsed["models"]["store"] == "/new/models", label
+        if seed is not None:
+            assert parsed["telemetry"]["enabled"] is True, label
 
 
 async def test_txn_is_reentrant_within_one_task(tmp_hal0_home: str) -> None:

--- a/tests/api/test_hal0_toml_lock_scope.py
+++ b/tests/api/test_hal0_toml_lock_scope.py
@@ -355,6 +355,29 @@ async def test_txn_body_timeout_is_not_relabelled_as_lock_contention(
     assert "propagation timed out" in str(caught.value)
 
 
+async def test_nested_txn_in_one_task_does_not_deadlock(tmp_hal0_home: str) -> None:
+    """A txn opened inside a txn by the same task must not hang.
+
+    ``HAL0_TOML_LOCK`` is reached before the file lock's owner check, so
+    without task tracking at the transaction level the inner acquire waits on
+    a lock its own caller holds — forever (#1721 review).
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    async def _nested() -> str:
+        async with hal0_config_txn(path=target, timeout=5) as outer:
+            outer.config.telemetry.enabled = True
+            outer.save()
+            async with hal0_config_txn(path=target, timeout=5) as inner:
+                # The inner txn sees the outer's committed write.
+                assert inner.config.telemetry.enabled is True
+                return "ok"
+
+    assert await asyncio.wait_for(_nested(), timeout=10) == "ok"
+
+
 async def test_txn_is_reentrant_within_one_task(tmp_hal0_home: str) -> None:
     """A nested txn in the same task passes through instead of self-deadlocking.
 
@@ -409,3 +432,98 @@ def test_no_hal0_toml_writer_hand_rolls_its_own_read_modify_write() -> None:
         "these modules write hal0.toml without the serialized RMW path "
         f"(hal0_config_txn / hal0_config_file_lock): {offenders}"
     )
+
+
+def test_raw_hal0_toml_writers_are_covered_too() -> None:
+    """The ratchet must catch RAW writers, not just ``save_hal0_config`` ones.
+
+    #1721 review: the updater's stamp pass and ``hal0 config migrate`` go
+    straight to ``write_toml_atomic`` against ``paths.hal0_toml()``, so scanning
+    for the typed writer alone let two cooperating processes escape the
+    advisory-lock contract entirely.
+    """
+    src = Path(__file__).resolve().parents[2] / "src" / "hal0"
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        if "write_toml_atomic(" not in text:
+            continue  # a mention in prose is not a writer
+        if "hal0_toml()" not in text and "_hal0_toml_path()" not in text:
+            continue  # writes some other TOML (slots, profiles, registry)
+        rel = py.relative_to(src).as_posix()
+        if rel == "config/loader.py":
+            continue
+        if "hal0_config_txn" in text or "hal0_config_file_lock" in text:
+            continue
+        offenders.append(rel)
+
+    assert not offenders, (
+        f"these modules write hal0.toml raw, outside the advisory lock: {offenders}"
+    )
+
+
+def test_installer_shell_writer_takes_the_advisory_lock() -> None:
+    """``install.sh`` patches [models].store while hal0-api may still be live.
+
+    It restarts the service only further down the script, so this write races a
+    settings PUT on a real upgrade. It cannot import hal0 (the venv may not
+    exist yet), so it takes the same lock file with plain fcntl.
+    """
+    install_sh = Path(__file__).resolve().parents[2] / "installer" / "install.sh"
+    text = install_sh.read_text(encoding="utf-8")
+    start = text.index('HAL0_TOML="${ETC_DIR}/hal0.toml"')
+    block = text[start : start + 3000]
+    assert "hal0.toml" in block
+    assert ".lock" in block and "flock" in block, (
+        "install.sh's [models].store patch must hold hal0.toml.lock"
+    )
+    assert "O_NOFOLLOW" in block, "the root-run lock open must refuse symlinks"
+
+
+def test_lock_file_open_refuses_a_symlink(tmp_path: Path) -> None:
+    """A symlinked lock file must be refused, not followed.
+
+    ``/etc/hal0`` is service-writable under the ownership flip while
+    ``install.sh`` / ``hal0 update`` take this lock as root, so following a
+    symlink would let the service account aim the next root-run upgrade at any
+    root-writable file (#1721 review).
+    """
+    target = tmp_path / "hal0.toml"
+    target.write_text("", encoding="utf-8")
+    victim = tmp_path / "victim"
+    victim.write_text("precious", encoding="utf-8")
+    (tmp_path / "hal0.toml.lock").symlink_to(victim)
+
+    with pytest.raises(OSError), file_lock(target):
+        pass  # pragma: no cover — the open must fail first
+    assert victim.read_text(encoding="utf-8") == "precious"
+
+
+async def test_async_lock_does_not_fake_reentrancy_for_a_sibling_task(
+    tmp_hal0_home: str,
+) -> None:
+    """A sibling task's blocking ``file_lock`` must not sail through.
+
+    The sync lock's re-entrancy is thread-local, and every task shares the loop
+    thread — so marking the thread as "already holding" while an async writer
+    runs would let an unrelated task write with no lock at all (#1721 review).
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    from hal0.config.locking import async_file_lock
+
+    sibling_got_lock = threading.Event()
+
+    async with async_file_lock(target, timeout=5):
+        # Same loop thread, different task → must contend, not pass through.
+        worker = threading.Thread(
+            target=lambda: (file_lock(target).__enter__(), sibling_got_lock.set()),
+            daemon=True,
+        )
+        worker.start()
+        assert not sibling_got_lock.wait(timeout=0.3), (
+            "a second acquirer took the lock while the async holder had it"
+        )
+    assert sibling_got_lock.wait(timeout=5)

--- a/tests/api/test_hal0_toml_lock_scope.py
+++ b/tests/api/test_hal0_toml_lock_scope.py
@@ -1,0 +1,411 @@
+"""#1721 — every hal0.toml writer shares one serialized read-modify-write path.
+
+#1717 gave ``routes/settings.py``'s ``PUT /api/settings`` and
+``routes/memory.py``'s ``PUT /api/memory/graph`` a shared ``HAL0_TOML_LOCK``.
+Four more whole-config read-modify-writes never joined it — the model-store
+setter, ``PUT /api/config/models``, ``PUT /api/auth/require`` and the updater's
+channel setter — so any of them could save its own pre-read snapshot after a
+protected request and erase the section that request had just written. Several
+also started from ``app.state.hal0_config``, a startup snapshot no writer
+refreshed.
+
+These tests pin the fix at three levels:
+
+  * every writer route genuinely waits on the shared in-process lock;
+  * every writer route reloads from DISK, so a stale cache can't clobber;
+  * the accessor holds a cross-process advisory lock too, and the off-loop
+    writers (updater migrations, installer) take the same one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import tomllib
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.api.routes import auth as auth_routes
+from hal0.api.routes import config as config_routes
+from hal0.api.routes import settings as settings_routes
+from hal0.api.routes import updater as updater_routes
+from hal0.config.loader import (
+    HAL0_TOML_LOCK,
+    ConfigLockBusy,
+    hal0_config_txn,
+    load_hal0_config,
+    save_hal0_config,
+)
+from hal0.config.locking import file_lock
+from hal0.config.schema import Hal0Config
+
+# ── request doubles ───────────────────────────────────────────────────────────
+
+
+class _FakeAppState:
+    pass
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.state = _FakeAppState()
+
+
+class _FakeRequest:
+    """Just enough Starlette ``Request`` surface for the writer routes."""
+
+    def __init__(self, body: dict[str, Any] | None = None) -> None:
+        self._body = body or {}
+        self.app = _FakeApp()
+
+    async def json(self) -> dict[str, Any]:
+        return self._body
+
+
+def _toml_path(home: str) -> Path:
+    return Path(home) / "etc" / "hal0" / "hal0.toml"
+
+
+def _seed_graph_section(home: str) -> Path:
+    """Put a graph section on disk that no in-memory snapshot knows about.
+
+    Stands in for "another writer just saved its section while this request
+    was in flight / before it started".
+    """
+    path = _toml_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '[memory.graph]\nenabled = true\nextraction_slot = "agent"\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _graph_survived(path: Path) -> bool:
+    parsed = tomllib.loads(path.read_text(encoding="utf-8"))
+    graph = parsed.get("memory", {}).get("graph", {})
+    return graph.get("enabled") is True and graph.get("extraction_slot") == "agent"
+
+
+# ── per-route drivers ─────────────────────────────────────────────────────────
+
+
+def _drive_settings() -> Callable[[], Awaitable[Any]]:
+    req = _FakeRequest({"telemetry": {"enabled": True}})
+    req.app.state.hal0_config = Hal0Config()  # stale snapshot, no graph section
+    return lambda: settings_routes.update_settings(req)
+
+
+def _drive_auth() -> Callable[[], Awaitable[Any]]:
+    req = _FakeRequest()
+    req.app.state.hal0_config = Hal0Config()
+    body = auth_routes.RequireAuthRequest(require_auth=False)
+    return lambda: auth_routes.set_require_auth(body, req)
+
+
+def _drive_config_models(store_root: Path) -> Callable[[], Awaitable[Any]]:
+    req = _FakeRequest({"roots": [str(store_root)]})
+    req.app.state.hal0_config = Hal0Config()
+    return lambda: config_routes.update_models_config(req)
+
+
+def _drive_channel(monkeypatch: pytest.MonkeyPatch) -> Callable[[], Awaitable[Any]]:
+    class _StubUpdater:
+        def __init__(self, channel: str | None = None) -> None:
+            self.channel = channel
+
+        async def check(self) -> dict[str, Any]:
+            return {"ok": True}
+
+    monkeypatch.setattr(updater_routes, "Updater", _StubUpdater)
+    req = _FakeRequest({"channel": "preview"})
+    req.app.state.hal0_config = Hal0Config()
+    return lambda: updater_routes.set_channel(req)
+
+
+def _drive_model_store(store_root: Path) -> Callable[[], Awaitable[Any]]:
+    req = _FakeRequest({"path": str(store_root)})
+    req.app.state.hal0_config = Hal0Config()
+    return lambda: settings_routes.set_model_store(req)
+
+
+def _all_drivers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Callable[[], Awaitable[Any]]]:
+    store_root = tmp_path / "store"
+    store_root.mkdir(exist_ok=True)
+    return {
+        "settings": _drive_settings(),
+        "auth_require": _drive_auth(),
+        "config_models": _drive_config_models(store_root),
+        "updater_channel": _drive_channel(monkeypatch),
+        "model_store": _drive_model_store(store_root),
+    }
+
+
+ROUTE_IDS = ["settings", "auth_require", "config_models", "updater_channel", "model_store"]
+
+
+# ── in-process serialization ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("route_id", ROUTE_IDS)
+async def test_writer_route_waits_for_the_shared_lock(
+    route_id: str, tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each hal0.toml writer must block while another holds HAL0_TOML_LOCK.
+
+    Before #1721 only the settings + memory/graph routes did; the other four
+    raced straight past a held lock and could overwrite the holder's section.
+    """
+    driver = _all_drivers(tmp_path, monkeypatch)[route_id]
+
+    await HAL0_TOML_LOCK.acquire()
+    try:
+        task = asyncio.ensure_future(driver())
+        await asyncio.sleep(0.05)
+        assert not task.done(), f"{route_id} must block on the shared hal0.toml lock"
+    finally:
+        HAL0_TOML_LOCK.release()
+
+    await task
+
+
+@pytest.mark.parametrize("route_id", ROUTE_IDS)
+async def test_writer_route_reloads_disk_instead_of_a_stale_cache(
+    route_id: str, tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A writer must never persist ``app.state.hal0_config``'s startup snapshot.
+
+    The graph section below exists only on disk — exactly the state left behind
+    by a concurrent ``PUT /api/memory/graph``. A writer that merges into the
+    cached snapshot erases it; one that reloads under the lock preserves it.
+    """
+    path = _seed_graph_section(tmp_hal0_home)
+    driver = _all_drivers(tmp_path, monkeypatch)[route_id]
+
+    await driver()
+
+    assert _graph_survived(path), f"{route_id} clobbered a section it never read"
+
+
+async def test_concurrent_writers_do_not_lose_updates(
+    tmp_hal0_home: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fire every writer at once; each one's key must be present at the end.
+
+    The lost update this reproduces needs no artificial delay: each route did
+    its own load → modify → save, so interleaving at any await lost whichever
+    section was written by the request that finished first.
+    """
+    _seed_graph_section(tmp_hal0_home)
+    drivers = _all_drivers(tmp_path, monkeypatch)
+
+    results = await asyncio.gather(*(d() for d in drivers.values()), return_exceptions=True)
+    for route_id, result in zip(drivers, results, strict=True):
+        assert not isinstance(result, BaseException), f"{route_id} failed: {result!r}"
+
+    final = load_hal0_config()
+    assert final.memory.graph.enabled is True  # graph section (disk-only) survived
+    assert final.memory.graph.extraction_slot == "agent"
+    assert final.telemetry.enabled is True  # settings PUT
+    assert final.telemetry.channel == "preview"  # updater channel PUT
+    assert final.security.require_auth is False  # auth PUT
+    assert str(tmp_path / "store") in (final.models.roots or [])  # config models PUT
+    assert final.models.store == str(tmp_path / "store")  # model-store POST
+
+
+# ── cross-process serialization ───────────────────────────────────────────────
+
+
+async def test_txn_waits_for_a_cross_process_advisory_lock(tmp_hal0_home: str) -> None:
+    """The in-process asyncio lock cannot see the CLI/installer/updater.
+
+    ``install.sh`` runs its post-activation hal0.toml migration BEFORE it
+    restarts hal0-api, so a live daemon can be mid-settings-PUT while another
+    process rewrites the same file. The txn therefore also holds the
+    ``hal0.toml.lock`` advisory lock — asserted here by taking that lock from
+    another thread (a stand-in for the other process) and requiring the txn to
+    refuse rather than race.
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def _hold_lock() -> None:
+        with file_lock(target):
+            held.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold_lock, daemon=True)
+    holder.start()
+    try:
+        assert held.wait(timeout=5)
+        with pytest.raises(ConfigLockBusy):
+            async with hal0_config_txn(path=target, timeout=0.2):
+                pass  # pragma: no cover — the acquire must fail first
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    # Lock free again → the same txn now succeeds.
+    async with hal0_config_txn(path=target, timeout=5) as txn:
+        assert isinstance(txn.config, Hal0Config)
+
+
+async def test_txn_does_not_block_the_event_loop_while_waiting(tmp_hal0_home: str) -> None:
+    """Waiting for the cross-process lock must be an await, not a stalled loop.
+
+    A blocking ``flock`` on the loop thread freezes every request in the
+    process, not just the config writer, for as long as the peer holds it.
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def _hold_lock() -> None:
+        with file_lock(target):
+            held.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold_lock, daemon=True)
+    holder.start()
+    ticks = 0
+    try:
+        assert held.wait(timeout=5)
+
+        async def _tick() -> None:
+            nonlocal ticks
+            for _ in range(5):
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        waiter = asyncio.ensure_future(_await_busy_txn(target))
+        await _tick()
+        assert ticks == 5, "other coroutines must keep running while the txn waits"
+        assert not waiter.done()
+    finally:
+        release.set()
+        holder.join(timeout=5)
+    await waiter
+
+
+async def _await_busy_txn(target: Path) -> None:
+    async with hal0_config_txn(path=target, timeout=10):
+        pass
+
+
+def test_updater_config_migration_takes_the_shared_file_lock(tmp_hal0_home: str) -> None:
+    """The updater's schema migration is a hal0.toml RMW like any other.
+
+    It runs either on an ``asyncio.to_thread`` inside the live API process or
+    as a bare ``hal0`` process from ``install.sh``; both need the advisory lock
+    the API writers hold, or a migration can erase a settings save (and vice
+    versa).
+    """
+    from hal0.updater.updater import _maybe_run_config_migrations
+
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    entered = threading.Event()
+    finished = threading.Event()
+
+    with file_lock(target):
+        worker = threading.Thread(
+            target=lambda: (entered.set(), _maybe_run_config_migrations(1), finished.set()),
+            daemon=True,
+        )
+        worker.start()
+        assert entered.wait(timeout=5)
+        # While this thread holds the lock the migration must not complete.
+        assert not finished.wait(timeout=0.3), "migration ran without the hal0.toml lock"
+
+    assert finished.wait(timeout=10), "migration never completed after the lock was released"
+    worker.join(timeout=5)
+
+
+async def test_txn_body_timeout_is_not_relabelled_as_lock_contention(
+    tmp_hal0_home: str,
+) -> None:
+    """A TimeoutError from the BODY must surface as itself.
+
+    The memory/graph route awaits a bounded hindsight-api restart inside the
+    critical section; reporting that as "another process is writing hal0.toml"
+    would send an operator hunting the wrong bug.
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    with pytest.raises(TimeoutError) as caught:
+        async with hal0_config_txn(path=target, timeout=5):
+            raise TimeoutError("propagation timed out")
+    assert not isinstance(caught.value, ConfigLockBusy)
+    assert "propagation timed out" in str(caught.value)
+
+
+async def test_txn_is_reentrant_within_one_task(tmp_hal0_home: str) -> None:
+    """A nested txn in the same task passes through instead of self-deadlocking.
+
+    ``asyncio.Lock`` is not recursive, so without an owner check a writer that
+    (directly or via a helper) opened a second txn would hang forever rather
+    than fail — the worst possible failure mode for a config write path.
+    """
+    target = _toml_path(tmp_hal0_home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    save_hal0_config(Hal0Config(), target)
+
+    async def _nested() -> str:
+        # The inner acquire is the one that used to hang.
+        async with hal0_config_txn(path=target, timeout=5), _reenter_file_lock(target):
+            return "ok"
+
+    assert await asyncio.wait_for(_nested(), timeout=10) == "ok"
+
+
+def _reenter_file_lock(target: Path) -> Any:
+    from hal0.config.locking import async_file_lock
+
+    return async_file_lock(target, timeout=2)
+
+
+# ── the ratchet ───────────────────────────────────────────────────────────────
+
+
+def test_no_hal0_toml_writer_hand_rolls_its_own_read_modify_write() -> None:
+    """#1721 happened because the lock lived at the call sites, not the writer.
+
+    Every module that persists a whole hal0.toml must go through
+    ``hal0_config_txn`` (event loop) or ``hal0_config_file_lock`` (sync/threaded)
+    — a new route that calls ``save_hal0_config`` directly reintroduces exactly
+    the lost update this issue is about. Allowlisted below are the loader
+    itself (which defines both) and nothing else.
+    """
+    src = Path(__file__).resolve().parents[2] / "src" / "hal0"
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8")
+        if "save_hal0_config(" not in text:
+            continue
+        rel = py.relative_to(src).as_posix()
+        if rel == "config/loader.py":
+            continue
+        if "hal0_config_txn" in text or "hal0_config_file_lock" in text:
+            continue
+        offenders.append(rel)
+
+    assert not offenders, (
+        "these modules write hal0.toml without the serialized RMW path "
+        f"(hal0_config_txn / hal0_config_file_lock): {offenders}"
+    )


### PR DESCRIPTION
## What

Closes #1721. Every `hal0.toml` read-modify-write now goes through one serialized accessor instead of each call site hand-rolling load → modify → save.

#1717 introduced `HAL0_TOML_LOCK` and wired it into `PUT /api/settings` + `PUT /api/memory/graph`. Codex correctly flagged that four more whole-config writers never joined it:

| writer | context | before | after |
|---|---|---|---|
| `PUT /api/settings` | loop | locked, reloads | `hal0_config_txn` |
| `PUT /api/memory/graph` | loop | locked, reloads | `hal0_config_txn` (+ now refreshes the app cache) |
| `POST /api/settings/models/store` | loop | **unlocked**, saved a pre-move snapshot | `hal0_config_txn` for the save only |
| `PUT /api/config/models` | loop | **unlocked** | `hal0_config_txn` |
| `PUT /api/auth/require` | loop | **unlocked** | `hal0_config_txn` |
| `PUT /api/updater/channel` | loop | **unlocked**, started from the stale cache | `hal0_config_txn` |
| updater schema migration | thread (`to_thread`) **and** separate process (`install.sh`) | **unlocked** | `hal0_config_file_lock` |
| profile-catalog stamp | same | **unlocked** | `hal0_config_file_lock` |
| installer storage choice | separate process | **unlocked** | `hal0_config_file_lock` |

## Why this shape

Option (b) — spread the existing lock to each call site — is what produced #1721: a lock every future caller must remember is a lock a future caller forgets. So the lock moved *into* the accessor. `hal0_config_txn()` loads from **disk** inside the critical section (never `app.state.hal0_config`, the startup snapshot no writer refreshed), and `txn.save()` refreshes that cache — closing the "writer left the cache stale" variant #1717's review found, at the writer instead of at each reader.

**Cross-process seam: fcntl is warranted, not skipped.** `installer/install.sh` runs its post-activation `hal0.toml` migration *before* it restarts `hal0-api` — i.e. against a live daemon that may be serving a settings PUT. An in-process `asyncio.Lock` cannot see that. The txn therefore also takes the repo's existing `config/locking.py` advisory lock on `hal0.toml.lock`, and the off-loop writers take the same one. `/etc/hal0/*.lock` already has a `PermRow`, so there is no new install surface. The wait is a polled `LOCK_NB` + `await`, so a peer holding the lock parks one coroutine rather than freezing the process.

**Model-store migration lock scope** (the question #1721 left open): the multi-file move stays **outside** the lock; only the save is serialized. The move can run for minutes and touches nothing in `hal0.toml`, so holding the config lock across it would stall every other writer for no protection. What actually needed fixing was the save — it persisted a snapshot taken *before* the move; it now re-reads under the lock and applies only `[models].store`.

Two latent hazards found while wiring this up and fixed: a module-level `asyncio.Lock` binds to the first loop that awaits it and raises on any later one (now `PerLoopLock`), and a nested async acquire by the holding task would hang forever on the non-recursive lock (now an owner check).

## Verification

`tests/api/test_hal0_toml_lock_scope.py` (17 tests): every writer waits on the shared lock; every writer reloads from disk; concurrent writers lose no update; the txn waits on a cross-process holder **without** stalling the loop; the updater migration blocks on the same file lock; a body `TimeoutError` is not relabelled as lock contention; and a ratchet that fails any future module writing `hal0.toml` outside the serialized path.

Red-first: 9 of them fail against the pre-fix writers (verified by stashing only the writer modules).

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api tests/config tests/memory tests/updater -q
2909 passed, 10 skipped in 728.88s
```

`ruff check` / `ruff format` clean; `mypy` unchanged (one pre-existing error in `loader.py`, present on `main`).

## Out of scope

Writers of *other* config files (`slots/*.toml`, `profiles.toml`, `capabilities.toml`) — they have their own `file_lock` story and no `hal0.toml` interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)