### PR TITLE
refactor(ui): drop the Model row from the Image generation capability panel

### DIFF
--- a/ui/src/dash/settings/pages/capabilities/ImagePanel.jsx
+++ b/ui/src/dash/settings/pages/capabilities/ImagePanel.jsx
@@ -9,7 +9,7 @@ import { useSlots, useSlotEdit, useSlotConfig } from '@/api/hooks/useSlots'
 import { SRow } from '../../shared/SRow.jsx'
 import { ApplyBadge } from '../../shared/ApplyBadge.jsx'
 import { useCapabilitySelection } from './useCapabilitySelection.js'
-import { statusChip, PanelHeader, PanelFooter, EnabledRow, ModelRow, selStyle, inputStyle } from './shared.jsx'
+import { statusChip, PanelHeader, PanelFooter, EnabledRow, selStyle, inputStyle } from './shared.jsx'
 
 const DEF_SIZE = "1024x1024"
 const DEF_STEPS = "0"
@@ -73,9 +73,12 @@ export function ImagePanel({ registry }) {
           <option value="comfyui">comfyui</option>
         </select>
       } />
-      <ModelRow items={sel.catalogItems} value={sel.model} onChange={sel.setModel}
-        placeholder="model id (e.g. sdxl-turbo-fp16)"
-        emptyHint="no capability-tagged image models installed — ComfyUI workflows pick their own checkpoint, so leaving this unset is normal" />
+      {/* No Model row here on purpose: ComfyUI workflows select their own
+          checkpoint per generation, so an img-slot model pick would be dead
+          config. Inventory and workflows live on the ComfyUI pane. */}
+      <SRow k="Checkpoint" sub="selected per-workflow by ComfyUI — manage models and workflows on the ComfyUI pane" v={
+        <a href="#slots/image" className="mono" style={{fontSize: 11, color: "var(--accent)"}}>ComfyUI pane →</a>
+      } />
 
       <div className="s-row" style={{paddingBottom: 4, borderBottom: "1px solid var(--line)"}}>
         <div className="k">

--- a/ui/src/dash/slots.jsx
+++ b/ui/src/dash/slots.jsx
@@ -607,7 +607,7 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   // slots, and is mutually exclusive with the LLM stack — so it gets its own
   // tab instead of a SlotCard in the Image group.
   const [tab, setTab] = useStateS(
-    slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks"
+    slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks" || slotParam === "image"
       ? slotParam
       : "inference",
   );
@@ -659,10 +659,11 @@ function SlotsView({ slotVariant, slotParam, onGo }) {
   }, [slotParam, slots]);
 
   // v0.5 nav: sidebar sub-links #slots/endpoints and #slots/profiles select the
-  // matching tab; navigating back to bare #slots (or a slot-name param) drops
-  // out of a sub-tab back to Inference.
+  // matching tab; #slots/image deep-links the ComfyUI pane (AI Capabilities →
+  // Image generation links here); navigating back to bare #slots (or a
+  // slot-name param) drops out of a sub-tab back to Inference.
   React.useEffect(() => {
-    if (slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks") setTab(slotParam);
+    if (slotParam === "endpoints" || slotParam === "profiles" || slotParam === "stacks" || slotParam === "image") setTab(slotParam);
     else setTab((t) => (t === "endpoints" || t === "profiles" || t === "stacks" ? "inference" : t));
   }, [slotParam]);
 

--- a/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
+++ b/ui/tests/e2e/specs/capability-catalog-pickers-v3.spec.ts
@@ -34,9 +34,10 @@ function capabilityRow(device: string, provider: string, model: string | null, s
 
 // Scopes a `Model` row (`.s-row` with `.k span` text "Model") to the panel
 // whose own title (`.s-panel`'s `.k span`) matches `title` — the AI
-// Capabilities page renders five Model rows (TTS, STT, Embed, Rerank,
-// Image), so a bare index into a page-wide `.s-row` collection is no longer
-// stable; scope by panel instead. Each test builds its own bound
+// Capabilities page renders four Model rows (TTS, STT, Embed, Rerank;
+// Image deliberately has none — ComfyUI workflows pick their own
+// checkpoint), so a bare index into a page-wide `.s-row` collection is no
+// longer stable; scope by panel instead. Each test builds its own bound
 // `panelModelRow` from its `page` fixture, mirroring how the neighbouring
 // panel locators (e.g. `ttsPanel` in voice-page-provider-copy-v3) are
 // built fresh per test.
@@ -124,18 +125,17 @@ test.describe('Capability catalog pickers (#1454)', () => {
     await expect(ttsRow).not.toContainText('no installed TTS models')
   })
 
-  test('Image-gen page: img Model picker renders as <select> populated from the bare-array catalog', async ({ page }) => {
+  test('Image-gen panel has no Model row — checkpoint choice belongs to ComfyUI workflows', async ({ page }) => {
     await page.route('**/api/capabilities', (route) => json(route, CAPS_MOCK))
     await page.goto('/#settings/imagegen')
     await expect(page.locator('.settings-content h2').first()).toHaveText('AI Capabilities')
-    const panelModelRow = makePanelModelRow(page)
 
-    const modelRow = panelModelRow(/^Image generation$/)
-    await expect(modelRow).toHaveCount(1)
-    const select = modelRow.locator('select')
-    await expect(select).toBeVisible()
-    await expect(select.locator('option', { hasText: 'sd-turbo' })).toHaveCount(1)
-    await expect(modelRow).not.toContainText('no installed image models')
+    const panel = page.locator('.s-panel').filter({ has: page.locator('.k span', { hasText: /^Image generation$/ }) })
+    // Engine select must still render before we assert the Model row away
+    // (guards against a blank-panel false pass).
+    await expect(panel.locator('select option', { hasText: 'comfyui' })).toHaveCount(1)
+    await expect(makePanelModelRow(page)(/^Image generation$/)).toHaveCount(0)
+    await expect(panel.locator('a[href="#slots/image"]')).toHaveCount(1)
   })
 
   test('Voice page: empty catalog still shows the honest "no installed" hint (not a false negative)', async ({ page }) => {


### PR DESCRIPTION
## What changed

Follow-up to #1774. The Image generation panel on the AI Capabilities settings page no longer offers a model pick at all — ComfyUI workflows select their own checkpoint per generation, so an img-slot model id was dead config (the img catalog is legitimately empty on a healthy install, leaving a confusing free-text field). In its place:

- A **Checkpoint** row stating checkpoints are selected per-workflow by ComfyUI, linking to the ComfyUI pane.
- `#slots/image` now deep-links the Slots view's Image Gen (ComfyUI) tab — previously only `endpoints`/`profiles`/`stacks` had sub-links, so there was no direct route to land that pointer on.

Enabled toggle, Engine (provider) select, and the `[image]` generation defaults (size/steps/idle-restore) stay as they were.

## Verification

- Browser-verified on the live dev server: panel renders Enabled/Engine/Checkpoint/defaults with no Model row; the Checkpoint link navigates to `#slots/image` with the ComfyUI tab active.
- `npm run lint`, `npm run test:unit` (121 passed), `capability-catalog-pickers-v3.spec.ts` e2e (7 passed — img spec rewritten to assert the row's absence plus the deep link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)