### PR TITLE
fix(cli,mcp): derive slot lifecycle timeouts from the server's own budget

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -156,7 +156,7 @@ selected with `--hardware`, and stored on the slot as `device` (`gpu-rocm`, `gpu
 | `model scan` | — | — |
 | `model add <path>` | `path` | `--id` (default `""`), `--name`, `--license` (default `""`), `--overwrite` |
 | `model store [path]` | optional `path` | `--migrate` |
-| `model run <ref>` | `ref` | `--slot`/`-s` (default `""`), `--timeout` (default `300`) |
+| `model run <ref>` | `ref` | `--slot`/`-s` (default `""`), `--timeout` (default: the derived slot-load budget from `hal0.slot_lifecycle_budget`, `622` at time of writing — see [slot lifecycle timeouts](#slot-lifecycle-timeouts)) |
 | `model import-backup <path>` | `path` (required) | `--force`/`-f`, `--dest` (default `/var/lib/hal0/registry/registry.toml`) |
 
 ## `hal0 memory` — manage hal0 memory (Hindsight engine)
@@ -358,6 +358,29 @@ dashboard/API-only (`/api/profiles`).
 | `board show <task_id>` | `task_id` | `--json` |
 | `board add <title>` | `title` | `--body` (default `""`), `--assignee` (default `""`), `--status` (default `triage`), `--board`, `--priority` (default `0`) |
 | `board move <task_id> <status>` | `task_id`, `status` | — |
+
+## Slot lifecycle timeouts
+
+Commands that drive the slot state machine — `slot load` / `unload` / `restart`
+/ `swap` / `delete`, `model run`, `capabilities set`, `update --restart-slots` —
+block until the server converges the slot. Their client read timeouts are not
+hand-picked; they are derived from the server's own bounds in
+`hal0.slot_lifecycle_budget` (the health poll, one container terminate per
+unload, an allowance for the pre-load evictions and for queueing behind an
+in-flight op on the same slot, plus a podman/systemd overhead factor).
+
+| Verb shape | Budget |
+|---|---|
+| load (`slot load`, `model run`, NPU backend load) | 621s |
+| unload (`slot unload`, `slot delete`, NPU backend unload) | 345s |
+| restart / swap (`slot restart`, `slot swap`, `capabilities set`) | 966s |
+| `update --restart-slots`, per drifted slot | 966s (3 slots = 2898s) |
+
+These are ceilings on a *wedged* daemon, not expected durations — a healthy
+load returns in seconds. But the commands print nothing while they wait, so a
+genuinely stuck slot can hold the terminal for the full budget. If you are
+scripting against them (CI, smoke tests), wrap the call in your own
+`timeout(1)` rather than relying on the CLI to give up first.
 
 ## Deprecated aliases
 

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -55,9 +55,17 @@ from typing import Any
 import structlog
 
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 from hal0.system import seam as _seam
 
 log = structlog.get_logger(__name__)
+
+#: Per-server MCP client timeout for ``hal0-admin``. The catalog exposes the
+#: blocking slot lifecycle tools (slot_load / slot_restart / model_swap /
+#: npu_backend_load), so a 60s client cap aborted an agent-driven load long
+#: before the server gave up — the outer half of #1832. Derived from the same
+#: budget the tools themselves forward with, rounded up to whole seconds.
+_HAL0_ADMIN_MCP_TIMEOUT_S = int(slot_lifecycle_timeout_s(loads=1, unloads=1)) + 1
 
 # Canonical last-run-report location. Lives outside $HERMES_HOME — Hermes owns
 # its own tree, and the report must survive a `hermes reset`. This is no longer
@@ -1323,7 +1331,7 @@ def _default_mcp_servers() -> list[dict[str, Any]]:
             "url": "http://127.0.0.1:8080/mcp/admin/mcp",
             "type": "http",
             "private": False,
-            "timeout": 60,
+            "timeout": _HAL0_ADMIN_MCP_TIMEOUT_S,
             "usage_hint": (
                 "query/manage hal0 platform state (slots, services, models, hardware). "
                 "Use when the operator asks about system state or wants to inspect a slot."
@@ -3122,7 +3130,7 @@ def _build_brain_profile_mcp_servers() -> dict[str, Any]:
             "type": "http",
             "url": "http://127.0.0.1:8080/mcp/admin/mcp",
             "headers": admin_headers,
-            "timeout": 60,
+            "timeout": _HAL0_ADMIN_MCP_TIMEOUT_S,
         },
         "hal0-memory": {
             "type": "http",

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -55,17 +55,26 @@ from typing import Any
 import structlog
 
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
-from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
 from hal0.system import seam as _seam
 
 log = structlog.get_logger(__name__)
 
 #: Per-server MCP client timeout for ``hal0-admin``. The catalog exposes the
 #: blocking slot lifecycle tools (slot_load / slot_restart / model_swap /
-#: npu_backend_load), so a 60s client cap aborted an agent-driven load long
-#: before the server gave up — the outer half of #1832. Derived from the same
-#: budget the tools themselves forward with, rounded up to whole seconds.
-_HAL0_ADMIN_MCP_TIMEOUT_S = int(slot_lifecycle_timeout_s(loads=1, unloads=1)) + 1
+#: npu_backend_load / capability_set / stack_apply), so a 60s client cap aborted
+#: an agent-driven load long before the server gave up — the outer half of
+#: #1832. It must cover the WORST tool in that catalog, not a representative
+#: one: derived from the restart shape, this outer client still truncated
+#: stack_apply, whose fan-out budget is several times larger.
+#: Computed from the same shape ``hal0.mcp.admin`` budgets its widest tool
+#: (stack_apply) with. It is NOT imported from that table: hal0.mcp.admin
+#: imports this module's package, so reaching into it here is a circular
+#: import that silently breaks MCP mounting. ``test_hal0_admin_mcp_timeout_
+#: covers_the_widest_bridge_tool`` pins the two against drift.
+_HAL0_ADMIN_MCP_TIMEOUT_S = (
+    int(slot_lifecycle_timeout_s(loads=1, unloads=1, slots=STACK_APPLY_SLOT_ALLOWANCE)) + 1
+)
 
 # Canonical last-run-report location. Lives outside $HERMES_HOME — Hermes owns
 # its own tree, and the report must survive a `hermes reset`. This is no longer

--- a/src/hal0/cli/_shared.py
+++ b/src/hal0/cli/_shared.py
@@ -16,6 +16,20 @@ _console = Console(stderr=True)
 
 NOT_IMPLEMENTED = "not implemented yet — see PLAN.md §13"
 
+#: TCP connect bound, kept short and independent of the per-call read budget.
+#: A local hal0-api either accepts immediately or is not there.
+_CONNECT_TIMEOUT_S = 5.0
+
+
+def _client_timeout(timeout: float) -> httpx.Timeout:
+    """Spend ``timeout`` on the read, not on connect/write/pool.
+
+    ``httpx.Client(timeout=<float>)`` sets every phase to that value, so the
+    multi-minute slot lifecycle budgets (#1832) would also let a half-open or
+    wedged daemon hang the CLI for minutes before the first byte.
+    """
+    return httpx.Timeout(timeout, connect=min(_CONNECT_TIMEOUT_S, timeout))
+
 
 def _api_base() -> str:
     """Return the hal0 API base URL, honouring HAL0_API_URL env override."""
@@ -230,8 +244,12 @@ def _api_request(
         headers.update(_auth_headers())
     if headers:
         kwargs["headers"] = headers
+    # ``timeout`` is the READ budget: the slot lifecycle call sites pass
+    # minutes because the server blocks until the slot converges (#1832).
+    # Widening connect to match would let a half-open daemon stall the CLI for
+    # that whole budget with no output, so connect stays short.
     try:
-        with httpx.Client(timeout=timeout) as client:
+        with httpx.Client(timeout=_client_timeout(timeout)) as client:
             resp = client.request(method, url, **kwargs)
     except httpx.HTTPError as exc:
         raise CliApiError(f"{method} {url} failed: {type(exc).__name__}: {exc}") from exc

--- a/src/hal0/cli/capabilities_commands.py
+++ b/src/hal0/cli/capabilities_commands.py
@@ -48,6 +48,17 @@ from hal0.capabilities.orchestrator import _CHILD_TO_CAPABILITY, LEGAL_SLOTS, le
 from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, api_post, die
 from hal0.config.locking import file_lock
 from hal0.registry.store import ModelRegistry
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+
+#: ``POST /api/capabilities/{slot}/{child}`` awaits the slot state machine
+#: inline: ``routes/capabilities.py`` calls ``CapabilityOrchestrator.apply``,
+#: which — depending on which fields changed — awaits ``SlotManager.load``
+#: (off→on), ``SlotManager.unload`` (on→off) or ``SlotManager.swap`` (model or
+#: backend change while on). The client cannot know which branch the server
+#: will take, so it budgets for the worst one: ``swap``, i.e. unload-then-load
+#: (#1832). Without this the command rides ``api_post``'s 10s default and
+#: reports failure on a capability change that in fact succeeded.
+CAPABILITY_SET_TIMEOUT_S = slot_lifecycle_timeout_s(loads=1, unloads=1)
 
 app = typer.Typer(
     name="capabilities",
@@ -161,7 +172,11 @@ def set_capability(
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        result = api_post(f"/api/capabilities/{slot}/{child}", json=body)
+        result = api_post(
+            f"/api/capabilities/{slot}/{child}",
+            json=body,
+            timeout=CAPABILITY_SET_TIMEOUT_S,
+        )
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -21,6 +21,7 @@ from hal0.cli._shared import (
 )
 from hal0.cli.registry_commands import DEFAULT_REGISTRY_PATH, _do_import_backup
 from hal0.registry.import_toml import import_toml_to_sqlite
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
 app = typer.Typer(help="Manage the local model registry.")
 console = Console()
@@ -582,8 +583,18 @@ def model_run(
         console.print(f"[dim]No --slot given; using slot [bold]{target}[/bold].[/dim]")
 
     # 3. Load with the model assigned.
+    #
+    # /api/slots/{name}/load blocks until the slot converges (#1832), so this
+    # POST needs the derived lifecycle budget: at api_post's generic 10s
+    # default the CLI died with a misleading "check compatibility" hint on a
+    # load that had in fact succeeded, and control never reached the readiness
+    # poll below that --timeout advertises.
     try:
-        api_post(f"/api/slots/{target}/load", json={"model_id": ref})
+        api_post(
+            f"/api/slots/{target}/load",
+            json={"model_id": ref},
+            timeout=slot_lifecycle_timeout_s(loads=1, unloads=0),
+        )
     except CliApiError as exc:
         die(f"{exc}\nCheck compatibility with: hal0 slot show {target}")
         return

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -535,7 +535,12 @@ def model_run(
         "", "--slot", "-s", help="Slot to run on (default: the first compatible slot)"
     ),
     timeout_s: int = typer.Option(
-        300, "--timeout", help="Seconds to wait for the slot to become ready."
+        # The default clears the server's own worst case for a load; a smaller
+        # explicit value is honoured end to end, including by the blocking POST
+        # below (#1832).
+        int(slot_lifecycle_timeout_s(loads=1, unloads=0)) + 1,
+        "--timeout",
+        help="Seconds to wait for the slot to become ready.",
     ),
 ) -> None:
     """Get a model serving: pull if needed, assign to a slot, load, wait ready.
@@ -588,12 +593,15 @@ def model_run(
     # POST needs the derived lifecycle budget: at api_post's generic 10s
     # default the CLI died with a misleading "check compatibility" hint on a
     # load that had in fact succeeded, and control never reached the readiness
-    # poll below that --timeout advertises.
+    # poll below that --timeout advertises. --timeout is the operator's whole
+    # wait budget, so it caps this POST too: `--timeout 30` must give up at
+    # ~30s, not sit in the request for minutes first.
+    load_budget = min(slot_lifecycle_timeout_s(loads=1, unloads=0), float(max(timeout_s, 1)))
     try:
         api_post(
             f"/api/slots/{target}/load",
             json={"model_id": ref},
-            timeout=slot_lifecycle_timeout_s(loads=1, unloads=0),
+            timeout=load_budget,
         )
     except CliApiError as exc:
         die(f"{exc}\nCheck compatibility with: hal0 slot show {target}")

--- a/src/hal0/cli/model_commands.py
+++ b/src/hal0/cli/model_commands.py
@@ -594,8 +594,10 @@ def model_run(
     # default the CLI died with a misleading "check compatibility" hint on a
     # load that had in fact succeeded, and control never reached the readiness
     # poll below that --timeout advertises. --timeout is the operator's whole
-    # wait budget, so it caps this POST too: `--timeout 30` must give up at
-    # ~30s, not sit in the request for minutes first.
+    # wait budget, so the deadline starts HERE, before the POST, and both
+    # phases draw on it: `--timeout 30` must give up ~30s from now, not spend
+    # 30s in the POST and then a fresh 30s in the poll.
+    deadline = time.monotonic() + max(timeout_s, 1)
     load_budget = min(slot_lifecycle_timeout_s(loads=1, unloads=0), float(max(timeout_s, 1)))
     try:
         api_post(
@@ -607,8 +609,8 @@ def model_run(
         die(f"{exc}\nCheck compatibility with: hal0 slot show {target}")
         return
 
-    # 4. Poll until ready (or failed/timeout).
-    deadline = time.monotonic() + max(timeout_s, 1)
+    # 4. Poll until ready (or failed/timeout) — on the deadline opened above,
+    # whose remaining budget the load has already been drawing down.
     state = "unknown"
     while time.monotonic() < deadline:
         try:

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -36,21 +36,22 @@ from hal0.cli._shared import (
     follow_sse_logs,
 )
 from hal0.hardware.stats import SLOT_PORT_RANGE_END, SLOT_PORT_RANGE_START
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
 app = typer.Typer(help="Manage inference slots.")
 console = Console()
 
 # The server-side state machine blocks the HTTP response until the slot
-# converges: SlotManager.load -> _await_ready polls /health for up to
-# providers.container._HEALTH_TIMEOUT_S (180s). restart and swap both
-# unload the live slot before loading the replacement, so their worst-case
-# budget stretches past a single load's. api_post's default 10s read
-# timeout is far under any of these budgets — every mutating lifecycle
-# verb would raise ReadTimeout and exit 1 on an operation that in fact
-# succeeded server-side (#1832). Give these call sites a client timeout
-# with real headroom over the server's own worst case instead of the
-# blanket default.
-SLOT_LIFECYCLE_TIMEOUT_S = 220.0
+# converges, so api_post's default 10s read timeout makes every mutating
+# lifecycle verb raise ReadTimeout and exit 1 on an operation that in fact
+# succeeded server-side (#1832). These budgets are DERIVED from the server's
+# own bounds (health poll + the terminates each verb performs, including the
+# sequential pre-load evictions inside load) — a hardcoded number is what let
+# #1832 come back at 220s against a 210s floor. See hal0.slot_lifecycle_budget.
+SLOT_LOAD_TIMEOUT_S = slot_lifecycle_timeout_s(loads=1, unloads=0)
+SLOT_UNLOAD_TIMEOUT_S = slot_lifecycle_timeout_s(loads=0, unloads=1)
+#: restart and swap are unload-then-load, so they carry both halves.
+SLOT_LIFECYCLE_TIMEOUT_S = slot_lifecycle_timeout_s(loads=1, unloads=1)
 
 
 class SlotProvider(StrEnum):
@@ -272,7 +273,7 @@ def slot_load(
         raise typer.Exit(1)
     try:
         body = {"model_id": model} if model else {}
-        snap = api_post(f"/api/slots/{name}/load", json=body, timeout=SLOT_LIFECYCLE_TIMEOUT_S)
+        snap = api_post(f"/api/slots/{name}/load", json=body, timeout=SLOT_LOAD_TIMEOUT_S)
     except CliApiError as exc:
         die(str(exc))
         return
@@ -290,7 +291,7 @@ def slot_unload(
     if _api_unreachable(url):
         raise typer.Exit(1)
     try:
-        snap = api_post(f"/api/slots/{name}/unload", timeout=SLOT_LIFECYCLE_TIMEOUT_S)
+        snap = api_post(f"/api/slots/{name}/unload", timeout=SLOT_UNLOAD_TIMEOUT_S)
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/cli/slot_commands.py
+++ b/src/hal0/cli/slot_commands.py
@@ -637,7 +637,13 @@ def slot_delete(
         )
     try:
         # ``force`` also bypasses the server-side seeded-slot guard.
-        api_delete(f"/api/slots/{name}", params={"force": "true"} if force else None)
+        # SlotManager.delete unloads a running slot first, so this blocks on
+        # the state machine like the other lifecycle verbs (#1832).
+        api_delete(
+            f"/api/slots/{name}",
+            params={"force": "true"} if force else None,
+            timeout=SLOT_UNLOAD_TIMEOUT_S,
+        )
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -479,10 +479,21 @@ def _restart_drifted_slots() -> None:
     # slot inside ONE request, so the client budget scales with the sweep
     # (#1832). At api_post's generic 10s default this reported failure while
     # the server went on bouncing every slot unattended.
+    #
+    # Send the slots we counted rather than letting the route recompute drift:
+    # otherwise a slot that drifts between the GET and the POST widens the
+    # server's sweep past the budget derived from that count.
+    names = [
+        str(s.get("slot"))
+        for s in (drift.get("slots") or [])
+        if isinstance(s, dict) and s.get("slot")
+    ]
+    payload = {"slots": names} if names else None
     try:
         body = api_post(
             "/api/updates/restart-slots",
-            timeout=slot_lifecycle_timeout_s(loads=1, unloads=1, slots=count),
+            json=payload,
+            timeout=slot_lifecycle_timeout_s(loads=1, unloads=1, slots=max(len(names), count)),
         )
     except CliApiError as exc:
         die(str(exc))

--- a/src/hal0/cli/update_commands.py
+++ b/src/hal0/cli/update_commands.py
@@ -39,6 +39,7 @@ from hal0.cli._shared import (
     api_put,
     die,
 )
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
 console = Console()
 
@@ -470,11 +471,19 @@ def _restart_drifted_slots() -> None:
     drifted slots and lists successes + per-slot failures.
     """
     drift = _fetch_slot_drift()
-    if int(drift.get("count") or 0) == 0:
+    count = int(drift.get("count") or 0)
+    if count == 0:
         console.print(Panel("[green]no slots need restart.[/green]", border_style="green"))
         return
+    # restart_drifted_slots loops `await sm.restart(name)` over every drifted
+    # slot inside ONE request, so the client budget scales with the sweep
+    # (#1832). At api_post's generic 10s default this reported failure while
+    # the server went on bouncing every slot unattended.
     try:
-        body = api_post("/api/updates/restart-slots")
+        body = api_post(
+            "/api/updates/restart-slots",
+            timeout=slot_lifecycle_timeout_s(loads=1, unloads=1, slots=count),
+        )
     except CliApiError as exc:
         die(str(exc))
         return

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1566,6 +1566,10 @@ _SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
     "slot_unload": slot_lifecycle_timeout_s(loads=0, unloads=1),
     "slot_restart": slot_lifecycle_timeout_s(loads=1, unloads=1),
     "model_swap": slot_lifecycle_timeout_s(loads=1, unloads=1),
+    # POST /api/backends/npu/{load,unload} awaits SlotManager.load/unload on
+    # the dynamic NPU slot in the request handler, same budget as the rest.
+    "npu_backend_load": slot_lifecycle_timeout_s(loads=1, unloads=0),
+    "npu_backend_unload": slot_lifecycle_timeout_s(loads=0, unloads=1),
 }
 
 

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1566,6 +1566,8 @@ _SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
     "slot_unload": slot_lifecycle_timeout_s(loads=0, unloads=1),
     "slot_restart": slot_lifecycle_timeout_s(loads=1, unloads=1),
     "model_swap": slot_lifecycle_timeout_s(loads=1, unloads=1),
+    # SlotManager.delete unloads a running slot before removing it.
+    "slot_delete": slot_lifecycle_timeout_s(loads=0, unloads=1),
     # POST /api/backends/npu/{load,unload} awaits SlotManager.load/unload on
     # the dynamic NPU slot in the request handler, same budget as the rest.
     "npu_backend_load": slot_lifecycle_timeout_s(loads=1, unloads=0),

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -178,6 +178,7 @@ from hal0.mcp.approval_queue import ApprovalQueue
 from hal0.mcp.memory import _ANNOTATIONS as _MEMORY_TOOL_ANNOTATIONS
 from hal0.mcp.probes import PROBE_TOOLS, dispatch_probe
 from hal0.memory.namespace import is_known_namespace
+from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
 
 # ── logs_tail secret redactor (security review MED-1) ────────────────────────
 #
@@ -1555,6 +1556,19 @@ def _rest_error_payload(body: Any, *, text: str = "") -> dict[str, Any]:
     }
 
 
+#: Tools whose REST route blocks on the slot state machine, and therefore
+#: cannot use ``_call_rest``'s generic 30s forward timeout: at 30s against a
+#: 180s+ health poll the agent is told the op failed while it succeeds
+#: server-side, the same defect #1832 fixed for the CLI. Budgets derive from
+#: :mod:`hal0.slot_lifecycle_budget` so a server-side retune carries here too.
+_SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
+    "slot_load": slot_lifecycle_timeout_s(loads=1, unloads=0),
+    "slot_unload": slot_lifecycle_timeout_s(loads=0, unloads=1),
+    "slot_restart": slot_lifecycle_timeout_s(loads=1, unloads=1),
+    "model_swap": slot_lifecycle_timeout_s(loads=1, unloads=1),
+}
+
+
 async def _call_rest(
     *,
     base_url: str,
@@ -1899,12 +1913,16 @@ async def _execute_tool(
         }
     url = _format_url(base_url, template, path_args)
     payload: dict[str, Any] | None = remainder if remainder else None
+    call: dict[str, Any] = {}
+    if tool in _SLOT_LIFECYCLE_TIMEOUT_S:
+        call["timeout_s"] = _SLOT_LIFECYCLE_TIMEOUT_S[tool]
     result = await _call_rest(
         base_url=base_url,
         bearer=bearer,
         method=method,
         url=url,
         payload=payload,
+        **call,
     )
     # Redact every Bearer / HAL0_BEARER_TOKEN occurrence before a
     # journald-backed response leaves this process. The REST routes

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1572,6 +1572,10 @@ _SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
     # the dynamic NPU slot in the request handler, same budget as the rest.
     "npu_backend_load": slot_lifecycle_timeout_s(loads=1, unloads=0),
     "npu_backend_unload": slot_lifecycle_timeout_s(loads=0, unloads=1),
+    # POST /api/capabilities/{slot}/{child} awaits CapabilityOrchestrator.apply,
+    # which drives SlotManager.load / unload / swap inline. Budget the worst
+    # branch (swap = unload-then-load); the disable branch only unloads.
+    "capability_set": slot_lifecycle_timeout_s(loads=1, unloads=1),
 }
 
 

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -1584,6 +1584,22 @@ _SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
     "stack_apply": slot_lifecycle_timeout_s(loads=1, unloads=1, slots=STACK_APPLY_SLOT_ALLOWANCE),
 }
 
+#: TCP connect bound for the REST forward, kept short and independent of the
+#: per-call read budget above — the same split ``hal0.cli._shared`` applies, for
+#: the same reason: a local hal0-api either accepts immediately or is not there,
+#: so spending a multi-minute lifecycle budget on *connect* turns a half-open
+#: daemon into a multi-minute hang instead of a fast failure.
+_CONNECT_TIMEOUT_S = 5.0
+
+
+def max_slot_lifecycle_timeout_s() -> float:
+    """Largest budget any lifecycle tool in this bridge can forward with.
+
+    An outer client that fronts these tools has to cover the worst of them, not
+    a representative one, or it truncates the slowest call it is responsible for.
+    """
+    return max(_SLOT_LIFECYCLE_TIMEOUT_S.values())
+
 
 async def _call_rest(
     *,
@@ -1618,7 +1634,8 @@ async def _call_rest(
     call_kwargs: dict[str, Any] = {"headers": headers}
     call_kwargs[payload_kwarg] = (payload or None) if payload_kwarg == "params" else (payload or {})
 
-    async with httpx.AsyncClient(base_url=base_url, timeout=timeout_s) as client:
+    timeout = httpx.Timeout(timeout_s, connect=min(_CONNECT_TIMEOUT_S, timeout_s))
+    async with httpx.AsyncClient(base_url=base_url, timeout=timeout) as client:
         verb = getattr(client, method.lower())
         response = await verb(url, **call_kwargs)
 

--- a/src/hal0/mcp/admin.py
+++ b/src/hal0/mcp/admin.py
@@ -178,7 +178,7 @@ from hal0.mcp.approval_queue import ApprovalQueue
 from hal0.mcp.memory import _ANNOTATIONS as _MEMORY_TOOL_ANNOTATIONS
 from hal0.mcp.probes import PROBE_TOOLS, dispatch_probe
 from hal0.memory.namespace import is_known_namespace
-from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
 
 # ── logs_tail secret redactor (security review MED-1) ────────────────────────
 #
@@ -1576,6 +1576,12 @@ _SLOT_LIFECYCLE_TIMEOUT_S: dict[str, float] = {
     # which drives SlotManager.load / unload / swap inline. Budget the worst
     # branch (swap = unload-then-load); the disable branch only unloads.
     "capability_set": slot_lifecycle_timeout_s(loads=1, unloads=1),
+    # POST /api/stacks/{slug}/apply awaits StackApplyEngine.converge, which
+    # drives load/swap/restart per stack entry and then unloads every residual
+    # running slot — the same fan-out shape as /api/updates/restart-slots, but
+    # over a slug the bridge cannot expand into a slot count without an extra
+    # round trip. Budget STACK_APPLY_SLOT_ALLOWANCE slots' worth.
+    "stack_apply": slot_lifecycle_timeout_s(loads=1, unloads=1, slots=STACK_APPLY_SLOT_ALLOWANCE),
 }
 
 

--- a/src/hal0/providers/container.py
+++ b/src/hal0/providers/container.py
@@ -82,6 +82,7 @@ from hal0.providers._gpu import (
     resolve_gpu_group_ids,
 )
 from hal0.providers.base import HealthCheck, Mount, Provider, RuntimeLaunchPlan
+from hal0.slot_lifecycle_budget import HEALTH_TIMEOUT_S
 from hal0.slots.activation import autoload_enabled
 from hal0.slots.argv import ResolvedArgv, resolve_argv
 from hal0.slots.naming import (
@@ -585,8 +586,11 @@ def _loopback_fence_command(command: list[str]) -> list[str]:
 
 
 # Health-check tuning: poll GET /health on the slot port.
+# The overall bound lives in hal0.slot_lifecycle_budget so the clients of the
+# blocking lifecycle endpoints derive their read timeout from it instead of
+# hardcoding a number this module can silently outgrow (#1832).
 _HEALTH_POLL_INTERVAL_S = 2.0
-_HEALTH_TIMEOUT_S = 180.0
+_HEALTH_TIMEOUT_S = HEALTH_TIMEOUT_S
 _HEALTH_REQUEST_TIMEOUT_S = 3.0
 
 #: Wall-clock bound on the teardown systemd verbs issued by

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -1,0 +1,68 @@
+"""One source of truth for how long a slot lifecycle call can block (#1832).
+
+The slot lifecycle endpoints (``load`` / ``unload`` / ``restart`` / ``swap``,
+and the fan-out ``/api/updates/restart-slots``) hold the HTTP response open
+until the server-side state machine converges. Every client of those
+endpoints — the CLI, the MCP admin bridge — therefore needs a read timeout
+derived from the *server's* worst case, not a hand-picked number that a later
+server-side retune silently invalidates.
+
+That is exactly how #1832 came back: the first fix hardcoded 220s against a
+210s server floor (180s health poll + one 30s terminate), leaving ~5% margin
+and no allowance at all for the sequential unloads
+:func:`hal0.slots.preload_evict.admit` performs *inside* the load path. Two
+evicted candidates already push a plain load past 240s, and the CLI reports
+failure on a load that in fact succeeded.
+
+This module owns the primitive budgets, and the server modules import them
+from here rather than declaring their own:
+
+  - :data:`HEALTH_TIMEOUT_S` — :func:`hal0.providers.container._await_health`
+  - :data:`TERMINATE_TIMEOUT_S` — :attr:`hal0.slots.manager.SlotManager._terminate_timeout_s`
+
+Deliberately dependency-free (stdlib only, no ``hal0`` imports) so the CLI can
+import it without dragging in the slot manager.
+"""
+
+from __future__ import annotations
+
+#: Wall-clock bound on the post-spawn ``/health`` poll. Mirrored by
+#: ``hal0.providers.container._HEALTH_TIMEOUT_S``.
+HEALTH_TIMEOUT_S = 180.0
+
+#: Wall-clock bound on a single container stop. Mirrored by
+#: ``hal0.slots.manager.SlotManager._terminate_timeout_s``.
+TERMINATE_TIMEOUT_S = 30.0
+
+#: Sequential unloads a single ``load`` may perform before it spawns
+#: anything: ``preload_evict.admit`` awaits ``host.unload(candidate)`` once per
+#: evicted candidate, in series, inside the load path. The true count is
+#: bounded only by the number of resident slots, so a client budget has to pick
+#: an allowance; three covers every fleet box we ship (chat + code + embedding
+#: resident at once) with the margin factor on top.
+EVICTION_UNLOAD_ALLOWANCE = 3
+
+#: Multiplier over the summed server budget covering what the server's own
+#: timeouts do not: podman/systemd fork + image resolution, JSON encode, the
+#: request/response hop, and the poll interval overshoot on each bound above.
+OVERHEAD_FACTOR = 1.15
+
+
+def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1) -> float:
+    """Client read timeout that clears the server's worst case, in seconds.
+
+    ``loads`` / ``unloads``: how many of each the endpoint performs per slot —
+    ``load`` is ``loads=1, unloads=0``; ``unload`` is ``loads=0, unloads=1``;
+    ``restart`` and ``swap`` are unload-then-load, so both.
+
+    ``slots``: how many slots the endpoint iterates over in one request
+    (``/api/updates/restart-slots`` loops ``sm.restart`` over every drifted
+    slot). Clamped to at least 1.
+
+    A load charges the health poll plus :data:`EVICTION_UNLOAD_ALLOWANCE`
+    terminates for the evictions ``preload_evict.admit`` may run before the
+    spawn; an unload charges one terminate.
+    """
+    per_slot = loads * (HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S)
+    per_slot += unloads * TERMINATE_TIMEOUT_S
+    return round(per_slot * max(int(slots), 1) * OVERHEAD_FACTOR, 1)

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -44,9 +44,10 @@ EVICTION_UNLOAD_ALLOWANCE = 3
 
 #: Every lifecycle verb takes the per-slot lock (``SlotManager._lock``), so a
 #: request can sit queued behind whatever is already converging that slot
-#: before doing any of its own work. Charged once per request — the dominant
-#: blocking phase of the holder is its health poll.
-LOCK_WAIT_ALLOWANCE_S = HEALTH_TIMEOUT_S
+#: before doing any of its own work. Charged once per request, at the cost of
+#: the worst thing that can hold the lock — a full load, evictions included,
+#: not just its health poll.
+LOCK_WAIT_ALLOWANCE_S = HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
 
 #: Multiplier over the summed server budget covering what the server's own
 #: timeouts do not: podman/systemd fork + image resolution, JSON encode, the

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -74,5 +74,8 @@ def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1
     """
     per_slot = loads * (HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S)
     per_slot += unloads * TERMINATE_TIMEOUT_S
-    total = per_slot * max(int(slots), 1) + LOCK_WAIT_ALLOWANCE_S
+    # The lock allowance is per slot, not per request: a fan-out sweep takes
+    # each slot's lock separately, so every target can independently queue
+    # behind something already converging that slot.
+    total = (per_slot + LOCK_WAIT_ALLOWANCE_S) * max(int(slots), 1)
     return round(total * OVERHEAD_FACTOR, 1)

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -74,8 +74,11 @@ def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1
     """
     per_slot = loads * (HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S)
     per_slot += unloads * TERMINATE_TIMEOUT_S
-    # The lock allowance is per slot, not per request: a fan-out sweep takes
-    # each slot's lock separately, so every target can independently queue
-    # behind something already converging that slot.
-    total = (per_slot + LOCK_WAIT_ALLOWANCE_S) * max(int(slots), 1)
+    # The lock allowance is charged per lock-acquiring phase, per slot. A
+    # compound verb does NOT hold one lock: ``SlotManager.restart`` releases
+    # after ``unload`` and reacquires inside ``load``, so another queued op can
+    # win the gap and be waited on twice. A fan-out sweep likewise takes each
+    # slot's lock separately.
+    lock_waits = max(loads + unloads, 1) * LOCK_WAIT_ALLOWANCE_S
+    total = (per_slot + lock_waits) * max(int(slots), 1)
     return round(total * OVERHEAD_FACTOR, 1)

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -42,6 +42,12 @@ TERMINATE_TIMEOUT_S = 30.0
 #: resident at once) with the margin factor on top.
 EVICTION_UNLOAD_ALLOWANCE = 3
 
+#: Every lifecycle verb takes the per-slot lock (``SlotManager._lock``), so a
+#: request can sit queued behind whatever is already converging that slot
+#: before doing any of its own work. Charged once per request — the dominant
+#: blocking phase of the holder is its health poll.
+LOCK_WAIT_ALLOWANCE_S = HEALTH_TIMEOUT_S
+
 #: Multiplier over the summed server budget covering what the server's own
 #: timeouts do not: podman/systemd fork + image resolution, JSON encode, the
 #: request/response hop, and the poll interval overshoot on each bound above.
@@ -61,8 +67,11 @@ def slot_lifecycle_timeout_s(*, loads: int = 1, unloads: int = 1, slots: int = 1
 
     A load charges the health poll plus :data:`EVICTION_UNLOAD_ALLOWANCE`
     terminates for the evictions ``preload_evict.admit`` may run before the
-    spawn; an unload charges one terminate.
+    spawn; an unload charges one terminate; the whole request additionally
+    charges one :data:`LOCK_WAIT_ALLOWANCE_S` for queueing behind an in-flight
+    op on the same slot.
     """
     per_slot = loads * (HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S)
     per_slot += unloads * TERMINATE_TIMEOUT_S
-    return round(per_slot * max(int(slots), 1) * OVERHEAD_FACTOR, 1)
+    total = per_slot * max(int(slots), 1) + LOCK_WAIT_ALLOWANCE_S
+    return round(total * OVERHEAD_FACTOR, 1)

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -63,6 +63,20 @@ EVICTION_UNLOAD_ALLOWANCE = 3
 #: not just its health poll.
 LOCK_WAIT_ALLOWANCE_S = HEALTH_TIMEOUT_S + EVICTION_UNLOAD_ALLOWANCE * TERMINATE_TIMEOUT_S
 
+#: Slots one ``POST /api/stacks/{slug}/apply`` may converge in a single request.
+#: ``StackApplyEngine.converge`` walks the stack's entries sequentially
+#: (``load`` / ``swap`` / ``restart``, apply.py:472/475/481) and then unloads
+#: every running slot the stack does not claim (apply.py:541), so the true count
+#: is ``len(stack.entries) + len(residual slots)``. The MCP bridge is handed a
+#: slug, not a slot list, and would need an extra ``GET /api/stacks/{slug}``
+#: round trip to count — so, like :data:`EVICTION_UNLOAD_ALLOWANCE`, this is a
+#: documented policy allowance rather than a derived bound. Six covers every
+#: stack we ship and every hand-built one seen on the fleet; a larger stack
+#: degrades to the pre-existing behaviour (client gives up, server finishes),
+#: which is strictly better than the 30s generic default that could not even
+#: cover one unload.
+STACK_APPLY_SLOT_ALLOWANCE = 6
+
 #: Multiplier over the summed server budget covering what the server's own
 #: timeouts do not: podman/systemd fork + image resolution, JSON encode, the
 #: request/response hop, and the poll interval overshoot on each bound above.

--- a/src/hal0/slot_lifecycle_budget.py
+++ b/src/hal0/slot_lifecycle_budget.py
@@ -40,6 +40,20 @@ TERMINATE_TIMEOUT_S = 30.0
 #: bounded only by the number of resident slots, so a client budget has to pick
 #: an allowance; three covers every fleet box we ship (chat + code + embedding
 #: resident at once) with the margin factor on top.
+#:
+#: CAVEAT — this is the one constant in this module with no server-side source.
+#: ``HEALTH_TIMEOUT_S`` and ``TERMINATE_TIMEOUT_S`` are the values the server
+#: itself imports from here, so retuning either propagates to every client and
+#: the parity test in ``tests/cli/test_slot_commands.py`` fails if someone
+#: re-declares a literal. ``preload_evict`` has no equivalent bound to import:
+#: nothing caps how many candidates ``admit`` evicts, so this number is a policy
+#: choice and a server change could invalidate it silently. The slack is
+#: currently large — ten resident slots evicting in series cost
+#: ``HEALTH_TIMEOUT_S + 10 * TERMINATE_TIMEOUT_S`` = 480s against a 621s load
+#: budget, because the per-phase lock allowance and ``OVERHEAD_FACTOR`` sit on
+#: top of the three charged here. Deriving it per call would mean a
+#: ``GET /api/slots`` before every lifecycle verb for a bound that is still an
+#: estimate; bounding it server-side is the real fix (#1869).
 EVICTION_UNLOAD_ALLOWANCE = 3
 
 #: Every lifecycle verb takes the per-slot lock (``SlotManager._lock``), so a

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -43,6 +43,7 @@ from hal0.slot_config import (
     slot_write_lock,
     write_slot_toml,
 )
+from hal0.slot_lifecycle_budget import TERMINATE_TIMEOUT_S
 from hal0.slots._cfg_helpers import (
     _cfg_port,
     _cfg_provider,
@@ -293,7 +294,10 @@ class SlotManager:
     #: an already-``failed`` unit can block forever; past this we abandon the
     #: wait so the caller can converge instead of hanging. Class-level so a
     #: deployment (or a test) can retune it without touching every call site.
-    _terminate_timeout_s: float = 30.0
+    #: The value lives in :mod:`hal0.slot_lifecycle_budget` so the clients of
+    #: the blocking lifecycle endpoints derive their read timeout from the same
+    #: number (#1832).
+    _terminate_timeout_s: float = TERMINATE_TIMEOUT_S
 
     def __init__(
         self,

--- a/src/hal0/slots/manager.py
+++ b/src/hal0/slots/manager.py
@@ -296,7 +296,10 @@ class SlotManager:
     #: deployment (or a test) can retune it without touching every call site.
     #: The value lives in :mod:`hal0.slot_lifecycle_budget` so the clients of
     #: the blocking lifecycle endpoints derive their read timeout from the same
-    #: number (#1832).
+    #: number (#1832). Retune it THERE, not by overriding this attribute at
+    #: runtime: the CLI and the MCP bridge are separate processes that read the
+    #: module constant, so an instance-level override widens the server's wait
+    #: without widening theirs and re-opens the timeout drift.
     _terminate_timeout_s: float = TERMINATE_TIMEOUT_S
 
     def __init__(

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2518,3 +2518,22 @@ def test_resolve_installer_root_falls_back_to_fhs_current(tmp_path):
 
     got = hp._resolve_installer_root(module_file=mod, prefix=str(venv))
     assert got == fhs / "current"
+
+
+def test_hal0_admin_mcp_timeout_clears_the_slot_lifecycle_budget():
+    """The bundled hal0-admin MCP client must out-wait its own blocking tools.
+
+    The admin catalog exposes slot_load / slot_restart / model_swap /
+    npu_backend_load, all of which block on the slot state machine. A 60s
+    per-server client cap aborted an agent-driven load long before the server
+    gave up — the outer half of #1832. Floor read from the server modules.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    floor = terminate + float(_HEALTH_TIMEOUT_S) + 2 * terminate
+
+    by_name = {s["name"]: s for s in hp._default_mcp_servers()}
+    assert by_name["hal0-admin"]["timeout"] >= floor
+    assert hp._build_brain_profile_mcp_servers()["hal0-admin"]["timeout"] >= floor

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2537,3 +2537,22 @@ def test_hal0_admin_mcp_timeout_clears_the_slot_lifecycle_budget():
     by_name = {s["name"]: s for s in hp._default_mcp_servers()}
     assert by_name["hal0-admin"]["timeout"] >= floor
     assert hp._build_brain_profile_mcp_servers()["hal0-admin"]["timeout"] >= floor
+
+
+def test_hal0_admin_mcp_timeout_covers_the_widest_bridge_tool():
+    """The outer MCP client must out-wait the WIDEST tool it fronts.
+
+    ``_HAL0_ADMIN_MCP_TIMEOUT_S`` was derived from the restart shape while the
+    catalog it fronts also exposes ``stack_apply``, whose fan-out budget is
+    several times larger — so the outer client truncated the single biggest
+    blocking call it is responsible for. It cannot import the bridge's table
+    directly (hal0.mcp.admin imports hal0.agents, so that is a circular import
+    that breaks MCP mounting), hence this drift pin.
+    """
+    from hal0.mcp.admin import max_slot_lifecycle_timeout_s
+
+    widest = max_slot_lifecycle_timeout_s()
+    assert widest <= hp._HAL0_ADMIN_MCP_TIMEOUT_S, (
+        f"outer MCP client caps at {hp._HAL0_ADMIN_MCP_TIMEOUT_S}s while the "
+        f"widest tool it fronts budgets {widest}s"
+    )

--- a/tests/cli/test_capabilities_commands.py
+++ b/tests/cli/test_capabilities_commands.py
@@ -159,3 +159,75 @@ def test_set_posts_only_provided_fields(monkeypatch: pytest.MonkeyPatch) -> None
     assert result.exit_code == 0, result.output
     assert captured["path"] == "/api/capabilities/embed/embed"
     assert captured["json"] == {"model": "bge-small"}
+
+
+# ── #1832: `capability set` blocks on the slot state machine ────────────────
+#
+# ``POST /api/capabilities/{slot}/{child}`` is not a config write that returns
+# immediately. ``routes/capabilities.py`` awaits ``CapabilityOrchestrator.apply``,
+# which awaits ``SlotManager.load`` (off→on), ``unload`` (on→off) or ``swap``
+# (model/backend change while on) *inline*, holding the response open until the
+# slot converges. On ``api_post``'s 10s default that is #1832 verbatim: the CLI
+# raises ReadTimeout and exits non-zero while the capability change succeeds.
+#
+# As in ``tests/cli/test_slot_commands.py``, the floor is computed from the
+# SERVER modules, never from the client constant under test — comparing the
+# client budget against the constant it was derived from would be a tautology.
+
+#: See ``tests/cli/test_slot_commands.py`` — ``preload_evict.admit`` runs one
+#: sequential ``host.unload`` per evicted candidate inside the load path; two
+#: is the modest case the client budget must at minimum cover.
+_MIN_EVICTION_UNLOADS = 2
+
+
+def _server_worst_case_s(*, loads: int = 1, unloads: int = 1) -> float:
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    load_phase = loads * (float(_HEALTH_TIMEOUT_S) + _MIN_EVICTION_UNLOADS * terminate)
+    return load_phase + unloads * terminate
+
+
+def _capture_set(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setattr(cc, "_api_unreachable", lambda _u: False)
+    captured: dict[str, Any] = {}
+
+    def fake_post(path: str, *, json: Any = None, **kw: Any) -> dict:
+        captured["path"] = path
+        captured["json"] = json
+        captured["kwargs"] = kw
+        return {"ok": True, "selection": json}
+
+    monkeypatch.setattr(cc, "api_post", fake_post)
+    return captured
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        # off→on: the orchestrator ensures the slot exists then awaits load.
+        ["set", "embed", "embed", "--enabled"],
+        # on→off: the orchestrator awaits unload.
+        ["set", "embed", "embed", "--disabled"],
+        # model change while on: the orchestrator awaits swap (unload-then-load).
+        ["set", "embed", "embed", "--model", "bge-small"],
+    ],
+)
+def test_capability_set_passes_the_lifecycle_timeout(
+    monkeypatch: pytest.MonkeyPatch, argv: list[str]
+) -> None:
+    captured = _capture_set(monkeypatch)
+    result = runner.invoke(cc.app, argv)
+    assert result.exit_code == 0, result.output
+    assert captured["path"] == "/api/capabilities/embed/embed"
+
+    # One request cannot know which branch the server will take, so the single
+    # budget it sends has to clear the worst one: swap, i.e. unload-then-load.
+    floor = _server_worst_case_s(loads=1, unloads=1)
+    kwargs = captured["kwargs"]
+    assert "timeout" in kwargs, "capability set passed no explicit timeout kwarg"
+    assert kwargs["timeout"] >= floor, (
+        f"timeout={kwargs['timeout']} is under the server's {floor}s worst case "
+        f"(the orchestrator's swap branch)"
+    )

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -18,6 +18,23 @@ from hal0.cli import model_commands
 runner = CliRunner()
 
 
+def _assert_clears_load_budget(kwargs: dict[str, Any]) -> None:
+    """A blocking slot-load POST must out-wait the server's own worst case.
+
+    Floor is computed from the server modules (the health poll plus the two
+    sequential pre-load evictions ``preload_evict.admit`` may run inside the
+    load path), never from the client constant under test.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    floor = float(_HEALTH_TIMEOUT_S) + 2 * float(SlotManager._terminate_timeout_s)
+    assert "timeout" in kwargs, "blocking load POST passed no explicit timeout kwarg"
+    assert kwargs["timeout"] >= floor, (
+        f"timeout={kwargs['timeout']} is under the server's {floor}s load worst case"
+    )
+
+
 @pytest.fixture(autouse=True)
 def _api_reachable(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(model_commands, "_api_unreachable", lambda _url: False)
@@ -331,10 +348,13 @@ def test_model_run_loads_and_waits_ready(monkeypatch: pytest.MonkeyPatch) -> Non
             return {"name": "chat", "status": "ready", "port": 8081}
         raise AssertionError(path)
 
-    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> Any:
+    posted: dict[str, Any] = {}
+
+    def fake_post(path: str, *, json: Any = None, **kw: Any) -> Any:
         calls.append(f"POST {path}")
         assert path == "/api/slots/chat/load"
         assert json == {"model_id": "qwen3-4b"}
+        posted["kwargs"] = kw
         return {"state": "loading"}
 
     monkeypatch.setattr(model_commands, "api_get", fake_get)
@@ -342,6 +362,11 @@ def test_model_run_loads_and_waits_ready(monkeypatch: pytest.MonkeyPatch) -> Non
     result = runner.invoke(model_commands.app, ["run", "qwen3-4b"])
     assert result.exit_code == 0, result.output
     assert "POST /api/slots/chat/load" in calls
+    # /api/slots/{name}/load blocks until the slot converges — the POST must
+    # carry the lifecycle budget, not api_post's generic 10s default (#1832).
+    # Without it the command reports failure on a load that succeeded, and
+    # never reaches the readiness poll its own --timeout advertises.
+    _assert_clears_load_budget(posted["kwargs"])
     assert "Ready" in result.output
     assert "curl" in result.output  # prints a copy-paste smoke test
 

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -416,3 +416,40 @@ def test_model_run_explicit_timeout_caps_the_blocking_load_post(
     result = runner.invoke(model_commands.app, ["run", "qwen3-4b", "--timeout", "5"])
     assert result.exit_code == 0, result.output
     assert posted["kwargs"]["timeout"] == 5.0
+
+
+def test_model_run_deadline_covers_the_load_not_just_the_poll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--timeout is one budget across both phases, not one per phase.
+
+    Opening the readiness deadline only after the POST returned meant a load
+    that consumed most of --timeout server-side still got a fresh full poll
+    window, so an advertised 100s limit could approach 200s.
+    """
+    import time as _time
+
+    clock = {"now": 0.0}
+    monkeypatch.setattr(_time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(_time, "sleep", lambda _s: None)
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        if path == "/api/models/qwen3-4b":
+            return {"id": "qwen3-4b"}
+        if path == "/api/slots":
+            return {"slots": [{"name": "chat"}]}
+        if path == "/api/slots/chat":
+            clock["now"] += 1.0  # never becomes ready
+            return {"name": "chat", "status": "warming"}
+        raise AssertionError(path)
+
+    def fake_post(path: str, *, json: Any = None, **_kw: Any) -> Any:
+        clock["now"] += 95.0  # the load ate most of the operator's budget
+        return {"state": "loading"}
+
+    monkeypatch.setattr(model_commands, "api_get", fake_get)
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(model_commands.app, ["run", "qwen3-4b", "--timeout", "100"])
+    assert result.exit_code == 1
+    # 95s of load plus at most 5s of polling — not 95 plus a fresh 100.
+    assert clock["now"] <= 100.0, f"waited {clock['now']}s against --timeout 100"

--- a/tests/cli/test_model_first_run_commands.py
+++ b/tests/cli/test_model_first_run_commands.py
@@ -384,3 +384,35 @@ def test_model_run_unregistered_model_names_the_fix(
     assert "hal0 model pull" in out
     assert "hal0 model add" in out
     assert "hal0 model scan" in out
+
+
+def test_model_run_explicit_timeout_caps_the_blocking_load_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--timeout is the operator's whole wait budget, POST included (#1832).
+
+    Giving the blocking load POST the full derived budget unconditionally would
+    make `hal0 model run --timeout 5` sit in the request for minutes before the
+    readiness poll it advertises ever starts.
+    """
+
+    def fake_get(path: str, **_kw: Any) -> Any:
+        if path == "/api/models/qwen3-4b":
+            return {"id": "qwen3-4b"}
+        if path == "/api/slots":
+            return {"slots": [{"name": "chat"}]}
+        if path == "/api/slots/chat":
+            return {"name": "chat", "status": "ready", "port": 8081}
+        raise AssertionError(path)
+
+    posted: dict[str, Any] = {}
+
+    def fake_post(path: str, *, json: Any = None, **kw: Any) -> Any:
+        posted["kwargs"] = kw
+        return {"state": "loading"}
+
+    monkeypatch.setattr(model_commands, "api_get", fake_get)
+    monkeypatch.setattr(shared, "api_post", fake_post)
+    result = runner.invoke(model_commands.app, ["run", "qwen3-4b", "--timeout", "5"])
+    assert result.exit_code == 0, result.output
+    assert posted["kwargs"]["timeout"] == 5.0

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -168,3 +168,23 @@ def test_sweep_budget_scales_the_lock_wait_per_slot() -> None:
     one = slot_lifecycle_timeout_s(loads=1, unloads=1, slots=1)
     three = slot_lifecycle_timeout_s(loads=1, unloads=1, slots=3)
     assert three >= 3 * one
+
+
+def test_restart_budget_charges_both_lock_acquisitions() -> None:
+    """restart is unload-then-load and takes the slot lock TWICE (#1832).
+
+    ``SlotManager.restart`` releases the lock after ``unload`` and reacquires
+    it inside ``load``, so another queued lifecycle op can win the gap and be
+    waited on a second time. Charging one lock allowance for the compound verb
+    under-budgets exactly the contended case the widening exists for.
+    """
+    from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+
+    from hal0.providers.container import _HEALTH_TIMEOUT_S  # isort: skip
+    from hal0.slots.manager import SlotManager  # isort: skip
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    load_phase = float(_HEALTH_TIMEOUT_S) + _MIN_EVICTION_UNLOADS * terminate
+    # Two lock waits (each capped by a full load) plus the verb's own work.
+    floor = 2 * load_phase + terminate + load_phase
+    assert slot_lifecycle_timeout_s(loads=1, unloads=1) >= floor

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -41,28 +41,80 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     return captured
 
 
-def _timeout_ge_server_budget(kwargs: dict[str, Any]) -> None:
-    """The CLI's client-side read timeout must clear the server's own
-    180s health-poll budget with real headroom — not just barely exceed
-    the old 10s default."""
+#: Sequential unloads a single ``load`` is expected to survive:
+#: ``preload_evict.admit`` awaits ``host.unload(candidate)`` once per evicted
+#: candidate, in series, before the spawn. Two is the modest case (a box with
+#: two resident slots to free); the client budget must at minimum cover it.
+_MIN_EVICTION_UNLOADS = 2
+
+
+def _server_worst_case_s(*, loads: int = 1, unloads: int = 1, slots: int = 1) -> float:
+    """The server's own floor for this endpoint, read from the server modules.
+
+    Deliberately computed from ``providers.container`` and ``SlotManager``
+    rather than from ``hal0.slot_lifecycle_budget`` — comparing the client
+    timeout against the constant it was derived from would be a tautology.
+    Retuning either server bound upward makes these tests fail, which is the
+    point: #1832 regressed because the client number was hand-picked.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    per_slot = loads * (float(_HEALTH_TIMEOUT_S) + _MIN_EVICTION_UNLOADS * terminate)
+    per_slot += unloads * terminate
+    return per_slot * slots
+
+
+def _timeout_ge_server_budget(
+    kwargs: dict[str, Any], *, loads: int = 1, unloads: int = 1, slots: int = 1
+) -> None:
+    """The CLI's client-side read timeout must clear the server's worst case.
+
+    Not "beat the old 10s default" and not "beat 180s": the endpoint blocks
+    for the health poll *plus* the terminates it performs (its own unload, and
+    the pre-load evictions ``preload_evict.admit`` runs inside the load path).
+    """
+    floor = _server_worst_case_s(loads=loads, unloads=unloads, slots=slots)
     assert "timeout" in kwargs, "lifecycle call site passed no explicit timeout kwarg"
-    assert kwargs["timeout"] >= 180.0, (
-        f"timeout={kwargs['timeout']} is under the server's 180s health-poll budget"
+    assert kwargs["timeout"] >= floor, (
+        f"timeout={kwargs['timeout']} is under the server's {floor}s worst case "
+        f"(loads={loads}, unloads={unloads}, slots={slots})"
     )
+
+
+def test_budget_constants_track_the_server_modules() -> None:
+    """The budget module mirrors the server bounds — drift must break the build.
+
+    ``slot_lifecycle_budget`` is the single source of truth the server modules
+    import from; if someone re-declares a literal in ``container.py`` or
+    ``SlotManager`` this fails instead of silently under-budgeting the CLI.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slot_lifecycle_budget import (
+        EVICTION_UNLOAD_ALLOWANCE,
+        HEALTH_TIMEOUT_S,
+        TERMINATE_TIMEOUT_S,
+    )
+    from hal0.slots.manager import SlotManager
+
+    assert _HEALTH_TIMEOUT_S == HEALTH_TIMEOUT_S
+    assert SlotManager._terminate_timeout_s == TERMINATE_TIMEOUT_S
+    assert EVICTION_UNLOAD_ALLOWANCE >= _MIN_EVICTION_UNLOADS
 
 
 def test_slot_load_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
     result = runner.invoke(slot_commands.app, ["load", "primary"])
     assert result.exit_code == 0, result.output
     assert captured["path"] == "/api/slots/primary/load"
-    _timeout_ge_server_budget(captured["kwargs"])
+    _timeout_ge_server_budget(captured["kwargs"], loads=1, unloads=0)
 
 
 def test_slot_unload_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
     result = runner.invoke(slot_commands.app, ["unload", "primary"])
     assert result.exit_code == 0, result.output
     assert captured["path"] == "/api/slots/primary/unload"
-    _timeout_ge_server_budget(captured["kwargs"])
+    _timeout_ge_server_budget(captured["kwargs"], loads=0, unloads=1)
 
 
 def test_slot_restart_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:

--- a/tests/cli/test_slot_commands.py
+++ b/tests/cli/test_slot_commands.py
@@ -131,3 +131,40 @@ def test_slot_swap_passes_lifecycle_timeout(captured: dict[str, Any]) -> None:
     assert result.exit_code == 0, result.output
     assert captured["path"] == "/api/slots/primary/swap"
     _timeout_ge_server_budget(captured["kwargs"])
+
+
+def test_slot_delete_passes_the_unload_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DELETE /api/slots/{name} unloads a running slot before removing it.
+
+    ``SlotManager.delete`` awaits ``unload`` for a live slot, so the delete
+    blocks on the state machine too and cannot ride api_delete's 10s default
+    (#1832) — the CLI would report a failed delete while the server finishes
+    stopping and removing the slot.
+    """
+    seen: dict[str, Any] = {}
+
+    def fake_delete(path: str, **kw: Any) -> dict[str, Any]:
+        seen["path"] = path
+        seen["kwargs"] = kw
+        return {}
+
+    monkeypatch.setattr(slot_commands, "_api_unreachable", lambda _url: False)
+    monkeypatch.setattr(slot_commands, "api_delete", fake_delete)
+    result = runner.invoke(slot_commands.app, ["delete", "primary", "--force"])
+    assert result.exit_code == 0, result.output
+    assert seen["path"] == "/api/slots/primary"
+    _timeout_ge_server_budget(seen["kwargs"], loads=0, unloads=1)
+
+
+def test_sweep_budget_scales_the_lock_wait_per_slot() -> None:
+    """A fan-out sweep takes each slot's lock separately (#1832).
+
+    ``/api/updates/restart-slots`` calls ``sm.restart`` per target, so every
+    target can independently queue behind an in-flight op on that slot —
+    charging one lock-wait for the whole request under-budgets the sweep.
+    """
+    from hal0.slot_lifecycle_budget import slot_lifecycle_timeout_s
+
+    one = slot_lifecycle_timeout_s(loads=1, unloads=1, slots=1)
+    three = slot_lifecycle_timeout_s(loads=1, unloads=1, slots=3)
+    assert three >= 3 * one

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -184,7 +184,7 @@ def test_restart_slots_scales_timeout_with_drifted_slot_count(
         return {}
 
     def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
-        posted[path] = kwargs
+        posted[path] = {**kwargs, "json": json}
         return {"restarted": drifted, "failed": [], "count": len(drifted)}
 
     monkeypatch.setattr(uc, "api_get", fake_get)
@@ -193,6 +193,9 @@ def test_restart_slots_scales_timeout_with_drifted_slot_count(
     assert result.exit_code == 0, result.output
 
     kwargs = posted["/api/updates/restart-slots"]
+    # The sweep is pinned to the slots the timeout was derived from — the route
+    # otherwise recomputes drift and can restart more than we budgeted for.
+    assert kwargs["json"] == {"slots": drifted}
     terminate = float(SlotManager._terminate_timeout_s)
     # Per slot: the unload (one terminate) plus the load (health poll + two
     # sequential pre-load evictions), times every drifted slot in the sweep.

--- a/tests/cli/test_update_commands.py
+++ b/tests/cli/test_update_commands.py
@@ -156,6 +156,54 @@ def test_restart_slots_bounces_only_drifted_and_skips_apply(
     assert "/api/updates/commit" not in calls["post"]
 
 
+def test_restart_slots_scales_timeout_with_drifted_slot_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The restart-slots POST must out-wait the whole server-side sweep (#1832).
+
+    ``restart_drifted_slots`` loops ``await sm.restart(name)`` over every
+    drifted slot in ONE request, and each restart is unload-then-load. At
+    ``api_post``'s generic 10s default the CLI reports failure while the sweep
+    goes on bouncing every slot unattended. The floor here is read from the
+    server modules, so a server-side retune breaks this test rather than
+    silently under-budgeting the client.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    monkeypatch.setattr(uc, "_api_unreachable", lambda url: False)
+    drifted = ["chat", "code", "embed"]
+    posted: dict = {}
+
+    def fake_get(path: str, **kwargs: object) -> dict:
+        if path == "/api/updates/slot-drift":
+            return {
+                "count": len(drifted),
+                "slots": [{"slot": name, "diffs": []} for name in drifted],
+            }
+        return {}
+
+    def fake_post(path: str, *, json: object = None, **kwargs: object) -> dict:
+        posted[path] = kwargs
+        return {"restarted": drifted, "failed": [], "count": len(drifted)}
+
+    monkeypatch.setattr(uc, "api_get", fake_get)
+    monkeypatch.setattr(uc, "api_post", fake_post)
+    result = runner.invoke(app, ["update", "--restart-slots"])
+    assert result.exit_code == 0, result.output
+
+    kwargs = posted["/api/updates/restart-slots"]
+    terminate = float(SlotManager._terminate_timeout_s)
+    # Per slot: the unload (one terminate) plus the load (health poll + two
+    # sequential pre-load evictions), times every drifted slot in the sweep.
+    floor = len(drifted) * (terminate + float(_HEALTH_TIMEOUT_S) + 2 * terminate)
+    assert "timeout" in kwargs, "restart-slots POST passed no explicit timeout kwarg"
+    assert kwargs["timeout"] >= floor, (
+        f"timeout={kwargs['timeout']} is under the {floor}s worst case for "
+        f"{len(drifted)} drifted slots"
+    )
+
+
 def test_restart_slots_clean_message_when_nothing_drifted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1387,6 +1387,22 @@ async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
         f"{floor}s server worst case"
     )
 
+    # npu_backend_load's handler awaits SlotManager.load on the dynamic NPU
+    # slot in-request, so it blocks the same way and needs the same budget.
+    # It is gated, so the REST hop only happens once approved.
+    mock_transport["timeout"] = None
+    pending = await admin.dispatch(
+        tool="npu_backend_load",
+        args={"model_id": "qwen3-4b"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    await queue.approve(pending["approval_id"])
+    assert mock_transport["timeout"] is not None, "npu_backend_load never reached REST"
+    assert mock_transport["timeout"] >= floor
+
     # A non-blocking read keeps the short generic default — the override is
     # scoped to the lifecycle tools, not a blanket widening.
     await admin.dispatch(

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1403,6 +1403,23 @@ async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
     assert mock_transport["timeout"] is not None, "npu_backend_load never reached REST"
     assert mock_transport["timeout"] >= floor
 
+    # slot_delete unloads a running slot before removing it, so it blocks too.
+    mock_transport["timeout"] = None
+    pending = await admin.dispatch(
+        tool="slot_delete",
+        args={"name": "scratch"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    await queue.approve(pending["approval_id"])
+    assert mock_transport["timeout"] is not None, "slot_delete never reached REST"
+    # It can queue behind an in-flight load on that slot and then terminate,
+    # so the generic 30s forward timeout — exactly the terminate bound, with
+    # nothing left for the lock wait — is not enough.
+    assert mock_transport["timeout"] >= float(_HEALTH_TIMEOUT_S) + terminate
+
     # A non-blocking read keeps the short generic default — the override is
     # scoped to the lifecycle tools, not a blanket widening.
     await admin.dispatch(

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1355,6 +1355,51 @@ async def test_registered_tool_raises_toolerror_on_missing_arg(queue: ApprovalQu
         await server.call_tool("model_show", {"args": {}})
 
 
+@pytest.mark.asyncio
+async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    """model_swap blocks on the slot state machine — 30s is not enough (#1832).
+
+    ``_call_rest``'s generic 30s forward timeout is far under the server's own
+    health-poll budget, so an agent driving a slot swap is told the call failed
+    while it succeeds server-side — the same defect the CLI carried. The floor
+    is read from the server modules, never from the budget module under test.
+    """
+    from hal0.providers.container import _HEALTH_TIMEOUT_S
+    from hal0.slots.manager import SlotManager
+
+    terminate = float(SlotManager._terminate_timeout_s)
+    # swap is unload-then-load: one terminate, plus the health poll and the two
+    # sequential pre-load evictions ``preload_evict.admit`` may run.
+    floor = terminate + float(_HEALTH_TIMEOUT_S) + 2 * terminate
+
+    await admin.dispatch(
+        tool="model_swap",
+        args={"name": "primary", "model_id": "qwen3:0.6b"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert mock_transport["timeout"] >= floor, (
+        f"model_swap forwarded at {mock_transport['timeout']}s, under the "
+        f"{floor}s server worst case"
+    )
+
+    # A non-blocking read keeps the short generic default — the override is
+    # scoped to the lifecycle tools, not a blanket widening.
+    await admin.dispatch(
+        tool="slot_list",
+        args={},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    assert mock_transport["timeout"] < floor
+
+
 def test_server_stamps_hal0_version_not_sdk_version(queue: ApprovalQueue) -> None:
     """serverInfo.version must be hal0's own version, not the ``mcp`` SDK
     package version FastMCP falls back to when nothing sets it explicitly."""

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -44,9 +44,18 @@ def mock_transport(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
             return self._payload
 
     class _MockClient:
-        def __init__(self, *, base_url: str, timeout: float) -> None:
+        def __init__(self, *, base_url: str, timeout: httpx.Timeout | float) -> None:
             captured["base_url"] = base_url
-            captured["timeout"] = timeout
+            # ``_call_rest`` splits the budget per phase (#1832): the lifecycle
+            # budget is the READ bound, connect stays short. Record both, and
+            # keep ``timeout`` meaning "the read budget" so the existing
+            # per-tool assertions still read naturally.
+            if isinstance(timeout, httpx.Timeout):
+                captured["timeout"] = timeout.read
+                captured["connect_timeout"] = timeout.connect
+            else:
+                captured["timeout"] = timeout
+                captured["connect_timeout"] = timeout
 
         async def __aenter__(self) -> _MockClient:
             return self
@@ -1480,3 +1489,41 @@ def test_server_stamps_hal0_version_not_sdk_version(queue: ApprovalQueue) -> Non
 
     server = admin.build_server(approval_queue=queue, base_url="http://t")
     assert server._mcp_server.version == hal0.__version__
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_budget_bounds_the_read_not_the_connect(
+    queue: ApprovalQueue, mock_transport: dict[str, Any]
+) -> None:
+    """A multi-minute lifecycle budget must not also be the TCP connect bound.
+
+    ``httpx.AsyncClient(timeout=<float>)`` applies that value to every phase, so
+    widening the forward budget from 30s to the slot lifecycle budget (#1832)
+    also widened *connect*. Against a half-open hal0-api that turns a fast
+    failure into a multi-minute hang — for ``stack_apply``, a 96-minute one.
+    The CLI already splits these in ``hal0.cli._shared._client_timeout``; the
+    MCP bridge has to do the same.
+    """
+    await admin.dispatch(
+        tool="model_swap",
+        args={"name": "primary", "model_id": "qwen3:0.6b"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+
+    assert mock_transport["connect_timeout"] == admin._CONNECT_TIMEOUT_S, (
+        f"connect bound is {mock_transport['connect_timeout']}s, expected the "
+        f"short {admin._CONNECT_TIMEOUT_S}s bound"
+    )
+    assert mock_transport["connect_timeout"] < mock_transport["timeout"], (
+        "connect must stay well under the read budget, otherwise the lifecycle "
+        "budget is being spent waiting for a socket that will never open"
+    )
+
+
+def test_max_slot_lifecycle_timeout_covers_every_bridge_tool() -> None:
+    """The advertised worst case must really be the worst of the table."""
+    assert admin.max_slot_lifecycle_timeout_s() == max(admin._SLOT_LIFECYCLE_TIMEOUT_S.values())
+    assert admin.max_slot_lifecycle_timeout_s() == admin._SLOT_LIFECYCLE_TIMEOUT_S["stack_apply"]

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1420,6 +1420,26 @@ async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
     # nothing left for the lock wait — is not enough.
     assert mock_transport["timeout"] >= float(_HEALTH_TIMEOUT_S) + terminate
 
+    # capability_set drives the same state machine one level up: the route
+    # awaits CapabilityOrchestrator.apply, which awaits SlotManager.load /
+    # unload / swap inline. Budget the worst branch — swap — exactly as the
+    # slot verbs do; the 30s generic forward is #1832 for agents.
+    mock_transport["timeout"] = None
+    pending = await admin.dispatch(
+        tool="capability_set",
+        args={"slot": "embed", "child": "embed", "model": "bge-small"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    await queue.approve(pending["approval_id"])
+    assert mock_transport["timeout"] is not None, "capability_set never reached REST"
+    assert mock_transport["timeout"] >= floor, (
+        f"capability_set forwarded at {mock_transport['timeout']}s, under the "
+        f"{floor}s server worst case"
+    )
+
     # A non-blocking read keeps the short generic default — the override is
     # scoped to the lifecycle tools, not a blanket widening.
     await admin.dispatch(

--- a/tests/mcp/test_admin.py
+++ b/tests/mcp/test_admin.py
@@ -1440,6 +1440,26 @@ async def test_slot_lifecycle_tools_forward_with_the_lifecycle_budget(
         f"{floor}s server worst case"
     )
 
+    # stack_apply fans the same state machine out over a whole stack:
+    # StackApplyEngine.converge loads/swaps/restarts per entry and then unloads
+    # every residual running slot, all inside the one request. It must clear at
+    # least a multi-slot worst case, not the single-slot one.
+    mock_transport["timeout"] = None
+    pending = await admin.dispatch(
+        tool="stack_apply",
+        args={"slug": "daily-driver"},
+        client_id="pi",
+        bearer="t",
+        base_url="http://t",
+        approval_queue=queue,
+    )
+    await queue.approve(pending["approval_id"])
+    assert mock_transport["timeout"] is not None, "stack_apply never reached REST"
+    assert mock_transport["timeout"] >= 2 * floor, (
+        f"stack_apply forwarded at {mock_transport['timeout']}s — it converges a "
+        f"whole stack sequentially, so it cannot ride a single slot's {floor}s"
+    )
+
     # A non-blocking read keeps the short generic default — the override is
     # scoped to the lifecycle tools, not a blanket widening.
     await admin.dispatch(


### PR DESCRIPTION
Remediates the blocking review findings on the already-merged PR #1851. That PR
fixed #1832 for four `hal0 slot` verbs by hardcoding `SLOT_LIFECYCLE_TIMEOUT_S =
220.0`; an independent review found the number does not clear the server's worst
case and that two blocking call sites were left on the 10s default. Those defects
are live on `main`, so this is a fix-forward.

Refs #1832. Closes #1857.

## What was wrong

**1. 220s does not clear the server budget.** `SlotManager.restart` is
unload-then-load: `_terminate_timeout_s` 30s + `_HEALTH_TIMEOUT_S` 180s = a 210s
floor before any podman/systemd overhead — ~5% margin, not the "real headroom"
the constant's comment claimed. Worse, `preload_evict.admit` (enabled by default)
runs `await host.unload(candidate)` sequentially per evicted candidate *inside*
the load path, so two evictions already push a plain load past 240s. On a
memory-tight box — exactly where load and swap are slowest — the
ReadTimeout-on-success still fires.

**2. `hal0 model run` was never fixed.** `model_commands.py` POSTs the same
blocking `/api/slots/{name}/load` at `api_post`'s 10s default. The command's own
`--timeout` (300s, documented in `docs/guides/pull-and-register-models.mdx`)
governs only the readiness poll that follows, so the 10s POST silently overrode
the advertised contract, control never reached the poll, and the false failure
printed a misleading `Check compatibility with: hal0 slot show <target>`.

**3. `hal0 update --restart-slots` was the worst instance and nobody flagged it.**
`update_commands.py` POSTs `/api/updates/restart-slots` at 10s, while
`restart_drifted_slots` loops `await sm.restart(name)` over every drifted slot in
one request. N × 210s of server budget against a 10s client cap: the CLI reports
failure while the sweep goes on bouncing every slot unattended.

**4. `hal0 capabilities set` is the same defect one level up** (found by the
re-review of this PR, fixed here). `POST /api/capabilities/{slot}/{child}` is not
a config write that returns immediately: `routes/capabilities.py` awaits
`CapabilityOrchestrator.apply`, which awaits `SlotManager.load` / `unload` /
`swap` inline. Both clients were still on a short generic default — the CLI on
`api_post`'s 10s, the MCP bridge on `_call_rest`'s 30s — so
`hal0 capability set voice tts --enabled` reproduced #1832 verbatim.

## What changed

New leaf module `hal0/slot_lifecycle_budget.py` is the single source of truth.
It owns the primitive bounds — `HEALTH_TIMEOUT_S`, `TERMINATE_TIMEOUT_S` — and
`providers/container.py` and `SlotManager` now import them instead of declaring
their own literals, so the server cannot retune out from under its clients.
`slot_lifecycle_timeout_s(loads=, unloads=, slots=)` derives the client budget:
the health poll, one terminate per unload the verb performs, an allowance for the
sequential pre-load evictions, a lock-wait allowance per lock-acquiring phase per
slot (a compound verb does **not** hold one lock — `SlotManager.restart` releases
after `unload` and reacquires inside `load`), and an overhead factor for
podman/systemd and the request hop.

**Every number below is derived, not literal** — they are what
`slot_lifecycle_timeout_s` returns on this branch today, and they move
automatically if the server retunes `_HEALTH_TIMEOUT_S` or `_terminate_timeout_s`:

| Verb shape | Budget as shipped |
|---|---|
| load (`slot load`, `model run`, NPU backend load) | **621s** |
| unload (`slot unload`, `slot delete`, NPU backend unload) | **345s** |
| restart / swap (`slot restart`, `slot swap`, `capabilities set`) | **966s** (16 min) |
| `update --restart-slots`, 3 drifted slots | **2898s** (48 min) |
| `update --restart-slots`, 10 drifted slots | 9660s (2.7 h) |

Read those as ceilings on a *wedged* daemon, not expected durations — a healthy
load returns in seconds and the client never waits. They are deliberately large
because the alternative is what #1832 reported: reporting failure on an operation
that succeeded. But they are also the thing to look at before approving this:
see the "silent wait" note below.

Call sites updated: the four `hal0 slot` verbs plus `slot delete`, `hal0 model
run`, `hal0 update --restart-slots` (scaled by the drift count it already
fetches, and now posting the slot names it counted so the server sweep cannot
outgrow the budget), `hal0 capabilities set`, the hal0-admin MCP lifecycle tools
(`slot_load`/`slot_unload`/`slot_restart`/`slot_delete`/`model_swap`/
`npu_backend_load`/`npu_backend_unload`/`capability_set`/`stack_apply`), and the
bundled hal0-admin MCP client timeout in both Hermes provisioning paths.

`stack_apply` is the one fan-out the bridge cannot size from its arguments:
`StackApplyEngine.converge` loads/swaps/restarts per stack entry and then
unloads every residual running slot, but the tool is handed a slug, not a slot
list. `STACK_APPLY_SLOT_ALLOWANCE = 6` is therefore a documented policy
allowance sitting next to `EVICTION_UNLOAD_ALLOWANCE`, not a derived bound — a
larger stack degrades to today's behaviour instead of regressing.
(`stack_import` was checked and does not converge, so it keeps the short
generic default.)

Two non-blocking review findings addressed while here:

- `_api_request` built `httpx.Client(timeout=<float>)`, which set connect/read/
  write/pool alike — a multi-minute read budget would have let a half-open daemon
  stall the CLI with no output. It now uses `httpx.Timeout(budget, connect=5.0)`.
- `hal0/mcp/admin.py::_call_rest` forwarded the lifecycle MCP tools at a blanket
  30s, i.e. the same success-reported-as-failure for agents. They now carry the
  derived budgets. That was follow-up issue #1857; this closes it.

Docs: `docs/reference/cli.mdx` said `model run --timeout` defaults to `300`; the
code default is now the derived load budget (622). Restated as derived rather
than as a literal that drifts again, and a new "Slot lifecycle timeouts" section
publishes the table above so an operator scripting against these commands knows
what they are signing up for.

## Deliberately not done, and what it costs

The issue's suggested poll-with-progress UX stays out of a fix-forward on a
merged regression. It is now filed as **#1870** with the numbers, because this PR
makes it materially worse rather than merely inheriting it: the silent-wait
ceiling moves from ~220s to 621s per slot op and 2898s for a three-slot sweep,
with no spinner, no state line and no elapsed counter, and
`scripts/release-test.sh:178/197/212` calls `slot load` over ssh with no
per-command timeout (`ConnectTimeout=10` bounds the handshake, not the command)
to bound it from outside.

`EVICTION_UNLOAD_ALLOWANCE = 3` remains the one constant in the budget module
with no server-side source to import — `preload_evict` has no bound on how many
candidates `admit` evicts. That is now documented in the module along with the
slack it has (ten resident slots evicting in series cost 480s against the 621s
load budget). Bounding it server-side is #1869.

## Verification

Regression tests are red without the fix and derive their floor from the *server*
modules (`providers.container._HEALTH_TIMEOUT_S`, `SlotManager._terminate_timeout_s`),
never from the client constant under test — the previous round regressed precisely
because the client number was hand-picked, and a tautological assertion would not
have caught it. Against the pre-fix tree:

```
FAILED tests/cli/test_slot_commands.py::test_slot_load_passes_lifecycle_timeout
FAILED tests/cli/test_slot_commands.py::test_slot_restart_passes_lifecycle_timeout
FAILED tests/cli/test_slot_commands.py::test_slot_swap_passes_lifecycle_timeout
E   AssertionError: timeout=220.0 is under the server's 270.0s worst case (loads=1, unloads=1, slots=1)

FAILED tests/cli/test_update_commands.py::test_restart_slots_scales_timeout_with_drifted_slot_count
FAILED tests/cli/test_model_first_run_commands.py::test_model_run_loads_and_waits_ready
E   AssertionError: blocking load POST passed no explicit timeout kwarg

FAILED tests/mcp/test_admin.py::test_slot_lifecycle_tools_forward_with_the_lifecycle_budget
```

The `capabilities set` fix carries the same proof. With only
`src/hal0/cli/capabilities_commands.py` and `src/hal0/mcp/admin.py` reverted and
the tests untouched:

```
FAILED tests/cli/test_capabilities_commands.py::test_capability_set_passes_the_lifecycle_timeout[argv0]
FAILED tests/cli/test_capabilities_commands.py::test_capability_set_passes_the_lifecycle_timeout[argv1]
FAILED tests/cli/test_capabilities_commands.py::test_capability_set_passes_the_lifecycle_timeout[argv2]
E   AssertionError: capability set passed no explicit timeout kwarg
E   assert 'timeout' in {}

FAILED tests/mcp/test_admin.py::test_slot_lifecycle_tools_forward_with_the_lifecycle_budget
E   AssertionError: capability_set forwarded at 30.0s, under the 270.0s server worst case
E   assert 30.0 >= 270.0
```

`stack_apply` likewise, with only `src/hal0/mcp/admin.py` and
`src/hal0/slot_lifecycle_budget.py` reverted:

```
FAILED tests/mcp/test_admin.py::test_slot_lifecycle_tools_forward_with_the_lifecycle_budget
E   AssertionError: stack_apply forwarded at 30.0s — it converges a whole stack
    sequentially, so it cannot ride a single slot's 270.0s
```

The three CLI cases are parametrized over the three orchestrator branches
(`--enabled` → load, `--disabled` → unload, `--model` → swap) because one request
cannot know which one the server will take and so has to budget for the worst.

All green after the fix. `ruff check` and `ruff format --check` clean across
`src` and `tests`.

No CHANGELOG hunk — the consolidated release PR owns that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
