### PR TITLE
fix(installer): run apparmor remediation before hard podman preflight gate

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1626,8 +1626,19 @@ fi
 # convergent fix writes `[containers] apparmor_profile="unconfined"` to
 # /etc/containers/containers.conf and retries — detected from the podman SMOKE
 # FAILURE (not OS/LXC sniffing), idempotent, unit-tested against recorded fakes
-# (see src/hal0/agents/containers_apparmor.py). Runs the shared, tested Python
-# module via the FHS venv so bash and Python never diverge.
+# (see src/hal0/agents/containers_apparmor.py).
+#
+# #1563: this used to be the ONLY place this fix ran — long after
+# `preflight_container_runtime` (line ~338, required mode) had already
+# hard-`die()`d on the exact same failure, making this dead code on the
+# platform shape it exists for. `_container_runtime_gate` in
+# installer/lib/preflight.sh now runs the same remediation (as a bare script,
+# since the venv/hal0 package don't exist yet at that earlier point) and
+# retries before failing, so this block is reached only once podman already
+# works. It stays as a defensive, idempotent no-op re-check via the FHS venv
+# — e.g. if `install.sh` is ever invoked with the early gate skipped/patched
+# out, or a future non-install caller reaches this point with a still-broken
+# profile.
 if [[ "${DEV_MODE}" -eq 0 && "${NO_START}" -eq 0 ]] && command -v podman >/dev/null 2>&1 \
     && [[ -x "${VENV_DIR}/bin/python" ]]; then
     if "${VENV_DIR}/bin/python" -m hal0.agents.containers_apparmor; then

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -488,6 +488,50 @@ _container_run_smoke_test() {
     _HAL0_CONTAINER_SMOKE_OUTPUT="$(timeout 30 "${rt}" run --rm "${image}" 2>&1)"
 }
 
+# AppArmor profile-load failure signature (#1563): on a privileged Ubuntu
+# 24.04 LXC whose Proxmox host has `lxc.apparmor.profile: unconfined` set,
+# podman cannot load its default AppArmor profile and `<rt> run` dies with
+# `apparmor_parser: ... Access denied` / "install profile containers-default
+# apparmor: exit status 243". Matched from the smoke failure text itself
+# (never OS/LXC sniffing) so it's never confused with the keyring-quota or
+# generic LXC-nesting failures below.
+_is_apparmor_profile_load_failure() {
+    local blob="$1"
+    printf '%s\n' "${blob}" | grep -qi 'apparmor' || return 1
+    printf '%s\n' "${blob}" \
+        | grep -qiE 'install profile containers-default|apparmor_parser.*access denied|exit status 243'
+}
+
+# Shared AppArmor remediation — invokes the SAME convergent fix
+# install.sh's post-install re-check runs
+# (src/hal0/agents/containers_apparmor.py: detect → write
+# `[containers] apparmor_profile = "unconfined"` → retry, idempotent). Run as
+# a bare script (`"${py}" "<path>/containers_apparmor.py"`), NOT `-m
+# hal0.agents.containers_apparmor` — this point in the installer is BEFORE the
+# venv exists / hal0 is pip-installed, so importing the `hal0.agents` package
+# (heavy transitive deps) would fail; the bare-script form only needs stdlib
+# (the module makes its one third-party import, structlog, optional for
+# exactly this reason).
+#
+# The script's own internal retry smoke uses a `podman run ... true` argv
+# that can false-fail on the distroless `quay.io/podman/hello` image's exec
+# (see `_container_run_smoke_test` above) even once the config fix has
+# landed — so its exit code is informational only; the real verdict is OUR
+# own `_container_run_smoke_test` re-run below.
+_apparmor_unconfined_remediate() {
+    local rt="$1"
+    local script="${REPO_ROOT:-}/src/hal0/agents/containers_apparmor.py"
+    local py="${PY:-python3}"
+    if [[ ! -f "${script}" ]] || ! command -v "${py}" >/dev/null 2>&1; then
+        warn "  can't locate ${script} (or ${py}) to run the apparmor remediation"
+        return 1
+    fi
+    local out
+    out="$("${py}" "${script}" 2>&1)" || true
+    printf '%s\n' "${out}" | sed 's/^/  /'
+    _container_run_smoke_test "${rt}"
+}
+
 # Run the real `<rt> run` smoke test and print an accurate remedy on failure.
 # Only called in REQUIRED mode (install.sh) — `hal0 doctor` stays fast and
 # side-effect-free (no image pull) in the default soft mode.
@@ -501,10 +545,32 @@ _container_run_smoke_test() {
 # misleading there (operator "fixes" a config that was never broken). Detect
 # that signature first and give the real remedy; fall through to the generic
 # LXC hint for every other failure shape so nothing else gets mis-masked.
+#
+# #1563: an AppArmor profile-load failure gets a THIRD branch, ahead of the
+# generic LXC fallback (which otherwise mis-masked it with a misleading
+# nesting/keyctl hint even when those flags were already set) — remediate
+# and re-probe BEFORE giving up, since the fix for this exact signature
+# already exists (containers_apparmor.py) but used to only run long after
+# this gate had already hard-died.
 _container_runtime_gate() {
     local rt="$1"
     if _container_run_smoke_test "${rt}"; then
         return 0
+    fi
+    if _is_apparmor_profile_load_failure "${_HAL0_CONTAINER_SMOKE_OUTPUT}"; then
+        warn "  ${rt} run: ${_HAL0_CONTAINER_SMOKE_OUTPUT}"
+        warn "  AppArmor profile-load failure detected — common on a privileged Ubuntu 24.04 LXC whose Proxmox"
+        warn "  host has 'lxc.apparmor.profile: unconfined' set. Attempting the automated unconfined-profile fix..."
+        if _apparmor_unconfined_remediate "${rt}"; then
+            info "  apparmor remediation applied — ${rt} run now succeeds, continuing install"
+            return 0
+        fi
+        err "${rt} info/version succeeded but '${rt} run' failed — the runtime can't actually launch a container"
+        warn "  automated AppArmor remediation did not resolve it — inspect /etc/containers/containers.conf(.d)"
+        warn "  and confirm 'apparmor_parser' can load policy inside this container. Manual workaround: on the"
+        warn "  PROXMOX HOST, in /etc/pve/lxc/<CTID>.conf set 'lxc.apparmor.profile: unconfined', then:"
+        warn "  pct stop <CTID> && pct start <CTID>, then re-run install.sh"
+        return 1
     fi
     err "${rt} info/version succeeded but '${rt} run' failed — the runtime can't actually launch a container"
     if printf '%s\n' "${_HAL0_CONTAINER_SMOKE_OUTPUT}" \

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -513,19 +513,34 @@ _is_apparmor_profile_load_failure() {
 # (the module makes its one third-party import, structlog, optional for
 # exactly this reason).
 #
-# The script's own internal retry smoke uses a `podman run ... true` argv
-# that can false-fail on the distroless `quay.io/podman/hello` image's exec
-# (see `_container_run_smoke_test` above) even once the config fix has
-# landed — so its exit code is informational only; the real verdict is OUR
-# own `_container_run_smoke_test` re-run below.
+# The script's own internal retry smoke honours HAL0_CONTAINER_SMOKE_IMAGE
+# (same var `_container_run_smoke_test` above honours) so an air-gapped/
+# mirrored-registry install probes with an image it can actually reach
+# instead of a hardcoded quay.io one — otherwise the helper would misclassify
+# an unreachable-image pull failure as "unrelated" and skip the fix even on a
+# genuinely apparmor-broken host. Its exit code is still informational only
+# (belt-and-suspenders against any other detection drift between the two
+# layers); the real verdict is OUR own `_container_run_smoke_test` re-run
+# below, against the exact same configured image.
 _apparmor_unconfined_remediate() {
     local rt="$1"
-    local script="${REPO_ROOT:-}/src/hal0/agents/containers_apparmor.py"
+    # install.sh always sets REPO_ROOT before this runs. The public
+    # `HAL0_CONTAINER_REQUIRED=1 bash installer/lib/preflight.sh` standalone
+    # mode does not — fall back to this file's own location
+    # (installer/lib/preflight.sh → repo root is two dirs up) so that path
+    # can remediate too instead of always reporting the helper missing.
+    local repo_root="${REPO_ROOT:-}"
+    if [[ -z "${repo_root}" ]]; then
+        repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+    fi
+    local script="${repo_root}/src/hal0/agents/containers_apparmor.py"
     local py="${PY:-python3}"
     if [[ ! -f "${script}" ]] || ! command -v "${py}" >/dev/null 2>&1; then
         warn "  can't locate ${script} (or ${py}) to run the apparmor remediation"
         return 1
     fi
+    # HAL0_CONTAINER_SMOKE_IMAGE, if set in the environment, is inherited by
+    # this subprocess automatically — the script reads the same var name.
     local out
     out="$("${py}" "${script}" 2>&1)" || true
     printf '%s\n' "${out}" | sed 's/^/  /'
@@ -566,10 +581,16 @@ _container_runtime_gate() {
             return 0
         fi
         err "${rt} info/version succeeded but '${rt} run' failed — the runtime can't actually launch a container"
-        warn "  automated AppArmor remediation did not resolve it — inspect /etc/containers/containers.conf(.d)"
-        warn "  and confirm 'apparmor_parser' can load policy inside this container. Manual workaround: on the"
-        warn "  PROXMOX HOST, in /etc/pve/lxc/<CTID>.conf set 'lxc.apparmor.profile: unconfined', then:"
-        warn "  pct stop <CTID> && pct start <CTID>, then re-run install.sh"
+        # NOTE: this branch only fires on an LXC that ALREADY has
+        # 'lxc.apparmor.profile: unconfined' on the Proxmox host (that's the
+        # detection signature above) — telling the operator to set it again
+        # would be circular and fix nothing. The remaining knobs are inside
+        # THIS container/guest, not the host.
+        warn "  automated AppArmor remediation (wrote apparmor_profile = \"unconfined\" to"
+        warn "  /etc/containers/containers.conf and retried) did NOT resolve it — inspect that file for a syntax"
+        warn "  error or conflicting override, confirm 'apparmor_parser --version' works inside THIS container"
+        warn "  (a missing/broken apparmor_parser here can't load ANY profile, confined or not), and check"
+        warn "  'podman info --debug' for the runtime's own apparmor_profile setting"
         return 1
     fi
     err "${rt} info/version succeeded but '${rt} run' failed — the runtime can't actually launch a container"

--- a/src/hal0/agents/containers_apparmor.py
+++ b/src/hal0/agents/containers_apparmor.py
@@ -34,6 +34,7 @@ optional below with a stdlib fallback. Everything else is stdlib-only
 from __future__ import annotations
 
 import os
+import re
 import subprocess  # nosec B404 — smoke-tests the local podman
 import tomllib
 from collections.abc import Callable
@@ -63,23 +64,43 @@ except ImportError:  # pragma: no cover - exercised by the early-installer path
 #: Canonical podman config the fix lands in (halo150 R4).
 CONTAINERS_CONF = Path("/etc/containers/containers.conf")
 
-#: A minimal, no-pull smoke: run ``true`` in a scratch container. We don't care
-#: about the image — the apparmor profile load fails BEFORE the image matters —
-#: so the busybox-less ``--rm`` + ``true`` shape keeps it cheap. Overridable.
-_SMOKE_ARGV: tuple[str, ...] = (
-    "podman",
-    "run",
-    "--rm",
-    "quay.io/podman/hello",
-    "true",
-)
+#: Default smoke image. The apparmor profile load fails BEFORE the image is
+#: pulled/run, so any image would do for detection — but on an air-gapped or
+#: mirrored-registry host (installer/lib/preflight.sh's
+#: HAL0_CONTAINER_SMOKE_IMAGE override) quay.io itself may be unreachable, in
+#: which case a hardcoded quay.io image here would fail the PULL, get
+#: misclassified as "unrelated", and skip the fix even on a genuinely
+#: apparmor-broken host. `_default_smoke_argv()` below honours the same
+#: HAL0_CONTAINER_SMOKE_IMAGE env var so the CLI entry (`_main`) always probes
+#: with whatever image the rest of the installer is actually configured to
+#: use. No trailing command override (e.g. `true`) — the default entrypoint
+#: matches installer/lib/preflight.sh's own smoke shape and avoids a false
+#: "unrelated" exec-not-found classification on a distroless image once the
+#: real (apparmor) problem is already fixed.
+_DEFAULT_SMOKE_IMAGE = "quay.io/podman/hello"
+_SMOKE_ARGV: tuple[str, ...] = ("podman", "run", "--rm", _DEFAULT_SMOKE_IMAGE)
 
-#: Substrings in podman's stderr that mark the unconfined-LXC apparmor failure.
-#: Matching BOTH the exit-243 code and this signature avoids reacting to an
-#: unrelated podman failure (missing image, no runtime, etc.).
-_APPARMOR_SIGNATURE: tuple[str, ...] = (
-    "apparmor",
+
+def _default_smoke_argv() -> tuple[str, ...]:
+    """Smoke argv for the CLI entry, honouring HAL0_CONTAINER_SMOKE_IMAGE."""
+    image = os.environ.get("HAL0_CONTAINER_SMOKE_IMAGE", _DEFAULT_SMOKE_IMAGE)
+    return ("podman", "run", "--rm", image)
+
+
+#: Substrings that mark the unconfined-LXC AppArmor profile-load failure in
+#: `<rt> run`'s combined output. Requires "apparmor" AND at least one of the
+#: more specific shapes below — mirrors (and must stay in lockstep with)
+#: installer/lib/preflight.sh's `_is_apparmor_profile_load_failure`, which
+#: runs this same classification a layer earlier (before the venv/this module
+#: exist) on the raw shell smoke-test output. Two independent failure text
+#: shapes are both real-world observed: the OCI-runtime wrapper message
+#: ("install profile containers-default apparmor: exit status 243") and the
+#: raw `apparmor_parser` failure ("apparmor_parser: ... Access denied").
+_APPARMOR_REQUIRED_TOKEN = "apparmor"
+_APPARMOR_SIGNATURE_ANY: tuple[str, ...] = (
     "install profile containers-default",
+    "access denied",
+    "exit status 243",
 )
 
 
@@ -116,7 +137,9 @@ def _is_apparmor_failure(proc: subprocess.CompletedProcess[str]) -> bool:
     if proc.returncode == 0:
         return False
     blob = f"{proc.stdout or ''}\n{proc.stderr or ''}".lower()
-    return all(sig in blob for sig in _APPARMOR_SIGNATURE)
+    if _APPARMOR_REQUIRED_TOKEN not in blob:
+        return False
+    return any(sig in blob for sig in _APPARMOR_SIGNATURE_ANY)
 
 
 def _apparmor_already_unconfined(conf_path: Path) -> bool:
@@ -129,6 +152,25 @@ def _apparmor_already_unconfined(conf_path: Path) -> bool:
     if not isinstance(containers, dict):
         return False
     return containers.get("apparmor_profile") == "unconfined"
+
+
+#: Matches a TOML table header, tolerating an inline comment after the
+#: closing bracket (e.g. ``[containers] # operator settings``). A naive
+#: ``stripped.endswith("]")`` check misses that shape entirely, fails to
+#: recognize an existing ``[containers]`` section, and appends a SECOND
+#: ``[containers]`` header below — invalid TOML
+#: (``Cannot declare ('containers',) twice``) that corrupts the host's
+#: podman config.
+_SECTION_HEADER_RE = re.compile(r"^\[([^\[\]]+)\]")
+
+
+def _section_header(line: str) -> str | None:
+    """Return the bracketed table name if ``line`` is a section header."""
+    stripped = line.strip()
+    if not stripped.startswith("["):
+        return None
+    m = _SECTION_HEADER_RE.match(stripped)
+    return m.group(1).strip() if m else None
 
 
 def _write_apparmor_unconfined(conf_path: Path) -> None:
@@ -152,16 +194,17 @@ def _write_apparmor_unconfined(conf_path: Path) -> None:
     inserted = False
     replaced = False
     for raw in existing:
-        stripped = raw.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
+        section = _section_header(raw)
+        if section is not None:
             # Leaving a section: if we were in [containers] and never inserted,
             # add the key just before the next section header.
             if in_containers and not inserted and not replaced:
                 out.append(line)
                 inserted = True
-            in_containers = stripped == "[containers]"
+            in_containers = section == "containers"
             out.append(raw)
             continue
+        stripped = raw.strip()
         if in_containers and stripped.startswith("apparmor_profile"):
             out.append(line)
             replaced = True
@@ -251,10 +294,13 @@ def _main() -> int:
 
     ``HAL0_APPARMOR_CONF`` overrides the target config path — used by tests to
     point this at a throwaway file instead of the real
-    ``/etc/containers/containers.conf``.
+    ``/etc/containers/containers.conf``. ``HAL0_CONTAINER_SMOKE_IMAGE`` (the
+    same var installer/lib/preflight.sh's own smoke test honours) overrides
+    the probe image, so an air-gapped/mirrored-registry install probes with
+    an image it can actually reach instead of a hardcoded quay.io one.
     """
     conf_path = Path(os.environ.get("HAL0_APPARMOR_CONF", str(CONTAINERS_CONF)))
-    result = ensure_podman_apparmor_usable(conf_path=conf_path)
+    result = ensure_podman_apparmor_usable(conf_path=conf_path, smoke_argv=_default_smoke_argv())
     print(f"apparmor-preflight: {result.outcome} wrote={result.wrote_config}")
     if result.detail:
         print(f"apparmor-preflight-detail: {result.detail}")

--- a/src/hal0/agents/containers_apparmor.py
+++ b/src/hal0/agents/containers_apparmor.py
@@ -19,10 +19,21 @@ config written (once) and the smoke retried.
 
 Every subprocess is injected (``run``) so the whole detect→write→retry chain is
 unit-tested against recorded fakes with no real podman or ``/etc`` writes.
+
+#1563: this module is also invoked as a bare script (``python
+containers_apparmor.py``, NOT ``python -m hal0.agents.containers_apparmor``)
+from ``installer/lib/preflight.sh``'s ``_container_runtime_gate`` — the EARLY
+hard podman preflight gate that runs before the venv exists / hal0 is
+pip-installed. Bare-script invocation skips the ``hal0.agents`` package
+``__init__`` (and its heavy transitive deps), but this file is still imported
+directly, so ``structlog`` — the one third-party import here — is made
+optional below with a stdlib fallback. Everything else is stdlib-only
+(``tomllib`` has been stdlib since 3.11; hal0's floor is 3.12).
 """
 
 from __future__ import annotations
 
+import os
 import subprocess  # nosec B404 — smoke-tests the local podman
 import tomllib
 from collections.abc import Callable
@@ -30,9 +41,24 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import structlog
+try:
+    import structlog
 
-log = structlog.get_logger(__name__)
+    log = structlog.get_logger(__name__)
+except ImportError:  # pragma: no cover - exercised by the early-installer path
+    # structlog isn't on the interpreter yet when this runs as a bare script
+    # before `pip install`. Fall back to a tiny stdlib logger with the same
+    # `log.info(event, **kw)` call shape used below.
+    import logging
+
+    class _FallbackLog:
+        _logger = logging.getLogger(__name__)
+
+        def info(self, event: str, **kw: Any) -> None:
+            extra = " ".join(f"{k}={v}" for k, v in kw.items())
+            self._logger.info("%s", f"{event} {extra}".rstrip())
+
+    log = _FallbackLog()  # type: ignore[assignment]
 
 #: Canonical podman config the fix lands in (halo150 R4).
 CONTAINERS_CONF = Path("/etc/containers/containers.conf")
@@ -214,13 +240,21 @@ __all__ = [
 
 
 def _main() -> int:
-    """CLI entry (``python -m hal0.agents.containers_apparmor``) for install.sh.
+    """CLI entry — run both as ``python -m hal0.agents.containers_apparmor``
+    (install.sh's post-install re-check) and as a bare script
+    (``python containers_apparmor.py``, install.sh's early
+    ``_container_runtime_gate`` remediation, #1563).
 
     Runs the convergent preflight and prints ``<outcome> wrote=<bool>``. Exit 0
     unless the retry still failed after writing the fix (``retry_failed`` → 1),
     so the installer can surface a genuine, unresolved apparmor blocker.
+
+    ``HAL0_APPARMOR_CONF`` overrides the target config path — used by tests to
+    point this at a throwaway file instead of the real
+    ``/etc/containers/containers.conf``.
     """
-    result = ensure_podman_apparmor_usable()
+    conf_path = Path(os.environ.get("HAL0_APPARMOR_CONF", str(CONTAINERS_CONF)))
+    result = ensure_podman_apparmor_usable(conf_path=conf_path)
     print(f"apparmor-preflight: {result.outcome} wrote={result.wrote_config}")
     if result.detail:
         print(f"apparmor-preflight-detail: {result.detail}")

--- a/tests/agents/test_containers_apparmor.py
+++ b/tests/agents/test_containers_apparmor.py
@@ -102,3 +102,50 @@ def test_no_podman_reports_cleanly(tmp_path: Path) -> None:
 
     result = ca.ensure_podman_apparmor_usable(run=_run, conf_path=tmp_path / "c.conf")
     assert result.outcome == "no_podman"
+
+
+# ── Codex #1728 P1 follow-ups ────────────────────────────────────────────────
+
+
+def test_apparmor_parser_access_denied_shape_is_also_recognized(tmp_path: Path) -> None:
+    # The raw `apparmor_parser` failure text (no "install profile
+    # containers-default" wrapper) is the OTHER real-world signature shape —
+    # installer/lib/preflight.sh's `_is_apparmor_profile_load_failure`
+    # recognizes it too; this module's own detection must stay in lockstep or
+    # the shell gate remediates while this helper reports "unrelated" and
+    # never writes the fix.
+    conf = tmp_path / "containers.conf"
+    stderr = "apparmor_parser: Warning ... apparmor_parser: profile load failed: Access denied"
+    run, calls = _recorder([_proc(243, stderr), _proc(0)])
+    result = ca.ensure_podman_apparmor_usable(run=run, conf_path=conf)
+    assert result.outcome == "fixed"
+    assert result.wrote_config
+    assert len(calls) == 2
+
+
+def test_default_smoke_argv_honours_smoke_image_env(monkeypatch) -> None:
+    monkeypatch.delenv("HAL0_CONTAINER_SMOKE_IMAGE", raising=False)
+    assert ca._default_smoke_argv() == ("podman", "run", "--rm", "quay.io/podman/hello")
+    monkeypatch.setenv("HAL0_CONTAINER_SMOKE_IMAGE", "registry.local/mirror/hello")
+    assert ca._default_smoke_argv() == ("podman", "run", "--rm", "registry.local/mirror/hello")
+
+
+def test_write_preserves_commented_section_header(tmp_path: Path) -> None:
+    # A header with a trailing inline comment (`[containers] # ...`) used to
+    # fail the naive `stripped.endswith("]")` check, so the writer never
+    # recognized the existing [containers] table and appended a SECOND one —
+    # invalid TOML ("Cannot declare ('containers',) twice").
+    conf = tmp_path / "containers.conf"
+    conf.write_text('[containers] # operator settings\nlog_driver = "journald"\n')
+    ca._write_apparmor_unconfined(conf)
+    text = conf.read_text()
+    assert text.count("[containers]") == 1  # no duplicate table header appended
+    assert "# operator settings" in text
+    assert 'log_driver = "journald"' in text
+    assert 'apparmor_profile = "unconfined"' in text
+    # Must still be valid, single-table TOML.
+    import tomllib
+
+    parsed = tomllib.loads(text)
+    assert parsed["containers"]["apparmor_profile"] == "unconfined"
+    assert parsed["containers"]["log_driver"] == "journald"

--- a/tests/installer/test_preflight_apparmor_gate.py
+++ b/tests/installer/test_preflight_apparmor_gate.py
@@ -54,9 +54,11 @@ def _fake_podman(tmp_path: Path, *, fail_calls: int, fail_stderr: str) -> None:
     sequence.
     """
     counter = tmp_path / "podman-calls"
+    argv_log = tmp_path / "podman-argv.log"
     _write_exec(
         tmp_path / "podman",
         f"""
+echo "$@" >> {argv_log!s}
 if [[ "$1" != "run" ]]; then
     exit 0
 fi
@@ -120,7 +122,24 @@ def test_apparmor_signature_detected_but_remediation_fails_still_hard_dies(
     rc, output = _run_gate(tmp_path, {})
     assert rc != 0, output
     assert "runtime can't actually launch a container" in output
-    assert "automated AppArmor remediation did not resolve it" in output
+    assert "did NOT resolve it" in output
+    # The failed-remediation message must not tell the operator to re-set the
+    # exact host-side flag that's already the documented cause of this branch
+    # (that would be circular and fix nothing).
+    assert "set it in /etc/pve/lxc" not in output
+
+
+def test_apparmor_remediation_resolves_helper_path_without_repo_root(tmp_path: Path) -> None:
+    # `HAL0_CONTAINER_REQUIRED=1 bash installer/lib/preflight.sh` (the
+    # documented standalone mode) never sets REPO_ROOT — install.sh is the
+    # only caller that does. The helper path must still resolve (from
+    # preflight.sh's own location) instead of always reporting itself
+    # missing.
+    _fake_podman(tmp_path, fail_calls=2, fail_stderr=_APPARMOR_STDERR)
+    rc, output = _run_gate(tmp_path, {"REPO_ROOT": ""})
+    assert rc == 0, output
+    assert "can't locate" not in output
+    assert "apparmor remediation applied" in output
 
 
 def test_unrelated_failure_does_not_trigger_apparmor_remediation(tmp_path: Path) -> None:
@@ -129,6 +148,27 @@ def test_unrelated_failure_does_not_trigger_apparmor_remediation(tmp_path: Path)
     assert rc != 0, output
     assert "apparmor" not in output.lower()
     assert not (tmp_path / "containers.conf").exists()
+
+
+def test_remediation_honours_configured_smoke_image(tmp_path: Path) -> None:
+    # HAL0_CONTAINER_SMOKE_IMAGE (air-gapped/mirrored-registry override) must
+    # reach the Python remediation helper's own internal smoke too — if the
+    # helper always probed a hardcoded quay.io image instead, an unreachable
+    # quay.io on this host would make it misclassify the pull failure as
+    # "unrelated" and skip the fix even though the outer gate already proved
+    # this is a genuine apparmor failure. The fake podman shim here doesn't
+    # care which image string it's called with; assert on the recorded argv
+    # log instead to prove the override actually reached the Python helper's
+    # own internal smoke, not just the outer bash smoke.
+    mirror_image = "registry.internal.example/mirror/hello"
+    _fake_podman(tmp_path, fail_calls=2, fail_stderr=_APPARMOR_STDERR)
+    rc, output = _run_gate(tmp_path, {"HAL0_CONTAINER_SMOKE_IMAGE": mirror_image})
+    assert rc == 0, output
+    assert "apparmor remediation applied" in output
+    assert (tmp_path / "containers.conf").exists()
+    argv_log = (tmp_path / "podman-argv.log").read_text()
+    assert mirror_image in argv_log
+    assert "quay.io/podman/hello" not in argv_log
 
 
 @pytest.mark.parametrize(

--- a/tests/installer/test_preflight_apparmor_gate.py
+++ b/tests/installer/test_preflight_apparmor_gate.py
@@ -1,0 +1,157 @@
+"""Contract tests for the AppArmor-remediation path in ``_container_runtime_gate``
+(#1563).
+
+``preflight_container_runtime``'s REQUIRED-mode gate used to hard-``die()``
+whenever ``<rt> run`` failed, before the automated AppArmor remediation
+(``src/hal0/agents/containers_apparmor.py``, wired in only at install.sh's
+late "AppArmor preflight" block) ever ran — making that fix dead code on the
+exact platform shape (a privileged Ubuntu 24.04 LXC with
+``lxc.apparmor.profile: unconfined`` on the Proxmox host) it exists for.
+
+``_container_runtime_gate`` now detects the AppArmor profile-load failure
+signature from the smoke-test output and runs the SAME remediation script
+(as a bare script, not ``-m hal0.agents.containers_apparmor``, since the
+venv/hal0 package don't exist yet at this point in the installer) before
+falling back to the hard failure. These tests drive it through a fake
+``podman`` shim on PATH (no real container runtime / AppArmor state
+required) covering:
+
+* apparmor-failure-signature detected → remediation invoked → retry
+  succeeds → gate returns 0 (install continues)
+* apparmor remediation fails (retry never succeeds) → gate still returns
+  non-zero (hard die path preserved)
+* an unrelated `<rt> run` failure never triggers remediation (existing
+  keyring/LXC branches stay untouched)
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+
+_APPARMOR_STDERR = (
+    "Error: default OCI runtime spec: install profile containers-default apparmor: exit status 243"
+)
+
+
+def _write_exec(path: Path, body: str) -> None:
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _fake_podman(tmp_path: Path, *, fail_calls: int, fail_stderr: str) -> None:
+    """A ``podman`` shim: fails (with ``fail_stderr``) for the first
+    ``fail_calls`` invocations of ``run``, then succeeds forever after.
+    Call count is tracked in a state file so both the outer bash smoke test
+    and the Python remediation script's own internal smoke share one
+    sequence.
+    """
+    counter = tmp_path / "podman-calls"
+    _write_exec(
+        tmp_path / "podman",
+        f"""
+if [[ "$1" != "run" ]]; then
+    exit 0
+fi
+n=0
+[[ -f {counter!s} ]] && n=$(cat {counter!s})
+n=$((n + 1))
+echo "$n" > {counter!s}
+if [[ "$n" -le {fail_calls} ]]; then
+    echo {fail_stderr!r} >&2
+    exit 243
+fi
+exit 0
+""",
+    )
+
+
+def _run_gate(tmp_path: Path, env_overrides: dict[str, str]) -> tuple[int, str]:
+    script = (
+        "set -uo pipefail\n"
+        f"source {_PREFLIGHT!s}\n"
+        "rc=0\n"
+        "_container_runtime_gate podman || rc=$?\n"
+        "exit $rc\n"
+    )
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}:{os.environ.get('PATH', '')}",
+        "REPO_ROOT": str(_REPO_ROOT),
+        "PY": os.environ.get("HAL0_PYTHON", "python3"),
+        "HAL0_APPARMOR_CONF": str(tmp_path / "containers.conf"),
+        **env_overrides,
+    }
+    proc = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True, cwd=str(tmp_path)
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_apparmor_signature_remediated_and_retry_succeeds(tmp_path: Path) -> None:
+    # First outer smoke fails w/ the apparmor signature; the remediation
+    # script's own internal smoke also still fails once (nothing written
+    # yet), then its post-write retry succeeds, then our own re-verify
+    # smoke succeeds too — 3 total apparmor-signature failures modelled.
+    _fake_podman(tmp_path, fail_calls=2, fail_stderr=_APPARMOR_STDERR)
+    rc, output = _run_gate(tmp_path, {})
+    assert rc == 0, output
+    assert "apparmor remediation applied" in output
+    conf = tmp_path / "containers.conf"
+    assert conf.exists()
+    assert 'apparmor_profile = "unconfined"' in conf.read_text()
+
+
+def test_apparmor_signature_detected_but_remediation_fails_still_hard_dies(
+    tmp_path: Path,
+) -> None:
+    # podman never recovers (e.g. a genuinely broken AppArmor policy) — the
+    # remediation script writes the config but the retry keeps failing, and
+    # our own re-verify keeps failing too. The gate must still return
+    # non-zero (hard-die path preserved upstream in install.sh).
+    _fake_podman(tmp_path, fail_calls=10_000, fail_stderr=_APPARMOR_STDERR)
+    rc, output = _run_gate(tmp_path, {})
+    assert rc != 0, output
+    assert "runtime can't actually launch a container" in output
+    assert "automated AppArmor remediation did not resolve it" in output
+
+
+def test_unrelated_failure_does_not_trigger_apparmor_remediation(tmp_path: Path) -> None:
+    _fake_podman(tmp_path, fail_calls=10_000, fail_stderr="Error: unable to pull image: not found")
+    rc, output = _run_gate(tmp_path, {})
+    assert rc != 0, output
+    assert "apparmor" not in output.lower()
+    assert not (tmp_path / "containers.conf").exists()
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        "Error: default OCI runtime spec: install profile containers-default apparmor: exit status 243",
+        "apparmor_parser: Warning ... apparmor_parser: profile load failed: Access denied",
+        "some wrapper text ... apparmor ... exit status 243 ... more text",
+    ],
+)
+def test_signature_matcher_recognizes_known_shapes(blob: str) -> None:
+    script = (
+        f"set -uo pipefail\nsource {_PREFLIGHT!s}\n_is_apparmor_profile_load_failure {blob!r}\n"
+    )
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_signature_matcher_rejects_unrelated_output() -> None:
+    script = (
+        "set -uo pipefail\n"
+        f"source {_PREFLIGHT!s}\n"
+        "_is_apparmor_profile_load_failure 'Error: unable to pull image: not found'\n"
+    )
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert proc.returncode != 0


### PR DESCRIPTION
## Summary

- `installer/lib/preflight.sh`'s `_container_runtime_gate` (called from `preflight_container_runtime` in `HAL0_CONTAINER_REQUIRED=1` mode, ~line 338 of `install.sh`) hard-died on any `podman run` failure before the automated AppArmor remediation (`src/hal0/agents/containers_apparmor.py`) ever ran. That fix was wired in only at `install.sh`'s late "AppArmor preflight" block (~line 1622) — dead code on the exact platform (privileged Ubuntu 24.04 LXC, `lxc.apparmor.profile: unconfined` on the Proxmox host) it exists to fix.
- `_container_runtime_gate` now recognizes the AppArmor profile-load failure signature (`apparmor_parser: ... Access denied` / `install profile containers-default apparmor: exit status 243`) ahead of the existing keyring-quota and generic-LXC branches, and — before hard-failing — runs the same remediation script and re-probes `podman run`. Genuinely unresolved cases (remediation fails, or the signature doesn't match) still hard-die via the existing `die()` message.
- The remediation script is invoked as a bare script (not `-m hal0.agents.containers_apparmor`) since the venv/hal0 package don't exist yet this early in the installer; `structlog` — its one third-party import — is now optional with a stdlib fallback so this works pre-pip-install. Added `HAL0_APPARMOR_CONF` env override for test isolation.
- The late `install.sh` block (~1622) is kept as a defensive, idempotent no-op re-check via the FHS venv rather than removed — harmless once the early gate has already fixed things.

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install tests/installer tests/agents/test_containers_apparmor.py -q` — 496 passed, 1 pre-existing skip (shellcheck not on PATH in this env)
- [x] New `tests/installer/test_preflight_apparmor_gate.py`: apparmor-signature detected → remediation invoked → retry succeeds → gate proceeds; remediation fails → hard die preserved; unrelated failure never triggers apparmor path; signature matcher unit tests
- [x] `shellcheck installer/install.sh installer/lib/preflight.sh` (binary found at `/tmp/shellcheck-stable/shellcheck`) — clean, only pre-existing unrelated warnings
- [x] `bash -n` on both scripts
- [x] `ruff check` / `ruff format --check` on touched Python files

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)