### PR TITLE
fix(models): backfill context window from curated catalogue on launch

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1216,6 +1216,19 @@ def _native_ctx(model_info: dict[str, Any]) -> int | None:
     Read straight off the GGUF arch max at import time — still a MODEL fact, but
     a derived one, so it only applies when nobody made an explicit choice, and it
     is dense-capped by the caller.
+
+    Falls back to the curated catalogue's ``context_length`` (#1617) when the
+    registry row itself carries no metadata at all. ``registry.pull._register``
+    only started stamping ``metadata.context_length`` on a completed pull as of
+    #1657/#1707 — a row created before that fix landed (e.g. the seeded brain
+    model on a box provisioned with an older build, or any curated pick that
+    predates the stamp) has an empty ``metadata`` dict forever, since nothing
+    re-runs detection on already-downloaded bytes. Without this, such a row
+    falls all the way through to :data:`_CTX_SAFE_FALLBACK` (8192) regardless
+    of how new the code is — the fix only helps FUTURE pulls, not boxes that
+    already have the file. Consulting the catalogue here means the resolver
+    self-heals on every launch, fresh install or upgrade alike, with no
+    migration step required.
     """
     md = model_info.get("metadata")
     if isinstance(md, dict) and md.get("context_length"):
@@ -1223,6 +1236,16 @@ def _native_ctx(model_info: dict[str, Any]) -> int | None:
             return int(md["context_length"])
         except (TypeError, ValueError):
             pass
+    model_id = model_info.get("_model_key")
+    if model_id:
+        try:
+            from hal0.registry.curated import get_curated
+
+            curated = get_curated(str(model_id))
+        except Exception:  # curated lookup must never break a launch
+            curated = None
+        if curated is not None and curated.context_length:
+            return int(curated.context_length)
     return None
 
 

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1327,6 +1327,40 @@ class TestContextSizeOwnership:
         mi = _model_info(defaults={"context_size": ok})
         assert _resolve_context_size(None, mi) == ok
 
+    # ── #1617: a stale/upgraded registry row must not stick at 8192 ─────────
+    #
+    # A row created before registry/pull.py started stamping
+    # ``metadata.context_length`` (#1657/#1707) has empty metadata FOREVER —
+    # nothing re-runs GGUF detection on bytes already on disk. The seeded
+    # brain model is the box-breaking case: its system prompt alone is
+    # ~14k tokens, so an 8192 fallback fails every hal0-brain turn AND every
+    # Hindsight extraction retain out of the box.
+
+    def test_curated_model_with_no_registry_metadata_does_not_fall_to_safe_floor(self) -> None:
+        """A curated id (the seeded brain model) with an empty ``metadata``
+        dict — the exact shape of a pre-#1657 registry row on an upgraded or
+        pre-fix-built box — must resolve from the curated catalogue's
+        ``context_length`` instead of the bare 8192 safe fallback."""
+        mi = _model_info(_model_key="hal0-brain-sft-q8-rocmfpx", metadata={})
+        assert _resolve_context_size(None, mi) != _CTX_SAFE_FALLBACK
+        assert _resolve_context_size(None, mi) == _CTX_DENSE_CAP
+
+    def test_curated_backfill_is_dense_capped_like_any_native_window(self) -> None:
+        """The curated catalogue's raw 131072 for the brain model must still
+        go through the same dense cap as a GGUF-detected native window — this
+        is a derived fact, not an operator's explicit choice, so an
+        unconfigured slot can't request an impractical KV cache."""
+        mi = _model_info(_model_key="hal0-brain-sft-q8-rocmfpx")
+        mi.pop("metadata", None)
+        assert _resolve_context_size(None, mi) == _CTX_DENSE_CAP
+
+    def test_unknown_model_with_no_metadata_still_falls_to_safe_floor(self) -> None:
+        """Non-curated ids have nothing to backfill from — the safe floor is
+        still correct there. Pins the existing behaviour so the curated
+        backfill doesn't quietly widen to every model."""
+        mi = _model_info(_model_key="some-operator-pulled-custom-model", metadata={})
+        assert _resolve_context_size(None, mi) == _CTX_SAFE_FALLBACK
+
     def test_bad_model_ctx_reaches_the_launch_command_as_the_fallback(self) -> None:
         """End-to-end through `container_spec`: the emitted `--ctx-size` is a
         usable number, not `-1`."""


### PR DESCRIPTION
## Summary

Closes #1617. On a fresh install (or, worse, an already-provisioned box), the
seeded `hal0-brain-sft-*` model resolves to the `_resolve_context_size` 8192
safe fallback, so the steward's ~14k-token system prompt fails every chat turn
and every Hindsight extraction retain out of the box. Reproduced live twice on
CT151 (`exceed_context_size_error`, n_ctx 8192 vs a 13.9k-token prompt).

`registry/pull.py` already stamps `metadata.context_length` from the curated
catalogue on a completed pull (#1657/#1707) — but that only helps **future**
pulls. Nothing re-runs GGUF detection on bytes already on disk, so a box
provisioned before that fix landed (or any curated pick pulled before then)
has an empty `metadata` dict forever, and the launch resolver falls all the
way to 8192 regardless of how new the code is.

## Fix

`providers.container._native_ctx` now falls back to the curated catalogue's
`context_length` (looked up by the registry model id, `model_info["_model_key"]`)
when the registry row itself carries no `metadata.context_length`. This runs
on every launch, not at pull/write time, so it self-heals fresh installs AND
already-provisioned/upgraded boxes with no migration step needed. The
backfilled value goes through the same `_CTX_DENSE_CAP` (32768) as any other
derived native window — a justified, RAM-conscious default that comfortably
covers the brain's ~14k-token prompt without requesting the model's full
131072 KV cache on an unconfigured slot. A non-curated model with no metadata
still falls through to the 8192 floor exactly as before (pinned by a new
test) — this only backfills for catalogue entries that HAVE a known window.

## Test plan

- [x] Red-first: new tests in `tests/providers/test_container.py::TestContextSizeOwnership`
      fail against the pre-fix resolver (8192 for the brain model with empty
      metadata) and pass after.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers/test_container.py -q` — 125 passed
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/registry tests/slots tests/api tests/providers -q` — 3305 passed, 1 skipped
- [x] Live-inspected CT151 (read-only, no changes made): it is currently in a pristine, not-yet-installed state (no hal0 install present), so a live before/after repro on that box wasn't possible this session — the traced code path (`registry/pull.py` → `providers.container._resolve_context_size`/`_native_ctx`) matches the issue's diagnosis and the operator's own live remediation (`PUT .../hal0-brain-sft-q8-rocmfpx {"defaults":{"context_size":32768}}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)