### PR TITLE
fix(capacity): key the cgroup probe off real artefact naming, not slot_id

### DIFF
--- a/src/hal0/slots/capacity.py
+++ b/src/hal0/slots/capacity.py
@@ -118,6 +118,11 @@ _DEFAULT_CTX_TOKENS = _CTX_DENSE_CAP
 # without claiming false precision. The model file size dominates the total.
 _KV_MIB_PER_1K_TOKENS = 0.5
 
+# systemd renders an unset/absent numeric property as UINT64_MAX on some
+# versions. Treat anything at or above 2^63 as "not a measurement" — no real
+# cgroup on a machine that exists reports 8 EiB resident.
+_MEM_SENTINEL_FLOOR = 1 << 63
+
 
 def _kv_estimate_mb(ctx_tokens: int) -> float:
     """Best-effort KV-cache size in MiB for a given context window."""
@@ -285,6 +290,12 @@ async def _systemd_unit_mem_bytes(slot_name: str) -> int:
     Returns 0 when the unit isn't loaded, accounting is disabled
     (``MemoryCurrent=[not set]``), or ``systemctl`` itself is unavailable —
     same fail-soft contract as :func:`_runtime_inspect_mem_bytes`.
+
+    Sentinel guard: some systemd versions render an unset / no-cgroup
+    ``MemoryCurrent`` as ``18446744073709551615`` (UINT64_MAX) instead of
+    ``[not set]``. That parses cleanly, and because the caller takes
+    ``max(cgroup_mb, estimate_mb)`` it would render ~16 EiB of resident
+    memory. Anything at or above 2^63 is a sentinel, not a measurement.
     """
     unit = slot_unit_name(slot_name)
     props = await systemd_props(unit, "MemoryCurrent")
@@ -292,7 +303,54 @@ async def _systemd_unit_mem_bytes(slot_name: str) -> int:
         mem = int(props.get("MemoryCurrent", "") or 0)
     except (TypeError, ValueError):
         return 0
+    if mem >= _MEM_SENTINEL_FLOOR:
+        return 0
     return mem if mem > 0 else 0
+
+
+def _artefact_token(slot: Any) -> str:
+    """The token a slot's on-disk artefacts are actually named after.
+
+    ``hal0-slot-<token>`` (container) / ``hal0-slot@<token>.service`` (unit)
+    are named after the slot's *display name* on every install, and after the
+    durable ``slot_id`` only on a box the operator has explicitly migrated
+    with ``hal0 slot migrate-id-keying``.
+
+    ``slot.slot_id`` alone is NOT that signal (#1839 follow-up):
+    :meth:`hal0.slots.manager.SlotManager.fold_identity` runs on every boot
+    and stamps an identity row — hence a ``slot_id`` — on every slot WITHOUT
+    renaming a single artefact or unit, and ``_stamp_id`` then copies it onto
+    every ``Slot`` returned by ``list()``/``status()``. Keying the cgroup
+    probe off ``slot_id`` alone therefore probes ``hal0-slot-1`` /
+    ``hal0-slot@1.service`` on a standard install where the real artefacts are
+    ``hal0-slot-brain`` / ``hal0-slot@brain.service``: both probes miss, the
+    cgroup read collapses to 0, and the resident figure silently degrades to
+    the coarse file-size estimate.
+
+    The authoritative predicate is the physical marker used by
+    :meth:`SlotManager._slot_id_if_id_keyed` — an ``<id>.toml`` in the slot
+    config dir, which only the migration writes. Mirrored here (as a plain
+    filesystem check) because capacity has no manager handle. Any error
+    reading the config dir degrades to the name, which is the pre-migration
+    shape and the overwhelmingly common one.
+    """
+    name = str(getattr(slot, "name", "") or "")
+    raw_id = getattr(slot, "slot_id", None)
+    try:
+        slot_id = int(raw_id) if raw_id is not None else 0
+    except (TypeError, ValueError):
+        return name
+    # Slot ids are SQLite AUTOINCREMENT (start at 1); <1 is a surrogate.
+    if slot_id < 1:
+        return name
+    try:
+        from hal0.config import paths
+
+        if (paths.slots_config_dir() / f"{slot_id}.toml").exists():
+            return str(slot_id)
+    except Exception:  # pragma: no cover - defensive
+        return name
+    return name
 
 
 def _host_has_capable_gpu() -> bool:
@@ -443,13 +501,13 @@ async def build_per_slot(
         #   • cgroup accurately includes weights → cgroup ≥ estimate → wins.
         #   • GTT not charged (cgroup too low)   → estimate wins → no under-report.
         #
-        # Artefact token, not display name (#1839 review): on an id-keyed box
-        # (post ``hal0 slot migrate-id-keying``) the container/unit is named
-        # off the durable ``slot_id``, not the mutable display ``name`` — the
-        # two diverge the moment a slot is renamed. Mirrors
-        # :func:`hal0.slots.naming.slot_instance_token`'s id-over-name
-        # preference without needing a full config mapping.
-        artefact_token = str(getattr(s, "slot_id", None) or s.name)
+        # Probe by the token the artefacts are ACTUALLY named after — the
+        # display name on every standard install, the durable id only on a
+        # box migrated with ``hal0 slot migrate-id-keying``. See
+        # :func:`_artefact_token`: a set ``slot_id`` is not that signal,
+        # because ``fold_identity()`` stamps one on every boot without
+        # renaming anything.
+        artefact_token = _artefact_token(s)
         cgroup_bytes = await _container_cgroup_mem_bytes(artefact_token)
         cgroup_mb = round(cgroup_bytes / (1024.0 * 1024.0), 1)
         resident_mb = max(cgroup_mb, estimate_mb)

--- a/tests/slots/test_capacity.py
+++ b/tests/slots/test_capacity.py
@@ -220,35 +220,100 @@ class TestBuildPerSlotGpuCapabilityGating:
 
 class TestBuildPerSlotArtefactToken:
     @pytest.mark.asyncio
-    async def test_probes_by_slot_id_when_id_keyed(self):
-        """PR review (#1839): on an id-keyed box the container/unit is named
-        off the durable slot_id, not the mutable display name — the cgroup
-        probe must be called with the id, not the name."""
+    async def test_probes_by_slot_id_when_id_keyed(self, tmp_path):
+        """On a genuinely id-keyed box (``hal0 slot migrate-id-keying`` has
+        run, so ``<id>.toml`` is the config on disk) the container/unit is
+        named off the durable slot_id — the cgroup probe must use the id."""
         slot = _make_slot("brain", backend="vulkan", slot_id=42)
+        (tmp_path / "42.toml").write_text("name = 'brain'\n", encoding="utf-8")
 
-        with patch(
-            "hal0.slots.capacity._container_cgroup_mem_bytes",
-            new_callable=AsyncMock,
-            return_value=0,
-        ) as mock_probe:
+        with (
+            patch("hal0.config.paths.slots_config_dir", return_value=tmp_path),
+            patch(
+                "hal0.slots.capacity._container_cgroup_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_probe,
+        ):
             await build_per_slot([slot], gpu_capable=True)
 
         mock_probe.assert_awaited_once_with("42")
 
     @pytest.mark.asyncio
-    async def test_probes_by_name_when_not_id_keyed(self):
-        """Legacy (pre-migration) slots have no slot_id — falls back to the
-        display name, unchanged from before this review fix."""
-        slot = _make_slot("brain", backend="vulkan", slot_id=None)
+    async def test_probes_by_name_when_slot_id_set_but_artefacts_name_keyed(self, tmp_path):
+        """THE standard install (#1839 repro box, and every un-migrated box).
 
-        with patch(
-            "hal0.slots.capacity._container_cgroup_mem_bytes",
-            new_callable=AsyncMock,
-            return_value=0,
-        ) as mock_probe:
+        ``SlotManager.fold_identity()`` runs on every boot and stamps a
+        ``slot_id`` on every slot WITHOUT renaming a single on-disk artefact
+        — the destructive rename only happens under ``hal0 slot
+        migrate-id-keying``. So ``slot_id`` being set says nothing about how
+        the container/unit is named: here the config is still ``brain.toml``,
+        the unit is ``hal0-slot@brain.service`` and the container is
+        ``hal0-slot-brain``. Probing by id would miss both, collapse the
+        cgroup read to 0, and silently under-report resident memory.
+        """
+        slot = _make_slot("brain", backend="vulkan", slot_id=1)
+        (tmp_path / "brain.toml").write_text("name = 'brain'\n", encoding="utf-8")
+
+        with (
+            patch("hal0.config.paths.slots_config_dir", return_value=tmp_path),
+            patch(
+                "hal0.slots.capacity._container_cgroup_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_probe,
+        ):
             await build_per_slot([slot], gpu_capable=True)
 
         mock_probe.assert_awaited_once_with("brain")
+
+    @pytest.mark.asyncio
+    async def test_probes_by_name_when_not_id_keyed(self, tmp_path):
+        """Pre-fold slots have no slot_id at all — falls back to the display
+        name, unchanged from before this review fix."""
+        slot = _make_slot("brain", backend="vulkan", slot_id=None)
+
+        with (
+            patch("hal0.config.paths.slots_config_dir", return_value=tmp_path),
+            patch(
+                "hal0.slots.capacity._container_cgroup_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ) as mock_probe,
+        ):
+            await build_per_slot([slot], gpu_capable=True)
+
+        mock_probe.assert_awaited_once_with("brain")
+
+    @pytest.mark.asyncio
+    async def test_id_keyed_probe_reports_real_cgroup_memory(self, tmp_path):
+        """End-to-end consequence of the token choice: a name-keyed box whose
+        unit reports 3 GiB must render 3072 MB, not the file-size estimate.
+
+        Drives the real :func:`_container_cgroup_mem_bytes` with only the
+        systemd property faked, so a wrong token shows up as a wrong number
+        rather than only a wrong mock argument.
+        """
+        slot = _make_slot("brain", backend="vulkan", slot_id=7)
+        (tmp_path / "brain.toml").write_text("name = 'brain'\n", encoding="utf-8")
+
+        async def fake_props(unit, *props):
+            if unit == "hal0-slot@brain.service":
+                return {"MemoryCurrent": str(3 * 1024 * 1024 * 1024)}
+            return {}
+
+        with (
+            patch("hal0.config.paths.slots_config_dir", return_value=tmp_path),
+            patch(
+                "hal0.slots.capacity._runtime_inspect_mem_bytes",
+                new_callable=AsyncMock,
+                return_value=0,
+            ),
+            patch("hal0.slots.capacity.systemd_props", new=fake_props),
+        ):
+            result = await build_per_slot([slot], gpu_capable=True)
+
+        assert result["brain"]["mem_mb"] == 3072.0
 
 
 # ── _systemd_unit_mem_bytes / _container_cgroup_mem_bytes fallback (defect 2) ──
@@ -281,6 +346,20 @@ class TestSystemdUnitMemFallback:
             "hal0.slots.capacity.systemd_props",
             new_callable=AsyncMock,
             return_value={"MemoryCurrent": "[not set]"},
+        ):
+            result = await _systemd_unit_mem_bytes("brain")
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_for_uint64_max_sentinel(self):
+        """Some systemd versions render an unset MemoryCurrent as UINT64_MAX
+        rather than '[not set]'. It parses cleanly, and capacity takes
+        max(cgroup_mb, estimate_mb) — so without a guard the slot renders
+        ~16 EiB resident instead of its real footprint."""
+        with patch(
+            "hal0.slots.capacity.systemd_props",
+            new_callable=AsyncMock,
+            return_value={"MemoryCurrent": "18446744073709551615"},
         ):
             result = await _systemd_unit_mem_bytes("brain")
         assert result == 0


### PR DESCRIPTION
Remediates blocking review findings on the **already-merged** PR #1856. Those defects are live on `main` right now, so this is a fix-forward rather than a change to that PR.

Refs #1839

## The defect

#1856 changed the capacity cgroup probe to key off `slot.slot_id`:

```python
artefact_token = str(getattr(s, "slot_id", None) or s.name)
```

`slot_id` being set does not mean the box is id-keyed. `SlotManager.fold_identity()` runs on **every boot** (`api/__init__.py`) and populates an identity row for every slot *without renaming any on-disk artefact or unit* — its own docstring says so — and `_stamp_id()` then stamps `slot.slot_id` onto every `Slot` returned by `list()`/`status()`. The destructive rename lives in `slots/migrate_id_keying.py`, which is deliberately not wired into the lifespan and only runs when an operator invokes `hal0 slot migrate-id-keying`.

So on a standard install the probe looked for `hal0-slot-1` / `hal0-slot@1.service` while the real artefacts are `hal0-slot-brain` / `hal0-slot@brain.service`. Both probes miss, `_container_cgroup_mem_bytes` returns 0, and `max(cgroup_mb, estimate_mb)` collapses to the coarse file-size estimate — i.e. #1839's under-report was not actually fixed. `metrics_collect.collect_local`, the path that *does* report accurate RSS on that box, keys both probes off `slot.name`.

## The fix

`_artefact_token()` mirrors the predicate that already exists for exactly this question — `SlotManager._slot_id_if_id_keyed()` (`manager.py:616`) — by checking the physical marker only the migration writes: an `<id>.toml` in the slot config dir. Id-keyed box → probe by id; everything else → probe by display name. Any error reading the config dir degrades to the name (the pre-migration shape, and the overwhelmingly common one).

Also fixes a second review nit in the same function: some systemd versions render an unset `MemoryCurrent` as `18446744073709551615` (UINT64_MAX) rather than `[not set]`. That parses cleanly, and because capacity takes `max(cgroup_mb, estimate_mb)` it would have rendered ~16 EiB resident. Guarded at `2^63`.

## Tests

The tests merged with #1856 encoded the defect as correct behaviour: `TestBuildPerSlotArtefactToken::test_probes_by_slot_id_when_id_keyed` asserted `probe("42")` for a slot with `slot_id=42` without ever establishing the box was id-keyed, and the name case only covered `slot_id=None` (the pre-fold state a live manager never leaves a slot in). Both are rewritten to establish the on-disk keying via a real config dir, and the missing case is added:

- `test_probes_by_name_when_slot_id_set_but_artefacts_name_keyed` — **the standard install**: `slot_id=1`, config still `brain.toml`.
- `test_id_keyed_probe_reports_real_cgroup_memory` — drives the real `_container_cgroup_mem_bytes` with only the systemd property faked, so a wrong token surfaces as a wrong *number* rather than only a wrong mock argument.
- `test_returns_zero_for_uint64_max_sentinel`.

Proof they fail against the unfixed code (`main` as merged):

```
FAILED tests/slots/test_capacity.py::TestBuildPerSlotArtefactToken::test_probes_by_name_when_slot_id_set_but_artefacts_name_keyed
FAILED tests/slots/test_capacity.py::TestBuildPerSlotArtefactToken::test_id_keyed_probe_reports_real_cgroup_memory
E       assert 16.4 == 3072.0
2 failed, 2 passed
```

## Verification

- `tests/slots tests/metrics tests/slot_view` — 928 passed.
- `ruff check` + `ruff format --check` clean.
- Live on ct152 (rc.5, fresh install, never migrated). Confirmed the preconditions first: config dir is name-keyed (`brain.toml`, no `<id>.toml`), the unit is `hal0-slot@utility.service`, and `GET /api/slots` reports `"id":1` — `slot_id` set, artefacts name-keyed, exactly the case the merged code gets wrong. With this branch's `capacity.py` dropped into the service venv, and `slot_id` hand-stamped to `1` the way `fold_identity()`/`_stamp_id()` does on every boot:

  ```
  slot utility slot_id 1 -> token utility
  {"utility": {"vram_mb": 0.0, "ram_mb": 678.6, "mem_mb": 678.6, ...}}
  ```

  678.6 MB is the real cgroup figure (`MemoryCurrent=712728576`); the box's installed code reports the 664.0 MB estimate. The box was restored to its original file and service state afterwards.

## Follow-up filed, out of scope here

#1862 — the third review finding (a nit): `_host_has_capable_gpu()` reads the cached `hardware.json`, which returns an all-defaults `HardwareInfo` when absent and validates the `vulkan_capable`/`compute_capable` keys to `False` when the file predates #1799. A real GPU box in either state now books VRAM as RAM. The conservative direction was deliberate in #1856, and fixing it needs a probe-freshness or re-probe decision that does not belong in this PR.

No CHANGELOG hunk — a separate consolidated PR owns that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)