### PR TITLE
fix(brain): gate native tools on runner capability, not image identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,31 +37,6 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
-- The brain steward's native-tools preflight asks whether the resolved runner
-  can *parse* tool calls instead of whether its image is byte-equal to the
-  current ROCmFPX default (#1789). The #1655 gate was
-  `image == DEFAULT_ROCMFPX_IMAGE`, so on any box whose slot runs a different
-  runner — every CPU-only install and every CUDA box, which resolve to the
-  plain upstream llama.cpp toolboxes, plus any deliberate `image_pin` — it
-  answered "no native tools" and `tools` were silently stripped from every
-  brain round. Those runners parse OpenAI `tools` perfectly well, so the
-  steward lost its live view of the box for no reason and answered "what slots
-  are loaded?" with invented slot names, with the `[brain_chat] read_only`
-  refusal path unreachable behind the same strip. The gate now denies only the
-  runners measured to reject a tools-attached request (the pre-ade07ba ROCmFPX
-  lineage, `NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS` — the #1626 "peg-native
-  format" 500) and assumes everything else capable; if that assumption is ever
-  wrong the first tool-format rejection is learned for the rest of the process
-  and that round is retried tools-less, so an unknown-bad runner degrades
-  instead of failing the turn. Behaviour on the default rocmfpx runner is
-  unchanged.
-- When tools genuinely cannot ride a brain turn — an incapable runner *and* no
-  `[brain_chat] tool_model` to reroute the round to — the steward now says so
-  instead of improvising: the turn carries an explicit "no live view of this
-  box" system notice, and the stream carries a `notice` frame with
-  `code: tools_unavailable` (rendered as a dim in-thread banner in the UI and a
-  `note:` line in `hal0 chat`). A fabricated answer about live state is worse
-  than an admitted gap.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,31 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
+- The brain steward's native-tools preflight asks whether the resolved runner
+  can *parse* tool calls instead of whether its image is byte-equal to the
+  current ROCmFPX default (#1789). The #1655 gate was
+  `image == DEFAULT_ROCMFPX_IMAGE`, so on any box whose slot runs a different
+  runner — every CPU-only install and every CUDA box, which resolve to the
+  plain upstream llama.cpp toolboxes, plus any deliberate `image_pin` — it
+  answered "no native tools" and `tools` were silently stripped from every
+  brain round. Those runners parse OpenAI `tools` perfectly well, so the
+  steward lost its live view of the box for no reason and answered "what slots
+  are loaded?" with invented slot names, with the `[brain_chat] read_only`
+  refusal path unreachable behind the same strip. The gate now denies only the
+  runners measured to reject a tools-attached request (the pre-ade07ba ROCmFPX
+  lineage, `NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS` — the #1626 "peg-native
+  format" 500) and assumes everything else capable; if that assumption is ever
+  wrong the first tool-format rejection is learned for the rest of the process
+  and that round is retried tools-less, so an unknown-bad runner degrades
+  instead of failing the turn. Behaviour on the default rocmfpx runner is
+  unchanged.
+- When tools genuinely cannot ride a brain turn — an incapable runner *and* no
+  `[brain_chat] tool_model` to reroute the round to — the steward now says so
+  instead of improvising: the turn carries an explicit "no live view of this
+  box" system notice, and the stream carries a `notice` frame with
+  `code: tools_unavailable` (rendered as a dim in-thread banner in the UI and a
+  `note:` line in `hal0 chat`). A fabricated answer about live state is worse
+  than an admitted gap.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/src/hal0/brain/chat.py
+++ b/src/hal0/brain/chat.py
@@ -1189,12 +1189,25 @@ def _unrouteable_model_error(tried_model: str) -> str:
 # GA default, but `_chat_stream` permits overrides (custom `model`/`image`,
 # or an intentional rollback via `image_pin`), and `retag_stale_slot_images`
 # only re-pins a stale image on `hal0 update run` — not preemptively, not on
-# every chat call. A brain round whose resolved slot is STILL on c077206 (or
-# any image other than DEFAULT_ROCMFPX_IMAGE) 500s on a `tools`-attached
-# completion exactly as before. `_resolved_slot_native_tools` checks the
-# CHAT model's resolved slot before every turn and `_tool_routing_llm` pops
-# `tools` off just that round when the check comes back negative — see
-# `_call_chat_model` below.
+# every chat call. A brain round whose resolved slot is STILL on c077206 500s
+# on a `tools`-attached completion exactly as before.
+# `_resolved_slot_native_tools` checks the CHAT model's resolved slot before
+# every turn and `_tool_routing_llm` pops `tools` off just that round when the
+# check comes back negative — see `_call_chat_model` below.
+#
+# THE CHECK IS A CAPABILITY QUESTION, NOT AN IMAGE-IDENTITY ONE (#1789). Until
+# rc.4 that preflight was literally `image == DEFAULT_ROCMFPX_IMAGE`, so it
+# answered "no native tools" for every runner that simply is not the current
+# GPU default — including the plain upstream llama.cpp toolboxes a CPU-only or
+# CUDA box resolves to, which parse OpenAI `tools` fine. On those boxes tools
+# were stripped from every brain round and the steward answered "what slots are
+# loaded?" with invented slot names. So the gate now DENIES the known-bad
+# lineage (`NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS`) plus anything a live round has
+# been caught rejecting (`_LEARNED_TOOL_INCAPABLE_IMAGES`), and assumes every
+# other runner capable. And when tools genuinely cannot ride the turn at all —
+# incapable runner AND no `tool_model` to reroute to — the turn carries an
+# explicit "no live view" system notice plus a `tools_unavailable` SSE frame,
+# because a fabricated answer is worse than an admitted gap.
 #
 # ROUTING SEMANTICS — per ROUND, not per conversation.
 #
@@ -1359,6 +1372,146 @@ def _tool_reroute_unavailable_message(tool_model: str, error: str) -> str:
     )
 
 
+#: Substrings that identify a runner rejecting the REQUEST because it could not
+#: reconcile the model's output with the tool-format parser it built from the
+#: chat template — the #1626 failure mode, verbatim from llama-server's error
+#: body, plus the other spellings llama.cpp / an OpenAI-shaped upstream use to
+#: refuse a ``tools`` payload outright. Lowercase; matched case-insensitively
+#: against the dispatch error text.
+#:
+#: This is the RUNTIME half of the capability gate: an image nobody has listed
+#: as incompatible is assumed capable, and if that assumption is wrong the
+#: first tools-attached round teaches
+#: :func:`_image_native_tools` otherwise instead of 500ing the turn.
+_TOOL_FORMAT_FAILURE_MARKERS: tuple[str, ...] = (
+    "peg-native format",
+    "does not match the expected",
+    "failed to parse tool call",
+    "unsupported tool",
+    "tools param requires",
+)
+
+#: Image refs learned at RUNTIME to reject tools-attached completions, keyed by
+#: effective image ref. Process-local and deliberately unbounded-but-tiny (one
+#: entry per distinct runner image a box has actually failed on); never
+#: persisted, so a runner upgrade clears it with the service restart that
+#: performs it.
+_LEARNED_TOOL_INCAPABLE_IMAGES: set[str] = set()
+
+
+def _is_tool_format_failure(response: Any) -> bool:
+    """Whether ``response`` is a dispatch error that reads as a tool-format reject.
+
+    Deliberately narrow: an ordinary 5xx, a timeout, or ``dispatch.no_route``
+    must NOT teach the gate that the runner is tool-incapable (that would
+    disable tools for the rest of the process over one blip). Only the
+    template-derived-parser rejections in
+    :data:`_TOOL_FORMAT_FAILURE_MARKERS` count.
+    """
+    if not isinstance(response, dict):
+        return False
+    err = response.get("error")
+    if not err:
+        return False
+    text = str(err).lower()
+    return any(marker in text for marker in _TOOL_FORMAT_FAILURE_MARKERS)
+
+
+def _image_native_tools(image: str | None) -> bool:
+    """Whether a runner ``image`` is expected to parse native OpenAI ``tools``.
+
+    CAPABILITY, not identity (#1789). The #1655 gate this replaces asked "is
+    the effective image exactly :data:`~hal0.config.schema.
+    DEFAULT_ROCMFPX_IMAGE`?", which answers "no native tools" for every runner
+    that merely is not the current GPU default — including the plain upstream
+    llama.cpp toolboxes a CPU-only or CUDA box resolves to
+    (:data:`~hal0.config.schema.FALLBACK_VULKAN_IMAGE` /
+    :data:`~hal0.config.schema.FALLBACK_CUDA_IMAGE`), which parse ``tools``
+    perfectly well. On those boxes the false negative stripped ``tools`` from
+    every brain round, so the steward answered platform questions from
+    imagination.
+
+    Two layers, in order:
+
+    1. the :data:`~hal0.config.schema.NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS` DENY
+       list — the pre-ade07ba ROCmFPX lineage that 500s the whole request;
+    2. :data:`_LEARNED_TOOL_INCAPABLE_IMAGES` — anything an actual round has
+       been observed to reject with a tool-format error this process.
+
+    Anything else is assumed CAPABLE. That default is safe precisely because of
+    layer 2: an unknown-bad runner degrades on its first tools-attached round
+    (retried tools-less in the same round, see ``_call_chat_model``) and is
+    remembered for every later turn, instead of the whole class of runners
+    being silently muted forever.
+    """
+    from hal0.config.schema import NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS
+
+    ref = (image or "").strip()
+    if not ref:
+        return True  # unknown image — best-effort default, same as the rest of the preflight
+    if ref in NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS:
+        return False
+    return ref not in _LEARNED_TOOL_INCAPABLE_IMAGES
+
+
+def _remember_tool_incapable_image(image: str | None) -> None:
+    """Record that ``image`` rejected a tools-attached completion."""
+    ref = (image or "").strip()
+    if not ref or ref in _LEARNED_TOOL_INCAPABLE_IMAGES:
+        return
+    _LEARNED_TOOL_INCAPABLE_IMAGES.add(ref)
+    log.warning(
+        "hal0.brain_chat.native_tools_unsupported",
+        image=ref,
+        detail="runner rejected a tools-attached completion; brain rounds go tools-less",
+    )
+
+
+def _tools_unavailable_notice(chat_model: str, tool_model: str) -> str:
+    """The system-level honesty line for a turn that has no tool surface.
+
+    #1789: the failure the operator actually hit was not an error — it was a
+    confident fabrication. When neither the chat model's runner nor a
+    ``tool_model`` reroute can carry ``tools``, the steward has NO live view of
+    the box, and must say so rather than describe slots it imagined. Injected
+    as a system message so it constrains the answer itself, and mirrored to the
+    stream as a ``notice`` frame for non-model consumers.
+    """
+    reroute = (
+        " The `[brain_chat] tool_model` reroute is off, so there is no second model to run "
+        "them either."
+        if not tool_model
+        else ""
+    )
+    return (
+        "LIVE PLATFORM TOOLS ARE UNAVAILABLE FOR THIS TURN. The runner backing the chat model "
+        f"({chat_model!r}) does not accept tool calls, so you have NO ability to read the live "
+        f"state of this box right now.{reroute}\n\n"
+        "Therefore: do NOT describe slots, models, jobs, boards, or any other live state as if "
+        "you had looked it up, and never invent names or values. Say plainly that you cannot "
+        "check live state on this turn, answer only from what is in this conversation and your "
+        "system prompt, and point the operator at the Slots/Models pages or the `hal0` CLI for "
+        "the real numbers. Mentioning that tools are unavailable is REQUIRED, not optional."
+    )
+
+
+def _prepend_system_notice(messages: list[dict[str, Any]], notice: str) -> None:
+    """Fold ``notice`` into the leading system message, in place.
+
+    Appending a system turn to the TAIL would be the obvious move and is not
+    template-safe — the chat templates this module already fights (qwen3.5's
+    ``multi_step_tool`` guard, see :func:`_frame_messages` / O18) expect the
+    conversation to end on a user/assistant/tool turn. Folding into the
+    existing system seed keeps the wire shape identical to a plain turn.
+    """
+    if messages and messages[0].get("role") == "system":
+        seed = messages[0].get("content")
+        if isinstance(seed, str):
+            messages[0] = {**messages[0], "content": f"{seed}\n\n{notice}" if seed else notice}
+            return
+    messages.insert(0, {"role": "system", "content": notice})
+
+
 def _synthetic_reply(text: str) -> dict[str, Any]:
     """An OpenAI-shaped completion carrying ``text`` as the assistant reply.
 
@@ -1378,6 +1531,7 @@ def _tool_routing_llm(
     tool_model: str,
     known_tool_names: frozenset[str],
     chat_model_native_tools: bool = True,
+    chat_model_image: str | None = None,
 ) -> LlmFn:
     """Wrap ``llm`` so TOOL rounds run on ``tool_model`` and chat stays on the brain.
 
@@ -1394,31 +1548,47 @@ def _tool_routing_llm(
 
     ``chat_model_native_tools`` (see :func:`_resolved_slot_native_tools`,
     computed by the caller against the CHAT model's resolved slot) gates
-    whether native ``tools`` ride a ``chat_model`` round at all. Only the
-    ade07ba-lineage runner (:data:`~hal0.config.schema.DEFAULT_ROCMFPX_IMAGE`)
-    parses the brain's tool dialect without 500ing — on any other resolved
-    image (a stale or deliberate ``image_pin`` to e.g. ``c077206``), sending
-    ``tools`` 500s the WHOLE completion ("peg-native format", #1626) before
-    ``_tool_intent_artefact`` ever sees a reply. When ``False`` this wrapper
-    pops ``tools`` off the ``chat_model`` round only — detection is
-    unaffected (it reads the reply text, not the request) and the reroute
-    below still fires normally. TOOL-model rounds always keep ``tools``.
+    whether native ``tools`` ride a ``chat_model`` round at all. A runner in
+    the known-incompatible set (the pre-ade07ba ROCmFPX lineage, see
+    :data:`~hal0.config.schema.NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS`) 500s the
+    WHOLE completion on a tools-attached request ("peg-native format", #1626)
+    before ``_tool_intent_artefact`` ever sees a reply. When ``False`` this
+    wrapper pops ``tools`` off the ``chat_model`` round only — detection is
+    unaffected (it reads the reply text, not the request) and the reroute below
+    still fires normally. TOOL-model rounds always keep ``tools``.
+
+    ``chat_model_image`` is the effective runner image behind ``chat_model``,
+    carried purely so a round that DOES hit a tool-format reject on a
+    presumed-capable runner can (a) retry itself tools-less instead of failing
+    the turn and (b) remember the image for every later turn (#1789 — the gate
+    is capability-based now, so "assume capable" needs a runtime correction
+    path). ``None`` keeps the old behaviour: no learning, no retry.
 
     See the module comment above this function for the full routing semantics
     and why the tool-capable model — not the 1B — finishes a tool chain.
     """
 
-    async def _call_chat_model(body: dict[str, Any]) -> dict[str, Any]:
-        """Run one completion on ``chat_model``, stripping ``tools`` when the
-        resolved slot's runner can't parse them without 500ing."""
-        if chat_model_native_tools:
-            return await llm(body)
+    async def _without_tools(body: dict[str, Any]) -> dict[str, Any]:
+        """One completion with ``tools`` popped off, then restored on the body."""
         native_tools = body.pop("tools", None)
         try:
             return await llm(body)
         finally:
             if native_tools is not None:
                 body["tools"] = native_tools
+
+    async def _call_chat_model(body: dict[str, Any]) -> dict[str, Any]:
+        """Run one completion on ``chat_model``, stripping ``tools`` when the
+        resolved slot's runner can't parse them without 500ing."""
+        if not chat_model_native_tools or not _image_native_tools(chat_model_image):
+            return await _without_tools(body)
+        response = await llm(body)
+        # Presumed-capable runner that turned out not to be: learn it, and
+        # salvage THIS round tools-less rather than handing the operator a 500.
+        if body.get("tools") and _is_tool_format_failure(response):
+            _remember_tool_incapable_image(chat_model_image)
+            return await _without_tools(body)
+        return response
 
     # Nothing to reroute TO, or nowhere to reroute FROM. Note this branch is
     # also what "no reroute" costs: a plain pass-through, not a wrapper that
@@ -1465,9 +1635,9 @@ def _tool_routing_llm(
         # brain slot always 500'd, which is why #1626 briefly stripped tools
         # from this round; the reroute below is now the fallback it was
         # designed to be, not the only path. `_call_chat_model` re-applies
-        # that strip whenever `chat_model_native_tools` says this box's
-        # resolved slot is NOT actually on ade07ba (#1655) — a stale or
-        # deliberate `image_pin` must degrade to the fallback, not 500.
+        # that strip whenever the resolved slot's runner is known — or has
+        # been caught — rejecting tools (#1655/#1789): a rollback to c077206
+        # must degrade to the fallback, not 500.
         response = await _call_chat_model(body)
         if not isinstance(response, dict) or response.get("error"):
             # A BRAIN-side failure keeps its documented contract exactly — the
@@ -1563,35 +1733,29 @@ async def _resolved_context_length(request: Request, model: Any) -> int | None:
     return int(res.context_length)
 
 
-async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
-    """Whether the container image backing the slot ``model`` resolves to is
-    known to parse native OpenAI ``tools`` on completions without 500ing.
+async def _resolved_slot_image(request: Request, model: Any) -> str | None:
+    """Effective runner image behind the slot ``model`` resolves to, or None.
 
-    Best-effort, mirroring :func:`_resolved_context_length`'s contract:
-    defaults to ``True`` (assume supported) whenever the slot, its config, or
-    its profile can't be resolved — so this never blocks a chat the guard
-    can't reason about, and never touches a non-container backend (FLM/NPU,
-    or a remote upstream with no local slot at all) that was never exposed to
-    the llama.cpp peg-format 500 in the first place.
+    Best-effort, mirroring :func:`_resolved_context_length`'s contract: returns
+    ``None`` whenever the slot, its config, or its profile can't be resolved —
+    so a caller can never draw a conclusion from a lookup that did not happen —
+    and also ``None`` for a non-container backend (FLM/NPU, or a remote
+    upstream with no local slot at all), which never routes through the
+    llama.cpp runner whose tool-format behaviour is what any of this is about.
 
-    Only returns ``False`` for a local container llm slot whose EFFECTIVE
-    image (``slot.image_pin`` escape hatch, or the runner-derived default —
-    see :func:`hal0.providers.container._resolve_image_ref`) resolves to
-    something other than the current :data:`~hal0.config.schema.
-    DEFAULT_ROCMFPX_IMAGE`. That covers both a deliberate rollback (e.g. to
-    ``c077206``) and an unretagged stale pin — :func:`hal0.updater.updater.
-    retag_stale_slot_images` only fixes those on ``hal0 update run``, not
-    preemptively or on every chat call (#1655).
+    Otherwise the EFFECTIVE image for a local container llm slot:
+    ``slot.image_pin`` (the escape hatch) or the runner-derived HW-gated
+    default — exactly :func:`hal0.providers.container._resolve_image_ref`, so
+    the ref checked here is the ref that actually launched.
     """
     if not isinstance(model, str) or not model:
-        return True
+        return None
     try:
         sm = getattr(request.app.state, "slot_manager", None)
         if sm is None:
-            return True
+            return None
 
         from hal0.api.routes.v1 import _normalize_loaded_models, _normalize_slot_views
-        from hal0.config.schema import DEFAULT_ROCMFPX_IMAGE
         from hal0.normalize.resolver import LiveSlotResolver, _configured_primary
         from hal0.profiles import ProfileCatalog
         from hal0.providers.container import _resolve_image_ref
@@ -1603,7 +1767,7 @@ async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
         )
         res = await resolver.resolve(model)
         if res is None:
-            return True
+            return None
 
         # A chain match names the slot directly; a fallback (nothing in the
         # chain loaded) still resolves to a real slot via the same
@@ -1613,7 +1777,7 @@ async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
             primary = _configured_primary(views)
             slot_name = primary.name if primary is not None else None
         if not slot_name:
-            return True
+            return None
 
         cfg = None
         for raw in await sm.iter_configs():
@@ -1621,11 +1785,11 @@ async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
                 cfg = raw
                 break
         if cfg is None or (cfg.get("type") or "").lower() != "llm":
-            return True
-        # FLM/NPU-backed slots never route through the ROCmFPX llama.cpp
-        # runner this check exists for — leave them alone.
+            return None
+        # FLM/NPU-backed slots never route through the llama.cpp container
+        # runner this lookup exists for — they have no image ref to speak of.
         if (cfg.get("device") or "").strip() == "npu" or (cfg.get("backend") or "") == "flm":
-            return True
+            return None
 
         # `_resolve_image_ref`'s tier-1 `image_pin` escape hatch is checked
         # BEFORE it ever touches `profile` — resolve the profile on a
@@ -1641,8 +1805,24 @@ async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
                 profile = None
         image = _resolve_image_ref(cfg, profile)
     except Exception:
-        return True
-    return image == DEFAULT_ROCMFPX_IMAGE
+        return None
+    return image or None
+
+
+async def _resolved_slot_native_tools(request: Request, model: Any) -> bool:
+    """Whether the runner behind the slot ``model`` resolves to is expected to
+    parse native OpenAI ``tools`` on completions without 500ing.
+
+    Composition of the two halves, and the whole of the #1789 fix: resolve the
+    EFFECTIVE image (:func:`_resolved_slot_image`), then ask the capability
+    question about it (:func:`_image_native_tools`) instead of comparing it to
+    one image constant. Defaults to ``True`` whenever the image can't be
+    resolved — the same best-effort contract :func:`_resolved_context_length`
+    has, so the preflight never mutes a chat it cannot reason about, and never
+    touches a non-container backend (FLM/NPU, remote upstream) that was never
+    exposed to the llama.cpp peg-format 500 in the first place.
+    """
+    return _image_native_tools(await _resolved_slot_image(request, model))
 
 
 def _context_exceeded_error(prompt_tokens: int, context_length: int, model: Any) -> str:
@@ -1746,18 +1926,41 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
     # which _tool_routing_llm treats as no reroute. See the routing-semantics
     # comment above _tool_intent_artefact.
     tool_model = (cfg.tool_model or "").strip()
-    # Preflight: does the CHAT model's resolved slot actually run a runner
-    # that parses native `tools` without 500ing? (#1655 — the reroute below
-    # assumed ade07ba unconditionally, with no check of the slot a stale or
-    # deliberate `image_pin` might still be pointed at.)
-    chat_model_native_tools = await _resolved_slot_native_tools(request, model)
+    # Preflight: does the CHAT model's resolved slot actually run a runner that
+    # parses native `tools` without 500ing? (#1655 — the reroute below assumed
+    # ade07ba unconditionally, with no check of the slot a stale or deliberate
+    # `image_pin` might still be pointed at. #1789 — asked as a CAPABILITY
+    # question about the resolved image, not "is it the GPU default", which
+    # answered False for every CPU-only/CUDA box and muted tools there.)
+    chat_model_image = await _resolved_slot_image(request, model)
+    chat_model_native_tools = _image_native_tools(chat_model_image)
     llm = _tool_routing_llm(
         llm,
         chat_model=model,
         tool_model=tool_model,
         known_tool_names=known_tool_names,
         chat_model_native_tools=chat_model_native_tools,
+        chat_model_image=chat_model_image,
     )
+
+    # HONESTY (#1789). Tools surfaced in the prompt but no round can actually
+    # carry them — the chat runner rejects them AND there is no reroute target
+    # to run them instead. Left alone the steward answers "what slots are
+    # loaded?" from imagination, which is worse than an error. Tell the MODEL
+    # (system message, so it constrains the reply) and tell the CLIENT (a
+    # `notice` frame carrying `tools_unavailable`).
+    # Same condition `_tool_routing_llm` uses to decide it has nothing to
+    # reroute to (an "off"/empty tool_model, or one that IS the chat model).
+    reroute_possible = bool(tool_model) and tool_model != model
+    tools_unavailable = bool(tools) and not chat_model_native_tools and not reroute_possible
+    if tools_unavailable:
+        _prepend_system_notice(messages, _tools_unavailable_notice(model, tool_model))
+        log.warning(
+            "hal0.brain_chat.tools_unavailable",
+            chat_model=model,
+            chat_model_image=chat_model_image or "(unresolved)",
+            tool_model=tool_model or "(off)",
+        )
 
     body: dict[str, Any] = {
         "model": model,
@@ -1778,6 +1981,23 @@ async def _chat_stream(request: Request, payload: dict[str, Any]) -> AsyncIterat
             )
             yield _sse({"type": "done"})
             return
+
+    # The client-facing half of the #1789 honesty layer. A `notice` frame is
+    # additive to the documented SSE contract (token/thinking/tool_call/
+    # tool_result/approval_required/error/done): every existing consumer
+    # ignores an unknown `type`, and the UI/CLI render it as a dim banner.
+    if tools_unavailable:
+        yield _sse(
+            {
+                "type": "notice",
+                "code": "tools_unavailable",
+                "message": (
+                    "Live platform tools are unavailable on this turn — the runner backing "
+                    f"{model!r} does not accept tool calls and `[brain_chat] tool_model` is off, "
+                    "so answers about live box state come from context only."
+                ),
+            }
+        )
 
     dispatch_fn = functools.partial(_dispatch_round, request, client, board)
     try:

--- a/src/hal0/cli/chat_commands.py
+++ b/src/hal0/cli/chat_commands.py
@@ -234,6 +234,10 @@ def _run_brain_turn(session: ChatSession, client: httpx.Client, url: str, user_t
                 f"[yellow]waiting on operator approval for {event.get('name')} "
                 f"(approval_id={event.get('approval_id')})[/yellow]"
             )
+        elif etype == "notice":
+            # Degradation the operator must see but which is not an error —
+            # e.g. `tools_unavailable` (#1789), where the reply is context-only.
+            console.print(f"[yellow]note:[/yellow] {event.get('message')}")
         elif etype == "error":
             console.print(f"[red]error:[/red] {event.get('message')}")
         elif etype == "done":

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -1049,6 +1049,40 @@ STALE_ROCMFPX_IMAGE_REFS = frozenset(
 FALLBACK_VULKAN_IMAGE = "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server"
 FALLBACK_CUDA_IMAGE = "ghcr.io/ggml-org/llama.cpp:server-cuda"
 
+#: Runner images KNOWN to reject a ``tools``-attached completion outright — the
+#: pre-ade07ba ROCmFPX lineage, where llama-server strips the MiniCPM5 vocab's
+#: tool-syntax control tokens before its template-derived parser sees them and
+#: 500s the WHOLE request with "The model produced output that does not match
+#: the expected peg-native format" (#1626).
+#:
+#: This is a DENY list, deliberately, and it is the inverse of the #1655 gate it
+#: replaces. That gate asked "is this image exactly ``DEFAULT_ROCMFPX_IMAGE``?"
+#: and therefore answered "no native tools" for every runner that simply is not
+#: the current default — including plain upstream llama.cpp toolboxes that parse
+#: OpenAI ``tools`` perfectly well. On a CPU-only or CUDA box (whose HW-gated
+#: default is :data:`FALLBACK_VULKAN_IMAGE` / :data:`FALLBACK_CUDA_IMAGE`) that
+#: false negative silently stripped ``tools`` from every brain round, so the
+#: steward answered platform questions from imagination (#1789).
+#:
+#: A ref that is not listed here is assumed CAPABLE; if it turns out not to be,
+#: :func:`hal0.brain.chat._image_native_tools` learns that at runtime from the
+#: first tool-format failure (see ``_TOOL_FORMAT_FAILURE_MARKERS``) and the
+#: round is retried tools-less, so an unknown-bad runner degrades exactly like a
+#: listed one instead of 500ing the turn.
+#:
+#: Note this is a SUBSET of :data:`STALE_ROCMFPX_IMAGE_REFS`: that set also
+#: carries the two former basic-lane toolbox defaults, which are ordinary
+#: llama.cpp builds with no MiniCPM5 parser and no peg-format failure mode.
+NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS = frozenset(
+    {
+        "ghcr.io/hal0ai/hal0-rocmfpx:c077206",
+        "ghcr.io/hal0ai/hal0-rocmfpx:vulkan-minicpm5",
+        "localhost/hal0-rocmfpx:vulkan-minicpm5",
+        "ghcr.io/hal0ai/hal0-rocmfpx:server",
+        "ghcr.io/hal0ai/amd-strix-halo-toolboxes:rocmfpx-7aa484a",
+    }
+)
+
 
 def resolve_default_image(backend: str | None, device_class: str | None = None) -> str:
     """Default container image for a slot lane with no explicit image pin.

--- a/tests/brain/test_brain_tool_reroute.py
+++ b/tests/brain/test_brain_tool_reroute.py
@@ -28,7 +28,12 @@ What this file locks down:
   * the reroute target having NO model bound — the default fresh-box state —
     produces a clear, actionable steward message: no crash, no empty reply;
   * ``hal0.toolloop.engine.run_tool_loop`` is untouched, so OmniRouter's use of
-    it is unchanged.
+    it is unchanged;
+  * the native-tools preflight is a CAPABILITY question about the resolved
+    runner image, not ``image == DEFAULT_ROCMFPX_IMAGE`` (#1789) — a non-Strix
+    box's fallback toolbox keeps real tool rounds, a runner caught rejecting
+    tools is learned at runtime, and a turn with no tool surface at all admits
+    it instead of fabricating live state.
 
 Scripted stub LLM, no network.
 
@@ -49,6 +54,10 @@ from hal0.config.schema import (
     BRAIN_TOOL_MODEL_DEFAULT,
     BRAIN_TOOL_MODEL_DISABLED,
     DEFAULT_ROCMFPX_IMAGE,
+    FALLBACK_CUDA_IMAGE,
+    FALLBACK_VULKAN_IMAGE,
+    NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS,
+    STALE_ROCMFPX_IMAGE_REFS,
     BrainChatConfig,
     Hal0Config,
 )
@@ -740,3 +749,238 @@ def test_default_image_pin_keeps_tools_on_the_chat_round() -> None:
 
     assert stub.models == ["hal0/brain", "hal0/agent"]
     assert stub.calls[0].get("tools"), "chat round on the default image lost native tools"
+
+
+# ── #1789: the gate asks about CAPABILITY, not image identity ───────────────
+#
+# The #1655 preflight above shipped as `image == DEFAULT_ROCMFPX_IMAGE`. That
+# is not the question it meant to ask: a CPU-only or CUDA box resolves its
+# runner to FALLBACK_VULKAN_IMAGE / FALLBACK_CUDA_IMAGE — ordinary upstream
+# llama.cpp builds with no MiniCPM5 parser and no peg-format failure mode, so
+# they parse OpenAI `tools` fine — and got `False`, which stripped `tools` from
+# EVERY brain round. Measured on CT151 during rc.4 validation: zero tool
+# frames, zero dispatch, and a confident answer naming slots that do not
+# exist. These tests pin the capability gate and the honesty fallback.
+
+
+def _clear_learned() -> None:
+    bc._LEARNED_TOOL_INCAPABLE_IMAGES.clear()
+
+
+_PEG_FORMAT_ERROR = (
+    "upstream 500 from slot brain: The model produced output that does not match "
+    "the expected peg-native format"
+)
+
+
+def test_image_native_tools_denies_only_the_known_bad_lineage() -> None:
+    """The gate's core table: deny the pre-ade07ba ROCmFPX refs, allow the rest.
+
+    Every ref in NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS is a runner measured to
+    500 the whole request on a tools-attached completion (#1626). Everything
+    else — today's default, the two HW-gated fallbacks a non-Strix box lands
+    on, an operator's own build — is assumed capable, which is the entire
+    #1789 fix.
+    """
+    _clear_learned()
+    for bad in NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS:
+        assert bc._image_native_tools(bad) is False, bad
+    for good in (
+        DEFAULT_ROCMFPX_IMAGE,
+        FALLBACK_VULKAN_IMAGE,  # CPU-only / non-Strix AMD box — the #1789 report
+        FALLBACK_CUDA_IMAGE,
+        "ghcr.io/example/my-own-llama-server:v9",
+    ):
+        assert bc._image_native_tools(good) is True, good
+    # An unresolvable image is not a verdict — best-effort default (True).
+    assert bc._image_native_tools(None) is True
+    assert bc._image_native_tools("   ") is True
+    # The former basic-lane toolbox defaults are STALE, not tool-incompatible:
+    # the updater retags them, but they parse `tools` perfectly meanwhile.
+    assert "ghcr.io/hal0ai/amd-strix-halo-toolboxes:vulkan-radv-server" in (
+        STALE_ROCMFPX_IMAGE_REFS
+    )
+    assert NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS < STALE_ROCMFPX_IMAGE_REFS
+
+
+def test_resolved_slot_native_tools_true_on_a_non_default_capable_image() -> None:
+    """The #1789 regression, at the preflight: a CPU-only box's runner is
+    NOT the rocmfpx default and must still be treated as tools-capable."""
+    _clear_learned()
+    request = _fake_request_with_slot(
+        _StubLLM([]),
+        _brain_slot_cfg(image_pin=FALLBACK_VULKAN_IMAGE, device="cpu"),
+        model="hal0/brain",
+    )
+    assert _run(bc._resolved_slot_native_tools(request, "hal0/brain")) is True
+
+
+def test_capable_non_default_image_runs_real_tool_rounds() -> None:
+    """End to end on a CPU-only box's runner: the chat round CARRIES `tools`,
+    the brain's native tool_call is dispatched, and the turn reads live state
+    instead of inventing it."""
+    _clear_learned()
+    stub = _StubLLM([_tool_call("list_slots", {}, "c1"), _final("Three slots are loaded.")])
+    request = _fake_request_with_slot(
+        stub,
+        _brain_slot_cfg(image_pin=FALLBACK_VULKAN_IMAGE, device="cpu"),
+        model="hal0/brain",
+        tool_model="hal0/agent",
+    )
+
+    events = _run(_collect(request))
+
+    assert stub.calls[0].get("tools"), "#1789: a capable non-default runner lost native tools"
+    assert [e["name"] for e in events if e["type"] == "tool_call"] == ["list_slots"]
+    assert not [e for e in events if e["type"] == "notice"], "tools worked — no notice is due"
+    assert _tokens(events) == "Three slots are loaded."
+
+
+def test_read_only_refusal_is_reachable_on_a_capable_non_default_image() -> None:
+    """#1789's second symptom: with tools stripped, `read_only=true` never got
+    a tool call to refuse, so a mutation request drew a hallucinated refusal
+    instead of the documented one. With the gate fixed the guard fires."""
+    _clear_learned()
+    stub = _StubLLM(
+        [
+            _tool_call("config_write", {"path": "brain_chat.read_only", "value": False}, "c1"),
+            _final("I can't do that in read-only mode."),
+        ]
+    )
+    request = _fake_request_with_slot(
+        stub,
+        _brain_slot_cfg(image_pin=FALLBACK_VULKAN_IMAGE, device="cpu"),
+        model="hal0/brain",
+        tool_model="hal0/agent",
+    )
+    request.app.state.hal0_config = Hal0Config(
+        brain_chat=BrainChatConfig(read_only=True, model="hal0/brain", tool_model="hal0/agent")
+    )
+
+    events = _run(_collect(request))
+
+    results = [e for e in events if e["type"] == "tool_result"]
+    assert results, "no tool was dispatched — the read-only guard is still unreachable"
+    assert "read-only mode" in json.dumps(results[0]["result"])
+
+
+def test_a_tool_format_reject_is_learned_and_the_round_is_salvaged() -> None:
+    """The runtime half of the gate. "Assume capable" is only safe because a
+    runner that turns out NOT to be teaches the gate on its first failure:
+    THIS round retries tools-less (no 500 reaches the operator) and every
+    later turn on that image goes out tools-less from the start."""
+    _clear_learned()
+    try:
+        stub = _StubLLM([{"error": _PEG_FORMAT_ERROR}, _final("Plain answer.")])
+        request = _fake_request_with_slot(
+            stub,
+            _brain_slot_cfg(image_pin="ghcr.io/example/surprise-runner:v1"),
+            model="hal0/brain",
+        )
+
+        events = _run(_collect(request))
+
+        assert stub.calls[0].get("tools"), "first attempt should try the native fast path"
+        assert not stub.calls[1].get("tools"), "the retry must drop tools"
+        assert _tokens(events) == "Plain answer."  # no 500 surfaced
+        assert bc._image_native_tools("ghcr.io/example/surprise-runner:v1") is False
+        # ...and the NEXT turn skips the doomed attempt entirely.
+        assert _run(bc._resolved_slot_native_tools(request, "hal0/brain")) is False, (
+            "the learned verdict must survive into later turns"
+        )
+    finally:
+        _clear_learned()
+
+
+def test_an_ordinary_dispatch_error_does_not_teach_the_gate() -> None:
+    """Fail-safe: a timeout / no_route / plain 500 must NOT mute tools for the
+    rest of the process, and must keep the documented error contract."""
+    _clear_learned()
+    try:
+        stub = _StubLLM([{"error": "dispatch.no_route: nothing loaded for hal0/brain"}])
+        request = _fake_request_with_slot(
+            stub, _brain_slot_cfg(image_pin=FALLBACK_CUDA_IMAGE), model="hal0/brain"
+        )
+
+        events = _run(_collect(request))
+
+        assert len(stub.calls) == 1, "a non-tool-format error must not trigger a retry"
+        assert any(e["type"] == "error" for e in events)
+        assert bc._image_native_tools(FALLBACK_CUDA_IMAGE) is True
+    finally:
+        _clear_learned()
+
+
+# ── #1789: honesty when tools cannot ride the turn at all ───────────────────
+
+
+def test_incapable_runner_with_no_reroute_says_so() -> None:
+    """No tool surface AND no reroute -> the turn is told, in the system seed,
+    that it has no live view, and the client gets a `tools_unavailable` frame.
+
+    This is the actual bug the operator hit: not an error, a fabrication. An
+    admitted gap is the required behaviour.
+    """
+    _clear_learned()
+    stub = _StubLLM([_final("I can't check live state right now.")])
+    request = _fake_request_with_slot(
+        stub,
+        _brain_slot_cfg(image_pin=_STALE_IMAGE),
+        model="hal0/brain",
+        tool_model="off",  # in BRAIN_TOOL_MODEL_DISABLED -> normalised to "" (no reroute)
+    )
+
+    events = _run(_collect(request))
+
+    notice = next(e for e in events if e["type"] == "notice")
+    assert notice["code"] == "tools_unavailable"
+    assert "context only" in notice["message"]
+    # The MODEL is constrained too — the notice rides the system seed, never a
+    # trailing system turn (template-safety, see _frame_messages / O18).
+    seed = stub.calls[0]["messages"][0]
+    assert seed["role"] == "system"
+    assert "LIVE PLATFORM TOOLS ARE UNAVAILABLE" in seed["content"]
+    assert all(m["role"] == "system" for m in stub.calls[0]["messages"][:1])
+    assert stub.calls[0]["messages"][-1]["role"] != "system"
+    assert not stub.calls[0].get("tools")
+
+
+def test_no_notice_when_a_reroute_can_still_run_tools() -> None:
+    """An incapable chat runner is NOT a lost tool surface while `tool_model`
+    is there to run the round — that path already works, so claiming tools are
+    unavailable would be its own lie."""
+    _clear_learned()
+    stub = _StubLLM(
+        [
+            _leaked(JINJA_LEAK),
+            _tool_call("list_slots", {}, "c1"),
+            _final("Three slots."),
+        ]
+    )
+    request = _fake_request_with_slot(
+        stub, _brain_slot_cfg(image_pin=_STALE_IMAGE), model="hal0/brain", tool_model="hal0/agent"
+    )
+
+    events = _run(_collect(request))
+
+    assert not [e for e in events if e["type"] == "notice"]
+    assert "LIVE PLATFORM TOOLS ARE UNAVAILABLE" not in json.dumps(stub.calls[0]["messages"])
+    assert _tokens(events) == "Three slots."
+
+
+def test_prepend_system_notice_folds_into_the_existing_seed() -> None:
+    """Never a trailing system turn: the chat templates this module already
+    fights expect the conversation to END on user/assistant/tool."""
+    messages = [
+        {"role": "system", "content": "You are the steward."},
+        {"role": "user", "content": "what slots are loaded?"},
+    ]
+    bc._prepend_system_notice(messages, "NOTICE")
+    assert messages[0]["content"] == "You are the steward.\n\nNOTICE"
+    assert len(messages) == 2
+
+    # No system seed at all -> the notice becomes one, at the FRONT.
+    bare = [{"role": "user", "content": "hi"}]
+    bc._prepend_system_notice(bare, "NOTICE")
+    assert bare[0] == {"role": "system", "content": "NOTICE"}
+    assert bare[-1]["role"] == "user"

--- a/ui/src/api/hooks/useBoard.ts
+++ b/ui/src/api/hooks/useBoard.ts
@@ -1213,7 +1213,7 @@ export function useBoardChat(board?: string): UseBoardChatResult {
 
     // Open SSE stream via fetch POST. Contract (see board_chat.py): the body
     // carries `messages` (OpenAI format) and optional `board`; the response
-    // is SSE frames `{type: token|tool_call|tool_result|done|error}`.
+    // is SSE frames `{type: token|tool_call|tool_result|notice|done|error}`.
     // `model` is deliberately OMITTED: board_chat.py resolves
     // `payload.get("model") or cfg.model or default_model`, so an explicit
     // client-sent model always wins and permanently defeats the
@@ -1446,6 +1446,23 @@ export function useBoardChat(board?: string): UseBoardChatResult {
                 }
                 break
               }
+              case 'notice':
+                // Degradation, not failure: the turn still answers, but with a
+                // caveat the operator must see (`tools_unavailable` — the
+                // runner can't carry tool calls, so there is no live view of
+                // the box this turn). Rendered as its own dim bubble so it
+                // can't be mistaken for the steward's own claim.
+                if (frame.message) {
+                  setMessages((prev) => [
+                    ...prev,
+                    {
+                      role: 'assistant',
+                      body: `ⓘ ${frame.message}`,
+                      at: new Date().toISOString(),
+                    },
+                  ])
+                }
+                break
               case 'error':
                 setMessages((prev) => [
                   ...prev,


### PR DESCRIPTION
## What

The brain steward's native-tools preflight (`_resolved_slot_native_tools`, from #1655) was `image == DEFAULT_ROCMFPX_IMAGE` — image identity, not runner capability. Any box whose brain slot runs a different runner (every CPU-only install and every CUDA box, which resolve to the plain upstream llama.cpp toolboxes via `FALLBACK_VULKAN_IMAGE` / `FALLBACK_CUDA_IMAGE`, plus any deliberate `image_pin`) got `False`, so `_call_chat_model` stripped `tools` from **every** brain round.

Those runners parse OpenAI `tools` perfectly well — verified on CT151 during rc.4 validation: the same slot returns clean native `tool_calls` when tools are attached directly. So the steward silently lost its live view of the box and answered "what slots are loaded?" with invented slot names, and the `[brain_chat] read_only` refusal path (`chat.py:1010`) was unreachable behind the same strip.

## How

Two layers, both needed:

**1. Capability gate.** `NATIVE_TOOL_INCOMPATIBLE_IMAGE_REFS` (new, in `config/schema.py`) is a DENY list of the runners actually measured to reject a tools-attached request — the pre-ade07ba ROCmFPX lineage and its #1626 `"peg-native format"` 500. Everything else is assumed capable. It is a strict subset of `STALE_ROCMFPX_IMAGE_REFS`: the two former basic-lane toolbox defaults are stale (the updater retags them) but tool-capable.

"Assume capable" is only safe with a runtime correction path, so there is one: if a presumed-capable runner rejects a tools-attached round with a tool-format error (`_TOOL_FORMAT_FAILURE_MARKERS`), that round is retried tools-less — no 500 reaches the operator — and the image is remembered in `_LEARNED_TOOL_INCAPABLE_IMAGES` so later turns skip the doomed attempt. Deliberately narrow: a timeout, `dispatch.no_route`, or a plain 5xx does **not** teach the gate. #1655's intent is preserved (a c077206 rollback still never sees `tools`), and behaviour on the default rocmfpx image is byte-for-byte unchanged.

**2. Honesty when stripped.** When tools cannot ride the turn at all — incapable runner **and** no `tool_model` reroute — the turn now carries an explicit "LIVE PLATFORM TOOLS ARE UNAVAILABLE" system notice, folded into the existing system seed rather than appended as a trailing system turn (template safety, see `_frame_messages` / O18), plus a `notice` SSE frame with `code: tools_unavailable`. The UI renders it as a dim in-thread banner and `hal0 chat` as a `note:` line; every other consumer ignores unknown frame types, so the addition is back-compatible. No notice fires when a `tool_model` reroute can still run the round — claiming otherwise would be its own lie.

## Verification

- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/brain/test_brain_tool_reroute.py -q` → 36 passed (11 new tests: the deny-list table, a capable non-default image running real tool rounds, the `read_only` refusal now reachable, learn-and-salvage on a tool-format reject, an ordinary error *not* teaching the gate, the notice/no-notice pair, seed folding).
- Full suite: `9733 passed, 15 skipped, 1 xfailed` (17m32s).
- `make lint` clean; `uv run ruff format --check .` shows only the 6 files already unformatted on `main` (none touched here).
- `mypy` on the touched modules reports only the 8 pre-existing errors in untouched regions of `chat.py` (lines 843–1122).

## Residual risk

- The learned-incapable set is process-local and never persisted, so a box on an unknown-bad runner pays one extra completion per service restart (the first failing round) before degrading. Persisting it would need a config surface; not worth it for a set expected to be empty.
- `_TOOL_FORMAT_FAILURE_MARKERS` is substring matching on upstream error text. A future llama.cpp wording change means the learn path misses and the round errors as it does today (no regression), not that tools are wrongly muted.
- The UI `notice` case was not exercised in a browser (no `ui/node_modules` in this worktree); it is a single additive `switch` arm mirroring `error`.

Closes #1789

🤖 Generated with [Claude Code](https://claude.com/claude-code)