### PR TITLE
fix(doctor,installer): stop and repair the netavark DNAT port black hole

### DIFF
--- a/installer/install.sh
+++ b/installer/install.sh
@@ -2922,6 +2922,38 @@ else
         fi
     fi
 
+    # Keep root's runtime directory pinned (#1814). podman stores every
+    # container's network namespace as a bind mount under /run/user/0/netns.
+    # That tmpfs belongs to user-runtime-dir@0.service, which logind STOPS —
+    # unmounting the tmpfs — as soon as root's last login session ends. One root
+    # SSH login/logout cycle therefore strands the netns of every container that
+    # was running at the time, and the next stop/restart of any of them fails
+    # teardown with "netavark: open container netns: ... No such file or
+    # directory" (exit 125). netavark then leaves that container's DNAT rule
+    # behind, and because nftables is first-match, the dead rule permanently
+    # shadows the live one: the slot's published port black-holes while the
+    # container inside is perfectly healthy, and neither `podman rm -f` nor
+    # `podman network reload` clears it.
+    #
+    # `loginctl enable-linger root` keeps user-runtime-dir@0 up for the life of
+    # the boot, independent of sessions, so the netns survives. Measured on a
+    # live box (podman 5.7.0): before linger, a container's SandboxKey is valid
+    # in the session that created it and dangling in the next one, and removing
+    # it leaks the rule; after linger, the SandboxKey survives the session cycle
+    # and removal is clean. Idempotent, reversible with `disable-linger`, and a
+    # no-op on boxes that already lingered. Repair for boxes that already
+    # accumulated leaks: `hal0 doctor ports --fix`.
+    if command -v loginctl >/dev/null 2>&1; then
+        if [[ -e /var/lib/systemd/linger/root ]]; then
+            info "root linger already enabled (container netns survive login cycles)"
+        elif loginctl enable-linger root >/dev/null 2>&1; then
+            info "root linger enabled — keeps /run/user/0/netns alive for podman (#1814)"
+        else
+            warn "could not enable root linger; container netns may be destroyed on root logout"
+            warn "  run: loginctl enable-linger root   (see 'hal0 doctor ports')"
+        fi
+    fi
+
     # hal0-agent@hermes — provision Hermes end-to-end on a FRESH install so the
     # box comes up with a fully-configured agent (config.yaml + MCP wiring +
     # personas + skills + install artifacts) WITHOUT a manual bootstrap step.

--- a/installer/wrappers/hal0-systemctl
+++ b/installer/wrappers/hal0-systemctl
@@ -73,6 +73,21 @@
 # sketched for this seam is NOT needed — that repair already runs as its own
 # independent root oneshot unit (packaging/systemd/hal0-podman-forward.service,
 # no User= — always root), entirely unaffected by hal0-api's User=hal0 flip.
+#
+# STALE-DNAT REPAIR (#1814): `prune-dnat` is the one verb here that touches the
+# firewall. It exists because a container that dies without netavark's teardown
+# running leaves its DNAT rule behind in inet netavark / nv_<netid>_dnat, and
+# nftables is first-match — so that dead rule permanently black-holes the port
+# for every later container. Deleting the handle is root-only, so it cannot be
+# a raw `nft` subprocess from the unprivileged API/CLI. It is NOT a general
+# "run nft" primitive: see validate_prunable_dnat below. The caller supplies a
+# port and a handle (both numeric), and the ROOT side re-derives everything
+# that matters — which chain the handle lives in, that the rule at that handle
+# really is a DNAT rule for that port, and that its target IP belongs to NO
+# running container. A handle naming a live container's rule, a rule in any
+# chain outside nv_*_dnat, or anything that is not a dport/dnat rule is
+# refused. The reachable effect is therefore bounded to "delete a netavark
+# DNAT rule that already routes nowhere".
 
 set -euo pipefail
 
@@ -478,6 +493,111 @@ validate_quadlet_body() {  # body on stdin -> QUADLET_BODY
   QUADLET_BODY="$out"
 }
 
+# ── stale-DNAT repair guard (#1814) ────────────────────────────────────────
+#
+# Sets PRUNE_CHAIN + PRUNE_TARGET_IP when (port, handle) names a rule this verb
+# is allowed to delete; dies otherwise. Fail-closed at every step.
+#
+# The unprivileged caller is trusted for NOTHING beyond two integers. In
+# particular it does not name the chain, does not hand over a rule expression,
+# and cannot make this reach a chain outside nv_*_dnat: the chain is discovered
+# HERE by walking `nft -a list table inet netavark` and tracking which chain
+# each line belongs to. The rule text at the requested handle must then match
+# the exact netavark DNAT shape for the requested port, and its target must be
+# an IP that no running container holds.
+#
+# Worst case if the hal0 account is compromised: it can delete netavark DNAT
+# rules that are already black holes — i.e. it can do nothing an unrepaired box
+# is not already doing to itself. It cannot ADD a rule, cannot REDIRECT a port
+# at an attacker-chosen address, cannot touch the filter/masquerade chains, and
+# cannot break a working published port (the live-target check refuses that
+# case explicitly). Claim only that: this is a *destructive-but-bounded* verb,
+# not a firewall-editing primitive.
+
+PRUNE_CHAIN=""
+PRUNE_TARGET_IP=""
+
+_PRUNE_DNAT_CHAIN_RE='^nv_[A-Za-z0-9_]+_dnat$'
+
+validate_port() {   # arg: a TCP/UDP port number
+  local p="$1"
+  [[ -n "$p" ]] || die "missing port"
+  [[ "$p" =~ ^[0-9]{1,5}$ ]] || die "bad port: $p"
+  (( p >= 1 && p <= 65535 )) || die "port out of range: $p"
+}
+
+validate_handle() { # arg: an nftables rule handle
+  local h="$1"
+  [[ -n "$h" ]] || die "missing handle"
+  [[ "$h" =~ ^[0-9]{1,10}$ ]] || die "bad handle: $h"
+  (( h >= 1 )) || die "handle out of range: $h"
+}
+
+# Echo one IPv4 per line for every RUNNING container. Empty output (no
+# containers) is legitimate and simply means every rule target is dead.
+_running_container_ips() {
+  local ids
+  ids="$(podman ps -q 2>/dev/null)" || die "prune-dnat: podman ps failed"
+  [[ -n "$ids" ]] || return 0
+  # shellcheck disable=SC2086 — ids is a newline list of hex ids from podman
+  podman inspect --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}
+{{end}}' $ids 2>/dev/null || die "prune-dnat: podman inspect failed"
+}
+
+validate_prunable_dnat() {  # args: port, handle
+  local port="$1" handle="$2"
+  local LC_ALL=C
+  local line chain="" rule_re ip
+
+  command -v nft >/dev/null 2>&1 || die "prune-dnat: nft not found"
+  command -v podman >/dev/null 2>&1 || die "prune-dnat: podman not found"
+
+  # Both interpolations are already pinned to digits by the validators above.
+  rule_re="^[[:space:]]*(ip[[:space:]]+daddr[[:space:]]+[0-9.]+[[:space:]]+)?"
+  rule_re+="(tcp|udp)[[:space:]]+dport[[:space:]]+${port}[[:space:]]+"
+  rule_re+="dnat[[:space:]]+ip[[:space:]]+to[[:space:]]+([0-9]{1,3}(\.[0-9]{1,3}){3}):[0-9]{1,5}"
+  rule_re+="[[:space:]]*#[[:space:]]*handle[[:space:]]+${handle}[[:space:]]*$"
+
+  local candidate
+  while IFS= read -r line; do
+    # A chain header switches context. Anything that is not an nv_*_dnat chain
+    # sets chain="" so its rules can never be reached by this verb, whatever
+    # handle the caller asked for.
+    if [[ "$line" =~ ^[[:space:]]*chain[[:space:]]+([^[:space:]]+)[[:space:]]*\{ ]]; then
+      candidate="${BASH_REMATCH[1]}"   # save: the next =~ clobbers BASH_REMATCH
+      chain=""
+      if [[ "$candidate" =~ $_PRUNE_DNAT_CHAIN_RE ]]; then
+        chain="$candidate"
+      fi
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]*\}[[:space:]]*$ ]]; then
+      chain=""
+      continue
+    fi
+    if [[ -n "$chain" ]] && [[ "$line" =~ $rule_re ]]; then
+      PRUNE_CHAIN="$chain"
+      PRUNE_TARGET_IP="${BASH_REMATCH[3]}"
+      break
+    fi
+  done < <(nft -a list table inet netavark 2>/dev/null || true)
+
+  [[ -n "$PRUNE_CHAIN" ]] \
+    || die "prune-dnat refused: no dport-${port} dnat rule at handle ${handle} in any nv_*_dnat chain"
+
+  # The whole point of the verb is that the target is already unreachable.
+  # Refuse to cut a live container's traffic, whatever the caller believes.
+  # Word-split, not line-read: podman's range template emits a trailing space
+  # per address, and a whitespace-padded token would silently never compare
+  # equal — i.e. the guard would pass for a LIVE container. Addresses are
+  # digits and dots, so splitting is exact.
+  for ip in $(_running_container_ips); do
+    if [[ "$ip" == "$PRUNE_TARGET_IP" ]]; then
+      die "prune-dnat refused: ${PRUNE_TARGET_IP} belongs to a running container"
+    fi
+  done
+}
+
 cmd="${1:-help}"; shift || true
 
 case "$cmd" in
@@ -584,6 +704,32 @@ case "$cmd" in
     printf '%s' "$QUADLET_BODY"
     ;;
 
+  prune-dnat)                 # prune-dnat <port> <handle>   (#1814)
+    # Delete ONE stale netavark DNAT rule. Everything that decides whether the
+    # delete is legal is re-derived root-side by validate_prunable_dnat: the
+    # chain, the rule shape, and that the target IP is dead. The nft argv below
+    # is built from that validated result, never from caller strings.
+    port="${1:-}"; handle="${2:-}"
+    validate_port "$port"
+    validate_handle "$handle"
+    validate_prunable_dnat "$port" "$handle"
+    nft delete rule inet netavark "$PRUNE_CHAIN" handle "$handle" \
+      || die "prune-dnat: nft delete failed for handle ${handle} in ${PRUNE_CHAIN}"
+    echo "pruned ${PRUNE_CHAIN} handle ${handle} (dport ${port} -> ${PRUNE_TARGET_IP}, dead)"
+    ;;
+
+  check-dnat)                 # check-dnat <port> <handle>   (#1814, side-effect-free)
+    # Dry run of the prune-dnat guard: says what a prune WOULD delete, or dies
+    # 64 with the refusal reason. Deletes nothing. Exists so the guard can be
+    # exercised by the test suite and by an operator debugging a refusal
+    # without touching the firewall — the check-quadlet / check-dropin posture.
+    port="${1:-}"; handle="${2:-}"
+    validate_port "$port"
+    validate_handle "$handle"
+    validate_prunable_dnat "$port" "$handle"
+    echo "prunable ${PRUNE_CHAIN} handle ${handle} (dport ${port} -> ${PRUNE_TARGET_IP}, dead)"
+    ;;
+
   daemon-reload)
     exec systemctl daemon-reload
     ;;
@@ -679,6 +825,8 @@ usage: hal0-systemctl <command> [slot-id|agent-id]
   write-hindsight-dropin           write ${HINDSIGHT_DROPIN_FILE} (body on stdin)
   check-dropin <gateway|hindsight> validate a drop-in body (stdin) without writing it
   check-quadlet [<slot-id>]        validate a .container body (stdin) without writing it
+  prune-dnat <port> <handle>       delete ONE stale (dead-target) netavark DNAT rule
+  check-dnat <port> <handle>       say whether that rule is prunable, without deleting it
   daemon-reload                    systemctl daemon-reload
   start|stop|restart <slot-id>     systemctl <verb> ${UNIT_PREFIX}<id>.service
   enable|disable <slot-id>         systemctl <verb> ${UNIT_PREFIX}<id>.service

--- a/packaging/sudoers/hal0-systemctl
+++ b/packaging/sudoers/hal0-systemctl
@@ -22,6 +22,16 @@
 # into the generated system unit, so an ExecStartPre= plus this helper's own
 # daemon-reload + start verbs was a one-shot root exec.
 #
+# FIREWALL REPAIR (#1814): prune-dnat is the only verb that touches nftables.
+# It deletes ONE stale netavark DNAT rule — the leaked, dead-target rule that
+# first-match-shadows a slot's live rule and black-holes its published port.
+# The caller passes two integers and nothing else: the root side re-derives the
+# chain from the live ruleset, requires the rule at that handle to be a DNAT
+# rule for that port inside an nv_*_dnat chain, and REFUSES when the target IP
+# belongs to a running container. So the grant cannot add a rule, cannot
+# redirect a port, cannot reach the filter/masquerade chains, and cannot break
+# a working published port — only remove rules that already route nowhere.
+#
 # WHAT THIS GRANT DOES *NOT* CLAIM: it is not a sandbox around slot content.
 # Slots run under rootful podman, and a slot's [Container] section legitimately
 # carries Image=/Volume=/AddDevice=/PodmanArgs=/Exec= whose values come from

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -469,6 +469,93 @@ def check_ports(slots: Any) -> Check:
     return Check("ports", "Slot ports", _PASS, f"{len(bound)} bound: {', '.join(map(str, bound))}")
 
 
+def check_port_dnat(slots: Any, audit: Callable[..., Any] | None = None) -> Check:
+    """Stale netavark DNAT rules on published slot ports (#1814).
+
+    A container that dies without netavark's teardown running leaves its DNAT
+    rule behind in ``inet netavark``. nftables is first-match, so that dead rule
+    permanently shadows the live one and the port black-holes even though the
+    container is healthy. Two heuristic-free signals — more than one DNAT rule
+    for a port, or a first match pointing at an IP no running container holds.
+
+    ``warn``, not ``fail``, when the audit can't run at all (no netavark table,
+    no ``nft``, no ``podman``, or the slots payload never arrived): the absence
+    of evidence is not evidence of corruption. Real corruption is a ``fail``
+    and names ``hal0 doctor ports --fix``.
+    """
+    label = "Port DNAT rules"
+    if not isinstance(slots, list):
+        return Check("port_dnat", label, _WARN, "no slots payload — run `hal0 doctor ports`")
+    ports = sorted({int(s["port"]) for s in slots if isinstance(s, dict) and s.get("port")})
+    if not ports:
+        return Check("port_dnat", label, _PASS, "no slot ports bound yet")
+
+    from hal0.system import netavark
+
+    try:
+        rules = netavark.read_dnat_rules()
+        live = netavark.read_live_container_ips()
+    except (netavark.NetavarkUnavailable, OSError, subprocess.SubprocessError) as exc:
+        return Check("port_dnat", label, _WARN, f"audit unavailable: {exc}")
+
+    verdicts = (audit or netavark.audit_ports)(ports, rules, live)
+    corrupt = [v for v in verdicts if v.corrupt]
+    if not corrupt:
+        return Check("port_dnat", label, _PASS, f"{len(ports)} port(s) clean in the netavark table")
+    stale = sum(len(v.stale) for v in corrupt)
+    names = ", ".join(str(v.port) for v in corrupt)
+    return Check(
+        "port_dnat",
+        label,
+        _FAIL,
+        f"{stale} stale DNAT rule(s) black-holing port(s) {names} "
+        "— repair with `hal0 doctor ports --fix`",
+    )
+
+
+def check_netns_durability(probe: Callable[[], Any] | None = None) -> Check:
+    """Can container network namespaces survive a root login/logout cycle? (#1814)
+
+    This is the *source* of the stale-DNAT leak the row above detects. podman
+    keeps each container's netns as a bind mount under ``/run/user/0/netns``,
+    which logind unmounts when root's last session ends unless root lingers.
+    Every container running at that moment is then unrepairable: its teardown
+    fails and leaks a DNAT rule that black-holes the port.
+
+    ``fail`` when a netns is ALREADY dangling (the leak is guaranteed on the
+    next stop), ``warn`` when linger is merely off but nothing is stranded yet,
+    ``pass`` otherwise.
+    """
+    label = "Container netns"
+    from hal0.system import netavark
+
+    try:
+        state = (probe or netavark.read_netns_durability)()
+    except (netavark.NetavarkUnavailable, OSError, subprocess.SubprocessError) as exc:
+        return Check("netns", label, _WARN, f"probe unavailable: {exc}")
+
+    if not state.sandbox_keys:
+        return Check("netns", label, _PASS, "no running containers to check")
+    dangling = state.dangling
+    if dangling:
+        return Check(
+            "netns",
+            label,
+            _FAIL,
+            f"{len(dangling)} running container(s) have a stranded netns — their next stop "
+            "WILL leak a DNAT rule. Fix: `loginctl enable-linger root`, then restart the slots",
+        )
+    if state.volatile:
+        return Check(
+            "netns",
+            label,
+            _WARN,
+            "netns live under /run/user/0 and root linger is off — a root logout will "
+            "strand them. Fix: `loginctl enable-linger root`",
+        )
+    return Check("netns", label, _PASS, f"{len(state.sandbox_keys)} netns durable")
+
+
 def _default_mcp_probe_targets() -> tuple[tuple[str, str], ...]:
     """(name, mount-root URL) pairs for hal0's two bundled MCP servers."""
     return (
@@ -725,12 +812,17 @@ def build_all_checks(base: str | None = None) -> list[Check]:
     from hal0.cli.doctor_commands import pending_layout_migration
 
     auth_payload = _get_any("/api/auth/status", base)
+    # One fetch, two rows: /api/slots container-probes every slot, so paying for
+    # it twice would double the roll-up's slowest leg.
+    slots_payload = _get_any("/api/slots", base, timeout=SLOTS_PROBE_TIMEOUT_S)
     extra_rows = [
         check_auth_posture(auth_payload),
         check_model_store(_get_any("/api/models", base)),
         check_migrations(pending_layout_migration()),
         check_ui_dist(),
-        check_ports(_get_any("/api/slots", base, timeout=SLOTS_PROBE_TIMEOUT_S)),
+        check_ports(slots_payload),
+        check_port_dnat(slots_payload),
+        check_netns_durability(),
         check_hal0_target(),
         check_secret_file_modes(),
         check_voice_stt_weights(),

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -1972,9 +1972,76 @@ def doctor_profiles(
 # ── hal0 doctor ports — the drill-down the roll-up's Slot ports row names ─────
 
 
+def _render_dnat(verdicts: list[Any]) -> None:
+    """Print the per-port netavark DNAT table (#1814)."""
+    table = Table(title="Netavark DNAT rules (published slot ports)", box=None, pad_edge=False)
+    table.add_column("port", justify="right")
+    table.add_column("rules", justify="right")
+    table.add_column("first match")
+    table.add_column("verdict")
+
+    for v in verdicts:
+        first = v.first_match
+        target = f"{first.target_ip}:{first.target_port}" if first else "—"
+        if not v.rules:
+            verdict = "[dim]no rule (slot not running)[/dim]"
+        elif v.corrupt:
+            verdict = f"[red]{v.reason()}[/red]"
+        else:
+            verdict = "[green]ok[/green]"
+        table.add_row(
+            f"[red]{v.port}[/red]" if v.corrupt else str(v.port),
+            str(len(v.rules)),
+            target,
+            verdict,
+        )
+    console.print(table)
+
+
+def _repair_dnat(verdicts: list[Any]) -> tuple[int, int]:
+    """Delete every stale DNAT handle behind a corrupt port. Returns (ok, failed).
+
+    Deletes highest-handle-first *within* a port so an earlier delete can never
+    renumber a handle we are about to use — nft handles are stable, but the
+    ordering costs nothing and removes the question. Live-targeted rules are
+    never candidates (see :attr:`PortVerdict.stale`), so a working slot cannot
+    be cut by a repair run.
+    """
+    from hal0.system.seam import SystemCtlSeam
+
+    seam = SystemCtlSeam()
+    ok = failed = 0
+    for verdict in verdicts:
+        if not verdict.corrupt:
+            continue
+        for rule in sorted(verdict.stale, key=lambda r: r.handle, reverse=True):
+            try:
+                seam.prune_dnat(verdict.port, rule.handle)
+            except Exception as exc:
+                failed += 1
+                detail = getattr(exc, "stderr", None) or str(exc)
+                console.print(
+                    f"[red]✗[/red]  port {verdict.port}: could not prune handle "
+                    f"{rule.handle}: {str(detail).strip()}"
+                )
+            else:
+                ok += 1
+                console.print(f"[green]✓[/green]  port {verdict.port}: pruned {rule.render()}")
+    return ok, failed
+
+
 @app.command("ports")
-def doctor_ports() -> None:
-    """Show which port each slot has bound, and flag collisions.
+def doctor_ports(
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help=(
+            "Delete the stale netavark DNAT rules found by the audit "
+            "(privileged, routed through the hal0-systemctl seam)."
+        ),
+    ),
+) -> None:
+    """Show which port each slot has bound, flag collisions and DNAT corruption.
 
     The drill-down for the ``Slot ports`` row in ``hal0 doctor all`` (#1501).
     Every other failing row in that table names a follow-up command; this one
@@ -1985,6 +2052,23 @@ def doctor_ports() -> None:
     legitimately takes longer than a normal API call. A timeout is reported as
     a timeout here, naming the budget it exceeded, rather than as the endpoint
     being down.
+
+    It then audits the nftables DNAT rules netavark publishes those ports with
+    (#1814). A container that dies without netavark's teardown running leaves
+    its DNAT rule behind, and because nftables is first-match, that dead rule
+    permanently shadows the correct one — the port answers nothing while the
+    container inside is perfectly healthy. Two signals, both unambiguous and
+    heuristic-free: more than one DNAT rule for a port, or a first-match rule
+    targeting an IP no running container holds.
+
+    ``--fix`` is the explicit repair. It is never a side effect of the audit:
+    deleting nftables rules is privileged and destructive, so it happens only
+    when an operator asks. Only rules whose target is already dead are deleted,
+    so a healthy port cannot be cut.
+
+    Exit codes:
+      0 — no collisions and no DNAT corruption (or every finding was repaired).
+      1 — a port collision, or DNAT corruption still present.
     """
     from hal0.cli._shared import CliApiError, api_get
     from hal0.cli.doctor_all import SLOTS_PROBE_TIMEOUT_S
@@ -2032,15 +2116,57 @@ def doctor_ports() -> None:
     console.print(table)
 
     collisions = {p: names for p, names in by_port.items() if len(names) > 1}
-    if collisions:
-        for port, names in sorted(collisions.items()):
-            console.print(
-                f"\n[red]✗[/red]  port {port} claimed by {len(names)}: {', '.join(names)}"
-            )
+    for port, names in sorted(collisions.items()):
+        console.print(f"\n[red]✗[/red]  port {port} claimed by {len(names)}: {', '.join(names)}")
+    if not collisions:
+        console.print(f"\n[green]✓[/green]  {len(bound)} port(s) bound, no collisions.")
+
+    # ── netavark DNAT audit (#1814) ──────────────────────────────────────────
+    from hal0.system.netavark import (
+        NetavarkUnavailable,
+        audit_ports,
+        read_dnat_rules,
+        read_live_container_ips,
+    )
+
+    try:
+        rules = read_dnat_rules()
+        live_ips = read_live_container_ips()
+    except (NetavarkUnavailable, OSError, subprocess.SubprocessError) as exc:
+        # No netavark table / no podman / no nft is not a finding — a box that
+        # publishes nothing through netavark has nothing to audit. Say so and
+        # keep the collision verdict as the exit code.
+        console.print(f"\n[dim]·[/dim]  netavark DNAT audit skipped: {exc}")
+        raise typer.Exit(1 if collisions else 0) from None
+
+    verdicts = audit_ports(sorted(by_port), rules, live_ips)
+    console.print()
+    _render_dnat(verdicts)
+
+    corrupt = [v for v in verdicts if v.corrupt]
+    if not corrupt:
+        console.print("\n[green]✓[/green]  netavark DNAT rules are clean on every bound port.")
+        raise typer.Exit(1 if collisions else 0)
+
+    stale_total = sum(len(v.stale) for v in corrupt)
+    console.print(
+        f"\n[red]✗[/red]  {len(corrupt)} port(s) have stale netavark DNAT rules "
+        f"({stale_total} dead rule(s)). nftables is first-match, so a leaked rule "
+        "black-holes the port even when the container is healthy."
+    )
+    if not fix:
+        console.print(
+            "    Repair with `hal0 doctor ports --fix` (privileged: routed through "
+            "the hal0-systemctl seam)."
+        )
         raise typer.Exit(1)
 
-    console.print(f"\n[green]✓[/green]  {len(bound)} port(s) bound, no collisions.")
-    raise typer.Exit(0)
+    console.print()
+    ok, failed = _repair_dnat(corrupt)
+    console.print(f"\n[bold]pruned {ok} stale rule(s), {failed} failure(s).[/bold]")
+    if failed or not ok:
+        raise typer.Exit(1)
+    raise typer.Exit(1 if collisions else 0)
 
 
 # ── hal0 doctor all — read-only evidence roll-up (§21.4) ──────────────────────

--- a/src/hal0/system/netavark.py
+++ b/src/hal0/system/netavark.py
@@ -1,0 +1,351 @@
+"""Netavark DNAT-table audit + repair — the port black-hole detector (#1814).
+
+Why this exists
+---------------
+Slot ports on a box are published with ``PublishPort=127.0.0.1:<p>:<p>``, which
+netavark implements as one nftables DNAT rule per container, in the
+``inet netavark`` table's ``nv_<netid>_dnat`` chain::
+
+    ip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.117:8083 # handle 473
+
+When a container goes away **without netavark's teardown running** — the podman
+``cleaning up container …: netavark: open container netns: … No such file or
+directory`` / ``status=125`` failure visible in a slot unit's journal — that
+rule is left behind pointing at a container IP that no longer exists.
+
+nftables is **first-match**. A leaked rule therefore permanently shadows the
+correct rule for every *subsequent* container on that port: traffic is DNAT'd
+into a black hole. It survives ``podman rm -f``, ``systemctl reset-failed`` and
+a fresh ``hal0 slot load``; ``podman network reload --all`` does not repair it
+(it fails with the same netns error and appends yet another rule). Deleting the
+stale handle restores the port instantly.
+
+The detector below is deliberately heuristic-free — both signals it reports are
+unambiguous corruption:
+
+``duplicate``
+    more than one DNAT rule for the same published port. netavark emits exactly
+    one per live container, so ``n > 1`` means ``n - 1`` leaks, whatever the
+    targets look like.
+
+``dead``
+    the *first-match* rule for a port targets an IP that no running container
+    holds. Nothing can reach it, and it shadows anything behind it.
+
+Everything here is read-only and cheap (one ``nft`` list + one ``podman ps``
+pass). Repair is a separate, explicitly-invoked path — see
+:meth:`hal0.system.seam.SystemCtlSeam.prune_dnat`, which routes the privileged
+delete through the ``hal0-systemctl prune-dnat`` seam verb rather than shelling
+``nft`` out of the API/CLI.
+
+Root cause of the leak itself (fixed separately in the same PR): podman on a
+hal0 box keeps container network namespaces under ``/run/user/0/netns``. That
+tmpfs is ``user-runtime-dir@0.service``'s, and logind unmounts it when root's
+last login session ends — so a single root SSH login/logout cycle strands the
+netns of every running container, and the *next* stop leaks. Pinning it up with
+``loginctl enable-linger root`` (installer) is the source fix; this module is
+the detector and the repair for boxes that already accumulated leaks.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+
+#: The nft table netavark owns. Fixed by netavark itself, not configurable.
+NETAVARK_TABLE = "inet netavark"
+
+#: Per-network DNAT chain, e.g. ``nv_2f259bab_10_88_0_0_nm16_dnat``. The chains
+#: this module will ever read, and the ONLY chains the seam's repair verb will
+#: ever delete from.
+DNAT_CHAIN_RE = re.compile(r"^nv_[A-Za-z0-9_]+_dnat$")
+
+_CHAIN_HEADER_RE = re.compile(r"^\s*chain\s+(?P<name>\S+)\s*\{")
+
+#: One DNAT rule line inside a ``nv_*_dnat`` chain. Two shapes occur in the
+#: wild: with an ``ip daddr`` guard (the loopback-published slot ports) and
+#: without (a ``0.0.0.0``-published port such as OpenWebUI's 3001). Both are
+#: matched; anything else in the chain (the ``NETAVARK-HOSTPORT-SETMARK`` jump
+#: rules that accompany every publish) is not a DNAT rule and is ignored.
+_DNAT_RULE_RE = re.compile(
+    r"^\s*(?:ip\s+daddr\s+(?P<daddr>\S+)\s+)?"
+    r"(?:tcp|udp)\s+dport\s+(?P<dport>\d{1,5})\s+"
+    r"dnat\s+ip\s+to\s+(?P<target_ip>\d{1,3}(?:\.\d{1,3}){3}):(?P<target_port>\d{1,5})"
+    r"\s*#\s*handle\s+(?P<handle>\d+)\s*$"
+)
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class DnatRule:
+    """One netavark DNAT rule, as parsed from ``nft -a list table``."""
+
+    chain: str
+    dport: int
+    target_ip: str
+    target_port: int
+    handle: int
+    daddr: str | None = None
+
+    def render(self) -> str:
+        """Human-readable one-liner for doctor output and repair receipts."""
+        guard = f"{self.daddr} " if self.daddr else ""
+        return (
+            f"{guard}dport {self.dport} -> {self.target_ip}:{self.target_port} "
+            f"(handle {self.handle})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PortVerdict:
+    """Corruption verdict for one published port.
+
+    ``rules`` is in nftables evaluation order, so ``rules[0]`` is the rule that
+    actually wins for traffic on this port.
+    """
+
+    port: int
+    rules: tuple[DnatRule, ...]
+    live_ips: frozenset[str]
+
+    @property
+    def first_match(self) -> DnatRule | None:
+        return self.rules[0] if self.rules else None
+
+    @property
+    def duplicate(self) -> bool:
+        """More than one DNAT rule for this port — ``n - 1`` of them are leaks."""
+        return len(self.rules) > 1
+
+    @property
+    def dead_first_match(self) -> bool:
+        """The winning rule targets an IP no running container holds."""
+        first = self.first_match
+        return first is not None and first.target_ip not in self.live_ips
+
+    @property
+    def corrupt(self) -> bool:
+        return self.duplicate or self.dead_first_match
+
+    @property
+    def stale(self) -> tuple[DnatRule, ...]:
+        """Rules a repair should delete: every rule whose target is not live.
+
+        Live-targeted rules are never touched, even when duplicated — deleting
+        the rule a working container is reachable through would *cause* the
+        outage this exists to fix. On a port whose live rule is shadowed, that
+        is exactly right: dropping the dead shadows promotes the live rule to
+        first match.
+        """
+        return tuple(r for r in self.rules if r.target_ip not in self.live_ips)
+
+    def reason(self) -> str:
+        """One-line explanation, or ``""`` when the port is clean."""
+        if not self.corrupt:
+            return ""
+        parts: list[str] = []
+        if self.duplicate:
+            parts.append(f"{len(self.rules)} DNAT rules (netavark emits exactly 1 per container)")
+        if self.dead_first_match:
+            first = self.first_match
+            assert first is not None
+            parts.append(f"first match targets {first.target_ip}, which no running container holds")
+        return "; ".join(parts)
+
+
+def parse_dnat_rules(nft_output: str) -> list[DnatRule]:
+    """Parse ``nft -a list table inet netavark`` output into DNAT rules.
+
+    Only lines inside a ``nv_*_dnat`` chain are considered, and only lines that
+    are genuinely DNAT rules. Rules are returned in file order, which is
+    nftables evaluation order within a chain.
+    """
+    rules: list[DnatRule] = []
+    chain: str | None = None
+    for line in nft_output.splitlines():
+        header = _CHAIN_HEADER_RE.match(line)
+        if header:
+            name = header.group("name")
+            chain = name if DNAT_CHAIN_RE.match(name) else None
+            continue
+        if line.strip() == "}":
+            chain = None
+            continue
+        if chain is None:
+            continue
+        m = _DNAT_RULE_RE.match(line)
+        if m is None:
+            continue
+        rules.append(
+            DnatRule(
+                chain=chain,
+                dport=int(m.group("dport")),
+                target_ip=m.group("target_ip"),
+                target_port=int(m.group("target_port")),
+                handle=int(m.group("handle")),
+                daddr=m.group("daddr"),
+            )
+        )
+    return rules
+
+
+def parse_container_ips(podman_output: str) -> set[str]:
+    """Collect IPv4 addresses out of a whitespace/newline-separated dump.
+
+    Fed by ``podman ps -q | xargs podman inspect --format '…IPAddress…'``; a
+    container with several networks contributes several addresses, and empty
+    fields (host-network containers) simply contribute none.
+    """
+    return {
+        tok
+        for tok in podman_output.replace(",", " ").split()
+        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", tok)
+    }
+
+
+def _run(runner: Runner, argv: Sequence[str], *, timeout: float) -> str:
+    proc = runner(  # nosec B603 — fixed argv, no shell
+        list(argv), capture_output=True, text=True, check=False, timeout=timeout
+    )
+    if proc.returncode != 0:
+        raise NetavarkUnavailable(
+            f"{argv[0]} failed ({proc.returncode}): {(proc.stderr or '').strip()}"
+        )
+    return proc.stdout or ""
+
+
+class NetavarkUnavailable(RuntimeError):
+    """``nft`` / ``podman`` missing, unreadable, or the netavark table absent.
+
+    Not a finding — a box with no netavark table (host networking only, or no
+    container runtime) has nothing to audit. Callers report this as "skipped",
+    never as corruption.
+    """
+
+
+def read_dnat_rules(*, runner: Runner = subprocess.run, timeout: float = 10.0) -> list[DnatRule]:
+    """Read the live netavark DNAT rules. Raises :class:`NetavarkUnavailable`."""
+    out = _run(runner, ["nft", "-a", "list", "table", *NETAVARK_TABLE.split()], timeout=timeout)
+    return parse_dnat_rules(out)
+
+
+def read_live_container_ips(*, runner: Runner = subprocess.run, timeout: float = 15.0) -> set[str]:
+    """IPv4 addresses of every **running** container.
+
+    ``podman ps`` (no ``-a``) is the definition of "live" that matters here: a
+    created-but-not-running container has no netns and no DNAT rule of its own,
+    so its old address must count as dead.
+    """
+    ids = _run(runner, ["podman", "ps", "-q"], timeout=timeout).split()
+    if not ids:
+        return set()
+    fmt = "{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}"
+    out = _run(runner, ["podman", "inspect", "--format", fmt, *ids], timeout=timeout)
+    return parse_container_ips(out)
+
+
+def audit_ports(
+    ports: Iterable[int],
+    rules: Sequence[DnatRule],
+    live_ips: Iterable[str],
+) -> list[PortVerdict]:
+    """Classify each published port against the live rule table. Pure."""
+    live = frozenset(live_ips)
+    by_port: dict[int, list[DnatRule]] = {}
+    for rule in rules:
+        by_port.setdefault(rule.dport, []).append(rule)
+    return [
+        PortVerdict(port=port, rules=tuple(by_port.get(port, ())), live_ips=live)
+        for port in sorted(set(ports))
+    ]
+
+
+# ── the leak's source: a netns directory logind can unmount (#1814) ───────────
+#
+# podman on a hal0 box stores container network namespaces as bind mounts under
+# ``/run/user/0/netns``. That tmpfs is ``user-runtime-dir@0.service``'s, and
+# logind unmounts it when root's LAST login session ends. So one root SSH
+# login/logout cycle strands the netns of every container that is running at the
+# time, and the next stop/restart of any of them fails teardown with
+# ``netavark: open container netns: … No such file or directory`` — leaking the
+# DNAT rule this module hunts.
+#
+# Measured on a live box (podman 5.7.0): a container started in one SSH session
+# has a valid SandboxKey; after that session closes and a new one opens, the
+# same SandboxKey is dangling. Removing a dangling-netns container leaks its
+# rule; removing one whose netns survived does not. ``loginctl enable-linger
+# root`` pins ``/run/user/0`` up independently of sessions and the leak stops.
+
+_NETNS_UNDER_RUNTIME_DIR_RE = re.compile(r"^/run/user/\d+/")
+
+#: Where systemd records lingering users (``loginctl enable-linger <user>``).
+LINGER_DIR = "/var/lib/systemd/linger"
+
+
+@dataclass(frozen=True, slots=True)
+class NetnsDurability:
+    """Whether container netns paths can survive a root login/logout cycle."""
+
+    sandbox_keys: tuple[str, ...]
+    linger_enabled: bool
+
+    @property
+    def volatile(self) -> bool:
+        """True when netns live in a runtime dir logind may unmount.
+
+        Only a problem while linger is off — with linger on, the runtime dir is
+        pinned for the life of the boot, which is exactly as durable as
+        ``/run/netns``.
+        """
+        return not self.linger_enabled and any(
+            _NETNS_UNDER_RUNTIME_DIR_RE.match(k) for k in self.sandbox_keys
+        )
+
+    @property
+    def dangling(self) -> tuple[str, ...]:
+        """Sandbox keys that have ALREADY been unmounted out from under a
+        running container — every one of these will leak a DNAT rule on stop."""
+        return tuple(k for k in self.sandbox_keys if k and not os.path.exists(k))
+
+
+def read_netns_durability(
+    *,
+    runner: Runner = subprocess.run,
+    timeout: float = 15.0,
+    linger_dir: str = LINGER_DIR,
+) -> NetnsDurability:
+    """Probe the netns storage location + root's linger state."""
+    ids = _run(runner, ["podman", "ps", "-q"], timeout=timeout).split()
+    keys: tuple[str, ...] = ()
+    if ids:
+        out = _run(
+            runner,
+            ["podman", "inspect", "--format", "{{.NetworkSettings.SandboxKey}}", *ids],
+            timeout=timeout,
+        )
+        keys = tuple(line.strip() for line in out.splitlines() if line.strip())
+    return NetnsDurability(
+        sandbox_keys=keys,
+        linger_enabled=os.path.exists(os.path.join(linger_dir, "root")),
+    )
+
+
+__all__ = [
+    "DNAT_CHAIN_RE",
+    "LINGER_DIR",
+    "NETAVARK_TABLE",
+    "DnatRule",
+    "NetavarkUnavailable",
+    "NetnsDurability",
+    "PortVerdict",
+    "audit_ports",
+    "parse_container_ips",
+    "parse_dnat_rules",
+    "read_dnat_rules",
+    "read_live_container_ips",
+    "read_netns_durability",
+]

--- a/src/hal0/system/seam.py
+++ b/src/hal0/system/seam.py
@@ -358,6 +358,59 @@ class SystemCtlSeam:
             timeout=timeout,
         )
 
+    def prune_dnat(
+        self,
+        port: int,
+        handle: int,
+        *,
+        dry_run: bool = False,
+        timeout: float | None = 30.0,
+    ) -> subprocess.CompletedProcess[str]:
+        """Delete one **stale** netavark DNAT rule (#1814).
+
+        A container that dies without netavark's teardown running leaves its
+        DNAT rule behind in ``inet netavark`` / ``nv_<netid>_dnat``. nftables is
+        first-match, so that dead rule black-holes the port for every later
+        container. Removing it needs root, so it routes through the wrapper's
+        ``prune-dnat`` verb rather than an ``nft`` subprocess here.
+
+        Only two integers cross the boundary. The root side re-derives the chain
+        by walking the live ruleset, requires the rule at ``handle`` to be a DNAT
+        rule for ``port``, and refuses outright when the target IP belongs to a
+        running container — so this cannot cut a working port, and cannot reach a
+        chain outside ``nv_*_dnat``. See the wrapper's STALE-DNAT REPAIR note.
+
+        ``dry_run`` uses the side-effect-free ``check-dnat`` verb instead: same
+        guard, no delete. The direct (root / dev / CI) branch is deliberately
+        absent — there is no unprivileged fallback for editing nftables, and a
+        non-root process without the seam must fail loudly rather than silently
+        skip the repair. Raises :class:`subprocess.CalledProcessError` (exit 64
+        from the wrapper) with the refusal reason on stderr.
+        """
+        if not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65535:
+            raise ValueError(f"bad port: {port!r}")
+        if not isinstance(handle, int) or isinstance(handle, bool) or handle < 1:
+            raise ValueError(f"bad handle: {handle!r}")
+        verb = "check-dnat" if dry_run else "prune-dnat"
+        if not self._is_hal0_user() and os.geteuid() == 0:
+            # Already root (the CLI run by an admin, the installer): call the
+            # wrapper directly. Same validation, one less sudo hop — and no
+            # sudoers grant is needed for `hal0 doctor ports --fix` as root.
+            return self._run(
+                [self._seam_bin, verb, str(port), str(handle)],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=timeout,
+            )
+        return self._run(
+            self._seam_argv(verb, str(port), str(handle)),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+
     def systemctl(
         self,
         *args: str,

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -564,15 +564,28 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         lambda **_kw: Check("hindsight_llm_auth", "Memory engine LLM auth", "pass", "stubbed"),
     )
 
+    # Stale-DNAT + netns rows (#1814) shell out to nft/podman otherwise;
+    # neutralise both so this composition test asserts the row list.
+    monkeypatch.setattr(
+        da, "check_port_dnat", lambda _s: Check("port_dnat", "Port DNAT rules", "pass", "stubbed")
+    )
+    monkeypatch.setattr(
+        da,
+        "check_netns_durability",
+        lambda *_a, **_k: Check("netns", "Container netns", "pass", "stubbed"),
+    )
+
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 12 extras.
-    assert keys[-12:] == [
+    # 7 verify rows + 14 extras.
+    assert keys[-14:] == [
         "auth",
         "models",
         "migrations",
         "ui-dist",
         "ports",
+        "port_dnat",
+        "netns",
         "hal0_target",
         "secret-modes",
         "stt-weights",

--- a/tests/cli/test_doctor_port_dnat.py
+++ b/tests/cli/test_doctor_port_dnat.py
@@ -1,0 +1,149 @@
+"""#1814 — the doctor surfaces for stale netavark DNAT rules.
+
+Covers the two ``doctor all`` rows (corruption + its source, netns durability)
+and the ``SystemCtlSeam.prune_dnat`` client side. The parser/classifier itself
+is pinned in ``tests/system/test_netavark.py`` against a real box capture.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hal0.cli.doctor_all import check_netns_durability, check_port_dnat
+from hal0.cli.doctor_verify import _FAIL, _PASS, _WARN
+from hal0.system import netavark
+from hal0.system.netavark import NetavarkUnavailable, NetnsDurability
+from hal0.system.seam import SystemCtlSeam
+
+NFT = """\
+table inet netavark { # handle 2
+\tchain nv_2f259bab_10_88_0_0_nm16_dnat { # handle 45
+\t\tip daddr 127.0.0.1 tcp dport 8081 dnat ip to 10.88.0.80:8081 # handle 341
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.92:8083 # handle 385
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.117:8083 # handle 473
+\t}
+}
+"""
+
+SLOTS = [{"name": "agent", "port": 8081}, {"name": "embed", "port": 8083}]
+
+
+@pytest.fixture
+def live(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(netavark, "read_dnat_rules", lambda: netavark.parse_dnat_rules(NFT))
+    monkeypatch.setattr(netavark, "read_live_container_ips", lambda: {"10.88.0.80", "10.88.0.117"})
+
+
+# ── doctor all: Port DNAT rules ──────────────────────────────────────────────
+
+
+def test_flags_the_poisoned_port_and_names_the_repair(live: None) -> None:
+    check = check_port_dnat(SLOTS)
+    assert check.status == _FAIL
+    assert "8083" in check.detail
+    assert "8081" not in check.detail  # the clean port is never named
+    assert "hal0 doctor ports --fix" in check.detail
+
+
+def test_passes_when_every_port_is_clean(live: None) -> None:
+    check = check_port_dnat([{"name": "agent", "port": 8081}])
+    assert check.status == _PASS
+
+
+def test_no_bound_ports_is_a_pass(live: None) -> None:
+    assert check_port_dnat([]).status == _PASS
+
+
+def test_missing_slots_payload_warns_rather_than_accusing() -> None:
+    assert check_port_dnat(None).status == _WARN
+
+
+def test_absent_netavark_table_warns_rather_than_failing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No nft / no netavark table is not corruption — absence of evidence."""
+
+    def boom() -> list[netavark.DnatRule]:
+        raise NetavarkUnavailable("nft failed (1): No such file or directory")
+
+    monkeypatch.setattr(netavark, "read_dnat_rules", boom)
+    check = check_port_dnat(SLOTS)
+    assert check.status == _WARN
+    assert "unavailable" in check.detail
+
+
+# ── doctor all: Container netns (the leak's source) ──────────────────────────
+
+
+def test_dangling_netns_fails_and_names_linger(tmp_path) -> None:
+    state = NetnsDurability(sandbox_keys=(str(tmp_path / "gone"),), linger_enabled=False)
+    check = check_netns_durability(lambda: state)
+    assert check.status == _FAIL
+    assert "loginctl enable-linger root" in check.detail
+
+
+class _Volatile:
+    """Netns that still exist but sit in a runtime dir logind may unmount."""
+
+    sandbox_keys = ("/run/user/0/netns/x",)
+    dangling: tuple[str, ...] = ()
+    volatile = True
+
+
+def test_volatile_but_intact_netns_only_warns() -> None:
+    check = check_netns_durability(_Volatile)
+    assert check.status == _WARN
+    assert "loginctl enable-linger root" in check.detail
+
+
+def test_durable_netns_passes(tmp_path) -> None:
+    key = tmp_path / "netns-live"
+    key.write_text("")
+    state = NetnsDurability(sandbox_keys=(str(key),), linger_enabled=False)
+    assert check_netns_durability(lambda: state).status == _PASS
+
+
+def test_no_containers_is_a_pass() -> None:
+    state = NetnsDurability(sandbox_keys=(), linger_enabled=False)
+    assert check_netns_durability(lambda: state).status == _PASS
+
+
+# ── the seam client ──────────────────────────────────────────────────────────
+
+
+def _seam(calls: list[list[str]]) -> SystemCtlSeam:
+    def run(argv, **kwargs):
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "pruned", "")
+
+    return SystemCtlSeam(run=run, is_hal0_user=lambda: True, seam_bin="/seam/hal0-systemctl")
+
+
+def test_prune_dnat_routes_through_sudo_with_two_integers() -> None:
+    calls: list[list[str]] = []
+    _seam(calls).prune_dnat(8083, 385)
+    assert calls == [["sudo", "-n", "/seam/hal0-systemctl", "prune-dnat", "8083", "385"]]
+
+
+def test_prune_dnat_dry_run_uses_the_check_verb() -> None:
+    calls: list[list[str]] = []
+    _seam(calls).prune_dnat(8083, 385, dry_run=True)
+    assert calls[0][3] == "check-dnat"
+
+
+@pytest.mark.parametrize("port", [0, 65536, -1, "8083", True, 8083.0])
+def test_prune_dnat_rejects_a_bad_port_before_spawning_anything(port: object) -> None:
+    calls: list[list[str]] = []
+    with pytest.raises(ValueError):
+        _seam(calls).prune_dnat(port, 385)  # type: ignore[arg-type]
+    assert calls == []
+
+
+@pytest.mark.parametrize("handle", [0, -1, "385", True, None])
+def test_prune_dnat_rejects_a_bad_handle_before_spawning_anything(handle: object) -> None:
+    calls: list[list[str]] = []
+    with pytest.raises(ValueError):
+        _seam(calls).prune_dnat(8083, handle)  # type: ignore[arg-type]
+    assert calls == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,13 +131,21 @@ def _reject_privileged_systemctl(argv: object) -> None:
         # non-systemctl file verbs (write-quadlet, remove-unit, ...) mutate
         # /etc as root, which a test must never do either.
         #
-        # `help`, `check-dropin` and `check-quadlet` are the exceptions: all
-        # three are pure — they read stdin/argv, write nothing, and never touch
-        # systemd. Running the real script IS the point for those
-        # (tests/installer's #1716 + #1740 suites exercise the root-side
-        # allow-lists against the shipped bash), and none needs sudo or root.
+        # `help`, `check-dropin`, `check-quadlet` and `check-dnat` are the
+        # exceptions: all four are pure — they read stdin/argv (and, for
+        # check-dnat, LIST the nft ruleset and running containers), write
+        # nothing, and never touch systemd or the firewall. Running the real
+        # script IS the point for those (tests/installer's #1716 + #1740 +
+        # #1814 suites exercise the root-side allow-lists against the shipped
+        # bash), and none needs sudo or root.
         seam_verb = next((p for p in inner[1:] if not p.startswith("-")), "")
-        if seam_verb and seam_verb not in {"help", "", "check-dropin", "check-quadlet"}:
+        if seam_verb and seam_verb not in {
+            "help",
+            "",
+            "check-dropin",
+            "check-quadlet",
+            "check-dnat",
+        }:
             raise AssertionError(
                 f"test tried to run the hal0-systemctl privilege seam for real: {parts!r}. "
                 "Inject a fake runner (or patch hal0.system.seam.agent_unit_argv) instead — "

--- a/tests/installer/test_systemctl_prune_dnat.py
+++ b/tests/installer/test_systemctl_prune_dnat.py
@@ -1,0 +1,183 @@
+"""#1814 — root-side guard for the ``prune-dnat`` seam verb.
+
+``prune-dnat`` is the only verb in ``installer/wrappers/hal0-systemctl`` that
+edits nftables, and the wrapper is reachable as root by the unprivileged
+``hal0`` service account (packaging/sudoers/hal0-systemctl). So the guard has to
+hold with the caller trusted for nothing beyond two integers.
+
+These tests exercise the REAL bash wrapper through its side-effect-free
+``check-dnat`` verb — the same ``validate_prunable_dnat`` the delete arm calls —
+with stub ``nft`` and ``podman`` binaries on PATH. No root, no sudo, no
+provisioned box, and nothing touches a real firewall. Same posture as the #1740
+``check-quadlet`` suite.
+
+The ruleset fixture is a verbatim capture from the box the bug was diagnosed on.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+WRAPPER = REPO / "installer" / "wrappers" / "hal0-systemctl"
+
+RULESET = """\
+table inet netavark { # handle 2
+\tchain POSTROUTING { # handle 3
+\t\tip saddr 10.88.0.0/16 jump nv_2f259bab_10_88_0_0_nm16 # handle 44
+\t}
+
+\tchain NETAVARK-HOSTPORT-DNAT { # handle 6
+\t\tip daddr 127.0.0.1 tcp dport 8083 jump nv_2f259bab_10_88_0_0_nm16_dnat # handle 442
+\t}
+
+\tchain nv_2f259bab_10_88_0_0_nm16_dnat { # handle 45
+\t\tip saddr 127.0.0.1 ip daddr 127.0.0.1 tcp dport 8083 jump NETAVARK-HOSTPORT-SETMARK # handle 444
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.92:8083 # handle 385
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.117:8083 # handle 473
+\t\tip daddr 127.0.0.1 tcp dport 8081 dnat ip to 10.88.0.80:8081 # handle 341
+\t}
+}
+"""
+
+#: 10.88.0.117 (embed) and 10.88.0.80 (agent) are running; .92 is the leak.
+LIVE_IPS = "10.88.0.117 \n10.88.0.80 \n"
+
+
+def _stub(path: Path, body: str) -> None:
+    path.write_text("#!/bin/bash\n" + body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def fakebin(tmp_path: Path) -> Path:
+    """A PATH dir with stub ``nft`` + ``podman``, plus the real coreutils."""
+    binder = tmp_path / "bin"
+    binder.mkdir()
+    ruleset = tmp_path / "ruleset.txt"
+    ruleset.write_text(RULESET)
+    ips = tmp_path / "ips.txt"
+    ips.write_text(LIVE_IPS)
+    _stub(
+        binder / "nft",
+        f'if [[ "$*" == *"list table"* ]]; then cat {ruleset}; exit 0; fi\n'
+        f'echo "$*" >> {tmp_path}/nft-calls.txt\n',
+    )
+    _stub(
+        binder / "podman",
+        f'if [[ "$1" == "ps" ]]; then echo abc; echo def; exit 0; fi\n'
+        f'if [[ "$1" == "inspect" ]]; then cat {ips}; exit 0; fi\nexit 1\n',
+    )
+    return binder
+
+
+def _check(fakebin: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PATH"] = f"{fakebin}:/usr/bin:/bin"
+    return subprocess.run(
+        [str(WRAPPER), "check-dnat", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+# ── the accepted case ────────────────────────────────────────────────────────
+
+
+def test_accepts_a_dead_target_rule(fakebin: Path) -> None:
+    proc = _check(fakebin, "8083", "385")
+    assert proc.returncode == 0, proc.stderr
+    assert "nv_2f259bab_10_88_0_0_nm16_dnat" in proc.stdout
+    assert "10.88.0.92" in proc.stdout
+
+
+# ── the refusals that make this narrow ───────────────────────────────────────
+
+
+def test_refuses_a_handle_whose_target_is_a_running_container(fakebin: Path) -> None:
+    """The core safety property: repair can never cut a working port."""
+    proc = _check(fakebin, "8083", "473")
+    assert proc.returncode == 64
+    assert "running container" in proc.stderr
+
+
+def test_refuses_a_live_single_rule_port(fakebin: Path) -> None:
+    proc = _check(fakebin, "8081", "341")
+    assert proc.returncode == 64
+    assert "running container" in proc.stderr
+
+
+def test_refuses_a_handle_that_belongs_to_a_different_port(fakebin: Path) -> None:
+    """Handle 385 IS a real DNAT handle, but for 8083 — asking to prune it as
+    port 8090 must not work, or the port argument would be decorative."""
+    proc = _check(fakebin, "8090", "385")
+    assert proc.returncode == 64
+    assert "no dport-8090 dnat rule at handle 385" in proc.stderr
+
+
+def test_refuses_a_handle_outside_any_nv_dnat_chain(fakebin: Path) -> None:
+    """Handle 442 is the NETAVARK-HOSTPORT-DNAT *jump* rule for 8083, and 444 is
+    a SETMARK jump inside the dnat chain. Neither is a DNAT rule; deleting
+    either would break hostport routing wholesale."""
+    for handle in ("442", "444", "44"):
+        proc = _check(fakebin, "8083", handle)
+        assert proc.returncode == 64, handle
+        assert "no dport-8083 dnat rule" in proc.stderr
+
+
+def test_refuses_an_unknown_handle(fakebin: Path) -> None:
+    assert _check(fakebin, "8083", "999999").returncode == 64
+
+
+@pytest.mark.parametrize(
+    "port",
+    ["0", "65536", "-1", "80a", "8083;rm", "8083 8081", "", "0x1f90", "+8083"],
+)
+def test_rejects_a_non_port(fakebin: Path, port: str) -> None:
+    proc = _check(fakebin, port, "385")
+    assert proc.returncode == 64
+    assert "port" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "handle",
+    ["0", "-3", "38a", "385;nft flush ruleset", "385 473", "", "handle"],
+)
+def test_rejects_a_non_handle(fakebin: Path, handle: str) -> None:
+    proc = _check(fakebin, "8083", handle)
+    assert proc.returncode == 64
+    assert "handle" in proc.stderr
+
+
+def test_check_dnat_never_touches_the_firewall(fakebin: Path, tmp_path: Path) -> None:
+    """The dry-run verb must not issue a single mutating nft call."""
+    _check(fakebin, "8083", "385")
+    assert not (tmp_path / "nft-calls.txt").exists()
+
+
+def test_dies_when_the_tools_are_missing(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    env = dict(os.environ)
+    env["PATH"] = str(empty)
+    proc = subprocess.run(
+        [str(WRAPPER), "check-dnat", "8083", "385"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode != 0
+
+
+def test_verb_is_advertised_in_help() -> None:
+    proc = subprocess.run([str(WRAPPER), "help"], capture_output=True, text=True, check=False)
+    assert "prune-dnat <port> <handle>" in proc.stdout
+    assert "check-dnat <port> <handle>" in proc.stdout

--- a/tests/system/test_netavark.py
+++ b/tests/system/test_netavark.py
@@ -1,0 +1,266 @@
+"""Stale-DNAT detection (#1814).
+
+Fixtures are VERBATIM captures from the box the bug was diagnosed on (CT151,
+podman 5.7.0, netavark), not hand-written approximations — the whole point of
+the detector is that it reads real ``nft -a list table inet netavark`` output.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hal0.system.netavark import (
+    NetavarkUnavailable,
+    NetnsDurability,
+    audit_ports,
+    parse_container_ips,
+    parse_dnat_rules,
+    read_dnat_rules,
+    read_live_container_ips,
+    read_netns_durability,
+)
+
+# ── real capture ─────────────────────────────────────────────────────────────
+#
+# Port 8081 (agent, never restarted): 1 rule -> 10.88.0.80, which IS a running
+# container. Clean.
+# Port 8083 (embed, restarted many times): 6 rules; the live container is
+# 10.88.0.117 but .92/.100/.102/.105/.109 shadow it. Black-holed.
+# Ports 8086/8089: 1 rule each, targeting IPs no running container holds — the
+# single-rule "first match points at a dead IP" case.
+# Port 3001 (OpenWebUI): the no-``ip daddr`` shape, live target. Clean.
+REAL_NFT = """\
+table inet netavark { # handle 2
+\tchain INPUT { # handle 1
+\t\ttype filter hook input priority filter; policy accept;
+\t\tip saddr 10.88.0.0/16 meta l4proto { tcp, udp } th dport 53 accept # handle 41
+\t}
+
+\tchain NETAVARK-HOSTPORT-DNAT { # handle 6
+\t\ttcp dport 3001 jump nv_2f259bab_10_88_0_0_nm16_dnat # handle 46
+\t\tip daddr 127.0.0.1 tcp dport 8083 jump nv_2f259bab_10_88_0_0_nm16_dnat # handle 442
+\t}
+
+\tchain nv_2f259bab_10_88_0_0_nm16_dnat { # handle 45
+\t\tip saddr 10.88.0.0/16 tcp dport 3001 jump NETAVARK-HOSTPORT-SETMARK # handle 47
+\t\tip saddr 127.0.0.1 tcp dport 3001 jump NETAVARK-HOSTPORT-SETMARK # handle 48
+\t\ttcp dport 3001 dnat ip to 10.88.0.4:8080 # handle 49
+\t\tip saddr 10.88.0.0/16 ip daddr 127.0.0.1 tcp dport 8081 jump NETAVARK-HOSTPORT-SETMARK # handle 339
+\t\tip saddr 127.0.0.1 ip daddr 127.0.0.1 tcp dport 8081 jump NETAVARK-HOSTPORT-SETMARK # handle 340
+\t\tip daddr 127.0.0.1 tcp dport 8081 dnat ip to 10.88.0.80:8081 # handle 341
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.92:8083 # handle 385
+\t\tip daddr 127.0.0.1 tcp dport 8086 dnat ip to 10.88.0.94:8086 # handle 389
+\t\tip daddr 127.0.0.1 tcp dport 8089 dnat ip to 10.88.0.98:8089 # handle 405
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.100:8083 # handle 413
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.102:8083 # handle 417
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.105:8083 # handle 429
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.109:8083 # handle 445
+\t\tip daddr 127.0.0.1 tcp dport 8083 dnat ip to 10.88.0.117:8083 # handle 473
+\t}
+}
+"""
+
+#: The three containers that were actually running when REAL_NFT was captured.
+REAL_LIVE_IPS = {"10.88.0.4", "10.88.0.80", "10.88.0.117"}
+
+
+# ── parsing ──────────────────────────────────────────────────────────────────
+
+
+def test_parses_only_dnat_rules_from_the_dnat_chain() -> None:
+    rules = parse_dnat_rules(REAL_NFT)
+    # 10 dnat rules; the SETMARK jumps and the NETAVARK-HOSTPORT-DNAT jump rules
+    # (which also carry `tcp dport <p>`) must NOT be counted.
+    assert len(rules) == 10
+    assert {r.chain for r in rules} == {"nv_2f259bab_10_88_0_0_nm16_dnat"}
+    assert all(r.handle not in {46, 47, 48, 442} for r in rules)
+
+
+def test_parses_the_no_daddr_shape() -> None:
+    rule = next(r for r in parse_dnat_rules(REAL_NFT) if r.dport == 3001)
+    assert rule.daddr is None
+    assert (rule.target_ip, rule.target_port, rule.handle) == ("10.88.0.4", 8080, 49)
+
+
+def test_parses_the_loopback_shape() -> None:
+    rule = next(r for r in parse_dnat_rules(REAL_NFT) if r.handle == 341)
+    assert rule.daddr == "127.0.0.1"
+    assert (rule.dport, rule.target_ip, rule.target_port) == (8081, "10.88.0.80", 8081)
+
+
+def test_rules_keep_nftables_evaluation_order() -> None:
+    handles = [r.handle for r in parse_dnat_rules(REAL_NFT) if r.dport == 8083]
+    assert handles == [385, 413, 417, 429, 445, 473]
+
+
+def test_empty_and_foreign_output_yield_nothing() -> None:
+    assert parse_dnat_rules("") == []
+    assert parse_dnat_rules("table inet filter {\n\tchain INPUT {\n\t}\n}\n") == []
+
+
+def test_parse_container_ips_ignores_blanks_and_non_ips() -> None:
+    assert parse_container_ips("10.88.0.4 \n\n10.88.0.80,10.88.0.117\nnot-an-ip\n") == {
+        "10.88.0.4",
+        "10.88.0.80",
+        "10.88.0.117",
+    }
+
+
+# ── classification ───────────────────────────────────────────────────────────
+
+
+def _verdicts(ports: list[int]) -> dict[int, object]:
+    rules = parse_dnat_rules(REAL_NFT)
+    return {v.port: v for v in audit_ports(ports, rules, REAL_LIVE_IPS)}
+
+
+def test_clean_single_rule_port_is_not_flagged() -> None:
+    v = _verdicts([8081])[8081]
+    assert len(v.rules) == 1
+    assert not v.duplicate and not v.dead_first_match and not v.corrupt
+    assert v.stale == ()
+    assert v.reason() == ""
+
+
+def test_clean_no_daddr_port_is_not_flagged() -> None:
+    assert not _verdicts([3001])[3001].corrupt
+
+
+def test_poisoned_port_is_flagged_as_duplicate_and_dead_first_match() -> None:
+    v = _verdicts([8083])[8083]
+    assert len(v.rules) == 6
+    assert v.duplicate and v.dead_first_match and v.corrupt
+    assert v.first_match.handle == 385
+    # The live container's rule (handle 473 -> .117) must survive repair.
+    assert [r.handle for r in v.stale] == [385, 413, 417, 429, 445]
+    assert "6 DNAT rules" in v.reason()
+    assert "10.88.0.92" in v.reason()
+
+
+def test_single_rule_pointing_at_a_dead_ip_is_flagged() -> None:
+    v = _verdicts([8086])[8086]
+    assert not v.duplicate
+    assert v.dead_first_match and v.corrupt
+    assert [r.handle for r in v.stale] == [389]
+
+
+def test_port_with_no_rule_at_all_is_not_corruption() -> None:
+    v = _verdicts([9999])[9999]
+    assert v.rules == ()
+    assert not v.corrupt
+    assert v.stale == ()
+
+
+def test_audit_covers_every_requested_port_once_sorted() -> None:
+    verdicts = audit_ports([8083, 8081, 8081], parse_dnat_rules(REAL_NFT), REAL_LIVE_IPS)
+    assert [v.port for v in verdicts] == [8081, 8083]
+
+
+def test_a_port_whose_only_rule_is_live_but_duplicated_keeps_the_live_rule() -> None:
+    """Duplicate rules both pointing at the SAME live container: still flagged
+    (netavark emits one per container), but repair must delete neither — cutting
+    a live rule is the outage this tool exists to prevent."""
+    nft = (
+        "table inet netavark { # handle 2\n"
+        "\tchain nv_abc_dnat { # handle 45\n"
+        "\t\tip daddr 127.0.0.1 tcp dport 8091 dnat ip to 10.88.0.7:8091 # handle 10\n"
+        "\t\tip daddr 127.0.0.1 tcp dport 8091 dnat ip to 10.88.0.7:8091 # handle 11\n"
+        "\t}\n"
+        "}\n"
+    )
+    v = audit_ports([8091], parse_dnat_rules(nft), {"10.88.0.7"})[0]
+    assert v.corrupt and v.duplicate and not v.dead_first_match
+    assert v.stale == ()
+
+
+# ── live readers (runner injected; no nft/podman needed) ─────────────────────
+
+
+def _fake_runner(table: dict[str, tuple[int, str]]):
+    def run(argv, **kwargs):
+        key = argv[0]
+        code, out = table[key]
+        return subprocess.CompletedProcess(argv, code, out, "boom" if code else "")
+
+    return run
+
+
+def test_read_dnat_rules_uses_the_netavark_table() -> None:
+    seen: list[list[str]] = []
+
+    def run(argv, **kwargs):
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, REAL_NFT, "")
+
+    rules = read_dnat_rules(runner=run)
+    assert seen == [["nft", "-a", "list", "table", "inet", "netavark"]]
+    assert len(rules) == 10
+
+
+def test_read_dnat_rules_raises_when_the_table_is_absent() -> None:
+    with pytest.raises(NetavarkUnavailable):
+        read_dnat_rules(runner=_fake_runner({"nft": (1, "")}))
+
+
+def test_read_live_container_ips_short_circuits_with_no_containers() -> None:
+    calls: list[str] = []
+
+    def run(argv, **kwargs):
+        calls.append(argv[1])
+        return subprocess.CompletedProcess(argv, 0, "\n", "")
+
+    assert read_live_container_ips(runner=run) == set()
+    assert calls == ["ps"]  # no `podman inspect` on an empty box
+
+
+def test_read_live_container_ips_parses_inspect_output() -> None:
+    def run(argv, **kwargs):
+        if argv[1] == "ps":
+            return subprocess.CompletedProcess(argv, 0, "abc\ndef\n", "")
+        return subprocess.CompletedProcess(argv, 0, "10.88.0.4 \n10.88.0.80 \n", "")
+
+    assert read_live_container_ips(runner=run) == {"10.88.0.4", "10.88.0.80"}
+
+
+# ── the leak's source: netns durability ──────────────────────────────────────
+
+
+def test_netns_under_runtime_dir_without_linger_is_volatile() -> None:
+    state = NetnsDurability(sandbox_keys=("/run/user/0/netns/netns-abc",), linger_enabled=False)
+    assert state.volatile
+
+
+def test_netns_under_runtime_dir_with_linger_is_durable() -> None:
+    state = NetnsDurability(sandbox_keys=("/run/user/0/netns/netns-abc",), linger_enabled=True)
+    assert not state.volatile
+
+
+def test_netns_outside_runtime_dir_is_durable() -> None:
+    state = NetnsDurability(sandbox_keys=("/run/netns/netns-abc",), linger_enabled=False)
+    assert not state.volatile
+
+
+def test_dangling_reports_keys_that_no_longer_exist(tmp_path) -> None:
+    alive = tmp_path / "netns-alive"
+    alive.write_text("")
+    state = NetnsDurability(
+        sandbox_keys=(str(alive), str(tmp_path / "netns-gone")), linger_enabled=False
+    )
+    assert state.dangling == (str(tmp_path / "netns-gone"),)
+
+
+def test_read_netns_durability_reads_linger_marker(tmp_path) -> None:
+    def run(argv, **kwargs):
+        if argv[1] == "ps":
+            return subprocess.CompletedProcess(argv, 0, "abc\n", "")
+        return subprocess.CompletedProcess(argv, 0, "/run/user/0/netns/netns-abc\n", "")
+
+    off = read_netns_durability(runner=run, linger_dir=str(tmp_path))
+    assert off.sandbox_keys == ("/run/user/0/netns/netns-abc",)
+    assert off.volatile
+
+    (tmp_path / "root").write_text("")
+    on = read_netns_durability(runner=run, linger_dir=str(tmp_path))
+    assert on.linger_enabled and not on.volatile


### PR DESCRIPTION
Closes #1814.

## What was wrong

A slot container that dies without netavark's teardown running leaves its DNAT rule behind in `inet netavark` / `nv_<netid>_dnat`. nftables is first-match, so that dead rule permanently shadows the correct rule for every later container on that port — the published port answers nothing while the container inside is perfectly healthy. It survives `podman rm -f`, `systemctl reset-failed` and a fresh `hal0 slot load`; `podman network reload --all` fails with the same netns error and appends another rule.

**Why teardown fails** (this PR's second half, and the part the issue left open): podman stores every container's netns as a bind mount under `/run/user/0/netns`. That tmpfs belongs to `user-runtime-dir@0.service`, which logind *stops — unmounting the tmpfs —* as soon as root's last login session ends. One root SSH login/logout cycle strands the netns of every running container, and the next stop leaks.

## What changed

**1. Detect + repair (`fix(doctor)`)**

New `hal0.system.netavark` module. Heuristic-free — both signals are unambiguous corruption:

- more than one DNAT rule for a published port (netavark emits exactly one per live container)
- the first-match rule targets an IP no running container holds

Read-only and cheap: one `nft` list plus one `podman ps` pass. Surfaces as a `Port DNAT rules` row in `hal0 doctor all` and a per-port table in `hal0 doctor ports`, which names the repair.

`hal0 doctor ports --fix` is the repair — explicit, never a side effect of the audit. Only rules whose target is already dead are candidates, so a healthy port cannot be cut.

**2. Stop the leak (`fix(installer)`)**

`loginctl enable-linger root` in the installer keeps `user-runtime-dir@0` up for the life of the boot, so the netns survives session cycles. Idempotent, reversible, no-op where already on. `hal0 doctor all` gains a `Container netns` row that fails when a running container's netns is already stranded (its next stop *will* leak) and warns when linger is merely off.

## Security note on the seam verb

Deleting nftables rules is privileged, so it goes behind `hal0-systemctl` as a new `prune-dnat` verb rather than an `nft` subprocess from the API/CLI. It is deliberately **not** a general "run nft" primitive:

- the caller passes **two integers** and nothing else — no chain, no rule expression, no path
- the root side re-derives the chain by walking the live ruleset, and will only ever match chains named `nv_*_dnat`
- the rule at that handle must match the exact netavark DNAT shape **for that port** — the port argument is load-bearing, not decorative
- it **refuses outright** when the target IP belongs to a running container

So the grant cannot add a rule, cannot redirect a port at an attacker-chosen address, cannot reach the filter/masquerade chains, and cannot break a working published port. Worst case under a compromised `hal0` account: it removes rules that already route nowhere. A side-effect-free `check-dnat` verb runs the same guard with no delete — that is what the test suite drives against the shipped bash.

## Verification

Unit tests use verbatim `nft -a list table inet netavark` captures from the box the bug was diagnosed on: a clean 1-rule port, a 6-rule poisoned port, single-rule dead-first-match ports, and the no-`ip daddr` (0.0.0.0-published) shape. The wrapper guard is exercised through the real bash with stub `nft`/`podman` on PATH.

On CT151 (podman 5.7.0):

- `hal0 doctor ports` flagged 5 ports / 10 dead rules and left the clean ports alone
- `hal0 doctor ports --fix` pruned all 10; the re-run reports every bound port clean, and `curl /health` on 8081 / 8083 / 8090 all return 200
- controlled A/B on poisoned port 8397: `min-1814.sh 8397` → **RED**, `hal0-systemctl prune-dnat 8397 497` → `min-1814.sh 8397` → **GREEN**
- refusal check: `check-dnat 8083 <live handle>` → exit 64, `prune-dnat refused: 10.88.0.124 belongs to a running container`
- source fix A/B: a slot restarted while its netns was already stranded still leaked one rule; the same slot restarted again with a netns born after `enable-linger` leaked nothing

Not deployed to CT105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
