### PR TITLE
fix(installer): brain steward tool-call copy reflects native tool-calling

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1901,8 +1901,8 @@ fi
 #
 # The AGENT anchor offer below shares this step (no extra ui_step banner, so
 # UI_STEP_TOTAL is unchanged) because it is the second half of one story: the
-# brain pull makes steward CHAT work; the agent pull is what makes steward
-# TOOL CALLS work.
+# brain pull makes the steward work out of the box (chat AND native tool
+# calls); the agent pull adds the bigger fallback tool-caller.
 ui_step "Steward + agent models"
 
 if [[ "${DEV_MODE}" -eq 1 ]]; then
@@ -1916,16 +1916,18 @@ else
 fi
 
 # ── agent anchor model — OPT-IN, size disclosed, default SKIP ───────────────
-# Measured on a GPU box: the 1B brain model does NOT emit tool calls. Given the
-# `hal0-function-xml` contract and an explicit tool request it reasons and
-# returns an empty `content` with no function block — exactly what
-# installer/etc-hal0/slots/brain.toml predicts. Tool turns are therefore routed
-# to `[brain_chat] tool_model`, whose code default is "hal0/agent"
-# (src/hal0/config/schema.py). But agent.toml ships model-less on purpose
-# (#1369: model-presence is the activation signal), so on a fresh box brain
-# tool calling is DEAD until someone binds an agent model.
+# As of runner ade07ba (DEFAULT_ROCMFPX_IMAGE) the brain models are NATIVE
+# tool-callers — the steward executes its own calls on the brain slot
+# (installer/etc-hal0/slots/brain.toml, verified live on the SFT quants and
+# the MiniCPM5 base). The `[brain_chat] tool_model` reroute, code default
+# "hal0/agent" (src/hal0/config/schema.py), remains as the FALLBACK: it
+# catches artefact rounds and covers older runner images or off-dialect
+# models. agent.toml still ships model-less on purpose (#1369: model-presence
+# is the activation signal), so on a fresh box that fallback has no live
+# target — and a bound agent model is also simply a much bigger tool-caller
+# than the ~1B brain.
 #
-# That is what this offer fixes — and the shape of the offer is the whole
+# That is what this offer provides — and the shape of the offer is the whole
 # point. Unlike the brain pull (unconditional, ~1-2 GB) the anchor is 15-31 GB,
 # so:
 #
@@ -1954,7 +1956,7 @@ if [[ "${DEV_MODE}" -eq 1 ]]; then
     :  # dev mode writes nothing to the system store — no offer, no notice
 elif [[ "${HAL0_SKIP_SETUP:-0}" == "1" || "${HAL0_PULL_AGENT_MODEL:-}" == "0" ]]; then
     info "Skipping the agent model (HAL0_SKIP_SETUP/HAL0_PULL_AGENT_MODEL=0 set)."
-    info "brain chat works, but TOOL CALLS need an agent model bound to the agent slot ([brain_chat] tool_model, default hal0/agent)."
+    info "The brain steward chats and calls tools on its own; an agent model is the optional bigger tool-caller behind the [brain_chat] tool_model fallback (default hal0/agent)."
 else
     # `|| true`: a plan that cannot be computed is simply no offer. Never fatal.
     _agent_plan="$(HAL0_AGENT_MODEL="${HAL0_AGENT_MODEL:-}" \
@@ -1970,7 +1972,7 @@ else
             _agent_wanted=1
         elif _interactive; then
             printf '\n' >/dev/tty 2>/dev/null || true
-            info "The brain steward can chat now, but it cannot CALL TOOLS on its own — it routes tool turns to the agent slot, which has no model yet."
+            info "The brain steward chats and calls tools on its own. An agent model adds a bigger tool-caller and gives the [brain_chat] tool_model fallback (default hal0/agent) a live target."
             info "Optional download: ${_agent_desc}"
             _tty_read _agent_answer "Download the agent model now? [y/N]" "n"
             case "${_agent_answer}" in
@@ -1993,8 +1995,8 @@ else
         fi
     fi
     if [[ "${_agent_wanted}" -ne 1 ]]; then
-        info "brain chat works, but TOOL CALLS need an agent model: the steward routes tool turns to [brain_chat] tool_model (default hal0/agent) and the agent slot has no model bound."
-        info "Assign one from the dashboard, or 'hal0 model pull <id> && hal0 slot load agent', whenever you like."
+        info "The brain steward keeps chatting and calling tools on its own; the [brain_chat] tool_model fallback (default hal0/agent) just has no live target until an agent model is bound."
+        info "Bind one from the dashboard, or 'hal0 model pull <id> && hal0 slot load agent --model <id>', whenever you like."
     fi
 fi
 

--- a/src/hal0/install/agent_model.py
+++ b/src/hal0/install/agent_model.py
@@ -1,21 +1,23 @@
 """Install-time OPT-IN provisioning of the `agent` anchor model (v1.0).
 
-Why this exists — the tool-calling gap it closes
-------------------------------------------------
-:mod:`hal0.install.brain_model` makes the steward chat work out of the box.
-It does not make the steward's TOOLS work. Measured directly on a GPU box:
-given the ``hal0-function-xml`` contract and an explicit tool request, the
-1.08B brain model reasons and returns an EMPTY ``content`` with no function
-block — exactly what ``installer/etc-hal0/slots/brain.toml`` predicts ("on the
-FPX brain runtime a 1B can't emit tool calls the native parser accepts"). The
-documented remedy is ``[brain_chat] tool_model`` (:class:`~hal0.config.schema.
-BrainChatConfig`), whose default is ``"hal0/agent"``.
+Why this exists — the fallback gap it closes
+--------------------------------------------
+:mod:`hal0.install.brain_model` makes the steward work out of the box: as of
+runner ade07ba (``DEFAULT_ROCMFPX_IMAGE``) the brain models are NATIVE
+tool-callers, so the steward chats AND executes its own calls on the brain
+slot (``installer/etc-hal0/slots/brain.toml``, verified live on the SFT
+quants and the MiniCPM5 base). The ``[brain_chat] tool_model`` reroute
+(:class:`~hal0.config.schema.BrainChatConfig`, default ``"hal0/agent"``)
+remains as the FALLBACK: it catches artefact rounds and covers older runner
+images or off-dialect models — and a bound agent model is also simply a much
+bigger tool-caller than the ~1B brain.
 
 But ``installer/etc-hal0/slots/agent.toml`` ships WITHOUT a ``[model].default``
 — deliberately, per spec-p3-brain §5b/5c: model-presence is the activation
 signal (#1369) and a surprise 20 GB download during a platform install is not
-acceptable. So on a fresh box the tool-routing target resolves to a slot with
-no model, and brain tool calling is dead until an operator picks something.
+acceptable. So on a fresh box the fallback resolves to a slot with no model:
+the steward still tool-calls, but without a net and without the quality
+upgrade, until an operator picks something.
 
 This module is the bridge, and the shape of it is the whole point:
 
@@ -69,10 +71,11 @@ AGENT_MODEL_IDS = (AGENT_MODEL_QUALITY, AGENT_MODEL_ANCHOR, AGENT_MODEL_LEAN)
 #: skipped, headless, no fitting rung, or a failed pull. The one thing an
 #: operator must not have to discover from a silent empty reply.
 SKIP_NOTICE = (
-    "brain chat works, but TOOL CALLS need an agent model: the steward routes "
-    "tool turns to [brain_chat] tool_model (default hal0/agent) and the agent "
-    "slot has no model bound. Assign one from the dashboard, or run "
-    "'hal0 model pull <id> && hal0 slot load agent', whenever you like."
+    "the brain steward chats and calls tools on its own; the [brain_chat] "
+    "tool_model fallback (default hal0/agent) has no live target until an "
+    "agent model is bound to the agent slot. Bind one from the dashboard, or "
+    "run 'hal0 model pull <id> && hal0 slot load agent --model <id>', "
+    "whenever you like."
 )
 
 

--- a/tests/installer/test_install_single_entry_point.py
+++ b/tests/installer/test_install_single_entry_point.py
@@ -342,12 +342,14 @@ def test_a_declined_or_failed_agent_pull_still_succeeds(agent_block: str) -> Non
     assert 'if [[ "${_agent_wanted}" -ne 1 ]]; then' in agent_block
 
 
-def test_the_skip_path_explains_what_tool_calls_now_need(agent_block: str) -> None:
-    """A blank tool call must never be a mystery: skipping has to say that brain
-    CHAT works, tool calls do not, and which setting points where."""
+def test_the_skip_path_explains_the_tool_model_fallback(agent_block: str) -> None:
+    """Skipping the agent pull must never read as a degraded install: the brain
+    is a native tool-caller (runner ade07ba), so the notice has to say the
+    steward chats AND calls tools on its own, and name the fallback setting
+    that stays targetless until an agent model is bound."""
     assert "tool_model" in agent_block
     assert "hal0/agent" in agent_block
-    assert "chat works" in agent_block
+    assert "calls tools on its own" in agent_block
 
 
 def test_agent_model_env_overrides_are_wired(install_sh_text: str) -> None:


### PR DESCRIPTION
## What changed

The installer's "Steward + agent models" step still told operators the brain "cannot CALL TOOLS on its own" and that tool calls require binding an agent model. That has been false since runner ade07ba: the brain models are native tool-callers (llama.cpp's MiniCPM5 parser preserves the vocab's tool-syntax control tokens and grammar-locks the call shape), so the steward executes its own calls on the brain slot. Verified against `installer/etc-hal0/slots/brain.toml` and `src/hal0/brain/chat.py` (reroute fires only on artefact rounds).

- Reworded the interactive lead-in, the env-skip notice, the post-skip notice (`installer/install.sh`) and `SKIP_NOTICE` (`src/hal0/install/agent_model.py`): brain chats **and** tool-calls out of the box; the agent model is the optional bigger tool-caller behind the `[brain_chat] tool_model` fallback (default `hal0/agent`).
- Rewrote the stale comment blocks ("1B does NOT emit tool calls", "tool calling is DEAD") and the module docstring to the same framing.
- Fixed a functionally broken CLI hint: `hal0 model pull <id> && hal0 slot load agent` — pull registers but never binds, and a bare `slot load` on the model-less agent slot bails to OFFLINE with a pick-a-model CTA (`SlotManager.load`, manager.py:1543). Now reads `hal0 slot load agent --model <id>`.

## Verification

- `bash -n installer/install.sh` clean
- `tests/install/test_agent_model.py` — 29 passed
- `ruff format --check` / `ruff check` clean on the touched Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)