### PR TITLE
fix(agents): self-heal the driver-env mode on an unprivileged provision

### DIFF
--- a/src/hal0/agents/hermes_provision.py
+++ b/src/hal0/agents/hermes_provision.py
@@ -5221,11 +5221,40 @@ def _write_driver_env(state: BootstrapState) -> tuple[Path, bool]:
         if unchanged:
             # Re-tighten perms even on a no-op content match — self-heals a
             # file written 0644 by an older build now that it may carry a
-            # secret. geteuid()==0 only; the seam path re-asserts 0600 on
-            # every write regardless (see installer/wrappers/hal0-agentenv).
+            # secret.
+            #
+            # Both privilege levels must heal here (issue #1876). Provisioning
+            # normally runs as `hal0`, NOT root (§7.4 F.7), so a root-only
+            # chmod healed exactly nothing on the population that needs it:
+            # an UPGRADED box hits `unchanged=True` on every reprovision and
+            # returned early with the stale 0644 intact, while a fresh install
+            # always takes the content-changing branch below (which pins 0600)
+            # and so looked fine. Unprivileged we cannot chmod a root:root
+            # file, so we re-drive the same `write-driver-env` seam verb with
+            # byte-identical content — the seam writes atomically (tmp + mv)
+            # and pins 0600 root:root, so the mode converges with no window in
+            # which the unit's EnvironmentFile is missing or partial.
+            #
+            # Reusing the existing verb rather than adding a `tighten-*` one is
+            # deliberate: it needs no new sudoers surface and it works against
+            # the hal0-agentenv wrapper already deployed on the old boxes that
+            # carry this defect.
             if os.geteuid() == 0:
                 with contextlib.suppress(OSError):
                     path.chmod(0o600)
+                return path, False
+            try:
+                mode = path.stat().st_mode & 0o777
+            except OSError:
+                mode = None
+            if mode == 0o600:
+                return path, False
+            log.info(
+                "hermes_provision.driver_env_perms_tightening",
+                path=str(path),
+                mode=None if mode is None else f"{mode:04o}",
+            )
+            _privileged_env_write("write-driver-env", body)
             return path, False
     if os.geteuid() == 0:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/agents/test_hermes_env_seam.py
+++ b/tests/agents/test_hermes_env_seam.py
@@ -208,6 +208,98 @@ def test_driver_env_self_heals_perms_on_content_match(
     assert (path.stat().st_mode & 0o777) == 0o600
 
 
+def _fake_agentenv_seam(target: Path):
+    """Stand-in for `sudo -n hal0-agentenv write-driver-env hermes`.
+
+    Mirrors the real wrapper's observable contract (installer/wrappers/
+    hal0-agentenv): write stdin to the driver path atomically and pin 0600.
+    Ownership is out of reach in a test, so only the mode is modelled.
+    """
+    calls: list[tuple[list[str], str]] = []
+
+    # `input` shadows the builtin on purpose — it is subprocess.run's kwarg name.
+    def _run(argv, *, input="", **_kw):
+        calls.append((list(argv), input))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        tmp = target.with_suffix(".seamtmp")
+        tmp.write_text(input, encoding="utf-8")
+        tmp.chmod(0o600)
+        tmp.replace(target)
+        return None
+
+    return calls, _run
+
+
+def test_driver_env_nonroot_self_heals_perms_on_content_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """THE regression shape for issue #1876: NON-root, content unchanged,
+    pre-existing mode 0644 → must end 0600.
+
+    This is the exact case an UPGRADED box hits on every reprovision, and the
+    only case the old code missed: provisioning runs as ``hal0``, so the
+    root-only ``path.chmod`` self-heal above never fired and the file kept a
+    world-readable ``HAL0_MCP_TOKEN``. A root-run test passes against the
+    broken code, which is why this survived — so this one must be non-root.
+    """
+    target = tmp_path / "agents" / "hermes.env"
+    target.parent.mkdir(parents=True)
+    monkeypatch.setattr(hp, "DRIVER_ENV_PATH", target)
+    monkeypatch.setattr(hp, "_HAL0_AGENTENV", "/usr/lib/hal0/bin/hal0-agentenv")
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "driver-env-admin-key")
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"), agent_id="hermes-agent")
+
+    # An older build's artifact: correct content, world-readable mode.
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    hp._write_driver_env(state)
+    target.chmod(0o644)
+    assert "HAL0_MCP_TOKEN=" in target.read_text()  # the file really carries a secret
+
+    # Now reprovision the way a real box does it: as the unprivileged hal0 user.
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+    calls, run = _fake_agentenv_seam(target)
+    monkeypatch.setattr(hp.subprocess, "run", run)
+    path, wrote = hp._write_driver_env(state)
+
+    assert wrote is False  # content unchanged — still the hash-skip branch
+    assert (path.stat().st_mode & 0o777) == 0o600
+    assert len(calls) == 1
+    argv, body = calls[0]
+    assert argv == [
+        "sudo",
+        "-n",
+        "/usr/lib/hal0/bin/hal0-agentenv",
+        "write-driver-env",
+        "hermes",
+    ]
+    assert "HAL0_MCP_TOKEN=" in body  # byte-identical re-drive, secret intact
+
+
+def test_driver_env_nonroot_skips_seam_when_mode_already_tight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-root + content unchanged + already 0600: stay a pure no-op.
+
+    The self-heal must not turn every reprovision into a sudo round-trip.
+    """
+    target = tmp_path / "agents" / "hermes.env"
+    target.parent.mkdir(parents=True)
+    monkeypatch.setattr(hp, "DRIVER_ENV_PATH", target)
+    monkeypatch.setenv("HAL0_ADMIN_KEY", "driver-env-admin-key")
+    state = hp.BootstrapState(hermes_home=str(tmp_path / "hh"), agent_id="hermes-agent")
+
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 0)
+    hp._write_driver_env(state)
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+    monkeypatch.setattr(hp.os, "geteuid", lambda: 1000)
+    with patch.object(hp.subprocess, "run") as run:
+        path, wrote = hp._write_driver_env(state)
+    run.assert_not_called()
+    assert wrote is False
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
 def test_driver_env_token_rotates_on_rerun(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A rotated HAL0_ADMIN_KEY reaches the next bootstrap/--repair run —
     same self-healing contract as the config.yaml bearer."""


### PR DESCRIPTION
## What

`/etc/hal0/agents/hermes.env` carries `HAL0_MCP_TOKEN`, a live bearer for the hal0-admin MCP surface. On any **upgraded** box it stayed mode **0644, world-readable**, and nothing re-tightened it.

`_write_driver_env` (`src/hal0/agents/hermes_provision.py`) re-tightened the mode on a no-op content match **only under `os.geteuid() == 0`**. Provisioning runs as the `hal0` user, not root (§7.4 F.7), so the exact case that needs healing — content already correct, mode wrong, running unprivileged — was the one case that silently did nothing, on every reprovision.

The changed-content branch was always fine: it delegates to `_privileged_env_write("write-driver-env", …)`, and the seam pins 0600. A fresh install always takes that branch; an upgrade always takes the hash-skip branch. The read-only fleet sweep in #1876 splits cleanly along exactly that line — every upgraded box 0644, every fresh install 0600.

## How

In the unprivileged skip branch: stat the file, and when the mode is not 0600, re-drive `_privileged_env_write("write-driver-env", body)` with byte-identical content.

**Why reuse the existing verb rather than add a `tighten-driver-env` one:** it needs no new sudoers surface, and it works against the `hal0-agentenv` wrapper *already deployed* on the old boxes that carry this defect — which is the whole affected population. The wrapper writes atomically (`mktemp` + `mv -f`) and pins 0600 root:root, so there is no window in which the unit's `EnvironmentFile=` is missing or partial. A file already at 0600 stays a pure no-op, so this does not add a sudo round-trip to every reprovision.

## Verification

The pre-existing regression test `test_driver_env_self_heals_perms_on_content_match` runs as **root** — it passes against the broken code. That is precisely why this survived. The new test reproduces the real shape: **non-root, content unchanged, mode 0644 → ends 0600**, with a stand-in for the seam that mirrors the real wrapper's contract.

Proven red before the fix (source change stashed, test present):

```
>       assert (path.stat().st_mode & 0o777) == 0o600
E       AssertionError: assert (33188 & 511) == 384
tests/agents/test_hermes_env_seam.py:264: AssertionError
FAILED tests/agents/test_hermes_env_seam.py::test_driver_env_nonroot_self_heals_perms_on_content_match
1 failed, 2 passed, 12 deselected
```

Green after: `tests/agents/test_hermes_env_seam.py` 15 passed; `tests/agents` 674 passed, 1 xfailed (pre-existing, unrelated — the `terminal.backend` deviation). `ruff check` and `ruff format --check` clean.

A second test pins the no-op: non-root + unchanged + already 0600 → the seam is not called.

## Sweep for the same pattern

The `hal0-agentenv` seam has exactly three verbs; I checked all of them.

- `write-driver-env` — the defect. Fixed here.
- `merge-secrets` (`/var/lib/hal0/secrets/agents/hermes.env`, credential-bearing) — **not affected.** `_write_secrets_env` has no unchanged/no-op branch; every call writes through, and both the root path (`_merge_env_file`, which chmods 0600 unconditionally as the owner) and the seam path pin 0600.
- `write-seed-toml` (`/etc/hal0/agents/hermes.toml`) — **not affected, and deliberately 0644.** It carries no secret values (`auth.env` names an env var, never the token). Its no-op branch (`has_seed and not repair`) returns early without any mode logic, which is consistent with its intended world-readable mode.

Wider `geteuid` sweep across `src/hal0`: the other root-gated blocks are not this defect class — they are chowns/cleanups on the genuinely-privileged updater side (`updater.py:1275`, `:3084`, `:3141`), or root-only hint text. `_write_runtime_json` chmods 0600 unconditionally (it is hal0-owned, in `$HERMES_HOME`); only its `chown` is root-gated, which is correct.

## Operator note

The repair only happens on reprovision. Existing boxes should be checked directly:

```
stat -c '%a' /etc/hal0/agents/hermes.env   # expect 600
```

Changelog line handed to the rc.6 section owner (#1860) rather than added here.

## Out of scope

Confidentiality of `api.env` / `upstreams.toml` under the `2775 hal0:hal0` `/etc/hal0` — the broader design question #1876 explicitly tracks separately. No box was mutated by this work; ct150 remains at 0644 as live evidence for the parallel session, as instructed.

Closes #1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)
