### PR TITLE
fix(installer): apply model-layout migration as install's final model step

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2671,6 +2671,29 @@ fi
 
 ui_step "Service start"
 
+# P4-model-layout backstop: the v0.1→v0.2 model-layout migration
+# (src/hal0/cli/migrate_commands.py) reads registry.toml + the on-disk
+# store and plants the canonical <recipe>/<capability>/ symlink farm under
+# /var/lib/hal0/models. Nothing upstream of this point ever calls it, so a
+# fresh install that just pulled the brain/agent chat model (registry pass,
+# #1615) and/or ComfyUI checkpoints (on-disk pass, "comfyui" v0.1.x dir)
+# ends up with those links outstanding — `hal0 doctor migrations` then
+# opens day one with a spurious "N link(s) pending" warning on a box that
+# has never run anything but this installer. Applying here, before the
+# P3-perms fix below, means any symlinks it plants get swept into that
+# recursive re-chown instead of sitting root-owned under the hal0-owned
+# models/ tree. Idempotent (a no-op on re-run) and non-destructive: it only
+# ever creates symlinks or reports a conflict, never overwrites one it
+# doesn't own (no --force) — a genuine conflict just resurfaces via
+# `hal0 doctor migrations` after install instead of aborting it.
+if [[ "${DEV_MODE}" -eq 0 ]]; then
+    if "${HAL0_BIN}" migrate model-layout --apply >/dev/null 2>&1; then
+        info "model-layout migration applied — canonical symlink tree is current"
+    else
+        warn "'${HAL0_BIN} migrate model-layout --apply' reported issues — run 'hal0 doctor migrations' after install"
+    fi
+fi
+
 # P3-perms migration backstop: hal0-api ships User=hal0 (above), so /etc/hal0
 # + /var/lib/hal0 must already be hal0-owned (2775/setgid) BEFORE the unit's
 # first start, or the daemon can't read/write its own config on boot. The


### PR DESCRIPTION
## Summary
- A pristine box came up with `hal0 doctor all` warning `Migrations — model-layout migration pending: 2 link(s)` because nothing in the installer ever called `hal0 migrate model-layout --apply`. The brain/agent chat model pull (registry-driven pass) and the ComfyUI checkpoint pull (on-disk `comfyui` pass) both leave symlinks outstanding until that command runs.
- Runs `hal0 migrate model-layout --apply` (best-effort, non-fatal) at the start of the "Service start" step, right before the existing `doctor perms --fix --force` call — so any symlinks it plants get swept into that step's recursive re-chown of `/var/lib/hal0` instead of sitting root-owned.
- No new install step / UI_STEP_TOTAL change: folded into the existing "Service start" step.

## Test plan
- [x] `bash -n installer/install.sh`
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install tests/installer -x -q` — 515 passed, 1 skipped (shellcheck not installed locally)
- [x] Verified `grep -c '^ui_step '` still matches `UI_STEP_TOTAL=16`

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)