### PR TITLE
fix(profiles): reject malformed shell quoting at save time

### DIFF
--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -36,7 +36,7 @@ from hal0.config.schema import (
     ProfileConfig,
     resolve_profile_flags,
 )
-from hal0.errors import Conflict, NotFound
+from hal0.errors import Conflict, NotFound, UnprocessableEntity
 
 log = logging.getLogger(__name__)
 
@@ -392,13 +392,29 @@ def screen_profile_flags(flags: str | None, *, grandfathered: str | None = None)
     the §5 hardware set ONLY: #1404's load-path sanitizer already strips the
     §21.7 managed args from stored profiles, so a managed flag can never be
     inherited in the first place.
+
+    ``flags`` itself must be valid shell text (#1730). #1639 added a
+    launch-time guard (``providers.container``, ``slot.profile_flags_malformed``)
+    so a divergent profile with unmatched quoting no longer 500s the
+    launch/preview path — but that only covers a profile that ALREADY made it
+    onto disk. This screen is the actual write seam (routes/import/CLI all
+    funnel through it), and until now it silently returned on a
+    ``shlex.split`` failure instead of rejecting it, so bad quoting sailed
+    straight through to persistence — the root cause #1639 patched around
+    rather than fixed. Reject it here instead, with the same error family the
+    launch-time guard uses, so the operator sees the problem at save time
+    instead of the next launch.
     """
     if not flags or not flags.strip():
         return
     try:
         tokens = shlex.split(flags)
-    except ValueError:
-        return  # schema/parser owns malformed quoting diagnostics
+    except ValueError as exc:
+        raise UnprocessableEntity(
+            f"profile flags are not valid shell text: {exc}",
+            code="profiles.flags_malformed",
+            details={"flags": flags},
+        ) from exc
     from hal0.slots.argv import (
         SLOT_HARDWARE_FLAGS,
         _canon,

--- a/tests/api/test_profiles_crud.py
+++ b/tests/api/test_profiles_crud.py
@@ -142,6 +142,42 @@ def test_update_profile_rejects_slot_hardware_flag(client: TestClient) -> None:
     assert r.json()["error"]["code"] == "slot.hardware_flag_denied"
 
 
+# ── #1730: malformed shell quoting must be rejected at save time ───────────
+
+
+def test_create_profile_rejects_unmatched_quoting(client: TestClient) -> None:
+    """#1639 added a launch-time guard for a divergent profile with unmatched
+    quotes (slot.profile_flags_malformed) so it no longer 500s the
+    launch/preview path — but a profile could still be SAVED with bad
+    quoting in the first place, since screen_profile_flags silently returned
+    on a shlex.split failure instead of rejecting it. The create hard-rejects
+    with a 422 and persists nothing."""
+    r = client.post(
+        "/api/profiles",
+        json={"name": "bad-quotes", "flags": '-fa on "unterminated'},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "profiles.flags_malformed"
+    listed = client.get("/api/profiles").json()
+    assert not any(p["name"] == "bad-quotes" for p in listed)
+
+
+def test_update_profile_rejects_unmatched_quoting(client: TestClient) -> None:
+    """PUT screens the same shlex.split validation — a clean profile edited to
+    carry unmatched quotes is rejected and the prior flags survive."""
+    created = client.post(
+        "/api/profiles",
+        json={"name": "edit-quotes", "flags": "-fa on"},
+    )
+    assert created.status_code == 201, created.text
+    r = client.put("/api/profiles/edit-quotes", json={"flags": "-b 2048 'unterminated"})
+    assert r.status_code == 422, r.text
+    assert r.json()["error"]["code"] == "profiles.flags_malformed"
+    listed = client.get("/api/profiles").json()
+    edited = next(p for p in listed if p["name"] == "edit-quotes")
+    assert edited["flags"] == "-fa on"
+
+
 def test_create_profile_rejects_managed_flag(client: TestClient) -> None:
     """§21.7: -c/--ctx-size (like --port/--model/--host/--alias) is hal0-managed
     — a profile that persists it only explodes later when stamped onto a model.

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from hal0.config.schema import MTP_FLAG_BUNDLE, ProfileConfig
-from hal0.errors import Conflict
+from hal0.errors import Conflict, UnprocessableEntity
 from hal0.profiles import ProfileCatalog, ProfilePatch
 
 
@@ -59,6 +59,36 @@ def test_create_update_delete_profile(tmp_hal0_home: str) -> None:
 
     catalog.delete("my-rocm")
     assert all(profile.name != "my-rocm" for profile in catalog.list())
+
+
+# ── #1730: malformed shell quoting must never reach disk ─────────────────
+#
+# #1639 added a launch-time guard (providers.container, code
+# slot.profile_flags_malformed) so a divergent profile with unmatched quotes
+# no longer 500s the launch/preview path — but that only fires for a profile
+# that ALREADY made it onto disk. The actual write seam
+# (screen_profile_flags, called by both ProfileCatalog.create/update and the
+# API routes) used to swallow the shlex.split ValueError and return, letting
+# bad quoting sail straight through to persistence.
+
+
+def test_create_rejects_unmatched_quoting(tmp_hal0_home: str) -> None:
+    catalog = ProfileCatalog()
+    with pytest.raises(UnprocessableEntity) as exc_info:
+        catalog.create("bad-quotes", ProfileConfig(flags='-fa on "unterminated'))
+    assert exc_info.value.code == "profiles.flags_malformed"
+    # Never persisted — a re-list must not show the rejected profile.
+    assert all(profile.name != "bad-quotes" for profile in catalog.list())
+
+
+def test_update_rejects_unmatched_quoting(tmp_hal0_home: str) -> None:
+    catalog = ProfileCatalog()
+    catalog.create("good-profile", ProfileConfig(flags="-fa on"))
+    with pytest.raises(UnprocessableEntity) as exc_info:
+        catalog.update("good-profile", ProfilePatch(flags="-fa on 'unterminated"))
+    assert exc_info.value.code == "profiles.flags_malformed"
+    # The prior valid flags must survive an update rejected on save.
+    assert catalog.resolve("good-profile").flags == "-fa on"
 
 
 def test_delete_profile_in_use_raises_conflict(tmp_hal0_home: str) -> None:


### PR DESCRIPTION
## Summary

Closes #1730. Follow-up from Codex review on #1639
(https://github.com/Hal0ai/hal0/pull/1639#discussion_r3743223255).

`screen_profile_flags` — the actual write seam POST/PUT `/api/profiles`,
`ProfileCatalog.create`/`update`, and the import/CLI paths all funnel
through — silently returned when `shlex.split` raised on the incoming
`flags` text, instead of rejecting it. `ProfileConfig.flags` itself has no
quoting validator either. So a profile with unmatched shell quoting could
still be saved via the API (or land via a hand-edited TOML), and only blew
up later at launch/preview time, where #1639 added a guard
(`slot.profile_flags_malformed`) specifically to turn that into a
controlled `UnprocessableEntity` instead of an unhandled 500.

## Fix

`screen_profile_flags` now raises `UnprocessableEntity` (422,
`profiles.flags_malformed`) when `shlex.split(flags)` fails, so both
`POST /api/profiles` and `PUT /api/profiles/{name}` reject bad quoting
before it's persisted — same validation, same error family the
launch-time guard already uses.

The TOML load path (`config/loader._sanitize_custom_profile_flags`) is
deliberately left alone: it already treats a `shlex.split` failure as
"leave for the write-path screens" so an existing malformed row (pre-guard
profile, hand edit) doesn't brick config load. Only the write boundary
hard-rejects new bad quoting — consistent with how the existing
hardware-flag/managed-flag screens handle pre-existing vs. newly-introduced
violations (grandfathering).

## Test plan

- [x] Red-first: 4 new tests (2 in `tests/profiles/test_catalog.py`, 2 in
      `tests/api/test_profiles_crud.py`) fail against the pre-fix
      `screen_profile_flags` and pass after.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/profiles/test_catalog.py tests/api/test_profiles_crud.py tests/config/test_profiles.py -q` — 106 passed
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/registry tests/slots tests/api tests/providers -q` — 3304 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)