### PR TITLE
fix(ui): align default-slot rows and stop truncating settings descriptions

### DIFF
--- a/ui/src/dash/settings/pages/models/LoadedModelsPage.jsx
+++ b/ui/src/dash/settings/pages/models/LoadedModelsPage.jsx
@@ -148,8 +148,13 @@ export function LoadedModelsPage() {
           </div>
           {types.map(type => {
             const cur = (byType[type].find(s => s.isDefault) || {}).name || "";
+            // Plain `.s-row` — `form-row` (the drawer/modal grid) used to ride
+            // along, but it is declared after `.s-row` in dashboard.css and
+            // carries `padding: 12px 0`, so it stripped the panel's 18px
+            // horizontal padding and pulled the modality labels out of line
+            // with every other row. `.default-slot-row` is a test hook only.
             return (
-              <div className="default-slot-row form-row s-row" key={type}>
+              <div className="default-slot-row s-row" key={type}>
                 <div className="k"><span>{type}</span></div>
                 <div className="v">
                   <select

--- a/ui/src/dash/settings/shared/SchemaRow.jsx
+++ b/ui/src/dash/settings/shared/SchemaRow.jsx
@@ -89,10 +89,13 @@ export const _advInputStyle = {
 // validator also accepts "cognee"/"mem0", which the factory silently maps to
 // hindsight — offering them would lie, so the page passes its own allowlist).
 // `descriptions` lets a page override a stale/missing schema description.
+// The description goes to SRow whole — the info popup wraps and caps its own
+// width, so truncating here only ever dropped the tail of a deliberate
+// multi-sentence warning (e.g. slots.publish_host's "only widen this on a
+// trusted network"). An empty description now yields no info icon at all.
 export function AdvRow({ dotKey, field, live, buf, onChange, registry, label: labelOverride, options: optionsOverride, description: descriptionOverride }) {
   const label = labelOverride || dotKey.split(".").slice(1).join(".");
   const desc = descriptionOverride || field?.description || "";
-  const shortDesc = desc.length > 150 ? desc.slice(0, 147) + "…" : desc;
   const options = optionsOverride || field?.enum || null;
   const isBool = field?.type === "boolean";
   const isNum = field?.type === "integer" || field?.type === "number";
@@ -136,7 +139,7 @@ export function AdvRow({ dotKey, field, live, buf, onChange, registry, label: la
   return (
     <SRow
       k={label}
-      sub={<span title={desc}>{shortDesc}</span>}
+      sub={desc}
       v={control}
       actions={<ApplyBadge settingsKey={dotKey} registry={registry} />}
     />

--- a/ui/tests/e2e/specs/settings-default-slots-v3.spec.ts
+++ b/ui/tests/e2e/specs/settings-default-slots-v3.spec.ts
@@ -31,3 +31,34 @@ test('Default slots pane sets the chosen slot default and clears the prior one',
   await expect.poll(() => puts.primary.length).toBeGreaterThan(0)
   expect(puts.primary[0].default).toBe(false)
 })
+
+// The modality rows carried `form-row` alongside `s-row`; `.form-row` is
+// declared later in dashboard.css with `padding: 12px 0`, so it stripped the
+// panel's 18px horizontal padding and left "llm" hanging outside the panel
+// while every sibling row stayed indented.
+test('modality rows share the panel indent with the other settings rows', async ({ page }) => {
+  await seedSlots(page, [A, B])
+  await page.goto('/#settings/slots')
+  const modality = page.locator('.default-slot-row .k').first()
+  await expect(modality).toBeVisible()
+
+  const header = await page.locator('.s-panel .s-row .k', { hasText: 'Default slots' }).first().boundingBox()
+  const row = await modality.boundingBox()
+  expect(Math.round(row!.x)).toBe(Math.round(header!.x))
+})
+
+// AdvRow used to slice descriptions at 150 chars, which silently dropped the
+// tail of deliberately long copy — slots.publish_host loses its "only widen
+// this on a trusted network" warning. The popup wraps and caps its own width,
+// so there is nothing for the truncation to protect.
+test('settings info popups carry the whole description, untruncated', async ({ page }) => {
+  await seedSlots(page, [A, B])
+  await page.goto('/#settings/slots')
+  const row = page.locator('.s-row', { has: page.locator('.k > span', { hasText: 'publish_host' }) })
+  await row.locator('.field-info-btn').hover()
+
+  const pop = page.locator('.field-info-pop[data-open="1"]')
+  await expect(pop).toBeVisible()
+  await expect(pop).toContainText('only widen this on a trusted network')
+  await expect(pop).not.toContainText('…')
+})


### PR DESCRIPTION
## What

Two defects on **Settings ▸ Loaded Models**.

**1. Modality rows hung outside the panel.** The Default-slots rows carried `form-row` alongside `s-row`. `.form-row` is declared *after* `.s-row` in `dashboard.css` and sets `padding: 12px 0`, so it won the cascade and stripped the panel's 18px horizontal padding. `llm` and its siblings sat flush against the panel edge while every other row stayed indented.

**2. Settings descriptions were cut at 150 characters.** `AdvRow` sliced `desc` before handing it to the info popup and kept the full text only in a native `title`. That silently dropped the tail of deliberately long copy — the `slots.publish_host` override lost its *"only widen this on a trusted network"* warning. The popup already wraps and caps its own width (`width: max-content; max-width: min(280px, 100vw - 16px)`), so the truncation protected nothing.

Side effect of dropping the `<span title>` wrapper: an empty description now renders **no** info icon, where before it rendered an icon over an empty popup.

## Why this branch is named `fix-narrow-popups`

The originally-reported symptom — one-word-per-line info popups — was already fixed on `main` by #1638 + #1709. Measuring every popup on live rc.3 (CT105 and CT150) confirmed correct sizing across settings (10 popups), the slot edit drawer (13), and the model drawer (17): all content-sized, 104–280px, none min-content squeezed. The reported screenshot matched the pre-#1638 CSS (`position: absolute; left: 22px`), i.e. a stale bundle in a long-open tab. No code change was needed for it.

## Verification

- `tsc --noEmit` clean, `eslint` clean on both touched files
- `vitest run` — 110 passed
- `playwright test settings-default-slots-v3 settings-v3 settings-hash-routing-v3` — 16 passed
- Two new assertions in `settings-default-slots-v3.spec.ts`, each **confirmed to fail against the pre-fix source** (stashed the two source files, both new tests went red, restored)
- Measured after the fix: left edges `Default slots` = `llm` = `max_slots` = 507px; `publish_host` popup 381 chars, no ellipsis, ending on "Applies on the next slot restart."

## Out of scope

Left the popup `max-width` at 280px rather than widening it — the untruncated `publish_host` description now renders at 280×146, which reads fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)