### PR TITLE
docs: web presentation hooks for the hal0.dev docs landing and slots page

### DIFF
--- a/docs/concepts/slots.mdx
+++ b/docs/concepts/slots.mdx
@@ -3,6 +3,11 @@ title: Slots
 description: A slot is one model served by one podman container. Learn the lifecycle state machine, the write-boundary partition between slot and model, single-flight dispatch, and the GPU arbiter.
 sidebar:
   order: 20
+# Version stamp rendered by the website next to the page title
+# (hal0-web PageTitle override). Product metadata, so it belongs here
+# with the page it describes rather than web-side, where the mirror
+# would overwrite it.
+appliesTo: v1.0
 ---
 
 import { Aside, Card, CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';

--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -6,6 +6,14 @@ sidebar:
 ---
 
 import { Card, CardGrid, LinkCard, Aside } from '@astrojs/starlight/components';
+// Rendered by the website only: the "Sections" card grid on
+// hal0.dev/docs/getting-started/. The component lives in hal0-web
+// (src/components/DocsSectionCards.astro) and derives its page counts
+// from the docs collection, so nothing here needs maintaining when
+// pages are added. This file is mirrored verbatim into hal0-web by
+// .github/workflows/mirror-docs.yml, which is why the import resolves
+// there and not in this repo.
+import DocsSectionCards from '../../../../components/DocsSectionCards.astro';
 
 **hal0** turns a Linux box into a polished, OpenAI-compatible inference
 appliance. It is built for the AMD Ryzen AI Max+ 395 ("Strix Halo") —
@@ -104,3 +112,7 @@ by network reachability — the right posture for a trusted LAN appliance.
 If hal0 is reachable from anywhere you do not control, front it with a
 reverse proxy that owns auth and TLS.
 </Aside>
+
+## Sections
+
+<DocsSectionCards />


### PR DESCRIPTION
Two small additions to mirrored docs so the website's presentation survives a sync.

## Why

`.github/workflows/mirror-docs.yml` rsyncs `docs/<section>/` into hal0-web with `--delete`, so this repo is the source of truth and anything the site adds on its own side is erased on the next run. That is what happened on 2026-08-10 (hal0-web `845f6df`): the site's Sections card grid and a version stamp were wiped, and four listing pages were deleted, taking three merged web PRs with them. The workflow behaved exactly as designed — the web side was editing generated files.

The web-side fix moves everything it can into `src/pages/` and components, out of the mirror's reach. These two hooks are the remainder, the parts that genuinely have to live next to the content.

## What

- **`getting-started/index.mdx`** — a `## Sections` heading and `<DocsSectionCards />`. The component lives in hal0-web and derives its page counts from the docs collection, so adding a page here needs no edit there. The `astro-icon` dependency and all the markup stay web-side; this repo gains one import line.
- **`concepts/slots.mdx`** — `appliesTo: v1.0`. Product metadata (which hal0 version the page describes), so it belongs beside the page rather than web-side where the mirror would overwrite it. The site renders it as a stamp next to the title; other pages can adopt the field as they become version-specific.

## Verification

Neither change affects this repo's build — `docs/` is plain markdown source here. Verified by replaying the mirror's own rsync into a hal0-web checkout and building: 72 pages, cards and stamp both render, counts agree with the sidebar (getting-started 8), and the import comment does not leak as page text (a real MDX hazard — a `//` block separated from an import by a blank line parses as a markdown paragraph).

🤖 Generated with [Claude Code](https://claude.com/claude-code)