### PR TITLE
fix(installer): wait on the dpkg/apt lock instead of dying on it

### DIFF
--- a/installer/agents/hermes-prereqs.sh
+++ b/installer/agents/hermes-prereqs.sh
@@ -121,11 +121,14 @@ if [ "$(id -u)" -eq 0 ]; then
 fi
 
 # Debian needs an index refresh before a first install on a fresh image.
+# -o DPkg::Lock::Timeout=120: this script runs well after boot, so
+# unattended-upgrades commonly still holds the dpkg/apt-get lock (#1584) —
+# poll for it instead of dying on the first hit.
 if [ "${family}" = "debian" ]; then
     if [ "$(id -u)" -eq 0 ]; then
-        apt-get update -qq || warn "apt-get update failed — install may still succeed from cache"
+        apt-get -o DPkg::Lock::Timeout=120 update -qq || warn "apt-get update failed — install may still succeed from cache"
     else
-        sudo apt-get update -qq || warn "apt-get update failed — install may still succeed from cache"
+        sudo apt-get -o DPkg::Lock::Timeout=120 update -qq || warn "apt-get update failed — install may still succeed from cache"
     fi
 fi
 

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2082,8 +2082,14 @@ elif ! command -v apt-get >/dev/null 2>&1; then
     warn "  GPU (Vulkan/ROCm) + CPU paths work normally; NPU/FLM slots stay disabled until you install"
     warn "  FastFlowLM ${FLM_DEB_VERSION} manually (see installer/README.md). 'flm validate' gates the NPU trio."
 else
+    # -o DPkg::Lock::Timeout=120 on every apt-get call in this step (and the
+    # hermes-prereqs.sh toolchain install later): this step and hermes
+    # provisioning both run well after boot, when unattended-upgrades
+    # commonly still holds the dpkg/apt-get lock (#1584) — poll for it up to
+    # 2 minutes instead of dying on the first hit like the earlier
+    # preflight apt phase, which wins the race by running right at start.
     ui_spinner_run "apt-get update (refresh package index)" \
-        apt-get update -qq
+        apt-get -o DPkg::Lock::Timeout=120 update -qq
 
     # FLM host-support gate. Upstream now ships a per-distro .deb (ubuntu24.04 /
     # ubuntu25.10 / ubuntu26.04 / debian13), each pinned against that release's
@@ -2112,9 +2118,9 @@ else
     if [[ "$(distro_id)" == "ubuntu" ]] \
         && ! apt-cache policy libxrt-npu2 2>/dev/null | grep -q lemonade-team; then
         if command -v add-apt-repository >/dev/null 2>&1 \
-            || apt-get install -y software-properties-common >/dev/null 2>&1; then
+            || apt-get -o DPkg::Lock::Timeout=120 install -y software-properties-common >/dev/null 2>&1; then
             if add-apt-repository -y ppa:lemonade-team/stable >/dev/null 2>&1; then
-                apt-get update -qq >/dev/null 2>&1 || true
+                apt-get -o DPkg::Lock::Timeout=120 update -qq >/dev/null 2>&1 || true
                 info "added lemonade-team PPA (libxrt-npu2 / AMDXDNA NPU runtime)"
             else
                 warn "could not add lemonade-team PPA — host NPU libs (libxrt-npu2) may be unavailable"
@@ -2126,7 +2132,7 @@ else
     # (or a pre-existing vendor repo on upgraded boxes). The FLM container image
     # bundles its own runtime, so a miss here only disables the HOST `flm
     # validate` probe, not the npu slot itself.
-    if apt-get install -y libxrt-npu2 >/dev/null 2>&1; then
+    if apt-get -o DPkg::Lock::Timeout=120 install -y libxrt-npu2 >/dev/null 2>&1; then
         info "libxrt-npu2 installed (AMDXDNA NPU runtime for the host flm probe)"
     else
         warn "libxrt-npu2 not available from configured apt sources — host 'flm validate' may fail"
@@ -2189,7 +2195,7 @@ else
         # `apt-get install -y /path/to.deb` pulls transitive deps from
         # apt (cleaner than `dpkg -i` + manual `apt-get -f install`).
         if ui_spinner_run "Installing FastFlowLM ${FLM_DEB_VERSION}" \
-            apt-get install -y "${FLM_DEB_TMP}"; then
+            apt-get -o DPkg::Lock::Timeout=120 install -y "${FLM_DEB_TMP}"; then
             rm -f "${FLM_DEB_TMP}"
             # Smoke-test the binary. `flm validate` returns 0 when the
             # NPU runtime is reachable AND the binary is wired up — it's

--- a/installer/lib/distro.sh
+++ b/installer/lib/distro.sh
@@ -94,7 +94,15 @@ pkg_install_cmd() {
     local pm
     pm="$(pkg_mgr)" || return 1
     case "${pm}" in
-        apt-get) printf 'sudo apt-get install -y %s\n' "$*" ;;
+        # -o DPkg::Lock::Timeout=120: unattended-upgrades runs on every fresh
+        # Ubuntu boot and commonly still holds the dpkg/apt-get lock when a
+        # post-phase installer step (hermes provisioning, NPU prereqs) wins
+        # the race against it (#1584). apt >= 1.9.11 (every supported target)
+        # honours this by polling for the lock instead of failing immediately.
+        # Placed before `install` so the emitted string still ENDS with the
+        # package list (tests/installer/test_distro.sh's "ends with package"
+        # invariant).
+        apt-get) printf 'sudo apt-get -o DPkg::Lock::Timeout=120 install -y %s\n' "$*" ;;
         dnf) printf 'sudo dnf install -y %s\n' "$*" ;;
         yum) printf 'sudo yum install -y %s\n' "$*" ;;
         zypper) printf 'sudo zypper install -y %s\n' "$*" ;;


### PR DESCRIPTION
## Summary
- `unattended-upgrades` runs on every fresh Ubuntu boot; an installer apt-get call that happens more than a few minutes after boot (hermes-prereqs.sh's toolchain install, the NPU prereqs step's PPA/libxrt-npu2/FastFlowLM .deb installs) commonly loses the dpkg/apt-get lock race and dies with a hard error instead of the graceful "degrade + remediation" fallback that already existed.
- Adds `-o DPkg::Lock::Timeout=120` (apt >= 1.9.11, present on every supported target) to:
  - `pkg_install_cmd`'s apt-get branch in `installer/lib/distro.sh` (covers hermes-prereqs.sh's `eval "${cmd}"` toolchain install, and every remediation hint that reuses the same helper)
  - hermes-prereqs.sh's two `apt-get update` calls
  - every apt-get call in install.sh's "NPU prerequisites" step (index refresh, PPA add, `software-properties-common`, `libxrt-npu2`, the FastFlowLM `.deb`)
- The flag is inserted before `install`/`update` (not appended) so the emitted command still *ends* with the package list — keeps `tests/installer/test_distro.sh`'s "ends with package" invariant intact.

## Test plan
- [x] `bash -n installer/install.sh installer/agents/hermes-prereqs.sh installer/lib/distro.sh`
- [x] `bash tests/installer/test_distro.sh` — PASS
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install tests/installer -x -q` — 515 passed, 1 skipped (shellcheck not installed locally)

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)