### PR TITLE
fix(profiles): grandfather unchanged pre-existing malformed flag quoting

### DIFF
--- a/src/hal0/profiles/__init__.py
+++ b/src/hal0/profiles/__init__.py
@@ -371,8 +371,7 @@ def screen_profile_flags(flags: str | None, *, grandfathered: str | None = None)
     funnel through :meth:`ProfileCatalog.create` / :meth:`ProfileCatalog.update`
     — so the guard lives here and the HTTP layer delegates to it rather than
     keeping a second copy. Enforces the model/profile ownership partition
-    (§5 hardware flags + §21.7 managed args). Empty/unset ``flags`` is a no-op;
-    malformed quoting is left to the schema layer's own diagnostics.
+    (§5 hardware flags + §21.7 managed args). Empty/unset ``flags`` is a no-op.
 
     ``grandfathered`` is the profile's CURRENTLY STORED flag text on an update
     (#1411). The §5 screen shipped with no data migration, so every custom
@@ -404,12 +403,29 @@ def screen_profile_flags(flags: str | None, *, grandfathered: str | None = None)
     rather than fixed. Reject it here instead, with the same error family the
     launch-time guard uses, so the operator sees the problem at save time
     instead of the next launch.
+
+    Malformed-quoting rejection is ALSO grandfathered (mirroring the §5
+    hardware-flag grandfathering above): a profile persisted before #1737
+    added this check can already carry bad quoting on disk. Routes forward
+    ``body.flags`` on every PUT and the UI drawer resends the stored flags
+    text verbatim, so without grandfathering, a save that only changes e.g.
+    ``device_class`` would re-screen the SAME already-broken flags and 422 —
+    making the profile un-editable for any field, the exact #1411 round-trip
+    trap recreated for quoting instead of hardware flags. The screen only
+    rejects a NEWLY-introduced or CHANGED malformed value; an unchanged
+    inherited one passes through (logged, not silently ignored).
     """
     if not flags or not flags.strip():
         return
     try:
         tokens = shlex.split(flags)
     except ValueError as exc:
+        if grandfathered is not None and flags == grandfathered:
+            log.info(
+                "profile flags carry pre-existing malformed quoting; grandfathered on update",
+                extra={"event": "profile.malformed_flags_grandfathered", "flags": flags},
+            )
+            return
         raise UnprocessableEntity(
             f"profile flags are not valid shell text: {exc}",
             code="profiles.flags_malformed",

--- a/tests/profiles/test_catalog.py
+++ b/tests/profiles/test_catalog.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from hal0.config.loader import load_profiles_config, save_profiles_config
 from hal0.config.schema import MTP_FLAG_BUNDLE, ProfileConfig
 from hal0.errors import Conflict, UnprocessableEntity
 from hal0.profiles import ProfileCatalog, ProfilePatch
@@ -89,6 +90,40 @@ def test_update_rejects_unmatched_quoting(tmp_hal0_home: str) -> None:
     assert exc_info.value.code == "profiles.flags_malformed"
     # The prior valid flags must survive an update rejected on save.
     assert catalog.resolve("good-profile").flags == "-fa on"
+
+
+def _persist_grandfathered_malformed_profile(name: str, flags: str) -> None:
+    """Write a profile with malformed flag quoting straight to disk, bypassing
+    ``screen_profile_flags`` — simulating a profile that was persisted before
+    #1737 started rejecting bad quoting at save time (the old code silently
+    swallowed the ``shlex.split`` ``ValueError``)."""
+    cfg = load_profiles_config()
+    cfg.profile[name] = ProfileConfig(flags=flags)
+    save_profiles_config(cfg)
+
+
+def test_update_allows_unchanged_grandfathered_malformed_flags(tmp_hal0_home: str) -> None:
+    """A profile persisted pre-#1737 with malformed quoting must stay editable
+    for OTHER fields: a save that resends the same (still-malformed) flags text
+    unchanged must not 422, mirroring the §5 hardware-flag grandfathering."""
+    _persist_grandfathered_malformed_profile("grandfathered-quotes", '-fa on "unterminated')
+    catalog = ProfileCatalog()
+    updated = catalog.update(
+        "grandfathered-quotes",
+        ProfilePatch(flags='-fa on "unterminated', device_class="cpu"),
+    )
+    assert updated.device_class == "cpu"
+    assert updated.flags == '-fa on "unterminated'
+
+
+def test_update_rejects_new_malformed_flags_even_when_grandfathered(tmp_hal0_home: str) -> None:
+    """Grandfathering only covers the UNCHANGED inherited text — changing the
+    flags to a DIFFERENT malformed value must still 422."""
+    _persist_grandfathered_malformed_profile("grandfathered-quotes-2", '-fa on "unterminated')
+    catalog = ProfileCatalog()
+    with pytest.raises(UnprocessableEntity) as exc_info:
+        catalog.update("grandfathered-quotes-2", ProfilePatch(flags="-fa on 'also-bad"))
+    assert exc_info.value.code == "profiles.flags_malformed"
 
 
 def test_delete_profile_in_use_raises_conflict(tmp_hal0_home: str) -> None:


### PR DESCRIPTION
## Summary

- #1737 made `screen_profile_flags` raise `UnprocessableEntity` on any `shlex.split` failure unconditionally, not gated by the `grandfathered` mechanism the §5 hardware-flag check already uses.
- A profile persisted with malformed quoting before #1737 became un-editable via `PUT /api/profiles/{name}` for ANY field change — `routes/profiles.py` always forwards `body.flags` and the UI drawer always resends stored flags verbatim, so an unrelated field save re-screens the same already-broken flags text and 422s. The exact #1411 round-trip trap, recreated for quoting.
- Fix: grandfather an update whose flags text is unchanged from the stored (already-malformed) value; a newly-introduced or changed malformed value still hard-rejects. Also removes the now-false docstring line ("malformed quoting is left to the schema layer's own diagnostics").

Closes #1742

## Test plan

- [x] Red-first: persisted a profile with malformed flags directly (bypassing the screen), then `PUT` changing only `device_class` with flags unchanged → 422'd before the fix
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/slots tests/profiles tests/api -q` → 2526 passed, 1 skipped (environmental)

🤖 Generated with [Claude Code](https://claude.com/claude-code)