### PR TITLE
feat(bench): telemetry in records + regression journaling (phase 4)

### DIFF
--- a/installer/bench/suites/lane-matrix.toml
+++ b/installer/bench/suites/lane-matrix.toml
@@ -6,7 +6,10 @@
 [suite]
 id          = "lane-matrix"
 description = "Lane x depth sweep on profile-class representatives, for hal0-tune"
-schedule    = "monthly"
+# No systemd timer runs this one at all (only hal0-bench.timer exists, and it
+# always runs "roster") — on-demand only: `hal0 bench run --suite lane-matrix`.
+# A [suite].schedule = "monthly" key used to be parsed here but nothing ever
+# read it or wired a monthly timer.
 budget_min  = 240
 exclusive   = true
 priority    = 40

--- a/installer/bench/suites/roster.toml
+++ b/installer/bench/suites/roster.toml
@@ -2,7 +2,10 @@
 [suite]
 id          = "roster"
 description = "Uniform head-to-head across the chat+coding roster"
-schedule    = "weekly"           # consumed by the timer policy (§6)
+# Weekly cadence lives in installer/systemd/hal0-bench.timer (fires `hal0
+# bench run --suite roster --scheduled`) + window.toml's politeness window,
+# not a field here — a [suite].schedule key used to be parsed but nothing
+# ever read it.
 budget_min  = 240                # hard wall-clock cap per session; planner orders cells by value
 exclusive   = true               # uses --exclusive windows; never publishes contended numbers
 priority    = 50

--- a/installer/bench/suites/smoke.toml
+++ b/installer/bench/suites/smoke.toml
@@ -1,21 +1,19 @@
-# suites/smoke.toml — fires on model-pull. Gives a freshly pulled model a
-# number (and an OOM/breakage signal) within minutes, automatically,
-# instead of waiting for the weekly roster window. See the bench design handoff §4
-# ("smoke") and §6 ("Model pulled/registered" trigger row).
+# suites/smoke.toml — a cheap first-light check for a freshly pulled/
+# registered model: one pp+tg pair at one depth, a number (and an OOM/
+# breakage signal) in minutes instead of waiting for the weekly roster
+# window. On-demand only — there is no model-pull trigger: no pull-completion
+# hook and no `--trigger` CLI argument exist in this codebase. Run manually
+# after a pull (`hal0 bench run --suite smoke`); the staleness rule below
+# means it only measures models with no record yet, so a manual run is cheap.
 
 [suite]
 id          = "smoke"
 description = "First-light check for a freshly pulled/registered model"
-schedule    = "trigger:model-pull"   # fired by the pull-completion hook, not the weekly timer
 budget_min  = 3                      # ~3 min: one pp+tg pair at one depth, nothing more
 exclusive   = false                  # allowed to run even while GPU slots are busy...
 priority    = 90                     # ...but jumps the queue when it does get a window
 
 [selector]
-# NOTE: the model-pull trigger hook is NOT wired yet — there is no
-# `--trigger` CLI argument. Until it lands, run this suite manually after a
-# pull (`hal0 bench run --suite smoke`); the staleness rule below means it
-# only measures models with no record yet, so a manual run is cheap.
 caps_any  = ["chat", "coder"]
 installed = true
 
@@ -29,9 +27,9 @@ reps     = 1              # smoke != roster: one sample is enough to catch OOM/h
 kinds = ["pp", "tg"]
 
 [staleness]
-# Smoke doesn't re-run on an age timer — the model-pull event is its only
-# trigger. max_age_days is set effectively-infinite so the planner never
-# re-queues a smoke cell on its own.
+# Smoke doesn't re-run on an age timer — it is run manually, on demand.
+# max_age_days is set effectively-infinite so the planner never re-queues a
+# smoke cell on its own once it has one ok record.
 max_age_days = 36500
 
 # NOTE — contended runs (the bench design handoff §4): because exclusive=false, a smoke

--- a/installer/wrappers/hal0-benchctl
+++ b/installer/wrappers/hal0-benchctl
@@ -329,12 +329,33 @@ case "$cmd" in
             fi
             printf 'null'
           }
+          # $1 = a pp_dpm_sclk-style table; prints the current (*-marked)
+          # clock in MHz, or null. The table format is stable amdgpu sysfs:
+          # "N: <mhz>Mhz [*]".
+          _tel_sclk() {
+            local f="$1" line
+            if [[ -n "$f" && -r "$f" ]]; then
+              line="$(grep '\*' "$f" 2>/dev/null | head -n 1)"
+              if [[ "$line" =~ ([0-9]+)[Mm][Hh]z ]]; then
+                printf '%s' "${BASH_REMATCH[1]}"; return 0
+              fi
+            fi
+            printf 'null'
+          }
+          GPU_DEV="${GPU_BUSY_SYSFS:+$(dirname "$GPU_BUSY_SYSFS")/device}"
           while true; do
             TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
             GPU_TEMP=$(_tel_num "${GPU_HWMON:+$GPU_HWMON/temp1_input}")
             GPU_POWER=$(_tel_num "${GPU_HWMON:+$GPU_HWMON/power1_average}")
             GPU_BUSY=$(_tel_num "$GPU_BUSY_SYSFS")
-            echo "{\"ts\":\"$TIMESTAMP\",\"temp_c\":$GPU_TEMP,\"power_mw\":$GPU_POWER,\"gpu_busy_pct\":$GPU_BUSY}" >> "$TELEMETRY_FILE"
+            # Memory + current shader clock (Phase 4): schema.Telemetry wants
+            # vram/gtt peaks and a throttle verdict; peaks and the >10% clock
+            # drop are computed by the unprivileged reader from these raw
+            # samples — this sampler stays a dumb 1 Hz recorder.
+            GPU_VRAM=$(_tel_num "${GPU_DEV:+$GPU_DEV/mem_info_vram_used}")
+            GPU_GTT=$(_tel_num "${GPU_DEV:+$GPU_DEV/mem_info_gtt_used}")
+            GPU_SCLK=$(_tel_sclk "${GPU_DEV:+$GPU_DEV/pp_dpm_sclk}")
+            echo "{\"ts\":\"$TIMESTAMP\",\"temp_c\":$GPU_TEMP,\"power_mw\":$GPU_POWER,\"gpu_busy_pct\":$GPU_BUSY,\"vram_b\":$GPU_VRAM,\"gtt_b\":$GPU_GTT,\"sclk_mhz\":$GPU_SCLK}" >> "$TELEMETRY_FILE"
             sleep 1
           done
         ) &

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -33,6 +33,7 @@ import hal0
 from .planner import fetch_registry_models, plan
 from .publish import build_roster, emit_site_ts, write_roster
 from .regress import check as regress_check
+from .regress import journal_flags as regress_journal
 from .runner import DEFAULT_API, describe_worklist, fetch_host, run_session
 from .runner import _traffic_in_flight as traffic_in_flight
 from .schema import Host
@@ -235,6 +236,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             print(f"[regress] {len(flags)} cell(s) flagged:")
             for f in flags:
                 print(f"  {f.model_id} {f.cell_key[:16]} {f.delta_pct}% vs {f.trailing_median}")
+            regress_journal(flags, suite.id)
     event = {
         "event": "bench.session.completed",
         "suite": result.suite_id,
@@ -476,6 +478,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
                 print(f"[worker] [regress] {len(flags)} cell(s) flagged:")
                 for f in flags:
                     print(f"  {f.model_id} {f.cell_key[:16]} {f.delta_pct}% vs {f.trailing_median}")
+                regress_journal(flags, suite.id)
             control.dequeue(item.get("id"))
             print(f"[worker] {suite.id} done: ok={result.cells_ok} failed={result.cells_failed}")
             control.write_status(None, _now_stamp())

--- a/src/hal0/bench/harness.py
+++ b/src/hal0/bench/harness.py
@@ -98,6 +98,7 @@ __all__ = [
     "default_lanes",
     "lane_specs",
     "run_cell",
+    "telemetry_argv",
 ]
 
 BENCHCTL = "/usr/lib/hal0/bin/hal0-benchctl"
@@ -249,6 +250,21 @@ def benchctl_exec_argv(podman_argv: list[str], timeout_s: int | None) -> list[st
     if timeout_s:
         argv += ["--timeout-s", str(timeout_s)]
     argv += ["--", *podman_argv]
+    return argv
+
+
+def telemetry_argv(action: str, run_id: str, tier: str = "") -> list[str]:
+    """The seam invocation for one telemetry verb call: ``sudo -n
+    hal0-benchctl telemetry <start|end> <run_id> [tier]`` (Phase 4). ``tier``
+    is ``BenchDeviceSpec.tier`` (amd|nvidia|cpu — the shim's own
+    ``validate_tier`` vocabulary); it is only meaningful for ``start`` and
+    omitted when empty (the shim falls back to probing, or ``end`` never
+    takes one at all). Mirrors :func:`benchctl_exec_argv`'s shape — a caller
+    (``runner.py``) supplies its OWN subprocess runner, this function only
+    composes the argv."""
+    argv = ["sudo", "-n", BENCHCTL, "telemetry", action, run_id]
+    if tier:
+        argv.append(tier)
     return argv
 
 

--- a/src/hal0/bench/parsers.py
+++ b/src/hal0/bench/parsers.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import statistics
 from dataclasses import dataclass, field
+from typing import Any
 
 from .schema import Config, Engine, Rep, Summary, Telemetry
 
@@ -178,6 +179,67 @@ def parse_llama_bench(
 # --------------------------------------------------------------------------- #
 # Tier B — server_ab.py (chat/reuse/embed/rerank) live-server
 # --------------------------------------------------------------------------- #
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry — hal0-benchctl's 1 Hz sampler JSONL (Phase 4)
+# --------------------------------------------------------------------------- #
+
+#: ≥3 consecutive samples >10% below the run's own peak sclk trips throttled.
+_THROTTLE_DROP_FRACTION = 0.10
+_THROTTLE_MIN_STREAK = 3
+
+
+def _throttle_flag(sclk_mhz: list[float]) -> bool | None:
+    """None when no sclk samples exist at all (the counter was unreadable —
+    §14.3 nullable, never a guessed False); otherwise the streak rule against
+    the run's OWN peak clock. Fewer than 3 total samples can never reach the
+    streak, so it correctly falls out to False rather than needing a special
+    case."""
+    if not sclk_mhz:
+        return None
+    peak = max(sclk_mhz)
+    if peak <= 0:
+        return None
+    threshold = peak * (1 - _THROTTLE_DROP_FRACTION)
+    streak = 0
+    for v in sclk_mhz:
+        if v < threshold:
+            streak += 1
+            if streak >= _THROTTLE_MIN_STREAK:
+                return True
+        else:
+            streak = 0
+    return False
+
+
+def parse_telemetry_samples(samples: list[dict[str, Any]]) -> Telemetry:
+    """Turn hal0-benchctl's 1 Hz raw sampler rows (``{ts,temp_c,power_mw,
+    gpu_busy_pct,vram_b,gtt_b,sclk_mhz}``, ``null`` for an unreadable counter —
+    installer/wrappers/hal0-benchctl's ``telemetry start`` verb) into the
+    derived :class:`Telemetry` a record carries. Every field is computed
+    independently from whichever samples actually carry it, so one dead
+    counter (e.g. GTT locked down by debugfs perms) never blanks the others.
+    An empty sample list (no telemetry.jsonl, or a run that never reached
+    ``telemetry start``) returns an all-None ``Telemetry`` — never raises,
+    never fabricates a value (DESIGN §3.2 / §14.3)."""
+
+    def nums(key: str) -> list[float]:
+        return [s[key] for s in samples if isinstance(s.get(key), (int, float))]
+
+    vram_b = nums("vram_b")
+    gtt_b = nums("gtt_b")
+    temp_millic = nums("temp_c")  # the sampler's key names the UNIT wrong: it's millidegrees
+    power_mw = nums("power_mw")
+    sclk_mhz = nums("sclk_mhz")
+
+    return Telemetry(
+        vram_peak_mb=round(max(vram_b) / (1024 * 1024)) if vram_b else None,
+        gtt_peak_mb=round(max(gtt_b) / (1024 * 1024)) if gtt_b else None,
+        gpu_edge_temp_max_c=round(max(temp_millic) / 1000) if temp_millic else None,
+        gpu_power_avg_w=round(statistics.mean(power_mw) / 1000) if power_mw else None,
+        throttled=_throttle_flag(sclk_mhz),
+    )
 
 
 def _sa_run_to_rep(run: dict) -> Rep | None:

--- a/src/hal0/bench/regress.py
+++ b/src/hal0/bench/regress.py
@@ -18,8 +18,14 @@ median by more than ``THRESHOLD_PCT``.
 
 from __future__ import annotations
 
+import asyncio
+import sys
 from dataclasses import dataclass
 from typing import Any
+
+from hal0.activity import AuditStore
+from hal0.board.store import BoardStore
+from hal0.config.paths import activity_db
 
 from .store import Store, _record_ts
 
@@ -115,3 +121,80 @@ def check(store: Store) -> list[Flag]:
             )
         )
     return flags
+
+
+#: Board task fires only when a session's flag count exceeds this — a lone
+#: flag is noise-tolerant (DESIGN §11), a cluster is worth an operator's eye.
+BOARD_TASK_THRESHOLD = 2
+
+
+def journal_flags(flags: list[Flag], suite_id: str) -> None:
+    """Emit ONE durable ``bench.regression`` event for a session's flags, and
+    (when more than :data:`BOARD_TASK_THRESHOLD` flag) an Operator Board task.
+
+    Uses hal0's OWN established durable-journal mechanism —
+    :class:`hal0.activity.AuditStore`, the same SQLite audit trail every other
+    subsystem's structural events land in (``slot.state``, ``pull.*``,
+    ``system.*`` — see that module + ``hal0.events.EventBus``'s ``sink``
+    hook). This module runs CLI-side (``hal0 bench run``/``worker``), off
+    hal0-api's FastAPI event loop, so it cannot reach ``app.state.events``;
+    ``AuditStore``/``BoardStore`` are both plain, dependency-free classes a
+    standalone process can open directly against the SAME on-disk store
+    (``hal0.config.paths.activity_db`` / the default board db — both
+    HAL0_HOME-aware, so tests never touch a real box's state; module-level
+    names, not lazy imports, so the test suite can inject a fake journal the
+    same way ``harness.BENCHCTL`` is monkeypatched elsewhere in this package).
+
+    Journaling is diagnostic, never load-bearing: any failure here is logged
+    to stderr and swallowed, never raised — a broken audit/board write must
+    not turn an otherwise-successful bench session into a failure.
+    """
+    if not flags:
+        return
+
+    detail = [
+        {
+            "cell_key": f.cell_key,
+            "model_id": f.model_id,
+            "delta_pct": f.delta_pct,
+            "trailing_median": f.trailing_median,
+            "run_ids": f.run_ids,
+        }
+        for f in flags
+    ]
+    message = f"{len(flags)} cell(s) regressed in suite {suite_id!r}"
+
+    try:
+        store = AuditStore(activity_db())
+        store.init_schema()
+        asyncio.run(
+            store.record(
+                kind="event",
+                category="bench",
+                action="bench.regression",
+                target=suite_id,
+                actor="system",
+                severity="warn",
+                message=message,
+                after={"suite": suite_id, "flags": detail},
+            )
+        )
+    except Exception as exc:  # journaling must never break the session
+        print(f"[regress] journal write failed: {exc!r}", file=sys.stderr)
+
+    if len(flags) <= BOARD_TASK_THRESHOLD:
+        return
+    try:
+        BoardStore().create_task(
+            {
+                "title": f"bench regression: {len(flags)} cell(s) in {suite_id!r}",
+                "body": "\n".join(
+                    f"- {f.model_id} {f.cell_key[:16]} {f.delta_pct}% vs {f.trailing_median}"
+                    for f in flags
+                ),
+                "status": "triage",
+                "created_by": "bench",
+            }
+        )
+    except Exception as exc:  # a board write must never break the session either
+        print(f"[regress] board task creation failed: {exc!r}", file=sys.stderr)

--- a/src/hal0/bench/runner.py
+++ b/src/hal0/bench/runner.py
@@ -54,10 +54,11 @@ import re
 import secrets
 import signal
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -66,8 +67,8 @@ from typing import TYPE_CHECKING, Any
 from . import harness
 from .adapters import guidellm, llama_benchy
 from .devices import BenchDeviceError, BenchDeviceSpec, resolve_bench_devices
-from .parsers import Parsed, parse_llama_bench, parse_server_ab
-from .schema import Engine, Host, Outcome, Record
+from .parsers import Parsed, parse_llama_bench, parse_server_ab, parse_telemetry_samples
+from .schema import Engine, Host, Outcome, Record, Telemetry
 from .store import Store
 
 if TYPE_CHECKING:
@@ -342,6 +343,91 @@ def _tier_a_per_attempt_s(cell) -> int:
 
 
 # --------------------------------------------------------------------------- #
+# Telemetry (Phase 4) — wraps ONE Tier-A group's actual sweep execution.
+#
+# Only Tier-A cells sample: they run inside an ExclusiveSlots window (or at
+# least a dedicated podman container with no other tenant), so every counter
+# unambiguously belongs to the bench. Tier-B/C (embed/rerank/reuse) and the
+# Phase-3 adapters (chat/http_pp/http_tg) drive a LIVE serving slot over
+# HTTP — the GPU is shared with whatever else that slot is doing, so
+# sampling there would attribute the slot's own load to the bench. Those
+# paths leave Telemetry all-None (Parsed's default), deliberately.
+# --------------------------------------------------------------------------- #
+
+_TELEMETRY_DEFAULT_ROOT = "/var/lib/hal0/benchmarks/v2/artifacts"
+
+
+def _telemetry_root() -> Path:
+    """The ROOT-SIDE dir ``hal0-benchctl telemetry start`` writes
+    ``<run_id>/telemetry.jsonl`` under: the V1 results tree
+    (``/var/lib/hal0/benchmarks``), NOT the v2 ``Store``'s own state root
+    (``store.py``'s ``$HAL0_BENCH_STATE`` — a deliberately separate tree, see
+    that module's docstring). Overridable via ``HAL0_BENCH_TELEMETRY_ROOT``
+    for the test suite; a real ``sudo hal0-benchctl`` invocation never sees
+    this override (sudo's ``env_reset`` strips it), so a real box always
+    samples under the hardcoded path regardless of the caller's environment —
+    the same posture as every other ``HAL0_BENCH_*`` test-only knob in this
+    package (see hal0-benchctl's own header)."""
+    return Path(os.environ.get("HAL0_BENCH_TELEMETRY_ROOT") or _TELEMETRY_DEFAULT_ROOT)
+
+
+def _run_telemetry_cmd(argv: list[str]) -> tuple[int, str]:
+    """Bare subprocess call for the telemetry start/end verbs: ``start``
+    backgrounds its own sampler and returns immediately, ``end`` just signals
+    it — both are short, so unlike the cell-execution path (``_tier_a_runner``)
+    no watchdog is warranted here. A module-level function (not inlined into
+    ``_telemetry_session``) so tests can monkeypatch it without a real
+    ``sudo``/``hal0-benchctl`` on PATH."""
+    proc = subprocess.run(argv, capture_output=True, text=True)
+    return proc.returncode, (proc.stderr or proc.stdout or "")
+
+
+@contextlib.contextmanager
+def _telemetry_session(run_id: str, tier: str) -> Iterator[None]:
+    """Wrap ONE Tier-A group's actual sweep execution in the root-side 1 Hz
+    sampler: ``telemetry start`` before, ``telemetry end`` ALWAYS after (in a
+    finally) — an orphaned root sampler that never gets an ``end`` loops
+    forever. Telemetry is diagnostic, not load-bearing for the measurement
+    itself: a failed start/end is a best-effort stderr warning, never an
+    exception that would abort the cell."""
+    rc, err = _run_telemetry_cmd(harness.telemetry_argv("start", run_id, tier))
+    if rc != 0:
+        print(f"[telemetry] start failed for {run_id}: {err.strip() or rc}", file=sys.stderr)
+    try:
+        yield
+    finally:
+        rc, err = _run_telemetry_cmd(harness.telemetry_argv("end", run_id))
+        if rc != 0:
+            print(f"[telemetry] end failed for {run_id}: {err.strip() or rc}", file=sys.stderr)
+
+
+def _load_telemetry(run_id: str) -> tuple[Telemetry, str]:
+    """Read the root-side ``telemetry.jsonl`` this run_id's sampler wrote (if
+    any) and parse it into :class:`Telemetry`. Returns the parsed telemetry
+    plus the RAW file text, so the caller can copy it into the record's own
+    artifacts dir for self-containedness (the root-side V1 results tree is
+    not part of what a bundle/backup ships). A missing file, an empty file, a
+    cell that never reached ``telemetry start``, or a corrupt line all
+    degrade to an all-None ``Telemetry`` and empty text — never raise
+    (telemetry is diagnostic, never load-bearing for the cell's own outcome)."""
+    src = _telemetry_root() / run_id / "telemetry.jsonl"
+    text = ""
+    if src.exists():
+        with contextlib.suppress(OSError):
+            text = src.read_text(encoding="utf-8")
+    samples: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            row = json.loads(line)
+            if isinstance(row, dict):
+                samples.append(row)
+    return parse_telemetry_samples(samples), text
+
+
+# --------------------------------------------------------------------------- #
 # Command builders (shared by the executor and `run --dry-run`)
 # --------------------------------------------------------------------------- #
 
@@ -527,7 +613,7 @@ def run_session(
     budget_s = budget_min * 60 if budget_min else None
     # (pp prompt, tg decode) sizes per (model,lane,depth,config) group.
     sizes = _group_sizes(cells)
-    sweep_cache: dict[tuple, tuple[list[dict], dict, Outcome]] = {}
+    sweep_cache: dict[tuple, tuple[list[dict], dict, Outcome, Telemetry, str]] = {}
 
     try:
         for cell in cells:
@@ -693,7 +779,7 @@ def _tier_a_record(
     matching the shell harness's per-SWEEP (not per-cell) ``--exclusive``."""
     key = _group_key(cell)
     if key in cache:
-        rows, meta, outcome = cache[key]  # sibling already swept this group
+        rows, meta, outcome, telemetry, telemetry_text = cache[key]  # sibling already swept this
         tail = ""
     else:
         pp, tg = sizes.get(key, (_DEFAULT_PP_PROMPT, _DEFAULT_TG_GEN))
@@ -715,11 +801,15 @@ def _tier_a_record(
             # crash the whole session with a bare KeyError.
             spec = harness.lane_specs()[cell.lane]
             devices = resolve_bench_devices()
-            if exclusive:
-                with harness.ExclusiveSlots():
+            # Telemetry (Phase 4) wraps the WHOLE sweep, including the
+            # exclusive stop/restart window — the sampler runs for as long as
+            # this group owns the GPU, not just the container's lifetime.
+            with _telemetry_session(run_id, devices.tier):
+                if exclusive:
+                    with harness.ExclusiveSlots():
+                        result = harness.run_cell(spec, devices, **run_kwargs)
+                else:
                     result = harness.run_cell(spec, devices, **run_kwargs)
-            else:
-                result = harness.run_cell(spec, devices, **run_kwargs)
         except (BenchDeviceError, RuntimeError, KeyError) as exc:
             # Device resolution failed, ExclusiveSlots could not stop a slot,
             # or the cell's lane isn't in harness.lane_specs() — a bad cell
@@ -729,15 +819,19 @@ def _tier_a_record(
         else:
             rows, meta, tail = result.rows, result.meta, result.tail
             outcome = _classify(result.rc, tail) if (result.rc != 0 or not rows) else Outcome.OK
-        cache[key] = (rows, meta, outcome)
+        telemetry, telemetry_text = _load_telemetry(run_id)
+        cache[key] = (rows, meta, outcome, telemetry, telemetry_text)
 
     # Copy the shared engine output into THIS cell's artifacts (self-contained).
     if rows:
         (artifacts / "llama-bench.json").write_text(json.dumps(rows, indent=2))
     if meta:
         (artifacts / "meta.json").write_text(json.dumps(meta, indent=2))
+    if telemetry_text:
+        (artifacts / "telemetry.jsonl").write_text(telemetry_text, encoding="utf-8")
 
     parsed = parse_llama_bench(rows, meta, cell.kind, cell.depth)
+    parsed.telemetry = telemetry
     if outcome is Outcome.OK and not parsed.reps:
         outcome = Outcome.FAILED  # sweep succeeded but this kind's row is missing
     return _assemble(cell, parsed, outcome, host, suite_id, run_id, artifacts, tail, api, trigger)

--- a/src/hal0/bench/suites.py
+++ b/src/hal0/bench/suites.py
@@ -7,11 +7,21 @@ agent contract and must parse with zero deps on the box (tomllib is stdlib on
 3.11+, which is exactly why this package pins ``requires-python >=3.11`` and does
 NOT depend on tomli — DESIGN task note).
 
-The five tables mirror DESIGN §4 one-to-one: ``[suite]`` (identity + schedule +
-budget), ``[selector]`` (which models, resolved against the registry at plan
-time — the planner does the resolving, not this loader), ``[matrix]`` (the
-axes), ``[cells]`` (measurement kinds), ``[staleness]`` (max age). Unknown keys
-are ignored, not fatal, so a newer suite file stays loadable by an older lab.
+The five tables mirror DESIGN §4 one-to-one: ``[suite]`` (identity + budget),
+``[selector]`` (which models, resolved against the registry at plan time — the
+planner does the resolving, not this loader), ``[matrix]`` (the axes),
+``[cells]`` (measurement kinds), ``[staleness]`` (max age). Unknown keys are
+ignored, not fatal, so a newer suite file stays loadable by an older lab.
+
+A suite's ``[suite].schedule`` key never existed as a real hook: it was parsed
+into a ``Suite.schedule`` field nothing ever read — no systemd timer or worker
+consulted it. It has been removed outright (Phase 4), not merely ignored. The
+actual cadence: ``installer/systemd/hal0-bench.timer`` fires weekly and always
+runs the "roster" suite (``hal0 bench run --suite roster --scheduled``, gated
+by ``run --scheduled``'s own politeness window — ``window.toml``,
+:func:`window_file`); every other suite (``lane-matrix``, ``smoke``, ad-hoc
+ones) is on-demand only, and the model-pull trigger ``smoke.toml`` used to
+advertise has no wired hook at all (see that file).
 """
 
 from __future__ import annotations
@@ -112,7 +122,6 @@ class Suite:
 
     id: str
     description: str = ""
-    schedule: str = "on-demand"  # weekly | monthly | on-demand | model-pull
     budget_min: int = 240
     exclusive: bool = True
     priority: int = 50
@@ -138,7 +147,6 @@ def suite_from_dict(data: dict, source_path: str = "") -> Suite:
     return Suite(
         id=suite_tbl["id"],
         description=suite_tbl.get("description", ""),
-        schedule=suite_tbl.get("schedule", "on-demand"),
         budget_min=int(suite_tbl.get("budget_min", 240)),
         exclusive=bool(suite_tbl.get("exclusive", True)),
         priority=int(suite_tbl.get("priority", 50)),

--- a/tests/bench/test_harness.py
+++ b/tests/bench/test_harness.py
@@ -60,6 +60,7 @@ from hal0.bench.harness import (
     default_lanes,
     lane_specs,
     run_cell,
+    telemetry_argv,
 )
 from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE, FALLBACK_VULKAN_IMAGE
 
@@ -413,6 +414,27 @@ class TestBenchctlExecArgv:
         argv = benchctl_exec_argv(["podman"], 0)
 
         assert "--timeout-s" not in argv
+
+
+# ── telemetry_argv (Phase 4) ────────────────────────────────────────────────
+
+
+class TestTelemetryArgv:
+    def test_start_carries_the_tier(self) -> None:
+        argv = telemetry_argv("start", "run-1", "amd")
+
+        assert argv == ["sudo", "-n", BENCHCTL, "telemetry", "start", "run-1", "amd"]
+
+    def test_end_never_carries_a_tier(self) -> None:
+        argv = telemetry_argv("end", "run-1")
+
+        assert argv == ["sudo", "-n", BENCHCTL, "telemetry", "end", "run-1"]
+
+    def test_empty_tier_is_omitted_not_passed_as_empty_string(self) -> None:
+        argv = telemetry_argv("start", "run-1", "")
+
+        assert argv == ["sudo", "-n", BENCHCTL, "telemetry", "start", "run-1"]
+        assert "" not in argv
 
 
 # ── run_cell ──────────────────────────────────────────────────────────────────

--- a/tests/bench/test_parsers.py
+++ b/tests/bench/test_parsers.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 import pytest
 
-from hal0.bench.parsers import llama_bench_row_kind, parse_llama_bench, parse_server_ab
+from hal0.bench.parsers import (
+    llama_bench_row_kind,
+    parse_llama_bench,
+    parse_server_ab,
+    parse_telemetry_samples,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -162,3 +167,102 @@ def test_parse_server_ab_drafts_without_accepted_does_not_crash():
     assert p.reps[0].decode_ts == 40.0
     assert p.reps[0].accept_rate is None  # unknowable, never invented, never crash
     assert p.reps[0].drafted == 12
+
+
+# --------------------------------------------------------------------------- #
+# Telemetry (Phase 4) — hal0-benchctl's 1 Hz sampler JSONL rows
+# --------------------------------------------------------------------------- #
+
+
+def _sample(ts="2026-08-09T00:00:00Z", **kw):
+    row = {
+        "ts": ts,
+        "temp_c": None,
+        "power_mw": None,
+        "gpu_busy_pct": None,
+        "vram_b": None,
+        "gtt_b": None,
+        "sclk_mhz": None,
+    }
+    row.update(kw)
+    return row
+
+
+def test_telemetry_empty_samples_is_all_none():
+    t = parse_telemetry_samples([])
+    assert t.vram_peak_mb is None
+    assert t.gtt_peak_mb is None
+    assert t.gpu_edge_temp_max_c is None
+    assert t.gpu_power_avg_w is None
+    assert t.throttled is None
+
+
+def test_telemetry_unit_conversions():
+    samples = [
+        _sample(
+            vram_b=2 * 1024 * 1024 * 1024,
+            gtt_b=512 * 1024 * 1024,
+            temp_c=45000,
+            power_mw=120000,
+        ),
+        _sample(
+            vram_b=3 * 1024 * 1024 * 1024,
+            gtt_b=256 * 1024 * 1024,
+            temp_c=52000,
+            power_mw=140000,
+        ),
+    ]
+    t = parse_telemetry_samples(samples)
+    assert t.vram_peak_mb == 3072  # bytes -> MB, peak (max) over samples
+    assert t.gtt_peak_mb == 512  # peak, not the last sample
+    assert t.gpu_edge_temp_max_c == 52  # millidegrees -> degrees C, max
+    assert t.gpu_power_avg_w == 130  # mW -> W, MEAN not max: (120000+140000)/2/1000
+
+
+def test_telemetry_missing_counter_stays_null_independently():
+    # gtt_b is unreadable on every sample (debugfs locked down) but vram_b
+    # isn't — one dead counter must not blank the others (§14.3).
+    samples = [
+        _sample(vram_b=1024 * 1024, gtt_b=None),
+        _sample(vram_b=2 * 1024 * 1024, gtt_b=None),
+    ]
+    t = parse_telemetry_samples(samples)
+    assert t.vram_peak_mb == 2
+    assert t.gtt_peak_mb is None
+
+
+def test_telemetry_throttle_flags_three_consecutive_drops_below_ten_percent():
+    # Peak sclk 2000 MHz; threshold is 1800 MHz. Three consecutive samples
+    # below that trips throttled=True.
+    samples = [
+        _sample(sclk_mhz=2000),
+        _sample(sclk_mhz=1700),
+        _sample(sclk_mhz=1600),
+        _sample(sclk_mhz=1650),
+    ]
+    t = parse_telemetry_samples(samples)
+    assert t.throttled is True
+
+
+def test_telemetry_throttle_false_when_drop_never_reaches_three_consecutive():
+    samples = [
+        _sample(sclk_mhz=2000),
+        _sample(sclk_mhz=1700),  # one drop...
+        _sample(sclk_mhz=2000),  # ...then recovers, streak resets
+        _sample(sclk_mhz=1700),
+    ]
+    t = parse_telemetry_samples(samples)
+    assert t.throttled is False
+
+
+def test_telemetry_throttle_false_within_ten_percent_band():
+    # 2000 -> 1900 is exactly a 5% drop, inside the >10% threshold.
+    samples = [_sample(sclk_mhz=2000), _sample(sclk_mhz=1900), _sample(sclk_mhz=1900)]
+    t = parse_telemetry_samples(samples)
+    assert t.throttled is False
+
+
+def test_telemetry_throttle_none_when_sclk_never_sampled():
+    samples = [_sample(vram_b=1024), _sample(vram_b=2048)]  # no sclk_mhz at all
+    t = parse_telemetry_samples(samples)
+    assert t.throttled is None

--- a/tests/bench/test_regress.py
+++ b/tests/bench/test_regress.py
@@ -1,0 +1,197 @@
+"""test_regress.py — regression detection math (DESIGN §11) + the
+``bench.regression`` journal/board wiring (Phase 4), against FAKED
+AuditStore/BoardStore (no real SQLite audit/board db touched)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from hal0.bench import regress
+from hal0.bench.regress import BOARD_TASK_THRESHOLD, Flag, journal_flags
+from hal0.bench.schema import (
+    Config,
+    Engine,
+    Host,
+    Identity,
+    Model,
+    Outcome,
+    Record,
+    Summary,
+    Workload,
+)
+from hal0.bench.store import Store
+
+
+def _flag(i: int = 0) -> Flag:
+    return Flag(
+        cell_key=f"sha256:cell{i}",
+        model_id=f"m{i}",
+        delta_pct=-15.0,
+        newest_ts="2026-08-01T00:00:00Z",
+        trailing_median=100.0,
+        run_ids=["prev", "newest"],
+    )
+
+
+class FakeAuditStore:
+    """Records every constructor call + every ``record()`` call — the module-
+    level ``regress.AuditStore`` name is monkeypatched to this class, mirroring
+    how the rest of this package fakes seams (``harness.BENCHCTL`` etc)."""
+
+    instances: ClassVar[list[FakeAuditStore]] = []
+
+    def __init__(self, path):
+        self.path = path
+        self.schema_inited = False
+        self.records: list[dict] = []
+        FakeAuditStore.instances.append(self)
+
+    def init_schema(self) -> None:
+        self.schema_inited = True
+
+    async def record(self, **kwargs) -> int:
+        self.records.append(kwargs)
+        return len(self.records)
+
+
+class ExplodingAuditStore(FakeAuditStore):
+    def init_schema(self) -> None:
+        raise RuntimeError("db locked")
+
+
+class FakeBoardStore:
+    instances: ClassVar[list[FakeBoardStore]] = []
+
+    def __init__(self):
+        self.tasks: list[dict] = []
+        FakeBoardStore.instances.append(self)
+
+    def create_task(self, body: dict) -> dict:
+        self.tasks.append(body)
+        return {"task": body}
+
+
+class ExplodingBoardStore(FakeBoardStore):
+    def create_task(self, body: dict) -> dict:
+        raise RuntimeError("board db locked")
+
+
+def _reset():
+    FakeAuditStore.instances = []
+    FakeBoardStore.instances = []
+
+
+class TestJournalFlags:
+    def test_no_flags_writes_nothing(self, monkeypatch):
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", FakeAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", FakeBoardStore)
+
+        journal_flags([], "roster")
+
+        assert FakeAuditStore.instances == []
+        assert FakeBoardStore.instances == []
+
+    def test_emits_one_audit_event_summarising_every_flag(self, monkeypatch):
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", FakeAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", FakeBoardStore)
+        flags = [_flag(0), _flag(1)]
+
+        journal_flags(flags, "roster")
+
+        [audit] = FakeAuditStore.instances
+        assert audit.schema_inited
+        [rec] = audit.records
+        assert rec["action"] == "bench.regression"
+        assert rec["category"] == "bench"
+        assert rec["target"] == "roster"
+        assert rec["severity"] == "warn"
+        assert len(rec["after"]["flags"]) == 2
+        assert rec["after"]["flags"][0]["cell_key"] == "sha256:cell0"
+
+    def test_board_task_only_above_threshold(self, monkeypatch):
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", FakeAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", FakeBoardStore)
+
+        at_threshold = [_flag(i) for i in range(BOARD_TASK_THRESHOLD)]
+        journal_flags(at_threshold, "roster")
+        assert FakeBoardStore.instances == []  # <= threshold: no task
+
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", FakeAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", FakeBoardStore)
+        above_threshold = [_flag(i) for i in range(BOARD_TASK_THRESHOLD + 1)]
+        journal_flags(above_threshold, "roster")
+        [board] = FakeBoardStore.instances
+        [task] = board.tasks
+        assert task["status"] == "triage"
+        assert str(BOARD_TASK_THRESHOLD + 1) in task["title"]
+
+    def test_audit_failure_never_raises_and_board_task_still_attempted(self, monkeypatch):
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", ExplodingAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", FakeBoardStore)
+        flags = [_flag(i) for i in range(BOARD_TASK_THRESHOLD + 1)]
+
+        journal_flags(flags, "roster")  # must not raise
+
+        [board] = FakeBoardStore.instances
+        assert board.tasks  # board path still ran despite the audit failure
+
+    def test_board_failure_never_raises(self, monkeypatch):
+        _reset()
+        monkeypatch.setattr(regress, "AuditStore", FakeAuditStore)
+        monkeypatch.setattr(regress, "BoardStore", ExplodingBoardStore)
+        flags = [_flag(i) for i in range(BOARD_TASK_THRESHOLD + 1)]
+
+        journal_flags(flags, "roster")  # must not raise
+
+        [audit] = FakeAuditStore.instances
+        assert audit.records  # the audit path still completed
+
+
+class TestRegressionCheck:
+    """A couple of DESIGN §11 sanity checks that predate Phase 4 but had no
+    dedicated test module yet."""
+
+    def _ok_record(self, decode_ts, run_id, hal0_version="1.0.0"):
+        return Record(
+            run_id=run_id,
+            suite="t",
+            trigger="manual",
+            identity=Identity(
+                model=Model(id="m1"),
+                engine=Engine(),
+                lane="rocm",
+                config=Config(),
+                workload=Workload(),
+            ),
+            host=Host(hal0_version=hal0_version),
+            outcome=Outcome.OK,
+            summary=Summary(decode_ts_med=decode_ts),
+        ).to_dict()
+
+    def test_flags_a_drop_past_threshold_with_stable_provenance(self, tmp_path):
+        store = Store(tmp_path)
+        for i, val in enumerate([100.0, 100.0, 100.0, 100.0]):
+            store.append_record(self._ok_record(val, f"r{i}"))
+        store.append_record(self._ok_record(50.0, "r-new"))  # >10% worse
+
+        flags = regress.check(store)
+
+        assert len(flags) == 1
+        assert flags[0].model_id == "m1"
+        assert flags[0].delta_pct < 0
+
+    def test_no_flag_when_provenance_changed(self, tmp_path):
+        store = Store(tmp_path)
+        for i, val in enumerate([100.0, 100.0, 100.0, 100.0]):
+            store.append_record(self._ok_record(val, f"r{i}"))
+        # hal0_version bumped on the newest record — an explained step, not a regression.
+        store.append_record(self._ok_record(50.0, "r-new", hal0_version="1.0.1"))
+
+        flags = regress.check(store)
+
+        assert flags == []

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -467,6 +467,13 @@ def _install_fake_seam(sandbox: Path, monkeypatch, calls: Path) -> None:
     monkeypatch.setattr(harness, "BENCHCTL", str(benchctl))
     monkeypatch.setattr(runner, "resolve_bench_devices", lambda: _CPU_DEVICES)
     monkeypatch.setattr(runner, "_traffic_in_flight", lambda *a, **k: False)
+    # Telemetry (Phase 4) is a SEPARATE seam call (`_run_telemetry_cmd`, not
+    # the podman-exec `runner` harness.run_cell threads through) — the fake
+    # benchctl script above unconditionally echoes "run" + the llama-bench
+    # rows for ANY invocation, so without this the telemetry start/end calls
+    # would also hit it and corrupt every test in this module that counts
+    # seam calls. Tests that care about telemetry itself override this.
+    monkeypatch.setattr(runner, "_run_telemetry_cmd", lambda argv: (0, ""))
 
 
 class TestSessionIntegration:
@@ -558,6 +565,174 @@ class TestSessionIntegration:
         [rec] = list(store.iter_records())
         assert rec["outcome"] == Outcome.FAILED.value
         assert "boom" in rec["note"]
+
+
+class TestTelemetrySession:
+    """``_telemetry_session`` (Phase 4): start/end argv shape + the
+    finally-always-ends guarantee (an orphaned root sampler loops forever)."""
+
+    def test_start_then_end_argv_shape(self, monkeypatch):
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            runner, "_run_telemetry_cmd", lambda argv: (calls.append(argv), (0, ""))[1]
+        )
+
+        with runner._telemetry_session("run-1", "amd"):
+            assert calls == [["sudo", "-n", harness.BENCHCTL, "telemetry", "start", "run-1", "amd"]]
+
+        assert calls == [
+            ["sudo", "-n", harness.BENCHCTL, "telemetry", "start", "run-1", "amd"],
+            ["sudo", "-n", harness.BENCHCTL, "telemetry", "end", "run-1"],
+        ]
+
+    def test_end_still_runs_when_the_body_raises(self, monkeypatch):
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            runner, "_run_telemetry_cmd", lambda argv: (calls.append(argv), (0, ""))[1]
+        )
+
+        with pytest.raises(RuntimeError), runner._telemetry_session("run-1", "cpu"):
+            raise RuntimeError("boom")
+
+        actions = [c[4] for c in calls]
+        assert actions == ["start", "end"]  # end still fired despite the raise
+
+    def test_a_failed_start_or_end_never_raises(self, monkeypatch, capsys):
+        monkeypatch.setattr(runner, "_run_telemetry_cmd", lambda argv: (1, "permission denied"))
+
+        with runner._telemetry_session("run-1", "amd"):
+            pass  # must not raise on either side
+
+        assert "permission denied" in capsys.readouterr().err
+
+
+class TestLoadTelemetry:
+    """``_load_telemetry`` (Phase 4): reads the root-side jsonl this run_id's
+    sampler wrote, if any — missing/empty degrades to an all-None Telemetry
+    and empty text, never an exception."""
+
+    def test_missing_file_is_all_none_and_empty_text(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HAL0_BENCH_TELEMETRY_ROOT", str(tmp_path / "nope"))
+
+        telemetry, text = runner._load_telemetry("run-1")
+
+        assert text == ""
+        assert telemetry.vram_peak_mb is None
+        assert telemetry.throttled is None
+
+    def test_reads_and_parses_real_samples(self, tmp_path, monkeypatch):
+        root = tmp_path / "telemetry-root"
+        monkeypatch.setenv("HAL0_BENCH_TELEMETRY_ROOT", str(root))
+        run_dir = root / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "telemetry.jsonl").write_text(
+            '{"ts":"t1","temp_c":45000,"power_mw":100000,"gpu_busy_pct":50,'
+            '"vram_b":1048576,"gtt_b":null,"sclk_mhz":2000}\n'
+            '{"ts":"t2","temp_c":46000,"power_mw":110000,"gpu_busy_pct":90,'
+            '"vram_b":2097152,"gtt_b":null,"sclk_mhz":1900}\n'
+        )
+
+        telemetry, text = runner._load_telemetry("run-1")
+
+        assert "vram_b" in text  # the raw text is returned for the caller to copy verbatim
+        assert telemetry.vram_peak_mb == 2  # 2097152 bytes -> 2 MB
+        assert telemetry.gpu_edge_temp_max_c == 46
+
+    def test_corrupt_line_is_skipped_not_fatal(self, tmp_path, monkeypatch):
+        root = tmp_path / "telemetry-root"
+        monkeypatch.setenv("HAL0_BENCH_TELEMETRY_ROOT", str(root))
+        run_dir = root / "run-1"
+        run_dir.mkdir(parents=True)
+        (run_dir / "telemetry.jsonl").write_text(
+            "not json at all\n"
+            '{"ts":"t1","temp_c":40000,"power_mw":null,"gpu_busy_pct":null,'
+            '"vram_b":null,"gtt_b":null,"sclk_mhz":null}\n'
+        )
+
+        telemetry, _text = runner._load_telemetry("run-1")
+
+        assert telemetry.gpu_edge_temp_max_c == 40
+
+
+class TestTierASamplesTelemetry:
+    """Integration: a Tier-A sweep starts/ends the sampler exactly once per
+    memoised group (not per cell), copies the raw jsonl into EACH sibling
+    cell's own artifacts dir, and stamps the parsed Telemetry onto both
+    records."""
+
+    def test_pp_tg_siblings_share_one_start_end_pair_and_both_get_telemetry(
+        self, sandbox, monkeypatch, tmp_path
+    ):
+        calls_path = sandbox / "calls"
+        _install_fake_seam(sandbox, monkeypatch, calls_path)
+        telemetry_root = sandbox / "telemetry-root"
+        monkeypatch.setenv("HAL0_BENCH_TELEMETRY_ROOT", str(telemetry_root))
+
+        telemetry_calls: list[list[str]] = []
+
+        def fake_telemetry_cmd(argv):
+            telemetry_calls.append(argv)
+            if argv[4] == "start":
+                run_id = argv[5]
+                d = telemetry_root / run_id
+                d.mkdir(parents=True, exist_ok=True)
+                (d / "telemetry.jsonl").write_text(
+                    '{"ts":"t","temp_c":50000,"power_mw":100000,"gpu_busy_pct":80,'
+                    '"vram_b":1048576,"gtt_b":null,"sclk_mhz":2000}\n'
+                )
+            return 0, ""
+
+        monkeypatch.setattr(runner, "_run_telemetry_cmd", fake_telemetry_cmd)
+
+        store = Store(tmp_path / "state")
+        host = Host(hal0_version="1.0.0", exclusive=True)
+        suite = _suite(["pp", "tg"])
+        cells = plan(suite, _registry(), store)
+
+        result = runner.run_session(cells, store, host, suite_id="t", api="http://x")
+
+        assert result.cells_ok == 2
+        starts = [c for c in telemetry_calls if c[4] == "start"]
+        ends = [c for c in telemetry_calls if c[4] == "end"]
+        assert len(starts) == 1  # ONE sampler session for the whole memoised group
+        assert len(ends) == 1
+        assert starts[0][6] == "cpu"  # BenchDeviceSpec(tier="cpu") from _CPU_DEVICES
+
+        records = list(store.iter_records())
+        assert len(records) == 2
+        for rec, run_id in zip(records, result.run_ids, strict=True):
+            assert rec["telemetry"]["vram_peak_mb"] == 1
+            assert rec["telemetry"]["gpu_edge_temp_max_c"] == 50
+            # self-contained: each sibling's OWN artifacts dir got the copy,
+            # not just the group's root-side triggering run_id.
+            assert (store.artifacts_dir(run_id) / "telemetry.jsonl").exists()
+
+    def test_missing_telemetry_jsonl_leaves_record_all_none_without_failing_cell(
+        self, sandbox, monkeypatch, tmp_path
+    ):
+        calls_path = sandbox / "calls"
+        _install_fake_seam(sandbox, monkeypatch, calls_path)
+        # No HAL0_BENCH_TELEMETRY_ROOT override and no file ever written —
+        # the sampler "started" but (as on a debugfs-locked-down box) never
+        # produced a readable jsonl.
+        monkeypatch.setenv("HAL0_BENCH_TELEMETRY_ROOT", str(tmp_path / "never-written"))
+
+        store = Store(tmp_path / "state")
+        host = Host(hal0_version="1.0.0", exclusive=True)
+        cells = _cells(["pp"], store)
+
+        result = runner.run_session(cells, store, host, suite_id="t", api="http://x")
+
+        assert result.cells_ok == 1  # telemetry absence never fails the cell
+        [rec] = list(store.iter_records())
+        assert rec["outcome"] == Outcome.OK.value
+        assert rec["telemetry"] == {
+            "vram_peak_mb": None,
+            "gtt_peak_mb": None,
+            "gpu_edge_temp_max_c": None,
+            "gpu_power_avg_w": None,
+            "throttled": None,
+        }
 
 
 class TestBogusLaneDefensiveLayer:

--- a/tests/bench/test_shipped_suites.py
+++ b/tests/bench/test_shipped_suites.py
@@ -4,11 +4,12 @@ unnoticed as fully non-functional because nothing ever loaded the real files."""
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 
 from hal0.bench.planner import KNOWN_KINDS, plan
 from hal0.bench.store import Store
-from hal0.bench.suites import load_suites
+from hal0.bench.suites import Suite, load_suites, suite_from_dict
 
 SEED_DIR = Path(__file__).resolve().parents[2] / "installer" / "bench" / "suites"
 
@@ -16,6 +17,41 @@ SEED_DIR = Path(__file__).resolve().parents[2] / "installer" / "bench" / "suites
 def test_every_shipped_suite_loads():
     suites = load_suites(SEED_DIR)
     assert set(suites) == {"roster", "smoke", "lane-matrix"}
+
+
+def test_suite_has_no_schedule_field():
+    """Phase 4 (bench-overhaul): the never-implemented ``Suite.schedule`` hook
+    is deleted outright, not stubbed — no systemd timer or worker ever
+    consulted it (cadence lives in installer/systemd/hal0-bench.timer +
+    window.toml's own politeness gate)."""
+    names = {f.name for f in dataclasses.fields(Suite)}
+    assert "schedule" not in names
+
+
+def test_a_schedule_key_in_toml_is_silently_ignored_not_fatal():
+    """A stray ``schedule =`` line (an operator's stale copy of an old suite
+    file) must not break loading — suites.py's contract is "unknown keys are
+    ignored, not fatal" (module docstring)."""
+    suite = suite_from_dict(
+        {
+            "suite": {"id": "t", "schedule": "weekly"},
+            "matrix": {"lanes": ["default"], "depths": [2048]},
+        }
+    )
+    assert not hasattr(suite, "schedule")
+    assert suite.id == "t"
+
+
+def test_shipped_toml_files_carry_no_schedule_key():
+    """Comments may still explain WHY the key is gone (they do); no shipped
+    file may carry an actual ``schedule =`` assignment."""
+    import re
+
+    for path in sorted(SEED_DIR.glob("*.toml")):
+        lines = [ln for ln in path.read_text().splitlines() if not ln.lstrip().startswith("#")]
+        assert not any(re.match(r"^\s*schedule\s*=", ln) for ln in lines), (
+            f"{path} still assigns [suite].schedule"
+        )
 
 
 def test_every_shipped_kind_is_runnable():


### PR DESCRIPTION
Phase 4 — the last backend phase of the benchmark overhaul (follows #1761/#1763/#1765).

## What changed

- **Telemetry stops being all-null.** The root-side 1 Hz sampler (`hal0-benchctl telemetry`, previously caller-less) now records `vram_b`/`gtt_b`/`sclk_mhz` alongside temp/power/busy (missing counters stay `null`, never 0), and `_tier_a_record` brackets each non-memoised Tier-A sweep with `telemetry start/end` — `end` in a `finally`, so no orphaned root sampler. `parsers.parse_telemetry_samples` folds the jsonl into `schema.Telemetry`: vram/gtt peaks (MB), max edge temp, avg power, and `throttled` = sclk >10% below the run's own peak for ≥3 consecutive samples. On this thermal-limited Strix Halo APU, runs aren't comparable without that context. Tier-B/C and adapter cells deliberately stay `None` (they share the GPU with the serving slot — sampling would attribute the slot's load to the bench).
- **Regression flags journal instead of stdout-only**: `regress.journal_flags` emits a `bench.regression` event through `hal0.activity.AuditStore` (the same durable trail slot/pull/system events use) and opens an Operator Board task when a session yields >2 flags (`hal0.board.store.BoardStore`, already in-tree). Best-effort: journaling failures log and never break a session.
- **Honest deletion**: `Suite.schedule` (parsed, never consulted — the systemd timer + queue own scheduling) and smoke's phantom model-pull trigger are gone; shipped suite TOMLs now state their real trigger.

## ⚠️ Privileged surface note

`installer/wrappers/hal0-benchctl` changes again — additively: three read-only sysfs samples inside the existing `telemetry` verb (no new verbs, no validation changes, sudoers untouched). Per the Phase-1/2 precedent this PR is **not** automerged; flagging for operator eyes even though the diff is small.

## Verification

`tests/bench`: **344 passed, 0 failed** (new coverage: telemetry parse math incl. throttle rule + unit conversions, start/end argv + finally-on-failure, all-None on missing jsonl, journal emission via fakes, suite-load without `schedule`). ruff + format clean; mypy delta 0; scar-ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)