### PR TITLE
fix(slots): launch unstamped models with their slot profile's flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,25 +37,6 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
-- Embedding and rerank slots launch with their profile's flags again, so
-  `/v1/embeddings` and `/v1/rerank` stop returning 501 on a fresh install
-  (#1787). The v1.0 flags-ownership redesign made a model's materialized
-  `defaults` the whole launch tune and a profile a copy-on-stamp template read
-  only in the drawer — but nothing on the fresh-install path stamps: `hal0
-  model scan`, `hal0 model pull` and the capability apply all register models
-  with `defaults = null`. Such a model contributed no tune, and the #1636
-  divergence overlay (gated on a *stamped* `defaults.profile`) stayed silent
-  too, so the `embed`/`rerank` slots launched llama-server without
-  `--embedding` / `--reranking` and served 501s while reporting `ready`. The
-  launch argv now carries a new `slot_profile_template` segment for exactly
-  that case — the slot profile's flags as the tune template, layered *below*
-  the model's own `extra_args`, screened against the §21.7 managed-arg denylist
-  and the slot hardware-flag partition like every other free-form source, and
-  gated on the same profile-fit predicate as the divergence overlay. A model
-  that carries tune text (stamped or hand-authored) is untouched: no live
-  profile read, and a stamped divergent tune still wins over the slot profile.
-  Preview (`GET /api/slots/.../resolved`) and launch share the segment builder,
-  so the previewed command still matches what launches.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,25 @@ applying. Add those subsections to a version's section to surface them; see
   their timeout on a doomed request — install-time smoke runs before any
   model has ever been loaded, so those two probes were guaranteed to "fail"
   for a reason that was never a real regression. (#1793)
+- Embedding and rerank slots launch with their profile's flags again, so
+  `/v1/embeddings` and `/v1/rerank` stop returning 501 on a fresh install
+  (#1787). The v1.0 flags-ownership redesign made a model's materialized
+  `defaults` the whole launch tune and a profile a copy-on-stamp template read
+  only in the drawer — but nothing on the fresh-install path stamps: `hal0
+  model scan`, `hal0 model pull` and the capability apply all register models
+  with `defaults = null`. Such a model contributed no tune, and the #1636
+  divergence overlay (gated on a *stamped* `defaults.profile`) stayed silent
+  too, so the `embed`/`rerank` slots launched llama-server without
+  `--embedding` / `--reranking` and served 501s while reporting `ready`. The
+  launch argv now carries a new `slot_profile_template` segment for exactly
+  that case — the slot profile's flags as the tune template, layered *below*
+  the model's own `extra_args`, screened against the §21.7 managed-arg denylist
+  and the slot hardware-flag partition like every other free-form source, and
+  gated on the same profile-fit predicate as the divergence overlay. A model
+  that carries tune text (stamped or hand-authored) is untouched: no live
+  profile read, and a stamped divergent tune still wins over the slot profile.
+  Preview (`GET /api/slots/.../resolved`) and launch share the segment builder,
+  so the previewed command still matches what launches.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1502,6 +1502,20 @@ def _resolve_llama_scalars(
     #     were inert before this overlay existed.
     # No MTP expansion here (``resolve_profile_flags`` with no override): the
     # ``--spec-draft-*`` bundle stays model-driven (see _effective_mtp).
+    def _profile_flags_text(prof: Any) -> str:
+        """``resolve_profile_flags`` for a profile that may be a plain Mapping.
+
+        ``_resolve_profile_or_base`` normally hands back a validated
+        ``ProfileConfig``, but the seam also accepts a raw profile Mapping (a
+        registry row read straight off disk, and the shape callers construct in
+        tests). ``resolve_profile_flags`` reaches for ``profile.flags`` and would
+        ``AttributeError`` on the Mapping — mirroring the ``getattr(profile,
+        "name", None)`` tolerance already used for the resolved-name check.
+        """
+        if isinstance(prof, Mapping):
+            return str(prof.get("flags") or "").strip()
+        return str(resolve_profile_flags(prof) or "").strip()
+
     slot_profile_flags = ""
     _cfg_profile = str(slot_cfg.get("profile") or "")
     _mi_defaults = model_info.get("defaults")
@@ -1517,7 +1531,7 @@ def _resolve_llama_scalars(
         from hal0.slots.profile_adopt import profile_fits_slot
 
         if profile_fits_slot(_cfg_profile, slot_cfg):
-            slot_profile_flags = str(resolve_profile_flags(profile) or "").strip()
+            slot_profile_flags = _profile_flags_text(profile)
         if slot_profile_flags and for_launch:
             log.info(
                 "slot.profile_divergence_applied",
@@ -1562,7 +1576,7 @@ def _resolve_llama_scalars(
         from hal0.slots.profile_adopt import profile_fits_slot
 
         if profile_fits_slot(_cfg_profile, slot_cfg):
-            slot_profile_template_flags = str(resolve_profile_flags(profile) or "").strip()
+            slot_profile_template_flags = _profile_flags_text(profile)
         if slot_profile_template_flags and for_launch:
             log.info(
                 "slot.profile_template_applied",

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -820,6 +820,37 @@ def _render_quadlet_from_plan(
     return "\n".join(lines)
 
 
+def _profile_flag_tokens(flags: str) -> list[str]:
+    """Tokenize a slot profile's flag text for the argv chain (shared screen).
+
+    Used by BOTH profile-sourced segments — the divergence overlay
+    (``slot_profile``, #1636) and the unstamped-model template
+    (``slot_profile_template``, #1787) — so they can never drift on quoting or
+    on the jinja rule.
+
+    ``--jinja`` is dropped: jinja is a runner+model CAPABILITY resolved once as
+    ``effective_jinja`` and injected/suppressed through
+    ``model_defaults.extra_args``. llama-server has no ``--no-jinja`` negation,
+    so a legacy or hand-authored profile's own ``--jinja`` token would otherwise
+    permanently defeat an explicit ``defaults.jinja=false``.
+    """
+    if not flags or not flags.strip():
+        return []
+    try:
+        tokens = shlex.split(flags)
+    except ValueError as exc:
+        # A profile's flags string is free text (operator-editable on disk) and
+        # the create/edit path has no quoting validator — unmatched quotes only
+        # surface here, where an unhandled ValueError would otherwise 500 the
+        # launch/preview. Fail with a controlled config error instead.
+        raise UnprocessableEntity(
+            f"slot profile flags are not valid shell text: {exc}",
+            code="slot.profile_flags_malformed",
+            details={"flags": flags},
+        ) from exc
+    return [t for t in tokens if t != "--jinja"]
+
+
 def _llama_argv_segments(
     *,
     port: int,
@@ -835,6 +866,7 @@ def _llama_argv_segments(
     slot_parallel: int | None = None,
     extra_args: str | None = None,
     slot_profile_flags: str = "",
+    slot_profile_template_flags: str = "",
 ) -> list[tuple[str, list[str]]]:
     """Build the ordered, labelled llama-server argv segments (SINGLE SOURCE).
 
@@ -860,13 +892,28 @@ def _llama_argv_segments(
     over the model tune — the per-slot flag-divergence path that replaced the
     retired duplicate-for-device model flow (PR #1635). The caller
     (:func:`_resolve_llama_scalars`) computes it divergence-gated; aligned and
-    provenance-less slots pass ``""`` and launch byte-identical to the stamped
+    already-stamped slots pass ``""`` and launch byte-identical to the stamped
     tune.
+
+    Unstamped-model template (#1787): copy-on-stamp only works once something
+    stamps. Auto-scan / pull / capability-apply register models with NO
+    ``defaults`` at all, so on a fresh box the model carries neither a
+    provenance nor a materialized tune, and BOTH the retired ``profile``
+    segment and the divergence overlay stay silent — an ``embedding``/``rerank``
+    slot then launches without ``--embedding`` / ``--reranking`` and serves 501s
+    for its only purpose. ``slot_profile_template_flags`` carries the slot
+    profile's flags for exactly that case: the model has no tune of its own, so
+    the profile template IS the tune until a stamp materializes it. It rides its
+    own UNTRUSTED ``slot_profile_template`` segment BELOW ``model_extra_args``
+    (a template is a floor, never an override) and the caller emits it only when
+    the model's ``defaults`` carry no ``extra_args`` — a hand-authored tune keeps
+    launching with no live profile read (golden #5).
 
     Precedence (lowest → highest; ``resolve_argv``/``normalize_argv`` keeps the
     LAST occurrence of each canonical flag)::
 
-        base < model_extra_args < slot_profile < slot_hardware < chat_template < mmproj
+        base < slot_profile_template < model_extra_args < slot_profile
+              < slot_hardware < chat_template < mmproj
 
     The slot hardware segment sits AFTER ``model_extra_args`` and
     ``slot_profile`` so the slot's typed ``-ngl``/``--threads`` win over any
@@ -930,35 +977,16 @@ def _llama_argv_segments(
     # (typed slot fields stay authoritative). The segment appears ONLY when a
     # divergence produced flags — the aligned case keeps the exact golden #5
     # segment shape (tests/golden_paths/test_gp05_stamped_launch_layering.py).
-    segments: list[tuple[str, list[str]]] = [
-        ("base", base),
-        ("model_extra_args", md_extra_tokens),
-    ]
-    if slot_profile_flags.strip():
-        try:
-            _profile_tokens = shlex.split(slot_profile_flags)
-        except ValueError as exc:
-            # A profile's flags string is free text (operator-editable on
-            # disk) and the create/edit path has no quoting validator —
-            # unmatched quotes only surface here, where an unhandled
-            # ValueError would otherwise 500 the launch/preview. Fail with a
-            # controlled config error instead.
-            raise UnprocessableEntity(
-                f"divergent slot profile flags are not valid shell text: {exc}",
-                code="slot.profile_flags_malformed",
-                details={"flags": slot_profile_flags},
-            ) from exc
-        # jinja is a runner+model CAPABILITY, resolved once as
-        # ``effective_jinja`` and injected/suppressed through
-        # ``model_defaults.extra_args`` above — never through a raw profile
-        # flag. llama-server has no ``--no-jinja`` negation, so a legacy or
-        # hand-authored profile's own ``--jinja`` token would otherwise
-        # permanently defeat an explicit ``defaults.jinja=false`` once it
-        # rides the (higher-precedence) slot_profile segment. Strip it so
-        # the overlay can never outrank the already-computed capability.
-        _profile_tokens = [t for t in _profile_tokens if t != "--jinja"]
-        if _profile_tokens:
-            segments.append(("slot_profile", _profile_tokens))
+    segments: list[tuple[str, list[str]]] = [("base", base)]
+    # Unstamped-model profile template (#1787), BELOW the model tune: a template
+    # is the floor a model's own defaults refine, never an override.
+    _template_tokens = _profile_flag_tokens(slot_profile_template_flags)
+    if _template_tokens:
+        segments.append(("slot_profile_template", _template_tokens))
+    segments.append(("model_extra_args", md_extra_tokens))
+    _profile_tokens = _profile_flag_tokens(slot_profile_flags)
+    if _profile_tokens:
+        segments.append(("slot_profile", _profile_tokens))
     segments += [
         ("slot_hardware", slot_hw_tokens),
         ("chat_template", chat_tokens),
@@ -986,6 +1014,7 @@ def _llama_launch_plan(
     slot_parallel: int | None = None,
     env: dict[str, str] | None = None,
     slot_profile_flags: str = "",
+    slot_profile_template_flags: str = "",
 ) -> RuntimeLaunchPlan:
     """Build the GPU/llama-server :class:`RuntimeLaunchPlan`.
 
@@ -1011,6 +1040,7 @@ def _llama_launch_plan(
         slot_parallel=slot_parallel,
         extra_args=extra_args,
         slot_profile_flags=slot_profile_flags,
+        slot_profile_template_flags=slot_profile_template_flags,
     )
     # resolve_argv over the labelled segments is argv-equivalent to
     # normalize_argv over the flat concatenation (pinned by tests/slots/
@@ -1498,6 +1528,55 @@ def _resolve_llama_scalars(
                 },
             )
 
+    # Unstamped-model profile template (#1787). Copy-on-stamp presumes SOMETHING
+    # stamped: the model's materialized ``defaults`` is the whole tune, and the
+    # profile is only read in the drawer. But auto-scan, pull and
+    # capability-apply all register models with no ``defaults`` at all, so on a
+    # fresh box neither the (retired) profile segment nor the divergence overlay
+    # above contributes anything — an ``embedding``/``rerank`` slot launches
+    # without ``--embedding``/``--reranking`` and every /v1/embeddings and
+    # /v1/rerank call 501s while the slot reports ready.
+    #
+    # For exactly that case the slot's profile supplies the tune as a template
+    # (``slot_profile_template``, layered BELOW the model tune). Gated so a
+    # stamped or hand-tuned model is untouched:
+    #   * the model records NO tune text (``defaults.extra_args`` empty/absent)
+    #     — a hand-authored tune is the operator's word and still launches with
+    #     no live profile read (golden #5 §8);
+    #   * the model records NO profile provenance — a stamped model is already
+    #     materialized, and its divergence case is the overlay above;
+    #   * the slot NAMES a profile and it is the one that resolved — a
+    #     missing-profile fallback to the backend base must not inject flags the
+    #     operator never picked (same rule as the overlay);
+    #   * the profile FITS the slot (``profile_fits_slot``) — a wrong-type
+    #     profile must not inject mode-changing flags.
+    slot_profile_template_flags = ""
+    _md_extra = _mi_defaults.get("extra_args") if isinstance(_mi_defaults, Mapping) else None
+    _has_model_tune = bool(_md_extra and str(_md_extra).strip())
+    if (
+        _cfg_profile
+        and not _has_model_tune
+        and not (isinstance(_provenance, str) and _provenance)
+        and (_resolved_name is None or _resolved_name == _cfg_profile)
+    ):
+        from hal0.slots.profile_adopt import profile_fits_slot
+
+        if profile_fits_slot(_cfg_profile, slot_cfg):
+            slot_profile_template_flags = str(resolve_profile_flags(profile) or "").strip()
+        if slot_profile_template_flags and for_launch:
+            log.info(
+                "slot.profile_template_applied",
+                extra={
+                    "slot": str(slot_cfg.get("name") or ""),
+                    "profile": _cfg_profile,
+                    "model": str(model_info.get("_model_key") or ""),
+                    "hint": (
+                        "model carries no stamped tune; launching with the slot "
+                        "profile's flags as the template (#1787)"
+                    ),
+                },
+            )
+
     if for_launch:
         workers = slot_cfg.get("workers")
         if workers is not None and int(workers or 1) != 1:
@@ -1642,6 +1721,7 @@ def _resolve_llama_scalars(
         "image": str(image),
         "flags_str": str(flags_str),
         "slot_profile_flags": str(slot_profile_flags),
+        "slot_profile_template_flags": str(slot_profile_template_flags),
         "context_size": context_size,
         "extra_args": extra_args,
         "server_env": server_env,
@@ -1791,6 +1871,7 @@ class ContainerProvider(Provider):
             slot_parallel=scalars["slot_parallel"],
             env=merged_env or None,
             slot_profile_flags=scalars["slot_profile_flags"],
+            slot_profile_template_flags=scalars["slot_profile_template_flags"],
         )
 
     # ── ContainerProvider-specific control plane ──────────────────────────────
@@ -2426,6 +2507,7 @@ def _resolve_slot_argv(
         slot_parallel=scalars["slot_parallel"],
         extra_args=scalars["extra_args"],
         slot_profile_flags=scalars["slot_profile_flags"],
+        slot_profile_template_flags=scalars["slot_profile_template_flags"],
     )
     return str(scalars["image"]), resolve_argv(segments)
 

--- a/src/hal0/slots/argv.py
+++ b/src/hal0/slots/argv.py
@@ -135,11 +135,23 @@ SLOT_HARDWARE_FLAGS: frozenset[str] = frozenset(
 #     provenance (``defaults.profile``). Profile saves already screen these
 #     flags, but the profile file is operator-editable on disk, so the launch
 #     merge re-screens them like any other free-form source.
+#   * ``slot_profile_template`` — the slot profile's flag text used as the tune
+#     TEMPLATE for a model that carries no stamped tune at all (#1787: auto-scan
+#     / pull / capability-apply never stamp ``defaults``). Same free-form source
+#     as ``slot_profile``, one tier LOWER (below ``model_extra_args``), so it
+#     rides the same managed-arg screen and the same hardware-flag strip.
 # A future request-level ``llamacpp_args`` segment (§7.1a 5-tier precedence
 # rewrite) adds its own label here so it rides the same guard.
 UNTRUSTED_SEGMENT_LABELS: frozenset[str] = frozenset(
-    {"extra_args", "model_extra_args", "slot_profile"}
+    {"extra_args", "model_extra_args", "slot_profile", "slot_profile_template"}
 )
+
+# Profile-sourced segment labels: free-form flag text copied off a profile
+# (divergence overlay + unstamped-model template). On top of the managed-arg
+# screen every untrusted label gets, these additionally have their SLOT-owned
+# hardware flags silently STRIPPED rather than hard-rejected — see
+# :func:`resolve_argv`.
+PROFILE_SEGMENT_LABELS: frozenset[str] = frozenset({"slot_profile", "slot_profile_template"})
 
 
 @dataclass(frozen=True)
@@ -397,7 +409,8 @@ def resolve_argv(segments: list[tuple[str, list[str]]]) -> ResolvedArgv:
     Raises:
         hal0.errors.BadRequest: an untrusted segment sets a managed flag.
 
-    ``slot_profile`` (#1636) additionally gets its hardware flags
+    The profile-sourced segments (``slot_profile`` #1636, ``slot_profile_template``
+    #1787) first get their hardware flags
     (``SLOT_HARDWARE_FLAGS``) silently stripped rather than hard-rejected: the
     profile save path only started enforcing the §5 partition guard after
     grandfathered/hand-edited profiles could already carry ``-dev``/
@@ -412,10 +425,14 @@ def resolve_argv(segments: list[tuple[str, list[str]]]) -> ResolvedArgv:
     tokens: list[str] = []
     sources: list[str] = []
     for label, seg in segments:
+        # Strip BEFORE the deny: ``-ngl`` sits in both denylists, and for a
+        # profile-sourced segment the partition rule is "silently ignored",
+        # not "fail the launch". Denying first would hard-reject every
+        # grandfathered profile that still carries ``-ngl 999``.
+        if label in PROFILE_SEGMENT_LABELS:
+            seg, _stripped = strip_managed_flags(seg, denylist=SLOT_HARDWARE_FLAGS)
         if label in UNTRUSTED_SEGMENT_LABELS:
             _deny_managed_flags(seg, segment=label)
-        if label == "slot_profile":
-            seg, _stripped = strip_managed_flags(seg, denylist=SLOT_HARDWARE_FLAGS)
         for tok in seg:
             tokens.append(tok)
             sources.append(label)
@@ -502,6 +519,7 @@ __all__ = [
     "APPEND_FLAGS",
     "FLAG_ALIASES",
     "MANAGED_ARGS_DENYLIST",
+    "PROFILE_SEGMENT_LABELS",
     "SLOT_HARDWARE_FLAGS",
     "UNTRUSTED_SEGMENT_LABELS",
     "FlagProvenance",

--- a/tests/api/test_slots_container_state.py
+++ b/tests/api/test_slots_container_state.py
@@ -279,13 +279,17 @@ def test_container_slot_has_runtime_profile_image_fields(
     )
 
 
-def test_container_slot_resolved_command_excludes_profile_flags(
+def test_container_slot_resolved_command_uses_profile_as_template_when_unstamped(
     client_with_container_slot: TestClient,
 ) -> None:
-    """FLAGS-own (spec-flags-ownership §2): a profile is a copy-on-stamp template
-    read only in the drawer — its flags NEVER reach the launch/preview command.
-    resolved_command reflects the model's materialized tune + structural base
-    flags, so the profile's --flash-attn/-ngl must NOT appear."""
+    """FLAGS-own (spec-flags-ownership §2) makes a profile a copy-on-stamp
+    template — but ``llama-3b`` here is UNSTAMPED (no registry row, so no
+    materialized ``defaults`` tune at all). #1787: for that case the slot
+    profile supplies the tune as the ``slot_profile_template`` segment, so its
+    ``--flash-attn`` DOES reach the preview — otherwise an embedding/rerank slot
+    launches without ``--embedding``/``--reranking``. The slot-owned hardware
+    flags stay partitioned off: the profile's ``-ngl 999`` is still stripped.
+    """
     from hal0.config.schema import ProfileConfig
 
     fake_profile = ProfileConfig(
@@ -320,9 +324,10 @@ def test_container_slot_resolved_command_excludes_profile_flags(
     joined = " ".join(rc)
     # Structural base flags are always present (resolved, not profile-sourced).
     assert "--model" in joined and "--port" in joined
-    # Profile flags are inert at launch/preview — the model owns the tune now.
-    assert "--flash-attn" not in joined, "profile flags must NOT reach resolved_command"
-    assert "-ngl" not in joined, "profile flags must NOT reach resolved_command"
+    # #1787: the unstamped model takes the profile's tune as its template.
+    assert "--flash-attn" in joined, "an unstamped model must take the profile template"
+    # ...but the slot owns the hardware grid — the profile's -ngl never rides along.
+    assert "-ngl" not in joined, "profile hardware flags must NOT reach resolved_command"
 
 
 def test_profileless_slot_has_null_image_and_command(

--- a/tests/providers/test_unstamped_profile_template.py
+++ b/tests/providers/test_unstamped_profile_template.py
@@ -1,0 +1,249 @@
+"""Unstamped-model profile template (#1787) — the copy-on-stamp floor.
+
+FLAGS-own made the model's materialized ``defaults`` the whole launch tune and
+a profile a copy-on-stamp template read only in the drawer. But nothing on the
+fresh-install path stamps: ``hal0 model scan``, pull and capability-apply all
+register models with ``defaults = null``. Such a model therefore contributed no
+tune at all, and the #1636 divergence overlay (gated on stamped provenance)
+stayed silent too — so an ``embedding``/``rerank`` slot launched without
+``--embedding``/``--reranking`` and served 501s while reporting ready.
+
+The template segment closes that hole for exactly the unstamped case::
+
+    base < slot_profile_template < model_extra_args < slot_profile
+         < slot_hardware < chat_template < mmproj
+
+A model that carries its own tune text (stamped OR hand-authored) is untouched:
+no live profile read, golden #5 shape preserved.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.config.schema import ProfileConfig
+from hal0.errors import BadRequest
+from hal0.providers.container import _llama_argv_segments, _resolve_llama_scalars
+from hal0.slots.argv import resolve_argv
+
+
+class _NamedProfile(ProfileConfig):
+    """ProfileConfig plus the ``name`` a ResolvedProfile carries."""
+
+    name: str = ""
+
+
+def _profile(name: str, flags: str) -> _NamedProfile:
+    return _NamedProfile(name=name, flags=flags, mtp=False)
+
+
+def _slot(profile: str, **kw) -> dict:
+    return {"name": "embed", "profile": profile, "port": 8083, **kw}
+
+
+def _model(defaults: dict | None) -> dict:
+    return {
+        "_model_key": "qwen3-embedding-0-6b-q8-0",
+        "path": "/m/qwen3-embedding.gguf",
+        "tags": ["embedding"],
+        "defaults": defaults,
+    }
+
+
+EMBED_FLAGS = "--embedding -fa on -b 8192 -ub 8192"
+
+
+# ── the GA blocker: auto-scanned model, embedding slot ───────────────────────
+
+
+def test_unstamped_model_takes_the_slot_profile_as_its_template():
+    """#1787 repro: ``defaults = null`` (auto-scan/pull) + ``profile=embedding``."""
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"), _model(None), _profile("embedding", EMBED_FLAGS)
+    )
+    assert scalars["slot_profile_template_flags"] == EMBED_FLAGS
+    assert scalars["slot_profile_flags"] == ""  # no provenance → no divergence
+
+
+def test_embedding_flag_reaches_the_launched_argv():
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"), _model(None), _profile("embedding", EMBED_FLAGS)
+    )
+    resolved = resolve_argv(
+        _llama_argv_segments(
+            port=8083,
+            model_path="/m/qwen3-embedding.gguf",
+            model_defaults=scalars["model_defaults"],
+            slot_profile_flags=scalars["slot_profile_flags"],
+            slot_profile_template_flags=scalars["slot_profile_template_flags"],
+        )
+    )
+    assert "--embedding" in resolved.argv
+    prov = {p.flag: p.source for p in resolved.provenance}
+    assert prov["--embedding"] == "slot_profile_template"
+
+
+def test_reranking_flag_reaches_the_launched_argv():
+    rerank_flags = "--reranking -fa on -b 8192 -ub 8192"
+    scalars = _resolve_llama_scalars(
+        _slot("reranking"), _model(None), _profile("reranking", rerank_flags)
+    )
+    resolved = resolve_argv(
+        _llama_argv_segments(
+            port=8086,
+            model_path="/m/qwen3-rerank.gguf",
+            model_defaults=scalars["model_defaults"],
+            slot_profile_template_flags=scalars["slot_profile_template_flags"],
+        )
+    )
+    assert "--reranking" in resolved.argv
+
+
+def test_empty_defaults_dict_is_also_unstamped():
+    """``defaults = {}`` (a registry row with an empty bundle) counts as unstamped."""
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"), _model({}), _profile("embedding", EMBED_FLAGS)
+    )
+    assert scalars["slot_profile_template_flags"] == EMBED_FLAGS
+
+
+def test_typed_only_defaults_are_still_unstamped():
+    """A row with typed knobs but no tune TEXT still needs the template."""
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"), _model({"n_gpu_layers": 99}), _profile("embedding", EMBED_FLAGS)
+    )
+    assert scalars["slot_profile_template_flags"] == EMBED_FLAGS
+
+
+# ── what the template must NOT touch ─────────────────────────────────────────
+
+
+def test_hand_authored_model_tune_suppresses_the_template():
+    """Golden #5 §8: a model that carries tune text launches with no profile read."""
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"), _model({"extra_args": "-b 2048"}), _profile("embedding", EMBED_FLAGS)
+    )
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+def test_stamped_model_suppresses_the_template():
+    scalars = _resolve_llama_scalars(
+        _slot("embedding"),
+        _model({"profile": "embedding", "extra_args": "-b 2048"}),
+        _profile("embedding", EMBED_FLAGS),
+    )
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+def test_stamped_divergent_model_keeps_the_1636_overlay():
+    """#1636 must not regress: stamped provenance still routes to ``slot_profile``."""
+    scalars = _resolve_llama_scalars(
+        _slot("coding", name="coder"),
+        {
+            "_model_key": "qwen3-4b",
+            "path": "/m/qwen3-4b.gguf",
+            "defaults": {"profile": "chat", "extra_args": "-b 2048"},
+        },
+        _profile("coding", "--temp 0.7"),
+    )
+    assert scalars["slot_profile_flags"] == "--temp 0.7"
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+def test_slot_with_no_profile_gets_no_template():
+    scalars = _resolve_llama_scalars(_slot(""), _model(None), _profile("", ""))
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+def test_base_fallback_profile_produces_no_template():
+    """The named profile no longer resolves; the backend base must not leak in."""
+    scalars = _resolve_llama_scalars(
+        _slot("retired-profile"), _model(None), _profile("rocm", "-fa on")
+    )
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+def test_wrong_type_profile_produces_no_template():
+    """An out-of-band TTS profile on an LLM slot must not inject its
+    mode-changing ``--model_path`` — same fit predicate the overlay uses."""
+    scalars = _resolve_llama_scalars(
+        _slot("kokoro", type="llm"), _model(None), _profile("kokoro", "--model_path /m/kokoro")
+    )
+    assert scalars["slot_profile_template_flags"] == ""
+
+
+# ── segment placement + screening ────────────────────────────────────────────
+
+
+def _segments(template: str = "", **kw):
+    return _llama_argv_segments(
+        port=8083,
+        model_path="/m/x.gguf",
+        model_defaults={"extra_args": "-b 2048"},
+        slot_profile_template_flags=template,
+        **kw,
+    )
+
+
+def test_template_segment_sits_below_the_model_tune():
+    labels = [label for label, _ in _segments("-b 8192", slot_n_gpu_layers=30)]
+    assert labels.index("slot_profile_template") < labels.index("model_extra_args")
+    assert labels.index("model_extra_args") < labels.index("slot_hardware")
+
+
+def test_no_segment_when_empty():
+    assert "slot_profile_template" not in {label for label, _ in _segments("")}
+
+
+def test_model_tune_wins_collisions_over_the_template():
+    resolved = resolve_argv(_segments("-b 8192 --embedding"))
+    prov = {p.flag: p.source for p in resolved.provenance}
+    assert resolved.argv[resolved.argv.index("-b") + 1] == "2048"
+    assert prov["-b"] == "model_extra_args"
+    # Template flags the model tune does not mention still reach the argv.
+    assert "--embedding" in resolved.argv
+
+
+def test_slot_hardware_still_wins_over_the_template():
+    resolved = resolve_argv(_segments("--threads 4", slot_threads=16))
+    assert resolved.argv[resolved.argv.index("--threads") + 1] == "16"
+
+
+def test_grandfathered_ngl_in_profile_is_stripped_not_rejected():
+    """``-ngl`` is on BOTH denylists; for a profile-sourced segment the §5
+    partition rule is "silently ignored", so a grandfathered ``-ngl 999``
+    profile must not hard-fail the launch (it used to be inert entirely)."""
+    resolved = resolve_argv(_segments("--flash-attn on -ngl 999", slot_n_gpu_layers=30))
+    assert "--flash-attn" in resolved.argv
+    assert resolved.argv[resolved.argv.index("-ngl") + 1] == "30"
+
+
+def test_grandfathered_ngl_in_divergent_profile_is_stripped_too():
+    """Same rule for the #1636 overlay segment — one code path, one behaviour."""
+    resolved = resolve_argv(
+        _llama_argv_segments(
+            port=8083,
+            model_path="/m/x.gguf",
+            model_defaults={"extra_args": "-b 2048"},
+            slot_profile_flags="--temp 0.7 -ngl 999",
+            slot_n_gpu_layers=30,
+        )
+    )
+    assert resolved.argv[resolved.argv.index("-ngl") + 1] == "30"
+
+
+def test_managed_flag_in_template_fails_loudly():
+    with pytest.raises(BadRequest):
+        resolve_argv(_segments("--port 9999"))
+
+
+def test_jinja_is_never_carried_by_the_template():
+    """jinja is a runner+model capability resolved as ``effective_jinja``."""
+    assert "--jinja" not in resolve_argv(_segments("--jinja -b 8192")).argv
+
+
+def test_malformed_template_flags_fail_controlled():
+    from hal0.errors import UnprocessableEntity
+
+    with pytest.raises(UnprocessableEntity):
+        _segments('--foo "unclosed')


### PR DESCRIPTION
## What

Adds a `slot_profile_template` segment to the llama-server argv chain: when a model carries **no tune of its own**, the slot's profile supplies the tune as a template. Fixes the v1.0 GA blocker where `/v1/embeddings` and `/v1/rerank` returned 501 on every backend while the capability slots reported `ready`.

## Why

The v1.0 flags-ownership redesign made a model's materialized `defaults` the whole launch tune, and a profile a *copy-on-stamp template* read only in the drawer. Copy-on-stamp presumes something stamps — nothing on the fresh-install path does. `hal0 model scan`, `hal0 model pull` and the capability apply all register models with `defaults = null` (verified live on the rc.4 box: the auto-scanned rerank model's registry row is `"defaults": null`).

So an unstamped model contributed no tune at all, and the #1636 divergence overlay — the only surviving profile-flag path — is gated on a **stamped** `defaults.profile`, so it stayed silent too. The `embed`/`rerank` slots launched without `--embedding` / `--reranking`:

```
--host 0.0.0.0 --port 8083 --model .../Qwen3-Embedding-0.6B-Q8_0.gguf \
  --alias qwen3-embedding-0-6b-q8-0 --ctx-size 4096 --jinja -ngl -1
```

### Design choice

The alternative was to make every model-binding flow (auto-scan, pull, capability-apply, slot edit) stamp `defaults` from the profile. That mutates shared registry state as a side effect of a slot action, needs a divergent-share policy for two slots sharing one model, and touches four flows plus a migration — a lot of blast radius for a GA blocker. This change instead fills the gap the stamp was supposed to fill, at the one place both launch and preview already agree on, and leaves the stamped world byte-identical. Making the binding flows stamp remains a coherent follow-up; it would simply make this segment stop firing.

New precedence:

```
base < slot_profile_template < model_extra_args < slot_profile < slot_hardware < chat_template < mmproj
```

The template sits **below** `model_extra_args` — a template is a floor, never an override — and is gated on:

* the model records no tune text (`defaults.extra_args` empty/absent) — a hand-authored tune still launches with **no live profile read** (golden #5 §8);
* the model records no profile provenance — a stamped model is already materialized, and its divergent case is the #1636 overlay, unchanged;
* the slot **names** a profile and it is the one that resolved — a missing-profile fallback to the backend base must not inject flags the operator never picked;
* `profile_fits_slot` — a wrong-type profile must not inject mode-changing flags.

It rides an UNTRUSTED label, so it goes through the same §21.7 managed-arg screen and the same slot hardware-flag partition as every other free-form source.

**Also fixed (latent):** profile-sourced segments now get their hardware flags stripped *before* the managed-arg deny. `-ngl` is in both lists, and the partition rule for a profile is "silently ignored", not "fail the launch" — denying first hard-rejected any grandfathered profile still carrying `-ngl 999`. The #1636 `slot_profile` overlay had the same landmine; both share one code path now.

## How verified

* New `tests/providers/test_unstamped_profile_template.py` — 20 tests: the #1787 repro (`defaults = null` + `profile = embedding` → `--embedding` in argv with `slot_profile_template` provenance), the rerank twin, empty/typed-only defaults, and the whole must-not-touch set (hand-authored tune, stamped tune, **stamped divergent tune still routes through #1636**, no-profile slot, base-fallback profile, wrong-type profile), plus segment placement, model-tune-wins-collisions, slot-hardware-wins, jinja stripping, managed-flag hard-fail, grandfathered `-ngl` stripped on both profile segments.
* `tests/api/test_slots_container_state.py::test_container_slot_resolved_command_excludes_profile_flags` renamed and inverted — its fixture model is unstamped, so the profile's `--flash-attn` now correctly reaches `resolved_command` while `-ngl` stays stripped. This is the one intentional behaviour-contract change.
* Golden path #5 (`tests/golden_paths/test_gp05_stamped_launch_layering.py`) and the #1636 divergence suite pass unchanged.
* Full suite: `HAL0_HOME=… uv run --extra dev pytest -q` → **9744 passed, 15 skipped, 1 xfailed**.
* `make lint` clean; `uv run ruff format --check src tests` clean.
* Grounded read-only against the live rc.4 repro box (CT151): replaying its exact `embed.toml` + registry row through the resolver reproduces the broken argv on `main` and yields `… --ctx-size 4096 --embedding -fa on -b 8192 -ub 8192 --jinja -ngl -1` with this change.

## Out of scope

* Stamping `defaults.profile` in the model-binding flows (the (a) option above) — a follow-up, not required for the fix.
* The drawer's provenance badge map (`ui/src/dash/slot-modals.jsx`) does not name `slot_profile` or `slot_profile_template`; both render through its generic fallback badge, so no UI change was needed.
* `/v1/embeddings` was not exercised end-to-end on hardware — CT151 was treated as read-only per the release-validation ground rules.

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)