### PR TITLE
chore(release-validation): record the closed coverage gaps on ct150 and ct151

### DIFF
--- a/tests/release-validation/boxes.toml
+++ b/tests/release-validation/boxes.toml
@@ -18,18 +18,20 @@ privileged = false
 gpu = false
 cores = 8
 ram_gb = 16
-snapshot = "pristine"
+snapshot = "rc5-installed"
 api = "http://10.0.1.151:8080"
 auth_required = false
-status = "unusable as of 2026-08-11 — do not select without checking"
+status = "PREFERRED fresh box as of 2026-08-12 — two snapshots, verified rc.5 install"
 notes = """
-Fresh-install lane. Reset: `pct rollback 151 pristine` on the hypervisor.
+Fresh-install lane. Reset: `pct rollback 151 pristine|rc5-installed` on the hypervisor.
 
-BLOCKED (2026-08-10, still true at the end of the rc.5 run): `pct rollback 151` wedged the
-hypervisor on a pool-wide ZFS `z_zrele` deadlock — every `zfs unmount` on rpool blocks and
-clearing it needs a hypervisor reboot. Do not attempt a rollback of 151, and avoid running `zfs`
-commands on 10.0.1.110, until an operator has rebooted the hypervisor and re-verified the
-snapshot. ct152 exists because of this.
+UNBLOCKED 2026-08-12: the hypervisor was rebooted (sysrq-b), the ZFS deadlock is gone, and
+`pct rollback 151 <snap>` is verified working again. This is now the BEST fresh box in the fleet
+— the only one with snapshots. Two reset points:
+  * `pristine`       — pre-install Ubuntu 26.04, for exercising the installer itself
+  * `rc5-installed`  — hal0 1.0.0-rc.5 immediately post-install: api + hermes active, no models
+                       pulled, no slots loaded, no lane residue. Reproduces #1827 out of the box.
+Prefer this box over ct152, which has no snapshot and carries two runs of residue.
 
 GOTCHAS, in order:
   1. The pristine snapshot has broken DNS — /etc/resolv.conf points at an unreachable
@@ -96,6 +98,12 @@ upgrade history, so record the exact from-version in CONTEXT.md before upgrading
 As of the rc.5 run it sat on 1.0.0-rc.3 and carried hermes-agent 0.19.0 (which DOES ship
 `hermes_cli/web_dist`), so it cannot reproduce the fresh-install hermes packaging defects
 (#1829) — an upgrade preserves the newer wheel's artefacts.
+UPGRADED rc.3 -> rc.5 on 2026-08-12 and converged; it now sits on 1.0.0-rc.5, so the NEXT run's
+from-version is rc.5. Found on the way: #1844 (the updater never refreshes /usr/local/bin/hal0,
+so `hal0 --version` kept reporting rc.3 while the API served rc.5) and #1845 (the "Convergence
+incomplete" panel's remediation omits --stop-services and cannot work as printed). Its
+agent.toml still carries context_size = 4096 from an old seed — upgrades never reconcile slot
+seeds, which is why Hermes fails here for a DIFFERENT reason than on a fresh box (see #1827).
 """
 
 [boxes.ct163-cpu-fresh]


### PR DESCRIPTION
## What

Fleet-file only (`tests/release-validation/boxes.toml`). Two of the coverage gaps the rc.5 report called out are now closed, and the file should stop describing the old state.

## ct151 — unblocked, and now the preferred fresh box

The hypervisor ZFS `z_zrele` deadlock that made it unusable is gone (host rebooted via sysrq-b; `reboot -f` hung too). `pct rollback 151 <snap>` re-verified working. It now carries **two reset points**, which no other fresh box has:

| Snapshot | State |
|---|---|
| `pristine` | pre-install Ubuntu 26.04, for exercising the installer itself |
| `rc5-installed` | rc.5 immediately post-install — api + hermes active, no models pulled, no slots loaded, no lane residue |

A fresh rc.5 install was run and verified on it end to end, and it **reproduces #1827 out of the box** (`defaults.context_size = None` → `/v1/models` brain 32768 → Hermes refuses at the 64,000 floor). `pct rollback 151 rc5-installed` gets a clean reproducing box in seconds, which is a better verification target than ct152 (no snapshot, two runs of residue).

## ct150 — upgrade lane finally run

Upgraded rc.3 → rc.5 in place and converged, so the next run's from-version is rc.5. Recorded because the box's value is its accumulated history and the from-version must be known.

Two defects filed from that run — #1844 (the updater never refreshes `/usr/local/bin/hal0`, so `hal0 --version` kept reporting rc.3 while the API served rc.5) and #1845 (the *Convergence incomplete* panel prints a remediation that cannot work — it omits `--stop-services`).

It also established that **upgrades never reconcile slot seeds**: shipped rc.5 seeds say `context_size = 65536`, the live `agent.toml` still says `4096` from an older release. That is why Hermes fails there for a *different* reason than on a fresh install — the model carries `defaults.context_size = 96000`, well above the floor, and the slot ceiling wins anyway. Posted to #1827, because it means the "stamp the model at install" fix seam alone would not fix an upgraded box.

## Verified

`tomllib` parses the file. No code touched.

## Still open

The remaining gaps are unchanged and still recorded in the report: the mechanical regression batch that died on a model quota, and the absence of any GPU fresh-install box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)