### PR TITLE
fix(memory): fall back to raw documents for literal recall

### DIFF
--- a/src/hal0/memory/hindsight_client.py
+++ b/src/hal0/memory/hindsight_client.py
@@ -272,6 +272,35 @@ class HindsightRestClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def list_documents(
+        self, *, bank_id, q=None, tags=None, tags_match=None, limit=100, offset=0
+    ):
+        """GET ``/documents`` — raw retained documents (#1794 fallback leg).
+
+        Hindsight's ``q`` here filters on **document id**, not body text —
+        there is no engine-side full-text search over raw content, so the
+        literal-recall fallback in ``HindsightProvider`` uses this only to
+        enumerate a bounded page of documents and then fetches each one's
+        ``original_text`` via :meth:`get_document` to substring-match.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if q is not None:
+            params["q"] = q
+        if tags:
+            params["tags"] = list(tags)
+        if tags_match is not None:
+            params["tags_match"] = tags_match
+        resp = await self._http.get(
+            f"/v1/default/banks/{bank_id}/documents", headers=self._headers(), params=params
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_document(self, *, bank_id, document_id):
+        """GET one document's full ``original_text`` (#1794 fallback leg)."""
+        doc = quote(str(document_id), safe="")
+        return await self.request_json("GET", f"/v1/default/banks/{bank_id}/documents/{doc}")
+
     async def delete_document(self, *, bank_id, document_id):
         # document_id is the only user-influenced value that lands in a URL path
         # segment (e.g. the deterministic ``<agent>:<session_id>`` id). Percent-

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -29,6 +29,7 @@ Maps hal0's engine-neutral MemoryProvider contract onto the shared
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from datetime import UTC, datetime
@@ -242,6 +243,34 @@ def _http_status(exc: Exception) -> int | None:
 # tier (deduplicated, evidence-grounded beliefs). hal0's default includes it;
 # callers can still narrow with an explicit ``types``.
 _DEFAULT_RECALL_TYPES = ("world", "experience", "observation")
+
+# ── raw-document recall fallback (#1794) ──────────────────────────────────
+#
+# Fact extraction rewrites facts as meta-observations and can drop the
+# literal value entirely (worst on small extraction models) — a marker,
+# ID, or key stored in good faith becomes unrecallable even though the raw
+# document text still holds it. Hindsight has no engine-side full-text
+# search over raw document bodies (``GET .../documents?q=`` matches the
+# document ID, not its content — confirmed against the live daemon's
+# OpenAPI schema), so this is the best hal0-side approximation: detect
+# literal-looking tokens in the query, and if none of the extracted facts
+# already contain them, scan a bounded page of the bank's most recent raw
+# documents and substring-match. The real fix is an engine-side raw-content
+# search endpoint (documented in issue #1794); this is a client-side
+# stopgap that AUGMENTS fact results with provenance, never replaces them.
+
+#: A "literal-looking" token: an alnum run (with ``-``/``_``) at least 4
+#: chars long that mixes letters and digits — catches markers (MARKER-7734),
+#: host/box ids (CT151), version-ish codes, etc. Plain words never match
+#: (no digit), so ordinary queries never trigger the fallback scan.
+_LITERAL_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{2,}")
+
+#: Bounded per-bank document scan — the engine has no content search, so
+#: this is a page-and-fetch-each walk; keep it cheap enough to run inline
+#: on every recall that has an uncovered literal token.
+_DOC_FALLBACK_MAX_DOCS_PER_BANK = 25
+#: Cap on how many raw-document results the fallback ever appends.
+_DOC_FALLBACK_MAX_RESULTS = 5
 
 # ── retain-pipeline health (#1420) ────────────────────────────────────────
 #
@@ -1274,6 +1303,25 @@ class HindsightProvider(MemoryProvider):
             union = await self._rerank_union(query, union)
         union.sort(key=self._precedence_key)  # stable: precedence wins ties
         budgeted = self._apply_token_budget(union, max_tokens)
+
+        # #1794 fallback: if the query names a literal-looking token (marker,
+        # ID, key) that no extracted fact's text actually contains, extraction
+        # may have dropped it — augment (never replace) with raw-document
+        # hits carrying it verbatim.
+        literal_tokens = self._literal_tokens(query)
+        if literal_tokens:
+            covered = " ".join((it.get("text") or "") for it in budgeted).lower()
+            uncovered = [t for t in literal_tokens if t.lower() not in covered]
+            if uncovered:
+                try:
+                    doc_items = await self._document_fallback(
+                        banks, uncovered, client_id=client_id, dataset=dataset
+                    )
+                except Exception:
+                    doc_items = []
+                if doc_items:
+                    budgeted = list(budgeted) + doc_items
+
         return RecallResults(
             budgeted,
             entities=entities_merged or None,
@@ -1765,4 +1813,105 @@ class HindsightProvider(MemoryProvider):
             "type": fact.get("type"),
             "entities": list(fact.get("entities") or []) or None,
             "source_fact_ids": list(fact.get("source_fact_ids") or []) or None,
+            # Provenance (#1794): every ordinary recall result is an
+            # extracted fact, as opposed to the raw-document fallback items
+            # ``_document_fallback`` appends.
+            "kind": "fact",
         }
+
+    # ── raw-document recall fallback (#1794) ─────────────────────────────
+
+    @staticmethod
+    def _literal_tokens(query: str) -> list[str]:
+        """Literal-looking tokens in ``query`` — see module-level comment."""
+        out: list[str] = []
+        for tok in _LITERAL_TOKEN_RE.findall(query or ""):
+            has_digit = any(c.isdigit() for c in tok)
+            has_alpha = any(c.isalpha() for c in tok)
+            if has_digit and has_alpha:
+                out.append(tok)
+        return out
+
+    async def _document_fallback(
+        self,
+        banks: list[str],
+        tokens: list[str],
+        *,
+        client_id: str | None,
+        dataset: str | list[str] | None,
+    ) -> list[dict[str, Any]]:
+        """Bounded raw-document scan for literal tokens fact-extraction lost.
+
+        Enumerates up to :data:`_DOC_FALLBACK_MAX_DOCS_PER_BANK` documents
+        per bank, fetches each one's full text, and keeps any whose text
+        contains a still-uncovered token. Fail-soft throughout: an engine
+        that can't answer ``list_documents``/``get_document`` (older build,
+        outage) yields no fallback items rather than erroring the recall.
+        """
+        import asyncio
+
+        async def _bank_docs(bank: str) -> list[tuple[str, dict[str, Any]]]:
+            try:
+                resp = await self._call(
+                    "list_documents", bank_id=bank, limit=_DOC_FALLBACK_MAX_DOCS_PER_BANK, offset=0
+                )
+            except Exception:
+                return []
+            items = resp.get("items") if isinstance(resp, dict) else None
+            return [(bank, it) for it in (items or []) if isinstance(it, dict) and it.get("id")]
+
+        per_bank = await asyncio.gather(*[_bank_docs(b) for b in banks])
+        candidates = [pair for group in per_bank for pair in group]
+        if not candidates:
+            return []
+
+        async def _fetch(bank: str, meta: dict[str, Any]) -> tuple[str, Any] | None:
+            try:
+                doc = await self._call("get_document", bank_id=bank, document_id=meta["id"])
+            except Exception:
+                return None
+            return (bank, doc)
+
+        fetched = await asyncio.gather(*[_fetch(b, m) for b, m in candidates])
+
+        caller = self._caller_agent(client_id)
+        projects, wants_unscoped = self._requested_scope(dataset)
+        remaining = {t.lower() for t in tokens}
+        out: list[dict[str, Any]] = []
+        for pair in fetched:
+            if pair is None or not remaining:
+                continue
+            bank, doc = pair
+            if not isinstance(doc, dict):
+                continue
+            text = doc.get("original_text") or ""
+            if not text:
+                continue
+            lower_text = text.lower()
+            hits = [t for t in remaining if t in lower_text]
+            if not hits:
+                continue
+            if self._unified_bank and not (
+                self._is_visible_to(doc, caller)
+                and self._is_in_scope(doc, projects, wants_unscoped)
+            ):
+                continue
+            out.append(
+                {
+                    "id": doc.get("id"),
+                    "text": text,
+                    "timestamp": doc.get("created_at") or _now(),
+                    "dataset": bank.replace("__", ":"),
+                    "tags": list(doc.get("tags") or []),
+                    "source": "raw_document",
+                    "metadata": {"kind": "document", "document_id": doc.get("id")},
+                    "score": None,
+                    "type": "document",
+                    "kind": "document",
+                }
+            )
+            for hit in hits:
+                remaining.discard(hit)
+            if len(out) >= _DOC_FALLBACK_MAX_RESULTS:
+                break
+        return out

--- a/tests/memory/test_hindsight_provider.py
+++ b/tests/memory/test_hindsight_provider.py
@@ -15,6 +15,10 @@ class FakeHindsightClient:
         self.recalled: list[dict] = []
         self.deleted: list[str] = []
         self._facts_by_bank: dict[str, list[dict]] = {}
+        #: raw documents keyed by bank_id, seeded directly by a test (or via
+        #: ``retain``, which also files the raw text here — #1794).
+        self._documents_by_bank: dict[str, dict[str, dict]] = {}
+        self.list_documents_calls: list[str] = []
         #: keyed by bank_id — response-level recall enrichment a test can seed.
         self._entities_by_bank: dict[str, dict] = {}
         self._chunks_by_bank: dict[str, dict] = {}
@@ -56,6 +60,13 @@ class FakeHindsightClient:
                 "mentioned_at": "2026-06-06T00:00:00+00:00",
             }
         )
+        self._documents_by_bank.setdefault(bank_id, {})[document_id] = {
+            "id": document_id,
+            "bank_id": bank_id,
+            "original_text": content,
+            "tags": list(tags or []),
+            "created_at": "2026-06-06T00:00:00+00:00",
+        }
         return {
             "success": True,
             "bank_id": bank_id,
@@ -199,6 +210,23 @@ class FakeHindsightClient:
             for f in raw
         ]
         return {"items": items, "total": len(all_facts), "limit": limit, "offset": offset}
+
+    # ── raw documents (#1794 fallback leg) ────────────────────────────────
+
+    async def list_documents(
+        self, *, bank_id, q=None, tags=None, tags_match=None, limit=100, offset=0
+    ):
+        self.list_documents_calls.append(bank_id)
+        docs = list(self._documents_by_bank.get(bank_id, {}).values())
+        page = docs[offset : offset + limit]
+        items = [{"id": d["id"], "text_length": len(d.get("original_text") or "")} for d in page]
+        return {"items": items, "total": len(docs), "limit": limit, "offset": offset}
+
+    async def get_document(self, *, bank_id, document_id):
+        doc = self._documents_by_bank.get(bank_id, {}).get(document_id)
+        if doc is None:
+            raise Fake404HindsightClient.NotFound()
+        return dict(doc)
 
 
 def test_namespace_to_bank_mapping():
@@ -740,6 +768,7 @@ async def test_recall_returns_list_compatible_results_with_entities_chunks_attrs
             "type": "world",
             "entities": None,
             "source_fact_ids": None,
+            "kind": "fact",
         }
     ]
     assert out.entities == {"Alice": {"entity_id": "e1", "canonical_name": "Alice"}}
@@ -1084,3 +1113,122 @@ async def test_consolidate_real_implementation_hits_engine():
     out = await p.consolidate(dataset="shared", client_id="hermes")
     assert out == {"operation_id": "op-consolidate", "deduplicated": False}
     assert fake.consolidated == ["shared"]
+
+
+# ── raw-document recall fallback (#1794) ──────────────────────────────────
+#
+# Fact extraction can rewrite a retained fact as a meta-observation and drop
+# a literal value (marker/ID/key) entirely, even though the raw document
+# text — filed alongside the fact — still holds it verbatim. These tests
+# exercise HindsightProvider.recall()'s fallback: when the query names a
+# literal-looking token no extracted fact's text contains, it scans a
+# bounded page of the bank's raw documents and augments (never replaces)
+# the fact results with any hit, carrying ``kind: "document"`` provenance.
+
+
+def _seed_extraction_gap(fake: FakeHindsightClient, *, bank_id: str, marker: str) -> None:
+    """Model the #1794 shape directly: the extracted fact is a meta-
+    observation with NO literal value, but the raw document still has it —
+    exactly what a real 0.8B-model extraction produces."""
+    fake._facts_by_bank.setdefault(bank_id, []).append(
+        {
+            "document_id": "d-meta",
+            "text": "User asks about the CT151 validation marker",
+            "tags": [],
+            "mentioned_at": "2026-08-09T00:00:00+00:00",
+        }
+    )
+    fake._documents_by_bank.setdefault(bank_id, {})["d-raw"] = {
+        "id": "d-raw",
+        "bank_id": bank_id,
+        "original_text": f"the CT151 validation marker is {marker}",
+        "tags": [],
+        "created_at": "2026-08-09T00:00:00+00:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_recall_falls_back_to_raw_document_for_dropped_literal():
+    fake = FakeHindsightClient()
+    _seed_extraction_gap(fake, bank_id="shared", marker="MARKER-7734")
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    out = await p.recall(
+        "what is the validation marker MARKER-7734", dataset="shared", client_id="hermes"
+    )
+
+    kinds = {item["text"]: item.get("kind") for item in out}
+    # The meta-fact is still present — augment, not displace.
+    assert kinds["User asks about the CT151 validation marker"] == "fact"
+    # The raw document carrying the literal is appended with document provenance.
+    doc_hits = [item for item in out if item.get("kind") == "document"]
+    assert len(doc_hits) == 1
+    assert "MARKER-7734" in doc_hits[0]["text"]
+    assert doc_hits[0]["source"] == "raw_document"
+    assert doc_hits[0]["metadata"]["document_id"] == "d-raw"
+
+
+@pytest.mark.asyncio
+async def test_recall_skips_fallback_when_fact_already_has_the_literal():
+    fake = FakeHindsightClient()
+    fake._facts_by_bank.setdefault("shared", []).append(
+        {
+            "document_id": "d1",
+            "text": "the validation marker is MARKER-7734",
+            "tags": [],
+            "mentioned_at": "2026-08-09T00:00:00+00:00",
+        }
+    )
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    out = await p.recall("MARKER-7734", dataset="shared", client_id="hermes")
+
+    assert all(item.get("kind") == "fact" for item in out)
+    assert fake.list_documents_calls == []  # no wasted scan — the fact already covers it
+
+
+@pytest.mark.asyncio
+async def test_recall_never_scans_documents_for_a_plain_query():
+    fake = FakeHindsightClient()
+    fake._facts_by_bank.setdefault("shared", []).append(
+        {
+            "document_id": "d1",
+            "text": "Alice likes coffee",
+            "tags": [],
+            "mentioned_at": "2026-08-09T00:00:00+00:00",
+        }
+    )
+    p = HindsightProvider(client=fake, client_id="hermes")
+
+    out = await p.recall("what does Alice like", dataset="shared", client_id="hermes")
+
+    assert [item.get("kind") for item in out] == ["fact"]
+    assert fake.list_documents_calls == []
+
+
+@pytest.mark.asyncio
+async def test_document_fallback_withholds_foreign_private_doc_in_unified_mode():
+    """Unified-bank ACL applies to the fallback too: a doc tagged private to
+    another agent must not leak into the caller's recall just because it
+    happens to contain the queried literal."""
+    fake = FakeHindsightClient()
+    fake._facts_by_bank.setdefault("shared", []).append(
+        {
+            "document_id": "d-meta",
+            "text": "someone asked about a marker",
+            "tags": [],
+            "mentioned_at": "2026-08-09T00:00:00+00:00",
+        }
+    )
+    fake._documents_by_bank.setdefault("shared", {})["d-raw"] = {
+        "id": "d-raw",
+        "bank_id": "shared",
+        "original_text": "the secret marker is MARKER-9999",
+        "tags": ["visibility:private", "agent:other-agent"],
+        "created_at": "2026-08-09T00:00:00+00:00",
+    }
+    p = HindsightProvider(client=fake, client_id="hermes", unified_bank=True)
+
+    out = await p.recall("MARKER-9999", dataset="shared", client_id="hermes")
+
+    assert all(item.get("kind") != "document" for item in out)


### PR DESCRIPTION
## Summary

Closes #1794 on the hal0 side (fact-extraction → recall gap). The
Hindsight engine has no raw-content search endpoint, so the engine-side
half of this stays open — see the follow-up note posted to the issue.

- `HindsightProvider.recall()` detects literal-looking query tokens
  (alnum runs mixing letters + digits, e.g. `MARKER-7734`, `CT151`) and,
  when none of the extracted facts already contain one, scans a bounded
  page of the bank's raw documents (`GET /documents` → `GET /documents/{id}`)
  and substring-matches.
- Any hit is **appended**, never replaces, the fact results — carries
  `kind: "document"` / `source: "raw_document"` provenance so callers can
  tell extracted facts from raw-document augmentation.
- Applies to `/api/memory/recall` and `search()` (which delegates to
  `recall()`), and therefore to the MCP `memory_recall`/`memory_search`
  tools too — all three call the same provider layer.
- Unified-bank ACL (`visibility:private` / `project:<id>`) is enforced on
  the fallback the same way it is on ordinary recall, so a raw document
  can't leak past the caller's normal read scope just because it happens
  to contain the queried literal.

## hal0-side vs engine-side

- **hal0-side (this PR)**: client-side fallback — enumerate + fetch-each
  raw documents and substring-match, capped at 25 docs/bank and 5
  fallback results per recall.
- **Engine-side (open)**: Hindsight's `GET .../documents?q=` filters on
  document *id*, not body text (confirmed against the live daemon's
  OpenAPI schema) — there is no raw-content search endpoint. The correct
  long-term fix is an engine-side full-text/substring search over
  `original_text` so hal0 doesn't need a page-and-fetch-each workaround.
  Noted as a comment on #1794.

## Test plan

- [x] New unit tests in `tests/memory/test_hindsight_provider.py`:
  fallback triggers on a dropped literal, skips when the fact already
  covers it, never scans for a plain (non-literal) query, and respects
  unified-bank private-doc visibility.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/memory/ -q` → 210 passed
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/ -k "memory or hindsight or mcp" -q` → 1203 passed
- [x] `make lint` → clean
- [x] `uv run ruff format --check` on touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)