### PR TITLE
fix(slots): emit --metrics so llama-server /metrics stops 501ing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ applying. Add those subsections to a version's section to surface them; see
 
 ### Fixed
 
+- Slots now launch llama-server with `--metrics`, so `/metrics` stops
+  returning 501 on every slot. `--metrics` was classified as a slot-owned
+  operational flag (`seed_profiles.toml` header comment) but the slot side
+  was never implemented — no typed `SlotConfig` field and nothing emitted
+  it — so `hal0.slots.metrics_collect.llama_metrics()` scraped a 501 on
+  every poll and swallowed it by design, leaving `hal0 slot metrics`
+  showing `Reqs 0` forever (`KV%` worked because it's synthesized from
+  `/slots`, which is on by default). New `SlotConfig.metrics` (default
+  `true`) rides the same trusted `slot_hardware` argv segment as
+  `-ngl`/`--threads`; the endpoint is loopback-only and never proxied by
+  the gateway. `metrics_collect.llama_metrics()` now also logs once at
+  debug per port on a 501 instead of degrading fully silently. Live tok/s
+  is a separate, already-working code path (the dispatcher's streaming
+  instrumentation) and is unaffected either way — this fixes the request
+  counters and queue-depth gauges (#1810).
 - Every seeded profile now requests `-fa auto` instead of forcing `-fa on`
   (#1811). Seeds are generic templates, and since #1787 they reach ~93% of
   registered models (the unstamped ones), so a forced Flash Attention kernel

--- a/src/hal0/config/schema.py
+++ b/src/hal0/config/schema.py
@@ -395,6 +395,20 @@ class SlotConfig(BaseModel):
             "``--threads`` and lets the runtime pick its own default."
         ),
     )
+    metrics: bool = Field(
+        default=True,
+        description=(
+            "METRICS — emits ``--metrics``, enabling llama-server's "
+            "``/metrics`` endpoint (Prometheus counters: tok/s, request "
+            "counts, …). Authoritative on the slot (spec-hw-slot-ownership "
+            "§2/§4 — an operational flag, never a profile concern). Default "
+            "True: the endpoint is loopback-only (127.0.0.1, never proxied "
+            "by the gateway) and the per-request counter overhead is "
+            "negligible. Without it, ``/metrics`` 501s and "
+            "``hal0.slots.metrics_collect`` can never populate tok/s or "
+            "request counts (#1810)."
+        ),
+    )
     binary: str = Field(
         default="",
         description=(

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -875,6 +875,7 @@ def _llama_argv_segments(
     slot_n_gpu_layers: int | None = None,
     slot_threads: int | None = None,
     slot_parallel: int | None = None,
+    slot_metrics: bool = True,
     extra_args: str | None = None,
     slot_profile_flags: str = "",
     slot_profile_template_flags: str = "",
@@ -888,8 +889,9 @@ def _llama_argv_segments(
 
     Ownership split (spec-hw-slot-ownership §2, reversing spec-flags-ownership
     §5): the SLOT owns the physical hardware grid (NGL → ``-ngl``, THREADS →
-    ``--threads``; ``-dev`` rides the GPU-visibility path, not here) as typed
-    fields, emitted in a TRUSTED ``slot_hardware`` segment. The MODEL still owns
+    ``--threads``, METRICS → ``--metrics``; ``-dev`` rides the
+    GPU-visibility path, not here) as typed fields, emitted in a TRUSTED
+    ``slot_hardware`` segment. The MODEL still owns
     the logical, device-agnostic tune — free-form ``defaults.extra_args``
     (``model_extra_args`` segment, still screened against the §21.7 managed-arg
     denylist by :func:`~hal0.slots.argv.resolve_argv`). The old ``profile``
@@ -978,6 +980,12 @@ def _llama_argv_segments(
         slot_hw_tokens += ["-ngl", str(int(slot_n_gpu_layers))]
     if slot_threads is not None and int(slot_threads) > 0:
         slot_hw_tokens += ["--threads", str(int(slot_threads))]
+    # METRICS (#1810): enables llama-server's ``/metrics`` endpoint, which
+    # hal0.slots.metrics_collect.llama_metrics() scrapes for tok/s + request
+    # counts. Loopback-only and never proxied by the gateway, so on-by-default
+    # is safe; SlotConfig.metrics lets an operator turn it off.
+    if slot_metrics:
+        slot_hw_tokens += ["--metrics"]
 
     chat_tokens = ["--chat-template-file", chat_template_path] if chat_template_path else []
     mmproj_tokens = ["--mmproj", mmproj] if mmproj else []
@@ -1023,6 +1031,7 @@ def _llama_launch_plan(
     slot_n_gpu_layers: int | None = None,
     slot_threads: int | None = None,
     slot_parallel: int | None = None,
+    slot_metrics: bool = True,
     env: dict[str, str] | None = None,
     slot_profile_flags: str = "",
     slot_profile_template_flags: str = "",
@@ -1049,6 +1058,7 @@ def _llama_launch_plan(
         slot_n_gpu_layers=slot_n_gpu_layers,
         slot_threads=slot_threads,
         slot_parallel=slot_parallel,
+        slot_metrics=slot_metrics,
         extra_args=extra_args,
         slot_profile_flags=slot_profile_flags,
         slot_profile_template_flags=slot_profile_template_flags,
@@ -1779,6 +1789,11 @@ def _resolve_llama_scalars(
     # (_llama_argv_segments' slot_hardware segment) renders -ngl / --threads.
     slot_n_gpu_layers = slot_cfg.get("n_gpu_layers")
     slot_threads = slot_cfg.get("threads")
+    # METRICS (#1810, spec-hw-slot-ownership §2/§4): typed slot field, default
+    # on. ``slot_cfg`` may be a hand-built dict/pre-migration TOML predating
+    # the field, so default to True (not to a falsy .get() miss) when absent.
+    slot_metrics_raw = slot_cfg.get("metrics")
+    slot_metrics = True if slot_metrics_raw is None else bool(slot_metrics_raw)
 
     # Multi-GPU pinning (SlotConfig.gpu_index): affects env/devices only —
     # never argv — so launch/preview argv parity is untouched.
@@ -1806,6 +1821,7 @@ def _resolve_llama_scalars(
         # reach the argv chain via _llama_argv_segments' slot_hardware segment.
         "slot_n_gpu_layers": slot_n_gpu_layers,
         "slot_threads": slot_threads,
+        "slot_metrics": slot_metrics,
         # slot_parallel stays inert (spec-flags-ownership §2 — sunset).
         "slot_parallel": None,
         # HARDWARE CLASS + GPU-vendor discriminator (spec-hw-slot-ownership §2):
@@ -1942,6 +1958,7 @@ class ContainerProvider(Provider):
             slot_n_gpu_layers=scalars["slot_n_gpu_layers"],
             slot_threads=scalars["slot_threads"],
             slot_parallel=scalars["slot_parallel"],
+            slot_metrics=scalars["slot_metrics"],
             env=merged_env or None,
             slot_profile_flags=scalars["slot_profile_flags"],
             slot_profile_template_flags=scalars["slot_profile_template_flags"],
@@ -2668,6 +2685,7 @@ def _resolve_slot_argv(
         slot_n_gpu_layers=scalars["slot_n_gpu_layers"],
         slot_threads=scalars["slot_threads"],
         slot_parallel=scalars["slot_parallel"],
+        slot_metrics=scalars["slot_metrics"],
         extra_args=scalars["extra_args"],
         slot_profile_flags=scalars["slot_profile_flags"],
         slot_profile_template_flags=scalars["slot_profile_template_flags"],

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -339,6 +339,13 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
         binary_val = cfg.get("binary")
         entry["binary"] = binary_val if isinstance(binary_val, str) else None
         entry["image_pin"] = cfg.get("image_pin")
+        # METRICS (#1810) — completes the HW-grid lift: SlotConfig.metrics
+        # controls whether --metrics reaches llama-server's argv. Surface it
+        # so the edit-drawer can show/toggle it instead of it being
+        # write-only via the raw /config endpoint. Absent → True (schema
+        # default), same fallback the argv-emission side uses.
+        metrics_val = cfg.get("metrics")
+        entry["metrics"] = True if metrics_val is None else bool(metrics_val)
         # Issue #548: expose rope_freq_base so the Edit drawer can dirty-track
         # it and avoid clobbering the on-disk value on unrelated saves.
         # Absent (None) is surfaced as-is — frontend treats null as "use

--- a/src/hal0/slots/metrics_collect.py
+++ b/src/hal0/slots/metrics_collect.py
@@ -38,7 +38,19 @@ resolve (``hal0.metrics.sampler`` imports ``_scrape_llama_metrics`` from there).
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
+
+log = logging.getLogger(__name__)
+
+# One-shot-per-port 501 notice (#1810): llama_metrics() is polled every few
+# seconds by collect_local(), and its contract is "empty dict on any
+# failure" so callers can merge unconditionally — that same fail-soft
+# design let a slot launched without ``--metrics`` degrade completely
+# silently forever (the root cause of #1810). Warn once per port per
+# process instead of every poll, so a slot missing the flag is visible in
+# the log without spamming it.
+_metrics_501_warned: set[int] = set()
 
 
 def tps_from_events(events: Any, window_s: float = 5.0) -> float:
@@ -201,10 +213,19 @@ async def llama_metrics(port: int) -> dict[str, Any]:
     # Duck-typed: any object with a status_code + text attr (real httpx
     # Response or a test stub) passes; exceptions returned by gather()
     # fall through to the synthesis branch below.
-    if (
-        not isinstance(metrics_resp, BaseException)
-        and getattr(metrics_resp, "status_code", 0) == 200
-    ):
+    metrics_status = (
+        0 if isinstance(metrics_resp, BaseException) else getattr(metrics_resp, "status_code", 0)
+    )
+    if metrics_status == 501 and port not in _metrics_501_warned:
+        # llama-server's canned reply when started without --metrics
+        # (#1810 root cause). Warn once per port so the gap is visible
+        # instead of silently degrading to tok/s '—' forever.
+        _metrics_501_warned.add(port)
+        log.debug("slot.metrics_endpoint_disabled", extra={"port": port})
+    elif metrics_status == 200:
+        _metrics_501_warned.discard(port)
+
+    if metrics_status == 200:
         for line in metrics_resp.text.splitlines():
             line = line.strip()
             if not line or line.startswith("#"):

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1248,6 +1248,62 @@ async def test_scrape_llama_metrics_clamps_overrun(
     assert out["kv_cache_usage"] == pytest.approx(1.0)
 
 
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_501_returns_empty_and_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1810: a slot launched without ``--metrics`` gets llama-server's canned
+    501. The scrape still degrades to {} (callers merge unconditionally), but
+    logs a one-shot debug notice per port instead of staying fully silent —
+    a second scrape on the same port must NOT log again."""
+    from hal0.slots import metrics_collect
+    from hal0.slots.metrics_collect import llama_metrics
+
+    metrics_collect._metrics_501_warned.clear()
+    resp_501 = _StubResponse(
+        status_code=501,
+        text='{"error":{"code":501,"message":"This server does not support metrics '
+        'endpoint. Start it with `--metrics`"}}',
+    )
+    slots_json = [{"id": 0, "n_ctx": 4096, "is_processing": False}]
+    _patch_httpx(monkeypatch, resp_501, _StubResponse(json_data=slots_json))
+
+    caplog_records: list[str] = []
+
+    class _Recorder:
+        def debug(self, msg: str, *_a: Any, **_kw: Any) -> None:
+            caplog_records.append(msg)
+
+    monkeypatch.setattr(metrics_collect, "log", _Recorder())
+
+    out1 = await llama_metrics(8087)
+    out2 = await llama_metrics(8087)
+
+    assert out1 == {}
+    assert out2 == {}
+    assert caplog_records.count("slot.metrics_endpoint_disabled") == 1
+
+
+@pytest.mark.asyncio
+async def test_scrape_llama_metrics_200_resets_501_warned_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slot that later reloads WITH ``--metrics`` clears the warned-port
+    memo, so a future regression on the same port logs again instead of
+    staying muted forever."""
+    from hal0.slots import metrics_collect
+
+    metrics_collect._metrics_501_warned.clear()
+    metrics_collect._metrics_501_warned.add(8087)
+
+    metrics_text = "llamacpp:requests_processing 0\nllamacpp:requests_deferred 0\n"
+    _patch_httpx(monkeypatch, _StubResponse(text=metrics_text), _StubResponse(json_data=[]))
+
+    await metrics_collect.llama_metrics(8087)
+
+    assert 8087 not in metrics_collect._metrics_501_warned
+
+
 # ── synthetic composite slot: truthful "serving" status ─────────────────────
 
 

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -134,6 +134,17 @@ class TestSlotConfig:
         assert s.threads == 0  # unset → launcher omits --threads
         assert s.binary == ""  # unset → HW-gated default via runner_for_backend
         assert s.image_pin is None  # no escape-hatch pin
+        # #1810: METRICS defaults ON — loopback-only endpoint, negligible
+        # overhead — so tok/s + request counts populate out of the box
+        # instead of requiring an operator to discover the flag exists.
+        assert s.metrics is True
+
+    def test_metrics_can_be_disabled(self) -> None:
+        s = SlotConfig(name="primary", port=8081, metrics=False)
+        assert s.metrics is False
+        dumped = s.model_dump()
+        assert dumped["metrics"] is False
+        assert SlotConfig(**dumped).metrics is False
 
     def test_hardware_grid_roundtrip(self) -> None:
         """Every new HW-grid field round-trips through construction + dump."""

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1715,6 +1715,28 @@ class TestSlotHardwareSegment:
         assert "slot_hardware" in labels
         assert "model_defaults" not in labels
 
+    def test_metrics_defaults_on(self) -> None:
+        # #1810: no slot_metrics kwarg → the safe default (loopback-only,
+        # negligible overhead) is ON, so --metrics reaches every slot unless
+        # an operator explicitly opts out.
+        argv = self._argv()
+        assert "--metrics" in argv
+
+    def test_metrics_explicit_true_emits_flag(self) -> None:
+        argv = self._argv(slot_metrics=True)
+        assert "--metrics" in argv
+
+    def test_metrics_explicit_false_omits_flag(self) -> None:
+        argv = self._argv(slot_metrics=False)
+        assert "--metrics" not in argv
+
+    def test_metrics_rides_the_trusted_slot_hardware_segment(self) -> None:
+        # --metrics must come from the SAME trusted, hal0-computed segment as
+        # -ngl/--threads — not a free-form/untrusted one — so it can never be
+        # smuggled or stripped by a model/profile flag save.
+        segs = dict(_llama_argv_segments(port=8081, model_path="/m.gguf", slot_metrics=True))
+        assert "--metrics" in segs["slot_hardware"]
+
 
 class TestFPXQuantRunnerGuard:
     """hal0#1790 defense-in-depth: a ROCmFPX-family quant (custom GGML tensor

--- a/tests/providers/test_container_assembler.py
+++ b/tests/providers/test_container_assembler.py
@@ -346,6 +346,7 @@ GOLDEN_MAXIMAL_ARGV: list[str] = [
     # slot_hardware (the slot's typed physical grid — wins the collision)
     "-ngl", "99",
     "--threads", "16",
+    "--metrics",
     # chat_template
     "--chat-template-file", "/etc/hal0/templates/qwen3.jinja",
     # mmproj
@@ -409,6 +410,7 @@ def test_golden_provenance_pins_which_segment_won_each_flag() -> None:
         ("--jinja", None, "model_extra_args"),
         ("-ngl", "99", "slot_hardware"),
         ("--threads", "16", "slot_hardware"),
+        ("--metrics", None, "slot_hardware"),
         ("--chat-template-file", "/etc/hal0/templates/qwen3.jinja", "chat_template"),
         ("--mmproj", "/var/lib/hal0/models/qwen3-4b/mmproj.gguf", "mmproj"),
     ]
@@ -443,9 +445,21 @@ def test_golden_launch_plan_command_equals_the_golden_argv() -> None:
 
 def test_golden_minimal_argv() -> None:
     """The floor: nothing but a port and a model path. Pins that no segment
-    leaks a default token in when its input is absent."""
-    argv = resolve_argv(_llama_argv_segments(port=8081, model_path="/m.gguf")).argv
+    leaks a default token in when its input is absent. ``slot_metrics``
+    defaults True (#1810 — metrics-on is the safe default), so it is
+    explicitly disabled here to keep this the true zero-hardware-grid floor;
+    see ``test_golden_minimal_argv_defaults_metrics_on`` for the real default."""
+    argv = resolve_argv(
+        _llama_argv_segments(port=8081, model_path="/m.gguf", slot_metrics=False)
+    ).argv
     assert argv == ["--host", "0.0.0.0", "--port", "8081", "--model", "/m.gguf"]
+
+
+def test_golden_minimal_argv_defaults_metrics_on() -> None:
+    """#1810: with no explicit ``slot_metrics``, the slot_hardware segment
+    still emits ``--metrics`` — the default is ON, not "absent"."""
+    argv = resolve_argv(_llama_argv_segments(port=8081, model_path="/m.gguf")).argv
+    assert argv == ["--host", "0.0.0.0", "--port", "8081", "--model", "/m.gguf", "--metrics"]
 
 
 def test_golden_later_segments_beat_a_model_tune_claiming_their_flags() -> None:
@@ -477,6 +491,7 @@ def test_golden_later_segments_beat_a_model_tune_claiming_their_flags() -> None:
         "--ctx-size", "4096",
         "-ngl", "0",
         "--threads", "16",
+        "--metrics",
         "--chat-template-file", "/etc/hal0/templates/real.jinja",
         "--mmproj", "/models/real-mmproj.gguf",
     ]  # fmt: skip

--- a/tests/providers/test_runtime_launch_plan.py
+++ b/tests/providers/test_runtime_launch_plan.py
@@ -192,6 +192,9 @@ def test_render_llama_shim_matches_equivalent_plan(monkeypatch) -> None:
             "--ctx-size",
             "131072",
             *shlex.split(flags),
+            # #1810: _llama_launch_plan's slot_metrics defaults True, so the
+            # shim (which doesn't pass it) emits --metrics unconditionally.
+            "--metrics",
         ],
         mounts=[Mount(_MODEL_STORE_MOUNT, _MODEL_STORE_MOUNT, read_only=True, selinux="z")],
         devices=["/dev/kfd", "/dev/dri/renderD128"],


### PR DESCRIPTION
## Summary

- `--metrics` was classified as a slot-owned operational flag (`src/hal0/config/data/seed_profiles.toml` header, per the seeded-profile-rework design), but the slot side was never implemented: no typed `SlotConfig` field, and nothing in `_llama_argv_segments`/`_llama_launch_plan` emitted it. Every slot's llama-server therefore ran without `--metrics`, and `hal0.slots.metrics_collect.llama_metrics()` scraped a 501 on every poll — swallowed by design ("empty dict on any failure") — so `hal0 slot metrics` showed `Reqs 0` forever. `KV%` worked because it's synthesized from `/slots`, which llama-server enables by default; that contrast is what made the gap obvious.
- Added `SlotConfig.metrics: bool` (default `True`) and wired it through `_llama_argv_segments` / `_llama_launch_plan` / `_resolve_llama_scalars` (both the launch path and the preview path share this builder). `--metrics` is emitted from the slot's **trusted** `slot_hardware` argv segment — the same one that carries `-ngl`/`--threads` — never from a free-form/untrusted source, matching the ownership split the issue called out.
- Default is **on**: the endpoint is loopback-only (127.0.0.1 only, never proxied by the gateway) and the per-request counter overhead is negligible.
- `metrics_collect.llama_metrics()` now logs once at debug per port when it gets a 501, instead of degrading fully silently — the next instance of a silently-missing endpoint will be visible.
- Surfaced the new field through `slot_view.config_enrichment()` for API/UI parity with its `n_gpu_layers`/`threads`/`binary` siblings (it's writable via the raw `/config` endpoint either way — `unknown_slot_config_keys()` derives its allowlist dynamically from the pydantic model).

## Design choice: typed field vs. unconditional emission

Went with a **typed `SlotConfig.metrics` field (default `True`)**, not unconditional emission, per the issue's stated preference. It stays consistent with the existing hardware-grid pattern (`n_gpu_layers`, `threads`) and gives an operator an explicit off switch without a config-file workaround, at zero extra cost given the endpoint's loopback-only exposure.

## Does this fix tok/s end-to-end?

**Partially — and it was never actually the tok/s blocker.** Traced the full path:

- `llama_metrics()` (`metrics_collect.py`) deliberately does **not** scrape `llamacpp:predicted_tokens_seconds` from `/metrics` — that gauge is a lifetime average since server start, not a live rate (see the existing comment at `metrics_collect.py:198-205`); scraping it previously made the tok/s indicator stick at a non-zero average forever.
- Live tok/s comes from a **separate, `--metrics`-independent** path: `_instrument_streaming_throughput()` (`api/routes/v1.py`) wraps streaming completions and feeds `app.state.tps_events` → `local_tps()`/`tps_from_events()`, merged into `GET /api/slots/metrics`.
- So `--metrics` fixes `requests_processing`/`requests_deferred`/`kv_cache_usage` (queue depth + KV gauges) for llama-backed slots. Tok/s populates once a slot has served at least one **streaming** chat completion through the dispatcher — unrelated to whether `--metrics` is on. If a slot never sees streaming traffic through that route, tok/s stays `—` regardless of this fix. Not expanding scope to touch that path here — flagging it explicitly rather than silently declaring victory.

## Real-box verification (CT151, CPU test box — NOT production CT105)

Deployed the patched `hal0` package into CT151's venv (`/usr/lib/hal0/venv`), restarted `hal0-api`, and reloaded the `agent` slot (port 8081 — avoided 8083/8090, which have the known podman port-forwarding defect, #1814):

```
$ podman inspect hal0-slot-agent --format '{{.Config.Cmd}}'
[--host 0.0.0.0 --port 8081 --model ... --alias qwen3.5-0.8b --ctx-size 32768 ... -ngl -1 --metrics]

$ podman exec hal0-slot-agent curl -s 127.0.0.1:8081/metrics
# HELP llamacpp:prompt_tokens_total Number of prompt tokens processed.
# TYPE llamacpp:prompt_tokens_total counter
llamacpp:prompt_tokens_total 0
...
```

`--metrics` is present in the launched argv and `/metrics` serves real counters instead of 501, confirmed from inside the container namespace. Host-side `curl 127.0.0.1:8081/metrics` returned `No route to host` — that's the pre-existing #1814 podman port-forwarding defect on this box, not a regression from this change (confirmed it also affects `hal0 slot metrics`'s ability to reach the slot from the host `hal0-api` process right now, independent of this fix).

Before the patch, the same slot's journal showed the exact 501 from the issue:
```
Aug 10 07:28:43 ... GET http://127.0.0.1:8081/metrics
Aug 10 07:28:43 ... "HTTP/1.1 501 Not Implemented"
```

## Test plan

- [x] `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/providers/ tests/golden_paths/ tests/slots/ tests/slot_view/ tests/config/ tests/api/test_slots_routes.py -q` → 2204 passed, 9 skipped (pre-existing env skips)
- [x] Full suite: `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest -q` → 9879 passed, 15 skipped, 1 xfailed (pre-existing), 0 failures
- [x] `make lint` → clean
- [x] `uv run ruff format --check .` on touched files → clean
- [x] New/updated tests: `SlotConfig.metrics` default + round-trip (`tests/config/test_schema.py`), `--metrics` emission + trusted-segment placement + on/off toggle (`tests/providers/test_container.py::TestSlotHardwareSegment`), golden-argv literal updates (`tests/providers/test_container_assembler.py`, `tests/providers/test_runtime_launch_plan.py`), 501 one-shot debug log + reset-on-recovery (`tests/api/test_slots_routes.py`)
- [x] Real-box verification on CT151 (see above)

Closes #1810

🤖 Generated with [Claude Code](https://claude.com/claude-code)