### PR TITLE
fix(slots): infer the capability profile a slot's type requires at create (#1830)

### DIFF
--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -81,6 +81,18 @@ hal0 slot create embed \
 
 6. **`--ctx-size`** — context window in tokens (default `4096`).
 
+7. **`--profile`** — the runtime profile (flag bundle + engine). Omit it
+   and hal0 infers the profile the slot's `--type` implies: `embedding` →
+   `embedding` (`--embedding`), `reranking` → `reranking`
+   (`--reranking`), `tts`/`transcription` → the engine for the chosen
+   device, `image` → `comfyui`. That inference is what makes a capability
+   slot actually serve its endpoint — an `embedding` slot with no
+   `--embedding` flag loads to `ready` and returns HTTP 501 from
+   `/v1/embeddings`. An `llm` slot infers nothing: no mode flag is at
+   stake, so its tune stays the model's (or yours). Change a slot's
+   profile later with `hal0 slot edit <name> --profile <profile>` or the
+   slot drawer.
+
 </Steps>
 
 Creating a slot writes its config and systemd drop-in but does **not**
@@ -180,11 +192,22 @@ setting one) is how you take a slot out of rotation without deleting it.
 ```sh
 hal0 slot edit agent --ctx-size 32768
 hal0 slot edit embed --hardware rocm
+hal0 slot edit rerank --profile reranking
 ```
 
 Pass any subset of `--model`, `--port`, `--ctx-size`, `--provider`,
-`--hardware`. At least one is required. Changes the container baked in
-(port, hardware grid) take effect on the next `restart`.
+`--hardware`, `--profile`. At least one is required. Changes the container
+baked in (port, hardware grid) take effect on the next `restart`.
+
+<Aside type="tip" title="Repairing a profile-less capability slot">
+Capability slots created before v1.0 could land on disk with no `profile`
+key — they load to `ready` but return HTTP 501 from their own endpoint,
+because the profile is what carries llama-server's `--embedding` /
+`--reranking` mode flag. Check with
+`grep profile /etc/hal0/slots/<name>.toml`; repair with
+`hal0 slot edit <name> --profile embedding` (or `reranking`) followed by
+`hal0 slot restart <name>`. Newly created slots infer it automatically.
+</Aside>
 
 ## Dashboard: the inline model-edit pencil
 

--- a/docs/guides/manage-slots.mdx
+++ b/docs/guides/manage-slots.mdx
@@ -84,8 +84,14 @@ hal0 slot create embed \
 7. **`--profile`** — the runtime profile (flag bundle + engine). Omit it
    and hal0 infers the profile the slot's `--type` implies: `embedding` →
    `embedding` (`--embedding`), `reranking` → `reranking`
-   (`--reranking`), `tts`/`transcription` → the engine for the chosen
-   device, `image` → `comfyui`. That inference is what makes a capability
+   (`--reranking`), `tts`/`transcription` → the engine hal0 ships for the
+   chosen device (Kokoro on CPU, Qwen3-TTS on ROCm, Moonshine for CPU
+   speech-to-text). Nothing is inferred where hal0 has no engine for that
+   pairing — a `tts` slot on a Vulkan device, for instance, keeps the CPU
+   Kokoro runtime rather than being pinned to the ROCm-only Qwen3 image.
+   An `image` slot also infers nothing: pass `--profile comfyui`
+   explicitly (the shipped `img` slot already carries it). That inference
+   is what makes a capability
    slot actually serve its endpoint — an `embedding` slot with no
    `--embedding` flag loads to `ready` and returns HTTP 501 from
    `/v1/embeddings`. An `llm` slot infers nothing: no mode flag is at

--- a/src/hal0/capabilities/orchestrator.py
+++ b/src/hal0/capabilities/orchestrator.py
@@ -37,7 +37,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hal0.capabilities.catalog import models_for_capability, tts_profile_for_device
+from hal0.capabilities.catalog import models_for_capability
 from hal0.capabilities.config import (
     CapabilityConfig,
     CapabilitySelection,
@@ -58,6 +58,7 @@ from hal0.registry.store import ModelRegistry
 from hal0.slot_config import SlotConfigStore, SlotSelection
 from hal0.slots.layout import resolve_slot_stem
 from hal0.slots.manager import SlotManager
+from hal0.slots.profile_adopt import type_implied_profile
 
 log = logging.getLogger(__name__)
 
@@ -82,12 +83,27 @@ _SLOT_TO_CHILD: dict[str, tuple[str, str]] = {
 # ── Trio dispatch discriminator: capability child → slot ``type`` ─────────────
 # The FLM trio (one ``flm serve`` process serving chat + embed + asr) is gated
 # in v1._is_npu_trio_request on the slot record's ``type`` field. Only the two
-# trio modalities carry a type; rerank/tts/img are NOT trio members and
-# get no ``type`` key (their auto-created slots are plain llama-server/dedicated
-# providers). Mirrors providers/flm._classify_flm_model emitting "embed"/"stt".
+# trio modalities are trio members — rerank/tts/img carry their own types via
+# ``_NON_TRIO_CHILD_TO_SLOT_TYPE`` below, and must NOT be added here.
+# Mirrors providers/flm._classify_flm_model emitting "embed"/"stt".
 _CHILD_TO_SLOT_TYPE: dict[str, str] = {
     "embed": "embedding",
     "stt": "transcription",
+}
+
+# child → slot ``type`` for the NON-trio children. Deliberately a SECOND map:
+# the trio discriminator above must keep exactly its two members (it also
+# answers "is this an NPU modality?"), but an auto-created slot still needs the
+# ``type`` its shipped seed carries — ``SlotManager.create``'s type-implied
+# profile inference (#1830), ``providers/container._spec_provider_for``'s
+# dispatch and ``hal0 doctor profiles``' profile-less capability check all key
+# on it. Without it a re-created ``rerank`` slot landed profile-less, launched
+# llama-server with no ``--reranking``, reported ``state=ready`` and 501'd
+# ``/v1/rerank``. Values match installer/etc-hal0/slots/{rerank,tts,img}.toml.
+_NON_TRIO_CHILD_TO_SLOT_TYPE: dict[str, str] = {
+    "rerank": "reranking",
+    "tts": "tts",
+    "img": "image",
 }
 
 # The legal capability/child surface — used by HTTP validation.
@@ -741,34 +757,40 @@ class CapabilityOrchestrator:
             # grey/unconfigured slot the dashboard renders as a picker.
             "model": {"default": selection.model or ""},
         }
-        # Stamp the trio dispatch discriminator for embed/stt children so
-        # v1._is_npu_trio_request can gate on it. Non-trio children
-        # (rerank/tts/img) get no ``type`` key.
+        # Stamp the slot ``type`` — the trio dispatch discriminator for the
+        # embed/stt children (so v1._is_npu_trio_request can gate on it), and
+        # the seed-matching type for the non-trio ones. rerank/img used to get
+        # NO ``type`` key here, which left a re-created rerank slot with no
+        # type for SlotManager.create's profile inference (#1830) to key on:
+        # it launched llama-server without ``--reranking``, reported ready and
+        # 501'd /v1/rerank.
         _, child = _SLOT_TO_CHILD.get(slot_name, (None, None))
-        slot_type = _CHILD_TO_SLOT_TYPE.get(child) if child else None
+        slot_type = (
+            _CHILD_TO_SLOT_TYPE.get(child) or _NON_TRIO_CHILD_TO_SLOT_TYPE.get(child)
+            if child
+            else None
+        )
         if slot_type:
             cfg_dict["type"] = slot_type
         # voice.tts engine switch (follow-up to #972): a (re)created tts slot
-        # must carry the engine's runtime profile + type so the spawn routes to
-        # the right provider (cpu→Kokoro, gpu→Qwen3). The builtin tts.toml
-        # normally exists so this path is the deleted-slot fallback.
+        # runs a dedicated container image. The builtin tts.toml normally
+        # exists so this path is the deleted-slot fallback.
         if child == "tts":
-            cfg_dict["type"] = "tts"
             cfg_dict["runtime"] = "container"
-            cfg_dict["profile"] = tts_profile_for_device(selection.device)
-        # voice.stt engine switch (moonshine reinstatement): a (re)created cpu
-        # stt slot carries the Moonshine profile explicitly, mirroring the tts
-        # mechanism above, rather than relying on MoonshineProvider's own
-        # profile-less default (belt-and-suspenders — the slot's on-disk shape
-        # then already matches what a reconciled EXISTING slot would carry via
-        # SlotConfigStore._engine_profile_for). The npu case never reaches
-        # here (`_apply_npu_trio_modality` / `_ensure_slot_exists_npu` handle
-        # it); ``profile_name_for_fit`` returns ``None`` for any device this
-        # branch could see beyond cpu, so the stamp only ever fires there.
-        elif child == "stt":
-            stt_profile = profile_name_for_fit("stt", selection.device, selection.provider or "")
-            if stt_profile is not None:
-                cfg_dict["profile"] = stt_profile
+        # tts/stt engine profile: stamped explicitly so the slot's on-disk
+        # shape already matches what a reconciled EXISTING slot would carry via
+        # SlotConfigStore._engine_profile_for, rather than relying on the
+        # provider's own profile-less default (belt-and-suspenders). It comes
+        # from the SHARED type-implied rule, which vetoes both a profile that
+        # does not fit the slot and a runtime family with no runner for this
+        # device — a Vulkan box must not be pinned to the ROCm-only qwen3tts
+        # image, and an unknown STT engine must not inherit Moonshine's
+        # profile. The npu case never reaches here (`_apply_npu_trio_modality`
+        # / `_ensure_slot_exists_npu` handle it).
+        if child in ("tts", "stt"):
+            engine_profile = type_implied_profile(cfg_dict)
+            if engine_profile is not None:
+                cfg_dict["profile"] = engine_profile
         try:
             await self._slot_manager.create(slot_name, cfg_dict)
         except Exception as exc:

--- a/src/hal0/capabilities/profile_fit.py
+++ b/src/hal0/capabilities/profile_fit.py
@@ -63,15 +63,23 @@ def profile_name_for_fit(capability: str, device: str, provider: str = "") -> st
         return None
     if device == "npu":
         return DEVICE_DEFAULT_PROFILES.get("npu")
-    if capability == "embed" and device in {"gpu-rocm", "gpu-vulkan"}:
-        # Dedicated GPU embed lane (llama-server --embedding), backend-coherent:
-        # gpu-rocm→embed, gpu-vulkan→vulkan-embed. Both non-MTP, so this honours
-        # the resolver's "never force MTP" contract. The base chat profile never
-        # emits --embedding, so embed must not fall through to it.
+    if capability == "embed":
+        # Dedicated embed lane (llama-server --embedding). Non-MTP, so this
+        # honours the resolver's "never force MTP" contract. The base chat
+        # profile never emits --embedding, so embed must not fall through to it.
+        #
+        # NOT device-gated (#1830): the 1.0 seed ``embedding`` profile is a
+        # device-agnostic logical tune (no ``device_class``, no ``backend``) —
+        # the old ``device in {gpu-rocm, gpu-vulkan}`` gate is a leftover from
+        # the retired per-backend ``embed``/``vulkan-embed`` seeds. On a
+        # CPU-only box it made this rule answer "no opinion", so an embed slot
+        # took a chat profile, launched with no ``--embedding``, reported
+        # ``state=ready`` and 501'd every ``/v1/embeddings`` call.
         return "embedding"
-    if capability == "rerank" and device in {"gpu-rocm", "gpu-vulkan"}:
-        # Dedicated GPU rerank lane (llama-server --reranking → /v1/rerank),
-        # backend-coherent: gpu-rocm→rerank, gpu-vulkan→vulkan-rerank.
+    if capability == "rerank":
+        # Dedicated rerank lane (llama-server --reranking → /v1/rerank); MUST
+        # stay a separate instance from embed. Device-agnostic for the same
+        # reason as embed above (#1830).
         return "reranking"
     if device in {"gpu-rocm", "gpu-vulkan"}:
         return DEVICE_DEFAULT_PROFILES.get(device)

--- a/src/hal0/cli/doctor_bundle.py
+++ b/src/hal0/cli/doctor_bundle.py
@@ -333,6 +333,7 @@ def _write_diagnostics_section(out: Path, *, base: str | None = None) -> None:
         profiles = catalog.list()
         valid_names = {p.name for p in profiles}
         slot_profiles: list[tuple[str, str | None]] = []
+        slot_types: dict[str, str] = {}
         # id-aware (P3-runtime-db inc4): report cfg.name (the real display
         # name), not the raw list_slots() stem — see the identical fix +
         # rationale in doctor_commands.doctor_profiles.
@@ -342,7 +343,9 @@ def _write_diagnostics_section(out: Path, *, base: str | None = None) -> None:
             except Exception:
                 continue
             slot_profiles.append((cfg.name, cfg.profile))
-        ref_rows = check_slot_profile_refs(slot_profiles, valid_names)
+            # Type feeds the profile-less capability check (#1830).
+            slot_types[cfg.name] = str(getattr(cfg, "type", "") or "")
+        ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types)
         img_rows = check_profile_images_present(profiles, _local_image_repos())
         profile_diagnoses = _diagnose_profiles(ref_rows, img_rows)
     except Exception:

--- a/src/hal0/cli/doctor_bundle.py
+++ b/src/hal0/cli/doctor_bundle.py
@@ -334,6 +334,7 @@ def _write_diagnostics_section(out: Path, *, base: str | None = None) -> None:
         valid_names = {p.name for p in profiles}
         slot_profiles: list[tuple[str, str | None]] = []
         slot_types: dict[str, str] = {}
+        slot_devices: dict[str, str] = {}
         # id-aware (P3-runtime-db inc4): report cfg.name (the real display
         # name), not the raw list_slots() stem — see the identical fix +
         # rationale in doctor_commands.doctor_profiles.
@@ -343,9 +344,12 @@ def _write_diagnostics_section(out: Path, *, base: str | None = None) -> None:
             except Exception:
                 continue
             slot_profiles.append((cfg.name, cfg.profile))
-            # Type feeds the profile-less capability check (#1830).
+            # Type + device feed the profile-less capability check (#1830):
+            # the type decides whether it is drift, the device which profile
+            # repairs it (npu embeddings want flm, not llama-server).
             slot_types[cfg.name] = str(getattr(cfg, "type", "") or "")
-        ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types)
+            slot_devices[cfg.name] = str(getattr(cfg, "device", "") or "")
+        ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types, slot_devices)
         img_rows = check_profile_images_present(profiles, _local_image_repos())
         profile_diagnoses = _diagnose_profiles(ref_rows, img_rows)
     except Exception:

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -1704,22 +1704,40 @@ def doctor_migrations(
 # check 2 (image-present) is advisory.
 
 
-#: Slot types where a MISSING profile is a proven silent failure, and the
-#: profile that repairs one (#1830). Both are device-agnostic llama-server
-#: seeds, so the repair command is the same on every box. ``tts`` /
-#: ``transcription`` / ``image`` are deliberately absent: their providers carry
-#: their own profile-less defaults, so an empty profile there is not (yet) a
-#: demonstrated 501.
+#: Slot types where a MISSING profile is a proven silent failure, mapped to the
+#: fallback repair profile (#1830). ``tts`` / ``transcription`` / ``image`` are
+#: deliberately absent: their providers carry their own profile-less defaults,
+#: so an empty profile there is not (yet) a demonstrated 501.
+#:
+#: The fallback is only used when the create-time rule
+#: (:func:`hal0.slots.profile_adopt.type_implied_profile`) cannot answer for
+#: this slot's (type, device) — that rule is the authority, so doctor's repair
+#: names the SAME profile a freshly created slot would get (an ``npu``
+#: embedding slot wants ``flm``, not llama-server's ``embedding``).
 _PROFILELESS_CAPABILITY_REPAIR: dict[str, str] = {
     "embedding": "embedding",
     "reranking": "reranking",
 }
 
 
+def _profileless_repair_for(slot_type: str, device: str) -> str | None:
+    """The profile that repairs a profile-less capability slot, or ``None``."""
+    if slot_type not in _PROFILELESS_CAPABILITY_REPAIR:
+        return None
+    try:
+        from hal0.slots.profile_adopt import type_implied_profile
+
+        inferred = type_implied_profile({"type": slot_type, "device": device})
+    except Exception:  # unreadable catalog — fall back to the static answer
+        inferred = None
+    return inferred or _PROFILELESS_CAPABILITY_REPAIR[slot_type]
+
+
 def check_slot_profile_refs(
     slot_profiles: list[tuple[str, str | None]],
     valid_names: set[str],
     slot_types: dict[str, str] | None = None,
+    slot_devices: dict[str, str] | None = None,
 ) -> list[dict[str, str]]:
     """Flag slots whose ``profile = "..."`` names a profile not in the catalog.
 
@@ -1736,13 +1754,18 @@ def check_slot_profile_refs(
     at create time, but no seed loop back-fills an existing TOML, so an upgraded
     box keeps whatever profile-less slots its operator created historically.
     ``slot_types`` maps slot name → slot type; callers that cannot supply it get
-    the old skip-everything-profile-less behaviour.
+    the old skip-everything-profile-less behaviour. ``slot_devices`` maps slot
+    name → device and only sharpens the suggested repair (the create-time rule
+    is device-keyed: ``npu`` embeddings run on FLM, not llama-server).
     """
     types = slot_types or {}
+    devices = slot_devices or {}
     rows: list[dict[str, str]] = []
     for slot, profile in slot_profiles:
         if not profile:
-            implied = _PROFILELESS_CAPABILITY_REPAIR.get(str(types.get(slot) or ""))
+            implied = _profileless_repair_for(
+                str(types.get(slot) or ""), str(devices.get(slot) or "")
+            )
             if implied is None:
                 continue  # llm / unknown type — no profile to resolve
             rows.append(
@@ -1976,6 +1999,7 @@ def doctor_profiles(
     # regardless of which stem it lives under.
     slot_profiles: list[tuple[str, str | None]] = []
     slot_types: dict[str, str] = {}
+    slot_devices: dict[str, str] = {}
     for slot_name in list_slots():
         try:
             cfg = load_slot_config(slot_name)
@@ -1985,10 +2009,12 @@ def doctor_profiles(
             )
             continue
         slot_profiles.append((cfg.name, cfg.profile))
-        # Type feeds the profile-less capability check (#1830).
+        # Type + device feed the profile-less capability check (#1830): the
+        # type decides whether it is drift, the device which profile repairs it.
         slot_types[cfg.name] = str(getattr(cfg, "type", "") or "")
+        slot_devices[cfg.name] = str(getattr(cfg, "device", "") or "")
 
-    ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types)
+    ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types, slot_devices)
     img_rows = check_profile_images_present(profiles, _local_image_repos())
 
     broken = [r for r in ref_rows if r["status"] == "drift"]
@@ -2002,8 +2028,9 @@ def doctor_profiles(
 
     if broken:
         console.print(
-            f"\n[red]✗[/red]  {len(broken)} slot(s) reference a missing profile — "
-            "fix before those slots can start."
+            f"\n[red]✗[/red]  {len(broken)} slot(s) have a broken profile reference "
+            "or none at all — a dangling reference stops the slot from starting; "
+            "a missing one lets it start and answer 501. See each row for the repair."
         )
         raise typer.Exit(1)
     console.print("\n[green]✓[/green]  every slot resolves to a real profile.")

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -1720,8 +1720,15 @@ _PROFILELESS_CAPABILITY_REPAIR: dict[str, str] = {
 }
 
 
-def _profileless_repair_for(slot_type: str, device: str) -> str | None:
-    """The profile that repairs a profile-less capability slot, or ``None``."""
+def _profileless_repair_for(slot_type: str, device: str, valid_names: set[str]) -> str | None:
+    """The profile that repairs a profile-less capability slot, or ``None``.
+
+    ``None`` means "this box has no profile that repairs it" — either the type
+    is not one where a missing profile is a proven 501, or the answer names a
+    profile the installed catalog does not have (a removed/renamed seed).
+    Never recommend a dangling reference: writing it would turn a slot that
+    starts-but-501s into one that cannot start at all.
+    """
     if slot_type not in _PROFILELESS_CAPABILITY_REPAIR:
         return None
     try:
@@ -1730,7 +1737,8 @@ def _profileless_repair_for(slot_type: str, device: str) -> str | None:
         inferred = type_implied_profile({"type": slot_type, "device": device})
     except Exception:  # unreadable catalog — fall back to the static answer
         inferred = None
-    return inferred or _PROFILELESS_CAPABILITY_REPAIR[slot_type]
+    repair = inferred or _PROFILELESS_CAPABILITY_REPAIR[slot_type]
+    return repair if repair in valid_names else None
 
 
 def check_slot_profile_refs(
@@ -1763,20 +1771,28 @@ def check_slot_profile_refs(
     rows: list[dict[str, str]] = []
     for slot, profile in slot_profiles:
         if not profile:
-            implied = _profileless_repair_for(
-                str(types.get(slot) or ""), str(devices.get(slot) or "")
-            )
-            if implied is None:
+            slot_type = str(types.get(slot) or "")
+            if slot_type not in _PROFILELESS_CAPABILITY_REPAIR:
                 continue  # llm / unknown type — no profile to resolve
+            implied = _profileless_repair_for(slot_type, str(devices.get(slot) or ""), valid_names)
+            repair = (
+                f"Repair: hal0 slot edit {slot} --profile {implied} && hal0 slot restart {slot}."
+                if implied
+                else (
+                    "No profile in this catalog serves that type/device — the seed it "
+                    "needs was removed or renamed. Restore the seed profiles before "
+                    "repairing the slot (pointing it at a missing profile would stop "
+                    "it starting at all)."
+                )
+            )
             rows.append(
                 {
                     "label": slot,
                     "status": "drift",
                     "detail": (
-                        f"{types[slot]} slot with NO profile — it will load "
+                        f"{slot_type} slot with NO profile — it will load "
                         f"'ready' and answer 501 on its own endpoint (the profile "
-                        f"carries the mode flag). Repair: hal0 slot edit {slot} "
-                        f"--profile {implied} && hal0 slot restart {slot}."
+                        f"carries the mode flag). {repair}"
                     ),
                 },
             )

--- a/src/hal0/cli/doctor_commands.py
+++ b/src/hal0/cli/doctor_commands.py
@@ -1704,22 +1704,60 @@ def doctor_migrations(
 # check 2 (image-present) is advisory.
 
 
+#: Slot types where a MISSING profile is a proven silent failure, and the
+#: profile that repairs one (#1830). Both are device-agnostic llama-server
+#: seeds, so the repair command is the same on every box. ``tts`` /
+#: ``transcription`` / ``image`` are deliberately absent: their providers carry
+#: their own profile-less defaults, so an empty profile there is not (yet) a
+#: demonstrated 501.
+_PROFILELESS_CAPABILITY_REPAIR: dict[str, str] = {
+    "embedding": "embedding",
+    "reranking": "reranking",
+}
+
+
 def check_slot_profile_refs(
     slot_profiles: list[tuple[str, str | None]],
     valid_names: set[str],
+    slot_types: dict[str, str] | None = None,
 ) -> list[dict[str, str]]:
     """Flag slots whose ``profile = "..."`` names a profile not in the catalog.
 
     ``resolve_slot_profile`` raises ``KeyError`` for a missing name only when the
     slot starts — so a renamed/deleted profile is a latent slot-start failure.
-    A slot with ``profile = None`` (base-image resolution) is legal and skipped.
     Returns one row per slot: ``ok`` when the reference resolves, ``drift`` when
     it dangles.
+
+    A profile-less slot is legal for ``llm`` (base-image resolution) and skipped.
+    For a CAPABILITY slot it is drift (#1830): the profile carries the mode flag
+    (``--embedding`` / ``--reranking``) or selects the engine, so without one the
+    slot loads to ``state=ready`` and returns 501 from its own endpoint —
+    silent, and nothing else in hal0 warns about it. New slots infer the profile
+    at create time, but no seed loop back-fills an existing TOML, so an upgraded
+    box keeps whatever profile-less slots its operator created historically.
+    ``slot_types`` maps slot name → slot type; callers that cannot supply it get
+    the old skip-everything-profile-less behaviour.
     """
+    types = slot_types or {}
     rows: list[dict[str, str]] = []
     for slot, profile in slot_profiles:
         if not profile:
-            continue  # base-image slot — no profile to resolve
+            implied = _PROFILELESS_CAPABILITY_REPAIR.get(str(types.get(slot) or ""))
+            if implied is None:
+                continue  # llm / unknown type — no profile to resolve
+            rows.append(
+                {
+                    "label": slot,
+                    "status": "drift",
+                    "detail": (
+                        f"{types[slot]} slot with NO profile — it will load "
+                        f"'ready' and answer 501 on its own endpoint (the profile "
+                        f"carries the mode flag). Repair: hal0 slot edit {slot} "
+                        f"--profile {implied} && hal0 slot restart {slot}."
+                    ),
+                },
+            )
+            continue
         if profile in valid_names:
             rows.append(
                 {"label": slot, "status": "ok", "detail": f"→ {profile}"},
@@ -1937,6 +1975,7 @@ def doctor_profiles(
     # always cfg.name — the real display name a bilingual TOML embeds
     # regardless of which stem it lives under.
     slot_profiles: list[tuple[str, str | None]] = []
+    slot_types: dict[str, str] = {}
     for slot_name in list_slots():
         try:
             cfg = load_slot_config(slot_name)
@@ -1946,8 +1985,10 @@ def doctor_profiles(
             )
             continue
         slot_profiles.append((cfg.name, cfg.profile))
+        # Type feeds the profile-less capability check (#1830).
+        slot_types[cfg.name] = str(getattr(cfg, "type", "") or "")
 
-    ref_rows = check_slot_profile_refs(slot_profiles, valid_names)
+    ref_rows = check_slot_profile_refs(slot_profiles, valid_names, slot_types)
     img_rows = check_profile_images_present(profiles, _local_image_repos())
 
     broken = [r for r in ref_rows if r["status"] == "drift"]

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -346,6 +346,7 @@ def model_assign(
         ctx_size=None,
         provider=None,
         hardware=None,
+        profile=None,
         backend=None,
     )
 

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -684,6 +684,9 @@ def slot_add(
         model=model,
         port=port,
         ctx_size=ctx_size,
+        # Explicit: a direct Python call gets typer's OptionInfo sentinel for
+        # any omitted parameter, which would then be POSTed as the profile.
+        profile=None,
     )
 
 

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -457,6 +457,16 @@ def slot_create(
         max=65535,
     ),
     ctx_size: int = typer.Option(4096, "--ctx-size", min=128),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help=(
+            "Runtime profile (flag bundle + engine). Default: inferred from "
+            "--type/--hardware — embedding → embedding (--embedding), "
+            "reranking → reranking (--reranking), tts/transcription → the "
+            "engine for the device, image → comfyui. An llm slot infers none."
+        ),
+    ),
 ) -> None:
     """Create a new slot config (POST /api/slots)."""
     url = _api_base()
@@ -493,6 +503,12 @@ def slot_create(
         "provider": str(provider),
         "model": {"default": model, "context_size": ctx_size},
     }
+    # Absent = let the create chokepoint infer the capability profile from
+    # type/device (#1830); an explicit name always wins. Never send an empty
+    # placeholder — that reads as a deliberate operator choice and suppresses
+    # the inference.
+    if profile:
+        body["profile"] = profile
     if port is not None:
         body["port"] = port
     else:
@@ -531,6 +547,15 @@ def slot_edit(
         case_sensitive=False,
         help="Change the slot's hardware backend (vulkan | rocm | cpu).",
     ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help=(
+            "Change the slot's runtime profile (flag bundle + engine) — e.g. "
+            "'embedding' / 'reranking' to repair a profile-less capability slot "
+            "created before the profile was inferred (#1830)."
+        ),
+    ),
     # HAL0-SUNSET: v1.0.0 — --backend renamed to --provider in v0.2; use --provider.
     backend: str | None = typer.Option(
         None,
@@ -566,10 +591,12 @@ def slot_edit(
         and ctx_size is None
         and provider is None
         and hardware is None
+        and profile is None
     ):
         console.print(
             "[bold yellow]No fields provided.[/bold yellow]  "
-            "Pass at least one of --model, --port, --ctx-size, --provider, --hardware."
+            "Pass at least one of --model, --port, --ctx-size, --provider, "
+            "--hardware, --profile."
         )
         raise typer.Exit(code=2)
 
@@ -578,6 +605,8 @@ def slot_edit(
         payload["port"] = port
     if provider is not None:
         payload["provider"] = str(provider)
+    if profile is not None:
+        payload["profile"] = profile
     if hardware is not None:
         payload["device"] = _HARDWARE_TO_DEVICE.get(hardware.value, hardware.value)
     if model is not None or ctx_size is not None:

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -464,7 +464,8 @@ def slot_create(
             "Runtime profile (flag bundle + engine). Default: inferred from "
             "--type/--hardware — embedding → embedding (--embedding), "
             "reranking → reranking (--reranking), tts/transcription → the "
-            "engine for the device, image → comfyui. An llm slot infers none."
+            "engine hal0 ships for that device (none is inferred where it "
+            "ships none). llm and image slots infer none."
         ),
     ),
 ) -> None:

--- a/src/hal0/install/profile_derive.py
+++ b/src/hal0/install/profile_derive.py
@@ -115,20 +115,27 @@ def derive_profile(capability: str, device: str) -> str:
     gpu-vulkan→vulkan, cpu→cpu-llm, npu→flm) and layers the install path's
     capability specialisations on top:
 
-    * ``embed`` → the backend-coherent embed lane: ``gpu-rocm``→``embed``,
-      ``gpu-vulkan``→``vulkan-embed`` (llama-server ``--embedding``). The base
-      chat profile never emits ``--embedding`` and would silently serve
-      ``/v1/completions``, so embed always takes a dedicated encoder profile.
-    * ``rerank`` → the backend-coherent rerank lane: ``gpu-rocm``→``rerank``,
-      ``gpu-vulkan``→``vulkan-rerank`` (llama-server ``--reranking`` →
+    * ``embed`` → the ``embedding`` profile (llama-server ``--embedding``) on
+      every llama-server device. The base chat profile never emits
+      ``--embedding`` and would silently serve ``/v1/completions``, so embed
+      always takes the dedicated encoder profile.
+    * ``rerank`` → the ``reranking`` profile (llama-server ``--reranking`` →
       ``/v1/rerank``); MUST stay a separate instance from embed.
+    * ``npu`` → ``flm`` for every capability, embed included: the NPU runs its
+      own runtime family, not llama-server.
     * ``cpu`` + ``tts`` → the kokoro ``tts`` profile.
 
     Chat/coder take the plain base profile — MTP is never auto-forced (the legacy
     MTP ``rocm-dnse`` profile was removed 2026-07-05; slots opt into the ROCmFPX
-    MTP profiles explicitly). NOTE: CPU has no dedicated embed/rerank seed yet, so
-    a CPU-only box's embed/rerank slot falls back to ``cpu-llm`` (a chat profile)
-    — that lane is still latent until a cpu-embed/cpu-rerank seed exists.
+    MTP profiles explicitly).
+
+    The embed/rerank lanes are deliberately NOT device-gated (#1830). The old
+    ``gpu-rocm``/``gpu-vulkan`` gate dated from the retired per-backend
+    ``embed``/``vulkan-embed`` seeds; the 1.0 ``embedding``/``reranking`` seeds
+    are device-agnostic logical tunes (no ``device_class``, no ``backend``), so
+    a CPU-only box gets them too. While the gate stood, a CPU embed/rerank slot
+    was seeded with a chat profile, launched without its mode flag, reported
+    ``state=ready`` and 501'd its own endpoint.
 
     An unknown device falls back to ``cpu-llm`` (the CPU-coherent llama-server
     profile) — returning a GPU profile there caused #807 to reject the slot on
@@ -139,29 +146,16 @@ def derive_profile(capability: str, device: str) -> str:
         # 2026-07-05; MTP dense now lives on the ROCmFPX profiles, which slots
         # opt into explicitly — derivation never silently forces MTP.)
         return "chat"
-    if capability == "embed":
-        # Embeddings get a dedicated embed profile (llama-server --embedding,
-        # -ub 8192) rather than the chat-tuned base — the chat KV-quant/batch
-        # flags are meaningless for a pooled encoder and the base chat profile
-        # never emits --embedding, so it would silently serve /v1/completions
-        # instead of /v1/embeddings. Route to the backend-coherent embed lane:
-        # gpu-rocm→embed, gpu-vulkan→vulkan-embed; other devices (incl. CPU,
-        # which has no dedicated embed seed yet) fall back to the base profile.
-        return (
-            "embedding"
-            if device in {"gpu-rocm", "gpu-vulkan"}
-            else DEVICE_DEFAULT_PROFILES.get(device, "cpu-chat")
-        )
-    if capability == "rerank":
-        # Rerankers get a dedicated rerank profile (llama-server --reranking →
-        # /v1/rerank); MUST stay a separate instance from embed. Same backend-
-        # coherent routing as embed (gpu-rocm→rerank, gpu-vulkan→vulkan-rerank);
-        # non-GPU falls back to the base profile (no dedicated CPU rerank seed).
-        return (
-            "reranking"
-            if device in {"gpu-rocm", "gpu-vulkan"}
-            else DEVICE_DEFAULT_PROFILES.get(device, "cpu-chat")
-        )
+    if capability in ("embed", "rerank") and device != "npu":
+        # Embeddings/rerankers get their dedicated profile (llama-server
+        # --embedding / --reranking, -ub 8192) rather than the chat-tuned base —
+        # the chat KV-quant/batch flags are meaningless for a pooled encoder,
+        # and the base chat profile never emits the mode flag, so the slot would
+        # silently serve /v1/completions instead of /v1/embeddings (or 501 on
+        # /v1/rerank). Device-agnostic (#1830): the seeds carry no device_class.
+        # NPU is excluded because it is a different runtime family (flm), which
+        # the base table below supplies.
+        return "embedding" if capability == "embed" else "reranking"
     if device == "cpu" and capability == "tts":
         # ``tts`` stays on the kokoro/CPU profile; everything else on CPU takes
         # the CPU-coherent llama-server profile from the base table below.

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -78,6 +78,7 @@ from hal0.slots.profile_adopt import (
     preferred_profile_for as _profile_adopt_preferred_profile_for,
 )
 from hal0.slots.profile_adopt import profile_fits_slot as _profile_adopt_profile_fits_slot
+from hal0.slots.profile_adopt import type_implied_profile
 from hal0.slots.reaper import _EVICT_AFTER_S, _IDLE_AFTER_S, _IDLE_MONITOR_INTERVAL_S, SlotReaper
 from hal0.slots.reaper import is_pinned as _reaper_is_pinned
 from hal0.slots.reaper import probe_host_free_mb as _reaper_probe_host_free_mb
@@ -2413,6 +2414,30 @@ class SlotManager:
             preferred = await self._preferred_profile_for(model_tbl.get("default"))
             if preferred and self._profile_fits_slot(preferred, cfg_dict):
                 cfg_dict["profile"] = preferred
+        # #1830: the model preference above was the ONLY create-time profile
+        # source, and auto-scan / ``model add`` / pull / the curated catalog all
+        # register models with ``defaults: null`` — so an embedding/reranking
+        # slot from ``hal0 slot create``, the New-slot modal, a stack apply or
+        # the capability orchestrator landed on disk with NO ``profile`` key.
+        # For those types the profile is not a tune, it is the mode flag
+        # (``--embedding`` / ``--reranking``) or the runtime engine; without it
+        # the slot loads to ``state=ready`` and 501s its own endpoint. Fall back
+        # to the profile the slot's TYPE implies (vetoed by the same fit check;
+        # ``llm`` slots infer nothing). An explicit profile still wins, and so
+        # does the model's stamped preference above.
+        if not cfg_dict.get("profile"):
+            implied = type_implied_profile(cfg_dict)
+            if implied:
+                cfg_dict["profile"] = implied
+                log.info(
+                    "slot.profile_inferred_from_type",
+                    extra={
+                        "slot": slot_name,
+                        "type": cfg_dict.get("type"),
+                        "device": cfg_dict.get("device"),
+                        "profile": implied,
+                    },
+                )
         # spec-hw-slot-ownership §2/§3: no model-driven runner/image adoption on
         # create. The runner is the slot's own ``binary`` field (default ""),
         # from which the launch path derives the image via

--- a/src/hal0/slots/profile_adopt.py
+++ b/src/hal0/slots/profile_adopt.py
@@ -101,6 +101,48 @@ _SLOT_TYPE_TO_CAPABILITY: dict[str, str] = {
     "image": "image",
 }
 
+#: The CLI's legacy ``--provider`` default (``hal0 slot create`` always sends
+#: it, even for a capability type that has nothing to do with llama-server).
+#: Treated as "unspecified" by the inference below so the CLI and the dashboard
+#: modal — which sends no provider at all — infer the SAME profile.
+_UNSPECIFIED_PROVIDER = "llama-server"
+
+
+def _runtime_family_fits_device(profile_name: str, cfg_dict: dict[str, Any]) -> bool:
+    """False when the profile's RUNTIME FAMILY has no runner for this device.
+
+    :func:`profile_fits_slot` compares the PROFILE's own ``device_class`` /
+    ``backend``, and the 1.0 seeds are deliberately device-agnostic logical
+    tunes with both fields ``None`` — so it waves ``qwen3-tts`` through for a
+    ``gpu-vulkan`` slot even though ``RUNNER_IMAGES["qwen3tts"]`` is ROCm-only
+    (``Qwen3TTSProvider`` unconditionally wires /dev/kfd + MIOpen). The runner
+    registry is the authority on which backend a runtime family can actually
+    run on, so an inferred profile is vetoed when the slot's backend conflicts
+    with its family's runner (#1830 follow-up).
+
+    Only the BACKEND is compared. The runner registry keys ComfyUI under the
+    pseudo device class ``img`` while its slot's device is ``gpu-rocm``, so a
+    device_class comparison would veto correct answers; hardware-class
+    coherence is already :func:`profile_fits_slot`'s job for any profile that
+    declares one.
+    """
+    from hal0.errors import NotFound
+    from hal0.model_meta import device_to_backend
+    from hal0.profiles import ProfileCatalog
+    from hal0.runners import get_runner, runner_matches
+
+    device = str(cfg_dict.get("device") or "").strip().lower()
+    if not device:
+        return True  # no device pinned yet — nothing to conflict with
+    try:
+        family = str(ProfileCatalog().resolve(profile_name).runtime_family or "")
+        runner = get_runner(family)
+    except NotFound:
+        # ``llama-server`` is a multi-runner family (one runner per backend)
+        # and so is not a runner key: nothing single-image to veto on.
+        return True
+    return runner_matches(runner, device_class=None, backend=device_to_backend(device)[1])
+
 
 def type_implied_profile(cfg_dict: dict[str, Any]) -> str | None:
     """The runtime profile a slot's TYPE requires, or ``None`` (#1830).
@@ -117,23 +159,38 @@ def type_implied_profile(cfg_dict: dict[str, Any]) -> str | None:
     (:func:`hal0.capabilities.profile_fit.profile_name_for_fit`), reached
     through the slot-type→capability translation above.
 
-    The answer is vetoed by :func:`profile_fits_slot`, so a candidate the
-    catalog does not have (or that does not match the slot's device/type) is
-    dropped rather than persisted — e.g. ``transcription`` on a GPU device,
-    where hal0 ships no STT engine. A catalog that cannot be read at all yields
-    ``None``: slot creation must never fail because inference could not run.
+    The answer is vetoed TWICE, so a candidate that cannot actually run on this
+    slot is dropped rather than persisted:
+
+    * :func:`profile_fits_slot` — the catalog must have it and its
+      device_class/backend/slot-type must match. E.g. ``transcription`` on a
+      GPU device, where hal0 ships no STT engine.
+    * :func:`_runtime_family_fits_device` — the profile's runtime family must
+      have a runner image for this slot's backend. E.g. ``tts`` on
+      ``gpu-vulkan``: the shared rule answers ``qwen3-tts`` for every GPU, but
+      the qwen3tts runner is ROCm-only, so a Vulkan box keeps the profile-less
+      Kokoro fallback ``providers/container._spec_provider_for`` applies
+      instead of being pinned to a container it cannot start.
+
+    A catalog that cannot be read at all yields ``None``: slot creation must
+    never fail because inference could not run.
     """
     capability = _SLOT_TYPE_TO_CAPABILITY.get(str(cfg_dict.get("type") or "").strip().lower())
     if not capability:
         return None
     device = str(cfg_dict.get("device") or "").strip().lower()
+    provider = str(cfg_dict.get("provider") or "").strip().lower()
+    if provider == _UNSPECIFIED_PROVIDER:
+        provider = ""
     try:
         from hal0.capabilities.profile_fit import profile_name_for_fit
 
-        candidate = profile_name_for_fit(capability, device, str(cfg_dict.get("provider") or ""))
+        candidate = profile_name_for_fit(capability, device, provider)
         if not candidate:
             return None
-        fits = profile_fits_slot(candidate, cfg_dict)
+        fits = profile_fits_slot(candidate, cfg_dict) and _runtime_family_fits_device(
+            candidate, cfg_dict
+        )
     except Exception:  # unreadable/broken catalog — never block the create
         log.warning(
             "slot.profile_inference_skipped",

--- a/src/hal0/slots/profile_adopt.py
+++ b/src/hal0/slots/profile_adopt.py
@@ -101,7 +101,7 @@ _SLOT_TYPE_TO_CAPABILITY: dict[str, str] = {
     "image": "image",
 }
 
-#: The CLI's legacy ``--provider`` default (``hal0 slot create`` always sends
+#: The CLI's historical ``--provider`` default (``hal0 slot create`` always sends
 #: it, even for a capability type that has nothing to do with llama-server).
 #: Treated as "unspecified" by the inference below so the CLI and the dashboard
 #: modal — which sends no provider at all — infer the SAME profile.

--- a/src/hal0/slots/profile_adopt.py
+++ b/src/hal0/slots/profile_adopt.py
@@ -88,6 +88,61 @@ def profile_fits_slot(profile_name: str, cfg_dict: dict[str, Any]) -> bool:
     return True
 
 
+#: Slot type → the capability string the shared ``(capability, device) →
+#: profile`` rule speaks (:func:`hal0.capabilities.profile_fit.profile_name_for_fit`).
+#: ``llm`` is deliberately absent: a chat slot has no mode flag at stake, so its
+#: tune stays the operator's (or the model's stamped) choice rather than a
+#: device default silently written into every new slot.
+_SLOT_TYPE_TO_CAPABILITY: dict[str, str] = {
+    "embedding": "embed",
+    "reranking": "rerank",
+    "transcription": "stt",
+    "tts": "tts",
+    "image": "image",
+}
+
+
+def type_implied_profile(cfg_dict: dict[str, Any]) -> str | None:
+    """The runtime profile a slot's TYPE requires, or ``None`` (#1830).
+
+    Creation-time counterpart of :func:`profile_fits_slot`. For every slot type
+    except ``llm`` the profile is a CORRECTNESS fact, not a tuning choice: it
+    carries the llama-server mode flag (``--embedding`` / ``--reranking``) or
+    selects the runtime engine (kokoro / qwen3-tts, moonshine, comfyui, FLM). A
+    capability slot created without one launches as a plain chat server,
+    reaches ``state=ready`` and 501s the one endpoint it exists to serve.
+
+    The ``(capability, device) → profile`` mapping is NOT re-derived here — it
+    is the single shared rule the picker and capability-apply already use
+    (:func:`hal0.capabilities.profile_fit.profile_name_for_fit`), reached
+    through the slot-type→capability translation above.
+
+    The answer is vetoed by :func:`profile_fits_slot`, so a candidate the
+    catalog does not have (or that does not match the slot's device/type) is
+    dropped rather than persisted — e.g. ``transcription`` on a GPU device,
+    where hal0 ships no STT engine. A catalog that cannot be read at all yields
+    ``None``: slot creation must never fail because inference could not run.
+    """
+    capability = _SLOT_TYPE_TO_CAPABILITY.get(str(cfg_dict.get("type") or "").strip().lower())
+    if not capability:
+        return None
+    device = str(cfg_dict.get("device") or "").strip().lower()
+    try:
+        from hal0.capabilities.profile_fit import profile_name_for_fit
+
+        candidate = profile_name_for_fit(capability, device, str(cfg_dict.get("provider") or ""))
+        if not candidate:
+            return None
+        fits = profile_fits_slot(candidate, cfg_dict)
+    except Exception:  # unreadable/broken catalog — never block the create
+        log.warning(
+            "slot.profile_inference_skipped",
+            extra={"type": cfg_dict.get("type"), "device": device},
+        )
+        return None
+    return candidate if fits else None
+
+
 # RETIRED (spec-hw-slot-ownership §2/§3): the model-driven preferred-runner
 # adoption (``preferred_runner_for`` + ``apply_preferred_runner``) is gone — the
 # runner is the slot's own ``SlotConfig.binary`` field, set by the operator, and
@@ -219,4 +274,5 @@ __all__ = [
     "preferred_profile_for",
     "profile_fits_slot",
     "runner_fits_slot",
+    "type_implied_profile",
 ]

--- a/tests/api/test_slot_create_profile_inference.py
+++ b/tests/api/test_slot_create_profile_inference.py
@@ -1,0 +1,92 @@
+"""POST /api/slots persists the capability profile the slot type implies (#1830).
+
+End-to-end cover for the dashboard "New slot" modal's exact body shape
+(``ui/src/dash/slots/CreateSlotModal.jsx`` sends
+``{name,type,runtime,model,device,autoload,priority}`` — no ``profile``). The
+inference itself lives at the ``SlotManager.create`` chokepoint; this pins the
+route → TOML result, which is what the rc.5 validation run actually read off
+the box (``/etc/hal0/slots/<name>.toml`` with no ``profile`` key → slot loads
+``ready`` and 501s ``/v1/rerank``).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hal0.api import create_app
+
+
+@pytest.fixture
+def isolated_app(tmp_hal0_home: str) -> FastAPI:
+    # Instantiate after tmp_hal0_home is in place (same rationale as
+    # test_slots_routes.isolated_app).
+    return create_app()
+
+
+@pytest.fixture
+def isolated_client(isolated_app: FastAPI) -> Iterator[TestClient]:
+    with TestClient(isolated_app) as c:
+        yield c
+
+
+def _slot_toml(home: str, name: str) -> dict:
+    return tomllib.loads(
+        (Path(home) / "etc" / "hal0" / "slots" / f"{name}.toml").read_text(encoding="utf-8")
+    )
+
+
+@pytest.mark.parametrize(
+    ("slot_type", "device", "expected"),
+    [
+        ("reranking", "gpu-rocm", "reranking"),
+        ("reranking", "cpu", "reranking"),
+        ("embedding", "gpu-rocm", "embedding"),
+        ("embedding", "cpu", "embedding"),
+    ],
+)
+def test_post_slots_persists_the_inferred_profile(
+    tmp_hal0_home: str,
+    isolated_client: TestClient,
+    slot_type: str,
+    device: str,
+    expected: str,
+) -> None:
+    r = isolated_client.post(
+        "/api/slots",
+        json={
+            "name": "zzskui",
+            "type": slot_type,
+            "runtime": "container",
+            "model": "rcmodel",
+            "device": device,
+            "autoload": False,
+            "priority": 50,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert _slot_toml(tmp_hal0_home, "zzskui").get("profile") == expected
+
+
+def test_post_slots_leaves_an_llm_slot_profileless(
+    tmp_hal0_home: str,
+    isolated_client: TestClient,
+) -> None:
+    r = isolated_client.post(
+        "/api/slots",
+        json={
+            "name": "zzskllm",
+            "type": "llm",
+            "runtime": "container",
+            "model": "rcmodel",
+            "device": "gpu-rocm",
+            "autoload": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert not _slot_toml(tmp_hal0_home, "zzskllm").get("profile")

--- a/tests/capabilities/test_orchestrator_autocreated_slot_type.py
+++ b/tests/capabilities/test_orchestrator_autocreated_slot_type.py
@@ -24,11 +24,11 @@ from typing import Any
 
 import pytest
 
-from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.capabilities.config import CapabilitySelection
-from hal0.slots.manager import SlotManager
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
 from hal0.ports.authority import PortAuthority
 from hal0.slots.identity import SlotIdentityStore
+from hal0.slots.manager import SlotManager
 
 
 def _manager(home: Path) -> SlotManager:

--- a/tests/capabilities/test_orchestrator_autocreated_slot_type.py
+++ b/tests/capabilities/test_orchestrator_autocreated_slot_type.py
@@ -1,0 +1,92 @@
+"""An orchestrator-auto-created capability slot carries its ``type`` (#1830).
+
+``CapabilityOrchestrator._ensure_slot_exists`` is the deleted-slot fallback:
+deleting the ``rerank`` slot flips its capability selection off, and
+re-enabling it from the dashboard recreates the TOML from the selection. It
+stamped a ``type`` for the two FLM-trio children only (embed/stt), so a
+recreated ``rerank`` slot landed with NO ``type`` key — which meant
+``SlotManager.create``'s type-implied profile inference had nothing to key on,
+the TOML landed profile-less, ``_spec_provider_for`` fell through to
+llama-server with no ``--reranking``, and the slot reported ``state=ready``
+while 501ing ``/v1/rerank``: the reported bug verbatim, on a path #1830's fix
+was advertised as covering. ``hal0 doctor profiles`` missed it too (its
+profile-less capability check keys on the same absent ``type``).
+
+The stamped types match the shipped seeds (``installer/etc-hal0/slots/
+rerank.toml`` → ``type = "reranking"``, ``img.toml`` → ``type = "image"``).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hal0.capabilities.orchestrator import CapabilityOrchestrator
+from hal0.capabilities.config import CapabilitySelection
+from hal0.slots.manager import SlotManager
+from hal0.ports.authority import PortAuthority
+from hal0.slots.identity import SlotIdentityStore
+
+
+def _manager(home: Path) -> SlotManager:
+    db = home / "hal0.db"
+    return SlotManager(
+        identity_store=SlotIdentityStore(db_path=db),
+        port_authority=PortAuthority(pool=(8081, 8200), db_path=db),
+    )
+
+
+def _read(home: Path, slot: str) -> dict[str, Any]:
+    with open(home / "etc" / "hal0" / "slots" / f"{slot}.toml", "rb") as f:
+        return tomllib.load(f)
+
+
+@pytest.mark.parametrize(
+    ("slot_name", "device", "expected_type", "expected_profile"),
+    [
+        ("rerank", "gpu-vulkan", "reranking", "reranking"),
+        ("rerank", "cpu", "reranking", "reranking"),
+        ("img", "gpu-rocm", "image", None),
+    ],
+)
+async def test_autocreated_non_trio_slot_carries_its_type(
+    tmp_hal0_home: str,
+    slot_name: str,
+    device: str,
+    expected_type: str,
+    expected_profile: str | None,
+) -> None:
+    home = Path(tmp_hal0_home)
+    orch = CapabilityOrchestrator(
+        _manager(home), config_path=home / "etc" / "hal0" / "capabilities.toml"
+    )
+
+    await orch._ensure_slot_exists(
+        slot_name,
+        CapabilitySelection(device=device, provider="llama-server", model="", enabled=True),
+    )
+
+    raw = _read(home, slot_name)
+    assert raw.get("type") == expected_type
+    assert raw.get("profile") == expected_profile
+
+
+async def test_autocreated_embed_slot_keeps_its_trio_type(tmp_hal0_home: str) -> None:
+    """HARD INVARIANT: the two FLM-trio children keep the types the NPU
+    dispatch gate (``v1._is_npu_trio_request``) reads."""
+    home = Path(tmp_hal0_home)
+    orch = CapabilityOrchestrator(
+        _manager(home), config_path=home / "etc" / "hal0" / "capabilities.toml"
+    )
+
+    await orch._ensure_slot_exists(
+        "embed",
+        CapabilitySelection(device="cpu", provider="llama-server", model="", enabled=True),
+    )
+
+    raw = _read(home, "embed")
+    assert raw.get("type") == "embedding"
+    assert raw.get("profile") == "embedding"

--- a/tests/cli/test_doctor_bundle.py
+++ b/tests/cli/test_doctor_bundle.py
@@ -152,6 +152,28 @@ def test_bundle_diagnostics_section_writes_expected_files(
     assert models == {"_unavailable": "/api/models"}  # API is down in this test
 
 
+def test_bundle_profile_repair_is_device_aware(tmp_hal0_home: str, tmp_path: Path) -> None:
+    """The bundle's profiles.json must recommend the same repair doctor does.
+
+    #1830: a profile-less capability slot is drift, and the repair is
+    device-keyed — an ``npu`` embedding slot runs the FLM runtime, so telling
+    the operator to write llama-server's ``embedding`` profile would move it
+    onto the wrong runtime family. The bundle path built its rows without the
+    slot devices while the interactive path passed them.
+    """
+    slots_dir = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / "npu-embed.toml").write_text(
+        'name = "npu-embed"\ntype = "embedding"\ndevice = "npu"\nport = 8099\n'
+    )
+
+    out = tmp_path / "bundle"
+    build_bundle(out, include_rocm_smi=False)
+
+    profiles = jsonlib.dumps(jsonlib.loads((out / "diagnostics" / "profiles.json").read_text()))
+    assert "hal0 slot edit npu-embed --profile flm" in profiles
+
+
 def test_bundle_no_logs_flag_skips_logs_dir(tmp_hal0_home: str, tmp_path: Path) -> None:
     out = tmp_path / "bundle"
     build_bundle(out, include_rocm_smi=False, include_logs=False)

--- a/tests/cli/test_doctor_profiles.py
+++ b/tests/cli/test_doctor_profiles.py
@@ -80,6 +80,25 @@ def test_refs_flag_a_profileless_capability_slot() -> None:
     assert "hal0 slot edit rerank --profile reranking" in rows[1]["detail"]
 
 
+def test_refs_repair_command_is_device_aware(tmp_hal0_home: str) -> None:
+    """The repair must name the profile create-time inference would choose.
+
+    Keying the repair on the slot TYPE alone told an NPU embedding slot to
+    run ``hal0 slot edit <name> --profile embedding`` — llama-server flags
+    (``--embedding -fa auto -b 8192 -ub 8192``) onto the FLM runtime. The
+    create-time rule in the same release answers ``flm`` for that pair, so
+    doctor now reuses it rather than keeping a second, disagreeing rule.
+    """
+    rows = check_slot_profile_refs(
+        [("npu-embed", None), ("cpu-embed", None)],
+        {"embedding", "flm"},
+        slot_types={"npu-embed": "embedding", "cpu-embed": "embedding"},
+        slot_devices={"npu-embed": "npu", "cpu-embed": "cpu"},
+    )
+    assert "hal0 slot edit npu-embed --profile flm" in rows[0]["detail"]
+    assert "hal0 slot edit cpu-embed --profile embedding" in rows[1]["detail"]
+
+
 def test_refs_still_skip_a_profileless_llm_slot() -> None:
     """An llm slot has no mode flag at stake — profile-less is legal there."""
     assert check_slot_profile_refs([("agent", None)], {"chat"}, slot_types={"agent": "llm"}) == []

--- a/tests/cli/test_doctor_profiles.py
+++ b/tests/cli/test_doctor_profiles.py
@@ -59,6 +59,32 @@ def test_refs_skip_base_image_slots() -> None:
     assert check_slot_profile_refs([("primary", None), ("x", "")], {"rocm"}) == []
 
 
+def test_refs_flag_a_profileless_capability_slot() -> None:
+    """#1830: a profile-less embedding/reranking slot is a silent 501.
+
+    Nothing warned about this shape. The slot loads to ``state=ready`` and
+    returns HTTP 501 from the one endpoint it exists to serve, because the
+    profile is what carries llama-server's ``--embedding``/``--reranking``.
+    New slots infer it at create time; an upgraded box carries whatever
+    profile-less slots its operator created historically, and no seed loop
+    back-fills an existing TOML — so doctor has to name it.
+    """
+    rows = check_slot_profile_refs(
+        [("embed", None), ("rerank", "")],
+        {"embedding", "reranking"},
+        slot_types={"embed": "embedding", "rerank": "reranking"},
+    )
+    assert [r["status"] for r in rows] == ["drift", "drift"]
+    assert "501" in rows[0]["detail"]
+    assert "hal0 slot edit embed --profile embedding" in rows[0]["detail"]
+    assert "hal0 slot edit rerank --profile reranking" in rows[1]["detail"]
+
+
+def test_refs_still_skip_a_profileless_llm_slot() -> None:
+    """An llm slot has no mode flag at stake — profile-less is legal there."""
+    assert check_slot_profile_refs([("agent", None)], {"chat"}, slot_types={"agent": "llm"}) == []
+
+
 # ── check_profile_images_present ──────────────────────────────────────────────
 
 

--- a/tests/cli/test_doctor_profiles.py
+++ b/tests/cli/test_doctor_profiles.py
@@ -99,6 +99,25 @@ def test_refs_repair_command_is_device_aware(tmp_hal0_home: str) -> None:
     assert "hal0 slot edit cpu-embed --profile embedding" in rows[1]["detail"]
 
 
+def test_refs_never_recommend_a_profile_missing_from_the_catalog(tmp_hal0_home: str) -> None:
+    """Repairing must not turn a 501 into a slot that cannot start at all.
+
+    If the seed the repair names has been removed/renamed in the installed
+    catalog, ``hal0 slot edit <slot> --profile <name>`` would write a dangling
+    reference — ``resolve_slot_profile`` then raises ``KeyError`` at start. The
+    row stays drift (the slot really is broken), but names no profile.
+    """
+    rows = check_slot_profile_refs(
+        [("rerank", None)],
+        {"chat"},  # catalog without the reranking seed
+        slot_types={"rerank": "reranking"},
+        slot_devices={"rerank": "cpu"},
+    )
+    assert rows[0]["status"] == "drift"
+    assert "--profile" not in rows[0]["detail"]
+    assert "501" in rows[0]["detail"]
+
+
 def test_refs_still_skip_a_profileless_llm_slot() -> None:
     """An llm slot has no mode flag at stake — profile-less is legal there."""
     assert check_slot_profile_refs([("agent", None)], {"chat"}, slot_types={"agent": "llm"}) == []

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -270,3 +270,48 @@ def test_bare_create_on_strix_halo_resolves_to_vulkan(
     # auto-resolves to vulkan from the Strix Halo fixture.
     assert captured["body"]["provider"] == "llama-server"
     assert captured["body"]["device"] == "gpu-vulkan"
+
+
+# ── --profile (#1830) ────────────────────────────────────────────────────────
+
+
+def test_profile_flag_is_forwarded(captured_post: dict[str, Any]) -> None:
+    """``slot create --profile`` pins the profile instead of inferring one."""
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "rr", "--type", "reranking", "--model", "demo", "--profile", "reranking"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured_post["body"]["profile"] == "reranking"
+
+
+def test_profile_omitted_leaves_the_key_absent(captured_post: dict[str, Any]) -> None:
+    """No ``--profile`` → no ``profile`` key at all.
+
+    An empty-string placeholder would look like an explicit operator choice at
+    the create chokepoint and defeat the type-implied inference (#1830).
+    """
+    result = runner.invoke(
+        slot_commands.app,
+        ["create", "rr", "--type", "reranking", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "profile" not in captured_post["body"]
+
+
+def test_edit_profile_flag_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``slot edit --profile`` PUTs it — the repair path for an existing slot."""
+    captured: dict[str, Any] = {}
+
+    def fake_put(path: str, *, json: dict[str, Any] | None = None, **_kw: Any) -> dict[str, Any]:
+        captured["path"] = path
+        captured["payload"] = json or {}
+        return {"state": "stopped"}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(slot_commands, "api_put", fake_put)
+
+    result = runner.invoke(slot_commands.app, ["edit", "rr", "--profile", "reranking"])
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/slots/rr/config"
+    assert captured["payload"] == {"profile": "reranking"}

--- a/tests/cli/test_slot_create_flags.py
+++ b/tests/cli/test_slot_create_flags.py
@@ -285,6 +285,21 @@ def test_profile_flag_is_forwarded(captured_post: dict[str, Any]) -> None:
     assert captured_post["body"]["profile"] == "reranking"
 
 
+def test_deprecated_add_alias_sends_no_profile(captured_post: dict[str, Any]) -> None:
+    """``slot add`` calls ``slot_create`` in-process — no OptionInfo leak.
+
+    A direct Python call to a Typer command binds the ``typer.Option(...)``
+    sentinel for every omitted parameter, so a new parameter that the alias
+    forgets to pass gets POSTed as that sentinel object.
+    """
+    result = runner.invoke(
+        slot_commands.app,
+        ["add", "rr", "--type", "reranking", "--model", "demo"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "profile" not in captured_post["body"]
+
+
 def test_profile_omitted_leaves_the_key_absent(captured_post: dict[str, Any]) -> None:
     """No ``--profile`` → no ``profile`` key at all.
 

--- a/tests/config/test_profile_derivation_parity.py
+++ b/tests/config/test_profile_derivation_parity.py
@@ -54,11 +54,19 @@ _DERIVE_MATRIX: dict[tuple[str, str], str] = {
     ("tts", "gpu-vulkan"): "chat",
     ("agent", "gpu-vulkan"): "chat",
     ("image", "gpu-vulkan"): "chat",
-    # cpu — tts → kokoro; image → comfyui; everything else → cpu-chat.
+    # cpu — embed/rerank take their (device-agnostic) lanes; tts → kokoro;
+    # everything else → cpu-chat.
+    #
+    # #1830 (DELIBERATE change, rc.5 finding): embed/rerank on cpu used to
+    # derive ``cpu-chat``, a chat profile that emits no ``--embedding`` /
+    # ``--reranking``. The gate dated from the retired per-backend
+    # embed/vulkan-embed seeds; the 1.0 seeds are device-agnostic, so a CPU-only
+    # box gets them too. While it stood, a CPU-only box's embed/rerank slot
+    # reported ``state=ready`` and 501'd its own endpoint.
     ("chat", "cpu"): "cpu-chat",
     ("coder", "cpu"): "cpu-chat",
-    ("embed", "cpu"): "cpu-chat",
-    ("rerank", "cpu"): "cpu-chat",
+    ("embed", "cpu"): "embedding",
+    ("rerank", "cpu"): "reranking",
     ("utility", "cpu"): "cpu-chat",
     ("tts", "cpu"): "kokoro",
     ("agent", "cpu"): "cpu-chat",

--- a/tests/install/test_profile_derive.py
+++ b/tests/install/test_profile_derive.py
@@ -183,9 +183,22 @@ def test_cpu_host_coder_derives_cpu_llm_profile():
     assert derive_profile("coder", "cpu") == "cpu-chat"
 
 
-def test_cpu_host_embed_derives_cpu_llm_profile():
-    """embed capability on a CPU host must derive to 'cpu-llm', not 'vulkan'."""
-    assert derive_profile("embed", "cpu") == "cpu-chat"
+def test_cpu_host_embed_derives_the_embedding_lane():
+    """embed on a CPU host derives the ``embedding`` lane, never a GPU profile.
+
+    #1830: this used to assert ``cpu-chat`` — a chat profile that emits no
+    ``--embedding``, so a CPU-only box's embed slot loaded ``ready`` and 501'd
+    ``/v1/embeddings``. The ``embedding`` seed is device-agnostic (backend and
+    device_class both None), so the #807/#834 coherence property the original
+    test protected — never a GPU-pinned profile on a CPU device — still holds.
+    """
+    from hal0.config.schema import SEED_PROFILES
+
+    assert derive_profile("embed", "cpu") == "embedding"
+    assert derive_profile("rerank", "cpu") == "reranking"
+    for name in ("embedding", "reranking"):
+        assert SEED_PROFILES[name].get("backend") is None
+        assert SEED_PROFILES[name].get("device_class") is None
 
 
 def test_cpu_host_tts_still_derives_tts_profile():

--- a/tests/slots/test_slot_type_profile_inference.py
+++ b/tests/slots/test_slot_type_profile_inference.py
@@ -1,0 +1,152 @@
+"""A capability slot is created with the profile its TYPE requires (#1830).
+
+For an ``embedding`` / ``reranking`` slot the profile is not a tuning choice:
+it carries the llama-server MODE FLAG (``--embedding`` / ``--reranking``) that
+makes the slot serve ``/v1/embeddings`` / ``/v1/rerank`` at all. Before this
+fix, the only create-time profile source was the model's stamped
+``defaults.profile`` (the Q1 adoption in ``SlotManager.create``) — and
+auto-scan, ``model add``, pull and the curated catalog all register models
+with ``defaults: null``. So every explicit creation path (``hal0 slot create``,
+the dashboard New-slot modal, a raw ``POST /api/slots``, a stack apply, the
+capability orchestrator's auto-create) wrote a slot TOML with NO ``profile``
+key, the #1787 profile-template gate had nothing to apply, and the slot loaded
+to ``state=ready`` while 501ing its own endpoint.
+
+``SlotManager.create`` is the one chokepoint every path funnels through, so
+the type-implied fallback lives there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hal0.registry.model import Model, ModelDefaults
+from hal0.registry.store import ModelRegistry
+from hal0.slots.manager import SlotManager
+from hal0.slots.profile_adopt import type_implied_profile
+
+
+def _register(model_id: str, *, profile: str | None = None) -> None:
+    ModelRegistry().add(
+        Model(
+            id=model_id,
+            path=f"/tmp/{model_id}.gguf",
+            capabilities=["chat"],
+            defaults=ModelDefaults(profile=profile) if profile else None,
+        )
+    )
+
+
+def _cfg(name: str, slot_type: str, device: str, model: str = "unstamped") -> dict:
+    # The shape the create modal / CLI / stack apply send: no ``profile`` key.
+    return {
+        "name": name,
+        "port": 8097,
+        "type": slot_type,
+        "device": device,
+        "provider": "llama-server",
+        "group": "custom",
+        "model": {"default": model},
+    }
+
+
+# ── the (type, device) → profile rule ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("slot_type", "device", "expected"),
+    [
+        # The rc.5 repro was a CPU-only box; the seed embedding/reranking
+        # profiles are device-agnostic, so every llama-server device gets them.
+        ("embedding", "cpu", "embedding"),
+        ("embedding", "gpu-rocm", "embedding"),
+        ("embedding", "gpu-vulkan", "embedding"),
+        ("reranking", "cpu", "reranking"),
+        ("reranking", "gpu-rocm", "reranking"),
+        ("reranking", "gpu-vulkan", "reranking"),
+        # NPU embeddings run on the FLM runtime, not llama-server.
+        ("embedding", "npu", "flm"),
+        # Engine-switched capability types.
+        ("tts", "cpu", "kokoro"),
+        ("tts", "gpu-rocm", "qwen3-tts"),
+        ("transcription", "cpu", "moonshine"),
+        ("image", "img", "comfyui"),
+        # An llm slot has no mode flag at stake — the tune stays the
+        # operator's (or the model's) choice, so nothing is inferred.
+        ("llm", "cpu", None),
+        ("llm", "gpu-rocm", None),
+        ("", "cpu", None),
+    ],
+)
+def test_type_implied_profile(
+    tmp_hal0_home: str, slot_type: str, device: str, expected: str | None
+) -> None:
+    assert type_implied_profile({"type": slot_type, "device": device}) == expected
+
+
+def test_type_implied_profile_vetoes_a_profile_that_does_not_fit(tmp_hal0_home: str) -> None:
+    """A candidate that does not fit the slot is dropped, never written.
+
+    ``transcription`` on a GPU device has no hal0 STT engine — the rule must
+    answer ``None`` rather than hand the slot a llama chat profile that would
+    never start the STT image.
+    """
+    assert type_implied_profile({"type": "transcription", "device": "gpu-rocm"}) is None
+
+
+# ── the create chokepoint ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("slot_type", "device", "expected"),
+    [
+        ("reranking", "cpu", "reranking"),
+        ("reranking", "gpu-rocm", "reranking"),
+        ("embedding", "cpu", "embedding"),
+        ("embedding", "gpu-vulkan", "embedding"),
+    ],
+)
+async def test_create_infers_capability_profile_for_unstamped_model(
+    tmp_hal0_home: str, slot_type: str, device: str, expected: str
+) -> None:
+    _register("unstamped")  # defaults: null — auto-scan / model add / pull
+    sm = SlotManager()
+    await sm.create("zz", _cfg("zz", slot_type, device))
+    assert (await sm.get_config("zz")).get("profile") == expected
+
+
+async def test_create_keeps_an_explicit_profile(tmp_hal0_home: str) -> None:
+    _register("unstamped")
+    sm = SlotManager()
+    cfg = _cfg("zz", "embedding", "cpu")
+    cfg["profile"] = "cpu-chat"
+    await sm.create("zz", cfg)
+    assert (await sm.get_config("zz")).get("profile") == "cpu-chat"
+
+
+async def test_create_keeps_the_models_stamped_profile(tmp_hal0_home: str) -> None:
+    """The Q1 model preference still wins over the type-implied fallback."""
+    _register("stamped", profile="cpu-chat")
+    sm = SlotManager()
+    await sm.create("zz", _cfg("zz", "embedding", "cpu", model="stamped"))
+    assert (await sm.get_config("zz")).get("profile") == "cpu-chat"
+
+
+async def test_create_leaves_llm_slots_profileless(tmp_hal0_home: str) -> None:
+    _register("unstamped")
+    sm = SlotManager()
+    await sm.create("zz", _cfg("zz", "llm", "cpu"))
+    assert not (await sm.get_config("zz")).get("profile")
+
+
+async def test_create_infers_without_a_model_bound(tmp_hal0_home: str) -> None:
+    """A grey/unconfigured capability slot (no model yet) still gets a profile.
+
+    The capability orchestrator's auto-create writes ``model.default = ""``;
+    the type is what makes the mode flag necessary, not the binding.
+    """
+    sm = SlotManager()
+    cfg = _cfg("zz", "reranking", "cpu")
+    cfg["model"] = {"default": ""}
+    await sm.create("zz", cfg)
+    assert (await sm.get_config("zz")).get("profile") == "reranking"

--- a/tests/slots/test_slot_type_profile_inference.py
+++ b/tests/slots/test_slot_type_profile_inference.py
@@ -145,9 +145,7 @@ def test_type_implied_profile_ignores_the_cli_legacy_provider_default(
     """
     assert type_implied_profile({"type": "transcription", "device": "cpu"}) == "moonshine"
     assert (
-        type_implied_profile(
-            {"type": "transcription", "device": "cpu", "provider": "llama-server"}
-        )
+        type_implied_profile({"type": "transcription", "device": "cpu", "provider": "llama-server"})
         == "moonshine"
     )
     # A named engine hal0 has no runtime for is still rejected.

--- a/tests/slots/test_slot_type_profile_inference.py
+++ b/tests/slots/test_slot_type_profile_inference.py
@@ -69,8 +69,18 @@ def _cfg(name: str, slot_type: str, device: str, model: str = "unstamped") -> di
         # Engine-switched capability types.
         ("tts", "cpu", "kokoro"),
         ("tts", "gpu-rocm", "qwen3-tts"),
+        # Qwen3-TTS ships a ROCm-only runner, so a Vulkan/CUDA box must NOT
+        # be pinned to it — it infers nothing and keeps the profile-less
+        # Kokoro fallback ``providers/container._spec_provider_for`` applies.
+        ("tts", "gpu-vulkan", None),
+        ("tts", "gpu-cuda", None),
         ("transcription", "cpu", "moonshine"),
-        ("image", "img", "comfyui"),
+        # ``image`` infers nothing today: the shared rule's generic GPU branch
+        # answers ``chat`` before its image branch and the fit veto drops it.
+        # Pinned as-is (the old ``("image", "img")`` row asserted an input no
+        # slot can have — ``img`` is a device_class, not a device; the shipped
+        # img.toml is device = "gpu-rocm").
+        ("image", "gpu-rocm", None),
         # An llm slot has no mode flag at stake — the tune stays the
         # operator's (or the model's) choice, so nothing is inferred.
         ("llm", "cpu", None),
@@ -92,6 +102,59 @@ def test_type_implied_profile_vetoes_a_profile_that_does_not_fit(tmp_hal0_home: 
     never start the STT image.
     """
     assert type_implied_profile({"type": "transcription", "device": "gpu-rocm"}) is None
+
+
+def test_type_implied_profile_vetoes_a_runtime_family_the_device_cannot_run(
+    tmp_hal0_home: str,
+) -> None:
+    """The RUNNER registry vetoes too, not just the profile's own fields.
+
+    ``profile_fits_slot`` compares the profile's ``device_class`` / ``backend``,
+    and the 1.0 seeds are device-agnostic logical tunes (both ``None``) — so it
+    waves ``qwen3-tts`` through for a gpu-vulkan slot. But
+    ``RUNNER_IMAGES["qwen3tts"]`` is ROCm-only (the provider wires /dev/kfd +
+    MIOpen), so the slot would be pinned to a container its own device cannot
+    run. Before the veto, ``hal0 slot create voice --type tts`` with no
+    ``--hardware`` on a Vulkan-defaulting box turned a working Kokoro CPU slot
+    into a dead Qwen3 one.
+    """
+    from hal0.profiles import ProfileCatalog
+    from hal0.slots.profile_adopt import profile_fits_slot, runner_fits_slot
+
+    cfg = {"type": "tts", "device": "gpu-vulkan"}
+    # The premise: the profile itself "fits" — only the runner disagrees.
+    assert profile_fits_slot("qwen3-tts", cfg) is True
+    assert ProfileCatalog().resolve("qwen3-tts").runtime_family == "qwen3tts"
+    assert runner_fits_slot("qwen3tts", cfg) is False
+
+    assert type_implied_profile(cfg) is None
+    # ROCm — the one backend that runner has an image for — still infers it.
+    assert type_implied_profile({"type": "tts", "device": "gpu-rocm"}) == "qwen3-tts"
+
+
+def test_type_implied_profile_ignores_the_cli_legacy_provider_default(
+    tmp_hal0_home: str,
+) -> None:
+    """``hal0 slot create`` always sends the legacy ``provider=llama-server``.
+
+    The STT rule rejects a provider it has no engine for (``whispercpp``), and
+    that guard swallowed the CLI's legacy default too — so the CLI got no
+    profile for a transcription slot while the dashboard modal (which sends no
+    provider) got Moonshine. ``llama-server`` is not an STT engine; it means
+    "unspecified" here.
+    """
+    assert type_implied_profile({"type": "transcription", "device": "cpu"}) == "moonshine"
+    assert (
+        type_implied_profile(
+            {"type": "transcription", "device": "cpu", "provider": "llama-server"}
+        )
+        == "moonshine"
+    )
+    # A named engine hal0 has no runtime for is still rejected.
+    assert (
+        type_implied_profile({"type": "transcription", "device": "cpu", "provider": "whispercpp"})
+        is None
+    )
 
 
 # ── the create chokepoint ────────────────────────────────────────────────────
@@ -136,6 +199,21 @@ async def test_create_leaves_llm_slots_profileless(tmp_hal0_home: str) -> None:
     _register("unstamped")
     sm = SlotManager()
     await sm.create("zz", _cfg("zz", "llm", "cpu"))
+    assert not (await sm.get_config("zz")).get("profile")
+
+
+async def test_create_leaves_a_vulkan_tts_slot_on_the_kokoro_fallback(
+    tmp_hal0_home: str,
+) -> None:
+    """`hal0 slot create voice --type tts` on a Vulkan box must not pin Qwen3.
+
+    The ROCm-only qwen3tts runner cannot start on a Vulkan device; the
+    profile-less TOML keeps ``_spec_provider_for``'s type=tts → Kokoro
+    fallback, which is what this path did before #1830's inference landed.
+    """
+    _register("unstamped")
+    sm = SlotManager()
+    await sm.create("zz", _cfg("zz", "tts", "gpu-vulkan"))
     assert not (await sm.get_config("zz")).get("profile")
 
 


### PR DESCRIPTION
## What changed

A capability slot is now created with the runtime profile its **type** requires, and the shared `(capability, device) → profile` rule stops pretending the embed/rerank profiles are GPU-only.

- **`SlotManager.create` infers the type-implied profile** (`src/hal0/slots/manager.py`). This is the one chokepoint every creation path funnels through — `hal0 slot create`, the dashboard New-slot modal, a raw `POST /api/slots`, a stack apply, and the capability orchestrator's `_ensure_slot_exists`. An explicit profile still wins, and so does the model's stamped `defaults.profile` (the existing Q1 adoption directly above); `llm` slots infer nothing.
  - **Correction (review round 2):** the chokepoint only covers a caller that supplies a slot `type`, and `_ensure_slot_exists` did not for the non-trio children. A re-created `rerank` slot landed with no `type`, so it inferred nothing, launched llama-server without `--reranking`, reported `state=ready` and 501'd `/v1/rerank` — the reported bug verbatim on the path this PR advertised as covered (and `doctor profiles` missed it for the same reason). `_ensure_slot_exists` now stamps the type its shipped seed carries for `rerank` → `reranking` and `img` → `image`, via a second map so the FLM-trio discriminator keeps exactly its two members.
- **New `hal0.slots.profile_adopt.type_implied_profile`** — translates slot type → capability and delegates to the existing shared rule `capabilities.profile_fit.profile_name_for_fit`, then vetoes the answer twice: with `profile_fits_slot` (catalog + device_class/backend/slot-type) and with the **runner registry** (`_runtime_family_fits_device`). No fourth copy of the mapping.
  - The runner veto exists because the first round regressed TTS: `tts` resolves `qwen3-tts` for *any* GPU device, but `RUNNER_IMAGES["qwen3tts"]` is ROCm-only, and the 1.0 seed profiles are device-agnostic tunes (`device_class = None`, `backend = None`) so `profile_fits_slot` waved it through. `hal0 slot create voice --type tts` with no `--hardware` on a Vulkan-defaulting box went from a working profile-less Kokoro CPU slot to one pinned to a container its device cannot start. Now nothing is inferred there and the `_spec_provider_for` Kokoro fallback stands. The orchestrator's tts/stt engine stamp routes through the same rule, so it gets the veto too.
- **The CLI's historical `--provider llama-server` default is treated as "unspecified"** by the inference. It made `hal0 slot create --type transcription --hardware cpu` infer nothing (the STT rule rejects providers it has no engine for) while the dashboard modal, which sends no provider, inferred Moonshine.
- **`profile_name_for_fit` and `install.profile_derive.derive_profile`: embed/rerank are no longer device-gated.** Both required `device in {gpu-rocm, gpu-vulkan}` — a leftover from the retired per-backend `embed`/`vulkan-embed` seeds. The 1.0 `embedding`/`reranking` seeds are device-agnostic logical tunes (`device_class = None`, `backend = None`), so a CPU box gets them too. NPU still resolves `flm` (different runtime family).
- **`hal0 slot create --profile` and `hal0 slot edit --profile`** — the operator override, and the repair path for a slot already on disk without one.
- **`hal0 doctor profiles` now flags a profile-less embedding/reranking slot** as drift, with the exact repair command — device-aware, reusing `type_implied_profile` so an `npu` embedding slot is told `--profile flm`, not llama-server's `embedding`. It previously skipped every profile-less slot as "base-image, legal". Its failure line no longer claims those slots cannot start (the whole point of #1830 is that they start and 501).
- Docs: `docs/guides/manage-slots.mdx` documents `--profile` on create/edit plus a repair aside.

## Why

Reported symptom (#1830): `hal0 slot create --type reranking` writes a TOML with no `profile` key, the slot loads to `state=ready`, and `/v1/rerank` answers `501 "Start it with --reranking"`.

Root cause is one layer below the create body the issue points at, and one layer wider:

1. **The model's stamped `defaults.profile` was the only create-time profile source.** Auto-scan, `model add`, pull and the curated catalog all register models with `defaults: null`, so the adoption never fired, nothing else supplied a profile, and the #1787 template gate in `providers/container.py` (which needs a truthy `_cfg_profile`) had nothing to apply. Fixing `_normalize_create_body` alone would have missed the capability orchestrator, which calls `SlotManager.create` directly and only ever stamps a profile for the tts/stt engine switch.
2. **The shared derivation rule had a CPU hole.** `profile_name_for_fit("embed", "cpu")` returned `None` and `derive_profile("embed", "cpu")` returned `cpu-chat` — a chat profile that emits no `--embedding`. So on a CPU-only box (which is exactly where the rc.5 repro ran) the guided installer's embed/rerank slots and capability-apply's fit inference were broken by the same defect, independent of the create path. The issue's "capability-apply-created slots launch correctly" holds on GPU only.

For any type but `llm` the profile is a correctness fact, not a tune: it carries llama-server's mode flag or selects the runtime engine.

## How it was verified

- New regression tests, red before the fix:
  - `tests/slots/test_slot_type_profile_inference.py` — the (type, device) → profile matrix, the fit veto, and `SlotManager.create` for embedding/reranking on cpu/rocm/vulkan, plus explicit-profile-wins, stamped-model-wins, `llm` untouched, and the model-less (grey capability slot) case.
  - `tests/api/test_slot_create_profile_inference.py` — the dashboard modal's exact body shape (`{name,type,runtime,model,device,autoload,priority}`, no profile) → the persisted TOML carries `profile`.
  - `tests/cli/test_slot_create_flags.py` — `--profile` forwarded on create and edit, absent when omitted, and the deprecated `slot add` alias sends no typer `OptionInfo` sentinel.
  - `tests/cli/test_doctor_profiles.py` — doctor flags a profile-less embedding/reranking slot, still skips a profile-less `llm` slot, and names the device-correct repair profile.
- Review round 2 regression tests, each red on the branch head before the fix (`5e7e7e26`):
  - `tests/slots/test_slot_type_profile_inference.py::test_type_implied_profile[tts-gpu-vulkan-None]`, `::test_type_implied_profile_vetoes_a_runtime_family_the_device_cannot_run`, `::test_create_leaves_a_vulkan_tts_slot_on_the_kokoro_fallback` — the TTS/Vulkan regression, at the rule and at `SlotManager.create`.
  - `tests/capabilities/test_orchestrator_autocreated_slot_type.py` — `_ensure_slot_exists` for `rerank` (both devices) and `img` writes the seed's `type`, and the rerank slot's TOML therefore carries `profile = "reranking"`; the embed child keeps its trio type.
  - `tests/slots/test_slot_type_profile_inference.py::test_type_implied_profile_ignores_the_cli_legacy_provider_default` and `tests/cli/test_doctor_profiles.py::test_refs_repair_command_is_device_aware`.
  - The old `("image", "img")` matrix row was replaced with the reachable `("image", "gpu-rocm")` one: `img` is a device_class, not a `DeviceLiteral`, so that row was green on an input no slot can have.
- Deliberate, commented updates to the two pinned matrices this changes: `tests/config/test_profile_derivation_parity.py` (`("embed","cpu") → embedding`, `("rerank","cpu") → reranking`) and `tests/install/test_profile_derive.py` (which now also asserts the seeds stay `backend=None`/`device_class=None`, preserving the #807/#834 coherence property the original test protected).
- Full suite green; `ruff check` and `ruff format --check` clean; `scripts/check_sunset.py` clean (scar markers 192 ≤ baseline 192). `mypy src` unchanged from `main`'s pre-existing errors — nothing new in the touched files.
- The full run also caught a real defect in this branch: the deprecated `model assign` / `slot add` aliases call the Typer commands in-process, so the new `profile` parameter arrived as an `OptionInfo` sentinel and was PUT/POSTed. Fixed, with a regression test.

## Deliberately out of scope

- **No launch-time back-fill.** A profile-less capability slot already on disk (an upgraded box, per the issue's ct105 read-only cross-check) is not silently repaired at argv-resolve time — that would inject mode-changing flags into the goldened launch path for slots the operator never re-saved. It gets a visible, auditable repair instead: `hal0 doctor profiles` names it and `hal0 slot edit <name> --profile <name>` fixes it. An updater sweep that back-fills existing TOMLs is a reasonable follow-up.
- **`GET /api/slots/<name>/resolved` returning `{"argv": null}`** for such a slot (issue's "Nothing warns" section) is untouched — separate defect, separate PR.
- No `CHANGELOG.md` hunk (per #1545; the consolidated entry lands at the end of the wave).
- `tts` / `transcription` are inferred at create time (where hal0 ships an engine for the device) but deliberately not flagged by doctor when absent: those providers carry their own profile-less defaults, so an empty profile there is not a demonstrated 501. `image` infers nothing at all — the shared rule's generic GPU branch answers `chat` before its image branch and the fit veto drops it; the CLI help and the guide now say so instead of promising `image → comfyui`. Reordering that shared rule would also move the picker's model-fit evaluation for image models, so it is a separate change.
- **The runner veto compares backend only.** The runner registry keys ComfyUI under the pseudo device class `img` while its slot's device is `gpu-rocm`, so a device_class comparison there would veto correct answers; hardware-class coherence stays `profile_fits_slot`'s job.

Closes #1830

