### PR TITLE
fix(updater): converge outstanding v1.0 profile-catalog reset when up to date (#1585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ applying. Add those subsections to a version's section to surface them; see
 ### Fixed
 
 - Enabling the rerank capability now creates/loads the `rerank` slot the dispatcher actually routes `/v1/rerankings` to (was `embed-rerank`, which nothing routed to); `embed-rerank` resolves as an alias.
+- `hal0 update` on an already-current box now converges an outstanding one-shot v1.0 profile-catalog reset instead of printing "nothing to apply" and hiding it (#1585). The reset rides `commit()`, but a box updated 0.9.8→1.0 ran commit under the *old* daemon, which had no reset — so it landed converged-except-for-this and then went silent. `/api/updates/check` now carries a read-only `profile_reset` snapshot, and a new local `POST /api/updates/converge-profiles` runs the reset with no download or swap. The up-to-date CLI path consults the snapshot: it converges (prompting or honoring `--yes` for the consent-needing case), converges silently when there's nothing to lose, and otherwise reports the reset as outstanding and exits 2 (up to date, convergence outstanding) rather than exiting 0 in silence.
 
 ## [1.0.0-rc.3] — 2026-08-09
 

--- a/src/hal0/api/routes/updater.py
+++ b/src/hal0/api/routes/updater.py
@@ -48,7 +48,14 @@ from hal0.config import paths
 from hal0.config.loader import hal0_config_txn, load_hal0_config
 from hal0.config.schema import Hal0Config
 from hal0.release.policy import ReleaseKind
-from hal0.updater import Updater, fetch_release_manifest, releases_url, validate_release_version
+from hal0.updater import (
+    Updater,
+    fetch_release_manifest,
+    profile_reset_status,
+    releases_url,
+    reset_profile_catalog,
+    validate_release_version,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -660,6 +667,11 @@ async def check_updates(request: Request) -> dict[str, Any]:
 
     # A revoked (yanked) latest is never offered as an available update.
     update_available = bool(latest) and not revoked and _is_newer(latest, __version__)
+    # #1585: the one-shot v1.0 profile-catalog reset runs inside commit(), so a
+    # box updated 0.9.8→1.0 by the OLD daemon (which had no reset) lands
+    # converged-except-for-this and then goes silent — `hal0 update` says
+    # "nothing to apply" and never mentions it. Surfacing the read-only status
+    # here lets the up-to-date CLI path converge it locally without an update.
     return {
         "current": __version__,
         "latest": latest or None,
@@ -669,6 +681,7 @@ async def check_updates(request: Request) -> dict[str, Any]:
         "revoked_reason": revoked_reason,
         "manifest_url": url,
         "manifest": manifest if isinstance(manifest, dict) else {},
+        "profile_reset": await asyncio.to_thread(profile_reset_status),
     }
 
 
@@ -835,6 +848,36 @@ async def commit_update(request: Request) -> dict[str, Any]:
     _persist_job(jobs[job_id])
     _spawn_update_task(request, _run_commit_job(jobs, job_id, channel, version, reset_profiles))
     return dict(jobs[job_id])
+
+
+@router.post("/converge-profiles")
+async def converge_profiles(request: Request) -> dict[str, Any]:
+    """Run the one-shot v1.0 profile-catalog reset as a standalone convergence.
+
+    #1585: the reset normally rides ``commit()``, but a box updated 0.9.8→1.0
+    ran commit under the *old* daemon, which had no reset — so it lands
+    converged-except-for-this and the up-to-date ``hal0 update`` path used to go
+    silent. This endpoint converges it without an update: no download, no
+    staging, no symlink swap — a purely local read-modify-write of
+    ``/etc/hal0``. It is idempotent (a stamped box reports ``already_reset`` and
+    changes nothing) and synchronous (the op is a backup + unlink + stamp, not a
+    job worth polling).
+
+    Body (optional): ``{"reset_profiles": true}`` — the operator's explicit
+    consent, exactly as ``/commit`` takes it. Omitted / false means no consent:
+    if the reset would destroy operator-authored profiles it is left outstanding
+    (``outcome: "declined"``); a no-op reset (fresh box, seeds only, or an
+    unparseable file) converges regardless. This daemon has no TTY, so consent
+    is always the caller's to supply.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    reset_profiles = body.get("reset_profiles") if isinstance(body, dict) else None
+    approved = True if reset_profiles is True else None
+    result = await asyncio.to_thread(reset_profile_catalog, approved=approved)
+    return dict(result)
 
 
 @router.get("/status/{job_id}")

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -266,6 +266,63 @@ def _decide_profile_reset(status: dict | None, *, yes: bool) -> bool | None:
     return None
 
 
+def _maybe_converge_profiles(status: dict | None, *, yes: bool) -> bool:
+    """Converge an outstanding v1.0 profile-catalog reset when no update is due.
+
+    #1585: the reset rides ``commit()``, but a box updated 0.9.8→1.0 ran commit
+    under the old daemon (no reset), so it lands converged-except-for-this and
+    the up-to-date path used to print "nothing to apply" and hide it. When the
+    ``/check`` snapshot says a reset is still due, converge it here — a local
+    ``/converge-profiles`` call, no download or swap.
+
+    Returns True when it handled the situation (converged, or raised ``Exit(2)``
+    because a consent-needing reset is outstanding). Returns False when there is
+    nothing due — the caller then prints its usual "nothing to apply".
+    """
+    if not isinstance(status, dict) or not status.get("due"):
+        return False
+
+    reset_profiles = _decide_profile_reset(status, yes=yes)
+
+    # Consent needed but not given (headless, or interactively declined): honor
+    # the half-converged contract — name it as outstanding and exit 2, distinct
+    # from a clean "up to date" (0).
+    if status.get("needs_consent") and reset_profiles is not True:
+        console.print(
+            Panel(
+                "[yellow]up to date, but this install is NOT fully converged.[/yellow]\n"
+                "The one-shot v1.0 profile-catalog reset is still outstanding.\n"
+                "[dim]Re-run `hal0 update --yes` on a terminal to converge. "
+                "(exit 2 = up to date, convergence outstanding)[/dim]",
+                border_style="yellow",
+            )
+        )
+        raise typer.Exit(2)
+
+    convergence_body: dict[str, object] = {}
+    if reset_profiles is True:
+        convergence_body["reset_profiles"] = True
+    try:
+        result = api_post("/api/updates/converge-profiles", json=convergence_body)
+    except CliApiError as exc:
+        die(str(exc))
+        return True
+
+    if result.get("performed"):
+        backup = result.get("backup")
+        console.print(
+            Panel(
+                "[green]profile catalog converged.[/green]"
+                + (f"\n[dim]backup: {backup}[/dim]" if backup else ""),
+                border_style="green",
+            )
+        )
+    else:
+        # already_reset / no_config — nothing was outstanding after all.
+        console.print("[dim]nothing to apply.[/dim]")
+    return True
+
+
 def _print_convergence(convergence: dict | None) -> bool:
     """Report how far the updated box is from the v1.0 on-disk shape.
 
@@ -516,6 +573,12 @@ def update(
 
     target_version = (target or "").lstrip("v") or None
     if not body.get("update_available") and not target_version:
+        # No new version — but a v1.0 profile-catalog reset may still be
+        # outstanding (#1585): it runs in commit(), which on the 0.9.8→1.0
+        # update ran under the old daemon that had no reset. Converge it here
+        # rather than going silent.
+        if _maybe_converge_profiles(body.get("profile_reset"), yes=yes):
+            return
         console.print("[dim]nothing to apply.[/dim]")
         return
 

--- a/tests/api/test_updater_routes.py
+++ b/tests/api/test_updater_routes.py
@@ -84,6 +84,70 @@ def test_check_returns_well_formed_envelope_with_update_available(
     assert isinstance(body["manifest"], dict)
 
 
+def test_check_includes_profile_reset_snapshot(isolated_client: TestClient) -> None:
+    """#1585: /check carries a read-only profile_reset status so the up-to-date
+    CLI path can converge an outstanding v1.0 reset without an update."""
+    r = isolated_client.get("/api/updates/check")
+    assert r.status_code == 200, r.text
+    pr = r.json()["profile_reset"]
+    assert isinstance(pr, dict)
+    assert "due" in pr and "needs_consent" in pr
+
+
+def _seed_pre_v1(hal0_home: str, *, custom: str | None = None) -> None:
+    """Write a pre-v1.0 hal0.toml (schema_version 1) and an optional custom profile."""
+    from hal0.config.paths import hal0_toml, profiles_toml
+
+    ht = hal0_toml()
+    ht.parent.mkdir(parents=True, exist_ok=True)
+    ht.write_text(
+        "[meta]\nschema_version = 1\n\n[slots]\nport_range_start = 8081\n", encoding="utf-8"
+    )
+    if custom is not None:
+        pt = profiles_toml()
+        pt.parent.mkdir(parents=True, exist_ok=True)
+        pt.write_text(f"[profile.{custom}]\ndescription = 'mine'\n", encoding="utf-8")
+
+
+def test_converge_profiles_resets_a_pre_v1_box_with_consent(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """#1585: a standalone converge deletes the pre-v1 catalog, stamps the gate,
+    and is idempotent — no update, no staging."""
+    from hal0.config.paths import profiles_toml
+
+    _seed_pre_v1(tmp_hal0_home, custom="mine")
+    assert profiles_toml().exists()
+
+    r = isolated_client.post("/api/updates/converge-profiles", json={"reset_profiles": True})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["performed"] is True
+    assert body["outcome"] == "reset"
+    assert body["backup"]
+    assert not profiles_toml().exists()
+
+    # Idempotent: a second call is a no-op on the now-stamped box.
+    r2 = isolated_client.post("/api/updates/converge-profiles", json={"reset_profiles": True})
+    assert r2.json()["outcome"] == "already_reset"
+    assert r2.json()["performed"] is False
+
+
+def test_converge_profiles_without_consent_leaves_custom_profiles(
+    isolated_client: TestClient, tmp_hal0_home: str
+) -> None:
+    """No consent + operator-authored profiles → declined, nothing deleted."""
+    from hal0.config.paths import profiles_toml
+
+    _seed_pre_v1(tmp_hal0_home, custom="mine")
+    r = isolated_client.post("/api/updates/converge-profiles", json={})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["performed"] is False
+    assert body["outcome"] == "declined"
+    assert profiles_toml().exists()
+
+
 def test_state_returns_shape_expected_by_dashboard(
     isolated_client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -307,6 +307,105 @@ def test_tty_decline_stages_without_commit(stub_api: dict, monkeypatch: pytest.M
     assert stub_api["commit_json"] is None  # declined → no commit
 
 
+def _up_to_date_stub(
+    monkeypatch: pytest.MonkeyPatch, *, profile_reset: dict, converge_result: dict
+) -> dict:
+    """Wire the CLI so /check reports no update but the given profile_reset, and
+    /converge-profiles returns ``converge_result``. Returns a captured dict."""
+    captured: dict = {"posts": [], "converge_json": None}
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    monkeypatch.setattr("hal0.updater.updater._is_editable_install", lambda: False)
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        return {
+            "current": "1.0.0",
+            "latest": "1.0.0",
+            "channel": "stable",
+            "update_available": False,
+            "manifest": {},
+            "profile_reset": profile_reset,
+        }
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        captured["posts"].append(path)
+        if path == "/api/updates/converge-profiles":
+            captured["converge_json"] = json
+            return converge_result
+        return {}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    return captured
+
+
+def test_up_to_date_converges_outstanding_reset_with_yes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1585: no update available but the v1.0 reset is due — `--yes` converges
+    it via /converge-profiles instead of printing a silent "nothing to apply"."""
+    cap = _up_to_date_stub(
+        monkeypatch,
+        profile_reset={"due": True, "needs_consent": True, "custom_profiles": ["mine"]},
+        converge_result={"performed": True, "outcome": "reset", "backup": "/var/lib/hal0/b.toml"},
+    )
+    result = runner.invoke(app, ["update", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert "/api/updates/converge-profiles" in cap["posts"]
+    assert cap["converge_json"] == {"reset_profiles": True}
+    assert "profile catalog converged" in result.output
+    assert "nothing to apply" not in result.output
+
+
+def test_up_to_date_outstanding_reset_headless_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless without --yes: a consent-needing reset is left outstanding, and
+    the CLI exits 2 (up to date, convergence outstanding) — never silent."""
+    cap = _up_to_date_stub(
+        monkeypatch,
+        profile_reset={"due": True, "needs_consent": True, "custom_profiles": ["mine"]},
+        converge_result={},
+    )
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 2, result.output
+    assert "NOT fully converged" in result.output
+    # Nothing was posted — consent was absent, so no wipe was attempted.
+    assert "/api/updates/converge-profiles" not in cap["posts"]
+
+
+def test_up_to_date_no_consent_needed_converges_silently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A due reset with nothing to lose (no custom profiles) converges without a
+    prompt even headless — reset_profiles is not sent, but the call is made."""
+    cap = _up_to_date_stub(
+        monkeypatch,
+        profile_reset={"due": True, "needs_consent": False, "custom_profiles": []},
+        converge_result={"performed": True, "outcome": "reset", "backup": None},
+    )
+    monkeypatch.setattr(uc, "_interactive", lambda: False)
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0, result.output
+    assert cap["converge_json"] == {}  # no consent flag needed
+    assert "profile catalog converged" in result.output
+
+
+def test_up_to_date_no_reset_due_says_nothing_to_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ordinary up-to-date box (reset already done) still says so, cleanly."""
+    cap = _up_to_date_stub(
+        monkeypatch,
+        profile_reset={"due": False, "reason": "already_reset", "needs_consent": False},
+        converge_result={},
+    )
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0, result.output
+    assert "nothing to apply" in result.output
+    assert "/api/updates/converge-profiles" not in cap["posts"]
+
+
 def test_rollback_headless_proceeds_without_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     """Headless/piped (non-TTY) rollback proceeds unattended, like apply."""
     monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)


### PR DESCRIPTION
## Problem

The one-shot v1.0 profile-catalog reset (#1574) rides `commit()`. But a box updated **0.9.8 → 1.0** ran `commit()` inside the *old* 0.9.8 daemon, whose updater had zero knowledge of the reset (`grep -c profile_reset` on 0.9.8's `updater.py` = 0). The new code only takes over after the post-swap restart, by which point the update job is done.

Net effect (validated on CT150 in the rc.1 report): every pre-v1.0 box completes the update **without** the catalog reset, then `hal0 update` prints `nothing to apply.` and exits 0 — never mentioning the reset is outstanding — until the *next* release finally runs the gate. That violates #1574's own "refuse to hand back a half-converged box without saying so" principle, in exactly the transition the feature was built for.

## Fix — option (a) from the issue: converge locally, no update required

- **`/api/updates/check`** now carries a read-only `profile_reset` snapshot (`profile_reset_status()`), so the up-to-date CLI path can see an outstanding reset.
- **New `POST /api/updates/converge-profiles`** runs `reset_profile_catalog()` as a standalone convergence: no download, no staging, no symlink swap — a purely local backup + unlink + stamp. Idempotent (`already_reset` on a stamped box) and synchronous (no job to poll). Takes the same `{"reset_profiles": true}` consent body as `/commit` (the daemon has no TTY).
- **The up-to-date CLI path** (`hal0 update`, the `nothing to apply` branch) consults the snapshot:
  - reset due, consent needed, `--yes` or interactive-confirm → converge via `/converge-profiles`;
  - reset due, nothing to lose (fresh box / seeds-only / unparseable) → converge silently;
  - reset due, consent needed, headless or declined → report it outstanding and **exit 2** (up to date, convergence outstanding), distinct from a clean `0`;
  - not due → the ordinary `nothing to apply.` exit 0.

This also gives 0.9.8→1.0 upgraders convergence on their first post-update `hal0 update`, one release early.

## Tests

CLI (`tests/cli/test_update_commands.py`): converge-with-`--yes`, headless-exit-2, no-consent-needed-silent-converge, and the ordinary not-due `nothing to apply`. Red-first verified (the three behavioral tests fail without the CLI change; the not-due one passes both ways).

API (`tests/api/test_updater_routes.py`): `/check` carries the `profile_reset` snapshot; `/converge-profiles` resets a seeded pre-v1 box with consent + is idempotent; declines without consent and leaves custom profiles intact.

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/updater tests/api/test_updater_routes.py tests/cli/test_update_commands.py -q
348 passed
```
`ruff format --check` + `ruff check` clean.

## Out of scope / follow-up

The rc.1 report also noted a cosmetic old-client `ConnectError` (the 0.9.8 CLI dies with exit 1 when the apply restarts hal0-api under its status poll, even though the update succeeds). That's unavoidable in already-shipped clients and belongs in the 1.0.0 release notes as a Known Issue ("verify with `hal0 --version`"), not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)