### PR TITLE
fix(security): stage release bytes in a root-only dir and pin them to extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,29 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Security
 
+- The privileged update stage no longer downloads, verifies and extracts the
+  release tarball out of the service-writable `/var/lib/hal0/cache/<version>/`
+  (#1738). That directory is `hal0:hal0` `0o2775` with no sticky bit, and the
+  post-stage ownership restore hands it back to the service account, so a
+  process compromised as `hal0` could substitute its own tarball in the window
+  between `cosign verify-blob` exiting and root calling `tarfile.open` — and
+  root would extract and `pip install` it. Staging now happens in a root-only
+  `0700` directory created under the install root and destroyed when the stage
+  ends, and the authenticated `digest_sha256` is re-derived from the very file
+  object the archive is read out of, so the bytes cosign accepted are provably
+  the bytes that land on disk. The cache directory now holds only the verified
+  manifest that `commit()` re-reads.
+- An interrupted extraction no longer wedges a version permanently. A killed
+  `extractall` used to leave the destination holding just the un-flattened
+  `hal0-<version>/` prefix, which the "is this a prior hal0 install" check did
+  not recognise, so every retry refused to extract over a non-empty directory —
+  unrecoverable for the unprivileged daemon, since the wedged tree is
+  root-owned. Extraction now drops a `.hal0-staging` sentinel for its duration
+  and the check also recognises an un-flattened prefix directory, so an
+  incomplete tree is quarantined and retried. The `.stale-<ts>` quarantine
+  directories, which accumulated one whole install tree per retry and were
+  never cleaned up, are now reaped: the newest three are kept for recovery and
+  anything older than 30 days goes.
 - The privileged `hal0-systemctl` wrapper now allow-lists the *content* of the
   two systemd drop-ins it writes as root (`write-gateway-dropin`,
   `write-hindsight-dropin`). Both verbs take their whole payload on stdin, and

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -3,8 +3,12 @@
 Updater handles the full update lifecycle:
   1. Check ``{HAL0_RELEASES_URL}`` (or ``https://releases.hal0.dev/{channel}.json``)
      for a newer version.
-  2. Download tarball + cosign signature to ``/var/lib/hal0/cache/<version>/``.
-  3. Verify the SHA-256 digest against the release manifest.
+  2. Download tarball + cosign signature into a root-only ``0700`` staging
+     directory under the install root (#1738 — never the service-writable
+     ``/var/lib/hal0/cache/<version>/``, which only holds the verified
+     manifest ``commit()`` re-reads).
+  3. Verify the SHA-256 digest against the release manifest, and re-derive it
+     from the same open file object the tarball is extracted from.
   4. ``cosign verify-blob`` against the exact GitHub Actions OIDC identity
      derived from the authenticated release kind and version.
   5. Extract to ``/usr/lib/hal0-<version>/`` (refuses non-empty paths).
@@ -46,8 +50,9 @@ import sys
 import tarfile
 import tempfile
 import time
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, BinaryIO, Literal
 from urllib.parse import urlparse
 
 import structlog
@@ -1000,47 +1005,199 @@ async def _fetch_verified_release_manifest(
 # ── Extraction + migration helpers ─────────────────────────────────────────────
 
 
+#: Written into a destination directory for the duration of an extraction and
+#: removed on success. Its presence means "a stage started here and did not
+#: finish" — the only marker that is reliable for *every* interruption shape,
+#: including the ones that leave no recognisable file layout behind at all.
+_STAGING_SENTINEL = ".hal0-staging"
+
+#: Quarantined trees (``<install-dir>.stale-<unix-ts>``) are kept so an
+#: operator can recover from a half-failed apply, but they were never cleaned
+#: up — one full install tree leaked per retry, forever. Keep the newest few
+#: regardless of age, and reap anything older than this.
+_QUARANTINE_KEEP = 3
+_QUARANTINE_MAX_AGE_S = 30 * 86400
+
+
 def _looks_like_hal0_install(path: Path) -> bool:
     """Heuristic: does ``path`` look like a prior hal0 tarball extraction?
 
-    A safe quarantine candidate has either a top-level ``VERSION`` file
-    or a ``pyproject.toml`` whose ``name`` is ``hal0ai`` (or the legacy
-    pre-rename ``hal0``). We deliberately refuse to touch unrelated
-    non-empty directories.
+    A safe quarantine candidate is one of:
+
+    * a leftover :data:`_STAGING_SENTINEL` — an extraction started here and
+      never completed, whatever it managed to write;
+    * a top-level ``VERSION`` file;
+    * an un-flattened ``hal0-<version>/`` prefix directory containing a
+      ``VERSION`` — the exact shape ``tf.extractall`` leaves when it is
+      interrupted before :func:`_extract_tarball` flattens the prefix away;
+    * a ``pyproject.toml`` whose ``name`` is ``hal0ai`` (or the legacy
+      pre-rename ``hal0``).
+
+    We deliberately refuse to touch unrelated non-empty directories: an
+    operator's own files at this path must never be silently moved aside.
+
+    The pyproject check reads the **whole** file. It used to read only
+    ``[:512]``, which never matched hal0's own manifest — ``name = "hal0ai"``
+    starts at byte 512 exactly — so the fallback was dead code, masked only
+    by release tarballs happening to ship a ``VERSION``. An installer rsync
+    tree has no ``VERSION``, so the fallback is the only thing that can
+    recognise it, and it has to actually run.
     """
+    if (path / _STAGING_SENTINEL).exists():
+        return True
     if (path / "VERSION").is_file():
         return True
+    for child in _iterdir_safe(path):
+        if child.is_dir() and child.name.startswith("hal0-") and (child / "VERSION").is_file():
+            return True
     pp = path / "pyproject.toml"
     if pp.is_file():
         try:
-            head = pp.read_text(encoding="utf-8", errors="replace")[:512]
+            body = pp.read_text(encoding="utf-8", errors="replace")
         except OSError:
             return False
         return any(
-            marker in head
+            marker in body
             for marker in ('name = "hal0ai"', "name = 'hal0ai'", 'name = "hal0"', "name = 'hal0'")
         )
     return False
 
 
-def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) -> None:
+def _iterdir_safe(path: Path) -> list[Path]:
+    """``path.iterdir()`` as a list, empty on any filesystem error."""
+    try:
+        return list(path.iterdir())
+    except OSError:
+        return []
+
+
+def _reap_stale_quarantines(
+    install_dir: Path,
+    *,
+    keep: int = _QUARANTINE_KEEP,
+    max_age_s: int = _QUARANTINE_MAX_AGE_S,
+    job_id: str | None = None,
+) -> None:
+    """Delete old ``<install_dir>.stale-<unix-ts>`` quarantine trees.
+
+    Quarantining is a self-heal (see :func:`_extract_tarball`) but nothing
+    ever removed the result, so a box that retried a failed apply a few times
+    accumulated whole install trees under ``/usr/lib/hal0`` indefinitely. The
+    newest ``keep`` are retained — recovery material for the failure that just
+    happened — and everything else, plus anything older than ``max_age_s``, is
+    removed. Best-effort and logged: failing to tidy is never a reason to
+    fail an update.
+    """
+    prefix = f"{install_dir.name}.stale-"
+    candidates: list[tuple[int, Path]] = []
+    for entry in _iterdir_safe(install_dir.parent):
+        if not entry.name.startswith(prefix) or not entry.is_dir():
+            continue
+        suffix = entry.name[len(prefix) :]
+        if not suffix.isdigit():
+            continue
+        candidates.append((int(suffix), entry))
+    if not candidates:
+        return
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    cutoff = int(time.time()) - max_age_s
+    for index, (stamp, entry) in enumerate(candidates):
+        # Two independent bounds, because either alone leaks: an age-only
+        # rule keeps every quarantine from a same-day retry storm, and a
+        # count-only rule keeps three full install trees forever.
+        if index < keep and stamp > cutoff:
+            continue
+        try:
+            shutil.rmtree(entry)
+        except OSError as exc:
+            log.warning(
+                "updater.quarantine_reap_failed", job_id=job_id, path=str(entry), error=str(exc)
+            )
+            continue
+        log.info("updater.quarantine_reaped", job_id=job_id, path=str(entry), stamp=stamp)
+
+
+@contextlib.contextmanager
+def _root_only_staging_dir(version: str, *, job_id: str | None = None) -> Iterator[Path]:
+    """Yield a fresh 0700 staging dir under the **root-owned** install root.
+
+    #1738: the release artifact used to be downloaded into
+    ``/var/lib/hal0/cache/<version>/`` and then re-opened *by path* four
+    times — download, sha256, ``cosign verify-blob`` (a subprocess), and
+    finally ``tarfile.open``. ``/var/lib/hal0`` is ``hal0:hal0`` ``0o2775``
+    with no sticky bit, and :func:`_restore_service_ownership` hands the
+    cache version dir back to the service account after every successful
+    stage — so the unprivileged account could substitute its own tarball in
+    the window between cosign exiting and root extracting, and root would
+    pip-install it. That defeats the entire "root re-fetches and re-verifies
+    the bytes itself" argument the privileged seam rests on.
+
+    ``mkdtemp`` creates the directory ``0700``, atomically and owned by the
+    creating euid — root on the seam path. Nothing but root can traverse it,
+    so no other principal can even name, let alone replace, the artifact
+    between verification and extraction. The dot-prefixed name can never
+    collide with a release-dir token (those forbid a leading ``.``; see the
+    token regex above), and the tree is removed unconditionally on the way
+    out so a failed stage leaks nothing.
+    """
+    root = _usr_lib_root()
+    root.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".stage-{version}-", dir=root))
+    try:
+        os.chmod(staging, 0o700)
+        yield staging
+    finally:
+        try:
+            shutil.rmtree(staging)
+        except OSError as exc:
+            log.warning(
+                "updater.staging_cleanup_failed", job_id=job_id, path=str(staging), error=str(exc)
+            )
+
+
+def _extract_tarball(
+    tarball: Path,
+    dest: Path,
+    *,
+    job_id: str | None = None,
+    expected_digest: str | None = None,
+) -> None:
     """Extract ``tarball`` to ``dest``.
 
     The tarball is expected to contain a top-level directory matching
     ``hal0-<version>/``; we strip that prefix to land files directly under
     ``dest`` (which the caller names ``/usr/lib/hal0-<version>/``).
 
+    ``expected_digest`` (#1738) is the authenticated ``manifest.digest_sha256``.
+    When given, the file is opened **once** and that single file object is used
+    for both the digest and the extraction — the bytes that are hashed are, by
+    construction, the bytes that are unpacked. Any substitution after
+    ``cosign verify-blob`` returned (a rename, a replace, or an in-place
+    rewrite of the same inode) fails the check and aborts the stage before a
+    single member is written. The caller additionally stages inside a
+    root-only directory (:func:`_root_only_staging_dir`) so no unprivileged
+    principal can reach the artifact in the first place; this check is the
+    inner, non-negotiable guarantee, not a substitute for that isolation.
+
     If ``dest`` already exists and looks like a prior hal0 extraction
-    (has ``VERSION`` or a hal0 ``pyproject.toml``), it is renamed aside
+    (see :func:`_looks_like_hal0_install`), it is renamed aside
     to ``dest.with_suffix(.stale-<unix-ts>)`` so a retry after a half-
     failed apply isn't permanently wedged. Unrelated non-empty dirs are
     still refused — we will not silently destroy whatever the operator
     parked there.
 
     Raises ``UpdateExtractError`` on filesystem issues, malformed
-    tarballs, or unsafe paths.
+    tarballs, or unsafe paths, and ``UpdateVerifyError`` when
+    ``expected_digest`` does not match the bytes about to be extracted.
     """
     dest = Path(dest)
+    # Open the artifact exactly once, and re-derive its digest from *that*
+    # handle, before anything on disk is disturbed — a mismatch must abort
+    # without quarantining the operator's existing install. The handle is
+    # what ``tarfile`` reads from below, so there is no second name lookup
+    # between the check and the use. On any raise before the ExitStack takes
+    # ownership, the handle is dropped and closed with the last reference.
+    handle = _open_digest_verified(tarball, expected_digest)
     if dest.exists():
         if not dest.is_dir():
             raise UpdateExtractError(
@@ -1120,10 +1277,22 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
     dest.mkdir(parents=True, exist_ok=True, mode=0o700)
     dest.chmod(0o700)
 
+    # Mark the destination as mid-stage for the whole extraction window. If we
+    # are killed anywhere below, the next attempt sees this sentinel, treats
+    # the tree as a prior (incomplete) hal0 extraction and quarantines it —
+    # instead of hitting "refusing to extract over non-empty directory" on
+    # every retry forever, which is unrecoverable for the unprivileged daemon
+    # because the wedged tree is root-owned.
+    sentinel = dest / _STAGING_SENTINEL
+    with contextlib.suppress(OSError):
+        sentinel.write_text("", encoding="utf-8")
+
     log.info("updater.extract_start", job_id=job_id, tarball=str(tarball), dest=str(dest))
     strip_prefix: str | None = None
     try:
-        with tarfile.open(tarball, "r:*") as tf:
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(contextlib.closing(handle))
+            tf = stack.enter_context(tarfile.open(fileobj=handle, mode="r:*"))
             members = tf.getmembers()
             if not members:
                 raise UpdateExtractError(
@@ -1172,6 +1341,11 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
             with contextlib.suppress(OSError):
                 inner.rmdir()
 
+    # Extraction (and its flatten) completed — drop the mid-stage marker so
+    # this tree reads as a finished install from here on.
+    with contextlib.suppress(OSError):
+        sentinel.unlink(missing_ok=True)
+
     # Now that extraction is complete and `dest` is no longer racing anyone,
     # widen it back to its final, correct mode: normalize the whole tree
     # (not just the top level) so assert_trusted_release_dir's precondition
@@ -1180,7 +1354,58 @@ def _extract_tarball(tarball: Path, dest: Path, *, job_id: str | None = None) ->
     # go-w-clean too, not just readable-only-by-owner forever.
     _normalize_staged_tree(dest, job_id=job_id)
 
+    # Tidy older quarantines now that a good tree exists at `dest` — the
+    # recovery material for *this* failure is kept, ancient copies are not.
+    _reap_stale_quarantines(dest, job_id=job_id)
+
     log.info("updater.extract_ok", job_id=job_id, dest=str(dest))
+
+
+def _open_digest_verified(tarball: Path, expected_digest: str | None) -> BinaryIO:
+    """Open ``tarball`` once and confirm its bytes match ``expected_digest``.
+
+    Returns the still-open, rewound binary handle. When ``expected_digest``
+    is ``None`` (callers outside the privileged release path) the file is
+    simply opened.
+
+    This is the #1738 fix's inner guarantee: hashing and extracting share a
+    single file object, so nothing that happens to the *path* between
+    ``cosign verify-blob`` and ``tarfile.open`` can change what gets
+    unpacked, and an in-place rewrite of the same inode is caught by the
+    digest itself.
+    """
+    try:
+        # SIM115 off: returning the *still-open* handle is the entire point —
+        # the caller closes it through an ExitStack once tarfile is done with
+        # it, so hashing and extraction cannot be split across two opens.
+        handle = open(tarball, "rb")  # noqa: SIM115
+    except OSError as exc:
+        raise UpdateExtractError(
+            f"could not open release tarball: {exc}",
+            details={"tarball": str(tarball), "error": str(exc)},
+        ) from exc
+    if expected_digest is None:
+        return handle
+    try:
+        h = hashlib.sha256()
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+        got = h.hexdigest()
+        handle.seek(0)
+    except OSError as exc:
+        handle.close()
+        raise UpdateExtractError(
+            f"could not read release tarball: {exc}",
+            details={"tarball": str(tarball), "error": str(exc)},
+        ) from exc
+    if got != expected_digest:
+        handle.close()
+        raise UpdateVerifyError(
+            "release tarball digest changed after verification — refusing to extract "
+            f"(expected {expected_digest}, got {got})",
+            details={"expected": expected_digest, "got": got, "tarball": str(tarball)},
+        )
+    return handle
 
 
 def _normalize_staged_tree(dest: Path, *, job_id: str | None = None) -> None:
@@ -2709,51 +2934,67 @@ async def stage_release(
     # scope; signed immutable same-version assets limit current release risk
     # because both prepares authenticate the same publisher-pinned bytes.
 
-    # Step 3: download tarball + Sigstore bundle (survives cert expiry, #1159).
+    # Steps 3-6 all happen inside a root-only staging directory (#1738). The
+    # artifact is downloaded, digested, cosign-verified and extracted without
+    # ever existing at a path a non-root principal can reach — the cache dir
+    # under /var/lib/hal0 is service-owned and must never hold bytes root is
+    # about to trust. The directory (and the artifact in it) is destroyed on
+    # the way out, success or failure.
     cache = _cache_dir(target_version)
     cache.mkdir(parents=True, exist_ok=True)
-    tarball_path = cache / f"hal0-{target_version}.tar.gz"
-    bundle_path = cache / f"hal0-{target_version}.tar.gz.bundle"
-    log.info("updater.download_start", job_id=job_id, version=target_version, url=manifest.url)
-    await _download(manifest.url, tarball_path)
-    await _download(manifest.bundle_url, bundle_path)
-    log.info(
-        "updater.download_ok",
-        job_id=job_id,
-        tarball=str(tarball_path),
-        bundle=str(bundle_path),
-    )
-
-    # Step 4: sha256 verify.
-    got_digest = _sha256_file(tarball_path)
-    if got_digest != manifest.digest_sha256:
-        raise UpdateVerifyError(
-            f"sha256 digest mismatch (expected {manifest.digest_sha256}, got {got_digest})",
-            details={
-                "expected": manifest.digest_sha256,
-                "got": got_digest,
-                "tarball": str(tarball_path),
-            },
-        )
-    log.info("updater.sha256_ok", job_id=job_id, digest=got_digest)
-
-    # Step 5: verify against the identity derived from authenticated release
-    # policy, never a manifest-selected broader expression.
-    expected_identity = exact_manifest_identity(manifest.release_kind, manifest.version)
-    await asyncio.to_thread(
-        _verify_cosign,
-        tarball_path,
-        bundle_path,
-        identity_regexp=expected_identity,
-        issuer=_MANIFEST_SIGNER_ISSUER,
-        job_id=job_id,
-    )
-
-    # Step 6: extract. `_extract_tarball` quarantines a prior hal0
-    # extraction at the same path (see its docstring) so a retry
-    # after a half-failed apply isn't permanently wedged.
     install_dir = _versioned_install_dir(target_version)
-    await asyncio.to_thread(_extract_tarball, tarball_path, install_dir, job_id=job_id)
+    with _root_only_staging_dir(target_version, job_id=job_id) as staging:
+        # Step 3: download tarball + Sigstore bundle (survives cert expiry, #1159).
+        tarball_path = staging / f"hal0-{target_version}.tar.gz"
+        bundle_path = staging / f"hal0-{target_version}.tar.gz.bundle"
+        log.info("updater.download_start", job_id=job_id, version=target_version, url=manifest.url)
+        await _download(manifest.url, tarball_path)
+        await _download(manifest.bundle_url, bundle_path)
+        log.info(
+            "updater.download_ok",
+            job_id=job_id,
+            tarball=str(tarball_path),
+            bundle=str(bundle_path),
+        )
+
+        # Step 4: sha256 verify.
+        got_digest = _sha256_file(tarball_path)
+        if got_digest != manifest.digest_sha256:
+            raise UpdateVerifyError(
+                f"sha256 digest mismatch (expected {manifest.digest_sha256}, got {got_digest})",
+                details={
+                    "expected": manifest.digest_sha256,
+                    "got": got_digest,
+                    "tarball": str(tarball_path),
+                },
+            )
+        log.info("updater.sha256_ok", job_id=job_id, digest=got_digest)
+
+        # Step 5: verify against the identity derived from authenticated release
+        # policy, never a manifest-selected broader expression.
+        expected_identity = exact_manifest_identity(manifest.release_kind, manifest.version)
+        await asyncio.to_thread(
+            _verify_cosign,
+            tarball_path,
+            bundle_path,
+            identity_regexp=expected_identity,
+            issuer=_MANIFEST_SIGNER_ISSUER,
+            job_id=job_id,
+        )
+
+        # Step 6: extract. The authenticated digest is re-derived from the very
+        # file object the tarball is read out of, so the bytes cosign accepted
+        # in step 5 are provably the bytes that land on disk. `_extract_tarball`
+        # also quarantines a prior hal0 extraction at the same path (see its
+        # docstring) so a retry after a half-failed apply isn't permanently
+        # wedged.
+        await asyncio.to_thread(
+            _extract_tarball,
+            tarball_path,
+            install_dir,
+            job_id=job_id,
+            expected_digest=manifest.digest_sha256,
+        )
 
     # Cache the verified manifest so commit() reads min_data_version without a
     # re-fetch (which could resolve a *newer* release than the one just

--- a/tests/updater/test_staging_toctou.py
+++ b/tests/updater/test_staging_toctou.py
@@ -1,0 +1,247 @@
+"""Staging-path hardening regressions (#1738 + adjacent extraction defects).
+
+Three defects, all on the privileged staging path:
+
+* **P0 (#1738)** — the release tarball was downloaded into the hal0-owned
+  ``/var/lib/hal0/cache/<version>/`` and re-opened *by path* four times
+  (download → sha256 → cosign → extract). Anything that can write that
+  directory could substitute its own bytes in the window between cosign
+  exiting and ``tarfile.open``, and root would extract + pip-install them.
+* **P2** — an interrupted ``extractall`` leaves ``dest`` holding only the
+  un-flattened ``hal0-<version>/`` prefix directory (or a bare staging
+  sentinel). ``_looks_like_hal0_install`` looked only at ``dest/VERSION``
+  and ``dest/pyproject.toml``, so every retry raised "refusing to extract
+  over non-empty directory" — a permanent wedge for that version, on a
+  root-owned tree the hal0 daemon cannot clean up itself.
+* **P3** — ``_looks_like_hal0_install``'s pyproject fallback read only the
+  first 512 bytes, and hal0's own ``pyproject.toml`` has ``name = "hal0ai"``
+  starting at byte 512 exactly. Dead code in practice, and wrong for any
+  installer rsync tree (which has no ``VERSION`` file).
+
+The fixtures are imported from :mod:`tests.updater.test_updater` so these
+tests exercise the same synthetic release the rest of the updater suite does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.config.paths import var_lib
+from hal0.updater import UpdateExtractError, Updater, UpdateVerifyError
+from hal0.updater.updater import (
+    _looks_like_hal0_install,
+    _usr_lib_root,
+    _versioned_install_dir,
+)
+
+# Fixtures live in the main updater test module; importing them here makes
+# them resolvable by pytest in this module too.
+from tests.updater.test_updater import (  # noqa: F401
+    cosign_skip,
+    synthetic_release,
+)
+
+# ── P0: the verified bytes are the extracted bytes ─────────────────────────────
+
+
+def test_stage_rejects_tarball_swapped_after_cosign(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Substituting the tarball after cosign returns must abort the stage.
+
+    The stub stands in for the #1738 attacker: it runs at exactly the moment
+    ``cosign verify-blob`` returns, and rewrites the artifact *in place* at
+    the path root is about to extract from — the strongest form of the race
+    (it survives a plain ``os.replace`` guard and an inode pin alike). The
+    re-digest immediately before extraction is what has to catch it.
+    """
+    evil = tmp_path / "evil.tar.gz"
+    evil.write_bytes(b"\x1f\x8b" + b"malicious payload" * 64)
+
+    def _swap_after_verify(tarball: Path, bundle: Path, **kwargs: Any) -> None:
+        Path(tarball).write_bytes(evil.read_bytes())
+
+    monkeypatch.setattr("hal0.updater.updater._verify_cosign", _swap_after_verify)
+
+    with pytest.raises(UpdateVerifyError) as exc_info:
+        asyncio.run(Updater().apply())
+
+    assert "digest" in str(exc_info.value).lower()
+    # Nothing malicious was ever unpacked.
+    install = _versioned_install_dir(synthetic_release["version"])
+    assert not (install / "VERSION").exists()
+
+
+def test_stage_downloads_outside_the_service_owned_cache(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The artifact never lands in the hal0-writable cache dir at all.
+
+    ``/var/lib/hal0`` is hal0:hal0 0o2775 with no sticky bit, and
+    ``_restore_service_ownership`` hands the cache version dir back to the
+    service account after every stage — so the cache is not a place root may
+    stage bytes it is about to trust. Staging happens in a root-only
+    ``mkdtemp`` under the install root instead.
+    """
+    seen: list[Path] = []
+
+    def _record(blob: Path, bundle: Path, **kwargs: Any) -> None:
+        seen.append(Path(blob))
+
+    monkeypatch.setattr("hal0.updater.updater._verify_cosign", _record)
+
+    asyncio.run(Updater().apply())
+
+    # The manifest itself is verified through the same seam; we want the
+    # release artifact's staging path.
+    tarballs = [p for p in seen if p.name.endswith(".tar.gz")]
+    assert tarballs, f"cosign never saw the release tarball (saw {seen})"
+    staged = tarballs[0]
+    cache_root = var_lib() / "cache"
+    assert cache_root not in staged.parents, f"{staged} is inside the service-owned cache"
+    assert _usr_lib_root() in staged.parents, f"{staged} is not under the root-only install root"
+    # Staging dir is torn down once the stage completes.
+    assert not staged.exists()
+    leftovers = [p for p in _usr_lib_root().iterdir() if p.name.startswith(".stage-")]
+    assert leftovers == []
+
+
+def test_stage_leaves_no_tarball_in_the_cache_dir(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """Only the verified manifest is cached; the artifact bytes are not."""
+    asyncio.run(Updater().prepare())
+    cache = var_lib() / "cache" / synthetic_release["version"]
+    assert cache.is_dir()
+    assert sorted(p.name for p in cache.iterdir()) == ["manifest.json"]
+
+
+# ── P2: an interrupted extraction must self-heal, not wedge ────────────────────
+
+
+def test_interrupted_extraction_prefix_dir_is_quarantined(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """A dest holding only the un-flattened ``hal0-<v>/`` prefix is recoverable.
+
+    This is the exact on-disk shape ``extractall`` leaves when it is killed
+    before the flatten step: no top-level ``VERSION``, no ``pyproject.toml``,
+    just the tarball's own prefix directory.
+    """
+    version = synthetic_release["version"]
+    install = _versioned_install_dir(version)
+    inner = install / f"hal0-{version}"
+    inner.mkdir(parents=True)
+    (inner / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+    (inner / "half-written.txt").write_text("interrupted", encoding="utf-8")
+
+    asyncio.run(Updater().apply())
+
+    assert (install / "VERSION").read_text().strip() == version
+    assert not inner.exists()
+    quarantined = [
+        p for p in install.parent.iterdir() if p.name.startswith(f"{install.name}.stale-")
+    ]
+    assert quarantined, "interrupted extraction was not quarantined"
+    assert (quarantined[0] / f"hal0-{version}" / "half-written.txt").is_file()
+
+
+def test_extraction_sentinel_marks_an_incomplete_stage(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """A leftover ``.hal0-staging`` sentinel alone is enough to quarantine.
+
+    Covers interruption shapes the prefix-dir heuristic cannot see (e.g. a
+    kill after the flatten moved one file and before it moved the rest).
+    """
+    version = synthetic_release["version"]
+    install = _versioned_install_dir(version)
+    install.mkdir(parents=True)
+    (install / ".hal0-staging").write_text("", encoding="utf-8")
+    (install / "partial-file").write_text("half", encoding="utf-8")
+
+    asyncio.run(Updater().apply())
+
+    assert (install / "VERSION").read_text().strip() == version
+    assert not (install / ".hal0-staging").exists(), "sentinel survived a successful stage"
+    assert not (install / "partial-file").exists()
+
+
+def test_foreign_directory_is_still_refused(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """The widened heuristic must not start eating operator directories."""
+    install = _versioned_install_dir(synthetic_release["version"])
+    install.mkdir(parents=True)
+    (install / "operator-notes.txt").write_text("do not delete", encoding="utf-8")
+
+    with pytest.raises(UpdateExtractError):
+        asyncio.run(Updater().apply())
+    assert (install / "operator-notes.txt").is_file()
+
+
+def test_old_quarantine_dirs_are_reaped(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """``.stale-<ts>`` quarantines accumulated forever; old ones are now reaped."""
+    version = synthetic_release["version"]
+    install = _versioned_install_dir(version)
+    root = install.parent
+    root.mkdir(parents=True, exist_ok=True)
+
+    now = int(time.time())
+    ancient = root / f"{install.name}.stale-{now - 90 * 86400}"
+    old = root / f"{install.name}.stale-{now - 60 * 86400}"
+    recent = root / f"{install.name}.stale-{now - 60}"
+    for d in (ancient, old, recent):
+        d.mkdir()
+        (d / "VERSION").write_text(f"{version}\n", encoding="utf-8")
+
+    asyncio.run(Updater().apply())
+
+    assert not ancient.exists(), "an ancient quarantine dir was not reaped"
+    assert not old.exists(), "an old quarantine dir was not reaped"
+    assert recent.is_dir(), "a recent quarantine dir must be kept for recovery"
+
+
+# ── P3: the pyproject fallback must actually work ──────────────────────────────
+
+
+def test_looks_like_hal0_install_reads_past_512_bytes(tmp_path: Path) -> None:
+    """A repo-shaped tree with no ``VERSION`` is recognised by pyproject alone.
+
+    hal0's real ``pyproject.toml`` puts ``name = "hal0ai"`` at byte 512
+    exactly, so the old ``[:512]`` slice never saw it — and an installer
+    rsync tree has no ``VERSION`` file to fall back on.
+    """
+    tree = tmp_path / "repo-shaped"
+    tree.mkdir()
+    header = "# " + "x" * 600 + "\n"
+    (tree / "pyproject.toml").write_text(
+        f'{header}[project]\nname = "hal0ai"\nversion = "1.0.0"\n', encoding="utf-8"
+    )
+    assert not (tree / "VERSION").exists()
+    assert _looks_like_hal0_install(tree) is True
+
+
+def test_looks_like_hal0_install_rejects_a_foreign_pyproject(tmp_path: Path) -> None:
+    """Reading the whole file must not turn the check into a wildcard."""
+    tree = tmp_path / "foreign"
+    tree.mkdir()
+    (tree / "pyproject.toml").write_text(
+        "# " + "y" * 900 + '\n[project]\nname = "somebody-elses-project"\n', encoding="utf-8"
+    )
+    assert _looks_like_hal0_install(tree) is False

--- a/tests/updater/test_updater.py
+++ b/tests/updater/test_updater.py
@@ -754,19 +754,24 @@ def test_preview_check_and_prepare_exercise_cosign_subprocess_without_activation
         ]
 
     artifact_call = verification_calls[4]
-    cached_tarball = updater_module._cache_dir(version) / f"hal0-{version}.tar.gz"
-    assert artifact_call["blob"] == str(cached_tarball)
-    assert artifact_call["bundle"] == f"{cached_tarball}.bundle"
+    # #1738: the artifact is verified inside a root-only staging dir under the
+    # install root, never in the service-writable /var/lib/hal0 cache.
+    staged_tarball = Path(artifact_call["blob"])
+    assert staged_tarball.name == f"hal0-{version}.tar.gz"
+    assert staged_tarball.parent.name.startswith(".stage-")
+    assert staged_tarball.parent.parent == updater_module._usr_lib_root()
+    assert updater_module._cache_dir(version) not in staged_tarball.parents
+    assert artifact_call["bundle"] == f"{staged_tarball}.bundle"
     assert artifact_call["blob_sha256"] == _sha256_of(synthetic_preview_release["tarball"])
     assert artifact_call["args"] == [
         "verify-blob",
         "--bundle",
-        str(Path(f"{cached_tarball}.bundle")),
+        str(Path(f"{staged_tarball}.bundle")),
         "--certificate-identity-regexp",
         payload["signer_identity"],
         "--certificate-oidc-issuer",
         payload["signer_issuer"],
-        str(cached_tarball),
+        str(staged_tarball),
     ]
 
 


### PR DESCRIPTION
## ⚠️ PRIVILEGED-SURFACE SECURITY CHANGE — operator review required

This touches the root-side update stage behind the `hal0-update` sudo grant.
**Automerge is deliberately NOT enabled.** Please review before merging.

Closes #1738. Also fixes the two adjacent staging-path defects found alongside
it (extraction wedge, dead pyproject fallback).

## What changed

### P0 — #1738, root RCE via cache TOCTOU

`stage_release` downloaded the release tarball into `/var/lib/hal0/cache/<version>/`
and re-opened it **by path** four times: download → `sha256` → `cosign verify-blob`
(a subprocess) → `tarfile.open`. Two independent ways the unprivileged `hal0`
account owns that directory: `_restore_service_ownership` chowns the cache version
dir back to `hal0:hal0` after every successful stage, and `/var/lib/hal0` is
`hal0:hal0` `0o2775` with no sticky bit. An attacker who is `hal0` swaps the
tarball after cosign exits; root extracts and `pip install`s it.

Both suggested fixes are implemented, because they close different halves of the
window and the strong one is cheap:

1. **Root-only staging directory** (the primary fix). `_root_only_staging_dir()`
   creates a `tempfile.mkdtemp(prefix=".stage-<version>-", dir=_usr_lib_root())`.
   `mkdtemp` creates it `0700` atomically, owned by the creating euid — root on
   the seam path. Download, digest, cosign and extraction all happen inside it;
   no other principal can traverse the directory, so the artifact cannot be named,
   let alone replaced. The tree is removed on the way out, success or failure.
   The dot-prefixed name can never collide with a release-dir token (the #1464
   token regex forbids a leading `.`), so it is invisible to
   `refresh_privileged_wrappers` and the activate-side path validation, and it
   composes with #1725's atomic `mkdir(mode=0o700)` work — same "root creates and
   therefore owns the inode" principle, applied one step earlier in the pipeline.
2. **Digest pinned to the extraction handle** (the inner guarantee).
   `_extract_tarball` now takes `expected_digest` and opens the artifact exactly
   once: the sha256 is computed from that handle and `tarfile` reads the archive
   from the *same* file object. So the bytes cosign accepted are provably the
   bytes that get unpacked, and even an in-place rewrite of the pinned inode
   fails the check. The check runs *before* the destination is touched, so a
   tampered artifact never causes an existing install to be quarantined.

The cache dir now holds only `manifest.json` (which `commit()` re-reads for
`min_data_version`, and which is re-validated against the authenticated target
there already).

**Confirmed as requested:** `_restore_service_ownership` is called at exactly one
site, with the *cache* dir — never with the extracted tree. The staged install
tree is left `root:root` by `_normalize_staged_tree`, which is what
`assert_trusted_release_dir` requires at activate time.

### P2 — extraction wedge + quarantine leak

An interrupted `extractall` leaves `dest` holding only the un-flattened
`hal0-<version>/` prefix directory. `_looks_like_hal0_install` looked only at
`dest/VERSION` and `dest/pyproject.toml` → `False` → every retry raised
"refusing to extract over non-empty directory". Permanently wedged, and
unrecoverable for the daemon because the tree is root-owned and the daemon is
`hal0`.

Both suggested markers are implemented: a `.hal0-staging` sentinel written for
the duration of the extraction (catches *every* interruption shape, including
ones that leave no recognisable layout), and recognition of an un-flattened
`hal0-*/VERSION` child (catches trees left by a build that predates the
sentinel). Either one makes the tree a quarantine candidate, so the retry
self-heals. Foreign directories are still refused — there's a test.

`_reap_stale_quarantines` now cleans the `.stale-<ts>` dirs, which previously
accumulated one full install tree per retry forever. Two bounds, because either
alone leaks: newest 3 kept (an age-only rule keeps everything from a same-day
retry storm), anything older than 30 days removed (a count-only rule keeps 3
trees on disk indefinitely).

### P3 — dead pyproject fallback

`_looks_like_hal0_install` read `pyproject.toml[:512]`, but hal0's own manifest
has `name = "hal0ai"` starting at byte 512 *exactly* — the fallback never
matched. Masked in practice only because release tarballs ship a `VERSION`
file; broken for installer rsync trees, which have none. It now reads and
searches the whole file. A second test pins that reading the whole file did not
turn the check into a wildcard.

## How it was verified

Red-first for each defect, in a new `tests/updater/test_staging_toctou.py`:

- **P0** `test_stage_rejects_tarball_swapped_after_cosign` — the `_verify_cosign`
  stub *is* the attacker: it rewrites the artifact in place at the moment cosign
  returns. Red before: the malicious bytes went to `tarfile.open`. Green after:
  `UpdateVerifyError`, nothing extracted.
  `test_stage_downloads_outside_the_service_owned_cache` pins the staging
  location (under the install root, not under the cache) and that no `.stage-*`
  dir is left behind; `test_stage_leaves_no_tarball_in_the_cache_dir` pins that
  the cache holds only `manifest.json`.
- **P2** `test_interrupted_extraction_prefix_dir_is_quarantined` builds the exact
  killed-`extractall` shape and asserts the retry succeeds with the old tree
  recoverable alongside; `test_extraction_sentinel_marks_an_incomplete_stage`
  does the same via the sentinel; `test_foreign_directory_is_still_refused`
  guards the widened heuristic; `test_old_quarantine_dirs_are_reaped` covers the
  reaper.
- **P3** `test_looks_like_hal0_install_reads_past_512_bytes` on a repo-shaped
  tree with no `VERSION`, plus the foreign-pyproject negative.

One existing assertion was updated: the preview cosign-subprocess rehearsal
asserted the artifact is verified at the *cache* path, which is exactly the
behaviour this PR removes; it now asserts the staging-dir shape instead.

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/system -x -q
418 passed in 9.60s

HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/test_updater_routes.py tests/installer -q
391 passed, 1 skipped

ruff check src tests            → All checks passed
mypy src                        → 9 errors in updater.py, identical to the pre-change baseline (no new)
scripts/check_sunset.py         → scar markers 192 <= baseline 193; no overdue shims
```

## Out of scope / follow-ups

- Concurrent `prepare()` calls for the same version still share the install path
  and are not serialized (pre-existing residual, documented in `stage_release`).
  The staging dirs are now per-call and unique, so they no longer contribute to
  it.
- The staging dir lives on the same filesystem as the install root rather than
  `/var/lib` — one release tarball of transient extra space there during a stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)