### PR TITLE
refactor(ui): icon-only service-restart apply badge with hover detail

### DIFF
--- a/ui/src/dash/settings/shared/ApplyBadge.jsx
+++ b/ui/src/dash/settings/shared/ApplyBadge.jsx
@@ -8,7 +8,10 @@
 //
 // Badge legend:
 //   immediate       → green "live"
-//   service-restart → amber "⟳ restart <service>"
+//   service-restart → amber "⟳" icon only — the affected service is in the
+//                     hover title ("Requires restarting <service>…"), not the
+//                     chip text (operator request: the repeated "restart
+//                     hal0-api" label was visual noise on dense pages)
 //   manual-restart  → red "⚠ manual restart"
 //
 // Extracted verbatim from settings.jsx (P3-ui split, phase 1) — no
@@ -34,8 +37,9 @@ export function ApplyBadge({ settingsKey, registry }) {
       className="chip"
       style={{
         fontFamily: "var(--jbm)",
-        fontSize: 10,
-        padding: "2px 8px",
+        fontSize: isServiceRestart ? 13 : 10,
+        lineHeight: isServiceRestart ? 1 : undefined,
+        padding: isServiceRestart ? "2px 6px" : "2px 8px",
         whiteSpace: "nowrap",
         color: isImmediate ? "var(--ok)" : isServiceRestart ? "var(--warn)" : "var(--err)",
         borderColor: isImmediate ? "var(--ok)" : isServiceRestart ? "var(--warn)" : "var(--err)",
@@ -54,7 +58,7 @@ export function ApplyBadge({ settingsKey, registry }) {
       }
     >
       {isImmediate && "live"}
-      {isServiceRestart && (svc ? `⟳ restart ${svc}` : "⟳ restart")}
+      {isServiceRestart && "⟳"}
       {isManualRestart && "⚠ manual restart"}
     </span>
   );

--- a/ui/src/dash/settings/shared/RestartApiPanel.jsx
+++ b/ui/src/dash/settings/shared/RestartApiPanel.jsx
@@ -67,7 +67,7 @@ export function RestartApiPanel() {
     <div className="s-panel">
       <SRow
         k="hal0-api service"
-        sub="Control plane · dashboard, slot manager, /v1 proxy. Restart to apply settings marked ⟳ restart hal0-api or ⚠ manual restart."
+        sub="Control plane · dashboard, slot manager, /v1 proxy. Restart to apply settings marked with the amber ⟳ badge or ⚠ manual restart."
         v={waiting
           ? <span className="mono" style={{color: "var(--warn)", fontSize: 11}}>restarting — waiting for /api/health…</span>
           : <span className="mono" style={{color: "var(--fg-3)", fontSize: 11}}>running</span>}


### PR DESCRIPTION
## What changed

Operator request: the amber "⟳ restart hal0-api" chip repeated on every service-restart settings row (settings pages, edit drawers) was visual noise. The service-restart apply badge now renders only the ⟳ icon, slightly larger (13px vs the chip's 10px text), with the full explanation on hover via the existing `title` ("Requires restarting hal0-api to take effect").

`ApplyBadge.jsx` is the single renderer for this chip across all settings surfaces, so one edit covers every instance. The `RestartApiPanel` helper copy that named the old chip text now says "marked with the amber ⟳ badge". The green "live" and red "⚠ manual restart" badges are unchanged.

## Verification

- `npm run lint`, `npm run test:unit` (121 passed), full Playwright e2e suite (632 passed, 17 skipped) — no spec pinned the old chip text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)