### PR TITLE
chore(release): cut v1.0.0-rc.5 and refresh the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,73 @@ breaking/migrations as callouts — from the cosign-verified tarball, before
 applying. Add those subsections to a version's section to surface them; see
 `scripts/gen_release_notes.py`.
 
-## [Unreleased]
+## [1.0.0-rc.5] — 2026-08-10
+
+The validation candidate: every defect the rc.4 fresh-install sweep turned up
+on real hardware, fixed and re-provable. Eleven findings (#1787–#1797) came out
+of that sweep; rc.5 closes all of them, adds the versioned validation kit that
+makes the next sweep compound instead of repeat, and fixes a podman/netavark
+failure mode that could black-hole a slot's published port on any box.
+
+### Highlights
+
+- **The netavark port black hole is detected and repairable.** A slot container
+  that dies without netavark's teardown leaves its DNAT rule behind; nftables is
+  first-match, so that dead rule permanently shadows every later container on
+  that port — the published port answers nothing while the container inside is
+  perfectly healthy, and it survives `podman rm -f`, `systemctl reset-failed`
+  and a fresh `hal0 slot load`. `hal0 doctor all` now carries a `Port DNAT
+  rules` row, `hal0 doctor ports` shows the per-port table, and `hal0 doctor
+  ports --fix` prunes only rules that already route nowhere. The installer also
+  stops the leak at its source by pinning root's runtime dir so container
+  netns survive logout (#1819, refs #1814).
+- **Slot telemetry tells the truth.** llama-server slots launch with
+  `--metrics`, so `/metrics` stops returning 501 and `hal0 slot metrics` shows
+  real request counters and queue depth (#1810). `ctx_max`, `/v1/models`
+  `context_length`/`max_context_window` and the SlotView dashboard now advertise
+  the *effective* context window the runner actually launched with rather than
+  the raw slot-TOML ceiling (#1788).
+- **Fresh installs serve every capability.** Embedding and rerank slots launch
+  with their profile's flags again, so `/v1/embeddings` and `/v1/rerank` stop
+  returning 501 while the slot reports `ready` (#1787) — the single largest
+  fresh-install defect in the rc.4 sweep, and the change that makes seeded
+  profile flags reach the ~93% of registered models that carry no stamped
+  tune.
+- **Profile tuning corrections.** Every seeded profile now requests `-fa auto`
+  instead of forcing `-fa on`, so Flash Attention falls back cleanly when it
+  cannot be scheduled on its layer's device (#1811/#1813). The brain seed moves
+  to `-b 2048 -ub 512` (the small batch cost ~12–14% prefill on CT105 with no
+  decode benefit) and to MiniCPM5's published sampler — `--top-p 0.95`, no
+  `--top-k` (#1815).
+- **Benchmarks can leave the box, deliberately.** `hal0 bench upload <bundle>`
+  and `hal0 bench bundle --upload` publish a result bundle to the bench API
+  behind `HAL0_BENCH_TOKEN`; uploads are content-addressed and idempotent, and
+  records that the publish API would reject are never bundled in the first
+  place (#1816).
+- **The release-candidate validation kit is versioned.** The ad-hoc workflows
+  used to validate rc.4 now live in `tests/release-validation/` as lane briefs,
+  a known-issues list, a regression register seeded with all eleven rc.4
+  findings, box profiles and a report template — so every finding filed in one
+  release becomes a mandatory probe in every release after it (#1817).
+
+### Added
+
+- `hal0 bench upload <bundle>` and `hal0 bench bundle --upload` — publish a
+  benchmark bundle to the bench API that backs
+  [hal0.dev/benchmarks](https://hal0.dev/benchmarks). Admin token from
+  `$HAL0_BENCH_TOKEN` only; deliberately no `--token` flag, since an argv
+  credential is visible in `ps`, shell history and journald (#1816).
+- `hal0 doctor ports` gains a per-port DNAT table and a `--fix` repair path,
+  plus a `Port DNAT rules` row in `hal0 doctor all`. Repair routes through new
+  `prune-dnat`/`check-dnat` verbs on the `hal0-systemctl` seam, which re-derive
+  the chain root-side and refuse any rule whose target IP belongs to a running
+  container (#1819).
+- `tests/release-validation/` — versioned release-candidate validation kit
+  (13 lane briefs, known-issues list, regression register, box profiles, report
+  template) with `.claude/workflows/rc-validate.js` orchestration and the rc.4
+  report backfilled as the comparison baseline (#1817).
+- `hal0 profile list` / `hal0 profile show` — read-only profile inspection from
+  the CLI, previously dashboard- and MCP-only (#1796).
 
 ### Fixed
 
@@ -128,6 +194,95 @@ applying. Add those subsections to a version's section to surface them; see
   having compute access rather than showing the host's, no more empty
   interpolations in the Benchmarks header, correct bank-count
   pluralization, and accessible names on the nav rail (#1797).
+- The brain seed profile no longer ships a Qwen-family sampler on a MiniCPM5
+  model: `-b 512 -ub 256` → `-b 2048 -ub 512` (the small batch cost ~12–14%
+  prefill throughput on ROCm across two independent measurement windows, with
+  no decode benefit), `--top-p 0.9` → `0.95`, and `--top-k 20` dropped —
+  matching MiniCPM5-1B's published no-think recommendation. These are
+  server-level defaults every brain request inherits unless the caller
+  overrides (#1815, refs #1811).
+- The installer's steward copy matches how the brain actually behaves. Since
+  runner `ade07ba` the brain models are native tool-callers, so the interactive
+  lead-in, both skip notices and `SKIP_NOTICE` no longer claim the steward
+  "cannot call tools on its own" or frame the agent model as a hard requirement
+  for tool calling. The post-skip hint is now the command that actually works
+  (`hal0 slot load agent --model <id>` — the bare form bails to OFFLINE on a
+  model-less slot) (#1784).
+- The FastFlowLM skip warning no longer claims an "Ubuntu .deb only" limit that
+  the script's own distro resolution contradicts — upstream ships SHA-pinned
+  per-distro artefacts for ubuntu24.04/25.10/26.04 and debian13. The "no agent
+  model fits this box" notice derives its floor from the curated ladder via a
+  new `--floor` mode on `agent_model.py` instead of hardcoding `~15 GB` in bash
+  (#1785).
+- `installer/README.md` is back in sync with `install.sh`: all 16 `ui_step`
+  banners in the right order, the previously omitted steward/agent model pull,
+  Node.js toolchain, ComfyUI model share, bundle-picker manifests and agent
+  skills, the six first-run/model-pull env knobs plus `HF_TOKEN`, and the
+  corrected claim that `hal0-api` runs as `User=hal0` with privileged
+  operations routed through the `hal0-systemctl`/`hal0-update` sudo seams
+  (#1786).
+
+### Docs
+
+- `docs/getting-started/index.mdx` and `docs/concepts/slots.mdx` carry the
+  presentation hooks hal0.dev needs (`## Sections` + `<DocsSectionCards />`,
+  and an `appliesTo: v1.0` stamp). The website mirrors `docs/<section>/` with
+  `rsync --delete`, so anything added web-side is erased on the next sync;
+  these hooks keep the site's section grid and version stamp alive without
+  pulling web dependencies into this repo (#1812).
+
+### Audience
+
+Preview-channel operators validating the 1.0 line ahead of GA, and fresh
+installs that want the current build. This is the release candidate that clears
+the rc.4 fresh-install findings on real hardware — it is the recommended pre-GA
+validation target, and it supersedes rc.4 for anyone hitting 501s on
+`/v1/embeddings`, `/v1/rerank` or `/metrics`. Boxes on the stable channel are
+not offered this tag.
+
+### Supported upgrades
+
+- `1.0.0-rc.4` → `1.0.0-rc.5` via `hal0 update` (preview channel). The GitHub
+  release asset URL (`https://github.com/Hal0ai/hal0/releases/download/v1.0.0-rc.5/preview.json`)
+  works end-to-end for install and update.
+- `1.0.0-rc.3` / `1.0.0-rc.2` / `1.0.0-rc.1` → `1.0.0-rc.5` directly, same
+  mechanism.
+- `0.9.8` → `1.0.0-rc.5` in place — re-run the installer or `hal0 update` on
+  the preview channel; the R5 migration set applies (see the
+  [1.0.0 changelog section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100--2026-08-07)).
+- Older than 0.9.8: step through 0.9.8 first.
+
+### Known issues
+
+The 0.9.8 CLI's spurious end-of-update `ConnectError` (the pre-1.0 client dies
+when the apply restarts hal0-api under its status poll, even though the update
+succeeds — verify with `hal0 --version`) and the first-boot
+`unattended-upgrades` dpkg race (#1584) carry forward. A box still on rc.1/rc.2
+whose venv predates #1663 is not *offered* a newer tag by the passive check —
+`hal0 update --target <version>` is the recovery path (#1715). Literal memory
+recall still leans on a client-side document fallback; the durable fix needs
+server-side content search in the memory engine and is tracked on #1794.
+
+### Operator migrations
+
+- **Stale DNAT rules (#1819):** a box that has been running slots across a root
+  SSH logout may already carry orphaned netavark DNAT rules. Run `hal0 doctor
+  ports` after updating; if it reports shadowed ports, `hal0 doctor ports --fix`
+  prunes them. New installs get the runtime-dir pin that prevents the leak.
+- **Deprecated `extra_args` at the seam (#1759)** and the **releases-URL
+  override (#1750)** migrations from rc.4 still apply to boxes coming from
+  rc.3 or earlier; see the
+  [1.0.0-rc.4 section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc4--2026-08-09).
+- The R5 operator-run migrators (slot-flag fold, id-keying) are unchanged from
+  rc.1.
+
+### Rollback
+
+Release tarballs are immutable and cosign-signed; roll back by re-installing
+the previous tag (`v1.0.0-rc.4`) from its GitHub release. No rc.5 change writes
+a state shape rc.4 cannot read — the new `SlotConfig.metrics` field defaults to
+`true` and is ignored by an older daemon, and the profile-flag corrections are
+re-derived from the shipped seeds on every launch.
 
 ## [1.0.0-rc.4] — 2026-08-09
 

--- a/README.md
+++ b/README.md
@@ -7,57 +7,40 @@
 
 ### Open-source home AI inference platform
 
-[hal0.dev](https://hal0.dev) · [Install](https://hal0.dev/docs/getting-started/install/) · [Docs](https://hal0.dev/docs/) · [Roadmap](https://hal0.dev/#roadmap) · [Discord](https://discord.gg/7M4y6dcUyq)
+**Stop running models from a chat tab.**
+
+[hal0.dev](https://hal0.dev) · [Install](https://hal0.dev/docs/getting-started/install/) · [Docs](https://hal0.dev/docs/) · [Benchmarks](https://hal0.dev/benchmarks) · [Roadmap](https://hal0.dev/#roadmap) · [Discord](https://discord.gg/7M4y6dcUyq)
 
 </div>
 
 ---
 
-hal0 turns a Linux box — ideally a Ryzen AI Max+ 395 with 128 GB of
-unified memory — into a polished, OpenAI-compatible inference appliance.
-Hardware-aware slots, prewired chat UI, signed self-update. One command
-installs the lot.
+hal0 turns a Linux box — ideally a Ryzen AI Max+ 395 with 128 GB of unified
+memory — into a private, OpenAI-compatible inference appliance. Chat,
+completions, embeddings, reranking, transcription, speech and image
+generation all answer on one `:8080/v1` surface, on hardware you own, with
+no per-token bill.
 
 Every inference workload runs as its own **podman container** under a
-`hal0-slot@<name>.service` unit. `hal0-api` on `:8080` is the sole
-control plane — it owns slot state machines, dispatches OpenAI-compatible
-`/v1/*` requests to the right slot port, and serves the dashboard. No
-shared inference daemon; no extra process to babysit.
-
-> **⚡ The installer is the whole setup.** There is no separate first-run
-> wizard to run afterwards. `install.sh` asks where models should live,
-> optionally takes a HuggingFace token, creates every capability slot,
-> downloads the hal0 brain steward model, and starts the API. When it
-> finishes, open the dashboard and assign models to slots.
+`hal0-slot@<name>.service` unit. `hal0-api` on `:8080` is the sole control
+plane — it owns slot state machines, dispatches `/v1/*` requests to the right
+slot port, and serves the dashboard. No shared inference daemon; no extra
+process to babysit.
 
 ```sh
 curl -fsSL https://hal0.dev/install.sh | sudo bash
 ```
 
-> **Status:** **release candidate — v1.0.0 stable is the target of the current cut.** Container-runtime era,
-> declarative config. Each slot (`agent`, `utility`, `embed`, `rerank`,
-> `stt`, `tts`, `img`, NPU trio) runs as a dedicated podman
-> container (`hal0-slot@<name>.service`). Slot definitions live in
-> `/etc/hal0/slots/<name>.toml`; backend profiles in
-> `/etc/hal0/profiles.toml`; the model catalog is `registry.toml` — the
-> single source of truth for every HuggingFace coordinate and SHA-256
-> digest. The launch command for every slot is resolved from a single
-> source (deduped, with per-flag provenance), **Stacks** apply
-> declarative model/slot layouts atomically, and profiles share the same
-> portable export/import envelope. hal0 is **Strix Halo native, not
-> Strix-Halo-only**: experimental CUDA + multi-GPU pinning ride alongside
-> the ROCm/Vulkan defaults. Companion services (Open WebUI, ComfyUI,
-> Hermes, Hindsight) are managed from one **Services** dashboard
-> page with mDNS discovery; the dashboard itself has a redesigned
-> fixed-band layout with a live telemetry header. Seed profiles are
-> virtual (code-defined, self-healing on upgrade) with dedicated
-> embed/rerank lanes and a model×profile×slot MTP decision; models carry
-> a preferred runtime profile, interrupted pulls resume, and voice runs
-> end-to-end (NPU or CPU/Moonshine STT + Kokoro or GPU Qwen3-TTS). The one-liner creates
-> every capability slot and pulls the `brain` steward model; the rest of
-> the slots land model-less, so you assign models from the dashboard (or
-> `hal0 model pull` + `hal0 slot load`) with no surprise downloads. See
-> [`CHANGELOG.md`](./CHANGELOG.md) for what ships in each release.
+> **⚡ The installer is the whole setup.** There is no separate first-run
+> wizard afterwards. `install.sh` asks where models should live, optionally
+> takes a HuggingFace token, seeds every capability slot, downloads the hal0
+> brain steward model, and starts the API. When it finishes, open the
+> dashboard and assign models to slots.
+
+> **Status: release candidate — `v1.0.0-rc.5`.** v1.0.0 stable is the target
+> of the current cut. rc.5 is the validation candidate: it closes every
+> defect the rc.4 fresh-install sweep found on real hardware. See
+> [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Screenshots
 
@@ -89,188 +72,226 @@ curl -fsSL https://hal0.dev/install.sh | sudo bash
 
 ## Why hal0
 
-**Strix Halo native, but not Strix-Halo-only.** The probe is UMA-aware
-on Strix Halo and falls back to portable parsers (`/proc/cpuinfo`,
-`/proc/meminfo`, `lspci`) on every other host. The `platform` field on
-`/api/hardware` resolves to one of `strix-halo`, `wsl2`, `lxc`,
-`proxmox-kvm`, `kvm`, `bare-metal-{nvidia,amd,intel}-gpu`, or
-`bare-metal-cpu-only`, and the dashboard only labels memory as
-"unified" when it actually is. The slot-fit warnings size against the
-real unified pool, not a BAR carve-out. The XDNA NPU is a first-class
-device — opt-in even at Pro/Max tier, packing three model roles into
-one process via the FLM trio (see below). 128 GB Ryzen AI Max+ 395 is
-the reference deployment — not a hopeful port.
+**Point your editor at your own box.** Aim any OpenAI-compatible client at
+`http://<box>:8080/v1` — Claude Code, Cline, Continue, an SDK, a cron job.
+A dedicated `coder` slot can serve your editor while the `agent` slot serves
+chat, each on its own container, model and flag set.
 
-**One control plane, six modalities, dedicated containers.** Each
-slot runs in isolation — chat, embed, rerank, STT, TTS, and image
-generation each get their own podman container with its own image,
-flags, port, and lifecycle. Concurrent workloads don't share a process
-pool; they share only the GPU through the arbiter. Slot state is
-persisted to `/var/lib/hal0/slots/<name>/state.json` and streamed via
-SSE. Chat + embed alone sustains ~258 tok/s on Strix Halo at the
-reference ROCm FP4 loadout.
+**Retrieval grounded on your data.** Embeddings and reranking are
+first-class slots, not an afterthought: `/v1/embeddings` and `/v1/rerank`
+run on the same box as chat, and the bundled Hindsight memory engine turns
+conversations into recallable facts behind an MCP server.
+
+**Speech and images on the same control plane.** Transcription
+(`/v1/audio/transcriptions`), speech (`/v1/audio/speech`) and image
+generation (`/v1/images/generations`, `/v1/images/edits`) are the same API,
+the same auth posture, the same dashboard — no second stack to operate.
+
+**Not another llama-server wrapper.** Every workload is a real
+systemd-managed slot with a typed lifecycle, persisted state
+(`/var/lib/hal0/slots/<name>/state.json`), SSE status streaming, per-slot
+journald logs and a GPU arbiter that keeps image generation from stealing
+the iGPU out from under a streaming completion.
+
+**Strix Halo native, but not Strix-Halo-only.** The probe is UMA-aware on
+Strix Halo and falls back to portable parsers (`/proc/cpuinfo`,
+`/proc/meminfo`, `lspci`) everywhere else. `platform` on `/api/hardware`
+resolves to one of `strix-halo`, `wsl2`, `lxc`, `proxmox-kvm`, `kvm`,
+`bare-metal-{nvidia,amd,intel}-gpu` or `bare-metal-cpu-only`, and the
+dashboard only labels memory "unified" when it actually is. Slot-fit
+warnings size against the real unified pool, not a BAR carve-out.
 
 **NPU multi-role via the FLM trio.** On Strix Halo with FastFlowLM
 installed, a single FLM process inside the `hal0-toolbox-flm` container
-hosts chat + transcription + embedding concurrently on the one AMDXDNA
-hardware context — ~2 GB NPU memory, gemma3:1b at 40 tok/s +
-Whisper-V3-Turbo + Embedding-Gemma all coresident. hal0 exposes this
-as one seeded `flm` slot (chat-first) whose `[npu]` table — or the
-dashboard's NPU drawer — toggles ASR and embed on the running
-`flm serve`; the occupancy card shows the coresident STT/embed
-sub-cards. The host-side FLM `.deb` is
-installed for device-sanity probes only — inference runs in the
-container. See ADR-0009 (FLM trio NPU packing) for why.
+hosts chat + transcription + embedding concurrently on one AMDXDNA hardware
+context — ~2 GB NPU memory, gemma3:1b at ~38.6 tok/s + Whisper-V3-Turbo +
+Embedding-Gemma all coresident. hal0 exposes this as one seeded `flm` slot
+(chat-first) whose `[npu]` table — or the dashboard's NPU drawer — toggles
+ASR and embed on the running `flm serve`. The host-side FLM `.deb` is
+installed for device-sanity probes only; inference runs in the container.
+See [docs/concepts/strix-halo.mdx](./docs/concepts/strix-halo.mdx).
 
-**Dispatcher with single-flight + OmniRouter tool-calling.** Registry-aware
-routing across local slots *and* external upstreams (OpenRouter,
-Anthropic, OpenAI, custom). The client-side OmniRouter loop provides
-8 OpenAI tool-calling tools (image generation/editing, TTS,
-transcription, vision, embed, rerank, route_to_chat) dispatched
-through hal0 from any chat slot whose model carries the `tool-calling`
-label. The set is filtered per request — a tool only appears in the
-prompt if its target slot is enabled and its model carries the
-required labels.
+**An agent that lives on the box.** The hal0-brain steward drives the
+platform from the dashboard's top bar, and Hermes/Pi install as real
+services prewired to the local API and MCP servers.
 
-**Reliability bar.** Atomic env file writes. Schema-validated TOML.
+**Reliability bar.** Atomic env-file writes. Schema-validated TOML.
 Structured error envelopes (`{"error":{"code":"slot.not_ready",...}}`).
-Cosign-verified self-update with one-flag rollback. Per-type LRU
-concurrency with active-inference protection — a serving slot cannot
-be evicted out from under a streaming request.
+Cosign-verified self-update with one-flag rollback. Per-type LRU concurrency
+with active-inference protection — a serving slot cannot be evicted out from
+under a streaming request. Privileged operations run through an allow-listed
+root seam, never a free-form shell.
+
+## Benchmarks
+
+Numbers below are from the public leaderboard at
+[hal0.dev/benchmarks](https://hal0.dev/benchmarks) — 26 models measured end
+to end on the reference box (AMD Ryzen AI Max+ 395, Radeon 8060S iGPU,
+128 GB LPDDR5X, ROCm 7.2.4), `rocm` lane, decode and prefill throughput plus
+TTFT, speculative accept rate, memory, watts and temperature per run.
+
+| Model | Params | Quant | Decode (tok/s) | Prefill (tok/s) |
+|---|---|---|---|---|
+| `qwen3.5-0.8b` | 0.8B | q4 | **169.8** | **6,248** |
+| `chadrock3-6-35b-uncensored` | 35B MoE | q4 | 102.1 | 890 |
+| `chadrock-35b-ace-saber` | 35B MoE | f16 | 100.5 | 903 |
+| `qwen3.6-35b-a3b-crown` | 35B MoE | f16 | 84.4 | 873 |
+| `qwopus3-5-4b-coder` | 4B | q4 | 85.0 | 889 |
+| `qwen3-4b` | 4B | q4 | 61.9 | 1,849 |
+| `gemma-4-26b-a4b` | 26B MoE | q4 | 40.9 | 1,336 |
+
+Concurrency and non-LLM lanes, same box:
+
+| Workload | Measurement |
+|---|---|
+| Chat + embed, concurrent | ~258 tok/s aggregate |
+| NPU chat (FLM trio, gemma3:1b) | ~38.6 tok/s in ~2 GB NPU memory |
+| TTS — Kokoro (CPU) | ~0.18 real-time factor |
+| TTS — Qwen3-TTS (ROCm) | ~0.48 real-time factor (~2.1× realtime) |
+
+Benchmarking is a first-class subsystem, not a spreadsheet: `hal0 bench
+plan|run|results|eval|bundle|upload` drives `llama-bench`/`llama-server`
+under a record schema with a dedup identity key, an in-dashboard Benchmarks
+page (roster / runs / evals / run-queue), and regression journaling. Results
+never leave the box on their own — `hal0 bench bundle` writes a
+content-addressed, host-redacted archive you can attach anywhere, and
+`hal0 bench upload` publishes one only when you type it. See
+[docs/reference/model-roster-benchmark.mdx](./docs/reference/model-roster-benchmark.mdx).
 
 ## What's in the box
 
 - **OpenAI-compatible `/v1/*` API** — chat, completions, embeddings,
-  rerank, audio transcriptions, audio speech, image generations,
-  image edits, models. Drop-in for any OpenAI SDK; point your client
-  at `http://localhost:8080/v1` and go.
+  rerank, audio transcriptions, audio speech, image generations, image
+  edits, models. Drop-in for any OpenAI SDK; point your client at
+  `http://localhost:8080/v1` and go.
 - **Slots** — each named target carries a `type`
-  (`llm | embedding | reranking | transcription | tts | image`),
-  a `device` (`gpu-rocm | gpu-vulkan | cpu | npu | img`), a `model`,
-  plus `enabled` and optional `default`. Five seeded slots (`flm`,
-  `tts`, `rerank`, `utility`, `img`) are written to
-  `/etc/hal0/slots/<name>.toml` during install (each gates on its own
-  runtime validation at load time — the `flm` NPU slot simply stays
-  grey without FastFlowLM hardware); the installer scaffolds the
-  additional capability slots (chat/`agent`, coder, embed, stt)
-  with empty model picks for the operator to fill.
-  User-added slots via `hal0 slot create NAME --type TYPE --model MODEL`.
-  Slots refer to a **profile** in `/etc/hal0/profiles.toml` that pins
-  the container image + flag bundle for that backend.
-- **Container runtime** — each slot runs as its own podman container
-  under `hal0-slot@<name>.service`. `hal0-api` on `:8080` is the
-  control plane; slot containers bind loopback ports (8081–8099 + fixed
-  seeds). No shared inference daemon. See
+  (`llm | embedding | reranking | transcription | tts | image`), a `device`
+  (`gpu-rocm | gpu-vulkan | gpu-cuda | cpu | npu | img`), a `model`, plus
+  `enabled` and an optional `default`. Ten curated slots (`agent`, `brain`,
+  `coder`, `embed`, `flm`, `img`, `qwen3tts`, `rerank`, `tts`, `utility`)
+  are seeded into `/etc/hal0/slots/<name>.toml` on install and each gates on
+  its own runtime validation at load time — the `flm` NPU slot simply stays
+  grey without FastFlowLM hardware. Add your own with
+  `hal0 slot create NAME --type TYPE --model MODEL`. A deliberate
+  `hal0 slot delete` is tombstoned, so re-running the installer never
+  resurrects it.
+- **Model owns its tune** — since v1.0 the *model*, not the slot, owns
+  `context_size`, `extra_args`, `chat_template`, `profile` and MTP. A slot's
+  `[model].context_size` is a ceiling; a model with no stamped tune inherits
+  its profile's template as a floor.
+- **Container runtime** — every slot runs as its own podman container under
+  `hal0-slot@<name>.service`, bound to a loopback port (8081–8099 + fixed
+  seeds). `hal0-api` on `:8080` is the only control plane. See
   [docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx).
 - **Provisioning lives in the installer** — `install.sh` is the single
-  user-facing entry point. It asks for model storage and an optional
-  HuggingFace token (on a terminal only), copies the curated slot seeds,
-  scaffolds the remaining capability slots, pulls the `brain` steward
-  model, and starts the API. Set `HAL0_SKIP_SETUP=1` to skip the
-  first-run seeding step, `HAL0_SKIP_BRAIN_MODEL=1` to skip the brain
-  pull, and `HAL0_NONINTERACTIVE=1` to suppress both prompts.
-- **Hardware-aware probe** — detects GPU / NPU / unified memory,
-  writes `/etc/hal0/hardware.json`, surfaces VRAM/RAM fit warnings
-  inline in the slot form and during install.
-- **Dispatcher** — registry-aware routing, cold-cache prefetch,
-  upstream fallback (OpenRouter, Anthropic, OpenAI, custom OpenAI-shaped
-  endpoints). Mix local + remote per-model in one config.
+  user-facing entry point: model storage, optional HuggingFace token (on a
+  terminal only), curated slot seeds, the `brain` steward pull, an optional
+  agent-model offer, and service start. `HAL0_SKIP_SETUP=1` skips first-run
+  seeding, `HAL0_SKIP_BRAIN_MODEL=1` skips the brain pull, and
+  `HAL0_NONINTERACTIVE=1` suppresses both prompts. See
+  [`installer/README.md`](./installer/README.md) for the full step list and
+  env-var table.
+- **Hardware-aware probe** — detects GPU / NPU / unified memory, writes
+  `/etc/hal0/hardware.json`, and surfaces VRAM/RAM fit warnings inline in
+  the slot form and during install.
+- **Dispatcher** — registry-aware routing, single-flight, cold-cache
+  prefetch, and upstream fallback (OpenRouter, Anthropic, OpenAI, Google AI
+  Studio, Ollama, custom OpenAI-shaped endpoints). Mix local + remote
+  per-model in one config.
 - **Dashboard** — React 18 + Vite UI for slot/model management,
-  hardware-aware configuration, live logs, system health, and a
-  built-in chat page (with popout window + reasoning toggle).
-  SSE-backed status + log tail. Journal panel streams per-slot
-  container logs via journald. Dark by default. Live telemetry —
-  Power & Thermal (GPU clock/temp/power) and Per-Slot Throughput —
-  is on by default, and the logs/events surface is unified across
-  channels with real source/slot attribution.
-  The slots page splits into Inference | Image Gen tabs: the Image-Gen
-  tab operates the ComfyUI container (live GTT/RAM gauges, queue
-  depth, model inventory) with a gated inference ⇄ generation iGPU
+  hardware-aware configuration, live logs, system health and a built-in chat
+  page (popout window + reasoning toggle). SSE-backed status and log tail; a
+  Journal panel streams per-slot container logs from journald. Live
+  telemetry — Power & Thermal (GPU clock/temp/power) and per-slot throughput
+  — is on by default. The slots page splits into Inference | Image Gen tabs;
+  the Image-Gen tab operates the ComfyUI container (live GTT/RAM gauges,
+  queue depth, model inventory) with a gated inference ⇄ generation iGPU
   switchover behind a blast-radius confirm.
-- **Extensions** — Apps (Open WebUI) and Agents (Hermes, Pi) are
-  installed and wired by dedicated installer stages; add or remove them
-  later with `hal0 agent install <name>`.
-- **Companion-service management** — `/api/services` is the declarative
-  source of truth for OpenWebUI, Hermes, Hindsight, ComfyUI, and n8n:
-  audit-logged systemd lifecycle actions (start/stop/restart/enable/
-  disable), mDNS `.local` advertisement, and a dedicated dashboard
-  Services page.
-- **Stacks** — declarative, runtime-switchable model/slot layouts as a
-  replacement for install-time bundle tiers. A `StackConfig` is planned
-  into a change set, applied atomically (with rollback) and converged
-  against the live slot set; drift is detected by content hash. Stacks
-  export/import via a checksummed `.hal0stack.json` envelope, and a live
-  config can be snapshotted back into a Stack.
-- **OpenWebUI prewired** — chat at `:3001`, zero config. The installer
-  writes `openwebui.env` pointing at the local hal0 API.
+- **AI Capabilities page** — one settings surface for TTS, STT, embeddings,
+  reranking, image generation and the NPU, with per-panel probe-failure
+  surfacing instead of a silent grey Save.
+- **Stacks** — declarative, runtime-switchable model/slot layouts. A
+  `StackConfig` is planned into a change set, applied atomically (with
+  rollback) and converged against the live slot set; drift is detected by
+  content hash. Stacks export/import via a checksummed `.hal0stack.json`
+  envelope, and a live config can be snapshotted back into a Stack.
 - **OmniRouter (8 tools)** — `generate_image`, `edit_image`,
   `text_to_speech`, `transcribe_audio`, `analyze_image` (vision),
-  `embed_text`, `rerank_documents`, `route_to_chat`. Dispatched
-  client-side from chat slots; dynamically filtered per request.
-- **Image generation, day one** — `POST /v1/images/generations` via
-  ComfyUI in the `img` slot container (ROCm). The installer seeds the
-  `img` slot and its ComfyUI model share as part of the install.
+  `embed_text`, `rerank_documents`, `route_to_chat`. Dispatched client-side
+  from any chat slot whose model carries the `tool-calling` label, and
+  filtered per request — a tool only appears in the prompt if its target
+  slot is enabled and its model carries the required labels.
+- **Companion-service management** — `/api/services` is the declarative
+  source of truth for OpenWebUI, Hermes, Hindsight, ComfyUI and n8n:
+  audit-logged systemd lifecycle actions (start/stop/restart/enable/
+  disable), mDNS `.local` advertisement, and a dedicated Services page.
+  OpenWebUI is prewired at `:3001` with zero config.
+- **Image generation, day one** — `POST /v1/images/generations` via ComfyUI
+  in the `img` slot container (ROCm). The installer seeds the `img` slot and
+  its ComfyUI model share.
 - **Atomic self-update with rollback** — `hal0 update --channel
   stable|preview|nightly`. Cosign-verified tarballs swap a
-  `/usr/lib/hal0/current` symlink; `--rollback` reverts.
-- **One-line install** — `curl -fsSL https://hal0.dev/install.sh | sudo bash`
-  creates every capability slot and its wiring automatically. The only
-  model it downloads is the `brain` steward; every other slot lands
-  model-less for you to fill from the dashboard. Piped through `bash`
-  it never prompts.
-  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects model pulls
-  off `/var/lib/hal0/models`). The bootstrap requires `jq` and `cosign`,
+  `/usr/lib/hal0/current` symlink; `--rollback` reverts. Staging happens in
+  a root-only directory with the authenticated digest pinned to the very
+  file object the archive is extracted from.
+- **One-line install** — `curl -fsSL https://hal0.dev/install.sh | sudo bash`.
+  The only model it downloads is the `brain` steward; every other slot lands
+  model-less for you to fill. Piped through `bash` it never prompts.
+  (`--models-dir=PATH` or `HAL0_MODELS_DIR=PATH` redirects model pulls off
+  `/var/lib/hal0/models`.) The bootstrap requires `jq` and `cosign`,
   authenticates the exact channel manifest before strict schema/channel
   parsing, then sha256- and Sigstore-bundle-verifies the tarball before
-  handing off to
-  [`installer/install.sh`](./installer/install.sh).
-  Re-running `install.sh` at any time is safe — every provisioning step
-  is idempotent and existing slot configs are never overwritten.
+  handing off to [`installer/install.sh`](./installer/install.sh). Re-running
+  it is safe: every provisioning step is idempotent and existing slot
+  configs are never overwritten.
 - **One-line Proxmox VE install** — on a Proxmox host, `bash -c "$(curl
   -fsSL https://raw.githubusercontent.com/Hal0ai/hal0/main/scripts/proxmox-ve/hal0.sh)"`
   creates an unprivileged Debian 13 LXC and runs the standard bootstrap
-  inside it. `--advanced` opens whiptail prompts; every parameter has
-  an env-var override (`CTID`, `RAM_MB`, `STORAGE`, …). Hardware-agnostic
-  — Strix Halo passthrough still requires the privileged-LXC recipe.
-  See [`scripts/proxmox-ve/README.md`](./scripts/proxmox-ve/README.md).
+  inside it. `--advanced` opens whiptail prompts; every parameter has an
+  env-var override (`CTID`, `RAM_MB`, `STORAGE`, …). Hardware-agnostic —
+  Strix Halo passthrough still needs the privileged-LXC recipe. See
+  [`scripts/proxmox-ve/README.md`](./scripts/proxmox-ve/README.md).
 
-### Bundled agents
+### Agents, MCP, and the brain steward
 
-hal0 ships **two MCP servers** and **two bundled agents**. The MCP
-servers (`/mcp/admin` for slot / model / capability / config / hardware
-/ log admin and `/mcp/memory` for Hindsight-backed long-term memory) are
-reachable by any MCP-speaking client — Claude Code, future RAG
-services, external scripts. Both bundled agents can be installed
-simultaneously: `pi-coder` (CLI shape, installed from `Hal0ai/pi-mono` fork via
-`@earendil-works/pi-coding-agent` on npm) and `Hermes-Agent` (service
-shape, installed via the hal0-owned `hermes` wrapper — `hal0-hermes` is
-kept as a back-compat symlink; connects to
-`hal0-api` via `HAL0_INFERENCE_BASE=http://127.0.0.1:8080`). Select
-one or both at any time via `hal0 agent install <name>`. Capital-D destructive MCP calls
-(`model_pull`, `slot_delete`, `config_write`, etc.) gate through a
-header bell + inbox modal in the dashboard, with CLI parity via
-`hal0 agent approvals {list,approve,deny}`. See
-[docs/concepts/agents.mdx](./docs/concepts/agents.mdx),
-[docs/reference/mcp-tools.mdx](./docs/reference/mcp-tools.mdx), and
-[docs/guides/run-agents.mdx](./docs/guides/run-agents.mdx).
+hal0 ships **two MCP servers** and **two bundled agents**. The MCP servers
+(`/mcp/admin` for slot / model / capability / config / hardware / log admin,
+`/mcp/memory` for Hindsight-backed long-term memory) are reachable by any
+MCP-speaking client — Claude Code, RAG services, your own scripts. Both
+bundled agents can be installed simultaneously: `pi-coder` (CLI shape, from
+the `Hal0ai/pi-mono` fork via `@earendil-works/pi-coding-agent` on npm) and
+`Hermes-Agent` (service shape, via the hal0-owned `hermes` wrapper —
+`hal0-hermes` remains a back-compat symlink — connecting to `hal0-api` at
+`HAL0_INFERENCE_BASE=http://127.0.0.1:8080`). Install either with
+`hal0 agent install <name>`. Destructive MCP calls (`model_pull`,
+`slot_delete`, `config_write`, …) gate through a header bell + inbox modal
+in the dashboard, with CLI parity via
+`hal0 agent approvals {list,approve,deny}`.
 
 The **hal0-brain steward** is a third, built-in persona wired to the
 dashboard's top-bar agent chat — no install step. It drives the platform
-through the full **180-tool `hal0-admin` catalog** (models, slots, stacks,
+through the **180-tool `hal0-admin` catalog** (models, slots, stacks,
 profiles, settings, upstreams, benchmarks) under a **per-persona tool
-policy**: `tools_allowed` hides tools, `require_approval` tightens them,
-and a `POLICY_NO_LOOSEN` floor keeps destructive/secret-bearing tools
-(`*_delete`, `config_write`, `provider_credential_write`) always gated —
-no persona edit can disarm them. Gated calls **pause the turn** for
-inline approve/deny; a `[brain_chat]` config gives operators a hard kill
-switch, a read-only mode, loop-budget knobs, and a slot override (run the
-steward on any slot, e.g. `hal0/npu`) from **Settings → Agents / Brain**.
+policy**: `tools_allowed` hides tools, `require_approval` tightens them, and
+a `POLICY_NO_LOOSEN` floor keeps destructive and secret-bearing tools
+(`*_delete`, `config_write`, `provider_credential_write`) always gated — no
+persona edit can disarm them. Gated calls **pause the turn** for inline
+approve/deny. A `[brain_chat]` config gives operators a hard kill switch, a
+read-only mode, loop-budget knobs and a slot override (run the steward on
+any slot, e.g. `hal0/npu`) from **Settings → Agents / Brain**. The shipped
+brain models are native tool-callers, so the steward executes its own calls
+on the brain slot out of the box; binding a larger model to the `agent` slot
+is the optional upgrade path via the `[brain_chat]` `tool_model` fallback.
+
+See [docs/concepts/agents.mdx](./docs/concepts/agents.mdx),
+[docs/reference/mcp-tools.mdx](./docs/reference/mcp-tools.mdx) and
+[docs/guides/run-agents.mdx](./docs/guides/run-agents.mdx).
 
 ## Backends
 
 Each capability runs in its own container, supervised by
-`hal0-slot@<name>.service`. The profile in `/etc/hal0/profiles.toml`
-pins the container image and flag bundle for each backend.
+`hal0-slot@<name>.service`. The profile in `/etc/hal0/profiles.toml` pins
+the flag bundle; the image is slot-owned.
 
 | Capability               | Profile / image                  | Device              | Notes                                                        |
 |--------------------------|----------------------------------|---------------------|--------------------------------------------------------------|
@@ -280,22 +301,27 @@ pins the container image and flag bundle for each backend.
 | TTS                      | `tts` (`hal0-toolbox-kokoro`) / `tts-qwen3` (`hal0-toolbox-qwen3tts`) | CPU / ROCm | `voice.tts` switches Kokoro (CPU) ⇄ Qwen3-TTS (GPU) without reconfiguring the slot |
 | image                    | `comfyui` (`docker.io/kyuz0/amd-strix-halo-comfyui`) | ROCm | Exclusive GPU via arbiter; SD Turbo / Flux-2-Klein-9B        |
 
-The NPU path is opt-in: the installer places a FastFlowLM `.deb` on
-the host for device-sanity probes (`flm validate`); inference runs
-inside the `hal0-toolbox-flm` container image. With FLM present, the
-installer seeds the `flm` slot; the NPU trio activates once `flm
-validate` passes on the host.
+Every seeded profile requests `-fa auto`, so Flash Attention is probed at
+startup and falls back cleanly when it cannot be scheduled on its layer's
+device. A model with a measured win from forcing it can set `-fa on` in its
+own `defaults.extra_args`.
 
-For the container-runtime operator reference — service layout, slot
-TOML fields, profiles, GPU arbiter, and day-2 commands — see
+The NPU path is opt-in: the installer places a FastFlowLM `.deb` on the host
+(SHA-pinned per distro — Ubuntu 24.04/25.10/26.04 and Debian 13) for
+device-sanity probes (`flm validate`); inference runs inside the
+`hal0-toolbox-flm` container. With FLM present the installer seeds the `flm`
+slot, and the NPU trio activates once `flm validate` passes.
+
+For the container-runtime operator reference — service layout, slot TOML
+fields, profiles, GPU arbiter and day-2 commands — see
 [docs/concepts/architecture.mdx](./docs/concepts/architecture.mdx) and
 [docs/guides/manage-slots.mdx](./docs/guides/manage-slots.mdx).
 
 ## Hardware
 
 Linux + systemd is the only hard requirement
-([`installer/lib/preflight.sh`](./installer/lib/preflight.sh), `preflight_systemd`). macOS and Windows
-are not in scope for v1.
+([`installer/lib/preflight.sh`](./installer/lib/preflight.sh),
+`preflight_systemd`). macOS and Windows are not in scope for v1.
 
 | Tier            | Hardware                                                                  | Status |
 |-----------------|---------------------------------------------------------------------------|--------|
@@ -305,6 +331,83 @@ are not in scope for v1.
 | **Supported**   | AMD Radeon RX 7000 / discrete (16–24 GB)                                  | ROCm or Vulkan container profiles; same `hal0-slot@<name>` lifecycle. |
 | **Fallback**    | CPU-only x86_64                                                            | `cpu-llm` profile — the Vulkan toolbox image run CPU-only (no GPU passed to the container). Usable for tiny models / smoke tests, not the headline experience. |
 
+## Setup and day-2 operation
+
+After the one-liner finishes, the dashboard is at `http://<box>:8080` and
+the API at `http://<box>:8080/v1`. Assign models from the dashboard, or:
+
+```sh
+hal0 model pull <hf-repo>/<file.gguf>   # resumable, disk-preflighted
+hal0 slot load agent --model <id>       # bind a model and start the container
+hal0 status                             # system + slot summary
+hal0 chat --brain                       # terminal REPL against the steward
+```
+
+`hal0 model pull` streams from Hugging Face into `registry.toml` under the
+`user.*` namespace — a disk-space preflight fails fast before a multi-GB
+pull, and an interrupted pull resumes via HTTP `Range` instead of restarting
+from zero.
+
+Diagnostics:
+
+```sh
+hal0 doctor all              # full pre-flight against the live host
+hal0 doctor ports            # port claims + netavark DNAT rule audit
+hal0 doctor ports --fix      # prune stale DNAT rules that black-hole a port
+hal0 system-info             # host / GPU / NPU / runtime evidence (read-only)
+```
+
+Services and logs:
+
+```sh
+systemctl status hal0-api
+systemctl list-units 'hal0-slot@*'
+journalctl -fu hal0-api
+journalctl -fu 'hal0-slot@*'
+systemctl restart hal0-slot@agent    # restart a wedged slot container
+```
+
+`hal0 uninstall [--keep-data]` tears down a running install (a thin wrapper
+over `installer/uninstall.sh`).
+
+### Auth posture
+
+hal0 ships built-in login, sessions and a deny-by-default route classifier,
+with three tiers — `anon` → `client` → `admin`. There is no per-user account
+system: a browser session is always admin-equivalent, and programmatic
+callers use `Authorization: Bearer <key>` (or `?api_key=` for WebSocket
+upgrades) against an admin or client key.
+
+**Auth ships off by default.** A fresh v1.0 install is trusted-LAN-open —
+the right posture for a homelab appliance — until an operator turns
+enforcement on:
+
+```sh
+hal0 auth rotate admin     # mint an admin key into /etc/hal0/api.env
+hal0 auth require on       # enforce; takes effect on the next request
+hal0 auth status           # show the current posture
+```
+
+hal0 does **not** terminate TLS or manage a user directory. If it is
+reachable from anything you don't physically control, front it with a
+reverse proxy that owns TLS — Traefik, nginx, Cloudflare Tunnel. Note that
+the optional OpenWebUI companion is a **second listener** on `:3001` that
+this auth model does not cover. See
+[`docs/operate/auth.mdx`](./docs/operate/auth.mdx) and
+[`docs/concepts/security.mdx`](./docs/concepts/security.mdx).
+
+### Proxmox integration (optional)
+
+If hal0 runs inside a Proxmox LXC, the container only sees its own cgroup
+slice of memory — other tenants, ZFS ARC and the host kernel draw from the
+same physical DIMMs as GPU GTT but are invisible from inside. To surface
+that, drop a read-only `PVEAuditor` API token into the dashboard's
+Settings → "Proxmox integration" panel. The unified-memory bar then swaps to
+the physical host's DIMM total and adds a muted "Proxmox host" segment for
+other-tenant + kernel pressure. The token is sensitive, stored 0600 at
+`/etc/hal0/proxmox.json`, and never echoed back by the API. Bare-metal and
+VM installs leave the panel off.
+
 ## Project layout
 
 ```
@@ -312,20 +415,21 @@ hal0/
 ├── src/hal0/         # Python package (FastAPI API + capability layer + ContainerProvider + CLI)
 │   ├── providers/    # ContainerProvider, FLMProvider, ComfyUI, etc.
 │   ├── slots/        # slot manager, state machine, GpuArbiter
+│   ├── bench/        # benchmark planner, runner, store, publish
 │   └── omni_router/  # client-side tool-calling loop + tool definitions
-├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard (v3)
+├── ui/               # React 18 + TypeScript + Vite + Tailwind 4 dashboard
 ├── installer/        # install.sh (writes /etc/hal0/, systemd units, hal0-api.service)
-│   ├── etc-hal0/     # seed slot TOMLs (flm, tts, rerank, utility, img) + profiles.toml
+│   ├── etc-hal0/     # curated slot seeds + profiles.toml
 │   └── systemd/      # hal0-agent@ template units
 ├── tests/            # pytest suite (α unit, β integration, γ release-gate)
-├── docs/             # user docs (mirror of hal0.dev/docs) + docs/adr/; dev notes in docs/.devdocs/ (local-only)
+│   └── release-validation/   # versioned RC validation kit (lanes, regressions, boxes)
+├── docs/             # user docs (mirrored to hal0.dev/docs) + docs/adr/
 ```
 
-The model catalog lives at `/var/lib/hal0/registry/registry.toml` —
-the single source of truth for HuggingFace coordinates, SHA-256
-digests, and curated filenames. Per-leaf symlinks under the models
-directory redirect to `/mnt/ai-models/` when a separate storage
-volume is in use.
+The model catalog lives at `/var/lib/hal0/registry/registry.toml` — the
+single source of truth for HuggingFace coordinates, SHA-256 digests and
+curated filenames. Per-leaf symlinks under the models directory redirect to
+a separate storage volume when one is in use.
 
 ## Quick start (development)
 
@@ -344,135 +448,70 @@ npm run dev
 The API lives at `http://127.0.0.1:8080`, the dashboard at the Vite dev
 server URL (usually `http://127.0.0.1:5173`).
 
-Run `hal0 doctor` any time to re-check pre-flight (systemd / python /
-disk / ports / NPU probe). `hal0 model pull <ref>` streams models from
-Hugging Face into `registry.toml` under the `user.*` namespace — a
-disk-space preflight fails fast before a multi-GB pull, and an
-interrupted pull resumes via HTTP `Range` instead of restarting from
-zero — and `hal0 uninstall [--keep-data]` tears down a running install (thin
-wrapper over `installer/uninstall.sh`).
-
-Useful day-2 commands:
-
-```sh
-# service status
-systemctl status hal0-api
-systemctl list-units 'hal0-slot@*'
-
-# logs
-journalctl -fu hal0-api
-journalctl -fu 'hal0-slot@*'
-
-# restart a wedged slot container
-systemctl restart hal0-slot@agent
-```
-
-### Auth posture
-
-Per ADR-0012 (remove auth and Caddy entirely, supersedes
-ADR-0001), hal0 ships with **no built-in auth and no bundled TLS**.
-`hal0-api` binds `0.0.0.0:8080` and treats every request as
-authenticated by virtue of network reachability — the right posture
-for a homelab appliance on a trusted LAN.
-
-If hal0 is reachable from anything you don't physically control,
-front it with an upstream reverse proxy that owns auth + TLS — Traefik,
-nginx, Cloudflare Tunnel, or your own preferred edge. See
-[`docs/concepts/security.mdx`](./docs/concepts/security.mdx) for example configs
-of each.
-
-### Proxmox integration (optional)
-
-If hal0 runs inside a Proxmox LXC, the container only sees its own
-cgroup slice of memory — other tenants, ZFS ARC, and the host kernel
-draw from the same physical DIMMs as GPU GTT but are invisible from
-inside. To surface that, drop a read-only `PVEAuditor` API token into
-the dashboard's Settings → "Proxmox integration" panel. Once saved,
-the unified-memory bar swaps to the physical host's DIMM total and
-adds a muted "Proxmox host" segment for other-tenant + kernel
-pressure. Token is sensitive and stored 0600 at
-`/etc/hal0/proxmox.json`; the API never echoes it back. Bare-metal and
-VM installs leave the panel off and the dashboard stays quiet.
-
 ## Roadmap
 
 No dates — items are direction. The closer to the left, the closer to
-running on your box. Full version at [hal0.dev/#roadmap](https://hal0.dev/#roadmap).
+running on your box. Full version at
+[hal0.dev/#roadmap](https://hal0.dev/#roadmap).
 
 ### Shipped (v1.0)
 
-- **hal0-brain steward** — the top-bar agent chat drives the whole
-  platform through the 180-tool `hal0-admin` catalog under a per-persona
-  tool policy, pausing turns on gated tools for inline approve/deny
-- **Upstream model controls** — manage external providers (OpenRouter,
-  Anthropic, OpenAI, Google AI Studio, Ollama, custom) with reactive
-  CRUD, per-upstream model filters, and an `enabled` kill-switch, all
-  from the CLI, MCP, and dashboard
+- **Per-slot podman containers** — every inference workload in its own
+  `hal0-slot@<name>.service`; `ContainerProvider` + `profiles.toml` replaced
+  the single-daemon model
+- **hal0-brain steward** — top-bar agent chat driving the 180-tool
+  `hal0-admin` catalog under a per-persona tool policy, pausing turns on
+  gated tools for inline approve/deny
+- **Model-owned tuning** — the model, not the slot, owns context size, MTP
+  and launch flags; profiles supply a floor, never an override
+- **Stacks** — declarative model/slot layouts applied atomically with
+  rollback, drift detection and a portable export envelope
 - **In-dashboard benchmarks** — the `hal0.bench` engine, `/api/benchmarks`,
-  and a Benchmarks page (roster / runs / evals / run-queue)
-- **Dashboard redesign + live telemetry header** — fixed-band layout
-  with a unified-memory hero, and a combined throughput / GPU / CPU /
-  NPU-occupancy metrics card that reads only from live probes
+  a Benchmarks page (roster / runs / evals / run-queue), shareable bundles
+  and leaderboard publishing
+- **Upstream model controls** — external providers (OpenRouter, Anthropic,
+  OpenAI, Google AI Studio, Ollama, custom) with reactive CRUD, per-upstream
+  model filters and an `enabled` kill switch across CLI, MCP and dashboard
 - **Companion services, one surface** — Open WebUI, ComfyUI, Hermes,
-  Hindsight, and n8n managed from a dashboard **Services** page with
-  mDNS discovery and allow-listed lifecycle actions
-- **GPU generalization** — experimental CUDA + per-slot `gpu_index`
-  pinning for multi-GPU hosts, alongside the ROCm/Vulkan defaults
-- **Virtual seed profiles** — code-defined and self-healing on upgrade,
-  with dedicated embed/rerank lanes and a model×profile×slot MTP
-  decision (tri-state Auto/On/Off)
-- **`hal0 mcp` CLI + two-way MCP** — manage MCP servers from the CLI;
-  hal0 hosts admin + memory servers and reaches external ones
-- **Per-slot podman containers** — every inference workload runs in
-  its own `hal0-slot@<name>.service` container; `ContainerProvider` +
-  `profiles.toml` replace the old single-daemon model
-  (epic #652, extraction #687, PRs #688–#726)
-- **GpuArbiter exclusive image mode** — ComfyUI gets the iGPU to
-  itself; LLM GPU slots pause and resume automatically
-- **NPU trio via `hal0-toolbox-flm` container** — FLM trio now runs
-  containerised; host FLM `.deb` is probe-only
-- **`registry.toml` as sole model catalog** — no secondary runtime
-  catalog to sync; `hal0 model` commands and the dashboard are the
-  only safe edit paths
-- **Slot-state Prometheus + EventBus journal** — per-slot observability
-  via journald (`hal0-slot@<name>`) and the dashboard Journal panel
-- **FLM trio NPU packing** — chat + ASR + embed coresident on one
-  AMDXDNA hardware context; toggle via `[npu]` in the slot TOML
-- **OmniRouter client-side tool-calling** — 8 tools, dynamic
-  per-request filtering, `route_to_chat` cross-slot delegation
-- **Installer-owned first-run provisioning** — replaces the web FirstRun
-  picker and the old post-install wizard: `install.sh` scaffolds the
-  model-less slot structure, pulls only the `brain` steward model, and
-  is the single user-facing entry point
-- **`hal0 registry import`** — one-shot v0.1.x → v0.3 registry
-  recovery from a backup tarball
-- Carried forward: OpenAI-compatible `/v1/*`, portable hardware
-  probe, capability slots + orchestrator, dispatcher with
-  single-flight + cold-cache prefetch, bundled OpenWebUI on `:3001`,
-  cosign-keyless self-update with rollback, bundled agents
-  (pi-coder / Hermes-Agent) + MCP admin + Hindsight memory MCP
+  Hindsight and n8n from a dashboard Services page with mDNS discovery
+- **FLM trio NPU packing** — chat + ASR + embed coresident on one AMDXDNA
+  hardware context, toggled from the slot TOML's `[npu]` table
+- **GpuArbiter exclusive image mode** — ComfyUI gets the iGPU to itself; LLM
+  GPU slots pause and resume automatically
+- **OmniRouter client-side tool-calling** — 8 tools, dynamic per-request
+  filtering, `route_to_chat` cross-slot delegation
+- **GPU generalization** — experimental CUDA and per-slot `gpu_index`
+  pinning for multi-GPU hosts alongside the ROCm/Vulkan defaults
+- **Built-in auth** — three tiers, deny-by-default route classification, key
+  rotation and enforcement toggling from CLI or dashboard
+- **Privileged-seam hardening** — the root wrapper allow-lists the content
+  of every unit, drop-in and quadlet it writes; update staging is root-only
+  with the verified digest pinned to the extraction handle
+- **Installer-owned first-run provisioning** — `install.sh` is the single
+  entry point: curated slot seeds, brain steward pull, service start
+- **`registry.toml` as sole model catalog**, slot-state Prometheus +
+  EventBus journal, `hal0 mcp` CLI with two-way MCP, cosign-keyless
+  self-update with rollback, bundled agents (pi-coder / Hermes-Agent)
 
 ### Soon
 
-- **Federated memory** — recall across local + remote sources behind
-  one memory surface (the MCP-client side shipped in v0.9)
-- **Loadout presets** — curated model/slot presets you can flash onto
-  a fresh install (the in-dashboard benchmark runs already shipped)
-- **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of
-  the install script; pacman and apt as first-class install paths
+- **Federated memory** — recall across local + remote sources behind one
+  memory surface (the MCP-client side shipped in v0.9)
+- **Loadout presets** — curated model/slot presets you can flash onto a
+  fresh install
+- **AUR PKGBUILD & Ubuntu PPA** — native distro packages on top of the
+  install script; pacman and apt as first-class install paths
 - Light mode toggle
 
 ### Exploring (v1.x +)
 
-- **Multi-host federation** — a slot mesh across LAN boxes — primary
-  on the Strix Halo, embed on the workstation, all behind one `/v1/*`
-  surface
-- **Fine-tune & LoRA hot-swap** — attach and rotate LoRAs against a
-  warm base model without unloading the underlying weights
-- **Per-model rate limits & budgets** — cost-style accounting for
-  local inference — cap a chatty agent without taking the whole box down
-- **ChatOps adapters** — Slack and Matrix bridges as extensions —
-  talk to hal0 from the rooms you already live in
+- **Multi-host federation** — a slot mesh across LAN boxes — primary on the
+  Strix Halo, embed on the workstation, all behind one `/v1/*` surface
+- **Fine-tune & LoRA hot-swap** — attach and rotate LoRAs against a warm
+  base model without unloading the underlying weights
+- **Per-model rate limits & budgets** — cost-style accounting for local
+  inference; cap a chatty agent without taking the whole box down
+- **ChatOps adapters** — Slack and Matrix bridges as extensions
 
 ## License
 
@@ -480,11 +519,10 @@ Apache 2.0. See [`LICENSE`](./LICENSE).
 
 ## Contributing
 
-The contribution model is still being decided.
-File issues for discussion; PRs aren't
-being accepted from outside contributors yet. See
-[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the test tiers and the
-eventual flow. For questions and general chat, join the
+The contribution model is still being decided. File issues for discussion;
+PRs aren't being accepted from outside contributors yet. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the test tiers and the eventual
+flow. For questions and general chat, join the
 [hal0 Discord](https://discord.gg/7M4y6dcUyq).
 
 This project adheres to the [Contributor Covenant](./CODE_OF_CONDUCT.md)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "_schema": "hal0.manifest.v1",
   "_comment": "Toolbox image registry pins per hal0 release. Each entry under `toolbox_images` is keyed by short image name (vulkan, rocm, flm, moonshine, kokoro, comfyui) and carries the canonical ghcr.io ref plus a sha256 digest. Empty/null digest means the image hasn't been published yet for this release — the runtime then pulls by tag and emits a warning. Run `scripts/update-toolbox-digests.sh` on main before cutting a release: it queries ghcr.io for each image's published content digest and patches this file in place so the pinned digests track the published images. Schema versioned via `_schema`; bump it when the shape changes. Toolbox images are public on `ghcr.io/hal0ai/`; the installer pulls them anonymously and `hal0 doctor toolbox-pull` asserts that contract holds. See docs/.devdocs/PLAN.md §12 and §17 (maintainer-local).",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "channel": "preview",
   "toolbox_images": {
     "vulkan": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # that resolves this project by distribution name must use "hal0ai".
 [project]
 name = "hal0ai"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 description = "Open-source home AI inference platform"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/set-version.py
+++ b/scripts/set-version.py
@@ -109,7 +109,7 @@ def _no_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
 
 def _write_json(path: Path, data: dict[str, object]) -> None:
     """Write *data* as pretty-printed JSON to *path*."""
-    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
 def _update_uv_lock_version(lock_text: str, new_version_pep440: str) -> str:
@@ -201,7 +201,7 @@ def set_version(root: Path, version: str) -> None:
     if "version" not in ui_pkg:
         raise ValueError(f"{ui_pkg_path} has no 'version' field")
     ui_pkg["version"] = version
-    candidates.append((ui_pkg_path, json.dumps(ui_pkg, indent=2) + "\n"))
+    candidates.append((ui_pkg_path, json.dumps(ui_pkg, indent=2, ensure_ascii=False) + "\n"))
 
     # ui/package-lock.json
     ui_lock_path = root / "ui" / "package-lock.json"
@@ -215,7 +215,7 @@ def set_version(root: Path, version: str) -> None:
             root_pkg = packages[""]
             if isinstance(root_pkg, dict):
                 root_pkg["version"] = version
-        candidates.append((ui_lock_path, json.dumps(ui_lock, indent=2) + "\n"))
+        candidates.append((ui_lock_path, json.dumps(ui_lock, indent=2, ensure_ascii=False) + "\n"))
 
     # manifest.json
     manifest_path = root / "manifest.json"
@@ -224,7 +224,7 @@ def set_version(root: Path, version: str) -> None:
         raise ValueError(f"{manifest_path} has no 'version' field")
     manifest["version"] = version
     manifest["channel"] = channel
-    candidates.append((manifest_path, json.dumps(manifest, indent=2) + "\n"))
+    candidates.append((manifest_path, json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"))
 
     # uv.lock — hal0ai package
     lock_path = root / "uv.lock"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hal0-ui",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hal0-ui",
-      "version": "1.0.0-rc.4",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hal0-ui",
   "private": true,
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "hal0ai"
-version = "1.0.0rc4"
+version = "1.0.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## What

Cuts **v1.0.0-rc.5** and brings `README.md` back in line with the shipped v1.0 product.

**Release cut**
- `scripts/update-toolbox-digests.sh` re-resolved all seven toolbox images — unchanged since rc.4, zero null digests.
- `python scripts/set-version.py 1.0.0-rc.5` across `pyproject.toml`, `manifest.json`, `ui/package.json`, `ui/package-lock.json`, `uv.lock`.
- New `## [1.0.0-rc.5]` CHANGELOG section with the preview-channel subsections (Audience / Supported upgrades / Known issues / Operator migrations / Rollback) and the six items missing from `Unreleased`: the netavark DNAT audit (#1819), `hal0 bench upload` (#1816), the release-validation kit (#1817), the brain sampler/batch correction (#1815), the installer copy + FLM distro fixes (#1784/#1785/#1786) and the docs presentation hooks (#1812).

**README**
- *Corrected*: the auth section still described ADR-0012's "no built-in auth" world — hal0 ships three-tier auth with a deny-by-default route classifier, off by default, enabled via `hal0 auth rotate/require`; the `:3001` OpenWebUI listener is explicitly called out as outside that model. Slot seeds said five curated slots; the installer seeds ten and honours delete tombstones.
- *Pruned*: the 25-line status blockquote is now the current tag plus a CHANGELOG pointer; the shipped-roadmap list is deduplicated.
- *Added*: a **Benchmarks** section with the public leaderboard numbers from the reference box (per-model decode/prefill, concurrent chat+embed, NPU and TTS lanes) and how bundles are shared; a **Setup and day-2** section with the real first commands including `hal0 doctor ports --fix`; model-owned tuning, the AI Capabilities page, `-fa auto`, per-distro FLM `.deb`s, and native brain tool-calling.
- Marketing framing from hal0.dev is folded into "Why hal0" so both surfaces say the same thing.

**Drive-by**: `set-version.py` wrote `json.dumps` without `ensure_ascii=False`, so every release bump re-escaped `manifest.json`'s em-dashes into `\uXXXX` and had to be hand-reverted. Fixed in its own commit.

## Verification

- `scripts/gen_release_notes.py --tag v1.0.0-rc.5 --channel preview` → 0 TBD, `highlights=6`, source `CHANGELOG.md#1.0.0-rc.5`
- `python -m hal0.release.policy v1.0.0-rc.5` → `kind=preview`, `manifest_targets=[preview]`, `github_prerelease=true`, `publish_pypi=false`
- `pytest tests/release tests/config` → 849 passed, 9 skipped
- `ruff check` / `ruff format --check` clean on the touched file

## Follow-up (out of scope)

Tag + `release.yml` watch after merge; the rc.5 fleet validation sweep runs from `tests/release-validation/`.