### PR TITLE
fix(api): advertise the EFFECTIVE context window, not the raw slot ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
+- Slot `ctx_max`, `/v1/models` `context_length`/`max_context_window`, and the
+  SlotView dashboard now advertise the EFFECTIVE context window llama-server
+  actually launched with, instead of the raw slot-TOML ceiling — a stale,
+  potentially larger number under the v1.0 model-owns-context-size split.
+  Clients that sized requests off the advertised ceiling could overrun the
+  real window and get truncated/rejected completions (#1788).
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -269,21 +269,16 @@ def _coerce_ctx(raw: Any) -> int | None:
     return ctx if ctx > 0 else None
 
 
-def _slot_ctx_size(
-    cfg: dict[str, Any],
-    model_registry: ModelRegistry | None = None,
-    model_id: str = "",
-) -> int | None:
-    """Resolve a slot's context length.
+def _raw_slot_ctx_ceiling(cfg: dict[str, Any]) -> int | None:
+    """Read the slot TOML's on-disk context-size ceiling, verbatim.
 
     The on-disk slot TOMLs are inconsistent about the key name:
     ``agent.toml`` uses ``[model] ctx_size`` while ``utility.toml``
     uses ``[model] context_size`` and ``chat.toml`` pins neither. Read
     BOTH keys (plus a couple of flat shapes seen in live /api/slots
-    payloads), then fall back to the model registry entry's
-    ``defaults.context_size`` so a slot that doesn't pin a ctx still
-    advertises the model's native window. Returns ``None`` only when no
-    source yields a positive value.
+    payloads). Returns ``None`` only when no source yields a positive
+    value — this is a hardware CEILING, not the effective window (see
+    :func:`_slot_ctx_size`).
     """
     model_section = cfg.get("model") or {}
     defaults = cfg.get("defaults") or {}
@@ -301,19 +296,34 @@ def _slot_ctx_size(
             ctx = _coerce_ctx(source.get(key))
             if ctx is not None:
                 return ctx
-
-    # Registry fallback — the model's declared default context window.
-    if model_registry is not None and model_id:
-        try:
-            entry = model_registry.get(model_id)
-        except Exception:
-            entry = None
-        if entry is not None:
-            entry_defaults = getattr(entry, "defaults", None)
-            ctx = _coerce_ctx(getattr(entry_defaults, "context_size", None))
-            if ctx is not None:
-                return ctx
     return None
+
+
+def _slot_ctx_size(
+    cfg: dict[str, Any],
+    model_registry: ModelRegistry | None = None,
+    model_id: str = "",
+) -> int | None:
+    """Resolve a slot's EFFECTIVE context length — what llama-server actually
+    runs with, not the raw slot-TOML ceiling (#1788).
+
+    The on-disk ``[model] ctx_size``/``context_size`` (:func:`_raw_slot_ctx_ceiling`)
+    is a hardware CEILING under the v1.0 ownership split: the MODEL owns
+    context size, and the slot value can only clamp it down, never raise it
+    above what the model declares. Delegates the actual precedence to
+    :func:`hal0.providers.container.resolve_effective_context_size` — the
+    SAME resolver the launch path uses — so this serializer can never drift
+    from the number llama-server was actually started with. Always returns a
+    positive int (the resolver's safe floor applies even when there is no
+    slot ceiling and no model info at all).
+    """
+    from hal0.providers.container import resolve_effective_context_size
+
+    slot_ceiling = _raw_slot_ctx_ceiling(cfg)
+    slot_name = str(cfg.get("name") or "")
+    return resolve_effective_context_size(
+        slot_ceiling, model_registry, model_id, slot_name=slot_name
+    )
 
 
 def _model_recipe(entry: Any) -> str | None:
@@ -390,12 +400,17 @@ async def hal0_slot_alias_models(
     * ``name`` — ``"<slot> · <model display name>"``; the display name is
       pulled from the model registry when the slot's model id is
       registered, falling back to the bare model id otherwise.
-    * ``context_length`` / ``max_context_window`` — the slot's configured
-      context window (reading either ``ctx_size`` or ``context_size`` from
-      the slot TOML), falling back to the model registry entry's
-      ``defaults.context_size``. Both keys carry the same value — some
-      OpenAI-compat clients probe ``max_context_window`` instead of the
-      canonical ``context_length``.
+    * ``context_length`` / ``max_context_window`` — the slot's EFFECTIVE
+      context window: what llama-server actually runs with, not the raw
+      slot-TOML ceiling (``ctx_size``/``context_size``). The MODEL owns
+      context size (v1.0 ownership split); the slot value only clamps it
+      down. See :func:`_slot_ctx_size` /
+      :func:`hal0.providers.container.resolve_effective_context_size`
+      (#1788 — this used to advertise the raw ceiling, which could be
+      larger than what the model was actually launched with, so clients
+      sizing requests off it could overrun the real window). Both keys
+      carry the same value — some OpenAI-compat clients probe
+      ``max_context_window`` instead of the canonical ``context_length``.
     * ``owned_by`` — ``"hal0"``.
     * ``downloaded`` — always ``True``: a bound llm slot's configured
       model is, by construction, a real file already resident on this

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1404,6 +1404,54 @@ def _guard_fpx_quant_runner(
     )
 
 
+def resolve_effective_context_size(
+    slot_ceiling: int | None,
+    model_registry: Any = None,
+    model_id: str = "",
+    *,
+    slot_name: str = "",
+) -> int:
+    """Public read-only-surface wrapper around :func:`_resolve_context_size`.
+
+    #1788: ``ctx_max``/``context_length``/``max_context_window`` on the slots
+    dashboard, ``/v1/models`` and the SlotView aggregator used to echo the
+    raw slot-TOML ceiling verbatim — the number llama-server was launched
+    with under the pre-1.0 "slot overrides model" rule, not the number it
+    actually runs with now that the MODEL owns context size (see
+    :func:`_resolve_context_size`'s docstring for the full precedence).
+    Clients that sized requests off the advertised (stale, larger) number
+    could overrun the real window and get truncated/rejected completions.
+
+    This wrapper is the ONE place read-only surfaces look up the model
+    registry entry and hand off to the shared resolver, so the ``min()``
+    clamp itself is never re-implemented in a view/serializer — any future
+    change to the precedence rule only has to happen in
+    :func:`_resolve_context_size`.
+
+    ``model_registry`` / ``model_id`` are best-effort: a ``None`` registry,
+    an empty ``model_id``, or a registry miss (hand-staged model, not-yet
+    -imported row) all degrade to an empty ``model_info``, which resolves
+    the same way an unregistered model does at launch time — dense-capped
+    native window if metadata happens to be present, else the safe 8192
+    floor, still clamped by ``slot_ceiling`` if that is smaller. A
+    model-less slot (no ``model_id`` at all) resolves the same way: there is
+    no model fact to be authoritative, so the safe floor (or the slot
+    ceiling, if lower) is reported rather than inventing a number.
+    """
+    model_info: dict[str, Any] = {}
+    if model_registry is not None and model_id:
+        try:
+            entry = model_registry.get(model_id)
+        except Exception:
+            entry = None
+        if entry is not None:
+            try:
+                model_info = entry.model_dump() if hasattr(entry, "model_dump") else dict(entry)
+            except Exception:
+                model_info = {}
+    return _resolve_context_size(slot_ceiling, model_info, slot_name=slot_name)
+
+
 def _resolve_llama_scalars(
     slot_cfg: dict[str, Any],
     model_info: dict[str, Any],

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -422,6 +422,36 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return out
 
 
+def _resolve_ctx_max(
+    raw_ctx_max: int | None,
+    model_registry: Any,
+    model_id: str,
+    slot_name: str,
+) -> int | None:
+    """Best-effort EFFECTIVE context resolution for the dashboard's ``ctx_max``.
+
+    #1788: ``config_enrichment`` lifts ``ctx_max`` straight off the slot
+    TOML — the raw hardware ceiling, not what llama-server actually runs
+    with now that the MODEL owns context size (v1.0 ownership split; see
+    :func:`hal0.providers.container._resolve_context_size`). The aggregator
+    calls this after merging ``config_enrichment``'s output so the
+    "ctx used / max" pane reports the same number the launch path resolved,
+    using the model registry the aggregator already carries.
+
+    Imported lazily (heavy neighbour, see module docstring) and never
+    raises: a resolution failure degrades to the raw TOML ceiling — the
+    pre-fix behavior — rather than breaking the slots list.
+    """
+    try:
+        from hal0.providers.container import resolve_effective_context_size
+
+        return resolve_effective_context_size(
+            raw_ctx_max, model_registry, model_id, slot_name=slot_name
+        )
+    except Exception:
+        return raw_ctx_max
+
+
 # ── concern 3: container probe ───────────────────────────────────────────────
 
 
@@ -917,6 +947,19 @@ class SlotViewAggregator:
             if c_extra:
                 for k, v in c_extra.items():
                     payload.setdefault(k, v)
+
+            # #1788: re-resolve ctx_max to the EFFECTIVE window (only when
+            # there's a model bound, or an explicit raw ceiling was lifted —
+            # a model-less slot with neither has nothing to resolve).
+            raw_ctx_max = payload.get("ctx_max")
+            model_id = str(payload.get("model_default") or "")
+            if model_id or isinstance(raw_ctx_max, int):
+                payload["ctx_max"] = _resolve_ctx_max(
+                    raw_ctx_max if isinstance(raw_ctx_max, int) else None,
+                    self._registry,
+                    model_id,
+                    slot_name,
+                )
 
         # Per-slot resident memory (model weights + KV-cache estimate) so the
         # dashboard memory map (W4) attributes a real footprint per slot. Only

--- a/tests/api/test_llm_slot_views.py
+++ b/tests/api/test_llm_slot_views.py
@@ -13,6 +13,29 @@ class _FakeSlotManager:
         return self._cfgs
 
 
+class _FakeDefaults:
+    def __init__(self, context_size):
+        self.context_size = context_size
+
+
+class _FakeModel:
+    def __init__(self, context_size=None):
+        self.defaults = _FakeDefaults(context_size)
+
+    def model_dump(self):
+        return {"defaults": {"context_size": self.defaults.context_size}, "metadata": {}}
+
+
+class _FakeModelRegistry:
+    def __init__(self, models):
+        self._models = models
+
+    def get(self, model_id):
+        if model_id not in self._models:
+            raise KeyError(model_id)
+        return self._models[model_id]
+
+
 @pytest.mark.asyncio
 async def test_llm_slot_views_filters_and_projects():
     cfgs = [
@@ -20,18 +43,25 @@ async def test_llm_slot_views_filters_and_projects():
             "name": "primary",
             "type": "llm",
             "device": "gpu-vulkan",
+            # slot ceiling (65536) is larger than what the model declares —
+            # #1788: the model wins, so the stale larger ceiling must not
+            # be echoed back.
             "model": {"default": "big", "context_size": 65536},
         },
         {
             "name": "utility",
             "type": "llm",
             "device": "gpu-vulkan",
-            "model": {"default": "tiny", "context_size": 8192},
+            # slot ceiling (4096) is smaller than the model's declared
+            # window — a genuine hardware clamp, so it wins.
+            "model": {"default": "tiny", "context_size": 4096},
         },
         {
             "name": "agent",
             "type": "llm",
             "device": "npu",
+            # ctx_size key (not context_size) must also be read correctly;
+            # model isn't registered, so resolution falls to the safe floor.
             "model": {"default": "flm", "ctx_size": 32768},
         },
         {"name": "embed", "type": "embedding", "model": {"default": "e5"}},
@@ -40,14 +70,22 @@ async def test_llm_slot_views_filters_and_projects():
         {"name": "nomodel", "type": "llm", "model": {}},
         {"name": "off", "type": "llm", "model": {"default": ""}},
     ]
-    views = await hal0_llm_slot_views(_FakeSlotManager(cfgs))
+    registry = _FakeModelRegistry(
+        {
+            "big": _FakeModel(context_size=8000),
+            "tiny": _FakeModel(context_size=16384),
+            # "flm" intentionally absent — unregistered model.
+        }
+    )
+    views = await hal0_llm_slot_views(_FakeSlotManager(cfgs), registry)
     by_name = {v["name"]: v for v in views}
     assert set(by_name) == {"primary", "utility", "agent"}
     assert by_name["primary"]["device"] == "gpu-vulkan"
-    assert by_name["primary"]["context_length"] == 65536
-    assert by_name["utility"]["context_length"] == 8192
-    # ctx_size key (not context_size) must also be read correctly
-    assert by_name["agent"]["context_length"] == 32768
+    # #1788: EFFECTIVE context, not the raw slot ceiling.
+    assert by_name["primary"]["context_length"] == 8000
+    assert by_name["utility"]["context_length"] == 4096
+    # unregistered model + slot ceiling above the safe floor → safe floor.
+    assert by_name["agent"]["context_length"] == 8192
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_v1_slot_alias_models.py
+++ b/tests/api/test_v1_slot_alias_models.py
@@ -37,6 +37,15 @@ class _FakeModel:
         self.name = name
         self.defaults = _FakeDefaults(context_size) if context_size is not None else None
 
+    def model_dump(self) -> dict[str, Any]:
+        # #1788: resolve_effective_context_size converts a registry entry via
+        # model_dump() (mirrors the real pydantic Model), so the fake needs
+        # to produce the same {"defaults": {"context_size": ...}} shape.
+        return {
+            "defaults": {"context_size": self.defaults.context_size} if self.defaults else {},
+            "metadata": {},
+        }
+
 
 class _FakeModelRegistry:
     def __init__(self, models: dict[str, tuple[str, int | None]]):
@@ -120,11 +129,15 @@ async def test_all_model_bound_llm_slots_emit_alias_entries() -> None:
     # utility's model isn't in the registry → falls back to the model id.
     assert by_id["utility"]["name"] == "utility · qwen3-zero-coder-v2-0.8b-f16"
 
-    # context_length surfaces for all three: agent-hermes via ``ctx_size``,
-    # utility via ``context_size``, primary via the registry fallback
-    # (defaults.context_size) since its TOML pins no ctx key.
-    assert by_id["agent-hermes"]["context_length"] == 65536
-    assert by_id["utility"]["context_length"] == 32768
+    # context_length is the EFFECTIVE window (#1788), not the raw slot-TOML
+    # ceiling: primary's model declares 65536 with no slot ceiling, so it
+    # passes through unchanged. agent-hermes and utility both pin a slot
+    # ceiling (``ctx_size`` / ``context_size``) but their models declare no
+    # context_size of their own, so resolution falls to the safe 8192 floor
+    # (well below either TOML ceiling) rather than echoing the stale,
+    # larger slot number.
+    assert by_id["agent-hermes"]["context_length"] == 8192
+    assert by_id["utility"]["context_length"] == 8192
     assert by_id["primary"]["context_length"] == 65536
 
     # §21.5: max_context_window aliases context_length (same value, for

--- a/tests/api/test_virtual_models.py
+++ b/tests/api/test_virtual_models.py
@@ -44,6 +44,11 @@ class _FakeModelEntry:
         self.name = model_id
         self.defaults = type("_", (), {"context_size": 65536})()
 
+    def model_dump(self):
+        # #1788: resolve_effective_context_size converts a registry entry via
+        # model_dump() (mirrors the real pydantic Model).
+        return {"defaults": {"context_size": self.defaults.context_size}, "metadata": {}}
+
 
 @pytest.fixture
 def configured_client(isolated_client, monkeypatch):

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -48,6 +48,7 @@ from hal0.providers.container import (
     _render_quadlet_from_plan,
     _resolve_context_size,
     _resolve_model_path,
+    resolve_effective_context_size,
     resolved_command_for_slot,
 )
 from hal0.slots.argv import resolve_argv
@@ -1367,6 +1368,72 @@ class TestContextSizeOwnership:
         cfg = _slot_cfg()
         mi = _model_info(defaults={"context_size": -1})
         assert self._ctx(self._spec(cfg, mi).command) == str(_CTX_SAFE_FALLBACK)
+
+
+class _FakeCtxDefaults:
+    def __init__(self, context_size: int | None) -> None:
+        self.context_size = context_size
+
+
+class _FakeCtxModel:
+    """Duck-typed registry entry — mirrors the real pydantic ``Model``."""
+
+    def __init__(self, context_size: int | None) -> None:
+        self.defaults = _FakeCtxDefaults(context_size)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"defaults": {"context_size": self.defaults.context_size}, "metadata": {}}
+
+
+class _FakeCtxRegistry:
+    def __init__(self, models: dict[str, Any]) -> None:
+        self._models = models
+
+    def get(self, model_id: str) -> Any:
+        if model_id not in self._models:
+            raise KeyError(model_id)
+        return self._models[model_id]
+
+
+class TestResolveEffectiveContextSize:
+    """#1788 — the read-only-surface wrapper read-only views (ctx_max,
+    /v1/models context_length/max_context_window) call instead of
+    re-implementing the model/slot precedence themselves."""
+
+    def test_matches_resolve_context_size_for_a_registered_model(self) -> None:
+        registry = _FakeCtxRegistry({"m": _FakeCtxModel(8000)})
+        assert resolve_effective_context_size(65536, registry, "m") == 8000
+
+    def test_slot_ceiling_still_clamps_down(self) -> None:
+        registry = _FakeCtxRegistry({"m": _FakeCtxModel(65536)})
+        assert resolve_effective_context_size(16384, registry, "m") == 16384
+
+    def test_none_registry_degrades_to_safe_floor(self) -> None:
+        assert resolve_effective_context_size(65536, None, "m") == _CTX_SAFE_FALLBACK
+
+    def test_empty_model_id_degrades_to_safe_floor(self) -> None:
+        registry = _FakeCtxRegistry({"m": _FakeCtxModel(8000)})
+        assert resolve_effective_context_size(65536, registry, "") == _CTX_SAFE_FALLBACK
+
+    def test_registry_miss_degrades_to_safe_floor(self) -> None:
+        registry = _FakeCtxRegistry({})
+        assert resolve_effective_context_size(65536, registry, "unregistered") == _CTX_SAFE_FALLBACK
+
+    def test_registry_get_raising_is_swallowed(self) -> None:
+        class _BoomRegistry:
+            def get(self, model_id: str) -> Any:
+                raise RuntimeError("registry exploded")
+
+        assert resolve_effective_context_size(65536, _BoomRegistry(), "m") == _CTX_SAFE_FALLBACK
+
+    def test_model_less_slot_with_no_ceiling_reports_the_safe_floor(self) -> None:
+        """A model-less slot (no id at all, no TOML ceiling) has no model fact
+        to be authoritative — the safe floor is reported rather than
+        inventing a number."""
+        assert resolve_effective_context_size(None, None, "") == _CTX_SAFE_FALLBACK
+
+    def test_always_returns_a_positive_int(self) -> None:
+        assert isinstance(resolve_effective_context_size(None, None, ""), int)
 
 
 class TestFamilyDefaults:

--- a/tests/slot_view/test_aggregator.py
+++ b/tests/slot_view/test_aggregator.py
@@ -891,6 +891,76 @@ class TestMemoryAttribution:
         assert seen["registry"] is marker
 
 
+# ── concern 4.5: ctx_max EFFECTIVE-window re-resolution (#1788) ─────────────
+
+
+class _FakeCtxDefaults:
+    def __init__(self, context_size: int | None) -> None:
+        self.context_size = context_size
+
+
+class _FakeCtxModel:
+    def __init__(self, context_size: int | None) -> None:
+        self.defaults = _FakeCtxDefaults(context_size)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"defaults": {"context_size": self.defaults.context_size}, "metadata": {}}
+
+
+class _FakeCtxRegistry:
+    def __init__(self, models: dict[str, Any]) -> None:
+        self._models = models
+
+    def get(self, model_id: str) -> Any:
+        if model_id not in self._models:
+            raise KeyError(model_id)
+        return self._models[model_id]
+
+
+class TestCtxMaxEffectiveResolution:
+    async def test_ctx_max_downgraded_to_model_window(self, no_mem: None) -> None:
+        # #1788: the slot TOML ceiling (65536) is stale/larger than what the
+        # model actually declares (8000) — the dashboard must surface the
+        # EFFECTIVE window, not the raw ceiling.
+        cfg = _llm_cfg(model={"default": "qwen3-4b", "context_size": 65536})
+        registry = _FakeCtxRegistry({"qwen3-4b": _FakeCtxModel(8000)})
+        agg = _agg(
+            FakeSlotManager(slots=[_slot(model_id="qwen3-4b")], configs=[cfg]),
+            registry=registry,
+        )
+        views = await agg.snapshot()
+        assert views[0].to_dict()["ctx_max"] == 8000
+
+    async def test_ctx_max_kept_at_hardware_ceiling_when_smaller(self, no_mem: None) -> None:
+        # A genuinely smaller slot ceiling (VRAM clamp) still wins over a
+        # larger model-declared window.
+        cfg = _llm_cfg(model={"default": "qwen3-4b", "context_size": 16384})
+        registry = _FakeCtxRegistry({"qwen3-4b": _FakeCtxModel(65536)})
+        agg = _agg(
+            FakeSlotManager(slots=[_slot(model_id="qwen3-4b")], configs=[cfg]),
+            registry=registry,
+        )
+        views = await agg.snapshot()
+        assert views[0].to_dict()["ctx_max"] == 16384
+
+    async def test_ctx_max_resolution_failure_degrades_to_raw_ceiling(
+        self, no_mem: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A broken resolver must never take down the whole slots list — fall
+        # back to the pre-fix (raw ceiling) value instead of raising.
+        def boom(*_a: Any, **_kw: Any) -> int:
+            raise RuntimeError("resolver exploded")
+
+        monkeypatch.setattr("hal0.providers.container.resolve_effective_context_size", boom)
+        cfg = _llm_cfg(model={"default": "qwen3-4b", "context_size": 65536})
+        agg = _agg(
+            FakeSlotManager(slots=[_slot(model_id="qwen3-4b")], configs=[cfg]),
+            registry=_FakeCtxRegistry({}),
+        )
+        views = await agg.snapshot()
+        assert views[0].to_dict()["ctx_max"] == 65536
+
+
 # ── concern 5: metric injection ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Slot `ctx_max`, `/v1/models` `context_length`/`max_context_window`, and the SlotView dashboard used to echo the raw slot-TOML `[model].ctx_size`/`context_size` verbatim. Under the v1.0 "model owns context size" split, that value is a hardware ceiling only — llama-server actually launches with `min(model_authoritative, slot_ceiling)`, computed by `providers/container._resolve_context_size`. Clients that sized requests off the advertised (stale, potentially larger) ceiling could overrun the real context window and get truncated/rejected completions.
- Adds `providers/container.resolve_effective_context_size(slot_ceiling, model_registry, model_id, *, slot_name)`, a thin read-only-surface wrapper around the existing launch-path resolver so the `min()` precedence logic lives in exactly one place.
- Routes the affected serializers through it instead of duplicating the clamp:
  - `slot_view/__init__.py`: `SlotViewAggregator.snapshot()` re-resolves `ctx_max` after `config_enrichment` lifts the raw TOML value (fails soft to the raw ceiling if resolution throws).
  - `api/__init__.py`: `_slot_ctx_size` (used by both `hal0_llm_slot_views`'s `context_length` and `hal0_slot_alias_models`'s `context_length`/`max_context_window`) now calls the resolver instead of falling back only to `defaults.context_size`.

### Fallback semantics

- Model without a registry `context_length`/`defaults.context_size`, a registry miss (unregistered/hand-staged model), and a model-less slot (no `model_id` at all) all degrade to the same safe **8192** floor the launch path uses — still clamped down further by the slot ceiling if that's smaller. There's no model fact to be authoritative in any of these cases, so the safe floor is reported rather than inventing a number.
- A `resolve_effective_context_size` failure (broken registry, unexpected type, etc.) is swallowed in the SlotView aggregator and degrades to the pre-fix raw-ceiling value rather than breaking the whole `/api/slots` list.

## Test plan

- [x] `tests/providers/test_container.py::TestResolveEffectiveContextSize` — new unit tests for the wrapper (registered model, clamp-down, `None` registry, empty model id, registry miss, registry exception, model-less slot, always-positive-int).
- [x] `tests/slot_view/test_aggregator.py::TestCtxMaxEffectiveResolution` — new tests for the `ctx_max` re-resolution in `SlotViewAggregator.snapshot()` (model-window downgrade, hardware-ceiling clamp preserved, resolver-failure fallback).
- [x] `tests/api/test_llm_slot_views.py`, `tests/api/test_v1_slot_alias_models.py`, `tests/api/test_virtual_models.py` — updated fakes/expectations to assert the EFFECTIVE window instead of the raw slot ceiling.
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers/test_container.py tests/api/ tests/slot_view/ -q` → **1918 passed, 1 skipped**
- [x] `make lint` → clean
- [x] `uv run ruff format --check .` → clean on all touched files (6 unrelated pre-existing files elsewhere in the repo need reformatting, untouched by this PR)

Closes #1788

🤖 Generated with [Claude Code](https://claude.com/claude-code)