### PR TITLE
fix(registry): stop reporting high confidence for a filename-derived gguf capability guess

### DIFF
--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -445,9 +445,13 @@ def model_add(
     if warning:
         console.print(f"  [yellow]warning:[/yellow] {warning}")
     elif confidence and confidence != "high":
+        # #1838 (codex review): a medium result can come from a filename
+        # guess OR from a header signal (attention.causal=False) that
+        # contradicts the "chat" default — don't claim it's always the
+        # filename, just that it's not a confident header read.
         console.print(
             f"  [yellow]confidence: {confidence}[/yellow] "
-            "(capabilities/backends guessed from the filename, not the file header)"
+            "(capabilities/backends could not be reliably read from the file header)"
         )
     console.print(
         f"[dim]Next: hal0 model run {mid}   (or: hal0 slot edit <slot> --model {mid})[/dim]"

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -401,7 +401,11 @@ def model_add(
     """Register an already-downloaded model file — capabilities auto-detected.
 
     Reads the file header to derive id, capabilities and backends; the
-    file stays where it is (no copy). Folds in the explicit-metadata flags
+    file stays where it is (no copy). When the header doesn't carry enough
+    signal (e.g. no ``pooling_type``), capabilities fall back to a filename
+    guess — watch for the confidence/warning line this command prints, and
+    fix a wrong guess with ``PUT /api/models/<id>``
+    (``{"capabilities": [...]}``). Folds in the explicit-metadata flags
     (``--id``, ``--name``, ``--license``) that the old ``model register``
     command exposed, so this command now covers both cases.
     """
@@ -430,6 +434,21 @@ def model_add(
     console.print(f"Registered [bold]{mid}[/bold] → {m.get('path', path)}")
     caps = ", ".join(m.get("capabilities", []) or []) or "—"
     console.print(f"  capabilities: {caps}")
+    # #1838: detect() may have guessed capabilities/backends from the
+    # filename alone (confidence != "high") or failed to read a valid GGUF
+    # header at all — both cases used to print the same confident success
+    # line as a header-derived "high" hit, which reads like a fact when
+    # it's a guess.
+    meta = m.get("metadata") or {}
+    confidence = meta.get("detection_confidence")
+    warning = meta.get("detection_warning")
+    if warning:
+        console.print(f"  [yellow]warning:[/yellow] {warning}")
+    elif confidence and confidence != "high":
+        console.print(
+            f"  [yellow]confidence: {confidence}[/yellow] "
+            "(capabilities/backends guessed from the filename, not the file header)"
+        )
     console.print(
         f"[dim]Next: hal0 model run {mid}   (or: hal0 slot edit <slot> --model {mid})[/dim]"
     )

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -8,12 +8,26 @@ persisting.
 Detection strategy, cheapest first:
 
 1. ``.gguf`` files → :func:`hal0.registry.gguf_header.read_gguf_header`
-   to pull arch + context_length + pooling_type. Strong evidence →
-   ``confidence='high'``. The four GGUF backends are seeded:
-   ``vulkan``, ``rocm``, ``cuda``, ``cpu``. Capability is ``embed`` when
-   ``pooling_type`` is present and non-zero (llama.cpp marks pooling_type
-   = NONE as 0 for chat models, > 0 for embed/rerank pooled outputs),
-   else ``chat``.
+   to pull arch + context_length + pooling_type + tags + attention.causal.
+   The four GGUF backends are seeded: ``vulkan``, ``rocm``, ``cuda``,
+   ``cpu``. Capability is derived, cheapest/strongest signal first:
+
+   a. ``pooling_type`` present → ``rerank`` (RANK=4), ``embed``
+      (MEAN/CLS/LAST, i.e. any other non-zero value), else ``chat``.
+      ``confidence='high'`` — read directly off the header.
+   b. ``pooling_type`` absent but ``general.tags`` carries an
+      unambiguous rerank/embed token (some converters drop the pooling
+      key but keep the tags) → same, ``confidence='high'``.
+   c. Neither present → fall back to the filename token table (also
+      used by the install-time auto-scan). When the filename carries a
+      rerank/embed token, that token alone decides the outcome — a
+      *guess*, not a header read, even though the GGUF header itself
+      parsed fine — ``confidence='medium'`` (#1838: this used to report
+      ``'high'`` for a filename-only guess). When the filename carries
+      no signal either, the bare ``chat`` default applies and stays
+      ``confidence='high'`` — that's the expected, correct answer for
+      the overwhelming majority of causal chat ggufs, which don't set
+      ``pooling_type`` at all.
 2. Non-GGUF: filename heuristic only.  Keywords cover the providers we
    currently ship:
 
@@ -358,25 +372,68 @@ def detect(path: str | Path) -> DetectionResult:
         # pooling_type in its header registered as capabilities: chat).
         is_rerank = pooling == 4
         is_embed = not is_rerank and isinstance(pooling, int) and pooling > 0
+        cap_source = "pooling_type" if (is_rerank or is_embed) else None
 
-        # Filename token fallback in case pooling_type is missing but the
-        # file is clearly embed/rerank (some converters drop it). Uses the
-        # full shared token table, NOT the narrower ``_filename_capability``
-        # helper above — that one deliberately collapses "rerank" to None
-        # for detect()'s *older* embed/asr/tts-only contract, which is
-        # exactly the gap that let a rerank filename fall through to "chat"
-        # here. ``discover.scan_and_register`` (the install-time auto-scan)
-        # reads the same full table via ``_guess_capability`` and gets
-        # rerank right for the identical file — reuse its source of truth
-        # instead of re-diverging.
+        # #1838: header tie-breakers for converters that drop pooling_type
+        # entirely (the jina-reranker-v1-tiny-en case: no <arch>.pooling_type
+        # key at all, so without these the classification came *solely*
+        # from the filename while confidence was still reported "high").
+        # These three signals are unambiguous when present and are checked
+        # BEFORE the filename fallback:
+        #   * general.tags carrying "reranker"/"cross-encoder" or "embed"/
+        #     "sentence-similarity" tokens
+        #   * <arch>.attention.causal == False, which rules out a causal
+        #     chat model (combined with a tags hit to pick rerank vs embed)
+        if not is_rerank and not is_embed:
+            tags = header.get("general.tags")
+            tag_set = {str(t).lower() for t in tags} if isinstance(tags, list) else set()
+            if tag_set & {"reranker", "cross-encoder", "rerank"}:
+                is_rerank = True
+                cap_source = "header_tags"
+            elif tag_set & {"embed", "embedding", "sentence-similarity", "feature-extraction"}:
+                is_embed = True
+                cap_source = "header_tags"
+
+        # Filename token fallback in case pooling_type/tags are missing but
+        # the file is clearly embed/rerank (some converters drop both).
+        # Uses the full shared token table, NOT the narrower
+        # ``_filename_capability`` helper above — that one deliberately
+        # collapses "rerank" to None for detect()'s *older* embed/asr/tts-
+        # only contract, which is exactly the gap that let a rerank
+        # filename fall through to "chat" here. ``discover.scan_and_register``
+        # (the install-time auto-scan) reads the same full table via
+        # ``_guess_capability`` and gets rerank right for the identical
+        # file — reuse its source of truth instead of re-diverging.
+        #
+        # Anything landing here has NO header-derived capability signal —
+        # the classification is a filename guess, so confidence is lowered
+        # below (#1838) even though the header itself parsed cleanly.
         if not is_rerank and not is_embed:
             filename_cap = capability_from_filename(p.name)
             if filename_cap == "rerank":
                 is_rerank = True
+                cap_source = "filename"
             elif filename_cap == "embed":
                 is_embed = True
+                cap_source = "filename"
 
         caps = ["rerank"] if is_rerank else (["embed"] if is_embed else ["chat"])
+        if cap_source is None:
+            # Neither the header nor the filename carried any capability
+            # signal at all. This is the ordinary case for the overwhelming
+            # majority of causal chat ggufs (llama.cpp doesn't emit
+            # pooling_type for them) — "chat" is the correct, expected
+            # answer here, not a guess, so confidence stays high.
+            cap_source = "default"
+
+        # Confidence reflects how the *capability* (not just the header
+        # read) was derived. Only a filename token OVERRIDING the default
+        # is a guess (#1838's actual bug: a rerank/embed filename token is
+        # what silently decided the outcome while confidence still said
+        # "high"). A header-derived signal (pooling_type or the tags/causal
+        # tie-breakers) is a read, and the bare "chat" default is the
+        # documented, expected fallback — both stay high.
+        confidence: Confidence = "medium" if cap_source == "filename" else "high"
 
         name_candidate = header.get("general.name") or header.get("general.basename")
         suggested_name = (
@@ -402,13 +459,16 @@ def detect(path: str | Path) -> DetectionResult:
             suggested_backends=list(_GGUF_BACKENDS),
             suggested_capabilities=caps,
             context_length=ctx_len_int,
-            confidence="high",
+            confidence=confidence,
             suggested_name=suggested_name,
             kind="llama",
             raw_hints={
                 "source": "gguf_header",
                 "architecture": arch,
                 "pooling_type": pooling,
+                "attention_causal": header.get("attention_causal"),
+                "tags": header.get("general.tags"),
+                "capability_source": cap_source,
                 "version": header.get("version"),
                 "name": header.get("general.name"),
                 "basename": header.get("general.basename"),

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -19,15 +19,24 @@ Detection strategy, cheapest first:
       unambiguous rerank/embed token (some converters drop the pooling
       key but keep the tags) → same, ``confidence='high'``.
    c. Neither present → fall back to the filename token table (also
-      used by the install-time auto-scan). When the filename carries a
+      used by the install-time auto-scan; a HF hub-cache symlink's own
+      name, not the resolved sha-blob's). When the filename carries a
       rerank/embed token, that token alone decides the outcome — a
       *guess*, not a header read, even though the GGUF header itself
       parsed fine — ``confidence='medium'`` (#1838: this used to report
       ``'high'`` for a filename-only guess). When the filename carries
-      no signal either, the bare ``chat`` default applies and stays
-      ``confidence='high'`` — that's the expected, correct answer for
-      the overwhelming majority of causal chat ggufs, which don't set
-      ``pooling_type`` at all.
+      no signal either:
+        - ``<arch>.attention.causal`` explicitly ``False`` contradicts
+          the ``chat`` default (it rules out a causal chat model) →
+          still ``chat`` (we don't know embed vs rerank), but
+          ``confidence='medium'``.
+        - otherwise the bare ``chat`` default applies and stays
+          ``confidence='high'`` — that's the expected, correct answer
+          for the overwhelming majority of causal chat ggufs, which
+          don't set ``pooling_type`` at all.
+   Note: an explicit ``pooling_type=0`` (NONE, the causal-chat value) is
+   authoritative and skips (b)/(c) entirely — a stray tag or filename
+   token can't override a header that already said "chat".
 2. Non-GGUF: filename heuristic only.  Keywords cover the providers we
    currently ship:
 
@@ -338,14 +347,25 @@ def _heuristic_only(path: Path) -> DetectionResult:
 # ── public API ─────────────────────────────────────────────────────────────
 
 
-def detect(path: str | Path) -> DetectionResult:
+def detect(path: str | Path, *, filename_hint: str | None = None) -> DetectionResult:
     """Inspect ``path`` and return a :class:`DetectionResult`.
 
     Never raises for an unreadable / missing / non-GGUF file: we fall
     back to the filename heuristic and lower the confidence.
+
+    ``filename_hint`` — the operator-typed name to use for the capability
+    filename-token fallback, when it differs from ``path`` (#1838: a
+    HuggingFace hub-cache symlink's real, human-readable name lives at
+    ``snapshots/<rev>/<name>.gguf``; ``path`` here is usually the
+    *resolved* sha-named blob it points at, which carries no filename
+    signal at all). Extension/header-validity checks still use ``path``
+    unchanged — that's the #1415 contract (an extensionless literal must
+    still consult the resolved target's suffix). Defaults to ``path``'s
+    own name when omitted.
     """
     p = Path(path)
     suffix = p.suffix.lower()
+    name_for_capability = filename_hint if filename_hint is not None else p.name
 
     # Try GGUF magic bytes regardless of extension — HF blob cache stores
     # GGUF data under content-hash filenames with no suffix.
@@ -372,19 +392,26 @@ def detect(path: str | Path) -> DetectionResult:
         # pooling_type in its header registered as capabilities: chat).
         is_rerank = pooling == 4
         is_embed = not is_rerank and isinstance(pooling, int) and pooling > 0
-        cap_source = "pooling_type" if (is_rerank or is_embed) else None
+        # pooling_type==0 (NONE) is an explicit, authoritative "this is a
+        # causal chat model" read too — not just non-zero values — so it
+        # also gets the "pooling_type" source/high confidence. The
+        # tie-breakers/fallbacks below are for headers that DROP the key
+        # entirely, not ones that set it to the chat value. Gate everything
+        # past this point on the key being genuinely absent so an explicit
+        # 0 can't be second-guessed by a stray tag or filename token.
+        pooling_present = pooling is not None
+        cap_source = "pooling_type" if pooling_present else None
+
+        causal = header.get("attention_causal")
 
         # #1838: header tie-breakers for converters that drop pooling_type
         # entirely (the jina-reranker-v1-tiny-en case: no <arch>.pooling_type
         # key at all, so without these the classification came *solely*
         # from the filename while confidence was still reported "high").
-        # These three signals are unambiguous when present and are checked
-        # BEFORE the filename fallback:
-        #   * general.tags carrying "reranker"/"cross-encoder" or "embed"/
-        #     "sentence-similarity" tokens
-        #   * <arch>.attention.causal == False, which rules out a causal
-        #     chat model (combined with a tags hit to pick rerank vs embed)
-        if not is_rerank and not is_embed:
+        # These are unambiguous when present and are checked BEFORE the
+        # filename fallback: general.tags carrying "reranker"/"cross-encoder"
+        # or "embed"/"sentence-similarity" tokens.
+        if not pooling_present:
             tags = header.get("general.tags")
             tag_set = {str(t).lower() for t in tags} if isinstance(tags, list) else set()
             if tag_set & {"reranker", "cross-encoder", "rerank"}:
@@ -405,11 +432,17 @@ def detect(path: str | Path) -> DetectionResult:
         # ``_guess_capability`` and gets rerank right for the identical
         # file — reuse its source of truth instead of re-diverging.
         #
+        # Uses ``name_for_capability`` (the operator-typed name when the
+        # caller supplied one), NOT ``p.name`` — a HF hub-cache symlink
+        # resolves ``p`` to a sha-named blob whose name carries no signal
+        # at all, which would otherwise hide a real filename token like
+        # "jina-reranker-*.gguf" from this fallback (#1838).
+        #
         # Anything landing here has NO header-derived capability signal —
         # the classification is a filename guess, so confidence is lowered
         # below (#1838) even though the header itself parsed cleanly.
-        if not is_rerank and not is_embed:
-            filename_cap = capability_from_filename(p.name)
+        if not pooling_present and not is_rerank and not is_embed:
+            filename_cap = capability_from_filename(name_for_capability)
             if filename_cap == "rerank":
                 is_rerank = True
                 cap_source = "filename"
@@ -419,21 +452,33 @@ def detect(path: str | Path) -> DetectionResult:
 
         caps = ["rerank"] if is_rerank else (["embed"] if is_embed else ["chat"])
         if cap_source is None:
-            # Neither the header nor the filename carried any capability
-            # signal at all. This is the ordinary case for the overwhelming
-            # majority of causal chat ggufs (llama.cpp doesn't emit
-            # pooling_type for them) — "chat" is the correct, expected
-            # answer here, not a guess, so confidence stays high.
             cap_source = "default"
+            if not pooling_present and causal is False:
+                # #1838: the header explicitly rules out a causal chat
+                # model (attention.causal=False) but neither tags nor the
+                # filename told us which non-chat capability it actually
+                # is. Defaulting to "chat" here would contradict evidence
+                # the header itself provided — that's worse than the
+                # ordinary "no signal at all" default, so it does not get
+                # the ordinary default's high confidence.
+                cap_source = "causal_conflict"
+            # else: neither the header nor the filename carried any
+            # capability signal at all. This is the ordinary case for the
+            # overwhelming majority of causal chat ggufs (llama.cpp doesn't
+            # emit pooling_type for them) — "chat" is the correct, expected
+            # answer here, not a guess, so confidence stays high.
 
         # Confidence reflects how the *capability* (not just the header
-        # read) was derived. Only a filename token OVERRIDING the default
-        # is a guess (#1838's actual bug: a rerank/embed filename token is
-        # what silently decided the outcome while confidence still said
-        # "high"). A header-derived signal (pooling_type or the tags/causal
-        # tie-breakers) is a read, and the bare "chat" default is the
-        # documented, expected fallback — both stay high.
-        confidence: Confidence = "medium" if cap_source == "filename" else "high"
+        # read) was derived. A filename token OVERRIDING the default, or a
+        # "chat" default that contradicts an explicit attention.causal=False
+        # read, is a guess (#1838's actual bug: a rerank/embed filename
+        # token is what silently decided the outcome while confidence still
+        # said "high"). A header-derived signal (pooling_type or the tags
+        # tie-breaker) is a read, and the ordinary no-signal "chat" default
+        # is the documented, expected fallback — both stay high.
+        confidence: Confidence = (
+            "medium" if cap_source in ("filename", "causal_conflict") else "high"
+        )
 
         name_candidate = header.get("general.name") or header.get("general.basename")
         suggested_name = (

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -432,10 +432,21 @@ def detect(path: str | Path, *, filename_hint: str | None = None) -> DetectionRe
         if not pooling_present:
             tags = header.get("general.tags")
             tag_set = {str(t).lower() for t in tags} if isinstance(tags, list) else set()
-            if tag_set & {"reranker", "cross-encoder", "rerank"}:
+            rerank_tag_hit = bool(tag_set & {"reranker", "cross-encoder", "rerank"})
+            embed_tag_hit = bool(
+                tag_set & {"embed", "embedding", "sentence-similarity", "feature-extraction"}
+            )
+            # #1838 (codex review): general.tags is free text — a converter
+            # can legally carry BOTH a rerank token and an embed token
+            # (e.g. a reranker also tagged "feature-extraction" for its
+            # underlying encoder). That's genuinely ambiguous, not a tie-
+            # breaker; fall through to the filename table rather than
+            # silently picking whichever group happened to be checked
+            # first.
+            if rerank_tag_hit and not embed_tag_hit:
                 is_rerank = True
                 cap_source = "header_tags"
-            elif tag_set & {"embed", "embedding", "sentence-similarity", "feature-extraction"}:
+            elif embed_tag_hit and not rerank_tag_hit:
                 is_embed = True
                 cap_source = "header_tags"
 

--- a/src/hal0/registry/detect.py
+++ b/src/hal0/registry/detect.py
@@ -280,10 +280,16 @@ def _filename_capability(name: str) -> str | None:
     return cap if cap in ("embed", "asr", "tts") else None
 
 
-def _heuristic_only(path: Path) -> DetectionResult:
-    """Fallback detection: filename heuristic, no header read."""
-    name = path.name.lower()
-    cap = _filename_capability(name)
+def _heuristic_only(path: Path, *, filename_hint: str | None = None) -> DetectionResult:
+    """Fallback detection: filename heuristic, no header read.
+
+    ``filename_hint`` — see :func:`detect`'s docstring (#1838). Used for
+    capability-token matching and the ``.gguf`` backend-seed check only;
+    identity fields (``suggested_name``, ``quant``, ``raw_hints["stem"/
+    "suffix"]``) stay derived from ``path`` itself.
+    """
+    hint_name = (filename_hint or path.name).lower()
+    cap = _filename_capability(hint_name)
 
     # A file under the ComfyUI models tree is an image-gen asset — tag it
     # image/comfyui so add-by-path / scan-preview file it on the dashboard's
@@ -305,11 +311,11 @@ def _heuristic_only(path: Path) -> DetectionResult:
     backends: list[str] = []
     caps: list[str] = []
     kind: Kind = "unknown"
-    if "moonshine" in name:
+    if "moonshine" in hint_name:
         backends = ["moonshine"]
         caps = ["asr"]
         kind = "moonshine"
-    elif "kokoro" in name:
+    elif "kokoro" in hint_name:
         backends = ["kokoro"]
         caps = ["tts"]
         kind = "kokoro"
@@ -326,7 +332,11 @@ def _heuristic_only(path: Path) -> DetectionResult:
         # embed-ish filename but extension says it's not GGUF — leave
         # backends empty; user picks. Treat as unknown until format is clear.
         caps = ["embed"]
-    elif path.suffix.lower() == ".gguf":
+    elif path.suffix.lower() == ".gguf" or Path(hint_name).suffix == ".gguf":
+        # #1838: the resolved path may be an extensionless HF hub-cache
+        # blob even though the operator's own filename (the hint) is
+        # unmistakably "*.gguf" — either one claiming .gguf is enough to
+        # seed the GGUF backends instead of leaving the row unclassified.
         backends = list(_GGUF_BACKENDS)
         caps = ["chat"]
         kind = "llama"
@@ -353,28 +363,36 @@ def detect(path: str | Path, *, filename_hint: str | None = None) -> DetectionRe
     Never raises for an unreadable / missing / non-GGUF file: we fall
     back to the filename heuristic and lower the confidence.
 
-    ``filename_hint`` — the operator-typed name to use for the capability
-    filename-token fallback, when it differs from ``path`` (#1838: a
-    HuggingFace hub-cache symlink's real, human-readable name lives at
-    ``snapshots/<rev>/<name>.gguf``; ``path`` here is usually the
-    *resolved* sha-named blob it points at, which carries no filename
-    signal at all). Extension/header-validity checks still use ``path``
-    unchanged — that's the #1415 contract (an extensionless literal must
-    still consult the resolved target's suffix). Defaults to ``path``'s
-    own name when omitted.
+    ``filename_hint`` — the operator-typed name to use for capability
+    filename-token matching AND the ".gguf claimed" check below, when it
+    differs from ``path`` (#1838: a HuggingFace hub-cache symlink's real,
+    human-readable name lives at ``snapshots/<rev>/<name>.gguf``; ``path``
+    here is usually the *resolved* sha-named blob it points at, which
+    carries no filename signal — and no ``.gguf`` suffix — at all).
+    Identity fields (``suggested_name``, quant-from-filename, ``stem``)
+    stay derived from ``path`` unchanged; only the two things that decide
+    "did the operator ask for a GGUF file" use the hint when given.
+    Defaults to ``path``'s own name when omitted.
     """
     p = Path(path)
     suffix = p.suffix.lower()
     name_for_capability = filename_hint if filename_hint is not None else p.name
+    # #1838: a resolved HF hub-cache blob is extensionless even when the
+    # symlink the operator pointed at is unmistakably "*.gguf" — without
+    # also checking the hint's suffix, a bad-magic blob silently fell all
+    # the way to the generic "unknown, no backends, no warning" path
+    # instead of the deliberate "claims .gguf but magic failed" one.
+    hint_suffix = Path(name_for_capability).suffix.lower()
+    claims_gguf = suffix == ".gguf" or hint_suffix == ".gguf"
 
     # Try GGUF magic bytes regardless of extension — HF blob cache stores
     # GGUF data under content-hash filenames with no suffix.
     header = read_gguf_header(p)
-    if header is not None or suffix == ".gguf":
+    if header is not None or claims_gguf:
         if header is None:
-            # Suffix claimed .gguf but magic failed: degrade to heuristic
-            # with the GGUF backend seed.
-            r = _heuristic_only(p)
+            # Suffix (or the operator-typed hint) claimed .gguf but magic
+            # failed: degrade to heuristic with the GGUF backend seed.
+            r = _heuristic_only(p, filename_hint=filename_hint)
             r.raw_hints["gguf_header_read"] = "failed"
             return r
 
@@ -524,7 +542,7 @@ def detect(path: str | Path, *, filename_hint: str | None = None) -> DetectionRe
         )
 
     # Non-GGUF file: filename heuristic only.
-    return _heuristic_only(p)
+    return _heuristic_only(p, filename_hint=filename_hint)
 
 
 __all__ = [

--- a/src/hal0/registry/gguf_header.py
+++ b/src/hal0/registry/gguf_header.py
@@ -290,11 +290,23 @@ def read_gguf_header(path: str | Path) -> dict[str, Any] | None:
                             f"{arch}.pooling_type",
                             f"{arch}.attention.causal",
                         )
-                    if not want and arch is None and key.endswith(".context_length"):
-                        # Capture arch-prefixed context_length even if we
-                        # haven't seen general.architecture yet (rare but
-                        # legal).  We stash both the value and the prefix
-                        # so we can promote later if it matches.
+                    if (
+                        not want
+                        and arch is None
+                        and (
+                            key.endswith(".context_length")
+                            or key.endswith(".pooling_type")
+                            or key.endswith(".attention.causal")
+                        )
+                    ):
+                        # Capture arch-prefixed context_length/pooling_type/
+                        # attention.causal even if we haven't seen
+                        # general.architecture yet (rare but legal — the
+                        # spec doesn't promise ordering, #1838 codex
+                        # review). We stash the value under its own
+                        # <prefix>.<key> and promote it below once/if the
+                        # matching arch turns up (or, absent that, take
+                        # the first one we saw).
                         want = True
 
                     if want:
@@ -323,12 +335,20 @@ def read_gguf_header(path: str | Path) -> dict[str, Any] | None:
                 if causal_key in out:
                     out["attention_causal"] = out[causal_key]
             else:
-                # No arch but we may have captured a *.context_length on
-                # the speculative branch above.  Promote the first one.
-                for k, v in out.items():
-                    if k.endswith(".context_length") and k != "context_length":
-                        out["context_length"] = v
-                        break
+                # No arch but we may have captured a *.context_length /
+                # *.pooling_type / *.attention.causal on the speculative
+                # branch above. Promote the first one of each.
+                for suffix, alias in (
+                    (".context_length", "context_length"),
+                    (".pooling_type", "pooling_type"),
+                    (".attention.causal", "attention_causal"),
+                ):
+                    if alias in out:
+                        continue
+                    for k, v in out.items():
+                        if k.endswith(suffix) and k != alias:
+                            out[alias] = v
+                            break
 
             return out
         finally:

--- a/src/hal0/registry/gguf_header.py
+++ b/src/hal0/registry/gguf_header.py
@@ -26,8 +26,10 @@ specifically::
 
     general.architecture
     general.embedding_length
+    general.tags
     <arch>.context_length
     <arch>.pooling_type
+    <arch>.attention.causal
 
 The parser skips other KV values without materialising them whenever it
 can, to keep memory + token cost bounded.
@@ -92,6 +94,11 @@ _INTERESTING_KEYS_STATIC: frozenset[str] = frozenset(
         # llama.cpp LLAMA_FTYPE enum — the authoritative quantisation
         # signal (WS-13); registry/detect maps it to a "Q4_K_M"-style label.
         "general.file_type",
+        # #1838: capability tie-breakers for headers that omit
+        # <arch>.pooling_type — a reranker/embed converter that drops the
+        # pooling key still tends to carry these. general.tags is an array
+        # of free-text strings (e.g. ["reranker", "cross-encoder"]).
+        "general.tags",
     }
 )
 
@@ -278,7 +285,11 @@ def read_gguf_header(path: str | Path) -> dict[str, Any] | None:
 
                     want = key in _INTERESTING_KEYS_STATIC
                     if not want and arch is not None:
-                        want = key == f"{arch}.context_length" or key == f"{arch}.pooling_type"
+                        want = key in (
+                            f"{arch}.context_length",
+                            f"{arch}.pooling_type",
+                            f"{arch}.attention.causal",
+                        )
                     if not want and arch is None and key.endswith(".context_length"):
                         # Capture arch-prefixed context_length even if we
                         # haven't seen general.architecture yet (rare but
@@ -304,10 +315,13 @@ def read_gguf_header(path: str | Path) -> dict[str, Any] | None:
             if arch:
                 ctx_key = f"{arch}.context_length"
                 pool_key = f"{arch}.pooling_type"
+                causal_key = f"{arch}.attention.causal"
                 if ctx_key in out:
                     out["context_length"] = out[ctx_key]
                 if pool_key in out:
                     out["pooling_type"] = out[pool_key]
+                if causal_key in out:
+                    out["attention_causal"] = out[causal_key]
             else:
                 # No arch but we may have captured a *.context_length on
                 # the speculative branch above.  Promote the first one.

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -364,7 +364,10 @@ async def commit_scan_rows(
         except OSError:
             resolved = path
 
-        detection = detect(resolved)
+        # #1838: see add_from_path's matching comment — pass the operator-
+        # typed name so a HF hub-cache symlink's resolved sha-named blob
+        # doesn't hide a real filename capability token.
+        detection = detect(resolved, filename_hint=path.name)
         backends = row.get("backends")
         capabilities = row.get("capabilities")
         if not isinstance(backends, list):
@@ -1043,7 +1046,11 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
             details={"path": str(path), "allowed": sorted(allowed_exts)},
         )
 
-    detection = detect(resolved)
+    # #1838: pass the operator-typed name for the capability filename-token
+    # fallback — a HF hub-cache symlink resolves to a sha-named blob whose
+    # name carries no signal at all, which would otherwise silently hide a
+    # real filename token like "jina-reranker-*.gguf" from detect().
+    detection = detect(resolved, filename_hint=path.name)
     raw_labels = body.get("labels")
     if isinstance(raw_labels, list) and raw_labels:
         capabilities = [str(c) for c in raw_labels if isinstance(c, str) and c.strip()]
@@ -1086,15 +1093,20 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
     # #1838: surface how confident detect() actually is instead of
     # dropping it on the floor — an operator who supplied no explicit
     # ``labels`` is trusting auto-detection, and a "medium"/"low" result
-    # (filename guess, or an unreadable/non-GGUF header) needs to reach
-    # the API response and the CLI line, not just detect()'s return value.
-    if not (isinstance(raw_labels, list) and raw_labels):
+    # (filename guess) needs to reach the API response and the CLI line,
+    # not just detect()'s return value.
+    explicit_labels = isinstance(raw_labels, list) and raw_labels
+    if not explicit_labels:
         metadata["detection_confidence"] = detection.confidence
-        if detection.raw_hints.get("gguf_header_read") == "failed":
-            metadata["detection_warning"] = (
-                "no valid GGUF header found (bad or missing magic bytes); "
-                "capabilities/backends are a filename guess"
-            )
+    # A failed GGUF header read is a fact about the FILE, not the requested
+    # capability — surface it even when the caller supplied explicit
+    # ``labels`` (only capability got overridden; the bytes on disk may
+    # still be garbage, and backends still come from detect()'s guess).
+    if detection.raw_hints.get("gguf_header_read") == "failed":
+        metadata["detection_warning"] = (
+            "no valid GGUF header found (bad or missing magic bytes); "
+            "capabilities/backends are a filename guess"
+        )
 
     try:
         model = Model(

--- a/src/hal0/services/models_service.py
+++ b/src/hal0/services/models_service.py
@@ -1083,6 +1083,18 @@ async def add_from_path(body: dict[str, Any], *, registry: Any, event_bus: Any) 
     metadata: dict[str, Any] = {"discovered": True, "source": "add-from-path"}
     if detection.context_length is not None:
         metadata["context_length"] = detection.context_length
+    # #1838: surface how confident detect() actually is instead of
+    # dropping it on the floor — an operator who supplied no explicit
+    # ``labels`` is trusting auto-detection, and a "medium"/"low" result
+    # (filename guess, or an unreadable/non-GGUF header) needs to reach
+    # the API response and the CLI line, not just detect()'s return value.
+    if not (isinstance(raw_labels, list) and raw_labels):
+        metadata["detection_confidence"] = detection.confidence
+        if detection.raw_hints.get("gguf_header_read") == "failed":
+            metadata["detection_warning"] = (
+                "no valid GGUF header found (bad or missing magic bytes); "
+                "capabilities/backends are a filename guess"
+            )
 
     try:
         model = Model(

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -117,6 +117,12 @@ def test_add_from_path_honours_explicit_id_and_labels(
     assert body["id"] == "user.my-custom-id"
     assert body["name"] == "My custom name"
     assert body["capabilities"] == ["embed", "chat"]
+    # #1838 (codex review): explicit labels override CAPABILITY, but the
+    # header-invalid warning is a fact about the bytes on disk, not the
+    # requested capability — it must still surface even when labels were
+    # supplied (this fixture's bytes have no valid GGUF magic either).
+    assert "detection_confidence" not in body["metadata"]
+    assert "no valid GGUF header" in body["metadata"]["detection_warning"]
 
 
 def test_add_from_path_rejects_missing_file(
@@ -278,6 +284,33 @@ def test_add_from_path_accepts_gguf_symlink_into_extensionless_blob(
     assert "qwen3" in body["id"].lower()
     assert link.resolve().name not in body["id"]
     assert link.resolve().name not in body["name"]
+
+
+def test_add_from_path_symlink_capability_uses_operators_filename(
+    add_path_client: tuple[TestClient, Path],
+) -> None:
+    """#1838 (codex review): a HF hub-cache symlink resolves to a sha-named
+    blob with no filename signal — detect() must fall back to the
+    operator-typed name (the symlink itself), not the opaque blob name, so
+    a real capability token like "reranker" isn't silently hidden."""
+    client, drop = add_path_client
+    kvs = [
+        ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+    ]
+    link = _hub_layout(
+        drop,
+        repo="jinaai/jina-reranker-v2-base-multilingual-GGUF",
+        revision="abc123",
+        filename="jina-reranker-v2-base.gguf",
+        body=_build_gguf(3, kvs),
+    )
+    assert link.resolve().suffix == "", "fixture must reproduce the extensionless blob"
+
+    r = client.post("/api/models/add-from-path", json={"path": str(link)})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["capabilities"] == ["rerank"]
+    assert body["metadata"]["detection_confidence"] == "medium"
 
 
 def test_add_from_path_id_from_filename_not_gguf_arch_header(

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -63,10 +63,37 @@ def test_add_from_path_registers_gguf(
     # GGUF backend seed (vulkan/rocm/cuda/cpu).
     assert "chat" in body["capabilities"]
     assert "vulkan" in body["backends"]
+    # #1838 part B: a file with a .gguf extension but no valid GGUF magic
+    # is still registered (by design — recoverable with `model rm`), but
+    # the API response must surface that the header read failed instead
+    # of silently reporting a confident "chat" registration.
+    assert body["metadata"]["detection_confidence"] == "low"
+    assert "no valid GGUF header" in body["metadata"]["detection_warning"]
 
     listing = client.get("/api/models").json()
     ids = {m["id"] for m in listing.get("models", [])}
     assert body["id"] in ids
+
+
+def test_add_from_path_surfaces_medium_confidence_for_filename_guess(
+    add_path_client: tuple[TestClient, Path],
+) -> None:
+    """A real GGUF header that has to fall back to a filename token for
+    capability (no pooling_type) must report confidence='medium', not the
+    'high' a header-derived read gets — the core #1838 gap."""
+    client, drop = add_path_client
+    kvs = [
+        ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+    ]
+    target = drop / "jina-reranker-v2-base.gguf"
+    target.write_bytes(_build_gguf(3, kvs))
+
+    r = client.post("/api/models/add-from-path", json={"path": str(target)})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["capabilities"] == ["rerank"]
+    assert body["metadata"]["detection_confidence"] == "medium"
+    assert "detection_warning" not in body["metadata"]
 
 
 def test_add_from_path_honours_explicit_id_and_labels(

--- a/tests/api/test_models_add_from_path.py
+++ b/tests/api/test_models_add_from_path.py
@@ -284,6 +284,13 @@ def test_add_from_path_accepts_gguf_symlink_into_extensionless_blob(
     assert "qwen3" in body["id"].lower()
     assert link.resolve().name not in body["id"]
     assert link.resolve().name not in body["name"]
+    # #1838 (codex review): this fixture's bytes have no valid GGUF magic,
+    # and the resolved blob is extensionless — before the fix, detect()
+    # only recognised "claims .gguf" off the resolved path's suffix, so
+    # this exact HF hub-cache shape silently fell through to "unknown, no
+    # backends, no warning" instead of the deliberate failed-header path.
+    assert set(body["backends"]) == {"vulkan", "rocm", "cuda", "cpu"}
+    assert "no valid GGUF header" in body["metadata"]["detection_warning"]
 
 
 def test_add_from_path_symlink_capability_uses_operators_filename(

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -71,6 +71,58 @@ def test_model_add_posts_add_from_path(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "hal0 model run" in result.output
 
 
+def test_model_add_warns_on_failed_gguf_header_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#1838 part B: a .gguf file with no valid GGUF magic still registers
+    (by design), but the CLI must print the warning instead of the same
+    confident success line a real header-derived registration gets."""
+
+    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> dict[str, Any]:
+        return {
+            "id": "zzskeprand",
+            "path": "/mnt/ai-models/zzskeprand.gguf",
+            "capabilities": ["chat"],
+            "metadata": {
+                "detection_confidence": "low",
+                "detection_warning": (
+                    "no valid GGUF header found (bad or missing magic bytes); "
+                    "capabilities/backends are a filename guess"
+                ),
+            },
+        }
+
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(
+        model_commands.app,
+        ["add", "/mnt/ai-models/zzskeprand.gguf"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "warning" in result.output.lower()
+    assert "no valid GGUF header" in result.output
+
+
+def test_model_add_shows_medium_confidence_for_filename_guess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1838: a filename-derived capability guess must be visibly flagged,
+    not printed identically to a header-derived 'high' confidence hit."""
+
+    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> dict[str, Any]:
+        return {
+            "id": "jina-reranker-v2-base",
+            "path": "/mnt/ai-models/jina-reranker-v2-base.gguf",
+            "capabilities": ["rerank"],
+            "metadata": {"detection_confidence": "medium"},
+        }
+
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(
+        model_commands.app,
+        ["add", "/mnt/ai-models/jina-reranker-v2-base.gguf"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "medium" in result.output.lower()
+
+
 def test_model_add_with_license_follows_up_with_put(monkeypatch: pytest.MonkeyPatch) -> None:
     """CLI consolidation: `add` folded in `register`'s explicit-metadata
     flags — `--license` isn't accepted by add-from-path, so it's applied

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -123,6 +123,32 @@ def test_model_add_shows_medium_confidence_for_filename_guess(
     assert "medium" in result.output.lower()
 
 
+def test_model_add_medium_confidence_message_not_filename_specific(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1838 (codex review): a medium result can come from a header signal
+    (attention.causal=False contradicting the chat default) rather than a
+    filename guess — the printed explanation must not claim it's always
+    the filename."""
+
+    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> dict[str, Any]:
+        return {
+            "id": "zzscratchrr",
+            "path": "/mnt/ai-models/zzscratchrr.gguf",
+            "capabilities": ["chat"],
+            "metadata": {"detection_confidence": "medium"},
+        }
+
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(
+        model_commands.app,
+        ["add", "/mnt/ai-models/zzscratchrr.gguf"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "medium" in result.output.lower()
+    assert "filename" not in result.output.lower()
+
+
 def test_model_add_with_license_follows_up_with_put(monkeypatch: pytest.MonkeyPatch) -> None:
     """CLI consolidation: `add` folded in `register`'s explicit-metadata
     flags — `--license` isn't accepted by add-from-path, so it's applied

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -40,6 +40,24 @@ class TestGgufChat:
         r = detect(p)
         assert r.suggested_capabilities == ["chat"]
 
+    def test_explicit_pooling_zero_not_overridden_by_tags_or_filename(self, tmp_path: Path) -> None:
+        """#1838 (codex review): pooling_type=0 is an authoritative "chat"
+        read — a stray general.tags entry or a rerank-sounding filename
+        must not second-guess it."""
+        tags_bytes = (
+            struct.pack("<I", _GGUF_TYPE_STRING) + struct.pack("<Q", 1) + _enc_str("reranker")
+        )
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+            ("bert.pooling_type", _GGUF_TYPE_UINT32, struct.pack("<I", 0)),
+            ("general.tags", _GGUF_TYPE_ARRAY, tags_bytes),
+        ]
+        p = _write_fixture(tmp_path, "jina-reranker-mislabeled-chat.gguf", _build_gguf(3, kvs))
+        r = detect(p)
+        assert r.suggested_capabilities == ["chat"]
+        assert r.confidence == "high"
+        assert r.raw_hints["capability_source"] == "pooling_type"
+
 
 class TestGgufEmbed:
     def test_pooling_type_nonzero_means_embed(self, tmp_path: Path) -> None:
@@ -134,6 +152,40 @@ class TestGgufRerank:
         assert r_token.suggested_capabilities == ["rerank"]
         assert r_token.confidence == "high"
         assert r_token.raw_hints["capability_source"] == "header_tags"
+
+    def test_causal_false_downgrades_chat_default_confidence(self, tmp_path: Path) -> None:
+        """#1838 (codex review): no pooling_type, no tags, no filename token
+        — but attention.causal=False rules out a causal chat model. "chat"
+        is still returned (embed vs rerank is genuinely unknown) but must
+        not claim the ordinary default's high confidence."""
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("jina-bert-v2")),
+            ("jina-bert-v2.attention.causal", _GGUF_TYPE_BOOL, struct.pack("<B", 0)),
+        ]
+        p = _write_fixture(tmp_path, "zzscratchrr-no-tags.gguf", _build_gguf(3, kvs))
+        r = detect(p)
+        assert r.suggested_capabilities == ["chat"]
+        assert r.confidence == "medium"
+        assert r.raw_hints["capability_source"] == "causal_conflict"
+
+    def test_filename_hint_used_for_symlink_capability_fallback(self, tmp_path: Path) -> None:
+        """#1838 (codex review): the resolved path passed to detect() may be
+        a HF hub-cache sha-named blob with no filename signal — the caller
+        can pass the operator-typed name via filename_hint so a real
+        capability token isn't hidden by symlink resolution."""
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+        ]
+        blob = _write_fixture(tmp_path, "a1b2c3d4e5f6", _build_gguf(3, kvs))
+        # No hint: the blob's own name carries no rerank/embed token.
+        r_no_hint = detect(blob)
+        assert r_no_hint.suggested_capabilities == ["chat"]
+        # With the operator's real filename supplied as a hint, the token
+        # table sees "jina-reranker" and correctly classifies rerank.
+        r_hinted = detect(blob, filename_hint="jina-reranker-v2-base.gguf")
+        assert r_hinted.suggested_capabilities == ["rerank"]
+        assert r_hinted.confidence == "medium"
+        assert r_hinted.raw_hints["capability_source"] == "filename"
 
 
 class TestGgufUnreadable:

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 from hal0.registry.detect import detect
 from hal0.registry.gguf_header import (
+    _GGUF_TYPE_ARRAY,
+    _GGUF_TYPE_BOOL,
     _GGUF_TYPE_STRING,
     _GGUF_TYPE_UINT32,
 )
@@ -62,7 +64,10 @@ class TestGgufEmbed:
         p = _write_fixture(tmp_path, "bge-m3-embedding.gguf", _build_gguf(3, kvs))
         r = detect(p)
         assert r.suggested_capabilities == ["embed"]
-        assert r.confidence == "high"
+        # #1838: a filename-only capability guess must NOT report the same
+        # confidence as a header-derived read.
+        assert r.confidence == "medium"
+        assert r.raw_hints["capability_source"] == "filename"
 
 
 class TestGgufRerank:
@@ -91,6 +96,44 @@ class TestGgufRerank:
         p = _write_fixture(tmp_path, "jina-reranker-v2-base.gguf", _build_gguf(3, kvs))
         r = detect(p)
         assert r.suggested_capabilities == ["rerank"]
+        # #1838: this is a filename guess (no pooling_type, no header
+        # tags/causal tie-breaker) — confidence must reflect that.
+        assert r.confidence == "medium"
+        assert r.raw_hints["capability_source"] == "filename"
+
+    def test_header_tags_tiebreaker_wins_over_ambiguous_filename(self, tmp_path: Path) -> None:
+        """The live #1838 repro: two byte-identical files (no pooling_type),
+        one with a filename token ("jina-reranker...") and one without
+        ("zzscratchrr.gguf") must classify identically once the header
+        carries general.tags / attention.causal — the filename must stop
+        being the deciding factor."""
+        tags_bytes = (
+            struct.pack("<I", _GGUF_TYPE_STRING)
+            + struct.pack("<Q", 2)
+            + _enc_str("reranker")
+            + _enc_str("cross-encoder")
+        )
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("jina-bert-v2")),
+            ("general.tags", _GGUF_TYPE_ARRAY, tags_bytes),
+            ("jina-bert-v2.attention.causal", _GGUF_TYPE_BOOL, struct.pack("<B", 0)),
+        ]
+        payload = _build_gguf(3, kvs)
+
+        # Filename carries no rerank/embed token at all.
+        p_no_token = _write_fixture(tmp_path, "zzscratchrr.gguf", payload)
+        r_no_token = detect(p_no_token)
+        assert r_no_token.suggested_capabilities == ["rerank"]
+        assert r_no_token.confidence == "high"
+        assert r_no_token.raw_hints["capability_source"] == "header_tags"
+
+        # Byte-identical file, filename DOES carry the "rerank" token —
+        # must agree with the token-less copy, not merely happen to match.
+        p_token = _write_fixture(tmp_path, "jina-reranker-v1-tiny-en.Q8_0.gguf", payload)
+        r_token = detect(p_token)
+        assert r_token.suggested_capabilities == ["rerank"]
+        assert r_token.confidence == "high"
+        assert r_token.raw_hints["capability_source"] == "header_tags"
 
 
 class TestGgufUnreadable:

--- a/tests/registry/test_detect.py
+++ b/tests/registry/test_detect.py
@@ -168,6 +168,40 @@ class TestGgufRerank:
         assert r.confidence == "medium"
         assert r.raw_hints["capability_source"] == "causal_conflict"
 
+    def test_conflicting_header_tags_fall_through_to_filename(self, tmp_path: Path) -> None:
+        """#1838 (codex review): general.tags is free text — a converter
+        can legally carry BOTH a rerank token and an embed token (e.g.
+        "reranker" + "feature-extraction" for the underlying encoder).
+        That's ambiguous, not a tie-breaker; the header_tags branch must
+        not silently pick one, it must fall through to the filename
+        table."""
+        tags_bytes = (
+            struct.pack("<I", _GGUF_TYPE_STRING)
+            + struct.pack("<Q", 2)
+            + _enc_str("reranker")
+            + _enc_str("feature-extraction")
+        )
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("jina-bert-v2")),
+            ("general.tags", _GGUF_TYPE_ARRAY, tags_bytes),
+        ]
+        payload = _build_gguf(3, kvs)
+
+        # No filename signal either → bare chat default, not a silent
+        # "first branch wins" rerank guess.
+        p = _write_fixture(tmp_path, "ambiguous-tags.gguf", payload)
+        r = detect(p)
+        assert r.suggested_capabilities == ["chat"]
+        assert r.raw_hints["capability_source"] == "default"
+
+        # Filename DOES carry a token → that token decides, not the
+        # ambiguous tags.
+        p_embed_name = _write_fixture(tmp_path, "ambiguous-tags-bge-embed.gguf", payload)
+        r_embed_name = detect(p_embed_name)
+        assert r_embed_name.suggested_capabilities == ["embed"]
+        assert r_embed_name.confidence == "medium"
+        assert r_embed_name.raw_hints["capability_source"] == "filename"
+
     def test_filename_hint_used_for_symlink_capability_fallback(self, tmp_path: Path) -> None:
         """#1838 (codex review): the resolved path passed to detect() may be
         a HF hub-cache sha-named blob with no filename signal — the caller

--- a/tests/registry/test_gguf_header.py
+++ b/tests/registry/test_gguf_header.py
@@ -11,6 +11,7 @@ import struct
 from pathlib import Path
 
 from hal0.registry.gguf_header import (
+    _GGUF_TYPE_BOOL,
     _GGUF_TYPE_FLOAT32,
     _GGUF_TYPE_STRING,
     _GGUF_TYPE_UINT32,
@@ -111,6 +112,41 @@ class TestArchitectureAndContextLength:
         assert out is not None
         assert out["pooling_type"] == 2
         assert out["context_length"] == 512
+
+    def test_attention_causal_promoted_when_arch_comes_first(self, tmp_path: Path) -> None:
+        kvs = [
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("jina-bert-v2")),
+            ("jina-bert-v2.attention.causal", _GGUF_TYPE_BOOL, struct.pack("<B", 0)),
+        ]
+        p = _write_fixture(tmp_path, "jina.gguf", _build_gguf(3, kvs))
+        out = read_gguf_header(p)
+        assert out is not None
+        assert out["attention_causal"] is False
+
+    def test_attention_causal_promoted_when_arch_comes_after(self, tmp_path: Path) -> None:
+        """#1838 (codex review): GGUF doesn't guarantee KV ordering — a
+        header whose <arch>.attention.causal entry precedes
+        general.architecture must still get promoted, the same way
+        <arch>.context_length already does via the speculative capture."""
+        kvs = [
+            ("jina-bert-v2.attention.causal", _GGUF_TYPE_BOOL, struct.pack("<B", 0)),
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("jina-bert-v2")),
+        ]
+        p = _write_fixture(tmp_path, "jina-reordered.gguf", _build_gguf(3, kvs))
+        out = read_gguf_header(p)
+        assert out is not None
+        assert out["attention_causal"] is False
+
+    def test_pooling_type_promoted_when_arch_comes_after(self, tmp_path: Path) -> None:
+        """Same ordering gap as attention.causal, for pooling_type."""
+        kvs = [
+            ("bert.pooling_type", _GGUF_TYPE_UINT32, struct.pack("<I", 4)),
+            ("general.architecture", _GGUF_TYPE_STRING, _enc_str("bert")),
+        ]
+        p = _write_fixture(tmp_path, "reranker-reordered.gguf", _build_gguf(3, kvs))
+        out = read_gguf_header(p)
+        assert out is not None
+        assert out["pooling_type"] == 4
 
 
 class TestSkipping:


### PR DESCRIPTION
## What changed

Two narrow gaps in `hal0.registry.detect.detect()` (called by `hal0 model add` / `POST /api/models/add-from-path`):

**(A) Root cause fix — capability classification was filename-dependent even though the header carried unambiguous tie-breakers.** When a GGUF header omits `<arch>.pooling_type`, `detect()` fell straight to a filename-token guess and *still* reported `confidence: high` — indistinguishable from a real header-derived read. Two byte-identical files differing only in filename (`zzscratchrr.gguf` vs `jina-reranker-v1-tiny-en.Q8_0.gguf`) landed on different capabilities (`chat` vs `rerank`), both reported as `high` confidence, even though the shared header carries three unambiguous non-chat signals: `general.architecture = jina-bert-v2`, `general.tags = ['reranker', 'cross-encoder', …]`, `<arch>.attention.causal = False`.

  Fix: `gguf_header.py` now also extracts `general.tags` and `<arch>.attention.causal`. `detect()` checks `general.tags` for an unambiguous rerank/embed token as a tie-breaker **before** falling to the filename table, so the header — not the filename — decides capability whenever it can. Confidence is now tied to *how the capability was derived*, not just whether the header parsed:
  - `pooling_type` present, or a header-tags tie-breaker fires → `confidence: high` (a read).
  - Filename token overrides the default → `confidence: medium` (a guess) — this is the actual #1838 bug: it used to report `high` here.
  - No signal anywhere → bare `chat` default → stays `high`, since that's the correct, expected answer for the overwhelming majority of causal-LLM ggufs (which never set `pooling_type` at all) — not a guess that needs hedging.

**(B) Surfacing, not fixing, the by-design fallback.** A `.gguf`-named file with no valid GGUF magic still registers as `chat` (deliberate — see `detect()`'s docstring, recoverable with `model rm`), but `confidence: low` and `gguf_header_read: failed` were computed by `detect()` and then silently dropped before the API response / CLI output. Now `add_from_path` stashes `detection_confidence` / `detection_warning` into the model's `metadata`, and `hal0 model add` prints a warning (or a confidence line) instead of a blanket "Registered" + "Next: hal0 model run" as if the detection had been a clean read.

Also nudged `model add --help` to mention the confidence/warning line and the `PUT /api/models/<id>` capability-fix workaround, since the current copy ("capabilities auto-detected", no hedge) is what the issue flagged as misleading.

## Why

Filed as hal0 issue #1838 from the rc.5 release-validation run (real box repro, `tests/release-validation/reports/v1.0.0-rc.5.md`). The root cause is `detect()` treating a filename-fallback guess as equally trustworthy as a header read, and dropping the confidence signal it already computes before it reaches any caller.

## How verified

- New regression test `test_header_tags_tiebreaker_wins_over_ambiguous_filename` reproduces the exact live A/B (byte-identical file, two filenames) and asserts both now classify identically as `rerank`/`high` via the header tags, not the filename.
- Updated the two existing filename-fallback tests (`test_filename_fallback_for_embed_without_pooling`, `test_filename_fallback_for_rerank_without_pooling`) to assert `confidence == "medium"` and `raw_hints["capability_source"] == "filename"`.
- New API test `test_add_from_path_surfaces_medium_confidence_for_filename_guess` and an added assertion on the existing bad-header test verify `add-from-path`'s response `metadata.detection_confidence` / `detection_warning`.
- New CLI tests `test_model_add_warns_on_failed_gguf_header_read` and `test_model_add_shows_medium_confidence_for_filename_guess` verify the printed warning/confidence line.
- `HAL0_HOME=$(mktemp -d) uv run --extra dev pytest tests/` — 9973 passed, 15 skipped, 1 xfailed (pre-existing, unrelated).
- `make lint` and `uv run ruff format --check src tests` — clean.

## Left out of scope

- The issue's optional `--capability` flag for `hal0 model add` (a UX nicety, not the confidence-misreporting bug) — the docstring now points at the existing `PUT /api/models/<id>` workaround instead.
- `general.architecture` alone is not used as a capability tie-breaker (only `general.tags` / `attention.causal`) — mapping specific architecture strings to capabilities would need a maintained lookup table and is a broader, separate change.

Closes #1838