### PR TITLE
fix(hermes): preflight the anchor context window against Hermes' floor

### DIFF
--- a/src/hal0/agents/anchor_window.py
+++ b/src/hal0/agents/anchor_window.py
@@ -1,0 +1,305 @@
+"""Preflight the context window behind Hermes' anchor model (#1867).
+
+Hermes refuses to run at all when the model it is pointed at advertises a
+context window below ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH``
+(64,000 at the pinned commit) — it raises rather than degrading. hal0's side of
+that contract is the EFFECTIVE window of the slot behind the anchor
+(``hal0/agent`` by default), which is::
+
+    effective = min(model's native/declared window, slot's [model].context_size)
+
+so either half can put the box under the floor:
+
+* the MODEL side — a registry row with no ``defaults.context_size`` resolving
+  to a small derived window (#1827's fresh-install half, fixed by #1852), and
+* the SLOT side — a configured ceiling that is itself below the floor. An
+  in-place upgrade never revisits an existing ``/etc/hal0/slots/<slot>.toml``,
+  so a box seeded by an older release keeps e.g. ``context_size = 4096``
+  forever even though its model happily declares 96000. #1852's "the ceiling
+  wins over the blanket dense cap" change cannot help there: a ceiling only
+  ever clamps DOWN.
+
+Nothing used to check this before handing the anchor to Hermes, so the second
+shape surfaced ~1.6s into the first turn as an opaque upstream agent error that
+named neither the slot nor the ceiling behind it. This module is the check: it
+resolves the anchor's effective window, compares it against Hermes' own floor
+(read FROM the installed Hermes when possible, see
+:func:`read_hermes_minimum_context`), and renders a message an operator can act
+on without reading any source — which slot, that slot's configured ceiling, the
+required floor, and the exact command that repairs it.
+
+Deliberately read-only. Rewriting an operator's slot ceiling during an update is
+a config mutation nobody has approved yet and is tracked as the other half of
+#1867; :func:`resolve_anchor_window` is the resolver that repair would be built
+on when it is decided (it already names the slot, its ceiling, and the target
+value the repair would need to write).
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 — asks the Hermes venv python for its own constant
+import tomllib
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+#: hal0's ONLY copy of Hermes' hard context floor — a fallback for when the
+#: installed Hermes cannot be asked (see :func:`read_hermes_minimum_context`).
+#: Mirrors ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH`` in the bundled
+#: Hermes (``[tool.hal0.upstream-hermes]`` pin in pyproject.toml). Hermes is not
+#: importable from hal0's own venv, so this cannot be a plain re-export; the
+#: drift guard is ``tests/agents/test_anchor_window.py``, which asserts every
+#: hal0-side copy of the number resolves to this constant and compares against
+#: the real Hermes constant whenever a Hermes install is reachable.
+HERMES_MINIMUM_CONTEXT_LENGTH = 64_000
+
+#: Where the slot TOMLs an operator (or the installer) writes ceilings into live.
+SLOTS_DIR = Path("/etc/hal0/slots")
+
+#: Prefix hal0's virtual model ids carry (``hal0/agent`` → slot ``agent``).
+_VIRTUAL_PREFIX = "hal0/"
+
+_FLOOR_PROBE = "from agent.model_metadata import MINIMUM_CONTEXT_LENGTH as m; print(int(m))"
+
+
+def read_hermes_minimum_context(
+    venv_python: str | Path | None,
+    *,
+    run: Callable[..., Any] = subprocess.run,
+) -> tuple[int, str]:
+    """Return ``(floor, source)`` — Hermes' own floor when it can be asked.
+
+    hal0 runs from its own venv and never imports Hermes, so the number is read
+    the only way it honestly can be: by asking the Hermes venv's interpreter for
+    ``agent.model_metadata.MINIMUM_CONTEXT_LENGTH``. Any failure (no venv yet, an
+    older Hermes without the constant, a Hermes that cannot import) degrades to
+    :data:`HERMES_MINIMUM_CONTEXT_LENGTH` with the reason recorded in ``source``,
+    because a preflight that raises is worse than one that uses the pinned value.
+
+    ``source`` is ``"hermes"`` when the live constant was read, else
+    ``"fallback:<why>"`` — so a message built off the fallback can say so.
+    """
+    if not venv_python:
+        return (HERMES_MINIMUM_CONTEXT_LENGTH, "fallback:no-venv")
+    try:
+        proc = run(  # nosec B603 — fixed argv, no shell, hal0-owned venv path
+            [str(venv_python), "-c", _FLOOR_PROBE],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return (HERMES_MINIMUM_CONTEXT_LENGTH, f"fallback:{type(exc).__name__}")
+    if getattr(proc, "returncode", 1) != 0:
+        return (HERMES_MINIMUM_CONTEXT_LENGTH, "fallback:probe-failed")
+    try:
+        value = int(str(getattr(proc, "stdout", "") or "").strip())
+    except (TypeError, ValueError):
+        return (HERMES_MINIMUM_CONTEXT_LENGTH, "fallback:unparsable")
+    if value <= 0:
+        return (HERMES_MINIMUM_CONTEXT_LENGTH, "fallback:non-positive")
+    return (value, "hermes")
+
+
+def anchor_slot_name(model_name: str) -> str:
+    """Slot alias behind an anchor model id (``hal0/agent`` → ``agent``).
+
+    A bare id (a slot pinned directly, e.g. under
+    ``HAL0_HERMES_LIVE_RESOLVE=0``) is already the alias.
+    """
+    name = (model_name or "").strip()
+    if name.startswith(_VIRTUAL_PREFIX):
+        return name[len(_VIRTUAL_PREFIX) :]
+    return name
+
+
+def read_slot_ceiling(slot: str, *, slots_dir: Path = SLOTS_DIR) -> int | None:
+    """The slot's on-disk ``[model].context_size`` ceiling, or ``None``.
+
+    ``None`` covers every "no usable ceiling" case alike — no TOML, no
+    ``[model]`` table, no key, and a hand-edited garbage value (``"64k"``) —
+    matching how :func:`hal0.providers.container._resolve_context_size` treats
+    an unparsable ceiling. ``ctx_size`` is accepted as the dashboard's alias for
+    the same key.
+    """
+    if not slot:
+        return None
+    path = Path(slots_dir) / f"{slot}.toml"
+    try:
+        raw = tomllib.loads(path.read_bytes().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+    model = raw.get("model")
+    if not isinstance(model, Mapping):
+        return None
+    for key in ("context_size", "ctx_size"):
+        value = model.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+def recommended_ceiling(floor: int) -> int:
+    """Smallest power-of-two window that clears ``floor`` (64,000 → 65,536).
+
+    The number the fix command tells the operator to write. Power-of-two so it
+    matches what the shipped seeds already ask for and what llama-server budgets
+    comfortably.
+    """
+    size = 1024
+    while size < floor:
+        size *= 2
+    return size
+
+
+@dataclass(frozen=True)
+class AnchorWindow:
+    """What the anchor actually resolves to, and whether Hermes can use it."""
+
+    model: str
+    """The anchor model id Hermes dispatches with (e.g. ``hal0/agent``)."""
+
+    slot: str
+    """Slot alias behind it (e.g. ``agent``)."""
+
+    effective: int | None
+    """Effective window as advertised to Hermes; ``None`` when unknown."""
+
+    ceiling: int | None
+    """The slot's configured ``[model].context_size``; ``None`` when unset."""
+
+    floor: int
+    """Hermes' ``MINIMUM_CONTEXT_LENGTH``."""
+
+    floor_source: str
+    """``"hermes"`` when read live, else ``"fallback:<why>"``."""
+
+    slots_dir: Path = SLOTS_DIR
+
+    @property
+    def slot_path(self) -> Path:
+        return Path(self.slots_dir) / f"{self.slot}.toml"
+
+    @property
+    def verdict(self) -> str:
+        """``ok`` | ``below_floor`` | ``unknown``.
+
+        ``unknown`` is a real answer, not a soft failure: with no advertised
+        window (nothing loaded, gateway unreachable) there is no evidence
+        either way, and claiming a failure on no evidence is how a preflight
+        becomes noise operators learn to ignore.
+        """
+        if self.effective is None:
+            return "unknown"
+        return "below_floor" if self.effective < self.floor else "ok"
+
+    @property
+    def ceiling_is_binding(self) -> bool:
+        """Is the SLOT ceiling what holds the window down (vs the model)?"""
+        return (
+            self.ceiling is not None
+            and self.effective is not None
+            and self.ceiling <= self.effective
+        )
+
+    @property
+    def fix_command(self) -> str:
+        """The exact command that repairs a ceiling-bound anchor."""
+        target = recommended_ceiling(self.floor)
+        return f"hal0 slot edit {self.slot} --ctx-size {target} && hal0 slot restart {self.slot}"
+
+    def message(self) -> str:
+        """One operator-facing line: both numbers, the slot, and what to run.
+
+        Written to be actionable with no source reading: which slot, its
+        configured ceiling, the floor it is under, and the command to run.
+        """
+        if self.verdict == "unknown":
+            return (
+                f"anchor {self.model!r} (slot {self.slot!r}) advertises no context window "
+                f"right now — cannot check it against Hermes' {self.floor:,}-token floor"
+            )
+        if self.verdict == "ok":
+            return (
+                f"anchor {self.model!r} (slot {self.slot!r}) resolves to "
+                f"{self.effective:,} tokens ≥ Hermes' {self.floor:,} floor"
+            )
+        floor_note = "" if self.floor_source == "hermes" else " (hal0's pinned copy of it)"
+        head = (
+            f"anchor {self.model!r} resolves to slot {self.slot!r} with an effective context "
+            f"window of {self.effective:,} tokens, below the {self.floor:,} tokens Hermes "
+            f"requires{floor_note} — Hermes raises rather than degrading, so EVERY turn "
+            f"will fail until this is raised."
+        )
+        if self.ceiling_is_binding:
+            return (
+                f"{head} The limit is this slot's own configured ceiling: "
+                f"[model].context_size = {self.ceiling:,} in {self.slot_path}. "
+                f"Fix: {self.fix_command}"
+            )
+        ceiling_note = (
+            f"the slot ceiling ({self.ceiling:,} in {self.slot_path}) is not the limit; "
+            if self.ceiling is not None
+            else f"no ceiling is set in {self.slot_path}; "
+        )
+        return (
+            f"{head} The limit is the model behind the slot — {ceiling_note}"
+            f"the model itself only advertises {self.effective:,}. Point slot "
+            f"{self.slot!r} at a model whose window is at least {self.floor:,} "
+            f"(`hal0 slot edit {self.slot} --model <model-id>`), or set "
+            f"defaults.context_size on the current model if it really supports more."
+        )
+
+
+def resolve_anchor_window(
+    model_name: str,
+    *,
+    contexts: Mapping[str, int],
+    floor: int = HERMES_MINIMUM_CONTEXT_LENGTH,
+    floor_source: str = "fallback:not-probed",
+    slots_dir: Path = SLOTS_DIR,
+) -> AnchorWindow:
+    """Resolve the anchor's effective window + configured ceiling into a verdict.
+
+    ``contexts`` is the gateway's ``/v1/models`` id → ``context_length`` map
+    (:func:`hal0.agents.hermes_provision._fetch_model_contexts`) — deliberately
+    the SAME surface Hermes gates on, so this cannot pass while Hermes refuses.
+    The id is looked up as given first, then under the bare slot alias, because
+    the gateway advertises chat slots by alias (``agent``) while hermes'
+    ``model.default`` is normally the virtual (``hal0/agent``).
+
+    Pure: every input is injected, so the ct150 shape (ceiling 4096 under a
+    96000-token model) is reproducible in a test without a box.
+    """
+    slot = anchor_slot_name(model_name)
+    effective = _lookup_context(contexts, model_name, slot)
+    ceiling = read_slot_ceiling(slot, slots_dir=slots_dir)
+    return AnchorWindow(
+        model=model_name,
+        slot=slot,
+        effective=effective,
+        ceiling=ceiling,
+        floor=floor,
+        floor_source=floor_source,
+        slots_dir=Path(slots_dir),
+    )
+
+
+def _lookup_context(contexts: Mapping[str, int], model_name: str, slot: str) -> int | None:
+    for key in (model_name, slot):
+        if not key:
+            continue
+        value = contexts.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value > 0:
+            return value
+    return None

--- a/src/hal0/agents/anchor_window.py
+++ b/src/hal0/agents/anchor_window.py
@@ -28,6 +28,20 @@ resolves the anchor's effective window, compares it against Hermes' own floor
 on without reading any source — which slot, that slot's configured ceiling, the
 required floor, and the exact command that repairs it.
 
+Two rules keep the answer honest, both bought the hard way:
+
+* **Ask the by-id route, never the anchor's spelling.** ``hal0/agent`` is a
+  virtual name that resolves through the routing fallback chain, so the slot it
+  is *spelled* like need not be the slot serving it. ct152 has an offline agent
+  slot, an ``agent.toml`` on disk, and ``hal0/agent`` answering out of the
+  BRAIN slot at 32,768 tokens — under the floor. ``GET /v1/models/{id}``
+  resolves that chain and carries the resulting window; the ``/v1/models`` LIST
+  never even mentions ``agent`` there.
+* **Unknown is not a pass.** A window that cannot be read is reported as
+  neither — callers skip or warn. On ct152 the alias lookup found nothing,
+  called it unknown and passed, which is how a box that refuses every turn read
+  green (the #1831 defect, on the detector for #1827).
+
 Deliberately read-only. Rewriting an operator's slot ceiling during an update is
 a config mutation nobody has approved yet and is tracked as the other half of
 #1867; :func:`resolve_anchor_window` is the resolver that repair would be built
@@ -39,7 +53,7 @@ from __future__ import annotations
 
 import subprocess  # nosec B404 — asks the Hermes venv python for its own constant
 import tomllib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -108,15 +122,72 @@ def read_hermes_minimum_context(
 
 
 def anchor_slot_name(model_name: str) -> str:
-    """Slot alias behind an anchor model id (``hal0/agent`` → ``agent``).
+    """The alias an anchor model id *spells* (``hal0/agent`` → ``agent``).
 
-    A bare id (a slot pinned directly, e.g. under
-    ``HAL0_HERMES_LIVE_RESOLVE=0``) is already the alias.
+    A NAMING convention only — emphatically not a routing answer. ``hal0/agent``
+    routes to whatever the resolver's fallback chain currently lands on, which
+    on a box with an offline agent slot is another slot entirely (ct152:
+    ``hal0/agent`` → the ``brain`` slot). Use :func:`serving_slot`, which asks
+    the gateway, to learn which slot is actually behind the anchor; this helper
+    only supplies the candidate that a live catalog can confirm or refute.
     """
     name = (model_name or "").strip()
     if name.startswith(_VIRTUAL_PREFIX):
         return name[len(_VIRTUAL_PREFIX) :]
     return name
+
+
+def serving_slot(
+    model_name: str,
+    *,
+    entry: Mapping[str, Any] | None,
+    catalog: Sequence[Mapping[str, Any]] | None = None,
+    slots_dir: Path = SLOTS_DIR,
+) -> str | None:
+    """Which slot is actually serving the anchor — ``None`` when unprovable.
+
+    ``entry`` is the ``GET /v1/models/{id}`` row. hal0's gateway builds it by
+    copying the RESOLVED slot's catalog row and rewriting only ``id`` back to
+    the requested handle (``api/routes/v1.py::_resolve_virtual_model_entry``),
+    so the serving slot is the ``/v1/models`` row that is identical to it in
+    every field except ``id``. That is a fact about the gateway's own
+    construction, not a guess about naming.
+
+    A ``hal0/*`` virtual is NEVER named from its spelling: ct152 has an
+    ``agent.toml`` sitting right there while ``hal0/agent`` is served by the
+    brain slot, so blaming the spelled slot's ceiling would send the operator
+    to edit a file that is not the problem. A bare id is different — there the
+    id IS the alias — but even then only when a slot TOML by that name exists,
+    without which a raw physical model id (the ``HAL0_HERMES_LIVE_RESOLVE=0``
+    shape) would invent a slot and a TOML path that were never on the box.
+    """
+    spelled = anchor_slot_name(model_name)
+    if entry is not None and catalog:
+        wanted = _row_identity(entry)
+        candidates = [
+            str(row.get("id"))
+            for row in catalog
+            if isinstance(row, Mapping)
+            and row.get("id")
+            and str(row.get("id")) != model_name
+            and _row_identity(row) == wanted
+        ]
+        if spelled in candidates:
+            return spelled
+        if len(candidates) == 1:
+            return candidates[0]
+        if candidates:
+            # Two slots serving byte-identical rows: the catalog cannot say
+            # which one answered, and a coin flip here names the wrong TOML.
+            return None
+    if model_name == spelled and spelled and (Path(slots_dir) / f"{spelled}.toml").exists():
+        return spelled
+    return None
+
+
+def _row_identity(row: Mapping[str, Any]) -> tuple[tuple[str, str], ...]:
+    """A catalog row reduced to everything but its ``id``, order-independent."""
+    return tuple(sorted((str(k), repr(v)) for k, v in row.items() if k != "id"))
 
 
 def read_slot_ceiling(slot: str, *, slots_dir: Path = SLOTS_DIR) -> int | None:
@@ -167,8 +238,8 @@ class AnchorWindow:
     model: str
     """The anchor model id Hermes dispatches with (e.g. ``hal0/agent``)."""
 
-    slot: str
-    """Slot alias behind it (e.g. ``agent``)."""
+    slot: str | None
+    """Slot the gateway is actually serving it from; ``None`` when unprovable."""
 
     effective: int | None
     """Effective window as advertised to Hermes; ``None`` when unknown."""
@@ -184,18 +255,23 @@ class AnchorWindow:
 
     slots_dir: Path = SLOTS_DIR
 
+    endpoint: str = ""
+    """Where the window was asked for — named in the ``unknown`` message."""
+
     @property
-    def slot_path(self) -> Path:
+    def slot_path(self) -> Path | None:
+        if not self.slot:
+            return None
         return Path(self.slots_dir) / f"{self.slot}.toml"
 
     @property
     def verdict(self) -> str:
         """``ok`` | ``below_floor`` | ``unknown``.
 
-        ``unknown`` is a real answer, not a soft failure: with no advertised
-        window (nothing loaded, gateway unreachable) there is no evidence
-        either way, and claiming a failure on no evidence is how a preflight
-        becomes noise operators learn to ignore.
+        ``unknown`` means *no evidence*, and no evidence is neither a pass nor
+        a failure — callers must report it as neither (the probe skips, doctor
+        warns). Reporting it as a pass is how #1831 shipped, and doing it on
+        the detector for #1827 would hide the very defect it exists to catch.
         """
         if self.effective is None:
             return "unknown"
@@ -212,7 +288,13 @@ class AnchorWindow:
 
     @property
     def fix_command(self) -> str:
-        """The exact command that repairs a ceiling-bound anchor."""
+        """The exact command that repairs a ceiling-bound anchor.
+
+        Empty when the serving slot could not be proven — a command naming a
+        slot that may not exist is worse than no command.
+        """
+        if not self.slot:
+            return ""
         target = recommended_ceiling(self.floor)
         return f"hal0 slot edit {self.slot} --ctx-size {target} && hal0 slot restart {self.slot}"
 
@@ -222,23 +304,31 @@ class AnchorWindow:
         Written to be actionable with no source reading: which slot, its
         configured ceiling, the floor it is under, and the command to run.
         """
+        where = f" at {self.endpoint}" if self.endpoint else ""
         if self.verdict == "unknown":
             return (
-                f"anchor {self.model!r} (slot {self.slot!r}) advertises no context window "
-                f"right now — cannot check it against Hermes' {self.floor:,}-token floor"
+                f"anchor {self.model!r} advertises no context window{where} right now — "
+                f"cannot check it against Hermes' {self.floor:,}-token floor, so this is "
+                f"NOT a pass: re-run once a chat model is loaded"
             )
         if self.verdict == "ok":
             return (
-                f"anchor {self.model!r} (slot {self.slot!r}) resolves to "
+                f"anchor {self.model!r} ({self._slot_note}) resolves to "
                 f"{self.effective:,} tokens ≥ Hermes' {self.floor:,} floor"
             )
         floor_note = "" if self.floor_source == "hermes" else " (hal0's pinned copy of it)"
         head = (
-            f"anchor {self.model!r} resolves to slot {self.slot!r} with an effective context "
+            f"anchor {self.model!r} resolves to {self._slot_note} with an effective context "
             f"window of {self.effective:,} tokens, below the {self.floor:,} tokens Hermes "
             f"requires{floor_note} — Hermes raises rather than degrading, so EVERY turn "
             f"will fail until this is raised."
         )
+        if self.slot is None:
+            return (
+                f"{head} hal0 could not prove which slot is serving it, so it cannot name "
+                f"the ceiling to raise — run `hal0 slot list` and raise the window of the "
+                f"slot behind {self.model!r} to at least {self.floor:,}."
+            )
         if self.ceiling_is_binding:
             return (
                 f"{head} The limit is this slot's own configured ceiling: "
@@ -258,30 +348,48 @@ class AnchorWindow:
             f"defaults.context_size on the current model if it really supports more."
         )
 
+    @property
+    def _slot_note(self) -> str:
+        return f"slot {self.slot!r}" if self.slot else "an unidentified slot"
+
 
 def resolve_anchor_window(
     model_name: str,
     *,
-    contexts: Mapping[str, int],
+    entry: Mapping[str, Any] | None = None,
+    catalog: Sequence[Mapping[str, Any]] | None = None,
+    contexts: Mapping[str, int] | None = None,
     floor: int = HERMES_MINIMUM_CONTEXT_LENGTH,
     floor_source: str = "fallback:not-probed",
     slots_dir: Path = SLOTS_DIR,
+    endpoint: str = "",
 ) -> AnchorWindow:
     """Resolve the anchor's effective window + configured ceiling into a verdict.
 
-    ``contexts`` is the gateway's ``/v1/models`` id → ``context_length`` map
-    (:func:`hal0.agents.hermes_provision._fetch_model_contexts`) — deliberately
-    the SAME surface Hermes gates on, so this cannot pass while Hermes refuses.
-    The id is looked up as given first, then under the bare slot alias, because
-    the gateway advertises chat slots by alias (``agent``) while hermes'
-    ``model.default`` is normally the virtual (``hal0/agent``).
+    ``entry`` is the authoritative input: the ``GET /v1/models/{id}`` row for
+    the anchor id itself. That route resolves the routing fallback chain the
+    same way chat dispatch does and carries the resulting ``context_length``,
+    so it answers "what window will Hermes actually get?" rather than "what
+    window does a slot spelled like the anchor have?".
 
-    Pure: every input is injected, so the ct150 shape (ceiling 4096 under a
-    96000-token model) is reproducible in a test without a box.
+    ``catalog`` is the ``GET /v1/models`` list, used only to name the slot the
+    entry came from (see :func:`serving_slot`).
+
+    ``contexts`` (the id → ``context_length`` map) is honoured for an EXACT id
+    match only — never under the spelled alias. On ct152 the anchor
+    ``hal0/agent`` resolves through the fallback chain to the ``brain`` slot's
+    32,768-token window while ``/v1/models`` lists no ``agent`` row at all; an
+    alias lookup there returns ``None`` and the caller cannot tell "fine" from
+    "cannot see", which is exactly how a broken box read green.
+
+    Pure: every input is injected, so both the ct150 shape (ceiling 4096 under
+    a 96000-token model) and the ct152 shape are reproducible without a box.
     """
-    slot = anchor_slot_name(model_name)
-    effective = _lookup_context(contexts, model_name, slot)
-    ceiling = read_slot_ceiling(slot, slots_dir=slots_dir)
+    slot = serving_slot(model_name, entry=entry, catalog=catalog, slots_dir=slots_dir)
+    effective = _entry_context(entry)
+    if effective is None and contexts:
+        effective = _positive_int(contexts.get(model_name))
+    ceiling = read_slot_ceiling(slot, slots_dir=slots_dir) if slot else None
     return AnchorWindow(
         model=model_name,
         slot=slot,
@@ -290,16 +398,17 @@ def resolve_anchor_window(
         floor=floor,
         floor_source=floor_source,
         slots_dir=Path(slots_dir),
+        endpoint=endpoint,
     )
 
 
-def _lookup_context(contexts: Mapping[str, int], model_name: str, slot: str) -> int | None:
-    for key in (model_name, slot):
-        if not key:
-            continue
-        value = contexts.get(key)
-        if isinstance(value, bool):
-            continue
-        if isinstance(value, int) and value > 0:
-            return value
-    return None
+def _entry_context(entry: Mapping[str, Any] | None) -> int | None:
+    if not isinstance(entry, Mapping):
+        return None
+    return _positive_int(entry.get("context_length"))
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value

--- a/src/hal0/agents/anchor_window.py
+++ b/src/hal0/agents/anchor_window.py
@@ -185,9 +185,19 @@ def serving_slot(
     return None
 
 
+#: Fields that differ between two reads of the *same* row and so cannot take
+#: part in identity. ``created`` is stamped per request by the gateway
+#: (``api/routes/v1.py`` ``int(time.time())``), and the by-id read and the
+#: catalog read are two separate requests — so any pair that straddles a second
+#: boundary would compare unequal and the serving slot would come back unnamed,
+#: taking the repair command out of the operator's error message. Measured at
+#: ~2.5% on an idle box, and worse under load.
+_VOLATILE_ROW_FIELDS = frozenset({"id", "created"})
+
+
 def _row_identity(row: Mapping[str, Any]) -> tuple[tuple[str, str], ...]:
-    """A catalog row reduced to everything but its ``id``, order-independent."""
-    return tuple(sorted((str(k), repr(v)) for k, v in row.items() if k != "id"))
+    """A catalog row reduced to its stable fields, order-independent."""
+    return tuple(sorted((str(k), repr(v)) for k, v in row.items() if k not in _VOLATILE_ROW_FIELDS))
 
 
 def read_slot_ceiling(slot: str, *, slots_dir: Path = SLOTS_DIR) -> int | None:

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -3314,6 +3314,40 @@ def _fetch_model_contexts() -> dict[str, int]:
     return out
 
 
+def _fetch_anchor_models(
+    model_id: str, base_url: str = "", gateway_url: str = ""
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    """``(by-id row, catalog rows)`` for ``model_id`` on the endpoint that serves it.
+
+    The by-id row is the authoritative window: ``GET /v1/models/{id}`` resolves
+    the routing fallback chain exactly as chat dispatch does and returns the
+    RESOLVED model's row (``api/routes/v1.py::_resolve_virtual_model_entry``),
+    so its ``context_length`` is the window Hermes will really be handed. The
+    list route cannot answer this — it deliberately never advertises the
+    canonical virtuals (#1153), and on a box whose agent slot is offline it
+    carries no row spelled like the anchor at all.
+
+    ``base_url`` is hermes' ``model.base_url``, so under
+    ``HAL0_HERMES_LIVE_RESOLVE=0`` the question goes to the pinned
+    llama-server the turns actually reach rather than to a gateway catalog
+    that deliberately suppresses that id (#1831's lesson, applied here).
+
+    Never raises: an unreachable endpoint yields ``(None, [])``, which the
+    caller must report as "cannot see", not as a pass.
+    """
+    base = (base_url or f"{(gateway_url or HAL0_API_URL).rstrip('/')}/v1").rstrip("/")
+    _status, entry = _http_status_json(f"{base}/models/{_quote_model_id(model_id)}")
+    row = entry if isinstance(entry, dict) and entry.get("id") else None
+    _listed_status, payload = _http_status_json(f"{base}/models")
+    entries = (payload or {}).get("data")
+    catalog = [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    if row is None:
+        # No by-id route (llama-server has none): the list route may still carry
+        # the id verbatim, which for a pinned physical id is the same evidence.
+        row = next((e for e in catalog if str(e.get("id")) == model_id), None)
+    return (row, catalog)
+
+
 def _fetch_model_route_ready(model_id: str, base_url: str = "") -> bool | None:
     """Is ``model_id`` routable **on the endpoint the caller will dispatch to**?
 
@@ -4834,24 +4868,28 @@ def _anchor_window(state: BootstrapState, io: InstallIO) -> AnchorWindow | str:
         cfg = yaml.safe_load(config_path.read_text()) or {}
     except (OSError, yaml.YAMLError) as exc:
         return f"config parse: {exc}"
-    model_name = ((cfg.get("model") or {}).get("default") or "").strip()
+    model_cfg = cfg.get("model") or {}
+    model_name = str(model_cfg.get("default") or "").strip()
     if not model_name:
         return "model.default unset in config.yaml"
+    base_url = str(model_cfg.get("base_url", "") or "")
     floor, floor_source = read_hermes_minimum_context(_venv_python(Path(state.venv)))
     try:
-        contexts = io.fetch_model_contexts()
+        entry, catalog = io.fetch_anchor_models(model_name, base_url)
     except Exception as exc:  # a preflight must never raise
         return f"could not read advertised windows ({exc})"
     return resolve_anchor_window(
         model_name,
-        contexts=contexts,
+        entry=entry,
+        catalog=catalog,
         floor=floor,
         floor_source=floor_source,
         slots_dir=ETC_HAL0_DIR / "slots",
+        endpoint=base_url or f"{HAL0_API_URL}/v1",
     )
 
 
-def _smoke_anchor_context_window(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
+def _smoke_anchor_context_window(state: BootstrapState, io: InstallIO) -> tuple[bool | None, str]:
     """Is the anchor's window at or above Hermes' hard floor? (#1867)
 
     Hermes raises below ``MINIMUM_CONTEXT_LENGTH`` instead of degrading, so a
@@ -4862,12 +4900,18 @@ def _smoke_anchor_context_window(state: BootstrapState, io: InstallIO) -> tuple[
     4096 an older release seeded, and ``min()`` of the two is what Hermes sees.
 
     Fails with both numbers, the slot, its ceiling, and the exact repair
-    command. An anchor that advertises nothing yet (no model loaded) is
-    ``unknown``, not a failure — the preflight only claims on evidence.
+    command. An anchor whose window cannot be read (nothing loaded, endpoint
+    unreachable, a backend that advertises no ``context_length``) is
+    ``unknown`` — reported as ``None``/SKIPPED, never as a pass. A preflight
+    that cannot see the value has to say so: passing on no evidence is how a
+    box that refuses every turn read green (#1831, and the ct152 shape that
+    #1867's own first cut still reported clean).
     """
     window = _anchor_window(state, io)
     if isinstance(window, str):
         return (False, window)
+    if window.verdict == "unknown":
+        return (None, window.message())
     if window.verdict == "below_floor":
         log.warning(
             "hermes.anchor_window_below_floor",
@@ -5037,7 +5081,7 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
     """
     state = ctx.state
     chat_ready, chat_reason = _chat_model_ready(state, ctx.io)
-    probes = [
+    probes: list[tuple[str, Callable[[BootstrapState, InstallIO], tuple[bool | None, str]]]] = [
         ("wrapper_ready", _smoke_wrapper_ready),
         ("hermes_doctor", _smoke_hermes_doctor),
         ("anchor_context_window", _smoke_anchor_context_window),
@@ -5059,6 +5103,13 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
             passed, detail = fn(state, ctx.io)
         except Exception as exc:
             passed, detail = (False, f"{type(exc).__name__}: {exc}")
+        if passed is None:
+            # A probe that ran and could not reach a verdict reports SKIPPED,
+            # never a pass — the roll-up must not read clean off no evidence.
+            detail = f"skipped: {detail}"
+            results[name] = {"passed": None, "skipped": True, "detail": detail}
+            skipped.append(f"{name}: {detail}")
+            continue
         results[name] = {"passed": passed, "detail": detail}
         if not passed:
             failures.append(f"{name}: {detail}")
@@ -5478,6 +5529,9 @@ class InstallIO:
     fetch_slots: Callable[[], list[dict[str, Any]]] = _fetch_slots
     fetch_model_contexts: Callable[[], dict[str, int]] = _fetch_model_contexts
     fetch_model_route_ready: Callable[[str, str], bool | None] = _fetch_model_route_ready
+    fetch_anchor_models: Callable[..., tuple[dict[str, Any] | None, list[dict[str, Any]]]] = (
+        _fetch_anchor_models
+    )
     probe_mcp_server: Callable[..., dict[str, Any]] = _probe_mcp_server
     mcp_memory_call: Callable[..., dict[str, Any]] = _mcp_memory_call
     install_venv: Callable[..., None] = _install_venv

--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -54,6 +54,11 @@ from typing import Any, NamedTuple
 
 import structlog
 
+from hal0.agents.anchor_window import (
+    AnchorWindow,
+    read_hermes_minimum_context,
+    resolve_anchor_window,
+)
 from hal0.agents.role_slots import candidate_from_slot_mapping, resolve_role_slots
 from hal0.slot_lifecycle_budget import STACK_APPLY_SLOT_ALLOWANCE, slot_lifecycle_timeout_s
 from hal0.system import seam as _seam
@@ -4681,7 +4686,8 @@ def _phase_voice_wire(ctx: _StepCtx) -> PhaseResult:
 
 # ── Phase K: smoke_tests ────────────────────────────────────────────────────
 #
-# Six non-fatal probes per plan §14 + #246. Each surface check writes a
+# Seven non-fatal probes per plan §14 + #246 (the seventh, anchor_context_window,
+# is #1867's window preflight). Each surface check writes a
 # `passed: bool` row into PhaseResult.details["results"]; failures
 # also carry a remediation hint operators can paste at the user.
 #
@@ -4807,6 +4813,78 @@ def _smoke_memory_roundtrip(state: BootstrapState, io: InstallIO) -> tuple[bool,
     return (False, "memory_search returned no items for just-written marker")
 
 
+def _anchor_window(state: BootstrapState, io: InstallIO) -> AnchorWindow | str:
+    """Resolve the anchor slot's effective window, or a reason it can't be (#1867).
+
+    Reads ``model.default`` from the live config.yaml (the id Hermes actually
+    dispatches with), asks the installed Hermes for its own
+    ``MINIMUM_CONTEXT_LENGTH`` rather than trusting a second hardcoded 64,000,
+    and pairs the gateway's advertised window with the slot's on-disk ceiling.
+
+    Returns a plain string when the question could not even be asked (no
+    config.yaml, no ``model.default``) — that is a config problem, not a window
+    verdict.
+    """
+    import yaml  # type: ignore[import-untyped]
+
+    config_path = Path(state.hermes_home) / "config.yaml"
+    if not config_path.exists():
+        return "config.yaml missing — bootstrap incomplete"
+    try:
+        cfg = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return f"config parse: {exc}"
+    model_name = ((cfg.get("model") or {}).get("default") or "").strip()
+    if not model_name:
+        return "model.default unset in config.yaml"
+    floor, floor_source = read_hermes_minimum_context(_venv_python(Path(state.venv)))
+    try:
+        contexts = io.fetch_model_contexts()
+    except Exception as exc:  # a preflight must never raise
+        return f"could not read advertised windows ({exc})"
+    return resolve_anchor_window(
+        model_name,
+        contexts=contexts,
+        floor=floor,
+        floor_source=floor_source,
+        slots_dir=ETC_HAL0_DIR / "slots",
+    )
+
+
+def _smoke_anchor_context_window(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
+    """Is the anchor's window at or above Hermes' hard floor? (#1867)
+
+    Hermes raises below ``MINIMUM_CONTEXT_LENGTH`` instead of degrading, so a
+    box whose anchor slot resolves under it refuses EVERY turn — and used to do
+    so as an opaque upstream error ~1.6s in, naming neither the slot nor the
+    ceiling that caused it. The classic shape is an upgraded box: the model
+    declares 96000, the agent slot's own ``[model].context_size`` is still the
+    4096 an older release seeded, and ``min()`` of the two is what Hermes sees.
+
+    Fails with both numbers, the slot, its ceiling, and the exact repair
+    command. An anchor that advertises nothing yet (no model loaded) is
+    ``unknown``, not a failure — the preflight only claims on evidence.
+    """
+    window = _anchor_window(state, io)
+    if isinstance(window, str):
+        return (False, window)
+    if window.verdict == "below_floor":
+        log.warning(
+            "hermes.anchor_window_below_floor",
+            extra={
+                "model": window.model,
+                "slot": window.slot,
+                "effective": window.effective,
+                "slot_ceiling": window.ceiling,
+                "floor": window.floor,
+                "floor_source": window.floor_source,
+                "fix": window.fix_command,
+            },
+        )
+        return (False, window.message())
+    return (True, window.message())
+
+
 def _smoke_admin_tools_list(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
     probe = io.probe_mcp_server(
         "http://127.0.0.1:8080/mcp/admin",
@@ -4882,7 +4960,17 @@ def _smoke_hermes_doctor(_state: BootstrapState, io: InstallIO) -> tuple[bool, s
 #: memory_add/memory_search tools directly and has no chat dependency
 #: whatsoever (#1831); gating it behind the chat anchor over-skipped it even
 #: when memory itself was fully working.
-_MODEL_DEPENDENT_PROBES = frozenset({"chat_completions"})
+#: ``anchor_context_window`` joins it for the same reason (#1867): with no chat
+#: model routable there is no advertised window to compare against Hermes'
+#: floor, so the honest report is ``skipped``, not a manufactured verdict.
+_MODEL_DEPENDENT_PROBES = frozenset({"chat_completions", "anchor_context_window"})
+
+#: Why each model-dependent probe skipped — a skip is a claim (#1793), so it
+#: has to state the claim that probe is actually making, not a borrowed one.
+_SKIP_REASONS = {
+    "chat_completions": "no chat model loaded",
+    "anchor_context_window": "no routable anchor to measure a window on",
+}
 
 
 def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
@@ -4940,7 +5028,7 @@ def _chat_model_ready(state: BootstrapState, io: InstallIO) -> tuple[bool, str]:
 
 
 def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
-    """Run six diagnostic probes; collect results into the checkpoint.
+    """Run the diagnostic probes; collect results into the checkpoint.
 
     ``status`` is ``warn`` (not ``ok``) when any probe genuinely fails — a
     phase that recorded failures must say so, not report a clean ``ok`` with
@@ -4952,6 +5040,7 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
     probes = [
         ("wrapper_ready", _smoke_wrapper_ready),
         ("hermes_doctor", _smoke_hermes_doctor),
+        ("anchor_context_window", _smoke_anchor_context_window),
         ("chat_completions", _smoke_chat_completions),
         ("memory_roundtrip", _smoke_memory_roundtrip),
         ("admin_tools_list", _smoke_admin_tools_list),
@@ -4962,7 +5051,7 @@ def _phase_smoke_tests(ctx: _StepCtx) -> PhaseResult:
     skipped: list[str] = []
     for name, fn in probes:
         if name in _MODEL_DEPENDENT_PROBES and not chat_ready:
-            detail = f"skipped: no chat model loaded ({chat_reason})"
+            detail = f"skipped: {_SKIP_REASONS[name]} ({chat_reason})"
             results[name] = {"passed": None, "skipped": True, "detail": detail}
             skipped.append(f"{name}: {detail}")
             continue

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -11,8 +11,10 @@ verify report-card classifiers (API, runners, DNS, capabilities, memory,
 OpenWebUI, Hermes), then adds the broader health rows the retrofit calls for:
 auth posture, model-store integrity, pending migrations, a stale-dashboard
 ``HAL0_UI_DIST`` override (#1589), bound slot ports, the ``hal0.target``
-boot-enable anchor (r5-sync-assessment §6.1), and the privileged sudo seams
-every slot op + self-update runs through (#1465).
+boot-enable anchor (r5-sync-assessment §6.1), the privileged sudo seams
+every slot op + self-update runs through (#1465), and the context window behind
+Hermes' anchor model (#1867 — the smoke probes never run on an in-place
+upgrade, which is the only shape that defect survives in).
 
 Strictly read-only — there is no ``--fix`` here; the per-surface subcommands
 own repair. Exit codes:
@@ -767,6 +769,82 @@ def check_hindsight_llm_auth(
     return Check(name, title, _PASS, "memory engine carries a current client-tier LLM key")
 
 
+def check_hermes_anchor_window(
+    *,
+    base: str | None = None,
+    config_path: Path | None = None,
+    fetch: Callable[..., tuple[dict[str, Any] | None, list[dict[str, Any]]]] | None = None,
+    slots_dir: Path | None = None,
+    venv_python: Path | None = None,
+) -> Check:
+    """The window behind Hermes' anchor must clear Hermes' hard floor (#1867).
+
+    Hermes raises below ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH``
+    instead of degrading, so a box whose anchor resolves under it refuses EVERY
+    turn with an opaque upstream error that names neither the slot nor the
+    ceiling behind it.
+
+    This row exists because the smoke probe alone cannot cover the shape the
+    defect actually lives in: ``installer/install.sh`` calls
+    ``install_hermes`` only when the hermes venv is ABSENT ("covers the upgrade
+    path where no provision ran"), so on an in-place upgrade — the one case
+    where a stale ``[model].context_size`` seeded by an older release survives —
+    no smoke test ever runs. ``hal0 doctor`` is what an operator runs when the
+    agent misbehaves, so the check has to be here too.
+
+    Verdicts: below the floor is a ``fail`` with the repair command; a window
+    that cannot be read is a ``warn`` (never a pass — see #1831); an
+    unprovisioned Hermes passes with nothing to check.
+    """
+    from hal0.agents.anchor_window import read_hermes_minimum_context, resolve_anchor_window
+    from hal0.agents.hermes_provision import (
+        HERMES_HOME_DEFAULT,
+        HERMES_VENV_DEFAULT,
+        _fetch_anchor_models,
+        _venv_python,
+    )
+
+    name, title = "hermes_anchor_window", "Hermes anchor context window"
+    path = config_path if config_path is not None else (HERMES_HOME_DEFAULT / "config.yaml")
+    if not path.exists():
+        return Check(name, title, _PASS, "hermes not provisioned — nothing to check")
+
+    import yaml
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return Check(name, title, _WARN, f"could not read {path}: {exc}")
+    model_cfg = (data.get("model") or {}) if isinstance(data, dict) else {}
+    model_name = str(model_cfg.get("default") or "").strip()
+    if not model_name:
+        return Check(name, title, _WARN, f"model.default is unset in {path}")
+    base_url = str(model_cfg.get("base_url", "") or "")
+
+    python = venv_python if venv_python is not None else _venv_python(HERMES_VENV_DEFAULT)
+    floor, floor_source = read_hermes_minimum_context(python if python.exists() else None)
+    fetcher = fetch if fetch is not None else _fetch_anchor_models
+    try:
+        entry, catalog = fetcher(model_name, base_url, base or "")
+    except Exception as exc:  # a read-only row must never raise
+        return Check(name, title, _WARN, f"could not read the advertised window: {exc}")
+
+    window = resolve_anchor_window(
+        model_name,
+        entry=entry,
+        catalog=catalog,
+        floor=floor,
+        floor_source=floor_source,
+        slots_dir=slots_dir if slots_dir is not None else Path("/etc/hal0/slots"),
+        endpoint=base_url,
+    )
+    if window.verdict == "below_floor":
+        return Check(name, title, _FAIL, window.message())
+    if window.verdict == "unknown":
+        return Check(name, title, _WARN, window.message())
+    return Check(name, title, _PASS, window.message())
+
+
 # ── orchestration ──────────────────────────────────────────────────────────────
 
 # GET /api/slots is the slowest read-only route hal0 serves: the aggregator
@@ -829,6 +907,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_seams(),
         check_mcp_mounts(),
         check_hermes_mcp_config_auth(auth=auth_payload),
+        check_hermes_anchor_window(base=base),
         check_hindsight_llm_auth(auth=auth_payload),
     ]
     return verify_rows + extra_rows
@@ -913,6 +992,7 @@ __all__ = [
     "build_all_checks",
     "check_auth_posture",
     "check_hal0_target",
+    "check_hermes_anchor_window",
     "check_hermes_mcp_config_auth",
     "check_hindsight_llm_auth",
     "check_mcp_mounts",

--- a/tests/agents/test_anchor_window.py
+++ b/tests/agents/test_anchor_window.py
@@ -121,6 +121,29 @@ class TestCt152FalseNegative:
         assert "hal0 slot edit brain --ctx-size 65536" in message
         assert "agent.toml" not in message
 
+    def test_a_created_skew_still_names_the_serving_slot(self, tmp_path: Path) -> None:
+        """The gateway stamps ``created`` per request, and the by-id read and
+        the catalog read are two separate requests. A pair that straddles a
+        second boundary must still match, or the serving slot comes back
+        unnamed and the operator loses the repair command -- which is the whole
+        deliverable of #1867. Measured at ~2.5% on an idle ct152.
+        """
+        _write_slot(tmp_path, "agent", "[model]\ncontext_size = 65536\n")
+        _write_slot(tmp_path, "brain", "[model]\ncontext_size = 32768\n")
+        entry = dict(CT152_BY_ID)
+        entry["created"] = int(entry.get("created", 0)) + 1
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            entry=entry,
+            catalog=CT152_CATALOG,
+            floor=64_000,
+            floor_source="hermes",
+            slots_dir=tmp_path,
+        )
+        assert window.verdict == "below_floor"
+        assert window.slot == "brain", "a one-second created skew lost the serving slot"
+        assert "hal0 slot edit brain --ctx-size 65536" in window.message()
+
     def test_a_virtual_is_never_named_from_its_spelling(self, tmp_path: Path) -> None:
         """Even with an ``agent.toml`` on disk, ``hal0/agent`` is only ever the
         slot the CATALOG says answered — the ct152 box has both, and the

--- a/tests/agents/test_anchor_window.py
+++ b/tests/agents/test_anchor_window.py
@@ -1,0 +1,254 @@
+"""Unit tests for :mod:`hal0.agents.anchor_window` — #1867's window preflight.
+
+Covers the ct150 repro shape (a model declaring 96000 behind a slot whose own
+``[model].context_size`` ceiling is 4096), the model-side shape it must not be
+confused with, the "no evidence yet" case, and the drift guard tying hal0's
+copy of Hermes' ``MINIMUM_CONTEXT_LENGTH`` to the real constant.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hal0.agents import anchor_window as aw
+
+
+def _write_slot(slots_dir: Path, name: str, body: str) -> None:
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    (slots_dir / f"{name}.toml").write_text(body, encoding="utf-8")
+
+
+class TestResolveAnchorWindow:
+    """The ct150 shape and its neighbours, resolved from injected facts only."""
+
+    def test_slot_ceiling_below_floor_is_named_with_both_numbers_and_a_fix(
+        self, tmp_path: Path
+    ) -> None:
+        """THE repro: model declares 96000, slot ceiling is 4096, Hermes refuses.
+
+        The operator must be able to act off this message alone — it has to
+        carry the slot, that slot's configured ceiling, the required floor, and
+        the command that repairs it.
+        """
+        slots = tmp_path / "slots"
+        _write_slot(slots, "agent", '[model]\ndefault = "brain-sft"\ncontext_size = 4096\n')
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            # What the gateway advertises for the agent slot on that box —
+            # min(96000 model window, 4096 slot ceiling).
+            contexts={"agent": 4096, "brain": 96000},
+            floor=64_000,
+            floor_source="hermes",
+            slots_dir=slots,
+        )
+        assert window.slot == "agent"
+        assert window.effective == 4096
+        assert window.ceiling == 4096
+        assert window.verdict == "below_floor"
+        assert window.ceiling_is_binding is True
+
+        message = window.message()
+        assert "4,096" in message  # the window Hermes sees
+        assert "64,000" in message  # the floor it needs
+        assert "agent" in message  # which slot
+        assert str(slots / "agent.toml") in message  # where the ceiling lives
+        assert "hal0 slot edit agent --ctx-size 65536" in message
+        assert "hal0 slot restart agent" in message
+        assert window.fix_command in message
+
+    def test_a_ceiling_above_the_floor_with_a_small_model_blames_the_model(
+        self, tmp_path: Path
+    ) -> None:
+        """The other way under the floor: the ceiling is fine, the model is not.
+
+        Telling this operator to raise a 65536 ceiling would be useless advice,
+        so the message must point at the model instead and must NOT hand them
+        the ``--ctx-size`` command.
+        """
+        slots = tmp_path / "slots"
+        _write_slot(slots, "agent", "[model]\ncontext_size = 65536\n")
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            contexts={"agent": 32768},
+            floor=64_000,
+            floor_source="hermes",
+            slots_dir=slots,
+        )
+        assert window.verdict == "below_floor"
+        assert window.ceiling_is_binding is False
+        message = window.message()
+        assert "32,768" in message
+        assert "65,536" in message
+        assert "--ctx-size" not in message
+        assert "hal0 slot edit agent --model" in message
+
+    def test_window_at_or_above_the_floor_is_ok(self, tmp_path: Path) -> None:
+        slots = tmp_path / "slots"
+        _write_slot(slots, "agent", "[model]\ncontext_size = 65536\n")
+        window = aw.resolve_anchor_window(
+            "hal0/agent", contexts={"agent": 65536}, floor=64_000, slots_dir=slots
+        )
+        assert window.verdict == "ok"
+        assert "65,536" in window.message()
+
+    def test_no_advertised_window_is_unknown_not_a_failure(self, tmp_path: Path) -> None:
+        """No evidence is not evidence of a failure — a preflight that cries
+        wolf when nothing is loaded is one operators learn to ignore."""
+        window = aw.resolve_anchor_window(
+            "hal0/agent", contexts={}, floor=64_000, slots_dir=tmp_path / "slots"
+        )
+        assert window.verdict == "unknown"
+        assert window.effective is None
+        assert "cannot check" in window.message()
+
+    def test_a_bare_pinned_slot_id_resolves_the_same_slot(self, tmp_path: Path) -> None:
+        """``HAL0_HERMES_LIVE_RESOLVE=0`` pins the raw slot alias, not the virtual."""
+        slots = tmp_path / "slots"
+        _write_slot(slots, "agent", "[model]\ncontext_size = 4096\n")
+        window = aw.resolve_anchor_window(
+            "agent", contexts={"agent": 4096}, floor=64_000, slots_dir=slots
+        )
+        assert window.slot == "agent"
+        assert window.verdict == "below_floor"
+
+    def test_the_virtual_id_wins_over_the_alias_when_both_are_advertised(
+        self, tmp_path: Path
+    ) -> None:
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            contexts={"hal0/agent": 65536, "agent": 4096},
+            floor=64_000,
+            slots_dir=tmp_path,
+        )
+        assert window.effective == 65536
+
+    def test_fallback_floor_says_so_in_the_message(self, tmp_path: Path) -> None:
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            contexts={"agent": 4096},
+            floor=64_000,
+            floor_source="fallback:no-venv",
+            slots_dir=tmp_path,
+        )
+        assert "pinned copy" in window.message()
+
+
+class TestReadSlotCeiling:
+    def test_missing_file_has_no_ceiling(self, tmp_path: Path) -> None:
+        assert aw.read_slot_ceiling("agent", slots_dir=tmp_path) is None
+
+    def test_garbage_ceiling_reads_as_absent(self, tmp_path: Path) -> None:
+        """A hand-edited ``"64k"`` is treated as no ceiling — same posture as
+        :func:`hal0.providers.container._resolve_context_size` (#1852)."""
+        _write_slot(tmp_path, "agent", '[model]\ncontext_size = "64k"\n')
+        assert aw.read_slot_ceiling("agent", slots_dir=tmp_path) is None
+
+    def test_ctx_size_alias_is_accepted(self, tmp_path: Path) -> None:
+        _write_slot(tmp_path, "agent", "[model]\nctx_size = 8192\n")
+        assert aw.read_slot_ceiling("agent", slots_dir=tmp_path) == 8192
+
+    def test_unparsable_toml_reads_as_absent(self, tmp_path: Path) -> None:
+        _write_slot(tmp_path, "agent", "[model\ncontext_size = 4096\n")
+        assert aw.read_slot_ceiling("agent", slots_dir=tmp_path) is None
+
+
+class TestRecommendedCeiling:
+    @pytest.mark.parametrize(
+        ("floor", "expected"),
+        [(64_000, 65_536), (65_536, 65_536), (65_537, 131_072), (32_000, 32_768)],
+    )
+    def test_next_power_of_two_at_or_above_the_floor(self, floor: int, expected: int) -> None:
+        assert aw.recommended_ceiling(floor) == expected
+        assert aw.recommended_ceiling(floor) >= floor
+
+
+class TestReadHermesMinimumContext:
+    """The floor is read FROM Hermes; the constant is only the fallback."""
+
+    def test_reads_the_constant_out_of_the_hermes_interpreter(self, tmp_path: Path) -> None:
+        """Runs a REAL interpreter against a REAL fake ``agent`` package, so the
+        probe's import line is exercised rather than mocked away."""
+        pkg = tmp_path / "agent"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "model_metadata.py").write_text("MINIMUM_CONTEXT_LENGTH = 70000\n", encoding="utf-8")
+        shim = tmp_path / "python-shim"
+        shim.write_text(
+            f'#!/bin/sh\nexec {sys.executable} "$@"\n',
+            encoding="utf-8",
+        )
+        shim.chmod(0o755)
+
+        def run(argv: list[str], **kwargs: Any) -> Any:
+            kwargs.pop("cwd", None)
+            return subprocess.run(argv, cwd=tmp_path, **kwargs)  # nosec B603 — test shim
+
+        floor, source = aw.read_hermes_minimum_context(shim, run=run)
+        assert (floor, source) == (70000, "hermes")
+
+    def test_no_venv_falls_back_to_the_pinned_constant(self) -> None:
+        floor, source = aw.read_hermes_minimum_context(None)
+        assert floor == aw.HERMES_MINIMUM_CONTEXT_LENGTH
+        assert source == "fallback:no-venv"
+
+    def test_a_failing_probe_falls_back_rather_than_raising(self) -> None:
+        def run(_argv: list[str], **_kwargs: Any) -> Any:
+            return SimpleNamespace(returncode=1, stdout="")
+
+        assert aw.read_hermes_minimum_context("/nope/python", run=run) == (
+            aw.HERMES_MINIMUM_CONTEXT_LENGTH,
+            "fallback:probe-failed",
+        )
+
+    def test_an_unparsable_answer_falls_back(self) -> None:
+        def run(_argv: list[str], **_kwargs: Any) -> Any:
+            return SimpleNamespace(returncode=0, stdout="lots\n")
+
+        assert aw.read_hermes_minimum_context("/nope/python", run=run) == (
+            aw.HERMES_MINIMUM_CONTEXT_LENGTH,
+            "fallback:unparsable",
+        )
+
+    def test_an_exploding_runner_falls_back(self) -> None:
+        def run(_argv: list[str], **_kwargs: Any) -> Any:
+            raise OSError("no such binary")
+
+        floor, source = aw.read_hermes_minimum_context("/nope/python", run=run)
+        assert floor == aw.HERMES_MINIMUM_CONTEXT_LENGTH
+        assert source.startswith("fallback:")
+
+
+class TestFloorDoesNotDrift:
+    """One number, one place — and it must still match the real Hermes."""
+
+    def test_every_hal0_side_copy_of_the_floor_is_this_constant(self) -> None:
+        """The two pre-existing test-side copies (#1827/#1852) now import this
+        module's constant, so the floor cannot be raised in one place and left
+        stale in another."""
+        from tests.install.test_static_seeds import _HERMES_MIN_CONTEXT as seeds_floor
+        from tests.providers.test_container import _HERMES_MIN_CONTEXT as container_floor
+
+        assert seeds_floor is aw.HERMES_MINIMUM_CONTEXT_LENGTH
+        assert container_floor is aw.HERMES_MINIMUM_CONTEXT_LENGTH
+
+    def test_matches_the_installed_hermes_when_one_is_reachable(self) -> None:
+        """The real drift check. Hermes is not importable from hal0's venv, so
+        this can only run where a provisioned Hermes venv exists (a box, or a
+        dev host with one) — it skips elsewhere rather than asserting nothing."""
+        python = Path("/var/lib/hal0/venvs/hermes/bin/python")
+        if not python.exists():
+            pytest.skip("no provisioned Hermes venv on this host")
+        floor, source = aw.read_hermes_minimum_context(python)
+        if source != "hermes":
+            pytest.skip(f"Hermes venv present but did not answer ({source})")
+        assert floor == aw.HERMES_MINIMUM_CONTEXT_LENGTH, (
+            f"the installed Hermes requires {floor} but hal0's "
+            f"HERMES_MINIMUM_CONTEXT_LENGTH says {aw.HERMES_MINIMUM_CONTEXT_LENGTH} — "
+            "update hal0.agents.anchor_window.HERMES_MINIMUM_CONTEXT_LENGTH"
+        )

--- a/tests/agents/test_anchor_window.py
+++ b/tests/agents/test_anchor_window.py
@@ -24,6 +24,133 @@ def _write_slot(slots_dir: Path, name: str, body: str) -> None:
     (slots_dir / f"{name}.toml").write_text(body, encoding="utf-8")
 
 
+#: Verbatim ``GET /v1/models`` off ct152 (10.0.1.152, rc.5) — the box whose
+#: agent slot is offline, so ``hal0/agent`` resolves through the routing
+#: fallback chain to the ``brain`` slot. Nothing in this list is spelled
+#: ``agent``; that absence is the whole false negative.
+CT152_CATALOG: list[dict[str, Any]] = [
+    {
+        "id": "brain",
+        "object": "model",
+        "created": 1786589347,
+        "owned_by": "hal0",
+        "name": "brain · hal0-brain-sft-f16",
+        "downloaded": True,
+        "context_length": 32768,
+        "max_context_window": 32768,
+        "labels": ["chat"],
+        "recipe": "chat",
+    },
+    {
+        "id": "utility",
+        "object": "model",
+        "created": 1786589347,
+        "owned_by": "hal0",
+        "name": "utility · Qwen3.5-0.8B",
+        "downloaded": True,
+        "context_length": 32768,
+        "max_context_window": 32768,
+        "labels": ["chat"],
+        "checkpoint": "Q4_K_XL",
+    },
+]
+
+#: Verbatim ``GET /v1/models/hal0/agent`` off the same box: the brain row with
+#: ``id`` rewritten back to the handle that was asked about.
+CT152_BY_ID: dict[str, Any] = {**CT152_CATALOG[0], "id": "hal0/agent"}
+
+
+def _catalog(**windows: int) -> list[dict[str, Any]]:
+    """A ``/v1/models`` list in the gateway's shape, one row per slot."""
+    return [
+        {"id": alias, "object": "model", "owned_by": "hal0", "context_length": ctx}
+        for alias, ctx in windows.items()
+    ]
+
+
+def _by_id(handle: str, row: dict[str, Any]) -> dict[str, Any]:
+    """What ``GET /v1/models/{handle}`` returns for a row: it, re-``id``-ed."""
+    return {**row, "id": handle}
+
+
+class TestCt152FalseNegative:
+    """The demonstrated false negative: a box that cannot chat, reported green.
+
+    ct152 runs rc.5 with its agent slot offline. Hermes' anchor is
+    ``hal0/agent``; the gateway resolves it to the brain slot's 32,768-token
+    window, which is below the 64,000 Hermes refuses to start under. The
+    ``/v1/models`` LIST carries no ``agent`` row at all, so resolving the
+    anchor by its spelled alias finds nothing — and "found nothing" must never
+    read as "fine".
+    """
+
+    def test_the_list_route_alone_cannot_see_the_window_so_it_is_not_ok(
+        self, tmp_path: Path
+    ) -> None:
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            contexts={"brain": 32768, "utility": 32768},
+            floor=64_000,
+            slots_dir=tmp_path,
+        )
+        assert window.effective is None
+        assert window.verdict == "unknown"
+        assert window.verdict != "ok"
+
+    def test_the_by_id_route_resolves_the_chain_and_names_the_serving_slot(
+        self, tmp_path: Path
+    ) -> None:
+        """The authoritative surface sees exactly what Hermes will be handed."""
+        _write_slot(tmp_path, "agent", "[model]\ncontext_size = 65536\n")
+        _write_slot(tmp_path, "brain", "[model]\ncontext_size = 32768\n")
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            entry=CT152_BY_ID,
+            catalog=CT152_CATALOG,
+            floor=64_000,
+            floor_source="hermes",
+            slots_dir=tmp_path,
+        )
+        assert window.effective == 32768
+        assert window.verdict == "below_floor"
+        # The slot behind the anchor is brain — NOT the alias it is spelled
+        # with, whose own ceiling (65,536) is fine and must not be blamed.
+        assert window.slot == "brain"
+        assert window.ceiling == 32768
+        message = window.message()
+        assert "hal0 slot edit brain --ctx-size 65536" in message
+        assert "agent.toml" not in message
+
+    def test_a_virtual_is_never_named_from_its_spelling(self, tmp_path: Path) -> None:
+        """Even with an ``agent.toml`` on disk, ``hal0/agent`` is only ever the
+        slot the CATALOG says answered — the ct152 box has both, and the
+        spelled one is the wrong answer."""
+        _write_slot(tmp_path, "agent", "[model]\ncontext_size = 65536\n")
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            entry={"id": "hal0/agent", "context_length": 32768},
+            catalog=[{"id": "something-else", "context_length": 4096}],
+            floor=64_000,
+            slots_dir=tmp_path,
+        )
+        assert window.slot is None
+        assert window.ceiling is None
+
+    def test_two_identical_rows_are_ambiguous_not_a_coin_flip(self, tmp_path: Path) -> None:
+        """Byte-identical rows under two aliases: the catalog cannot say which
+        one answered, and guessing names the wrong TOML in the fix command."""
+        row = {"object": "model", "owned_by": "hal0", "context_length": 32768}
+        window = aw.resolve_anchor_window(
+            "hal0/agent",
+            entry={**row, "id": "hal0/agent"},
+            catalog=[{**row, "id": "brain"}, {**row, "id": "spare"}],
+            floor=64_000,
+            slots_dir=tmp_path,
+        )
+        assert window.slot is None
+        assert window.fix_command == ""
+
+
 class TestResolveAnchorWindow:
     """The ct150 shape and its neighbours, resolved from injected facts only."""
 
@@ -38,11 +165,13 @@ class TestResolveAnchorWindow:
         """
         slots = tmp_path / "slots"
         _write_slot(slots, "agent", '[model]\ndefault = "brain-sft"\ncontext_size = 4096\n')
+        # What the gateway advertises for the agent slot on that box —
+        # min(96000 model window, 4096 slot ceiling).
+        catalog = _catalog(agent=4096, brain=96000)
         window = aw.resolve_anchor_window(
             "hal0/agent",
-            # What the gateway advertises for the agent slot on that box —
-            # min(96000 model window, 4096 slot ceiling).
-            contexts={"agent": 4096, "brain": 96000},
+            entry=_by_id("hal0/agent", catalog[0]),
+            catalog=catalog,
             floor=64_000,
             floor_source="hermes",
             slots_dir=slots,
@@ -73,9 +202,11 @@ class TestResolveAnchorWindow:
         """
         slots = tmp_path / "slots"
         _write_slot(slots, "agent", "[model]\ncontext_size = 65536\n")
+        catalog = _catalog(agent=32768)
         window = aw.resolve_anchor_window(
             "hal0/agent",
-            contexts={"agent": 32768},
+            entry=_by_id("hal0/agent", catalog[0]),
+            catalog=catalog,
             floor=64_000,
             floor_source="hermes",
             slots_dir=slots,
@@ -91,47 +222,81 @@ class TestResolveAnchorWindow:
     def test_window_at_or_above_the_floor_is_ok(self, tmp_path: Path) -> None:
         slots = tmp_path / "slots"
         _write_slot(slots, "agent", "[model]\ncontext_size = 65536\n")
+        catalog = _catalog(agent=65536)
         window = aw.resolve_anchor_window(
-            "hal0/agent", contexts={"agent": 65536}, floor=64_000, slots_dir=slots
+            "hal0/agent",
+            entry=_by_id("hal0/agent", catalog[0]),
+            catalog=catalog,
+            floor=64_000,
+            slots_dir=slots,
         )
         assert window.verdict == "ok"
         assert "65,536" in window.message()
 
-    def test_no_advertised_window_is_unknown_not_a_failure(self, tmp_path: Path) -> None:
-        """No evidence is not evidence of a failure — a preflight that cries
-        wolf when nothing is loaded is one operators learn to ignore."""
+    def test_no_advertised_window_is_unknown_and_says_it_is_not_a_pass(
+        self, tmp_path: Path
+    ) -> None:
+        """No evidence is not evidence of a failure — but it is emphatically
+        not a pass either, and the message has to say which of the two it is."""
         window = aw.resolve_anchor_window(
-            "hal0/agent", contexts={}, floor=64_000, slots_dir=tmp_path / "slots"
+            "hal0/agent", entry=None, catalog=[], floor=64_000, slots_dir=tmp_path / "slots"
         )
         assert window.verdict == "unknown"
         assert window.effective is None
         assert "cannot check" in window.message()
+        assert "NOT a pass" in window.message()
 
     def test_a_bare_pinned_slot_id_resolves_the_same_slot(self, tmp_path: Path) -> None:
         """``HAL0_HERMES_LIVE_RESOLVE=0`` pins the raw slot alias, not the virtual."""
         slots = tmp_path / "slots"
         _write_slot(slots, "agent", "[model]\ncontext_size = 4096\n")
         window = aw.resolve_anchor_window(
-            "agent", contexts={"agent": 4096}, floor=64_000, slots_dir=slots
+            "agent",
+            entry={"id": "agent", "context_length": 4096},
+            catalog=_catalog(agent=4096),
+            floor=64_000,
+            slots_dir=slots,
         )
         assert window.slot == "agent"
         assert window.verdict == "below_floor"
 
-    def test_the_virtual_id_wins_over_the_alias_when_both_are_advertised(
-        self, tmp_path: Path
-    ) -> None:
+    def test_a_raw_physical_model_id_never_invents_a_slot(self, tmp_path: Path) -> None:
+        """Codex's P1: under ``HAL0_HERMES_LIVE_RESOLVE=0`` the anchor is a raw
+        physical model id served by a slot-local llama-server. There is no
+        ``/etc/hal0/slots/<that id>.toml`` and never was, so no slot, no ceiling
+        and no ``--ctx-size`` command may be manufactured for it."""
         window = aw.resolve_anchor_window(
-            "hal0/agent",
-            contexts={"hal0/agent": 65536, "agent": 4096},
+            "qwen3-30b-a3b-instruct",
+            entry={"id": "qwen3-30b-a3b-instruct", "context_length": 8192},
+            catalog=[{"id": "qwen3-30b-a3b-instruct", "object": "model"}],
             floor=64_000,
             slots_dir=tmp_path,
         )
+        assert window.slot is None
+        assert window.slot_path is None
+        assert window.fix_command == ""
+        assert window.verdict == "below_floor"
+        message = window.message()
+        assert ".toml" not in message
+        assert "--ctx-size" not in message
+        assert "8,192" in message
+
+    def test_an_exact_id_in_the_list_route_still_counts(self, tmp_path: Path) -> None:
+        """A pinned id the LIST route carries verbatim is real evidence — but
+        only under that exact id, never under a spelled-alias guess."""
+        window = aw.resolve_anchor_window(
+            "hal0/agent", contexts={"hal0/agent": 65536}, floor=64_000, slots_dir=tmp_path
+        )
         assert window.effective == 65536
+        assert window.verdict == "ok"
 
     def test_fallback_floor_says_so_in_the_message(self, tmp_path: Path) -> None:
+        _write_slot(tmp_path, "agent", "[model]\ncontext_size = 4096\n")
+        catalog = _catalog(agent=4096)
         window = aw.resolve_anchor_window(
             "hal0/agent",
-            contexts={"agent": 4096},
+            entry=_by_id("hal0/agent", catalog[0]),
+            catalog=catalog,
             floor=64_000,
             floor_source="fallback:no-venv",
             slots_dir=tmp_path,

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2036,6 +2036,7 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     monkeypatch.setattr(hp, "_smoke_memory_roundtrip", lambda s, io: (True, "1 item"))
     monkeypatch.setattr(hp, "_smoke_admin_tools_list", lambda s, io: (True, "8 tools"))
     monkeypatch.setattr(hp, "_smoke_hermes_md_contains_primary", lambda s, io: (True, "ok"))
+    monkeypatch.setattr(hp, "_smoke_anchor_context_window", lambda s, io: (True, "65,536 ≥ floor"))
     out = hp._phase_smoke_tests(hp._StepCtx(state=state, io=io))
     assert out.status == hp.PhaseStatus.OK
     assert out.details["failures"] == []
@@ -2043,6 +2044,7 @@ def test_smoke_tests_phase_runs_each_probe_collecting_results(
     assert set(out.details["results"].keys()) == {
         "wrapper_ready",
         "hermes_doctor",
+        "anchor_context_window",
         "chat_completions",
         "memory_roundtrip",
         "admin_tools_list",
@@ -2096,7 +2098,12 @@ def test_smoke_tests_phase_skips_model_dependent_probes_without_chat_model(
     assert calls == []  # the chat-gated probe never ran
     assert out.status == hp.PhaseStatus.OK  # skips aren't failures
     assert out.details["failures"] == []
-    assert len(out.details["skipped"]) == 1
+    # Both model-dependent probes skip: chat_completions and #1867's
+    # anchor_context_window, which has no advertised window to measure either.
+    assert {s.split(":")[0] for s in out.details["skipped"]} == {
+        "chat_completions",
+        "anchor_context_window",
+    }
     assert out.details["results"]["chat_completions"]["skipped"] is True
     assert "no chat model loaded" in out.details["results"]["chat_completions"]["detail"]
     assert out.details["results"]["memory_roundtrip"] == {"passed": True, "detail": "1 item"}
@@ -2362,7 +2369,10 @@ def test_virtual_anchor_with_no_live_slot_still_skips(
     state = hp.BootstrapState(hermes_home=str(hh))
     out = hp._phase_smoke_tests(hp._StepCtx(state=state))
     assert out.details["results"]["chat_completions"]["skipped"] is True
-    assert len(out.details["skipped"]) == 1
+    assert {s.split(":")[0] for s in out.details["skipped"]} == {
+        "chat_completions",
+        "anchor_context_window",
+    }
 
 
 def test_live_resolve_virtual_anchor_runs_the_probe(
@@ -2391,6 +2401,109 @@ def test_live_resolve_virtual_anchor_runs_the_probe(
     out = hp._phase_smoke_tests(hp._StepCtx(state=state))
     assert ran == ["x"]
     assert out.details["skipped"] == []
+
+
+class TestAnchorContextWindowPreflight:
+    """#1867 — the anchor's window is checked before Hermes ever sees it.
+
+    Reproduces the ct150 box exactly: the model behind the agent slot declares
+    96000, but the slot's own ``[model].context_size`` ceiling is still the 4096
+    an older release seeded, so ``min()`` hands Hermes 4,096 and Hermes — which
+    raises below ``MINIMUM_CONTEXT_LENGTH`` rather than degrading — refuses
+    every turn. Before this preflight nothing named the slot or the ceiling; the
+    operator saw only an opaque upstream error ~1.6 s into the first turn.
+
+    Production wiring only: the real ``_phase_smoke_tests``, the real
+    ``_fetch_model_contexts`` over a fake network, a real slot TOML on disk.
+    """
+
+    @staticmethod
+    def _ct150_box(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        slot_ceiling: int,
+        advertised: int,
+    ) -> hp.BootstrapState:
+        hh = tmp_path / "hh"
+        hh.mkdir()
+        (hh / "config.yaml").write_text(
+            "model:\n  default: hal0/agent\n  base_url: http://127.0.0.1:8080/v1\n"
+        )
+        etc = tmp_path / "etc-hal0"
+        (etc / "slots").mkdir(parents=True)
+        (etc / "slots" / "agent.toml").write_text(
+            f'[model]\ndefault = "hal0-brain-sft-q8-rocmfpx"\ncontext_size = {slot_ceiling}\n'
+        )
+        monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+        _fake_http(
+            monkeypatch,
+            {
+                # The anchor routes fine — this box is not broken in the way the
+                # #1831 routability preflight looks for.
+                "http://127.0.0.1:8080/v1/models/hal0/agent": {"id": "hal0/agent"},
+                # ...but the window it advertises is what Hermes gates on, and
+                # the model behind it declares 96000 while the slot says 4096.
+                "http://127.0.0.1:8080/v1/models": {
+                    "data": [
+                        {"id": "agent", "context_length": advertised},
+                        {"id": "brain", "context_length": 96000},
+                    ]
+                },
+            },
+        )
+        _stub_non_chat_probes(monkeypatch)
+        monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (True, "ready"))
+        # No provisioned Hermes venv under a unit test, so the floor comes from
+        # hal0's pinned copy of MINIMUM_CONTEXT_LENGTH.
+        return hp.BootstrapState(hermes_home=str(hh), venv=str(tmp_path / "no-venv"))
+
+    def test_a_slot_ceiling_under_the_floor_fails_loudly_with_the_fix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        state = self._ct150_box(tmp_path, monkeypatch, slot_ceiling=4096, advertised=4096)
+        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+
+        result = out.details["results"]["anchor_context_window"]
+        assert result["passed"] is False, out.details["results"]
+        assert out.status == hp.PhaseStatus.WARN
+        detail = result["detail"]
+        # Everything an operator needs, without opening a source file.
+        assert "agent" in detail
+        assert "4,096" in detail
+        assert "64,000" in detail
+        assert "agent.toml" in detail
+        assert "hal0 slot edit agent --ctx-size 65536" in detail
+        assert any("anchor_context_window" in f for f in out.details["failures"])
+
+    def test_a_ceiling_above_the_floor_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        state = self._ct150_box(tmp_path, monkeypatch, slot_ceiling=65536, advertised=65536)
+        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+        assert out.details["results"]["anchor_context_window"]["passed"] is True
+        assert out.status == hp.PhaseStatus.OK
+
+    def test_no_routable_anchor_skips_instead_of_inventing_a_verdict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Install-time run, before any model was ever loaded: there is no
+        advertised window to judge, so the probe reports ``skipped`` — the same
+        rule the chat probe follows (#1793)."""
+        hh = tmp_path / "hh"
+        hh.mkdir()
+        (hh / "config.yaml").write_text(
+            "model:\n  default: hal0/agent\n  base_url: http://127.0.0.1:8080/v1\n"
+        )
+        _fake_http(monkeypatch, {"http://127.0.0.1:8080/v1/models": {"data": []}})
+        _stub_non_chat_probes(monkeypatch)
+        monkeypatch.setattr(
+            hp, "_smoke_chat_completions", lambda s, io: pytest.fail("probe must not run")
+        )
+        state = hp.BootstrapState(hermes_home=str(hh))
+        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+        assert out.details["results"]["anchor_context_window"]["skipped"] is True
+        assert out.status == hp.PhaseStatus.OK
 
 
 class TestFetchModelRouteReady:

--- a/tests/agents/test_hermes_provision.py
+++ b/tests/agents/test_hermes_provision.py
@@ -2320,7 +2320,10 @@ def test_pinned_backend_config_does_not_skip_chat_probe(
         f"chat_completions was skipped on a live pinned backend: "
         f"{out.details['results']['chat_completions']} (probed: {seen})"
     )
-    assert out.details["skipped"] == []
+    # Scoped to the chat probe: #1867's anchor_context_window legitimately
+    # skips here (this fake catalog advertises no context_length), and a
+    # blanket "nothing skipped" would make that skip look like a chat bug.
+    assert not any(s.startswith("chat_completions") for s in out.details["skipped"])
 
 
 def test_unverifiable_route_runs_the_probe_instead_of_skipping(
@@ -2346,7 +2349,10 @@ def test_unverifiable_route_runs_the_probe_instead_of_skipping(
     state = hp.BootstrapState(hermes_home=str(hh))
     out = hp._phase_smoke_tests(hp._StepCtx(state=state))
     assert ran == ["x"]
-    assert out.details["skipped"] == []
+    # Scoped to the chat probe: #1867's anchor_context_window legitimately
+    # skips here (this fake catalog advertises no context_length), and a
+    # blanket "nothing skipped" would make that skip look like a chat bug.
+    assert not any(s.startswith("chat_completions") for s in out.details["skipped"])
     assert any("chat_completions" in f for f in out.details["failures"])
 
 
@@ -2400,7 +2406,10 @@ def test_live_resolve_virtual_anchor_runs_the_probe(
     state = hp.BootstrapState(hermes_home=str(hh))
     out = hp._phase_smoke_tests(hp._StepCtx(state=state))
     assert ran == ["x"]
-    assert out.details["skipped"] == []
+    # Scoped to the chat probe: #1867's anchor_context_window legitimately
+    # skips here (this fake catalog advertises no context_length), and a
+    # blanket "nothing skipped" would make that skip look like a chat bug.
+    assert not any(s.startswith("chat_completions") for s in out.details["skipped"])
 
 
 class TestAnchorContextWindowPreflight:
@@ -2414,7 +2423,7 @@ class TestAnchorContextWindowPreflight:
     operator saw only an opaque upstream error ~1.6 s into the first turn.
 
     Production wiring only: the real ``_phase_smoke_tests``, the real
-    ``_fetch_model_contexts`` over a fake network, a real slot TOML on disk.
+    ``_fetch_anchor_models`` over a fake network, a real slot TOML on disk.
     """
 
     @staticmethod
@@ -2436,18 +2445,28 @@ class TestAnchorContextWindowPreflight:
             f'[model]\ndefault = "hal0-brain-sft-q8-rocmfpx"\ncontext_size = {slot_ceiling}\n'
         )
         monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+        # The by-id row is the RESOLVED slot's catalog row with ``id`` rewritten
+        # back to the requested handle — the gateway's own construction
+        # (``api/routes/v1.py::_resolve_virtual_model_entry``), captured off a
+        # live box in ``_CT152_*`` below.
+        agent_row = {
+            "id": "agent",
+            "object": "model",
+            "owned_by": "hal0",
+            "name": "agent · hal0-brain-sft-q8-rocmfpx",
+            "context_length": advertised,
+        }
         _fake_http(
             monkeypatch,
             {
                 # The anchor routes fine — this box is not broken in the way the
-                # #1831 routability preflight looks for.
-                "http://127.0.0.1:8080/v1/models/hal0/agent": {"id": "hal0/agent"},
-                # ...but the window it advertises is what Hermes gates on, and
-                # the model behind it declares 96000 while the slot says 4096.
+                # #1831 routability preflight looks for. What it hands Hermes is
+                # min(96000 model window, the slot's own ceiling).
+                "http://127.0.0.1:8080/v1/models/hal0/agent": {**agent_row, "id": "hal0/agent"},
                 "http://127.0.0.1:8080/v1/models": {
                     "data": [
-                        {"id": "agent", "context_length": advertised},
-                        {"id": "brain", "context_length": 96000},
+                        agent_row,
+                        {"id": "brain", "owned_by": "hal0", "context_length": 96000},
                     ]
                 },
             },
@@ -2504,6 +2523,124 @@ class TestAnchorContextWindowPreflight:
         out = hp._phase_smoke_tests(hp._StepCtx(state=state))
         assert out.details["results"]["anchor_context_window"]["skipped"] is True
         assert out.status == hp.PhaseStatus.OK
+
+    def test_ct152_the_anchor_falls_back_to_another_slot_and_must_not_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE false negative, off the live ct152 box (rc.5).
+
+        The agent slot is offline (``model_id: null``) so ``hal0/agent``
+        resolves through the routing fallback chain to the BRAIN slot's
+        32,768-token window — under Hermes' 64,000 floor, i.e. a box that
+        cannot chat. But ``/v1/models`` lists only ``brain`` and ``utility``:
+        there is no row spelled ``agent`` or ``hal0/agent`` anywhere in it, so
+        a probe that looks the anchor up by its spelled alias sees nothing,
+        calls the window unknown, and reports a PASS.
+
+        Payloads are verbatim captures from 10.0.1.152 — the expectation comes
+        from the gateway itself, not from anything hal0's resolver computes.
+        """
+        hh = tmp_path / "hh"
+        hh.mkdir()
+        (hh / "config.yaml").write_text(
+            "model:\n  default: hal0/agent\n  base_url: http://127.0.0.1:8080/v1\n"
+        )
+        etc = tmp_path / "etc-hal0"
+        (etc / "slots").mkdir(parents=True)
+        # The agent slot's TOML still exists on that box; it is simply not what
+        # the anchor resolves to, so its ceiling must not be blamed.
+        (etc / "slots" / "agent.toml").write_text("[model]\ncontext_size = 65536\n")
+        (etc / "slots" / "brain.toml").write_text("[model]\ncontext_size = 32768\n")
+        monkeypatch.setattr(hp, "ETC_HAL0_DIR", etc)
+        _fake_http(
+            monkeypatch,
+            {
+                "http://127.0.0.1:8080/v1/models/hal0/agent": _CT152_BY_ID,
+                "http://127.0.0.1:8080/v1/models": {"data": _CT152_CATALOG},
+            },
+        )
+        _stub_non_chat_probes(monkeypatch)
+        monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (True, "ready"))
+        state = hp.BootstrapState(hermes_home=str(hh), venv=str(tmp_path / "no-venv"))
+
+        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+        result = out.details["results"]["anchor_context_window"]
+        assert result["passed"] is not True, result  # the whole point of #1867
+        assert result["passed"] is False
+        detail = result["detail"]
+        assert "32,768" in detail
+        assert "64,000" in detail
+        # The serving slot is brain, not the alias the anchor is spelled with.
+        assert "'brain'" in detail
+        assert "hal0 slot edit brain --ctx-size 65536" in detail
+        assert "agent.toml" not in detail
+
+    def test_an_unreadable_window_skips_rather_than_passing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A routable anchor whose backend advertises no ``context_length``
+        (the ``HAL0_HERMES_LIVE_RESOLVE=0`` shape against a plain llama-server)
+        is unknown — and unknown is reported as SKIPPED, never as a pass."""
+        hh = tmp_path / "hh"
+        hh.mkdir()
+        (hh / "config.yaml").write_text(
+            "model:\n  default: qwen3-30b-a3b-instruct\n  base_url: http://127.0.0.1:8081/v1\n"
+        )
+        _fake_http(
+            monkeypatch,
+            {
+                "http://127.0.0.1:8081/v1/models": {
+                    "data": [{"id": "qwen3-30b-a3b-instruct", "object": "model"}]
+                }
+            },
+        )
+        _stub_non_chat_probes(monkeypatch)
+        monkeypatch.setattr(hp, "_smoke_chat_completions", lambda s, io: (True, "ready"))
+        state = hp.BootstrapState(hermes_home=str(hh), venv=str(tmp_path / "no-venv"))
+
+        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
+        result = out.details["results"]["anchor_context_window"]
+        assert result["passed"] is None
+        assert result["skipped"] is True
+        assert "NOT a pass" in result["detail"]
+        # A slot TOML path is never invented for a raw physical model id.
+        assert ".toml" not in result["detail"]
+        assert out.details["failures"] == []
+
+
+#: Verbatim ``GET /v1/models`` from ct152 (10.0.1.152, rc.5, agent slot
+#: offline). Note what is NOT here: any row spelled ``agent`` or ``hal0/agent``.
+_CT152_CATALOG: list[dict[str, Any]] = [
+    {
+        "id": "brain",
+        "object": "model",
+        "created": 1786589347,
+        "owned_by": "hal0",
+        "name": "brain · hal0-brain-sft-f16",
+        "downloaded": True,
+        "context_length": 32768,
+        "max_context_window": 32768,
+        "labels": ["chat"],
+        "recipe": "chat",
+    },
+    {
+        "id": "utility",
+        "object": "model",
+        "created": 1786589347,
+        "owned_by": "hal0",
+        "name": "utility · Qwen3.5-0.8B",
+        "downloaded": True,
+        "context_length": 32768,
+        "max_context_window": 32768,
+        "labels": ["chat"],
+        "checkpoint": "Q4_K_XL",
+    },
+]
+
+#: Verbatim ``GET /v1/models/hal0/agent`` from the same box — the routing
+#: fallback chain resolved to the brain slot, so this is the brain row with
+#: ``id`` rewritten back to the handle Hermes asked about.
+_CT152_BY_ID: dict[str, Any] = {**_CT152_CATALOG[0], "id": "hal0/agent"}
 
 
 class TestFetchModelRouteReady:

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -502,6 +502,121 @@ def test_hermes_mcp_auth_warns_on_unreadable_config(tmp_path) -> None:  # type: 
     assert c.status == "warn"
 
 
+# ── check_hermes_anchor_window ────────────────────────────────────────────────
+#
+# #1867's window preflight has to be reachable on the path the defect lives on.
+# ``installer/install.sh`` only calls ``install_hermes`` when the hermes venv is
+# ABSENT ("covers the upgrade path where no provision ran"), so on an in-place
+# upgrade — the one shape where a stale ``[model].context_size`` from an older
+# release survives — the smoke probes never run at all. ``hal0 doctor`` is what
+# an operator runs when the agent misbehaves, so the row lives here too.
+#
+# The payloads below are verbatim captures from ct152 (10.0.1.152, rc.5), a box
+# whose agent slot is offline: ``hal0/agent`` resolves through the routing
+# fallback chain to the brain slot's 32,768-token window (under Hermes' 64,000
+# floor, i.e. it cannot chat) while ``/v1/models`` lists no ``agent`` row at all.
+
+_CT152_BRAIN_ROW = {
+    "id": "brain",
+    "object": "model",
+    "created": 1786589347,
+    "owned_by": "hal0",
+    "name": "brain · hal0-brain-sft-f16",
+    "downloaded": True,
+    "context_length": 32768,
+    "max_context_window": 32768,
+    "labels": ["chat"],
+    "recipe": "chat",
+}
+_CT152_CATALOG = [
+    _CT152_BRAIN_ROW,
+    {
+        "id": "utility",
+        "object": "model",
+        "created": 1786589347,
+        "owned_by": "hal0",
+        "name": "utility · Qwen3.5-0.8B",
+        "downloaded": True,
+        "context_length": 32768,
+        "max_context_window": 32768,
+        "labels": ["chat"],
+        "checkpoint": "Q4_K_XL",
+    },
+]
+_CT152_BY_ID = {**_CT152_BRAIN_ROW, "id": "hal0/agent"}
+
+
+def _hermes_config(tmp_path, anchor: str = "hal0/agent"):  # type: ignore[no-untyped-def]
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(f"model:\n  default: {anchor}\n  base_url: http://127.0.0.1:8080/v1\n")
+    return cfg
+
+
+def test_anchor_window_passes_when_hermes_is_not_provisioned(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    c = da.check_hermes_anchor_window(config_path=tmp_path / "nope.yaml")
+    assert c.status == "pass"
+    assert "not provisioned" in c.detail
+
+
+def test_anchor_window_fails_on_the_ct152_shape(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The demonstrated false negative, as an operator would meet it on an
+    upgraded box: `hal0 doctor` must name the real serving slot and the fix."""
+    slots = tmp_path / "slots"
+    slots.mkdir()
+    (slots / "brain.toml").write_text("[model]\ncontext_size = 32768\n")
+    (slots / "agent.toml").write_text("[model]\ncontext_size = 65536\n")
+    c = da.check_hermes_anchor_window(
+        config_path=_hermes_config(tmp_path),
+        fetch=lambda *_a: (_CT152_BY_ID, _CT152_CATALOG),
+        slots_dir=slots,
+        venv_python=tmp_path / "no-venv-python",
+    )
+    assert c.status == "fail"
+    assert "32,768" in c.detail and "64,000" in c.detail
+    assert "hal0 slot edit brain --ctx-size 65536" in c.detail
+    assert "agent.toml" not in c.detail
+
+
+def test_anchor_window_warns_rather_than_passing_when_it_cannot_see_the_window(  # type: ignore[no-untyped-def]
+    tmp_path,
+) -> None:
+    """The gateway is unreachable / advertises nothing: no evidence is not a
+    pass. Passing on no evidence is exactly how the broken box read green."""
+    c = da.check_hermes_anchor_window(
+        config_path=_hermes_config(tmp_path),
+        fetch=lambda *_a: (None, []),
+        slots_dir=tmp_path / "slots",
+        venv_python=tmp_path / "no-venv-python",
+    )
+    assert c.status == "warn"
+    assert "NOT a pass" in c.detail
+
+
+def test_anchor_window_passes_when_the_window_clears_the_floor(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    row = {"id": "agent", "owned_by": "hal0", "context_length": 65536}
+    c = da.check_hermes_anchor_window(
+        config_path=_hermes_config(tmp_path),
+        fetch=lambda *_a: ({**row, "id": "hal0/agent"}, [row]),
+        slots_dir=tmp_path / "slots",
+        venv_python=tmp_path / "no-venv-python",
+    )
+    assert c.status == "pass"
+    assert "65,536" in c.detail
+
+
+def test_anchor_window_warns_when_the_fetch_explodes(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def _boom(*_a):  # type: ignore[no-untyped-def]
+        raise RuntimeError("connection refused")
+
+    c = da.check_hermes_anchor_window(
+        config_path=_hermes_config(tmp_path),
+        fetch=_boom,
+        venv_python=tmp_path / "no-venv-python",
+    )
+    assert c.status == "warn"
+    assert "connection refused" in c.detail
+
+
 # ── build_all_checks orchestration ────────────────────────────────────────────
 
 
@@ -563,6 +678,13 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "check_hindsight_llm_auth",
         lambda **_kw: Check("hindsight_llm_auth", "Memory engine LLM auth", "pass", "stubbed"),
     )
+    monkeypatch.setattr(
+        da,
+        "check_hermes_anchor_window",
+        lambda **_kw: Check(
+            "hermes_anchor_window", "Hermes anchor context window", "pass", "stubbed"
+        ),
+    )
 
     # Stale-DNAT + netns rows (#1814) shell out to nft/podman otherwise;
     # neutralise both so this composition test asserts the row list.
@@ -577,8 +699,8 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
 
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 14 extras.
-    assert keys[-14:] == [
+    # 7 verify rows + 15 extras.
+    assert keys[-15:] == [
         "auth",
         "models",
         "migrations",
@@ -592,6 +714,7 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "seams",
         "mcp_mounts",
         "hermes_mcp_auth",
+        "hermes_anchor_window",
         "hindsight_llm_auth",
     ]
     assert "api" in keys and "runners" in keys

--- a/tests/install/test_static_seeds.py
+++ b/tests/install/test_static_seeds.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from hal0.agents.anchor_window import HERMES_MINIMUM_CONTEXT_LENGTH
 from hal0.install.brain_model import BRAIN_MODEL_IDS
 from hal0.install.static_seeds import STATIC_SEED_SLOTS, seed_static_slots
 from hal0.providers.container import _resolve_context_size
@@ -137,7 +138,8 @@ def test_seed_static_slots_default_args_seed_real_tree(tmp_path: Path) -> None:
 # so either half drifting back down fails here instead of on a box.
 
 #: ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH`` in the bundled Hermes.
-_HERMES_MIN_CONTEXT = 64_000
+#: Imported, not re-typed: hal0 keeps exactly one copy of this number (#1867).
+_HERMES_MIN_CONTEXT = HERMES_MINIMUM_CONTEXT_LENGTH
 
 #: Seeds the bundled Hermes agent can be pointed at: ``hal0/agent`` (which falls
 #: back to ``brain`` while the agent slot is model-less), ``hal0/brain``, and

--- a/tests/providers/test_container.py
+++ b/tests/providers/test_container.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hal0.agents.anchor_window import HERMES_MINIMUM_CONTEXT_LENGTH
 from hal0.config.schema import (
     FAMILY_DEFAULTS,
     MTP_FLAG_BUNDLE,
@@ -1375,7 +1376,8 @@ class TestContextSizeOwnership:
 #: Hermes' hard gate — ``agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH`` in the
 #: bundled agent. Below it the agent REFUSES TO START (``agent_init.py`` raises);
 #: it does not degrade, so a slot that lands under this is a cannot-chat box.
-_HERMES_MIN_CONTEXT = 64_000
+#: Imported, not re-typed: hal0 keeps exactly one copy of this number (#1867).
+_HERMES_MIN_CONTEXT = HERMES_MINIMUM_CONTEXT_LENGTH
 
 #: A curated brain pick whose catalogue row carries a ``context_length`` but
 #: whose registry row on an older-build box carries no ``metadata`` at all


### PR DESCRIPTION
## What

Preflights the context window behind Hermes' anchor model and fails loudly, with
both numbers and the repair command, when it is under Hermes' hard floor.

`Refs #1867` — this is the **first half** only. The upgrade-time reconciliation of
a slot seed the operator never chose (defect 1 in the issue) stays open.

## Why

Hermes raises below `agent/model_metadata.py::MINIMUM_CONTEXT_LENGTH` (64,000)
rather than degrading. A slot's effective window is
`min(model's declared window, slot's [model].context_size ceiling)`, so either
half can put a box under the floor. #1852 fixed the model side for fresh
installs; it cannot help the ct150 shape, where the model declares 96000 and the
agent slot's own ceiling is still the 4096 an older release seeded — a ceiling
only ever clamps down.

Nothing checked this before handing the anchor to Hermes, so the operator saw an
opaque upstream agent error ~1.6 s into every turn that named neither the slot
nor the ceiling behind it, and reasonably concluded rc.6 had not fixed #1827.

## What changed

- **New `hal0.agents.anchor_window`** — a pure, fully-injected resolver: anchor
  model id → effective window (from `GET /v1/models/{id}`, which resolves the
  routing fallback chain the same way chat dispatch does) → the slot the gateway
  actually served it from → that slot's on-disk ceiling → verdict
  (`ok` / `below_floor` / `unknown`) + an operator-facing message.
- **New `anchor_context_window` smoke probe** in `hermes_provision`, next to
  #1831's routability preflight. Below the floor it fails with:

  ```
  anchor 'hal0/agent' resolves to slot 'agent' with an effective context window
  of 4,096 tokens, below the 64,000 tokens Hermes requires — Hermes raises
  rather than degrading, so EVERY turn will fail until this is raised. The limit
  is this slot's own configured ceiling: [model].context_size = 4,096 in
  /etc/hal0/slots/agent.toml. Fix: hal0 slot edit agent --ctx-size 65536 &&
  hal0 slot restart agent
  ```

  When the ceiling is *not* the binding constraint the message blames the model
  instead and deliberately does **not** hand over the `--ctx-size` command,
  which would be useless advice there.
- **`unknown` is never a pass.** A window that cannot be read (nothing loaded,
  endpoint unreachable, a backend advertising no `context_length`) reports
  `skipped` — from the probe itself, not only from the install-time gate — and
  the message says in words that it is not a pass. The probe also joins
  `_MODEL_DEPENDENT_PROBES` so an install-time run skips before it dials.
- **A `hal0 doctor all` row (`hermes_anchor_window`).** `installer/install.sh`
  calls `install_hermes` only when the hermes venv is ABSENT ("covers the
  upgrade path where no provision ran"), so on an in-place upgrade — the one
  shape a stale `[model].context_size` survives in — no smoke test runs at all.
  Below the floor is a `fail` with the repair command; a window that cannot be
  read is a `warn`; an unprovisioned Hermes passes.
- **The floor is read FROM Hermes** — `read_hermes_minimum_context()` asks the
  provisioned Hermes venv's interpreter for its own `MINIMUM_CONTEXT_LENGTH`
  (Hermes is not importable from hal0's venv, so this is the only honest read)
  and degrades to one pinned constant with the reason recorded, which the message
  discloses. The two pre-existing test-side copies of `64_000` (#1827/#1852) now
  import that constant, and a drift test compares it against the real Hermes on
  any host with a provisioned venv.

## Explicitly out of scope

Automatically rewriting the operator's slot ceiling during an update. That is a
config mutation nobody has approved and is the other half of #1867.
`resolve_anchor_window` makes that repair easier when it is decided: it already
names the slot, its ceiling, and (via `recommended_ceiling`/`fix_command`) the
exact value the repair would write.

## Round 2 — the two blocking findings

**1. It never ran on the in-place-upgrade path.** `_phase_smoke_tests` is only
reachable from `install_hermes()`, which the installer skips when the hermes
venv already exists. Fixed by the `hal0 doctor all` row above — the tool an
operator reaches for when the agent misbehaves.

**2. It green-passed a box that genuinely cannot chat.** Reproduced on live
ct152 (rc.5): the agent slot is offline, so `hal0/agent` resolves through the
fallback chain to the **brain** slot's 32,768-token window (under the 64,000
floor), while `GET /v1/models` lists only `brain` and `utility` — no `agent`
row at all. The alias lookup found nothing, called the window `unknown`, and
returned `passed=True`.

Both halves are fixed: the window now comes from the by-id route, and the
serving slot is identified from the gateway's own construction (the by-id row
is the resolved slot's catalog row with `id` rewritten) rather than from the
anchor's spelling — so the fix command names `brain`, not the innocent
`agent.toml` sitting right next to it on that box. Where the slot is ambiguous
or unprovable there is no slot, no ceiling and no command. And `unknown` now
reports SKIPPED.

Codex's P1 is covered too: the anchor is asked of `model.base_url` (the
endpoint Hermes dispatches to) rather than a gateway catalog that deliberately
suppresses a pinned physical id, and a raw physical model id no longer derives
a slot TOML path that was never on the box.

## Verification

**Round 2.** The ct152 regression drives the real `_phase_smoke_tests` over
payloads captured verbatim from 10.0.1.152, so the expectation comes from the
live gateway, not from anything hal0's resolver computes. Against the code as
it stood before this round:

```
>       assert result["passed"] is not True, result  # the whole point of #1867
E       AssertionError: {'detail': "anchor 'hal0/agent' (slot 'agent') advertises
E         no context window right now — cannot check it against Hermes'
E         64,000-token floor", 'passed': True}
E       assert True is not True
FAILED tests/agents/test_hermes_provision.py::TestAnchorContextWindowPreflight::test_ct152_the_anchor_falls_back_to_another_slot_and_must_not_pass
FAILED tests/agents/test_hermes_provision.py::TestAnchorContextWindowPreflight::test_an_unreadable_window_skips_rather_than_passing
FAILED tests/agents/test_anchor_window.py::TestCt152FalseNegative::test_the_by_id_route_resolves_the_chain_and_names_the_serving_slot
FAILED tests/agents/test_anchor_window.py::TestCt152FalseNegative::test_a_virtual_is_never_named_from_its_spelling
FAILED tests/agents/test_anchor_window.py::TestCt152FalseNegative::test_two_identical_rows_are_ambiguous_not_a_coin_flip
5 failed, 1 passed
```

**Round 1.** Regression test run against **unfixed** code (`hermes_provision.py` reverted to
`github/main`, `anchor_window.py` removed):

```
    def test_a_slot_ceiling_under_the_floor_fails_loudly_with_the_fix(...):
        state = self._ct150_box(tmp_path, monkeypatch, slot_ceiling=4096, advertised=4096)
        out = hp._phase_smoke_tests(hp._StepCtx(state=state))
>       result = out.details["results"]["anchor_context_window"]
E       KeyError: 'anchor_context_window'
FAILED ...::test_a_slot_ceiling_under_the_floor_fails_loudly_with_the_fix
FAILED ...::test_a_ceiling_above_the_floor_passes
FAILED ...::test_no_routable_anchor_skips_instead_of_inventing_a_verdict
3 failed in 0.39s
```

With the fix: `tests/agents tests/install tests/providers` → 1476 passed,
1 skipped (the Hermes-venv drift check, absent on a dev host), 1 xfailed.
`ruff check` and `ruff format --check` clean; `mypy` clean on the new module.

The `TestAnchorContextWindowPreflight` tests drive the **real** `_phase_smoke_tests`
over a fake network and a real slot TOML on disk — no hand-stamped result shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

