### PR TITLE
fix(api): evict a deleted slot's model id and stop poisoning the composite catalogue

### DIFF
--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -181,6 +181,23 @@ async def _fetch_hal0_composite_models(
     now: Callable[[], float] = time.monotonic,
     ttl_seconds: float = _HAL0_MODEL_CACHE_TTL_SECONDS,
 ) -> list[str]:
+    """Aggregated catalogue only — see :func:`_fetch_hal0_composite_models_detailed`.
+
+    Drops the ``degraded`` flag, so callers that REPLACE state from this
+    result should use the detailed form instead (#1837 follow-up).
+    """
+    models, _degraded = await _fetch_hal0_composite_models_detailed(
+        slot_manager, now=now, ttl_seconds=ttl_seconds
+    )
+    return models
+
+
+async def _fetch_hal0_composite_models_detailed(
+    slot_manager: SlotManager,
+    *,
+    now: Callable[[], float] = time.monotonic,
+    ttl_seconds: float = _HAL0_MODEL_CACHE_TTL_SECONDS,
+) -> tuple[list[str], bool]:
     """Aggregate every ready chat-capable slot's model id into one catalogue.
 
     Direct read over the live slot config — no pseudo-upstream is
@@ -204,17 +221,39 @@ async def _fetch_hal0_composite_models(
     The returned list is sorted + deduplicated and cached for
     ``ttl_seconds`` to keep the cold-start fan-out cheap while still
     picking up new slots within a handful of seconds.
+
+    Returns:
+        ``(models, degraded)``. ``degraded=True`` means the enumeration
+        did NOT see every configured slot — ``iter_configs`` raised, or
+        it skipped a slot whose TOML wouldn't parse. A degraded result is
+        a floor, not a catalogue: because callers REPLACE their bucket
+        with it, a degraded result must never be cached under the TTL nor
+        written over a known-good bucket, or one momentarily unparseable
+        slot TOML un-advertises a healthy slot's model until the next
+        refresh (and, since ``/v1/models`` reads the bucket rather than
+        this fetch, there is no self-heal short of another slot-ready
+        event or an ``hal0-api`` restart).
     """
     cached = _HAL0_MODEL_CACHE.get(_HAL0_COMPOSITE_CACHE_KEY)
     monotonic_now = now()
     if cached is not None and cached[0] > monotonic_now:
-        return list(cached[1])
+        return list(cached[1]), False
 
+    skipped: list[str] = []
     try:
-        cfgs = await slot_manager.iter_configs()
-    except Exception as exc:  # pragma: no cover — defensive
+        detailed = getattr(slot_manager, "iter_configs_detailed", None)
+        if callable(detailed):
+            cfgs, skipped = await detailed()
+        else:  # pragma: no cover — test doubles / older managers
+            cfgs = await slot_manager.iter_configs()
+    except Exception as exc:
         log.warning("upstream.hal0_composite_iter_failed", error=str(exc))
-        cfgs = []
+        # Enumeration failed outright — report an empty FLOOR, flagged
+        # degraded, and leave the TTL cache untouched so the next call
+        # retries immediately instead of serving this failure for 5s.
+        return [], True
+    if skipped:
+        log.warning("upstream.hal0_composite_partial_enumeration", skipped=list(skipped))
 
     seen: set[str] = set()
     models: list[str] = []
@@ -243,26 +282,17 @@ async def _fetch_hal0_composite_models(
         models.append(model_id)
 
     for cfg in cfgs:
-        name = cfg.get("name", "")
-        is_flm = "flm" in (cfg.get("provider", ""), cfg.get("backend", ""))
-        if not is_flm or not name:
-            continue
-        # Two config shapes accepted here — see _seed_multiplex_models for
-        # why (container-era [npu] table vs. pre-#733 [defaults] load_*).
-        npu_table = cfg.get("npu") or {}
-        defaults = cfg.get("defaults") or {}
-        load_embed = npu_table.get("embed") or defaults.get("load_embed")
-        load_asr = npu_table.get("asr") or defaults.get("load_asr")
-        if load_embed and _FLM_EMBED_TAG not in seen:
-            seen.add(_FLM_EMBED_TAG)
-            models.append(_FLM_EMBED_TAG)
-        if load_asr and _FLM_ASR_TAG not in seen:
-            seen.add(_FLM_ASR_TAG)
-            models.append(_FLM_ASR_TAG)
+        for tag in _flm_multiplex_tags(cfg):
+            if tag in seen:
+                continue
+            seen.add(tag)
+            models.append(tag)
 
     models.sort()
+    if skipped:
+        return models, True
     _HAL0_MODEL_CACHE[_HAL0_COMPOSITE_CACHE_KEY] = (monotonic_now + ttl_seconds, list(models))
-    return models
+    return models, False
 
 
 def _slot_model_id(cfg: dict[str, Any]) -> str:
@@ -644,6 +674,14 @@ async def _prime_hal0_composite_cache(
     :func:`_fetch_hal0_composite_models` — so replacing here doesn't drop
     them.
 
+    The one exception to the replace is a DEGRADED enumeration — see
+    :func:`_fetch_hal0_composite_models_detailed`. If the slot catalogue
+    couldn't be read in full (``iter_configs`` raised, or a slot's TOML
+    wouldn't parse) the previous bucket is left exactly as it was: a
+    partial read is a floor, and replacing with it would un-advertise a
+    healthy slot's model permanently. Deletion still evicts — a deleted
+    slot is simply absent from a complete enumeration.
+
     Skipped if an explicit ``upstreams.toml`` entry already claims the
     name ``hal0`` — operator overrides win, and their entry's model cache
     is populated the same way as any other remote upstream (dispatch
@@ -653,8 +691,44 @@ async def _prime_hal0_composite_cache(
     if upstreams.get("hal0") is not None:
         log.info("slots.hal0_composite_skipped", reason="explicit_upstream_registered")
         return
-    models = await _fetch_hal0_composite_models(slot_manager)
+    models, degraded = await _fetch_hal0_composite_models_detailed(slot_manager)
+    if degraded:
+        log.warning(
+            "slots.hal0_composite_prime_skipped",
+            reason="degraded_enumeration",
+            kept=len(model_cache.get("hal0", []) or []),
+        )
+        return
     model_cache["hal0"] = list(models)
+
+
+async def hal0_refresh_composite_models(app: Any) -> None:
+    """Re-derive ``model_cache["hal0"]`` right now, from live slot config.
+
+    Slot mutations that change the composite catalogue — DELETE
+    ``/api/slots/{name}``, or a config write that rebinds
+    ``model.default`` — produce no ``slot.state`` ``ready`` event, so the
+    event-driven re-prime in :func:`_refresh_model_cache_on_ready` never
+    fires for them. Without this, a deleted slot's model id stayed
+    advertised by ``/v1/models`` (and the dashboard's synthetic ``hal0``
+    tile) until some UNRELATED slot happened to go ready, or ``hal0-api``
+    restarted — #1837, reproduced on ct152.
+
+    Best-effort and never raises: the catalogue is a discovery surface,
+    and failing a successful delete because the cache refresh hiccupped
+    would be worse than a few seconds of staleness.
+    """
+    state = getattr(app, "state", None)
+    upstreams = getattr(state, "upstreams", None)
+    slot_manager = getattr(state, "slot_manager", None)
+    model_cache = getattr(state, "upstream_models", None)
+    if upstreams is None or slot_manager is None or model_cache is None:
+        return
+    try:
+        _hal0_model_cache_clear()
+        await _prime_hal0_composite_cache(upstreams, slot_manager, model_cache)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("model_cache.hal0_composite_refresh_failed", error=str(exc))
 
 
 # ── FLM multiplex model seeding ────────────────────────────────────────────
@@ -667,6 +741,34 @@ async def _prime_hal0_composite_cache(
 # to nowhere. Seed the cache explicitly.
 _FLM_EMBED_TAG = "embed-gemma:300m"
 _FLM_ASR_TAG = "whisper-v3:turbo"
+
+
+def _flm_multiplex_tags(cfg: dict[str, Any]) -> list[str]:
+    """Multiplex tags an FLM slot's config opts into, in stable order.
+
+    One shared derivation for both consumers — the composite fetch
+    (:func:`_fetch_hal0_composite_models_detailed`, which re-derives them
+    on every read so a REPLACE-based prime can't drop them) and
+    :func:`_seed_multiplex_models`. They used to be verbatim copies; a
+    drift between them would show as tags present at startup and silently
+    vanishing on the first slot-ready re-prime.
+
+    Two config shapes are accepted: the container-era ``[npu]`` table
+    (what FLMProvider builds its ``--asr`` / ``--embed`` argv from) and
+    the pre-#733 ``[defaults] load_*`` legacy keys.
+    """
+    if not cfg.get("name"):
+        return []
+    if "flm" not in (cfg.get("provider", ""), cfg.get("backend", "")):
+        return []
+    npu_table = cfg.get("npu") or {}
+    defaults = cfg.get("defaults") or {}
+    tags: list[str] = []
+    if npu_table.get("embed") or defaults.get("load_embed"):
+        tags.append(_FLM_EMBED_TAG)
+    if npu_table.get("asr") or defaults.get("load_asr"):
+        tags.append(_FLM_ASR_TAG)
+    return tags
 
 
 async def _refresh_model_cache_on_ready(
@@ -747,23 +849,11 @@ async def _seed_multiplex_models(
         return
     bucket = model_cache.setdefault("hal0", [])
     for cfg in cfgs:
-        name = cfg.get("name", "")
-        is_flm = "flm" in (cfg.get("provider", ""), cfg.get("backend", ""))
-        if not is_flm or not name:
-            continue
-        # Container-era schema is the [npu] table (what FLMProvider builds
-        # the --asr/--embed argv from); [defaults] load_* is the pre-#733
-        # legacy shape, kept so older tomls keep seeding.
-        npu_table = cfg.get("npu") or {}
-        defaults = cfg.get("defaults") or {}
-        load_embed = npu_table.get("embed") or defaults.get("load_embed")
-        load_asr = npu_table.get("asr") or defaults.get("load_asr")
-        if load_embed and _FLM_EMBED_TAG not in bucket:
-            bucket.append(_FLM_EMBED_TAG)
-            log.info("slots.multiplex_seeded", slot=name, model=_FLM_EMBED_TAG)
-        if load_asr and _FLM_ASR_TAG not in bucket:
-            bucket.append(_FLM_ASR_TAG)
-            log.info("slots.multiplex_seeded", slot=name, model=_FLM_ASR_TAG)
+        for tag in _flm_multiplex_tags(cfg):
+            if tag in bucket:
+                continue
+            bucket.append(tag)
+            log.info("slots.multiplex_seeded", slot=cfg.get("name", ""), model=tag)
 
 
 def _hydrate_upstreams(registry: UpstreamRegistry) -> None:

--- a/src/hal0/api/__init__.py
+++ b/src/hal0/api/__init__.py
@@ -11,7 +11,7 @@ import contextlib
 import os
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any
@@ -653,6 +653,8 @@ async def _prime_hal0_composite_cache(
     upstreams: UpstreamRegistry,
     slot_manager: SlotManager,
     model_cache: dict[str, list[str]],
+    *,
+    evict: Iterable[str] = (),
 ) -> None:
     """Warm the ``model_cache["hal0"]`` bucket via a direct slot-config read.
 
@@ -682,6 +684,12 @@ async def _prime_hal0_composite_cache(
     healthy slot's model permanently. Deletion still evicts — a deleted
     slot is simply absent from a complete enumeration.
 
+    ``evict`` is for callers that KNOW an id just went away (the delete /
+    config-rebind routes). Those ids are dropped from the bucket even on
+    the degraded path, unless the partial read shows another slot still
+    binding them — otherwise one unrelated malformed slot TOML would keep
+    a genuinely deleted model id advertised.
+
     Skipped if an explicit ``upstreams.toml`` entry already claims the
     name ``hal0`` — operator overrides win, and their entry's model cache
     is populated the same way as any other remote upstream (dispatch
@@ -698,11 +706,37 @@ async def _prime_hal0_composite_cache(
             reason="degraded_enumeration",
             kept=len(model_cache.get("hal0", []) or []),
         )
+        _evict_from_composite_bucket(model_cache, evict, still_bound=set(models))
         return
     model_cache["hal0"] = list(models)
 
 
-async def hal0_refresh_composite_models(app: Any) -> None:
+def _evict_from_composite_bucket(
+    model_cache: dict[str, list[str]],
+    evict: Iterable[str],
+    *,
+    still_bound: set[str],
+) -> None:
+    """Drop caller-KNOWN-dead ids from the bucket without a full replace.
+
+    Only used on the degraded path: the enumeration was partial, so the
+    bucket has to be kept, but a caller that just deleted a slot (or
+    rebound its model) knows for certain that id is gone and shouldn't
+    have to wait for a healthy read. ``still_bound`` is the partial read's
+    own catalogue — if the id is in there, another slot still serves it
+    and it must survive.
+    """
+    doomed = {mid for mid in evict if mid and mid not in still_bound}
+    if not doomed:
+        return
+    bucket = model_cache.get("hal0")
+    if not bucket:
+        return
+    model_cache["hal0"] = [mid for mid in bucket if mid not in doomed]
+    log.info("slots.hal0_composite_partial_evict", evicted=sorted(doomed))
+
+
+async def hal0_refresh_composite_models(app: Any, *, evict: Iterable[str] = ()) -> None:
     """Re-derive ``model_cache["hal0"]`` right now, from live slot config.
 
     Slot mutations that change the composite catalogue — DELETE
@@ -713,6 +747,12 @@ async def hal0_refresh_composite_models(app: Any) -> None:
     advertised by ``/v1/models`` (and the dashboard's synthetic ``hal0``
     tile) until some UNRELATED slot happened to go ready, or ``hal0-api``
     restarted — #1837, reproduced on ct152.
+
+    ``evict`` carries the ids the caller KNOWS it just removed (a deleted
+    slot's model id, the pre-write id of a rebind). They're dropped even
+    when the fresh read comes back degraded — see
+    :func:`_prime_hal0_composite_cache` — so one unrelated malformed slot
+    TOML can't keep a deleted id advertised.
 
     Best-effort and never raises: the catalogue is a discovery surface,
     and failing a successful delete because the cache refresh hiccupped
@@ -726,7 +766,7 @@ async def hal0_refresh_composite_models(app: Any) -> None:
         return
     try:
         _hal0_model_cache_clear()
-        await _prime_hal0_composite_cache(upstreams, slot_manager, model_cache)
+        await _prime_hal0_composite_cache(upstreams, slot_manager, model_cache, evict=evict)
     except Exception as exc:  # pragma: no cover — defensive
         log.warning("model_cache.hal0_composite_refresh_failed", error=str(exc))
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1094,14 +1094,20 @@ async def _refresh_composite_catalogue(
     stayed advertised, hard-404ing on dispatch, until an unrelated slot
     went ready or hal0-api restarted.
 
-    ``before`` is the pre-write config: its model id is passed as a known
-    eviction so the id disappears even if the fresh slot-config read comes
-    back degraded (one unrelated malformed TOML must not keep it alive).
+    ``before`` is the pre-write config: everything it used to contribute to
+    the catalogue is passed as a known eviction so those ids disappear even
+    if the fresh slot-config read comes back degraded (one unrelated
+    malformed TOML must not keep them alive). That is the slot's own model
+    id AND any FLM multiplex tag it opted into — an FLM slot serves
+    ``embed-gemma:300m`` / ``whisper-v3:turbo`` from the same process, and
+    deleting it takes those with it. Ids another slot still binds are
+    spared by the refresh itself.
     """
-    from hal0.api import _slot_model_id, hal0_refresh_composite_models
+    from hal0.api import _flm_multiplex_tags, _slot_model_id, hal0_refresh_composite_models
 
-    stale = _slot_model_id(before or {})
-    await hal0_refresh_composite_models(request.app, evict=[stale] if stale else [])
+    cfg = before or {}
+    stale = [mid for mid in (_slot_model_id(cfg), *_flm_multiplex_tags(cfg)) if mid]
+    await hal0_refresh_composite_models(request.app, evict=stale)
 
 
 @router.delete("/{name}")

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1082,6 +1082,28 @@ async def _safe_config(sm: Any, name: str) -> dict[str, Any] | None:
         return None
 
 
+async def _refresh_composite_catalogue(
+    request: Request, before: dict[str, Any] | None = None
+) -> None:
+    """Re-derive ``model_cache["hal0"]`` after a catalogue-changing write.
+
+    #1837: deleting a slot, or rebinding its ``model.default``, changes
+    which model ids ``/v1/models`` (and the dashboard's synthetic ``hal0``
+    tile) should advertise — but emits no ``slot.state`` ``ready`` event,
+    which is the only thing the runtime re-prime listens to. So the old id
+    stayed advertised, hard-404ing on dispatch, until an unrelated slot
+    went ready or hal0-api restarted.
+
+    ``before`` is the pre-write config: its model id is passed as a known
+    eviction so the id disappears even if the fresh slot-config read comes
+    back degraded (one unrelated malformed TOML must not keep it alive).
+    """
+    from hal0.api import _slot_model_id, hal0_refresh_composite_models
+
+    stale = _slot_model_id(before or {})
+    await hal0_refresh_composite_models(request.app, evict=[stale] if stale else [])
+
+
 @router.delete("/{name}")
 @_invalidates_snapshot
 async def delete_slot(name: str, request: Request, force: bool = False) -> dict[str, object]:
@@ -1092,9 +1114,10 @@ async def delete_slot(name: str, request: Request, force: bool = False) -> dict[
     surfaces as 4xx. Pass ``?force=true`` to delete a seeded slot anyway (an
     install/update reconcile may re-seed it later).
     """
-    from hal0.api import hal0_refresh_composite_models
-
     sm = _get_slot_manager(request)
+    # Snapshot before the delete so the composite refresh below knows which
+    # id just went away even if the post-delete read comes back degraded.
+    before = await _safe_config(sm, name)
     async with record_action(request, category="slot", action="slot.delete", target=name):
         await sm.delete(name, force=force)
     # #1837: deleting a slot unloads it (ready -> offline) and emits no
@@ -1102,7 +1125,7 @@ async def delete_slot(name: str, request: Request, force: bool = False) -> dict[
     # slot-ready never fires — the dead slot's model id kept being
     # advertised by /v1/models (hard-404ing on dispatch) until an
     # unrelated slot went ready or hal0-api restarted. Evict here.
-    await hal0_refresh_composite_models(request.app)
+    await _refresh_composite_catalogue(request, before)
     return {"name": name, "deleted": True, "forced": force}
 
 
@@ -1155,8 +1178,6 @@ async def get_slot_resolved(name: str, request: Request) -> dict[str, object]:
 @_invalidates_snapshot
 async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     """Update a slot's config. Body: partial SlotConfig (shallow merge)."""
-    from hal0.api import hal0_refresh_composite_models
-
     sm = _get_slot_manager(request)
     try:
         body = await request.json()
@@ -1207,7 +1228,7 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     # type), which changes the composite catalogue without producing a
     # ``ready`` event. Re-derive it now rather than advertising the old id
     # until some unrelated slot happens to go ready.
-    await hal0_refresh_composite_models(request.app)
+    await _refresh_composite_catalogue(request, before)
     # NOTE (#1369): this route is a PURE config write — no lifecycle side
     # effect. It used to unload a running slot on an ``enabled: false`` body
     # (so the faded card matched reality); with the field gone, config edits
@@ -1267,6 +1288,9 @@ async def update_slot_defaults(name: str, request: Request) -> dict[str, object]
     ) as _rec:
         snap = await sm.update_config(name, {"model": body})
         _rec.after = {"model": body}
+    # ``default`` is a ModelConfig field, so this route can rebind the slot's
+    # model id just like PUT /config — same #1837 eviction applies.
+    await _refresh_composite_catalogue(request, before)
     return _slot_to_dict(snap, request)
 
 

--- a/src/hal0/api/routes/slots.py
+++ b/src/hal0/api/routes/slots.py
@@ -1092,9 +1092,17 @@ async def delete_slot(name: str, request: Request, force: bool = False) -> dict[
     surfaces as 4xx. Pass ``?force=true`` to delete a seeded slot anyway (an
     install/update reconcile may re-seed it later).
     """
+    from hal0.api import hal0_refresh_composite_models
+
     sm = _get_slot_manager(request)
     async with record_action(request, category="slot", action="slot.delete", target=name):
         await sm.delete(name, force=force)
+    # #1837: deleting a slot unloads it (ready -> offline) and emits no
+    # ``ready`` event, so the composite-catalogue re-prime that rides on
+    # slot-ready never fires — the dead slot's model id kept being
+    # advertised by /v1/models (hard-404ing on dispatch) until an
+    # unrelated slot went ready or hal0-api restarted. Evict here.
+    await hal0_refresh_composite_models(request.app)
     return {"name": name, "deleted": True, "forced": force}
 
 
@@ -1147,6 +1155,8 @@ async def get_slot_resolved(name: str, request: Request) -> dict[str, object]:
 @_invalidates_snapshot
 async def update_slot_config(name: str, request: Request) -> dict[str, object]:
     """Update a slot's config. Body: partial SlotConfig (shallow merge)."""
+    from hal0.api import hal0_refresh_composite_models
+
     sm = _get_slot_manager(request)
     try:
         body = await request.json()
@@ -1193,6 +1203,11 @@ async def update_slot_config(name: str, request: Request) -> dict[str, object]:
                 slot=name,
                 error=str(exc),
             )
+    # #1837: a config write can rebind ``model.default`` (or flip the slot's
+    # type), which changes the composite catalogue without producing a
+    # ``ready`` event. Re-derive it now rather than advertising the old id
+    # until some unrelated slot happens to go ready.
+    await hal0_refresh_composite_models(request.app)
     # NOTE (#1369): this route is a PURE config write — no lifecycle side
     # effect. It used to unload a running slot on an ``enabled: false`` body
     # (so the faded card matched reality); with the field gone, config edits

--- a/src/hal0/api/routes/v1.py
+++ b/src/hal0/api/routes/v1.py
@@ -901,12 +901,33 @@ async def _aggregate_models(request: Request, *, show_all: bool) -> list[dict[st
     # chat-capable slot's model id, aggregated straight from slot config
     # (see hal0.api._fetch_hal0_composite_models). No pseudo-upstream is
     # registered in the routing table for this, so there's nothing to fetch
-    # over HTTP here; ``model_cache["hal0"]`` is refreshed on startup,
-    # slot-state events, and the dispatcher passthrough path. Skipped when
-    # an operator has defined a real "hal0" upstream in upstreams.toml —
-    # that entry is picked up by the loop below like any other remote.
+    # over HTTP here. Skipped when an operator has defined a real "hal0"
+    # upstream in upstreams.toml — that entry is picked up by the loop
+    # below like any other remote.
+    #
+    # #1837: re-read it here rather than trusting ``model_cache["hal0"]``
+    # alone. The bucket is maintained by edges (startup, slot-ready,
+    # slot mutations); anything that misses an edge — or a mutation that
+    # landed while one slot's TOML momentarily wouldn't parse — leaves the
+    # bucket wrong with nothing to correct it. The read is served from a
+    # 5s TTL cache, so this stays cheap, and it makes the catalogue
+    # self-healing instead of event-perfect. A DEGRADED read (enumeration
+    # raised, or a slot was skipped) is not authoritative and falls back
+    # to the bucket; a complete one refreshes it for the dashboard's
+    # synthetic ``hal0`` tile too.
+    composite_models = model_cache.get("hal0", [])
+    if upstreams.get("hal0") is None and slot_manager is not None:
+        from hal0.api import _fetch_hal0_composite_models_detailed
+
+        try:
+            fresh, degraded = await _fetch_hal0_composite_models_detailed(slot_manager)
+        except Exception:
+            fresh, degraded = [], True
+        if not degraded:
+            composite_models = fresh
+            model_cache["hal0"] = list(fresh)
     if upstreams.get("hal0") is None:
-        for mid in model_cache.get("hal0", []):
+        for mid in composite_models:
             if mid in seen or mid in chat_model_ids:
                 continue
             row = _catalog_row(mid, "hal0")

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -686,8 +686,16 @@ class SlotManager:
             return str(name)
         return None
 
-    def _iter_configured_slots(self) -> list[tuple[int | None, str, Path]]:
+    def _iter_configured_slots(
+        self, *, dropped: list[str] | None = None
+    ) -> list[tuple[int | None, str, Path]]:
         """Enumerate configured slots as ``(slot_id | None, name, toml_path)``.
+
+        Pass ``dropped`` to collect the stems of files this enumeration
+        threw away before the caller ever saw them (an id-keyed TOML whose
+        name can't be recovered). Callers that REPLACE derived state need
+        that: an omission here is indistinguishable from a deletion, and
+        :meth:`iter_configs_detailed` folds it into its skip report.
 
         THE single bilingual chokepoint that replaced the three glob-stem-as-
         name sites (``list_slots`` / ``_all_configured_slot_names`` /
@@ -714,6 +722,8 @@ class SlotManager:
                 name = self._slot_name_from_id_toml(p, sid)
                 if name is None:
                     log.warning("slot.id_toml_no_name", extra={"path": str(p), "id": sid})
+                    if dropped is not None:
+                        dropped.append(stem)
                     continue
                 assert not name.isdigit(), f"enumerator leaked a digit name for {p}"
                 out.append((sid, name, p))
@@ -2198,13 +2208,20 @@ class SlotManager:
         read, or one unparseable TOML silently un-advertises a healthy
         slot's model until the next refresh.
 
+        Both omission points are reported: a config that fails to parse
+        here, AND a file the bilingual enumerator itself dropped (an
+        id-keyed ``143.toml`` whose name can't be recovered never reaches
+        this loop at all).
+
         Returns:
-            ``(configs, skipped_names)`` — the config dicts in stable
-            order, and the names of the slots that failed to parse.
+            ``(configs, skipped)`` — the config dicts in stable order, and
+            the names (or bare file stems, for a pre-enumeration drop) of
+            the slots this read did not see.
         """
         out: list[dict[str, Any]] = []
         skipped: list[str] = []
-        for name in self._all_configured_slot_names():
+        entries = self._iter_configured_slots(dropped=skipped)
+        for _sid, name, _path in entries:
             try:
                 cfg = await self._load_slot_config(name)
             except SlotConfigError as exc:

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -2183,7 +2183,27 @@ class SlotManager:
             least ``name`` and ``port``; the rest of the SlotConfig
             shape (``backend``, ``provider``, …) round-trips verbatim.
         """
+        cfgs, _skipped = await self.iter_configs_detailed()
+        return cfgs
+
+    async def iter_configs_detailed(self) -> tuple[list[dict[str, Any]], list[str]]:
+        """Like :meth:`iter_configs`, but also report the slots it skipped.
+
+        A slot whose TOML is momentarily unreadable or unparseable is
+        skipped with a warning and omitted from the returned list — so a
+        bare ``iter_configs()`` result is indistinguishable from "that
+        slot no longer exists". Callers that REPLACE derived state from
+        this enumeration (the ``/v1/models`` composite catalogue, #1837)
+        must be able to tell a genuinely shorter catalogue from a partial
+        read, or one unparseable TOML silently un-advertises a healthy
+        slot's model until the next refresh.
+
+        Returns:
+            ``(configs, skipped_names)`` — the config dicts in stable
+            order, and the names of the slots that failed to parse.
+        """
         out: list[dict[str, Any]] = []
+        skipped: list[str] = []
         for name in self._all_configured_slot_names():
             try:
                 cfg = await self._load_slot_config(name)
@@ -2192,9 +2212,10 @@ class SlotManager:
                     "slot.config_skipped",
                     extra={"slot": name, "error": str(exc)},
                 )
+                skipped.append(name)
                 continue
             out.append(cfg)
-        return out
+        return out, skipped
 
     # ── PR-10: seeded slot catalogue + routing helpers ──────────────────────
     #

--- a/tests/api/test_seed_multiplex_models.py
+++ b/tests/api/test_seed_multiplex_models.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from hal0.api import _seed_multiplex_models
+from hal0.api import (
+    _hal0_model_cache_clear,
+    _prime_hal0_composite_cache,
+    _seed_multiplex_models,
+)
+from hal0.upstreams.registry import UpstreamRegistry
 
 CANONICAL_EMBED = "embed-gemma:300m"
 CANONICAL_ASR = "whisper-v3:turbo"
@@ -94,3 +99,59 @@ class TestNonMatching:
         await _seed([_npu_cfg()], cache)
         assert cache["hal0"].count(CANONICAL_EMBED) == 1
         assert cache["hal0"].count(CANONICAL_ASR) == 1
+
+
+class TestPrimePathDerivesTheSameTags:
+    """The LIVE path is the composite prime, not the seeder.
+
+    Since #1837 the prime REPLACES ``model_cache["hal0"]``, which makes
+    :func:`_prime_hal0_composite_cache` — not ``_seed_multiplex_models``
+    — the thing that has to emit these tags on every slot-ready refresh.
+    The seeder is now a belt-and-braces no-op on the startup path, so a
+    suite that only exercises it would stay green while the tags vanished
+    on the first re-prime.
+    """
+
+    async def test_prime_emits_the_tags_for_the_npu_table_shape(self) -> None:
+        _hal0_model_cache_clear()
+        cache: dict[str, list[str]] = {}
+        await _prime_hal0_composite_cache(UpstreamRegistry(), FakeSlotManager([_npu_cfg()]), cache)
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR in cache["hal0"]
+
+    async def test_prime_emits_the_tags_for_the_legacy_defaults_shape(self) -> None:
+        _hal0_model_cache_clear()
+        cache: dict[str, list[str]] = {}
+        await _prime_hal0_composite_cache(
+            UpstreamRegistry(),
+            FakeSlotManager(
+                [
+                    {
+                        "name": "npu",
+                        "type": "llm",
+                        "provider": "flm",
+                        "defaults": {"load_embed": True, "load_asr": True},
+                    }
+                ]
+            ),
+            cache,
+        )
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR in cache["hal0"]
+
+    async def test_reprime_keeps_the_tags_while_evicting_a_deleted_slot(self) -> None:
+        """The exact interaction #1837's replace put at risk."""
+        _hal0_model_cache_clear()
+        cache: dict[str, list[str]] = {}
+        mgr = FakeSlotManager(
+            [_npu_cfg(), {"name": "chat", "type": "llm", "model_default": "ghost-model"}]
+        )
+        await _prime_hal0_composite_cache(UpstreamRegistry(), mgr, cache)
+        assert "ghost-model" in cache["hal0"]
+
+        _hal0_model_cache_clear()
+        mgr._configs = [_npu_cfg()]
+        await _prime_hal0_composite_cache(UpstreamRegistry(), mgr, cache)
+        assert "ghost-model" not in cache["hal0"]
+        assert CANONICAL_EMBED in cache["hal0"]
+        assert CANONICAL_ASR in cache["hal0"]

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -638,6 +638,49 @@ def test_delete_forwards_force_query_param(
     assert isolated_client.get("/api/slots/chat/config").status_code == 404
 
 
+def test_delete_evicts_the_slots_model_id_from_the_composite_catalogue(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    """#1837: DELETE must un-advertise the slot's model id immediately.
+
+    ``SlotManager.delete`` unloads the slot (ready -> offline) and emits no
+    ``ready`` event, so the event-driven composite re-prime never fires for
+    it. Before the fix the id stayed in ``model_cache["hal0"]`` — which is
+    what ``/v1/models`` and the dashboard's synthetic ``hal0`` tile read —
+    until some UNRELATED slot went ready or hal0-api restarted, and it
+    hard-404s on dispatch the whole time (no slot, no registry entry).
+    """
+    app, client = isolated_app_client
+    cache = app.state.upstream_models
+    assert "qwen3-4b-q4_k_m" in cache.get("hal0", []), "precondition: id is advertised"
+
+    r = client.delete("/api/slots/chat")
+    assert r.status_code == 200, r.text
+
+    assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
+
+
+def test_config_write_rebinding_the_model_default_evicts_the_old_id(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    """#1837, same shape via the other mutation: PUT /config that rebinds
+    ``model.default`` emits no ``ready`` event either, so the old id has to
+    be evicted (and the new one advertised) on the write itself."""
+    app, client = isolated_app_client
+    assert "qwen3-4b-q4_k_m" in app.state.upstream_models.get("hal0", [])
+
+    r = client.put("/api/slots/chat/config", json={"model": {"default": "qwen3-8b-q4_k_m"}})
+    assert r.status_code == 200, r.text
+
+    bucket = app.state.upstream_models.get("hal0", [])
+    assert "qwen3-4b-q4_k_m" not in bucket
+    assert "qwen3-8b-q4_k_m" in bucket
+
+
 # ── §21.10 operator pin: route guards + payload exposure (#1367) ────────────
 
 

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -724,6 +724,63 @@ def test_delete_evicts_even_when_an_unrelated_slot_toml_is_malformed(
     assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
 
 
+def test_a_degraded_eviction_self_heals_once_the_catalogue_reads_clean(
+    tmp_hal0_home: str,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+) -> None:
+    """Two slots can share a model id, and the degraded path can't tell.
+
+    If the SIBLING that still binds the id is the slot whose TOML was
+    skipped, the known-eviction drops an id that is still served. That
+    window has to close on its own: ``/v1/models`` re-reads the catalogue
+    behind its 5s TTL, so the first clean read restores the id without
+    waiting for a slot-ready event or a restart.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "twin",
+        [
+            'name = "twin"',
+            "port = 8198",
+            'type = "llm"',
+            'provider = "llama-server"',
+            "[model]",
+            'default = "qwen3-4b-q4_k_m"',  # same id as the `chat` slot
+        ],
+    )
+    app: FastAPI = create_app()
+    with TestClient(app) as client:
+        assert "qwen3-4b-q4_k_m" in app.state.upstream_models.get("hal0", [])
+
+        # `twin` is the slot that goes unreadable, so the post-delete read
+        # can't see that it still binds the shared id.
+        (slot_root / "twin.toml").write_text("name = = broken\n[model\n", encoding="utf-8")
+        assert client.delete("/api/slots/chat").status_code == 200
+        assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
+
+        # Operator fixes the TOML. No slot event, no restart — the next
+        # /v1/models re-read is what has to bring the id back.
+        _seed_slot_toml(
+            tmp_hal0_home,
+            "twin",
+            [
+                'name = "twin"',
+                "port = 8198",
+                'type = "llm"',
+                'provider = "llama-server"',
+                "[model]",
+                'default = "qwen3-4b-q4_k_m"',
+            ],
+        )
+        from hal0.api import _hal0_model_cache_clear
+
+        _hal0_model_cache_clear()  # skip the 5s TTL rather than sleeping
+
+        assert client.get("/v1/models").status_code == 200
+        assert "qwen3-4b-q4_k_m" in app.state.upstream_models.get("hal0", [])
+
+
 def test_delete_of_an_flm_slot_evicts_its_multiplex_tags_on_a_degraded_read(
     tmp_hal0_home: str,
     slot_root: Path,

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -681,6 +681,49 @@ def test_config_write_rebinding_the_model_default_evicts_the_old_id(
     assert "qwen3-8b-q4_k_m" in bucket
 
 
+def test_patch_defaults_rebinding_the_model_default_evicts_the_old_id(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    """PATCH /defaults writes through ``update_config(name, {"model": …})``
+    and ``default`` is a ModelConfig field, so it can rebind the model id
+    exactly like PUT /config — and must evict the old id the same way."""
+    app, client = isolated_app_client
+    assert "qwen3-4b-q4_k_m" in app.state.upstream_models.get("hal0", [])
+
+    r = client.patch("/api/slots/chat/defaults", json={"default": "qwen3-8b-q4_k_m"})
+    assert r.status_code == 200, r.text
+
+    bucket = app.state.upstream_models.get("hal0", [])
+    assert "qwen3-4b-q4_k_m" not in bucket
+    assert "qwen3-8b-q4_k_m" in bucket
+
+
+def test_delete_evicts_even_when_an_unrelated_slot_toml_is_malformed(
+    slot_root: Path,
+    container_stub: dict[str, Any],
+    isolated_app_client: tuple[FastAPI, TestClient],
+) -> None:
+    """A degraded enumeration keeps the bucket — but not the id the caller
+    just deleted.
+
+    The partial-read guard must not resurrect the #1837 ghost: with one
+    unrelated malformed slot TOML on disk, the post-delete read comes back
+    degraded, so the bucket is preserved wholesale — yet the deleted
+    slot's model id is KNOWN dead and has to go.
+    """
+    app, client = isolated_app_client
+    assert "qwen3-4b-q4_k_m" in app.state.upstream_models.get("hal0", [])
+
+    (slot_root / "wrecked.toml").write_text("name = = broken\n[model\n", encoding="utf-8")
+
+    r = client.delete("/api/slots/chat")
+    assert r.status_code == 200, r.text
+
+    assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
+
+
 # ── §21.10 operator pin: route guards + payload exposure (#1367) ────────────
 
 

--- a/tests/api/test_slots_routes.py
+++ b/tests/api/test_slots_routes.py
@@ -724,6 +724,52 @@ def test_delete_evicts_even_when_an_unrelated_slot_toml_is_malformed(
     assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
 
 
+def test_delete_of_an_flm_slot_evicts_its_multiplex_tags_on_a_degraded_read(
+    tmp_hal0_home: str,
+    slot_root: Path,
+    container_stub: dict[str, Any],
+) -> None:
+    """An FLM slot serves its multiplex tags from the same process, so
+    deleting it takes ``embed-gemma:300m`` / ``whisper-v3:turbo`` with it.
+
+    On a degraded read the bucket is preserved wholesale, so those tags
+    have to be named as known evictions alongside the slot's own model id
+    — otherwise they keep being advertised and hard-fail on dispatch.
+    """
+    _seed_slot_toml(
+        tmp_hal0_home,
+        "flmx",
+        [
+            'name = "flmx"',
+            "port = 8199",
+            'type = "llm"',
+            'device = "npu"',
+            'backend = "flm"',
+            "[npu]",
+            "embed = true",
+            "asr = true",
+            "[model]",
+            'default = "gemma3-1b"',
+        ],
+    )
+    app: FastAPI = create_app()
+    with TestClient(app) as client:
+        bucket = app.state.upstream_models.get("hal0", [])
+        assert "embed-gemma:300m" in bucket and "whisper-v3:turbo" in bucket
+
+        (slot_root / "wrecked.toml").write_text("name = = broken\n[model\n", encoding="utf-8")
+
+        r = client.delete("/api/slots/flmx")
+        assert r.status_code == 200, r.text
+
+        after = app.state.upstream_models.get("hal0", [])
+        assert "gemma3-1b" not in after
+        assert "embed-gemma:300m" not in after
+        assert "whisper-v3:turbo" not in after
+        # The unrelated healthy slot's model survives the degraded read.
+        assert "qwen3-4b-q4_k_m" in after
+
+
 # ── §21.10 operator pin: route guards + payload exposure (#1367) ────────────
 
 

--- a/tests/api/test_upstream_dedup.py
+++ b/tests/api/test_upstream_dedup.py
@@ -420,6 +420,53 @@ async def test_partial_enumeration_is_not_cached_under_the_ttl() -> None:
 
 
 @pytest.mark.asyncio
+async def test_degraded_read_still_evicts_an_id_the_caller_knows_is_dead() -> None:
+    """The delete path passes the id it just removed. Keeping the whole
+    bucket on a degraded read must not keep THAT id — otherwise one
+    unrelated malformed slot TOML resurrects the #1837 ghost."""
+    registry = UpstreamRegistry()
+    model_cache: dict[str, list[str]] = {}
+
+    await _prime_hal0_composite_cache(
+        registry, _FakeSlotManager(_two_named_chat_slots()), model_cache
+    )
+    assert model_cache["hal0"] == ["m-a", "m-b"]
+
+    _hal0_model_cache_clear()
+    # slot-b was deleted; slot-c's TOML happens to be unparseable, so the
+    # read is degraded and slot-a is all that comes back.
+    degraded = _PartialSlotManager(
+        [{"name": "slot-a", "type": "llm", "model_default": "m-a"}],
+        skipped=["slot-c"],
+    )
+    await _prime_hal0_composite_cache(registry, degraded, model_cache, evict=["m-b"])
+    assert model_cache["hal0"] == ["m-a"]
+
+
+@pytest.mark.asyncio
+async def test_degraded_evict_spares_an_id_another_slot_still_binds() -> None:
+    """Two slots can share a model id. Deleting one must not un-advertise
+    the id while the other still serves it."""
+    registry = UpstreamRegistry()
+    model_cache: dict[str, list[str]] = {}
+    shared = [
+        {"name": "slot-a", "type": "llm", "model_default": "m-shared"},
+        {"name": "slot-b", "type": "llm", "model_default": "m-shared"},
+    ]
+
+    await _prime_hal0_composite_cache(registry, _FakeSlotManager(shared), model_cache)
+    assert model_cache["hal0"] == ["m-shared"]
+
+    _hal0_model_cache_clear()
+    degraded = _PartialSlotManager(
+        [{"name": "slot-a", "type": "llm", "model_default": "m-shared"}],
+        skipped=["slot-c"],
+    )
+    await _prime_hal0_composite_cache(registry, degraded, model_cache, evict=["m-shared"])
+    assert model_cache["hal0"] == ["m-shared"]
+
+
+@pytest.mark.asyncio
 async def test_a_complete_enumeration_still_evicts_a_deleted_slot() -> None:
     """The degraded guard must not resurrect the #1837 merge-forward: a
     COMPLETE read that no longer lists ``slot-b`` still evicts ``m-b``."""

--- a/tests/api/test_upstream_dedup.py
+++ b/tests/api/test_upstream_dedup.py
@@ -29,6 +29,7 @@ import pytest
 
 from hal0.api import (
     _fetch_hal0_composite_models,
+    _fetch_hal0_composite_models_detailed,
     _hal0_model_cache_clear,
     _prime_hal0_composite_cache,
 )
@@ -302,3 +303,134 @@ def test_public_symbol_exports() -> None:
     assert callable(_prime_hal0_composite_cache)
     assert asyncio.iscoroutinefunction(_fetch_hal0_composite_models)
     assert asyncio.iscoroutinefunction(_prime_hal0_composite_cache)
+
+
+# ── #1837 follow-up: a degraded enumeration must not wipe the bucket ────────
+#
+# The replace-don't-merge fix (#1837) made the prime authoritative: whatever
+# the fetch returns becomes ``model_cache["hal0"]``. That is correct for a
+# COMPLETE enumeration and destructive for a partial one — ``iter_configs``
+# raising, or skipping a slot whose TOML momentarily won't parse, would
+# otherwise un-advertise a healthy slot's model until an unrelated slot went
+# ready or hal0-api restarted (``/v1/models`` reads the bucket, not the
+# fetch, so there is no self-heal).
+
+
+class _ExplodingSlotManager:
+    """Enumeration fails outright (permissions blip, IO error)."""
+
+    async def iter_configs(self) -> list[dict[str, Any]]:
+        raise RuntimeError("transient enumeration failure")
+
+    async def iter_configs_detailed(self) -> tuple[list[dict[str, Any]], list[str]]:
+        raise RuntimeError("transient enumeration failure")
+
+
+class _PartialSlotManager(_FakeSlotManager):
+    """One slot's TOML won't parse, so it's skipped.
+
+    The real ``SlotManager.iter_configs`` swallows ``SlotConfigError`` per
+    slot and keeps going, which makes a partial read indistinguishable
+    from a genuinely shorter catalogue unless the skip is reported —
+    ``iter_configs_detailed`` is what reports it (covered against the real
+    manager in ``tests/slots/test_iter_configs_detailed.py``).
+    """
+
+    def __init__(self, configs: list[dict[str, Any]], skipped: list[str]):
+        super().__init__(configs)
+        self._skipped = skipped
+
+    async def iter_configs_detailed(self) -> tuple[list[dict[str, Any]], list[str]]:
+        return list(self._configs), list(self._skipped)
+
+
+def _two_named_chat_slots() -> list[dict[str, Any]]:
+    return [
+        {"name": "slot-a", "type": "llm", "model_default": "m-a"},
+        {"name": "slot-b", "type": "llm", "model_default": "m-b"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_enumeration_leaves_the_previous_bucket_intact() -> None:
+    """A transient ``iter_configs`` failure must not empty
+    ``model_cache["hal0"]`` — it is a failure to observe, not an
+    observation that every slot is gone."""
+    registry = UpstreamRegistry()
+    model_cache: dict[str, list[str]] = {}
+    healthy = _FakeSlotManager(_two_named_chat_slots())
+
+    await _prime_hal0_composite_cache(registry, healthy, model_cache)
+    assert model_cache["hal0"] == ["m-a", "m-b"]
+
+    _hal0_model_cache_clear()
+    await _prime_hal0_composite_cache(registry, _ExplodingSlotManager(), model_cache)
+    assert model_cache["hal0"] == ["m-a", "m-b"], "a failed read wiped the catalogue"
+
+
+@pytest.mark.asyncio
+async def test_failed_enumeration_is_not_cached_under_the_ttl() -> None:
+    """The failure result must not be written to the 5s TTL cache, or a
+    single blip suppresses the catalogue for the whole window."""
+    _hal0_model_cache_clear()
+    models, degraded = await _fetch_hal0_composite_models_detailed(_ExplodingSlotManager())
+    assert (models, degraded) == ([], True)
+
+    # Immediately afterwards — well inside the TTL — a healthy manager
+    # must be consulted rather than served the cached failure.
+    recovered = await _fetch_hal0_composite_models(_FakeSlotManager(_two_named_chat_slots()))
+    assert recovered == ["m-a", "m-b"]
+
+
+@pytest.mark.asyncio
+async def test_partial_enumeration_does_not_drop_a_healthy_slots_model() -> None:
+    """One unparseable slot TOML shortens the enumeration; replacing the
+    bucket with that floor would permanently un-advertise ``m-b``."""
+    registry = UpstreamRegistry()
+    model_cache: dict[str, list[str]] = {}
+
+    await _prime_hal0_composite_cache(
+        registry, _FakeSlotManager(_two_named_chat_slots()), model_cache
+    )
+    assert model_cache["hal0"] == ["m-a", "m-b"]
+
+    _hal0_model_cache_clear()
+    partial = _PartialSlotManager(
+        [{"name": "slot-a", "type": "llm", "model_default": "m-a"}],
+        skipped=["slot-b"],
+    )
+    await _prime_hal0_composite_cache(registry, partial, model_cache)
+    assert model_cache["hal0"] == ["m-a", "m-b"], "a skipped slot's model was dropped"
+
+
+@pytest.mark.asyncio
+async def test_partial_enumeration_is_not_cached_under_the_ttl() -> None:
+    """A partial read must not be served for the rest of the TTL window
+    either — the next call re-reads and can recover the full catalogue."""
+    _hal0_model_cache_clear()
+    partial = _PartialSlotManager(
+        [{"name": "slot-a", "type": "llm", "model_default": "m-a"}],
+        skipped=["slot-b"],
+    )
+    models, degraded = await _fetch_hal0_composite_models_detailed(partial)
+    assert (models, degraded) == (["m-a"], True)
+
+    recovered = await _fetch_hal0_composite_models(_FakeSlotManager(_two_named_chat_slots()))
+    assert recovered == ["m-a", "m-b"]
+
+
+@pytest.mark.asyncio
+async def test_a_complete_enumeration_still_evicts_a_deleted_slot() -> None:
+    """The degraded guard must not resurrect the #1837 merge-forward: a
+    COMPLETE read that no longer lists ``slot-b`` still evicts ``m-b``."""
+    registry = UpstreamRegistry()
+    model_cache: dict[str, list[str]] = {}
+    slot_mgr = _FakeSlotManager(_two_named_chat_slots())
+
+    await _prime_hal0_composite_cache(registry, slot_mgr, model_cache)
+    assert model_cache["hal0"] == ["m-a", "m-b"]
+
+    _hal0_model_cache_clear()
+    slot_mgr._configs = [{"name": "slot-a", "type": "llm", "model_default": "m-a"}]
+    await _prime_hal0_composite_cache(registry, slot_mgr, model_cache)
+    assert model_cache["hal0"] == ["m-a"]

--- a/tests/slots/test_iter_configs_detailed.py
+++ b/tests/slots/test_iter_configs_detailed.py
@@ -1,0 +1,88 @@
+"""``SlotManager.iter_configs_detailed`` — report what the read skipped.
+
+``iter_configs`` swallows a per-slot ``SlotConfigError`` and continues, so
+its return value cannot distinguish "that slot is gone" from "that slot's
+TOML momentarily wouldn't parse". Callers that REPLACE derived state from
+the enumeration need that distinction: the ``/v1/models`` composite
+catalogue replaces ``model_cache["hal0"]`` wholesale (#1837), and doing
+that with a partial read silently un-advertises a healthy slot's model.
+
+These cases run against the REAL manager over real on-disk TOMLs — the
+api-side guard is unit-tested with a double in
+``tests/api/test_upstream_dedup.py``, and this is what proves the double's
+shape is one the production code path actually produces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hal0.slots.manager import SlotManager
+
+
+def _write(root: Path, name: str, body: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.toml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_detailed_reports_a_slot_whose_toml_does_not_parse(
+    tmp_hal0_home: str,
+) -> None:
+    """A malformed TOML is skipped from the configs AND named in the
+    skipped list — the healthy sibling still comes back."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write(
+        root,
+        "healthy",
+        'name = "healthy"\nport = 8191\nprovider = "llama-server"\n[model]\ndefault = "m-a"\n',
+    )
+    _write(root, "broken", 'name = "broken"\nport = = = 8192\n[model\n')
+
+    sm = SlotManager()
+    cfgs, skipped = await sm.iter_configs_detailed()
+
+    names = {c.get("name") for c in cfgs}
+    assert "healthy" in names
+    assert "broken" not in names
+    assert skipped == ["broken"], f"skipped slots not reported: {skipped!r}"
+
+
+@pytest.mark.asyncio
+async def test_detailed_reports_nothing_skipped_for_a_clean_catalogue(
+    tmp_hal0_home: str,
+) -> None:
+    """The common case: every configured slot parses, so nothing is
+    reported skipped and the caller may safely replace derived state."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write(
+        root,
+        "healthy",
+        'name = "healthy"\nport = 8191\nprovider = "llama-server"\n[model]\ndefault = "m-a"\n',
+    )
+
+    sm = SlotManager()
+    cfgs, skipped = await sm.iter_configs_detailed()
+
+    assert skipped == []
+    assert "healthy" in {c.get("name") for c in cfgs}
+
+
+@pytest.mark.asyncio
+async def test_iter_configs_still_returns_a_bare_list(tmp_hal0_home: str) -> None:
+    """The existing ``iter_configs`` contract is unchanged — it delegates
+    to the detailed form and drops the skip report."""
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write(
+        root,
+        "healthy",
+        'name = "healthy"\nport = 8191\nprovider = "llama-server"\n[model]\ndefault = "m-a"\n',
+    )
+
+    sm = SlotManager()
+    cfgs = await sm.iter_configs()
+
+    assert isinstance(cfgs, list)
+    assert "healthy" in {c.get("name") for c in cfgs}

--- a/tests/slots/test_iter_configs_detailed.py
+++ b/tests/slots/test_iter_configs_detailed.py
@@ -51,6 +51,32 @@ async def test_detailed_reports_a_slot_whose_toml_does_not_parse(
 
 
 @pytest.mark.asyncio
+async def test_detailed_reports_an_id_keyed_toml_dropped_before_the_parse(
+    tmp_hal0_home: str,
+) -> None:
+    """An id-keyed ``143.toml`` whose name can't be recovered is dropped by
+    the bilingual enumerator itself — it never reaches the parse loop.
+
+    That omission is invisible to a caller unless it's reported too:
+    ``skipped`` would come back empty, the read would look COMPLETE, and
+    the composite catalogue would be replaced without that slot's model.
+    """
+    root = Path(tmp_hal0_home) / "etc" / "hal0" / "slots"
+    _write(
+        root,
+        "healthy",
+        'name = "healthy"\nport = 8191\nprovider = "llama-server"\n[model]\ndefault = "m-a"\n',
+    )
+    _write(root, "143", "port = = 9000\nname = =\n")
+
+    sm = SlotManager()
+    cfgs, skipped = await sm.iter_configs_detailed()
+
+    assert "healthy" in {c.get("name") for c in cfgs}
+    assert "143" in skipped, f"pre-enumeration drop not reported: {skipped!r}"
+
+
+@pytest.mark.asyncio
 async def test_detailed_reports_nothing_skipped_for_a_clean_catalogue(
     tmp_hal0_home: str,
 ) -> None:


### PR DESCRIPTION
Fix-forward for two blocking review findings on the already-merged **#1850** (`Refs #1837`). Both defects are live on `main` right now.

## 1. The issue's own repro still reproduced (incomplete fix)

`DELETE /api/slots/{name}` calls `SlotManager.delete`, which unloads the slot (`ready -> offline`) and emits **no `ready` event**. The only runtime re-prime, `_refresh_model_cache_on_ready`, gates on `data["to"] == "ready"`, and `/v1/models` (plus the dashboard's synthetic `hal0` tile) read `model_cache["hal0"]` directly rather than calling the fetch. So after deleting a slot, its model id stayed advertised — hard-404ing on dispatch, since neither a slot nor a registry entry backs it — until some *unrelated* slot went ready or `hal0-api` restarted. #1850 converted "never evicted" into "evicted opportunistically on an unrelated edge".

Fixed on the mutation itself: `DELETE /{name}` and `PUT /{name}/config` (which can rebind `model.default`) both call the new best-effort `hal0_refresh_composite_models(app)` — punch the TTL cache, re-derive the bucket.

## 2. Regression introduced by #1850 (the more urgent half)

`_fetch_hal0_composite_models` converted an `iter_configs()` exception into `cfgs = []`, cached that empty list under the 5s TTL, and `_prime_hal0_composite_cache` then wrote it over the bucket unconditionally. The pre-#1850 merge made this harmless. The **partial** case is the likelier one: `iter_configs` swallows a per-slot `SlotConfigError` and continues, so one momentarily unparseable slot TOML silently shortened the catalogue and dropped a healthy slot's model id — permanently, because `/v1/models` reads the bucket rather than the fetch, so there is no self-heal short of another ready event or a restart. (Note the existing `model_cache.hal0_composite_refresh_failed` log line could never fire — the fetch swallowed the error first.)

- `SlotManager.iter_configs_detailed()` now returns `(configs, skipped_names)`; `iter_configs()` delegates and drops the report, so its contract is unchanged.
- The fetch returns `(models, degraded)`. `degraded` = enumeration raised, or a slot was skipped.
- A degraded result is **never** cached under the TTL (so the next call retries immediately) and **never** written over a known-good bucket.
- A *complete* enumeration still REPLACES, so deletion still evicts — that is pinned by its own test.

## Non-blocking findings

- **nit — duplicated FLM multiplex derivation:** addressed. Folded both copies into one `_flm_multiplex_tags(cfg)` helper, and added `TestPrimePathDerivesTheSameTags` so the *live* prime path (not just the now-no-op seeder) is covered for both config shapes, including a re-prime that evicts a deleted slot while keeping the tags.
- **nit — `regressions.yaml` marking #1837 closed:** no change needed. That hunk is not on `main` — #1850's merge (4187e9bb) touched only `src/hal0/api/__init__.py` and `tests/api/test_upstream_dedup.py`. The register entry `v1-models-never-evicts` is unmodified and has no closed/status field.

## Verification

Every new test was run against the unfixed tree first.

Delete path, before the fix:
```
>       assert "qwen3-4b-q4_k_m" not in app.state.upstream_models.get("hal0", [])
E       AssertionError: assert 'qwen3-4b-q4_k_m' not in ['qwen3-4b-q4_k_m']
```

Degraded enumeration, before the fix:
```
E       AssertionError: assert [] == ['m-a', 'm-b']          # transient failure wiped the bucket
E       AssertionError: assert ['m-a'] == ['m-a', 'm-b']     # one skipped slot dropped m-b
```

`iter_configs_detailed` is covered against the **real** `SlotManager` over a real malformed TOML on disk (`tests/slots/test_iter_configs_detailed.py`) so the api-side double's shape is one the production path actually produces.

After: `tests/api` + `tests/slots` green, `ruff check` and `ruff format --check` clean.

No CHANGELOG hunk — a separate consolidated PR owns that.

---

## Review rounds on this PR (Codex, 5 × P2 — all verified, all fixed)

1. **Malformed id-keyed TOML not reported as skipped** (`c22114ef`) — `_iter_configured_slots` dropped a digit-stemmed `143.toml` whose name can't be recovered *before* the parse loop, so the read looked COMPLETE. It now reports pre-enumeration drops.
2. **Degraded read kept the id the caller just deleted** (`c22114ef`) — callers now pass known-dead ids (`evict=`); they're dropped even on the degraded path, and spared if the partial read shows another slot still binding them.
3. **`PATCH /{name}/defaults` not refreshed** (`c22114ef`) — `default` is a `ModelConfig` field, so that route can rebind the model id too. Same refresh.
4. **FLM multiplex tags not evicted with the slot** (`c03ff7bd`) — an FLM slot serves `embed-gemma:300m` / `whisper-v3:turbo` from the same process; `_flm_multiplex_tags(before)` now joins the eviction list.
5. **Shared id belonging to the skipped slot** (`ace73125`) — a partial read can't tell "nobody binds this" from "the binder is the file I couldn't read". The eviction stays (a ghost id hard-404s; an under-advertised id doesn't); the window closes instead. `/v1/models` re-reads the catalogue behind its 5s TTL and refreshes the bucket on a complete read, so a wrongly-dropped id returns with no slot event and no restart — which also removes the structural assumption (every mutation must hit an edge) that made #1837 possible.

Each round has its own failing-first proof in the PR comments. Final: `tests/api` + `tests/slots` → 2547 passed, 1 skipped; `ruff check` + `ruff format --check` clean; all eight CI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
