### PR TITLE
feat(bench): shareable result bundles + explicit upload client

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -48,7 +48,7 @@ global flag is controlled per-command via environment variables instead — see
 | `hal0 probe` | **Deprecated**, hidden. Alias for `hal0 config hardware --refresh`. | — |
 | `hal0 serve` | Start the hal0 API server (used by `hal0-api.service`). | `--host` (default `127.0.0.1`, env `HAL0_BIND_HOST`), `--port` (default `8080`, env `HAL0_PORT`), `--reload` |
 | `hal0 uninstall` | Uninstall hal0. Conservative by default. | `--purge` (alias `--clean-slate`), `--keep-data`, `--force`/`-f` (honors `HAL0_FORCE=1`), `--dev` (tears down a dev install at `$PWD/.hal0ai`) |
-| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval` |
+| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval, bundle, upload` |
 | `hal0 chat` | Interactive chat REPL. | `--model` (default `"agent"`), `--base-url` (default `http://127.0.0.1:8080/v1`, env `HAL0_CHAT_BASE_URL`), `--no-stream`, `--brain` (talk to the hal0-brain steward instead) |
 | `hal0 system-info` | Host system info. | `--json` |
 | `hal0 ports` | Port allocation view. | `--json` |

--- a/docs/reference/model-roster-benchmark.mdx
+++ b/docs/reference/model-roster-benchmark.mdx
@@ -125,7 +125,7 @@ curated per-*profile*, not per-model, and is distinct from the JSONL pipeline ab
 ### CLI
 
 ```sh
-hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval
+hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|bundle|upload
 ```
 
 `hal0 bench` is a raw argparse passthrough (not a Typer sub-app) — run
@@ -134,3 +134,18 @@ hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval
 (drives `llama-bench`/`llama-server`), `bench/store.py` (JSONL/db layer),
 `bench/publish.py` (pushes results to the dashboard), `bench/suites.py`,
 `bench/regress.py`.
+
+### Sharing results
+
+Benchmark results never leave the box automatically. To share a run on
+[hal0.dev/benchmarks](https://hal0.dev/benchmarks):
+
+```bash
+hal0 bench bundle --list                       # see what's eligible
+hal0 bench bundle --runs <run_id> --title "Strix Halo, ROCm 7" -o run.hal0bench.tar.gz
+HAL0_BENCH_TOKEN=... hal0 bench upload run.hal0bench.tar.gz
+```
+
+A bundle contains the schema-2 records (resolved flags, engine digests,
+telemetry), the profile/suite TOMLs you pass with `--profile`, and optional
+raw artifacts (`--with-artifacts`). `host.name` is redacted by default.

--- a/src/hal0/bench/bundle.py
+++ b/src/hal0/bench/bundle.py
@@ -10,9 +10,18 @@ trusting the client.
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import io
+import json
+import tarfile
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
+from .evalrun import read_evals
+from .schema import canonical_json
 from .store import Store
 
 
@@ -52,3 +61,107 @@ def select_records(store: Store, spec: BundleSpec) -> list[dict[str, Any]]:
             continue
         out.append(rec)
     return out
+
+
+BUNDLE_SCHEMA = 1
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _redact(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out = []
+    for rec in records:
+        rec = copy.deepcopy(rec)
+        if "host" in rec:
+            rec["host"]["name"] = "redacted"
+        out.append(rec)
+    return out
+
+
+def _hal0_version() -> str:
+    try:
+        import hal0
+
+        return getattr(hal0, "__version__", "") or ""
+    except ImportError:
+        return ""
+
+
+def write_bundle(
+    store: Store, spec: BundleSpec, out_path: Path | str
+) -> tuple[Path, dict[str, Any]]:
+    """Build a bundle tar.gz at ``out_path``; returns (path, manifest).
+
+    Members: manifest.json + records.jsonl + optional evals.jsonl +
+    profiles/*.toml + optional artifacts/<run_id>/*. ``bundle_id`` is the
+    sha256 of the canonical files-hash map — content-addressed, so a re-pack
+    of identical content dedupes server-side, and any member tamper breaks it.
+    """
+    records = select_records(store, spec)
+    if not records:
+        raise ValueError("no ok records match the selection — nothing to bundle")
+    if spec.redact_hostname:
+        records = _redact(records)
+
+    model_ids = {r.get("identity", {}).get("model", {}).get("id") for r in records}
+    evals = [e for e in read_evals() if e.get("model") in model_ids]
+
+    members: dict[str, bytes] = {}
+    members["records.jsonl"] = ("\n".join(canonical_json(r) for r in records) + "\n").encode()
+    if evals:
+        members["evals.jsonl"] = ("\n".join(canonical_json(e) for e in evals) + "\n").encode()
+    profiles_meta = []
+    for p in spec.profile_paths:
+        pp = Path(p)
+        data = pp.read_bytes()
+        arcname = f"profiles/{pp.name}"
+        members[arcname] = data
+        profiles_meta.append({"name": pp.name, "sha256": _sha256(data)})
+    if spec.with_artifacts:
+        for rec in records:
+            run_id = rec["run_id"]
+            adir = store.artifacts_root / run_id
+            if adir.is_dir():
+                for f in sorted(adir.rglob("*")):
+                    if f.is_file():
+                        members[f"artifacts/{run_id}/{f.relative_to(adir)}"] = f.read_bytes()
+
+    files = {name: _sha256(data) for name, data in sorted(members.items())}
+    bundle_id = "sha256:" + _sha256(canonical_json(files).encode())
+
+    host = copy.deepcopy(records[-1].get("host", {}))  # newest record's env
+    manifest = {
+        "bundle_schema": BUNDLE_SCHEMA,
+        "bundle_id": bundle_id,
+        "created_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hal0_version": _hal0_version(),
+        "title": spec.title,
+        "notes": spec.notes,
+        "host": host,
+        "records": [
+            {
+                "run_id": r["run_id"],
+                "cell_key": r.get("cell_key", ""),
+                "kind": r.get("identity", {}).get("workload", {}).get("kind", ""),
+                "model_id": r.get("identity", {}).get("model", {}).get("id", ""),
+            }
+            for r in records
+        ],
+        "profiles": profiles_meta,
+        "artifacts": spec.with_artifacts,
+        "files": files,
+    }
+
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(out, "w:gz") as tf:
+        payload = {"manifest.json": json.dumps(manifest, indent=2).encode(), **members}
+        for name in sorted(payload):
+            data = payload[name]
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            info.mtime = 0  # deterministic archive for byte-identical re-packs
+            tf.addfile(info, io.BytesIO(data))
+    return out, manifest

--- a/src/hal0/bench/bundle.py
+++ b/src/hal0/bench/bundle.py
@@ -162,6 +162,8 @@ def write_bundle(
             data = payload[name]
             info = tarfile.TarInfo(name)
             info.size = len(data)
-            info.mtime = 0  # deterministic archive for byte-identical re-packs
+            info.mtime = (
+                0  # stable member metadata; determinism lives in bundle_id, not archive bytes
+            )
             tf.addfile(info, io.BytesIO(data))
     return out, manifest

--- a/src/hal0/bench/bundle.py
+++ b/src/hal0/bench/bundle.py
@@ -1,0 +1,54 @@
+"""bundle.py — the shareable result bundle (site-pipeline DESIGN, P1).
+
+A bundle is a SELECTION + PACKAGING layer over the store: no new measurement,
+no mutation. Only ``ok`` records are eligible (Outcome contract, schema.py) —
+the public board must never carry a contended or failed number. The manifest
+carries a sha256 for every member file and a ``bundle_id`` derived from those
+hashes, so the server can verify integrity and dedupe re-uploads without
+trusting the client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .store import Store
+
+
+@dataclass
+class BundleSpec:
+    """What goes into a bundle. All selectors AND together; an empty spec
+    selects every ok record (explicit upload is still a separate verb, so an
+    over-wide bundle is inspectable before it goes anywhere)."""
+
+    run_ids: list[str] | None = None
+    suite: str | None = None
+    since: str | None = None  # ISO lower bound, compared against run_id's stamp
+    title: str = ""
+    notes: str = ""
+    with_artifacts: bool = False
+    redact_hostname: bool = True
+    profile_paths: list[str] = field(default_factory=list)
+
+
+def _record_ts(rec: dict[str, Any]) -> str:
+    run_id = rec.get("run_id") or ""
+    return run_id.split("Z-")[0] + "Z" if "Z-" in run_id else run_id
+
+
+def select_records(store: Store, spec: BundleSpec) -> list[dict[str, Any]]:
+    """Filter records.jsonl down to the bundle's contents, append order kept."""
+    wanted = set(spec.run_ids) if spec.run_ids else None
+    out: list[dict[str, Any]] = []
+    for rec in store.iter_records():
+        if rec.get("outcome") != "ok":
+            continue
+        if wanted is not None and rec.get("run_id") not in wanted:
+            continue
+        if spec.suite and rec.get("suite") != spec.suite:
+            continue
+        if spec.since and _record_ts(rec) < spec.since:
+            continue
+        out.append(rec)
+    return out

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -581,6 +581,41 @@ def cmd_publish(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_bundle(args: argparse.Namespace) -> int:
+    from .bundle import BundleSpec, select_records, write_bundle
+
+    store = Store()
+    spec = BundleSpec(
+        run_ids=args.runs.split(",") if args.runs else None,
+        suite=args.bundle_suite,
+        since=args.since,
+        title=args.title,
+        notes=args.notes,
+        with_artifacts=args.with_artifacts,
+        redact_hostname=not args.no_redact_hostname,
+        profile_paths=args.profile or [],
+    )
+    if args.list:
+        recs = select_records(store, spec)
+        print(f"{len(recs)} bundle-eligible record(s):")
+        for r in recs:
+            ident = r.get("identity", {})
+            print(
+                f"  {r['run_id']}  {ident.get('model', {}).get('id', '?'):40s} "
+                f"{ident.get('lane', '?'):12s} "
+                f"{ident.get('workload', {}).get('kind', '?'):6s} "
+                f"suite={r.get('suite', '?')}"
+            )
+        return 0
+    try:
+        path, manifest = write_bundle(store, spec, args.out)
+    except ValueError as exc:
+        print(f"bundle: {exc}", file=sys.stderr)
+        return 1
+    print(f"wrote {path} ({len(manifest['records'])} record(s), {manifest['bundle_id']})")
+    return 0
+
+
 def cmd_eval(args: argparse.Namespace) -> int:
     """Agentic task eval (the quality tier): drive each model as a real Hermes
     agent through verifiable-value tasks and score correctness + speed.
@@ -775,6 +810,24 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--check", action="store_true", help="diff without writing")
     p.add_argument("--site-ts", default=None, help="also emit the site data .ts to this path")
     p.set_defaults(func=cmd_publish)
+
+    p = sub.add_parser("bundle", help="package selected ok records into a shareable archive")
+    p.add_argument("--list", action="store_true", help="print bundle-eligible records; no write")
+    p.add_argument("--runs", default=None, help="comma-separated run_ids (default: all ok)")
+    # --suite is taken at the top level; dest avoids colliding with other verbs' args.suite
+    p.add_argument(
+        "--suite", dest="bundle_suite", default=None, help="only records from this suite"
+    )
+    p.add_argument("--since", default=None, help="ISO lower bound on record timestamp")
+    p.add_argument("--title", default="", help="human title stored in the manifest")
+    p.add_argument("--notes", default="", help="free-form notes stored in the manifest")
+    p.add_argument("--with-artifacts", action="store_true", help="include raw artifacts/")
+    p.add_argument(
+        "--no-redact-hostname", action="store_true", help="keep host.name in shared records"
+    )
+    p.add_argument("--profile", action="append", help="profile/suite TOML to include; repeatable")
+    p.add_argument("-o", "--out", default="bench-bundle.hal0bench.tar.gz", help="output path")
+    p.set_defaults(func=cmd_bundle)
 
     p = sub.add_parser(
         "eval", help="agentic task eval (quality tier): score a model as a real agent"

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -616,6 +616,23 @@ def cmd_bundle(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_upload(args: argparse.Namespace) -> int:
+    from . import upload as _upload
+
+    path = Path(args.bundle)
+    if not path.is_file():
+        print(f"upload: {path} not found", file=sys.stderr)
+        return 1
+    try:
+        resp = _upload.upload_bundle(path, api=args.upload_api, token=args.token)
+    except _upload.UploadError as exc:
+        print(f"upload: {exc}", file=sys.stderr)
+        return 1
+    url = resp.get("url") or resp.get("bundle_id") or "ok"
+    print(f"uploaded: {url}")
+    return 0
+
+
 def cmd_eval(args: argparse.Namespace) -> int:
     """Agentic task eval (the quality tier): drive each model as a real Hermes
     agent through verifiable-value tasks and score correctness + speed.
@@ -828,6 +845,17 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--profile", action="append", help="profile/suite TOML to include; repeatable")
     p.add_argument("-o", "--out", default="bench-bundle.hal0bench.tar.gz", help="output path")
     p.set_defaults(func=cmd_bundle)
+
+    p = sub.add_parser("upload", help="push a bundle to the public benchmarks API (explicit only)")
+    p.add_argument("bundle", help="path to a .hal0bench.tar.gz built by `hal0 bench bundle`")
+    p.add_argument(
+        "--api",
+        dest="upload_api",
+        default=None,
+        help="bench API base (default $HAL0_BENCH_API_BASE or https://api.hal0.dev)",
+    )
+    p.add_argument("--token", default=None, help="bearer token (default $HAL0_BENCH_TOKEN)")
+    p.set_defaults(func=cmd_upload)
 
     p = sub.add_parser(
         "eval", help="agentic task eval (quality tier): score a model as a real agent"

--- a/src/hal0/bench/upload.py
+++ b/src/hal0/bench/upload.py
@@ -18,6 +18,20 @@ from typing import Any
 DEFAULT_API_BASE = "https://api.hal0.dev"
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse all redirects on the upload POST: the Authorization: Bearer
+    header must never follow a redirect off-host — urllib's default redirect
+    handler would happily re-send it to whatever Location the server names.
+    Returning None here makes urllib raise HTTPError for any 3xx response,
+    which the existing HTTPError handler below turns into an UploadError."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_opener = urllib.request.build_opener(_NoRedirect)
+
+
 class UploadError(Exception):
     def __init__(self, message: str, status: int | None = None) -> None:
         super().__init__(message)
@@ -52,11 +66,11 @@ def upload_bundle(
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=120) as resp:
+        with _opener.open(req, timeout=120) as resp:
             return json.loads(resp.read().decode() or "{}")
     except urllib.error.HTTPError as exc:
         try:
-            payload = json.loads(exc.read().decode() or "{}")
+            payload = json.loads(exc.read().decode(errors="replace") or "{}")
         except json.JSONDecodeError:
             payload = {}
         detail = payload.get("errors") or payload.get("error") or exc.reason

--- a/src/hal0/bench/upload.py
+++ b/src/hal0/bench/upload.py
@@ -1,0 +1,65 @@
+"""upload.py — the explicit, opt-in push of a bundle to the public bench API.
+
+stdlib urllib only (bench-path rule). Nothing here runs automatically: upload
+is a verb the operator invokes, consistent with the project's no-telemetry
+stance. The server dedupes on the manifest's content-addressed bundle_id, so
+retrying a flaky upload is always safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_API_BASE = "https://api.hal0.dev"
+
+
+class UploadError(Exception):
+    def __init__(self, message: str, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def api_base() -> str:
+    return os.environ.get("HAL0_BENCH_API_BASE", "").rstrip("/") or DEFAULT_API_BASE
+
+
+def upload_bundle(
+    path: Path | str, api: str | None = None, token: str | None = None
+) -> dict[str, Any]:
+    """POST the bundle to ``<api>/v1/bundles``; return the parsed JSON reply.
+
+    Raises UploadError with the HTTP status and the server's machine-readable
+    ``errors``/``error`` payload — the CLI prints these verbatim so a rejected
+    bundle is diagnosable without server logs.
+    """
+    tok = token or os.environ.get("HAL0_BENCH_TOKEN", "")
+    if not tok:
+        raise UploadError("no token: set HAL0_BENCH_TOKEN or pass --token")
+    base = (api or api_base()).rstrip("/")
+    data = Path(path).read_bytes()
+    req = urllib.request.Request(
+        f"{base}/v1/bundles",
+        data=data,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {tok}",
+            "Content-Type": "application/gzip",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode() or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        detail = payload.get("errors") or payload.get("error") or exc.reason
+        raise UploadError(f"upload rejected ({exc.code}): {detail}", status=exc.code) from exc
+    except urllib.error.URLError as exc:
+        raise UploadError(f"cannot reach {base}: {exc.reason}") from exc

--- a/tests/bench/test_bundle.py
+++ b/tests/bench/test_bundle.py
@@ -8,6 +8,9 @@ unless explicitly requested.
 
 from __future__ import annotations
 
+import json
+import tarfile
+
 from hal0.bench.bundle import BundleSpec, select_records
 from hal0.bench.store import Store
 
@@ -75,3 +78,86 @@ def test_select_by_suite_and_since(tmp_path, monkeypatch):
     )
     got = select_records(store, BundleSpec(suite="roster", since="2026-08-01"))
     assert [r["run_id"] for r in got] == ["2026-08-05T00:00:00Z-new222"]
+
+
+def test_write_bundle_layout_manifest_and_redaction(tmp_path, monkeypatch):
+    store = _store(tmp_path, monkeypatch, [_rec("2026-08-01T00:00:00Z-aaa111")])
+    # a profile TOML to carry along
+    prof = tmp_path / "chat.toml"
+    prof.write_text('[profile.chat]\nflags = "-fa 1"\n')
+    out = tmp_path / "out.hal0bench.tar.gz"
+
+    from hal0.bench.bundle import write_bundle
+
+    path, _manifest = write_bundle(
+        store,
+        BundleSpec(title="strix run", profile_paths=[str(prof)]),
+        out,
+    )
+    assert path == out and out.exists()
+
+    with tarfile.open(out, "r:gz") as tf:
+        names = sorted(tf.getnames())
+        assert names == ["manifest.json", "profiles/chat.toml", "records.jsonl"]
+        m = json.loads(tf.extractfile("manifest.json").read())
+        recs = tf.extractfile("records.jsonl").read().decode()
+
+    assert m["bundle_schema"] == 1
+    assert m["bundle_id"].startswith("sha256:")
+    assert m["title"] == "strix run"
+    assert m["records"] == [
+        {
+            "run_id": "2026-08-01T00:00:00Z-aaa111",
+            "cell_key": "sha256:m1-2026-08-01T00:00:00Z-aaa111",
+            "kind": "tg",
+            "model_id": "m1",
+        }
+    ]
+    assert m["profiles"] == [{"name": "chat.toml", "sha256": m["files"]["profiles/chat.toml"]}]
+    # every member except manifest.json is hashed in files{}
+    assert set(m["files"]) == {"records.jsonl", "profiles/chat.toml"}
+    # hostname redacted in BOTH manifest host block and shipped records
+    assert m["host"]["name"] == "redacted"
+    assert m["host"]["gpu"] == "Strix Halo"
+    assert "my-secret-hostname" not in recs
+
+
+def test_bundle_id_is_deterministic_and_content_addressed(tmp_path, monkeypatch):
+    from hal0.bench.bundle import write_bundle
+
+    store = _store(tmp_path, monkeypatch, [_rec("2026-08-01T00:00:00Z-aaa111")])
+    _, m1 = write_bundle(store, BundleSpec(), tmp_path / "a.tar.gz")
+    _, m2 = write_bundle(store, BundleSpec(), tmp_path / "b.tar.gz")
+    assert m1["bundle_id"] == m2["bundle_id"]
+
+    store.append_record(_rec("2026-08-02T00:00:00Z-bbb222"))
+    _, m3 = write_bundle(store, BundleSpec(), tmp_path / "c.tar.gz")
+    assert m3["bundle_id"] != m1["bundle_id"]
+
+
+def test_write_bundle_refuses_empty_selection(tmp_path, monkeypatch):
+    import pytest
+
+    from hal0.bench.bundle import write_bundle
+
+    store = _store(tmp_path, monkeypatch, [_rec("2026-08-01T00:00:00Z-aaa111", outcome="failed")])
+    with pytest.raises(ValueError, match="no ok records"):
+        write_bundle(store, BundleSpec(), tmp_path / "x.tar.gz")
+
+
+def test_write_bundle_includes_evals_for_selected_models(tmp_path, monkeypatch):
+    from hal0.bench.bundle import write_bundle
+
+    store = _store(tmp_path, monkeypatch, [_rec("2026-08-01T00:00:00Z-aaa111", model="m1")])
+    # evals.jsonl lives in the same state root (evalrun._evals_path)
+    (tmp_path / "evals.jsonl").write_text(
+        json.dumps({"run_id": "e1", "model": "m1", "task": "cipher", "score": 1.0})
+        + "\n"
+        + json.dumps({"run_id": "e2", "model": "OTHER", "task": "cipher", "score": 0.0})
+        + "\n"
+    )
+    _, m = write_bundle(store, BundleSpec(), tmp_path / "out.tar.gz")
+    with tarfile.open(tmp_path / "out.tar.gz", "r:gz") as tf:
+        evals = [json.loads(x) for x in tf.extractfile("evals.jsonl").read().decode().splitlines()]
+    assert [e["model"] for e in evals] == ["m1"]
+    assert "evals.jsonl" in m["files"]

--- a/tests/bench/test_bundle.py
+++ b/tests/bench/test_bundle.py
@@ -1,0 +1,77 @@
+"""test_bundle.py — bundle = a faithful, selective package of ok records.
+
+Selection contract: only outcome=="ok" records; filterable by run_id set,
+suite, and ISO `since` lower bound (record ts derives from run_id, same rule
+as store._record_ts). Redaction contract: host.name never leaves the box
+unless explicitly requested.
+"""
+
+from __future__ import annotations
+
+from hal0.bench.bundle import BundleSpec, select_records
+from hal0.bench.store import Store
+
+
+def _rec(run_id: str, outcome: str = "ok", suite: str = "roster", model: str = "m1") -> dict:
+    return {
+        "run_id": run_id,
+        "cell_key": f"sha256:{model}-{run_id}",
+        "suite": suite,
+        "trigger": "manual",
+        "identity": {
+            "model": {"id": model},
+            "lane": "rocm",
+            "workload": {"kind": "tg", "depth": 2048},
+        },
+        "host": {"name": "my-secret-hostname", "gpu": "Strix Halo", "hal0_version": "1.0"},
+        "outcome": outcome,
+        "summary": {"decode_ts_med": 42.0},
+        "schema": 2,
+    }
+
+
+def _store(tmp_path, monkeypatch, records) -> Store:
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    store = Store()
+    for r in records:
+        store.append_record(r)
+    return store
+
+
+def test_select_only_ok_records(tmp_path, monkeypatch):
+    store = _store(
+        tmp_path,
+        monkeypatch,
+        [
+            _rec("2026-08-01T00:00:00Z-aaa111"),
+            _rec("2026-08-01T00:00:01Z-bbb222", outcome="failed"),
+            _rec("2026-08-01T00:00:02Z-ccc333", outcome="oom"),
+        ],
+    )
+    got = select_records(store, BundleSpec())
+    assert [r["run_id"] for r in got] == ["2026-08-01T00:00:00Z-aaa111"]
+
+
+def test_select_by_run_ids(tmp_path, monkeypatch):
+    store = _store(
+        tmp_path,
+        monkeypatch,
+        [_rec("2026-08-01T00:00:00Z-aaa111"), _rec("2026-08-02T00:00:00Z-bbb222")],
+    )
+    spec = BundleSpec(run_ids=["2026-08-02T00:00:00Z-bbb222"])
+    got = select_records(store, spec)
+    assert [r["run_id"] for r in got] == ["2026-08-02T00:00:00Z-bbb222"]
+
+
+def test_select_by_suite_and_since(tmp_path, monkeypatch):
+    store = _store(
+        tmp_path,
+        monkeypatch,
+        [
+            _rec("2026-07-01T00:00:00Z-old111", suite="roster"),
+            _rec("2026-08-05T00:00:00Z-new222", suite="roster"),
+            _rec("2026-08-05T00:00:00Z-new333", suite="smoke"),
+        ],
+    )
+    got = select_records(store, BundleSpec(suite="roster", since="2026-08-01"))
+    assert [r["run_id"] for r in got] == ["2026-08-05T00:00:00Z-new222"]

--- a/tests/bench/test_cli_bundle.py
+++ b/tests/bench/test_cli_bundle.py
@@ -1,0 +1,59 @@
+"""CLI wiring for `hal0 bench bundle` — list mode and build mode. Tests drive
+main(argv) directly (same pattern as the other verb tests) with the store
+pointed at tmp_path via HAL0_BENCH_STATE."""
+
+from __future__ import annotations
+
+import tarfile
+
+from hal0.bench.cli import main
+from hal0.bench.store import Store
+
+
+def _seed(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    store = Store()
+    store.append_record(
+        {
+            "run_id": "2026-08-01T00:00:00Z-aaa111",
+            "cell_key": "sha256:k1",
+            "suite": "roster",
+            "trigger": "manual",
+            "identity": {
+                "model": {"id": "qwen3-30b"},
+                "lane": "rocm",
+                "workload": {"kind": "tg", "depth": 2048},
+            },
+            "host": {"name": "box", "hal0_version": "1.0"},
+            "outcome": "ok",
+            "summary": {"decode_ts_med": 42.0},
+            "schema": 2,
+        }
+    )
+
+
+def test_bundle_list_prints_candidates(tmp_path, monkeypatch, capsys):
+    _seed(tmp_path, monkeypatch)
+    rc = main(["bundle", "--list"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "2026-08-01T00:00:00Z-aaa111" in out
+    assert "qwen3-30b" in out
+
+
+def test_bundle_writes_archive(tmp_path, monkeypatch, capsys):
+    _seed(tmp_path, monkeypatch)
+    out_file = tmp_path / "b.hal0bench.tar.gz"
+    rc = main(["bundle", "--runs", "2026-08-01T00:00:00Z-aaa111", "-o", str(out_file)])
+    assert rc == 0
+    assert out_file.exists()
+    with tarfile.open(out_file, "r:gz") as tf:
+        assert "manifest.json" in tf.getnames()
+    assert "sha256:" in capsys.readouterr().out  # prints bundle_id
+
+
+def test_bundle_empty_selection_fails_cleanly(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    rc = main(["bundle", "-o", str(tmp_path / "x.tar.gz")])
+    assert rc == 1
+    assert "no ok records" in capsys.readouterr().err

--- a/tests/bench/test_cli_upload.py
+++ b/tests/bench/test_cli_upload.py
@@ -1,0 +1,44 @@
+"""CLI wiring for `hal0 bench upload` — monkeypatches the upload module's
+client function (the HTTP path is covered for real in test_upload.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.bench.cli import main
+
+
+@pytest.fixture
+def bundle_file(tmp_path):
+    p = tmp_path / "b.hal0bench.tar.gz"
+    p.write_bytes(b"\x1f\x8bdata")
+    return p
+
+
+def test_upload_prints_url(bundle_file, monkeypatch, capsys):
+    import hal0.bench.upload as up
+
+    monkeypatch.setattr(
+        up, "upload_bundle", lambda path, api=None, token=None: {"url": "https://hal0.dev/x"}
+    )
+    rc = main(["upload", str(bundle_file)])
+    assert rc == 0
+    assert "https://hal0.dev/x" in capsys.readouterr().out
+
+
+def test_upload_error_exits_1(bundle_file, monkeypatch, capsys):
+    import hal0.bench.upload as up
+
+    def _boom(path, api=None, token=None):
+        raise up.UploadError("upload rejected (422): ['bad hash']", status=422)
+
+    monkeypatch.setattr(up, "upload_bundle", _boom)
+    rc = main(["upload", str(bundle_file)])
+    assert rc == 1
+    assert "bad hash" in capsys.readouterr().err
+
+
+def test_upload_missing_file_exits_1(tmp_path, capsys):
+    rc = main(["upload", str(tmp_path / "nope.tar.gz")])
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err

--- a/tests/bench/test_upload.py
+++ b/tests/bench/test_upload.py
@@ -24,6 +24,12 @@ class _Handler(BaseHTTPRequestHandler):
             {"path": self.path, "auth": self.headers.get("Authorization"), "len": len(body)}
         )
         auth = self.headers.get("Authorization", "")
+        if auth == "Bearer redirect-token":
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.1:1/elsewhere")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
         if auth != "Bearer good-token":
             code, payload = 401, {"error": "unauthorized"}
         elif len(body) == 0:
@@ -91,3 +97,9 @@ def test_missing_token_is_a_clean_error(bundle_file, monkeypatch):
     monkeypatch.delenv("HAL0_BENCH_TOKEN", raising=False)
     with pytest.raises(UploadError, match="HAL0_BENCH_TOKEN"):
         upload_bundle(bundle_file, api="http://127.0.0.1:1")
+
+
+def test_upload_does_not_follow_redirect_with_bearer_token(server, bundle_file):
+    with pytest.raises(UploadError) as ei:
+        upload_bundle(bundle_file, api=server, token="redirect-token")
+    assert ei.value.status == 302

--- a/tests/bench/test_upload.py
+++ b/tests/bench/test_upload.py
@@ -1,0 +1,93 @@
+"""Upload client against a real local HTTP server (stdlib http.server in a
+thread) — no mocking of urllib internals, so header/body handling is tested
+for real. Server-side contract exercised: 200 ok, 401 unauthorized, 422 with
+machine-readable errors[]."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+
+import pytest
+
+from hal0.bench.upload import UploadError, upload_bundle
+
+
+class _Handler(BaseHTTPRequestHandler):
+    seen: ClassVar[list[dict]] = []
+
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        _Handler.seen.append(
+            {"path": self.path, "auth": self.headers.get("Authorization"), "len": len(body)}
+        )
+        auth = self.headers.get("Authorization", "")
+        if auth != "Bearer good-token":
+            code, payload = 401, {"error": "unauthorized"}
+        elif len(body) == 0:
+            code, payload = 422, {"errors": ["empty body"]}
+        else:
+            code, payload = 200, {"bundle_id": "sha256:x", "url": "https://hal0.dev/benchmarks"}
+        data = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def log_message(self, *a):  # keep pytest output clean
+        pass
+
+
+@pytest.fixture
+def server():
+    _Handler.seen = []
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{srv.server_port}"
+    srv.shutdown()
+
+
+@pytest.fixture
+def bundle_file(tmp_path):
+    p = tmp_path / "b.hal0bench.tar.gz"
+    p.write_bytes(b"\x1f\x8b-fake-gzip-payload")
+    return p
+
+
+def test_upload_success_posts_bundle_with_bearer(server, bundle_file):
+    resp = upload_bundle(bundle_file, api=server, token="good-token")
+    assert resp["url"] == "https://hal0.dev/benchmarks"
+    req = _Handler.seen[0]
+    assert req["path"] == "/v1/bundles"
+    assert req["auth"] == "Bearer good-token"
+    assert req["len"] == bundle_file.stat().st_size
+
+
+def test_upload_401_raises_with_status(server, bundle_file):
+    with pytest.raises(UploadError) as ei:
+        upload_bundle(bundle_file, api=server, token="bad-token")
+    assert ei.value.status == 401
+
+
+def test_upload_422_surfaces_server_errors(server, tmp_path):
+    empty = tmp_path / "empty.tar.gz"
+    empty.write_bytes(b"")
+    with pytest.raises(UploadError, match="empty body") as ei:
+        upload_bundle(empty, api=server, token="good-token")
+    assert ei.value.status == 422
+
+
+def test_token_from_env(server, bundle_file, monkeypatch):
+    monkeypatch.setenv("HAL0_BENCH_TOKEN", "good-token")
+    resp = upload_bundle(bundle_file, api=server)
+    assert resp["bundle_id"] == "sha256:x"
+
+
+def test_missing_token_is_a_clean_error(bundle_file, monkeypatch):
+    monkeypatch.delenv("HAL0_BENCH_TOKEN", raising=False)
+    with pytest.raises(UploadError, match="HAL0_BENCH_TOKEN"):
+        upload_bundle(bundle_file, api="http://127.0.0.1:1")


### PR DESCRIPTION
## Summary

First slice of the benchmark run + publish pipeline (site-pipeline design P1): package selected schema-2 records into a shareable, content-addressed bundle and push it — explicitly, never automatically — to the public bench API.

- `hal0 bench bundle` — select ok-only records (`--runs`/`--suite`/`--since`, `--list` preview), pack `manifest.json` + `records.jsonl` + optional `evals.jsonl`, profile TOMLs (`--profile`), and raw artifacts (`--with-artifacts`) into a `.hal0bench.tar.gz`. `bundle_id` is sha256 over the member-hash map; `host.name` redacted by default.
- `hal0 bench upload` — stdlib urllib client, `Authorization: Bearer $HAL0_BENCH_TOKEN`, POST `/v1/bundles` on `$HAL0_BENCH_API_BASE` (default api.hal0.dev). Typed errors surface the server's 422 error list; redirects are refused so the bearer token can never follow a 3xx off-host.
- Docs: CLI verb list + a "Sharing results" section in the model-roster reference.

Server side (Cloudflare Worker + R2 + D1) lands separately as P2 in the hal0-web repo.

## Testing

- 19 new tests across `test_bundle.py`, `test_upload.py` (real threaded http.server, incl. 302 no-follow), `test_cli_bundle.py`, `test_cli_upload.py`.
- Full `tests/bench/` suite: 157 passed.
- Manual smoke: seed record → `bundle --list` → `bundle -o` → `tar tzf` shows manifest + records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)