### PR TITLE
fix(cli/api): rc.4 validation polish rollup (14 items)

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -318,6 +318,16 @@ disambiguation.
 | `registry export` | — | `--out` (default: canonical registry path) |
 | `registry import-sqlite` | — | `--registry-file` (default: canonical registry path) |
 
+## `hal0 profile` — inspect launch-flag profiles
+
+Read-only: full CRUD (create/update/delete/generate/import/export) is
+dashboard/API-only (`/api/profiles`).
+
+| Command | Args | Flags |
+|---|---|---|
+| `profile list` | — | `--json` |
+| `profile show <name>` | `name` | `--json` |
+
 ## `hal0 mcp` — manage MCP servers
 
 | Command | Args | Flags |

--- a/installer/lib/preflight.sh
+++ b/installer/lib/preflight.sh
@@ -1402,7 +1402,17 @@ preflight_all() {
     preflight_disk    || rc=$?
     preflight_ports   || rc=$?
     if (( rc == 0 )); then
-        info "all pre-flight checks passed"
+        # A soft check (e.g. no GPU, git missing, node too old) can warn()
+        # without ever flipping ``rc`` — that's by design (a warning must not
+        # fail a valid CPU-only / no-git install). But an unconditional "all
+        # passed" while warnings sit right above it reads as a contradiction
+        # (#1796). Reflect the warning count in the summary instead of
+        # hiding it.
+        if (( ${UI_WARN_COUNT:-0} > 0 )); then
+            warn "pre-flight checks passed with ${UI_WARN_COUNT} warning(s) — see above"
+        else
+            info "all pre-flight checks passed"
+        fi
     else
         err "one or more pre-flight checks failed (see above)"
     fi

--- a/installer/lib/ui.sh
+++ b/installer/lib/ui.sh
@@ -106,9 +106,16 @@ _ui_repeat() {
 }
 
 # ── Log helpers (preserve signatures) ───────────────────────────────────────
+# UI_WARN_COUNT / UI_ERR_COUNT: bumped by every warn()/err() call so a caller
+# (preflight_all's summary line, #1796) can tell "printed warnings along the
+# way" from "clean run" even on a soft check whose own return code stays 0 by
+# design — counting return codes alone silently drops those warnings from the
+# final verdict.
+UI_WARN_COUNT=${UI_WARN_COUNT:-0}
+UI_ERR_COUNT=${UI_ERR_COUNT:-0}
 info()  { printf '%s%s%s  %s\n' "${GRN}" "${UI_GLYPH_OK}"   "${RST}" "$*"; }
-warn()  { printf '%s%s%s  %s\n' "${YEL}" "${UI_GLYPH_WARN}" "${RST}" "$*" >&2; }
-err()   { printf '%s%s%s  %s\n' "${RED}" "${UI_GLYPH_ERR}"  "${RST}" "$*" >&2; }
+warn()  { UI_WARN_COUNT=$((UI_WARN_COUNT + 1)); printf '%s%s%s  %s\n' "${YEL}" "${UI_GLYPH_WARN}" "${RST}" "$*" >&2; }
+err()   { UI_ERR_COUNT=$((UI_ERR_COUNT + 1)); printf '%s%s%s  %s\n' "${RED}" "${UI_GLYPH_ERR}"  "${RST}" "$*" >&2; }
 die()   { err "$*"; exit 1; }
 
 # ── ui_banner ───────────────────────────────────────────────────────────────

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -2465,7 +2465,7 @@ def _mount_dashboard(app: FastAPI) -> None:
     import os
     from pathlib import Path
 
-    from fastapi.responses import FileResponse, Response
+    from fastapi.responses import FileResponse, RedirectResponse, Response
     from fastapi.staticfiles import StaticFiles
 
     candidates: list[Path] = []
@@ -2497,11 +2497,27 @@ def _mount_dashboard(app: FastAPI) -> None:
     async def _favicon() -> Response:
         return FileResponse(dist / "favicon.svg")
 
+    # Bare top-level paths that collide with a real ``/api/...`` endpoint —
+    # an uptime probe or client hitting the un-prefixed name by habit (or by
+    # following a generic FastAPI tutorial) got 200 HTML from the SPA catch-
+    # all instead of ever reaching the real route (#1796): a probe pointed at
+    # ``/health`` reports "healthy" forever, static HTML has no failure mode.
+    # 307 preserves the method (a probe may HEAD it) unlike a 302/303.
+    _SPA_API_REDIRECTS = {
+        "health": "/api/health",
+        "openapi.json": "/api/openapi.json",
+        "docs": "/api/docs",
+        "redoc": "/api/redoc",
+    }
+
     @app.get("/{full_path:path}", include_in_schema=False)
     async def _spa(full_path: str) -> Response:
         # Don't shadow API routes — those return 404 normally if missing.
         if full_path.startswith("api/") or full_path.startswith("v1/"):
             return Response(status_code=404)
+        redirect_target = _SPA_API_REDIRECTS.get(full_path)
+        if redirect_target is not None:
+            return RedirectResponse(redirect_target, status_code=307)
         # no-cache so browsers always revalidate index.html and pick up a new
         # build's hashed assets immediately (hashed /assets stay cacheable).
         # Without this the dashboard serves stale after a deploy until a hard

--- a/src/hal0/api/routes/mcp.py
+++ b/src/hal0/api/routes/mcp.py
@@ -447,8 +447,13 @@ def _connect_url(request: Request, mount: str) -> str:
     Uses the request's own host so a user browsing the page sees the URL
     their own client should hit (not the canonical hal0 hostname, which
     they may not be able to resolve from where they are sitting).
+
+    The trailing ``/mcp`` matches the FastMCP Streamable HTTP transport path
+    each server is actually mounted under (see
+    ``hal0.api.mcp_mount.mount_mcp_servers``); the bare ``/mcp/<mount>``
+    root 405s (#1796) — clients must POST to ``/mcp/<mount>/mcp``.
     """
-    return f"{request.url.scheme}://{request.url.netloc}/mcp/{mount}"
+    return f"{request.url.scheme}://{request.url.netloc}/mcp/{mount}/mcp"
 
 
 # ── Routes ──────────────────────────────────────────────────────────────────

--- a/src/hal0/api/routes/memory.py
+++ b/src/hal0/api/routes/memory.py
@@ -628,7 +628,11 @@ async def memory_add(request: Request) -> dict[str, Any]:
     body = await _read_json_body(request)
     text = body.get("text")
     if not isinstance(text, str) or not text:
-        raise Hal0Error(
+        # BadRequest (400), not the bare Hal0Error base (which defaults to
+        # code="system.internal", status=500) — a caller sending a wrong
+        # field name landed here and got told the *server* was broken
+        # (#1796) when the request body was the problem.
+        raise BadRequest(
             "memory_add requires 'text' (non-empty string)",
             details={"path": "/api/memory/add"},
         )
@@ -636,7 +640,7 @@ async def memory_add(request: Request) -> dict[str, Any]:
         # Source is server-injected from the X-hal0-Agent
         # header so callers cannot impersonate another agent in the
         # audit log.
-        raise Hal0Error(
+        raise BadRequest(
             "memory_add 'source' is server-injected from X-hal0-Agent and cannot be supplied",
             details={"path": "/api/memory/add"},
         )

--- a/src/hal0/api/routes/memory_admin.py
+++ b/src/hal0/api/routes/memory_admin.py
@@ -215,6 +215,51 @@ async def engine_status(request: Request) -> dict[str, Any]:
 _GRAPH_CACHE = _sg.GraphCache()
 
 
+#: Every one of these being zero/absent on an otherwise-200 stats response is
+#: the shape Hindsight returns for a bank id that was never created (#1796) —
+#: it never itself 404s the way its sibling routes (``/profile``, ``/config``,
+#: ...) do. A genuinely empty-but-real bank looks identical over this same
+#: key set, so this is only a trigger to go double-check existence, never a
+#: verdict on its own.
+_ZERO_STATS_KEYS = ("total_nodes", "total_documents", "total_observations")
+
+
+def _looks_like_placeholder_stats(stats: Any) -> bool:
+    if not isinstance(stats, dict):
+        return False
+    return all(not stats.get(k) for k in _ZERO_STATS_KEYS)
+
+
+@router.get("/banks/{bank_id}/stats")
+async def bank_stats(request: Request, bank_id: str) -> Any:
+    """Per-bank stats — 404 for an unknown bank instead of a zeroed 200.
+
+    Hindsight's own ``GET /v1/default/banks/{bank}/stats`` answers 200 with
+    every counter at zero for a bank id that was never created (#1796),
+    indistinguishable from a real, merely-empty bank — unlike an upstream
+    4xx/5xx on this same route, which still passes through unchanged (a
+    real Hindsight-side error is not this route's business to reinterpret).
+    Only when the 2xx body itself looks like the all-zero placeholder do we
+    pay for a second call — confirming against the authoritative
+    ``GET /v1/default/banks`` listing — rather than on every request.
+    """
+    client = _client(request)
+    _validate_segments({"bank_id": bank_id})
+    stats = await _forward(client, "GET", f"/v1/default/banks/{bank_id}/stats")
+    if not _looks_like_placeholder_stats(stats):
+        return stats
+    banks_resp = await _forward(client, "GET", "/v1/default/banks")
+    banks = banks_resp.get("banks") if isinstance(banks_resp, dict) else banks_resp
+    known_ids = (
+        {(b.get("bank_id") if isinstance(b, dict) else b) for b in banks}
+        if isinstance(banks, list)
+        else set()
+    )
+    if bank_id not in known_ids:
+        raise NotFound(f"bank {bank_id!r} does not exist", code="memory.bank_not_found")
+    return stats
+
+
 @router.get("/banks/{bank_id}/graph/subgraph")
 async def bank_subgraph(request: Request, bank_id: str) -> dict[str, Any]:
     client = _client(request)
@@ -503,7 +548,9 @@ _FORWARDS: tuple[tuple[str, str, str], ...] = (
     ("PATCH", "/banks/{bank_id}", "/v1/default/banks/{bank_id}"),
     # DELETE /banks/{bank_id} is NOT here — it is special-cased into the guarded
     # ``delete_bank`` handler above (irreversible; requires ?confirm=<bank_id>).
-    ("GET", "/banks/{bank_id}/stats", "/v1/default/banks/{bank_id}/stats"),
+    # GET /banks/{bank_id}/stats is NOT here either — see ``bank_stats`` below
+    # (#1796: the plain passthrough returned 200 with all-zero counts for an
+    # unknown bank id instead of 404).
     (
         "GET",
         "/banks/{bank_id}/stats/timeseries",

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -526,6 +526,10 @@ def cmd_results(args: argparse.Namespace) -> int:
     rows = store.results(model=args.model, since=args.since, limit=args.limit)
     if args.json:
         print(json.dumps(rows, indent=2))
+    elif not rows:
+        # An empty table and "nothing has ever run" look identical with no
+        # output at all (#1796) — say so instead of printing nothing.
+        print("no records")
     else:
         for r in rows:
             print(

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -7,10 +7,12 @@ Entry point declared in pyproject.toml:
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
 
+import structlog
 import typer
 import uvicorn
 from rich.console import Console
@@ -41,6 +43,7 @@ from hal0.cli.memory_commands import app as memory_app
 from hal0.cli.migrate_commands import app as migrate_app
 from hal0.cli.model_commands import app as model_app
 from hal0.cli.ports_command import ports_cmd
+from hal0.cli.profile_commands import app as profile_app
 from hal0.cli.registry_commands import app as registry_app
 from hal0.cli.setup_command import app as setup_app
 from hal0.cli.slot_commands import app as slot_app
@@ -81,6 +84,9 @@ app.add_typer(agent_app, name="agent")
 app.add_typer(app_ext_app, name="app")
 app.add_typer(migrate_app, name="migrate")
 app.add_typer(registry_app, name="registry")
+# Issue #1796 — ``hal0 profile {list,show}``, the read half of /api/profiles
+# every slot TOML references but which had no CLI surface at all.
+app.add_typer(profile_app, name="profile")
 # Issue #504 — ``hal0 mcp {list,status,install,uninstall,restart,catalog}``
 # CLI over /api/mcp/*. Mounted after registry before setup.
 app.add_typer(mcp_app, name="mcp")
@@ -126,6 +132,27 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
+def _configure_cli_logging() -> None:
+    """Filter structlog output for one-shot CLI commands.
+
+    Nothing in the CLI process ever calls ``structlog.configure``, so it runs
+    with structlog's own default — a bare print logger with NO level filter.
+    Any ``log.debug(...)`` on a code path a command happens to exercise (e.g.
+    the hardware probe's nvidia-smi fallback) prints straight to stdout,
+    above the command's own table (#1796). Default to WARNING so debug/info
+    telemetry stays silent for humans; ``HAL0_LOG_LEVEL`` still overrides for
+    anyone who wants it back (mirrors the server-side log level env var).
+    """
+    level_name = os.environ.get("HAL0_LOG_LEVEL", "WARNING").strip().upper()
+    level = logging.getLevelName(level_name)
+    if not isinstance(level, int):
+        level = logging.WARNING
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
+
 @app.callback()
 def main_callback(
     version: bool | None = typer.Option(
@@ -142,6 +169,7 @@ def main_callback(
     # hal0-bench-worker.service process) and every one-shot CLI call are
     # both covered by one hook. Unhandled CLI exceptions are then picked up
     # by the SDK's own excepthook integration. Inert without a DSN.
+    _configure_cli_logging()
     sentry.init_sentry("cli")
 
 

--- a/src/hal0/cli/main.py
+++ b/src/hal0/cli/main.py
@@ -142,7 +142,19 @@ def _configure_cli_logging() -> None:
     above the command's own table (#1796). Default to WARNING so debug/info
     telemetry stays silent for humans; ``HAL0_LOG_LEVEL`` still overrides for
     anyone who wants it back (mirrors the server-side log level env var).
+
+    ``structlog.configure`` is process-global, not per-invocation — fine for
+    a real CLI process (one command, one process, exits). But
+    ``typer.testing.CliRunner`` invokes this callback IN-PROCESS, so under
+    pytest this would leak a WARNING-level filter into the rest of the same
+    test session and silently swallow ``log.info``/``log.debug`` calls other
+    tests assert on (e.g. tests/dispatcher/test_router.py's
+    ``dispatch.decision`` log-capture test). Skip under pytest — the leak
+    this function fixes is a real-process phenomenon; a live pytest run
+    reveals it fine on its own by watching stdout.
     """
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return
     level_name = os.environ.get("HAL0_LOG_LEVEL", "WARNING").strip().upper()
     level = logging.getLevelName(level_name)
     if not isinstance(level, int):

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -60,6 +60,7 @@ def model_list(
         return
     models = data.get("models", []) if isinstance(data, dict) else data
     table = Table(title=f"Models ({len(models)})")
+    table.add_column("")  # default-model marker (#1796); unlabeled like `git branch`'s `*`
     table.add_column("ID", style="bold")
     table.add_column("Name")
     table.add_column("Upstream")
@@ -69,6 +70,7 @@ def model_list(
         return
     for m in models:
         table.add_row(
+            "[green]*[/green]" if m.get("default") else "",
             m.get("id", "—"),
             m.get("name") or m.get("id", "—"),
             m.get("upstream") or m.get("owned_by") or "—",
@@ -366,7 +368,12 @@ def model_scan() -> None:
         die(str(exc))
         return
     added = result.get("added", []) or []
-    skipped = result.get("skipped", 0)
+    # scan_and_register() (and the /api/models/scan route wrapping it) returns
+    # "skipped" as a *list* of skipped entries, matching "added" — not a
+    # count. Printing it raw rendered "4 added, [] skipped" (#1796); take the
+    # length like the boot-time auto-scan log line already does.
+    skipped_raw = result.get("skipped", []) or []
+    skipped = len(skipped_raw) if isinstance(skipped_raw, list) else skipped_raw
     roots = result.get("scanned_roots", []) or []
     console.print(f"Scanned: {', '.join(roots) or '—'}")
     for mid in added:

--- a/src/hal0/cli/profile_commands.py
+++ b/src/hal0/cli/profile_commands.py
@@ -1,0 +1,125 @@
+"""``hal0 profile`` subcommands — thin CLI over ``/api/profiles``.
+
+Before this file existed there was no CLI surface for profiles at all
+(#1796): 17 server-side profiles with full CRUD live at ``/api/profiles``
+(+``/generate``, ``/import``, ``/export``), and every slot TOML references
+one by name, but ``hal0 profile`` returned "No such command". ``list`` /
+``show`` cover the minimum read surface an operator needs to answer "what
+profiles exist" and "what does this one resolve to" without a REST client —
+mirroring the read half of the dashboard's Profiles page and
+``GET /api/profiles`` / ``GET /api/profiles/{name}``. Write operations
+(create/update/delete/generate/import/export) stay API/dashboard-only for
+now; add them here the same way if operators ask for scriptable writes.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, die
+
+app = typer.Typer(
+    name="profile",
+    help="Inspect launch-flag profiles (read-only; full CRUD lives in the dashboard/API).",
+    no_args_is_help=True,
+)
+
+console = Console()
+
+
+@app.command("list")
+def profile_list(
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/profiles JSON for CI/pipe use (no Rich table).",
+    ),
+) -> None:
+    """List every profile in the catalog (GET /api/profiles)."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        profiles = api_get("/api/profiles")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(profiles, indent=2))
+        return
+    if not isinstance(profiles, list) or not profiles:
+        console.print("[dim]No profiles available.[/dim]")
+        return
+    table = Table(title=f"Profiles ({len(profiles)})")
+    table.add_column("Name", style="bold")
+    table.add_column("Device")
+    table.add_column("Backend")
+    table.add_column("MTP")
+    table.add_column("Intent")
+    table.add_column("tok/s", justify="right")
+    table.add_column("Used by")
+    for p in profiles:
+        if not isinstance(p, dict):
+            continue
+        tps = p.get("tps")
+        used_by = p.get("used_by") or []
+        table.add_row(
+            p.get("name", "—"),
+            p.get("device_class") or "—",
+            p.get("backend") or "—",
+            "yes" if p.get("mtp") else "",
+            p.get("intent") or "—",
+            f"{tps:.1f}" if isinstance(tps, (int, float)) else "—",
+            ", ".join(used_by) if used_by else "—",
+        )
+    console.print(table)
+
+
+@app.command("show")
+def profile_show(
+    name: str = typer.Argument(..., help="Profile name to inspect"),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw /api/profiles/{name} JSON for CI/pipe use (no Rich panel).",
+    ),
+) -> None:
+    """Resolve a single profile by name (GET /api/profiles/{name})."""
+    url = _api_base()
+    if _api_unreachable(url):
+        raise typer.Exit(1)
+    try:
+        profile = api_get(f"/api/profiles/{name}")
+    except CliApiError as exc:
+        die(str(exc))
+        return
+    if json_out:
+        typer.echo(jsonlib.dumps(profile, indent=2))
+        return
+    if not isinstance(profile, dict):
+        die(f"unexpected response for profile {name!r}")
+        return
+    for key in (
+        "name",
+        "device_class",
+        "backend",
+        "mtp",
+        "intent",
+        "quant",
+        "tps",
+        "rtf",
+    ):
+        if key in profile:
+            console.print(f"[bold]{key}[/bold]: {profile[key]}")
+    used_by = profile.get("used_by") or []
+    console.print(f"[bold]used_by[/bold]: {', '.join(used_by) if used_by else '—'}")
+    flags = profile.get("resolved_flags") or profile.get("flags")
+    if flags:
+        console.print(f"[bold]flags[/bold]: {flags}")
+
+
+__all__ = ["app"]

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -749,11 +749,12 @@ def slot_metrics(
             continue
         tps = m.get("tokens_per_sec")
         kv = m.get("kv_cache_usage")
+        mem = m.get("mem_rss_mb")
         table.add_row(
             slot_name,
             f"{tps:.1f}" if isinstance(tps, (int, float)) else "—",
             f"{kv * 100:.0f}" if isinstance(kv, (int, float)) else "—",
-            str(m.get("mem_rss_mb", "—")),
+            f"{mem:.1f}" if isinstance(mem, (int, float)) else "—",
             str(m.get("uptime_seconds", "—")),
             str(m.get("requests_processing", "—")),
         )

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -58,13 +58,43 @@ class UpdateChannel(StrEnum):
     nightly = "nightly"
 
 
+#: A manifest whose version is exactly "0.0.0" (optionally paired with an
+#: all-zero digest) is the placeholder the release service serves for a
+#: channel with nothing published yet — not a real, installable target.
+#: Rendering it as "→ 0.0.0 up to date" tells the operator there is nothing
+#: to install when the truth is nobody has published anything here.
+_PLACEHOLDER_VERSION = "0.0.0"
+_PLACEHOLDER_DIGEST = "0" * 64
+
+
+def _is_placeholder_manifest(latest: str, manifest: dict) -> bool:
+    if latest.strip() == _PLACEHOLDER_VERSION:
+        return True
+    digest = manifest.get("digest_sha256")
+    return isinstance(digest, str) and digest == _PLACEHOLDER_DIGEST
+
+
 def _print_check(body: dict) -> None:
     """Render the /api/updates/check response as a rich panel + table."""
     current = body.get("current", "?")
-    latest = body.get("latest") or "—"
+    latest_raw = str(body.get("latest") or "")
     channel = body.get("channel", "stable")
     available = body.get("update_available", False)
+    manifest = body.get("manifest") or {}
+    if not isinstance(manifest, dict):
+        manifest = {}
 
+    if _is_placeholder_manifest(latest_raw, manifest):
+        console.print(
+            Panel(
+                f"[bold]hal0[/bold] {current}  ({channel})  "
+                "[yellow]no release published on this channel[/yellow]",
+                border_style="cyan",
+            )
+        )
+        return
+
+    latest = latest_raw or "—"
     status = "[green]update available[/green]" if available else "[dim]up to date[/dim]"
     console.print(
         Panel(
@@ -72,9 +102,6 @@ def _print_check(body: dict) -> None:
             border_style="cyan",
         )
     )
-    manifest = body.get("manifest") or {}
-    if not isinstance(manifest, dict):
-        manifest = {}
     if manifest:
         table = Table(show_header=False, box=None, padding=(0, 2))
         for key in ("released_at", "notes_url", "digest_sha256", "signer_identity"):

--- a/src/hal0/hardware/probe.py
+++ b/src/hal0/hardware/probe.py
@@ -169,6 +169,14 @@ def _parse_cpuinfo() -> tuple[str, int, int]:
         threads = os.cpu_count() or 0
     sockets = max(1, len(physical_ids))
     cores = cores_per_socket * sockets if cores_per_socket > 0 else threads
+    # In a container, "processor" stanzas (threads) are cgroup/affinity-limited
+    # to what the container actually gets, but "cpu cores" is a per-die
+    # hardware constant carried over from the host and NOT namespaced — so an
+    # 8-vCPU LXC on a 16-core host reports the impossible "16 cores / 8
+    # threads" (#1796). Physical cores can never exceed logical threads, so
+    # clamp to the value we can actually trust.
+    if threads and cores > threads:
+        cores = threads
     return model, cores, threads
 
 

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -271,6 +271,7 @@ def _redact_logs_payload(payload: Any) -> Any:
 # server module itself (the orchestrator decides whether to mount).
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+    from mcp.server.fastmcp.exceptions import ToolError  # type: ignore[import-not-found]
     from mcp.types import ToolAnnotations  # type: ignore[import-not-found]
 except ImportError as _import_exc:  # pragma: no cover — exercised at install time
     raise ImportError(
@@ -3041,6 +3042,14 @@ def build_server(
     tool the agent picked.
     """
     server = FastMCP(name)
+    # FastMCP's constructor has no ``version`` kwarg, so the underlying
+    # ``mcp.server.lowlevel.Server`` defaults ``initialize``'s
+    # ``serverInfo.version`` to the ``mcp`` SDK package version (e.g.
+    # "1.28.1") — a client sees the FastMCP library version, not hal0's own
+    # (#1796). Stamp it post-construction on the wrapped server object.
+    from hal0 import __version__ as _hal0_version
+
+    server._mcp_server.version = _hal0_version
 
     def _resolve() -> tuple[str | None, str]:
         if bearer_resolver is None:
@@ -3054,7 +3063,7 @@ def build_server(
     def _register(tool_name: str, description: str) -> None:
         async def _tool(args: dict[str, Any] | None = None) -> dict[str, Any]:
             bearer, client_id = _resolve()
-            return await dispatch(
+            result = await dispatch(
                 tool=tool_name,
                 args=args or {},
                 client_id=client_id,
@@ -3063,6 +3072,18 @@ def build_server(
                 approval_queue=approval_queue,
                 memory_dispatcher=memory_dispatcher,
             )
+            # dispatch()/_execute_tool() signal failure (bad/missing args,
+            # unknown tool, denied/refused policy, REST 4xx/5xx, ...) by
+            # returning ``{"status": "error", "error": {...}}`` rather than
+            # raising — a normal return, so FastMCP's CallToolResult came
+            # back ``isError: false`` with the error dict just sitting in
+            # the content as if it were a successful payload (#1796). Raise
+            # here so the lowlevel handler's ``except Exception`` path sets
+            # ``isError: true`` the way every MCP client expects to detect
+            # a failed call without string-sniffing the content.
+            if isinstance(result, dict) and result.get("status") == "error":
+                raise ToolError(json.dumps(result.get("error", result)))
+            return result
 
         _tool.__name__ = tool_name
         _tool.__doc__ = description

--- a/src/hal0/mcp/memory.py
+++ b/src/hal0/mcp/memory.py
@@ -67,6 +67,7 @@ mounts at ``/mcp/memory`` via ``app.mount()``.
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import UTC, datetime
 from typing import Any
@@ -81,6 +82,7 @@ from hal0.memory.namespace import (
 
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+    from mcp.server.fastmcp.exceptions import ToolError  # type: ignore[import-not-found]
     from mcp.types import ToolAnnotations  # type: ignore[import-not-found]
 except ImportError as _import_exc:  # pragma: no cover — exercised at install time
     raise ImportError(
@@ -1399,12 +1401,35 @@ def build_server(
     surface's bulk-delete gate (#1302).
     """
     server = FastMCP(name)
-    dispatcher = make_dispatcher(
+    # See hal0.mcp.admin's build_admin_mcp_server for why this is stamped
+    # post-construction (#1796): FastMCP has no ``version`` kwarg, so
+    # ``serverInfo.version`` otherwise defaults to the ``mcp`` SDK version.
+    from hal0 import __version__ as _hal0_version
+
+    server._mcp_server.version = _hal0_version
+    _raw_dispatcher = make_dispatcher(
         wrapper,
         client_id_resolver=client_id_resolver,
         private_resolver=private_resolver,
         approval_queue=approval_queue,
     )
+
+    async def dispatcher(tool: str, args: dict[str, Any]) -> dict[str, Any]:
+        """Every ``@server.tool`` function below calls this, unchanged.
+
+        ``_raw_dispatcher`` signals failure (bad args, memory-schema error,
+        engine exception, ...) as a normal ``{"status": "error", ...}``
+        return, same convention as ``hal0.mcp.admin.dispatch`` — so every
+        one of this mount's tool calls came back ``isError: false`` even on
+        a hard validation failure (#1796; ``POST /api/memory/add`` with a
+        wrong field name is the concrete repro). Raise here, once, instead
+        of touching all ~20 ``@server.tool`` bodies below — FastMCP's
+        lowlevel handler catches the exception and flips ``isError: true``.
+        """
+        result = await _raw_dispatcher(tool, args)
+        if isinstance(result, dict) and result.get("status") == "error":
+            raise ToolError(json.dumps(result.get("error", result)))
+        return result
 
     # Typed signatures so FastMCP publishes real parameter schemas —
     # the old single ``args: dict`` param advertised an opaque object

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -349,17 +349,34 @@ def detect(path: str | Path) -> DetectionResult:
         ctx_len_int: int | None = ctx_len if isinstance(ctx_len, int) else None
 
         pooling = header.get("pooling_type")
-        # llama.cpp uses pooling_type=0 (NONE) for causal chat models and
-        # >0 (MEAN=1, CLS=2, LAST=3, RANK=4) for embedding / rerank.
-        # Treat any positive int as a strong embed signal.
-        is_embed = isinstance(pooling, int) and pooling > 0
+        # llama.cpp uses pooling_type=0 (NONE) for causal chat models,
+        # MEAN=1/CLS=2/LAST=3 for embedding, and RANK=4 for cross-encoder
+        # rerankers. RANK used to be folded into the generic "positive int
+        # => embed" bucket below, which collapsed rerankers to "embed" (and,
+        # once the filename fallback also missed — see next comment — all
+        # the way down to the "chat" default, #1796: a reranker gguf with no
+        # pooling_type in its header registered as capabilities: chat).
+        is_rerank = pooling == 4
+        is_embed = not is_rerank and isinstance(pooling, int) and pooling > 0
 
-        # Filename embed-token fallback in case pooling_type is missing
-        # but the file is clearly an embed model (some converters drop it).
-        if not is_embed and _filename_capability(p.name) == "embed":
-            is_embed = True
+        # Filename token fallback in case pooling_type is missing but the
+        # file is clearly embed/rerank (some converters drop it). Uses the
+        # full shared token table, NOT the narrower ``_filename_capability``
+        # helper above — that one deliberately collapses "rerank" to None
+        # for detect()'s *older* embed/asr/tts-only contract, which is
+        # exactly the gap that let a rerank filename fall through to "chat"
+        # here. ``discover.scan_and_register`` (the install-time auto-scan)
+        # reads the same full table via ``_guess_capability`` and gets
+        # rerank right for the identical file — reuse its source of truth
+        # instead of re-diverging.
+        if not is_rerank and not is_embed:
+            filename_cap = capability_from_filename(p.name)
+            if filename_cap == "rerank":
+                is_rerank = True
+            elif filename_cap == "embed":
+                is_embed = True
 
-        caps = ["embed"] if is_embed else ["chat"]
+        caps = ["rerank"] if is_rerank else (["embed"] if is_embed else ["chat"])
 
         name_candidate = header.get("general.name") or header.get("general.basename")
         suggested_name = (

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1054,13 +1054,18 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
     if isinstance(raw_id, str) and raw_id.strip():
         model_id = raw_id.strip()
     else:
-        # Prefer the detector's suggested_name (post-GGUF arch+param sniff)
-        # falling back to the slug of the stem so two paths to the same
-        # file land on the same id as the auto-scan would. The stem comes
-        # from the operator's path, not the resolved target — a hub-cache
-        # symlink resolves to a sha-named blob whose stem is 64 hex chars
-        # (#1415).
-        model_id = _normalise_id(detection.suggested_name or path.stem)
+        # Slug of the filename stem — same source discover.scan_and_register
+        # uses (``CandidateModel.suggested_id = _normalise_id(naming_source.stem)``,
+        # registry/discover.py), so a file registered by hand and the same
+        # file picked up by the install-time auto-scan land on the same id.
+        # Previously this preferred the GGUF header's ``general.name`` /
+        # ``general.basename`` (via ``detection.suggested_name``), which is
+        # the model's upstream architecture label, not a filesystem identity
+        # — e.g. a "jina-reranker-v2" file registering as id
+        # "jina-bert-implementation" (#1796). The stem comes from the
+        # operator's path, not the resolved target — a hub-cache symlink
+        # resolves to a sha-named blob whose stem is 64 hex chars (#1415).
+        model_id = _normalise_id(path.stem)
 
     raw_name = body.get("name")
     if isinstance(raw_name, str) and raw_name.strip():

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -344,9 +344,25 @@ async def build_per_slot(
         cgroup_mb = round(cgroup_bytes / (1024.0 * 1024.0), 1)
         resident_mb = max(cgroup_mb, estimate_mb)
 
+        # ── VRAM vs. RAM attribution (#1796) ────────────────────────────
+        # ``backend`` here is the normalized effective-backend token from
+        # ``_cfg_effective_backend`` ("rocm" | "vulkan" | "cuda" | "cpu" |
+        # "flm"), NOT the raw slot.backend passed straight through — it is
+        # the single source the dashboard's own backend chip trusts. A
+        # ``cpu`` slot has no discrete VRAM pool to charge: its weights are
+        # resident in system RAM, so booking them under vram_mb reads as
+        # phantom GPU usage on a GPU-less box (RAM MB 0.0 alongside a
+        # nonzero VRAM MB). Attribute to ram_mb instead; every GPU backend
+        # (and the flm/NPU fallback above, which shares this UMA-style
+        # accounting) keeps the historical vram_mb attribution.
+        if backend == "cpu":
+            vram_mb, ram_mb = 0.0, resident_mb
+        else:
+            vram_mb, ram_mb = resident_mb, 0.0
+
         out[s.name] = {
-            "vram_mb": resident_mb,
-            "ram_mb": 0.0,
+            "vram_mb": vram_mb,
+            "ram_mb": ram_mb,
             "mem_mb": resident_mb,
             "state": state,
             "model_id": model_id,

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2423,6 +2423,19 @@ class SlotManager:
         ):
             with contextlib.suppress(FileNotFoundError):
                 path.unlink()
+        # The per-slot working directory (/var/lib/hal0/slots/<name>/, and
+        # its id-keyed sibling once migrated) holds nothing but state.json —
+        # unlinked above — so it is always empty at this point. rmdir()
+        # rather than leaving it behind as litter (#1796); best-effort and
+        # non-fatal (a stray extra file some other component dropped there
+        # must not turn a slot delete into an error, it just leaves that one
+        # dir behind for a human to look at).
+        dirs_to_prune = [paths.slot_data_dir(slot_name)]
+        if ident is not None:
+            dirs_to_prune.append(paths.slot_data_dir(str(ident.id)))
+        for slot_dir in dirs_to_prune:
+            with contextlib.suppress(FileNotFoundError, OSError):
+                slot_dir.rmdir()
         # Drop in-memory bookkeeping last. Resolve the handle BEFORE forgetting
         # the binding (and note the identity row was just deleted, so peek the
         # cached handle rather than re-resolving through the store).

--- a/tests/api/test_mcp_routes.py
+++ b/tests/api/test_mcp_routes.py
@@ -146,8 +146,11 @@ def test_servers_returns_introspected_counts(client: TestClient) -> None:
     assert by_id["hal0-admin"]["bundled"] is True
     assert by_id["hal0-admin"]["state"] == "running"
     assert by_id["hal0-admin"]["transport"] == "streamable-http"
-    assert by_id["hal0-admin"]["connect_url"].endswith("/mcp/admin")
-    assert by_id["hal0-memory"]["connect_url"].endswith("/mcp/memory")
+    # #1796: the FastMCP Streamable HTTP transport is mounted one level
+    # deeper than the mount id — /mcp/admin/mcp, not /mcp/admin (the bare
+    # mount root 405s).
+    assert by_id["hal0-admin"]["connect_url"].endswith("/mcp/admin/mcp")
+    assert by_id["hal0-memory"]["connect_url"].endswith("/mcp/memory/mcp")
     assert by_id["hal0-memory"]["tools"] == 4
 
 

--- a/tests/api/test_memory_admin_routes.py
+++ b/tests/api/test_memory_admin_routes.py
@@ -134,6 +134,30 @@ def test_leading_colon_bank_id_still_400(client: TestClient) -> None:
     assert r.json()["error"]["code"] == "memory.invalid_bank"
 
 
+# ── #1796: unknown-bank stats must 404, not 200 with zeroed counters ───────────
+
+
+def test_stats_for_unknown_bank_404s(client: TestClient, recorder: _Recorder) -> None:
+    """Hindsight's own /stats answers 200 all-zero for a bank that was never
+    created — the exact shape reported live. The route must double-check
+    against the bank listing and 404 rather than forward that verbatim."""
+    recorder.respond("GET", "/v1/default/banks/ghost-bank/stats", 200, {"bank_id": "ghost-bank"})
+    recorder.respond("GET", "/v1/default/banks", 200, {"banks": [{"bank_id": "shared"}]})
+    r = client.get("/api/memory/banks/ghost-bank/stats")
+    assert r.status_code == 404
+    assert r.json()["error"]["code"] == "memory.bank_not_found"
+
+
+def test_stats_for_real_but_empty_bank_still_200s(client: TestClient, recorder: _Recorder) -> None:
+    """A real bank with genuinely zero items must NOT 404 — only an id
+    missing from the bank listing does."""
+    recorder.respond("GET", "/v1/default/banks/fresh-bank/stats", 200, {"bank_id": "fresh-bank"})
+    recorder.respond("GET", "/v1/default/banks", 200, {"banks": [{"bank_id": "fresh-bank"}]})
+    r = client.get("/api/memory/banks/fresh-bank/stats")
+    assert r.status_code == 200
+    assert r.json()["bank_id"] == "fresh-bank"
+
+
 # ── forwarding: reads ──────────────────────────────────────────────────────────
 
 

--- a/tests/api/test_memory_rest_routes.py
+++ b/tests/api/test_memory_rest_routes.py
@@ -221,6 +221,33 @@ def test_add_caller_supplied_source_rejected(client: TestClient, stub_wrapper: S
     assert stub_wrapper.add_calls == []
 
 
+def test_add_missing_text_is_400_not_500(client: TestClient, stub_wrapper: StubWrapper) -> None:
+    """#1796: a client typo'd/wrong field name (no ``text`` key) is the
+    CLIENT's mistake — it must come back as a 400-class validation error,
+    not ``code: "system.internal"`` (the bare Hal0Error default, which
+    reads as "hal0 itself is broken")."""
+    r = client.post(
+        "/api/memory/add",
+        json={"body": "wrong field name"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] != "system.internal"
+    assert stub_wrapper.add_calls == []
+
+
+def test_add_caller_supplied_source_is_400_not_500(
+    client: TestClient, stub_wrapper: StubWrapper
+) -> None:
+    r = client.post(
+        "/api/memory/add",
+        json={"text": "x", "source": "fake-agent"},
+        headers={"X-hal0-Agent": "hermes-agent"},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] != "system.internal"
+
+
 # ── /api/memory/search ─────────────────────────────────────────────────────
 
 

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -9,6 +9,7 @@ duplicate id without overwrite, and bad body.
 
 from __future__ import annotations
 
+import struct
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hal0.api import create_app
+from hal0.registry.gguf_header import _GGUF_TYPE_STRING, _GGUF_TYPE_UINT32
+from tests.registry.test_gguf_header import _build_gguf, _enc_str
 
 
 @pytest.fixture
@@ -248,6 +251,30 @@ def test_add_from_path_accepts_gguf_symlink_into_extensionless_blob(
     assert "qwen3" in body["id"].lower()
     assert link.resolve().name not in body["id"]
     assert link.resolve().name not in body["name"]
+
+
+def test_add_from_path_id_from_filename_not_gguf_arch_header(
+    add_path_client: tuple[TestClient, Path],
+) -> None:
+    """#1796: the registered id must come from the filename, not the GGUF
+    header's ``general.name``/``general.basename`` — the live repro was a
+    "jina-reranker-v2-base.gguf" file registering as id
+    "jina-bert-implementation" (the upstream architecture label baked into
+    the header, not a filesystem identity)."""
+    client, drop = add_path_client
+    kvs = [
+        ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+        ("general.name", _GGUF_TYPE_STRING, _enc_str("jina-bert-implementation")),
+        ("bert.context_length", _GGUF_TYPE_UINT32, struct.pack("<I", 512)),
+    ]
+    target = drop / "jina-reranker-v2-base.gguf"
+    target.write_bytes(_build_gguf(3, kvs))
+
+    r = client.post("/api/models/add-from-path", json={"path": str(target)})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["id"] == "jina-reranker-v2-base"
+    assert "jina-bert-implementation" not in body["id"]
 
 
 def test_add_from_path_symlink_to_disallowed_extension_still_rejected(

--- a/tests/api/test_spa_catch_all_redirects.py
+++ b/tests/api/test_spa_catch_all_redirects.py
@@ -1,0 +1,57 @@
+"""SPA catch-all redirects for probe-shaped bare paths (#1796).
+
+A production box has the UI dist built and mounted, so the SPA catch-all
+was quietly serving 200 HTML at ``/health``, ``/openapi.json``, ``/docs``,
+``/redoc`` — the un-prefixed names of real ``/api/...`` endpoints. An
+uptime probe pointed at the bare ``/health`` (a very natural guess) reported
+"healthy" forever off static HTML, never reaching the real check.
+
+``_mount_dashboard`` only runs when a UI dist directory is found
+(``HAL0_UI_DIST`` env or a repo-relative ``ui/dist``), so this test builds a
+minimal fake dist to exercise the real mount path end-to-end rather than
+mocking the route directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+@pytest.fixture
+def spa_client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text("<html>spa</html>")
+    (dist / "favicon.svg").write_text("<svg/>")
+    monkeypatch.setenv("HAL0_UI_DIST", str(dist))
+    app = create_app()
+    with TestClient(app, follow_redirects=False) as c:
+        yield c
+
+
+@pytest.mark.parametrize(
+    "bare_path,api_path",
+    [
+        ("/health", "/api/health"),
+        ("/openapi.json", "/api/openapi.json"),
+        ("/docs", "/api/docs"),
+        ("/redoc", "/api/redoc"),
+    ],
+)
+def test_bare_api_lookalike_redirects_to_api(
+    spa_client: TestClient, bare_path: str, api_path: str
+) -> None:
+    r = spa_client.get(bare_path)
+    assert r.status_code == 307, r.text
+    assert r.headers["location"] == api_path
+
+
+def test_unrelated_spa_route_still_serves_index(spa_client: TestClient) -> None:
+    r = spa_client.get("/some/dashboard/route")
+    assert r.status_code == 200
+    assert r.text == "<html>spa</html>"

--- a/tests/bench/test_cli_results.py
+++ b/tests/bench/test_cli_results.py
@@ -1,0 +1,25 @@
+"""`hal0 bench results` — empty-store output (#1796).
+
+Before this fix an empty ``bench.db`` printed nothing at all for the
+non-``--json`` path, indistinguishable from a hung/broken command.
+"""
+
+from __future__ import annotations
+
+from hal0.bench.cli import main
+
+
+def test_results_empty_prints_no_records(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    rc = main(["results"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no records" in out
+
+
+def test_results_empty_json_stays_empty_list(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    rc = main(["results", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out.strip() == "[]"

--- a/tests/cli/test_model_list_default_marker.py
+++ b/tests/cli/test_model_list_default_marker.py
@@ -1,0 +1,50 @@
+"""``hal0 model list`` marks the default model in its Rich table (#1796).
+
+Before this fix, promoting a model with ``hal0 model default <id>`` was
+only visible via ``model show``/the API — the list table had no column at
+all reflecting which model was default.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import model_commands
+
+runner = CliRunner()
+
+
+def _stub_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(model_commands, "_api_unreachable", lambda _url: False)
+
+
+def test_default_model_marked_in_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "models": [
+            {"id": "qwen3-4b", "name": "Qwen3 4B", "default": True},
+            {"id": "llama-8b", "name": "Llama 8B", "default": False},
+        ]
+    }
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(model_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(model_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    default_line = next(line for line in lines if "qwen3-4b" in line)
+    other_line = next(line for line in lines if "llama-8b" in line)
+    assert "*" in default_line
+    assert "*" not in other_line
+
+
+def test_no_default_model_marks_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload: dict[str, Any] = {"models": [{"id": "qwen3-4b", "name": "Qwen3 4B"}]}
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(model_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(model_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "*" not in result.output

--- a/tests/cli/test_profile_commands.py
+++ b/tests/cli/test_profile_commands.py
@@ -1,0 +1,104 @@
+"""``hal0 profile`` — thin CLI over /api/profiles (#1796).
+
+There was no CLI surface for profiles at all before this file; ``list`` /
+``show`` cover the read half of ``/api/profiles`` every slot TOML
+references.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import profile_commands
+
+runner = CliRunner()
+
+
+def _stub_reachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(profile_commands, "_api_unreachable", lambda _url: False)
+
+
+def test_list_json_emits_raw_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [{"name": "rocm", "device_class": "gpu", "backend": "rocm"}]
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(profile_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(profile_commands.app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == payload
+
+
+def test_list_renders_table_with_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = [
+        {
+            "name": "rocm",
+            "device_class": "gpu",
+            "backend": "rocm",
+            "mtp": False,
+            "intent": "MoE agents",
+            "tps": 52.8,
+            "used_by": ["primary"],
+        },
+        {
+            "name": "cpu",
+            "device_class": "cpu",
+            "backend": None,
+            "mtp": False,
+            "intent": None,
+            "tps": None,
+            "used_by": [],
+        },
+    ]
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(profile_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(profile_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "rocm" in result.output
+    assert "cpu" in result.output
+    assert "primary" in result.output
+
+
+def test_list_empty_shows_dim_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(profile_commands, "api_get", lambda _p, **_k: [])
+
+    result = runner.invoke(profile_commands.app, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "No profiles available" in result.output
+
+
+def test_show_json_emits_raw_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {"name": "rocm", "device_class": "gpu", "used_by": ["primary"]}
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(profile_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(profile_commands.app, ["show", "rocm", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == payload
+
+
+def test_show_renders_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "name": "rocm",
+        "device_class": "gpu",
+        "backend": "rocm",
+        "mtp": False,
+        "intent": "MoE agents",
+        "quant": "FP4",
+        "tps": 52.8,
+        "rtf": None,
+        "used_by": ["primary"],
+        "resolved_flags": "-fa on",
+    }
+    _stub_reachable(monkeypatch)
+    monkeypatch.setattr(profile_commands, "api_get", lambda _p, **_k: payload)
+
+    result = runner.invoke(profile_commands.app, ["show", "rocm"])
+    assert result.exit_code == 0, result.output
+    assert "rocm" in result.output
+    assert "primary" in result.output
+    assert "-fa on" in result.output

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -552,3 +552,42 @@ def test_poll_job_gives_up_once_the_unreachable_budget_is_spent(
     with pytest.raises(SystemExit) as excinfo:
         uc._poll_job("c1", terminal=("applied", "failed"))
     assert excinfo.value.code == 1
+
+
+# ── _print_check placeholder-manifest rendering (#1796) ──────────────────────
+
+
+def test_print_check_placeholder_manifest_says_no_release(capsys: pytest.CaptureFixture) -> None:
+    """A channel with nothing published serves version '0.0.0' + an
+    all-zero digest — rendering that as a real "-> 0.0.0 up to date" target
+    misleads the operator into thinking there IS a release on this channel."""
+    uc._print_check(
+        {
+            "current": "1.0.0rc4",
+            "latest": "0.0.0",
+            "channel": "stable",
+            "update_available": False,
+            "manifest": {
+                "digest_sha256": "0" * 64,
+                "released_at": "2026-05-15",
+            },
+        }
+    )
+    out = capsys.readouterr().out
+    assert "no release published on this channel" in out
+    assert "up to date" not in out
+
+
+def test_print_check_real_manifest_renders_normally(capsys: pytest.CaptureFixture) -> None:
+    uc._print_check(
+        {
+            "current": "1.0.0rc4",
+            "latest": "1.0.0",
+            "channel": "stable",
+            "update_available": True,
+            "manifest": {"digest_sha256": "a" * 64, "released_at": "2026-08-01"},
+        }
+    )
+    out = capsys.readouterr().out
+    assert "no release published" not in out
+    assert "1.0.0" in out

--- a/tests/golden_paths/test_gp10_slot_delete.py
+++ b/tests/golden_paths/test_gp10_slot_delete.py
@@ -24,6 +24,8 @@ half is covered by the halo143 acceptance runbook (slot-teardown step).
 
 from __future__ import annotations
 
+from hal0.config import paths
+
 from .conftest import FakeContainerProvider, make_create_body
 
 
@@ -66,6 +68,11 @@ def test_delete_cleans_up_unit_state_and_port(
         assert client.get("/api/slots/gp10/config").status_code == 404
         # And the stable-id lookup no longer resolves the deleted identity.
         assert client.get(f"/api/slots/by-id/{slot_id}").status_code == 404
+
+        # #1796: the now-empty per-slot working directory
+        # (/var/lib/hal0/slots/gp10/) must not survive the delete either —
+        # only state.json lived there, and that was already unlinked above.
+        assert not paths.slot_data_dir("gp10").exists()
 
 
 def test_delete_is_idempotent(

--- a/tests/hardware/test_probe.py
+++ b/tests/hardware/test_probe.py
@@ -56,8 +56,14 @@ def test_parse_cpuinfo(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(probe_mod, "_read_text", fake_read_text)
     model, cores, threads = probe_mod._parse_cpuinfo()
     assert model.startswith("AMD Ryzen AI Max+")
-    assert cores == 16
+    # This sample is deliberately the impossible-topology shape from #1796:
+    # only 3 "processor" stanzas (a container's cgroup-limited view) paired
+    # with "cpu cores: 16" (the host-wide, non-namespaced hardware constant).
+    # Physical cores can never exceed logical threads, so the clamp in
+    # _parse_cpuinfo caps the reported cores at the trustworthy threads count
+    # instead of surfacing "16 cores / 3 threads".
     assert threads == 3
+    assert cores == 3
 
 
 _MEMINFO_SAMPLE = """\

--- a/tests/installer/test_preflight_all_summary.py
+++ b/tests/installer/test_preflight_all_summary.py
@@ -1,0 +1,88 @@
+"""``preflight_all``'s closing summary line must reflect warnings (#1796).
+
+Before this fix, ``hal0 doctor`` printed six ``!!`` warning lines and then
+an unconditional "OK all pre-flight checks passed" (exit 0) — the summary
+contradicted the body it was summarizing. ``preflight_all`` now sources the
+real ``UI_WARN_COUNT`` counter ui.sh's ``warn()`` bumps and folds it into
+the closing line; these tests exercise both real files together (subprocess,
+real bash — same technique as the other ``tests/installer/test_preflight_*``
+suites) rather than stubbing ui.sh away, since the counter IS the fix.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_UI = _REPO_ROOT / "installer" / "lib" / "ui.sh"
+_PREFLIGHT = _REPO_ROOT / "installer" / "lib" / "preflight.sh"
+
+#: Every sub-check preflight_all calls, stubbed to a controllable outcome.
+_ALL_CHECKS = (
+    "preflight_bootstrap_prereqs",
+    "preflight_arch",
+    "preflight_systemd",
+    "preflight_python",
+    "preflight_venv",
+    "preflight_hindsight_python",
+    "preflight_writable",
+    "preflight_network",
+    "preflight_container_runtime",
+    "preflight_git",
+    "preflight_podman_network_backend",
+    "preflight_podman_forward",
+    "preflight_gpu",
+    "preflight_node",
+    "preflight_disk",
+    "preflight_ports",
+)
+
+
+def _run(overrides: str) -> subprocess.CompletedProcess[str]:
+    """Source the real ui.sh + preflight.sh, stub every sub-check per
+    *overrides* (bash function bodies, redefined after sourcing — bash
+    allows this), then invoke preflight_all and capture its output."""
+    stub_all_clean = "\n".join(f"{name}() {{ return 0; }}" for name in _ALL_CHECKS)
+    script = (
+        "set -uo pipefail\n"
+        f"source {_UI!s}\n"
+        f"source {_PREFLIGHT!s}\n"
+        f"{stub_all_clean}\n"
+        f"{overrides}\n"
+        "preflight_all; rc=$?\n"
+        'echo "EXIT:${rc}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_all_clean_says_all_passed() -> None:
+    result = _run("")
+    combined = result.stdout + result.stderr
+    assert "all pre-flight checks passed" in combined
+    assert "warning" not in combined
+    assert "EXIT:0" in result.stdout
+
+
+def test_soft_warning_reflected_in_summary_not_hidden() -> None:
+    """A soft check (e.g. no GPU) warns without flipping rc — the summary
+    must say so instead of claiming an unconditional clean pass."""
+    result = _run(
+        'preflight_gpu() { warn "no GPU detected — CPU-only install"; return 0; }\n'
+        'preflight_git() { warn "git not found"; return 0; }\n'
+    )
+    combined = result.stdout + result.stderr
+    assert "EXIT:0" in result.stdout
+    assert "all pre-flight checks passed" not in combined
+    assert "passed with 2 warning(s)" in combined
+
+
+def test_hard_failure_still_reports_failed() -> None:
+    result = _run('preflight_python() { err "python too old"; return 1; }\n')
+    combined = result.stdout + result.stderr
+    assert "EXIT:1" in result.stdout
+    assert "one or more pre-flight checks failed" in combined

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1335,3 +1335,30 @@ async def test_rest_failure_with_unparseable_body_still_gets_a_code(
     assert result["http_status"] == 502
     assert isinstance(result["error"]["code"], str)
     assert "502 Bad Gateway" in str(result["error"])
+
+
+# ── #1796: tool-argument errors must surface as isError:true ────────────────
+#
+# ``dispatch()``'s ``{"status": "error", ...}`` return is a normal value, not
+# an exception — nothing told FastMCP the call failed, so every registered
+# tool answered isError:false even for a hard argument-validation failure.
+# ``model_show`` with no ``model_id`` hits ``_split_args``'s KeyError path
+# (``mcp.missing_arg``) deterministically, no REST mocking required.
+
+
+@pytest.mark.asyncio
+async def test_registered_tool_raises_toolerror_on_missing_arg(queue: ApprovalQueue) -> None:
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    with pytest.raises(ToolError):
+        await server.call_tool("model_show", {"args": {}})
+
+
+def test_server_stamps_hal0_version_not_sdk_version(queue: ApprovalQueue) -> None:
+    """serverInfo.version must be hal0's own version, not the ``mcp`` SDK
+    package version FastMCP falls back to when nothing sets it explicitly."""
+    import hal0
+
+    server = admin.build_server(approval_queue=queue, base_url="http://t")
+    assert server._mcp_server.version == hal0.__version__

--- a/tests/mcp/test_memory.py
+++ b/tests/mcp/test_memory.py
@@ -534,3 +534,37 @@ async def test_bulk_delete_gate_matches_admin_classification() -> None:
 
     assert is_gated("memory_delete", {"ids": ["a", "b"]}) is True
     assert is_gated("memory_delete", {"ids": ["a"]}) is False
+
+
+# ── #1796: tool-argument errors must surface as isError:true ────────────────
+#
+# make_dispatcher()'s error envelope (``{"status": "error", ...}``) is a
+# normal return value, not an exception — FastMCP has no way to know it
+# means "this call failed" unless something raises. Before this fix every
+# one of this mount's ~20 tools returned isError:false even on a hard
+# validation failure (a wrong field name, an unknown tool, ...).
+
+
+@pytest.mark.asyncio
+async def test_standalone_server_raises_toolerror_on_dispatcher_failure(
+    wrapper: _FakeWrapper,
+) -> None:
+    """Calling ``memory_add`` with no ``text`` — a dispatcher-level
+    validation failure — must raise, not just return an error dict, so the
+    FastMCP lowlevel handler flips isError to true instead of embedding the
+    error envelope as if it were a successful payload."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    server = memory.build_server(wrapper=wrapper)
+    with pytest.raises(ToolError):
+        await server.call_tool("memory_add", {"args": {}})
+
+
+def test_server_stamps_hal0_version_not_sdk_version() -> None:
+    """serverInfo.version must be hal0's own version, not the ``mcp`` SDK
+    package version FastMCP falls back to when nothing sets it explicitly
+    (FastMCP's constructor has no ``version`` kwarg)."""
+    import hal0
+
+    server = memory.build_server(wrapper=_FakeWrapper())
+    assert server._mcp_server.version == hal0.__version__

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -65,6 +65,34 @@ class TestGgufEmbed:
         assert r.confidence == "high"
 
 
+class TestGgufRerank:
+    """#1796: a reranker gguf must classify as rerank, not chat/embed —
+    the bug that let a reranker register with ``capabilities: chat``."""
+
+    def test_pooling_type_rank_means_rerank(self, tmp_path: Path) -> None:
+        # llama.cpp pooling_type=4 (RANK) is the cross-encoder rerank signal.
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+            ("bert.context_length", _GGUF_TYPE_UINT32, struct.pack("<I", 512)),
+            ("bert.pooling_type", _GGUF_TYPE_UINT32, struct.pack("<I", 4)),
+        ]
+        p = _write_fixture(tmp_path, "jina-bert-implementation.gguf", _build_gguf(3, kvs))
+        r = detect(p)
+        assert r.suggested_capabilities == ["rerank"]
+        assert r.confidence == "high"
+
+    def test_filename_fallback_for_rerank_without_pooling(self, tmp_path: Path) -> None:
+        # No pooling_type in the header at all — the exact live repro: the
+        # header only carries the arch name, so the old code fell all the
+        # way through to the "chat" default. The filename token must win.
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+        ]
+        p = _write_fixture(tmp_path, "jina-reranker-v2-base.gguf", _build_gguf(3, kvs))
+        r = detect(p)
+        assert r.suggested_capabilities == ["rerank"]
+
+
 class TestGgufUnreadable:
     def test_bad_gguf_degrades_to_filename_heuristic(self, tmp_path: Path) -> None:
         p = tmp_path / "qwen3-4b.gguf"

--- a/tests/slots/test_container_cgroup_mem.py
+++ b/tests/slots/test_container_cgroup_mem.py
@@ -304,6 +304,41 @@ class TestBuildPerSlotContainerPath:
         assert result["npu-chat"]["mem_mb"] == round(4.5 * 1024, 1)
 
     @pytest.mark.asyncio
+    async def test_cpu_backend_books_under_ram_not_vram(self):
+        """#1796: a GPU-less (backend='cpu') slot has no discrete VRAM pool —
+        its resident footprint belongs under ram_mb, not vram_mb (which used
+        to book CPU-resident model memory as phantom GPU usage)."""
+        slot = self._make_slot("cpu-primary", backend="cpu")
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=4 * 1024 * 1024 * 1024,  # 4 GiB
+        ):
+            result = await build_per_slot([slot])
+
+        row = result["cpu-primary"]
+        assert row["vram_mb"] == 0.0
+        assert row["ram_mb"] == row["mem_mb"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_gpu_backend_still_books_under_vram(self):
+        """Sibling check: a real GPU backend keeps the pre-#1796 vram_mb
+        attribution — only 'cpu' moves to ram_mb."""
+        slot = self._make_slot("gpu-primary", backend="vulkan")
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=4 * 1024 * 1024 * 1024,
+        ):
+            result = await build_per_slot([slot])
+
+        row = result["gpu-primary"]
+        assert row["ram_mb"] == 0.0
+        assert row["vram_mb"] == row["mem_mb"] > 0.0
+
+    @pytest.mark.asyncio
     async def test_offline_slot_omitted(self):
         """Slots in non-resident states produce no row."""
         slot = self._make_slot("primary", state="offline")


### PR DESCRIPTION
## Summary

Fixes the 14-item CLI/API polish rollup from rc.4 fresh-install validation (issue #1796). Organized as five commits by concern:

1. **CLI output polish** — doctor summary reflects warnings, system-info impossible cores/threads + leaked debug line, model scan `[] skipped`, slot metrics raw float Mem MB, bench results silent-when-empty, slot delete leftover dir, slot capacity VRAM/RAM misattribution on GPU-less boxes, model list default marker, update --check placeholder-manifest rendering.
2. **Registry** — `hal0 model add` id-from-filename (not GGUF arch header) + reranker capability autodetect fix (RANK pooling_type + full filename token table, matching the auto-scan path).
3. **API error semantics** — `/api/memory/add` validation errors are 400 not 500/system.internal; `/api/memory/banks/{id}/stats` 404s for an unknown bank instead of a zeroed 200; SPA catch-all 307-redirects bare `/health`, `/openapi.json`, `/docs`, `/redoc` to their `/api/...` equivalents.
4. **MCP** — `connect_url` carries the real `/mcp` transport suffix, `serverInfo.version` reports hal0's own version (not the `mcp` SDK's), tool-argument errors surface as `isError:true`.
5. **`hal0 profile` CLI** — new `list`/`show` read surface over `/api/profiles` (was previously CLI-absent entirely).

### Disposition per issue item

| # | Item | Disposition |
|---|------|-------------|
| 1 | `update --check` placeholder manifest | Fixed |
| 2 | system-info impossible cores/threads + debug leak | Fixed (both halves) |
| 3 | doctor summary contradicts warnings | Fixed |
| 4 | model scan `[] skipped` | Fixed |
| 5 | slot metrics raw float Mem MB / tok/s `—` | Mem MB formatting fixed; tok/s `—` traced to the metrics sampler not populating `tokens_per_sec` yet — noted, not fixed (out of scope for a formatting pass) |
| 6 | bench results silent when empty | Fixed |
| 7 | slot delete leaves empty dir | Fixed |
| 8 | slot capacity books CPU memory under VRAM | Fixed |
| 9 | model list default-marker | Fixed |
| 10 | model add id-from-header + rerank misclassify | Fixed (both halves) |
| 11 | MCP connect_url missing `/mcp` suffix | Fixed |
| 12 | `hal0 profile` CLI | Fixed (list/show; write ops stay API/dashboard-only) |
| 13 | bank stats 404 / memory-add validation code | Fixed (both halves) |
| 14 | SPA catch-all / MCP serverInfo.version / isError | Fixed (all three) |

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q <targeted suites per commit>` — all green (see commits for exact scope: hardware/probe, registry/detect, cli/update_commands, cli/model_list_default_marker, bench/cli_results, golden_paths/gp10_slot_delete, slots/container_cgroup_mem, installer/preflight_all_summary, api/models_add_from_path, api/memory_rest_routes, api/memory_admin_routes, api/spa_catch_all_redirects, api/mcp_routes, mcp/test_admin, mcp/test_memory, cli/profile_commands)
- [x] `make lint` — clean
- [x] `uv run ruff format --check src tests` — clean
- [ ] Full `tests/` suite — not run to completion (box was under load from a concurrent full-suite run in a sibling worktree; timed out at ~22% after 10 min). Targeted suites across every touched module are green.

Closes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)