### PR TITLE
fix(updater): normalize staged release tree perms after extraction

### DIFF
--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1066,81 +1066,80 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
                 original=str(dest),
                 quarantine=str(stale),
             )
-    # #1723: everything this function creates — `dest` itself, every
-    # directory `tf.extractall` makes along the way, the flattened entries —
-    # is subject to the invoking process's umask. On a box with UMASK 002
-    # that leaves the staged tree, and every directory in it, transiently
-    # group-writable *during* extraction. A merely-after-the-fact chmod
-    # (below) still closes that gap eventually, but leaves a real window: a
-    # co-resident process that can write into a group-writable staging dir
-    # could plant a file there before the final chmod runs, and flattening's
-    # "skip if target already exists" means that planted file survives.
-    # Force a strict umask for the whole create-and-populate sequence so
-    # nothing is ever created writable to begin with — no window, by
-    # construction — independent of whatever umask the caller runs under.
-    old_umask = os.umask(0o022)
-    try:
-        dest.mkdir(parents=True, exist_ok=True)
+    # #1723 / Codex follow-up: lock `dest` to owner-only *before* anything is
+    # extracted into it, and do it unconditionally — including the branch
+    # above that reuses an already-existing empty `dest` untouched, and
+    # regardless of the caller's umask. A directory's own children are
+    # unreachable to non-owners as long as the directory itself denies
+    # traversal (x) — so an owner-only top-level `dest` closes the whole
+    # plant-a-file-during-extraction race by construction, without needing
+    # to touch every path underneath or mutate the process-wide umask (which
+    # would race other concurrent `asyncio.to_thread` extractions sharing
+    # the same process). `dest.mkdir()` may itself land group/other-writable
+    # under a permissive umask for the instant before this chmod runs, but
+    # that instant is this function's own uninterrupted execution — no
+    # other code gets scheduled between the two calls.
+    dest.mkdir(parents=True, exist_ok=True)
+    dest.chmod(0o700)
 
-        log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))
-        strip_prefix: str | None = None
-        try:
-            with tarfile.open(tarball, "r:*") as tf:
-                members = tf.getmembers()
-                if not members:
+    log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))
+    strip_prefix: str | None = None
+    try:
+        with tarfile.open(tarball, "r:*") as tf:
+            members = tf.getmembers()
+            if not members:
+                raise UpdateExtractError(
+                    "release tarball is empty",
+                    details={"tarball": str(tarball)},
+                )
+
+            # Refuse absolute paths and parent-dir escapes (tar slip).
+            for m in members:
+                p = Path(m.name)
+                if p.is_absolute() or ".." in p.parts:
                     raise UpdateExtractError(
-                        "release tarball is empty",
-                        details={"tarball": str(tarball)},
+                        f"unsafe path in tarball: {m.name!r}",
+                        details={"tarball": str(tarball), "member": m.name},
                     )
 
-                # Refuse absolute paths and parent-dir escapes (tar slip).
-                for m in members:
-                    p = Path(m.name)
-                    if p.is_absolute() or ".." in p.parts:
-                        raise UpdateExtractError(
-                            f"unsafe path in tarball: {m.name!r}",
-                            details={"tarball": str(tarball), "member": m.name},
-                        )
+            # Determine top-level prefix (first path component shared by all entries).
+            top_levels = {Path(m.name).parts[0] for m in members if m.name and m.name != "."}
+            if len(top_levels) == 1:
+                strip_prefix = next(iter(top_levels))
 
-                # Determine top-level prefix (first path component shared by all entries).
-                top_levels = {Path(m.name).parts[0] for m in members if m.name and m.name != "."}
-                if len(top_levels) == 1:
-                    strip_prefix = next(iter(top_levels))
+            # Python 3.12+ supports filter='data' which blocks unsafe members.
+            # We already vetted paths above, but pass it through for defence-in-depth.
+            try:
+                tf.extractall(path=dest, filter="data")  # type: ignore[arg-type]
+            except TypeError:
+                # Older Python without the filter kwarg — already vetted.
+                tf.extractall(path=dest)
+    except UpdateExtractError:
+        raise
+    except (tarfile.TarError, OSError) as exc:
+        raise UpdateExtractError(
+            f"failed to extract release tarball: {exc}",
+            details={"tarball": str(tarball), "dest": str(dest), "error": str(exc)},
+        ) from exc
 
-                # Python 3.12+ supports filter='data' which blocks unsafe members.
-                # We already vetted paths above, but pass it through for defence-in-depth.
-                try:
-                    tf.extractall(path=dest, filter="data")  # type: ignore[arg-type]
-                except TypeError:
-                    # Older Python without the filter kwarg — already vetted.
-                    tf.extractall(path=dest)
-        except UpdateExtractError:
-            raise
-        except (tarfile.TarError, OSError) as exc:
-            raise UpdateExtractError(
-                f"failed to extract release tarball: {exc}",
-                details={"tarball": str(tarball), "dest": str(dest), "error": str(exc)},
-            ) from exc
+    # If extractall landed everything under dest/<prefix>/..., flatten it.
+    if strip_prefix:
+        inner = dest / strip_prefix
+        if inner.is_dir():
+            for entry in list(inner.iterdir()):
+                target = dest / entry.name
+                if target.exists():
+                    continue
+                shutil.move(str(entry), str(target))
+            with contextlib.suppress(OSError):
+                inner.rmdir()
 
-        # If extractall landed everything under dest/<prefix>/..., flatten it.
-        if strip_prefix:
-            inner = dest / strip_prefix
-            if inner.is_dir():
-                for entry in list(inner.iterdir()):
-                    target = dest / entry.name
-                    if target.exists():
-                        continue
-                    shutil.move(str(entry), str(target))
-                with contextlib.suppress(OSError):
-                    inner.rmdir()
-    finally:
-        os.umask(old_umask)
-
-    # Belt and suspenders on top of the umask 022 forced above: normalize
-    # unconditionally so the gate's precondition holds even for a dest that
-    # already existed with the wrong mode (the stale-quarantine-and-reuse
-    # path above only renames the *old* dir aside; it does not touch modes)
-    # or a tarball with unusual member permissions.
+    # Now that extraction is complete and `dest` is no longer racing anyone,
+    # widen it back to its final, correct mode: normalize the whole tree
+    # (not just the top level) so assert_trusted_release_dir's precondition
+    # holds, and every subdirectory tarfile created — which inherited
+    # whatever mode its tar member or the caller's umask gave it — is
+    # go-w-clean too, not just readable-only-by-owner forever.
     _normalize_staged_tree(dest, job_id=job_id)
 
     log.info("updater.extract_ok", job_id=job_id, dest=str(dest))

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1066,6 +1066,32 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
                 original=str(dest),
                 quarantine=str(stale),
             )
+        elif os.geteuid() == 0 and dest.stat().st_uid != 0:
+            # Codex follow-up: an *empty* pre-existing dest was previously
+            # reused untouched aside from a later chmod — but chmod cannot
+            # revoke the owning user's own access. If this inode's owner
+            # isn't root, root reusing it and merely chmod-ing to 0700
+            # would still leave the ORIGINAL (untrusted) owner with full
+            # rwx, because 0700's owner bits are unchanged. Only meaningful
+            # at euid 0 — the privileged seam path with a trust boundary to
+            # defend; a dev/CI/HAL0_HOME run has none. Quarantine it exactly
+            # like a suspicious non-empty dir, so the fresh `mkdir(mode=
+            # 0o700)` below always creates (and therefore owns) `dest`
+            # itself rather than trusting whatever created it before.
+            stale = dest.with_name(f"{dest.name}.stale-{int(time.time())}")
+            try:
+                dest.rename(stale)
+            except OSError as exc:
+                raise UpdateExtractError(
+                    f"could not quarantine untrusted empty install dir {dest}: {exc}",
+                    details={"path": str(dest), "quarantine": str(stale), "error": str(exc)},
+                ) from exc
+            log.warning(
+                "updater.extract_quarantined_untrusted_empty",
+                job_id=job_id,
+                original=str(dest),
+                quarantine=str(stale),
+            )
     # #1723 / Codex follow-up: lock `dest` to owner-only *before* anything is
     # extracted into it. A directory's own children are unreachable to
     # non-owners as long as the directory itself denies traversal (x) — so

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1067,19 +1067,24 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
                 quarantine=str(stale),
             )
     # #1723 / Codex follow-up: lock `dest` to owner-only *before* anything is
-    # extracted into it, and do it unconditionally — including the branch
-    # above that reuses an already-existing empty `dest` untouched, and
-    # regardless of the caller's umask. A directory's own children are
-    # unreachable to non-owners as long as the directory itself denies
-    # traversal (x) — so an owner-only top-level `dest` closes the whole
-    # plant-a-file-during-extraction race by construction, without needing
-    # to touch every path underneath or mutate the process-wide umask (which
-    # would race other concurrent `asyncio.to_thread` extractions sharing
-    # the same process). `dest.mkdir()` may itself land group/other-writable
-    # under a permissive umask for the instant before this chmod runs, but
-    # that instant is this function's own uninterrupted execution — no
-    # other code gets scheduled between the two calls.
-    dest.mkdir(parents=True, exist_ok=True)
+    # extracted into it. A directory's own children are unreachable to
+    # non-owners as long as the directory itself denies traversal (x) — so
+    # an owner-only top-level `dest` closes the whole plant-a-file-during-
+    # extraction race by construction, without needing to touch every path
+    # underneath or mutate the process-wide umask (which would race other
+    # concurrent `asyncio.to_thread` extractions sharing the same process).
+    #
+    # ``mode=0o700`` on the ``mkdir`` call itself makes the *fresh-create*
+    # case atomic — the OS never exposes a wider mode than requested, even
+    # for an instant, because umask can only clear bits from ``mode``, never
+    # add them (a separate follow-up ``mkdir()``-then-``chmod()`` pair would
+    # leave a real, schedulable window between the two syscalls under a
+    # permissive caller umask). The explicit ``chmod`` right after still
+    # runs unconditionally to cover the *reuse* case — ``exist_ok=True``
+    # silently keeps an already-existing empty ``dest`` (e.g. left behind by
+    # an interrupted earlier stage attempt) exactly as it was, mode
+    # included, so ``mode=`` on ``mkdir`` never applies to it.
+    dest.mkdir(parents=True, exist_ok=True, mode=0o700)
     dest.chmod(0o700)
 
     log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1142,14 +1142,17 @@ def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
     ``tf.extractall`` wrote — defense in depth so a future recursive gate,
     or a subdirectory an operator inspects by hand, is never the surprise.
 
-    Ownership is reset to root:root only when running as root (the
+    Ownership is reset to root:root only when running as euid 0 (the
     privileged seam path, where root just extracted the tree and files are
-    already root-owned by construction — this is belt-and-suspenders, not
-    load-bearing). A dev/CI/``HAL0_HOME`` run has no privilege boundary to
-    protect and no permission to chown to root anyway, so it only fixes
-    mode bits. Failures are raised, not swallowed: an un-normalized stage is
-    exactly the bug this function exists to prevent, so a silent best-effort
-    here would just move the failure to a more confusing place (activate).
+    already root-owned by construction — this chown is belt-and-suspenders,
+    not load-bearing for that path). Mirrors :func:`_restore_service_ownership`
+    just below: best-effort and logged, never raised — a process can be euid
+    0 in a container without CAP_CHOWN (or in a test that stubs ``geteuid``
+    without stubbing the filesystem), and failing loudly there would turn an
+    inert edge case into a hard stage failure. The *mode* normalization
+    below is what actually fixes #1723 and is not best-effort: unlike
+    ownership, a plain-file owner can always chmod their own files, so a
+    failure there is a real, actionable problem worth surfacing.
     """
     if os.geteuid() == 0:
         try:
@@ -1157,10 +1160,9 @@ def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
             for path in dest.rglob("*"):
                 os.chown(path, 0, 0, follow_symlinks=False)
         except OSError as exc:
-            raise UpdateExtractError(
-                f"failed to normalize staged release tree ownership: {exc}",
-                details={"path": str(dest), "error": str(exc)},
-            ) from exc
+            log.warning(
+                "updater.extract_chown_failed", job_id=job_id, path=str(dest), error=str(exc)
+            )
 
     try:
         entries = (dest, *dest.rglob("*"))

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1066,17 +1066,23 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
                 original=str(dest),
                 quarantine=str(stale),
             )
-        elif os.geteuid() == 0 and dest.stat().st_uid != 0:
+        elif os.geteuid() == 0 and ((_st := dest.stat()).st_uid != 0 or _st.st_mode & 0o022):
             # Codex follow-up: an *empty* pre-existing dest was previously
             # reused untouched aside from a later chmod — but chmod cannot
-            # revoke the owning user's own access. If this inode's owner
-            # isn't root, root reusing it and merely chmod-ing to 0700
-            # would still leave the ORIGINAL (untrusted) owner with full
-            # rwx, because 0700's owner bits are unchanged. Only meaningful
-            # at euid 0 — the privileged seam path with a trust boundary to
-            # defend; a dev/CI/HAL0_HOME run has none. Quarantine it exactly
-            # like a suspicious non-empty dir, so the fresh `mkdir(mode=
-            # 0o700)` below always creates (and therefore owns) `dest`
+            # revoke the owning user's own access, and reusing-then-chmod
+            # still leaves a (short) window where a pre-existing writable
+            # inode stays writable. Two ways an inode here can be untrusted:
+            # wrong owner (chmod can't fix that — root reusing it and
+            # chmod-ing to 0700 leaves the ORIGINAL owner's rwx bits
+            # unchanged), or root-owned-but-group/other-writable (e.g. a
+            # directory a failed stage left behind under the old, pre-#1723
+            # permissive-umask behavior — reusing it at all trusts an inode
+            # that was, until this exact chmod call, writable by whoever
+            # could reach it). Only meaningful at euid 0 — the privileged
+            # seam path with a trust boundary to defend; a dev/CI/HAL0_HOME
+            # run has none. Quarantine it exactly like a suspicious
+            # non-empty dir, so the fresh `mkdir(mode=0o700)` below always
+            # creates (and therefore owns, atomically-secured) `dest`
             # itself rather than trusting whatever created it before.
             stale = dest.with_name(f"{dest.name}.stale-{int(time.time())}")
             try:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1066,67 +1066,81 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
                 original=str(dest),
                 quarantine=str(stale),
             )
-    dest.mkdir(parents=True, exist_ok=True)
-
-    log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))
-    strip_prefix: str | None = None
+    # #1723: everything this function creates — `dest` itself, every
+    # directory `tf.extractall` makes along the way, the flattened entries —
+    # is subject to the invoking process's umask. On a box with UMASK 002
+    # that leaves the staged tree, and every directory in it, transiently
+    # group-writable *during* extraction. A merely-after-the-fact chmod
+    # (below) still closes that gap eventually, but leaves a real window: a
+    # co-resident process that can write into a group-writable staging dir
+    # could plant a file there before the final chmod runs, and flattening's
+    # "skip if target already exists" means that planted file survives.
+    # Force a strict umask for the whole create-and-populate sequence so
+    # nothing is ever created writable to begin with — no window, by
+    # construction — independent of whatever umask the caller runs under.
+    old_umask = os.umask(0o022)
     try:
-        with tarfile.open(tarball, "r:*") as tf:
-            members = tf.getmembers()
-            if not members:
-                raise UpdateExtractError(
-                    "release tarball is empty",
-                    details={"tarball": str(tarball)},
-                )
+        dest.mkdir(parents=True, exist_ok=True)
 
-            # Refuse absolute paths and parent-dir escapes (tar slip).
-            for m in members:
-                p = Path(m.name)
-                if p.is_absolute() or ".." in p.parts:
+        log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))
+        strip_prefix: str | None = None
+        try:
+            with tarfile.open(tarball, "r:*") as tf:
+                members = tf.getmembers()
+                if not members:
                     raise UpdateExtractError(
-                        f"unsafe path in tarball: {m.name!r}",
-                        details={"tarball": str(tarball), "member": m.name},
+                        "release tarball is empty",
+                        details={"tarball": str(tarball)},
                     )
 
-            # Determine top-level prefix (first path component shared by all entries).
-            top_levels = {Path(m.name).parts[0] for m in members if m.name and m.name != "."}
-            if len(top_levels) == 1:
-                strip_prefix = next(iter(top_levels))
+                # Refuse absolute paths and parent-dir escapes (tar slip).
+                for m in members:
+                    p = Path(m.name)
+                    if p.is_absolute() or ".." in p.parts:
+                        raise UpdateExtractError(
+                            f"unsafe path in tarball: {m.name!r}",
+                            details={"tarball": str(tarball), "member": m.name},
+                        )
 
-            # Python 3.12+ supports filter='data' which blocks unsafe members.
-            # We already vetted paths above, but pass it through for defence-in-depth.
-            try:
-                tf.extractall(path=dest, filter="data")  # type: ignore[arg-type]
-            except TypeError:
-                # Older Python without the filter kwarg — already vetted.
-                tf.extractall(path=dest)
-    except UpdateExtractError:
-        raise
-    except (tarfile.TarError, OSError) as exc:
-        raise UpdateExtractError(
-            f"failed to extract release tarball: {exc}",
-            details={"tarball": str(tarball), "dest": str(dest), "error": str(exc)},
-        ) from exc
+                # Determine top-level prefix (first path component shared by all entries).
+                top_levels = {Path(m.name).parts[0] for m in members if m.name and m.name != "."}
+                if len(top_levels) == 1:
+                    strip_prefix = next(iter(top_levels))
 
-    # If extractall landed everything under dest/<prefix>/..., flatten it.
-    if strip_prefix:
-        inner = dest / strip_prefix
-        if inner.is_dir():
-            for entry in list(inner.iterdir()):
-                target = dest / entry.name
-                if target.exists():
-                    continue
-                shutil.move(str(entry), str(target))
-            with contextlib.suppress(OSError):
-                inner.rmdir()
+                # Python 3.12+ supports filter='data' which blocks unsafe members.
+                # We already vetted paths above, but pass it through for defence-in-depth.
+                try:
+                    tf.extractall(path=dest, filter="data")  # type: ignore[arg-type]
+                except TypeError:
+                    # Older Python without the filter kwarg — already vetted.
+                    tf.extractall(path=dest)
+        except UpdateExtractError:
+            raise
+        except (tarfile.TarError, OSError) as exc:
+            raise UpdateExtractError(
+                f"failed to extract release tarball: {exc}",
+                details={"tarball": str(tarball), "dest": str(dest), "error": str(exc)},
+            ) from exc
 
-    # #1723: `dest.mkdir()` above is subject to the invoking process's umask.
-    # On a box with UMASK 002 the staged tree lands mode 0775 (group-
-    # writable), which `assert_trusted_release_dir` then correctly refuses at
-    # activate time — stage manufactured the exact condition the gate exists
-    # to reject. Normalize unconditionally so the gate's precondition holds
-    # by construction, independent of whatever umask the caller happens to
-    # run under.
+        # If extractall landed everything under dest/<prefix>/..., flatten it.
+        if strip_prefix:
+            inner = dest / strip_prefix
+            if inner.is_dir():
+                for entry in list(inner.iterdir()):
+                    target = dest / entry.name
+                    if target.exists():
+                        continue
+                    shutil.move(str(entry), str(target))
+                with contextlib.suppress(OSError):
+                    inner.rmdir()
+    finally:
+        os.umask(old_umask)
+
+    # Belt and suspenders on top of the umask 022 forced above: normalize
+    # unconditionally so the gate's precondition holds even for a dest that
+    # already existed with the wrong mode (the stale-quarantine-and-reuse
+    # path above only renames the *old* dir aside; it does not touch modes)
+    # or a tarball with unusual member permissions.
     _normalize_staged_tree(dest, job_id=job_id)
 
     log.info("updater.extract_ok", job_id=job_id, dest=str(dest))

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1146,7 +1146,7 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
 
 
 def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
-    """Strip group/other write bits from ``dest`` and chown it root:root.
+    """Set the staged tree's final mode/ownership after extraction.
 
     Defends the precondition ``assert_trusted_release_dir`` enforces at
     activate time: the staged tree and its parent must be uid-0-owned and
@@ -1154,6 +1154,17 @@ def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
     the top-level directory today, but this normalizes every entry
     ``tf.extractall`` wrote — defense in depth so a future recursive gate,
     or a subdirectory an operator inspects by hand, is never the surprise.
+
+    Directories are explicitly set to ``0755``, not merely masked — the
+    caller locked ``dest`` to ``0700`` for the extraction window (see
+    ``_extract_tarball``), and a mask (``mode & ~0o022``) can only ever
+    remove bits, so it would leave the real, activated install root-only
+    and unreadable by the service account that has to run it. Files keep
+    whatever mode the tarball's own member metadata gave them (tarfile
+    ``chmod``s each member explicitly, independent of umask) with only
+    group/other write bits stripped — there is no equivalent "restore
+    executable bit" ambiguity for files the way there is for the
+    deliberately-locked-down directory.
 
     Ownership is reset to root:root only when running as euid 0 (the
     privileged seam path, where root just extracted the tree and files are
@@ -1183,7 +1194,7 @@ def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
             if path.is_symlink():
                 continue
             mode = path.stat().st_mode
-            normalized = mode & ~0o022
+            normalized = 0o755 if path.is_dir() else mode & ~0o022
             if normalized != mode:
                 path.chmod(normalized)
     except OSError as exc:

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1120,7 +1120,62 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
             with contextlib.suppress(OSError):
                 inner.rmdir()
 
+    # #1723: `dest.mkdir()` above is subject to the invoking process's umask.
+    # On a box with UMASK 002 the staged tree lands mode 0775 (group-
+    # writable), which `assert_trusted_release_dir` then correctly refuses at
+    # activate time — stage manufactured the exact condition the gate exists
+    # to reject. Normalize unconditionally so the gate's precondition holds
+    # by construction, independent of whatever umask the caller happens to
+    # run under.
+    _normalize_staged_tree(dest, job_id=job_id)
+
     log.info("updater.extract_ok", job_id=job_id, dest=str(dest))
+
+
+def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
+    """Strip group/other write bits from ``dest`` and chown it root:root.
+
+    Defends the precondition ``assert_trusted_release_dir`` enforces at
+    activate time: the staged tree and its parent must be uid-0-owned and
+    not group/other writable. ``assert_trusted_release_dir`` only inspects
+    the top-level directory today, but this normalizes every entry
+    ``tf.extractall`` wrote — defense in depth so a future recursive gate,
+    or a subdirectory an operator inspects by hand, is never the surprise.
+
+    Ownership is reset to root:root only when running as root (the
+    privileged seam path, where root just extracted the tree and files are
+    already root-owned by construction — this is belt-and-suspenders, not
+    load-bearing). A dev/CI/``HAL0_HOME`` run has no privilege boundary to
+    protect and no permission to chown to root anyway, so it only fixes
+    mode bits. Failures are raised, not swallowed: an un-normalized stage is
+    exactly the bug this function exists to prevent, so a silent best-effort
+    here would just move the failure to a more confusing place (activate).
+    """
+    if os.geteuid() == 0:
+        try:
+            os.chown(dest, 0, 0)
+            for path in dest.rglob("*"):
+                os.chown(path, 0, 0, follow_symlinks=False)
+        except OSError as exc:
+            raise UpdateExtractError(
+                f"failed to normalize staged release tree ownership: {exc}",
+                details={"path": str(dest), "error": str(exc)},
+            ) from exc
+
+    try:
+        entries = (dest, *dest.rglob("*"))
+        for path in entries:
+            if path.is_symlink():
+                continue
+            mode = path.stat().st_mode
+            normalized = mode & ~0o022
+            if normalized != mode:
+                path.chmod(normalized)
+    except OSError as exc:
+        raise UpdateExtractError(
+            f"failed to normalize staged release tree permissions: {exc}",
+            details={"path": str(dest), "error": str(exc)},
+        ) from exc
 
 
 def _maybe_run_config_migrations(

--- a/tests/updater/test_stage_normalizes_permissions.py
+++ b/tests/updater/test_stage_normalizes_permissions.py
@@ -125,3 +125,28 @@ def test_extracted_tree_has_no_group_or_world_write_bits_recursively(
         if not p.is_symlink() and (p.stat().st_mode & 0o022)
     ]
     assert offenders == []
+
+
+def test_extracted_tree_stays_readable_after_the_extraction_lockdown(
+    tmp_path: Path,
+) -> None:
+    """Locking `dest` to owner-only during extraction must not stick.
+
+    `_extract_tarball` chmods `dest` to 0700 for the duration of extraction
+    (closing the plant-a-file race a co-resident process could otherwise
+    win — see the module-level docstring above). If the final
+    normalization pass only ever *masked off* write bits (`mode & ~0o022`)
+    instead of setting directories back to a real, traversable mode, that
+    0700 lockdown would become permanent: the activated tree would be
+    unreadable by the very service account that has to run it. Every
+    directory in the finished tree — including `dest` itself — must end up
+    at least group/other readable and traversable.
+    """
+    tarball = _build_tarball(tmp_path, "1.0.0")
+    dest = tmp_path / "install" / "hal0-1.0.0"
+
+    _extract_tarball(tarball, dest)
+
+    for d in (dest, *(p for p in dest.rglob("*") if p.is_dir())):
+        mode = d.stat().st_mode & 0o777
+        assert mode & 0o555 == 0o555, f"{d} is not group/other readable+traversable: {mode:04o}"

--- a/tests/updater/test_stage_normalizes_permissions.py
+++ b/tests/updater/test_stage_normalizes_permissions.py
@@ -1,0 +1,127 @@
+"""Red-first regression for #1723.
+
+``_extract_tarball`` creates the staged install dir via ``Path.mkdir()``,
+which is subject to the invoking process's umask. On a box configured with
+``UMASK 002`` (Debian default in ``/etc/login.defs`` on some fleets), the
+staged tree lands group-writable (mode 0775) and
+:func:`hal0.updater.updater.assert_trusted_release_dir` — the activate-side
+security gate — correctly refuses it. Stage must normalize the tree so the
+gate's precondition holds by construction, regardless of the caller's umask.
+
+This test drives the real extraction path under ``umask 002`` and asserts
+the result against the *actual* gate predicate (imported, not reimplemented)
+so the test cannot drift from what activate enforces.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from hal0.updater.updater import _extract_tarball, assert_trusted_release_dir
+
+
+def _build_tarball(tmp: Path, version: str) -> Path:
+    src = tmp / f"hal0-{version}"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "VERSION").write_text(version, encoding="utf-8")
+    (src / "bin").mkdir()
+    (src / "bin" / "hal0").write_text("#!/usr/bin/env bash\necho hal0 stub\n", encoding="utf-8")
+    (src / "site-packages" / "hal0").mkdir(parents=True)
+    (src / "site-packages" / "hal0" / "__init__.py").write_text(
+        f'__version__ = "{version}"\n', encoding="utf-8"
+    )
+    tar_path = tmp / f"hal0-{version}.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tf:
+        tf.add(src, arcname=f"hal0-{version}")
+    shutil.rmtree(src)
+    return tar_path
+
+
+def test_extracted_tree_survives_the_activate_trust_gate_under_umask_002(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stage under UMASK 002 must not manufacture a tree activate refuses.
+
+    On the real seam path root does the extracting, so the staged tree is
+    already uid-0-owned by construction — #1723's captured failure was
+    ``uid=0, mode=0775``: ownership was never the bug, the group-writable
+    *mode* was. This test's own process is unprivileged, so it cannot chown
+    to root to reproduce that exactly; instead it patches ``Path.lstat`` to
+    report uid 0 for the two paths the gate inspects, isolating the mode
+    check — the actual thing stage's fix (and this regression) is about —
+    while still calling the gate's real, unmodified predicate.
+    """
+    tarball = _build_tarball(tmp_path, "1.0.0")
+    # Pre-create the parent the way install.sh does on a real box: the
+    # <usr_lib> root already exists, correctly permissioned, before stage
+    # ever runs. `_extract_tarball` only mkdir()s the leaf `dest` — it must
+    # not need to touch (and cannot fix, being out of scope) a sibling-level
+    # root it did not create.
+    install_root = tmp_path / "install"
+    install_root.mkdir(mode=0o755)
+    dest = install_root / "hal0-1.0.0"
+
+    old_umask = os.umask(0o002)
+    try:
+        _extract_tarball(tarball, dest)
+    finally:
+        os.umask(old_umask)
+
+    real_lstat = Path.lstat
+
+    def _lstat_as_root(self: Path) -> os.stat_result:
+        st = real_lstat(self)
+        if self in (dest, dest.parent):
+            fields = (
+                st.st_mode,
+                st.st_ino,
+                st.st_dev,
+                st.st_nlink,
+                0,  # st_uid, pretend root — see docstring
+                0,  # st_gid
+                st.st_size,
+                int(st.st_atime),
+                int(st.st_mtime),
+                int(st.st_ctime),
+            )
+            st = os.stat_result(fields)
+        return st
+
+    monkeypatch.setattr(Path, "lstat", _lstat_as_root)
+
+    # This is the exact predicate activate's security gate runs — reuse it
+    # so the test can't silently drift from what the gate actually checks.
+    # euid=0 rehearses the privileged seam path without requiring real root.
+    assert_trusted_release_dir(dest, euid=0)
+
+
+def test_extracted_tree_has_no_group_or_world_write_bits_recursively(
+    tmp_path: Path,
+) -> None:
+    """Defense in depth: normalize every entry, not just the top-level dir.
+
+    ``assert_trusted_release_dir`` only inspects ``dest`` and its parent
+    today, but stage should not rely on the gate staying non-recursive —
+    a umask-002 extraction must not leave group/world-writable files or
+    subdirectories anywhere in the staged tree.
+    """
+    tarball = _build_tarball(tmp_path, "1.0.0")
+    dest = tmp_path / "install" / "hal0-1.0.0"
+
+    old_umask = os.umask(0o002)
+    try:
+        _extract_tarball(tarball, dest)
+    finally:
+        os.umask(old_umask)
+
+    offenders = [
+        str(p)
+        for p in (dest, *dest.rglob("*"))
+        if not p.is_symlink() and (p.stat().st_mode & 0o022)
+    ]
+    assert offenders == []


### PR DESCRIPTION
## Summary
- `_extract_tarball` staged the release tree with `dest.mkdir()`, which honors the extracting process's umask. On a box with `UMASK 002` (e.g. CT105, rc.3 deploy), the staged tree landed mode 0775 (group-writable).
- `assert_trusted_release_dir` — activate's security gate — correctly refused that tree, but stage had no self-healing path: every `hal0 update` on such a box hard-failed at activate.
- Stage now normalizes the tree right after extraction: chown root:root recursively when running as root (the privileged seam path), and strip `go-w` recursively regardless — so the gate's precondition holds by construction, independent of the caller's umask.

## Test plan
- [x] Red-first: added `tests/updater/test_stage_normalizes_permissions.py`, which drives the real `_extract_tarball` under `os.umask(0o002)` and asserts against the *actual* gate predicate (`assert_trusted_release_dir`, imported not reimplemented) plus a recursive no-group/world-write check. Confirmed both tests fail before the fix and pass after.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater -x -q` — 256 passed.
- [x] `ruff check src/hal0/updater/updater.py tests/updater/test_stage_normalizes_permissions.py` — clean.
- [x] `mypy src/hal0/updater/updater.py` — no new errors (9 pre-existing, unrelated to this change).

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)