### PR TITLE
fix(providers): honor a configured slot ceiling over the blanket dense cap

### DIFF
--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1195,6 +1195,12 @@ def _profile_runtime_family(slot_cfg: dict[str, Any]) -> str | None:
 # GGUF arch max, cap dense models so an unconfigured slot can't request an
 # impractically large KV cache, and otherwise use a safe floor. Mirrors
 # hal0.hardware.recommend's installer-side policy.
+#
+# _CTX_DENSE_CAP is an UNCONFIGURED-slot guard, not a hardware fact — see
+# _dense_cap_for. A slot that pins its own [model].context_size is by
+# definition configured, and applying this blanket constant *underneath* that
+# number is what shipped every fresh install at 32768 despite three seeds
+# asking for 65536 (#1827).
 _CTX_SAFE_FALLBACK = 8192
 _CTX_DENSE_CAP = 32768
 
@@ -1300,6 +1306,63 @@ def _native_ctx(model_info: dict[str, Any]) -> int | None:
     return None
 
 
+def _slot_ceiling_int(slot_ceiling: Any) -> int | None:
+    """The slot's ``[model].context_size`` as an int, or None when unusable.
+
+    The slot table reaches :func:`_resolve_context_size` as a raw dict straight
+    off the TOML — no schema validation between disk and here — so a
+    hand-edited ``context_size = "64k"`` used to take the launch path out with a
+    ``ValueError``. Unusable means ABSENT: the slot simply expresses no ceiling,
+    exactly like a slot that never wrote one.
+    """
+    if slot_ceiling is None:
+        return None
+    try:
+        return int(slot_ceiling)
+    except (TypeError, ValueError):
+        log.warning(
+            "slot.context_size_unparseable_ceiling",
+            extra={
+                "raw": repr(slot_ceiling),
+                "hint": "the slot's [model].context_size is not a number; ignoring it "
+                "and letting the model's own window decide. Fix it in the slot drawer.",
+            },
+        )
+        return None
+
+
+def _dense_cap_for(slot_ceiling: int | None) -> int:
+    """The cap to apply to a DERIVED (native/curated) window for this slot.
+
+    :data:`_CTX_DENSE_CAP` exists so an **unconfigured** slot cannot ask for an
+    impractically large KV cache off the back of a 131072/262144-token arch max.
+    It is a blanket constant: hardware-independent, box-independent and —
+    the bug — configuration-independent.
+
+    #1827: a slot with an on-disk ``[model].context_size`` is *configured*. That
+    number was written either by the installer as a hardware budget
+    (:func:`hal0.install.orchestrate._clamp_context_size`), by a shipped seed, or
+    by an operator in the slot drawer. Applying the 32768 constant underneath it
+    meant a fresh install resolved every installer-pulled model to 32768 no
+    matter what the slot asked for — ``installer/etc-hal0/slots/{agent,brain,
+    utility}.toml`` all ask for 65536, and all three silently launched (and,
+    post-#1802, honestly advertised) 32768. That is below the bundled Hermes
+    agent's hard 64,000 floor, so ``hermes -z`` could not start on a box
+    straight out of ``install.sh``.
+
+    So: when a ceiling is on disk, it *is* the cap. The result stays bounded
+    twice over — never above the model's own native window, and never above the
+    ceiling itself (the caller's clamp) — so a slot can only reach a window that
+    BOTH the model supports and the box was explicitly configured for. With no
+    ceiling on disk nothing is configured and the blanket cap still applies,
+    which keeps :data:`hal0.slots.capacity._DEFAULT_CTX_TOKENS` (the
+    unpinned-slot budget estimate) correct as written.
+    """
+    if slot_ceiling is None:
+        return _CTX_DENSE_CAP
+    return max(_CTX_DENSE_CAP, slot_ceiling)
+
+
 def _resolve_context_size(
     slot_ceiling: int | None,
     model_info: dict[str, Any],
@@ -1318,10 +1381,11 @@ def _resolve_context_size(
        but an unparseable or implausible value is ignored rather than launched
        (#1414; see :data:`_CTX_MIN_PLAUSIBLE`).
     2. ``model_info["metadata"]["context_length"]`` — the GGUF-derived native
-       window (:func:`_native_ctx`), dense-capped at :data:`_CTX_DENSE_CAP`.
-       Still a model fact, but a *derived* one, so an explicit choice outranks
-       it — the reverse of the pre-1.0 order, which let a 262144-token arch max
-       shadow a deliberate ``defaults.context_size``.
+       window (:func:`_native_ctx`), dense-capped at :func:`_dense_cap_for`
+       (:data:`_CTX_DENSE_CAP`, or the slot's own configured ceiling when that
+       is higher — #1827). Still a model fact, but a *derived* one, so an
+       explicit choice outranks it — the reverse of the pre-1.0 order, which let
+       a 262144-token arch max shadow a deliberate ``defaults.context_size``.
     3. :data:`_CTX_SAFE_FALLBACK` (8192) — never llama-server's silent 4096.
 
     ``slot_ceiling`` (the on-disk ``[model].context_size``) is NO LONGER an
@@ -1337,29 +1401,37 @@ def _resolve_context_size(
 
     Net effect on a box that already has a slot-level ``context_size`` on disk:
     where the clamp was below the model's window (the installer's case) the
-    effective context is UNCHANGED; where the slot was silently inflating the
-    model's window (the dual-ownership bug) it drops to what the model asked
-    for. The effective context can therefore only stay the same or shrink —
-    never grow — so no box gains a KV cache it cannot hold. Every case where
-    the ceiling actually changes the answer is logged, so the change is visible
-    in ``journalctl -u hal0-api`` rather than silent.
+    effective context is UNCHANGED; where the slot was silently inflating a
+    model's EXPLICIT window (the dual-ownership bug) it drops to what the model
+    asked for. The one case where the ceiling can RAISE the answer is the
+    *derived* window (path 2): there the ceiling replaces the blanket dense cap
+    instead of being applied under it (:func:`_dense_cap_for`, #1827), so the
+    slot gets the window its own config asked for — still bounded by the
+    model's native window, still never above the ceiling, and never reached at
+    all on a slot with no ceiling written. Every case where the ceiling changes
+    the answer is logged, so the change is visible in ``journalctl -u hal0-api``
+    rather than silent.
 
     Guarantees a non-None int.
     """
+    ceiling = _slot_ceiling_int(slot_ceiling)
+
     declared = _model_declared_ctx(model_info)
     if declared is not None:
         resolved, source = declared, "model.defaults.context_size"
     else:
         native = _native_ctx(model_info)
         if native:
-            resolved, source = min(native, _CTX_DENSE_CAP), "model.metadata.context_length"
+            resolved, source = (
+                min(native, _dense_cap_for(ceiling)),
+                "model.metadata.context_length",
+            )
         else:
             resolved, source = _CTX_SAFE_FALLBACK, "safe_fallback"
 
-    if slot_ceiling is None:
+    if ceiling is None:
         return resolved
 
-    ceiling = int(slot_ceiling)
     if ceiling < resolved:
         log.info(
             "slot.context_size_clamped_by_slot",

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -1293,7 +1293,7 @@ def _native_ctx(model_info: dict[str, Any]) -> int | None:
             return int(md["context_length"])
         except (TypeError, ValueError):
             pass
-    model_id = model_info.get("_model_key")
+    model_id = model_info.get("_model_key") or model_info.get("id")
     if model_id:
         try:
             from hal0.registry.curated import get_curated
@@ -1314,11 +1314,24 @@ def _slot_ceiling_int(slot_ceiling: Any) -> int | None:
     hand-edited ``context_size = "64k"`` used to take the launch path out with a
     ``ValueError``. Unusable means ABSENT: the slot simply expresses no ceiling,
     exactly like a slot that never wrote one.
+
+    Implausible means unusable too, on the same
+    ``[_CTX_MIN_PLAUSIBLE, _CTX_MAX_PLAUSIBLE]`` range the MODEL path screens
+    against (:func:`_model_declared_ctx`). This matters more now than it did
+    when the ceiling could only clamp down: under #1827 the ceiling REPLACES
+    the dense cap on the derived path, so a hand-written ``context_size =
+    99999999`` (or a row persisted before the API's
+    ``model.context_size_out_of_range`` screen existed) would hand a 262144-
+    native model the very impractically-large KV cache :data:`_CTX_DENSE_CAP`
+    exists to prevent — #1108's first-warm OOM. ``0`` and ``-1`` are screened
+    here for the same reason: they are not a ceiling of zero, they are a slot
+    that never wrote one, and passing them through to ``--ctx-size`` is a slot
+    that never warms.
     """
     if slot_ceiling is None:
         return None
     try:
-        return int(slot_ceiling)
+        value = int(slot_ceiling)
     except (TypeError, ValueError):
         log.warning(
             "slot.context_size_unparseable_ceiling",
@@ -1329,6 +1342,20 @@ def _slot_ceiling_int(slot_ceiling: Any) -> int | None:
             },
         )
         return None
+    if not (_CTX_MIN_PLAUSIBLE <= value <= _CTX_MAX_PLAUSIBLE):
+        log.warning(
+            "slot.context_size_implausible_ceiling",
+            extra={
+                "value": value,
+                "min": _CTX_MIN_PLAUSIBLE,
+                "max": _CTX_MAX_PLAUSIBLE,
+                "hint": "the slot's [model].context_size is outside the plausible range; "
+                "ignoring it and letting the model's own window decide. Fix it in the "
+                "slot drawer.",
+            },
+        )
+        return None
+    return value
 
 
 def _dense_cap_for(slot_ceiling: int | None) -> int:
@@ -1448,6 +1475,13 @@ def _resolve_context_size(
         )
         return ceiling
     if ceiling > resolved:
+        # Two different situations share this branch, and the hint has to say
+        # which one it is. On the DERIVED path the ceiling already won as far
+        # as it can (#1827) and the remaining limit is the model's real native
+        # window — telling that operator to "set the window on the model" would
+        # invite them to write a defaults.context_size ABOVE what the GGUF
+        # actually supports, which is not dense-capped.
+        derived = source == "model.metadata.context_length"
         log.warning(
             "slot.context_size_no_longer_overrides",
             extra={
@@ -1456,9 +1490,15 @@ def _resolve_context_size(
                 "model_ctx_source": source,
                 "slot_context_size": ceiling,
                 "effective": resolved,
-                "hint": "the MODEL owns context size in 1.0; this slot's larger "
-                "[model].context_size no longer wins. Set the window on the model to "
-                "restore it.",
+                "hint": (
+                    "clamped to the model's native window; this slot's larger "
+                    "[model].context_size cannot conjure context the model does not "
+                    "support."
+                    if derived
+                    else "the MODEL owns context size in 1.0; this slot's larger "
+                    "[model].context_size no longer wins. Set the window on the model to "
+                    "restore it."
+                ),
             },
         )
     return resolved
@@ -1572,6 +1612,19 @@ def resolve_effective_context_size(
                 model_info = entry.model_dump() if hasattr(entry, "model_dump") else dict(entry)
             except Exception:
                 model_info = {}
+    # The launch path stamps ``_model_key`` onto the info dict it builds
+    # (:mod:`hal0.slots.manager`, :func:`_best_effort_model_info`);
+    # ``Model.model_dump()`` does NOT — it is not a
+    # field on :class:`hal0.registry.model.Model` and pydantic would not accept
+    # a leading-underscore one. Without this line the read-only surfaces reach
+    # :func:`_native_ctx` with no model id, so the #1617 curated backfill can
+    # never fire here and an empty-``metadata`` registry row advertises the
+    # 8192 safe floor while llama-server is launched with the real window.
+    # That is the Hermes-visible number (``/v1/models``,
+    # ``api.__init__._slot_ctx_size``, the SlotView aggregator), so the gate it
+    # refuses on was the advertised one, not the served one.
+    if model_id:
+        model_info.setdefault("_model_key", model_id)
     return _resolve_context_size(slot_ceiling, model_info, slot_name=slot_name)
 
 

--- a/tests/install/test_static_seeds.py
+++ b/tests/install/test_static_seeds.py
@@ -8,9 +8,14 @@ copy-if-absent contract independently of the lifespan wiring.
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
+import pytest
+
+from hal0.install.brain_model import BRAIN_MODEL_IDS
 from hal0.install.static_seeds import STATIC_SEED_SLOTS, seed_static_slots
+from hal0.providers.container import _resolve_context_size
 
 
 def _fake_installer_root(tmp_path: Path, names: tuple[str, ...] = STATIC_SEED_SLOTS) -> Path:
@@ -116,3 +121,51 @@ def test_seed_static_slots_default_args_seed_real_tree(tmp_path: Path) -> None:
     dest = tmp_path / "slots"
     seeded = seed_static_slots(slots_dir=dest)
     assert set(seeded) == set(STATIC_SEED_SLOTS)
+
+
+# ── #1827: a shipped seed must actually deliver the window it asks for ────────
+#
+# The seed TOML is only half the contract — providers.container._resolve_context_size
+# decides what a slot LAUNCHES with. rc.5 shipped three seeds asking for 65536
+# that all launched at 32768, because the derived-window path applied a blanket
+# dense cap underneath the seeded ceiling. 32768 is below Hermes' hard 64,000
+# floor, so the bundled agent could not start on a fresh install at all.
+#
+# This walks the real shipped TOMLs through the real resolver with the model
+# shape a fresh install actually produces (an installer-pulled brain model: a
+# native window off the curated catalogue, no explicit defaults.context_size),
+# so either half drifting back down fails here instead of on a box.
+
+#: ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH`` in the bundled Hermes.
+_HERMES_MIN_CONTEXT = 64_000
+
+#: Seeds the bundled Hermes agent can be pointed at: ``hal0/agent`` (which falls
+#: back to ``brain`` while the agent slot is model-less), ``hal0/brain``, and
+#: ``hal0/utility`` — the three chat surfaces an operator is told to try.
+_HERMES_REACHABLE_SEEDS = ("agent", "brain", "utility")
+
+
+def _seed_ceiling(name: str) -> int | None:
+    repo_root = Path(__file__).resolve().parents[2]
+    raw = (repo_root / "installer" / "etc-hal0" / "slots" / f"{name}.toml").read_bytes()
+    return tomllib.loads(raw.decode("utf-8")).get("model", {}).get("context_size")
+
+
+@pytest.mark.parametrize("slot_name", _HERMES_REACHABLE_SEEDS)
+@pytest.mark.parametrize("model_id", BRAIN_MODEL_IDS)
+def test_shipped_seed_resolves_above_the_hermes_floor(slot_name: str, model_id: str) -> None:
+    ceiling = _seed_ceiling(slot_name)
+    assert ceiling is not None, f"{slot_name}.toml lost its [model].context_size"
+    assert ceiling >= _HERMES_MIN_CONTEXT, (
+        f"{slot_name}.toml asks for {ceiling}, below Hermes' {_HERMES_MIN_CONTEXT} floor"
+    )
+    # A freshly pulled row: the curated catalogue supplies the native window
+    # (directly, or via the #1617 backfill while metadata is still empty), and
+    # nothing on the install path stamps a model-level context size.
+    model_info = {"_model_key": model_id, "metadata": {}, "defaults": {"context_size": None}}
+    effective = _resolve_context_size(ceiling, model_info, slot_name=slot_name)
+    assert effective >= _HERMES_MIN_CONTEXT, (
+        f"{slot_name} seed asks for {ceiling} but resolves to {effective} "
+        f"with model {model_id} — below Hermes' floor, so `hermes -z` cannot start"
+    )
+    assert effective == ceiling

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -40,6 +40,7 @@ from hal0.providers.container import (
     _MODEL_STORE_MOUNT,
     _UNIT_STOP_TIMEOUT_S,
     ContainerProvider,
+    _best_effort_model_info,
     _container_runtime,
     _image_mismatch,
     _llama_argv_segments,
@@ -51,6 +52,7 @@ from hal0.providers.container import (
     resolve_effective_context_size,
     resolved_command_for_slot,
 )
+from hal0.registry.model import Model
 from hal0.slots.argv import resolve_argv
 
 # Podman is the only supported runtime under Quadlet; the shims below ignore
@@ -1375,6 +1377,11 @@ class TestContextSizeOwnership:
 #: it does not degrade, so a slot that lands under this is a cannot-chat box.
 _HERMES_MIN_CONTEXT = 64_000
 
+#: A curated brain pick whose catalogue row carries a ``context_length`` but
+#: whose registry row on an older-build box carries no ``metadata`` at all
+#: (#1617). This is the shape the curated backfill exists for.
+_CURATED_BRAIN_ID = "hal0-brain-sft-q8-rocmfpx"
+
 
 class TestDenseCapDoesNotUndercutAConfiguredSlot:
     """#1827 — the dense cap is an UNCONFIGURED-slot guard, not a hardware fact.
@@ -1430,8 +1437,15 @@ class TestDenseCapDoesNotUndercutAConfiguredSlot:
     def test_curated_backfill_path_also_clears_the_floor(self) -> None:
         """The #1617 self-heal shape (registry row with empty ``metadata``,
         window recovered from the curated catalogue) is what a box pulled by an
-        older build actually has, so it must clear the floor too."""
-        mi = _model_info(_model_key="hal0-brain-sft-q8-rocmfpx", metadata={})
+        older build actually has, so it must clear the floor too.
+
+        Deliberately built from a REAL :class:`hal0.registry.model.Model` dump
+        rather than a hand-written dict: the only thing this shape has to
+        identify the model by is whatever ``model_dump()`` actually emits.
+        """
+        mi = dict(Model(id=_CURATED_BRAIN_ID, path="/mnt/ai-models/brain.gguf").model_dump())
+        mi["_model_key"] = _CURATED_BRAIN_ID  # what slots/manager stamps at launch
+        assert mi.get("metadata") in ({}, None)
         assert _resolve_context_size(65536, mi, slot_name="brain") >= _HERMES_MIN_CONTEXT
 
     def test_unpinned_slot_is_still_dense_capped(self) -> None:
@@ -1480,6 +1494,20 @@ class TestDenseCapDoesNotUndercutAConfiguredSlot:
         derived window falls back to the blanket cap instead of the launch path
         dying on an ``int()`` of ``"64k"``."""
         mi = _model_info(metadata={"context_length": 131072})
+        assert _resolve_context_size(bad, mi) == _CTX_DENSE_CAP
+
+    @pytest.mark.parametrize("bad", [0, -1, 99999999, 2**24 + 1, 127])
+    def test_implausible_ceiling_falls_back_to_the_blanket_cap(self, bad: int) -> None:
+        """Now that the ceiling REPLACES the dense cap on the derived path, an
+        implausible one has to be screened on the same
+        ``[_CTX_MIN_PLAUSIBLE, _CTX_MAX_PLAUSIBLE]`` range the model path uses.
+        ``ModelConfig.context_size`` has ``ge=128`` and no upper bound, and rows
+        written before the API's ``model.context_size_out_of_range`` screen are
+        still readable — so ``99999999`` really is on disk somewhere, and it
+        would hand a 262144-native model exactly the impractical KV cache
+        :data:`_CTX_DENSE_CAP` exists to prevent (#1108's first-warm OOM).
+        ``0``/``-1`` are a slot that never warms rather than a ceiling."""
+        mi = _model_info(metadata={"context_length": 262144})
         assert _resolve_context_size(bad, mi) == _CTX_DENSE_CAP
 
 
@@ -1547,6 +1575,79 @@ class TestResolveEffectiveContextSize:
 
     def test_always_returns_a_positive_int(self) -> None:
         assert isinstance(resolve_effective_context_size(None, None, ""), int)
+
+
+class TestAdvertisedWindowMatchesTheServedWindow:
+    """#1827 — the number Hermes gates on is the ADVERTISED one.
+
+    Hermes reads ``/v1/models``, which (like ``api.__init__._slot_ctx_size``
+    and the SlotView aggregator) goes through
+    :func:`resolve_effective_context_size`, NOT through the launch path. That
+    wrapper builds its ``model_info`` from ``Model.model_dump()`` — and
+    ``_model_key`` is not a field on :class:`hal0.registry.model.Model`; only
+    the launch path stamps it. So the #1617 curated backfill was unreachable
+    from the read-only side: an empty-``metadata`` registry row (every box
+    provisioned before #1657/#1707 stamped ``metadata.context_length``)
+    advertised the 8192 safe floor while llama-server was launched with the
+    real window. Hermes still refused, just with a different number.
+
+    These tests must use a REAL pydantic ``Model``. Hand-stamping
+    ``_model_key`` onto a literal dict tests a shape the read-only path can
+    never produce, and passes with or without the fix.
+    """
+
+    @staticmethod
+    def _registry(model: Model) -> Any:
+        class _Registry:
+            def get(self, model_id: str) -> Any:
+                if model_id != model.id:
+                    raise KeyError(model_id)
+                return model
+
+        return _Registry()
+
+    @staticmethod
+    def _ctx(command: list[str]) -> str | None:
+        return command[command.index("--ctx-size") + 1] if "--ctx-size" in command else None
+
+    def test_curated_backfill_is_reachable_from_the_read_only_surface(self) -> None:
+        """THE REGRESSION: registry row with no metadata, seed ceiling 65536.
+        Without the fix this returns 8192 and Hermes refuses."""
+        model = Model(id=_CURATED_BRAIN_ID, path="/mnt/ai-models/brain.gguf")
+        assert not model.model_dump().get("metadata")
+        advertised = resolve_effective_context_size(
+            65536, self._registry(model), _CURATED_BRAIN_ID, slot_name="brain"
+        )
+        assert advertised == 65536
+        assert advertised >= _HERMES_MIN_CONTEXT
+
+    def test_advertised_equals_what_llama_server_is_launched_with(self) -> None:
+        """The two halves of #1802's honest-advertising contract, both driven
+        off the same registry entry through their own real code paths."""
+        model = Model(id=_CURATED_BRAIN_ID, path="/mnt/ai-models/brain.gguf")
+        cfg = _slot_cfg(model={"default": _CURATED_BRAIN_ID, "context_size": 65536})
+        registry = self._registry(model)
+
+        advertised = resolve_effective_context_size(
+            65536, registry, _CURATED_BRAIN_ID, slot_name="brain"
+        )
+        with (
+            patch("hal0.registry.store.ModelRegistry", lambda *a, **k: registry),
+            patch(
+                "hal0.providers.container._resolve_profile",
+                return_value=_moe_profile(),
+            ),
+        ):
+            served = self._ctx(
+                ContainerProvider().container_spec(cfg, _best_effort_model_info(cfg)).command
+            )
+        assert served == str(advertised) == "65536"
+
+    def test_registry_entry_without_an_id_key_still_degrades_safely(self) -> None:
+        """A duck-typed entry whose ``model_dump()`` omits both ``id`` and
+        ``metadata`` has nothing to look up — the safe floor, not a crash."""
+        registry = _FakeCtxRegistry({"m": _FakeCtxModel(None)})
+        assert resolve_effective_context_size(65536, registry, "m") == _CTX_SAFE_FALLBACK
 
 
 class TestFamilyDefaults:

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -1370,6 +1370,119 @@ class TestContextSizeOwnership:
         assert self._ctx(self._spec(cfg, mi).command) == str(_CTX_SAFE_FALLBACK)
 
 
+#: Hermes' hard gate — ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH`` in the
+#: bundled agent. Below it the agent REFUSES TO START (``agent_init.py`` raises);
+#: it does not degrade, so a slot that lands under this is a cannot-chat box.
+_HERMES_MIN_CONTEXT = 64_000
+
+
+class TestDenseCapDoesNotUndercutAConfiguredSlot:
+    """#1827 — the dense cap is an UNCONFIGURED-slot guard, not a hardware fact.
+
+    A fresh 1.0.0-rc.5 install could not run the bundled Hermes agent at all.
+    The installer-pulled brain model carries no ``defaults.context_size``, so
+    its window came from the DERIVED native path — where the blanket 32768
+    dense cap was applied *underneath* the shipped seed's ``context_size =
+    65536``. Every seeded chat slot therefore launched (and, post-#1802,
+    honestly advertised) 32768 no matter what the seed asked for and no matter
+    how much memory the box had. 32768 < 64000, so ``hermes -z`` hard-errored.
+
+    The seed ceiling is by definition *configured* state: written either by the
+    installer's hardware budget (:func:`hal0.install.orchestrate._clamp_context_size`)
+    or by an operator. Honoring it as the cap for the derived window restores
+    the pre-1.0 effective window for exactly these slots, while every other
+    guarantee holds: never above the model's native window, never above the
+    ceiling, and unchanged for a slot with no ceiling on disk.
+    """
+
+    def _spec(self, cfg: dict[str, Any], model_info: dict[str, Any]):
+        provider = ContainerProvider()
+        with patch(
+            "hal0.providers.container._resolve_profile",
+            return_value=_moe_profile(),
+        ):
+            return provider.container_spec(cfg, model_info)
+
+    @staticmethod
+    def _ctx(command: list[str]) -> str | None:
+        return command[command.index("--ctx-size") + 1] if "--ctx-size" in command else None
+
+    def test_fresh_install_brain_slot_clears_the_hermes_floor(self) -> None:
+        """THE REGRESSION: shipped seed ceiling 65536 + an installer-pulled
+        model with a 131072 native window and no explicit context size."""
+        mi = _model_info(
+            _model_key="hal0-brain-sft-f16",
+            metadata={"context_length": 131072},
+            defaults={"context_size": None},
+        )
+        resolved = _resolve_context_size(65536, mi, slot_name="brain")
+        assert resolved == 65536
+        assert resolved >= _HERMES_MIN_CONTEXT
+
+    def test_configured_ceiling_reaches_the_launch_command(self) -> None:
+        """End-to-end through ``container_spec``: ``--ctx-size 65536`` is what
+        llama-server actually serves, so #1802's honest ``/v1/models``
+        advertising reports the same number Hermes gates on."""
+        cfg = _slot_cfg(model={"default": "m.gguf", "context_size": 65536})
+        mi = _model_info(metadata={"context_length": 131072})
+        assert self._ctx(self._spec(cfg, mi).command) == "65536"
+
+    def test_curated_backfill_path_also_clears_the_floor(self) -> None:
+        """The #1617 self-heal shape (registry row with empty ``metadata``,
+        window recovered from the curated catalogue) is what a box pulled by an
+        older build actually has, so it must clear the floor too."""
+        mi = _model_info(_model_key="hal0-brain-sft-q8-rocmfpx", metadata={})
+        assert _resolve_context_size(65536, mi, slot_name="brain") >= _HERMES_MIN_CONTEXT
+
+    def test_unpinned_slot_is_still_dense_capped(self) -> None:
+        """No ceiling on disk means nothing is configured, so the blanket cap
+        still applies — the invariant :data:`hal0.slots.capacity._DEFAULT_CTX_TOKENS`
+        budgets against."""
+        mi = _model_info(metadata={"context_length": 131072})
+        assert _resolve_context_size(None, mi) == _CTX_DENSE_CAP
+
+    @pytest.mark.parametrize("ceiling", [4096, 8192, 16384, 32768])
+    def test_ceiling_below_the_dense_cap_is_unchanged(self, ceiling: int) -> None:
+        """The installer's VRAM-budget clamp (#1108) is untouched: a ceiling at
+        or below the dense cap still wins outright."""
+        mi = _model_info(metadata={"context_length": 131072})
+        assert _resolve_context_size(ceiling, mi) == ceiling
+
+    def test_never_exceeds_the_models_native_window(self) -> None:
+        """A generous ceiling cannot conjure context the model does not have."""
+        mi = _model_info(metadata={"context_length": 40960})
+        assert _resolve_context_size(131072, mi) == 40960
+
+    @pytest.mark.parametrize("ceiling", [128, 4096, 32768, 65536, 131072, 262144])
+    def test_never_exceeds_the_configured_ceiling(self, ceiling: int) -> None:
+        """Property: for a derived window, effective <= ceiling always, so a
+        slot can only reach a window the box was explicitly configured for."""
+        mi = _model_info(metadata={"context_length": 262144})
+        assert _resolve_context_size(ceiling, mi) <= ceiling
+
+    def test_explicit_model_window_still_outranks_the_ceiling(self) -> None:
+        """Unchanged: the ceiling replaces the dense cap only on the DERIVED
+        path. An explicit model window is authoritative and is still only
+        clamped down by the ceiling, never raised by it."""
+        mi = _model_info(metadata={"context_length": 131072}, defaults={"context_size": 16384})
+        assert _resolve_context_size(65536, mi) == 16384
+
+    def test_no_model_window_at_all_still_uses_the_safe_floor(self) -> None:
+        """A slot ceiling is not evidence about the model, so it cannot inflate
+        the 8192 safe fallback either."""
+        mi = _model_info(_model_key="some-operator-pulled-custom-model", metadata={})
+        assert _resolve_context_size(65536, mi) == _CTX_SAFE_FALLBACK
+
+    @pytest.mark.parametrize("bad", ["nonsense", "", [65536], {}])
+    def test_unparseable_ceiling_falls_back_to_the_blanket_cap(self, bad: Any) -> None:
+        """A garbage hand-edited ``[model].context_size`` is not a configuration
+        signal — the slot table reaches this resolver unvalidated, so the
+        derived window falls back to the blanket cap instead of the launch path
+        dying on an ``int()`` of ``"64k"``."""
+        mi = _model_info(metadata={"context_length": 131072})
+        assert _resolve_context_size(bad, mi) == _CTX_DENSE_CAP
+
+
 class _FakeCtxDefaults:
     def __init__(self, context_size: int | None) -> None:
         self.context_size = context_size


### PR DESCRIPTION
## What changed

`providers.container._resolve_context_size` no longer applies the blanket
`_CTX_DENSE_CAP = 32768` *underneath* a slot's on-disk `[model].context_size`.
For the DERIVED window path (the model declares no `defaults.context_size`, so
the window comes from the GGUF arch max / curated catalogue) the cap is now the
slot's own configured ceiling when one is written — `_dense_cap_for()`.

Also: a garbage hand-edited ceiling (`context_size = "64k"`) is now treated as
absent rather than taking the launch path out with a `ValueError` — the slot
table reaches this resolver as a raw dict with no schema validation in between,
and I now read it one step earlier. An *implausible* ceiling is screened the
same way, on the same `[_CTX_MIN_PLAUSIBLE, _CTX_MAX_PLAUSIBLE]` range the model
path uses: now that the ceiling REPLACES the dense cap on the derived path, a
hand-written (or pre-screen, still-readable) `99999999` would hand a
262144-native model exactly the impractical KV cache `_CTX_DENSE_CAP` exists to
prevent (#1108's first-warm OOM), and `0`/`-1` are a slot that never warms
rather than a ceiling of zero.

### Second commit — the advertised window has to reach the same backfill

The read-only surfaces Hermes actually gates on (`/v1/models`,
`api.__init__._slot_ctx_size`, the SlotView aggregator) go through
`resolve_effective_context_size`, which builds its `model_info` from
`entry.model_dump()`. `_model_key` is **not** a field on
`registry.model.Model` — only the launch path stamps it — so `_native_ctx`
reached the read-only path with no model id and the #1617 curated backfill
could never fire there. Measured on this branch before the second commit, on
ct152 against its real registry entry with `metadata` emptied to the
older-build shape: **advertised 8192, served 65536**. Hermes would still have
refused, just with a different number. Fixed by stamping `_model_key` in the
wrapper (and letting `_native_ctx` fall back to the `id` key a `model_dump()`
does carry).

The `slot.context_size_no_longer_overrides` warning is also now
derived-path-aware. On that path the ceiling already won as far as it can and
the remaining limit is the model's native window; the old hint ("set the window
on the model to restore it") invited the operator to write a
`defaults.context_size` above what the GGUF actually supports, which is not
dense-capped.

## Why (root cause)

`Refs #1827` (deliberately NOT `Closes` — see "What this does not fix") — on a fresh 1.0.0-rc.5 install the bundled Hermes agent could
not start at all:

```
Model hal0/agent has a context window of 32,768 tokens, which is below the
minimum 64,000 required by Hermes Agent.
```

The installer-pulled brain model carries no `defaults.context_size`, so its
window came from the derived path: `min(native 131072, 32768)` = 32768. The
shipped seeds `installer/etc-hal0/slots/{agent,brain,utility}.toml` all ask for
`context_size = 65536`, but under the v1.0 ownership flip the slot value is a
ceiling that can only clamp DOWN — so 65536 could never be reached and all
three slots launched (and, after #1802's honest advertising, reported) 32768.
That is below Hermes' hard `MINIMUM_CONTEXT_LENGTH = 64_000`, which raises
rather than degrades.

The root defect is that `_CTX_DENSE_CAP` is an **unconfigured-slot** guard —
it exists so a slot nobody tuned can't request a 262144-token KV cache — but it
was being applied to *configured* slots too. A ceiling on disk is written by the
installer's hardware budget (`install.orchestrate._clamp_context_size`), by a
shipped seed, or by an operator; it is by definition a configuration signal.
The shipped configuration and the resolver disagreed, and the resolver silently
won. This is hardware-independent, so a fresh GPU install hit it identically.

Fixing it at the resolver rather than by stamping `defaults.context_size` on the
pulled model means it self-heals on upgraded boxes too, with no migration step,
and it does not require lying to Hermes: llama-server actually gets
`--ctx-size 65536`, so what `/v1/models` advertises is what is served.

## Invariants preserved

- Never above the model's native window (a big ceiling can't conjure context).
- Never above the ceiling itself.
- A slot with **no** ceiling on disk is unchanged — still `min(native, 32768)`,
  which is what `slots.capacity._DEFAULT_CTX_TOKENS` budgets against.
- A ceiling at or below 32768 still wins outright (#1108's VRAM clamp intact).
- An explicit `defaults.context_size` on the model is still authoritative and
  is still only clamped down by the ceiling, never raised by it.
- The `safe_fallback` 8192 path is unchanged — a ceiling is not evidence about
  the model.

## Verification

### On-box (ct152, 10.0.1.152, rc.5, restored to its rc.5 baseline afterwards)

Branch `container.py` dropped into `/usr/lib/hal0/venv/.../hal0/providers/`,
`hal0-api` restarted:

| | rc.5 baseline | this branch |
|---|---|---|
| `/v1/models` → `brain`, `utility` | `32768` | **`65536`** |
| wrapper vs the real registry row | `32768` | `65536` |
| wrapper vs the same row with `metadata={}` (older-build shape) | **`8192`** | **`65536`** |
| rendered quadlet after a slot restart | `--ctx-size 32768` | `--ctx-size 65536` |
| llama-server `/props` → `n_ctx` | — | **`65536`** |
| `hermes -z "reply with OK"` | timed out (see below) | **exit 0, answered `OK`** |

So the advertised number, the rendered argv and the window llama-server reports
back all agree at 65536, above Hermes' 64,000 floor, on a real box. The rc.5
baseline `hermes -z` run timed out rather than emitting the context-window
refusal string, so that one cell is not a clean negative control — the refusal
itself is documented on ct151/ct150 in #1827. The box was restored to its rc.5
baseline afterwards (file checksum verified, temp files removed, `utility`
quadlet re-rendered back to `--ctx-size 32768`).

### Tests

- New regression tests, red before the fix and green after:
  - `tests/providers/test_container.py::TestDenseCapDoesNotUndercutAConfiguredSlot`
    (11 cases: the fresh-install shape, end-to-end `--ctx-size` through
    `container_spec`, the #1617 curated-backfill shape, and each invariant above)
  - `tests/providers/test_container.py::TestAdvertisedWindowMatchesTheServedWindow`
    — the second commit's coverage, driven through the PUBLIC wrapper against a
    real pydantic `Model` (no hand-stamped `_model_key`, which is a shape the
    read-only path can never produce), plus an equality test that the advertised
    number and the `--ctx-size` `container_spec` emits are the same number.
    Verified red on the unfixed branch: `assert '65536' == '8192'`.
  - `tests/install/test_static_seeds.py::test_shipped_seed_resolves_above_the_hermes_floor`
    — walks the REAL shipped `agent`/`brain`/`utility` TOMLs through the REAL
    resolver against each `BRAIN_MODEL_IDS` pick, so either half of the contract
    drifting back under 64,000 fails in CI instead of on a box.
- `uv run --extra dev pytest tests/providers tests/install tests/slots tests/api`
  → **3285 passed, 1 skipped** (no hermes
  needed by the new tests).
- `uv run ruff check src tests` → clean; `uv run ruff format --check src tests` → clean.

## What this does NOT fix — why `Refs`, not `Closes`

#1827 must stay open. The issue thread's ct150 comment documents a second,
independent path to the same refusal that this change does nothing for: a box
where the model already carries `defaults.context_size = 96000` and the agent
slot's own ceiling is `4096`, so the effective window is 4096 and Hermes refuses
anyway. A ceiling-aware dense cap cannot help when the ceiling is the thing that
is too low. Behind it sit two defects — in-place upgrades never reconcile a slot
seed the operator never chose, and nothing preflights the anchor window before
handing it to Hermes.

Filed as **#1867**, which #1827 should be closed against together with this PR.

For the same reason the claim that this "self-heals upgraded boxes with no
migration step" is scoped: it does, but only where the existing ceiling is
already >= 64K (or absent). A box carrying an old 4096 ceiling stays broken
until #1867 lands.

## Deliberately out of scope

- **Filed as #1868:** `hardware/recommend._resolve_primary_ctx`'s own `_DENSE_CTX_CAP = 32768` is
  untouched. It writes a *ceiling* for the recommended primary slot, and with
  this change that ceiling is now honored as written — but the Hermes-reachable
  slots are the static seeds, not the primary recommendation. Raising the
  recommender's dense policy is a separate tuning call.
- **Filed as #1868:** static seeds are still copied verbatim by `install.sh` without a
  hardware-budget clamp. A tiny box therefore now gets the 65536 the seed always
  asked for (and that pre-1.0 hal0 actually served) rather than an accidental
  32768. Hardware-clamping the static seeds at install time is a real follow-up,
  but it is a different change with a different blast radius.
- `agent` being absent from `/v1/models` (model-less llm slots are omitted by
  design) is incidental to this issue and left alone.
- No CHANGELOG hunk, per the wave rule (#1545).
