### PR TITLE
fix(ui): surface capability probe failure per panel instead of silent grey Save

### DIFF
--- a/ui/src/dash/settings/pages/capabilities/EmbedPanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/EmbedPanel.jsx
@@ -29,7 +29,7 @@ export function EmbedPanel() {
         emptyHint="no installed embedding models — install one in the Models view" />
       <SRow k="Serves" sub="memory (Hindsight) embeds with its own bundled model — this slot serves API/RAG traffic" mono
         v={<span style={{color: "var(--fg-4)"}}>/v1/embeddings</span>} />
-      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave}
+      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave} probe={sel.capsQuery}
         disabled={!sel.dirty || sel.loading || sel.errored || sel.applyCapability.isPending}
         saving={sel.applyCapability.isPending} label="Save embeddings" />
     </div>

--- a/ui/src/dash/settings/pages/capabilities/ImagePanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/ImagePanel.jsx
@@ -75,7 +75,7 @@ export function ImagePanel({ registry }) {
       } />
       <ModelRow items={sel.catalogItems} value={sel.model} onChange={sel.setModel}
         placeholder="model id (e.g. sdxl-turbo-fp16)"
-        emptyHint="no installed image models — install one in the Models view" />
+        emptyHint="no capability-tagged image models installed — ComfyUI workflows pick their own checkpoint, so leaving this unset is normal" />
 
       <div className="s-row" style={{paddingBottom: 4, borderBottom: "1px solid var(--line)"}}>
         <div className="k">
@@ -108,7 +108,7 @@ export function ImagePanel({ registry }) {
           <span className="mono" style={{fontSize: 11, color: "var(--fg-4)"}}>No img slot configured — create one in the Slots view to edit generation defaults.</span>
         </div>
       )}
-      <PanelFooter dirty={dirty} onReset={resetAll} onSave={doSave}
+      <PanelFooter dirty={dirty} onReset={resetAll} onSave={doSave} probe={sel.capsQuery}
         disabled={!dirty || sel.loading || sel.errored || sel.applyCapability.isPending || editSlot.isPending}
         saving={sel.applyCapability.isPending || editSlot.isPending} label="Save image generation" />
     </div>

--- a/ui/src/dash/settings/pages/capabilities/RerankPanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/RerankPanel.jsx
@@ -31,7 +31,7 @@ export function RerankPanel() {
       <SRow k="Memory recall reranker" sub="the memory subsystem's second-pass reranker client is configured separately" v={
         <a href="#settings/memory" className="mono" style={{fontSize: 11, color: "var(--accent)"}}>Memory settings →</a>
       } />
-      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave}
+      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave} probe={sel.capsQuery}
         disabled={!sel.dirty || sel.loading || sel.errored || sel.applyCapability.isPending}
         saving={sel.applyCapability.isPending} label="Save reranking" />
     </div>

--- a/ui/src/dash/settings/pages/capabilities/SttPanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/SttPanel.jsx
@@ -35,7 +35,7 @@ export function SttPanel() {
         } mono v={<span style={{color: "var(--fg-4)"}}>{p === "moonshine" ? "English" : "engine-dependent"}</span>} />
       <SRow k="NPU mode" sub="device npu serves whisper from the FLM trio ([npu].asr on the anchor slot) — tune it in the NPU anchor panel below" mono
         v={<span style={{color: "var(--fg-4)"}}>{sel.selection.device === "npu" ? "FLM trio" : "—"}</span>} />
-      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave}
+      <PanelFooter dirty={sel.dirty} onReset={sel.reset} onSave={doSave} probe={sel.capsQuery}
         disabled={!sel.dirty || sel.loading || sel.errored || sel.applyCapability.isPending}
         saving={sel.applyCapability.isPending} label="Save STT" />
     </div>

--- a/ui/src/dash/settings/pages/capabilities/TtsPanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/TtsPanel.jsx
@@ -130,7 +130,7 @@ export function TtsPanel({ registry }) {
             : isQwen3 ? "set by the loaded Qwen3-TTS model at startup — not configurable"
             : "not configurable — determined by the active engine"
         } mono v={<span style={{color: "var(--fg-4)"}}>{isKokoro ? "24 kHz" : "engine-dependent"}</span>} />
-      <PanelFooter dirty={dirty} onReset={resetAll} onSave={doSave}
+      <PanelFooter dirty={dirty} onReset={resetAll} onSave={doSave} probe={sel.capsQuery}
         disabled={!dirty || !speedValid || sel.loading || sel.errored || sel.applyCapability.isPending || editSlot.isPending}
         saving={sel.applyCapability.isPending || editSlot.isPending} label="Save TTS" />
     </div>

--- a/ui/src/dash/settings/pages/capabilities/shared.jsx
+++ b/ui/src/dash/settings/pages/capabilities/shared.jsx
@@ -31,9 +31,22 @@ export function PanelHeader({ title, info, chip, onToggle, open }) {
   )
 }
 
-export function PanelFooter({ dirty, onReset, onSave, disabled, saving, label }) {
+// `probe` is the panel's capabilities query (sel.capsQuery). While it is
+// failing or still loading, Save is gated (#1467 — never write against
+// unknown live state); without this note that gate reads as a dead grey
+// button with no explanation, so say why and offer a Retry.
+export function PanelFooter({ dirty, onReset, onSave, disabled, saving, label, probe }) {
+  const note = probe?.isError
+    ? <>
+        <span style={{color: "var(--err)"}}>capability probe failed — Save disabled</span>
+        <button className="btn ghost sm" style={{marginLeft: 8}} onClick={() => probe.refetch()}>Retry</button>
+      </>
+    : probe?.isLoading
+      ? <span style={{color: "var(--fg-4)"}}>loading capability state…</span>
+      : null
   return (
-    <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>
+    <div style={{display: "flex", justifyContent: "flex-end", alignItems: "center", gap: 8, padding: "8px 12px 4px"}}>
+      {note && <span className="mono" style={{marginRight: "auto", fontSize: 11, display: "inline-flex", alignItems: "center"}}>{note}</span>}
       {dirty && <button className="btn ghost sm" onClick={onReset}>Reset</button>}
       <button className="btn sm" disabled={disabled} onClick={onSave}>{saving ? "Saving…" : label}</button>
     </div>
@@ -51,6 +64,12 @@ export function ModelRow({ items, value, onChange, placeholder, emptyHint }) {
     items.length > 0 ? (
       <select value={value} onChange={e => onChange(e.target.value)} style={selStyle}>
         <option value="">— unset —</option>
+        {value && !items.some(m => rowId(m) === value) && (
+          // Saved selection missing from the catalog (uninstalled model,
+          // stale registry) — surface it instead of silently rendering the
+          // select as "— unset —" while the form state still holds the id.
+          <option value={value}>{value} (saved)</option>
+        )}
         {items.map(m => <option key={rowId(m)} value={rowId(m)}>{rowId(m)}</option>)}
       </select>
     ) : (

--- a/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
+++ b/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
@@ -174,6 +174,41 @@ test.describe('Capability catalog pickers (#1454)', () => {
     await expect(panel.locator('select option', { hasText: 'bge-reranker-v2-m3' })).toHaveCount(1)
     await expect(panel.locator('a[href="#settings/memory"]')).toHaveCount(1)
   })
+
+  test('toggling Enabled marks the panel dirty and lights its Save button', async ({ page }) => {
+    await page.route('**/api/capabilities', (route) => json(route, CAPS_MOCK))
+    await page.goto('/#settings/capabilities')
+    const panel = page.locator('.s-panel').filter({ has: page.locator('.k span', { hasText: /^Embeddings$/ }) })
+    const save = panel.getByRole('button', { name: 'Save embeddings' })
+    await expect(save).toBeDisabled()
+    await panel.getByRole('checkbox').click()
+    await expect(save).toBeEnabled()
+    await expect(panel.getByRole('button', { name: 'Reset' })).toBeVisible()
+  })
+
+  test('failed /api/capabilities probe shows the per-panel note with Retry, then recovers', async ({ page }) => {
+    // #1498/#1527 escape hatch: opt /api/capabilities out of forced-mock
+    // substitution so our 500 fulfil below actually reaches react-query —
+    // without this, mockFetch papers any non-ok networkFirst response over
+    // with the baked payload and capsQuery.isError is unreachable (the
+    // test-infra gap flagged in the #1467 note at the bottom of this file).
+    await page.addInitScript(() => {
+      ;(window as unknown as { __hal0MockPassthrough: string[] }).__hal0MockPassthrough = ['/api/capabilities']
+    })
+    let fail = true
+    await page.route('**/api/capabilities', (route) =>
+      fail ? route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"boom"}' }) : json(route, CAPS_MOCK))
+    await page.goto('/#settings/capabilities')
+
+    const panel = page.locator('.s-panel').filter({ has: page.locator('.k span', { hasText: /^Embeddings$/ }) })
+    await expect(panel.getByText('capability probe failed — Save disabled')).toBeVisible()
+    await expect(panel.getByRole('button', { name: 'Save embeddings' })).toBeDisabled()
+
+    fail = false
+    await panel.getByRole('button', { name: 'Retry' }).click()
+    await expect(panel.getByText('capability probe failed — Save disabled')).toHaveCount(0)
+    await expect(panel.locator('select option', { hasText: 'nomic-embed-text-v1.5' })).toHaveCount(1)
+  })
 })
 
 // #1467 item 4: neither page had an isError branch for GET /api/capabilities
@@ -184,15 +219,9 @@ test.describe('Capability catalog pickers (#1454)', () => {
 // suppressed via `errored` alongside the existing dirty/loading/pending
 // gates (VoicePage.jsx Save STT / Save TTS, ImageGenPage.jsx Save Image-gen).
 //
-// NOT e2e-covered: `/api/capabilities` is `networkFirst` in
-// src/api/mock.ts's MOCK_ALLOWLIST (needed so THIS spec's page.route
-// fixtures above stay authoritative under the suite's forced-mock build —
-// see the allowlist comment). But `mockFetch`'s FORCED+networkFirst branch
-// substitutes the baked payload for ANY non-ok response, network exception
-// included (`if (FORCED && hit.row.networkFirst && !res.ok) { …fallback… }`)
-// — so a page.route 500/abort on this endpoint is silently papered over
-// with a 200 mock payload before it ever reaches react-query, and
-// capsQuery.isError is unreachable from a Playwright spec against this
-// harness. Verified by direct code inspection instead (matches the
-// AdvancedPage/SecretsPage isError precedent exactly); flagged in the
-// #1467 report as a test-infra gap, not a shortcut in the fix itself.
+// The isError branch WAS untestable here (mockFetch's FORCED+networkFirst
+// branch substituted the baked payload for any non-ok response before it
+// reached react-query). The #1498/#1527 `__hal0MockPassthrough` escape
+// hatch closed that gap — the "failed /api/capabilities probe" spec above
+// opts the endpoint out of substitution and drives the 500 → per-panel
+// note → Retry → recovery path end to end.


### PR DESCRIPTION
## What changed

The unified AI Capabilities settings page gates every panel's Save on `capsQuery.isError`/`isLoading` (#1467 — never write against unknown live state), but the only signal was a small banner at the top of the page. When `GET /api/capabilities` fails, every panel renders editable controls whose Save stays grey with no explanation, and the empty catalogs degrade every model picker to a bare text input. That is exactly the report this fixes: "all the sections save buttons remain grey" + "empty text fields for model names".

- **PanelFooter** now takes the capabilities query and renders an inline `capability probe failed — Save disabled` note with a **Retry** button (refetch), plus a `loading capability state…` note while the probe is in flight.
- **ModelRow** lists a saved-but-uncataloged model id as `<id> (saved)` instead of silently displaying the select as unset (mirrors the TTS voice picker's behavior).
- **Image panel** empty hint no longer claims image models must be installed — ComfyUI workflows pick their own checkpoint, so an unset model is normal there.

Note: the model pickers already are dropdowns fed from the capability-tagged catalogs (`catalogs.<slot>.<child>`); the bare text fields only appear when the probe fails (now clearly signposted) or a catalog is genuinely empty.

## Why it looked broken

Reproduced: a dev server without `VITE_API_TARGET` proxies `/api` to the default `127.0.0.1:8080`; the proxy 500 makes the capabilities query error, which (correctly) disables Save everywhere — but with no per-panel explanation. Against a healthy API (CT105) the page already worked: dropdowns populated, toggling Enabled lights Save.

## Verification

- Browser-verified both states on this branch: healthy API (dropdowns, Save lights on toggle) and failing probe (per-panel note + Retry, recovery after the API returns).
- `npm run lint`, `npm run typecheck`, `npm run test:unit` (121 passed).
- e2e: `capability-catalog-pickers-v3.spec.ts` extended with a toggle-enables-Save spec and the previously-untestable `isError` path, now driven end to end via the #1498/#1527 `__hal0MockPassthrough` escape hatch (7 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)