### PR TITLE
feat(bench): publish bundles to the bench API with `hal0 bench upload`

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -48,7 +48,7 @@ global flag is controlled per-command via environment variables instead — see
 | `hal0 probe` | **Deprecated**, hidden. Alias for `hal0 config hardware --refresh`. | — |
 | `hal0 serve` | Start the hal0 API server (used by `hal0-api.service`). | `--host` (default `127.0.0.1`, env `HAL0_BIND_HOST`), `--port` (default `8080`, env `HAL0_PORT`), `--reload` |
 | `hal0 uninstall` | Uninstall hal0. Conservative by default. | `--purge` (alias `--clean-slate`), `--keep-data`, `--force`/`-f` (honors `HAL0_FORCE=1`), `--dev` (tears down a dev install at `$PWD/.hal0ai`) |
-| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval, bundle` |
+| `hal0 bench ...` | Benchmark pipeline. Raw argparse passthrough (`allow_extra_args`), see [Model roster & benchmarks](/docs/reference/model-roster-benchmark/). | verbs: `plan, run, worker, status, results, history, reindex, devices, publish, eval, bundle, upload` |
 | `hal0 chat` | Interactive chat REPL. | `--model` (default `"agent"`), `--base-url` (default `http://127.0.0.1:8080/v1`, env `HAL0_CHAT_BASE_URL`), `--no-stream`, `--brain` (talk to the hal0-brain steward instead) |
 | `hal0 system-info` | Host system info. | `--json` |
 | `hal0 ports` | Port allocation view. | `--json` |

--- a/docs/reference/model-roster-benchmark.mdx
+++ b/docs/reference/model-roster-benchmark.mdx
@@ -125,7 +125,7 @@ curated per-*profile*, not per-model, and is distinct from the JSONL pipeline ab
 ### CLI
 
 ```sh
-hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|bundle
+hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|bundle|upload
 ```
 
 `hal0 bench` is a raw argparse passthrough (not a Typer sub-app) — run
@@ -137,9 +137,10 @@ hal0 bench plan|run|status|worker|results|history|reindex|devices|publish|eval|b
 
 ### Sharing results
 
-Benchmark results never leave the box — there is no upload path. To share a
-run, package it as a self-contained bundle and attach it wherever you discuss
-it (forum thread, issue, chat):
+Benchmark results never leave the box on their own — nothing is uploaded in
+the background, and no verb here runs unattended. Sharing is always an
+explicit command you type. To share a run, package it as a self-contained
+bundle and attach it wherever you discuss it (forum thread, issue, chat):
 
 ```bash
 hal0 bench bundle --list                       # see what's eligible
@@ -151,3 +152,28 @@ telemetry), the profile/suite TOMLs you pass with `--profile`, and optional
 raw artifacts (`--with-artifacts`). `host.name` is redacted by default, the
 manifest carries a sha256 for every member, and the whole archive is
 content-addressed — anyone can verify and reproduce what you measured.
+
+Records with `outcome: ok` but no throughput measurement at all are left out
+of bundles: they carry nothing to publish, and the publish API rejects a whole
+upload over a single one.
+
+### Publishing to the public leaderboard
+
+Maintainers of the hal0.dev leaderboard publish a bundle to the bench API,
+which is what backs [hal0.dev/benchmarks](https://hal0.dev/benchmarks). This
+requires an admin token and is not something a normal install needs:
+
+```bash
+export HAL0_BENCH_TOKEN=…                      # admin token; never a CLI flag
+hal0 bench upload run.hal0bench.tar.gz
+hal0 bench bundle --runs <run_id> --upload     # or bundle + publish in one step
+```
+
+The token is read from the environment only — passing a credential as an argv
+value would expose it in `ps`, in shell history, and in any journald unit that
+logs the command line.
+
+Uploads are idempotent. The API is content-addressed, so re-sending a bundle
+that is already published is a no-op that reports the existing record count,
+and re-sending one that was unpublished restores it. A retry after a network
+failure cannot duplicate records.

--- a/src/hal0/bench/bundle.py
+++ b/src/hal0/bench/bundle.py
@@ -49,8 +49,28 @@ def _record_ts(rec: dict[str, Any]) -> str:
     return run_id.split("Z-")[0] + "Z" if "Z-" in run_id else run_id
 
 
+# The publish API rejects a record carrying none of these, and it rejects the
+# WHOLE bundle when it finds one — so a bundle containing such a record is
+# unpublishable in its entirety. Kept in sync with the bench API worker's
+# parseRecordLine ("no summary metrics present").
+_PUBLISHABLE_METRICS = ("decode_ts_med", "prefill_ts_med", "ttft_ms_p50", "ttft_ms_p95")
+
+
+def _has_publishable_metrics(rec: dict[str, Any]) -> bool:
+    summary = rec.get("summary") or {}
+    return any(summary.get(k) is not None for k in _PUBLISHABLE_METRICS)
+
+
 def select_records(store: Store, spec: BundleSpec) -> list[dict[str, Any]]:
-    """Filter records.jsonl down to the bundle's contents, append order kept."""
+    """Filter records.jsonl down to the bundle's contents, append order kept.
+
+    Records with `outcome: ok` but no throughput metrics at all are skipped.
+    In practice these are v1-era server-ab rows for the embed/rerank SLOTS
+    rather than models — `build_roster` already drops them for the same
+    reason (no gguf, so a slot never shows up as a model). Including them cost
+    the entire bundle: the API's validator fails the whole upload on the first
+    such record, so two junk rows made 130 good ones unpublishable.
+    """
     wanted = set(spec.run_ids) if spec.run_ids else None
     out: list[dict[str, Any]] = []
     for rec in store.iter_records():
@@ -61,6 +81,8 @@ def select_records(store: Store, spec: BundleSpec) -> list[dict[str, Any]]:
         if spec.suite and rec.get("suite") != spec.suite:
             continue
         if spec.since and _record_ts(rec) < spec.since:
+            continue
+        if not _has_publishable_metrics(rec):
             continue
         out.append(rec)
     return out

--- a/src/hal0/bench/bundle.py
+++ b/src/hal0/bench/bundle.py
@@ -4,10 +4,20 @@ A bundle is a SELECTION + PACKAGING layer over the store: no new measurement,
 no mutation. Only ``ok`` records are eligible (Outcome contract, schema.py) —
 a shared bundle must never carry a contended or failed number. The manifest
 carries a sha256 for every member file and a ``bundle_id`` derived from those
-hashes, so any consumer (a reader on the forums, or a future opt-in ingest
-system) can verify integrity and dedupe re-shares without trusting the
-producer. Bundles land on local disk only; there is no upload path in the
-public release (operator decision 2026-08-09) — sharing one is a manual act.
+hashes, so any consumer (a reader on the forums, or the bench API's ingest)
+can verify integrity and dedupe re-shares without trusting the producer.
+
+Sharing stays a manual act (operator decision 2026-08-09): writing a bundle
+puts it on local disk and nothing more. Nothing is uploaded in the
+background, on a timer, or as a side effect of a benchmark run. The one
+upload path — ``hal0 bench upload`` / ``bundle --upload`` — is an explicit
+verb gated on an admin token that only the hal0.dev leaderboard maintainer
+holds, so for an ordinary install there is still no way for results to
+leave the box.
+
+Records with ``ok`` but no throughput measurement are excluded from the
+selection: they carry nothing to publish, and the publish API rejects an
+entire upload over one of them.
 """
 
 from __future__ import annotations

--- a/src/hal0/bench/cli.py
+++ b/src/hal0/bench/cli.py
@@ -12,6 +12,8 @@ modules — the CLI holds no logic of its own beyond wiring + output formatting:
     reindex    rebuild bench.db from records.jsonl (store.reindex)
     devices    GPU device nodes benchmark containers use (devices.resolve_bench_devices)
     publish    regenerate roster.json (+ --check diff) (publish.*)
+    bundle     package ok records into a shareable archive (bundle.write_bundle)
+    upload     publish a bundle archive to the bench API (api.hal0.dev/v1/bundles)
 
 Runs unprivileged; Tier A cells go through the seam inside ``run``. (The
 one-time ``import-v1`` migration verb was removed after every box migrated —
@@ -22,8 +24,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import urllib.error
+import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -626,7 +630,88 @@ def cmd_bundle(args: argparse.Namespace) -> int:
         print(f"bundle: {exc}", file=sys.stderr)
         return 1
     print(f"wrote {path} ({len(manifest['records'])} record(s), {manifest['bundle_id']})")
+    if getattr(args, "upload", False):
+        return _upload_bundle(Path(path), args.api_url, _upload_token(args))
     return 0
+
+
+DEFAULT_BENCH_API = "https://api.hal0.dev"
+_TOKEN_ENV = "HAL0_BENCH_TOKEN"  # the env var's NAME, not a credential
+
+
+def _upload_token(args: argparse.Namespace) -> str | None:
+    """Admin token from the environment only.
+
+    Deliberately NOT a --token flag: a credential passed as an argv value is
+    visible in `ps`, the shell history file, and any journald/systemd unit that
+    logs the command line. The env var keeps it out of all three.
+    """
+    token = os.environ.get(_TOKEN_ENV)
+    return token.strip() or None if token else None
+
+
+def _upload_bundle(path: Path, api: str, token: str | None) -> int:
+    """POST a bundle tar.gz to the bench API's admin ingest endpoint.
+
+    The API is content-addressed: re-uploading a bundle whose bundle_id is
+    already published is a no-op that reports the existing record count, and
+    re-uploading one that was soft-deleted republishes it. So this verb is
+    safe to re-run — a retry after a network failure cannot duplicate rows.
+    """
+    if not token:
+        print(
+            f"upload: ${_TOKEN_ENV} is not set (admin token required)",
+            file=sys.stderr,
+        )
+        return 1
+    if not path.is_file():
+        print(f"upload: no such bundle: {path}", file=sys.stderr)
+        return 1
+
+    body = path.read_bytes()
+    url = f"{api.rstrip('/')}/v1/bundles"
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "authorization": f"Bearer {token}",
+            "content-type": "application/gzip",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as res:
+            payload = json.loads(res.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            # The worker answers errors as {"errors": [...]}; surface those
+            # verbatim rather than a bare status, since validation rejections
+            # name the offending record line.
+            body_json = json.loads(exc.read().decode() or "{}")
+            detail = "; ".join(body_json.get("errors") or []) or str(body_json)
+        except (ValueError, OSError):
+            detail = exc.reason or ""
+        hint = f" (is ${_TOKEN_ENV} current?)" if exc.code == 401 else ""
+        print(f"upload: HTTP {exc.code}{hint}: {detail}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        print(f"upload: could not reach {url}: {exc}", file=sys.stderr)
+        return 1
+
+    bundle_id = payload.get("bundle_id", "?")
+    records = payload.get("records", "?")
+    if payload.get("republished"):
+        print(f"republished {bundle_id} ({records} record(s) restored)")
+    else:
+        print(f"uploaded {bundle_id} ({records} record(s))")
+    if payload.get("url"):
+        print(payload["url"])
+    return 0
+
+
+def cmd_upload(args: argparse.Namespace) -> int:
+    return _upload_bundle(Path(args.path), args.api_url, _upload_token(args))
 
 
 def cmd_eval(args: argparse.Namespace) -> int:
@@ -857,7 +942,24 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--profile", action="append", help="profile/suite TOML to include; repeatable")
     p.add_argument("-o", "--out", default="bench-bundle.hal0bench.tar.gz", help="output path")
+    p.add_argument(
+        "--upload", action="store_true", help=f"POST the bundle to the bench API (${_TOKEN_ENV})"
+    )
+    p.add_argument(
+        "--api-url",
+        default=DEFAULT_BENCH_API,
+        help=f"bench API base for --upload (default {DEFAULT_BENCH_API})",
+    )
     p.set_defaults(func=cmd_bundle)
+
+    p = sub.add_parser("upload", help="publish an existing bundle archive to the bench API")
+    p.add_argument("path", help="path to a .hal0bench.tar.gz written by `hal0 bench bundle`")
+    p.add_argument(
+        "--api-url",
+        default=DEFAULT_BENCH_API,
+        help=f"bench API base (default {DEFAULT_BENCH_API})",
+    )
+    p.set_defaults(func=cmd_upload)
 
     p = sub.add_parser(
         "eval", help="agentic task eval (quality tier): score a model as a real agent"

--- a/tests/bench/test_bundle.py
+++ b/tests/bench/test_bundle.py
@@ -55,6 +55,35 @@ def test_select_only_ok_records(tmp_path, monkeypatch):
     assert [r["run_id"] for r in got] == ["2026-08-01T00:00:00Z-aaa111"]
 
 
+def test_select_skips_ok_records_with_no_throughput_metrics(tmp_path, monkeypatch):
+    """v1-era embed/rerank SLOT rows are outcome=ok but carry no metrics. The
+    publish API rejects the whole bundle over one of them, so they must never
+    be selected — observed against real CT105 data, where two such rows made
+    130 good records unpublishable."""
+    empty = _rec("2026-08-01T00:00:01Z-bbb222", model="rerank")
+    empty["summary"] = {"decode_ts_med": None, "prefill_ts_med": None, "ttft_ms_p50": None}
+    missing = _rec("2026-08-01T00:00:02Z-ccc333", model="embed")
+    del missing["summary"]
+
+    store = _store(tmp_path, monkeypatch, [_rec("2026-08-01T00:00:00Z-aaa111"), empty, missing])
+
+    got = select_records(store, BundleSpec())
+    assert [r["run_id"] for r in got] == ["2026-08-01T00:00:00Z-aaa111"]
+
+
+def test_select_keeps_a_record_with_only_a_non_decode_metric(tmp_path, monkeypatch):
+    """Any one of the four throughput metrics is enough — a pp-only record has
+    no decode_ts_med but is still perfectly publishable."""
+    pp_only = _rec("2026-08-01T00:00:01Z-bbb222")
+    pp_only["summary"] = {"decode_ts_med": None, "prefill_ts_med": 900.5}
+
+    store = _store(tmp_path, monkeypatch, [pp_only])
+
+    assert [r["run_id"] for r in select_records(store, BundleSpec())] == [
+        "2026-08-01T00:00:01Z-bbb222"
+    ]
+
+
 def test_select_by_run_ids(tmp_path, monkeypatch):
     store = _store(
         tmp_path,

--- a/tests/bench/test_cli_upload.py
+++ b/tests/bench/test_cli_upload.py
@@ -1,0 +1,230 @@
+"""CLI wiring for `hal0 bench upload` (and `bundle --upload`).
+
+Drives main(argv) directly like the other verb tests. The network is never
+touched: urllib.request.urlopen is monkeypatched at the module the CLI imports
+it through, so these assert the REQUEST the CLI would send and how it reports
+each response, not the worker's behaviour (which is covered by the worker's own
+suite in hal0-web).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+from hal0.bench.cli import main
+from hal0.bench.store import Store
+
+TOKEN_ENV = "HAL0_BENCH_TOKEN"
+
+
+def _seed(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HAL0_BENCH_STATE", str(tmp_path))
+    store = Store()
+    store.append_record(
+        {
+            "run_id": "2026-08-01T00:00:00Z-aaa111",
+            "cell_key": "sha256:k1",
+            "suite": "roster",
+            "trigger": "manual",
+            "identity": {
+                "model": {"id": "qwen3-30b"},
+                "lane": "rocm",
+                "workload": {"kind": "tg", "depth": 2048},
+            },
+            "host": {"name": "box", "hal0_version": "1.0"},
+            "outcome": "ok",
+            "summary": {"decode_ts_med": 42.0},
+            "schema": 2,
+        }
+    )
+
+
+def _bundle(tmp_path, monkeypatch):
+    _seed(tmp_path, monkeypatch)
+    out_file = tmp_path / "b.hal0bench.tar.gz"
+    assert main(["bundle", "--runs", "2026-08-01T00:00:00Z-aaa111", "-o", str(out_file)]) == 0
+    return out_file
+
+
+class _Response:
+    def __init__(self, payload: dict):
+        self._body = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+def _capture(monkeypatch, payload: dict) -> dict:
+    """Patch urlopen to record the outgoing request and return `payload`."""
+    seen: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["headers"] = {k.lower(): v for k, v in req.headers.items()}
+        seen["body"] = req.data
+        seen["timeout"] = timeout
+        return _Response(payload)
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", fake_urlopen)
+    return seen
+
+
+def test_upload_posts_bundle_with_bearer_token(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+    seen = _capture(monkeypatch, {"bundle_id": "sha256:abc", "records": 1})
+
+    rc = main(["upload", str(bundle)])
+
+    assert rc == 0
+    assert seen["url"] == "https://api.hal0.dev/v1/bundles"
+    assert seen["method"] == "POST"
+    assert seen["headers"]["authorization"] == "Bearer s3cret"
+    assert seen["headers"]["content-type"] == "application/gzip"
+    assert seen["body"] == bundle.read_bytes()
+    assert "uploaded sha256:abc (1 record(s))" in capsys.readouterr().out
+
+
+def test_upload_honours_api_url_override(tmp_path, monkeypatch):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+    seen = _capture(monkeypatch, {"bundle_id": "sha256:abc", "records": 1})
+
+    assert main(["upload", str(bundle), "--api-url", "http://localhost:8787/"]) == 0
+    # Trailing slash on the base must not produce a doubled separator.
+    assert seen["url"] == "http://localhost:8787/v1/bundles"
+
+
+def test_upload_reports_republish_distinctly(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+    _capture(monkeypatch, {"bundle_id": "sha256:abc", "records": 3, "republished": True})
+
+    assert main(["upload", str(bundle)]) == 0
+    assert "republished sha256:abc (3 record(s) restored)" in capsys.readouterr().out
+
+
+def test_upload_without_token_fails_before_any_request(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.delenv(TOKEN_ENV, raising=False)
+
+    def explode(*_a, **_kw):  # pragma: no cover - must never run
+        raise AssertionError("upload attempted a request without a token")
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", explode)
+
+    assert main(["upload", str(bundle)]) == 1
+    assert TOKEN_ENV in capsys.readouterr().err
+
+
+def test_upload_missing_file_is_a_clean_error(tmp_path, monkeypatch, capsys):
+    _seed(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+
+    assert main(["upload", str(tmp_path / "nope.tar.gz")]) == 1
+    assert "no such bundle" in capsys.readouterr().err
+
+
+def test_upload_surfaces_worker_validation_errors(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            422,
+            "Unprocessable Entity",
+            {},
+            io.BytesIO(
+                json.dumps({"errors": ["records.jsonl line 2: bad cell_key format"]}).encode()
+            ),
+        )
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["upload", str(bundle)]) == 1
+    err = capsys.readouterr().err
+    assert "HTTP 422" in err
+    # The rejection names the offending line — that detail is the whole point.
+    assert "bad cell_key format" in err
+
+
+def test_upload_401_hints_at_the_token(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "stale")
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url, 401, "Unauthorized", {}, io.BytesIO(b'{"errors":["bad token"]}')
+        )
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["upload", str(bundle)]) == 1
+    assert TOKEN_ENV in capsys.readouterr().err
+
+
+def test_upload_unreachable_api_is_a_clean_error(tmp_path, monkeypatch, capsys):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["upload", str(bundle)]) == 1
+    assert "could not reach" in capsys.readouterr().err
+
+
+def test_bundle_upload_flag_writes_then_uploads(tmp_path, monkeypatch, capsys):
+    _seed(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+    seen = _capture(monkeypatch, {"bundle_id": "sha256:abc", "records": 1})
+    out_file = tmp_path / "b.hal0bench.tar.gz"
+
+    rc = main(["bundle", "--runs", "2026-08-01T00:00:00Z-aaa111", "-o", str(out_file), "--upload"])
+
+    assert rc == 0
+    assert out_file.exists()
+    assert seen["body"] == out_file.read_bytes()
+    out = capsys.readouterr().out
+    assert "wrote" in out and "uploaded sha256:abc" in out
+
+
+def test_bundle_without_upload_flag_makes_no_request(tmp_path, monkeypatch):
+    _seed(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, "s3cret")
+
+    def explode(*_a, **_kw):  # pragma: no cover - must never run
+        raise AssertionError("bundle uploaded without --upload")
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", explode)
+
+    out_file = tmp_path / "b.hal0bench.tar.gz"
+    assert main(["bundle", "--runs", "2026-08-01T00:00:00Z-aaa111", "-o", str(out_file)]) == 0
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_blank_token_is_treated_as_unset(tmp_path, monkeypatch, capsys, value):
+    bundle = _bundle(tmp_path, monkeypatch)
+    monkeypatch.setenv(TOKEN_ENV, value)
+
+    def explode(*_a, **_kw):  # pragma: no cover - must never run
+        raise AssertionError("upload attempted a request with a blank token")
+
+    monkeypatch.setattr("hal0.bench.cli.urllib.request.urlopen", explode)
+
+    assert main(["upload", str(bundle)]) == 1
+    assert TOKEN_ENV in capsys.readouterr().err


### PR DESCRIPTION
## Why

`hal0 bench bundle` wrote a tar.gz to disk and stopped. Nothing ever moved a bundle to `api.hal0.dev`, so the bench API's D1 would stay empty however many benchmarks the box ran, and the public leaderboard at hal0.dev/benchmarks would keep serving its build-time snapshot forever.

This is the producer half of that gap. The consumer half (the Worker) is hal0-web#63.

## What

- **`hal0 bench upload <path>`** — publish a bundle written earlier. Retryable on its own, which is what you want after a network failure.
- **`hal0 bench bundle --upload`** — the one-shot path a cron would use.
- **`select_records` now skips `outcome: ok` records with no throughput metrics.**

## The selection fix is not cosmetic

Running a real 132-record bundle built from live CT105 data against the Worker, the upload was rejected outright:

```
upload: HTTP 422: records.jsonl line 88: no summary metrics present; ...
```

Two rows — v1-era server-ab records for the **embed/rerank slots**, not models — carried no decode/prefill/ttft at all. The API's validator fails the whole upload on the first such record, so those two made the other 130 unpublishable. `build_roster` already drops these for the same underlying reason (no gguf, so a slot never appears as a model); the bundle builder was the last place that still shipped them.

Filtered at the producer rather than loosening the API: a record with nothing measured has nothing to publish, and keeping the upload atomic is what makes a retry safe. Any one of the four throughput metrics qualifies, so a pp-only record still bundles.

## Token handling

The admin token comes from `$HAL0_BENCH_TOKEN` and deliberately has **no `--token` flag** — a credential passed as an argv value is visible in `ps`, in shell history, and in any journald unit that logs the command line. A blank or whitespace-only value is treated as unset rather than sent as an empty bearer token.

Worker validation rejections are surfaced verbatim (they name the offending records.jsonl line, the only actionable part); a 401 adds a hint naming the env var.

## Safe to re-run

The API is content-addressed: re-uploading an already-published `bundle_id` is a no-op reporting the existing record count, and re-uploading a soft-deleted one republishes it. A retry cannot duplicate records.

## Verification

- `pytest tests/bench` — **385 passed**
- `ruff check` + `ruff format --check` clean
- 12 new CLI tests; network never touched (`urlopen` patched), asserting the request shape and each response path
- **End to end against a real Worker**: seeded a store with 132 live CT105 records → `bundle` → `upload` → `wrangler dev` (miniflare D1/R2) → `130 record(s)` ingested, then read back via `/v1/roster` and `/v1/runs/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)