### PR TITLE
fix(api): resolve slot detail ctx_max to the effective window

### DIFF
--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -44,6 +44,7 @@ from hal0.slot_view import (
     config_enrichment,
     container_enrichment,
     loaded_model_names_from_slots,
+    resolve_ctx_max,
     serialize_slot,
     synthesize_upstream_entries,
 )
@@ -1040,6 +1041,21 @@ async def get_slot(name: str, request: Request) -> dict[str, object]:
         if c_extra:
             for k, v in c_extra.items():
                 out.setdefault(k, v)
+
+        # #1835: config_enrichment above lifts ctx_max verbatim off the slot
+        # TOML (the raw hardware ceiling) — #1788/#1802 re-resolved this to
+        # the EFFECTIVE window on the list route only, leaving this detail
+        # route to advertise a number that can contradict its own
+        # ``resolved_command``. Mirror the list route's re-resolution here.
+        raw_ctx_max = out.get("ctx_max")
+        model_id = str(out.get("model_default") or "")
+        if model_id or isinstance(raw_ctx_max, int):
+            out["ctx_max"] = resolve_ctx_max(
+                raw_ctx_max if isinstance(raw_ctx_max, int) else None,
+                getattr(request.app.state, "model_registry", None),
+                model_id,
+                name,
+            )
         return out
     except Exception:
         # Fall through to synthetic lookup before re-raising — a remote

--- a/src/hal0/slot_view/__init__.py
+++ b/src/hal0/slot_view/__init__.py
@@ -70,6 +70,7 @@ __all__ = [
     "config_enrichment",
     "container_enrichment",
     "loaded_model_names_from_slots",
+    "resolve_ctx_max",
     "serialize_slot",
     "synthesize_upstream_entries",
 ]
@@ -429,7 +430,7 @@ def config_enrichment(configs: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return out
 
 
-def _resolve_ctx_max(
+def resolve_ctx_max(
     raw_ctx_max: int | None,
     model_registry: Any,
     model_id: str,
@@ -441,13 +442,15 @@ def _resolve_ctx_max(
     TOML — the raw hardware ceiling, not what llama-server actually runs
     with now that the MODEL owns context size (v1.0 ownership split; see
     :func:`hal0.providers.container._resolve_context_size`). The aggregator
-    calls this after merging ``config_enrichment``'s output so the
-    "ctx used / max" pane reports the same number the launch path resolved,
-    using the model registry the aggregator already carries.
+    (and, per #1835, the ``GET /api/slots/{name}`` detail route) calls this
+    after merging ``config_enrichment``'s output so the "ctx used / max"
+    pane and the per-slot detail body both report the same number the
+    launch path resolved, using the model registry the caller already
+    carries.
 
     Imported lazily (heavy neighbour, see module docstring) and never
     raises: a resolution failure degrades to the raw TOML ceiling — the
-    pre-fix behavior — rather than breaking the slots list.
+    pre-fix behavior — rather than breaking the caller.
     """
     try:
         from hal0.providers.container import resolve_effective_context_size
@@ -961,7 +964,7 @@ class SlotViewAggregator:
             raw_ctx_max = payload.get("ctx_max")
             model_id = str(payload.get("model_default") or "")
             if model_id or isinstance(raw_ctx_max, int):
-                payload["ctx_max"] = _resolve_ctx_max(
+                payload["ctx_max"] = resolve_ctx_max(
                     raw_ctx_max if isinstance(raw_ctx_max, int) else None,
                     self._registry,
                     model_id,

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -1828,6 +1828,68 @@ def test_get_slot_includes_config_enrichment(
     assert body["model_default"] == "gemma3-1b"
 
 
+class _FakeCtxDefaults:
+    def __init__(self, context_size: int | None) -> None:
+        self.context_size = context_size
+
+
+class _FakeCtxModel:
+    def __init__(self, context_size: int | None) -> None:
+        self.defaults = _FakeCtxDefaults(context_size)
+
+    def model_dump(self) -> dict[str, Any]:
+        return {"defaults": {"context_size": self.defaults.context_size}, "metadata": {}}
+
+
+class _FakeCtxRegistry:
+    def __init__(self, models: dict[str, Any]) -> None:
+        self._models = models
+
+    def get(self, model_id: str) -> Any:
+        if model_id not in self._models:
+            raise KeyError(model_id)
+        return self._models[model_id]
+
+
+def test_get_slot_resolves_ctx_max_to_effective_window(
+    tmp_hal0_home: str,
+    container_stub: dict[str, Any],
+    isolated_client: TestClient,
+    isolated_app: FastAPI,
+) -> None:
+    """#1835: GET /api/slots/{name} must re-resolve ``ctx_max`` to the
+    EFFECTIVE window (#1788/#1802's fix), not echo the raw slot-TOML
+    ceiling verbatim. #1802 fixed ``GET /api/slots`` (list) only; this is
+    the detail-route regression that survived it.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "chat",
+        [
+            'name = "chat"',
+            "port = 8081",
+            'device = "gpu-vulkan"',
+            'provider = "llama-server"',
+            'runtime = "container"',
+            'profile = "vulkan-radv"',
+            "[model]",
+            'default = "qwen3-4b"',
+            "context_size = 65536",
+        ],
+    )
+    # The registered model's declared window (8000) is smaller than the
+    # slot's raw TOML ceiling (65536) — the EFFECTIVE window must win.
+    isolated_app.state.model_registry = _FakeCtxRegistry({"qwen3-4b": _FakeCtxModel(8000)})
+
+    r = isolated_client.get("/api/slots/chat")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ctx_max"] == 8000, (
+        f"detail route must report the effective window, not the raw TOML "
+        f"ceiling; got {body['ctx_max']!r}"
+    )
+
+
 def test_get_slot_includes_config_drift_when_requested(
     slot_root: Path,
     container_stub: dict[str, Any],


### PR DESCRIPTION
## What changed

`GET /api/slots/{name}` was lifting `ctx_max` verbatim off the slot TOML
via `config_enrichment` — the raw hardware ceiling — instead of the
EFFECTIVE window llama-server actually runs with. `GET /api/slots`
(list) and `/v1/models` were already fixed to re-resolve this in #1802
(building on #1788), but that fix only wired the list-aggregator path;
the single-slot detail route (`get_slot` in `src/hal0/api/routes/slots.py`)
was never touched by it, so it kept advertising a number that could
contradict its own `resolved_command` field in the same response body.

- Exported `hal0.slot_view`'s ctx_max resolver as `resolve_ctx_max`
  (was private `_resolve_ctx_max`, used only by `SlotViewAggregator`).
- Called it from `get_slot` after config/container enrichment, mirroring
  exactly the aggregator's existing re-resolution logic (same
  raw-ceiling / model-id gate, same registry lookup, same graceful
  degrade-to-raw-ceiling on resolver failure).

## Why

Reported by the v1.0.0-rc.5 release-validation run
(`tests/release-validation/reports/v1.0.0-rc.5.md`, finding
`ctx-advertised-vs-resolved`). Confirmed live on ct152 (fresh install)
and ct105 (upgraded prod, GPU) — on an upgraded box the detail route
overstated a live slot's context window by 2.5x (164000 vs. the
resolved_command's actual 65536).

Root cause is exactly as the issue diagnosed: #1802's commit wired
the re-resolution into the aggregator (`SlotViewAggregator.snapshot`)
but `get_slot`'s standalone enrichment path never called it.

## Verified

- New regression test `test_get_slot_resolves_ctx_max_to_effective_window`
  in `tests/api/test_slots_routes.py`: fails before the fix (asserts
  8000 effective window, gets 65536 raw ceiling), passes after.
- `HAL0_HOME=$(mktemp -d) uv run pytest tests/api/ tests/slot_view/ -q`
  → 1803 passed, 1 skipped.
- `uv run ruff check` / `uv run ruff format --check` clean on all
  touched files (repo has pre-existing unrelated lint/format issues in
  `packaging/` and `scripts/`, untouched by this branch).

## Left out of scope

- `/api/slots/{name}/config` intentionally still returns the raw TOML
  ceiling — that endpoint is documented as returning the on-disk config
  verbatim (the operator's edit surface), and the issue explicitly
  confirms that's correct, not part of this bug.
- CHANGELOG.md not touched per the release fix-wave convention
  (tracked separately, #1545) — a consolidated CHANGELOG PR lands at
  the end of the wave.

Closes #1835