### PR TITLE
test(release): v1.0.0-rc.5 validation report and kit curation to v2

### DIFF
--- a/.claude/workflows/rc-validate.js
+++ b/.claude/workflows/rc-validate.js
@@ -35,6 +35,7 @@ const RUN = `/mnt/mintdev/artifacts/hal0-release-validation/${VERSION}`
 // Box id -> role. Mirrors tests/release-validation/boxes.toml.
 const BOX_ROLES = {
   'ct151-cpu-fresh': 'fresh',
+  'ct152-cpu-fresh': 'fresh',
   'ct163-cpu-fresh': 'fresh-alt',
   'ct150-update': 'update',
   'ct105-prod': 'prod',
@@ -245,6 +246,20 @@ phase('Sweep')
 
 const freshBox = BOX_IDS.find((b) => BOX_ROLES[b] === 'fresh' || BOX_ROLES[b] === 'fresh-alt')
 const updateBox = BOX_IDS.find((b) => BOX_ROLES[b] === 'update')
+
+// A box id that is missing from BOX_ROLES resolves to no role, which used to make the whole
+// Sweep phase spawn zero agents in silence — triage then "succeeded" off the preflight
+// CONTEXT.md alone and the run looked complete. Abort instead: an unknown box is a kit bug.
+const unroled = BOX_IDS.filter((b) => !BOX_ROLES[b])
+if (unroled.length) {
+  throw new Error(
+    `unknown box id(s): ${unroled.join(', ')} — add them to BOX_ROLES in this script AND to ` +
+    `tests/release-validation/boxes.toml. Known ids: ${Object.keys(BOX_ROLES).join(', ')}`,
+  )
+}
+if (!freshBox && !updateBox) {
+  throw new Error(`no box with role fresh/fresh-alt/update in ${BOX_IDS.join(', ')} — nothing to sweep`)
+}
 
 function laneAgent(kind, key, box, extra, opts) {
   return agent(`${BASE}

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -97,7 +97,15 @@ A full two-box run is roughly 25–30 agents. Restrict `lanes` for smaller passe
 * **The idle reaper (300 s, `idle_timeout_s`) evicts slots between stages.** A stage that finds
   a slot offline should reload it and say so, not report it as a regression.
 * **`/mnt/ai-models` ggufs on the workstation are often symlinks into `huggingface/hub`** —
-  staging them to a box needs `rsync -L`.
+  staging them to a box needs `rsync -L`. And `/mnt/ai-models` is not in hal0's model roots, so
+  a staged gguf is invisible until `hal0 model add` runs.
+* **A fix that names one surface usually fixed one surface.** rc.5's three half-fixes (#1802
+  fixed two of four ctx surfaces, #1807 fixed the seeded profile path but not `slot create`,
+  #1797's telemetry gate covered two of three pages) all passed a narrow re-probe. When a
+  regression entry names a surface, probe the whole class.
+* **`promote_ready: true` in `regressions.yaml` is a to-do list.** An entry that is mechanical
+  and stable belongs in `pytest` or `scripts/release-test.sh`, and should be deleted from the kit
+  in the PR that writes the test.
 
 ## Versioning policy
 
@@ -107,6 +115,24 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 
 ### Kit changelog
 
+* **2** (2026-08-11) — curation after the `v1.0.0-rc.5` run. `regressions.yaml` grows from 11 to
+  26 entries: the 15 findings filed as #1827–#1841, plus an `rc5_note` and `last_result` on every
+  rc.4 entry recording what actually held on a real box. Two rc.4 repros were rewritten because
+  they were unrunnable as written — `brain-tools-image-gate` no longer asks a probe agent to
+  repin the shared brain slot, and `fact-extraction-strips-literals` is now explicitly gated on a
+  retain reaching a terminal state. `known-issues.yaml` grows from 8 to 29: eighteen candidates
+  the adversarial pass refuted or ruled by-design are banked with their rationale and a
+  `still_report_if` clause, so the next run does not spend budget re-deriving them; six entries
+  are flagged `review_due` against v1.0.0. Lane briefs absorbed the checks agents invented this
+  run — the ones that paid were **generalisations of a previous release's narrow check**: sweep
+  every bank sub-resource rather than `/stats`; compare context windows on all four surfaces
+  rather than two; assert provisioning honesty on every phase and on warnings and skips, not just
+  recorded failures; gate GPU telemetry per page rather than per dashboard. Also: the brain lane
+  gets `budget_min = 20` (a single CPU tool turn exceeds the 12-minute default, which is why its
+  last three checks went untested twice running), the memory lane's dependency on an untouched
+  `utility` slot is recorded as an ordering constraint in `kit.toml`, and `boxes.toml` records
+  that ct151 is wedged, that ct152 has no snapshot and carries residue, and precisely why
+  ct105-prod cannot cross-check the two hermes fresh-install defects.
 * **1** (2026-08-10) — initial extraction from the rc.4 validation workflows. Five read-only
   lanes, six stateful lanes, one update lane, 11 regression entries seeded from rc.4 issues
   #1787–#1797, four adjudicated by-design entries in known-issues.

--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -21,8 +21,16 @@ ram_gb = 16
 snapshot = "pristine"
 api = "http://10.0.1.151:8080"
 auth_required = false
+status = "unusable as of 2026-08-11 — do not select without checking"
 notes = """
 Fresh-install lane. Reset: `pct rollback 151 pristine` on the hypervisor.
+
+BLOCKED (2026-08-10, still true at the end of the rc.5 run): `pct rollback 151` wedged the
+hypervisor on a pool-wide ZFS `z_zrele` deadlock — every `zfs unmount` on rpool blocks and
+clearing it needs a hypervisor reboot. Do not attempt a rollback of 151, and avoid running `zfs`
+commands on 10.0.1.110, until an operator has rebooted the hypervisor and re-verified the
+snapshot. ct152 exists because of this.
+
 GOTCHAS, in order:
   1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
      Tailscale 100.100.100.100. Fix it before anything else or the install fails opaquely.
@@ -31,6 +39,43 @@ GOTCHAS, in order:
      symlinks into huggingface/hub, so use `rsync -L`.
   4. An unprivileged LXC sees the host's sysfs with no /dev/dri — hardware probes that key on
      AMD DRM sysfs alone will misreport (root cause of #1790).
+"""
+
+[boxes.ct152-cpu-fresh]
+role = "fresh"
+ctid = 152
+hostname = "hal0-rc5-fresh-2604"
+ip = "10.0.1.152"
+os = "ubuntu 26.04"
+privileged = false
+gpu = false
+cores = 8
+ram_gb = 16
+snapshot = "none"
+api = "http://10.0.1.152:8080"
+auth_required = false
+notes = """
+Stand-in fresh box built for the rc.5 run, from `local:vztmpl/ubuntu-26.04-standard_26.04-1`
+rather than from a snapshot, because ct151's `pct rollback` wedged on a pool-wide ZFS
+`z_zrele` deadlock (every `zfs unmount` on rpool blocks; needs a hypervisor reboot to clear).
+Same profile as ct151-cpu-fresh: 26.04, unprivileged, CPU-only, 8c/16G/200G.
+GOTCHAS:
+  1. The PVE standard template ships WITHOUT curl — `curl | bash` fails with
+     "curl: command not found" before hal0 is reached. Install curl + ca-certificates first.
+  2. No GPU passthrough: the install needs HAL0_ALLOW_CPU_ONLY=1.
+  3. No NFS mount; rsync -L test models to /mnt/ai-models. NOTE: /mnt/ai-models is NOT in hal0's
+     model roots (`[models] roots = ["/var/lib/hal0/models"]`), so a staged gguf is invisible to
+     hal0 until a stateful lane runs `hal0 model add`. Read-only lanes must record this as
+     `skipped`, not `fail`.
+  4. STILL NO SNAPSHOT, and it is now carrying two runs of residue. Every stateful mutation is
+     permanent for the whole run — take a `pristine` snapshot immediately after the next clean
+     install, before any lane runs. Known residue after the rc.5 run: a `not-found/failed`
+     `hal0-slot@zzskeptic.service` job in `systemctl --failed`; an orphaned
+     /var/lib/hal0/models/zzbroken/zzbroken.gguf (2 MB of non-model bytes, handy as a
+     deliberately unloadable model); activity.db / hal0.db / .hermes carrying prior history, so
+     nothing may assert "no prior activity".
+  5. /proc/loadavg is not namespaced in this LXC — it reflects the hypervisor. Use %Cpu and
+     per-process CPU, never load average, when arguing about contention.
 """
 
 [boxes.ct150-update]
@@ -48,6 +93,9 @@ HAL0_RELEASES_URL is a file:// stage at /var/lib/hal0/rc2/preview.json (director
 historical, not a version claim) — restage the new manifest + bundle there, or point it at the
 GitHub asset URL (works end-to-end since rc.3). No snapshot reset: its value is accumulated
 upgrade history, so record the exact from-version in CONTEXT.md before upgrading.
+As of the rc.5 run it sat on 1.0.0-rc.3 and carried hermes-agent 0.19.0 (which DOES ship
+`hermes_cli/web_dist`), so it cannot reproduce the fresh-install hermes packaging defects
+(#1829) — an upgrade preserves the newer wheel's artefacts.
 """
 
 [boxes.ct163-cpu-fresh]
@@ -78,6 +126,18 @@ PRODUCTION. READ-ONLY, always — no slot loads, no config writes, no service re
 in a validation run is to answer "is this finding an artifact of the CPU-only test box?" on
 real GPU hardware. Anonymous /api/* returns 401; run `hal0 ...` on the box instead of curl
 from the workstation. Not part of the default matrix; opt in per run.
+
+Was running 1.0.0rc5 during the rc.5 validation, which made it an unusually good cross-check —
+but it is an UPGRADED box with months of operator tuning, so "prod is fine" is weak evidence
+about a fresh install. Specifics found the hard way in rc.5:
+  * its venv carries an ORPHANED hermes_cli/web_dist from an older hermes (present in no
+    dist-info RECORD), so the fresh-install board-token defect (#1829) cannot be seen here;
+  * its brain model carries an operator-set defaults.context_size and its hermes config points
+    at a cloud model, so the 64K-floor blocker (#1827) cannot be seen here either;
+  * its slots and capability bindings are hand-tuned, so a seeded-default finding will not
+    reproduce.
+Use it to answer "is this CPU-only or hardware-independent?", never "does a fresh GPU install
+work?".
 """
 
 # No GPU fresh-install box exists today. Every fresh-install finding that touches backend

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 1
+kit_version = 2
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".
@@ -28,6 +28,9 @@ verify_effort = "high"
 readonly_budget_min = 10
 stateful_budget_min = 12
 update_budget_min = 20
+
+# A lane may override the budget for its kind with `budget_min` on its [[lane]] entry. The
+# preflight agent reads these and writes them into CONTEXT.md, which is what lane agents obey.
 
 # Scratch root for run artifacts (CONTEXT.md, raw lane output). Not in the repo — only the
 # final report is committed.
@@ -89,6 +92,10 @@ kind = "stateful"
 order = 3
 brief = "lanes/stateful/brain.md"
 boxes = ["fresh"]
+# One brain tool turn on a CPU box can exceed the 12-minute stateful default on its own; checks
+# 6-8 (including the never-yet-validated read_only guard) went untested in rc.4 and rc.5 for
+# exactly that reason.
+budget_min = 20
 
 [[lane]]
 key = "memory"
@@ -96,6 +103,9 @@ kind = "stateful"
 order = 4
 brief = "lanes/stateful/memory.md"
 boxes = ["fresh"]
+# ORDERING CONSTRAINT: the memory lane's first check needs the `utility` slot in its as-shipped,
+# model-less state (regression memory-retain-dead-letter / #1792). Lanes 1-3 must NOT bind a
+# model to `utility`; in rc.5 one did, and #1792 could not be probed at all that release.
 
 [[lane]]
 key = "capabilities"

--- a/tests/release-validation/known-issues.yaml
+++ b/tests/release-validation/known-issues.yaml
@@ -10,13 +10,18 @@
 #                       Includes WHY, so a later agent does not relitigate it from scratch.
 #
 # Entries carry `review_at`: the release by which someone must recheck whether this is still
-# true. Kit curation (phase 8) flags entries past their review point.
+# true. Kit curation (phase 8) flags entries past their review point with `review_due: true`.
+#
+# `review_due: true` means the NEXT release must either re-adjudicate the entry or delete it.
+# Do not treat a review-due entry as automatically still valid.
 
 schema: 1
-updated: 2026-08-10
+updated: 2026-08-11
 updated_for: v1.0.0-rc.5
 
 known_issues:
+  # ── Open defects, already tracked ───────────────────────────────────────────
+
   - id: slot-logs-empty
     status: open
     issue: 1429
@@ -24,6 +29,7 @@ known_issues:
       `hal0 slot logs <name>` returns "no logs" for healthy container slots — the quadlet sets
       LogDriver=none.
     review_at: v1.0.0
+    review_due: true
 
   - id: load-restart-error-surfacing
     status: open
@@ -31,14 +37,24 @@ known_issues:
     summary: >-
       Slot load/restart failures surface as CLI timeouts or generic errors rather than the
       underlying runner error.
+    note: >-
+      rc.5 found the INVERSE defect producing a byte-identical string — a SUCCESSFUL slot verb
+      also prints `ReadTimeout` and exits 1, because `api_post` caps the client read at 10 s
+      against a 180 s server budget (#1832). Do not assume a ReadTimeout means the operation
+      failed; always verify the server-side outcome before reporting either issue.
     review_at: v1.0.0
+    review_due: true
 
   - id: hindsight-doctor-status-mismatch
     status: open
     issue: 1543
     summary: >-
       `hal0 doctor` and `hal0 memory status` disagree about hindsight health.
+    note: >-
+      `hal0 doctor` emits no memory write-health line at all on rc.5, so it is NOT a
+      compensating surface for #1833's green-while-empty status panel.
     review_at: v1.0.0
+    review_due: true
 
   - id: changelog-hunk-conflicts
     status: open
@@ -47,6 +63,9 @@ known_issues:
       Per-PR CHANGELOG hunks re-conflict every open branch on each merge. Process issue, not a
       product defect — matters only during a fix wave.
     review_at: v1.0.0
+    review_due: true
+
+  # ── Adjudicated by-design: dispatcher and routing ───────────────────────────
 
   - id: dispatcher-unknown-model-passthrough
     status: by-design
@@ -63,6 +82,333 @@ known_issues:
       resolution_path with no corresponding loaded slot.
     review_at: v1.1.0
 
+  - id: model-default-marker-is-per-type-fallback
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 model default <id>` does not change which model answers a request with no `model`
+      field, or with `model: "default"`. On a box whose `agent` anchor slot has no model bound
+      (a CPU-only fresh install), such requests 404 with `dispatch.no_route`.
+    why: >-
+      The registry marker is the per-TYPE MODEL default consumed by
+      `hal0.registry.fallback.fallback_local_model` Step 0 — the model a slot of that dispatcher
+      type falls back to when its own configured model is not locally servable. It is documented
+      as orthogonal to routing (services/models_service.py:110-117, "This is the MODEL default;
+      it is orthogonal to the SLOT default") and covered by seven tests in
+      tests/slots/test_model_fallback.py. Default ROUTE selection is ADR-0023's hardcoded
+      `agent` anchor, changed with `hal0 slot edit agent --model <id>`. The string "default" has
+      no special meaning and is not an OpenAI sentinel.
+    still_report_if: >-
+      Release notes or docs start claiming a routing effect for `hal0 model default`; OR the
+      marker fails at its real job (a slot whose configured model is missing from disk does not
+      prefer the servable same-type model carrying the flag); OR a request with no `model` field
+      404s on a box where the `agent` slot DOES have a model bound in /etc/hal0/slots/agent.toml.
+    review_at: v1.1.0
+
+  - id: dispatcher-300s-read-timeout
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      A non-streaming POST /v1/chat/completions that the upstream slot cannot answer inside
+      `[dispatcher] direct_read_timeout_s` (shipped default 300.0) is cut off by hal0-api.
+    why: >-
+      `direct_read_timeout_s` is a first-class documented knob (schema default 300.0, range
+      30-600, hot-applied via service-restart[hal0-api]) and exists to stop one slow upstream
+      starving the connection pool (#415). Streaming is explicitly exempt and is what a real
+      chat client uses — verified: `stream:true` returned 200 on the same saturated box where
+      the non-streaming request 502'd. A slot that cannot emit four tokens in 120 s is genuinely
+      too slow; the cut-off is an accurate report, not a spurious one.
+    still_report_if: >-
+      The error is emitted BEFORE the configured timeout has elapsed — measure it by correlating
+      request_id between `dispatch.decision` and `dispatch.forward_failed` in the hal0-api
+      journal, do not assert it; OR the same error appears on a streaming request; OR the
+      upstream answers the identical request inside the deadline when hit directly on its own
+      port while hal0-api still fails it. (The MISLABEL — 502 "unreachable" instead of 504 with
+      the deadline named — is a separate real defect, filed in rollup #1840.)
+    review_at: v1.1.0
+
+  - id: memory-operations-route-is-bank-scoped
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `GET /api/memory/operations` and `GET /api/memory/ops` both 404 with an empty body.
+    why: >-
+      Neither path has ever existed. Async operations are bank-scoped by construction; the real
+      route is `GET /api/memory/banks/{bank_id}/operations`, which IS published in
+      /api/openapi.json and rendered at /api/docs. There is no cross-bank aggregate on the
+      server — `hal0 memory ops` synthesizes one client-side by fanning out over the bank list.
+      "ops" is a Typer subcommand group, not a URL segment. An empty-bodied 404 for an unknown
+      /api/* path is uniform hal0 behaviour.
+    still_report_if: >-
+      `/api/memory/banks/{bank_id}/operations` itself 404s or 500s for a bank that exists; OR
+      the OpenAPI document advertises a memory operations path that does not resolve; OR docs,
+      the UI, an error message, or a lane brief tells a user to call a top-level
+      /api/memory/operations.
+    review_at: v1.1.0
+
+  # ── Adjudicated by-design: slots ────────────────────────────────────────────
+
+  - id: crash-loop-warming-180s-window
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      A crash-looped slot reads `warming` for roughly 180 s after `hal0 slot load`, even though
+      systemd gave up at ~21 s, before flipping to `error`.
+    why: >-
+      The ~180 s dwell is `providers/container._HEALTH_TIMEOUT_S`, the deliberate cold-load
+      ceiling. The in-flight `load()` holds the per-slot lock, which intentionally locks the
+      watchdog out so it cannot race a legitimately slow load into an illegal transition
+      (`SlotWatchdog._stamp_locked`). During the window `container_status: crashed` is already
+      present in the same API response, and the slot then flips to `error` carrying the full
+      systemd verdict and the `journalctl` command. Measured on rc.5: error at +183 s, stable.
+    still_report_if: >-
+      The slot is still `warming` more than ~240 s after the load call; OR `metadata.message` is
+      empty once `state` is `error`; OR `container_status` never reaches `crashed` while the
+      unit is `failed`; OR a GPU box shows a materially longer dwell.
+    review_at: v1.1.0
+
+  - id: cpu-pinned-slot-keeps-ngl-flag
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 slot edit <slot> --hardware cpu` leaves `n_gpu_layers` alone, so a CPU-pinned slot's
+      resolved argv still carries `-ngl -1`, and `hal0 slot edit` has no `--n-gpu-layers` flag.
+    why: >-
+      `device` (placement/fence) and `n_gpu_layers` (offload count) are separate typed fields of
+      the slot hardware grid. `--hardware cpu` does real work: it re-resolves the runner image to
+      the CPU runner and sets device_class="cpu", which makes
+      `ContainerProvider.container_spec` emit ZERO `AddDevice=/dev/kfd|/dev/dri/*` lines and zero
+      render/video group-adds — verified on the GPU prod box, whose one cpu-device slot quadlet
+      has no AddDevice at all. The residual `-ngl -1` is inert argv noise on a container with no
+      GPU to offload to, and keeping it means a flip back to a GPU device preserves the
+      operator's setting. Note the CPU runner image tag literally contains the string "vulkan"
+      (amd-strix-halo-toolboxes:vulkan-radv-server) — that is not the GPU image.
+    still_report_if: >-
+      A slot with `device = "cpu"` actually receives GPU passthrough — its quadlet contains
+      `AddDevice=/dev/kfd`, `AddDevice=/dev/dri/*`, an `nvidia.com/gpu=` CDI entry, or a
+      render/video `--group-add`; OR its resolved argv[0] is the GPU runner image with no
+      image_pin set; OR llama-server on a CPU-pinned slot logs non-zero offloaded layers. Do NOT
+      re-report merely on `-ngl -1` in the argv, nor on the CPU image's tag name.
+    review_at: v1.1.0
+
+  - id: slot-config-endpoint-returns-raw-ceiling
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `GET /api/slots/{name}/config` returns the slot TOML's `[model].context_size` (e.g. 65536)
+      even when the effective served window is smaller.
+    why: >-
+      That endpoint is documented as "return the slot's TOML config as a dict" — the raw operator
+      edit surface. `[model].context_size` there is the hardware ceiling by definition
+      (`providers/container._resolve_context_size` takes the min of it and the model's
+      authoritative value), not the effective window.
+    still_report_if: >-
+      The /config value is presented to a user as the effective or served context window, or
+      writing it no longer changes the ceiling used by the launch path. (The DETAIL route
+      `GET /api/slots/{name}` returning the raw ceiling as `ctx_max` is a real defect — #1835.)
+    review_at: v1.1.0
+
+  - id: capabilities-seed-devices-from-slot-tomls
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      The first-boot seed of /etc/hal0/capabilities.toml pre-fills each child's `device` with a
+      GPU backend (`gpu-vulkan`, `gpu-rocm`) regardless of host hardware.
+    why: >-
+      `orchestrator.initialize_if_missing` copies `device` verbatim from the shipped static
+      /etc/hal0/slots/<name>.toml. It never reads hardware.json — proven by the empty
+      `voice.stt` device (no stt.toml ships) and by the seed writing `gpu-vulkan` on a box whose
+      probe says `vulkan_capable: false`. It is a template copy, correct on real hardware, and
+      every selection ships `enabled = false` with an empty model, so nothing is bound. A wrong
+      device is caught loudly at apply time by `_validate_model_in_catalog` /
+      `capability.no_engine_for_device`.
+    still_report_if: >-
+      The seeded device is derived from hardware.json (two differently-specced boxes get
+      different seeds); OR an `enabled = true` selection is written at install time; OR enabling
+      a capability at its seeded device produces a slot that reports ready while serving nothing.
+      The `img.img = gpu-rocm` seed versus the ComfyUI allow-list (`gpu-vulkan` only) mismatch is
+      real but is filed once inside rollup #1840 — do not re-file it every run.
+    review_at: v1.1.0
+
+  # ── Adjudicated by-design: memory ───────────────────────────────────────────
+
+  - id: hindsight-extraction-shares-utility-slot
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    related_issue: 1834
+    summary: >-
+      Hindsight fact extraction is pointed at `hal0/utility`, the same slot that carries hermes'
+      auxiliary roles (compression, approval, mcp, memory_flush, skills_hub).
+    why: >-
+      Deliberate and documented in installer/systemd/hindsight-api.service, justified against a
+      measured alternative (~2 s/turn on utility vs 77-160 s on the NPU) and operator-overridable
+      via `hal0 memory graph enable --slot <name>`, which writes a drop-in that survives upgrade.
+      On a GPU box `utility` carries its own small model, distinct from the `agent`/`brain` chat
+      anchors, so extraction and user chat do not even share a process.
+    still_report_if: >-
+      The retain queue fails to drain across two consecutive 10-minute samples with pending>0 and
+      an op whose age RESETS after `attempt=4/4` (the requeue loop — that is #1834, report
+      against it); OR `llamacpp:requests_deferred` on the extraction slot is non-zero while an
+      interactive chat request to a DIFFERENT loaded slot is degraded; OR any of this is observed
+      on a box with working GPU acceleration.
+    review_at: v1.1.0
+
+  - id: hermes-memory-turn-slow-on-cpu
+    status: by-design
+    adjudicated: v1.0.0-rc.4
+    reaffirmed: v1.0.0-rc.5
+    related_issue: 1834
+    summary: >-
+      Hermes memory-tool turns take minutes on the CPU-only box.
+    why: >-
+      Model slowness, not a deadlock — store 53 s, recall 15 s with a 0.8 B model on 8 CPU cores
+      under controlled retest.
+    note: >-
+      The rc.4 still_report_if clause ("the retain op and the chat turn are provably contending
+      for the same slot") WAS satisfied in rc.5 and produced #1834. The contention question is
+      now adjudicated under `hindsight-extraction-shares-utility-slot`; report timing there, not
+      here. This entry now covers only raw per-turn latency.
+    still_report_if: >-
+      A turn exceeds ~120 s on a box with GPU acceleration.
+    review_at: v1.0.0
+    review_due: true
+
+  - id: memory-ops-processing-not-retryable
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 memory ops retry --all-failed` says "Nothing to retry." and `retry --id` returns 409
+      while retain ops sit in `processing`.
+    why: >-
+      `processing` means the Hindsight engine still owns the op and has its own retry ladder
+      scheduled (retry_count / next_retry_at, visible via `ops list --json`). Retrying would
+      double-queue it, so the engine refuses with an explicit body: "cannot be retried: status is
+      'processing', expected 'failed' or 'cancelled'". After the ladder exhausts, the op flips to
+      `failed` and `--all-failed` picks it up — verified end to end on rc.5, no restart, no data
+      loss. A cancel handle exists over REST (DELETE /api/memory/banks/{bank}/operations/{id})
+      and MCP (memory_operation_cancel); it is only missing as a CLI verb (rollup #1840).
+    still_report_if: >-
+      An op stays in `processing` with retry_count not advancing for >60 min; OR an op reaches
+      `failed` and `--all-failed` still does not queue it; OR the 409 body stops naming the
+      current status; OR a retain is lost with no `failed` op and no `hal0 memory status` error.
+    review_at: v1.1.0
+
+  - id: batch-retain-parent-rows-are-bookkeeping
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      Every retain produces TWO rows in hindsight's operation list — a `retain` child that does
+      the work and a `batch_retain` parent that sits `pending` and is never claimed by a worker
+      (`payload_null=N claimable=0` in [PENDING_BREAKDOWN]).
+    why: >-
+      The parent is vendored hindsight parent/sub-batch bookkeeping: `task_payload IS NULL` by
+      design so no worker claims it, reconciled by `poller._maybe_update_parent_operation` when
+      all children terminate. Observed live: a parent flipped pending -> failed in the same
+      second its child exhausted retries, inheriting the child's error. Production shows 25
+      `batch_retain completed` and ZERO pending. `exclude_parents=true` filters them over REST,
+      MCP and the provider — only the CLI lacks the flag, which is why counts read double.
+    still_report_if: >-
+      A `batch_retain` parent stays `pending` after ALL rows whose
+      `result_metadata.parent_operation_id` equals its id have reached completed/failed — verify
+      with a join, not by eyeballing the CLI table; OR a parent stays pending on a box where
+      retains are completing normally; OR a completed parent's status/error does not mirror its
+      children.
+    review_at: v1.1.0
+
+  - id: memory-enabled-is-restart-scoped
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      After `hal0 memory disable`, `hal0 memory status` still prints "State ON / Writes landing"
+      and POST /api/memory/add still returns 200, until hal0-api is restarted.
+    why: >-
+      `[memory].enabled` is a registered `service-restart[hal0-api]` key; the provider is built
+      once in create_app(). The disable command prints "Takes effect on the next hal0-api
+      restart: systemctl restart hal0-api" in the same breath. `memory_enabled` is defined as
+      `app.state.memory_provider is not None` and a test pins that identity so the field stays
+      trustworthy — printing OFF while the provider is live and ingesting would be the silently
+      wrong answer. No pending-restart indicator exists for ANY of hal0's ~40 service-restart
+      keys; adding one is an enhancement, not a memory bug.
+    still_report_if: >-
+      `systemctl restart hal0-api` after `hal0 memory disable` does NOT actually disable the
+      subsystem; OR `hal0 memory status` ever contradicts the live provider (OFF while
+      /api/memory/add 200s, or ON while /api/memory/list 503s); OR the disable command stops
+      printing the restart line; OR hal0 grows a pending-restart indicator for other keys and
+      memory.enabled is left out.
+    review_at: v1.1.0
+
+  # ── Adjudicated by-design: brain chat ───────────────────────────────────────
+
+  - id: brain-chat-sse-silent-until-first-frame
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `POST /api/brain/chat` sends its SSE 200 head immediately (TTFB ~15 ms) and then emits
+      nothing until the first round produces a frame — on a CPU box that can be minutes. A curl
+      with a shorter `--max-time` records `HTTP=200 SIZE=0`.
+    why: >-
+      That is the client aborting, not an empty server response. Measured: a round that failed
+      still delivered `data: {"type":"error",...}` followed by `data: {"type":"done"}` at +289 s.
+      There is no silent-close path — a per-round upstream failure always produces error+done,
+      and budget exhaustion yields an explicit error frame. The documented `ping` frame is
+      emitted only while an approval gate is parked, by design. The dashboard drawer renders a
+      typing indicator and sets no client timeout. Also by design: no `tools_unavailable` notice
+      when `[brain_chat] tool_model` differs from the chat model, because the round can be
+      rerouted.
+    still_report_if: >-
+      A turn is held open PAST the server's own `[brain_chat] completion_timeout_s` (+30 s
+      grace) and the stream closes with NO error frame and NO done frame; OR a turn that streams
+      tool_call/tool_result frames reaches `done` with no token frame at all; OR `hal0 chat
+      --brain` aborts with `transport error: ReadTimeout` on a box where the round completes in
+      under 120 s (the CLI hard-codes a 120 s client timeout against a 300 s server budget —
+      that mismatch is real and worth reporting when it bites).
+    review_at: v1.1.0
+
+  - id: brain-turn-cancelled-on-client-disconnect
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      A brain turn is NOT orphaned when the client goes away. Do not re-file "closing the client
+      leaves the tool loop burning rounds".
+    why: >-
+      `run_tool_loop` runs inline in the SSE generator (no create_task, no shield, no
+      BackgroundTask), uvicorn advertises ASGI spec 2.3, so Starlette's StreamingResponse takes
+      the listen-for-disconnect path and throws CancelledError into the generator. Reproduced
+      against hal0's own venv and middleware stack: cancellation landed in the same second the
+      client was killed, mid-round, before any frame. Journal lines showing another model on
+      another slot during your window are other lanes' traffic — match on model/upstream, not on
+      request_id churn (each round legitimately mints a fresh loopback request_id).
+    still_report_if: >-
+      The generator is observed still running >30 s after a proven TCP disconnect (a `finally`
+      log line that never fires, or a second round's `dispatch.decision` whose upstream matches
+      the configured `[brain_chat]` model); OR hal0 starts wrapping the turn in
+      create_task/shield/BackgroundTask; OR a BaseHTTPMiddleware is added that swallows
+      http.disconnect; OR, on a QUIESCED box, the slot is measurably still computing >60 s after
+      the client dies (that narrow "one in-flight upstream completion" question is unmeasured —
+      file it as its own candidate, not as this one).
+    review_at: v1.1.0
+
+  - id: brain-chat-hand-parsed-body
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `POST /api/brain/chat` publishes no `requestBody` in /api/openapi.json, returns 200 rather
+      than 4xx for a bad body, and frames an empty payload as a single empty user turn.
+    why: >-
+      Hand-parsed `await request.json()` handlers with no FastAPI body model are the documented
+      house convention (tests/api/test_typed_bodies.py), covering 113 of 141 mutating operations
+      including all of /v1/*. HTTP 200 plus an in-stream error frame is the error channel for
+      this SSE surface. The empty-payload framing is deliberately tested as O18 template safety —
+      a system-only turn 500s the chat template. No OpenAPI client generation exists in the repo.
+    still_report_if: >-
+      The surface answers a body it could not parse, or a body whose `messages` key is present
+      but not a list, with a normal model turn and NO {"type":"error"} SSE frame — that residue
+      is real and is filed in rollup #1840. Do not re-report the absent requestBody, the 200
+      status on this SSE route, or the empty-body framing.
+    review_at: v1.1.0
+
+  # ── Adjudicated by-design: MCP, CLI, UI ─────────────────────────────────────
+
   - id: mcp-lan-421-invalid-host
     status: by-design
     adjudicated: v1.0.0-rc.4
@@ -73,21 +419,155 @@ known_issues:
       API is anonymous-open. Configurable via HAL0_MCP_ALLOWED_HOSTS in api.env.
     still_report_if: >-
       HAL0_MCP_ALLOWED_HOSTS is set correctly and the 421 persists, or the documented connect
-      URL still omits the /mcp suffix (that part was real — folded into #1796).
+      URL still omits the /mcp suffix.
     review_at: v1.1.0
 
-  - id: hermes-memory-turn-slow-on-cpu
+  - id: mcp-args-additional-properties-open
     status: by-design
-    adjudicated: v1.0.0-rc.4
+    adjudicated: v1.0.0-rc.5
     summary: >-
-      Hermes memory-tool turns take minutes on the CPU-only box.
+      Every MCP admin tool schema carries `additionalProperties: true` on its inner `args`
+      object, so an undeclared or misspelled key is forwarded to the REST layer rather than
+      rejected by the MCP layer.
     why: >-
-      Unreproduced as a hang under controlled retest — store 53 s, recall 15 s with a 0.8 B
-      model on 8 CPU cores. Consistent with model slowness, not a deadlock.
+      The admin server is a generated proxy over 180 REST routes; the schema is left open so an
+      agent can pass fields a tool's DESCRIPTION calls out but the schema cannot enumerate
+      (slot_edit's arbitrary config keys). Documented in `tool_param_schema`'s docstring and
+      pinned by three tests. Validation is genuinely present: missing required args are rejected
+      in the MCP layer (`mcp.missing_arg`), and type/range errors are rejected by FastAPI
+      (`validation.invalid` with a `loc`). Exact parity with a direct curl of the same route was
+      verified. No droppable optional flag widens a destructive operation — `force`, `prune` and
+      `pin` all fail safe.
     still_report_if: >-
-      A turn exceeds ~120 s on a box with GPU acceleration, or the retain op and the chat turn
-      are provably contending for the same slot (that would hit single-GPU boxes too).
-    review_at: v1.0.0
+      A tool that DECLARES an optional property silently ignores a misspelling of that property
+      and returns isError=false with a semantically different result; OR a dropped key widens the
+      blast radius of a gated tool (a lost `dry_run`/`confirm`/scope arg causing an unintended
+      mutation); OR an MCP tool accepts an arg shape the equivalent REST call rejects.
+    review_at: v1.1.0
+
+  - id: cli-model-list-default-marker-column
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 model list` has an unlabelled leading column that is blank on every row.
+    why: >-
+      That column IS the rc.4 fix (#1796/#1807): the default-model marker, unlabelled in the
+      style of `git branch`'s `*`. It renders a green `*` on the row whose /api/models entry has
+      `"default": true`, and is blank only when no model is flagged — a state
+      tests/cli/test_model_list_default_marker.py asserts as correct. It never appears in
+      `--json`. Note the adjacent, separate question: on a default install no model is flagged
+      default at all, so the column stays blank; if that matters, file it as a
+      default-assignment candidate, not as a table-rendering bug.
+    still_report_if: >-
+      A model with `"default": true` renders WITHOUT the `*`, or the `*` lands on the wrong row,
+      or the marker leaks into `--json`.
+    review_at: v1.1.0
+
+  - id: cli-agent-status-detail-truncated
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      The Detail column of `hal0 agent status <name>` slices its JSON blob at 60 characters with
+      no ellipsis, cutting mid-token.
+    why: >-
+      Deliberate teaser, rationale in-code at agent_commands.py:1331. #1798 added the surfaces
+      that carry the actionable content instead: a dedicated Failures column, colour-coded phase
+      status, a trailing `warn:` footer, and a branch that renders recorded failures as plain
+      text, bypassing the slice. `--json` exists on this exact command, is documented in
+      `--help`, is regression-tested, and emits the complete payload.
+    still_report_if: >-
+      `--json` is missing, errors, or omits data the table shows; OR a phase reaches fail/warn
+      and neither the Failures column, the status colour, nor the footer surfaces it; OR the
+      slice cuts a `reason`/`phase_failures` string (those branches are supposed to bypass it).
+      Separately: `details["warnings"]` is invisible in the table because only
+      `details["failures"]` is routed around the slice — that belongs to #1828, not here.
+    review_at: v1.1.0
+
+  - id: cli-bench-is-argparse-passthrough
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 bench --help` prints plain argparse text rather than a Rich panel, `hal0 bench list`
+      errors with "invalid choice", and `hal0 bench --version` is accepted at group level.
+    why: >-
+      Documented as a raw argparse passthrough in two user-facing reference pages
+      (docs/reference/cli.mdx:51, docs/reference/model-roster-benchmark.mdx:131) and in the
+      module docstring, with the rationale (stdlib-only argparse, precedent from
+      installer/bench/server_ab.py) — registered in main.py with allow_extra_args +
+      ignore_unknown_options rather than re-declaring twelve verbs as Typer commands. `list` is
+      not a universal sibling verb: memory, config, comfyui, registry, auth, update and migrate
+      all reject it too, and Typer's own unknown-subcommand exit code is also 2.
+    still_report_if: >-
+      A verb documented in docs/reference/cli.mdx is missing from the argparse choices or errors
+      when invoked; OR `hal0 bench <verb> --help` fails; OR the passthrough swallows a parent-app
+      flag; OR a mutating bench verb (run, worker, publish, upload) misparses its arguments
+      because of ignore_unknown_options and acts on the wrong target.
+    review_at: v1.1.0
+
+  - id: model-display-name-from-gguf-general-name
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      `hal0 model list` can show an odd Name such as "Jina Bert Implementation" for a reranker.
+    why: >-
+      That string is the file's own `general.name` key, printed verbatim — NOT the arch header
+      (`general.architecture` there is `jina-bert-v2`, which never appears in hal0's output).
+      hal0 deliberately separates the registry ID (filesystem identity — the thing rc.5 fixed in
+      #1807 so hand-registration and auto-scan converge) from the display name (what the model
+      declares about itself, which is why Qwen models render readably). The odd value is an
+      upstream converter mislabel; `hal0 model add --name` and `PUT /api/models/{id}` override it.
+    still_report_if: >-
+      The Name column shows the value of `general.architecture`; OR `--name` is ignored; OR two
+      files with DIFFERENT `general.name` values collide onto one display name. Two registrations
+      of the same file sharing a name is not a finding. The `model add` (general.name) versus
+      auto-scan (filename stem) display divergence is cosmetic and known — report it only if it
+      causes an id collision or a duplicate registry entry.
+    review_at: v1.1.0
+
+  - id: ui-agents-card-amber-ready-dot
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      The Agents page Hermes card shows an amber dot labelled "READY" while hal0-agent@hermes is
+      active and other surfaces say "up".
+    why: >-
+      `agents-overview.jsx` deliberately refuses green for a merely-live unit — green ("serving")
+      is reserved for a backing slot actively generating tokens (#1459: "never a fake 'serving'
+      while idle"). unit_active=true with an idle slot is amber/"ready" by contract. The visible
+      text is "READY"; the word "stale" is only the internal CSS class. The health block's "—"
+      for model and ctx is a correct rendering of an offline, unassigned primary slot.
+    still_report_if: >-
+      The card's VISIBLE text (not the title/aria-label attribute) reads anything other than
+      ready/serving/down/unknown while unit_active is true, or the dot renders red/"down" while
+      systemctl reports the unit active. The CSS class leaking into title/aria-label is a real
+      small bug and is filed in rollup #1841.
+    review_at: v1.1.0
+
+  - id: hermes-state-md-as-of-is-change-marker
+    status: by-design
+    adjudicated: v1.0.0-rc.5
+    summary: >-
+      The `_as_of:` footer in the "# Live system state" block injected at hermes session start
+      can be many hours old.
+    why: >-
+      `_as_of` is bumped only when the substantive body CHANGES (content-hash gate); a render
+      that confirms the body still current bumps mtime via os.utime and deliberately leaves
+      `_as_of` alone so the injected bytes stay prompt-cache-identical. An old `_as_of` therefore
+      means "unchanged since", not "stale data". The hook is bound by hermes' own 2 s
+      on_session_start timeout, so it cannot probe synchronously — it cats a pre-rendered
+      snapshot and kicks a detached refresh. Verified on the GPU prod box: `_as_of` 12.6 h old on
+      a file verified 34 minutes earlier.
+    still_report_if: >-
+      The injected body is demonstrably WRONG about live state at the moment of injection (names
+      a model or capability that is not loaded, or omits one that is) — file that as a
+      missed-change-event defect with a diff of the body against `hal0 slot list`, NOT as a stale
+      timestamp. Note `spawn_context_refresh()` has only two call sites (SlotManager.swap and
+      capability apply): plain slot load, unload, restart and idle-reap do NOT refresh STATE.md,
+      which is the plausible real bug hiding behind the timestamp. Also report if the hook
+      exceeds the 2 s hermes hook timeout.
+    review_at: v1.1.0
+
+  # ── Historical, unexplained ─────────────────────────────────────────────────
 
   - id: brain-model-file-vanished-post-pull
     status: by-design
@@ -98,7 +578,9 @@ known_issues:
     why: >-
       Never filed — cause unproven, and an operator UI action in the same window is the likely
       explanation. Recorded so the next occurrence is recognised as the second, not the first.
+      Did not recur in rc.5.
     still_report_if: >-
       It happens again with no concurrent UI session. Then it is real and urgent — capture the
       pull job record, the store listing timestamps, and the hal0-api journal for the window.
     review_at: v1.0.0
+    review_due: true

--- a/tests/release-validation/lanes/readonly/api.md
+++ b/tests/release-validation/lanes/readonly/api.md
@@ -6,33 +6,48 @@ Probe the REST surface from the workstation with curl against `$API` (from `CONT
 ## Checks
 
 1. **Route inventory.** `GET $API/api/openapi.json` first — it is the source of truth for what
-   exists in this build. Record the route count and diff it against the count in the previous
-   release's report (in `reports/`). A route that vanished between releases is a finding.
+   exists in this build. Record the **full sorted path list** in your report, not just the count:
+   a count-only comparison cannot tell an added route from a removed one. Diff it against the
+   list in the previous release's report. A route that vanished between releases is a finding.
 2. **Core surface.** Walk at minimum: `/health`, `/api/status`, `/api/slots`,
    `/api/slots/{name}`, `/api/slots/{name}/config`, `/api/models`, `/api/settings`,
-   `/api/capabilities`, `/api/profiles`, `/api/activity`, `/api/memory`, `/api/memory/engine`,
-   `/api/memory/banks`, `/api/bench`, `/api/upstreams`, `/api/agents`, `/api/apps`,
-   `/api/auth/status`, `/api/board`, `/api/update/status`, `/v1/models`.
-   For each: well-formed JSON, no 5xx, no stack traces in the body, values that make sense for
+   `/api/capabilities`, `/api/hardware`, `/api/profiles`, `/api/activity`, `/api/services`,
+   `/api/memory`, `/api/memory/engine`, `/api/memory/banks`, `/api/bench`, `/api/upstreams`,
+   `/api/agents`, `/api/apps`, `/api/auth/status`, `/api/board`, `/api/update/status`,
+   `/v1/models`. For each: well-formed JSON, no 5xx, no stack traces, values that make sense for
    this box.
 3. **Version consistency.** The version string must be identical and correct everywhere it
    appears: `/api/status`, `/api/settings`, the UI-facing settings payload, `hal0 --version`.
    Note the exact form (PEP 440 `1.0.0rc5` vs tag form `1.0.0-rc.5`) and whether the two forms
    are used consistently.
-4. **Self-consistency.** Cross-check fields that describe the same reality:
-   * slot `ctx_max` / `config.context_size` vs the runner's actual `--ctx-size` (regression
-     `ctx-advertised-vs-resolved`)
-   * slot `health_ok` / `image_status` vs the slot's reported state — rc.4 had a ready+healthy
-     slot advertising `health_ok=false, image_status=missing`
-   * `/v1/models` ids vs the refs that are actually servable
-5. **Error shape.** Probe 3–4 malformed requests: unknown slot name, unknown bank id, bad query
-   params, unknown model in a GET. Expect clean structured 4xx JSON. A 200 with zeroed data for
-   a nonexistent resource is a finding (rc.4 `/api/memory/banks/{id}/stats` did this).
-6. **Catch-all shadowing.** Confirm the SPA catch-all does not serve HTML 200 at API paths —
-   rc.4 shadowed `/health`, `/openapi.json`, `/docs` (the real ones live under `/api/`).
-7. **Auth posture.** Confirm the observed anonymous access matches what `/api/auth/status`
-   claims. On an auth-enabled box, confirm anonymous requests are actually rejected.
-8. **CORS headers** — present and sane, or absent by design? Record which.
+4. **Context window, all four surfaces at once** — regression `ctx-advertised-vs-resolved`
+   (#1788) and `slot-detail-ctx-max-raw` (#1835). For every slot, compare `ctx_max` from the
+   LIST route, `ctx_max` from the DETAIL route, `context_length` in `/v1/models`, and the
+   `--ctx-size` in the same detail payload's `resolved_command`. rc.5 fixed two of the four and
+   a two-surface check scored it "fixed". `/api/slots/{name}/config` legitimately reports the
+   raw TOML ceiling (see `known-issues.yaml`) — exclude it from the equality test but record it.
+5. **Every advertised id must be resolvable** — regression `v1-models-never-evicts` (#1837).
+   Every id in `/v1/models` must be either a registered model in `/api/models` or a configured
+   slot name in `/api/slots`. One `comm -23` over the two sorted sets. Run it late in the run,
+   after a stateful lane has created and deleted a slot — that is when a ghost appears.
+6. **Self-consistency, elsewhere.** slot `health_ok` / `image_status` vs the slot's reported
+   state (rc.4 had a ready+healthy slot advertising `health_ok=false, image_status=missing`).
+7. **Error shape.** Probe malformed requests: unknown slot name, bad query params, unknown model
+   in a GET. Expect clean structured 4xx JSON. A 200 with zeroed data for a nonexistent resource
+   is a finding.
+8. **Nonexistent-bank sweep.** Do not check only `/stats`. Walk EVERY bank sub-resource with an
+   invented bank id — `memories, tags, entities, entities/graph, documents, directives,
+   mental-models, operations, graph, graph/subgraph, config, stats/timeseries, stats, profile,
+   export` — and record the status per route. rc.4 filed `/stats` alone and the fix did not
+   generalise; rc.5 found twelve more returning 200 with an empty payload indistinguishable from
+   a real, merely-empty bank.
+9. **Catch-all shadowing.** Confirm the SPA catch-all does not serve HTML 200 at API paths, and
+   **follow the redirects** (`curl -sL`): `/health`, `/openapi.json`, `/docs` 307 to their
+   `/api/` forms, and the target must itself resolve 200. A 307 alone proves nothing.
+10. **Auth posture.** Confirm the observed anonymous access matches what `/api/auth/status`
+    claims. On an auth-enabled box, confirm anonymous requests are actually rejected.
+11. **Headers.** Record the response headers verbatim (CORS, security headers, server banner) so
+    a silent change in exposure posture shows up in next release's diff.
 
 ## Carry-forward
 

--- a/tests/release-validation/lanes/readonly/cli.md
+++ b/tests/release-validation/lanes/readonly/cli.md
@@ -6,30 +6,48 @@ command group is unfamiliar, run `--help` first and only run the verbs that clea
 ## Checks
 
 1. **Surface walk.** `hal0 --version`, `status`, `system-info`, `ports`, `doctor`,
-   `slot list|status|show <name>|metrics|capacity|logs <name>`, `model list|show <id>|store`,
-   `memory status`, `config` (read subcommands), `upstream list`, `capabilities list`,
-   `agent list|status <name>`, `app` (read-only status), `registry` (read-only inspect),
-   `mcp list|status <server>`, `auth status`, `board` (read-only verbs), `bench` (list/records),
-   `profile` (if it exists — rc.4 had 17 server-side profiles with full CRUD API and **no CLI
-   at all**; check whether that gap closed), `update --check` (checks only — never apply).
-2. **Exit codes and tracebacks.** Any Python traceback reaching the user is a finding regardless
-   of severity elsewhere. Any command exiting 0 while printing an error is a finding.
+   `doctor perms`, `slot list|status|show <name>|metrics|capacity|logs <name>`,
+   `model list|show <id>|store`, `memory status|bank list|ops list`, `config` (read
+   subcommands), `upstream list`, `capabilities list`, `agent list|status <name>`, `app`
+   (read-only status), `registry` (read-only inspect), `mcp list|status <server>`,
+   `auth status`, `board` (read-only verbs), `bench` (list/records), `profile list|show <name>`,
+   `update --check` (checks only — never apply).
+2. **Exit codes, measured properly.** Capture them as `out=$(cmd); rc=$?` — **never through a
+   pipe**. Piping to `head` masks the real exit status and silently turns this check into a
+   false pass. Any Python traceback reaching the user is a finding regardless of severity
+   elsewhere. Any command exiting 0 while printing an error, or non-zero on success, is a
+   finding.
 3. **Truthfulness against the system.** The CLI's claims must match the box:
    * `hal0 slot list` state vs `systemctl is-active hal0-slot@<name>` for every slot
    * `hal0 status` vs the actual set of running units
-   * `hal0 system-info` cores/threads vs `nproc` (rc.4 leaked host cores into a container view,
-     producing an impossible "cores/threads 16 / 8")
-   * `hal0 doctor` verdict vs its own warnings (rc.4 printed six `!!` warnings then "OK all
-     pre-flight checks passed")
-   * `hal0 update --check` against the staged manifest — real versions and digests, not a
-     placeholder
-4. **Presentation.** Broken tables, unformatted raw floats, empty output where a table was
+   * `hal0 system-info` cores/threads vs `nproc`
+   * `hal0 doctor` verdict vs its own warnings, and whether it mentions any unit sitting in
+     `systemctl --failed`
+   * `hal0 update --check` against the staged manifest — real versions and digests
+4. **Same fact, two commands.** Where two verbs report the same underlying thing they must
+   agree. In particular:
+   * `hal0 profile show <name>` field by field against `GET /api/profiles/<name>` and against
+     the matching row of `hal0 profile list` — rc.5's new profile CLI drops `used_by` on the
+     detail view (#1840 item 11)
+   * the aggregate `hal0` pseudo-slot across `slot list`, `slot show hal0` and `slot logs hal0`
+     — and note that its `/api/slots` entry carries no `state` key, so naive `s["state"]`
+     iteration KeyErrors on it
+   * every slot's declared `context_size` against the `--ctx-size` in its resolved command; a
+     clamp must be visible to the user, not only in the hal0-api journal
+5. **Presentation.** Broken tables, unformatted raw floats, empty output where a table was
    promised, debug log lines leaking above output, colour codes in non-tty output.
-5. **Error quality.** Run 2–3 commands with wrong arguments (unknown slot, unknown model,
-   missing required arg). The error should tell a user what to do next.
+6. **Error quality.** Run 2–3 commands with wrong arguments (unknown slot, unknown model,
+   missing required arg, a path the `hal0` service user cannot read). The error should tell a
+   user what to do next, and must not blame the wrong cause.
+
+## Before you diff CLI state against systemd
+
+Record which other lanes are mutating the box in your window. On a shared box, a slot loaded or
+a slot created by another agent mid-lane reads exactly like CLI/systemd drift. Say what was
+running; an unattributed drift claim is a suspicion, not a finding.
 
 ## Carry-forward
 
-Rollup issue #1796 collected fourteen items from this lane in rc.4. Rollups are cheap to file
-and cheap to lose track of — when you find several small CLI defects, enumerate every one
-individually in your findings even if they will be filed as a single issue.
+Rollups are cheap to file and cheap to lose track of — when you find several small CLI defects,
+enumerate every one individually in your findings even if they will be filed as a single issue
+(#1796 collected fourteen in rc.4; #1840 collected thirteen in rc.5).

--- a/tests/release-validation/lanes/readonly/hermes.md
+++ b/tests/release-validation/lanes/readonly/hermes.md
@@ -9,24 +9,42 @@ chat messages — that is the `hermes-e2e` stateful lane.
 1. **Units.** `systemctl status hal0-agent@hermes hermes-gateway --no-pager`. Running? Restart
    count? Then `journalctl -u <each> --since -1h | grep -iE 'error|traceback|fail'` — quote only
    decisive lines. A restart loop that systemd is quietly absorbing is a major finding.
-2. **Provisioning record.** Find the provisioning/smoke record and compare each phase's status
-   against its own recorded sub-results. rc.4 recorded 2/6 smoke failures and still reported
-   `status=ok` (#1793). This is regression `hermes-smoke-ok-over-failures` — check it here.
-3. **Local endpoints.** The gateway listens on loopback (ports in `CONTEXT.md`; rc.4 used 9119
-   for the dashboard API and 8642 for the gateway). Curl each for a health/status route. Record
-   what 8642 is actually for, from its config — not from assumption.
-4. **Status-string honesty.** Whatever the unit or CLI says about the dashboard must match what
-   the dashboard actually serves. rc.4 claimed "dashboard reachable" while every route returned
-   `{"error":"Frontend not built…"}`. The unbuilt frontend is expected (upstream build artifact,
-   not shipped in the wheel); a status string that hides it is not.
-5. **Data dir.** `/var/lib/hal0/.hermes` — config present, sane permissions, error logs. Never
+2. **Provisioning record, applied to EVERY phase.** Do not check only `smoke_tests`. For each
+   phase in `provision.json`, assert `status != ok` whenever `details.warnings` is non-empty,
+   whenever a headline probe is `skipped`, or whenever a list the phase exists to populate (e.g.
+   `bundled_skills_linked`) is empty. That generalisation is what caught both rc.5 hermes
+   findings — #1828 (five EACCES warnings under `context_link: ok`) and #1831 (two headline
+   probes permanently skipped under `smoke_tests: ok`). Regression
+   `hermes-smoke-ok-over-failures`. When a probe records a SKIP, cross-check its stated reason
+   before believing it: rc.5's reason string ("'hal0/agent' not loaded on the gateway") was
+   false, and `GET /v1/models/hal0/agent` returned 200 at the same moment.
+3. **Bundled skills actually landed.** Every directory listed in `skills.external_dirs` in
+   `/var/lib/hal0/.hermes/config.yaml` must be non-empty, every skill shipped under
+   `/usr/share/hal0/skills` must be reachable from one of them, and
+   `.skills_prompt_snapshot.json` must carry a non-empty manifest. Then check the mechanism, not
+   just the outcome: `ls -ld` each target directory against the `User=` of whatever writes it —
+   a `User=hal0` writer against a `root:root` directory is the shape of #1828.
+4. **Local endpoints.** The gateway listens on loopback (ports in `CONTEXT.md`; rc.5 used 9119
+   for the hermes dashboard and 8642 for the `api_server` OpenAI-compatible platform). Read the
+   port assignments out of `gateway_state.json` plus `/api/status` `gateways[].ports` rather
+   than trusting last release's numbers. Curl each for a health/status route.
+5. **Status-string honesty, and the wheel behind it.** Whatever the unit or CLI says about the
+   dashboard must match what it serves. Also check the packaging: `ls
+   /var/lib/hal0/venvs/hermes/lib/python3*/site-packages/hermes_cli/web_dist`. The pinned wheel
+   shipping no `web_dist` is not merely a cosmetic gap — it is the root cause of #1829, because
+   hal0-api harvests the kanban bearer by scraping that page.
+6. **Data dir.** `/var/lib/hal0/.hermes` — config present, sane permissions, error logs. Never
    print a full API key; last four characters only.
-6. **Dependencies.** The hindsight API on loopback: health endpoint, and the bank list if
+7. **Dependencies.** The hindsight API on loopback: health endpoint, and the bank list if
    discoverable. A fresh box should not have failed memory operations sitting in a bank.
-7. **Defaults posture.** No external integration (slack/discord/telegram/etc.) should be
+8. **Defaults posture.** No external integration (slack/discord/telegram/etc.) should be
    configured or enabled on a fresh install. Anything enabled by default is a finding.
-8. **Wiring.** Session hooks installed by the installer should be allowlisted and actually fire;
+9. **Wiring.** Session hooks installed by the installer should be allowlisted and actually fire;
    plugin kinds should resolve rather than silently downgrade (both were rc.4 #1795 items).
+   Run the `on_session_start` hook by hand as the hermes user and check its payload is fresh
+   *enough*: an `_as_of` older than the hook's own TTL is expected and adjudicated
+   (`known-issues.yaml: hermes-state-md-as-of-is-change-marker`) — what is reportable is the
+   injected BODY disagreeing with `hal0 slot list` at the moment of injection.
 
 ## Carry-forward
 

--- a/tests/release-validation/lanes/readonly/mcp.md
+++ b/tests/release-validation/lanes/readonly/mcp.md
@@ -22,18 +22,33 @@ Speak MCP streamable-HTTP JSON-RPC with curl from the box (`127.0.0.1`), not fro
 ## Checks
 
 1. Protocol handshake completes; session id is honoured.
-2. Tool counts match what the docs and `hal0 mcp` claim, per server. A drift in count between
-   releases is worth reporting even if nothing is broken — it usually means a tool was added or
-   lost unintentionally.
+2. **Tool counts, four surfaces.** Compare `tools/list`, `hal0 mcp list`,
+   `GET /api/mcp/servers`, and the shipped docs — not just two. A mismatch between the REST view
+   and the MCP view means the registry and the served surface have diverged. A drift in count
+   between releases is worth reporting even if nothing is broken.
 3. Tool schemas are structurally valid (name, description, non-empty inputSchema).
-4. Call 1–2 clearly read-only tools per server (a status/list/recall tool — nothing that
+4. **Annotations.** Every tool in `tools/list` must carry `annotations`, and `destructiveHint`
+   must be `true` for the delete family (`model_delete`, `slot_delete`, …) and `false` for
+   load/unload. Agents route safety decisions off these hints, so a lost or flipped annotation
+   is silently dangerous. rc.5 baseline: admin 180/180 annotated, 106 `readOnlyHint: true`,
+   13 `destructiveHint: true`.
+5. **Declared capabilities are implemented.** For each capability advertised in the initialize
+   response (prompts, resources), call the matching list method and require a real result rather
+   than `-32601 Method not found`.
+6. **Session scoping.** Replay a session id obtained from `/mcp/admin/mcp` against
+   `/mcp/memory/mcp` and require rejection (rc.5 correctly returns `-32600 Session not found`).
+   A cross-mount session leak is a security finding.
+7. Call 1–2 clearly read-only tools per server (a status/list/recall tool — nothing that
    creates, mutates, or deletes) and judge the result.
-5. **Error protocol.** Call a tool with a deliberately wrong argument. The JSON-RPC response
-   must carry `isError: true` — rc.4 returned `isError: false` on argument errors, which makes
-   every client treat a failure as a success.
-6. `serverInfo` reports the hal0 version, not the FastMCP library version (rc.4 reported
+8. **Error protocol.** Call a tool with (a) a missing required arg and (b) a wrong-typed
+   required value. Both must return `isError: true` — rc.4 returned `isError: false` on argument
+   errors, which makes every client treat a failure as a success. Then call one with an
+   **unknown extra key** and record what happens: the inner `args` object is deliberately open
+   (`known-issues.yaml: mcp-args-additional-properties-open`), so an ignored unknown key is
+   expected — read that entry's `still_report_if` before filing anything.
+9. `serverInfo` reports the hal0 version, not the FastMCP library version (rc.4 reported
    FastMCP 1.28.1).
-7. Latency: note anything that takes more than a couple of seconds for a list call.
+10. Latency: note anything that takes more than a couple of seconds for a list call.
 
 ## Carry-forward
 

--- a/tests/release-validation/lanes/readonly/ui.md
+++ b/tests/release-validation/lanes/readonly/ui.md
@@ -25,15 +25,30 @@ Load the Playwright MCP tools via ToolSearch: `browser_navigate`, `browser_snaps
 4. **Version and interpolation.** The version string must be shown and correct (rc.4 Settings
    showed "hal0 version —"). Look for empty template interpolations — rc.4's benchmarks header
    rendered "· GB · hal0 v". Check pluralisation ("1 banks").
-5. **Telemetry honesty.** On a box with no GPU, the dashboard must not present *host* GPU
-   statistics as local capacity (rc.4 showed igpu 100% / 83 °C / 116 GB GTT on a GPU-less
-   16 GB container). This is the highest-value check in the lane: it is the class of defect
-   where the UI is confidently wrong rather than visibly broken.
-6. **Badge agreement.** Every status badge must agree with the system: bench worker badge vs
-   `systemctl is-active hal0-bench-worker`, slot badges vs slot state, memory/agent health.
-7. **Accessibility floor.** Nav rail icons and icon-only buttons have accessible names; the
-   snapshot is navigable.
-8. Screenshot each section for the report.
+5. **Telemetry honesty, per page.** On a box with no GPU, the dashboard must not present *host*
+   GPU or NPU statistics as local capacity. Assert it on **every page that draws an accelerator
+   tile**, against `/api/hardware` `compute_capable` — not once for "the dashboard". rc.4's fix
+   covered Overview and Settings and missed the Slots page telemetry header, and a
+   single-surface check scored that as fixed (#1841 item 1). This is the highest-value check in
+   the lane: the UI is confidently wrong rather than visibly broken.
+6. **Widget vs section agreement.** A summary widget must not contradict the full section or the
+   API behind it. Concretely: the Overview "Services" widget must be non-empty whenever
+   `/api/services` returns at least one entry (rc.5's was unconditionally dead, #1836), and the
+   Slots page counts must be internally consistent — rendered rows == card header count ==
+   footer "slots N" == tab badge.
+7. **Badge agreement.** Every status badge must agree with the system: bench worker badge vs
+   `systemctl is-active hal0-bench-worker`, slot badges vs slot state, and the agent card health
+   badge vs BOTH `/api/agents` `unit_active` and the footer service chips — three sources that
+   have disagreed before. Note that an amber "READY" dot on the Hermes card is by design
+   (`known-issues.yaml: ui-agents-card-amber-ready-dot`).
+8. **Accessibility floor, asserted not eyeballed.** Every interactive element in the persistent
+   top bar and nav rail must have a non-empty accessible name, and the name must not be an
+   internal CSS class. Check at a **rail-width viewport (721–1080 px)** as well as full width:
+   the rail hides `.lbl` spans, which is where rc.5's unnamed service links were only visible.
+9. Screenshot each section for the report.
+
+If another lane is mutating the box during your window, say so. Every "does the UI show real
+data" comparison is only valid if the baseline is re-read at the same instant.
 
 Close the browser when done.
 

--- a/tests/release-validation/lanes/stateful/brain.md
+++ b/tests/release-validation/lanes/stateful/brain.md
@@ -4,40 +4,69 @@ The hal0-brain steward: the built-in assistant that answers questions about the 
 tools. Its failure mode is not crashing — it is **confident fabrication**, which is the single
 most damaging defect class in the product, because the user cannot tell.
 
+## Budget and pacing
+
+This lane gets a longer budget than the other stateful lanes (`budget_min` in `kit.toml`) because
+on a CPU box a single tool turn can exceed the whole 12-minute default — which is why checks 7–9
+went untested for two releases running. Give every brain request a client timeout LONGER than
+`[brain_chat] completion_timeout_s` (300 s default), and prefer the cheap per-tool probes in
+check 5 over whole conversations. If you run out of time, say which checks you skipped.
+
+Also: cross-check the timestamp in your handoff string against the box's own clock before
+trusting the slot layout it describes. rc.5's handoff was stamped ten minutes ahead of box time
+and described a layout that had already changed.
+
 ## Checks
 
-1. **Find the surface.** `hal0 chat --help` on the box, and grep the OpenAPI paths for
-   brain/chat routes — the dashboard uses one of them. Record the current `brain_chat` config
-   (enabled, read_only, model, tool_model, max_rounds) before testing.
+1. **Find the surface and record the runner.** `hal0 chat --help` on the box, grep the OpenAPI
+   paths for brain/chat routes, and record the current `brain_chat` config (enabled, read_only,
+   model, tool_model, max_rounds) **and the brain slot's resolved runner image**
+   (`systemctl cat hal0-slot@brain | grep '^Image='`). #1789 was an image-identity bug; without
+   the image recorded, neither a pass nor a fail is attributable.
 2. **CLI chat.** One-shot if a flag supports it; otherwise drive the REPL with a piped here-doc.
-   Does it connect, answer from the expected slot, and exit cleanly? Quote the reply.
-3. **API chat.** POST the brain chat route with a simple message. Does it round-trip/stream?
-   Does the route have a real requestBody schema, and does malformed JSON produce a real error
-   rather than being coerced to `{}` (rc.4 did the latter)?
-4. **Tool rounds** — regression `brain-tools-image-gate` (#1789). Ask something only tools can
-   answer: *"what slots are loaded right now?"*. Then check three things independently:
-   * the reply's factual accuracy against `hal0 slot list`
-   * tool frames present in the stream
-   * tool dispatch present in the hal0-api journal
-
-   rc.4 failed all three at once and answered with invented slot names. The fix moved the gate
-   off runner-image identity, so test on **whatever runner this box actually has**, and say
-   which one that was.
-5. **Tool-model unavailable.** Point `tool_model` at a slot that is offline and ask the same
+   Does it connect, answer from the expected slot, and exit cleanly? Quote the reply. Note that
+   `hal0 chat --brain` hard-codes a 120 s client timeout against a 300 s server budget — a
+   `transport error: ReadTimeout` there is a client artefact, not a server hang.
+3. **The stream says something.** POST the brain chat route and assert that a frame — token,
+   ping, tool_call, or error — arrives within a bounded time, and that the stream always
+   terminates with `done`. The rc.5 failure mode was a zero-byte HTTP 200, which every
+   "did it 200?" check passes. Note the head goes out in ~15 ms and silence until the first
+   round is by-design (`known-issues.yaml: brain-chat-sse-silent-until-first-frame`); what is
+   reportable is a stream held past `completion_timeout_s` with neither an error nor a done
+   frame.
+4. **Malformed body.** POST an unparseable body and a body whose `messages` is the wrong type.
+   The route is hand-parsed by house convention and answers 200 on this SSE surface — that part
+   is adjudicated (`known-issues.yaml: brain-chat-hand-parsed-body`). What must happen is an
+   `{"type":"error"}` frame; silently answering an empty question is the finding.
+5. **Every tool, individually** — regression `brain-tools-image-gate` (#1789) and
+   `brain-board-tools-401` (#1829). Do not rely on one conversation to exercise the tool
+   surface: drive each family with a direct question that needs exactly that tool — a slots
+   question, a board question (`get_board`), a memory question. rc.5's dead board surface was
+   only visible because an unrelated question happened to reach for it. For each: check the
+   reply's accuracy against the box, tool frames in the stream, and tool dispatch in the
+   hal0-api journal. If a tool family errors, reproduce it in-process against the client class
+   rather than through a multi-minute chat turn — that turns a 5-minute probe into a 1-second
+   one.
+6. **Tool-model unavailable.** Point `tool_model` at a slot that is offline and ask the same
    question. The steward must degrade honestly — "tools unavailable" — not hallucinate. Then
    load that slot and confirm tools engage.
-6. **read_only guard.** With `read_only=true`, ask the steward to perform a mutating action.
-   It must refuse. rc.4 could never reach this guard because tool rounds never fired, so it has
-   effectively never been validated — treat it as untested until you see it refuse.
-7. **Round limits.** Ask something that would need more than `max_rounds` tool calls. Does it
+7. **read_only guard.** With `read_only=true`, ask the steward to perform a mutating action. It
+   must refuse. This has never been reached in a validation run — treat it as untested until you
+   see it refuse, and prioritise it over check 8 if time is short.
+8. **Round limits.** Ask something that would need more than `max_rounds` tool calls. Does it
    stop cleanly and say so?
+
+Client disconnect is settled: closing the client DOES cancel the turn
+(`known-issues.yaml: brain-turn-cancelled-on-client-disconnect`). Do not spend budget re-deriving
+it; read that entry's `still_report_if` if you suspect otherwise.
 
 ## Fabrication test (run this one carefully)
 
 Ask two or three questions whose true answers you already know from the box, phrased so a
-non-tool answer would be plausible. Any answer that is fluent and wrong, with no tool call
-behind it, is a `major` finding on its own — regardless of whether the tools plumbing "works".
+non-tool answer would be plausible. Any answer that is fluent and wrong, with no tool call behind
+it, is a `major` finding on its own — regardless of whether the tools plumbing "works".
 
 ## Leave behind
 
-Brain healthy. Note any slot you loaded for the tool-model test.
+Brain healthy. Note any slot you loaded for the tool-model test, and restore `brain_chat` config
+values you changed.

--- a/tests/release-validation/lanes/stateful/capabilities.md
+++ b/tests/release-validation/lanes/stateful/capabilities.md
@@ -5,9 +5,17 @@ drives when setting hal0 up for their hardware.
 
 ## Checks
 
-1. **Baseline.** `hal0 capabilities --help` and `list`, plus `GET /api/capabilities`. Record
-   which capabilities ship enabled and on which backend. A CPU-only box that ships capabilities
-   bound to a GPU backend is a finding in itself.
+Record `systemctl --failed` verbatim at lane entry and lane exit and diff them. On a box with no
+snapshot, residue accumulates anonymously across a serialised run unless each lane bounds its own.
+
+1. **Baseline, cross-checked against the advertised backends.** `hal0 capabilities --help` and
+   `list`, plus `GET /api/capabilities`. Then assert that every device named in the shipped
+   `/etc/hal0/capabilities.toml` appears in `/api/capabilities` `.backends` **and** in the
+   catalog rows the picker actually offers for that child. The seed copying a GPU device out of
+   the shipped slot TOML is by-design (`known-issues.yaml:
+   capabilities-seed-devices-from-slot-tomls`); a default selection naming a backend the host
+   never advertises, or one no catalog row can match, is a hard fail — that is where the seed
+   costs the user something.
 2. **Enable a capability against the real hardware.** Bind the embedding model to the embed
    capability on the backend this box actually has, and enable it. Does the flip from the seeded
    default work cleanly? Does enabling load or require the slot? Verify through both
@@ -16,22 +24,34 @@ drives when setting hal0 up for their hardware.
    config (`[memory.embedding] rerank_model`, `rerank_gateway_url`). Issue a rerank through the
    gateway with a query and three documents. In rc.4 this whole path was dead because profile
    flags never reached argv (#1787).
-4. **Model defaults.** Promote a model to default for its type. Verify `hal0 model list` marks
-   it (rc.4 had no default marker at all) and that a chat completion with no `model` field, or
-   `model=default`, uses it.
-5. **Registry mutations.** `hal0 model add` on a copy of a gguf staged into a scratch directory
+4. **Model defaults.** Promote a model to default for its type. Verify `hal0 model list` marks it
+   with the `*` in the unlabelled first column. Then probe dispatch with all three client shapes
+   — omitted `model`, `model: "default"`, and the explicit id — because only the third normally
+   gets tested and it is the one that hides the behaviour. The marker NOT steering the dispatcher
+   is by-design (`known-issues.yaml: model-default-marker-is-per-type-fallback`); what is
+   reportable is a model-less completion 404ing on a box whose `agent` anchor slot HAS a model
+   bound.
+5. **Registry mutations.** `hal0 model add` on copies of a gguf staged into a scratch directory
    (copy, never move, and never touch the shared store's originals):
-   * Is the capability type auto-detected correctly? rc.4 misclassified a reranker as `chat`.
-   * Is the id derived sensibly? rc.4 derived it from an arch header, producing
-     `jina-bert-implementation`.
+   * Is the capability type auto-detected correctly? Register the **same file twice under two
+     different names** — the upstream filename and a neutral one. Byte-identical input yielding
+     two different types is the shortest possible proof of a detection bug and removes all
+     argument about whether the file is unusual (#1838).
+   * Register the same bytes by two different PATHS as well (`hal0 model add` versus the
+     install-time auto-scan) and diff the resulting ids and display names.
+   * Feed it a file with a `.gguf` name and no GGUF magic. Accepted as `chat` is a finding.
+   * Try one add from a directory the `hal0` service user cannot read (e.g. under `/root`) — the
+     first place an operator puts a downloaded gguf. The refusal is correct; an error that
+     cannot distinguish "unreadable" from "missing" is not.
    * Then `hal0 model rm <id>`: does it remove the registry entry, the file, or both — and does
-     it *ask*? A remove that silently deletes files from a shared store is a `critical` finding.
-     Clean up the scratch directory afterwards.
-6. **Profiles.** rc.4 shipped 17 server-side profiles with a full CRUD API and **no CLI**.
-   Check whether `hal0 profile` now exists; if not, that gap stands. Inspect what a profile
-   contains and confirm the API's view matches what a loaded slot actually got — this is the
-   same seam as #1787, from the configuration side. Do not destructively rewrite the brain
-   profile; use a throwaway.
+     it *ask*? Assert the file survives and that `hal0 model rm <id> < /dev/null` aborts rather
+     than proceeding unprompted. A remove that silently deletes files from a shared store is a
+     `critical` finding. Clean up the scratch directory afterwards.
+6. **Profiles.** `hal0 profile` exists as of rc.5. Inspect what a profile contains, confirm the
+   API's view matches what a loaded slot actually got (the same seam as #1787 from the
+   configuration side), and diff `hal0 profile show <name>` field by field against both
+   `GET /api/profiles/<name>` and the matching row of `hal0 profile list` — the detail view
+   already drops `used_by`. Do not destructively rewrite the brain profile; use a throwaway.
 7. **Registry consistency after all of the above.** Re-list models and slots. Orphans, dangling
    references, stale capability bindings?
 

--- a/tests/release-validation/lanes/stateful/hermes-e2e.md
+++ b/tests/release-validation/lanes/stateful/hermes-e2e.md
@@ -4,37 +4,58 @@ Hermes end to end, with models actually loaded. You run last precisely because t
 leave the box in the state hermes needs — which is itself worth noting, since a real user has to
 reach that state on their own.
 
+## Check 0, and it costs 1.3 seconds
+
+Before planning anything else, run the context-window gate:
+
+```sh
+grep -rn 'MINIMUM_CONTEXT_LENGTH' \
+  /var/lib/hal0/venvs/hermes/lib/python3*/site-packages/agent/model_metadata.py
+curl -s $API/v1/models | jq '.data[] | {id, context_length}'
+grep -n 'model:' -A3 /var/lib/hal0/.hermes/config.yaml
+```
+
+Every chat-capable model hal0 advertises must meet or exceed Hermes' hard floor, and the id
+named by `model.default` must resolve. rc.5's GA blocker (#1827) was exactly this mismatch and it
+took 1.6 s to hit — but only if you check it before you start composing chat turns. Regression
+`hermes-cannot-chat-64k-floor`.
+
+Also verify each entrypoint verb EXISTS before planning around it (`hal0 agent --help`). rc.5's
+brief named `hal0 agent smoke <name>`, which does not ship — a missing verb is a recorded finding,
+not something to improvise past.
+
 ## Checks
 
-1. **Entrypoint.** Find how a user talks to hermes: `hal0 agent --help` verbs, the hermes CLI on
-   the box (check the systemd unit's `User=` and run as the right user), or the dashboard API.
-   The dashboard API key lives under `/var/lib/hal0/.hermes` — never print more than its last
-   four characters.
-2. **Plain chat.** Send: *"Reply with exactly: HERMES-RC-OK"*. Does a reply come back? Record
-   latency. From the journals, which model did it actually use, and did the request reach hal0's
-   `/v1` with a ref that routes? rc.4 logged a per-session `dispatch.no_route` for `hal0/agent`
-   before falling back — noise that indicates the wiring is wrong even when the answer arrives.
-3. **Memory roundtrip.** Ask hermes to remember a marker (*"Remember: the validation marker is
-   MARKER-7734"*), then in a separate turn ask it to recall it. Use generous timeouts and watch
-   both the `hal0-agent@hermes` and `hal0-api` journals.
-   * Did the store actually reach the memory backend, or only a local file? rc.4 wrote the
-     marker to a local `USER.md` and nothing else, making recall impossible.
+1. **Entrypoint.** Find how a user talks to hermes: `hal0 agent` verbs, the hermes CLI on the box
+   (check the systemd unit's `User=` and run as the right user), or the dashboard API. The
+   dashboard API key lives under `/var/lib/hal0/.hermes` — never print more than its last four
+   characters. Restore any config file you modify, byte for byte, and say so.
+2. **Plain chat.** Send: *"Reply with exactly: HERMES-RC-OK"* with the SHIPPED config, not a
+   patched one. Does a reply come back? Record latency. From the journals, which model did it
+   actually use, and did the request reach hal0's `/v1` with a ref that routes?
+3. **Memory roundtrip, as a delta not an absolute.** Time a no-memory turn of the same shape
+   FIRST, then the memory turn, and report the multiplier. On a contended CPU box the absolute
+   is meaningless; a 3x is not. Then:
+   * Did the store actually reach the memory backend, or only a local file?
    * Is the recall correct, or a hallucination that merely sounds right?
-   * Which backend was it supposed to use — hindsight via hal0's memory MCP, or its own store?
-     Confirm the configured wiring matches the observed behaviour.
-   * On slowness: see `known-issues.yaml: hermes-memory-turn-slow-on-cpu`. Minutes on a CPU box
-     with a tiny model is expected. What is *not* expected is a turn never completing, or the
-     retain op and the chat turn contending for the same slot — that would deadlock single-GPU
-     boxes too, and is `major`.
-4. **Re-run the provisioning smoke** now that models are loaded (`hal0 agent smoke <name>` or
-   whatever the current verb is). Do the previously failing phases pass? And — regression
-   `hermes-smoke-ok-over-failures` (#1793) — does a phase with recorded failures now report
-   warn/fail rather than ok? Verify by reading the record, not the summary line.
-5. **Gateway.** Confirm what the gateway port is for from its config, health-check it, and
-   confirm no external integrations are enabled.
-6. **Tool use.** Ask hermes something requiring a hal0 tool call (platform state). Same
+   * Confirm the configured wiring matches the observed backend.
+   * Raw per-turn slowness on CPU is adjudicated (`known-issues.yaml:
+     hermes-memory-turn-slow-on-cpu`); slot contention now belongs to
+     `hindsight-extraction-shares-utility-slot` and the memory lane's check 7.
+4. **Context-window consistency across surfaces.** For the model hermes is bound to, assert
+   `/api/slots/<name>.ctx_max` == `/v1/models[<id>].context_length` == the resolved `--ctx-size`
+   in the slot unit. Three surfaces, one number — and this is the number the agent's own gate
+   reads.
+5. **Re-run the provisioning smoke** now that models are loaded, and read the RECORD, not the
+   summary line: no phase may report `ok` while carrying `details.warnings`, and no headline
+   probe may be silently `skipped` (#1828, #1831). Regression `hermes-smoke-ok-over-failures`.
+6. **Gateway.** Confirm what each hermes port is for from `gateway_state.json` and `/api/status`
+   `gateways[].ports` rather than from last release's numbers, health-check them, and confirm no
+   external integrations are enabled.
+7. **Tool use.** Ask hermes something requiring a hal0 tool call (platform state). Same
    fabrication standard as the brain lane: fluent and wrong with no tool call is a finding.
 
 ## Leave behind
 
-Hermes running. Brain, utility, and embed slots healthy.
+Hermes running with its SHIPPED config restored. Brain, utility, and embed slots healthy. State
+every config file you touched and its final contents in `box_state_on_exit`.

--- a/tests/release-validation/lanes/stateful/memory.md
+++ b/tests/release-validation/lanes/stateful/memory.md
@@ -4,43 +4,73 @@ The hindsight-backed memory subsystem: retain, recall, search, banks, and the as
 pipeline. rc.4's memory findings were all about the **fresh-install window** — the period before
 any model is loaded — so start there before you fix the environment.
 
-## Order matters
+## Order matters, and it is a scheduling constraint on the whole run
 
-Do step 1 **before** loading anything, or you destroy the evidence.
+Do step 1 **before** loading anything, or you destroy the evidence. In rc.5 an earlier stateful
+lane had already bound a model to the `utility` slot, so the #1792 regression could not be tested
+at all. Either this lane runs before any lane that touches `utility`, or the earlier lanes must
+declare `utility` off-limits — say in your report which of the two you got.
+
+## Checks
 
 1. **Fresh-install window** — regression `memory-retain-dead-letter` (#1792). With the utility
    slot in its as-shipped state, attempt a retain. Then inspect the operation: does it queue and
    wait for routing, retry with backoff, or burn its retries and dead-letter permanently?
-   Record `hal0 memory status` — a pristine install reporting "Writes FAILING" is a finding.
-   Also record what `HINDSIGHT_API_LLM_MODEL` points at and whether that target ships with a
-   model assigned.
+   Record `hal0 memory status`, and record what `HINDSIGHT_API_LLM_MODEL` points at and whether
+   that target ships with a model assigned.
 2. **Baseline inventory.** `hal0 memory status`, `hal0 memory --help`, `GET /api/memory/engine`,
-   `/api/memory/banks`, `/api/memory/list`. A fresh box should have zero failed operations —
-   rc.4 had two on arrival.
+   `/api/memory/banks`, `/api/memory/list`. A fresh box should have zero failed operations.
+   Enumerate the banks you EXPECT on a fresh install (`shared`, and `agents` for the peer
+   registry) and record which exist and when each was created — rc.5 had no `agents` bank at all
+   after 16 h of uptime, and with no check the fleet has no signal on whether agent identity
+   cards have anywhere to land.
 3. **Fix the routing.** Assign a chat model to the utility slot and load it. Confirm the
    hindsight target ref now routes (`POST /v1/chat/completions` with that exact ref). If it
-   still does not resolve, find what ref *does* and report the mapping gap precisely — that
-   mismatch was the root cause in rc.4.
-4. **Retain.** Store a memory containing a literal marker, e.g. *"the CT151 validation marker is
-   MARKER-7734"*. Wait for the async op; check its status through to completion.
-5. **Recall and search** — regression `fact-extraction-strips-literals` (#1794). Query for the
-   concept ("what is the CT151 validation marker?") and for the literal ("MARKER-7734").
-   Does the literal come back? State explicitly whether it came from extracted facts or from
-   the document fallback: the fallback is a workaround, and a durable fix needs server-side
-   content search that does not exist yet.
-6. **Dead-letter recovery.** Retry any failed operations (`hal0 memory ops retry`, the
-   operations API, or the MCP `memory_operation_retry` tool). Do they recover losslessly? If
-   there is no recovery path at all, that is the finding.
-7. **Disable / enable.** `hal0 memory disable` then `enable`, checking `/api/memory/engine`
-   between steps. Does the API degrade gracefully and recover cleanly, or does something stay
-   broken?
-8. **Bank hygiene.** Which banks exist on a fresh box, and when are they created? rc.4 only
-   created the `agents` bank on an hal0-api restart. Confirm bank stats are real — a nonexistent
-   bank must 404, not return zeroed stats with a 200.
-9. **Error surfacing.** Send a malformed add (wrong field name). The error should name the
-   field, not surface as `system.internal`.
+   still does not resolve, find what ref *does* and report the mapping gap precisely.
+4. **Retain, then prove it LANDED.** Store a memory containing a literal marker, e.g. *"the
+   <BOX> validation marker is MARKER-7734"*. Do not stop at the HTTP 200 and the operation id —
+   that is what made rc.5's headline defect invisible to every check. Poll until the store is
+   actually non-empty: `GET /api/memory/list` returns items AND the write bank's `fact_count` is
+   non-zero, with an explicit deadline. **An op still `processing` past the deadline is a `fail`,
+   not a `skipped`.** Regression `memory-extraction-never-lands` (#1834).
+5. **Terminal state within a bound.** Independently of check 4, assert that every operation you
+   create reaches `completed` or `failed` within a stated time. rc.4 dead-lettered and rc.5 hung
+   in `processing`; a check written against either behaviour alone misses the other. Terminal-
+   state-within-N is the invariant that survives both. Note that `hal0 memory ops list` shows a
+   `batch_retain` PARENT alongside each `retain` child, so counts read double — that is
+   bookkeeping, adjudicated (`known-issues.yaml: batch-retain-parent-rows-are-bookkeeping`).
+6. **Status must not contradict ground truth** — regression `memory-status-green-while-empty`
+   (#1833). Run `hal0 memory status` and `hal0 memory bank list` in the same breath and make the
+   contradiction itself the assertion: "Writes landing" is a `fail` while the write bank's
+   `fact_count` is 0 with ops outstanding, or while `journalctl -u hindsight-api` is emitting
+   `[STUCK_STACK]`.
+7. **Contention, measured not argued** — `known-issues.yaml:
+   hindsight-extraction-shares-utility-slot`. Read `HINDSIGHT_API_LLM_MODEL`, resolve the serving
+   slot's llama-server pid via `/proc/<pid>/cgroup`, then time a trivial chat turn to that same
+   ref with and without a retain in flight. Also sample the runner's `/metrics`
+   (`requests_processing`, `requests_deferred`) and `/slots` (`params.n_predict`). This is the
+   only mechanical way to promote the by-design entry back into a finding, and it is currently
+   reachable only by hand.
+8. **Recall and search** — regression `fact-extraction-strips-literals` (#1794). GATED on check 4
+   actually landing; if nothing landed, report `blocked` and point at #1834. Query for the
+   concept and for the literal. State explicitly whether the literal came from extracted facts
+   or from the document fallback — the fallback is a workaround, not the fix.
+9. **Recovery surfaces.** Retry any failed operations (`hal0 memory ops retry`, the operations
+   API, or MCP `memory_operation_retry`). Include the negative path: while an op is `processing`,
+   `--all-failed` says "Nothing to retry." and `--id` 409s — that is by-design
+   (`known-issues.yaml: memory-ops-processing-not-retryable`), but check the 409 body reaches the
+   user and that a way to see the scheduled retry exists (`retry_count` / `next_retry_at`).
+   "Nothing to retry" printed over a visibly wedged queue is a passing-looking output for a
+   broken situation.
+10. **Disable / enable.** `hal0 memory disable` then `enable`, checking `/api/memory/engine`
+    between steps. Deferred-apply is by-design (`known-issues.yaml:
+    memory-enabled-is-restart-scoped`) — record whether POST /api/memory/add still 200s in that
+    window, and whether the restart actually disables the subsystem.
+11. **Bank hygiene and error surfacing.** A nonexistent bank must 404 on its sub-resources, not
+    return an empty 200 (the api lane sweeps all of them; spot-check here). Send a malformed add
+    (wrong field name) — the error should name the field, not surface as `system.internal`.
 
 ## Leave behind
 
-Memory enabled, utility slot loaded, brain healthy. Note the marker you stored — the hermes lane
-will look for its own separately.
+Memory enabled, utility slot loaded, brain healthy. Note the marker you stored and the state of
+every operation you created — the hermes lane will look for its own marker separately.

--- a/tests/release-validation/lanes/stateful/routing.md
+++ b/tests/release-validation/lanes/stateful/routing.md
@@ -6,31 +6,49 @@ tiny and their answers are irrelevant.
 
 ## Checks
 
-1. **Model refs.** `GET $API/v1/models` — record the id set. Then `POST /v1/chat/completions`
+**Pick your workhorse slot first.** Measure the generation rate of each ready chat slot and use
+the fastest for the wire-format checks. On a CPU box the brain F16 model needs ~98 s for eight
+tokens; using it naively consumes the entire lane budget.
+
+1. **Model refs.** `GET $API/v1/models` — record the id set. Assert it is a subset of
+   `hal0 model list` ids UNION `hal0 slot list` names (one `comm -23`); rc.5 advertised three
+   ghost ids belonging to deleted slots, each of which hard-404s
+   (regression `v1-models-never-evicts`, #1837). Then `POST /v1/chat/completions`
    (non-streaming, `max_tokens` ~40) with each plausible ref shape: the slot name (`brain`), the
    raw model id, and the namespaced alias (`hal0/brain`). Which resolve? Which 404? Is the error
-   JSON clean and actionable? Any ref advertised in `/v1/models` that is not servable is a
-   finding.
+   JSON clean and actionable?
 2. **Streaming.** Same request with `stream=true`: SSE chunks well-formed, `[DONE]` terminator
    present, no truncation.
 3. **Embeddings** — regression `profile-flags-argv` (#1787). `POST /v1/embeddings` against the
    embed slot's ref: returns a vector, dimensionality sane, a batch of 2 inputs works. rc.4
    returned 501 "start with --embeddings" while the slot reported ready.
 4. **Rerank.** `POST` the rerank route with a query and three documents: scores returned and
-   ordered sensibly. Same 501 failure mode in rc.4.
+   ordered sensibly. Same 501 failure mode in rc.4. Probe the **unversioned** `/rerank` as well
+   as `/v1/rerank` — Cohere- and Jina-compatible clients default to the unversioned path and
+   hal0 answers it with 405. Record it as pass or warn deliberately rather than discovering it
+   ad hoc.
 5. **Legacy.** `POST /v1/completions` — supported, or a clean documented error.
 6. **Dispatcher behaviour on an unloaded model.** Request a model that is registered but NOT
    loaded. Watch the hal0-api journal during the call. Per ADR-0023 Rule 9 the anchor slot
    answers and discloses the substitution in the response `model` field — that is by design
    (see `known-issues.yaml`). What you are checking is that the disclosure actually happens and
    the journal's `resolution_path` names a slot that is really loaded.
-7. **Tool-call passthrough.** A chat completion with a trivial `tools` array: does the request
-   reach the runner with tools intact, or is it silently stripped? Check the runner's own view,
-   not just the response. Silent stripping is the shape of #1789.
-8. **Concurrency.** Four parallel short chat requests to one slot: all complete, no 5xx, no
+7. **Error messages must not contradict the registry.** For every 4xx the dispatcher returns,
+   check the top-level `error.message` against `hal0 model list`: it must never claim a model is
+   "not found in registry" for an id that IS registered. Cheap invariant, caught a real defect
+   in rc.5 (#1840 item 7).
+8. **Tool-call passthrough.** A chat completion with a trivial `tools` array: does the request
+   reach the runner with tools intact, or is it silently stripped? Compare the response through
+   `:8080` against the same request sent **directly to the runner port** on `127.0.0.1` — the
+   gateway response alone cannot distinguish passthrough from re-synthesis. Silent stripping is
+   the shape of #1789.
+9. **Concurrency.** Four parallel short chat requests to one slot: all complete, no 5xx, no
    interleaved corruption.
-9. **Timeouts and long generations.** One request with a large `max_tokens` — does anything in
-   the path (proxy, gateway, client default) cut it off mid-stream without saying so?
+10. **Timeouts and long generations.** One request with a large `max_tokens` — does anything in
+    the path (proxy, gateway, client default) cut it off mid-stream without saying so? A
+    non-streaming request cut off at `[dispatcher] direct_read_timeout_s` (300 s default) is
+    by-design (`known-issues.yaml: dispatcher-300s-read-timeout`); measure the elapsed time
+    before filing, and note that streaming is exempt.
 
 ## Leave behind
 

--- a/tests/release-validation/lanes/stateful/slots.md
+++ b/tests/release-validation/lanes/stateful/slots.md
@@ -1,7 +1,14 @@
 # Lane: slots (stateful, order 1)
 
-Slot lifecycle end to end. You run first, so the box is in its post-install state — capture
-what that state actually is before you change it.
+Slot lifecycle end to end. You run first, so the box is in its post-install state — capture what
+that state actually is before you change it.
+
+## Before you start, and again at the end
+
+Record `systemctl --failed` and `hal0 slot list` verbatim at lane entry and lane exit, and diff
+them. That makes residue you create attributable instead of anonymous, and it fails loudly if
+another agent is mutating the box: if slots appear that you did not create, stop and say so —
+capacity, port and failed-unit assertions are worthless on a contended box.
 
 ## Checks
 
@@ -9,34 +16,54 @@ what that state actually is before you change it.
    status, before touching anything. On a fresh install this is a finding-rich moment: which
    slots ship seeded, which ship model-less, and does anything already look wrong?
 2. **Assign + load.** Take the embed slot: `hal0 slot edit embed --model <embedding model>
-   --hardware <backend>`, then `hal0 slot load embed`. Poll its health endpoint until ok (≤120 s
-   on CPU). Watch the state transitions in `hal0 slot list` while it warms — do they progress
-   sensibly (offline → warming → ready), and does the terminal state match the unit?
+   --hardware <backend>`, then `hal0 slot load embed`. **Time the load and record the CLI exit
+   code** (`out=$(...); rc=$?`) — regression `slot-verbs-10s-client-timeout` (#1832): the client
+   caps its read at 10 s against a 180 s server budget, so a load that succeeds can exit 1 with
+   `ReadTimeout`. Always verify the server-side outcome before believing either result. Poll
+   health until ok (≤120 s on CPU) and watch the state transitions.
 3. **A second slot.** Same flow for the rerank slot, so two are live at once.
 4. **Restart / unload.** `hal0 slot restart <name>` — comes back healthy? `hal0 slot unload
-   <name>` — clean stop, state offline, unit stopped, port released?
+   <name>` — clean stop, state offline, unit stopped, port released? Record exit codes here too;
+   all three mutating verbs share the same client timeout.
 5. **Create / delete.** `hal0 slot create --help`, then create a throwaway slot on a free port
    (`hal0 ports`), assign a small chat model, load, verify health, unload, delete. Check for
-   residue: unit files, `/var/lib/hal0/slots/<name>/`, claimed ports, registry entries. rc.4
-   left an empty state directory behind.
-6. **Swap on a healthy slot.** `hal0 slot swap <slot> --model <other model>`. Even if the CLI
-   throws a `ReadTimeout`, wait and verify server-side: `systemctl cat hal0-slot@<slot> |
-   grep -o -- '--model [^ ]*'` and the runner's own `/v1/models`. Then swap back and confirm
-   healthy. Both the quadlet and the served model must change.
-7. **Swap and lifecycle on an UNhealthy slot** — regression `crash-loop-lifecycle` (#1791).
-   Deliberately induce a crash loop on a throwaway slot by assigning a model the runner cannot
-   load. Then check: what state is reported while it crash-loops and after the systemd start
-   limit is hit? Is the death surfaced anywhere a user would see (`hal0 status`, `doctor`, the
-   dashboard)? Does swap write the NEW model? Clean the throwaway slot up afterwards.
-8. **Profile flags reach argv** — regression `profile-flags-argv` (#1787), the rc.4 GA-blocker.
-   For each loaded slot, compare its profile's flags against the resolved runner argv. Include
-   at least one model that has never been stamped with `defaults.profile` (register a fresh
-   gguf via `hal0 model add` and assign it) — the unstamped path is the one that broke.
-9. `hal0 slot metrics` and `hal0 slot capacity` reflect what is actually loaded, with correct
-   units — rc.4 booked CPU memory under "VRAM MB" with "RAM MB 0.0".
+   residue: unit files, `/var/lib/hal0/slots/<name>/`, claimed ports, registry entries, and a
+   new entry in `systemctl --failed`.
+6. **A capability slot created by hand** — regression `slot-create-no-profile-501` (#1830).
+   Create a `--type reranking` slot AND a `--type embedding` slot with `hal0 slot create`, bound
+   to a model registered via `hal0 model add` (which leaves `defaults: null`). Then: does the
+   written TOML carry a `profile` key? does the resolved argv carry `--reranking` /
+   `--embeddings`? does the endpoint answer, or 501 while the slot reports `ready`? This is the
+   path the shipped seeds do not exercise, and it is where #1787 still lives.
+7. **Swap on a healthy slot.** `hal0 slot swap <slot> --model <other model>`. Even if the CLI
+   throws a `ReadTimeout`, wait **60 s** and only then verify server-side: `systemctl cat
+   hal0-slot@<slot> | grep -o -- '--model [^ ]*'` and the runner's own `/v1/models`. Reading it
+   immediately shows the OLD model because the previous load still holds the per-slot lock —
+   that misreading cost rc.5 a false regression. Then swap back and confirm healthy.
+8. **Swap and lifecycle on an UNhealthy slot** — regression `crash-loop-lifecycle` (#1791).
+   Induce a crash loop on a throwaway slot by binding it to a file the runner cannot load, then
+   poll for **four minutes**: state, `container_status`, `metadata.message`, and
+   `systemctl show -p ActiveState -p Result -p NRestarts`. A `warming` reading inside the first
+   ~180 s is by-design (`known-issues.yaml: crash-loop-warming-180s-window`) — the finding is a
+   state that never converges, an empty message on `error`, or a death nothing surfaces in
+   `hal0 status` / `hal0 doctor`. Then swap it to a good model and clean it up.
+9. **Reject a bad model file.** Feed `hal0 model add` a file with a `.gguf` name and no GGUF
+   magic (`head -c 2000000 /dev/urandom`). rc.5 admitted it as `capabilities: chat` (#1838) —
+   precisely the input that makes check 8's crash loop reachable by accident rather than on
+   purpose. Delete the registration afterwards.
+10. **Backend selection is real, not a label.** Diff `systemctl cat hal0-slot@<slot>` between the
+    same slot pinned to `cpu` and to the box's GPU backend. What must change is the runner
+    **image** and the `AddDevice=` lines; a residual `-ngl -1` on a CPU-pinned slot is inert and
+    adjudicated (`known-issues.yaml: cpu-pinned-slot-keeps-ngl-flag`). Restore the original
+    device when done.
+11. **Memory accounting** — regression `slot-capacity-vram-attribution` (#1839).
+    `hal0 slot capacity` must not book VRAM on a box where `/api/hardware` reports no
+    compute-capable GPU, and its Total MB must be reconcilable with `hal0 slot metrics` Mem MB
+    for the same slot in the same second. State which figure is real RSS and which is an
+    estimate.
 
 ## Leave behind
 
 Brain slot loaded and healthy on the CPU-viable chat model; embed slot loaded (the memory lane
-uses it); rerank unloaded; every throwaway slot deleted. State all of this in
-`box_state_on_exit`.
+uses it); rerank unloaded; every throwaway slot deleted and its unit reset. State all of this in
+`box_state_on_exit`, including anything you could not clean up.

--- a/tests/release-validation/lanes/update/post-upgrade.md
+++ b/tests/release-validation/lanes/update/post-upgrade.md
@@ -21,7 +21,11 @@ did not ask for?**
 2. **Seed reconciliation.** New seeds shipped by the release (profiles, slots, curated models)
    must be *added* without clobbering user modifications. Find a seed the user had modified and
    confirm the modification survived. Tombstoned/retired seeds must actually disappear rather
-   than resurrect.
+   than resurrect. **The seed loop does not back-fill existing files**, which makes an upgraded
+   box MORE exposed than a fresh one to two rc.5 defects — check both here: capability slots the
+   operator created historically carry no `profile` key and 501 their own endpoint (#1830), and
+   slot TOMLs carrying larger ceilings written by earlier releases widen the advertised-vs-served
+   context gap (#1835).
 3. **Functional smoke on the upgraded box.** A short version of the fresh-box lanes: chat
    completion, embeddings, a memory retain and recall, a brain steward question, the dashboard
    loading with real data. Anything broken here that works on the freshly installed box is an

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -4,9 +4,9 @@
 # release, forever, until it is promoted into pytest or scripts/release-test.sh (set
 # `promoted_to:` and drop it in the same PR).
 #
-# This is the mechanism that makes the kit compound. rc.4 found eleven issues; rc.5 must prove
-# all eleven are actually gone on a real box, because they were fixed against unit tests and CI,
-# not against a fresh end-to-end install.
+# This is the mechanism that makes the kit compound. rc.4 found eleven issues; rc.5 proved on a
+# real box that most were genuinely fixed, that two were only half-fixed, and that two probes
+# could not be run at all as written — which is worth more than any of them passing CI.
 #
 # tier: mechanical -> run the repro, compare to `expect`, no judgement needed (fable)
 #       judgment   -> requires reading source, weighing intent, or interpreting output (sonnet)
@@ -16,35 +16,45 @@
 #   regressed  — repro reproduces the original defect
 #   partial    — some of `expect` holds, some does not (say exactly which)
 #   blocked    — could not run the repro (say why; NEVER report this as fixed)
+#
+# `promote_ready: true` marks an entry whose repro is mechanical and stable enough to become a
+# pytest case or a `scripts/release-test.sh` step. The next fix wave should write that test and
+# delete the entry. Moving work out of this kit and into CI is the goal, not a loss.
 
 schema: 1
-updated: 2026-08-10
+updated: 2026-08-11
 
 regressions:
+  # ── Carried from v1.0.0-rc.4 ────────────────────────────────────────────────
+
   - id: profile-flags-argv
     issue: 1787
     from: v1.0.0-rc.4
     severity: ga-blocker
     tier: judgment
-    lane: routing
+    lane: slots
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
-      Profile flags never reached llama-server argv for models with no `defaults.profile` stamp
-      (auto-scan / pull / capability-apply never stamp it, and the #1636 overlay is gated on the
-      stamp). /v1/embeddings and /v1/rerank returned 501 "start with --embeddings" while the
-      capability slots reported ready.
+      Profile flags never reached llama-server argv for models with no `defaults.profile` stamp.
+      /v1/embeddings and /v1/rerank returned 501 "start with --embeddings" while the capability
+      slots reported ready.
     fix: >-
       A `slot_profile_template` argv segment, applied BELOW `model_extra_args`.
+    rc5_note: >-
+      Holds for the INSTALLER-SEEDED embed/rerank slots (their TOMLs ship a `profile` key). Does
+      NOT hold for a slot created by `hal0 slot create` or the dashboard modal, because neither
+      writes a `profile` key at all and the #1787 template gate requires one — filed as #1830.
+      Keep probing both paths; they are different code.
     repro: |
-      Assign the embedding model to the embed slot on the CPU backend and load it, then:
-        curl -s $API/v1/embeddings -d '{"model":"embed","input":["hello"]}'
+      Seeded path: assign the embedding model to the shipped `embed` slot, load it, then
+        curl -s $API/v1/embeddings -d '{"model":"<id>","input":["hello"]}'
         systemctl cat hal0-slot@embed | grep -o -- '--embedding'
-      Repeat for rerank with the jina reranker and POST /v1/rerank.
-      Then do it with a model that has NEVER been stamped: register a fresh gguf via
-      `hal0 model add` and assign it, so the unstamped path is what is exercised.
+      Repeat for the shipped `rerank` slot and POST /v1/rerank.
+      Unstamped path: register a fresh gguf with `hal0 model add` (that leaves `defaults: null`)
+      and assign it to a seeded capability slot, so the unstamped model path is exercised.
     expect: >-
-      Embeddings return a vector of sane dimensionality; rerank returns scores; the resolved
-      argv contains --embedding / --reranking; model_extra_args still win over the profile
-      template where they overlap.
+      Embeddings return a vector of sane dimensionality; rerank returns ordered scores; the
+      resolved argv contains --embedding / --reranking.
 
   - id: ctx-advertised-vs-resolved
     issue: 1788
@@ -52,16 +62,25 @@ regressions:
     severity: major
     tier: mechanical
     lane: api
+    promote_ready: true
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
       Slot `ctx_max` and `/v1/models` `context_length` advertised the raw slot-TOML context
       (65536) while the effective resolved window was 32768.
+    rc5_note: >-
+      #1802 fixed the LIST route and /v1/models only. `GET /api/slots/{name}` (and therefore
+      `hal0 slot show`) still returns the raw TOML ceiling — filed as #1835. Probe all four
+      surfaces, not two; checking only two would have scored this release "fixed".
     repro: |
-      curl -s $API/api/slots/brain | jq '.ctx_max, .config.context_size'
-      curl -s $API/v1/models | jq '.data[] | {id, context_length}'
-      systemctl cat hal0-slot@brain | grep -o -- '--ctx-size [0-9]*'
+      For every slot, in one pass:
+        curl -s $API/api/slots        | jq '.[] | {name, ctx_max}'
+        curl -s $API/api/slots/<name> | jq '{ctx_max, argv: .resolved_command}'
+        curl -s $API/v1/models        | jq '.data[] | {id, context_length}'
+        systemctl cat hal0-slot@<name> | grep -o -- '--ctx-size [0-9]*'
     expect: >-
-      The advertised value equals the value actually passed to the runner. If a clamp applies,
-      the API reports the clamped number (and ideally discloses the clamp).
+      Every read-only surface reports the EFFECTIVE window — the number actually passed to the
+      runner — and they agree with each other. `GET /api/slots/{name}/config` legitimately
+      returns the raw TOML ceiling (see known-issues `slot-config-endpoint-returns-raw-ceiling`).
 
   - id: brain-tools-image-gate
     issue: 1789
@@ -69,16 +88,29 @@ regressions:
     severity: major
     tier: judgment
     lane: brain
+    last_result: { release: v1.0.0-rc.5, result: blocked }
     summary: >-
       Brain native-tools were gated on `image == DEFAULT_ROCMFPX_IMAGE`, so any other runner
       silently stripped tools and the steward fabricated live platform state with no signal.
+    rc5_note: >-
+      Blocked in rc.5: the old repro required the brain slot to be on a NON-default runner
+      image, which means repinning the shared brain slot — not a probe agent's mutation to make.
+      Repro rewritten below as source-plus-observation. Only the brain stateful lane, which owns
+      the slot, may repin the image.
     repro: |
-      With the brain slot on a runner image that is NOT the default, ask the steward a
-      platform-state question that requires tools ("what slots are loaded right now?").
-      Watch for tool frames in the SSE stream and tool dispatch in the hal0-api journal.
+      1. Record the brain slot's resolved runner image — a pass or fail is not attributable
+         without it:
+           systemctl cat hal0-slot@brain | grep '^Image='
+      2. Read the gate in the installed tree:
+           grep -n '_image_native_tools' -A 25 \
+             /usr/lib/hal0/venv/lib/python3*/site-packages/hal0/brain/chat.py
+         It must DENY-list known-incompatible images, not ALLOW-list one default.
+      3. Ask the steward a tools-only question ("what slots are loaded right now?") and check
+         for tool frames in the SSE stream plus tool dispatch in the hal0-api journal.
     expect: >-
       Either tool rounds engage, or the steward states plainly that tools are unavailable on
-      this runner. Confident invented slot names with zero tool frames is the regression.
+      this runner. Confident invented slot names with zero tool frames is the regression. An
+      allow-list keyed on one image id is the regression even if this box's image is on it.
 
   - id: cpu-install-fpx-brain-default
     issue: 1790
@@ -86,24 +118,30 @@ regressions:
     severity: major
     tier: judgment
     lane: preflight
+    promote_ready: true
+    last_result: { release: v1.0.0-rc.5, result: fixed }
     summary: >-
       A CPU-only fresh install defaulted the brain slot to an FPX quant whose runner exits 139
-      (SIGSEGV) ~5 s into load, crash-looping to the systemd start limit. Root cause was
-      `hardware.probe._amd_gpu_info` hardcoding `vulkan_capable=True` on any AMD DRM sysfs
-      sighting — and an unprivileged LXC sees the host's sysfs with no /dev/dri.
+      (SIGSEGV) ~5 s into load. Root cause: `hardware.probe._amd_gpu_info` hardcoding
+      `vulkan_capable=True` on any AMD DRM sysfs sighting.
     fix: >-
       Probe gated on a real render node, plus a 422 guard refusing ROCmFPX quants on non-FPX
       runners.
+    rc5_note: >-
+      Both halves held. The 422 guard is a pure unit-testable assertion — promote it. The
+      residual sysfs GPU row in hardware.json (with compute/vulkan correctly false) is expected
+      noise on an unprivileged LXC; do not re-file it.
     repro: |
       On the fresh CPU-only box immediately after install:
-        hal0 system-info          # what does it claim about GPU / vulkan capability?
+        hal0 system-info          # GPU row must read Compute=no, Vulkan=no
         hal0 slot show brain      # which model did the install choose?
         journalctl -u hal0-slot@brain --since -1h | grep -iE 'segv|139|start-limit'
-      Then try to force it: assign an FPX quant to a slot on a non-FPX runner.
+      Then force it: copy any gguf to a filename containing ROCMFP8, `hal0 model add` it, create
+      a cpu-hardware slot bound to it, and `hal0 slot load`.
     expect: >-
-      Hardware probe reports no GPU / not vulkan-capable with no /dev/dri present; the install
-      picks a CPU-viable brain model; assigning an FPX quant to a non-FPX runner is refused
-      with a 422 rather than accepted into a crash loop.
+      Hardware probe reports not compute/vulkan-capable with no /dev/dri present; the install
+      picks a CPU-viable brain model; loading an FPX quant on a non-FPX runner is refused with a
+      422 naming the runner, with no container launched.
 
   - id: crash-loop-lifecycle
     issue: 1791
@@ -111,21 +149,28 @@ regressions:
     severity: major
     tier: judgment
     lane: slots
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
       A crash-looping slot reported `warming` indefinitely, died silently at the systemd start
-      limit with nothing surfacing it, and `hal0 slot swap` on it rewrote the quadlet with the
-      OLD model.
+      limit, and `hal0 slot swap` on it rewrote the quadlet with the OLD model.
+    rc5_note: >-
+      Two of three fixed. The slot converges to `error` at ~183 s carrying the systemd verdict,
+      and swap writes the NEW model (rc.5's "old model" readings were taken while a previous
+      load still held the per-slot lock — always re-read after 60 s). The ~180 s `warming` dwell
+      is by-design (`known-issues: crash-loop-warming-180s-window`). Still missing: `hal0 doctor`
+      never mentions a slot unit sitting in systemd `failed` (rollup #1840).
     repro: |
-      Deliberately induce a crash loop on a throwaway slot (assign a model the runner cannot
-      load), then:
-        hal0 slot list / GET /api/slots      # state after the start limit is hit?
-        hal0 status                          # is the failure surfaced anywhere?
-        hal0 slot swap <throwaway> --model <a good model>
-        systemctl cat hal0-slot@<throwaway> | grep -o -- '--model [^ ]*'
-      Clean up the throwaway slot afterwards.
+      Induce a crash loop on a throwaway slot (bind it to a non-model file such as
+      /var/lib/hal0/models/zzbroken/zzbroken.gguf), then poll every 10 s for FOUR MINUTES:
+        curl -s $API/api/slots/<n> | jq '{state, container_status, msg: .metadata.message}'
+        systemctl show hal0-slot@<n> -p ActiveState -p Result -p NRestarts
+      Then: hal0 status; hal0 doctor; hal0 slot swap <n> --model <a good model>; wait 60 s;
+      systemctl cat hal0-slot@<n> | grep -o -- '--model [^ ]*'.
+      Delete the throwaway slot and confirm `systemctl --failed` gained no new entry.
     expect: >-
-      State reflects reality (failed/crashed, not warming); the start-limit death is surfaced
-      in status/doctor; swap writes the NEW model to the quadlet even on an unhealthy slot.
+      State reaches `error` within ~240 s with a non-empty `metadata.message` naming the systemd
+      result; `container_status` reads `crashed` from the moment the unit fails; swap writes the
+      NEW model; doctor or status surfaces the failed unit; delete leaves no failed unit behind.
 
   - id: memory-retain-dead-letter
     issue: 1792
@@ -133,19 +178,26 @@ regressions:
     severity: minor
     tier: judgment
     lane: memory
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
       On a fresh install, HINDSIGHT_API_LLM_MODEL=hal0/utility targets a model-less clean-seed
-      slot, so every retain's fact extraction 404s (dispatch.no_route) through its retries and
-      dead-letters permanently, with no auto-retry once a model does appear.
+      slot, so every retain's fact extraction 404s (dispatch.no_route) and dead-letters
+      permanently.
+    rc5_note: >-
+      The dead-letter is gone — retains queue instead, and `hal0 memory status` reports
+      "Writes FAILING" rather than losing them silently. The queue nonetheless did not drain
+      once routing recovered, for a different reason (extraction timeout, #1834). Keep this
+      entry scoped to the 404/dead-letter mechanism; do not conflate it with #1834.
     repro: |
-      On the fresh box BEFORE loading any model into the utility slot, trigger a retain, then
-      confirm it fails. Then give utility a model, load it, and wait.
+      On the fresh box BEFORE any model is bound to the utility slot, POST /api/memory/add,
+      then:
+        hal0 memory ops list --json     # status, retry_count, error_message
         hal0 memory status
-        hal0 memory ops list      # dead letters from the no-model window?
+      Then bind a chat model to utility, load it, and poll the op to a TERMINAL state.
     expect: >-
-      Either retains queue rather than dead-letter while no model is available, or dead-letters
-      are retried automatically once routing recovers. A permanent silent loss of the user's
-      first memories is the regression.
+      No op dead-letters silently. Errors, if any, name a timeout or a route failure explicitly
+      and are visible in `hal0 memory status`. A `dispatch.no_route` for hal0/utility while a
+      model IS bound is the regression.
 
   - id: hermes-smoke-ok-over-failures
     issue: 1793
@@ -153,34 +205,50 @@ regressions:
     severity: major
     tier: mechanical
     lane: hermes
+    promote_ready: true
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
-      Hermes provisioning recorded 2/6 smoke-test failures (chat timeout, memory roundtrip
-      no-marker) and still reported phase `status=ok`. Reporting-integrity defect — it hid a
-      real smoke failure for an entire release.
+      Hermes provisioning recorded 2/6 smoke-test failures and still reported phase `status=ok`.
+    rc5_note: >-
+      The literal wording is satisfied — but rc.5 converted the two failing probes into
+      permanent SKIPS (#1831), and `context_link` reports ok while carrying five EACCES warnings
+      (#1828). Write the assertion against skips and warnings too, not just recorded failures.
+      That generalisation is what caught both rc.5 findings.
     repro: |
-      Read the provisioning record on the fresh box and compare the phase status against its
-      own recorded sub-results.
+      python3 -c "import json;d=json.load(open('/var/lib/hal0/state/agents/hermes/provision.json'));
+      [print(k, v['status'], 'failures=', len(v.get('details',{}).get('failures') or []),
+             'warnings=', len(v.get('details',{}).get('warnings') or []),
+             'skipped=', v.get('details',{}).get('skipped_count'))
+       for k,v in d['phases'].items()]"
     expect: >-
-      A phase with recorded failures reports warn/fail, never ok.
+      No phase reports `ok` while carrying entries in `details.failures` OR `details.warnings`;
+      no headline probe is silently `skipped`; a list a phase exists to populate (e.g.
+      `bundled_skills_linked`) is not empty on a phase reporting ok.
 
   - id: fact-extraction-strips-literals
     issue: 1794
     from: v1.0.0-rc.4
     severity: minor
     tier: judgment
-    partial_fix: true
-    summary: >-
-      Fact extraction strips literal values, so stored markers and IDs were unrecoverable via
-      recall even though the raw documents held them. Fixed hal0-side with a document fallback;
-      a durable fix needs server-side content search in the Hindsight engine (no such endpoint
-      exists yet).
     lane: memory
+    partial_fix: true
+    depends_on: memory-extraction-never-lands
+    last_result: { release: v1.0.0-rc.5, result: blocked }
+    summary: >-
+      Fact extraction strips literal values, so stored markers were unrecoverable via recall.
+      Fixed hal0-side with a document fallback; a durable fix needs server-side content search.
+    rc5_note: >-
+      Blocked in rc.5 — nothing ever landed in the store, so there was nothing to recall. This
+      probe is GATED: do not attempt it until a retain has reached a terminal `completed` state.
+      If the retain never completes, report `blocked` and point at #1834.
     repro: |
-      Retain "the CT151 validation marker is MARKER-7734", wait for the op to complete, then
-      recall "what is the CT151 validation marker?" and also search for the literal MARKER-7734.
+      Retain "the <BOX> validation marker is MARKER-7734". Poll `hal0 memory ops list --json`
+      until the op is `completed` (hard deadline 10 min; past that, report blocked). Then:
+        hal0 memory recall "what is the validation marker?"
+        curl -s $API/api/memory/search -d '{"query":"MARKER-7734"}'
     expect: >-
-      The literal comes back via the document fallback. Note explicitly whether it came from
-      extracted facts or the fallback — the fallback is the workaround, not the fix.
+      The literal comes back. State explicitly whether it came from extracted facts or the
+      document fallback — the fallback is the workaround, not the fix.
 
   - id: hermes-polish-rollup
     issue: 1795
@@ -188,19 +256,22 @@ regressions:
     severity: rollup
     tier: mechanical
     lane: hermes
+    last_result: { release: v1.0.0-rc.5, result: fixed }
     summary: >-
-      Four hermes rough edges: dashboard frontend not built while status claimed "dashboard
-      reachable" (status string corrected; the frontend itself is an upstream build artifact
-      not shipped in the wheel — permanently out of scope hal0-side), installer-wired session
-      hook skipped as not-allowlisted, plugin kind `provider` unknown and downgraded to
-      `standalone`, per-session dispatch.no_route for hal0/agent before fallback.
+      Four hermes rough edges: dishonest "dashboard reachable" status string, non-allowlisted
+      session hook, plugin kind `provider` downgraded, per-session dispatch.no_route noise.
+    rc5_note: >-
+      All four held. But the unbuilt hermes dashboard frontend is NOT out of scope after all —
+      the pinned wheel shipping no `web_dist` is the root cause of #1829. Check the wheel, not
+      just the status string.
     repro: |
       Check the hermes unit status string, the session-hook allowlist, the plugin kind
-      resolution, and grep the hermes journal for dispatch.no_route on a fresh session.
+      resolution, grep the hermes journal for dispatch.no_route on a fresh session, and:
+        ls /var/lib/hal0/venvs/hermes/lib/python3*/site-packages/hermes_cli/web_dist
+        curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9119/
     expect: >-
-      Status strings are truthful; hook is allowlisted; plugin kind resolves; no per-session
-      no_route noise. The unbuilt frontend itself is expected — only a dishonest status string
-      about it is a regression.
+      Status strings truthful; hook allowlisted; plugin kind resolves; no per-session no_route
+      noise; the hermes wheel ships `web_dist` and `GET :9119/` returns 200.
 
   - id: cli-api-polish-rollup
     issue: 1796
@@ -208,19 +279,19 @@ regressions:
     severity: rollup
     tier: mechanical
     lane: cli
+    promote_ready: true
+    last_result: { release: v1.0.0-rc.5, result: fixed }
     summary: >-
       Fourteen CLI/API rough edges from the rc.4 sweep.
+    rc5_note: >-
+      All fourteen corrected. Every item is a one-line CLI or HTTP assertion — this whole entry
+      belongs in `scripts/release-test.sh` and should be deleted from the kit once it is there.
     repro: |
-      Re-run each, comparing against the rc.4 symptom:
-        hal0 update --check        # not a placeholder "X -> 0.0.0 (stable)" with a zeroed digest
-        hal0 system-info           # cores/threads must not be impossible (host cores leaking in)
-        hal0 doctor                # must not print warnings then claim "all checks passed"
-        hal0 slot metrics          # formatted numbers, not raw 1223.69921875
-        hal0 bench results         # prints something
-        hal0 system-info           # no debug log line leaking above the table
-        curl $API/api/memory/banks/doesnotexist/stats   # 404, not 200 with zeroed stats
-        curl $API/health $API/openapi.json $API/docs    # SPA catch-all must not shadow these
-        hal0 mcp status hal0-admin # advertised connect URL must be POSTable (needs /mcp suffix)
+      hal0 update --check;  hal0 system-info;  hal0 doctor;  hal0 slot metrics
+      hal0 bench results;   hal0 mcp status hal0-admin
+      curl -s -o /dev/null -w '%{http_code}\n' $API/api/memory/banks/doesnotexist/stats
+      curl -sL -o /dev/null -w '%{http_code}\n' $API/health $API/openapi.json $API/docs
+      hal0 model add <a reranker gguf under its upstream filename>   # capabilities + id
     expect: All fourteen corrected. Report per-item, not as one verdict.
 
   - id: ui-polish-rollup
@@ -229,14 +300,380 @@ regressions:
     severity: rollup
     tier: mechanical
     lane: ui
+    last_result: { release: v1.0.0-rc.5, result: partial }
     summary: >-
       Six dashboard rough edges from the rc.4 Playwright sweep.
+    rc5_note: >-
+      Five of six fixed. Item 3 (host GPU telemetry presented as local capacity) was fixed on
+      Overview and Settings but MISSED on the Slots page telemetry header — refiled inside
+      #1841. Check every page that draws an accelerator tile, not "the dashboard".
     repro: |
-      Drive the dashboard with Playwright and check:
-        - bench worker badge agrees with `systemctl is-active hal0-bench-worker`
-        - Settings shows a hal0 version, not "—"
-        - telemetry does not present HOST GPU stats as local capacity on a GPU-less box
-        - benchmarks header has no empty interpolations ("· GB · hal0 v")
-        - pluralisation ("1 banks")
-        - nav rail icons have accessible names
-    expect: All six corrected.
+      Drive the dashboard with Playwright and check on EVERY page that renders an accelerator
+      tile: bench worker badge vs `systemctl is-active hal0-bench-worker`; Settings version
+      string; GPU/NPU tiles gated on /api/hardware `compute_capable`; empty interpolations;
+      pluralisation; nav rail accessible names.
+    expect: All six corrected, on every page — not just the page the fix PR named.
+
+  # ── Filed from v1.0.0-rc.5 ──────────────────────────────────────────────────
+
+  - id: hermes-cannot-chat-64k-floor
+    issue: 1827
+    from: v1.0.0-rc.5
+    severity: ga-blocker
+    tier: mechanical
+    lane: hermes-e2e
+    promote_ready: true
+    summary: >-
+      On a fresh install the bundled Hermes agent refuses to start: the installer-pulled brain
+      model resolves to an effective 32768 ctx (`_CTX_DENSE_CAP` in providers/container.py),
+      below Hermes' hard 64000 floor. Nothing on the install path stamps a model-level
+      `defaults.context_size`, so the 65536 ceilings in the shipped slot TOMLs are discarded.
+      Not caused by the #1802 advertising fix — that fix stopped hiding it.
+    repro: |
+      sudo -u hal0 HOME=/var/lib/hal0 hermes -z "Reply with exactly: HERMES-RC-OK"
+      # and, independently of hermes:
+      curl -s $API/v1/models | jq '.data[] | {id, context_length}'
+      grep -rn 'MINIMUM_CONTEXT_LENGTH' \
+        /var/lib/hal0/venvs/hermes/lib/python3*/site-packages/agent/model_metadata.py
+    expect: >-
+      Hermes answers. Every chat-capable id in /v1/models advertises a context_length >= the
+      bundled agent's MINIMUM_CONTEXT_LENGTH, and the id named by `model.default` in
+      /var/lib/hal0/.hermes/config.yaml resolves. Setting `model.context_length` in the hermes
+      config is NOT a fix — it asserts a window llama-server does not serve.
+
+  - id: bundled-skills-not-linked
+    issue: 1828
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: hermes
+    promote_ready: true
+    summary: >-
+      All five bundled hal0 agent skills fail to link on a fresh install — install.sh creates
+      /etc/hal0/agent-skills as root:root 0755 with no PermRow, and the privilege-dropped
+      `hal0 agent bootstrap hermes` (running as hal0) gets EACCES on every symlink. Hermes comes
+      up with an empty skill manifest while `_phase_context_link` still returns PhaseStatus.OK.
+    repro: |
+      ls -la /etc/hal0/agent-skills/ ; ls /usr/share/hal0/skills/
+      cat /var/lib/hal0/.hermes/.skills_prompt_snapshot.json
+      hal0 agent status hermes --json | jq '.phases.context_link'
+      hal0 doctor perms | grep -i skill
+    expect: >-
+      /etc/hal0/agent-skills is hal0-owned and holds a symlink per bundled skill; the Hermes
+      skill manifest is non-empty; `context_link` reports warn/fail if any symlink failed;
+      `hal0 doctor perms` carries a row for the directory.
+
+  - id: brain-board-tools-401
+    issue: 1829
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: brain
+    summary: >-
+      Every hal0-api -> Hermes kanban forward goes out with NO credential and 401s, killing all
+      sixteen brain board tools. The pinned hermes wheel (0.18.2) ships no `hermes_cli/web_dist`,
+      so `GET :9119/` 404s and `_fetch_html_token()` has no HTML to scrape the rotating bearer
+      out of; neither HERMES_SESSION_TOKEN nor HERMES_DASHBOARD_SESSION_TOKEN is provisioned.
+      Second defect in the same place: the brain still reads the Hermes kanban while
+      /api/board/* was rewired to the local hal0 BoardStore (KB-4), so a token-only fix would
+      trade a loud error for silent divergence.
+    repro: |
+      /usr/lib/hal0/venv/bin/python - <<'PY'
+      import asyncio
+      from hal0.board import HermesKanbanClient
+      async def main():
+          c = HermesKanbanClient.from_env()
+          print("token:", repr(await c._current_token()))
+          try: print("OK", await c.request_json("GET", "/board"))
+          except Exception as e: print("ERR", type(e).__name__, e, getattr(e, "details", None))
+          await c.aclose()
+      asyncio.run(main())
+      PY
+      curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9119/
+    expect: >-
+      A token is obtained (or none is needed because the brain reads the local BoardStore) and
+      the board read returns data. NOTE: this cannot be validated on an UPGRADED box — an
+      orphaned `web_dist` from an older hermes makes prod pass by accident. Fresh box only.
+
+  - id: slot-create-no-profile-501
+    issue: 1830
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: slots
+    promote_ready: true
+    summary: >-
+      `hal0 slot create` and the dashboard "New slot" modal write a slot TOML with no `profile`
+      key (neither `create` nor `edit` has a `--profile` option). The #1787 template gate is
+      conditioned on a truthy profile, so a capability slot bound to an unstamped model loads to
+      `state=ready` and 501s the one endpoint it exists to serve. An incomplete fix, not a
+      regression: rc.4 broke the seeded path too.
+    repro: |
+      hal0 model add <a reranker gguf> --id zzrr
+      hal0 slot create zzrrslot --type reranking --hardware cpu --model zzrr --port 8097
+      grep -c '^profile' /etc/hal0/slots/zzrrslot.toml            # expect >= 1
+      hal0 slot load zzrrslot
+      systemctl cat hal0-slot@zzrrslot | grep -m1 '^Exec='        # expect --reranking
+      curl -s -w ' http=%{http_code}' localhost:8097/v1/rerank \
+        -d '{"model":"zzrr","query":"what is a cat","documents":["a cat is a feline","steel"]}'
+      # repeat with --type embedding and /v1/embeddings, then clean up slot + model
+    expect: >-
+      The created slot's TOML carries a profile derived from `--type` (or the launch path
+      applies the capability flag anyway); the resolved argv contains --reranking/--embeddings;
+      the endpoint returns 200. A slot that reports `ready` and 501s its own endpoint is the
+      regression.
+
+  - id: smoke-preflight-skips-chat-probes
+    issue: 1831
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: hermes
+    promote_ready: true
+    summary: >-
+      rc.5's new `_chat_model_ready` preflight checks hermes' `model.default` (`hal0/agent`)
+      against the ids in GET /v1/models, which deliberately never advertises the `hal0/*`
+      virtual names. The gate can never open on the shipped config, so `chat_completions` and
+      `memory_roundtrip` are skipped on every install — with a false reason ("not loaded on the
+      gateway") while `GET /v1/models/hal0/agent` returns 200. `memory_roundtrip` has no chat
+      dependency at all and should not be behind the gate.
+    repro: |
+      hal0 agent status hermes --json | jq '.phases.smoke_tests'
+      curl -s $API/v1/models | jq -r '.data[].id'
+      curl -s -o /dev/null -w '%{http_code}\n' $API/v1/models/hal0/agent
+      grep -n 'model:' -A3 /var/lib/hal0/.hermes/config.yaml
+    expect: >-
+      Neither chat_completions nor memory_roundtrip is skipped on a box where the anchor
+      resolves. If a probe IS skipped, cross-check the recorded reason against
+      `GET /v1/models/{id}` before believing it.
+
+  - id: slot-verbs-10s-client-timeout
+    issue: 1832
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: slots
+    promote_ready: true
+    summary: >-
+      Every mutating `hal0 slot` verb posts through `api_post`, whose default timeout is 10.0 s,
+      against a server that blocks for the full 180 s `_HEALTH_TIMEOUT_S` health budget. Any
+      load/unload/restart over ~10 s prints `ReadTimeout` and exits 1 on an operation that
+      succeeded — including inside hal0's own `scripts/release-test.sh`, which gates on that
+      exit status. Distinct from #1424 (real failures being undiagnosable) but byte-identical on
+      screen: check both.
+    repro: |
+      hal0 slot unload brain; sleep 5
+      time hal0 slot load brain; echo "exit=$?"
+      hal0 slot list | grep brain      # poll until ready — did the load in fact succeed?
+      # repeat for restart and unload
+    expect: >-
+      A load/unload/restart that succeeds exits 0. If the CLI cannot wait, it must poll and say
+      so — never exit 1 on a successful operation.
+
+  - id: memory-status-green-while-empty
+    issue: 1833
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: memory
+    promote_ready: true
+    summary: >-
+      `hal0 memory status` prints "Writes landing" whenever hindsight's `failed` counter has not
+      GROWN since the previous 30 s sample — independent of whether any fact ever landed. Ops
+      wedged in `processing` never touch the counter, and the purely-timed 600 s recovery hold
+      flips the panel green with nothing recovered. Verified oscillation: FAILING at 02:40 ->
+      "Writes landing" at 02:51, facts=0 throughout.
+    repro: |
+      hal0 memory status ; hal0 memory bank list
+      curl -s $API/api/memory/banks | jq '.[] | {bank_id, fact_count}'
+      journalctl -u hindsight-api --since -20min -o cat | grep -c STUCK_STACK
+    expect: >-
+      `hal0 memory status` never reports "Writes landing" while the write bank's fact_count is 0
+      with pending/processing ops outstanding, or while the hindsight worker is emitting
+      STUCK_STACK. Recovery must be evidence-based (one completed op), not a 600 s timer.
+
+  - id: memory-extraction-never-lands
+    issue: 1834
+    from: v1.0.0-rc.5
+    severity: major
+    tier: judgment
+    lane: memory
+    summary: >-
+      hal0 wires hindsight fact extraction at the shared `utility` slot
+      (HINDSIGHT_API_LLM_MODEL=hal0/utility, installer-owned unit) with no worker-concurrency
+      cap, no max_tokens cap (observed n_predict 64000) and a 300 s x 4 retry ladder that
+      REQUEUES on exhaustion. On a CPU-only install the 3.2 k-token extraction prompt needs
+      ~223 s of prefill alone, so every attempt times out, four concurrent extractions saturate
+      the one llama-server, and the queue provably never drains. Co-locating extraction on
+      `utility` is by-design; the unbounded retry and concurrency are not.
+    repro: |
+      curl -s -X POST $API/api/memory/add -d '{"text":"the RC validation marker is MARKER-7734"}'
+      # 10 min later, and again 10 min after that:
+      hal0 memory status ; hal0 memory ops list --json | jq '.[] | {id,status,retry_count}'
+      curl -s http://127.0.0.1:<utility port>/metrics \
+        | grep -E 'requests_processing|requests_deferred|prompt_tokens_seconds'
+      curl -s http://127.0.0.1:<utility port>/slots | jq '.[].params.n_predict'
+    expect: >-
+      The retain queue drains, or fails with a bounded, non-requeueing ladder and an
+      operator-visible reason. `requests_deferred` on the extraction slot must not be pinned
+      non-zero while an interactive chat request to the same slot is starved. An op whose age
+      RESETS after `attempt=4/4` is the requeue loop and is the regression.
+
+  - id: slot-detail-ctx-max-raw
+    issue: 1835
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: api
+    promote_ready: true
+    summary: >-
+      `GET /api/slots/{name}` merges `slot_view.config_enrichment`, which lifts `ctx_max`
+      verbatim from the slot TOML, while the list route re-resolves it via `_resolve_ctx_max`.
+      The detail body contradicts the `resolved_command` in its own payload, and
+      `hal0 slot show` inherits the wrong number. Reproduced on the GPU prod box too (agent
+      slot: 164000 advertised vs --ctx-size 65536 served).
+    repro: |
+      curl -s $API/api/slots/<name> \
+        | jq -c '{ctx_max, argv: (.resolved_command|index("--ctx-size") as $i|.[$i+1])}'
+      curl -s $API/api/slots | jq -c '.[]|select(.name=="<name>")|{ctx_max}'
+    expect: >-
+      Detail and list agree, and both equal the `--ctx-size` in the same payload's
+      resolved_command.
+
+  - id: ui-overview-services-widget-dead
+    issue: 1836
+    from: v1.0.0-rc.5
+    severity: major
+    tier: mechanical
+    lane: ui
+    promote_ready: true
+    summary: >-
+      The Overview dashboard's Services widget always renders "no companion services".
+      `RDServicesCard` reads `svc.data?.services` while `useServices()` returns
+      `{ services, mdns, pending }` — no `data` key. Unconditionally dead, in the default
+      layout, and present in every shipped bundle back to 0.9.1.
+    repro: |
+      curl -s $API/api/services | jq '.services | length'     # non-zero
+      # then read the Services widget text on the dashboard Overview page
+    expect: >-
+      The widget lists a card per entry returned by /api/services. Better: a `ui/tests/e2e/`
+      spec asserting RDServicesCard renders N cards for an N-entry fixture.
+
+  - id: v1-models-never-evicts
+    issue: 1837
+    from: v1.0.0-rc.5
+    severity: minor
+    tier: mechanical
+    lane: routing
+    promote_ready: true
+    summary: >-
+      `_prime_hal0_composite_cache` MERGES the fresh slot-config read into the existing bucket
+      instead of replacing it, so any model id bound to an llm slot when the cache was primed
+      stays in /v1/models for the life of the hal0-api process — including after the slot and
+      the registry entry are gone. Those ids hard-404 with dispatch.no_route.
+    repro: |
+      comm -23 <(curl -s $API/v1/models | jq -r '.data[].id' | sort) \
+               <(cat <(curl -s $API/api/models | jq -r '.[].id') \
+                     <(curl -s $API/api/slots  | jq -r '.[].name') | sort -u)
+    expect: >-
+      Empty output — every id advertised by /v1/models is either a registered model or a
+      configured slot name. Run this AFTER a stateful lane has created and deleted a slot; that
+      is when the ghost appears.
+
+  - id: model-add-detection-honesty
+    issue: 1838
+    from: v1.0.0-rc.5
+    severity: minor
+    tier: mechanical
+    lane: capabilities
+    promote_ready: true
+    summary: >-
+      `detect()` keys capability on `<arch>.pooling_type`, then falls back to a filename token
+      table, then to `chat` — while still reporting `confidence: high`. A byte-identical
+      reranker renamed loses its `rerank` classification. Separately, a file with a .gguf
+      extension and no GGUF magic is accepted and registered as `chat` (internally
+      `confidence=low`, `gguf_header_read=failed`, neither surfaced).
+    repro: |
+      cp <reranker>.gguf /mnt/ai-models/scratch/zzrenamed.gguf
+      hal0 model add /mnt/ai-models/scratch/zzrenamed.gguf --id zzrenamed   # capabilities?
+      hal0 model add <same file, upstream name>        --id zzorig          # capabilities?
+      head -c 2000000 /dev/urandom > /mnt/ai-models/scratch/zzrand.gguf
+      hal0 model add /mnt/ai-models/scratch/zzrand.gguf --id zzrand         # accepted?
+      # clean up all three registrations and the scratch dir
+    expect: >-
+      A file with no GGUF magic is rejected, or registered with a surfaced low-confidence
+      warning. The add response and CLI line surface `confidence` and `gguf_header_read`.
+      Architecture / attention.causal / general.tags are consulted before the filename. A model
+      added under its UPSTREAM filename must be classified correctly — that half is the #1796
+      regression and is the serious one.
+
+  - id: slot-capacity-vram-attribution
+    issue: 1839
+    from: v1.0.0-rc.5
+    severity: minor
+    tier: mechanical
+    lane: slots
+    promote_ready: true
+    summary: >-
+      `hal0 slot capacity` books a slot's memory to VRAM purely from its configured `device`,
+      never consulting whether a usable GPU exists — and the shipped seeds hardcode
+      `device = "gpu-vulkan"`, so a CPU-only install shows VRAM in use with 0.0 RAM. Separately,
+      the cgroup probe shells `podman inspect` as `User=hal0` against ROOT slot containers, so
+      it silently returns 0 and every figure collapses to the coarse file-size estimate
+      (2131.7 MB reported vs 2987.9 MB real RSS).
+    repro: |
+      hal0 slot capacity
+      ls /dev/dri || echo "no render node"
+      curl -s $API/api/hardware | jq '.gpus[0] | {compute_capable, vulkan_capable}'
+      curl -s $API/api/slots/metrics | jq '.[] | {name, mem_rss_mb}'
+    expect: >-
+      On a box where /api/hardware reports no compute-capable GPU, no slot reports non-zero
+      VRAM MB. `hal0 slot capacity` Total MB and `hal0 slot metrics` Mem MB agree for the same
+      slot in the same second, or the kit records which is RSS and which is model size.
+
+  - id: cli-api-polish-rollup-rc5
+    issue: 1840
+    from: v1.0.0-rc.5
+    severity: rollup
+    tier: mechanical
+    lane: cli
+    summary: >-
+      Thirteen CLI/API rough edges from the rc.5 sweep.
+    repro: |
+      Re-run each against its rc.5 symptom:
+        1.  hal0 memory ops retry --id <a processing op>  # 409 must carry details.upstream.detail
+        2.  hal0 memory ops list                          # retry_count / next_retry_at columns
+        3.  hal0 memory ops cancel --help                 # verb must exist (REST/MCP already do)
+        4.  a >300 s non-streaming completion             # 504 + "did not respond within N s",
+                                                          #   not 502 "upstream unreachable"
+        5.  crash a throwaway slot, then delete it        # systemctl --failed gains nothing
+        6.  hal0 doctor                                   # names any slot unit in systemd failed
+        7.  POST /v1/chat/completions with a registered-but-unroutable model id
+                                                          # must not say "not found in registry"
+        8.  POST /api/brain/chat --data-binary '{bad'     # must emit an SSE error frame
+        9.  GET /api/memory/banks/nosuchbank/{memories,tags,entities,entities/graph,documents,
+              directives,mental-models,operations,graph,graph/subgraph,config,stats/timeseries}
+                                                          # 404, not 200 with an empty payload
+        10. hal0 model add <a file under /root>           # EACCES distinguished from missing
+        11. hal0 profile show <name>                      # used_by must match GET /api/profiles
+        12. GET /api/slots/hal0 with every slot offline   # must not report status=serving
+        13. /etc/hal0/capabilities.toml img.img device    # must be offerable by the img picker
+    expect: All thirteen corrected. Report per-item, not as one verdict.
+
+  - id: ui-polish-rollup-rc5
+    issue: 1841
+    from: v1.0.0-rc.5
+    severity: rollup
+    tier: mechanical
+    lane: ui
+    summary: >-
+      Three dashboard rough edges from the rc.5 sweep.
+    repro: |
+      1. Slots page telemetry header on a GPU-less box: the GPU and NPU cells must be gated on
+         /api/hardware `compute_capable` (ThCellGpu / ThCellNpu in
+         ui/src/dash/telemetry-header.jsx have no gate; every sibling surface does).
+      2. Agents page Hermes card: the four StatusDot spans must not carry the raw CSS class
+         ("stale" / "soon") as their title and aria-label.
+      3. Sidebar at a 721-1080 px viewport (rail mode): the OpenWebUI and Hermes service anchors
+         must have a non-empty accessible name — the `.lbl` span is display:none at that width.
+    expect: All three corrected.

--- a/tests/release-validation/reports/v1.0.0-rc.5.md
+++ b/tests/release-validation/reports/v1.0.0-rc.5.md
@@ -1,0 +1,270 @@
+# hal0 v1.0.0-rc.5 — release validation
+
+**Date:** 2026-08-10 → 2026-08-11 (UTC) · **Kit version:** 1 (`tests/release-validation/kit.toml`) · **Mode:** file — 15 GitHub issues filed, [#1827](https://github.com/Hal0ai/hal0/issues/1827)–[#1841](https://github.com/Hal0ai/hal0/issues/1841)
+
+**Boxes:**
+
+| Box | Role | CTID / host | IP | OS / container | Hardware | Install | Notes |
+|---|---|---|---|---|---|---|---|
+| `ct152-cpu-fresh` | fresh | 152 · `hal0-rc5-fresh-2604` | 10.0.1.152 | Ubuntu 26.04, **unprivileged** LXC, systemd 259, podman 5.7.0, python 3.14 | 8 cores / 16 GiB / 0 swap / 200 G rootfs (181 G free) · **no GPU passthrough, no `/dev/dri`** | fresh `curl \| bash` install 2026-08-10 09:33–09:41 UTC with `HAL0_ALLOW_CPU_ONLY=1`; build `1.0.0rc5` (PEP 440 of `1.0.0-rc.5`) | anonymous API on `:8080`; **no snapshot — cannot be rolled back**; second run against this box (a degraded run 1 on 2026-08-10 left residue, see Coverage) |
+| `ct105-prod` | prod | 105 · `hal0` | 10.0.1.142 | privileged, long-lived, upgraded (not fresh) | AMD Strix Halo, real `/dev/dri/renderD128` | upgraded to `1.0.0rc5` | **READ-ONLY cross-check only.** Used by 18 of the 41 verifications to answer "is this an artifact of the CPU-only box?" |
+| `ct150-update` | update | 150 · `halo` | 10.0.1.150 | — | CPU-only | left on rc.3 | **Not exercised this run** — update lane skipped (see Coverage) |
+| `ct151-cpu-fresh` | fresh | 151 | 10.0.1.151 | — | — | — | **Unusable.** `pct rollback 151` wedged the hypervisor on a pool-wide ZFS `z_zrele` deadlock. ct152 exists because of this. |
+
+**Method:** the full kit-driven pipeline against ct152, one box.
+
+1. **Preflight** (1 agent, sonnet) — re-verified every `boxes.toml` fact against `pct config 152` and on-box probes; wrote `CONTEXT.md`. No stale-kit findings. Two minor observations, neither run-invalidating.
+2. **Read-only sweep** (5 parallel agents, sonnet) — `api`, `cli`, `mcp`, `hermes`, `ui`. 10-minute budget each.
+3. **Stateful lane** (6 serialised agents, sonnet, high effort) — `slots` → `routing` → `brain` → `memory` → `capabilities` → `hermes-e2e`. 12-minute budget each, each handing the next an explicit `box_state_on_exit`.
+4. **Regression probes** (6 agents; mechanical = fable, judgment = sonnet) — against `regressions.yaml`.
+5. **Triage** (opus) — deduped 46 raw lane findings against `known-issues.yaml`, dropped 8 as known/non-findings, promoted 41 candidates.
+6. **Adversarial verification** (41 agents, opus, high effort) — every candidate independently re-reproduced on the box, with a read-only GPU cross-check on ct105-prod wherever the finding touched hardware, backend selection, or install lineage.
+7. **Synthesis** (opus) — this document.
+
+**Test models staged:** `/mnt/ai-models` — `qwen3.5-0.8b` (`Qwen3.5-0.8B-UD-Q4_K_XL.gguf`, 559 MB, chat), `qwen3-embedding-0.6b-q8` (639 MB), `jina-reranker-v1-tiny-en-q8` (37 MB). Registered in hal0 at run start: exactly one model, `hal0-brain-sft-f16` (2.0 GB, F16, installer-pulled). The staged ggufs are **invisible to hal0** (`[models] roots = ["/var/lib/hal0/models"]` only) — stateful lanes registered them via `hal0 model add` as `rcchat` / `rcembed` / `rcrerank`.
+
+**Headline totals:** **174 checks** — 84 read-only (54 pass) · 90 stateful (40 pass). **6 regression probes run** (1 fixed · 0 regressed · 3 partial · 2 blocked); 5 further register entries covered indirectly by lane evidence. **46 raw findings → 41 verified → 27 stand · 14 reclassified.** Of the 27: **1 GA-blocker · 10 major · 14 minor · 2 cosmetic.**
+
+Compared with rc.4: 94 read-only checks → 84; 64 → 54 read-only passes; ~60 → 90 stateful checks; 11 filed issues → 27 standing findings, but the *composition* changed completely — rc.4's blockers were core inference and slot lifecycle, rc.5's single blocker is the bundled agent's startup gate. The pass **rate** dropped (rc.4 68% read-only, rc.5 64%; stateful 44%) largely because rc.5's lanes are deeper and because a saturated 8-core box turned many stateful checks into `skipped`, not because more things broke.
+
+---
+
+## Verdict
+
+**Do not ship 1.0.0-rc.5 as GA — one blocker: on a fresh install the bundled Hermes agent cannot start a single turn, and the smoke test that was supposed to catch that was silently disabled in this very release.**
+
+The specific blockers:
+
+* **GA-blocker — `hermes-cannot-chat-64k-floor`.** On a fresh rc.5 install `hermes -z "..."` hard-errors in 1.6 s: *"Model hal0/agent has a context window of 32,768 tokens, which is below the minimum 64,000 required by Hermes Agent."* Root cause is `_CTX_DENSE_CAP = 32768` in `src/hal0/providers/container.py:1199`: an installer-pulled model with no `defaults.context_size` resolves to `min(native, 32768)` even though `installer/etc-hal0/slots/{brain,agent,utility}.toml` all set `context_size = 65536`. rc.5 did not create the mis-sizing — PR #1802 (#1788's fix) stopped *hiding* it, so a box where Hermes worked on rc.4 can stop working on upgrade. A verified in-product fix exists (`PUT /api/models/<id> {"defaults":{"context_size":65536}}` clears the gate with the shipped config untouched), but nothing on the install path stamps it and no doc mentions it. A fresh GPU install would hit this identically — the cap is hardware-independent.
+* **Blocker-adjacent (why the blocker shipped) — `smoke-tests-permanently-skip-chat-probes`.** rc.5's new `_chat_model_ready` preflight (commit 56ad690e / #1798) checks hermes' `model.default` against the ids in `GET /v1/models` — a list that deliberately never advertises `hal0/*` virtual names. The shipped default *is* `hal0/agent`, so the gate can never open: `chat_completions` and `memory_roundtrip` are skipped on every hal0-only install with the false reason `'hal0/agent' not loaded on the gateway`, and the phase records `status: ok`. rc.4's fix for "ok over failures" converted two failing probes into two permanently skipped ones. (It would not itself have caught the 64K gate — those probes bypass the hermes CLI — but it is the reason nobody noticed the surface degrade.)
+* **Fresh-install regression, 100% of new installs — `bundled-skills-not-linked-phase-ok`.** All five bundled agent skills fail to link (`install.sh` creates `/etc/hal0/agent-skills` root-owned; the §7.4 privilege drop then runs bootstrap as `hal0` → five `EACCES` symlink failures) and Hermes comes up with an empty skill manifest — while `_phase_context_link` returns `PhaseStatus.OK` unconditionally. `hal0 doctor` and `hal0 doctor perms` mention it zero times. Prod escapes only because its directory predates the 2026-07-18 privilege drop.
+* **Incomplete rc.4 fix, silent wrongness — `slot-create-no-profile-501`.** #1787's fix is gated on a truthy `_cfg_profile`, and *no* explicit slot-creation path writes one: `hal0 slot create` has no `--profile`, and the dashboard "New slot" modal / `POST /api/slots` omit it. A reranking slot created that way loads to `state=ready` and 501s `/v1/rerank`; same for embedding. Installer-seeded `embed`/`rerank` slots are fine, so the changelog's "fresh installs serve every capability" claim holds — but a GPU box hits this too (ct105's own `embed` slot is exactly the failing shape).
+
+Everything else is major-and-below and would not, on its own, hold GA.
+
+### Minimum gate for the next candidate
+
+| # | Item | Why it is on the gate |
+|---|---|---|
+| 1 | `hermes-cannot-chat-64k-floor` | The bundled agent is unusable out of the box on **every** fresh install, GPU or CPU, and upgraded boxes can regress. Fix must stamp a model-level `defaults.context_size` (or raise `_CTX_DENSE_CAP`) — **not** by setting `model.context_length` in hermes' config, which asserts a window llama-server does not serve. |
+| 2 | `smoke-tests-permanently-skip-chat-probes` | Reporting integrity, and it is the reason item 1 shipped. Resolve the anchor via `GET /v1/models/{id}` (which handles virtuals) instead of list membership, ungate `memory_roundtrip` (it has no chat dependency), and add a test pinning the *shipped* default against a realistic payload. |
+| 3 | `bundled-skills-not-linked-phase-ok` | Silent, 100% of new installs, two-file fix: add a `PermRow` for `/etc/hal0/agent-skills` and make `_phase_context_link` return `WARN` when `skill_warnings` is non-empty (the #1793 precedent already exists at line 4784). |
+| 4 | `slot-create-no-profile-501` | Silent wrongness — the slot reports `ready` and 501s the one endpoint it exists for. Reopens the rc.4 GA-blocker on a path the fix did not cover. Either derive a default `profile` from `--type` in `slot create` / `POST /api/slots`, or drop the `_cfg_profile` gate for the no-tune case. |
+| 5 | `brain-get-board-401` | The steward's entire board surface (4 read tools + 12 mutation tools) is dead on every fresh install, because `hermes-agent` 0.18.2 ships no `web_dist`, so the HTML-scraped bearer never exists. Correct fix is to rewire the brain's board tools onto the local `BoardStore` the way KB-4 (`e18c25ab`) already did for `/api/board/*` — patching only the token would leave the steward answering from a *different* board than the UI shows. |
+| 6 | `ctx-advertised-vs-resolved` | rc.4's #1788 came back partially: PR #1802 fixed the list route and `/v1/models` but missed `GET /api/slots/{name}`, which still returns the raw TOML ceiling. Confirmed on prod at a 2.5× overstatement on a **live serving** slot. A regression-register entry must not survive two releases. |
+| 7 | `slot-load-readtimeout-on-success` | Every mutating `hal0 slot` verb caps its HTTP read at 10 s (`api_post` default) against a 180 s server-side health budget, so a successful load exits 1 with `ReadTimeout`. It corrupts hal0's own `scripts/release-test.sh` pass/fail signal and is indistinguishable from #1424's real failures — fix them together. |
+
+Not on the gate, deliberately: the memory cluster (`memory-retain-never-lands`, `memory-status-reports-healthy-while-empty`, `utility-slot-contention`). All three are real and major, but all three are **CPU-only** consequences of a 0.8 B model running fact extraction at 0.12 tok/s against a 300 s timeout; the identical build and config lands writes on ct105-prod with 10,294 facts in bank `shared`. They belong in the 1.0.x window with a preflight throughput check and an extraction concurrency cap — not in the GA gate, unless CPU-only is declared a first-class supported target, in which case they join the list.
+
+### What held up well
+
+Nine of the eleven rc.4 issues genuinely stayed fixed on a real box, and several rc.5-specific surfaces were solid under adversarial re-reproduction:
+
+* **The #1790 hardware-probe fix is real and complete.** `hal0 system-info` reports `Compute=no, Vulkan=no` for the leaked Strix Halo entry, the install picked a CPU-viable brain model (`hal0-brain-sft-f16`, F16, not an FPX quant), no SIGSEGV/start-limit anywhere in 48 h of journal, and the new 422 guard refused a forced ROCmFPX-on-CPU load with an exact, actionable message and no crash loop. Cleanest fix of the wave.
+* **The #1787 seeded path is fixed.** The `embed` slot's argv carries `--embedding` and `/v1/embeddings` returns 1024 dims both directly and through the API; a profile-bearing rerank slot launches `--reranking -fa auto -b 8192` and returns sane ordered scores. Only the *unstamped CLI-created* path regressed.
+* **The #1791 crash-loop lifecycle fix holds.** A crash-looped slot now converges to `error` at ~183 s carrying the exact systemd verdict and recovery command, visible in `slot list`, `status`, `slot show` and the API; `swap` on an unhealthy slot writes the NEW model. Two reporting agents filed "stuck warming forever" and both were wrong — they sampled inside the deliberate 180 s cold-load ceiling.
+* **The #1792 dead-letter is gone.** Nothing is silently lost; retains queue, `hal0 memory status` loudly reports `Writes FAILING`, and `hal0 memory ops retry --all-failed` verifiably requeues them.
+* **Dispatcher and routing are correct.** `resolution_path=passthrough:<slot>` is logged for every successful route; route-layer autoload (#430) means a registered chat model on an offline llm slot loads on demand rather than 404ing; `/v1/embeddings` and `/v1/rerankings` both returned 200 against cold slots during verification. Two candidates alleging routing defects were refuted outright.
+* **Client-disconnect handling, request framing, and MCP schema discipline are sound.** A brain turn is cancelled within the same second the client disconnects (verified with a faithful clone of hal0's middleware stack on the box's own interpreter); MCP rejects missing required args (`mcp.missing_arg`) and FastAPI/pydantic rejects wrong-typed args (`validation.invalid`) at exact parity with the equivalent REST call.
+* **Error envelopes are structured and typed almost everywhere.** No 500s were produced by any lane; the failures that exist are wrong *codes* and wrong *wording*, not unstructured crashes.
+* **The kit itself earned its keep.** Adversarial verification killed or downgraded 14 of 41 candidates (34%) — including three that would have sent a fix agent to revert an rc.5 fix. The prod read-only cross-check changed the applicability verdict on 6 findings. Lane discipline held: every stateful lane handed the next an accurate `box_state_on_exit` on a box with no snapshot.
+
+---
+
+## Regression results
+
+Every entry in `regressions.yaml`. Six were run as dedicated probes; five were covered by lane and verification evidence rather than a standalone probe agent — marked as such, because "covered indirectly" is not the same assurance as a run repro.
+
+| Regression | Issue | Result | Evidence |
+|---|---|---|---|
+| `profile-flags-argv` | 1787 | **partial** | HOLDS for the canonical unstamped path: `embed` slot Exec carries `--embedding`, `/v1/embeddings` → 200 / 1024 dims direct and via API; a slot with `profile = "reranking"` launches `--reranking -fa auto -b 8192 -ub 8192` and `/v1/rerank` → 200 (0.1969 vs 0.0058). DOES NOT HOLD on a new residual path: `hal0 slot create zzrgslot --type reranking …` → `slot load` → `state=ready`, Exec has **no** `--reranking`, `/v1/rerank` → **501** — the exact rc.4 symptom. The "model_extra_args win over the template" clause is NOT TESTED and unreachable at runtime by design (`_has_model_tune` suppresses the template entirely); asserted only statically at `src/hal0/slots/argv.py:146`. → finding `slot-create-no-profile-501`. |
+| `ctx-advertised-vs-resolved` | 1788 | **partial** (covered by lane + verification, no standalone probe) | `GET /api/slots` → `ctx_max 32768`, `/v1/models` → `32768`, `/api/slots/brain/resolved` → `--ctx-size 32768` — all fixed by PR #1802. But `GET /api/slots/brain` → `ctx_max 65536` against its own `resolved_command`'s `32768`, and `hal0 slot show brain` inherits it. `slot_view/__init__.py:958` re-resolves on the list path; `routes/slots.py:1033` does not on the detail path. Confirmed worse on prod: `/api/slots/agent` advertises 164000 while the live slot serves `--ctx-size 65536`. → finding `ctx-advertised-vs-resolved`. |
+| `brain-tools-image-gate` | 1789 | **blocked** | The repro requires the brain slot on a **non-default** runner image; `systemctl cat hal0-slot@brain` → `ghcr.io/hal0ai/hal0-rocmfpx:ade07ba` = `DEFAULT_ROCMFPX_IMAGE`, and `POST /api/brain/chat` takes no model/slot parameter, so the only way to exercise it is repinning the shared brain slot — out of bounds for a probe agent while the serialised `brain` lane had not yet run. Fallback attempt on the default image produced no data (two `curl -m 275` runs returned 200 then zero body bytes under concurrent load). Source-level only, NOT a substitute for an on-box result: the identity gate is gone (`chat.py:1420` defaults unknown images to CAPABLE and denies only a named incompatible set; `chat.py:1955` emits a `notice` SSE frame carrying `tools_unavailable`). **Kit fix required**: the repro must not require repinning the shared brain slot, or must be assigned to the brain lane which owns that mutation. |
+| `cpu-install-fpx-brain-default` | 1790 | **fixed** | Both halves hold. `hal0 system-info` → `Compute=no, Vulkan=no`; `hal0 slot show brain` → `hal0-brain-sft-f16` (F16, 2.0 GB, CPU-viable); `journalctl -u hal0-slot@brain --since -48h \| grep -iE 'segv\|139\|start-limit'` → no matches. Forced 422 guard: a `ROCmFP8`-quant model on a `cpu` runner → `HTTP 422: model 'zzfpxmodel' is a ROCmFP8 build (custom GGML tensor types 100/103) that only the ROCmFPX runner can load … loading it would SIGSEGV the container`; API state `error` with that message, no container launched. The residual sysfs GPU row is the banked #1790 noise, not re-reported. |
+| `crash-loop-lifecycle` | 1791 | **partial** (probe) → **substantially fixed** (verification) | Probe reported 1 of 3 clauses holding: swap writes the NEW model (verified quadlet + TOML + `state=ready model=rcchat`), but state read `warming` at +90 s and `doctor` said nothing. Adversarial verification **refuted the "forever" core**: polled every 10 s, the slot went `warming` at +11 s, `container_status: crashed` at +21 s, and flipped to `error` at **+183 s** with `hal0-slot@zzskep.service failed (result=exit-code, restarts=5) — see journalctl…`, visible in `slot list`, `status`, `slot show` and the API. Both reporting agents sampled inside the deliberate `_HEALTH_TIMEOUT_S = 180 s` cold-load ceiling. Genuine residue: **`hal0 doctor` never mentions a slot unit sitting in systemd `failed`**, before or after the flip. → finding `crash-loop-slot-reports-warming` (downgraded to minor). |
+| `memory-retain-dead-letter` | 1792 | **partial** | HOLDS — no dead-lettering: `POST /api/memory/add` against a model-less `utility` → 200 with an operation_id that stayed `pending`, not `failed`, and no `dispatch.no_route` for hal0/utility in the journal. DOES NOT HOLD — recovery: ~5.5 min after `utility` reached `ready` with `rcchat` the op had not drained and recall returned "No results." Verification later established why: not a queue defect but a 300 s extraction timeout the op eventually reached (`failed` at 02:38:50, 4 attempts × 300 s), and `hal0 memory ops retry --all-failed` does requeue it. → findings `memory-retain-never-lands`, `memory-no-recovery-for-stuck-ops`. |
+| `hermes-smoke-ok-over-failures` | 1793 | **partial** (covered by lane + verification, no standalone probe) | The *policy* is fixed — a phase with recorded failures now renders a Failures column, colour-coded status, and a `warn:` footer, live on prod (`smoke_tests` shows real failure text). But on ct152 the two probes that would produce failures are now **permanently skipped** and the phase records `failures: [], skipped_count: 2, status: ok`. Separately, `context_link` carries five `Permission denied` warnings and still returns `PhaseStatus.OK` — `PhaseStatus.WARN` exists and is used in exactly one place repo-wide. → findings `smoke-tests-permanently-skip-chat-probes`, `bundled-skills-not-linked-phase-ok`. |
+| `fact-extraction-strips-literals` | 1794 | **blocked** | Precondition never met inside budget. The retain of `"the CT152 rc5 validation marker is MARKER-7734"` stayed `pending` for ~15 min including 5.5 min after `utility` went ready; `/api/memory/list` → `{"items":[]}`, so "document stored, facts stripped" is indistinguishable from "nothing stored yet". Recall by phrase and by literal both → "No results."; `/api/memory/search` → `{"items":[]}`. **Kit fix required**: chain this probe explicitly behind a completed retain (poll `hal0 memory ops list` until the op leaves `pending`, with a stated timeout), or move it into the memory lane which can pre-warm `utility` first. |
+| `hermes-polish-rollup` | 1795 | **partial** (covered by lane, no standalone probe) | Verified indirectly by the hermes and hermes-e2e lanes. Not re-observed: per-session `dispatch.no_route` noise, plugin-kind downgrade, hook allowlist. Re-observed and worse than "expected": the hermes dashboard on :9119 is not merely unbuilt — the pinned `hermes-agent` 0.18.2 wheel ships **no `web_dist` at all**, which also breaks hal0's board bearer harvest. → finding `brain-get-board-401`. |
+| `cli-api-polish-rollup` | 1796 | **mostly fixed** (covered by the cli/api lanes, per-item where checked) | Confirmed corrected: default marker in `hal0 model list` (renders `*` on `rcchat`); `hal0 model add` reranker classification (`capabilities: ['rerank']`, id from filename stem, commit 53be7e9d); `hal0 profile` CLI now exists; `/api/memory/banks/doesnotexist/stats` → 404 typed envelope; `/api/openapi.json` and `/api/docs` served correctly with the SPA catch-all redirecting. Still open in a narrower form: **twelve other** bank-scoped sub-resources still 200 for a nonexistent bank (`nonexistent-memory-bank-returns-200`); `hal0 slot capacity` still books CPU RAM as VRAM for gpu-declared slots (`slot-capacity-books-ram-as-vram`); `hal0 doctor` still prints 11 warnings (annotated, not claimed-passing). Four rc.4 sub-items (`update --check` placeholder, `system-info` core count, `slot metrics` formatting, `bench results` empty) were **not individually re-checked** — recorded as `skipped`, not as fixed. |
+| `ui-polish-rollup` | 1797 | **partial** (covered by the ui lane) | Item 3 (host GPU telemetry presented as local capacity) came back: commit 85eb9da7 gated Overview, HealthStrip, RDUtilizationCard and memory-map on `computeCapable` but **missed `ThCellGpu`/`ThCellNpu` in `ui/src/dash/telemetry-header.jsx`**, which the Slots page mounts — rendering 100% util / 2900 MHz / 59 °C / 73 W of the *host's* iGPU on a GPU-less box, directly under a correctly-gated "memory · system" label. The commit body explicitly claimed the Slots surface. → finding `ui-slots-page-fake-gpu-telemetry`. The other five items were not individually re-verified this run; the UI lane spent its budget on new surfaces (4/11 pass). |
+
+---
+
+## Filed issues
+
+Mode was `file`. The 27 standing findings were filed as **15 issues**, [#1827](https://github.com/Hal0ai/hal0/issues/1827)–[#1841](https://github.com/Hal0ai/hal0/issues/1841) — 13 individual issues plus two rollups (`#1840` cli/api, 13 items; `#1841` ui, 3 items). `memory-retain-never-lands` and `utility-slot-contention` were merged into `#1834` as one root cause. Ranked most severe first within each band.
+
+| Key | Issue |
+|---|---|
+| `hermes-cannot-chat-64k-floor` | [#1827](https://github.com/Hal0ai/hal0/issues/1827) |
+| `bundled-skills-not-linked-phase-ok` | [#1828](https://github.com/Hal0ai/hal0/issues/1828) |
+| `brain-get-board-401` | [#1829](https://github.com/Hal0ai/hal0/issues/1829) |
+| `slot-create-no-profile-501` | [#1830](https://github.com/Hal0ai/hal0/issues/1830) |
+| `smoke-tests-permanently-skip-chat-probes` | [#1831](https://github.com/Hal0ai/hal0/issues/1831) |
+| `slot-load-readtimeout-on-success` | [#1832](https://github.com/Hal0ai/hal0/issues/1832) |
+| `memory-status-reports-healthy-while-empty` | [#1833](https://github.com/Hal0ai/hal0/issues/1833) |
+| `memory-retain-never-lands` + `utility-slot-contention` | [#1834](https://github.com/Hal0ai/hal0/issues/1834) |
+| `ctx-advertised-vs-resolved` | [#1835](https://github.com/Hal0ai/hal0/issues/1835) |
+| `ui-overview-services-widget-empty` | [#1836](https://github.com/Hal0ai/hal0/issues/1836) |
+| `v1-models-advertises-orphan-zzbroken` | [#1837](https://github.com/Hal0ai/hal0/issues/1837) |
+| `model-add-capability-misdetection` | [#1838](https://github.com/Hal0ai/hal0/issues/1838) |
+| `slot-capacity-books-ram-as-vram` | [#1839](https://github.com/Hal0ai/hal0/issues/1839) |
+| remaining cli/api minors + cosmetics | [#1840](https://github.com/Hal0ai/hal0/issues/1840) (13 items) |
+| remaining ui minors | [#1841](https://github.com/Hal0ai/hal0/issues/1841) (3 items) |
+
+
+| Key | Severity | Title |
+|---|---|---|
+| `hermes-cannot-chat-64k-floor` | **GA-blocker** | bundled Hermes refuses every turn on a fresh install — dense ctx cap 32768 vs Hermes' 64,000 floor |
+| `smoke-tests-permanently-skip-chat-probes` | major | rc.5's new smoke preflight can never pass on the shipped `hal0/agent` default — two probes permanently skipped, phase `ok` |
+| `bundled-skills-not-linked-phase-ok` | major | all five bundled agent skills fail to link (EACCES on root-owned `/etc/hal0/agent-skills`); Hermes manifest empty; phase reports `ok` |
+| `brain-get-board-401` | major | steward's whole board tool surface 401s — pinned hermes 0.18.2 ships no `web_dist`, so the scraped bearer never exists (plus: the brain still reads the Hermes kanban, not the hal0 `BoardStore`) |
+| `slot-create-no-profile-501` | major | `hal0 slot create` / dashboard "New slot" write no `profile`, so capability slots load `ready` and 501 (`--reranking` / `--embeddings` missing) |
+| `ctx-advertised-vs-resolved` | major | `GET /api/slots/{name}` still returns the raw TOML ceiling as `ctx_max`, contradicting its own `resolved_command` (2.5× overstatement on a live prod slot) |
+| `slot-load-readtimeout-on-success` | major | every mutating `hal0 slot` verb caps its read at 10 s vs a 180 s server budget — successful load/unload/restart exits 1 with `ReadTimeout` |
+| `ui-overview-services-widget-empty` | major | Overview "Services" widget is unconditionally dead (`svc.data?.services` — the hook returns no `data` key); says "no companion services" with three up |
+| `memory-retain-never-lands` | major | *(CPU-only)* fact extraction never finishes inside 300 s; every retain fails after 4×300 s; bank `shared` `fact_count=0` |
+| `memory-status-reports-healthy-while-empty` | major | `hal0 memory status` prints `Writes landing` whenever the `failed` counter has not *increased*, oscillating green with 0 facts stored |
+| `utility-slot-contention` | major | Hindsight extraction (4 concurrent, `n_predict: 64000`, 4-retry ladder, requeue on exhaustion) saturates the single `utility` llama-server; queue never drains |
+| `crash-loop-slot-reports-warming` | minor | ~160 s window where a start-limit-dead slot reads `warming` (by-design ceiling); real residue: `hal0 doctor` never reports a failed slot unit |
+| `memory-no-recovery-for-stuck-ops` | minor | CLI ergonomics: `ops retry --id` swallows the API's explanatory 409 body; no `retry_count`/`next_retry_at` column; no `ops cancel` verb (REST + MCP have one) |
+| `v1-models-advertises-orphan-zzbroken` | minor | `/v1/models` never evicts an id — `_prime_hal0_composite_cache` merges instead of replacing, so deleted slots' models stay advertised for the process lifetime and then hard-404 |
+| `model-add-capability-misdetection` | minor | capability falls back to a filename token when the gguf header omits `pooling_type` (confidence still reported `high`); non-GGUF bytes accepted as `chat` |
+| `ui-slots-page-fake-gpu-telemetry` | minor | Slots page `ThCellGpu`/`ThCellNpu` render host iGPU telemetry ungated on `computeCapable` — the one surface 85eb9da7 claimed and missed |
+| `slot-capacity-books-ram-as-vram` | minor | `hal0 slot capacity` books resident memory to VRAM from the declared `device`; shipped seeds hardcode `gpu-vulkan`, so a GPU-less box shows phantom VRAM (plus: the cgroup probe silently fails as `hal0` against root podman, so figures under-report ~28%) |
+| `api-upstream-readtimeout-on-healthy-slot` | minor | a 300 s `direct_read_timeout_s` expiry is returned as 502 `dispatch.upstream_unavailable` "unreachable" with empty `details.error` — the dispatcher distinguishes dead-vs-overloaded internally and discards it at the boundary |
+| `slot-delete-leaves-failed-unit` | minor | deleting a slot whose unit is `failed` leaves `hal0-slot@<t>.service not-found failed` in `systemctl --failed`; the NPU delete route already calls `reset-failed`, the general one does not |
+| `dispatch-no-route-message-misleads` | minor | `dispatch.no_route` always opens "model 'X' not found in registry" even when `hal0 model list` shows it; the true cause sits one level down in `details.legacy_error` |
+| `nonexistent-memory-bank-returns-200` | minor | twelve bank-scoped sub-resources return 200 with byte-identical empty payloads for a nonexistent bank; only `/stats`, `/profile`, `/export` 404 |
+| `model-add-root-path-error-misleading` | minor | present-but-unreadable and genuinely-missing files both return 400 `model.path_missing` "is not a readable file", with no mention of the `hal0` service user |
+| `cli-profile-show-used-by-empty` | minor | `ProfileCatalog.resolve()` never builds the used_by index — `GET /api/profiles/{name}` and `hal0 profile show` always report `used_by: []` while the list endpoint is correct (confirmed on prod) |
+| `hal0-aggregate-slot-entry-inconsistent` | minor | `GET /api/slots/{name}` omits `loaded_models`, so the synthetic `hal0` composite hardcodes `serving` while `hal0 slot list` correctly says `offline` — the exact case `test_synthetic_composite_slot_offline_when_nothing_loaded` guards on the list route |
+| `ui-openwebui-link-unnamed` | minor | at 721–1080 px the sidebar rail hides `.lbl`, leaving the OpenWebUI (and Hermes) anchors with an empty accessible name; every sibling control has an explicit `aria-label`/`title` |
+| `capabilities-toml-seeds-gpu-devices` | cosmetic | first-boot seed copies `device` verbatim from the static slot TOML, so `img.img` is always `gpu-rocm` — a value the ComfyUI allow-list (`gpu-vulkan` only) can never offer, on any hardware |
+| `ui-agents-card-stale-badge` | cosmetic | Agents card `StatusDot`s leak the internal CSS class as `title`/`aria-label` ("stale", "soon") because `agent-card.jsx` passes `cls` without `title` |
+
+**Reclassified by adversarial verification (not filed):**
+
+These are the ones worth reading — each is a plausible-sounding candidate that a future run will rediscover unless the reasoning is banked. Each should become a `known-issues.yaml` entry with the `still_report_if` clause quoted.
+
+1. **`model-default-ignored-by-dispatcher` → by-design.** `hal0 model default <id>` is the per-**type** model fallback consumed by `registry.fallback.fallback_local_model` Step 0, documented as "orthogonal to the SLOT default" (`models_service.py:110-117`) and covered by 7 tests. Default *route* selection is ADR-0023's hardcoded `agent` anchor, changed with `hal0 slot edit agent --model <id>`. The real residue is that a CPU-only fresh install leaves the `agent` anchor unpopulated, so model-less completions 404 — one line in the run report, not a routing bug. `still_report_if`: the marker is retargeted to influence routing and still does not; or a slot whose configured model is missing does not prefer the same-type default; or a model-less request 404s on a box where `agent` **has** a model bound.
+2. **`brain-chat-zero-byte-200` → refuted.** `HTTP=200 SIZE=0` is what curl prints when *its own* `--max-time` fires before the first frame. Measured TTFB 0.015 s; the failing round did deliver `data: {"type":"error", …}` + `done` at +289 s (SIZE=365). The reporter's `-m 240` expired 60 s before the server's own 300 s round deadline. Survives, much smaller: `hal0 chat --brain` hard-codes `auth_client(timeout=120.0)` against a server `completion_timeout_s` of 300, and the documented `ping` frame is only emitted while an approval gate is parked.
+3. **`hardware-cpu-flag-not-honoured-in-argv` → by-design.** `--hardware cpu` is not a label: it re-resolves the runner image (`hal0-rocmfpx:ade07ba` → `amd-strix-halo-toolboxes:vulkan-radv-server`, which is the **cpu** Runner's image despite the tag name) and sets `device_class=cpu`, which emits **zero** `AddDevice=/dev/kfd|/dev/dri/*` lines — proven on prod by diffing `hal0-slot@1.container` against `hal0-slot@stt.container`. The residual `-ngl -1` is inert argv noise on a container with no GPU. `still_report_if`: a `device = "cpu"` slot actually receives GPU passthrough in its launch spec, or its `argv[0]` is the GPU runner image with no pin.
+4. **`brain-turn-ignores-client-disconnect` → refuted.** Starlette cancels the SSE generator (uvicorn advertises ASGI 2.3 → the `listen_for_disconnect` task-group path) within the same second; reproduced on the box's own interpreter with a faithful middleware clone. The offered log evidence (`model=rcchat resolution_path=passthrough:utility`) cannot come from a brain turn — `[brain_chat] tool_model = "hal0/agent"` never resolves to `utility`; it was another lane's traffic.
+5. **`batch-retain-rows-permanently-pending` → refuted.** `batch_retain` is Hindsight's parent bookkeeping row (`task_payload IS NULL`, deliberately unclaimable; `payload_null=N claimable=0` is the *instrument reporting the design*). It reconciles when its child terminates — watched live: parent `f96f4634` went `pending → failed` in the same transaction as child `eb3e0e45`. Prod has 25 `batch_retain completed` and **zero** pending. Residue: the CLI double-counts parent+child, and `exclude_parents` is plumbed through REST/MCP/provider but not the CLI.
+6. **`memory-operations-route-404` → by-design.** `/api/memory/operations` never existed — and neither does the candidate's claimed "real route" `/api/memory/ops` (also 404). `ops` is a Typer subcommand group. The real route is `/api/memory/banks/{bank_id}/operations`, published in `/api/openapi.json`, and the CLI fans it out client-side.
+7. **`memory-disable-not-reflected-in-status` → by-design.** `[memory].enabled` is a registered `service-restart[hal0-api]` key, and the disable command itself prints "Takes effect on the next hal0-api restart". `memory_enabled` is *defined* as `app.state.memory_provider is not None` and `tests/api/test_memory_gate.py:60` locks that identity — printing OFF while the provider is live and ingesting would be the silent-wrongness case. No pending-restart indicator exists for any of ~40 such keys.
+8. **`mcp-args-no-schema-validation` → by-design.** `additionalProperties: true` on the inner `args` object is deliberate (`slot_edit`'s open-ended config keys), documented in the docstring and pinned by three tests. Missing required args ARE rejected (`mcp.missing_arg`); wrong types ARE rejected by pydantic (`validation.invalid`). Exact parity with a direct curl. No droppable flag widens a destructive operation (`force`/`prune`/`pin` all fail safe).
+9. **`brain-chat-accepts-any-body` → mostly by-design.** Hand-parsed `await request.json()` handlers with no `requestBody` are the house convention (113 of 141 mutating operations; `tests/api/test_typed_bodies.py`), and an empty payload framed as one empty user turn is *tested* as O18 template safety. Surviving 4-line residue: an unparseable body or a wrongly-typed `messages` is answered as an empty question with **no** `{"type":"error"}` frame, on a surface that has an error channel. Do **not** convert the route to a Pydantic body model.
+10. **`hermes-hook-stale-live-state` → by-design.** `_as_of` is an "unchanged since" marker, not a freshness clock: the content-hash gate bumps mtime via `os.utime` and deliberately leaves `_as_of` alone so the injected bytes stay prompt-cache-identical. Prod shows a 12.6 h `_as_of` on a file verified 34 min earlier, and the 2 s hermes hook timeout forbids a synchronous probe. **The real bug hiding behind this**: `spawn_context_refresh()` has only two call sites (`SlotManager.swap`, capability apply) — plain load/unload/restart/idle-reap do not refresh STATE.md. File *that*, with a body diff, not the timestamp.
+11. **`model-list-name-from-arch-header` → by-design.** hal0 prints `general.name` verbatim; the arch header (`jina-bert-v2`) appears nowhere. mradermacher's build baked the *code-repo* label `jina-bert-implementation` into `general.name`. Counter-examples on the same box: `qwen3` → `Qwen3 Embedding 0.6b`, `qwen35` → `Qwen3.5-0.8B`. Residue: `model add` names from `general.name` while install-time auto-scan names from the filename stem.
+12. **`cli-agent-status-truncates-json` → by-design.** The 60-char Detail slice is deliberate and commented (`agent_commands.py:1331`); `--json` **does** exist, is documented, is regression-tested, and emits the full 15 KB payload; recorded *failures* deliberately bypass the slice (visible on prod). The residue belongs to `bundled-skills-not-linked-phase-ok`: the escape hatch reads `details["failures"]` but not `details["warnings"]`.
+13. **`cli-model-list-blank-column` → by-design.** The unlabelled column IS the rc.4 fix (#1796/#1807), a `git branch`-style `*`; it renders correctly on `rcchat` and `tests/cli/test_model_list_default_marker.py::test_no_default_model_marks_nothing` asserts blank-when-no-default. Filing it would ask a fix agent to revert what a previous RC run demanded. Adjacent and separable: no model is flagged default on a fresh install (0 of 62 on prod).
+14. **`cli-bench-group-is-argparse` → by-design.** Documented in two user-facing reference pages plus the module docstring, with the rationale (stdlib-only argparse, `server_ab.py` precedent). Exit code 2 for an unknown verb matches Typer's; `list` is not a universal sibling verb (7 other groups reject it too). Only help-text rendering differs.
+
+**Known-issue dupes (not re-filed):** Hermes memory-turn slowness on CPU → `hermes-memory-turn-slow-on-cpu` *(note: its `still_report_if` "retain op and chat turn provably contending for the same slot" is now **satisfied** — `resolution_path=passthrough:utility` proves it, and that is promoted as `utility-slot-contention`)*; `hal0 slot load`/`swap` surfacing server-side failures as a bare CLI `ReadTimeout` → #1424 *(the inverse — a **successful** load reporting ReadTimeout — is not covered and is filed as `slot-load-readtimeout-on-success`)*; MCP 421 from the LAN → `mcp-lan-421-invalid-host` (neither clause met); `hardware.json` phantom GPU/NPU → #1790, banked in CONTEXT.md *(consumers that **act** on it are filed: `capabilities-toml-seeds-gpu-devices`, `ui-slots-page-fake-gpu-telemetry`)*; `image_status=missing` on serving slots and the ~12 min silent first-boot image pull → banked run-1 observations.
+
+---
+
+## Lane reports
+
+### Read-only sweep — 84 checks, 54 pass (64%)
+
+| Lane | Checks | Pass | Findings | Headline |
+|---|---|---|---|---|
+| `api` | 14 | 8 | 3 | `GET /api/slots/{name}` `ctx_max` divergence (#1788 residue); `/v1/models` never evicts deleted slot models; twelve bank sub-resources 200 for a nonexistent bank |
+| `cli` | 33 | 24 | 6 | `slot load/unload/restart` exit 1 on success (10 s vs 180 s); `profile show` always `used_by: []`; `model add` filename-fallback classification; unreadable-vs-missing path conflation; `slot capacity` VRAM attribution; `slot show hal0` says `serving` while `slot list` says `offline` |
+| `mcp` | 12 | 9 | 1 | args schema openness (reclassified by-design) |
+| `hermes` | 14 | 9 | 2 | `context_link` phase `ok` over five EACCES symlink failures; smoke preflight permanently skipping two probes |
+| `ui` | 11 | 4 | 4 | Overview Services widget dead on every install; Slots page host-GPU telemetry ungated; sidebar rail a11y name loss; Agents card class-name leak |
+
+The UI lane is the weakest at 4/11 — worth noting that three of the seven non-passes were `skipped` for budget after Playwright startup, not failures. `mcp` at 9/12 with only one (reclassified) finding is the healthiest surface in the sweep.
+
+### Stateful lane — 90 checks, 40 pass (44%), in execution order
+
+| # | Lane | Checks | Pass | Findings | Headline |
+|---|---|---|---|---|---|
+| 1 | `slots` | 13 | 8 | 6 | Crash-loop lifecycle largely fixed (converges to `error` at 183 s); `slot create` writes no `profile`; delete leaves a `failed` unit; capacity books RAM as VRAM |
+| 2 | `routing` | 12 | 8 | 2 | Dispatch itself correct (`passthrough:<slot>` logged, autoload works); `dispatch.no_route` wording misleads; 300 s read timeout reported as "unreachable" |
+| 3 | `brain` | 15 | 4 | 4 | Board tool surface 401s end to end; zero-byte-200 and disconnect claims both refuted; steward chat itself works when the slot is free |
+| 4 | `memory` | 15 | 3 | 7 | The worst lane, and the most CPU-specific: extraction at 0.12 tok/s never finishes inside 300 s, `Writes landing` oscillates green over an empty store, retry ergonomics thin |
+| 5 | `capabilities` | 15 | 9 | 5 | Enable/apply flows work with typed guards; `img.img` seed device unreachable by the picker; hand-created capability slots 501 |
+| 6 | `hermes-e2e` | 20 | 8 | 6 | The GA-blocker landed here: Hermes refuses every turn at the 64K floor with the shipped config; skills manifest empty; board dead |
+
+Lane 4 (`memory`) at 3/15 is the standout, but the verification pass reframed it: two of its seven findings were refuted, and the remaining cluster is one root cause (CPU throughput vs a 300 s timeout, amplified by uncapped extraction concurrency) wearing four different faces. On GPU hardware the same code, config and build lands writes — proven, not inferred.
+
+Lanes 3–6 all ran while the box was saturated (up to 341 requests in 6 minutes from concurrent agents; two llama-servers at 653% and 375% CPU on 8 cores). Several checks that read as failures were client-budget artefacts; verification caught four of them.
+
+### Update lane
+
+**Not run.** See Coverage.
+
+---
+
+## Coverage and honesty
+
+What this run did **not** establish, stated plainly so the next run does not inherit false confidence.
+
+**Lanes skipped entirely**
+
+* **`upgrade` and `post-upgrade` (ct150).** Not exercised. rc.3 → rc.5 in-place upgrade behaviour is **unverified**. This matters more than usual this release: `hermes-cannot-chat-64k-floor` is specifically a case where a box on which Hermes worked in rc.4 can *stop* working on upgrade to rc.5 (rc.4's `/v1/models` echoed the raw 65536 ceiling, so the gate passed while llama-server already ran `--ctx-size 32768`). **ct150 must be run before GA**, targeted at that one question.
+* **`api` and `cli` on the `prod` box.** `kit.toml` lists both for `boxes = ["fresh", "prod"]`; only `fresh` ran. Prod was used read-only for 18 targeted cross-checks by verification agents, not as a lane.
+* **`ct163-cpu-fresh`** (privileged, Ubuntu 24.04) — not in the default matrix, not opted into. No finding this run smelled privilege- or distro-specific.
+
+**The mechanical regression batch never ran**
+
+The `regressions:mechanical` agent died on `You've reached your Fable 5 limit`, so **no dedicated probe ran for any `tier: mechanical` entry**: `ctx-advertised-vs-resolved` (#1788), `hermes-smoke-ok-over-failures` (#1793), `hermes-polish-rollup` (#1795), `cli-api-polish-rollup` (#1796), `ui-polish-rollup` (#1797). Those are exactly the five rows marked "covered by lane and verification evidence, no standalone probe" in the regression table above — the coverage is real but it is incidental, not a run of the registered repro, and it is why four `cli-api-polish-rollup` sub-items and five `ui-polish-rollup` sub-items went unchecked. **Kit fix:** the fable tier needs a fallback to the workhorse tier on a quota error rather than dropping the batch, and a batch that returns nothing must fail the phase loudly instead of being absorbed by synthesis.
+
+**Checks skipped inside lanes**
+
+* Four `cli-api-polish-rollup` sub-items (`update --check` placeholder, `system-info` core count, `slot metrics` number formatting, `bench results` empty output) were **not individually re-checked**. They are recorded as `skipped`, not fixed.
+* Five of six `ui-polish-rollup` sub-items were not individually re-verified; the UI lane spent its budget on new surfaces.
+* Two regression probes are `blocked` with the reasons above (`brain-tools-image-gate`, `fact-extraction-strips-literals`). Neither may be read as "fixed".
+* The `profile-flags-argv` clause "model_extra_args still win over the profile template where they overlap" is **not testable at runtime** by design and was verified only by reading `src/hal0/slots/argv.py:146`.
+
+**What the fleet cannot test at all**
+
+* **There is no GPU fresh-install box.** Every finding touching backend selection, profile flags, hardware probing, or native tool calling carries a *judgement* about GPU applicability derived from read-only inspection of ct105-prod, not a measurement. ct105 is additionally an **upgraded** box with months of operator tuning, so "prod is fine" repeatedly turned out to mean "prod escapes by history" — that is exactly how `brain-get-board-401` (orphaned `web_dist` from a pre-0.19 install) and `bundled-skills-not-linked-phase-ok` (directory predates the 2026-07-18 privilege drop) survived to rc.5 unnoticed. **This is the single largest gap in the fleet and should be closed before GA.**
+* **ct152 has no snapshot.** It could not be reset before this run and cannot be reset after; run-1 residue (a permanently `failed` `hal0-slot@zzskeptic.service`, an orphaned `zzbroken.gguf`, and run-1 history in `hal0.db`/`activity.db`/`.hermes`) was carried through the whole run and treated as pre-existing. Any claim of the form "no prior activity" is invalid on this box. **Take a pristine snapshot before the next install.**
+* **CPU-only timings are not product timings.** Every latency number here comes from an 8-core box running 0.8 B–2 GB models on the plain CPU backend, frequently with 5–10 concurrent agent lanes. Three of the eleven majors are CPU-throughput consequences.
+* **Concurrency contaminated measurement.** Multiple verification agents worked the same box simultaneously; at least four candidates' original evidence turned out to be another lane's traffic. Future runs should either serialise verification on a single box or stamp every probe with a request id the agent can filter on.
+
+---
+
+## Kit changes proposed
+
+Applied by PR, not silently.
+
+**New `known-issues.yaml` entries** (all fourteen reclassifications above, each with the `why:` and `still_report_if:` already drafted in the verification output). Highest value, because each one prevents a re-discovery:
+
+* `crash-loop-warming-180s-window` (by-design) — the ~180 s dwell is `_HEALTH_TIMEOUT_S`; the watchdog is intentionally locked out while `load()` holds the slot lock. Report only past ~240 s, or if `metadata.message` is empty once `state` is `error`.
+* `memory-ops-processing-not-retryable` (by-design) — `processing` means the engine still owns the op and has its own ladder scheduled; the 409 is correct and its body says so.
+* `slot-config-endpoint-returns-raw-ceiling` (by-design) — `/api/slots/{name}/config` is the raw TOML edit surface; the ceiling belongs there. Only the detail route's `ctx_max` is the defect.
+* `capabilities-seed-devices-from-slot-tomls` (by-design) — the seed is a template copy, not a hardware decision; identical on GPU and CPU boxes.
+* `model-add-capability-filename-fallback`, `dispatcher-model-default-is-per-type`, `mcp-args-additional-properties-open`, `brain-chat-hand-parsed-body`, `hermes-state-md-as-of-is-change-marker`, `memory-enabled-deferred-apply`, `hindsight-batch-retain-parent-rows`, `cli-agent-status-detail-slice`, `cli-model-list-default-marker-column`, `cli-bench-argparse-passthrough`, `ui-agents-card-amber-ready-dot`.
+* Update `hermes-memory-turn-slow-on-cpu`: its `still_report_if` contention clause **fired** this run. Either close it out or rewrite the clause now that `utility-slot-contention` owns that question.
+
+**New regression entries** — all 27 standing findings, with these flagged as must-not-recur: `hermes-cannot-chat-64k-floor`, `slot-create-no-profile-501`, `ctx-advertised-vs-resolved` (second occurrence — escalate), `bundled-skills-not-linked-phase-ok`, `smoke-tests-permanently-skip-chat-probes`, `brain-get-board-401`, `slot-load-readtimeout-on-success`.
+
+**Regression register fixes required**
+
+* `brain-tools-image-gate` (#1789): rewrite the repro so it does not require repinning the shared brain slot, or move it into the `brain` lane which owns that mutation. As written it is unrunnable and will report `blocked` forever.
+* `fact-extraction-strips-literals` (#1794): chain it explicitly behind a completed retain — poll `hal0 memory ops list` until the op leaves `pending`, with a stated timeout — or move it into the `memory` lane, which can pre-warm `utility` first.
+* `cli-api-polish-rollup` (#1796) and `ui-polish-rollup` (#1797): both are 14- and 6-item rollups probed as one unit, and therefore partially skipped two runs running. Split each into per-item checks, or promote the mechanical ones into `scripts/release-test.sh`.
+
+**Lane brief additions**
+
+* `_shared.md`: add an explicit warning that other lanes are running concurrently — before filing a latency or "hang" finding, correlate the `request_id` between `dispatch.decision` and `dispatch.forward_failed`, and state the client budget used. Four candidates this run were client-abort or cross-lane artefacts.
+* `_shared.md`: add "when a load/unload/restart CLI call returns `ReadTimeout`, poll to a terminal state before concluding" — it caught out three lanes and one regression probe.
+* `slots.md`: state the `_HEALTH_TIMEOUT_S = 180 s` cold-load ceiling explicitly, so no future lane files "stuck warming" from a single early sample.
+* `hermes-e2e.md`: add a first check that runs `hermes -z` with the **shipped, unmodified** `config.yaml` before any lane is allowed to edit it. This run's blocker was nearly masked by an earlier lane's workaround.
+* `ui.md`: pin the viewport size. `ui-openwebui-link-unnamed` only exists between 721–1080 px, and it was discovered by accident at the tool's default 780 px.
+
+**Worth promoting into pytest / `scripts/release-test.sh`**
+
+* `GET /api/slots/{name}` `ctx_max` must equal the `--ctx-size` in its own `resolved_command` (closes #1788's residue permanently; the list-path test exists, the detail-path one does not).
+* `GET /api/slots/{name}` composite `hal0` entry must agree with `GET /api/slots` (extend `test_synthetic_composite_slot_offline_when_nothing_loaded` to the per-name route).
+* A perms test asserting `/etc/hal0/agent-skills` is `hal0:hal0` after install, and a `_phase_context_link` test that exercises a symlink `EACCES` (both current tests point `HAL0_BUNDLED_SKILLS` at a nonexistent dir, which is why this shipped).
+* A smoke-preflight test pinning the **shipped** `model.default` (`hal0/agent`) against a realistic `/v1/models` payload.
+* `scripts/release-test.sh` currently gates on `hal0 slot load`'s exit status, which is wrong today (`slot-load-readtimeout-on-success`). Fix the CLI timeout and the script's assumption together.


### PR DESCRIPTION
## What

First real run of the versioned release-validation kit (`tests/release-validation/`), against `v1.0.0-rc.5`.

- **`tests/release-validation/reports/v1.0.0-rc.5.md`** — the run report.
- **Kit curation, `kit_version` 1 → 2** — `regressions.yaml` 11 → 26 entries, `known-issues.yaml` 8 → 29, two unrunnable rc.4 repros rewritten, lane briefs gain the checks the agents had to invent.
- **`.claude/workflows/rc-validate.js`** — hard abort on an unknown/unroled box id, plus `ct152-cpu-fresh` registered in `BOX_ROLES` and `boxes.toml`.

## Result

59 agents, 174 checks against `ct152-cpu-fresh` (CPU-only Ubuntu 26.04 unprivileged LXC) with read-only GPU cross-checks on `ct105-prod`. 46 raw findings → 41 adversarially verified → **27 standing** (1 GA-blocker, 10 major, 14 minor, 2 cosmetic); 14 refuted or reclassified as by-design. Filed as #1827–#1841.

**Verdict: do not ship rc.5 as GA.** The bundled Hermes agent refuses every turn on a fresh install — an installer-pulled model with no `defaults.context_size` resolves through `_CTX_DENSE_CAP = 32768`, below Hermes' hard 64,000 floor (#1827). rc.5's own new smoke preflight could never have caught it: it resolves `hal0/agent` against a `/v1/models` list that by design never advertises `hal0/*` virtuals, so both chat probes are permanently skipped while the phase records `ok` (#1831).

Nine of the eleven rc.4 issues genuinely held on a real box; #1790's hardware-probe fix was the cleanest of the wave.

## Why the workflow guard

The first attempt at this run silently produced a verdict having never touched a lane: `ct152-cpu-fresh` was missing from `BOX_ROLES`, so `freshBox` was `undefined`, the Sweep phase enqueued zero agents, and Triage built "candidates" from the preflight `CONTEXT.md` alone. It now throws.

## Verified

`node --check` on the workflow; every YAML and TOML in the kit parses. The report's own *Coverage and honesty* section states what this run did **not** establish — the update lane never ran, the mechanical regression batch died on a model quota so five registered repros have only incidental coverage, and the fleet still has no GPU fresh-install box.

## Out of scope / follow-up

- `ct151-cpu-fresh` is unusable: `pct rollback 151` wedged the hypervisor on a pool-wide ZFS `z_zrele` deadlock. Needs an operator reboot of 10.0.1.110. `ct152` exists because of this.
- rc.3 → rc.5 in-place upgrade is unverified, and #1827 is exactly the shape of defect that bites on upgrade. Run `ct150` before tagging GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)