### PR TITLE
chore(security): document the bundled agent trust boundary for 1.0 (ADR-0002 Option C)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,8 +66,17 @@ the agent can `cat`. The axis that matters is which UID the agent runs as.
 
 This is the shipped default for hal0 1.0 and an accepted risk, disclosed here
 rather than papered over. Giving the agent its own system user with no sudoers
-grants — the change that actually closes the chain — is tracked for 1.1. The
-analysis, the evidence, and the rejected alternatives are in
+grants is tracked for 1.1, but a new `User=` alone does not close the chain:
+`/etc/hal0` is `hal0:hal0 2775` (setgid, see
+`hal0.install.perms.ownership_table()`), so a split agent left in the shared
+`hal0` *group* could still create or replace `hal0.toml`/`api.env` there —
+and an unreadable or malformed `hal0.toml` makes the API's own auth gate
+(`hal0.api.auth._config_require_auth()`) treat `require_auth` as unset and
+fall back to its OFF default, reopening the exact privileged-API path this
+document warns about. Closing the chain for 1.1 means the UID split *and*
+dropping the agent out of the `hal0` group / config-tree write access — not
+the UID split alone. The analysis, the evidence, and the rejected alternatives
+are in
 ADR-0002 — agent credential isolation, under review in
 [PR #1880](https://github.com/Hal0ai/hal0/pull/1880) and landing at
 `docs/adr/0002-agent-credential-isolation.md`. (Linked as a PR, not as a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,7 @@ injection from content it reads — it can reach every credential the box holds.
 | `User=hal0` (unprivileged, not root) | The agent is not UID 0; kernel-level and other-user data stay out of reach | Any separation from `hal0-api`, which is the same UID |
 | systemd sandboxing on the units (`ProtectSystem=strict`, `PrivateTmp`, restricted `ReadWritePaths=`) | Integrity: the agent cannot rewrite `/usr`, `/boot`, or most of `/etc` | Confidentiality of anything the `hal0` user may read, including `/proc` of same-UID processes |
 | `NoNewPrivileges=yes` on `hal0-agent@` | The agent's own processes cannot invoke the setuid `sudo` wrappers | Anything about `hal0-api`, which sets no such restriction and is reachable with the admin key the agent can read |
-| `0600 root:root` on `/etc/hal0/agents/<instance>.env` | The agent cannot read *another* agent's MCP token | Protection of `api.env`-sourced values, which are already in the API's environment |
+| `0600 root:root` on `/etc/hal0/agents/<instance>.env` | The agent cannot *open another instance's file*, and cannot create, replace or unlink one | Confidentiality of that instance's `HAL0_MCP_TOKEN`: with two agent instances running as the same user, either can read the other's `/proc/<pid>/environ`, so the file mode does not isolate the token itself |
 | Owner-only `0600` on `/etc/hal0/api.env` | Other local accounts cannot read it | Anything against the agent, which is the owner |
 
 Moving secrets into a `root:root 0600` file loaded by pid1 does **not** close

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,12 +24,16 @@ runs as. Two consequences follow, and neither is hypothetical:
   `PTRACE_MODE_READ_FSCREDS`, which a same-UID process passes. Yama's
   `kernel.yama.ptrace_scope` does not prevent it — that knob gates
   `PTRACE_MODE_ATTACH`, not same-UID reads. So every secret in the API's
-  environment (`HAL0_ADMIN_KEY`, provider API keys, `HF_TOKEN`, the agent's own
-  session token) is reachable by the agent regardless of the mode or ownership
-  of the file those values were loaded from. This has been verified on a live
-  box, not merely reasoned about.
+  environment (`HAL0_ADMIN_KEY`, provider API keys, `HF_TOKEN`) is reachable by
+  the agent regardless of the mode or ownership of the file those values were
+  loaded from. The chat-proxy session secret is not an API env var — it is a
+  file at `/var/lib/hal0/agents/secret.bin` (`0600`, owned by `hal0`) — but the
+  same same-UID logic applies to it too: the agent is the file's owner, so it
+  can simply read the file directly, no `/proc` trick required. This has been
+  verified on a live box, not merely reasoned about.
 - **The `hal0` account is root-equivalent by design.** The sudo grants hal0
-  installs (`hal0-systemctl`, `hal0-agentenv`, `hal0-benchctl`, `hal0-update`)
+  installs (`hal0-systemctl`, `hal0-agentenv`, `hal0-benchctl`, `hal0-podman-ro`,
+  `hal0-update`)
   are issued to the *user* `hal0`, which the agent also is. Slots run under
   rootful podman, so anything that can author a slot's `[Container]` spec can
   `Volume=`-mount arbitrary host paths — `installer/wrappers/hal0-systemctl`'s
@@ -49,7 +53,7 @@ injection from content it reads — it can reach every credential the box holds.
 | Control | Buys | Does not buy |
 | --- | --- | --- |
 | `User=hal0` (unprivileged, not root) | The agent is not UID 0; kernel-level and other-user data stay out of reach | Any separation from `hal0-api`, which is the same UID |
-| systemd sandboxing on the units (`ProtectSystem=strict`, `PrivateTmp`, restricted `ReadWritePaths=`) | Integrity: the agent cannot rewrite `/usr`, `/boot`, or most of `/etc` | Confidentiality of anything the `hal0` user may read, including `/proc` of same-UID processes |
+| systemd sandboxing on `hal0-agent@` (`ProtectSystem=strict`, `PrivateTmp`, restricted `ReadWritePaths=`) | Integrity: the agent cannot rewrite `/usr`, `/boot`, or most of `/etc` | Confidentiality of anything the `hal0` user may read, including `/proc` of same-UID processes; `hal0-api.service` sets none of these directives |
 | `NoNewPrivileges=yes` on `hal0-agent@` | The agent's own processes cannot invoke the setuid `sudo` wrappers | Anything about `hal0-api`, which sets no such restriction and is reachable with the admin key the agent can read |
 | `0600 root:root` on `/etc/hal0/agents/<instance>.env` | The agent cannot *open another instance's file*, and cannot create, replace or unlink one | Confidentiality of that instance's `HAL0_MCP_TOKEN`: with two agent instances running as the same user, either can read the other's `/proc/<pid>/environ`, so the file mode does not isolate the token itself |
 | Owner-only `0600` on `/etc/hal0/api.env` | Other local accounts cannot read it | Anything against the agent, which is the owner |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,72 @@ back-patched.
 | `main` (latest)| :white_check_mark: |
 | tagged alphas  | latest only        |
 
+## Bundled agent trust boundary
+
+**Treat the bundled agent as root-equivalent on the box it runs on.**
+
+hal0 ships a bundled agent (Hermes) provisioned with `terminal.backend = local`,
+so it can execute arbitrary shell commands on the host. It runs under
+`hal0-agent@<instance>.service` as `User=hal0` — the same user `hal0-api.service`
+runs as. Two consequences follow, and neither is hypothetical:
+
+- **Same UID means same credentials.** Reading `/proc/<pid>/environ` requires
+  `PTRACE_MODE_READ_FSCREDS`, which a same-UID process passes. Yama's
+  `kernel.yama.ptrace_scope` does not prevent it — that knob gates
+  `PTRACE_MODE_ATTACH`, not same-UID reads. So every secret in the API's
+  environment (`HAL0_ADMIN_KEY`, provider API keys, `HF_TOKEN`, the agent's own
+  session token) is reachable by the agent regardless of the mode or ownership
+  of the file those values were loaded from. This has been verified on a live
+  box, not merely reasoned about.
+- **The `hal0` account is root-equivalent by design.** The sudo grants hal0
+  installs (`hal0-systemctl`, `hal0-agentenv`, `hal0-benchctl`, `hal0-update`)
+  are issued to the *user* `hal0`, which the agent also is. Slots run under
+  rootful podman, so anything that can author a slot's `[Container]` spec can
+  `Volume=`-mount arbitrary host paths — `installer/wrappers/hal0-systemctl`'s
+  own "HONEST BOUNDARY" comment block has said so since #1740.
+
+  One honest qualifier: `hal0-agent@.service` sets `NoNewPrivileges=yes`, so a
+  process *inside the agent unit* cannot invoke those setuid `sudo` wrappers
+  directly. That is a real speed bump, not a boundary — `hal0-api.service` sets
+  no such restriction, and the admin key the agent can read out of the API's
+  `/proc/<pid>/environ` drives the same privileged paths through the API.
+
+Therefore: **if the agent can be made to run a command — including via prompt
+injection from content it reads — it can reach every credential the box holds.**
+
+### What the compensating controls do and do not buy
+
+| Control | Buys | Does not buy |
+| --- | --- | --- |
+| `User=hal0` (unprivileged, not root) | The agent is not UID 0; kernel-level and other-user data stay out of reach | Any separation from `hal0-api`, which is the same UID |
+| systemd sandboxing on the units (`ProtectSystem=strict`, `PrivateTmp`, restricted `ReadWritePaths=`) | Integrity: the agent cannot rewrite `/usr`, `/boot`, or most of `/etc` | Confidentiality of anything the `hal0` user may read, including `/proc` of same-UID processes |
+| `NoNewPrivileges=yes` on `hal0-agent@` | The agent's own processes cannot invoke the setuid `sudo` wrappers | Anything about `hal0-api`, which sets no such restriction and is reachable with the admin key the agent can read |
+| `0600 root:root` on `/etc/hal0/agents/<instance>.env` | The agent cannot read *another* agent's MCP token | Protection of `api.env`-sourced values, which are already in the API's environment |
+| Owner-only `0600` on `/etc/hal0/api.env` | Other local accounts cannot read it | Anything against the agent, which is the owner |
+
+Moving secrets into a `root:root 0600` file loaded by pid1 does **not** close
+this: it relocates the value from a file the agent can `cat` to a `/proc` node
+the agent can `cat`. The axis that matters is which UID the agent runs as.
+
+### Status: accepted, documented risk for 1.0
+
+This is the shipped default for hal0 1.0 and an accepted risk, disclosed here
+rather than papered over. Giving the agent its own system user with no sudoers
+grants — the change that actually closes the chain — is tracked for 1.1. The
+analysis, the evidence, and the rejected alternatives are in
+[ADR-0002 — agent credential isolation](docs/adr/0002-agent-credential-isolation.md)
+(proposed in [PR #1880](https://github.com/Hal0ai/hal0/pull/1880)).
+
+`hal0 doctor` reports this posture directly: the **Agent UID split** row warns
+when an agent unit resolves to the same `User=` as `hal0-api.service`.
+
+### If you cannot accept it
+
+- Run the box without the bundled agent (do not install/enable `hal0-agent@*`), or
+- Do not give the agent a local shell (`terminal.backend` other than `local`), and
+- Do not feed the agent untrusted content on a box holding credentials you care
+  about, and do not reuse those credentials elsewhere.
+
 ## Reporting a Vulnerability
 
 **Please do not open a public GitHub issue for security vulnerabilities.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,8 +64,11 @@ This is the shipped default for hal0 1.0 and an accepted risk, disclosed here
 rather than papered over. Giving the agent its own system user with no sudoers
 grants — the change that actually closes the chain — is tracked for 1.1. The
 analysis, the evidence, and the rejected alternatives are in
-[ADR-0002 — agent credential isolation](docs/adr/0002-agent-credential-isolation.md)
-(proposed in [PR #1880](https://github.com/Hal0ai/hal0/pull/1880)).
+ADR-0002 — agent credential isolation, under review in
+[PR #1880](https://github.com/Hal0ai/hal0/pull/1880) and landing at
+`docs/adr/0002-agent-credential-isolation.md`. (Linked as a PR, not as a
+relative path, because the ADR is still a proposal awaiting an operator
+decision — a link that 404s in-tree would be worse than one extra click.)
 
 `hal0 doctor` reports this posture directly: the **Agent UID split** row warns
 when an agent unit resolves to the same `User=` as `hal0-api.service`.

--- a/installer/systemd/hal0-agent@.service
+++ b/installer/systemd/hal0-agent@.service
@@ -105,7 +105,7 @@ LogsDirectory=hal0
 #
 # Be honest about what the boundary buys. /etc/hal0 is hal0:hal0 2775 and
 # most of its contents are hal0-owned: api.env is 0600 hal0:hal0,
-# upstreams.toml 0644 hal0:hal0 — both readable AND rewritable by the
+# upstreams.toml 0640 hal0:hal0 — both readable AND rewritable by the
 # User=hal0 agent once the path is writable. There is no root-owned
 # tokens.toml / auth.toml gating anything; those files do not exist on any
 # box. Because the directory itself is hal0-owned and not sticky, the

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -81,20 +81,31 @@ def _hal0_toml_path() -> Path:
     return _config_path(ConfigFile.hal0)
 
 
+class ConfigSeedOwnershipError(RuntimeError):
+    """A freshly-seeded config file could not be chowned to the hal0 service account.
+
+    Raised by :func:`_fchown_to_service_owner` and left uncaught by
+    :func:`_seed_config_file` on purpose — the caller (``config edit``)
+    turns this into a loud, non-zero-exit error rather than silently
+    publishing a file the service account can't read (see both docstrings
+    for why that matters).
+    """
+
+
 def _fchown_to_service_owner(fd: int) -> None:
-    """Best-effort ``fchown`` a freshly-seeded config file's fd to hal0:hal0.
+    """``fchown`` a freshly-seeded config file's fd to hal0:hal0, or abort.
 
     Seeding at 0600/0640 (:data:`HAL0_TOML_SEED_MODE` /
     :data:`UPSTREAMS_TOML_MODE`) is only correct if the file ends up owned
     by the account those modes are meant to admit. ``hal0-api.service`` runs
     ``User=hal0``/``Group=hal0`` (``installer/install.sh``); left unhandled,
     ``sudo hal0 config edit`` — or any invocation by root, or by a third
-    unprivileged user — seeds a file the service account cannot open, and
-    ``load_hal0_config()``/``_config_require_auth()`` swallow that
-    ``PermissionError`` into a bare "unset", silently falling back to
-    ``require_auth`` OFF. The previous bare ``write_text`` at 0644 never hit
-    this because 0644 stays world-readable regardless of owner — the mode
-    fix alone introduced this gap (Codex review on a5f4fe5d).
+    unprivileged user in the ``hal0`` group — seeds a file the service
+    account cannot open, and ``load_hal0_config()``/``_config_require_auth()``
+    swallow that ``PermissionError`` into a bare "unset", silently falling
+    back to ``require_auth`` OFF. The previous bare ``write_text`` at 0644
+    never hit this because 0644 stays world-readable regardless of owner —
+    the mode fix alone introduced this gap (Codex review on a5f4fe5d).
 
     Only root can ``chown`` to an arbitrary uid; an unprivileged owner can
     at most ``chgrp`` to a group they already belong to. So:
@@ -102,25 +113,33 @@ def _fchown_to_service_owner(fd: int) -> None:
     - No system ``hal0`` account on this box (``pwd.getpwnam``/
       ``grp.getgrnam`` raise ``KeyError`` — the common case in a dev/CI
       sandbox with no hal0 service installed): nothing sensible to chown
-      to, skip.
+      to, and nothing is going to try reading this file as that user
+      either — skip silently, seed succeeds.
     - Invoking as the ``hal0`` service user already: ``os.fchown`` is a
       no-op modulo confirming the uid/gid, succeeds trivially.
     - Invoking as root (the ``sudo hal0 config edit`` case): chown
       succeeds, the canonical owner is applied.
-    - Invoking as any other unprivileged user: ``os.fchown`` raises
-      ``PermissionError``, caught and swallowed here. The seed is left
-      owned by the invoking user — a narrower, pre-existing-class gap
-      (the file didn't exist at all a moment ago) rather than a new one;
-      ``hal0 doctor perms --fix`` (root-gated) is the documented
-      remediation, same as any other ownership drift under ``/etc/hal0``.
+    - Invoking as any other unprivileged user — including one in the
+      ``hal0`` group, since group membership never lets you ``chown``
+      to a different owner: ``os.fchown`` raises ``OSError``
+      (``PermissionError`` is the common case; widened from that to
+      ``OSError`` on review, since a read-only mount raising ``EROFS``
+      deserves the identical loud abort, not a bare traceback). Raises
+      :class:`ConfigSeedOwnershipError` so the caller aborts the seed
+      outright instead of quietly publishing a file ``hal0-api`` can't
+      read — see :func:`_seed_config_file`.
     """
     try:
         uid = pwd.getpwnam(_SERVICE_USER).pw_uid
         gid = grp.getgrnam(_SERVICE_GROUP).gr_gid
     except KeyError:
         return
-    with contextlib.suppress(PermissionError):
+    try:
         os.fchown(fd, uid, gid)
+    except OSError as exc:
+        raise ConfigSeedOwnershipError(
+            f"could not chown to {_SERVICE_USER}:{_SERVICE_GROUP}: {exc}"
+        ) from exc
 
 
 def _seed_config_file(path: Path, content: str, mode: int) -> None:
@@ -137,6 +156,12 @@ def _seed_config_file(path: Path, content: str, mode: int) -> None:
     the CLI, silently widening a file whose canonical mode is 0600/0640 and
     whose canonical owner is the ``hal0`` service account, the moment it's
     created via ``edit`` rather than via the API's own writer.
+
+    Raises:
+        ConfigSeedOwnershipError: if a system ``hal0`` account exists but
+            the seed could not be chowned to it. The temp file is closed
+            and unlinked before this propagates — ``path`` is left exactly
+            as it was (absent), never published half-owned.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path: Path | None = None
@@ -233,24 +258,26 @@ def config_edit(
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
         if which == ConfigFile.hal0:
-            _seed_config_file(
-                path,
+            seed_content = (
                 "# hal0 configuration — see `hal0 config show` for the live shape.\n"
                 "[meta]\nschema_version = 1\n\n"
-                "[slots]\nport_range_start = 8081\nport_range_end = 8099\n",
-                HAL0_TOML_SEED_MODE,
+                "[slots]\nport_range_start = 8081\nport_range_end = 8099\n"
             )
+            seed_mode = HAL0_TOML_SEED_MODE
         elif which == ConfigFile.upstreams:
-            _seed_config_file(
-                path,
-                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n",
-                UPSTREAMS_TOML_MODE,
-            )
+            seed_content = f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n"
+            seed_mode = UPSTREAMS_TOML_MODE
         else:
-            _seed_config_file(
-                path,
-                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n",
-                PROVIDERS_TOML_SEED_MODE,
+            seed_content = f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n"
+            seed_mode = PROVIDERS_TOML_SEED_MODE
+        try:
+            _seed_config_file(path, seed_content, seed_mode)
+        except ConfigSeedOwnershipError as exc:
+            die(
+                f"cannot seed {path}: {exc}. This box has a hal0 service "
+                "account, and hal0-api (User=hal0) would not be able to read "
+                "a seed owned by you at this file's canonical mode. Re-run "
+                "with [bold]sudo[/bold] so the seed lands hal0-owned."
             )
     try:
         subprocess.run([editor, str(path)], check=True)

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -7,6 +7,7 @@ import json as jsonlib
 import os
 import stat
 import subprocess
+import tempfile
 from enum import StrEnum
 from pathlib import Path
 
@@ -16,6 +17,19 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 
 from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, die
+from hal0.config.paths import UPSTREAMS_TOML_MODE
+
+#: Canonical mode for a freshly-seeded hal0.toml — matches perms.py's
+#: PermRow for the file. No shared constant exists yet (perms.py inlines
+#: the literal too); this comment is the cross-reference.
+HAL0_TOML_SEED_MODE = 0o600
+
+#: Canonical mode for a freshly-seeded providers.toml. save_providers_config's
+#: atomic rewrite passes no explicit mode to write_toml_atomic, so
+#: tempfile.mkstemp's own default (0600) is what "canonical" already means
+#: for this file — matched here so the seed doesn't drift from the first
+#: real write.
+PROVIDERS_TOML_SEED_MODE = 0o600
 
 app = typer.Typer(help="Inspect and manage hal0 configuration.")
 console = Console()
@@ -54,6 +68,42 @@ def _config_path(which: ConfigFile) -> Path:
 def _hal0_toml_path() -> Path:
     """Return the on-disk hal0.toml path, honouring HAL0_HOME."""
     return _config_path(ConfigFile.hal0)
+
+
+def _seed_config_file(path: Path, content: str, mode: int) -> None:
+    """Atomically create *path* with *content*, at its canonical *mode*.
+
+    Mirrors ``hal0.config.loader.write_toml_atomic``'s fchmod-before-rename
+    pattern (tempfile.mkstemp + os.fchmod on the owned descriptor +
+    os.replace), but for the raw commented-TOML text `config edit` seeds a
+    missing file with — that text isn't a TOML-encodable dict, so
+    ``write_toml_atomic`` itself can't be reused directly. A bare
+    ``Path.write_text`` would instead go through ``open()``'s 0644 default
+    (mediated by the process umask), silently widening a file whose
+    canonical mode is 0600/0640 the moment it's created via ``edit`` rather
+    than via the API's own writer.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        fd, tmp_str = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        tmp_path = Path(tmp_str)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                os.fchmod(f.fileno(), mode)
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+        except BaseException:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+            raise
+        os.replace(tmp_path, path)
+        tmp_path = None  # rename succeeded; don't clean up in finally
+    finally:
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
 
 
 @app.command("show")
@@ -127,14 +177,24 @@ def config_edit(
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
         if which == ConfigFile.hal0:
-            path.write_text(
+            _seed_config_file(
+                path,
                 "# hal0 configuration — see `hal0 config show` for the live shape.\n"
                 "[meta]\nschema_version = 1\n\n"
-                "[slots]\nport_range_start = 8081\nport_range_end = 8099\n"
+                "[slots]\nport_range_start = 8081\nport_range_end = 8099\n",
+                HAL0_TOML_SEED_MODE,
+            )
+        elif which == ConfigFile.upstreams:
+            _seed_config_file(
+                path,
+                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n",
+                UPSTREAMS_TOML_MODE,
             )
         else:
-            path.write_text(
-                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n"
+            _seed_config_file(
+                path,
+                f"# hal0 {which.value} configuration — created by `hal0 config edit`.\n",
+                PROVIDERS_TOML_SEED_MODE,
             )
     try:
         subprocess.run([editor, str(path)], check=True)

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import grp
 import json as jsonlib
 import os
+import pwd
 import stat
 import subprocess
 import tempfile
@@ -30,6 +32,15 @@ HAL0_TOML_SEED_MODE = 0o600
 #: for this file — matched here so the seed doesn't drift from the first
 #: real write.
 PROVIDERS_TOML_SEED_MODE = 0o600
+
+#: Service account a freshly-seeded config file should end up owned by, so
+#: hal0-api.service (``User=hal0``/``Group=hal0``) can actually read it.
+#: Mirrors ``hal0.install.perms.ownership_table()``'s ``service_user`` /
+#: ``service_group`` defaults — the single source of truth for hal0 path
+#: ownership — without importing that module here (it pulls in the full
+#: installer surface for one pair of names).
+_SERVICE_USER = "hal0"
+_SERVICE_GROUP = "hal0"
 
 app = typer.Typer(help="Inspect and manage hal0 configuration.")
 console = Console()
@@ -70,18 +81,62 @@ def _hal0_toml_path() -> Path:
     return _config_path(ConfigFile.hal0)
 
 
+def _fchown_to_service_owner(fd: int) -> None:
+    """Best-effort ``fchown`` a freshly-seeded config file's fd to hal0:hal0.
+
+    Seeding at 0600/0640 (:data:`HAL0_TOML_SEED_MODE` /
+    :data:`UPSTREAMS_TOML_MODE`) is only correct if the file ends up owned
+    by the account those modes are meant to admit. ``hal0-api.service`` runs
+    ``User=hal0``/``Group=hal0`` (``installer/install.sh``); left unhandled,
+    ``sudo hal0 config edit`` — or any invocation by root, or by a third
+    unprivileged user — seeds a file the service account cannot open, and
+    ``load_hal0_config()``/``_config_require_auth()`` swallow that
+    ``PermissionError`` into a bare "unset", silently falling back to
+    ``require_auth`` OFF. The previous bare ``write_text`` at 0644 never hit
+    this because 0644 stays world-readable regardless of owner — the mode
+    fix alone introduced this gap (Codex review on a5f4fe5d).
+
+    Only root can ``chown`` to an arbitrary uid; an unprivileged owner can
+    at most ``chgrp`` to a group they already belong to. So:
+
+    - No system ``hal0`` account on this box (``pwd.getpwnam``/
+      ``grp.getgrnam`` raise ``KeyError`` — the common case in a dev/CI
+      sandbox with no hal0 service installed): nothing sensible to chown
+      to, skip.
+    - Invoking as the ``hal0`` service user already: ``os.fchown`` is a
+      no-op modulo confirming the uid/gid, succeeds trivially.
+    - Invoking as root (the ``sudo hal0 config edit`` case): chown
+      succeeds, the canonical owner is applied.
+    - Invoking as any other unprivileged user: ``os.fchown`` raises
+      ``PermissionError``, caught and swallowed here. The seed is left
+      owned by the invoking user — a narrower, pre-existing-class gap
+      (the file didn't exist at all a moment ago) rather than a new one;
+      ``hal0 doctor perms --fix`` (root-gated) is the documented
+      remediation, same as any other ownership drift under ``/etc/hal0``.
+    """
+    try:
+        uid = pwd.getpwnam(_SERVICE_USER).pw_uid
+        gid = grp.getgrnam(_SERVICE_GROUP).gr_gid
+    except KeyError:
+        return
+    with contextlib.suppress(PermissionError):
+        os.fchown(fd, uid, gid)
+
+
 def _seed_config_file(path: Path, content: str, mode: int) -> None:
-    """Atomically create *path* with *content*, at its canonical *mode*.
+    """Atomically create *path* with *content*, at its canonical *mode* and
+    owner.
 
     Mirrors ``hal0.config.loader.write_toml_atomic``'s fchmod-before-rename
-    pattern (tempfile.mkstemp + os.fchmod on the owned descriptor +
-    os.replace), but for the raw commented-TOML text `config edit` seeds a
+    pattern (tempfile.mkstemp + os.fchmod/os.fchown on the owned descriptor
+    + os.replace), but for the raw commented-TOML text `config edit` seeds a
     missing file with — that text isn't a TOML-encodable dict, so
     ``write_toml_atomic`` itself can't be reused directly. A bare
     ``Path.write_text`` would instead go through ``open()``'s 0644 default
-    (mediated by the process umask), silently widening a file whose
-    canonical mode is 0600/0640 the moment it's created via ``edit`` rather
-    than via the API's own writer.
+    (mediated by the process umask) and leave the file owned by whoever ran
+    the CLI, silently widening a file whose canonical mode is 0600/0640 and
+    whose canonical owner is the ``hal0`` service account, the moment it's
+    created via ``edit`` rather than via the API's own writer.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path: Path | None = None
@@ -91,6 +146,7 @@ def _seed_config_file(path: Path, content: str, mode: int) -> None:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 os.fchmod(f.fileno(), mode)
+                _fchown_to_service_owner(f.fileno())
                 f.write(content)
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -70,17 +70,24 @@ def config_show(
     # Translate PermissionError into a clear hint — pre-v0.1.3 installs
     # left /etc/hal0 mode 0700 in some umask-tightened environments,
     # which makes `hal0 config show` from a non-root shell explode with
-    # a raw Python traceback. Re-run under sudo or chmod the config tree
-    # 0755/0644 (the installer does this for fresh installs as of
-    # v0.1.3).
+    # a raw Python traceback.
+    #
+    # The remedy is sudo, or membership of the `hal0` group — deliberately NOT
+    # `chmod 0644`, which this hint used to recommend. Every file under
+    # /etc/hal0 is either secret-bearing (api.env, hal0.toml, slots/*.toml) or
+    # inventory the box has no reason to publish to every local account
+    # (upstreams.toml, ADR-0002); telling an operator to widen it is telling
+    # them to undo `hal0 doctor perms`, which converges the mode straight back.
     try:
         body = path.read_text()
     except PermissionError as exc:
         console.print(f"[red]Permission denied:[/red] {path}")
         console.print(
-            "[dim]The config is owned by root. Re-run with [bold]sudo[/bold], "
-            "or run [bold]sudo chmod 0755 /etc/hal0 && sudo chmod 0644 "
-            f"{path}[/bold] once and the command will work without sudo.[/dim]"
+            "[dim]The config is owned by the service account. Re-run with "
+            "[bold]sudo[/bold], or add yourself to the [bold]hal0[/bold] group "
+            "([bold]sudo usermod -aG hal0 $USER[/bold], then re-login). Do not "
+            "chmod it world-readable — /etc/hal0 holds credentials and provider "
+            "inventory, and `hal0 doctor perms` re-tightens it anyway.[/dim]"
         )
         raise typer.Exit(1) from exc
     console.print(

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import json as jsonlib
 import os
+import stat
 import subprocess
 from enum import StrEnum
 from pathlib import Path
@@ -72,21 +74,33 @@ def config_show(
     # which makes `hal0 config show` from a non-root shell explode with
     # a raw Python traceback.
     #
-    # The remedy is sudo, or membership of the `hal0` group — deliberately NOT
-    # `chmod 0644`, which this hint used to recommend. Every file under
-    # /etc/hal0 is either secret-bearing (api.env, hal0.toml, slots/*.toml) or
-    # inventory the box has no reason to publish to every local account
-    # (upstreams.toml, ADR-0002); telling an operator to widen it is telling
-    # them to undo `hal0 doctor perms`, which converges the mode straight back.
+    # The remedy is sudo — deliberately NOT `chmod 0644`, which this hint used
+    # to recommend. Every file under /etc/hal0 is either secret-bearing
+    # (api.env, hal0.toml, slots/*.toml) or inventory the box has no reason to
+    # publish to every local account (upstreams.toml, ADR-0002); telling an
+    # operator to widen it is telling them to undo `hal0 doctor perms`, which
+    # converges the mode straight back.
+    #
+    # Group membership is offered ONLY when this file actually grants group
+    # read: hal0.toml is 0600 by design, so "join the hal0 group" would send an
+    # operator through a re-login to hit the identical error.
     try:
         body = path.read_text()
     except PermissionError as exc:
         console.print(f"[red]Permission denied:[/red] {path}")
+        group_readable = False
+        with contextlib.suppress(OSError):
+            group_readable = bool(path.stat().st_mode & stat.S_IRGRP)
+        remedy = (
+            "Re-run with [bold]sudo[/bold], or add yourself to the file's group "
+            "([bold]sudo usermod -aG hal0 $USER[/bold], then re-login)."
+            if group_readable
+            else "Re-run with [bold]sudo[/bold] — this file is owner-only by design, "
+            "so group membership will not help."
+        )
         console.print(
-            "[dim]The config is owned by the service account. Re-run with "
-            "[bold]sudo[/bold], or add yourself to the [bold]hal0[/bold] group "
-            "([bold]sudo usermod -aG hal0 $USER[/bold], then re-login). Do not "
-            "chmod it world-readable — /etc/hal0 holds credentials and provider "
+            f"[dim]The config is owned by the service account. {remedy} Do not "
+            "widen it with chmod — /etc/hal0 holds credentials and provider "
             "inventory, and `hal0 doctor perms` re-tightens it anyway.[/dim]"
         )
         raise typer.Exit(1) from exc

--- a/src/hal0/cli/config_commands.py
+++ b/src/hal0/cli/config_commands.py
@@ -19,6 +19,7 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 
 from hal0.cli._shared import CliApiError, _api_base, _api_unreachable, api_get, die
+from hal0.config import paths as _config_paths
 from hal0.config.paths import UPSTREAMS_TOML_MODE
 
 #: Canonical mode for a freshly-seeded hal0.toml — matches perms.py's
@@ -107,14 +108,24 @@ def _fchown_to_service_owner(fd: int) -> None:
     never hit this because 0644 stays world-readable regardless of owner —
     the mode fix alone introduced this gap (Codex review on a5f4fe5d).
 
+    Only enforced against the REAL ``/etc/hal0`` — a HAL0_HOME sandbox is
+    never actually the tree ``hal0-api.service`` reads, so there is no real
+    ownership requirement to enforce there regardless of whether this
+    particular host happens to have a system ``hal0`` account. (hal0's own
+    dev/CI boxes do, since hal0 also runs on them for real — keying this
+    off "does a hal0 account exist" instead of "is this the real
+    ``/etc/hal0``" made ``HAL0_HOME=$(mktemp -d) hal0 config edit`` die with
+    the sudo hint on every one of those boxes, a regression caught on
+    review of commit ca3295ff.)
+
     Only root can ``chown`` to an arbitrary uid; an unprivileged owner can
-    at most ``chgrp`` to a group they already belong to. So:
+    at most ``chgrp`` to a group they already belong to. So, once we know
+    we're targeting the real ``/etc/hal0``:
 
     - No system ``hal0`` account on this box (``pwd.getpwnam``/
-      ``grp.getgrnam`` raise ``KeyError`` — the common case in a dev/CI
-      sandbox with no hal0 service installed): nothing sensible to chown
-      to, and nothing is going to try reading this file as that user
-      either — skip silently, seed succeeds.
+      ``grp.getgrnam`` raise ``KeyError`` — a hal0 install that hasn't
+      created its service account yet): nothing sensible to chown to,
+      skip silently, seed succeeds.
     - Invoking as the ``hal0`` service user already: ``os.fchown`` is a
       no-op modulo confirming the uid/gid, succeeds trivially.
     - Invoking as root (the ``sudo hal0 config edit`` case): chown
@@ -129,6 +140,8 @@ def _fchown_to_service_owner(fd: int) -> None:
       outright instead of quietly publishing a file ``hal0-api`` can't
       read — see :func:`_seed_config_file`.
     """
+    if _config_paths.etc() != Path("/etc/hal0"):
+        return
     try:
         uid = pwd.getpwnam(_SERVICE_USER).pw_uid
         gid = grp.getgrnam(_SERVICE_GROUP).gr_gid

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -211,14 +211,20 @@ def _provisioned_agent_units(unit_dir: Path | None = None) -> list[str]:
 
     ``systemctl list-units`` reports units *in memory*, and the ``.wants``
     symlinks only cover *enabled* instances — but ``hal0 agent disable`` stops
-    and disables an instance without removing its drop-in, its env file or its
-    config, and ``hal0 agent start`` brings it straight back. That instance is
-    still the boundary this row reports on, so discovery also reads the
-    persistent artifacts:
+    and disables an instance without removing its env file or its config, and
+    ``hal0 agent start`` brings it straight back. That instance is still the
+    boundary this row reports on, so discovery also reads the install-state
+    artifacts:
 
     * ``<unit_dir>/*.target.wants/hal0-agent@*.service`` — enable symlinks
-    * ``<unit_dir>/hal0-agent@<i>.service.d/`` — per-instance drop-in dirs
-    * ``/etc/hal0/agents/<i>.{toml,env}`` — per-instance config / env
+    * ``/etc/hal0/agents/<i>.{toml,env}`` — per-instance config / env, written
+      by provisioning
+
+    Deliberately **not** the ``hal0-agent@<i>.service.d/`` drop-in dirs:
+    ``installer/install.sh`` lays down ``hal0-agent@hermes.service.d/`` on every
+    install "whether or not bootstrap has been run", so a box installed with the
+    documented ``HAL0_SKIP_HERMES=1`` escape hatch has the drop-in and no agent.
+    Counting it would warn about an agent the operator deliberately declined.
 
     Best effort: an unreadable directory contributes nothing rather than
     raising. Callers treat "found nothing anywhere" as no agent only when the
@@ -229,9 +235,6 @@ def _provisioned_agent_units(unit_dir: Path | None = None) -> list[str]:
     with contextlib.suppress(OSError):
         for wants in sorted(root.glob("*.target.wants")):
             names.update(p.name for p in wants.glob(_AGENT_UNIT_GLOB))
-    with contextlib.suppress(OSError):
-        for dropin in root.glob("hal0-agent@*.service.d"):
-            names.add(dropin.name[: -len(".d")])
     with contextlib.suppress(OSError):
         for cfg in paths.agents_config_dir().iterdir():
             if cfg.suffix in (".toml", ".env") and cfg.stem:
@@ -338,7 +341,7 @@ def check_agent_uid_isolation(
             f"{', '.join(shared)} runs as the same user as {_API_UNIT} — {who} — so the "
             "bundled agent's shell can read the API's /proc/<pid>/environ and every credential "
             "in it — accepted, documented 1.0 posture; see SECURITY.md 'Bundled agent trust "
-            "boundary' and docs/adr/0002-agent-credential-isolation.md",
+            "boundary' (ADR-0002)",
         )
     if unknown:
         return Check(

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -28,6 +28,7 @@ own repair. Exit codes:
 
 from __future__ import annotations
 
+import contextlib
 import json as jsonlib
 import pwd
 import shutil
@@ -164,8 +165,9 @@ def _agent_units() -> list[str] | None:
       ``--all`` adds inactive-but-loaded ones, not an instance that was stopped
       and unloaded. That instance is still installed and still the boundary
       this row exists to report on.
-    * enable symlinks under ``<unit_dir>/multi-user.target.wants/`` survive an
-      unload, so an enabled-but-unloaded instance is found there.
+    * the persistent artifacts an instance leaves on disk (enable symlink,
+      drop-in dir, per-agent config/env) survive both an unload and a
+      ``hal0 agent disable`` — see :func:`_provisioned_agent_units`.
 
     ``None`` is *unknown*, distinct from ``[]`` (definitively no agent): no
     ``systemctl`` on PATH, or the manager failed to answer. Collapsing the two
@@ -200,24 +202,41 @@ def _agent_units() -> list[str] | None:
         name = fields[0] if fields else ""
         if name.startswith("hal0-agent@") and name.endswith(".service"):
             units.add(name)
-    units |= set(_enabled_agent_units())
+    units |= set(_provisioned_agent_units())
     return sorted(units)
 
 
-def _enabled_agent_units(unit_dir: Path | None = None) -> list[str]:
-    """Enabled ``hal0-agent@*`` instances, from the ``.wants`` enable symlinks.
+def _provisioned_agent_units(unit_dir: Path | None = None) -> list[str]:
+    """Agent instances that exist on disk, whatever systemd currently has loaded.
 
-    Catches the instance systemd has unloaded (stopped, no drop-in touched
-    since), which ``list-units`` does not report at all.
+    ``systemctl list-units`` reports units *in memory*, and the ``.wants``
+    symlinks only cover *enabled* instances — but ``hal0 agent disable`` stops
+    and disables an instance without removing its drop-in, its env file or its
+    config, and ``hal0 agent start`` brings it straight back. That instance is
+    still the boundary this row reports on, so discovery also reads the
+    persistent artifacts:
+
+    * ``<unit_dir>/*.target.wants/hal0-agent@*.service`` — enable symlinks
+    * ``<unit_dir>/hal0-agent@<i>.service.d/`` — per-instance drop-in dirs
+    * ``/etc/hal0/agents/<i>.{toml,env}`` — per-instance config / env
+
+    Best effort: an unreadable directory contributes nothing rather than
+    raising. Callers treat "found nothing anywhere" as no agent only when the
+    systemd probe *also* answered cleanly.
     """
     root = unit_dir if unit_dir is not None else Path("/etc/systemd/system")
-    found: list[str] = []
-    try:
+    names: set[str] = set()
+    with contextlib.suppress(OSError):
         for wants in sorted(root.glob("*.target.wants")):
-            found.extend(p.name for p in sorted(wants.glob(_AGENT_UNIT_GLOB)))
-    except OSError:
-        return []
-    return found
+            names.update(p.name for p in wants.glob(_AGENT_UNIT_GLOB))
+    with contextlib.suppress(OSError):
+        for dropin in root.glob("hal0-agent@*.service.d"):
+            names.add(dropin.name[: -len(".d")])
+    with contextlib.suppress(OSError):
+        for cfg in paths.agents_config_dir().iterdir():
+            if cfg.suffix in (".toml", ".env") and cfg.stem:
+                names.add(f"hal0-agent@{cfg.stem}.service")
+    return sorted(names)
 
 
 def _resolve_uid(user: str) -> int | None:

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -29,6 +29,7 @@ own repair. Exit codes:
 from __future__ import annotations
 
 import json as jsonlib
+import pwd
 import shutil
 import stat
 import subprocess
@@ -153,10 +154,25 @@ def _unit_user(unit: str) -> str | None:
     return result.stdout.strip() or "root"
 
 
-def _agent_units() -> list[str]:
-    """Installed/loaded ``hal0-agent@<instance>.service`` units, best effort."""
+def _agent_units() -> list[str] | None:
+    """Provisioned ``hal0-agent@<instance>.service`` units, or ``None`` if unknown.
+
+    Two sources, unioned, because neither alone answers "is a bundled agent
+    installed on this box":
+
+    * ``systemctl list-units --all`` only lists units currently *in memory* —
+      ``--all`` adds inactive-but-loaded ones, not an instance that was stopped
+      and unloaded. That instance is still installed and still the boundary
+      this row exists to report on.
+    * enable symlinks under ``<unit_dir>/multi-user.target.wants/`` survive an
+      unload, so an enabled-but-unloaded instance is found there.
+
+    ``None`` is *unknown*, distinct from ``[]`` (definitively no agent): no
+    ``systemctl`` on PATH, or the manager failed to answer. Collapsing the two
+    would turn a transient systemd error into a clean row.
+    """
     if shutil.which("systemctl") is None:
-        return []
+        return None
     try:
         result = subprocess.run(  # nosec B603 B607
             [
@@ -175,21 +191,50 @@ def _agent_units() -> list[str]:
             timeout=5,
         )
     except (OSError, subprocess.SubprocessError):
-        return []
+        return None
     if result.returncode != 0:
-        return []
-    units: list[str] = []
+        return None
+    units: set[str] = set()
     for line in result.stdout.splitlines():
-        name = line.split(maxsplit=1)[0] if line.split() else ""
+        fields = line.split()
+        name = fields[0] if fields else ""
         if name.startswith("hal0-agent@") and name.endswith(".service"):
-            units.append(name)
-    return units
+            units.add(name)
+    units |= set(_enabled_agent_units())
+    return sorted(units)
+
+
+def _enabled_agent_units(unit_dir: Path | None = None) -> list[str]:
+    """Enabled ``hal0-agent@*`` instances, from the ``.wants`` enable symlinks.
+
+    Catches the instance systemd has unloaded (stopped, no drop-in touched
+    since), which ``list-units`` does not report at all.
+    """
+    root = unit_dir if unit_dir is not None else Path("/etc/systemd/system")
+    found: list[str] = []
+    try:
+        for wants in sorted(root.glob("*.target.wants")):
+            found.extend(p.name for p in sorted(wants.glob(_AGENT_UNIT_GLOB)))
+    except OSError:
+        return []
+    return found
+
+
+def _resolve_uid(user: str) -> int | None:
+    """``User=`` value → numeric uid. Accepts a name or a numeric literal."""
+    if user.isdigit():
+        return int(user)
+    try:
+        return pwd.getpwnam(user).pw_uid
+    except KeyError:
+        return None
 
 
 def check_agent_uid_isolation(
     *,
     unit_user: Callable[[str], str | None] | None = None,
-    agent_units: Callable[[], list[str]] | None = None,
+    agent_units: Callable[[], list[str] | None] | None = None,
+    resolve_uid: Callable[[str], int | None] | None = None,
 ) -> Check:
     """Does the bundled agent share ``hal0-api``'s UID? (ADR-0002, advisory.)
 
@@ -208,18 +253,31 @@ def check_agent_uid_isolation(
     reading ``hal0 doctor`` learns where the boundary is rather than inferring
     a boundary that is not there. ADR-0002 tracks the agent-UID split for 1.1.
 
-    Both probes are injectable so the classification is testable without
-    systemd (mirrors :func:`check_hal0_target`).
+    All three probes (unit discovery, ``User=`` lookup, uid resolution) are
+    injectable so the classification is testable without systemd or a real
+    passwd database (mirrors :func:`check_hal0_target`). Every "could not tell"
+    answer warns rather than passing: a row whose failure mode is a silent
+    all-clear would be worse than no row.
     """
     probe_user = unit_user if unit_user is not None else _unit_user
     probe_units = agent_units if agent_units is not None else _agent_units
+    probe_uid = resolve_uid if resolve_uid is not None else _resolve_uid
+
     units = probe_units()
+    if units is None:
+        return Check(
+            "agent-uid",
+            "Agent UID split",
+            _WARN,
+            "could not enumerate hal0-agent@* units (systemd unavailable or not answering) — "
+            "agent/API UID split unknown; see SECURITY.md 'Bundled agent trust boundary'",
+        )
     if not units:
         return Check(
             "agent-uid",
             "Agent UID split",
             _PASS,
-            "no hal0-agent@* unit installed — no bundled agent on this box",
+            "no bundled agent: no hal0-agent@* unit is installed on this box",
         )
     api_user = probe_user(_API_UNIT)
     if api_user is None:
@@ -230,20 +288,46 @@ def check_agent_uid_isolation(
             f"could not read User= for {_API_UNIT} — agent/API UID split unknown "
             "(see SECURITY.md 'Bundled agent trust boundary')",
         )
-    shared = []
+    api_uid = probe_uid(api_user)
+
+    shared: list[str] = []
+    unknown: list[str] = []
     for unit in units:
         agent_user = probe_user(unit)
-        if agent_user is not None and agent_user == api_user:
+        if agent_user is None:
+            unknown.append(unit)
+            continue
+        # Compare resolved UIDs when both sides resolve: a drop-in may spell one
+        # side numerically or via an alias account, and the kernel check this row
+        # audits is on the UID, not on the string in the unit file. Fall back to
+        # the strings only when a name does not resolve (e.g. a unit naming an
+        # account that does not exist on this box).
+        agent_uid = probe_uid(agent_user)
+        same = (
+            api_uid == agent_uid
+            if (api_uid is not None and agent_uid is not None)
+            else agent_user == api_user
+        )
+        if same:
             shared.append(unit)
     if shared:
+        who = f"{api_user} (uid {api_uid})" if api_uid is not None else api_user
         return Check(
             "agent-uid",
             "Agent UID split",
             _WARN,
-            f"{', '.join(shared)} runs as the same user as {_API_UNIT} ({api_user}), so the "
+            f"{', '.join(shared)} runs as the same user as {_API_UNIT} — {who} — so the "
             "bundled agent's shell can read the API's /proc/<pid>/environ and every credential "
             "in it — accepted, documented 1.0 posture; see SECURITY.md 'Bundled agent trust "
             "boundary' and docs/adr/0002-agent-credential-isolation.md",
+        )
+    if unknown:
+        return Check(
+            "agent-uid",
+            "Agent UID split",
+            _WARN,
+            f"could not read User= for {', '.join(unknown)} — cannot claim the agent runs "
+            "under its own UID; see SECURITY.md 'Bundled agent trust boundary'",
         )
     return Check(
         "agent-uid",

--- a/src/hal0/cli/doctor_all.py
+++ b/src/hal0/cli/doctor_all.py
@@ -12,7 +12,9 @@ OpenWebUI, Hermes), then adds the broader health rows the retrofit calls for:
 auth posture, model-store integrity, pending migrations, a stale-dashboard
 ``HAL0_UI_DIST`` override (#1589), bound slot ports, the ``hal0.target``
 boot-enable anchor (r5-sync-assessment §6.1), the privileged sudo seams
-every slot op + self-update runs through (#1465), and the context window behind
+every slot op + self-update runs through (#1465), whether the bundled agent
+shares ``hal0-api``'s UID (ADR-0002 — advisory, it is the shipped default),
+and the context window behind
 Hermes' anchor model (#1867 — the smoke probes never run on an in-place
 upgrade, which is the only shape that defect survives in).
 
@@ -120,6 +122,135 @@ def check_secret_file_modes() -> Check:
             critical=True,
         )
     return Check("secret-modes", "Secret file modes", _PASS, "secret files are owner-only")
+
+
+#: The API unit, and the agent template whose instances carry the bundled agent.
+_API_UNIT = "hal0-api.service"
+_AGENT_UNIT_GLOB = "hal0-agent@*.service"
+
+
+def _unit_user(unit: str) -> str | None:
+    """``systemctl show -p User --value <unit>`` → the effective ``User=``.
+
+    ``None`` means the question could not be asked (no ``systemctl``, unit
+    unknown); an empty ``User=`` means the unit runs as ``root``, which
+    systemd reports as the empty string, so that is normalised here.
+    """
+    if shutil.which("systemctl") is None:
+        return None
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["systemctl", "show", "-p", "User", "--value", unit],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or "root"
+
+
+def _agent_units() -> list[str]:
+    """Installed/loaded ``hal0-agent@<instance>.service`` units, best effort."""
+    if shutil.which("systemctl") is None:
+        return []
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            [
+                "systemctl",
+                "list-units",
+                "--all",
+                "--plain",
+                "--no-legend",
+                "--no-pager",
+                "--type=service",
+                _AGENT_UNIT_GLOB,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    units: list[str] = []
+    for line in result.stdout.splitlines():
+        name = line.split(maxsplit=1)[0] if line.split() else ""
+        if name.startswith("hal0-agent@") and name.endswith(".service"):
+            units.append(name)
+    return units
+
+
+def check_agent_uid_isolation(
+    *,
+    unit_user: Callable[[str], str | None] | None = None,
+    agent_units: Callable[[], list[str]] | None = None,
+) -> Check:
+    """Does the bundled agent share ``hal0-api``'s UID? (ADR-0002, advisory.)
+
+    ``hal0-api.service`` and ``hal0-agent@<instance>.service`` both ship with
+    ``User=hal0``. Same UID means the agent — which is provisioned with
+    ``terminal.backend = local`` and can therefore run shell commands — passes
+    ``PTRACE_MODE_READ_FSCREDS`` against the API process and can read
+    ``/proc/<pid>/environ``, i.e. every credential the API holds. Yama's
+    ``ptrace_scope`` does not stop this; it gates ``PTRACE_MODE_ATTACH``, not
+    same-UID reads. The ``hal0`` account additionally holds the sudo grants
+    that author rootful podman slot specs, so it is root-equivalent by design
+    (``installer/wrappers/hal0-systemctl``'s HONEST BOUNDARY block).
+
+    This is the **shipped 1.0 default** and an accepted, documented risk, so
+    the row is a ``warn``, never a ``fail``: it exists to make sure an operator
+    reading ``hal0 doctor`` learns where the boundary is rather than inferring
+    a boundary that is not there. ADR-0002 tracks the agent-UID split for 1.1.
+
+    Both probes are injectable so the classification is testable without
+    systemd (mirrors :func:`check_hal0_target`).
+    """
+    probe_user = unit_user if unit_user is not None else _unit_user
+    probe_units = agent_units if agent_units is not None else _agent_units
+    units = probe_units()
+    if not units:
+        return Check(
+            "agent-uid",
+            "Agent UID split",
+            _PASS,
+            "no hal0-agent@* unit installed — no bundled agent on this box",
+        )
+    api_user = probe_user(_API_UNIT)
+    if api_user is None:
+        return Check(
+            "agent-uid",
+            "Agent UID split",
+            _WARN,
+            f"could not read User= for {_API_UNIT} — agent/API UID split unknown "
+            "(see SECURITY.md 'Bundled agent trust boundary')",
+        )
+    shared = []
+    for unit in units:
+        agent_user = probe_user(unit)
+        if agent_user is not None and agent_user == api_user:
+            shared.append(unit)
+    if shared:
+        return Check(
+            "agent-uid",
+            "Agent UID split",
+            _WARN,
+            f"{', '.join(shared)} runs as the same user as {_API_UNIT} ({api_user}), so the "
+            "bundled agent's shell can read the API's /proc/<pid>/environ and every credential "
+            "in it — accepted, documented 1.0 posture; see SECURITY.md 'Bundled agent trust "
+            "boundary' and docs/adr/0002-agent-credential-isolation.md",
+        )
+    return Check(
+        "agent-uid",
+        "Agent UID split",
+        _PASS,
+        f"agent unit(s) run as a different user than {_API_UNIT} ({api_user})",
+    )
 
 
 def check_voice_stt_weights() -> Check:
@@ -903,6 +1034,7 @@ def build_all_checks(base: str | None = None) -> list[Check]:
         check_netns_durability(),
         check_hal0_target(),
         check_secret_file_modes(),
+        check_agent_uid_isolation(),
         check_voice_stt_weights(),
         check_seams(),
         check_mcp_mounts(),

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -75,7 +75,7 @@ class ConfigParseError(ConfigError):
 # ── Atomic TOML write ─────────────────────────────────────────────────────────
 
 
-def write_toml_atomic(path: Path | str, data: dict[str, Any]) -> None:
+def write_toml_atomic(path: Path | str, data: dict[str, Any], *, mode: int | None = None) -> None:
     """Write a TOML file atomically.
 
     Mirrors hal0.config.env.write_env_atomic but for TOML payloads:
@@ -86,6 +86,11 @@ def write_toml_atomic(path: Path | str, data: dict[str, Any]) -> None:
     Args:
         path: Destination path for the TOML file.
         data: Mapping that tomli_w.dump understands.
+        mode: Optional explicit mode for the result. ``tempfile.mkstemp``
+            creates the replacement 0600 and ``os.replace`` carries that mode
+            onto the destination, so a file whose canonical mode is anything
+            else drifts on every rewrite until ``doctor perms --fix`` runs.
+            Callers with a canonical mode pass it here.
 
     Raises:
         OSError: If the directory cannot be created, disk full, or the
@@ -112,6 +117,8 @@ def write_toml_atomic(path: Path | str, data: dict[str, Any]) -> None:
             with contextlib.suppress(OSError):
                 os.close(fd)
             raise
+        if mode is not None:
+            os.chmod(tmp_path, mode)  # before the rename: never a visible wrong mode
         os.replace(tmp_path, path)
         tmp_path = None  # rename succeeded; don't clean up in finally
     finally:
@@ -735,7 +742,11 @@ def save_upstreams_config(cfg: UpstreamsConfig, path: Path | None = None) -> Non
     unaffected: any field omitted on write is re-defaulted on read.
     """
     target = path if path is not None else paths.etc() / "upstreams.toml"
-    write_toml_atomic(target, cfg.model_dump(mode="python", exclude_none=True))
+    write_toml_atomic(
+        target,
+        cfg.model_dump(mode="python", exclude_none=True),
+        mode=paths.UPSTREAMS_TOML_MODE,
+    )
 
 
 # ── profiles.toml ─────────────────────────────────────────────────────────────

--- a/src/hal0/config/loader.py
+++ b/src/hal0/config/loader.py
@@ -110,6 +110,12 @@ def write_toml_atomic(path: Path | str, data: dict[str, Any], *, mode: int | Non
         tmp_path = Path(tmp_str)
         try:
             with os.fdopen(fd, "wb") as f:
+                # fchmod, not chmod: the mode is applied to the descriptor we
+                # already own, before the rename — so there is never a moment
+                # where the destination carries the wrong mode, and no second
+                # path lookup that a swapped tempfile could ride in on.
+                if mode is not None:
+                    os.fchmod(f.fileno(), mode)
                 tomli_w.dump(data, f)
                 f.flush()
                 os.fsync(f.fileno())
@@ -117,8 +123,6 @@ def write_toml_atomic(path: Path | str, data: dict[str, Any], *, mode: int | Non
             with contextlib.suppress(OSError):
                 os.close(fd)
             raise
-        if mode is not None:
-            os.chmod(tmp_path, mode)  # before the rename: never a visible wrong mode
         os.replace(tmp_path, path)
         tmp_path = None  # rename succeeded; don't clean up in finally
     finally:

--- a/src/hal0/config/paths.py
+++ b/src/hal0/config/paths.py
@@ -90,6 +90,20 @@ def etc() -> Path:
 #: becomes world-readable the moment a second account joins the group.
 API_ENV_MODE = 0o600
 
+#: Mode for ``/etc/hal0/upstreams.toml``.
+#:
+#: The file carries no credential *values* (``auth_value_env`` names a variable
+#: the upstream registry resolves from the environment at request time), but the
+#: provider/endpoint inventory it does carry is not public information — ADR-0002
+#: dropped it from 0644. 0640, not 0600: every consumer is ``hal0`` or root, and
+#: the group bit keeps an operator added to the ``hal0`` group able to read it.
+#:
+#: One constant, two writers: :mod:`hal0.install.perms` converges it and
+#: :func:`hal0.config.loader.save_upstreams_config` applies it on every atomic
+#: rewrite. api.env earned its comment above by having four disagreeing writers;
+#: this one starts with one number.
+UPSTREAMS_TOML_MODE = 0o640
+
 
 def api_env() -> Path:
     """Return the api.env path (/etc/hal0/api.env or the HAL0_HOME sandbox).

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -214,7 +214,14 @@ def ownership_table(
         # one.
         PermRow(etc / "update.conf", "root", "root", 0o644, role="update.conf"),
         PermRow(etc / "capabilities.toml", etc_owner, etc_group, 0o600, role="capabilities.toml"),
-        PermRow(etc / "upstreams.toml", etc_owner, etc_group, 0o644, role="upstreams.toml"),
+        # upstreams.toml holds no credential VALUES — `auth_value_env` names the
+        # variable and the registry resolves it from the process environment at
+        # request time (upstreams/registry.py). Its 0644 was therefore metadata
+        # disclosure, not credential exposure: the box's provider/endpoint
+        # inventory readable by every local account. 0640 keeps every real
+        # consumer working (hal0-api, hal0-agent@* and the CLI all run as
+        # hal0/root, group hal0) and drops the world bit (ADR-0002, Option C).
+        PermRow(etc / "upstreams.toml", etc_owner, etc_group, 0o640, role="upstreams.toml"),
         PermRow(paths.hardware_json(), etc_owner, etc_group, 0o644, role="hardware.json"),
         PermRow(paths.openwebui_env(), etc_owner, etc_group, 0o600, role="openwebui.env"),
         PermRow(

--- a/src/hal0/install/perms.py
+++ b/src/hal0/install/perms.py
@@ -221,7 +221,13 @@ def ownership_table(
         # inventory readable by every local account. 0640 keeps every real
         # consumer working (hal0-api, hal0-agent@* and the CLI all run as
         # hal0/root, group hal0) and drops the world bit (ADR-0002, Option C).
-        PermRow(etc / "upstreams.toml", etc_owner, etc_group, 0o640, role="upstreams.toml"),
+        PermRow(
+            etc / "upstreams.toml",
+            etc_owner,
+            etc_group,
+            paths.UPSTREAMS_TOML_MODE,
+            role="upstreams.toml",
+        ),
         PermRow(paths.hardware_json(), etc_owner, etc_group, 0o644, role="hardware.json"),
         PermRow(paths.openwebui_env(), etc_owner, etc_group, 0o600, role="openwebui.env"),
         PermRow(

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -70,3 +70,36 @@ def test_config_edit_upstreams_seeds_and_opens_upstreams_toml(monkeypatch, tmp_p
     assert seeded.exists()
     # hal0.toml's bespoke seed content must NOT leak into other files.
     assert "port_range_start" not in seeded.read_text()
+
+
+def test_permission_denied_hint_does_not_recommend_widening_the_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The remedy is sudo or group membership — never `chmod 0644`.
+
+    upstreams.toml is 0640 as of ADR-0002 (its provider inventory is not public
+    information). The old hint told an operator hitting PermissionError to
+    `sudo chmod 0644` the selected file, i.e. to undo that tightening by hand —
+    and `hal0 doctor perms` would then converge it back, so the advice was both
+    harmful and wrong. Asserts the rendered hint directly.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    target = cfg_dir / "upstreams.toml"
+    target.write_text("[[upstream]]\nname = 'demo'\n")
+
+    def _boom(*_a, **_k):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+
+    result = runner.invoke(config_commands.app, ["show", "upstreams"])
+
+    assert result.exit_code == 1, result.output
+    # Rich wraps the panel, so compare with all whitespace removed — a
+    # recommendation split across two lines is still a recommendation.
+    out = "".join(result.output.split())
+    assert "Permissiondenied" in out
+    assert "0644" not in out, f"hint still names a world-readable mode: {result.output}"
+    assert "sudochmod" not in out, f"hint still recommends a chmod: {result.output}"
+    assert "sudo" in out
+    assert "usermod-aGhal0" in out

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import stat
 from pathlib import Path
 
-import pytest
 from typer.testing import CliRunner
 
 from hal0.cli import config_commands
@@ -19,26 +18,19 @@ from hal0.cli import config_commands
 runner = CliRunner()
 
 
-@pytest.fixture(autouse=True)
-def _no_real_service_account(monkeypatch):
-    """Default every test in this file to "no system hal0 account" for
-    ``_seed_config_file``'s ownership step.
+def _simulate_real_etc_hal0(monkeypatch) -> None:
+    """Make ``_fchown_to_service_owner``'s "is this the real /etc/hal0?"
+    guard say yes, while file I/O still happens in the test's HAL0_HOME
+    sandbox.
 
-    A HAL0_HOME sandbox is never actually ``/etc/hal0`` — it's a throwaway
-    temp tree — so there is no real chown target, regardless of whether
-    *this* machine happens to have a system ``hal0`` account (hal0's own
-    dev/CI boxes do, since hal0 is genuinely installed on them). Without
-    this, seed tests would pass or fail depending on host state instead of
-    on the code under test. The tests that specifically exercise the
-    privileged/chown-denied paths override ``pwd.getpwnam``/
-    ``grp.getgrnam`` themselves, after this fixture runs.
+    Only the tests that specifically exercise the privileged/chown-denied
+    ownership paths need this — everything else should exercise the
+    ordinary "we're in a sandbox, skip ownership entirely" branch exactly
+    as production code does outside a real install, regardless of whether
+    this particular host happens to have a system ``hal0`` account (hal0's
+    own dev/CI boxes do, since hal0 also runs on them for real).
     """
-
-    def _no_such_account(name: str):
-        raise KeyError(name)
-
-    monkeypatch.setattr(config_commands.pwd, "getpwnam", _no_such_account)
-    monkeypatch.setattr(config_commands.grp, "getgrnam", _no_such_account)
+    monkeypatch.setattr(config_commands._config_paths, "etc", lambda: Path("/etc/hal0"))
 
 
 def _set_home(monkeypatch, tmp_path: Path) -> Path:
@@ -149,6 +141,7 @@ def test_config_edit_seed_chowns_to_service_owner_when_privileged(
     having a system ``hal0`` account.
     """
     _set_home(monkeypatch, tmp_path)
+    _simulate_real_etc_hal0(monkeypatch)
     monkeypatch.setenv("EDITOR", "true")
 
     class _FakePasswd:
@@ -183,6 +176,7 @@ def test_config_edit_seed_rejects_seed_when_chown_denied(monkeypatch, tmp_path: 
     and a message that tells the operator to re-run under sudo.
     """
     cfg_dir = _set_home(monkeypatch, tmp_path)
+    _simulate_real_etc_hal0(monkeypatch)
     monkeypatch.setenv("EDITOR", "true")
 
     class _FakePasswd:
@@ -211,6 +205,7 @@ def test_config_edit_seed_rejects_seed_on_other_oserror(monkeypatch, tmp_path: P
     abort, not an unhandled traceback.
     """
     cfg_dir = _set_home(monkeypatch, tmp_path)
+    _simulate_real_etc_hal0(monkeypatch)
     monkeypatch.setenv("EDITOR", "true")
 
     class _FakePasswd:
@@ -230,6 +225,33 @@ def test_config_edit_seed_rejects_seed_on_other_oserror(monkeypatch, tmp_path: P
     assert result.exit_code != 0
     assert not (cfg_dir / "upstreams.toml").exists()
     assert "sudo" in result.output
+
+
+def test_config_edit_seed_ignores_host_hal0_account_in_sandbox(monkeypatch, tmp_path: Path) -> None:
+    """A HAL0_HOME sandbox seed must succeed regardless of whether the real
+    host machine happens to have a system ``hal0`` account.
+
+    Deliberately does NOT monkeypatch ``pwd``/``grp``/``os.fchown``/``etc()``
+    — this exercises the actual ``pwd.getpwnam("hal0")`` lookup against
+    whatever this box really has. hal0's own dev/CI boxes genuinely install
+    a system ``hal0`` account (hal0 also runs on them for real), so on such
+    a box this is also a regression test for keying the ownership
+    requirement off "does a hal0 account exist" instead of "is this the
+    real /etc/hal0" (review finding on commit ca3295ff): that version
+    resolved the real ``hal0`` uid/gid, tried to ``fchown`` a HAL0_HOME
+    sandbox file to it, failed (the test process isn't root or ``hal0``),
+    and made this command die with the sudo hint for a throwaway temp tree
+    ``hal0-api`` will never read.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    result = runner.invoke(config_commands.app, ["edit", "upstreams"])
+    assert result.exit_code == 0, result.output
+    seeded = cfg_dir / "upstreams.toml"
+    assert seeded.exists()
+    mode = stat.S_IMODE(seeded.stat().st_mode)
+    assert mode == 0o640, f"expected upstreams.toml seeded at 0640, got {oct(mode)}"
 
 
 def test_permission_denied_hint_does_not_recommend_widening_the_file(

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -86,6 +86,7 @@ def test_permission_denied_hint_does_not_recommend_widening_the_file(
     cfg_dir = _set_home(monkeypatch, tmp_path)
     target = cfg_dir / "upstreams.toml"
     target.write_text("[[upstream]]\nname = 'demo'\n")
+    target.chmod(0o640)
 
     def _boom(*_a, **_k):
         raise PermissionError(13, "Permission denied")
@@ -103,3 +104,30 @@ def test_permission_denied_hint_does_not_recommend_widening_the_file(
     assert "sudochmod" not in out, f"hint still recommends a chmod: {result.output}"
     assert "sudo" in out
     assert "usermod-aGhal0" in out
+
+
+def test_permission_denied_hint_omits_group_advice_for_owner_only_files(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """hal0.toml is 0600 by design — "join the hal0 group" would not help.
+
+    Sending an operator through `usermod -aG` and a re-login only to hit the
+    identical error is worse than no advice, so the remedy is mode-aware.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    target = cfg_dir / "hal0.toml"
+    target.write_text("[meta]\nschema_version = 1\n")
+    target.chmod(0o600)
+
+    def _boom(*_a, **_k):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+
+    result = runner.invoke(config_commands.app, ["show"])
+
+    assert result.exit_code == 1, result.output
+    out = "".join(result.output.split())
+    assert "usermod" not in out, f"group advice on an owner-only file: {result.output}"
+    assert "sudo" in out
+    assert "owner-only" in out

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -8,6 +8,7 @@ error in upstreams.toml, there was no `edit`/`show` target for it.
 
 from __future__ import annotations
 
+import stat
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -70,6 +71,43 @@ def test_config_edit_upstreams_seeds_and_opens_upstreams_toml(monkeypatch, tmp_p
     assert seeded.exists()
     # hal0.toml's bespoke seed content must NOT leak into other files.
     assert "port_range_start" not in seeded.read_text()
+
+
+def test_config_edit_upstreams_seeds_at_canonical_mode(monkeypatch, tmp_path: Path) -> None:
+    """A freshly-seeded upstreams.toml must land at 0640, not the 0644 that a
+    bare ``Path.write_text`` produces.
+
+    ADR-0002 tightened upstreams.toml to 0640 (UPSTREAMS_TOML_MODE) precisely
+    because its provider/endpoint inventory is not public information —
+    `save_upstreams_config`'s atomic rewrite already honours that mode, but
+    `hal0 config edit upstreams` seeding a *missing* file went through a bare
+    `write_text`, which carries the process umask (typically 0644) instead.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    result = runner.invoke(config_commands.app, ["edit", "upstreams"])
+    assert result.exit_code == 0, result.output
+    seeded = cfg_dir / "upstreams.toml"
+    assert seeded.exists()
+    mode = stat.S_IMODE(seeded.stat().st_mode)
+    assert mode == 0o640, f"expected upstreams.toml seeded at 0640, got {oct(mode)}"
+
+
+def test_config_edit_hal0_seeds_at_canonical_mode(monkeypatch, tmp_path: Path) -> None:
+    """A freshly-seeded hal0.toml must land at 0600, matching perms.py's
+    canonical mode for the file — the same bare-``write_text`` gap as
+    upstreams.toml, pre-existing but fixed by the same change.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    result = runner.invoke(config_commands.app, ["edit", "hal0"])
+    assert result.exit_code == 0, result.output
+    seeded = cfg_dir / "hal0.toml"
+    assert seeded.exists()
+    mode = stat.S_IMODE(seeded.stat().st_mode)
+    assert mode == 0o600, f"expected hal0.toml seeded at 0600, got {oct(mode)}"
 
 
 def test_permission_denied_hint_does_not_recommend_widening_the_file(

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -110,6 +110,75 @@ def test_config_edit_hal0_seeds_at_canonical_mode(monkeypatch, tmp_path: Path) -
     assert mode == 0o600, f"expected hal0.toml seeded at 0600, got {oct(mode)}"
 
 
+def test_config_edit_seed_chowns_to_service_owner_when_privileged(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A seed written while running as root (e.g. ``sudo hal0 config edit``)
+    must land owned by the ``hal0`` service account, not root.
+
+    hal0-api.service runs ``User=hal0``; combined with the seed's new
+    canonical 0600/0640 mode, a root-owned (or third-user-owned) seed is one
+    the API's own service account cannot open — ``_config_require_auth()``
+    swallows that ``PermissionError`` into "unset" and falls back to
+    ``require_auth`` OFF (Codex P2 on a5f4fe5d, the mode-only fix). Faking
+    "root" here via monkeypatched ``pwd``/``grp``/``os.fchown`` so the test
+    doesn't depend on the runner actually being root or this box actually
+    having a system ``hal0`` account.
+    """
+    _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    class _FakePasswd:
+        pw_uid = 4242
+
+    class _FakeGroup:
+        gr_gid = 4343
+
+    chown_calls: list[tuple[int, int, int]] = []
+
+    def _fake_fchown(fd: int, uid: int, gid: int) -> None:
+        chown_calls.append((fd, uid, gid))
+
+    monkeypatch.setattr(config_commands.pwd, "getpwnam", lambda name: _FakePasswd())
+    monkeypatch.setattr(config_commands.grp, "getgrnam", lambda name: _FakeGroup())
+    monkeypatch.setattr(config_commands.os, "fchown", _fake_fchown)
+
+    result = runner.invoke(config_commands.app, ["edit", "hal0"])
+    assert result.exit_code == 0, result.output
+    assert len(chown_calls) == 1, f"expected exactly one fchown attempt, got {chown_calls}"
+    _fd, uid, gid = chown_calls[0]
+    assert (uid, gid) == (4242, 4343), f"chowned to the wrong target: {chown_calls}"
+
+
+def test_config_edit_seed_survives_chown_permission_denied(monkeypatch, tmp_path: Path) -> None:
+    """An unprivileged third-user invocation cannot chown to the service
+    account (POSIX: only root may chown to an arbitrary uid) — the seed
+    must still be written successfully rather than the command crashing.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    class _FakePasswd:
+        pw_uid = 4242
+
+    class _FakeGroup:
+        gr_gid = 4343
+
+    def _denied_fchown(fd: int, uid: int, gid: int) -> None:
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(config_commands.pwd, "getpwnam", lambda name: _FakePasswd())
+    monkeypatch.setattr(config_commands.grp, "getgrnam", lambda name: _FakeGroup())
+    monkeypatch.setattr(config_commands.os, "fchown", _denied_fchown)
+
+    result = runner.invoke(config_commands.app, ["edit", "hal0"])
+    assert result.exit_code == 0, result.output
+    seeded = cfg_dir / "hal0.toml"
+    assert seeded.exists()
+    mode = stat.S_IMODE(seeded.stat().st_mode)
+    assert mode == 0o600, "mode must still land correctly even when chown is denied"
+
+
 def test_permission_denied_hint_does_not_recommend_widening_the_file(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_config_show_edit_selector.py
+++ b/tests/cli/test_config_show_edit_selector.py
@@ -11,11 +11,34 @@ from __future__ import annotations
 import stat
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from hal0.cli import config_commands
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _no_real_service_account(monkeypatch):
+    """Default every test in this file to "no system hal0 account" for
+    ``_seed_config_file``'s ownership step.
+
+    A HAL0_HOME sandbox is never actually ``/etc/hal0`` — it's a throwaway
+    temp tree — so there is no real chown target, regardless of whether
+    *this* machine happens to have a system ``hal0`` account (hal0's own
+    dev/CI boxes do, since hal0 is genuinely installed on them). Without
+    this, seed tests would pass or fail depending on host state instead of
+    on the code under test. The tests that specifically exercise the
+    privileged/chown-denied paths override ``pwd.getpwnam``/
+    ``grp.getgrnam`` themselves, after this fixture runs.
+    """
+
+    def _no_such_account(name: str):
+        raise KeyError(name)
+
+    monkeypatch.setattr(config_commands.pwd, "getpwnam", _no_such_account)
+    monkeypatch.setattr(config_commands.grp, "getgrnam", _no_such_account)
 
 
 def _set_home(monkeypatch, tmp_path: Path) -> Path:
@@ -150,10 +173,14 @@ def test_config_edit_seed_chowns_to_service_owner_when_privileged(
     assert (uid, gid) == (4242, 4343), f"chowned to the wrong target: {chown_calls}"
 
 
-def test_config_edit_seed_survives_chown_permission_denied(monkeypatch, tmp_path: Path) -> None:
+def test_config_edit_seed_rejects_seed_when_chown_denied(monkeypatch, tmp_path: Path) -> None:
     """An unprivileged third-user invocation cannot chown to the service
-    account (POSIX: only root may chown to an arbitrary uid) — the seed
-    must still be written successfully rather than the command crashing.
+    account (POSIX: only root may chown to an arbitrary uid). Publishing the
+    seed anyway would hand the operator a self-owned hal0.toml at 0600 that
+    hal0-api (User=hal0) cannot read — and _config_require_auth() turns that
+    unreadable-config case into a silent fall-back to require_auth OFF. The
+    command must instead abort loudly: nonzero exit, no file left behind,
+    and a message that tells the operator to re-run under sudo.
     """
     cfg_dir = _set_home(monkeypatch, tmp_path)
     monkeypatch.setenv("EDITOR", "true")
@@ -172,11 +199,37 @@ def test_config_edit_seed_survives_chown_permission_denied(monkeypatch, tmp_path
     monkeypatch.setattr(config_commands.os, "fchown", _denied_fchown)
 
     result = runner.invoke(config_commands.app, ["edit", "hal0"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code != 0, "a chown-denied seed must abort, not silently succeed"
     seeded = cfg_dir / "hal0.toml"
-    assert seeded.exists()
-    mode = stat.S_IMODE(seeded.stat().st_mode)
-    assert mode == 0o600, "mode must still land correctly even when chown is denied"
+    assert not seeded.exists(), "the unreadable-to-hal0-api seed must not be left on disk"
+    assert "sudo" in result.output, f"error must point the operator at sudo: {result.output}"
+
+
+def test_config_edit_seed_rejects_seed_on_other_oserror(monkeypatch, tmp_path: Path) -> None:
+    """Widened from bare PermissionError to OSError on review (e.g. EROFS on
+    a read-only-remounted /etc) — any chown failure must hit the same loud
+    abort, not an unhandled traceback.
+    """
+    cfg_dir = _set_home(monkeypatch, tmp_path)
+    monkeypatch.setenv("EDITOR", "true")
+
+    class _FakePasswd:
+        pw_uid = 4242
+
+    class _FakeGroup:
+        gr_gid = 4343
+
+    def _erofs_fchown(fd: int, uid: int, gid: int) -> None:
+        raise OSError(30, "Read-only file system")  # errno.EROFS
+
+    monkeypatch.setattr(config_commands.pwd, "getpwnam", lambda name: _FakePasswd())
+    monkeypatch.setattr(config_commands.grp, "getgrnam", lambda name: _FakeGroup())
+    monkeypatch.setattr(config_commands.os, "fchown", _erofs_fchown)
+
+    result = runner.invoke(config_commands.app, ["edit", "upstreams"])
+    assert result.exit_code != 0
+    assert not (cfg_dir / "upstreams.toml").exists()
+    assert "sudo" in result.output
 
 
 def test_permission_denied_hint_does_not_recommend_widening_the_file(

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -276,6 +276,107 @@ def test_hal0_target_enabled_probe_no_systemctl(monkeypatch: pytest.MonkeyPatch)
     assert da._hal0_target_enabled_probe() is None
 
 
+# ── check_agent_uid_isolation (ADR-0002) ──────────────────────────────────────
+
+
+def test_agent_uid_shared_with_api_warns() -> None:
+    """The shipped default: both units are User=hal0 → advisory warn, never fail.
+
+    This is the row's whole reason to exist — an operator reading `hal0 doctor`
+    on a stock box must be told that the bundled agent shares the API's UID and
+    can therefore read its credentials out of /proc.
+    """
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda _u: "hal0",
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+    )
+    assert c.key == "agent-uid"
+    assert c.status == "warn"
+    assert c.critical is False
+    assert "hal0-agent@hermes.service" in c.detail
+    assert "SECURITY.md" in c.detail
+
+
+def test_agent_uid_split_passes() -> None:
+    """The 1.1 posture: the agent has its own account → clean row."""
+    users = {"hal0-api.service": "hal0", "hal0-agent@hermes.service": "hal0-agent"}
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: users[u],
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+    )
+    assert c.status == "pass"
+
+
+def test_agent_uid_no_agent_unit_passes() -> None:
+    """No bundled agent installed — there is no boundary to report on."""
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda _u: "hal0",
+        agent_units=lambda: [],
+    )
+    assert c.status == "pass"
+    assert "no bundled agent" in c.detail
+
+
+def test_agent_uid_unknown_api_user_warns() -> None:
+    """systemctl could not answer for hal0-api — say unknown, do not claim clean."""
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: None if u == "hal0-api.service" else "hal0",
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+    )
+    assert c.status == "warn"
+    assert "unknown" in c.detail
+
+
+def test_agent_uid_flags_only_the_sharing_instance() -> None:
+    """A mixed box names the instance that shares, not the one that does not."""
+    users = {
+        "hal0-api.service": "hal0",
+        "hal0-agent@hermes.service": "hal0",
+        "hal0-agent@other.service": "hal0-agent",
+    }
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: users[u],
+        agent_units=lambda: ["hal0-agent@hermes.service", "hal0-agent@other.service"],
+    )
+    assert c.status == "warn"
+    assert "hal0-agent@hermes.service" in c.detail
+    assert "hal0-agent@other.service" not in c.detail
+
+
+def test_agent_uid_probes_degrade_without_systemctl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(da.shutil, "which", lambda _cmd: None)
+    assert da._unit_user("hal0-api.service") is None
+    assert da._agent_units() == []
+
+
+def test_unit_user_reports_root_for_an_empty_user_directive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """systemd renders an unset User= as the empty string; that means root."""
+    monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
+
+    class _R:
+        returncode = 0
+        stdout = "\n"
+
+    monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
+    assert da._unit_user("hal0-api.service") == "root"
+
+
+def test_agent_units_parses_list_units_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
+
+    class _R:
+        returncode = 0
+        stdout = (
+            "hal0-agent@hermes.service loaded active running hal0 agent (hermes)\n"
+            "hal0-agent@other.service  loaded inactive dead  hal0 agent (other)\n"
+        )
+
+    monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
+    assert da._agent_units() == ["hal0-agent@hermes.service", "hal0-agent@other.service"]
+
+
 # ── overall_verdict + exit codes ──────────────────────────────────────────────
 
 
@@ -697,10 +798,18 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         lambda *_a, **_k: Check("netns", "Container netns", "pass", "stubbed"),
     )
 
+    # Agent-UID row (ADR-0002) shells out to systemctl otherwise; neutralise it
+    # so this composition test asserts the row list, not the host's units.
+    monkeypatch.setattr(
+        da,
+        "check_agent_uid_isolation",
+        lambda **_kw: Check("agent-uid", "Agent UID split", "pass", "stubbed"),
+    )
+
     checks = da.build_all_checks()
     keys = [c.key for c in checks]
-    # 7 verify rows + 15 extras.
-    assert keys[-15:] == [
+    # 7 verify rows + 16 extras.
+    assert keys[-16:] == [
         "auth",
         "models",
         "migrations",
@@ -710,6 +819,7 @@ def test_build_all_checks_composes_verify_plus_extras(monkeypatch: pytest.Monkey
         "netns",
         "hal0_target",
         "secret-modes",
+        "agent-uid",
         "stt-weights",
         "seams",
         "mcp_mounts",

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -366,7 +366,7 @@ def test_unit_user_reports_root_for_an_empty_user_directive(
 
 def test_agent_units_parses_list_units_output(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
-    monkeypatch.setattr(da, "_enabled_agent_units", lambda: [])
+    monkeypatch.setattr(da, "_provisioned_agent_units", lambda: [])
 
     class _R:
         returncode = 0
@@ -391,7 +391,7 @@ def test_agent_units_is_unknown_when_systemctl_errors(monkeypatch: pytest.Monkey
     assert da._agent_units() is None
 
 
-def test_agent_units_finds_a_stopped_unloaded_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_agent_units_finds_a_stopped_disabled_instance(monkeypatch: pytest.MonkeyPatch) -> None:
     """`list-units` only reports units in memory; the enable symlink outlives that.
 
     An operator who stopped the agent has not uninstalled it — the boundary is
@@ -404,20 +404,43 @@ def test_agent_units_finds_a_stopped_unloaded_instance(monkeypatch: pytest.Monke
         stdout = ""
 
     monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
-    monkeypatch.setattr(da, "_enabled_agent_units", lambda: ["hal0-agent@hermes.service"])
+    monkeypatch.setattr(da, "_provisioned_agent_units", lambda: ["hal0-agent@hermes.service"])
     assert da._agent_units() == ["hal0-agent@hermes.service"]
 
 
-def test_enabled_agent_units_reads_wants_symlinks(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_provisioned_agent_units_reads_wants_symlinks(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
     wants = tmp_path / "multi-user.target.wants"
     wants.mkdir()
     (wants / "hal0-agent@hermes.service").symlink_to(tmp_path / "hal0-agent@.service")
     (wants / "hal0-api.service").symlink_to(tmp_path / "hal0-api.service")
-    assert da._enabled_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
+    assert da._provisioned_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
 
 
-def test_enabled_agent_units_missing_unit_dir_is_empty(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    assert da._enabled_agent_units(tmp_path / "nope") == []
+def test_provisioned_agent_units_reads_dropin_dirs(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """`hal0 agent disable` leaves the drop-in dir behind — that instance still counts."""
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
+    (tmp_path / "hal0-agent@hermes.service.d").mkdir()
+    (tmp_path / "hal0-api.service.d").mkdir()
+    assert da._provisioned_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
+
+
+def test_provisioned_agent_units_reads_per_agent_config(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
+    agents = tmp_path / "home" / "etc" / "hal0" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "hermes.toml").write_text("")
+    (agents / "other.env").write_text("")
+    (agents / "README").write_text("")
+    assert da._provisioned_agent_units(tmp_path) == [
+        "hal0-agent@hermes.service",
+        "hal0-agent@other.service",
+    ]
+
+
+def test_provisioned_agent_units_missing_unit_dir_is_empty(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
+    assert da._provisioned_agent_units(tmp_path / "nope") == []
 
 
 def test_agent_uid_unknown_inventory_warns() -> None:

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -344,9 +344,10 @@ def test_agent_uid_flags_only_the_sharing_instance() -> None:
 
 
 def test_agent_uid_probes_degrade_without_systemctl(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No systemctl → *unknown*, never an empty inventory (which would read clean)."""
     monkeypatch.setattr(da.shutil, "which", lambda _cmd: None)
     assert da._unit_user("hal0-api.service") is None
-    assert da._agent_units() == []
+    assert da._agent_units() is None
 
 
 def test_unit_user_reports_root_for_an_empty_user_directive(
@@ -365,6 +366,7 @@ def test_unit_user_reports_root_for_an_empty_user_directive(
 
 def test_agent_units_parses_list_units_output(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
+    monkeypatch.setattr(da, "_enabled_agent_units", lambda: [])
 
     class _R:
         returncode = 0
@@ -375,6 +377,95 @@ def test_agent_units_parses_list_units_output(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
     assert da._agent_units() == ["hal0-agent@hermes.service", "hal0-agent@other.service"]
+
+
+def test_agent_units_is_unknown_when_systemctl_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A manager error must not be laundered into "no agent installed"."""
+    monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
+
+    class _R:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
+    assert da._agent_units() is None
+
+
+def test_agent_units_finds_a_stopped_unloaded_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`list-units` only reports units in memory; the enable symlink outlives that.
+
+    An operator who stopped the agent has not uninstalled it — the boundary is
+    still there the moment it starts again, so the row must still see it.
+    """
+    monkeypatch.setattr(da.shutil, "which", lambda _cmd: "/usr/bin/systemctl")
+
+    class _R:
+        returncode = 0
+        stdout = ""
+
+    monkeypatch.setattr(da.subprocess, "run", lambda *_a, **_k: _R())
+    monkeypatch.setattr(da, "_enabled_agent_units", lambda: ["hal0-agent@hermes.service"])
+    assert da._agent_units() == ["hal0-agent@hermes.service"]
+
+
+def test_enabled_agent_units_reads_wants_symlinks(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wants = tmp_path / "multi-user.target.wants"
+    wants.mkdir()
+    (wants / "hal0-agent@hermes.service").symlink_to(tmp_path / "hal0-agent@.service")
+    (wants / "hal0-api.service").symlink_to(tmp_path / "hal0-api.service")
+    assert da._enabled_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
+
+
+def test_enabled_agent_units_missing_unit_dir_is_empty(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    assert da._enabled_agent_units(tmp_path / "nope") == []
+
+
+def test_agent_uid_unknown_inventory_warns() -> None:
+    """systemd could not be asked → warn, not a clean row."""
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda _u: "hal0",
+        agent_units=lambda: None,
+    )
+    assert c.status == "warn"
+    assert "could not enumerate" in c.detail
+
+
+def test_agent_uid_unknown_agent_user_warns_instead_of_passing() -> None:
+    """An unreadable agent User= must not fall through to "runs as a different user"."""
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: "hal0" if u == "hal0-api.service" else None,
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+    )
+    assert c.status == "warn"
+    assert "hal0-agent@hermes.service" in c.detail
+    assert "could not read User=" in c.detail
+
+
+def test_agent_uid_compares_resolved_uids_not_strings() -> None:
+    """A drop-in spelling one side numerically is still the same UID to the kernel."""
+    users = {"hal0-api.service": "hal0", "hal0-agent@hermes.service": "991"}
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: users[u],
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+        resolve_uid=lambda user: 991 if user in ("hal0", "991") else None,
+    )
+    assert c.status == "warn", "numeric-vs-name spelling must not read as a UID split"
+    assert "uid 991" in c.detail
+
+
+def test_agent_uid_distinct_uids_pass_despite_a_shared_prefix() -> None:
+    users = {"hal0-api.service": "hal0", "hal0-agent@hermes.service": "hal0-agent"}
+    c = da.check_agent_uid_isolation(
+        unit_user=lambda u: users[u],
+        agent_units=lambda: ["hal0-agent@hermes.service"],
+        resolve_uid=lambda user: {"hal0": 991, "hal0-agent": 992}[user],
+    )
+    assert c.status == "pass"
+
+
+def test_resolve_uid_accepts_a_numeric_literal_and_unknown_names() -> None:
+    assert da._resolve_uid("4242") == 4242
+    assert da._resolve_uid("definitely-not-a-real-account-x9") is None
 
 
 # ── overall_verdict + exit codes ──────────────────────────────────────────────

--- a/tests/cli/test_doctor_all.py
+++ b/tests/cli/test_doctor_all.py
@@ -417,12 +417,19 @@ def test_provisioned_agent_units_reads_wants_symlinks(tmp_path, monkeypatch) -> 
     assert da._provisioned_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
 
 
-def test_provisioned_agent_units_reads_dropin_dirs(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    """`hal0 agent disable` leaves the drop-in dir behind — that instance still counts."""
+def test_provisioned_agent_units_ignores_the_shipped_dropin_dir(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A drop-in dir alone is not evidence of an installed agent.
+
+    `installer/install.sh` writes `hal0-agent@hermes.service.d/override.conf`
+    on every install "whether or not bootstrap has been run", so a box built
+    with the documented `HAL0_SKIP_HERMES=1` has the drop-in and no agent.
+    Counting it would warn about an agent the operator deliberately declined.
+    """
     monkeypatch.setenv("HAL0_HOME", str(tmp_path / "home"))
-    (tmp_path / "hal0-agent@hermes.service.d").mkdir()
-    (tmp_path / "hal0-api.service.d").mkdir()
-    assert da._provisioned_agent_units(tmp_path) == ["hal0-agent@hermes.service"]
+    dropin = tmp_path / "hal0-agent@hermes.service.d"
+    dropin.mkdir()
+    (dropin / "override.conf").write_text("[Service]\n")
+    assert da._provisioned_agent_units(tmp_path) == []
 
 
 def test_provisioned_agent_units_reads_per_agent_config(tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -10,6 +10,7 @@ Covers:
 
 from __future__ import annotations
 
+import os
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
@@ -715,3 +716,29 @@ class TestManifestLoader:
         )
         loaded = load_manifest()
         assert loaded["toolbox_images"]["flm"]["digest"] == "sha256:etc"
+
+
+def test_save_upstreams_config_lands_the_canonical_mode(tmp_path: Path) -> None:
+    """The atomic rewrite must not drop upstreams.toml's declared mode.
+
+    ``write_toml_atomic`` builds its replacement with ``tempfile.mkstemp``
+    (0600) and ``os.replace``s it over the destination, so every provider
+    create/patch/delete used to discard the 0640 that ``install/perms.py``
+    declares — the file sat in permission drift until ``doctor perms --fix``
+    ran, and an operator in the ``hal0`` group lost read access mid-session.
+    """
+    target = tmp_path / "upstreams.toml"
+    target.write_text("")
+    os.chmod(target, 0o600)
+
+    save_upstreams_config(UpstreamsConfig(upstream=[]), path=target)
+
+    assert target.stat().st_mode & 0o777 == paths.UPSTREAMS_TOML_MODE
+    assert paths.UPSTREAMS_TOML_MODE & 0o007 == 0, "canonical mode must not be world-readable"
+
+
+def test_write_toml_atomic_without_a_mode_is_unchanged(tmp_path: Path) -> None:
+    """The mode argument is opt-in: callers that pass nothing keep mkstemp's 0600."""
+    target = tmp_path / "plain.toml"
+    write_toml_atomic(target, {"a": 1})
+    assert target.stat().st_mode & 0o777 == 0o600

--- a/tests/docs/test_security_md_documents_agent_boundary.py
+++ b/tests/docs/test_security_md_documents_agent_boundary.py
@@ -1,0 +1,84 @@
+"""``SECURITY.md`` must state the bundled agent's trust boundary (ADR-0002).
+
+hal0 1.0 ships a bundled agent with ``terminal.backend = local`` running as
+``User=hal0`` — the same user ``hal0-api.service`` runs as. Same UID means the
+agent can read the API process's ``/proc/<pid>/environ`` and therefore every
+credential the API holds; the ``hal0`` account additionally owns the privileged
+seams that author rootful podman slots. That is an accepted risk for 1.0
+(ADR-0002 Option C), and an accepted risk is only accepted if it is written
+down where an operator will read it.
+
+Before this, ``SECURITY.md`` was a reporting-process page only: nothing in the
+repo told an operator that giving the bundled agent untrusted content is
+equivalent to giving it the box. This test pins the disclosure so a later tidy
+of ``SECURITY.md`` cannot quietly delete it, and pins the honesty requirement
+in both directions — the compensating controls have to be named *and* their
+limits have to be named.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SECURITY_MD = _REPO_ROOT / "SECURITY.md"
+
+_SECTION = "## Bundled agent trust boundary"
+
+
+def _boundary_section(text: str) -> str:
+    """Slice out the trust-boundary section (up to the next ``## `` heading)."""
+    start = text.index(_SECTION)
+    rest = text[start:]
+    nxt = rest.find("\n## ", 1)
+    return rest if nxt == -1 else rest[:nxt]
+
+
+def _text() -> str:
+    assert _SECURITY_MD.exists(), f"missing {_SECURITY_MD}"
+    return _SECURITY_MD.read_text(encoding="utf-8")
+
+
+def test_security_md_has_a_bundled_agent_section() -> None:
+    assert _SECTION in _text(), (
+        f"{_SECURITY_MD.name} must carry a '{_SECTION}' section — the 1.0 posture is a "
+        "documented accepted risk, and undocumented is not accepted"
+    )
+
+
+def test_section_names_the_shared_uid_and_the_proc_read() -> None:
+    section = _boundary_section(_text())
+    for token in ("hal0-api", "hal0-agent@", "/proc/", "terminal.backend"):
+        assert token in section, f"trust-boundary section never mentions {token!r}"
+    assert "ptrace_scope" in section, (
+        "the section must say that ptrace_scope does not prevent the same-UID read — "
+        "otherwise a reader assumes a hardening knob they already have covers this"
+    )
+
+
+def test_section_names_compensating_controls_and_their_limits() -> None:
+    """Honest in both directions: controls named, limits named."""
+    section = _boundary_section(_text())
+    for control in ("NoNewPrivileges", "ProtectSystem", "podman"):
+        assert control in section, f"compensating-control inventory omits {control!r}"
+    assert "Does not buy" in section, (
+        "the section lists controls without listing what they do not buy — that is the "
+        "overstatement this disclosure exists to avoid"
+    )
+
+
+def test_section_declares_the_status_and_links_the_adr() -> None:
+    section = _boundary_section(_text())
+    assert "accepted" in section.lower(), "the section never states this is an accepted risk"
+    assert "1.1" in section, "the section never says the agent-UID split is tracked for 1.1"
+    assert "docs/adr/0002-agent-credential-isolation.md" in section, (
+        "the section must link ADR-0002, which carries the evidence and the rejected alternatives"
+    )
+
+
+def test_section_points_at_the_doctor_row() -> None:
+    section = _boundary_section(_text())
+    assert "Agent UID split" in section, (
+        "the doctor row and the docs must name each other — the row's detail string "
+        "sends the operator here"
+    )

--- a/tests/install/test_perms.py
+++ b/tests/install/test_perms.py
@@ -746,3 +746,21 @@ def test_regular_files_are_still_reconciled_alongside_symlinks(tmp_path: Path) -
     assert plain in applied
     assert oct(plain.stat().st_mode & 0o7777) == oct(0o644)
     assert oct(outside.stat().st_mode & 0o7777) == oct(0o600)
+
+
+def test_upstreams_toml_is_not_world_readable(tmp_hal0_home: str) -> None:
+    """upstreams.toml drops the world bit (ADR-0002, Option C item 3).
+
+    The file carries no credential *values* — ``auth_value_env`` names an
+    environment variable and the registry resolves it at request time — but the
+    provider/endpoint inventory it does carry was readable by every local
+    account at 0644. 0640 keeps every in-tree consumer working: hal0-api,
+    hal0-agent@* and the CLI all run as ``hal0`` (or root), and the file's group
+    is ``hal0``. Asserted against the ownership table under the service-user
+    flip, because that is the posture every installed box runs.
+    """
+    rows = _by_target(perms.ownership_table(service_user="hal0"))
+    row = rows[paths.etc() / "upstreams.toml"]
+    assert (row.owner, row.group) == ("hal0", "hal0")
+    assert row.mode & 0o007 == 0, f"upstreams.toml is world-readable: {row.mode:o}"
+    assert row.mode == 0o640


### PR DESCRIPTION
Lands ADR-0002 **Option C** items 1–3 (see #1880 for the full analysis and the
evidence — this PR does not re-derive it).

## Why

`hal0-api.service` and `hal0-agent@<instance>.service` both ship `User=hal0`.
Same UID, so the bundled agent — provisioned with `terminal.backend = local`,
i.e. it has a shell — can read the API process's `/proc/<pid>/environ` and with
it every credential the services hold. `kernel.yama.ptrace_scope` does not
prevent this: it gates `PTRACE_MODE_ATTACH`, not same-UID reads. The `hal0`
account is additionally root-equivalent by design — slots run under rootful
podman, so whatever can author a `[Container]` spec can `Volume=`-mount host
paths, which `installer/wrappers/hal0-systemctl`'s own HONEST BOUNDARY block has
stated since #1740. It has simply never been said anywhere an operator reads.

This PR does not change that posture. It documents it, surfaces it in
`hal0 doctor`, and takes the one free tightening that was available.

## What changed

1. **`SECURITY.md` — "Bundled agent trust boundary".** States the posture
   plainly, then a control-by-control table of what each compensating control
   *buys* and what it *does not*: unprivileged `User=hal0` (not root, but the
   same UID as the API), `ProtectSystem=strict`/`PrivateTmp`/`ReadWritePaths=`
   (integrity, not confidentiality against a same-UID read), `0600 root:root`
   on the per-agent env file, `0600` on `api.env` (useless against its owner).
   One honest qualifier added on top of the ADR: `hal0-agent@.service` sets
   `NoNewPrivileges=yes`, so a process inside the agent unit cannot invoke the
   setuid sudo wrappers *directly* — a speed bump, not a boundary, because
   `hal0-api.service` sets no such restriction and the admin key read out of
   `/proc` drives the same privileged paths through the API. Status is stated
   outright: accepted, documented risk for 1.0, agent-UID split tracked for
   1.1, link to ADR-0002, plus what to do if you cannot accept it.
2. **`hal0 doctor` row `agent-uid` / "Agent UID split"**
   (`src/hal0/cli/doctor_all.py`). Warns — never fails, this is the shipped
   default — when a `hal0-agent@*` unit resolves to the same `User=` as
   `hal0-api.service`, says in one line what that implies, and points at the
   SECURITY.md section and the ADR. Both probes (`systemctl show -p User`,
   `systemctl list-units 'hal0-agent@*.service'`) are injectable seams,
   mirroring `check_hal0_target`, so classification is tested without systemd.
   No agent unit installed → pass; `systemctl` unable to answer → warn
   "unknown", not a silent pass.
3. **`upstreams.toml` → `0640`** (`src/hal0/install/perms.py`). Metadata only,
   but free.

## Consumer check before the mode change (item 3)

Asked and answered before touching the `PermRow`:

- `grep` for `upstreams.toml` / `UPSTREAMS` across `src`, `installer`,
  `packaging`, `tests`: the readers are `src/hal0/config/loader.py`
  (`load_upstreams_config`), `src/hal0/api/__init__.py` startup priming,
  `src/hal0/api/routes/providers.py` CRUD, and `hal0 config show/edit`.
- Those run in `hal0-api.service` (`User=hal0`), `hal0-agent@*.service`
  (`User=hal0`) or the CLI (root, or `hal0`). The file is `hal0:hal0`, so
  `0640` is readable by all of them.
- No container mounts `/etc/hal0` — searched every `Volume=`/bind-mount site in
  `src`, `installer`, `packaging`; OpenWebUI and the slot Quadlets do not touch
  it.
- Writers: `installer/install.sh` (`[[ ! -f ]]`-guarded create, default umask)
  and `write_toml_atomic`; the perms engine converges the mode either way.
- **The one behaviour change worth naming:** an operator running the `hal0` CLI
  as their *own* unprivileged account, not in group `hal0`, could previously
  `hal0 config show upstreams`. After this they need `sudo` or group
  membership. ADR-0002 Q5 flagged exactly this and found no in-tree dependency;
  I found none either, but it is out-of-repo-script-shaped, so it is called out
  here.
- Stale comment in `installer/systemd/hal0-agent@.service` (which quoted
  "upstreams.toml 0644") updated to match.

## Regression tests — each fails without its fix

`tests/install/test_perms.py::test_upstreams_toml_is_not_world_readable`, with
the `perms.py` hunk reverted:

```
>       assert row.mode & 0o007 == 0, f"upstreams.toml is world-readable: {row.mode:o}"
E       AssertionError: upstreams.toml is world-readable: 644
E       assert (420 & 7) == 0
1 failed, 33 deselected
```

`tests/docs/test_security_md_documents_agent_boundary.py`, with the
`SECURITY.md` hunk reverted (5/5 fail):

```
E       ValueError: substring not found   # "## Bundled agent trust boundary"
FAILED test_security_md_has_a_bundled_agent_section
FAILED test_section_names_the_shared_uid_and_the_proc_read
FAILED test_section_names_compensating_controls_and_their_limits
FAILED test_section_declares_the_status_and_links_the_adr
FAILED test_section_points_at_the_doctor_row
5 failed
```

`tests/cli/test_doctor_all.py`, with the `doctor_all.py` hunk reverted (8 new
row tests + the pre-existing composition test):

```
tests/cli/test_doctor_all.py:803: AttributeError
FAILED test_agent_uid_shared_with_api_warns
FAILED test_agent_uid_split_passes
FAILED test_agent_uid_no_agent_unit_passes
FAILED test_agent_uid_unknown_api_user_warns
FAILED test_agent_uid_flags_only_the_sharing_instance
FAILED test_agent_uid_probes_degrade_without_systemctl
FAILED test_unit_user_reports_root_for_an_empty_user_directive
FAILED test_agent_units_parses_list_units_output
FAILED test_build_all_checks_composes_verify_plus_extras
9 failed, 61 passed
```

The doc tests assert the *content* of `SECURITY.md` directly rather than
reimplementing a rule; the perms test asserts the shipped ownership table, not a
copy of it.

## Verification

- `uv run ruff check src tests` → All checks passed
- `uv run ruff format --check src tests` → 1142 files already formatted
- `pytest tests/docs tests/cli/test_doctor_all.py tests/install/test_perms.py tests/cli/test_doctor_perms.py` → 123 passed
- No box was written to. No secret value was read, printed, or committed.

## Out of scope

- ADR-0002 item 4 (the agent's missing-`HAL0_MCP_TOKEN` degraded state) — not
  requested here, still tracked in the ADR.
- The ADR file itself lands with #1880; the `SECURITY.md` link resolves once
  that merges.
- No CHANGELOG hunk — #1860 owns the rc.6 section. Suggested line:
  `Added: SECURITY.md now documents the bundled agent's trust boundary — the agent shares hal0-api's UID and can therefore reach every credential the box holds — plus a hal0 doctor "Agent UID split" row reporting the posture, and upstreams.toml tightened to 0640 (ADR-0002).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
