### PR TITLE
fix(memory): auto-retry no-chat-model dead letters, honest status wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,19 +37,6 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
-- **Memory: no-chat-model window no longer dead-letters retains forever.**
-  On a fresh install, before any chat slot serves a model, every retain's
-  fact-extraction call 404s `dispatch.no_route` against hal0's own
-  dispatcher — expected, since every llm slot ships model-less (WS-E
-  #1107). Hindsight's poller exhausted its retry ladder and dead-lettered
-  the op with nothing to re-queue it once a model finally loaded, and
-  `hal0 memory status` printed `Writes FAILING` for what was really just
-  a startup window (#1792). `/api/status` (and `hal0 memory status`) now
-  report a `waiting — no chat model loaded` state instead of `FAILING`
-  when the configured extraction slot has no model bound, and once a
-  routable chat model appears, a bounded auto-retry sweep (cooldown +
-  sweep-count capped, so a genuinely broken pipeline still surfaces as
-  FAILING) re-queues whatever dead-lettered during the window.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
+- **Memory: no-chat-model window no longer dead-letters retains forever.**
+  On a fresh install, before any chat slot serves a model, every retain's
+  fact-extraction call 404s `dispatch.no_route` against hal0's own
+  dispatcher — expected, since every llm slot ships model-less (WS-E
+  #1107). Hindsight's poller exhausted its retry ladder and dead-lettered
+  the op with nothing to re-queue it once a model finally loaded, and
+  `hal0 memory status` printed `Writes FAILING` for what was really just
+  a startup window (#1792). `/api/status` (and `hal0 memory status`) now
+  report a `waiting — no chat model loaded` state instead of `FAILING`
+  when the configured extraction slot has no model bound, and once a
+  routable chat model appears, a bounded auto-retry sweep (cooldown +
+  sweep-count capped, so a genuinely broken pipeline still surfaces as
+  FAILING) re-queues whatever dead-lettered during the window.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/src/hal0/api/routes/health.py
+++ b/src/hal0/api/routes/health.py
@@ -16,6 +16,7 @@ a follow-up (scrape each container's own ``/metrics``).
 
 from __future__ import annotations
 
+import contextlib
 import shutil
 from pathlib import Path
 from typing import Any
@@ -70,6 +71,36 @@ def _memory_degraded(request: Request) -> bool | None:
     return bool(getattr(provider, "degraded", False))
 
 
+async def _extraction_target_resolves(request: Request, provider: Any) -> bool | None:
+    """Does the memory engine's configured extraction slot resolve to a
+    model-bound llm slot right now? (#1792)
+
+    Hindsight's native fact-extraction calls back into hal0's own
+    OpenAI-compat dispatcher (``HINDSIGHT_API_LLM_MODEL=hal0/<slot>``); on a
+    fresh install every llm slot ships model-less (WS-E #1107), so that call
+    404s ``dispatch.no_route`` until the operator loads a model — a
+    deterministic, hal0-side fact, not something that needs to be inferred
+    from Hindsight's own error text.
+
+    Returns ``None`` when this can't be determined (no slot manager wired —
+    e.g. a test app that bypasses the normal lifespan, or a provider with no
+    ``extraction_slot`` of its own): callers must treat that as "unknown",
+    never as evidence either way.
+    """
+    if getattr(request.app.state, "slot_manager", None) is None:
+        return None
+    extraction_slot = getattr(provider, "extraction_slot", None)
+    if not extraction_slot:
+        return None
+    from hal0.api.routes.memory import _enabled_llm_slots
+
+    try:
+        available = await _enabled_llm_slots(request)
+    except Exception:  # pragma: no cover — defensive, matches _enabled_llm_slots' own fail-soft
+        return None
+    return extraction_slot in available
+
+
 async def _memory_write_health(request: Request) -> dict[str, Any] | None:
     """Retain-pipeline health for /api/status, or None when unavailable.
 
@@ -88,6 +119,15 @@ async def _memory_write_health(request: Request) -> dict[str, Any] | None:
     Fail-soft: the probe behind this is TTL-cached inside the provider and
     swallows engine errors, and any unexpected raise degrades to None rather
     than 500ing the dashboard's poll.
+
+    #1792: when the engine's operation counters show writes degraded AND the
+    configured extraction slot has no model bound yet, that is the ENTIRE
+    explanation — every failure in that window is the same dispatch.no_route
+    404, not an operator-actionable outage — so this downgrades the verdict
+    to a "waiting" state instead of FAILING. Conversely, once the slot
+    resolves, this opportunistically kicks a bounded auto-retry sweep so
+    whatever dead-lettered during the window recovers without a manual
+    ``hal0 memory ops retry``.
     """
     provider = getattr(request.app.state, "memory_provider", None)
     if provider is None:
@@ -100,7 +140,29 @@ async def _memory_write_health(request: Request) -> dict[str, Any] | None:
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("hal0.memory.write_health_failed", error=str(exc))
         return None
-    return health if isinstance(health, dict) else None
+    if not isinstance(health, dict):
+        return None
+
+    resolves = await _extraction_target_resolves(request, provider)
+    if resolves is False and health.get("degraded"):
+        health = dict(health)
+        health["degraded"] = False
+        health["reason"] = "no_chat_model"
+        health["waiting_on"] = "chat_model"
+    elif resolves is True:
+        retry = getattr(provider, "maybe_auto_retry_dead_letters", None)
+        if retry is not None:
+            try:
+                retried = await retry()
+            except Exception as exc:  # pragma: no cover — defensive, never blocks /api/status
+                log.warning("hal0.memory.auto_retry_dead_letters_failed", error=str(exc))
+                retried = None
+            if retried:
+                with contextlib.suppress(Exception):
+                    fresh = await probe(max_age_s=0)
+                    if isinstance(fresh, dict):
+                        health = fresh
+    return health
 
 
 @router.get("/status")
@@ -187,7 +249,9 @@ async def get_status(request: Request) -> dict[str, Any]:
         # — reads keep working while every write is silently dropped.
         # True  → writes were recently observed to fail (raised retain, or the
         #         engine's failed-operation counter climbing).
-        # False → the retain pipeline looks healthy.
+        # False → the retain pipeline looks healthy — OR (#1792) it's in the
+        #         expected no-chat-model window on a fresh install, in which
+        #         case ``memory_write_health.waiting_on == "chat_model"``.
         # None  → memory disabled, or the provider has no retain pipeline.
         "memory_write_degraded": (
             None if memory_write_health is None else bool(memory_write_health.get("degraded"))

--- a/src/hal0/cli/memory_commands.py
+++ b/src/hal0/cli/memory_commands.py
@@ -138,7 +138,17 @@ def _add_write_rows(t: Table, s: dict) -> None:
         # No retain pipeline to report on (volatile fallback / other provider).
         return
     reason = (health or {}).get("reason")
-    if write_degraded is True:
+    if (health or {}).get("waiting_on") == "chat_model":
+        # #1792: a fresh install ships every llm slot model-less, so every
+        # retain's extraction call 404s until the operator loads one — that
+        # is expected, self-healing (auto-retry kicks in once a model is
+        # bound), and not "memory is broken".
+        t.add_row(
+            "Writes",
+            "[yellow]waiting[/yellow] — no chat model loaded: retains will "
+            "process once one is available",
+        )
+    elif write_degraded is True:
         detail = (health or {}).get("last_error") or reason or "unknown"
         t.add_row("Writes", f"[red]FAILING[/red] — {reason}: {detail}")
     elif reason == "unknown":

--- a/src/hal0/memory/hindsight_provider.py
+++ b/src/hal0/memory/hindsight_provider.py
@@ -290,6 +290,28 @@ _WRITE_HEALTH_TTL_S = 30.0
 #: Operation statuses sampled from the engine's operations endpoint.
 _WRITE_OP_STATUSES = ("failed", "pending", "processing")
 
+# ── auto-retry of no-chat-model dead letters (#1792) ──────────────────────
+#
+# A fresh install ships every llm slot model-less (WS-E #1107); until the
+# operator loads one, every retain's extraction call 404s against hal0's own
+# dispatcher (dispatch.no_route). Hindsight's poller exhausts its own retry
+# ladder (~28 minutes) and dead-letters the op — nothing then re-queues it
+# once a model finally loads. ``maybe_auto_retry_dead_letters`` closes that
+# gap; these bounds keep it from ever becoming an unattended retry storm for
+# a *different*, genuinely broken pipeline.
+
+#: Minimum gap between two auto-retry sweeps.
+_AUTO_RETRY_COOLDOWN_S = 60.0
+
+#: Hard cap on sweeps for this provider's lifetime. A model-availability
+#: window closes once, so a handful of sweeps is plenty; capping means a
+#: pipeline that is failing for some OTHER reason surfaces as genuinely
+#: FAILING again after this budget instead of retrying forever.
+_AUTO_RETRY_MAX_SWEEPS = 5
+
+#: Cap on ops requeued per sweep — a backstop against a runaway ledger.
+_AUTO_RETRY_MAX_OPS = 200
+
 
 class RecallResults(list):
     """``recall()``'s return value: a ``list[dict]`` of MemoryItem-shaped
@@ -366,11 +388,25 @@ class HindsightProvider(MemoryProvider):
         self._ops_sample: dict[str, int] | None = None
         self._write_health: dict[str, Any] | None = None
         self._write_health_at: float | None = None
+        # Auto-retry bookkeeping (#1792) — see the constants above.
+        self._auto_retry_last_at: float | None = None
+        self._auto_retry_sweeps_done = 0
 
     @property
     def hindsight_client(self) -> Any:
         """REST client handle for the engine admin surface (memory_admin routes)."""
         return self._client
+
+    @property
+    def extraction_slot(self) -> str:
+        """The local llm slot Hindsight's native extraction is pointed at.
+
+        Read by ``/api/status`` (#1792) to tell "writes are failing because
+        this slot has no model bound yet" apart from a genuine pipeline
+        failure — the route layer owns the slot-manager lookup (this
+        provider has no slot-manager handle), so it only needs the name.
+        """
+        return self._extraction_slot
 
     # ── Live engine health (#1301) ─────────────────────────────────────
 
@@ -539,6 +575,91 @@ class HindsightProvider(MemoryProvider):
         self._write_health = out
         self._write_health_at = now
         return dict(out)
+
+    async def maybe_auto_retry_dead_letters(self) -> dict[str, Any] | None:
+        """Best-effort auto-retry of failed retain ops once a model is bound (#1792).
+
+        The caller (``hal0.api.routes.health._memory_write_health``) only
+        invokes this after confirming the extraction slot now resolves to a
+        model-bound llm slot — that is the signal a retry is worth
+        attempting, since a stalled no-route window is the one failure mode
+        this whole issue is about. Returns ``None`` when there is nothing to
+        do (no failed ops, cooldown still running, or the sweep budget is
+        spent) or a ``{bank, queued, skipped, sweep}`` tally when a sweep
+        actually ran.
+
+        Bounded by :data:`_AUTO_RETRY_COOLDOWN_S` and
+        :data:`_AUTO_RETRY_MAX_SWEEPS` so a pipeline that keeps failing for
+        some OTHER reason after a model loads stops being auto-retried and
+        goes back to reading as genuinely FAILING, rather than retrying
+        forever on every ``/api/status`` poll.
+        """
+        health = await self.write_health()
+        ops = health.get("operations") if isinstance(health, dict) else None
+        failed = int((ops or {}).get("failed") or 0)
+        if failed <= 0:
+            return None
+        if self._auto_retry_sweeps_done >= _AUTO_RETRY_MAX_SWEEPS:
+            return None
+        now = time.monotonic()
+        if (
+            self._auto_retry_last_at is not None
+            and (now - self._auto_retry_last_at) < _AUTO_RETRY_COOLDOWN_S
+        ):
+            return None
+        self._auto_retry_last_at = now
+        self._auto_retry_sweeps_done += 1
+
+        bank = health.get("bank")
+        if not bank:
+            return None
+        try:
+            resp = await self._client.request_json(
+                "GET",
+                f"/v1/default/banks/{bank}/operations",
+                params={"status": "failed", "limit": _AUTO_RETRY_MAX_OPS},
+            )
+        except Exception as exc:
+            log.debug("hal0.memory.auto_retry_list_failed", bank=bank, error=str(exc))
+            return None
+        ops_list = resp.get("operations") if isinstance(resp, dict) else None
+        op_ids = [
+            entry.get("id")
+            for entry in (ops_list or [])
+            if isinstance(entry, dict) and entry.get("id")
+        ]
+
+        queued = skipped = 0
+        for op_id in op_ids:
+            try:
+                res = await self._client.request_json(
+                    "POST", f"/v1/default/banks/{bank}/operations/{op_id}/retry"
+                )
+            except Exception:
+                skipped += 1
+                continue
+            if not isinstance(res, dict) or bool(res.get("success", True)):
+                queued += 1
+            else:
+                skipped += 1
+
+        log.info(
+            "hal0.memory.auto_retry_dead_letters",
+            bank=bank,
+            queued=queued,
+            skipped=skipped,
+            sweep=self._auto_retry_sweeps_done,
+        )
+        # Force a fresh sample on the next read so status reflects the retry
+        # immediately instead of the stale cached verdict.
+        self._write_health = None
+        self._write_health_at = None
+        return {
+            "bank": bank,
+            "queued": queued,
+            "skipped": skipped,
+            "sweep": self._auto_retry_sweeps_done,
+        }
 
     async def _call(self, method: str, /, **kwargs: Any) -> Any:
         """Invoke a client method, updating the live ``degraded`` flag.

--- a/tests/api/test_memory_write_degraded_status.py
+++ b/tests/api/test_memory_write_degraded_status.py
@@ -9,6 +9,14 @@ The wire contract asserted here:
   ``hal0 memory status`` to print — the reason plus the engine's own
   failed/pending operation counts, which is the only thing on the whole
   surface that could distinguish lxc105 from a healthy box.
+
+#1792 adds a second layer on top: on a fresh install every llm slot ships
+model-less, so a growing failed-operation count can ALSO mean "no chat model
+has ever been loaded yet" rather than a genuine outage. The tests below that
+exercise generic failure detection wire a routable extraction slot
+(``_route_extraction_slot``) so they keep testing that shape specifically;
+the ``TestNoChatModelWindow`` class covers the model-less case and the
+auto-retry it triggers once a model appears.
 """
 
 from __future__ import annotations
@@ -22,6 +30,21 @@ from hal0.api import create_app
 from hal0.config.loader import save_hal0_config
 from hal0.config.schema import Hal0Config, MemoryConfig
 from hal0.memory.hindsight_provider import HindsightProvider
+
+
+def _route_extraction_slot(monkeypatch: pytest.MonkeyPatch, *slots: str) -> None:
+    """Make ``_extraction_target_resolves`` see ``slots`` as model-bound.
+
+    Patches the same ``_enabled_llm_slots`` helper the route layer calls, so
+    tests don't need to stand up a real SlotManager + model-bound config just
+    to prove a slot resolves.
+    """
+    import hal0.api.routes.memory as memory_routes
+
+    async def _fake_enabled_llm_slots(_request: Any) -> list[str]:
+        return list(slots)
+
+    monkeypatch.setattr(memory_routes, "_enabled_llm_slots", _fake_enabled_llm_slots)
 
 
 class _AcceptingClient:
@@ -68,9 +91,15 @@ def test_write_fields_are_none_when_memory_is_disabled(tmp_hal0_home: str) -> No
 
 @pytest.mark.asyncio
 async def test_failing_retain_shows_up_on_status_without_touching_memory_degraded(
-    tmp_hal0_home: str,
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """THE regression: every retain fails, ``memory_degraded`` stays false."""
+    """THE regression: every retain fails, ``memory_degraded`` stays false.
+
+    Extraction slot routed as resolvable (#1792) — this test is about a
+    genuine failure with a model already bound, not the no-chat-model window
+    (that's ``TestNoChatModelWindow`` below).
+    """
+    _route_extraction_slot(monkeypatch, "utility")
     app, c = _build(True)
     engine = _AcceptingClient()
     provider = HindsightProvider(client=engine, client_id="hermes", unified_bank=True)
@@ -124,3 +153,127 @@ def test_provider_without_write_health_reports_none(tmp_hal0_home: str) -> None:
 
     assert body["memory_degraded"] is True
     assert body["memory_write_degraded"] is None
+
+
+# ── #1792: the no-chat-model window ─────────────────────────────────────────
+
+
+class _NoChatModelClient:
+    """Simulates the #1792 shape: every retain is accepted, but its
+    extraction call 404s ``dispatch.no_route`` because no llm slot has a
+    model bound yet — so a set of ops sit permanently ``failed`` until
+    something retries them. Retrying an id here "succeeds", same as the real
+    engine once a route exists.
+    """
+
+    def __init__(self, failed_ids: list[str]) -> None:
+        self._failed_ids = list(failed_ids)
+        self.retried: list[str] = []
+
+    async def retain(self, **_kwargs: Any) -> dict[str, str]:
+        return {"operation_id": "op-new"}
+
+    async def recall(self, **_kwargs: Any) -> dict[str, list[Any]]:
+        return {"results": []}
+
+    async def request_json(
+        self, method: str, path: str, *, params: dict[str, Any] | None = None, **_kw: Any
+    ) -> Any:
+        params = params or {}
+        if method == "GET" and path.endswith("/operations"):
+            if params.get("limit") == 1:
+                # The count-only sample write_health() sums per status.
+                counts = {"failed": len(self._failed_ids), "pending": 0, "processing": 0}
+                return {"total": counts.get(str(params.get("status")), 0)}
+            # The full listing the auto-retry sweep walks.
+            return {"operations": [{"id": op_id} for op_id in self._failed_ids]}
+        if method == "POST" and path.endswith("/retry"):
+            op_id = path.rsplit("/", 2)[1]
+            if op_id in self._failed_ids:
+                self._failed_ids.remove(op_id)
+                self.retried.append(op_id)
+            return {"success": True}
+        raise AssertionError(f"unexpected call: {method} {path} {params}")
+
+
+@pytest.mark.asyncio
+async def test_no_chat_model_downgrades_failing_to_a_waiting_state(
+    tmp_hal0_home: str,
+) -> None:
+    """No monkeypatch here: a fresh test app's SlotManager has no model-bound
+    llm slots by default, matching a real fresh install — exactly the shape
+    #1792 needs ``hal0 memory status`` to stop calling FAILING."""
+    app, c = _build(True)
+    engine = _NoChatModelClient(["op-1", "op-2"])
+    provider = HindsightProvider(client=engine, client_id="hermes", unified_bank=True)
+    app.state.memory_provider = provider
+
+    await provider.write_health()
+    engine._failed_ids.append("op-3")
+    await provider.write_health(max_age_s=0)
+    assert provider.write_degraded is True, "sanity: the engine-level signal is degraded"
+
+    with c:
+        body = c.get("/api/status").json()
+
+    # The honest status (#1792): not FAILING, and the reason says why.
+    assert body["memory_write_degraded"] is False
+    health = body["memory_write_health"]
+    assert health["waiting_on"] == "chat_model"
+    assert health["reason"] == "no_chat_model"
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_fires_once_a_chat_model_resolves(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, c = _build(True)
+    engine = _NoChatModelClient(["op-1", "op-2"])
+    provider = HindsightProvider(client=engine, client_id="hermes", unified_bank=True)
+    app.state.memory_provider = provider
+
+    await provider.write_health()
+    engine._failed_ids.append("op-3")
+    await provider.write_health(max_age_s=0)
+
+    # A chat model just became routable — the extraction slot now resolves.
+    _route_extraction_slot(monkeypatch, "utility")
+
+    with c:
+        body = c.get("/api/status").json()
+
+    # The auto-retry swept every dead-lettered op on the bank it tracks.
+    assert sorted(engine.retried) == ["op-1", "op-2", "op-3"]
+    assert body["memory_write_health"]["operations"]["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_is_bounded_by_a_cooldown(
+    tmp_hal0_home: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second poll inside the cooldown window must not sweep again — the
+    dashboard/status poll happens every few seconds and must never turn into
+    a retry-storm against the engine."""
+    app, c = _build(True)
+    engine = _NoChatModelClient(["op-1"])
+    provider = HindsightProvider(client=engine, client_id="hermes", unified_bank=True)
+    app.state.memory_provider = provider
+
+    await provider.write_health()
+    engine._failed_ids = ["op-1", "op-2"]
+    await provider.write_health(max_age_s=0)
+
+    _route_extraction_slot(monkeypatch, "utility")
+
+    with c:
+        c.get("/api/status")
+        first_sweep_count = provider._auto_retry_sweeps_done
+        # Re-dead-letter an op to prove a second sweep, if it ran, would be
+        # observable — then poll again immediately.
+        engine._failed_ids.append("op-3")
+        provider._write_health = None
+        provider._write_health_at = None
+        c.get("/api/status")
+
+    assert provider._auto_retry_sweeps_done == first_sweep_count == 1
+    assert "op-3" not in engine.retried

--- a/tests/cli/test_memory_status_write_rows.py
+++ b/tests/cli/test_memory_status_write_rows.py
@@ -42,6 +42,20 @@ _FAILING = {
     },
 }
 
+_WAITING = {
+    "memory_enabled": True,
+    "memory_degraded": False,
+    "memory_write_degraded": False,
+    "memory_write_health": {
+        "degraded": False,
+        "reason": "no_chat_model",
+        "last_error": None,
+        "operations": {"failed": 2, "pending": 0, "processing": 0},
+        "bank": "shared",
+        "waiting_on": "chat_model",
+    },
+}
+
 _HEALTHY = {
     "memory_enabled": True,
     "memory_degraded": False,
@@ -65,6 +79,20 @@ def test_failing_retains_are_visible(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "retain_operations_failing" in out
     assert "failed=173" in out
     assert "pending=5" in out
+
+
+def test_no_chat_model_window_reads_as_waiting_not_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1792: a fresh install before any chat slot serves a model must not
+    read as "memory is broken" — it self-heals once a model loads."""
+    _stub(monkeypatch, _WAITING)
+    result = runner.invoke(_test_app, [])
+    assert result.exit_code == 0, result.output
+    out = " ".join(result.output.split())
+    assert "FAILING" not in out
+    assert "waiting" in out
+    assert "no chat model loaded" in out
 
 
 def test_healthy_box_reads_differently(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/memory/test_memory_write_degraded.py
+++ b/tests/memory/test_memory_write_degraded.py
@@ -43,6 +43,9 @@ class _FakeClient:
         self.operations: dict[str, dict[str, int]] = {}
         self.operation_calls: list[tuple[str, str | None]] = []
         self.request_error: Exception | None = None
+        #: bank -> [op_id, ...] failed ids the auto-retry sweep should see/retry.
+        self.failed_ids: dict[str, list[str]] = {}
+        self.retried: list[str] = []
 
     async def retain(self, **_kwargs: Any) -> dict[str, str]:
         if self.retain_error is not None:
@@ -57,8 +60,19 @@ class _FakeClient:
     ) -> Any:
         if self.request_error is not None:
             raise self.request_error
+        params = params or {}
+        if method == "GET" and path.endswith("/operations") and params.get("limit") != 1:
+            bank = path.split("/banks/", 1)[1].split("/", 1)[0]
+            return {"operations": [{"id": op_id} for op_id in self.failed_ids.get(bank, [])]}
+        if method == "POST" and path.endswith("/retry"):
+            op_id = path.rsplit("/", 2)[1]
+            self.retried.append(op_id)
+            for ids in self.failed_ids.values():
+                if op_id in ids:
+                    ids.remove(op_id)
+            return {"success": True}
         bank = path.split("/banks/", 1)[1].split("/", 1)[0]
-        status = (params or {}).get("status")
+        status = params.get("status")
         self.operation_calls.append((bank, status))
         return {"total": self.operations.get(bank, {}).get(str(status), 0)}
 
@@ -201,3 +215,84 @@ async def test_a_raised_retain_wins_over_a_clean_probe() -> None:
     assert out["degraded"] is True
     assert out["reason"] == "retain_failed"
     assert "refused" in (out["last_error"] or "")
+
+
+# ── auto-retry of no-chat-model dead letters (#1792) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_noop_when_nothing_failed() -> None:
+    client = _FakeClient()
+    p = _provider(client)
+    client.operations["shared"] = {"failed": 0, "pending": 0, "processing": 0}
+
+    assert await p.maybe_auto_retry_dead_letters() is None
+    assert client.retried == []
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_requeues_every_failed_op_on_the_tracked_bank() -> None:
+    client = _FakeClient()
+    p = _provider(client)
+    client.failed_ids["shared"] = ["op-1", "op-2"]
+    client.operations["shared"] = {"failed": 2, "pending": 0, "processing": 0}
+
+    result = await p.maybe_auto_retry_dead_letters()
+
+    assert result is not None
+    assert result["bank"] == "shared"
+    assert result["queued"] == 2
+    assert result["skipped"] == 0
+    assert sorted(client.retried) == ["op-1", "op-2"]
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_respects_the_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    import hal0.memory.hindsight_provider as hp
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(hp.time, "monotonic", lambda: fake_now[0])
+
+    client = _FakeClient()
+    p = _provider(client)
+    client.failed_ids["shared"] = ["op-1"]
+    client.operations["shared"] = {"failed": 1, "pending": 0, "processing": 0}
+
+    first = await p.maybe_auto_retry_dead_letters()
+    assert first is not None
+
+    client.failed_ids["shared"] = ["op-2"]
+    client.operations["shared"] = {"failed": 1, "pending": 0, "processing": 0}
+    fake_now[0] += hp._AUTO_RETRY_COOLDOWN_S - 1
+    assert await p.maybe_auto_retry_dead_letters() is None
+    assert "op-2" not in client.retried
+
+    fake_now[0] += 2  # past the cooldown now
+    second = await p.maybe_auto_retry_dead_letters()
+    assert second is not None
+    assert "op-2" in client.retried
+
+
+@pytest.mark.asyncio
+async def test_auto_retry_stops_after_the_sweep_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pipeline that keeps failing for a DIFFERENT reason after a model
+    loads must stop being auto-retried and go back to reading as FAILING —
+    this budget is what makes that happen."""
+    import hal0.memory.hindsight_provider as hp
+
+    fake_now = [1000.0]
+    monkeypatch.setattr(hp.time, "monotonic", lambda: fake_now[0])
+
+    client = _FakeClient()
+    p = _provider(client)
+
+    for i in range(hp._AUTO_RETRY_MAX_SWEEPS):
+        client.failed_ids["shared"] = [f"op-{i}"]
+        client.operations["shared"] = {"failed": 1, "pending": 0, "processing": 0}
+        assert await p.maybe_auto_retry_dead_letters() is not None
+        fake_now[0] += hp._AUTO_RETRY_COOLDOWN_S + 1
+
+    client.failed_ids["shared"] = ["op-final"]
+    client.operations["shared"] = {"failed": 1, "pending": 0, "processing": 0}
+    assert await p.maybe_auto_retry_dead_letters() is None
+    assert "op-final" not in client.retried


### PR DESCRIPTION
## Summary

Fresh install ships every llm slot model-less (WS-E #1107). Before any chat slot serves a model, every retain's fact-extraction call 404s `dispatch.no_route` against hal0's own OpenAI-compat dispatcher (`HINDSIGHT_API_LLM_MODEL=hal0/utility`, a deliberately model-less clean seed). Hindsight's poller retries ~28 minutes then permanently dead-letters the op — nothing auto-retries it once a model finally loads, and `hal0 memory status` reads **"Writes FAILING"** the whole time even though this is an expected, self-healing startup window, not an operator-actionable outage.

- **Honest status.** `/api/status` (and `hal0 memory status`) now report `degraded: false` + `waiting_on: "chat_model"` / a **"waiting — no chat model loaded: retains will process once one is available"** row instead of `FAILING`, when the write pipeline shows degraded AND the configured extraction slot has no model bound. That check is deterministic and hal0-side (does `extraction_slot` resolve to a model-bound llm slot?) — not string-sniffing Hindsight's own error text, so it can't drift from what actually causes the 404.
- **Auto-retry.** Once a routable chat model appears, `HindsightProvider.maybe_auto_retry_dead_letters()` sweeps the failed ops on the tracked bank and re-queues them via Hindsight's existing `POST /operations/{id}/retry` (the same call `hal0 memory ops retry` already uses manually). Bounded by a 60s cooldown and a hard 5-sweep cap per provider lifetime, so a pipeline that keeps failing for a genuinely *different* reason after a model loads goes back to reading as FAILING instead of being retried forever on every `/api/status` poll.

Scope note: the actual extraction attempt happens entirely inside the Hindsight daemon (not in this repo), so a true "queue-without-attempting" preflight isn't available from hal0's side — this closes the gap the issue flagged as achievable ("auto-retry dead-lettered ops on model-availability events" + "at minimum ... say ... instead of Writes FAILING").

Closes #1792 · Related #1543, #1420, #1301

## Test plan

- [x] New tests: `HindsightProvider.maybe_auto_retry_dead_letters` (noop when nothing failed, requeues on the tracked bank, cooldown-bounded, sweep-budget-bounded)
- [x] New tests: `/api/status` downgrades FAILING→waiting when the extraction slot doesn't resolve, and fires the auto-retry once it does (`tests/api/test_memory_write_degraded_status.py`)
- [x] New test: `hal0 memory status` prints the waiting wording, not FAILING (`tests/cli/test_memory_status_write_rows.py`)
- [x] Updated the pre-existing #1420 regression test to route a resolvable extraction slot, so it keeps testing "genuine failure with a model already bound" distinctly from the new no-chat-model case
- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/api tests/cli tests/memory -q` → 2608 passed, 1 skipped
- [x] `make lint` → clean
- [x] `uv run ruff format --check .` on touched files → clean (repo-wide check flags 6 pre-existing unrelated files, untouched by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)