### PR TITLE
fix(installer): surface real smoke_tests failures instead of a silent ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ breaking/migrations as callouts — from the cosign-verified tarball, before
 applying. Add those subsections to a version's section to surface them; see
 `scripts/gen_release_notes.py`.
 
+## [Unreleased]
+
+### Fixed
+
+- Hermes provision's `smoke_tests` phase now reports `warn` (not a silent
+  `ok`) when any probe records a real failure — `hal0 agent status` and its
+  `--json` surface a dedicated failure/skipped count instead of burying it
+  in the Detail JSON blob. It still never fails the overall install: smoke
+  stays diagnostic. The `chat_completions` and `memory_roundtrip` probes now
+  preflight whether a chat-capable model is actually routable
+  (`model.default` in `config.yaml` cross-checked against the live gateway
+  model list) and report `skipped: no chat model loaded` instead of burning
+  their timeout on a doomed request — install-time smoke runs before any
+  model has ever been loaded, so those two probes were guaranteed to "fail"
+  for a reason that was never a real regression. (#1793)
+
 ## [1.0.0-rc.4] — 2026-08-09
 
 ### Highlights

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -70,7 +70,12 @@ _STATE_FILE_NAME = "provision.json"
 class PhaseStatus(StrEnum):
     """Per-step outcome.
 
-    ``ok``   — step completed.
+    ``ok``   — step completed cleanly.
+    ``warn`` — step completed but recorded non-fatal failures the operator
+               should see (e.g. smoke_tests with one or more failed probes).
+               Does NOT fail the overall install (:attr:`InstallReport.ok`
+               only looks at ``fail``) — a warn phase converged, it just has
+               something worth surfacing (#1793).
     ``skip`` — step didn't apply for this env (e.g. voice_wire with no slots).
     ``fail`` — step ran and failed.
 
@@ -78,6 +83,7 @@ class PhaseStatus(StrEnum):
     """
 
     OK = "ok"
+    WARN = "warn"
     SKIP = "skip"
     FAIL = "fail"
 
@@ -4504,9 +4510,19 @@ def _phase_voice_wire(ctx: _StepCtx) -> PhaseResult:
 # `passed: bool` row into PhaseResult.details["results"]; failures
 # also carry a remediation hint operators can paste at the user.
 #
-# The phase status is OK even with failures — smoke_tests are
-# diagnostic, not gating. self_report surfaces the rollup in the
-# bootstrap-completion memory item.
+# The phase never FAILS the install over a smoke miss — smoke_tests are
+# diagnostic, not gating — but a phase carrying real failures must not
+# report itself ``ok`` either (#1793): the phase status is ``warn`` when
+# any probe fails, so `hal0 agent status` / the API surface it instead of
+# burying it in the Detail column. self_report surfaces the same rollup in
+# the bootstrap-completion memory item.
+#
+# chat_completions and memory_roundtrip both need a routable chat model to
+# mean anything; at install time — before any model has ever been loaded —
+# that's structurally impossible, so a preflight (`_chat_model_ready`)
+# decides ONCE whether the route is live and both probes report
+# `skipped: no chat model loaded` instead of burning their timeout on a
+# doomed request that then gets recorded as an opaque failure.
 
 
 def _wrapper_bin() -> Path:
@@ -4682,9 +4698,55 @@ def _smoke_hermes_doctor(_state: BootstrapState, io: InstallIO) -> tuple[bool, s
     return (result.returncode == 0, f"rc={result.returncode}")
 
 
+#: Probes that only mean something once a chat-capable model is actually
+#: routable. Gated behind :func:`_chat_model_ready` so an install-time smoke
+#: run (no model has ever been loaded yet) reports `skipped`, not a timeout.
+_MODEL_DEPENDENT_PROBES = frozenset({"chat_completions", "memory_roundtrip"})
+
+
+def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
+    """Cheap preflight: is a chat-capable model actually routable right now?
+
+    Reads ``model.default`` from config.yaml — the exact field
+    :func:`_smoke_chat_completions` targets — and cross-checks it against the
+    live gateway model list via ``io.fetch_model_contexts`` (the same
+    ``/v1/models`` seam ``model_automap`` already uses), instead of paying a
+    full chat-completion round trip just to find out nothing is loaded. This
+    is what lets smoke_tests tell "the route is genuinely broken" (a real
+    failure) apart from "no chat model exists yet" (#1793) — never raises;
+    any config/parse/network problem reports not-ready with the reason.
+    """
+    import yaml  # type: ignore[import-untyped]
+
+    config_path = Path(state.hermes_home) / "config.yaml"
+    if not config_path.exists():
+        return False, "config.yaml missing"
+    try:
+        cfg = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return False, f"config parse: {exc}"
+    model_name = (cfg.get("model") or {}).get("default", "")
+    if not model_name:
+        return False, "model.default unset in config.yaml"
+    try:
+        contexts = io.fetch_model_contexts()
+    except Exception as exc:  # preflight must never raise
+        return False, f"gateway probe failed: {exc}"
+    if model_name not in contexts:
+        return False, f"'{model_name}' not loaded on the gateway"
+    return True, "ready"
+
+
 def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
-    """Run six diagnostic probes; collect results into the checkpoint."""
+    """Run six diagnostic probes; collect results into the checkpoint.
+
+    ``status`` is ``warn`` (not ``ok``) when any probe genuinely fails — a
+    phase that recorded failures must say so, not report a clean ``ok`` with
+    the failures buried in ``details`` (#1793). It never becomes ``fail``:
+    smoke_tests stays diagnostic, so the overall install still succeeds.
+    """
     state = ctx.state
+    chat_ready, chat_reason = _chat_model_ready(state, ctx.io)
     probes = [
         ("wrapper_ready", _smoke_wrapper_ready),
         ("hermes_doctor", _smoke_hermes_doctor),
@@ -4695,7 +4757,13 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
     ]
     results: dict[str, dict[str, Any]] = {}
     failures: list[str] = []
+    skipped: list[str] = []
     for name, fn in probes:
+        if name in _MODEL_DEPENDENT_PROBES and not chat_ready:
+            detail = f"skipped: no chat model loaded ({chat_reason})"
+            results[name] = {"passed": None, "skipped": True, "detail": detail}
+            skipped.append(f"{name}: {detail}")
+            continue
         try:
             passed, detail = fn(state, ctx.io)
         except Exception as exc:
@@ -4703,9 +4771,10 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
         results[name] = {"passed": passed, "detail": detail}
         if not passed:
             failures.append(f"{name}: {detail}")
+    status = PhaseStatus.WARN if failures else PhaseStatus.OK
     return PhaseResult(
-        status=PhaseStatus.OK,
-        details={"results": results, "failures": failures},
+        status=status,
+        details={"results": results, "failures": failures, "skipped": skipped},
     )
 
 
@@ -5335,21 +5404,36 @@ def _write_run_report(report: InstallReport, state_root: Path | None) -> None:
     root = state_root if state_root is not None else _DEFAULT_STATE_ROOT
     root.mkdir(parents=True, exist_ok=True)
     now = _utcnow()
+
+    def _phase_entry(s: InstallStep) -> dict[str, Any]:
+        # `failure_count` is derived generically from `details["failures"]`
+        # (a list[str]) so any phase — not just smoke_tests — that records
+        # non-fatal failures surfaces a count `hal0 agent status` can render
+        # as its own column instead of forcing operators to parse the
+        # (possibly truncated) Detail JSON blob (#1793).
+        failures = s.details.get("failures") if isinstance(s.details, dict) else None
+        skipped = s.details.get("skipped") if isinstance(s.details, dict) else None
+        entry: dict[str, Any] = {
+            "status": s.status,
+            "at": now,
+            "changed": s.changed,
+        }
+        if isinstance(failures, list) and failures:
+            entry["failure_count"] = len(failures)
+        if isinstance(skipped, list) and skipped:
+            entry["skipped_count"] = len(skipped)
+        if s.reason:
+            entry["reason"] = s.reason
+        if s.details:
+            entry["details"] = s.details
+        return entry
+
     data = {
         "hal0_version": _hal0_version_string(),
         "hermes_version": _hermes_version_pin(),
         "completed_at": now if report.ok else None,
         "repair": report.repair,
-        "phases": {
-            s.name: {
-                "status": s.status,
-                "at": now,
-                "changed": s.changed,
-                **({"reason": s.reason} if s.reason else {}),
-                **({"details": s.details} if s.details else {}),
-            }
-            for s in report.steps
-        },
+        "phases": {s.name: _phase_entry(s) for s in report.steps},
     }
     target = root / _STATE_FILE_NAME
     tmp = target.with_suffix(".json.tmp")

--- a/src/hal0/cli/agent_commands.py
+++ b/src/hal0/cli/agent_commands.py
@@ -1325,12 +1325,46 @@ def agent_status(
     table = Table(title=f"{name} bootstrap status")
     table.add_column("Phase", style="bold")
     table.add_column("Status")
+    table.add_column("Failures")
     table.add_column("At")
     table.add_column("Detail")
+    # #1793: a phase can carry recorded failures (smoke_tests) without
+    # failing the install — those must not read as a silent "ok". Color +
+    # a dedicated Failures column surface the count instead of leaving it
+    # buried inside the (possibly truncated) Detail JSON blob.
+    status_style = {"ok": "green", "warn": "yellow", "fail": "red bold", "skip": "dim"}
+    warn_phases: list[str] = []
     for phase, entry in (data.get("phases") or {}).items():
-        detail = entry.get("reason") or _json.dumps(entry.get("details") or {})[:60]
-        table.add_row(phase, entry.get("status", "—"), entry.get("at", "—"), detail)
+        status = entry.get("status", "—")
+        style = status_style.get(status)
+        status_cell = f"[{style}]{status}[/{style}]" if style else status
+        failure_count = entry.get("failure_count")
+        skipped_count = entry.get("skipped_count")
+        failure_bits = []
+        if failure_count:
+            failure_bits.append(f"[red]{failure_count} failed[/red]")
+        if skipped_count:
+            failure_bits.append(f"[dim]{skipped_count} skipped[/dim]")
+        failures_cell = " ".join(failure_bits) or "—"
+        details_blob = entry.get("details") or {}
+        phase_failures = details_blob.get("failures") if isinstance(details_blob, dict) else None
+        if entry.get("reason"):
+            detail = entry["reason"]
+        elif phase_failures:
+            shown = "; ".join(phase_failures[:2])
+            more = len(phase_failures) - 2
+            detail = f"{shown} (+{more} more)" if more > 0 else shown
+        else:
+            detail = _json.dumps(details_blob)[:60]
+        table.add_row(phase, status_cell, failures_cell, entry.get("at", "—"), detail)
+        if status == "warn":
+            warn_phases.append(phase)
     console.print(table)
+    if warn_phases:
+        console.print(
+            f"[yellow]warn: {', '.join(warn_phases)} recorded failures — "
+            f"see Detail or `--json` for the full list.[/yellow]"
+        )
     console.print(
         f"[dim]hal0={data.get('hal0_version', '?')} "
         f"hermes={data.get('hermes_version', '?')} "

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -59,7 +59,14 @@ def test_install_hermes_marks_every_step_ok_or_skip(
     )
     assert report.ok, report.failed
     for step in report.steps:
-        assert step.status in {"ok", "skip"}, f"{step.name}: {step.status}"
+        # smoke_tests may legitimately land on "warn" (#1793): it's
+        # diagnostic-only and never fails the install, but a phase that
+        # recorded a real probe failure must say so rather than reporting a
+        # silent "ok" — see
+        # test_smoke_tests_phase_records_failures_as_warn_without_blocking
+        # for the behavior this permits.
+        allowed = {"ok", "skip", "warn"} if step.name == "smoke_tests" else {"ok", "skip"}
+        assert step.status in allowed, f"{step.name}: {step.status}"
 
 
 def test_install_hermes_writes_last_run_report(
@@ -1940,10 +1947,21 @@ def test_voice_wire_does_not_provision_stt_when_npu_anchor_is_not_ready(
 # ── #246 phase impls — smoke_tests + self_report ────────────────────────────
 
 
+def _write_ready_chat_config(hermes_home: Path, model_name: str = "m1") -> None:
+    """Drop a config.yaml + matching gateway model so :func:`hp._chat_model_ready`
+    reports ready — the precondition the model-dependent probes need to
+    actually run instead of self-skipping (#1793)."""
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(f"model:\n  default: {model_name}\n")
+
+
 def test_smoke_tests_phase_runs_each_probe_collecting_results(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    hh = tmp_path / "hh"
+    _write_ready_chat_config(hh)
+    state = hp.BootstrapState(hermes_home=str(hh))
+    io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
     # All six probes return (True, "...") so we exercise the rollup
     # without depending on a real Hermes binary or HTTP listener.
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
@@ -1952,9 +1970,10 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
     monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
     monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
-    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["failures"] == []
+    assert out.details["skipped"] == []
     assert set(out.details["results"].keys()) == {
         "wrapper_ready",
         "hermes_doctor",
@@ -1965,20 +1984,139 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     }
 
 
-def test_smoke_tests_phase_records_failures_without_blocking(
+def test_smoke_tests_phase_records_failures_as_warn_without_blocking(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+    """A genuinely failing probe flips the phase to ``warn`` (#1793) — visible,
+    but still non-gating: the overall install must not fail over a smoke miss."""
+    hh = tmp_path / "hh"
+    _write_ready_chat_config(hh)
+    state = hp.BootstrapState(hermes_home=str(hh))
+    io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (False, "wrapper missing"))
     monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
     monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (False, "503"))
     monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
     monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
     monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
-    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
-    assert out.status == hp.PhaseStatus.OK  # diagnostic — not a blocker
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state, io=io))
+    assert out.status == hp.PhaseStatus.WARN  # visible, but not a blocker
     assert len(out.details["failures"]) == 2
     assert any("wrapper_ready" in f for f in out.details["failures"])
+    assert any("chat_completions" in f for f in out.details["failures"])
+
+
+def test_smoke_tests_phase_skips_model_dependent_probes_without_chat_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No routable chat model at smoke time (e.g. install-time run, before any
+    model has ever been loaded) → chat_completions/memory_roundtrip report
+    ``skipped``, not a timeout recorded as an opaque failure (#1793)."""
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))  # no config.yaml at all
+    calls: list[str] = []
+
+    def _boom(_s: hp.BootstrapState, _io: hp.InstallIO) -> tuple[bool, str]:
+        calls.append("called")
+        return (False, "should not have run")
+
+    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_chat_completions", _boom)
+    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", _boom)
+    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
+    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    assert calls == []  # gated probes never ran
+    assert out.status == hp.PhaseStatus.OK  # skips aren't failures
+    assert out.details["failures"] == []
+    assert len(out.details["skipped"]) == 2
+    assert out.details["results"]["chat_completions"]["skipped"] is True
+    assert "no chat model loaded" in out.details["results"]["chat_completions"]["detail"]
+    assert out.details["results"]["memory_roundtrip"]["skipped"] is True
+
+
+class TestChatModelReady:
+    """Direct coverage of the :func:`hp._chat_model_ready` preflight (#1793)."""
+
+    def test_missing_config_not_ready(self, tmp_path: Path) -> None:
+        state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))
+        ready, reason = hp._chat_model_ready(state, hp.InstallIO())
+        assert ready is False
+        assert "config.yaml missing" in reason
+
+    def test_unset_model_default_not_ready(self, tmp_path: Path) -> None:
+        hh = tmp_path / "hh"
+        hh.mkdir()
+        (hh / "config.yaml").write_text("{}\n")
+        state = hp.BootstrapState(hermes_home=str(hh))
+        ready, reason = hp._chat_model_ready(state, hp.InstallIO())
+        assert ready is False
+        assert "model.default unset" in reason
+
+    def test_model_not_on_gateway_not_ready(self, tmp_path: Path) -> None:
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "m1")
+        state = hp.BootstrapState(hermes_home=str(hh))
+        io = hp.InstallIO(fetch_model_contexts=lambda: {"other": 4096})
+        ready, reason = hp._chat_model_ready(state, io)
+        assert ready is False
+        assert "not loaded on the gateway" in reason
+
+    def test_model_on_gateway_ready(self, tmp_path: Path) -> None:
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "m1")
+        state = hp.BootstrapState(hermes_home=str(hh))
+        io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
+        ready, reason = hp._chat_model_ready(state, io)
+        assert ready is True
+        assert reason == "ready"
+
+    def test_gateway_probe_exception_not_ready(self, tmp_path: Path) -> None:
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "m1")
+        state = hp.BootstrapState(hermes_home=str(hh))
+
+        def _boom() -> dict[str, int]:
+            raise RuntimeError("gateway unreachable")
+
+        io = hp.InstallIO(fetch_model_contexts=_boom)
+        ready, reason = hp._chat_model_ready(state, io)
+        assert ready is False
+        assert "gateway probe failed" in reason
+
+
+def test_write_run_report_surfaces_failure_and_skipped_counts(tmp_path: Path) -> None:
+    """`hal0 agent status` reads `failure_count`/`skipped_count` off the
+    persisted phase entry — this pins the aggregation `_write_run_report`
+    derives from `details["failures"]`/`details["skipped"]` (#1793), for any
+    phase, not just smoke_tests."""
+    report = hp.InstallReport(
+        hermes_home=str(tmp_path / "hh"),
+        venv=str(tmp_path / "venv"),
+        agent_id="hermes-agent",
+        steps=[
+            hp.InstallStep(
+                name="smoke_tests",
+                status=hp.PhaseStatus.WARN,
+                details={
+                    "results": {},
+                    "failures": ["wrapper_ready: wrapper missing"],
+                    "skipped": ["chat_completions: skipped: no chat model loaded (...)"],
+                },
+            ),
+            hp.InstallStep(name="env_probe", status=hp.PhaseStatus.OK, details={}),
+        ],
+    )
+    state_root = tmp_path / "state"
+    hp._write_run_report(report, state_root)
+    data = json.loads((state_root / "provision.json").read_text())
+    smoke = data["phases"]["smoke_tests"]
+    assert smoke["status"] == "warn"
+    assert smoke["failure_count"] == 1
+    assert smoke["skipped_count"] == 1
+    env_probe = data["phases"]["env_probe"]
+    assert "failure_count" not in env_probe
+    assert "skipped_count" not in env_probe
 
 
 def test_self_report_writes_summary_memory_and_handles_failure(

--- a/tests/agents/test_hermes_provision_idempotency.py
+++ b/tests/agents/test_hermes_provision_idempotency.py
@@ -99,9 +99,13 @@ def test_two_consecutive_runs_converge(target: tuple[Path, Path]) -> None:
     assert (persona_root / "active.txt").read_text(encoding="utf-8") == active_1
     # The retired coder seed must not reappear.
     assert not (persona_root / "coder.toml").exists()
-    # Every step ends ok or skip on both runs.
+    # Every step ends ok or skip on both runs — except smoke_tests, which may
+    # legitimately land on "warn" (#1793): it's diagnostic-only and never
+    # fails the install, but a phase that recorded a real probe failure must
+    # say so rather than reporting a silent "ok".
     for step in r2.steps:
-        assert step.status in {"ok", "skip"}, f"{step.name}: {step.status}"
+        allowed = {"ok", "skip", "warn"} if step.name == "smoke_tests" else {"ok", "skip"}
+        assert step.status in allowed, f"{step.name}: {step.status}"
 
 
 def test_report_written_for_agent_status(target: tuple[Path, Path], tmp_path: Path) -> None:

--- a/tests/cli/test_agent_status.py
+++ b/tests/cli/test_agent_status.py
@@ -86,3 +86,73 @@ def test_status_non_json_still_renders_table(provision_state: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "bootstrap status" in result.output
     assert "toolchain" in result.output
+
+
+@pytest.fixture
+def warn_provision_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A provision.json with a smoke_tests phase carrying real failures
+    (#1793) — the exact shape that used to render as a silent ``ok``."""
+    state_dir = tmp_path / "hermes"
+    state_dir.mkdir(parents=True)
+    state_file = state_dir / "provision.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "hal0_version": "1.2.3",
+                "hermes_version": "0.9.0",
+                "completed_at": "2026-08-09T00:00:00Z",
+                "phases": {
+                    "toolchain": {"status": "ok", "at": "2026-08-09T00:00:00Z"},
+                    "smoke_tests": {
+                        "status": "warn",
+                        "at": "2026-08-09T00:00:01Z",
+                        "failure_count": 1,
+                        "skipped_count": 2,
+                        "details": {
+                            "failures": ["wrapper_ready: wrapper missing"],
+                            "skipped": [
+                                "chat_completions: skipped: no chat model loaded",
+                                "memory_roundtrip: skipped: no chat model loaded",
+                            ],
+                        },
+                    },
+                },
+            }
+        )
+    )
+    monkeypatch.setattr(
+        agent_commands, "_agent_provision_state_file", lambda name: state_dir / "provision.json"
+    )
+    return state_file
+
+
+def test_status_json_surfaces_warn_status_and_counts(warn_provision_state: Path) -> None:
+    """#1793: a phase with recorded failures must report itself ``warn`` (not
+    ``ok``) and the failure/skip counts must be present for CI/pipe
+    consumers, not buried only in the (possibly truncated) Detail text."""
+    result = runner.invoke(agent_commands.app, ["status", "hermes", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    smoke = payload["phases"]["smoke_tests"]
+    assert smoke["status"] == "warn"
+    assert smoke["failure_count"] == 1
+    assert smoke["skipped_count"] == 2
+
+
+def test_status_table_surfaces_warn_phase_and_failure_count(
+    warn_provision_state: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same fixture through the Rich-table path: the status column must not
+    read ``ok``, and the dedicated Failures column must show the count
+    instead of leaving it only in the (possibly truncated) Detail JSON.
+
+    Force a wide terminal so Rich doesn't wrap the "1 failed 2 skipped" cell
+    across lines under the CliRunner's default (narrow, non-tty) width and
+    break the substring checks below.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+    result = runner.invoke(agent_commands.app, ["status", "hermes"])
+    assert result.exit_code == 0, result.output
+    assert "warn" in result.output
+    assert "1 failed" in result.output
+    assert "2 skipped" in result.output


### PR DESCRIPTION
## Summary
- `smoke_tests` phase now reports `status=warn` (never `ok`) when any probe records a real failure — never fails the install, smoke stays diagnostic-only.
- `hal0 agent status` and its `--json` output surface the signal directly: a dedicated Failures column (`N failed`, `N skipped`) in the table, and `failure_count`/`skipped_count` fields on the phase entry in JSON — no more digging through the (possibly truncated) Detail blob.
- `chat_completions` and `memory_roundtrip` now preflight whether a chat-capable model is actually routable (`model.default` in `config.yaml` cross-checked against the live gateway model list via `io.fetch_model_contexts`) before running. At install time — before any model has ever been loaded — that route is structurally dead, so these two probes now report `skipped: no chat model loaded (...)` instead of burning their timeout and recording an opaque failure that was never a real regression.

## Test plan
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/agents/test_hermes_provision.py tests/agents/test_hermes_provision_idempotency.py tests/cli/test_agent_status.py -q` → 138 passed
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/agents tests/cli -q` → 1335 passed, 1 xfailed (vs 1326 passed on main — +9 new)
- [x] `make lint` → clean
- [x] `uv run ruff format --check .` on touched files → clean (pre-existing unrelated diffs in 6 other files left untouched)

Two pre-existing tests (`test_install_hermes_marks_every_step_ok_or_skip`, `test_two_consecutive_runs_converge`) hardcoded the assumption that every phase always lands on `ok`/`skip`. Updated both to allow `smoke_tests` to also land on `warn`, since that's now the truthful, by-design outcome when a probe genuinely fails — they still forbid `warn` on every other phase.

Closes #1793

🤖 Generated with [Claude Code](https://claude.com/claude-code)