### PR TITLE
fix(seam): pin quadlet PodmanArgs= to the two rendered compat flags (#1759)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Security
 
+- The `hal0-systemctl write-quadlet` allow-list now pins `PodmanArgs=` to the
+  two flags the renderer emits (`--group-add <gid>`, `--security-opt <token>`)
+  instead of accepting any non-empty value (#1759). Podman's quadlet generator
+  copies `PodmanArgs=` verbatim into the generated root unit's `podman run`
+  argv, so a persistent flag like `--runtime <path>` or `--hooks-dir <dir>`
+  made podman exec an attacker-named binary **as root with no container
+  involved** — a direct host-exec primitive reachable from the unprivileged
+  `hal0` account, exactly what #1740 set out to close. **Breaking (deprecated
+  feature):** the `extra_args` escape hatch, which rendered arbitrary
+  `podman run` flags through `PodmanArgs=` and already logged
+  `container.extra_args_deprecated`, is no longer honoured on a hal0-service
+  install — such a slot is refused at the root seam. Move those flags to typed
+  Quadlet keys in a `hal0-slot@<token>.container.d/` drop-in.
 - The privileged update stage no longer downloads, verifies and extracts the
   release tarball out of the service-writable `/var/lib/hal0/cache/<version>/`
   (#1738). That directory is `hal0:hal0` `0o2775` with no sticky bit, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,18 +31,20 @@ applying. Add those subsections to a version's section to surface them; see
 ### Security
 
 - The `hal0-systemctl write-quadlet` allow-list now pins `PodmanArgs=` to the
-  two flags the renderer emits (`--group-add <gid>`, `--security-opt <token>`)
-  instead of accepting any non-empty value (#1759). Podman's quadlet generator
-  copies `PodmanArgs=` verbatim into the generated root unit's `podman run`
-  argv, so a persistent flag like `--runtime <path>` or `--hooks-dir <dir>`
-  made podman exec an attacker-named binary **as root with no container
-  involved** — a direct host-exec primitive reachable from the unprivileged
-  `hal0` account, exactly what #1740 set out to close. **Breaking (deprecated
-  feature):** the `extra_args` escape hatch, which rendered arbitrary
-  `podman run` flags through `PodmanArgs=` and already logged
-  `container.extra_args_deprecated`, is no longer honoured on a hal0-service
-  install — such a slot is refused at the root seam. Move those flags to typed
-  Quadlet keys in a `hal0-slot@<token>.container.d/` drop-in.
+  exact flags hal0's providers emit — `--group-add <gid>`, `--security-opt
+  <token>` (GPU/llama-server), `--ipc <mode>` (comfyui), `--ulimit
+  <name=v[:v]>` (flm/NPU) — instead of accepting any non-empty value (#1759).
+  Podman's quadlet generator copies `PodmanArgs=` verbatim into the generated
+  root unit's `podman run` argv, so a persistent flag like `--runtime <path>`
+  or `--hooks-dir <dir>` made podman exec an attacker-named binary **as root
+  with no container involved** — a direct host-exec primitive reachable from
+  the unprivileged `hal0` account, exactly what #1740 set out to close. All
+  shipped providers keep loading; only out-of-list flags are refused. **Minor
+  breaking (deprecated feature):** the free-form `extra_args` escape hatch
+  (already logging `container.extra_args_deprecated`) is honoured on a
+  hal0-service install only for flags in that list — an out-of-list flag now
+  makes the slot refuse at the root seam. Move those to typed Quadlet keys in a
+  `hal0-slot@<token>.container.d/` drop-in.
 - The privileged update stage no longer downloads, verifies and extracts the
   release tarball out of the service-writable `/var/lib/hal0/cache/<version>/`
   (#1738). That directory is `hal0:hal0` `0o2775` with no sticky bit, and the

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -53,17 +53,20 @@
 # removes the DIRECT host-side exec primitive — no host `[Service]`/`[Unit]`
 # directive beyond the five/three fixed ones, no `Exec*=` on the host side, no
 # `User=`/`Group=`, no second section, no `[Install] WantedBy=` other than
-# hal0.target. It does NOT make an hal0-account compromise non-root-equivalent:
-# `[Container]` legitimately carries `Image=`, `Volume=`, `AddDevice=`,
-# `PodmanArgs=` and `Exec=`, whose values are operator/config-derived and cannot
-# be pinned here (the model-store and data roots are runtime config, and a
-# path allow-list would be bypassable via a symlink under a root the hal0 user
-# already owns). Slots run under ROOTFUL podman, so anyone who can author a
-# slot's container spec can mount host paths into a container they control.
-# That is a property of the slot feature itself, not of this wrapper; the
-# containment for it is "run slots rootless / pin mount roots", tracked
-# separately. Claim only what is true: this seam is a *syntactic* boundary on
-# the unit file, and a hard boundary against direct host exec.
+# hal0.target. `PodmanArgs=` IS host-side too — quadlet copies it into the
+# generated unit's `podman run` argv — so it is pinned to the exact two flags
+# the renderer emits (`--group-add`/`--security-opt`); a `--runtime`/`--hooks-dir`
+# root exec is refused (#1759, validate_podman_args). It does NOT make an
+# hal0-account compromise non-root-equivalent: `[Container]` still legitimately
+# carries `Image=`, `Volume=`, `AddDevice=` and in-container `Exec=`, whose
+# values are operator/config-derived and cannot be pinned here (the model-store
+# and data roots are runtime config, and a path allow-list would be bypassable
+# via a symlink under a root the hal0 user already owns). Slots run under ROOTFUL
+# podman, so anyone who can author a slot's container spec can mount host paths
+# into a container they control. That containment is "run slots rootless / pin
+# mount roots", tracked separately. Claim only what is true: this seam is a
+# *syntactic* boundary on the unit file, and a hard boundary against direct host
+# exec — including the PodmanArgs host-exec flags, now that they are pinned.
 #
 # NOTE: the iptables FORWARD-chain repair the original P3-perms design doc
 # sketched for this seam is NOT needed — that repair already runs as its own
@@ -299,8 +302,46 @@ _QRE_DURATION='^[0-9]{1,9}(ns|us|ms|s|m|h|d|w)?$'
 _QRE_RETRIES='^[0-9]{1,4}$'
 _QRE_RESTART='^(always|on-failure|no)$'
 _QRE_WANTEDBY='^hal0\.target$'
+# The two flags _render_quadlet_from_plan ever emits into PodmanArgs=: a numeric
+# supplementary GID and a security-opt token. See validate_podman_args (#1759).
+_QRE_GID='^[0-9]{1,7}$'
+_QRE_SECOPT='^[A-Za-z0-9_.:=@,+-]{1,128}$'
 
 _quadlet_die() { die "quadlet rejected: $1"; }
+
+# PodmanArgs= is NOT in-container argv — podman's quadlet generator copies it
+# VERBATIM into the generated root unit's ExecStart
+# `/usr/bin/podman run … <PodmanArgs> … <image> <Exec>`, so a persistent flag
+# like `--runtime <path>` or `--hooks-dir <dir>` makes podman EXEC an
+# attacker-named binary as root with no container in the way (#1759). It cannot
+# be left as a "non-empty" charset pin. The renderer (_render_quadlet_from_plan)
+# only ever emits `--group-add <numeric-gid>` and `--security-opt <token>`, so
+# pin to exactly those two flag/value shapes. The deprecated `extra_args`
+# escape hatch (which already logs container.extra_args_deprecated) is
+# intentionally no longer honoured through this root seam.
+validate_podman_args() {  # arg: the PodmanArgs= value
+  local value="$1"
+  local -a toks=()
+  # The renderer joins shlex.quote'd tokens with single spaces; our emitted
+  # values (numeric gids, security-opt tokens) never need quoting, so a plain
+  # word-split is exact. A value that DID carry a quote/space fails closed here.
+  read -r -a toks <<<"$value"
+  local n=${#toks[@]} i=0
+  (( n >= 2 )) || _quadlet_die "PodmanArgs must be --group-add/--security-opt pairs: $value"
+  while (( i < n )); do
+    case "${toks[i]}" in
+      --group-add)
+        (( i + 1 < n )) || _quadlet_die "PodmanArgs --group-add missing value"
+        [[ "${toks[i+1]}" =~ $_QRE_GID ]] || _quadlet_die "bad --group-add gid: ${toks[i+1]}"
+        i=$(( i + 2 )) ;;
+      --security-opt)
+        (( i + 1 < n )) || _quadlet_die "PodmanArgs --security-opt missing value"
+        [[ "${toks[i+1]}" =~ $_QRE_SECOPT ]] || _quadlet_die "bad --security-opt: ${toks[i+1]}"
+        i=$(( i + 2 )) ;;
+      *) _quadlet_die "PodmanArgs flag not allowed (only --group-add/--security-opt): ${toks[i]}" ;;
+    esac
+  done
+}
 
 validate_quadlet_directive() {  # args: section, "Key=Value" line
   local section="$1" line="$2" key value
@@ -341,13 +382,12 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
     'Container|HealthStartPeriod'|'Container|HealthInterval'|'Container|HealthTimeout')
       [[ "$value" =~ $_QRE_DURATION ]] || _quadlet_die "bad $key: $value" ;;
     'Container|HealthRetries')  [[ "$value" =~ $_QRE_RETRIES ]]  || _quadlet_die "bad HealthRetries: $value" ;;
-    # PodmanArgs= is podman's own flag passthrough (--group-add/--security-opt,
-    # plus the deprecated extra_args escape hatch) and Exec= is the argv INSIDE
-    # the container. Neither has a fixed shape in the render contract, so both
-    # are bounded (non-empty, control-byte-free, length-capped by the per-line
-    # check) and nothing more. Constraining them further would buy nothing while
-    # Volume=/AddDevice= remain open — see HONEST BOUNDARY.
-    'Container|PodmanArgs')     [[ -n "$value" ]]                || _quadlet_die "empty PodmanArgs" ;;
+    # PodmanArgs= lands host-side in the generated unit's `podman run` argv, so
+    # it is allow-listed to the two flag shapes the renderer emits — anything
+    # else (notably --runtime/--hooks-dir, a direct root exec) is refused. See
+    # validate_podman_args (#1759). Exec= is the argv INSIDE the container
+    # (after the image), so it has no fixed shape and stays bounded only.
+    'Container|PodmanArgs')     validate_podman_args "$value" ;;
     'Container|Exec')           [[ -n "$value" ]]                || _quadlet_die "empty Exec" ;;
 
     # ── [Service] ───────────────────────────────────────────────────────

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -54,9 +54,10 @@
 # directive beyond the five/three fixed ones, no `Exec*=` on the host side, no
 # `User=`/`Group=`, no second section, no `[Install] WantedBy=` other than
 # hal0.target. `PodmanArgs=` IS host-side too — quadlet copies it into the
-# generated unit's `podman run` argv — so it is pinned to the exact two flags
-# the renderer emits (`--group-add`/`--security-opt`); a `--runtime`/`--hooks-dir`
-# root exec is refused (#1759, validate_podman_args). It does NOT make an
+# generated unit's `podman run` argv — so it is pinned to exactly the flags
+# hal0's providers emit (`--group-add`/`--security-opt`/`--ipc`/`--ulimit`); a
+# `--runtime`/`--hooks-dir` root exec is refused (#1759, validate_podman_args).
+# It does NOT make an
 # hal0-account compromise non-root-equivalent: `[Container]` still legitimately
 # carries `Image=`, `Volume=`, `AddDevice=` and in-container `Exec=`, whose
 # values are operator/config-derived and cannot be pinned here (the model-store
@@ -302,10 +303,13 @@ _QRE_DURATION='^[0-9]{1,9}(ns|us|ms|s|m|h|d|w)?$'
 _QRE_RETRIES='^[0-9]{1,4}$'
 _QRE_RESTART='^(always|on-failure|no)$'
 _QRE_WANTEDBY='^hal0\.target$'
-# The two flags _render_quadlet_from_plan ever emits into PodmanArgs=: a numeric
-# supplementary GID and a security-opt token. See validate_podman_args (#1759).
+# The four flags hal0's providers emit into PodmanArgs= (GPU/llama:
+# --group-add/--security-opt; comfyui: --ipc=host; flm: --ulimit memlock=-1).
+# See validate_podman_args (#1759).
 _QRE_GID='^[0-9]{1,7}$'
 _QRE_SECOPT='^[A-Za-z0-9_.:=@,+-]{1,128}$'
+_QRE_IPC='^(host|none|private|shareable|container:[A-Za-z0-9_.-]{1,64})$'
+_QRE_ULIMIT='^[a-z]{1,16}=-?[0-9]{1,20}(:-?[0-9]{1,20})?$'
 
 _quadlet_die() { die "quadlet rejected: $1"; }
 
@@ -314,31 +318,45 @@ _quadlet_die() { die "quadlet rejected: $1"; }
 # `/usr/bin/podman run … <PodmanArgs> … <image> <Exec>`, so a persistent flag
 # like `--runtime <path>` or `--hooks-dir <dir>` makes podman EXEC an
 # attacker-named binary as root with no container in the way (#1759). It cannot
-# be left as a "non-empty" charset pin. The renderer (_render_quadlet_from_plan)
-# only ever emits `--group-add <numeric-gid>` and `--security-opt <token>`, so
-# pin to exactly those two flag/value shapes. The deprecated `extra_args`
-# escape hatch (which already logs container.extra_args_deprecated) is
-# intentionally no longer honoured through this root seam.
+# be left as a "non-empty" charset pin. Allow-list exactly the flags hal0's
+# own providers emit — nothing else, fail-closed:
+#   --group-add <numeric-gid>   GPU/llama-server compat (render group ids)
+#   --security-opt <token>      GPU/llama-server + comfyui (seccomp/apparmor/label)
+#   --ipc <host|none|…>         comfyui (--ipc=host)
+#   --ulimit <name=soft[:hard]> flm/NPU (--ulimit memlock=-1)
+# The exec-family (--runtime/--hooks-dir/…) and everything else is refused. The
+# deprecated free-form `extra_args` escape hatch (which already logs
+# container.extra_args_deprecated) is only honoured insofar as its flags fall in
+# this list; anything outside it is refused at the seam.
+#
+# Both `--flag=value` (one token) and `--flag value` (two tokens) are accepted —
+# comfyui emits the `=` form, the GPU path emits the space form.
 validate_podman_args() {  # arg: the PodmanArgs= value
   local value="$1"
   local -a toks=()
-  # The renderer joins shlex.quote'd tokens with single spaces; our emitted
-  # values (numeric gids, security-opt tokens) never need quoting, so a plain
+  # The renderer joins shlex.quote'd tokens with single spaces; every value we
+  # emit (gids, security-opt/ipc/ulimit tokens) is quote-free, so a plain
   # word-split is exact. A value that DID carry a quote/space fails closed here.
   read -r -a toks <<<"$value"
-  local n=${#toks[@]} i=0
-  (( n >= 2 )) || _quadlet_die "PodmanArgs must be --group-add/--security-opt pairs: $value"
+  local n=${#toks[@]} i=0 t flag arg
+  (( n >= 1 )) || _quadlet_die "empty PodmanArgs"
   while (( i < n )); do
-    case "${toks[i]}" in
-      --group-add)
-        (( i + 1 < n )) || _quadlet_die "PodmanArgs --group-add missing value"
-        [[ "${toks[i+1]}" =~ $_QRE_GID ]] || _quadlet_die "bad --group-add gid: ${toks[i+1]}"
-        i=$(( i + 2 )) ;;
-      --security-opt)
-        (( i + 1 < n )) || _quadlet_die "PodmanArgs --security-opt missing value"
-        [[ "${toks[i+1]}" =~ $_QRE_SECOPT ]] || _quadlet_die "bad --security-opt: ${toks[i+1]}"
-        i=$(( i + 2 )) ;;
-      *) _quadlet_die "PodmanArgs flag not allowed (only --group-add/--security-opt): ${toks[i]}" ;;
+    t="${toks[i]}"
+    if [[ "$t" == --*=* ]]; then
+      flag="${t%%=*}"; arg="${t#*=}"; i=$(( i + 1 ))
+    elif [[ "$t" == --* ]]; then
+      flag="$t"
+      (( i + 1 < n )) || _quadlet_die "PodmanArgs $flag missing value"
+      arg="${toks[i+1]}"; i=$(( i + 2 ))
+    else
+      _quadlet_die "PodmanArgs expected a --flag, got: $t"
+    fi
+    case "$flag" in
+      --group-add)    [[ "$arg" =~ $_QRE_GID ]]    || _quadlet_die "bad --group-add gid: $arg" ;;
+      --security-opt) [[ "$arg" =~ $_QRE_SECOPT ]] || _quadlet_die "bad --security-opt: $arg" ;;
+      --ipc)          [[ "$arg" =~ $_QRE_IPC ]]    || _quadlet_die "bad --ipc: $arg" ;;
+      --ulimit)       [[ "$arg" =~ $_QRE_ULIMIT ]] || _quadlet_die "bad --ulimit: $arg" ;;
+      *) _quadlet_die "PodmanArgs flag not allowed: $flag" ;;
     esac
   done
 }
@@ -383,7 +401,7 @@ validate_quadlet_directive() {  # args: section, "Key=Value" line
       [[ "$value" =~ $_QRE_DURATION ]] || _quadlet_die "bad $key: $value" ;;
     'Container|HealthRetries')  [[ "$value" =~ $_QRE_RETRIES ]]  || _quadlet_die "bad HealthRetries: $value" ;;
     # PodmanArgs= lands host-side in the generated unit's `podman run` argv, so
-    # it is allow-listed to the two flag shapes the renderer emits — anything
+    # it is allow-listed to the flag shapes hal0's providers emit — anything
     # else (notably --runtime/--hooks-dir, a direct root exec) is refused. See
     # validate_podman_args (#1759). Exec= is the argv INSIDE the container
     # (after the image), so it has no fixed shape and stays bounded only.

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -174,17 +174,30 @@ _PLANS: dict[str, tuple[RuntimeLaunchPlan, dict[str, Any]]] = {
         ),
         {"autoload": False},
     ),
-    "deprecated-extra-args": (
-        RuntimeLaunchPlan(
-            image="ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
-            command=["llama-server"],
-            extra_args=["--ipc=host", "--ulimit memlock=-1"],
-            port=8101,
-            network_mode="",
-        ),
-        {},
-    ),
 }
+
+
+# The deprecated `extra_args` escape hatch (RuntimeLaunchPlan.extra_args) renders
+# arbitrary `podman run` flags into PodmanArgs=, which #1759 now refuses at the
+# root seam — that passthrough was the surviving root-exec vector. It is
+# intentionally NOT in _PLANS' accepted set; this pins the refusal instead.
+def test_deprecated_extra_args_are_refused_at_the_seam() -> None:
+    """A slot using the deprecated extra_args passthrough (arbitrary podman run
+    flags) is rejected on the root side after #1759, by design."""
+    from hal0.providers.base import RuntimeLaunchPlan as _Plan
+    from hal0.providers.container import _render_quadlet_from_plan as _render
+
+    plan = _Plan(
+        image="ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
+        command=["llama-server"],
+        extra_args=["--ipc=host", "--ulimit memlock=-1"],
+        port=8101,
+        network_mode="",
+    )
+    body = _render("chat", plan)
+    assert "PodmanArgs=" in body  # the renderer still emits it (with a warning)
+    err = _rejects(body, "chat")
+    assert "PodmanArgs" in err
 
 
 @pytest.mark.parametrize("shape", sorted(_PLANS))
@@ -192,6 +205,17 @@ _PLANS: dict[str, tuple[RuntimeLaunchPlan, dict[str, Any]]] = {
 def test_rendered_units_are_accepted_byte_for_byte(shape: str, token: str) -> None:
     plan, kwargs = _PLANS[shape]
     _accepts(_render_quadlet_from_plan(token, plan, **kwargs), token)
+
+
+def test_podman_args_allows_only_the_rendered_compat_flags() -> None:
+    """#1759: the two flags the renderer emits into PodmanArgs= are accepted,
+    in the multi-pair shape a GPU slot actually produces."""
+    body = (
+        "[Container]\nImage=ghcr.io/hal0ai/x:v1\nContainerName=hal0-slot-chat\n"
+        "PodmanArgs=--group-add 44 --group-add 991 "
+        "--security-opt seccomp=unconfined --security-opt label=disable\n"
+    )
+    _accepts(body, "chat")
 
 
 def test_live_container_provider_render_is_accepted() -> None:
@@ -271,6 +295,17 @@ ESCALATIONS = {
     "health-interval-not-a-duration": f"{_HEAD}HealthInterval=30 seconds\n",
     "unknown-container-key": f"{_HEAD}Rootfs=/\n",
     "notify-key": f"{_HEAD}Notify=true\n",
+    # #1759: PodmanArgs= lands host-side in `podman run` argv — a persistent
+    # flag pointing at an attacker binary is a direct root exec, no container.
+    "podmanargs-runtime": f"{_HEAD}PodmanArgs=--runtime /tmp/evil.sh\n",
+    "podmanargs-hooks-dir": f"{_HEAD}PodmanArgs=--hooks-dir /tmp/hooks\n",
+    "podmanargs-privileged": f"{_HEAD}PodmanArgs=--privileged\n",
+    "podmanargs-bind-root": f"{_HEAD}PodmanArgs=--volume /:/host\n",
+    "podmanargs-group-add-nonnumeric": f"{_HEAD}PodmanArgs=--group-add root\n",
+    "podmanargs-security-opt-then-runtime": (
+        f"{_HEAD}PodmanArgs=--security-opt label=disable --runtime /tmp/evil.sh\n"
+    ),
+    "podmanargs-group-add-missing-value": f"{_HEAD}PodmanArgs=--group-add\n",
     # [Service] value pinning.
     "service-standardoutput-file": f"{_HEAD}\n[Service]\nStandardOutput=file:/root/.ssh/authorized_keys\n",
     "service-syslogidentifier-free": f"{_HEAD}\n[Service]\nSyslogIdentifier=../evil\n",

--- a/tests/installer/test_systemctl_quadlet_validation.py
+++ b/tests/installer/test_systemctl_quadlet_validation.py
@@ -174,23 +174,46 @@ _PLANS: dict[str, tuple[RuntimeLaunchPlan, dict[str, Any]]] = {
         ),
         {"autoload": False},
     ),
+    # #1759: the two shipped providers that emit PodmanArgs= flags beyond the
+    # GPU compat pair. Their rendered bodies must still pass the seam, or the
+    # slot fails to load on a hal0-service install.
+    "comfyui-ipc-host": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-comfyui:v1",
+            command=["python", "main.py"],
+            port=8188,
+            network_mode="host",
+            extra_args=["--ipc=host"],
+        ),
+        {},
+    ),
+    "flm-ulimit-memlock": (
+        RuntimeLaunchPlan(
+            image="ghcr.io/hal0ai/hal0-flm:v1",
+            command=["flm", "serve"],
+            port=8110,
+            network_mode="",
+            extra_args=["--ulimit memlock=-1"],
+        ),
+        {},
+    ),
 }
 
 
-# The deprecated `extra_args` escape hatch (RuntimeLaunchPlan.extra_args) renders
-# arbitrary `podman run` flags into PodmanArgs=, which #1759 now refuses at the
-# root seam — that passthrough was the surviving root-exec vector. It is
-# intentionally NOT in _PLANS' accepted set; this pins the refusal instead.
-def test_deprecated_extra_args_are_refused_at_the_seam() -> None:
-    """A slot using the deprecated extra_args passthrough (arbitrary podman run
-    flags) is rejected on the root side after #1759, by design."""
+# The deprecated `extra_args` escape hatch renders arbitrary `podman run` flags
+# into PodmanArgs=. #1759 allow-lists only the flags hal0's providers emit
+# (--group-add/--security-opt/--ipc/--ulimit), so an out-of-list flag is refused
+# at the root seam — that was the surviving root-exec vector. Pinned here.
+def test_out_of_allowlist_podman_args_are_refused_at_the_seam() -> None:
+    """A slot whose extra_args carry a flag outside the provider allow-list
+    (e.g. --privileged) is rejected on the root side after #1759, by design."""
     from hal0.providers.base import RuntimeLaunchPlan as _Plan
     from hal0.providers.container import _render_quadlet_from_plan as _render
 
     plan = _Plan(
         image="ghcr.io/hal0ai/hal0-toolbox-vulkan:v1",
         command=["llama-server"],
-        extra_args=["--ipc=host", "--ulimit memlock=-1"],
+        extra_args=["--privileged"],
         port=8101,
         network_mode="",
     )


### PR DESCRIPTION
## Security — surviving root RCE from the `hal0` account

Found by a second adversarial review of #1748 (after merge). #1748's allow-list closed host-side `[Service]`/`[Unit]` smuggling but left `Container|PodmanArgs` accepting **any** non-empty value. Podman's quadlet generator copies `PodmanArgs=` verbatim into the generated root unit's `ExecStart=/usr/bin/podman run … <PodmanArgs> … <image>` argv, so a persistent flag makes podman **exec an attacker-named binary as root, with no container involved**:

```
printf '[Container]\nImage=docker.io/library/alpine\nContainerName=hal0-slot-chat\nPodmanArgs=--runtime /tmp/evil.sh\nExec=/bin/true\n' \
  | installer/wrappers/hal0-systemctl check-quadlet chat ; echo rc=$?
# before: rc=0 (accepted)   after: rc=64 (rejected)
```

`--runtime` is "the OCI binary podman execs"; `--hooks-dir` is equally exec-y. This is a **direct host-exec primitive** from the unprivileged `hal0` account (sudoers-pinned wrapper) — the "root RCE from the hal0 account" #1740 was filed for. Distinct from the documented `[Container]` mount-based residual, and it contradicts the wrapper's own "hard boundary against direct host exec" claim.

## Fix

`validate_podman_args` allow-lists exactly the flag/value shapes hal0's own providers emit, fail-closed, and refuses everything else (notably the exec-family):

| Flag | Value shape | Emitted by |
|------|-------------|-----------|
| `--group-add` | numeric gid | GPU/llama-server compat |
| `--security-opt` | token (`seccomp=…`, `apparmor=…`, `label=disable`) | GPU/llama + comfyui |
| `--ipc` | `host`/`none`/`private`/`shareable`/`container:ID` | comfyui (`--ipc=host`) |
| `--ulimit` | `name=soft[:hard]` | flm/NPU (`--ulimit memlock=-1`) |

Both `--flag=value` and `--flag value` forms are handled. The validated reconstruction is still what's written. The wrapper's HONEST BOUNDARY header is corrected (it wrongly said `PodmanArgs=` couldn't be pinned).

**Two `extra_args`, not to be confused:** the live UI `extra_args` (`[server].extra_args`, `model.defaults.extra_args`) are *llama-server* flags that render into the in-container `Exec=` argv — this PR does not touch `Exec=`, so that feature is unaffected. Only the separate `RuntimeLaunchPlan/ContainerSpec.extra_args` → `PodmanArgs=` channel is restricted here.

> ⚠️ An earlier cut of this PR pinned only `--group-add`/`--security-opt`, which would have broken **comfyui** (`--ipc=host`) and **flm** (`--ulimit memlock=-1`) slot loads. Caught before merge; both are now covered and pinned by render-acceptance tests.

## Minor breaking (deprecated feature)

The free-form `extra_args` escape hatch (arbitrary `podman run` flags, already logging `container.extra_args_deprecated`) is honoured on a hal0-service install **only for flags in the list above**; an out-of-list flag (e.g. `--privileged`) now refuses at the seam. Move those to typed Quadlet keys in a `hal0-slot@<token>.container.d/` drop-in. (Dev/CI installs write quadlets directly, not through the seam, so they're unaffected.)

## Tests

`tests/installer/test_systemctl_quadlet_validation.py`: exec-family (`--runtime`, `--hooks-dir`, `--privileged`, `--volume /:/host`, non-numeric gid, missing value, `--ipc=host … --runtime …`) rejected rc 64; the real GPU compat multi-pair render **plus** comfyui `--ipc=host` and flm `--ulimit memlock=-1` renders accepted byte-for-byte; out-of-allowlist `extra_args` pinned as refused.

```
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/installer/test_systemctl_quadlet_validation.py tests/system/test_seam.py tests/providers -q
586 passed
```
`ruff check` + `ruff format --check` clean; `bash -n` clean.

## Tracking

`Closes #1759`, `Refs #1740` (the P1 was auto-closed by #1748 while this primitive survived). Other #1748-review nits (F4 charset bounds) remain in #1756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)