### PR TITLE
fix(agents): check chat-anchor routability against the endpoint the probe uses

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3301,11 +3301,13 @@ def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
     listed_status, payload = _http_status_json(f"{base}/models")
     if listed_status is None or not (200 <= listed_status < 300):
         return None
-    ids = {
-        str(entry.get("id"))
-        for entry in ((payload or {}).get("data") or [])
-        if isinstance(entry, dict) and entry.get("id")
-    }
+    entries = (payload or {}).get("data")
+    if not isinstance(entries, list):
+        # 2xx with a body we could not parse into a catalog is not evidence of
+        # an EMPTY catalog — it is no evidence at all. An empty ``data`` list
+        # is a real answer; a missing or malformed one is not.
+        return None
+    ids = {str(entry.get("id")) for entry in entries if isinstance(entry, dict) and entry.get("id")}
     if model_id in ids:
         return True
     if model_id.startswith("hal0/"):

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3283,9 +3283,9 @@ def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
        deliberately never advertises them (#1153).
     2. On 404, ``GET {base_url}/models`` — llama-server and friends have no
        by-id route at all but do list the model they have loaded.
-    3. Still nothing: only a ``hal0/*`` name **asked of the hal0 gateway** is
-       conclusively absent — that is the one endpoint that resolves the
-       virtuals by id or not at all. Elsewhere the prefix carries no routing
+    3. Still nothing: only a **canonical virtual name asked of the hal0
+       gateway** is conclusively absent — that pair is exactly what the by-id
+       route resolves. Elsewhere the ``hal0/`` prefix carries no routing
        meaning, and any other id could simply be folded into an alias row, so
        report ``None`` and let the caller run the real probe rather than skip
        on a guess.
@@ -3313,13 +3313,30 @@ def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
     ids = {str(entry.get("id")) for entry in entries if isinstance(entry, dict) and entry.get("id")}
     if model_id in ids:
         return True
-    if model_id.startswith("hal0/") and base == gateway.rstrip("/"):
-        # Only the gateway gives ``hal0/*`` routing meaning: it resolves the
-        # virtuals through the by-id route or nowhere. On a pinned backend the
-        # prefix is just characters in a model id, so its absence proves
-        # nothing.
+    if base == gateway.rstrip("/") and _is_canonical_virtual(model_id):
+        # A CANONICAL virtual asked of the GATEWAY is the one conclusive
+        # negative available: that pair is exactly what the by-id route
+        # resolves, so a 404 plus a valid catalog means no slot backs it.
+        # Neither half generalises — on a pinned backend the ``hal0/`` prefix
+        # is just characters in a model id, and a physical registry id may
+        # legitimately carry the prefix while chat dispatch still resolves it
+        # by exact match.
         return False
     return None
+
+
+def _is_canonical_virtual(model_id: str) -> bool:
+    """Is ``model_id`` one of hal0's advertised virtual names?
+
+    Read from the resolver's own table rather than re-deriving it from the
+    ``hal0/`` prefix, which is deliberately broader (ADR-0023 §2: any enabled
+    llm slot is addressable as ``hal0/<slot>``).
+    """
+    try:
+        from hal0.normalize.resolver import DEFAULT_CHAINS
+    except Exception:  # pragma: no cover — defensive
+        return False
+    return model_id in DEFAULT_CHAINS
 
 
 def _quote_model_id(model_id: str) -> str:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3256,35 +3256,90 @@ def _fetch_model_contexts() -> dict[str, int]:
     return out
 
 
-def _fetch_model_route_ready(model_id: str) -> bool:
-    """Ask ``GET /v1/models/{id}`` whether ``model_id`` actually routes.
+def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
+    """Is ``model_id`` routable **on the endpoint the caller will dispatch to**?
 
-    Unlike :func:`_fetch_model_contexts` (backed by the **list** route,
-    ``GET /v1/models``), this hits the **by-id** route, which resolves hal0's
-    canonical virtual names (``hal0/agent``, ``hal0/utility``, ``hal0/npu``)
-    via the LiveSlotResolver (see ``_resolve_virtual_model_entry`` in
-    ``hal0.api.routes.v1``). The list route deliberately never advertises
-    those virtuals (#1153) and also folds a chat slot's raw model id into
-    its alias entry, so checking list *membership* against the shipped
-    ``model.default: hal0/agent`` can never succeed even when the model is
-    fully routable (#1831). 404/other client errors and network failures
-    both mean "not ready"; only a clean response counts.
+    Three-valued on purpose:
+
+    * ``True``  — the endpoint says the id resolves.
+    * ``False`` — the endpoint authoritatively says it does not.
+    * ``None``  — inconclusive; the endpoint's answer does not settle it.
+
+    ``base_url`` is hermes' ``model.base_url`` (empty → the hal0 gateway),
+    i.e. the same origin :func:`_smoke_chat_completions` POSTs
+    ``/chat/completions`` to. Asking a *different* server is how #1831
+    happened: under ``HAL0_HERMES_LIVE_RESOLVE=0`` the config pins a chat
+    slot's own llama-server plus that slot's RAW physical model id, and the
+    gateway catalog deliberately suppresses that id in favour of the slot's
+    alias row (``hal0_chat_slot_model_ids``) while its by-id route only
+    resolves ``hal0/*`` virtuals — so the gateway 404s an id that routes
+    perfectly well where the probe actually sends it.
+
+    Resolution order, cheapest first:
+
+    1. ``GET {base_url}/models/{id}`` — the by-id route. hal0's gateway
+       resolves the canonical virtuals (``hal0/agent`` …) here via the
+       LiveSlotResolver (``_resolve_virtual_model_entry``); the list route
+       deliberately never advertises them (#1153).
+    2. On 404, ``GET {base_url}/models`` — llama-server and friends have no
+       by-id route at all but do list the model they have loaded.
+    3. Still nothing: only a ``hal0/*`` name is conclusively absent (the
+       gateway resolves those by id or not at all). Any other id could
+       simply be folded into an alias row, so report ``None`` and let the
+       caller run the real probe rather than skip on a guess.
+
+    Never raises: every transport failure is inconclusive, not "not ready" —
+    an unreachable endpoint is a fact the chat probe should report, not one
+    the preflight should hide behind a skip.
+    """
+    base = (base_url or f"{HAL0_API_URL}/v1").rstrip("/")
+    status = _http_status_json(f"{base}/models/{_quote_model_id(model_id)}")[0]
+    if status is not None and 200 <= status < 300:
+        return True
+    if status != 404:
+        return None  # 5xx / auth / unreachable — no evidence either way
+    listed_status, payload = _http_status_json(f"{base}/models")
+    if listed_status is None or not (200 <= listed_status < 300):
+        return None
+    ids = {
+        str(entry.get("id"))
+        for entry in ((payload or {}).get("data") or [])
+        if isinstance(entry, dict) and entry.get("id")
+    }
+    if model_id in ids:
+        return True
+    if model_id.startswith("hal0/"):
+        return False  # a virtual resolves through the by-id route or nowhere
+    return None
+
+
+def _quote_model_id(model_id: str) -> str:
+    from urllib.parse import quote
+
+    return quote(model_id, safe="/")
+
+
+def _http_status_json(url: str) -> tuple[int | None, dict[str, Any] | None]:
+    """``GET url`` → ``(status, decoded_json)``; ``(None, None)`` if unreachable.
+
+    An HTTP error still carries a status (that is the evidence callers need
+    to tell "the server said no" from "the server said nothing").
     """
     from urllib.error import HTTPError, URLError
-    from urllib.parse import quote
     from urllib.request import Request, urlopen
 
-    req = Request(
-        f"{HAL0_API_URL}/v1/models/{quote(model_id, safe='/')}",
-        headers={"Accept": "application/json"},
-    )
+    req = Request(url, headers={"Accept": "application/json"})
     try:
         with urlopen(req, timeout=3.0) as resp:
-            return 200 <= resp.status < 300
-    except HTTPError:
-        return False
+            try:
+                body = json.loads(resp.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+                body = None
+            return (resp.status, body if isinstance(body, dict) else None)
+    except HTTPError as exc:
+        return (exc.code, None)
     except (URLError, OSError, TimeoutError):
-        return False
+        return (None, None)
 
 
 def _slot_kind(slot: dict[str, Any]) -> str:
@@ -4754,27 +4809,29 @@ _MODEL_DEPENDENT_PROBES = frozenset({"chat_completions"})
 def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
     """Cheap preflight: is a chat-capable model actually routable right now?
 
-    Reads ``model.default`` from config.yaml — the exact field
-    :func:`_smoke_chat_completions` targets — and cross-checks it against the
-    live gateway via ``io.fetch_model_route_ready`` (``GET
-    /v1/models/{id}``), instead of paying a full chat-completion round trip
-    just to find out nothing is loaded.
+    Reads ``model.default`` AND ``model.base_url`` from config.yaml — the two
+    fields :func:`_smoke_chat_completions` dispatches with — and asks *that
+    endpoint* whether the id routes (``io.fetch_model_route_ready``), instead
+    of paying a full chat-completion round trip just to find out nothing is
+    loaded.
 
-    This resolves the anchor through the **by-id** route rather than
-    checking membership in the **list** route's payload (``GET
-    /v1/models``): the list route deliberately never advertises hal0's
-    canonical virtual names (``hal0/agent`` et al. — see
-    ``_aggregate_models`` in ``hal0.api.routes.v1``, #1153) and also folds a
-    chat slot's raw model id into its alias entry, so list membership can
-    never hold for the shipped ``model.default: hal0/agent`` even when the
-    model is fully routable. The by-id route resolves virtuals via the
-    LiveSlotResolver (``_resolve_virtual_model_entry``), matching exactly
-    what :func:`_smoke_chat_completions` itself dispatches against (#1831).
+    Two rules keep this honest, both learned from #1831:
 
-    This is what lets smoke_tests tell "the route is genuinely broken" (a
-    real failure) apart from "no chat model exists yet" (#1793) — never
-    raises; any config/parse/network problem reports not-ready with the
-    reason.
+    * **Ask the endpoint the probe will use.** Consulting the hal0 gateway's
+      catalog is answering a routability question with a discovery answer.
+      Under ``HAL0_HERMES_LIVE_RESOLVE=0`` the probe POSTs straight at a chat
+      slot's llama-server using that slot's raw physical model id, which the
+      gateway catalog suppresses in favour of the slot's alias row and whose
+      by-id route only resolves ``hal0/*`` virtuals — a guaranteed 404 for a
+      route that works.
+    * **Skip only on affirmative evidence.** ``fetch_model_route_ready``
+      returns ``None`` when the endpoint's answer settles nothing; then the
+      probe RUNS and reports what really happens. A skip is a claim ("no
+      chat model exists yet", #1793) and must be earned, because a wrong
+      skip is invisible — it reads as a clean install.
+
+    Never raises: any config/parse/probe problem resolves to a decision plus
+    the reason behind it.
     """
     import yaml  # type: ignore[import-untyped]
 
@@ -4785,15 +4842,21 @@ def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
         cfg = yaml.safe_load(config_path.read_text()) or {}
     except (OSError, yaml.YAMLError) as exc:
         return False, f"config parse: {exc}"
-    model_name = (cfg.get("model") or {}).get("default", "")
+    model_cfg = cfg.get("model") or {}
+    model_name = model_cfg.get("default", "")
     if not model_name:
         return False, "model.default unset in config.yaml"
+    base_url = str(model_cfg.get("base_url", "") or "")
     try:
-        routable = io.fetch_model_route_ready(model_name)
+        routable = io.fetch_model_route_ready(model_name, base_url)
     except Exception as exc:  # preflight must never raise
-        return False, f"gateway probe failed: {exc}"
+        # Inconclusive, not negative: let the probe report the real state.
+        return True, f"route probe errored ({exc}); probing anyway"
+    endpoint = base_url or f"{HAL0_API_URL}/v1"
+    if routable is None:
+        return True, f"'{model_name}' unverifiable at {endpoint}; probing anyway"
     if not routable:
-        return False, f"'{model_name}' not loaded on the gateway"
+        return False, f"'{model_name}' has no route at {endpoint}"
     return True, "ready"
 
 
@@ -5246,7 +5309,7 @@ class InstallIO:
     http_get: Callable[..., int] = _http_get
     fetch_slots: Callable[[], list[dict[str, Any]]] = _fetch_slots
     fetch_model_contexts: Callable[[], dict[str, int]] = _fetch_model_contexts
-    fetch_model_route_ready: Callable[[str], bool] = _fetch_model_route_ready
+    fetch_model_route_ready: Callable[[str, str], bool | None] = _fetch_model_route_ready
     probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
     mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
     install_venv: Callable[..., None] = _install_venv

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3283,16 +3283,19 @@ def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
        deliberately never advertises them (#1153).
     2. On 404, ``GET {base_url}/models`` — llama-server and friends have no
        by-id route at all but do list the model they have loaded.
-    3. Still nothing: only a ``hal0/*`` name is conclusively absent (the
-       gateway resolves those by id or not at all). Any other id could
-       simply be folded into an alias row, so report ``None`` and let the
-       caller run the real probe rather than skip on a guess.
+    3. Still nothing: only a ``hal0/*`` name **asked of the hal0 gateway** is
+       conclusively absent — that is the one endpoint that resolves the
+       virtuals by id or not at all. Elsewhere the prefix carries no routing
+       meaning, and any other id could simply be folded into an alias row, so
+       report ``None`` and let the caller run the real probe rather than skip
+       on a guess.
 
     Never raises: every transport failure is inconclusive, not "not ready" —
     an unreachable endpoint is a fact the chat probe should report, not one
     the preflight should hide behind a skip.
     """
-    base = (base_url or f"{HAL0_API_URL}/v1").rstrip("/")
+    gateway = f"{HAL0_API_URL}/v1"
+    base = (base_url or gateway).rstrip("/")
     status = _http_status_json(f"{base}/models/{_quote_model_id(model_id)}")[0]
     if status is not None and 200 <= status < 300:
         return True
@@ -3310,8 +3313,12 @@ def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
     ids = {str(entry.get("id")) for entry in entries if isinstance(entry, dict) and entry.get("id")}
     if model_id in ids:
         return True
-    if model_id.startswith("hal0/"):
-        return False  # a virtual resolves through the by-id route or nowhere
+    if model_id.startswith("hal0/") and base == gateway.rstrip("/"):
+        # Only the gateway gives ``hal0/*`` routing meaning: it resolves the
+        # virtuals through the by-id route or nowhere. On a pinned backend the
+        # prefix is just characters in a model id, so its absence proves
+        # nothing.
+        return False
     return None
 
 

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1947,12 +1947,20 @@ def test_voice_wire_does_not_provision_stt_when_npu_anchor_is_not_ready(
 # ── #246 phase impls — smoke_tests + self_report ────────────────────────────
 
 
-def _write_ready_chat_config(hermes_home: Path, model_name: str = "m1") -> None:
+def _write_ready_chat_config(
+    hermes_home: Path,
+    model_name: str = "m1",
+    base_url: str = "http://127.0.0.1:8080/v1",
+) -> None:
     """Drop a config.yaml + matching gateway model so :func:`hp._chat_model_ready`
     reports ready — the precondition the model-dependent probes need to
-    actually run instead of self-skipping (#1793)."""
+    actually run instead of self-skipping (#1793). ``base_url`` is written
+    because the preflight resolves the anchor against THAT endpoint, the one
+    the chat probe dispatches to (#1831)."""
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "config.yaml").write_text(f"model:\n  default: {model_name}\n")
+    (hermes_home / "config.yaml").write_text(
+        f"model:\n  default: {model_name}\n  base_url: {base_url}\n"
+    )
 
 
 def test_smoke_tests_phase_runs_each_probe_collecting_results(
@@ -1961,7 +1969,7 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     hh = tmp_path / "hh"
     _write_ready_chat_config(hh)
     state = hp.BootstrapState(hermes_home=str(hh))
-    io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
+    io = hp.InstallIO(fetch_model_route_ready=lambda model_id, base_url="": model_id == "m1")
     # All six probes return (True, "...") so we exercise the rollup
     # without depending on a real Hermes binary or HTTP listener.
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
@@ -1992,7 +2000,7 @@ def test_smoke_tests_phase_records_failures_as_warn_without_blocking(
     hh = tmp_path / "hh"
     _write_ready_chat_config(hh)
     state = hp.BootstrapState(hermes_home=str(hh))
-    io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
+    io = hp.InstallIO(fetch_model_route_ready=lambda model_id, base_url="": model_id == "m1")
     monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (False, "wrapper missing"))
     monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
     monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (False, "503"))
@@ -2054,36 +2062,63 @@ class TestChatModelReady:
         assert ready is False
         assert "model.default unset" in reason
 
-    def test_model_not_on_gateway_not_ready(self, tmp_path: Path) -> None:
+    def test_model_with_no_route_not_ready(self, tmp_path: Path) -> None:
         hh = tmp_path / "hh"
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
-        io = hp.InstallIO(fetch_model_route_ready=lambda model_id: False)
+        io = hp.InstallIO(fetch_model_route_ready=lambda model_id, base_url="": False)
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is False
-        assert "not loaded on the gateway" in reason
+        assert "has no route at http://127.0.0.1:8080/v1" in reason
 
-    def test_model_on_gateway_ready(self, tmp_path: Path) -> None:
+    def test_routable_model_ready(self, tmp_path: Path) -> None:
         hh = tmp_path / "hh"
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
-        io = hp.InstallIO(fetch_model_route_ready=lambda model_id: model_id == "m1")
+        io = hp.InstallIO(fetch_model_route_ready=lambda model_id, base_url="": model_id == "m1")
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is True
         assert reason == "ready"
 
-    def test_gateway_probe_exception_not_ready(self, tmp_path: Path) -> None:
+    def test_preflight_asks_about_the_configured_base_url(self, tmp_path: Path) -> None:
+        """The endpoint under test is ``model.base_url`` — whatever the chat
+        probe will POST to — not a hardcoded gateway (#1831)."""
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "raw-model-id", base_url="http://127.0.0.1:8081/v1")
+        state = hp.BootstrapState(hermes_home=str(hh))
+        asked: list[tuple[str, str]] = []
+
+        def _record(model_id: str, base_url: str = "") -> bool:
+            asked.append((model_id, base_url))
+            return True
+
+        hp._chat_model_ready(state, hp.InstallIO(fetch_model_route_ready=_record))
+        assert asked == [("raw-model-id", "http://127.0.0.1:8081/v1")]
+
+    def test_inconclusive_route_runs_the_probe(self, tmp_path: Path) -> None:
+        """``None`` means the endpoint settled nothing — run the probe. A skip
+        is a claim and must be earned (#1831)."""
+        hh = tmp_path / "hh"
+        _write_ready_chat_config(hh, "m1")
+        state = hp.BootstrapState(hermes_home=str(hh))
+        io = hp.InstallIO(fetch_model_route_ready=lambda model_id, base_url="": None)
+        ready, reason = hp._chat_model_ready(state, io)
+        assert ready is True
+        assert "unverifiable" in reason
+
+    def test_probe_exception_does_not_skip(self, tmp_path: Path) -> None:
+        """A broken preflight must not silently suppress the probe it gates."""
         hh = tmp_path / "hh"
         _write_ready_chat_config(hh, "m1")
         state = hp.BootstrapState(hermes_home=str(hh))
 
-        def _boom(_model_id: str) -> bool:
+        def _boom(_model_id: str, _base_url: str = "") -> bool:
             raise RuntimeError("gateway unreachable")
 
         io = hp.InstallIO(fetch_model_route_ready=_boom)
         ready, reason = hp._chat_model_ready(state, io)
-        assert ready is False
-        assert "gateway probe failed" in reason
+        assert ready is True
+        assert "route probe errored" in reason
 
     def test_shipped_virtual_default_ready_via_by_id_route_not_list(self, tmp_path: Path) -> None:
         """Regression (#1831): the shipped ``model.default: hal0/agent`` is
@@ -2102,7 +2137,7 @@ class TestChatModelReady:
         # by design — only the underlying slot alias is listed.
         realistic_list_contexts = {"brain": 32768, "utility": 8192}
 
-        def fetch_model_route_ready(model_id: str) -> bool:
+        def fetch_model_route_ready(model_id: str, _base_url: str = "") -> bool:
             # The by-id route resolves virtuals; list membership is
             # irrelevant to it.
             return model_id == "hal0/agent"
@@ -2114,6 +2149,235 @@ class TestChatModelReady:
         ready, reason = hp._chat_model_ready(state, io)
         assert ready is True
         assert reason == "ready"
+
+
+# ── #1831 follow-up: the preflight must interrogate the endpoint the chat
+# probe actually dispatches against, and must never skip on a guess ─────────
+
+
+class _FakeHTTPResponse:
+    """Minimal stand-in for what ``urlopen`` yields (context manager + read)."""
+
+    def __init__(self, status: int, payload: Any) -> None:
+        self.status = status
+        self._payload = json.dumps(payload).encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _fake_http(
+    monkeypatch: pytest.MonkeyPatch,
+    routes: dict[str, Any],
+    seen: list[str] | None = None,
+    *,
+    unreachable: set[str] | None = None,
+) -> None:
+    """Patch the real network boundary (``urllib.request.urlopen``).
+
+    Patching HTTP rather than the ``InstallIO`` seam is deliberate: these
+    tests must exercise the PRODUCTION wiring end to end, so a regression
+    shows up as wrong behaviour instead of a signature mismatch on a fake.
+    Any URL not in ``routes`` 404s; anything in ``unreachable`` raises a
+    connection error.
+    """
+    import urllib.request
+    from urllib.error import HTTPError, URLError
+
+    def _urlopen(req: Any, timeout: float | None = None) -> _FakeHTTPResponse:
+        url = getattr(req, "full_url", None) or str(req)
+        if seen is not None:
+            seen.append(url)
+        for prefix in unreachable or set():
+            if url.startswith(prefix):
+                raise URLError("connection refused")
+        if url in routes:
+            return _FakeHTTPResponse(200, routes[url])
+        raise HTTPError(url, 404, "Not Found", None, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+
+
+def _stub_non_chat_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(hp, "_smoke_wrapper_ready", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_hermes_doctor", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
+    monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
+    monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
+
+
+def test_pinned_backend_config_does_not_skip_chat_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``HAL0_HERMES_LIVE_RESOLVE=0`` pins ``model.base_url`` at the chat
+    slot's own llama-server and ``model.default`` at that slot's RAW physical
+    model id (``_config_pairs``). The gateway's catalog suppresses exactly
+    that raw id in favour of the slot's alias row (``hal0_chat_slot_model_ids``)
+    and its by-id route only resolves ``hal0/*`` virtuals, so asking the
+    GATEWAY about the id 404s even though the route is perfectly live —
+    the probe is skipped forever with the false reason "not loaded on the
+    gateway" (#1831). The preflight must interrogate the endpoint the chat
+    probe itself POSTs to (``model.base_url``), which does advertise the id.
+
+    Production wiring only: no ``InstallIO`` fake, just a fake network.
+    """
+    hh = tmp_path / "hh"
+    hh.mkdir()
+    (hh / "config.yaml").write_text(
+        "model:\n  default: qwen3-30b-a3b-instruct\n  base_url: http://127.0.0.1:8081/v1\n"
+    )
+    seen: list[str] = []
+    _fake_http(
+        monkeypatch,
+        {
+            # The pinned llama-server advertises its own loaded model...
+            "http://127.0.0.1:8081/v1/models": {"data": [{"id": "qwen3-30b-a3b-instruct"}]},
+            # ...while the gateway catalog folds it into the alias row, so
+            # neither the list nor the by-id route mentions it.
+            "http://127.0.0.1:8080/v1/models": {"data": [{"id": "brain"}]},
+        },
+        seen,
+    )
+    _stub_non_chat_probes(monkeypatch)
+    ran: list[str] = []
+    monkeypatch.setattr(
+        hp, "_smoke_chat_completions", lambda s, io: (ran.append("x"), (True, "ready"))[1]
+    )
+    state = hp.BootstrapState(hermes_home=str(hh))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    assert ran == ["x"], (
+        f"chat_completions was skipped on a live pinned backend: "
+        f"{out.details['results']['chat_completions']} (probed: {seen})"
+    )
+    assert out.details["skipped"] == []
+
+
+def test_unverifiable_route_runs_the_probe_instead_of_skipping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 404 from a backend that simply doesn't implement the by-id route and
+    doesn't list the id either is INCONCLUSIVE, not proof of "no model". The
+    preflight exists to avoid a doomed 60 s round trip when nothing is
+    loaded; when it cannot tell, running the probe (and reporting whatever
+    really happens) beats a skip with an invented reason."""
+    hh = tmp_path / "hh"
+    hh.mkdir()
+    (hh / "config.yaml").write_text(
+        "model:\n  default: some-physical-id\n  base_url: http://127.0.0.1:8081/v1\n"
+    )
+    # The backend answers the list route but advertises a different id.
+    _fake_http(monkeypatch, {"http://127.0.0.1:8081/v1/models": {"data": [{"id": "other"}]}})
+    _stub_non_chat_probes(monkeypatch)
+    ran: list[str] = []
+    monkeypatch.setattr(
+        hp, "_smoke_chat_completions", lambda s, io: (ran.append("x"), (False, "503"))[1]
+    )
+    state = hp.BootstrapState(hermes_home=str(hh))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    assert ran == ["x"]
+    assert out.details["skipped"] == []
+    assert any("chat_completions" in f for f in out.details["failures"])
+
+
+def test_virtual_anchor_with_no_live_slot_still_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The #1793 install-time skip must survive: the gateway DOES resolve
+    ``hal0/*`` virtuals by id, so a 404 there is affirmative evidence that no
+    chat slot is live — skip rather than burn the probe's timeout."""
+    hh = tmp_path / "hh"
+    hh.mkdir()
+    (hh / "config.yaml").write_text(
+        "model:\n  default: hal0/agent\n  base_url: http://127.0.0.1:8080/v1\n"
+    )
+    _fake_http(monkeypatch, {"http://127.0.0.1:8080/v1/models": {"data": [{"id": "brain"}]}})
+    _stub_non_chat_probes(monkeypatch)
+    monkeypatch.setattr(
+        hp, "_smoke_chat_completions", lambda s, io: pytest.fail("probe must not run")
+    )
+    state = hp.BootstrapState(hermes_home=str(hh))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    assert out.details["results"]["chat_completions"]["skipped"] is True
+    assert len(out.details["skipped"]) == 1
+
+
+def test_live_resolve_virtual_anchor_runs_the_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shipped default: ``hal0/agent`` against the gateway resolves
+    through the by-id route even though the list route never advertises it."""
+    hh = tmp_path / "hh"
+    hh.mkdir()
+    (hh / "config.yaml").write_text(
+        "model:\n  default: hal0/agent\n  base_url: http://127.0.0.1:8080/v1\n"
+    )
+    _fake_http(
+        monkeypatch,
+        {
+            "http://127.0.0.1:8080/v1/models/hal0/agent": {"id": "hal0/agent"},
+            "http://127.0.0.1:8080/v1/models": {"data": [{"id": "brain"}]},
+        },
+    )
+    _stub_non_chat_probes(monkeypatch)
+    ran: list[str] = []
+    monkeypatch.setattr(
+        hp, "_smoke_chat_completions", lambda s, io: (ran.append("x"), (True, "ready"))[1]
+    )
+    state = hp.BootstrapState(hermes_home=str(hh))
+    out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+    assert ran == ["x"]
+    assert out.details["skipped"] == []
+
+
+class TestFetchModelRouteReady:
+    """Direct coverage of the real ``_fetch_model_route_ready`` — the seam's
+    DEFAULT binding, which nothing exercised before (the fakes all replaced
+    it, so a wiring or URL-shape mistake shipped silently)."""
+
+    def test_installio_default_binds_the_real_implementation(self) -> None:
+        assert hp.InstallIO().fetch_model_route_ready is hp._fetch_model_route_ready
+
+    def test_by_id_hit_preserves_slashes_in_virtual_names(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str] = []
+        _fake_http(monkeypatch, {"http://gw/v1/models/hal0/agent": {"id": "hal0/agent"}}, seen)
+        assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is True
+        assert seen[0] == "http://gw/v1/models/hal0/agent"
+
+    def test_list_fallback_when_by_id_route_is_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_http(monkeypatch, {"http://be/v1/models": {"data": [{"id": "m1"}]}})
+        assert hp._fetch_model_route_ready("m1", "http://be/v1") is True
+
+    def test_unknown_physical_id_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_http(monkeypatch, {"http://be/v1/models": {"data": [{"id": "other"}]}})
+        assert hp._fetch_model_route_ready("m1", "http://be/v1") is None
+
+    def test_unresolvable_virtual_is_conclusively_not_ready(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _fake_http(monkeypatch, {"http://gw/v1/models": {"data": [{"id": "brain"}]}})
+        assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is False
+
+    def test_unreachable_endpoint_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_http(monkeypatch, {}, unreachable={"http://be/"})
+        assert hp._fetch_model_route_ready("m1", "http://be/v1") is None
+
+    def test_empty_base_url_falls_back_to_the_gateway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str] = []
+        _fake_http(monkeypatch, {f"{hp.HAL0_API_URL}/v1/models/hal0/agent": {"id": "x"}}, seen)
+        assert hp._fetch_model_route_ready("hal0/agent", "") is True
+        assert seen[0] == f"{hp.HAL0_API_URL}/v1/models/hal0/agent"
 
 
 def test_write_run_report_surfaces_failure_and_skipped_counts(tmp_path: Path) -> None:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2376,7 +2376,24 @@ class TestFetchModelRouteReady:
         route that lists a different alias proves nothing, so this must not
         harden into a skip."""
         _fake_http(monkeypatch, {"http://127.0.0.1:8081/v1/models": {"data": [{"id": "brain"}]}})
-        assert hp._fetch_model_route_ready("hal0/weird-id", "http://127.0.0.1:8081/v1") is None
+        assert hp._fetch_model_route_ready("hal0/agent", "http://127.0.0.1:8081/v1") is None
+
+    def test_non_canonical_hal0_prefixed_id_is_inconclusive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A physical registry id may legitimately start with ``hal0/`` (the
+        id constraint is only non-emptiness), and the catalog suppresses raw
+        chat ids in favour of their alias row — while chat dispatch still
+        resolves the exact physical id to its owning slot. Only the resolver's
+        CANONICAL virtual names earn a conclusive negative."""
+        gw = f"{hp.HAL0_API_URL}/v1"
+        _fake_http(monkeypatch, {f"{gw}/models": {"data": [{"id": "brain"}]}})
+        assert hp._fetch_model_route_ready("hal0/some-physical-gguf", gw) is None
+        # ...but the advertised virtuals still are conclusive.
+        from hal0.normalize.resolver import DEFAULT_CHAINS
+
+        for virtual in DEFAULT_CHAINS:
+            assert hp._fetch_model_route_ready(virtual, gw) is False, virtual
 
     def test_empty_catalog_is_conclusive_but_malformed_one_is_not(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2364,8 +2364,19 @@ class TestFetchModelRouteReady:
     def test_unresolvable_virtual_is_conclusively_not_ready(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _fake_http(monkeypatch, {"http://gw/v1/models": {"data": [{"id": "brain"}]}})
-        assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is False
+        gw = f"{hp.HAL0_API_URL}/v1"
+        _fake_http(monkeypatch, {f"{gw}/models": {"data": [{"id": "brain"}]}})
+        assert hp._fetch_model_route_ready("hal0/agent", gw) is False
+
+    def test_hal0_prefix_is_only_authoritative_on_the_gateway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``hal0/`` only means "virtual" to the hal0 gateway. On a pinned
+        backend it is just characters in a model id — a backend with no by-id
+        route that lists a different alias proves nothing, so this must not
+        harden into a skip."""
+        _fake_http(monkeypatch, {"http://127.0.0.1:8081/v1/models": {"data": [{"id": "brain"}]}})
+        assert hp._fetch_model_route_ready("hal0/weird-id", "http://127.0.0.1:8081/v1") is None
 
     def test_empty_catalog_is_conclusive_but_malformed_one_is_not(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2373,11 +2384,12 @@ class TestFetchModelRouteReady:
         """A 2xx list response with no usable ``data`` is not evidence of an
         EMPTY catalog — it is no evidence at all, so it must not produce a
         skip. A genuinely empty ``data`` list is a real answer."""
-        _fake_http(monkeypatch, {"http://gw/v1/models": {"data": []}})
-        assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is False
+        gw = f"{hp.HAL0_API_URL}/v1"
+        _fake_http(monkeypatch, {f"{gw}/models": {"data": []}})
+        assert hp._fetch_model_route_ready("hal0/agent", gw) is False
         for junk in ({"error": "nope"}, {"data": "not-a-list"}, {}):
-            _fake_http(monkeypatch, {"http://gw/v1/models": junk})
-            assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is None, junk
+            _fake_http(monkeypatch, {f"{gw}/models": junk})
+            assert hp._fetch_model_route_ready("hal0/agent", gw) is None, junk
 
     def test_unreachable_endpoint_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _fake_http(monkeypatch, {}, unreachable={"http://be/"})

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2367,6 +2367,18 @@ class TestFetchModelRouteReady:
         _fake_http(monkeypatch, {"http://gw/v1/models": {"data": [{"id": "brain"}]}})
         assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is False
 
+    def test_empty_catalog_is_conclusive_but_malformed_one_is_not(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 2xx list response with no usable ``data`` is not evidence of an
+        EMPTY catalog — it is no evidence at all, so it must not produce a
+        skip. A genuinely empty ``data`` list is a real answer."""
+        _fake_http(monkeypatch, {"http://gw/v1/models": {"data": []}})
+        assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is False
+        for junk in ({"error": "nope"}, {"data": "not-a-list"}, {}):
+            _fake_http(monkeypatch, {"http://gw/v1/models": junk})
+            assert hp._fetch_model_route_ready("hal0/agent", "http://gw/v1") is None, junk
+
     def test_unreachable_endpoint_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _fake_http(monkeypatch, {}, unreachable={"http://be/"})
         assert hp._fetch_model_route_ready("m1", "http://be/v1") is None

--- a/tests/release-validation/README.md
+++ b/tests/release-validation/README.md
@@ -115,6 +115,15 @@ known-issues, or regressions, and add a line to the changelog below. A report re
 
 ### Kit changelog
 
+* **3** (2026-08-12) — `smoke-preflight-skips-chat-probes` (#1831) rewritten. As filed it probed
+  only hermes' default live-resolve config — the half of the defect rc.5 fixed — so it would have
+  reported `fixed` while the `HAL0_HERMES_LIVE_RESOLVE=0` mode the issue actually named stayed
+  broken. It now probes both resolution modes, names the pinned mode as the one to look for, and
+  requires any recorded skip reason to be checked against the endpoint in `model.base_url` rather
+  than the gateway catalog. Retiered `judgment`, `promote_ready: false`: the unit-level half moved
+  into `tests/agents/test_hermes_provision.py`, and what remains needs a live box. The lesson
+  generalises — **a register entry that cannot fail is worse than none**, and an entry probing
+  only the configuration a fix was written against is exactly that.
 * **2** (2026-08-11) — curation after the `v1.0.0-rc.5` run. `regressions.yaml` grows from 11 to
   26 entries: the 15 findings filed as #1827–#1841, plus an `rc5_note` and `last_result` on every
   rc.4 entry recording what actually held on a real box. Two rc.4 repros were rewritten because

--- a/tests/release-validation/kit.toml
+++ b/tests/release-validation/kit.toml
@@ -4,7 +4,7 @@
 # scripts cannot read the filesystem, so when you add a lane here you must also add it to the
 # LANES table in the script. The brief itself is only ever read by the agent that runs it.
 
-kit_version = 2
+kit_version = 3
 
 [defaults]
 # Model tier per phase. Rationale in README "Phases".

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -427,25 +427,52 @@ regressions:
     issue: 1831
     from: v1.0.0-rc.5
     severity: major
-    tier: mechanical
+    tier: judgment
     lane: hermes
-    promote_ready: true
+    promote_ready: false
     summary: >-
-      rc.5's new `_chat_model_ready` preflight checks hermes' `model.default` (`hal0/agent`)
+      rc.5's `_chat_model_ready` preflight checked hermes' `model.default` (`hal0/agent`)
       against the ids in GET /v1/models, which deliberately never advertises the `hal0/*`
-      virtual names. The gate can never open on the shipped config, so `chat_completions` and
-      `memory_roundtrip` are skipped on every install — with a false reason ("not loaded on the
+      virtual names. The gate could never open on the shipped config, so `chat_completions` and
+      `memory_roundtrip` were skipped on every install — with a false reason ("not loaded on the
       gateway") while `GET /v1/models/hal0/agent` returns 200. `memory_roundtrip` has no chat
-      dependency at all and should not be behind the gate.
+      dependency at all and should not have been behind the gate.
+    fix: >-
+      Two waves. rc.5 ungated `memory_roundtrip` and resolved the anchor through the by-id
+      route; the follow-up made the preflight ask the endpoint hermes' `model.base_url` points
+      at (the one the probe POSTs to) and made the answer three-valued, so a skip requires
+      affirmative evidence and anything inconclusive runs the probe.
+    rc5_note: >-
+      The first wave fixed the DEFAULT config only. This register entry, as originally written,
+      probed only that config — so it would have reported `fixed` while the mode the issue
+      actually named was still broken. A register entry that cannot fail is worse than none.
+      Probe BOTH resolution modes below; they are different code paths.
     repro: |
+      # Mode A — shipped live-resolve default (model.default: hal0/agent, base_url :8080/v1)
       hal0 agent status hermes --json | jq '.phases.smoke_tests'
-      curl -s $API/v1/models | jq -r '.data[].id'
-      curl -s -o /dev/null -w '%{http_code}\n' $API/v1/models/hal0/agent
-      grep -n 'model:' -A3 /var/lib/hal0/.hermes/config.yaml
+      curl -s -o /dev/null -w '%{http_code}\n' $API/v1/models/hal0/agent   # expect 200
+      #
+      # Mode B — the pinned single-backend mode the issue named. This is the one that hid.
+      # `model.default` becomes a chat slot's RAW physical model id and `model.base_url` its own
+      # llama-server, neither of which the gateway catalog will confirm.
+      HAL0_HERMES_LIVE_RESOLVE=0 hal0 agent bootstrap hermes --repair
+      CFG=/var/lib/hal0/.hermes/config.yaml
+      grep -A3 '^model:' $CFG                                  # note default + base_url
+      MID=$(awk '/^model:/{f=1} f&&/^  default:/{print $2; exit}' $CFG)
+      BURL=$(awk '/^model:/{f=1} f&&/^  base_url:/{print $2; exit}' $CFG)
+      curl -s "$BURL/models" | jq -r '.data[].id'              # the id IS here...
+      curl -s -o /dev/null -w '%{http_code}\n' "$API/v1/models/$MID"   # ...and 404s here
+      hal0 agent status hermes --json | jq '.phases.smoke_tests'
+      # Restore the default afterwards: hal0 agent bootstrap hermes --repair
     expect: >-
-      Neither chat_completions nor memory_roundtrip is skipped on a box where the anchor
-      resolves. If a probe IS skipped, cross-check the recorded reason against
-      `GET /v1/models/{id}` before believing it.
+      In BOTH modes, with a chat slot loaded, `chat_completions` runs (passes or fails on its
+      own merits) and `memory_roundtrip` runs unconditionally. A skip in mode B is the
+      regression, even if mode A is clean. Any recorded skip reason must be verified against
+      the endpoint in `model.base_url` — NOT the gateway catalog — before it is believed; the
+      original defect was precisely a plausible-sounding skip reason that named the wrong
+      server. Unit-level coverage of both modes now lives in
+      tests/agents/test_hermes_provision.py (the pinned-backend and unverifiable-route cases);
+      what stays here is the on-box half, which needs a real install and cannot be a pytest.
 
   - id: slot-verbs-10s-client-timeout
     issue: 1832

--- a/tests/release-validation/regressions.yaml
+++ b/tests/release-validation/regressions.yaml
@@ -455,15 +455,26 @@ regressions:
       # Mode B — the pinned single-backend mode the issue named. This is the one that hid.
       # `model.default` becomes a chat slot's RAW physical model id and `model.base_url` its own
       # llama-server, neither of which the gateway catalog will confirm.
-      HAL0_HERMES_LIVE_RESOLVE=0 hal0 agent bootstrap hermes --repair
-      CFG=/var/lib/hal0/.hermes/config.yaml
-      grep -A3 '^model:' $CFG                                  # note default + base_url
-      MID=$(awk '/^model:/{f=1} f&&/^  default:/{print $2; exit}' $CFG)
-      BURL=$(awk '/^model:/{f=1} f&&/^  base_url:/{print $2; exit}' $CFG)
-      curl -s "$BURL/models" | jq -r '.data[].id'              # the id IS here...
-      curl -s -o /dev/null -w '%{http_code}\n' "$API/v1/models/$MID"   # ...and 404s here
-      hal0 agent status hermes --json | jq '.phases.smoke_tests'
-      # Restore the default afterwards: hal0 agent bootstrap hermes --repair
+      #
+      # Do NOT re-bootstrap hermes to get there: that rewrites the shared config.yaml while the
+      # other lanes probe the same box concurrently, and restoring it afterwards cannot undo what
+      # they observed in the meantime. Drive the installed preflight against a throwaway hermes
+      # home instead — same code, same live endpoints, nothing shared mutated.
+      # Needs a loaded chat slot; note its port and configured model id first.
+      hal0 slot list                                           # pick a loaded llm slot
+      grep -E '^(port|default)' /etc/hal0/slots/<slot>.toml     # -> PORT, PHYS_ID
+      curl -s http://127.0.0.1:<PORT>/v1/models                 # the backend knows the model...
+      curl -s -o /dev/null -w '%{http_code}\n' "$API/v1/models/<PHYS_ID>"   # ...gateway 404s it
+      /usr/lib/hal0/venv/bin/python - <<'PY'
+      import pathlib, tempfile
+      from hal0.agents import hermes_provision as hp
+      d = pathlib.Path(tempfile.mkdtemp())
+      (d / "config.yaml").write_text(
+          "model:\n  default: <PHYS_ID>\n  base_url: http://127.0.0.1:<PORT>/v1\n"
+      )
+      print(hp._chat_model_ready(hp.BootstrapState(hermes_home=str(d)), hp.InstallIO()))
+      PY
+      # (True, ...) = the probe would run. (False, ...) = the defect, still live.
     expect: >-
       In BOTH modes, with a chat slot loaded, `chat_completions` runs (passes or fails on its
       own merits) and `memory_roundtrip` runs unconditionally. A skip in mode B is the


### PR DESCRIPTION
Remediates blocking review findings on the already-merged **#1849**. `Refs #1831`.

#1849 fixed the shipped live-resolve config and stopped there. The independent
review found that the `HAL0_HERMES_LIVE_RESOLVE=0` path the issue explicitly
named is still broken on `main` right now, and — worse — that the regression
register entry meant to catch it passes on the default config while hiding it.

## The defect that is live on main

Under `HAL0_HERMES_LIVE_RESOLVE=0`, `_config_pairs` writes
`model.default = primary["model_id"]` (a chat slot's **raw physical** model id)
and `model.base_url = primary["backend_url"]` (that slot's own llama-server).
The preflight then asks the **hal0 gateway** about that id:

* the gateway's list route suppresses raw chat model ids in favour of the slot's
  alias row (`hal0_chat_slot_model_ids`, which explicitly does not filter on
  loaded state), and
* `get_model`'s `_resolve_virtual_model_entry` returns `None` for anything not
  starting with `hal0/`.

So the by-id route 404s an id that routes perfectly well, `_chat_model_ready`
returns False, and `chat_completions` is skipped forever with the same false
reason as before: `'<physical-id>' not loaded on the gateway`. In that mode
`_smoke_chat_completions` never touches the gateway catalog at all, which also
made #1849's new docstring claim ("matching exactly what `_smoke_chat_completions`
itself dispatches against") false precisely where it mattered.

The root cause the reviewer named is the real one: **the preflight was using a
discovery catalog to answer a routability question.** The by-id route is a better
catalog, not a routability check.

## What changed

**1. Ask the endpoint the probe will actually use.**
`_fetch_model_route_ready(model_id, base_url)` now takes hermes' `model.base_url`
— the origin `_smoke_chat_completions` POSTs `/chat/completions` to — and falls
back from the by-id route to the list route (llama-server has no by-id route but
does list what it has loaded).

**2. A skip must be earned.** The function is three-valued: `True` routes,
`False` the endpoint authoritatively says it does not, `None` inconclusive. Only
a `hal0/*` virtual against the gateway can produce `False` (the gateway resolves
those by id or nowhere). Anything inconclusive — an unknown physical id, a 5xx,
an unreachable endpoint, or a raised exception in the preflight itself — now runs
the probe and reports what really happens. A skip is a claim ("no chat model
exists yet", #1793) and a wrong one is invisible: it reads as a clean install.

The #1793 install-time behaviour is preserved and pinned by a test:
`hal0/agent` + no live slot still skips.

**3. The register entry can now fail.** `regressions.yaml`
`smoke-preflight-skips-chat-probes` probed only the default config, so it would
have reported `fixed` while the named mode stayed broken. It now probes both
resolution modes, names the pinned mode as the failing one to look for, and
requires any recorded skip reason to be cross-checked against `model.base_url`
rather than the gateway catalog. Retiered `judgment` / `promote_ready: false`:
the unit-level half is now in pytest; the rest needs a real install on a box.

## Verification

The reviewer's other complaint about #1849 was that its regression test failed
pre-fix on a **seam signature change**, not on behaviour. This one patches the
real network boundary (`urllib.request.urlopen`) and drives production wiring —
`hp._StepCtx(state=state)` with the default `InstallIO` — so it fails on the
defect itself. Against unfixed `main`:

```
FAILED tests/agents/test_hermes_provision.py::test_pinned_backend_config_does_not_skip_chat_probe
E  AssertionError: chat_completions was skipped on a live pinned backend:
   {'passed': None, 'skipped': True,
    'detail': "skipped: no chat model loaded ('qwen3-30b-a3b-instruct' not loaded on the gateway)"}
   (probed: ['http://127.0.0.1:8080/v1/models/qwen3-30b-a3b-instruct'])
```

Note the probed URL: port 8080, the gateway, while the config points the chat
probe at 8081. That is the bug verbatim.

Also added, closing the reviewer's nits: `TestFetchModelRouteReady` covers the
real default binding (`InstallIO().fetch_model_route_ready is _fetch_model_route_ready`
— nothing asserted this before, so a wiring typo would have shipped silently),
URL shape, slash preservation in virtual names, the list fallback, and each
tri-state outcome.

```
1390 passed, 1 xfailed        # tests/agents + tests/cli
ruff check / ruff format --check   clean
mypy src/hal0/agents/hermes_provision.py — 14 pre-existing errors, none in the changed lines
```

## Judgement on the non-blocking findings

* **memory_roundtrip ungating changes fresh-install output** (nit): correct as
  merged, no change. It goes through `io.mcp_memory_call` with a 5 s timeout and
  has no chat dependency; a memory layer that is not answering yet flips
  `smoke_tests` from a skip to `warn`, which is the honest report. Same hal0-api
  process `admin_tools_list` already requires. Flagged here so the next
  validation run expects it rather than files it.
* **Codex bot posted nothing on #1849** (nit): informational; nothing to fix.
  Recorded so the silence is not mistaken for a clean bot pass.

No CHANGELOG hunk (the consolidated PR owns it). Automerge deliberately not
enabled.
