### PR TITLE
feat(ui): unify dashboard chrome with the hal0.dev design-system pack

### DIFF
--- a/ui/src/dash/connections.css
+++ b/ui/src/dash/connections.css
@@ -361,7 +361,7 @@
 
 /* per-tool capability badges — the blast-radius manifest */
 .mt-badge { font-family: var(--jbm); font-size: 8.5px; text-transform: uppercase; letter-spacing: 0.05em; padding: 1px 6px; border-radius: var(--rad-pill); border: 1px solid var(--line); color: var(--fg-4); }
-.mt-badge.gated { color: var(--warn); border-color: rgba(242,121,43,0.4); background: rgba(242,121,43,0.08); }
+.mt-badge.gated { color: var(--warn); border-color: rgba(232,185,78,0.4); background: rgba(232,185,78,0.08); }
 .mt-badge.destructive { color: var(--err); border-color: var(--err-line); background: rgba(255,90,90,0.07); }
 .mt-badge.read { color: var(--ok); border-color: var(--ok-line); background: var(--ok-soft); }
 .mt-badge.world { color: var(--info); border-color: rgba(90,160,255,0.35); background: rgba(90,160,255,0.07); }

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -26,7 +26,7 @@
   --comfy-line: rgba(229, 184, 79, 0.34);
   --comfy-bg: #1b1605;
   --comfy-glow: rgba(229, 184, 79, 0.2);
-  /* --warn/--warn-soft/--warn-line inherit from dashboard.css (canonical #f2792b) */
+  /* --warn/--warn-soft/--warn-line inherit from dashboard.css (canonical #e8b94e) */
   font-family: var(--geist);
   color: var(--fg);
 }

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -928,8 +928,20 @@
   display: grid;
   gap: 12px;
 }
+/* Capability slots (embed / rerank / tts / stt) sit four to a row so a full
+   utility loadout reads as one complete rank; collapses on narrow panes. */
 :is(.infer-pane, .npu-pane) .scards.compact {
-  grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+@media (max-width: 1100px) {
+  :is(.infer-pane, .npu-pane) .scards.compact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 560px) {
+  :is(.infer-pane, .npu-pane) .scards.compact {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 :is(.infer-pane, .npu-pane) .scards.full {
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
@@ -958,6 +970,7 @@
   width: 2px;
   background: var(--bk, transparent);
   opacity: 0.85;
+  z-index: 1; /* stays visible over the full-bleed .scard-foot bar */
 }
 :is(.infer-pane, .npu-pane) .scard:hover {
   border-color: var(--line-strong);
@@ -1149,17 +1162,18 @@
 :is(.infer-pane, .npu-pane) .scard-meta .m .v.muted {
   color: var(--fg-5);
 }
+/* Bottom action bar — the same full-bleed dark strip the stack cards
+   (.stk-lib-f) and profile cards use: sunken fill, top hairline, pinned to
+   the card's bottom edge. Negative margins escape .scard-b's 10px/12px pad. */
 :is(.infer-pane, .npu-pane) .scard-foot {
   display: flex;
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
-  padding-top: 9px;
+  margin: auto -12px -10px;
+  padding: 8px 11px;
   border-top: 1px solid var(--line-soft);
-}
-:is(.infer-pane, .npu-pane) .scard-foot.bare {
-  border-top: none;
-  padding-top: 0;
+  background: var(--bg);
 }
 :is(.infer-pane, .npu-pane) .scard-foot .grow {
   flex: 1;

--- a/ui/src/dash/engine-panes.css
+++ b/ui/src/dash/engine-panes.css
@@ -928,20 +928,8 @@
   display: grid;
   gap: 12px;
 }
-/* Capability slots (embed / rerank / tts / stt) sit four to a row so a full
-   utility loadout reads as one complete rank; collapses on narrow panes. */
 :is(.infer-pane, .npu-pane) .scards.compact {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-@media (max-width: 1100px) {
-  :is(.infer-pane, .npu-pane) .scards.compact {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (max-width: 560px) {
-  :is(.infer-pane, .npu-pane) .scards.compact {
-    grid-template-columns: minmax(0, 1fr);
-  }
+  grid-template-columns: repeat(auto-fill, minmax(232px, 1fr));
 }
 :is(.infer-pane, .npu-pane) .scards.full {
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
@@ -1409,10 +1397,22 @@
    A tighter grid below the headline chat/agent cards: header = dot + name +
    port, body = model text + a minimal Start/Stop/Restart cluster. No meta row,
    no model picker. Scoped to .infer-pane (the NPU pane has its own markup). */
+/* Capability slots (embed / rerank / tts / stt) sit four to a row so a full
+   utility loadout reads as one complete rank; collapses on narrow panes. */
 .infer-pane .util-mini {
   display: grid;
   gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(218px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+@media (max-width: 1100px) {
+  .infer-pane .util-mini {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 560px) {
+  .infer-pane .util-mini {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 .infer-pane .mcard {
   position: relative;
@@ -1474,11 +1474,14 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Body doubles as the card's bottom action bar — same sunken strip as the
+   stack/profile/slot cards. */
 .infer-pane .mcard-b {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
+  background: var(--bg);
 }
 .infer-pane .mcard-b .smodel {
   flex: 1;

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -407,7 +407,7 @@ export function SlotScard({
   // gets the amber .acc emphasis.
   const tpsLive = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
   const ttftLive = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
-  const metricKey = s.name + ' ' + (s.model || '')
+  const metricKey = s.name + '::' + (s.model || '')
   if (tpsLive != null || ttftLive != null) {
     const prev = lastServingMetrics.get(metricKey) || {}
     lastServingMetrics.set(metricKey, {

--- a/ui/src/dash/inference-pane.jsx
+++ b/ui/src/dash/inference-pane.jsx
@@ -21,6 +21,8 @@
 //   - useMemoryMapModel()  → per-slot resident memory (real mem_mb) + GTT pool
 //   - useSlot{Restart,Unload,Load,Swap} → real lifecycle mutations
 // Absent metrics render an em-dash; the pane never fabricates a number.
+// Serving metrics (tok/s, ttft) are sticky per slot+model: a stopped slot
+// keeps its last live reading (plain, not amber) rather than clearing.
 //
 // Per the design voice: lowercase mono labels, no emoji in the chrome,
 // em-dash for any metric the backend hasn't reported.
@@ -45,6 +47,12 @@ import { useCardReorder } from './slots/card-order.js'
 import { devKind } from '@/lib/deviceMeta'
 
 const { useState: useStateI } = React
+
+// Last live serving metrics per slot+model, so a paused/stopped slot keeps
+// showing its most recent real reading instead of collapsing to an em-dash.
+// Module-level on purpose: survives card unmount/remount within the session;
+// a page reload starts clean.
+const lastServingMetrics = new Map()
 
 // ── icons (16×16, thin-line family — ported from the design's infer-core) ──
 const II = ({ d, size = 16, sw = 1.5, children, fill = 'none' }) => (
@@ -393,8 +401,23 @@ export function SlotScard({
   // that never union with /api/status) never trips this.
   const pending = s._enriched === false && ph !== 'off'
   const memGb = typeof s.mem_mb === 'number' && s.mem_mb > 0 ? round1(s.mem_mb / 1024) : null
-  const tps = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
-  const ttft = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
+  // Serving metrics are sticky: when serving stops the API zeroes them, but
+  // the card keeps the last live reading (keyed per slot+model so a model
+  // swap never inherits the previous model's numbers). Only a live reading
+  // gets the amber .acc emphasis.
+  const tpsLive = typeof s.metrics?.toks === 'number' && s.metrics.toks > 0 ? s.metrics.toks : null
+  const ttftLive = typeof s.metrics?.ttft === 'number' && s.metrics.ttft > 0 ? s.metrics.ttft : null
+  const metricKey = s.name + ' ' + (s.model || '')
+  if (tpsLive != null || ttftLive != null) {
+    const prev = lastServingMetrics.get(metricKey) || {}
+    lastServingMetrics.set(metricKey, {
+      tps: tpsLive ?? prev.tps,
+      ttft: ttftLive ?? prev.ttft,
+    })
+  }
+  const held = lastServingMetrics.get(metricKey) || {}
+  const tps = tpsLive ?? held.tps ?? null
+  const ttft = ttftLive ?? held.ttft ?? null
   return (
     <div
       className={
@@ -445,7 +468,7 @@ export function SlotScard({
           <div className="scard-meta">
             <div className="m">
               <div className="l">tok/s</div>
-              <div className={'v' + (tps ? ' acc' : ' muted')}>{tps || '—'}</div>
+              <div className={'v' + (tpsLive ? ' acc' : tps ? '' : ' muted')}>{tps || '—'}</div>
             </div>
             <div className="m">
               <div className="l">ttft</div>

--- a/ui/src/dash/npu-pane.jsx
+++ b/ui/src/dash/npu-pane.jsx
@@ -525,23 +525,17 @@ export function NpuOccupancyCard({ slots }) {
             XDNA 2 · npu
           </span>
           <span className="grow" />
-          <button className="btn ghost sm ctl-start" title="Start"
-            onClick={() => handlers.onStart(anchorSlot)} disabled={!anchorSlot}>
-            ▶
-          </button>
-          <button className="btn ghost sm ctl-stop" title="Stop"
-            onClick={() => handlers.onStop(anchorSlot)} disabled={!anchorSlot}>
-            ■
-          </button>
-          <button className="btn ghost sm ctl-restart" title="Restart"
-            onClick={() => handlers.onRestart(anchorSlot)} disabled={!anchorSlot}>
-            ↻
-          </button>
-          <button className="btn ghost sm ctl-logs" title="Logs"
-            onClick={() => handlers.onLogs(anchorSlot)} disabled={!anchorSlot}>
-            📋
-          </button>
-          <button className="btn ghost sm" title="Configure FLM slot" onClick={() => anchorSlot && (window.location.hash = '#slots/' + anchorSlot.name)} disabled={!anchorSlot} style={{fontSize: 13}}>✎ Configure</button>
+          {/* Same .sctrl icon controls the inference slot cards use — the
+              old text/emoji ghost buttons (▶ ■ ↻ 📋 ✎ Configure) are gone. */}
+          <SlotControls
+            phase={anchorSlot ? slotCtrlPhase(anchorSlot) : 'off'}
+            busy={!anchorSlot}
+            onStart={() => anchorSlot && handlers.onStart(anchorSlot)}
+            onStop={() => anchorSlot && handlers.onStop(anchorSlot)}
+            onRestart={() => anchorSlot && handlers.onRestart(anchorSlot)}
+            onLogs={() => anchorSlot && handlers.onLogs(anchorSlot)}
+            onEdit={() => anchorSlot && (window.location.hash = '#slots/' + anchorSlot.name)}
+          />
         </div>
         <div className="wcard-b">
           <div className="combo">

--- a/ui/src/dash/npu.css
+++ b/ui/src/dash/npu.css
@@ -101,33 +101,6 @@
   padding: 16px;
 }
 
-/* header lifecycle controls — each action carries its own hue:
-   start purple (NPU accent) · stop red · restart yellow · logs grey */
-.npu-card .wcard-h .btn.ctl-start {
-  color: var(--npu);
-  border-color: var(--npu-line);
-}
-.npu-card .wcard-h .btn.ctl-start:hover {
-  background: var(--npu-soft);
-}
-.npu-card .wcard-h .btn.ctl-stop {
-  color: var(--err);
-  border-color: var(--err-line);
-}
-.npu-card .wcard-h .btn.ctl-stop:hover {
-  background: var(--err-soft);
-}
-.npu-card .wcard-h .btn.ctl-restart {
-  color: var(--warn);
-  border-color: var(--warn-line);
-}
-.npu-card .wcard-h .btn.ctl-restart:hover {
-  background: var(--warn-soft);
-}
-.npu-card .wcard-h .btn.ctl-logs {
-  color: var(--fg-3);
-}
-
 /* device pill — [ XDNA 2 · npu ] */
 .npu-card .npu-pill {
   display: inline-flex;

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -7,7 +7,7 @@
 /* has a single source of truth. --warming-glow is a glow rgba, kept local.      */
 :root {
   --warming: var(--warn);
-  --warming-glow: rgba(242, 121, 43, 0.35);
+  --warming-glow: rgba(232, 185, 78, 0.35);
   --ok-glow:  rgba(111, 207, 151, 0.35);
 }
 
@@ -100,7 +100,7 @@
 
 .sdot.warming {
   background: var(--warming);
-  box-shadow: 0 0 8px var(--warming-glow, rgba(242, 121, 43, 0.35));
+  box-shadow: 0 0 8px var(--warming-glow, rgba(232, 185, 78, 0.35));
   animation: pulse 1.4s ease-in-out infinite;
 }
 

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -157,10 +157,10 @@
 .sh {
   height: 28px;
   font-family: var(--jbm);
-  font-size: 9px;
+  font-size: 10px;
   text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--fg-4);
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
   border-bottom: 1px solid var(--line);
 }
 

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -351,36 +351,28 @@ a { color: inherit; text-decoration: none; }
 
 /* Notification bell — icon-only launcher + anchored dropdown panel. */
 .tb-bell-wrap { position: relative; display: inline-flex; }
+/* Topbar bell — the shared .iconbtn idiom (class kept for testids/selectors).
+   Amber is reserved for the live signals: unread state and the open popover. */
 .tb-bell {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 30px;
-  height: 28px;
-  border: 1px solid var(--line);
-  border-radius: var(--rad);
-  background: var(--bg-2);
-  color: var(--fg-2);
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: var(--rad-sm);
+  background: transparent;
+  color: var(--fg-3);
   cursor: pointer;
-  transition: color .16s ease, border-color .16s ease, background .16s ease, box-shadow .16s ease;
+  transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
 }
-.tb-bell svg {
-  color: #fff;
-  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55));
-  transition: color .16s ease, filter .16s ease;
-}
-.tb-bell:hover { border-color: var(--accent-line); background: var(--accent-soft); }
-.tb-bell:hover svg,
-.tb-bell.on svg,
-.tb-bell.has svg {
-  color: var(--accent);
-  filter: drop-shadow(0 0 5px var(--accent)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
-}
+.tb-bell:hover { color: var(--fg); background: var(--bg-2); border-color: var(--line); }
+.tb-bell.has svg { color: var(--accent); }
 .tb-bell.on {
+  color: var(--accent);
   border-color: var(--accent-line);
   background: var(--accent-soft);
-  box-shadow: 0 0 0 1px var(--accent-line), 0 0 14px -4px var(--accent);
 }
 .tb-bell-badge {
   position: absolute;
@@ -402,30 +394,22 @@ a { color: inherit; text-decoration: none; }
   box-shadow: 0 0 0 2px var(--bg-1);
 }
 /* Documentation launcher — same icon-button chrome as the notification bell. */
+/* Topbar docs link — shared .iconbtn idiom. */
 .tb-docs {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 30px;
-  height: 28px;
-  border: 1px solid var(--line);
-  border-radius: var(--rad);
-  background: var(--bg-2);
-  color: var(--fg-2);
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: var(--rad-sm);
+  background: transparent;
+  color: var(--fg-3);
   cursor: pointer;
   text-decoration: none;
-  transition: color .16s ease, border-color .16s ease, background .16s ease, box-shadow .16s ease;
+  transition: color var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease);
 }
-.tb-docs svg {
-  color: #fff;
-  filter: drop-shadow(0 1px 1.5px rgba(0, 0, 0, 0.55));
-  transition: color .16s ease, filter .16s ease;
-}
-.tb-docs:hover { border-color: var(--accent-line); background: var(--accent-soft); }
-.tb-docs:hover svg {
-  color: var(--accent);
-  filter: drop-shadow(0 0 5px var(--accent)) drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
-}
+.tb-docs:hover { color: var(--fg); background: var(--bg-2); border-color: var(--line); }
 .notif-pop {
   position: absolute;
   top: calc(100% + 8px);
@@ -2294,15 +2278,22 @@ select.npu-sel {
 }
 .mdl-sort-grp { flex-shrink: 0; flex-wrap: nowrap; }
 .mdl-clear:hover { color: var(--err); border-color: var(--err-line); }
+/* Filter chips — the shared .fpill idiom (kept under the .mdl-chip name
+   because e2e selectors target it). */
 .mdl-chip {
-  padding: 3px 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 11px;
   border: 1px solid var(--line);
-  border-radius: 3px;
-  background: transparent;
+  border-radius: var(--rad-pill);
+  background: var(--bg-1);
   font-family: var(--jbm);
-  font-size: 11px;
+  font-size: 11.5px;
   color: var(--fg-3);
   cursor: pointer;
+  transition: all var(--dur-fast) var(--ease);
 }
 .mdl-chip:hover { color: var(--fg); border-color: var(--line-strong); }
 .mdl-chip.on { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
@@ -2704,16 +2695,16 @@ select.npu-sel {
   display: none;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 30px;
+  height: 30px;
   padding: 0;
   background: transparent;
-  border: 1px solid var(--line);
-  border-radius: var(--rad);
-  color: var(--fg-2);
+  border: 1px solid transparent;
+  border-radius: var(--rad-sm);
+  color: var(--fg-3);
   cursor: pointer;
 }
-.tb-menu:hover { color: var(--fg); border-color: var(--line-strong); }
+.tb-menu:hover { color: var(--fg); background: var(--bg-2); border-color: var(--line); }
 
 .nav-drawer-backdrop {
   position: fixed;

--- a/ui/src/dashboard.css
+++ b/ui/src/dashboard.css
@@ -38,9 +38,9 @@
   --ok:           #6fcf97;
   --ok-soft:      rgba(111, 207, 151, 0.10);
   --ok-line:      rgba(111, 207, 151, 0.30);
-  --warn:         #f2792b;
-  --warn-soft:    rgba(242, 121, 43, 0.10);
-  --warn-line:    rgba(242, 121, 43, 0.30);
+  --warn:         #e8b94e;
+  --warn-soft:    rgba(232, 185, 78, 0.10);
+  --warn-line:    rgba(232, 185, 78, 0.30);
   --err:          #ef6b6b;
   --err-soft:     rgba(239, 107, 107, 0.10);
   --err-line:     rgba(239, 107, 107, 0.30);
@@ -48,9 +48,10 @@
   --info-soft:    rgba(127, 184, 255, 0.10);
   --info-line:    rgba(127, 184, 255, 0.30);
 
-  /* Device colours */
-  --dev-rocm:     #7fb8ff;
-  --dev-vulkan:   #f9d884;
+  /* Device colours — a lane reads the same hue in a chip, a table cell and
+     a chart legend. Values are the unified-chrome set (design system). */
+  --dev-rocm:     #d76b6b;
+  --dev-vulkan:   #7fb8ff;
   --dev-cpu:      #9c9c95;
   --dev-npu:      #c896ff;
   --dev-img:      #3c6597;  /* ComfyUI image-gen tag (decoupled from --comfy accent) */
@@ -151,8 +152,8 @@ a { color: inherit; text-decoration: none; }
 ::-webkit-scrollbar-thumb:hover { background: var(--line-strong); }
 
 /* ─── focus ─────────────────────────────────────────────────────── */
-:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
-::selection { background: var(--accent); color: #0a0a0a; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; border-radius: 2px; }
+::selection { background: var(--accent-glow); color: var(--fg); }
 
 /* ─── App shell ─────────────────────────────────────────────────── */
 .app {
@@ -182,10 +183,27 @@ a { color: inherit; text-decoration: none; }
   align-items: center;
   gap: 16px;
   padding: 0 20px 0 18px;
-  border-bottom: 1px solid var(--line);
   background: var(--bg);
   position: relative;
   z-index: 10;
+}
+/* The chrome "filament": a 1px bottom hairline that brightens to sodium
+   amber at centre with a faint under-glow — shared with hal0.dev's header. */
+.topbar::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    var(--line) 18%,
+    color-mix(in srgb, var(--accent) 70%, var(--line)) 50%,
+    var(--line) 82%,
+    transparent 100%);
+  box-shadow: 0 1px 14px rgba(255, 176, 0, 0.09);
+  pointer-events: none;
 }
 .tb-brand {
   display: flex;
@@ -617,7 +635,7 @@ a { color: inherit; text-decoration: none; }
 .footer {
   grid-area: footer;
   border-top: 1px solid var(--line);
-  background: var(--bg);
+  background: var(--bg-sunken);
   display: grid;
   grid-template-rows: auto auto;
   font-family: var(--jbm);
@@ -1042,6 +1060,7 @@ a { color: inherit; text-decoration: none; }
   height: 30px;
 }
 .btn:hover { filter: brightness(1.06); }
+.btn:active { transform: translateY(0.5px); }
 .btn.ghost { background: transparent; color: var(--fg); border-color: var(--line); }
 .btn.ghost:hover { border-color: var(--fg-3); background: var(--bg-2); }
 .btn.danger { background: transparent; color: var(--err); border-color: var(--err-line); }
@@ -1070,8 +1089,8 @@ a { color: inherit; text-decoration: none; }
 .chip.warn { background: var(--warn-soft); color: var(--warn); border-color: var(--warn-line); }
 .chip.err { background: var(--err-soft); color: var(--err); border-color: var(--err-line); }
 .chip.info { background: var(--info-soft); color: var(--info); border-color: var(--info-line); }
-.chip.dev-rocm { color: var(--dev-rocm); border-color: rgba(127, 184, 255, 0.30); background: rgba(127, 184, 255, 0.08); }
-.chip.dev-vulkan { color: var(--dev-vulkan); border-color: rgba(249, 216, 132, 0.30); background: rgba(249, 216, 132, 0.08); }
+.chip.dev-rocm { color: var(--dev-rocm); border-color: rgba(215, 107, 107, 0.30); background: rgba(215, 107, 107, 0.08); }
+.chip.dev-vulkan { color: var(--dev-vulkan); border-color: rgba(127, 184, 255, 0.30); background: rgba(127, 184, 255, 0.08); }
 .chip.dev-cpu { color: var(--dev-cpu); border-color: var(--line-strong); background: var(--bg-2); }
 .chip.dev-npu { color: var(--dev-npu); border-color: rgba(200, 150, 255, 0.30); background: rgba(200, 150, 255, 0.08); }
 .chip.dev-img { color: var(--dev-img); border-color: rgba(60, 101, 151, 0.30); background: rgba(60, 101, 151, 0.08); }
@@ -1115,6 +1134,122 @@ a { color: inherit; text-decoration: none; }
 @media (prefers-reduced-motion: reduce) {
   .dot.serving, .dot.warming, .dot.loading { animation: none; }
 }
+
+/* ─── Unified-chrome shared primitives ──────────────────────────
+   Same vocabulary as hal0.dev's site chrome (icon buttons, search trigger,
+   filter pills, terminal well, data table). Authored once here; views adopt
+   these instead of growing bespoke equivalents. */
+.iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--rad-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--fg-3);
+  cursor: pointer;
+  position: relative;
+  transition: color var(--dur-fast) var(--ease),
+    background var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease);
+}
+.iconbtn:hover { color: var(--fg); background: var(--bg-2); border-color: var(--line); }
+.iconbtn .pip {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+}
+
+.searchbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 30px;
+  padding: 0 8px 0 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--rad-sm);
+  background: var(--bg-1);
+  color: var(--fg-4);
+  font-family: var(--jbm);
+  font-size: 11.5px;
+  cursor: pointer;
+  min-width: 180px;
+  transition: border-color var(--dur-fast) var(--ease);
+}
+.searchbtn:hover { border-color: var(--line-strong); color: var(--fg-3); }
+.searchbtn .k {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--fg-4);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 1px 4px;
+}
+
+.fbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.fpill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 11px;
+  border-radius: var(--rad-pill);
+  border: 1px solid var(--line);
+  background: var(--bg-1);
+  color: var(--fg-3);
+  font-family: var(--jbm);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: all var(--dur-fast) var(--ease);
+}
+.fpill:hover { border-color: var(--line-strong); color: var(--fg); }
+.fpill.on { background: var(--accent-soft); border-color: var(--accent-line); color: var(--accent); }
+.fpill .n { color: var(--fg-4); font-size: 10px; }
+.fgroup { display: flex; align-items: center; gap: 8px; }
+
+/* terminal well — amber only on the token you can act on */
+.well {
+  background: var(--bg-sunken);
+  border: 1px solid var(--line);
+  border-radius: var(--rad);
+  font-family: var(--jbm);
+  font-size: 12.5px;
+  line-height: 1.7;
+}
+
+/* data table — mono, uppercase 10px headers, numeric right-aligned */
+.dtable { width: 100%; border-collapse: collapse; font-family: var(--jbm); font-size: 12.5px; }
+.dtable th {
+  text-align: left;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+  font-weight: 500;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  background: var(--bg);
+}
+.dtable th.n, .dtable td.n {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "zero" 1, "tnum" 1;
+}
+.dtable th.sorted { color: var(--accent); }
+.dtable td { padding: 10px 12px; border-bottom: 1px solid var(--line-soft); color: var(--fg-2); white-space: nowrap; }
+.dtable tbody tr:hover td { background: var(--bg-2); }
+.dtable td.lead { color: var(--fg); }
+.dtable .hero { color: var(--accent); }
+
+.hairline { height: 1px; background: var(--line); border: 0; margin: 0; }
 
 /* Section title — used inside views */
 .sec {

--- a/ui/tests/e2e/specs/warm-color-tones.spec.ts
+++ b/ui/tests/e2e/specs/warm-color-tones.spec.ts
@@ -30,7 +30,7 @@ import { test, expect } from '../fixtures/apiMock'
 
 // Canonical --warn (dashboard.css). Retint contract: change --warn there,
 // then update this one constant. rgb() is how getComputedStyle reports it.
-const WARM_RGB = 'rgb(242, 121, 43)'
+const WARM_RGB = 'rgb(232, 185, 78)'
 
 type Probe = { site: string; ancestor: string; el: string; prop: 'backgroundColor' | 'color' }
 


### PR DESCRIPTION
## What

Aligns the dashboard's common components with the unified chrome sheet (`01 Unified Chrome.html`) from the hal0.dev design handoff. Two commits:

1. **Chrome + tokens** — corrects drifted tokens (`--warn` → `#e8b94e`; load-bearing lane hues `--dev-rocm #d76b6b` / `--dev-vulkan #7fb8ff`, which newer surfaces already assumed via fallbacks), retints the dev chips, adds the header filament (amber-centre hairline + under-glow), moves selection to the amber glow wash, 3px focus offset, button press nudge, sunken footer, and lands the shared primitives (`.iconbtn`, `.searchbtn`, `.fbar`/`.fpill`, `.well`, `.dtable`, `.hairline`) in dashboard.css.
2. **Convergence pass** — restyles existing bespoke components onto those primitives without renaming classes: topbar bell/docs/menu → iconbtn idiom, models filter chips → fpill idiom, slot-list header → dtable header spec.

## Why

The design pack's single non-negotiable is one visual system across every surface. The dashboard already shared the DNA but had drifted: orange warn, rocm/vulkan hues swapped against the design system (and against overhaul.css's own fallbacks), no filament, and per-view one-off components.

## Verification

- `vite build` clean; 121/121 unit tests pass
- Headless-browser check of computed tokens (`--dev-vulkan #7fb8ff`, `--dev-rocm #d76b6b`, `--warn #e8b94e`) and screenshots of Overview / Slots / Benchmarks
- Merge against `h0/bench-dash-roster-style` verified clean (bench work in flight adopts the same tokens)

## Out of scope

Page-level redesigns from the pack (benchmarks, profiles surfaces) — the benchmarks page is in flight on `h0/bench-phase4-telemetry` / `h0/bench-dash-roster-style` and picks these tokens up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)