### PR TITLE
fix(update): drop file:// from privileged releases-URL resolve

### DIFF
--- a/installer/wrappers/hal0-update
+++ b/installer/wrappers/hal0-update
@@ -93,13 +93,25 @@ validate_dir_name() {
 #
 # Root does NOT accept the URL via sudo argv or the caller's environment —
 # both are an injection surface into a root process. Instead it reads the
-# SAME root-owned trusted config the daemon reads, itself, as root. No
-# `source`/`eval` of the file (it also carries provider tokens and
-# HAL0_ADMIN_KEY/HAL0_CLIENT_KEY): exactly the ``HAL0_RELEASES_URL=`` line is
-# grep+cut out, and it must look like an http(s)/file URL before it is
-# exported into the Python re-entry's environment. A present-but-malformed
-# value dies loudly here rather than silently falling back to the default —
-# that silent fallback is the exact bug being fixed.
+# SAME api.env the daemon reads, itself, as root. No `source`/`eval` of the
+# file (it also carries provider tokens and HAL0_ADMIN_KEY/HAL0_CLIENT_KEY):
+# exactly the ``HAL0_RELEASES_URL=`` line is grep+cut out. A present-but-
+# malformed value dies loudly here rather than silently falling back to the
+# default — that silent fallback is the exact bug #1690 fixed.
+#
+# #1751 — api.env is NOT root-owned trusted config: under the hardened perms
+# flip (src/hal0/install/perms.py, etc_owner=service_user — the shipped v1.0
+# default), api.env is hal0:hal0 0600, so the unprivileged `hal0` account
+# fully controls this value, including whatever scheme it names. `https://`
+# is safe (root just fetches a URL, same as any client). `file://` on THIS
+# privileged path is not: it would let a hal0-writable value steer root's
+# manifest read at Path(path).read_bytes()/shutil.copyfile() (see
+# hal0.updater.updater._fetch_release_manifest_bytes/_download) against an
+# arbitrary local path — cosign identity+issuer pinning would be the only
+# remaining backstop, and this wrapper must not rely on that. The daemon-side
+# (unprivileged) resolver in hal0.updater.updater.releases_url() keeps
+# file:// for tests and local-mirror dev installs; only the root re-entry
+# below is restricted.
 resolve_releases_url() {
   local etc_root="/etc/hal0"
   # HAL0_HOME sandboxes the whole config root for dev installs + integration
@@ -128,8 +140,8 @@ resolve_releases_url() {
 
   [[ -n "${raw}" ]] || return 0
   case "${raw}" in
-    https://*|file://*) export HAL0_RELEASES_URL="${raw}" ;;
-    *) die "bad HAL0_RELEASES_URL in ${env_file} (must be https:// or file://): ${raw}" ;;
+    https://*) export HAL0_RELEASES_URL="${raw}" ;;
+    *) die "bad HAL0_RELEASES_URL in ${env_file} (must be https://): ${raw}" ;;
   esac
 }
 

--- a/tests/installer/test_hal0_update_wrapper.py
+++ b/tests/installer/test_hal0_update_wrapper.py
@@ -151,14 +151,21 @@ def test_stage_reads_releases_url_from_hal0_home_api_env(installed: Path, tmp_pa
     assert _released_url(installed) == "https://mirror.example/preview.json"
 
 
-def test_stage_accepts_a_file_url(installed: Path, tmp_path: Path) -> None:
+def test_stage_refuses_a_file_url(installed: Path, tmp_path: Path) -> None:
+    """#1751 — api.env is hal0:hal0 0600 under the hardened perms flip (the
+    shipped v1.0 default), so the unprivileged `hal0` account fully controls
+    this value. A `file://` scheme on the PRIVILEGED path would let it steer
+    root's manifest fetch at Path(path).read_bytes()/shutil.copyfile against
+    an arbitrary local path. Only https:// is trusted here; the daemon-side
+    (unprivileged) resolver in updater.py keeps file:// for tests/dev."""
     hal0_home = tmp_path / "sandbox"
     _write_api_env(hal0_home, "HAL0_RELEASES_URL=file:///srv/hal0-releases/stable.json\n")
 
-    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+    rc, argv, stderr = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
 
-    assert rc == 0
-    assert _released_url(installed) == "file:///srv/hal0-releases/stable.json"
+    assert rc == 64
+    assert argv == [], "a hal0-writable file:// override must never reach the interpreter"
+    assert "hal0-update:" in stderr
 
 
 def test_stage_strips_matching_quotes_around_releases_url(installed: Path, tmp_path: Path) -> None:
@@ -250,7 +257,7 @@ def test_stage_never_forwards_unrelated_api_env_secrets(installed: Path, tmp_pat
         "javascript:alert(1)",
         "ftp://mirror.example/stable.json",
         "not-a-url",
-        "http://mirror.example/stable.json",  # https:// or file:// only, per #1690
+        "http://mirror.example/stable.json",  # https:// only, per #1751
     ],
 )
 def test_stage_refuses_a_releases_url_with_a_disallowed_scheme(


### PR DESCRIPTION
## PRIVILEGED-SURFACE security change

Closes #1751

### Problem

`installer/wrappers/hal0-update`'s `resolve_releases_url()` reads
`HAL0_RELEASES_URL` from `/etc/hal0/api.env` and forwards it into root's
release-manifest fetch (`hal0.updater.privileged stage`). Its comment called
`api.env` "root-owned trusted config" — false under the hardened perms flip
(`src/hal0/install/perms.py`, `etc_owner=service_user`, the shipped v1.0
default): `api.env` is `hal0:hal0` `0600`. The unprivileged `hal0` service
account fully controls it, including the accepted `file://` scheme, which
routes root's fetch through `Path(path).read_bytes()`/`shutil.copyfile()`
(`hal0.updater.updater._fetch_release_manifest_bytes` / `_download`) against
an arbitrary local path. cosign identity+issuer pinning was the only
remaining backstop — a property the wrapper's own comment said it wasn't
relying on.

### Option chosen: A (minimal) — drop `file://` from the privileged path only

Two options were on the table:
- **A**: on the privileged resolve path only, accept `https://` and reject
  `file://`; fix the comment.
- **B**: move the releases-URL override to a new root:root `0644` file
  (e.g. `/etc/hal0/update.conf`) with its own `perms.py` `PermRow`, read as
  root instead of via `api.env`.

Went with **A**. The deployed fleet currently relies on
`HAL0_RELEASES_URL` in `api.env` as the documented interim mechanism for the
preview-channel workaround (`scripts/release-prototype/RELEASE_PIPELINE_NOTES.md`,
#1690) — both the daemon's own unprivileged check *and* root's privileged
re-fetch read that same value today so they agree on which host to hit.
Option B would sever that agreement for every already-provisioned box
(`api.env`'s override would keep steering the daemon's check but stop
steering root's re-fetch, reproducing the exact "#1690" failure mode: a
custom-URL box passes `/api/updates/check` then always fails `stage`)
unless paired with a migration step to also populate the new file at
install/upgrade time. That's real additional surface for a P2 with a
narrow, well-understood fix available. `https://` is safe for root to accept
here (root is just fetching a URL like any client); `file://` is the only
scheme that turns a hal0-writable value into an arbitrary-local-path read
under root, so removing only that scheme closes the hole without touching
the operator override mechanism, the daemon-side resolver, or its test
fixtures.

### Changes

- `resolve_releases_url()` in `installer/wrappers/hal0-update`: privileged
  path now accepts only `https://` (was `https://|file://`); `die` message
  updated to match.
- Corrected the block comment's false "root-owned trusted config" claim with
  an explicit explanation of the perms-flip ownership and why `file://` is
  unsafe there but `https://` isn't.
- `hal0.updater.updater.releases_url()` / `_fetch_release_manifest_bytes()` /
  `_download()` (the **unprivileged daemon-side** resolver) are untouched —
  `file://` still works there for tests and local-mirror dev installs.

### Test plan

- Red-first: `tests/installer/test_hal0_update_wrapper.py::test_stage_accepts_a_file_url`
  (asserted the vulnerable behavior) rewritten as
  `test_stage_refuses_a_file_url` (asserts `file://` in `api.env` is refused,
  rc 64, nothing forwarded to the interpreter); confirmed it failed against
  the pre-fix wrapper, then passed after the fix. `https://` case
  (`test_stage_reads_releases_url_from_hal0_home_api_env`) still passes.
  `http://` moved from "must be https:// or file://" to "https:// only" in
  the disallowed-scheme parametrize.
- `bash -n installer/wrappers/hal0-update` — clean.
- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/install tests/installer -x -q` — **827 passed, 1 skipped** (shellcheck not installed locally; that test self-skips).
- shellcheck not available in this sandbox — CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)