### PR TITLE
fix(slots): canonicalize --flag=value form before denylist matching

### DIFF
--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -169,6 +169,18 @@ def _is_flag(tok: str) -> bool:
 
 
 def _canon(flag: str) -> str:
+    """Canonicalize a flag token for dedup/denylist matching.
+
+    Handles the GNU ``--long=value`` join form by splitting off the ``=value``
+    suffix before the alias lookup — otherwise ``--model=/etc/passwd`` never
+    equals ``--model`` and sails past every exact-string denylist check
+    (``MANAGED_ARGS_DENYLIST``/``SLOT_HARDWARE_FLAGS``) despite being
+    equivalent to the two-token form. Only ``--long`` flags use this form;
+    short flags (``-b``) don't take an ``=`` join in practice, so they're left
+    alone.
+    """
+    if flag.startswith("--") and "=" in flag:
+        flag = flag.split("=", 1)[0]
     return FLAG_ALIASES.get(flag, flag)
 
 

--- a/tests/slots/test_argv.py
+++ b/tests/slots/test_argv.py
@@ -330,6 +330,25 @@ def test_resolve_argv_rejects_multiple_managed_flags_in_one_extra_args() -> None
     assert exc_info.value.details["flags"] == ["--model", "--port"]
 
 
+def test_resolve_argv_rejects_managed_flag_equals_form_in_extra_args() -> None:
+    """GNU ``--flag=value`` join form must canonicalize the same as the
+    two-token form — a caller can't bypass the §21.7 denylist just by using
+    ``=`` instead of a space."""
+    segments = [*_BASE_SEGMENTS, ("extra_args", ["--host=0.0.0.0"])]
+    with pytest.raises(BadRequest) as exc_info:
+        resolve_argv(segments)
+    assert exc_info.value.code == "slot.managed_arg_denied"
+
+
+def test_resolve_argv_rejects_managed_flag_equals_form_in_slot_profile() -> None:
+    """The #1636 ``slot_profile`` untrusted segment is equally exposed to the
+    ``=`` join-form bypass."""
+    segments = [*_BASE_SEGMENTS, ("slot_profile", ["--model=/etc/passwd"])]
+    with pytest.raises(BadRequest) as exc_info:
+        resolve_argv(segments)
+    assert exc_info.value.code == "slot.managed_arg_denied"
+
+
 def test_resolve_argv_allows_clean_extra_args() -> None:
     """A slot's real extra_args (bench tuning, no managed flags) passes through."""
     segments = [*_BASE_SEGMENTS, ("extra_args", ["--flash-attn", "on", "--threads", "8"])]


### PR DESCRIPTION
## Summary

- `_canon()` did `FLAG_ALIASES.get(flag, flag)` on the raw token with no handling of the GNU `--flag=value` join form, so `--model=/etc/passwd` or `--host=0.0.0.0` never canonicalized to `--model`/`--host` and sailed past `_deny_managed_flags`/`_deny_slot_hardware_flags`/`strip_managed_flags` — all exact-string checks against the canon key.
- Pre-existing on `extra_args`/`model_extra_args`; also affects the #1636 `slot_profile` untrusted segment.
- Fix: split `--long=value` at the `=` during canonicalization so the flag half matches the denylist while the emitted token keeps the value.

Closes #1741

## Test plan

- [x] Red-first: `resolve_argv([("slot_profile", ["--model=/etc/passwd"])])` and `("extra_args", ["--host=0.0.0.0"])` raised `DID NOT RAISE` before the fix
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slots tests/profiles tests/api -q` → 2526 passed, 1 skipped (environmental)

🤖 Generated with [Claude Code](https://claude.com/claude-code)