### PR TITLE
polish(ui): rc.4 fresh-install validation sweep — 6 items

### DIFF
--- a/ui/src/dash/Benchmarks.tsx
+++ b/ui/src/dash/Benchmarks.tsx
@@ -18,6 +18,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { apiDelete, apiGet, apiPost } from '../api/client';
+import { useUpdateState } from '../api/hooks/useUpdates';
 
 /* ── types ── */
 
@@ -460,7 +461,36 @@ const Benchmarks: React.FC = () => {
   }, [loadQueue]);
 
   const measured = roster.filter(m => m.measured !== false).length;
+  // #1797(1): `control.state` is the operator-armed intent ("running" only
+  // after Start is pressed — SAFE BY DEFAULT, bench/control.py) — it says
+  // nothing about whether the `hal0-bench-worker` systemd poller is even
+  // alive. The badge collapsed both into one word, so an armed-off-but-alive
+  // worker rendered "worker: stopped" indistinguishably from a dead unit,
+  // which is what the validator read as contradicting `systemctl
+  // is-active`. GET /queue already returns `updated` — the worker's own
+  // heartbeat (bench/cli.py cmd_worker writes it every poll tick, alive or
+  // idle) — so use its recency as the real liveness signal instead of
+  // inferring it from the armed state.
   const workerState = queue?.control?.state || 'stopped';
+  const workerHeartbeatAgeMs = queue?.updated ? Date.now() - Date.parse(queue.updated) : null;
+  const workerAlive = workerHeartbeatAgeMs != null && workerHeartbeatAgeMs >= 0 && workerHeartbeatAgeMs < 30_000;
+  const workerLabel = workerAlive
+    ? (workerState === 'running' ? 'running' : workerState === 'paused' ? 'paused (worker alive)' : 'idle (worker alive)')
+    : 'not reporting';
+  // #1797(4): `host` is derived from a records.jsonl scan (publish.py
+  // _default_host) — on a fresh install with no runs yet it's
+  // {gpu: null, mem_gb: null, hal0: null}, which rendered the literal
+  // "· GB · hal0 v" with both figures empty. Render only the segments that
+  // have a value, and fall back to the live running version (same
+  // hal0.__version__ GET /api/health serves) when the store hasn't
+  // recorded one yet.
+  const { data: updateState } = useUpdateState();
+  const hal0Version = host?.hal0 || updateState?.hal0?.current || null;
+  const headerBits = [
+    host?.gpu || null,
+    host?.mem_gb != null ? `${host.mem_gb} GB` : null,
+    hal0Version ? `hal0 v${hal0Version}` : null,
+  ].filter(Boolean);
 
   return (
     <div className="view" data-testid="benchmarks-view">
@@ -468,9 +498,9 @@ const Benchmarks: React.FC = () => {
         <span className="vh-eye mono">Performance</span>
         <h1>Benchmarks</h1>
         <span className="vh-spacer" />
-        {host && (
+        {headerBits.length > 0 && (
           <span style={{ fontFamily: mono, fontSize: 11, color: 'var(--fg-4)' }}>
-            {host.gpu} &middot; {host.mem_gb} GB &middot; hal0 v{host.hal0}
+            {headerBits.join(' · ')}
           </span>
         )}
         <button className="btn ghost sm" onClick={loadRoster}>Refresh</button>
@@ -494,9 +524,11 @@ const Benchmarks: React.FC = () => {
             <span>{label}</span>
             {ct != null && <span className="slot-tab-ct num">{ct}</span>}
             {id === 'queue' && (
-              <span title={`worker: ${workerState}`} style={{
+              <span title={`worker: ${workerLabel}`} style={{
                 width: 7, height: 7, borderRadius: '50%',
-                background: workerState === 'running' ? 'var(--ok)' : workerState === 'paused' ? 'var(--warn)' : 'var(--fg-5)',
+                background: workerState === 'running' ? 'var(--ok)'
+                  : workerState === 'paused' ? 'var(--warn)'
+                  : workerAlive ? 'var(--fg-4)' : 'var(--fg-5)',
               }} />
             )}
           </button>
@@ -1704,6 +1736,11 @@ function QueueTab({ queue, roster, refresh, onQueueModel }: {
   const exclusive = queue?.control?.exclusive ?? true;
   const items = queue?.items || [];
   const active = queue?.active;
+  // #1797(1): distinguish "armed off, daemon alive" (state=stopped but the
+  // worker's own heartbeat in `updated` is fresh) from "daemon not
+  // reporting" — see the queue-tab badge above for the full rationale.
+  const workerHeartbeatAgeMs = queue?.updated ? Date.now() - Date.parse(queue.updated) : null;
+  const workerAlive = workerHeartbeatAgeMs != null && workerHeartbeatAgeMs >= 0 && workerHeartbeatAgeMs < 30_000;
   const suites: string[] = plan?.suites_considered?.length ? plan.suites_considered : ['roster', 'smoke', 'lane-matrix'];
   const staleBySuite: Record<string, number> = {};
   for (const c of plan?.cells || []) staleBySuite[c.suite] = (staleBySuite[c.suite] || 0) + 1;
@@ -1723,6 +1760,11 @@ function QueueTab({ queue, roster, refresh, onQueueModel }: {
             {state === 'running' && !active && (
               <span style={{ fontFamily: mono, fontSize: 10, color: 'var(--fg-4)' }}>
                 nothing running; queued items start immediately
+              </span>
+            )}
+            {state === 'stopped' && (
+              <span style={{ fontFamily: mono, fontSize: 10, color: 'var(--fg-4)' }}>
+                {workerAlive ? 'hal0-bench-worker is running, idle until Start' : 'hal0-bench-worker not reporting'}
               </span>
             )}
             <span className="vh-spacer" style={{ flex: 1 }} />

--- a/ui/src/dash/chrome.jsx
+++ b/ui/src/dash/chrome.jsx
@@ -550,7 +550,18 @@ function NavList({ route, param, onGo, testPrefix }) {
             <div
               className={"sb-row" + (_navActive(route, param, it.id) ? " active" : "") + (it.children ? " has-children" : "")}
               data-testid={tid(it.id)}
+              role="button"
+              tabIndex={0}
+              aria-label={it.label}
+              aria-current={_navActive(route, param, it.id) ? "page" : undefined}
               onClick={() => { if (it.children) setOpen(o => ({ ...o, [it.id]: true })); onGo(it.id); }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  if (it.children) setOpen(o => ({ ...o, [it.id]: true }));
+                  onGo(it.id);
+                }
+              }}
             >
               {it.icon}
               <span className="lbl">{it.label}</span>
@@ -572,7 +583,12 @@ function NavList({ route, param, onGo, testPrefix }) {
                 key={ch.id}
                 className={"sb-row sb-sub" + (_navActive(route, param, ch.id) ? " active" : "")}
                 data-testid={tid(ch.id)}
+                role="button"
+                tabIndex={0}
+                aria-label={ch.label}
+                aria-current={_navActive(route, param, ch.id) ? "page" : undefined}
                 onClick={() => onGo(ch.id)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onGo(ch.id); } }}
               >
                 <span className="lbl">{ch.label}</span>
               </div>

--- a/ui/src/dash/dashboard-redesign.jsx
+++ b/ui/src/dash/dashboard-redesign.jsx
@@ -253,6 +253,13 @@ function HeroStrip({ slots, heroTps, layout, swapMode, onToggleSwapMode, onToggl
 // ─── band 0 · health strip ───────────────────────────────────────────────────
 
 function HealthStrip({ slots, heroTps, attentionItems }) {
+  // #1797(3): /api/hardware sees the DRM node whether or not THIS box can
+  // actually drive it (LXC shares the host's /sys/class/drm read-only) — a
+  // CPU-only container reports the host iGPU's util/temp as if it were its
+  // own. `computeCapable` is the one probe field backed by a real capability
+  // check (rocm-smi presence, hardware/probe.py), so it's the honest gate.
+  const hw = useHardware()
+  const hasGpu = !!hw.data?.computeCapable
   const attentionCount = attentionItems.length
   // Compact summary across the broadened set: approvals vs everything else
   // (error slots, failed downloads, update, drift, messages) as "alerts".
@@ -299,8 +306,8 @@ function HealthStrip({ slots, heroTps, attentionItems }) {
       </div>
       <div className="rd-health-cell">
         <div className="rd-health-k mono">igpu</div>
-        <div className="rd-health-v mono num">
-          {gpuPct != null ? <>{gpuPct}%{gpuTemp != null && <span className="sub"> · {gpuTemp}°C</span>}</> : '—'}
+        <div className="rd-health-v mono num" title={hasGpu ? undefined : 'No GPU compute access on this box'}>
+          {hasGpu && gpuPct != null ? <>{gpuPct}%{gpuTemp != null && <span className="sub"> · {gpuTemp}°C</span>}</> : '—'}
         </div>
       </div>
       <div className="rd-health-cell">
@@ -572,10 +579,18 @@ function RDUtilizationCard({ swap }) {
   const slotsQuery = useSlots()
   const slots = slotsQuery.data ?? []
 
+  // #1797(3): the DRM/XDNA nodes are visible from any LXC sharing the host
+  // kernel, so gpu_util/npu_status leak the HOST's accelerator state on a
+  // container with no actual compute access. `computeCapable` is the only
+  // probe field backed by a real capability test (rocm-smi presence) —
+  // gate both the iGPU and NPU rows on it so a CPU-only box shows its own
+  // truth (dash, "no GPU/NPU access") instead of the host's numbers.
+  const hasGpu = !!hw.data?.computeCapable
+
   const gpuGhz = st?.gpu_clock_mhz != null ? (st.gpu_clock_mhz / 1000).toFixed(1) : null
   const gpuTemp = st?.gpu_temp_c != null ? Math.round(st.gpu_temp_c) : null
   const gpuW = power.data?.gpu_power_w != null ? Math.round(power.data.gpu_power_w) : null
-  const gpuCaption = [
+  const gpuCaption = !hasGpu ? 'no GPU access' : [
     gpuGhz != null ? `${gpuGhz} GHz` : null,
     gpuTemp != null ? `${gpuTemp}°C` : null,
     gpuW != null ? `${gpuW} W` : null,
@@ -583,11 +598,11 @@ function RDUtilizationCard({ swap }) {
 
   const cores = hw.data?.cores
   const npuStatus = st?.npu_status ?? null
-  const npuActive = npuStatus?.ok ?? null
-  const npuUtil = st?.npu_util ?? null
-  const npuGb = npuStatus?.model_mb ? mbToGb(npuStatus.model_mb) : null
+  const npuActive = hasGpu ? (npuStatus?.ok ?? null) : null
+  const npuUtil = hasGpu ? (st?.npu_util ?? null) : null
+  const npuGb = hasGpu && npuStatus?.model_mb ? mbToGb(npuStatus.model_mb) : null
   const npuSlots = slots.filter((s) => (s.device || '') === 'npu' && s.coresident).map((s) => s.name)
-  const npuCaption = [
+  const npuCaption = !hasGpu ? 'no NPU access' : [
     npuSlots.length > 1 ? `${npuSlots.join(' + ')} coresident` : (npuSlots[0] || null),
     npuGb != null ? `${npuGb.toFixed(1)} GB` : null,
   ].filter(Boolean).join(' · ') || (npuActive == null ? 'pending driver' : null)
@@ -598,8 +613,8 @@ function RDUtilizationCard({ swap }) {
         <UtilRow
           dotColor="var(--dev-vulkan)"
           name="igpu"
-          sub={hw.data?.gpu || null}
-          pct={st?.gpu_util ?? null}
+          sub={hasGpu ? (hw.data?.gpu || null) : 'no gpu'}
+          pct={hasGpu ? (st?.gpu_util ?? null) : null}
           caption={gpuCaption}
         />
         <UtilRow

--- a/ui/src/dash/memory-map.jsx
+++ b/ui/src/dash/memory-map.jsx
@@ -127,26 +127,34 @@ export function useMemoryMapModel() {
   // against it. Prefer the live GTT cap; fall back to the static unified/ram
   // probe when the live value is unavailable (keeps non-UMA + test mocks sane).
   const rawHw = hw.data || {}
+  // #1797(3): the GTT/unified-memory pool is a HOST resource — /api/hardware
+  // sees the host's DRM node (LXC shares the kernel's /sys/class/drm) even
+  // when this container has no real GPU compute access, so an unqualified
+  // "unified" memoryKind on a CPU-only box reported the host's ~116GB GTT
+  // ceiling as this box's own pool. `computeCapable` is the one probe field
+  // backed by an actual capability check (rocm-smi presence) — gate the
+  // GPU-pool framing on it and fall back to plain system RAM otherwise.
+  const hasGpu = !!rawHw.computeCapable
   const ramTotalGb = rawHw.ram?.total ?? 0
-  const gttCapGb = mbToGb(stats.data?.gpu_vram_total_mb || stats.data?.gtt_total_mb || 0)
-  const unifiedFromProbe = mbToGb(rawHw.unified_memory_mb || 0)
+  const gttCapGb = hasGpu ? mbToGb(stats.data?.gpu_vram_total_mb || stats.data?.gtt_total_mb || 0) : 0
+  const unifiedFromProbe = hasGpu ? mbToGb(rawHw.unified_memory_mb || 0) : 0
   const unifiedGb =
     gttCapGb ||
     unifiedFromProbe ||
     ramTotalGb ||
     mbToGb(stats.data?.ram_total_mb || 0)
   const platformLabel = rawHw.platform_label || rawHw.platform || ''
-  const memoryKind = rawHw.memoryKind === 'unified' ? 'unified' : 'system'
+  const memoryKind = hasGpu && rawHw.memoryKind === 'unified' ? 'unified' : 'system'
   // On UMA the pool ceiling is the GTT cap, not the whole unified RAM
   // (see unifiedGb above). Don't render the raw 'unified' kind — it reads
   // as "unified 80GB" and misleads. Label it as the GPU/GTT pool instead.
   const poolLabel = memoryKind === 'unified' ? 'GPU pool (GTT)' : 'system'
 
   const ramUsedGb = mbToGb(stats.data?.ram_used_mb || 0)
-  const gttUsedGb = mbToGb(
-    stats.data?.gtt_used_mb ?? stats.data?.vram_used_mb ?? 0,
-  )
-  const npuModelGb = mbToGb(stats.data?.npu_status?.model_mb || 0)
+  const gttUsedGb = hasGpu
+    ? mbToGb(stats.data?.gtt_used_mb ?? stats.data?.vram_used_mb ?? 0)
+    : 0
+  const npuModelGb = hasGpu ? mbToGb(stats.data?.npu_status?.model_mb || 0) : 0
 
   // N1 (slot-status unifier): isSlotLive() handles both enriched (container)
   // and container (container_status + container_health) runtimes. Replaces

--- a/ui/src/dash/memory.jsx
+++ b/ui/src/dash/memory.jsx
@@ -187,7 +187,7 @@ function MemHindsightCard({
     <>
       <span>{e.version ? `v${e.version}` : 'version unknown'}</span>
       <span className="pf-sep">·</span>
-      <span>{e.banks_total != null ? `${e.banks_total} banks` : '— banks'}</span>
+      <span>{e.banks_total != null ? `${e.banks_total} bank${e.banks_total === 1 ? '' : 's'}` : '— banks'}</span>
     </>
   );
   const stats = [

--- a/ui/src/dash/settings/pages/general/OverviewPage.jsx
+++ b/ui/src/dash/settings/pages/general/OverviewPage.jsx
@@ -14,8 +14,10 @@
 //   - useRequestsRollup() → GET /api/stats/requests  (dispatcher /v1 rollup)
 import { useState, useEffect } from 'react'
 import { useHealthSystem, failingChecks } from '@/api/hooks/useRuntime'
+import { useHardware } from '@/api/hooks/useHardware'
 import { useStatsHardware } from '@/api/hooks/useStatsHardware'
 import { useStatsPower } from '@/api/hooks/useStatsPower'
+import { useUpdateState } from '@/api/hooks/useUpdates'
 import { useRequestsRollup } from '@/api/hooks/useRequestsRollup'
 import { useServicesHealth } from '@/api/hooks/useServicesHealth'
 import { useSettingsClient } from '../../data/settingsClient.js'
@@ -96,7 +98,15 @@ function ServicesPanel() {
 
 function HardwarePanel() {
   const stats = useStatsHardware()
+  const hw = useHardware()
   const H = stats.data
+  // #1797(3): /api/stats/hardware sees the host's DRM/XDNA nodes whether or
+  // not this box (an LXC sharing the host kernel) actually has GPU compute
+  // access — a CPU-only container was rendering the host's GPU/NPU numbers
+  // as its own capacity. `computeCapable` is the one probe field backed by
+  // a real capability check (rocm-smi presence); gate the GPU/NPU rows on
+  // it and keep RAM/CPU, which are genuinely this box's own.
+  const hasGpu = !!hw.data?.computeCapable
 
   return (
     <div className="s-panel" style={{ marginTop: 12 }}>
@@ -108,10 +118,16 @@ function HardwarePanel() {
       {H && (
         <>
           <SRow k="RAM" sub="Host memory in use" mono v={<span style={{ color: 'var(--fg-2)' }}>{_mb(H.ram_used_mb)} / {_mb(H.ram_total_mb)}</span>} />
-          <SRow k="GPU utilization" sub="Compute load on the primary accelerator" mono v={_pct(H.gpu_util)} />
-          <SRow k="GPU VRAM" sub="Dedicated/GTT memory in use" mono v={<span style={{ color: 'var(--fg-3)' }}>{_mb(H.gpu_vram_used_mb ?? H.gtt_used_mb)} / {_mb(H.gpu_vram_total_mb)}</span>} />
           <SRow k="CPU utilization" sub="Host CPU load" mono v={_pct(H.cpu_util)} />
-          {H.npu_status && <SRow k="NPU" sub="XDNA/FastFlowLM model residency" v={_statusChip(H.npu_status.ok, `${H.npu_status.ok ? 'ok' : 'not ok'} · ${_mb(H.npu_status.model_mb)}`)} />}
+          {hasGpu ? (
+            <>
+              <SRow k="GPU utilization" sub="Compute load on the primary accelerator" mono v={_pct(H.gpu_util)} />
+              <SRow k="GPU VRAM" sub="Dedicated/GTT memory in use" mono v={<span style={{ color: 'var(--fg-3)' }}>{_mb(H.gpu_vram_used_mb ?? H.gtt_used_mb)} / {_mb(H.gpu_vram_total_mb)}</span>} />
+              {H.npu_status && <SRow k="NPU" sub="XDNA/FastFlowLM model residency" v={_statusChip(H.npu_status.ok, `${H.npu_status.ok ? 'ok' : 'not ok'} · ${_mb(H.npu_status.model_mb)}`)} />}
+            </>
+          ) : (
+            <SRow k="GPU" sub="No GPU compute access on this box" mono v={<span style={{ color: 'var(--fg-4)' }}>—</span>} />
+          )}
         </>
       )}
     </div>
@@ -120,7 +136,9 @@ function HardwarePanel() {
 
 function PowerPanel() {
   const power = useStatsPower()
+  const hw = useHardware()
   const P = power.data
+  const hasGpu = !!hw.data?.computeCapable
 
   return (
     <div className="s-panel" style={{ marginTop: 12 }}>
@@ -130,9 +148,15 @@ function PowerPanel() {
       {power.isPending && <div style={{ padding: 12, color: 'var(--fg-4)', fontFamily: 'var(--jbm)', fontSize: 12 }}>source pending — no hwmon sensor exposed on this host</div>}
       {!power.isPending && P && (
         <>
-          <SRow k="GPU power draw" mono v={P.gpu_power_w != null ? `${Math.round(P.gpu_power_w)} W` : '—'} />
-          <SRow k="GPU clock" mono v={P.gpu_sclk_mhz != null ? `${P.gpu_sclk_mhz} MHz` : '—'} />
-          <SRow k="GPU temperature" mono v={P.gpu_temp_c != null ? `${Math.round(P.gpu_temp_c)}°C` : '—'} />
+          {hasGpu ? (
+            <>
+              <SRow k="GPU power draw" mono v={P.gpu_power_w != null ? `${Math.round(P.gpu_power_w)} W` : '—'} />
+              <SRow k="GPU clock" mono v={P.gpu_sclk_mhz != null ? `${P.gpu_sclk_mhz} MHz` : '—'} />
+              <SRow k="GPU temperature" mono v={P.gpu_temp_c != null ? `${Math.round(P.gpu_temp_c)}°C` : '—'} />
+            </>
+          ) : (
+            <SRow k="GPU" sub="No GPU compute access on this box" mono v={<span style={{ color: 'var(--fg-4)' }}>—</span>} />
+          )}
           <SRow k="CPU temperature" mono v={P.cpu_temp_c != null ? `${Math.round(P.cpu_temp_c)}°C` : '—'} />
         </>
       )}
@@ -189,8 +213,16 @@ function PrivacyVersionPanel() {
     }
   };
 
+  // #1797(2): the config's `meta` block only ever carries `schema_version`
+  // (hal0.toml [meta], config/schema.py MetaConfig) — `meta.hal0_version`
+  // was never populated by any backend route, so this always rendered "—".
+  // The running API version lives at GET /api/updates/state → hal0.current
+  // (same `hal0.__version__` GET /api/health serves; main.jsx's tab-title
+  // sync already reads it from here), so wire the field to that instead of
+  // a config key that doesn't exist.
+  const { data: updateState } = useUpdateState();
   const meta = settings.data?.meta || {};
-  const version = meta.hal0_version || "—";
+  const version = updateState?.hal0?.current || "—";
   const schemaVer = meta.schema_version != null ? String(meta.schema_version) : "—";
 
   return (


### PR DESCRIPTION
## Summary

Fixes the 6-item dashboard polish sweep from rc.4 fresh-install validation (CT151, CPU-only, Playwright smoke):

1. **Benchmarks "Run Queue" badge said `worker: stopped`** while `hal0-bench-worker` was active. Root cause: the badge only read `control.state` (the operator-armed "Start pressed" intent — safe-by-default, `bench/control.py`), never the worker's own heartbeat that GET `/api/benchmarks/queue` already returns (`updated`). Now derives liveness from heartbeat recency and reports armed-state and process-liveness as distinct signals instead of conflating them.
2. **Settings → Version & privacy showed `hal0 version —`**. Root cause: the UI read `settings.data.meta.hal0_version`, a key that never existed in `hal0.toml`'s `[meta]` block (only `schema_version` does). Wired to `GET /api/updates/state → hal0.current` — the same `hal0.__version__` `/api/health` serves.
3. **Host GPU/NPU telemetry shown as local capacity on CPU-only boxes** (igpu 100%/83°C/122W, "npu active", GPU pool (GTT) free 115.5GB, GPU VRAM 1.0/116.0GB) on a GPU-less 16GB CT. Root cause: `/api/hardware` and `/api/stats/hardware` see the *host's* DRM/XDNA nodes (an LXC shares the host kernel's `/sys/class/drm` read-only) regardless of whether the container can actually drive the GPU. `computeCapable` (`hardware/probe.py`'s `rocm-smi` presence check) is the one probed field backed by a real capability test — gated the Overview health strip, Utilization card, Slots memory map, and Settings hardware/power panels on it, falling back to true CPU/RAM figures.
4. **Benchmarks header rendered `· GB · hal0 v`** with both interpolations empty on a fresh install (no runs yet → `host` derived from an empty records scan). Now renders only the segments that have a value, with the hal0 version falling back to the same live-version source as item 2.
5. **Memory page pluralization**: `v0.8.4 · 1 banks` → `1 bank`.
6. **Left nav rail icons had no accessible names.** All 8 primary rows (+ sub-links) were bare `<div onClick>` — no role, no keyboard access. Added `role="button"`, `tabIndex`, Enter/Space activation, and `aria-label`/`aria-current`. `data-testid`s unchanged.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 121/121 passed (12 files)
- [x] Verified `/api/hardware`, `/api/stats/hardware`, `/api/stats/power`, `/api/benchmarks/queue`, `/api/updates/state` response shapes against the real CT151 CPU-only box (10.0.1.151) to ground the fixes
- No Python touched

Closes #1797

🤖 Generated with [Claude Code](https://claude.com/claude-code)