### PR TITLE
fix(stacks): restart live slot when apply changes config but not model

### DIFF
--- a/src/hal0/api/routes/stacks.py
+++ b/src/hal0/api/routes/stacks.py
@@ -435,11 +435,16 @@ async def apply_stack(slug: str, request: Request, dry_run: bool = False) -> dic
         converged: dict[str, Any] = {}
         converge_ok = not create_errors
         if slot_manager is not None and orchestrator is not None:
-            report = await engine.converge(cfg)
+            # Slots whose file Phase A rewrote — converge restarts the ones
+            # whose model didn't change so a profile/flags edit reaches the
+            # running server instead of waiting for the next manual reload.
+            changed_slots = {row["slot"] for row in _diff_rows(plan) if row["changed"]}
+            report = await engine.converge(cfg, changed_slots)
             converge_ok = converge_ok and not report.errors
             converged = {
                 "loaded": report.loaded,
                 "swapped": report.swapped,
+                "reloaded": report.reloaded,
                 "skipped": report.skipped,
                 "unloaded": report.unloaded,
                 "capabilities_applied": report.capabilities_applied,

--- a/src/hal0/stacks/apply.py
+++ b/src/hal0/stacks/apply.py
@@ -123,6 +123,9 @@ class ConvergeReport:
     unloaded: list[str]
     capabilities_applied: list[str]
     errors: list[tuple[str, str]]
+    #: Slots restarted because their config changed while the model didn't
+    #: (profile/flags-only edits — the running server had stale args).
+    reloaded: list[str] = field(default_factory=list)
 
 
 class StackApplyEngine:
@@ -409,7 +412,9 @@ class StackApplyEngine:
 
     # ── converge (Phase B — runtime lifecycle) ───────────────────────────────
 
-    async def converge(self, stack: StackConfig) -> ConvergeReport:
+    async def converge(
+        self, stack: StackConfig, changed_slots: set[str] | frozenset[str] = frozenset()
+    ) -> ConvergeReport:
         """Drive SlotManager/orchestrator so live runtime matches ``stack``.
 
         Three passes over one ``SlotManager.list()`` snapshot: load/swap the
@@ -418,6 +423,11 @@ class StackApplyEngine:
         (declarative replace). Per-slot failures are recorded in the report,
         never raised — a committed config (PR-2a) is never unwound by a
         lifecycle hiccup.
+
+        ``changed_slots`` names the slots whose config Phase A rewrote. A
+        dispatchable slot already on the stack's model but listed here is
+        restarted so the running server picks up the new config (a profile-only
+        change would otherwise leave it serving with stale args).
         """
         if self._slot_manager is None or self._orchestrator is None:
             raise RuntimeError("converge() requires slot_manager and orchestrator")
@@ -431,7 +441,7 @@ class StackApplyEngine:
             if not entry.model:
                 continue
             touched.add(entry.slot)
-            await self._converge_primary(entry, snapshots.get(entry.slot), report)
+            await self._converge_primary(entry, snapshots.get(entry.slot), report, changed_slots)
 
         # Pass 2 — capability children (enabled rows only).
         await self._converge_capabilities(stack, touched, report)
@@ -442,9 +452,13 @@ class StackApplyEngine:
         return report
 
     async def _converge_primary(
-        self, entry: StackSlotEntry, snap: Any, report: ConvergeReport
+        self,
+        entry: StackSlotEntry,
+        snap: Any,
+        report: ConvergeReport,
+        changed_slots: set[str] | frozenset[str] = frozenset(),
     ) -> None:
-        """Load / swap / skip one primary slot to match ``entry.model``."""
+        """Load / swap / reload / skip one primary slot to match ``entry``."""
         try:
             if snap is not None and snap.state in _TRANSITIONAL:
                 report.skipped.append(entry.slot)
@@ -460,6 +474,12 @@ class StackApplyEngine:
             elif snap.model_id != entry.model:
                 await self._slot_manager.swap(entry.slot, entry.model)
                 report.swapped.append(entry.slot)
+            elif entry.slot in changed_slots:
+                # Same model, new config (profile/flags edit): restart so the
+                # server relaunches with the rewritten slot file instead of
+                # serving on stale args.
+                await self._slot_manager.restart(entry.slot)
+                report.reloaded.append(entry.slot)
             else:
                 report.skipped.append(entry.slot)
         except Exception as exc:  # per-slot failures are reported, not raised

--- a/tests/stacks/conftest.py
+++ b/tests/stacks/conftest.py
@@ -63,6 +63,10 @@ class RecordingSlotManager:
         self.calls.append(("unload", slot_name, None))
         return FakeSnap(slot_name, SlotState.OFFLINE, None)
 
+    async def restart(self, slot_name: str) -> FakeSnap:
+        self.calls.append(("restart", slot_name, None))
+        return FakeSnap(slot_name, SlotState.READY, None)
+
 
 class RecordingOrchestrator:
     """Records capability apply() calls."""

--- a/tests/stacks/test_converge_primary.py
+++ b/tests/stacks/test_converge_primary.py
@@ -54,6 +54,49 @@ class TestPrimaryConverge:
         assert report.skipped == ["agent"]
         assert not [c for c in sm.calls if c[0] in ("load", "swap")]
 
+    async def test_same_model_changed_config_is_reloaded(self) -> None:
+        # Profile-only (or flags-only) change: Phase A rewrote the slot file but
+        # the model is unchanged — the running server must restart to pick up
+        # the new config instead of silently keeping its old flags.
+        sm = RecordingSlotManager([FakeSnap("agent", SlotState.READY, "ace-saber")])
+        report = await _engine(sm).converge(
+            _stack(StackSlotEntry(slot="agent", model="ace-saber")), changed_slots={"agent"}
+        )
+        assert ("restart", "agent", None) in sm.calls
+        assert report.reloaded == ["agent"]
+        assert report.skipped == []
+
+    async def test_same_model_unchanged_config_is_still_skipped(self) -> None:
+        sm = RecordingSlotManager([FakeSnap("agent", SlotState.READY, "ace-saber")])
+        report = await _engine(sm).converge(
+            _stack(StackSlotEntry(slot="agent", model="ace-saber")), changed_slots={"utility"}
+        )
+        assert report.skipped == ["agent"]
+        assert not [c for c in sm.calls if c[0] in ("load", "swap", "restart")]
+
+    async def test_changed_config_different_model_swaps_not_restarts(self) -> None:
+        # A model change subsumes the config reload — swap already restarts the
+        # container; a second restart would double-bounce the slot.
+        sm = RecordingSlotManager([FakeSnap("agent", SlotState.READY, "old-model")])
+        report = await _engine(sm).converge(
+            _stack(StackSlotEntry(slot="agent", model="ace-saber")), changed_slots={"agent"}
+        )
+        assert ("swap", "agent", "ace-saber") in sm.calls
+        assert report.swapped == ["agent"]
+        assert not [c for c in sm.calls if c[0] == "restart"]
+
+    async def test_reload_failure_is_recorded_not_raised(self) -> None:
+        class Boom(RecordingSlotManager):
+            async def restart(self, slot_name):
+                raise RuntimeError("restart failed")
+
+        sm = Boom([FakeSnap("agent", SlotState.READY, "ace-saber")])
+        report = await _engine(sm).converge(
+            _stack(StackSlotEntry(slot="agent", model="ace-saber")), changed_slots={"agent"}
+        )
+        assert report.errors == [("agent", "restart failed")]
+        assert report.reloaded == []
+
     async def test_entry_without_model_is_ignored(self) -> None:
         sm = RecordingSlotManager([])
         report = await _engine(sm).converge(


### PR DESCRIPTION
## What

Stack apply's Phase B (converge) keyed solely on model identity: a profile- or flags-only change committed the new slot config to disk (Phase A), but the running server was reported `skipped` and kept serving with stale args until a manual reload. Drift still reported `clean`, so the divergence was silent.

`converge()` now accepts the set of slots whose file Phase A rewrote. A dispatchable slot already on the stack's model but listed there is restarted via `SlotManager.restart()` (unload + load, clears the crash-loop breaker) and reported in a new `reloaded` bucket on the converge report / API response. A model change still goes through `swap` alone — its container restart already picks up the new config, so the slot is not double-bounced.

## Why

Found while live-driving the stacks feature end-to-end on CT150 (rc3 + main-tip wheel): snapshot → clone with agent profile flipped → apply committed cleanly and converged with no errors, but `hal0-slot@agent` kept running the old profile's flags.

## Verified

- 4 new unit tests in `tests/stacks/test_converge_primary.py` (reload on changed config, skip when unchanged, swap-not-restart on model change, restart failure recorded not raised)
- Full stacks + routes + MCP admin suites green (136 passed)
- ruff format/check + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)