### PR TITLE
docs(bench): scope result sharing to bundles; mark upload maintainer-only

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -48,7 +48,7 @@ global flag is controlled per-command via environment variables instead — see
 | `hal0 probe` | **Deprecated**, hidden. Alias for `hal0 config hardware --refresh`. | — |
 | `hal0 serve` | Start the hal0 API server (used by `hal0-api.service`). | `--host` (default `127.0.0.1`, env `HAL0_BIND_HOST`), `--port` (default `8080`, env `HAL0_PORT`), `--reload` |
 | `hal0 uninstall` | Uninstall hal0. Conservative by default. | `--purge` (alias `--clean-slate`), `--keep-data`, `--force`/`-f` (honors `HAL0_FORCE=1`), `--dev` (tears down a dev install at `$PWD/.hal0ai`) |
-| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval, bundle, upload` |
+| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval, bundle` (+ maintainer-only `upload`) |
 | `hal0 chat` | Interactive chat REPL. | `--model` (default `"agent"`), `--base-url` (default `http://127.0.0.1:8080/v1`, env `HAL0_CHAT_BASE_URL`), `--no-stream`, `--brain` (talk to the hal0-brain steward instead) |
 | `hal0 system-info` | Host system info. | `--json` |
 | `hal0 ports` | Port allocation view. | `--json` |

--- a/docs/reference/model-roster-benchmark.mdx
+++ b/docs/reference/model-roster-benchmark.mdx
@@ -137,15 +137,21 @@ hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|b
 
 ### Sharing results
 
-Benchmark results never leave the box automatically. To share a run on
-[hal0.dev/benchmarks](https://hal0.dev/benchmarks):
+Benchmark results never leave the box automatically. To share a run, package
+it as a self-contained bundle and attach it wherever you discuss it (forum
+thread, issue, chat):
 
 ```bash
 hal0 bench bundle --list                       # see what's eligible
 hal0 bench bundle --runs <run_id> --title "Strix Halo, ROCm 7" -o run.hal0bench.tar.gz
-HAL0_BENCH_TOKEN=... hal0 bench upload run.hal0bench.tar.gz
 ```
 
 A bundle contains the schema-2 records (resolved flags, engine digests,
 telemetry), the profile/suite TOMLs you pass with `--profile`, and optional
-raw artifacts (`--with-artifacts`). `host.name` is redacted by default.
+raw artifacts (`--with-artifacts`). `host.name` is redacted by default, the
+manifest carries a sha256 for every member, and the whole archive is
+content-addressed — anyone can verify and reproduce what you measured.
+
+`hal0 bench upload` is a maintainer tool for publishing curated results to
+the hal0.dev roster; it requires a publishing token and does nothing without
+one.

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -846,7 +846,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("-o", "--out", default="bench-bundle.hal0bench.tar.gz", help="output path")
     p.set_defaults(func=cmd_bundle)
 
-    p = sub.add_parser("upload", help="push a bundle to the public benchmarks API (explicit only)")
+    p = sub.add_parser(
+        "upload", help="maintainer: publish a bundle to the hal0.dev roster (requires token)"
+    )
     p.add_argument("bundle", help="path to a .hal0bench.tar.gz built by `hal0 bench bundle`")
     p.add_argument(
         "--api",


### PR DESCRIPTION
## Summary

Product decision: publishing benchmarks to the live hal0.dev site stays out of the public release. Users track results via their local roster and share the self-contained `.hal0bench.tar.gz` bundle (forums, issues) — bundles are content-addressed and hash-verified, so shared results remain reproducible and tamper-evident.

- `model-roster-benchmark.mdx` "Sharing results": reframed around bundle-file sharing; removed the hal0.dev upload walkthrough; notes `upload` is a maintainer tool.
- `cli.mdx`: verb list marks `upload` maintainer-only.
- `cli.py`: upload subparser help says maintainer + token required.

No behavior change — `hal0 bench upload` was already inert without `HAL0_BENCH_TOKEN`. The server side (hal0-web#63) stays parked as the future manual-curation rail.

## Testing

`ruff format --check` + `ruff check` clean; `tests/bench/test_cli_upload.py` + `test_cli_bundle.py`: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)