### PR TITLE
fix(bench): retire hand-rolled columns from hal0 bench eval's result table

### DIFF
--- a/src/hal0/bench/adapters/tool_eval.py
+++ b/src/hal0/bench/adapters/tool_eval.py
@@ -424,7 +424,9 @@ def _task_outcome(status: str, failure_kind: str | None) -> str:
     return "ok" if status == "pass" else "failed"
 
 
-def _parse_task(row: dict[str, Any], tool_version: str, scoring_era: str) -> ToolEvalTaskRecord:
+def _parse_task(
+    row: dict[str, Any], tool_version: str, scoring_era: str, run_final_score: int | None = None
+) -> ToolEvalTaskRecord:
     status = str(row.get("status") or "")
     points = row.get("points")
     score = round(points / 2, 3) if isinstance(points, int | float) else 0.0
@@ -436,6 +438,12 @@ def _parse_task(row: dict[str, Any], tool_version: str, scoring_era: str) -> Too
         "ttft_ms": row.get("ttft_ms"),
         "prompt_tokens": row.get("prompt_tokens"),
         "completion_tokens": row.get("completion_tokens"),
+        # Raw per-scenario points ({0,1,2} per the tool's own scale) and the
+        # RUN-level final_score (0-100, tool-eval-bench's own headline
+        # number) — both needed by the CLI table (#1775: the old table read
+        # neither and printed retired hand-rolled columns instead).
+        "points": points if isinstance(points, int | float) else None,
+        "final_score": run_final_score,
     }
     return ToolEvalTaskRecord(
         task_id=str(row.get("scenario_id") or ""),
@@ -470,18 +478,23 @@ def parse_scores(doc: dict[str, Any]) -> ToolEvalSuiteRecord:
     tool_version = str(raw_version) if raw_version else ""
     scoring_era = classify_scoring_era(tool_version)
 
+    status = str(doc.get("status") or "")
+    final_score = doc.get("final_score")
+    total_scenarios = doc.get("total_scenarios")
+
     scores = doc.get("scores") if isinstance(doc.get("scores"), dict) else {}
     scenario_results = scores.get("scenario_results")
     rows = scenario_results if isinstance(scenario_results, list) else []
-    tasks = [_parse_task(row, tool_version, scoring_era) for row in rows if isinstance(row, dict)]
+    run_final_score = final_score if isinstance(final_score, int) else None
+    tasks = [
+        _parse_task(row, tool_version, scoring_era, run_final_score)
+        for row in rows
+        if isinstance(row, dict)
+    ]
 
     metadata = doc.get("metadata") if isinstance(doc.get("metadata"), dict) else {}
     config = doc.get("config") if isinstance(doc.get("config"), dict) else {}
     model = str(metadata.get("model") or config.get("model") or "")
-
-    status = str(doc.get("status") or "")
-    final_score = doc.get("final_score")
-    total_scenarios = doc.get("total_scenarios")
 
     return ToolEvalSuiteRecord(
         run_id=str(doc.get("run_id") or ""),

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -26,6 +26,7 @@ import sys
 import urllib.error
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import hal0
 
@@ -37,6 +38,9 @@ from .runner import _traffic_in_flight as traffic_in_flight
 from .schema import Host
 from .store import Store
 from .suites import Suite, load_suite_file, load_suites, suite_dir, window_file
+
+if TYPE_CHECKING:
+    from .evalrun import EvalRecord
 
 # Politeness policy for --scheduled (DESIGN §6): only proceed inside the
 # maintenance window and when the GPU is quiet. Window default is Sun 03:00-07:00
@@ -687,18 +691,24 @@ def cmd_eval(args: argparse.Namespace) -> int:
                 rec = evalrun.run_task(task, model, run_id, args.api, workroot)
                 evalrun.append_eval(rec)
                 rows.append(rec)
-                mark = "OK " if rec.correct else ("~  " if rec.score > 0 else "X  ")
-                m = rec.metrics
-                print(
-                    f"  {mark} score={rec.score} got={rec.answer!r} "
-                    f"want={rec.expected!r} wall={m.get('wall_s')}s "
-                    f"tools={m.get('tool_calls')} tok_out={m.get('tokens_out')} "
-                    f"steps={len(rec.checkpoints_hit)}/{rec.checkpoints_total}"
-                )
+                print(_format_eval_row(rec))
 
     if rows:
         print("\n" + _eval_table(rows))
     return 0
+
+
+def _format_eval_row(rec: EvalRecord) -> str:
+    """One scenario's result line, in tool-eval-bench's own vocabulary
+    (scenario id / status / points / duration / the run's final score) — NOT
+    the retired hand-rolled columns (``got/want/wall/tools/tok_out/steps``)
+    that tool-eval-bench (Bench Phase 3) never produces (#1775)."""
+    mark = "OK " if rec.correct else ("~  " if rec.score > 0 else "X  ")
+    m = rec.metrics
+    return (
+        f"  {mark} {rec.task_id} status={rec.outcome} points={m.get('points')} "
+        f"duration={m.get('duration_seconds')}s final_score={m.get('final_score')}"
+    )
 
 
 def _eval_table(rows: list) -> str:
@@ -718,7 +728,7 @@ def _eval_table(rows: list) -> str:
                 continue
             scores.append(r.score)
             tag = "ok" if r.correct else f"{r.score:.2f}"
-            cells.append(f"{tag} {r.metrics.get('wall_s', '?')}s".ljust(14))
+            cells.append(f"{tag} {r.metrics.get('duration_seconds', '?')}s".ljust(14))
         avg = f"{sum(scores) / len(scores):.2f}" if scores else "-"
         out.append(m.ljust(w) + "  " + "  ".join(cells) + f"  {avg}")
     return "\n".join(out)

--- a/tests/bench/adapters/fixtures/tool_eval/passing_run.json
+++ b/tests/bench/adapters/fixtures/tool_eval/passing_run.json
@@ -1,0 +1,96 @@
+{
+  "schema_version": "1",
+  "tool_eval_bench_version": "2.5.0",
+  "final_score": 100,
+  "rating": "★★★★★ Excellent",
+  "safety_warnings": [],
+  "deployability": 100,
+  "responsiveness": 100,
+  "total_scenarios": 1,
+  "run_id": "2026-08-09T18-12-04.221000Z_a1b2c3d4",
+  "status": "completed",
+  "config": {
+    "model": "chadrock-35b-ace-saber-rocmfp4-mtp",
+    "backend": "llamacpp",
+    "base_url": "http://***:8999",
+    "temperature": 0.0,
+    "timeout_seconds": 15.0,
+    "max_turns": 8,
+    "seed": null,
+    "reference_date": null,
+    "scenario_count": 1,
+    "scenario_ids": [
+      "TC-68"
+    ],
+    "concurrency": 1,
+    "error_rate": 0.0,
+    "alpha": 0.7,
+    "extra_params": null,
+    "weight_by_difficulty": false,
+    "config_fingerprint": "b3c1a09e7f21"
+  },
+  "scores": {
+    "final_score": 100,
+    "total_points": 2,
+    "max_points": 2,
+    "rating": "★★★★★ Excellent",
+    "category_scores": [
+      {
+        "category": "A",
+        "label": "Tool Selection",
+        "earned": 2,
+        "max": 2,
+        "percent": 100,
+        "pass_count": 1,
+        "partial_count": 0,
+        "fail_count": 0
+      }
+    ],
+    "scenario_results": [
+      {
+        "scenario_id": "TC-68",
+        "status": "pass",
+        "points": 2,
+        "summary": "Correctly routed the request to get_weather with the right location.",
+        "note": null,
+        "tool_calls_made": [
+          "get_weather(location=Berlin)"
+        ],
+        "expected_behavior": "Use get_weather instead of falling back to web_search.",
+        "duration_seconds": 6.22,
+        "turn_count": 2,
+        "raw_log": "model=chadrock-35b-ace-saber-rocmfp4-mtp\nscenario=TC-68\nprompt=What's the weather like in Berlin right now?\n\nassistant=starting\ntool_choice=auto\nassistant_turn_1=[tool_call get_weather(location=Berlin)]\ntool_result=8C and overcast\nassistant_turn_2=It's 8C and overcast in Berlin right now.\nfinal_answer=It's 8C and overcast in Berlin right now.\n\nverdict=pass\nsummary=Correctly routed the request to get_weather with the right location.",
+        "ttft_ms": 118.4,
+        "turn_latencies_ms": [
+          2100.0,
+          1050.0
+        ],
+        "prompt_tokens": 312,
+        "completion_tokens": 41,
+        "total_tokens": 353
+      }
+    ]
+  },
+  "metadata": {
+    "tool_version": "2.5.0",
+    "hostname": "ct105",
+    "platform_info": "Linux-ct105-x86_64-with-glibc2.39",
+    "python_version": "3.12.11",
+    "model": "chadrock-35b-ace-saber-rocmfp4-mtp",
+    "backend": "llamacpp",
+    "base_url": "http://***:8999",
+    "temperature": 0.0,
+    "max_turns": 8,
+    "timeout_seconds": 15.0,
+    "scenario_selector": "TC-68",
+    "trials": 1,
+    "parallel": 1,
+    "error_rate": 0.0,
+    "thinking_enabled": true
+  },
+  "safety_gate": {
+    "passed": true,
+    "warnings": []
+  },
+  "report_path": "runs/2026/08/2026-08-09T18-12-04.221000Z_a1b2c3d4.md"
+}

--- a/tests/bench/adapters/test_tool_eval.py
+++ b/tests/bench/adapters/test_tool_eval.py
@@ -235,6 +235,32 @@ def test_parse_scores_happy_run() -> None:
     assert task.answer  # summary prose carried through
 
 
+def test_parse_scores_passing_run_never_maps_to_score_zero() -> None:
+    """Regression for #1775: a real v2.5.0 document for a scenario that
+    tool-eval-bench itself scored ``final_score: 100`` (pass, points=2) must
+    never come out of this parser as ``score: 0.0``. ``passing_run.json`` is
+    hand-crafted (not machine-captured — a genuine tool-executing PASS
+    requires reproducing tool-eval-bench's internal tool-call protocol in
+    the fake server, out of scope here) but mirrors ``happy_run.json``'s
+    real captured key set exactly (schema_version/tool_eval_bench_version/
+    final_score/rating/deployability/responsiveness/total_scenarios/run_id/
+    status/config incl. config_fingerprint/scores incl. category_scores and
+    scenario_results/metadata/safety_gate/report_path) — see module
+    docstring and the issue for the real shape this pins down."""
+    doc = _load("passing_run.json")
+    suite = tool_eval.parse_scores(doc)
+
+    assert suite.final_score == 100
+    task = next(t for t in suite.tasks if t.task_id == "TC-68")
+    assert task.outcome == "ok"
+    assert task.correct is True
+    assert task.score == 1.0
+    assert task.score != 0.0
+    assert task.metrics["points"] == 2
+    assert task.metrics["final_score"] == 100
+    assert task.metrics["duration_seconds"] == 6.22
+
+
 def test_parse_scores_dev_version_stamps_lenient_version() -> None:
     doc = _load("dev_version_run.json")
     suite = tool_eval.parse_scores(doc)

--- a/tests/bench/test_cli_eval.py
+++ b/tests/bench/test_cli_eval.py
@@ -1,0 +1,64 @@
+"""hal0 bench eval's result display (#1775): tool-eval-bench (Bench Phase 3)
+replaced the old hand-rolled Hermes-driven eval scorer, but the CLI's result
+table kept printing that scorer's columns (``got``/``want``/``wall``/
+``tools``/``tok_out``/``steps``) — fields tool-eval-bench's JSON envelope
+never produces (see ``adapters/tool_eval.py``'s module docstring for its real
+shape). This locks the display down to the vocabulary the tool actually
+reports: scenario id, status, points, duration, and the run's final score."""
+
+from __future__ import annotations
+
+from hal0.bench import evalrun
+from hal0.bench.cli import _format_eval_row
+
+
+def _passing_record() -> evalrun.EvalRecord:
+    return evalrun.EvalRecord(
+        run_id="run-1",
+        suite="agentic",
+        task_id="TC-68",
+        kind="A",
+        model="chadrock-35b-ace-saber-rocmfp4-mtp",
+        outcome="ok",
+        score=1.0,
+        correct=True,
+        expected="Use get_weather.",
+        answer="Correctly used the tool.",
+        checkpoints_hit=["get_weather(Berlin)"],
+        checkpoints_total=0,
+        metrics={
+            "duration_seconds": 6.22,
+            "points": 2,
+            "final_score": 100,
+            "wall_s": 6.22,
+            "tool_calls": 1,
+        },
+        note="",
+        tool_version="2.5.0",
+        scoring_era="hardened-2026-08",
+    )
+
+
+def test_format_eval_row_uses_tool_eval_bench_vocabulary():
+    line = _format_eval_row(_passing_record())
+    assert "TC-68" in line
+    assert "status=ok" in line
+    assert "points=2" in line
+    assert "duration=6.22s" in line
+    assert "final_score=100" in line
+
+
+def test_format_eval_row_never_prints_the_retired_hand_rolled_columns():
+    line = _format_eval_row(_passing_record())
+    for retired in ("got=", "want=", "wall=", "tools=", "tok_out=", "steps="):
+        assert retired not in line, f"retired hand-rolled column {retired!r} still printed"
+
+
+def test_format_eval_row_never_prints_score_zero_for_a_passing_scenario():
+    """The #1775 symptom: a real pass (final_score 100) rendered as
+    ``score=0.0``. The old format string is gone entirely now, but pin down
+    the underlying invariant too — a correct, full-points record's line
+    never claims a zero final_score."""
+    line = _format_eval_row(_passing_record())
+    assert "final_score=0 " not in line
+    assert not line.rstrip().endswith("final_score=0")

--- a/tests/bench/test_evalrun.py
+++ b/tests/bench/test_evalrun.py
@@ -11,9 +11,12 @@ shells out to a real tool-eval-bench binary (CI has none installed).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from hal0.bench import evalrun
 from hal0.bench.adapters.tool_eval import ERA_HARDENED
+
+_TOOL_EVAL_FIXTURES = Path(__file__).resolve().parent / "adapters" / "fixtures" / "tool_eval"
 
 
 def _scenario_doc(ids: list[str]) -> str:
@@ -155,6 +158,47 @@ class TestRunTask:
         assert rec.outcome == "failed"
         assert rec.correct is False
         assert rec.score == 0.0
+
+    def test_real_shaped_v2_5_0_passing_document_never_maps_to_score_zero(self, tmp_path):
+        """Regression for #1775: ``hal0 bench eval`` mapped a passing
+        tool-eval-bench run (real ``final_score: 100``) to ``score=0.0``,
+        printed with the retired hand-rolled table columns (``got/want/
+        wall/tools/tok_out/steps``, all empty/None — the ``_failed_record``
+        defaults). This feeds ``run_task`` a document shaped exactly like a
+        real v2.5.0 ``--json-file`` envelope (see
+        ``tests/bench/adapters/fixtures/tool_eval/passing_run.json``, and
+        ``adapters/tool_eval.py``'s module docstring for the real shape) and
+        asserts the score survives the full evalrun -> adapter round trip —
+        not just the adapter's own parser (already covered by
+        ``test_tool_eval.py::test_parse_scores_passing_run_never_maps_to_score_zero``)."""
+        doc = json.loads((_TOOL_EVAL_FIXTURES / "passing_run.json").read_text())
+        task = evalrun.Task(id="TC-68", kind="A")
+
+        def fake_runner(argv, timeout_s):
+            out_path = argv[argv.index("--json-file") + 1]
+            with open(out_path, "w") as fh:
+                json.dump(doc, fh)
+            return 0, "", ""
+
+        rec = evalrun.run_task(
+            task,
+            "chadrock-35b-ace-saber-rocmfp4-mtp",
+            "run-1",
+            "http://127.0.0.1:8080",
+            tmp_path,
+            runner=fake_runner,
+        )
+
+        assert rec.outcome == "ok"
+        assert rec.correct is True
+        assert rec.score == 1.0
+        assert rec.score != 0.0
+        assert rec.answer  # not '' like the _failed_record default
+        assert rec.expected  # not '' like the _failed_record default
+        assert rec.metrics["duration_seconds"] == 6.22
+        assert rec.metrics["wall_s"] == 6.22  # legacy alias still populated
+        assert rec.metrics["points"] == 2
+        assert rec.metrics["final_score"] == 100
 
     def test_connection_failure_never_raises(self, tmp_path):
         """A pre-flight connection failure (adapters/tool_eval.py's real


### PR DESCRIPTION
## Summary
- Investigated #1775 (`hal0 bench eval` mapping a passing tool-eval-bench run — real `final_score: 100` — to `score=0.0`). The Phase-3 wiring in `evalrun.py` + `adapters/tool_eval.py` already parses a real v2.5.0 `--json-file` envelope correctly: verified with a new end-to-end regression test (`evalrun.run_task` -> `tool_eval.parse_scores`) fed a realistic full-shaped passing document mirroring the real captured `happy_run.json` key set (`schema_version`/`tool_eval_bench_version`/`final_score`/`rating`/`deployability`/`responsiveness`/`total_scenarios`/`run_id`/`status`/`config` incl. `config_fingerprint`/`scores` incl. `category_scores` and `scenario_results`/`metadata`/`safety_gate`/`report_path`) — score survives at `1.0`, not `0.0`.
- Fixed the actual visible bug the issue also flagged: the CLI's per-scenario print line and summary table still printed the retired hand-rolled Hermes-era columns (`got`/`want`/`wall`/`tools`/`tok_out`/`steps`, all empty/None when a record happens to be a `_failed_record`) that tool-eval-bench never produces. Extracted `_format_eval_row()` to print the vocabulary tool-eval-bench actually reports: scenario id, status, points, duration, and the run's `final_score`.
- Threaded `points` and the run-level `final_score` through `adapters/tool_eval.py`'s per-task `metrics` dict so the CLI can read them directly instead of re-deriving from the normalized 0.0–1.0 `score`.

## Root cause (one sentence)
The score/parse wiring was already correct on `main`; the CLI display was still printing retired hand-rolled columns tool-eval-bench doesn't emit, and the raw `score=0.0` CT105 symptom is most plausibly a stale-deploy pip wheel-cache no-op on that box (a known gotcha there) rather than a current source defect — fixed the display regardless and added regression coverage locking the real shape down.

## Test plan
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/bench -p no:cacheprovider -q` — 325 passed
- [x] `ruff check` / `ruff format --check` on touched files — clean
- [x] `mypy src/hal0/bench/{cli,evalrun,adapters/tool_eval}.py` — 16 pre-existing errors, same count as `main` (no new errors introduced)
- [x] `grep -rn legacy src/` on touched files — clean (scar-ratchet)

Closes #1775