### PR TITLE
fix(bench): pin tool-eval-bench's output dir; run it from a neutral cwd

### DIFF
--- a/src/hal0/bench/adapters/tool_eval.py
+++ b/src/hal0/bench/adapters/tool_eval.py
@@ -243,6 +243,11 @@ def build_argv(request: ToolEvalRequest) -> list[str]:
         argv.append("--no-live")
     argv += ["--json", "--json-file", str(request.output_path)]
     argv += list(request.extra_args)
+    # Pin the tool's working data/output dir next to the json file: with no
+    # --output-dir the tool mkdirs ./data relative to the CWD, and a service
+    # CWD the hal0 user cannot write (found on-box 2026-08-09: sudo kept
+    # CWD=/root -> PermissionError before any scenario ran).
+    argv += ["--output-dir", str(Path(request.output_path).parent)]
     return argv
 
 
@@ -270,7 +275,11 @@ def _default_runner(argv: list[str], timeout_s: float) -> tuple[int, str, str]:
     hardened callable with their own process-group watchdog (same rationale
     as ``harness._default_runner``); tests inject a fake that runs neither
     the tool nor a network."""
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+    import tempfile
+
+    proc = subprocess.run(
+        argv, capture_output=True, text=True, timeout=timeout_s, cwd=tempfile.gettempdir()
+    )
     return proc.returncode, proc.stdout, proc.stderr
 
 

--- a/tests/bench/adapters/test_tool_eval.py
+++ b/tests/bench/adapters/test_tool_eval.py
@@ -372,3 +372,18 @@ def test_scoring_eras_are_never_silently_equal() -> None:
     if it broke."""
     assert tool_eval.classify_scoring_era("2.5.0") != tool_eval.classify_scoring_era("2.4.9")
     assert tool_eval.classify_scoring_era("2.5.0") != tool_eval.classify_scoring_era("garbage")
+
+
+def test_argv_pins_output_dir_next_to_the_json_file(tmp_path):
+    """No --output-dir means the tool mkdirs ./data relative to the CWD —
+    which a service CWD may not permit (on-box PermissionError, 2026-08-09)."""
+    req = tool_eval.ToolEvalRequest(
+        python_exe="/usr/bin/python3",
+        base_url="http://127.0.0.1:8080/v1",
+        model="m",
+        output_path=tmp_path / "runs" / "out.json",
+        scenarios=("TC-68",),
+    )
+    argv = tool_eval.build_argv(req)
+    i = argv.index("--output-dir")
+    assert argv[i + 1] == str(tmp_path / "runs")


### PR DESCRIPTION
Without --output-dir the tool mkdirs ./data relative to the CWD, and the
eval path inherits whatever CWD the service or a sudo invocation carries
(/root on the CT105 validation run — PermissionError before any scenario
ran). The argv now pins --output-dir next to the --json-file target and
the default runner executes from the temp dir, same posture as the
guidellm .env fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
