### PR TITLE
fix(cli): give slot lifecycle verbs a client timeout with server headroom

### DIFF
--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -40,6 +40,18 @@ from hal0.hardware.stats import SLOT_PORT_RANGE_END, SLOT_PORT_RANGE_START
 app = typer.Typer(help="Manage inference slots.")
 console = Console()
 
+# The server-side state machine blocks the HTTP response until the slot
+# converges: SlotManager.load -> _await_ready polls /health for up to
+# providers.container._HEALTH_TIMEOUT_S (180s). restart and swap both
+# unload the live slot before loading the replacement, so their worst-case
+# budget stretches past a single load's. api_post's default 10s read
+# timeout is far under any of these budgets — every mutating lifecycle
+# verb would raise ReadTimeout and exit 1 on an operation that in fact
+# succeeded server-side (#1832). Give these call sites a client timeout
+# with real headroom over the server's own worst case instead of the
+# blanket default.
+SLOT_LIFECYCLE_TIMEOUT_S = 220.0
+
 
 class SlotProvider(StrEnum):
     """Providers valid for a slot (mirrors PLAN.md §1 provider list).
@@ -260,7 +272,7 @@ def slot_load(
         raise typer.Exit(1)
     try:
         body = {"model_id": model} if model else {}
-        snap = api_post(f"/api/slots/{name}/load", json=body)
+        snap = api_post(f"/api/slots/{name}/load", json=body, timeout=SLOT_LIFECYCLE_TIMEOUT_S)
     except CliApiError as exc:
         die(str(exc))
         return
@@ -278,7 +290,7 @@ def slot_unload(
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        snap = api_post(f"/api/slots/{name}/unload")
+        snap = api_post(f"/api/slots/{name}/unload", timeout=SLOT_LIFECYCLE_TIMEOUT_S)
     except CliApiError as exc:
         die(str(exc))
         return
@@ -294,7 +306,7 @@ def slot_restart(
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        snap = api_post(f"/api/slots/{name}/restart")
+        snap = api_post(f"/api/slots/{name}/restart", timeout=SLOT_LIFECYCLE_TIMEOUT_S)
     except CliApiError as exc:
         die(str(exc))
         return
@@ -348,7 +360,9 @@ def slot_swap(
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        snap = api_post(f"/api/slots/{name}/swap", json={"model_id": model})
+        snap = api_post(
+            f"/api/slots/{name}/swap", json={"model_id": model}, timeout=SLOT_LIFECYCLE_TIMEOUT_S
+        )
     except CliApiError as exc:
         die(str(exc))
         return

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -1,0 +1,81 @@
+"""Tests for the mutating ``hal0 slot`` verbs' HTTP timeout (#1832).
+
+The server-side lifecycle handlers (load/unload/restart/swap) block the
+HTTP response until the slot's state machine converges — up to 180s for
+a cold load (``providers.container._HEALTH_TIMEOUT_S``), and longer still
+for restart/swap, which unload then load. ``api_post``'s default read
+timeout is 10s, an 18x mismatch: any lifecycle op over ~10s used to raise
+``ReadTimeout`` and exit 1 while the operation continued and completed
+successfully server-side. These call sites must pass an explicit timeout
+with headroom over the server's worst-case budget.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from hal0.cli import slot_commands
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_unreachable(_url: str) -> bool:
+        return False
+
+    def fake_post(path: str, *, json: dict[str, Any] | None = None, **kw: Any) -> dict[str, Any]:
+        captured["method"] = "POST"
+        captured["path"] = path
+        captured["body"] = json or {}
+        captured["kwargs"] = kw
+        return {"state": "serving", "model_id": (json or {}).get("model_id")}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", fake_unreachable)
+    monkeypatch.setattr(slot_commands, "api_post", fake_post)
+    return captured
+
+
+def _timeout_ge_server_budget(kwargs: dict[str, Any]) -> None:
+    """The CLI's client-side read timeout must clear the server's own
+    180s health-poll budget with real headroom — not just barely exceed
+    the old 10s default."""
+    assert "timeout" in kwargs, "lifecycle call site passed no explicit timeout kwarg"
+    assert kwargs["timeout"] >= 180.0, (
+        f"timeout={kwargs['timeout']} is under the server's 180s health-poll budget"
+    )
+
+
+def test_slot_load_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
+    result = runner.invoke(slot_commands.app, ["load", "primary"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/slots/primary/load"
+    _timeout_ge_server_budget(captured["kwargs"])
+
+
+def test_slot_unload_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
+    result = runner.invoke(slot_commands.app, ["unload", "primary"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/slots/primary/unload"
+    _timeout_ge_server_budget(captured["kwargs"])
+
+
+def test_slot_restart_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
+    result = runner.invoke(slot_commands.app, ["restart", "primary"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/slots/primary/restart"
+    _timeout_ge_server_budget(captured["kwargs"])
+
+
+def test_slot_swap_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
+    result = runner.invoke(
+        slot_commands.app, ["swap", "primary", "--model", "demo", "--no-persist"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/slots/primary/swap"
+    _timeout_ge_server_budget(captured["kwargs"])


### PR DESCRIPTION
## What

`hal0 slot load/unload/restart/swap` now pass an explicit
`SLOT_LIFECYCLE_TIMEOUT_S = 220.0` client-side read timeout at their
`api_post` call sites, instead of falling through to `api_post`'s
`timeout: float = 10.0` default.

## Why

Every one of these verbs blocks the HTTP response server-side until the
slot's state machine converges:

- `load`: `SlotManager.load()` → `_await_ready()` polls `/health` for up
  to `providers.container._HEALTH_TIMEOUT_S = 180.0`.
- `unload`: bounded terminate (`_terminate_timeout_s`).
- `restart`: unload then a full load — worse than a single load.
- `swap`: unloads the live slot then loads the new model — same shape
  as restart.

`api_post`'s default 10s read timeout is an 18x mismatch against the
180s server budget alone, and worse for restart/swap. Any lifecycle op
over ~10s raised `httpx.ReadTimeout`, printed `Error: ... ReadTimeout:
timed out`, and exited 1 — while the operation continued unattended
server-side and completed successfully. This is a **success reported
as a failure**, not a genuine timeout: confirmed on ct152 (CPU-only)
where `load` converged to `ready` ~73s after the CLI had already
printed the error and exited, and on the GPU box (#1424's own repro)
where `load`/`restart` took 22–72s.

This corrupts scripted callers too:
`scripts/release-test.sh` gates pass/fail on the exit code, and
`installer/install.sh`'s documented `hal0 model pull <id> && hal0 slot
load agent --model <id>` chain fails on its own success.

`rename` (`api_post(.../rename)`) and `create` (`api_post("/api/slots")`)
were deliberately left at the 10s default — neither blocks on the
health poll server-side (`create_slot` only writes config; the caller
follows up with a separate `load`), so raising their timeout would just
mask a genuinely slow/broken request.

## How verified

- Added `tests/cli/test_slot_commands.py`: monkeypatches `api_post` to
  capture call kwargs and asserts each of load/unload/restart/swap
  passes `timeout >= 180.0`. Confirmed the test fails against
  unpatched `slot_commands.py` (no `timeout` kwarg captured) before the
  fix, and passes after.
- `uv run pytest tests/cli/ -q` → 721 passed.
- `uv run ruff check src tests` / `ruff format --check src tests` → clean.

## Out of scope

- #1424 (server-side load/restart semantics — 200 with `state: offline`,
  `CalledProcessError` escaping as 500, no `reset-failed` before
  restart) is a separate, distinct defect per the issue.
- No `--wait`/progress-poll flag or `HAL0_API_TIMEOUT` env override was
  added — the issue's "better" option was left for a follow-up if
  wanted; a bounded, generous client timeout fully resolves the
  reported symptom.

Closes #1832