### PR TITLE
fix(bench): mount the root that contains the model; run guidellm from a neutral cwd

### DIFF
--- a/installer/wrappers/hal0-benchctl
+++ b/installer/wrappers/hal0-benchctl
@@ -61,6 +61,11 @@ _resolve_model_root() {
   printf '%s' /mnt/ai-models
 }
 MODEL_ROOT="$(_resolve_model_root)"
+# The historic store root. A relocated box (store moved to /var/lib/hal0/
+# models) still carries pre-relocation models under this path, and the
+# registry points at wherever a model actually lives — so BOTH roots are
+# legitimate mount/-m prefixes. Closed two-element set, not caller-shaped.
+LEGACY_MODEL_ROOT="/mnt/ai-models"
 
 die() { echo "hal0-benchctl: $1" >&2; exit 2; }
 
@@ -102,12 +107,12 @@ validate_device_flag() {
   [[ -c "$node" ]]
 }
 
-validate_model() {   # arg: path relative to MODEL_ROOT
-  local rel="$1"
+validate_model() {   # args: allowed root, path relative to it
+  local root="$1" rel="$2"
   [[ -n "$rel" ]]                              || die "missing model path"
   [[ "$rel" != *..* ]]                         || die "path traversal in model path"
   [[ "$rel" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*\.gguf$ ]] || die "bad model path: $rel"
-  [[ -f "$MODEL_ROOT/$rel" ]]                  || die "model not found under $MODEL_ROOT: $rel"
+  [[ -f "$root/$rel" ]]                        || die "model not found under $root: $rel"
 }
 
 # Hardware tier vocabulary — the shell mirror of hal0.bench.devices' TIER_*.
@@ -158,6 +163,7 @@ case "$cmd" in
 
     seen_rm=0
     volume_ok=0
+    mounted_root=""
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --rm) seen_rm=1; shift ;;
@@ -171,9 +177,15 @@ case "$cmd" in
           esac
           shift 2 ;;
         --volume=*)
-          # Exactly the read-only model-store self-mount, nothing else.
-          [[ "$1" == "--volume=${MODEL_ROOT}:${MODEL_ROOT}:ro,z" ]] \
-            || die "volume not allowed: $1"
+          # Exactly a read-only model-store self-mount (resolved or historic
+          # root), nothing else.
+          if [[ "$1" == "--volume=${MODEL_ROOT}:${MODEL_ROOT}:ro,z" ]]; then
+            mounted_root="$MODEL_ROOT"
+          elif [[ "$1" == "--volume=${LEGACY_MODEL_ROOT}:${LEGACY_MODEL_ROOT}:ro,z" ]]; then
+            mounted_root="$LEGACY_MODEL_ROOT"
+          else
+            die "volume not allowed: $1"
+          fi
           volume_ok=1; shift ;;
         -e)
           # EXACT-value allowlist, never a pattern. A pattern wide enough for
@@ -201,8 +213,12 @@ case "$cmd" in
     shift
     [[ "${1:-}" == "-m" ]] || die "expected -m <model> after the image"
     model_abs="${2:-}"
-    [[ "$model_abs" == "$MODEL_ROOT"/* ]] || die "model not under $MODEL_ROOT: $model_abs"
-    validate_model "${model_abs#"$MODEL_ROOT"/}"
+    # -m must sit under the SAME root that was mounted — a model outside the
+    # container's volume would be unreachable anyway, and mixing roots is a
+    # composition bug worth failing loudly on.
+    [[ "$model_abs" == "$mounted_root"/* ]] \
+      || die "model not under the mounted root $mounted_root: $model_abs"
+    validate_model "$mounted_root" "${model_abs#"$mounted_root"/}"
     shift 2
 
     # Only whitelisted llama-bench tuning flags + safe values. -o must be json

--- a/src/hal0/bench/adapters/guidellm.py
+++ b/src/hal0/bench/adapters/guidellm.py
@@ -195,11 +195,19 @@ def _default_runner(argv: list[str], timeout_s: float | None) -> tuple[int, str,
     head = resolve_tool(argv[0])
     if head is not None:
         argv = [head, *argv[1:]]
+    # guidellm's settings layer probes ./.env in the CWD at startup; run
+    # from a neutral readable directory so a service CWD the hal0 user
+    # cannot read (found on-box 2026-08-09: PermissionError on '.env')
+    # never crashes the tool before it starts.
+    import tempfile
+
+    run_cwd = tempfile.gettempdir()
     proc = subprocess.Popen(
         argv,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        cwd=run_cwd,
         start_new_session=True,
     )
     try:

--- a/src/hal0/bench/runner.py
+++ b/src/hal0/bench/runner.py
@@ -83,16 +83,24 @@ SERVER_AB = "/usr/lib/hal0/bench/server_ab.py"
 LEGACY_MODEL_ROOT = "/mnt/ai-models"
 
 
-def _model_root() -> str:
-    """The LIVE model-store root (``hal0.config.paths.model_store_root``) —
-    the same resolver ``hal0-benchctl``'s ``exec`` verb uses independently to
-    compute its own ``$MODEL_ROOT``. The composed ``--volume=``/``-m`` argv
-    must use THIS root, not whichever historic root a registry path happened to
-    be stripped against (see ``_rel_gguf``): the shim re-resolves the root
-    itself and will reject an argv built against a different one (#1516)."""
+def _containing_root(gguf: str) -> tuple[str, str]:
+    """(root, rel) for a registry gguf path: the allowed root the path
+    actually sits under (longest-prefix match over ``_model_roots``) plus the
+    path relative to it. The composed ``--volume=``/``-m`` argv must use the
+    CONTAINING root, never a rebuilt "resolved-root + stripped-rel" — on a
+    box whose store was relocated (CT105, 2026-08), pre-relocation models
+    still live under the historic ``/mnt/ai-models``, and rebuilding their
+    paths against the new store root pointed every Tier-A cell at a file
+    that does not exist (found on the first deploy validation, 2026-08-09).
+    The shim accepts either root, so no path escapes validation. A relative
+    path falls back to the live resolved root."""
+    for root in _model_roots():
+        prefix = root + "/"
+        if gguf.startswith(prefix):
+            return root, gguf[len(prefix) :]
     from hal0.config.paths import model_store_root
 
-    return model_store_root().rstrip("/")
+    return model_store_root().rstrip("/"), gguf.lstrip("/")
 
 
 def _model_roots() -> list[str]:
@@ -262,18 +270,6 @@ def _gpu_slot_serving(api: str) -> bool:
 # --------------------------------------------------------------------------- #
 
 
-def _rel_gguf(gguf: str) -> str:
-    """The model path the seam expects: relative to the model-store root,
-    ending .gguf (hal0-benchctl validate_model). Absolute registry paths are
-    stripped against the RESOLVED store root(s), not a hardcoded literal
-    (#1516)."""
-    for root in _model_roots():
-        prefix = root + "/"
-        if gguf.startswith(prefix):
-            return gguf[len(prefix) :]
-    return gguf.lstrip("/")
-
-
 def _run_subprocess(cmd: list[str], timeout_s: float, log_path: Path) -> tuple[int, str]:
     """Run one engine subprocess under the watchdog, teeing output to ``log_path``.
     Returns (returncode, tail). A timeout returns rc=-9 → ``hang``.
@@ -385,8 +381,8 @@ def _tier_a_cmd(cell, pp_prompt: int, tg_gen: int, devices: BenchDeviceSpec) -> 
     plan-bypassing entry point) can still land here, so the KeyError is a
     deliberate, documented failure mode rather than a silent default."""
     spec = harness.lane_specs()[cell.lane]
-    model_root = _model_root()
-    model_path = f"{model_root}/{_rel_gguf(cell.identity.model.gguf)}"
+    model_root, model_rel = _containing_root(cell.identity.model.gguf)
+    model_path = f"{model_root}/{model_rel}"
     flags = _tier_a_flags(cell, pp_prompt, tg_gen)
     podman_argv = harness.compose_podman_argv(spec, devices, model_path, model_root, flags)
     per_attempt = _tier_a_per_attempt_s(cell)
@@ -696,8 +692,7 @@ def _tier_a_record(
         tail = ""
     else:
         pp, tg = sizes.get(key, (_DEFAULT_PP_PROMPT, _DEFAULT_TG_GEN))
-        model_root = _model_root()
-        model_rel = _rel_gguf(cell.identity.model.gguf)
+        model_root, model_rel = _containing_root(cell.identity.model.gguf)
         flags = _tier_a_flags(cell, pp, tg)
         log = artifacts / "sweep-benchctl.log"
         run_kwargs = {

--- a/tests/bench/test_benchctl_shim.py
+++ b/tests/bench/test_benchctl_shim.py
@@ -504,3 +504,52 @@ class TestTelemetrySampler:
 def test_the_shim_is_syntactically_valid() -> None:
     proc = subprocess.run(["bash", "-n", str(BENCHCTL)], capture_output=True, text=True, timeout=60)
     assert proc.returncode == 0, proc.stderr
+
+
+class TestLegacyRootMount:
+    """A relocated store leaves pre-relocation models under the historic
+    /mnt/ai-models; both self-mounts are legitimate (closed two-root set)."""
+
+    def test_legacy_root_mount_and_model_accepted(self, tmp_path) -> None:
+        model_root = _model_root(tmp_path)
+        legacy_root = tmp_path / "legacy-models"
+        legacy_model = legacy_root / "tiny/tiny.gguf"
+        legacy_model.parent.mkdir(parents=True)
+        legacy_model.write_bytes(b"GGUF")
+        argv_log = tmp_path / "podman-argv.log"
+        bindir = _stub_bin(tmp_path, model_root, argv_log=argv_log)
+        env = _env(tmp_path, bindir, model_root)
+        env["HAL0_BENCHCTL_LEGACY_ROOT_TEST"] = "1"  # doc marker only
+
+        argv = _cpu_argv(legacy_root, legacy_model)
+
+        # rewrite the shim's LEGACY_MODEL_ROOT for the test via a patched copy
+        patched = tmp_path / "benchctl-patched"
+        patched.write_text(
+            BENCHCTL.read_text().replace(
+                'LEGACY_MODEL_ROOT="/mnt/ai-models"',
+                f'LEGACY_MODEL_ROOT="{legacy_root}"',
+            )
+        )
+        proc = subprocess.run(
+            ["bash", str(patched), "exec", "--", *argv],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+    def test_model_outside_the_mounted_root_is_rejected(self, tmp_path) -> None:
+        model_root = _model_root(tmp_path)
+        model_abs = _write_model(model_root)
+        bindir = _stub_bin(tmp_path, model_root)
+        env = _env(tmp_path, bindir, model_root)
+        argv = _cpu_argv(model_root, model_abs)
+        # mount the resolved root but point -m at a legacy-root path
+        argv[argv.index("-m") + 1] = "/mnt/ai-models/tiny/tiny.gguf"
+
+        proc = _run(["exec", "--", *argv], env)
+
+        assert proc.returncode != 0
+        assert "not under the mounted root" in proc.stderr

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -328,20 +328,32 @@ class TestLlamaBenchyDispatch:
 
 
 class TestPaths:
-    def test_rel_gguf_strips_resolved_store_root(self, monkeypatch):
+    def test_containing_root_for_a_store_path(self, monkeypatch):
         from hal0.config import paths as hal0_paths
 
         monkeypatch.setattr(hal0_paths, "model_store_root", lambda: "/var/lib/hal0/models")
-        assert runner._rel_gguf("/var/lib/hal0/models/d/M.gguf") == "d/M.gguf"
+        assert runner._containing_root("/var/lib/hal0/models/d/M.gguf") == (
+            "/var/lib/hal0/models",
+            "d/M.gguf",
+        )
 
-    def test_rel_gguf_still_strips_the_legacy_root(self):
-        assert runner._rel_gguf("/mnt/ai-models/d/M.gguf") == "d/M.gguf"
+    def test_containing_root_keeps_a_legacy_rooted_model_under_its_own_root(self, monkeypatch):
+        """A relocated store must not rebuild a pre-relocation model's path
+        against the new root — the file lives under /mnt/ai-models and only
+        exists there (CT105 deploy validation, 2026-08-09)."""
+        from hal0.config import paths as hal0_paths
 
-    def test_model_root_is_the_live_resolved_store(self, monkeypatch):
+        monkeypatch.setattr(hal0_paths, "model_store_root", lambda: "/var/lib/hal0/models")
+        assert runner._containing_root("/mnt/ai-models/d/M.gguf") == (
+            "/mnt/ai-models",
+            "d/M.gguf",
+        )
+
+    def test_containing_root_relative_path_falls_back_to_the_live_store(self, monkeypatch):
         from hal0.config import paths as hal0_paths
 
         monkeypatch.setattr(hal0_paths, "model_store_root", lambda: "/var/lib/hal0/models/")
-        assert runner._model_root() == "/var/lib/hal0/models"
+        assert runner._containing_root("d/M.gguf") == ("/var/lib/hal0/models", "d/M.gguf")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
First CT105 deploy validation findings:

- A relocated model store (live root /var/lib/hal0/models) still carries
  pre-relocation models under the historic /mnt/ai-models, and the runner
  rebuilt every path against the live root — pointing Tier-A cells at
  files that do not exist. runner._containing_root() now keeps a model
  under the root that actually holds it, and the hal0-benchctl exec verb
  accepts either self-mount (closed two-root set: resolved store or the
  historic root; -m must sit under the mounted root). This also explains
  a share of the old corpus's mass Tier-A failures on the relocated box.
- guidellm's settings layer probes ./.env in the CWD at startup and the
  service CWD is not readable by the hal0 user (PermissionError). The
  default runner now executes from the temp dir.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
