### PR TITLE
docs(security): link ADR-0002 in-tree and name the doctor subcommand

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,13 +77,11 @@ document warns about. Closing the chain for 1.1 means the UID split *and*
 dropping the agent out of the `hal0` group / config-tree write access — not
 the UID split alone. The analysis, the evidence, and the rejected alternatives
 are in
-ADR-0002 — agent credential isolation, under review in
-[PR #1880](https://github.com/Hal0ai/hal0/pull/1880) and landing at
-`docs/adr/0002-agent-credential-isolation.md`. (Linked as a PR, not as a
-relative path, because the ADR is still a proposal awaiting an operator
-decision — a link that 404s in-tree would be worse than one extra click.)
+[ADR-0002 — agent credential isolation](docs/adr/0002-agent-credential-isolation.md),
+accepted for 1.0 as Option C on 2026-08-15 (merged in
+[PR #1880](https://github.com/Hal0ai/hal0/pull/1880)).
 
-`hal0 doctor` reports this posture directly: the **Agent UID split** row warns
+`hal0 doctor all` reports this posture directly: the **Agent UID split** row warns
 when an agent unit resolves to the same `User=` as `hal0-api.service`.
 
 ### If you cannot accept it


### PR DESCRIPTION
## What

Two one-line accuracy fixes in `SECURITY.md`, both follow-ups from the rc.6 wave:

- The ADR-0002 reference was deliberately a PR URL while the ADR was an unmerged proposal; #1880 has now merged, so the link points at `docs/adr/0002-agent-credential-isolation.md` and records the Option C acceptance (operator decision, 2026-08-15).
- The Agent UID split doctor row is emitted by `hal0 doctor all` (built by `build_all_checks()`), not the bare `hal0 doctor`, which runs the preflight script. Same correction Codex established on PR #1884 for the changelog.

## Verification

`tests/docs/test_security_md_documents_agent_boundary.py` — 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)