### PR TITLE
fix(installer): correct FLM distro claims and derive agent-floor GB from the ladder

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -1961,7 +1961,14 @@ else
         "${VENV_DIR}/bin/python" -m hal0.install.agent_model --plan 2>/dev/null || true)"
     _agent_plan="${_agent_plan%%$'\n'*}"
     if [[ -z "${_agent_plan}" || "${_agent_plan}" != *$'\t'* ]]; then
-        info "No agent model fits this box (a ROCm/Vulkan device and ~15 GB of pool are the floor) — not offering one."
+        # Floor comes from the curated ladder itself (`--floor` reads the
+        # smallest rung's vram_gb_min — catalogue only, no hardware probe), so
+        # this notice can't drift from `_smallest_rung_gb()` the way a bash
+        # literal would. `|| true` + regex guard: a broken venv still prints
+        # a sane fallback instead of aborting under `set -euo pipefail`.
+        _agent_floor="$("${VENV_DIR}/bin/python" -m hal0.install.agent_model --floor 2>/dev/null || true)"
+        [[ "${_agent_floor}" =~ ^[0-9]+$ ]] || _agent_floor=15
+        info "No agent model fits this box (a ROCm/Vulkan device and ~${_agent_floor} GB of pool are the floor) — not offering one."
     else
         _agent_id="${_agent_plan%%$'\t'*}"
         _agent_desc="${_agent_plan#*$'\t'}"
@@ -2075,13 +2082,13 @@ if [[ "${DEV_MODE}" -eq 1 ]]; then
     info "          install manually if exercising NPU paths: see installer/README.md"
 elif ! command -v apt-get >/dev/null 2>&1; then
     # Non-Debian host (Fedora, Arch/CachyOS, openSUSE…). FastFlowLM upstream
-    # ships only an Ubuntu .deb + a Windows .msi — there is no dnf/pacman/
+    # ships Debian/Ubuntu .debs + a Windows .msi — there is no dnf/pacman/
     # zypper artefact and the libxrt-npu2 runtime is Debian-packaged too — so
     # the NPU prereqs genuinely can't be auto-installed here. This is an
     # upstream packaging limit, not a hal0 one: GPU (Vulkan/ROCm) and CPU
     # paths are fully supported on this distro; only the NPU/FLM trio waits
     # on a manual FastFlowLM install. Surface it honestly and keep going.
-    warn "$(distro_pretty): skipping NPU prereqs — FastFlowLM ships an Ubuntu .deb only (upstream)"
+    warn "$(distro_pretty): skipping NPU prereqs — FastFlowLM ships Debian/Ubuntu .debs only (no dnf/pacman/zypper artefact upstream)"
     warn "  GPU (Vulkan/ROCm) + CPU paths work normally; NPU/FLM slots stay disabled until you install"
     warn "  FastFlowLM ${FLM_DEB_VERSION} manually (see installer/README.md). 'flm validate' gates the NPU trio."
 else

--- a/src/hal0/install/agent_model.py
+++ b/src/hal0/install/agent_model.py
@@ -237,12 +237,15 @@ def _load_hardware() -> HardwareInfo:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """``python -m hal0.install.agent_model [--plan]`` — install.sh entry point.
+    """``python -m hal0.install.agent_model [--plan|--floor]`` — install.sh entry point.
 
     ``--plan`` is the *offer* half: it prints one ``id\\tsentence`` line (or
     nothing) and exits 0 without touching the network. install.sh turns that
-    into the consent prompt. No arguments is the *pull* half, run only after
-    the operator said yes.
+    into the consent prompt. ``--floor`` prints the smallest curated rung's
+    ``vram_gb_min`` as a bare integer (no hardware probe — catalogue only), so
+    the "no agent model fits this box" notice can quote the real floor instead
+    of a bash-side literal that drifts from the ladder. No arguments is the
+    *pull* half, run only after the operator said yes.
 
     NEVER raises: install.sh runs under ``set -euo pipefail`` and a traceback
     escaping here would abort a whole install over an optional model.
@@ -251,6 +254,10 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.WARNING, format="  %(message)s")
     override = (os.environ.get("HAL0_AGENT_MODEL") or "").strip() or None
     hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN") or None
+
+    if "--floor" in argv:
+        print(f"{_smallest_rung_gb():.0f}")
+        return 0
 
     if "--plan" in argv:
         try:

--- a/tests/install/test_agent_model.py
+++ b/tests/install/test_agent_model.py
@@ -298,6 +298,31 @@ def test_plan_exits_zero_even_when_the_probe_explodes(monkeypatch: pytest.Monkey
     assert main(["--plan"]) == 0
 
 
+def test_floor_prints_the_smallest_rungs_vram_floor_as_a_bare_int(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """install.sh's "no agent model fits this box" notice interpolates this
+    figure instead of hardcoding a GB number — it must match the curated
+    ladder's actual smallest rung, not drift from it."""
+    import hal0.install.agent_model as am
+
+    assert main(["--floor"]) == 0
+    out = capsys.readouterr().out
+    assert out == f"{am._smallest_rung_gb():.0f}\n"
+
+
+def test_floor_never_touches_hardware(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--floor`` reads the catalogue only — no hardware probe, so it stays
+    correct even when hardware.json is missing or unreadable."""
+    import hal0.install.agent_model as am
+
+    def _boom() -> None:
+        raise AssertionError("--floor must never probe hardware")
+
+    monkeypatch.setattr(am, "_load_hardware", _boom)
+    assert main(["--floor"]) == 0
+
+
 def test_main_returns_nonzero_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
     import hal0.install.agent_model as am
 


### PR DESCRIPTION
## Summary
- FastFlowLM upstream now ships a per-distro .deb (ubuntu24.04, ubuntu25.10, ubuntu26.04, debian13 — each SHA-256 pinned, see `_flm_sha_for_suffix` and the `case "$(distro_id)"` resolution in `installer/install.sh`), but two spots still claimed "Ubuntu .deb only" — contradicted by the script's own logic a few lines above:
  - The non-apt-branch warn now reads: `"$(distro_pretty): skipping NPU prereqs — FastFlowLM ships Debian/Ubuntu .debs only (no dnf/pacman/zypper artefact upstream)"`
  - The preceding comment now says "ships Debian/Ubuntu .debs + a Windows .msi" (was "only an Ubuntu .deb + a Windows .msi").
- The "no agent model fits this box" notice hardcoded `~15 GB` in bash while Python already computes the real floor from the curated ladder (`_smallest_rung_gb()` in `src/hal0/install/agent_model.py`). Added a `--floor` CLI mode (catalogue-only, no hardware probe) that prints the floor as a bare integer; `install.sh` now fetches it before printing the notice, falling back to the literal `15` if the venv/python call fails, so the surrounding comment's promise — "Bash never hardcodes a GB number" — actually holds.

## Why
Both fixes correct installer-facing copy that had drifted from the code driving it, which is misleading to operators reading the warnings/notices during install.

## How verified
```
bash -n installer/install.sh
uv run ruff format --check src/hal0/install/agent_model.py tests/install/test_agent_model.py
uv run ruff check src/hal0/install/agent_model.py tests/install/test_agent_model.py
HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/install/test_agent_model.py -q
```
All pass: `2 files already formatted`, `All checks passed!`, `31 passed`. Added two new tests: `test_floor_prints_the_smallest_rungs_vram_floor_as_a_bare_int` and `test_floor_never_touches_hardware`.

`installer/README.md` is untouched (owned by another in-flight PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)