### PR TITLE
fix(hardware): gate vulkan_capable on a real render node, guard FPX quants at launch

### DIFF
--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -410,6 +410,18 @@ def _amd_gpu_info(drm: Path, index: int, compute_capable: bool) -> GPUInfo:
     On Strix Halo (UMA) the vram_total counter reports the small carve-out;
     the real model-loading pool is GTT. We pick the larger of vram_total and
     gtt_total so the slot-form's "will it fit" check uses the right number.
+
+    ``vulkan_capable`` used to be hardcoded True on the theory that "amdgpu
+    ships Mesa Vulkan" — true on bare metal, but WRONG in an unprivileged
+    container: ``/sys/class/drm/card*/device`` can still expose the host's
+    sysfs (VRAM counters, PCI uevent) even when the container was never
+    given the matching ``/dev/dri/renderD*`` node, because sysfs and devtmpfs
+    are gated independently by the container runtime. Without a passed-through
+    render node there is no usable Vulkan ICD path, so Vulkan capability must
+    be gated on the render node actually existing (see hal0#1790: a GPU-less
+    LXC's sysfs-only view of the host's Strix Halo iGPU made
+    ``rocmfpx_capable()`` return True and installed the FPX brain quant onto a
+    box that could never load it, SIGSEGV-ing the runner).
     """
     vram_total = _read_sysfs_mb(drm / "mem_info_vram_total") or 0.0
     gtt_total = _read_sysfs_mb(drm / "mem_info_gtt_total") or 0.0
@@ -440,7 +452,9 @@ def _amd_gpu_info(drm: Path, index: int, compute_capable: bool) -> GPUInfo:
         driver="amdgpu",
         drm_path=str(drm),
         compute_capable=compute_capable,
-        vulkan_capable=True,  # amdgpu ships Mesa Vulkan
+        # amdgpu ships Mesa Vulkan, but only usable when the render node was
+        # actually passed through — see the docstring above.
+        vulkan_capable=bool(_first_render_node()),
     )
 
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1341,6 +1341,69 @@ def _resolve_context_size(
     return resolved
 
 
+#: ROCmFPX-family quant labels (:func:`hal0.registry.detect.quant_from_rocmfpx_filename`)
+#: all share this prefix — ``ROCmFP3``/``ROCmFP4``/``ROCmFP6``/``ROCmFP8``/``ROCmFPX``.
+#: Exact marker, not a heuristic: these are custom GGML tensor type ids (100 /
+#: 103) that a stock llama.cpp header parse can't map to a known quant, so the
+#: filename token is the only source and it is unambiguous — a false positive
+#: here would need a model file to literally carry one of these tokens without
+#: actually being a ROCmFPX repack.
+_FPX_QUANT_PREFIX = "ROCmFP"
+
+
+def _guard_fpx_quant_runner(
+    slot_cfg: dict[str, Any] | Mapping[str, Any] | None,
+    model_info: dict[str, Any],
+    runner: Any,
+) -> None:
+    """Refuse to launch a ROCmFPX-family quant on a non-ROCmFPX runner.
+
+    hal0#1790: a GPU-less LXC (CT151, ``HAL0_ALLOW_CPU_ONLY=1``) had its
+    ``vulkan_capable`` probe fact mis-derived True from host sysfs visible
+    without a passed-through render node, so ``rocmfpx_capable()`` picked
+    ``hal0-brain-sft-q8-rocmfpx`` for a box that could never load it — the
+    ``cpu`` runner's stock llama.cpp SIGSEGVs (exit 139) on the custom GGML
+    tensor type ids (100 / 103) those quants carry. The probe fix
+    (``hal0.hardware.probe._amd_gpu_info``) stops the installer from making
+    this pick going forward; this is the belt-and-suspenders backstop for
+    every OTHER way a bad pairing could still reach a launch — a stale slot
+    TOML from before the probe fix, a manual ``HAL0_BRAIN_MODEL`` override,
+    or an operator hand-swapping a model onto a ``cpu`` slot. Checked at the
+    single point (:func:`_resolve_llama_scalars`) both the real launch and
+    the preview path share, right after the runner is resolved, so it can
+    never be bypassed by a route that skips some other layer.
+
+    Raises :class:`UnprocessableEntity` (422) with the exact quant/runner
+    facts in ``details`` rather than letting the container crash-loop.
+    """
+    quant = str((model_info or {}).get("quant") or "")
+    if not quant.startswith(_FPX_QUANT_PREFIX):
+        return
+    from hal0.runners import FPX_RUNNER_KEYS
+
+    if getattr(runner, "key", None) in FPX_RUNNER_KEYS:
+        return
+    slot_name = ""
+    if isinstance(slot_cfg, Mapping):
+        raw_name = slot_cfg.get("name")
+        slot_name = raw_name if isinstance(raw_name, str) else ""
+    model_key = str((model_info or {}).get("_model_key") or (model_info or {}).get("id") or "?")
+    raise UnprocessableEntity(
+        f"model {model_key!r} is a {quant} build (custom GGML tensor types 100/103) that "
+        f"only the ROCmFPX runner can load; the resolved runner here is "
+        f"{getattr(runner, 'key', '?')!r} — loading it would SIGSEGV the container. "
+        "Pick a non-ROCmFPX build (e.g. hal0-brain-sft-f16) or move this slot to a "
+        "gpu-rocm/gpu-vulkan device.",
+        code="slot.unsupported_quant_for_runner",
+        details={
+            "slot": slot_name,
+            "model": model_key,
+            "quant": quant,
+            "runner": getattr(runner, "key", None),
+        },
+    )
+
+
 def _resolve_llama_scalars(
     slot_cfg: dict[str, Any],
     model_info: dict[str, Any],
@@ -1374,6 +1437,8 @@ def _resolve_llama_scalars(
     effective_backend, effective_device_class = _effective_backend_and_device_class(
         slot_cfg, profile
     )
+    if for_launch:
+        _guard_fpx_quant_runner(slot_cfg, model_info, runner)
     effective_mtp = _effective_mtp(model_info, runner, log_ineligible=for_launch)
     # FLAGS-own (spec-flags-ownership §2, golden #5): resolve the image WITHOUT
     # resolving the profile's flags — the profile flag resolver

--- a/src/hal0/runners/__init__.py
+++ b/src/hal0/runners/__init__.py
@@ -295,6 +295,16 @@ def runner_for_backend(backend: str | None, device_class: str | None = None) -> 
     return get_runner("rocmfpx")
 
 
+#: The only two runner keys whose image is :data:`DEFAULT_ROCMFPX_IMAGE` — the
+#: single fork build that understands the custom GGML tensor type ids (100 /
+#: 103) a ROCmFPX-family GGUF (``hal0-brain-sft-q8-rocmfpx`` and friends) is
+#: packed with. Every other runner (``cpu``, ``cuda``, …) runs stock
+#: llama.cpp, which SIGSEGVs on those tensor types instead of rejecting them
+#: cleanly (hal0#1790). Used by the launch-time quant/runner compatibility
+#: guard in :func:`hal0.providers.container._resolve_llama_scalars`.
+FPX_RUNNER_KEYS = frozenset({"rocmfpx", "vulkanfpx"})
+
+
 def runner_matches(runner: Runner, *, device_class: str | None, backend: str | None) -> bool:
     """True when ``runner`` is a valid choice for a given device/backend lane.
 
@@ -311,6 +321,7 @@ def runner_matches(runner: Runner, *, device_class: str | None, backend: str | N
 
 
 __all__ = [
+    "FPX_RUNNER_KEYS",
     "RUNNER_IMAGES",
     "STALE_RUNNER_IMAGE_REFS",
     "Runner",

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -192,6 +192,11 @@ def test_detect_amd_via_drm(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
 
     # _detect_amd now enumerates every card via _amd_drm_devices (plural).
     monkeypatch.setattr(probe_mod, "_amd_drm_devices", lambda: [drm])
+    # A real /dev/dri/renderD* node passed through — bare metal / a
+    # privileged container. Explicit (not incidental host state) so this
+    # test is deterministic regardless of what /dev/dri looks like on the
+    # box running the suite.
+    monkeypatch.setattr(probe_mod, "_first_render_node", lambda dri_dir=None: "/dev/dri/renderD128")
     monkeypatch.setattr(
         probe_mod,
         "_run",
@@ -214,6 +219,43 @@ def test_detect_amd_via_drm(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     assert info.compute_capable is True
     assert info.vulkan_capable is True
     assert info.drm_path == str(drm)
+
+
+def test_detect_amd_via_drm_no_render_node_is_not_vulkan_capable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """hal0#1790 — the CT151 shape: an unprivileged LXC whose sysfs still
+    exposes the host's AMD DRM device (VRAM counters, PCI uevent all present,
+    just like bare metal) but was never given the matching
+    ``/dev/dri/renderD*`` node. There is no usable Vulkan ICD path here, so
+    ``vulkan_capable`` must be False even though every OTHER sysfs signal
+    looks identical to a real GPU box — this is exactly what made
+    ``rocmfpx_capable()`` (hal0.install.brain_model) mis-select the FPX brain
+    quant for a box that can only SIGSEGV on it.
+    """
+    drm = tmp_path / "drm" / "card1" / "device"
+    drm.mkdir(parents=True)
+    (drm / "mem_info_vram_total").write_text(str(1024 * 1024 * 1024))
+    (drm / "uevent").write_text("PCI_SLOT_NAME=0000:bf:00.0\n")
+
+    monkeypatch.setattr(probe_mod, "_amd_drm_devices", lambda: [drm])
+    monkeypatch.setattr(probe_mod, "_first_render_node", lambda dri_dir=None: "")
+    monkeypatch.setattr(
+        probe_mod,
+        "_run",
+        _mk_run(
+            {
+                "lspci": (0, "bf:00.0 VGA controller: AMD Strix Halo [Radeon 8060S]", ""),
+                # No rocm-smi in the container either (matches CT151).
+                "rocm-smi": (-1, "", "not found"),
+                "nvidia-smi": (-1, "", "not found"),
+            }
+        ),
+    )
+    info = probe_mod._detect_amd()
+    assert info is not None
+    assert info.vulkan_capable is False
+    assert info.compute_capable is False
 
 
 def test_detect_amd_no_drm(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/install/test_brain_model.py
+++ b/tests/install/test_brain_model.py
@@ -87,6 +87,45 @@ def test_override_selects_a_known_variant() -> None:
     )
 
 
+class TestHardwareDecisionMatrix:
+    """The full selection matrix hal0#1790 asked for: gpu-rocm / gpu-vulkan /
+    cpu-only, each driven through :func:`brain_model_for_hardware` exactly as
+    ``hal0.install.brain_model.main`` calls it (hardware first, no override).
+    """
+
+    def test_gpu_rocm_box_selects_rocmfpx(self) -> None:
+        hw = _hw(gpus=[GPUInfo(vendor="amd", compute_capable=True, vulkan_capable=False)])
+        assert rocmfpx_capable(hw) is True
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+
+    def test_gpu_vulkan_box_selects_rocmfpx(self) -> None:
+        hw = _hw(gpus=[GPUInfo(vendor="amd", compute_capable=False, vulkan_capable=True)])
+        assert rocmfpx_capable(hw) is True
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_ROCMFPX
+
+    def test_cpu_only_box_selects_portable_f16(self) -> None:
+        """No compute, no Vulkan, no strix-halo platform — the F16 build."""
+        hw = _hw(gpus=[])
+        assert rocmfpx_capable(hw) is False
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_PORTABLE
+
+    def test_gpu_present_but_neither_compute_nor_vulkan_capable_selects_f16(self) -> None:
+        """hal0#1790's exact shape one layer up: an AMD GPU row IS present in
+        ``hw.gpus`` (sysfs saw it) but both capability flags are False — this
+        is what ``hal0.hardware.probe._amd_gpu_info`` now produces for a
+        GPU-less LXC once its render-node gate is in place. Before that fix
+        this GPUInfo would have carried ``vulkan_capable=True`` unconditionally
+        and this test would have asserted BRAIN_MODEL_ROCMFPX instead — the
+        regression this matrix exists to pin.
+        """
+        hw = _hw(
+            platform="lxc",
+            gpus=[GPUInfo(vendor="amd", compute_capable=False, vulkan_capable=False)],
+        )
+        assert rocmfpx_capable(hw) is False
+        assert brain_model_for_hardware(hw) == BRAIN_MODEL_PORTABLE
+
+
 def test_unknown_override_falls_back_instead_of_404ing() -> None:
     """An off-catalogue HAL0_BRAIN_MODEL must not become a doomed pull.
 

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1644,3 +1644,81 @@ class TestSlotHardwareSegment:
         labels = [lbl for lbl, _toks in _llama_argv_segments(port=8081, model_path="/m.gguf")]
         assert "slot_hardware" in labels
         assert "model_defaults" not in labels
+
+
+class TestFPXQuantRunnerGuard:
+    """hal0#1790 defense-in-depth: a ROCmFPX-family quant (custom GGML tensor
+    type ids 100/103 — see ``hal0.registry.detect.quant_from_rocmfpx_filename``)
+    must never reach a launch on a runner that isn't ``rocmfpx``/``vulkanfpx``.
+    The probe fix (``hal0.hardware.probe._amd_gpu_info``) stops the installer
+    from picking this pairing going forward; this guard is the backstop for a
+    stale slot TOML, a manual ``HAL0_BRAIN_MODEL`` override, or a hand-swapped
+    model — refuse the launch with a clear error instead of a SIGSEGV crash
+    loop (exit 139).
+    """
+
+    _GPU_NODES: ClassVar[list[str]] = ["/dev/kfd", "/dev/dri/renderD128"]
+
+    def _spec(self, cfg: dict[str, Any], model_info: dict[str, Any], profile: ProfileConfig):
+        provider = ContainerProvider()
+        with (
+            patch("hal0.providers.container._resolve_profile", return_value=profile),
+            patch(
+                "hal0.providers.container.resolve_gpu_device_paths",
+                return_value=list(self._GPU_NODES),
+            ),
+            patch("hal0.providers.container.os.path.exists", return_value=True),
+            patch("hal0.providers.container.resolve_gpu_group_ids", return_value=[993, 44]),
+        ):
+            return provider.container_spec(cfg, model_info)
+
+    def test_rocmfpx_quant_on_cpu_slot_is_refused(self) -> None:
+        """The exact hal0#1790 shape: hal0-brain-sft-q8-rocmfpx on a device='cpu'
+        slot. The old wrong pairing must now raise instead of spawning."""
+        cpu_chat = ProfileConfig(flags="--threads-batch 8 --jinja -b 256 -ub 256")
+        cfg = _slot_cfg(device="cpu", profile="cpu-chat", name="brain")
+        model_info = _model_info(quant="ROCmFP8", _model_key="hal0-brain-sft-q8-rocmfpx")
+        with pytest.raises(_container_mod.UnprocessableEntity) as exc_info:
+            self._spec(cfg, model_info, cpu_chat)
+        err = exc_info.value
+        assert err.code == "slot.unsupported_quant_for_runner"
+        assert err.details["quant"] == "ROCmFP8"
+        assert err.details["runner"] == "cpu"
+        assert err.details["model"] == "hal0-brain-sft-q8-rocmfpx"
+
+    @pytest.mark.parametrize("quant", ["ROCmFP3", "ROCmFP4", "ROCmFP6", "ROCmFP8", "ROCmFPX"])
+    def test_every_fpx_family_label_is_refused_on_cpu(self, quant: str) -> None:
+        cpu_chat = ProfileConfig(flags="--threads-batch 8 --jinja -b 256 -ub 256")
+        cfg = _slot_cfg(device="cpu", profile="cpu-chat")
+        model_info = _model_info(quant=quant)
+        with pytest.raises(_container_mod.UnprocessableEntity):
+            self._spec(cfg, model_info, cpu_chat)
+
+    def test_rocmfpx_quant_on_gpu_rocm_slot_is_allowed(self) -> None:
+        rocm = SEED_PROFILES["chat"]
+        cfg = _slot_cfg(device="gpu-rocm", profile="chat")
+        model_info = _model_info(quant="ROCmFP8", _model_key="hal0-brain-sft-q8-rocmfpx")
+        spec = self._spec(cfg, model_info, rocm)
+        assert spec is not None  # no raise — rocmfpx runner accepts its own family
+
+    def test_rocmfpx_quant_on_gpu_vulkan_slot_is_allowed(self) -> None:
+        vulkan = ProfileConfig(flags="-fa on", backend="vulkan")
+        cfg = _slot_cfg(device="gpu-vulkan", profile="vulkan-chat", binary="vulkanfpx")
+        model_info = _model_info(quant="ROCmFP4")
+        spec = self._spec(cfg, model_info, vulkan)
+        assert spec is not None
+
+    def test_plain_quant_on_cpu_slot_is_unaffected(self) -> None:
+        """A normal quant (no ROCmFP* marker) must never trip the guard."""
+        cpu_chat = ProfileConfig(flags="--threads-batch 8 --jinja -b 256 -ub 256")
+        cfg = _slot_cfg(device="cpu", profile="cpu-chat")
+        model_info = _model_info(quant="Q4_K_M")
+        spec = self._spec(cfg, model_info, cpu_chat)
+        assert spec is not None
+
+    def test_no_quant_on_cpu_slot_is_unaffected(self) -> None:
+        cpu_chat = ProfileConfig(flags="--threads-batch 8 --jinja -b 256 -ub 256")
+        cfg = _slot_cfg(device="cpu", profile="cpu-chat")
+        model_info = _model_info()  # no "quant" key at all
+        spec = self._spec(cfg, model_info, cpu_chat)
+        assert spec is not None


### PR DESCRIPTION
## Summary

- CT151 (a GPU-less unprivileged LXC, `HAL0_ALLOW_CPU_ONLY=1`) crash-looped its brain slot with SIGSEGV (exit 139) every ~5s because the installer picked `hal0-brain-sft-q8-rocmfpx`, a build with custom GGML tensor type ids (100/103) that only the ROCmFPX runner can load.
- **Root cause**: `hal0.hardware.probe._amd_gpu_info` hardcoded `vulkan_capable=True` on any AMD DRM sysfs sighting. An unprivileged container can still see the host's sysfs (VRAM counters, PCI uevent) without ever getting the matching `/dev/dri/renderD*` node passed through, so there is no usable Vulkan ICD path. `rocmfpx_capable()` trusted the false `vulkan_capable` and `brain_model_for_hardware()` picked the FPX quant for a box that could never run it.
- Confirmed directly on CT151's captured `hardware.json`: `vulkan_capable: true`, `compute_capable: false`, `platform: "lxc"`, no `/dev/dri`.
- **Fix**: `vulkan_capable` now requires an actual render node (`bool(_first_render_node())`) instead of the vendor hardcode.
- **Defense in depth**: `hal0.providers.container._resolve_llama_scalars` now gates every real launch on runner/quant compatibility. A ROCmFPX-family quant (the exact `ROCmFP*` marker `registry/detect.quant_from_rocmfpx_filename` already derives for these custom-tensor-type files) reaching a non-`rocmfpx`/`vulkanfpx` runner raises `UnprocessableEntity` (422, `slot.unsupported_quant_for_runner`) with the exact slot/model/quant/runner facts, instead of spawning a container that SIGSEGVs. This backstops stale slot TOMLs, `HAL0_BRAIN_MODEL` overrides, and manual model swaps that the probe fix alone can't catch.

Closes #1790

## Test plan

- [x] `tests/hardware/test_probe.py` — pinned the pre-existing `test_detect_amd_via_drm` to an explicit render-node mock (it was accidentally passing off real `/dev/dri` state on some hosts) and added `test_detect_amd_via_drm_no_render_node_is_not_vulkan_capable`, the exact CT151 shape.
- [x] `tests/install/test_brain_model.py` — added `TestHardwareDecisionMatrix` (gpu-rocm / gpu-vulkan / cpu-only, plus the "GPU row present but neither compute nor vulkan capable" regression shape).
- [x] `tests/providers/test_container.py` — added `TestFPXQuantRunnerGuard`: every `ROCmFP*` family label refused on a `cpu` slot, allowed on `gpu-rocm`/`gpu-vulkan`, and confirmed inert for plain quants / no-quant models.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/hardware/ tests/install/ tests/providers/ tests/runners/ tests/slots/ -q` → 1633 passed
- [x] `make lint` → all checks passed
- [x] `uv run ruff format --check .` on touched files → already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)