### PR TITLE
fix(agents): resolve chat anchor by-id, ungate memory_roundtrip

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3256,6 +3256,37 @@ def _fetch_model_contexts() -> dict[str, int]:
     return out
 
 
+def _fetch_model_route_ready(model_id: str) -> bool:
+    """Ask ``GET /v1/models/{id}`` whether ``model_id`` actually routes.
+
+    Unlike :func:`_fetch_model_contexts` (backed by the **list** route,
+    ``GET /v1/models``), this hits the **by-id** route, which resolves hal0's
+    canonical virtual names (``hal0/agent``, ``hal0/utility``, ``hal0/npu``)
+    via the LiveSlotResolver (see ``_resolve_virtual_model_entry`` in
+    ``hal0.api.routes.v1``). The list route deliberately never advertises
+    those virtuals (#1153) and also folds a chat slot's raw model id into
+    its alias entry, so checking list *membership* against the shipped
+    ``model.default: hal0/agent`` can never succeed even when the model is
+    fully routable (#1831). 404/other client errors and network failures
+    both mean "not ready"; only a clean response counts.
+    """
+    from urllib.error import HTTPError, URLError
+    from urllib.parse import quote
+    from urllib.request import Request, urlopen
+
+    req = Request(
+        f"{HAL0_API_URL}/v1/models/{quote(model_id, safe='/')}",
+        headers={"Accept": "application/json"},
+    )
+    try:
+        with urlopen(req, timeout=3.0) as resp:
+            return 200 <= resp.status < 300
+    except HTTPError:
+        return False
+    except (URLError, OSError, TimeoutError):
+        return False
+
+
 def _slot_kind(slot: dict[str, Any]) -> str:
     """Best-effort capability classifier — handles a few schema variants.
 
@@ -4527,12 +4558,14 @@ def _phase_voice_wire(ctx: _StepCtx) -> PhaseResult:
 # burying it in the Detail column. self_report surfaces the same rollup in
 # the bootstrap-completion memory item.
 #
-# chat_completions and memory_roundtrip both need a routable chat model to
-# mean anything; at install time — before any model has ever been loaded —
-# that's structurally impossible, so a preflight (`_chat_model_ready`)
-# decides ONCE whether the route is live and both probes report
-# `skipped: no chat model loaded` instead of burning their timeout on a
-# doomed request that then gets recorded as an opaque failure.
+# chat_completions needs a routable chat model to mean anything; at install
+# time — before any model has ever been loaded — that's structurally
+# impossible, so a preflight (`_chat_model_ready`) decides ONCE whether the
+# route is live and the probe reports `skipped: no chat model loaded`
+# instead of burning its timeout on a doomed request that then gets
+# recorded as an opaque failure. memory_roundtrip has no chat dependency
+# whatsoever (it drives the MCP memory_add/memory_search tools directly) and
+# always runs (#1831).
 
 
 def _wrapper_bin() -> Path:
@@ -4711,7 +4744,11 @@ def _smoke_hermes_doctor(_state: BootstrapState, io: InstallIO) -> tuple[bool, s
 #: Probes that only mean something once a chat-capable model is actually
 #: routable. Gated behind :func:`_chat_model_ready` so an install-time smoke
 #: run (no model has ever been loaded yet) reports `skipped`, not a timeout.
-_MODEL_DEPENDENT_PROBES = frozenset({"chat_completions", "memory_roundtrip"})
+#: memory_roundtrip does NOT belong here — it exercises the MCP
+#: memory_add/memory_search tools directly and has no chat dependency
+#: whatsoever (#1831); gating it behind the chat anchor over-skipped it even
+#: when memory itself was fully working.
+_MODEL_DEPENDENT_PROBES = frozenset({"chat_completions"})
 
 
 def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
@@ -4719,12 +4756,25 @@ def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
 
     Reads ``model.default`` from config.yaml — the exact field
     :func:`_smoke_chat_completions` targets — and cross-checks it against the
-    live gateway model list via ``io.fetch_model_contexts`` (the same
-    ``/v1/models`` seam ``model_automap`` already uses), instead of paying a
-    full chat-completion round trip just to find out nothing is loaded. This
-    is what lets smoke_tests tell "the route is genuinely broken" (a real
-    failure) apart from "no chat model exists yet" (#1793) — never raises;
-    any config/parse/network problem reports not-ready with the reason.
+    live gateway via ``io.fetch_model_route_ready`` (``GET
+    /v1/models/{id}``), instead of paying a full chat-completion round trip
+    just to find out nothing is loaded.
+
+    This resolves the anchor through the **by-id** route rather than
+    checking membership in the **list** route's payload (``GET
+    /v1/models``): the list route deliberately never advertises hal0's
+    canonical virtual names (``hal0/agent`` et al. — see
+    ``_aggregate_models`` in ``hal0.api.routes.v1``, #1153) and also folds a
+    chat slot's raw model id into its alias entry, so list membership can
+    never hold for the shipped ``model.default: hal0/agent`` even when the
+    model is fully routable. The by-id route resolves virtuals via the
+    LiveSlotResolver (``_resolve_virtual_model_entry``), matching exactly
+    what :func:`_smoke_chat_completions` itself dispatches against (#1831).
+
+    This is what lets smoke_tests tell "the route is genuinely broken" (a
+    real failure) apart from "no chat model exists yet" (#1793) — never
+    raises; any config/parse/network problem reports not-ready with the
+    reason.
     """
     import yaml  # type: ignore[import-untyped]
 
@@ -4739,10 +4789,10 @@ def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
     if not model_name:
         return False, "model.default unset in config.yaml"
     try:
-        contexts = io.fetch_model_contexts()
+        routable = io.fetch_model_route_ready(model_name)
     except Exception as exc:  # preflight must never raise
         return False, f"gateway probe failed: {exc}"
-    if model_name not in contexts:
+    if not routable:
         return False, f"'{model_name}' not loaded on the gateway"
     return True, "ready"
 
@@ -5196,6 +5246,7 @@ class InstallIO:
     http_get: Callable[..., int] = _http_get
     fetch_slots: Callable[[], list[dict[str, Any]]] = _fetch_slots
     fetch_model_contexts: Callable[[], dict[str, int]] = _fetch_model_contexts
+    fetch_model_route_ready: Callable[[str], bool] = _fetch_model_route_ready
     probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
     mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
     install_venv: Callable[..., None] = _install_venv

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2085,9 +2085,7 @@ class TestChatModelReady:
         assert ready is False
         assert "gateway probe failed" in reason
 
-    def test_shipped_virtual_default_ready_via_by_id_route_not_list(
-        self, tmp_path: Path
-    ) -> None:
+    def test_shipped_virtual_default_ready_via_by_id_route_not_list(self, tmp_path: Path) -> None:
         """Regression (#1831): the shipped ``model.default: hal0/agent`` is
         NEVER a member of ``GET /v1/models``' list payload — that route
         deliberately never advertises hal0's canonical virtuals (#1153) — so

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1961,7 +1961,7 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     hh = tmp_path / "hh"
     _write_ready_chat_config(hh)
     state = hp.BootstrapState(hermes_home=str(hh))
-    io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
+    io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
     # All six probes return (True, "...") so we exercise the rollup
     # without depending on a real Hermes binary or HTTP listener.
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
@@ -1992,7 +1992,7 @@ def test_smoke_tests_phase_records_failures_as_warn_without_blocking(
     hh = tmp_path / "hh"
     _write_ready_chat_config(hh)
     state = hp.BootstrapState(hermes_home=str(hh))
-    io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
+    io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (False, "wrapper missing"))
     monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
     monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (False, "503"))
@@ -2010,8 +2010,9 @@ def test_smoke_tests_phase_skips_model_dependent_probes_without_chat_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """No routable chat model at smoke time (e.g. install-time run, before any
-    model has ever been loaded) → chat_completions/memory_roundtrip report
-    ``skipped``, not a timeout recorded as an opaque failure (#1793)."""
+    model has ever been loaded) → chat_completions reports ``skipped``, not a
+    timeout recorded as an opaque failure (#1793). memory_roundtrip has no
+    chat dependency and must still run (#1831)."""
     state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"))  # no config.yaml at all
     calls: list[str] = []
 
@@ -2022,17 +2023,17 @@ def test_smoke_tests_phase_skips_model_dependent_probes_without_chat_model(
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
     monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
     monkeypatch.setattr(hp, "_smoke_chat_completions", _boom)
-    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", _boom)
+    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
     monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
     monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
     out = hp._phase_smoke_tests(hp._StepCtx(state=state))
-    assert calls == []  # gated probes never ran
+    assert calls == []  # the chat-gated probe never ran
     assert out.status == hp.PhaseStatus.OK  # skips aren't failures
     assert out.details["failures"] == []
-    assert len(out.details["skipped"]) == 2
+    assert len(out.details["skipped"]) == 1
     assert out.details["results"]["chat_completions"]["skipped"] is True
     assert "no chat model loaded" in out.details["results"]["chat_completions"]["detail"]
-    assert out.details["results"]["memory_roundtrip"]["skipped"] is True
+    assert out.details["results"]["memory_roundtrip"] == {"passed": True, "detail": "1 item"}
 
 
 class TestChatModelReady:
@@ -2057,7 +2058,7 @@ class TestChatModelReady:
         hh = tmp_path / "hh"
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
-        io = hp.InstallIO(fetch_model_contexts=lambda: {"other": 4096})
+        io = hp.InstallIO(fetch_model_route_ready=lambda model_id: False)
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is False
         assert "not loaded on the gateway" in reason
@@ -2066,7 +2067,7 @@ class TestChatModelReady:
         hh = tmp_path / "hh"
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
-        io = hp.InstallIO(fetch_model_contexts=lambda: {"m1": 8192})
+        io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is True
         assert reason == "ready"
@@ -2076,13 +2077,45 @@ class TestChatModelReady:
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
 
-        def _boom() -> dict[str, int]:
+        def _boom(_model_id: str) -> bool:
             raise RuntimeError("gateway unreachable")
 
-        io = hp.InstallIO(fetch_model_contexts=_boom)
+        io = hp.InstallIO(fetch_model_route_ready=_boom)
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is False
         assert "gateway probe failed" in reason
+
+    def test_shipped_virtual_default_ready_via_by_id_route_not_list(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (#1831): the shipped ``model.default: hal0/agent`` is
+        NEVER a member of ``GET /v1/models``' list payload — that route
+        deliberately never advertises hal0's canonical virtuals (#1153) — so
+        the preflight must resolve the anchor through the **by-id** route
+        (``GET /v1/models/{id}``, which the gateway resolves through the
+        LiveSlotResolver) instead of checking list membership. A regression
+        here reintroduces "chat_completions and memory_roundtrip are skipped
+        on every install"."""
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "hal0/agent")
+        state = hp.BootstrapState(hermes_home=str(hh))
+
+        # A realistic /v1/models list payload: never contains "hal0/agent",
+        # by design — only the underlying slot alias is listed.
+        realistic_list_contexts = {"brain": 32768, "utility": 8192}
+
+        def fetch_model_route_ready(model_id: str) -> bool:
+            # The by-id route resolves virtuals; list membership is
+            # irrelevant to it.
+            return model_id == "hal0/agent"
+
+        io = hp.InstallIO(
+            fetch_model_contexts=lambda: realistic_list_contexts,
+            fetch_model_route_ready=fetch_model_route_ready,
+        )
+        ready, reason = hp._chat_model_ready(state, io)
+        assert ready is True
+        assert reason == "ready"
 
 
 def test_write_run_report_surfaces_failure_and_skipped_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed

`_chat_model_ready` (the rc.5 smoke-test chat preflight) cross-checked
`model.default` against `GET /v1/models` — the **list** route, which
deliberately never advertises hal0's canonical virtual names (`hal0/agent`,
`hal0/utility`, `hal0/npu`, #1153) and folds a chat slot's raw model id into
its alias entry. The shipped default is `model.default: hal0/agent`, so the
anchor could never be a member of that list on any box. Result:
`chat_completions` and `memory_roundtrip` were skipped on every hal0 install
with a false `'hal0/agent' not loaded on the gateway` reason.

Fix, matching the issue's recommendation:

- Add `_fetch_model_route_ready(model_id)`, which hits `GET
  /v1/models/{id}` (the **by-id** route — resolves virtuals via the
  LiveSlotResolver, and is exactly what `_smoke_chat_completions` itself
  dispatches against) instead of checking list membership.
- `_chat_model_ready` now calls this through a new `InstallIO.
  fetch_model_route_ready` seam instead of `fetch_model_contexts`.
- Ungate `memory_roundtrip` from `_MODEL_DEPENDENT_PROBES`: it drives the
  MCP `memory_add`/`memory_search` tools directly and has no chat
  dependency, so gating it behind the chat anchor over-skipped it even when
  memory was fully working (secondary defect called out in the issue).

## Why

Two release-gating probes were permanently dead on the shipped
configuration (rc.4's chat-timeout and memory-no-marker regressions,
regressions.yaml `hermes-smoke-ok-over-failures` / #1793, would no longer
be caught). Root cause is the list-vs-by-id route mismatch, not a bug in
the probes themselves — same seam `_smoke_chat_completions` already uses
correctly.

## How verified

- New regression test `TestChatModelReady::
  test_shipped_virtual_default_ready_via_by_id_route_not_list` pins the
  real shipped default (`model.default: hal0/agent`) against a realistic
  `/v1/models` list payload that never contains it, and confirms readiness
  comes from the by-id route. Failed before the fix (list-membership
  check), passes after.
- Updated the three existing tests that depended on the old
  `fetch_model_contexts`-based gate (`TestChatModelReady`,
  `test_smoke_tests_phase_runs_each_probe_collecting_results`,
  `test_smoke_tests_phase_records_failures_as_warn_without_blocking`,
  `test_smoke_tests_phase_skips_model_dependent_probes_without_chat_model` —
  the last now asserts `memory_roundtrip` runs even when the chat anchor is
  not ready).
- `uv run pytest tests/agents/ -q` → 653 passed, 1 xfailed (pre-existing,
  unrelated).
- `uv run pytest -q` (full suite) → passed.
- `uv run ruff check` / `uv run ruff format --check` on both changed files
  → clean.

## Out of scope

- `CHANGELOG.md` is intentionally untouched (per wave convention — one
  consolidated CHANGELOG PR lands at the end).
- Did not touch `_smoke_chat_completions` or `_smoke_memory_roundtrip`
  themselves — both were already correct (issue's "Not claimed" section);
  only the preflight anchor check and the probe gating set changed.

Closes #1831