### PR TITLE
fix(doctor): warn when api.env's HAL0_UI_DIST diverges from current

### DIFF
--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -9,9 +9,10 @@ command, with ``--json`` for machine consumers.
 It re-uses the tested :class:`hal0.cli.doctor_verify.Check` row type and the
 verify report-card classifiers (API, runners, DNS, capabilities, memory,
 OpenWebUI, Hermes), then adds the broader health rows the retrofit calls for:
-auth posture, model-store integrity, pending migrations, bound slot ports,
-the ``hal0.target`` boot-enable anchor (r5-sync-assessment §6.1), and the
-privileged sudo seams every slot op + self-update runs through (#1465).
+auth posture, model-store integrity, pending migrations, a stale-dashboard
+``HAL0_UI_DIST`` override (#1589), bound slot ports, the ``hal0.target``
+boot-enable anchor (r5-sync-assessment §6.1), and the privileged sudo seams
+every slot op + self-update runs through (#1465).
 
 Strictly read-only — there is no ``--fix`` here; the per-surface subcommands
 own repair. Exit codes:
@@ -224,6 +225,87 @@ def check_migrations(pending: tuple[int, int] | None) -> Check:
         "Migrations",
         _WARN,
         f"model-layout migration pending: {detail} — run `hal0 migrate model-layout --apply`",
+    )
+
+
+def _read_env_value(
+    env_path: Path, key: str, *, read_text: Callable[[Path], str] | None = None
+) -> str | None:
+    """Best-effort ``KEY=value`` read from an ``EnvironmentFile``-style file.
+
+    Mirrors the line convention :mod:`hal0.api._env_store` writes (a plain
+    or double-quoted ``KEY=value``, one per line — see ``_line_targets_key``).
+    A commented-out line (``# KEY=value``) does not count as set. Returns
+    ``None`` when the file, or the key inside it, is absent — never raises.
+    """
+    _read = read_text if read_text is not None else (lambda p: p.read_text(encoding="utf-8"))
+    try:
+        text = _read(env_path)
+    except OSError:
+        return None
+    prefix = f"{key}="
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            value = stripped[len(prefix) :]
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+            return value
+    return None
+
+
+def check_ui_dist(
+    *, api_env_path: Path | None = None, current_ui_dist: Path | None = None
+) -> Check:
+    """Compare the effective dashboard bundle against the current release.
+
+    ``HAL0_UI_DIST`` in ``api.env`` is installer-owned wiring, not operator
+    config — on an FHS box its only correct value is ``<current>/ui/dist``
+    (see :func:`hal0.config.paths.usr_lib`). The installer only *writes* that
+    line when ``api.env`` doesn't exist yet (fresh install); on every
+    subsequent run it preserves whatever sits outside the marker-delimited
+    network block, by design, so an operator edit elsewhere in the file
+    survives. That same preservation means a box that ever had
+    ``HAL0_UI_DIST`` pointed at an older layout (e.g. a pre-FHS git-deploy
+    tree) silently stops receiving UI updates on every future upgrade: the
+    updater stages a fresh bundle under the new release, and the dashboard
+    keeps serving the stale one against the new API (#1589).
+
+    No override at all is the common, healthy case (the FastAPI mount falls
+    through to ``<current>/ui/dist`` on its own — see
+    ``hal0.api._mount_dashboard``) and passes silently.
+    """
+    api_env_path = api_env_path if api_env_path is not None else paths.api_env()
+    expected = current_ui_dist if current_ui_dist is not None else (paths.usr_lib() / "ui" / "dist")
+
+    override = _read_env_value(api_env_path, "HAL0_UI_DIST")
+    if not override:
+        return Check(
+            "ui-dist",
+            "Dashboard bundle",
+            _PASS,
+            "no HAL0_UI_DIST override in api.env — tracks the current release bundle",
+        )
+
+    override_path = Path(override)
+    try:
+        matches = override_path.resolve() == expected.resolve()
+    except OSError:
+        matches = override_path == expected
+    if matches:
+        return Check(
+            "ui-dist",
+            "Dashboard bundle",
+            _PASS,
+            f"HAL0_UI_DIST={override} matches the current release bundle",
+        )
+    return Check(
+        "ui-dist",
+        "Dashboard bundle",
+        _WARN,
+        f"HAL0_UI_DIST={override} in api.env does not resolve inside {expected} (the current "
+        "release bundle) — the dashboard may be serving a stale UI against the new API. Remove "
+        f"the override (or point it at {expected}) in api.env, then restart hal0-api.",
     )
 
 
@@ -647,6 +729,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_auth_posture(auth_payload),
         check_model_store(_get_any("/api/models", base)),
         check_migrations(pending_layout_migration()),
+        check_ui_dist(),
         check_ports(_get_any("/api/slots", base, timeout=SLOTS_PROBE_TIMEOUT_S)),
         check_hal0_target(),
         check_secret_file_modes(),
@@ -745,6 +828,7 @@ __all__ = [
     "check_model_store",
     "check_ports",
     "check_seams",
+    "check_ui_dist",
     "doctor_all_cmd",
     "overall_verdict",
     "probe_builtin_mcp_mounts",

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -85,6 +85,63 @@ def test_migrations_pending_warns() -> None:
     assert "5 link" in c.detail
 
 
+# ── check_ui_dist ──────────────────────────────────────────────────────────────
+
+
+def test_ui_dist_no_api_env_passes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    c = da.check_ui_dist(
+        api_env_path=tmp_path / "missing.env", current_ui_dist=tmp_path / "current/ui/dist"
+    )
+    assert c.status == "pass" and c.key == "ui-dist"
+    assert "no HAL0_UI_DIST override" in c.detail
+
+
+def test_ui_dist_no_override_line_passes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = tmp_path / "api.env"
+    env.write_text("HAL0_PORT=8080\nHAL0_LOG_LEVEL=info\n")
+    c = da.check_ui_dist(api_env_path=env, current_ui_dist=tmp_path / "current/ui/dist")
+    assert c.status == "pass"
+
+
+def test_ui_dist_matches_current_passes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    current = tmp_path / "current" / "ui" / "dist"
+    current.mkdir(parents=True)
+    env = tmp_path / "api.env"
+    env.write_text(f"HAL0_UI_DIST={current}\n")
+    c = da.check_ui_dist(api_env_path=env, current_ui_dist=current)
+    assert c.status == "pass"
+    assert "matches the current release bundle" in c.detail
+
+
+def test_ui_dist_stale_override_warns(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    stale = tmp_path / "old-layout" / "ui" / "dist"
+    stale.mkdir(parents=True)
+    current = tmp_path / "current" / "ui" / "dist"
+    current.mkdir(parents=True)
+    env = tmp_path / "api.env"
+    env.write_text(f"HAL0_UI_DIST={stale}\n")
+    c = da.check_ui_dist(api_env_path=env, current_ui_dist=current)
+    assert c.status == "warn"
+    assert str(stale) in c.detail
+    assert "restart hal0-api" in c.detail
+
+
+def test_ui_dist_commented_out_line_does_not_count(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = tmp_path / "api.env"
+    env.write_text('# HAL0_UI_DIST="/old/ui/dist"\n')
+    c = da.check_ui_dist(api_env_path=env, current_ui_dist=tmp_path / "current/ui/dist")
+    assert c.status == "pass"
+
+
+def test_ui_dist_quoted_value_is_unquoted(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    current = tmp_path / "current" / "ui" / "dist"
+    current.mkdir(parents=True)
+    env = tmp_path / "api.env"
+    env.write_text(f'HAL0_UI_DIST="{current}"\n')
+    c = da.check_ui_dist(api_env_path=env, current_ui_dist=current)
+    assert c.status == "pass"
+
+
 # ── check_ports ───────────────────────────────────────────────────────────────
 
 
@@ -473,6 +530,11 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(da, "_get_any", _fake_get)
     monkeypatch.setattr("hal0.cli.doctor_commands.pending_layout_migration", lambda: (0, 0))
+    # ui-dist (#1589) reads real api.env otherwise; neutralise it so this
+    # composition test asserts the row list, not the host's api.env content.
+    monkeypatch.setattr(
+        da, "check_ui_dist", lambda: Check("ui-dist", "Dashboard bundle", "pass", "stubbed")
+    )
     # model file existence + hal0.target unit file: pretend present so
     # neither spuriously fails.
     monkeypatch.setattr(da.Path, "exists", lambda self: True)
@@ -504,11 +566,12 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 11 extras.
-    assert keys[-11:] == [
+    # 7 verify rows + 12 extras.
+    assert keys[-12:] == [
         "auth",
         "models",
         "migrations",
+        "ui-dist",
         "ports",
         "hal0_target",
         "secret-modes",


### PR DESCRIPTION
## Summary
- `HAL0_UI_DIST` in `/etc/hal0/api.env` is installer-owned wiring, not operator config — its only correct value on an FHS box is `<current>/ui/dist`. The installer writes it once, on first `api.env` creation, then preserves whatever sits outside the marker-delimited network block on every later run (by design — operator edits elsewhere must survive). A box that ever had `HAL0_UI_DIST` pointed at an older layout (pre-FHS git-deploy tree, per the lxc105 incident in #1589) silently stops receiving UI updates on every future upgrade: new API, stale dashboard.
- Adds a `hal0 doctor all` row (`check_ui_dist`, key `ui-dist`) that reads the effective `HAL0_UI_DIST` from `api.env` and warns with a remediation line when it doesn't resolve to `<current>/ui/dist`. No override at all — the common, healthy case — passes silently.
- Scoped to the doctor-row option the issue names as sufficient on its own ("A `hal0 doctor` row comparing the served asset ... would also have caught this class directly"); left the updater/installer write-path untouched to keep this PR focused and low-risk.

## Test plan
- [x] New unit tests for `check_ui_dist` (no api.env, no override line, matching override, stale override, commented-out line, quoted value)
- [x] Updated `test_build_all_checks_composes_verify_plus_extras` for the new row (7 verify + 12 extras)
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/cli -x -q` — 677 passed

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)