### PR TITLE
fix(perms): never dereference symlinks when applying the ownership table

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2685,10 +2685,14 @@ ui_step "Service start"
 # #1615) and/or ComfyUI checkpoints (on-disk pass, "comfyui" v0.1.x dir)
 # ends up with those links outstanding — `hal0 doctor migrations` then
 # opens day one with a spurious "N link(s) pending" warning on a box that
-# has never run anything but this installer. Applying here, before the
-# P3-perms fix below, means any symlinks it plants get swept into that
-# recursive re-chown instead of sitting root-owned under the hal0-owned
-# models/ tree. Idempotent (a no-op on re-run) and non-destructive: it only
+# has never run anything but this installer. Ordering against the P3-perms
+# fix below no longer matters (#1739): the perms table deliberately SKIPS
+# symlinks — chown/chmod follow them, so sweeping the planted links into the
+# recursive re-chown, as this step originally intended, rewrote the
+# operator's real files under /mnt/ai-models. The links are left exactly as
+# migrate created them, which is also what migrate's "does not write to
+# /mnt/ai-models at all" invariant requires. Idempotent (a no-op on re-run)
+# and non-destructive: it only
 # ever creates symlinks or reports a conflict, never overwrites one it
 # doesn't own (no --force) — a genuine conflict just resurfaces via
 # `hal0 doctor migrations` after install instead of aborting it.

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -599,7 +599,8 @@ def _diagnose_audit_rows(
     :func:`check_hermes_ownership`, :func:`check_tree_group_share`, and
     ``hal0.install.perms.audit_rows`` all share this exact row vocabulary
     (``{path,label,status,detail}``), so one adapter covers every
-    ``doctor perms`` sub-check (§2.1). ``absent`` rows carry no finding.
+    ``doctor perms`` sub-check (§2.1). ``absent`` and ``symlink`` rows carry
+    no finding (a ``symlink`` row is one perms deliberately left alone, #1739).
     ``drift`` rows each become one ``fail`` Diagnosis; when nothing drifted,
     a single ``HAL0-DOCTOR-OK`` info row is emitted instead of an empty list
     so a clean ``--json`` run still has something to show.
@@ -749,6 +750,9 @@ def _render_audit(title: str, rows: list[dict[str, str]]) -> None:
         "ok": "[green]ok[/green]",
         "drift": "[red]DRIFT[/red]",
         "absent": "[dim]absent[/dim]",
+        # #1739: perms deliberately never follows a symlink, so its target
+        # (outside the declared tree) is never chowned.
+        "symlink": "[dim]symlink[/dim]",
     }
     table = Table(title=title)
     table.add_column("Check", style="bold")

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -44,6 +44,15 @@ Design notes:
     distinct from recursed dirs (``child_mode``).
   - Stat/chown/chmod are injected seams so the plan/diff/audit logic is unit
     tested without a real privileged filesystem.
+  - SYMLINKS ARE NEVER FOLLOWED, AND NEVER WRITTEN TO (#1739). ``os.chown`` /
+    ``os.chmod`` dereference by default, so a symlink matched by a row would
+    have rewritten its TARGET's owner+mode — a file that by definition lives
+    OUTSIDE hal0's declared tree. ``hal0 migrate model-layout`` plants exactly
+    such links (``/var/lib/hal0/models/... -> /mnt/ai-models/...``) under the
+    recursive ``models/`` row, so every install/upgrade re-chowned the
+    operator's real model store. A link target's ownership is not hal0's
+    concern; symlinks are therefore dropped during glob expansion, never
+    counted as drift, and hard-refused in :func:`_apply_one`.
 """
 
 from __future__ import annotations
@@ -508,6 +517,10 @@ class PermObservation:
     owner: str | None
     group: str | None
     mode: int | None
+    #: True when the path itself is a symlink. Observations are ``lstat``-based,
+    #: so ``owner``/``group``/``mode`` describe the LINK, never its target
+    #: (#1739). A symlink is never reconciled — see :attr:`PermDiff.changed`.
+    is_symlink: bool = False
 
 
 def _owner_name(uid: int) -> str | None:
@@ -536,6 +549,7 @@ def observe(path: Path) -> PermObservation:
         owner=_owner_name(st.st_uid),
         group=_group_name(st.st_gid),
         mode=stat_mod.S_IMODE(st.st_mode),
+        is_symlink=stat_mod.S_ISLNK(st.st_mode),
     )
 
 
@@ -546,9 +560,12 @@ def observe(path: Path) -> PermObservation:
 class PermDiff:
     """The declared target for one concrete path, plus its current observation.
 
-    ``changed`` is true only when the path EXISTS and at least one of owner /
-    group / mode differs from the declared target. An absent path is never
-    "changed" (nothing to chown); it is surfaced separately as ``absent``.
+    ``changed`` is true only when the path EXISTS, is not a symlink, and at
+    least one of owner / group / mode differs from the declared target. An
+    absent path is never "changed" (nothing to chown); it is surfaced
+    separately as ``absent``. A SYMLINK is never "changed" either (#1739):
+    reconciling it would mean ``chown``/``chmod`` on its target, which lives
+    outside the declared tree; it is surfaced as ``symlink``.
     """
 
     path: Path
@@ -560,7 +577,7 @@ class PermDiff:
 
     @property
     def changed(self) -> bool:
-        if not self.before.exists:
+        if not self.before.exists or self.before.is_symlink:
             return False
         return (
             self.before.owner != self.owner
@@ -600,9 +617,34 @@ def _child_mode_for(row: PermRow, child: Path) -> int:
     rows only ever match files).
     """
     dir_mode = row.child_mode if row.child_mode is not None else row.mode
-    if child.is_dir():
+    if child.is_dir() and not child.is_symlink():
         return dir_mode
     return row.child_file_mode if row.child_file_mode is not None else dir_mode
+
+
+def _is_or_is_under_symlink(child: Path, base: Path) -> bool:
+    """True when ``child`` is a symlink, or sits below one, relative to ``base``.
+
+    Both cases mean "reconciling this path would write outside the declared
+    tree" (#1739): the link itself dereferences on ``chown``/``chmod``, and a
+    path found by walking THROUGH a symlinked directory is a real file in
+    someone else's tree (e.g. ``/mnt/ai-models/...`` reached via the
+    ``models/`` links planted by ``hal0 migrate model-layout``). Checked
+    explicitly rather than relying on ``Path.rglob``'s no-follow behaviour, so
+    the guarantee does not depend on the pathlib version.
+    """
+    if child.is_symlink():
+        return True
+    try:
+        rel = child.relative_to(base)
+    except ValueError:  # pragma: no cover - matches are always under base
+        return False
+    cur = base
+    for part in rel.parts[:-1]:
+        cur = cur / part
+        if cur.is_symlink():
+            return True
+    return False
 
 
 def _expand_row(row: PermRow) -> list[tuple[Path, PermRow]]:
@@ -621,6 +663,10 @@ def _expand_row(row: PermRow) -> list[tuple[Path, PermRow]]:
     out: list[tuple[Path, PermRow]] = [(row.target, row)]
     matches = row.target.rglob(row.glob) if row.recursive else row.target.glob(row.glob)
     for child in sorted(matches):
+        # #1739: a symlink (or anything reached through one) is not hal0's to
+        # own — drop it from the plan entirely so it can never be chowned.
+        if _is_or_is_under_symlink(child, row.target):
+            continue
         out.append(
             (
                 child,
@@ -678,8 +724,18 @@ def _apply_one(
     *,
     chown: Callable[[str, int, int], None],
     chmod: Callable[[str, int], None],
+    islink: Callable[[str], bool] = os.path.islink,
 ) -> None:
-    """Resolve owner/group to ids and apply chown + chmod to one path."""
+    """Resolve owner/group to ids and apply chown + chmod to one path.
+
+    Hard-refuses symlinks (#1739). ``os.chown``/``os.chmod`` follow symlinks
+    (and Linux has no ``lchmod``), so applying to a link would rewrite its
+    TARGET outside the declared tree. Symlinks are already dropped in
+    :func:`_expand_row` and never marked ``changed``; this is the last-line
+    guard that also covers the rollback path and any future caller.
+    """
+    if islink(str(path)):
+        return
     uid = pwd.getpwnam(owner).pw_uid
     gid = grp.getgrnam(group).gr_gid
     chown(str(path), uid, gid)
@@ -736,6 +792,18 @@ def audit_rows(plan_: OwnershipPlan) -> list[dict[str, str]]:
                     "label": d.role,
                     "status": "absent",
                     "detail": "not present",
+                }
+            )
+            continue
+        if d.before.is_symlink:
+            # #1739: never reconciled — reported so the audit stays honest
+            # about what it deliberately left alone.
+            rows.append(
+                {
+                    "path": str(d.path),
+                    "label": d.role,
+                    "status": "symlink",
+                    "detail": "symlink, not followed",
                 }
             )
             continue

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -6,7 +6,10 @@ Covers:
     never ``changed``.
   * Glob rows expand to one diff per matching child.
   * ``commit()`` applies drifted diffs and rolls back atomically on failure.
-  * ``audit_rows`` renders the ok / drift / absent vocabulary.
+  * ``audit_rows`` renders the ok / drift / absent / symlink vocabulary.
+  * Symlinks are never dereferenced by ``plan()``/``commit()`` (#1739) — the
+    model-layout links planted under ``models/`` must leave their targets
+    under ``/mnt/ai-models`` byte-for-byte untouched.
   * ``ownership_table()`` builds under HAL0_HOME so it is test-isolated.
 
 The plan/diff/commit logic is exercised through injected ``observe_fn`` /
@@ -586,3 +589,138 @@ def test_flip_honors_custom_service_group(tmp_hal0_home: str) -> None:
     assert rows[paths.var_lib()].group == "svcgrp"
     # pinned-root rows ignore the service group.
     assert rows[paths.agents_config_dir()].group == "root"
+
+
+# ── #1739: symlinks are never dereferenced (P0 model-store regression) ────────
+
+
+def test_commit_never_dereferences_symlink_under_recursive_row(tmp_path: Path) -> None:
+    """The #1739 repro: a symlink under a recursive row must not touch its target.
+
+    ``hal0 migrate model-layout --apply`` plants
+    ``/var/lib/hal0/models/<name> -> /mnt/ai-models/<name>`` links, which the
+    recursive ``models/`` row matched. Because ``os.chown``/``os.chmod``
+    follow symlinks, ``commit()`` rewrote the operator's REAL model file
+    (owner ``hal0:hal0``, mode 0644) on every install/upgrade — outside the
+    declared tree, contradicting migrate's "does not write to /mnt/ai-models
+    at all" invariant. The target must come back byte-for-byte untouched.
+    """
+    owner, group = _me()
+    tree = tmp_path / "models"
+    tree.mkdir()
+    outside = tmp_path / "ai-models"
+    outside.mkdir()
+    real = outside / "weights.gguf"
+    real.write_bytes(b"weights")
+    os.chmod(real, 0o600)
+    (tree / "weights.gguf").symlink_to(real)
+
+    row = perms.PermRow(
+        tree, owner, group, 0o2775, glob="*", recursive=True, child_file_mode=0o644, role="models"
+    )
+    pl = perms.plan([row])
+    applied = perms.commit(pl)
+
+    assert real not in applied
+    assert (tree / "weights.gguf") not in applied
+    assert oct(real.stat().st_mode & 0o7777) == oct(0o600), "symlink target was chmod'd"
+    assert (tree / "weights.gguf").is_symlink(), "the link itself must survive"
+
+
+def test_plan_skips_paths_reached_through_a_symlinked_directory(tmp_path: Path) -> None:
+    """Walking THROUGH a symlinked dir would chown real files directly.
+
+    Same #1739 hazard one level up: ``migrate model-layout`` links whole
+    per-model DIRECTORIES, so a recursive glob that descends into the link
+    yields real paths under ``/mnt/ai-models`` that are not themselves
+    symlinks — ``_apply_one``'s link check would not save them. They must
+    never enter the plan at all.
+    """
+    owner, group = _me()
+    tree = tmp_path / "models"
+    tree.mkdir()
+    outside_dir = tmp_path / "ai-models" / "llama"
+    outside_dir.mkdir(parents=True)
+    real = outside_dir / "weights.gguf"
+    real.write_bytes(b"weights")
+    os.chmod(real, 0o600)
+    (tree / "llama").symlink_to(outside_dir)
+
+    row = perms.PermRow(
+        tree, owner, group, 0o2775, glob="*", recursive=True, child_file_mode=0o644, role="models"
+    )
+    pl = perms.plan([row])
+    planned = {d.path for d in pl.diffs}
+
+    assert tree in planned  # the declared dir itself is still owned
+    assert (tree / "llama") not in planned
+    assert real not in planned
+    perms.commit(pl)
+    assert oct(real.stat().st_mode & 0o7777) == oct(0o600)
+
+
+def test_non_glob_symlink_row_is_never_drift_and_audits_as_symlink(tmp_path: Path) -> None:
+    """A declared row whose own target is a symlink is reported, never fixed."""
+    owner, group = _me()
+    real = tmp_path / "real.env"
+    real.write_text("K=V")
+    os.chmod(real, 0o600)
+    link = tmp_path / "api.env"
+    link.symlink_to(real)
+
+    pl = perms.plan([perms.PermRow(link, owner, group, 0o640, role="api.env")])
+    assert pl.changed is False
+    assert pl.drifted == ()
+    assert pl.diffs[0].before.is_symlink is True
+
+    rows = perms.audit_rows(pl)
+    assert rows[0]["status"] == "symlink"
+    assert perms.commit(pl) == []
+    assert oct(real.stat().st_mode & 0o7777) == oct(0o600)
+
+
+def test_apply_one_hard_refuses_a_symlink_even_when_planned(tmp_path: Path) -> None:
+    """Last-line guard: chown/chmod are not called for a symlink path.
+
+    Defence in depth for the rollback path and any future caller that builds a
+    diff without going through ``_expand_row``.
+    """
+    owner, group = _me()
+    real = tmp_path / "real.bin"
+    real.write_bytes(b"x")
+    link = tmp_path / "link.bin"
+    link.symlink_to(real)
+
+    calls: list[tuple[str, str]] = []
+    perms._apply_one(
+        link,
+        owner,
+        group,
+        0o644,
+        chown=lambda p, u, g: calls.append(("chown", p)),
+        chmod=lambda p, m: calls.append(("chmod", p)),
+    )
+    assert calls == []
+
+
+def test_regular_files_are_still_reconciled_alongside_symlinks(tmp_path: Path) -> None:
+    """The skip is surgical: real files under the same row are still fixed."""
+    owner, group = _me()
+    tree = tmp_path / "models"
+    tree.mkdir()
+    plain = tree / "plain.gguf"
+    plain.write_bytes(b"w")
+    os.chmod(plain, 0o600)
+    outside = tmp_path / "outside.gguf"
+    outside.write_bytes(b"w")
+    os.chmod(outside, 0o600)
+    (tree / "linked.gguf").symlink_to(outside)
+
+    row = perms.PermRow(
+        tree, owner, group, 0o755, glob="*", recursive=True, child_file_mode=0o644, role="models"
+    )
+    applied = perms.commit(perms.plan([row]))
+
+    assert plain in applied
+    assert oct(plain.stat().st_mode & 0o7777) == oct(0o644)
+    assert oct(outside.stat().st_mode & 0o7777) == oct(0o600)


### PR DESCRIPTION
## What

`hal0 doctor perms --fix` (and every install/upgrade, which runs it) dereferenced symlinks and rewrote the files they point at. Fixes #1739 (P0, regression from #1732).

`hal0 migrate model-layout --apply` plants `/var/lib/hal0/models/<name>` → `/mnt/ai-models/<name>` symlinks. The perms table's recursive `models/` row matched them via `rglob`, and `commit()` → `_apply_one()` called `os.chown`/`os.chmod`, both of which follow symlinks (Linux has no `lchmod`). Result: the operator's **real model-store files** were re-owned `hal0:hal0` and re-moded `0644`, outside hal0's declared tree, on every install and every upgrade — directly contradicting `migrate_commands.py`'s documented "does not write to `/mnt/ai-models` at all" invariant.

## How

The whole commit path is now `lstat`-based and symlink-skipping, at three layers:

1. **`_expand_row`** drops any glob match that is a symlink *or that was reached by walking through one*. The second case matters: `migrate model-layout` links whole per-model **directories**, so recursing into the link yields real paths under `/mnt/ai-models` that are not themselves symlinks — a link check in `_apply_one` alone would not save them. Checked explicitly rather than relying on `Path.rglob`'s no-follow behaviour, so the guarantee does not depend on the pathlib version.
2. **`PermObservation.is_symlink`** (observations were already `lstat`-based) + `PermDiff.changed` is never true for a symlink. A declared row whose own target is a link plans as a no-op and audits as a new `symlink` status instead of `drift` (badge added to `doctor_commands._render_audit`; `_diagnose_audit_rows` carries no finding for it, like `absent`).
3. **`_apply_one`** hard-refuses a symlink — last-line guard covering the rollback path and any future caller.

Skipping (rather than `chown(follow_symlinks=False)` on the link itself) is the safer choice and matches migrate's invariant: a link target's ownership is not hal0's concern. The skip is surgical — real files under the same row are still reconciled.

### install.sh ordering comment

#1732 deliberately placed the migration **before** `doctor perms --fix` so planted symlinks would be "swept into that recursive re-chown". That intent *is* the bug. With this fix symlinks are skipped, so the ordering no longer matters; the comment is corrected to say so. **The migration itself is not reverted** — it correctly fixes the #1615 doctor warning.

## Verification

Red-first. The five new tests in `tests/install/test_perms.py` (which had zero symlink coverage) all fail against the pre-fix code — the review's exact repro, a symlink under a recursive `PermRow`, shows the target's mode flipping `0o600` → `0o644`:

```
FAILED test_commit_never_dereferences_symlink_under_recursive_row
FAILED test_plan_skips_paths_reached_through_a_symlinked_directory
FAILED test_non_glob_symlink_row_is_never_drift_and_audits_as_symlink
FAILED test_apply_one_hard_refuses_a_symlink_even_when_planned
FAILED test_regular_files_are_still_reconciled_alongside_symlinks
5 failed, 27 deselected
```

With the fix:

- `tests/install tests/installer` — **570 passed**, 1 skipped (shellcheck not installed locally)
- `+ tests/security tests/agents/test_hermes_security_deliverables.py` — **763 passed**
- `tests/cli` (covers the `_render_audit` badge change) — **677 passed**
- `ruff check` clean, `ruff format --check` clean
- `mypy` on both touched files: only the pre-existing `doctor_commands.py:386 no-any-return`, outside this diff

## Risk

Strictly safer: this only *stops* writes to paths hal0 never should have touched. No path that was correctly reconciled before is skipped now (covered by `test_regular_files_are_still_reconciled_alongside_symlinks`).

Closes #1739

🤖 Generated with [Claude Code](https://claude.com/claude-code)