### PR TITLE
chore(release-validation): forbid fix agents from merging their own PRs

### DIFF
--- a/.claude/workflows/rc-fix-fleet.js
+++ b/.claude/workflows/rc-fix-fleet.js
@@ -37,6 +37,14 @@ PROCESS RULES (learned the hard way during the rc.4 fix wave — follow them exa
   - Never force-push a shared branch, rewrite pushed history, or bypass branch protection.
   - Never automerge anything touching credentials, CI/CD configuration, infrastructure, or
     migrations — those get surfaced for human review.
+  - NEVER MERGE YOUR OWN PR, and never enable automerge on it. Open it, get it green, stop there.
+    Merging belongs to the Land phase, which runs only AFTER an independent reviewer has read your
+    diff. This is the single most expensive lesson of the rc.5 wave: fix agents self-merged 4 PRs
+    between 03:44 and 05:22 while the Review phase had not yet started, so the reviews were written
+    against code already on main. 7 of 10 PRs came back changes-requested and 2 of those did not
+    fix the reported defect at all — including one that introduced a fresh cache-poisoning
+    regression. Green CI is not review. The wave's own GitOps autonomy rules ("enable automerge
+    once checks are green") are SUSPENDED inside a fix wave for exactly this reason.
 `
 
 // ── phase 0: plan ────────────────────────────────────────────────────────────

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -86,6 +86,16 @@ A full two-box run is roughly 25–30 agents. Restrict `lanes` for smaller passe
   neither can reproduce.
 * **Run fix agents ~6 at a time.** A 12-wide fleet was killed twice by host restarts during the
   rc.4 wave, losing uncommitted work each time.
+* **Fix agents must never merge their own PR.** Green CI is not review. During the rc.5 wave four
+  agents self-merged between 03:44 and 05:22 UTC while the Review phase had not started, so those
+  reviews were written against code already on `main`. The round then returned **7 of 10 PRs
+  changes-requested**, two of which did not fix the reported defect at all and one of which
+  introduced a fresh cache-poisoning regression — all of it live on `main` and needing a
+  fix-forward wave. Opening the PR and getting it green is the fix agent's terminal state; the
+  Land phase merges, and only after an independent reviewer has read the diff.
+* **Commit and push early inside an agent worktree.** Every mid-flight kill so far (three across
+  rc.4 and rc.5) cost exactly the work that was sitting uncommitted. Squash-merge makes noisy
+  intermediate commits free. See the rescue recipe when a wave dies with dirty agent trees.
 * **No per-PR CHANGELOG hunks during a fix wave.** Every merge re-conflicts every remaining
   branch (tracked as #1545). Consolidate in one CHANGELOG PR at the end.
 * **The merge train catches what per-branch CI cannot.** rc.4's #1808 × #1799 integration break


### PR DESCRIPTION
## What

Adds a hard rule to the `rc-fix-fleet` workflow's process lessons (handed verbatim to every fix agent) and to the validation kit README: **a fix agent never merges its own PR and never enables automerge on it.**

## Why

During the rc.5 fix wave, four fix agents self-merged between 03:44 and 05:22 UTC while the Review phase had not yet started. The independent opus reviews were consequently written against code already on `main`.

That review round returned **7 of 10 PRs `changes-requested`**:

| PR | Issue | Verdict | Fixes reported defect? |
|---|---|---|---|
| #1849 | #1831 | changes-requested | partially |
| #1850 | #1837 | changes-requested | **no** |
| #1851 | #1832 | changes-requested | partially |
| #1856 | #1839 | changes-requested | **no** |

All four were already merged. #1850 also introduced a new regression (a transient `iter_configs()` failure now poisons the 5s TTL cache and wipes the model bucket) while fixing something else. A fix-forward remediation wave is now required for defects that review had already caught.

Green CI is not review. Opening a PR and getting it green is a fix agent's terminal state; the Land phase merges, after a reviewer has read the diff. The workspace GitOps rule that enables automerge once checks are green is explicitly suspended inside a fix wave.

Also records the commit-early lesson — all three mid-flight kills across the rc.4 and rc.5 waves cost exactly the work sitting uncommitted in agent worktrees.

## Verification

Documentation and agent-prompt text only; no runtime code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)