### PR TITLE
chore(release): v1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,46 @@ breaking/migrations as callouts — from the cosign-verified tarball, before
 applying. Add those subsections to a version's section to surface them; see
 `scripts/gen_release_notes.py`.
 
-## [Unreleased]
+## [1.0.0-rc.4] — 2026-08-09
+
+### Highlights
+
+- **Privileged-seam hardening.** The `hal0-systemctl` root wrapper now
+  allow-lists the *content* of everything it writes — systemd drop-ins
+  (#1718), quadlet bodies with the raw `write-unit` verb removed (#1748), and
+  `PodmanArgs=` pinned to the flags providers emit, closing a `--runtime`
+  host-exec path (#1759). The update staging path closes a verify→extract
+  TOCTOU (root-only stage dir + digest pinned to the extraction handle, #1745),
+  reaps orphaned staging/quarantine trees (#1755), never dereferences symlinks
+  when applying ownership (#1743), and only trusts a root-owned config for the
+  releases-URL override (#1750). Slot flag denylisting canonicalizes the
+  `--flag=value` form (#1746) and rejects malformed shell quoting at save time
+  (#1737/#1749).
+- **Fresh-install & update robustness.** The installer waits on the dpkg/apt
+  lock instead of dying (#1733), runs AppArmor remediation before the podman
+  preflight gate (#1728), preflights git for Hermes (#1727), and applies the
+  model-layout migration as its final model step (#1732). An up-to-date
+  `hal0 update` now converges an outstanding v1.0 profile-catalog reset instead
+  of going silent (#1585/#1757); staged trees get their perms normalized after
+  extraction (#1725); every `hal0.toml` write goes through one serialized
+  read-modify-write path (#1724).
+- **Capabilities & settings UI.** A unified **AI Capabilities** page (TTS, STT,
+  embeddings, reranking, image generation, NPU) with a canonical rerank slot
+  (#1747), a memory reranker model picker (#1781), and per-panel probe-failure
+  surfacing instead of a silent grey Save (#1774).
+- **Dashboard redesign.** The main and Benchmarks dashboards now share the
+  hal0.dev design-system chrome (#1764/#1768), with benchmark trigger/config/
+  outcomes/regressions surfaced (#1744) and assorted tile/row polish
+  (#1729/#1779/#1780/#1782).
+- **Benchmark system overhaul.** Adopts GuideLLM, llama-benchy and
+  tool-eval-bench (#1765), adds record telemetry + regression journaling
+  (#1766) and shareable result bundles (#1758), folds the shell harness into
+  Python behind a validate-and-exec `benchctl` shim (#1761), and makes the
+  measurements truthful and the pipeline reliable (#1736 and follow-ups).
+- **Slots.** Per-slot profile-flag divergence overlay with a cross-device
+  picker (#1639), and a live slot now restarts when apply changes config but
+  not the model (#1770).
+- **Docs.** Quick-start and migration guide rewritten for v1.0 (#1731).
 
 ### Added
 
@@ -114,6 +153,59 @@ applying. Add those subsections to a version's section to surface them; see
 
 - Enabling the rerank capability now creates/loads the `rerank` slot the dispatcher actually routes `/v1/rerankings` to (was `embed-rerank`, which nothing routed to); `embed-rerank` resolves as an alias.
 - `hal0 update` on an already-current box now converges an outstanding one-shot v1.0 profile-catalog reset instead of printing "nothing to apply" and hiding it (#1585). The reset rides `commit()`, but a box updated 0.9.8→1.0 ran commit under the *old* daemon, which had no reset — so it landed converged-except-for-this and then went silent. `/api/updates/check` now carries a read-only `profile_reset` snapshot, and a new local `POST /api/updates/converge-profiles` runs the reset with no download or swap. The up-to-date CLI path consults the snapshot: it converges (prompting or honoring `--yes` for the consent-needing case), converges silently when there's nothing to lose, and otherwise reports the reset as outstanding and exits 2 (up to date, convergence outstanding) rather than exiting 0 in silence.
+
+### Audience
+
+Preview-channel operators validating the 1.0 line ahead of GA, and fresh
+installs that want the current build. This is the release-candidate carrying
+the privileged-seam hardening cluster (#1738/#1740/#1750/#1759); it is the
+recommended pre-GA validation target. Boxes on the stable channel are not
+offered this tag.
+
+### Supported upgrades
+
+- `1.0.0-rc.3` → `1.0.0-rc.4` via `hal0 update` (preview channel). The GitHub
+  release asset URL (`https://github.com/Hal0ai/hal0/releases/download/v1.0.0-rc.4/preview.json`)
+  works end-to-end for install and update.
+- `1.0.0-rc.2` / `1.0.0-rc.1` → `1.0.0-rc.4` directly, same mechanism.
+- `0.9.8` → `1.0.0-rc.4` in place — re-run the installer or `hal0 update` on
+  the preview channel; the R5 migration set applies (see the
+  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+  The profile-catalog reset that used to defer silently on this transition now
+  converges on the first post-update `hal0 update` (#1585).
+- Older than 0.9.8: step through 0.9.8 first.
+
+### Known issues
+
+The 0.9.8 CLI's spurious end-of-update `ConnectError` (the pre-1.0 client dies
+when the apply restarts hal0-api under its status poll, even though the update
+succeeds — verify with `hal0 --version`) and the first-boot
+`unattended-upgrades` dpkg race (#1584) carry forward. A box still on rc.1/rc.2
+whose venv predates #1663 is not *offered* a newer tag by the passive check —
+`hal0 update --target <version>` is the recovery path (#1715). The rc.1
+profile-catalog-defer item is resolved this release (#1585).
+
+### Operator migrations
+
+- **Releases-URL override (#1750):** a `file://` `HAL0_RELEASES_URL` is no
+  longer accepted from the service-owned `/etc/hal0/api.env` — put it in the
+  root-owned `/etc/hal0/update.conf` (`root:root 0644`) instead. `https://`
+  overrides in `api.env` are unchanged, so boxes using the GitHub asset URL
+  need no action; only `file://`-staging boxes move the line.
+- **Deprecated `extra_args` at the seam (#1759):** a slot whose deprecated
+  free-form `extra_args` carries a `podman run` flag outside
+  `--group-add`/`--security-opt`/`--ipc`/`--ulimit` is now refused at the root
+  seam on a hal0-service install. Move those flags to typed Quadlet keys in a
+  `hal0-slot@<token>.container.d/` drop-in. Shipped providers are unaffected.
+- The R5 operator-run migrators (slot-flag fold, id-keying) are unchanged from
+  rc.1.
+
+### Rollback
+
+Release tarballs are immutable and cosign-signed; roll back by re-installing
+the previous tag (`v1.0.0-rc.3`) from its GitHub release. No rc.4 change writes
+a state shape rc.3 cannot read — the profile-catalog reset stamps the same
+`schema_version = 2` rc.3's commit path already used.
 
 ## [1.0.0-rc.3] — 2026-08-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
-  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release \u2014 the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md \u00a712 and \u00a717 (maintainer-local).",
-  "version": "1.0.0-rc.3",
+  "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
+  "version": "1.0.0-rc.4",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {
@@ -17,7 +17,7 @@
     "flm": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-flm:0.9.44",
       "digest": "sha256:49c175ce799061b07d3c84b1bdece9d8dcb74be5f9717f95fb52f51bd5020fc9",
-      "_notes": "FastFlowLM v0.9.44 on AMD XDNA2 NPU (toolbox rebuilt from packaging/toolbox/flm.Dockerfile FLM_REF=v0.9.44 \u2014 `flm version` inside reports v0.9.44). Requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest via scripts/update-toolbox-digests.sh accept-set (confirmed post-push 2026-07-10)."
+      "_notes": "FastFlowLM v0.9.44 on AMD XDNA2 NPU (toolbox rebuilt from packaging/toolbox/flm.Dockerfile FLM_REF=v0.9.44 — `flm version` inside reports v0.9.44). Requires amdxdna driver on the host (kernel >= 6.14 in-tree, or >= 6.10 via amdxdna-dkms) + NPU firmware >= 1.1.0.0. Digest is the GHCR registry digest via scripts/update-toolbox-digests.sh accept-set (confirmed post-push 2026-07-10)."
     },
     "moonshine": {
       "tag": "ghcr.io/hal0ai/hal0-toolbox-moonshine:v1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.3",
+      "version": "1.0.0-rc.4",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc3"
+version = "1.0.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Fourth 1.0 release candidate — the pre-GA validation target. Rebuilt on the current `main` tip (`295181bd`) so it includes **every PR merged for this candidate**.

## Included
- **Privileged-seam hardening:** #1738 (staging TOCTOU + `.stage-*` reaper), #1740 (quadlet body allow-list), #1750 (releases-URL two-trust split), #1759 (`PodmanArgs` host-exec allow-list), #1585 (up-to-date profile-catalog convergence).
- **UI / dashboard / bench polish:** #1764, #1766 (phase-4 telemetry/journaling), #1768, #1770, #1774, #1776–#1782 and siblings (code-merged; these added no operator-facing CHANGELOG bullets, so the changelog reflects the operator-visible set only).

## Release mechanics
- `set-version.py 1.0.0-rc.4` (pyproject/ui/manifest/uv.lock)
- toolbox digests refreshed: 7 updated, 0 null
- CHANGELOG `[Unreleased]` → `[1.0.0-rc.4]` with the required preview subsections

## Validated
- `gen_release_notes.py --tag v1.0.0-rc.4 --channel preview` → 0 TBD
- `hal0.release.policy v1.0.0-rc.4` → preview / prerelease / not-latest / no-PyPI
- `pytest tests/release` → 92 passed

## Operator migrations flagged
- `file://` `HAL0_RELEASES_URL` moves from `api.env` → root-owned `/etc/hal0/update.conf` (#1750)
- deprecated out-of-list `extra_args` podman flags now refused at the seam (#1759)

## ⚠️ Cut is operator-gated
**Automerge is deliberately NOT enabled.** Merge is the operator's call. The signed build fires only after the operator merges this PR and pushes the `v1.0.0-rc.4` tag on the squash commit (release.yml: build → cosign → publish; PyPI skipped for previews).

🤖 Generated with [Claude Code](https://claude.com/claude-code)