### PR TITLE
fix(release): recognise '### Operator migrations' as the migrations subsection

### DIFF
--- a/src/hal0/release/notes.py
+++ b/src/hal0/release/notes.py
@@ -71,16 +71,37 @@ def extract_changelog_section(changelog: str, version: str) -> str:
 #: structured ``release.json`` lists the updater CLI renders as callouts.
 _STRUCTURED_KEYS = ("highlights", "breaking", "migrations")
 
+#: Heading spellings the CHANGELOG actually uses that mean one of
+#: :data:`_STRUCTURED_KEYS`, normalised to that key so ``release.json`` keeps its
+#: three-key shape and ``hal0.updater.updater._read_release_notes`` is unchanged.
+#: ``Operator migrations`` is the convention every release section since 1.0.0
+#: writes — and it silently matched nothing until #1874, so the migrations
+#: callout in ``hal0 update`` was empty for every release ever cut.
+_HEADING_ALIASES = {
+    "operator migrations": "migrations",
+    "migration": "migrations",
+    "breaking changes": "breaking",
+    "highlight": "highlights",
+}
+
+
+def _normalise_heading(heading: str) -> str:
+    """Lowercase a ``### `` heading and fold known spelling variants onto a key."""
+    key = heading.strip().lower()
+    return _HEADING_ALIASES.get(key, key)
+
 
 def extract_structured(section_md: str) -> dict[str, list[str]]:
-    """Pull the optional ``### Highlights`` / ``### Breaking`` / ``### Migrations``
-    subsections of a changelog version section into structured lists.
+    """Pull the optional ``### Highlights`` / ``### Breaking`` / ``### Operator
+    migrations`` subsections of a changelog version section into structured lists.
 
     Only **top-level** bullet headlines (a line beginning ``- `` or ``* `` with
     no leading indent) are collected — nested/continuation lines are skipped so
     each entry stays a concise one-liner suitable for a CLI callout. Subsection
-    headings are matched case-insensitively; any missing subsection yields an
-    empty list. A heading repeated within one version section **accumulates**
+    headings are matched case-insensitively and known spelling variants are
+    folded onto their key (see :data:`_HEADING_ALIASES`: ``### Operator
+    migrations`` — what every real release section writes — is ``migrations``);
+    any missing subsection yields an empty list. A heading repeated within one version section **accumulates**
     in document order rather than overwriting (#1499) — union-resolving a
     CHANGELOG merge conflict routinely leaves two ``### Breaking`` blocks in
     one release, and dropping the earlier one under-reports the update in the
@@ -96,7 +117,7 @@ def extract_structured(section_md: str) -> dict[str, list[str]]:
     parts = re.split(r"^###\s+(.+?)\s*$", section_md, flags=re.MULTILINE)
     pairs = iter(parts[1:])
     for heading, body in zip(pairs, pairs, strict=False):
-        key = heading.strip().lower()
+        key = _normalise_heading(heading)
         if key in out:
             out[key].extend(
                 line[2:].strip() for line in body.splitlines() if line[:2] in ("- ", "* ")

--- a/src/hal0/release/notes.py
+++ b/src/hal0/release/notes.py
@@ -95,9 +95,14 @@ def extract_structured(section_md: str) -> dict[str, list[str]]:
     """Pull the optional ``### Highlights`` / ``### Breaking`` / ``### Operator
     migrations`` subsections of a changelog version section into structured lists.
 
-    Only **top-level** bullet headlines (a line beginning ``- `` or ``* `` with
-    no leading indent) are collected — nested/continuation lines are skipped so
-    each entry stays a concise one-liner suitable for a CLI callout. Subsection
+    Only **top-level** bullets (a line beginning ``- `` or ``* `` with no
+    leading indent) start an entry. Markdown-wrapped continuation lines — the
+    indented lines that are not themselves bullets — are joined onto the entry
+    they belong to and collapsed to single spaces, so the entry reads as one
+    line without losing its tail. Nested sub-bullets are skipped and end the
+    entry they sit under. (Before #1874 only the first physical line survived,
+    which truncated every real migration entry mid-sentence and dropped every
+    remediation command past the first line break.) Subsection
     headings are matched case-insensitively and known spelling variants are
     folded onto their key (see :data:`_HEADING_ALIASES`: ``### Operator
     migrations`` — what every real release section writes — is ``migrations``);
@@ -119,7 +124,39 @@ def extract_structured(section_md: str) -> dict[str, list[str]]:
     for heading, body in zip(pairs, pairs, strict=False):
         key = _normalise_heading(heading)
         if key in out:
-            out[key].extend(
-                line[2:].strip() for line in body.splitlines() if line[:2] in ("- ", "* ")
-            )
+            out[key].extend(_bullet_entries(body))
     return out
+
+
+def _bullet_entries(body: str) -> list[str]:
+    """Top-level bullets of ``body``, each joined with its wrapped continuation lines.
+
+    A line starting ``- ``/``* `` at column 0 opens an entry. Indented lines that
+    are not themselves bullets continue it; a nested sub-bullet, a blank line or
+    an unindented non-bullet line closes it. Every entry is whitespace-collapsed
+    so a markdown-wrapped bullet becomes one readable callout line.
+    """
+    entries: list[str] = []
+    current: list[str] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current is not None:
+            joined = " ".join(" ".join(current).split())
+            if joined:
+                entries.append(joined)
+            current = None
+
+    for line in body.splitlines():
+        if line[:2] in ("- ", "* "):
+            flush()
+            current = [line[2:]]
+            continue
+        stripped = line.strip()
+        indented = line[:1] in (" ", "\t")
+        if current is not None and indented and stripped and stripped[:2] not in ("- ", "* "):
+            current.append(stripped)
+            continue
+        flush()
+    flush()
+    return entries

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -445,6 +445,19 @@ def test_rc6_operator_migrations_are_extracted():
             assert issue in joined, f"rc.6 migration for {issue} missing from {migrations}"
 
 
+def test_heading_aliases_fold_onto_the_three_release_json_keys():
+    """Variant spellings normalise instead of adding a fourth key — release.json
+    keeps the shape ``hal0.updater.updater._read_release_notes`` expects."""
+    s = extract_structured(
+        "### Operator migrations\n- run doctor ports\n\n"
+        "### Breaking changes\n- removed the old seam\n\n"
+        "### Migrations\n- and the short spelling too\n"
+    )
+    assert sorted(s) == ["breaking", "highlights", "migrations"]
+    assert s["migrations"] == ["run doctor ports", "and the short spelling too"]
+    assert s["breaking"] == ["removed the old seam"]
+
+
 def test_no_shipped_structured_heading_variant_is_unrecognised():
     """Sibling-risk sweep: any breaking/migration-flavoured ``###`` heading the real
     CHANGELOG uses must land in one of the structured keys. Catches a future

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
+import pytest
+
 from hal0.release.notes import extract_changelog_section, extract_structured
 
 # ── Sample CHANGELOG document used across tests ────────────────────────────
@@ -359,3 +364,97 @@ def test_preview_notes_heading_audience_present(tmp_path):
     notes = (out / "RELEASE_NOTES.md").read_text(encoding="utf-8")
     assert "## Audience" in notes
     assert "## Known issues" in notes
+
+
+# ── Regression: the *shipped* CHANGELOG.md, not a fixture (#1874) ────────────
+#
+# ``extract_structured`` was only ever exercised against synthetic fixtures that
+# used a ``### Migrations`` heading. Every real release section writes ``###
+# Operator migrations``, which matched nothing — so ``release.json``'s
+# ``migrations`` list, the callout ``hal0 update`` renders before an operator
+# confirms, has been empty for every release ever cut. These tests read the real
+# CHANGELOG.md that ships in the tarball, so a heading the project actually uses
+# can never again be silently unrecognised.
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SHIPPED_CHANGELOG = (_REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def _shipped_sections() -> list[tuple[str, str]]:
+    """``(version, body)`` for every ``## [<version>]`` section of CHANGELOG.md."""
+    parts = re.split(r"^## \[v?([^\]]+)\][^\n]*$", _SHIPPED_CHANGELOG, flags=re.MULTILINE)
+    it = iter(parts[1:])
+    return [(v.strip(), body) for v, body in zip(it, it, strict=False)]
+
+
+def _bullets_under(body: str, heading: str) -> list[str]:
+    """Top-level bullet headlines under ``### <heading>``, parsed independently of
+    ``extract_structured`` so the expectation is not derived from the code under test."""
+    m = re.search(rf"^###\s+{re.escape(heading)}\s*$", body, re.MULTILINE | re.IGNORECASE)
+    if not m:
+        return []
+    rest = body[m.end() :]
+    stop = re.search(r"^#{2,3} ", rest, re.MULTILINE)
+    block = rest[: stop.start()] if stop else rest
+    return [line[2:].strip() for line in block.splitlines() if line[:2] in ("- ", "* ")]
+
+
+_SECTIONS_WITH_OPERATOR_MIGRATIONS = [
+    pytest.param(version, body, id=version)
+    for version, body in _shipped_sections()
+    if _bullets_under(body, "Operator migrations")
+]
+
+
+def test_shipped_changelog_actually_uses_the_operator_migrations_heading():
+    """Guard the guard: if the convention ever changes, the sweep below must not
+    quietly degrade into asserting nothing."""
+    assert _SECTIONS_WITH_OPERATOR_MIGRATIONS, (
+        "no shipped CHANGELOG section carries '### Operator migrations' with bullets"
+    )
+
+
+@pytest.mark.parametrize(("version", "body"), _SECTIONS_WITH_OPERATOR_MIGRATIONS)
+def test_shipped_operator_migrations_reach_release_json(version, body):
+    """Every real release section that documents operator migrations must yield
+    them in ``release.json``'s ``migrations`` list."""
+    extracted = extract_structured(body)["migrations"]
+    expected = _bullets_under(body, "Operator migrations")
+    assert extracted, f"{version}: documents {len(expected)} operator migrations, extracted none"
+    for bullet in expected:
+        assert bullet in extracted, f"{version}: migration bullet dropped: {bullet!r}"
+
+
+def test_rc6_operator_migrations_are_extracted():
+    """#1874's headline case: the rc.6 section's operator migrations (#1830 /
+    #1827 / #1828) must reach the update callout.
+
+    The rc.6 CHANGELOG section is owned by a separate PR; until it lands this
+    pins rc.5 — the newest shipped section with the heading — and self-arms for
+    rc.6 the moment that section exists.
+    """
+    sections = dict(_shipped_sections())
+    version = "1.0.0-rc.6" if "1.0.0-rc.6" in sections else "1.0.0-rc.5"
+    migrations = extract_structured(sections[version])["migrations"]
+    assert migrations, f"{version} documents operator migrations but extracted none"
+    if version == "1.0.0-rc.5":
+        assert any("#1819" in m for m in migrations), migrations
+    else:
+        joined = " ".join(migrations)
+        for issue in ("#1830", "#1827", "#1828"):
+            assert issue in joined, f"rc.6 migration for {issue} missing from {migrations}"
+
+
+def test_no_shipped_structured_heading_variant_is_unrecognised():
+    """Sibling-risk sweep: any breaking/migration-flavoured ``###`` heading the real
+    CHANGELOG uses must land in one of the structured keys. Catches a future
+    ``### Breaking changes`` the same way this caught ``### Operator migrations``."""
+    headings = {
+        h.strip()
+        for h in re.findall(r"^###\s+(.+?)\s*$", _SHIPPED_CHANGELOG, flags=re.MULTILINE)
+        if re.search(r"migrat|breaking", h, re.IGNORECASE)
+    }
+    unrecognised = sorted(
+        h for h in headings if not any(extract_structured(f"### {h}\n- probe\n").values())
+    )
+    assert not unrecognised, f"CHANGELOG headings that extract into nothing: {unrecognised}"

--- a/tests/release/test_notes.py
+++ b/tests/release/test_notes.py
@@ -211,6 +211,39 @@ def test_extract_structured_case_insensitive_and_skips_nested_bullets():
     assert extract_structured(md)["breaking"] == ["top level", "another top"]
 
 
+def test_extract_structured_joins_wrapped_continuation_lines():
+    """A markdown-wrapped bullet is one entry, not its first physical line (#1874).
+
+    Every real migration bullet wraps across 4-6 lines, so keeping only the first
+    line dropped every remediation command out of the ``hal0 update`` callout.
+    ``highlights`` and ``breaking`` wrap the same way and join the same way.
+    """
+    md = (
+        "### Migrations\n"
+        "- **Profile-less slots (#1830):** a slot created under rc.5 keeps its\n"
+        "  old profile. Run `hal0 slot edit <name> --profile embedding`, then\n"
+        "  `hal0 slot restart`.\n"
+        "- second migration\n"
+        "\n"
+        "### Highlights\n"
+        "- a highlight that\n"
+        "  wraps too\n"
+    )
+    s = extract_structured(md)
+    assert s["migrations"] == [
+        "**Profile-less slots (#1830):** a slot created under rc.5 keeps its old "
+        "profile. Run `hal0 slot edit <name> --profile embedding`, then `hal0 slot restart`.",
+        "second migration",
+    ]
+    assert s["highlights"] == ["a highlight that wraps too"]
+
+
+def test_extract_structured_nested_bullet_ends_its_parent_entry():
+    """A sub-bullet is skipped and its own wrapped lines do not glue onto the parent."""
+    md = "### Breaking\n- top level\n  wraps\n  - nested is skipped\n    and its tail too\n- another top\n"
+    assert extract_structured(md)["breaking"] == ["top level wraps", "another top"]
+
+
 def test_extract_structured_accumulates_repeated_headings():
     """A repeated heading must not discard the earlier block (#1499).
 
@@ -387,22 +420,33 @@ def _shipped_sections() -> list[tuple[str, str]]:
     return [(v.strip(), body) for v, body in zip(it, it, strict=False)]
 
 
-def _bullets_under(body: str, heading: str) -> list[str]:
-    """Top-level bullet headlines under ``### <heading>``, parsed independently of
-    ``extract_structured`` so the expectation is not derived from the code under test."""
+def _block_under(body: str, heading: str) -> str:
+    """The raw markdown under ``### <heading>``, up to the next ``##``/``###``.
+
+    Deliberately does **no** bullet parsing: the production defect this file
+    guards was in how bullets and their wrapped continuation lines are turned
+    into entries, so any helper that re-derived that rule would simply agree
+    with the bug (that is exactly how round 1 shipped a truncating extractor
+    under a green test). Expectations below are derived from literal strings
+    present in this raw block instead.
+    """
     m = re.search(rf"^###\s+{re.escape(heading)}\s*$", body, re.MULTILINE | re.IGNORECASE)
     if not m:
-        return []
+        return ""
     rest = body[m.end() :]
     stop = re.search(r"^#{2,3} ", rest, re.MULTILINE)
-    block = rest[: stop.start()] if stop else rest
-    return [line[2:].strip() for line in block.splitlines() if line[:2] in ("- ", "* ")]
+    return rest[: stop.start()] if stop else rest
+
+
+def _flat(text: str) -> str:
+    """Whitespace-collapsed text, so a markdown-wrapped phrase matches its joined form."""
+    return " ".join(text.split())
 
 
 _SECTIONS_WITH_OPERATOR_MIGRATIONS = [
     pytest.param(version, body, id=version)
     for version, body in _shipped_sections()
-    if _bullets_under(body, "Operator migrations")
+    if re.search(r"^[-*] ", _block_under(body, "Operator migrations"), re.MULTILINE)
 ]
 
 
@@ -417,32 +461,62 @@ def test_shipped_changelog_actually_uses_the_operator_migrations_heading():
 @pytest.mark.parametrize(("version", "body"), _SECTIONS_WITH_OPERATOR_MIGRATIONS)
 def test_shipped_operator_migrations_reach_release_json(version, body):
     """Every real release section that documents operator migrations must yield
-    them in ``release.json``'s ``migrations`` list."""
-    extracted = extract_structured(body)["migrations"]
-    expected = _bullets_under(body, "Operator migrations")
-    assert extracted, f"{version}: documents {len(expected)} operator migrations, extracted none"
-    for bullet in expected:
-        assert bullet in extracted, f"{version}: migration bullet dropped: {bullet!r}"
+    them in ``release.json``'s ``migrations`` list — whole, not truncated.
 
-
-def test_rc6_operator_migrations_are_extracted():
-    """#1874's headline case: the rc.6 section's operator migrations (#1830 /
-    #1827 / #1828) must reach the update callout.
-
-    The rc.6 CHANGELOG section is owned by a separate PR; until it lands this
-    pins rc.5 — the newest shipped section with the heading — and self-arms for
-    rc.6 the moment that section exists.
+    The completeness expectation is every inline-code span the block's raw
+    markdown contains (commands, paths, config keys). Those are what an operator
+    has to type, they are exactly what a first-physical-line-only extractor
+    dropped, and they are read straight out of the CHANGELOG text rather than
+    re-parsed with the rule under test.
     """
+    block = _block_under(body, "Operator migrations")
+    extracted = extract_structured(body)["migrations"]
+    assert extracted, f"{version}: documents operator migrations, extracted none"
+
+    joined = _flat(" ".join(extracted))
+    for span in re.findall(r"`([^`]+)`", block):
+        assert _flat(span) in joined, (
+            f"{version}: `{_flat(span)}` documented under Operator migrations but missing "
+            f"from the extracted callout — entry truncated at its first line? {extracted}"
+        )
+
+
+@pytest.mark.parametrize(("version", "body"), _SECTIONS_WITH_OPERATOR_MIGRATIONS)
+def test_shipped_migration_entries_are_not_cut_mid_markdown(version, body):
+    """A truncated entry leaves an unterminated ``**``/backtick span. rc.5's first
+    migration ended mid-noun with a dangling bold marker in the rendered callout."""
+    for entry in extract_structured(body)["migrations"]:
+        assert entry.count("**") % 2 == 0, f"{version}: unterminated bold span: {entry!r}"
+        assert entry.count("`") % 2 == 0, f"{version}: unterminated code span: {entry!r}"
+
+
+def test_rc6_operator_migrations_carry_their_remediation_commands():
+    """#1874's headline case: the rc.6 operator migrations (#1830 / #1827 / #1828)
+    must reach the update callout *with the command the operator has to run*.
+
+    ``hal0 slot edit`` sits past the first line break of the #1830 bullet, so the
+    heading fix alone renders a sentence fragment and this assertion fails. The
+    rc.6 CHANGELOG section is owned by a separate PR; until it lands this pins
+    rc.5 (whose ``hal0 doctor ports --fix`` is likewise past the first break) and
+    self-arms for rc.6 the moment that section exists.
+    """
+    expected_commands = {
+        "1.0.0-rc.6": ("hal0 slot edit", "hal0 doctor profiles"),
+        "1.0.0-rc.5": ("hal0 doctor ports --fix",),
+    }
     sections = dict(_shipped_sections())
     version = "1.0.0-rc.6" if "1.0.0-rc.6" in sections else "1.0.0-rc.5"
     migrations = extract_structured(sections[version])["migrations"]
     assert migrations, f"{version} documents operator migrations but extracted none"
-    if version == "1.0.0-rc.5":
-        assert any("#1819" in m for m in migrations), migrations
-    else:
-        joined = " ".join(migrations)
+
+    joined = _flat(" ".join(migrations))
+    for command in expected_commands[version]:
+        assert command in joined, f"{version}: remediation command {command!r} lost: {migrations}"
+    if version == "1.0.0-rc.6":
         for issue in ("#1830", "#1827", "#1828"):
             assert issue in joined, f"rc.6 migration for {issue} missing from {migrations}"
+    else:
+        assert "#1819" in joined, migrations
 
 
 def test_heading_aliases_fold_onto_the_three_release_json_keys():


### PR DESCRIPTION
## What

Two defects in the same path, both of which had to be fixed before the `hal0 update` migrations callout is worth anything to an operator.

**1. The heading never matched.** `extract_structured` matched CHANGELOG subsection headings against the literal keys `highlights` / `breaking` / `migrations`. Every real release section writes `### Operator migrations`, which never equalled `"migrations"`, so `release.json`'s `migrations` list — the callout `hal0 update` renders before an operator confirms — has been empty for every release ever cut. Known spellings are now folded onto the canonical key (`_HEADING_ALIASES`) rather than adding a fourth key, so `release.json` keeps its three-list shape and `hal0.updater.updater._read_release_notes` is unchanged.

**2. The entries it then produced were truncated.** `extract_structured` kept only the **first physical line** of each bullet. Every real rc.4/rc.5/rc.6 migration bullet is markdown-wrapped across 4-6 lines, so unblocking the heading rendered four sentence fragments:

```
**Profile-less capability slots (#1830):** a slot created under rc.5 or
**Context windows widen on update (#1827):** brain, agent and utility slots
**Bundled agent skills on an already-installed box (#1828):** the permission
**Stale DNAT rules (#1819)** from rc.5, and the **deprecated `extra_args` at
```

Every remediation command — `hal0 doctor profiles`, `hal0 slot edit <name> --profile embedding`, `hal0 slot restart`, `hal0 doctor ports --fix` — sits past the first line break and was dropped; rc.5's first entry ended mid-noun with an unterminated bold span. Continuation lines (indented lines that are not themselves `- `/`* ` bullets) are now joined onto the entry they belong to and whitespace-collapsed to one readable line. A nested sub-bullet still ends its parent and is still skipped, and its own wrapped tail does not glue onto the parent.

**This truncation affected `highlights` identically, and is PRE-EXISTING — not introduced by this PR.** Both lists render through the same extractor; the heading fix only made the migrations case visible. Fixing the extractor fixes both.

Codex flagged the truncation as P2 on `da578c3d` (it was right, on both the defect and the self-confirming helper); that thread is answered and resolved.

## Why the tests are the point

The pre-existing coverage only ever fed the extractor a synthetic `### Migrations` heading no release actually uses — it passed against the broken code. Round 1's replacement was **self-confirming on the wrapping dimension**: its `_bullets_under` helper repeated the same `line[:2] in ("- ", "* ")` first-line-only rule, so it agreed with the bug it was supposed to catch.

`_bullets_under` is gone. Expectations are now derived from literal strings present in the shipped `CHANGELOG.md`, never by re-parsing bullets:

- `test_shipped_operator_migrations_reach_release_json` — every inline-code span (`` `...` ``) appearing in the raw `### Operator migrations` block must survive, whitespace-normalised, into the extracted entries. Those spans are the commands and paths the operator has to type, and they are exactly what a first-line-only extractor drops.
- `test_rc6_operator_migrations_carry_their_remediation_commands` — asserts a known command string reaches the callout: `hal0 slot edit` / `hal0 doctor profiles` for rc.6, pinned to rc.5's `hal0 doctor ports --fix` until PR #1860 lands the rc.6 section, and self-arming the moment it does.
- `test_shipped_migration_entries_are_not_cut_mid_markdown` — balanced `**` and backtick counts, catching an entry severed mid-span.
- `test_extract_structured_joins_wrapped_continuation_lines` / `..._nested_bullet_ends_its_parent_entry` — synthetic units for the join rule and the sub-bullet skip.
- Retained: the non-empty guard (the sweep cannot degrade into asserting nothing) and the sibling-risk heading sweep (a future `### Breaking changes` is caught the same way).
- `test_extract_structured_case_insensitive_and_skips_nested_bullets` is unchanged and green.

Red against the unfixed extractor (production file stashed, tests as shipped here):

```
FAILED tests/release/test_notes.py::test_extract_structured_joins_wrapped_continuation_lines
FAILED tests/release/test_notes.py::test_extract_structured_nested_bullet_ends_its_parent_entry
FAILED tests/release/test_notes.py::test_shipped_operator_migrations_reach_release_json[1.0.0-rc.5]
FAILED tests/release/test_notes.py::test_shipped_operator_migrations_reach_release_json[1.0.0-rc.4]
FAILED tests/release/test_notes.py::test_shipped_migration_entries_are_not_cut_mid_markdown[1.0.0-rc.5]
FAILED tests/release/test_notes.py::test_rc6_operator_migrations_carry_their_remediation_commands
6 failed, 26 passed

E  AssertionError: 1.0.0-rc.5: remediation command 'hal0 doctor ports --fix' lost:
   ['**Stale DNAT rules (#1819):** a box that has been running slots across a root',
    '**Deprecated `extra_args` at the seam (#1759)** and the **releases-URL',
    'The R5 operator-run migrators (slot-flag fold, id-keying) are unchanged from']
```

## Sibling risk: checked

`### Breaking` is the only breaking-flavoured heading in the whole CHANGELOG (8 occurrences, no `Breaking changes` variant), so it has never been silently empty. `breaking changes` is in the alias map defensively, and the sweep fails loudly if a variant ever appears.

## Verification

- `uv run --extra dev pytest tests/release tests/updater -q` → **370 passed**
- `uv run --extra dev ruff check src tests` → clean; `uv run --extra dev ruff format --check src tests` → clean
- Against the shipped rc.5 section, the migrations entries now carry their full text, e.g. `**Stale DNAT rules (#1819):** … Run `hal0 doctor ports` after updating; if it reports shadowed ports, `hal0 doctor ports --fix` prunes them. …`

## Out of scope

No CHANGELOG hunk — PR #1860 owns the rc.6 section. A changelog line for this fix is left to the release PR.

Closes #1874

🤖 Generated with [Claude Code](https://claude.com/claude-code)
