### PR TITLE
fix(slots): gate VRAM attribution on real GPU capability, add systemd cgroup fallback

### DIFF
--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -442,7 +442,15 @@ async def build_per_slot(
         # MAX of the cgroup and the registry estimate:
         #   • cgroup accurately includes weights → cgroup ≥ estimate → wins.
         #   • GTT not charged (cgroup too low)   → estimate wins → no under-report.
-        cgroup_bytes = await _container_cgroup_mem_bytes(s.name)
+        #
+        # Artefact token, not display name (#1839 review): on an id-keyed box
+        # (post ``hal0 slot migrate-id-keying``) the container/unit is named
+        # off the durable ``slot_id``, not the mutable display ``name`` — the
+        # two diverge the moment a slot is renamed. Mirrors
+        # :func:`hal0.slots.naming.slot_instance_token`'s id-over-name
+        # preference without needing a full config mapping.
+        artefact_token = str(getattr(s, "slot_id", None) or s.name)
+        cgroup_bytes = await _container_cgroup_mem_bytes(artefact_token)
         cgroup_mb = round(cgroup_bytes / (1024.0 * 1024.0), 1)
         resident_mb = max(cgroup_mb, estimate_mb)
 
@@ -464,8 +472,14 @@ async def build_per_slot(
         # hardware, so a GPU-declared slot on a GPU-less box (no
         # vulkan/compute-capable GPU probed) must ALSO book to ram_mb —
         # otherwise a CPU-only install shows phantom VRAM usage even
-        # though ``backend`` never says "cpu".
-        if backend == "cpu" or not gpu_capable:
+        # though ``backend`` never says "cpu". ``is_npu`` slots are
+        # EXCLUDED from this gate: an FLM slot that fell through to this
+        # common path (catalog miss / zero ``footprint_gb``) still uses the
+        # NPU's own UMA-style vram_mb accounting regardless of classic GPU
+        # capability — an NPU-only host has ``gpu_capable=False`` but its
+        # NPU slots never held phantom *GPU* VRAM in the first place, so
+        # the #1839 gate does not apply to them.
+        if backend == "cpu" or (not is_npu and not gpu_capable):
             vram_mb, ram_mb = 0.0, resident_mb
         else:
             vram_mb, ram_mb = resident_mb, 0.0

--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -35,6 +35,8 @@ from typing import TYPE_CHECKING, Any
 # silently diverging again (container.py is owned by another workstream, so
 # the constants cannot be moved to a neutral module from here).
 from hal0.providers.container import _CTX_DENSE_CAP
+from hal0.slots.metrics_collect import systemd_props
+from hal0.slots.naming import slot_unit_name
 from hal0.slots.state import SlotError
 
 if TYPE_CHECKING:
@@ -163,6 +165,44 @@ def _ctx_tokens_for(model_meta: dict[str, Any] | None) -> int:
 
 
 async def _container_cgroup_mem_bytes(slot_name: str) -> int:
+    """Cgroup-wide ``memory.current`` for the container/unit backing *slot_name*.
+
+    Two probes, tried in order:
+
+      1. :func:`_runtime_inspect_mem_bytes` — ``<runtime> inspect`` the
+         podman/docker container directly (highest fidelity: reads the
+         *container's* cgroup, not the systemd unit's).
+      2. :func:`_systemd_unit_mem_bytes` — the slot's own
+         ``hal0-slot@<name>.service`` unit's ``MemoryCurrent`` property,
+         read via ``systemctl show``.
+
+    Why two: on a standard install ``hal0-api`` runs unprivileged
+    (``User=hal0``, P3-perms) while slot containers are ROOTFUL podman
+    (Quadlet-launched, root's container store). ``podman inspect`` issued
+    from the API process is therefore permission-denied against root's
+    store and probe 1 silently returns 0 on *every* standard install, not
+    just when the container is absent (#1839). ``systemctl show`` has no
+    such problem — systemd (running as root) tracks each unit's cgroup
+    memory accounting as a property that any user can read, which is also
+    why ``/api/slots/metrics`` (:func:`hal0.slots.metrics_collect.collect_local`,
+    which already leans on this exact fallback) reports accurate RSS while
+    this probe used to silently under-report.
+
+    Returns 0 only when BOTH probes come up empty (container absent AND
+    the unit itself isn't loaded / has no cgroup) — not exceptional, it
+    just means the slot isn't backed by a live container/unit.
+
+    The returned value includes model weights + KV-cache + runtime
+    overhead as measured by the cgroup; callers MUST NOT add an
+    additional KV estimate on top.
+    """
+    mem_bytes = await _runtime_inspect_mem_bytes(slot_name)
+    if mem_bytes > 0:
+        return mem_bytes
+    return await _systemd_unit_mem_bytes(slot_name)
+
+
+async def _runtime_inspect_mem_bytes(slot_name: str) -> int:
     """Cgroup-wide ``memory.current`` for the podman/docker container backing *slot_name*.
 
     Container name convention: ``hal0-slot-<slot_name>`` (matches the
@@ -176,13 +216,10 @@ async def _container_cgroup_mem_bytes(slot_name: str) -> int:
       3. Read ``/proc/<pid>/cgroup`` for the cgroupv2 unified path.
       4. Read ``/sys/fs/cgroup/<path>/memory.current``.
 
-    Returns 0 on any error so the caller can fall back gracefully —
-    a missing/stopped container is not exceptional; it just means the
-    slot is not backed by a container runtime.
-
-    The returned value includes model weights + KV-cache + runtime
-    overhead as measured by the cgroup; callers MUST NOT add an
-    additional KV estimate on top.
+    Returns 0 on any error (including permission denied — a rootless
+    caller inspecting a rootful container) so the caller
+    (:func:`_container_cgroup_mem_bytes`) can fall back to the systemd
+    unit's own ``MemoryCurrent``.
     """
     import shutil
 
@@ -235,11 +272,61 @@ async def _container_cgroup_mem_bytes(slot_name: str) -> int:
         return 0
 
 
+async def _systemd_unit_mem_bytes(slot_name: str) -> int:
+    """``MemoryCurrent`` of the slot's own ``hal0-slot@<name>.service`` unit.
+
+    Read via ``systemctl show -p MemoryCurrent`` (:func:`hal0.slots.metrics_collect.systemd_props`)
+    — a plain systemd property query, not a container-runtime inspect, so it
+    needs no elevated privilege even when the container itself is ROOTFUL
+    podman (#1839). Quadlet places the container's workload cgroup under the
+    generated unit, so ``MemoryCurrent`` tracks the same memory the runtime
+    probe above tries (and often fails) to read directly.
+
+    Returns 0 when the unit isn't loaded, accounting is disabled
+    (``MemoryCurrent=[not set]``), or ``systemctl`` itself is unavailable —
+    same fail-soft contract as :func:`_runtime_inspect_mem_bytes`.
+    """
+    unit = slot_unit_name(slot_name)
+    props = await systemd_props(unit, "MemoryCurrent")
+    try:
+        mem = int(props.get("MemoryCurrent", "") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return mem if mem > 0 else 0
+
+
+def _host_has_capable_gpu() -> bool:
+    """True if the hardware probe found at least one usable GPU on this box.
+
+    "Usable" means Vulkan- or compute- (ROCm/CUDA) capable — the same
+    ``vulkan_capable`` / ``compute_capable`` signal #1799 added to
+    :class:`~hal0.config.schema.GPUInfo` and that :mod:`hal0.hardware.recommend`
+    already gates device recommendations on. Reads the cached
+    ``/etc/hal0/hardware.json`` written by ``hal0 probe`` via
+    :func:`hal0.config.loader.load_hardware_info` — cheap (one small JSON
+    file, no re-probe) and honest: an absent file / no probed GPU degrades
+    to ``HardwareInfo(gpus=[])``, which correctly reads as "no capable GPU"
+    rather than raising.
+
+    Never raises: any error probing/loading hardware state degrades to
+    ``False`` (the conservative choice — books memory as RAM rather than
+    risking phantom VRAM on a box we couldn't positively confirm has one).
+    """
+    try:
+        from hal0.config.loader import load_hardware_info
+
+        info = load_hardware_info()
+    except Exception:
+        return False
+    return any(g.vulkan_capable or g.compute_capable for g in info.gpus)
+
+
 async def build_per_slot(
     slots: list[Any],
     *,
     registry: Any | None = None,
     flm_catalog: dict[str, dict[str, Any]] | None = None,
+    gpu_capable: bool | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Build the ``per_slot`` memory map for loaded slots.
 
@@ -277,7 +364,22 @@ async def build_per_slot(
     ``flm_catalog`` (``{tag: entry}``) may be supplied by the caller to
     avoid re-probing FLM; when omitted it is built lazily on first NPU
     slot encountered.
+
+    ``gpu_capable`` (#1839) gates the VRAM/RAM split: even a slot
+    *configured* for a GPU backend (``vulkan``/``rocm``/``cuda``) has no
+    discrete VRAM pool to charge on a box with no usable GPU — the shipped
+    static seeds hardcode ``device = "gpu-vulkan"`` regardless of
+    hardware, so a GPU-less install (``HAL0_ALLOW_CPU_ONLY=1``) would
+    otherwise book resident memory as VRAM purely from the configured
+    token, never consulting whether a GPU actually exists. When ``None``
+    (the default) this is resolved once via :func:`_host_has_capable_gpu`,
+    which reads the cached hardware probe (``vulkan_capable`` /
+    ``compute_capable`` on any detected GPU, #1799's signal). Callers that
+    already have a fresher :class:`~hal0.config.schema.HardwareInfo` may
+    pass the resolved bool directly to skip the re-read.
     """
+    if gpu_capable is None:
+        gpu_capable = _host_has_capable_gpu()
     out: dict[str, dict[str, Any]] = {}
     for s in slots:
         state = str(getattr(s, "state", "") or "").lower()
@@ -344,7 +446,7 @@ async def build_per_slot(
         cgroup_mb = round(cgroup_bytes / (1024.0 * 1024.0), 1)
         resident_mb = max(cgroup_mb, estimate_mb)
 
-        # ── VRAM vs. RAM attribution (#1796) ────────────────────────────
+        # ── VRAM vs. RAM attribution (#1796, #1839) ─────────────────────
         # ``backend`` here is the normalized effective-backend token from
         # ``_cfg_effective_backend`` ("rocm" | "vulkan" | "cuda" | "cpu" |
         # "flm"), NOT the raw slot.backend passed straight through — it is
@@ -355,7 +457,15 @@ async def build_per_slot(
         # nonzero VRAM MB). Attribute to ram_mb instead; every GPU backend
         # (and the flm/NPU fallback above, which shares this UMA-style
         # accounting) keeps the historical vram_mb attribution.
-        if backend == "cpu":
+        #
+        # #1839: ``backend`` is the *configured* device token — it says
+        # nothing about whether a usable GPU actually exists. The shipped
+        # static seeds hardcode ``device = "gpu-vulkan"`` regardless of
+        # hardware, so a GPU-declared slot on a GPU-less box (no
+        # vulkan/compute-capable GPU probed) must ALSO book to ram_mb —
+        # otherwise a CPU-only install shows phantom VRAM usage even
+        # though ``backend`` never says "cpu".
+        if backend == "cpu" or not gpu_capable:
             vram_mb, ram_mb = 0.0, resident_mb
         else:
             vram_mb, ram_mb = resident_mb, 0.0
@@ -509,6 +619,7 @@ __all__ = [
     "CapacityProbeError",
     "CapacitySnapshot",
     "_container_cgroup_mem_bytes",
+    "_host_has_capable_gpu",
     "build_per_slot",
     "estimate_file_size_kv_mb",
 ]

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -34,12 +34,13 @@ from hal0.slots.capacity import (
 # ── helpers ──────────────────────────────────────────────────────────────
 
 
-def _make_slot(name, state="ready", model_id="mymodel", backend="vulkan"):
+def _make_slot(name, state="ready", model_id="mymodel", backend="vulkan", slot_id=None):
     slot = MagicMock()
     slot.name = name
     slot.state = state
     slot.model_id = model_id
     slot.backend = backend
+    slot.slot_id = slot_id
     slot.metadata = {"provider": "llama-server", "backend": backend}
     return slot
 
@@ -181,6 +182,73 @@ class TestBuildPerSlotGpuCapabilityGating:
         row = result["brain"]
         assert row["vram_mb"] == 0.0
         assert row["ram_mb"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_npu_fallthrough_keeps_vram_attribution_without_gpu(self):
+        """PR review (#1839): an FLM slot that falls through the NPU catalog
+        branch (miss / zero footprint_gb) must keep its historical UMA-style
+        vram_mb attribution even on a box with gpu_capable=False (NPU-only
+        host) — the classic-GPU gate must not apply to NPU slots."""
+        slot = _make_slot("npu-chat", backend="flm")
+        slot.metadata = {"provider": "flm", "backend": "flm"}
+
+        model_mock = MagicMock()
+        model_mock.size_bytes = 4 * 1024 * 1024 * 1024
+        model_mock.model_dump = lambda: {}
+        registry = MagicMock()
+        registry.get = MagicMock(return_value=model_mock)
+
+        # footprint_gb missing/zero -> falls through past the FLM `continue`.
+        flm_catalog = {"mymodel": {"footprint_gb": 0.0, "size_bytes": 0}}
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=0,
+        ):
+            result = await build_per_slot(
+                [slot], registry=registry, flm_catalog=flm_catalog, gpu_capable=False
+            )
+
+        row = result["npu-chat"]
+        assert row["ram_mb"] == 0.0
+        assert row["vram_mb"] == row["mem_mb"] > 0.0
+
+
+# ── build_per_slot: artefact-token cgroup probe (id-keying review) ───────
+
+
+class TestBuildPerSlotArtefactToken:
+    @pytest.mark.asyncio
+    async def test_probes_by_slot_id_when_id_keyed(self):
+        """PR review (#1839): on an id-keyed box the container/unit is named
+        off the durable slot_id, not the mutable display name — the cgroup
+        probe must be called with the id, not the name."""
+        slot = _make_slot("brain", backend="vulkan", slot_id=42)
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_probe:
+            await build_per_slot([slot], gpu_capable=True)
+
+        mock_probe.assert_awaited_once_with("42")
+
+    @pytest.mark.asyncio
+    async def test_probes_by_name_when_not_id_keyed(self):
+        """Legacy (pre-migration) slots have no slot_id — falls back to the
+        display name, unchanged from before this review fix."""
+        slot = _make_slot("brain", backend="vulkan", slot_id=None)
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=0,
+        ) as mock_probe:
+            await build_per_slot([slot], gpu_capable=True)
+
+        mock_probe.assert_awaited_once_with("brain")
 
 
 # ── _systemd_unit_mem_bytes / _container_cgroup_mem_bytes fallback (defect 2) ──

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -1,0 +1,264 @@
+"""Tests for hal0.slots.capacity: GPU-capability VRAM/RAM gating (#1839)
+and the systemd-unit cgroup fallback.
+
+Two related regressions, both filed as #1839:
+
+1. ``build_per_slot`` used to book a GPU-*declared* slot's memory as
+   ``vram_mb`` purely from the configured ``device`` token, never
+   consulting whether a usable GPU actually exists. The shipped static
+   seeds hardcode ``device = "gpu-vulkan"`` regardless of hardware, so a
+   GPU-less (``HAL0_ALLOW_CPU_ONLY=1``) install showed phantom VRAM usage.
+   ``gpu_capable`` (resolved from the hardware probe's
+   ``vulkan_capable``/``compute_capable`` signal when not passed
+   explicitly) now gates the split.
+
+2. ``_container_cgroup_mem_bytes`` shelled ``podman inspect`` from the API
+   process, which runs unprivileged (``User=hal0``) against ROOTFUL slot
+   containers — permission denied, silently returns 0 on every standard
+   install. It now falls back to the slot's own systemd unit's
+   ``MemoryCurrent`` property (``systemctl show``, no privilege needed).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from hal0.slots.capacity import (
+    _host_has_capable_gpu,
+    _systemd_unit_mem_bytes,
+    build_per_slot,
+)
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_slot(name, state="ready", model_id="mymodel", backend="vulkan"):
+    slot = MagicMock()
+    slot.name = name
+    slot.state = state
+    slot.model_id = model_id
+    slot.backend = backend
+    slot.metadata = {"provider": "llama-server", "backend": backend}
+    return slot
+
+
+def _hw_info(vulkan_capable=False, compute_capable=False, no_gpus=False):
+    """Fake object shaped like hal0.config.schema.HardwareInfo."""
+    info = MagicMock()
+    if no_gpus:
+        info.gpus = []
+    else:
+        gpu = MagicMock()
+        gpu.vulkan_capable = vulkan_capable
+        gpu.compute_capable = compute_capable
+        info.gpus = [gpu]
+    return info
+
+
+# ── _host_has_capable_gpu ────────────────────────────────────────────────
+
+
+class TestHostHasCapableGpu:
+    def test_true_when_vulkan_capable_gpu_present(self):
+        with patch(
+            "hal0.config.loader.load_hardware_info",
+            return_value=_hw_info(vulkan_capable=True),
+        ):
+            assert _host_has_capable_gpu() is True
+
+    def test_true_when_compute_capable_gpu_present(self):
+        with patch(
+            "hal0.config.loader.load_hardware_info",
+            return_value=_hw_info(compute_capable=True),
+        ):
+            assert _host_has_capable_gpu() is True
+
+    def test_false_when_no_gpus(self):
+        with patch(
+            "hal0.config.loader.load_hardware_info",
+            return_value=_hw_info(no_gpus=True),
+        ):
+            assert _host_has_capable_gpu() is False
+
+    def test_false_when_gpu_present_but_not_capable(self):
+        """A GPU sysfs node with no capable render node (#1839's box) — the
+        exact CPU-only-LXC repro. Not vulkan- or compute-capable."""
+        with patch(
+            "hal0.config.loader.load_hardware_info",
+            return_value=_hw_info(vulkan_capable=False, compute_capable=False),
+        ):
+            assert _host_has_capable_gpu() is False
+
+    def test_false_on_probe_error(self):
+        """Never raises — a broken/missing hardware.json degrades to False,
+        the conservative choice (books memory as RAM, not phantom VRAM)."""
+        with patch(
+            "hal0.config.loader.load_hardware_info",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _host_has_capable_gpu() is False
+
+
+# ── build_per_slot: GPU-capability gating (defect 1) ─────────────────────
+
+
+class TestBuildPerSlotGpuCapabilityGating:
+    @pytest.mark.asyncio
+    async def test_gpu_declared_slot_books_ram_on_gpu_less_box(self):
+        """#1839 repro: a slot configured with a GPU backend token
+        (device=gpu-vulkan -> backend='vulkan') on a box with NO usable
+        GPU must book its resident footprint under ram_mb, not vram_mb —
+        the pre-fix behaviour showed phantom VRAM usage on a CPU-only box.
+        """
+        slot = _make_slot("brain", backend="vulkan")
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=2 * 1024 * 1024 * 1024,  # 2 GiB
+        ):
+            result = await build_per_slot([slot], gpu_capable=False)
+
+        row = result["brain"]
+        assert row["vram_mb"] == 0.0
+        assert row["ram_mb"] == row["mem_mb"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_gpu_declared_slot_books_vram_on_gpu_box(self):
+        """Sibling check: the same GPU-declared slot on a box that DOES
+        have a usable GPU keeps booking under vram_mb — #1839's fix must
+        not regress the working (GPU box) case."""
+        slot = _make_slot("brain", backend="vulkan")
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=2 * 1024 * 1024 * 1024,
+        ):
+            result = await build_per_slot([slot], gpu_capable=True)
+
+        row = result["brain"]
+        assert row["ram_mb"] == 0.0
+        assert row["vram_mb"] == row["mem_mb"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_cpu_backend_books_ram_even_when_gpu_capable(self):
+        """A slot explicitly configured 'cpu' still books to ram_mb even
+        on a box that DOES have a capable GPU — the per-slot 'cpu' choice
+        wins over host capability (#1796 behaviour preserved)."""
+        slot = _make_slot("utility", backend="cpu")
+
+        with patch(
+            "hal0.slots.capacity._container_cgroup_mem_bytes",
+            new_callable=AsyncMock,
+            return_value=1 * 1024 * 1024 * 1024,
+        ):
+            result = await build_per_slot([slot], gpu_capable=True)
+
+        row = result["utility"]
+        assert row["vram_mb"] == 0.0
+        assert row["ram_mb"] == row["mem_mb"] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_gpu_capable_none_resolves_via_host_probe(self):
+        """When the caller doesn't pass gpu_capable, build_per_slot
+        resolves it itself via _host_has_capable_gpu() rather than
+        defaulting to True (which would silently reintroduce #1839)."""
+        slot = _make_slot("brain", backend="vulkan")
+
+        with (
+            patch(
+                "hal0.slots.capacity._container_cgroup_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=2 * 1024 * 1024 * 1024,
+            ),
+            patch("hal0.slots.capacity._host_has_capable_gpu", return_value=False),
+        ):
+            result = await build_per_slot([slot])
+
+        row = result["brain"]
+        assert row["vram_mb"] == 0.0
+        assert row["ram_mb"] > 0.0
+
+
+# ── _systemd_unit_mem_bytes / _container_cgroup_mem_bytes fallback (defect 2) ──
+
+
+class TestSystemdUnitMemFallback:
+    @pytest.mark.asyncio
+    async def test_reads_memory_current_from_unit(self):
+        with patch(
+            "hal0.slots.capacity.systemd_props",
+            new_callable=AsyncMock,
+            return_value={"MemoryCurrent": "2147483648"},
+        ) as mock_props:
+            result = await _systemd_unit_mem_bytes("brain")
+
+        assert result == 2147483648
+        # Queried the slot's own systemd unit, not a container name.
+        mock_props.assert_awaited_once_with("hal0-slot@brain.service", "MemoryCurrent")
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_unit_not_loaded(self):
+        with patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}):
+            result = await _systemd_unit_mem_bytes("brain")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_accounting_disabled(self):
+        """systemd reports '[not set]' when MemoryAccounting is off."""
+        with patch(
+            "hal0.slots.capacity.systemd_props",
+            new_callable=AsyncMock,
+            return_value={"MemoryCurrent": "[not set]"},
+        ):
+            result = await _systemd_unit_mem_bytes("brain")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_container_cgroup_mem_bytes_uses_fallback_when_runtime_probe_fails(self):
+        """#1839: the end-to-end probe must not silently collapse to 0 just
+        because podman inspect failed (permission denied against a rootful
+        container) — it must fall back to the unit's own MemoryCurrent."""
+        from hal0.slots.capacity import _container_cgroup_mem_bytes
+
+        with (
+            patch(
+                "hal0.slots.capacity._runtime_inspect_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch(
+                "hal0.slots.capacity._systemd_unit_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=3133931520,  # ~2987.85 MiB, matches the issue's repro
+            ),
+        ):
+            result = await _container_cgroup_mem_bytes("brain")
+
+        assert result == 3133931520
+
+    @pytest.mark.asyncio
+    async def test_container_cgroup_mem_bytes_prefers_runtime_probe_when_it_succeeds(self):
+        """The higher-fidelity runtime-inspect probe wins when it actually
+        works (e.g. hal0-api itself running as root, or a rootless slot)."""
+        from hal0.slots.capacity import _container_cgroup_mem_bytes
+
+        with (
+            patch(
+                "hal0.slots.capacity._runtime_inspect_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=999,
+            ),
+            patch(
+                "hal0.slots.capacity._systemd_unit_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=123456,
+            ) as mock_fallback,
+        ):
+            result = await _container_cgroup_mem_bytes("brain")
+
+        assert result == 999
+        mock_fallback.assert_not_called()

--- a/tests/slots/test_container_cgroup_mem.py
+++ b/tests/slots/test_container_cgroup_mem.py
@@ -4,6 +4,14 @@ Covers :func:`hal0.slots.capacity._container_cgroup_mem_bytes` — the
 function that reads live ``memory.current`` for a podman/docker container
 named ``hal0-slot-<name>``.  All subprocess and file I/O is mocked so
 these tests run without a real container runtime.
+
+Every test in ``TestContainerCgroupMemBytes`` that exercises a
+*runtime-probe* failure path (no runtime, container not found, timeout,
+cgroupv1, unreadable memory.current) also patches ``systemd_props`` — since
+#1839, ``_container_cgroup_mem_bytes`` falls back to the slot's systemd
+unit's own ``MemoryCurrent`` when the runtime probe fails, and that
+fallback must stay mocked here too or these tests would shell out to a
+real (nonexistent, in CI) ``systemctl`` binary.
 """
 
 from __future__ import annotations
@@ -59,17 +67,22 @@ class TestContainerCgroupMemBytes:
 
     @pytest.mark.asyncio
     async def test_returns_zero_when_no_runtime(self):
-        """No podman or docker binary → 0."""
-        with patch("shutil.which", return_value=None):
+        """No podman or docker binary → 0 (both probes come up empty)."""
+        with (
+            patch("shutil.which", return_value=None),
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
+        ):
             result = await _container_cgroup_mem_bytes("primary")
         assert result == 0
 
     @pytest.mark.asyncio
     async def test_returns_zero_when_container_not_found(self):
-        """Container inspect returns non-zero (container doesn't exist) → 0."""
+        """Container inspect returns non-zero (container doesn't exist) → 0
+        when the systemd-unit fallback also comes up empty."""
         with (
             patch("shutil.which", return_value="/usr/bin/podman"),
             patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
         ):
             mock_exec.return_value = _make_proc(returncode=1, stdout=b"")
             result = await _container_cgroup_mem_bytes("primary")
@@ -77,10 +90,12 @@ class TestContainerCgroupMemBytes:
 
     @pytest.mark.asyncio
     async def test_returns_zero_when_pid_is_zero(self):
-        """Inspect returns PID 0 (stopped container) → 0."""
+        """Inspect returns PID 0 (stopped container) → 0 when the systemd
+        fallback also comes up empty."""
         with (
             patch("shutil.which", return_value="/usr/bin/podman"),
             patch("asyncio.create_subprocess_exec") as mock_exec,
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
         ):
             mock_exec.return_value = _make_proc(returncode=0, stdout=b"0\n")
             result = await _container_cgroup_mem_bytes("primary")
@@ -88,11 +103,13 @@ class TestContainerCgroupMemBytes:
 
     @pytest.mark.asyncio
     async def test_returns_zero_on_inspect_timeout(self):
-        """asyncio.wait_for timeout during inspect → 0."""
+        """asyncio.wait_for timeout during inspect → 0 when the systemd
+        fallback also comes up empty."""
         with (
             patch("shutil.which", return_value="/usr/bin/podman"),
             patch("asyncio.create_subprocess_exec") as mock_exec,
             patch("asyncio.wait_for", side_effect=TimeoutError),
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
         ):
             mock_exec.return_value = _make_proc(returncode=0, stdout=b"12\n")
             result = await _container_cgroup_mem_bytes("primary")
@@ -100,7 +117,8 @@ class TestContainerCgroupMemBytes:
 
     @pytest.mark.asyncio
     async def test_returns_zero_on_cgroup_v1(self):
-        """cgroupv1 line lacks '::' → probe cannot walk path → 0."""
+        """cgroupv1 line lacks '::' → probe cannot walk path → 0 when the
+        systemd fallback also comes up empty."""
         cg_line = "1:cpu,cpuacct:/system.slice/podman-abc.scope\n"
 
         def _open_side_effect(path, *args, **kwargs):
@@ -112,6 +130,7 @@ class TestContainerCgroupMemBytes:
             patch("shutil.which", return_value="/usr/bin/podman"),
             patch("asyncio.create_subprocess_exec") as mock_exec,
             patch("builtins.open", side_effect=_open_side_effect),
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
         ):
             mock_exec.return_value = _make_proc(returncode=0, stdout=b"99\n")
             result = await _container_cgroup_mem_bytes("primary")
@@ -119,7 +138,8 @@ class TestContainerCgroupMemBytes:
 
     @pytest.mark.asyncio
     async def test_returns_zero_when_memory_current_unreadable(self):
-        """memory.current read fails (OSError) → 0."""
+        """memory.current read fails (OSError) → 0 when the systemd
+        fallback also comes up empty."""
         cg_line = "0::/system.slice/libpod-abc.scope\n"
 
         def _open_side_effect(path, *args, **kwargs):
@@ -131,6 +151,7 @@ class TestContainerCgroupMemBytes:
             patch("shutil.which", return_value="/usr/bin/podman"),
             patch("asyncio.create_subprocess_exec") as mock_exec,
             patch("builtins.open", side_effect=_open_side_effect),
+            patch("hal0.slots.capacity.systemd_props", new_callable=AsyncMock, return_value={}),
         ):
             mock_exec.return_value = _make_proc(returncode=0, stdout=b"42\n")
             result = await _container_cgroup_mem_bytes("primary")
@@ -194,7 +215,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=cgroup_bytes,
         ):
-            result = await build_per_slot([slot])
+            result = await build_per_slot([slot], gpu_capable=True)
 
         assert "primary" in result
         row = result["primary"]
@@ -225,7 +246,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=small_cgroup,
         ):
-            result = await build_per_slot([slot], registry=registry)
+            result = await build_per_slot([slot], registry=registry, gpu_capable=True)
 
         row = result["primary-container"]
         cgroup_mb = small_cgroup / (1024.0 * 1024.0)
@@ -251,7 +272,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=big_cgroup,
         ):
-            result = await build_per_slot([slot], registry=registry)
+            result = await build_per_slot([slot], registry=registry, gpu_capable=True)
 
         row = result["primary-container"]
         expected_mb = round(big_cgroup / (1024.0 * 1024.0), 1)
@@ -273,7 +294,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=0,
         ):
-            result = await build_per_slot([slot], registry=registry)
+            result = await build_per_slot([slot], registry=registry, gpu_capable=True)
 
         assert "primary" in result
         row = result["primary"]
@@ -297,7 +318,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=99999,  # should never be called
         ) as mock_probe:
-            result = await build_per_slot([slot], flm_catalog=flm_catalog)
+            result = await build_per_slot([slot], flm_catalog=flm_catalog, gpu_capable=True)
 
         mock_probe.assert_not_called()
         assert "npu-chat" in result
@@ -315,7 +336,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=4 * 1024 * 1024 * 1024,  # 4 GiB
         ):
-            result = await build_per_slot([slot])
+            result = await build_per_slot([slot], gpu_capable=True)
 
         row = result["cpu-primary"]
         assert row["vram_mb"] == 0.0
@@ -332,7 +353,7 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=4 * 1024 * 1024 * 1024,
         ):
-            result = await build_per_slot([slot])
+            result = await build_per_slot([slot], gpu_capable=True)
 
         row = result["gpu-primary"]
         assert row["ram_mb"] == 0.0
@@ -347,5 +368,5 @@ class TestBuildPerSlotContainerPath:
             new_callable=AsyncMock,
             return_value=0,
         ):
-            result = await build_per_slot([slot])
+            result = await build_per_slot([slot], gpu_capable=True)
         assert result == {}

--- a/tests/slots/test_container_cgroup_mem.py
+++ b/tests/slots/test_container_cgroup_mem.py
@@ -195,12 +195,13 @@ class TestBuildPerSlotContainerPath:
     """Verify build_per_slot uses cgroup bytes for container slots
     and falls back to file-size estimate when the cgroup probe is empty."""
 
-    def _make_slot(self, name, state="ready", model_id="mymodel", backend="rocm"):
+    def _make_slot(self, name, state="ready", model_id="mymodel", backend="rocm", slot_id=None):
         slot = MagicMock()
         slot.name = name
         slot.state = state
         slot.model_id = model_id
         slot.backend = backend
+        slot.slot_id = slot_id
         slot.metadata = {"provider": "llama-server", "backend": backend}
         return slot
 


### PR DESCRIPTION
## Summary

Two related root-cause fixes in `hal0.slots.capacity` (#1839):

1. **VRAM booked from the configured device, not real GPU capability.**
   `build_per_slot` attributed resident memory to `vram_mb` purely from the
   slot's *configured* backend token (`device = "gpu-vulkan"` etc.), never
   checking whether a usable GPU exists. The shipped static seeds hardcode
   `device = "gpu-vulkan"` regardless of hardware, so any CPU-only install
   (`HAL0_ALLOW_CPU_ONLY=1`) showed phantom VRAM usage — the exact
   "phantom GPU usage on a GPU-less box" the earlier #1807/#1796 fix
   thought it had removed (it only added a `backend == "cpu"` branch,
   which the seeded `gpu-vulkan` slots never hit). `build_per_slot` now
   takes an optional `gpu_capable` flag (auto-resolved from the cached
   hardware probe's `vulkan_capable`/`compute_capable` signal, #1799, via
   the new `_host_has_capable_gpu()`) and books to `ram_mb` whenever no
   capable GPU is present, regardless of the configured backend token.

2. **The cgroup probe silently under-reported on every standard install.**
   `_container_cgroup_mem_bytes` shelled `podman inspect` from the
   `hal0-api` process, which runs unprivileged (`User=hal0`, P3-perms)
   against ROOTFUL slot containers (Quadlet, root's podman store).
   `podman inspect` issued from the API process is therefore
   permission-denied and silently returns 0 — not just when a container
   is genuinely absent, but on every normal install (a 28% under-report
   in the issue's own repro: `capacity` reported 2131.7 MB vs. the
   accurate 2987.85 MB from `/api/slots/metrics`). Root cause traced one
   layer deeper than the issue's framing: `/api/slots/metrics`
   (`hal0.slots.metrics_collect.collect_local`) already has this exact
   same permission gap in its own container-inspect probe, but silently
   *works* because it already falls back to the slot's systemd unit's own
   `MemoryCurrent` property (`systemctl show`, needs no elevated
   privilege). `_container_cgroup_mem_bytes` now falls back the same way
   when the runtime-inspect probe fails.

## Root cause note (for the issue)

Both defects are display/diagnostics-only per the issue's own scoping
note — `mem_mb` is correct and no admission-control/eviction path reads
`vram_mb`. Left the "adjacent" `used_slots`/`max_slots` display bug
(`routes/slots.py:1006` passing `len(slots)`) out of scope — it's a
distinct defect with its own fix seam, not part of either of #1839's two
described root causes.

## How it was verified

- New `tests/slots/test_capacity.py`: exercises `_host_has_capable_gpu()`
  (capable / not-capable / no-GPU / probe-error), the `gpu_capable` gate
  in `build_per_slot` (GPU-declared slot on a GPU-less box → `ram_mb`;
  same slot on a GPU box → `vram_mb`; explicit `cpu` backend still wins
  over host capability; unset `gpu_capable` resolves via the host probe
  rather than defaulting True), and the `_systemd_unit_mem_bytes`
  fallback (reads `MemoryCurrent`, handles unit-not-loaded /
  accounting-disabled, and the `_container_cgroup_mem_bytes` composition
  prefers the higher-fidelity runtime probe when it succeeds).
- Updated `tests/slots/test_container_cgroup_mem.py` so every
  runtime-probe-failure test also mocks the new systemd fallback (it
  would otherwise shell out to a real, nonexistent-in-CI `systemctl`).
- `uv run ruff check src tests` — clean.
- `uv run ruff format --check src tests` — clean.
- `uv run mypy src/hal0/slots/capacity.py` — clean.
- `HAL0_HOME=$(mktemp -d) uv run pytest -q` — full suite: 9983 passed,
  15 skipped, 1 xfailed, 0 failures.

## Left out of scope

- Rewriting the shipped static seeds / `install.sh` to resolve `device`
  down to `cpu` at install time on a GPU-less box (issue's fix-seam
  option (b)) — broader than this display fix, tracked as a possible
  follow-up in the issue itself.
- The adjacent `used_slots`/`max_slots` display mismatch noted in the
  issue — separate defect, separate fix seam.
- Deduplicating `hal0.slots.capacity`'s and
  `hal0.slots.metrics_collect`'s near-identical runtime-inspect cgroup
  probes — pre-existing duplication, not introduced or worsened here.

Closes #1839