### PR TITLE
fix(ui): stack the NPU tile owner tags so names never wrap or truncate

### DIFF
--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -1763,9 +1763,14 @@
   text-transform: uppercase;
   color: var(--fg-5);
 }
+/* Owner tags stack vertically so each name ("stt-npu", "embed-npu") gets a
+   full single line instead of wrapping/truncating in the inline row. */
 .th-tags {
   display: flex;
-  gap: 5px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 3px;
+  min-width: 0;
 }
 .th-tag {
   display: inline-flex;
@@ -1777,6 +1782,7 @@
   border-radius: 3px;
   font-family: var(--jbm);
   font-size: 10px;
+  white-space: nowrap;
 }
 .th-tag .sw {
   width: 7px;

--- a/ui/src/dash/overhaul.css
+++ b/ui/src/dash/overhaul.css
@@ -1641,6 +1641,10 @@
 }
 .th-digits.c3 { grid-template-columns: repeat(3, 1fr); }
 .th-digits.c2 { grid-template-columns: repeat(2, 1fr); }
+/* A tall neighbour (the NPU tile's stacked owner tags) must not float the
+   other digits to the top of the stretched row — keep values baseline-low,
+   where they sat when every cell was one line high. */
+.th-digits > .th-digit { align-self: end; }
 .th-digit .v {
   font-family: var(--jbm);
   font-size: 22px;


### PR DESCRIPTION
The telemetry-header NPU tile rendered its owner tags inline, so `stt-npu` wrapped to two lines and `embed-npu` clipped at the tile edge (operator screenshot). Tags now stack in a column at full width — one name per line, `white-space: nowrap`.

Verified with a live headless-browser screenshot on the dev server: three occupied owner tags render cleanly, tile spacing intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)