### PR TITLE
fix(bench): scope the skipped-contended downgrade to Tier-A kinds

### DIFF
--- a/src/hal0/bench/runner.py
+++ b/src/hal0/bench/runner.py
@@ -941,9 +941,19 @@ def _assemble(
             identity.config.kv = cfg.kv
         if cfg.ctx:
             identity.config.ctx = cfg.ctx
-    # Non-exclusive cell measured while a GPU slot was serving → not clean enough
-    # to publish (DESIGN §4 smoke): downgrade an otherwise-ok outcome.
-    if outcome is Outcome.OK and not host.exclusive and _gpu_slot_serving(api):
+    # Non-exclusive TIER-A cell measured while a GPU slot was serving → not
+    # clean enough to publish (DESIGN §4 smoke): downgrade an otherwise-ok
+    # outcome. Tier-A only: a serving-tier cell (chat/http_*/reuse/embed/
+    # rerank) measures THROUGH a live serving slot — its target being up is
+    # the measurement precondition, not contention, and the blanket check
+    # downgraded every such cell unconditionally (CT105 deploy validation,
+    # 2026-08-09). Those records keep host.exclusive=False as context.
+    if (
+        outcome is Outcome.OK
+        and cell.kind in _TIER_A_KINDS
+        and not host.exclusive
+        and _gpu_slot_serving(api)
+    ):
         outcome = Outcome.SKIPPED_CONTENDED
     note = (
         ""

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -545,3 +545,42 @@ class TestBogusLaneDefensiveLayer:
         [rec] = list(store.iter_records())
         assert rec["outcome"] == Outcome.FAILED.value
         assert "bogus" in rec["note"]
+
+
+class TestContendedDowngradeScope:
+    """The skipped-contended downgrade is Tier-A-only: serving-tier cells
+    measure THROUGH a live slot, so 'a slot is serving' is their
+    precondition, not contention (CT105 deploy validation, 2026-08-09)."""
+
+    def _outcome_for(self, kind, tmp_path, monkeypatch):
+        from hal0.bench.parsers import Parsed
+        from hal0.bench.schema import Host, Outcome
+
+        monkeypatch.setattr(runner, "_gpu_slot_serving", lambda api: True)
+        import hal0.bench.planner as _planner
+
+        monkeypatch.setattr(_planner.adapters, "resolve_tool", lambda _n: "/usr/bin/true")
+        (cell,) = _cells([kind], Store(tmp_path))
+        rec = runner._assemble(
+            cell,
+            Parsed(),
+            Outcome.OK,
+            Host(exclusive=False),
+            "s",
+            "rid",
+            tmp_path / "artifacts" / "rid",
+            "",
+            "http://x",
+        )
+        return rec.outcome
+
+    def test_tier_a_still_downgrades(self, tmp_path, monkeypatch):
+        from hal0.bench.schema import Outcome
+
+        assert self._outcome_for("tg", tmp_path, monkeypatch) is Outcome.SKIPPED_CONTENDED
+
+    @pytest.mark.parametrize("kind", ["chat", "http_pp", "http_tg", "reuse", "embed", "rerank"])
+    def test_serving_tier_keeps_ok(self, kind, tmp_path, monkeypatch):
+        from hal0.bench.schema import Outcome
+
+        assert self._outcome_for(kind, tmp_path, monkeypatch) is Outcome.OK


### PR DESCRIPTION
A serving-tier cell (chat/http_pp/http_tg/reuse/embed/rerank) measures
THROUGH a live slot — the target being up is its measurement
precondition, not contention — but the blanket downgrade turned every
such non-exclusive cell into skipped-contended unconditionally (CT105
deploy validation, 2026-08-09: llama-benchy measured real pp/tg numbers
through the live slot and lost them to the label). Tier-A smoke cells
keep the downgrade; serving-tier records keep host.exclusive=False as
context.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
