### PR TITLE
fix(bench): resolve adapter tools through the venv bin, not just PATH

### DIFF
--- a/src/hal0/bench/adapters/__init__.py
+++ b/src/hal0/bench/adapters/__init__.py
@@ -12,6 +12,11 @@ integration's job, not the adapter's (docs/superpowers/plans/
 2026-08-09-bench-phase3-oss-adapters.md).
 """
 
+import os
+import shutil
+import sys
+from pathlib import Path
+
 # Pinned tool versions (re-verified 2026-08-09; plan: docs/superpowers/plans/
 # 2026-08-09-bench-phase3-oss-adapters.md). guidellm is a PyPI extra of the
 # hal0ai distribution (`pip install 'hal0ai[bench-guidellm]'`); the other two
@@ -27,3 +32,20 @@ LLAMA_BENCHY_PIN = (
 TOOL_EVAL_BENCH_PIN = (
     "tool-eval-bench @ git+https://github.com/SeraphimSerapis/tool-eval-bench@v2.5.0"
 )
+
+
+def resolve_tool(name: str) -> str | None:
+    """Absolute path of an adapter tool binary, or None if absent.
+
+    ``$PATH`` first, then the running interpreter's own bin directory —
+    console scripts land there when a tool is pip-installed into hal0's
+    venv, and the service PATH never includes the venv bin (found on-box
+    2026-08-09: every venv-installed tool was invisible to the plan-time
+    gate and to the default subprocess runners)."""
+    found = shutil.which(name)
+    if found:
+        return found
+    cand = Path(sys.executable).parent / name
+    if cand.is_file() and os.access(cand, os.X_OK):
+        return str(cand)
+    return None

--- a/src/hal0/bench/adapters/guidellm.py
+++ b/src/hal0/bench/adapters/guidellm.py
@@ -188,6 +188,13 @@ def _default_runner(argv: list[str], timeout_s: float | None) -> tuple[int, str,
     timeout kills guidellm's whole worker pool, not just the parent (mirrors
     ``runner._run_subprocess``). Tests inject a fake that needs no real
     ``guidellm`` on PATH at all."""
+    # Resolve the console-script through PATH-or-venv-bin: the service PATH
+    # never includes the venv bin where a pip-installed tool's script lands.
+    from . import resolve_tool
+
+    head = resolve_tool(argv[0])
+    if head is not None:
+        argv = [head, *argv[1:]]
     proc = subprocess.Popen(
         argv,
         stdout=subprocess.PIPE,

--- a/src/hal0/bench/adapters/llama_benchy.py
+++ b/src/hal0/bench/adapters/llama_benchy.py
@@ -185,6 +185,13 @@ def _default_runner(argv: list[str], timeout_s: float | None) -> tuple[int, str,
     so :func:`run_llama_benchy` can classify it as :attr:`Outcome.HANG`
     without a try/except at the call site.
     """
+    # Resolve the console-script through PATH-or-venv-bin: the service PATH
+    # never includes the venv bin where a pip-installed tool's script lands.
+    from . import resolve_tool
+
+    head = resolve_tool(argv[0])
+    if head is not None:
+        argv = [head, *argv[1:]]
     proc = subprocess.Popen(
         argv,
         stdout=subprocess.PIPE,

--- a/src/hal0/bench/evalrun.py
+++ b/src/hal0/bench/evalrun.py
@@ -29,7 +29,6 @@ scores across the hardening boundary" contract).
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -59,10 +58,12 @@ def tool_eval_missing() -> str | None:
     it can). Checked up-front by the CLI and worker so a box without it gets
     one clean message instead of a per-scenario traceback (the same #1526
     rule the old ``hermes_missing`` enforced, now for the pinned tool)."""
-    if shutil.which(TOOL_EVAL_BENCH_BIN) is None:
+    import importlib.util
+
+    if importlib.util.find_spec("tool_eval_bench") is None:
         return (
-            f"{TOOL_EVAL_BENCH_BIN!r} not found on PATH (pin: {TOOL_EVAL_BENCH_PIN}) — "
-            "agentic eval needs tool-eval-bench installed"
+            f"tool_eval_bench is not importable by this interpreter (pin: {TOOL_EVAL_BENCH_PIN}) — "
+            "agentic eval needs tool-eval-bench installed in hal0's venv"
         )
     return None
 

--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -25,14 +25,13 @@ exactly the cells it changed, no re-bench checklist.
 from __future__ import annotations
 
 import shlex
-import shutil
 import sys
 import urllib.request
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from . import harness
+from . import adapters, harness
 from .adapters import GUIDELLM_PIN, LLAMA_BENCHY_PIN
 from .adapters.guidellm import GUIDELLM_BIN
 from .adapters.llama_benchy import LLAMA_BENCHY_BIN
@@ -428,14 +427,17 @@ def plan(
     missing_tools = sorted(
         k
         for k in suite.cells.kinds
-        if k in _ADAPTER_TOOL_FOR_KIND and shutil.which(_ADAPTER_TOOL_FOR_KIND[k][0]) is None
+        if k in _ADAPTER_TOOL_FOR_KIND
+        and adapters.resolve_tool(_ADAPTER_TOOL_FOR_KIND[k][0]) is None
     )
     if missing_tools:
         detail = "; ".join(
             f"{k!r} needs {_ADAPTER_TOOL_FOR_KIND[k][0]!r} (pin: {_ADAPTER_TOOL_FOR_KIND[k][1]})"
             for k in missing_tools
         )
-        raise ValueError(f"suite {suite.id!r}: required tool(s) not on PATH — {detail}")
+        raise ValueError(
+            f"suite {suite.id!r}: required tool(s) not found (PATH or venv bin) — {detail}"
+        )
     current = store.newest_ok_by_cell()  # cell_key -> newest ok record
     max_age = timedelta(days=suite.staleness.max_age_days)
     known_lanes = set(harness.lane_specs())

--- a/tests/bench/adapters/test_resolve_tool.py
+++ b/tests/bench/adapters/test_resolve_tool.py
@@ -1,0 +1,46 @@
+"""resolve_tool: PATH first, then the interpreter's own bin dir (venv
+console scripts are invisible to the service PATH — found on-box 2026-08-09)."""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+from hal0.bench import adapters
+
+
+def test_path_hit_wins(tmp_path, monkeypatch):
+    tool = tmp_path / "sometool"
+    tool.write_text("#!/bin/sh\n")
+    tool.chmod(tool.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    assert adapters.resolve_tool("sometool") == str(tool)
+
+
+def test_venv_bin_fallback(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))  # empty dir: no PATH hit
+    bindir = tmp_path / "venv-bin"
+    bindir.mkdir()
+    tool = bindir / "venvtool"
+    tool.write_text("#!/bin/sh\n")
+    tool.chmod(0o755)
+    monkeypatch.setattr(sys, "executable", str(bindir / "python3"))
+    assert adapters.resolve_tool("venvtool") == str(tool)
+
+
+def test_missing_everywhere_is_none(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "nowhere" / "python3"))
+    assert adapters.resolve_tool("ghost-tool") is None
+
+
+def test_non_executable_venv_candidate_is_skipped(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", str(tmp_path))
+    bindir = tmp_path / "vb"
+    bindir.mkdir()
+    (bindir / "plainfile").write_text("data")
+    monkeypatch.setattr(sys, "executable", str(bindir / "python3"))
+    if os.access(bindir / "plainfile", os.X_OK):  # exotic umask boxes
+        (bindir / "plainfile").chmod(0o644)
+    assert adapters.resolve_tool("plainfile") is None

--- a/tests/bench/test_evalrun.py
+++ b/tests/bench/test_evalrun.py
@@ -70,12 +70,14 @@ class TestEnsureTasks:
         assert evalrun.ensure_tasks() == []
 
 
-def test_tool_eval_missing_checks_path(monkeypatch):
-    monkeypatch.setattr(evalrun.shutil, "which", lambda name: None)
-    msg = evalrun.tool_eval_missing()
-    assert msg and "tool-eval-bench" in msg
+def test_tool_eval_missing_checks_importability(monkeypatch):
+    import importlib.util
 
-    monkeypatch.setattr(evalrun.shutil, "which", lambda name: "/usr/bin/tool-eval-bench")
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    msg = evalrun.tool_eval_missing()
+    assert msg and "tool_eval_bench" in msg
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
     assert evalrun.tool_eval_missing() is None
 
 

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -40,7 +40,7 @@ def _adapter_tools_present(monkeypatch):
     KIND). CI has neither guidellm nor llama-benchy installed, so every test
     in this module that plans one of those kinds needs the gate satisfied —
     autouse so individual tests don't have to remember it."""
-    monkeypatch.setattr(planner.shutil, "which", lambda _name: "/usr/bin/true")
+    monkeypatch.setattr(planner.adapters, "resolve_tool", lambda _name: "/usr/bin/true")
 
 
 @pytest.fixture
@@ -173,7 +173,7 @@ class TestTierBCCmd:
         """Bench Phase 3 design decision 5: a kind whose adapter binary is
         missing fails at PLAN time, naming the pin — never a mid-session
         per-cell failure loop."""
-        monkeypatch.setattr(planner.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(planner.adapters, "resolve_tool", lambda _name: None)
         with pytest.raises(ValueError, match=r"guidellm==0\.7\.3"):
             plan(_suite(["chat"]), _registry(), Store(tmp_path))
 


### PR DESCRIPTION
Found on the first CT105 deploy validation: the phase-3 tools are pip-
installed into hal0's venv, whose bin directory is never on the service
PATH — so the plan-time availability gate rejected every adapter kind and
the default subprocess runners would have failed the same way at exec.

adapters.resolve_tool() checks PATH first, then the running interpreter's
own bin directory; the planner gate and the guidellm/llama-benchy default
runners use it (injected fake runners in tests are unaffected), and
evalrun's gate now checks tool_eval_bench importability to match its
python -m execution path.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
