### PR TITLE
fix/v1 models cache eviction

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -247,9 +247,8 @@ async def _fetch_hal0_composite_models(
         is_flm = "flm" in (cfg.get("provider", ""), cfg.get("backend", ""))
         if not is_flm or not name:
             continue
-        # Container-era schema is the [npu] table (what FLMProvider builds
-        # the --asr/--embed argv from); [defaults] load_* is the pre-#733
-        # legacy shape, kept so older tomls keep seeding.
+        # Two config shapes accepted here — see _seed_multiplex_models for
+        # why (container-era [npu] table vs. pre-#733 [defaults] load_*).
         npu_table = cfg.get("npu") or {}
         defaults = cfg.get("defaults") or {}
         load_embed = npu_table.get("embed") or defaults.get("load_embed")

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -191,6 +191,16 @@ async def _fetch_hal0_composite_models(
     place without an operator having to wire a matching upstreams.toml
     entry per slot.
 
+    Also folds in the FLM multiplex tags (``embed-gemma:300m`` /
+    ``whisper-v3:turbo``, see :func:`_seed_multiplex_models`) for any FLM
+    slot whose config opts into them — those tags never appear in an FLM
+    slot's own ``model.default`` (they ride along on the same process) so
+    they have to be derived here, freshly, on every fetch. Doing it inside
+    this fetch (rather than as a separate merge step downstream) is what
+    lets callers safely REPLACE their cache with this return value instead
+    of merging it forward (#1837 — a merge-forward is how a deleted slot's
+    model id kept getting advertised after the slot was gone).
+
     The returned list is sorted + deduplicated and cached for
     ``ttl_seconds`` to keep the cold-start fan-out cheap while still
     picking up new slots within a handful of seconds.
@@ -231,6 +241,25 @@ async def _fetch_hal0_composite_models(
             continue
         seen.add(model_id)
         models.append(model_id)
+
+    for cfg in cfgs:
+        name = cfg.get("name", "")
+        is_flm = "flm" in (cfg.get("provider", ""), cfg.get("backend", ""))
+        if not is_flm or not name:
+            continue
+        # Container-era schema is the [npu] table (what FLMProvider builds
+        # the --asr/--embed argv from); [defaults] load_* is the pre-#733
+        # legacy shape, kept so older tomls keep seeding.
+        npu_table = cfg.get("npu") or {}
+        defaults = cfg.get("defaults") or {}
+        load_embed = npu_table.get("embed") or defaults.get("load_embed")
+        load_asr = npu_table.get("asr") or defaults.get("load_asr")
+        if load_embed and _FLM_EMBED_TAG not in seen:
+            seen.add(_FLM_EMBED_TAG)
+            models.append(_FLM_EMBED_TAG)
+        if load_asr and _FLM_ASR_TAG not in seen:
+            seen.add(_FLM_ASR_TAG)
+            models.append(_FLM_ASR_TAG)
 
     models.sort()
     _HAL0_MODEL_CACHE[_HAL0_COMPOSITE_CACHE_KEY] = (monotonic_now + ttl_seconds, list(models))
@@ -604,10 +633,17 @@ async def _prime_hal0_composite_cache(
     means the first request after startup doesn't have to pay the
     slot-iteration cost.
 
-    Merges rather than replaces: any tag already in the bucket that the
-    fresh catalogue read doesn't reproduce (e.g. FLM multiplex tags seeded
-    by :func:`_seed_multiplex_models`) is preserved, mirroring
-    ``_fetch_and_cache``'s merge behaviour for ordinary upstreams.
+    REPLACES ``model_cache["hal0"]`` wholesale on every call — it must NOT
+    merge the fresh catalogue read with whatever was there before. A slot
+    that's since been deleted (or rebound to a different model) must have
+    its old id fall out of the bucket, not accumulate forever (#1837: a
+    merge-forward left deleted slots' model ids advertised via
+    ``/v1/models`` for the life of the ``hal0-api`` process — ids that hard
+    404 on dispatch since neither a slot nor a registry entry backs them
+    anymore). FLM multiplex tags (``embed-gemma:300m`` / ``whisper-v3:turbo``)
+    are freshly re-derived on every call too — see
+    :func:`_fetch_hal0_composite_models` — so replacing here doesn't drop
+    them.
 
     Skipped if an explicit ``upstreams.toml`` entry already claims the
     name ``hal0`` — operator overrides win, and their entry's model cache
@@ -619,12 +655,7 @@ async def _prime_hal0_composite_cache(
         log.info("slots.hal0_composite_skipped", reason="explicit_upstream_registered")
         return
     models = await _fetch_hal0_composite_models(slot_manager)
-    existing = model_cache.get("hal0", [])
-    merged = list(models)
-    for tag in existing:
-        if tag not in merged:
-            merged.append(tag)
-    model_cache["hal0"] = merged
+    model_cache["hal0"] = list(models)
 
 
 # ── FLM multiplex model seeding ────────────────────────────────────────────
@@ -700,10 +731,15 @@ async def _seed_multiplex_models(
     """Add FLM multiplex tags (embed-gemma, whisper-v3:turbo) to the model
     cache for slots whose config opts into the matching multiplex.
 
-    Idempotent — appends only when missing. Runs after
-    ``_prime_hal0_composite_cache``. The multiplex tags are merged into the
-    ``hal0`` cache bucket (the direct-read composite catalogue) so the
-    dispatcher's passthrough match still picks them up.
+    Idempotent — appends only when missing. Historically ran after
+    ``_prime_hal0_composite_cache`` to backfill tags a merge-based prime
+    wouldn't otherwise produce; :func:`_fetch_hal0_composite_models` (and
+    therefore ``_prime_hal0_composite_cache``, which now REPLACES rather
+    than merges — #1837) derives the same tags itself on every call, so
+    this is a no-op belt-and-braces call on the startup path. Kept as a
+    standalone helper for direct unit coverage and for any caller that
+    populates ``model_cache["hal0"]`` some other way (e.g. an explicit
+    ``upstreams.toml`` override, where priming is skipped entirely).
     """
     try:
         cfgs = await slot_manager.iter_configs()

--- a/tests/api/test_upstream_dedup.py
+++ b/tests/api/test_upstream_dedup.py
@@ -113,6 +113,35 @@ async def test_no_pseudo_upstream_is_registered_in_the_routing_table() -> None:
 
 
 @pytest.mark.asyncio
+async def test_priming_evicts_a_model_id_whose_slot_was_deleted() -> None:
+    """#1837: a chat slot bound to ``ghost-model`` gets deleted. The next
+    prime (e.g. triggered by a DIFFERENT slot's ready event) must drop
+    ``ghost-model`` from ``model_cache["hal0"]`` — not merge it forward
+    forever. A merged-forward id hard-404s: it's absent from both the
+    registry and every live slot, so dispatch has nowhere to route it."""
+    registry = UpstreamRegistry()
+    slot_mgr = _FakeSlotManager(
+        [
+            {"name": "primary", "type": "llm", "model_default": "ghost-model"},
+        ]
+    )
+    model_cache: dict[str, list[str]] = {}
+
+    # First prime — the now-deleted slot is still alive and advertised.
+    await _prime_hal0_composite_cache(registry, slot_mgr, model_cache)
+    assert model_cache["hal0"] == ["ghost-model"]
+
+    # The operator deletes the "primary" slot. A later re-prime (any slot
+    # transitioning to ready re-primes the whole composite bucket) must
+    # replace the bucket, not merge the stale id forward.
+    _hal0_model_cache_clear()
+    slot_mgr._configs = []
+    await _prime_hal0_composite_cache(registry, slot_mgr, model_cache)
+
+    assert model_cache["hal0"] == []
+
+
+@pytest.mark.asyncio
 async def test_priming_is_a_noop_when_operator_defines_a_real_hal0_upstream() -> None:
     """If ``hal0`` is already registered (operator override via
     upstreams.toml) priming the direct-read cache is skipped so the


### PR DESCRIPTION
## Summary

- `GET /v1/models` never evicted a deleted slot's model id from its `hal0`-owned composite catalogue: `_prime_hal0_composite_cache` **merged** the fresh slot-config read into `model_cache["hal0"]` instead of replacing it, so any id ever bound to an `llm` slot stayed advertised for the life of the `hal0-api` process — including after the slot (and its registry entry) were deleted. Clients that pick a model from `/v1/models` could pick a ghost id that hard-404s (`dispatch.no_route`) on every request.
- Root cause: the merge existed only so a fresh (replacing) prime wouldn't drop the FLM multiplex tags (`embed-gemma:300m`, `whisper-v3:turbo`) seeded separately by `_seed_multiplex_models`. Fixed at the root by folding that tag derivation directly into `_fetch_hal0_composite_models` (it already reads the same slot configs), so every fetch produces the complete, correct set — including multiplex tags — and `_prime_hal0_composite_cache` can safely `model_cache["hal0"] = list(models)` on every call instead of merging forward.
- `_seed_multiplex_models` is left in place (still covered by its own unit tests, still called on the startup path) but is now effectively a no-op there since the prime it follows already includes the multiplex tags; it remains useful for callers that populate `model_cache["hal0"]` some other way (e.g. an explicit `upstreams.toml` override, where composite priming is skipped entirely).

## Why

Reported by the v1.0.0-rc.5 release-validation run (issue #1837, finding `v1-models-advertises-orphan-zzbroken`): a client building its model picker from `/v1/models` could offer an id that can never work. The issue's own repro attempt (orphan file on disk + `hal0 model add/rm`) was a red herring — the composite catalogue is built from *live slot configs*, not the registry or disk — so I reproduced the real mechanism directly: prime with a slot bound to a model id, delete the slot, re-prime, and assert the id survives (it did, before this fix).

## Verification

- New regression test `test_priming_evicts_a_model_id_whose_slot_was_deleted` in `tests/api/test_upstream_dedup.py` — fails on `main` (asserts `['ghost-model'] == []`, gets `['ghost-model']`), passes after the fix.
- `uv run --extra dev pytest tests/api -q` — 1731 passed, 1 skipped (pre-existing journalctl skip), including all `test_upstream_dedup.py`, `test_seed_multiplex_models.py`, and `test_model_cache_refresh.py` cases (multiplex seeding and the ready-event re-prime path both still behave correctly).
- `uv run --extra dev ruff check` / `ruff format --check` on the touched files — clean.

## Out of scope

- `CHANGELOG.md` — left untouched per the fix-wave convention (tracked separately, #1545).
- The milder, more common variant noted in the issue (rebinding a chat slot from model A to B leaves A advertised) resolves through the existing by-design agent-anchor substitution and isn't a 404 — not touched here.

Closes #1837