### PR TITLE
fix(updater): trust only root-owned config for the releases-URL override (#1750)

### DIFF
--- a/installer/wrappers/hal0-update
+++ b/installer/wrappers/hal0-update
@@ -92,45 +92,87 @@ validate_dir_name() {
 # (releases.hal0.dev) that does not exist yet.
 #
 # Root does NOT accept the URL via sudo argv or the caller's environment —
-# both are an injection surface into a root process. Instead it reads the
-# SAME root-owned trusted config the daemon reads, itself, as root. No
-# `source`/`eval` of the file (it also carries provider tokens and
-# HAL0_ADMIN_KEY/HAL0_CLIENT_KEY): exactly the ``HAL0_RELEASES_URL=`` line is
-# grep+cut out, and it must look like an http(s)/file URL before it is
-# exported into the Python re-entry's environment. A present-but-malformed
-# value dies loudly here rather than silently falling back to the default —
-# that silent fallback is the exact bug being fixed.
+# both are an injection surface into a root process. It reads the config
+# itself, as root, with no `source`/`eval` of the file (these files also carry
+# provider tokens and HAL0_ADMIN_KEY/HAL0_CLIENT_KEY): exactly the
+# ``HAL0_RELEASES_URL=`` line is grep+cut out, and it must look like an
+# accepted URL before it is exported into the Python re-entry's environment.
+# A present-but-malformed value dies loudly here rather than silently falling
+# back to the default — that silent fallback is the exact bug #1690 fixed.
+#
+# #1750 — the two config files are NOT equally trusted, and an earlier version
+# of this comment wrongly called api.env a root-owned trusted config that root
+# and the daemon both read. It is not: src/hal0/install/perms.py builds the
+# /etc/hal0 rows with ``etc_owner = service_user if flipped else "root"`` and
+# ``service_user="hal0"`` is the DEFAULT (the hardened flip), so on a shipped
+# box /etc/hal0/api.env is hal0:hal0 0600 — writable by the very unprivileged
+# account this sudo grant exists to contain. Hence two sources, two trust
+# levels:
+#
+#   /etc/hal0/update.conf  root:root 0644 (its own perms.py PermRow, optional)
+#       Genuinely root-owned, so it may name any accepted scheme including
+#       file://. Checked first and authoritative — a value here cannot be
+#       overridden from the service-owned file.
+#   /etc/hal0/api.env      service-owned under the flip
+#       Still honoured, because #1690's interim mechanism lives there and
+#       operators rely on it while releases.hal0.dev does not exist — but
+#       https:// ONLY. A file:// from here would let a process compromised as
+#       hal0 point ROOT's manifest fetch at an arbitrary local path
+#       (Path(...).read_bytes()/shutil.copyfile on the Python side), so it is
+#       refused with a pointer at update.conf.
+#
+# Cosign identity+issuer pinning still backstops whatever URL wins; it is not
+# asked to be the only thing standing between the service account and root.
 resolve_releases_url() {
   local etc_root="/etc/hal0"
   # HAL0_HOME sandboxes the whole config root for dev installs + integration
   # tests (src/hal0/config/paths.py: etc()/api_env()) — mirrored here so a
-  # sandboxed run resolves the exact api.env the Python side resolves,
-  # never a real box's /etc/hal0/api.env.
+  # sandboxed run resolves the exact files the Python side resolves,
+  # never a real box's /etc/hal0.
   if [[ -n "${HAL0_HOME:-}" ]]; then
     etc_root="${HAL0_HOME}/etc/hal0"
   fi
-  local env_file="${etc_root}/api.env"
-  [[ -r "${env_file}" ]] || return 0
 
   local raw
+  # Root-owned file first: it may name file:// as well as https://.
+  raw="$(read_releases_url "${etc_root}/update.conf")"
+  if [[ -n "${raw}" ]]; then
+    case "${raw}" in
+      https://*|file://*) export HAL0_RELEASES_URL="${raw}"; return 0 ;;
+      *) die "bad HAL0_RELEASES_URL in ${etc_root}/update.conf (must be https:// or file://): ${raw}" ;;
+    esac
+  fi
+
+  # Service-owned fallback: https:// only.
+  raw="$(read_releases_url "${etc_root}/api.env")"
+  [[ -n "${raw}" ]] || return 0
+  case "${raw}" in
+    https://*) export HAL0_RELEASES_URL="${raw}" ;;
+    file://*)
+      die "refusing a file:// HAL0_RELEASES_URL from ${etc_root}/api.env (service-owned; put it in ${etc_root}/update.conf, root:root 0644): ${raw}"
+      ;;
+    *) die "bad HAL0_RELEASES_URL in ${etc_root}/api.env (must be https://): ${raw}" ;;
+  esac
+}
+
+# Echo the last ``HAL0_RELEASES_URL=`` value in a KEY=VALUE file, or nothing.
+read_releases_url() {
+  local file="$1" raw
+  [[ -r "${file}" ]] || return 0
+
   # `|| true`: grep exits 1 on no match (the common case — most boxes never
   # set this override), and with `pipefail` that would otherwise trip
   # `set -e` and kill the whole seam with an opaque rc=1 before `stage` ever
   # runs. No match is not an error here, just "no override configured".
-  raw="$(grep -E '^HAL0_RELEASES_URL=' -- "${env_file}" 2>/dev/null | tail -n1 | cut -d'=' -f2-)" || true
+  raw="$(grep -E '^HAL0_RELEASES_URL=' -- "${file}" 2>/dev/null | tail -n1 | cut -d'=' -f2-)" || true
   raw="${raw%$'\r'}"
-  # api.env is a plain KEY=VALUE file; strip one layer of matching quotes if
-  # the operator added them (systemd's EnvironmentFile= parser does the same).
+  # Both files are plain KEY=VALUE; strip one layer of matching quotes if the
+  # operator added them (systemd's EnvironmentFile= parser does the same).
   case "${raw}" in
     \"*\") raw="${raw#\"}"; raw="${raw%\"}" ;;
     \'*\') raw="${raw#\'}"; raw="${raw%\'}" ;;
   esac
-
-  [[ -n "${raw}" ]] || return 0
-  case "${raw}" in
-    https://*|file://*) export HAL0_RELEASES_URL="${raw}" ;;
-    *) die "bad HAL0_RELEASES_URL in ${env_file} (must be https:// or file://): ${raw}" ;;
-  esac
+  printf '%s' "${raw}"
 }
 
 cmd="${1:-help}"; shift || true

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -205,6 +205,14 @@ def ownership_table(
         # dashboard writer and the key rotation applied). One constant, shared
         # with both of those and with installer/install.sh.
         PermRow(etc / "api.env", etc_owner, etc_group, paths.API_ENV_MODE, role="api.env"),
+        # update.conf is the ROOT-owned releases-URL override (#1750). It is
+        # pinned root:root under the flip too, on purpose: the privileged
+        # hal0-update wrapper reads it as root and lets it name a file:// URL,
+        # which api.env (service-owned once flipped) is not allowed to do —
+        # otherwise a process compromised as hal0 would choose the manifest
+        # root fetches. Optional: only boxes with a custom release source have
+        # one.
+        PermRow(etc / "update.conf", "root", "root", 0o644, role="update.conf"),
         PermRow(etc / "capabilities.toml", etc_owner, etc_group, 0o600, role="capabilities.toml"),
         PermRow(etc / "upstreams.toml", etc_owner, etc_group, 0o644, role="upstreams.toml"),
         PermRow(paths.hardware_json(), etc_owner, etc_group, 0o644, role="hardware.json"),

--- a/tests/installer/test_hal0_update_wrapper.py
+++ b/tests/installer/test_hal0_update_wrapper.py
@@ -151,14 +151,18 @@ def test_stage_reads_releases_url_from_hal0_home_api_env(installed: Path, tmp_pa
     assert _released_url(installed) == "https://mirror.example/preview.json"
 
 
-def test_stage_accepts_a_file_url(installed: Path, tmp_path: Path) -> None:
+def test_stage_refuses_a_file_url_from_api_env(installed: Path, tmp_path: Path) -> None:
+    """#1750: api.env is hal0-owned under the hardened flip, so a ``file://``
+    there is the unprivileged account picking a local path for ROOT to read as
+    a release manifest. Only the root-owned update.conf may name one."""
     hal0_home = tmp_path / "sandbox"
     _write_api_env(hal0_home, "HAL0_RELEASES_URL=file:///srv/hal0-releases/stable.json\n")
 
-    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+    rc, argv, stderr = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
 
-    assert rc == 0
-    assert _released_url(installed) == "file:///srv/hal0-releases/stable.json"
+    assert rc != 0
+    assert argv == [], "the interpreter must not be reached at all"
+    assert "update.conf" in stderr
 
 
 def test_stage_strips_matching_quotes_around_releases_url(installed: Path, tmp_path: Path) -> None:
@@ -250,7 +254,7 @@ def test_stage_never_forwards_unrelated_api_env_secrets(installed: Path, tmp_pat
         "javascript:alert(1)",
         "ftp://mirror.example/stable.json",
         "not-a-url",
-        "http://mirror.example/stable.json",  # https:// or file:// only, per #1690
+        "http://mirror.example/stable.json",  # https:// only from api.env (#1690, #1750)
     ],
 )
 def test_stage_refuses_a_releases_url_with_a_disallowed_scheme(
@@ -338,6 +342,73 @@ def test_wrapper_resolves_the_venv_from_its_own_location(tmp_path: Path) -> None
     rc, argv, _ = _run(lib, "check")
     assert rc == 0
     assert argv[-1] == "check"
+
+
+# ── root-owned override file (#1750) ───────────────────────────────────────────
+
+
+def _write_update_conf(hal0_home: Path, body: str) -> None:
+    """Lay out $HAL0_HOME/etc/hal0/update.conf — the root:root override file."""
+    etc = hal0_home / "etc" / "hal0"
+    etc.mkdir(parents=True, exist_ok=True)
+    (etc / "update.conf").write_text(body)
+
+
+def test_stage_reads_releases_url_from_root_owned_update_conf(
+    installed: Path, tmp_path: Path
+) -> None:
+    hal0_home = tmp_path / "sandbox"
+    _write_update_conf(hal0_home, "HAL0_RELEASES_URL=https://mirror.example/stable.json\n")
+
+    rc, argv, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert argv == ["-I", "-m", "hal0.updater.privileged", "stage", "stable"]
+    assert _released_url(installed) == "https://mirror.example/stable.json"
+
+
+def test_update_conf_may_name_a_file_url(installed: Path, tmp_path: Path) -> None:
+    """`file://` stays available for the LXC smoke / release-prototype flow —
+    but only from the file the unprivileged account cannot write."""
+    hal0_home = tmp_path / "sandbox"
+    _write_update_conf(hal0_home, "HAL0_RELEASES_URL=file:///srv/hal0-releases/stable.json\n")
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "file:///srv/hal0-releases/stable.json"
+
+
+def test_update_conf_wins_over_api_env(installed: Path, tmp_path: Path) -> None:
+    """The root-owned file is authoritative; the service-owned one cannot
+    override an operator's explicit root-side choice."""
+    hal0_home = tmp_path / "sandbox"
+    _write_update_conf(hal0_home, "HAL0_RELEASES_URL=https://trusted.example/stable.json\n")
+    _write_api_env(hal0_home, "HAL0_RELEASES_URL=https://attacker.example/stable.json\n")
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "https://trusted.example/stable.json"
+
+
+def test_api_env_is_still_honoured_for_https(installed: Path, tmp_path: Path) -> None:
+    """#1690's interim mechanism keeps working on boxes with no update.conf."""
+    hal0_home = tmp_path / "sandbox"
+    _write_api_env(hal0_home, "HAL0_RELEASES_URL=https://mirror.example/stable.json\n")
+
+    rc, _, _ = _run(installed, "stage", "stable", env={"HAL0_HOME": str(hal0_home)})
+
+    assert rc == 0
+    assert _released_url(installed) == "https://mirror.example/stable.json"
+
+
+def test_wrapper_does_not_claim_api_env_is_root_owned() -> None:
+    """#1750: the comment asserting api.env is 'root-owned trusted config' was
+    false under the hardened perms flip and must not come back."""
+    text = WRAPPER.read_text()
+    assert "SAME root-owned trusted config" not in text
+    assert "update.conf" in text
 
 
 def test_wrapper_and_python_dir_regexes_agree() -> None:


### PR DESCRIPTION
Closes #1750 (P2 security, found by the pre-GA verification review).

## Problem
The hal0-update wrapper's resolve_releases_url() read HAL0_RELEASES_URL from /etc/hal0/api.env and called it 'root-owned trusted config'. Under the hardened perms flip, api.env is hal0:hal0 0600 — writable by the unprivileged account the sudo grant exists to contain. A file:// value there points root's manifest fetch at an arbitrary local path (Path.read_bytes/copyfile), with cosign identity pinning the only backstop.

## Fix (Option B — preserves the operator override from trusted config)
- New /etc/hal0/update.conf (root:root 0644, its own optional perms.py PermRow) is authoritative and may name any scheme including file://.
- api.env is still honoured for #1690's interim mechanism operators rely on, but https:// ONLY there; a file:// is refused with a pointer at update.conf.
- Corrects the false 'root-owned' comment.

## Verification
- tests/installer/test_hal0_update_wrapper.py + tests/install: 274 passed.
- New tests cover: file:// in api.env is refused on the privileged path; https:// in api.env still honoured; update.conf takes precedence and may carry file://.

Note: this work was authored by the staging-fix agent and stranded uncommitted on the #1745 branch during a session crash; recovered onto its own branch here. PRIVILEGED-SURFACE — reviewed by the agent-reviewer per operator delegation; escalating only if serious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)