### PR TITLE
fix(profiles): brain profile uses MiniCPM5's sampler recommendation and llama.cpp's default batch

### DIFF
--- a/src/hal0/config/data/seed_profiles.toml
+++ b/src/hal0/config/data/seed_profiles.toml
@@ -121,12 +121,20 @@ quant = ""
 # Brain steward workload + MiniCPM5-family quirks (per
 # spec-p3-brain.final.md §5a). Brain is 1:1 with its model (the only
 # 1B model the steward runs), so a single combined profile is cleaner
-# than overlay. Small batch (1B model), reasoning off — the 1B rambles
-# past any completion budget with thinking on, so the profile suppresses
-# it at launch. On runner ade07ba the model emits NATIVE tool calls on
-# this slot; artefact rounds still reroute per turn to `[brain_chat]
-# tool_model` (ADR-0023 fallback).
-flags = "--jinja -fa auto -b 512 -ub 256 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.9 --top-k 20 --no-mmproj"
+# than overlay. Reasoning off — the 1B rambles past any completion budget
+# with thinking on, so the profile suppresses it at launch. On runner
+# ade07ba the model emits NATIVE tool calls on this slot; artefact rounds
+# still reroute per turn to `[brain_chat] tool_model` (ADR-0023 fallback).
+#
+# Sampler values are MiniCPM5-1B's own published no-think recommendation
+# (temp 0.7, top_p 0.95; the model card's think mode is 0.9/0.95, and this
+# profile launches with reasoning off). Upstream recommends no top_k at
+# all — the previous `--top-p 0.9 --top-k 20` was the Qwen3 sampler default
+# carried over from a Qwen-family profile, not a MiniCPM5 fact. Batch is
+# llama.cpp's default 2048/512, matching every other seeded profile: the
+# earlier 512/256 measured ~12-14% SLOWER prefill on rocm with no decode
+# benefit, reproduced across two independent windows (#1811).
+flags = "--jinja -fa auto -b 2048 -ub 512 --reasoning off --reasoning-format none --reasoning-budget -1 --no-context-shift --temp 0.7 --top-p 0.95 --no-mmproj"
 mtp = false
 intent = "Brain steward (1B MiniCPM5 + persona + tool-call routing) · 64K ctx"
 quant = ""


### PR DESCRIPTION
Three corrections to the `brain` seed, surfaced by the #1811 pre-GA review once #1787/#1808 made profile flags actually reach the (unstamped) brain model. These are server-level defaults every brain request inherits unless the caller overrides them, so they're worth getting right before GA.

**Stacked on #1813** (`-fa auto`) — both edit `seed_profiles.toml`. Merge that first; this rebases cleanly onto it. The diff here is the brain line only.

## 1. `-b 512 -ub 256` → `-b 2048 -ub 512`

Benchmarked on CT105 against the real brain model (`hal0-brain-sft-fpx8`, Q8_0) with `llama-bench` via direct `podman run`, constants `-fa 1 -ngl 99 -d 2048 -p 512 -n 128`:

| lane | config | pp512 tok/s | tg128 tok/s |
|---|---|---|---|
| rocm | `-b 2048 -ub 512` | ~2750–2860 | ~69 |
| rocm | `-b 512 -ub 256` | ~2410–2470 | ~69–70 |

The small batch costs **12.4% / 13.6% prefill** (two independent back-to-back windows, compared within-window to cancel the box's live-traffic drift) and buys **nothing on decode**. The vulkan lane was inconclusive — the effect's sign flipped between windows, so contention exceeds signal at this model size; not claiming a result there. Full data on #1811.

2048/512 is llama.cpp's default and what `chat`, `agent`, `chadrock-dense` and `chadrock-moe` already use — `brain` was the lone outlier.

## 2. `--top-p 0.9` → `--top-p 0.95`

MiniCPM5-1B's published recommendation is `temp 0.7 / top_p 0.95` for no-think and `0.9 / 0.95` for think — consistent across the [model card](https://huggingface.co/openbmb/MiniCPM5-1B) and the [official llama.cpp deployment doc](https://github.com/OpenBMB/MiniCPM/blob/main/docs/deployment/llama_cpp.md). This profile launches with `--reasoning off`, so no-think is the right column and `--temp 0.7` was already correct. Only `top_p` was off.

## 3. Drop `--top-k 20`

Upstream recommends no `top_k` at all. `top_p 0.9` + `top_k 20` is the **Qwen3** sampler default — inherited from a Qwen-family profile rather than derived from MiniCPM5. hal0's own Qwen-family profiles legitimately keep `--top-k 20`; they're untouched here.

Caveat stated plainly: `hal0-brain-sft` is a fine-tune, so it *could* justify diverging from the base model's recommendation — but nothing in the repo documents such a decision, and the Qwen-shaped values point to inheritance. If a future measurement justifies different values, they belong in the model's `defaults.extra_args` (or documented in the profile's `intent`), not silently in a seed.

## Verified

`HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers tests/config tests/brain tests/slots -q` → **2185 passed, 9 skipped**. `make lint` clean.

Refs #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)