### PR TITLE
fix(seam): allow-list quadlet bodies and drop the raw write-unit verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ applying. Add those subsections to a version's section to surface them; see
   loud error and nothing is written. The wrapper persists the validated
   reconstruction rather than raw stdin, and a new side-effect-free
   `check-dropin <gateway|hindsight>` verb dry-runs the allow-list.
+- The same wrapper's `write-quadlet` verb now allow-lists its body too, and the
+  raw-stdin `write-unit` verb is **removed**. A `.container` file is not just a
+  container spec — podman's quadlet generator copies its `[Unit]`, `[Service]`
+  and `[Install]` sections verbatim into the generated system unit — so an
+  unvalidated body meant a process compromised as the unprivileged `hal0`
+  account could write `[Service] ExecStartPre=/bin/sh -c '…'`, then use the
+  wrapper's own `daemon-reload` + `start` verbs for an unconditional root exec.
+  The root side now accepts only the sections, directive keys and value shapes
+  the one renderer (`_render_quadlet_from_plan`) emits, in that order, each at
+  most once, and writes its own validated reconstruction. `write-unit` had no
+  producer left after the Quadlet migration and no render contract to
+  allow-list against, so it was deleted rather than guessed at. A new
+  side-effect-free `check-quadlet [<slot-id>]` verb dry-runs the allow-list.
+  **Scope, stated honestly:** this closes the direct host-side exec primitive;
+  it does not make an `hal0`-account compromise non-root-equivalent, because
+  slots run under rootful podman and a slot's `[Container]` section
+  legitimately carries config-derived `Image=`/`Volume=`/`AddDevice=`/
+  `PodmanArgs=`/`Exec=` values. Containing *that* means running slots rootless
+  or pinning mount roots.
 
 ## [1.0.0-rc.3] — 2026-08-09
 

--- a/docs/operate/services.mdx
+++ b/docs/operate/services.mdx
@@ -54,7 +54,16 @@ WantedBy=multi-user.target
 - **User/group** — `hal0:hal0`. Root-only operations (writing per-slot
   units, `daemon-reload`, restarting itself during an update) go through a
   narrow `sudo -n` wrapper (`hal0-systemctl`) rather than running the daemon
-  as root.
+  as root. Every wrapper verb that takes a payload on stdin allow-lists that
+  payload on the root side and writes its own validated reconstruction, so a
+  hand-crafted unit body cannot smuggle a host-side `ExecStartPre=` or
+  `User=root` past it. Use `hal0-systemctl check-quadlet < unit` (or
+  `check-dropin <gateway|hindsight> < body`) to see why something was refused;
+  both validate and echo without writing anything. Note the limit of that
+  boundary: slots run under rootful podman and a slot's `[Container]` section
+  legitimately mounts host paths and passes through devices, so an attacker who
+  owns the `hal0` account can still author a privileged container. The wrapper
+  is a check on the unit *file*, not a sandbox around slot content.
 - **WorkingDirectory** — the `current` symlink in a production install, so
   `hal0 update`'s atomic swap moves it without rewriting the unit.
 - **ExecStart** — no `--host` flag. The bind host comes from

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -288,7 +288,13 @@ _QRE_DEVICE='^[A-Za-z0-9_./:=-]{1,255}$'
 _QRE_CAP='^[A-Za-z0-9_]{1,64}$'
 _QRE_VOLUME='^[A-Za-z0-9_./:,+@%=-]{1,512}$'
 _QRE_ENV='^[A-Za-z_][A-Za-z0-9_]*=.{0,1024}$'
-_QRE_PUBLISH='^[0-9A-Fa-f.:]{1,45}:[0-9]{1,5}:[0-9]{1,5}$'
+# host:hostport:ctrport. The host is [slots].publish_host, which its schema
+# validator (_publish_host_sane) already constrains to a bare IPv4 or hostname
+# — no spaces, ':' or '/' — so the host segment here is colon-free; IPv6
+# literals are unsupported at that layer. A bare-IPv4-only charset would
+# false-reject the documented hostname case (e.g. hal0.local) and brick every
+# bridge-mode slot on such a box.
+_QRE_PUBLISH='^[A-Za-z0-9._-]{1,253}:[0-9]{1,5}:[0-9]{1,5}$'
 _QRE_DURATION='^[0-9]{1,9}(ns|us|ms|s|m|h|d|w)?$'
 _QRE_RETRIES='^[0-9]{1,4}$'
 _QRE_RESTART='^(always|on-failure|no)$'

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -34,6 +34,37 @@
 # validate_dropin_body below. The unprivileged caller's own templating is a
 # convenience, never a control.
 #
+# QUADLET CONTENT (#1740): the same hole was still open one case arm below.
+# `write-quadlet` installed its whole stdin verbatim as a root-owned
+# /etc/containers/systemd/hal0-slot@<id>.container. A .container file is NOT
+# just a container spec: podman's generator copies its `[Unit]`, `[Service]`
+# and `[Install]` sections through VERBATIM into the generated system unit, so
+# a `[Service]` with `ExecStartPre=/bin/sh -c '…'` plus this wrapper's own
+# `daemon-reload` + `start` verbs was an unconditional root exec — no container
+# involved. `write-unit` (a raw /etc/systemd/system/*.service write) was the
+# same hole with no validation possible at all; it had no producer left after
+# P3-quadlet and is DELETED rather than guessed at. What remains is
+# validate_quadlet_body below: an allow-list of exactly the sections, keys and
+# value shapes _render_quadlet_from_plan (src/hal0/providers/container.py)
+# emits, and — as with the drop-ins — the validated RECONSTRUCTION is what is
+# written, never raw stdin.
+#
+# HONEST BOUNDARY (read this before calling the seam a sandbox): the allow-list
+# removes the DIRECT host-side exec primitive — no host `[Service]`/`[Unit]`
+# directive beyond the five/three fixed ones, no `Exec*=` on the host side, no
+# `User=`/`Group=`, no second section, no `[Install] WantedBy=` other than
+# hal0.target. It does NOT make an hal0-account compromise non-root-equivalent:
+# `[Container]` legitimately carries `Image=`, `Volume=`, `AddDevice=`,
+# `PodmanArgs=` and `Exec=`, whose values are operator/config-derived and cannot
+# be pinned here (the model-store and data roots are runtime config, and a
+# path allow-list would be bypassable via a symlink under a root the hal0 user
+# already owns). Slots run under ROOTFUL podman, so anyone who can author a
+# slot's container spec can mount host paths into a container they control.
+# That is a property of the slot feature itself, not of this wrapper; the
+# containment for it is "run slots rootless / pin mount roots", tracked
+# separately. Claim only what is true: this seam is a *syntactic* boundary on
+# the unit file, and a hard boundary against direct host exec.
+#
 # NOTE: the iptables FORWARD-chain repair the original P3-perms design doc
 # sketched for this seam is NOT needed — that repair already runs as its own
 # independent root oneshot unit (packaging/systemd/hal0-podman-forward.service,
@@ -213,14 +244,187 @@ validate_dropin_body() {  # arg: kind (gateway|hindsight); body on stdin
   DROPIN_BODY="$out"
 }
 
+# ── quadlet content allow-list (#1740) ─────────────────────────────────────
+#
+# Root-side validation for `write-quadlet`. Same design as the drop-in
+# allow-list above — closed key set, pinned value charsets, validated
+# reconstruction written instead of raw stdin — but over the richer grammar
+# `_render_quadlet_from_plan` actually emits:
+#
+#   # comment lines (the two generated-by banners)
+#   [Unit]      Description= StartLimitIntervalSec= StartLimitBurst=
+#   [Container] Image= ContainerName= LogDriver= Network= AddDevice=
+#               AddCapability= PodmanArgs= Volume= Environment= PublishPort=
+#               HealthCmd= HealthStartPeriod= HealthInterval= HealthRetries=
+#               HealthTimeout= Exec=
+#   [Service]   Restart= RestartSec= SyslogIdentifier= StandardOutput=
+#               StandardError=
+#   [Install]   WantedBy=hal0.target        (omitted when autoload = false)
+#
+# Sections may appear at most once and only in that order; [Container] is
+# mandatory. Every other section (`[Unit]`-lookalikes, a second `[Service]`,
+# `[Path]`, `[Timer]`, …) and every key outside its section's list is refused,
+# which is what closes the ExecStartPre/User=root smuggling path. Leading
+# whitespace, `Key = v`, `;` comments, CR/tab/NUL and any other control byte,
+# and a trailing backslash (systemd line continuation, which would hide a
+# second logical directive on a value line) are all refused too.
+#
+# See the HONEST BOUNDARY note in the header for what this deliberately does
+# NOT claim: [Container] values are config-derived and only charset-pinned.
+
+QUADLET_BODY=""
+
+_QUADLET_MAX_LINES=400
+_QUADLET_MAX_LINE=4096
+
+# Value patterns, kept as named variables so the case arms below read as a
+# table and the regexes are not re-quoted per use.
+_QRE_DESCRIPTION='^hal0 container inference slot \([A-Za-z0-9_.-]{1,64}\)$'
+_QRE_UINT='^[0-9]{1,9}$'
+_QRE_IMAGE='^[A-Za-z0-9][A-Za-z0-9._/:@-]{0,254}$'
+_QRE_CTRNAME='^hal0-slot-[A-Za-z0-9_.-]{1,64}$'
+_QRE_NETWORK='^[A-Za-z0-9_.:-]{1,64}$'
+_QRE_DEVICE='^[A-Za-z0-9_./:=-]{1,255}$'
+_QRE_CAP='^[A-Za-z0-9_]{1,64}$'
+_QRE_VOLUME='^[A-Za-z0-9_./:,+@%=-]{1,512}$'
+_QRE_ENV='^[A-Za-z_][A-Za-z0-9_]*=.{0,1024}$'
+_QRE_PUBLISH='^[0-9A-Fa-f.:]{1,45}:[0-9]{1,5}:[0-9]{1,5}$'
+_QRE_DURATION='^[0-9]{1,9}(ns|us|ms|s|m|h|d|w)?$'
+_QRE_RETRIES='^[0-9]{1,4}$'
+_QRE_RESTART='^(always|on-failure|no)$'
+_QRE_WANTEDBY='^hal0\.target$'
+
+_quadlet_die() { die "quadlet rejected: $1"; }
+
+validate_quadlet_directive() {  # args: section, "Key=Value" line
+  local section="$1" line="$2" key value
+  [[ "$line" == *=* ]] || _quadlet_die "not a Key=Value directive: $line"
+  key="${line%%=*}"
+  value="${line#*=}"
+  # No spaces, no tabs, no quoting around the key: `Key = v` / ` Key=v` are
+  # refused rather than normalised, so there is one accepted spelling per
+  # directive and no second parse to disagree with systemd's.
+  [[ "$key" =~ ^[A-Za-z][A-Za-z0-9]*$ ]] || _quadlet_die "bad directive key: $key"
+
+  case "${section}|${key}" in
+    # ── [Unit] ──────────────────────────────────────────────────────────
+    # Only the three the renderer emits. Notably absent, and refused:
+    # OnFailure=, Requires=, ConditionPathExists= and every other unit key.
+    'Unit|Description')            [[ "$value" =~ $_QRE_DESCRIPTION ]] || _quadlet_die "bad Description: $value" ;;
+    'Unit|StartLimitIntervalSec')  [[ "$value" =~ $_QRE_UINT ]]        || _quadlet_die "bad StartLimitIntervalSec: $value" ;;
+    'Unit|StartLimitBurst')        [[ "$value" =~ $_QRE_UINT ]]        || _quadlet_die "bad StartLimitBurst: $value" ;;
+
+    # ── [Container] ─────────────────────────────────────────────────────
+    # Charset-pinned, not semantics-pinned — see the HONEST BOUNDARY note.
+    'Container|Image')          [[ "$value" =~ $_QRE_IMAGE ]]    || _quadlet_die "bad Image: $value" ;;
+    'Container|ContainerName')  [[ "$value" =~ $_QRE_CTRNAME ]]  || _quadlet_die "bad ContainerName: $value" ;;
+    'Container|LogDriver')      [[ "$value" == "none" ]]         || _quadlet_die "bad LogDriver: $value" ;;
+    'Container|Network')        [[ "$value" =~ $_QRE_NETWORK ]]  || _quadlet_die "bad Network: $value" ;;
+    'Container|AddDevice')
+      [[ "$value" =~ $_QRE_DEVICE ]] || _quadlet_die "bad AddDevice: $value"
+      [[ "$value" != *".."* ]] || _quadlet_die "AddDevice traversal: $value"
+      ;;
+    'Container|AddCapability')  [[ "$value" =~ $_QRE_CAP ]]      || _quadlet_die "bad AddCapability: $value" ;;
+    'Container|Volume')
+      [[ "$value" =~ $_QRE_VOLUME ]] || _quadlet_die "bad Volume: $value"
+      [[ "$value" != *".."* ]] || _quadlet_die "Volume traversal: $value"
+      ;;
+    'Container|Environment')    [[ "$value" =~ $_QRE_ENV ]]      || _quadlet_die "bad Environment: $value" ;;
+    'Container|PublishPort')    [[ "$value" =~ $_QRE_PUBLISH ]]  || _quadlet_die "bad PublishPort: $value" ;;
+    'Container|HealthCmd')      [[ -n "$value" ]]                || _quadlet_die "empty HealthCmd" ;;
+    'Container|HealthStartPeriod'|'Container|HealthInterval'|'Container|HealthTimeout')
+      [[ "$value" =~ $_QRE_DURATION ]] || _quadlet_die "bad $key: $value" ;;
+    'Container|HealthRetries')  [[ "$value" =~ $_QRE_RETRIES ]]  || _quadlet_die "bad HealthRetries: $value" ;;
+    # PodmanArgs= is podman's own flag passthrough (--group-add/--security-opt,
+    # plus the deprecated extra_args escape hatch) and Exec= is the argv INSIDE
+    # the container. Neither has a fixed shape in the render contract, so both
+    # are bounded (non-empty, control-byte-free, length-capped by the per-line
+    # check) and nothing more. Constraining them further would buy nothing while
+    # Volume=/AddDevice= remain open — see HONEST BOUNDARY.
+    'Container|PodmanArgs')     [[ -n "$value" ]]                || _quadlet_die "empty PodmanArgs" ;;
+    'Container|Exec')           [[ -n "$value" ]]                || _quadlet_die "empty Exec" ;;
+
+    # ── [Service] ───────────────────────────────────────────────────────
+    # Copied VERBATIM into the generated system unit by podman's quadlet
+    # generator — i.e. host-side root. Exactly the five the renderer emits;
+    # every Exec*=, User=, Group=, WorkingDirectory=, … lands in the default
+    # arm below and dies.
+    'Service|Restart')           [[ "$value" =~ $_QRE_RESTART ]] || _quadlet_die "bad Restart: $value" ;;
+    'Service|RestartSec')        [[ "$value" =~ $_QRE_UINT ]]    || _quadlet_die "bad RestartSec: $value" ;;
+    'Service|SyslogIdentifier')  [[ "$value" =~ $_QRE_CTRNAME ]] || _quadlet_die "bad SyslogIdentifier: $value" ;;
+    'Service|StandardOutput')    [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardOutput: $value" ;;
+    'Service|StandardError')     [[ "$value" == "journal" ]]     || _quadlet_die "bad StandardError: $value" ;;
+
+    # ── [Install] ───────────────────────────────────────────────────────
+    # hal0.target only: a WantedBy= on any other target would let a slot unit
+    # be pulled into an arbitrary boot path.
+    'Install|WantedBy')          [[ "$value" =~ $_QRE_WANTEDBY ]] || _quadlet_die "bad WantedBy: $value" ;;
+
+    *) _quadlet_die "directive not allowed in [$section]: $key" ;;
+  esac
+}
+
+validate_quadlet_body() {  # body on stdin -> QUADLET_BODY
+  local LC_ALL=C
+  local line out="" section="" rank=0 next_rank directives=0 seen_container=0
+  local -a lines=()
+
+  mapfile -t lines
+  (( ${#lines[@]} <= _QUADLET_MAX_LINES )) \
+    || _quadlet_die "too many lines (${#lines[@]} > ${_QUADLET_MAX_LINES})"
+
+  for line in "${lines[@]}"; do
+    (( ${#line} <= _QUADLET_MAX_LINE )) || _quadlet_die "line too long (${#line} bytes)"
+    # One check kills CR, tab, NUL and the rest of C0/DEL, so nothing can
+    # smuggle a second logical line or an invisible directive. High bytes stay
+    # legal (the banner comments and Description= are UTF-8 prose).
+    [[ ! "$line" =~ [[:cntrl:]] ]] || _quadlet_die "control byte in line: $line"
+    [[ "$line" != *\\ ]] || _quadlet_die "line continuation: $line"
+
+    case "$line" in
+      "")   ;;                                          # blank line
+      "#"*) ;;                                          # banner comment
+      "["*)
+        case "$line" in
+          "[Unit]")      next_rank=1 ;;
+          "[Container]") next_rank=2; seen_container=1 ;;
+          "[Service]")   next_rank=3 ;;
+          "[Install]")   next_rank=4 ;;
+          *) _quadlet_die "section not allowed: $line" ;;
+        esac
+        # Strictly increasing: each section at most once, and only in the
+        # order the renderer emits them. A second [Service] (the classic
+        # override-smuggling trick) fails here even though [Service] itself
+        # is a legal section.
+        (( next_rank > rank )) || _quadlet_die "section out of order or duplicated: $line"
+        rank=$next_rank
+        section="${line:1:${#line}-2}"
+        ;;
+      *)
+        [[ -n "$section" ]] || _quadlet_die "directive before any section: $line"
+        validate_quadlet_directive "$section" "$line"
+        directives=$(( directives + 1 ))
+        ;;
+    esac
+    out+="${line}"$'\n'
+  done
+
+  (( seen_container == 1 )) || _quadlet_die "no [Container] section"
+  (( directives > 0 )) || _quadlet_die "no allowed directives in body"
+  QUADLET_BODY="$out"
+}
+
 cmd="${1:-help}"; shift || true
 
 case "$cmd" in
-  write-unit)                 # write-unit <slot-id>   (unit body on stdin)
-    id="${1:-}"; validate_slot_id "$id"
-    path="${UNIT_DIR}/${UNIT_PREFIX}${id}.service"
-    install -m 0644 -o root -g root /dev/stdin "$path"
-    ;;
+  # write-unit was REMOVED in #1740. It installed an unvalidated stdin as a
+  # root-owned /etc/systemd/system/hal0-slot@<id>.service — an unconditional
+  # root exec primitive — and P3-quadlet left it with no producer at all: the
+  # sole renderer of slot-unit text (_render_quadlet_from_plan) emits a
+  # `.container`, written through write-quadlet. There is no render contract
+  # left to derive an allow-list from, so the verb is deleted rather than
+  # guessed at. remove-unit stays: it only ever rm -f's a pinned name, and
+  # legacy pre-quadlet .service files still need cleaning up.
 
   remove-unit)                # remove-unit <slot-id>   (rm -f semantics: ok if absent)
     id="${1:-}"; validate_slot_id "$id"
@@ -228,9 +432,24 @@ case "$cmd" in
     ;;
 
   write-quadlet)              # write-quadlet <slot-id>   (.container body on stdin)
+    # #1740: the body is allow-listed BEFORE anything is created, and what
+    # lands in /etc/containers/systemd is the validated reconstruction
+    # ($QUADLET_BODY), never raw stdin. Atomic (tmp + mv) like the drop-in
+    # arms — `install /dev/stdin` misbehaves overwriting an existing target
+    # when the source is a pipe, and a half-written .container would make the
+    # next daemon-reload drop the slot's generated unit entirely.
     id="${1:-}"; validate_slot_id "$id"
+    validate_quadlet_body
+    quadlet_path="${QUADLET_DIR}/${UNIT_PREFIX}${id}.container"
     install -d -m 0755 -o root -g root "$QUADLET_DIR"
-    install -m 0644 -o root -g root /dev/stdin "${QUADLET_DIR}/${UNIT_PREFIX}${id}.container"
+    umask 022
+    tmp="$(mktemp "${quadlet_path}.XXXXXX")"
+    trap 'rm -f "$tmp"' EXIT
+    printf '%s' "$QUADLET_BODY" > "$tmp"
+    chown root:root "$tmp"
+    chmod 0644 "$tmp"
+    mv -f "$tmp" "$quadlet_path"
+    trap - EXIT
     ;;
 
   remove-quadlet)             # remove-quadlet <slot-id>   (rm -f semantics: ok if absent)
@@ -287,6 +506,18 @@ case "$cmd" in
     kind="${1:-}"
     validate_dropin_body "$kind"
     printf '%s' "$DROPIN_BODY"
+    ;;
+
+  check-quadlet)              # check-quadlet [<slot-id>]   (.container body on stdin)
+    # Side-effect-free dry run of the #1740 allow-list: validates the optional
+    # slot id and the body, then echoes back exactly what a write would
+    # persist, or dies 64 with the reason. Writes nothing, touches no unit,
+    # reloads nothing — it exists so the allow-list can be exercised (by the
+    # test suite against the SHIPPED bash, and by an operator debugging a
+    # rejected unit) without a privileged write.
+    if (( $# > 0 )); then validate_slot_id "${1:-}"; fi
+    validate_quadlet_body
+    printf '%s' "$QUADLET_BODY"
     ;;
 
   daemon-reload)
@@ -357,13 +588,13 @@ case "$cmd" in
   help|"")
     cat <<EOF
 usage: hal0-systemctl <command> [slot-id|agent-id]
-  write-unit <slot-id>             write ${UNIT_DIR}/${UNIT_PREFIX}<id>.service (body on stdin)
-  remove-unit <slot-id>            rm -f ${UNIT_DIR}/${UNIT_PREFIX}<id>.service
-  write-quadlet <slot-id>          write ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container (body on stdin)
+  remove-unit <slot-id>            rm -f ${UNIT_DIR}/${UNIT_PREFIX}<id>.service (legacy pre-quadlet)
+  write-quadlet <slot-id>          write ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container (allow-listed body on stdin)
   remove-quadlet <slot-id>         rm -f ${QUADLET_DIR}/${UNIT_PREFIX}<id>.container
   write-gateway-dropin             write ${GATEWAY_DROPIN_FILE} (body on stdin)
   write-hindsight-dropin           write ${HINDSIGHT_DROPIN_FILE} (body on stdin)
   check-dropin <gateway|hindsight> validate a drop-in body (stdin) without writing it
+  check-quadlet [<slot-id>]        validate a .container body (stdin) without writing it
   daemon-reload                    systemctl daemon-reload
   start|stop|restart <slot-id>     systemctl <verb> ${UNIT_PREFIX}<id>.service
   enable|disable <slot-id>         systemctl <verb> ${UNIT_PREFIX}<id>.service

--- a/packaging/sudoers/hal0-systemctl
+++ b/packaging/sudoers/hal0-systemctl
@@ -2,15 +2,33 @@
 #
 # hal0-api runs as the unprivileged `hal0` system user (User=hal0,
 # installer/install.sh). It delegates the genuinely-root slot-lifecycle ops —
-# writing a per-slot unit under /etc/systemd/system, writing the fixed
-# hermes-gateway secrets drop-in, daemon-reload,
+# writing a per-slot Podman Quadlet under /etc/containers/systemd, writing the
+# fixed hermes-gateway and hindsight-api drop-ins, daemon-reload,
 # start/stop/restart/enable/disable/reset-failed of a slot unit,
 # stop/disable of a bundled-agent unit (hal0-agent@<id>.service, the #453
 # uninstall teardown), and restarting itself on self-update — to
 # /usr/lib/hal0/bin/hal0-systemctl, which is the entire privileged surface:
 # the helper validates every slot id AND every agent id (strict identifier
-# regexes), builds every unit name and target path itself (the gateway drop-in
-# path is a literal), never evaluates a shell, and accepts no wildcards.
+# regexes), builds every unit name and target path itself (the drop-in paths
+# are literals), never evaluates a shell, and accepts no wildcards.
+#
+# CONTENT, not just argv (#1716 + #1740): every verb that takes a payload on
+# stdin — write-gateway-dropin, write-hindsight-dropin, write-quadlet — parses
+# that payload against a root-side ALLOW-LIST of the exact sections, directive
+# keys and value shapes its renderer emits, and writes its own validated
+# reconstruction rather than the bytes it was handed. The raw-stdin verb
+# write-unit was deleted in #1740. Without this the grant was effectively
+# "hal0 may run any command as root": a .container carries [Service] straight
+# into the generated system unit, so an ExecStartPre= plus this helper's own
+# daemon-reload + start verbs was a one-shot root exec.
+#
+# WHAT THIS GRANT DOES *NOT* CLAIM: it is not a sandbox around slot content.
+# Slots run under rootful podman, and a slot's [Container] section legitimately
+# carries Image=/Volume=/AddDevice=/PodmanArgs=/Exec= whose values come from
+# runtime config, so an attacker who owns the hal0 account can still author a
+# container that mounts host paths. Closing THAT means running slots rootless
+# or pinning mount roots — not a sudoers change. See the HONEST BOUNDARY note
+# at the top of installer/wrappers/hal0-systemctl.
 #
 # NOTE: the grant is pinned to the helper BINARY, not to an argv list, so
 # adding stop-agent/disable-agent needs no sudoers change — the helper's own

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -255,20 +255,14 @@ class SystemCtlSeam:
     def _seam_argv(self, *parts: str) -> list[str]:
         return ["sudo", "-n", self._seam_bin, *parts]
 
-    def write_unit(self, unit_path: Path, unit_text: str) -> None:
-        """Write a ``hal0-slot@<id>.service`` unit file."""
-        if not self._is_hal0_user():
-            unit_path.write_text(unit_text)
-            return
-        slot_id = _slot_id_from_unit(unit_path.name)
-        if slot_id is None:
-            raise ValueError(f"not a hal0-slot@ unit: {unit_path.name!r}")
-        self._run(
-            self._seam_argv("write-unit", slot_id),
-            input=unit_text,
-            text=True,
-            check=True,
-        )
+    # ``write_unit`` (and the wrapper's ``write-unit`` verb) were REMOVED in
+    # #1740. It shipped an unvalidated body to a root-owned
+    # ``/etc/systemd/system/hal0-slot@<id>.service`` — an unconditional root
+    # exec primitive reachable from the unprivileged hal0 account — and
+    # P3-quadlet had already left it with no producer: the sole renderer of
+    # slot-unit text (``_render_quadlet_from_plan``) emits a ``.container``,
+    # written via :meth:`write_quadlet`. ``remove_unit`` stays for legacy
+    # pre-quadlet ``.service`` cleanup.
 
     def remove_unit(self, unit_path: Path) -> None:
         """Delete a ``hal0-slot@<id>.service`` unit file (no-op if absent)."""
@@ -285,11 +279,19 @@ class SystemCtlSeam:
     def write_quadlet(self, quadlet_path: Path, unit_text: str) -> None:
         """Write a ``hal0-slot@<token>.container`` Quadlet source file (P3-quadlet).
 
-        The declarative Quadlet replacement for :meth:`write_unit`: root-owned by
-        design under ``/etc/containers/systemd/``, so a hal0-service-user install
-        routes the write through ``hal0-systemctl write-quadlet <token>`` (body on
-        stdin). Dev/CI/test (not the hal0 user) writes directly, exactly as
-        before P3-perms.
+        The declarative Quadlet replacement for the removed ``write_unit``:
+        root-owned by design under ``/etc/containers/systemd/``, so a
+        hal0-service-user install routes the write through ``hal0-systemctl
+        write-quadlet <token>`` (body on stdin). Dev/CI/test (not the hal0 user)
+        writes directly, exactly as before P3-perms.
+
+        #1740: ``unit_text`` is NOT trusted by the root side. The wrapper
+        allow-lists the body against exactly the sections/keys
+        ``_render_quadlet_from_plan`` emits and persists its own validated
+        reconstruction, so a body this (unprivileged) process could tamper with
+        can no longer carry a host-side ``[Service] ExecStartPre=``. Rendering
+        here is a convenience, never the control — see the wrapper's HONEST
+        BOUNDARY note for what the allow-list does and does not claim.
         """
         if not self._is_hal0_user():
             quadlet_path.parent.mkdir(parents=True, exist_ok=True)
@@ -324,7 +326,7 @@ class SystemCtlSeam:
     ) -> None:
         """Write the hindsight-api extraction drop-in (#1641).
 
-        Unlike :meth:`write_unit` / :meth:`write_quadlet` there is no id to
+        Unlike :meth:`write_quadlet` there is no id to
         validate: the target is a single fixed file, so the seam verb takes only
         the body on stdin and the root side owns the path outright (the
         ``write-gateway-dropin`` posture). ``path`` is therefore used **only** on

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,16 +128,16 @@ def _reject_privileged_systemctl(argv: object) -> None:
     if program in _SEAM_BIN_NAMES:
         # Seam verbs are `<systemctl-verb>` (slot family) or
         # `<systemctl-verb>-agent` (agent family); both mutate. The
-        # non-systemctl file verbs (write-unit, write-quadlet, ...) mutate
+        # non-systemctl file verbs (write-quadlet, remove-unit, ...) mutate
         # /etc as root, which a test must never do either.
         #
-        # `help` and `check-dropin` are the exceptions: both are pure — they
-        # read stdin/argv, write nothing, and never touch systemd. Running the
-        # real script IS the point for those (tests/installer's #1716 suite
-        # exercises the root-side drop-in allow-list against the shipped bash),
-        # and neither needs sudo or root.
+        # `help`, `check-dropin` and `check-quadlet` are the exceptions: all
+        # three are pure — they read stdin/argv, write nothing, and never touch
+        # systemd. Running the real script IS the point for those
+        # (tests/installer's #1716 + #1740 suites exercise the root-side
+        # allow-lists against the shipped bash), and none needs sudo or root.
         seam_verb = next((p for p in inner[1:] if not p.startswith("-")), "")
-        if seam_verb and seam_verb not in {"help", "", "check-dropin"}:
+        if seam_verb and seam_verb not in {"help", "", "check-dropin", "check-quadlet"}:
             raise AssertionError(
                 f"test tried to run the hal0-systemctl privilege seam for real: {parts!r}. "
                 "Inject a fake runner (or patch hal0.system.seam.agent_unit_argv) instead — "

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -1,0 +1,309 @@
+"""#1740 — root-side content allow-list for the ``write-quadlet`` verb.
+
+``installer/wrappers/hal0-systemctl`` is reachable as root by the unprivileged
+``hal0`` service account (packaging/sudoers/hal0-systemctl), so *stdin* is
+attacker-controlled at a privilege boundary. ``write-quadlet`` used to
+``install /dev/stdin`` verbatim into
+``/etc/containers/systemd/hal0-slot@<id>.container``.
+
+A ``.container`` file is not merely a container spec: podman's quadlet
+generator copies its ``[Unit]``, ``[Service]`` and ``[Install]`` sections
+through VERBATIM into the generated system unit. So a ``[Service]`` carrying
+``ExecStartPre=/bin/sh -c 'id>/root/pwned'``, followed by this same wrapper's
+``daemon-reload`` + ``start`` verbs, was an unconditional root exec — no
+container escape required. #1718 closed exactly this hole for the two drop-in
+verbs and left this one open.
+
+These tests exercise the *real* bash wrapper through its side-effect-free
+``check-quadlet`` verb (the same validator the write arm calls), so they need
+no root, no sudo and no provisioned box — the #1718 suite's posture.
+
+The legitimate bodies come from the actual renderer
+(:func:`hal0.providers.container._render_quadlet_from_plan`, the ONE producer
+of slot-unit text) rather than being retyped, so a renderer change the
+allow-list would reject fails here instead of on a production host.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hal0.providers.base import HealthCheck, Mount, RuntimeLaunchPlan
+from hal0.providers.container import ContainerProvider, _render_quadlet_from_plan
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-systemctl"
+
+
+def _check(body: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the real wrapper's validator over ``body``. rc 0 = accepted."""
+    return subprocess.run(
+        [str(WRAPPER), "check-quadlet", *args],
+        input=body,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+
+def _accepts(body: str, *args: str) -> None:
+    proc = _check(body, *args)
+    assert proc.returncode == 0, f"rejected: {proc.stderr}"
+    # The write arm persists the VALIDATED reconstruction, not the raw stdin,
+    # so what is echoed here is byte-for-byte what lands in /etc.
+    assert proc.stdout == body
+
+
+def _rejects(body: str, *args: str) -> str:
+    proc = _check(body, *args)
+    assert proc.returncode == 64, f"accepted (rc={proc.returncode}): {body!r}"
+    return proc.stderr
+
+
+# ── the wrapper still parses, and the write arm actually validates ─────────
+
+
+def test_wrapper_is_syntactically_valid() -> None:
+    proc = subprocess.run(["bash", "-n", str(WRAPPER)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_write_quadlet_arm_validates_before_writing() -> None:
+    """The validator must be on the write path, not merely available: a
+    ``check-quadlet`` verb nothing calls would be security theatre."""
+    text = WRAPPER.read_text()
+    arm = text.split("  write-quadlet)", 1)[1].split("\n    ;;", 1)[0]
+    # Comments explain the history; only the executable lines are the contract.
+    code = "\n".join(ln for ln in arm.splitlines() if not ln.lstrip().startswith("#"))
+    assert "validate_quadlet_body" in code
+    # …and it writes the validated reconstruction, never raw stdin.
+    assert "QUADLET_BODY" in code
+    assert "/dev/stdin" not in code
+    assert "cat > " not in code
+
+
+def test_write_unit_verb_is_gone() -> None:
+    """``write-unit`` installed an unvalidated body as a root-owned
+    ``/etc/systemd/system/*.service``. P3-quadlet left it with no producer, so
+    there is no render contract to allow-list against — the verb is deleted."""
+    text = WRAPPER.read_text()
+    assert "\n  write-unit)" not in text
+    from hal0.system.seam import SystemCtlSeam
+
+    assert not hasattr(SystemCtlSeam, "write_unit")
+
+
+# ── the real renderer's output, byte-for-byte ──────────────────────────────
+#
+# One plan per shape the fleet actually renders. Every optional key in
+# ``_render_quadlet_from_plan`` is covered by at least one entry.
+
+_PLANS: dict[str, tuple[RuntimeLaunchPlan, dict[str, Any]]] = {
+    "minimal": (
+        RuntimeLaunchPlan(image="ghcr.io/hal0ai/hal0-toolbox-rocm:v1", command=[], network_mode=""),
+        {},
+    ),
+    "gpu-llama-bridge": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-toolbox-rocm:v1",
+            command=[
+                "/opt/llama.cpp/build/bin/llama-server",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8095",
+                "-m",
+                "/mnt/ai-models/gguf/model-Q4_K_M.gguf",
+                "--chat-template-kwargs",
+                '{"enable_thinking":false}',
+            ],
+            env={"HSA_OVERRIDE_GFX_VERSION": "11.0.0", "HIP_VISIBLE_DEVICES": "0"},
+            mounts=[
+                Mount("/mnt/ai-models", "/mnt/ai-models", read_only=True),
+                Mount("/var/lib/hal0/cache", "/cache", read_only=False, selinux="z"),
+            ],
+            devices=["/dev/kfd", "/dev/dri/renderD128"],
+            cap_add=["SYS_PTRACE"],
+            security_opt=["seccomp=unconfined", "label=disable"],
+            group_add=["44", "991"],
+            port=8095,
+            network_mode="",
+            health=HealthCheck(cmd="curl -fsS http://127.0.0.1:8095/health || exit 1"),
+        ),
+        {"publish_host": "0.0.0.0", "network_mode_default": "bridge"},
+    ),
+    "host-net-comfyui": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-comfyui:v1",
+            command=["python", "main.py", "--listen", "0.0.0.0", "--port", "8188"],
+            mounts=[Mount("/var/lib/hal0/comfyui/models", "/root/comfy-models")],
+            devices=["nvidia.com/gpu=all"],
+            port=8188,
+            network_mode="host",
+        ),
+        {},
+    ),
+    "npu-flm": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-flm:v1",
+            command=["flm", "serve", "qwen3-8b", "--port", "8110"],
+            env={"FLM_CACHE": "/cache"},
+            devices=["/dev/accel/accel0"],
+            port=8110,
+            network_mode="",
+        ),
+        {"autoload": False},
+    ),
+    "deprecated-extra-args": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+            command=["llama-server"],
+            extra_args=["--ipc=host", "--ulimit memlock=-1"],
+            port=8101,
+            network_mode="",
+        ),
+        {},
+    ),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(_PLANS))
+@pytest.mark.parametrize("token", ["chat", "slot_1", "Mixed-Case", "a" * 64])
+def test_rendered_units_are_accepted_byte_for_byte(shape: str, token: str) -> None:
+    plan, kwargs = _PLANS[shape]
+    _accepts(_render_quadlet_from_plan(token, plan, **kwargs), token)
+
+
+def test_live_container_provider_render_is_accepted() -> None:
+    """End-to-end through the production path: ``ContainerProvider.container_spec``
+    → ``_render_quadlet_from_plan``, not a hand-built plan."""
+    provider = ContainerProvider()
+    profile = MagicMock()
+    profile.image = "ghcr.io/hal0ai/hal0-toolbox-rocm:v1"
+    profile.flags = ""
+    profile.backend = "rocm"
+    profile.device_class = "gpu"
+    profile.name = "rocm"
+    slot_cfg = {
+        "name": "chat",
+        "port": 8095,
+        "profile": "rocm",
+        "model": {"default": "m", "context_size": 131072},
+    }
+    model_info = {"path": "/mnt/ai-models/model.gguf", "_model_key": "m"}
+    with (
+        patch("hal0.providers.container._resolve_profile", return_value=profile),
+        patch(
+            "hal0.providers.container.resolve_gpu_device_paths",
+            return_value=["/dev/kfd", "/dev/dri/renderD128"],
+        ),
+        patch("hal0.providers.container.resolve_gpu_group_ids", return_value=["44", "991"]),
+    ):
+        text = provider._render_quadlet_text(slot_cfg, model_info)
+    _accepts(text, "chat")
+
+
+# ── the escalation payloads ────────────────────────────────────────────────
+
+_HEAD = "[Container]\nImage=ghcr.io/hal0ai/x:v1\nContainerName=hal0-slot-chat\n"
+
+ESCALATIONS = {
+    # The #1740 primitive itself: a host-side [Service] the quadlet generator
+    # copies through verbatim.
+    "execstartpre-smuggling": f"{_HEAD}\n[Service]\nExecStartPre=/bin/sh -c 'id>/root/pwned'\n",
+    "execstart-override": f"{_HEAD}\n[Service]\nExecStart=/bin/sh -c 'id>/root/pwned'\n",
+    "execstartpost": f"{_HEAD}\n[Service]\nRestart=always\nExecStartPost=/bin/sh -c ':'\n",
+    "execstop": f"{_HEAD}\n[Service]\nExecStop=/bin/sh -c ':'\n",
+    "execreload": f"{_HEAD}\n[Service]\nExecReload=/bin/sh -c ':'\n",
+    "user-root": f"{_HEAD}\n[Service]\nRestart=always\nUser=root\n",
+    "group-root": f"{_HEAD}\n[Service]\nRestart=always\nGroup=root\n",
+    "second-service-section": (
+        f"{_HEAD}\n[Service]\nRestart=always\n\n[Service]\nExecStartPre=/bin/sh\n"
+    ),
+    "second-container-section": f"{_HEAD}\n[Container]\nImage=evil\n",
+    "service-before-container": f"[Service]\nExecStart=/bin/sh\n\n{_HEAD}",
+    "unit-after-container": f"{_HEAD}\n[Unit]\nDescription=x\n",
+    "unknown-section": f"{_HEAD}\n[Timer]\nOnCalendar=*-*-* *:*:00\n",
+    "unit-onfailure": f"[Unit]\nOnFailure=evil.service\n\n{_HEAD}",
+    "unit-condition": f"[Unit]\nConditionPathExists=/tmp/x\n\n{_HEAD}",
+    "install-other-target": f"{_HEAD}\n[Install]\nWantedBy=multi-user.target\n",
+    "install-also": f"{_HEAD}\n[Install]\nAlso=evil.service\n",
+    "line-continuation": f"{_HEAD}\n[Service]\nRestart=always \\\nExecStartPre=/bin/sh\n",
+    "crlf-body": f"{_HEAD}\n[Service]\r\nExecStartPre=/bin/sh\n",
+    "cr-inside-directive": f"{_HEAD}\n[Service]\nRestart=always\rUser=root\n",
+    "tab-indented-directive": f"{_HEAD}\n[Service]\n\tUser=root\n",
+    "leading-whitespace-directive": f"{_HEAD}\n[Service]\n  User=root\n",
+    "spaced-key": f"{_HEAD}\n[Service]\nUser = root\n",
+    "semicolon-comment-then-directive": f"{_HEAD}\n[Service]\n; note\nUser=root\n",
+    "directive-before-section": "Image=ghcr.io/hal0ai/x:v1\n[Container]\nImage=x\n",
+    "no-section": "ExecStartPre=/bin/sh\n",
+    "empty-body": "",
+    "section-only": "[Container]\n",
+    "no-container-section": "[Unit]\nStartLimitBurst=5\n",
+    # [Container] value pinning.
+    "container-name-not-a-slot": "[Container]\nImage=x\nContainerName=../../root\n",
+    "volume-traversal": f"{_HEAD}Volume=/var/lib/hal0/../../etc:/etc:rw\n",
+    "device-traversal": f"{_HEAD}AddDevice=/dev/../root\n",
+    "publishport-not-numeric": f"{_HEAD}PublishPort=127.0.0.1:$(id):80\n",
+    "logdriver-other": f"{_HEAD}LogDriver=journald\n",
+    "environment-bad-name": f"{_HEAD}Environment=9BAD=1\n",
+    "health-retries-not-numeric": f"{_HEAD}HealthRetries=$(id)\n",
+    "health-interval-not-a-duration": f"{_HEAD}HealthInterval=30 seconds\n",
+    "unknown-container-key": f"{_HEAD}Rootfs=/\n",
+    "notify-key": f"{_HEAD}Notify=true\n",
+    # [Service] value pinning.
+    "service-standardoutput-file": f"{_HEAD}\n[Service]\nStandardOutput=file:/root/.ssh/authorized_keys\n",
+    "service-syslogidentifier-free": f"{_HEAD}\n[Service]\nSyslogIdentifier=../evil\n",
+    "service-restart-free": f"{_HEAD}\n[Service]\nRestart=/bin/sh\n",
+    "service-workingdirectory": f"{_HEAD}\n[Service]\nWorkingDirectory=/root\n",
+    "service-environmentfile": f"{_HEAD}\n[Service]\nEnvironmentFile=/tmp/evil.env\n",
+    "service-permissionsstartonly": f"{_HEAD}\n[Service]\nPermissionsStartOnly=true\n",
+}
+
+
+@pytest.mark.parametrize("name", sorted(ESCALATIONS))
+def test_rejects_escalation_payloads(name: str) -> None:
+    _rejects(ESCALATIONS[name])
+
+
+# ── the id is validated on the same (root) side ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "../../etc/systemd/system/evil",
+        "..",
+        "chat/../evil",
+        "chat.service",
+        "chat evil",
+        "chat;id",
+        "a" * 65,
+        "",
+    ],
+)
+def test_rejects_traversal_and_malformed_slot_ids(bad_id: str) -> None:
+    proc = _check(f"{_HEAD}", bad_id)
+    assert proc.returncode == 64, f"accepted id {bad_id!r}"
+    assert "slot id" in proc.stderr
+
+
+# ── bounds + inert content ─────────────────────────────────────────────────
+
+
+def test_absurdly_long_line_is_rejected() -> None:
+    _rejects(f"{_HEAD}Environment=X=" + "a" * 8192 + "\n")
+
+
+def test_absurdly_many_lines_are_rejected() -> None:
+    _rejects("# pad\n" * 5000 + _HEAD)
+
+
+def test_comments_and_blank_lines_are_allowed() -> None:
+    _accepts(f"# hal0 container slot — generated by ContainerProvider.\n#\n\n{_HEAD}")

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -138,6 +138,20 @@ _PLANS: dict[str, tuple[RuntimeLaunchPlan, dict[str, Any]]] = {
         ),
         {"publish_host": "0.0.0.0", "network_mode_default": "bridge"},
     ),
+    "hostname-publish-host": (
+        # #1740 F1 regression: [slots].publish_host permits a bare hostname
+        # (SlotsConfig._publish_host_sane), so a bridge-mode slot renders
+        # PublishPort=<hostname>:port:port. An IPv4-only allow-list charset
+        # false-rejected this documented, default-path config and bricked the
+        # slot load.
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-toolbox-rocm:v1",
+            command=["llama-server", "--port", "8095"],
+            port=8095,
+            network_mode="",
+        ),
+        {"publish_host": "hal0.local", "network_mode_default": "bridge"},
+    ),
     "host-net-comfyui": (
         RuntimeLaunchPlan(
             image="ghcr.io/hal0ai/hal0-comfyui:v1",

--- a/tests/system/test_seam.py
+++ b/tests/system/test_seam.py
@@ -43,36 +43,15 @@ def _recorder():
     return calls, _run
 
 
-# ── write_unit ─────────────────────────────────────────────────────────────
+# ── write_unit is gone (#1740) ─────────────────────────────────────────────
 
 
-def test_write_unit_direct_when_not_hal0_user(tmp_path: Path) -> None:
-    calls, run = _recorder()
-    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: False)
-    unit = tmp_path / "hal0-slot@chat.service"
-
-    seam.write_unit(unit, "[Unit]\n")
-
-    assert unit.read_text() == "[Unit]\n"
-    assert calls == []  # never shelled out
-
-
-def test_write_unit_routes_through_seam_when_hal0_user(tmp_path: Path) -> None:
-    calls, run = _recorder()
-    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
-    unit = tmp_path / "hal0-slot@chat.service"
-
-    seam.write_unit(unit, "[Unit]\n")
-
-    assert not unit.exists()  # never written directly
-    assert calls == [["sudo", "-n", SEAM_BIN, "write-unit", "chat"]]
-
-
-def test_write_unit_rejects_non_slot_unit_name(tmp_path: Path) -> None:
-    _, run = _recorder()
-    seam = SystemCtlSeam(run=run, is_hal0_user=lambda: True)
-    with pytest.raises(ValueError, match="not a hal0-slot@ unit"):
-        seam.write_unit(tmp_path / "hal0-api.service", "[Unit]\n")
+def test_write_unit_is_removed() -> None:
+    """``write_unit``/``write-unit`` shipped an unvalidated body to a root-owned
+    ``/etc/systemd/system/*.service``. P3-quadlet left it without a producer —
+    ``_render_quadlet_from_plan`` emits a ``.container`` — so there was no
+    render contract to allow-list against and the verb was deleted outright."""
+    assert not hasattr(SystemCtlSeam, "write_unit")
 
 
 # ── write_quadlet / remove_quadlet (P3-quadlet) ──────────────────────────────

--- a/tests/system/test_seam_agent_units.py
+++ b/tests/system/test_seam_agent_units.py
@@ -335,7 +335,7 @@ def _reject(argv: object) -> None:
         ["systemctl", "stop", "hal0-agent@hermes.service"],
         ["sudo", "-n", SEAM_BIN, "stop-agent", "hermes"],
         ["sudo", "-n", SEAM_BIN, "disable-agent", "hermes"],
-        ["sudo", "-n", SEAM_BIN, "write-unit", "slot"],
+        ["sudo", "-n", SEAM_BIN, "write-quadlet", "slot"],
         ["sudo", "systemctl", "restart", "hal0-api.service"],
         ["sudo", "-u", "hal0", "systemctl", "stop", "x.service"],
         "sudo -n /usr/lib/hal0/bin/hal0-systemctl stop-agent hermes",


### PR DESCRIPTION
**PRIVILEGED-SURFACE SECURITY CHANGE — operator review required. Automerge is deliberately NOT enabled.**

Closes #1740.

## The hole

`installer/wrappers/hal0-systemctl`'s `write-quadlet` did:

```sh
install -m 0644 -o root -g root /dev/stdin "${QUADLET_DIR}/hal0-slot@${id}.container"
```

with `validate_slot_id` on the *id* and **nothing at all** on the body. The sudoers grant (`packaging/sudoers/hal0-systemctl`) is pinned to the binary, not to an argv list, so the unprivileged `hal0` service account may run the wrapper as root with any stdin.

A `.container` file is not merely a container spec: podman's quadlet generator copies its `[Unit]`, `[Service]` and `[Install]` sections through **verbatim** into the generated system unit. So

```
[Container]
Image=…
[Service]
ExecStartPre=/bin/sh -c 'id>/root/pwned'
```

plus this same wrapper's own `daemon-reload` + `start` verbs was an **unconditional root exec** — no container escape involved. #1718 closed exactly this hole for the two drop-in verbs and left this one open, while the wrapper and sudoers comments claimed the seam was a boundary.

`write-unit` was the same primitive with nothing in the way at all: an unvalidated body written straight to `/etc/systemd/system/hal0-slot@<id>.service`.

## The fix

**`validate_quadlet_body`** — mirrors #1718's `validate_dropin_body` design (validated reconstruction, not raw stdin; charset/section discipline; loud `die 64` on the first thing not explicitly permitted), over the richer grammar `_render_quadlet_from_plan` actually emits:

| Section | Allowed keys |
|---|---|
| `[Unit]` | `Description=` (pinned to the rendered sentence), `StartLimitIntervalSec=`, `StartLimitBurst=` |
| `[Container]` | `Image=` `ContainerName=` `LogDriver=none` `Network=` `AddDevice=` `AddCapability=` `PodmanArgs=` `Volume=` `Environment=` `PublishPort=` `HealthCmd=` `HealthStartPeriod=` `HealthInterval=` `HealthRetries=` `HealthTimeout=` `Exec=` |
| `[Service]` | `Restart=` `RestartSec=` `SyslogIdentifier=` `StandardOutput=journal` `StandardError=journal` |
| `[Install]` | `WantedBy=hal0.target` |

Sections may appear **at most once and only in render order**; `[Container]` is mandatory. Every other section (a second `[Service]`, `[Timer]`, …) and every key outside its section's list is refused — that is what closes the `ExecStartPre=` / `User=root` smuggling path. Comments and blank lines stay inert. Leading whitespace, `Key = v`, `;` comments, control bytes (CR/tab/NUL) and trailing-backslash line continuations are all refused. The write arm persists `$QUADLET_BODY` (the validated reconstruction) atomically via tmp + `mv`, never `/dev/stdin`.

**`check-quadlet [<slot-id>]`** — side-effect-free dry run, mirroring `check-dropin`. Validates the optional id and the body, echoes exactly what a write would persist, touches nothing. It is what the test suite drives, and what an operator uses to debug a rejected unit.

**`write-unit` is removed, not validated.** P3-quadlet left it with *no producer*: the sole renderer of slot-unit text emits a `.container`, written through `write-quadlet`. With no render contract there is no allow-list to derive, so inventing one would be theatre. `SystemCtlSeam.write_unit` goes with it. `remove-unit` stays — it only ever `rm -f`s a pinned name, and legacy pre-quadlet `.service` files still need cleaning up.

## The residual, stated precisely (please read this part)

The allow-list removes the **direct host-side exec primitive**: no host `[Service]`/`[Unit]` directive beyond the fixed ones, no `Exec*=` on the host side, no `User=`/`Group=`, no second section, no `WantedBy=` off `hal0.target`.

It does **not** make an `hal0`-account compromise non-root-equivalent. Slots run under **rootful podman**, and a slot's `[Container]` section legitimately carries `Image=`, `Volume=`, `AddDevice=`, `PodmanArgs=` and `Exec=` whose values are operator/config-derived. Those are charset-pinned and traversal-checked but not semantically constrained, because they cannot be: the model-store and data roots are runtime config, and a path allow-list would be bypassable through a symlink under a root the `hal0` user already owns. So an attacker who owns the `hal0` account can still author a container that mounts host paths.

That is a property of the slot feature itself, not of this wrapper. Containing it means running slots rootless or pinning mount roots — a separate change. The wrapper header, the sudoers comments, `docs/operate/services.mdx` and the CHANGELOG now say exactly this instead of implying a sandbox.

## Verification

Red-first. Tests drive the **shipped bash** through `check-quadlet` (no root, no sudo, no provisioned box — the #1718 suite's posture).

Rejected: `ExecStartPre`/`ExecStart`/`ExecStartPost`/`ExecStop`/`ExecReload` smuggling, `User=root`, `Group=root`, a second `[Service]`, a second `[Container]`, `[Service]` before `[Container]`, `[Unit]` after `[Container]`, `[Timer]`, `[Unit] OnFailure=`/`ConditionPathExists=`, `[Install] WantedBy=multi-user.target`, `[Install] Also=`, line continuation, CRLF, bare CR inside a directive, tab- and space-indented directives, `Key = v`, `;`-comment-then-directive, directive before any section, empty body, section-only, no `[Container]`, `Volume=`/`AddDevice=` traversal, non-numeric `PublishPort=`/`HealthRetries=`, `LogDriver=journald`, `StandardOutput=file:/root/.ssh/authorized_keys`, `WorkingDirectory=`, `EnvironmentFile=`, and traversal/malformed slot ids (`../../etc/…`, `..`, `chat.service`, `chat;id`, 65 chars, empty).

Accepted byte-for-byte: the real renderer's output for minimal, GPU/llama bridge-net (mounts, devices, caps, `PodmanArgs` group/security opts, health block, widened `PublishPort`), host-net ComfyUI, NPU/FLM with `autoload = false` (no `[Install]`), and the deprecated `extra_args` passthrough — each across four token shapes — plus a live `ContainerProvider._render_quadlet_text` render through the production path.

```
bash -n installer/wrappers/hal0-systemctl                                    # OK (shellcheck not installed here; CI runs it)
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/system tests/installer tests/slots tests/providers -q
# 1775 passed, 1 skipped
ruff check src tests                                                          # All checks passed
mypy src/hal0/system/seam.py                                                  # no issues
```

## Out of scope / follow-up

- Rootless slot execution, or pinning `Volume=` sources to a resolved allow-list of model/data roots — the only things that would close the residual above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)