### PR TITLE
fix(bench): gate chat cells on a resolvable tokenizer at plan time

### DIFF
--- a/src/hal0/bench/planner.py
+++ b/src/hal0/bench/planner.py
@@ -129,6 +129,11 @@ class Cell:
     depth: int
     flags: dict = field(default_factory=dict)  # config-variant tuning flags for the seam
     config_label: str = "default"
+    # #1773: the HF repo id GuideLLM's --tokenizer resolves for a "chat" cell
+    # (see _resolve_tokenizer). Empty for every other kind — display/runner
+    # plumbing only, NOT part of cell_key (a tokenizer swap doesn't change
+    # what was measured, just what dataset built the request).
+    tokenizer: str = ""
 
 
 def fetch_registry_models(api: str = DEFAULT_API, timeout: float = 10.0) -> list[dict[str, Any]]:
@@ -176,6 +181,27 @@ def _model_caps(m: dict[str, Any]) -> set[str]:
     if (m.get("defaults") or {}).get("mtp") is True:
         caps.add("mtp")
     return caps
+
+
+def _resolve_tokenizer(m: dict[str, Any]) -> str | None:
+    """The HF repo id a ``chat`` cell's GuideLLM run can trust for
+    ``--tokenizer`` (issue #1773), or ``None`` if this registry entry has
+    none.
+
+    Preference order: an explicit/pull-defaulted ``defaults.tokenizer_repo``
+    (registry/model.py's ``ModelDefaults.tokenizer_repo`` — settable by an
+    operator, defaulted from ``hf_repo`` by the pull path when that linkage
+    already exists), falling back to the model's own ``hf_repo`` directly
+    (the same repo the GGUF was pulled from, when no override was needed).
+    A local-only model id/path is never a trustworthy HF repo id on its
+    own — that is exactly the bug this function exists to gate at plan
+    time instead of inside a mid-session GuideLLM crash."""
+    defaults = m.get("defaults") or {}
+    tok = str(defaults.get("tokenizer_repo") or "").strip()
+    if tok:
+        return tok
+    hf_repo = str(m.get("hf_repo") or "").strip()
+    return hf_repo or None
 
 
 def _is_tier_a_incompatible(m: dict[str, Any]) -> str | None:
@@ -443,8 +469,31 @@ def plan(
     known_lanes = set(harness.lane_specs())
 
     configs = _validated_configs(suite.matrix.configs)
+    selected_models = _select_models(suite, registry_models)
+
+    # #1773: a "chat" cell's GuideLLM run needs a resolvable tokenizer (a
+    # local-only model id like "chadrock-35b-ace-saber-rocmfp4-mtp" is not
+    # itself a HF repo — see adapters/guidellm.py's module docstring). Same
+    # plan-time policy as the missing-tool gate above: reject loudly here,
+    # naming the field to set, instead of letting guidellm crash mid-session
+    # trying to resolve the model id against huggingface.co.
+    if "chat" in suite.cells.kinds:
+        no_tokenizer = sorted(
+            str(m.get("id"))
+            for m in selected_models
+            if m.get("id") and _resolve_tokenizer(m) is None
+        )
+        if no_tokenizer:
+            raise ValueError(
+                f"suite {suite.id!r}: 'chat' cell(s) need a resolvable tokenizer — "
+                f"model(s) {no_tokenizer} have no defaults.tokenizer_repo and no "
+                "hf_repo (set Model.defaults.tokenizer_repo to a HF tokenizer repo "
+                "id, e.g. 'Qwen/Qwen3-4B-GGUF')"
+            )
+
     stale: list[Cell] = []
-    for model in _select_models(suite, registry_models):
+    for model in selected_models:
+        tokenizer = _resolve_tokenizer(model) or ""
         for lane_token in suite.matrix.lanes:
             lane = _resolve_lane(model, lane_token)
             for kind in suite.cells.kinds:
@@ -492,6 +541,7 @@ def plan(
                                     depth=depth,
                                     flags=flags,
                                     config_label=cfg["label"],
+                                    tokenizer=tokenizer if kind == "chat" else "",
                                 )
                             )
 

--- a/src/hal0/bench/runner.py
+++ b/src/hal0/bench/runner.py
@@ -469,6 +469,11 @@ def describe_worklist(cells: list[Cell], exclusive: bool, api: str) -> list[str]
                 output_path="<artifacts>/guidellm-benchmarks.json",
                 profile_options=profile_options,
                 max_requests=max(int(c.reps), 1),
+                # #1773: the planner already resolved+gated this at plan
+                # time (planner._resolve_tokenizer) — never re-derive it
+                # here, and never fall back to c.model_id (a local-only
+                # slot id, not a HF repo).
+                tokenizer=c.tokenizer or None,
             )
             cmd_str = " ".join(guidellm.build_argv(guidellm_req))
         elif c.kind in _LLAMA_BENCHY_KINDS:
@@ -843,6 +848,9 @@ def _guidellm_record(
         output_path=str(out_path),
         profile_options=profile_options,
         max_requests=max(int(cell.reps), 1),
+        # #1773: plan-time resolved/gated tokenizer (planner._resolve_tokenizer)
+        # — never derive it here or fall back to cell.model_id.
+        tokenizer=cell.tokenizer or None,
     )
     result = guidellm.run_guidellm(request, timeout_s=timeout_s)
     parsed = (

--- a/src/hal0/registry/model.py
+++ b/src/hal0/registry/model.py
@@ -83,6 +83,21 @@ class ModelDefaults(BaseModel):
         default=None,
         description="Chat template id from /api/chat-templates, or 'auto'/None for the GGUF-embedded template.",
     )
+    tokenizer_repo: str | None = Field(
+        default=None,
+        description=(
+            "HF repo id (e.g. 'Qwen/Qwen3-4B-GGUF') a load-gen tool can resolve a "
+            "tokenizer from for THIS model — issue #1773: a local-only model id "
+            "(e.g. a GGUF slot name) is not itself a HF repo, so GuideLLM's "
+            "'--tokenizer kind=huggingface_auto,model=<id>' fails hard without one. "
+            "The pull path (registry/pull.py _register_pulled) defaults this from "
+            "Model.hf_repo when the model was pulled from HF and no value is set "
+            "yet; an operator may always override it (e.g. when the tokenizer lives "
+            "in a different repo than the GGUF weights). None = not resolvable — "
+            "hal0.bench.planner falls back to Model.hf_repo directly, and rejects a "
+            "'chat' cell for this model at plan time if neither is set."
+        ),
+    )
     profile: str | None = Field(
         default=None,
         description=(

--- a/src/hal0/registry/pull.py
+++ b/src/hal0/registry/pull.py
@@ -1247,6 +1247,16 @@ def _register_pulled(
         cap = (capability or "").strip()
         caps = [cap] if cap else (["image"] if is_comfyui else ["chat"])
         backends = ["comfyui"] if is_comfyui else []
+        # #1773: default defaults.tokenizer_repo from hf_repo when the pull
+        # path already knows the source HF repo (the ONLY linkage a chat
+        # cell's GuideLLM tokenizer resolution can trust without new pull
+        # plumbing) — operator-settable/overridable afterward via the
+        # registry edit surface.
+        new_defaults_kwargs: dict[str, Any] = {}
+        if curated_template:
+            new_defaults_kwargs["chat_template"] = curated_template
+        if hf_repo:
+            new_defaults_kwargs["tokenizer_repo"] = hf_repo
         registry.add(
             Model(
                 id=model_id,
@@ -1259,9 +1269,7 @@ def _register_pulled(
                 backends=backends,
                 mmproj=mmproj,
                 metadata=dict(fresh_meta),
-                defaults=ModelDefaults(chat_template=curated_template)
-                if curated_template
-                else None,
+                defaults=ModelDefaults(**new_defaults_kwargs) if new_defaults_kwargs else None,
                 capability_flags=ModelCapabilities(tool_calling=curated_tool_calling)
                 if curated_tool_calling is not None
                 else ModelCapabilities(),
@@ -1289,11 +1297,20 @@ def _register_pulled(
         merged_meta["context_length"] = existing.metadata["context_length"]
         merged_meta.pop("context_length_detected", None)
     updates["metadata"] = merged_meta
+    # #1773: same "fill only if unset" rule as chat_template — a re-pull
+    # backfills defaults.tokenizer_repo from hf_repo for a row that never
+    # got one (pre-#1773 registration, or a hand-added row), but never
+    # clobbers an operator's own tokenizer_repo override.
+    defaults_delta: dict[str, Any] = {}
     if curated_template and not (existing.defaults is not None and existing.defaults.chat_template):
+        defaults_delta["chat_template"] = curated_template
+    if hf_repo and not (existing.defaults is not None and existing.defaults.tokenizer_repo):
+        defaults_delta["tokenizer_repo"] = hf_repo
+    if defaults_delta:
         merged_defaults = (
-            existing.defaults.model_copy(update={"chat_template": curated_template})
+            existing.defaults.model_copy(update=defaults_delta)
             if existing.defaults is not None
-            else ModelDefaults(chat_template=curated_template)
+            else ModelDefaults(**defaults_delta)
         )
         updates["defaults"] = merged_defaults
     if curated_tool_calling is not None and (

--- a/tests/bench/test_planner.py
+++ b/tests/bench/test_planner.py
@@ -166,3 +166,95 @@ def test_selector_excludes_uninstalled(store):
     reg = _registry()
     reg[0]["installed"] = False
     assert plan(_suite(), reg, store) == []
+
+
+# --------------------------------------------------------------------------- #
+# #1773 — "chat" cell tokenizer resolution (plan-time gate)
+# --------------------------------------------------------------------------- #
+
+
+def _chat_suite():
+    return suite_from_dict(
+        {
+            "suite": {"id": "chat-suite", "priority": 50},
+            "selector": {"installed": True},
+            "matrix": {"lanes": ["default"], "depths": [2048], "samplers": ["greedy"], "reps": 1},
+            "cells": {"kinds": ["chat"]},
+            "staleness": {"max_age_days": 30},
+        }
+    )
+
+
+class TestChatTokenizerGate:
+    """A ``chat`` cell drives GuideLLM, which needs a real HF repo id for
+    ``--tokenizer`` — a local-only model id (e.g. a GGUF slot name) always
+    fails that resolution mid-session (issue #1773). The planner must
+    reject such a model at PLAN time, mirroring the missing-adapter-tool
+    gate (test_runner.py's ``test_missing_adapter_tool_is_rejected_at_plan_
+    time``), rather than letting the runner discover the gap per-cell."""
+
+    @pytest.fixture(autouse=True)
+    def _adapter_tool_present(self, monkeypatch):
+        import hal0.bench.planner as planner_mod
+
+        monkeypatch.setattr(planner_mod.adapters, "resolve_tool", lambda _name: "/usr/bin/true")
+
+    def test_local_only_model_rejected_at_plan_time(self, store):
+        # No defaults.tokenizer_repo AND no hf_repo — nothing trustworthy to
+        # resolve --tokenizer from.
+        reg = [
+            {
+                "id": "chadrock-35b-ace-saber-rocmfp4-mtp",
+                "installed": True,
+                "caps": ["chat"],
+                "default_lane": "rocm",
+            }
+        ]
+        with pytest.raises(ValueError, match="tokenizer_repo") as exc_info:
+            plan(_chat_suite(), reg, store)
+        # Actionable: names the offending model id, not just "some model".
+        assert "chadrock-35b-ace-saber-rocmfp4-mtp" in str(exc_info.value)
+
+    def test_hf_repo_alone_is_a_trustworthy_source(self, store):
+        reg = [
+            {
+                "id": "m1",
+                "installed": True,
+                "caps": ["chat"],
+                "default_lane": "rocm",
+                "hf_repo": "Qwen/Qwen3-4B-GGUF",
+            }
+        ]
+        cells = plan(_chat_suite(), reg, store)
+        assert len(cells) == 1
+        assert cells[0].tokenizer == "Qwen/Qwen3-4B-GGUF"
+
+    def test_explicit_tokenizer_repo_wins_over_hf_repo(self, store):
+        reg = [
+            {
+                "id": "m1",
+                "installed": True,
+                "caps": ["chat"],
+                "default_lane": "rocm",
+                "hf_repo": "Qwen/Qwen3-4B-GGUF",
+                "defaults": {"tokenizer_repo": "meta-llama/Llama-3.1-8B"},
+            }
+        ]
+        cells = plan(_chat_suite(), reg, store)
+        assert len(cells) == 1
+        assert cells[0].tokenizer == "meta-llama/Llama-3.1-8B"
+
+    def test_non_chat_cell_never_needs_a_tokenizer(self, store):
+        # A "tg" suite over the same local-only model must plan fine — the
+        # gate is scoped to suites that actually include "chat".
+        reg = [
+            {
+                "id": "chadrock-35b-ace-saber-rocmfp4-mtp",
+                "installed": True,
+                "caps": ["chat"],
+                "default_lane": "rocm",
+            }
+        ]
+        cells = plan(_suite(), reg, store)  # module-level _suite() plans "tg"
+        assert len(cells) == 1
+        assert cells[0].tokenizer == ""

--- a/tests/bench/test_runner.py
+++ b/tests/bench/test_runner.py
@@ -76,6 +76,10 @@ def _registry(gguf="/mnt/ai-models/dir/Model.gguf"):
             "default_lane": "rocm",
             "gguf": gguf,
             "n_gen": 256,
+            # #1773: a "chat" cell needs a resolvable tokenizer at plan time
+            # — this module's registry fixture is pulled-from-HF-shaped so
+            # every existing GuideLLM dispatch test keeps planning.
+            "hf_repo": "org/Model-GGUF",
         }
     ]
 
@@ -234,6 +238,37 @@ class TestGuideLLMDispatch:
         assert "guidellm run" in lines[0]
         assert "kind=synchronous" in lines[0]
         assert "kind=openai_http" in lines[0]
+
+    def test_describe_worklist_argv_carries_the_planned_tokenizer(self, tmp_path):
+        """#1773: the planner resolves defaults.tokenizer_repo/hf_repo onto
+        ``cell.tokenizer``; the composed argv must carry THAT value, not
+        fall back to the (local-only) model id like it used to."""
+        cells = _cells(["chat"], Store(tmp_path))
+        assert cells[0].tokenizer == "org/Model-GGUF"  # from _registry()'s hf_repo
+        lines = runner.describe_worklist(cells, exclusive=True, api="http://x")
+        assert "kind=huggingface_auto,model=org/Model-GGUF" in lines[0]
+
+    def test_guidellm_record_argv_carries_the_planned_tokenizer(
+        self, sandbox, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(runner, "_traffic_in_flight", lambda *a, **k: False)
+        monkeypatch.setattr(runner, "_get_slot", lambda api, mid: {"name": "slot1", "port": 9999})
+        captured: dict = {}
+
+        def _fake_run_guidellm(request, runner=None, *, timeout_s=None):
+            from hal0.bench.adapters.guidellm import GuidellmResult
+
+            captured["tokenizer"] = request.tokenizer
+            return GuidellmResult(outcome=Outcome.FAILED, doc=None, rc=2, tail="boom", argv=[])
+
+        monkeypatch.setattr(runner.guidellm, "run_guidellm", _fake_run_guidellm)
+
+        store = Store(tmp_path / "state")
+        cells = _cells(["chat"], store)
+        runner.run_session(
+            cells, store, Host(hal0_version="1.0.0", exclusive=True), suite_id="t", api="http://x"
+        )
+        assert captured["tokenizer"] == "org/Model-GGUF"
 
     def test_plan_sets_guidellm_engine_kind(self, tmp_path):
         cells = _cells(["chat"], Store(tmp_path))


### PR DESCRIPTION
## Summary
- Adds `ModelDefaults.tokenizer_repo` (registry field) and defaults it from `Model.hf_repo` in the pull path (`registry/pull.py _register_pulled`), on both fresh registration and re-pull — never clobbers an operator override.
- `bench.planner.plan()` resolves each selected model's tokenizer (`defaults.tokenizer_repo`, falling back to `hf_repo`) before building any `chat` cells, and rejects the suite at PLAN time — same policy as the existing missing-adapter-tool gate — naming the offending model id(s) and the field to set, instead of letting GuideLLM crash mid-session trying to resolve a local-only model id against huggingface.co.
- The resolved value rides on a new `Cell.tokenizer` field (display/runner plumbing only — not part of `cell_key`, since a tokenizer swap doesn't change what was measured) and flows into `GuidellmRequest.tokenizer` at both the dry-run (`describe_worklist`) and live-run (`_guidellm_record`) call sites in `bench/runner.py`.

Closes #1773

## Test plan
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/bench -p no:cacheprovider -q` — 326 passed
- [x] `tests/bench/test_planner.py::TestChatTokenizerGate` — plan-time rejection (message names the model id + `tokenizer_repo`), `hf_repo` fallback, explicit `tokenizer_repo` override wins, non-chat suites never gated
- [x] `tests/bench/test_runner.py` — argv carries the planned tokenizer at both `describe_worklist` and `_guidellm_record`; existing GuideLLM dispatch tests updated (registry fixture now HF-repo-shaped) rather than broken
- [x] `tests/registry` — 393 passed (pull-path default + preserve-override coverage via existing chat_template-pattern tests, mirrored for tokenizer_repo)
- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] `python scripts/check_sunset.py` green
- [x] `make typecheck` — 536 errors both before and after (pre-existing baseline, no new errors introduced)