### PR TITLE
fix(updater): reap orphaned .stage-* staging dirs (#1754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ applying. Add those subsections to a version's section to surface them; see
   directories, which accumulated one whole install tree per retry and were
   never cleaned up, are now reaped: the newest three are kept for recovery and
   anything older than 30 days goes.
+- The root-only `.stage-<version>-XXXXXX` staging directory (#1738) is now also
+  reaped on the next apply. Its teardown runs in a `finally`, which a SIGKILL /
+  OOM / power-cut skips, leaking a full release tarball under the root
+  filesystem per killed stage. Orphans older than an hour — comfortably above
+  the 30-minute privileged stage timeout, so a live concurrent stage is never
+  touched — are swept. (#1754)
 - The privileged `hal0-systemctl` wrapper now allow-lists the *content* of the
   two systemd drop-ins it writes as root (`write-gateway-dropin`,
   `write-hindsight-dropin`). Both verbs take their whole payload on stdin, and

--- a/src/hal0/updater/updater.py
+++ b/src/hal0/updater/updater.py
@@ -1018,6 +1018,15 @@ _STAGING_SENTINEL = ".hal0-staging"
 _QUARANTINE_KEEP = 3
 _QUARANTINE_MAX_AGE_S = 30 * 86400
 
+#: Orphaned ``.stage-<version>-XXXXXX`` staging dirs (see
+#: :func:`_root_only_staging_dir`) are removed in a ``finally``, which does not
+#: run on SIGKILL / OOM / power-cut. A killed stage therefore leaks a fresh
+#: ``mkdtemp`` dir holding a full release tarball under the root filesystem,
+#: forever. Reap any older than this. The floor is comfortably above the
+#: privileged stage timeout (``_STAGE_TIMEOUT`` = 1800s) so a live concurrent
+#: stage's own dir — always freshly created — can never be swept.
+_STAGING_MAX_AGE_S = 3600
+
 
 def _looks_like_hal0_install(path: Path) -> bool:
     """Heuristic: does ``path`` look like a prior hal0 tarball extraction?
@@ -1117,6 +1126,43 @@ def _reap_stale_quarantines(
         log.info("updater.quarantine_reaped", job_id=job_id, path=str(entry), stamp=stamp)
 
 
+def _reap_stale_staging_dirs(
+    *,
+    max_age_s: int = _STAGING_MAX_AGE_S,
+    job_id: str | None = None,
+) -> None:
+    """Delete orphaned ``.stage-<version>-XXXXXX`` dirs under the install root.
+
+    :func:`_root_only_staging_dir` tears its dir down in a ``finally``, so a
+    stage killed by SIGKILL / OOM / power-cut leaks the whole ``mkdtemp`` tree —
+    a full release tarball — under ``/usr/lib/hal0`` with nothing to sweep it.
+    The ``.stale-`` quarantine reaper doesn't match this prefix, so it grew
+    unbounded, one dir per killed stage. Reap any ``.stage-`` dir older than
+    ``max_age_s`` by mtime; the floor sits above ``_STAGE_TIMEOUT`` so a live
+    concurrent stage's freshly-created dir is always spared. Best-effort and
+    logged: failing to tidy is never a reason to fail an update.
+    """
+    root = _usr_lib_root()
+    cutoff = time.time() - max_age_s
+    for entry in _iterdir_safe(root):
+        if not entry.name.startswith(".stage-") or not entry.is_dir():
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > cutoff:
+            continue
+        try:
+            shutil.rmtree(entry)
+        except OSError as exc:
+            log.warning(
+                "updater.staging_reap_failed", job_id=job_id, path=str(entry), error=str(exc)
+            )
+            continue
+        log.info("updater.staging_reaped", job_id=job_id, path=str(entry))
+
+
 @contextlib.contextmanager
 def _root_only_staging_dir(version: str, *, job_id: str | None = None) -> Iterator[Path]:
     """Yield a fresh 0700 staging dir under the **root-owned** install root.
@@ -1171,17 +1217,19 @@ def _extract_tarball(
     ``expected_digest`` (#1738) is the authenticated ``manifest.digest_sha256``.
     When given, the file is opened **once** and that single file object is used
     for both the digest and the extraction — the bytes that are hashed are, by
-    construction, the bytes that are unpacked. Any substitution after
-    ``cosign verify-blob`` returned (a rename, a replace, or an in-place
-    rewrite of the same inode) fails the check and aborts the stage before a
-    single member is written. The caller additionally stages inside a
-    root-only directory (:func:`_root_only_staging_dir`) so no unprivileged
-    principal can reach the artifact in the first place; this check is the
-    inner, non-negotiable guarantee, not a substitute for that isolation.
+    construction, the bytes that are unpacked. Any substitution between
+    ``cosign verify-blob`` returning and this hash pass (a rename, a replace,
+    or an in-place rewrite of the artifact) fails the check and aborts the
+    stage before a single member is written. A rewrite of the pinned inode
+    *after* the hash pass is not re-checked — the fd pins the inode, not its
+    bytes — so the guarantee against that is the root-only staging isolation
+    (:func:`_root_only_staging_dir`), which keeps any unprivileged principal
+    from reaching the artifact in the first place. This digest check is the
+    inner, non-negotiable half; the isolation is the load-bearing one.
 
     If ``dest`` already exists and looks like a prior hal0 extraction
     (see :func:`_looks_like_hal0_install`), it is renamed aside
-    to ``dest.with_suffix(.stale-<unix-ts>)`` so a retry after a half-
+    to ``dest.with_name(<name>.stale-<unix-ts>)`` so a retry after a half-
     failed apply isn't permanently wedged. Unrelated non-empty dirs are
     still refused — we will not silently destroy whatever the operator
     parked there.
@@ -1357,6 +1405,9 @@ def _extract_tarball(
     # Tidy older quarantines now that a good tree exists at `dest` — the
     # recovery material for *this* failure is kept, ancient copies are not.
     _reap_stale_quarantines(dest, job_id=job_id)
+    # Sweep any staging dirs orphaned by a SIGKILLed stage (the current one is
+    # still live and too fresh to match the age floor).
+    _reap_stale_staging_dirs(job_id=job_id)
 
     log.info("updater.extract_ok", job_id=job_id, dest=str(dest))
 
@@ -1370,9 +1421,14 @@ def _open_digest_verified(tarball: Path, expected_digest: str | None) -> BinaryI
 
     This is the #1738 fix's inner guarantee: hashing and extracting share a
     single file object, so nothing that happens to the *path* between
-    ``cosign verify-blob`` and ``tarfile.open`` can change what gets
-    unpacked, and an in-place rewrite of the same inode is caught by the
-    digest itself.
+    ``cosign verify-blob`` and ``tarfile.open`` — a rename or an
+    ``os.replace`` of a different inode — can change what gets unpacked.
+    Holding the fd pins the *inode*, not its bytes: a rewrite of the pinned
+    inode after this hash pass would not be re-checked, so the load-bearing
+    guarantee against that is the root-only staging isolation
+    (:func:`_root_only_staging_dir`), which keeps any other principal from
+    reaching the artifact at all. This check is the non-negotiable inner half,
+    not a standalone one.
     """
     try:
         # SIM115 off: returning the *still-open* handle is the entire point —
@@ -3422,7 +3478,8 @@ class Updater:
 
           1. Fetch + schema-validate the release manifest.
           2. Confirm the target version (caller-pinned or manifest.version).
-          3. Download tarball + signature to ``/var/lib/hal0/cache/<version>/``.
+          3. Download tarball + signature into a root-only staging dir under
+             the install root (#1738 — never the hal0-writable cache).
           4. SHA-256 verify against the manifest digest.
           5. Cosign verify-blob against the GH Actions OIDC identity.
           6. Extract to ``/usr/lib/hal0-<version>/`` (refuse non-empty).

--- a/tests/updater/test_staging_toctou.py
+++ b/tests/updater/test_staging_toctou.py
@@ -25,6 +25,7 @@ tests exercise the same synthetic release the rest of the updater suite does.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -215,6 +216,51 @@ def test_old_quarantine_dirs_are_reaped(
     assert not ancient.exists(), "an ancient quarantine dir was not reaped"
     assert not old.exists(), "an old quarantine dir was not reaped"
     assert recent.is_dir(), "a recent quarantine dir must be kept for recovery"
+
+
+def test_orphaned_staging_dirs_are_reaped(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """A ``.stage-*`` dir left by a SIGKILLed stage is swept on the next apply.
+
+    ``_root_only_staging_dir`` only cleans up in a ``finally``, so a stage
+    killed by SIGKILL / OOM / power-cut leaks a fresh ``mkdtemp`` dir holding a
+    full release tarball under the root filesystem, forever. An in-flight
+    stage's own dir is fresh and must survive.
+    """
+    root = _usr_lib_root()
+    root.mkdir(parents=True, exist_ok=True)
+
+    orphan = root / ".stage-0.0.1-deadbeef"
+    orphan.mkdir()
+    (orphan / "hal0-0.0.1.tar.gz").write_bytes(b"\x1f\x8b" + b"leaked tarball" * 64)
+    old_time = time.time() - 3 * 3600
+    os.utime(orphan, (old_time, old_time))
+
+    asyncio.run(Updater().apply())
+
+    assert not orphan.exists(), "an orphaned staging dir was not reaped"
+    # The apply's own (now torn-down) staging dir left nothing either.
+    leftovers = [p for p in root.iterdir() if p.name.startswith(".stage-")]
+    assert leftovers == [], f"staging dirs leaked: {leftovers}"
+
+
+def test_live_staging_dir_is_not_reaped(
+    synthetic_release: dict[str, Any],  # noqa: F811
+    cosign_skip: None,  # noqa: F811
+) -> None:
+    """A freshly-created ``.stage-*`` dir (a concurrent live stage) is spared."""
+    root = _usr_lib_root()
+    root.mkdir(parents=True, exist_ok=True)
+
+    fresh = root / ".stage-9.9.9-livestage"
+    fresh.mkdir()
+    (fresh / "in-flight.tar.gz").write_bytes(b"\x1f\x8b" + b"live" * 8)
+
+    asyncio.run(Updater().apply())
+
+    assert fresh.is_dir(), "a fresh (live) staging dir must not be reaped"
 
 
 # ── P3: the pyproject fallback must actually work ──────────────────────────────


### PR DESCRIPTION
## What

The `#1745` adversarial review flagged two follow-ups; this closes #1754.

1. **`.stage-*` staging-dir leak (P3 disk leak).** `_root_only_staging_dir` (updater.py) creates `mkdtemp(prefix=".stage-<version>-", dir=/usr/lib/hal0)` and tears it down in a `finally`. `finally` does not run on SIGKILL / OOM / power-cut, and the privileged helper is hard-bounded at `_STAGE_TIMEOUT = 1800s`, so a timed-out or killed stage leaves a full release tarball under the root filesystem forever. The existing `.stale-` quarantine reaper (`_reap_stale_quarantines`) only matches `f"{install_dir.name}.stale-"`, so nothing swept the `.stage-` prefix — one leaked dir per killed stage. Ironic given #1745 added a reaper for exactly this class of leak on `.stale-`.

   Adds `_reap_stale_staging_dirs()`, called right after `_reap_stale_quarantines` in `_extract_tarball`. It removes `.stage-*` dirs under the install root older than `_STAGING_MAX_AGE_S = 3600s` by mtime. The floor sits well above the 1800s stage timeout, so a live concurrent stage — whose dir is always freshly created — can never be swept. Best-effort and logged, exactly like the quarantine reaper.

2. **Docstring corrections.** The `_open_digest_verified` / `_extract_tarball` docstrings claimed "an in-place rewrite of the same inode is caught by the digest itself." That's only true for a rewrite *before* the hash pass — holding the fd pins the inode, not its bytes, so a post-hash rewrite of the pinned inode is not re-checked. The load-bearing guarantee against that is the root-only staging isolation, and the docstrings now say so. Also `with_suffix` → `with_name` in the quarantine-rename note (the code already uses `with_name`), and `prepare()`'s step-3 line still pointed at the retired `/var/lib/hal0/cache/<version>/` staging path.

## Tests

- `test_orphaned_staging_dirs_are_reaped` — a planted old `.stage-0.0.1-deadbeef/` holding a tarball is swept by a subsequent `apply()`. Red-first verified: fails without the reaper.
- `test_live_staging_dir_is_not_reaped` — a fresh `.stage-*` (a concurrent live stage) survives. Passes both ways (negative control).

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/system tests/installer -q
760 passed, 1 skipped in 14.37s
```
`ruff format --check` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)