### PR TITLE
docs(changelog): document the terminal opt-in and security-posture changes in rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,36 @@ unconditionally (#1828). Both now fail loudly.
   GPU and reads real container memory instead of silently under-reporting it by
   roughly a third (#1839), and `hal0 model add` no longer claims high confidence
   for a capability it guessed from the filename (#1838).
+- **Hermes' terminal tool is off by default.** A fresh, piped or
+  non-interactive install no longer hands the bundled agent a local shell
+  running as the `hal0` service user — root-equivalent on this box — without
+  the operator saying so. Opt in at the installer prompt, with
+  `hal0 agent install hermes --terminal-tool`, or via `HAL0_HERMES_TERMINAL=1`;
+  a box whose `config.yaml` already carries an explicit `terminal.backend`
+  keeps it enabled across the update. Off also disables the `code_execution`
+  and `delegation` toolsets, since both reach a shell one hop away from
+  `terminal` (#1882).
+
+### Breaking
+
+- **Hermes' terminal tool now defaults off on a fresh, piped or
+  non-interactive install.** Every prior release wrote
+  `terminal.backend: local` unconditionally, handing the bundled agent a
+  shell running as the `hal0` service user — root-equivalent on this box —
+  without asking. A fresh install, a piped (`curl … | bash`) install, a
+  headless install, or any install run with `HAL0_NONINTERACTIVE=1` now
+  leaves the terminal tool disabled unless the operator opts in: the
+  installer's interactive prompt, `hal0 agent install hermes
+  --terminal-tool`, or `HAL0_HERMES_TERMINAL=1`. Turning it off also
+  disables the `code_execution` and `delegation` toolsets — `execute_code`
+  runs arbitrary code as the same user, and `delegate_task` could otherwise
+  hand a subagent the `terminal` toolset directly. Skills that stop working
+  with it off: `hal0-service-management`, `hal0-bench`,
+  `hal0-bench-autopilot`, `hal0-tune` and `hal0-quantize`. A box whose
+  `config.yaml` already carries an explicit `terminal.backend` — set by
+  hal0's own provisioning at any point in its history, or by the operator by
+  hand — is read as a prior opt-in and keeps the terminal enabled across
+  `hal0 update`; no action needed there (#1882).
 
 ### Added
 
@@ -191,6 +221,14 @@ unconditionally (#1828). Both now fail loudly.
   chain is measured and named correctly rather than guessed from the model's
   spelling, and a window hal0 cannot read reports as skipped rather than as a
   pass (#1867).
+- A missing `hal0.toml`, `upstreams.toml` or `providers.toml` seeded by
+  `hal0 config edit` now lands at its canonical mode (`0600`, `0640`, `0600`
+  respectively) instead of the umask-mediated `0644` a bare file write
+  produced, and is chowned to the `hal0` service owner on a real install so
+  `hal0-api.service` can still read what it seeded. An operator whose seed
+  can't reach that ownership — running as neither `hal0` nor root — now gets
+  a loud failure pointing at `sudo` instead of a file `hal0-api` cannot open
+  (#1881).
 
 ### Security
 
@@ -202,6 +240,22 @@ unconditionally (#1828). Both now fail loudly.
   installs were always 0600. **Existing boxes are repaired on the next
   reprovision, not by the update itself** — check with
   `stat -c '%a' /etc/hal0/agents/hermes.env`, expect `600` (#1876).
+- `hal0 doctor` gains an **Agent UID split** row that warns — never fails,
+  since sharing a UID is the shipped 1.0 default — when a `hal0-agent@*` unit
+  resolves to the same `User=` as `hal0-api.service`. Same UID means the
+  bundled agent's `local` terminal backend can read the API process's
+  `/proc/<pid>/environ`, and therefore every credential the API holds;
+  `kernel.yama.ptrace_scope` does not stop it, since that setting gates
+  `PTRACE_MODE_ATTACH`, not same-UID reads. `SECURITY.md` gains a new
+  "Bundled agent trust boundary" section laying out the posture
+  control-by-control, with a status of accepted, documented risk for 1.0 —
+  the agent/API UID split is tracked for 1.1 under ADR-0002 (#1881).
+- `upstreams.toml` drops from world-readable `0644` to `0640`. The file
+  carries no credential values — `auth_value_env` only names an environment
+  variable the registry resolves from the process environment at request
+  time — but its provider/endpoint inventory was readable by every local
+  account; every real consumer (`hal0-api`, `hal0-agent@*`, the CLI) runs as
+  `hal0` or root, group `hal0` (#1881).
 
 ### Docs
 
@@ -320,6 +374,18 @@ targeted at the 1.0.x line.
   the seam (#1759)** / **releases-URL override (#1750)** migrations from rc.4,
   still apply to boxes coming from an older tag; see the
   [1.0.0-rc.5 section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc5--2026-08-10).
+- **Terminal tool off by default on new installs (#1882):** a box installed
+  fresh, or provisioned non-interactively (a piped `curl … | bash` install, a
+  headless install, or one run with `HAL0_NONINTERACTIVE=1`), no longer
+  enables Hermes' `local` terminal backend automatically — `code_execution`
+  and `delegation` come off with it. Nothing to run if that is what you want.
+  To enable it, answer yes at the installer's prompt on an interactive
+  install, or run `hal0 agent install hermes --terminal-tool` (add
+  `HAL0_HERMES_TERMINAL=1` for an unattended install). An existing box whose
+  `config.yaml` already carries an explicit `terminal.backend` — anything
+  hal0 has ever provisioned, or a cwd the operator set by hand — is read as a
+  prior opt-in and keeps it enabled across `hal0 update`; nothing to run
+  there either.
 
 ### Rollback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,44 +81,49 @@ unconditionally (#1828). Both now fail loudly.
   GPU and reads real container memory instead of silently under-reporting it by
   roughly a third (#1839), and `hal0 model add` no longer claims high confidence
   for a capability it guessed from the filename (#1838).
-- **Hermes' terminal tool is off by default.** A fresh, piped or
-  non-interactive install no longer hands the bundled agent a local shell
-  running as the `hal0` service user — root-equivalent on this box — without
-  the operator saying so. Opt in at the installer prompt, with
+- **Hermes' terminal tool is off by default on a fresh install.** A fresh
+  install — interactive (declined at the prompt), piped, headless, or run
+  with `HAL0_NONINTERACTIVE=1` — no longer hands the bundled agent a local
+  shell running as the `hal0` service user — root-equivalent on this box —
+  without the operator saying so. Opt in at the installer prompt, with
   `sudo hal0 agent install hermes --terminal-tool`, or via
-  `HAL0_HERMES_TERMINAL=1`. This only changes what a fresh provision writes:
-  a bare `hal0 update` never touches Hermes' config, so an already-provisioned
-  box keeps its existing terminal posture untouched by the update itself; the
-  new default-off rule is evaluated the next time Hermes is reprovisioned —
-  where a `config.yaml` already carrying a non-`local` backend, or `local`
-  with a non-default `cwd` (hal0-provisioned or hand-set), still reads as
-  consent and keeps it enabled, while `local` with no `cwd` or the default
-  `cwd: "."` does not and comes back off. Off also disables the
-  `code_execution` and `delegation` toolsets, since both reach a shell one
-  hop away from `terminal` (#1882).
+  `HAL0_HERMES_TERMINAL=1`. This governs only a fresh provision: a bare
+  `hal0 update` never touches Hermes' config, and re-running the installer
+  against a box that already has Hermes provisioned skips the prompt and
+  any environment answer entirely, so an already-provisioned box's terminal
+  posture is untouched either way. The new default-off rule is evaluated
+  the next time Hermes is actually reprovisioned — where a `config.yaml`
+  already carrying a non-`local` backend, or `local` with a non-default
+  `cwd` (hal0-provisioned or hand-set), still reads as consent and keeps it
+  enabled, while `local` with no `cwd` or the default `cwd: "."` does not
+  and comes back off. Off also disables the `code_execution` and
+  `delegation` toolsets, since both reach a shell one hop away from
+  `terminal` (#1882).
 
 ### Breaking
 
-- **Hermes' terminal tool now defaults off on a fresh, piped or
-  non-interactive install.** Every prior release wrote
-  `terminal.backend: local` unconditionally, handing the bundled agent a
-  shell running as the `hal0` service user — root-equivalent on this box —
-  without asking. A fresh install, a piped (`curl … | bash`) install, a
-  headless install, or any install run with `HAL0_NONINTERACTIVE=1` now
-  leaves the terminal tool disabled unless the operator opts in: the
-  installer's interactive prompt, `sudo hal0 agent install hermes
-  --terminal-tool`, or `HAL0_HERMES_TERMINAL=1`. Turning it off also
-  disables the `code_execution` and `delegation` toolsets — `execute_code`
-  runs arbitrary code as the same user, and `delegate_task` could otherwise
-  hand a subagent the `terminal` toolset directly. Skills that stop working
-  with it off: `hal0-service-management`, `hal0-bench`,
-  `hal0-bench-autopilot`, `hal0-tune` and `hal0-quantize`. This default only
-  governs what a fresh Hermes provision writes — a bare `hal0 update` never
-  reprovisions Hermes, so it does not touch an existing box's terminal
-  posture at all. At the next reprovision or bootstrap, a `config.yaml`
-  that already carries a backend other than `local`, or `local` together
-  with a non-default `cwd` — anything hal0's own provisioning has ever
-  written, or a path the operator set by hand — is read as a prior opt-in
+- **Hermes' terminal tool now defaults off on a fresh install.** Every
+  prior release wrote `terminal.backend: local` unconditionally, handing
+  the bundled agent a shell running as the `hal0` service user —
+  root-equivalent on this box — without asking. A fresh install —
+  interactive (declined), piped (`curl … | bash`), headless, or run with
+  `HAL0_NONINTERACTIVE=1` — now leaves the terminal tool disabled unless
+  the operator opts in: the installer's interactive prompt (fresh installs
+  only), `sudo hal0 agent install hermes --terminal-tool`, or
+  `HAL0_HERMES_TERMINAL=1`. Turning it off also disables the
+  `code_execution` and `delegation` toolsets — `execute_code` runs
+  arbitrary code as the same user, and `delegate_task` could otherwise hand
+  a subagent the `terminal` toolset directly. Skills that stop working with
+  it off: `hal0-service-management`, `hal0-bench`, `hal0-bench-autopilot`,
+  `hal0-tune` and `hal0-quantize`. This default only governs what a fresh
+  Hermes provision writes — a bare `hal0 update` never reprovisions Hermes,
+  and re-running the installer against a box that already has Hermes
+  provisioned skips the prompt and any environment answer entirely, so
+  neither touches an existing box's terminal posture at all. At the next
+  ACTUAL reprovision or bootstrap, a `config.yaml` that already carries a
+  backend other than `local`, or `local` together with a non-default
+  `cwd` — anything hal0's own provisioning has ever written, or a path the
+  operator set by hand — is read as a prior opt-in
   and keeps the terminal enabled. `local` with no `cwd`, or the default
   `cwd: "."` that `hermes config migrate` can materialise on its own, is
   NOT read as consent: that box comes back off at the next reprovision,
@@ -256,8 +261,8 @@ unconditionally (#1828). Both now fail loudly.
   installs were always 0600. **Existing boxes are repaired on the next
   reprovision, not by the update itself** — check with
   `stat -c '%a' /etc/hal0/agents/hermes.env`, expect `600` (#1876).
-- `hal0 doctor` gains an **Agent UID split** row that warns — never fails,
-  since sharing a UID is the shipped 1.0 default — when a `hal0-agent@*` unit
+- `hal0 doctor all` gains an **Agent UID split** row that warns — never
+  fails, since sharing a UID is the shipped 1.0 default — when a `hal0-agent@*` unit
   resolves to the same `User=` as `hal0-api.service`. Same UID means the
   bundled agent's `local` terminal backend can read the API process's
   `/proc/<pid>/environ`, and therefore every credential the API holds;
@@ -279,7 +284,11 @@ unconditionally (#1828). Both now fail loudly.
   **A bare `hal0 update` does not touch the file either**, so an existing
   `upstreams.toml` already on disk at `0644` stays `0644` until an actual
   provider write happens or an operator converges it directly with
-  `sudo hal0 doctor perms --fix` (#1881).
+  `sudo hal0 doctor perms --fix`. CLI impact: `hal0 config show upstreams`
+  reads the file directly as the invoking user — no privilege drop — so once
+  a box is at `0640`, an ordinary login user who is neither `hal0` nor root
+  and not in the `hal0` group gets a permission error and needs `sudo` or
+  `hal0`-group membership to read it (#1881).
 
 ### Docs
 
@@ -398,9 +407,9 @@ targeted at the 1.0.x line.
   the seam (#1759)** / **releases-URL override (#1750)** migrations from rc.4,
   still apply to boxes coming from an older tag; see the
   [1.0.0-rc.5 section](https://github.com/Hal0ai/hal0/blob/main/CHANGELOG.md#100-rc5--2026-08-10).
-- **Terminal tool off by default on new installs (#1882):** a box installed
-  fresh, or provisioned non-interactively (a piped `curl … | bash` install, a
-  headless install, or one run with `HAL0_NONINTERACTIVE=1`), no longer
+- **Terminal tool off by default on new installs (#1882):** a box freshly
+  provisioned — interactive (declined), piped (`curl … | bash`), headless,
+  or run with `HAL0_NONINTERACTIVE=1` — no longer
   enables Hermes' `local` terminal backend automatically — `code_execution`
   and `delegation` come off with it. Nothing to run if that is what you want.
   To enable it, answer yes at the installer's prompt on an interactive
@@ -420,8 +429,12 @@ targeted at the 1.0.x line.
   `HAL0_HERMES_TERMINAL=1` before reprovisioning — rather than relying on
   the default. Since this is a root-equivalent shell, an operator who wants
   it off right now, without waiting for a reprovision, can run
-  `sudo hal0 agent install hermes --no-terminal-tool` (or
-  `HAL0_HERMES_TERMINAL=0` before reprovisioning) at any time.
+  `sudo hal0 agent install hermes --no-terminal-tool` at any time — note
+  this also `systemctl enable --now`s the agent unit, so it starts Hermes
+  if it was deliberately stopped. To change only the posture, without that
+  side effect, run `sudo env HAL0_HERMES_TERMINAL=0 hal0 agent reprovision
+  hermes` instead: `reprovision` only `try-restart`s an already-running
+  unit, a no-op on a stopped one.
 
 ### Rollback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,7 +434,11 @@ targeted at the 1.0.x line.
   if it was deliberately stopped. To change only the posture, without that
   side effect, run `sudo env HAL0_HERMES_TERMINAL=0 hal0 agent reprovision
   hermes` instead: `reprovision` only `try-restart`s an already-running
-  unit, a no-op on a stopped one.
+  unit, a no-op on a stopped one. Either command only works on the CLI that
+  is actually rc.6: on an in-place upgrade, `/usr/local/bin/hal0` can still
+  resolve the previous release (#1844) — check with `hal0 --version` and
+  re-run the installer if it disagrees with the installed tag before
+  relying on either opt-out.
 
 ### Rollback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,10 +86,12 @@ unconditionally (#1828). Both now fail loudly.
   running as the `hal0` service user — root-equivalent on this box — without
   the operator saying so. Opt in at the installer prompt, with
   `hal0 agent install hermes --terminal-tool`, or via `HAL0_HERMES_TERMINAL=1`;
-  a box whose `config.yaml` already carries an explicit `terminal.backend`
-  keeps it enabled across the update. Off also disables the `code_execution`
-  and `delegation` toolsets, since both reach a shell one hop away from
-  `terminal` (#1882).
+  a box whose `config.yaml` already carries a non-`local` backend, or `local`
+  with a non-default `cwd` (hal0-provisioned or hand-set), keeps it enabled
+  across the update — `local` with no `cwd` or the default `cwd: "."` is not
+  read as consent and starts off, like a fresh install. Off also disables the
+  `code_execution` and `delegation` toolsets, since both reach a shell one
+  hop away from `terminal` (#1882).
 
 ### Breaking
 
@@ -107,10 +109,14 @@ unconditionally (#1828). Both now fail loudly.
   hand a subagent the `terminal` toolset directly. Skills that stop working
   with it off: `hal0-service-management`, `hal0-bench`,
   `hal0-bench-autopilot`, `hal0-tune` and `hal0-quantize`. A box whose
-  `config.yaml` already carries an explicit `terminal.backend` — set by
-  hal0's own provisioning at any point in its history, or by the operator by
-  hand — is read as a prior opt-in and keeps the terminal enabled across
-  `hal0 update`; no action needed there (#1882).
+  `config.yaml` already carries a backend other than `local`, or `local`
+  together with a non-default `cwd` — anything hal0's own provisioning has
+  ever written, or a path the operator set by hand — is read as a prior
+  opt-in and keeps the terminal enabled across `hal0 update`. `local` with no
+  `cwd`, or the default `cwd: "."` that `hermes config migrate` can
+  materialise on its own, is NOT read as consent: that box starts off, same
+  as a fresh install, and needs `hal0 agent install hermes --terminal-tool`
+  to opt back in (#1882).
 
 ### Added
 
@@ -225,10 +231,13 @@ unconditionally (#1828). Both now fail loudly.
   `hal0 config edit` now lands at its canonical mode (`0600`, `0640`, `0600`
   respectively) instead of the umask-mediated `0644` a bare file write
   produced, and is chowned to the `hal0` service owner on a real install so
-  `hal0-api.service` can still read what it seeded. An operator whose seed
-  can't reach that ownership — running as neither `hal0` nor root — now gets
-  a loud failure pointing at `sudo` instead of a file `hal0-api` cannot open
-  (#1881).
+  `hal0-api.service` can still read what it seeded. An operator who can
+  create the file — in the `hal0` group, on a box where `/etc/hal0` is
+  group-writable — but is neither `hal0` nor root now gets a loud failure
+  pointing at `sudo` instead of a file `hal0-api` cannot open. An operator
+  outside the `hal0` group entirely still fails earlier, at file creation,
+  with a raw permission error rather than that same clean message — tracked
+  separately (#1881).
 
 ### Security
 
@@ -250,12 +259,17 @@ unconditionally (#1828). Both now fail loudly.
   "Bundled agent trust boundary" section laying out the posture
   control-by-control, with a status of accepted, documented risk for 1.0 —
   the agent/API UID split is tracked for 1.1 under ADR-0002 (#1881).
-- `upstreams.toml` drops from world-readable `0644` to `0640`. The file
-  carries no credential values — `auth_value_env` only names an environment
-  variable the registry resolves from the process environment at request
-  time — but its provider/endpoint inventory was readable by every local
-  account; every real consumer (`hal0-api`, `hal0-agent@*`, the CLI) runs as
-  `hal0` or root, group `hal0` (#1881).
+- `upstreams.toml`'s canonical mode drops from world-readable `0644` to
+  `0640` on a fresh install and on every rewrite through `hal0 config edit
+  upstreams` or the API's own writer. The file carries no credential values —
+  `auth_value_env` only names an environment variable the registry resolves
+  from the process environment at request time — but its provider/endpoint
+  inventory was readable by every local account; every real consumer
+  (`hal0-api`, `hal0-agent@*`, the CLI) runs as `hal0` or root, group `hal0`.
+  **A bare `hal0 update` does not rewrite the file**, so an existing
+  `upstreams.toml` already on disk at `0644` stays `0644` until something
+  rewrites it or an operator converges it directly with
+  `sudo hal0 doctor perms --fix` (#1881).
 
 ### Docs
 
@@ -381,11 +395,15 @@ targeted at the 1.0.x line.
   and `delegation` come off with it. Nothing to run if that is what you want.
   To enable it, answer yes at the installer's prompt on an interactive
   install, or run `hal0 agent install hermes --terminal-tool` (add
-  `HAL0_HERMES_TERMINAL=1` for an unattended install). An existing box whose
-  `config.yaml` already carries an explicit `terminal.backend` — anything
-  hal0 has ever provisioned, or a cwd the operator set by hand — is read as a
-  prior opt-in and keeps it enabled across `hal0 update`; nothing to run
-  there either.
+  `HAL0_HERMES_TERMINAL=1` for an unattended install). An existing box keeps
+  its terminal enabled across `hal0 update` only when `config.yaml` reads as
+  a real prior choice: a backend other than `local`, or `local` with a `cwd`
+  hal0's own provisioning has ever written, or one the operator set by hand.
+  `local` with no `cwd`, or the default `cwd: "."`, is NOT read as consent —
+  that box starts off after the update, same as a fresh install, so an
+  operator who hand-configured a plain `local` backend at its default `cwd`
+  needs to re-opt-in with `hal0 agent install hermes --terminal-tool` (or
+  `HAL0_HERMES_TERMINAL=1`) to get it back.
 
 ### Rollback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,11 +85,15 @@ unconditionally (#1828). Both now fail loudly.
   non-interactive install no longer hands the bundled agent a local shell
   running as the `hal0` service user — root-equivalent on this box — without
   the operator saying so. Opt in at the installer prompt, with
-  `hal0 agent install hermes --terminal-tool`, or via `HAL0_HERMES_TERMINAL=1`;
-  a box whose `config.yaml` already carries a non-`local` backend, or `local`
-  with a non-default `cwd` (hal0-provisioned or hand-set), keeps it enabled
-  across the update — `local` with no `cwd` or the default `cwd: "."` is not
-  read as consent and starts off, like a fresh install. Off also disables the
+  `sudo hal0 agent install hermes --terminal-tool`, or via
+  `HAL0_HERMES_TERMINAL=1`. This only changes what a fresh provision writes:
+  a bare `hal0 update` never touches Hermes' config, so an already-provisioned
+  box keeps its existing terminal posture untouched by the update itself; the
+  new default-off rule is evaluated the next time Hermes is reprovisioned —
+  where a `config.yaml` already carrying a non-`local` backend, or `local`
+  with a non-default `cwd` (hal0-provisioned or hand-set), still reads as
+  consent and keeps it enabled, while `local` with no `cwd` or the default
+  `cwd: "."` does not and comes back off. Off also disables the
   `code_execution` and `delegation` toolsets, since both reach a shell one
   hop away from `terminal` (#1882).
 
@@ -102,21 +106,24 @@ unconditionally (#1828). Both now fail loudly.
   without asking. A fresh install, a piped (`curl … | bash`) install, a
   headless install, or any install run with `HAL0_NONINTERACTIVE=1` now
   leaves the terminal tool disabled unless the operator opts in: the
-  installer's interactive prompt, `hal0 agent install hermes
+  installer's interactive prompt, `sudo hal0 agent install hermes
   --terminal-tool`, or `HAL0_HERMES_TERMINAL=1`. Turning it off also
   disables the `code_execution` and `delegation` toolsets — `execute_code`
   runs arbitrary code as the same user, and `delegate_task` could otherwise
   hand a subagent the `terminal` toolset directly. Skills that stop working
   with it off: `hal0-service-management`, `hal0-bench`,
-  `hal0-bench-autopilot`, `hal0-tune` and `hal0-quantize`. A box whose
-  `config.yaml` already carries a backend other than `local`, or `local`
-  together with a non-default `cwd` — anything hal0's own provisioning has
-  ever written, or a path the operator set by hand — is read as a prior
-  opt-in and keeps the terminal enabled across `hal0 update`. `local` with no
-  `cwd`, or the default `cwd: "."` that `hermes config migrate` can
-  materialise on its own, is NOT read as consent: that box starts off, same
-  as a fresh install, and needs `hal0 agent install hermes --terminal-tool`
-  to opt back in (#1882).
+  `hal0-bench-autopilot`, `hal0-tune` and `hal0-quantize`. This default only
+  governs what a fresh Hermes provision writes — a bare `hal0 update` never
+  reprovisions Hermes, so it does not touch an existing box's terminal
+  posture at all. At the next reprovision or bootstrap, a `config.yaml`
+  that already carries a backend other than `local`, or `local` together
+  with a non-default `cwd` — anything hal0's own provisioning has ever
+  written, or a path the operator set by hand — is read as a prior opt-in
+  and keeps the terminal enabled. `local` with no `cwd`, or the default
+  `cwd: "."` that `hermes config migrate` can materialise on its own, is
+  NOT read as consent: that box comes back off at the next reprovision,
+  same as a fresh install, and needs
+  `sudo hal0 agent install hermes --terminal-tool` to opt back in (#1882).
 
 ### Added
 
@@ -260,15 +267,18 @@ unconditionally (#1828). Both now fail loudly.
   control-by-control, with a status of accepted, documented risk for 1.0 —
   the agent/API UID split is tracked for 1.1 under ADR-0002 (#1881).
 - `upstreams.toml`'s canonical mode drops from world-readable `0644` to
-  `0640` on a fresh install and on every rewrite through `hal0 config edit
-  upstreams` or the API's own writer. The file carries no credential values —
-  `auth_value_env` only names an environment variable the registry resolves
-  from the process environment at request time — but its provider/endpoint
-  inventory was readable by every local account; every real consumer
-  (`hal0-api`, `hal0-agent@*`, the CLI) runs as `hal0` or root, group `hal0`.
-  **A bare `hal0 update` does not rewrite the file**, so an existing
-  `upstreams.toml` already on disk at `0644` stays `0644` until something
-  rewrites it or an operator converges it directly with
+  `0640` when `hal0 config edit upstreams` seeds a *missing* file, and on
+  every write through the API's `save_upstreams_config` writer (provider
+  create/patch/delete). Opening an EXISTING `upstreams.toml` in
+  `hal0 config edit upstreams` only launches `$EDITOR` — it never touches
+  the file's mode. The file carries no credential values — `auth_value_env`
+  only names an environment variable the registry resolves from the process
+  environment at request time — but its provider/endpoint inventory was
+  readable by every local account; every real consumer (`hal0-api`,
+  `hal0-agent@*`, the CLI) runs as `hal0` or root, group `hal0`.
+  **A bare `hal0 update` does not touch the file either**, so an existing
+  `upstreams.toml` already on disk at `0644` stays `0644` until an actual
+  provider write happens or an operator converges it directly with
   `sudo hal0 doctor perms --fix` (#1881).
 
 ### Docs
@@ -394,16 +404,24 @@ targeted at the 1.0.x line.
   enables Hermes' `local` terminal backend automatically — `code_execution`
   and `delegation` come off with it. Nothing to run if that is what you want.
   To enable it, answer yes at the installer's prompt on an interactive
-  install, or run `hal0 agent install hermes --terminal-tool` (add
-  `HAL0_HERMES_TERMINAL=1` for an unattended install). An existing box keeps
-  its terminal enabled across `hal0 update` only when `config.yaml` reads as
-  a real prior choice: a backend other than `local`, or `local` with a `cwd`
-  hal0's own provisioning has ever written, or one the operator set by hand.
-  `local` with no `cwd`, or the default `cwd: "."`, is NOT read as consent —
-  that box starts off after the update, same as a fresh install, so an
-  operator who hand-configured a plain `local` backend at its default `cwd`
-  needs to re-opt-in with `hal0 agent install hermes --terminal-tool` (or
-  `HAL0_HERMES_TERMINAL=1`) to get it back.
+  install, or run `sudo hal0 agent install hermes --terminal-tool` (add
+  `HAL0_HERMES_TERMINAL=1` for an unattended install). A bare `hal0 update`
+  never touches Hermes' config — Hermes is only (re)provisioned by the
+  installer or by `hal0 agent install|bootstrap|reprovision hermes` — so an
+  existing box's terminal posture is untouched by the update itself and
+  stays exactly as it was. The default-off behaviour only applies at the
+  NEXT reprovision or bootstrap: at that point, `config.yaml` reading as a
+  real prior choice (a backend other than `local`, or `local` with a `cwd`
+  hal0's own provisioning has ever written, or one the operator set by hand)
+  keeps the terminal enabled, while `local` with no `cwd` or the default
+  `cwd: "."` is NOT read as consent and comes back off. An operator with
+  that shape who wants the terminal to stay on should re-opt-in explicitly —
+  `sudo hal0 agent install hermes --terminal-tool` or
+  `HAL0_HERMES_TERMINAL=1` before reprovisioning — rather than relying on
+  the default. Since this is a root-equivalent shell, an operator who wants
+  it off right now, without waiting for a reprovision, can run
+  `sudo hal0 agent install hermes --no-terminal-tool` (or
+  `HAL0_HERMES_TERMINAL=0` before reprovisioning) at any time.
 
 ### Rollback
 


### PR DESCRIPTION
## What

Adds two PRs that landed on `main` after the rc.6 CHANGELOG section was
merged in #1860:

- **#1882** (BREAKING): Hermes' terminal tool is now an explicit opt-in,
  off by default on a fresh, piped or non-interactive install
  (`code_execution` and `delegation` go off with it; existing boxes with an
  explicit `terminal.backend` already set keep it enabled across the
  update). Adds a Highlights entry, a new `### Breaking` subsection, and an
  Operator migrations entry for operators who want to turn it back on.
- **#1881**: documents the bundled agent's trust boundary for 1.0
  (ADR-0002 Option C) — a new `hal0 doctor` "Agent UID split" warn row,
  `upstreams.toml` dropping to `0640`, and config seeds
  (`hal0.toml`/`upstreams.toml`/`providers.toml`) landing at their
  canonical mode with service ownership on a real install. Split across
  `### Security` (doctor row, `0640`) and `### Fixed` (seed-mode/ownership
  bug) to match the section's existing style.

## Why

The rc.6 changelog section is the source of truth `scripts/gen_release_notes.py`
renders into `release.json` (the structured highlights/breaking/migrations
banner `hal0 update` shows an operator before they confirm). Without this,
the #1882 breaking change and the #1881 security-posture changes would ship
undocumented in the rc.6 release notes.

## Verification

- Every claim was checked against `git show 82a1349e` / `git show e8db7ee3`
  directly, not against a prompt summary.
- `uv run python scripts/gen_release_notes.py --tag v1.0.0-rc.6 --channel
  preview --out-dir <tmp>` exits **0** and reports
  `highlights=7 breaking=1 migrations=6` (up from the merged section's
  `highlights=6 breaking=0 migrations=5`).
- Extracted every backtick span from the resulting `release.json` and
  confirmed none carry an injected internal space from the source
  markdown's line wraps (the wrapped `hal0 agent install hermes
  --terminal-tool` span in particular reconstructs correctly).
- `uv run --extra dev pytest tests/release/` — 104 passed.

Not merging — leaving this open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)