### PR TITLE
test(release): add versioned release-candidate validation kit

### DIFF
--- a/.claude/workflows/rc-fix-fleet.js
+++ b/.claude/workflows/rc-fix-fleet.js
@@ -1,0 +1,266 @@
+export const meta = {
+  name: 'rc-fix-fleet',
+  description: 'Fix wave for validated release findings: one worktree-isolated agent per issue, batched, reviewed, PRs watched to a conclusion',
+  whenToUse: 'After rc-validate has filed issues and the operator has explicitly asked for the fix wave. Takes {issues, repo, project}.',
+  phases: [
+    { title: 'Plan', detail: 'classify each issue: difficulty, tier, blast radius', model: 'opus' },
+    { title: 'Fix', detail: 'batches of 6, one worktree per issue' },
+    { title: 'Review', detail: 'independent reviewer per PR', model: 'opus' },
+    { title: 'Land', detail: 'watch CI, merge, verify the merged tip' },
+    { title: 'Changelog', detail: 'one consolidated CHANGELOG PR at the end' },
+  ],
+}
+
+const A = args || {}
+const ISSUES = A.issues || []
+const REPO = A.repo                      // the worktree this session runs in (for reading the kit)
+const PROJECT = A.project || REPO        // canonical checkout that owns the worktrees
+const BATCH = A.batch || 6               // see the process lesson below — do not raise this casually
+const LAND = A.land || 'watch'           // 'watch' = watch CI and merge; 'hold' = stop at green
+
+if (!ISSUES.length) throw new Error('rc-fix-fleet requires args.issues, e.g. [1787, 1788]')
+if (!REPO) throw new Error('rc-fix-fleet requires args.repo (path to the hal0 worktree)')
+
+// Process lessons from the rc.4 fix wave. These are not style preferences; each one cost a
+// rerun. Handed to every agent verbatim.
+const LESSONS = `
+PROCESS RULES (learned the hard way during the rc.4 fix wave — follow them exactly):
+  - ONE issue per branch, one branch per worktree, one PR per branch. Never mix concerns.
+  - Branch naming: fix/<slug>, feat/<slug>, chore/<slug>, docs/<slug>, refactor/<slug>.
+  - DO NOT touch CHANGELOG.md. Per-PR CHANGELOG hunks re-conflict every remaining open branch on
+    every merge (tracked as #1545). One consolidated CHANGELOG PR lands at the end of the wave.
+  - Run the project's checks before pushing: tests, lint, AND format-check. CI runs
+    \`ruff format --check\`, which \`make lint\` does not — a formatting-only red is a wasted
+    cycle. CI also has no hermes available; do not add a test that needs it.
+  - Write a regression test that fails before your fix and passes after. A fix with no test will
+    be re-found by the next release's validation run.
+  - Never force-push a shared branch, rewrite pushed history, or bypass branch protection.
+  - Never automerge anything touching credentials, CI/CD configuration, infrastructure, or
+    migrations — those get surfaced for human review.
+`
+
+// ── phase 0: plan ────────────────────────────────────────────────────────────
+phase('Plan')
+
+const PLAN = {
+  type: 'object',
+  required: ['assignments'],
+  properties: {
+    assignments: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['issue', 'title', 'slug', 'tier', 'rationale'],
+        properties: {
+          issue: { type: 'number' },
+          title: { type: 'string' },
+          slug: { type: 'string', description: 'kebab-case branch slug' },
+          tier: { enum: ['opus', 'sonnet'], description: 'never below sonnet for these' },
+          branch_prefix: { enum: ['fix', 'feat', 'chore', 'docs', 'refactor'] },
+          rationale: { type: 'string' },
+          blast_radius: { type: 'string' },
+          needs_human: { type: 'boolean', description: 'credentials, CI/CD, infra, or migrations' },
+          conflicts_with: { type: 'array', items: { type: 'number' }, description: 'other issues touching the same files' },
+        },
+      },
+    },
+  },
+}
+
+const plan = await agent(`
+You are planning a fix wave for hal0 release findings.
+
+ISSUES: ${ISSUES.join(', ')}
+REPO: ${REPO}
+
+Read each issue with \`gh issue view\`, and read enough of the code to judge it. For each, decide:
+  - the branch prefix and slug
+  - the model tier: opus for architecture, security, cross-cutting refactors, and ambiguous
+    debugging; sonnet for ordinary single-subsystem fixes. Never below sonnet.
+  - blast radius: which subsystems and files the fix will touch
+  - which OTHER issues in this wave touch the same files — those must not run in the same batch,
+    because two worktrees editing the same file produce a merge train nobody can untangle
+  - needs_human: true if it touches credentials, CI/CD config, infrastructure, or migrations
+
+Order the assignments so that conflicting issues land in different batches and the highest-severity
+fixes go first.
+
+${LESSONS}`, { label: 'plan', phase: 'Plan', schema: PLAN, model: 'opus', effort: 'high' })
+
+const assignments = ((plan && plan.assignments) || []).filter((a) => !a.needs_human)
+const deferred = ((plan && plan.assignments) || []).filter((a) => a.needs_human)
+if (deferred.length) log(`deferred to human review (credentials/CI/infra/migrations): ${deferred.map((d) => '#' + d.issue).join(', ')}`)
+if (!assignments.length) return { aborted: 'nothing to fix autonomously', deferred }
+
+// ── phase 1: fix, in batches ─────────────────────────────────────────────────
+// Deliberately batched rather than run wide. A 12-wide fleet was killed twice by host restarts
+// during the rc.4 wave, losing every uncommitted worktree both times. Batching bounds the loss.
+phase('Fix')
+
+const FIX = {
+  type: 'object',
+  required: ['issue', 'status', 'summary'],
+  properties: {
+    issue: { type: 'number' },
+    status: { enum: ['pr-opened', 'no-change-needed', 'blocked'] },
+    pr: { type: 'number' },
+    branch: { type: 'string' },
+    summary: { type: 'string' },
+    root_cause: { type: 'string' },
+    tests_added: { type: 'string' },
+    checks: { type: 'string', description: 'exact commands run and their outcome' },
+    blocked_reason: { type: 'string' },
+  },
+}
+
+const fixes = []
+for (let i = 0; i < assignments.length; i += BATCH) {
+  const batch = assignments.slice(i, i + BATCH)
+  log(`fix batch ${Math.floor(i / BATCH) + 1}: ${batch.map((a) => '#' + a.issue).join(', ')}`)
+  const done = await parallel(batch.map((a) => () => agent(`
+Fix hal0 issue #${a.issue}: ${a.title}
+
+Canonical checkout: ${PROJECT}
+Branch: ${a.branch_prefix || 'fix'}/${a.slug}   (create it from origin/main)
+Blast radius from planning: ${a.blast_radius || 'unknown — determine it yourself'}
+
+Work like this:
+1. \`gh issue view ${a.issue}\` — read the full report including the repro and the validation
+   evidence. The issue came from an agent driving a real box, so the repro is real; reproduce it
+   locally or in a test before you change anything.
+2. Find the ROOT cause, not the symptom. The rc.4 wave's most valuable fixes were the ones where
+   the reported symptom was two layers above the actual defect. If the root cause is deeper or
+   broader than the issue describes, fix the root cause and say so on the issue.
+3. Write a failing test first, then make it pass.
+4. Run the checks: tests, lint, and format-check. All green before you push.
+5. Open a PR with \`gh pr create --fill --base main\`. Body: what changed, why, how it was
+   verified, and anything deliberately left out of scope. Reference \`Closes #${a.issue}\`.
+
+${LESSONS}
+
+Return the schema. If the issue turns out not to reproduce or to be already fixed, that is a
+legitimate outcome — status "no-change-needed" with your evidence, and comment on the issue.`,
+    { label: `fix:#${a.issue}`, phase: 'Fix', schema: FIX, model: a.tier, isolation: 'worktree' })))
+  fixes.push(...done.filter(Boolean))
+}
+
+const prs = fixes.filter((f) => f.status === 'pr-opened' && f.pr)
+log(`${prs.length} PRs opened, ${fixes.filter((f) => f.status === 'blocked').length} blocked, ${fixes.filter((f) => f.status === 'no-change-needed').length} no-change-needed`)
+
+// ── phase 2: review ──────────────────────────────────────────────────────────
+phase('Review')
+
+const REVIEW = {
+  type: 'object',
+  required: ['pr', 'verdict', 'findings'],
+  properties: {
+    pr: { type: 'number' },
+    verdict: { enum: ['approve', 'changes-requested'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['severity', 'detail'],
+        properties: {
+          severity: { enum: ['blocking', 'nit'] },
+          file: { type: 'string' },
+          detail: { type: 'string' },
+        },
+      },
+    },
+    fixes_the_reported_defect: { type: 'boolean' },
+  },
+}
+
+const reviews = (await parallel(prs.map((p) => () => agent(`
+Review PR #${p.pr} in Hal0ai/hal0 (fixes issue #${p.issue}).
+
+You did not write this code and you are not here to be agreeable. Check, in order:
+1. Does it actually fix the defect the issue reports? Read the issue's repro and confirm the diff
+   addresses that exact path — not an adjacent one that merely looks similar.
+2. Is the fix at the root cause or at the symptom? A symptom patch that leaves the cause in place
+   will be re-found by the next validation run; say so.
+3. Does the new test fail without the fix? Verify by reasoning about the test, not by trusting the
+   PR description.
+4. Regressions: what else calls the changed code? Does the change alter behaviour for callers the
+   issue never mentioned?
+5. Scope creep: unrelated changes, drive-by refactors, CHANGELOG.md hunks (which are forbidden in
+   this wave — flag as blocking).
+6. Also triage any Codex review-bot comments already on the PR: verify each claim before acting
+   on it, then fix, file, or dismiss it deliberately. The bot can hit usage limits and post
+   nothing at all — its silence is not an approval.
+
+Post your review on the PR. Return the schema.`,
+  { label: `review:#${p.pr}`, phase: 'Review', schema: REVIEW, model: 'opus', effort: 'high' })))).filter(Boolean)
+
+const approved = reviews.filter((r) => r.verdict === 'approve').map((r) => r.pr)
+const needsWork = reviews.filter((r) => r.verdict === 'changes-requested')
+log(`review: ${approved.length} approved, ${needsWork.length} need changes`)
+
+// ── phase 3: land ────────────────────────────────────────────────────────────
+let landing = null
+if (LAND === 'watch' && approved.length) {
+  phase('Land')
+  landing = await agent(`
+Land the approved PRs: ${approved.map((n) => '#' + n).join(', ')}   (repo Hal0ai/hal0)
+
+For each, in severity order:
+1. Rebase on current main (never merge main back in — keep history linear).
+2. Watch CI to a conclusion. Poll \`gh pr checks <n>\` rather than using --watch, which has been
+   unreliable here. On a red check, read the failing job log and fix the cause on the branch;
+   never re-run hoping it flakes green. If it genuinely is flaky, say so and point at the
+   evidence.
+3. \`gh pr merge <n> --squash --auto --delete-branch\` once green.
+4. Note the automerge hazard: automerge deletes the branch on merge, so a push that lands after
+   the merge orphans those commits. Confirm everything you intend to ship is pushed BEFORE
+   enabling automerge on that PR.
+
+CRITICAL — the merge train catches what per-branch CI cannot. During the rc.4 wave, two PRs each
+green in isolation broke each other on the merged tip. So after every two or three merges, check
+out the merged main, run the full test suite there, and fix any integration break on the next
+branch before it merges. Report every such break you find.
+
+Do not merge anything touching credentials, CI/CD configuration, infrastructure, or migrations —
+surface those instead.
+
+Return: what merged, what did not and why, and any integration break the merge train exposed.`,
+    { label: 'land', phase: 'Land', model: 'opus', effort: 'high' })
+}
+
+// ── phase 4: consolidated changelog ──────────────────────────────────────────
+let changelog = null
+if (landing) {
+  phase('Changelog')
+  changelog = await agent(`
+Write ONE consolidated CHANGELOG PR covering this fix wave.
+
+Merged fixes: ${JSON.stringify(fixes.map((f) => ({ issue: f.issue, pr: f.pr, summary: f.summary })), null, 1)}
+Landing report: ${typeof landing === 'string' ? landing.slice(0, 4000) : JSON.stringify(landing).slice(0, 4000)}
+
+This is deliberately last and deliberately single: per-PR CHANGELOG hunks re-conflict every open
+branch on every merge (#1545), which is why no fix PR in this wave touched the file.
+
+Read CHANGELOG.md and match the existing section conventions exactly — the release workflow
+parses this file, so structure matters:
+  - the section heading must match the tag that will be cut
+  - a preview-channel section needs its Audience / Known issues / Supported upgrades / Operator
+    migrations / Rollback subsections as \`###\`, never \`##\` (an \`##\` terminates the
+    extractor)
+  - Breaking and Migrations bullets need a complete first physical line — the structured
+    extractor takes only the unindented \`- \` line
+  - no intra-changelog fragment links; use absolute GitHub URLs
+
+One entry per user-visible change, written for a user rather than a reviewer, each referencing
+its issue. Open the PR and return its number.`,
+    { label: 'changelog', phase: 'Changelog', model: 'opus' })
+}
+
+return {
+  issues: ISSUES,
+  deferred_to_human: deferred.map((d) => ({ issue: d.issue, why: d.rationale })),
+  fixes: fixes.map((f) => ({ issue: f.issue, status: f.status, pr: f.pr, root_cause: f.root_cause })),
+  reviews: reviews.map((r) => ({ pr: r.pr, verdict: r.verdict, blocking: (r.findings || []).filter((x) => x.severity === 'blocking').length })),
+  landing,
+  changelog,
+  next: 'Re-run rc-validate on a freshly installed build of the merged tip. Fixes verified only by CI are not verified.',
+}

--- a/.claude/workflows/rc-validate.js
+++ b/.claude/workflows/rc-validate.js
@@ -1,0 +1,541 @@
+export const meta = {
+  name: 'rc-validate',
+  description: 'Versioned release-candidate validation: preflight, lane sweep, regression probes, adversarial verification, report',
+  whenToUse: 'Validating a hal0 release candidate on the test fleet. Reset and install the RC on the boxes first, then run this with {version, boxes, mode, repo}.',
+  phases: [
+    { title: 'Preflight', detail: 'per-box readiness gate, writes CONTEXT.md' },
+    { title: 'Sweep', detail: 'read-only lanes, stateful lanes, update lanes, regression probes' },
+    { title: 'Triage', detail: 'dedup, drop known issues, rank candidates', model: 'opus' },
+    { title: 'Verify', detail: 'one skeptic per candidate finding', model: 'opus' },
+    { title: 'Report', detail: 'synthesis into the committed report', model: 'opus' },
+    { title: 'File', detail: 'GitHub issue per confirmed finding' },
+    { title: 'Curate', detail: 'fold what we learned back into the kit' },
+  ],
+}
+
+// ── args ─────────────────────────────────────────────────────────────────────
+const A = args || {}
+const VERSION = A.version
+const MODE = A.mode || 'file'                    // 'report' | 'file'
+const REPO = A.repo || process_cwd_placeholder() // see below
+const BOX_IDS = A.boxes && A.boxes.length ? A.boxes : ['ct151-cpu-fresh']
+const ONLY = A.lanes && A.lanes.length ? A.lanes : null
+
+function process_cwd_placeholder() {
+  // Workflow scripts have no filesystem or process access. The repo path must be passed in;
+  // agents are told to fail loudly rather than guess if it is missing.
+  return '<REPO PATH NOT PROVIDED — locate the hal0 worktree yourself and say so in your report>'
+}
+
+if (!VERSION) throw new Error('rc-validate requires args.version, e.g. "1.0.0-rc.5"')
+
+const KIT = `${REPO}/tests/release-validation`
+const RUN = `/mnt/mintdev/artifacts/hal0-release-validation/${VERSION}`
+
+// Box id -> role. Mirrors tests/release-validation/boxes.toml.
+const BOX_ROLES = {
+  'ct151-cpu-fresh': 'fresh',
+  'ct163-cpu-fresh': 'fresh-alt',
+  'ct150-update': 'update',
+  'ct105-prod': 'prod',
+}
+
+// Lane registry. MIRRORS tests/release-validation/kit.toml — keep both in sync.
+const LANES = {
+  readonly: ['api', 'cli', 'mcp', 'hermes', 'ui'],
+  stateful: ['slots', 'routing', 'brain', 'memory', 'capabilities', 'hermes-e2e'],
+  update: ['upgrade', 'post-upgrade'],
+}
+const briefPath = (kind, key) => `${KIT}/lanes/${kind === 'readonly' ? 'readonly' : kind}/${key}.md`
+const wanted = (key) => !ONLY || ONLY.includes(key)
+
+// ── schemas ──────────────────────────────────────────────────────────────────
+const FINDING = {
+  type: 'object',
+  required: ['title', 'severity', 'evidence', 'repro'],
+  properties: {
+    title: { type: 'string' },
+    severity: { enum: ['critical', 'major', 'minor', 'cosmetic'] },
+    evidence: { type: 'string', description: 'exact command plus the shortest decisive output line' },
+    repro: { type: 'string', description: 'steps another agent can run blind' },
+    surface: { type: 'string', description: 'cli | api | ui | mcp | hermes | brain | memory | slots | update' },
+    user_impact: { type: 'string' },
+  },
+}
+
+const LANE_RESULT = {
+  type: 'object',
+  required: ['lane', 'box', 'tested', 'findings'],
+  properties: {
+    lane: { type: 'string' },
+    box: { type: 'string' },
+    tested: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['check', 'result'],
+        properties: {
+          check: { type: 'string' },
+          result: { enum: ['pass', 'fail', 'warn', 'known', 'skipped'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+    findings: { type: 'array', items: FINDING },
+    box_state_on_exit: { type: 'string' },
+    new_checks_worth_keeping: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'checks you invented that are not in the brief and should be next release',
+    },
+  },
+}
+
+const PREFLIGHT = {
+  type: 'object',
+  required: ['box', 'ready', 'observed_version', 'summary'],
+  properties: {
+    box: { type: 'string' },
+    ready: { type: 'boolean' },
+    observed_version: { type: 'string' },
+    blocker: { type: 'string', description: 'why the run cannot proceed on this box' },
+    summary: { type: 'string' },
+    context_path: { type: 'string' },
+    findings: { type: 'array', items: FINDING },
+  },
+}
+
+const REGRESSION_RESULT = {
+  type: 'object',
+  required: ['results'],
+  properties: {
+    results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'issue', 'result', 'evidence'],
+        properties: {
+          id: { type: 'string' },
+          issue: { type: 'number' },
+          result: { enum: ['fixed', 'regressed', 'partial', 'blocked'] },
+          evidence: { type: 'string' },
+          detail: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const TRIAGE = {
+  type: 'object',
+  required: ['candidates', 'dropped'],
+  properties: {
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['key', 'title', 'claim', 'severity_claimed', 'evidence', 'repro'],
+        properties: {
+          key: { type: 'string', description: 'short kebab-case slug' },
+          title: { type: 'string' },
+          claim: { type: 'string', description: 'the merged claim across every lane that saw it' },
+          severity_claimed: { enum: ['critical', 'major', 'minor', 'cosmetic'] },
+          evidence: { type: 'string' },
+          repro: { type: 'string' },
+          lanes: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+    dropped: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['title', 'reason'],
+        properties: { title: { type: 'string' }, reason: { type: 'string' } },
+      },
+    },
+  },
+}
+
+const VERDICT = {
+  type: 'object',
+  required: ['key', 'verdict', 'classification', 'tightened_claim', 'evidence'],
+  properties: {
+    key: { type: 'string' },
+    verdict: { enum: ['confirmed', 'refuted', 'partially-confirmed'] },
+    classification: { enum: ['ga-blocker', 'major', 'minor', 'cosmetic', 'by-design'] },
+    tightened_claim: { type: 'string', description: 'exactly what reproduces, no more' },
+    evidence: { type: 'string' },
+    other_hardware_applicability: { type: 'string', description: 'would a GPU box / privileged container / upgraded box hit this?' },
+    by_design_rationale: { type: 'string', description: 'if by-design: why, and the still_report_if clause for known-issues.yaml' },
+  },
+}
+
+// ── shared prompt preamble ───────────────────────────────────────────────────
+const BASE = `
+You are one agent in the hal0 release-candidate validation suite.
+
+VERSION UNDER TEST: ${VERSION}
+KIT (versioned, in-repo): ${KIT}
+RUN DIRECTORY (scratch, not in the repo): ${RUN}
+
+Read these before doing anything, in this order:
+  1. ${RUN}/CONTEXT.md            — live facts for this run. Beats everything else.
+  2. ${KIT}/lanes/_shared.md      — reporting rules, severity, box discipline.
+  3. ${KIT}/known-issues.yaml     — do not re-report anything listed there.
+
+If ${KIT} does not exist at that path, stop and say so — do not guess a different path.
+`
+
+// ── phase 0: preflight ───────────────────────────────────────────────────────
+phase('Preflight')
+
+const preflights = await parallel(BOX_IDS.map((boxId) => () => agent(`
+You are the PREFLIGHT agent for box ${boxId} (role: ${BOX_ROLES[boxId] || 'unknown'}).
+
+VERSION UNDER TEST: ${VERSION}
+KIT: ${KIT}   RUN DIRECTORY: ${RUN}
+
+Read ${KIT}/boxes.toml for this box's access details, hardware, reset procedure, and gotchas,
+and ${KIT}/lanes/_shared.md for the reporting rules.
+
+Your job is to establish ground truth and gate the run. Do it read-only except for writing your
+own CONTEXT file.
+
+1. Reach the box over SSH and confirm the API answers.
+2. Confirm the INSTALLED VERSION IS ${VERSION}. If it is not, set ready=false with a blocker —
+   validating the wrong build wastes the entire run. For an update-role box the installed
+   version should still be the PREVIOUS release (the upgrade lane performs the upgrade); record
+   the exact from-version and treat that as correct.
+3. Confirm every fact in boxes.toml for this box is still true (IP, OS, privileged, GPU, cores,
+   RAM, auth posture). Report each stale fact as a finding — a stale kit is a real defect in the
+   kit.
+4. Inventory: registered models and their sizes, every slot with its assigned model and state,
+   running units, disk headroom in the model store, and whether any slot is already failed.
+5. Note anything about the FRESH-INSTALL STATE that a user would hit — this is the highest-value
+   observation window in the whole run and it closes as soon as the stateful lanes start
+   mutating. Record the installer's own output/log if it is still on the box.
+6. Write ${RUN}/CONTEXT.md (create the directory). It must contain, concretely:
+   - version under test, box id, hostname, IP, API base URL, exact SSH invocation
+   - hardware and OS, whether this box has a GPU, and the backend that applies
+   - the staged test models by id, type, size, and which are known-good on this hardware
+   - current slot state at run start
+   - per-lane time budgets from ${KIT}/kit.toml
+   - the box's gotchas from boxes.toml, restated as operational instructions
+   - for update boxes: the from-version and the release-staging configuration
+   Write it for an agent that knows nothing about this fleet. Every later agent depends on it.
+
+Return the schema. Set ready=false only for something that genuinely invalidates the run.
+`, { label: `preflight:${boxId}`, phase: 'Preflight', schema: PREFLIGHT })))
+
+const ok = preflights.filter(Boolean)
+const blocked = ok.filter((p) => !p.ready)
+if (blocked.length || ok.length !== BOX_IDS.length) {
+  log(`preflight gate failed — ${blocked.length} box(es) not ready, ${BOX_IDS.length - ok.length} agent failure(s)`)
+  return { aborted: 'preflight', preflights: ok }
+}
+log(`preflight ok on ${ok.map((p) => p.box).join(', ')} — version ${ok.map((p) => p.observed_version).join(' / ')}`)
+
+// ── phase 1: lanes ───────────────────────────────────────────────────────────
+// Read-only lanes, the serialised stateful chain, the serialised update chain, and the
+// regression probes all run concurrently. The only ordering constraint in the whole suite is
+// that stateful work on a SINGLE box must be serialised — two agents mutating one install
+// produce findings neither can reproduce.
+phase('Sweep')
+
+const freshBox = BOX_IDS.find((b) => BOX_ROLES[b] === 'fresh' || BOX_ROLES[b] === 'fresh-alt')
+const updateBox = BOX_IDS.find((b) => BOX_ROLES[b] === 'update')
+
+function laneAgent(kind, key, box, extra, opts) {
+  return agent(`${BASE}
+YOUR LANE: ${key} (${kind}) on box ${box}
+YOUR BRIEF: ${briefPath(kind, key)} — read it now and work through it.
+${extra || ''}
+Write your raw notes to ${RUN}/lanes/${box}-${key}.md as you go, then return the schema.
+Set box="${box}" and lane="${key}".`, Object.assign({ label: `${kind}:${key}`, phase: 'Sweep', schema: LANE_RESULT }, opts || {}))
+}
+
+// serialised chain: each stage is handed the previous stage's box_state_on_exit verbatim
+async function chain(kind, keys, box) {
+  const out = []
+  let prev = 'as left by preflight — see CONTEXT.md'
+  for (const key of keys) {
+    if (!wanted(key)) continue
+    const r = await laneAgent(kind, key, box,
+      `\nBOX STATE LEFT BY THE PREVIOUS STAGE (trust this over CONTEXT.md where they differ):\n${prev}\n`,
+      { effort: 'high' })
+    if (r) { out.push(r); prev = r.box_state_on_exit || prev }
+    else log(`${kind}:${key} returned nothing — later stages inherit the last known box state`)
+  }
+  return out
+}
+
+const work = []
+
+if (freshBox) {
+  for (const key of LANES.readonly) {
+    if (wanted(key)) work.push(() => laneAgent('readonly', key, freshBox))
+  }
+  work.push(() => chain('stateful', LANES.stateful, freshBox))
+}
+if (updateBox) {
+  work.push(() => chain('update', LANES.update, updateBox))
+}
+
+// Regression probes. Split by tier so the mechanical ones run cheap: the fast-bulk tier can
+// run a documented repro and compare against `expect`, but anything needing source reading or
+// intent judgement stays on the workhorse tier.
+const REG_BATCHES = [
+  { tier: 'mechanical', model: 'fable', desc: 'entries with tier: mechanical' },
+  { tier: 'judgment', desc: 'entries with tier: judgment' },  // no model override: inherit session tier
+]
+if (freshBox && wanted('regressions')) {
+  for (const b of REG_BATCHES) {
+    const regOpts = Object.assign(
+      { label: `regressions:${b.tier}`, phase: 'Sweep', schema: REGRESSION_RESULT },
+      b.model ? { model: b.model } : {},
+    )
+    work.push(() => agent(`${BASE}
+YOU RUN THE REGRESSION PROBES (${b.desc}) on box ${freshBox}.
+
+Read ${KIT}/regressions.yaml. Take EVERY entry whose tier is "${b.tier}" and run its \`repro\`
+against this box, comparing what you observe to its \`expect\`.
+
+These are defects filed against a previous release and fixed since. They were fixed against unit
+tests and CI, not against a fresh end-to-end install — proving they are actually gone on a real
+box is the entire point of this phase.
+
+Rules:
+  - Use the result vocabulary defined in the file: fixed | regressed | partial | blocked.
+  - "blocked" is honest and useful. Reporting a probe you could not run as "fixed" is not.
+  - "partial" needs you to say exactly which part of \`expect\` held and which did not.
+  - Some repros need a slot loaded or a model registered. You may do that. The stateful lanes are
+    running on this same box concurrently, so before you mutate anything, re-read the slot state
+    rather than assuming, prefer creating your own throwaway slot over reusing a shared one, and
+    never unload a slot you did not load.
+  - If an entry's repro no longer matches the current CLI or API surface, say so — a stale
+    regression entry is itself a finding worth reporting to the curation phase.
+
+Return one result object per entry you ran.`, regOpts))
+  }
+}
+
+const swept = await parallel(work)
+const laneResults = swept.filter(Boolean).flatMap((r) => (Array.isArray(r) ? r : (r.results ? [] : [r])))
+const regressionResults = swept.filter(Boolean).filter((r) => !Array.isArray(r) && r.results).flatMap((r) => r.results)
+
+const totalChecks = laneResults.reduce((n, r) => n + (r.tested ? r.tested.length : 0), 0)
+const rawFindings = laneResults.flatMap((r) => (r.findings || []).map((f) => Object.assign({}, f, { lane: r.lane, box: r.box })))
+log(`sweep done — ${laneResults.length} lanes, ${totalChecks} checks, ${rawFindings.length} raw findings, ${regressionResults.length} regression probes`)
+
+// ── phase 2: triage ──────────────────────────────────────────────────────────
+// Genuine barrier: dedup needs every finding at once, and verification is expensive enough that
+// verifying duplicates is worth avoiding.
+phase('Triage')
+
+const regressedNow = regressionResults.filter((r) => r.result === 'regressed' || r.result === 'partial')
+
+const triage = await agent(`${BASE}
+You are the TRIAGE agent. You have every raw finding from every lane, plus the regression probe
+results. Produce the candidate list that the adversarial verifiers will attack.
+
+RAW FINDINGS (JSON):
+${JSON.stringify(rawFindings, null, 1)}
+
+REGRESSION PROBES THAT DID NOT COME BACK CLEAN (JSON):
+${JSON.stringify(regressedNow, null, 1)}
+
+Do this:
+1. Merge findings that are the same defect seen from different surfaces. A CLI symptom and an API
+   symptom with one root cause are ONE candidate — say so in the claim and keep both evidence
+   lines. Merging is where a 40-finding sweep becomes an 11-issue report.
+2. Drop anything already covered by ${KIT}/known-issues.yaml, unless that entry's
+   \`still_report_if\` clause is met. Put each drop in \`dropped\` with the reason and the
+   issue id — the report needs the dupe list.
+3. Drop anything whose evidence would not let another agent reproduce it. Say so; a suspicion is
+   not a finding. If it looks important but under-evidenced, keep it and say the evidence is thin
+   so the verifier knows what to attack first.
+4. Every regression that came back regressed or partial becomes a candidate automatically, at the
+   severity of the original issue or higher. A defect that was fixed and came back is worse than
+   one that was never fixed.
+5. Rank by user impact, not by how interesting the bug is. Silent wrongness — a feature that
+   reports success while doing nothing — outranks loud breakage.
+6. Read the source where it decides the merge: the installed tree on the box, and the repo at
+   ${REPO}. Two symptoms with one line of shared cause should not become two issues.
+
+Give each candidate a short kebab-case \`key\`; the verifiers are keyed on it.`,
+  { label: 'triage', phase: 'Triage', schema: TRIAGE, model: 'opus' })
+
+if (!triage || !triage.candidates.length) {
+  log('triage produced no candidates')
+}
+const candidates = (triage && triage.candidates) || []
+log(`triage: ${candidates.length} candidates, ${((triage && triage.dropped) || []).length} dropped`)
+
+// ── phase 3: adversarial verification ────────────────────────────────────────
+phase('Verify')
+
+const verdicts = (await parallel(candidates.map((c) => () => agent(`${BASE}
+You are a SKEPTIC. Your job is to REFUTE the finding below, not to confirm it.
+
+CANDIDATE (${c.key}): ${c.title}
+CLAIM: ${c.claim}
+CLAIMED SEVERITY: ${c.severity_claimed}
+EVIDENCE OFFERED: ${c.evidence}
+REPRO OFFERED: ${c.repro}
+
+Reproduce it fresh with your own commands — do not take the reporting agent's word for anything.
+Then attack it:
+  - Is it intended behaviour? Check config defaults, --help text, the ADRs in ${REPO}/docs/adr,
+    and the installed source on the box. rc.4 had four candidates die exactly here.
+  - Is the evidence misread — a different slot, a stale cache, a reaped slot, a timeout that was
+    really model slowness on CPU?
+  - Is it specific to this box's environment (CPU-only, unprivileged container, no /dev/dri)
+    rather than a defect a normal install would hit?
+  - Is it already covered by ${KIT}/known-issues.yaml under a different description?
+
+If it survives, TIGHTEN it: state exactly what reproduces and nothing more. An overclaimed issue
+wastes a fix agent's time and gets closed as not-reproducible.
+
+Then classify: ga-blocker (breaks core promised functionality for a typical user), major (real
+defect, workaround exists), minor, cosmetic, or by-design. If by-design, write the rationale AND
+the \`still_report_if\` clause that should go into known-issues.yaml, so no future run
+relitigates it.
+
+Also judge \`other_hardware_applicability\`: would a GPU box, a privileged container, or an
+upgraded (rather than freshly installed) box hit this? There is no GPU fresh-install box in the
+fleet, so a read-only cross-check against the production box is the best available evidence —
+use it when the finding touches backend selection, profile flags, hardware probing, or native
+tool calling.
+
+Non-destructive repro only. If you load a slot, restore what you found. Set key="${c.key}".`,
+  { label: `verify:${c.key}`, phase: 'Verify', schema: VERDICT, model: 'opus', effort: 'high' })))).filter(Boolean)
+
+const confirmed = verdicts.filter((v) => v.verdict !== 'refuted' && v.classification !== 'by-design')
+const killed = verdicts.filter((v) => v.verdict === 'refuted' || v.classification === 'by-design')
+log(`verify: ${confirmed.length} confirmed, ${killed.length} refuted or reclassified as by-design`)
+
+// ── phase 4: report ──────────────────────────────────────────────────────────
+phase('Report')
+
+const report = await agent(`${BASE}
+You are the SYNTHESIS agent. Write the release validation report.
+
+Use the skeleton at ${KIT}/templates/report.md, and read the previous release's report in
+${KIT}/reports/ so the two are comparable — same section order, same tables, and call out what
+changed between releases (check counts, route counts, which lanes got quieter).
+
+INPUTS
+Preflight: ${JSON.stringify(preflights.filter(Boolean).map((p) => ({ box: p.box, version: p.observed_version, summary: p.summary })), null, 1)}
+Lane results: ${JSON.stringify(laneResults.map((r) => ({ lane: r.lane, box: r.box, checks: (r.tested || []).length, pass: (r.tested || []).filter((t) => t.result === 'pass').length, findings: (r.findings || []).length })), null, 1)}
+Regression probes: ${JSON.stringify(regressionResults, null, 1)}
+Verified findings: ${JSON.stringify(verdicts, null, 1)}
+Dropped in triage: ${JSON.stringify((triage && triage.dropped) || [], null, 1)}
+Raw lane notes: ${RUN}/lanes/*.md
+
+Write it to BOTH:
+  - ${RUN}/report.md
+  - ${KIT}/reports/v${VERSION}.md   (this one is committed — it is the durable record)
+
+Requirements:
+  - Lead with the verdict: ship or do not ship, in one sentence, then the specific blockers.
+  - State the minimum gate for the next candidate and why each item is on it.
+  - Include the "what held up well" section. A report that lists only failures gives a false
+    picture of the release and hides which lanes are earning their keep.
+  - Every regression entry appears in the regression table, including the ones that came back
+    clean, and including the blocked ones with the reason they were blocked.
+  - Reclassified and refuted candidates get their own section with the reasoning that killed
+    them — that reasoning is what stops the next run rediscovering them.
+  - Record kit_version from ${KIT}/kit.toml and the exact box configurations.
+  - Be honest about coverage: which lanes were skipped, which checks were skipped, what the
+    fleet cannot test at all (there is no GPU fresh-install box).
+
+Return the path you wrote plus a 10-line summary suitable for pasting into a release thread.`,
+  { label: 'report', phase: 'Report', model: 'opus' })
+
+// ── phase 5: file issues ─────────────────────────────────────────────────────
+let filed = null
+if (MODE === 'file' && confirmed.length) {
+  phase('File')
+  filed = await agent(`${BASE}
+File one GitHub issue per confirmed finding, in the Hal0ai/hal0 repo, with \`gh\`.
+
+CONFIRMED FINDINGS: ${JSON.stringify(confirmed, null, 1)}
+REPORT: ${KIT}/reports/v${VERSION}.md
+
+Rules:
+  - Search existing open issues first. If one already covers it, comment with the new evidence
+    instead of filing a duplicate, and say so in your output.
+  - Title: the tightened claim, imperative and specific. Not "memory is broken".
+  - Body: what happens, what should happen, exact repro, decisive evidence line, environment
+    (version, box, hardware), severity and why, and the applicability judgement for other
+    hardware. Link the report.
+  - Group genuinely trivial polish items into ONE rollup issue per surface (cli/api, ui, hermes),
+    with a checklist — but enumerate every item individually inside it. rc.4 used this shape and
+    it worked.
+  - Label with the triage labels this repo uses. A finding with a complete repro is
+    ready-for-agent; one that needs a decision is ready-for-human.
+  - Do not close, edit, or reopen anything else.
+
+Return the filed issue numbers with titles and the dupes you commented on instead.`,
+    { label: 'file-issues', phase: 'File' })
+}
+
+// ── phase 6: curation — this is what makes the kit compound ──────────────────
+phase('Curate')
+
+const curation = await agent(`${BASE}
+You are the KIT CURATION agent. Fold what this run learned back into the kit so the next release
+starts from here instead of from scratch. This phase is the reason the kit exists.
+
+INPUTS
+Verified findings: ${JSON.stringify(verdicts, null, 1)}
+Regression probes: ${JSON.stringify(regressionResults, null, 1)}
+Checks agents invented that were not in any brief: ${JSON.stringify(laneResults.flatMap((r) => (r.new_checks_worth_keeping || []).map((c) => ({ lane: r.lane, check: c }))), null, 1)}
+Filed issues: ${filed ? JSON.stringify(filed) : '(mode=report — nothing filed)'}
+
+Edit the kit in ${REPO} (a normal working-tree edit; do not commit):
+
+1. ${KIT}/regressions.yaml — add an entry for every newly filed finding: id, issue, from
+   (v${VERSION}), severity, tier, lane, summary, repro, expect. The repro must be runnable by an
+   agent that has never seen this run. Remove entries you promoted into pytest or
+   scripts/release-test.sh, and mark ones that are ready to promote.
+2. ${KIT}/known-issues.yaml — add every candidate the verifiers refuted or ruled by-design, with
+   its rationale and its \`still_report_if\` clause. Update \`updated_for\`. Flag entries past
+   their \`review_at\` release.
+3. ${KIT}/lanes/**.md — add the checks agents invented to the brief that should have contained
+   them, in the brief's existing voice. Delete checks that have gone stale or been promoted into
+   automated tests. Keep briefs readable: a brief nobody finishes inside its time budget is worse
+   than a shorter one that gets completed.
+4. ${KIT}/boxes.toml — correct anything preflight found stale.
+5. ${KIT}/kit.toml — bump kit_version, and add a changelog line to ${KIT}/README.md describing
+   what changed and why.
+
+Also identify checks that should stop needing an agent at all: anything mechanical and stable
+belongs in pytest or scripts/release-test.sh. List them with the specific test that should be
+written. Moving work out of this kit and into CI is a success, not a loss.
+
+Return a summary of every file you changed and what you changed in it, plus the promotion list.
+Do not commit — the operator reviews the diff.`,
+  { label: 'curate', phase: 'Curate' })
+
+return {
+  version: VERSION,
+  boxes: BOX_IDS,
+  mode: MODE,
+  lanes: laneResults.length,
+  checks: totalChecks,
+  regressions: {
+    total: regressionResults.length,
+    fixed: regressionResults.filter((r) => r.result === 'fixed').length,
+    regressed: regressionResults.filter((r) => r.result === 'regressed').length,
+    partial: regressionResults.filter((r) => r.result === 'partial').length,
+    blocked: regressionResults.filter((r) => r.result === 'blocked').length,
+  },
+  candidates: candidates.length,
+  confirmed: confirmed.map((v) => ({ key: v.key, classification: v.classification, claim: v.tightened_claim })),
+  refuted: killed.map((v) => ({ key: v.key, classification: v.classification, why: v.by_design_rationale || v.evidence })),
+  report,
+  filed,
+  curation,
+}

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -1,0 +1,112 @@
+# hal0 release-candidate validation kit
+
+A versioned, replicable, agent-driven validation suite for release candidates. It is the
+successor to the three ad-hoc workflows used for `v1.0.0-rc.4` (`rc4-readonly-sweep`,
+`rc4-stateful-lane`, `rc4-verify-majors`), generalised so every release runs the same lanes,
+carries forward what the previous release learned, and gets sharper rather than starting over.
+
+This kit is **not** a substitute for `pytest` or `scripts/release-test.sh`. Those verify what we
+already knew to check. This kit is exploratory: agents drive the real product on real boxes the
+way a user would, and the things they find are folded back into the kit — and, when they are
+mechanical enough, into `pytest`/`release-test.sh` so they stop needing an agent at all.
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `kit.toml` | Kit version, lane registry, model tier per lane, phase configuration |
+| `boxes.toml` | The fleet: box profiles, access details, capabilities, reset procedure |
+| `known-issues.yaml` | Do-not-re-report list — open dupes and adjudicated by-design behaviour |
+| `regressions.yaml` | Every previously filed finding, re-probed on every subsequent release |
+| `lanes/readonly/*.md` | Read-only surface briefs (safe to run in parallel, no mutations) |
+| `lanes/stateful/*.md` | Stateful briefs (serialised on one box, mutations expected) |
+| `lanes/update/*.md` | In-place upgrade briefs (run on the update box, parallel to the fresh box) |
+| `templates/report.md` | Report skeleton the synthesis phase fills in |
+| `reports/*.md` | One committed report per validated release |
+
+The orchestration lives at `.claude/workflows/rc-validate.js` (and `rc-fix-fleet.js` for the
+optional fix wave). Workflow scripts have no filesystem access by design, so they carry **paths**,
+not content: each agent reads its own brief, `CONTEXT.md`, `known-issues.yaml`, and
+`regressions.yaml` itself.
+
+## Running a validation
+
+```sh
+# 1. Reset and install the RC on the target boxes (operator, out of band):
+#    ct151-cpu-fresh  -> pct rollback 151 pristine, fix resolv.conf, fresh install
+#    ct150-update     -> stage the new preview manifest, leave it on the PREVIOUS release
+#
+# 2. Then, from a Claude Code session in the hal0 repo:
+```
+
+Invoke the `rc-validate` workflow with args:
+
+```json
+{
+  "version": "1.0.0-rc.5",
+  "boxes": ["ct151-cpu-fresh", "ct150-update"],
+  "mode": "file",
+  "repo": "/abs/path/to/hal0/worktree"
+}
+```
+
+* `mode: "report"` — findings, verification, and a written report. Nothing is filed.
+* `mode: "file"` — the above, plus a GitHub issue per confirmed finding. **Default.**
+* `lanes: ["api","cli",…]` — restrict the run (smoke re-check after a hotfix).
+
+The fix wave is deliberately a **separate** workflow (`rc-fix-fleet`) and only runs when the
+operator asks for it. It takes the filed issue numbers, works ~6 agents wide (see *Process
+lessons*), and monitors each PR to a conclusion.
+
+## Phases
+
+| # | Phase | Agents | Tier | Barrier? |
+|---|---|---|---|---|
+| 0 | Preflight | 1 per box | sonnet | yes — a version/reachability mismatch aborts the run |
+| 1 | Read-only sweep | 1 per read-only lane | sonnet | no (pipelines into triage) |
+| 2 | Stateful lane | 1 per stateful lane, **serialised** | sonnet, effort high | serialised by construction |
+| 2b | Update lane | 1–2 on the update box | sonnet, effort high | runs concurrently with 2 (different box) |
+| 3 | Regression probes | 1 per `regressions.yaml` batch | fable (mechanical) / sonnet (judgment) | no |
+| 4 | Triage + dedup | 1 | opus | yes — needs every finding at once |
+| 5 | Adversarial verify | 1 skeptic per candidate | opus, effort high | no |
+| 6 | Synthesis + report | 1 | opus | yes |
+| 7 | File issues (`mode: file`) | 1 | sonnet | — |
+| 8 | Kit curation | 1 | sonnet | — |
+
+Phase 8 is what makes the kit compound: it writes back the new known-issues, promotes every
+filed finding into `regressions.yaml`, and appends any new check an agent invented to the lane
+brief that should have contained it. Its output is a diff for the operator to review, not a
+silent commit.
+
+A full two-box run is roughly 25–30 agents. Restrict `lanes` for smaller passes.
+
+## Process lessons (carried forward, do not relearn)
+
+* **Serialise stateful work per box.** Two agents mutating one hal0 install produce findings
+  neither can reproduce.
+* **Run fix agents ~6 at a time.** A 12-wide fleet was killed twice by host restarts during the
+  rc.4 wave, losing uncommitted work each time.
+* **No per-PR CHANGELOG hunks during a fix wave.** Every merge re-conflicts every remaining
+  branch (tracked as #1545). Consolidate in one CHANGELOG PR at the end.
+* **The merge train catches what per-branch CI cannot.** rc.4's #1808 × #1799 integration break
+  was invisible on both branches. Re-run the suite on the merged tip, not on the branches.
+* **Adversarial verification pays for itself.** Four of rc.4's would-be issues were refuted or
+  reclassified as by-design before filing.
+* **Skeptics need the source.** Verifiers read the installed tree (`/usr/lib/hal0/venv/...`),
+  not just the black-box behaviour.
+* **The idle reaper (300 s, `idle_timeout_s`) evicts slots between stages.** A stage that finds
+  a slot offline should reload it and say so, not report it as a regression.
+* **`/mnt/ai-models` ggufs on the workstation are often symlinks into `huggingface/hub`** —
+  staging them to a box needs `rsync -L`.
+
+## Versioning policy
+
+`kit.toml` carries `kit_version`. Bump it in the same PR as any change to lane briefs,
+known-issues, or regressions, and add a line to the changelog below. A report records the
+`kit_version` it ran under, so an old report can always be read against the rules it ran with.
+
+### Kit changelog
+
+* **1** (2026-08-10) — initial extraction from the rc.4 validation workflows. Five read-only
+  lanes, six stateful lanes, one update lane, 11 regression entries seeded from rc.4 issues
+  #1787–#1797, four adjudicated by-design entries in known-issues.

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -1,0 +1,86 @@
+# The validation fleet. Update this file when a box is rebuilt, re-IP'd, or retired.
+#
+# `role` is what the lane registry in kit.toml keys off ("fresh", "update", "prod").
+# Everything else is context handed to the preflight agent, which verifies it before the run
+# starts. If a fact here is stale, preflight fails the run — that is the point.
+
+hypervisor = "10.0.1.110"      # Proxmox; `pct` runs here. SSH direct to the guests, not via this.
+ssh_key = "~/.ssh/thin-mint"
+ssh_user = "root"
+
+[boxes.ct151-cpu-fresh]
+role = "fresh"
+ctid = 151
+hostname = "hal0-rc2-fresh-2604"
+ip = "10.0.1.151"
+os = "ubuntu 26.04"
+privileged = false
+gpu = false
+cores = 8
+ram_gb = 16
+snapshot = "pristine"
+api = "http://10.0.1.151:8080"
+auth_required = false
+notes = """
+Fresh-install lane. Reset: `pct rollback 151 pristine` on the hypervisor.
+GOTCHAS, in order:
+  1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
+     Tailscale 100.100.100.100. Fix it before anything else or the install fails opaquely.
+  2. No GPU passthrough: the install needs HAL0_ALLOW_CPU_ONLY=1.
+  3. No NFS mount. Test models must be rsynced to /mnt/ai-models; workstation ggufs are often
+     symlinks into huggingface/hub, so use `rsync -L`.
+  4. An unprivileged LXC sees the host's sysfs with no /dev/dri — hardware probes that key on
+     AMD DRM sysfs alone will misreport (root cause of #1790).
+"""
+
+[boxes.ct150-update]
+role = "update"
+ctid = 150
+hostname = "halo"
+ip = "10.0.1.150"
+os = "ubuntu"
+gpu = false
+api = "http://10.0.1.150:8080"
+auth_required = false
+notes = """
+In-place upgrade lane. Left on the PREVIOUS release; the run upgrades it to the RC under test.
+HAL0_RELEASES_URL is a file:// stage at /var/lib/hal0/rc2/preview.json (directory name is
+historical, not a version claim) — restage the new manifest + bundle there, or point it at the
+GitHub asset URL (works end-to-end since rc.3). No snapshot reset: its value is accumulated
+upgrade history, so record the exact from-version in CONTEXT.md before upgrading.
+"""
+
+[boxes.ct163-cpu-fresh]
+role = "fresh-alt"
+ctid = 163
+hostname = "hal0-rc2-fresh-2404"
+ip = "10.0.1.163"
+os = "ubuntu 24.04"
+privileged = true
+gpu = false
+snapshot = "pristine"
+notes = """
+Second fresh-install box: privileged, older Ubuntu. Not in the default matrix — enable it when
+a finding smells privilege- or distro-specific. AppArmor blocks podman until remediated
+(#1563 ordering bug; workaround: containers.conf.d apparmor_profile="unconfined").
+"""
+
+[boxes.ct105-prod]
+role = "prod"
+ctid = 105
+hostname = "hal0"
+ip = "10.0.1.142"
+gpu = true
+api = "http://10.0.1.142:8080"
+auth_required = true
+notes = """
+PRODUCTION. READ-ONLY, always — no slot loads, no config writes, no service restarts. Its job
+in a validation run is to answer "is this finding an artifact of the CPU-only test box?" on
+real GPU hardware. Anonymous /api/* returns 401; run `hal0 ...` on the box instead of curl
+from the workstation. Not part of the default matrix; opt in per run.
+"""
+
+# No GPU fresh-install box exists today. Every fresh-install finding that touches backend
+# selection, profile flags, hardware probing, or native tool-calling therefore carries an
+# explicit "would a GPU box hit this?" judgement (read-only cross-check on ct105-prod) rather
+# than a measurement. Standing gap — worth closing before GA.

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -1,0 +1,129 @@
+# hal0 release-candidate validation kit — registry.
+#
+# The workflow (.claude/workflows/rc-validate.js) mirrors this file's lane list. Workflow
+# scripts cannot read the filesystem, so when you add a lane here you must also add it to the
+# LANES table in the script. The brief itself is only ever read by the agent that runs it.
+
+kit_version = 1
+
+[defaults]
+# Model tier per phase. Rationale in README "Phases".
+preflight = "sonnet"
+readonly = "sonnet"
+stateful = "sonnet"
+update = "sonnet"
+regression_mechanical = "fable"
+regression_judgment = "sonnet"
+triage = "opus"
+verify = "opus"
+synthesis = "opus"
+curation = "sonnet"
+
+# Reasoning effort overrides (omitted = inherit session effort).
+stateful_effort = "high"
+verify_effort = "high"
+
+# Per-agent soft time budget, minutes. Agents are told to stop and report at this point
+# rather than run long; an unfinished check is reported as "skipped", never as "pass".
+readonly_budget_min = 10
+stateful_budget_min = 12
+update_budget_min = 20
+
+# Scratch root for run artifacts (CONTEXT.md, raw lane output). Not in the repo — only the
+# final report is committed.
+run_root = "/mnt/mintdev/artifacts/hal0-release-validation"
+
+# ── Read-only lanes ──────────────────────────────────────────────────────────
+# Safe to run fully in parallel. No mutations of any kind.
+
+[[lane]]
+key = "api"
+kind = "readonly"
+brief = "lanes/readonly/api.md"
+boxes = ["fresh", "prod"]
+
+[[lane]]
+key = "cli"
+kind = "readonly"
+brief = "lanes/readonly/cli.md"
+boxes = ["fresh", "prod"]
+
+[[lane]]
+key = "mcp"
+kind = "readonly"
+brief = "lanes/readonly/mcp.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "hermes"
+kind = "readonly"
+brief = "lanes/readonly/hermes.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "ui"
+kind = "readonly"
+brief = "lanes/readonly/ui.md"
+boxes = ["fresh"]
+
+# ── Stateful lanes ───────────────────────────────────────────────────────────
+# Serialised in this order on a single box. Each hands the next its box state.
+
+[[lane]]
+key = "slots"
+kind = "stateful"
+order = 1
+brief = "lanes/stateful/slots.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "routing"
+kind = "stateful"
+order = 2
+brief = "lanes/stateful/routing.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "brain"
+kind = "stateful"
+order = 3
+brief = "lanes/stateful/brain.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "memory"
+kind = "stateful"
+order = 4
+brief = "lanes/stateful/memory.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "capabilities"
+kind = "stateful"
+order = 5
+brief = "lanes/stateful/capabilities.md"
+boxes = ["fresh"]
+
+[[lane]]
+key = "hermes-e2e"
+kind = "stateful"
+order = 6
+brief = "lanes/stateful/hermes-e2e.md"
+boxes = ["fresh"]
+
+# ── Update lane ──────────────────────────────────────────────────────────────
+# Runs on the update box concurrently with the fresh box's stateful lanes.
+
+[[lane]]
+key = "upgrade"
+kind = "update"
+order = 1
+brief = "lanes/update/upgrade.md"
+boxes = ["update"]
+
+[[lane]]
+key = "post-upgrade"
+kind = "update"
+order = 2
+brief = "lanes/update/post-upgrade.md"
+boxes = ["update"]

--- a/tests/release-validation/known-issues.yaml
+++ b/tests/release-validation/known-issues.yaml
@@ -1,0 +1,104 @@
+# Do-not-re-report list.
+#
+# Every lane agent reads this file and is told: if you observe one of these, record it as a
+# `known` result and move on. Re-reporting known behaviour is how a validation run drowns in
+# noise and buries the real finding.
+#
+# Two kinds of entry:
+#   status: open      — a real defect with an open issue. Still broken, already tracked.
+#   status: by-design — adjudicated, usually by a previous adversarial verification pass.
+#                       Includes WHY, so a later agent does not relitigate it from scratch.
+#
+# Entries carry `review_at`: the release by which someone must recheck whether this is still
+# true. Kit curation (phase 8) flags entries past their review point.
+
+schema: 1
+updated: 2026-08-10
+updated_for: v1.0.0-rc.5
+
+known_issues:
+  - id: slot-logs-empty
+    status: open
+    issue: 1429
+    summary: >-
+      `hal0 slot logs <name>` returns "no logs" for healthy container slots — the quadlet sets
+      LogDriver=none.
+    review_at: v1.0.0
+
+  - id: load-restart-error-surfacing
+    status: open
+    issue: 1424
+    summary: >-
+      Slot load/restart failures surface as CLI timeouts or generic errors rather than the
+      underlying runner error.
+    review_at: v1.0.0
+
+  - id: hindsight-doctor-status-mismatch
+    status: open
+    issue: 1543
+    summary: >-
+      `hal0 doctor` and `hal0 memory status` disagree about hindsight health.
+    review_at: v1.0.0
+
+  - id: changelog-hunk-conflicts
+    status: open
+    issue: 1545
+    summary: >-
+      Per-PR CHANGELOG hunks re-conflict every open branch on each merge. Process issue, not a
+      product defect — matters only during a fix wave.
+    review_at: v1.0.0
+
+  - id: dispatcher-unknown-model-passthrough
+    status: by-design
+    adjudicated: v1.0.0-rc.4
+    summary: >-
+      A request naming a registered-but-unloaded model is answered by the `agent` anchor slot
+      rather than 404ing.
+    why: >-
+      ADR-0023 Rule 9. The substitution is disclosed in the response `model` field and in the
+      dispatch journal (`resolution_path=legacy_slot:agent`). No strict-404 knob exists; that
+      would be an enhancement request, not a bug report.
+    still_report_if: >-
+      The substitution is NOT disclosed in the response model field, or the journal shows a
+      resolution_path with no corresponding loaded slot.
+    review_at: v1.1.0
+
+  - id: mcp-lan-421-invalid-host
+    status: by-design
+    adjudicated: v1.0.0-rc.4
+    summary: >-
+      `POST http://<box>:8080/mcp/admin/mcp` from the LAN returns 421 "Invalid Host header".
+    why: >-
+      Deliberate localhost-only DNS-rebinding floor on /mcp/*, independent of whether the REST
+      API is anonymous-open. Configurable via HAL0_MCP_ALLOWED_HOSTS in api.env.
+    still_report_if: >-
+      HAL0_MCP_ALLOWED_HOSTS is set correctly and the 421 persists, or the documented connect
+      URL still omits the /mcp suffix (that part was real — folded into #1796).
+    review_at: v1.1.0
+
+  - id: hermes-memory-turn-slow-on-cpu
+    status: by-design
+    adjudicated: v1.0.0-rc.4
+    summary: >-
+      Hermes memory-tool turns take minutes on the CPU-only box.
+    why: >-
+      Unreproduced as a hang under controlled retest — store 53 s, recall 15 s with a 0.8 B
+      model on 8 CPU cores. Consistent with model slowness, not a deadlock.
+    still_report_if: >-
+      A turn exceeds ~120 s on a box with GPU acceleration, or the retain op and the chat turn
+      are provably contending for the same slot (that would hit single-GPU boxes too).
+    review_at: v1.0.0
+
+  - id: brain-model-file-vanished-post-pull
+    status: by-design
+    adjudicated: v1.0.0-rc.4
+    summary: >-
+      During rc.4 setup a pulled 1.14 GB brain gguf disappeared from the store minutes after a
+      verified pull.
+    why: >-
+      Never filed — cause unproven, and an operator UI action in the same window is the likely
+      explanation. Recorded so the next occurrence is recognised as the second, not the first.
+    still_report_if: >-
+      It happens again with no concurrent UI session. Then it is real and urgent — capture the
+      pull job record, the store listing timestamps, and the hal0-api journal for the window.
+    review_at: v1.0.0

--- a/tests/release-validation/lanes/_shared.md
+++ b/tests/release-validation/lanes/_shared.md
@@ -1,0 +1,58 @@
+# Shared rules — every lane agent reads this first
+
+You are validating a hal0 release candidate on a real box. Read, in this order:
+
+1. `CONTEXT.md` in your run directory — the live facts for this run: version under test, box,
+   IP, API base, SSH invocation, which models are staged, current slot state, and (for stateful
+   lanes) the state the previous stage left behind. **`CONTEXT.md` beats anything written here
+   or in your brief.** If they disagree, trust `CONTEXT.md` and say so in your report.
+2. `known-issues.yaml` — do not re-report anything listed there. Record it as `known` and move
+   on. Each by-design entry has a `still_report_if:` clause; that clause is the only thing that
+   turns it back into a finding.
+3. Your own lane brief.
+
+## Report discipline
+
+* Every check gets a result: `pass`, `fail`, `warn`, `known`, or `skipped`. A check you ran out
+  of time for is `skipped`. **Never report a check you did not actually run as `pass`.**
+* Every finding needs the **exact command** and the **shortest decisive output line**. Not a
+  full dump, not a paraphrase. If you cannot produce a repro another agent can run blind, you
+  do not have a finding yet — you have a suspicion, and it should be reported as one.
+* Severity:
+  * `critical` — data loss, or a core promised feature is completely broken
+  * `major` — a feature is unusable or silently returns the wrong result; workaround may exist
+  * `minor` — rough edge, friction, recoverable
+  * `cosmetic` — presentation only
+* **Silent wrongness outranks loud brokenness.** A feature that reports success while doing
+  nothing is worse than one that errors. Weight severity accordingly.
+* Report what a *user* would experience, not what an expert who knows the workaround would.
+  "Works once you load the utility slot" is a finding, not a pass, on a fresh install.
+
+## Discipline about the box
+
+* Respect your lane's mutation budget. Read-only lanes: GET requests and read-only CLI verbs
+  only — no loads, unloads, restarts, writes, or POST/PUT/DELETE except any explicitly listed
+  in your brief. If a command might change state, skip it and record it as `skipped`.
+* Stateful lanes: mutate freely within your brief, but never uninstall hal0, never permanently
+  stop or mask hal0-api or the hermes units, never delete files from the shared model store,
+  never reboot, and never touch anything off-box.
+* The idle reaper (`idle_timeout_s`, 300 s by default) evicts slots between stages. Finding a
+  slot offline that a previous stage left loaded is **expected** — reload it, note it, do not
+  file it.
+* Model loads on a CPU box take 30–90 s. Poll health; be patient; use long curl timeouts. A
+  CLI `ReadTimeout` does not mean the server abandoned the operation — always verify the
+  server-side outcome before concluding.
+* Stay inside your time budget (in `CONTEXT.md`). Stop and report rather than running long;
+  a partial report delivered is worth more than a complete one that never lands.
+
+## Leaving the box
+
+Stateful lanes end by stating `box_state_on_exit` precisely — which slots are loaded with which
+models, what config you changed, what you created and did not clean up. The next stage is
+handed that string verbatim and will trust it.
+
+## What a good lane report looks like
+
+Findings are the deliverable, but so is the negative space: a lane that reports "28 checks, 26
+pass, 2 fail" is far more useful than one that reports only the two failures, because next
+release we can see what stopped being checked.

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -1,0 +1,40 @@
+# Lane: api (read-only)
+
+Probe the REST surface from the workstation with curl against `$API` (from `CONTEXT.md`).
+**GET only.** No POST/PUT/DELETE.
+
+## Checks
+
+1. **Route inventory.** `GET $API/api/openapi.json` first — it is the source of truth for what
+   exists in this build. Record the route count and diff it against the count in the previous
+   release's report (in `reports/`). A route that vanished between releases is a finding.
+2. **Core surface.** Walk at minimum: `/health`, `/api/status`, `/api/slots`,
+   `/api/slots/{name}`, `/api/slots/{name}/config`, `/api/models`, `/api/settings`,
+   `/api/capabilities`, `/api/profiles`, `/api/activity`, `/api/memory`, `/api/memory/engine`,
+   `/api/memory/banks`, `/api/bench`, `/api/upstreams`, `/api/agents`, `/api/apps`,
+   `/api/auth/status`, `/api/board`, `/api/update/status`, `/v1/models`.
+   For each: well-formed JSON, no 5xx, no stack traces in the body, values that make sense for
+   this box.
+3. **Version consistency.** The version string must be identical and correct everywhere it
+   appears: `/api/status`, `/api/settings`, the UI-facing settings payload, `hal0 --version`.
+   Note the exact form (PEP 440 `1.0.0rc5` vs tag form `1.0.0-rc.5`) and whether the two forms
+   are used consistently.
+4. **Self-consistency.** Cross-check fields that describe the same reality:
+   * slot `ctx_max` / `config.context_size` vs the runner's actual `--ctx-size` (regression
+     `ctx-advertised-vs-resolved`)
+   * slot `health_ok` / `image_status` vs the slot's reported state — rc.4 had a ready+healthy
+     slot advertising `health_ok=false, image_status=missing`
+   * `/v1/models` ids vs the refs that are actually servable
+5. **Error shape.** Probe 3–4 malformed requests: unknown slot name, unknown bank id, bad query
+   params, unknown model in a GET. Expect clean structured 4xx JSON. A 200 with zeroed data for
+   a nonexistent resource is a finding (rc.4 `/api/memory/banks/{id}/stats` did this).
+6. **Catch-all shadowing.** Confirm the SPA catch-all does not serve HTML 200 at API paths —
+   rc.4 shadowed `/health`, `/openapi.json`, `/docs` (the real ones live under `/api/`).
+7. **Auth posture.** Confirm the observed anonymous access matches what `/api/auth/status`
+   claims. On an auth-enabled box, confirm anonymous requests are actually rejected.
+8. **CORS headers** — present and sane, or absent by design? Record which.
+
+## Carry-forward
+
+Add a check here whenever an API defect is found by another lane or by a user. This lane is the
+cheapest place to catch a regression, so it should grow every release.

--- a/tests/release-validation/lanes/readonly/cli.md
+++ b/tests/release-validation/lanes/readonly/cli.md
@@ -1,0 +1,35 @@
+# Lane: cli (read-only)
+
+Drive the `hal0` CLI over SSH (invocation in `CONTEXT.md`). **Read-only verbs only.** When a
+command group is unfamiliar, run `--help` first and only run the verbs that clearly read.
+
+## Checks
+
+1. **Surface walk.** `hal0 --version`, `status`, `system-info`, `ports`, `doctor`,
+   `slot list|status|show <name>|metrics|capacity|logs <name>`, `model list|show <id>|store`,
+   `memory status`, `config` (read subcommands), `upstream list`, `capabilities list`,
+   `agent list|status <name>`, `app` (read-only status), `registry` (read-only inspect),
+   `mcp list|status <server>`, `auth status`, `board` (read-only verbs), `bench` (list/records),
+   `profile` (if it exists — rc.4 had 17 server-side profiles with full CRUD API and **no CLI
+   at all**; check whether that gap closed), `update --check` (checks only — never apply).
+2. **Exit codes and tracebacks.** Any Python traceback reaching the user is a finding regardless
+   of severity elsewhere. Any command exiting 0 while printing an error is a finding.
+3. **Truthfulness against the system.** The CLI's claims must match the box:
+   * `hal0 slot list` state vs `systemctl is-active hal0-slot@<name>` for every slot
+   * `hal0 status` vs the actual set of running units
+   * `hal0 system-info` cores/threads vs `nproc` (rc.4 leaked host cores into a container view,
+     producing an impossible "cores/threads 16 / 8")
+   * `hal0 doctor` verdict vs its own warnings (rc.4 printed six `!!` warnings then "OK all
+     pre-flight checks passed")
+   * `hal0 update --check` against the staged manifest — real versions and digests, not a
+     placeholder
+4. **Presentation.** Broken tables, unformatted raw floats, empty output where a table was
+   promised, debug log lines leaking above output, colour codes in non-tty output.
+5. **Error quality.** Run 2–3 commands with wrong arguments (unknown slot, unknown model,
+   missing required arg). The error should tell a user what to do next.
+
+## Carry-forward
+
+Rollup issue #1796 collected fourteen items from this lane in rc.4. Rollups are cheap to file
+and cheap to lose track of — when you find several small CLI defects, enumerate every one
+individually in your findings even if they will be filed as a single issue.

--- a/tests/release-validation/lanes/readonly/hermes.md
+++ b/tests/release-validation/lanes/readonly/hermes.md
@@ -1,0 +1,34 @@
+# Lane: hermes (read-only)
+
+Hermes is the bundled agent. It runs as `hal0-agent@hermes` plus `hermes-gateway`. This lane
+asks a single question: **is hermes actually functional, or merely "running"?** Do not send it
+chat messages — that is the `hermes-e2e` stateful lane.
+
+## Checks
+
+1. **Units.** `systemctl status hal0-agent@hermes hermes-gateway --no-pager`. Running? Restart
+   count? Then `journalctl -u <each> --since -1h | grep -iE 'error|traceback|fail'` — quote only
+   decisive lines. A restart loop that systemd is quietly absorbing is a major finding.
+2. **Provisioning record.** Find the provisioning/smoke record and compare each phase's status
+   against its own recorded sub-results. rc.4 recorded 2/6 smoke failures and still reported
+   `status=ok` (#1793). This is regression `hermes-smoke-ok-over-failures` — check it here.
+3. **Local endpoints.** The gateway listens on loopback (ports in `CONTEXT.md`; rc.4 used 9119
+   for the dashboard API and 8642 for the gateway). Curl each for a health/status route. Record
+   what 8642 is actually for, from its config — not from assumption.
+4. **Status-string honesty.** Whatever the unit or CLI says about the dashboard must match what
+   the dashboard actually serves. rc.4 claimed "dashboard reachable" while every route returned
+   `{"error":"Frontend not built…"}`. The unbuilt frontend is expected (upstream build artifact,
+   not shipped in the wheel); a status string that hides it is not.
+5. **Data dir.** `/var/lib/hal0/.hermes` — config present, sane permissions, error logs. Never
+   print a full API key; last four characters only.
+6. **Dependencies.** The hindsight API on loopback: health endpoint, and the bank list if
+   discoverable. A fresh box should not have failed memory operations sitting in a bank.
+7. **Defaults posture.** No external integration (slack/discord/telegram/etc.) should be
+   configured or enabled on a fresh install. Anything enabled by default is a finding.
+8. **Wiring.** Session hooks installed by the installer should be allowlisted and actually fire;
+   plugin kinds should resolve rather than silently downgrade (both were rc.4 #1795 items).
+
+## Carry-forward
+
+Hermes findings have historically been *reporting* defects rather than functional ones. Treat
+any gap between what hermes says about itself and what it does as `major`.

--- a/tests/release-validation/lanes/readonly/mcp.md
+++ b/tests/release-validation/lanes/readonly/mcp.md
@@ -1,0 +1,42 @@
+# Lane: mcp (read-only)
+
+hal0 bundles two MCP servers — `hal0-admin` (~180 tools) and `hal0-memory` (~26). Validate the
+protocol, the tool inventory, and a couple of genuinely read-only tool calls.
+
+## Getting connected
+
+Discover the mount paths rather than assuming them: `hal0 mcp list` / `hal0 mcp status <server>`
+on the box, plus the OpenAPI route list. Note that in rc.4 the URL the CLI advertised was not
+the URL that worked (`/mcp/admin` → 405; the real endpoint was `/mcp/admin/mcp`) — **check
+whether the advertised URL is directly usable, because that is itself a check.**
+
+Speak MCP streamable-HTTP JSON-RPC with curl from the box (`127.0.0.1`), not from the LAN: the
+`/mcp/*` mount enforces a localhost-only DNS-rebinding floor and answers LAN requests with
+421 (see `known-issues.yaml: mcp-lan-421-invalid-host`).
+
+* `POST initialize` with `protocolVersion` and `capabilities {}`
+* header `Accept: application/json, text/event-stream` — responses may be SSE-framed
+* carry the `Mcp-Session-Id` from the initialize response
+* `notifications/initialized`, then `tools/list`
+
+## Checks
+
+1. Protocol handshake completes; session id is honoured.
+2. Tool counts match what the docs and `hal0 mcp` claim, per server. A drift in count between
+   releases is worth reporting even if nothing is broken — it usually means a tool was added or
+   lost unintentionally.
+3. Tool schemas are structurally valid (name, description, non-empty inputSchema).
+4. Call 1–2 clearly read-only tools per server (a status/list/recall tool — nothing that
+   creates, mutates, or deletes) and judge the result.
+5. **Error protocol.** Call a tool with a deliberately wrong argument. The JSON-RPC response
+   must carry `isError: true` — rc.4 returned `isError: false` on argument errors, which makes
+   every client treat a failure as a success.
+6. `serverInfo` reports the hal0 version, not the FastMCP library version (rc.4 reported
+   FastMCP 1.28.1).
+7. Latency: note anything that takes more than a couple of seconds for a list call.
+
+## Carry-forward
+
+The MCP surface is how other agents consume hal0, so *silent* protocol wrongness here is worse
+than elsewhere — a client cannot tell it is being lied to. Weight `isError`, schema validity,
+and session handling as `major` by default.

--- a/tests/release-validation/lanes/readonly/ui.md
+++ b/tests/release-validation/lanes/readonly/ui.md
@@ -1,0 +1,44 @@
+# Lane: ui (read-only, Playwright)
+
+Live smoke of the dashboard against the real box. This complements — does not replace — the 108
+mocked specs in `ui/tests/e2e/`. Those prove the components behave against fixtures; this proves
+the shipped build renders **real data from a real install**, which is where rc.4's UI findings
+all lived.
+
+Load the Playwright MCP tools via ToolSearch: `browser_navigate`, `browser_snapshot`,
+`browser_console_messages`, `browser_take_screenshot`, `browser_click`, `browser_tabs`,
+`browser_close`.
+
+## Rules
+
+**Click navigation links only.** Do not toggle switches, submit forms, or press action buttons
+(no load/unload/save/delete). If a page needs an interaction to reveal its state, record it as
+`skipped` and note that the stateful UI path is untested.
+
+## Checks
+
+1. Navigate to `$API` (from `CONTEXT.md`), wait for render, take an accessibility snapshot.
+2. Visit every top-level nav section. On each: does it render **real** data (do the slots shown
+   match `hal0 slot list`?), error toasts, blank panes, spinners still going after 15 s.
+3. `browser_console_messages` on each page — report every error, and warnings that indicate a
+   real problem (failed fetches, unhandled rejections, hydration mismatches).
+4. **Version and interpolation.** The version string must be shown and correct (rc.4 Settings
+   showed "hal0 version —"). Look for empty template interpolations — rc.4's benchmarks header
+   rendered "· GB · hal0 v". Check pluralisation ("1 banks").
+5. **Telemetry honesty.** On a box with no GPU, the dashboard must not present *host* GPU
+   statistics as local capacity (rc.4 showed igpu 100% / 83 °C / 116 GB GTT on a GPU-less
+   16 GB container). This is the highest-value check in the lane: it is the class of defect
+   where the UI is confidently wrong rather than visibly broken.
+6. **Badge agreement.** Every status badge must agree with the system: bench worker badge vs
+   `systemctl is-active hal0-bench-worker`, slot badges vs slot state, memory/agent health.
+7. **Accessibility floor.** Nav rail icons and icon-only buttons have accessible names; the
+   snapshot is navigable.
+8. Screenshot each section for the report.
+
+Close the browser when done.
+
+## Carry-forward
+
+Anything found here that can be expressed against fixtures should be promoted into
+`ui/tests/e2e/` as a spec in the fix PR, and then removed from this brief. This lane should
+only hold checks that genuinely require a live install.

--- a/tests/release-validation/lanes/stateful/brain.md
+++ b/tests/release-validation/lanes/stateful/brain.md
@@ -1,0 +1,43 @@
+# Lane: brain (stateful, order 3)
+
+The hal0-brain steward: the built-in assistant that answers questions about the platform using
+tools. Its failure mode is not crashing — it is **confident fabrication**, which is the single
+most damaging defect class in the product, because the user cannot tell.
+
+## Checks
+
+1. **Find the surface.** `hal0 chat --help` on the box, and grep the OpenAPI paths for
+   brain/chat routes — the dashboard uses one of them. Record the current `brain_chat` config
+   (enabled, read_only, model, tool_model, max_rounds) before testing.
+2. **CLI chat.** One-shot if a flag supports it; otherwise drive the REPL with a piped here-doc.
+   Does it connect, answer from the expected slot, and exit cleanly? Quote the reply.
+3. **API chat.** POST the brain chat route with a simple message. Does it round-trip/stream?
+   Does the route have a real requestBody schema, and does malformed JSON produce a real error
+   rather than being coerced to `{}` (rc.4 did the latter)?
+4. **Tool rounds** — regression `brain-tools-image-gate` (#1789). Ask something only tools can
+   answer: *"what slots are loaded right now?"*. Then check three things independently:
+   * the reply's factual accuracy against `hal0 slot list`
+   * tool frames present in the stream
+   * tool dispatch present in the hal0-api journal
+
+   rc.4 failed all three at once and answered with invented slot names. The fix moved the gate
+   off runner-image identity, so test on **whatever runner this box actually has**, and say
+   which one that was.
+5. **Tool-model unavailable.** Point `tool_model` at a slot that is offline and ask the same
+   question. The steward must degrade honestly — "tools unavailable" — not hallucinate. Then
+   load that slot and confirm tools engage.
+6. **read_only guard.** With `read_only=true`, ask the steward to perform a mutating action.
+   It must refuse. rc.4 could never reach this guard because tool rounds never fired, so it has
+   effectively never been validated — treat it as untested until you see it refuse.
+7. **Round limits.** Ask something that would need more than `max_rounds` tool calls. Does it
+   stop cleanly and say so?
+
+## Fabrication test (run this one carefully)
+
+Ask two or three questions whose true answers you already know from the box, phrased so a
+non-tool answer would be plausible. Any answer that is fluent and wrong, with no tool call
+behind it, is a `major` finding on its own — regardless of whether the tools plumbing "works".
+
+## Leave behind
+
+Brain healthy. Note any slot you loaded for the tool-model test.

--- a/tests/release-validation/lanes/stateful/capabilities.md
+++ b/tests/release-validation/lanes/stateful/capabilities.md
@@ -1,0 +1,41 @@
+# Lane: capabilities (stateful, order 5)
+
+Capability slots, the model registry, and profiles — the configuration surface a user actually
+drives when setting hal0 up for their hardware.
+
+## Checks
+
+1. **Baseline.** `hal0 capabilities --help` and `list`, plus `GET /api/capabilities`. Record
+   which capabilities ship enabled and on which backend. A CPU-only box that ships capabilities
+   bound to a GPU backend is a finding in itself.
+2. **Enable a capability against the real hardware.** Bind the embedding model to the embed
+   capability on the backend this box actually has, and enable it. Does the flip from the seeded
+   default work cleanly? Does enabling load or require the slot? Verify through both
+   `capabilities list` and the API.
+3. **Same for the rerank child**, then verify the path that consumes it: the memory reranker
+   config (`[memory.embedding] rerank_model`, `rerank_gateway_url`). Issue a rerank through the
+   gateway with a query and three documents. In rc.4 this whole path was dead because profile
+   flags never reached argv (#1787).
+4. **Model defaults.** Promote a model to default for its type. Verify `hal0 model list` marks
+   it (rc.4 had no default marker at all) and that a chat completion with no `model` field, or
+   `model=default`, uses it.
+5. **Registry mutations.** `hal0 model add` on a copy of a gguf staged into a scratch directory
+   (copy, never move, and never touch the shared store's originals):
+   * Is the capability type auto-detected correctly? rc.4 misclassified a reranker as `chat`.
+   * Is the id derived sensibly? rc.4 derived it from an arch header, producing
+     `jina-bert-implementation`.
+   * Then `hal0 model rm <id>`: does it remove the registry entry, the file, or both — and does
+     it *ask*? A remove that silently deletes files from a shared store is a `critical` finding.
+     Clean up the scratch directory afterwards.
+6. **Profiles.** rc.4 shipped 17 server-side profiles with a full CRUD API and **no CLI**.
+   Check whether `hal0 profile` now exists; if not, that gap stands. Inspect what a profile
+   contains and confirm the API's view matches what a loaded slot actually got — this is the
+   same seam as #1787, from the configuration side. Do not destructively rewrite the brain
+   profile; use a throwaway.
+7. **Registry consistency after all of the above.** Re-list models and slots. Orphans, dangling
+   references, stale capability bindings?
+
+## Leave behind
+
+Capabilities left enabled on the backend this box supports; defaults set; scratch model files
+and throwaway profiles removed. Brain and utility slots healthy.

--- a/tests/release-validation/lanes/stateful/hermes-e2e.md
+++ b/tests/release-validation/lanes/stateful/hermes-e2e.md
@@ -1,0 +1,40 @@
+# Lane: hermes-e2e (stateful, order 6)
+
+Hermes end to end, with models actually loaded. You run last precisely because the earlier lanes
+leave the box in the state hermes needs — which is itself worth noting, since a real user has to
+reach that state on their own.
+
+## Checks
+
+1. **Entrypoint.** Find how a user talks to hermes: `hal0 agent --help` verbs, the hermes CLI on
+   the box (check the systemd unit's `User=` and run as the right user), or the dashboard API.
+   The dashboard API key lives under `/var/lib/hal0/.hermes` — never print more than its last
+   four characters.
+2. **Plain chat.** Send: *"Reply with exactly: HERMES-RC-OK"*. Does a reply come back? Record
+   latency. From the journals, which model did it actually use, and did the request reach hal0's
+   `/v1` with a ref that routes? rc.4 logged a per-session `dispatch.no_route` for `hal0/agent`
+   before falling back — noise that indicates the wiring is wrong even when the answer arrives.
+3. **Memory roundtrip.** Ask hermes to remember a marker (*"Remember: the validation marker is
+   MARKER-7734"*), then in a separate turn ask it to recall it. Use generous timeouts and watch
+   both the `hal0-agent@hermes` and `hal0-api` journals.
+   * Did the store actually reach the memory backend, or only a local file? rc.4 wrote the
+     marker to a local `USER.md` and nothing else, making recall impossible.
+   * Is the recall correct, or a hallucination that merely sounds right?
+   * Which backend was it supposed to use — hindsight via hal0's memory MCP, or its own store?
+     Confirm the configured wiring matches the observed behaviour.
+   * On slowness: see `known-issues.yaml: hermes-memory-turn-slow-on-cpu`. Minutes on a CPU box
+     with a tiny model is expected. What is *not* expected is a turn never completing, or the
+     retain op and the chat turn contending for the same slot — that would deadlock single-GPU
+     boxes too, and is `major`.
+4. **Re-run the provisioning smoke** now that models are loaded (`hal0 agent smoke <name>` or
+   whatever the current verb is). Do the previously failing phases pass? And — regression
+   `hermes-smoke-ok-over-failures` (#1793) — does a phase with recorded failures now report
+   warn/fail rather than ok? Verify by reading the record, not the summary line.
+5. **Gateway.** Confirm what the gateway port is for from its config, health-check it, and
+   confirm no external integrations are enabled.
+6. **Tool use.** Ask hermes something requiring a hal0 tool call (platform state). Same
+   fabrication standard as the brain lane: fluent and wrong with no tool call is a finding.
+
+## Leave behind
+
+Hermes running. Brain, utility, and embed slots healthy.

--- a/tests/release-validation/lanes/stateful/memory.md
+++ b/tests/release-validation/lanes/stateful/memory.md
@@ -1,0 +1,46 @@
+# Lane: memory (stateful, order 4)
+
+The hindsight-backed memory subsystem: retain, recall, search, banks, and the async operation
+pipeline. rc.4's memory findings were all about the **fresh-install window** — the period before
+any model is loaded — so start there before you fix the environment.
+
+## Order matters
+
+Do step 1 **before** loading anything, or you destroy the evidence.
+
+1. **Fresh-install window** — regression `memory-retain-dead-letter` (#1792). With the utility
+   slot in its as-shipped state, attempt a retain. Then inspect the operation: does it queue and
+   wait for routing, retry with backoff, or burn its retries and dead-letter permanently?
+   Record `hal0 memory status` — a pristine install reporting "Writes FAILING" is a finding.
+   Also record what `HINDSIGHT_API_LLM_MODEL` points at and whether that target ships with a
+   model assigned.
+2. **Baseline inventory.** `hal0 memory status`, `hal0 memory --help`, `GET /api/memory/engine`,
+   `/api/memory/banks`, `/api/memory/list`. A fresh box should have zero failed operations —
+   rc.4 had two on arrival.
+3. **Fix the routing.** Assign a chat model to the utility slot and load it. Confirm the
+   hindsight target ref now routes (`POST /v1/chat/completions` with that exact ref). If it
+   still does not resolve, find what ref *does* and report the mapping gap precisely — that
+   mismatch was the root cause in rc.4.
+4. **Retain.** Store a memory containing a literal marker, e.g. *"the CT151 validation marker is
+   MARKER-7734"*. Wait for the async op; check its status through to completion.
+5. **Recall and search** — regression `fact-extraction-strips-literals` (#1794). Query for the
+   concept ("what is the CT151 validation marker?") and for the literal ("MARKER-7734").
+   Does the literal come back? State explicitly whether it came from extracted facts or from
+   the document fallback: the fallback is a workaround, and a durable fix needs server-side
+   content search that does not exist yet.
+6. **Dead-letter recovery.** Retry any failed operations (`hal0 memory ops retry`, the
+   operations API, or the MCP `memory_operation_retry` tool). Do they recover losslessly? If
+   there is no recovery path at all, that is the finding.
+7. **Disable / enable.** `hal0 memory disable` then `enable`, checking `/api/memory/engine`
+   between steps. Does the API degrade gracefully and recover cleanly, or does something stay
+   broken?
+8. **Bank hygiene.** Which banks exist on a fresh box, and when are they created? rc.4 only
+   created the `agents` bank on an hal0-api restart. Confirm bank stats are real — a nonexistent
+   bank must 404, not return zeroed stats with a 200.
+9. **Error surfacing.** Send a malformed add (wrong field name). The error should name the
+   field, not surface as `system.internal`.
+
+## Leave behind
+
+Memory enabled, utility slot loaded, brain healthy. Note the marker you stored — the hermes lane
+will look for its own separately.

--- a/tests/release-validation/lanes/stateful/routing.md
+++ b/tests/release-validation/lanes/stateful/routing.md
@@ -1,0 +1,37 @@
+# Lane: routing (stateful, order 2)
+
+The OpenAI-compatible surface and the dispatcher. This is where hal0 either is or is not a drop-in
+endpoint, so wire-format correctness matters more than model output quality — the test models are
+tiny and their answers are irrelevant.
+
+## Checks
+
+1. **Model refs.** `GET $API/v1/models` — record the id set. Then `POST /v1/chat/completions`
+   (non-streaming, `max_tokens` ~40) with each plausible ref shape: the slot name (`brain`), the
+   raw model id, and the namespaced alias (`hal0/brain`). Which resolve? Which 404? Is the error
+   JSON clean and actionable? Any ref advertised in `/v1/models` that is not servable is a
+   finding.
+2. **Streaming.** Same request with `stream=true`: SSE chunks well-formed, `[DONE]` terminator
+   present, no truncation.
+3. **Embeddings** — regression `profile-flags-argv` (#1787). `POST /v1/embeddings` against the
+   embed slot's ref: returns a vector, dimensionality sane, a batch of 2 inputs works. rc.4
+   returned 501 "start with --embeddings" while the slot reported ready.
+4. **Rerank.** `POST` the rerank route with a query and three documents: scores returned and
+   ordered sensibly. Same 501 failure mode in rc.4.
+5. **Legacy.** `POST /v1/completions` — supported, or a clean documented error.
+6. **Dispatcher behaviour on an unloaded model.** Request a model that is registered but NOT
+   loaded. Watch the hal0-api journal during the call. Per ADR-0023 Rule 9 the anchor slot
+   answers and discloses the substitution in the response `model` field — that is by design
+   (see `known-issues.yaml`). What you are checking is that the disclosure actually happens and
+   the journal's `resolution_path` names a slot that is really loaded.
+7. **Tool-call passthrough.** A chat completion with a trivial `tools` array: does the request
+   reach the runner with tools intact, or is it silently stripped? Check the runner's own view,
+   not just the response. Silent stripping is the shape of #1789.
+8. **Concurrency.** Four parallel short chat requests to one slot: all complete, no 5xx, no
+   interleaved corruption.
+9. **Timeouts and long generations.** One request with a large `max_tokens` — does anything in
+   the path (proxy, gateway, client default) cut it off mid-stream without saying so?
+
+## Leave behind
+
+Brain and embed loaded and healthy. Any model you caused to auto-load, unload again.

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -1,0 +1,42 @@
+# Lane: slots (stateful, order 1)
+
+Slot lifecycle end to end. You run first, so the box is in its post-install state — capture
+what that state actually is before you change it.
+
+## Checks
+
+1. **Post-install baseline.** Record every slot, its assigned model, its state, and the unit
+   status, before touching anything. On a fresh install this is a finding-rich moment: which
+   slots ship seeded, which ship model-less, and does anything already look wrong?
+2. **Assign + load.** Take the embed slot: `hal0 slot edit embed --model <embedding model>
+   --hardware <backend>`, then `hal0 slot load embed`. Poll its health endpoint until ok (≤120 s
+   on CPU). Watch the state transitions in `hal0 slot list` while it warms — do they progress
+   sensibly (offline → warming → ready), and does the terminal state match the unit?
+3. **A second slot.** Same flow for the rerank slot, so two are live at once.
+4. **Restart / unload.** `hal0 slot restart <name>` — comes back healthy? `hal0 slot unload
+   <name>` — clean stop, state offline, unit stopped, port released?
+5. **Create / delete.** `hal0 slot create --help`, then create a throwaway slot on a free port
+   (`hal0 ports`), assign a small chat model, load, verify health, unload, delete. Check for
+   residue: unit files, `/var/lib/hal0/slots/<name>/`, claimed ports, registry entries. rc.4
+   left an empty state directory behind.
+6. **Swap on a healthy slot.** `hal0 slot swap <slot> --model <other model>`. Even if the CLI
+   throws a `ReadTimeout`, wait and verify server-side: `systemctl cat hal0-slot@<slot> |
+   grep -o -- '--model [^ ]*'` and the runner's own `/v1/models`. Then swap back and confirm
+   healthy. Both the quadlet and the served model must change.
+7. **Swap and lifecycle on an UNhealthy slot** — regression `crash-loop-lifecycle` (#1791).
+   Deliberately induce a crash loop on a throwaway slot by assigning a model the runner cannot
+   load. Then check: what state is reported while it crash-loops and after the systemd start
+   limit is hit? Is the death surfaced anywhere a user would see (`hal0 status`, `doctor`, the
+   dashboard)? Does swap write the NEW model? Clean the throwaway slot up afterwards.
+8. **Profile flags reach argv** — regression `profile-flags-argv` (#1787), the rc.4 GA-blocker.
+   For each loaded slot, compare its profile's flags against the resolved runner argv. Include
+   at least one model that has never been stamped with `defaults.profile` (register a fresh
+   gguf via `hal0 model add` and assign it) — the unstamped path is the one that broke.
+9. `hal0 slot metrics` and `hal0 slot capacity` reflect what is actually loaded, with correct
+   units — rc.4 booked CPU memory under "VRAM MB" with "RAM MB 0.0".
+
+## Leave behind
+
+Brain slot loaded and healthy on the CPU-viable chat model; embed slot loaded (the memory lane
+uses it); rerank unloaded; every throwaway slot deleted. State all of this in
+`box_state_on_exit`.

--- a/tests/release-validation/lanes/update/post-upgrade.md
+++ b/tests/release-validation/lanes/update/post-upgrade.md
@@ -1,0 +1,40 @@
+# Lane: post-upgrade (update box, order 2)
+
+Diff the box against the "before" snapshot the `upgrade` stage recorded, then prove the upgraded
+install works — not just that it starts.
+
+The question this lane answers: **did the user lose anything, and did anything change that they
+did not ask for?**
+
+## Checks
+
+1. **State diff.** Re-capture everything the upgrade stage snapshotted and diff it item by item:
+   * slots — same names, same assigned models, same ports, same profiles? A slot silently
+     re-seeded to a shipped default has destroyed the user's configuration.
+   * config — user-set values preserved? New settings introduced with sane defaults, rather
+     than overwriting an explicit choice?
+   * capabilities and model registry — bindings intact, no orphans, no duplicated entries
+   * memory banks — counts preserved, nothing dropped, no new failed operations
+   * `/etc/hal0` and `/var/lib/hal0` — ownership and permissions unchanged
+   Report every difference, including the intended ones; the intended ones are the release note
+   material.
+2. **Seed reconciliation.** New seeds shipped by the release (profiles, slots, curated models)
+   must be *added* without clobbering user modifications. Find a seed the user had modified and
+   confirm the modification survived. Tombstoned/retired seeds must actually disappear rather
+   than resurrect.
+3. **Functional smoke on the upgraded box.** A short version of the fresh-box lanes: chat
+   completion, embeddings, a memory retain and recall, a brain steward question, the dashboard
+   loading with real data. Anything broken here that works on the freshly installed box is an
+   upgrade-path defect, and those are the most expensive kind to ship.
+4. **Version consistency.** Every surface reports the new version: CLI, API, dashboard, MCP
+   `serverInfo`, systemd unit descriptions.
+5. **Unit and quadlet refresh.** Did unit files, quadlets, and runner image references actually
+   get rewritten to the new release's values, or are stale ones still on disk? Check for leftover
+   files from the previous version's layout.
+6. **Second update check.** `hal0 update --check` on the upgraded box must now report up to
+   date, against the same manifest.
+
+## Leave behind
+
+The box healthy on the new version, with its accumulated state intact — it is the input to the
+*next* release's upgrade lane, so do not reset it.

--- a/tests/release-validation/lanes/update/upgrade.md
+++ b/tests/release-validation/lanes/update/upgrade.md
@@ -1,0 +1,47 @@
+# Lane: upgrade (update box, order 1)
+
+The in-place upgrade path — the one every existing user takes, and the one rc.4 never validated.
+This lane runs on the update box concurrently with the fresh box's stateful lanes; the two boxes
+never interact.
+
+The box arrives on the **previous** release with accumulated state. That accumulated state is
+the asset: it is the only place migrations, seed reconciliation, and config carry-forward get
+exercised against something other than a clean slate.
+
+## Before you touch anything
+
+Capture a complete "before" snapshot and write it into your report — you cannot compare after
+the fact otherwise:
+
+* `hal0 --version`, the release channel, and `HAL0_RELEASES_URL`
+* every slot: name, assigned model, state, port, profile
+* `hal0 config` dump, capability bindings, model registry listing
+* memory bank inventory and counts
+* which units are enabled and running
+* file inventory and ownership of `/etc/hal0` and `/var/lib/hal0`
+
+## Checks
+
+1. **Discovery.** `hal0 update --check`. Does it see the new version, with a real version string
+   and a real digest? rc.4's check rendered a placeholder manifest as "1.0.0rc4 → 0.0.0 (stable)
+   up to date" with a zeroed digest — a user on that build would never be told an update exists.
+2. **Ranking.** Does it correctly rank the RC against what is installed, including the rc-vs-GA
+   ordering? A wrong ranking silently withholds the update. `hal0 update --target <ver>`
+   bypasses the gate and is the documented recovery — confirm it still works, and note that
+   needing it *is* the finding.
+3. **The upgrade itself.** Run it. Capture the full output. Watch for: staged-tree permission
+   gates (a box with `UMASK 002` produces a 0775 staged tree that the activate security gate
+   refuses — the gate's own hint is the remediation), signature/digest verification, service
+   restarts, and how long the API is unavailable.
+4. **Failure honesty.** If any phase fails or warns, does the command say so and exit non-zero?
+   A successful-looking upgrade that half-applied is the worst outcome in this lane.
+5. **Migrations.** Which migrations ran? Do they log what they changed? Re-run the upgrade (or
+   the activation step) and confirm migrations are idempotent.
+6. **Rollback.** `hal0 update --rollback`. Does it return the box to the previous version with
+   its state intact? Then roll forward again. If rollback is not exercised here it is not
+   exercised anywhere.
+
+## Leave behind
+
+The box on the new version, healthy, with the "before" snapshot recorded in your report for the
+`post-upgrade` stage to diff against.

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -1,0 +1,242 @@
+# Regression register.
+#
+# Every finding filed in a previous release lands here and is re-probed on every subsequent
+# release, forever, until it is promoted into pytest or scripts/release-test.sh (set
+# `promoted_to:` and drop it in the same PR).
+#
+# This is the mechanism that makes the kit compound. rc.4 found eleven issues; rc.5 must prove
+# all eleven are actually gone on a real box, because they were fixed against unit tests and CI,
+# not against a fresh end-to-end install.
+#
+# tier: mechanical -> run the repro, compare to `expect`, no judgement needed (fable)
+#       judgment   -> requires reading source, weighing intent, or interpreting output (sonnet)
+#
+# result vocabulary the probe agent must use:
+#   fixed      — repro runs, `expect` holds
+#   regressed  — repro reproduces the original defect
+#   partial    — some of `expect` holds, some does not (say exactly which)
+#   blocked    — could not run the repro (say why; NEVER report this as fixed)
+
+schema: 1
+updated: 2026-08-10
+
+regressions:
+  - id: profile-flags-argv
+    issue: 1787
+    from: v1.0.0-rc.4
+    severity: ga-blocker
+    tier: judgment
+    lane: routing
+    summary: >-
+      Profile flags never reached llama-server argv for models with no `defaults.profile` stamp
+      (auto-scan / pull / capability-apply never stamp it, and the #1636 overlay is gated on the
+      stamp). /v1/embeddings and /v1/rerank returned 501 "start with --embeddings" while the
+      capability slots reported ready.
+    fix: >-
+      A `slot_profile_template` argv segment, applied BELOW `model_extra_args`.
+    repro: |
+      Assign the embedding model to the embed slot on the CPU backend and load it, then:
+        curl -s $API/v1/embeddings -d '{"model":"embed","input":["hello"]}'
+        systemctl cat hal0-slot@embed | grep -o -- '--embedding'
+      Repeat for rerank with the jina reranker and POST /v1/rerank.
+      Then do it with a model that has NEVER been stamped: register a fresh gguf via
+      `hal0 model add` and assign it, so the unstamped path is what is exercised.
+    expect: >-
+      Embeddings return a vector of sane dimensionality; rerank returns scores; the resolved
+      argv contains --embedding / --reranking; model_extra_args still win over the profile
+      template where they overlap.
+
+  - id: ctx-advertised-vs-resolved
+    issue: 1788
+    from: v1.0.0-rc.4
+    severity: major
+    tier: mechanical
+    lane: api
+    summary: >-
+      Slot `ctx_max` and `/v1/models` `context_length` advertised the raw slot-TOML context
+      (65536) while the effective resolved window was 32768.
+    repro: |
+      curl -s $API/api/slots/brain | jq '.ctx_max, .config.context_size'
+      curl -s $API/v1/models | jq '.data[] | {id, context_length}'
+      systemctl cat hal0-slot@brain | grep -o -- '--ctx-size [0-9]*'
+    expect: >-
+      The advertised value equals the value actually passed to the runner. If a clamp applies,
+      the API reports the clamped number (and ideally discloses the clamp).
+
+  - id: brain-tools-image-gate
+    issue: 1789
+    from: v1.0.0-rc.4
+    severity: major
+    tier: judgment
+    lane: brain
+    summary: >-
+      Brain native-tools were gated on `image == DEFAULT_ROCMFPX_IMAGE`, so any other runner
+      silently stripped tools and the steward fabricated live platform state with no signal.
+    repro: |
+      With the brain slot on a runner image that is NOT the default, ask the steward a
+      platform-state question that requires tools ("what slots are loaded right now?").
+      Watch for tool frames in the SSE stream and tool dispatch in the hal0-api journal.
+    expect: >-
+      Either tool rounds engage, or the steward states plainly that tools are unavailable on
+      this runner. Confident invented slot names with zero tool frames is the regression.
+
+  - id: cpu-install-fpx-brain-default
+    issue: 1790
+    from: v1.0.0-rc.4
+    severity: major
+    tier: judgment
+    lane: preflight
+    summary: >-
+      A CPU-only fresh install defaulted the brain slot to an FPX quant whose runner exits 139
+      (SIGSEGV) ~5 s into load, crash-looping to the systemd start limit. Root cause was
+      `hardware.probe._amd_gpu_info` hardcoding `vulkan_capable=True` on any AMD DRM sysfs
+      sighting — and an unprivileged LXC sees the host's sysfs with no /dev/dri.
+    fix: >-
+      Probe gated on a real render node, plus a 422 guard refusing ROCmFPX quants on non-FPX
+      runners.
+    repro: |
+      On the fresh CPU-only box immediately after install:
+        hal0 system-info          # what does it claim about GPU / vulkan capability?
+        hal0 slot show brain      # which model did the install choose?
+        journalctl -u hal0-slot@brain --since -1h | grep -iE 'segv|139|start-limit'
+      Then try to force it: assign an FPX quant to a slot on a non-FPX runner.
+    expect: >-
+      Hardware probe reports no GPU / not vulkan-capable with no /dev/dri present; the install
+      picks a CPU-viable brain model; assigning an FPX quant to a non-FPX runner is refused
+      with a 422 rather than accepted into a crash loop.
+
+  - id: crash-loop-lifecycle
+    issue: 1791
+    from: v1.0.0-rc.4
+    severity: major
+    tier: judgment
+    lane: slots
+    summary: >-
+      A crash-looping slot reported `warming` indefinitely, died silently at the systemd start
+      limit with nothing surfacing it, and `hal0 slot swap` on it rewrote the quadlet with the
+      OLD model.
+    repro: |
+      Deliberately induce a crash loop on a throwaway slot (assign a model the runner cannot
+      load), then:
+        hal0 slot list / GET /api/slots      # state after the start limit is hit?
+        hal0 status                          # is the failure surfaced anywhere?
+        hal0 slot swap <throwaway> --model <a good model>
+        systemctl cat hal0-slot@<throwaway> | grep -o -- '--model [^ ]*'
+      Clean up the throwaway slot afterwards.
+    expect: >-
+      State reflects reality (failed/crashed, not warming); the start-limit death is surfaced
+      in status/doctor; swap writes the NEW model to the quadlet even on an unhealthy slot.
+
+  - id: memory-retain-dead-letter
+    issue: 1792
+    from: v1.0.0-rc.4
+    severity: minor
+    tier: judgment
+    lane: memory
+    summary: >-
+      On a fresh install, HINDSIGHT_API_LLM_MODEL=hal0/utility targets a model-less clean-seed
+      slot, so every retain's fact extraction 404s (dispatch.no_route) through its retries and
+      dead-letters permanently, with no auto-retry once a model does appear.
+    repro: |
+      On the fresh box BEFORE loading any model into the utility slot, trigger a retain, then
+      confirm it fails. Then give utility a model, load it, and wait.
+        hal0 memory status
+        hal0 memory ops list      # dead letters from the no-model window?
+    expect: >-
+      Either retains queue rather than dead-letter while no model is available, or dead-letters
+      are retried automatically once routing recovers. A permanent silent loss of the user's
+      first memories is the regression.
+
+  - id: hermes-smoke-ok-over-failures
+    issue: 1793
+    from: v1.0.0-rc.4
+    severity: major
+    tier: mechanical
+    lane: hermes
+    summary: >-
+      Hermes provisioning recorded 2/6 smoke-test failures (chat timeout, memory roundtrip
+      no-marker) and still reported phase `status=ok`. Reporting-integrity defect — it hid a
+      real smoke failure for an entire release.
+    repro: |
+      Read the provisioning record on the fresh box and compare the phase status against its
+      own recorded sub-results.
+    expect: >-
+      A phase with recorded failures reports warn/fail, never ok.
+
+  - id: fact-extraction-strips-literals
+    issue: 1794
+    from: v1.0.0-rc.4
+    severity: minor
+    tier: judgment
+    partial_fix: true
+    summary: >-
+      Fact extraction strips literal values, so stored markers and IDs were unrecoverable via
+      recall even though the raw documents held them. Fixed hal0-side with a document fallback;
+      a durable fix needs server-side content search in the Hindsight engine (no such endpoint
+      exists yet).
+    lane: memory
+    repro: |
+      Retain "the CT151 validation marker is MARKER-7734", wait for the op to complete, then
+      recall "what is the CT151 validation marker?" and also search for the literal MARKER-7734.
+    expect: >-
+      The literal comes back via the document fallback. Note explicitly whether it came from
+      extracted facts or the fallback — the fallback is the workaround, not the fix.
+
+  - id: hermes-polish-rollup
+    issue: 1795
+    from: v1.0.0-rc.4
+    severity: rollup
+    tier: mechanical
+    lane: hermes
+    summary: >-
+      Four hermes rough edges: dashboard frontend not built while status claimed "dashboard
+      reachable" (status string corrected; the frontend itself is an upstream build artifact
+      not shipped in the wheel — permanently out of scope hal0-side), installer-wired session
+      hook skipped as not-allowlisted, plugin kind `provider` unknown and downgraded to
+      `standalone`, per-session dispatch.no_route for hal0/agent before fallback.
+    repro: |
+      Check the hermes unit status string, the session-hook allowlist, the plugin kind
+      resolution, and grep the hermes journal for dispatch.no_route on a fresh session.
+    expect: >-
+      Status strings are truthful; hook is allowlisted; plugin kind resolves; no per-session
+      no_route noise. The unbuilt frontend itself is expected — only a dishonest status string
+      about it is a regression.
+
+  - id: cli-api-polish-rollup
+    issue: 1796
+    from: v1.0.0-rc.4
+    severity: rollup
+    tier: mechanical
+    lane: cli
+    summary: >-
+      Fourteen CLI/API rough edges from the rc.4 sweep.
+    repro: |
+      Re-run each, comparing against the rc.4 symptom:
+        hal0 update --check        # not a placeholder "X -> 0.0.0 (stable)" with a zeroed digest
+        hal0 system-info           # cores/threads must not be impossible (host cores leaking in)
+        hal0 doctor                # must not print warnings then claim "all checks passed"
+        hal0 slot metrics          # formatted numbers, not raw 1223.69921875
+        hal0 bench results         # prints something
+        hal0 system-info           # no debug log line leaking above the table
+        curl $API/api/memory/banks/doesnotexist/stats   # 404, not 200 with zeroed stats
+        curl $API/health $API/openapi.json $API/docs    # SPA catch-all must not shadow these
+        hal0 mcp status hal0-admin # advertised connect URL must be POSTable (needs /mcp suffix)
+    expect: All fourteen corrected. Report per-item, not as one verdict.
+
+  - id: ui-polish-rollup
+    issue: 1797
+    from: v1.0.0-rc.4
+    severity: rollup
+    tier: mechanical
+    lane: ui
+    summary: >-
+      Six dashboard rough edges from the rc.4 Playwright sweep.
+    repro: |
+      Drive the dashboard with Playwright and check:
+        - bench worker badge agrees with `systemctl is-active hal0-bench-worker`
+        - Settings shows a hal0 version, not "—"
+        - telemetry does not present HOST GPU stats as local capacity on a GPU-less box
+        - benchmarks header has no empty interpolations ("· GB · hal0 v")
+        - pluralisation ("1 banks")
+        - nav rail icons have accessible names
+    expect: All six corrected.

--- a/tests/release-validation/reports/v1.0.0-rc.4.md
+++ b/tests/release-validation/reports/v1.0.0-rc.4.md
@@ -1,0 +1,109 @@
+<!--
+Backfilled from /mnt/mintdev/artifacts/hal0-rc4-validation-2026-08-09.md.
+This run predates the validation kit — it was driven by three ad-hoc workflows
+(rc4-readonly-sweep, rc4-stateful-lane, rc4-verify-majors) whose briefs became
+tests/release-validation/lanes/. Kept here as the baseline the next report compares against.
+kit_version: 0 (pre-kit)
+-->
+
+# hal0 v1.0.0-rc.4 — fresh-install release validation (CT151)
+
+**Date:** 2026-08-09 · **Box:** CT151 `hal0-rc2-fresh-2604`, 10.0.1.151, Ubuntu 26.04 unprivileged LXC, CPU-only (no GPU passthrough), 8 cores / 16 GB RAM · **Build:** `hal0 1.0.0rc4`, installed fresh ~20:45 UTC by the operator.
+
+**Method:** three orchestrated workflows against the live box —
+
+1. `rc4-readonly-sweep` — 5 parallel agents: REST API surface (27 checks), CLI surface (28), MCP servers (14), Hermes integration (11), dashboard UI via Playwright (14).
+2. `rc4-stateful-lane` — 6 serialized agents: slot lifecycle, OpenAI-surface routing, brain steward, memory subsystem, capabilities + registry mutations, Hermes end-to-end.
+3. `rc4-verify-majors` — 7 adversarial verifiers re-reproducing every major finding before filing.
+
+Test models staged into the operator-default store `/mnt/ai-models` (box has no NFS mount; files rsynced): `qwen3.5-0.8b` (chat), `qwen3-embedding-0.6b-q8`, `jina-reranker-v1-tiny-en-q8`, `qwen3-zero-coder-v2-0.8b-f16`, `hal0-brain-sft-q8-rocmfpx` (1.1 GB).
+
+**Headline totals:** 94 read-only checks (64 pass) + 60 stateful checks. Findings after verification: see tables below. GitHub issues filed are linked inline.
+
+---
+
+## Fix wave outcome (2026-08-10)
+
+All eleven filed issues were fixed and merged the same night — PRs #1798–#1808, one per issue, each in its own worktree with tests, lint, and format-check, reviewed before merge (the Codex review bot was out of quota, so review was done in-session). **Every issue #1787–#1797 is closed.**
+
+Notable results beyond the fixes themselves:
+
+- **#1790's root cause was deeper than the report.** The FPX-on-CPU segfault traced back to `hardware.probe._amd_gpu_info` hardcoding `vulkan_capable=True` on any AMD DRM sysfs sighting — and an unprivileged LXC sees the host's sysfs with no `/dev/dri` passed through. Fixed by gating on a real render node, plus a 422 guard refusing ROCmFPX quants on non-FPX runners.
+- **#1793's fix surfaced a latent bug:** two tests asserted "every phase is ok/skip", which the truthful WARN status broke — revealing a real smoke failure the always-ok bug had been hiding all along.
+- **The merge train caught a cross-PR integration break** CI on the individual branches could not: #1808's new template path called `resolve_profile_flags()` on a code path #1799's guard test reaches with a Mapping profile → `AttributeError`. Fixed on the branch before merge.
+- **#1794 is partial by necessity:** the hal0-side document fallback landed, but a durable fix needs server-side content search in the Hindsight engine (no such endpoint exists). Documented on the issue.
+- **#1795 item 1 was infeasible hal0-side:** hermes's dashboard frontend is an upstream build artifact not shipped in the wheel. The misleading "dashboard reachable" status string was corrected instead.
+- CHANGELOG entries were consolidated into PR #1809 after per-PR hunks caused repeated merge conflicts (the pattern #1545 tracks).
+
+**Brain backend question settled:** keep `gpu-vulkan` — it is already the shipped seed and CT105 prod default. Fresh A/B on the current brain model + ade07ba runner: vulkan wins decode +12% (114.0 vs 101.4 tok/s, tight variance), rocm wins prefill +63% (3837 vs 2350). Decode is what interactive steward chat feels, and there is no production token-ratio telemetry to argue prefill dominance (the brain slot runs without `--metrics`). Revisit if agentic prefill load is later shown to dominate.
+
+**Re-validation still required before GA:** these fixes were verified by unit/integration tests and CI, not by a fresh end-to-end install. A clean CT151 rollback + rc.5 install should re-run the validation lanes before tagging.
+
+---
+
+## Verdict (as of rc.4, pre-fix)
+
+**Not ready to tag 1.0 GA as-is.** One GA-blocker plus a cluster of first-run breakages:
+
+- **GA-blocker — #1787:** profile flags never reach llama-server argv for unstamped models, on **every backend** — `/v1/embeddings` and `/v1/rerank` 501 while the capability slots report ready; memory reranker path dead. Verified on this box and cross-checked read-only on CT105 (rocm).
+- **Major, all installs — #1788:** slot `ctx_max` / `/v1/models context_length` advertise the raw slot-TOML context (65536) while the resolved effective window is 32768.
+- **Major, CPU-only / custom-runner installs — #1789, #1790, #1791:** brain steward silently strips tools and fabricates platform state (image-identity gate); FPX default brain model segfault-loops on CPU; crash-loop lifecycle (stuck `warming`, silent start-limit death, swap-reapplies-old-model).
+- **First-run friction — #1792, #1793:** memory retains dead-letter permanently in the no-model window with no auto-retry; hermes provision smoke reports `ok` over recorded failures.
+- **Memory trust — #1794:** fact extraction strips literal values; stored markers/IDs unrecoverable via recall even though raw docs hold them.
+
+**Minimum rc.5 gate:** #1787 and #1788 (affect every install), #1793 (reporting integrity). If CPU-only installs are a supported GA target, add #1789/#1790/#1791. #1792/#1794 are strong candidates but have workarounds.
+
+**What held up well:** installer completed cleanly end-to-end; REST surface robust (no 500s anywhere, clean structured 4xx, 281 routes); slot lifecycle (create/load/swap/restart/unload/delete) solid on healthy slots; OpenAI chat surface correct incl. SSE streaming, legacy `/v1/completions`, concurrency; memory retain/recall/search works once a chat model is loaded, with lossless manual op retry; MCP JSON-RPC protocol correct (180+26 tools); dashboard renders every page with live data; hermes plain chat round-trips.
+
+---
+
+## Filed issues
+
+| # | Severity | Title |
+|---|----------|-------|
+| [#1787](https://github.com/Hal0ai/hal0/issues/1787) | **GA-blocker** | profile flags never reach llama-server argv — embeddings/rerank 501 while ready |
+| [#1788](https://github.com/Hal0ai/hal0/issues/1788) | major | ctx_max//v1/models advertise raw TOML context, not resolved window |
+| [#1789](https://github.com/Hal0ai/hal0/issues/1789) | major | brain native-tools gate keys on image identity → silent tool strip + fabrication |
+| [#1790](https://github.com/Hal0ai/hal0/issues/1790) | major | CPU-only install defaults brain to FPX quant that segfaults the runner |
+| [#1791](https://github.com/Hal0ai/hal0/issues/1791) | major | crash-looping slot lifecycle: stuck warming, silent start-limit death, swap misapply |
+| [#1792](https://github.com/Hal0ai/hal0/issues/1792) | minor | memory retains dead-letter in the no-model window, no auto-retry |
+| [#1793](https://github.com/Hal0ai/hal0/issues/1793) | major | hermes provision smoke_tests reports ok over recorded failures |
+| [#1794](https://github.com/Hal0ai/hal0/issues/1794) | minor | fact extraction strips literal values — unrecoverable via recall |
+| [#1795](https://github.com/Hal0ai/hal0/issues/1795) | rollup | hermes polish ×4 (frontend, hook, plugin kind, no_route) |
+| [#1796](https://github.com/Hal0ai/hal0/issues/1796) | rollup | CLI/API polish ×14 |
+| [#1797](https://github.com/Hal0ai/hal0/issues/1797) | rollup | UI polish ×6 |
+
+**Reclassified by adversarial verification (not filed as bugs):**
+- Dispatcher answering unknown model ids from the `agent` anchor slot — **by design** (ADR-0023 Rule 9); substitution is disclosed in the response `model` field and journal. No strict-404 knob exists; noted as a possible enhancement.
+- MCP 421 "Invalid Host header" from LAN — **by design** (deliberate localhost-only DNS-rebinding floor for `/mcp/*`); documented fix `HAL0_MCP_ALLOWED_HOSTS` in api.env. The wrong connect-URL string is real → rolled into #1796.
+- Hermes memory-turn "hang" — unreproduced under controlled retest (store 53 s, recall 15 s on CPU); original 240 s timeout consistent with 0.8B CPU slowness, not deadlock.
+- "Wrong-model passthrough serves brain" detail from stage 2 — fresh repro routes via `legacy_slot:agent`, matching the documented fallback.
+
+**Known-issue dupes (not re-filed):** slot logs empty (LogDriver=none) → #1429; load/restart error surfacing → #1424 (referenced from #1791); hindsight/doctor status mismatch → #1543 (referenced from #1792).
+
+## Pre-verification observations log
+
+### Setup-phase findings (manually reproduced)
+
+1. **FPX brain model segfaults on CPU-only install; brain slot crash-loops out of the box.** Fresh install pulled `hal0-brain-sft-q8-rocmfpx` as brain default; runner exits 139 (SIGSEGV) ~5 s into load, 842 MB peak. Same container + plain `Qwen3.5-0.8B-UD-Q4_K_XL.gguf` loads fine and serves. Systemd hits start-limit after 5 tries; slot permanently down; nothing surfaces it.
+2. **Slot state stuck `warming` while unit `failed`.** `hal0 status` and `/api/slots` report `warming` indefinitely during/after a crash loop.
+3. **`hal0 slot swap`/`load` on a crash-looping slot:** CLI `ReadTimeout`, and swap rewrote the quadlet with the *old* model. On a **healthy** slot swap works correctly (retested both directions, verified quadlet + served model) — narrowed to crash-loop interaction.
+4. **Brain model file vanished post-pull (unexplained).** Pull job record: completed 20:49, sha256 verified, 1.14 GB at `/mnt/ai-models/chat/hal0-brain-sft-q8-rocmfpx/model.gguf`; dir empty by 21:12. Possibly an operator UI action ~20:57 (browser at 10.0.1.125 polling `/api/models/pulls`). Not filed — cause unproven.
+5. `chat-template seed skipped: [Errno 13] Permission denied: '/mnt/ai-models/chat-templates'` — hal0-api (uid `hal0`) can't write a root-owned store; only surfaced in journal.
+
+### Read-only sweep
+
+- **API (20/27 pass):** `/api/memory/banks/{id}/stats` returns 200 zeroed stats for nonexistent banks; brain advertises ctx 65536 while llama-server runs `--ctx-size 32768`; slot metadata self-contradicts (`health_ok=false`, `image_status=missing` on ready+healthy slot); SPA catch-all serves 200 HTML at `/health`, `/openapi.json`, `/docs` (real ones under `/api/`); no CORS; version reads `1.0.0rc4` (PEP 440) everywhere.
+- **CLI (18/28 pass):** `hal0 update --check` renders placeholder manifest as "1.0.0rc4 → 0.0.0 (stable) up to date" with zeroed digest; `system-info` reports impossible "cores/threads 16 / 8" (host cores leak into container view, nproc=8); `doctor` prints 6 `!!` warnings then "OK all pre-flight checks passed"; `slot logs` returns "no logs" for healthy container slots (LogDriver=none — already filed as #1429); `slot metrics` prints raw float `1223.69921875`; `bench results` prints nothing; debug log line leaks above `system-info` table.
+- **MCP (8/14 pass):** advertised connect URL `http://127.0.0.1:8080/mcp/admin` returns 405 — real endpoint `/mcp/admin/mcp`; LAN access rejected 421 "Invalid Host header" (FastMCP DNS-rebinding protection) despite anonymous-open REST API; tool arg errors return `isError:false`; `serverInfo.version` reports FastMCP 1.28.1 not hal0 version; `shared` bank shows 2 failed operations on a fresh box.
+- **Hermes (7/11 pass):** hindsight fact-extraction 404-loops (29 occurrences in 2 h); provision smoke tests recorded 2/6 failures (chat timeout, memory roundtrip no marker) yet phase `status=ok`; hermes dashboard (:9119) has no built frontend — `{"error":"Frontend not built…"}` on every route while unit status says "dashboard reachable"; installer-wired session hook skipped as not-allowlisted; plugin kind `provider` unknown → downgraded to `standalone`.
+- **UI (11/14 pass, Playwright):** bench worker badge "worker: stopped" while `hal0-bench-worker` active; Settings "hal0 version —"; host GPU telemetry (igpu 100% · 83 °C, 116 GB GTT pool) presented as local capacity on a GPU-less 16 GB CT; benchmarks header renders "· GB · hal0 v" (empty interpolations); "1 banks"; nav rail icons lack accessible names.
+
+### Stateful lane
+
+- **Slot lifecycle (9/11 pass):** edit/load/restart/unload/create/delete all work; delete leaves empty `/var/lib/hal0/slots/<name>/`; `slot capacity` books CPU memory under "VRAM MB" (RAM MB 0.0); crash-looped slot found permanently down at stage start (start-limit, no recovery/alert).
+- **Routing:** chat non-streaming + streaming + legacy `/v1/completions` OK; clean 404 JSON for unknown models. **`/v1/embeddings` 501** ("start with --embeddings") and **`/v1/rerank` 501** — capability slots report ready but the CPU-backend launch drops profile flags (`--embedding`, `--reranking`); memory reranker path dead. **Dispatcher passthrough serves the wrong model** — request for a registered-but-unloaded model returns 200 generated by the brain slot's 0.8 B. `/v1/models` id set inconsistent with servable refs.
+- **Brain steward:** chat works (CLI + `/api/brain/chat`); **tool rounds never engage** — platform-state questions answered with confident fabrications (invented slots) whether `tool_model` target is offline or loaded; `read_only` guard unreachable; `/api/brain/chat` has no requestBody schema and coerces malformed JSON to `{}`.
+- **Memory:** retain/recall/search work once `utility` slot has a model; root cause of fresh-install failure: `HINDSIGHT_API_LLM_MODEL=hal0/utility` targets a model-less clean-seed slot; failed ops retryable (recovered both dead-letters); idle reaper (300 s) silently evicts slots incl. brain; `agents` bank only created on hal0-api restart; `/api/memory/add` wrong-field error surfaces as `system.internal`.
+- **Capabilities/registry:** enable/set flows work; `model add` misclassifies reranker gguf as `chat` and derives id from arch header (`jina-bert-implementation`); `model rm` behavior verified; no default marker in `model list`; **no CLI for profiles** (17 server-side profiles, full CRUD API, `hal0 profile` doesn't exist).
+- **Hermes e2e:** plain chat round-trips (~18 s on CPU); **memory-tool turns hang 4 min+/timeout with no reply**; store landed only in local `USER.md`, never recallable — roundtrip broken; recall hallucinated; per-session `dispatch.no_route` for `hal0/agent` before fallback; reprovision smoke confirmed "ok despite failures" reporting.

--- a/tests/release-validation/templates/report.md
+++ b/tests/release-validation/templates/report.md
@@ -1,0 +1,71 @@
+# hal0 <VERSION> — release validation
+
+**Date:** <DATE> · **Kit version:** <KIT_VERSION> · **Mode:** <report|file>
+**Boxes:** <box id, hostname, IP, OS, hardware, install method, from-version for update boxes>
+
+**Method:** <phases actually run, agent count per phase, model tier per phase. Note any lane
+skipped and why.>
+
+**Test models staged:** <ids and sizes>
+
+**Headline totals:** <N read-only checks (M pass) · N stateful checks (M pass) · N regression
+probes (M fixed / M regressed / M partial / M blocked)>
+
+---
+
+## Verdict
+
+<Ship / do not ship, in one sentence, followed by the specific blockers.>
+
+**Minimum gate for the next candidate:** <issue numbers and why each one is on the list.>
+
+**What held up well:** <the negative space — surfaces that were exercised and were solid. This
+section is what stops the report reading as if the product is on fire, and it tells the next
+run which lanes are earning their keep.>
+
+---
+
+## Regression results
+
+| Regression | Issue | Result | Evidence |
+|---|---|---|---|
+
+<Every entry in regressions.yaml appears here. `blocked` entries must say what blocked them.>
+
+---
+
+## Filed issues
+
+| # | Severity | Title |
+|---|---|---|
+
+**Reclassified by adversarial verification (not filed):**
+
+<Finding, verdict, and the reasoning that killed or downgraded it. These become
+known-issues.yaml entries with a `why:` — write them so a future agent does not relitigate.>
+
+**Known-issue dupes (not re-filed):** <finding → existing issue number>
+
+---
+
+## Lane reports
+
+### Read-only sweep
+
+<Per lane: pass/total, then the findings with exact command and decisive output line.>
+
+### Stateful lane
+
+<Per lane, in execution order.>
+
+### Update lane
+
+<Before/after diff summary, then findings.>
+
+---
+
+## Kit changes proposed
+
+<Output of the curation phase: new known-issues entries, new regression entries, lane brief
+additions, checks worth promoting into pytest or scripts/release-test.sh. Applied by PR, not
+silently.>


### PR DESCRIPTION
## What

Extracts the three ad-hoc workflows used to validate `v1.0.0-rc.4` into a versioned, replicable validation suite, ahead of the rc.5 cut.

- **`tests/release-validation/`** — the kit: `kit.toml` (lane registry, model tier per phase), `boxes.toml` (the test fleet, with each box's gotchas as operational instructions), `known-issues.yaml` (do-not-re-report list, including the four rc.4 candidates that adversarial verification ruled by-design), `regressions.yaml` (all eleven rc.4 findings, #1787–#1797, as mandatory re-probes), 13 lane briefs, and a report template.
- **`.claude/workflows/rc-validate.js`** — orchestration: preflight gate → concurrent lane sweep (read-only parallel, stateful serialised, update box in parallel, regression probes) → triage → adversarial verification → report → optional issue filing → kit curation.
- **`.claude/workflows/rc-fix-fleet.js`** — the optional fix wave, only run when explicitly asked for.
- **`tests/release-validation/reports/v1.0.0-rc.4.md`** — the rc.4 report backfilled as the comparison baseline.

## Why

rc.4's validation found a GA-blocker and ten other issues, but the method lived only in a session transcript. This makes it a repo artifact that improves per release instead of being re-derived.

Two mechanisms make it compound:

1. **Regression register.** Every finding filed in a release is re-probed on every release after it, forever, until it is promoted into `pytest` or `scripts/release-test.sh`. rc.4's fixes were verified by unit tests and CI, *not* by a fresh end-to-end install — rc.5 has to prove them gone on a real box.
2. **Curation phase.** The last phase of each run writes back new known-issues, promotes filed findings into the regression register, adds checks agents invented to the brief that should have held them, and flags checks stable enough to leave the kit for CI. It produces a diff for review, never a silent commit.

Process lessons from rc.4 are encoded rather than remembered: serialise stateful work per box, batch fix agents six wide, no per-PR CHANGELOG hunks, and run a merge-train integration check that per-branch CI cannot.

## Model tiers

sonnet for lane sweeps, fable for mechanical regression repros, opus for triage / adversarial verification / synthesis. Adversarial verification is kept because it earned its place — four of rc.4's would-be issues were refuted or reclassified before filing.

## How it was verified

`node --check` on both workflow scripts; `tomllib` parse on both TOML files; `yaml.safe_load` on both YAML files. Documentation and orchestration only — no product code changes, no test-suite impact.

## Out of scope / follow-up

- The kit has no GPU fresh-install box to run against. Every fresh-install finding touching backend selection, profile flags, hardware probing, or native tool-calling therefore carries a *judgement* about GPU applicability rather than a measurement. Recorded as a standing gap in `boxes.toml`; worth closing before GA.
- The kit is unexercised. Its first real run is rc.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)