### PR TITLE
fix(hermes): rc.4 fresh-install polish sweep — 4 items

### DIFF
--- a/installer/agents/hermes/plugins/hal0-provider/plugin.yaml
+++ b/installer/agents/hermes/plugins/hal0-provider/plugin.yaml
@@ -5,6 +5,6 @@
 # role aliases. Registers under `name: hal0` at plugins/model-providers/hal0/.
 
 name: hal0
-kind: provider
+kind: model-provider
 version: 1.0.0
 description: hal0 ProviderProfile — pins chat + aux slots to the local hal0-api (chat_completions, live discovery).

--- a/src/hal0/agents/hermes/plugins/provider_hal0/plugin.yaml
+++ b/src/hal0/agents/hermes/plugins/provider_hal0/plugin.yaml
@@ -5,6 +5,6 @@
 # role aliases. Registers under `name: hal0` at plugins/model-providers/hal0/.
 
 name: hal0
-kind: provider
+kind: model-provider
 version: 1.0.0
 description: hal0 ProviderProfile — pins chat + aux slots to the local hal0-api (chat_completions, live discovery).

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -1442,6 +1442,16 @@ def _build_config_overlay(
     base_url = "http://127.0.0.1:8080/v1" if live_resolve_enabled else primary["backend_url"]
     pairs: list[tuple[str, Any]] = []
 
+    # hooks_auto_accept — the provisioner is also the thing that installs
+    # ``hooks.on_session_start`` (SESSION_START_HOOK, below via
+    # HAL0_CONFIG_LIST_KEYS): a headless box has no TTY to answer the
+    # first-run "approve this hook?" prompt, so without this the hook is
+    # silently skipped every session (agent.shell_hooks: "not allowlisted")
+    # and system-state injection never happens (#1795 item 2). Same
+    # mechanism hermes itself documents as the non-interactive path
+    # (--accept-hooks / HERMES_ACCEPT_HOOKS=1 / hooks_auto_accept: true).
+    pairs.append(("hooks_auto_accept", True))
+
     # model.* — the OpenAI-compatible-LAN wiring. ``provider: custom`` is
     # hermes's built-in bucket for Ollama/vLLM/llama.cpp endpoints; hal0 is
     # that endpoint. max_tokens guards the thinking-model silent-TUI (#635).

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -989,12 +989,71 @@ async def get_model(
     for entry in data:
         if isinstance(entry, dict) and entry.get("id") == model_id:
             return entry
+
+    virtual_entry = await _resolve_virtual_model_entry(request, model_id, data)
+    if virtual_entry is not None:
+        return virtual_entry
+
     from hal0.dispatcher.router import NoRouteFound
 
     raise NoRouteFound(
         f"model {model_id!r} is not advertised by any configured upstream",
         details={"model": model_id},
     )
+
+
+async def _resolve_virtual_model_entry(
+    request: Request, model_id: str, data: list[dict[str, Any]]
+) -> dict[str, object] | None:
+    """Resolve a hal0 virtual model name (``hal0/agent`` et al.) the same way
+    the chat-completions path does (:func:`_normalize_chat_body`), so a
+    client that ``GET``s ``/v1/models/{id}`` to validate a virtual name
+    before chatting doesn't 404 (#1795 item 4).
+
+    Hermes probes ``model.default`` (``hal0/agent`` under live-resolve) via
+    this route on every session start; the aggregated catalog deliberately
+    never lists the canonical virtuals (see the comment in
+    ``_aggregate_models`` — they'd double-list each slot), so the plain
+    id-match loop above always missed and logged a ``dispatch.no_route``
+    before the very next chat turn resolved the same name fine. Returns a
+    catalog row for the resolved physical model with ``id`` rewritten back
+    to the requested virtual name so the caller's own handle round-trips.
+    ``None`` when ``model_id`` isn't a virtual name or doesn't resolve to
+    any advertised row.
+    """
+    if not model_id.startswith("hal0/"):
+        return None
+    from hal0.normalize.resolver import LiveSlotResolver
+
+    views = await _normalize_slot_views(request)
+    resolver = LiveSlotResolver(
+        slot_views_provider=lambda: views,
+        loaded_models_provider=lambda: _normalize_loaded_models(request),
+    )
+    try:
+        res = await resolver.resolve(model_id)
+    except Exception:
+        return None
+    if res is None or not res.model_id:
+        return None
+    # The aggregated catalog lists a co-resident chat slot under its ALIAS
+    # (e.g. "agent"), not its physical model id (e.g. "big") — see
+    # ``hal0_slot_alias_models`` / the test_virtual_models module docstring.
+    # ``res.matched_name`` is that alias when the resolver matched a LIVE
+    # slot in the chain. On the ``fallback=True`` path (nothing in the chain
+    # currently loaded — the common case right after a fresh boot, which is
+    # exactly when hermes probes this route) the resolver deliberately
+    # returns ``matched_name=None``, so fall back to scanning the same slot
+    # views for whichever slot owns ``res.model_id`` and use ITS alias.
+    candidate_ids: list[str] = []
+    if res.matched_name:
+        candidate_ids.append(res.matched_name)
+    candidate_ids.extend(v.name for v in views if v.model_id == res.model_id)
+    candidate_ids.append(res.model_id)
+    for entry in data:
+        if isinstance(entry, dict) and entry.get("id") in candidate_ids:
+            return {**entry, "id": model_id}
+    return None
 
 
 @router.post("/chat/completions")

--- a/src/hal0/cli/agent_shim.py
+++ b/src/hal0/cli/agent_shim.py
@@ -312,6 +312,24 @@ def _build_hermes_argv(cfg: AgentConfig) -> list[str]:
     return argv
 
 
+def _dashboard_ready_status(cfg: AgentConfig) -> str:
+    """The sd_notify ``STATUS=`` string once the hermes process is reachable.
+
+    #1795 item 1: hermes-cli's wheel does not ship a built ``web_dist`` (the
+    dashboard frontend is an upstream external dependency's build artifact,
+    out of hal0's control) and a fresh-install box has no node/npm toolchain
+    to build one at provision time. When that's the case every dashboard
+    route 404s with "Frontend not built. Run: cd web && npm run build" even
+    though the hermes process itself IS up and serving (``/api/events``,
+    ``/api/pty`` — everything except the static UI). Unconditionally
+    claiming "dashboard reachable" in that state is misleading, so the
+    status string reflects whichever case actually held at launch.
+    """
+    if _resolve_web_dist(cfg) is not None:
+        return "hermes dashboard reachable"
+    return "hermes agent up; dashboard UI not built (no web_dist bundled)"
+
+
 _RUNAS_USER = "hal0"
 
 
@@ -409,7 +427,7 @@ def cmd_serve(cfg: AgentConfig) -> int:
             )
         argv = _build_hermes_argv(cfg)
         env = _build_hermes_env(cfg)
-        ready_status = "hermes dashboard reachable"
+        ready_status = _dashboard_ready_status(cfg)
     else:
         _die(f"agent type '{cfg.agent_type}' not supported by this shim yet")
 

--- a/tests/api/test_virtual_models.py
+++ b/tests/api/test_virtual_models.py
@@ -127,3 +127,39 @@ def test_hal0_chat_not_advertised(client, monkeypatch):
 
     ids = [r["id"] for r in client.get("/v1/models").json()["data"]]
     assert "hal0/chat" not in ids
+
+
+def test_get_model_resolves_virtual_name(client, monkeypatch):
+    """#1795 item 4: GET /v1/models/hal0/agent resolves instead of 404ing.
+
+    hal0/agent isn't listed in /v1/models (by design — see module docstring),
+    but hermes probes exactly this route via ``GET /v1/models/{model.default}``
+    on every session start. Before the fix this logged a dispatch.no_route
+    error every session even though the very next chat turn resolved the
+    same virtual name fine via the identical LiveSlotResolver path.
+    """
+    sm = _FakeSlotManager()
+    mr = _FakeModelRegistry()
+    client.app.state.slot_manager = sm
+    client.app.state.model_registry = mr
+    monkeypatch.setattr("hal0.api.hal0_chat_slot_model_ids", lambda sm: {"big"})
+
+    response = client.get("/v1/models/hal0/agent")
+    assert response.status_code == 200, response.text
+    row = response.json()
+    # The requested virtual name round-trips as the id even though the
+    # resolved catalog row underneath is the physical "agent" slot alias.
+    assert row["id"] == "hal0/agent"
+    assert row["owned_by"] == "hal0"
+
+
+def test_get_model_unresolvable_virtual_name_still_404s(client, monkeypatch):
+    """A virtual name with no matching slot still 404s (no false positives)."""
+    sm = _FakeSlotManager()
+    mr = _FakeModelRegistry()
+    client.app.state.slot_manager = sm
+    client.app.state.model_registry = mr
+    monkeypatch.setattr("hal0.api.hal0_chat_slot_model_ids", lambda sm: {"big"})
+
+    response = client.get("/v1/models/hal0/does-not-exist")
+    assert response.status_code == 404

--- a/tests/cli/test_agent_shim.py
+++ b/tests/cli/test_agent_shim.py
@@ -209,6 +209,27 @@ class TestHermesArgv:
         host_idx = argv.index("--host")
         assert argv[host_idx + 1] == "127.0.0.1"
 
+
+class TestDashboardReadyStatus:
+    """#1795 item 1: the sd_notify STATUS= string must not claim the
+    dashboard is reachable when the wheel shipped no built frontend."""
+
+    @staticmethod
+    def _mk_web_dist(venv: Path, pyver: str = "python3.12") -> Path:
+        dist = venv / "lib" / pyver / "site-packages" / "hermes_cli" / "web_dist"
+        dist.mkdir(parents=True)
+        return dist
+
+    def test_reachable_when_web_dist_present(self, tmp_path: Path) -> None:
+        self._mk_web_dist(tmp_path)
+        status = agent_shim._dashboard_ready_status(_cfg(venv=tmp_path))
+        assert status == "hermes dashboard reachable"
+
+    def test_not_built_when_web_dist_missing(self, tmp_path: Path) -> None:
+        status = agent_shim._dashboard_ready_status(_cfg(venv=tmp_path))
+        assert status == "hermes agent up; dashboard UI not built (no web_dist bundled)"
+        assert "reachable" not in status
+
     def test_no_open_browser(self) -> None:
         argv = agent_shim._build_hermes_argv(_cfg())
         assert "--no-open" in argv


### PR DESCRIPTION
## Summary

Rollup fix for the four hermes-integration findings from the rc.4 fresh-install validation sweep (CT151).

1. **Dashboard ships without a built frontend** — the hermes-cli wheel does not bundle a built `web_dist` (upstream's own frontend build artifact) and the box has no node/npm toolchain to build one at provision time. Building it hal0-side is out of scope for this polish sweep (would mean adding a node toolchain to provisioning). Instead, `hal0-agent`'s `sd_notify STATUS=` string now reflects reality: `"hermes dashboard reachable"` only when a `web_dist` was actually resolved, otherwise `"hermes agent up; dashboard UI not built (no web_dist bundled)"`. The process (API/PTY/WS) genuinely is up either way — only the UI claim was wrong.
2. **Installer-wired session hook never executed** — the provisioner installs `hooks.on_session_start` (`inject-system-state.sh`) but never set the accept mechanism it controls, so hermes's TTY-approval gate skipped the hook on every headless session start. Config overlay now also sets `hooks_auto_accept: true`.
3. **Bundled plugin kind `provider` → `model-provider`** — matches hermes_cli's actual valid-kind set (`backend, exclusive, model-provider, platform, standalone`); previously silently downgraded to `standalone` with a startup warning.
4. **`dispatch.no_route` logged every session for `hal0/agent`** — hermes probes `GET /v1/models/{model.default}` on session start; `hal0/agent` is deliberately never listed in the aggregated `/v1/models` catalog (would double-list every slot), so the plain id-match lookup always missed. `GET /v1/models/{id}` now resolves `hal0/*` virtual names through the same `LiveSlotResolver` chain `/chat/completions` already uses, before falling through to `NoRouteFound`.

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api/test_virtual_models.py tests/api/test_v1_dispatch.py tests/api/test_v1_models_filters.py tests/api/test_models_routes.py tests/cli/test_agent_shim.py tests/agents/test_hermes_provision.py tests/agents/test_hermes_provision_mcp_auth.py tests/agents/test_hermes_live_resolve_render.py tests/agents/test_hermes_security_deliverables.py tests/normalize/test_resolver.py tests/api/test_chat_normalization.py -q` → 318 passed
- [x] `make lint` → clean
- [x] `uv run ruff format --check` on touched files → clean
- [x] Live-box grounding via read-only SSH to CT151 (10.0.1.151) confirmed: no `web_dist` anywhere under the hermes venv, no `npm`/`node` on the box, `hooks_auto_accept` absent from `config.yaml`, repeated `not allowlisted` warnings in `agent.log`, and `plugin.yaml` `kind: provider` matching the issue's exact log lines.
- [ ] Not re-deployed to CT151 (read-only grounding only, per task scope) — recommend re-validating on the next rc.5 fresh-install sweep.

Closes #1795

🤖 Generated with [Claude Code](https://claude.com/claude-code)