### PR TITLE
fix(install,agents): make the bundled-skill mirror hal0-writable and report WARN

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -50,7 +50,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import structlog
 
@@ -2352,17 +2352,35 @@ def _relink_managed(target: Path, link: Path) -> bool:
     return True
 
 
-def _mirror_bundled_skills(src_root: Path, dst_root: Path) -> tuple[list[str], list[str]]:
+class SkillMirror(NamedTuple):
+    """What one ``_mirror_bundled_skills`` pass did.
+
+    ``failed`` is the subset of ``warnings`` that are real per-skill link
+    FAILURES (#1828) — a bundled skill that exists on disk and could not be
+    mirrored, so the agent comes up without it. The absent-source warning is
+    deliberately NOT in here: a dev install ships no /usr/share/hal0/skills at
+    all, and "nothing to mirror" is not a partial failure. Only ``failed``
+    drives the phase status.
+    """
+
+    linked: list[str]
+    warnings: list[str]
+    failed: list[str]
+
+
+def _mirror_bundled_skills(src_root: Path, dst_root: Path) -> SkillMirror:
     """Symlink every immediate child of ``src_root`` into ``dst_root``.
 
-    Returns ``(linked, warnings)``. Missing src is a warning, not a
-    failure — bundled skills are optional in a dev install.
+    Missing src is a warning, not a failure — bundled skills are optional in a
+    dev install. A skill that IS present and fails to link is a failure and is
+    reported as one (see :class:`SkillMirror`).
     """
     linked: list[str] = []
     warnings: list[str] = []
+    failed: list[str] = []
     if not src_root.exists():
         warnings.append(f"hal0-bundled skills source {src_root} not present; nothing to mirror")
-        return linked, warnings
+        return SkillMirror(linked, warnings, failed)
     dst_root.mkdir(parents=True, exist_ok=True)
     for entry in sorted(src_root.iterdir()):
         link = dst_root / entry.name
@@ -2370,8 +2388,10 @@ def _mirror_bundled_skills(src_root: Path, dst_root: Path) -> tuple[list[str], l
             if _safe_symlink(entry, link):
                 linked.append(entry.name)
         except OSError as exc:
-            warnings.append(f"symlink {entry.name}: {exc}")
-    return linked, warnings
+            msg = f"symlink {entry.name}: {exc}"
+            warnings.append(msg)
+            failed.append(msg)
+    return SkillMirror(linked, warnings, failed)
 
 
 def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
@@ -2557,13 +2577,29 @@ def _phase_context_link(ctx: _StepCtx) -> PhaseResult:
             warnings.append(f"MCP-CLIENTS.md write to /etc/hal0: {exc}")
 
     # Mirror bundled skills last so a failure here doesn't block context files.
-    linked, skill_warnings = _mirror_bundled_skills(HAL0_BUNDLED_SKILLS, ETC_HAL0_AGENT_SKILLS)
+    mirror = _mirror_bundled_skills(HAL0_BUNDLED_SKILLS, ETC_HAL0_AGENT_SKILLS)
+    linked = mirror.linked
     details["bundled_skills_linked"] = linked
-    warnings.extend(skill_warnings)
+    warnings.extend(mirror.warnings)
     details["warnings"] = warnings
     details["changed"] = changed or bool(details["links"]) or bool(linked)
 
-    return PhaseResult(status=PhaseStatus.OK, details=details)
+    # #1828: a phase whose skill mirror failed must not report ``ok``. Each
+    # failed link means the agent comes up without that skill — the five EACCES
+    # symlinks (root-owned mirror + the §7.4 privilege drop) read as a clean
+    # install in both `hal0 agent status` and provision.json, and the only
+    # signal was a warnings list nobody reads on a green phase.
+    #
+    # This is the partial-failure precedent for provisioning phases: a step
+    # that converged but could not do part of its declared job reports WARN,
+    # which is non-fatal by construction (``InstallReport.ok`` only looks at
+    # ``fail``, and #1793 already set this shape for smoke_tests). Only real
+    # link failures are status-bearing: an absent bundled-skill source (dev
+    # install) stays a plain warning, and the render/HERMES.md warnings above
+    # keep their existing status because those paths have declared fallbacks
+    # (#244) — the skill mirror has none.
+    status = PhaseStatus.WARN if mirror.failed else PhaseStatus.OK
+    return PhaseResult(status=status, details=details)
 
 
 # ── Phase H: namespace_register ─────────────────────────────────────────────

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -246,6 +246,33 @@ def ownership_table(
         # agents/ is the dashboard-only Hermes world — pinned root:root (#843),
         # under the flip too: the API only reads it.
         PermRow(paths.agents_config_dir(), "root", "root", 0o755, role="agents/"),
+        # agent-skills/ — the bundled-skill MIRROR (#1828). Unlike agents/ next
+        # to it, this dir is WRITTEN by the provisioner: context_link's
+        # ``_mirror_bundled_skills`` symlinks each /usr/share/hal0/skills entry
+        # into it, and since the §7.4 privilege drop (5faef6d6) that writer is
+        # `hal0 agent bootstrap hermes` re-exec'd as the hal0 user. install.sh
+        # creates the dir as root (root:root 0755) and the /etc/hal0 root row
+        # above is non-recursive, so nothing ever handed it to hal0 — all five
+        # symlinks got EACCES on 100% of fresh installs and Hermes came up with
+        # an empty skill manifest.
+        #
+        # Narrowest row that fixes it: the DIRECTORY only, group-writable to the
+        # already-shared hal0 group, mirroring the /etc/hal0 config-root row
+        # (2775 — setgid so links planted by any hal0-group member keep the
+        # shared group). Deliberately NOT: world-writable (0777 would let any
+        # local user plant a skill Hermes then executes), recursive/globbed (the
+        # contents are symlinks, which the store refuses to write anyway —
+        # #1739), and NOT a change to any root-owned parent (/etc/hal0 is
+        # already hal0:hal0 2775 under the flip; nothing above it moves).
+        # Root-era (service_user="root") keeps root:root 0755 byte-for-byte —
+        # that era never drops privileges, so it never had the bug.
+        PermRow(
+            etc / "agent-skills",
+            etc_owner,
+            etc_group,
+            etc_dir_mode,
+            role="agent-skills/ (bundled-skill mirror)",
+        ),
         # ── /var/lib/hal0 — mutable state (already service-owned) ──────────────
         PermRow(
             var_lib,

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -1723,9 +1723,67 @@ def test_relink_managed_migrates_real_file_to_symlink(tmp_path: Path) -> None:
 
 
 def test_context_link_skill_mirror_warns_when_src_missing(tmp_path: Path) -> None:
-    linked, warnings = hp._mirror_bundled_skills(tmp_path / "no-src", tmp_path / "dst")
-    assert linked == []
-    assert any("not present" in w for w in warnings)
+    mirror = hp._mirror_bundled_skills(tmp_path / "no-src", tmp_path / "dst")
+    assert mirror.linked == []
+    assert any("not present" in w for w in mirror.warnings)
+    # A dev install ships no bundled skills at all — "nothing to mirror" is not
+    # a partial failure, so it must not colour the phase status (#1828).
+    assert mirror.failed == []
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses directory write permissions")
+def test_context_link_warns_when_bundled_skill_symlinks_are_denied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1828: a phase that produced five EACCES symlink errors must not say ``ok``.
+
+    Reproduces the fresh-install shape exactly: the bundled-skill SOURCE exists
+    (``/usr/share/hal0/skills`` with real skill dirs) but the MIRROR dir is not
+    writable by the (privilege-dropped) user running bootstrap, so every
+    ``os.symlink`` raises EACCES. The two pre-existing context_link tests point
+    ``HAL0_BUNDLED_SKILLS`` at a nonexistent dir, so neither can ever exercise a
+    real symlink denial — which is why this shipped.
+    """
+    hermes_home = tmp_path / "hh"
+    hermes_home.mkdir()
+    state = hp.BootstrapState(hermes_home=str(hermes_home))
+    etc = tmp_path / "etc" / "hal0"
+    monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+    monkeypatch.setattr(hp, "RUNTIME_SNAPSHOT_DIR", tmp_path)
+
+    # A REAL bundled-skill source, as install.sh ships it.
+    src = tmp_path / "usr" / "share" / "hal0" / "skills"
+    for name in ("hal0-bench", "hal0-tune"):
+        (src / name).mkdir(parents=True)
+        (src / name / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    monkeypatch.setattr(hp, "HAL0_BUNDLED_SKILLS", src)
+
+    # …and a mirror dir the running user cannot write (the on-box shape is
+    # root:root 0755 with bootstrap re-exec'd as hal0; 0o555 is the same denial
+    # without needing a second uid).
+    mirror = etc / "agent-skills"
+    mirror.mkdir(parents=True)
+    os.chmod(mirror, 0o555)
+
+    io = hp.InstallIO(
+        fetch_slots=lambda: [],
+        fetch_model_contexts=lambda: {},
+        http_get=lambda *_a, **_kw: 0,
+    )
+    try:
+        monkeypatch.setattr(hp, "ETC_HAL0_AGENT_SKILLS", mirror)
+        out = hp._phase_context_link(hp._StepCtx(state=state, io=io))
+    finally:
+        os.chmod(mirror, 0o755)  # let tmp_path teardown clean up
+
+    # The mirror really did fail — no links, one warning per skill.
+    assert out.details["bundled_skills_linked"] == []
+    assert not list(mirror.iterdir())
+    denied = [w for w in out.details["warnings"] if w.startswith("symlink ")]
+    assert len(denied) == 2, out.details["warnings"]
+    assert all("Permission denied" in w for w in denied), denied
+    # …and the phase says so instead of reporting a clean install.
+    assert out.status == hp.PhaseStatus.WARN
 
 
 def test_context_link_falls_back_when_soul_render_fails(

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -253,6 +253,28 @@ def test_flip_keeps_agents_and_secrets_root_owned(tmp_hal0_home: str) -> None:
     assert (secrets.owner, secrets.group) == ("root", "root")
 
 
+def test_agent_skills_mirror_is_service_writable(tmp_hal0_home: str) -> None:
+    """#1828: /etc/hal0/agent-skills must be writable by the service account.
+
+    install.sh births it root:root 0755 and the §7.4 privilege drop then runs
+    `hal0 agent bootstrap hermes` as hal0, so context_link's five
+    ``os.symlink`` calls all hit EACCES and the agent comes up with an empty
+    skill manifest. The row is dir-only (its contents are symlinks, which the
+    store never writes) and mirrors the /etc/hal0 config-root row: setgid 2775
+    so links the hal0 group plants inherit the shared group.
+    """
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    mirror = rows[paths.etc() / "agent-skills"]
+    assert (mirror.owner, mirror.group, mirror.mode) == ("hal0", "hal0", 0o2775)
+    # Narrow on purpose: no glob/recursion into the mirrored skill symlinks.
+    assert mirror.glob is None
+    assert mirror.recursive is False
+    # The root-era table keeps its byte-identical root:root 0755.
+    root_rows = _by_target(perms.ownership_table(service_user="root"))
+    root_mirror = root_rows[paths.etc() / "agent-skills"]
+    assert (root_mirror.owner, root_mirror.group, root_mirror.mode) == ("root", "root", 0o755)
+
+
 def test_flip_makes_state_root_service_owned(tmp_hal0_home: str) -> None:
     """/var/lib/hal0 + HERMES_HOME flip to the service user under the flip."""
     rows = _by_target(perms.ownership_table(service_user="hal0"))


### PR DESCRIPTION
Closes #1828.

## What was broken

`installer/install.sh:2675` creates `/etc/hal0/agent-skills` as root (`root:root 0755`). Since the §7.4 privilege drop (`5faef6d6`, 2026-07-18) the installer re-execs `hal0 agent bootstrap hermes` **as the hal0 user**, so `_mirror_bundled_skills` gets EACCES on all five `os.symlink` calls. The `/etc/hal0` config-root `PermRow` flips only the parent and is non-recursive, so nothing ever handed the mirror dir to hal0 — and `doctor perms` had no row to report drift against. Hermes comes up with a completely empty skill manifest on 100% of fresh installs, and `_phase_context_link` returned `PhaseStatus.OK` unconditionally while stashing the five EACCES strings in a warnings list nobody reads on a green phase.

## The permission boundary that moves — stated plainly

**New row:** `/etc/hal0/agent-skills` → `hal0:hal0 2775` (setgid), directory only, non-recursive, under the hardened flip. `service_user="root"` (the rollback table) keeps `root:root 0755` byte-for-byte; that era never drops privileges, so it never had the bug.

**Who gains what:** members of the `hal0` group — in practice the `hal0` service account, i.e. `hal0-api`, `hal0-agent@hermes`, and the privilege-dropped bootstrap re-exec — gain create/rename/unlink inside that one directory. They can plant, replace or remove skill symlinks there. Nothing else changes: no ownership change to any parent (`/etc/hal0` is already `hal0:hal0 2775` under the flip, and the row does not touch it or anything above it), no recursion, no new access to `agents/`, `secrets/`, or `/usr/share/hal0/skills` (the read-only ship dir stays root-owned).

**Why the narrower alternatives do not work:**
- *No row at all (status quo):* the writer is unprivileged by design; it cannot chown its own target.
- *Have the installer `chown` it once instead of adding a row:* that is exactly the class of out-of-band fixup `OwnershipStore` exists to replace — `doctor perms` would still show no row, so drift would stay invisible and unrepairable, and an upgraded box that never had the dir would never be healed.
- *Give hal0 the file only, not the dir:* the contents are symlinks created and replaced by name (`os.symlink` + `os.replace`), which needs **directory** write. There is no narrower unit than the dir.
- *0777 / world-writable:* would let any local user plant a skill Hermes then loads and executes. Rejected.
- *Recursive / globbed row:* unnecessary and wrong — the contents are symlinks, which the store refuses to write at all (#1739).
- *Point the mirror at the already-writable `/var/lib/hal0/skills` instead:* that changes the documented layout (`installer/README.md:63`), collides operator drop-ins with managed links, and leaves `/etc/hal0/agent-skills` on `skills.external_dirs` as a permanently-broken root-owned dir.

**Runtime exposure note:** the same processes already have write on `/etc/hal0` itself (which holds `hal0.toml`, `api.env`, `slots/*.toml`) — this row does not widen the *set* of principals, only extends an existing principal's reach by one subdirectory it was always supposed to own.

## Reporting integrity — the partial-failure precedent

`_phase_context_link` now returns `PhaseStatus.WARN` when a bundled skill that exists on disk failed to link. **This is the precedent for how provisioning phases report partial failure:** a step that converged but could not do part of its declared job reports `WARN`, which is non-fatal by construction (`InstallReport.ok` only looks at `fail`) and matches the #1793 shape already used by `smoke_tests`. `hal0 agent status` and `provision.json` now show `warn` for a box whose skills did not link, instead of `ok`.

One deliberate narrowing versus the issue's literal wording ("WARN when `skill_warnings` is non-empty"): an **absent** bundled-skill source stays a plain warning and does not colour the status. A dev install ships no `/usr/share/hal0/skills` at all, so "nothing to mirror" is not a partial failure — making it `WARN` would turn every dev bootstrap permanently yellow and force `test_install_hermes_marks_every_step_ok_or_skip` to stop asserting its contract. `_mirror_bundled_skills` therefore returns a `SkillMirror` NamedTuple that separates real per-skill link **failures** from advisory warnings; only `failed` is status-bearing. If the reviewer wants the literal all-warnings behaviour instead, it is a one-line change at the `status = ...` line.

Out of scope, called out rather than silently included: `_step_changed` still returns `False` for any non-`OK` phase, so a `WARN` context_link reports `changed=False` even though it rendered files. That is pre-existing `WARN` semantics shared with `smoke_tests` and belongs in its own change.

## Verification

The regression test exercises a REAL symlink EACCES — a real bundled-skill source with two skill dirs, mirroring into a dir the running user cannot write — and asserts `WARN`. Both pre-existing context_link tests point `HAL0_BUNDLED_SKILLS` at a nonexistent directory, so neither could ever catch this.

Run against the **unfixed** code (both new tests fail):

```
tests/agents/test_hermes_provision.py::test_context_link_warns_when_bundled_skill_symlinks_are_denied
E       AssertionError: assert <PhaseStatus.OK: 'ok'> == <PhaseStatus.WARN: 'warn'>
E         - warn
E         + ok

tests/install/test_perms.py::test_agent_skills_mirror_is_service_writable
>       mirror = rows[paths.etc() / "agent-skills"]
E       KeyError: PosixPath('.../etc/hal0/agent-skills')

=========================== 2 failed in 0.31s ===========================
```

With the fix: `916 passed, 1 xfailed` across `tests/agents/ tests/install/`, full suite + `ruff check src tests` + `ruff format --check src tests` clean.

No CHANGELOG hunk — a separate consolidated PR owns that.

Not merging this myself; leaving it for independent review.