### PR TITLE
fix(installer): preflight and auto-install git for Hermes provisioning

### DIFF
--- a/installer/agents/hermes-prereqs.sh
+++ b/installer/agents/hermes-prereqs.sh
@@ -5,8 +5,21 @@
 # at /var/lib/hal0/venvs/hermes. That needs an OS toolchain a clean box
 # may lack: a python3 that can `python3 -m venv` (Debian/Ubuntu split this
 # into the separate python3-venv package — the classic clean-Ubuntu trap),
-# python3-pip, and pipx. This script ensures all four are present, using
-# lib/distro.sh for cross-distro package naming.
+# python3-pip, pipx, and git. This script ensures all five are present,
+# using lib/distro.sh for cross-distro package naming.
+#
+# git is required because the provisioner's `pip install
+# git+https://github.com/NousResearch/hermes-agent.git@<rev>` shells out to
+# `git clone`; a stock minimal distro image doesn't ship it (#1726, #1727
+# review). This script is the SHARED choke point for both provisioning
+# entry points — install.sh's inline `hal0 agent install hermes` call and
+# the standalone/deferred `hal0 agent install hermes` an operator runs
+# manually (e.g. after HAL0_SKIP_HERMES=1, or per the remediation hint on
+# a failed inline provision) — both go through
+# hal0.cli.agent_commands._install_hermes, which shells out to this exact
+# script (see installer/install.sh's own preflight_git gate, which is
+# fast-path defense-in-depth only; this script is what actually covers
+# both call sites).
 #
 # Idempotent: probes first and installs nothing when the toolchain is
 # already complete. Cross-distro via the same package-manager detection
@@ -31,6 +44,11 @@ have_venv() { [ -n "${PY}" ] && "${PY}" -c 'import venv, ensurepip' >/dev/null 2
 have_pip() { [ -n "${PY}" ] && "${PY}" -m pip --version >/dev/null 2>&1; }
 have_pipx() { command -v pipx >/dev/null 2>&1; }
 have_uv() { command -v uv >/dev/null 2>&1; }
+# `command -v git` only proves a `git` file resolves on PATH, not that it
+# runs (a non-executable file — permissions drift, a half-finished package
+# install — still resolves). `git --version` is the real functional probe
+# (#1727 review).
+have_git() { git --version >/dev/null 2>&1; }
 
 # hermes-agent wheels pin `requires-python >=3.11,<3.14`. On a box whose only
 # interpreter is 3.14+ (e.g. Ubuntu 26.04, whose apt has no python3.12), pip
@@ -71,25 +89,26 @@ uv could not be installed for the managed-interpreter fallback. Install uv
 }
 
 # Toolchain is "complete" only when the interpreter fallback is also satisfiable:
-# venv+pip+pipx AND (a system Python in range OR uv for the managed fallback).
-if have_venv && have_pip && have_pipx && { have_system_hermes_py || have_uv; }; then
-    info "toolchain already present (python venv + pip + pipx + interpreter path) — nothing to do"
+# venv+pip+pipx+git AND (a system Python in range OR uv for the managed fallback).
+if have_venv && have_pip && have_pipx && have_git && { have_system_hermes_py || have_uv; }; then
+    info "toolchain already present (python venv + pip + pipx + git + interpreter path) — nothing to do"
     exit 0
 fi
 
 # ── Resolve per-family package names ─────────────────────────────────────────
 # Names differ by ecosystem, not distro. venv: bundled everywhere except
 # Debian/Ubuntu. pipx: `python-pipx` on Arch, `pipx` elsewhere it's packaged.
+# git: package named `git` on every family below.
 family="$(distro_family || true)"
 case "${family}" in
-    debian) pkgs=(python3 python3-venv python3-pip pipx) ;;
-    fedora) pkgs=(python3 python3-pip pipx) ;;
-    arch) pkgs=(python python-pip python-pipx) ;;
-    suse) pkgs=(python3 python3-pip python3-pipx) ;;
-    alpine) pkgs=(python3 py3-pip pipx) ;;
+    debian) pkgs=(python3 python3-venv python3-pip pipx git) ;;
+    fedora) pkgs=(python3 python3-pip pipx git) ;;
+    arch) pkgs=(python python-pip python-pipx git) ;;
+    suse) pkgs=(python3 python3-pip python3-pipx git) ;;
+    alpine) pkgs=(python3 py3-pip pipx git) ;;
     *)
         die "unrecognised package manager — install Python 3.11+ (with the venv
-stdlib module), pip, and pipx manually, then re-run \`hal0 agent install hermes\`."
+stdlib module), pip, pipx, and git manually, then re-run \`hal0 agent install hermes\`."
         ;;
 esac
 
@@ -122,6 +141,14 @@ PY="$(command -v python3.12 || command -v python3 || true)"
 have_venv || die "python venv module still missing after install — check ${PY:-python3} and \`$(python_venv_hint)\`"
 have_pip || warn "python pip still not importable — bootstrap will bootstrap it via ensurepip"
 have_pipx || warn "pipx not on PATH after install — Hermes still installs into the managed venv; pipx is optional tooling"
+# git is load-bearing, not optional — `pip install git+...` (the very next
+# phase of provisioning) hard-requires it, so a still-missing/unusable git
+# here must die loudly with a remediation line rather than warn and let the
+# pip clone fail with the original opaque error three steps later (#1726,
+# #1727 review).
+have_git || die "git still missing or not runnable after install — install it manually
+(e.g. \`$(pkg_install_cmd git 2>/dev/null || echo 'install git via your distro package manager')\`),
+then re-run \`hal0 agent install hermes\`."
 
 # hermes-agent's Python-version floor: ensure a usable interpreter path (system
 # 3.11-3.13, or uv for the managed fallback on a 3.14-only box).

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2838,12 +2838,19 @@ else
         # general preflight (above, ~L346) doesn't cover git, so a stock
         # minimal image without it sailed through every earlier check only to
         # have this step die deep inside pip with "Cannot find command 'git'"
-        # (#1726). Gate here, defense-in-depth: HAL0_GIT_REQUIRED=1
-        # auto-installs it via the detected package manager. Consistent with
-        # the #1584 graceful-degradation precedent, a git install failure
-        # does NOT abort the overall install — it fails this provisioning
-        # step loudly, with a git-specific remediation line, exactly like any
-        # other Hermes provisioning failure below.
+        # (#1726). Gate here as a FAST, install.sh-local defense-in-depth
+        # check: HAL0_GIT_REQUIRED=1 auto-installs it via the detected
+        # package manager before we even shell out to the CLI. The
+        # AUTHORITATIVE fix lives in installer/agents/hermes-prereqs.sh (also
+        # updated for #1726) — that script is the shared choke point for
+        # BOTH this inline call and the standalone/deferred `hal0 agent
+        # install hermes` an operator runs manually later, so it's the one
+        # place that must not miss git regardless of entry point (#1727
+        # review). Consistent with the #1584 graceful-degradation precedent,
+        # a git install failure here does NOT abort the overall install — it
+        # fails this provisioning step loudly, with a git-specific
+        # remediation line, exactly like any other Hermes provisioning
+        # failure below.
         elif ! HAL0_GIT_REQUIRED=1 preflight_git; then
             warn "hermes provisioning skipped — git is required (pip installs hermes-agent from a git URL) and could not be installed"
             warn "  install git manually ($(pkg_install_cmd git 2>/dev/null || echo 'via your distro package manager')), then run '${HAL0_BIN} agent install hermes'"

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2833,6 +2833,20 @@ else
     if [[ -f "${AGENT_UNIT_DST}" && ! -x "/var/lib/hal0/venvs/hermes/bin/hermes" ]]; then
         if [[ "${HAL0_SKIP_HERMES:-0}" -eq 1 ]]; then
             info "skipping hermes provisioning (HAL0_SKIP_HERMES=1) — run '${HAL0_BIN} agent install hermes' later"
+        # `hal0 agent install hermes` pip-installs hermes-agent straight from
+        # a git URL, which pip implements by shelling out to `git clone`. The
+        # general preflight (above, ~L346) doesn't cover git, so a stock
+        # minimal image without it sailed through every earlier check only to
+        # have this step die deep inside pip with "Cannot find command 'git'"
+        # (#1726). Gate here, defense-in-depth: HAL0_GIT_REQUIRED=1
+        # auto-installs it via the detected package manager. Consistent with
+        # the #1584 graceful-degradation precedent, a git install failure
+        # does NOT abort the overall install — it fails this provisioning
+        # step loudly, with a git-specific remediation line, exactly like any
+        # other Hermes provisioning failure below.
+        elif ! HAL0_GIT_REQUIRED=1 preflight_git; then
+            warn "hermes provisioning skipped — git is required (pip installs hermes-agent from a git URL) and could not be installed"
+            warn "  install git manually ($(pkg_install_cmd git 2>/dev/null || echo 'via your distro package manager')), then run '${HAL0_BIN} agent install hermes'"
         else
             info "provisioning Hermes agent (toolchain + bootstrap) — this can take a few minutes…"
             if "${HAL0_BIN}" agent install hermes; then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -641,14 +641,25 @@ preflight_docker() { preflight_container_runtime "$@"; }
 #
 #   Unset (default, e.g. `hal0 doctor` / preflight_all) — soft: warn +
 #     return 1 so a read-only report finishes without mutating the system.
+#
+# Codex review (#1727): `command -v git` only proves a `git` file resolves
+# on PATH, not that it runs — a non-executable file (permissions drift, a
+# half-finished package install) still resolves via `command -v` and would
+# have reported success right up until pip's own `git clone` failed with
+# the original error. `git --version` is the actual functional probe: it
+# both resolves the binary AND proves the OS will exec it.
+_git_usable() {
+    git --version >/dev/null 2>&1
+}
+
 preflight_git() {
-    if command -v git >/dev/null 2>&1; then
+    if _git_usable; then
         info "git: $(git --version 2>/dev/null | head -n1 || echo present)"
         return 0
     fi
 
     if [[ "${HAL0_GIT_REQUIRED:-0}" != "1" ]]; then
-        warn "git not found — Hermes agent provisioning (pip install git+...) will fail until it's installed"
+        warn "git not found or not runnable — Hermes agent provisioning (pip install git+...) will fail until it's installed"
         return 1
     fi
 
@@ -665,7 +676,7 @@ preflight_git() {
             apk) apk add git || ok=0 ;;
             *) ok=0 ;;
         esac
-        if [[ "${ok}" -eq 1 ]] && command -v git >/dev/null 2>&1; then
+        if [[ "${ok}" -eq 1 ]] && _git_usable; then
             info "git: $(git --version 2>/dev/null | head -n1 || echo present)"
             return 0
         fi

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -28,6 +28,14 @@
 #                                flag so a fresh box never finishes with every
 #                                slot dead ("no container runtime found").
 #                                `preflight_docker` is a back-compat alias.
+#   preflight_git              — git on PATH (needed for Hermes agent
+#                                provisioning's `pip install git+...`). Soft
+#                                by default (warns + returns 1). Set
+#                                HAL0_GIT_REQUIRED=1 to auto-install it via
+#                                the detected package manager, hard-failing
+#                                with the exact one-liner if that's not
+#                                possible; install.sh sets the flag right
+#                                before the Hermes provisioning step (#1726).
 #   preflight_gpu              — GPU/NPU device nodes visible + group wiring
 #                                sane. Soft by default (always returns 0;
 #                                CPU-only is a valid install) but prints the
@@ -87,6 +95,11 @@
 #                        manager) and hard-fails (returns non-zero) when it
 #                        can't. Default empty → soft mode for `hal0 doctor`.
 #                        Legacy HAL0_DOCKER_REQUIRED is still honoured.
+#   HAL0_GIT_REQUIRED  — when "1", preflight_git auto-installs git (via the
+#                        detected package manager) and returns non-zero when
+#                        it can't. Default empty → soft mode for `hal0
+#                        doctor` (warn + return 1). install.sh sets the flag
+#                        immediately before Hermes provisioning (#1726).
 #   HAL0_GPU_GATE      — when "1", preflight_gpu returns a classification code
 #                        (see HAL0_GPU_RC_*) instead of always 0, so install.sh
 #                        can smart-block a broken LXC passthrough. Default 0 →
@@ -608,6 +621,67 @@ preflight_container_runtime() {
 
 # Back-compat alias: older docs / `hal0 doctor` builds call preflight_docker.
 preflight_docker() { preflight_container_runtime "$@"; }
+
+# git — Hermes agent provisioning runs `pip install
+# git+https://github.com/NousResearch/hermes-agent.git@<rev>`, which pip
+# implements by shelling out to `git clone`. A stock minimal distro image
+# (fresh Ubuntu 24.04 LXC/cloud template, no git preinstalled) doesn't ship
+# it, so that pip install dies with "ERROR: Cannot find command 'git'" deep
+# inside the Hermes toolchain step (#1726) unless something checks for it
+# first. Two modes, mirroring preflight_container_runtime/preflight_venv:
+#
+#   HAL0_GIT_REQUIRED=1 (install.sh sets this immediately before the Hermes
+#     provisioning step) — auto-install git via the detected package
+#     manager; return non-zero with the exact remediation one-liner if that
+#     doesn't resolve it. The caller decides what to do with a failure here
+#     (install.sh treats it the same as any other Hermes provisioning
+#     failure — non-fatal to the overall install, per #1584's established
+#     graceful-degradation pattern — but the message is specific to git
+#     instead of being buried in pip's clone-failure noise).
+#
+#   Unset (default, e.g. `hal0 doctor` / preflight_all) — soft: warn +
+#     return 1 so a read-only report finishes without mutating the system.
+preflight_git() {
+    if command -v git >/dev/null 2>&1; then
+        info "git: $(git --version 2>/dev/null | head -n1 || echo present)"
+        return 0
+    fi
+
+    if [[ "${HAL0_GIT_REQUIRED:-0}" != "1" ]]; then
+        warn "git not found — Hermes agent provisioning (pip install git+...) will fail until it's installed"
+        return 1
+    fi
+
+    local pm
+    if pm="$(pkg_mgr)"; then
+        info "installing git (required for Hermes agent provisioning)"
+        local ok=1
+        case "${pm}" in
+            apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -q git || ok=0 ;;
+            dnf) dnf install -y git || ok=0 ;;
+            yum) yum install -y git || ok=0 ;;
+            zypper) zypper install -y git || ok=0 ;;
+            pacman) pacman -S --noconfirm git || ok=0 ;;
+            apk) apk add git || ok=0 ;;
+            *) ok=0 ;;
+        esac
+        if [[ "${ok}" -eq 1 ]] && command -v git >/dev/null 2>&1; then
+            info "git: $(git --version 2>/dev/null | head -n1 || echo present)"
+            return 0
+        fi
+        err "git install failed — see output above"
+        return 1
+    fi
+
+    err "git not found and no recognised package manager"
+    local git_install
+    if git_install="$(pkg_install_cmd git)"; then
+        warn "  install with: ${git_install}"
+    else
+        warn "  install git via your distro's package manager then re-run install.sh"
+    fi
+    return 1
+}
 
 # Extract the leading major-version integer from a version string, e.g.
 # "podman version 6.0.0" / "netavark 2.1.0" / "6.0.0" → "6". Echoes nothing
@@ -1222,6 +1296,7 @@ preflight_all() {
     preflight_writable || rc=$?
     preflight_network || rc=$?
     preflight_container_runtime || rc=$?
+    preflight_git     || rc=$?
     preflight_podman_network_backend || rc=$?
     preflight_podman_forward || rc=$?
     preflight_gpu     || rc=$?

--- a/tests/installer/test_hermes_prereqs_git.py
+++ b/tests/installer/test_hermes_prereqs_git.py
@@ -1,0 +1,181 @@
+"""git coverage in installer/agents/hermes-prereqs.sh — #1726 / #1727 review.
+
+Codex review on PR #1727 flagged that the original fix only gated
+``installer/install.sh``'s INLINE Hermes provisioning call
+(``"${HAL0_BIN}" agent install hermes``) on a git preflight — the
+STANDALONE/deferred path (an operator running ``hal0 agent install
+hermes`` manually, e.g. after ``HAL0_SKIP_HERMES=1``, or per the
+remediation hint printed on a failed inline provision) goes through
+``hal0.cli.agent_commands._install_hermes`` →
+``installer/agents/hermes-prereqs.sh`` directly and never touched
+install.sh's gate. That path stayed exposed to the original bug: a
+git-less box would still hit pip's "Cannot find command 'git'" untouched.
+
+``hermes-prereqs.sh`` is the SHARED choke point for both entry points
+(install.sh shells out to the exact same ``hal0 agent install hermes``
+CLI command, which runs this same script) — this fix adds git to its
+existing toolchain probe/install/verify pipeline (mirroring how it
+already handles python3-venv/pip/pipx), which covers both call sites at
+once.
+
+These tests exercise the real script end-to-end via subprocess (same
+technique as ``tests/installer/test_bootstrap_prereq_parity.py``), with a
+minimal fake toolchain (python3.12 + pipx already "present") so only the
+git-specific behavior is under test, plus static-text assertions proving
+git is wired into every distro family's package list and the
+functional (not just presence) verification.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREREQS = _REPO_ROOT / "installer" / "agents" / "hermes-prereqs.sh"
+
+
+def _write_exe(path: Path, body: str) -> None:
+    path.unlink(missing_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+_FAKE_PYTHON312 = """#!/usr/bin/env bash
+if [[ "$1" == "-c" ]]; then
+    exit 0
+fi
+if [[ "$1" == "-m" && "$2" == "pip" ]]; then
+    echo "pip 24.0"
+    exit 0
+fi
+exit 0
+"""
+
+_FAKE_PIPX = "#!/usr/bin/env bash\nexit 0\n"
+
+_FAKE_GIT_WORKING = "#!/usr/bin/env bash\necho 'git version 2.43.0'\nexit 0\n"
+
+
+@pytest.fixture
+def base_bin_dir(tmp_path: Path) -> Path:
+    """Real bash + a fake, always-satisfied python3.12/pipx toolchain — only
+    git varies per test."""
+    d = tmp_path / "bin"
+    d.mkdir()
+    for tool in ("bash", "dirname", "cat", "uname", "id", "chmod"):
+        found = shutil.which(tool)
+        if found:
+            os.symlink(found, d / tool)
+    _write_exe(d / "python3.12", _FAKE_PYTHON312)
+    _write_exe(d / "pipx", _FAKE_PIPX)
+    # Tests run as a non-root user, so hermes-prereqs.sh's `id -u` check
+    # keeps the `sudo ` prefix pkg_install_cmd emits — a passthrough fake
+    # sudo keeps the install commands runnable without real privileges.
+    _write_exe(d / "sudo", "#!/usr/bin/env bash\nexec \"$@\"\n")
+    return d
+
+
+def _run_prereqs(bin_dir: Path) -> subprocess.CompletedProcess:
+    env = {"PATH": str(bin_dir)}
+    return subprocess.run(
+        ["bash", str(_PREREQS)], env=env, capture_output=True, text=True, check=False
+    )
+
+
+class TestGitAlreadyPresent:
+    def test_toolchain_complete_with_git_skips_install(self, base_bin_dir: Path) -> None:
+        _write_exe(base_bin_dir / "git", _FAKE_GIT_WORKING)
+        proc = _run_prereqs(base_bin_dir)
+        assert proc.returncode == 0, proc.stderr
+        assert "toolchain already present" in proc.stdout
+        assert "git" in proc.stdout
+        # No apt-get should have been invoked — everything was already there.
+        assert not (base_bin_dir / "apt-get.called").exists()
+
+
+class TestGitMissingTriggersInstall:
+    def test_missing_git_installs_it_via_apt_get(self, base_bin_dir: Path) -> None:
+        marker = base_bin_dir / "apt-get.called"
+        apt_get_body = f"""#!/usr/bin/env bash
+echo "$@" >> {marker}
+if [[ "$*" == *git* ]]; then
+    cat > {base_bin_dir / "git"} <<'GITEOF'
+{_FAKE_GIT_WORKING}
+GITEOF
+    chmod +x {base_bin_dir / "git"}
+fi
+exit 0
+"""
+        _write_exe(base_bin_dir / "apt-get", apt_get_body)
+        proc = _run_prereqs(base_bin_dir)
+        assert proc.returncode == 0, proc.stderr
+        assert marker.exists(), "apt-get was never invoked for the missing-git case"
+        assert "git" in marker.read_text()
+        assert "toolchain ready" in proc.stdout
+
+    def test_apt_get_succeeds_but_git_still_unusable_is_fatal(self, base_bin_dir: Path) -> None:
+        # apt-get "succeeds" (exit 0) but never actually drops a working git
+        # (stale/offline apt cache, package missing from the mirror) — the
+        # post-install verification must catch this and die, not report
+        # "toolchain ready" only for the very next `pip install git+...` to
+        # fail with the original opaque error.
+        _write_exe(base_bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+        proc = _run_prereqs(base_bin_dir)
+        assert proc.returncode != 0
+        out = proc.stdout + proc.stderr
+        assert "git" in out.lower()
+        assert "still missing or not runnable" in out
+
+    def test_non_executable_git_on_path_is_not_trusted(self, base_bin_dir: Path) -> None:
+        # A `git` file that resolves on PATH but can't actually run (matches
+        # the Codex "command -v doesn't prove it executes" finding) must be
+        # treated the same as git being fully absent.
+        bogus = base_bin_dir / "git"
+        bogus.write_text("not a real executable\n", encoding="utf-8")
+        bogus.chmod(0o644)  # deliberately non-executable
+        _write_exe(base_bin_dir / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+        proc = _run_prereqs(base_bin_dir)
+        assert proc.returncode != 0
+        assert "still missing or not runnable" in (proc.stdout + proc.stderr)
+
+
+class TestStaticWiring:
+    """Every distro family's package list must include git, and the
+    functional (not just presence) predicate must be in place."""
+
+    _TEXT = _PREREQS.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "family_line",
+        [
+            "debian) pkgs=(python3 python3-venv python3-pip pipx git) ;;",
+            "fedora) pkgs=(python3 python3-pip pipx git) ;;",
+            "arch) pkgs=(python python-pip python-pipx git) ;;",
+            "suse) pkgs=(python3 python3-pip python3-pipx git) ;;",
+            "alpine) pkgs=(python3 py3-pip pipx git) ;;",
+        ],
+    )
+    def test_family_package_list_includes_git(self, family_line: str) -> None:
+        assert family_line in self._TEXT
+
+    def test_have_git_uses_functional_probe_not_command_dash_v(self) -> None:
+        assert "have_git() { git --version >/dev/null 2>&1; }" in self._TEXT
+
+    def test_already_complete_gate_requires_git(self) -> None:
+        assert "have_venv && have_pip && have_pipx && have_git" in self._TEXT
+
+    def test_post_install_verification_dies_on_missing_git(self) -> None:
+        assert 'have_git || die "git still missing or not runnable' in self._TEXT
+
+
+def test_bash_syntax_check() -> None:
+    proc = subprocess.run(
+        ["bash", "-n", str(_PREREQS)], capture_output=True, text=True, check=False
+    )
+    assert proc.returncode == 0, f"{_PREREQS}: {proc.stderr}"

--- a/tests/installer/test_hermes_prereqs_git.py
+++ b/tests/installer/test_hermes_prereqs_git.py
@@ -77,7 +77,7 @@ def base_bin_dir(tmp_path: Path) -> Path:
     # Tests run as a non-root user, so hermes-prereqs.sh's `id -u` check
     # keeps the `sudo ` prefix pkg_install_cmd emits — a passthrough fake
     # sudo keeps the install commands runnable without real privileges.
-    _write_exe(d / "sudo", "#!/usr/bin/env bash\nexec \"$@\"\n")
+    _write_exe(d / "sudo", '#!/usr/bin/env bash\nexec "$@"\n')
     return d
 
 

--- a/tests/installer/test_preflight_git.py
+++ b/tests/installer/test_preflight_git.py
@@ -1,0 +1,245 @@
+"""git preflight for Hermes provisioning — #1726.
+
+``hal0 agent install hermes`` pip-installs hermes-agent straight from a git
+URL (``pip install git+https://github.com/NousResearch/hermes-agent.git@...``),
+which pip implements by shelling out to ``git clone``. Before this fix,
+nothing in installer/install.sh checked that ``git`` was on PATH before
+that step ran, so a stock minimal distro image without it (a fresh
+Ubuntu 24.04 LXC/cloud template — no git preinstalled) sailed through
+every earlier preflight check, printed "=== hal0 is ready ===", and only
+surfaced the failure later via ``hal0 doctor all`` ("WARN Hermes systemd
+unit inactive or absent").
+
+``preflight_git`` (added to installer/lib/preflight.sh) closes that gap,
+mirroring ``preflight_container_runtime``'s two-mode shape:
+
+  * soft (default, ``hal0 doctor``) — warn + return 1 when git is missing,
+    never mutates the system.
+  * required (``HAL0_GIT_REQUIRED=1``, set by install.sh immediately
+    before the Hermes provisioning step) — auto-install git via the
+    detected package manager; hard-fail (return 1) with a remediation
+    one-liner if that doesn't resolve it.
+
+These tests exercise the shell function directly (subprocess, real bash —
+the same technique ``tests/installer/test_preflight_python_floor.py`` and
+``tests/installer/test_bootstrap_prereq_parity.py`` use) against a
+restricted PATH, plus static-text assertions proving install.sh's Hermes
+provisioning block gates on ``preflight_git`` and that a git-install
+failure degrades gracefully (mirrors the #1584 precedent: it does not
+``die()`` the overall install, it fails only the Hermes step loudly with
+a git-specific remediation line).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+_INSTALL_SH = _REPO_ROOT / "installer" / "install.sh"
+
+_STUBS = (
+    "info() { printf 'INFO: %s\\n' \"$*\"; }\n"
+    "warn() { printf 'WARN: %s\\n' \"$*\"; }\n"
+    "err()  { printf 'ERR: %s\\n' \"$*\" >&2; }\n"
+    'die()  { err "$*"; exit 1; }\n'
+)
+
+
+def _write_exe(path: Path, body: str = "#!/usr/bin/env bash\nexit 0\n") -> None:
+    path.unlink(missing_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+# preflight.sh only sources ui.sh / distro.sh when `info` / `pkg_install_cmd`
+# aren't already defined. Our _STUBS pre-defines info/warn/err/die (so ui.sh
+# is skipped) but deliberately leaves pkg_install_cmd undefined so distro.sh
+# gets sourced for real — preflight_git's pkg_mgr()/pkg_install_cmd() calls
+# need real distro.sh logic (probing the restricted PATH via `command -v`)
+# to meaningfully exercise the apt-get auto-install branch below. That
+# source needs `dirname` on PATH; the apt-get-mock scripts need `cat`.
+_BASE_TOOLS = ("bash", "dirname", "cat")
+
+
+def _seed_base_tools(d: Path) -> None:
+    for tool in _BASE_TOOLS:
+        if (d / tool).exists():
+            continue
+        found = shutil.which(tool)
+        assert found is not None, f"no {tool} on the test runner's PATH"
+        os.symlink(found, d / tool)
+
+
+def _run(script_body: str, bin_dir: Path, extra_env: dict[str, str] | None = None):
+    # subprocess.run(["bash", ...]) resolves "bash" against the PATH we hand
+    # it, not the test runner's own PATH — seed real base tools alongside the
+    # restricted bin dir (same technique as test_preflight_python_floor.py).
+    _seed_base_tools(bin_dir)
+    script = "set -euo pipefail\n" + _STUBS + f"source {_PREFLIGHT!s}\n" + script_body
+    env = {"PATH": str(bin_dir), **(extra_env or {})}
+    return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+
+
+@pytest.fixture
+def bin_dir_without_git(tmp_path: Path) -> Path:
+    """A restricted PATH dir with no git and no recognised package manager."""
+    d = tmp_path / "bin"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def bin_dir_with_git(tmp_path: Path) -> Path:
+    d = tmp_path / "bin"
+    d.mkdir()
+    _write_exe(d / "git", "#!/usr/bin/env bash\necho 'git version 2.43.0'\nexit 0\n")
+    return d
+
+
+class TestPreflightGitSoftMode:
+    """Default mode (HAL0_GIT_REQUIRED unset) — used by `hal0 doctor` /
+    preflight_all. Never mutates the system."""
+
+    def test_git_present_passes(self, bin_dir_with_git: Path) -> None:
+        proc = _run("preflight_git; exit $?\n", bin_dir_with_git)
+        assert proc.returncode == 0, proc.stderr
+        assert "git" in proc.stdout.lower()
+
+    def test_git_absent_warns_and_returns_nonzero(self, bin_dir_without_git: Path) -> None:
+        proc = _run("rc=0; preflight_git || rc=$?; exit $rc\n", bin_dir_without_git)
+        assert proc.returncode != 0
+        out = proc.stdout + proc.stderr
+        assert "git not found" in out
+        assert "Hermes" in out
+
+    def test_git_absent_does_not_attempt_install(self, bin_dir_without_git: Path) -> None:
+        # No pkg_mgr candidate (apt-get/dnf/...) exists on the restricted
+        # PATH; soft mode must not even try to call one.
+        proc = _run("rc=0; preflight_git || rc=$?; exit $rc\n", bin_dir_without_git)
+        assert proc.returncode != 0
+        assert "installing git" not in (proc.stdout + proc.stderr)
+
+
+class TestPreflightGitRequiredMode:
+    """HAL0_GIT_REQUIRED=1 — install.sh's mode right before Hermes
+    provisioning. Auto-installs via the detected package manager (mocked
+    apt-get here), hard-fails with a remediation line otherwise."""
+
+    def test_git_already_present_short_circuits(self, bin_dir_with_git: Path) -> None:
+        proc = _run(
+            "preflight_git; exit $?\n", bin_dir_with_git, extra_env={"HAL0_GIT_REQUIRED": "1"}
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert "installing git" not in (proc.stdout + proc.stderr)
+
+    def test_missing_git_triggers_auto_install_via_apt_get(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        # Mock apt-get: records its invocation to a marker file, then drops a
+        # fake `git` onto PATH so the post-install `command -v git` re-check
+        # succeeds — proves preflight_git actually re-verifies after install
+        # rather than trusting the exit code blindly.
+        marker = tmp_path / "apt-get.called"
+        apt_get_body = f"""#!/usr/bin/env bash
+echo "$@" > {marker}
+cat > {d / "git"} <<'GITEOF'
+#!/usr/bin/env bash
+echo 'git version 2.43.0'
+exit 0
+GITEOF
+chmod +x {d / "git"}
+exit 0
+"""
+        _write_exe(d / "apt-get", apt_get_body)
+        proc = _run("preflight_git; exit $?\n", d, extra_env={"HAL0_GIT_REQUIRED": "1"})
+        assert proc.returncode == 0, proc.stderr
+        assert marker.exists(), "apt-get was never invoked — auto-install path not taken"
+        assert "-y" in marker.read_text()
+        assert "git" in marker.read_text()
+
+    def test_apt_get_present_but_install_fails_is_a_hard_failure(self, tmp_path: Path) -> None:
+        d = tmp_path / "bin"
+        d.mkdir()
+        # apt-get "succeeds" (exit 0) but never actually drops a git binary
+        # (e.g. package unavailable in a stale/offline apt cache) — the
+        # post-install re-check must catch this and fail closed, not report
+        # success just because the package-manager invocation didn't error.
+        _write_exe(d / "apt-get", "#!/usr/bin/env bash\nexit 0\n")
+        proc = _run(
+            "rc=0; preflight_git || rc=$?; exit $rc\n", d, extra_env={"HAL0_GIT_REQUIRED": "1"}
+        )
+        assert proc.returncode != 0
+
+    def test_no_package_manager_hard_fails_with_remediation(
+        self, bin_dir_without_git: Path
+    ) -> None:
+        proc = _run(
+            "pkg_mgr() { return 1; }\n"
+            "pkg_install_cmd() { return 1; }\n"
+            "rc=0; preflight_git || rc=$?; exit $rc\n",
+            bin_dir_without_git,
+            extra_env={"HAL0_GIT_REQUIRED": "1"},
+        )
+        assert proc.returncode != 0
+        out = proc.stdout + proc.stderr
+        assert "git" in out.lower()
+
+
+class TestInstallShWiring:
+    """install.sh must gate Hermes provisioning on preflight_git, and a git
+    failure there must degrade gracefully (mirrors #1584's established
+    precedent for Hermes provisioning failures: warn + remediation, not a
+    fatal die() of the whole install)."""
+
+    def test_install_sh_gates_hermes_provisioning_on_preflight_git(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        m = re.search(
+            r"provisioning Hermes agent \(toolchain \+ bootstrap\)",
+            text,
+        )
+        assert m is not None, "Hermes provisioning info line not found in install.sh"
+        # The preflight_git gate must appear in the same Hermes-provisioning
+        # if/elif/else block, immediately ahead of the actual provisioning
+        # call, not merely somewhere else in the file.
+        window_start = max(0, m.start() - 1500)
+        window = text[window_start : m.start()]
+        assert "preflight_git" in window
+        assert "HAL0_GIT_REQUIRED=1" in window
+
+    def test_git_preflight_failure_does_not_die_the_install(self) -> None:
+        text = _INSTALL_SH.read_text(encoding="utf-8")
+        m = re.search(
+            r"elif ! HAL0_GIT_REQUIRED=1 preflight_git; then(.*?)\n        else\n",
+            text,
+            re.DOTALL,
+        )
+        assert m is not None, "preflight_git gate branch not found in install.sh"
+        body = m.group(1)
+        # This branch must warn with a remediation line, not die()/exit the
+        # installer — a git-install failure is a Hermes-provisioning-only
+        # failure, consistent with every other failure mode in this block.
+        assert re.search(r"\bdie\b", body) is None
+        assert "exit" not in body
+        assert "warn" in body
+        assert "git" in body.lower()
+        assert "agent install hermes" in body
+
+    def test_preflight_all_includes_git(self) -> None:
+        text = _PREFLIGHT.read_text(encoding="utf-8")
+        assert re.search(r"preflight_git\s*\|\|\s*rc=\$\?", text)
+
+
+def test_bash_syntax_check() -> None:
+    for path in (_INSTALL_SH, _PREFLIGHT):
+        proc = subprocess.run(
+            ["bash", "-n", str(path)], capture_output=True, text=True, check=False
+        )
+        assert proc.returncode == 0, f"{path}: {proc.stderr}"

--- a/tests/installer/test_preflight_git.py
+++ b/tests/installer/test_preflight_git.py
@@ -66,7 +66,7 @@ def _write_exe(path: Path, body: str = "#!/usr/bin/env bash\nexit 0\n") -> None:
 # need real distro.sh logic (probing the restricted PATH via `command -v`)
 # to meaningfully exercise the apt-get auto-install branch below. That
 # source needs `dirname` on PATH; the apt-get-mock scripts need `cat`.
-_BASE_TOOLS = ("bash", "dirname", "cat")
+_BASE_TOOLS = ("bash", "dirname", "cat", "chmod")
 
 
 def _seed_base_tools(d: Path) -> None:


### PR DESCRIPTION
## Summary
- `hal0 agent install hermes` pip-installs `hermes-agent` from a git URL, which pip implements by shelling out to `git clone` — a stock minimal distro image (fresh Ubuntu 24.04 LXC/cloud template) doesn't ship `git`, and nothing in `install.sh` checked for it before that step ran, so the install died deep inside pip with `ERROR: Cannot find command 'git'` while every earlier preflight check (and the final `=== hal0 is ready ===` box) still passed clean (#1726).
- Add `preflight_git` to `installer/lib/preflight.sh`, mirroring `preflight_container_runtime`'s two-mode shape: soft (default, `hal0 doctor`) warns; `HAL0_GIT_REQUIRED=1` auto-installs git via the detected package manager (`lib/distro.sh`) and hard-fails with a remediation one-liner otherwise. Wired into `preflight_all` for `hal0 doctor` visibility.
- `install.sh` gates the Hermes provisioning step on `preflight_git` (defense in depth, right before the pip install that needs it). Consistent with the #1584 graceful-degradation precedent, a git-install failure does **not** abort the overall install — it fails only the Hermes provisioning step loudly, with a git-specific remediation line, the same way any other Hermes provisioning failure in that block is already handled.

## Test plan
- [x] New `tests/installer/test_preflight_git.py` — soft/required mode behavior, mocked `apt-get` auto-install path, install.sh wiring (gate present, failure doesn't `die()`), `bash -n` syntax check.
- [x] `shellcheck -x installer/install.sh installer/lib/preflight.sh` — same 10 pre-existing warnings as on `main`, none introduced by this change (no `shellcheck` on `$PATH`, so downloaded 0.11.0 stable release binary to verify).
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install tests/installer -x -q` — 493 passed, 1 skipped (pre-existing, unrelated `shellcheck not installed` skip in `test_platform_gate_hardening.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)