### PR TITLE
feat(ui): memory reranker model picker with builtin + rerank catalog options

### DIFF
--- a/ui/src/dash/settings/pages/data/MemoryPage.jsx
+++ b/ui/src/dash/settings/pages/data/MemoryPage.jsx
@@ -5,6 +5,7 @@
 // #settings/memory deep links keep working.
 import { useState, useEffect } from 'react'
 import { useSettingsClient } from '../../data/settingsClient.js'
+import { useCapabilities } from '@/api/hooks/useCapabilities'
 import { useMemoryGraphStatus, useRetryFailedExtractions, useUpdateMemoryGraph } from '@/api/hooks/useMemory'
 import { ApplyBadge } from '../../shared/ApplyBadge.jsx'
 import { SRow } from '../../shared/SRow.jsx'
@@ -94,14 +95,38 @@ function MemoryRerankerPanel({ registry }) {
   const schema = schemaQuery.data || null;
   const live = settings.data || null;
 
+  const RERANK_MODEL_KEY = "memory.embedding.rerank_model";
   const RERANK_KEYS = [
     "memory.embedding.rerank_gateway_url",
-    "memory.embedding.rerank_model",
+    RERANK_MODEL_KEY,
     "memory.embedding.rerank_connect_timeout_s",
     "memory.embedding.rerank_read_timeout_s",
   ];
   const fields = {};
   for (const k of RERANK_KEYS) fields[k] = _schemaField(schema, k);
+
+  // rerank_model picker: the builtin (schema default, served without a rerank
+  // slot) plus every capability-tagged rerank model from the embed.rerank
+  // catalog, annotated with its gpu/npu backends. A saved id outside both
+  // stays pickable as "(saved)" so the operator can see and move off it.
+  // Free text is not offered — an id the gateway can't resolve just makes
+  // Hal0Reranker fail-soft to fused vector ordering on every recall.
+  const capsQuery = useCapabilities();
+  const rerankCatalog = capsQuery.data?.catalogs?.embed?.rerank || [];
+  const builtinModel = fields[RERANK_MODEL_KEY]?.default || "builtin.jina-reranker-v1-tiny-en-q8";
+  const savedModel = _getIn(live, RERANK_MODEL_KEY);
+  const modelOptions = [
+    { value: builtinModel, label: `${builtinModel} · builtin (default)` },
+    ...rerankCatalog
+      .filter(m => m.id && m.id !== builtinModel)
+      .map(m => {
+        const backends = [...new Set((m.backends || []).map(b => String(b.id || "")).filter(Boolean))];
+        return { value: m.id, label: backends.length ? `${m.id} · ${backends.join(" / ")}` : m.id };
+      }),
+  ];
+  if (savedModel && !modelOptions.some(o => o.value === savedModel)) {
+    modelOptions.unshift({ value: savedModel, label: `${savedModel} (saved)` });
+  }
 
   const [buf, setBuf] = useState({});
   const onChange = (dotKey, value) => setBuf(b => ({ ...b, [dotKey]: value }));
@@ -147,6 +172,7 @@ function MemoryRerankerPanel({ registry }) {
           buf={buf[k]}
           onChange={onChange}
           registry={registry}
+          options={k === RERANK_MODEL_KEY ? modelOptions : undefined}
         />
       ))}
       <div style={{display: "flex", justifyContent: "flex-end", gap: 8, padding: "8px 12px 4px"}}>

--- a/ui/src/dash/settings/shared/SchemaRow.jsx
+++ b/ui/src/dash/settings/shared/SchemaRow.jsx
@@ -88,6 +88,9 @@ export const _advInputStyle = {
 // `options` lets a page override enum choices per-key (e.g. memory.engine's
 // validator also accepts "cognee"/"mem0", which the factory silently maps to
 // hindsight — offering them would lie, so the page passes its own allowlist).
+// Entries are plain strings, or `{value, label}` objects when the display
+// text should differ from the persisted value (e.g. the memory reranker's
+// model picker annotating catalog rows with their gpu/npu backends).
 // `descriptions` lets a page override a stale/missing schema description.
 // The description goes to SRow whole — the info popup wraps and caps its own
 // width, so truncating here only ever dropped the tail of a deliberate
@@ -111,7 +114,11 @@ export function AdvRow({ dotKey, field, live, buf, onChange, registry, label: la
   } else if (options) {
     control = (
       <select value={current} onChange={e => onChange(dotKey, e.target.value)} style={_advInputStyle}>
-        {options.map(o => <option key={o} value={o}>{o}</option>)}
+        {options.map(o => {
+          const v = typeof o === "object" && o != null ? o.value : o;
+          const l = typeof o === "object" && o != null ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
       </select>
     );
   } else if (isNum) {

--- a/ui/tests/e2e/specs/memory-rerank-model-picker-v3.spec.ts
+++ b/ui/tests/e2e/specs/memory-rerank-model-picker-v3.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * memory-rerank-model-picker-v3 — Settings → Memory → Reranker.
+ *
+ * `memory.embedding.rerank_model` renders as a dropdown, not free text:
+ * the builtin (schema default, served without a rerank slot) plus every
+ * capability-tagged rerank model from the `catalogs.embed.rerank` catalog,
+ * each annotated with its gpu/npu backends. A saved id outside both stays
+ * pickable as "(saved)". Free text is not offered — an id the gateway
+ * can't resolve makes Hal0Reranker fail-soft to fused vector ordering on
+ * every recall, silently.
+ */
+import { test, expect, json } from '../fixtures/apiMock'
+
+const BUILTIN = 'builtin.jina-reranker-v1-tiny-en-q8'
+
+const CAPS_MOCK = {
+  backends: [],
+  catalogs: {
+    embed: {
+      embed: [],
+      rerank: [
+        {
+          id: 'bge-reranker-v2-m3',
+          capabilities: ['rerank'],
+          size_gb: 0.56,
+          backends: [
+            { id: 'gpu-rocm', provider: 'llama-server', downloaded: true, pullable: true },
+            { id: 'npu', provider: 'flm', downloaded: true, pullable: true },
+          ],
+        },
+      ],
+    },
+    voice: { stt: [], tts: [] },
+    img: { img: [] },
+  },
+  selections: { embed: {}, voice: {}, img: {} },
+}
+
+test.describe('Memory reranker model picker', () => {
+  test('rerank_model is a dropdown: builtin default + backend-annotated catalog rows', async ({ page }) => {
+    await page.route('**/api/capabilities', (route) => json(route, CAPS_MOCK))
+    await page.goto('/#settings/memory')
+
+    const row = page.locator('.s-row')
+      .filter({ has: page.locator('.k span', { hasText: /^embedding\.rerank_model$/ }) })
+    const select = row.locator('select')
+    await expect(select).toBeVisible()
+    await expect(select.locator(`option[value="${BUILTIN}"]`)).toHaveText(`${BUILTIN} · builtin (default)`)
+    await expect(select.locator('option[value="bge-reranker-v2-m3"]')).toHaveText('bge-reranker-v2-m3 · gpu-rocm / npu')
+    // No free-text fallback for this key.
+    await expect(row.locator('input[type="text"], input:not([type])')).toHaveCount(0)
+  })
+
+  test('picking a catalog model dirties the panel and lights Save reranker', async ({ page }) => {
+    await page.route('**/api/capabilities', (route) => json(route, CAPS_MOCK))
+    await page.goto('/#settings/memory')
+
+    const row = page.locator('.s-row')
+      .filter({ has: page.locator('.k span', { hasText: /^embedding\.rerank_model$/ }) })
+    const save = page.getByRole('button', { name: 'Save reranker' })
+    await expect(row.locator('select')).toBeVisible()
+    await expect(save).toBeDisabled()
+    await row.locator('select').selectOption('bge-reranker-v2-m3')
+    await expect(save).toBeEnabled()
+  })
+})


### PR DESCRIPTION
## What changed

Settings → Memory → Reranker: `embedding.rerank_model` is now a dropdown instead of free text:

- **builtin.jina-reranker-v1-tiny-en-q8 · builtin (default)** — the schema default, served without a rerank slot.
- Every capability-tagged rerank model from the `catalogs.embed.rerank` catalog (GET /api/capabilities), annotated with the backends it runs on (e.g. `bge-reranker-v2-m3-q4_k_m · gpu-vulkan / gpu-rocm / cpu`; NPU-backed rows annotate `npu` automatically).
- A saved id outside both lists stays pickable as `<id> (saved)` so the operator can see and move off a stale value.

Free text is deliberately gone for this key: a typo'd id never errors — `Hal0Reranker` fail-softs to fused vector ordering on every recall, silently.

`AdvRow`'s per-key `options` override now accepts `{value, label}` entries alongside plain strings (backward compatible) to carry the backend annotations.

## Verification

- Browser-verified against the live CT105 API: dropdown renders builtin (selected) + both catalog rerankers with backend annotations; picking one enables Save reranker.
- `npm run lint`, `npm run test:unit` (121 passed), new `memory-rerank-model-picker-v3.spec.ts` e2e (2 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)